### PR TITLE
fix(tui): refuse to open right-panel preview when the tab has no content

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -371,6 +371,13 @@ class RightPanel(Widget):
     # ── preview pane ─────────────────────────────────────────────────────────
 
     def _toggle_preview(self) -> None:
+        # Refuse to open the preview pane on a tab that has nothing to show
+        # (e.g. agents tab with no running / recent skills, or memory tab
+        # with an empty SHARED bucket). Otherwise the user sees a blank
+        # `—` preview window with no obvious recovery, and has to press
+        # Space again to dismiss it.
+        if not self._preview_visible and not self._has_previewable_content():
+            return
         self._preview_visible = not self._preview_visible
         try:
             pane = self.query_one("#preview-pane", _PreviewPane)
@@ -381,6 +388,19 @@ class RightPanel(Widget):
                 pane.remove_class("preview-visible")
         except Exception as exc:
             logger.warning("right_panel toggle_preview failed: %s", exc)
+
+    def _has_previewable_content(self) -> bool:
+        """Whether the current tab has at least one item the preview pane
+        can render. Keys / cost tabs never have previews."""
+        if self._panel_type == "docs":
+            return bool(self._docs_files)
+        if self._panel_type == "events":
+            return bool(self._events_visible)
+        if self._panel_type == "memory":
+            return bool(self._memory_entries)
+        if self._panel_type == "agents":
+            return bool(self._agents_items)
+        return False
 
     def _update_preview(self) -> None:
         try:


### PR DESCRIPTION
## Summary

- Pressing Space on a right-panel tab with nothing previewable (agents tab with no running / recent skill runs, memory tab with empty SHARED bucket, etc.) still toggled the preview pane open. `_update_preview` then fell through to `pane.clear()` and the user saw a blank window with only a `—` title — requiring a **second** Space press to dismiss.
- Add `_has_previewable_content()` and guard `_toggle_preview` so the pane stays closed when there is nothing meaningful to show on the current tab. Existing tabs with content are unaffected.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: Memory tab with empty SHARED → Space → preview stays closed (was: opened blank `—` window)
- [x] Visual: Agents tab with a recent skill run → Space → preview still opens and shows the run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)