### PR TITLE
feat(tui): Ctrl+P/N navigates to every turn header, not just agent replies

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -207,12 +207,15 @@ class ConversationView(Widget):
         within_window = (now - self._last_speaker_at) < _GROUP_WINDOW_S
         if not (same_speaker and within_window):
             log = self._log()
-            # Record turn anchor for agent turns (B4 navigation)
-            if speaker == "reyn":
-                self._turn_anchors.append(len(log.lines))
-                # Cap to last 200 to avoid unbounded growth (long sessions)
-                if len(self._turn_anchors) > 200:
-                    self._turn_anchors = self._turn_anchors[-200:]
+            # Record a turn anchor whenever a new speaker header appears
+            # — agent replies, user inputs, and system / slash-command
+            # results. Ctrl+P / Ctrl+N then walk through every header in
+            # order, which matches the user's mental model of "jump to
+            # the previous turn" better than "jump only to agent replies".
+            self._turn_anchors.append(len(log.lines))
+            # Cap to last 200 to avoid unbounded growth (long sessions)
+            if len(self._turn_anchors) > 200:
+                self._turn_anchors = self._turn_anchors[-200:]
             log.write(_msg_header(label_text, name_style, dash_style))
         self._last_speaker = speaker
         self._last_speaker_at = now


### PR DESCRIPTION
## Summary

- `ConversationView._maybe_write_header` only appended a turn anchor when `speaker == \"reyn\"`. So `Ctrl+P` / `Ctrl+N` skipped the user's own prompts and the `system` headers from PR #55 (slash-command outputs).
- The nav feels half-broken: pressing \"prev turn\" while reviewing a long session jumps to the agent reply two turns back, skipping the user question that prompted it.
- Anchor every speaker header instead. The user's mental model of \"previous turn\" is just \"previous header\", regardless of who spoke.
- The 200-entry cap keeps memory bounded for long sessions (unchanged).

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: send `/cost` then a regular message; Ctrl+P walks back through reyn → you → system → you, in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)