### PR TITLE
fix(chat): skip pacing-gate clear for /-slash commands

### DIFF
--- a/src/reyn/chat/repl.py
+++ b/src/reyn/chat/repl.py
@@ -72,7 +72,15 @@ async def _input_loop(
             continue
         # Mark a reply as in flight before submit so the pacing gate on
         # the next iteration blocks until the output loop signals it.
-        if reply_seen is not None:
+        # `/`-prefixed slash commands (`/list`, `/attach`, `/answer`, ...)
+        # bypass the router and emit only `status` (no router reply),
+        # so clearing the gate for them would deadlock the next pipe
+        # iteration. `/quit` and `/exit` are handled above and never
+        # reach this branch. Intervention answers (plain text that
+        # happens to answer a pending ask_user) can still deadlock the
+        # pipe; that path is rare in scripted use and tracked as a
+        # known limitation.
+        if reply_seen is not None and not text.startswith("/"):
             reply_seen.clear()
         await attached.submit_user_text(text)
 


### PR DESCRIPTION
## Summary

Follow-up to #72 (`fix(chat): drain piped /quit + EOF replies via input-loop pacing gate`).

During self-review of #72 I realised the pacing gate has a hole: slash commands (`/list`, `/cancel`, `/answer`, `/attach`, …) bypass the router via `_maybe_handle_slash` and emit only `status` / `error` outbox kinds — `status` is not in the gate-release set `{agent, skill_done, error}`, so `printf '/list\nWhat is X?\n' | reyn chat --cui` would clear the gate after `/list`, block forever waiting for an `agent` reply that never comes, and the next pipe line is never read.

This commit landed on the same branch as #72 but didn't make the merge (PR was merged with only the first commit). Re-submitting cleanly.

## Fix

One-line guard in `_input_loop`: only clear the gate when the submit is non-slash text. `/quit` / `/exit` are still handled at the REPL level above this branch.

```python
if reply_seen is not None and not text.startswith("/"):
    reply_seen.clear()
```

Diff: `src/reyn/chat/repl.py`, +9 / -1 (1 line of code + 7 lines of comment explaining the why and the residual intervention-answer limitation).

## Test plan

Verified manually with `gemini-2.5-flash-lite` via the local litellm proxy:

- [x] **`/list` then text + `/quit`** — `printf '/list\nWhat is Reyn?\n/quit\n' | reyn chat --cui` → list output shown, reply rendered, no deadlock
- [x] **`/list` only + EOF** — `printf '/list\n' | reyn chat --cui` → list output shown, ~1.8 s exit
- [x] **`/halp` unknown command + EOF** — `printf '/halp\n' | reyn chat --cui` → usage hint shown, ~1.8 s exit
- [x] **Plain text single + multi turn** — unchanged from #72
- [x] **Immediate `/quit` no submit** — unchanged from #72
- [x] `pytest -k 'chat or repl'` — 257 passed, 0 regressions (same as #72)
- [x] `ruff check src/reyn/chat/repl.py`

## Residual limitation (deferred; documented in code comment)

Plain text that routes through `_maybe_answer_oldest_intervention` (= answering a pending `ask_user` from a running skill) emits `intervention_resolved`, which is also not in the gate-release set. The eventual `agent` reply emitted when the resumed skill finishes WILL release the gate, so async-skill paths are fine; a synchronous router-blocking ask_user during pipe is the genuine remaining edge case. Cleanly addressed only by migrating CUI to `MessageBus.request` semantics (= FP-0013 transport unification for CUI), deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)