### PR TITLE
fix(tui): surface j↓/k↑ hint on every right-panel tab header

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -1251,15 +1251,15 @@ class RightPanel(Widget):
 
     def _panel_header_markup(self) -> str:
         if self._panel_type == "keys":
-            return f"[bold {_CORAL}]Key Bindings[/]"
+            return f"[bold {_CORAL}]Key Bindings[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "agents":
-            return f"[bold {_CORAL}]Agents[/]"
+            return f"[bold {_CORAL}]Agents[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "memory":
-            return f"[bold {_CORAL}]Memory[/]  [#555555]j↓  k↑  space=open[/]"
+            return f"[bold {_CORAL}]Memory[/]  [#555555]j↓ k↑ space=open[/]"
         if self._panel_type == "cost":
-            return f"[bold {_CORAL}]Cost[/]"
+            return f"[bold {_CORAL}]Cost[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "docs":
-            return f"[bold {_CORAL}]Docs[/]  [#555555]j↓  k↑  space=open[/]"
+            return f"[bold {_CORAL}]Docs[/]  [#555555]j↓ k↑ space=open[/]"
         if self._panel_type == "events":
             filter_name, _ = _FILTER_GROUPS[self._event_filter_idx]
             tail = _TAIL_CYCLE[self._event_tail_idx]


### PR DESCRIPTION
## Summary

- Memory / Docs / Events tab headers already showed `j↓ k↑`, but **Keys / Agents / Cost** did not — yet `j`/`k` is bound for those tabs too (scrolls the upper content, or moves the cursor on Agents).
- Without the hint, users had no clue scrolling was available. The gated `f` / `t` bindings shown lower in the Keys list went undiscovered because they sat below the fold.
- Add the same hint to every panel header. Normalise existing strings to single-space separators while at it — saves 3 cells on the narrow header.

## Before / after

```
Before:  Key Bindings            <- no hint, scroll is invisible
After:   Key Bindings  j↓ k↑     <- scroll discoverable
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: Keys / Agents / Cost / Memory / Docs all show `j↓ k↑` in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)