### PR TITLE
fix(tui): scroll events tab into view as cursor moves with j/k

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -475,8 +475,33 @@ class RightPanel(Widget):
             return
         self._events_cursor = (self._events_cursor + delta) % n
         self._invalidate()
+        self._scroll_events_into_view()
         if self._preview_visible:
             self._update_preview()
+
+    def _scroll_events_into_view(self) -> None:
+        """Scroll #panel-scroll so the events cursor line is visible.
+
+        Each event renders as one row (PR #79 trimmed timestamp to
+        HH:MM:SS; the type fits next to it on the same line). The
+        ``user_message_received`` rows have an extra `↳` reply line —
+        approximated as 1 here; the small over-/under-scroll on those
+        is barely noticeable.
+        """
+        try:
+            vs = self.query_one("#panel-scroll", VerticalScroll)
+            current = int(vs.scroll_y)
+            visible = vs.size.height
+            if visible <= 0:
+                return
+            # Assume 1 line per event; +1 for content padding-top.
+            y = 1 + self._events_cursor
+            if y < current:
+                vs.scroll_to(y=y, animate=False)
+            elif y >= current + visible:
+                vs.scroll_to(y=y - visible + 1, animate=False)
+        except Exception as exc:
+            logger.warning("right_panel scroll_events_into_view failed: %s", exc)
 
     def _render_as_yaml(self, value: Any) -> Any:
         """Format ``value`` as a YAML block + Rich syntax highlighter.


### PR DESCRIPTION
## Summary

- After PR #69 (cursor wraparound), `j` / `k` correctly cycle the events cursor — but the panel viewport stayed put, so on the default 200-event tail the cursor would walk off-screen and the user couldn't see where their selection landed.
- Docs tab already had `_scroll_docs_into_view`; events tab didn't.
- Add `_scroll_events_into_view` modelled on the docs implementation. Each event renders as one row (since PR #79's HH:MM:SS trim), so the math is just `y = 1 + cursor_index`.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 36 passed
- [ ] Visual: with > viewport-height events visible, press j repeatedly — cursor stays in view

## Note

Memory / agents tabs have the same gap; deferred to follow-ups — the events tab is the high-cardinality case in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)