### PR TITLE
feat(cli/run): auto-wrap bare-data JSON input with the entry artifact envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ Full tutorial: [docs/guide/getting-started/02-your-first-skill.md](docs/guide/ge
 
 ```bash
 # Index any glob into a named source — one source per chunking strategy.
-reyn run index_docs '{"source":"my_docs","path":"docs/**/*.md","description":"Project documentation"}'
+# The CLI also accepts the bare data dict
+#   '{"source":..., "path":..., "description":...}'
+# and auto-wraps it with the artifact envelope.
+reyn run index_docs '{"type":"index_docs_input","data":{"source":"my_docs","path":"docs/**/*.md","description":"Project documentation"}}'
 
 # Chat — the LLM calls `recall` automatically when an indexed source covers the topic.
 reyn chat

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -87,7 +87,9 @@ def run(args: argparse.Namespace) -> None:
     loaded = load_skill_from_args(args)
 
     raw_input = _read_input(args)
-    initial_input = _parse_cli_input(raw_input)
+    initial_input = _parse_cli_input(
+        raw_input, default_type=_entry_input_type(loaded.skill),
+    )
 
     model, resolved_model = session.model_for(args)
     # output_language is Optional[str]. None propagates all the way down
@@ -176,12 +178,62 @@ def _read_input(args: argparse.Namespace) -> str:
     sys.exit(1)
 
 
-def _parse_cli_input(raw: str) -> dict:
-    """Accept JSON or natural language. Natural language → user_message artifact."""
+def _entry_input_type(skill) -> str | None:
+    """Return the artifact type name to wrap a bare-data CLI input dict with,
+    or None when the wrap isn't safe to apply automatically.
+
+    Safe to wrap when the entry phase has exactly one input artifact (no
+    ``anyOf`` union) and that artifact is declared ``wrapped: true`` (default)
+    so its compiled schema carries ``{type, data}`` envelope properties.
+
+    Skipped when:
+      - entry phase missing (defensive)
+      - input is an ``anyOf`` of multiple artifact types (= which type would
+        we wrap with? — leave to the user)
+      - artifact is declared ``wrapped: false`` (= no envelope; the bare dict
+        IS the artifact, not its inner data)
+    """
+    entry = skill.phases.get(skill.entry_phase)
+    if entry is None:
+        return None
+    schema = entry.input_schema or {}
+    if "anyOf" in schema:
+        return None
+    props = schema.get("properties") or {}
+    if "type" not in props or "data" not in props:
+        return None
+    return entry.input_schema_name
+
+
+def _parse_cli_input(raw: str, *, default_type: str | None = None) -> dict:
+    """Accept JSON or natural language and return a Reyn artifact dict.
+
+    Cases:
+      - **Non-JSON text** → wrapped as ``{type: user_message, data: {text}}``.
+      - **JSON dict already in envelope form** (= has a ``type`` key) →
+        passed through unchanged.
+      - **JSON dict in bare-data form + ``default_type`` provided** →
+        auto-wrapped as ``{type: default_type, data: <parsed>}``. This is
+        the path that lets ``reyn run index_docs '{"source":..., "path":...}'``
+        (README's RAG demo) work without forcing users to know the artifact
+        envelope; the skill loader supplies the target type via
+        ``_entry_input_type``.
+      - **Anything else** (JSON list, string, number, dict with no
+        ``default_type``) → passed through unchanged; downstream artifact
+        validation reports the mismatch.
+    """
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
     except json.JSONDecodeError:
         return {"type": "user_message", "data": {"text": raw}}
+
+    if (
+        isinstance(parsed, dict)
+        and "type" not in parsed
+        and default_type is not None
+    ):
+        return {"type": default_type, "data": parsed}
+    return parsed
 
 
 def _build_permission_resolver(config, shell_allowed: bool, unsafe_python: bool = False):

--- a/tests/test_cli_run_input_auto_wrap.py
+++ b/tests/test_cli_run_input_auto_wrap.py
@@ -1,0 +1,64 @@
+"""Tier 2: ``reyn run`` CLI input parser auto-wrap contract.
+
+The parser's job is to turn a CLI-supplied input string (JSON or natural
+language) into a Reyn artifact dict. When the JSON form is a bare data
+dict (= no ``type`` envelope) and the skill loader has identified the
+entry phase's wrapped artifact type, the parser auto-wraps it as
+``{"type": <name>, "data": <bare>}``. This is the path that lets the
+README's RAG demo
+
+    reyn run index_docs '{"source":...,"path":...,"description":...}'
+
+work without forcing readers to know the artifact contract.
+
+The invariant pinned here is the parser contract — pure function, no
+filesystem, no LLM. End-to-end CLI behaviour is exercised separately
+through manual run smoke (see PR description).
+"""
+from __future__ import annotations
+
+from reyn.cli.commands.run import _parse_cli_input
+
+
+def test_bare_dict_wraps_with_default_type():
+    """Tier 2: bare data dict + default_type → wrapped artifact."""
+    out = _parse_cli_input(
+        '{"source":"my_docs","path":"docs/**/*.md"}',
+        default_type="index_docs_input",
+    )
+    assert out == {
+        "type": "index_docs_input",
+        "data": {"source": "my_docs", "path": "docs/**/*.md"},
+    }
+
+
+def test_already_wrapped_passes_through():
+    """Tier 2: a dict that already carries ``type`` is not re-wrapped."""
+    raw = '{"type":"index_docs_input","data":{"source":"x"}}'
+    out = _parse_cli_input(raw, default_type="index_docs_input")
+    assert out == {
+        "type": "index_docs_input",
+        "data": {"source": "x"},
+    }
+
+
+def test_no_default_type_passes_dict_through():
+    """Tier 2: with no default_type the parser does not invent one."""
+    out = _parse_cli_input('{"foo":"bar"}', default_type=None)
+    assert out == {"foo": "bar"}
+
+
+def test_non_json_text_wraps_as_user_message():
+    """Tier 2: non-JSON text becomes a user_message regardless of default_type."""
+    out = _parse_cli_input("hello world", default_type="index_docs_input")
+    assert out == {"type": "user_message", "data": {"text": "hello world"}}
+
+
+def test_bare_dict_with_type_key_passes_through():
+    """Tier 2: a dict that already carries ``type`` is left alone even
+    when the supplied default_type would have wrapped it differently."""
+    out = _parse_cli_input(
+        '{"type":"other_artifact","data":{"foo":"bar"}}',
+        default_type="index_docs_input",
+    )
+    assert out["type"] == "other_artifact"


### PR DESCRIPTION
## Summary

Companion to #101 (which unblocks the safe-mode `glob` import in
`extract_and_split`). Together they restore the README's flagship RAG
demo end-to-end for fresh-install users.

The bug: a copy-paste of the README's index_docs command —

```bash
reyn run index_docs '{"source":"my_docs","path":"docs/**/*.md","description":"Project documentation"}'
```

— failed with the unhelpful error

```
Error during execution: LLM aborted workflow at phase 'strategy':
Cost threshold exceeded: 0 chunks (threshold 0) - Aborting to prevent excessive costs.
```

Root cause: `_parse_cli_input` passed the bare JSON dict through unchanged, the OS saved it as `type: unknown`, the python preprocessor `gather_samples` read `data.path` (which doesn't exist in the bare form), found an empty string, returned `file_count: 0`, and the LLM dutifully aborted. The user has no way to translate that back to *"your input was missing the `{type, data}` envelope"*.

The skill loader knew the answer all along — every wrapped artifact compiles to a JSON schema with `properties.type` + `properties.data`. The CLI just wasn't asking. This patch teaches it to.

## Fix

`_entry_input_type(skill)` inspects the entry phase's resolved input schema and returns the artifact name iff the wrap is unambiguous:

- single artifact (no `anyOf`)
- declared `wrapped: true` (= schema has `{type, data}` envelope properties)

It returns `None` for:

- `anyOf` unions (= which type should we pick? — leave to the user)
- `wrapped: false` artifacts (= the bare dict IS the artifact, not its inner data)
- skills with no resolvable entry phase (= defensive)

The fallback "do nothing" preserves the prior behaviour for those cases.

`_parse_cli_input(raw, *, default_type=...)` then auto-wraps when the parsed JSON is a dict without a `type` key. Already-wrapped input, NL text, and non-dict JSON values pass through unchanged.

`stdlib/index_docs/skill.md` already documents both shapes (= `"reyn run accepts both; the bare-data form is auto-wrapped"`); this PR makes the documented contract true. README's index_docs example is updated to show the canonical wrapped form, with a comment noting the bare form is also accepted.

Diff: 3 files, +124 / -5 (+1 new test file).

## Test plan

- [x] **Unit** — `pytest tests/test_cli_run_input_auto_wrap.py` → 5/5 passed (bare-dict wrap, already-wrapped passthrough, no-default passthrough, NL text → user_message, type-keyed dict passthrough)
- [x] **Broader sweep** — `pytest -k '(run or cli or skill_loader or parse_cli) and not mcp and not fp0016'` → 404 passed, 0 regressions (mcp-related failures are pre-existing: `mcp` Python module not installed in local venv)
- [x] `ruff check src/reyn/cli/commands/run.py tests/test_cli_run_input_auto_wrap.py`
- [x] **Manual e2e: bare-data → auto-wrap**
  - `reyn run index_docs '{"source":"my_docs","path":"docs/concepts/*.md","description":"d"}'`
  - Output `input type      : index_docs_input` (= auto-wrapped) and the strategy phase runs through to produce a `chunk_strategy` artifact
- [x] **Manual e2e: already-wrapped → unchanged** — same skill with explicit `{type, data}` envelope still works
- [x] **Manual e2e: NL text → user_message** — `reyn run direct_llm "hello world"` shows `input type : user_message`
- [x] **Manual e2e: bare dict for direct_llm** — `reyn run direct_llm '{"text":"hello"}'` auto-wraps as `user_message` (= direct_llm's entry input)

## Dependency

This PR makes the README's bare-form copy-paste reach the strategy phase. The subsequent `extract_and_split` postprocessor step is unblocked by #101. Both PRs are needed to deliver the end-to-end RAG demo to fresh-install users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)