### PR TITLE
feat(tui): hint how to recover when events filter excludes everything

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -491,7 +491,24 @@ def render_events(
         visible = all_events
 
     if not visible:
-        return "[#555555]  (no matching events)[/]", []
+        # Two distinct empty states:
+        #   1. `all_events` empty → pool itself is empty (no events logged yet).
+        #      The existing "no matching events" wording is already meaningful;
+        #      there's nothing to cycle to that would help.
+        #   2. `all_events` non-empty but filter excluded everything → user
+        #      cycled to a filter (e.g. `phase`, `rag`) whose event types
+        #      haven't fired this session. They need a reminder of HOW to
+        #      cycle to a different filter (the `[f]` header hint is only
+        #      visible when the panel is wider than the filter name).
+        if not all_events:
+            return "[#555555]  (no matching events)[/]", []
+        return (
+            f"[#555555]  (no events matching filter: [/]"
+            f"[bold #aaaaaa]{_esc(filter_name)}[/][#555555])[/]\n"
+            f"[#555555]  press [/][bold #aaaaaa]\\[f][/]"
+            f"[#555555] to cycle filter · [/]"
+            f"[bold #aaaaaa]\\[t][/][#555555] for tail size[/]"
+        ), []
 
     # Newest-first window — also returned to the caller for cursor / preview
     windowed = list(visible[-tail:])[::-1]


### PR DESCRIPTION
## Summary

- When the events tab cycles to a filter group (e.g. `phase`, `rag`) whose event types haven't fired this session, the panel rendered a terse `(no matching events)` with no on-screen recovery hint.
- The `[f]` / `[t]` header hints are only visible when the panel is wide enough to fit them past the filter name, so a narrow panel left the user stuck wondering how to get back to `all`.
- Now: if `all_events` is non-empty but the active filter excluded everything, render a two-line dim hint that names the excluded filter and tells the user that `[f]` cycles the filter and `[t]` cycles the tail. The truly-empty-pool case (no events logged yet) keeps the existing wording because cycling wouldn't help.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 36 passed
- [ ] Manual: cycle to `phase` filter on a fresh session before any phase fires, confirm the two-line hint renders with the filter name bolded
- [ ] Manual: confirm the truly-empty `.reyn/events` case still shows the original `(no matching events)` wording

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>