### PR TITLE
fix(tui): seal orphan streaming rows on Ctrl+C cancel

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -561,7 +561,28 @@ class ReynTUIApp(App):
                 task.cancel()
                 cancelled_plans += 1
 
-        if cancelled_skills == 0 and cancelled_plans == 0:
+        # Seal any orphan streaming rows. The router cancel above stops the
+        # producer but no `__stream_end__` is emitted, so the StreamingRow's
+        # blinking cursor would otherwise persist forever. Snapshot first —
+        # end_stream() mutates conv._stream_rows.
+        cancelled_streams = 0
+        if conv is not None:
+            from rich.text import Text as _RichText
+            for msg_id in list(conv._stream_rows.keys()):
+                try:
+                    conv.end_stream(msg_id)
+                    conv._write_log(
+                        _RichText("  ⌁ cancelled", style="dim italic #888888"),
+                    )
+                    cancelled_streams += 1
+                except Exception:
+                    pass
+
+        if (
+            cancelled_skills == 0
+            and cancelled_plans == 0
+            and cancelled_streams == 0
+        ):
             self._voice_status(
                 "(nothing in-flight to cancel)", style="dim #555555",
             )
@@ -574,6 +595,10 @@ class ReynTUIApp(App):
         if cancelled_plans:
             parts.append(
                 f"{cancelled_plans} plan{'s' if cancelled_plans != 1 else ''}"
+            )
+        if cancelled_streams:
+            parts.append(
+                f"{cancelled_streams} stream{'s' if cancelled_streams != 1 else ''}"
             )
         self._voice_status(
             f"✗ cancelled {' + '.join(parts)}", style="bold #aa6666",


### PR DESCRIPTION
## Summary

- When the user pressed Ctrl+C mid-stream, the router cancellation stopped the producer task but no `__stream_end__` event was emitted — so `ConversationView.end_stream()` never ran and the `StreamingRow`'s blinking cursor kept ticking forever.
- `action_cancel_inflight` now snapshots `conv._stream_rows` keys after the existing task-cancel pass and calls `end_stream(msg_id)` on each. A dim `⌁ cancelled` marker line is written under each sealed reply so the user can see it was interrupted.
- The cancellation summary now counts sealed streams alongside cancelled skills/plans, and an orphan stream alone is enough to avoid the "(nothing in-flight to cancel)" early return.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [ ] Visual: trigger a long LLM reply, press Ctrl+C mid-stream → cursor stops, `⌁ cancelled` line appears, summary reads `✗ cancelled N skill + 1 stream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>