### PR TITLE
fix(slash): /help Tab hint described the wrong behaviour

### DIFF
--- a/src/reyn/chat/slash/help.py
+++ b/src/reyn/chat/slash/help.py
@@ -26,6 +26,9 @@ async def help_cmd(session: "object", args: str) -> None:
     for name, summary in rows:
         lines.append(f"  /{name:<{width}}  {summary}")
     lines.append("")
-    lines.append("Tab opens the command palette with the same list.")
+    lines.append(
+        "Type / to open the command palette. Tab inserts the highlighted "
+        "command (and keeps the cursor); Enter inserts + submits."
+    )
 
     await reply(session, "\n".join(lines))


### PR DESCRIPTION
## Summary

- `/help`'s trailing line read `Tab opens the command palette with the same list.` That's misleading on two counts:
  1. Tab on an empty input opens nothing — it's a no-op until the slash-picker is already visible (= input starts with `/`).
  2. When the picker IS open, Tab inserts the highlighted command but doesn't submit — Enter does both (since PR #59).
- Replace with an accurate one-liner that distinguishes the three keystrokes operators actually use: `/` opens the palette, Tab inserts, Enter inserts + submits.

## Before / after

```
Before:  Tab opens the command palette with the same list.

After:   Type / to open the command palette. Tab inserts the highlighted
         command (and keeps the cursor); Enter inserts + submits.
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)