### PR TITLE
fix(tui): wire `/` on Docs tab to /docs-filter + advertise it in header

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -326,6 +326,15 @@ class RightPanel(Widget):
             # an issue tracker.
             event.prevent_default()
             self._copy_current_view()
+        elif event.key == "/":
+            # Docs tab only: pre-fill the conv input with the
+            # `/docs-filter` slash command so the user can type a
+            # substring and press Enter. Advertised by keys_tab._DOCS_KEYS
+            # and the Docs header `/=filter` hint. MVP — no inline
+            # filter buffer; just hand off to the existing slash command.
+            if self._panel_type == "docs":
+                event.prevent_default()
+                self._prefill_docs_filter()
 
 
     def on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
@@ -999,6 +1008,30 @@ class RightPanel(Widget):
         except Exception as exc:
             logger.warning("right_panel copy status failed: %s", exc)
 
+    def _prefill_docs_filter(self) -> None:
+        """`/` on the Docs tab — focus InputBar and pre-fill `/docs-filter `.
+
+        MVP: hand off to the existing `/docs-filter` slash command instead of
+        building an inline filter buffer. The user types the substring and
+        hits Enter; an empty submission clears the filter (same as invoking
+        the slash command directly).
+        """
+        from .. import InputBar  # late import → avoid cycle
+        try:
+            inputbar = self.app.query_one("#inputbar", InputBar)
+        except Exception as exc:
+            logger.warning("right_panel prefill docs filter failed: %s", exc)
+            return
+        try:
+            ta = inputbar.query_one("#input")
+            ta.load_text("/docs-filter ")
+            # Move cursor past the trailing space so the user types the
+            # substring directly without having to skip whitespace.
+            ta.move_cursor((0, len("/docs-filter ")))
+            inputbar.focus_input()
+        except Exception as exc:
+            logger.warning("right_panel prefill docs filter focus failed: %s", exc)
+
     def _build_recent_skill_bundle(self, item: dict) -> str:
         """Header + events YAML for a finished skill run."""
         import json as _json
@@ -1259,7 +1292,10 @@ class RightPanel(Widget):
         if self._panel_type == "cost":
             return f"[bold {_CORAL}]Cost[/]"
         if self._panel_type == "docs":
-            return f"[bold {_CORAL}]Docs[/]  [#555555]j↓  k↑  space=open[/]"
+            return (
+                f"[bold {_CORAL}]Docs[/]"
+                f"  [#555555]j↓  k↑  space=open  /=filter[/]"
+            )
         if self._panel_type == "events":
             filter_name, _ = _FILTER_GROUPS[self._event_filter_idx]
             tail = _TAIL_CYCLE[self._event_tail_idx]


### PR DESCRIPTION
## Summary

- `widgets/right_panel/keys_tab.py:_DOCS_KEYS` advertised `/` as a gated Docs binding, but `RightPanel.on_key` had no `/` branch — pressing `/` on the Docs tab silently did nothing. The keys-tab help was a lie.
- The Docs header markup read `j↓  k↑  space=open` only; first-time users had no way to learn that `/docs-filter` exists until they happened to type the slash command from chat.
- Wire `/` on the Docs tab to focus the InputBar and pre-fill `/docs-filter ` (with the cursor parked past the trailing space), so the user just types the substring and hits Enter. Empty submission clears the filter — same semantics as invoking the slash command directly.
- Add ` /=filter` to the Docs header markup so the binding is discoverable from the panel itself.

## Scope

MVP — no inline filter buffer. This PR hands off to the existing `/docs-filter` slash command path (`app_outbox._on_docs_filter`) rather than building a parallel filter input. An inline buffer would be a separate, larger change.

## Before / after

```
Before:  Docs  j↓  k↑  space=open                  ← `/` is bound per keys_tab but inert
After:   Docs  j↓  k↑  space=open  /=filter        ← `/` focuses InputBar + pre-fills `/docs-filter `
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [ ] Visual: open Docs tab, press `/` → InputBar gains focus pre-filled with `/docs-filter `, cursor past the space; type `arch` + Enter → docs list filters to entries containing `arch`
- [ ] Visual: Docs header shows ` /=filter` next to ` space=open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)