### PR TITLE
fix(chat-sp): inject cwd context so 'this repo' resolves to the workspace

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -516,6 +516,11 @@ class RouterLoop:
             host, "get_universal_wrappers_enabled", None,
         )
         _univ_enabled = bool(_univ_enabled_getter()) if _univ_enabled_getter else False
+        # Same getattr-fallback pattern: hosts without get_cwd (= FakeRouterHost
+        # in LLMReplay tests) skip the Environment section so the SP byte
+        # content stays unchanged for cached fixtures.
+        _cwd_getter = getattr(host, "get_cwd", None)
+        _cwd_str = _cwd_getter() if _cwd_getter else None
         # FP-0034 Phase 2 step 1: D14 visibility gate for search_actions.
         # Only show search_actions when (a) wrappers are on, (b) the
         # operator configured an embedding model class, AND (c) the
@@ -650,6 +655,7 @@ class RouterLoop:
                 # in LLMReplay tests) default to False so SP byte content stays
                 # unchanged for cached fixtures.
                 universal_wrappers_enabled=_univ_enabled,
+                cwd=_cwd_str,
             )
         # ChatSession._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -29,6 +29,7 @@ def build_system_prompt(
     project_context: str = "",
     indexed_sources_section: str | None = None,
     universal_wrappers_enabled: bool = False,  # FP-0034 PR-3b-v
+    cwd: str | None = None,
 ) -> str:
     """Render the system prompt for the tool_use router loop.
 
@@ -62,6 +63,12 @@ def build_system_prompt(
             When None (default), no Indexed sources section is emitted
             (= backward compat for callers that have not yet wired up
             the manifest, e.g. tests and non-chat execution paths).
+        cwd: current working directory the agent is running from. When
+            provided, an ## Environment section tells the LLM to treat
+            unqualified references like "this repo" / "this code" /
+            "the codebase" as the project at ``cwd``. When None
+            (default), the section is omitted — preserves SP byte
+            content for tests that don't plumb cwd through.
     """
     mcp_section = _render_mcp(mcp_servers)
 
@@ -127,6 +134,28 @@ def build_system_prompt(
         "For chitchat or self-questions, reply without tools.",
         "",
     ])
+
+    # ── 3.4. Environment (CWD context, P7-clean) ─────────────────────────────
+    # Tells the LLM where it is running so unqualified references like
+    # "this repo" / "this code" / "the codebase" / "ここのコード" map to
+    # the workspace at cwd. Without this the LLM defaults to its training
+    # prior ("please share the repository URL") even when the user is
+    # obviously inside a checked-out repo. P7: no skill-specific strings,
+    # only environment facts and routing hints to existing categories.
+    if cwd:
+        parts.append("## Environment")
+        parts.append("")
+        parts.append(f"cwd: {cwd}")
+        parts.append("")
+        parts.append(
+            "When the user refers to \"this repo\", \"this code\", \"the codebase\","
+            " \"this project\", \"ここ\", or any other unqualified reference to"
+            " surrounding source, interpret it as the project at the cwd above."
+            " Do NOT ask for a repository URL or path — discover the contents"
+            " with list_actions(category=['file']) → invoke_action(file__list, ...)"
+            " → invoke_action(file__read, ...) within the cwd's read scope."
+        )
+        parts.append("")
 
     # ── 3.5. Universal catalog (FP-0034 §D9, opt-in via action_retrieval) ────
     # When the operator has enabled the universal catalog (= reyn.yaml

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -298,6 +298,18 @@ class RouterHostAdapter:
         """
         return self._project_context or ""
 
+    def get_cwd(self) -> str:
+        """Current working directory the agent process is running from.
+
+        Threaded into the router's system prompt so unqualified user
+        references like "this repo" / "this code" / "the codebase" map
+        to the project at this path. Without it the LLM falls back to
+        its training prior ("please share the repository URL") even when
+        the user is obviously inside a checked-out repo.
+        """
+        import os
+        return os.getcwd()
+
     def get_universal_wrappers_enabled(self) -> bool:
         """Return whether FP-0034 universal catalog wrappers are enabled.
 


### PR DESCRIPTION
## Summary

Closes #73.

A light/HN user running `reyn chat` inside their checked-out repo and asking *"Summarize this repo"* got **"please provide the URL of the repository"** 10/10 times on `gemini-2.5-flash-lite`. The router LLM had no way to know it was operating inside a workspace — with no cwd hint in the system prompt the training prior ("share the repo URL") dominated, even though the agent literally has `file__list` and `file__read` available.

Surfaced during the first-touch dogfood pass (originally [PR #72](https://github.com/tya5/reyn/pull/72)). Verified again on `c8fae2e` (latest main).

## Fix

Add a `## Environment` section to `build_system_prompt`:

```
## Environment

cwd: /Users/.../my-project

When the user refers to "this repo", "this code", "the codebase",
"this project", "ここ", or any other unqualified reference to
surrounding source, interpret it as the project at the cwd above.
Do NOT ask for a repository URL or path — discover the contents
with list_actions(category=['file']) → invoke_action(file__list, ...)
→ invoke_action(file__read, ...) within the cwd's read scope.
```

Wiring: new `RouterHostAdapter.get_cwd()` returns `os.getcwd()`; RouterLoop plumbs it through `build_system_prompt(cwd=…)`. `build_system_prompt` emits the Environment block only when `cwd` is non-None — narrow hosts that don't implement `get_cwd` (= `FakeRouterHost` in the LLMReplay suite) skip the section so cached fixture args_hash stays stable. Pattern matches the existing `universal_wrappers_enabled` getattr-fallback in the same file.

Diff: 3 files, +47 / 0.

## Test plan

Verified manually with `gemini-2.5-flash-lite` via the local litellm proxy:

| scenario | pre-fix N=10 | post-fix |
|---|---|---|
| *Summarize this repo* | 10/10 ASKS for URL/path | 4-5/5 takes initiative (summarises the repo) |
| *What is Reyn?* | 3/3 OK (no regression target) | 3/3 OK |
| *List your features* | (already clean on main) | 10/10 clean (no `default_api.*` regression) |

The residual ~10-20% ask-rate post-fix is variability of the weak default model — the LLM still occasionally asks for *narrowing* ("which files do you want me to focus on") rather than the pre-fix *"what's the URL"* — i.e. it now understands the local context and just wants scoping, which is a reasonable behavior.

- [x] `pytest -k 'chat or router or system_prompt'` — 451 passed, 0 regressions
- [x] `pytest tests/test_replay_skill_router.py tests/test_router_invoke_skill_enum.py tests/test_router_skill_description_truncation.py` — 35 passed (LLMReplay fixtures unchanged thanks to getattr-fallback)
- [x] `ruff check src/reyn/`

## SP cost

The Environment section adds ~50-60 tokens to the SP. It sits in the static cache-prefix block (after Capabilities, before Behaviour) so the cost is paid once per session and amortised across turns via the Anthropic prompt cache. P7-clean (no skill-specific strings, only environment facts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)