### PR TITLE
fix(tui): warn before dropping trailing lines on slash dispatch

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2273,8 +2273,29 @@ class ChatSession:
 
         Unknown slash commands also return True (with a hint on outbox) to
         keep the router from running on user typos like "/halp".
+
+        Multi-line slash input: slash commands today are line-oriented and
+        do not accept multi-line args. When the user submits `/cmd …\nmore`,
+        the trailing content was previously bundled into `args` and then
+        silently dropped by handlers that ignore their args (e.g. `/cost`,
+        `/help`, `/list`). We now warn before dispatching and feed the
+        handler only the first line, so the user sees that the extra lines
+        were not part of the command.
         """
         from reyn.chat.slash import REGISTRY
+
+        # Multi-line guard — keep only the first line for dispatch, warn if
+        # any non-whitespace content exists on later lines.
+        first_line, sep, rest = text.partition("\n")
+        if sep and rest.strip():
+            await self._put_outbox(OutboxMessage(
+                kind="system",
+                text=(
+                    f"note: {first_line.split(maxsplit=1)[0]} ignored extra "
+                    "lines; only the first line is treated as the command."
+                ),
+            ))
+        text = first_line
 
         body = text[1:].lstrip()
         if not body:

--- a/tests/test_slash_multi_line_dispatch.py
+++ b/tests/test_slash_multi_line_dispatch.py
@@ -1,0 +1,117 @@
+"""Tier 2: slash dispatch must not silently drop trailing lines.
+
+Bug context — slash commands are line-oriented today. Handlers that ignore
+their args (``/cost``, ``/help``, ``/list``, ``/skills`` …) used to consume
+everything after the first whitespace, including newlines, and then drop
+it on the floor. The user saw their full multi-line message echoed in the
+chat but no acknowledgement that the trailing lines were ignored.
+
+Dispatch now slices ``text`` to the first line before invoking the handler
+and emits a ``kind="system"`` warning when later lines carry non-whitespace
+content. Whitespace-only trailing lines stay silent (no false-positive
+warning on a stray trailing newline from the input widget).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _drain_outbox(session: ChatSession) -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+@pytest.mark.asyncio
+async def test_multi_line_slash_warns_and_dispatches_first_line(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: extra non-whitespace lines after a slash command produce a warning."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash(
+        "/skill list\nthis was meant to be a question",
+    )
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    systems = [m for m in msgs if m.kind == "system"]
+    combined = "\n".join(m.text for m in systems)
+
+    # A warning naming the command + "ignored extra lines" hint.
+    assert "ignored extra lines" in combined
+    assert "/skill" in combined
+    # The original handler still ran — /skill list emits "(no active skills)"
+    # when nothing is running.
+    assert "no active skills" in combined.lower()
+
+
+@pytest.mark.asyncio
+async def test_trailing_newline_only_does_not_warn(tmp_path, monkeypatch):
+    """Tier 2: ``/cmd\\n`` (trailing newline, no content) must not warn."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/skill list\n")
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    combined = "\n".join(m.text for m in msgs if m.kind == "system")
+    assert "ignored extra lines" not in combined
+
+
+@pytest.mark.asyncio
+async def test_trailing_whitespace_lines_do_not_warn(tmp_path, monkeypatch):
+    """Tier 2: trailing whitespace-only lines must not produce a warning."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/skill list\n   \n\t\n")
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    combined = "\n".join(m.text for m in msgs if m.kind == "system")
+    assert "ignored extra lines" not in combined
+
+
+@pytest.mark.asyncio
+async def test_args_on_first_line_still_reach_handler(tmp_path, monkeypatch):
+    """Tier 2: first-line args (``/cmd arg1 arg2``) still reach the handler.
+
+    Uses ``/skill discard <id>`` because its error path is observable on the
+    outbox without needing to set up a full skill run — the handler reports
+    ``no running skill matches '<id>'`` when the id is unknown.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash(
+        "/skill discard bogus_id\nstray line",
+    )
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    combined = "\n".join(m.text for m in msgs)
+    # Warning fired …
+    assert "ignored extra lines" in combined
+    # … and the handler ran with "bogus_id" as the arg.
+    assert "bogus_id" in combined


### PR DESCRIPTION
## Summary

- Slash dispatch silently dropped trailing lines from multi-line user input. Handlers that ignore their args (`/cost`, `/help`, `/list`, `/skills`, ...) consumed everything after the first whitespace — including newlines — and threw it away. The user saw their full multi-line message echoed in chat but no acknowledgement that reyn only ran the command.
- `_maybe_handle_slash` now slices `text` to the first line before invoking the handler and emits a `kind="system"` warning when later lines carry non-whitespace content. Whitespace-only trailing lines (e.g. a stray input-widget newline) stay silent.
- New Tier 2 test file `tests/test_slash_multi_line_dispatch.py` pins the four observable behaviours: warn-and-dispatch on `/cmd\nextra`, no-warn on `/cmd\n` (trailing newline), no-warn on whitespace-only trailing lines, and first-line args (`/skill discard <id>`) still reach the handler.

## Test plan

- [x] `pytest tests/test_slash_multi_line_dispatch.py` — 4/4 pass
- [x] `pytest tests/` — 3284 passed, 11 skipped, 2 xfailed (pre-existing). No regressions.