### PR TITLE
fix(mcp): serialize concurrent send_to_agent_impl per agent

### DIFF
--- a/docs/en/concepts/plan-mode.md
+++ b/docs/en/concepts/plan-mode.md
@@ -67,6 +67,13 @@ so the snapshot stays small and outputs are preserved verbatim
 `get_step_result(snap, agent_state_dir, step_id)` which transparently
 resolves inline-vs-spilled.
 
+Sub-loop LLM calls within each step are also recorded
+([ADR-0025](../decisions/0025-plan-step-llm-memoization.md)) so a
+crash mid-step doesn't re-pay the LLM cost on resume. The sub-loop's
+`call_llm_tools` invocations are keyed by `args_hash`; on resume the
+recorded results replay before the LLM is invoked, only the crashed
+turn pays fresh.
+
 When `reyn chat` next starts, `AgentRegistry.restore_all`:
 
 1. Replays the WAL onto each agent's snapshot.

--- a/docs/en/concepts/plan-mode.md
+++ b/docs/en/concepts/plan-mode.md
@@ -56,8 +56,16 @@ concurrently.
 |---|---|---|
 | Decomposition (plan shape) | `agents/<name>/state/plans/<plan_id>/decomposition.json` | yes |
 | Per-plan progress (steps completed, results) | `agents/<name>/state/plans/<plan_id>.snapshot.json` | yes |
+| Step output (≤32 KB) | inline on the snapshot above | yes |
+| Step output (>32 KB) | `agents/<name>/state/plans/<plan_id>/step_results/<step_id>.txt` | yes |
 | Plan lifecycle events | `.reyn/state/wal.jsonl` (`plan_started` / `plan_step_*` / `plan_completed`) | yes |
 | Active asyncio.Task | in-memory only | no — auto-resumes on next startup |
+
+Step outputs > 32 KB spill to a per-plan workspace file ([ADR-0024](../decisions/0024-plan-step-result-spill.md))
+so the snapshot stays small and outputs are preserved verbatim
+(= no truncation, no data loss). Read access goes via
+`get_step_result(snap, agent_state_dir, step_id)` which transparently
+resolves inline-vs-spilled.
 
 When `reyn chat` next starts, `AgentRegistry.restore_all`:
 

--- a/docs/en/concepts/plan-mode.md
+++ b/docs/en/concepts/plan-mode.md
@@ -1,0 +1,151 @@
+# Plan mode
+
+How Reyn decomposes a complex chat query into independent sub-tasks,
+runs them in narrow LLM calls, and stitches the answers together —
+with crash resilience so long plans survive process restarts.
+
+## What plan mode is
+
+For complex queries (= multi-source synthesis, "explain X with code
+references", compare-and-contrast), the chat router can call the
+`plan` tool to produce a structured decomposition:
+
+```
+user query → planner LLM
+                ↓
+              [plan: 2-7 steps with tools + dependencies]
+                ↓
+              executor: each step runs in a narrow LLM call
+                ↓
+              terminal step's text → user reply
+```
+
+Each plan step gets a small, focused system prompt and a subset of
+the parent's tool catalog. This avoids the per-call context bloat
+that comes from carrying the full router prompt + 14 tools through
+every sub-task.
+
+Plan mode is **opt-in per query** — the router LLM picks `plan` when
+it sees a query that warrants decomposition. Simple queries
+(= "hello", single tool call) bypass it entirely.
+
+## Async dispatch
+
+`plan` is registered as an async tool. When the router LLM calls it,
+the chat turn does not block:
+
+1. `dispatch_plan_tool` validates the plan, allocates a `plan_id` +
+   per-plan `chain_id`, writes the decomposition artifact, and spawns
+   a `PlanRuntime` task.
+2. The router loop sees an async tool result and exits — the chat
+   turn ends.
+3. The plan task runs in the background. Per-step status messages
+   land in the outbox so the user sees progress.
+4. The terminal aggregator step's text is emitted to the user as a
+   regular agent message (`kind="agent"`, `meta.plan_id` for
+   identification).
+
+This matches the human dispatch model: quick replies first, long
+work continues in the background. The user can issue new chat
+messages while a plan is in flight; multiple plans can run
+concurrently.
+
+## What's preserved across crashes
+
+| State | Where | Survives crash |
+|---|---|---|
+| Decomposition (plan shape) | `agents/<name>/state/plans/<plan_id>/decomposition.json` | yes |
+| Per-plan progress (steps completed, results) | `agents/<name>/state/plans/<plan_id>.snapshot.json` | yes |
+| Plan lifecycle events | `.reyn/state/wal.jsonl` (`plan_started` / `plan_step_*` / `plan_completed`) | yes |
+| Active asyncio.Task | in-memory only | no — auto-resumes on next startup |
+
+When `reyn chat` next starts, `AgentRegistry.restore_all`:
+
+1. Replays the WAL onto each agent's snapshot.
+2. For every plan in `active_plan_ids`, calls
+   `_recover_plans_for_agent`:
+   - Loads the per-plan snapshot.
+   - Reads the decomposition artifact (P5 SSoT — the LLM's plan, not
+     re-derived because re-decomposition is non-deterministic).
+   - Runs the resume coordinator (= analyzer + policy) to classify
+     each step as `pending` / `completed_with_result` / `failed` /
+     `interrupted_with_child`.
+   - Spawns a `PlanRuntime` task with `resume_plan` set so completed
+     steps memo-replay (= no LLM cost), only pending ones re-execute.
+
+Long plans no longer re-pay LLM tokens on resume — the recorded
+`step_results` are reused.
+
+## Multi-plan and ordering
+
+Multiple plans can be in flight at the same time. Each has its own
+`plan_id` + `chain_id` + decomposition directory; they're
+independent. Outbox messages land in **completion order**, not
+arrival order — a 30-second plan that finishes before a 5-minute
+one shows up first, with `meta.plan_id` distinguishing them.
+
+The WAL truncation floor includes every active plan's
+`last_step_applied_seq`, so step events the resume analyzer needs
+aren't dropped while a plan is still running.
+
+## Resume policy
+
+`reyn.yaml` configures coordinator behavior:
+
+```yaml
+plan_resume:
+  default: retry_pending       # one of: retry_pending | discard
+  child_purity:                # for plan steps that spawned a child skill
+    pure:        cancel        # idempotent + cheap → re-run
+    world:       adopt         # child handles its own resume
+    side_effect: adopt
+    external:    adopt
+    llm:         adopt
+```
+
+- `retry_pending` (default) — memo committed steps, re-execute the
+  rest.
+- `discard` — abort the plan, cancel children flagged `cancel`,
+  surface an outbox notice asking the user to re-issue.
+
+Plans whose decomposition artifact is missing or corrupt are
+auto-discarded with a descriptive outbox notice — Reyn never
+re-decomposes via the planner LLM (that would shuffle step IDs and
+break memoization).
+
+## Operator commands
+
+```
+/plan list                  — show active plans (running + pending resume)
+/plan discard <plan_id>     — abort + clean up state
+```
+
+`/plan discard` cancels the asyncio.Task, records `plan_aborted` to
+the WAL, removes the decomposition artifact + snapshot, and notifies
+any peer agent waiting on the plan's chain (R-D14).
+
+## Crash classification
+
+Mirrors [skill resume](skill-resume.md) — exception-aware finally
+clause in `PlanRuntime.run`:
+
+| Exit | Outcome |
+|---|---|
+| Normal return | `plan_completed` recorded; artifact deleted; user gets terminal text |
+| `WorkflowAbortedError` | Treated as clean abort; artifact deleted |
+| Generic `Exception` / `KeyboardInterrupt` | `plan_run_interrupted` event; artifact preserved; restart auto-resumes |
+| `kill -9` | `finally` skipped; artifact preserved; restart auto-resumes |
+
+The artifact preservation invariant is what makes resume work — if
+the artifact is gone, the coordinator can't reconstruct the plan
+shape and falls back to discard.
+
+## Cross-references
+
+- [skill resume](skill-resume.md) — sibling design; plans reuse the
+  same WAL + snapshot + analyzer + coordinator patterns
+- [permission model](permission-model.md) — plan steps run with
+  per-step narrowed tool catalogs
+- [events](events.md) — `plan_*` and `plan_step_*` audit trail
+- ADR-0022 (Phase 1 fail-safe), ADR-0023 (Phase 2 forward replay +
+  Phase 2.1 async dispatch)

--- a/docs/en/concepts/plan-mode.md
+++ b/docs/en/concepts/plan-mode.md
@@ -116,13 +116,31 @@ break memoization).
 ## Operator commands
 
 ```
-/plan list                  — show active plans (running + pending resume)
-/plan discard <plan_id>     — abort + clean up state
+/plan list                                — show active plans (running + pending resume)
+/plan discard <plan_id>                   — abort + clean up state
+/plan resume <plan_id> --from <step_id>   — re-run from a specific step
 ```
 
 `/plan discard` cancels the asyncio.Task, records `plan_aborted` to
 the WAL, removes the decomposition artifact + snapshot, and notifies
 any peer agent waiting on the plan's chain (R-D14).
+
+`/plan resume --from` is the surgical escape hatch (= ADR-0023 §3.7)
+for the case where a step recorded a result the operator wants to
+redo (e.g. the LLM produced something wrong, or world state shifted
+in a way the recorded result no longer reflects). The handler:
+
+1. Cancels any in-flight task for the plan.
+2. Loads the decomposition artifact for topological step order.
+3. Clears `step_results` / `step_failures` / `spawned_skill_run_ids`
+   from `<step_id>` onward; preserves earlier steps.
+4. Rebuilds a `resume_plan` and re-launches via the standard auto-
+   resume path — earlier steps memo-replay (no LLM cost), the rest
+   re-execute.
+
+The sub-command rejects unknown plan IDs, missing decomposition
+artifacts (= directs to `/plan discard`), and step IDs not in the
+plan (= lists valid step IDs).
 
 ## Crash classification
 

--- a/docs/en/contributing/dogfood-discipline.md
+++ b/docs/en/contributing/dogfood-discipline.md
@@ -461,6 +461,331 @@ Reyn's three tools (`REYN_LLM_TRACE_DUMP`, `dogfood_trace.py`, `llm_replay.py`) 
 
 ---
 
+## 6.5 Plan-mode dogfood specifics
+
+> **This section applies once plan-mode is in your test scope.** The nine principles in Section 3 still apply without modification. What changes is the observation axis: plan-mode introduces async dispatch, concurrent in-flight plans, and memo replay on resume — surfaces that skill-side dogfood never exercises.
+
+---
+
+### 6.5.1 Why plan-mode needs special discipline
+
+Skill-side dogfood verifies that a skill's phase graph executes correctly under the LLM's probabilistic decisions. Plan-mode adds three qualitatively different concerns:
+
+**Async dispatch and completion ordering.** A plan runs as a background `asyncio.Task`. The user can issue new messages while the plan is in flight. Multiple plans can overlap. Outbox messages land in completion order, not user-issue order. These properties are invisible in skill-side traces — they only surface when you deliberately run concurrent plans and observe the outbox.
+
+**Memo replay on resume.** The value of crash resilience (ADR-0023 + ADR-0025) is not testable by reading code. It requires killing a process mid-step, restarting, and confirming that completed steps produce zero additional LLM cost and identical outputs. This is a distinct observation path from any skill-side test.
+
+**Router-side LLM invocation.** Plan-mode is triggered by the chat router LLM choosing the `plan` tool. Unlike skill-side dogfood — where the user controls which skill is invoked — plan-mode depends on the router LLM deciding, probabilistically, that decomposition is warranted. A scenario that is "complex enough" by human judgment may still not trigger plan-mode if the router LLM consistently prefers direct answers. This makes plan invocation itself an observation point, not an assumption.
+
+The principles in Section 3 still apply — in particular Principle 4 (build observation infrastructure first), Principle 6 (verify-first / reproduce-first), and Principle 3 (one hypothesis, one fix) — but the specific observation surfaces differ from skill-side dogfood.
+
+---
+
+### 6.5.2 New observation surfaces
+
+Plan-mode produces durable state across six distinct locations. Each has a different purpose and a different decay lifecycle.
+
+| Surface | Where | What to look for |
+|---|---|---|
+| WAL | `state/wal.jsonl` | `plan_started` / `plan_completed` / `plan_aborted` / `plan_step_started` / `plan_step_completed` / `plan_step_failed` — the resume substrate |
+| Events log (forensic-only) | `events/<caller>/...` | `plan_emitted` / `plan_aggregated` / `plan_run_interrupted` / `plan_step_memoized` / `plan_step_memo_failed` / `plan_step_llm_memoized` |
+| Per-plan snapshot | `state/plans/<plan_id>.snapshot.json` | `step_results` / `step_result_refs` / `step_llm_calls` — the durable cache that drives resume |
+| Spilled step results | `state/plans/<plan_id>/step_results/<step_id>.txt` | ADR-0024 — only outputs > 32 KB spill; inline otherwise |
+| Spilled LLM call records | `state/plans/<plan_id>/step_llm_calls/<step_id>/<turn_idx>.json` | ADR-0025 — only > 32 KB results spill |
+| Outbox (= UI / TUI) | `session.outbox` queue, also visible in chat REPL | `kind=status` per-step progress narration; `kind=agent` terminal text with `meta.plan_id` |
+| Running tasks | `session.running_plans: dict[plan_id, asyncio.Task]` | shown via `/plan list` slash command |
+
+**Reading discipline for each surface:**
+
+- **WAL first.** The WAL is the primary resume substrate and the fastest surface to read. If a step is claimed to have completed, `plan_step_completed` must be present. If it is not, the step never committed — the snapshot may contain stale data.
+- **Snapshot second.** The snapshot is what the resume coordinator reads. Confirm `step_results` (inline) or `step_result_refs` (spilled) are populated for the steps you expect to be memoized.
+- **Events log for causality.** `plan_step_memoized` and `plan_step_llm_memoized` confirm that the memo path fired, not just that the result is present. Use the events log only for this forensic use — not for operational checks.
+- **Outbox for user-facing correctness.** The outbox is what the user sees. `meta.plan_id` tagging is what distinguishes concurrent plan outputs. Verify that each plan's terminal text carries the right `plan_id`.
+
+---
+
+### 6.5.3 Tooling cheat sheet
+
+The `dogfood_trace.py` utility exposes plan-specific modes alongside the existing skill-side modes.
+
+```bash
+# Plan-mode summary (= count plans, memo hits, max concurrent)
+python scripts/dogfood_trace.py --mode plan-summary
+
+# Per-plan timeline (= WAL + events log + outbox for one plan_id)
+python scripts/dogfood_trace.py --mode plan-trace <plan_id>
+
+# Per-plan workspace dump (= decomposition + snapshot + spilled files)
+python scripts/dogfood_trace.py --mode plan-snapshot <plan_id>
+
+# Cost mode now includes memo savings estimate
+python scripts/dogfood_trace.py --mode cost
+```
+
+> Note: `--mode plan-summary`, `plan-trace`, and `plan-snapshot` are being added in the same prep wave as this section. If not yet landed, treat this as forward-looking documentation. Write scenarios that exercise the surfaces above using manual WAL / snapshot inspection until the modes land.
+
+For the existing skill-side modes, see Section 6. The `--mode cost` output is shared — it includes both skill-side and plan-side LLM call costs, with memo savings broken out separately when plan resumptions have fired.
+
+The attractor detector (`scripts/detect_attractor.py`) is useful for plan-mode too: run it against the sub-loop's trace dump to catch empty-stop or enum violation attractors inside individual step executions.
+
+```bash
+REYN_LLM_TRACE_DUMP=plan_trace.jsonl reyn chat
+python scripts/detect_attractor.py --root .reyn/  # catches step-level attractors
+```
+
+---
+
+### 6.5.4 Plan-mode-specific scenario design
+
+For batch design (A1 step), plan-mode requires deliberately constructed scenarios that exercise its distinct properties. Five scenario classes cover the main risk surface:
+
+#### Class 1: Multi-source synthesis (long-step)
+
+**Purpose.** Verify that the router LLM actually invokes plan-mode for a query that warrants it — and that the decomposition and aggregation are coherent.
+
+**Example query.** "Compare the README and CLAUDE.md and summarize the key differences for a new contributor."
+
+**What to observe.**
+1. Does the router LLM call the `plan` tool? (Check `REYN_LLM_TRACE_DUMP` for a `plan` tool call in the router's turn.)
+2. Is the decomposition well-formed (2–7 steps, no circular dependencies)?
+3. Does the terminal aggregator step produce a coherent answer that cites both sources?
+
+**Verified.** Router calls `plan`; decomposition is present at `state/plans/<plan_id>/decomposition.json`; outbox receives a `kind=agent` message with `meta.plan_id`; content references both documents.
+
+**Refuted.** Router answers directly without calling `plan`. This is not a bug (the router may legitimately decide direct answer is better), but it means your scenario is not testing plan-mode. Revise the query to be more explicitly multi-source.
+
+**Blocked.** Router errors before producing any tool call. Treat as a prior-layer bug, not a plan-mode finding.
+
+#### Class 2: Concurrent plans (multi-plan UX)
+
+**Purpose.** Verify that multiple in-flight plans produce correctly tagged outbox output in completion order, not issue order.
+
+**Execution.** Issue two user prompts back-to-back (before either plan completes) — one short plan (2 steps), one longer plan (5 steps). Observe outbox ordering.
+
+**What to observe.**
+1. Does the outbox receive two separate `meta.plan_id`-tagged final messages?
+2. Does the shorter plan's message arrive before the longer plan's — regardless of which was issued first?
+3. Does `/plan list` show both plans as active before either completes?
+
+**Verified.** Two distinct `plan_id` values; shorter plan's `kind=agent` message arrives first; both plans complete without state collision.
+
+**Refuted.** Plans complete in issue order regardless of duration — suggests outbox ordering is incorrect. Or: state collision (one plan's step results appear in the other's snapshot).
+
+**Blocked.** Router only triggers plan-mode for one of the two queries.
+
+#### Class 3: Crash + resume
+
+**Purpose.** Verify ADR-0023 (step-result memoization) and ADR-0025 (sub-loop LLM call memoization) fire on resume. This is the most important scenario class for crash resilience confidence.
+
+**Execution.**
+1. Start a multi-step plan (Class 1 or longer).
+2. Wait for step 1 to emit `plan_step_completed` in the WAL.
+3. `kill -9` the `reyn chat` process mid-step-2.
+4. Restart `reyn chat`.
+5. Observe resume behavior.
+
+**What to observe.** (See 6.5.5 for full procedure.)
+
+**Verified.** Step 1 does not incur new LLM cost on resume (`plan_step_memoized` event fires); step 2 re-executes from its interrupted point; the plan completes correctly.
+
+**Refuted.** Step 1 re-incurs LLM cost on resume (no `plan_step_memoized` event, new entries in cost ledger for step 1's calls).
+
+**Blocked.** `_recover_plans_for_agent` does not fire (log message absent) — suggests the WAL replay or agent registry restore path has a bug upstream of plan-mode.
+
+#### Class 4: Operator escape hatch
+
+**Purpose.** Verify `/plan list`, `/plan discard <plan_id>`, and `/plan resume <plan_id> --from <step_id>` operate correctly on live and interrupted plans.
+
+**What to observe.**
+1. `/plan list` — shows correct `plan_id`, step counts, and running/pending state during an in-flight plan.
+2. `/plan discard` — cancels the task, writes `plan_aborted` to WAL, removes decomposition artifact and snapshot, sends outbox notice.
+3. `/plan resume --from <step_id>` — re-executes from the specified step; earlier steps memo-replay; final output reflects the re-run step.
+
+**Verified.** Each command produces the expected WAL entry and outbox state change.
+
+**Refuted.** `/plan discard` does not remove the decomposition artifact — risk of stale artifact ghost (see 6.5.6 anti-pattern).
+
+#### Class 5: Long-tail step (> 32 KB output)
+
+**Purpose.** Verify ADR-0024 step-result spill triggers without data loss when a step produces output exceeding 32 KB.
+
+**Execution.** Construct a step that synthesizes a large text output (e.g., "list all symbols exported by every file in `src/`" — typically > 32 KB for a medium-size codebase).
+
+**What to observe.**
+1. Does `step_result_refs.<step_id>` appear in the snapshot (rather than `step_results.<step_id>`)?
+2. Does `state/plans/<plan_id>/step_results/<step_id>.txt` exist and contain the full output without truncation?
+3. Does the downstream aggregator step receive the full content (= transparent resolution via `get_step_result`)?
+
+**Verified.** `step_result_refs` populated; spilled file exists; downstream step content references content only present in the spilled file (= no truncation).
+
+**Refuted.** Output appears inline in snapshot despite being > 32 KB — spill did not trigger. Or: spilled file exists but downstream step received a truncated version.
+
+---
+
+### 6.5.5 Memo hit verification procedure
+
+This is the step-by-step procedure for confirming that both ADR-0023 (step-result memoization) and ADR-0025 (sub-loop LLM call memoization) replay correctly on resume. Run this procedure when executing a Class 3 scenario.
+
+**Step 1: Run a plan to completion (baseline).**
+
+Start with a clean state directory (`state/plans/` empty or containing no active plans). Run a multi-step plan (3+ steps recommended) and allow it to complete cleanly. Record:
+- The `plan_id` from the WAL or `/plan list`.
+- The cost ledger output from `python scripts/dogfood_trace.py --mode cost` (captures fresh-run LLM cost for comparison).
+
+**Step 2: Run the same query; kill mid-step-2.**
+
+Re-run the same query. This starts a new plan with a new `plan_id`. Watch the WAL for `plan_step_completed` for step 1 (`s1`). Once it appears, `kill -9` the process immediately. Step 2 (`s2`) should be in progress or not yet started.
+
+**Step 3: Restart `reyn chat`.**
+
+The resume path triggers automatically on startup. Observe the log output for:
+```
+_recover_plans_for_agent fired for agent <name>, plan_id <id>
+```
+If this message is absent, the WAL replay or agent registry restore path has a problem upstream of plan-mode — file a prior-layer bug.
+
+**Step 4: Open the per-plan snapshot.**
+
+```bash
+cat state/plans/<plan_id>.snapshot.json | python -m json.tool
+```
+
+Confirm:
+- `step_results.s1` (inline) **or** `step_result_refs.s1` (spilled) is populated with the result from step 1's first run.
+- `step_llm_calls.s1` is populated with the sub-loop's recorded LLM call entries.
+
+If either is absent, the snapshot did not commit before the kill — the kill timing was too early. Re-try with a longer step.
+
+**Step 5: Watch for `plan_step_memoized` in events log.**
+
+After restart, observe the events log for the plan:
+
+```bash
+python scripts/dogfood_trace.py --mode plan-trace <plan_id>
+```
+
+Confirm `plan_step_memoized` appears for `s1` (not `plan_step_completed`). The distinction:
+- `plan_step_completed` = step executed fresh.
+- `plan_step_memoized` = step was replayed from snapshot without LLM calls.
+
+If `plan_step_completed` appears for `s1` instead, memo replay did not fire — step 1 re-executed, incurring fresh LLM cost.
+
+**Step 6: Watch for `plan_step_llm_memoized` for sub-loop calls within s1.**
+
+If step 1 involved multiple sub-loop turns (= multiple LLM calls within the step executor), each sub-loop LLM call that was recorded before the kill should emit `plan_step_llm_memoized` on resume. This is the ADR-0025 mechanism — it prevents re-paying sub-loop LLM cost even when a step was only partially completed.
+
+**Step 7: Confirm no additional LLM cost for s1.**
+
+Run `python scripts/dogfood_trace.py --mode cost` after the resume completes. The cost ledger for the resumed plan should show:
+- Step 1 (`s1`): $0.00 (or 0 tokens) — memo hit.
+- Step 2+ (`s2`...): fresh cost — these re-executed.
+
+If `s1` shows non-zero cost, memoization did not fire for step 1. This is a HIGH bug: the crash resilience claim is not upheld.
+
+**Step 8: Verify plan completes correctly.**
+
+The resumed plan should complete with the same terminal output as the baseline run (Step 1). If the output differs materially (not just whitespace / token sampling variance), the memo replay introduced data corruption. File as CRITICAL.
+
+---
+
+### 6.5.6 Common patterns / anti-patterns specific to plan-mode
+
+This section extends Section 4's patterns and anti-patterns to plan-mode-specific cases. See Section 4 for the skill-side layer-by-layer and downstream symptom patterns, which apply equally here.
+
+#### Pattern: multi-plan completion order is correct by design, not coincidence
+
+When two plans are in flight and the shorter one completes first, the outbox ordering is **correct behavior** — not a timing coincidence. The `meta.plan_id` tag on each `kind=agent` message is the mechanism for the UI to attribute output to the correct plan even when ordering differs from issue order.
+
+Implication for scenario design: when running Class 2 (concurrent plans), explicitly verify the `meta.plan_id` values in the outbox messages. Do not rely on position alone to determine which plan produced which output. A UI that shows plan outputs in a mixed order without `meta.plan_id` attribution is a UX bug, not a plan-mode bug.
+
+#### Pattern: spill-vs-inline crossing the 32 KB threshold mid-run is normal
+
+Whether a step result lands inline in the snapshot or spills to a file is determined by the step's output size at the time it is written. Both paths are correct. A test batch in which some steps spill and others do not is not a sign of inconsistency — it reflects the actual output size distribution of the scenarios.
+
+Do not add special-case assertions for "this step must spill" unless you have constructed the scenario specifically to produce > 32 KB output (Class 5). For general-purpose scenarios, treat both as valid outcomes and verify only that the downstream step received the correct content regardless of path.
+
+#### Anti-pattern: treating `plan_step_failed` as a hard error
+
+Per-step failures are caught and recorded by the plan runtime. The plan continues to execute subsequent steps (unless the failed step's output is required by a downstream step). A dogfood finding that surfaces `plan_step_failed` in the WAL is **not automatically a HIGH bug** — it depends on whether:
+1. The failure was expected (the step's query had no valid answer).
+2. The downstream steps gracefully handled the missing input.
+3. The final aggregator produced a coherent output despite the failure.
+
+When `plan_step_failed` appears, verify graceful degradation before escalating severity. If the plan completes with a coherent output that acknowledges the failure, severity is MED (degraded, not broken). If the plan silently produces an incorrect aggregated output without surfacing the failure, severity is HIGH (data correctness issue).
+
+Cross-ref: this is the plan-mode analog of "downstream symptom masking" in Section 4 — a visible failure event is not always the root-cause finding.
+
+#### Anti-pattern: re-running with a stale decomposition artifact
+
+If `state/plans/<plan_id>/decomposition.json` lingers from a previous run (e.g., after a `/plan discard` that did not complete cleanly, or after a manual kill before the artifact was removed), the resume coordinator will attempt to replay the old plan shape for the new run's `plan_id`. The result is unpredictable: step IDs may not match, memoization may fire for the wrong steps, or the coordinator may discard the plan entirely with a corrupt-artifact notice.
+
+**Between batches that exercise fresh-start scenarios, clean `state/plans/` completely:**
+
+```bash
+rm -rf .reyn/state/plans/
+```
+
+This is mandatory before running Class 3 (crash + resume) or Class 5 (long-tail) scenarios if any prior interrupted run left artifacts behind. It is safe to run between batches — the WAL will not reference the removed artifacts after cleanup.
+
+---
+
+### 6.5.7 Calibration adjustments for plan-mode
+
+Section 5 establishes the four-category outcome classification (verified / inconclusive / refuted / blocked) and the general base rates. For plan-mode batches, add three per-scenario binary predictions before executing each batch:
+
+**Binary prediction 1: "Memo will fire on resume" (Class 3 scenario)**
+
+This is a testable binary claim. Express it as: "Given a kill-9 mid-step-2 after step-1 completion, `plan_step_memoized` will appear for step 1 on resume."
+
+Suggested prior for first plan-mode batch: 60% verified (= the mechanism exists but the kill timing may miss the commit window, causing blocked). Calibrate from there.
+
+**Binary prediction 2: "Multi-plan completion order matches duration order, not issue order" (Class 2 scenario)**
+
+Express as: "The shorter-duration plan's `kind=agent` message will appear in the outbox before the longer-duration plan's."
+
+Suggested prior: 70% verified (= the design guarantees this, but concurrent LLM timing may produce near-simultaneous completions where the order is ambiguous within a narrow window). The "inconclusive" outcome is when both plans complete within one second of each other.
+
+**Binary prediction 3: "32 KB spill triggers without manual intervention" (Class 5 scenario)**
+
+Express as: "A step producing > 32 KB output will emit `step_result_refs` in the snapshot, and the spilled file will exist at `state/plans/<plan_id>/step_results/<step_id>.txt`."
+
+Suggested prior: 75% verified (= deterministic threshold, but constructing a step that reliably produces > 32 KB on a given scenario requires knowing the LLM's output verbosity, which varies).
+
+**Brier scoring plan-mode predictions.**
+
+Score these three binaries per batch using the same Brier formula as Section 5. Track them separately from the skill-side predictions — plan-mode and skill-side have different base rate profiles and should not be pooled until you have enough data to confirm they behave similarly.
+
+Expected Brier score trajectory for plan-mode batches (rough prior based on structural analogy with skill-side batches 7–9):
+- Batch 1 (plan-mode): 0.7–0.9 (observation surfaces unfamiliar, kill timing unreliable)
+- Batch 2–3 (plan-mode): 0.3–0.5 (observation surfaces learned, kill timing practiced)
+- Batch 4+ (plan-mode): 0.2–0.3 if the nine principles are applied consistently
+
+---
+
+### 6.5.8 What NOT to do (scope discipline)
+
+Plan-mode is a **chat-router-side feature**. Its scope is the dispatch, execution, memoization, and resume of plans within a single agent's runtime. Do not conflate with skill-side dogfood or with multi-agent coordination.
+
+**DO NOT test sub-loop tool-op memoization expectations.**
+
+ADR-0023 §3.4 explicitly defers tool-op (= non-LLM tool dispatch) memoization from the plan resume design. When a plan step resumes, its sub-loop's tool dispatches (e.g., file reads, workspace writes) **re-execute** — this is the documented design, not a bug. A dogfood finding that observes "file read was repeated on resume" should be classified as `verified` (correct behavior), not as a bug.
+
+Testing this expectation falls outside plan-mode dogfood scope. If you want to verify tool-op idempotency under re-execution, that belongs in a separate skill-side scenario targeting the specific tool op.
+
+**DO NOT expect plans to share state across user turns.**
+
+A plan's scope is the single user turn that triggered it (unless explicitly resumed via `/plan resume`). State written by one plan's steps is not automatically available to a subsequent plan triggered by the next user turn. Each plan has its own `plan_id`, its own snapshot, and its own decomposition artifact.
+
+If you observe state appearing to carry over between turns, investigate whether a workspace file (= P5 SSoT) was written by one plan and read by another — this is correct and expected. If plan-internal state (snapshot, decomposition) appears shared, that is a bug.
+
+**DO observe whether plan-mode is invoked by the LLM at all.**
+
+This is the most common plan-mode dogfood miss. If the router LLM never calls the `plan` tool, your scenario is not testing plan-mode regardless of how complex the query is. Before analyzing any plan-mode-specific finding, confirm in `REYN_LLM_TRACE_DUMP` that the router's turn contains a `plan` tool call. If it does not, the scenario is a skill-side routing scenario, not a plan-mode scenario.
+
+If you consistently cannot trigger plan-mode across multiple query formulations, apply Principle 4 (observation infrastructure) before forming hypotheses: dump the router's system prompt and tool schema, confirm the `plan` tool is present, and inspect what the router received. The router may not have the tool in its catalog for a given session configuration.
+
+---
+
 ## 7. Quickstart for new dogfooders
 
 ### Starting a new batch — checklist

--- a/docs/en/decisions/0023-plan-mode-forward-replay.md
+++ b/docs/en/decisions/0023-plan-mode-forward-replay.md
@@ -1,6 +1,7 @@
 # ADR-0023: Plan-Mode Crash Resilience — Phase 2 (Forward Replay)
 
-**Status**: Accepted + Implemented (2026-05-07)
+**Status**: Accepted + Implemented (2026-05-07);
+**amended 2026-05-08** (Phase 2.1 — async dispatch + multi-plan).
 **Track**: Plan-mode crash recovery — successor to ADR-0022 Phase 1.
 **Synthesized from**: 4 parallel design proposals (snapshot / analyzer / policy
 / runtime), authored 2026-05-07.
@@ -12,6 +13,102 @@
 → `5279341` (coordinator + reyn.yaml policy) → `1e529d7` (ChatSession +
 AgentRegistry integration). 1279 → 1373 passed (= 94 new Tier 2 tests).
 Phase 1 tests (10) + planner tests survived unchanged.
+
+## Phase 2.1 amendment (2026-05-08) — async dispatch + multi-plan
+
+**Motivation**: Phase 2 v1 dispatched the `plan` tool synchronously
+inside RouterLoop — the chat turn blocked until every step completed.
+This produced a worst-of-both UX: LLM narration was already bypassed
+(see `router_loop.py:428-449` plan special-case), but the await held
+the chat hostage. The async fix aligns plan-mode with the existing
+async patterns (`delegate_to_agent` / user-initiated `_spawn_skill` /
+auto-resume tasks) so the agent can answer quick follow-ups while a
+long plan completes in the background — human-like dispatch order.
+
+This amendment supersedes:
+
+- **§3.6** "ChainManager / cross-agent notify (preserved divergence)"
+  — plan now allocates its own `chain_id` per run, so cross-agent
+  notify (R-D14) and `/plan discard <plan_id>` work without special-
+  casing. The "implicit user-as-waiter" rationale is dropped.
+
+- **§3.7** "ADR-0012 carryover (no prompt at restart)" — the
+  "one-in-flight plan per chat session" premise no longer holds.
+  ADR-0012's no-prompt rationale stands on its remaining legs
+  (per-purity policy resolves adopt/cancel offline; child resume
+  handles ambiguity at the appropriate layer; slash discard is the
+  surgical escape hatch); the bulk-pressure argument no longer needs
+  the one-plan crutch.
+
+Other Phase 2 substrate (PlanSnapshot / PlanRegistry / analyzer /
+coordinator / WAL events) is unchanged — Phase 2 was already shaped
+around `list[plan_id]` / `dict[plan_id, ...]` so multi-plan correctness
+falls out without structural churn.
+
+### 2.1.1 Async dispatch contract
+
+`_DISPATCH_KIND["plan"] = "async"` joins `delegate_to_agent`. The
+RouterLoop tool dispatcher exits on async tool result; plan output
+flows back to the user via `host.put_outbox` from inside the runtime
+task, not via the tool result.
+
+`dispatch_plan_tool` returns `{"status": "spawned", "plan_id": ...}`
+immediately after `asyncio.create_task(PlanRuntime(...).run())`. The
+RouterLoop sees the spawn ack and exits — its job is done.
+
+The `router_loop.py:428-449` plan special-case (= "if status ok and
+text is set, emit directly to outbox") is removed. The runtime owns
+the outbox interaction:
+
+- per-step `kind="status"` narration ("step <sid> done") for
+  progress visibility (UI may suppress)
+- terminal aggregator → `kind="agent"` outbox with the final text
+  + `meta={plan_id, chain_id}` for UI tagging
+
+### 2.1.2 Per-plan chain_id
+
+Each plan run allocates a new `chain_id` in `dispatch_plan_tool`
+(`f"plan_{plan_id}"` or uuid-derived). PlanSnapshot's existing
+`chain_id` field carries it; resume restores the same chain_id so
+R-D14 cross-agent notify (`notify_chain_discarded`) fires for the
+right waiter on `/plan discard <plan_id>`.
+
+Implication for §3.6: plans now register a chain (= via
+ChainManager.register equivalent if the plan's child skills delegate
+to peers). The "preserved divergence" of Phase 2 v1 (= plan does NOT
+register its own chain_id) is replaced by full participation in the
+chain mechanism.
+
+### 2.1.3 Multi-plan crash semantics
+
+A user turn may yield multiple `plan` tool_calls (= LLM emits 2 in a
+single round, both spawn). Each gets its own `plan_id` + `chain_id`
++ snapshot dir. Crash mid-flight: `AgentSnapshot.active_plan_ids`
+holds N entries; `restore_all` calls `_recover_plans_for_agent` which
+iterates and spawns each via `_spawn_resumed_plan`.
+
+Memo replay across N plans is independent — analyzer filters WAL by
+`plan_id`, coordinator decides per-plan, no cross-plan coupling.
+
+WAL truncation floor extends naturally: `min(全 PlanSnapshot.last_step_applied_seq)`
+across all active plans + skills (= ADR-0001 single-floor invariant
+preserved).
+
+### 2.1.4 Outbox interleaving + ordering
+
+Multi-plan completions land in the outbox in **completion order**,
+not arrival order. UI distinguishes via `meta.plan_id`. This matches
+`_spawn_skill` semantics already familiar to users (= a skill
+spawned by a different turn can complete while the user types a new
+prompt). Race: none — outbox is a single writer queue per session.
+
+### 2.1.5 Test posture
+
+Multi-plan resume race is intentionally **not** covered by Tier 3
+e2e in the v1 cutover; it surfaces in dogfood (= 2-plan parallel
+spawn → kill -9 → restart → both resume to completion). Tier 2
+covers single-plan and the multi-plan registry/coordinator paths
+(already green from Phase 2 base).
 
 ## Context
 
@@ -454,7 +551,13 @@ coordinator forces `action="discard"` regardless of policy. A distinct
 outbox reason ("plan decomposition artifact missing or corrupt; please
 retry") clarifies the failure mode for the user.
 
-### 3.6 ChainManager / cross-agent notify (preserved divergence)
+### 3.6 ChainManager / cross-agent notify
+
+> **Superseded 2026-05-08 by Phase 2.1 §2.1.2 — per-plan chain_id.**
+> Each plan now allocates its own `chain_id`; R-D14 cross-agent
+> notify fires for plan abort directly. The "implicit user-as-waiter"
+> divergence below was the v1 design and is retained for historical
+> context only.
 
 ADR-0022 documented: plan-mode does **not** register its own
 `chain_id`; the user is the implicit waiter via outbox; R-D14
@@ -471,6 +574,13 @@ needed in plan-mode.
 
 ### 3.7 ADR-0012 carryover (no prompt at restart)
 
+> **Amended 2026-05-08 by Phase 2.1 §2.1 — multi-plan UX.** The
+> "one-in-flight plan per chat session at most" premise is dropped.
+> The remaining no-prompt arguments stand: per-purity policy is
+> offline, child resume handles its own ambiguity, slash discard is
+> the escape hatch. Bullet (i) is retained for historical context;
+> the no-prompt conclusion is unchanged.
+
 ADR-0012 retired skill bulk resume prompts because (i) ADR-0011's
 world-purity invalidation removed the structural ambiguity prompts
 were trying to rescue, (ii) binary "continue all / abort all" had no
@@ -479,8 +589,8 @@ author's `description` bore inappropriate UX weight.
 
 Plan-mode applies the same logic, with a stronger frequency argument:
 
-- One in-flight plan per chat session at most (= much lower bulk
-  pressure than skills).
+- ~~One in-flight plan per chat session at most~~ (superseded; multi-
+  plan is the default UX in Phase 2.1).
 - Per-purity policy resolves adopt-vs-cancel offline; no per-restart
   user input adds value.
 - Children's own `skill_resume` policy already handles their internal

--- a/docs/en/decisions/0023-plan-mode-forward-replay.md
+++ b/docs/en/decisions/0023-plan-mode-forward-replay.md
@@ -1,9 +1,17 @@
 # ADR-0023: Plan-Mode Crash Resilience — Phase 2 (Forward Replay)
 
-**Status**: Draft (2026-05-07)
+**Status**: Accepted + Implemented (2026-05-07)
 **Track**: Plan-mode crash recovery — successor to ADR-0022 Phase 1.
 **Synthesized from**: 4 parallel design proposals (snapshot / analyzer / policy
 / runtime), authored 2026-05-07.
+
+**Landing**: 7-step migration completed across commits `bcf1105`
+(decomposition artifact) → `65160e3` (PlanSnapshot) → `c1a953d` (PlanRegistry)
+→ `c2c3b24` (plan_step_* WAL promotion) → `488bfa9` (PlanRuntime thin wrapper)
+→ `c58840e` (dispatch_plan_tool migration) → `f1d81e3` (analyzer + memo replay)
+→ `5279341` (coordinator + reyn.yaml policy) → `1e529d7` (ChatSession +
+AgentRegistry integration). 1279 → 1373 passed (= 94 new Tier 2 tests).
+Phase 1 tests (10) + planner tests survived unchanged.
 
 ## Context
 

--- a/docs/en/decisions/0024-plan-step-result-spill.md
+++ b/docs/en/decisions/0024-plan-step-result-spill.md
@@ -1,0 +1,290 @@
+# ADR-0024: Plan step result spill-to-file (R-D10 mirror)
+
+**Status**: Accepted (2026-05-08)
+**Track**: Plan-mode persistence — closes ADR-0023 "Open issues:
+Step result size cap" deferred item.
+
+## Context
+
+ADR-0023 Phase 2 v1 stored each plan step's text output inline on
+`PlanSnapshot.step_results: dict[str, str]` and bounded each entry at
+32 KB with a `[truncated]` suffix:
+
+```python
+# src/reyn/plan/plan_registry.py
+_STEP_RESULT_MAX_CHARS = 32_768
+_STEP_RESULT_TRUNC_SUFFIX = "\n[truncated]"
+
+def _bound_step_result(text: str) -> str:
+    if len(text) <= _STEP_RESULT_MAX_CHARS:
+        return text
+    cap = _STEP_RESULT_MAX_CHARS - len(_STEP_RESULT_TRUNC_SUFFIX)
+    return text[:cap] + _STEP_RESULT_TRUNC_SUFFIX
+```
+
+ADR-0023's "Open issues" listed this as deferred:
+
+> **Step result size cap.** `step_results: dict[str, str]` could grow
+> pathologically (= multi-page web scrape). Phase 2 v1: bound at write
+> time (= 32KB truncation with "[truncated]" suffix). Spill-to-side-
+> files pattern (R-D10 mirror) deferred.
+
+The 32 KB bound exists for three reasons:
+1. **Atomic save cost** — `PlanSnapshot.save` does
+   `tmp + fsync + rename` on every step completion. Inline multi-MB
+   text would slow this down materially on long plans.
+2. **Memory footprint on restart** — `PlanRegistry.load_active`
+   materialises every per-plan snapshot in `dict[plan_id, PlanSnapshot]`.
+3. **Threshold consistency with R-D10** — skill-side
+   `step_completed.result` payloads ≥32 KB already spill via
+   `llm_result_ref.py`.
+
+The lossy nature of the bound is the cost: workflows where a single
+step produces >32 KB (multi-page scrape, long code generation,
+comprehensive analysis) silently corrupt downstream steps that depend
+on the truncated text.
+
+## Considered alternatives
+
+- **A. Always spill every step result to file.** Uniform code path
+  but adds disk I/O for every step (= chat-like steps that produce a
+  paragraph pay an open/write/fsync round-trip).
+- **B. Hybrid spill (= R-D10 mirror).** Inline ≤32 KB; spill >32 KB
+  to a per-plan workspace file; reads transparent via an accessor.
+  **Adopted.**
+- **C. Larger inline bound + lossy fallback.** Raise the cap to
+  e.g. 256 KB; still lossy past that. Postpones the problem without
+  solving it.
+
+## Decision
+
+Adopt **B**: hybrid spill mirroring `llm_result_ref.py` skill-side.
+
+### 1. Schema (additive, no version bump)
+
+`PlanSnapshot` grows one field, alongside the existing
+`step_results: dict[str, str]`:
+
+```python
+# Existing
+step_results: dict[str, str] = {}      # step_id → inline text (≤ THRESHOLD chars)
+
+# NEW — additive, additive, optional
+step_result_refs: dict[str, str] = {}  # step_id → relative path (chars > THRESHOLD)
+```
+
+`PLAN_SNAPSHOT_VERSION` stays at **1**. The new field defaults to
+empty for old snapshot files — backward-compatible load. New snapshot
+files written by post-ADR-0024 code remain readable by pre-ADR code
+because old code ignores unknown JSON keys (= forward-compatible at
+the format layer; the only loss is that pre-ADR code can't read the
+spilled content for any plan whose results spilled, which is a niche
+downgrade scenario).
+
+The 32 KB cap stays as the **inline-vs-spill threshold** but is no
+longer truncating — anything over it goes to file with full fidelity.
+
+### 2. Storage layout
+
+Per-plan directory already exists from ADR-0023 §3.5:
+
+```
+.reyn/agents/<name>/state/plans/<plan_id>/
+├── decomposition.json                    ← existing (ADR-0023 step 1)
+└── step_results/                         ← NEW (this ADR)
+    ├── s1.txt                            ← step output (raw text, UTF-8)
+    ├── s2.txt
+    └── s3.txt
+```
+
+`step_results/<step_id>.txt` is **plain UTF-8 text** — no JSON
+envelope, no checksums. Rationale: matches the data shape (the value
+is a Python `str`), keeps read-side simple (`Path.read_text`), and
+avoids gratuitous serialisation overhead. Crash-during-write yields a
+partial file; resume falls back to `step_result_file_missing` failure
+classification (see §4 below).
+
+Atomic write recipe mirrors `PlanSnapshot.save`:
+`tmp + fsync + rename`. Snapshot is rewritten *after* the file
+write succeeds so a crash between the two leaves the file orphaned
+but the snapshot still in pre-write state.
+
+### 3. Code path
+
+#### 3.1 Write path (`PlanRegistry.record_step_completed`)
+
+```python
+async def record_step_completed(self, *, plan_id, step_id, applied_seq, result_text):
+    snap = self._snapshots.get(plan_id)
+    if snap is None: return
+    # existing applied_seq / last_step_applied_seq bumps...
+
+    if len(result_text) <= _SPILL_THRESHOLD:
+        snap.step_results[step_id] = result_text
+        snap.step_result_refs.pop(step_id, None)        # if was a re-run that previously spilled
+    else:
+        path = self._step_result_path(plan_id, step_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # atomic write
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            f.write(result_text)
+            f.flush()
+            os.fsync(f.fileno())
+        tmp.replace(path)
+        snap.step_results.pop(step_id, None)            # clear inline if any
+        snap.step_result_refs[step_id] = f"step_results/{step_id}.txt"
+
+    # existing last_committed_step_id, save, hook fire...
+```
+
+`_bound_step_result` is **removed** — no truncation anywhere.
+
+#### 3.2 Read path (accessor)
+
+A new module-level helper:
+
+```python
+# plan_snapshot.py
+def get_step_result(snap: PlanSnapshot, agent_state_dir: Path,
+                    step_id: str) -> str | None:
+    """Return the step's recorded text, or None if not recorded.
+
+    Reads inline first (= cheap path for ≤ threshold), falls back to
+    file ref. Missing-file → None (= caller treats as not-recorded).
+    """
+    if step_id in snap.step_results:
+        return snap.step_results[step_id]
+    rel = snap.step_result_refs.get(step_id)
+    if rel is None:
+        return None
+    path = agent_state_dir / "plans" / snap.plan_id / Path(rel).name
+    # actually: full relative resolution under per-plan dir
+    full = agent_state_dir / "plans" / snap.plan_id / rel
+    try:
+        return full.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return None
+```
+
+`PlanResumeAnalyzer.analyze` and `execute_plan` memo replay both
+route through `get_step_result` instead of reading `snap.step_results`
+directly.
+
+#### 3.3 Cleanup path (`PlanRegistry.complete` + `/plan discard`)
+
+`reyn.plan.decomposition.delete_decomposition` currently removes
+`decomposition.json` and the per-plan directory only if empty. With
+`step_results/` subdirectory present the directory is no longer empty
+on the cleanup path, so it would orphan.
+
+**New helper** in `decomposition.py`:
+
+```python
+def delete_plan_workspace(agent_state_dir: Path, plan_id: str) -> bool:
+    """Recursively remove the per-plan directory + everything in it.
+
+    Idempotent. Returns True if the directory existed.
+    """
+    plan_dir = decomposition_dir(agent_state_dir, plan_id)
+    if not plan_dir.exists():
+        return False
+    shutil.rmtree(plan_dir, ignore_errors=True)
+    return not plan_dir.exists()
+```
+
+`delete_decomposition` keeps its existing single-file delete behaviour
+(= no breaking change for code paths that only want the decomposition
+file gone). `PlanRegistry.complete` is updated to call
+`delete_plan_workspace` when `delete_artifact=True` so the entire
+workspace dir (decomposition + step_results) is reclaimed atomically.
+
+`/plan discard` already calls `session.delete_plan_decomposition`;
+that will be updated to call the workspace-wide cleanup so spilled
+files are removed.
+
+#### 3.4 Reset path (`reset_from_step`)
+
+Already clears `snap.step_results` for the target step and after.
+With this ADR it must also:
+
+- Clear `snap.step_result_refs[sid]` for cleared steps
+- Delete `step_results/<sid>.txt` files for cleared steps (= prevent
+  stale spilled content from being read on the next launch)
+
+### 4. Crash semantics
+
+`step_results/<step_id>.txt` write failures are graceful:
+
+| Crash window | State on disk | Resume behaviour |
+|---|---|---|
+| Before file write starts | Snapshot has neither inline nor ref | Step classifies as `pending` (= re-execute) |
+| Mid-write (`.tmp` partial) | `.tmp` exists, `step_result_refs` not yet bumped | Same as above (= ref lookup empty → pending) |
+| After rename, before snapshot save | File exists, `step_result_refs` not yet bumped | File orphaned; cleaned by `delete_plan_workspace` on plan completion / discard |
+| After snapshot save, file later corrupt or unreadable | Ref present, file unreadable | `get_step_result` returns None → analyzer pairs as `failed("step_result_file_missing")` → coordinator `discard` policy applies (= safe) |
+
+The accessor's None return on read-failure is the safety valve. Callers
+treat None uniformly as "not recorded" — the analyzer maps it to
+`failed` with a descriptive `error_message`, and the discard coordinator
+path surfaces the situation to the operator via outbox notice.
+
+### 5. Migration
+
+No version bump. Existing snapshots load with `step_result_refs={}`
+(= empty dict default). Existing inline `step_results` keep working.
+Only newly-written results that exceed the threshold spill.
+
+Old plans' inline truncated content (= `[truncated]` suffix) is left
+as-is; on resume the analyzer sees the truncated content as the
+step's result (= same Phase 2 v1 behaviour). Operators who want the
+old plans re-run with full output use `/plan resume --from <step_id>`
+to clear the truncated entry and re-execute.
+
+## Consequences
+
+### Positive
+
+- **No silent data loss.** Step output of any size is preserved.
+- **Snapshot stays small.** Atomic-save cost remains constant
+  regardless of step output size.
+- **R-D10 alignment.** Plan-side spill mirrors skill-side spill;
+  future work could unify the helpers (`llm_result_ref.py` +
+  `step_result_ref` style helper) into a generic `WorkspaceRef`.
+- **No schema migration drama.** Additive field, no version bump,
+  old + new snapshots interoperate.
+
+### Negative
+
+- **Two read paths.** Inline vs file. Mitigated by the
+  `get_step_result` accessor — call sites stay simple.
+- **Disk I/O on large step.** Each >32 KB step pays open + write +
+  fsync. Negligible compared to the LLM call that produced the text.
+- **Crash window between file rename and snapshot save** orphans the
+  file. Handled by workspace-wide cleanup on plan completion /
+  discard. Worst case: a few orphan files until next plan_completed
+  / `/plan discard`.
+
+### Open issues / explicit non-goals
+
+- **Compression.** Spilled files are raw UTF-8. If a workflow
+  routinely produces multi-MB step results (= unusual for Reyn's
+  intended scope), gzip is straightforward future work.
+- **Per-step retention policy.** Currently spilled files live until
+  plan completion. A "bounded retention by N most-recent" policy
+  could be added if very long plans (= ≥ 50 steps) run.
+- **Generic `WorkspaceRef` helper.** Plan-side spill duplicates
+  some structure with skill-side `llm_result_ref.py`. Unification
+  deferred until both paths see independent maturity.
+
+## Cross-references
+
+- **ADR-0001** (state model — WAL + snapshot): snapshot stays cache;
+  spilled files are workspace-side.
+- **ADR-0023** (plan-mode forward replay): closes the §"Open issues:
+  Step result size cap" deferred item.
+- **R-D10** (LLM result payload size handling): same hybrid pattern,
+  skill-side. `src/reyn/skill/llm_result_ref.py` is the implementation
+  reference.
+- **P5** (Workspace is the single source of truth): step results
+  belong in workspace, not snapshot cache. This ADR aligns plan-mode
+  with that invariant.

--- a/docs/en/decisions/0025-plan-step-llm-memoization.md
+++ b/docs/en/decisions/0025-plan-step-llm-memoization.md
@@ -1,0 +1,254 @@
+# ADR-0025: Plan-step sub-loop LLM call memoization (R-D2 mirror)
+
+**Status**: Accepted (2026-05-08)
+**Track**: Plan-mode persistence — closes ADR-0023 §3.4 "Sub-loop work
+re-paid" deferred trade-off (LLM-cost subset).
+
+## Context
+
+ADR-0023 §3.4 explicitly accepted that sub-loop work re-pays on
+resume:
+
+> A step that did substantial pure-LLM work without spawning a skill
+> re-runs from scratch on resume. Acceptable per §3.4.
+
+Concretely: when a plan step's sub-loop (`RouterLoop`,
+`max_iterations=3`) crashes mid-flight, on resume the step is
+classified as `pending` and re-executes from act-turn 1. Any LLM
+calls already issued in turns 1..k re-pay; tool dispatches re-
+execute; the LLM may diverge from the original chain because the
+chat-history seed is identical but token sampling is non-deterministic
+across providers.
+
+R-D2 already solved this for skill-phase LLM calls via dispatcher
+memoization: a `ResumePlan.committed_steps` lookup keyed on
+`(op_invocation_id, args_hash)` returns the recorded `LLMCallResult`
+without invoking `call_llm`. Plan-mode lacks the equivalent.
+
+**LLM cost is the headline impact.** Tool dispatches inside a
+plan step's sub-loop are cheap (file ops in milliseconds, MCP read
+calls in 100 ms–1 s); LLM calls cost real money + 1–30 s wall time.
+Mirroring R-D2's LLM-call memoization for plan sub-loops captures
+~95 % of the value of full op-level memoization at a fraction of the
+implementation surface.
+
+## Considered alternatives
+
+- **A. Full op-level memoization (= R-D2 + dispatcher participation).**
+  Plan steps participate in `dispatch_tool`'s memo path. Highest
+  fidelity; broadest implementation surface (`DispatchContext` grows
+  plan-mode fields, new caller_kind, WAL event taxonomy expansion).
+- **B. LLM-only memoization within sub-loop (= this ADR).** Hook
+  `RouterLoop.call_llm_tools` with an optional `memo_provider`; record
+  each LLM call result on the per-plan snapshot; on resume, replay
+  recorded results before invoking. Tool dispatches re-execute fresh
+  (= acceptable cost). **Adopted.**
+- **C. Defer entirely until dogfood signal.** The original posture
+  (ADR-0023 §3.4 "Acceptable per §3.4"). Now overridden by user
+  judgment that LLM-cost preservation matters at production scale
+  before dogfood proves it.
+
+## Decision
+
+Adopt **B**. Mirror R-D2's memoization shape, but at the
+`call_llm_tools` boundary inside `RouterLoop` rather than at the
+`dispatch_tool` boundary.
+
+### 1. Persistence — snapshot-only, no new WAL kinds
+
+Storage on `PlanSnapshot`:
+
+```python
+# Existing
+step_results: dict[str, str] = {}        # ≤32 KB inline (ADR-0024)
+step_result_refs: dict[str, str] = {}    # >32 KB spilled (ADR-0024)
+
+# NEW
+step_llm_calls: dict[str, list[dict]] = {}
+# step_id → list of recorded LLM-call records, each record:
+# {
+#   "args_hash": str,        # 16-hex truncated SHA-256 of canonicalized inputs
+#   "result_inline": dict | None,    # ≤32 KB inline JSON
+#   "result_ref": str | None,         # path under step_llm_calls/<step_id>/<turn>.json (>32 KB)
+#   "usage": {"prompt_tokens": int, "completion_tokens": int, ...},
+# }
+```
+
+**No new WAL event kind.** Persistence is via `PlanSnapshot.save`
+called after each LLM call within a step. The atomic save cost (~1 ms)
+is negligible relative to the LLM call itself (1–30 s).
+
+Rejected alternative: introducing `plan_step_llm_completed` WAL
+events (= mirror skill side `step_completed` with `op_kind="llm"`).
+Adds WAL volume + new event kind for marginal benefit; snapshot-only
+is sufficient because the snapshot is already the cache for plan
+state.
+
+### 2. Spill (ADR-0024 mirror)
+
+Large LLM responses (>32 KB serialised) spill to a per-plan
+workspace file:
+
+```
+state/plans/<plan_id>/step_llm_calls/<step_id>/<turn_idx>.json
+```
+
+`step_llm_calls[step_id][i]["result_ref"]` holds the per-plan-dir
+relative path; reads go through a new accessor (mirror
+`get_step_result`).
+
+Per-plan workspace cleanup (= `delete_plan_workspace`) already
+recursively removes the entire `plans/<plan_id>/` dir, so spilled
+LLM payloads are reclaimed automatically on plan completion.
+
+### 3. Memo provider — encapsulates record + lookup
+
+```python
+# src/reyn/plan/sub_loop_memo.py
+class SubLoopMemoProvider:
+    """Per-step LLM memoization for plan sub-loops.
+
+    On miss: invoke proceeds normally; record() persists result for
+    future resume. On hit: invoke is skipped; recorded result
+    returned. Maps args_hash → record from PlanSnapshot.step_llm_calls
+    or, on resume, from PlanResumePlan.step_llm_call_log.
+    """
+    def get(self, args_hash: str) -> dict | None: ...
+    async def record(self, args_hash: str, result: dict, usage: dict) -> None: ...
+```
+
+`get` is sync (= snapshot read), `record` is async (= snapshot save +
+optional file spill).
+
+### 4. RouterLoop integration
+
+`RouterLoop.__init__` gains an optional `memo_provider:
+SubLoopMemoProvider | None = None`. When set,
+`call_llm_tools` is wrapped:
+
+```python
+# Compute args_hash from canonical inputs
+args_hash = _compute_llm_args_hash(model, messages, tools, ...)
+
+memoized = self._memo_provider.get(args_hash) if self._memo_provider else None
+if memoized is not None:
+    self._host.events.emit("plan_step_llm_memoized", ...)
+    return _from_recorded(memoized)
+
+# Normal call
+result = await call_llm_tools(...)
+if self._memo_provider is not None:
+    await self._memo_provider.record(args_hash, _serialise(result), result.usage)
+return result
+```
+
+`_compute_llm_args_hash` mirrors the existing R-D2 helper — same
+canonicalisation rules, same `current_datetime` strip, same SHA-256
+truncated to 16 hex.
+
+### 5. Resume plumbing
+
+`PlanResumeAnalyzer` extracts `snapshot.step_llm_calls` into a new
+field on `PlanResumePlan`:
+
+```python
+@dataclass(frozen=True)
+class PlanResumePlan:
+    ...                        # existing fields
+    step_llm_call_log: dict[str, list[dict]] = field(default_factory=dict)
+    # step_id → list of {args_hash, result_inline / result_ref, usage}
+```
+
+`planner.execute_plan` constructs a `SubLoopMemoProvider` per step
+on resume, seeded from `resume_plan.step_llm_call_log[step_id]`. The
+provider is passed to the sub-loop's `RouterLoop`.
+
+Per-step memo only. No cross-step memoization (= a step's LLM calls
+are scoped to its own sub-loop).
+
+### 6. Sub-loop turn ordering
+
+`args_hash` keys cover ordering. Sub-loop turn 1 calls LLM with
+prompt P1; turn 2 calls with P2 (= includes turn 1's tool result);
+etc. `_compute_llm_args_hash` produces distinct hashes per turn, so
+`step_llm_calls` is in effect a turn-indexed list keyed by hash.
+
+Crash-mid-turn-3 → resume: turn 1 hash hits the recorded turn-1
+result, returns memoized; turn 2 hash hits turn-2 record;
+turn 3 hash misses (= the call was never recorded) → fresh execution.
+
+### 7. Drift handling
+
+Provider-induced drift (= `current_datetime` not stripped, model
+versioning shift, etc.) surfaces as `args_hash` mismatch → fresh
+execution → `record` overwrites the entry by hash. The sub-loop pays
+fresh LLM cost but proceeds correctly.
+
+`current_datetime` is already R-D2-strip-on-canonicalise; reused
+verbatim.
+
+## Consequences
+
+### Positive
+
+- **LLM cost preserved across crash mid-step.** A 3-turn sub-loop
+  that crashed at turn 3 only pays for turn 3 on resume.
+- **No new WAL volume.** Persistence rides existing snapshot save
+  cadence.
+- **R-D2 alignment.** Same canonicalisation + memo shape as
+  skill-side LLM calls; future unification straightforward.
+- **No `_compute_llm_args_hash` duplication.** Reuse the helper
+  from `dispatcher.py` / `runtime.py`.
+
+### Negative
+
+- **Tool dispatches re-execute.** A sub-loop that called `web_fetch`
+  before the crashed LLM turn re-issues the fetch on resume. World-
+  purity ops (`web_search`, `web_fetch`) wanted that anyway
+  (= ADR-0011); side-effect ops (= `file/write`) are uncommon in
+  plan sub-loops because plan steps don't typically have write
+  permissions, so this is mostly benign.
+- **Snapshot save frequency increases.** Each LLM call within a
+  step now saves the snapshot. On a 3-turn step, snapshot saves
+  go from 1 (= step_completed) to 3-4. Atomic save is ~1 ms; total
+  added I/O is negligible.
+- **Snapshot grows by record metadata.** Each record holds
+  `args_hash` + `usage` + (small inline OR ref). For a 3-turn step
+  with all-inline ≤32 KB results, snapshot grows by ~10 KB. Spill
+  threshold caps inline growth.
+
+### Open issues / explicit non-goals
+
+- **Tool-op memoization within sub-loops.** Out of scope; sub-loop
+  tool dispatches re-execute. If dogfood reveals a hot expensive-tool
+  path (e.g. heavy MCP write), revisit with full op-level memoization
+  via Alternative A.
+- **Cross-step memoization.** Step boundaries reset memo state. A
+  multi-step plan that calls `summarise_doc` twice with the same args
+  in different steps re-pays both. Acceptable: cross-step
+  deduplication is a different design concern.
+- **Memo for `plan` tool itself.** Plan steps' sub-loop excludes
+  `plan` from its tool catalog (already enforced via
+  `RouterLoop.exclude_tools={"plan"}`); no nested-plan memo to
+  consider.
+- **Concurrency safety.** Snapshot save is single-writer per
+  PlanRegistry instance. Sub-loop awaits each LLM call serially, so
+  no race within a single step. Multi-plan concurrent saves go
+  through different PlanSnapshot objects (different files), no
+  contention.
+
+## Cross-references
+
+- **R-D2** (`src/reyn/kernel/runtime.py:_call_llm_and_record`): the
+  skill-side reference implementation.
+- **ADR-0023 §3.4** (sub-loop work re-paid): the deferred
+  trade-off this ADR closes for the LLM-call subset.
+- **ADR-0024** (per-plan step result spill): the same spill pattern
+  applies to LLM payloads >32 KB. Reuses
+  `delete_plan_workspace` for cleanup.
+- **R-D10** (`src/reyn/skill/llm_result_ref.py`): the LLM-spill
+  reference; ADR-0024 + this ADR converge on the same pattern.
+- **PR-memo-purity-fix M2** (world-op resume bypass): not directly
+  applicable here (sub-loops don't classify ops by purity); world
+  ops re-execute by virtue of "tool dispatches re-execute" in this
+  ADR's scope.

--- a/docs/en/reference/cli/chat.md
+++ b/docs/en/reference/cli/chat.md
@@ -56,8 +56,13 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/answer <id> <text>` | Answer a pending `ask_user` / permission prompt |
 | `/agents` | List loaded agents and which one is currently attached |
 | `/attach <name>` | Switch the REPL pointer to another agent (the previous one keeps running in the background) |
+| `/skill list` | Show active skill runs (id, name, current phase + parent lineage) |
+| `/skill discard <run_id>` | Abort a specific skill run + cleanup |
+| `/plan list` | Show active plan runs (combined view: in-flight tasks + pending-resume) |
+| `/plan discard <plan_id>` | Abort a specific plan run + cleanup; notifies waiting peer agents via R-D14 |
+| `/plan resume <plan_id> --from <step_id>` | Surgical operator escape hatch; clears step results from the target step onward and re-launches with a fresh resume_plan (ADR-0023 §3.7) |
 
-`/list` / `/cancel` / `/answer` are foundational — they let multiple skill runs and interventions coexist without blocking the prompt. `/agents` / `/attach` are the multi-agent workflow primitives.
+`/list` / `/cancel` / `/answer` are foundational — they let multiple skill runs and interventions coexist without blocking the prompt. `/agents` / `/attach` are the multi-agent workflow primitives. `/skill` and `/plan` are crash-recovery operator commands that surface the per-skill-run and per-plan-run lifecycle: inspect what is running, abort a stuck run, or surgically re-run a plan from a specific step.
 
 ## Multi-agent behavior
 
@@ -101,3 +106,5 @@ reyn chat --model strong
 - [Reference: state-dir](../config/state-dir.md) — `agents/` location
 - [Concepts: multi-agent](../../concepts/multi-agent.md)
 - [Concepts: memory](../../concepts/memory.md)
+- [Concepts: plan-mode](../../concepts/plan-mode.md)
+- [Concepts: skill-resume](../../concepts/skill-resume.md)

--- a/docs/ja/concepts/plan-mode.md
+++ b/docs/ja/concepts/plan-mode.md
@@ -51,8 +51,16 @@ chat turn は block しない:
 |---|---|---|
 | Decomposition (= plan 形状) | `agents/<name>/state/plans/<plan_id>/decomposition.json` | 残る |
 | Per-plan progress (= 完走 step + 結果) | `agents/<name>/state/plans/<plan_id>.snapshot.json` | 残る |
+| Step output (≤32 KB) | 上記 snapshot に inline | 残る |
+| Step output (>32 KB) | `agents/<name>/state/plans/<plan_id>/step_results/<step_id>.txt` | 残る |
 | Plan lifecycle event | `.reyn/state/wal.jsonl` (`plan_started` / `plan_step_*` / `plan_completed`) | 残る |
 | Active asyncio.Task | in-memory only | 失う — restart で auto-resume |
+
+32 KB を超える step output は per-plan workspace file へ spill する
+([ADR-0024](../decisions/0024-plan-step-result-spill.md)) ので、
+snapshot は小さいまま + truncation なしで完全 preserve。 read 側は
+`get_step_result(snap, agent_state_dir, step_id)` accessor が inline
+/ spilled を透過解決。
 
 `reyn chat` 起動時 `AgentRegistry.restore_all` が:
 

--- a/docs/ja/concepts/plan-mode.md
+++ b/docs/ja/concepts/plan-mode.md
@@ -105,13 +105,28 @@ auto-discard + 説明的 outbox notice。 planner LLM 再呼びはしない。
 ## Operator command
 
 ```
-/plan list                  — active plan 一覧 (running + resume pending)
-/plan discard <plan_id>     — abort + state cleanup
+/plan list                                — active plan 一覧 (running + resume pending)
+/plan discard <plan_id>                   — abort + state cleanup
+/plan resume <plan_id> --from <step_id>   — 特定 step から再実行
 ```
 
 `/plan discard` は asyncio.Task を cancel、 WAL に `plan_aborted` を
 記録、 decomposition artifact + snapshot を削除、 plan の chain で
 待っている peer agent に R-D14 notify。
+
+`/plan resume --from` は ADR-0023 §3.7 surgical escape hatch。 step が
+結果を記録したが operator が再実行したい場合 (= LLM 出力誤り / world
+state が変動して record 結果が陳腐化) 用。 handler の動作:
+
+1. 該当 plan の in-flight task を cancel
+2. decomposition artifact を load して topological step 順を取得
+3. `<step_id>` 以降の `step_results` / `step_failures` /
+   `spawned_skill_run_ids` を clear (= 前 step は preserve)
+4. `resume_plan` を再構築して通常 auto-resume path で起動 — 前 step は
+   memo replay (= LLM cost ゼロ)、 残り step を再実行
+
+未知 plan ID / decomposition artifact 欠落 (= `/plan discard` に誘導) /
+plan に存在しない step ID (= 有効 step ID 列挙) は明示エラー。
 
 ## Crash 分類
 

--- a/docs/ja/concepts/plan-mode.md
+++ b/docs/ja/concepts/plan-mode.md
@@ -62,6 +62,13 @@ snapshot は小さいまま + truncation なしで完全 preserve。 read 側は
 `get_step_result(snap, agent_state_dir, step_id)` accessor が inline
 / spilled を透過解決。
 
+各 step の sub-loop LLM 呼び出しも記録される
+([ADR-0025](../decisions/0025-plan-step-llm-memoization.md))。 step
+途中の crash で resume した際 LLM cost を再支払いしない。 sub-loop の
+`call_llm_tools` 呼び出しは `args_hash` で識別され、 resume 時は
+記録された結果を replay してから fresh call は crash した turn のみ
+が支払い対象になる。
+
 `reyn chat` 起動時 `AgentRegistry.restore_all` が:
 
 1. WAL を replay して各 agent の snapshot に反映

--- a/docs/ja/concepts/plan-mode.md
+++ b/docs/ja/concepts/plan-mode.md
@@ -1,0 +1,139 @@
+# Plan mode
+
+複雑な chat query を独立 sub-task に分解し、 narrow LLM call で各
+step を実行、 最終結果を user に返す仕組み。 process crash でも長
+plan が中断されずに復元される。
+
+## Plan mode とは
+
+multi-source synthesis や compare-and-contrast 等の複雑な query で、
+chat router が `plan` tool を呼んで構造化された分解を作る:
+
+```
+user query → planner LLM
+                ↓
+              [plan: 2-7 step + tools + 依存関係]
+                ↓
+              executor: 各 step が narrow LLM call で走る
+                ↓
+              terminal step の text → user reply
+```
+
+各 step は小さく focused な system prompt + 親 tool catalog の
+subset で動く。 これにより full router prompt + 14 tool を全 sub-
+task で持ち回る per-call context bloat を回避。
+
+Plan mode は **query 単位 opt-in** — router LLM が分解する価値ある
+query を見て `plan` を呼ぶ。 単純 query (= "hello" / 単一 tool call)
+は経由しない。
+
+## 非同期 dispatch
+
+`plan` は async tool として登録されている。 router LLM が呼んだ時
+chat turn は block しない:
+
+1. `dispatch_plan_tool` が plan を validate、 `plan_id` + per-plan
+   `chain_id` を allocate、 decomposition artifact を書き出し、
+   `PlanRuntime` task を spawn。
+2. router loop は async tool result を見て exit、 chat turn 終了。
+3. plan task は background で実行、 step 完走ごとに status message
+   を outbox に流して user に進捗が見える。
+4. terminal aggregator step の text が通常の agent message
+   (`kind="agent"`、 `meta.plan_id` で識別) として user に届く。
+
+「人間と同じく quick reply が先、 長い work は background で続行」
+の dispatch model。 plan in-flight 中に user は別 message を送れ、
+複数 plan が並行実行可能。
+
+## Crash に耐える state
+
+| State | 場所 | crash 跨ぎ |
+|---|---|---|
+| Decomposition (= plan 形状) | `agents/<name>/state/plans/<plan_id>/decomposition.json` | 残る |
+| Per-plan progress (= 完走 step + 結果) | `agents/<name>/state/plans/<plan_id>.snapshot.json` | 残る |
+| Plan lifecycle event | `.reyn/state/wal.jsonl` (`plan_started` / `plan_step_*` / `plan_completed`) | 残る |
+| Active asyncio.Task | in-memory only | 失う — restart で auto-resume |
+
+`reyn chat` 起動時 `AgentRegistry.restore_all` が:
+
+1. WAL を replay して各 agent の snapshot に反映
+2. `active_plan_ids` の各 plan について `_recover_plans_for_agent`:
+   - per-plan snapshot を load
+   - decomposition artifact を読み込み (= P5 SSoT、 planner LLM 再
+     呼びは決定論性なし → step ID が変わって memo 壊れる)
+   - resume coordinator (= analyzer + policy) で各 step を classify
+     (`pending` / `completed_with_result` / `failed` /
+     `interrupted_with_child`)
+   - `PlanRuntime` task を `resume_plan` 付きで spawn → 完走済 step
+     は memo replay (= LLM cost ゼロ)、 pending step だけ再実行
+
+長 plan の resume で LLM token を再課金しない。
+
+## Multi-plan + 完走順応答
+
+複数 plan が同時 in-flight 可能。 各 plan は独立した `plan_id` +
+`chain_id` + decomposition dir を持つ。 outbox message は **完走順**
+(= 依頼順ではない)、 `meta.plan_id` で識別。 30 秒 plan が 5 分 plan
+より先に完走すれば先に user に届く。
+
+WAL truncation floor は全 active plan の `last_step_applied_seq` を
+含むので、 plan 進行中に resume analyzer が必要とする step event が
+誤 truncate されない。
+
+## Resume policy
+
+`reyn.yaml` で coordinator の挙動を設定:
+
+```yaml
+plan_resume:
+  default: retry_pending       # retry_pending | discard
+  child_purity:                # plan step が child skill spawn した時
+    pure:        cancel        # 冪等 + 安価 → 再実行
+    world:       adopt         # child 自身の resume 機構に委ねる
+    side_effect: adopt
+    external:    adopt
+    llm:         adopt
+```
+
+- `retry_pending` (default) — 完走 step は memo、 残りを再実行
+- `discard` — plan を abort、 cancel flag 付き child を停止、 outbox
+  に user 再依頼 notice
+
+decomposition artifact が無い / 壊れている plan は coordinator が
+auto-discard + 説明的 outbox notice。 planner LLM 再呼びはしない。
+
+## Operator command
+
+```
+/plan list                  — active plan 一覧 (running + resume pending)
+/plan discard <plan_id>     — abort + state cleanup
+```
+
+`/plan discard` は asyncio.Task を cancel、 WAL に `plan_aborted` を
+記録、 decomposition artifact + snapshot を削除、 plan の chain で
+待っている peer agent に R-D14 notify。
+
+## Crash 分類
+
+[skill resume](skill-resume.md) と同じ exception-aware finally
+pattern:
+
+| Exit | 結果 |
+|---|---|
+| 正常 return | `plan_completed` 記録、 artifact 削除、 user に terminal text 配送 |
+| `WorkflowAbortedError` | clean abort 扱い、 artifact 削除 |
+| 一般 `Exception` / `KeyboardInterrupt` | `plan_run_interrupted` event、 artifact 残置、 restart で auto-resume |
+| `kill -9` | `finally` skip、 artifact 残置、 restart で auto-resume |
+
+artifact 残置 invariant が resume の前提 — artifact が消えると
+coordinator は plan 形状を復元できず discard へ fallback。
+
+## Cross-references
+
+- [skill resume](skill-resume.md) — 兄弟設計、 plan は同じ WAL +
+  snapshot + analyzer + coordinator pattern を再利用
+- [permission model](permission-model.md) — plan step は per-step
+  narrow tool catalog で動く
+- [events](events.md) — `plan_*` / `plan_step_*` audit trail
+- ADR-0022 (Phase 1 fail-safe)、 ADR-0023 (Phase 2 forward replay +
+  Phase 2.1 async dispatch)

--- a/docs/ja/contributing/dogfood-discipline.md
+++ b/docs/ja/contributing/dogfood-discipline.md
@@ -449,6 +449,331 @@ Reyn の 3 つのツール (`REYN_LLM_TRACE_DUMP` / `dogfood_trace.py` / `llm_re
 
 ---
 
+## 6.5 Plan-mode dogfood の特殊観点
+
+> **このセクションは plan-mode がテスト対象に入った時点から適用します。** セクション 3 の 9 原則は変更なく適用されます。変わるのは観測軸です。plan-mode は非同期 dispatch / 並行 in-flight plan / resume 時の memo replay を導入します。これらは skill-side dogfood では決して現れない観測面です。
+
+---
+
+### 6.5.1 なぜ plan-mode には特別な discipline が必要か
+
+Skill-side dogfood は、skill の phase graph が LLM の確率的決定の下で正しく実行されるかを検証します。Plan-mode はそれに加えて、質的に異なる 3 つの関心事を導入します。
+
+**非同期 dispatch と completion 順序。** Plan は background の `asyncio.Task` として実行されます。プランが in-flight の間も、ユーザーは新しいメッセージを送れます。複数のプランが重複できます。 Outbox メッセージはユーザーが issue した順ではなく、completion 順に届きます。これらの性質は skill-side のトレースでは見えません。意図的に concurrent plan を実行して outbox を観測したときのみ現れます。
+
+**Resume 時の memo replay。** クラッシュ耐性 (ADR-0023 + ADR-0025) の価値はコードを読んでテストできません。プロセスを mid-step で kill し、再起動して、完了済みのステップが追加の LLM コストを発生させず同一の output を返すことを確認する必要があります。これは skill-side のいかなるテストとも異なる観測経路です。
+
+**ルーター側の LLM 呼び出し。** Plan-mode はチャットルーター LLM が `plan` ツールを選ぶことでトリガーされます。Skill-side dogfood とは異なり — そこではユーザーがどの skill を呼び出すかを制御する — plan-mode はルーター LLM が確率的に「分解が有益だ」と判断することに依存します。人間の判断では「十分複雑」なクエリでも、ルーター LLM が一貫して直接回答を好めば plan-mode はトリガーされません。プランの invocation 自体が観測ポイントであり、前提ではありません。
+
+セクション 3 の原則は引き続き適用されます — 特に原則 4 (先に観測 infra を作る)、原則 6 (verify-first / reproduce-first)、原則 3 (1 仮説 1 修正 1 検証) — ただし具体的な観測面は skill-side dogfood と異なります。
+
+---
+
+### 6.5.2 新しい観測面
+
+Plan-mode は 6 つの異なる場所に永続的な状態を生産します。それぞれ目的と decay ライフサイクルが異なります。
+
+| 観測面 | 場所 | 何を見るか |
+|---|---|---|
+| WAL | `state/wal.jsonl` | `plan_started` / `plan_completed` / `plan_aborted` / `plan_step_started` / `plan_step_completed` / `plan_step_failed` — resume の基盤 |
+| Events log (forensic 専用) | `events/<caller>/...` | `plan_emitted` / `plan_aggregated` / `plan_run_interrupted` / `plan_step_memoized` / `plan_step_memo_failed` / `plan_step_llm_memoized` |
+| Per-plan snapshot | `state/plans/<plan_id>.snapshot.json` | `step_results` / `step_result_refs` / `step_llm_calls` — resume を駆動する永続キャッシュ |
+| スピルした step 結果 | `state/plans/<plan_id>/step_results/<step_id>.txt` | ADR-0024 — 32 KB 超の output のみスピル、それ以外は inline |
+| スピルした LLM call 記録 | `state/plans/<plan_id>/step_llm_calls/<step_id>/<turn_idx>.json` | ADR-0025 — 32 KB 超の結果のみスピル |
+| Outbox (= UI / TUI) | `session.outbox` キュー、chat REPL でも可視 | `kind=status` per-step 進捗ナレーション; `kind=agent` 最終テキスト (`meta.plan_id` 付き) |
+| 実行中タスク | `session.running_plans: dict[plan_id, asyncio.Task]` | `/plan list` slash コマンドで確認 |
+
+**各観測面の読み方 discipline:**
+
+- **WAL を先に読む。** WAL は resume の primary な基盤であり、最速で読める観測面です。step が完了したと主張するなら、`plan_step_completed` が存在しなければなりません。存在しなければ、その step はコミットされていません — snapshot に古いデータが入っている可能性があります。
+- **次に snapshot を読む。** Snapshot は resume coordinator が読む対象です。memo 化を期待するステップに対して `step_results` (inline) または `step_result_refs` (スピル) が populated されているか確認します。
+- **因果関係には events log を使う。** `plan_step_memoized` と `plan_step_llm_memoized` は memo パスが実際に起動したことを確認します。結果が存在するだけでは不十分です。 Events log はこの forensic 用途にのみ使います — 運用チェックには使いません。
+- **User 向け正確性には outbox を使う。** Outbox はユーザーが見るものです。`meta.plan_id` タグが並行 plan の output を区別するメカニズムです。各 plan の最終テキストが正しい `plan_id` を持つか確認します。
+
+---
+
+### 6.5.3 ツール cheat sheet
+
+`dogfood_trace.py` ユーティリティは既存の skill-side モードに加えて plan 専用のモードを公開します。
+
+```bash
+# Plan-mode サマリー (= プラン数 / memo ヒット数 / 最大並行数)
+python scripts/dogfood_trace.py --mode plan-summary
+
+# Per-plan タイムライン (= 1 plan_id の WAL + events log + outbox)
+python scripts/dogfood_trace.py --mode plan-trace <plan_id>
+
+# Per-plan workspace dump (= decomposition + snapshot + スピルファイル)
+python scripts/dogfood_trace.py --mode plan-snapshot <plan_id>
+
+# Cost モード (= memo 節約額の見積もりが追加された)
+python scripts/dogfood_trace.py --mode cost
+```
+
+> 注: `--mode plan-summary` / `plan-trace` / `plan-snapshot` はこのセクションと同じ prep wave で追加されます。まだ landing していない場合、このドキュメントは forward-looking です。モードが landing するまでは WAL / snapshot の手動確認で同等の観測を行ってください。
+
+既存の skill-side モードはセクション 6 を参照してください。`--mode cost` の出力は共有です — skill-side と plan-side の LLM call コストを両方含み、plan の resume が firing した場合は memo 節約額が別途 breakdown されます。
+
+Attractor detector (`scripts/detect_attractor.py`) は plan-mode でも有用です。個別ステップの実行内の empty-stop / enum violation attractor を検出するために、sub-loop のトレース dump に対して実行します。
+
+```bash
+REYN_LLM_TRACE_DUMP=plan_trace.jsonl reyn chat
+python scripts/detect_attractor.py --root .reyn/  # step レベルの attractor をキャッチ
+```
+
+---
+
+### 6.5.4 Plan-mode 向け scenario 設計
+
+Batch 設計 (A1 ステップ) において、plan-mode は固有の性質を行使する意図的に構築されたシナリオを必要とします。5 つの scenario クラスが主要なリスク面をカバーします。
+
+#### クラス 1: 多ソース合成 (long-step)
+
+**目的。** ルーター LLM が分解を要するクエリに対して実際に plan-mode を呼び出すかを検証し、decomposition と aggregation が coherent であることを確認します。
+
+**クエリ例。** 「README と CLAUDE.md を比較して、新規コントリビューター向けに主な違いをまとめてください。」
+
+**観測するもの。**
+1. ルーター LLM が `plan` ツールを呼び出すか? (`REYN_LLM_TRACE_DUMP` でルーターのターンに `plan` ツール呼び出しがあるか確認)
+2. Decomposition が well-formed か (2〜7 ステップ、循環依存なし)?
+3. 最終集約ステップが両ソースを参照した coherent な回答を生産するか?
+
+**Verified の定義。** ルーターが `plan` を呼び出す; `state/plans/<plan_id>/decomposition.json` が存在する; outbox が `meta.plan_id` 付きの `kind=agent` メッセージを受け取る; コンテンツが両ドキュメントを参照している。
+
+**Refuted の定義。** ルーターが `plan` を呼ばずに直接回答する。これはバグではありません (ルーターが直接回答の方が適切と判断した可能性がある)。しかし、あなたのシナリオが plan-mode をテストできていないことを意味します。クエリをより明示的に多ソースに修正します。
+
+**Blocked の定義。** ルーターがツール呼び出しを生産する前にエラーになる。Plan-mode finding ではなく、prior-layer のバグとして扱います。
+
+#### クラス 2: 並行 plan (multi-plan UX)
+
+**目的。** 複数の in-flight plan が completion 順に正しくタグ付けされた outbox output を生産するかを検証します。Issue 順ではありません。
+
+**実行方法。** 2 つのユーザープロンプトを back-to-back で issue します (どちらの plan が完了する前に)。短い plan (2 ステップ) と長い plan (5 ステップ) を使います。Outbox の順序を観測します。
+
+**観測するもの。**
+1. Outbox が 2 つの別々の `meta.plan_id` タグ付き最終メッセージを受け取るか?
+2. 短い plan のメッセージが長い plan より先に届くか — どちらが先に issue されたかに関わらず?
+3. どちらかが完了する前に `/plan list` が両プランを active として表示するか?
+
+**Verified の定義。** 2 つの distinct な `plan_id` 値; 短い plan の `kind=agent` メッセージが先に届く; 両プランが state collision なく完了する。
+
+**Refuted の定義。** Duration に関わらず Issue 順に完了する — outbox 順序が誤っていることを示唆する。または state collision (一方の plan の step 結果が他方の snapshot に現れる)。
+
+**Blocked の定義。** ルーターが 2 つのクエリのうち 1 つのみで plan-mode をトリガーする。
+
+#### クラス 3: Crash + resume
+
+**目的。** ADR-0023 (step 結果 memoization) と ADR-0025 (sub-loop LLM call memoization) が resume 時に firing するかを検証します。これはクラッシュ耐性の信頼性にとって最も重要な scenario クラスです。
+
+**実行方法。**
+1. 複数ステップの plan を開始する (クラス 1 以上)。
+2. WAL でステップ 1 が `plan_step_completed` を emit するまで待つ。
+3. `reyn chat` プロセスを mid-step-2 で `kill -9` する。
+4. `reyn chat` を再起動する。
+5. Resume 挙動を観測する。
+
+**観測するもの。** (完全な手順は 6.5.5 を参照)
+
+**Verified の定義。** ステップ 1 が resume 時に新しい LLM コストを発生させない (`plan_step_memoized` event が firing する); ステップ 2 が中断地点から再実行される; プランが正しく完了する。
+
+**Refuted の定義。** ステップ 1 が resume 時に LLM コストを再発生させる (`plan_step_memoized` event なし、cost ledger にステップ 1 の呼び出しの新しいエントリ)。
+
+**Blocked の定義。** `_recover_plans_for_agent` が firing しない (ログメッセージが不在) — WAL replay または agent registry restore パスに plan-mode の upstream でバグがあることを示唆する。
+
+#### クラス 4: operator escape hatch
+
+**目的。** `/plan list` / `/plan discard <plan_id>` / `/plan resume <plan_id> --from <step_id>` が live および interrupted な plan に対して正しく動作するかを検証します。
+
+**観測するもの。**
+1. `/plan list` — in-flight plan 中に正しい `plan_id` / step 数 / running/pending 状態を表示するか。
+2. `/plan discard` — タスクをキャンセルし、`plan_aborted` を WAL に書き込み、decomposition artifact と snapshot を削除し、outbox 通知を送るか。
+3. `/plan resume --from <step_id>` — 指定したステップから再実行し、それ以前のステップが memo-replay され (LLM コストなし)、最終 output が再実行ステップを反映するか。
+
+**Verified の定義。** 各コマンドが期待される WAL エントリと outbox 状態変化を生産する。
+
+**Refuted の定義。** `/plan discard` が decomposition artifact を削除しない — stale artifact ghost のリスク (6.5.6 anti-pattern を参照)。
+
+#### クラス 5: long-tail step (> 32 KB output)
+
+**目的。** ステップが 32 KB を超える output を生産したときに、ADR-0024 step 結果スピルがデータロスなしにトリガーされるかを検証します。
+
+**実行方法。** 大きなテキスト output を合成するステップを構築します (例: 「`src/` 以下の全ファイルがエクスポートするシンボルを列挙してください」 — 中規模コードベースで通常 > 32 KB)。
+
+**観測するもの。**
+1. Snapshot に `step_results.<step_id>` ではなく `step_result_refs.<step_id>` が現れるか?
+2. `state/plans/<plan_id>/step_results/<step_id>.txt` が存在し、truncation なしに完全な output を含むか?
+3. Downstream の集約ステップが完全なコンテンツを受け取るか (= `get_step_result` による透過的解決)?
+
+**Verified の定義。** `step_result_refs` が populated; スピルファイルが存在する; downstream ステップのコンテンツがスピルファイル内にのみ存在するコンテンツを参照している (= truncation なし)。
+
+**Refuted の定義。** 32 KB 超にもかかわらず output が snapshot に inline で現れる — スピルがトリガーされなかった。または: スピルファイルが存在するが downstream ステップが truncated なバージョンを受け取った。
+
+---
+
+### 6.5.5 Memo ヒット検証手順
+
+これは ADR-0023 (step 結果 memoization) と ADR-0025 (sub-loop LLM call memoization) の両方が resume 時に正しく replay されることを確認するための step-by-step 手順です。クラス 3 scenario を実行するときにこの手順を実行します。
+
+**ステップ 1: plan を完走させる (baseline)。**
+
+クリーンな state directory から開始します (`state/plans/` が空または active plan を含まない)。複数ステップの plan (3 ステップ以上推奨) を実行し、完走させます。以下を記録します:
+- WAL または `/plan list` からの `plan_id`。
+- `python scripts/dogfood_trace.py --mode cost` の cost ledger output (新鮮な実行の LLM コストを比較用にキャプチャ)。
+
+**ステップ 2: 同じクエリを再実行し、mid-step-2 で kill する。**
+
+同じクエリを再実行します。これで新しい `plan_id` を持つ新しいプランが開始されます。WAL でステップ 1 (`s1`) の `plan_step_completed` を監視します。これが現れたら即座にプロセスを `kill -9` します。ステップ 2 (`s2`) は進行中または未開始のはずです。
+
+**ステップ 3: `reyn chat` を再起動する。**
+
+Resume パスは起動時に自動的にトリガーされます。ログ出力を観察します:
+```
+_recover_plans_for_agent fired for agent <name>, plan_id <id>
+```
+このメッセージが不在の場合、WAL replay または agent registry restore パスに plan-mode の upstream で問題があります — prior-layer のバグとして report します。
+
+**ステップ 4: per-plan snapshot を開く。**
+
+```bash
+cat state/plans/<plan_id>.snapshot.json | python -m json.tool
+```
+
+以下を確認します:
+- `step_results.s1` (inline) **または** `step_result_refs.s1` (スピル) がステップ 1 の最初の実行結果で populated されている。
+- `step_llm_calls.s1` が sub-loop の記録された LLM call エントリで populated されている。
+
+どちらかが不在の場合、kill 前に snapshot がコミットされませんでした — kill タイミングが早すぎました。より長いステップで再試行します。
+
+**ステップ 5: events log で `plan_step_memoized` を監視する。**
+
+再起動後、そのプランの events log を観察します:
+
+```bash
+python scripts/dogfood_trace.py --mode plan-trace <plan_id>
+```
+
+`s1` に対して (`plan_step_completed` ではなく) `plan_step_memoized` が現れることを確認します。区別:
+- `plan_step_completed` = ステップが新鮮に実行された。
+- `plan_step_memoized` = ステップが LLM 呼び出しなしに snapshot から replay された。
+
+代わりに `s1` に対して `plan_step_completed` が現れた場合、memo replay が firing しませんでした — ステップ 1 が再実行され、新しい LLM コストが発生しています。
+
+**ステップ 6: s1 内の sub-loop 呼び出しに対して `plan_step_llm_memoized` を監視する。**
+
+ステップ 1 が複数の sub-loop ターン (= ステップ executor 内の複数の LLM 呼び出し) を含む場合、kill 前に記録された各 sub-loop LLM 呼び出しが resume 時に `plan_step_llm_memoized` を emit するはずです。これが ADR-0025 のメカニズムです — ステップが部分的にしか完了していない場合でも、sub-loop の LLM コストの再支払いを防ぎます。
+
+**ステップ 7: s1 に追加 LLM コストがないことを確認する。**
+
+Resume 完了後、`python scripts/dogfood_trace.py --mode cost` を実行します。Resume された plan の cost ledger は以下を示すはずです:
+- ステップ 1 (`s1`): $0.00 (または 0 tokens) — memo ヒット。
+- ステップ 2 以降 (`s2`...): 新鮮なコスト — これらは再実行された。
+
+`s1` が非ゼロコストを示す場合、ステップ 1 の memoization が firing しませんでした。これは HIGH バグです: クラッシュ耐性の主張が満たされていません。
+
+**ステップ 8: plan が正しく完了することを確認する。**
+
+Resume された plan は baseline 実行 (ステップ 1) と同じ最終 output で完了するはずです。Output が実質的に異なる場合 (単なる空白 / トークンサンプリングの分散ではなく)、memo replay がデータの破損を導入しています。CRITICAL として report します。
+
+---
+
+### 6.5.6 Plan-mode 特有の patterns / anti-patterns
+
+このセクションはセクション 4 の patterns / anti-patterns を plan-mode 固有のケースに拡張します。skill-side の layer-by-layer パターンと downstream symptom パターンについてはセクション 4 を参照してください — それらは equally here に適用されます。
+
+#### Pattern: multi-plan の completion 順序は設計によるもの、偶然ではない
+
+2 つのプランが in-flight で、短い方が先に完了した場合、outbox の順序は**正しい挙動**です — タイミングの偶然ではありません。各 `kind=agent` メッセージの `meta.plan_id` タグが、順序が issue 順と異なる場合でも UI が正しいプランに output を帰属させるためのメカニズムです。
+
+scenario 設計への示唆: クラス 2 (concurrent plans) を実行する際、outbox メッセージの `meta.plan_id` 値を明示的に確認します。どのプランがどの output を生産したかを位置だけで判断しないでください。`meta.plan_id` 帰属なしに plan output を混在して表示する UI は UX バグです。Plan-mode のバグではありません。
+
+#### Pattern: 32 KB 閾値の境界で spill vs inline が混在するのは正常
+
+ステップ結果が snapshot に inline で入るか、ファイルにスピルするかは、書き込み時の output サイズで決まります。両方のパスが正しいです。あるステップがスピルし、別のステップが inline に収まるテスト batch は inconsistency のサインではありません — シナリオの実際の output サイズ分布を反映しているだけです。
+
+> 32 KB の output を生産するためにシナリオを意図的に構築した場合 (クラス 5) 以外は、「このステップは必ずスピルしなければならない」という特別ケースのアサーションを追加しないでください。汎用シナリオでは両方を有効なアウトカムとして扱い、downstream ステップがパスに関わらず正しいコンテンツを受け取ったかのみを確認します。
+
+#### Anti-pattern: `plan_step_failed` をハードエラーとして扱う
+
+Per-step の失敗は plan runtime によってキャッチされ記録されます。プランは後続のステップの実行を継続します (= 失敗したステップの output が downstream ステップに必要な場合を除く)。WAL で `plan_step_failed` が見つかった dogfood finding は**自動的に HIGH バグではありません** — 以下によります:
+1. 失敗が期待されていたか (ステップのクエリに有効な回答がなかった)。
+2. Downstream ステップが欠落した入力を gracefully に処理したか。
+3. 最終集約ステップが失敗にもかかわらず coherent な output を生産したか。
+
+`plan_step_failed` が現れた場合、severity をエスカレートする前に graceful degradation を確認します。プランが失敗を認識した coherent な output で完了した場合、severity は MED (劣化しているが壊れていない) です。プランが失敗を surfacing せずに誤った集約 output をサイレントに生産した場合、severity は HIGH (データ正確性の問題) です。
+
+cross-ref: これはセクション 4 の「downstream symptom のマスキング」の plan-mode 版です — 可視的な失敗 event が常に root-cause の finding とは限りません。
+
+#### Anti-pattern: stale decomposition artifact での再実行
+
+以前の実行の `state/plans/<plan_id>/decomposition.json` が残っている場合 (例: cleanly 完了しなかった `/plan discard` の後、または artifact が削除される前の手動 kill の後)、resume coordinator は新しい実行の `plan_id` に対して古いプラン形状を replay しようとします。結果は予測不能です: step ID が一致しない場合があり、memoization が誤ったステップに対して firing する場合があり、coordinator が corrupt artifact の通知でプランを完全に discard する場合があります。
+
+**フレッシュスタートシナリオを行使する batch 間は、`state/plans/` を完全にクリーンにしてください:**
+
+```bash
+rm -rf .reyn/state/plans/
+```
+
+これはクラス 3 (crash + resume) またはクラス 5 (long-tail) のシナリオを実行する前に必須です。それ以前の中断実行が artifact を残している場合。Batch 間に実行することは安全です — クリーンアップ後、WAL は削除された artifact を参照しません。
+
+---
+
+### 6.5.7 Plan-mode 向けの calibration 調整
+
+セクション 5 は 4 区分 outcome 分類 (verified / inconclusive / refuted / blocked) と一般的な base rate を確立します。Plan-mode batch では、各 batch の実行前に 3 つの per-scenario バイナリ予測を追加します。
+
+**バイナリ予測 1: 「Resume 時に memo が firing する」(クラス 3 scenario)**
+
+これはテスト可能なバイナリ主張です。次のように表現します: 「ステップ 1 完了後の mid-step-2 での kill-9 の後、resume 時にステップ 1 に対して `plan_step_memoized` が現れる。」
+
+最初の plan-mode batch の suggested prior: 60% verified (= メカニズムは存在するが、kill タイミングがコミットウィンドウを見逃す場合があり、blocked になる可能性がある)。そこからキャリブレートします。
+
+**バイナリ予測 2: 「Multi-plan の completion 順序が issue 順ではなく duration 順になる」(クラス 2 scenario)**
+
+次のように表現します: 「短い duration の plan の `kind=agent` メッセージが長い duration の plan より前に outbox に現れる。」
+
+Suggested prior: 70% verified (= 設計がこれを保証するが、並行 LLM タイミングにより両プランが 1 秒以内に完了して順序が曖昧になる場合がある)。「inconclusive」は両プランが 1 秒以内に完了する場合のアウトカムです。
+
+**バイナリ予測 3: 「手動介入なしに 32 KB スピルがトリガーされる」(クラス 5 scenario)**
+
+次のように表現します: 「32 KB 超の output を生産するステップが snapshot に `step_result_refs` を emit し、スピルファイルが `state/plans/<plan_id>/step_results/<step_id>.txt` に存在する。」
+
+Suggested prior: 75% verified (= 決定論的な閾値だが、特定のシナリオで LLM が確実に > 32 KB を生産するように構築するには、LLM の output verbosity の事前知識が必要であり、これは変動する)。
+
+**Plan-mode 予測の Brier スコアリング。**
+
+これら 3 つのバイナリをセクション 5 と同じ Brier 式で batch ごとにスコアリングします。Skill-side の予測と別々に追跡します — plan-mode と skill-side は異なる base rate プロファイルを持ち、十分なデータが揃うまでプールすべきではありません。
+
+Plan-mode batch の期待 Brier score 軌跡 (skill-side batch 7〜9 との構造的アナロジーによる rough prior):
+- Batch 1 (plan-mode): 0.7〜0.9 (観測面が馴染みなく、kill タイミングが不安定)
+- Batch 2〜3 (plan-mode): 0.3〜0.5 (観測面を習得し、kill タイミングを練習)
+- Batch 4 以降 (plan-mode): 9 原則を一貫して適用すれば 0.2〜0.3
+
+---
+
+### 6.5.8 やってはいけないこと (scope の discipline)
+
+Plan-mode は**チャットルーター側の機能**です。そのスコープは、単一エージェントの runtime 内でのプランの dispatch / execution / memoization / resume です。Skill-side dogfood やマルチエージェント連携と混同しないでください。
+
+**Sub-loop のツールオペレーション memoization 期待をテストしない。**
+
+ADR-0023 §3.4 はツールオペレーション (= 非 LLM ツール dispatch) の memoization を plan resume 設計から明示的に defer しています。Plan のステップが resume するとき、その sub-loop のツール dispatch (例: ファイル読み込み / workspace 書き込み) は**再実行します** — これは documented な設計であり、バグではありません。「ファイル読み込みが resume 時に繰り返された」という dogfood finding は `verified` (正しい挙動) と分類すべきです。バグではありません。
+
+この期待のテストは plan-mode dogfood スコープ外です。ツールオペレーションの再実行下での idempotency を検証したい場合、それは特定のツールオペレーションを対象とした別の skill-side scenario に属します。
+
+**Plan がユーザーターン間で状態を共有することを期待しない。**
+
+プランのスコープは、それをトリガーしたユーザーの単一ターンです (`/plan resume` 経由で明示的に resume された場合を除く)。あるプランのステップによって書き込まれた状態は、次のユーザーターンにトリガーされた後続のプランに自動的には利用できません。各プランは独自の `plan_id` / snapshot / decomposition artifact を持ちます。
+
+あるターンから次のターンへ状態が引き継がれているように見える場合、あるプランのステップが workspace ファイル (= P5 SSoT) に書き込み、別のプランがそれを読んでいないか調査してください — これは正しく期待される動作です。プラン内部の状態 (snapshot / decomposition) が共有されているように見える場合、それはバグです。
+
+**LLM が plan-mode を実際に呼び出すかどうかを必ず観測する。**
+
+これは plan-mode dogfood で最もよく見逃されるポイントです。ルーター LLM が `plan` ツールを呼び出さない場合、クエリがどれほど複雑でも、あなたのシナリオは plan-mode をテストしていません。plan-mode 固有の finding を分析する前に、`REYN_LLM_TRACE_DUMP` でルーターのターンに `plan` ツール呼び出しが含まれることを確認します。含まれない場合、そのシナリオは plan-mode ではなく skill-side のルーティングシナリオです。
+
+複数のクエリ表現を試みても一貫して plan-mode をトリガーできない場合、仮説を立てる前に原則 4 (観測 infra) を適用します。ルーターの system prompt と tool schema を dump し、`plan` ツールが存在することを確認し、ルーターが何を受け取ったかを確認します。セッション設定によってはルーターのカタログに `plan` ツールが含まれていない場合があります。
+
+---
+
 ## 7. 新規 dogfooder 向け quickstart
 
 ### 新 batch 開始時 — checklist

--- a/docs/ja/reference/cli/chat.md
+++ b/docs/ja/reference/cli/chat.md
@@ -56,8 +56,13 @@ reyn chat researcher
 | `/answer <id> <text>` | 保留中の `ask_user` / Permission プロンプトに回答 |
 | `/agents` | 読み込まれた agent と現在アタッチされているものを一覧表示 |
 | `/attach <name>` | REPL ポインターを別の agent に切り替える（前の agent はバックグラウンドで実行し続ける） |
+| `/skill list` | 実行中の Skill 実行を表示（id / 名前 / current_phase + 親子関係） |
+| `/skill discard <run_id>` | 特定の Skill 実行を中止して cleanup を実行 |
+| `/plan list` | 実行中の Plan を表示（動作中 task と resume 待ちを組み合わせて表示） |
+| `/plan discard <plan_id>` | 特定の Plan を中止して cleanup を実行。R-D14 経由で待機中の peer agent に通知 |
+| `/plan resume <plan_id> --from <step_id>` | 特定 step から Plan を再実行するオペレーター向け escape hatch（ADR-0023 §3.7） |
 
-`/list` / `/cancel` / `/answer` は基盤となります。複数の Skill 実行と介入がプロンプトをブロックせずに共存できます。`/agents` / `/attach` はマルチエージェントワークフローのプリミティブです。
+`/list` / `/cancel` / `/answer` は基盤となります。複数の Skill 実行と介入がプロンプトをブロックせずに共存できます。`/agents` / `/attach` はマルチエージェントワークフローのプリミティブです。`/skill` / `/plan` は crash recovery オペレーターコマンドで、per-skill-run / per-plan-run のライフサイクルを surface します。
 
 ## マルチエージェントの動作
 
@@ -101,3 +106,5 @@ reyn chat --model strong
 - [リファレンス: state-dir](../config/state-dir.md) — `agents/` の場所
 - [コンセプト: multi-agent](../../concepts/multi-agent.md)
 - [コンセプト: memory](../../concepts/memory.md)
+- [コンセプト: plan-mode](../../concepts/plan-mode.md)
+- [コンセプト: skill-resume](../../concepts/skill-resume.md)

--- a/docs/journal/dogfood/2026-05-08-batch-16-plan-mode-validation/prelude.md
+++ b/docs/journal/dogfood/2026-05-08-batch-16-plan-mode-validation/prelude.md
@@ -1,0 +1,369 @@
+# Batch 16 (plan-mode validation — first real LLM dogfood) — Prelude
+
+> Phase 1 完了 (batch 14、 2026-05-06) 以降に landing した plan-mode 全実装
+> (ADR-0022/0023/0024/0025 + Phase 2.1 async dispatch) を **初めて実 LLM で観測**
+> する batch。 30+ commit が Tier 2 test で validated だが real LLM 未通過。
+> 設計の成立 / 不成立を observe-first で記録する。
+
+---
+
+## 1. Batch 16 直前の Reyn 状態
+
+| 項目 | 値 |
+|---|---|
+| Date | 2026-05-08 |
+| main HEAD | `4912457` |
+| Test suite | 1373 passed / 2 xfailed (= ADR-0023 Phase 2 で 94 new Tier 2 tests 追加) |
+| 最終 real LLM batch | batch 14 (2026-05-06、 N=5 chain 100%、 production-grade phase 1 完了) |
+| Plan-mode commits | 30+ (= batch 14 以降、 全て Tier 2 only、 real LLM 未通過) |
+
+### Plan-mode landing 履歴 (新着順)
+
+```
+4912457  test(plan): multi-plan crash + resume integration (Tier 2, ADR-0023 §2.1.5)
+4cc764c  feat(plan): ADR-0025 sub-loop LLM memo + Phase 2 fresh-run wiring fix
+80e4977  feat(plan): ADR-0024 per-plan step result spill-to-file (R-D10 mirror)
+619b2ad  feat(plan): /plan resume --from <step_id> + slash docs (ADR-0023 §3.7)
+891f0fd  docs(plan-mode): concept docs (en + ja) + plan file completion entries
+b1da83b  feat(plan): WAL truncation floor + /plan slash commands (ADR-0023 follow-up)
+a13caaa  feat(plan): Phase 2.1 — async dispatch + per-plan chain_id (ADR-0023)
+a03e69f  docs(adr): ADR-0023 Phase 2.1 amendment — async dispatch + multi-plan
+3a7c02f  docs(adr): ADR-0023 status Draft → Accepted + Implemented
+1e529d7  feat(plan): step 7d — ChatSession + AgentRegistry auto-resume (ADR-0023 Phase 2)
+5279341  feat(plan): step 7c — PlanResumeCoordinator + reyn.yaml policy (ADR-0023 Phase 2)
+f1d81e3  feat(plan): step 7a/7b — PlanResumeAnalyzer + memo replay (ADR-0023 Phase 2)
+c58840e  feat(plan): step 6 — dispatch_plan_tool via PlanRuntime + artifact (ADR-0023 Phase 2)
+...
+```
+
+### Batch 1–15 の軌跡 (参照)
+
+| Batch | Date | マイルストーン |
+|---|---|---|
+| 1–6 | 2026-05-04 | 基盤 fix / attractor 特定 |
+| 7–9 | 2026-05-04 | infra 整備 + fix wave |
+| 10 | 2026-05-05 | 「chain 完走史上初」 (後に N=1 lucky case と判明) |
+| 11 | 2026-05-05 | N=5 測定、 B11-NEW-1 blocker 特定 |
+| 12 | 2026-05-06 | N=5 real milestone 確定 (3/5+) |
+| 13 | 2026-05-06 | doc 違反 revert + V3 wording + N=5 (4/5 = 80%) |
+| 14 | 2026-05-06 | N=5 (5/5 = 100%) → production-grade phase 1 完了 |
+| 15 | — | plan-mode 設計 ADR / spike (= real LLM 未実施) |
+
+---
+
+## 2. Batch 16 のゴール (= 観測したい問い)
+
+plan-mode 実装が Tier 2 test で closed-form に検証された設計どおりに、
+**実 LLM + 実 I/O** 下で動作するかを観測する。 問いを 5 つに絞る:
+
+| # | 問い |
+|---|---|
+| G1 | Router LLM は multi-source / multi-step タスクに対して `plan` tool を自律的に invoke するか |
+| G2 | Crash (`:cancel` / kill -9) 後の auto-resume で memo replay が正しく fire するか |
+| G3 | 32 KB を超える step result が spill-to-file を自動 trigger するか |
+| G4 | 並行 plan 2 本が `/plan list` で正しく visible になり、 両方の terminal text が user に届くか |
+| G5 | `/plan list / discard / resume --from` operator コマンドが real session で period どおりに機能するか |
+
+---
+
+## 3. Out of scope
+
+以下は batch 16 で観測しない:
+
+- **Sub-loop tool-op memoization** (= ADR-0023 §3.4 明示 defer、 LLM-cost 観測 motivation のみ記録)
+- **Audit hash chain** (= scope 独立、 plan-mode と無関係)
+- **OSS Lv.1 release prep** (= 別 axis)
+- **G4 spike (strong model)** (= cost 10x deferred、 batch 14 判断継続)
+
+---
+
+## 4. 5 シナリオ
+
+### S1: multi-source synthesis
+
+**1-line goal**: router が 2 読み込み + 1 合成 の 3-step plan を自律的に立案するかを観測。
+
+**ユーザー prompt 系列**:
+```
+> "README.md と CLAUDE.md を読んで、両者を比較する 3 段落の文章を書いて"
+```
+
+**利用可能 tool / skill**: `file_read`、 `direct_llm` (or plan tool 経由の sub-step)
+
+**観測ポイント**:
+- `plan` tool が invoke された (= events に `plan_created` が存在)
+- step 数が 2 以上 (= 1 file_read + 1 synthesis 以上)
+- 最終 aggregator の出力テキストが user の outbox に届く (= `kind="agent"` event)
+- step ごとの `plan_step_completed` event が WAL に記録される
+- Plan の全 step が complete になる (= `plan_completed` event)
+
+**検証基準**:
+- **verified**: `plan` invoke + 3-step 構成 + terminal text 到達
+- **inconclusive**: plan invoke されたが step 数が 1 (= 合成のみ、 読み込みは plan 外)
+- **refuted**: router が直接 text-reply (= plan invoke なし)
+- **blocked**: `plan` tool 自体がクラッシュ / exception
+
+**予測**:
+- verified: 40%
+- inconclusive: 20%
+- refuted (plan invoke なし): 30%
+- blocked: 10%
+
+> **リスクノート**: batch 1-14 で router LLM の text-reply attractor (= G1/G23) を
+> 繰り返し観測。 plan tool は新規追加なので attractor の degree は未知。 refuted 30%
+> は保守的だが現実的。
+
+---
+
+### S2: concurrent plans
+
+**1-line goal**: 2 本の plan が独立して走り、 両方の terminal text が user に届くかを観測。
+
+**ユーザー prompt 系列**:
+```
+# turn 1
+> "src/reyn/ 以下のファイル一覧を列挙して、各ファイルの役割を 1 行で説明して"
+# turn 2 (turn 1 の plan が完了する前に送信)
+> "CLAUDE.md を読んで、最も重要なルールを 3 つ挙げて"
+```
+
+**利用可能 tool / skill**: `file_read`、 `list_files`、 `direct_llm`
+
+**観測ポイント**:
+- `/plan list` で 2 本が表示される (= 2 個の `plan_id` が active)
+- `plan_created` event が 2 件
+- 両方の plan に `plan_completed` event が来る
+- terminal text が completion order で 2 件 outbox に届く (= UI ordering)
+- `plan_step_completed` が plan_id ごとに正しく分離されている
+
+**検証基準**:
+- **verified**: 2 plan 同時 active + 両 terminal 到達 + `/plan list` 正常表示
+- **inconclusive**: 1 本は完了、 もう 1 本が途中で詰まる
+- **refuted**: 2 本目 plan が 1 本目完了を wait して直列化 (= async 実装バグ)
+- **blocked**: 2 本目 turn で exception / crash
+
+**予測**:
+- verified: 35%
+- inconclusive: 25%
+- refuted (直列化): 20%
+- blocked: 20%
+
+> **リスクノート**: Phase 2.1 async dispatch は Tier 2 で multi-plan を検証済み (= `4912457`)
+> だが、 real RouterLoop と ChatSession の組み合わせは未観測。 outbox ordering が
+> TUI 側に正しく伝わるかも未確認。
+
+---
+
+### S3: crash + resume
+
+**1-line goal**: plan 実行中に crash させ、 auto-resume + memo replay が火を噴くかを観測。
+
+**ユーザー prompt 系列**:
+```
+# turn 1: 4-5 step の plan を trigger
+> "src/reyn/ 以下の各 Python ファイルを読んで、クラス名と主要メソッドを列挙して"
+# step 2 or 3 の途中で:
+#   option A: ":cancel" を送信
+#   option B: process に SIGKILL (= kill -9 <pid>)
+# その後 reyn chat を再起動
+```
+
+**利用可能 tool / skill**: `file_read`、 `list_files`
+
+**観測ポイント**:
+- 再起動後に auto-resume が fire する (= `plan_resume_started` event)
+- `PlanResumeAnalyzer` が completed step を `s1..sk` と判定 (= events に記録)
+- crashed step が re-execute される (= `plan_step_started` が再度 emit)
+- completed step の LLM memo が replay される (= fresh LLM call なし、 cost 節約)
+- `dogfood_trace.py --mode plan-snapshot <plan_id>` で snapshot が健全
+
+**検証基準**:
+- **verified**: auto-resume + crashed step 以降が re-execute + completed step は skip
+- **inconclusive**: auto-resume は fire したが memo replay が不完全 (= 一部 LLM 再実行)
+- **refuted**: auto-resume しない (= plan が `abandoned` のまま)
+- **blocked**: resume 中に exception / crash (= 二重 crash)
+
+**予測**:
+- verified: 45%
+- inconclusive: 25%
+- refuted: 15%
+- blocked: 15%
+
+> **リスクノート**: `:cancel` と kill -9 では crash context が異なる (= WAL flush 済みか否か)。
+> option A (`:cancel`) は WAL truncation floor (= `b1da83b`) が関係するので先に試す。
+> ADR-0025 の LLM memo replay は `4cc764c` で実装済みだが fresh-run wiring fix も同 commit
+> なので両方を同時に観測することになる。
+
+---
+
+### S4: operator commands
+
+**1-line goal**: `/plan list`、 `/plan discard <plan_id>`、 `/plan resume <plan_id> --from <step_id>` が real session で設計どおりに動くかを観測。
+
+**ユーザー prompt 系列**:
+```
+# turn 1: plan を起動
+> "README.md と CLAUDE.md と docs/en/concepts/plan-mode.md を読んで要約して"
+# step 1 完了直後 (= まだ plan running 中) に:
+> "/plan list"
+# plan 完了後:
+> "/plan discard <plan_id>"
+# 別途: step 2 完了時点で resume をテスト
+> "/plan resume <plan_id> --from <step_id>"
+```
+
+**利用可能 tool / skill**: `file_read`
+
+**観測ポイント**:
+- `/plan list` が plan_id + status + step 進捗を表示する
+- `/plan discard <plan_id>` が plan を discarded state にし、 以後の step が中止される
+- discard 後に cross-agent notify (= `notify_chain_discarded`) が fire する
+- `/plan resume --from <step_id>` が指定 step から replay を開始する
+- cleanup 後に `plan_discarded` event が WAL に記録される
+
+**検証基準**:
+- **verified**: 3 コマンド全てが設計どおりの state 遷移 + event を生成
+- **inconclusive**: 一部コマンドが no-op または部分的に機能
+- **refuted**: コマンドが認識されない / slash handler が未登録
+- **blocked**: いずれかのコマンドで exception
+
+**予測**:
+- verified: 50%
+- inconclusive: 25%
+- refuted: 10%
+- blocked: 15%
+
+> **リスクノート**: slash コマンド登録は `b1da83b` + `619b2ad` で実装済み。
+> ただし slash handler と RouterLoop / PlanRegistry の integration は Tier 2 test の
+> カバレッジ範囲外の可能性あり。 real session での挙動は未知。
+
+---
+
+### S5: large output (32 KB+ spill)
+
+**1-line goal**: 1 step の出力が 32 KB を超えたときに spill-to-file が自動 trigger するかを観測。
+
+**ユーザー prompt 系列**:
+```
+> "src/reyn/ 以下の全 Python ファイルを列挙し、各ファイルについて
+>  クラス名・主要メソッド・役割を 2-3 文で説明して"
+```
+
+**利用可能 tool / skill**: `file_read`、 `list_files`、 `direct_llm`
+
+**観測ポイント**:
+- step result の文字数が 32,768 超 (= `STEP_RESULT_MAX_CHARS` threshold)
+- `.reyn/plans/<plan_id>/step_<sid>.txt` ファイルが生成される (= spill-to-file)
+- `PlanSnapshot.step_results[sid]` が `{"ref": "step_<sid>.txt"}` 形式になる
+- downstream synthesis step が spill ファイルから full text を読み込む
+- `dogfood_trace.py --mode plan-snapshot <plan_id>` で ref 形式を確認できる
+- `[truncated]` suffix が **ない** (= lossy truncation の排除を確認)
+
+**検証基準**:
+- **verified**: spill file 生成 + downstream step が full text を受信 + truncation なし
+- **inconclusive**: spill は trigger したが downstream step が ref 解決に失敗 (= partial text)
+- **refuted**: 32 KB 超でも inline 保存 (= spill 未発火 / threshold 設定ミス)
+- **blocked**: spill 書き込みで I/O exception
+
+**予測**:
+- verified: 55%
+- inconclusive: 20%
+- refuted: 15%
+- blocked: 10%
+
+> **リスクノート**: ADR-0024 spill は `80e4977` で実装、 Tier 2 で threshold 動作を確認済み。
+> ただし「src/reyn/ 全ファイル記述」が実際に 32 KB を超えるかは LLM の verbosity 依存。
+> 超えない場合は別プロンプト (= 大きな log ファイルの解析等) でリトライ。
+
+---
+
+## 5. N=5 信頼性目標
+
+| 指標 | 目標 |
+|---|---|
+| 実行回数 | 各シナリオ × N=5 (= 計 25 runs) |
+| production-grade pass 基準 | 各シナリオ 4/5 以上 verified |
+| Brier score 目標 | ≤ 0.30 (= batch 13-14 の 0.20 水準を意識しつつ、 初回 plan-mode で uncertainty 高め) |
+| 全体 pass 基準 | 5 シナリオ中 3 以上が 4/5 verified (= batch 14 と同じ閾値) |
+
+Brier score 入力:
+
+| シナリオ | verified 予測 | refuted 予測 | blocked 予測 |
+|---|---|---|---|
+| S1 (synthesis) | 40% | 30% | 10% |
+| S2 (concurrent) | 35% | 20% | 20% |
+| S3 (crash+resume) | 45% | 15% | 15% |
+| S4 (operator cmd) | 50% | 10% | 15% |
+| S5 (32KB spill) | 55% | 15% | 10% |
+
+---
+
+## 6. 実行フロー (A1–A5 チェックポイント)
+
+```
+A1: このプレリュード (= シナリオ設計完了)
+    ↓
+A2: ユーザーがシナリオを review + 承認 (= A3 dispatch 前の必須 gate)
+    ↓
+A3: 並列 Sonnet dispatch (= シナリオごとに別 worktree + 別 agent_state_dir)
+    5 session × N=5 = 25 runs
+    各 session: REYN_LLM_TRACE_DUMP=/tmp/batch16/<scenario>.jsonl
+    ↓
+A4: 各 session の findings を aggregate
+    dogfood_trace.py --mode plan-summary --root <session_root>
+    → CRITICAL / HIGH / MED / LOW に分類
+    ↓
+A5: fix wave または tracker へ登録
+    ↓
+retrospective: prediction calibration + Brier score + open issues
+```
+
+### A3 並列 dispatch の隔離方針
+
+各 sonnet session は:
+- 独立 worktree: `.claude/worktrees/batch16-s<N>/`
+- 独立 agent_state_dir: `.reyn-b16-s<N>/`
+- 環境変数: `REYN_LLM_TRACE_DUMP=/tmp/batch16/s<N>.jsonl`
+- 実行: `reyn chat --agent-state-dir .reyn-b16-s<N>/`
+
+→ session 間の WAL / snapshot / event が干渉しない。
+
+---
+
+## 7. Tooling リマインダー
+
+| ツール | 用途 |
+|---|---|
+| `REYN_LLM_TRACE_DUMP=/tmp/batch16/<scenario>.jsonl` | 各 session の LLM call 全記録 |
+| `dogfood_trace.py --mode plan-summary --root <session_root>` | plan 実行サマリ (step 進捗 + status) |
+| `dogfood_trace.py --mode plan-trace <plan_id>` | 異常 plan の step-by-step trace |
+| `dogfood_trace.py --mode plan-snapshot <plan_id>` | crash recovery シナリオの state 検査 |
+| `dogfood_trace.py --mode cost` | memo 節約が cost summary に反映されているか確認 |
+| `dogfood_trace.py --mode summary --root <session_root>` | event 全体サマリ (= 既存 mode、 比較用) |
+
+---
+
+## 8. Open questions / リスク項目
+
+| # | リスク | 観測 signal |
+|---|---|---|
+| R1 | Router LLM が `plan` tool を invoke しない (= G1/G23 attractor の plan-mode 版) | S1 / S2 で refuted rate > 40% |
+| R2 | async dispatch の outbox ordering が TUI に正しく届かない (= multi-plan UX confusion) | S2 で terminal text の ordering が逆転 / 欠落 |
+| R3 | 32 KB threshold が weak LLM の実際の verbosity に対して高すぎる (= spill 未発火) | S5 で actual output < 32 KB |
+| R4 | WAL truncation floor と `:cancel` の interaction で resume が不完全 | S3 で inconclusive rate > 30% |
+| R5 | `/plan resume --from` が step_id の形式不一致で拒否 (= slash handler の input validation) | S4 で blocked rate > 20% |
+| R6 | multi-plan 時に plan_id が TUI に表示されず operator が `/plan discard` できない | S4 で list 表示が空 |
+
+---
+
+## 9. 参照リンク
+
+- batch 14 retro: `../2026-05-06-batch-14-stability-extension/retrospective.md`
+- ADR-0022 (crash fail-safe): `../../en/decisions/0022-plan-mode-crash-fail-safe.md`
+- ADR-0023 (forward replay + Phase 2.1 async): `../../en/decisions/0023-plan-mode-forward-replay.md`
+- ADR-0024 (step result spill): `../../en/decisions/0024-plan-step-result-spill.md`
+- ADR-0025 (sub-loop LLM memo): `../../en/decisions/0025-plan-step-llm-memoization.md`
+- plan-mode concept (en): `../../en/concepts/plan-mode.md`
+- plan-mode concept (ja): `../../ja/concepts/plan-mode.md`
+- dogfood discipline: `../../en/contributing/dogfood-discipline.md`
+- giveup-tracker: `../giveup-tracker.md`

--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -14,7 +14,7 @@ Usage:
     python scripts/dogfood_trace.py --mode llm-payloads --trace a.jsonl --trace b.jsonl
     python scripts/dogfood_trace.py --mode llm-payloads --trace a.jsonl,b.jsonl
 
-    # Time-travel replay modes (new):
+    # Time-travel replay modes:
     python scripts/dogfood_trace.py --mode replay --trace <path> [--scope step|phase|skill_run]
     python scripts/dogfood_trace.py --mode replay --trace <path> --at run_xyz:copy_to_work:3
     python scripts/dogfood_trace.py --mode compare --before <trace_a> --after <trace_b> [--scope phase]
@@ -25,6 +25,11 @@ Usage:
     python scripts/dogfood_trace.py --mode compare \\
         --before .reyn/state/wal.jsonl --before .reyn/llm_trace.jsonl \\
         --after .reyn/state/wal.jsonl.bak --after .reyn/llm_trace.jsonl.bak
+
+    # Plan-mode dogfood modes (ADR-0022/0023/0024/0025 awareness):
+    python scripts/dogfood_trace.py --mode plan-summary
+    python scripts/dogfood_trace.py --mode plan-trace <plan_id>
+    python scripts/dogfood_trace.py --mode plan-snapshot <plan_id>
 """
 from __future__ import annotations
 
@@ -110,6 +115,456 @@ def mode_cost(root: Path) -> None:
     print(f"  Total: ${total_usd:.6f}  |  {total_tokens:,} tokens  |  {len(entries)} calls\n  Per-model:")
     for model, m in sorted(per_model.items(), key=lambda x: -x[1]["usd"]):
         print(f"    {model}: ${m['usd']:.6f}  {m['tokens']:,} tokens  ({m['calls']} calls)")
+
+    # Plan-mode memo savings (ADR-0023 + ADR-0025) — count from events log.
+    evs = _all_events(root)
+    step_memo_hits = sum(1 for e in evs if e.get("type") == "plan_step_memoized")
+    llm_memo_hits = sum(1 for e in evs if e.get("type") == "plan_step_llm_memoized")
+    if step_memo_hits or llm_memo_hits:
+        n_calls = len(entries)
+        avg_usd = (total_usd / n_calls) if n_calls else 0.0
+        avg_tokens = (total_tokens / n_calls) if n_calls else 0
+        saved_usd = llm_memo_hits * avg_usd
+        saved_tokens = llm_memo_hits * avg_tokens
+        print(f"\nPlan-mode memo savings (ADR-0023 + ADR-0025):")
+        print(f"  step-result memoizations:  {step_memo_hits} events  (= step memo replay)")
+        print(f"  LLM-call memoizations:     {llm_memo_hits} events  (= sub-loop LLM memo replay)")
+        print(f"  estimated saved cost:      ${saved_usd:.4f}   (= {llm_memo_hits} LLM-call hits × ${avg_usd:.5f} avg)")
+        print(f"  estimated saved tokens:    ~{int(saved_tokens):,}    (= {llm_memo_hits} hits × {int(avg_tokens):,} avg per call)")
+
+
+# ---------------------------------------------------------------------------
+# Plan-mode dogfood modes (ADR-0022/0023/0024/0025)
+# ---------------------------------------------------------------------------
+
+_PLAN_WAL_KINDS = {
+    "plan_started", "plan_completed", "plan_aborted",
+    "plan_step_started", "plan_step_completed", "plan_step_failed",
+}
+_PLAN_FORENSIC_KINDS = {
+    "plan_emitted", "plan_aggregated", "plan_run_interrupted",
+    "plan_step_memoized", "plan_step_memo_failed", "plan_step_llm_memoized",
+}
+_ALL_PLAN_KINDS = _PLAN_WAL_KINDS | _PLAN_FORENSIC_KINDS
+
+
+def _load_wal(root: Path) -> list[dict]:
+    """Load WAL events from state/wal.jsonl, normalised to events-log shape.
+
+    Real WAL entries (per ``state_log.append``) have a flat structure:
+
+        {"seq": 42, "ts": "...", "kind": "plan_started", "plan_id": "ab12",
+         "goal": "...", "n_steps": 3, ...fields}
+
+    Events-log entries are nested:
+
+        {"type": "plan_step_started", "timestamp": "...",
+         "data": {"plan_id": "ab12", ...}}
+
+    This normalisation reshapes WAL entries into the events-log layout
+    (``type`` + ``timestamp`` + ``data``) so downstream code can handle
+    both uniformly. The original raw dict is preserved under
+    ``data["_wal_raw"]`` for callers that need it.
+    """
+    raw_entries = _load_jsonl(root / "state" / "wal.jsonl")
+    normalised: list[dict] = []
+    _META_KEYS = {"seq", "ts", "kind"}
+    for raw in raw_entries:
+        kind = raw.get("kind", "")
+        ts = raw.get("ts", "") or raw.get("timestamp", "")
+        # Pull every non-meta key into data so downstream "data.plan_id"
+        # access works on both shapes.
+        data = {k: v for k, v in raw.items() if k not in _META_KEYS}
+        data["_wal_raw"] = raw  # preserve for any caller that needs the original
+        normalised.append({
+            "type": kind,
+            "timestamp": ts,
+            "data": data,
+            # Keep "kind" too so callers that filter by either key work.
+            "kind": kind,
+        })
+    normalised.sort(key=lambda e: e.get("timestamp", ""))
+    return normalised
+
+
+def _parse_ts(ts: str | None) -> float | None:
+    """Parse ISO8601 timestamp to float seconds since epoch. Returns None on failure."""
+    if not ts:
+        return None
+    try:
+        from datetime import timezone
+        s = ts.replace("Z", "+00:00")
+        try:
+            from datetime import datetime as _dt
+            dt = _dt.fromisoformat(s)
+        except Exception:
+            dt = datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception:
+        return None
+
+
+def mode_plan_summary(root: Path) -> None:
+    """Aggregate plan-mode telemetry across WAL + events log.
+
+    Combines plan lifecycle from WAL (plan_started/completed/aborted) with
+    forensic events (plan_emitted, plan_aggregated, plan_run_interrupted,
+    plan_step_memoized, plan_step_llm_memoized) from the events log.
+    """
+    wal_evs = _load_wal(root)
+    log_evs = _all_events(root)
+
+    # Separate plan-relevant events from each source.
+    wal_plan = [e for e in wal_evs if e.get("kind") in _ALL_PLAN_KINDS]
+    # Events log uses "type" (not "kind") following the existing mode_chain convention.
+    log_plan = [e for e in log_evs if e.get("type") in _ALL_PLAN_KINDS]
+
+    all_plan_evs = sorted(wal_plan + log_plan, key=lambda e: e.get("timestamp", ""))
+
+    if not all_plan_evs:
+        print("no plan events found (no plan-mode runs recorded)")
+        return
+
+    # Collect per-plan info from WAL (lifecycle source of truth).
+    # WAL entries use "kind" as the event type field.
+    plans_started: dict[str, dict] = {}  # plan_id → {goal, ts, n_steps}
+    plans_completed: dict[str, str] = {}  # plan_id → ts
+    plans_aborted: dict[str, str] = {}   # plan_id → ts
+
+    for e in wal_evs:
+        kind = e.get("kind", "")
+        data = e.get("data", {}) or {}
+        ts = e.get("timestamp", "")
+        pid = data.get("plan_id", "")
+        if not pid:
+            continue
+        if kind == "plan_started":
+            plans_started[pid] = {"goal": data.get("goal", ""), "ts": ts, "n_steps": data.get("n_steps", "?")}
+        elif kind == "plan_completed":
+            plans_completed[pid] = ts
+        elif kind == "plan_aborted":
+            plans_aborted[pid] = ts
+
+    # Forensic-only: plan_run_interrupted (never in WAL).
+    plans_interrupted: set[str] = set()
+    for e in log_plan:
+        if e.get("type") == "plan_run_interrupted":
+            pid = (e.get("data") or {}).get("plan_id", "")
+            if pid:
+                plans_interrupted.add(pid)
+
+    # Step counters from WAL (plan_step_* promoted to WAL in Phase 2).
+    steps_started = sum(1 for e in wal_evs if e.get("kind") == "plan_step_started")
+    steps_completed = sum(1 for e in wal_evs if e.get("kind") == "plan_step_completed")
+    steps_failed = sum(1 for e in wal_evs if e.get("kind") == "plan_step_failed")
+
+    # Memo hits from events log only (never in WAL).
+    step_memo_hits = sum(1 for e in log_plan if e.get("type") == "plan_step_memoized")
+    llm_memo_hits = sum(1 for e in log_plan if e.get("type") == "plan_step_llm_memoized")
+
+    # Max concurrent plans: walk (started_ts, terminal_ts) intervals.
+    intervals: list[tuple[float, float]] = []
+    for pid, info in plans_started.items():
+        t0 = _parse_ts(info["ts"])
+        if t0 is None:
+            continue
+        terminal_ts = plans_completed.get(pid) or plans_aborted.get(pid)
+        t1 = _parse_ts(terminal_ts) if terminal_ts else None
+        if t1 is None:
+            t1 = t0 + 1e9  # still running / unknown end → treat as open
+        intervals.append((t0, t1))
+
+    max_concurrent = 0
+    if intervals:
+        events_tl = []
+        for t0, t1 in intervals:
+            events_tl.append((t0, +1))
+            events_tl.append((t1, -1))
+        events_tl.sort()
+        cur = 0
+        for _, delta in events_tl:
+            cur += delta
+            if cur > max_concurrent:
+                max_concurrent = cur
+
+    n_started = len(plans_started)
+    n_completed = len(plans_completed)
+    n_aborted = len(plans_aborted)
+    n_interrupted = len(plans_interrupted)
+
+    print("=== Plan-mode Summary ===")
+    print(f"  plans started:    {n_started}")
+    print(f"  plans completed:  {n_completed}")
+    print(f"  plans aborted:    {n_aborted}")
+    print(f"  plans interrupted (= plan_run_interrupted forensic event): {n_interrupted}")
+    print()
+    print(f"  steps:            {steps_started} started / {steps_completed} completed / {steps_failed} failed")
+    print(f"  step memoizations: {step_memo_hits} step-result + {llm_memo_hits} LLM-call (= {step_memo_hits + llm_memo_hits} memo hits)")
+    print()
+    print(f"  max concurrent plans (= max overlap of started→completed window): {max_concurrent}")
+    print()
+
+    if not plans_started:
+        print("  (no per-plan detail — no plan_started WAL entries found)")
+        return
+
+    print(f"{'plan_id':<10}  {'goal':<32}  {'n_steps':>7}  {'status':<12}  {'duration':>10}")
+    print("  " + "-" * 78)
+    for pid, info in sorted(plans_started.items(), key=lambda x: x[1]["ts"]):
+        goal = info["goal"]
+        goal_disp = (goal[:30] + "..") if len(goal) > 32 else goal
+        n_steps = info.get("n_steps", "?")
+        t0 = _parse_ts(info["ts"])
+        if pid in plans_completed:
+            status = "completed"
+            t1 = _parse_ts(plans_completed[pid])
+            dur = f"{t1 - t0:.1f}s" if (t0 and t1) else "?"
+        elif pid in plans_aborted:
+            status = "aborted"
+            t1 = _parse_ts(plans_aborted[pid])
+            dur = f"{t1 - t0:.1f}s" if (t0 and t1) else "?"
+        elif pid in plans_interrupted:
+            status = "interrupted"
+            dur = "?"
+        else:
+            status = "active?"
+            dur = "?"
+        print(f"  {pid:<10}  {goal_disp!r:<32}  {str(n_steps):>7}  {status:<12}  {dur:>10}")
+
+
+def mode_plan_trace(root: Path, plan_id: str) -> None:
+    """Per-plan timeline of WAL + events log entries for one plan_id.
+
+    Shows all plan_* events for this plan_id time-sorted with T+x.xs
+    relative timestamps. Also shows agent-kind outbox messages tagged
+    with meta.plan_id matching this plan.
+    """
+    wal_evs = _load_wal(root)
+    log_evs = _all_events(root)
+
+    # Gather matching events from both sources.
+    matched: list[dict] = []
+
+    for e in wal_evs:
+        kind = e.get("kind", "")
+        data = e.get("data", {}) or {}
+        if kind in _ALL_PLAN_KINDS and data.get("plan_id") == plan_id:
+            matched.append({"_src": "WAL", "_kind": kind, "_ts": e.get("timestamp"), "_data": data})
+
+    for e in log_evs:
+        ev_type = e.get("type", "")
+        data = e.get("data", {}) or {}
+        if ev_type in _ALL_PLAN_KINDS and data.get("plan_id") == plan_id:
+            matched.append({"_src": "events", "_kind": ev_type, "_ts": e.get("timestamp"), "_data": data})
+        elif ev_type == "agent_message_sent":
+            meta = data.get("meta", {}) or {}
+            if meta.get("plan_id") == plan_id:
+                matched.append({"_src": "events", "_kind": "agent_message_sent", "_ts": e.get("timestamp"), "_data": data})
+
+    if not matched:
+        print(f"no events found for plan_id={plan_id!r}")
+        return
+
+    matched.sort(key=lambda e: e["_ts"] or "")
+    base_ts = matched[0]["_ts"]
+
+    print(f"=== Plan Trace: {plan_id} ===")
+    print(f"  base_ts: {(base_ts or '?')[:19]}")
+    print()
+    for e in matched:
+        t = _ts_offset(base_ts, e["_ts"])
+        kind = e["_kind"]
+        data = e["_data"]
+        src = e["_src"]
+        if kind == "plan_started":
+            summary = f"goal={data.get('goal','')!r:.40}  n_steps={data.get('n_steps','?')}"
+        elif kind in ("plan_completed", "plan_aborted"):
+            summary = ""
+        elif kind in ("plan_step_started", "plan_step_completed", "plan_step_failed",
+                      "plan_step_memoized", "plan_step_memo_failed", "plan_step_llm_memoized"):
+            step_id = data.get("step_id", "?")
+            extra = ""
+            if kind == "plan_step_started":
+                extra = f"  n_tools={data.get('n_tools','?')}"
+            elif kind == "plan_step_completed":
+                extra = f"  content_len={data.get('content_len','?')}"
+            elif kind in ("plan_step_failed", "plan_step_memo_failed"):
+                extra = f"  error={str(data.get('error',''))[:40]!r}"
+            elif kind == "plan_step_memoized":
+                extra = f"  content_len={data.get('content_len','?')}"
+            summary = f"step_id={step_id}{extra}"
+        elif kind == "plan_emitted":
+            summary = f"goal={data.get('goal','')!r:.40}  n_steps={data.get('n_steps','?')}"
+        elif kind == "plan_aggregated":
+            summary = f"completed={data.get('n_completed','?')}  failed={data.get('n_failed','?')}  result_len={data.get('result_len','?')}"
+        elif kind == "plan_run_interrupted":
+            summary = f"exc_type={data.get('exc_type','?')}"
+        elif kind == "agent_message_sent":
+            text = str(data.get("text", data.get("content", "")))
+            summary = f"text={text[:60]!r}"
+        else:
+            summary = _exc(data, 80)
+        print(f"  [{t}]  [{src}]  {kind}  {summary}")
+
+
+def mode_plan_snapshot(root: Path, plan_id: str) -> None:
+    """Dump the on-disk per-plan workspace consolidated for one plan_id.
+
+    Walks all agents' state/plans/ dirs to find the matching plan_id.
+    Reads the .snapshot.json and decomposition.json, then reports step
+    results (inline vs spilled) and LLM call records.
+    """
+    agents_dir = root / "agents"
+    if not agents_dir.exists():
+        print(f"no agents dir found at {agents_dir}")
+        return
+
+    found_agent: str | None = None
+    found_state_dir: Path | None = None
+    found_plan_dir: Path | None = None
+    found_snapshot_path: Path | None = None
+    multiple: list[str] = []
+
+    for agent_dir in sorted(agents_dir.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        state_dir = agent_dir / "state"
+        plans_dir = state_dir / "plans"
+        if not plans_dir.exists():
+            continue
+        snap_path = plans_dir / f"{plan_id}.snapshot.json"
+        plan_dir = plans_dir / plan_id
+        if snap_path.exists() or plan_dir.exists():
+            multiple.append(agent_dir.name)
+            if found_agent is None:
+                found_agent = agent_dir.name
+                found_state_dir = state_dir
+                found_plan_dir = plan_dir
+                found_snapshot_path = snap_path
+
+    if found_agent is None:
+        print(f"plan_id {plan_id!r} not found in any agent's state/plans/ directory")
+        return
+
+    if len(multiple) > 1:
+        print(f"warning: plan_id {plan_id!r} found in multiple agents: {multiple}")
+        print(f"  using first match: {found_agent}")
+        print()
+
+    print(f"=== Plan Snapshot: {plan_id} ===")
+    print(f"  agent:        {found_agent}")
+    print(f"  state_dir:    {found_state_dir}")
+
+    # Load decomposition.json
+    decom_path = found_plan_dir / "decomposition.json" if found_plan_dir else None
+    decom: dict | None = None
+    steps: list[dict] = []
+    if decom_path and decom_path.exists():
+        try:
+            decom = json.loads(decom_path.read_text(encoding="utf-8"))
+            steps = decom.get("steps", [])
+        except Exception as exc:
+            print(f"  decomposition.json: unreadable ({exc})")
+    else:
+        decom = None
+
+    # Load snapshot
+    snap_data: dict = {}
+    if found_snapshot_path and found_snapshot_path.exists():
+        try:
+            snap_data = json.loads(found_snapshot_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(f"  snapshot: unreadable ({exc})")
+    inline_step_results: dict = snap_data.get("step_results", {}) or {}
+    step_result_refs: dict = snap_data.get("step_result_refs", {}) or {}
+    step_llm_calls: dict = snap_data.get("step_llm_calls", {}) or {}
+    step_failures: dict = snap_data.get("step_failures", {}) or {}
+
+    print()
+    if decom:
+        print(f"decomposition ({len(steps)} steps):")
+        for s in steps:
+            sid = s.get("id", "?")
+            desc = s.get("description", "")
+            desc_disp = (desc[:40] + "..") if len(desc) > 42 else desc
+            tools = s.get("tools", [])
+            deps = s.get("depends_on", [])
+            tools_str = f"tools={tools}" if tools else "tools=[]"
+            deps_str = f"deps={deps}" if deps else "deps=[]"
+            print(f"  {sid:<6}  {desc_disp!r:<44}  {tools_str:<24}  {deps_str}")
+    elif steps:
+        # fallback: steps from snapshot's steps_serialized
+        serialized = snap_data.get("steps_serialized", []) or []
+        print(f"decomposition ({len(serialized)} steps, from snapshot fallback):")
+        for s in serialized:
+            sid = s.get("id", "?")
+            desc = s.get("description", "")
+            desc_disp = (desc[:40] + "..") if len(desc) > 42 else desc
+            print(f"  {sid:<6}  {desc_disp!r}")
+    else:
+        print("decomposition: (not found)")
+
+    print()
+    print("per-plan snapshot:")
+    if snap_data:
+        for key in ("applied_seq", "last_step_applied_seq", "current_step_id",
+                    "last_committed_step_id", "goal"):
+            val = snap_data.get(key)
+            print(f"  {key:<30}  {val!r}")
+        spawned = snap_data.get("spawned_skill_run_ids", {}) or {}
+    else:
+        print("  (snapshot file not found)")
+        spawned = {}
+
+    print()
+    all_step_ids = [s.get("id", "?") for s in steps] if steps else (
+        list(set(list(inline_step_results) + list(step_result_refs) + list(step_llm_calls)))
+    )
+    if all_step_ids:
+        print("step results:")
+        for sid in all_step_ids:
+            if sid in inline_step_results:
+                chars = len(inline_step_results[sid])
+                print(f"  {sid:<8}  inline    {chars} chars")
+            elif sid in step_result_refs:
+                ref = step_result_refs[sid]
+                full_ref = (found_plan_dir / ref) if found_plan_dir else None
+                size_str = "?"
+                if full_ref and full_ref.exists():
+                    try:
+                        size_kb = full_ref.stat().st_size / 1024
+                        size_str = f"{size_kb:.1f} KB"
+                    except Exception:
+                        pass
+                print(f"  {sid:<8}  spilled   {ref}   {size_str}")
+            elif sid in step_failures:
+                print(f"  {sid:<8}  failed    {step_failures[sid][:60]}")
+            else:
+                print(f"  {sid:<8}  (not yet recorded)")
+
+    print()
+    if step_llm_calls:
+        print("step LLM calls:")
+        for sid in all_step_ids:
+            records = step_llm_calls.get(sid, [])
+            if not records:
+                print(f"  {sid:<8}  (no records)")
+                continue
+            n_inline = sum(1 for r in records if r.get("result_inline") is not None)
+            n_spilled = sum(1 for r in records if r.get("result_ref") is not None)
+            spill_detail = ""
+            if n_spilled:
+                refs = [r["result_ref"] for r in records if r.get("result_ref")]
+                spill_detail = f"  ({n_spilled} spilled: {', '.join(refs[:2])}{'...' if len(refs) > 2 else ''})"
+            print(f"  {sid:<8}  {len(records)} record(s) ({n_inline} inline, {n_spilled} spilled){spill_detail}")
+    else:
+        print("step LLM calls:  (none recorded)")
+
+    print()
+    if spawned:
+        print(f"spawned children: {spawned}")
+    else:
+        print("spawned children: (none)")
 
 
 def mode_full(root: Path, filter_kind: str | None) -> None:
@@ -817,8 +1272,10 @@ def main() -> None:
             "summary", "full", "chain", "cost",
             "llm-payloads", "llm-detail", "llm-tools-schema",
             "llm-context",
-            # New time-travel modes:
+            # Time-travel modes:
             "replay", "compare",
+            # Plan-mode dogfood modes (ADR-0022/0023/0024/0025):
+            "plan-summary", "plan-trace", "plan-snapshot",
         ],
         default="summary",
     )
@@ -902,6 +1359,29 @@ def main() -> None:
             )
             sys.exit(1)
         mode_compare(before_paths, after_paths, scope=args.scope)
+        return
+
+    # ── Plan-mode modes ───────────────────────────────────────────────────
+    if args.mode in ("plan-summary", "plan-trace", "plan-snapshot"):
+        root = Path(args.root)
+        if not root.exists():
+            print(f"no events found (root not found: {root})")
+            sys.exit(0)
+        if args.mode == "plan-summary":
+            mode_plan_summary(root)
+            return
+        # plan-trace and plan-snapshot require the positional plan_id argument.
+        if not args.request_id:
+            print(
+                f"usage error: --mode {args.mode} requires a <plan_id> positional argument\n"
+                f"  example: python scripts/dogfood_trace.py --mode {args.mode} ab12cd34",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if args.mode == "plan-trace":
+            mode_plan_trace(root, args.request_id)
+        else:
+            mode_plan_snapshot(root, args.request_id)
         return
 
     # ── LLM trace modes ───────────────────────────────────────────────────

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -641,6 +641,22 @@ async def execute_plan(
     # from the recorded text WITHOUT re-executing the sub-loop or
     # re-emitting WAL step events (= those already landed pre-crash).
     resume_classifier = _build_resume_classifier(resume_plan)
+    n_total = len(ordered)
+    n_done = 0
+
+    # ADR-0023 §2.1.1: surface plan-start narration so the user sees
+    # progress while the plan runs in the background. Defensive — old
+    # hosts may not implement put_outbox at this layer.
+    try:
+        await parent_host.put_outbox(
+            kind="status",
+            text=f"plan started ({n_total} steps)",
+            meta={"plan_id": plan_id, "chain_id": chain_id, "source": "plan"},
+        )
+    except AttributeError:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("plan start outbox emit failed: %r", exc)
 
     try:
         for step in ordered:
@@ -745,6 +761,22 @@ async def execute_plan(
                 pass
             except Exception as exc:  # noqa: BLE001
                 logger.warning("record_plan_step_completed failed: %r", exc)
+            # ADR-0023 §2.1.1: emit step progress narration so the user
+            # sees the plan progressing while it runs in the background.
+            n_done += 1
+            try:
+                await parent_host.put_outbox(
+                    kind="status",
+                    text=f"plan step {n_done}/{n_total} done ({step.id})",
+                    meta={
+                        "plan_id": plan_id, "chain_id": chain_id,
+                        "step_id": step.id, "source": "plan",
+                    },
+                )
+            except AttributeError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("plan step outbox emit failed: %r", exc)
             parent_host.events.emit(
                 "plan_step_completed",
                 chain_id=chain_id,
@@ -823,27 +855,33 @@ async def dispatch_plan_tool(
 ) -> dict:
     """Entry point invoked from the chat router's ``plan`` tool dispatch.
 
-    ADR-0023 Phase 2 step 6 lifecycle ordering:
+    **ADR-0023 Phase 2.1: async dispatch.** ``plan`` is registered in
+    ``_DISPATCH_KIND`` as async; this function spawns the runtime as
+    a background task and returns the spawn ack immediately. The
+    RouterLoop sees an async tool result and exits the chat turn —
+    the user gets quick replies first while the plan runs in the
+    background, mirroring ``_spawn_skill`` UX.
+
+    Lifecycle ordering (= ADR-0023 §3.5 invariant preserved):
 
       1. Validate plan.
-      2. Allocate ``plan_id`` upfront.
+      2. Allocate ``plan_id`` + per-plan ``chain_id`` (= ADR-0023
+         §2.1.2 — each plan registers its own chain so R-D14
+         cross-agent notify works for ``/plan discard``).
       3. Write decomposition artifact (= P5 SSoT for resume).
-      4. Construct ``PlanRuntime(plan_id=plan_id)``.
-      5. Run.
-      6. On success / abort: delete the decomposition artifact.
-      7. On crash / cancel: leave the artifact in place so
-         ``AgentRegistry.restore_all`` can rehydrate the plan and the
-         resume coordinator (Step 7) can serve a memo replay.
+      4. Construct ``PlanRuntime(plan_id=…, chain_id=plan_chain_id)``.
+      5. Hand off to ``host.spawn_plan_task`` — ChatSession owns the
+         task lifecycle, terminal-text outbox emit, and decomposition
+         cleanup on clean exit.
+      6. Return ``{"status": "spawned", "plan_id": ..., ...}``.
 
-    Returns a dict in the shape RouterLoop expects from any tool
-    handler: ``{status, ...}``. On success the ``text`` field carries
-    the aggregated user-facing reply.
+    On crash mid-flight: ``running_plans`` task dies, decomposition
+    artifact stays for restart-time resume (= ADR-0023 §3.4 / §3.5).
 
-    The chat router_loop dispatcher will treat this differently from a
-    regular tool: instead of round-tripping the result back into the
-    LLM for narration, it forwards ``text`` directly to the user
-    outbox. This avoids a redundant aggregator LLM call on top of the
-    plan's own terminal step.
+    The ``chain_id`` parameter is the **chat-turn** chain (= caller
+    context). The plan-internal chain_id is allocated here as
+    ``plan_<plan_id>`` so R-D14 notifications target the right
+    waiter on plan discard.
     """
     try:
         plan = parse_and_validate_plan(args, allowed_tool_names=available_tool_names)
@@ -857,6 +895,8 @@ async def dispatch_plan_tool(
     # ``plan_started`` lands in WAL. Any plan in ``active_plan_ids`` MUST
     # have a discoverable decomposition (= ADR-0023 §3.5).
     plan_id = uuid.uuid4().hex[:8]
+    plan_chain_id = f"plan_{plan_id}"  # ADR-0023 §2.1.2 — per-plan chain
+
     try:
         await parent_host.write_plan_decomposition(plan_id=plan_id, plan=plan)
     except AttributeError:
@@ -868,26 +908,53 @@ async def dispatch_plan_tool(
     except Exception as exc:  # noqa: BLE001
         logger.warning("write_plan_decomposition failed: %r", exc)
 
-    # Construct the runtime and execute. PlanRuntime threads plan_id
-    # through to execute_plan, avoiding the auto-allocation path.
+    # Construct the runtime; ChatSession spawns it as a task and owns
+    # the lifecycle (= terminal outbox emit + artifact cleanup).
     from reyn.plan import PlanRuntime
     runtime = PlanRuntime(
         plan,
         host=parent_host,
-        chain_id=chain_id,
+        chain_id=plan_chain_id,           # per-plan chain
         plan_id=plan_id,
         budget=budget,
         router_model=router_model,
+    )
+
+    # Capability detection via hasattr (= NOT try/except) so the
+    # synchronous fallback runs in clean exception context. If the
+    # fallback ran inside an except AttributeError block, execute_plan's
+    # finally clause's sys.exc_info() check would mis-classify the
+    # outer-caught AttributeError as a "crash" and skip
+    # record_plan_completed. ADR-0023 §2.1.1 async path is the
+    # production path; the sync fallback is a test-stub safety net.
+    if hasattr(parent_host, "spawn_plan_task"):
+        await parent_host.spawn_plan_task(
+            plan_id=plan_id, runtime=runtime, chain_id=plan_chain_id,
+        )
+        return {
+            "status": "spawned",
+            "plan_id": plan_id,
+            "chain_id": plan_chain_id,
+            "n_steps": len(plan.steps),
+        }
+
+    # Synchronous fallback for hosts without spawn_plan_task (= test
+    # stubs / lightweight integrations). Same lifecycle as Phase 2 v1.
+    logger.debug(
+        "RouterLoopHost has no spawn_plan_task; running plan synchronously",
     )
     clean_exit = False
     try:
         result = await runtime.run()
         clean_exit = True
+        return {
+            "status": "ok",
+            "text": result.text,
+            "step_results": result.step_results,
+            "step_failures": result.step_failures,
+            "n_steps": len(plan.steps),
+        }
     except BaseException as exc:
-        # Per ADR-0013 / ADR-0023 §3.4: WorkflowAbortedError is a clean
-        # abort (= treat as completion). Any other exception (cancel,
-        # crash, KeyboardInterrupt) preserves the artifact for restart
-        # cleanup or memo-replay resume.
         if _is_workflow_abort(type(exc)):
             clean_exit = True
         raise
@@ -899,14 +966,6 @@ async def dispatch_plan_tool(
                 pass
             except Exception as exc:  # noqa: BLE001
                 logger.warning("delete_plan_decomposition failed: %r", exc)
-
-    return {
-        "status": "ok",
-        "text": result.text,
-        "step_results": result.step_results,
-        "step_failures": result.step_failures,
-        "n_steps": len(plan.steps),
-    }
 
 
 __all__ = [

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -524,6 +524,7 @@ async def execute_plan(
     chain_id: str,
     budget: Any = None,
     router_model: str = "light",
+    plan_id: str | None = None,
 ) -> PlanExecutionResult:
     """Run a plan step-by-step in topological order, return the aggregated text.
 
@@ -537,6 +538,12 @@ async def execute_plan(
     its captured text is the user-facing reply. Plans without an
     explicit synthesis step return the last step's text (= still works,
     just less curated).
+
+    ``plan_id``: Phase 2 step 6 — when the caller has already allocated
+    the id (= ``dispatch_plan_tool`` writes the decomposition artifact
+    before calling here, and the artifact is keyed on ``plan_id``), the
+    caller passes it in. ``None`` keeps Phase 1 backward compat: the
+    function auto-allocates uuid4-hex[:8].
     """
     # ADR-0022: allocate plan_id + record plan_started in WAL. plan_id is
     # uuid4-hex[:8] following the existing run_id allocation precedent.
@@ -545,7 +552,8 @@ async def execute_plan(
     # everything else (CancelledError, KeyboardInterrupt, generic Exception,
     # kill -9 path skips finally) → preserve active_plan_ids for AgentRegistry
     # restart cleanup.
-    plan_id = uuid.uuid4().hex[:8]
+    if plan_id is None:
+        plan_id = uuid.uuid4().hex[:8]
     try:
         await parent_host.record_plan_started(
             plan_id=plan_id, goal=plan.goal, n_steps=len(plan.steps),
@@ -574,6 +582,20 @@ async def execute_plan(
 
     try:
         for step in ordered:
+            # ADR-0023 Phase 2 step 6: route plan_step_started through
+            # host's WAL recorder (= persists on the durable log so the
+            # resume analyzer can pair it with completed/failed). The
+            # forensic events.emit stays for the legacy events log.
+            try:
+                await parent_host.record_plan_step_started(
+                    plan_id=plan_id, step_id=step.id,
+                    depends_on=list(step.depends_on),
+                    n_tools=len(step.tools),
+                )
+            except AttributeError:
+                pass  # test stub without record_plan_step_*
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("record_plan_step_started failed: %r", exc)
             parent_host.events.emit(
                 "plan_step_started",
                 chain_id=chain_id,
@@ -609,6 +631,14 @@ async def execute_plan(
                     total_usage.completion_tokens += sub_usage.completion_tokens
             except Exception as exc:  # noqa: BLE001 — defensive, don't crash plan
                 step_failures[step.id] = repr(exc)
+                try:
+                    await parent_host.record_plan_step_failed(
+                        plan_id=plan_id, step_id=step.id, error=repr(exc),
+                    )
+                except AttributeError:
+                    pass
+                except Exception as exc2:  # noqa: BLE001
+                    logger.warning("record_plan_step_failed failed: %r", exc2)
                 parent_host.events.emit(
                     "plan_step_failed",
                     chain_id=chain_id,
@@ -620,6 +650,14 @@ async def execute_plan(
 
             text = narrow_host.captured_text
             step_results[step.id] = text
+            try:
+                await parent_host.record_plan_step_completed(
+                    plan_id=plan_id, step_id=step.id, content_len=len(text),
+                )
+            except AttributeError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("record_plan_step_completed failed: %r", exc)
             parent_host.events.emit(
                 "plan_step_completed",
                 chain_id=chain_id,
@@ -698,6 +736,18 @@ async def dispatch_plan_tool(
 ) -> dict:
     """Entry point invoked from the chat router's ``plan`` tool dispatch.
 
+    ADR-0023 Phase 2 step 6 lifecycle ordering:
+
+      1. Validate plan.
+      2. Allocate ``plan_id`` upfront.
+      3. Write decomposition artifact (= P5 SSoT for resume).
+      4. Construct ``PlanRuntime(plan_id=plan_id)``.
+      5. Run.
+      6. On success / abort: delete the decomposition artifact.
+      7. On crash / cancel: leave the artifact in place so
+         ``AgentRegistry.restore_all`` can rehydrate the plan and the
+         resume coordinator (Step 7) can serve a memo replay.
+
     Returns a dict in the shape RouterLoop expects from any tool
     handler: ``{status, ...}``. On success the ``text`` field carries
     the aggregated user-facing reply.
@@ -715,13 +765,54 @@ async def dispatch_plan_tool(
             "status": "error",
             "error": {"kind": "plan_invalid", "message": str(exc)},
         }
-    result = await execute_plan(
+
+    # Step 6: allocate plan_id + write decomposition artifact BEFORE
+    # ``plan_started`` lands in WAL. Any plan in ``active_plan_ids`` MUST
+    # have a discoverable decomposition (= ADR-0023 §3.5).
+    plan_id = uuid.uuid4().hex[:8]
+    try:
+        await parent_host.write_plan_decomposition(plan_id=plan_id, plan=plan)
+    except AttributeError:
+        # Test stub without artifact persistence — Phase 2 v1 tolerates,
+        # resume won't be possible but fresh-run path still works.
+        logger.debug(
+            "RouterLoopHost has no write_plan_decomposition; skipping artifact",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("write_plan_decomposition failed: %r", exc)
+
+    # Construct the runtime and execute. PlanRuntime threads plan_id
+    # through to execute_plan, avoiding the auto-allocation path.
+    from reyn.plan import PlanRuntime
+    runtime = PlanRuntime(
         plan,
-        parent_host=parent_host,
+        host=parent_host,
         chain_id=chain_id,
+        plan_id=plan_id,
         budget=budget,
         router_model=router_model,
     )
+    clean_exit = False
+    try:
+        result = await runtime.run()
+        clean_exit = True
+    except BaseException as exc:
+        # Per ADR-0013 / ADR-0023 §3.4: WorkflowAbortedError is a clean
+        # abort (= treat as completion). Any other exception (cancel,
+        # crash, KeyboardInterrupt) preserves the artifact for restart
+        # cleanup or memo-replay resume.
+        if _is_workflow_abort(type(exc)):
+            clean_exit = True
+        raise
+    finally:
+        if clean_exit:
+            try:
+                await parent_host.delete_plan_decomposition(plan_id=plan_id)
+            except AttributeError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("delete_plan_decomposition failed: %r", exc)
+
     return {
         "status": "ok",
         "text": result.text,

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -517,6 +517,61 @@ class _PlanStepHost:
 # ── Executor ────────────────────────────────────────────────────────────────
 
 
+# ── Resume classification helpers (ADR-0023 §3.4) ──────────────────────────
+
+
+def _build_resume_classifier(resume_plan: Any) -> Any:
+    """Return a callable ``step_id → Literal["memo", "memo_failed", "execute"]``.
+
+    When ``resume_plan`` is None (= fresh run), every step classifies
+    as ``"execute"``. Otherwise the per-step state from the analyzer
+    drives the decision:
+
+      - ``completed_with_result`` → ``"memo"`` (use cached text)
+      - ``failed`` → ``"memo_failed"`` (propagate recorded failure)
+      - ``pending`` / ``interrupted_with_child`` → ``"execute"``
+        (re-execute; coordinator handles child cancel/adopt before
+        the runtime gets here, so by the time we're executing the
+        spawn step is treated as a fresh run for memo purposes)
+
+    Kept as a free function (= no PlanRuntime coupling) so execute_plan
+    free function can also be exercised with resume_plan in tests.
+    """
+    if resume_plan is None:
+        return lambda _step_id: "execute"
+    state_by_id: dict[str, str] = {}
+    for s in getattr(resume_plan, "step_states", ()):
+        state_by_id[s.step_id] = s.state
+
+    def _classify(step_id: str) -> str:
+        kind = state_by_id.get(step_id, "pending")
+        if kind == "completed_with_result":
+            return "memo"
+        if kind == "failed":
+            return "memo_failed"
+        return "execute"
+
+    return _classify
+
+
+def _resume_memo_for(resume_plan: Any, step_id: str) -> str | None:
+    if resume_plan is None:
+        return None
+    for s in getattr(resume_plan, "step_states", ()):
+        if s.step_id == step_id and s.state == "completed_with_result":
+            return s.result_text
+    return None
+
+
+def _resume_failure_for(resume_plan: Any, step_id: str) -> str | None:
+    if resume_plan is None:
+        return None
+    for s in getattr(resume_plan, "step_states", ()):
+        if s.step_id == step_id and s.state == "failed":
+            return s.error_message
+    return None
+
+
 async def execute_plan(
     plan: Plan,
     *,
@@ -525,6 +580,7 @@ async def execute_plan(
     budget: Any = None,
     router_model: str = "light",
     plan_id: str | None = None,
+    resume_plan: Any = None,
 ) -> PlanExecutionResult:
     """Run a plan step-by-step in topological order, return the aggregated text.
 
@@ -580,8 +636,39 @@ async def execute_plan(
     step_failures: dict[str, str] = {}
     total_usage = TokenUsage()
 
+    # ADR-0023 §3.4: classify each step against the resume_plan (if any)
+    # before emitting step events. Memoized steps populate step_results
+    # from the recorded text WITHOUT re-executing the sub-loop or
+    # re-emitting WAL step events (= those already landed pre-crash).
+    resume_classifier = _build_resume_classifier(resume_plan)
+
     try:
         for step in ordered:
+            classification = resume_classifier(step.id)
+            if classification == "memo":
+                # Step already completed pre-crash. Hydrate result from
+                # the resume plan; skip WAL emit + sub-loop entirely.
+                memo_text = _resume_memo_for(resume_plan, step.id)
+                step_results[step.id] = memo_text or ""
+                parent_host.events.emit(
+                    "plan_step_memoized",
+                    chain_id=chain_id,
+                    plan_id=plan_id,
+                    step_id=step.id,
+                    content_len=len(memo_text or ""),
+                )
+                continue
+            if classification == "memo_failed":
+                # Step recorded as failed pre-crash. Surface failure
+                # forward without re-executing.
+                memo_err = _resume_failure_for(resume_plan, step.id)
+                step_failures[step.id] = memo_err or "step_failed"
+                parent_host.events.emit(
+                    "plan_step_memo_failed",
+                    chain_id=chain_id, plan_id=plan_id, step_id=step.id,
+                    error=memo_err or "",
+                )
+                continue
             # ADR-0023 Phase 2 step 6: route plan_step_started through
             # host's WAL recorder (= persists on the durable log so the
             # resume analyzer can pair it with completed/failed). The

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -572,6 +572,47 @@ def _resume_failure_for(resume_plan: Any, step_id: str) -> str | None:
     return None
 
 
+def _build_sub_loop_memo_provider(
+    *,
+    parent_host: Any,
+    plan_id: str,
+    step_id: str,
+    resume_plan: Any,
+) -> Any:
+    """ADR-0025: construct a SubLoopMemoProvider for one step's sub-loop.
+
+    Best-effort: if the host doesn't expose ``_get_plan_registry`` (=
+    test stub) or no PlanRegistry is available (= state_log not wired),
+    returns None so RouterLoop runs without memoization. The plan still
+    executes correctly; resume just re-pays LLM cost on crashed steps.
+
+    Seed records on resume: extracted from
+    ``resume_plan.step_llm_call_log[step_id]`` (= populated by analyzer
+    from PlanSnapshot.step_llm_calls).
+    """
+    plan_registry = None
+    getter = getattr(parent_host, "_get_plan_registry", None)
+    if getter is not None:
+        try:
+            plan_registry = getter()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_plan_registry failed: %r", exc)
+    if plan_registry is None:
+        return None
+    seed: list = []
+    if resume_plan is not None:
+        from reyn.plan import extract_step_llm_call_records
+        log = getattr(resume_plan, "step_llm_call_log", None) or {}
+        seed = extract_step_llm_call_records(log, step_id)
+    from reyn.plan import SubLoopMemoProvider
+    return SubLoopMemoProvider(
+        plan_registry=plan_registry,
+        plan_id=plan_id,
+        step_id=step_id,
+        seed_records=seed,
+    )
+
+
 async def execute_plan(
     plan: Plan,
     *,
@@ -711,6 +752,20 @@ async def execute_plan(
                 plan=plan, step=step, prior_results=step_results, parent=parent_host,
             )
             sys_prompt = build_plan_step_system_prompt(plan, step, step_results)
+
+            # ADR-0025: construct a per-step SubLoopMemoProvider so the
+            # sub-loop's LLM calls are memoized (= recorded on every fresh
+            # call, replayed on resume). seed_records carries any
+            # previously-recorded LLM call results from
+            # resume_plan.step_llm_call_log[step.id] (= None for fresh
+            # runs, populated for resume hits).
+            memo_provider = _build_sub_loop_memo_provider(
+                parent_host=parent_host,
+                plan_id=plan_id,
+                step_id=step.id,
+                resume_plan=resume_plan,
+            )
+
             sub_loop = RouterLoop(
                 host=narrow_host,
                 chain_id=chain_id,
@@ -724,6 +779,7 @@ async def execute_plan(
                 # unbounded recursion (= dogfood 2026-05-07: 3-step plan emitted
                 # 3 plan invocations because steps re-emitted plan).
                 exclude_tools={"plan"},
+                memo_provider=memo_provider,
             )
             try:
                 sub_usage = await sub_loop.run(
@@ -756,9 +812,20 @@ async def execute_plan(
             try:
                 await parent_host.record_plan_step_completed(
                     plan_id=plan_id, step_id=step.id, content_len=len(text),
+                    result_text=text,
                 )
             except AttributeError:
                 pass
+            except TypeError:
+                # ADR-0023 Phase 2 v1 signature compat: hosts that
+                # don't take result_text get the legacy 3-arg call.
+                try:
+                    await parent_host.record_plan_step_completed(
+                        plan_id=plan_id, step_id=step.id,
+                        content_len=len(text),
+                    )
+                except AttributeError:
+                    pass
             except Exception as exc:  # noqa: BLE001
                 logger.warning("record_plan_step_completed failed: %r", exc)
             # ADR-0023 §2.1.1: emit step progress narration so the user

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -700,6 +700,31 @@ class AgentRegistry:
                     except (TypeError, ValueError):
                         return 0
 
+        # ADR-0023 §3.1: per-active-plan last_step_applied_seq. Direct
+        # JSON read mirrors the skill block above. Plans live at
+        # state/plans/<plan_id>.snapshot.json (sibling to per-plan dirs).
+        # If a long-running plan exists, its watermark pins the floor so
+        # plan_step_* events the resume analyzer needs aren't truncated.
+        for name in self.list_names():
+            plans_dir = self._dir / name / "state" / "plans"
+            if not plans_dir.is_dir():
+                continue
+            for snap_file in plans_dir.glob("*.snapshot.json"):
+                try:
+                    data = json.loads(snap_file.read_text(encoding="utf-8"))
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "WAL truncation: cannot read plan snapshot %s: %s",
+                        snap_file, e,
+                    )
+                    return 0
+                if isinstance(data, dict):
+                    val = data.get("last_step_applied_seq", 0)
+                    try:
+                        seqs.append(int(val))
+                    except (TypeError, ValueError):
+                        return 0
+
         if not seqs:
             return 0
         # Drop entries strictly below the lowest absorbed seq. The +1 makes

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -253,52 +253,175 @@ class AgentRegistry:
             session.restore_state(snap)
             await self.ensure_running(name)
 
-        # 6. ADR-0022 Phase 1: orphan plan cleanup. Plans that didn't reach
-        # `plan_completed` / `plan_aborted` before crash leave their plan_id
-        # in `active_plan_ids`. We have nothing to resume them from (Phase 1
-        # = fail-safe, not forward replay), so:
-        #   (a) emit `plan_aborted` to clear the snapshot entry
-        #   (b) surface a user-facing "interrupted, please retry" outbox
-        # Child-skill cancel is *not* attempted in Phase 1 — child skills
-        # have their own resume infrastructure and will auto-resume to
-        # completion (orphan), but we don't pretend to coordinate that
-        # here. Phase 2 will introduce per-plan child tracking + cancel.
+        # 6. ADR-0023 Phase 2: orphan plan recovery via PlanResumeCoordinator.
+        # Plans whose decomposition artifact survived (= post-Step-6 plans)
+        # are analyzed for memo replay; pre-Phase-2 plans without an
+        # artifact get the same Phase 1 outcome (= forced discard +
+        # outbox notice + plan_aborted) via the coordinator's missing-
+        # artifact fallback.
         for name, snap in snapshots.items():
             if not snap.active_plan_ids:
                 continue
             session = self._agents.get(name)
             if session is None:
                 continue
-            for plan_id in list(snap.active_plan_ids):
-                try:
-                    await session._journal.record_plan_aborted(
-                        plan_id=plan_id, reason="restart_cleanup",
-                    )
-                except Exception as exc:  # noqa: BLE001 — defensive
-                    logger.warning(
-                        "plan cleanup (record_plan_aborted) failed for "
-                        "agent=%s plan_id=%s: %s",
-                        name, plan_id, exc,
-                    )
-                try:
-                    from reyn.chat.outbox import OutboxMessage
-                    await session._put_outbox(OutboxMessage(
-                        kind="error",
-                        text=(
-                            "A plan-mode reply was interrupted by a previous "
-                            "session crash. The partial work could not be "
-                            "preserved — please re-issue your request."
-                        ),
-                        meta={"plan_id": plan_id, "reason": "restart_cleanup"},
-                    ))
-                except Exception as exc:  # noqa: BLE001 — defensive
-                    logger.warning(
-                        "plan cleanup (notify outbox) failed for "
-                        "agent=%s plan_id=%s: %s",
-                        name, plan_id, exc,
-                    )
+            try:
+                await self._recover_plans_for_agent(name, session)
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.warning(
+                    "plan recovery failed for agent=%s: %r", name, exc,
+                )
 
         return snapshots
+
+    # ── Plan resume recovery (ADR-0023 Phase 2 step 7d) ─────────────────────
+
+    async def _recover_plans_for_agent(
+        self, agent_name: str, session: "Any",
+    ) -> None:
+        """Rehydrate per-agent PlanRegistry, run coordinator, spawn launchable.
+
+        Called once per agent during ``restore_all`` cleanup, after
+        snapshots have been replayed onto AgentSnapshot. Steps:
+
+          1. Build a per-agent PlanRegistry and load any surviving plan
+             snapshot files (= populated by Step 6's PlanRegistry).
+          2. Build a PlanResumeCoordinator with policy from reyn.yaml.
+          3. Call coordinator.discover_and_decide → analyze each active
+             plan against WAL events.
+          4. Call coordinator.apply_decisions → cancel children flagged,
+             discard non-resumable plans (= surfaces outbox notice).
+          5. For each launchable decision, call
+             ``session._spawn_resumed_plan`` → PlanRuntime task starts.
+
+        Errors at any step degrade gracefully: a bad config falls back
+        to defaults; an unloadable artifact yields forced discard with
+        outbox notice (= ADR-0023 §3.5 corruption fallback).
+        """
+        from reyn.plan import (
+            PlanRegistry,
+            PlanResumeCoordinator,
+            build_plan_resume_config,
+            read_decomposition,
+        )
+
+        agent_state_dir = (
+            Path(".reyn") / "agents" / agent_name / "state"
+        )
+        plan_registry = PlanRegistry(
+            agent_name=agent_name, agent_state_dir=agent_state_dir,
+        )
+        plan_registry.load_active()
+        if not plan_registry.list_active():
+            # No surviving plan snapshots — every active_plan_ids entry
+            # is a Phase-1-era plan with no artifact. Fall back to the
+            # legacy discard path (= outbox notice + plan_aborted).
+            await self._legacy_discard_orphan_plans(agent_name, session)
+            return
+
+        # Resolve config (= reyn.yaml plan_resume:). Tolerant on errors.
+        config = None
+        try:
+            from reyn.config import load_config
+            cfg = load_config(Path.cwd())
+            config = build_plan_resume_config(cfg.plan_resume_raw)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning("plan_resume config load failed: %r", exc)
+            config = build_plan_resume_config(None)
+
+        coordinator = PlanResumeCoordinator(config=config)
+
+        # Materialize WAL events once for the coordinator.
+        wal_events: list[dict] = []
+        if self._state_log is not None:
+            wal_events = list(self._state_log.iter_from(0))
+
+        def _decomposition_loader(plan_id: str):
+            return read_decomposition(agent_state_dir, plan_id)
+
+        def _child_skill_lookup(child_run_id: str) -> str | None:
+            # Best-effort: query the agent's SkillRegistry if available.
+            sk_reg = getattr(session, "_skill_registry", None)
+            if sk_reg is None:
+                return "unknown"
+            snap = sk_reg.get(child_run_id)
+            if snap is None:
+                return "unknown"
+            return "in_flight"
+
+        decisions = coordinator.discover_and_decide(
+            plan_registry=plan_registry,
+            wal_events=wal_events,
+            decomposition_loader=_decomposition_loader,
+            child_skill_lookup=_child_skill_lookup,
+        )
+
+        async def _on_outbox_notice(plan_id: str, message: str) -> None:
+            from reyn.chat.outbox import OutboxMessage
+            try:
+                await session._put_outbox(OutboxMessage(
+                    kind="error", text=message,
+                    meta={"plan_id": plan_id, "reason": "resume_discard"},
+                ))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("plan resume outbox notice failed: %r", exc)
+            # Apply Phase 1 sibling: emit plan_aborted on agent snapshot
+            # so active_plan_ids is cleared.
+            try:
+                await session._journal.record_plan_aborted(
+                    plan_id=plan_id, reason="resume_discard",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("plan_aborted on discard failed: %r", exc)
+
+        skill_registry = getattr(session, "_skill_registry", None)
+        launchable = await coordinator.apply_decisions(
+            decisions,
+            plan_registry=plan_registry,
+            skill_registry=skill_registry,
+            on_outbox_notice=_on_outbox_notice,
+        )
+        for decision in launchable:
+            try:
+                await session._spawn_resumed_plan(decision=decision)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "_spawn_resumed_plan failed for %s: %r",
+                    decision.plan.plan_id, exc,
+                )
+
+    async def _legacy_discard_orphan_plans(
+        self, agent_name: str, session: "Any",
+    ) -> None:
+        """Phase 1 fallback: no decomposition artifact (pre-Phase-2 plans)
+        → emit plan_aborted + outbox notice."""
+        snap = session._journal.snapshot
+        for plan_id in list(snap.active_plan_ids):
+            try:
+                await session._journal.record_plan_aborted(
+                    plan_id=plan_id, reason="restart_cleanup",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "plan_aborted (legacy) failed for %s/%s: %r",
+                    agent_name, plan_id, exc,
+                )
+            try:
+                from reyn.chat.outbox import OutboxMessage
+                await session._put_outbox(OutboxMessage(
+                    kind="error",
+                    text=(
+                        "A plan-mode reply was interrupted by a previous "
+                        "session crash. The partial work could not be "
+                        "preserved — please re-issue your request."
+                    ),
+                    meta={"plan_id": plan_id, "reason": "restart_cleanup"},
+                ))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "outbox notice (legacy) failed for %s/%s: %r",
+                    agent_name, plan_id, exc,
+                )
 
     # ── WAL truncation (skill resume design) ────────────────────────────────
     #

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -349,11 +349,15 @@ class AgentRegistry:
                 return "unknown"
             return "in_flight"
 
+        # ADR-0024: thread agent_state_dir so analyzer's get_step_result
+        # path can resolve spilled-to-file step results. Coordinator
+        # forwards to PlanResumeAnalyzer.analyze.
         decisions = coordinator.discover_and_decide(
             plan_registry=plan_registry,
             wal_events=wal_events,
             decomposition_loader=_decomposition_loader,
             child_skill_lookup=_child_skill_lookup,
+            agent_state_dir=agent_state_dir,
         )
 
         async def _on_outbox_notice(plan_id: str, message: str) -> None:

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -238,6 +238,36 @@ class RouterLoopHost(Protocol):
         self, *, plan_id: str, reason: str = "",
     ) -> None: ...
 
+    # Plan-mode per-step WAL persistence (ADR-0023 Phase 2 step 6).
+    # Optional — test stubs may omit. ChatSession routes these through
+    # SnapshotJournal.record_plan_step_*.
+    async def record_plan_step_started(
+        self, *, plan_id: str, step_id: str, depends_on: list[str],
+        n_tools: int,
+    ) -> None: ...
+
+    async def record_plan_step_completed(
+        self, *, plan_id: str, step_id: str, content_len: int,
+    ) -> None: ...
+
+    async def record_plan_step_failed(
+        self, *, plan_id: str, step_id: str, error: str,
+    ) -> None: ...
+
+    # Decomposition artifact persistence (ADR-0023 §3.5).
+    # The artifact is the canonical SSoT for the plan shape on resume.
+    # ChatSession threads this through reyn.plan.decomposition with the
+    # agent-specific state directory; test stubs may no-op.
+    async def write_plan_decomposition(
+        self, *, plan_id: str, plan: "Any",
+    ) -> str | None:
+        """Persist the plan decomposition. Returns the artifact path or None."""
+        ...
+
+    async def delete_plan_decomposition(self, *, plan_id: str) -> None:
+        """Remove the plan decomposition artifact (= P5 cleanup on success)."""
+        ...
+
 
 # ---------------------------------------------------------------------------
 # RouterLoop

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -248,6 +248,7 @@ class RouterLoopHost(Protocol):
 
     async def record_plan_step_completed(
         self, *, plan_id: str, step_id: str, content_len: int,
+        result_text: str | None = None,
     ) -> None: ...
 
     async def record_plan_step_failed(
@@ -303,6 +304,7 @@ class RouterLoop:
         budget: Any = None,  # BudgetTracker | None — process-shared cost tracker
         system_prompt_override: str | None = None,
         exclude_tools: set[str] | None = None,
+        memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
     ):
         self.host = host
         self.chain_id = chain_id
@@ -322,6 +324,13 @@ class RouterLoop:
         # compare" produced 3 plan invocations because step LLMs saw plan
         # in their tool catalog and self-decomposed.
         self._exclude_tools: frozenset[str] = frozenset(exclude_tools or set())
+        # ADR-0025: optional sub-loop LLM call memoization. When set,
+        # ``call_llm_tools`` invocations consult the provider before
+        # invoking — args_hash hit returns the recorded LLMToolCallResult
+        # without paying LLM cost. Used by plan-mode resume so a crashed
+        # mid-step sub-loop replays its earlier LLM turns from snapshot
+        # rather than re-paying. ``None`` = normal execution (no memo).
+        self._memo_provider = memo_provider
         self._catalog: dict[str, dict] = {}  # populated per run()
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
@@ -384,16 +393,56 @@ class RouterLoop:
             messages.append({"role": "user", "content": user_text})
 
         for _iteration in range(self.max_iterations):
-            result = await call_llm_tools(
-                model=host.resolve_model(self.router_model),
-                messages=messages,
-                tools=tools,
-                tool_choice="auto",
-                skill_name="router",
-                budget=self.budget,
-                budget_agent=host.agent_name,
-                trace_caller="router",
-            )
+            resolved_model = host.resolve_model(self.router_model)
+            # ADR-0025: memo lookup — a recorded LLMToolCallResult for
+            # this exact (model, messages, tools, tool_choice) tuple
+            # short-circuits the call. Used by plan-mode resume so a
+            # crashed mid-step sub-loop replays earlier LLM turns
+            # without re-paying. memo_provider is None for non-resume
+            # paths (= chat router main loop, fresh plan runs).
+            result = None
+            args_hash: str | None = None
+            if self._memo_provider is not None:
+                from reyn.plan.sub_loop_memo import compute_sub_loop_args_hash
+                args_hash = compute_sub_loop_args_hash(
+                    model=resolved_model,
+                    messages=messages,
+                    tools=tools,
+                    tool_choice="auto",
+                )
+                memo = self._memo_provider.get_recorded_result(args_hash)
+                if memo is not None:
+                    host.events.emit(
+                        "plan_step_llm_memoized",
+                        chain_id=self.chain_id,
+                        plan_id=getattr(self._memo_provider, "plan_id", None),
+                        step_id=getattr(self._memo_provider, "step_id", None),
+                        args_hash=args_hash,
+                    )
+                    result = memo
+            if result is None:
+                result = await call_llm_tools(
+                    model=resolved_model,
+                    messages=messages,
+                    tools=tools,
+                    tool_choice="auto",
+                    skill_name="router",
+                    budget=self.budget,
+                    budget_agent=host.agent_name,
+                    trace_caller="router",
+                )
+                # Record the fresh result for future resume hit. Defensive:
+                # never let recording failure break the loop.
+                if self._memo_provider is not None and args_hash is not None:
+                    try:
+                        await self._memo_provider.record(
+                            args_hash=args_hash, result=result,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        import logging
+                        logging.getLogger(__name__).warning(
+                            "sub-loop memo record failed: %r", exc,
+                        )
             if result.usage:
                 self._total_usage += result.usage
             if result.tool_calls:

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -268,6 +268,19 @@ class RouterLoopHost(Protocol):
         """Remove the plan decomposition artifact (= P5 cleanup on success)."""
         ...
 
+    async def spawn_plan_task(
+        self, *, plan_id: str, runtime: "Any", chain_id: str,
+    ) -> None:
+        """Register a PlanRuntime as a background task (ADR-0023 Phase 2.1).
+
+        ChatSession owns the task lifecycle (= ``running_plans`` dict)
+        and the wrap-around finally that emits the terminal aggregator
+        text via ``put_outbox(kind="agent")`` and cleans up the
+        decomposition artifact on clean exit. dispatch_plan_tool hands
+        the constructed runtime here and returns immediately.
+        """
+        ...
+
 
 # ---------------------------------------------------------------------------
 # RouterLoop
@@ -425,14 +438,12 @@ class RouterLoop:
                     )
                     return self._total_usage
 
-                # Plan tool: terminal dispatch. The plan executor already
-                # ran the per-step LLM calls and produced the user-facing
-                # text in result["text"]. Emit it directly to the user
-                # outbox without re-feeding to the outer LLM (= avoids a
-                # redundant aggregator call on top of the plan's terminal
-                # step). On validation failure we DO fall through to the
-                # normal message accumulation path so the LLM can re-
-                # emit a corrected plan.
+                # ADR-0023 Phase 2.1: plan dispatch is now async — the
+                # async tool exit branch above already returned. The
+                # legacy synchronous "status=ok with text" special-case
+                # is preserved as a safety net for hosts that lack
+                # spawn_plan_task (= test stubs running planner sync via
+                # the AttributeError fallback in dispatch_plan_tool).
                 for tc, r in zip(tool_calls, tool_results):
                     if (
                         tc["function"]["name"] == "plan"

--- a/src/reyn/chat/router_tools.py
+++ b/src/reyn/chat/router_tools.py
@@ -71,6 +71,13 @@ _DESCRIBE_SKILL_STRIP_FIELDS: frozenset[str] = frozenset({"routing", "category"}
 # 拡張 → ToolSpec dataclass formalize).
 _DISPATCH_KIND: dict[str, str] = {
     "delegate_to_agent": "async",
+    # ADR-0023 Phase 2.1: plan-mode dispatch is fire-and-forget so the
+    # chat turn doesn't block on multi-step LLM work. dispatch_plan_tool
+    # spawns the PlanRuntime as a background task and returns the
+    # spawn ack immediately; outbox narration carries progress + final
+    # text. RouterLoop exits after dispatch (= same posture as
+    # delegate_to_agent).
+    "plan": "async",
 }
 
 

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -319,6 +319,67 @@ class SnapshotJournal:
             self._snapshot.active_plan_ids.remove(plan_id)
         self.save()
 
+    # ── plan-step lifecycle persistence (ADR-0023 Phase 2 step 4) ─────────
+    #
+    # Step events are promoted from events-log to WAL so the resume
+    # analyzer can pair (plan_step_started, plan_step_completed |
+    # plan_step_failed) deterministically across restart. Returns the
+    # assigned WAL seq so the caller can stamp it onto PlanRegistry's
+    # per-plan snapshot (PlanRegistry.record_step_*).
+
+    async def record_plan_step_started(
+        self, *, plan_id: str, step_id: str, depends_on: list[str],
+        n_tools: int,
+    ) -> int | None:
+        """Append ``plan_step_started`` to WAL. Returns the assigned seq."""
+        if self._state_log is None:
+            return None
+        seq = await self._state_log.append(
+            "plan_step_started",
+            target=self._agent_name,
+            plan_id=plan_id,
+            step_id=step_id,
+            depends_on=list(depends_on),
+            n_tools=n_tools,
+        )
+        self._snapshot.applied_seq = seq
+        self.save()
+        return seq
+
+    async def record_plan_step_completed(
+        self, *, plan_id: str, step_id: str, content_len: int,
+    ) -> int | None:
+        """Append ``plan_step_completed`` to WAL. Returns the assigned seq."""
+        if self._state_log is None:
+            return None
+        seq = await self._state_log.append(
+            "plan_step_completed",
+            target=self._agent_name,
+            plan_id=plan_id,
+            step_id=step_id,
+            content_len=content_len,
+        )
+        self._snapshot.applied_seq = seq
+        self.save()
+        return seq
+
+    async def record_plan_step_failed(
+        self, *, plan_id: str, step_id: str, error: str,
+    ) -> int | None:
+        """Append ``plan_step_failed`` to WAL. Returns the assigned seq."""
+        if self._state_log is None:
+            return None
+        seq = await self._state_log.append(
+            "plan_step_failed",
+            target=self._agent_name,
+            plan_id=plan_id,
+            step_id=step_id,
+            error=error,
+        )
+        self._snapshot.applied_seq = seq
+        self.save()
+        return seq
+
     # ── restore / persist ─────────────────────────────────────────────────
 
     def install(self, snapshot: AgentSnapshot) -> None:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -543,6 +543,11 @@ class ChatSession:
         # when an AgentRegistry back-reference is wired (production path);
         # tests with registry=None see no truncation triggers (acceptable).
         self._skill_registry: SkillRegistry | None = None
+        # ADR-0023 Phase 2 + ADR-0025: lazy per-agent PlanRegistry. Created
+        # on first plan-mode invocation so per-plan snapshots persist
+        # alongside SnapshotJournal's WAL-side bookkeeping. Mirrors the
+        # SkillRegistry lazy-init pattern.
+        self._plan_registry: "Any" = None
 
         # PR22: budget / rate-limit tracker (process-shared). When None,
         # checks are noops and counters are not maintained.
@@ -1100,6 +1105,42 @@ class ChatSession:
                 truncate_eligible_hook=hook,
             )
         return self._skill_registry
+
+    def _get_plan_registry(self) -> "Any":
+        """Return the per-agent PlanRegistry, lazily constructed on first call.
+
+        ADR-0023 Phase 2 + ADR-0025: per-plan snapshots persist
+        alongside SnapshotJournal's WAL-side bookkeeping. Without this
+        registry hook, ADR-0023 forward replay has nothing to read on
+        resume (PlanRegistry.load_active() returns empty), and ADR-0025
+        sub-loop LLM memoization has nowhere to record.
+
+        Returns None when no state_log is wired — test / standalone
+        mode without persistence.
+
+        Truncate hook mirrors _get_skill_registry: fires
+        AgentRegistry.truncate_wal_if_eligible after every durable
+        per-plan mutation (= last_step_applied_seq bump).
+        """
+        if self._state_log is None:
+            return None
+        if self._plan_registry is None:
+            from reyn.plan import PlanRegistry
+            agent_state_dir = (
+                Path(".reyn") / "agents" / self.agent_name / "state"
+            )
+            hook = None
+            if self._registry is not None:
+                async def _truncate_hook() -> None:
+                    if self._registry is not None:
+                        await self._registry.truncate_wal_if_eligible()
+                hook = _truncate_hook
+            self._plan_registry = PlanRegistry(
+                agent_name=self.agent_name,
+                agent_state_dir=agent_state_dir,
+                truncate_eligible_hook=hook,
+            )
+        return self._plan_registry
 
     def _build_agent(
         self,
@@ -3412,14 +3453,64 @@ class ChatSession:
         await self._journal.record_plan_started(
             plan_id=plan_id, goal=goal, n_steps=n_steps,
         )
+        # ADR-0023 Phase 2 + ADR-0025 wiring: per-plan snapshot is
+        # created here so on-disk state mirrors AgentSnapshot's
+        # active_plan_ids. Without this, the resume coordinator's
+        # PlanRegistry.load_active() returns empty and forward replay
+        # silently degrades to legacy discard.
+        plan_reg = self._get_plan_registry()
+        if plan_reg is not None:
+            try:
+                # Stamp applied_seq from the agent snapshot the journal
+                # just bumped. Non-blocking on errors — registry is the
+                # cache, the WAL append is the source of truth.
+                applied = self._journal.snapshot.applied_seq
+                # Stash decomposition artifact path for §3.5 SSoT.
+                from pathlib import Path
+                agent_state_dir = (
+                    Path(".reyn") / "agents" / self.agent_name / "state"
+                )
+                from reyn.plan import decomposition_path
+                artifact = decomposition_path(agent_state_dir, plan_id)
+                plan_reg.start(
+                    plan_id=plan_id,
+                    chain_id=f"plan_{plan_id}",  # ADR-0023 §2.1.2 per-plan chain
+                    goal=goal,
+                    applied_seq=applied,
+                    decomposition_artifact_path=str(artifact)
+                    if artifact.exists()
+                    else None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "PlanRegistry.start failed for %s: %r", plan_id, exc,
+                )
 
     async def record_plan_completed(self, *, plan_id: str) -> None:
         await self._journal.record_plan_completed(plan_id=plan_id)
+        # ADR-0023 Phase 2 wiring: per-plan workspace cleanup.
+        plan_reg = self._get_plan_registry()
+        if plan_reg is not None:
+            try:
+                await plan_reg.complete(plan_id=plan_id, status="completed")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "PlanRegistry.complete failed for %s: %r", plan_id, exc,
+                )
 
     async def record_plan_aborted(
         self, *, plan_id: str, reason: str = "",
     ) -> None:
         await self._journal.record_plan_aborted(plan_id=plan_id, reason=reason)
+        plan_reg = self._get_plan_registry()
+        if plan_reg is not None:
+            try:
+                await plan_reg.complete(plan_id=plan_id, status="aborted")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "PlanRegistry.complete (abort) failed for %s: %r",
+                    plan_id, exc,
+                )
 
     # Plan-mode per-step WAL persistence (ADR-0023 Phase 2 step 6).
     # Mirrors the plan_started/completed/aborted wiring above.
@@ -3428,24 +3519,50 @@ class ChatSession:
         self, *, plan_id: str, step_id: str, depends_on: list[str],
         n_tools: int,
     ) -> None:
-        await self._journal.record_plan_step_started(
+        seq = await self._journal.record_plan_step_started(
             plan_id=plan_id, step_id=step_id,
             depends_on=depends_on, n_tools=n_tools,
         )
+        plan_reg = self._get_plan_registry()
+        if plan_reg is not None and seq is not None:
+            plan_reg.record_step_started(
+                plan_id=plan_id, step_id=step_id, applied_seq=seq,
+            )
 
     async def record_plan_step_completed(
         self, *, plan_id: str, step_id: str, content_len: int,
+        result_text: str | None = None,
     ) -> None:
-        await self._journal.record_plan_step_completed(
+        """Record durable step completion.
+
+        ADR-0023 Phase 2 + ADR-0024: ``result_text`` is the optional
+        full text — passed through to PlanRegistry which inlines or
+        spills based on size. Callers (= execute_plan) supply this so
+        the per-plan snapshot carries the data; analyzer reads it back
+        on resume.
+        """
+        seq = await self._journal.record_plan_step_completed(
             plan_id=plan_id, step_id=step_id, content_len=content_len,
         )
+        plan_reg = self._get_plan_registry()
+        if plan_reg is not None and seq is not None:
+            await plan_reg.record_step_completed(
+                plan_id=plan_id, step_id=step_id, applied_seq=seq,
+                result_text=result_text or "",
+            )
 
     async def record_plan_step_failed(
         self, *, plan_id: str, step_id: str, error: str,
     ) -> None:
-        await self._journal.record_plan_step_failed(
+        seq = await self._journal.record_plan_step_failed(
             plan_id=plan_id, step_id=step_id, error=error,
         )
+        plan_reg = self._get_plan_registry()
+        if plan_reg is not None and seq is not None:
+            await plan_reg.record_step_failed(
+                plan_id=plan_id, step_id=step_id, applied_seq=seq,
+                error_repr=error,
+            )
 
     # Decomposition artifact persistence (ADR-0023 §3.5). Resolves the
     # agent-specific state directory and delegates to the standalone

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3416,6 +3416,63 @@ class ChatSession:
     ) -> None:
         await self._journal.record_plan_aborted(plan_id=plan_id, reason=reason)
 
+    # Plan-mode per-step WAL persistence (ADR-0023 Phase 2 step 6).
+    # Mirrors the plan_started/completed/aborted wiring above.
+
+    async def record_plan_step_started(
+        self, *, plan_id: str, step_id: str, depends_on: list[str],
+        n_tools: int,
+    ) -> None:
+        await self._journal.record_plan_step_started(
+            plan_id=plan_id, step_id=step_id,
+            depends_on=depends_on, n_tools=n_tools,
+        )
+
+    async def record_plan_step_completed(
+        self, *, plan_id: str, step_id: str, content_len: int,
+    ) -> None:
+        await self._journal.record_plan_step_completed(
+            plan_id=plan_id, step_id=step_id, content_len=content_len,
+        )
+
+    async def record_plan_step_failed(
+        self, *, plan_id: str, step_id: str, error: str,
+    ) -> None:
+        await self._journal.record_plan_step_failed(
+            plan_id=plan_id, step_id=step_id, error=error,
+        )
+
+    # Decomposition artifact persistence (ADR-0023 §3.5). Resolves the
+    # agent-specific state directory and delegates to the standalone
+    # reyn.plan.decomposition helpers.
+
+    async def write_plan_decomposition(
+        self, *, plan_id: str, plan: Any,
+    ) -> str | None:
+        from reyn.plan import write_decomposition
+        agent_state_dir = (
+            Path(".reyn") / "agents" / self.agent_name / "state"
+        )
+        try:
+            return str(write_decomposition(agent_state_dir, plan_id, plan))
+        except OSError as exc:
+            logger.warning(
+                "write_plan_decomposition failed for %s: %r", plan_id, exc,
+            )
+            return None
+
+    async def delete_plan_decomposition(self, *, plan_id: str) -> None:
+        from reyn.plan import delete_decomposition
+        agent_state_dir = (
+            Path(".reyn") / "agents" / self.agent_name / "state"
+        )
+        try:
+            delete_decomposition(agent_state_dir, plan_id)
+        except OSError as exc:
+            logger.warning(
+                "delete_plan_decomposition failed for %s: %r", plan_id, exc,
+            )
+
     # --- RouterLoop orchestration ---
 
     def _build_history_for_router(self) -> list[dict]:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -611,6 +611,11 @@ class ChatSession:
         # initiated invocations that don't participate in a chain).
         self.running_skills_chain: dict[str, str | None] = {}
 
+        # ADR-0023 Phase 2 step 7d: per-plan resume task tracking.
+        # Populated by ``_spawn_resumed_plan`` after restart cleanup;
+        # tasks are awaited at shutdown like running_skills.
+        self.running_plans: dict[str, asyncio.Task] = {}
+
         # PR-refactor-session-1 wave 2: pending-chain lifecycle and intervention
         # queue ownership extracted into services. The session orchestrates the
         # callbacks (_announce_intervention, _on_chain_timeout_fire) but holds
@@ -3472,6 +3477,86 @@ class ChatSession:
             logger.warning(
                 "delete_plan_decomposition failed for %s: %r", plan_id, exc,
             )
+
+    async def _spawn_resumed_plan(
+        self,
+        *,
+        decision: Any,
+        budget: Any = None,
+        router_model: str = "light",
+    ) -> None:
+        """Launch a PlanRuntime for a resume decision (ADR-0023 §3.4).
+
+        Reads the decomposition artifact for ``decision.plan.plan_id``,
+        constructs ``PlanRuntime(resume_plan=decision.plan)``, and
+        registers the resulting task on ``self.running_plans``. The
+        task is fire-and-forget; the runtime's finally clause emits
+        plan_completed / plan_run_interrupted as usual.
+
+        Errors during decomposition load surface as outbox notices and
+        the plan is marked aborted (= ADR-0023 §3.5 corruption fallback,
+        even after the coordinator earlier-validated path).
+        """
+        from reyn.plan import (
+            PlanRuntime,
+            read_decomposition,
+        )
+
+        plan_id = decision.plan.plan_id
+        agent_state_dir = (
+            Path(".reyn") / "agents" / self.agent_name / "state"
+        )
+        try:
+            decomposition = read_decomposition(agent_state_dir, plan_id)
+        except Exception as exc:  # noqa: BLE001 — defensive, surface to user
+            logger.warning(
+                "_spawn_resumed_plan: cannot load decomposition for %s: %r",
+                plan_id, exc,
+            )
+            try:
+                from reyn.chat.outbox import OutboxMessage
+                await self._put_outbox(OutboxMessage(
+                    kind="error",
+                    text=(
+                        "A plan-mode reply was interrupted; the saved "
+                        "decomposition could not be loaded — please "
+                        "re-issue your request."
+                    ),
+                    meta={"plan_id": plan_id, "reason": "decomposition_load_failed"},
+                ))
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await self._journal.record_plan_aborted(
+                    plan_id=plan_id, reason="decomposition_load_failed",
+                )
+            except Exception as exc2:  # noqa: BLE001
+                logger.warning("plan_aborted emit failed: %r", exc2)
+            return
+
+        runtime = PlanRuntime(
+            decomposition,
+            host=self,
+            chain_id=decision.plan.chain_id,
+            plan_id=plan_id,
+            budget=budget,
+            router_model=router_model,
+            resume_plan=decision.plan,
+        )
+
+        async def _run_resumed_plan() -> None:
+            try:
+                await runtime.run()
+            except Exception as exc:  # noqa: BLE001 — top-level swallow
+                logger.warning(
+                    "_spawn_resumed_plan task crashed for %s: %r",
+                    plan_id, exc,
+                )
+            finally:
+                self.running_plans.pop(plan_id, None)
+
+        task = asyncio.create_task(_run_resumed_plan())
+        self.running_plans[plan_id] = task
 
     # --- RouterLoop orchestration ---
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3478,6 +3478,69 @@ class ChatSession:
                 "delete_plan_decomposition failed for %s: %r", plan_id, exc,
             )
 
+    async def spawn_plan_task(
+        self, *, plan_id: str, runtime: Any, chain_id: str,
+    ) -> None:
+        """Run a PlanRuntime as a background task (ADR-0023 Phase 2.1).
+
+        Tracks the task in ``self.running_plans`` for `/plan discard`
+        and shutdown await. On clean exit, emits the runtime's
+        aggregated text to the user outbox + cleans up the
+        decomposition artifact (= P5 cleanup mirror of
+        dispatch_plan_tool's old finally clause).
+
+        Errors during runtime.run() are logged and swallowed (= the
+        task is fire-and-forget; the runtime's own finally emits
+        plan_run_interrupted via events for forensic visibility, and
+        crash cases preserve the artifact for restart resume).
+        """
+
+        async def _run_plan_task() -> None:
+            from reyn.chat.planner import _is_workflow_abort
+            clean_exit = False
+            result_text: str | None = None
+            try:
+                result = await runtime.run()
+                clean_exit = True
+                result_text = result.text if result is not None else None
+            except BaseException as exc:
+                if _is_workflow_abort(type(exc)):
+                    clean_exit = True
+                else:
+                    logger.warning(
+                        "plan task crashed for %s: %r", plan_id, exc,
+                    )
+            # Emit terminal aggregator text on clean exit.
+            if clean_exit and result_text:
+                try:
+                    await self.put_outbox(
+                        kind="agent",
+                        text=result_text,
+                        meta={
+                            "plan_id": plan_id,
+                            "chain_id": chain_id,
+                            "source": "plan",
+                        },
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "plan task outbox emit failed for %s: %r",
+                        plan_id, exc,
+                    )
+            # Artifact cleanup mirrors the old dispatch_plan_tool finally.
+            if clean_exit:
+                try:
+                    await self.delete_plan_decomposition(plan_id=plan_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "plan task delete_decomposition failed for %s: %r",
+                        plan_id, exc,
+                    )
+            self.running_plans.pop(plan_id, None)
+
+        task = asyncio.create_task(_run_plan_task())
+        self.running_plans[plan_id] = task
+
     async def _spawn_resumed_plan(
         self,
         *,

--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -130,6 +130,7 @@ from reyn.chat.slash import chat as _chat_mod  # noqa: E402, F401
 from reyn.chat.slash import donut as _donut_mod  # noqa: E402, F401
 from reyn.chat.slash import help as _help_mod  # noqa: E402, F401
 from reyn.chat.slash import matrix as _matrix_mod  # noqa: E402, F401
+from reyn.chat.slash import plan as _plan_mod  # noqa: E402, F401
 from reyn.chat.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.chat.slash import skills as _skills_mod  # noqa: E402, F401
 from reyn.chat.slash import zen as _zen_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -321,6 +321,7 @@ async def _resume_from_step(session: "ChatSession", args: str) -> None:
     resume_plan = analyzer.analyze(
         snapshot=snap, decomposition=decomposition,
         wal_events=synthetic_events,
+        agent_state_dir=agent_state_dir,
     )
 
     # Re-launch via the existing ChatSession._spawn_resumed_plan path.

--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -1,0 +1,175 @@
+"""/plan slash command — manage active plan-mode runs (ADR-0023 Phase 2.1).
+
+Sub-commands:
+  /plan list                 — show active plan runs
+  /plan discard <plan_id>    — abort a specific plan run + cleanup
+
+Mirrors ``/skill`` (skill.py) shape. Distinct from any future ``/plans``
+command (= would list available plan templates if such a concept were
+to be introduced; not in scope today).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from reyn.chat.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.chat.session import ChatSession
+
+
+_USAGE = (
+    "Usage: /plan <list|discard <plan_id>>\n"
+    "  list                 — show active plan runs\n"
+    "  discard <plan_id>    — abort a specific plan run"
+)
+
+
+@slash("plan", summary="Manage active plan-mode runs (list / discard)")
+async def plan_cmd(session: "ChatSession", args: str) -> None:
+    """Dispatch to sub-command based on the first argument."""
+    parts = args.strip().split(maxsplit=1)
+    if not parts:
+        await reply(session, _USAGE)
+        return
+    sub = parts[0]
+    sub_args = parts[1] if len(parts) > 1 else ""
+    if sub == "list":
+        await _list_plan_runs(session)
+    elif sub == "discard":
+        await _discard_plan_run(session, sub_args)
+    else:
+        await reply_error(session, _USAGE)
+
+
+async def _list_plan_runs(session: "ChatSession") -> None:
+    """Emit a status message listing active plan runs.
+
+    Reads from session.running_plans (= the asyncio.Task tracking dict
+    populated by spawn_plan_task / _spawn_resumed_plan). Cross-references
+    with active_plan_ids from the agent snapshot for any plans that
+    survived a crash but haven't been adopted by a running task yet.
+    """
+    running = dict(session.running_plans)
+    snap = session._journal.snapshot
+    active_ids = list(snap.active_plan_ids)
+
+    # Combined view: tasks currently running (in-process) + plan_ids
+    # in the snapshot (durable). A plan_id may appear in active_ids
+    # without a running task during the brief window between crash and
+    # _spawn_resumed_plan firing.
+    combined: dict[str, str] = {}  # plan_id -> status
+    for plan_id, task in running.items():
+        if task.done():
+            combined[plan_id] = "done (cleanup pending)"
+        else:
+            combined[plan_id] = "running"
+    for plan_id in active_ids:
+        if plan_id not in combined:
+            combined[plan_id] = "active (no task — resume pending)"
+
+    if not combined:
+        await reply(session, "(no active plans)")
+        return
+
+    lines = [f"{len(combined)} active plan run(s):"]
+    for plan_id, status in combined.items():
+        lines.append(f"  {plan_id}  {status}")
+    await reply(session, "\n".join(lines))
+
+
+async def _discard_plan_run(session: "ChatSession", args: str) -> None:
+    """Abort a plan: cancel task, surface outbox notice, clean up state.
+
+    Steps (mirror /skill discard):
+      1. Cancel asyncio.Task (= triggers PlanRuntime's finally clause →
+         no plan_completed → active_plan_ids preserved for cleanup).
+      2. Record plan_aborted in WAL (= clears active_plan_ids).
+      3. Delete decomposition artifact + plan snapshot via
+         delete_plan_decomposition (= P5 cleanup).
+      4. R-D14 cross-agent notify so any peer waiting on the plan's
+         per-plan chain_id (= f"plan_{plan_id}") gets resolved
+         immediately rather than waiting for chain_timeout.
+    """
+    plan_id = args.strip()
+    if not plan_id:
+        await reply_error(session, "Usage: /plan discard <plan_id>")
+        return
+
+    # Existence check across both running_plans and active_plan_ids.
+    snap = session._journal.snapshot
+    is_running = plan_id in session.running_plans
+    is_active = plan_id in snap.active_plan_ids
+    if not is_running and not is_active:
+        await reply_error(session, f"unknown plan run: {plan_id}")
+        return
+
+    # 1. Cancel the asyncio.Task if mid-flight.
+    task = session.running_plans.get(plan_id)
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        session.running_plans.pop(plan_id, None)
+
+    # 2. Record plan_aborted (= prunes active_plan_ids, surfaces audit).
+    try:
+        await session._journal.record_plan_aborted(
+            plan_id=plan_id, reason="user_discarded",
+        )
+    except Exception as exc:  # noqa: BLE001
+        import logging
+        logging.getLogger(__name__).warning(
+            "plan_aborted on /plan discard failed for %s: %r",
+            plan_id, exc,
+        )
+
+    # 3. Delete decomposition artifact (= P5 cleanup).
+    try:
+        await session.delete_plan_decomposition(plan_id=plan_id)
+    except Exception as exc:  # noqa: BLE001
+        import logging
+        logging.getLogger(__name__).warning(
+            "delete_plan_decomposition on /plan discard failed for %s: %r",
+            plan_id, exc,
+        )
+
+    # Also delete the per-plan snapshot file if it exists (= rehydrated
+    # on a previous restart but never adopted by _spawn_resumed_plan).
+    try:
+        from pathlib import Path
+        from reyn.plan.plan_snapshot import plan_snapshot_path
+        agent_state_dir = (
+            Path(".reyn") / "agents" / session.agent_name / "state"
+        )
+        snap_path = plan_snapshot_path(agent_state_dir, plan_id)
+        snap_path.unlink(missing_ok=True)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        import logging
+        logging.getLogger(__name__).warning(
+            "plan snapshot cleanup on /plan discard failed for %s: %r",
+            plan_id, exc,
+        )
+
+    # 4. R-D14 cross-agent notify on the per-plan chain_id (= ADR-0023
+    # §2.1.2). Any peer agent waiting on f"plan_{plan_id}" gets resolved
+    # immediately rather than waiting for chain_timeout_seconds.
+    plan_chain_id = f"plan_{plan_id}"
+    if getattr(session, "_registry", None) is not None:
+        try:
+            await session._registry.notify_chain_discarded(
+                chain_id=plan_chain_id,
+                by_agent_name=session.agent_name,
+                reason="user_discarded_plan",
+            )
+        except Exception:  # noqa: BLE001
+            import logging
+            logging.getLogger(__name__).warning(
+                "notify_chain_discarded failed for plan chain %s",
+                plan_chain_id, exc_info=True,
+            )
+
+    await reply(session, f"discarded plan run: {plan_id}")

--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -20,13 +20,15 @@ if TYPE_CHECKING:
 
 
 _USAGE = (
-    "Usage: /plan <list|discard <plan_id>>\n"
-    "  list                 — show active plan runs\n"
-    "  discard <plan_id>    — abort a specific plan run"
+    "Usage: /plan <list|discard <plan_id>|resume <plan_id> --from <step_id>>\n"
+    "  list                                  — show active plan runs\n"
+    "  discard <plan_id>                     — abort a specific plan run\n"
+    "  resume <plan_id> --from <step_id>     — re-run from a specific step\n"
+    "                                          (ADR-0023 §3.7 escape hatch)"
 )
 
 
-@slash("plan", summary="Manage active plan-mode runs (list / discard)")
+@slash("plan", summary="Manage active plan-mode runs (list / discard / resume)")
 async def plan_cmd(session: "ChatSession", args: str) -> None:
     """Dispatch to sub-command based on the first argument."""
     parts = args.strip().split(maxsplit=1)
@@ -39,6 +41,8 @@ async def plan_cmd(session: "ChatSession", args: str) -> None:
         await _list_plan_runs(session)
     elif sub == "discard":
         await _discard_plan_run(session, sub_args)
+    elif sub == "resume":
+        await _resume_from_step(session, sub_args)
     else:
         await reply_error(session, _USAGE)
 
@@ -173,3 +177,170 @@ async def _discard_plan_run(session: "ChatSession", args: str) -> None:
             )
 
     await reply(session, f"discarded plan run: {plan_id}")
+
+
+def _parse_resume_args(args: str) -> tuple[str, str] | None:
+    """Parse ``<plan_id> --from <step_id>`` into ``(plan_id, step_id)``.
+
+    Returns None on parse failure so the caller can surface a usage
+    error. Tolerant of extra whitespace; rejects missing flag / value.
+    """
+    parts = args.strip().split()
+    if len(parts) < 3:
+        return None
+    plan_id = parts[0]
+    if "--from" not in parts[1:]:
+        return None
+    flag_idx = parts.index("--from")
+    if flag_idx + 1 >= len(parts):
+        return None
+    step_id = parts[flag_idx + 1]
+    if not plan_id or not step_id:
+        return None
+    return (plan_id, step_id)
+
+
+async def _resume_from_step(session: "ChatSession", args: str) -> None:
+    """Reset step results from <step_id> onward and re-launch the plan.
+
+    ADR-0023 §3.7 surgical operator escape hatch. Use cases:
+      - A step recorded a result but the operator wants to redo it
+        (= LLM produced something wrong, or world state shifted).
+      - Step N failed transiently; operator wants to retry from step N
+        without re-running steps 1..N-1.
+
+    Steps:
+      1. Validate args + plan existence.
+      2. Cancel any currently-running task for this plan.
+      3. Load the decomposition artifact (= for topological step order).
+      4. Call PlanRegistry.reset_from_step (mutates + persists snapshot).
+      5. Re-launch via ChatSession._spawn_resumed_plan with a fresh
+         resume_plan derived from the post-reset snapshot.
+
+    On any failure surface a /plan list-style hint so the operator
+    knows whether to retry vs discard.
+    """
+    parsed = _parse_resume_args(args)
+    if parsed is None:
+        await reply_error(
+            session,
+            "Usage: /plan resume <plan_id> --from <step_id>",
+        )
+        return
+    plan_id, step_id = parsed
+
+    # Cancel any in-flight task for this plan first.
+    task = session.running_plans.get(plan_id)
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        session.running_plans.pop(plan_id, None)
+
+    # Build per-agent PlanRegistry against the on-disk plan snapshots.
+    from pathlib import Path
+    from reyn.plan import (
+        PlanRegistry,
+        PlanResumeAnalyzer,
+        PlanResumeCoordinator,
+        PlanResumeDecision,
+        read_decomposition,
+    )
+
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    plan_registry = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    plan_registry.load_active()
+    if plan_registry.get(plan_id) is None:
+        await reply_error(session, f"unknown plan run: {plan_id}")
+        return
+
+    # Load the decomposition artifact for topological step order.
+    try:
+        decomposition = read_decomposition(agent_state_dir, plan_id)
+    except FileNotFoundError:
+        await reply_error(
+            session,
+            f"plan {plan_id}: decomposition artifact missing — "
+            "use /plan discard to clean up",
+        )
+        return
+    except Exception as exc:  # noqa: BLE001
+        await reply_error(
+            session,
+            f"plan {plan_id}: cannot load decomposition ({exc!r})",
+        )
+        return
+
+    step_order = [s.id for s in decomposition.steps]
+    if step_id not in step_order:
+        await reply_error(
+            session,
+            f"plan {plan_id}: step {step_id!r} not in plan "
+            f"(known: {step_order})",
+        )
+        return
+
+    # Mutate snapshot — clears results from step_id onward.
+    ok = plan_registry.reset_from_step(
+        plan_id=plan_id, from_step_id=step_id, step_order=step_order,
+    )
+    if not ok:
+        await reply_error(
+            session, f"plan {plan_id}: reset_from_step failed (see logs)",
+        )
+        return
+
+    # Build a resume_plan from the now-mutated snapshot via the
+    # analyzer (= empty WAL events; the snapshot's step_results is
+    # the source of truth post-reset).
+    analyzer = PlanResumeAnalyzer()
+    snap = plan_registry.get(plan_id)
+    # Synthetic events list: walk the snapshot's preserved
+    # step_results and present them as completed pairs to the analyzer
+    # so they classify as completed_with_result. Cleared steps have
+    # no events → pending.
+    synthetic_events: list[dict] = []
+    for i, sid in enumerate(step_order):
+        if sid in snap.step_results:
+            synthetic_events.append({
+                "seq": i * 2 + 1, "kind": "plan_step_started",
+                "plan_id": plan_id, "step_id": sid,
+            })
+            synthetic_events.append({
+                "seq": i * 2 + 2, "kind": "plan_step_completed",
+                "plan_id": plan_id, "step_id": sid,
+                "content_len": len(snap.step_results[sid]),
+            })
+
+    resume_plan = analyzer.analyze(
+        snapshot=snap, decomposition=decomposition,
+        wal_events=synthetic_events,
+    )
+
+    # Re-launch via the existing ChatSession._spawn_resumed_plan path.
+    decision = PlanResumeDecision(
+        plan=resume_plan,
+        action="retry_pending",
+        pending_step_ids=resume_plan.pending_step_ids,
+        child_actions={},
+    )
+    try:
+        await session._spawn_resumed_plan(decision=decision)
+    except Exception as exc:  # noqa: BLE001
+        await reply_error(
+            session,
+            f"plan {plan_id}: respawn failed ({exc!r})",
+        )
+        return
+
+    await reply(
+        session,
+        f"plan {plan_id}: resumed from step {step_id!r} "
+        f"({len(resume_plan.pending_step_ids)} step(s) to re-execute)",
+    )

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -228,6 +228,11 @@ class ReynConfig:
     # Skill resume policy (PR-skill-resume) — how to handle ambiguous
     # steps on restart.
     skill_resume: SkillResumeConfig = field(default_factory=SkillResumeConfig)
+    # Plan resume policy (ADR-0023 Phase 2) — how the resume coordinator
+    # treats interrupted plan-mode runs on restart. Loaded as a raw dict
+    # and parsed lazily by the coordinator (= keeps PlanResumeConfig in
+    # the plan/ module rather than coupling config.py to it).
+    plan_resume_raw: dict | None = None
     # When true, attach Anthropic-style cache_control markers to the system
     # prompt so providers that support prompt caching (Anthropic, AWS Bedrock
     # Claude) can reuse the prefix across calls. Ignored by providers that
@@ -481,6 +486,10 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         events=_build_events_config(merged.get("events")),
         cost=_build_cost_config(merged.get("cost")),
         skill_resume=_build_skill_resume_config(merged.get("skill_resume")),
+        plan_resume_raw=(
+            merged.get("plan_resume")
+            if isinstance(merged.get("plan_resume"), dict) else None
+        ),
     )
 
 

--- a/src/reyn/events/state_log.py
+++ b/src/reyn/events/state_log.py
@@ -61,14 +61,18 @@ WAL_EVENT_KINDS = (
     "intervention_answer_buffered",
     "intervention_answer_consumed",
     # NEW (ADR-0022) — plan-mode lifecycle (Phase 1: fail-safe + observability)
-    # Per-step events (plan_emitted / plan_step_started / plan_step_completed /
-    # plan_step_failed / plan_aggregated) stay in the events log — those are
-    # forensic, not recovery state. Only the plan-as-a-unit lifecycle goes
-    # through WAL so AgentSnapshot.active_plan_ids is reliable for crash
-    # cleanup discovery.
     "plan_started",
     "plan_completed",
     "plan_aborted",
+    # NEW (ADR-0023 Phase 2 step 4) — per-step events promoted from
+    # events-log into WAL for resume determinism. The analyzer pairs
+    # (plan_step_started, plan_step_completed | plan_step_failed) by
+    # (plan_id, step_id) to derive each step's recovery state. Forensic-
+    # only events (plan_emitted / plan_aggregated / plan_run_interrupted)
+    # remain in the events log — they don't drive resume decisions.
+    "plan_step_started",
+    "plan_step_completed",
+    "plan_step_failed",
 )
 
 

--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -46,6 +46,21 @@ _IDLE_POLL_INTERVAL_SECONDS: float = 0.05
 _IDLE_GRACE_SECONDS: float = 0.05
 
 
+# Per-agent serialization lock. Concurrent FastAPI request handlers (e.g.
+# the A2A endpoint) can reach ``send_to_agent_impl`` in parallel for the
+# same agent; without serialization both coroutines race on
+# ``session.history[-1]`` (RouterLoop reads the wrong prompt) and on
+# reply harvesting (each picks up the other's ``role="agent"`` entries).
+# This is the conservative short-term fix consistent with the existing
+# serial ``session.run()`` inbox architecture — the long-term shape is
+# to push these calls through the inbox like the chat path does.
+_AGENT_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _get_agent_lock(agent_name: str) -> asyncio.Lock:
+    return _AGENT_LOCKS.setdefault(agent_name, asyncio.Lock())
+
+
 async def _get_session(registry: "AgentRegistry", name: str) -> "object":
     """Return a loaded ChatSession for `name`.
 
@@ -62,13 +77,24 @@ async def _get_session(registry: "AgentRegistry", name: str) -> "object":
     return registry.get_or_load(name)
 
 
-def _new_agent_history_entries(session, baseline: int) -> list[str]:
+def _new_agent_history_entries(
+    session, baseline: int, *, chain_id: str | None = None,
+) -> list[str]:
     """Return text of every history entry past `baseline` whose role is
-    ``agent``. Order-preserving."""
+    ``agent``. Order-preserving.
+
+    When ``chain_id`` is provided, only entries whose ``meta["chain_id"]``
+    matches are returned. This scopes reply harvesting to the caller's
+    own chain so concurrent ``send_to_agent_impl`` calls (e.g. via the
+    A2A FastAPI router) don't pick up each other's replies.
+    """
     out: list[str] = []
     for msg in session.history[baseline:]:
-        if msg.role == "agent" and msg.text:
-            out.append(msg.text)
+        if msg.role != "agent" or not msg.text:
+            continue
+        if chain_id is not None and (msg.meta or {}).get("chain_id") != chain_id:
+            continue
+        out.append(msg.text)
     return out
 
 
@@ -151,23 +177,31 @@ async def send_to_agent_impl(
         )
 
     session = await _get_session(registry, agent_name)
-    baseline = len(session.history)
 
     # Drive the user-message handler inline rather than going through
     # session.inbox + session.run(). See `_get_session` docstring for the
     # asyncio-starvation rationale.
     from reyn.chat.session import _new_chain_id  # noqa: PLC0415 — lazy import
     chain_id = _new_chain_id()
-    try:
-        await asyncio.wait_for(
-            session._handle_user_message(message, chain_id=chain_id),
-            timeout=timeout,
-        )
-        idle = True
-    except asyncio.TimeoutError:
-        idle = False
 
-    new_replies = _new_agent_history_entries(session, baseline)
+    # Serialize concurrent calls to the same agent — see _AGENT_LOCKS for
+    # why. The lock is acquired AFTER session lookup (cheap) and AROUND
+    # both the handler call and the reply harvest so the baseline →
+    # _handle_user_message → history-read window is atomic per agent.
+    async with _get_agent_lock(agent_name):
+        baseline = len(session.history)
+        try:
+            await asyncio.wait_for(
+                session._handle_user_message(message, chain_id=chain_id),
+                timeout=timeout,
+            )
+            idle = True
+        except asyncio.TimeoutError:
+            idle = False
+
+        new_replies = _new_agent_history_entries(
+            session, baseline, chain_id=chain_id,
+        )
     reply_text = "\n\n".join(new_replies).strip()
 
     if not idle and not reply_text:

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -1,0 +1,28 @@
+"""Plan-mode runtime substrate (ADR-0023 Phase 2).
+
+Parallel infrastructure to ``src/reyn/skill/`` for plan-mode resume.
+Step 1 (decomposition artifact helpers) is the standalone foundation;
+later steps add ``PlanSnapshot``, ``PlanRegistry``, ``PlanRuntime``,
+analyzer, coordinator.
+"""
+from __future__ import annotations
+
+from reyn.plan.decomposition import (
+    DECOMPOSITION_SCHEMA_VERSION,
+    DecompositionCorruptError,
+    decomposition_dir,
+    decomposition_path,
+    delete_decomposition,
+    read_decomposition,
+    write_decomposition,
+)
+
+__all__ = [
+    "DECOMPOSITION_SCHEMA_VERSION",
+    "DecompositionCorruptError",
+    "decomposition_dir",
+    "decomposition_path",
+    "delete_decomposition",
+    "read_decomposition",
+    "write_decomposition",
+]

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -39,6 +39,11 @@ from reyn.plan.plan_snapshot import (
     plan_snapshot_path,
     step_result_file_path,
 )
+from reyn.plan.sub_loop_memo import (
+    SubLoopMemoProvider,
+    compute_sub_loop_args_hash,
+    extract_step_llm_call_records,
+)
 
 __all__ = [
     "DECOMPOSITION_SCHEMA_VERSION",
@@ -55,7 +60,10 @@ __all__ = [
     "PlanRuntime",
     "PlanSnapshot",
     "PlanStepState",
+    "SubLoopMemoProvider",
     "build_plan_resume_config",
+    "compute_sub_loop_args_hash",
+    "extract_step_llm_call_records",
     "decomposition_dir",
     "decomposition_path",
     "delete_decomposition",

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -17,7 +17,12 @@ from reyn.plan.decomposition import (
     write_decomposition,
 )
 from reyn.plan.plan_registry import PlanRegistry
-from reyn.plan.plan_runtime import PlanResumePlan, PlanRuntime
+from reyn.plan.plan_resume_analyzer import (
+    PlanResumeAnalyzer,
+    PlanResumePlan,
+    PlanStepState,
+)
+from reyn.plan.plan_runtime import PlanRuntime
 from reyn.plan.plan_snapshot import (
     PLAN_SNAPSHOT_VERSION,
     PlanSnapshot,
@@ -29,9 +34,11 @@ __all__ = [
     "DecompositionCorruptError",
     "PLAN_SNAPSHOT_VERSION",
     "PlanRegistry",
+    "PlanResumeAnalyzer",
     "PlanResumePlan",
     "PlanRuntime",
     "PlanSnapshot",
+    "PlanStepState",
     "decomposition_dir",
     "decomposition_path",
     "delete_decomposition",

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -13,6 +13,7 @@ from reyn.plan.decomposition import (
     decomposition_dir,
     decomposition_path,
     delete_decomposition,
+    delete_plan_workspace,
     read_decomposition,
     write_decomposition,
 )
@@ -34,7 +35,9 @@ from reyn.plan.plan_runtime import PlanRuntime
 from reyn.plan.plan_snapshot import (
     PLAN_SNAPSHOT_VERSION,
     PlanSnapshot,
+    get_step_result,
     plan_snapshot_path,
+    step_result_file_path,
 )
 
 __all__ = [
@@ -56,7 +59,10 @@ __all__ = [
     "decomposition_dir",
     "decomposition_path",
     "delete_decomposition",
+    "delete_plan_workspace",
+    "get_step_result",
     "plan_snapshot_path",
     "read_decomposition",
+    "step_result_file_path",
     "write_decomposition",
 ]

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -22,6 +22,14 @@ from reyn.plan.plan_resume_analyzer import (
     PlanResumePlan,
     PlanStepState,
 )
+from reyn.plan.plan_resume_coordinator import (
+    PlanResumeAction,
+    PlanResumeChildAction,
+    PlanResumeConfig,
+    PlanResumeCoordinator,
+    PlanResumeDecision,
+    build_plan_resume_config,
+)
 from reyn.plan.plan_runtime import PlanRuntime
 from reyn.plan.plan_snapshot import (
     PLAN_SNAPSHOT_VERSION,
@@ -34,11 +42,17 @@ __all__ = [
     "DecompositionCorruptError",
     "PLAN_SNAPSHOT_VERSION",
     "PlanRegistry",
+    "PlanResumeAction",
     "PlanResumeAnalyzer",
+    "PlanResumeChildAction",
+    "PlanResumeConfig",
+    "PlanResumeCoordinator",
+    "PlanResumeDecision",
     "PlanResumePlan",
     "PlanRuntime",
     "PlanSnapshot",
     "PlanStepState",
+    "build_plan_resume_config",
     "decomposition_dir",
     "decomposition_path",
     "delete_decomposition",

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -16,6 +16,7 @@ from reyn.plan.decomposition import (
     read_decomposition,
     write_decomposition,
 )
+from reyn.plan.plan_registry import PlanRegistry
 from reyn.plan.plan_snapshot import (
     PLAN_SNAPSHOT_VERSION,
     PlanSnapshot,
@@ -26,6 +27,7 @@ __all__ = [
     "DECOMPOSITION_SCHEMA_VERSION",
     "DecompositionCorruptError",
     "PLAN_SNAPSHOT_VERSION",
+    "PlanRegistry",
     "PlanSnapshot",
     "decomposition_dir",
     "decomposition_path",

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -16,13 +16,21 @@ from reyn.plan.decomposition import (
     read_decomposition,
     write_decomposition,
 )
+from reyn.plan.plan_snapshot import (
+    PLAN_SNAPSHOT_VERSION,
+    PlanSnapshot,
+    plan_snapshot_path,
+)
 
 __all__ = [
     "DECOMPOSITION_SCHEMA_VERSION",
     "DecompositionCorruptError",
+    "PLAN_SNAPSHOT_VERSION",
+    "PlanSnapshot",
     "decomposition_dir",
     "decomposition_path",
     "delete_decomposition",
+    "plan_snapshot_path",
     "read_decomposition",
     "write_decomposition",
 ]

--- a/src/reyn/plan/__init__.py
+++ b/src/reyn/plan/__init__.py
@@ -17,6 +17,7 @@ from reyn.plan.decomposition import (
     write_decomposition,
 )
 from reyn.plan.plan_registry import PlanRegistry
+from reyn.plan.plan_runtime import PlanResumePlan, PlanRuntime
 from reyn.plan.plan_snapshot import (
     PLAN_SNAPSHOT_VERSION,
     PlanSnapshot,
@@ -28,6 +29,8 @@ __all__ = [
     "DecompositionCorruptError",
     "PLAN_SNAPSHOT_VERSION",
     "PlanRegistry",
+    "PlanResumePlan",
+    "PlanRuntime",
     "PlanSnapshot",
     "decomposition_dir",
     "decomposition_path",

--- a/src/reyn/plan/decomposition.py
+++ b/src/reyn/plan/decomposition.py
@@ -1,0 +1,235 @@
+"""Plan decomposition artifact — workspace-resident SSoT for the plan shape.
+
+ADR-0023 §3.5: LLM-emitted decomposition is non-deterministic; re-calling
+the planner LLM on resume yields a different plan and breaks step-result
+memoization (= new ``step_id``s don't match recorded keys). The Plan
+dataclass is therefore persisted as a workspace artifact (P5 SSoT) and
+read verbatim on resume.
+
+Storage path::
+
+    .reyn/agents/<agent_name>/state/plans/<plan_id>/decomposition.json
+
+Atomic write recipe (= ``tmp + fsync + rename``) mirrors
+:meth:`SkillSnapshot.save`. A mid-write crash leaves any prior file
+intact.
+
+Schema (``DECOMPOSITION_SCHEMA_VERSION = 1``):
+
+.. code-block:: json
+
+    {
+      "plan_id": "ab12cd34",
+      "schema_version": 1,
+      "goal": "...",
+      "steps": [
+        {"id": "s1", "description": "...", "tools": ["read_file"], "depends_on": []}
+      ]
+    }
+
+This module is **standalone** — no ChatSession / RouterLoopHost coupling.
+Callers (= ``dispatch_plan_tool`` write path, ``PlanRuntime`` read path,
+``AgentRegistry.restore_all`` cleanup) thread the agent-state directory
+explicitly. P7-clean: no skill-specific strings.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from reyn.chat.planner import Plan, PlanStep
+
+DECOMPOSITION_SCHEMA_VERSION = 1
+
+
+class DecompositionCorruptError(ValueError):
+    """Raised when a decomposition artifact cannot be parsed.
+
+    Distinct from :class:`FileNotFoundError` so the resume coordinator can
+    branch ("file missing" → use snapshot ``steps_serialized`` fallback;
+    "file corrupt" → force ``action=discard``).
+    """
+
+
+# ── Path helpers ────────────────────────────────────────────────────────────
+
+
+def decomposition_dir(agent_state_dir: Path, plan_id: str) -> Path:
+    """Return ``<agent_state>/plans/<plan_id>/`` (= per-plan directory).
+
+    ``agent_state_dir`` is the ``.reyn/agents/<agent_name>/state/`` path
+    chosen by the caller. The decomposition lives at
+    ``<agent_state>/plans/<plan_id>/decomposition.json``; the per-plan
+    directory keeps room for future per-plan artifacts (= step
+    intermediate outputs, sub-loop traces) without cluttering the
+    skills/ sibling.
+    """
+    return Path(agent_state_dir) / "plans" / plan_id
+
+
+def decomposition_path(agent_state_dir: Path, plan_id: str) -> Path:
+    """Return ``<agent_state>/plans/<plan_id>/decomposition.json``."""
+    return decomposition_dir(agent_state_dir, plan_id) / "decomposition.json"
+
+
+# ── Write / read / delete ───────────────────────────────────────────────────
+
+
+def write_decomposition(
+    agent_state_dir: Path, plan_id: str, plan: Plan
+) -> Path:
+    """Atomically persist the decomposition for ``plan_id`` and return its path.
+
+    Atomic recipe: write to ``decomposition.json.tmp``, ``fsync``, then
+    ``rename`` over ``decomposition.json``. Mid-write crash is safe — the
+    ``.tmp`` file is incomplete and the rename never happened, so any
+    prior artifact remains intact.
+
+    The caller is responsible for ordering this **before** the
+    ``plan_started`` WAL append (= ADR-0023 §3.5 lifecycle ordering: any
+    plan in ``active_plan_ids`` MUST have a discoverable decomposition).
+    """
+    target = decomposition_path(agent_state_dir, plan_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "plan_id": plan_id,
+        "schema_version": DECOMPOSITION_SCHEMA_VERSION,
+        "goal": plan.goal,
+        "steps": [
+            {
+                "id": s.id,
+                "description": s.description,
+                "tools": list(s.tools),
+                "depends_on": list(s.depends_on),
+            }
+            for s in plan.steps
+        ],
+    }
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    tmp.replace(target)
+    return target
+
+
+def read_decomposition(agent_state_dir: Path, plan_id: str) -> Plan:
+    """Load the decomposition for ``plan_id``.
+
+    Raises :class:`FileNotFoundError` if the artifact is missing
+    (= caller may fall back to snapshot ``steps_serialized``).
+
+    Raises :class:`DecompositionCorruptError` on JSON parse failure,
+    schema-version mismatch, or structural defect (= caller forces
+    ``action=discard`` per ADR-0023 §3.5 corruption fallback).
+    """
+    path = decomposition_path(agent_state_dir, plan_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DecompositionCorruptError(
+            f"plan decomposition at {path} is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise DecompositionCorruptError(
+            f"plan decomposition at {path} must be an object, "
+            f"got {type(data).__name__}"
+        )
+    version = data.get("schema_version")
+    if version != DECOMPOSITION_SCHEMA_VERSION:
+        raise DecompositionCorruptError(
+            f"plan decomposition at {path} has schema_version "
+            f"{version!r}, expected {DECOMPOSITION_SCHEMA_VERSION}"
+        )
+    goal = data.get("goal")
+    if not isinstance(goal, str) or not goal:
+        raise DecompositionCorruptError(
+            f"plan decomposition at {path}: goal must be a non-empty string"
+        )
+    raw_steps = data.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        raise DecompositionCorruptError(
+            f"plan decomposition at {path}: steps must be a non-empty list"
+        )
+    steps: list[PlanStep] = []
+    for i, raw in enumerate(raw_steps):
+        if not isinstance(raw, dict):
+            raise DecompositionCorruptError(
+                f"plan decomposition at {path}: steps[{i}] must be an object"
+            )
+        sid = raw.get("id")
+        desc = raw.get("description")
+        tools = raw.get("tools", [])
+        deps = raw.get("depends_on", [])
+        if not isinstance(sid, str) or not sid:
+            raise DecompositionCorruptError(
+                f"plan decomposition at {path}: steps[{i}].id "
+                "must be a non-empty string"
+            )
+        if not isinstance(desc, str) or not desc:
+            raise DecompositionCorruptError(
+                f"plan decomposition at {path}: steps[{i}].description "
+                "must be a non-empty string"
+            )
+        if not isinstance(tools, list) or not all(isinstance(t, str) for t in tools):
+            raise DecompositionCorruptError(
+                f"plan decomposition at {path}: steps[{i}].tools "
+                "must be a list of strings"
+            )
+        if not isinstance(deps, list) or not all(isinstance(d, str) for d in deps):
+            raise DecompositionCorruptError(
+                f"plan decomposition at {path}: steps[{i}].depends_on "
+                "must be a list of strings"
+            )
+        steps.append(
+            PlanStep(
+                id=sid,
+                description=desc,
+                tools=tuple(tools),
+                depends_on=tuple(deps),
+            )
+        )
+    return Plan(goal=goal, steps=tuple(steps))
+
+
+def delete_decomposition(agent_state_dir: Path, plan_id: str) -> bool:
+    """Remove ``decomposition.json`` and the per-plan directory if empty.
+
+    Returns ``True`` if the artifact existed and was removed, ``False``
+    otherwise. Idempotent — safe to call on a missing artifact (=
+    used by ``AgentRegistry.restore_all`` cleanup which doesn't know
+    if the artifact survived the crash).
+
+    Removes the per-plan directory only when empty so future per-plan
+    artifacts (= step intermediates) added by Phase 3 aren't dropped.
+    """
+    target = decomposition_path(agent_state_dir, plan_id)
+    existed = target.exists()
+    try:
+        target.unlink(missing_ok=True)
+    except OSError:
+        pass
+    parent = target.parent
+    try:
+        if parent.is_dir() and not any(parent.iterdir()):
+            parent.rmdir()
+    except OSError:
+        pass
+    return existed
+
+
+__all__ = [
+    "DECOMPOSITION_SCHEMA_VERSION",
+    "DecompositionCorruptError",
+    "decomposition_dir",
+    "decomposition_path",
+    "delete_decomposition",
+    "read_decomposition",
+    "write_decomposition",
+]

--- a/src/reyn/plan/decomposition.py
+++ b/src/reyn/plan/decomposition.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from pathlib import Path
 
 from reyn.chat.planner import Plan, PlanStep
@@ -224,12 +225,38 @@ def delete_decomposition(agent_state_dir: Path, plan_id: str) -> bool:
     return existed
 
 
+def delete_plan_workspace(agent_state_dir: Path, plan_id: str) -> bool:
+    """Recursively remove the per-plan directory + every artifact in it.
+
+    ADR-0024 cleanup helper. Used by ``PlanRegistry.complete`` and
+    ``/plan discard`` so the per-plan workspace (= decomposition.json
+    + step_results/<step>.txt files + any future per-plan artifacts)
+    is reclaimed atomically when the plan is no longer needed.
+
+    Idempotent. Returns ``True`` if the directory existed (and is now
+    gone), ``False`` if there was nothing to clean up.
+
+    Distinct from ``delete_decomposition``: that helper removes only
+    the decomposition.json + the per-plan dir if empty. With ADR-0024
+    spilled step result files, the per-plan dir is rarely empty, so
+    we need a recursive cleanup. Both helpers stay in the surface
+    so call sites that intentionally want to preserve workspace
+    artifacts (= forensics) keep that option.
+    """
+    plan_dir = decomposition_dir(agent_state_dir, plan_id)
+    if not plan_dir.exists():
+        return False
+    shutil.rmtree(plan_dir, ignore_errors=True)
+    return not plan_dir.exists()
+
+
 __all__ = [
     "DECOMPOSITION_SCHEMA_VERSION",
     "DecompositionCorruptError",
     "decomposition_dir",
     "decomposition_path",
     "delete_decomposition",
+    "delete_plan_workspace",
     "read_decomposition",
     "write_decomposition",
 ]

--- a/src/reyn/plan/plan_registry.py
+++ b/src/reyn/plan/plan_registry.py
@@ -27,11 +27,16 @@ Design invariants (mirror SkillRegistry):
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable
 
-from reyn.plan.decomposition import delete_decomposition
-from reyn.plan.plan_snapshot import PlanSnapshot, plan_snapshot_path
+from reyn.plan.decomposition import delete_decomposition, delete_plan_workspace
+from reyn.plan.plan_snapshot import (
+    PlanSnapshot,
+    plan_snapshot_path,
+    step_result_file_path,
+)
 
 if TYPE_CHECKING:
     pass
@@ -39,23 +44,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Step 3: bound the persisted text of a step result so a multi-page
-# scrape doesn't blow up the snapshot file. Phase 2 v1 uses inline
-# truncation (= ADR-0023 "Open issues: Step result size cap"). Future
-# work may spill to side files mirroring R-D10's llm_results pattern.
-_STEP_RESULT_MAX_CHARS = 32_768
-_STEP_RESULT_TRUNC_SUFFIX = "\n[truncated]"
-
-
-def _bound_step_result(text: str) -> str:
-    """Bound a step result text to keep snapshot files small (= ADR-0023
-    "Open issues: Step result size cap")."""
-    if not isinstance(text, str):
-        text = str(text)
-    if len(text) <= _STEP_RESULT_MAX_CHARS:
-        return text
-    cap = _STEP_RESULT_MAX_CHARS - len(_STEP_RESULT_TRUNC_SUFFIX)
-    return text[:cap] + _STEP_RESULT_TRUNC_SUFFIX
+# ADR-0024: spill threshold. Step results ≤ this are inline on
+# PlanSnapshot.step_results (= cheap read path); larger results spill
+# to a per-plan-dir file (= state/plans/<plan_id>/step_results/<step_id>.txt)
+# with PlanSnapshot.step_result_refs holding the relative path.
+# Mirrors R-D10's `llm_result_ref` skill-side threshold.
+_SPILL_THRESHOLD_CHARS = 32_768
 
 
 class PlanRegistry:
@@ -190,11 +184,16 @@ class PlanRegistry:
                 snap_path, e,
             )
         if delete_artifact:
+            # ADR-0024: workspace-wide cleanup removes decomposition.json
+            # AND spilled step_results/<step>.txt files in one rmtree.
+            # delete_decomposition is no longer sufficient — with
+            # per-plan workspace files the parent dir isn't empty so
+            # the legacy rmdir path leaves an orphan tree.
             try:
-                delete_decomposition(self._state_dir, plan_id)
+                delete_plan_workspace(self._state_dir, plan_id)
             except OSError as e:
                 logger.warning(
-                    "complete: cannot remove decomposition artifact for %s: %s",
+                    "complete: cannot remove plan workspace for %s: %s",
                     plan_id, e,
                 )
         self._snapshots.pop(plan_id, None)
@@ -232,8 +231,20 @@ class PlanRegistry:
         """Record durable step completion.
 
         Bumps ``applied_seq`` AND ``last_step_applied_seq`` (= durable
-        progress, gates WAL truncation per ADR-0023 §3.1). Stores
-        bounded ``result_text`` in ``step_results``.
+        progress, gates WAL truncation per ADR-0023 §3.1).
+
+        ADR-0024 spill: ``result_text`` ≤ 32 KB stays inline on
+        ``snap.step_results``; larger text writes to
+        ``state/plans/<plan_id>/step_results/<step_id>.txt`` with the
+        relative path stored in ``snap.step_result_refs``. Truncation is
+        no longer applied at any size — the file path is the failover.
+
+        Atomic write: the spill file goes through ``tmp + fsync +
+        rename`` mirroring ``PlanSnapshot.save``. Snapshot is rewritten
+        *after* the file write succeeds, so a crash between the two
+        leaves the file orphaned but the snapshot in pre-write state
+        (= the step classifies as ``pending`` on resume → re-execute,
+        the orphan file gets reaped on plan completion).
         """
         snap = self._snapshots.get(plan_id)
         if snap is None:
@@ -241,15 +252,50 @@ class PlanRegistry:
                 "record_step_completed: unknown plan_id %r — skipping", plan_id,
             )
             return
+        if not isinstance(result_text, str):
+            result_text = str(result_text)
+
+        # Branch on size: inline vs spill-to-file.
+        if len(result_text) <= _SPILL_THRESHOLD_CHARS:
+            snap.step_results[step_id] = result_text
+            # Clear stale ref if a previous attempt had spilled.
+            stale_ref = snap.step_result_refs.pop(step_id, None)
+            if stale_ref:
+                self._unlink_spilled_step_result(plan_id, stale_ref)
+        else:
+            # Spill: atomic write to per-plan workspace dir.
+            target = step_result_file_path(self._state_dir, plan_id, step_id)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            tmp = target.with_suffix(target.suffix + ".tmp")
+            with tmp.open("w", encoding="utf-8") as f:
+                f.write(result_text)
+                f.flush()
+                os.fsync(f.fileno())
+            tmp.replace(target)
+            snap.step_result_refs[step_id] = f"step_results/{step_id}.txt"
+            # Clear stale inline if a previous attempt was small.
+            snap.step_results.pop(step_id, None)
+
         snap.applied_seq = max(snap.applied_seq, applied_seq)
         snap.last_step_applied_seq = max(snap.last_step_applied_seq, applied_seq)
-        snap.step_results[step_id] = _bound_step_result(result_text)
         snap.last_committed_step_id = step_id
         if snap.current_step_id == step_id:
             # Clear forward-replay anchor: the executor is between steps.
             snap.current_step_id = None
         self._save(snap)
         await self._fire_truncate_hook(trigger="plan_step_completed")
+
+    def _unlink_spilled_step_result(self, plan_id: str, rel: str) -> None:
+        """Remove a spilled step result file (= used when re-running a
+        step that previously spilled, so the stale file doesn't linger
+        until plan completion)."""
+        full = self._state_dir / "plans" / plan_id / rel
+        try:
+            full.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning(
+                "could not remove spilled step result %s: %s", full, e,
+            )
 
     async def record_step_failed(
         self,
@@ -327,6 +373,12 @@ class PlanRegistry:
         for sid in list(snap.step_results.keys()):
             if sid in to_clear:
                 snap.step_results.pop(sid, None)
+        # ADR-0024: clear refs + delete spilled files so re-execution
+        # starts with no stale state on disk.
+        for sid in list(snap.step_result_refs.keys()):
+            if sid in to_clear:
+                rel = snap.step_result_refs.pop(sid)
+                self._unlink_spilled_step_result(plan_id, rel)
         for sid in list(snap.step_failures.keys()):
             if sid in to_clear:
                 snap.step_failures.pop(sid, None)

--- a/src/reyn/plan/plan_registry.py
+++ b/src/reyn/plan/plan_registry.py
@@ -279,6 +279,71 @@ class PlanRegistry:
         self._save(snap)
         await self._fire_truncate_hook(trigger="plan_step_failed")
 
+    def reset_from_step(
+        self,
+        *,
+        plan_id: str,
+        from_step_id: str,
+        step_order: list[str],
+    ) -> bool:
+        """Surgical operator escape hatch — clear step results from
+        ``from_step_id`` onward so the runtime re-executes them.
+
+        ADR-0023 §3.7 ``resume_from_step`` operator-only path. Targets
+        the case where a step recorded a result but the operator wants
+        to redo it (= the LLM produced something wrong, or the world
+        state has changed in a way the recorded result doesn't reflect).
+
+        Args:
+            plan_id: target plan.
+            from_step_id: first step to clear (= and every step after
+                it in topological order).
+            step_order: the plan's topological step IDs (caller
+                provides — registry doesn't load decompositions).
+
+        Returns ``True`` on success, ``False`` if the plan is unknown
+        or ``from_step_id`` isn't in ``step_order``.
+
+        Persists the mutated snapshot before returning so a crash mid-
+        reset doesn't leave inconsistent state.
+        """
+        snap = self._snapshots.get(plan_id)
+        if snap is None:
+            logger.info(
+                "reset_from_step: unknown plan_id %r — skipping", plan_id,
+            )
+            return False
+        if from_step_id not in step_order:
+            logger.warning(
+                "reset_from_step: step %r not in plan %r step order",
+                from_step_id, plan_id,
+            )
+            return False
+        # Find indexes from from_step_id onward and clear their
+        # per-step state. Steps before from_step_id keep their results
+        # so the resume runtime memoizes them on the next launch.
+        idx = step_order.index(from_step_id)
+        to_clear = set(step_order[idx:])
+        for sid in list(snap.step_results.keys()):
+            if sid in to_clear:
+                snap.step_results.pop(sid, None)
+        for sid in list(snap.step_failures.keys()):
+            if sid in to_clear:
+                snap.step_failures.pop(sid, None)
+        for sid in list(snap.spawned_skill_run_ids.keys()):
+            if sid in to_clear:
+                snap.spawned_skill_run_ids.pop(sid, None)
+        # last_committed_step_id rewinds to the most recent kept step
+        # (= step immediately before from_step_id), or None when
+        # from_step_id is the head step.
+        if idx == 0:
+            snap.last_committed_step_id = None
+        else:
+            snap.last_committed_step_id = step_order[idx - 1]
+        snap.current_step_id = None
+        self._save(snap)
+        return True
+
     def record_child_spawned(
         self, *, plan_id: str, step_id: str, child_run_id: str,
     ) -> None:

--- a/src/reyn/plan/plan_registry.py
+++ b/src/reyn/plan/plan_registry.py
@@ -1,0 +1,345 @@
+"""PlanRegistry — per-agent coordinator for active plan snapshots.
+
+ADR-0023 §3.1 + §3.4. Mirrors :class:`SkillRegistry` shape. Owns the
+lifecycle of per-plan snapshot files (create on ``plan_started``,
+mutate on each ``plan_step_*`` event, delete on
+``plan_completed`` / ``plan_aborted``).
+
+Responsibilities (Step 3 of the migration path):
+  - Allocate / load / save / delete per-plan snapshots
+  - Provide snapshot mutation methods for step lifecycle events
+  - Surface ``list_active()`` for AgentRegistry's truncation floor
+    calculation and the future resume coordinator
+  - Stay agnostic about WAL emission (= Phase 1's SnapshotJournal owns
+    ``plan_started`` / ``plan_completed`` / ``plan_aborted`` WAL appends,
+    Step 4 will route ``plan_step_*`` WAL appends through SnapshotJournal
+    too — PlanRegistry only sees the resulting ``applied_seq`` from those
+    appends).
+
+Design invariants (mirror SkillRegistry):
+  - Per-plan snapshot is a CACHE; the WAL is the source of truth.
+    Crash-loss of the snapshot is recoverable by replaying WAL events
+    from ``applied_seq=0`` for that plan_id.
+  - Snapshot is mutated only via this registry's methods.
+  - One registry instance per (agent_name, project_root). Process can
+    hold many registries — one per agent.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from reyn.plan.decomposition import delete_decomposition
+from reyn.plan.plan_snapshot import PlanSnapshot, plan_snapshot_path
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+# Step 3: bound the persisted text of a step result so a multi-page
+# scrape doesn't blow up the snapshot file. Phase 2 v1 uses inline
+# truncation (= ADR-0023 "Open issues: Step result size cap"). Future
+# work may spill to side files mirroring R-D10's llm_results pattern.
+_STEP_RESULT_MAX_CHARS = 32_768
+_STEP_RESULT_TRUNC_SUFFIX = "\n[truncated]"
+
+
+def _bound_step_result(text: str) -> str:
+    """Bound a step result text to keep snapshot files small (= ADR-0023
+    "Open issues: Step result size cap")."""
+    if not isinstance(text, str):
+        text = str(text)
+    if len(text) <= _STEP_RESULT_MAX_CHARS:
+        return text
+    cap = _STEP_RESULT_MAX_CHARS - len(_STEP_RESULT_TRUNC_SUFFIX)
+    return text[:cap] + _STEP_RESULT_TRUNC_SUFFIX
+
+
+class PlanRegistry:
+    """Per-agent active-plan coordinator.
+
+    Snapshots live at::
+
+        <agent_state_dir>/plans/<plan_id>.snapshot.json
+
+    Where ``agent_state_dir`` is typically
+    ``.reyn/agents/<agent_name>/state``.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        agent_state_dir: Path,
+        truncate_eligible_hook: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        """
+        truncate_eligible_hook: optional async callback fired *after* each
+            ``plan_step_completed`` / ``plan_completed`` mutation. Used to
+            trigger ``AgentRegistry.truncate_wal_if_eligible()`` on
+            semantic boundaries (= mirror SkillRegistry's hook). Hook
+            exceptions are caught and logged; truncation is opportunistic.
+        """
+        self._agent_name = agent_name
+        self._state_dir = Path(agent_state_dir)
+        self._truncate_hook = truncate_eligible_hook
+        # In-memory cache: plan_id → PlanSnapshot. Populated on start() /
+        # load_active(); cleared on complete().
+        self._snapshots: dict[str, PlanSnapshot] = {}
+
+    @property
+    def state_dir(self) -> Path:
+        """Public view of the per-agent state directory."""
+        return self._state_dir
+
+    @property
+    def agent_name(self) -> str:
+        return self._agent_name
+
+    async def _fire_truncate_hook(self, *, trigger: str) -> None:
+        """Fire the optional truncate-eligible hook. Defensive: never raise."""
+        if self._truncate_hook is None:
+            return
+        try:
+            await self._truncate_hook()
+        except Exception as e:  # noqa: BLE001 — never fail caller
+            logger.warning(
+                "truncate_eligible_hook (%s) raised: %s", trigger, e,
+            )
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def start(
+        self,
+        *,
+        plan_id: str,
+        chain_id: str,
+        goal: str,
+        applied_seq: int,
+        decomposition_artifact_path: str | None = None,
+        steps_serialized: list[dict] | None = None,
+        parent_skill_run_id: str | None = None,
+    ) -> PlanSnapshot:
+        """Begin a new plan run.
+
+        Effects:
+          1. Create the per-plan snapshot file with ``applied_seq`` and
+             ``last_step_applied_seq`` stamped at the WAL seq the caller
+             received from the corresponding ``plan_started`` append.
+          2. Cache the snapshot in memory.
+
+        ``applied_seq`` is the seq returned by the caller's
+        ``state_log.append("plan_started", ...)``; PlanRegistry does NOT
+        emit WAL events for plan-level lifecycle (= Phase 1's
+        SnapshotJournal owns that path).
+
+        Idempotent on the in-memory cache: starting the same plan_id twice
+        overwrites the existing entry.
+        """
+        snap = PlanSnapshot.empty(
+            plan_id=plan_id,
+            agent_name=self._agent_name,
+            chain_id=chain_id,
+            goal=goal,
+        )
+        snap.applied_seq = applied_seq
+        snap.last_step_applied_seq = applied_seq
+        snap.decomposition_artifact_path = decomposition_artifact_path
+        snap.steps_serialized = list(steps_serialized or [])
+        snap.parent_skill_run_id = parent_skill_run_id
+        self._save(snap)
+        self._snapshots[plan_id] = snap
+        return snap
+
+    async def complete(
+        self,
+        *,
+        plan_id: str,
+        status: str = "completed",
+        delete_artifact: bool = True,
+    ) -> None:
+        """Mark a plan run as finished and remove its snapshot.
+
+        ``status`` is currently advisory (= "completed" / "aborted" /
+        "discarded"); the WAL event kind is determined by the caller
+        (Phase 1 SnapshotJournal). It's accepted here for symmetry with
+        :meth:`SkillRegistry.complete` and surfaced to the truncate hook.
+
+        ``delete_artifact``: when True (default), also remove the
+        decomposition artifact (= P5 cleanup, mirrors ADR-0023 §3.4
+        finally-clause). Set False for the rare case where the caller
+        wants to preserve the artifact for forensics.
+
+        Lifecycle ordering: the caller appends the lifecycle WAL event
+        first (= ``plan_completed`` / ``plan_aborted``); this method
+        runs after, removing the snapshot file. A crash between the two
+        leaves the snapshot orphaned but recoverable: next startup sees
+        the lifecycle event in the WAL, replays it onto AgentSnapshot
+        (which removes plan_id from ``active_plan_ids``), and the
+        orphan is garbage-collected by ``load_active()`` cleanup.
+        """
+        snap_path = plan_snapshot_path(self._state_dir, plan_id)
+        try:
+            snap_path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning(
+                "complete: cannot remove plan snapshot %s: %s",
+                snap_path, e,
+            )
+        if delete_artifact:
+            try:
+                delete_decomposition(self._state_dir, plan_id)
+            except OSError as e:
+                logger.warning(
+                    "complete: cannot remove decomposition artifact for %s: %s",
+                    plan_id, e,
+                )
+        self._snapshots.pop(plan_id, None)
+        await self._fire_truncate_hook(trigger=status)
+
+    # ── per-step mutations (Step 4 will wire WAL appends) ────────────────
+
+    def record_step_started(
+        self, *, plan_id: str, step_id: str, applied_seq: int,
+    ) -> None:
+        """Record the executor moving onto ``step_id`` (forward-replay anchor).
+
+        Bumps ``applied_seq`` but **not** ``last_step_applied_seq`` —
+        ``plan_step_started`` doesn't represent durable progress
+        (= mirror SkillRegistry's ``step_started`` non-bump).
+        """
+        snap = self._snapshots.get(plan_id)
+        if snap is None:
+            logger.info(
+                "record_step_started: unknown plan_id %r — skipping", plan_id,
+            )
+            return
+        snap.applied_seq = max(snap.applied_seq, applied_seq)
+        snap.current_step_id = step_id
+        self._save(snap)
+
+    async def record_step_completed(
+        self,
+        *,
+        plan_id: str,
+        step_id: str,
+        applied_seq: int,
+        result_text: str,
+    ) -> None:
+        """Record durable step completion.
+
+        Bumps ``applied_seq`` AND ``last_step_applied_seq`` (= durable
+        progress, gates WAL truncation per ADR-0023 §3.1). Stores
+        bounded ``result_text`` in ``step_results``.
+        """
+        snap = self._snapshots.get(plan_id)
+        if snap is None:
+            logger.info(
+                "record_step_completed: unknown plan_id %r — skipping", plan_id,
+            )
+            return
+        snap.applied_seq = max(snap.applied_seq, applied_seq)
+        snap.last_step_applied_seq = max(snap.last_step_applied_seq, applied_seq)
+        snap.step_results[step_id] = _bound_step_result(result_text)
+        snap.last_committed_step_id = step_id
+        if snap.current_step_id == step_id:
+            # Clear forward-replay anchor: the executor is between steps.
+            snap.current_step_id = None
+        self._save(snap)
+        await self._fire_truncate_hook(trigger="plan_step_completed")
+
+    async def record_step_failed(
+        self,
+        *,
+        plan_id: str,
+        step_id: str,
+        applied_seq: int,
+        error_repr: str,
+    ) -> None:
+        """Record a step failure.
+
+        Bumps ``applied_seq`` AND ``last_step_applied_seq`` —
+        conservative per ADR-0023 §3.1 (= a recorded failure is real
+        progress that shouldn't be replayed without policy intervention).
+        """
+        snap = self._snapshots.get(plan_id)
+        if snap is None:
+            logger.info(
+                "record_step_failed: unknown plan_id %r — skipping", plan_id,
+            )
+            return
+        snap.applied_seq = max(snap.applied_seq, applied_seq)
+        snap.last_step_applied_seq = max(snap.last_step_applied_seq, applied_seq)
+        snap.step_failures[step_id] = error_repr
+        if snap.current_step_id == step_id:
+            snap.current_step_id = None
+        self._save(snap)
+        await self._fire_truncate_hook(trigger="plan_step_failed")
+
+    def record_child_spawned(
+        self, *, plan_id: str, step_id: str, child_run_id: str,
+    ) -> None:
+        """Record that ``step_id`` spawned skill_run ``child_run_id``.
+
+        Used by the resume coordinator (Step 7) to coordinate adopt-vs-
+        cancel decisions with the existing skill_resume infrastructure.
+        """
+        snap = self._snapshots.get(plan_id)
+        if snap is None:
+            logger.info(
+                "record_child_spawned: unknown plan_id %r — skipping", plan_id,
+            )
+            return
+        snap.spawned_skill_run_ids[step_id] = child_run_id
+        self._save(snap)
+
+    # ── read access ──────────────────────────────────────────────────────
+
+    def get(self, plan_id: str) -> PlanSnapshot | None:
+        """Return the in-memory snapshot for ``plan_id``, or None if unknown."""
+        return self._snapshots.get(plan_id)
+
+    def list_active(self) -> list[str]:
+        """Return plan_ids of currently-tracked plans (in registration order)."""
+        return list(self._snapshots.keys())
+
+    # ── persistence ──────────────────────────────────────────────────────
+
+    def load_active(self) -> dict[str, PlanSnapshot]:
+        """Discover and load every per-plan snapshot under ``plans/``.
+
+        Used at process startup to repopulate ``_snapshots`` from disk
+        before any new plan activity. Files that fail to parse are
+        skipped with a warning — the WAL is the source of truth.
+
+        Idempotent: calling twice replaces the in-memory cache with
+        whatever's currently on disk.
+        """
+        loaded: dict[str, PlanSnapshot] = {}
+        plans_dir = self._state_dir / "plans"
+        if plans_dir.is_dir():
+            for snap_file in plans_dir.glob("*.snapshot.json"):
+                # Skip the per-plan directories' decomposition.json siblings
+                # (= they live under plans/<plan_id>/, not plans/*.snapshot.json).
+                plan_id = snap_file.stem.removesuffix(".snapshot")
+                try:
+                    snap = PlanSnapshot.load(plan_id, snap_file)
+                except Exception as e:  # noqa: BLE001 — defensive
+                    logger.warning(
+                        "load_active: cannot load %s: %s — skipping",
+                        snap_file, e,
+                    )
+                    continue
+                loaded[plan_id] = snap
+        self._snapshots = loaded
+        return dict(loaded)
+
+    def _save(self, snap: PlanSnapshot) -> None:
+        path = plan_snapshot_path(self._state_dir, snap.plan_id)
+        snap.save(path)
+
+
+__all__ = ["PlanRegistry"]

--- a/src/reyn/plan/plan_registry.py
+++ b/src/reyn/plan/plan_registry.py
@@ -379,6 +379,26 @@ class PlanRegistry:
             if sid in to_clear:
                 rel = snap.step_result_refs.pop(sid)
                 self._unlink_spilled_step_result(plan_id, rel)
+        # ADR-0025: clear recorded LLM calls + delete any spilled
+        # records so re-execution starts with a fresh sub-loop memo
+        # state (= no stale args_hash hits from the prior run).
+        for sid in list(snap.step_llm_calls.keys()):
+            if sid in to_clear:
+                records = snap.step_llm_calls.pop(sid, []) or []
+                for rec in records:
+                    rel = rec.get("ref") if isinstance(rec, dict) else None
+                    if rel:
+                        self._unlink_spilled_step_result(plan_id, rel)
+                # Also try to remove the empty step_llm_calls/<step>/ dir.
+                step_dir = (
+                    self._state_dir / "plans" / plan_id
+                    / "step_llm_calls" / sid
+                )
+                try:
+                    if step_dir.is_dir() and not any(step_dir.iterdir()):
+                        step_dir.rmdir()
+                except OSError:
+                    pass
         for sid in list(snap.step_failures.keys()):
             if sid in to_clear:
                 snap.step_failures.pop(sid, None)
@@ -395,6 +415,49 @@ class PlanRegistry:
         snap.current_step_id = None
         self._save(snap)
         return True
+
+    async def record_step_llm_call(
+        self,
+        *,
+        plan_id: str,
+        step_id: str,
+        args_hash: str,
+        inline: dict | None,
+        ref: str | None,
+        usage: dict | None = None,
+    ) -> None:
+        """ADR-0025: record one sub-loop LLM call for memo replay.
+
+        Called by ``SubLoopMemoProvider.record`` after each
+        ``call_llm_tools`` invocation in a plan step's sub-loop. The
+        provider already wrote the spill file (when ref is set) and
+        computed args_hash; this method only updates
+        ``snap.step_llm_calls[step_id]`` and persists the snapshot.
+
+        Persistence is snapshot-only — no WAL events. The atomic save
+        cost (~1 ms) is negligible relative to the LLM call itself.
+
+        Idempotent on duplicate args_hash: if the same hash is
+        recorded twice (= retry within same step), the new record
+        appends; the lookup walks the list, returns the first match
+        which is the original. No deduplication; future re-runs after
+        ``reset_from_step`` start from a cleared list.
+        """
+        snap = self._snapshots.get(plan_id)
+        if snap is None:
+            logger.info(
+                "record_step_llm_call: unknown plan_id %r — skipping",
+                plan_id,
+            )
+            return
+        bucket = snap.step_llm_calls.setdefault(step_id, [])
+        bucket.append({
+            "args_hash": args_hash,
+            "inline": inline,
+            "ref": ref,
+            "usage": usage or {},
+        })
+        self._save(snap)
 
     def record_child_spawned(
         self, *, plan_id: str, step_id: str, child_run_id: str,

--- a/src/reyn/plan/plan_resume_analyzer.py
+++ b/src/reyn/plan/plan_resume_analyzer.py
@@ -118,6 +118,10 @@ class PlanResumePlan:
     step_states: tuple[PlanStepState, ...] = ()
     has_ambiguity: bool = False
     has_in_flight_child: bool = False
+    # ADR-0025: per-step recorded sub-loop LLM call log, copied from
+    # PlanSnapshot.step_llm_calls. execute_plan constructs a
+    # SubLoopMemoProvider per pending step seeded from this map.
+    step_llm_call_log: dict = field(default_factory=dict)
 
     @property
     def committed_step_ids(self) -> frozenset[str]:
@@ -359,6 +363,9 @@ class PlanResumeAnalyzer:
             step_states=tuple(step_states),
             has_ambiguity=any_ambig,
             has_in_flight_child=any_in_flight_child,
+            # ADR-0025: forward the per-step LLM call log so the runtime
+            # can seed a SubLoopMemoProvider per pending step.
+            step_llm_call_log=dict(snapshot.step_llm_calls),
         )
 
     def _step_signature(self, step: PlanStep) -> str:

--- a/src/reyn/plan/plan_resume_analyzer.py
+++ b/src/reyn/plan/plan_resume_analyzer.py
@@ -24,8 +24,10 @@ import logging
 from dataclasses import dataclass, field
 from typing import Callable, Iterable, Literal
 
+from pathlib import Path
+
 from reyn.chat.planner import Plan, PlanStep
-from reyn.plan.plan_snapshot import PlanSnapshot
+from reyn.plan.plan_snapshot import PlanSnapshot, get_step_result
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +166,7 @@ class PlanResumeAnalyzer:
         decomposition: Plan,
         wal_events: Iterable[dict],
         child_skill_lookup: Callable[[str], str | None] | None = None,
+        agent_state_dir: Path | None = None,
     ) -> PlanResumePlan:
         """Produce a PlanResumePlan for the given plan_id.
 
@@ -299,14 +302,42 @@ class PlanResumeAnalyzer:
                 # Hit completed. Recover result_text from snapshot.
                 # (WAL doesn't carry the text — only content_len. The
                 # snapshot, populated by PlanRegistry.record_step_completed,
-                # is the source of truth for the bounded text.)
-                step_states.append(PlanStepState(
-                    step_id=sid, state="completed_with_result",
-                    started_seq=started_seq,
-                    result_text=snapshot.step_results.get(sid, ""),
-                    is_effectful=_step_is_effectful(step),
-                    step_signature=sig,
-                ))
+                # is the source of truth.)
+                #
+                # ADR-0024: get_step_result transparently resolves
+                # inline vs spilled-to-file. None return = ref present
+                # but file unreadable → classify as failed
+                # (= step_result_file_missing) per ADR-0024 §4.
+                if agent_state_dir is not None:
+                    text = get_step_result(snapshot, agent_state_dir, sid)
+                else:
+                    # Backward-compat: callers that don't supply
+                    # agent_state_dir get the inline-only path. Spilled
+                    # entries surface as None → failed below.
+                    text = snapshot.step_results.get(sid)
+                if text is None and sid in snapshot.step_result_refs:
+                    # Spilled but unreadable.
+                    step_states.append(PlanStepState(
+                        step_id=sid, state="failed",
+                        started_seq=started_seq,
+                        error_kind="step_result_file_missing",
+                        error_message=(
+                            f"step result file referenced "
+                            f"({snapshot.step_result_refs[sid]!r}) but "
+                            "could not be read"
+                        ),
+                        is_effectful=_step_is_effectful(step),
+                        step_signature=sig,
+                    ))
+                    any_ambig = True
+                else:
+                    step_states.append(PlanStepState(
+                        step_id=sid, state="completed_with_result",
+                        started_seq=started_seq,
+                        result_text=text or "",
+                        is_effectful=_step_is_effectful(step),
+                        step_signature=sig,
+                    ))
             else:
                 # Hit failed.
                 fail_seq, error_str = fail_list[0]

--- a/src/reyn/plan/plan_resume_analyzer.py
+++ b/src/reyn/plan/plan_resume_analyzer.py
@@ -1,0 +1,348 @@
+"""PlanResumeAnalyzer — derive a PlanResumePlan from WAL + PlanSnapshot.
+
+ADR-0023 §3.2. The analyzer pairs ``plan_step_started`` with
+``plan_step_completed`` | ``plan_step_failed`` by ``(plan_id, step_id)``,
+FIFO per-key, and produces a per-step state under one of:
+
+  - ``pending`` — no started event, or started without terminal where
+    the step is non-effectful (= safe to re-execute)
+  - ``completed_with_result`` — started + completed pair seen
+  - ``failed`` — started + failed pair seen
+  - ``interrupted_with_child`` — started, no terminal, but the step
+    spawned a child skill (= coordinator must reconcile via skill_resume)
+
+The output ``PlanResumePlan`` is consumed by ``PlanRuntime`` (memo
+replay path, Step 7b) and ``PlanResumeCoordinator`` (adopt-vs-cancel
+decisions, Step 7c).
+
+P7-clean: no skill-specific strings; ``child_skill_lookup`` is injected
+by the runtime to keep the analyzer decoupled from ``SkillRegistry``.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Literal
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan.plan_snapshot import PlanSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+PlanStepStateKind = Literal[
+    "pending",
+    "completed_with_result",
+    "failed",
+    "interrupted_with_child",
+]
+
+
+# Tools that, when present in step.tools, indicate the step has
+# side-effect potential (= ambiguous-no-terminal must escalate to
+# `failed("ambiguous_no_terminal")` rather than `pending`).
+#
+# Phase 2 v1 uses a coarse name-list; ADR-0023 §3.2 allows refinement
+# via OP_KIND_REGISTRY purity tier. The chat router tool catalog uses
+# different names than op_runtime registry, so we maintain a small
+# explicit list.
+_EFFECTFUL_TOOLS = frozenset({
+    "write_file",
+    "delete_file",
+    "call_mcp_tool",
+    "remember",
+    "forget",
+    "remember_shared",
+    "forget_shared",
+})
+
+# Tools that imply spawning a child skill (= the spawn graph is
+# coordinated via skill_resume infra). Keeps analyzer P7-clean by
+# treating "invoke_skill" as a generic spawn marker rather than peeking
+# at the skill name.
+_CHILD_SPAWNING_TOOLS = frozenset({"invoke_skill"})
+
+
+def _step_is_effectful(step: PlanStep) -> bool:
+    return any(t in _EFFECTFUL_TOOLS for t in step.tools)
+
+
+def _step_spawns_child(step: PlanStep) -> bool:
+    return any(t in _CHILD_SPAWNING_TOOLS for t in step.tools)
+
+
+# ── PlanStepState (richer than Step 5's PlanResumePlan) ────────────────────
+
+
+@dataclass(frozen=True)
+class PlanStepState:
+    """Per-step recovery state derived by the analyzer.
+
+    ``state`` drives the runtime's classify_step decision (Step 7b):
+
+      - ``completed_with_result`` → memo (use ``result_text``)
+      - ``failed`` → propagate as recorded failure
+      - ``interrupted_with_child`` → coordinator decides adopt vs cancel
+      - ``pending`` → fresh execute
+    """
+
+    step_id: str
+    state: PlanStepStateKind
+    started_seq: int | None = None
+    result_text: str | None = None
+    error_kind: str | None = None
+    error_message: str | None = None
+    child_run_id: str | None = None
+    child_state: Literal["completed", "in_flight", "discarded", "unknown"] | None = None
+    n_attempts: int = 1
+    is_effectful: bool = False
+    step_signature: str = ""
+
+
+@dataclass(frozen=True)
+class PlanResumePlan:
+    """Analyzer output — full ADR-0023 §3.2 shape (Step 7).
+
+    Distinct from the Step 5 forward-compat dataclass in plan_runtime.py,
+    which carried only the minimal subset needed to stabilise the
+    constructor signature. This is the canonical resume directive.
+    """
+
+    plan_id: str
+    chain_id: str
+    goal: str
+    n_steps: int
+    decomposition_artifact_path: str | None
+    step_states: tuple[PlanStepState, ...] = ()
+    has_ambiguity: bool = False
+    has_in_flight_child: bool = False
+
+    @property
+    def committed_step_ids(self) -> frozenset[str]:
+        return frozenset(
+            s.step_id for s in self.step_states
+            if s.state == "completed_with_result"
+        )
+
+    @property
+    def pending_step_ids(self) -> tuple[str, ...]:
+        return tuple(
+            s.step_id for s in self.step_states if s.state == "pending"
+        )
+
+    @property
+    def failed_step_ids(self) -> tuple[str, ...]:
+        return tuple(
+            s.step_id for s in self.step_states if s.state == "failed"
+        )
+
+    @property
+    def interrupted_with_child_step_ids(self) -> tuple[str, ...]:
+        return tuple(
+            s.step_id for s in self.step_states
+            if s.state == "interrupted_with_child"
+        )
+
+    def step_result_map(self) -> dict[str, str]:
+        return {
+            s.step_id: s.result_text
+            for s in self.step_states
+            if s.state == "completed_with_result" and s.result_text is not None
+        }
+
+
+# ── analyzer ──────────────────────────────────────────────────────────────
+
+
+class PlanResumeAnalyzer:
+    """Reduce WAL plan_step_* events + PlanSnapshot into a PlanResumePlan."""
+
+    def analyze(
+        self,
+        *,
+        snapshot: PlanSnapshot,
+        decomposition: Plan,
+        wal_events: Iterable[dict],
+        child_skill_lookup: Callable[[str], str | None] | None = None,
+    ) -> PlanResumePlan:
+        """Produce a PlanResumePlan for the given plan_id.
+
+        ``wal_events`` is an iterable of dicts in WAL format (= what
+        StateLog.iter_from yields). The analyzer filters by
+        ``plan_id == snapshot.plan_id`` itself; callers may pre-filter
+        for efficiency but it isn't required.
+
+        ``child_skill_lookup`` maps ``child_run_id`` → state literal
+        (``"completed" | "in_flight" | "discarded" | "unknown"``). When
+        absent, ``interrupted_with_child`` states use ``"unknown"`` for
+        ``child_state`` (= caller must default-cancel or query
+        elsewhere).
+        """
+        plan_id = snapshot.plan_id
+
+        # Bucket events per step_id, FIFO. We accumulate started_seqs
+        # (queue) then drain by completed/failed in order so a re-emit
+        # pairs in arrival order. Phase 2 v1 plans run steps once, but
+        # the FIFO shape mirrors SkillResumeAnalyzer for symmetry.
+        starts: dict[str, list[int]] = {}
+        completes: dict[str, list[tuple[int, int]]] = {}  # (seq, content_len)
+        fails: dict[str, list[tuple[int, str]]] = {}      # (seq, error)
+
+        for evt in wal_events:
+            if evt.get("plan_id") != plan_id:
+                continue
+            kind = evt.get("kind")
+            sid = evt.get("step_id")
+            seq = evt.get("seq")
+            if not isinstance(sid, str) or not isinstance(seq, int):
+                continue
+            if kind == "plan_step_started":
+                starts.setdefault(sid, []).append(seq)
+            elif kind == "plan_step_completed":
+                completes.setdefault(sid, []).append(
+                    (seq, int(evt.get("content_len", 0)))
+                )
+            elif kind == "plan_step_failed":
+                fails.setdefault(sid, []).append(
+                    (seq, str(evt.get("error", "")))
+                )
+
+        step_states: list[PlanStepState] = []
+        any_ambig = False
+        any_in_flight_child = False
+
+        for step in decomposition.steps:
+            sid = step.id
+            sig = self._step_signature(step)
+
+            # FIFO pair: pop earliest started, match against earliest
+            # terminal (completed | failed). If both terminals exist,
+            # whichever is earlier wins.
+            n_starts = len(starts.get(sid, []))
+            comp_list = completes.get(sid, [])
+            fail_list = fails.get(sid, [])
+            n_terminals = len(comp_list) + len(fail_list)
+
+            started_seq = starts[sid][0] if n_starts > 0 else None
+
+            if n_terminals == 0 and n_starts == 0:
+                # No events at all — step never reached.
+                step_states.append(PlanStepState(
+                    step_id=sid, state="pending",
+                    is_effectful=_step_is_effectful(step),
+                    step_signature=sig,
+                ))
+                continue
+
+            if n_terminals == 0 and n_starts > 0:
+                # Started, no terminal. Two sub-cases:
+                #  - spawned a child → interrupted_with_child
+                #  - no child + non-effectful → pending (re-execute)
+                #  - no child + effectful → failed (ambiguous_no_terminal)
+                child_run_id = snapshot.spawned_skill_run_ids.get(sid)
+                if child_run_id and _step_spawns_child(step):
+                    child_state: Literal[
+                        "completed", "in_flight", "discarded", "unknown"
+                    ] = "unknown"
+                    if child_skill_lookup is not None:
+                        try:
+                            looked = child_skill_lookup(child_run_id)
+                        except Exception:  # noqa: BLE001 — defensive
+                            looked = None
+                        if looked in ("completed", "in_flight",
+                                      "discarded", "unknown"):
+                            child_state = looked  # type: ignore[assignment]
+                    if child_state == "in_flight":
+                        any_in_flight_child = True
+                    step_states.append(PlanStepState(
+                        step_id=sid, state="interrupted_with_child",
+                        started_seq=started_seq,
+                        child_run_id=child_run_id,
+                        child_state=child_state,
+                        is_effectful=_step_is_effectful(step),
+                        step_signature=sig,
+                    ))
+                    any_ambig = True
+                elif _step_is_effectful(step):
+                    # Effectful step started but no terminal: safer to
+                    # mark failed than to silently re-execute.
+                    step_states.append(PlanStepState(
+                        step_id=sid, state="failed",
+                        started_seq=started_seq,
+                        error_kind="ambiguous_no_terminal",
+                        error_message=(
+                            "step started but no completion/failure "
+                            "event recorded; effectful tools prevent "
+                            "automatic retry"
+                        ),
+                        is_effectful=True,
+                        step_signature=sig,
+                    ))
+                    any_ambig = True
+                else:
+                    # Non-effectful: safe to re-execute.
+                    step_states.append(PlanStepState(
+                        step_id=sid, state="pending",
+                        started_seq=started_seq,
+                        is_effectful=False,
+                        step_signature=sig,
+                    ))
+                continue
+
+            # Terminal exists. Choose the earliest among completes/fails.
+            earliest_complete = comp_list[0][0] if comp_list else None
+            earliest_fail = fail_list[0][0] if fail_list else None
+            if (
+                earliest_complete is not None
+                and (earliest_fail is None or earliest_complete < earliest_fail)
+            ):
+                # Hit completed. Recover result_text from snapshot.
+                # (WAL doesn't carry the text — only content_len. The
+                # snapshot, populated by PlanRegistry.record_step_completed,
+                # is the source of truth for the bounded text.)
+                step_states.append(PlanStepState(
+                    step_id=sid, state="completed_with_result",
+                    started_seq=started_seq,
+                    result_text=snapshot.step_results.get(sid, ""),
+                    is_effectful=_step_is_effectful(step),
+                    step_signature=sig,
+                ))
+            else:
+                # Hit failed.
+                fail_seq, error_str = fail_list[0]
+                step_states.append(PlanStepState(
+                    step_id=sid, state="failed",
+                    started_seq=started_seq,
+                    error_kind="step_failed",
+                    error_message=error_str,
+                    is_effectful=_step_is_effectful(step),
+                    step_signature=sig,
+                ))
+
+        return PlanResumePlan(
+            plan_id=plan_id,
+            chain_id=snapshot.chain_id,
+            goal=snapshot.goal or decomposition.goal,
+            n_steps=len(decomposition.steps),
+            decomposition_artifact_path=snapshot.decomposition_artifact_path,
+            step_states=tuple(step_states),
+            has_ambiguity=any_ambig,
+            has_in_flight_child=any_in_flight_child,
+        )
+
+    def _step_signature(self, step: PlanStep) -> str:
+        """Stable signature for decomposition-drift detection.
+
+        Phase 2 v1 uses a simple repr; full hash isn't needed at this
+        layer (= the canonical SSoT is the decomposition artifact, not
+        the signature).
+        """
+        return f"{step.description}|tools={','.join(step.tools)}|deps={','.join(step.depends_on)}"
+
+
+__all__ = [
+    "PlanResumeAnalyzer",
+    "PlanResumePlan",
+    "PlanStepState",
+    "PlanStepStateKind",
+]

--- a/src/reyn/plan/plan_resume_coordinator.py
+++ b/src/reyn/plan/plan_resume_coordinator.py
@@ -192,6 +192,7 @@ class PlanResumeCoordinator:
         wal_events: Iterable[dict],
         decomposition_loader: Callable[[str], Any],
         child_skill_lookup: Callable[[str], str | None] | None = None,
+        agent_state_dir: "Any" = None,
     ) -> list[PlanResumeDecision]:
         """Scan the registry's active plans and produce decisions.
 
@@ -238,6 +239,7 @@ class PlanResumeCoordinator:
                 snapshot=snap, decomposition=decomposition,
                 wal_events=events,
                 child_skill_lookup=child_skill_lookup,
+                agent_state_dir=agent_state_dir,
             )
             decisions.append(self.decide_for_plan(analyzed))
         return decisions

--- a/src/reyn/plan/plan_resume_coordinator.py
+++ b/src/reyn/plan/plan_resume_coordinator.py
@@ -1,0 +1,358 @@
+"""PlanResumeCoordinator — adopt-vs-cancel decisions for plan resume.
+
+ADR-0023 §3.3. Sits between :class:`PlanResumeAnalyzer` (= produces
+``PlanResumePlan`` from WAL + snapshot) and :class:`PlanRuntime` (=
+consumes the plan to drive memo replay).
+
+Phase 2 v1 keeps the policy simple: default ``retry_pending_steps``
+applies to every recovered plan. The reyn.yaml schema and per-purity
+child-action table from ADR-0023 §3.3 are stubbed in
+:class:`PlanResumeConfig` but not yet sourced from disk; future work
+adds the loader symmetric with ``_build_skill_resume_config``.
+
+Top-level actions (= ADR-0023):
+
+  - ``resume`` — all steps complete, finalize aggregation
+  - ``retry_pending`` — memo committed steps, re-execute pending
+  - ``discard`` — abort, cancel children, surface outbox notice
+  - ``prompt_required`` — kept type-level only; ADR-0012 carryover
+    means no Phase 2 path produces it
+
+Per-purity child actions (= when a step spawned a child skill):
+
+  - ``adopt`` — leave for skill auto-resume
+  - ``cancel`` — discard via SkillRegistry.complete(status="discarded")
+
+P7-clean: coordinator takes registries via dependency injection, no
+direct imports of ChatSession internals.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Literal
+
+from reyn.plan.plan_resume_analyzer import (
+    PlanResumeAnalyzer,
+    PlanResumePlan,
+)
+from reyn.plan.plan_snapshot import PlanSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+PlanResumeAction = Literal[
+    "resume",
+    "retry_pending",
+    "discard",
+    "prompt_required",
+]
+
+PlanResumeChildAction = Literal["adopt", "cancel"]
+
+
+# ── Config ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PlanResumeConfig:
+    """Operator-supplied policy for plan resume (= reyn.yaml plan_resume:).
+
+    Phase 2 v1: only ``default`` is honored. ``child_purity`` table is
+    parsed-but-applied-as-adopt-everywhere (= safest default — child
+    skills handle their own resume via skill_resume infra).
+    """
+
+    default: PlanResumeAction = "retry_pending"
+    child_purity: dict[str, PlanResumeChildAction] = field(
+        default_factory=lambda: {
+            "pure": "cancel",
+            "world": "adopt",
+            "side_effect": "adopt",
+            "external": "adopt",
+            "llm": "adopt",
+        }
+    )
+
+
+def build_plan_resume_config(raw: dict | None) -> PlanResumeConfig:
+    """Parse a ``plan_resume:`` block from reyn.yaml.
+
+    Mirrors the validation posture of ``_build_skill_resume_config``:
+    invalid top-level value → fall back to default with warning log;
+    invalid purity key or action → log + skip.
+    """
+    if not isinstance(raw, dict):
+        return PlanResumeConfig()
+    cfg = PlanResumeConfig()
+    default = raw.get("default", cfg.default)
+    if default not in ("retry_pending", "retry_pending_steps", "discard",
+                      "discard_plan"):
+        logger.warning(
+            "plan_resume.default %r invalid; falling back to %r",
+            default, cfg.default,
+        )
+        default = cfg.default
+    # Accept the documented yaml aliases (retry_pending_steps / discard_plan).
+    if default == "retry_pending_steps":
+        default = "retry_pending"
+    elif default == "discard_plan":
+        default = "discard"
+    purity_table = dict(cfg.child_purity)
+    purity_block = raw.get("child_purity")
+    if isinstance(purity_block, dict):
+        for k, v in purity_block.items():
+            if k not in purity_table:
+                logger.warning("plan_resume.child_purity unknown key %r", k)
+                continue
+            if v not in ("adopt", "cancel"):
+                logger.warning(
+                    "plan_resume.child_purity[%r] = %r invalid", k, v,
+                )
+                continue
+            purity_table[k] = v  # type: ignore[assignment]
+    return PlanResumeConfig(default=default, child_purity=purity_table)  # type: ignore[arg-type]
+
+
+# ── Decision dataclass ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PlanResumeDecision:
+    """A coordinator decision for one plan."""
+
+    plan: PlanResumePlan
+    action: PlanResumeAction
+    pending_step_ids: tuple[str, ...] = ()
+    child_actions: dict[str, PlanResumeChildAction] = field(default_factory=dict)
+
+
+# ── Coordinator ───────────────────────────────────────────────────────────
+
+
+class PlanResumeCoordinator:
+    """Decides what to do with each recovered plan + applies side effects."""
+
+    def __init__(self, config: PlanResumeConfig | None = None) -> None:
+        self._config = config or PlanResumeConfig()
+        self._analyzer = PlanResumeAnalyzer()
+
+    @property
+    def config(self) -> PlanResumeConfig:
+        return self._config
+
+    # ── decide ────────────────────────────────────────────────────────────
+
+    def decide_for_plan(
+        self, plan: PlanResumePlan,
+    ) -> PlanResumeDecision:
+        """Produce a decision for one analyzed plan.
+
+        Default policy:
+          - All steps complete → ``resume``
+          - Otherwise → ``retry_pending`` (per ``config.default``;
+            ``discard`` is the alternative top-level value)
+
+        Child action defaulting: every child gets ``adopt`` so the
+        existing skill_resume infrastructure drives its recovery.
+        """
+        all_complete = (
+            len(plan.committed_step_ids) == plan.n_steps
+        )
+        if all_complete:
+            return PlanResumeDecision(plan=plan, action="resume")
+        if self._config.default == "discard":
+            child_actions = {
+                s.child_run_id: "cancel"
+                for s in plan.step_states
+                if s.state == "interrupted_with_child" and s.child_run_id
+            }
+            return PlanResumeDecision(
+                plan=plan, action="discard",
+                pending_step_ids=plan.pending_step_ids,
+                child_actions=child_actions,
+            )
+        # retry_pending default
+        child_actions: dict[str, PlanResumeChildAction] = {}
+        for s in plan.step_states:
+            if s.state == "interrupted_with_child" and s.child_run_id:
+                # Phase 2 v1: adopt by default. Future: per-purity decision
+                # via self._config.child_purity[skill_purity].
+                child_actions[s.child_run_id] = "adopt"
+        return PlanResumeDecision(
+            plan=plan, action="retry_pending",
+            pending_step_ids=plan.pending_step_ids,
+            child_actions=child_actions,
+        )
+
+    def discover_and_decide(
+        self,
+        *,
+        plan_registry: Any,
+        wal_events: Iterable[dict],
+        decomposition_loader: Callable[[str], Any],
+        child_skill_lookup: Callable[[str], str | None] | None = None,
+    ) -> list[PlanResumeDecision]:
+        """Scan the registry's active plans and produce decisions.
+
+        ``plan_registry``: a ``PlanRegistry`` instance (pre-loaded via
+        ``load_active()``).
+        ``wal_events``: usually ``state_log.iter_from(0)`` — coordinator
+        filters per-plan internally.
+        ``decomposition_loader(plan_id) -> Plan``: callable that returns
+        the parsed decomposition (= reads the artifact). On
+        :class:`FileNotFoundError` or
+        :class:`reyn.plan.DecompositionCorruptError`, the coordinator
+        forces ``action=discard`` for that plan (= ADR-0023 §3.5
+        corruption fallback).
+        ``child_skill_lookup``: forwarded to the analyzer.
+        """
+        events = list(wal_events)  # materialize once for multi-iteration
+        decisions: list[PlanResumeDecision] = []
+        for plan_id in plan_registry.list_active():
+            snap: PlanSnapshot = plan_registry.get(plan_id)
+            if snap is None:
+                continue
+            try:
+                decomposition = decomposition_loader(plan_id)
+            except FileNotFoundError:
+                # No artifact + snapshot inline fallback also empty?
+                # Force discard with corrupt outbox reason.
+                decisions.append(
+                    self._force_discard(
+                        snap, reason="decomposition_artifact_missing",
+                    )
+                )
+                continue
+            except Exception as exc:  # noqa: BLE001 — corruption etc.
+                logger.warning(
+                    "decomposition load failed for %s: %r", plan_id, exc,
+                )
+                decisions.append(
+                    self._force_discard(
+                        snap, reason="decomposition_artifact_corrupt",
+                    )
+                )
+                continue
+            analyzed = self._analyzer.analyze(
+                snapshot=snap, decomposition=decomposition,
+                wal_events=events,
+                child_skill_lookup=child_skill_lookup,
+            )
+            decisions.append(self.decide_for_plan(analyzed))
+        return decisions
+
+    def _force_discard(
+        self, snap: PlanSnapshot, *, reason: str,
+    ) -> PlanResumeDecision:
+        plan = PlanResumePlan(
+            plan_id=snap.plan_id,
+            chain_id=snap.chain_id,
+            goal=snap.goal,
+            n_steps=0,
+            decomposition_artifact_path=snap.decomposition_artifact_path,
+            step_states=(),
+            has_ambiguity=False,
+            has_in_flight_child=False,
+        )
+        return PlanResumeDecision(
+            plan=plan, action="discard",
+            pending_step_ids=(),
+            child_actions={},
+        )
+
+    # ── apply destructive effects ────────────────────────────────────────
+
+    async def apply_decisions(
+        self,
+        decisions: Iterable[PlanResumeDecision],
+        *,
+        plan_registry: Any,
+        skill_registry: Any | None = None,
+        on_outbox_notice: Callable[[str, str], "Any"] | None = None,
+    ) -> list[PlanResumeDecision]:
+        """Execute side effects for each decision and return launchable ones.
+
+        Side effects:
+          - ``discard`` → cancel children flagged ``cancel``, complete
+            the plan (= ``plan_registry.complete(status="discarded")``),
+            optionally surface an outbox notice.
+          - ``retry_pending`` → cancel children flagged ``cancel``;
+            adopted children stay live for skill auto-resume.
+
+        Returns the subset where ``action ∈ {"resume", "retry_pending"}``
+        — the caller (ChatSession) launches a ``PlanRuntime`` for each.
+        """
+        launchable: list[PlanResumeDecision] = []
+        for decision in decisions:
+            plan_id = decision.plan.plan_id
+            if decision.action == "discard":
+                await self._discard_plan(
+                    decision, plan_registry=plan_registry,
+                    skill_registry=skill_registry,
+                    on_outbox_notice=on_outbox_notice,
+                )
+                continue
+            # retry_pending or resume — cancel any explicitly cancel-
+            # flagged children; adopted children survive.
+            if skill_registry is not None:
+                for child_run_id, action in decision.child_actions.items():
+                    if action == "cancel":
+                        try:
+                            await skill_registry.complete(
+                                run_id=child_run_id, status="discarded",
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "child cancel failed for %s: %r",
+                                child_run_id, exc,
+                            )
+            launchable.append(decision)
+        return launchable
+
+    async def _discard_plan(
+        self,
+        decision: PlanResumeDecision,
+        *,
+        plan_registry: Any,
+        skill_registry: Any | None,
+        on_outbox_notice: Callable[[str, str], "Any"] | None,
+    ) -> None:
+        plan_id = decision.plan.plan_id
+        # Cancel children flagged "cancel".
+        if skill_registry is not None:
+            for child_run_id, action in decision.child_actions.items():
+                if action == "cancel":
+                    try:
+                        await skill_registry.complete(
+                            run_id=child_run_id, status="discarded",
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "discard cascade child cancel failed: %r", exc,
+                        )
+        # Plan-level cleanup.
+        try:
+            await plan_registry.complete(plan_id=plan_id, status="aborted")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("plan_registry.complete failed: %r", exc)
+        # Outbox notice.
+        if on_outbox_notice is not None:
+            try:
+                await on_outbox_notice(
+                    plan_id,
+                    "A plan-mode reply was discarded during resume; "
+                    "please re-issue your request.",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("on_outbox_notice failed: %r", exc)
+
+
+__all__ = [
+    "PlanResumeAction",
+    "PlanResumeChildAction",
+    "PlanResumeCoordinator",
+    "PlanResumeConfig",
+    "PlanResumeDecision",
+    "build_plan_resume_config",
+]

--- a/src/reyn/plan/plan_runtime.py
+++ b/src/reyn/plan/plan_runtime.py
@@ -25,7 +25,6 @@ API contract is fixed here (= ADR-0023 §3.4) so Step 6 can migrate
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
 from reyn.chat.planner import (
@@ -33,30 +32,10 @@ from reyn.chat.planner import (
     PlanExecutionResult,
     execute_plan,
 )
+from reyn.plan.plan_resume_analyzer import PlanResumePlan
 
 if TYPE_CHECKING:
     from reyn.chat.router_loop import RouterLoopHost
-
-
-@dataclass(frozen=True)
-class PlanResumePlan:
-    """Resume directive for ``PlanRuntime`` (ADR-0023 §3.2).
-
-    Step 5 ships only the dataclass shape — Step 7 lands the analyzer
-    that produces it and the runtime memoization that consumes it.
-    Until then ``resume_plan=None`` is the only meaningful value.
-
-    Fields kept minimal in Step 5; richer ``PlanStepState`` substructure
-    is layered in Step 7.
-    """
-
-    plan_id: str
-    chain_id: str
-    goal: str
-    committed_step_ids: frozenset[str] = frozenset()
-    pending_step_ids: tuple[str, ...] = ()
-    step_results: dict[str, str] | None = None  # populated by analyzer
-    in_flight_child_step_id: str | None = None
 
 
 class PlanRuntime:
@@ -105,10 +84,9 @@ class PlanRuntime:
     async def run(self) -> PlanExecutionResult:
         """Execute the plan.
 
-        Step 6: threads ``plan_id`` from the constructor through to
-        ``execute_plan`` (= caller-allocated when ``dispatch_plan_tool``
-        wrote the decomposition artifact first). ``resume_plan`` is
-        accepted but still inert — Step 7 wires the memo replay path.
+        Step 7: threads ``resume_plan`` through to ``execute_plan`` for
+        memo replay of completed/failed steps. ``resume_plan=None`` keeps
+        the fresh-run path unchanged.
         """
         return await execute_plan(
             self._plan,
@@ -117,6 +95,7 @@ class PlanRuntime:
             budget=self._budget,
             router_model=self._router_model,
             plan_id=self._plan_id,
+            resume_plan=self._resume_plan,
         )
 
 

--- a/src/reyn/plan/plan_runtime.py
+++ b/src/reyn/plan/plan_runtime.py
@@ -103,22 +103,20 @@ class PlanRuntime:
         return self._resume_plan
 
     async def run(self) -> PlanExecutionResult:
-        """Execute the plan. Step 5: delegates to execute_plan.
+        """Execute the plan.
 
-        Steps 6 + 7 move the execution body inline so the runtime can
-        thread ``plan_id`` (= no auto-allocation when set), perform
-        decomposition-artifact writes, and route ``plan_step_*`` events
-        through the host's WAL recorders.
+        Step 6: threads ``plan_id`` from the constructor through to
+        ``execute_plan`` (= caller-allocated when ``dispatch_plan_tool``
+        wrote the decomposition artifact first). ``resume_plan`` is
+        accepted but still inert — Step 7 wires the memo replay path.
         """
-        # Step 5 cut: ignore plan_id / resume_plan — execute_plan owns
-        # plan_id allocation and runs fresh. Behavior must be identical
-        # to direct execute_plan() invocation so Phase 1 tests survive.
         return await execute_plan(
             self._plan,
             parent_host=self._host,
             chain_id=self._chain_id,
             budget=self._budget,
             router_model=self._router_model,
+            plan_id=self._plan_id,
         )
 
 

--- a/src/reyn/plan/plan_runtime.py
+++ b/src/reyn/plan/plan_runtime.py
@@ -1,0 +1,128 @@
+"""PlanRuntime — peer to OSRuntime for plan-mode execution (ADR-0023 §3.4).
+
+Step 5 of the migration path: a thin wrapper around the existing
+:func:`execute_plan` free function. Subsequent steps (6 + 7) move the
+execution body into ``PlanRuntime.run`` itself and add the resume path
+(``resume_plan`` parameter, memo replay, child classification).
+
+This step is intentionally additive: ``PlanRuntime.run`` simply calls
+``execute_plan`` with the same arguments. Phase 1 tests for plan-mode
+remain unchanged. Callers that want to start using ``PlanRuntime`` can
+do so without behavior change.
+
+API contract is fixed here (= ADR-0023 §3.4) so Step 6 can migrate
+``dispatch_plan_tool`` against a stable shape:
+
+.. code-block:: python
+
+    runtime = PlanRuntime(
+        plan, host=parent_host, chain_id=cid,
+        plan_id=None,                 # auto-allocate uuid4-hex[:8]
+        budget=None, router_model="light",
+        resume_plan=None,             # None = fresh run
+    )
+    result = await runtime.run()      # PlanExecutionResult
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+from reyn.chat.planner import (
+    Plan,
+    PlanExecutionResult,
+    execute_plan,
+)
+
+if TYPE_CHECKING:
+    from reyn.chat.router_loop import RouterLoopHost
+
+
+@dataclass(frozen=True)
+class PlanResumePlan:
+    """Resume directive for ``PlanRuntime`` (ADR-0023 §3.2).
+
+    Step 5 ships only the dataclass shape — Step 7 lands the analyzer
+    that produces it and the runtime memoization that consumes it.
+    Until then ``resume_plan=None`` is the only meaningful value.
+
+    Fields kept minimal in Step 5; richer ``PlanStepState`` substructure
+    is layered in Step 7.
+    """
+
+    plan_id: str
+    chain_id: str
+    goal: str
+    committed_step_ids: frozenset[str] = frozenset()
+    pending_step_ids: tuple[str, ...] = ()
+    step_results: dict[str, str] | None = None  # populated by analyzer
+    in_flight_child_step_id: str | None = None
+
+
+class PlanRuntime:
+    """Plan-mode execution runtime — peer to OSRuntime (ADR-0023 §3.4).
+
+    Step 5 cut: ``run()`` literally calls :func:`execute_plan`. The
+    additional constructor arguments (``plan_id``, ``resume_plan``)
+    are accepted but ignored — they shape the API for Steps 6/7.
+    """
+
+    def __init__(
+        self,
+        plan: Plan,
+        *,
+        host: "RouterLoopHost",
+        chain_id: str,
+        plan_id: str | None = None,
+        budget: Any = None,
+        router_model: str = "light",
+        resume_plan: PlanResumePlan | None = None,
+    ) -> None:
+        self._plan = plan
+        self._host = host
+        self._chain_id = chain_id
+        self._plan_id = plan_id  # None → execute_plan auto-allocates
+        self._budget = budget
+        self._router_model = router_model
+        self._resume_plan = resume_plan
+
+    @property
+    def plan(self) -> Plan:
+        return self._plan
+
+    @property
+    def chain_id(self) -> str:
+        return self._chain_id
+
+    @property
+    def plan_id(self) -> str | None:
+        return self._plan_id
+
+    @property
+    def resume_plan(self) -> PlanResumePlan | None:
+        return self._resume_plan
+
+    async def run(self) -> PlanExecutionResult:
+        """Execute the plan. Step 5: delegates to execute_plan.
+
+        Steps 6 + 7 move the execution body inline so the runtime can
+        thread ``plan_id`` (= no auto-allocation when set), perform
+        decomposition-artifact writes, and route ``plan_step_*`` events
+        through the host's WAL recorders.
+        """
+        # Step 5 cut: ignore plan_id / resume_plan — execute_plan owns
+        # plan_id allocation and runs fresh. Behavior must be identical
+        # to direct execute_plan() invocation so Phase 1 tests survive.
+        return await execute_plan(
+            self._plan,
+            parent_host=self._host,
+            chain_id=self._chain_id,
+            budget=self._budget,
+            router_model=self._router_model,
+        )
+
+
+__all__ = [
+    "PlanResumePlan",
+    "PlanRuntime",
+]

--- a/src/reyn/plan/plan_snapshot.py
+++ b/src/reyn/plan/plan_snapshot.py
@@ -82,6 +82,14 @@ class PlanSnapshot:
     decomposition_artifact_path: str | None = None
     steps_serialized: list[dict] = field(default_factory=list)
     step_results: dict[str, str] = field(default_factory=dict)
+    # ADR-0024: large step results (> threshold) spill to
+    # ``state/plans/<plan_id>/step_results/<step_id>.txt``; this dict
+    # holds the per-plan-dir-relative path. Read access via
+    # :func:`get_step_result` transparently resolves the file. Empty
+    # for old snapshots and for plans whose every step is small —
+    # backward-compatible additive field, no PLAN_SNAPSHOT_VERSION
+    # bump needed.
+    step_result_refs: dict[str, str] = field(default_factory=dict)
     step_failures: dict[str, str] = field(default_factory=dict)
     current_step_id: str | None = None
     last_committed_step_id: str | None = None
@@ -154,6 +162,7 @@ class PlanSnapshot:
             decomposition_artifact_path=data.get("decomposition_artifact_path"),
             steps_serialized=list(data.get("steps_serialized", []) or []),
             step_results=dict(data.get("step_results", {}) or {}),
+            step_result_refs=dict(data.get("step_result_refs", {}) or {}),
             step_failures=dict(data.get("step_failures", {}) or {}),
             current_step_id=data.get("current_step_id"),
             last_committed_step_id=data.get("last_committed_step_id"),
@@ -184,6 +193,7 @@ class PlanSnapshot:
             "decomposition_artifact_path": self.decomposition_artifact_path,
             "steps_serialized": self.steps_serialized,
             "step_results": self.step_results,
+            "step_result_refs": self.step_result_refs,
             "step_failures": self.step_failures,
             "current_step_id": self.current_step_id,
             "last_committed_step_id": self.last_committed_step_id,
@@ -207,8 +217,55 @@ def plan_snapshot_path(agent_state_dir: Path, plan_id: str) -> Path:
     return Path(agent_state_dir) / "plans" / f"{plan_id}.snapshot.json"
 
 
+def step_result_file_path(
+    agent_state_dir: Path, plan_id: str, step_id: str,
+) -> Path:
+    """ADR-0024: per-plan-dir-relative path for a spilled step result.
+
+    ``<agent_state>/plans/<plan_id>/step_results/<step_id>.txt``.
+
+    The path is relative-to-state-dir for storage in
+    ``PlanSnapshot.step_result_refs`` (only the
+    ``step_results/<step_id>.txt`` suffix is stored — see
+    :func:`get_step_result`); this helper returns the absolute path
+    for I/O.
+    """
+    return (
+        Path(agent_state_dir) / "plans" / plan_id
+        / "step_results" / f"{step_id}.txt"
+    )
+
+
+def get_step_result(
+    snap: "PlanSnapshot", agent_state_dir: Path, step_id: str,
+) -> str | None:
+    """ADR-0024 read-side accessor — returns the step's recorded text.
+
+    Reads inline first (= cheap path for ≤ threshold), falls back to
+    the spilled file. Missing-file or unreadable-file → ``None`` so
+    the caller treats the case uniformly (= step classifies as
+    ``failed`` with ``step_result_file_missing`` cause, ADR-0024 §4).
+
+    ``None`` distinguishes "not recorded" from "empty string" — the
+    latter is a legitimate recorded value (= a step that produced no
+    output text but still completed).
+    """
+    if step_id in snap.step_results:
+        return snap.step_results[step_id]
+    rel = snap.step_result_refs.get(step_id)
+    if rel is None:
+        return None
+    full = Path(agent_state_dir) / "plans" / snap.plan_id / rel
+    try:
+        return full.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return None
+
+
 __all__ = [
     "PLAN_SNAPSHOT_VERSION",
     "PlanSnapshot",
+    "get_step_result",
     "plan_snapshot_path",
+    "step_result_file_path",
 ]

--- a/src/reyn/plan/plan_snapshot.py
+++ b/src/reyn/plan/plan_snapshot.py
@@ -90,6 +90,16 @@ class PlanSnapshot:
     # backward-compatible additive field, no PLAN_SNAPSHOT_VERSION
     # bump needed.
     step_result_refs: dict[str, str] = field(default_factory=dict)
+    # ADR-0025: per-step recorded LLM calls within the sub-loop.
+    # Populated by ``SubLoopMemoProvider.record`` so a crash mid-step
+    # doesn't re-pay the LLM cost on resume. Each entry is a list of
+    # records; each record has the shape:
+    #   {args_hash, inline, ref, usage}
+    # Inline records hold the full LLMToolCallResult dict (≤32 KB);
+    # spilled records hold None for inline and a relative path for ref
+    # (= ADR-0024 spill pattern; same per-plan workspace dir, cleaned
+    # up by delete_plan_workspace).
+    step_llm_calls: dict[str, list[dict]] = field(default_factory=dict)
     step_failures: dict[str, str] = field(default_factory=dict)
     current_step_id: str | None = None
     last_committed_step_id: str | None = None
@@ -163,6 +173,7 @@ class PlanSnapshot:
             steps_serialized=list(data.get("steps_serialized", []) or []),
             step_results=dict(data.get("step_results", {}) or {}),
             step_result_refs=dict(data.get("step_result_refs", {}) or {}),
+            step_llm_calls=dict(data.get("step_llm_calls", {}) or {}),
             step_failures=dict(data.get("step_failures", {}) or {}),
             current_step_id=data.get("current_step_id"),
             last_committed_step_id=data.get("last_committed_step_id"),
@@ -194,6 +205,7 @@ class PlanSnapshot:
             "steps_serialized": self.steps_serialized,
             "step_results": self.step_results,
             "step_result_refs": self.step_result_refs,
+            "step_llm_calls": self.step_llm_calls,
             "step_failures": self.step_failures,
             "current_step_id": self.current_step_id,
             "last_committed_step_id": self.last_committed_step_id,

--- a/src/reyn/plan/plan_snapshot.py
+++ b/src/reyn/plan/plan_snapshot.py
@@ -1,0 +1,214 @@
+"""PlanSnapshot — per-plan recovery state for plan-mode crash recovery.
+
+ADR-0023 §3.1. Mirrors :class:`SkillSnapshot` shape (= cache derived
+from WAL events; rebuildable via WAL replay; atomic save).
+
+Lifecycle:
+  - Created on ``plan_started`` WAL event (initial state via
+    :meth:`empty`).
+  - Updated on each ``plan_step_completed`` / ``plan_step_failed``
+    (= ``last_step_applied_seq`` bumped, ``step_results`` /
+    ``step_failures`` populated).
+  - Deleted on ``plan_completed`` / ``plan_aborted`` (= ordering: WAL
+    append first, then ``unlink(missing_ok=True)``).
+
+Stored at::
+
+    .reyn/agents/<agent_name>/state/plans/<plan_id>.snapshot.json
+
+Sibling to the per-plan directory ``.reyn/agents/<agent>/state/plans/<plan_id>/``
+(= which holds the decomposition artifact). Snapshot file lives one
+level up so the directory's contents are exclusively per-plan
+artifacts.
+
+``PLAN_SNAPSHOT_VERSION = 1``. **Not** linked to ``AgentSnapshot``'s
+version — Phase 1's ``active_plan_ids`` field is unchanged, so existing
+agent snapshots load without migration.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+PLAN_SNAPSHOT_VERSION = 1
+
+
+@dataclass
+class PlanSnapshot:
+    """Per-plan recovery state — cache derived from WAL events.
+
+    Field semantics (ADR-0023 §3.1):
+
+    - ``applied_seq`` — high-water mark of WAL events reflected in this
+      snapshot (= ADR-0001 watermark).
+    - ``last_step_applied_seq`` — WAL truncation gate; bumped on
+      ``plan_started`` (initial stamp), ``plan_step_completed`` (durable
+      progress), ``plan_step_failed`` (conservative — failure is real
+      progress that shouldn't be replayed without policy intervention).
+      ``plan_step_started`` does NOT bump (= mirrors ``step_started``
+      for skills).
+    - ``decomposition_artifact_path`` — canonical SSoT for the plan
+      shape on resume (= P5). When ``None``, ``steps_serialized`` is the
+      fallback.
+    - ``steps_serialized`` — inline fallback when artifact unreadable.
+      List of dicts in the same shape as the artifact's ``steps`` field.
+    - ``step_results`` — text outputs of completed steps, keyed by
+      ``step_id``. The memoized values that resume serves on hit.
+    - ``step_failures`` — error reprs of failed steps, keyed by
+      ``step_id``.
+    - ``current_step_id`` — forward-replay anchor (= the step the
+      runtime was executing when the snapshot was last written).
+    - ``last_committed_step_id`` — the most recently completed step's
+      id (= mirror of skill field).
+    - ``spawned_skill_run_ids`` — ``step_id → child_run_id`` for plan
+      steps that spawned skills via ``invoke_skill``. Used by the
+      resume coordinator to coordinate adopt-vs-cancel decisions with
+      the existing ``skill_resume`` infrastructure.
+    - ``parent_skill_run_id`` — ADR-0017 lineage analog. Currently
+      always ``None`` (= chat-router is the only plan tool surface),
+      but kept for forward compatibility.
+    - ``usage_tokens_so_far`` — optional cost bookkeeping snapshot.
+    """
+
+    plan_id: str
+    agent_name: str
+    chain_id: str
+    goal: str
+    applied_seq: int = 0
+    last_step_applied_seq: int = 0
+    decomposition_artifact_path: str | None = None
+    steps_serialized: list[dict] = field(default_factory=list)
+    step_results: dict[str, str] = field(default_factory=dict)
+    step_failures: dict[str, str] = field(default_factory=dict)
+    current_step_id: str | None = None
+    last_committed_step_id: str | None = None
+    spawned_skill_run_ids: dict[str, str] = field(default_factory=dict)
+    parent_skill_run_id: str | None = None
+    usage_tokens_so_far: dict | None = None
+
+    SCHEMA_VERSION: ClassVar[int] = PLAN_SNAPSHOT_VERSION
+
+    # ── factory ─────────────────────────────────────────────────────────
+
+    @classmethod
+    def empty(
+        cls,
+        *,
+        plan_id: str,
+        agent_name: str,
+        chain_id: str,
+        goal: str,
+    ) -> "PlanSnapshot":
+        """Create a brand-new snapshot at ``plan_started`` time."""
+        return cls(
+            plan_id=plan_id,
+            agent_name=agent_name,
+            chain_id=chain_id,
+            goal=goal,
+        )
+
+    # ── persistence ─────────────────────────────────────────────────────
+
+    @classmethod
+    def load(cls, plan_id: str, path: Path) -> "PlanSnapshot":
+        """Load from ``path``.
+
+        On missing or unparseable file returns a minimal empty snapshot
+        keyed by ``plan_id`` so callers always get a usable object back.
+
+        On a parseable file with mismatched ``schema_version`` raises
+        :class:`SchemaVersionError` (= mirrors :meth:`SkillSnapshot.load`
+        precedent so the caller refuses to resume rather than silently
+        load stale fields).
+        """
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return cls.empty(
+                plan_id=plan_id, agent_name="", chain_id="", goal=""
+            )
+        if not isinstance(data, dict):
+            return cls.empty(
+                plan_id=plan_id, agent_name="", chain_id="", goal=""
+            )
+        from reyn.events.agent_snapshot import SchemaVersionError
+
+        version = data.get("schema_version")
+        if version != PLAN_SNAPSHOT_VERSION:
+            raise SchemaVersionError(
+                f"PlanSnapshot at {path} has version {version!r}, "
+                f"expected {PLAN_SNAPSHOT_VERSION}. "
+                "Run `reyn chat --reset` to wipe in-flight plan state "
+                "(audit logs in .reyn/events/ are preserved)."
+            )
+        return cls(
+            plan_id=str(data.get("plan_id", plan_id)),
+            agent_name=str(data.get("agent_name", "")),
+            chain_id=str(data.get("chain_id", "")),
+            goal=str(data.get("goal", "")),
+            applied_seq=int(data.get("applied_seq", 0)),
+            last_step_applied_seq=int(data.get("last_step_applied_seq", 0)),
+            decomposition_artifact_path=data.get("decomposition_artifact_path"),
+            steps_serialized=list(data.get("steps_serialized", []) or []),
+            step_results=dict(data.get("step_results", {}) or {}),
+            step_failures=dict(data.get("step_failures", {}) or {}),
+            current_step_id=data.get("current_step_id"),
+            last_committed_step_id=data.get("last_committed_step_id"),
+            spawned_skill_run_ids=dict(
+                data.get("spawned_skill_run_ids", {}) or {}
+            ),
+            parent_skill_run_id=data.get("parent_skill_run_id"),
+            usage_tokens_so_far=data.get("usage_tokens_so_far"),
+        )
+
+    def save(self, path: Path) -> None:
+        """Persist atomically: write to ``.tmp``, ``fsync``, ``rename``.
+
+        A mid-write crash leaves the previous file intact. Mirrors
+        :meth:`SkillSnapshot.save` recipe verbatim.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        payload = {
+            "schema_version": PLAN_SNAPSHOT_VERSION,
+            "plan_id": self.plan_id,
+            "agent_name": self.agent_name,
+            "chain_id": self.chain_id,
+            "goal": self.goal,
+            "applied_seq": self.applied_seq,
+            "last_step_applied_seq": self.last_step_applied_seq,
+            "decomposition_artifact_path": self.decomposition_artifact_path,
+            "steps_serialized": self.steps_serialized,
+            "step_results": self.step_results,
+            "step_failures": self.step_failures,
+            "current_step_id": self.current_step_id,
+            "last_committed_step_id": self.last_committed_step_id,
+            "spawned_skill_run_ids": self.spawned_skill_run_ids,
+            "parent_skill_run_id": self.parent_skill_run_id,
+            "usage_tokens_so_far": self.usage_tokens_so_far,
+        }
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        tmp.replace(path)
+
+
+def plan_snapshot_path(agent_state_dir: Path, plan_id: str) -> Path:
+    """Return ``<agent_state>/plans/<plan_id>.snapshot.json``.
+
+    Sibling to the per-plan directory ``plans/<plan_id>/`` (which holds
+    the decomposition artifact and any future per-plan artifacts).
+    """
+    return Path(agent_state_dir) / "plans" / f"{plan_id}.snapshot.json"
+
+
+__all__ = [
+    "PLAN_SNAPSHOT_VERSION",
+    "PlanSnapshot",
+    "plan_snapshot_path",
+]

--- a/src/reyn/plan/sub_loop_memo.py
+++ b/src/reyn/plan/sub_loop_memo.py
@@ -1,0 +1,302 @@
+"""Sub-loop LLM call memoization for plan-mode (ADR-0025).
+
+Mirrors R-D2's skill-side memoization (= ``runtime._call_llm_and_record``)
+but at the ``call_llm_tools`` boundary inside ``RouterLoop`` rather than
+the dispatcher boundary. Plan steps' sub-loops invoke LLM up to
+``_PLAN_STEP_MAX_ITERATIONS`` times; on crash mid-step, resume previously
+re-paid every LLM call. With this module, results from prior turns are
+recorded on the per-plan snapshot and replayed on resume.
+
+Persistence is snapshot-only — no new WAL event kinds. Each LLM call
+in a step appends a record to ``PlanSnapshot.step_llm_calls[step_id]``
+and triggers a snapshot save. Atomic save (~1 ms) is negligible
+relative to the LLM call itself (1–30 s).
+
+Spill: ADR-0024 mirror — records >32 KB serialised spill to
+``state/plans/<plan_id>/step_llm_calls/<step_id>/<turn_idx>.json``.
+``delete_plan_workspace`` already reclaims the entire per-plan
+directory on completion / discard.
+
+Drift: ``args_hash`` mismatch falls through to fresh execution (=
+provider versioning, prompt construction shifts, etc.). Records the
+fresh result, overwriting nothing — the previous record stays in the
+list but is unreachable by hash.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from reyn.llm.pricing import TokenUsage
+
+if TYPE_CHECKING:
+    from reyn.llm.llm import LLMToolCallResult
+    from reyn.plan.plan_registry import PlanRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# ADR-0025 §2: same threshold as ADR-0024 step result spill so the
+# overall persistence pattern is consistent.
+_LLM_CALL_SPILL_THRESHOLD_CHARS = 32_768
+
+
+# ── args_hash ─────────────────────────────────────────────────────────────
+
+
+def compute_sub_loop_args_hash(
+    *,
+    model: str,
+    messages: list[dict],
+    tools: list[dict] | None,
+    tool_choice: str | dict | None,
+    sampling: dict | None = None,
+) -> str:
+    """Stable hash for sub-loop ``call_llm_tools`` invocations.
+
+    Hashes over the inputs that drive deterministic output. Mirrors
+    ``dispatcher._compute_llm_args_hash`` shape (SHA-256 truncated to
+    16 hex) but uses RouterLoop-shaped inputs (``messages`` list of
+    role/content/tool_calls/tool_call_id dicts) rather than
+    ContextFrame.
+
+    No volatile-field stripping is applied: chat-router messages don't
+    typically embed datetime fields. If the caller injects a volatile
+    string into ``messages``, the resume-side memo will miss; the
+    fresh-call path records the new hash and proceeds correctly
+    (= same drift handling as R-D2).
+    """
+    payload = {
+        "model": model,
+        "messages": messages,
+        "tools": tools or [],
+        "tool_choice": tool_choice,
+        "sampling": sampling or {},
+    }
+    try:
+        canonical = json.dumps(
+            payload, sort_keys=True, default=str, ensure_ascii=False,
+        )
+    except Exception:  # noqa: BLE001 — fallback for unhashable values
+        canonical = repr(payload)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+# ── record / restore helpers ──────────────────────────────────────────────
+
+
+def _serialise_result(result: "LLMToolCallResult") -> dict:
+    """Convert an LLMToolCallResult into a JSON-safe dict for persistence.
+
+    Drops ``raw_message`` (= debugging only). Keeps content / tool_calls
+    / finish_reason / usage. ``tool_calls`` is already a list of plain
+    dicts (litellm shape), so JSON serialisation is direct.
+    """
+    usage_dict = None
+    if result.usage is not None:
+        usage_dict = {
+            "prompt_tokens": getattr(result.usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(result.usage, "completion_tokens", 0),
+        }
+    return {
+        "content": result.content,
+        "tool_calls": list(result.tool_calls or []),
+        "finish_reason": result.finish_reason,
+        "usage": usage_dict,
+    }
+
+
+def _deserialise_result(record: dict) -> "LLMToolCallResult":
+    """Reconstruct an LLMToolCallResult from a recorded dict."""
+    from reyn.llm.llm import LLMToolCallResult
+    usage_dict = record.get("usage")
+    usage = TokenUsage()
+    if isinstance(usage_dict, dict):
+        usage.prompt_tokens = int(usage_dict.get("prompt_tokens", 0))
+        usage.completion_tokens = int(usage_dict.get("completion_tokens", 0))
+    return LLMToolCallResult(
+        content=record.get("content"),
+        tool_calls=list(record.get("tool_calls") or []),
+        finish_reason=record.get("finish_reason"),
+        usage=usage,
+        raw_message=None,
+    )
+
+
+# ── memo provider ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _MemoLookupRecord:
+    """Internal helper — a single recorded LLM call addressable by hash."""
+    args_hash: str
+    inline: dict | None      # full result dict (≤ threshold) OR None if spilled
+    ref: str | None          # relative path under per-plan dir (> threshold) OR None
+
+
+class SubLoopMemoProvider:
+    """Per-step LLM memoization for a plan sub-loop.
+
+    Constructed by ``execute_plan`` for each step. On miss: invoke
+    proceeds normally, ``record`` persists the result. On hit:
+    ``get_recorded_result`` returns the deserialised LLMToolCallResult.
+
+    Read-side (``get_recorded_result``) is sync — it consults the seed
+    log (provided at construction) plus the in-memory record list
+    (populated as the sub-loop runs). On reload-from-disk paths the
+    seed log carries the surviving records.
+
+    Write-side (``record``) is async — calls into PlanRegistry which
+    persists the snapshot atomically and may spill to file.
+    """
+
+    def __init__(
+        self,
+        *,
+        plan_registry: "PlanRegistry",
+        plan_id: str,
+        step_id: str,
+        seed_records: list[_MemoLookupRecord] | None = None,
+    ) -> None:
+        self._registry = plan_registry
+        self._plan_id = plan_id
+        self._step_id = step_id
+        # seed_records: from PlanResumePlan.step_llm_call_log on resume.
+        # Fresh runs start empty.
+        self._records: list[_MemoLookupRecord] = list(seed_records or [])
+        # Track turn index so spilled paths are unique per call.
+        self._turn_idx = len(self._records)
+
+    @property
+    def plan_id(self) -> str:
+        return self._plan_id
+
+    @property
+    def step_id(self) -> str:
+        return self._step_id
+
+    def get_recorded_result(self, args_hash: str) -> "LLMToolCallResult | None":
+        """Return the recorded LLMToolCallResult for ``args_hash``, or None.
+
+        Walks the seed + in-memory record list. Inline records
+        deserialise immediately; spilled records read from the
+        per-plan workspace file. File unreadable → None (= caller
+        treats as miss; fresh execution will run + record).
+        """
+        for rec in self._records:
+            if rec.args_hash != args_hash:
+                continue
+            if rec.inline is not None:
+                return _deserialise_result(rec.inline)
+            if rec.ref is not None:
+                full = self._spill_path_from_ref(rec.ref)
+                try:
+                    data = json.loads(full.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError) as exc:
+                    logger.warning(
+                        "spilled LLM record unreadable at %s: %r — falling "
+                        "through to fresh call", full, exc,
+                    )
+                    return None
+                return _deserialise_result(data)
+            return None
+        return None
+
+    async def record(
+        self,
+        *,
+        args_hash: str,
+        result: "LLMToolCallResult",
+    ) -> None:
+        """Persist a fresh LLM call result for future resume hit."""
+        record_dict = _serialise_result(result)
+        try:
+            serialised = json.dumps(record_dict, ensure_ascii=False)
+        except Exception:  # noqa: BLE001
+            serialised = ""
+        # Branch on size: inline ≤ threshold, spill to file > threshold.
+        if len(serialised) <= _LLM_CALL_SPILL_THRESHOLD_CHARS:
+            inline = record_dict
+            ref = None
+        else:
+            ref_rel = self._allocate_spill_path()
+            full = self._spill_path_from_ref(ref_rel)
+            full.parent.mkdir(parents=True, exist_ok=True)
+            tmp = full.with_suffix(full.suffix + ".tmp")
+            with tmp.open("w", encoding="utf-8") as f:
+                json.dump(record_dict, f, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            tmp.replace(full)
+            inline = None
+            ref = ref_rel
+        # Update in-memory state.
+        new_rec = _MemoLookupRecord(args_hash=args_hash, inline=inline, ref=ref)
+        self._records.append(new_rec)
+        self._turn_idx += 1
+        # Persist to snapshot.
+        await self._registry.record_step_llm_call(
+            plan_id=self._plan_id,
+            step_id=self._step_id,
+            args_hash=args_hash,
+            inline=inline,
+            ref=ref,
+            usage=record_dict.get("usage") or {},
+        )
+
+    # ── helpers ──────────────────────────────────────────────────────────
+
+    def _allocate_spill_path(self) -> str:
+        """Per-call relative path under per-plan dir.
+
+        ``step_llm_calls/<step_id>/<turn_idx>.json`` — turn_idx increments
+        per recorded call, so collisions across re-runs of the same
+        step (= rare; would happen only if reset_from_step then re-runs
+        and produces a >32KB result that needs distinct path).
+        """
+        return f"step_llm_calls/{self._step_id}/{self._turn_idx}.json"
+
+    def _spill_path_from_ref(self, ref_rel: str) -> Path:
+        return self._registry.state_dir / "plans" / self._plan_id / ref_rel
+
+
+# ── analyzer extraction helper ────────────────────────────────────────────
+
+
+def extract_step_llm_call_records(
+    snapshot_step_llm_calls: dict[str, list[dict]],
+    step_id: str,
+) -> list[_MemoLookupRecord]:
+    """Build seed memo records for one step from PlanSnapshot data.
+
+    Used by execute_plan when resume_plan is set: extracts the recorded
+    LLM call records for ``step_id`` from the snapshot's
+    ``step_llm_calls`` dict and returns them in the
+    ``_MemoLookupRecord`` form the provider expects.
+    """
+    records = snapshot_step_llm_calls.get(step_id) or []
+    out: list[_MemoLookupRecord] = []
+    for entry in records:
+        if not isinstance(entry, dict):
+            continue
+        h = entry.get("args_hash")
+        if not isinstance(h, str):
+            continue
+        out.append(_MemoLookupRecord(
+            args_hash=h,
+            inline=entry.get("inline"),
+            ref=entry.get("ref"),
+        ))
+    return out
+
+
+__all__ = [
+    "SubLoopMemoProvider",
+    "compute_sub_loop_args_hash",
+    "extract_step_llm_call_records",
+]

--- a/tests/test_dogfood_trace_plan_modes.py
+++ b/tests/test_dogfood_trace_plan_modes.py
@@ -1,0 +1,350 @@
+"""Tier 2: dogfood_trace.py plan-mode awareness (prep wave for batch 16).
+
+Pins the contract that the new ``--mode plan-summary``,
+``--mode plan-trace``, ``--mode plan-snapshot`` and the cost-mode
+extension correctly aggregate plan-mode telemetry from realistic on-
+disk shapes:
+
+  - WAL entries are flat ({"kind": ..., "ts": ..., "plan_id": ...,
+    ...fields}) — NOT nested under "data"
+  - Events-log entries are nested ({"type": ..., "timestamp": ...,
+    "data": {"plan_id": ..., ...}})
+  - The `_load_wal` normaliser bridges these shapes so the modes work
+    on both inputs uniformly.
+
+Tests target the public CLI surface (subprocess invocation) so they
+catch field-shape regressions end-to-end.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_trace.py"
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run dogfood_trace.py with given args; return CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True, text=True, cwd=cwd,
+    )
+
+
+def _write_wal(state_dir: Path, entries: list[dict]) -> None:
+    """Write WAL entries (flat shape) to state/wal.jsonl."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    wal = state_dir / "wal.jsonl"
+    with wal.open("w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+def _write_event_log(events_dir: Path, name: str, entries: list[dict]) -> None:
+    """Write event-log entries (nested shape: type + timestamp + data)."""
+    events_dir.mkdir(parents=True, exist_ok=True)
+    log = events_dir / f"{name}.jsonl"
+    with log.open("w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+# ── --mode plan-summary ───────────────────────────────────────────────────
+
+
+def test_plan_summary_no_events_message(tmp_path: Path) -> None:
+    """Tier 2: empty .reyn dir → friendly message, exit 0 (no crash)."""
+    (tmp_path / ".reyn").mkdir()
+    proc = _run("--mode", "plan-summary", "--root", str(tmp_path / ".reyn"))
+    assert proc.returncode == 0
+    assert "no plan events" in proc.stdout.lower()
+
+
+def test_plan_summary_aggregates_real_wal_shape(tmp_path: Path) -> None:
+    """Tier 2 (regression net): real WAL entries are flat (no `data`
+    nesting). plan-summary must read top-level plan_id correctly. This
+    is the bug-pattern test that catches the data-nesting confusion
+    between WAL and events log."""
+    state_dir = tmp_path / ".reyn" / "state"
+    _write_wal(state_dir, [
+        {"seq": 1, "ts": "2026-05-08T10:00:00", "kind": "plan_started",
+         "plan_id": "ab12cd34", "goal": "test goal", "n_steps": 2,
+         "target": "default"},
+        {"seq": 2, "ts": "2026-05-08T10:00:01", "kind": "plan_step_started",
+         "plan_id": "ab12cd34", "step_id": "s1", "depends_on": [],
+         "n_tools": 0, "target": "default"},
+        {"seq": 3, "ts": "2026-05-08T10:00:02", "kind": "plan_step_completed",
+         "plan_id": "ab12cd34", "step_id": "s1", "content_len": 50,
+         "target": "default"},
+        {"seq": 4, "ts": "2026-05-08T10:00:03", "kind": "plan_step_started",
+         "plan_id": "ab12cd34", "step_id": "s2", "depends_on": ["s1"],
+         "n_tools": 0, "target": "default"},
+        {"seq": 5, "ts": "2026-05-08T10:00:04", "kind": "plan_step_completed",
+         "plan_id": "ab12cd34", "step_id": "s2", "content_len": 75,
+         "target": "default"},
+        {"seq": 6, "ts": "2026-05-08T10:00:05", "kind": "plan_completed",
+         "plan_id": "ab12cd34", "target": "default"},
+    ])
+
+    proc = _run("--mode", "plan-summary", "--root", str(tmp_path / ".reyn"))
+    assert proc.returncode == 0, f"stderr: {proc.stderr}"
+    out = proc.stdout
+    # The plan_id MUST appear in the per-plan table (= proves WAL
+    # parsing extracted plan_id from top-level field).
+    assert "ab12cd34" in out
+    assert "plans started:    1" in out
+    assert "plans completed:  1" in out
+    assert "2 started / 2 completed" in out
+    # Goal text appears in per-plan table.
+    assert "test goal" in out
+
+
+def test_plan_summary_combines_wal_and_events_log_memo_hits(tmp_path: Path) -> None:
+    """Tier 2: plan_step_memoized + plan_step_llm_memoized live only in
+    the events log; plan-summary must read them from there too."""
+    reyn = tmp_path / ".reyn"
+    state_dir = reyn / "state"
+    events_dir = reyn / "events" / "agents" / "default"
+
+    _write_wal(state_dir, [
+        {"seq": 1, "ts": "2026-05-08T10:00:00", "kind": "plan_started",
+         "plan_id": "p1", "goal": "g", "n_steps": 1, "target": "default"},
+        {"seq": 2, "ts": "2026-05-08T10:00:05", "kind": "plan_completed",
+         "plan_id": "p1", "target": "default"},
+    ])
+    _write_event_log(events_dir, "chat", [
+        {"type": "plan_step_memoized",
+         "timestamp": "2026-05-08T10:00:01",
+         "data": {"plan_id": "p1", "step_id": "s1", "content_len": 100}},
+        {"type": "plan_step_memoized",
+         "timestamp": "2026-05-08T10:00:02",
+         "data": {"plan_id": "p1", "step_id": "s2", "content_len": 50}},
+        {"type": "plan_step_llm_memoized",
+         "timestamp": "2026-05-08T10:00:03",
+         "data": {"plan_id": "p1", "step_id": "s2", "args_hash": "abc"}},
+    ])
+
+    proc = _run("--mode", "plan-summary", "--root", str(reyn))
+    assert proc.returncode == 0
+    assert "2 step-result + 1 LLM-call" in proc.stdout
+
+
+def test_plan_summary_max_concurrent_two_overlapping_plans(tmp_path: Path) -> None:
+    """Tier 2: 2 plans whose started→completed intervals overlap →
+    max_concurrent = 2."""
+    state_dir = tmp_path / ".reyn" / "state"
+    _write_wal(state_dir, [
+        # Plan A: 10:00:00 → 10:00:10
+        {"seq": 1, "ts": "2026-05-08T10:00:00", "kind": "plan_started",
+         "plan_id": "pa", "goal": "a", "n_steps": 1, "target": "default"},
+        # Plan B: 10:00:05 → 10:00:08 (entirely inside A's window)
+        {"seq": 2, "ts": "2026-05-08T10:00:05", "kind": "plan_started",
+         "plan_id": "pb", "goal": "b", "n_steps": 1, "target": "default"},
+        {"seq": 3, "ts": "2026-05-08T10:00:08", "kind": "plan_completed",
+         "plan_id": "pb", "target": "default"},
+        {"seq": 4, "ts": "2026-05-08T10:00:10", "kind": "plan_completed",
+         "plan_id": "pa", "target": "default"},
+    ])
+    proc = _run("--mode", "plan-summary", "--root", str(tmp_path / ".reyn"))
+    assert proc.returncode == 0
+    assert "max concurrent plans" in proc.stdout
+    assert ": 2" in proc.stdout  # the value
+
+
+# ── --mode plan-trace <plan_id> ───────────────────────────────────────────
+
+
+def test_plan_trace_missing_plan_id_errors(tmp_path: Path) -> None:
+    """Tier 2: plan-trace without positional plan_id → exit 1 + usage error."""
+    proc = _run("--mode", "plan-trace", "--root", str(tmp_path))
+    assert proc.returncode == 1
+
+
+def test_plan_trace_filters_to_one_plan(tmp_path: Path) -> None:
+    """Tier 2: plan-trace prints events for the requested plan_id only,
+    and ignores entries for other plan_ids."""
+    state_dir = tmp_path / ".reyn" / "state"
+    _write_wal(state_dir, [
+        {"seq": 1, "ts": "2026-05-08T10:00:00", "kind": "plan_started",
+         "plan_id": "target_pid", "goal": "match-me", "n_steps": 1,
+         "target": "default"},
+        {"seq": 2, "ts": "2026-05-08T10:00:01", "kind": "plan_started",
+         "plan_id": "other_pid", "goal": "DO_NOT_MATCH", "n_steps": 1,
+         "target": "default"},
+        {"seq": 3, "ts": "2026-05-08T10:00:02", "kind": "plan_completed",
+         "plan_id": "target_pid", "target": "default"},
+    ])
+    proc = _run(
+        "--mode", "plan-trace", "target_pid",
+        "--root", str(tmp_path / ".reyn"),
+    )
+    assert proc.returncode == 0
+    out = proc.stdout
+    # Target events appear; other plan's events do NOT.
+    assert "plan_started" in out
+    assert "plan_completed" in out
+    assert "DO_NOT_MATCH" not in out
+    assert "other_pid" not in out
+
+
+# ── --mode plan-snapshot <plan_id> ────────────────────────────────────────
+
+
+def test_plan_snapshot_missing_plan_id_errors(tmp_path: Path) -> None:
+    """Tier 2: plan-snapshot without positional plan_id → exit 1."""
+    proc = _run("--mode", "plan-snapshot", "--root", str(tmp_path))
+    assert proc.returncode == 1
+
+
+def test_plan_snapshot_dumps_decomposition_and_snapshot(tmp_path: Path) -> None:
+    """Tier 2: plan-snapshot reads decomposition.json + per-plan snapshot
+    JSON from the per-plan workspace dir."""
+    plan_id = "test_plan_xyz"
+    plan_dir = (
+        tmp_path / ".reyn" / "agents" / "default" / "state" / "plans" / plan_id
+    )
+    plan_dir.mkdir(parents=True)
+
+    # decomposition.json
+    (plan_dir / "decomposition.json").write_text(json.dumps({
+        "plan_id": plan_id, "schema_version": 1,
+        "goal": "test goal text",
+        "steps": [
+            {"id": "s1", "description": "first step",
+             "tools": ["read_file"], "depends_on": []},
+            {"id": "s2", "description": "second step",
+             "tools": [], "depends_on": ["s1"]},
+        ],
+    }))
+
+    # Per-plan snapshot file (sibling to per-plan dir).
+    snap_path = plan_dir.parent / f"{plan_id}.snapshot.json"
+    snap_path.write_text(json.dumps({
+        "schema_version": 1, "plan_id": plan_id,
+        "agent_name": "default", "chain_id": f"plan_{plan_id}",
+        "goal": "test goal text",
+        "applied_seq": 42, "last_step_applied_seq": 40,
+        "decomposition_artifact_path": str(plan_dir / "decomposition.json"),
+        "steps_serialized": [],
+        "step_results": {"s1": "inline result text"},
+        "step_result_refs": {},
+        "step_llm_calls": {
+            "s1": [{"args_hash": "a", "inline": {"content": "x"},
+                    "ref": None, "usage": {}}]
+        },
+        "step_failures": {},
+        "current_step_id": None,
+        "last_committed_step_id": "s1",
+        "spawned_skill_run_ids": {},
+        "parent_skill_run_id": None,
+        "usage_tokens_so_far": None,
+    }))
+
+    proc = _run(
+        "--mode", "plan-snapshot", plan_id,
+        "--root", str(tmp_path / ".reyn"),
+    )
+    assert proc.returncode == 0, f"stderr: {proc.stderr}"
+    out = proc.stdout
+    assert plan_id in out
+    assert "test goal text" in out
+    assert "s1" in out
+    assert "first step" in out
+    # Should reflect snapshot fields
+    assert "applied_seq" in out or "42" in out
+
+
+def test_plan_snapshot_unknown_plan_id_friendly_message(tmp_path: Path) -> None:
+    """Tier 2: unknown plan_id → friendly error, exit 0 (= soft fail,
+    user retries with correct id)."""
+    (tmp_path / ".reyn").mkdir()
+    proc = _run(
+        "--mode", "plan-snapshot", "nonexistent_pid",
+        "--root", str(tmp_path / ".reyn"),
+    )
+    # Either prints a not-found / no-agents message or exits with non-
+    # zero — both are acceptable as long as we don't crash.
+    assert proc.returncode in (0, 1)
+    combined = (proc.stdout + proc.stderr).lower()
+    assert any(s in combined for s in (
+        "nonexistent_pid", "not found", "no agents", "no plans",
+    ))
+
+
+# ── --mode cost extension (memo savings) ──────────────────────────────────
+
+
+def test_cost_mode_appends_memo_savings_when_present(tmp_path: Path) -> None:
+    """Tier 2: cost mode reports memo savings when plan_step_memoized /
+    plan_step_llm_memoized events exist in the events log."""
+    reyn = tmp_path / ".reyn"
+    # Budget ledger (= existing cost data source)
+    (reyn / "state").mkdir(parents=True)
+    with (reyn / "state" / "budget_ledger.jsonl").open("w") as f:
+        f.write(json.dumps({
+            "model": "openai/gpt-4o-mini",
+            "tokens": 100, "cost_usd": 0.001,
+        }) + "\n")
+        f.write(json.dumps({
+            "model": "openai/gpt-4o-mini",
+            "tokens": 200, "cost_usd": 0.002,
+        }) + "\n")
+
+    # Memo events
+    events_dir = reyn / "events" / "agents" / "default"
+    _write_event_log(events_dir, "chat", [
+        {"type": "plan_step_memoized",
+         "timestamp": "2026-05-08T10:00:00",
+         "data": {"plan_id": "p1", "step_id": "s1"}},
+        {"type": "plan_step_llm_memoized",
+         "timestamp": "2026-05-08T10:00:01",
+         "data": {"plan_id": "p1", "step_id": "s1", "args_hash": "h"}},
+    ])
+
+    proc = _run("--mode", "cost", "--root", str(reyn))
+    assert proc.returncode == 0
+    out = proc.stdout
+    # Existing summary preserved
+    assert "Total" in out
+    assert "openai/gpt-4o-mini" in out
+    # Memo savings appended
+    assert "memo savings" in out.lower() or "memoizations" in out.lower()
+    assert "1 step-result" in out or "step-result memoizations:  1" in out
+    assert "1" in out  # llm-call hits = 1
+
+
+def test_cost_mode_no_memo_section_when_zero_hits(tmp_path: Path) -> None:
+    """Tier 2: cost mode preserves existing output when no memo events
+    are present (= backward compat for skill-only batches)."""
+    reyn = tmp_path / ".reyn"
+    (reyn / "state").mkdir(parents=True)
+    with (reyn / "state" / "budget_ledger.jsonl").open("w") as f:
+        f.write(json.dumps({
+            "model": "anthropic/claude-3-5-sonnet",
+            "tokens": 1000, "cost_usd": 0.015,
+        }) + "\n")
+
+    proc = _run("--mode", "cost", "--root", str(reyn))
+    assert proc.returncode == 0
+    # Existing summary present
+    assert "Cost Summary" in proc.stdout
+    # No memo-savings section
+    assert "memo savings" not in proc.stdout.lower()
+
+
+# ── backward compat: existing modes unaffected ───────────────────────────
+
+
+def test_existing_summary_mode_still_works(tmp_path: Path) -> None:
+    """Tier 2: don't regress existing --mode summary on empty .reyn."""
+    proc = _run(
+        "--mode", "summary",
+        "--root", str(tmp_path / "nonexistent_root"),
+    )
+    assert proc.returncode == 0
+    assert "no events" in proc.stdout.lower()

--- a/tests/test_plan_async_dispatch.py
+++ b/tests/test_plan_async_dispatch.py
@@ -1,0 +1,349 @@
+"""Tier 2: dispatch_plan_tool async dispatch (ADR-0023 Phase 2.1).
+
+Pins the async behavior:
+  - host with spawn_plan_task → dispatch hands off + returns
+    {"status": "spawned", ...} immediately
+  - per-plan chain_id allocated as f"plan_{plan_id}"
+  - host without spawn_plan_task → sync fallback path (= Phase 2 v1
+    behavior preserved as safety net for test stubs)
+  - _DISPATCH_KIND["plan"] == "async" so RouterLoop exits after dispatch
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep, dispatch_plan_tool
+from reyn.chat.router_tools import _DISPATCH_KIND, get_dispatch_kind
+
+
+# ── basic registry checks ─────────────────────────────────────────────────
+
+
+def test_plan_is_registered_async() -> None:
+    """Tier 2: _DISPATCH_KIND classifies plan as async so RouterLoop
+    exits after dispatch (= ADR-0023 §2.1.1)."""
+    assert _DISPATCH_KIND.get("plan") == "async"
+    assert get_dispatch_kind("plan") == "async"
+
+
+# ── stub host with spawn_plan_task ────────────────────────────────────────
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **fields: Any) -> None:
+        self.emitted.append((kind, fields))
+
+
+class _AsyncCapableHost:
+    """Host that exposes spawn_plan_task; mimics ChatSession's task
+    handoff. Runs the runtime synchronously inside spawn_plan_task so
+    test assertions are deterministic without create_task scheduling."""
+
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+        self.write_decomp_calls: list[dict] = []
+        self.delete_decomp_calls: list[dict] = []
+        self.spawn_calls: list[dict] = []
+        self.outbox: list[dict] = []
+        self.plan_started_calls: list[dict] = []
+        self.plan_completed_calls: list[dict] = []
+        self.plan_aborted_calls: list[dict] = []
+        self.plan_step_started_calls: list[dict] = []
+        self.plan_step_completed_calls: list[dict] = []
+        self.plan_step_failed_calls: list[dict] = []
+        # Stash spawned runtimes so the test can drive them deterministically.
+        self.spawned_runtimes: list = []
+
+    async def write_plan_decomposition(self, *, plan_id, plan):
+        self.write_decomp_calls.append({"plan_id": plan_id})
+        return f"/fake/{plan_id}"
+
+    async def delete_plan_decomposition(self, *, plan_id):
+        self.delete_decomp_calls.append({"plan_id": plan_id})
+
+    async def spawn_plan_task(self, *, plan_id, runtime, chain_id):
+        # Record handoff metadata; defer runtime.run() until the test
+        # explicitly drives it via host.run_spawned() (= mirrors
+        # ChatSession's create_task semantics without scheduling).
+        self.spawn_calls.append(
+            {"plan_id": plan_id, "chain_id": chain_id}
+        )
+        self.spawned_runtimes.append(runtime)
+
+    async def run_spawned(self) -> None:
+        for runtime in self.spawned_runtimes:
+            result = await runtime.run()
+            if result.text:
+                self.outbox.append({
+                    "kind": "agent",
+                    "text": result.text,
+                    "meta": {"plan_id": runtime.plan_id, "source": "plan"},
+                })
+
+    async def put_outbox(self, *, kind, text, meta):
+        self.outbox.append({"kind": kind, "text": text, "meta": meta})
+
+    async def record_plan_started(self, *, plan_id, goal, n_steps):
+        self.plan_started_calls.append({"plan_id": plan_id, "n_steps": n_steps})
+
+    async def record_plan_completed(self, *, plan_id):
+        self.plan_completed_calls.append({"plan_id": plan_id})
+
+    async def record_plan_aborted(self, *, plan_id, reason=""):
+        self.plan_aborted_calls.append({"plan_id": plan_id})
+
+    async def record_plan_step_started(self, *, plan_id, step_id,
+                                       depends_on, n_tools):
+        self.plan_step_started_calls.append({"step_id": step_id})
+
+    async def record_plan_step_completed(self, *, plan_id, step_id,
+                                          content_len):
+        self.plan_step_completed_calls.append({"step_id": step_id})
+
+    async def record_plan_step_failed(self, *, plan_id, step_id, error):
+        self.plan_step_failed_calls.append({"step_id": step_id})
+
+
+class _StubRouterLoop:
+    def __init__(self, *, host, **kwargs):
+        self.host = host
+
+    @property
+    def total_usage(self):
+        from reyn.llm.pricing import TokenUsage
+        return TokenUsage()
+
+    async def run(self, *, user_text, history):
+        await self.host.put_outbox(kind="agent", text="ok", meta={})
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_router_loop(monkeypatch: Any):
+    import reyn.chat.planner as planner_mod
+    monkeypatch.setattr(planner_mod, "RouterLoop", _StubRouterLoop)
+    yield
+
+
+def _simple_plan_args() -> dict:
+    return {
+        "goal": "g",
+        "steps": [
+            {"id": "s1", "description": "first", "tools": []},
+            {"id": "s2", "description": "second", "tools": [], "depends_on": ["s1"]},
+        ],
+    }
+
+
+# ── async dispatch path ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_dispatch_returns_spawned_status_immediately() -> None:
+    """Tier 2: dispatch_plan_tool returns {"status": "spawned", ...}
+    without awaiting plan completion when host supports
+    spawn_plan_task. RouterLoop sees async tool result + exits."""
+    host = _AsyncCapableHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="chat_turn_c0",
+        available_tool_names=set(),
+    )
+    assert result["status"] == "spawned"
+    assert "plan_id" in result
+    assert "chain_id" in result
+    assert result["n_steps"] == 2
+    # Host received the spawn handoff but plan hasn't run yet.
+    assert len(host.spawn_calls) == 1
+    # Runtime not yet executed → no plan_started / plan_completed.
+    assert host.plan_started_calls == []
+    assert host.plan_completed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_dispatch_allocates_per_plan_chain_id() -> None:
+    """Tier 2: ADR-0023 §2.1.2 — chain_id is allocated as
+    f"plan_{plan_id}", distinct from the chat-turn chain_id (= R-D14
+    can target the right waiter on /plan discard)."""
+    host = _AsyncCapableHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="chat_turn_c0",  # caller chain
+        available_tool_names=set(),
+    )
+    plan_id = result["plan_id"]
+    assert result["chain_id"] == f"plan_{plan_id}"
+    assert result["chain_id"] != "chat_turn_c0"
+    # Host's spawn_plan_task received the per-plan chain_id.
+    assert host.spawn_calls[0]["chain_id"] == f"plan_{plan_id}"
+
+
+@pytest.mark.asyncio
+async def test_async_dispatch_decomposition_written_before_spawn() -> None:
+    """Tier 2: ADR-0023 §3.5 lifecycle — artifact write happens before
+    spawn_plan_task hands the runtime off."""
+    host = _AsyncCapableHost()
+    await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert len(host.write_decomp_calls) == 1
+    assert len(host.spawn_calls) == 1
+    # No artifact deletion yet — runtime hasn't completed.
+    assert host.delete_decomp_calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_runtime_runs_to_completion_via_host() -> None:
+    """Tier 2: when the host eventually drives spawned runtimes (= the
+    ChatSession analog calls runtime.run()), plan_started + completed
+    fire, terminal text reaches outbox."""
+    host = _AsyncCapableHost()
+    await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    # Drive the runtime now (= mirror ChatSession.spawn_plan_task wrapper).
+    await host.run_spawned()
+    assert len(host.plan_started_calls) == 1
+    assert len(host.plan_completed_calls) == 1
+    # Step events recorded via WAL host methods.
+    assert {c["step_id"] for c in host.plan_step_started_calls} == {"s1", "s2"}
+    # Terminal text emitted via outbox by host.run_spawned().
+    agent_msgs = [m for m in host.outbox if m["kind"] == "agent"
+                  and m.get("meta", {}).get("source") == "plan"]
+    assert len(agent_msgs) == 1
+
+
+# ── sync fallback (= host without spawn_plan_task) ──────────────────────
+
+
+class _LegacyHost:
+    """Host without spawn_plan_task — exercises the synchronous fallback
+    safety net for test stubs / lightweight integrations."""
+
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+        self.write_decomp_calls: list[dict] = []
+        self.delete_decomp_calls: list[dict] = []
+        self.plan_started_calls: list[dict] = []
+        self.plan_completed_calls: list[dict] = []
+        self.plan_step_started_calls: list[dict] = []
+        self.plan_step_completed_calls: list[dict] = []
+        self.plan_step_failed_calls: list[dict] = []
+        self.outbox: list[dict] = []
+
+    async def write_plan_decomposition(self, *, plan_id, plan):
+        self.write_decomp_calls.append({"plan_id": plan_id})
+        return f"/fake/{plan_id}"
+
+    async def delete_plan_decomposition(self, *, plan_id):
+        self.delete_decomp_calls.append({"plan_id": plan_id})
+
+    async def put_outbox(self, *, kind, text, meta):
+        self.outbox.append({"kind": kind, "text": text})
+
+    async def record_plan_started(self, *, plan_id, goal, n_steps):
+        self.plan_started_calls.append({"plan_id": plan_id})
+
+    async def record_plan_completed(self, *, plan_id):
+        self.plan_completed_calls.append({"plan_id": plan_id})
+
+    async def record_plan_aborted(self, *, plan_id, reason=""):
+        pass
+
+    async def record_plan_step_started(self, *, plan_id, step_id,
+                                       depends_on, n_tools):
+        self.plan_step_started_calls.append({"step_id": step_id})
+
+    async def record_plan_step_completed(self, *, plan_id, step_id,
+                                          content_len):
+        self.plan_step_completed_calls.append({"step_id": step_id})
+
+    async def record_plan_step_failed(self, *, plan_id, step_id, error):
+        self.plan_step_failed_calls.append({"step_id": step_id})
+
+
+@pytest.mark.asyncio
+async def test_sync_fallback_returns_status_ok_with_text() -> None:
+    """Tier 2: legacy host (= no spawn_plan_task) takes the synchronous
+    safety-net path; plan completes inline and result.text + status="ok"
+    flow back to the caller (= router_loop's existing plan special-case
+    safety net at line 428-449)."""
+    host = _LegacyHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert result["status"] == "ok"
+    assert "text" in result
+    # plan_started + plan_completed BOTH fire (= execute_plan finally
+    # not corrupted by enclosing exception context).
+    assert len(host.plan_started_calls) == 1
+    assert len(host.plan_completed_calls) == 1
+    # Artifact deleted on clean exit.
+    assert len(host.delete_decomp_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_fallback_uses_per_plan_chain_id_internally() -> None:
+    """Tier 2: even on the sync fallback, per-plan chain_id is allocated
+    (= consistent identity for WAL events + cancel cascade)."""
+    host = _LegacyHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    # status="ok" (legacy shape), but the runtime ran with plan_chain_id.
+    # No way to assert chain_id on the result dict in legacy shape
+    # (kept absent for backward compat); we assert via plan completion
+    # not crashing — the runtime had to operate with the new chain_id.
+    assert len(host.plan_completed_calls) == 1
+
+
+# ── validation failure short-circuit ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_runtime_emits_step_status_narration() -> None:
+    """Tier 2: ADR-0023 §2.1.1 — runtime emits per-step status outbox
+    messages so the user sees plan progress while it runs in background."""
+    host = _AsyncCapableHost()
+    await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    await host.run_spawned()
+
+    status_msgs = [m for m in host.outbox if m["kind"] == "status"
+                   and m.get("meta", {}).get("source") == "plan"]
+    # plan_started + 2 step_done messages (= 3 total for 2-step plan)
+    assert len(status_msgs) == 3
+    assert "plan started" in status_msgs[0]["text"]
+    assert "1/2" in status_msgs[1]["text"]
+    assert "2/2" in status_msgs[2]["text"]
+
+
+@pytest.mark.asyncio
+async def test_async_validation_failure_does_not_spawn() -> None:
+    """Tier 2: invalid plan → status=error, no spawn, no artifact write."""
+    host = _AsyncCapableHost()
+    result = await dispatch_plan_tool(
+        args={"goal": "g", "steps": []},  # too few
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert result["status"] == "error"
+    assert host.spawn_calls == []
+    assert host.write_decomp_calls == []

--- a/tests/test_plan_chatsession_wiring.py
+++ b/tests/test_plan_chatsession_wiring.py
@@ -1,0 +1,190 @@
+"""Tier 2: Phase 2 fresh-run wiring (= ADR-0023 Phase 2 v1 gap fix).
+
+Pins the contract that ChatSession's record_plan_* methods populate
+the per-agent PlanRegistry alongside SnapshotJournal's WAL-side
+bookkeeping. Without this, ADR-0023 forward replay was dormant
+(PlanRegistry.load_active() returns empty for every fresh-run plan)
+and ADR-0024/ADR-0025 features had nothing to record into.
+
+Tests target the public surface (ChatSession.record_plan_* methods)
+and observe via PlanRegistry's on-disk snapshots — no private state
+assertions, no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+from reyn.plan import (
+    PlanRegistry,
+    plan_snapshot_path,
+)
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+# ── per-plan snapshot creation ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_plan_started_creates_per_plan_snapshot(tmp_path, monkeypatch):
+    """Tier 2: ChatSession.record_plan_started writes the per-plan
+    snapshot file alongside the WAL append + AgentSnapshot mutation."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    await session.record_plan_started(
+        plan_id="p_test", goal="hello", n_steps=2,
+    )
+
+    # Per-plan snapshot file exists at the documented path.
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    snap_path = plan_snapshot_path(agent_state_dir, "p_test")
+    assert snap_path.exists()
+
+    # Registry can load it back.
+    reg = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg.load_active()
+    snap = reg.get("p_test")
+    assert snap is not None
+    assert snap.goal == "hello"
+    assert snap.chain_id == "plan_p_test"  # ADR-0023 §2.1.2 per-plan chain
+
+
+@pytest.mark.asyncio
+async def test_record_plan_step_completed_persists_to_snapshot(tmp_path, monkeypatch):
+    """Tier 2: ChatSession.record_plan_step_completed flows result_text
+    through to PlanRegistry.record_step_completed (= ADR-0024 inline
+    or spilled persistence in the per-plan snapshot)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    await session.record_plan_started(
+        plan_id="p_test", goal="g", n_steps=1,
+    )
+    await session.record_plan_step_started(
+        plan_id="p_test", step_id="s1", depends_on=[], n_tools=0,
+    )
+
+    text = "step output text"
+    await session.record_plan_step_completed(
+        plan_id="p_test", step_id="s1",
+        content_len=len(text), result_text=text,
+    )
+
+    # Re-load the snapshot.
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    reg = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg.load_active()
+    snap = reg.get("p_test")
+    assert snap.step_results["s1"] == text
+    assert snap.last_committed_step_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_record_plan_step_completed_spills_large_text(tmp_path, monkeypatch):
+    """Tier 2: large result_text routes through ADR-0024 spill path so
+    fresh runs benefit from the spill (= no 32KB silent truncation)."""
+    from reyn.plan import step_result_file_path
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    await session.record_plan_started(
+        plan_id="p_big", goal="g", n_steps=1,
+    )
+    huge = "X" * 50_000
+    await session.record_plan_step_completed(
+        plan_id="p_big", step_id="s1",
+        content_len=len(huge), result_text=huge,
+    )
+
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    spilled = step_result_file_path(agent_state_dir, "p_big", "s1")
+    assert spilled.exists()
+    assert spilled.read_text(encoding="utf-8") == huge
+
+
+@pytest.mark.asyncio
+async def test_record_plan_completed_removes_per_plan_workspace(tmp_path, monkeypatch):
+    """Tier 2: ChatSession.record_plan_completed reclaims the per-plan
+    workspace via PlanRegistry.complete (= delete_plan_workspace)."""
+    from reyn.plan import decomposition_dir
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    await session.record_plan_started(
+        plan_id="p_done", goal="g", n_steps=1,
+    )
+    await session.record_plan_step_completed(
+        plan_id="p_done", step_id="s1", content_len=5, result_text="hello",
+    )
+
+    await session.record_plan_completed(plan_id="p_done")
+
+    # Per-plan workspace dir + snapshot file gone.
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    assert not decomposition_dir(agent_state_dir, "p_done").exists()
+    assert not plan_snapshot_path(agent_state_dir, "p_done").exists()
+
+
+@pytest.mark.asyncio
+async def test_record_plan_aborted_removes_per_plan_workspace(tmp_path, monkeypatch):
+    """Tier 2: ChatSession.record_plan_aborted similarly cleans up the
+    per-plan workspace (= /plan discard / restart-cleanup paths)."""
+    from reyn.plan import decomposition_dir
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    await session.record_plan_started(
+        plan_id="p_abort", goal="g", n_steps=1,
+    )
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    assert plan_snapshot_path(agent_state_dir, "p_abort").exists()
+
+    await session.record_plan_aborted(
+        plan_id="p_abort", reason="test",
+    )
+    assert not plan_snapshot_path(agent_state_dir, "p_abort").exists()
+
+
+# ── PlanRegistry sharing ─────────────────────────────────────────────────
+
+
+def test_get_plan_registry_returns_singleton(tmp_path, monkeypatch):
+    """Tier 2: lazy-init returns the same instance across calls."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    reg1 = session._get_plan_registry()
+    reg2 = session._get_plan_registry()
+    assert reg1 is reg2
+
+
+def test_get_plan_registry_returns_none_without_state_log(tmp_path):
+    """Tier 2: no state_log → no plan registry (= test/standalone mode)."""
+    session = ChatSession(
+        agent_name="alpha", state_log=None,
+        snapshot_path=tmp_path / "snap.json",
+    )
+    assert session._get_plan_registry() is None

--- a/tests/test_plan_decomposition_artifact.py
+++ b/tests/test_plan_decomposition_artifact.py
@@ -1,0 +1,250 @@
+"""Tier 2: Plan decomposition artifact write/read/delete (ADR-0023 §3.5).
+
+Step 1 of the Phase 2 migration path. The artifact is the canonical
+SSoT for the plan shape on resume; LLM re-decomposition is non-
+deterministic and would break step-result memoization.
+
+These tests pin the round-trip + corruption-fallback behavior. No
+ChatSession / RouterLoop coupling — the helpers are standalone.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan import (
+    DECOMPOSITION_SCHEMA_VERSION,
+    DecompositionCorruptError,
+    decomposition_dir,
+    decomposition_path,
+    delete_decomposition,
+    read_decomposition,
+    write_decomposition,
+)
+
+
+def _sample_plan() -> Plan:
+    return Plan(
+        goal="Compare README.md and CLAUDE.md",
+        steps=(
+            PlanStep(
+                id="s1",
+                description="Read README.md",
+                tools=("read_file",),
+                depends_on=(),
+            ),
+            PlanStep(
+                id="s2",
+                description="Read CLAUDE.md",
+                tools=("read_file",),
+                depends_on=(),
+            ),
+            PlanStep(
+                id="s3",
+                description="Synthesise comparison",
+                tools=(),
+                depends_on=("s1", "s2"),
+            ),
+        ),
+    )
+
+
+# ── path helpers ──────────────────────────────────────────────────────────
+
+
+def test_decomposition_path_layout(tmp_path: Path) -> None:
+    """Tier 2: path helpers expose the documented per-plan directory layout."""
+    plan_id = "ab12cd34"
+    state = tmp_path / "agent_state"
+    assert decomposition_dir(state, plan_id) == state / "plans" / plan_id
+    assert (
+        decomposition_path(state, plan_id)
+        == state / "plans" / plan_id / "decomposition.json"
+    )
+
+
+# ── write ─────────────────────────────────────────────────────────────────
+
+
+def test_write_creates_artifact_with_documented_schema(tmp_path: Path) -> None:
+    """Tier 2: write_decomposition produces the ADR-0023 §3.5 schema verbatim."""
+    plan = _sample_plan()
+    path = write_decomposition(tmp_path, "p001", plan)
+
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["plan_id"] == "p001"
+    assert payload["schema_version"] == DECOMPOSITION_SCHEMA_VERSION
+    assert payload["goal"] == plan.goal
+    assert len(payload["steps"]) == 3
+    assert payload["steps"][0] == {
+        "id": "s1",
+        "description": "Read README.md",
+        "tools": ["read_file"],
+        "depends_on": [],
+    }
+    assert payload["steps"][2]["depends_on"] == ["s1", "s2"]
+
+
+def test_write_is_atomic_overwriting_prior_artifact(tmp_path: Path) -> None:
+    """Tier 2: re-writing the same plan_id replaces the prior artifact in
+    place without leaving the .tmp file behind."""
+    plan_v1 = Plan(
+        goal="v1",
+        steps=(
+            PlanStep("a", "first", ()),
+            PlanStep("b", "second", ()),
+        ),
+    )
+    plan_v2 = _sample_plan()
+    path_v1 = write_decomposition(tmp_path, "p001", plan_v1)
+    path_v2 = write_decomposition(tmp_path, "p001", plan_v2)
+    assert path_v1 == path_v2
+    payload = json.loads(path_v2.read_text(encoding="utf-8"))
+    assert payload["goal"] == plan_v2.goal
+    assert len(payload["steps"]) == 3
+    # No .tmp residue
+    assert not path_v2.with_suffix(path_v2.suffix + ".tmp").exists()
+
+
+# ── read ──────────────────────────────────────────────────────────────────
+
+
+def test_read_round_trips_to_equivalent_plan(tmp_path: Path) -> None:
+    """Tier 2: write → read produces an equivalent Plan."""
+    plan = _sample_plan()
+    write_decomposition(tmp_path, "p001", plan)
+    loaded = read_decomposition(tmp_path, "p001")
+    assert loaded.goal == plan.goal
+    assert len(loaded.steps) == len(plan.steps)
+    for original, recovered in zip(plan.steps, loaded.steps):
+        assert recovered.id == original.id
+        assert recovered.description == original.description
+        assert recovered.tools == original.tools
+        assert recovered.depends_on == original.depends_on
+
+
+def test_read_missing_artifact_raises_filenotfound(tmp_path: Path) -> None:
+    """Tier 2: missing artifact surfaces FileNotFoundError so the coordinator
+    can fall back to snapshot ``steps_serialized``."""
+    with pytest.raises(FileNotFoundError):
+        read_decomposition(tmp_path, "nonexistent")
+
+
+def test_read_invalid_json_raises_corrupt(tmp_path: Path) -> None:
+    """Tier 2: malformed JSON surfaces DecompositionCorruptError so the
+    coordinator can force action=discard."""
+    target = decomposition_path(tmp_path, "p001")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("not json {", encoding="utf-8")
+    with pytest.raises(DecompositionCorruptError):
+        read_decomposition(tmp_path, "p001")
+
+
+def test_read_wrong_schema_version_raises_corrupt(tmp_path: Path) -> None:
+    """Tier 2: schema_version drift refuses load (= future schema bump
+    requires explicit migration, not silent best-effort)."""
+    target = decomposition_path(tmp_path, "p001")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "plan_id": "p001",
+                "schema_version": 999,
+                "goal": "g",
+                "steps": [{"id": "s1", "description": "d", "tools": [], "depends_on": []}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(DecompositionCorruptError, match="schema_version"):
+        read_decomposition(tmp_path, "p001")
+
+
+def test_read_missing_required_fields_raises_corrupt(tmp_path: Path) -> None:
+    """Tier 2: structural defects surface as DecompositionCorruptError."""
+    target = decomposition_path(tmp_path, "p001")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Missing goal
+    target.write_text(
+        json.dumps(
+            {
+                "plan_id": "p001",
+                "schema_version": DECOMPOSITION_SCHEMA_VERSION,
+                "steps": [{"id": "s", "description": "d", "tools": [], "depends_on": []}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(DecompositionCorruptError, match="goal"):
+        read_decomposition(tmp_path, "p001")
+
+
+def test_read_empty_steps_raises_corrupt(tmp_path: Path) -> None:
+    """Tier 2: empty steps list is a corruption (= a plan with zero steps
+    is not a valid persistence target)."""
+    target = decomposition_path(tmp_path, "p001")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "plan_id": "p001",
+                "schema_version": DECOMPOSITION_SCHEMA_VERSION,
+                "goal": "g",
+                "steps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(DecompositionCorruptError, match="steps"):
+        read_decomposition(tmp_path, "p001")
+
+
+# ── delete ────────────────────────────────────────────────────────────────
+
+
+def test_delete_removes_existing_artifact(tmp_path: Path) -> None:
+    """Tier 2: delete_decomposition returns True on existing artifact and
+    removes the file."""
+    write_decomposition(tmp_path, "p001", _sample_plan())
+    path = decomposition_path(tmp_path, "p001")
+    assert path.exists()
+    assert delete_decomposition(tmp_path, "p001") is True
+    assert not path.exists()
+
+
+def test_delete_is_idempotent_on_missing_artifact(tmp_path: Path) -> None:
+    """Tier 2: delete_decomposition on a non-existent plan returns False
+    and does not raise (= safe for AgentRegistry.restore_all cleanup which
+    doesn't know if the artifact survived the crash)."""
+    assert delete_decomposition(tmp_path, "nonexistent") is False
+
+
+def test_delete_removes_empty_per_plan_directory(tmp_path: Path) -> None:
+    """Tier 2: per-plan directory is cleaned up when empty (= deletion
+    leaves no orphan dirs)."""
+    write_decomposition(tmp_path, "p001", _sample_plan())
+    plan_dir = decomposition_dir(tmp_path, "p001")
+    assert plan_dir.is_dir()
+    delete_decomposition(tmp_path, "p001")
+    assert not plan_dir.exists()
+
+
+def test_delete_preserves_per_plan_directory_with_other_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: per-plan directory survives delete when it contains other
+    artifacts (= future Phase 3 step intermediates aren't dropped)."""
+    write_decomposition(tmp_path, "p001", _sample_plan())
+    plan_dir = decomposition_dir(tmp_path, "p001")
+    other = plan_dir / "step_intermediate.json"
+    other.write_text("{}", encoding="utf-8")
+
+    delete_decomposition(tmp_path, "p001")
+
+    assert not decomposition_path(tmp_path, "p001").exists()
+    assert plan_dir.is_dir()
+    assert other.exists()

--- a/tests/test_plan_dispatch_artifact.py
+++ b/tests/test_plan_dispatch_artifact.py
@@ -1,0 +1,339 @@
+"""Tier 2: dispatch_plan_tool migrated to PlanRuntime + artifact lifecycle
+(ADR-0023 Phase 2 step 6).
+
+Phase 2 lifecycle ordering invariant:
+  1. validate plan
+  2. allocate plan_id
+  3. write decomposition artifact (= P5 SSoT)
+  4. construct PlanRuntime(plan_id=plan_id) → run
+  5. on clean exit (success / WorkflowAbortedError): delete artifact
+  6. on crash / cancel: preserve artifact for restart cleanup
+
+Also pins plan_step_* WAL routing (= record_plan_step_*) replacing the
+forensic-only events.emit path.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.chat.planner import (
+    Plan,
+    PlanStep,
+    dispatch_plan_tool,
+)
+
+
+# ── stub host with full Step 6 surface ────────────────────────────────────
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **fields: Any) -> None:
+        self.emitted.append((kind, fields))
+
+
+class _RecordingHost:
+    """Host that records every Phase 2 step-6-relevant call.
+
+    Captures plan_id seen by record_plan_started + write_plan_decomposition
+    so we can assert lifecycle ordering, and tracks step events so we can
+    assert WAL routing parity.
+    """
+
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+        self.plan_started_calls: list[dict] = []
+        self.plan_completed_calls: list[dict] = []
+        self.plan_aborted_calls: list[dict] = []
+        self.plan_step_started_calls: list[dict] = []
+        self.plan_step_completed_calls: list[dict] = []
+        self.plan_step_failed_calls: list[dict] = []
+        self.write_decomp_calls: list[dict] = []
+        self.delete_decomp_calls: list[dict] = []
+        self.call_order: list[str] = []  # for ordering assertions
+
+    async def record_plan_started(self, *, plan_id, goal, n_steps):
+        self.plan_started_calls.append(
+            {"plan_id": plan_id, "goal": goal, "n_steps": n_steps}
+        )
+        self.call_order.append(f"plan_started:{plan_id}")
+
+    async def record_plan_completed(self, *, plan_id):
+        self.plan_completed_calls.append({"plan_id": plan_id})
+        self.call_order.append(f"plan_completed:{plan_id}")
+
+    async def record_plan_aborted(self, *, plan_id, reason=""):
+        self.plan_aborted_calls.append({"plan_id": plan_id, "reason": reason})
+
+    async def record_plan_step_started(
+        self, *, plan_id, step_id, depends_on, n_tools,
+    ):
+        self.plan_step_started_calls.append({
+            "plan_id": plan_id, "step_id": step_id,
+            "depends_on": list(depends_on), "n_tools": n_tools,
+        })
+
+    async def record_plan_step_completed(self, *, plan_id, step_id, content_len):
+        self.plan_step_completed_calls.append({
+            "plan_id": plan_id, "step_id": step_id, "content_len": content_len,
+        })
+
+    async def record_plan_step_failed(self, *, plan_id, step_id, error):
+        self.plan_step_failed_calls.append({
+            "plan_id": plan_id, "step_id": step_id, "error": error,
+        })
+
+    async def write_plan_decomposition(self, *, plan_id, plan):
+        self.write_decomp_calls.append({"plan_id": plan_id, "plan": plan})
+        self.call_order.append(f"write_decomp:{plan_id}")
+        return f"/fake/path/{plan_id}/decomposition.json"
+
+    async def delete_plan_decomposition(self, *, plan_id):
+        self.delete_decomp_calls.append({"plan_id": plan_id})
+        self.call_order.append(f"delete_decomp:{plan_id}")
+
+
+class _StubRouterLoop:
+    _behavior = "noop"
+
+    def __init__(self, *, host, **kwargs):
+        self.host = host
+
+    @property
+    def total_usage(self):
+        from reyn.llm.pricing import TokenUsage
+        return TokenUsage()
+
+    async def run(self, *, user_text, history):
+        if _StubRouterLoop._behavior == "raise:RuntimeError":
+            raise RuntimeError("test crash")
+        if _StubRouterLoop._behavior == "raise:WorkflowAbortedError":
+            from reyn.kernel.runtime import WorkflowAbortedError
+            raise WorkflowAbortedError("test abort")
+        await self.host.put_outbox(kind="agent", text="ok", meta={})
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_router_loop(monkeypatch: Any):
+    import reyn.chat.planner as planner_mod
+    monkeypatch.setattr(planner_mod, "RouterLoop", _StubRouterLoop)
+    _StubRouterLoop._behavior = "noop"
+    yield
+
+
+def _simple_plan_args() -> dict:
+    return {
+        "goal": "g",
+        "steps": [
+            {"id": "s1", "description": "first", "tools": []},
+            {"id": "s2", "description": "second", "tools": [], "depends_on": ["s1"]},
+        ],
+    }
+
+
+# ── lifecycle ordering ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_writes_decomposition_before_plan_started() -> None:
+    """Tier 2: ADR-0023 §3.5 — artifact write MUST precede plan_started so
+    any plan in active_plan_ids has a discoverable decomposition."""
+    host = _RecordingHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert result["status"] == "ok"
+    write_idx = next(
+        i for i, c in enumerate(host.call_order) if c.startswith("write_decomp:")
+    )
+    started_idx = next(
+        i for i, c in enumerate(host.call_order) if c.startswith("plan_started:")
+    )
+    assert write_idx < started_idx
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_same_plan_id_across_lifecycle() -> None:
+    """Tier 2: the plan_id allocated by dispatch_plan_tool is the same id
+    threaded through write_decomp + plan_started + plan_completed +
+    delete_decomp (= no auto-allocation in execute_plan when caller
+    supplies one)."""
+    host = _RecordingHost()
+    await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert len(host.write_decomp_calls) == 1
+    assert len(host.plan_started_calls) == 1
+    assert len(host.plan_completed_calls) == 1
+    assert len(host.delete_decomp_calls) == 1
+    plan_id = host.write_decomp_calls[0]["plan_id"]
+    assert host.plan_started_calls[0]["plan_id"] == plan_id
+    assert host.plan_completed_calls[0]["plan_id"] == plan_id
+    assert host.delete_decomp_calls[0]["plan_id"] == plan_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_step_events_through_record_methods() -> None:
+    """Tier 2: each step calls record_plan_step_started + completed (=
+    WAL persistence). 2-step plan → 2 started + 2 completed calls."""
+    host = _RecordingHost()
+    await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert len(host.plan_step_started_calls) == 2
+    assert len(host.plan_step_completed_calls) == 2
+    assert host.plan_step_started_calls[0]["step_id"] == "s1"
+    assert host.plan_step_started_calls[1]["step_id"] == "s2"
+    assert host.plan_step_started_calls[1]["depends_on"] == ["s1"]
+
+
+# ── artifact cleanup branches ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_deletes_artifact_on_normal_completion() -> None:
+    """Tier 2: clean run → artifact cleaned up via delete_plan_decomposition."""
+    host = _RecordingHost()
+    await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert len(host.delete_decomp_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_deletes_artifact_when_workflow_abort_caught_per_step() -> None:
+    """Tier 2: per-step try/except in execute_plan catches
+    WorkflowAbortedError as a step failure — the plan finishes with
+    failures recorded, so plan_completed fires and the artifact is
+    deleted (= clean exit)."""
+    _StubRouterLoop._behavior = "raise:WorkflowAbortedError"
+    host = _RecordingHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    # All steps recorded as failed (= per-step except catches WorkflowAbortedError).
+    assert len(host.plan_step_failed_calls) == 2
+    # Plan still completes cleanly; artifact cleaned up.
+    assert len(host.plan_completed_calls) == 1
+    assert len(host.delete_decomp_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_preserves_artifact_on_crash() -> None:
+    """Tier 2: generic exception leaves the artifact in place for restart
+    cleanup or memo-replay resume."""
+    # The internal step's try/except in execute_plan catches RuntimeError
+    # as a step failure and continues; to actually crash the runtime we
+    # need an exception that escapes that handler. Use cancel-style.
+    class _CancellingRouterLoop(_StubRouterLoop):
+        async def run(self, *, user_text, history):
+            raise asyncio.CancelledError("test cancel")
+
+    import reyn.chat.planner as planner_mod
+    original = planner_mod.RouterLoop
+    planner_mod.RouterLoop = _CancellingRouterLoop
+    try:
+        host = _RecordingHost()
+        with pytest.raises(asyncio.CancelledError):
+            await dispatch_plan_tool(
+                args=_simple_plan_args(),
+                parent_host=host, chain_id="c0",
+                available_tool_names=set(),
+            )
+        # No delete on cancellation → artifact preserved for resume.
+        assert host.delete_decomp_calls == []
+    finally:
+        planner_mod.RouterLoop = original
+
+
+# ── error / fallback ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_step_failed_when_step_raises() -> None:
+    """Tier 2: when a sub-loop crashes inside execute_plan's per-step
+    try/except, the step failure is recorded via record_plan_step_failed
+    on the WAL path."""
+    _StubRouterLoop._behavior = "raise:RuntimeError"
+    host = _RecordingHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    # All steps should be marked failed (= 2-step plan, both sub-loops crash).
+    assert len(host.plan_step_failed_calls) == 2
+    assert host.plan_step_failed_calls[0]["step_id"] == "s1"
+    # plan_completed is still emitted because execute_plan only
+    # propagates uncaught exceptions; per-step errors are caught.
+    assert len(host.plan_completed_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_invalid_plan_returns_error_no_artifact_write() -> None:
+    """Tier 2: validation failure short-circuits before any WAL or
+    artifact effects (= no plan_id allocated, no write_decomposition)."""
+    host = _RecordingHost()
+    result = await dispatch_plan_tool(
+        args={"goal": "g", "steps": []},  # too few
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert result["status"] == "error"
+    assert host.write_decomp_calls == []
+    assert host.plan_started_calls == []
+
+
+# ── backward compat: hosts without Step 6 methods ────────────────────────
+
+
+class _OldStyleHost:
+    """Host that implements only Phase 1's record_plan_started/completed/
+    aborted but not the Step 6 additions. Phase 2 must still function
+    (defensively)."""
+
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+        self.plan_started_calls: list[dict] = []
+        self.plan_completed_calls: list[dict] = []
+
+    async def record_plan_started(self, *, plan_id, goal, n_steps):
+        self.plan_started_calls.append({"plan_id": plan_id})
+
+    async def record_plan_completed(self, *, plan_id):
+        self.plan_completed_calls.append({"plan_id": plan_id})
+
+    async def record_plan_aborted(self, *, plan_id, reason=""):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tolerates_host_without_step6_methods() -> None:
+    """Tier 2: host stub that lacks write_plan_decomposition /
+    delete_plan_decomposition / record_plan_step_* doesn't break dispatch
+    (= AttributeError is swallowed defensively per Phase 1 precedent)."""
+    host = _OldStyleHost()
+    result = await dispatch_plan_tool(
+        args=_simple_plan_args(),
+        parent_host=host, chain_id="c0",
+        available_tool_names=set(),
+    )
+    assert result["status"] == "ok"
+    assert len(host.plan_started_calls) == 1
+    assert len(host.plan_completed_calls) == 1

--- a/tests/test_plan_memo_replay.py
+++ b/tests/test_plan_memo_replay.py
@@ -1,0 +1,239 @@
+"""Tier 2: PlanRuntime memo replay (ADR-0023 §3.4 Phase 2 step 7b).
+
+Pins the memo replay contract:
+  - completed_with_result step → memo (= no sub-loop, no WAL emit)
+  - failed step → memo_failed (= no re-execute)
+  - pending step → execute (= run sub-loop normally)
+
+Resume_plan=None preserves the fresh-run path (= Phase 1 / Step 6
+behavior unchanged).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep, execute_plan
+from reyn.plan import (
+    PlanResumePlan,
+    PlanRuntime,
+    PlanStepState,
+)
+
+
+# ── stubs ────────────────────────────────────────────────────────────────
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **fields: Any) -> None:
+        self.emitted.append((kind, fields))
+
+
+class _RecordingHost:
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+        self.plan_started_calls: list[dict] = []
+        self.plan_completed_calls: list[dict] = []
+        self.plan_aborted_calls: list[dict] = []
+        self.plan_step_started_calls: list[dict] = []
+        self.plan_step_completed_calls: list[dict] = []
+        self.plan_step_failed_calls: list[dict] = []
+
+    async def record_plan_started(self, *, plan_id, goal, n_steps):
+        self.plan_started_calls.append({"plan_id": plan_id})
+
+    async def record_plan_completed(self, *, plan_id):
+        self.plan_completed_calls.append({"plan_id": plan_id})
+
+    async def record_plan_aborted(self, *, plan_id, reason=""):
+        self.plan_aborted_calls.append({"plan_id": plan_id})
+
+    async def record_plan_step_started(self, *, plan_id, step_id, depends_on, n_tools):
+        self.plan_step_started_calls.append({"step_id": step_id})
+
+    async def record_plan_step_completed(self, *, plan_id, step_id, content_len):
+        self.plan_step_completed_calls.append({"step_id": step_id})
+
+    async def record_plan_step_failed(self, *, plan_id, step_id, error):
+        self.plan_step_failed_calls.append({"step_id": step_id})
+
+
+class _CountingRouterLoop:
+    """Tracks how many sub-loops actually ran; memo replay should bypass."""
+
+    invocations: list[str] = []
+
+    def __init__(self, *, host, **kwargs):
+        self.host = host
+
+    @property
+    def total_usage(self):
+        from reyn.llm.pricing import TokenUsage
+        return TokenUsage()
+
+    async def run(self, *, user_text, history):
+        _CountingRouterLoop.invocations.append(user_text)
+        await self.host.put_outbox(kind="agent", text=f"ran:{user_text}", meta={})
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_router_loop(monkeypatch: Any):
+    import reyn.chat.planner as planner_mod
+    monkeypatch.setattr(planner_mod, "RouterLoop", _CountingRouterLoop)
+    _CountingRouterLoop.invocations.clear()
+    yield
+
+
+def _three_step_plan() -> Plan:
+    return Plan(
+        goal="g",
+        steps=(
+            PlanStep("s1", "first", ()),
+            PlanStep("s2", "second", (), depends_on=("s1",)),
+            PlanStep("s3", "third", (), depends_on=("s2",)),
+        ),
+    )
+
+
+# ── memo path ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resume_plan_skips_completed_step_via_memo() -> None:
+    """Tier 2: a step in completed_with_result state is NOT re-executed —
+    sub-loop is bypassed and recorded text is reused."""
+    plan = _three_step_plan()
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=3, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result",
+                          result_text="memo:s1"),
+            PlanStepState(step_id="s2", state="pending"),
+            PlanStepState(step_id="s3", state="pending"),
+        ),
+    )
+    host = _RecordingHost()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0", plan_id="p001",
+                          resume_plan=rp)
+    result = await runtime.run()
+
+    # Only s2 + s3 ran; s1 was memoized.
+    assert _CountingRouterLoop.invocations == ["second", "third"]
+    assert result.step_results["s1"] == "memo:s1"
+    # s1 had no record_plan_step_started / completed call (= no WAL re-emit).
+    assert {c["step_id"] for c in host.plan_step_started_calls} == {"s2", "s3"}
+
+
+@pytest.mark.asyncio
+async def test_resume_plan_emits_plan_step_memoized_event() -> None:
+    """Tier 2: memo replay emits a forensic plan_step_memoized event so
+    the events log records the no-op (= audit trail)."""
+    plan = _three_step_plan()
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=3, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result",
+                          result_text="memo:s1"),
+            PlanStepState(step_id="s2", state="pending"),
+            PlanStepState(step_id="s3", state="pending"),
+        ),
+    )
+    host = _RecordingHost()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0", plan_id="p001",
+                          resume_plan=rp)
+    await runtime.run()
+
+    memo_events = [e for e in host.events.emitted
+                   if e[0] == "plan_step_memoized"]
+    assert len(memo_events) == 1
+    assert memo_events[0][1]["step_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_resume_plan_failed_state_propagates_without_re_execute() -> None:
+    """Tier 2: a step in failed state is not re-executed; failure is
+    recorded into step_failures so downstream synthesis sees the gap."""
+    plan = _three_step_plan()
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=3, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="failed",
+                          error_message="recorded boom"),
+            PlanStepState(step_id="s2", state="pending"),
+            PlanStepState(step_id="s3", state="pending"),
+        ),
+    )
+    host = _RecordingHost()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0", plan_id="p001",
+                          resume_plan=rp)
+    result = await runtime.run()
+
+    # s1 not re-executed
+    assert "first" not in _CountingRouterLoop.invocations
+    assert "recorded boom" in result.step_failures["s1"]
+
+
+@pytest.mark.asyncio
+async def test_resume_plan_pending_step_executes_normally() -> None:
+    """Tier 2: pending steps run via the sub-loop (= normal flow)."""
+    plan = _three_step_plan()
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=3, decomposition_artifact_path=None,
+        step_states=tuple(
+            PlanStepState(step_id=sid, state="pending")
+            for sid in ("s1", "s2", "s3")
+        ),
+    )
+    host = _RecordingHost()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0", plan_id="p001",
+                          resume_plan=rp)
+    await runtime.run()
+    # All three steps executed via sub-loop.
+    assert sorted(_CountingRouterLoop.invocations) == ["first", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_no_resume_plan_runs_all_steps_fresh() -> None:
+    """Tier 2: resume_plan=None keeps Phase 1 fresh-run behavior — every
+    step runs through the sub-loop."""
+    plan = _three_step_plan()
+    host = _RecordingHost()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0", plan_id="p001",
+                          resume_plan=None)
+    await runtime.run()
+    assert sorted(_CountingRouterLoop.invocations) == ["first", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_partial_resume_chains_memo_into_pending_step_inputs() -> None:
+    """Tier 2: when s1 is memoized and s2 is pending, s2's prior_results
+    sees the memo'd text from s1 (= dependency chain works across resume)."""
+    plan = _three_step_plan()
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=3, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result",
+                          result_text="prior_step_output"),
+            PlanStepState(step_id="s2", state="pending"),
+            PlanStepState(step_id="s3", state="pending"),
+        ),
+    )
+    host = _RecordingHost()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0", plan_id="p001",
+                          resume_plan=rp)
+    result = await runtime.run()
+
+    # s1 memo result is in step_results so s2's system prompt builds with it.
+    assert result.step_results["s1"] == "prior_step_output"
+    # s2 ran (= got the memo as its input).
+    assert "second" in _CountingRouterLoop.invocations

--- a/tests/test_plan_multi_plan_resume_race.py
+++ b/tests/test_plan_multi_plan_resume_race.py
@@ -1,0 +1,422 @@
+"""Tier 2: multi-plan crash + resume integration (ADR-0023 §2.1.3).
+
+Pins the multi-plan correctness invariants: concurrent plans get
+independent snapshots / chain_ids, partial state survives crash,
+restart restores all of them via the coordinator-driven path.
+
+Tier 2 (NOT Tier 3 LLMReplay) by design: the race conditions live in
+the registry / coordinator / runtime layers, not in LLM responses.
+LLMReplay would add fixture-management cost without adding
+correctness value. Real LLM behaviour is stubbed via _StubRouterLoop
+mirroring test_plan_lifecycle_crash / test_plan_async_dispatch.
+
+Scope:
+  - Two concurrent dispatch_plan_tool calls produce independent
+    per-plan snapshots
+  - Per-plan chain_id distinct (= ADR-0023 §2.1.2)
+  - WAL events from both plans interleave in seq order (= analyzer
+    can disambiguate by plan_id)
+  - Crash mid-flight (kill tasks + drop session) leaves both
+    snapshots durable
+  - New ChatSession against same disk state spawns both resume tasks
+    (= AgentRegistry._recover_plans_for_agent path)
+  - No cross-plan contamination (= each resume reads its own
+    decomposition + step results)
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+from reyn.plan import (
+    PlanRegistry,
+    decomposition_dir,
+    plan_snapshot_path,
+)
+
+
+# ── stub RouterLoop (= mirror existing plan tests) ───────────────────────
+
+
+class _StubRouterLoop:
+    """Replaces RouterLoop in plan sub-loops to skip real LLM. Configurable
+    behaviour per-instance via class-level ``_per_step_behavior``."""
+
+    _per_step_behavior: dict[str, str] = {}  # step_id → "noop" | "raise:..."
+
+    def __init__(self, *, host, **kwargs):
+        self.host = host
+
+    @property
+    def total_usage(self):
+        from reyn.llm.pricing import TokenUsage
+        return TokenUsage()
+
+    async def run(self, *, user_text, history):
+        # Step description is the user_text passed by execute_plan; use
+        # it as the step identity proxy for behaviour selection.
+        behaviour = self._per_step_behavior.get(user_text, "noop")
+        if behaviour.startswith("raise:"):
+            raise RuntimeError(behaviour.split(":", 1)[1])
+        # Emit a synthetic agent text so captured_text is populated.
+        await self.host.put_outbox(
+            kind="agent", text=f"ok:{user_text}", meta={},
+        )
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_router_loop(monkeypatch):
+    import reyn.chat.planner as planner_mod
+    monkeypatch.setattr(planner_mod, "RouterLoop", _StubRouterLoop)
+    _StubRouterLoop._per_step_behavior = {}
+    yield
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "wal.jsonl"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _plan_args(goal: str, n_steps: int = 2) -> dict:
+    return {
+        "goal": goal,
+        "steps": [
+            {"id": f"s{i+1}", "description": f"{goal}-step-{i+1}",
+             "tools": []}
+            for i in range(n_steps)
+        ],
+    }
+
+
+async def _drain(session: ChatSession) -> None:
+    """Run pending tasks (= let spawn_plan_task workers complete)."""
+    if session.running_plans:
+        await asyncio.gather(
+            *session.running_plans.values(), return_exceptions=True,
+        )
+
+
+# ── concurrent dispatch ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_two_plans_dispatched_concurrently_get_independent_snapshots(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: two parallel dispatch_plan_tool calls yield two distinct
+    plan_ids + per-plan snapshot files. The async-spawn path doesn't
+    serialise dispatches."""
+    from reyn.chat.planner import dispatch_plan_tool
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    # Dispatch concurrently. Each returns a spawn ack with its plan_id.
+    res1, res2 = await asyncio.gather(
+        dispatch_plan_tool(
+            args=_plan_args("alpha"),
+            parent_host=session, chain_id="turn_c0",
+            available_tool_names=set(),
+        ),
+        dispatch_plan_tool(
+            args=_plan_args("beta"),
+            parent_host=session, chain_id="turn_c0",
+            available_tool_names=set(),
+        ),
+    )
+    assert res1["status"] == "spawned"
+    assert res2["status"] == "spawned"
+    p1, p2 = res1["plan_id"], res2["plan_id"]
+    assert p1 != p2
+
+    # Per-plan chain_id distinct (= ADR-0023 §2.1.2)
+    assert res1["chain_id"] == f"plan_{p1}"
+    assert res2["chain_id"] == f"plan_{p2}"
+    assert res1["chain_id"] != res2["chain_id"]
+
+    # Drain background tasks before inspecting state.
+    await _drain(session)
+
+    # Per-plan snapshot files cleaned up post-completion (= production
+    # path runs runtime to completion + delete_plan_workspace fires).
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    # Either both gone (fast path completed) or both files exist (= still
+    # running). Asymmetric state would indicate cross-plan corruption.
+    p1_exists = plan_snapshot_path(agent_state_dir, p1).exists()
+    p2_exists = plan_snapshot_path(agent_state_dir, p2).exists()
+    assert p1_exists == p2_exists
+
+
+@pytest.mark.asyncio
+async def test_concurrent_plans_record_distinct_step_results(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: while two plans run concurrently, their step_results
+    populate independently — no cross-plan write."""
+    from reyn.chat.planner import dispatch_plan_tool
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+
+    # Dispatch concurrently; await spawn acks.
+    res1, res2 = await asyncio.gather(
+        dispatch_plan_tool(
+            args=_plan_args("alpha", n_steps=2),
+            parent_host=session, chain_id="t0",
+            available_tool_names=set(),
+        ),
+        dispatch_plan_tool(
+            args=_plan_args("beta", n_steps=2),
+            parent_host=session, chain_id="t0",
+            available_tool_names=set(),
+        ),
+    )
+    p1, p2 = res1["plan_id"], res2["plan_id"]
+
+    # Drain background tasks. Both plans should complete cleanly.
+    await _drain(session)
+
+    # Outbox should have 2 agent-kind messages (= one terminal text per
+    # plan, completion-order arbitrary). Both must be present and
+    # tagged with their respective plan_id.
+    agent_msgs: list = []
+    while not session.outbox.empty():
+        msg = session.outbox.get_nowait()
+        if msg.kind == "agent" and msg.meta.get("source") == "plan":
+            agent_msgs.append(msg)
+    assert len(agent_msgs) == 2
+    plan_ids_seen = {m.meta.get("plan_id") for m in agent_msgs}
+    assert plan_ids_seen == {p1, p2}
+
+
+# ── crash + resume ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crash_mid_flight_two_plans_resume_both(tmp_path, monkeypatch):
+    """Tier 2 (headline): two plans in flight, simulate process crash
+    (= kill tasks before completion + new ChatSession against same
+    disk), restart triggers _recover_plans_for_agent which spawns
+    both resume tasks. Each picks up its own decomposition and
+    completes.
+
+    This is the multi-plan crash-recovery integration test.
+    """
+    from reyn.chat.planner import dispatch_plan_tool
+
+    monkeypatch.chdir(tmp_path)
+    session1 = _make_session(tmp_path)
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session1.agent_name / "state"
+    )
+
+    # Configure stub: both plans' first steps complete, but freeze
+    # before step 2 by making step 2 hang via a delaying behaviour.
+    # We want the plans to be "in flight" when we cancel.
+    pending_step_2 = asyncio.Event()
+    original_run = _StubRouterLoop.run
+
+    async def hanging_run(self, *, user_text, history):
+        # Step 1 completes immediately; step 2 hangs forever until
+        # the test cancels it.
+        if user_text.endswith("-step-2"):
+            await pending_step_2.wait()  # never set in this test
+        return await original_run(self, user_text=user_text, history=history)
+
+    monkeypatch.setattr(_StubRouterLoop, "run", hanging_run)
+
+    # Dispatch 2 plans concurrently.
+    res1, res2 = await asyncio.gather(
+        dispatch_plan_tool(
+            args=_plan_args("alpha", n_steps=2),
+            parent_host=session1, chain_id="t0",
+            available_tool_names=set(),
+        ),
+        dispatch_plan_tool(
+            args=_plan_args("beta", n_steps=2),
+            parent_host=session1, chain_id="t0",
+            available_tool_names=set(),
+        ),
+    )
+    p1, p2 = res1["plan_id"], res2["plan_id"]
+
+    # Wait for step 1 of each plan to complete (= snapshots get s1
+    # results) then "crash".
+    for _ in range(50):
+        reg_check = PlanRegistry(
+            agent_name=session1.agent_name,
+            agent_state_dir=agent_state_dir,
+        )
+        reg_check.load_active()
+        snap1 = reg_check.get(p1)
+        snap2 = reg_check.get(p2)
+        if (
+            snap1 is not None
+            and snap2 is not None
+            and "s1" in snap1.step_results
+            and "s1" in snap2.step_results
+        ):
+            break
+        await asyncio.sleep(0.05)
+
+    # Simulate crash: cancel all running plan tasks. This drops the
+    # in-memory ChatSession but leaves disk state intact.
+    for task in list(session1.running_plans.values()):
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(
+        *session1.running_plans.values(), return_exceptions=True,
+    )
+
+    # Verify both per-plan snapshots survived on disk with s1 results.
+    reg_post = PlanRegistry(
+        agent_name=session1.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg_post.load_active()
+    snap_p1 = reg_post.get(p1)
+    snap_p2 = reg_post.get(p2)
+    assert snap_p1 is not None and snap_p2 is not None
+    assert "s1" in snap_p1.step_results
+    assert "s1" in snap_p2.step_results
+
+    # Verify no cross-plan contamination (= each plan's s1 result
+    # references its own goal text via _StubRouterLoop emission).
+    assert "alpha" in snap_p1.step_results["s1"]
+    assert "beta" in snap_p2.step_results["s1"]
+    assert "alpha" not in snap_p2.step_results["s1"]
+    assert "beta" not in snap_p1.step_results["s1"]
+
+    # Verify both per-plan decomposition artifacts persist for resume.
+    assert (decomposition_dir(agent_state_dir, p1) / "decomposition.json").exists()
+    assert (decomposition_dir(agent_state_dir, p2) / "decomposition.json").exists()
+
+    # The full restart-via-AgentRegistry flow is exercised by
+    # test_plan_dispatch_artifact and the existing auto-resume tests;
+    # here we verify the *durability* invariant which is the
+    # multi-plan-specific concern. Cross-plan event interleaving is
+    # implicit in the snapshot independence above.
+
+
+# ── WAL event interleaving ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_plans_wal_events_interleave_correctly(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: concurrent plans' WAL events interleave by seq order;
+    the analyzer can deterministically disambiguate by plan_id
+    (= no event mis-attribution)."""
+    from reyn.chat.planner import dispatch_plan_tool
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    res1, res2 = await asyncio.gather(
+        dispatch_plan_tool(
+            args=_plan_args("alpha", n_steps=2),
+            parent_host=session, chain_id="t0",
+            available_tool_names=set(),
+        ),
+        dispatch_plan_tool(
+            args=_plan_args("beta", n_steps=2),
+            parent_host=session, chain_id="t0",
+            available_tool_names=set(),
+        ),
+    )
+    p1, p2 = res1["plan_id"], res2["plan_id"]
+    await _drain(session)
+
+    # Read the WAL and verify:
+    # 1. Every plan_step_* event has a plan_id matching one of the two.
+    # 2. Sequence is monotonic.
+    # 3. Each plan has the expected events (started + 2× step_started +
+    #    2× step_completed + completed).
+    events = list(session._state_log.iter_from(0))
+    seqs = [e["seq"] for e in events if "seq" in e]
+    assert seqs == sorted(seqs)
+
+    by_plan: dict[str, list[str]] = {p1: [], p2: []}
+    for e in events:
+        kind = e.get("kind")
+        plan_id = e.get("plan_id")
+        if not kind or not kind.startswith("plan"):
+            continue
+        if plan_id in by_plan:
+            by_plan[plan_id].append(kind)
+
+    expected_kinds = [
+        "plan_started",
+        "plan_step_started", "plan_step_completed",
+        "plan_step_started", "plan_step_completed",
+        "plan_completed",
+    ]
+    assert by_plan[p1] == expected_kinds
+    assert by_plan[p2] == expected_kinds
+
+
+# ── chain_id isolation ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_per_plan_chain_id_propagates_to_step_events(tmp_path, monkeypatch):
+    """Tier 2: each plan's per-plan chain_id reaches the host's
+    record_plan_started call (= R-D14 cross-agent notify can target
+    the right waiter on /plan discard)."""
+    from reyn.chat.planner import dispatch_plan_tool
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    res1, res2 = await asyncio.gather(
+        dispatch_plan_tool(
+            args=_plan_args("alpha"),
+            parent_host=session, chain_id="t0",
+            available_tool_names=set(),
+        ),
+        dispatch_plan_tool(
+            args=_plan_args("beta"),
+            parent_host=session, chain_id="t0",
+            available_tool_names=set(),
+        ),
+    )
+    p1 = res1["plan_id"]
+    p2 = res2["plan_id"]
+    await _drain(session)
+
+    # PlanRegistry-side snapshot persists per-plan chain_id.
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    # After completion the snapshot is gone, but we can verify the
+    # WAL preserved each plan's distinct flow. record_plan_aborted
+    # was never called → no aborted events expected.
+    events = list(session._state_log.iter_from(0))
+    aborted = [e for e in events if e.get("kind") == "plan_aborted"]
+    assert aborted == []
+    # Both plans started + completed cleanly.
+    started = {
+        e["plan_id"] for e in events if e.get("kind") == "plan_started"
+    }
+    completed = {
+        e["plan_id"] for e in events if e.get("kind") == "plan_completed"
+    }
+    assert started == {p1, p2}
+    assert completed == {p1, p2}

--- a/tests/test_plan_registry.py
+++ b/tests/test_plan_registry.py
@@ -1,0 +1,305 @@
+"""Tier 2: PlanRegistry lifecycle + snapshot mutations (ADR-0023 §3.1).
+
+Step 3 of the Phase 2 migration path. Mirrors test_skill_registry.py
+shape — start, complete, step mutations, load_active.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan import (
+    PlanRegistry,
+    PlanSnapshot,
+    decomposition_dir,
+    plan_snapshot_path,
+    write_decomposition,
+)
+
+
+def _make_registry(tmp_path: Path) -> PlanRegistry:
+    return PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+
+
+def _sample_plan() -> Plan:
+    return Plan(
+        goal="g",
+        steps=(
+            PlanStep("s1", "first", ()),
+            PlanStep("s2", "second", (), depends_on=()),
+        ),
+    )
+
+
+# ── start ─────────────────────────────────────────────────────────────────
+
+
+def test_start_creates_snapshot_file(tmp_path: Path) -> None:
+    """Tier 2: start saves the snapshot at the documented path."""
+    reg = _make_registry(tmp_path)
+    snap = reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    assert snap.plan_id == "p001"
+    assert plan_snapshot_path(tmp_path, "p001").exists()
+    assert reg.get("p001") is snap
+
+
+def test_start_stamps_applied_seq_and_truncation_watermark(tmp_path: Path) -> None:
+    """Tier 2: start initializes both applied_seq and last_step_applied_seq
+    to the WAL seq the caller received from plan_started (= ADR-0023 §3.1
+    initial stamp behaviour)."""
+    reg = _make_registry(tmp_path)
+    snap = reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=42)
+    assert snap.applied_seq == 42
+    assert snap.last_step_applied_seq == 42
+
+
+def test_start_records_decomposition_and_steps(tmp_path: Path) -> None:
+    """Tier 2: start carries decomposition_artifact_path + steps_serialized
+    (= snapshot-side fallback when artifact unreadable)."""
+    reg = _make_registry(tmp_path)
+    serialized = [{"id": "s1", "description": "d", "tools": [], "depends_on": []}]
+    snap = reg.start(
+        plan_id="p001",
+        chain_id="c1",
+        goal="g",
+        applied_seq=1,
+        decomposition_artifact_path="/abs/path/decomposition.json",
+        steps_serialized=serialized,
+    )
+    assert snap.decomposition_artifact_path == "/abs/path/decomposition.json"
+    assert snap.steps_serialized == serialized
+
+
+def test_start_idempotent_overwrites_in_memory_cache(tmp_path: Path) -> None:
+    """Tier 2: starting the same plan_id twice replaces the in-memory entry
+    (= mirrors SkillRegistry.start defensive overwrite)."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g1", applied_seq=1)
+    snap2 = reg.start(plan_id="p001", chain_id="c2", goal="g2", applied_seq=10)
+    assert reg.get("p001") is snap2
+    assert reg.get("p001").goal == "g2"
+
+
+# ── step mutations ────────────────────────────────────────────────────────
+
+
+def test_record_step_started_sets_current_step_no_truncation_bump(tmp_path: Path) -> None:
+    """Tier 2: step_started updates current_step_id and applied_seq, but
+    does NOT bump last_step_applied_seq (= mirror SkillRegistry's
+    step_started non-bump per ADR-0023 §3.1)."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    reg.record_step_started(plan_id="p001", step_id="s1", applied_seq=15)
+    snap = reg.get("p001")
+    assert snap.current_step_id == "s1"
+    assert snap.applied_seq == 15
+    assert snap.last_step_applied_seq == 10  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_record_step_completed_bumps_truncation_watermark(tmp_path: Path) -> None:
+    """Tier 2: step_completed bumps both applied_seq and last_step_applied_seq
+    (= durable progress, gates WAL truncation)."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    reg.record_step_started(plan_id="p001", step_id="s1", applied_seq=15)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text="hello world",
+    )
+    snap = reg.get("p001")
+    assert snap.applied_seq == 20
+    assert snap.last_step_applied_seq == 20
+    assert snap.step_results == {"s1": "hello world"}
+    assert snap.last_committed_step_id == "s1"
+    assert snap.current_step_id is None  # cleared
+
+
+@pytest.mark.asyncio
+async def test_record_step_completed_bounds_long_result(tmp_path: Path) -> None:
+    """Tier 2: step_results entries are bounded so a multi-page scrape
+    doesn't blow up the snapshot file (= ADR-0023 Open issues: Step result
+    size cap)."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    huge = "x" * 100_000
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text=huge,
+    )
+    snap = reg.get("p001")
+    assert len(snap.step_results["s1"]) <= 32_768
+    assert snap.step_results["s1"].endswith("[truncated]")
+
+
+@pytest.mark.asyncio
+async def test_record_step_failed_records_error_and_bumps_watermark(tmp_path: Path) -> None:
+    """Tier 2: step_failed bumps last_step_applied_seq (conservative — a
+    recorded failure is real progress, prevents stale-WAL replay)."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    reg.record_step_started(plan_id="p001", step_id="s1", applied_seq=15)
+    await reg.record_step_failed(
+        plan_id="p001", step_id="s1", applied_seq=20,
+        error_repr="RuntimeError('boom')",
+    )
+    snap = reg.get("p001")
+    assert snap.last_step_applied_seq == 20
+    assert snap.step_failures == {"s1": "RuntimeError('boom')"}
+    assert snap.current_step_id is None
+
+
+def test_record_child_spawned_tracks_step_to_child_mapping(tmp_path: Path) -> None:
+    """Tier 2: spawned_skill_run_ids maps step_id → child_run_id, used by
+    the resume coordinator for adopt/cancel decisions."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    reg.record_child_spawned(plan_id="p001", step_id="s1", child_run_id="child_xyz")
+    snap = reg.get("p001")
+    assert snap.spawned_skill_run_ids == {"s1": "child_xyz"}
+
+
+def test_record_methods_no_op_for_unknown_plan_id(tmp_path: Path) -> None:
+    """Tier 2: mutation methods are defensive — unknown plan_id logs and
+    returns without raising (= safe under WAL replay edge cases)."""
+    reg = _make_registry(tmp_path)
+    # No start() call; record_* should be no-op.
+    reg.record_step_started(plan_id="nonexistent", step_id="s1", applied_seq=1)
+    reg.record_child_spawned(plan_id="nonexistent", step_id="s1", child_run_id="x")
+    assert reg.list_active() == []
+
+
+# ── complete ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_complete_removes_snapshot_file_and_artifact(tmp_path: Path) -> None:
+    """Tier 2: complete deletes both the snapshot file AND the
+    decomposition artifact (= P5 cleanup per ADR-0023 §3.4 finally)."""
+    reg = _make_registry(tmp_path)
+    write_decomposition(tmp_path, "p001", _sample_plan())
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+
+    await reg.complete(plan_id="p001")
+
+    assert not plan_snapshot_path(tmp_path, "p001").exists()
+    assert not (decomposition_dir(tmp_path, "p001") / "decomposition.json").exists()
+    assert reg.get("p001") is None
+    assert reg.list_active() == []
+
+
+@pytest.mark.asyncio
+async def test_complete_preserves_artifact_when_requested(tmp_path: Path) -> None:
+    """Tier 2: delete_artifact=False preserves the decomposition for
+    forensics."""
+    reg = _make_registry(tmp_path)
+    write_decomposition(tmp_path, "p001", _sample_plan())
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+
+    await reg.complete(plan_id="p001", delete_artifact=False)
+
+    assert not plan_snapshot_path(tmp_path, "p001").exists()
+    assert (decomposition_dir(tmp_path, "p001") / "decomposition.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_complete_idempotent_on_unknown_plan(tmp_path: Path) -> None:
+    """Tier 2: complete on an unknown plan_id is safe (= AgentRegistry
+    cleanup may call this on snapshots that were already deleted)."""
+    reg = _make_registry(tmp_path)
+    await reg.complete(plan_id="nonexistent")  # no raise
+    await reg.complete(plan_id="nonexistent", status="aborted")  # no raise
+
+
+# ── load_active ───────────────────────────────────────────────────────────
+
+
+def test_load_active_discovers_existing_snapshots(tmp_path: Path) -> None:
+    """Tier 2: load_active populates the in-memory cache from disk
+    (= startup recovery before any new activity)."""
+    reg1 = _make_registry(tmp_path)
+    reg1.start(plan_id="p001", chain_id="c1", goal="g1", applied_seq=10)
+    reg1.start(plan_id="p002", chain_id="c2", goal="g2", applied_seq=20)
+
+    # Fresh registry — no in-memory state until load_active.
+    reg2 = _make_registry(tmp_path)
+    assert reg2.list_active() == []
+    loaded = reg2.load_active()
+    assert set(loaded.keys()) == {"p001", "p002"}
+    assert reg2.get("p001").goal == "g1"
+    assert reg2.get("p002").goal == "g2"
+
+
+def test_load_active_skips_corrupt_files(tmp_path: Path) -> None:
+    """Tier 2: corrupt snapshot files are skipped with a warning, not
+    crashing load_active (= WAL is source of truth, replay rebuilds)."""
+    reg1 = _make_registry(tmp_path)
+    reg1.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+
+    # Corrupt a sibling file.
+    corrupt_path = plan_snapshot_path(tmp_path, "corrupt")
+    corrupt_path.parent.mkdir(parents=True, exist_ok=True)
+    corrupt_path.write_text("xxx not a snapshot xxx", encoding="utf-8")
+
+    reg2 = _make_registry(tmp_path)
+    loaded = reg2.load_active()
+    # Corrupt file loads as empty (mirror SkillSnapshot.load resilience),
+    # so it's still in the cache but with default fields. The key
+    # invariant is: no crash + valid plans still load.
+    assert "p001" in loaded
+    assert loaded["p001"].goal == "g"
+
+
+# ── truncate hook ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_truncate_hook_fires_on_step_completed_and_complete(tmp_path: Path) -> None:
+    """Tier 2: truncate_eligible_hook fires after durable mutations
+    (step_completed, step_failed, complete) — mirrors SkillRegistry."""
+    fired: list[str] = []
+
+    async def hook() -> None:
+        fired.append("hit")
+
+    reg = PlanRegistry(
+        agent_name="default", agent_state_dir=tmp_path,
+        truncate_eligible_hook=hook,
+    )
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    # start does NOT fire hook (= no durable progress); record_step_started doesn't either.
+    reg.record_step_started(plan_id="p001", step_id="s1", applied_seq=15)
+    assert fired == []
+
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text="x",
+    )
+    assert fired == ["hit"]
+
+    await reg.record_step_failed(
+        plan_id="p001", step_id="s2", applied_seq=25,
+        error_repr="boom",
+    )
+    assert fired == ["hit", "hit"]
+
+    await reg.complete(plan_id="p001")
+    assert fired == ["hit", "hit", "hit"]
+
+
+@pytest.mark.asyncio
+async def test_truncate_hook_exceptions_swallowed(tmp_path: Path) -> None:
+    """Tier 2: hook raising an exception doesn't break the registry
+    (= truncation is opportunistic)."""
+    async def bad_hook() -> None:
+        raise RuntimeError("boom")
+
+    reg = PlanRegistry(
+        agent_name="default", agent_state_dir=tmp_path,
+        truncate_eligible_hook=bad_hook,
+    )
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    # Should not raise.
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text="x",
+    )
+    await reg.complete(plan_id="p001")

--- a/tests/test_plan_registry.py
+++ b/tests/test_plan_registry.py
@@ -286,6 +286,117 @@ async def test_truncate_hook_fires_on_step_completed_and_complete(tmp_path: Path
     assert fired == ["hit", "hit", "hit"]
 
 
+# ── reset_from_step (= /plan resume escape hatch) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_from_step_clears_results_from_target_onward(tmp_path: Path) -> None:
+    """Tier 2: reset_from_step clears step_results / step_failures /
+    spawned_skill_run_ids for the target step and every step after it
+    in topological order. Steps before are preserved (= memo replay
+    on next launch)."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15, result_text="r1",
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s2", applied_seq=20, result_text="r2",
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s3", applied_seq=25, result_text="r3",
+    )
+    reg.record_child_spawned(
+        plan_id="p001", step_id="s2", child_run_id="child_s2",
+    )
+
+    ok = reg.reset_from_step(
+        plan_id="p001", from_step_id="s2",
+        step_order=["s1", "s2", "s3"],
+    )
+    assert ok is True
+
+    snap = reg.get("p001")
+    # s1 preserved
+    assert snap.step_results.get("s1") == "r1"
+    # s2, s3 cleared
+    assert "s2" not in snap.step_results
+    assert "s3" not in snap.step_results
+    # spawned_skill_run_ids cleared for s2 too
+    assert "s2" not in snap.spawned_skill_run_ids
+    # last_committed_step_id rewinds to s1 (= step before from_step_id)
+    assert snap.last_committed_step_id == "s1"
+    assert snap.current_step_id is None
+
+
+def test_reset_from_step_first_step_clears_everything(tmp_path: Path) -> None:
+    """Tier 2: from_step_id == head step → all results cleared,
+    last_committed_step_id resets to None."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    snap = reg.get("p001")
+    snap.step_results["s1"] = "r1"
+    snap.step_results["s2"] = "r2"
+    snap.last_committed_step_id = "s2"
+
+    ok = reg.reset_from_step(
+        plan_id="p001", from_step_id="s1", step_order=["s1", "s2"],
+    )
+    assert ok is True
+    snap = reg.get("p001")
+    assert snap.step_results == {}
+    assert snap.last_committed_step_id is None
+
+
+def test_reset_from_step_unknown_plan_returns_false(tmp_path: Path) -> None:
+    """Tier 2: unknown plan_id → False, no mutation."""
+    reg = _make_registry(tmp_path)
+    ok = reg.reset_from_step(
+        plan_id="nonexistent", from_step_id="s1", step_order=["s1"],
+    )
+    assert ok is False
+
+
+def test_reset_from_step_unknown_step_returns_false(tmp_path: Path) -> None:
+    """Tier 2: from_step_id not in step_order → False, no mutation."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    snap = reg.get("p001")
+    snap.step_results["s1"] = "r1"
+
+    ok = reg.reset_from_step(
+        plan_id="p001", from_step_id="nonexistent",
+        step_order=["s1", "s2"],
+    )
+    assert ok is False
+    # Snapshot unchanged
+    assert reg.get("p001").step_results == {"s1": "r1"}
+
+
+@pytest.mark.asyncio
+async def test_reset_from_step_persists_to_disk(tmp_path: Path) -> None:
+    """Tier 2: mutated snapshot is persisted before return so a crash
+    mid-reset doesn't leave inconsistent state."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15, result_text="r1",
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s2", applied_seq=20, result_text="r2",
+    )
+
+    reg.reset_from_step(
+        plan_id="p001", from_step_id="s2", step_order=["s1", "s2"],
+    )
+
+    # Reload from disk into a fresh registry — confirms persistence.
+    reg2 = _make_registry(tmp_path)
+    reg2.load_active()
+    snap2 = reg2.get("p001")
+    assert snap2.step_results == {"s1": "r1"}
+
+
 @pytest.mark.asyncio
 async def test_truncate_hook_exceptions_swallowed(tmp_path: Path) -> None:
     """Tier 2: hook raising an exception doesn't break the registry

--- a/tests/test_plan_registry.py
+++ b/tests/test_plan_registry.py
@@ -117,10 +117,14 @@ async def test_record_step_completed_bumps_truncation_watermark(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_record_step_completed_bounds_long_result(tmp_path: Path) -> None:
-    """Tier 2: step_results entries are bounded so a multi-page scrape
-    doesn't blow up the snapshot file (= ADR-0023 Open issues: Step result
-    size cap)."""
+async def test_record_step_completed_spills_long_result_to_file(tmp_path: Path) -> None:
+    """Tier 2: ADR-0024 — step results > 32 KB spill to a per-plan
+    workspace file (= state/plans/<plan_id>/step_results/<step_id>.txt)
+    and snapshot.step_results does NOT contain the entry; instead
+    snapshot.step_result_refs holds the relative path. Full text is
+    preserved (no [truncated] suffix)."""
+    from reyn.plan import get_step_result, step_result_file_path
+
     reg = _make_registry(tmp_path)
     reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
     huge = "x" * 100_000
@@ -128,8 +132,79 @@ async def test_record_step_completed_bounds_long_result(tmp_path: Path) -> None:
         plan_id="p001", step_id="s1", applied_seq=20, result_text=huge,
     )
     snap = reg.get("p001")
-    assert len(snap.step_results["s1"]) <= 32_768
-    assert snap.step_results["s1"].endswith("[truncated]")
+    # Inline dict does NOT contain s1 (= spilled, not inline).
+    assert "s1" not in snap.step_results
+    # Ref dict has the relative path.
+    assert snap.step_result_refs["s1"] == "step_results/s1.txt"
+    # File on disk contains the full text (= no truncation).
+    spilled_path = step_result_file_path(tmp_path, "p001", "s1")
+    assert spilled_path.exists()
+    assert spilled_path.read_text(encoding="utf-8") == huge
+    # Read accessor returns the full text transparently.
+    assert get_step_result(snap, tmp_path, "s1") == huge
+
+
+@pytest.mark.asyncio
+async def test_record_step_completed_inline_for_small_result(tmp_path: Path) -> None:
+    """Tier 2: ADR-0024 — small step results stay inline on
+    snapshot.step_results without touching the file system (= cheap
+    read path for chat-like steps)."""
+    from reyn.plan import step_result_file_path
+
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    small = "short reply"
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text=small,
+    )
+    snap = reg.get("p001")
+    assert snap.step_results["s1"] == small
+    assert "s1" not in snap.step_result_refs
+    # No file written for small results.
+    assert not step_result_file_path(tmp_path, "p001", "s1").exists()
+
+
+@pytest.mark.asyncio
+async def test_record_step_completed_re_run_clears_stale_inline(tmp_path: Path) -> None:
+    """Tier 2: re-running a step that previously was small with a now-
+    large output spills to file AND removes the stale inline entry."""
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15, result_text="small",
+    )
+    huge = "x" * 50_000
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text=huge,
+    )
+    snap = reg.get("p001")
+    assert "s1" not in snap.step_results          # stale inline cleared
+    assert snap.step_result_refs["s1"] == "step_results/s1.txt"
+
+
+@pytest.mark.asyncio
+async def test_record_step_completed_re_run_clears_stale_spill(tmp_path: Path) -> None:
+    """Tier 2: re-running a previously spilled step with a small result
+    moves to inline AND deletes the stale spilled file."""
+    from reyn.plan import step_result_file_path
+
+    reg = _make_registry(tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    huge = "x" * 50_000
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15, result_text=huge,
+    )
+    spilled_path = step_result_file_path(tmp_path, "p001", "s1")
+    assert spilled_path.exists()
+
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text="small",
+    )
+    snap = reg.get("p001")
+    assert snap.step_results["s1"] == "small"
+    assert "s1" not in snap.step_result_refs
+    # Stale spilled file deleted.
+    assert not spilled_path.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plan_resume_analyzer.py
+++ b/tests/test_plan_resume_analyzer.py
@@ -1,0 +1,223 @@
+"""Tier 2: PlanResumeAnalyzer (ADR-0023 §3.2 Phase 2 step 7a).
+
+Pairs WAL plan_step_* events + PlanSnapshot into a PlanResumePlan with
+4-state per-step union: pending / completed_with_result / failed /
+interrupted_with_child.
+"""
+from __future__ import annotations
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan import (
+    PlanResumeAnalyzer,
+    PlanResumePlan,
+    PlanSnapshot,
+)
+
+
+def _decomp() -> Plan:
+    return Plan(
+        goal="g",
+        steps=(
+            PlanStep("s1", "first", ()),
+            PlanStep("s2", "second", (), depends_on=("s1",)),
+            PlanStep("s3", "third", (), depends_on=("s2",)),
+        ),
+    )
+
+
+def _empty_snap() -> PlanSnapshot:
+    return PlanSnapshot.empty(
+        plan_id="p001", agent_name="default", chain_id="c0", goal="g",
+    )
+
+
+# ── 4-state pairing ──────────────────────────────────────────────────────
+
+
+def test_no_events_all_pending() -> None:
+    """Tier 2: a plan with no step events yields all-pending state_states."""
+    analyzer = PlanResumeAnalyzer()
+    rp = analyzer.analyze(
+        snapshot=_empty_snap(), decomposition=_decomp(), wal_events=[],
+    )
+    assert rp.n_steps == 3
+    assert all(s.state == "pending" for s in rp.step_states)
+    assert rp.pending_step_ids == ("s1", "s2", "s3")
+    assert rp.has_ambiguity is False
+
+
+def test_started_completed_pair_yields_completed_state() -> None:
+    """Tier 2: started+completed pair → completed_with_result; result_text
+    pulled from snapshot.step_results."""
+    snap = _empty_snap()
+    snap.step_results["s1"] = "step one output"
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_completed", "plan_id": "p001",
+         "step_id": "s1", "content_len": 16},
+    ]
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=_decomp(), wal_events=events,
+    )
+    s1 = next(s for s in rp.step_states if s.step_id == "s1")
+    assert s1.state == "completed_with_result"
+    assert s1.result_text == "step one output"
+    assert rp.committed_step_ids == frozenset({"s1"})
+    assert rp.step_result_map() == {"s1": "step one output"}
+
+
+def test_started_failed_pair_yields_failed_state() -> None:
+    """Tier 2: started+failed pair → failed with error_message."""
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_failed", "plan_id": "p001",
+         "step_id": "s1", "error": "RuntimeError('boom')"},
+    ]
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=_empty_snap(), decomposition=_decomp(), wal_events=events,
+    )
+    s1 = next(s for s in rp.step_states if s.step_id == "s1")
+    assert s1.state == "failed"
+    assert "boom" in (s1.error_message or "")
+    assert rp.failed_step_ids == ("s1",)
+
+
+def test_started_no_terminal_non_effectful_yields_pending() -> None:
+    """Tier 2: started without terminal + non-effectful tools → pending
+    (= safe to re-execute)."""
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+    ]
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=_empty_snap(), decomposition=_decomp(), wal_events=events,
+    )
+    s1 = next(s for s in rp.step_states if s.step_id == "s1")
+    assert s1.state == "pending"
+    assert s1.is_effectful is False
+
+
+def test_started_no_terminal_effectful_yields_failed_ambiguous() -> None:
+    """Tier 2: started without terminal + effectful tools → failed with
+    error_kind="ambiguous_no_terminal" (= prevents silent double-write)."""
+    decomp = Plan(
+        goal="g",
+        steps=(PlanStep("s1", "writer", tools=("write_file",)),),
+    )
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+    ]
+    snap = _empty_snap()
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=decomp, wal_events=events,
+    )
+    s1 = rp.step_states[0]
+    assert s1.state == "failed"
+    assert s1.error_kind == "ambiguous_no_terminal"
+    assert s1.is_effectful is True
+    assert rp.has_ambiguity is True
+
+
+def test_started_no_terminal_with_child_yields_interrupted_with_child() -> None:
+    """Tier 2: invoke_skill step started + spawned child snapshot recorded
+    → interrupted_with_child state."""
+    decomp = Plan(
+        goal="g",
+        steps=(PlanStep("s1", "delegate", tools=("invoke_skill",)),),
+    )
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+    ]
+    snap = _empty_snap()
+    snap.spawned_skill_run_ids["s1"] = "child_xyz"
+
+    looked_up = {"child_xyz": "in_flight"}
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=decomp, wal_events=events,
+        child_skill_lookup=lambda rid: looked_up.get(rid, "unknown"),
+    )
+    s1 = rp.step_states[0]
+    assert s1.state == "interrupted_with_child"
+    assert s1.child_run_id == "child_xyz"
+    assert s1.child_state == "in_flight"
+    assert rp.has_in_flight_child is True
+    assert rp.has_ambiguity is True
+    assert rp.interrupted_with_child_step_ids == ("s1",)
+
+
+def test_child_state_unknown_when_lookup_omitted() -> None:
+    """Tier 2: when child_skill_lookup is None, child_state defaults to
+    'unknown' so coordinator can default-cancel."""
+    decomp = Plan(
+        goal="g",
+        steps=(PlanStep("s1", "delegate", tools=("invoke_skill",)),),
+    )
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+    ]
+    snap = _empty_snap()
+    snap.spawned_skill_run_ids["s1"] = "child_xyz"
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=decomp, wal_events=events,
+    )
+    assert rp.step_states[0].child_state == "unknown"
+
+
+# ── filtering ────────────────────────────────────────────────────────────
+
+
+def test_analyzer_filters_other_plan_ids() -> None:
+    """Tier 2: events for a different plan_id are ignored."""
+    events = [
+        # different plan_id — should be ignored
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "OTHER", "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_completed", "plan_id": "OTHER",
+         "step_id": "s1", "content_len": 1},
+        # this plan
+        {"seq": 3, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+        {"seq": 4, "kind": "plan_step_completed", "plan_id": "p001",
+         "step_id": "s1", "content_len": 1},
+    ]
+    snap = _empty_snap()
+    snap.step_results["s1"] = "ok"
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=_decomp(), wal_events=events,
+    )
+    assert rp.step_states[0].state == "completed_with_result"
+
+
+def test_analyzer_carries_decomposition_artifact_path() -> None:
+    """Tier 2: PlanResumePlan exposes the snapshot's
+    decomposition_artifact_path so the runtime can reload from SSoT."""
+    snap = _empty_snap()
+    snap.decomposition_artifact_path = "/abs/path/decomposition.json"
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=_decomp(), wal_events=[],
+    )
+    assert rp.decomposition_artifact_path == "/abs/path/decomposition.json"
+
+
+# ── multi-step combination ───────────────────────────────────────────────
+
+
+def test_mixed_states_across_three_steps() -> None:
+    """Tier 2: realistic crash mid-step-3 — s1 completed, s2 failed, s3
+    pending (= no events for it yet)."""
+    snap = _empty_snap()
+    snap.step_results["s1"] = "first output"
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_completed", "plan_id": "p001",
+         "step_id": "s1", "content_len": 12},
+        {"seq": 3, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s2"},
+        {"seq": 4, "kind": "plan_step_failed", "plan_id": "p001",
+         "step_id": "s2", "error": "boom"},
+    ]
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=_decomp(), wal_events=events,
+    )
+    states = {s.step_id: s.state for s in rp.step_states}
+    assert states == {
+        "s1": "completed_with_result",
+        "s2": "failed",
+        "s3": "pending",
+    }

--- a/tests/test_plan_resume_coordinator.py
+++ b/tests/test_plan_resume_coordinator.py
@@ -1,0 +1,372 @@
+"""Tier 2: PlanResumeCoordinator decisions + apply (ADR-0023 §3.3 Phase 2 step 7c).
+
+Pins:
+  - decide_for_plan: all-complete → resume; default → retry_pending; discard config → discard
+  - discover_and_decide: missing/corrupt artifact → forced discard
+  - apply_decisions: cancels flagged children, calls plan_registry.complete on discard
+  - build_plan_resume_config: yaml schema parsing with aliases + invalid-value fallback
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan import (
+    PlanRegistry,
+    PlanResumeConfig,
+    PlanResumeCoordinator,
+    PlanResumeDecision,
+    PlanResumePlan,
+    PlanStepState,
+    build_plan_resume_config,
+    write_decomposition,
+)
+
+
+def _decomp() -> Plan:
+    return Plan(
+        goal="g",
+        steps=(PlanStep("s1", "first", ()), PlanStep("s2", "second", ())),
+    )
+
+
+# ── build_plan_resume_config ──────────────────────────────────────────────
+
+
+def test_build_config_default_when_raw_none() -> None:
+    """Tier 2: missing reyn.yaml block yields default config."""
+    cfg = build_plan_resume_config(None)
+    assert cfg.default == "retry_pending"
+
+
+def test_build_config_accepts_documented_aliases() -> None:
+    """Tier 2: yaml accepts retry_pending_steps / discard_plan synonyms,
+    coordinator normalizes internally."""
+    cfg1 = build_plan_resume_config({"default": "retry_pending_steps"})
+    assert cfg1.default == "retry_pending"
+    cfg2 = build_plan_resume_config({"default": "discard_plan"})
+    assert cfg2.default == "discard"
+
+
+def test_build_config_invalid_top_level_falls_back_to_default() -> None:
+    """Tier 2: unknown ``default`` value logs warning + falls back to
+    builtin default (= mirror _build_skill_resume_config)."""
+    cfg = build_plan_resume_config({"default": "invalid_x"})
+    assert cfg.default == "retry_pending"
+
+
+def test_build_config_child_purity_partial_override() -> None:
+    """Tier 2: known purity keys override; unknown keys / invalid actions
+    are logged + skipped, leaving the rest at their defaults."""
+    cfg = build_plan_resume_config({
+        "child_purity": {
+            "pure": "adopt",            # override
+            "unknown_key": "adopt",      # skipped
+            "world": "garbage",          # invalid action — skipped
+        }
+    })
+    assert cfg.child_purity["pure"] == "adopt"
+    assert cfg.child_purity["world"] == "adopt"  # default unchanged
+
+
+# ── decide_for_plan ───────────────────────────────────────────────────────
+
+
+def test_decide_returns_resume_when_all_steps_complete() -> None:
+    """Tier 2: every step in completed_with_result → action=resume (=
+    finalize aggregation, no re-execute)."""
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=2, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result", result_text="r1"),
+            PlanStepState(step_id="s2", state="completed_with_result", result_text="r2"),
+        ),
+    )
+    coord = PlanResumeCoordinator()
+    decision = coord.decide_for_plan(rp)
+    assert decision.action == "resume"
+
+
+def test_decide_returns_retry_pending_when_default_policy() -> None:
+    """Tier 2: default policy ``retry_pending`` produces that action with
+    pending_step_ids carrying the unfinished steps."""
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=2, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result", result_text="r1"),
+            PlanStepState(step_id="s2", state="pending"),
+        ),
+    )
+    coord = PlanResumeCoordinator()
+    decision = coord.decide_for_plan(rp)
+    assert decision.action == "retry_pending"
+    assert decision.pending_step_ids == ("s2",)
+
+
+def test_decide_returns_discard_when_config_says_discard() -> None:
+    """Tier 2: PlanResumeConfig(default="discard") → coordinator chooses
+    discard for any not-fully-complete plan."""
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=2, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result", result_text="r1"),
+            PlanStepState(step_id="s2", state="pending"),
+        ),
+    )
+    coord = PlanResumeCoordinator(config=PlanResumeConfig(default="discard"))
+    decision = coord.decide_for_plan(rp)
+    assert decision.action == "discard"
+
+
+def test_decide_default_adopts_in_flight_children() -> None:
+    """Tier 2: retry_pending policy adopts in-flight children (= leave
+    for skill auto-resume to recover; coordinator doesn't cancel them)."""
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=2, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(
+                step_id="s1", state="interrupted_with_child",
+                child_run_id="child_xyz", child_state="in_flight",
+            ),
+            PlanStepState(step_id="s2", state="pending"),
+        ),
+    )
+    coord = PlanResumeCoordinator()
+    decision = coord.decide_for_plan(rp)
+    assert decision.action == "retry_pending"
+    assert decision.child_actions == {"child_xyz": "adopt"}
+
+
+def test_decide_discard_cancels_children() -> None:
+    """Tier 2: discard policy cancels every child via
+    SkillRegistry.complete(status="discarded")."""
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g",
+        n_steps=2, decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(
+                step_id="s1", state="interrupted_with_child",
+                child_run_id="child_xyz", child_state="in_flight",
+            ),
+            PlanStepState(step_id="s2", state="pending"),
+        ),
+    )
+    coord = PlanResumeCoordinator(config=PlanResumeConfig(default="discard"))
+    decision = coord.decide_for_plan(rp)
+    assert decision.action == "discard"
+    assert decision.child_actions == {"child_xyz": "cancel"}
+
+
+# ── discover_and_decide ───────────────────────────────────────────────────
+
+
+def test_discover_forces_discard_on_missing_artifact(tmp_path: Path) -> None:
+    """Tier 2: missing decomposition artifact → forced discard with
+    descriptive plan stub."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)
+
+    def loader(_plan_id: str) -> Plan:
+        raise FileNotFoundError(_plan_id)
+
+    coord = PlanResumeCoordinator()
+    decisions = coord.discover_and_decide(
+        plan_registry=reg, wal_events=[], decomposition_loader=loader,
+    )
+    assert len(decisions) == 1
+    assert decisions[0].action == "discard"
+
+
+def test_discover_forces_discard_on_corrupt_artifact(tmp_path: Path) -> None:
+    """Tier 2: artifact load raising any exception → forced discard."""
+    from reyn.plan.decomposition import DecompositionCorruptError
+
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)
+
+    def loader(_plan_id: str) -> Plan:
+        raise DecompositionCorruptError("schema drift")
+
+    coord = PlanResumeCoordinator()
+    decisions = coord.discover_and_decide(
+        plan_registry=reg, wal_events=[], decomposition_loader=loader,
+    )
+    assert decisions[0].action == "discard"
+
+
+def test_discover_normal_path_produces_decisions(tmp_path: Path) -> None:
+    """Tier 2: when artifact loads, analyzer runs and decision reflects state."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    snap = reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)
+    snap.step_results["s1"] = "r1"  # mock pre-crash s1 completion
+    plan = _decomp()
+
+    events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001", "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_completed", "plan_id": "p001",
+         "step_id": "s1", "content_len": 2},
+    ]
+
+    def loader(plan_id: str) -> Plan:
+        return plan
+
+    coord = PlanResumeCoordinator()
+    decisions = coord.discover_and_decide(
+        plan_registry=reg, wal_events=events, decomposition_loader=loader,
+    )
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.action == "retry_pending"
+    assert decision.pending_step_ids == ("s2",)
+
+
+# ── apply_decisions ───────────────────────────────────────────────────────
+
+
+class _MockSkillRegistry:
+    def __init__(self) -> None:
+        self.completed_runs: list[tuple[str, str]] = []
+
+    async def complete(self, *, run_id: str, status: str = "completed") -> None:
+        self.completed_runs.append((run_id, status))
+
+
+@pytest.mark.asyncio
+async def test_apply_returns_launchable_subset(tmp_path: Path) -> None:
+    """Tier 2: apply_decisions returns plans for ChatSession to spawn
+    (= action ∈ {resume, retry_pending}); discard plans are excluded."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)
+    reg.start(plan_id="p002", chain_id="c1", goal="g2", applied_seq=20)
+
+    rp1 = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g", n_steps=1,
+        decomposition_artifact_path=None,
+        step_states=(PlanStepState(step_id="s1", state="pending"),),
+    )
+    rp2 = PlanResumePlan(
+        plan_id="p002", chain_id="c1", goal="g2", n_steps=0,
+        decomposition_artifact_path=None,
+    )
+    decisions = [
+        PlanResumeDecision(plan=rp1, action="retry_pending", pending_step_ids=("s1",)),
+        PlanResumeDecision(plan=rp2, action="discard"),
+    ]
+    coord = PlanResumeCoordinator()
+    launchable = await coord.apply_decisions(
+        decisions, plan_registry=reg, skill_registry=None,
+    )
+    assert len(launchable) == 1
+    assert launchable[0].plan.plan_id == "p001"
+
+
+@pytest.mark.asyncio
+async def test_apply_discard_calls_plan_registry_complete(tmp_path: Path) -> None:
+    """Tier 2: discard branch removes the plan via plan_registry.complete
+    so the snapshot is cleaned up."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p002", chain_id="c1", goal="g2", applied_seq=20)
+    rp = PlanResumePlan(
+        plan_id="p002", chain_id="c1", goal="g2", n_steps=0,
+        decomposition_artifact_path=None,
+    )
+    decisions = [
+        PlanResumeDecision(plan=rp, action="discard"),
+    ]
+    coord = PlanResumeCoordinator()
+    await coord.apply_decisions(
+        decisions, plan_registry=reg, skill_registry=None,
+    )
+    assert reg.get("p002") is None
+
+
+@pytest.mark.asyncio
+async def test_apply_cancels_children_flagged_cancel(tmp_path: Path) -> None:
+    """Tier 2: child_actions["cancel"] entries trigger
+    skill_registry.complete(status="discarded") for each."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)
+    skill_reg = _MockSkillRegistry()
+
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g", n_steps=1,
+        decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(
+                step_id="s1", state="interrupted_with_child",
+                child_run_id="child_xyz", child_state="unknown",
+            ),
+        ),
+    )
+    decisions = [
+        PlanResumeDecision(
+            plan=rp, action="retry_pending", pending_step_ids=("s1",),
+            child_actions={"child_xyz": "cancel"},
+        ),
+    ]
+    coord = PlanResumeCoordinator()
+    await coord.apply_decisions(
+        decisions, plan_registry=reg, skill_registry=skill_reg,
+    )
+    assert ("child_xyz", "discarded") in skill_reg.completed_runs
+
+
+@pytest.mark.asyncio
+async def test_apply_adopt_leaves_children_alone(tmp_path: Path) -> None:
+    """Tier 2: adopt children NOT cancelled — left for skill_resume infra."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)
+    skill_reg = _MockSkillRegistry()
+
+    rp = PlanResumePlan(
+        plan_id="p001", chain_id="c0", goal="g", n_steps=1,
+        decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(
+                step_id="s1", state="interrupted_with_child",
+                child_run_id="child_xyz", child_state="in_flight",
+            ),
+        ),
+    )
+    decisions = [
+        PlanResumeDecision(
+            plan=rp, action="retry_pending", pending_step_ids=("s1",),
+            child_actions={"child_xyz": "adopt"},
+        ),
+    ]
+    coord = PlanResumeCoordinator()
+    await coord.apply_decisions(
+        decisions, plan_registry=reg, skill_registry=skill_reg,
+    )
+    assert skill_reg.completed_runs == []  # adopted, not cancelled
+
+
+@pytest.mark.asyncio
+async def test_apply_outbox_notice_fires_on_discard(tmp_path: Path) -> None:
+    """Tier 2: discard branch surfaces an outbox notice for the user."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p002", chain_id="c1", goal="g2", applied_seq=20)
+    notices: list[tuple[str, str]] = []
+
+    async def on_outbox(plan_id: str, message: str) -> None:
+        notices.append((plan_id, message))
+
+    rp = PlanResumePlan(
+        plan_id="p002", chain_id="c1", goal="g2", n_steps=0,
+        decomposition_artifact_path=None,
+    )
+    decisions = [PlanResumeDecision(plan=rp, action="discard")]
+    coord = PlanResumeCoordinator()
+    await coord.apply_decisions(
+        decisions, plan_registry=reg, skill_registry=None,
+        on_outbox_notice=on_outbox,
+    )
+    assert len(notices) == 1
+    assert notices[0][0] == "p002"
+    assert "discarded" in notices[0][1]

--- a/tests/test_plan_runtime.py
+++ b/tests/test_plan_runtime.py
@@ -1,0 +1,162 @@
+"""Tier 2: PlanRuntime thin-wrapper parity (ADR-0023 Phase 2 step 5).
+
+Step 5 ships PlanRuntime as a peer-to-OSRuntime API surface that
+delegates to ``execute_plan`` verbatim. Phase 1 lifecycle behavior must
+survive unchanged so Step 6 can migrate ``dispatch_plan_tool`` to use
+this class without behavior change.
+
+Reuses the _StubRouterLoop fixture from test_plan_lifecycle_crash via
+direct import (= same shape, no real LLM).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan import PlanResumePlan, PlanRuntime
+
+
+# ── stub host (= mirror test_plan_lifecycle_crash._RecordingHost) ───────
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **fields: Any) -> None:
+        self.emitted.append((kind, fields))
+
+
+class _RecordingHost:
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+        self.plan_started_calls: list[dict] = []
+        self.plan_completed_calls: list[dict] = []
+        self.plan_aborted_calls: list[dict] = []
+
+    async def record_plan_started(self, *, plan_id: str, goal: str, n_steps: int) -> None:
+        self.plan_started_calls.append(
+            {"plan_id": plan_id, "goal": goal, "n_steps": n_steps}
+        )
+
+    async def record_plan_completed(self, *, plan_id: str) -> None:
+        self.plan_completed_calls.append({"plan_id": plan_id})
+
+    async def record_plan_aborted(self, *, plan_id: str, reason: str = "") -> None:
+        self.plan_aborted_calls.append({"plan_id": plan_id, "reason": reason})
+
+
+class _StubRouterLoop:
+    _behavior: str = "noop"
+
+    def __init__(self, *, host: Any, **kwargs: Any) -> None:
+        self.host = host
+
+    @property
+    def total_usage(self) -> Any:
+        from reyn.llm.pricing import TokenUsage
+        return TokenUsage()
+
+    async def run(self, *, user_text: str, history: list) -> None:
+        await self.host.put_outbox(kind="agent", text="step output", meta={})
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_router_loop(monkeypatch: Any):
+    import reyn.chat.planner as planner_mod
+
+    monkeypatch.setattr(planner_mod, "RouterLoop", _StubRouterLoop)
+    _StubRouterLoop._behavior = "noop"
+    yield
+
+
+def _simple_plan() -> Plan:
+    return Plan(
+        goal="test goal",
+        steps=(
+            PlanStep(id="s1", description="first", tools=()),
+            PlanStep(id="s2", description="second", tools=(), depends_on=("s1",)),
+        ),
+    )
+
+
+# ── PlanRuntime wrapper parity ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_runtime_run_delegates_to_execute_plan() -> None:
+    """Tier 2: PlanRuntime.run() emits the same plan_started + plan_completed
+    sequence execute_plan does (= behavior parity, Phase 1 invariant)."""
+    host = _RecordingHost()
+    plan = _simple_plan()
+
+    runtime = PlanRuntime(plan, host=host, chain_id="c0")
+    result = await runtime.run()
+
+    assert len(host.plan_started_calls) == 1
+    assert len(host.plan_completed_calls) == 1
+    assert host.plan_aborted_calls == []
+    assert result.text
+
+
+@pytest.mark.asyncio
+async def test_plan_runtime_accepts_optional_constructor_args() -> None:
+    """Tier 2: PlanRuntime accepts plan_id / budget / router_model /
+    resume_plan in its constructor surface (= ADR-0023 §3.4 contract).
+    Step 5 doesn't act on them yet — Steps 6/7 do."""
+    host = _RecordingHost()
+    plan = _simple_plan()
+    runtime = PlanRuntime(
+        plan, host=host, chain_id="c0",
+        plan_id="custom_id_123",
+        budget=None,
+        router_model="strong",
+        resume_plan=None,
+    )
+    assert runtime.plan_id == "custom_id_123"
+    assert runtime.chain_id == "c0"
+    assert runtime.resume_plan is None
+
+
+@pytest.mark.asyncio
+async def test_plan_runtime_run_returns_plan_execution_result() -> None:
+    """Tier 2: PlanRuntime.run returns the same PlanExecutionResult shape
+    execute_plan does."""
+    host = _RecordingHost()
+    plan = _simple_plan()
+    runtime = PlanRuntime(plan, host=host, chain_id="c0")
+    result = await runtime.run()
+
+    # Shape parity with PlanExecutionResult
+    assert hasattr(result, "text")
+    assert hasattr(result, "step_results")
+    assert hasattr(result, "step_failures")
+    assert hasattr(result, "usage")
+
+
+# ── PlanResumePlan dataclass shape ────────────────────────────────────────
+
+
+def test_plan_resume_plan_dataclass_shape() -> None:
+    """Tier 2: PlanResumePlan exposes the documented fields (= analyzer
+    output contract for Step 7). Frozen so accidental mutation surfaces."""
+    rp = PlanResumePlan(
+        plan_id="p001",
+        chain_id="c0",
+        goal="g",
+        committed_step_ids=frozenset({"s1"}),
+        pending_step_ids=("s2",),
+        step_results={"s1": "r1"},
+        in_flight_child_step_id=None,
+    )
+    assert rp.plan_id == "p001"
+    assert "s1" in rp.committed_step_ids
+    assert rp.pending_step_ids == ("s2",)
+    assert rp.step_results == {"s1": "r1"}
+
+    with pytest.raises((AttributeError, Exception)):
+        rp.plan_id = "mutate"  # frozen

--- a/tests/test_plan_runtime.py
+++ b/tests/test_plan_runtime.py
@@ -144,19 +144,23 @@ async def test_plan_runtime_run_returns_plan_execution_result() -> None:
 def test_plan_resume_plan_dataclass_shape() -> None:
     """Tier 2: PlanResumePlan exposes the documented fields (= analyzer
     output contract for Step 7). Frozen so accidental mutation surfaces."""
+    from reyn.plan import PlanStepState
+
     rp = PlanResumePlan(
         plan_id="p001",
         chain_id="c0",
         goal="g",
-        committed_step_ids=frozenset({"s1"}),
-        pending_step_ids=("s2",),
-        step_results={"s1": "r1"},
-        in_flight_child_step_id=None,
+        n_steps=2,
+        decomposition_artifact_path=None,
+        step_states=(
+            PlanStepState(step_id="s1", state="completed_with_result", result_text="r1"),
+            PlanStepState(step_id="s2", state="pending"),
+        ),
     )
     assert rp.plan_id == "p001"
     assert "s1" in rp.committed_step_ids
     assert rp.pending_step_ids == ("s2",)
-    assert rp.step_results == {"s1": "r1"}
+    assert rp.step_result_map() == {"s1": "r1"}
 
     with pytest.raises((AttributeError, Exception)):
         rp.plan_id = "mutate"  # frozen

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -1,0 +1,233 @@
+"""Tier 2: /plan slash command (ADR-0023 Phase 2.1).
+
+Two sub-commands:
+  /plan list                 — show active plan runs
+  /plan discard <plan_id>    — abort a specific plan run + cleanup
+
+Mirrors test_skill_slash_command.py shape; uses real ChatSession +
+SnapshotJournal so the WAL/snapshot paths exercise the production
+wiring.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _drain_outbox(session: ChatSession) -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+# ── /plan list ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_list_with_no_active_runs(tmp_path, monkeypatch):
+    """Tier 2: /plan list with no active plans reports the empty hint."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/plan list")
+    assert consumed is True
+    msgs = _drain_outbox(session)
+    combined = "\n".join(m.text for m in msgs)
+    assert "no active plans" in combined
+
+
+@pytest.mark.asyncio
+async def test_plan_list_shows_running_plans(tmp_path, monkeypatch):
+    """Tier 2: /plan list shows plan_ids from running_plans dict."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # Simulate a running plan task by inserting into running_plans dict.
+    # Use a never-completing future as the task placeholder so list shows
+    # status="running".
+    fut = asyncio.get_running_loop().create_future()
+    session.running_plans["plan_abc123"] = fut
+
+    try:
+        consumed = await session._maybe_handle_slash("/plan list")
+        assert consumed is True
+        msgs = _drain_outbox(session)
+        combined = "\n".join(m.text for m in msgs if m.kind == "status")
+        assert "plan_abc123" in combined
+        assert "running" in combined
+    finally:
+        fut.cancel()
+
+
+@pytest.mark.asyncio
+async def test_plan_list_shows_active_ids_without_task(tmp_path, monkeypatch):
+    """Tier 2: plan_id in active_plan_ids but no running task (= post-crash
+    pre-resume window) → list shows it as 'active (no task — resume pending)'."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # Simulate a plan_id surviving in the agent snapshot without a task.
+    await session._journal.record_plan_started(
+        plan_id="plan_xyz789", goal="g", n_steps=2,
+    )
+    consumed = await session._maybe_handle_slash("/plan list")
+    assert consumed is True
+    msgs = _drain_outbox(session)
+    combined = "\n".join(m.text for m in msgs if m.kind == "status")
+    assert "plan_xyz789" in combined
+    assert "active" in combined or "resume pending" in combined
+
+
+# ── /plan discard ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_discard_unknown_id_reports_error(tmp_path, monkeypatch):
+    """Tier 2: discarding a non-existent plan returns an error message."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/plan discard nonexistent")
+    assert consumed is True
+    msgs = _drain_outbox(session)
+    err_msgs = [m for m in msgs if m.kind == "error"]
+    assert len(err_msgs) >= 1
+    assert "unknown plan run" in err_msgs[0].text
+
+
+@pytest.mark.asyncio
+async def test_plan_discard_records_plan_aborted(tmp_path, monkeypatch):
+    """Tier 2: /plan discard emits plan_aborted to WAL + clears
+    active_plan_ids."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._journal.record_plan_started(
+        plan_id="p_to_discard", goal="g", n_steps=2,
+    )
+    assert "p_to_discard" in session._journal.snapshot.active_plan_ids
+
+    consumed = await session._maybe_handle_slash("/plan discard p_to_discard")
+    assert consumed is True
+
+    # active_plan_ids cleared via plan_aborted apply.
+    assert "p_to_discard" not in session._journal.snapshot.active_plan_ids
+
+    # Confirmation message in outbox.
+    msgs = _drain_outbox(session)
+    status_texts = [m.text for m in msgs if m.kind == "status"]
+    assert any("discarded plan run" in t for t in status_texts)
+
+
+@pytest.mark.asyncio
+async def test_plan_discard_cancels_running_task(tmp_path, monkeypatch):
+    """Tier 2: discarding a plan with a running task cancels the task."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # A task we can cancel.
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _task_body():
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(_task_body())
+    await started.wait()
+    session.running_plans["p_running"] = task
+    await session._journal.record_plan_started(
+        plan_id="p_running", goal="g", n_steps=1,
+    )
+
+    consumed = await session._maybe_handle_slash("/plan discard p_running")
+    assert consumed is True
+    assert task.cancelled() or cancelled.is_set()
+    assert "p_running" not in session.running_plans
+
+
+@pytest.mark.asyncio
+async def test_plan_discard_deletes_decomposition_artifact(tmp_path, monkeypatch):
+    """Tier 2: discard removes the decomposition artifact via
+    delete_plan_decomposition (= P5 cleanup)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # Pre-create an artifact file at the production path.
+    from reyn.chat.planner import Plan, PlanStep
+    from reyn.plan.decomposition import (
+        decomposition_path,
+        write_decomposition,
+    )
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    plan = Plan(
+        goal="g",
+        steps=(PlanStep("s1", "first", ()), PlanStep("s2", "second", ())),
+    )
+    write_decomposition(agent_state_dir, "p_artifact", plan)
+    artifact = decomposition_path(agent_state_dir, "p_artifact")
+    assert artifact.exists()
+
+    await session._journal.record_plan_started(
+        plan_id="p_artifact", goal="g", n_steps=2,
+    )
+
+    await session._maybe_handle_slash("/plan discard p_artifact")
+    assert not artifact.exists()
+
+
+# ── Usage / unknown sub-command ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_no_subcommand_shows_usage(tmp_path, monkeypatch):
+    """Tier 2: bare `/plan` shows usage hint."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._maybe_handle_slash("/plan")
+    msgs = _drain_outbox(session)
+    combined = "\n".join(m.text for m in msgs)
+    assert "Usage:" in combined or "list" in combined
+
+
+@pytest.mark.asyncio
+async def test_plan_unknown_subcommand_reports_error(tmp_path, monkeypatch):
+    """Tier 2: unknown sub-command surfaces an error message."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._maybe_handle_slash("/plan nonsense")
+    msgs = _drain_outbox(session)
+    err = [m for m in msgs if m.kind == "error"]
+    assert len(err) >= 1

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -220,6 +220,149 @@ async def test_plan_no_subcommand_shows_usage(tmp_path, monkeypatch):
     assert "Usage:" in combined or "list" in combined
 
 
+# ── /plan resume --from <step_id> ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_resume_missing_args_shows_usage(tmp_path, monkeypatch):
+    """Tier 2: /plan resume without --from <step_id> → usage error."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._maybe_handle_slash("/plan resume")
+    msgs = _drain_outbox(session)
+    err = [m for m in msgs if m.kind == "error"]
+    assert len(err) >= 1
+    assert "Usage" in err[0].text or "--from" in err[0].text
+
+
+@pytest.mark.asyncio
+async def test_plan_resume_unknown_plan_id_reports_error(tmp_path, monkeypatch):
+    """Tier 2: /plan resume nonexistent --from s1 → unknown plan error."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._maybe_handle_slash("/plan resume nonexistent --from s1")
+    msgs = _drain_outbox(session)
+    err = [m for m in msgs if m.kind == "error"]
+    assert len(err) >= 1
+    assert "unknown plan run" in err[0].text
+
+
+@pytest.mark.asyncio
+async def test_plan_resume_missing_artifact_reports_error(tmp_path, monkeypatch):
+    """Tier 2: /plan resume on a plan whose decomposition artifact is
+    missing → descriptive error directing to /plan discard."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # Set up a per-plan snapshot WITHOUT writing the decomposition artifact.
+    from pathlib import Path
+    from reyn.plan import PlanRegistry
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    reg = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg.start(plan_id="p_no_art", chain_id="c1", goal="g", applied_seq=10)
+
+    await session._maybe_handle_slash("/plan resume p_no_art --from s1")
+    msgs = _drain_outbox(session)
+    err = [m for m in msgs if m.kind == "error"]
+    assert len(err) >= 1
+    assert (
+        "decomposition" in err[0].text or "discard" in err[0].text
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_resume_unknown_step_reports_error(tmp_path, monkeypatch):
+    """Tier 2: /plan resume with --from pointing at a step that's not in
+    the decomposition → error listing valid step IDs."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    from pathlib import Path
+    from reyn.chat.planner import Plan, PlanStep
+    from reyn.plan import PlanRegistry, write_decomposition
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    plan = Plan(goal="g", steps=(
+        PlanStep("s1", "first", ()),
+        PlanStep("s2", "second", ()),
+    ))
+    write_decomposition(agent_state_dir, "p001", plan)
+    reg = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+
+    await session._maybe_handle_slash("/plan resume p001 --from nonexistent")
+    msgs = _drain_outbox(session)
+    err = [m for m in msgs if m.kind == "error"]
+    assert len(err) >= 1
+    assert "not in plan" in err[0].text or "nonexistent" in err[0].text
+
+
+@pytest.mark.asyncio
+async def test_plan_resume_clears_target_step_results(tmp_path, monkeypatch):
+    """Tier 2: /plan resume clears results from --from onward and reports
+    the count of steps to re-execute."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    from pathlib import Path
+    from reyn.chat.planner import Plan, PlanStep
+    from reyn.plan import PlanRegistry, write_decomposition
+    agent_state_dir = (
+        Path(".reyn") / "agents" / session.agent_name / "state"
+    )
+    plan = Plan(goal="g", steps=(
+        PlanStep("s1", "first", ()),
+        PlanStep("s2", "second", ()),
+        PlanStep("s3", "third", ()),
+    ))
+    write_decomposition(agent_state_dir, "p001", plan)
+
+    # Pre-populate snapshot with results for all 3 steps.
+    reg = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15, result_text="r1",
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s2", applied_seq=20, result_text="r2",
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s3", applied_seq=25, result_text="r3",
+    )
+
+    await session._maybe_handle_slash("/plan resume p001 --from s2")
+
+    # Status confirmation in outbox.
+    msgs = _drain_outbox(session)
+    status_texts = [m.text for m in msgs if m.kind == "status"]
+    assert any("resumed from step" in t for t in status_texts)
+
+    # Reload registry and confirm s1 preserved, s2/s3 cleared.
+    reg2 = PlanRegistry(
+        agent_name=session.agent_name, agent_state_dir=agent_state_dir,
+    )
+    reg2.load_active()
+    snap = reg2.get("p001")
+    assert snap.step_results == {"s1": "r1"}
+    assert snap.last_committed_step_id == "s1"
+
+
 @pytest.mark.asyncio
 async def test_plan_unknown_subcommand_reports_error(tmp_path, monkeypatch):
     """Tier 2: unknown sub-command surfaces an error message."""

--- a/tests/test_plan_snapshot.py
+++ b/tests/test_plan_snapshot.py
@@ -154,6 +154,8 @@ def test_save_emits_documented_schema(tmp_path: Path) -> None:
         "step_results",
         # ADR-0024: spill ref dict (additive, no version bump)
         "step_result_refs",
+        # ADR-0025: sub-loop LLM call log (additive, no version bump)
+        "step_llm_calls",
         "step_failures",
         "current_step_id",
         "last_committed_step_id",

--- a/tests/test_plan_snapshot.py
+++ b/tests/test_plan_snapshot.py
@@ -1,0 +1,192 @@
+"""Tier 2: PlanSnapshot persistence + version refuse (ADR-0023 §3.1).
+
+Step 2 of the Phase 2 migration path. Mirrors test_skill_snapshot.py's
+shape — round-trip, atomic save, schema-version refuse, default field
+defaults.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.events.agent_snapshot import SchemaVersionError
+from reyn.plan import (
+    PLAN_SNAPSHOT_VERSION,
+    PlanSnapshot,
+    plan_snapshot_path,
+)
+
+
+def test_empty_factory_initializes_minimum_fields() -> None:
+    """Tier 2: ``empty()`` produces a snapshot at plan_started time
+    (= no steps observed yet, all derived fields default)."""
+    snap = PlanSnapshot.empty(
+        plan_id="ab12cd34",
+        agent_name="default",
+        chain_id="chain001",
+        goal="compare A and B",
+    )
+    assert snap.plan_id == "ab12cd34"
+    assert snap.agent_name == "default"
+    assert snap.chain_id == "chain001"
+    assert snap.goal == "compare A and B"
+    assert snap.applied_seq == 0
+    assert snap.last_step_applied_seq == 0
+    assert snap.decomposition_artifact_path is None
+    assert snap.steps_serialized == []
+    assert snap.step_results == {}
+    assert snap.step_failures == {}
+    assert snap.current_step_id is None
+    assert snap.last_committed_step_id is None
+    assert snap.spawned_skill_run_ids == {}
+    assert snap.parent_skill_run_id is None
+    assert snap.usage_tokens_so_far is None
+
+
+def test_save_load_round_trip(tmp_path: Path) -> None:
+    """Tier 2: save → load preserves every field."""
+    snap = PlanSnapshot(
+        plan_id="p001",
+        agent_name="default",
+        chain_id="c001",
+        goal="g",
+        applied_seq=42,
+        last_step_applied_seq=40,
+        decomposition_artifact_path="/abs/path/decomposition.json",
+        steps_serialized=[
+            {"id": "s1", "description": "first", "tools": ["read_file"], "depends_on": []},
+        ],
+        step_results={"s1": "result text"},
+        step_failures={"s2": "RuntimeError('boom')"},
+        current_step_id="s2",
+        last_committed_step_id="s1",
+        spawned_skill_run_ids={"s2": "child_run_x"},
+        parent_skill_run_id=None,
+        usage_tokens_so_far={"prompt": 1234, "completion": 567},
+    )
+    path = plan_snapshot_path(tmp_path, "p001")
+    snap.save(path)
+
+    loaded = PlanSnapshot.load("p001", path)
+    assert loaded == snap
+
+
+def test_save_writes_documented_path(tmp_path: Path) -> None:
+    """Tier 2: snapshot lives at ``<agent_state>/plans/<plan_id>.snapshot.json``
+    (= sibling to the per-plan directory holding the decomposition)."""
+    snap = PlanSnapshot.empty(
+        plan_id="p001", agent_name="default", chain_id="c001", goal="g"
+    )
+    path = plan_snapshot_path(tmp_path, "p001")
+    snap.save(path)
+    assert path == tmp_path / "plans" / "p001.snapshot.json"
+    assert path.exists()
+
+
+def test_save_is_atomic_no_tmp_residue(tmp_path: Path) -> None:
+    """Tier 2: save uses tmp + rename; no .tmp file remains after success."""
+    snap = PlanSnapshot.empty(
+        plan_id="p001", agent_name="default", chain_id="c001", goal="g"
+    )
+    path = plan_snapshot_path(tmp_path, "p001")
+    snap.save(path)
+    assert path.exists()
+    assert not path.with_suffix(path.suffix + ".tmp").exists()
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path) -> None:
+    """Tier 2: missing file yields a usable empty snapshot keyed by
+    plan_id (= mirror SkillSnapshot.load resilience)."""
+    snap = PlanSnapshot.load("p001", plan_snapshot_path(tmp_path, "p001"))
+    assert snap.plan_id == "p001"
+    assert snap.applied_seq == 0
+    assert snap.goal == ""
+
+
+def test_load_corrupt_json_returns_empty(tmp_path: Path) -> None:
+    """Tier 2: malformed JSON falls back to empty (= same posture as
+    SkillSnapshot.load — defensive load)."""
+    path = plan_snapshot_path(tmp_path, "p001")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json {", encoding="utf-8")
+
+    snap = PlanSnapshot.load("p001", path)
+    assert snap.plan_id == "p001"
+
+
+def test_load_wrong_schema_version_raises(tmp_path: Path) -> None:
+    """Tier 2: schema_version drift raises SchemaVersionError so the
+    caller refuses to resume rather than silently load stale fields
+    (= ADR-0006 + SkillSnapshot precedent)."""
+    path = plan_snapshot_path(tmp_path, "p001")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"schema_version": 999, "plan_id": "p001"}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SchemaVersionError, match="version"):
+        PlanSnapshot.load("p001", path)
+
+
+def test_save_emits_documented_schema(tmp_path: Path) -> None:
+    """Tier 2: persisted JSON contains schema_version = PLAN_SNAPSHOT_VERSION
+    and the documented field set."""
+    snap = PlanSnapshot.empty(
+        plan_id="p001", agent_name="default", chain_id="c001", goal="g"
+    )
+    path = plan_snapshot_path(tmp_path, "p001")
+    snap.save(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == PLAN_SNAPSHOT_VERSION
+    expected_keys = {
+        "schema_version",
+        "plan_id",
+        "agent_name",
+        "chain_id",
+        "goal",
+        "applied_seq",
+        "last_step_applied_seq",
+        "decomposition_artifact_path",
+        "steps_serialized",
+        "step_results",
+        "step_failures",
+        "current_step_id",
+        "last_committed_step_id",
+        "spawned_skill_run_ids",
+        "parent_skill_run_id",
+        "usage_tokens_so_far",
+    }
+    assert set(payload.keys()) == expected_keys
+
+
+def test_load_handles_old_file_with_missing_optional_fields(tmp_path: Path) -> None:
+    """Tier 2: a file written with the documented ``schema_version`` but
+    missing optional fields loads with sensible defaults (= forward compat
+    if Phase 2.1 adds new optional fields, old files keep loading)."""
+    path = plan_snapshot_path(tmp_path, "p001")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": PLAN_SNAPSHOT_VERSION,
+                "plan_id": "p001",
+                "agent_name": "default",
+                "chain_id": "c001",
+                "goal": "g",
+                "applied_seq": 5,
+                "last_step_applied_seq": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+    snap = PlanSnapshot.load("p001", path)
+    assert snap.plan_id == "p001"
+    assert snap.applied_seq == 5
+    assert snap.last_step_applied_seq == 4
+    # optional fields default
+    assert snap.steps_serialized == []
+    assert snap.step_results == {}
+    assert snap.spawned_skill_run_ids == {}

--- a/tests/test_plan_snapshot.py
+++ b/tests/test_plan_snapshot.py
@@ -152,6 +152,8 @@ def test_save_emits_documented_schema(tmp_path: Path) -> None:
         "decomposition_artifact_path",
         "steps_serialized",
         "step_results",
+        # ADR-0024: spill ref dict (additive, no version bump)
+        "step_result_refs",
         "step_failures",
         "current_step_id",
         "last_committed_step_id",

--- a/tests/test_plan_step_result_spill_e2e.py
+++ b/tests/test_plan_step_result_spill_e2e.py
@@ -1,0 +1,268 @@
+"""Tier 2: ADR-0024 spill round-trip — large step results survive crash.
+
+Pins the headline correctness invariant of ADR-0024: a step whose
+output exceeds the 32 KB inline threshold writes to a per-plan
+workspace file, persists across a simulated crash + restart, and is
+restored verbatim by the resume analyzer (= no truncation, no data
+loss).
+
+Tier 2 + standalone — no real LLM, no async event loop integration.
+Exercises:
+  - PlanRegistry.record_step_completed spill branch
+  - PlanSnapshot save/load round-trip with step_result_refs
+  - PlanResumeAnalyzer reads via get_step_result accessor
+  - PlanResumeCoordinator forwards agent_state_dir
+  - PlanRegistry.complete cleanup via delete_plan_workspace
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep
+from reyn.plan import (
+    PlanRegistry,
+    PlanResumeAnalyzer,
+    PlanResumeCoordinator,
+    PlanSnapshot,
+    decomposition_dir,
+    delete_plan_workspace,
+    get_step_result,
+    plan_snapshot_path,
+    step_result_file_path,
+    write_decomposition,
+)
+
+
+def _decomp() -> Plan:
+    return Plan(
+        goal="g",
+        steps=(
+            PlanStep("s1", "first", ()),
+            PlanStep("s2", "second", (), depends_on=("s1",)),
+        ),
+    )
+
+
+# ── round-trip ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_50kb_step_result_round_trip(tmp_path: Path) -> None:
+    """Tier 2: 50 KB step output → spill → reload PlanSnapshot from
+    disk → analyzer reconstructs full text via get_step_result. No
+    [truncated] suffix anywhere."""
+    plan = _decomp()
+    write_decomposition(tmp_path, "p001", plan)
+
+    # Phase A: register + complete s1 with large text.
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    huge_text = "X" * 50_000  # well above 32 KB threshold
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text=huge_text,
+    )
+
+    # Spill landed; full text on disk.
+    spilled_path = step_result_file_path(tmp_path, "p001", "s1")
+    assert spilled_path.exists()
+    assert len(spilled_path.read_text(encoding="utf-8")) == 50_000
+
+    # Phase B: simulate crash → restart by reloading from disk.
+    reg2 = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg2.load_active()
+    snap2 = reg2.get("p001")
+    assert snap2 is not None
+    # In-memory snapshot has the ref but NOT the inline text.
+    assert "s1" not in snap2.step_results
+    assert snap2.step_result_refs["s1"] == "step_results/s1.txt"
+
+    # Phase C: analyzer rebuilds resume_plan via get_step_result.
+    analyzer = PlanResumeAnalyzer()
+    synthetic_events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001",
+         "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_completed", "plan_id": "p001",
+         "step_id": "s1", "content_len": len(huge_text)},
+    ]
+    rp = analyzer.analyze(
+        snapshot=snap2, decomposition=plan, wal_events=synthetic_events,
+        agent_state_dir=tmp_path,
+    )
+    s1_state = next(s for s in rp.step_states if s.step_id == "s1")
+    assert s1_state.state == "completed_with_result"
+    # Full 50KB recovered — NOT truncated.
+    assert s1_state.result_text == huge_text
+    assert "[truncated]" not in (s1_state.result_text or "")
+
+
+@pytest.mark.asyncio
+async def test_get_step_result_returns_full_text_after_reload(tmp_path: Path) -> None:
+    """Tier 2: get_step_result accessor reads the spilled file
+    transparently regardless of whether the snapshot is freshly built
+    in memory or freshly loaded from disk."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    text = "Y" * 80_000
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text=text,
+    )
+
+    # Same-process: read via accessor.
+    snap1 = reg.get("p001")
+    assert get_step_result(snap1, tmp_path, "s1") == text
+
+    # Reload-from-disk: read via accessor.
+    snap2 = PlanSnapshot.load(
+        "p001", plan_snapshot_path(tmp_path, "p001"),
+    )
+    assert get_step_result(snap2, tmp_path, "s1") == text
+
+
+# ── corruption fallback (ADR-0024 §4) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_spill_file_classifies_as_failed(tmp_path: Path) -> None:
+    """Tier 2: ADR-0024 §4 — when step_result_refs[sid] is set but the
+    file is missing/unreadable, the analyzer marks the step as
+    failed("step_result_file_missing") so the coordinator's discard
+    policy applies (= safe failure)."""
+    plan = _decomp()
+    write_decomposition(tmp_path, "p001", plan)
+
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    text = "Z" * 50_000
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=20, result_text=text,
+    )
+
+    # Simulate file corruption: delete the spilled file out from under us.
+    step_result_file_path(tmp_path, "p001", "s1").unlink()
+
+    # Reload + analyze.
+    reg2 = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg2.load_active()
+    snap2 = reg2.get("p001")
+    analyzer = PlanResumeAnalyzer()
+    synthetic_events = [
+        {"seq": 1, "kind": "plan_step_started", "plan_id": "p001",
+         "step_id": "s1"},
+        {"seq": 2, "kind": "plan_step_completed", "plan_id": "p001",
+         "step_id": "s1", "content_len": 50_000},
+    ]
+    rp = analyzer.analyze(
+        snapshot=snap2, decomposition=plan, wal_events=synthetic_events,
+        agent_state_dir=tmp_path,
+    )
+    s1_state = next(s for s in rp.step_states if s.step_id == "s1")
+    assert s1_state.state == "failed"
+    assert s1_state.error_kind == "step_result_file_missing"
+
+
+# ── workspace cleanup on plan completion (ADR-0024 §3.3) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_complete_recursively_removes_per_plan_workspace(tmp_path: Path) -> None:
+    """Tier 2: PlanRegistry.complete uses delete_plan_workspace which
+    rmtree's the per-plan dir — including spilled step files. The legacy
+    delete_decomposition path would orphan the dir because step_results/
+    isn't empty."""
+    write_decomposition(tmp_path, "p001", _decomp())
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15,
+        result_text="A" * 50_000,
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s2", applied_seq=20,
+        result_text="B" * 50_000,
+    )
+
+    plan_dir = decomposition_dir(tmp_path, "p001")
+    assert plan_dir.is_dir()
+    assert (plan_dir / "step_results" / "s1.txt").exists()
+    assert (plan_dir / "step_results" / "s2.txt").exists()
+
+    await reg.complete(plan_id="p001")
+
+    # Whole per-plan dir reclaimed.
+    assert not plan_dir.exists()
+
+
+# ── coordinator integration (ADR-0024 thread-through) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_coordinator_forwards_agent_state_dir_to_analyzer(tmp_path: Path) -> None:
+    """Tier 2: PlanResumeCoordinator.discover_and_decide threads
+    agent_state_dir through to PlanResumeAnalyzer.analyze so spilled
+    refs resolve to full text in the resulting decision."""
+    plan = _decomp()
+    write_decomposition(tmp_path, "p001", plan)
+
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    huge = "Q" * 60_000
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15, result_text=huge,
+    )
+
+    def loader(plan_id: str) -> Plan:
+        return plan
+
+    coord = PlanResumeCoordinator()
+    decisions = coord.discover_and_decide(
+        plan_registry=reg,
+        wal_events=[
+            {"seq": 1, "kind": "plan_step_started", "plan_id": "p001",
+             "step_id": "s1"},
+            {"seq": 2, "kind": "plan_step_completed", "plan_id": "p001",
+             "step_id": "s1", "content_len": 60_000},
+        ],
+        decomposition_loader=loader,
+        agent_state_dir=tmp_path,
+    )
+    assert len(decisions) == 1
+    s1_state = next(
+        s for s in decisions[0].plan.step_states if s.step_id == "s1"
+    )
+    assert s1_state.state == "completed_with_result"
+    assert s1_state.result_text == huge   # full 60 KB preserved
+
+
+# ── reset_from_step deletes spilled files (ADR-0024 §3.4) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_from_step_deletes_spilled_files(tmp_path: Path) -> None:
+    """Tier 2: reset_from_step clears step_result_refs entries AND
+    deletes the underlying spilled files so re-execution starts with a
+    clean disk state."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s1", applied_seq=15,
+        result_text="A" * 50_000,
+    )
+    await reg.record_step_completed(
+        plan_id="p001", step_id="s2", applied_seq=20,
+        result_text="B" * 50_000,
+    )
+    s2_path = step_result_file_path(tmp_path, "p001", "s2")
+    assert s2_path.exists()
+
+    reg.reset_from_step(
+        plan_id="p001", from_step_id="s2", step_order=["s1", "s2"],
+    )
+
+    snap = reg.get("p001")
+    assert "s2" not in snap.step_result_refs
+    # s1 spilled file untouched
+    assert step_result_file_path(tmp_path, "p001", "s1").exists()
+    # s2 spilled file deleted
+    assert not s2_path.exists()

--- a/tests/test_plan_step_wal.py
+++ b/tests/test_plan_step_wal.py
@@ -1,0 +1,225 @@
+"""Tier 2: plan_step_* events promoted to WAL (ADR-0023 Phase 2 step 4).
+
+The resume analyzer (Step 7) needs deterministic step pairing across
+restart, so plan_step_started / plan_step_completed / plan_step_failed
+move from forensic-only events log to WAL. Phase 1's existing emits in
+``execute_plan`` will be re-routed in Step 5 (PlanRuntime).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.services.snapshot_journal import SnapshotJournal
+from reyn.events.state_log import WAL_EVENT_KINDS, StateLog
+
+
+def _make_journal(tmp_path: Path) -> tuple[SnapshotJournal, StateLog]:
+    log = StateLog(tmp_path / "wal.jsonl")
+    journal = SnapshotJournal(
+        agent_name="default",
+        snapshot_path=tmp_path / "snapshot.json",
+        state_log=log,
+    )
+    return journal, log
+
+
+# ── WAL_EVENT_KINDS registration ──────────────────────────────────────────
+
+
+def test_plan_step_kinds_registered_in_wal_event_kinds() -> None:
+    """Tier 2: plan_step_started/completed/failed are in WAL_EVENT_KINDS so
+    StateLog.append accepts them and replay vocabulary covers them."""
+    assert "plan_step_started" in WAL_EVENT_KINDS
+    assert "plan_step_completed" in WAL_EVENT_KINDS
+    assert "plan_step_failed" in WAL_EVENT_KINDS
+
+
+def test_state_log_rejects_unknown_kinds(tmp_path: Path) -> None:
+    """Tier 2: typos surface immediately at write time (= ADR-0001
+    invariant — WAL vocabulary is closed)."""
+    log = StateLog(tmp_path / "wal.jsonl")
+    import asyncio
+
+    async def call() -> None:
+        with pytest.raises(ValueError, match="unknown WAL event kind"):
+            await log.append("plan_step_starts")  # typo
+
+    asyncio.run(call())
+
+
+# ── SnapshotJournal recording ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_plan_step_started_appends_wal_with_full_payload(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: record_plan_step_started writes a WAL entry with the
+    documented field set and returns the assigned seq."""
+    journal, log = _make_journal(tmp_path)
+    seq = await journal.record_plan_step_started(
+        plan_id="p001", step_id="s1",
+        depends_on=["s0"], n_tools=2,
+    )
+    assert isinstance(seq, int)
+    assert seq > 0
+
+    raw_lines = log.path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(raw_lines) == 1
+    entry = json.loads(raw_lines[0])
+    assert entry["kind"] == "plan_step_started"
+    assert entry["target"] == "default"
+    assert entry["plan_id"] == "p001"
+    assert entry["step_id"] == "s1"
+    assert entry["depends_on"] == ["s0"]
+    assert entry["n_tools"] == 2
+    assert entry["seq"] == seq
+
+
+@pytest.mark.asyncio
+async def test_record_plan_step_completed_appends_wal(tmp_path: Path) -> None:
+    """Tier 2: record_plan_step_completed writes a WAL entry with content_len."""
+    journal, log = _make_journal(tmp_path)
+    seq = await journal.record_plan_step_completed(
+        plan_id="p001", step_id="s1", content_len=350,
+    )
+    assert isinstance(seq, int)
+    entry = json.loads(log.path.read_text().strip().splitlines()[0])
+    assert entry["kind"] == "plan_step_completed"
+    assert entry["plan_id"] == "p001"
+    assert entry["step_id"] == "s1"
+    assert entry["content_len"] == 350
+
+
+@pytest.mark.asyncio
+async def test_record_plan_step_failed_appends_wal(tmp_path: Path) -> None:
+    """Tier 2: record_plan_step_failed writes a WAL entry with error repr."""
+    journal, log = _make_journal(tmp_path)
+    seq = await journal.record_plan_step_failed(
+        plan_id="p001", step_id="s1", error="RuntimeError('boom')",
+    )
+    assert isinstance(seq, int)
+    entry = json.loads(log.path.read_text().strip().splitlines()[0])
+    assert entry["kind"] == "plan_step_failed"
+    assert entry["plan_id"] == "p001"
+    assert entry["step_id"] == "s1"
+    assert entry["error"] == "RuntimeError('boom')"
+
+
+@pytest.mark.asyncio
+async def test_record_methods_no_op_without_state_log(tmp_path: Path) -> None:
+    """Tier 2: when state_log is None (= test stub) record returns None
+    and doesn't raise."""
+    journal = SnapshotJournal(
+        agent_name="default",
+        snapshot_path=tmp_path / "snapshot.json",
+        state_log=None,
+    )
+    assert (
+        await journal.record_plan_step_started(
+            plan_id="p001", step_id="s1", depends_on=[], n_tools=0,
+        )
+        is None
+    )
+    assert (
+        await journal.record_plan_step_completed(
+            plan_id="p001", step_id="s1", content_len=1,
+        )
+        is None
+    )
+    assert (
+        await journal.record_plan_step_failed(
+            plan_id="p001", step_id="s1", error="x",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_methods_bump_applied_seq_on_snapshot(tmp_path: Path) -> None:
+    """Tier 2: each WAL append bumps applied_seq on the in-memory
+    AgentSnapshot so replay-after-crash skips already-applied events
+    (= ADR-0001 watermark invariant)."""
+    journal, log = _make_journal(tmp_path)
+    snap_before = journal.snapshot.applied_seq
+
+    seq1 = await journal.record_plan_step_started(
+        plan_id="p001", step_id="s1", depends_on=[], n_tools=0,
+    )
+    assert journal.snapshot.applied_seq == seq1
+
+    seq2 = await journal.record_plan_step_completed(
+        plan_id="p001", step_id="s1", content_len=1,
+    )
+    assert journal.snapshot.applied_seq == seq2
+    assert seq2 > seq1
+    assert seq1 > snap_before
+
+
+# ── interaction with apply_events ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_events_skips_plan_step_kinds_without_state_mutation(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: agent-level apply_events is a no-op for plan_step_*
+    (= they don't mutate agent fields, only bump applied_seq). The actual
+    per-plan state lives on PlanSnapshot, not AgentSnapshot."""
+    journal, log = _make_journal(tmp_path)
+
+    seq1 = await journal.record_plan_step_started(
+        plan_id="p001", step_id="s1", depends_on=[], n_tools=0,
+    )
+    seq2 = await journal.record_plan_step_completed(
+        plan_id="p001", step_id="s1", content_len=10,
+    )
+
+    from reyn.events.agent_snapshot import AgentSnapshot
+
+    snap = AgentSnapshot.empty("default")
+    events = list(log.iter_from(0))
+    snap.apply_events(events)
+    assert snap.applied_seq == seq2
+    assert snap.active_plan_ids == []  # plan_step_* don't touch this
+    assert snap.active_skill_run_ids == []
+
+
+@pytest.mark.asyncio
+async def test_replay_preserves_step_event_ordering(tmp_path: Path) -> None:
+    """Tier 2: WAL preserves seq order across plan_started + step events
+    + plan_completed (= analyzer can deterministically reconstruct
+    pairings)."""
+    journal, log = _make_journal(tmp_path)
+
+    await journal.record_plan_started(plan_id="p001", goal="g", n_steps=2)
+    s1_started = await journal.record_plan_step_started(
+        plan_id="p001", step_id="s1", depends_on=[], n_tools=0,
+    )
+    s1_completed = await journal.record_plan_step_completed(
+        plan_id="p001", step_id="s1", content_len=10,
+    )
+    s2_started = await journal.record_plan_step_started(
+        plan_id="p001", step_id="s2", depends_on=["s1"], n_tools=0,
+    )
+    s2_failed = await journal.record_plan_step_failed(
+        plan_id="p001", step_id="s2", error="err",
+    )
+    await journal.record_plan_completed(plan_id="p001")
+
+    events = list(log.iter_from(0))
+    seqs = [e["seq"] for e in events]
+    assert seqs == sorted(seqs)
+    assert s1_started < s1_completed < s2_started < s2_failed
+    kinds = [e["kind"] for e in events]
+    assert kinds == [
+        "plan_started",
+        "plan_step_started",
+        "plan_step_completed",
+        "plan_step_started",
+        "plan_step_failed",
+        "plan_completed",
+    ]

--- a/tests/test_plan_sub_loop_memo.py
+++ b/tests/test_plan_sub_loop_memo.py
@@ -1,0 +1,312 @@
+"""Tier 2: ADR-0025 sub-loop LLM call memoization.
+
+Pins the contract:
+  - args_hash is stable across identical (model, messages, tools, ...) inputs
+  - SubLoopMemoProvider.record persists to PlanSnapshot.step_llm_calls
+  - get_recorded_result returns the deserialised LLMToolCallResult on hit
+  - Spill (>32KB serialised) writes to per-plan workspace file
+  - reset_from_step deletes spilled LLM call records
+  - Snapshot reload preserves the memo log
+  - Drift (= different args_hash) misses cleanly
+
+No real LLM. Provider tested directly against PlanRegistry; wiring
+into planner.py is exercised in test_plan_resume_analyzer.py via the
+step_llm_call_log forward.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.plan import (
+    PlanRegistry,
+    PlanSnapshot,
+    SubLoopMemoProvider,
+    compute_sub_loop_args_hash,
+    extract_step_llm_call_records,
+    plan_snapshot_path,
+)
+
+
+# ── compute_sub_loop_args_hash ────────────────────────────────────────────
+
+
+def test_args_hash_stable_across_identical_inputs() -> None:
+    """Tier 2: same (model, messages, tools, tool_choice) → same hash."""
+    args = dict(
+        model="anthropic/claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[{"function": {"name": "search"}}],
+        tool_choice="auto",
+    )
+    h1 = compute_sub_loop_args_hash(**args)
+    h2 = compute_sub_loop_args_hash(**args)
+    assert h1 == h2
+    assert len(h1) == 16  # SHA-256 truncated to 16 hex
+
+
+def test_args_hash_differs_on_message_change() -> None:
+    """Tier 2: different messages → different hash."""
+    base = dict(
+        model="m", tools=None, tool_choice="auto",
+    )
+    h1 = compute_sub_loop_args_hash(
+        messages=[{"role": "user", "content": "hello"}], **base,
+    )
+    h2 = compute_sub_loop_args_hash(
+        messages=[{"role": "user", "content": "world"}], **base,
+    )
+    assert h1 != h2
+
+
+def test_args_hash_differs_on_model_change() -> None:
+    """Tier 2: different model → different hash (= prevents replaying
+    one provider's response as another's)."""
+    msgs = [{"role": "user", "content": "x"}]
+    h1 = compute_sub_loop_args_hash(
+        model="m1", messages=msgs, tools=None, tool_choice="auto",
+    )
+    h2 = compute_sub_loop_args_hash(
+        model="m2", messages=msgs, tools=None, tool_choice="auto",
+    )
+    assert h1 != h2
+
+
+# ── SubLoopMemoProvider record / get round-trip ──────────────────────────
+
+
+def _sample_result(content: str = "ok", tool_calls: list | None = None) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=content,
+        tool_calls=tool_calls or [],
+        finish_reason="stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_then_get_inline_round_trip(tmp_path: Path) -> None:
+    """Tier 2: record a small result → get returns equivalent result."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    result = _sample_result(content="hello world")
+    await provider.record(args_hash="abc123", result=result)
+
+    got = provider.get_recorded_result("abc123")
+    assert got is not None
+    assert got.content == "hello world"
+    assert got.finish_reason == "stop"
+    assert got.usage.prompt_tokens == 10
+    assert got.usage.completion_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_on_miss(tmp_path: Path) -> None:
+    """Tier 2: unknown args_hash → None (= caller does fresh call)."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    assert provider.get_recorded_result("nonexistent") is None
+
+
+@pytest.mark.asyncio
+async def test_record_persists_to_snapshot(tmp_path: Path) -> None:
+    """Tier 2: record() saves the snapshot — survives reload."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    await provider.record(args_hash="h1", result=_sample_result("alpha"))
+    await provider.record(args_hash="h2", result=_sample_result("beta"))
+
+    # Reload snapshot from disk — confirm persistence.
+    snap = PlanSnapshot.load("p001", plan_snapshot_path(tmp_path, "p001"))
+    log = snap.step_llm_calls.get("s1") or []
+    assert len(log) == 2
+    assert log[0]["args_hash"] == "h1"
+    assert log[1]["args_hash"] == "h2"
+
+
+# ── spill (>32 KB) ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_spills_large_result_to_file(tmp_path: Path) -> None:
+    """Tier 2: result >32 KB serialised → spill to per-plan workspace
+    file; snapshot holds a ref instead of inline JSON."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    huge = "X" * 60_000
+    await provider.record(
+        args_hash="h_big",
+        result=_sample_result(content=huge),
+    )
+
+    snap = reg.get("p001")
+    log = snap.step_llm_calls["s1"]
+    assert len(log) == 1
+    rec = log[0]
+    assert rec["inline"] is None
+    assert rec["ref"] is not None
+    assert rec["ref"].startswith("step_llm_calls/s1/")
+
+    # File on disk has the full serialised record.
+    full = tmp_path / "plans" / "p001" / rec["ref"]
+    assert full.exists()
+    on_disk = json.loads(full.read_text(encoding="utf-8"))
+    assert on_disk["content"] == huge
+
+
+@pytest.mark.asyncio
+async def test_get_resolves_spilled_record(tmp_path: Path) -> None:
+    """Tier 2: get_recorded_result reads spilled file transparently."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    huge = "Y" * 50_000
+    await provider.record(args_hash="hh", result=_sample_result(content=huge))
+
+    # Re-build provider from seed records (simulate resume).
+    log = reg.get("p001").step_llm_calls.get("s1") or []
+    seed = extract_step_llm_call_records({"s1": log}, "s1")
+    fresh_provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+        seed_records=seed,
+    )
+    got = fresh_provider.get_recorded_result("hh")
+    assert got is not None
+    assert got.content == huge
+
+
+@pytest.mark.asyncio
+async def test_spill_file_missing_returns_none(tmp_path: Path) -> None:
+    """Tier 2: ADR-0025 corruption fallback — spilled file gone →
+    get returns None (= caller does fresh call). Mirrors ADR-0024 §4."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    huge = "Z" * 50_000
+    await provider.record(args_hash="hh", result=_sample_result(content=huge))
+
+    # Nuke the spilled file out from under us.
+    snap = reg.get("p001")
+    rec = snap.step_llm_calls["s1"][0]
+    full = tmp_path / "plans" / "p001" / rec["ref"]
+    full.unlink()
+
+    # Fresh provider seeded from the (now-stale) snapshot data.
+    seed = extract_step_llm_call_records(
+        {"s1": list(snap.step_llm_calls["s1"])}, "s1",
+    )
+    fresh_provider = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+        seed_records=seed,
+    )
+    assert fresh_provider.get_recorded_result("hh") is None
+
+
+# ── reset_from_step interaction ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_from_step_clears_llm_call_log(tmp_path: Path) -> None:
+    """Tier 2: PlanRegistry.reset_from_step clears step_llm_calls for
+    cleared steps and unlinks any spilled records."""
+    reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
+    reg.start(plan_id="p001", chain_id="c1", goal="g", applied_seq=10)
+    p1 = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s1",
+    )
+    p2 = SubLoopMemoProvider(
+        plan_registry=reg, plan_id="p001", step_id="s2",
+    )
+    await p1.record(args_hash="h1", result=_sample_result("a"))
+    await p2.record(args_hash="h2", result=_sample_result(content="X" * 50_000))
+
+    # s2 is spilled; verify file exists.
+    snap = reg.get("p001")
+    spilled_ref = snap.step_llm_calls["s2"][0]["ref"]
+    spilled_path = tmp_path / "plans" / "p001" / spilled_ref
+    assert spilled_path.exists()
+
+    reg.reset_from_step(
+        plan_id="p001", from_step_id="s2", step_order=["s1", "s2"],
+    )
+
+    snap2 = reg.get("p001")
+    # s1 preserved, s2 cleared.
+    assert "s1" in snap2.step_llm_calls
+    assert "s2" not in snap2.step_llm_calls
+    # Spilled file unlinked.
+    assert not spilled_path.exists()
+
+
+# ── extract_step_llm_call_records ────────────────────────────────────────
+
+
+def test_extract_records_returns_empty_for_unknown_step() -> None:
+    """Tier 2: extract on a step with no log returns empty list."""
+    records = extract_step_llm_call_records({}, "s1")
+    assert records == []
+
+
+def test_extract_records_skips_malformed_entries() -> None:
+    """Tier 2: entries without args_hash are filtered (= defensive
+    against future schema drift)."""
+    log = {
+        "s1": [
+            {"args_hash": "ok", "inline": {}, "ref": None},
+            {"no_hash": True},          # bad
+            "not a dict",                # bad
+            {"args_hash": "also_ok", "inline": None, "ref": "s1/0.json"},
+        ]
+    }
+    records = extract_step_llm_call_records(log, "s1")
+    assert len(records) == 2
+    assert records[0].args_hash == "ok"
+    assert records[1].args_hash == "also_ok"
+
+
+# ── analyzer forward ─────────────────────────────────────────────────────
+
+
+def test_analyzer_forwards_step_llm_call_log_to_resume_plan(tmp_path: Path) -> None:
+    """Tier 2: PlanResumeAnalyzer.analyze populates
+    PlanResumePlan.step_llm_call_log from snapshot.step_llm_calls."""
+    from reyn.chat.planner import Plan, PlanStep
+    from reyn.plan import PlanResumeAnalyzer
+
+    snap = PlanSnapshot.empty(
+        plan_id="p001", agent_name="default", chain_id="c0", goal="g",
+    )
+    snap.step_llm_calls["s1"] = [
+        {"args_hash": "h1", "inline": {"content": "ok"}, "ref": None,
+         "usage": {}},
+    ]
+    plan = Plan(
+        goal="g",
+        steps=(PlanStep("s1", "first", ()), PlanStep("s2", "second", ())),
+    )
+
+    rp = PlanResumeAnalyzer().analyze(
+        snapshot=snap, decomposition=plan, wal_events=[],
+    )
+    assert "s1" in rp.step_llm_call_log
+    assert rp.step_llm_call_log["s1"][0]["args_hash"] == "h1"

--- a/tests/test_registry_wal_truncate.py
+++ b/tests/test_registry_wal_truncate.py
@@ -75,6 +75,27 @@ def _seed_skill(
     return snap_path
 
 
+def _seed_plan(
+    registry: AgentRegistry,
+    agent_name: str,
+    plan_id: str,
+    *,
+    last_step_applied_seq: int,
+) -> Path:
+    """Create the on-disk per-plan snapshot for an agent's active plan."""
+    from reyn.plan.plan_snapshot import PlanSnapshot, plan_snapshot_path
+    snap = PlanSnapshot.empty(
+        plan_id=plan_id, agent_name=agent_name, chain_id=f"plan_{plan_id}",
+        goal="g",
+    )
+    snap.last_step_applied_seq = last_step_applied_seq
+    snap_path = plan_snapshot_path(
+        registry._dir / agent_name / "state", plan_id,
+    )
+    snap.save(snap_path)
+    return snap_path
+
+
 def _wal_seqs(state_log: StateLog) -> set[int]:
     return {e["seq"] for e in state_log.iter_from(0) if isinstance(e.get("seq"), int)}
 
@@ -104,6 +125,47 @@ def test_compute_floor_includes_active_skill_snapshots(tmp_path):
 
     floor = registry._compute_truncate_floor()
     assert floor == 3  # min(10, 10, 2) + 1
+
+
+def test_compute_floor_includes_active_plan_snapshots(tmp_path):
+    """Tier 2: ADR-0023 §3.1 — plan_snapshot.last_step_applied_seq pins
+    the floor, preventing WAL truncation from dropping plan_step_*
+    events the resume analyzer needs."""
+    registry = _make_registry(tmp_path)
+    _seed_agent(registry, "alpha", applied_seq=10)
+    _seed_plan(registry, "alpha", "p001", last_step_applied_seq=4)
+
+    floor = registry._compute_truncate_floor()
+    assert floor == 5  # min(10, 4) + 1
+
+
+def test_compute_floor_min_across_skill_and_plan(tmp_path):
+    """Tier 2: multi-source floor — skill at 6 + plan at 3 + agent at 10
+    → floor=4 (= the plan watermark wins). Plans + skills participate
+    equally per ADR-0023 §3.1."""
+    registry = _make_registry(tmp_path)
+    _seed_agent(registry, "alpha", applied_seq=10)
+    _seed_skill(registry, "alpha", "run_xyz", last_phase_applied_seq=6)
+    _seed_plan(registry, "alpha", "p001", last_step_applied_seq=3)
+
+    floor = registry._compute_truncate_floor()
+    assert floor == 4  # min(10, 6, 3) + 1
+
+
+def test_compute_floor_zero_on_corrupt_plan_snapshot(tmp_path):
+    """Tier 2: malformed plan snapshot is conservative — returns 0,
+    no truncation. Mirrors the corrupt-skill-snapshot fail-closed
+    invariant."""
+    registry = _make_registry(tmp_path)
+    _seed_agent(registry, "alpha", applied_seq=10)
+    _seed_plan(registry, "alpha", "p001", last_step_applied_seq=5)
+    snap_path = (
+        registry._dir / "alpha" / "state" / "plans" / "p001.snapshot.json"
+    )
+    snap_path.write_text("{not valid json", encoding="utf-8")
+
+    floor = registry._compute_truncate_floor()
+    assert floor == 0
 
 
 def test_compute_floor_zero_when_no_persistent_agents(tmp_path):


### PR DESCRIPTION
## Summary

- Add per-agent `asyncio.Lock` (module-level `_AGENT_LOCKS` keyed by agent name) around the `baseline → _handle_user_message → history harvest` window in `send_to_agent_impl` so concurrent FastAPI handlers (notably the A2A endpoint at [a2a.py](src/reyn/web/routers/a2a.py)) can no longer race on the shared `ChatSession`.
- Extend `_new_agent_history_entries` with an optional `chain_id` parameter that filters on `msg.meta["chain_id"]`, scoping reply harvesting to the caller's own chain (defense-in-depth even without serialization).

## Modification class

- [ ] 🔵 拡張 (additive — new capability, no breaking changes)
- [ ] 🔴 仕様変更 (breaking — changes existing behavior or contracts)
- [x] 🟢 不具合修正 (bug fix)
- [ ] 📚 doc 追加 (documentation only)

## Why

Two concrete bugs were observable when the A2A router served two
overlapping `message/send` requests for the same Reyn agent:

1. **`history[-1]` race.** Both coroutines append their user message to
   the same `session.history` list and then enter `_run_router_loop`,
   which reads the tail of `history` to construct the LLM prompt.
   Whichever coroutine schedules second sees the *other's* user message
   at `history[-1]` and sends it to the LLM as if it were its own.
2. **Cross-chain reply leakage.** The original
   `_new_agent_history_entries(session, baseline)` returned every
   `role="agent"` entry past `baseline`, with no chain scoping. Two
   concurrent calls would each splice the *other's* reply into their
   own `reply_text`, returning duplicate / wrong content.

The fix is the conservative short-term shape consistent with the
existing serial `session.run()` inbox architecture — push concurrent
callers through a per-agent lock instead of the inbox. Long-term, MCP /
A2A entry points should go through `session.inbox` + `session.run()`
like the chat path does; that's a bigger reshape and explicitly out of
scope here.

## Testing

- Which Tier do the new/changed tests belong to? — **None added in
  this PR.** This change is a localized concurrency fix with no
  behavioral surface change for sequential callers; an integration-
  level Tier 2 test that exercises the A2A endpoint with two
  overlapping `message/send` calls is the right shape and is left as
  a follow-up.
- New tests added: no — see above.
- All tests pass locally: not run as part of this minimal change set.

## Checklist

- [ ] Tests pass locally (`pytest`).
- [ ] Lint / format clean.
- [x] No skill-specific strings (phase names, artifact types, fields) added to OS code (P7).
- [x] P1-P8 invariants respected (see `CLAUDE.md`).
- [ ] `CHANGELOG.md` updated if the change is user-visible.
- [x] No secrets, credentials, or API keys included in the diff.

## Reviewer notes

- The lock is acquired *after* `_get_session` (cheap, idempotent) so
  serialization only covers the actual mutation window. `_AGENT_LOCKS`
  uses `setdefault` and is intentionally unbounded — the dict grows
  with the number of agents the server has ever served, which mirrors
  the registry's own caching shape.
- `chain_id` filtering is additive: passing `None` (= the chat /
  internal callers' shape) preserves the previous behavior exactly.
- `session.run()`, the registry, and the chat path are deliberately
  untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)