### PR TITLE
feat(tui): show +N more pending badge on InterventionWidget

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -230,6 +230,7 @@ class ReynTUIApp(App):
         text: str,
         iv_id: str,
         choices: list[tuple[str, str]] | None = None,
+        queued_extra: int = 0,
     ) -> None:
         """Mount an InterventionWidget inline in the conversation view.
 
@@ -237,6 +238,10 @@ class ReynTUIApp(App):
         rendered. The user's answer (chip label or free text) is routed via
         session._maybe_answer_oldest_intervention — which matches hotkeys /
         choice labels against the pending intervention.
+
+        ``queued_extra`` surfaces the number of additional pending
+        interventions waiting behind the head one (caller-computed) so the
+        widget can render a persistent ``+N more pending`` badge.
         """
         async def _callback(answer: str) -> None:
             session = self._get_session()
@@ -248,6 +253,7 @@ class ReynTUIApp(App):
             choices=choices,
             answer_callback=_callback,
             iv_id=iv_id,
+            queued_extra=queued_extra,
         )
 
     def _maybe_refresh_status(self, header: ReynHeader | None = None) -> None:

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -267,6 +267,12 @@ class OutboxRouter:
         Hides the sticky ``⟳ thinking…`` indicator first: while the
         agent is waiting for a human answer, "thinking" is misleading
         — the system is blocked on user input, not on the model.
+
+        Computes ``queued_extra`` from the session's intervention registry
+        so the widget can render a persistent ``+N more pending`` badge.
+        The sticky ``awaiting answer (N queued)`` status gets overwritten
+        by the next ``thinking…`` event, so we need an inline persistent
+        signal instead.
         """
         conv.hide_status()
         iv_id = msg.meta.get("intervention_id", "")
@@ -274,7 +280,20 @@ class OutboxRouter:
         choices = None
         if raw_choices:
             choices = [(c["label"], c["id"]) for c in raw_choices]
-        self._app._mount_intervention(conv, msg.text, iv_id, choices)
+        # Best-effort queue depth — the registry owns the canonical count;
+        # any failure (no session attached, attribute missing on a stubbed
+        # session in tests) falls back to 0 so we never break the mount.
+        queued_extra = 0
+        try:
+            session = self._app._get_session()
+            registry = getattr(session, "_interventions", None) if session else None
+            if registry is not None:
+                queued_extra = max(0, registry.queued_count() - 1)
+        except Exception:
+            queued_extra = 0
+        self._app._mount_intervention(
+            conv, msg.text, iv_id, choices, queued_extra=queued_extra,
+        )
 
     def _on_intervention_resolved(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -488,6 +488,7 @@ class ConversationView(Widget):
         choices: list[tuple[str, str]] | None = None,
         answer_callback=None,
         iv_id: str = "",
+        queued_extra: int = 0,
     ) -> InterventionWidget:
         self._consume_empty_hint()
         widget = InterventionWidget(
@@ -495,6 +496,7 @@ class ConversationView(Widget):
             choices=choices,
             answer_callback=answer_callback,
             iv_id=iv_id,
+            queued_extra=queued_extra,
         )
         self.mount(widget)
         widget.scroll_visible()

--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -27,6 +27,10 @@ class InterventionWidget(Widget):
                          When empty, only a free-text input is shown.
         answer_callback: Coroutine called with the user's answer string.
         iv_id:           Intervention ID (for logging / targeting).
+        queued_extra:    Number of additional pending interventions waiting
+                         behind this one. When > 0, a dim ``+N more pending``
+                         label is rendered in the widget header so the user
+                         has a persistent signal that more questions follow.
     """
 
     DEFAULT_CSS = """
@@ -75,6 +79,13 @@ class InterventionWidget(Widget):
         height: auto;
         width: 1fr;
     }
+    InterventionWidget Label.iv-queued {
+        color: #888888;
+        text-style: dim;
+        padding-bottom: 1;
+        height: auto;
+        width: 1fr;
+    }
     """
 
     class Answered(Message):
@@ -91,6 +102,7 @@ class InterventionWidget(Widget):
         choices: list[tuple[str, str]] | None = None,
         answer_callback: Callable[[str], Awaitable[None]] | None = None,
         iv_id: str = "",
+        queued_extra: int = 0,
         id: str | None = None,
     ) -> None:
         super().__init__(id=id or f"iv_{iv_id[:8]}")
@@ -98,10 +110,16 @@ class InterventionWidget(Widget):
         self._choices = choices or []
         self._answer_callback = answer_callback
         self._iv_id = iv_id
+        self._queued_extra = max(0, int(queued_extra))
         self._show_input = not self._choices  # no chips → always show free text
 
     def compose(self) -> ComposeResult:
         yield Label(f"  {self._question}", classes="iv-question")
+        if self._queued_extra > 0:
+            yield Label(
+                f"  +{self._queued_extra} more pending",
+                classes="iv-queued",
+            )
         if self._choices:
             with Widget(classes="iv-chips"):
                 for label, choice_id in self._choices:


### PR DESCRIPTION
## Summary

- When multiple skills queue `ask_user` interventions, only the head `InterventionWidget` is mounted in the conv pane. The `intervention_handler` emits an `awaiting answer (N queued)` sticky, but that goes to the 1-line `StickyStatus` and gets overwritten by the next `thinking...` event — so the user has no persistent signal that more questions are waiting.
- This PR adds an optional `queued_extra: int` parameter to `InterventionWidget`. When `> 0`, a small dim `+N more pending` label is appended to the widget's header.
- `app_outbox._on_intervention` reads `queued_count()` off the session's intervention registry and threads `queued_extra = count - 1` through `app._mount_intervention` -> `conv.mount_intervention` -> the widget.
- Registry lookup is wrapped in a defensive try/except with a `0` fallback so a missing session / stubbed registry (in tests) never breaks the mount path.

## Files changed

- `src/reyn/chat/tui/widgets/intervention.py` — new `queued_extra` ctor arg, new `.iv-queued` CSS class, conditional Label in `compose()`.
- `src/reyn/chat/tui/widgets/conversation.py` — `mount_intervention` forwards the new kwarg.
- `src/reyn/chat/tui/app.py` — `_mount_intervention` accepts and forwards the new kwarg.
- `src/reyn/chat/tui/app_outbox.py` — `_on_intervention` computes `queued_extra` from `session._interventions.queued_count() - 1`.

## Test plan

- [x] `pytest tests/` — 3277 passed, 11 skipped, 2 xfailed (baseline unchanged).
- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed (existing `mount_intervention` tests still green with new optional kwarg).
- [ ] Manual: queue 3 `ask_user` interventions from a skill; verify the head widget renders `+2 more pending` and that the badge updates to `+1 more pending` after the head is answered.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>