### PR TITLE
fix(slash): list every stdlib skill in /skills (was always empty)

### DIFF
--- a/src/reyn/chat/slash/skills.py
+++ b/src/reyn/chat/slash/skills.py
@@ -21,8 +21,12 @@ async def skills_cmd(session: "object", args: str) -> None:
     from reyn.skill.skill_paths import stdlib_root
 
     project_root = Path.cwd()
+    # stdlib skills live under <stdlib_root>/skills/<name>/skill.md, not
+    # directly under <stdlib_root>. The old path always produced an empty
+    # list, so /skills hid every shipped skill (chat_compactor, eval,
+    # direct_llm, skill_router, …).
     sources: list[tuple[str, list[str]]] = [
-        ("stdlib", _list_skills(stdlib_root())),
+        ("stdlib", _list_skills(stdlib_root() / "skills")),
         ("project", _list_skills(project_root / "reyn" / "project")),
         ("local", _list_skills(project_root / "reyn" / "local")),
     ]


### PR DESCRIPTION
## Summary

- `/skills` walked `stdlib_root()` looking for `<name>/skill.md`, but the stdlib layout puts skills under `stdlib_root()/skills/<name>/skill.md`. The top-level dir only contains `artifacts/` and `skills/`, neither of which has a `skill.md` at depth 1, so the stdlib branch of the output was **always empty**.
- 15 shipped skills (chat_compactor, eval, skill_builder, word_stats_demo, …) were effectively invisible to anyone running `/skills`.

## Before / after

```
Before:  available skills:
           project: simple_memo_app, writing_review_app

After:   available skills:
           stdlib: chat_compactor, direct_llm, eval, eval_builder, index_docs,
                   index_events, judge_phase, mcp_install, mcp_search, ops_report,
                   read_local_files, skill_builder, skill_importer, skill_improver,
                   word_stats_demo
           project: simple_memo_app, writing_review_app
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed
- [x] Visual: `/skills` now shows the stdlib + project sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)