### PR TITLE
fix(stdlib/index_docs): unblock extract_and_split mode: safe per the 2026-05-15 R-PURE-MODE audit

### DIFF
--- a/src/reyn/kernel/_python_allowlist.py
+++ b/src/reyn/kernel/_python_allowlist.py
@@ -14,12 +14,24 @@ from input alone — `math`, `json`, `re`, `hashlib`, `collections`, ...).
 
 What `mode: safe` rules out by *syntactic unreachability*:
 
-  - filesystem path I/O — `glob`, `os`, `pathlib`, `shutil`, `tempfile`
+  - file content I/O — `open` (banned builtin), `os.read` / `os.write`,
+    `pathlib.Path.read_text` / `write_text`, `shutil`, `tempfile`
   - network — `urllib`, `socket`, `http`, `ssl`, `requests`, `httpx`
   - subprocess / external command — `subprocess`, `os.system`, `popen`
   - environment — `os.environ`, `sys.argv` (= operator-injected state)
   - dynamic code — `exec`, `eval`, `compile`, `__import__`,
     `importlib`, file-reading codec / encoding loaders
+
+`glob` is admitted as a *restricted ambient source* — it exposes operator
+filesystem state (= the set of paths matching a pattern) but never reads
+file content. The carveout was made explicit by the 2026-05-15
+``R-PURE-MODE-REDEFINE`` stdlib audit, which signed off on stdlib
+``index_docs.extract_and_split`` (= ``mode: safe`` python step calling
+``glob.glob``) on the grounds that path enumeration without content read
+preserves the safe-mode contract for the step's *output* (= the path
+list; downstream content reads happen in a paired ``mode: unsafe`` step).
+See ``docs/deep-dives/audits/2026-05-15-pure-mode-stdlib-audit.md`` for
+the full reasoning.
 
 Authors who need *any* of the above must declare `mode: unsafe` (= stdlib
 auto-allowed via `reyn run`, user skills need `--allow-unsafe-python` or
@@ -69,6 +81,14 @@ PURE_STDLIB_ALLOWLIST: frozenset[str] = frozenset({
     "datetime",    # ambient: system clock via datetime.now(); also pure date arithmetic
     "calendar",    # pure: calendar arithmetic (grouped here; no system clock read at any call site)
     "zoneinfo",    # ambient: bundled IANA TZ database shipped with Python (static files)
+
+    # --- restricted ambient: filesystem path enumeration (no content read) ---
+    "glob",        # restricted: path-list reads only (= operator filesystem
+                   #             state, but content reads stay in mode: unsafe).
+                   #             Carveout endorsed by the 2026-05-15
+                   #             R-PURE-MODE-REDEFINE stdlib audit; see
+                   #             docs/deep-dives/audits/2026-05-15-pure-mode-
+                   #             stdlib-audit.md.
 
     # --- pure: data encoding and hashing ---
     "json",        # pure: JSON serialisation / deserialisation

--- a/src/reyn/stdlib/skills/index_docs/chunkers.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers.py
@@ -8,8 +8,10 @@ Override pattern (ADR-0033 §2.1): project-specific chunkers (Python AST,
 custom Markdown) replace this module via skill.md ``module:`` override.
 
 R-PURE-MODE-REDEFINE Class A split (postprocessor steps):
-  ``extract_and_split`` (mode: safe) — glob enum + pure chunking, no file
-    content read; safe step.
+  ``extract_and_split`` (mode: safe) — moved to companion module
+    ``chunkers_safe.py``; this module's ``import os`` / ``import
+    reyn.api.unsafe.file`` would otherwise be inherited by the safe-mode
+    AST validator (which walks all module imports), forcing it to fail.
   ``write_chunks_with_lock`` (mode: unsafe, minimal) — irreducible minimum:
     source file content read, advisory lock acquire/release, .jsonl write.
 
@@ -194,27 +196,10 @@ def cost_preflight(artifact: dict) -> dict:
 _CHUNKS_JSONL_PATH = "artifacts/chunks.jsonl"
 
 
-def extract_and_split(artifact: dict) -> list:
-    """Postprocessor python step (mode: safe): glob enum — enumerates source files.
-
-    Receives the LLM's finish artifact (= chunk_strategy). Enumerates files
-    matching the path glob and returns an ordered list of source file paths.
-    Does NOT read file content — content read is deferred to the unsafe step
-    ``write_chunks_with_lock``.
-
-    Glob ownership rationale (R-PURE-MODE audit): ``_glob_files`` exposes
-    filesystem path state (list of paths) but not file content. This is the
-    same pattern as ``gather_samples`` which calls ``_api_glob_files`` as a
-    preprocessor step. Contract-compliant for mode: safe.
-
-    Returns a list of source-file path dicts placed at ``data.chunk_list``:
-        [{"source_path": str}, ...]
-    """
-    data = artifact.get("data") or {}
-    path = str(data.get("path") or "")
-
-    file_paths = _glob_files(path)
-    return [{"source_path": fp} for fp in file_paths]
+# ``extract_and_split`` was moved to ``chunkers_safe.py`` so the safe-mode
+# AST validator, which walks all module-level imports via ``ast.walk(tree)``,
+# does not reject it because of this module's legitimate ``os`` /
+# ``reyn.api.unsafe.file`` imports used by the surrounding unsafe-mode steps.
 
 
 def write_chunks_with_lock(artifact: dict) -> dict:

--- a/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
@@ -1,0 +1,55 @@
+"""Safe-mode postprocessor step for index_docs (= the `extract_and_split`
+path enumeration phase).
+
+Split out from ``chunkers.py`` so that ``extract_and_split`` can actually run
+under ``mode: safe``. The companion ``chunkers.py`` module legitimately
+imports ``os`` / ``reyn.api.unsafe.file`` for its unsafe-mode steps
+(``gather_samples``, ``cost_preflight``, ``write_chunks_with_lock``), and the
+safe-mode AST validator walks all imports in the module via ``ast.walk(tree)``
+— so a single-file layout forces every safe-mode step to inherit those
+unsafe imports. Following the audit's own Wave 2 pattern (= ``aggregate``
+→ ``aggregate_pure``), this module hosts only the safe-mode step and the
+exact set of imports the safe-mode allowlist admits.
+
+R-PURE-MODE-REDEFINE audit (2026-05-15) signed off on ``glob.glob`` as a
+restricted ambient source for path-list-only enumeration. See
+``docs/deep-dives/audits/2026-05-15-pure-mode-stdlib-audit.md`` and
+``_python_allowlist.py`` for the contract.
+"""
+from __future__ import annotations
+
+import glob as _glob_mod
+
+
+def extract_and_split(artifact: dict) -> list:
+    """Postprocessor python step (mode: safe): glob enum — enumerates source files.
+
+    Receives the LLM's finish artifact (= chunk_strategy). Enumerates files
+    matching the path glob and returns an ordered list of source file paths.
+    Does NOT read file content — content read is deferred to the unsafe step
+    ``write_chunks_with_lock``.
+
+    Glob ownership rationale (R-PURE-MODE audit, 2026-05-15): ``glob.glob``
+    exposes filesystem path state (= list of paths matching the pattern) but
+    never reads file content. The audit endorsed this as a restricted
+    ambient source — see ``docs/deep-dives/audits/2026-05-15-pure-mode-
+    stdlib-audit.md`` for the full reasoning.
+
+    No ``os.path.isfile`` filter: keeping the safe-mode allowlist narrow
+    means this module imports only ``glob``. ``glob.glob`` does not
+    distinguish files from directories, but for typed-extension patterns
+    (``**/*.md``, ``**/*.py``, …) directory matches are exotic. If one
+    does sneak through, the downstream ``write_chunks_with_lock`` (=
+    mode: unsafe) fails explicitly at content read time, which is
+    preferable to a silent drop.
+
+    Returns a list of source-file path dicts placed at ``data.chunk_list``:
+        [{"source_path": str}, ...]
+    """
+    data = artifact.get("data") or {}
+    path = str(data.get("path") or "")
+    if not path:
+        return []
+
+    matches = _glob_mod.glob(path, recursive=True)
+    return [{"source_path": fp} for fp in sorted(matches)]

--- a/src/reyn/stdlib/skills/index_docs/skill.md
+++ b/src/reyn/stdlib/skills/index_docs/skill.md
@@ -39,7 +39,7 @@ permissions:
       function: cost_preflight
       mode: unsafe
       timeout: 10
-    - module: ./chunkers.py
+    - module: ./chunkers_safe.py
       function: extract_and_split
       mode: safe
       timeout: 30
@@ -56,9 +56,11 @@ permissions:
 postprocessor:
   output_schema: index_summary
   steps:
-    # Step 1: safe — glob enum (path list only, no file content read)
+    # Step 1: safe — glob enum (path list only, no file content read).
+    # Lives in chunkers_safe.py (separate module) so the safe-mode AST
+    # validator does not inherit chunkers.py's legitimate unsafe imports.
     - type: python
-      module: ./chunkers.py
+      module: ./chunkers_safe.py
       function: extract_and_split
       into: data.chunk_list
       mode: safe

--- a/tests/test_index_docs_pure_split_invariants.py
+++ b/tests/test_index_docs_pure_split_invariants.py
@@ -56,7 +56,7 @@ def test_extract_and_split_returns_path_list_without_content_read(tmp_path):
     return value or side-effecting the artifact). An empty-glob case is also
     tested to confirm no error is raised for missing files.
     """
-    from reyn.stdlib.skills.index_docs.chunkers import extract_and_split
+    from reyn.stdlib.skills.index_docs.chunkers_safe import extract_and_split
 
     # ── Case 1: real files ────────────────────────────────────────────────────
     (tmp_path / "a.md").write_text("hello world", encoding="utf-8")


### PR DESCRIPTION
## Summary

The README's flagship RAG demo —

```bash
reyn run index_docs '{"source":"my_docs","path":"docs/**/*.md","description":"Project documentation"}'
reyn chat
> What is the care boundary in Reyn?
```

— fails for any fresh-install user at the `extract_and_split` postprocessor step:

```
SafeModeViolation: safe mode: import of 'glob' not allowed
```

The 2026-05-15 R-PURE-MODE audit (`docs/deep-dives/audits/2026-05-15-pure-mode-stdlib-audit.md`) signed off on this step as *"already correctly labelled `mode: safe`"* on the grounds that path enumeration (= a glob result) is a restricted ambient source exposing filesystem state but never reading file content. Two pieces of the audit's design never landed in the runtime:

1. `src/reyn/kernel/_python_allowlist.py` still rejected `import glob` and listed it under "rules out by syntactic unreachability".
2. `extract_and_split` lived in `chunkers.py` alongside legitimately unsafe steps (`gather_samples`, `write_chunks_with_lock`) that import `os` / `reyn.api.unsafe.file`. The safe-mode AST validator walks every module-level import via `ast.walk(tree)`, so those unsafe imports were inherited by the safe step.

This is the FP scan finding: the audit's design is settled — the runtime just never caught up. See the FP scan summary at https://github.com/tya5/reyn/issues/14 (FP-0013) / https://github.com/tya5/reyn/issues/15 (FP-0014) for the framework around safe / unsafe modes; the audit itself documents the case-by-case conclusions for each stdlib step including `extract_and_split`.

## Fix

Close both gaps without changing the audit's stance:

1. **Allowlist**: add `glob` to `PURE_STDLIB_ALLOWLIST` as a *restricted ambient* entry, and rewrite the docstring's `rules out` block to match — `glob` is admitted for path-list-only reads; file content I/O (`open`, `os.read`, `pathlib.Path.read_text`, `shutil`, `tempfile`) remains explicitly rejected. Docstring cites the 2026-05-15 audit by path.

2. **Module split**: move `extract_and_split` out of `chunkers.py` into a new sibling module `chunkers_safe.py` whose only import is `glob`. Pattern matches the audit's Wave 2 precedent (`aggregate.py` → `aggregate_pure.py`). `chunkers.py` keeps a docstring pointer.

3. **Skill.md**: the postprocessor step and the matching `permissions.python` entry both now reference `./chunkers_safe.py:extract_and_split`. `chunk_list` shape unchanged; downstream `write_chunks_with_lock` reads it as before.

4. **Inline glob, no `os.path.isfile` filter**: the shared `_glob_files` helper applies a defensive `os.path.isfile` filter against directory-shaped glob matches — `chunkers_safe.py` cannot import `os`, so the safe step calls `glob.glob` inline and trusts the pattern. For typed-extension globs (`**/*.md`, `**/*.py`) directory matches are exotic; if one slips through, the downstream `write_chunks_with_lock` (mode: unsafe) fails explicitly at content read time.

Diff: 5 files, +90 / -28.

## Test plan

- [x] **Targeted tests pass** — `pytest tests/test_index_docs_pure_split_invariants.py tests/test_chunkers.py tests/test_python_allowlist_reyn_packages.py` → 33 passed
- [x] **Broader sweep clean** — `pytest -k 'index_docs or chunkers or allowlist'` → 67 passed, 7 skipped, 0 failures
- [x] `ruff check src/reyn/`
- [x] **Manual e2e** — `OPENAI_API_KEY=dummy reyn run index_docs '{"type":"index_docs_input","data":{"source":"my_docs","path":"docs/**/*.md","description":"Project documentation"}}'` → strategy phase completes, `extract_and_split` runs (no SafeModeViolation), `write_chunks_with_lock` writes chunks, pipeline proceeds to the embed step. Embed step then hits an unrelated litellm auth error against `dummy` key — out of scope here (= the audit's safe-mode contract for `extract_and_split` is what this PR fixes).
- [x] **Manual** — verified the pre-fix error is reproduced on `main` HEAD before the change

## Intentional scope limits

- **No new test for `glob` in allowlist.** Per the testing policy (`docs/deep-dives/contributing/testing.md`), per-commit regression duplicates are Tier 4. The existing `test_index_docs_pure_split_invariants.py` already imports and runs `extract_and_split`, which exercises the allowlist transitively.
- **README copy-paste still requires the wrapped JSON form** (`{"type":"index_docs_input","data":{...}}`). That's a separate finding (input artifact wrapping); will be a separate PR.
- **Audit document is not updated.** The audit's "extract_and_split already correctly labelled" claim was technically inaccurate at the time (= the runtime rejected the import) — this PR makes the claim factually true. Updating the audit retroactively would be doc churn for no reader benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)