### PR TITLE
fix(tui): tighten right-panel tab strip so more tabs fit at default width

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -78,7 +78,8 @@ class RightPanel(Widget):
 
     RightPanel Tab {
         color: #666666;
-        padding: 0 2;
+        padding: 0 0;
+        margin: 0 1 0 0;
     }
 
     RightPanel Tab.-active {


### PR DESCRIPTION
## Summary

- Each `Tab` had `padding: 0 2` (2 cells on each side). At the default 33% panel width, only 3 of the 6 tabs (Keys / Events / Agents) fit on screen — Memory / Cost / Docs sat off-screen until the user cycled in.
- Switch to `padding: 0` plus a single-cell right margin so adjacent tabs are separated by one space instead of four.
- Result: 4 tabs (Keys / Events / Agents / Memory) now render at default panel width. Cost and Docs slide in when cycled, same as before.

## Before / after

```
Before:  │  Keys    Events    Agent              <- 3 visible (Agent truncated)
After:   │Keys Events Agents Memory              <- 4 visible
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: 4 tabs visible at default width; Tab cycling still scrolls Cost/Docs into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)