### PR TITLE
fix(tui): show a remember-tool hint in the empty Memory tab

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -36,7 +36,9 @@ def render_memory(
     def _render_scope(entries: list, label: str, label_color: str) -> None:
         lines.append(f"[bold {label_color}]  {_esc(label)}[/]")
         if not entries:
-            lines.append("[#555555]    (empty)[/]")
+            lines.append(
+                "[#555555]    (empty — ask reyn to \"remember <fact>\")[/]"
+            )
             lines.append("")
             return
         groups: dict[str, list] = {


### PR DESCRIPTION
## Summary

- The Memory tab in the right panel renders `(empty)` under SHARED / AGENT buckets when no entries exist on disk. A new user has no way to discover how memory gets populated — the natural reaction is "this project doesn't use memory" and the feature stays buried.
- The router actually exposes `remember_shared` / `remember_agent` tools (see `_handle_remember_shared` / `_handle_remember_agent` in `src/reyn/chat/router_tools.py`), and they fire when the user says "remember X about this project". There is no `/remember*` slash command in `src/reyn/chat/slash/`, so the hint points at the natural-language path that actually works.
- Replace the `(empty)` placeholder in `_render_scope` with a single dim line: `(empty — ask reyn to "remember <fact>")`. The same helper renders SHARED and each per-agent bucket, so both inherit the hint for free. No styling escalation — the hint stays in `#555555` so it doesn't compete with real entries when they show up.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — all 36 tests pass.
- [x] Manual render with an empty workspace shows the new hint under both `SHARED` and a stub `AGENT planner` bucket; populated buckets are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)