### PR TITLE
fix(tui): right-align cost-inline suffix with Rich justify

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -543,11 +543,18 @@ class ConversationView(Widget):
     # ── cost suffix (A4) ──────────────────────────────────────────────────────
 
     def render_cost_suffix(self, tokens: int, cost_usd: float, elapsed_s: float) -> None:
-        """Append a dim per-turn cost suffix. Caller decides when (opt-in)."""
-        t = Text()
-        t.append("                              ")  # right-leaning padding
-        t.append(f"⌁ {tokens}t · ${cost_usd:.4f} · {elapsed_s:.1f}s",
-                 style="dim #666666")
+        """Append a dim per-turn cost suffix, right-aligned. Caller decides when (opt-in).
+
+        Uses Rich's ``justify="right"`` so the suffix tracks the actual content
+        width at render time. A hard-coded space prefix would either centre the
+        suffix on wider terminals or push it off-screen when the right panel is
+        open and the conv pane shrinks.
+        """
+        t = Text(
+            f"⌁ {tokens}t · ${cost_usd:.4f} · {elapsed_s:.1f}s",
+            style="dim #666666",
+            justify="right",
+        )
         self._write_log(t)
 
     # ── turn navigation (B4) ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `ConversationView.render_cost_suffix` used a hard-coded 30-space prefix to fake right-alignment. The result depended on terminal width: centred-ish at 120 cols, off-screen when the right panel narrowed the conv pane.
- Replaced the prefix with `Text(..., justify="right")` so Rich pads to the actual content width at render time. Dim `#666666` styling preserved.

## Test plan
- [x] `pytest tests/cli/test_tui_smoke.py` — 36/36 pass
- [x] Verified Rich segments render right-aligned at varying widths (40 / 80 / 120)
- [ ] Manual: open TUI, enable `/cost-inline`, toggle right panel with Ctrl+B, confirm suffix sticks to the right edge of the conv pane in both states

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)