### PR TITLE
feat(tui): peek next/prev item from focused preview pane (Shift+J/K, n/p)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -206,6 +206,23 @@ class _PreviewPane(Widget):
             event.prevent_default()
             event.stop()
             self.scroll_line(-1)
+        elif event.key in ("J", "N", "n"):
+            # Peek-next-item without leaving the preview: walk up to the
+            # parent RightPanel and advance the active tab's cursor by +1.
+            # The cursor-move helper re-renders the preview itself when
+            # the pane is visible (see `_docs_move` et al.), so this stays
+            # a single keystroke for "show me the next doc / event /
+            # memory entry / agent run". `n` is the bonus alias because
+            # some terminals (esp. on Windows / over SSH) don't deliver
+            # Shift+letter as a distinct key event.
+            event.prevent_default()
+            event.stop()
+            self._navigate_parent_cursor(+1)
+        elif event.key in ("K", "P", "p"):
+            # Peek-previous-item, mirror of J / n above.
+            event.prevent_default()
+            event.stop()
+            self._navigate_parent_cursor(-1)
         elif event.key == "d":
             # vim-style half-page down — bigger jump than `j` for the
             # long event-YAML dumps where line-by-line is tedious.
@@ -232,6 +249,34 @@ class _PreviewPane(Widget):
             event.prevent_default()
             event.stop()
             self.post_message(self.CloseRequested())
+
+    def _navigate_parent_cursor(self, delta: int) -> None:
+        """Walk up to the parent ``RightPanel`` and move its tab cursor.
+
+        Dispatches per active tab — docs / events / memory / agents each
+        have their own cursor + cursor-move helper. The helper takes care
+        of refreshing the preview when the pane is visible, so we don't
+        call ``_update_preview`` directly here. Tabs without a cursor
+        concept (keys / cost) are no-ops.
+        """
+        # late import to avoid circular: shells.py is imported by __init__.py.
+        from . import RightPanel
+        parent = None
+        for ancestor in self.ancestors_with_self:
+            if isinstance(ancestor, RightPanel):
+                parent = ancestor
+                break
+        if parent is None:
+            return
+        tab = parent.panel_type
+        if tab == "docs":
+            parent._docs_move(delta)
+        elif tab == "events":
+            parent._events_move(delta)
+        elif tab == "memory":
+            parent._memory_move(delta)
+        elif tab == "agents":
+            parent._agents_move(delta)
 
     def show_markdown(self, path: Path) -> None:
         from rich.markdown import Markdown as RichMarkdown
@@ -313,7 +358,7 @@ class _PreviewPane(Widget):
             name = "—"
         try:
             self.query_one("#preview-header", Label).update(
-                f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→"
+                f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→  J/n=next K/p=prev"
             )
         except Exception as exc:
             logger.warning("right_panel preview header update failed: %s", exc)

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -606,6 +606,88 @@ async def test_preview_pane_vim_keys_scroll_richlog():
         assert deltas["col"] == [+1, -1]
 
 
+# ── test: right panel — preview pane peek-next/prev without refocus ──────────
+
+@pytest.mark.asyncio
+async def test_preview_pane_shift_jk_moves_parent_tab_cursor():
+    """Tier 2: J / K / n / p inside a focused _PreviewPane move the parent tab cursor.
+
+    The user expectation is: preview is open, focus is on the preview pane
+    (via Tab cycling or close-preview restore), pressing J / n advances to
+    the *next* doc / event / memory / agent item without first having to
+    refocus the upper list. Pins that contract per active tab so a future
+    refactor of the dispatch can't silently regress it. Lowercase j / k
+    remain scroll-inside-preview and must not move the cursor.
+    """
+    from reyn.chat.tui.widgets.right_panel.shells import _PreviewPane
+
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel")
+        pane = panel.query_one("#preview-pane", _PreviewPane)
+
+        class _FakeKey:
+            def __init__(self, key: str) -> None:
+                self.key = key
+
+            def prevent_default(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+        # ── docs tab: J advances _docs_cursor, K reverses it ──
+        panel._panel_type = "docs"
+        panel._docs_files = [Path("/tmp/a.md"), Path("/tmp/b.md"), Path("/tmp/c.md")]
+        panel._docs_groups = {"": panel._docs_files}
+        panel._docs_cursor = 0
+
+        pane.on_key(_FakeKey("J"))
+        assert panel._docs_cursor == 1, "J should advance the docs cursor"
+        pane.on_key(_FakeKey("n"))  # bonus alias
+        assert panel._docs_cursor == 2, "n alias should also advance"
+        pane.on_key(_FakeKey("J"))  # wrap forward
+        assert panel._docs_cursor == 0
+        pane.on_key(_FakeKey("K"))  # wrap backward
+        assert panel._docs_cursor == 2
+        pane.on_key(_FakeKey("p"))  # bonus alias for previous
+        assert panel._docs_cursor == 1
+
+        # Lowercase j / k must NOT move the parent cursor (still scroll-inside).
+        before = panel._docs_cursor
+        pane.on_key(_FakeKey("j"))
+        pane.on_key(_FakeKey("k"))
+        assert panel._docs_cursor == before, "lowercase j/k must not move parent cursor"
+
+        # ── events tab: same contract on the events cursor ──
+        panel._panel_type = "events"
+        panel._events_visible = [{"type": "e0"}, {"type": "e1"}, {"type": "e2"}]
+        panel._events_cursor = 0
+        pane.on_key(_FakeKey("J"))
+        assert panel._events_cursor == 1
+        pane.on_key(_FakeKey("K"))
+        assert panel._events_cursor == 0
+
+        # ── memory tab ──
+        panel._panel_type = "memory"
+        panel._memory_entries = [object(), object(), object()]
+        panel._memory_cursor = 0
+        pane.on_key(_FakeKey("J"))
+        assert panel._memory_cursor == 1
+        pane.on_key(_FakeKey("K"))
+        assert panel._memory_cursor == 0
+
+        # ── agents tab ──
+        panel._panel_type = "agents"
+        panel._agents_items = [{"kind": "x"}, {"kind": "y"}]
+        panel._agents_cursor = 0
+        pane.on_key(_FakeKey("J"))
+        assert panel._agents_cursor == 1
+        pane.on_key(_FakeKey("K"))
+        assert panel._agents_cursor == 0
+
+
 # ── test: right panel — event filter cycling ─────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- On the Docs tab (and Events / Memory / Agents), pressing Space opens the preview pane. Focus often lands on `_PreviewPane` (via Tab cycling or close-preview restore), and lowercase `j` / `k` then scrolls inside the markdown — trapping the user. Peeking at the next doc previously cost three keystrokes: Tab to refocus the list, `j`, Space.
- Add `Shift+J` / `Shift+K` (with `n` / `p` aliases for terminals that don't deliver Shift+letter as a distinct key event) to `_PreviewPane.on_key`. The handler walks up to the parent `RightPanel` and dispatches to the active tab's cursor-move helper (`_docs_move` / `_events_move` / `_memory_move` / `_agents_move`), which already re-renders the preview when the pane is visible.
- Lowercase `j` / `k` keeps its scroll-inside-preview behaviour — the new keys are additive.
- Preview header hint updated to advertise `J/n=next K/p=prev`.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — all 36 tests pass (35 pre-existing + 1 new pin: `test_preview_pane_shift_jk_moves_parent_tab_cursor`).
- [x] New test exercises docs / events / memory / agents in turn and verifies lowercase `j` / `k` does NOT move the parent cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)