### PR TITLE
feat(tui): Ctrl+U clears the whole input buffer

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -10,6 +10,7 @@ Keybindings (handled here):
   Enter         → If picker has matches: insert "/cmdname " (confirm).
                   Otherwise: submit the message.
   Ctrl+J        → Insert a newline.
+  Ctrl+U        → Clear the whole input (single or multi-line).
   Tab           → Same as confirm-from-picker (no-op when picker is closed).
   Up / Down     → Picker selection when picker visible; otherwise input
                   history when the cursor is on the first/last row.
@@ -43,6 +44,7 @@ class InputBar(Widget):
         Binding("down", "key_down", "Down", priority=True, show=False),
         Binding("escape", "dismiss_picker", "Esc", priority=True, show=False),
         Binding("ctrl+j", "newline", "Newline", priority=True, show=False),
+        Binding("ctrl+u", "clear_input", "Clear input", priority=True, show=False),
         Binding("ctrl+l", "clear_conversation", "Clear", priority=True, show=False),
         Binding("ctrl+d", "quit_app", "Quit", priority=True, show=False),
         Binding("ctrl+c", "cancel", "Cancel", priority=True, show=False),
@@ -225,6 +227,22 @@ class InputBar(Widget):
         ta = self._textarea()
         if ta is not None:
             ta.insert("\n")
+
+    def action_clear_input(self) -> None:
+        """Ctrl+U — wipe the whole input.
+
+        The TextArea's default Ctrl+U only deletes from the cursor back
+        to the start of the current line, which is unintuitive for a
+        multi-line composer. Operators expect Ctrl+U to clear the entire
+        buffer (matching readline-on-a-single-line semantics for the
+        common case).
+        """
+        ta = self._textarea()
+        if ta is not None:
+            ta.clear()
+        picker = self._picker()
+        if picker is not None and picker.visible_:
+            picker.hide()
 
     def action_clear_conversation(self) -> None:
         self.post_message(self.ClearConversation())


### PR DESCRIPTION
## Summary

- `TextArea`'s default Ctrl+U deletes from the cursor back to the start of the **current** line only, which is unintuitive in a multi-line composer: clearing a 3-line draft took Ctrl+U × 3 (plus Down keystrokes between each, because the cursor needs to be at the end of every line first).
- Rebind Ctrl+U to wipe the entire buffer, matching readline-on-a-single-line semantics for the common case.
- Also hides the slash picker so it doesn't keep showing matches against the now-empty input.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: typed `line one\\nline two\\nline three` → Ctrl+U → input fully cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)