### PR TITLE
fix(tui): show full error message in expanded ErrorBox

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -9,7 +9,7 @@ After click (expanded):
     ✗ [skill#run_id]: error message  ▼
       detail line 1
       detail line 2
-      … N more  [B→events]
+      … N more  Ctrl+B → events
 
 Press Esc to dismiss (handled by ConversationView / app.py via the
 `_error_boxes` list — same API as before).
@@ -123,7 +123,12 @@ class ErrorBox(Widget):
             if overflow > 0:
                 detail_text += f"\n… {overflow} more"
             yield Static(detail_text, classes="eb-details")
-            yield Label("[B→events] for full trace", classes="eb-hint")
+            yield Label("Ctrl+B → events for full trace", classes="eb-hint")
+        else:
+            # No details supplied — fall back to the full (untruncated) message
+            # so long errors are still readable when the box is expanded.
+            yield Static(self._message, classes="eb-details")
+            yield Label("Ctrl+B → events for full trace", classes="eb-hint")
 
     # ── interaction ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `ErrorBox._header_text()` truncates the collapsed header at 72 chars with `…`, but no caller in the repo ever populates the optional `details` field — every `kind="error"` outbox emit in `chat/session.py` and `chat/registry.py` passes `text` + `meta` only. Result: expanding a long error reveals an empty block, and the truncated tail of the message has no path to the screen.
- When `self._details` is empty, fall back to rendering the full untruncated `self._message` inside the `eb-details` block. When details are provided, behaviour is unchanged.
- Replace the misleading `[B→events] for full trace` hint with `Ctrl+B → events for full trace`. `B` alone is not bound anywhere in `app.py BINDINGS`; `ctrl+b` is the real `action_toggle_panel` binding (the panel preserves the last focal tab).

Caller-side (`session.py` / `conversation.mount_error`) is intentionally left untouched — the expanded view now reads the message that's already on the widget.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [ ] Visual: trigger a long router error → header is truncated with `…`, click to expand → full message visible inside the expanded block, hint reads `Ctrl+B → events for full trace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)