### PR TITLE
fix(tui): make permission-denied error message actionable

### DIFF
--- a/src/reyn/dispatch/dispatcher.py
+++ b/src/reyn/dispatch/dispatcher.py
@@ -217,6 +217,7 @@ async def dispatch_tool(
     try:
         result = await invoker(args)
     except PermissionError as e:
+        enriched = _enrich_permission_message(name, str(e))
         ctx.events.emit(
             "tool_failed",
             caller_kind=ctx.caller_kind,
@@ -225,15 +226,15 @@ async def dispatch_tool(
             chain_id=ctx.chain_id,
             args_hash=args_hash,
             error_kind="permission_denied",
-            message=str(e),
+            message=enriched,
         )
         if emit_step and purity != OpPurity.pure:
             await _wal_step_failed(
                 ctx, name, args_hash, op_invocation_id,
-                "permission_denied", str(e),
+                "permission_denied", enriched,
             )
         return {"status": "error",
-                "error": {"kind": "permission_denied", "message": str(e)}}
+                "error": {"kind": "permission_denied", "message": enriched}}
     except Exception as e:  # noqa: BLE001 — caller errors are normalized
         ctx.events.emit(
             "tool_failed",
@@ -478,6 +479,67 @@ def _compute_llm_args_hash(
     except Exception:  # noqa: BLE001 — fall back to repr for unhashable values
         canonical = repr(payload)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+# ── Permission-denied message enrichment ─────────────────────────────────────
+# Maps a dispatch tool name → config key the user would set in
+# reyn.yaml / reyn.local.yaml to grant the capability. The hint is appended
+# to the underlying PermissionError text so the user sees both WHAT was
+# denied and HOW to allow it without leaving the chat to read source.
+#
+# Names cover both router-tool catalog entries (read_file, web_fetch, …)
+# and skill_phase op kinds (file, shell, web_fetch, …). Unmapped names
+# fall back to a generic "see logs / events tab" suffix — better than
+# fabricating a config key the user can't actually find.
+_PERMISSION_CONFIG_HINTS: dict[str, str] = {
+    # File ops — router catalog + skill_phase "file" op kind.
+    "file": "permissions.file.read / file.write: allow",
+    "read_file": "permissions.file.read: allow",
+    "write_file": "permissions.file.write: allow",
+    "delete_file": "permissions.file.write: allow",
+    "list_directory": "permissions.file.read: allow",
+    # Shell.
+    "shell": "permissions.shell: allow",
+    # MCP family.
+    "mcp": "permissions.mcp.<server>: allow",
+    "call_mcp_tool": "permissions.mcp.<server>: allow",
+    "list_mcp_tools": "permissions.mcp.<server>: allow",
+    "describe_mcp_tool": "permissions.mcp.<server>: allow",
+    "mcp_install": "permissions.mcp_install: allow",
+    "mcp_drop_server": "permissions.mcp_drop_server: allow",
+    # Web.
+    "web_fetch": "permissions.web.fetch: allow",
+    "web_search": "permissions.web.search: allow",
+    # Index ops.
+    "index_drop": "permissions.index_drop: allow",
+    "drop_source": "permissions.index_drop: allow",
+}
+
+
+def _enrich_permission_message(tool: str, original: str) -> str:
+    """Append an actionable config hint to a PermissionError message.
+
+    The hint points the user at the reyn.yaml / reyn.local.yaml config key
+    that grants the capability. Format keeps the original message as the
+    prefix (so callers / tests that look for substrings in the underlying
+    text continue to work) and adds a single trailing line:
+
+        <original>
+        To allow: add `<config-key>` to reyn.local.yaml under permissions:
+
+    Unknown tool names fall back to a generic suffix that points at the
+    events tab instead of fabricating a config key.
+    """
+    hint = _PERMISSION_CONFIG_HINTS.get(tool)
+    if hint is None:
+        return (
+            f"{original}\n"
+            f"To allow: see the events tab for the full permission trace."
+        )
+    return (
+        f"{original}\n"
+        f"To allow: add `{hint}` to reyn.local.yaml under permissions:"
+    )
 
 
 def _error(ctx: DispatchContext, name: str, kind: str, message: str) -> dict:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -128,6 +128,81 @@ def test_permission_error_inside_invoker_returns_permission_denied():
     asyncio.run(main())
 
 
+def test_permission_denied_message_includes_actionable_hint():
+    """Tier 2: permission_denied messages MUST include a "To allow:" hint.
+
+    Without the hint, the user sees a bare PermissionError and has no path
+    forward besides reading source. The hint is appended after the original
+    message so substring checks ("nope" etc.) keep working downstream.
+    """
+    write_catalog = {
+        "write_file": {
+            "function": {
+                "name": "write_file",
+                "description": "Write a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        }
+    }
+
+    async def main():
+        async def invoker(args):
+            raise PermissionError("write to '/tmp/foo' was not approved.")
+        ctx, ev = make_ctx(catalog=write_catalog)
+        result = await dispatch_tool(
+            name="write_file", args={"path": "/tmp/foo"},
+            ctx=ctx, invoker=invoker,
+        )
+        msg = result["error"]["message"]
+        # Original error stays as the prefix (substring contract).
+        assert "write to '/tmp/foo' was not approved." in msg
+        # Actionable hint is appended.
+        assert "To allow:" in msg
+        # The hint names the matching config key for the tool.
+        assert "file.write" in msg
+        # And points the user at a config file they can edit.
+        assert "reyn.local.yaml" in msg
+
+        # The same hint flows through to the tool_failed audit event so
+        # later inspection (events tab / forensics) sees what the user saw.
+        failed = [e for e in ev.events if e[0] == "tool_failed"]
+        assert failed, "tool_failed event must fire on permission_denied"
+        assert "To allow:" in failed[0][1]["message"]
+    asyncio.run(main())
+
+
+def test_permission_denied_unmapped_tool_falls_back_to_generic_hint():
+    """Tier 2: unmapped tool names get a generic suffix, not a fabricated key.
+
+    The fix must never invent a config key that doesn't exist; an unknown
+    tool gets the "see the events tab" suffix instead.
+    """
+    catalog = {
+        "some_unmapped_tool": {
+            "function": {"name": "some_unmapped_tool", "description": "x"},
+        }
+    }
+
+    async def main():
+        async def invoker(args):
+            raise PermissionError("nope")
+        ctx, _ = make_ctx(catalog=catalog)
+        result = await dispatch_tool(
+            name="some_unmapped_tool", args={},
+            ctx=ctx, invoker=invoker,
+        )
+        msg = result["error"]["message"]
+        assert "nope" in msg
+        assert "To allow:" in msg
+        # Generic fallback — no fabricated config key.
+        assert "events tab" in msg
+    asyncio.run(main())
+
+
 def test_generic_exception_inside_invoker_returns_exception_kind():
     async def main():
         async def invoker(args):


### PR DESCRIPTION
## Summary

- `dispatch_tool` catches `PermissionError`, returns `{"kind":"permission_denied", "message": str(e)}`, and that text becomes the user-visible `✗ <skill#abcd>: …` error in the TUI. Some `PermissionError` strings from `PermissionResolver` are already verbose (file.read / file.write), but many are terse (`shell access denied`, `web fetch denied`, `tool 'X' access denied`), leaving the user with no path forward.
- This change appends a single `To allow: add \`<config-key>\` to reyn.local.yaml under permissions:` line to the message inside the dispatcher's permission-denied branch. The config key is selected from a small table keyed on the dispatch tool name (covers router catalog entries `read_file` / `write_file` / `web_fetch` / `call_mcp_tool` / `mcp_install` / … and skill_phase op kinds `file` / `shell` / `mcp` / `web_fetch` / `index_drop` / …).
- Unmapped tool names fall back to `To allow: see the events tab for the full permission trace.` — explicitly avoiding fabricating a config key that doesn't exist.
- The original `PermissionError` text stays as the prefix, so the existing substring asserts (`"nope" in message`) in `test_dispatcher.py`, `test_dispatcher_wal_step_events.py`, and `test_dispatcher_resume_memoization.py` keep passing. The same enriched message also lands in the `tool_failed` audit event and the WAL `step_failed` entry, so forensics see what the user saw.
- The hint is added at the dispatcher boundary (the single point all permission-denied paths flow through), so the fix covers both router-tool calls and skill-phase op invocations without touching the `PermissionResolver` itself.
- ErrorBox header still truncates at 72 chars, and PR #66 already routes the full text into the expanded body — so the user sees the prefix on the collapsed header and the actionable suffix when they expand.

## Test plan

- [x] `pytest tests/` — 3279 passed, 11 skipped, 2 xfailed
- [x] New Tier 2 invariants in `tests/test_dispatcher.py`:
  - `test_permission_denied_message_includes_actionable_hint`
  - `test_permission_denied_unmapped_tool_falls_back_to_generic_hint`
- [ ] Visual: trigger a `file.write` permission denial in chat → header shows the truncated prefix, expand → `To allow: add \`permissions.file.write: allow\` to reyn.local.yaml under permissions:` line visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)