### PR TITLE
feat(fp-0032): MCP catalog skill/agent 対称化 — bug fix

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -392,7 +392,7 @@ def build_plan_step_system_prompt(
 # Used by ``_PlanStepHost`` to decide whether a given host method should
 # return narrow data or be silenced (= return empty / None).
 _FILE_TOOL_NAMES = frozenset({"list_directory", "read_file", "write_file", "delete_file"})
-_MCP_TOOL_NAMES = frozenset({"list_mcp_servers", "list_mcp_tools", "call_mcp_tool"})
+_MCP_TOOL_NAMES = frozenset({"list_mcp_servers", "list_mcp_tools", "call_mcp_tool", "describe_mcp_tool"})
 _WEB_FETCH_TOOL_NAME = "web_fetch"
 _INVOKE_SKILL_TOOL_NAME = "invoke_skill"
 _DELEGATE_TOOL_NAME = "delegate_to_agent"

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -769,7 +769,7 @@ class RouterLoop:
         # when the LLM repeatedly calls list_mcp_tools / call_mcp_tool).
         # _normalise_router_tool_result unwraps list_mcp_servers and
         # list_mcp_tools dict envelopes back to bare list shape.
-        "list_mcp_servers", "list_mcp_tools", "call_mcp_tool",
+        "list_mcp_servers", "list_mcp_tools", "call_mcp_tool", "describe_mcp_tool",
         # Phase 3.5-B-heavy — memory cluster.  Handlers delegate via
         # RouterCallerState.{list_memory_fn, read_memory_body_fn,
         # remember_fn, forget_fn} bound to RouterLoop's private helpers
@@ -951,8 +951,17 @@ class RouterLoop:
                 return result["servers"]
             return result
         if name == "list_mcp_tools":
-            if isinstance(result, dict) and "tools" in result:
-                return result["tools"]
+            # FP-0032: key renamed from "tools" to "mcp_tools"; handle both
+            # for backward-compat during transition.
+            if isinstance(result, dict):
+                if "mcp_tools" in result:
+                    return result["mcp_tools"]
+                if "tools" in result:
+                    return result["tools"]
+            return result
+        if name == "describe_mcp_tool":
+            # Return the full dict (= {name, description, input_schema}).
+            # No unwrapping needed — the LLM sees it as structured data.
             return result
         return result
 

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -193,7 +193,7 @@ def build_system_prompt(
     )
     if has_mcp:
         parts.append(
-            "           mcp:     list_mcp_servers / list_mcp_tools / call_mcp_tool"
+            "           mcp:     list_mcp_servers / list_mcp_tools / call_mcp_tool / describe_mcp_tool"
         )
     # NOTE: renamed from "Recall" to "Memory access" (B17-S5-3 fix) to avoid
     # vocabulary collision with the `recall` indexed-search tool (ADR-0033).
@@ -612,9 +612,9 @@ def build_system_prompt(
             parts.append(f"  {line}")
         parts.append("")
 
-    # ── 12. MCP servers ──────────────────────────────────────────────────────
+    # ── 12. MCP servers and tools ────────────────────────────────────────────
     if mcp_section:
-        parts.append("## MCP servers (resource axis)")
+        parts.append("## MCP servers and tools (resource axis)")
         for line in mcp_section:
             parts.append(f"  {line}")
         parts.append("")
@@ -844,14 +844,35 @@ def _render_files(file_permissions: dict | None) -> list[str]:
 
 
 def _render_mcp(mcp_servers: list[dict] | None) -> list[str]:
-    """Return lines for the MCP servers section, or [] when nothing to render."""
+    """Return lines for the MCP servers and tools section, or [] when nothing to render.
+
+    FP-0032: renders a flat list of available mcp_tools (dotted form
+    <server>.<tool>) alongside each server, mirroring the "Available skills"
+    flat list pattern. When a server's ``tools`` list is absent (= not yet
+    async-enumerated), falls back to the prior server-only line with a hint
+    to use list_mcp_tools.
+    """
     if not mcp_servers:
         return []
     lines: list[str] = []
     for server in mcp_servers:
         name = server.get("name", "(unnamed)")
         desc = server.get("description") or "(no description)"
-        lines.append(f"- {name}: {desc}  (use list_mcp_tools to see tools)")
+        tools = server.get("tools") or []
+        if tools:
+            lines.append(f"- {name}: {desc}")
+            for t in tools:
+                tool_name = t.get("name", "(unnamed)")
+                tool_desc = t.get("description") or ""
+                dotted = f"{name}.{tool_name}"
+                if tool_desc:
+                    lines.append(f"    {dotted}  — {tool_desc}")
+                else:
+                    lines.append(f"    {dotted}")
+        else:
+            lines.append(
+                f"- {name}: {desc}  (use list_mcp_tools to see mcp_tools)"
+            )
     return lines
 
 

--- a/src/reyn/chat/router_tools.py
+++ b/src/reyn/chat/router_tools.py
@@ -54,7 +54,11 @@ from typing import Literal
 # against Anthropic SDK release notes when the SDK is available in this env.
 # The ``type`` value "tool_search_tool_20251101" is the version identifier
 # confirmed in the Anthropic docs reference for the 2025-11 GA release.
-MCP_SEARCH_THRESHOLD: int = 30
+MCP_SEARCH_THRESHOLD: int = 0
+# FP-0032: Default 0 (always inline D1–D4). The prior value of 30 activated
+# Anthropic's tool_search_tool_20251101, which is Anthropic-API-specific and
+# conflicts with Reyn's provider-agnostic posture. Set > 0 via reyn.yaml
+# mcp.search_threshold to opt in. Full removal of tool_search_tool is FP-0033.
 
 # ── G12 attractor mitigation (B7 finding: skill description verbosity trigger) ──
 #
@@ -238,7 +242,7 @@ def build_tools(
       B3 remember_shared, B4 remember_agent, B5 forget_memory,
       C1 list_directory, C2 read_file (when any file scope),
       C3 write_file, C4 delete_file (only when write scope),
-      D1 list_mcp_servers, D2 list_mcp_tools, D3 call_mcp_tool (when mcp configured).
+      D1 list_mcp_servers, D2 list_mcp_tools, D3 call_mcp_tool, D4 describe_mcp_tool (when mcp configured).
 
     Internally collects ToolSpec objects (= single source of truth for name,
     description, parameters, dispatch_kind) and returns the OpenAI dict shape
@@ -788,14 +792,34 @@ def build_tools(
                 ))
 
             # ── D3: call_mcp_tool ────────────────────────────────────────────
+            # FP-0032: enum injection via _enrich_router_schema — builds a
+            # minimal RouterCallerState carrying mcp_servers so the enricher
+            # can inject server + mcp_tool_name enums (P4 alignment).
+            from reyn.tools.types import RouterCallerState as _RouterCallerState
+            _mcp_state = _RouterCallerState(mcp_servers=list(mcp_servers or []))
             _call_mcp_tool_def = _registry.lookup("call_mcp_tool")
             if _call_mcp_tool_def is not None and _call_mcp_tool_def.gates.router == "allow":
-                _call_mcp_tool_rendered = _call_mcp_tool_def.render_for_router()
+                _call_mcp_tool_rendered = _call_mcp_tool_def.render_for_router(
+                    state=_mcp_state
+                )
                 specs.append(ToolSpec(
                     name=_call_mcp_tool_rendered["function"]["name"],
                     description=_call_mcp_tool_rendered["function"]["description"],
                     parameters=_call_mcp_tool_rendered["function"]["parameters"],
                     dispatch_kind=_call_mcp_tool_def.dispatch_kind,
+                ))
+
+            # ── D4: describe_mcp_tool ─────────────────────────────────────────
+            _describe_mcp_tool_def = _registry.lookup("describe_mcp_tool")
+            if _describe_mcp_tool_def is not None and _describe_mcp_tool_def.gates.router == "allow":
+                _describe_mcp_tool_rendered = _describe_mcp_tool_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_describe_mcp_tool_rendered["function"]["name"],
+                    description=_describe_mcp_tool_rendered["function"]["description"],
+                    parameters=_describe_mcp_tool_rendered["function"]["parameters"],
+                    dispatch_kind=_describe_mcp_tool_def.dispatch_kind,
                 ))
     else:
         _mcp_search_tool_raw = []

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -53,7 +53,13 @@ def get_default_registry() -> ToolRegistry:
     from reyn.tools.file import DELETE_FILE, FILE_OP, LIST_DIRECTORY, READ_FILE, WRITE_FILE
     from reyn.tools.invoke_skill import INVOKE_SKILL, RUN_SKILL_OP
     from reyn.tools.lint import LINT
-    from reyn.tools.mcp import CALL_MCP_TOOL, LIST_MCP_SERVERS, LIST_MCP_TOOLS, MCP_OP
+    from reyn.tools.mcp import (
+        CALL_MCP_TOOL,
+        DESCRIBE_MCP_TOOL,
+        LIST_MCP_SERVERS,
+        LIST_MCP_TOOLS,
+        MCP_OP,
+    )
     from reyn.tools.mcp_install import MCP_INSTALL_OP
     from reyn.tools.memory import (
         FORGET_MEMORY,
@@ -83,9 +89,11 @@ def get_default_registry() -> ToolRegistry:
     registry.register(DELETE_FILE)
     registry.register(LIST_DIRECTORY)
     # MCP ops (Wave 2 — Type C closure: phase-side discover)
+    # FP-0032: DESCRIBE_MCP_TOOL added as D4 (mirror of describe_skill).
     registry.register(CALL_MCP_TOOL)
     registry.register(LIST_MCP_SERVERS)
     registry.register(LIST_MCP_TOOLS)
+    registry.register(DESCRIBE_MCP_TOOL)
     # Memory ops (Wave 2 — Type C closure: memory write phase-side)
     registry.register(LIST_MEMORY)
     registry.register(READ_MEMORY_BODY)

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -2,12 +2,13 @@
 
 Three capabilities are registered here:
 
-  CALL_MCP_TOOL   — gates.router=allow, gates.phase=allow
+  CALL_MCP_TOOL    — gates.router=allow, gates.phase=allow
   LIST_MCP_SERVERS — gates.router=allow, gates.phase=allow  (Type C closure)
-  LIST_MCP_TOOLS  — gates.router=allow, gates.phase=allow  (Type C closure)
+  LIST_MCP_TOOLS   — gates.router=allow, gates.phase=allow  (Type C closure)
+  DESCRIBE_MCP_TOOL — gates.router=allow, gates.phase=allow (FP-0032 D4)
 
 Per ADR-0026 Open Q #6, router-side fine-grained names are canonical:
-call_mcp_tool / list_mcp_servers / list_mcp_tools.
+call_mcp_tool / list_mcp_servers / list_mcp_tools / describe_mcp_tool.
 
 ## Phase-side dispatch status (M3 metadata-only)
 
@@ -43,9 +44,13 @@ is handled by the caller per ADR-0026 M3 wave pattern.
 """
 from __future__ import annotations
 
-from typing import Any, Mapping
+import copy
+from typing import TYPE_CHECKING, Any, Mapping
 
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+if TYPE_CHECKING:
+    from reyn.tools.types import RouterCallerState
 
 # ── Description constants (byte-identical to router_tools.py D1/D2/D3) ────────
 
@@ -60,8 +65,14 @@ _LIST_MCP_TOOLS_DESCRIPTION = (
 )
 
 _CALL_MCP_TOOL_DESCRIPTION = (
-    "Invoke an MCP server tool. Construct args matching "
-    "the tool's input schema (see list_mcp_tools)."
+    "Invoke a mcp_tool on an MCP server. Construct args matching "
+    "the mcp_tool's input schema (see describe_mcp_tool)."
+)
+
+_DESCRIBE_MCP_TOOL_DESCRIPTION = (
+    "Get the input schema for one mcp_tool registered on an MCP server. "
+    "Call this before call_mcp_tool if you're unsure how to "
+    "construct the args."
 )
 
 
@@ -84,11 +95,38 @@ _LIST_MCP_TOOLS_PARAMETERS: dict[str, Any] = {
 _CALL_MCP_TOOL_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "server": {"type": "string"},
-        "tool": {"type": "string"},
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+        "mcp_tool_name": {
+            "type": "string",
+            "description": (
+                "Dotted mcp_tool identifier: <server>.<tool> — choose from "
+                "the enum. Use describe_mcp_tool for the full input schema."
+            ),
+        },
         "args": {"type": "object"},
     },
-    "required": ["server", "tool", "args"],
+    "required": ["server", "mcp_tool_name", "args"],
+}
+
+_DESCRIBE_MCP_TOOL_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+        "mcp_tool_name": {
+            "type": "string",
+            "description": (
+                "Dotted mcp_tool identifier: <server>.<tool> — choose from "
+                "the enum."
+            ),
+        },
+    },
+    "required": ["server", "mcp_tool_name"],
 }
 
 
@@ -129,12 +167,24 @@ async def _handle_list_mcp_tools(
     Router path: delegates to host.mcp_list_tools(server) via ctx.router_state.
     Phase path: registered with gates.phase=allow (Type C metadata closure),
     but phase-side Control IR executor wiring is deferred to M4.
+
+    FP-0032: returns ``mcp_tools`` key (not ``tools``) to avoid structural
+    collision with OpenAI tool-definition shape. Each entry is trimmed to
+    ``{name, description}`` only — ``inputSchema`` is omitted so the LLM
+    cannot mistake an mcp_tool for a top-level callable. Full schema is
+    available via ``describe_mcp_tool``.
     """
     if ctx.caller_kind == "router":
         host = _require_host(ctx)
         server = str(args["server"])
         result = await host.mcp_list_tools(server)
-        return {"tools": result}
+        # Strip inputSchema from each entry so the shape does not resemble
+        # an OpenAI tool definition (FP-0032 root-cause fix).
+        trimmed = [
+            {k: v for k, v in t.items() if k != "inputSchema"}
+            for t in (result or [])
+        ]
+        return {"mcp_tools": trimmed}
 
     return {
         "error": (
@@ -165,9 +215,12 @@ async def _handle_call_mcp_tool(
     if ctx.caller_kind == "router":
         host = _require_host(ctx)
         server = str(args["server"])
-        tool = str(args["tool"])
+        mcp_tool_name = str(args["mcp_tool_name"])
+        # Dotted form "server.tool_name" → extract the bare tool name for MCPClient.
+        # If the caller passed a bare name (no dot), use it as-is for compatibility.
+        bare_tool = mcp_tool_name.split(".", 1)[-1] if "." in mcp_tool_name else mcp_tool_name
         tool_args = dict(args.get("args") or {})
-        return await host.mcp_call_tool(server, tool, tool_args)
+        return await host.mcp_call_tool(server, bare_tool, tool_args)
 
     # Phase path: build MCPIROp and dispatch through op_runtime.
     # Lazy import to avoid circular dependency at registry-init time.
@@ -177,7 +230,9 @@ async def _handle_call_mcp_tool(
     from reyn.schemas.models import MCPIROp
 
     server = str(args["server"])
-    tool = str(args["tool"])
+    mcp_tool_name = str(args["mcp_tool_name"])
+    # Dotted form → extract bare tool name for MCPIROp.
+    tool = mcp_tool_name.split(".", 1)[-1] if "." in mcp_tool_name else mcp_tool_name
     tool_args = dict(args.get("args") or {})
 
     op = MCPIROp(kind="mcp", server=server, tool=tool, args=tool_args)
@@ -258,6 +313,93 @@ def _require_host(ctx: ToolContext) -> Any:
     )
 
 
+# ── FP-0032: Schema enricher for call_mcp_tool / describe_mcp_tool ───────────
+
+
+def _enrich_router_schema(rendered: dict, state: "RouterCallerState") -> dict:
+    """Inject server + mcp_tool_name enums from currently-configured MCP servers.
+
+    The enum lists are dynamic: they depend on which MCP servers are wired into
+    the current chat session (= reyn.yaml `mcp` config + per-server tool listings).
+    Without these enums, the LLM could emit arbitrary string values for
+    ``server`` and ``mcp_tool_name``, leading to runtime "unknown server" errors
+    or the FP-0032 bug (LLM emits a bare mcp_tool_name as if it were a
+    top-level tool call).
+
+    ``mcp_servers`` entries: [{name, description, ...}, ...] — may optionally
+    carry a ``tools`` list [{name, ...}, ...] for tool-level enum injection.
+    When ``tools`` is absent (common: tool listing requires async enumeration),
+    the mcp_tool_name enum is omitted and the field stays a plain string.
+
+    Returns a NEW dict — does not mutate the input.
+    """
+    mcp_servers = state.mcp_servers or []
+    server_names = [str(s["name"]) for s in mcp_servers if "name" in s]
+    mcp_tool_names = [
+        f"{s['name']}.{t['name']}"
+        for s in mcp_servers
+        for t in s.get("tools", [])
+        if "name" in s and "name" in t
+    ]
+    new = copy.deepcopy(rendered)
+    props = new["function"]["parameters"]["properties"]
+    server_prop = props.get("server")
+    mcp_tool_prop = props.get("mcp_tool_name")
+    if server_prop is not None:
+        if server_names:
+            server_prop["enum"] = server_names
+        else:
+            server_prop.pop("enum", None)
+    if mcp_tool_prop is not None:
+        if mcp_tool_names:
+            mcp_tool_prop["enum"] = mcp_tool_names
+        else:
+            mcp_tool_prop.pop("enum", None)
+    return new
+
+
+# ── FP-0032 D4: describe_mcp_tool handler ────────────────────────────────────
+
+
+async def _handle_describe_mcp_tool(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Return {name, description, input_schema} for the requested mcp_tool.
+
+    Router path: calls host.mcp_list_tools(server) to get the tool listing,
+    then filters to the requested mcp_tool_name. The dotted form
+    ``<server>.<tool>`` is resolved to the bare tool name for the lookup.
+
+    Phase path: deferred to M4 (metadata closure only — same as list_mcp_tools).
+    """
+    if ctx.caller_kind == "router":
+        host = _require_host(ctx)
+        server = str(args["server"])
+        mcp_tool_name = str(args["mcp_tool_name"])
+        bare_tool = mcp_tool_name.split(".", 1)[-1] if "." in mcp_tool_name else mcp_tool_name
+        all_tools = await host.mcp_list_tools(server) or []
+        for t in all_tools:
+            if str(t.get("name", "")) == bare_tool:
+                return {
+                    "name": t.get("name"),
+                    "description": t.get("description", ""),
+                    "input_schema": t.get("inputSchema", {}),
+                }
+        return {
+            "error": (
+                f"mcp_tool {mcp_tool_name!r} not found on server {server!r}. "
+                "Use list_mcp_tools to see available mcp_tools."
+            )
+        }
+
+    return {
+        "error": (
+            "describe_mcp_tool phase-side dispatch not yet wired "
+            "(M4 task). ToolDefinition registered for metadata closure only."
+        )
+    }
+
+
 # ── ToolDefinitions ───────────────────────────────────────────────────────────
 
 LIST_MCP_SERVERS = ToolDefinition(
@@ -288,6 +430,18 @@ CALL_MCP_TOOL = ToolDefinition(
     handler=_handle_call_mcp_tool,
     category="discovery",
     purity="side_effect",  # call_mcp_tool has arbitrary side effects
+    schema_enricher=_enrich_router_schema,
+)
+
+DESCRIBE_MCP_TOOL = ToolDefinition(
+    name="describe_mcp_tool",
+    description=_DESCRIBE_MCP_TOOL_DESCRIPTION,
+    parameters=_DESCRIBE_MCP_TOOL_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_describe_mcp_tool,
+    category="discovery",
+    purity="read_only",
+    schema_enricher=_enrich_router_schema,
 )
 
 

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -140,6 +140,14 @@ class RouterCallerState:
     remember_fn: Callable[..., Awaitable[Any]] | None = None
     forget_fn: Callable[[str, str], Awaitable[Any]] | None = None
 
+    # FP-0032: MCP server list for enum injection into call_mcp_tool /
+    # describe_mcp_tool. Shape: [{name, description, tools?: [{name, ...}]}, ...]
+    # Matches the ``mcp_servers`` arg passed to build_tools() and
+    # build_system_prompt().  Populated by RouterLoop when building the
+    # RouterCallerState for MCP tool dispatch.  When None, enum injection
+    # is skipped and the schema falls back to plain string (graceful empty case).
+    mcp_servers: list[Mapping[str, Any]] | None = None
+
 
 @dataclass
 class PhaseCallerState:

--- a/tests/test_mcp_search_tool_invariants.py
+++ b/tests/test_mcp_search_tool_invariants.py
@@ -53,61 +53,73 @@ def _tool_names(tools: list[dict]) -> set[str]:
 
 
 def test_below_threshold_uses_inline_mcp_tools():
-    """Tier 2: build_tools() < threshold → inline D1–D3 MCP tools present; no search tool.
+    """Tier 2: build_tools() < explicit threshold → inline D1–D4 MCP tools present; no search tool.
 
     FP-0024 Component D backward-compat invariant: when MCP server count
     is strictly below mcp_search_threshold, behavior is identical to pre-FP-0024
-    (D1–D3 inline tools, no tool_search_tool entry in the catalog).
+    (D1–D4 inline tools, no tool_search_tool entry in the catalog).
+
+    FP-0032: MCP_SEARCH_THRESHOLD is now 0 (default-off for Anthropic-specific
+    tool_search_tool). This test uses an explicit threshold > 0 to test the
+    threshold gate logic.
     """
-    # Use threshold-1 servers to stay below the threshold.
-    below_count = max(1, MCP_SEARCH_THRESHOLD - 1)
+    # Use an explicit threshold to test the threshold-gate logic.
+    # FP-0032: MCP_SEARCH_THRESHOLD defaults to 0 (opt-in only); use 5 here.
+    _explicit_threshold = 5
+    below_count = max(1, _explicit_threshold - 1)
     servers = _make_mcp_servers(below_count)
 
     tools = build_tools(
         _SAMPLE_SKILLS,
         _SAMPLE_AGENTS,
         mcp_servers=servers,
-        mcp_search_threshold=MCP_SEARCH_THRESHOLD,
+        mcp_search_threshold=_explicit_threshold,
     )
     names = _tool_names(tools)
 
-    # All three inline MCP tools must be present.
-    missing = _INLINE_MCP_TOOL_NAMES - names
+    # All four inline MCP tools must be present (FP-0032 adds describe_mcp_tool).
+    _INLINE_MCP_TOOL_NAMES_FP0032 = _INLINE_MCP_TOOL_NAMES | {"describe_mcp_tool"}
+    missing = _INLINE_MCP_TOOL_NAMES_FP0032 - names
     assert not missing, (
         f"Inline MCP tools missing below threshold (count={below_count}, "
-        f"threshold={MCP_SEARCH_THRESHOLD}): {missing}. Got names: {names}"
+        f"threshold={_explicit_threshold}): {missing}. Got names: {names}"
     )
 
     # tool_search_tool must NOT be present.
     assert "tool_search" not in names, (
         f"tool_search unexpectedly present below threshold "
-        f"(count={below_count}, threshold={MCP_SEARCH_THRESHOLD})"
+        f"(count={below_count}, threshold={_explicit_threshold})"
     )
 
 
 def test_above_threshold_uses_search_tool():
-    """Tier 2: build_tools() >= threshold → tool_search_tool present; inline D1–D3 absent.
+    """Tier 2: build_tools() >= explicit threshold → tool_search_tool present; inline D1–D3 absent.
 
     FP-0024 Component D core invariant: when MCP server count meets or exceeds
-    mcp_search_threshold, the catalog contains exactly the tool_search_tool
+    an explicit mcp_search_threshold > 0, the catalog contains the tool_search_tool
     meta-tool and none of the individual D1–D3 MCP management tools.
+
+    FP-0032: MCP_SEARCH_THRESHOLD is now 0 (Anthropic tool_search_tool default-off).
+    Callers must opt in by passing mcp_search_threshold > 0. This test validates the
+    threshold gate still works when explicitly set.
     """
-    # Use threshold servers (>= threshold triggers the switch).
-    at_count = MCP_SEARCH_THRESHOLD
+    # Use an explicit threshold to test the threshold-gate logic.
+    _explicit_threshold = 5
+    at_count = _explicit_threshold
     servers = _make_mcp_servers(at_count)
 
     tools = build_tools(
         _SAMPLE_SKILLS,
         _SAMPLE_AGENTS,
         mcp_servers=servers,
-        mcp_search_threshold=MCP_SEARCH_THRESHOLD,
+        mcp_search_threshold=_explicit_threshold,
     )
     names = _tool_names(tools)
 
     # tool_search meta-tool must be present.
     assert "tool_search" in names, (
-        f"tool_search missing at threshold "
-        f"(count={at_count}, threshold={MCP_SEARCH_THRESHOLD}). Got names: {names}"
+        f"tool_search missing at explicit threshold "
+        f"(count={at_count}, threshold={_explicit_threshold}). Got names: {names}"
     )
 
     # Inline D1–D3 tools must NOT be present (schema-load savings require exclusion).

--- a/tests/test_mcp_unified.py
+++ b/tests/test_mcp_unified.py
@@ -1,8 +1,9 @@
 """Tier 2: MCP ToolDefinitions M3 Wave 2 invariants (ADR-0026 M3 + Type C closure).
 
 Verifies that CALL_MCP_TOOL, LIST_MCP_SERVERS, and LIST_MCP_TOOLS ToolDefinitions:
-- Produce byte-identical description/parameters output to the prior ToolSpec
-  literals in router_tools.py. Drift would invalidate replay fixtures.
+- Produce correct description/parameters output matching the FP-0032 contract.
+  (Prior byte-identity tests against the legacy ``tool`` param name have been
+  updated to reflect the FP-0032 vocabulary unification: ``tool`` → ``mcp_tool_name``.)
 - Have the correct gates (all 3 have router=allow, phase=allow — Type C closure).
 - Have correct purity and category.
 - Are renderable via render_for_router() and render_for_phase().
@@ -31,30 +32,29 @@ from reyn.tools.registry import ToolRegistry
 # ── 1. CALL_MCP_TOOL — byte-identity gate ─────────────────────────────────────
 
 def test_call_mcp_tool_router_render_exact_description():
-    """Tier 2: CALL_MCP_TOOL description is byte-identical to the legacy ToolSpec
-    description in router_tools.py D3. Any diff is a stop signal."""
+    """Tier 2: CALL_MCP_TOOL description matches the FP-0032 vocabulary contract
+    (mcp_tool_name instead of tool, describe_mcp_tool instead of list_mcp_tools)."""
     rendered = CALL_MCP_TOOL.render_for_router()
-    legacy_description = (
-        "Invoke an MCP server tool. Construct args matching "
-        "the tool's input schema (see list_mcp_tools)."
+    fp0032_description = (
+        "Invoke a mcp_tool on an MCP server. Construct args matching "
+        "the mcp_tool's input schema (see describe_mcp_tool)."
     )
-    assert rendered["function"]["description"] == legacy_description
+    assert rendered["function"]["description"] == fp0032_description
 
 
 def test_call_mcp_tool_router_render_exact_parameters():
-    """Tier 2: CALL_MCP_TOOL parameters schema is byte-identical to the legacy
-    ToolSpec parameters in router_tools.py D3."""
+    """Tier 2: CALL_MCP_TOOL parameters schema matches the FP-0032 contract
+    (mcp_tool_name replaces tool; enum-injectable descriptions on server + mcp_tool_name)."""
     rendered = CALL_MCP_TOOL.render_for_router()
-    legacy_parameters = {
-        "type": "object",
-        "properties": {
-            "server": {"type": "string"},
-            "tool": {"type": "string"},
-            "args": {"type": "object"},
-        },
-        "required": ["server", "tool", "args"],
-    }
-    assert rendered["function"]["parameters"] == legacy_parameters
+    params = rendered["function"]["parameters"]
+    assert params["type"] == "object"
+    assert "server" in params["properties"]
+    assert "mcp_tool_name" in params["properties"]
+    assert "args" in params["properties"]
+    assert "tool" not in params["properties"], (
+        "Legacy 'tool' param must be removed — FP-0032 renames to 'mcp_tool_name'"
+    )
+    assert set(params["required"]) == {"server", "mcp_tool_name", "args"}
 
 
 def test_call_mcp_tool_router_render_name():
@@ -198,12 +198,15 @@ def test_all_mcp_tools_category_discovery():
 
 def test_call_mcp_tool_render_for_phase_shape():
     """Tier 2: CALL_MCP_TOOL.render_for_phase() has kind, description, args_schema,
-    purity with correct values."""
+    purity with correct FP-0032 values (mcp_tool_name instead of tool)."""
     rendered = CALL_MCP_TOOL.render_for_phase()
     assert rendered["kind"] == "call_mcp_tool"
     assert rendered["description"] == _CALL_MCP_TOOL_DESCRIPTION
-    assert rendered["args_schema"]["properties"]["server"] == {"type": "string"}
-    assert rendered["args_schema"]["properties"]["tool"] == {"type": "string"}
+    assert "server" in rendered["args_schema"]["properties"]
+    assert "mcp_tool_name" in rendered["args_schema"]["properties"]
+    assert "tool" not in rendered["args_schema"]["properties"], (
+        "Legacy 'tool' key must not appear in render_for_phase — FP-0032 rename"
+    )
     assert rendered["args_schema"]["properties"]["args"] == {"type": "object"}
     assert rendered["purity"] == "side_effect"
 
@@ -284,10 +287,12 @@ def test_call_mcp_tool_args_schema_accepts_object():
 
 
 def test_call_mcp_tool_required_fields():
-    """Tier 2: call_mcp_tool requires exactly server + tool + args (no optional
-    wriggle room in the required list — all 3 must be provided)."""
+    """Tier 2: call_mcp_tool requires exactly server + mcp_tool_name + args
+    (FP-0032 vocabulary: 'tool' renamed to 'mcp_tool_name')."""
     params = dict(CALL_MCP_TOOL.parameters)
-    assert set(params["required"]) == {"server", "tool", "args"}
+    assert set(params["required"]) == {"server", "mcp_tool_name", "args"}, (
+        "FP-0032: 'tool' must be replaced by 'mcp_tool_name' in required fields"
+    )
 
 
 def test_call_mcp_tool_render_for_router_top_level_shape():

--- a/tests/test_router_call_mcp_tool_enum.py
+++ b/tests/test_router_call_mcp_tool_enum.py
@@ -1,0 +1,495 @@
+"""Tier 2: FP-0032 MCP catalog parity — enum injection + describe_mcp_tool + SP flat list.
+
+Verifies the three-layer affordance control gap between skill/agent and MCP is closed:
+  1. Schema enum: call_mcp_tool.server and call_mcp_tool.mcp_tool_name get enum injection.
+  2. SP flat list: system prompt contains "## MCP servers and tools" flat listing.
+  3. Describe helper: describe_mcp_tool is registered and returns full input_schema.
+
+Also pins:
+  - Vocabulary unification: 'tool' → 'mcp_tool_name' in call_mcp_tool parameters.
+  - list_mcp_tools returns 'mcp_tools' key (not 'tools') and omits inputSchema.
+  - MCP_SEARCH_THRESHOLD == 0 (Anthropic tool_search_tool default-off).
+  - describe_mcp_tool has same enum injection as call_mcp_tool (symmetry invariant).
+
+Pattern source: tests/test_router_invoke_skill_enum.py.
+Policy: Tier 2, real instances, no unittest.mock / MagicMock / AsyncMock / patch.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.chat.router_tools import MCP_SEARCH_THRESHOLD, build_tools
+from reyn.tools import get_default_registry
+from reyn.tools.mcp import (
+    DESCRIBE_MCP_TOOL,
+    _handle_list_mcp_tools,
+)
+from reyn.tools.types import RouterCallerState, ToolContext
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_SKILLS = [{"name": "direct_llm", "description": "Direct LLM call", "category": "general"}]
+_AGENTS = [{"name": "researcher", "role": "Research agent", "cluster": "default"}]
+_EMPTY_MEMORY: dict = {"status": "not_found", "content": ""}
+
+_MCP_SERVERS_NO_TOOLS = [
+    {"name": "brave", "description": "Brave Search MCP"},
+    {"name": "github", "description": "GitHub MCP"},
+]
+
+_MCP_SERVERS_WITH_TOOLS = [
+    {
+        "name": "brave",
+        "description": "Brave Search MCP",
+        "tools": [
+            {"name": "search", "description": "Search the web", "inputSchema": {"type": "object"}},
+            {"name": "news", "description": "News search", "inputSchema": {"type": "object"}},
+        ],
+    },
+    {
+        "name": "github",
+        "description": "GitHub MCP",
+        "tools": [
+            {"name": "create_issue", "description": "Create a new issue", "inputSchema": {"type": "object"}},
+        ],
+    },
+]
+
+
+def _get_tool(tools: list[dict], name: str) -> dict | None:
+    """Return the function-level dict for the named tool, or None."""
+    for t in tools:
+        if t.get("type") == "function" and t["function"]["name"] == name:
+            return t["function"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# (1) Vocabulary unification: 'tool' → 'mcp_tool_name'
+# ---------------------------------------------------------------------------
+
+
+def test_call_mcp_tool_param_renamed_to_mcp_tool_name():
+    """Tier 2: call_mcp_tool.parameters uses 'mcp_tool_name', not 'tool'.
+
+    FP-0032 vocabulary unification: the old 'tool' param collided with OpenAI's
+    standard 'tool' semantics. 'mcp_tool_name' is unambiguous.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    fn = _get_tool(tools, "call_mcp_tool")
+    assert fn is not None, "call_mcp_tool must be present when mcp_servers are configured"
+    props = fn["parameters"]["properties"]
+    assert "mcp_tool_name" in props, (
+        "call_mcp_tool must have 'mcp_tool_name' parameter (FP-0032 rename)"
+    )
+    assert "tool" not in props, (
+        "Legacy 'tool' param must be absent from call_mcp_tool (FP-0032 rename)"
+    )
+    assert "mcp_tool_name" in fn["parameters"]["required"], (
+        "'mcp_tool_name' must be in required fields"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) Schema enum injection: server
+# ---------------------------------------------------------------------------
+
+
+def test_call_mcp_tool_server_enum_injected():
+    """Tier 2: call_mcp_tool.server gets an enum from configured mcp_servers.
+
+    P4 alignment: LLM can only pick from OS-provided server names.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    fn = _get_tool(tools, "call_mcp_tool")
+    assert fn is not None
+    server_schema = fn["parameters"]["properties"]["server"]
+    assert "enum" in server_schema, (
+        "call_mcp_tool.server must have an enum when mcp_servers are configured"
+    )
+    assert set(server_schema["enum"]) == {"brave", "github"}, (
+        f"server enum must match mcp_servers names; got {server_schema['enum']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) Schema enum injection: mcp_tool_name (dotted form)
+# ---------------------------------------------------------------------------
+
+
+def test_call_mcp_tool_mcp_tool_name_enum_injected_when_tools_available():
+    """Tier 2: call_mcp_tool.mcp_tool_name gets an enum in dotted form when
+    mcp_servers entries carry a 'tools' list.
+
+    Dotted form <server>.<tool> avoids name collision across servers.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=_MCP_SERVERS_WITH_TOOLS)
+    fn = _get_tool(tools, "call_mcp_tool")
+    assert fn is not None
+    tool_name_schema = fn["parameters"]["properties"]["mcp_tool_name"]
+    assert "enum" in tool_name_schema, (
+        "call_mcp_tool.mcp_tool_name must have an enum when server tool listings are available"
+    )
+    expected = {"brave.search", "brave.news", "github.create_issue"}
+    assert set(tool_name_schema["enum"]) == expected, (
+        f"mcp_tool_name enum must use dotted form; got {tool_name_schema['enum']}"
+    )
+
+
+def test_call_mcp_tool_no_mcp_tool_name_enum_when_no_tools_listed():
+    """Tier 2: call_mcp_tool.mcp_tool_name is plain string when mcp_servers
+    don't carry tool listings (common: async enumeration not done yet).
+
+    Graceful fallback: schema remains valid, no empty enum.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    fn = _get_tool(tools, "call_mcp_tool")
+    assert fn is not None
+    tool_name_schema = fn["parameters"]["properties"]["mcp_tool_name"]
+    assert "enum" not in tool_name_schema, (
+        "call_mcp_tool.mcp_tool_name must NOT have an enum when no tool listings are present "
+        f"(got: {tool_name_schema})"
+    )
+    assert tool_name_schema.get("type") == "string"
+
+
+# ---------------------------------------------------------------------------
+# (4) No enum when no mcp_servers configured
+# ---------------------------------------------------------------------------
+
+
+def test_call_mcp_tool_not_present_when_no_mcp_servers():
+    """Tier 2: call_mcp_tool is absent from the tool list when mcp_servers=[].
+
+    Same pattern as invoke_skill being absent when available_skills=[].
+    An empty-server catalog should not present MCP tools at all.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=[])
+    names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
+    assert "call_mcp_tool" not in names, (
+        "call_mcp_tool must be absent when mcp_servers is empty"
+    )
+    assert "describe_mcp_tool" not in names, (
+        "describe_mcp_tool must be absent when mcp_servers is empty"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (5) describe_mcp_tool registered in default registry
+# ---------------------------------------------------------------------------
+
+
+def test_describe_mcp_tool_registered_in_default_registry():
+    """Tier 2: describe_mcp_tool appears in get_default_registry() (D4 registration).
+
+    Mirrors test for describe_skill registration. Missing registration means
+    the tool is unreachable from the router dispatch path.
+    """
+    registry = get_default_registry()
+    describe_def = registry.lookup("describe_mcp_tool")
+    assert describe_def is not None, (
+        "describe_mcp_tool must be registered in get_default_registry()"
+    )
+    assert describe_def.name == "describe_mcp_tool"
+    assert describe_def.gates.router == "allow"
+    assert describe_def.gates.phase == "allow"
+
+
+# ---------------------------------------------------------------------------
+# (6) describe_mcp_tool handler returns input_schema
+# ---------------------------------------------------------------------------
+
+
+def test_describe_mcp_tool_handler_returns_input_schema():
+    """Tier 2: describe_mcp_tool handler returns {name, description, input_schema}
+    for a valid mcp_tool_name via a fake host adapter.
+
+    Uses a real ToolContext + real handler; no mocks.
+    """
+    class _FakeHost:
+        async def mcp_list_tools(self, server: str) -> list[dict]:
+            return [
+                {
+                    "name": "search",
+                    "description": "Search the web",
+                    "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            ]
+        async def mcp_list_servers(self) -> list[dict]:
+            return [{"name": "brave", "description": "Brave"}]
+        async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+            return {}
+
+    host = _FakeHost()
+    rs = RouterCallerState(host=host)
+    ctx = ToolContext(
+        caller_kind="router",
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        router_state=rs,
+    )
+
+    result = asyncio.run(
+        DESCRIBE_MCP_TOOL.handler(
+            {"server": "brave", "mcp_tool_name": "brave.search"},
+            ctx,
+        )
+    )
+    assert "error" not in result, f"describe_mcp_tool returned error: {result}"
+    assert result.get("name") == "search"
+    assert "input_schema" in result, "describe_mcp_tool must return 'input_schema' key"
+    assert result["input_schema"] == {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# (7) describe_mcp_tool enum mirrors call_mcp_tool (symmetry invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_describe_mcp_tool_enum_mirrors_call_mcp_tool():
+    """Tier 2: describe_mcp_tool.server + mcp_tool_name enums are identical to
+    call_mcp_tool's enums when mcp_servers carry tool listings.
+
+    Symmetry invariant: both tools constrain LLM to the same candidate set.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=_MCP_SERVERS_WITH_TOOLS)
+    call_fn = _get_tool(tools, "call_mcp_tool")
+    describe_fn = _get_tool(tools, "describe_mcp_tool")
+    assert call_fn is not None, "call_mcp_tool must be present"
+    assert describe_fn is not None, "describe_mcp_tool must be present"
+
+    call_server_enum = call_fn["parameters"]["properties"]["server"].get("enum")
+    describe_server_enum = describe_fn["parameters"]["properties"]["server"].get("enum")
+    assert call_server_enum == describe_server_enum, (
+        f"server enum mismatch: call={call_server_enum}, describe={describe_server_enum}"
+    )
+
+    call_tool_enum = call_fn["parameters"]["properties"]["mcp_tool_name"].get("enum")
+    describe_tool_enum = describe_fn["parameters"]["properties"]["mcp_tool_name"].get("enum")
+    assert call_tool_enum == describe_tool_enum, (
+        f"mcp_tool_name enum mismatch: call={call_tool_enum}, describe={describe_tool_enum}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (8) list_mcp_tools returns 'mcp_tools' key
+# ---------------------------------------------------------------------------
+
+
+def test_list_mcp_tools_returns_mcp_tools_key():
+    """Tier 2: _handle_list_mcp_tools returns {'mcp_tools': [...]} not {'tools': [...]}.
+
+    FP-0032 root-cause fix: 'tools' key collided with OpenAI tool-definition shape,
+    causing the LLM to interpret listed mcp_tools as top-level callables.
+    """
+    class _FakeHost:
+        async def mcp_list_tools(self, server: str) -> list[dict]:
+            return [{"name": "search", "description": "Search", "inputSchema": {}}]
+        async def mcp_list_servers(self) -> list[dict]:
+            return []
+        async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+            return {}
+
+    host = _FakeHost()
+    rs = RouterCallerState(host=host)
+    ctx = ToolContext(
+        caller_kind="router",
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        router_state=rs,
+    )
+
+    result = asyncio.run(
+        _handle_list_mcp_tools({"server": "brave"}, ctx)
+    )
+    assert "mcp_tools" in result, (
+        f"list_mcp_tools must return 'mcp_tools' key (FP-0032); got: {list(result.keys())}"
+    )
+    assert "tools" not in result, (
+        "list_mcp_tools must NOT return legacy 'tools' key (FP-0032 rename)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (9) list_mcp_tools omits inputSchema from each entry
+# ---------------------------------------------------------------------------
+
+
+def test_list_mcp_tools_omits_input_schema():
+    """Tier 2: each entry in mcp_tools result has no 'inputSchema' key.
+
+    FP-0032 structural fix: inputSchema presence makes the entry structurally
+    identical to an OpenAI function tool definition, causing the LLM to treat
+    mcp_tools as directly callable. Removing inputSchema breaks the false affordance.
+    Full schema is available via describe_mcp_tool.
+    """
+    class _FakeHost:
+        async def mcp_list_tools(self, server: str) -> list[dict]:
+            return [
+                {"name": "search", "description": "Search", "inputSchema": {"type": "object"}},
+                {"name": "news", "description": "News", "inputSchema": {"type": "object"}},
+            ]
+        async def mcp_list_servers(self) -> list[dict]:
+            return []
+        async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+            return {}
+
+    host = _FakeHost()
+    rs = RouterCallerState(host=host)
+    ctx = ToolContext(
+        caller_kind="router",
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        router_state=rs,
+    )
+
+    result = asyncio.run(
+        _handle_list_mcp_tools({"server": "brave"}, ctx)
+    )
+    for entry in result["mcp_tools"]:
+        assert "inputSchema" not in entry, (
+            f"list_mcp_tools entry must not contain 'inputSchema' (FP-0032); got: {entry}"
+        )
+        assert "name" in entry, "Each mcp_tools entry must have 'name'"
+
+
+# ---------------------------------------------------------------------------
+# (10) System prompt "## MCP servers and tools" flat list
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_renders_flat_mcp_tool_list():
+    """Tier 2: system prompt contains '## MCP servers and tools' section with
+    flat dotted-form tool listing when mcp_servers carry tool info.
+
+    Mirrors the 'Available skills' flat list pattern — provides the LLM with
+    context layer alongside the schema-layer enum constraint.
+    """
+    prompt = build_system_prompt(
+        agent_name="chat",
+        agent_role="assistant",
+        available_skills=_SKILLS,
+        available_agents=[],
+        memory_index=_EMPTY_MEMORY,
+        mcp_servers=_MCP_SERVERS_WITH_TOOLS,
+    )
+    assert "## MCP servers and tools" in prompt, (
+        "SP must contain '## MCP servers and tools' section header"
+    )
+    # Dotted form tool names must appear in the flat list
+    assert "brave.search" in prompt, (
+        "'brave.search' dotted tool name must appear in SP MCP flat list"
+    )
+    assert "brave.news" in prompt, (
+        "'brave.news' dotted tool name must appear in SP MCP flat list"
+    )
+    assert "github.create_issue" in prompt, (
+        "'github.create_issue' dotted tool name must appear in SP MCP flat list"
+    )
+
+
+def test_system_prompt_mcp_section_fallback_when_no_tool_list():
+    """Tier 2: when mcp_servers have no 'tools' list, SP shows server-level entry
+    with hint to use list_mcp_tools to discover mcp_tools.
+
+    Graceful fallback: server is still surfaced; hint replaces the flat list.
+    """
+    prompt = build_system_prompt(
+        agent_name="chat",
+        agent_role="assistant",
+        available_skills=_SKILLS,
+        available_agents=[],
+        memory_index=_EMPTY_MEMORY,
+        mcp_servers=_MCP_SERVERS_NO_TOOLS,
+    )
+    assert "## MCP servers and tools" in prompt, (
+        "SP must still show MCP section even when no tool listings available"
+    )
+    assert "brave" in prompt, "'brave' server name must appear in SP MCP section"
+    assert "list_mcp_tools" in prompt, (
+        "SP must hint 'list_mcp_tools' when mcp_tools are not pre-listed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (11) MCP_SEARCH_THRESHOLD defaults to 0
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_search_threshold_defaults_to_zero():
+    """Tier 2: MCP_SEARCH_THRESHOLD == 0 (FP-0032 default-off for Anthropic tool_search_tool).
+
+    Anthropic's tool_search_tool is provider-specific; Reyn's default must be
+    provider-agnostic. Threshold 0 means always inline (no tool_search_tool).
+    Operators can opt in by setting mcp.search_threshold > 0 in reyn.yaml.
+    """
+    assert MCP_SEARCH_THRESHOLD == 0, (
+        f"MCP_SEARCH_THRESHOLD must be 0 (FP-0032 default-off); got {MCP_SEARCH_THRESHOLD}"
+    )
+
+
+def test_default_threshold_always_inline():
+    """Tier 2: with MCP_SEARCH_THRESHOLD=0 (default), build_tools() always inlines
+    D1–D4 regardless of server count — no tool_search_tool unless explicit opt-in.
+    """
+    # Many servers — with threshold=0, always inline
+    many_servers = [
+        {"name": f"server_{i}", "description": f"Server {i}"}
+        for i in range(50)
+    ]
+    tools = build_tools(
+        _SKILLS,
+        _AGENTS,
+        mcp_servers=many_servers,
+        mcp_search_threshold=MCP_SEARCH_THRESHOLD,  # == 0
+    )
+    names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
+    assert "call_mcp_tool" in names, (
+        "call_mcp_tool must be inline at threshold=0 regardless of server count"
+    )
+    assert "describe_mcp_tool" in names, (
+        "describe_mcp_tool must be inline at threshold=0 regardless of server count"
+    )
+    tool_search_tools = [t for t in tools if t.get("type", "").startswith("tool_search_tool")]
+    assert not tool_search_tools, (
+        "tool_search_tool must NOT appear when threshold=0 (default-off)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (12) describe_mcp_tool present in build_tools output
+# ---------------------------------------------------------------------------
+
+
+def test_describe_mcp_tool_present_in_build_tools():
+    """Tier 2: describe_mcp_tool appears in build_tools() output when mcp_servers
+    are configured (D4 alongside D1–D3).
+
+    Closes the symmetry gap: skill has describe_skill, agent has describe_agent,
+    MCP now has describe_mcp_tool.
+    """
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
+    assert "describe_mcp_tool" in names, (
+        "describe_mcp_tool (D4) must appear in build_tools output alongside D1–D3"
+    )
+
+
+def test_describe_mcp_tool_absent_when_no_mcp_servers():
+    """Tier 2: describe_mcp_tool is absent when mcp_servers=[] (same guard as D1–D3)."""
+    tools = build_tools(_SKILLS, _AGENTS, mcp_servers=None)
+    names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
+    assert "describe_mcp_tool" not in names, (
+        "describe_mcp_tool must be absent when no mcp_servers configured"
+    )

--- a/tests/test_router_tools.py
+++ b/tests/test_router_tools.py
@@ -268,9 +268,10 @@ def test_mcp_tools_present_when_servers_configured():
 
 def test_total_tool_count_with_full_permissions():
     """Full file + MCP permissions → 11 baseline + 4 file C1-C4
-    + 2 web E1+E2 (both always on since FP-0022) + 3 MCP D1-D3
+    + 2 web E1+E2 (both always on since FP-0022) + 4 MCP D1-D4
     + 2 reyn_src F1-F2 + 1 plan G1
-    + 2 RAG H1-H2 (recall + drop_source) = 25 tools total.
+    + 2 RAG H1-H2 (recall + drop_source) = 26 tools total.
+    FP-0032: D4 describe_mcp_tool added alongside D1-D3.
     web_fetch_allowed param is kept for backward compat but now a no-op.
     """
     tools = build_tools(
@@ -280,7 +281,7 @@ def test_total_tool_count_with_full_permissions():
         mcp_servers=SAMPLE_MCP_SERVERS,
         web_fetch_allowed=True,
     )
-    assert len(tools) == 25, f"Expected 25 tools with full permissions, got {len(tools)}"
+    assert len(tools) == 26, f"Expected 26 tools with full permissions, got {len(tools)}"
 
 
 # ── Gemini-safe schema checks apply to new tools too ──────────────────────────


### PR DESCRIPTION
## Summary

Closes #34. Fixes the bug where LLM emits `tool_calls: [{name: "brave_search", ...}]` after `list_mcp_tools` returns `{name, inputSchema}` shape, treating the MCP tool as a top-level callable (= which it isn't — MCP tools are invoked via `call_mcp_tool`).

Root cause: MCP wrapper lacks the 3-layer affordance control (schema enum + SP flat list + describe helper) that skill/agent already have.

## Changes

- **Vocabulary unification**: `tool` → `mcp_tool_name` throughout MCP wrapper (avoids overload with OpenAI's standard "tool"); parameter `args["tool"]` → `args["mcp_tool_name"]`; dotted form `<server>.<tool>` for clarity
- **`list_mcp_tools`**: return key `"tools"` → `"mcp_tools"` (breaks OpenAI-tool-def structural collision); `inputSchema` dropped from each entry (use `describe_mcp_tool` for full schema; mirrors `list_skills`/`describe_skill` pattern)
- **`call_mcp_tool`** + new **`describe_mcp_tool`**: `_enrich_router_schema` injects dynamic enums for `server` + `mcp_tool_name` params (pattern from `invoke_skill._enrich_router_schema`); `RouterCallerState.mcp_servers` field added to carry server list for injection
- **System prompt**: `_render_mcp()` extended to flat-list dotted tool names when server entries carry `tools`; header renamed "MCP servers and tools (resource axis)"; intent axis adds `describe_mcp_tool`
- **`MCP_SEARCH_THRESHOLD`**: 30 → 0 (Anthropic `tool_search_tool_20251101` is provider-specific; Reyn default must be provider-agnostic; opt-in via `mcp.search_threshold > 0`; full removal is FP-0033)
- **`get_default_registry()`**: `DESCRIBE_MCP_TOOL` registered as D4 alongside D1–D3
- **`router_loop._normalise_router_tool_result`**: handles `mcp_tools` key + `describe_mcp_tool` dispatch
- **`planner._MCP_TOOL_NAMES`**: adds `describe_mcp_tool`

## Symmetry gap closed

| Control layer | skill | agent | MCP (before) | MCP (after) |
|---|---|---|---|---|
| schema enum | ✓ `invoke_skill.name` | ✓ `delegate_to_agent.to` | ✗ | ✓ `call_mcp_tool.server` + `mcp_tool_name` |
| SP flat list | ✓ "Available skills" | ✓ "Available agents" | ✗ (server names only) | ✓ "Available MCP tools" |
| describe helper | ✓ `describe_skill` | ✓ `describe_agent` | ✗ | ✓ `describe_mcp_tool` |

## Test plan

- [x] `pytest tests/test_router_call_mcp_tool_enum.py -v` — 16 new Tier 2 tests pass
- [x] `pytest tests/ -k mcp -v` — 232 MCP tests pass, no regression
- [x] `pytest -q` — 2598 passed, 4 skipped, 2 xfailed (full suite green)
- [x] `ruff check` — clean on all changed files
- [x] `mkdocs build --strict` — builds successfully (pre-existing anchor warnings unchanged)
- [x] Vocabulary check: `grep -rn '"tool":' src/reyn/tools/mcp.py` — zero hits
- [ ] Manual: invoke MCP tool end-to-end via `reyn web` A2A endpoint

## Prerequisites for FP-0034

Phase 0 of #36 — must land before FP-0034 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)