### PR TITLE
feat(tui): surface Ctrl+P/N turn-nav keys in hints

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -168,7 +168,7 @@ class ConversationView(Widget):
         # B5: empty-state hint, removed on first message
         yield Static(
             "  Type [bold]/[/] for commands  ·  [bold]Ctrl+B[/] panel  ·  "
-            "[bold]Ctrl+L[/] clear  ·  ↑ history",
+            "[bold]Ctrl+L[/] clear  ·  ↑ history  ·  [bold]Ctrl+P/N[/] turn",
             id="empty-hint",
             markup=True,
         )

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -361,8 +361,12 @@ class InputBar(Widget):
     # ── hint rendering ────────────────────────────────────────────────────────
 
     def _build_hint(self) -> str:
+        # Stays on one line (~84 cols). Dropped Ctrl+O / Ctrl+R / Ctrl+\
+        # / Ctrl+C — all visible in the Keys tab, all infrequent or
+        # discoverable on demand. Ctrl+P/N turn was missing from every
+        # user-facing surface above the fold; that's the whole point of
+        # this hint. Ctrl+B panel stays so users can find the Keys tab.
         return (
-            "  Enter send  │  Ctrl+J newline  │  Ctrl+D quit  │  "
-            "Ctrl+L clear  │  Ctrl+C cancel  │  Ctrl+B panel  │  "
-            "Ctrl+O focus panel  │  Ctrl+R voice  │  Ctrl+\\ shot"
+            "  Enter send │ Ctrl+J nl │ Ctrl+D quit │ Ctrl+L clear │ "
+            "Ctrl+B panel │ Ctrl+P/N turn"
         )


### PR DESCRIPTION
## Summary

- Footer hint (`InputBar._build_hint`): append `Ctrl+P/N turn`. Trim `Ctrl+O focus panel`, `Ctrl+R voice`, `Ctrl+\ shot`, and `Ctrl+C cancel` to keep the line under 90 cols (was ~155, now ~84). All dropped keys remain visible in the Keys tab.
- Empty-state hint (`ConversationView.compose`): append `Ctrl+P/N turn` alongside the existing `↑ history` input-history hint.

## Why

Ctrl+P/N (prev / next turn) were only surfaced inside the right-panel Keys tab under `[CONVERSATION]`, which sits below the fold at default panel size after PR #58 made bindings one-line-per-entry. Users had no organic way to discover the most useful chat-navigation keys.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 36/36 pass
- [ ] Visual check at 80-col terminal: footer fits on one line
- [ ] Empty-state hint shows `Ctrl+P/N turn` before any user input

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>