### PR TITLE
fix(tui): truncate right-panel content lines to prevent word-boundary wrapping

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rich.text import Text
 from textual.app import ComposeResult, RenderResult
 from textual.message import Message
 from textual.widget import Widget
@@ -66,7 +67,21 @@ class _PanelContent(Static):
 
     def render(self) -> RenderResult:
         try:
-            return self._panel._panel_markup()
+            markup = self._panel._panel_markup()
+            if not isinstance(markup, str):
+                return markup
+            width = self.content_region.width
+            if width <= 0:
+                return Text.from_markup(markup)
+            # Truncate each line independently so long values
+            # (event types, file names, …) don't wrap into multiple
+            # rows and split words mid-line.
+            parts: list[Text] = []
+            for line_markup in markup.split("\n"):
+                line_t = Text.from_markup(line_markup)
+                line_t.truncate(width, overflow="ellipsis")
+                parts.append(line_t)
+            return Text("\n").join(parts)
         except Exception as exc:
             logger.warning("right_panel content render failed: %s", exc)
             return ""


### PR DESCRIPTION
## Summary

- Right-panel body content was word-wrapping at column boundaries: `evaluation-and-observability.ja` displayed as `evaluation-and` / `-observability.ja`, `user_message_received` as `user_message_receive` / `d`, timestamps split across two rows.
- Setting `no_wrap=True` on the Text alone did not stop the wrapping — Textual's render pipeline wraps regardless.
- Fix: convert the panel markup to `rich.Text`, split by newlines, call `truncate(width, overflow=\"ellipsis\")` per line, then join with the Text-aware join. Each event/file/memory row stays on one line; oversized values are ellipsized at the right edge.

This matches the per-line truncation already applied to the panel header in PR #50.

## Test plan

- [x] `pytest tests/` — 3321 passed
- [ ] In TUI: Events tab — `user_message_received` no longer splits into two lines
- [ ] In TUI: Docs tab — `evaluation-and-observability` filename ellipsized at the right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)