### PR TITLE
fix(budget): align tokens column across Today / Month rows

### DIFF
--- a/src/reyn/budget/budget.py
+++ b/src/reyn/budget/budget.py
@@ -1129,6 +1129,15 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
         cfg.monthly_tokens.is_active,
         cfg.monthly_cost_usd.is_active,
     ]):
+        # Pre-compute the label column width so `tokens` lines up across
+        # Today / Month rows. `Today (YYYY-MM-DD):` is 4 chars wider than
+        # `Month (YYYY-MM):`; the old hand-rolled "   " spacing assumed an
+        # exact label length and broke when day_label / month_label format
+        # changed.
+        day_label_part = f"Today ({day_label}):" if day_label else ""
+        month_label_part = f"Month ({month_label}):" if month_label else ""
+        label_col = max(len(day_label_part), len(month_label_part)) + 1
+
         if day_label:
             tok_cap = cfg.daily_tokens
             cost_cap = cfg.daily_cost_usd
@@ -1140,7 +1149,9 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
                 f"${daily_cost:.4f} / ${cost_cap.hard_limit:.2f}{_pct(daily_cost, cost_cap.hard_limit)}"
                 if cost_cap.is_active else f"${daily_cost:.4f}"
             )
-            lines.append(f"  Today ({day_label}):   tokens {tok_str} | {cost_str}")
+            lines.append(
+                f"  {day_label_part:<{label_col}}tokens {tok_str} | {cost_str}"
+            )
 
         if month_label:
             tok_cap = cfg.monthly_tokens
@@ -1153,7 +1164,9 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
                 f"${monthly_cost:.4f} / ${cost_cap.hard_limit:.2f}{_pct(monthly_cost, cost_cap.hard_limit)}"
                 if cost_cap.is_active else f"${monthly_cost:.4f}"
             )
-            lines.append(f"  Month ({month_label}): tokens {tok_str} | {cost_str}")
+            lines.append(
+                f"  {month_label_part:<{label_col}}tokens {tok_str} | {cost_str}"
+            )
 
         lines.append("")
 


### PR DESCRIPTION
## Summary

`format_budget_output` hand-spaced the two label rows to align the `tokens` column:

```
Before:  Today (2026-05-17):   tokens 32,178 | \$0.0029
         Month (2026-05): tokens 32,178 | \$0.0029
                          ^^ misaligned
```

The `\":   \"` padding after `Today:` assumed an exact label length. When the label parts diverge (`Today (2026-05-17):` is 4 chars wider than `Month (2026-05):`), the `tokens` column shifts and the eye has to re-locate for each row.

Pre-compute `label_col = max(len(day), len(month)) + 1` and use `\":<label_col\":` so the column stays aligned regardless of label length or future format changes.

```
After:   Today (2026-05-17):  tokens 32,178 | \$0.0029
         Month (2026-05):     tokens 32,178 | \$0.0029
                              ^ aligned
```

## Test plan

- [x] `pytest tests/ -k budget` — 63 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)