### PR TITLE
fix(tui): hide sticky status when an error or intervention is mounted

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -451,6 +451,11 @@ class ConversationView(Widget):
         skill_name: str = "",
     ) -> ErrorBox:
         self._consume_empty_hint()
+        # Hide any sticky "thinking…" — the turn is over (it failed).
+        # Otherwise the elapsed counter keeps incrementing forever next
+        # to a stale message, e.g. "⟳ thinking · 87.4s" while the
+        # ErrorBox below already shows "router failed".
+        self.hide_status()
         box = ErrorBox(
             message=message,
             details=details,
@@ -490,6 +495,9 @@ class ConversationView(Widget):
         iv_id: str = "",
     ) -> InterventionWidget:
         self._consume_empty_hint()
+        # The run is now blocked on the user's answer; "thinking…" is no
+        # longer accurate, hide the live counter while we wait.
+        self.hide_status()
         widget = InterventionWidget(
             question=question,
             choices=choices,


### PR DESCRIPTION
## Summary

- When the router failed, `ConversationView.mount_error()` mounted the ErrorBox but **left the sticky-status bar showing** `⟳ thinking · NNs` with the elapsed counter ticking up next to a stale message — the user saw a live \"thinking\" indicator alongside a \"router failed\" error box.
- Similarly, `mount_intervention()` left the spinner running even though the system is paused waiting on the user's answer.
- Call `hide_status()` from both paths so the sticky bar clears as soon as a terminal or blocking event takes over the view.

Related: PR #55 already addressed the bulk of the original report by moving slash-command FINAL outputs out of the sticky into the persistent chat log. This PR handles the remaining cases where the sticky was a live indicator for an operation that just completed.

## Test plan

- [x] `pytest tests/` — 3321 passed
- [ ] Visual: trigger a router error → \"thinking\" spinner disappears when the ErrorBox shows
- [ ] Visual: trigger an ask_user intervention → spinner clears while waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)