### PR TITLE
fix(tui): truncate right-panel header to prevent word-wrap on long filter names

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rich.text import Text
 from textual.app import ComposeResult, RenderResult
 from textual.message import Message
 from textual.widget import Widget
@@ -42,13 +43,17 @@ class _PanelHeader(Static):
 
     def render(self) -> RenderResult:
         try:
-            return self._panel._panel_header_markup()
+            markup = self._panel._panel_header_markup()
+            t = Text.from_markup(markup)
+            w = self.content_region.width
+            if w > 0:
+                t.truncate(w)
+            return t
         except Exception as exc:
             logger.warning("right_panel header render failed: %s", exc)
             return ""
 
     def invalidate(self) -> None:
-        self._layout_cache.clear()
         self.refresh()
 
 
@@ -73,7 +78,6 @@ class _PanelContent(Static):
 
     def invalidate(self) -> None:
         """Force a re-render on the next frame."""
-        self._layout_cache.clear()
         self.refresh(layout=True)
 
 


### PR DESCRIPTION
## Summary

- `_PanelHeader.render()` was returning the markup string directly; Rich word-wrapped at word boundaries when the string exceeded the widget's content width (22 chars)
- `safety` (23 chars) and `internal` (25 chars) filter labels wrapped to a second line, displaying only "Events" in the header
- Fix: convert markup to `rich.Text` and call `truncate(content_region.width)` before returning
- Also removes redundant `_layout_cache.clear()` calls in `invalidate()` methods — `refresh()` already clears the cache

## Test plan

- [ ] Switch Events panel filter to `safety` → header shows `Events  filter:safet` (truncated, not wrapped)
- [ ] Switch to `internal` → header shows `Events  filter:inter`
- [ ] All other filters (all, phase, llm, tool, rag, skill, plan, error, user) display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)