### PR TITLE
feat(tui): persist slash-command output in chat log (kind="system")

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2280,7 +2280,7 @@ class ChatSession:
         if not body:
             known = ", ".join(f"/{n}" for n in REGISTRY.names())
             await self._put_outbox(OutboxMessage(
-                kind="status",
+                kind="system",
                 text=f"known commands: {known}",
             ))
             return True
@@ -2291,7 +2291,7 @@ class ChatSession:
         if slash_cmd is None:
             known = ", ".join(f"/{n}" for n in REGISTRY.names())
             await self._put_outbox(OutboxMessage(
-                kind="status",
+                kind="system",
                 text=f"unknown command /{cmd}; try: {known}",
             ))
             return True
@@ -2325,7 +2325,7 @@ class ChatSession:
                 lines.append(
                     f"  {iv.id[:8]}  {iv.kind:<20}  {iv.skill_name or '?'}#{short}"
                 )
-        await self._put_outbox(OutboxMessage(kind="status", text="\n".join(lines)))
+        await self._put_outbox(OutboxMessage(kind="system", text="\n".join(lines)))
 
     async def _slash_cancel(self, args: str) -> None:
         """`/cancel <id-prefix>` — cancel a running skill task."""
@@ -2350,12 +2350,12 @@ class ChatSession:
         task = self.running_skills.get(rid)
         if task is None or task.done():
             await self._put_outbox(OutboxMessage(
-                kind="status", text=f"skill {_run_short(rid)} already finished",
+                kind="system", text=f"skill {_run_short(rid)} already finished",
             ))
             return
         task.cancel()
         await self._put_outbox(OutboxMessage(
-            kind="status", text="cancel requested",
+            kind="system", text="cancel requested",
             meta=_run_meta(rid, None),
         ))
 
@@ -2402,7 +2402,7 @@ class ChatSession:
         names = self._registry.list_names()
         if not names:
             await self._put_outbox(OutboxMessage(
-                kind="status", text="no agents (this should not happen — default auto-creates)",
+                kind="system", text="no agents (this should not happen — default auto-creates)",
             ))
             return
         attached = self._registry.attached_name
@@ -2420,7 +2420,7 @@ class ChatSession:
             mark = "*" if n == attached else (" " if n not in loaded else "·")
             lines.append(f"  {mark} {n:<24} {last_str:<17} {role[:60]}")
         lines.append("(* = attached, · = loaded, blank = not yet loaded)")
-        await self._put_outbox(OutboxMessage(kind="status", text="\n".join(lines)))
+        await self._put_outbox(OutboxMessage(kind="system", text="\n".join(lines)))
 
     async def _slash_attach(self, args: str) -> None:
         """`/attach <name>` — switch attached agent.
@@ -2449,7 +2449,7 @@ class ChatSession:
             return
         if name == self._registry.attached_name:
             await self._put_outbox(OutboxMessage(
-                kind="status", text=f"already attached to {name!r}",
+                kind="system", text=f"already attached to {name!r}",
             ))
             return
         # The REPL drains its own outbox loop. Send the attach request as a
@@ -2463,11 +2463,11 @@ class ChatSession:
         line = self._budget.cost_line()
         if line is None:
             await self._put_outbox(OutboxMessage(
-                kind="status",
+                kind="system",
                 text="budget tracker is disabled (no `cost:` config or non-chat mode)",
             ))
             return
-        await self._put_outbox(OutboxMessage(kind="status", text=line))
+        await self._put_outbox(OutboxMessage(kind="system", text=line))
 
     async def _slash_budget(self, args: str) -> None:
         """`/budget` (full breakdown) / `/budget reset` (clear counters)."""
@@ -2476,7 +2476,7 @@ class ChatSession:
             before = self._budget.reset_all()
             if before is None:
                 await self._put_outbox(OutboxMessage(
-                    kind="status",
+                    kind="system",
                     text="budget tracker is disabled (no `cost:` config or non-chat mode)",
                 ))
                 return
@@ -2495,16 +2495,16 @@ class ChatSession:
                 "they auto-reset at period boundary."
             )
             lines.append("Use `/budget` to verify.")
-            await self._put_outbox(OutboxMessage(kind="status", text="\n".join(lines)))
+            await self._put_outbox(OutboxMessage(kind="system", text="\n".join(lines)))
             return
         text = self._budget.budget_full()
         if text is None:
             await self._put_outbox(OutboxMessage(
-                kind="status",
+                kind="system",
                 text="budget tracker is disabled (no `cost:` config or non-chat mode)",
             ))
             return
-        await self._put_outbox(OutboxMessage(kind="status", text=text))
+        await self._put_outbox(OutboxMessage(kind="system", text=text))
 
     # ── skill spawn (FP-0019 Wave 1b) ───────────────────────────────────────────
     # Business logic lives in SkillRunner. Session keeps thin delegating
@@ -3049,7 +3049,7 @@ class ChatSession:
                 )
                 try:
                     await self._put_outbox(OutboxMessage(
-                        kind="status",
+                        kind="system",
                         text=f"以下の計画で実行します:\n{plan_summary}",
                         meta={"plan_id": plan_id, "source": "plan_summary"},
                     ))

--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -106,11 +106,14 @@ def slash(
 # ── reply helpers ──────────────────────────────────────────────────────────
 
 
-async def reply(session: "object", text: str, *, kind: str = "status") -> None:
+async def reply(session: "object", text: str, *, kind: str = "system") -> None:
     """Emit a slash-command reply via the session outbox.
 
-    Default kind is `status` (dim italic in the TUI). Use `reply_error`
-    for errors, or pass an explicit kind for special cases.
+    Default kind is ``system`` (persistent log entry with a neutral
+    ``system`` header) so prior command outputs remain visible when the
+    user runs multiple commands in succession. Pass ``kind="status"``
+    for ephemeral one-line indicators that should overwrite. Use
+    ``reply_error`` for errors.
     """
     from reyn.chat.outbox import OutboxMessage
     await session._put_outbox(OutboxMessage(kind=kind, text=text))

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -220,6 +220,7 @@ class ConversationView(Widget):
 
         Routing:
           agent      → header + Markdown inline (with B3 fold for >30 lines)
+          system     → header + plain-text inline (persistent slash output)
           intervention/trace/status/skill_done → suppressed (handled elsewhere)
           error      → ErrorBox widget
           others     → plain Rich Text line
@@ -241,6 +242,10 @@ class ConversationView(Widget):
             self._render_agent_markdown(msg)
             return
 
+        if msg.kind == "system":
+            self._render_system_message(msg)
+            return
+
         if msg.kind == "error":
             self.mount_error(
                 message=msg.text,
@@ -260,6 +265,24 @@ class ConversationView(Widget):
         self._consume_empty_hint()
         self._maybe_write_header("you", "you", "bold #4abbb5", "#1f5856")
         self._write_log(Text(text))
+        self._write_log(Text(""))
+
+    def _render_system_message(self, msg: OutboxMessage) -> None:
+        """Render a slash-command (or other OS-generated) message persistently.
+
+        Distinct from ``agent`` so the log doesn't claim the LLM produced
+        these lines, and distinct from ``status`` so prior outputs survive
+        when running multiple commands in a row.
+
+        Rendered as plain text (newlines preserved, no Markdown) under a
+        neutral ``system`` header in dim grey.
+        """
+        self._consume_empty_hint()
+        self.hide_status()
+        self._maybe_write_header("system", "system", "bold #888888", "#444444")
+        log = self._log()
+        for line in (msg.text or "").splitlines() or [""]:
+            log.write(Text(line))
         self._write_log(Text(""))
 
     def _render_agent_markdown(self, msg: OutboxMessage) -> None:
@@ -581,7 +604,7 @@ def _format_message(msg: OutboxMessage) -> Text | None:
     body = f"{meta_pfx}{msg.text}"
 
     if msg.kind in {"__end__", "__attach_request__", "intervention",
-                    "agent", "status", "error", "trace", "skill_done"}:
+                    "agent", "system", "status", "error", "trace", "skill_done"}:
         return None
     # Unknown kind — show raw with subtle prefix
     t = Text()

--- a/tests/test_plan_chatsession_wiring.py
+++ b/tests/test_plan_chatsession_wiring.py
@@ -251,7 +251,7 @@ async def test_spawn_plan_task_emits_plan_summary_before_execution(
         try:
             msg = session.outbox.get_nowait()
             if (
-                msg.kind == "status"
+                msg.kind == "system"
                 and msg.meta.get("source") == "plan_summary"
             ):
                 summary_msgs.append(msg)

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -69,7 +69,7 @@ async def test_plan_list_shows_running_plans(tmp_path, monkeypatch):
         consumed = await session._maybe_handle_slash("/plan list")
         assert consumed is True
         msgs = _drain_outbox(session)
-        combined = "\n".join(m.text for m in msgs if m.kind == "status")
+        combined = "\n".join(m.text for m in msgs if m.kind == "system")
         assert "plan_abc123" in combined
         assert "running" in combined
     finally:
@@ -91,7 +91,7 @@ async def test_plan_list_shows_active_ids_without_task(tmp_path, monkeypatch):
     consumed = await session._maybe_handle_slash("/plan list")
     assert consumed is True
     msgs = _drain_outbox(session)
-    combined = "\n".join(m.text for m in msgs if m.kind == "status")
+    combined = "\n".join(m.text for m in msgs if m.kind == "system")
     assert "plan_xyz789" in combined
     assert "active" in combined or "resume pending" in combined
 
@@ -135,7 +135,7 @@ async def test_plan_discard_records_plan_aborted(tmp_path, monkeypatch):
 
     # Confirmation message in outbox.
     msgs = _drain_outbox(session)
-    status_texts = [m.text for m in msgs if m.kind == "status"]
+    status_texts = [m.text for m in msgs if m.kind == "system"]
     assert any("discarded plan run" in t for t in status_texts)
 
 
@@ -353,7 +353,7 @@ async def test_plan_resume_clears_target_step_results(tmp_path, monkeypatch):
 
     # Status confirmation in outbox.
     msgs = _drain_outbox(session)
-    status_texts = [m.text for m in msgs if m.kind == "status"]
+    status_texts = [m.text for m in msgs if m.kind == "system"]
     assert any("resumed from step" in t for t in status_texts)
 
     # Reload registry and confirm s1 preserved, s2/s3 cleared.

--- a/tests/test_skill_slash_command.py
+++ b/tests/test_skill_slash_command.py
@@ -70,7 +70,7 @@ async def test_skill_list_shows_active_runs(tmp_path, monkeypatch):
     assert consumed is True
 
     msgs = _drain_outbox(session)
-    status_texts = [m.text for m in msgs if m.kind == "status"]
+    status_texts = [m.text for m in msgs if m.kind == "system"]
     combined = "\n".join(status_texts)
     assert "run_A" in combined
     assert "blog_writer" in combined


### PR DESCRIPTION
## Summary

- Slash commands (`/cost`, `/agents`, `/list`, `/skill list`, `/budget`, `/help`, etc.) emitted their **final output** as `kind=\"status\"`. The chat router routes `status` to `StickyStatus`, a 1-line widget that overwrites on each `show()`.
- Result: only the **latest** reply was visible. Multi-line lists (`/agents`, `/budget`, `/help`) silently truncated to a single line.
- Fix: introduce `kind=\"system\"` for OS-generated persistent log entries — distinct from `agent` (the LLM isn't credited) and from `status` (the message survives subsequent commands).
- `ConversationView._render_system_message()` renders with a neutral grey `system` header, plain text (no Markdown / fold logic).
- Transient indicators (`thinking…`, `cancelled`, `resuming…`, plan-step progress lines) keep `kind=\"status\"` — ephemeral by design.

## Files changed

- `src/reyn/chat/tui/widgets/conversation.py` — add `system` rendering branch + `_render_system_message`
- `src/reyn/chat/slash/__init__.py` — `reply()` default `kind` flipped to `\"system\"`
- `src/reyn/chat/session.py` — slash final outputs (`/list`, `/cancel`, `/agents`, `/cost`, `/budget`, `/attach`, dispatcher fallbacks, plan_summary) use `\"system\"`
- 3 test files updated to match new kind

## Test plan

- [x] `pytest tests/` — 3321 passed
- [ ] In TUI: run `/cost`, then `/agents`, then `/list` — all three replies remain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)