### PR TITLE
fix(tui): restore empty-state hint after Ctrl+L clears the chat

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -132,6 +132,9 @@ class ConversationView(Widget):
         padding: 0 1;
         height: auto;
     }
+    ConversationView #empty-hint.hidden {
+        display: none;
+    }
     """
 
     def __init__(self, *, scroll_end: bool = True, id: str | None = None) -> None:
@@ -188,7 +191,8 @@ class ConversationView(Widget):
             return
         self._has_first_message = True
         try:
-            self.query_one("#empty-hint", Static).remove()
+            # Hide instead of remove so /clear can bring it back.
+            self.query_one("#empty-hint", Static).add_class("hidden")
         except Exception:
             pass
 
@@ -566,6 +570,12 @@ class ConversationView(Widget):
         self._last_long_reply = None
         # Hide sticky status
         self.hide_status()
+        # Restore the empty-state hint so the next session looks fresh.
+        self._has_first_message = False
+        try:
+            self.query_one("#empty-hint", Static).remove_class("hidden")
+        except Exception:
+            pass
 
 
 # ── formatting helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `ConversationView` removed the \"Type `/` for commands · …\" hint widget on the first message and never put it back. Pressing Ctrl+L cleared the log but the helper line stayed gone — freshly-cleared sessions had no on-screen reminder of the slash entry point.
- Switch to hide-via-CSS-class instead of remove. `clear()` drops the class and resets `_has_first_message`, so a cleared session looks identical to first launch.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: send `/cost`, press Ctrl+L, the hint reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)