### PR TITLE
fix(tui): wrap right-panel j/k cursor at list edges

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -401,12 +401,17 @@ class RightPanel(Widget):
     # ── events / memory cursor + preview integration ─────────────────────────
 
     def _events_move(self, delta: int) -> None:
-        """Move the events tab cursor and refresh; sync preview if open."""
-        if not self._events_visible:
+        """Move the events tab cursor and refresh; sync preview if open.
+
+        Cursor wraps around modulo the list length — `j` past the last
+        item returns to index 0, `k` from the top jumps to the last
+        item (Vim-list behaviour).
+        """
+        n = len(self._events_visible)
+        if n == 0:
+            self._events_cursor = 0
             return
-        self._events_cursor = max(
-            0, min(len(self._events_visible) - 1, self._events_cursor + delta),
-        )
+        self._events_cursor = (self._events_cursor + delta) % n
         self._invalidate()
         if self._preview_visible:
             self._update_preview()
@@ -472,12 +477,15 @@ class RightPanel(Widget):
         pane.show_text(title, self._render_as_yaml(ev))
 
     def _memory_move(self, delta: int) -> None:
-        """Move the memory tab cursor; sync preview if open."""
-        if not self._memory_entries:
+        """Move the memory tab cursor; sync preview if open.
+
+        Cursor wraps around modulo the list length (Vim-list behaviour).
+        """
+        n = len(self._memory_entries)
+        if n == 0:
+            self._memory_cursor = 0
             return
-        self._memory_cursor = max(
-            0, min(len(self._memory_entries) - 1, self._memory_cursor + delta),
-        )
+        self._memory_cursor = (self._memory_cursor + delta) % n
         self._invalidate()
         if self._preview_visible:
             self._update_preview()
@@ -508,12 +516,15 @@ class RightPanel(Widget):
     # ── agents tab cursor + preview integration ──────────────────────────────
 
     def _agents_move(self, delta: int) -> None:
-        """Move the agents tab cursor; sync preview if open."""
-        if not self._agents_items:
+        """Move the agents tab cursor; sync preview if open.
+
+        Cursor wraps around modulo the list length (Vim-list behaviour).
+        """
+        n = len(self._agents_items)
+        if n == 0:
+            self._agents_cursor = 0
             return
-        self._agents_cursor = max(
-            0, min(len(self._agents_items) - 1, self._agents_cursor + delta),
-        )
+        self._agents_cursor = (self._agents_cursor + delta) % n
         self._invalidate()
         if self._preview_visible:
             self._update_preview()
@@ -1202,9 +1213,17 @@ class RightPanel(Widget):
     # ── docs navigation ───────────────────────────────────────────────────────
 
     def _docs_move(self, delta: int) -> None:
-        if not self._docs_files:
+        """Move the docs cursor over the flat file list; sync preview / scroll.
+
+        Cursor wraps around modulo the file count (Vim-list behaviour).
+        Wrapping is over the flat `_docs_files` order — sections are a
+        rendering concern, not a separate navigation axis here.
+        """
+        n = len(self._docs_files)
+        if n == 0:
+            self._docs_cursor = 0
             return
-        self._docs_cursor = max(0, min(len(self._docs_files) - 1, self._docs_cursor + delta))
+        self._docs_cursor = (self._docs_cursor + delta) % n
         self._invalidate()
         if self._preview_visible:
             self._update_preview()

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -639,10 +639,11 @@ async def test_event_filter_cycling_rotates_through_groups():
 
 @pytest.mark.asyncio
 async def test_docs_cursor_advances_with_j_keypress():
-    """Tier 2: docs tab j keypress advances _docs_cursor and stays in bounds.
+    """Tier 2: docs tab j keypress advances _docs_cursor and wraps modulo length.
 
     Pins the contract that pressing j on the docs tab moves the cursor
-    forward by one and never overflows past the last file.
+    forward by one, and that stepping past the last file wraps back to
+    the first (Vim-list behaviour) — same for k from the top.
     """
     app = _make_app()
     async with app.run_test(headless=True) as pilot:
@@ -660,12 +661,12 @@ async def test_docs_cursor_advances_with_j_keypress():
         assert panel._docs_cursor == 1
         panel._docs_move(+1)
         assert panel._docs_cursor == 2
-        # Bounded — does not overflow past the last file.
+        # Wraparound — stepping past the last file returns to index 0.
         panel._docs_move(+1)
-        assert panel._docs_cursor == 2
-        # Reverse navigation works too.
+        assert panel._docs_cursor == 0
+        # Reverse from the top wraps to the last file.
         panel._docs_move(-1)
-        assert panel._docs_cursor == 1
+        assert panel._docs_cursor == 2
 
 
 # ── test: right panel — tab cycling ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- On the **docs / events / memory / agents** tabs, pressing `j` past the last item used to stop dead; same for `k` at the top. No visible affordance meant the keybinding looked broken.
- Replace the `max(0, min(n-1, cursor + delta))` clamp in `_events_move`, `_memory_move`, `_agents_move`, and `_docs_move` with modulo wrap, so `j` wraps from the last item to index 0 and `k` from the top jumps to the last item (Vim-list behaviour).
- The h/l `_panel_resize` clamp is intentionally left alone — its bounds (24..max width) are a meaningful geometry constraint, not a cyclic list.

## Before / after

```
Before:  j j j j … cursor stops at last item, no feedback
After:   j j j j … wraps last → 0; k from 0 jumps to last
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Updated `test_docs_cursor_advances_with_j_keypress` to pin the new wraparound contract (was pinning the old clamp)
- [ ] Visual: on each of docs / events / memory / agents, hammer `j` past the bottom and confirm cursor wraps to top; same with `k` from the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)