### PR TITLE
fix(tui): show only HH:MM:SS for event rows so the type is visible

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -511,7 +511,13 @@ def render_events(
             lines.append("")
         prev_chain = chain_id
 
-        ts = _esc(str(ev.get("timestamp", ""))[:19].replace("T", " "))
+        # Use HH:MM:SS only — the full ISO timestamp consumed 19 chars on the
+        # narrow panel and the event-type was pushed off-screen behind an `…`.
+        # Date is rarely needed at-a-glance for events tab consumers; the
+        # full timestamp is still in the JSON preview opened with Space.
+        raw_ts = str(ev.get("timestamp", ""))
+        # "2026-05-17T09:54:42…" — the time block lives in chars 11-19
+        ts = _esc(raw_ts[11:19] if len(raw_ts) >= 19 else raw_ts)
         color = _EVENT_COLORS.get(ev_type, _DEFAULT_EVENT_COLOR)
         hint = _esc(_event_hint(ev))
         hint_part = f"  [#555555]{hint}[/]" if hint else ""


### PR DESCRIPTION
## Summary

- The events tab rendered each row as `<cursor> 2026-05-17 09:54:43  <event_type>`. On the default-sized right panel (~22 col content width), the 19-char ISO timestamp ate the entire row and the event type collapsed to `…`.
- Caught while testing PR #56 (the no-wrap truncation): timestamps fit but the actually-useful field — the event type — was always behind the ellipsis.
- Strip the date prefix and render just `HH:MM:SS`. The full timestamp is still available in the JSON preview opened with Space, and the events tab is overwhelmingly used to scan **today's** events.

## Before / after (22-col content width)

```
Before:  ▶ 2026-05-17 09:54:4…
         ▶ 2026-05-17 09:54:4…
After:   ▶ 09:54:43  llm_call…
         ▶ 09:54:43  context_…
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: events tab now shows `HH:MM:SS  <event_type>` rows; type is readable at default panel width

🤖 Generated with [Claude Code](https://claude.com/claude-code)