### PR TITLE
research: FP-0010/0024/0028-34 実装レビュー + Control IR gap 調査 + FP-0036 アセスメント

### DIFF
--- a/docs/deep-dives/research/control-ir-gap-rag-ops.md
+++ b/docs/deep-dives/research/control-ir-gap-rag-ops.md
@@ -1,0 +1,322 @@
+---
+type: research
+topic: control-ir / RAG ops documentation gap
+status: stable
+last_updated: 2026-05-17
+audience: [writer, implementer]
+---
+
+# Control IR Gap Analysis — ADR-0033 RAG ops 未記載問題
+
+## Summary
+
+`docs/reference/runtime/control-ir.md` および `.ja.md` に、ADR-0033 (RAG-extensible OS) で
+実装された 5 つの op が記載されていない。
+English 版は 5 op 欠落、Japanese 版はさらに `mcp_install` も欠落しており計 6 op。
+
+## Gap 一覧
+
+| op kind | `OP_KIND_MODEL_MAP` | control-ir.md | control-ir.ja.md |
+|---|---|---|---|
+| `embed` | ✅ (ADR-0033) | ❌ | ❌ |
+| `index_write` | ✅ (ADR-0033) | ❌ | ❌ |
+| `index_query` | ✅ (ADR-0033) | ❌ | ❌ |
+| `recall` | ✅ (ADR-0033) | ❌ | ❌ |
+| `index_drop` | ✅ (ADR-0033) | ❌ | ❌ |
+| `mcp_install` | ✅ | ✅ | ❌ |
+
+**Source of truth**: `src/reyn/op_runtime/registry.py` — `OP_KIND_MODEL_MAP` が全 op 種別の
+正規リスト。CLAUDE.md ルール: `control-ir.md` は `OP_KIND_MODEL_MAP` と常に同期が必要。
+
+## 調査根拠
+
+- `registry.py` の `OP_KIND_MODEL_MAP` には 17 op kinds が列挙されている。
+- `control-ir.md` の section header を確認したところ RAG ops 5 種が欠落。
+- `control-ir.ja.md` は `mcp_install` セクションも存在しない（English 版には存在）。
+- 各 op の schema / permission は `src/reyn/schemas/models.py` と各 `op_runtime/*.py` で確認済み。
+
+---
+
+## Writer 向け: 追加コンテンツ案
+
+以下は `control-ir.md` の "## `mcp_install`" セクションの直後に挿入する 5 セクションの
+proposed content。Writer はこれをそのまま貼り付けて体裁を整えてください。
+
+---
+
+### `embed`
+
+テキストを埋め込みベクトルに変換する（ADR-0033 §2.1）。2 つの入力形式がある。
+
+**Form A — inline** (小ペイロード、クエリ埋め込みなど):
+
+```json
+{
+  "kind": "embed",
+  "texts": ["What is Reyn?", "How does the OS work?"],
+  "model": "standard"
+}
+```
+
+返値: `{"vectors": [[0.1, ...], [0.2, ...]], "model": "text-embedding-3-small"}`
+
+**Form B — artifact reference** (大ペイロード、インデックス構築など):
+
+```json
+{
+  "kind": "embed",
+  "input_artifact": "chunks.jsonl",
+  "text_field": "text",
+  "output_artifact": "chunks_embedded.jsonl",
+  "model": "standard"
+}
+```
+
+返値: `{"embedded_count": 1024, "skipped_count": 0}`
+
+`model` は `reyn.yaml` の `embedding.classes` マップ内のエントリ名、または
+`"openai/text-embedding-3-small"` のような直接指定。デフォルト `"standard"` は
+`reyn.yaml` で解決される。
+
+**Permission**: なし（外部 API 呼び出しだが現在は permission gate なし）。
+トークンコストは発生する（OpPurity: `external`）。
+
+---
+
+### `index_write`
+
+チャンク（テキスト + ベクトル + メタデータ）をインデックスバックエンドに書き込む
+（ADR-0033 §2.1）。2 つの入力形式がある。
+
+**Form A — inline**:
+
+```json
+{
+  "kind": "index_write",
+  "source": "my_docs",
+  "chunks": [
+    {"text": "Reyn is an agent OS", "vector": [0.1, ...], "metadata": {"file": "intro.md"}}
+  ],
+  "mode": "append",
+  "description": "Project documentation",
+  "path": "docs/**/*.md"
+}
+```
+
+**Form B — artifact reference** (`embed` Form B の出力を直接受け取る):
+
+```json
+{
+  "kind": "index_write",
+  "source": "my_docs",
+  "input_artifact": "chunks_embedded.jsonl",
+  "mode": "replace",
+  "description": "Project documentation",
+  "path": "docs/**/*.md"
+}
+```
+
+`mode: replace` はソース全体を置換し、`append` は追記する。
+
+`description` / `path` を指定すると `SourceManifest` に記録され、
+ルーターシステムプロンプトの "Indexed sources" セクションに反映される
+（LLM が `recall` 対象を正しく選択するために必要）。
+
+**Permission**: なし（ワークスペース内部 write — P5 の `.reyn/` デフォルトゾーン）。
+
+---
+
+### `index_query`
+
+単一ソースに対してセマンティック検索を実行する（ADR-0033 §2.1）。
+直接使用よりも `recall` マクロ op 経由が推奨される。
+
+```json
+{
+  "kind": "index_query",
+  "source": "my_docs",
+  "query_vector": [0.1, 0.2, ...],
+  "top_k": 5,
+  "filters": {"file_type": "md"}
+}
+```
+
+`query_vector` を省略すると enumerate fallback（空リストを返す）。
+
+返値: `{"chunks": [{"text": "...", "score": 0.92, "metadata": {...}}, ...], "mode": "semantic"}`
+
+**Permission**: なし（読み取り専用、OpPurity: `world`）。
+
+---
+
+### `recall`
+
+`embed` + `index_query` を束ねたマクロ op（ADR-0033 §2.1）。
+複数ソースを横断して上位 K チャンクをマージする。
+単一の Control IR op として使用でき、サブ op ごとに P6 イベントが記録される。
+
+```json
+{
+  "kind": "recall",
+  "query": "How does crash recovery work in Reyn?",
+  "sources": ["reyn_code", "my_docs"],
+  "top_k": 5,
+  "embedding_model": "standard",
+  "filters": {}
+}
+```
+
+返値: `{"chunks": [{"text": "...", "score": 0.95, "source": "reyn_code", ...}, ...], "sources_queried": 2}`
+
+`sources` は必須（デフォルトなし）。複数ソースのスコアは比較可能ではないため、
+返値はスコア降順でソートされるが異なるソース間では参考値として扱うこと。
+
+**Permission**: なし（サブ op の `embed` / `index_query` が個別に処理、OpPurity: `external`）。
+
+---
+
+### `index_drop`
+
+インデックスソースを完全に削除する（ADR-0033 §2.1）。破壊的操作のため同意ゲートあり。
+
+```json
+{
+  "kind": "index_drop",
+  "source": "my_docs"
+}
+```
+
+`source` のすべてのチャンクとバックエンドエントリを削除する。元に戻せない。
+
+**Permission**: スキルフロントマターに `permissions.index_drop: true` が必要。
+設定で `permissions.index_drop: deny` とすると全スキルで無効化できる。
+
+---
+
+## `control-ir.ja.md` 向け追加コンテンツ
+
+上記 5 ops の日本語版セクションは以下の通り。
+
+また `.ja.md` には `mcp_install` セクションも存在しないため、
+English 版から翻訳して追加する必要がある（別途 writer 判断）。
+
+---
+
+### `embed`（日本語）
+
+テキストを埋め込みベクトルに変換する（ADR-0033 §2.1）。
+
+**Form A — インライン**（小ペイロード）:
+
+```json
+{"kind": "embed", "texts": ["Reyn とは？"], "model": "standard"}
+```
+
+返値: `{"vectors": [[0.1, ...]], "model": "text-embedding-3-small"}`
+
+**Form B — artifact 参照**（大ペイロード）:
+
+```json
+{
+  "kind": "embed",
+  "input_artifact": "chunks.jsonl",
+  "text_field": "text",
+  "output_artifact": "chunks_embedded.jsonl",
+  "model": "standard"
+}
+```
+
+`model` は `reyn.yaml` の `embedding.classes` エントリ名またはモデル直接指定。
+
+**Permission**: なし（OpPurity: `external`）。
+
+---
+
+### `index_write`（日本語）
+
+チャンク（テキスト + ベクトル + メタデータ）をインデックスバックエンドへ書き込む（ADR-0033 §2.1）。
+
+```json
+{
+  "kind": "index_write",
+  "source": "my_docs",
+  "chunks": [{"text": "...", "vector": [...], "metadata": {}}],
+  "mode": "append",
+  "description": "プロジェクトドキュメント",
+  "path": "docs/**/*.md"
+}
+```
+
+artifact 参照形式（Form B）: `input_artifact` フィールドで JSONL パスを指定。
+
+`description` / `path` を設定するとシステムプロンプトの "Indexed sources" に反映される。
+
+**Permission**: なし（ワークスペース内部 write）。
+
+---
+
+### `index_query`（日本語）
+
+単一ソースに対するセマンティック検索（ADR-0033 §2.1）。通常は `recall` を使用する。
+
+```json
+{"kind": "index_query", "source": "my_docs", "query_vector": [...], "top_k": 5}
+```
+
+**Permission**: なし（読み取り専用）。
+
+---
+
+### `recall`（日本語）
+
+`embed` + `index_query` をまとめたマクロ op（ADR-0033 §2.1）。複数ソース横断検索。
+
+```json
+{
+  "kind": "recall",
+  "query": "クラッシュ回復はどう動くか？",
+  "sources": ["reyn_code", "my_docs"],
+  "top_k": 5
+}
+```
+
+**Permission**: なし（OpPurity: `external`）。
+
+---
+
+### `index_drop`（日本語）
+
+インデックスソースを完全削除する（ADR-0033 §2.1）。破壊的操作。
+
+```json
+{"kind": "index_drop", "source": "my_docs"}
+```
+
+**Permission**: スキルフロントマターに `permissions.index_drop: true` が必要。
+
+---
+
+## 影響範囲
+
+この gap によって生じうる問題:
+1. **スキル作成者が RAG ops を使う方法を知れない**: `control-ir.md` が参照先のため、
+   index_docs スキルや recall_memory スキルを模倣したカスタムスキルを書けない。
+2. **`allowed_ops` 申告漏れ**: スキルフロントマターで `allowed_ops` を正しく申告できない
+   （`index_drop` は permission gate があるため特に重要）。
+3. **`control-ir.md` と `OP_KIND_MODEL_MAP` の同期ルール違反**: CLAUDE.md の
+   「`control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`」ルールに抵触している。
+
+## 推奨アクション
+
+- **Writer**: 上記 proposed content を `control-ir.md`（`## mcp_install` の後）および
+  `control-ir.ja.md`（同位置、`mcp_install` セクションも追加）に追記する。
+- **実装者**: 追加不要（ops は実装済み、gap はドキュメントのみ）。
+- **Issue**: このドキュメントをもとに GitHub issue を発行して追跡する（下記参照）。
+
+## 関連
+
+- `src/reyn/op_runtime/registry.py` — `OP_KIND_MODEL_MAP` 正規リスト
+- `src/reyn/schemas/models.py` — IROp スキーマ定義
+- `src/reyn/op_runtime/embed.py` / `index_write.py` / `index_query.py` / `recall.py` / `index_drop.py`
+- ADR-0033: RAG-extensible OS
+- `docs/deep-dives/research/doc-improvement-proposals.md` — 既存 doc gap リスト

--- a/docs/deep-dives/research/fp-0035-permission-communication-analysis.md
+++ b/docs/deep-dives/research/fp-0035-permission-communication-analysis.md
@@ -1,0 +1,264 @@
+---
+type: research
+topic: FP-0035 Sandbox/Permission LLM Communication — 設計空間分析
+status: stable
+last_updated: 2026-05-17
+audience: [implementer, architect]
+---
+
+# FP-0035 設計空間分析 — Permission Communication パターン
+
+GitHub issue: #39  
+関連: `src/reyn/permissions/permissions.py` / `src/reyn/tools/universal_catalog.py` / `src/reyn/chat/router_tools.py`
+
+---
+
+## 1. 現状の実装サーベイ
+
+FP-0035 が "4 pattern を evaluate する" と言っているが、実装を読むと
+**permission type ごとにすでに異なるパターンが採用されている**。
+まず現状を正確に把握する。
+
+### 1.1 PermissionError メッセージの質（コード直接確認）
+
+| Permission type | メッセージ品質 | LLM への actionability |
+|---|---|---|
+| `file.read` | 高 | YAML スニペット付き。`skill.md` に何を書けばよいかを完全指示 |
+| `file.write` | 高 | 同上 |
+| `shell` | 高 | `permissions: shell: true` を追記するよう指示 |
+| `mcp` | 高 | `permissions: mcp: [server_name]` + FP-0016 エージェント許可リスト説明 |
+| `mcp_install` | 高 | PermissionDecl 未宣言 / 設定 deny / ユーザー拒否を別メッセージで区別 |
+| `index_drop` | 高 | `permissions.index_drop: true` への誘導 |
+| `web.fetch` | **低** | "web fetch denied by config (web.fetch: deny)" or "web fetch denied" のみ |
+| `web.search` | **低** | "web search denied by config (web.search: deny)" のみ |
+| `sandboxed_exec` | n/a | Permission gate なし — `SandboxPolicy` は LLM が op 内で宣言 |
+| budget | n/a | `PermissionError` でなく `budget_exceeded` event + TUI 表示 |
+
+**観察**: `file` / `shell` / `mcp` / `index_drop` は "Pattern B+" として成熟している。
+`web` 系は Pattern B だが error message が non-actionable（LLM が何もできない）。
+
+### 1.2 カタログの permission 反映状況
+
+`universal_catalog.py` の `visible_categories()` は `"web"` を常に含む。
+`router_tools.py` の web_search / web_fetch は FP-0022 以降カタログから外れず、
+実行時に `PermissionResolver` で deny される。
+
+**結果**: `web.search: deny` 設定時でも LLM は `web` カテゴリを `list_actions` で見え、
+`invoke_action("web__web_search", ...)` を試行 → non-actionable エラー → wasted call、
+の完全な Pattern B 失敗ケースが成立する。
+
+---
+
+## 2. Permission type × 認証レイヤー マトリクス
+
+FP-0035 が見落としている重要な軸: **「誰が deny を出しているか」** によって
+最適パターンが異なる。
+
+| 認証レイヤー | 例 | LLM が回復可能か | 最適パターン |
+|---|---|---|---|
+| **Config-deny** (reyn.yaml) | `web.fetch: deny` | ❌ 不可 (operator 設定) | **D: カタログから除外** |
+| **Approval-pending** (未承認) | 未知パスへの file.read | ✅ ask_user で申請可 | **B+: actionable error** |
+| **Decl-missing** (スキル未宣言) | `shell` 未宣言 | ✅ 実行前に設計修正可 | **B+: YAML スニペット付き error** |
+| **Agent-allowlist** (FP-0016) | `allowed_mcp` scope 外 | ❌ 設計レベルの制約 | **B (現状維持)** |
+
+この分類から **universal な 1 pattern** は存在しない。
+正しいフレームワークは「permission type ごとに適切なパターンを選択する」。
+
+---
+
+## 3. Permission type 別の推奨パターン
+
+### 3.1 file.read / file.write — **現状維持 (Pattern B+)**
+
+現在の実装は既に最適に近い:
+- CWD 配下はデフォルト許可 → 多くのケースでエラーが出ない
+- CWD 外への試行 → YAML スニペット付き actionable error
+- LLM はエラーを受けて `ask_user` で追加承認を申請できる
+
+変更不要。ただし dogfood で "wasted call rate" を測定し、
+restrictive scope (e.g., `read_paths: [src/]` のみ許可) で
+Pattern A (upfront disclosure) が有意に改善するかを確認すべき。
+
+**dogfood での検証ポイント**:
+- Pattern A: SP に `## Permitted paths: src/` を追加
+- Pattern B (現状): 試行 → PermissionError フィードバック
+- 比較指標: wasted call 数、plan correctness
+
+### 3.2 web.search / web.fetch — **config-deny は Pattern D、approval は Pattern B+**
+
+**現状の問題**:
+- `web.search: deny` でも `list_actions` に `web` カテゴリが出続ける
+- Non-actionable error のみ → LLM が何もできない
+
+**推奨設計**:
+
+```
+Config check:
+  web.search: deny  → list_actions の web カテゴリから web_search を除外 (Pattern D)
+  web.fetch: deny   → list_actions から web_fetch を除外 (Pattern D)
+
+Session approval:
+  web.fetch: allow not set → 試行 → InterventionBus で approve/deny prompt (Pattern B+)
+  web.search は read-only → config deny 以外は常に allow (現状通り)
+```
+
+`visible_categories()` または `list_actions` ハンドラに
+`permission_resolver._is_config_denied("web.search")` を反映させる改修が必要。
+
+**実装コスト**: SMALL。`universal_catalog.py` の `visible_categories()` か
+`router_tools.py` の Section E に config deny check を追加するだけ。
+
+### 3.3 shell — **現状維持 (Pattern B+)**
+
+`permissions: shell: true` の未宣言は Decl-missing パターン (actionable)。
+Config deny (`--allow-shell` なし) は approval-pending (InterventionBus)。
+メッセージ品質は十分。
+
+### 3.4 mcp — **現状維持 (Pattern B+)**
+
+FP-0016 で Confused Deputy 対策 (`allowed_mcp` allowlist) まで組み込まれており、
+error message は区別済み。変更不要。
+
+### 3.5 sandboxed_exec — **"Declarative" パターンとして維持**
+
+`SandboxPolicy` は LLM が op 内で毎回宣言する設計:
+```json
+{
+  "kind": "sandboxed_exec",
+  "argv": ["python", "script.py"],
+  "policy": {"network": false, "read_paths": ["src/"], "write_paths": [".reyn/"]}
+}
+```
+
+これは A/B/C/D どれとも異なる **"Declarative" パターン**: LLM が制約を宣言し、
+OS がそれに従って backend を選択・実行する。Permission gate が事前に走らないため
+wasted call が発生しない設計になっている。
+
+**変更不要**。ただし `describe_action("exec__sandboxed_exec")` のレスポンスに
+`SandboxPolicy` フィールドの説明を補足すると LLM の policy 選択精度が上がる可能性がある
+(= Phase 2 候補)。
+
+### 3.6 budget — **Pattern A を維持・強化**
+
+Budget は "permission" でなく "resource limit" であり、試行で回復できない。
+現状: `budget_warn` イベント + TUI 表示 (Pattern A partial)。
+
+**推奨**: budget_remaining が threshold を下回った時点で SP に
+`## Budget: ¥{remaining} / ¥{limit} (XX% remaining)` を追加する。
+これにより LLM が大量 web_fetch を控える、あるいは ask_user で方針確認するきっかけになる。
+
+**実装コスト**: SMALL。`router_system_prompt.py` に budget section を条件付きで追加。
+
+---
+
+## 4. FP-0035 の 4 パターン評価（改訂版）
+
+FP-0035 が挙げた 4 パターンを 実装結果から改訂評価:
+
+| Pattern | 適用すべき permission type | 実装状態 |
+|---|---|---|
+| **A. Upfront disclosure** | budget (残量 warning 時) | 未実装 (SP budget section なし) |
+| **B. Trial-and-error** | file / shell / mcp / index_drop (approval-pending / decl-missing) | ✅ 実装済・成熟 |
+| **C. On-demand introspection** | sandboxed_exec policy description | 部分的 (describe_action あり、policy detail なし) |
+| **D. Structural gating** | web.search / web.fetch (config-deny 時) | ❌ **未実装 — 最大の gap** |
+| **"Declarative"** (新パターン) | sandboxed_exec | ✅ 実装済 |
+
+---
+
+## 5. 最大 gap の特定
+
+**最優先で対処すべき gap: web ops の config-deny 時 Pattern D 未実装**
+
+1. `web.search: deny` + `web.fetch: deny` はオペレーター設定であり LLM が回避不可
+2. しかし `list_actions` の `web` カテゴリには変化なし
+3. LLM が試行 → non-actionable error → plan が止まる
+
+これは FP-0035 の "dogfood-first" を待たず修正できる **cost:SMALL のバグ的な改善**。
+独立した issue として早期対処を推奨する。
+
+---
+
+## 6. Phase 1 評価フレームワーク設計（FP-0036 向け入力）
+
+FP-0035 の Phase 1 は「evaluation framework establish」。
+FP-0036 framework が着地したら以下の dogfood シナリオセットで評価する:
+
+### 測定指標
+
+| 指標 | 計測方法 |
+|---|---|
+| Wasted call rate | events log の `permission_denied` 直前の tool call 数 |
+| Plan correctness | judge verifier (rubric: "did LLM achieve the stated goal?") |
+| SP token cost | `context_built` event の `system_prompt_tokens` field |
+| Error recovery rate | `permission_denied` 後に LLM が ask_user or 別路線に転換できたか |
+
+### シナリオ設計案
+
+```yaml
+# dogfood/scenarios/regression/permissions.yaml
+scenarios:
+  - id: file_cwd_boundary
+    covers: [permissions/file-read, permissions/trial-and-error]
+    input: "src/reyn/schemas/models.py を読んで MCPIROp の定義を教えて"
+    expected:
+      events:
+        must_emit: [{type: routing_decided}]
+        must_not_emit: [{type: permission_denied}]
+
+  - id: web_config_deny
+    covers: [permissions/web-config-deny, permissions/structural-gating]
+    input: "最新の Anthropic ニュースを web 検索して教えて"
+    # reyn.yaml: web.search: deny
+    expected:
+      reply:
+        kind: judge
+        rubric:
+          - LLM informs user web search is disabled
+          - LLM does NOT attempt web_search after being told it's unavailable
+      events:
+        must_not_emit: [{type: permission_denied}]  # Pattern D: no wasted call
+
+  - id: restrictive_file_scope
+    covers: [permissions/file-read, permissions/upfront-vs-trial]
+    input: "tests/ ディレクトリの全テストを一覧して"
+    # reyn.yaml: file.read: deny for outside CWD subdir
+    expected:
+      events:
+        # Pattern B: 1 wasted call ok, recovery via ask_user
+        must_emit: [{type: ask_user_presented}]
+```
+
+---
+
+## 7. 推奨アクション
+
+| Priority | アクション | コスト | FP |
+|---|---|---|---|
+| P0 | web config-deny 時に `list_actions` から除外 (Pattern D) | SMALL | 新 issue 発行 |
+| P1 | budget SP section (Pattern A, 残量 threshold 以下で表示) | SMALL | FP-0035 Phase 2 候補 |
+| P2 | FP-0036 framework 着地後に dogfood scenario set `permissions.yaml` を authoring | MEDIUM | FP-0036 scenario wave |
+| P3 | `describe_action("exec__sandboxed_exec")` に SandboxPolicy フィールド説明を追加 (Pattern C 強化) | SMALL | FP-0035 Phase 2 候補 |
+| defer | Pattern A の full file scope disclosure | — | dogfood 結果次第 |
+
+---
+
+## 8. 新 issue 提案: web config-deny Pattern D
+
+上記 P0 の内容を独立 issue として発行:
+
+- `visible_categories()` または `list_actions` handler が `permission_resolver` から
+  `web.search: deny` / `web.fetch: deny` の設定を読み取り、
+  該当 action を除外する
+- `REYN_LLM_RECORD` なしで再現可能なシンプルな改修
+- FP-0034 §D14 の visibility gate (exec / search) と同じ設計思想
+
+---
+
+## 関連
+
+- `src/reyn/permissions/permissions.py` — PermissionResolver + error messages
+- `src/reyn/tools/universal_catalog.py` — `visible_categories()` / `list_actions`
+- `src/reyn/chat/router_tools.py` — Section E web tools (L510–)
+- FP-0034 (#36 closed) — B23-PRE-1 SP simplify、trial-and-error 採択の経緯
+- FP-0036 (#44) — dogfood framework、Phase 1 評価の前提
+- `docs/deep-dives/research/fp-0036-dogfood-framework-assessment.md` — 評価フレームワーク設計

--- a/docs/deep-dives/research/fp-0036-dogfood-framework-assessment.md
+++ b/docs/deep-dives/research/fp-0036-dogfood-framework-assessment.md
@@ -1,0 +1,371 @@
+---
+type: research
+topic: FP-0036 Dogfood Scenario Framework — 実装アセスメント
+status: stable
+last_updated: 2026-05-17
+audience: [implementer, architect]
+---
+
+# FP-0036 実装アセスメント — Dogfood Scenario Framework
+
+GitHub issue: #44  
+関連: `dogfood-discipline.md` / `src/reyn/testing/replay.py` / `docs/feature-map.md`
+
+---
+
+## 1. 現状把握
+
+FP-0036 で "今あるもの" として列挙された 3 つの確認結果:
+
+| 要素 | 確認結果 |
+|---|---|
+| `dogfood/scenarios/*.yaml` | ✅ 存在。`long_session_v1.yaml` (7 multi-turn) / `fp_0011_0012_retest.yaml` / `fp_0011_narration.yaml` — いずれも `expected` なし、runner なし |
+| `reyn eval` (FP-0007) | ✅ 着地済み。`--threshold` / exit-code 2 / `reyn eval compare` パターンが確立されている |
+| `src/reyn/dogfood/` モジュール | ❌ 未存在 |
+
+**追加で確認した既存資産（FP-0036 本文に言及なし）:**
+
+| 資産 | 場所 | 備考 |
+|---|---|---|
+| `LLMReplay` | `src/reyn/testing/replay.py` | `REYN_LLM_RECORD=1` / SHA-256 keyed JSONL fixtures / mature |
+| `judge_output` op | `src/reyn/op_runtime/judge_output.py` | Component C reply verifier の backend として直接再利用可 |
+| `dogfood-discipline.md` | `docs/deep-dives/contributing/` | 1155 行。4-band outcome / 9+ principles / 4-batch 構造 — Component B runner の UX の根拠文書 |
+| `docs/feature-map.md` | `docs/` | 全機能 (17 op + stdlib + CLI + config) を網羅。Component D の covers タグ source-of-truth |
+| `reyn web` A2A endpoint | `scripts/` | stdout piping より高信頼度のチャット実行 driver として使用可 |
+
+---
+
+## 2. コンポーネント別アセスメント
+
+### Component A — Scenario YAML schema + loader (MEDIUM)
+
+**新規性**: 既存 YAML との互換性が問題になる。
+
+現行の `fp_0011_0012_retest.yaml` は以下のキーを使用:
+```yaml
+metadata:
+  name: ...
+  spike_id: ...
+  retest_floor_n: 10
+scenarios:
+  - id: s-fp11-1-...
+    user_prompt: |
+      ...
+    verification_axes: [D1, D2, ...]
+```
+
+FP-0036 提案の新スキーマ (`type: dogfood_scenario_set` / `covers: [...]` /
+`expected.reply|events|artifacts`) とは別形式。
+
+**推奨**: 新スキーマファイルは別ディレクトリ
+(`dogfood/scenarios/regression/`) に置き、既存ファイルはレガシー
+（= input-only、runner 非対応）として扱う。Loader は `type:` フィールドで
+ディスパッチし、legacy 形式は読み込み可能・実行不可とする。
+
+**設計注意点**:
+- `multi_turn` シナリオ（= `prompts: [...]` 形式）を新スキーマでも保持すること。
+  `input` フィールドを `str | list[str]` として multi-turn に対応させる。
+- `expected` の `per_turn_expected` 対応は MVP でスキップして良い（FP-0036 本文も示唆）。
+
+---
+
+### Component B — Runner CLI (MEDIUM)
+
+**最重要設計決定: チャット実行 driver の選択**
+
+FP-0036 は具体的な driver を指定していない。3 つの選択肢がある:
+
+| 方式 | 信頼度 | 実装コスト | 備考 |
+|---|---|---|---|
+| A: `subprocess` + stdin pipe | 低 | 低 | 既存 `dogfood_g4_spike.py` の方式。イベントログ取得に worktree 操作が必要 |
+| B: `reyn web` A2A endpoint | 中 | 中 | HTTP + structured response。`dogfood-discipline.md` §6 推奨 |
+| C: In-process (= `reyn eval` と同様) | 高 | 高 | `ChatSession` 直接呼び出し。replay に最適だが session.py 依存が深い |
+
+**推奨: MVP は方式 B (`reyn web`)、長期は方式 C**。
+
+方式 B の理由:
+- `reyn web` は既に存在し、dogfood 用途で実績がある
+- stdout piping (A) よりイベントログへのアクセスが確実
+- in-process (C) は isolation が弱く、失敗時のワークスペース汚染リスクがある
+
+**イベントログ取得の課題**:
+Runner はチャットセッションの `.reyn/events/*.jsonl` を取得して
+Component C (events verifier) に渡す必要がある。方式 B の場合:
+- セッションごとに専用 `--state-dir` を指定し、run 完了後に読み出す。
+- `run_id` = `datetime + scenario_id` で一意なセッション dir を作れる。
+
+**CLI UX 推奨**:
+```
+reyn dogfood run <yaml>           # 基本実行
+reyn dogfood run <yaml> --n 3     # N回実行 (安定性バンド)
+reyn dogfood run <yaml> --replay  # LLMReplay fixture 使用
+reyn dogfood report <run_id>      # 4-band サマリー
+reyn dogfood coverage             # feature-map 未カバー表示
+reyn dogfood compare <base> <cand>  # 回帰 diff
+```
+
+MVP scope: `run` + `report` のみ。`compare` は Component E。
+
+---
+
+### Component C — Verifier triad (SMALL)
+
+**reply verifier**:
+- `judge` → `judge_output` op を内部で dispatch。**FP-0007 D の着地済み実装を直接再利用。**
+- `substring` / `exact` / `regex` → 純関数。trivial。
+- コスト注意: `judge` は LLM call を消費する。`--replay` なしで N=5 実行すると
+  `N × scenario 数 × 1 judge call` のコストがかかる。LLMReplay (Component F) が
+  cost 削減の鍵。
+
+**events verifier**:
+- `must_emit`: イベントの `type` + `count` + `payload` パターンを JSON Schema で照合。
+- `must_not_emit`: 同イベントタイプの不在確認。
+- sequence: ordered subsequence（= 単調増加インデックスで実装可）。
+- **P6 イベントログは append-only JSONL** — シンプルな行ストリームで対処できる。
+
+**artifacts verifier**:
+- `present: true` は workspace snapshot 内の artifact ファイル存在確認のみ。
+- `fingerprint` (SHA256) はオプション。MVP でスキップ推奨（= fixture 更新コストが高い）。
+
+**outcome 合成ルール**（FP-0036 "worst-case" を具体化）:
+
+```
+refuted > blocked > inconclusive > verified
+```
+
+3 つの verifier の中で最も重篤な outcome がシナリオ outcome になる。
+この strict ルールは初期シナリオ設計が甘い場合に `refuted` rate が高くなるが、
+それ自体がシグナル（= 設計フィードバック）なので意図通り。
+
+---
+
+### Component D — Feature-map coverage matrix (SMALL)
+
+**feature-map.md のパースに関する警告**:
+
+FP-0036 は `docs/feature-map.md` をパースすると書いているが、
+同ファイルは人間向け markdown（Mermaid + table 混在）のため機械パースが脆い。
+
+**推奨**: 別途 `dogfood/feature-map-index.yaml` を作成する。
+
+```yaml
+# dogfood/feature-map-index.yaml
+features:
+  - path: os-core/phase-engine/act-decide-loop
+    label: Act/Decide loop
+    reference: docs/concepts/principles.md
+  - path: control-ir/embed
+    label: embed op
+    reference: docs/reference/runtime/control-ir.md
+  # ... (feature-map.md のテーブルから抽出)
+```
+
+`reyn dogfood coverage` はこの YAML + 各シナリオの `covers:` タグを突き合わせる。
+`feature-map.md` のメンテと `feature-map-index.yaml` の同期は手動で良い（低頻度更新）。
+
+この方法の利点:
+- `feature-map.md` を壊さずに coverage 機能を実装できる
+- feature-map に新項目が追加されたときに coverage gap が自動的に visible になる
+
+---
+
+### Component E — Baseline compare (SMALL)
+
+`reyn eval compare` の実装パターンをそのまま移植可能:
+- `--threshold FLOAT` → 4-band の `verified` 率の閾値
+- exit code 2 → `verified` 率が閾値を下回る
+- Brier score = `Σ (predicted_p - actual_binary)^2 / N` — calibration 指標
+
+**追加推奨**: `--scenario-filter <id>` で特定シナリオの diff に絞る機能。
+回帰確認時に「どのシナリオで変化したか」をピンポイントで見るユースケースが多い。
+
+---
+
+### Component F — LLMReplay fixture integration (SMALL)
+
+`LLMReplay` の API は既に:
+```python
+replay = LLMReplay(fixture_path, mode="replay")
+replay.install()  # litellm.acompletion を monkeypatch
+```
+
+Component F の実装は薄い wrapper のみ:
+```python
+# src/reyn/dogfood/replay.py
+def fixture_path_for(scenario_id: str, run_dir: Path) -> Path:
+    return run_dir / "fixtures" / f"{scenario_id}.jsonl"
+```
+
+**重要**: `reyn dogfood run --replay` は `REYN_LLM_RECORD` を無視して
+既存 fixture を使う。Fixture 不在時は `MissingFixture` を `blocked` outcome
+に変換する（= runner が fixture の有無を `blocked` の条件として扱う）。
+
+Fixture 鮮度管理:
+- Fixture JSONL の先頭行に `{"schema_version": 1, "recorded_at": "..."}` を追加推奨。
+- Runner が schema version mismatch を検出したら警告 + re-record 促進。
+
+---
+
+## 3. 実装順序の推奨
+
+依存グラフ:
+
+```
+F (LLMReplay wrapper)
+│
+A (Schema + Loader) ──→ C (Verifiers) ──→ B MVP (run + report)
+                                          │
+D (feature-map-index.yaml) ──────────────→ B coverage subcommand
+                                          │
+E (Baseline compare) ────────────────────→ B compare subcommand
+```
+
+**推奨 PR 分割**:
+
+| PR | 内容 | 依存 |
+|---|---|---|
+| PR-1 | Component F + A + C | なし |
+| PR-2 | Component B MVP (`run` + `report`) | PR-1 |
+| PR-3 | Component D (`dogfood/feature-map-index.yaml` + `coverage` subcommand) | PR-2 |
+| PR-4 | Component E (`compare` subcommand) | PR-2 |
+| PR-5 | シナリオ authoring wave (別 wave) | PR-2 着地後 |
+
+PR-1 → PR-2 の順番が最重要。F+A+C を先に出すことで:
+- Verifier ロジックを単体テスト可能な状態で確認できる
+- Runner 実装時に verifier の API が固まっている
+
+---
+
+## 4. Open design points に対する推奨回答
+
+FP-0036 が "resolve before implementation" とした 4 点:
+
+### 1. シナリオセットの粒度
+
+**推奨: per-category YAML + coverage index**。
+
+```
+dogfood/scenarios/regression/
+  chat_router.yaml         # chat-router/* covers
+  control_ir_ops.yaml      # control-ir/* covers
+  stdlib_skills.yaml       # stdlib-skill/* covers
+  permissions.yaml         # permissions/* covers
+  rag_memory.yaml          # rag/* / memory/* covers
+  sandbox.yaml             # sandbox/* covers
+  multi_agent.yaml         # multi-agent/* covers
+  README.md                # index of all sets + coverage %
+```
+
+1 ファイルに全シナリオを集めると PR レビューが困難になる。
+feature-map のセクション構造に合わせることで coverage gap が自然に可視化される。
+
+### 2. Baseline の保存場所
+
+**MVP: `.reyn/dogfood/` (per-developer)**。
+
+Rationale: 初期段階では baseline の "正解" が developer 間で異なる可能性が高い。
+共有 baseline は LLM モデルバージョン / API レートの差異で false regression が増える。
+`reyn dogfood run --baseline <label>` でローカルに named baseline を作成し、
+将来 CI で共有する場合は `--export <path>` でエクスポートするパスを用意する。
+
+### 3. Fixture の鮮度管理
+
+**推奨: schema version + リリースタグ時 re-record 推奨**。
+
+- Fixture JSONL にメタデータ行 (`schema_version`, `recorded_at`, `reyn_version`) を追加
+- Runner は schema version mismatch を `blocked` outcome + 警告として扱う
+- 完全自動 re-record は避ける（= 意図せず behavior 変化を fixture に焼き付けるリスク）
+- `reyn dogfood run --record <set>` で明示的に再録できる形にする
+
+### 4. Outcome 合成
+
+**推奨: events/artifacts verifier が reply judge より優先**。
+
+Rationale: events / artifacts は deterministic な binary check（= pass/fail）なのに対して、
+reply judge は probabilistic（= LLM score）。Binary check が fail した場合に
+probabilistic check を `inconclusive` に倒す設計にすると、
+P6 event log による客観的証拠を優先でき、余計な LLM コストを節約できる。
+
+```
+合成ルール:
+  events/artifacts いずれかが refuted  → シナリオ refuted
+  events/artifacts いずれかが blocked  → シナリオ blocked
+  events/artifacts 全 pass + judge inconclusive → シナリオ inconclusive
+  events/artifacts 全 pass + judge verified     → シナリオ verified
+```
+
+---
+
+## 5. リスクと懸念事項
+
+### R1: イベントキャプチャの信頼度（中リスク）
+
+`reyn web` driver 経由でも、セッション用 `--state-dir` を正確に受け渡せないと
+events.jsonl が空になる。MVP 段階で `--state-dir` のハンドシェイクを確実に
+テストする必要がある（= Tier 2 OS invariant test: events file 生成確認）。
+
+### R2: judge_output コスト（低リスク）
+
+N=5 実行 × 20 シナリオ = 100 judge calls/suite run。LLMReplay fixture が
+ない状態での初回フル run がコスト高。**対策**: Fixture 作成を
+`PR-1 のマージ後・PR-2 前` に一度 `--record` 走行でまとめて行う。
+
+### R3: feature-map-index.yaml のメンテ遅延（低リスク）
+
+新機能追加時に `feature-map.md` は更新されても `feature-map-index.yaml` が
+更新されないと coverage が不正確になる。**対策**: PR テンプレートに
+「新機能追加時は `dogfood/feature-map-index.yaml` も更新する」を追記する。
+
+### R4: LLMReplay のモデル変更耐性（中リスク）
+
+`LLMReplay` の fixture key は `model + canonical_json(messages)` の SHA-256。
+モデルバージョン更新時（例: `gemini-2.5-flash-lite` → `gemini-2.5-flash-lite-001`）に
+全 fixture が miss する。**対策**: Fixture 内に `model_class` (= `light`/`standard`/`strong`)
+を別途記録し、`MissingFixture` を `blocked` として報告する設計を Component F に組み込む。
+
+---
+
+## 6. "framework PR" の最小スコープ定義
+
+FP-0036 は "framework PR を先に出し、scenario authoring は別 wave" としている。
+Framework PR の Done 条件を明確化する:
+
+**必須 (= framework PR に含める)**:
+- `dogfood/scenarios/regression/` ディレクトリ + README
+- `src/reyn/dogfood/{__init__, scenarios, verifiers/, replay}.py` (PR-1)
+- `reyn dogfood run <yaml>` + `reyn dogfood report <run_id>` (PR-2 MVP)
+- `dogfood/feature-map-index.yaml` (D)
+- Tier 1/2 テスト (verifiers 単体 + schema loader)
+
+**defer (= 別 PR)**:
+- `reyn dogfood coverage` (D — feature-map-index が確定してから)
+- `reyn dogfood compare` (E)
+- シナリオ authoring (PR-5)
+
+---
+
+## 7. FP-0035 との関係
+
+FP-0035 (Sandbox/Permission LLM Communication) は「dogfood-driven 設計スタディ」と
+明示しており、FP-0036 の framework が着地してからでないと評価できない。
+FP-0035 の Phase 1 (評価フレームワーク確立) は FP-0036 の PR-2 着地が前提条件。
+
+依存関係:
+```
+FP-0036 PR-2 (runner MVP) → FP-0035 Phase 1 評価 → FP-0035 Phase 2 実装
+```
+
+---
+
+## まとめ
+
+| 項目 | 評価 |
+|---|---|
+| P7 compliance | ✅ OS 層変更なし、`src/reyn/dogfood/` は完全独立 |
+| 既存資産の再利用率 | 高 — `LLMReplay` / `judge_output` / `reyn eval compare` パターン / `feature-map.md` すべて再利用可 |
+| MVP コスト | MEDIUM — PR-1 + PR-2 で 1-1.5 day |
+| 最大リスク | イベントキャプチャの `--state-dir` ハンドシェイク |
+| 最優先 open design point | **driver 選択 (B: `reyn web` 推奨)** と **feature-map-index.yaml の新規作成** |
+
+FP-0036 は設計として健全。依存が全て着地済みで実装可能な状態。
+開始前に driver 選択と feature-map-index.yaml 作成方針を確定させること。

--- a/docs/deep-dives/research/fp-implementation-review-fp10-fp24-fp28-34.md
+++ b/docs/deep-dives/research/fp-implementation-review-fp10-fp24-fp28-34.md
@@ -1,0 +1,305 @@
+---
+title: FP-0010 / FP-0024 / FP-0028〜0034 実装レビュー
+status: draft
+last_updated: 2026-05-16
+author: researcher
+sources:
+  - "gh issue view 11,25,29,30,31,32,34,35,36"
+  - "src/reyn/chat/planner.py"
+  - "src/reyn/chat/session.py"
+  - "src/reyn/chat/router_loop.py"
+  - "src/reyn/chat/router_tools.py"
+  - "src/reyn/chat/router_system_prompt.py"
+  - "src/reyn/tools/mcp.py"
+  - "src/reyn/tools/universal_catalog.py"
+  - "src/reyn/tools/universal_dispatch.py"
+  - "src/reyn/tools/action_index.py"
+  - "src/reyn/tools/action_usage_tracker.py"
+  - "src/reyn/tools/mcp_drop.py"
+  - "src/reyn/tools/plan.py"
+  - "src/reyn/config.py"
+---
+
+# FP-0010 / FP-0024 / FP-0028〜0034 実装レビュー
+
+## TL;DR
+
+| FP | タイトル | 実装状態 | 主な問題 |
+|---|---|---|---|
+| FP-0028 | プラン進捗 UX | ✅ 正常 | なし |
+| FP-0029 | イテレーション予算 | ✅ 正常 | なし |
+| FP-0030 | ステップ結果品質 | ⚠️ 部分的不整合 | `plan.py` 記述が intent と乖離 |
+| FP-0031 | Planner UX 改善 | ✅ 正常 | なし |
+| FP-0032 | MCP カタログ対称化 | ⚠️ デッドコード | `mcp_section` 変数が未使用 |
+| FP-0033 | Hot-list アーキテクチャ | ✅ (FP-0034 に統合) | — |
+| FP-0034 | 統一 tool retrieval | ✅ Phase 1〜3 実装済み | コメント陳腐化、plan.py ツール名参照陳腐化 |
+| FP-0010 | RAG ルーティング | ✅ (FP-0034 に統合) | — |
+| FP-0024 | セマンティックツール選択 | ✅ (FP-0034 に統合) | — |
+
+---
+
+## 1. FP-0028: プラン進捗 UX
+
+**Issue 意図**: `"plan step 2/4 done (s3)"` → `"plan step 2/4: auth.py を読む"` に変更。
+
+**実装確認** (`src/reyn/chat/planner.py`):
+```python
+# L864
+desc_preview = (step.description or step.id)[:60]
+
+# L1014 (成功時)
+text=f"plan step {n_done}/{n_total}: {desc_preview}"
+
+# L974 (失敗時, FP-0031-B と統合)
+text=f"plan step {n_done + 1}/{n_total}: {desc_preview} → 失敗 ({err_summary})"
+```
+
+**判定**: ✅ Issue 意図と完全一致。フォールバック (`step.id`) も実装済み。
+
+---
+
+## 2. FP-0029: プランステップのイテレーション予算
+
+**Issue 意図**: `_PLAN_STEP_MAX_ITERATIONS = 3` → `5` に引き上げ。`reyn.yaml` での上書き対応。
+
+**実装確認**:
+- `planner.py` L74: `_PLAN_STEP_MAX_ITERATIONS = 5` ✅
+- `config.py` L843: `PlanConfig.step_max_iterations: int = 5` ✅
+- `config.py` L1580: `step_max_raw = raw.get("step_max_iterations")` → `reyn.yaml` の `plan.step_max_iterations:` で上書き可能 ✅
+
+**判定**: ✅ 定数変更 + Config 統合の両方が実装済み。
+
+---
+
+## 3. FP-0030: プランステップ結果品質
+
+**Issue 意図 (2 ファイル)**:
+1. `planner.py` `build_plan_step_system_prompt` のガイダンスを "1–3 sentences" → "Report what this step found. Include code snippets, ~800 chars soft limit" に変更
+2. `plan.py` `_PLAN_DESCRIPTION` の陳腐化テキスト「ターミナルステップが合成」→「ルーターが合成」に更新
+
+**実装確認**:
+
+### planner.py (L370–374) ✅
+```python
+"Report what this step found. Include concrete details: code snippets, "
+"function signatures, specific line numbers, exact values, structured data. "
+"Aim for ~800 characters as a soft target; exceed if the content requires "
+"it (e.g. multi-line code blocks). Be factual — a separate synthesis step "
+"will produce the user reply."
+```
+→ Issue 意図と一致。
+
+### plan.py ⚠️ 部分的不整合
+
+**`_PLAN_DESCRIPTION` (L54–56)**:
+```python
+"Each step summarises what it found; the router "
+"synthesises the final reply after all steps "
+"complete."
+```
+Issue 提案テキスト:
+> "After all steps complete, the router synthesises step results into a final reply. Design each step to gather specific evidence (code, facts, data); a dedicated synthesis turn handles the final reply."
+
+現在の実装は「ターミナルステップ」の言及を除去できているが、**"summarises"** という動詞が残っている。Issue が求める **"gather specific evidence (code, facts, data)"** という指示が欠落。
+
+**`steps_json` パラメータ説明 (L87–88)**:
+```python
+"Each step should "
+"summarise what it found; the router synthesises "
+"the final reply after all steps complete."
+```
+同様に "summarise" が残っている。
+
+**`steps_json` の `tools` フィールド説明 (L80–82)**: [→ FP-0034 との交差問題、§5 参照]
+
+**影響**: `plan` ツールの説明を読んだ LLM（= 計画作成時）は、ステップが「要約」を返すものと理解する。一方で実際のステップ実行時には「コードスニペット・行番号・具体的証拠」を返すよう促される。計画設計と実行ガイダンスの意図がズレており、合成品質に影響する可能性がある。
+
+**判定**: ⚠️ `build_plan_step_system_prompt` は正しく更新済み。`plan.py` の記述は不完全更新。
+
+---
+
+## 4. FP-0031: Planner 実行 UX 改善
+
+**Issue 意図**: A=計画報告 / B=失敗ステータス / C=自動リトライ / D=上限確認。
+
+**実装確認**:
+
+| Component | 実装場所 | 状態 |
+|---|---|---|
+| A. 計画事前報告 | `session.py` L3007–3023 (`spawn_plan_task`) | ✅ |
+| B. 失敗ステータス通知 | `planner.py` L974 | ✅ |
+| C. 自動リトライ (`_PLAN_STEP_RETRY_LIMIT = 3`) | `planner.py` L856–920 | ✅ |
+| D. 上限到達時ユーザー確認 | `planner.py` L921–945 (`handle_limit_exceeded`) | ✅ |
+
+```python
+# session.py L3019
+text=f"以下の計画で実行します:\n{plan_summary}"
+
+# planner.py L893
+text=f"  リトライ {attempt}/{step_retry_limit}: {desc_preview}"
+```
+
+**判定**: ✅ 全 4 コンポーネント実装済み。
+
+---
+
+## 5. FP-0032: MCP tool catalog の skill/agent 対称化
+
+**Issue 意図**: 語彙統一 (`tool` → `mcp_tool_name`)、schema enum 注入、`describe_mcp_tool` 追加、SP flat list 追加、`MCP_SEARCH_THRESHOLD = 0`。
+
+**実装確認**:
+
+| 変更 | 実装場所 | 状態 |
+|---|---|---|
+| 語彙統一 (`mcp_tool_name`) | `tools/mcp.py` L96–130 | ✅ |
+| `_enrich_router_schema` (enum 注入) | `tools/mcp.py` L316–358 | ✅ |
+| `describe_mcp_tool` + handler | `tools/mcp.py` L362–445 | ✅ |
+| SP flat list `_render_mcp()` | `router_system_prompt.py` L423–456 | ✅ 実装あり |
+| `MCP_SEARCH_THRESHOLD = 0` | `router_tools.py` L57 | ✅ |
+
+### ⚠️ デッドコード問題
+
+`router_system_prompt.py` L66:
+```python
+mcp_section = _render_mcp(mcp_servers)
+```
+
+この変数 `mcp_section` は **`parts` に一度も `append` されない**。FP-0034 の wrapper-only モード移行に伴い、MCP 節の SP 掲載は意図的に廃止されたが（L301–303 のコメントが確認）、`_render_mcp()` の呼び出し自体が削除されていない。
+
+影響:
+- 毎ターン無駄に `_render_mcp(mcp_servers)` が実行される（MCP サーバー・ツールが多い環境で無視できないコスト）
+- 将来の読み手が「MCP 節は SP に含まれている」と誤解するリスク
+
+**判定**: ⚠️ FP-0032 本体は正常実装。`mcp_section` のデッドコードが FP-0034 との統合時に残存。
+
+---
+
+## 6. FP-0033 / FP-0010 / FP-0024
+
+いずれも FP-0034 に supersede されてクローズ。実装は §7 (FP-0034) にまとめて反映。
+
+---
+
+## 7. FP-0034: 統一 tool retrieval アーキテクチャ
+
+FP-0034 は 6 Phase 構成。実装状態を Phase ごとに確認。
+
+### Phase 0: FP-0032 landing ✅
+
+### Phase 1: Universal catalog wrappers ✅
+
+`tools/universal_catalog.py`:
+- `LIST_ACTIONS`, `DESCRIBE_ACTION`, `INVOKE_ACTION` — real handlers 実装済み
+- `SEARCH_ACTIONS` — Phase 2 の ActionEmbeddingIndex に依存するが、handler は stub でなく実装済み（`rs.action_embedding_index` 参照、embedding 未設定なら空リスト返却で graceful degrade）
+- `split_qualified_name`, `build_qualified_name`, `is_valid_qualified_name` — qualified name ユーティリティ ✅
+- D14 visibility gating (`is_search_available`, `is_exec_available`, `visible_categories`) ✅
+
+`tools/universal_dispatch.py`:
+- PR-2 routing layer — `resolve_invoke_action`, `resolve_describe_action`, `suggest_similar_names` ✅
+- `mcp.operation__drop_server` rule (PR-4) ✅
+
+`config.py`:
+- `ActionRetrievalConfig.universal_wrappers_enabled = True` (デフォルト ON) ✅
+- `hot_list_n = 10` (デフォルト) ✅
+
+`router_tools.py`:
+- Section I: universal wrappers を tools= に追加 (L844–866) ✅
+- Section J: legacy tool 除外 (L874–890) ✅
+- Section K: hot list direct aliases (L892–904) ✅
+
+### Phase 2: Foundation Layer (ActionEmbeddingIndex + ActionUsageTracker) ✅
+
+- `tools/action_index.py` (373 行): SQLite-WAL 永続化付き `ActionEmbeddingIndex` ✅
+- `tools/action_usage_tracker.py` (180 行): freq + recency ベースの hot list 選出 ✅
+- `tools/mcp_drop.py`: `mcp.operation__drop_server` op (FP-0034 §D23 PR-4) ✅
+
+### Phase 3: Self-improvement Loop (routing_decided event) ✅
+
+`router_loop.py` L828–866:
+- `invoke_action` 呼出し時に `routing_decided` P6 event を emit
+- `hot_list_alias` 経由の呼出し時も source="hot_list_alias" で emit
+- outcome: `error` / `success` の 2 値 ✅
+
+### Phase 4: SP refactor ✅
+
+`router_system_prompt.py`:
+- `universal_wrappers_enabled=True` 時: "## Action categories" 節 (13 カテゴリ、static) ✅
+- legacy flat list 節 (Skills / Agents / MCP / Indexed sources / Files) は wrapper-only パスで省略 ✅
+
+### Phase 5: 既存 wrapper 統合 / Phase 6: cleanup
+
+`router_tools.py` Section J で legacy tool を tools= から除外済み ✅  
+ただし `build_tools()` 内での legacy tool 構築コード (A1–D4) は まだ削除されていない（= universal_wrappers_enabled=True 時は無駄に構築して直後に除外）。これは Phase 5/6 cleanup の残タスク。
+
+---
+
+## 8. 横断的問題: plan.py と universal catalog のミスマッチ
+
+`plan.py` の `steps_json` 説明 (L80–82):
+```python
+"tools: list of TOP-LEVEL tool names this step "
+"calls (e.g. \"reyn_src_read\", \"web_search\", "
+"\"invoke_skill\")."
+```
+
+FP-0034 universal mode では:
+- `reyn_src_read` → `invoke_action(action_name="reyn.source__read", ...)`
+- `web_search` → `invoke_action(action_name="web__search", ...)`
+- `invoke_skill` → `invoke_action(action_name="skill__...", ...)`
+
+計画作成時に LLM が `tools` フィールドに `["reyn_src_read"]` と入力しても、Plan Step の実行環境では `reyn_src_read` は tools= に存在しない（Section J で除外済み）。
+
+FP-0034 Phase 5 が完了した時点では、`plan.py` の `steps_json` ツール名例を universal 形式に更新する必要がある。
+
+---
+
+## 9. 問題サマリと推奨アクション
+
+### 🐛 Bug (軽微)
+
+**B1: `mcp_section` デッドコード** (`router_system_prompt.py` L66)  
+```python
+# L66 — 削除すべき
+mcp_section = _render_mcp(mcp_servers)
+```
+毎ターン実行されるが結果が使われない。`build_system_prompt()` の引数 `mcp_servers` は `router_system_prompt.py` で今後も使われないなら削除候補。
+
+### ⚠️ Inconsistency (機能影響あり)
+
+**I1: `plan.py` の "summarise" 残存** (FP-0030 不完全更新)  
+- `_PLAN_DESCRIPTION` (L54): "summarises" → "gathers specific evidence (code, facts, data)"
+- `steps_json` 説明 (L88): "summarise what it found" → "report concrete evidence"
+- `steps_json` 例示 step.description (L93): "summarise findings" → "report evidence"
+
+計画作成 LLM が "summarise" 意図でステップを設計し、実行 LLM が "report concrete evidence" で実行するギャップが生じる。
+
+**I2: `plan.py` の古いツール名例** (FP-0034 追従漏れ)  
+`steps_json` (L80–82) のツール名例 (`reyn_src_read`, `web_search`, `invoke_skill`) が universal catalog 後の名前と不一致。`invoke_action` を使うよう更新が必要。
+
+### 📝 Stale comment
+
+**S1: `router_tools.py` L840–843 のコメント**  
+> "Phase 1 keeps it OFF unconditionally because (a) the handler is a NotImplementedError stub awaiting Phase 2's ActionEmbeddingIndex"
+
+実際には `search_actions` handler は NotImplementedError stub ではなく実装済み。正しくは「`search_actions_visible=False` (embedding 未設定) によって非公開」。
+
+### 📋 Phase 5/6 残タスク
+
+`build_tools()` が `universal_wrappers_enabled=True` 時に legacy tool (A1〜D4) を構築してから Section J で除外するパターンは、段階的移行の痕跡。Phase 5/6 で legacy tool 構築コードごと削除すればレイテンシと可読性が改善する。
+
+---
+
+## 10. 推奨 GitHub Issue
+
+以下を新規 issue として発行予定:
+
+1. **FP-0030 followup: `plan.py` の "summarise" → "gather evidence" テキスト更新** (SMALL)
+   - `_PLAN_DESCRIPTION`, `steps_json` 説明, 例示 step の記述を FP-0030 提案テキストに合わせる
+   - `steps_json` のツール名例も universal catalog 形式に更新 (FP-0034 追従)
+
+2. **cleanup: `mcp_section` デッドコード除去** (SMALL)
+   - `router_system_prompt.py` L66 の `mcp_section = _render_mcp(mcp_servers)` 削除
+   - 引数 `mcp_servers` が完全不要なら関数シグネチャからも除去
+
+3. **comment fix: `router_tools.py` の `search_actions` に関するコメント陳腐化** (SMALL)
+   - Phase 1 コメントを「handler は stub」→「embedding 未設定により非公開」に修正


### PR DESCRIPTION
## Summary

3 つの研究ドキュメントと関連 GitHub issues を追加するリサーチ PR。

- **FP-0010 / FP-0024 / FP-0028–0034 実装レビュー** — 各 FP の実装が設計意図と一致しているかをコードレベルで検証。3 つの問題点（plan.py "summarise" 残存 / mcp_section dead code / search_actions stale comment）を特定し issues #40 / #41 / #42 として発行。
- **Control IR ops gap 調査** — `OP_KIND_MODEL_MAP` と `control-ir.md` の差分を分析。ADR-0033 RAG ops 5 種 (`embed` / `index_write` / `index_query` / `recall` / `index_drop`) が English/Japanese 両版で未記載（CLAUDE.md の同期ルール違反）。Writer 向け proposed content を研究ノートとして提供。issue #47 として追跡。
- **FP-0036 実装アセスメント** — Dogfood Scenario Framework 6 コンポーネントの依存グラフ・推奨 PR 分割・open design 4 点への回答・リスク分析を文書化。

## 成果物

| ファイル | 内容 |
|---|---|
| `docs/deep-dives/research/fp-implementation-review-fp10-fp24-fp28-34.md` | FP-0010/0024/0028-0034 実装レビュー |
| `docs/deep-dives/research/control-ir-gap-rag-ops.md` | Control IR RAG ops gap + proposed content |
| `docs/deep-dives/research/fp-0036-dogfood-framework-assessment.md` | FP-0036 実装アセスメント |

## 関連 Issues

- #40 — `plan.py` に FP-0030 "summarise" 残存
- #41 — `router_system_prompt.py` の `mcp_section` dead code
- #42 — `router_tools.py` の `search_actions` stale comment
- #47 — `control-ir.md` に ADR-0033 RAG ops 5 種が未記載

## Test plan

- [ ] 研究ドキュメントの内容確認（コードベースとの整合性）
- [ ] issue #47 の proposed content を `control-ir.md` / `control-ir.ja.md` に反映（writer 担当）
- [ ] FP-0036 実装開始前に open design points（driver 選択 / feature-map-index.yaml 作成）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)