### PR TITLE
fix(tui): drop transparent right-panel borders that rendered as visible box

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -95,12 +95,9 @@ class _PanelTop(Widget):
         height: 1fr;
         layout: vertical;
         border-left: solid #2a2a2a;
-        border-top: solid transparent;
-        border-right: solid transparent;
-        border-bottom: solid transparent;
     }
     _PanelTop.x-focused {
-        border: solid $primary;
+        border-left: solid $primary;
     }
     """
 
@@ -141,8 +138,6 @@ class _PreviewPane(Widget):
         height: 1fr;
         border-top: solid #2a2a2a;
         border-left: solid #2a2a2a;
-        border-right: solid transparent;
-        border-bottom: solid transparent;
         layout: vertical;
     }
     _PreviewPane.preview-visible {
@@ -155,7 +150,8 @@ class _PreviewPane(Widget):
         padding: 0 1;
     }
     _PreviewPane:focus {
-        border: solid $primary;
+        border-top: solid $primary;
+        border-left: solid $primary;
     }
     _PreviewPane:focus #preview-header {
         color: $primary;


### PR DESCRIPTION
## Summary

- `_PanelTop` and `_PreviewPane` declared `border-{top,right,bottom}: solid transparent` on top of the intended `border-left: solid #2a2a2a`. Textual still draws box-drawing glyphs at those cells; with `transparent` falling back to the default foreground, the panel rendered with a full `┌────┐` frame around the content (the user-reported \"二重ボーダー\").
- Drop the transparent edges. Only the intentional left border remains.
- Focus styles flip just `border-left` to coral so the focused state is still distinct without re-introducing the full box.

## Before / after

Before:
```
│  Keys    Events    Agent
│━╸━━━━╺━━━━━━━━━━━━━━━━━━
┌────────────────────────┐
│ Key Bindings           │
│────────────────────────│
│   [GLOBAL]             │
```

After:
```
│  Keys    Events    Agent
│━╸━━━━╺━━━━━━━━━━━━━━━━━━
│ Key Bindings
│─────────────────────────
│   [GLOBAL]
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: launched TUI with `PYTHONPATH=tui-coder/src` and confirmed `┌─┐` box is gone on Keys + Events tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)