### PR TITLE
fix(tui): scroll memory + agents tabs into view as cursor moves with j/k

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -132,12 +132,19 @@ class RightPanel(Widget):
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
+        # y-coord (0-indexed line) of each memory entry's name row in the
+        # rendered output. Populated by `render_memory`; used by
+        # `_scroll_memory_into_view` to keep the cursor visible as j/k
+        # moves it past the panel viewport.
+        self._memory_entry_ys: list[int] = []
         # Agents tab state — same cursor pattern as events / memory.
         # `_agents_items` is the flat list returned by `render_agents`,
         # one entry per running skill / running plan / recent skill /
         # recent plan. Used by j/k navigation and preview rendering.
         self._agents_cursor: int = 0
         self._agents_items: list[dict] = []
+        # y-coord of each agents-tab item; populated by `render_agents`.
+        self._agents_item_ys: list[int] = []
 
     # ── composition ──────────────────────────────────────────────────────────
 
@@ -574,8 +581,37 @@ class RightPanel(Widget):
             return
         self._memory_cursor = (self._memory_cursor + delta) % n
         self._invalidate()
+        self._scroll_memory_into_view()
         if self._preview_visible:
             self._update_preview()
+
+    def _scroll_memory_into_view(self) -> None:
+        """Scroll #panel-scroll so the memory cursor row is visible.
+
+        Memory entries render with variable structure (section headers,
+        per-type subheaders, optional description rows, blank separators),
+        so an arithmetic ``y = f(cursor)`` would be wrong as soon as a
+        type group changes. ``render_memory`` records the exact y of each
+        entry's name row in ``_memory_entry_ys``; we just look it up here.
+
+        Same idiom as the events-tab fix in PR #97.
+        """
+        try:
+            vs = self.query_one("#panel-scroll", VerticalScroll)
+            current = int(vs.scroll_y)
+            visible = vs.size.height
+            if visible <= 0:
+                return
+            if not (0 <= self._memory_cursor < len(self._memory_entry_ys)):
+                return
+            # +1 for content padding-top, matching the events-tab fix.
+            y = 1 + self._memory_entry_ys[self._memory_cursor]
+            if y < current:
+                vs.scroll_to(y=y, animate=False)
+            elif y >= current + visible:
+                vs.scroll_to(y=y - visible + 1, animate=False)
+        except Exception as exc:
+            logger.warning("right_panel scroll_memory_into_view failed: %s", exc)
 
     def _show_memory_in_preview(self, pane: _PreviewPane) -> None:
         """Render the cursor's memory entry's body as Markdown in the preview."""
@@ -613,8 +649,36 @@ class RightPanel(Widget):
             return
         self._agents_cursor = (self._agents_cursor + delta) % n
         self._invalidate()
+        self._scroll_agents_into_view()
         if self._preview_visible:
             self._update_preview()
+
+    def _scroll_agents_into_view(self) -> None:
+        """Scroll #panel-scroll so the agents cursor row is visible.
+
+        Agents tab uses a RichTree per agent; each running skill / plan
+        / recent row spans 1-2 lines (a child node like a phase or goal
+        adds a second). ``render_agents`` records the exact y of each
+        selectable item in ``_agents_item_ys`` so we don't have to guess.
+
+        Same idiom as the events- and memory-tab fixes (PR #97 + this PR).
+        """
+        try:
+            vs = self.query_one("#panel-scroll", VerticalScroll)
+            current = int(vs.scroll_y)
+            visible = vs.size.height
+            if visible <= 0:
+                return
+            if not (0 <= self._agents_cursor < len(self._agents_item_ys)):
+                return
+            # +1 for content padding-top, matching the events-tab fix.
+            y = 1 + self._agents_item_ys[self._agents_cursor]
+            if y < current:
+                vs.scroll_to(y=y, animate=False)
+            elif y >= current + visible:
+                vs.scroll_to(y=y - visible + 1, animate=False)
+        except Exception as exc:
+            logger.warning("right_panel scroll_agents_into_view failed: %s", exc)
 
     def _show_agent_in_preview(self, pane: _PreviewPane) -> None:
         """Render the cursor's agent-tab item in the preview pane.
@@ -1430,20 +1494,22 @@ class RightPanel(Widget):
                     self._events_cursor = max(0, len(windowed) - 1)
                 return rendered
             if self._panel_type == "agents":
-                rendered, flat_items = render_agents(
+                rendered, flat_items, item_ys = render_agents(
                     self._registry, self._exec_state,
                     project_root=self._project_root,
                     cursor=self._agents_cursor,
                 )
                 self._agents_items = flat_items
+                self._agents_item_ys = item_ys
                 if self._agents_cursor >= len(flat_items):
                     self._agents_cursor = max(0, len(flat_items) - 1)
                 return rendered
             if self._panel_type == "memory":
-                rendered, flat_entries = render_memory(
+                rendered, flat_entries, entry_ys = render_memory(
                     self._project_root, cursor=self._memory_cursor,
                 )
                 self._memory_entries = flat_entries
+                self._memory_entry_ys = entry_ys
                 if self._memory_cursor >= len(flat_entries):
                     self._memory_cursor = max(0, len(flat_entries) - 1)
                 return rendered

--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -383,8 +383,8 @@ def render_agents(
     *,
     project_root: Path | None = None,
     cursor: int = 0,
-) -> tuple[Any, list[dict]]:
-    """Return ``(renderable, flat_items)`` for the agents tab.
+) -> tuple[Any, list[dict], list[int]]:
+    """Return ``(renderable, flat_items, item_ys)`` for the agents tab.
 
     ``project_root`` is optional — when provided, the RECENT subsection
     surfaces the last few completed skill runs and finished plans by reading
@@ -399,20 +399,31 @@ def render_agents(
     running skill / running plan / recent skill / recent plan. Each entry
     carries enough metadata for the preview pane to build a detail view
     without re-reading the registry.
+
+    ``item_ys`` is the 0-indexed y-coordinate (line number) of each item's
+    row in the rendered output, so the orchestrator can scroll the cursor
+    into view as j/k cycles past the visible window. Tracked here because
+    RichTree's guide-line layout makes the y-coord impossible to predict
+    arithmetically from the cursor index alone — running skills add 1-2
+    lines, recent plans with a goal add 2 lines, etc.
     """
     flat_items: list[dict] = []
+    item_ys: list[int] = []
+    # Line counter for tracking item y-coords as we build the renderable.
+    # Each tree-node add() = 1 line; blank between agent blocks = 1 line.
+    y_counter = 0
 
     if registry is None:
-        return "[#555555]  (no registry)[/]", flat_items
+        return "[#555555]  (no registry)[/]", flat_items, item_ys
 
     try:
         names = registry.list_names()
     except Exception as exc:
         logger.warning("right_panel agents: registry.list_names() failed: %s", exc)
-        return "[#555555]  (registry unavailable)[/]", flat_items
+        return "[#555555]  (registry unavailable)[/]", flat_items, item_ys
 
     if not names:
-        return "[#555555]  (no agents)[/]", flat_items
+        return "[#555555]  (no agents)[/]", flat_items, item_ys
 
     try:
         attached = registry.attached_name
@@ -428,7 +439,12 @@ def render_agents(
 
     agent_trees: list[Any] = []
 
-    for name in names:
+    for agent_idx, name in enumerate(names):
+        # Blank separator between agent blocks (matches the interleave below).
+        if agent_idx > 0:
+            y_counter += 1
+        # Root label of this agent's RichTree is one line.
+        y_counter += 1
         is_attached = name == attached
         in_loaded = name in loaded
 
@@ -503,6 +519,10 @@ def render_agents(
                     style=name_style or "#dddddd",
                 )
                 skill_node = tree.add(skill_label)
+                # Record the y of this item's selectable row, then bump
+                # past the skill row (and an optional phase child row).
+                item_ys.append(y_counter)
+                y_counter += 1
 
                 phase = info.get("phase", "")
                 if phase:
@@ -512,6 +532,7 @@ def render_agents(
                     if visits > 1:
                         phase_label.append(f"  v{visits}", style="#444444")
                     skill_node.add(phase_label)
+                    y_counter += 1
                 flat_items.append({
                     "kind": "running_skill",
                     "agent": name,
@@ -550,9 +571,12 @@ def render_agents(
                     style="#44cc88" if p["status"] == "running" else "#aaaa55",
                 )
                 plan_node = tree.add(plan_label)
+                item_ys.append(y_counter)
+                y_counter += 1
                 if p["goal"]:
                     goal = p["goal"][:60] + ("…" if len(p["goal"]) > 60 else "")
                     plan_node.add(RichText(goal, style="#555555"))
+                    y_counter += 1
                 flat_items.append({
                     "kind": "running_plan",
                     "agent": name,
@@ -591,6 +615,8 @@ def render_agents(
             recent_node = tree.add(
                 RichText("recent", style="#777777")
             )
+            # The "recent" header occupies its own line.
+            y_counter += 1
             for s in recent_skills:
                 pfx, _ = _cursor_prefix(len(flat_items))
                 line = RichText()
@@ -621,6 +647,8 @@ def render_agents(
                 if s["ts"]:
                     line.append(f"  {s['ts']}", style="#444444")
                 recent_node.add(line)
+                item_ys.append(y_counter)
+                y_counter += 1
                 flat_items.append({
                     "kind": "recent_skill",
                     "agent": name,
@@ -645,9 +673,12 @@ def render_agents(
                 if p["ts"]:
                     line.append(f"  {p['ts']}", style="#444444")
                 node = recent_node.add(line)
+                item_ys.append(y_counter)
+                y_counter += 1
                 if p["goal"]:
                     goal = p["goal"][:60] + ("…" if len(p["goal"]) > 60 else "")
                     node.add(RichText(goal, style="#555555"))
+                    y_counter += 1
                 flat_items.append({
                     "kind": "recent_plan",
                     "agent": name,
@@ -681,6 +712,7 @@ def render_agents(
                 tree.add(RichText(
                     f"last: {ts_str}{count_part}", style="#555555",
                 ))
+                y_counter += 1
                 if snippet:
                     # Collapse all whitespace runs to single spaces FIRST,
                     # then truncate. The user's last message may be a
@@ -699,6 +731,7 @@ def render_agents(
                     line2.append("↳ ", style="#555555")
                     line2.append(short, style="#444444")
                     tree.add(line2)
+                    y_counter += 1
 
         agent_trees.append(tree)
 
@@ -708,7 +741,7 @@ def render_agents(
         if i > 0:
             items.append(RichText(""))
         items.append(tree)
-    return RichGroup(*items), flat_items
+    return RichGroup(*items), flat_items, item_ys
 
 
 __all__ = ["render_agents"]

--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -18,20 +18,27 @@ def render_memory(
     project_root: Path | None,
     *,
     cursor: int = 0,
-) -> tuple[str, list[Any]]:
-    """Return Rich markup + the flat ordered list of MemoryEntry items.
+) -> tuple[str, list[Any], list[int]]:
+    """Return Rich markup + the flat ordered list of MemoryEntry items
+    + the y-coordinate (= 0-indexed line number) of each entry's name row.
 
     The flat list lets the orchestrator drive cursor navigation and the
     Enter→preview integration without re-walking the disk. The row at
     index ``cursor`` is highlighted with a coral ▶ prefix.
+
+    ``entry_ys[i]`` is the line-index of ``flat_entries[i]``'s name row in
+    the rendered output. Section labels, per-type subheaders and blank
+    separators all bump the y, so the orchestrator can't predict it
+    arithmetically — we record it here, where the structure is known.
     """
     if project_root is None:
-        return "[#555555]  (no project root)[/]", []
+        return "[#555555]  (no project root)[/]", [], []
 
     from reyn.memory.memory import list_entries
 
     lines: list[str] = []
     flat_entries: list[Any] = []
+    entry_ys: list[int] = []
 
     def _render_scope(entries: list, label: str, label_color: str) -> None:
         lines.append(f"[bold {label_color}]  {_esc(label)}[/]")
@@ -58,6 +65,7 @@ def render_memory(
             lines.append(f"[bold {color}]    \\[{type_key.upper()}][/]")
             for e in group:
                 flat_entries.append(e)
+                entry_ys.append(len(lines))
                 is_cursor = (len(flat_entries) - 1) == cursor
                 indent = f"[bold {_CORAL}]    ▶ [/]" if is_cursor else "      "
                 name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
@@ -68,6 +76,7 @@ def render_memory(
             lines.append("[bold #888888]    \\[OTHER][/]")
             for e in other:
                 flat_entries.append(e)
+                entry_ys.append(len(lines))
                 is_cursor = (len(flat_entries) - 1) == cursor
                 indent = f"[bold {_CORAL}]    ▶ [/]" if is_cursor else "      "
                 name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
@@ -88,7 +97,7 @@ def render_memory(
             agent_entries = list_entries(mem_dir)
             _render_scope(agent_entries, f"AGENT  {agent_dir.name}", "#7a9fc7")
 
-    return "\n".join(lines), flat_entries
+    return "\n".join(lines), flat_entries, entry_ys
 
 
 __all__ = ["render_memory"]


### PR DESCRIPTION
## Summary

Extends [PR #97](https://github.com/tya5/reyn/pull/97) (which fixed the events tab) to the memory and agents tabs, which were explicitly deferred in that PR's note.

After `j`/`k` cycles the cursor past the visible window in the memory or agents tab, the panel viewport now follows the cursor — same behaviour the events tab just got.

## Implementation note

Memory entries and agents items have variable line counts per row:

- Memory: each entry can be 1 line (name) or 2 lines (name + indented description); section labels (`SHARED`, `AGENT <name>`), per-type subheaders (`[USER]`, `[FEEDBACK]`, …) and blank separators bump the line index unpredictably.
- Agents: items render via RichTree; a running skill is 1 line for the label + an optional second line for the phase child node; a recent_plan with a goal is 2 lines; blank lines between agent blocks.

An arithmetic `y = f(cursor)` (which works for the events tab where every row is 1 line) would mis-scroll the moment a section boundary or child node showed up. Instead, `render_memory` and `render_agents` now record each selectable item's y-coordinate at render time and return it alongside the flat item list, and the new `_scroll_memory_into_view` / `_scroll_agents_into_view` helpers just look it up.

Both helpers run after `_invalidate()` and before the preview refresh — same call-site shape as `_scroll_events_into_view` in PR #97.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py` — 36 passed
- [ ] Manual: open memory tab with > viewport-height worth of entries; press `j` past the last visible row → viewport follows
- [ ] Manual: open agents tab with > viewport-height worth of running / recent items; press `j` / `k` → viewport follows
- [ ] Manual: confirm preview pane (Space) still tracks the cursor in both tabs

## Base

This PR targets `feat/tui-events-scroll-into-view` (PR #97) rather than `main` because it depends on the events-tab fix landing first — the diff is purely the memory/agents extension. Once #97 merges, GitHub will retarget this to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)