### PR TITLE
feat(tui): show +N more footer when slash picker truncates matches

### DIFF
--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -30,7 +30,8 @@ class SlashPicker(Static):
     DEFAULT_CSS = """
     SlashPicker {
         height: auto;
-        max-height: 10;
+        /* 8 command rows + 1 "+N more" footer + 2 border rows = 11. */
+        max-height: 11;
         background: #1a1a1a;
         border: solid $primary;
         padding: 0 1;
@@ -47,6 +48,10 @@ class SlashPicker(Static):
         super().__init__("", id=id)
         self._matches: list[SlashCommand] = []
         self._selected: int = 0
+        # Total matches before truncation to _MAX_VISIBLE. Surfaced as a
+        # "+N more — keep typing to filter" footer when the picker can't
+        # show every match.
+        self._total_matches: int = 0
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -60,6 +65,7 @@ class SlashPicker(Static):
 
     def set_matches(self, matches: list[SlashCommand]) -> None:
         """Replace the match list. Resets selection to row 0."""
+        self._total_matches = len(matches)
         self._matches = list(matches)[:_MAX_VISIBLE]
         self._selected = 0
         if self._matches:
@@ -116,4 +122,14 @@ class SlashPicker(Static):
             if i > 0:
                 body.append("\n")
             body.append_text(row)
+        # When the typed prefix matches more commands than the picker
+        # can display, surface the overflow so the user knows there's
+        # more to discover by narrowing the prefix.
+        hidden = self._total_matches - len(self._matches)
+        if hidden > 0:
+            body.append("\n")
+            body.append(
+                f"  +{hidden} more — keep typing to filter",
+                style="dim #888888",
+            )
         self.update(body)


### PR DESCRIPTION
## Summary

- `SlashPicker.set_matches` capped the displayed list at `_MAX_VISIBLE=8` without telling the user the typed prefix matched more commands. With 16 visible slash commands and a bare `/` prefix, the user saw **8 of 16** and had no signal that more existed — they couldn't tell whether typing a letter would narrow further or only re-match what was already on screen.
- Track the total match count and render `+N more — keep typing to filter` in dim style after the visible rows when N > 0.
- Bump `max-height` from 10 → 11 (= 8 rows + 1 footer + 2-row border) so the footer isn't clipped.

## Before / after

```
Before:    /copy         …
           /cost         …
           …
           /agents       …   ← 8 of 16 shown, no signal more exist

After:     /copy         …
           /cost         …
           …
           /agents       …
           +8 more — keep typing to filter
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 36 passed
- [x] Visual: type `/` → picker shows 8 commands + `+8 more` footer
- [x] Visual: type `/c` → 4 matches (cancel/copy/cost/cost-inline), no footer (≤ 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)