### PR TITLE
fix(tui): surface fold-stash invalidation with inline marker

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -326,9 +326,17 @@ class ConversationView(Widget):
         # Always remember the full text — independent of fold thresholds.
         self._last_reply_full = text
         log = self._log()
+        # Detect that a prior fold is about to be invalidated. The single-slot
+        # ``_last_long_reply`` is replaced (or cleared) by every new agent
+        # reply, so any old fold hint up-screen still reads "type /expand to
+        # show" while /expand itself silently no-ops. Flag it inline so the
+        # user can tell the previous fold is no longer reachable.
+        had_prev_fold = self._last_long_reply is not None
         lines = text.split("\n")
         if len(lines) <= _FOLD_THRESHOLD_LINES:
             log.write(RichMarkdown(text))
+            if had_prev_fold:
+                self._write_fold_expired_marker()
             self._last_long_reply = None
             return
         preview = "\n".join(lines[:_FOLD_THRESHOLD_LINES])
@@ -342,7 +350,22 @@ class ConversationView(Widget):
         hint.append("/expand", style=f"bold {_CORAL}")
         hint.append(" to show ]", style=f"dim {_CORAL}")
         log.write(hint)
+        if had_prev_fold:
+            self._write_fold_expired_marker()
         self._last_long_reply = text
+
+    def _write_fold_expired_marker(self) -> None:
+        """Emit a dim marker noting that an earlier fold's /expand is gone.
+
+        The fold stash is a single slot — every new agent reply either
+        clears it (short reply) or replaces it (next long reply). Either
+        way the earlier fold's /expand becomes unreachable; this marker
+        makes that visible chronologically so users don't keep typing
+        /expand into a no-op.
+        """
+        marker = Text()
+        marker.append("  [ ↑ earlier fold cleared ]", style=f"dim {_CORAL}")
+        self._log().write(marker)
 
     def expand_last_reply(self) -> bool:
         """Append the full text of the most recently truncated reply.

--- a/tests/cli/test_fold_stash_expired_marker.py
+++ b/tests/cli/test_fold_stash_expired_marker.py
@@ -1,0 +1,144 @@
+"""Tier 2: fold-stash invalidation is surfaced inline, not silent.
+
+The B3 fold mechanism stashes the full text of a long agent reply in
+``_last_long_reply`` and offers `/expand` to flush the rest. The stash is
+a single slot — any subsequent agent reply (short or long) overwrites
+it. Before this fix the user kept seeing the old fold hint up-screen
+while `/expand` silently no-ops; nothing in the log indicated that the
+fold had been invalidated.
+
+These tests pin the contract that when an earlier fold's stash is
+cleared or replaced, a dim "[ ↑ earlier fold cleared ]" marker lands in
+the RichLog so the user can tell `/expand` no longer points at the old
+reply.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _log_text(log: RichLog) -> str:
+    """Concat all strip text in the RichLog for substring searches."""
+    return "\n".join("".join(seg.text for seg in strip) for strip in log.lines)
+
+
+def _long_reply(line_count: int = 60) -> str:
+    return "\n".join(f"line {i}" for i in range(line_count))
+
+
+@pytest.mark.asyncio
+async def test_short_reply_after_fold_writes_expired_marker():
+    """Short reply following a folded long reply emits the expired marker.
+
+    The single-slot stash is cleared by the short reply; up-screen the
+    old fold hint still reads "type /expand to show", so the marker is
+    the only on-screen cue that /expand no longer works.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # Turn 1: long reply → stash populated, fold hint emitted
+        conv._write_agent_markdown_with_fold(_long_reply(60))
+        await pilot.pause()
+        assert conv.has_pending_expand
+
+        # Turn 2: short reply → stash cleared, marker should appear
+        conv._write_agent_markdown_with_fold("short ack")
+        await pilot.pause()
+        assert not conv.has_pending_expand
+        rendered = _log_text(log)
+        assert "earlier fold cleared" in rendered, (
+            f"expected expired marker after short reply, got:\n{rendered}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_long_reply_after_fold_writes_expired_marker():
+    """Second long reply replaces the stash and still flags the user.
+
+    /expand now targets the NEW reply; the marker prevents the user
+    from assuming /expand still points at the older content.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._write_agent_markdown_with_fold(_long_reply(60))
+        await pilot.pause()
+        first_stash = conv._last_long_reply
+
+        conv._write_agent_markdown_with_fold(_long_reply(80))
+        await pilot.pause()
+        # Stash was replaced (new content), not None
+        assert conv._last_long_reply is not None
+        assert conv._last_long_reply != first_stash
+        rendered = _log_text(log)
+        assert "earlier fold cleared" in rendered, (
+            f"expected expired marker after replacing fold, got:\n{rendered}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_first_reply_does_not_emit_expired_marker():
+    """No prior fold → no marker (the marker is only relevant on invalidation)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._write_agent_markdown_with_fold("first ever reply")
+        await pilot.pause()
+
+        rendered = _log_text(log)
+        assert "earlier fold cleared" not in rendered, (
+            f"marker leaked on first reply:\n{rendered}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_short_then_short_no_marker():
+    """Two short replies in a row → no fold ever existed, no marker.
+
+    Defends against accidentally emitting the marker whenever the stash
+    transitions None → None.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._write_agent_markdown_with_fold("hi")
+        await pilot.pause()
+        conv._write_agent_markdown_with_fold("there")
+        await pilot.pause()
+
+        rendered = _log_text(log)
+        assert "earlier fold cleared" not in rendered, rendered


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- The B3 fold mechanism stashes the full text of a long agent reply in ``_last_long_reply`` and offers ``/expand`` to flush the rest. The stash is a **single slot** — any subsequent agent reply (short or long) overwrites it. Before this fix, the user kept seeing the old fold hint up-screen (\"type /expand to show\") while ``/expand`` silently returned False; nothing in the conv pane indicated the earlier fold was no longer reachable.
- When an earlier fold is about to be cleared (short reply) or replaced (next long reply), emit a dim ``[ ↑ earlier fold cleared ]`` marker into the RichLog. The marker is chronological — it lands right after the new turn's body, so the user sees cause and effect together.
- Regression test (Tier 2, ``tests/cli/test_fold_stash_expired_marker.py``) pins the contract: short-after-long emits the marker, long-after-long emits it, first-ever-reply does not, short-after-short does not.

## Why

Found by a UX exploration pass: ``_last_long_reply`` is set in one branch of ``_write_agent_markdown_with_fold`` and cleared in the other, with no on-screen signal at the transition. The visible hint up-screen still promises ``/expand`` works, so users keep typing it into a no-op.

## Test plan

- [x] ``pytest tests/cli/test_fold_stash_expired_marker.py`` — 4 passed
- [x] ``pytest tests/cli/test_tui_smoke.py`` — 36 passed (no regression in existing TUI smoke tests)
- [x] Manual reasoning: marker text is neutral (\"earlier fold cleared\") and works for both clear and replace cases without making promises about where ``/expand`` now points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)