### PR TITLE
feat(cli): pre-check provider credentials before opening reyn chat / run / mcp

### DIFF
--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -152,6 +152,8 @@ def run(args: argparse.Namespace) -> None:
     from reyn.permissions.permissions import PermissionResolver
 
     session_cfg = Session.from_args(args)
+    from reyn.cli.credentials_check import verify_credentials_or_exit
+    verify_credentials_or_exit(session_cfg, args)
     model, _ = session_cfg.model_for(args)
     output_language = session_cfg.output_language_for(args)
     safety = session_cfg.safety_for(args)

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -301,6 +301,8 @@ def run_serve(args: argparse.Namespace) -> None:
     from reyn.permissions.permissions import PermissionResolver
 
     session_cfg = Session.from_args(args)
+    from reyn.cli.credentials_check import verify_credentials_or_exit
+    verify_credentials_or_exit(session_cfg, args)
     model, _ = session_cfg.model_for(args)
     output_language = session_cfg.output_language_for(args)
     safety = session_cfg.safety_for(args)

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -82,6 +82,8 @@ def register(sub) -> None:
 
 def run(args: argparse.Namespace) -> None:
     session = Session.from_args(args)
+    from reyn.cli.credentials_check import verify_credentials_or_exit
+    verify_credentials_or_exit(session, args)
     loaded = load_skill_from_args(args)
 
     raw_input = _read_input(args)

--- a/src/reyn/cli/credentials_check.py
+++ b/src/reyn/cli/credentials_check.py
@@ -1,0 +1,78 @@
+"""Credential pre-check for LLM-using commands.
+
+Light/HN-user UX: surface "no API key set" as an actionable startup error
+with explicit fix instructions, instead of a cryptic litellm
+``InternalServerError: Missing credentials`` that fires after the
+``reyn chat`` banner appears (and after ``reyn run`` has printed its
+``skill / model / input`` header). The check covers the dominant
+mis-configuration path — no env var AND no api_base proxy.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.cli.session import Session
+
+
+# Mapping from litellm provider prefix → required env var (litellm convention).
+# Providers not listed here are not pre-checked; litellm raises its own
+# error if their credentials are missing. This is intentionally narrow:
+# false positives (= rejecting a setup that would actually work) are worse
+# than false negatives (= late litellm error for an unusual provider).
+_PROVIDER_ENV_VARS: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "azure": "AZURE_API_KEY",
+}
+
+
+def verify_credentials_or_exit(
+    session: "Session", args: argparse.Namespace,
+) -> None:
+    """Exit 1 with an actionable message if the model the command will use
+    has no credentials configured (no env var AND no api_base proxy).
+    """
+    config = session.config
+
+    # When a proxy api_base is configured the proxy handles auth — provider
+    # env vars become optional (the proxy may accept any string or use its
+    # own credential).  Skip the check entirely in that case.
+    if config.api_base:
+        return
+
+    # Resolve to the litellm model string the command will actually use
+    # (honours --model on the CLI).  Its provider prefix (everything before
+    # the first "/") tells us which env var is required.
+    try:
+        _, resolved = session.model_for(args)
+    except Exception:
+        return  # resolver failure — let downstream surface its own error
+
+    if "/" not in resolved:
+        return  # bare model name; trust the resolver
+
+    provider = resolved.split("/", 1)[0]
+    env_var = _PROVIDER_ENV_VARS.get(provider)
+    if env_var is None:
+        return  # unknown provider — let litellm raise
+
+    if os.environ.get(env_var):  # falsy on both None and empty string
+        return
+
+    sys.stderr.write(
+        f"Error: no API key found for the configured model ({resolved}).\n"
+        f"\n"
+        f"Set the {env_var} environment variable:\n"
+        f"    export {env_var}=<your-key>\n"
+        f"\n"
+        f"Or point reyn.local.yaml at a local proxy:\n"
+        f"    echo 'api_base: http://localhost:4000' > reyn.local.yaml\n"
+        f"\n"
+        f"See docs/guide/getting-started/01-installation.md for details.\n"
+    )
+    sys.exit(1)


### PR DESCRIPTION
## Summary

Fresh-user / HN scenario: `reyn chat` with no `OPENAI_API_KEY` and no `api_base` proxy used to:

1. print the REYN banner
2. accept a turn, show `[…] thinking…`
3. fail with the cryptic litellm error
   > `litellm.InternalServerError: OpenAIException - Missing credentials. Please pass an api_key, workload_identity, admin_api_key, or set the OPENAI_API_KEY or OPENAI_ADMIN_KEY environment variable. LiteLLM Retried: 1 times`
4. exit **0** (= breaks shell scripting)

The classification (*"InternalServerError"*) and the *"litellm.…"* prefix make the message read like a Reyn / proxy outage rather than a user-side configuration gap, and routing into a TUI banner before failing wastes a turn of user trust. Surfaced during the first-touch dogfood pass.

## Fix

Tiny pre-check, `verify_credentials_or_exit(session, args)`, called from `reyn chat`, `reyn run`, and `reyn mcp serve` right after `Session.from_args` resolves the model. Maps the model's litellm provider prefix to the required env var, and exits 1 with an actionable message when both the env var and `config.api_base` are missing:

```
Error: no API key found for the configured model (openai/gemini-2.5-flash-lite).

Set the OPENAI_API_KEY environment variable:
    export OPENAI_API_KEY=<your-key>

Or point reyn.local.yaml at a local proxy:
    echo 'api_base: http://localhost:4000' > reyn.local.yaml

See docs/guide/getting-started/01-installation.md for details.
```

Provider → env var mapping (litellm convention):

| Prefix | Env var |
|---|---|
| `openai/` | `OPENAI_API_KEY` |
| `anthropic/` | `ANTHROPIC_API_KEY` |
| `gemini/` | `GEMINI_API_KEY` |
| `azure/` | `AZURE_API_KEY` |

Diff: 1 new file (78 lines) + 3 entry-point hooks (2 lines each) = **+84 / 0**.

## Intentional scope limits

- **`config.api_base` configured → skip.** The proxy handles auth; the env var becomes optional. Reyn already uses a `"dummy"` api_key fallback in this case (`llm.py:514`), which is the intended design.
- **Provider prefix not in the mapping** (bedrock / ollama / vertex / …) → skip and defer to litellm's native error path. False positives (rejecting a setup that would actually work) are worse than false negatives.
- **Empty-string env vars** are treated the same as unset (`if os.environ.get(...)` — falsy on both `None` and `""`).
- **CLI override of `--model`** is honoured (`session.model_for(args)` returns the override when present), so `reyn chat --model strong` checks the strong-tier model's provider, not the default's.

## Test plan

Verified manually with a clean env (`env -i HOME PATH` + no `reyn.local.yaml` + no `~/.reyn/secrets.env`):

| scenario | pre-fix | post-fix |
|---|---|---|
| no key, no proxy | banner → litellm 500 → exit 0 | **actionable error, exit 1** |
| real `OPENAI_API_KEY` set | proceeds to litellm | unchanged (pre-check passes) |
| proxy via `reyn.local.yaml: api_base` | succeeds via proxy | unchanged (pre-check skipped) |

- [x] `pytest -k 'cli or chat or session or run'` — 596 passed, 0 regressions (8 pre-existing errors are `mcp` extra not installed in local venv; unrelated)
- [x] `ruff check src/reyn/cli/`

## Not added

- **Test** pinning the pre-check exit path. Per `docs/deep-dives/contributing/testing.md`, CLI output formatting is not Tier 1 in the current revision ("CLI UX is being reworked"), and a regression test for this specific message would be Tier 4 (per-commit duplicate). Happy to add if you'd prefer a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)