### PR TITLE
fix(tui): show 4dp cost in header so cheap-model spend stays visible

### DIFF
--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -99,7 +99,11 @@ class ReynHeader(Widget):
         if self._tokens_cap is not None:
             tok_str += f" / {self._tokens_cap:,}"
         tok_str += " tok"
-        cost_str = f"${self._cost_usd:.2f}"
+        # Use 4 decimals so the cheap-model spend stays visible. With 2dp
+        # `gemini-flash-lite` rounds to `$0.00` even after dozens of calls;
+        # users see the token counter tick up but think the cost is free.
+        # The cap (when set) is at a larger scale, so 2dp there is fine.
+        cost_str = f"${self._cost_usd:.4f}"
         if self._cost_cap is not None:
             cost_str += f" / ${self._cost_cap:.2f}"
         parts.append(tok_str)


### PR DESCRIPTION
## Summary

- `ReynHeader._format_status` formatted `cost_usd` as `\${...:.2f}`. With gemini-flash-lite at ~$0.0001 per call, dozens of router turns accumulate to ~$0.001 and still display as `\$0.00` — the token counter ticks up but the cost looks frozen, so users think they're spending nothing.
- `/cost` already prints 4dp (`\$0.0010`), so the header and the slash command disagree on precision.
- Switch the header to 4dp so the actual spend is visible from turn one.
- The cap (when set) stays 2dp — it's at a larger scale where 2dp is correct.

## Before / after

```
Before:  default │ standard │ 24,776 tok │ $0.00  │ 2026-05-17
After:   default │ standard │ 24,776 tok │ $0.0010 │ 2026-05-17
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] No tests asserted on the 2dp format

🤖 Generated with [Claude Code](https://claude.com/claude-code)