### PR TITLE
test(slash): regression for /skills listing bundled stdlib + project

### DIFF
--- a/tests/test_skills_slash_command.py
+++ b/tests/test_skills_slash_command.py
@@ -1,0 +1,101 @@
+"""Tier 2: /skills slash command — list available skills.
+
+Regression test for PR #82. The previous implementation walked
+``stdlib_root()`` looking for ``<name>/skill.md``, but the stdlib layout
+is ``stdlib_root()/skills/<name>/skill.md``. The directory listing of
+``stdlib_root()`` only contains ``artifacts/`` and ``skills/``, neither
+of which has a ``skill.md`` at the top level, so the stdlib branch of
+the output was always empty.
+
+Asserting that the stdlib branch is non-empty when stdlib skills ship
+in the source tree is the test that would have caught PR #82's bug.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    """Build a ChatSession redirected to ``tmp_path``."""
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _drain_outbox(session: ChatSession) -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+@pytest.mark.asyncio
+async def test_skills_lists_bundled_stdlib(tmp_path, monkeypatch):
+    """Tier 2: /skills includes the bundled stdlib catalogue.
+
+    The stdlib ships at least one skill (eval, direct_llm, …) under
+    ``src/reyn/stdlib/skills/<name>/skill.md``. If the slash command's
+    path resolution is correct, the output MUST mention the stdlib
+    label and at least one bundled skill name.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/skills")
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    system_texts = [m.text for m in msgs if m.kind == "system"]
+    combined = "\n".join(system_texts)
+
+    # The bug PR #82 fixed: stdlib branch was always empty. Asserting
+    # that a known-bundled stdlib skill appears under the stdlib label
+    # is the minimal regression guard.
+    assert "stdlib:" in combined, (
+        f"/skills output is missing the stdlib label: {combined!r}"
+    )
+    # `eval` is one of the bundled stdlib skills shipped in this repo
+    # (src/reyn/stdlib/skills/eval/skill.md). Any reasonable assertion
+    # over the bundled catalogue picks one stable name.
+    assert "eval" in combined, (
+        f"/skills did not list any bundled stdlib skill: {combined!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skills_lists_project_skills(tmp_path, monkeypatch):
+    """Tier 2: /skills includes project-layer skills under ``reyn/project/``.
+
+    Mirrors :func:`reyn.skill.skill_paths.resolve_skill_path` — the
+    slash command MUST find skills written to the same project layout
+    that the runtime resolver expects.
+    """
+    project_skill = tmp_path / "reyn" / "project" / "demo_skill"
+    project_skill.mkdir(parents=True)
+    (project_skill / "skill.md").write_text("# demo_skill\n")
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/skills")
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    system_texts = [m.text for m in msgs if m.kind == "system"]
+    combined = "\n".join(system_texts)
+
+    assert "project:" in combined, (
+        f"/skills output is missing the project label: {combined!r}"
+    )
+    assert "demo_skill" in combined, (
+        f"/skills did not list the project-layer skill: {combined!r}"
+    )


### PR DESCRIPTION
## Summary

PR #82 fixed `/skills` walking `stdlib_root()` instead of `stdlib_root() / "skills"` — 15 shipped skills were silently absent from the output. The reason the bug slipped through is that no test asserted on a non-empty stdlib list.

Add two Tier 2 regression guards:
- `/skills` MUST include the `stdlib:` label and at least one bundled skill (anchored on `eval`, which is stable).
- `/skills` MUST include the `project:` label and any skill written under `reyn/project/<name>/skill.md`.

The first assertion was directly verified to fail against the pre-#82 code path (`stdlib_root()` instead of `stdlib_root() / "skills"`):

```
AssertionError: /skills output is missing the stdlib label:
'available skills:\n  (none found)'
```

## Test plan

- [x] `pytest tests/test_skills_slash_command.py -v` — both tests pass against current `main`
- [x] Reverted `skills.py` to the pre-PR-#82 code locally and confirmed the stdlib-label assertion fails
- [x] `pytest tests/cli/test_tui_smoke.py` — 35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)