### PR TITLE
fix(tui): classify router-loop failures into actionable error buckets

### DIFF
--- a/src/reyn/chat/error_format.py
+++ b/src/reyn/chat/error_format.py
@@ -1,0 +1,101 @@
+"""Friendly classification of router / LLM-call failure exceptions.
+
+The chat layer catches a broad ``except Exception`` around the router
+loop because failures arrive from many providers via litellm and the
+exact import path is provider-specific. Without classification, every
+failure surfaces as ``router failed: <RawExceptionRepr>`` which leaks
+provider internals (multi-line JSON blobs, raw exception class names)
+and gives the user no path forward.
+
+This module maps the common patterns to a short, actionable prefix:
+
+    [rate limit]      provider 429 — wait a moment and retry
+    [provider error]  provider 5xx / connection failure — retry shortly
+    [auth error]      bad / missing API key
+    [timeout]         client- or server-side timeout
+    [bad request]     malformed prompt or oversized context
+    [budget exceeded] reyn-side budget cap (BudgetExceeded)
+
+The classifier inspects ``type(exc).__name__`` and falls back to a
+``status_code`` attribute when present. It deliberately does NOT
+import litellm or httpx — keeping this layer free of provider deps
+means new provider exceptions don't have to be re-imported here as
+long as their class names follow common conventions.
+"""
+from __future__ import annotations
+
+from reyn.budget.budget import BudgetExceeded
+
+
+def classify_router_error(exc: BaseException) -> str:
+    """Return a one-line user-facing description of *exc*.
+
+    Format: ``"router failed: [<bucket>] <detail> • <hint>"``. Falls back
+    to ``"router failed: <repr>"`` when no bucket matches.
+    """
+    if isinstance(exc, BudgetExceeded):
+        return (
+            f"router failed: [budget exceeded] {exc.dimension}: {exc.detail} "
+            "• try /budget reset or wait for the next period"
+        )
+
+    name = type(exc).__name__
+    msg = str(exc) or name
+    code = getattr(exc, "status_code", None)
+
+    bucket = _bucket_for(name, code)
+    if bucket is None:
+        return f"router failed: {msg}"
+    label, hint = bucket
+    # Trim the verbose part — keep just the first sentence / line so the
+    # user-facing version doesn't carry multi-line JSON from the provider.
+    short = msg.splitlines()[0]
+    if len(short) > 200:
+        short = short[:200] + "…"
+    return f"router failed: [{label}] {short} • {hint}"
+
+
+def _bucket_for(name: str, code: int | None) -> tuple[str, str] | None:
+    """Return a ``(label, hint)`` pair for the matched bucket, or None.
+
+    Class-name matching is intentionally substring-based so subclasses
+    (``RateLimitError``, ``OpenAIRateLimitError``, …) all fall into the
+    same bucket. ``status_code`` is the secondary signal for providers
+    that wrap everything in a single ``APIError`` class — and it's
+    checked BEFORE the generic-name buckets so a ``WrappedAPIError``
+    with ``status_code=400`` lands in [bad request], not [provider error].
+    """
+    # Rate limit — 429
+    if "RateLimit" in name or code == 429:
+        return "rate limit", "wait a moment then retry"
+    # Auth — 401 / 403
+    if "Authentication" in name or "PermissionDenied" in name or code in (401, 403):
+        return "auth error", "check your API key for the active provider"
+    # Timeout (client or server)
+    if "Timeout" in name or "APITimeoutError" in name or code == 408:
+        return "timeout", "retry or check your network"
+    # Connection — DNS / TCP / TLS
+    if "Connection" in name or "ConnectError" in name:
+        return "connection error", "check network connectivity and retry"
+    # Status-code-driven precedence: 4xx (other than auth/rate) → bad request;
+    # 5xx → provider error. This runs BEFORE the class-name fallback so a
+    # wrapper class named ``WrappedAPIError`` with status_code=400 lands in
+    # the right bucket.
+    if isinstance(code, int):
+        if code == 400 or 410 <= code < 500:
+            return "bad request", "check the prompt / model name / context size"
+        if 500 <= code < 600:
+            return "provider error", "retry or check provider status"
+    # Class-name fallback for providers without a status_code attribute.
+    if "BadRequest" in name or "InvalidRequest" in name:
+        return "bad request", "check the prompt / model name / context size"
+    if (
+        "ServiceUnavailable" in name
+        or "InternalServerError" in name
+        or "APIError" in name
+    ):
+        return "provider error", "retry or check provider status"
+    return None
+
+
+__all__ = ["classify_router_error"]

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -22,6 +22,7 @@ from reyn.budget.budget import (
     format_refusal_message,
     format_warn_message,
 )
+from reyn.chat.error_format import classify_router_error
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.services import (
     AutoResumeHandler,
@@ -1360,7 +1361,7 @@ class ChatSession:
             return
         except Exception as exc:
             await self._put_outbox(OutboxMessage(
-                kind="error", text=f"router failed: {exc}",
+                kind="error", text=classify_router_error(exc),
                 meta={"chain_id": chain_id},
             ))
             return

--- a/tests/test_router_error_classify.py
+++ b/tests/test_router_error_classify.py
@@ -1,0 +1,137 @@
+"""Tier 1: contract test for classify_router_error.
+
+The router-loop catch in ``ChatSession`` previously surfaced raw
+exceptions as ``router failed: <repr>`` — typically a litellm class
+name followed by a multi-line JSON blob, truncated mid-sentence by the
+ErrorBox renderer. This module classifies the common buckets so the
+user sees an actionable prefix and hint.
+
+Pins the public function behaviour against a representative set of
+provider exception shapes, including the BudgetExceeded path.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.budget.budget import BudgetExceeded
+from reyn.chat.error_format import classify_router_error
+
+
+# ── synthetic exception shapes mimicking provider classes ────────────────────
+
+
+class RateLimitError(Exception):
+    pass
+
+
+class AnthropicRateLimitError(Exception):
+    """Subclass-named variant — substring match on class name still classifies."""
+
+
+class AuthenticationError(Exception):
+    pass
+
+
+class APITimeoutError(Exception):
+    pass
+
+
+class ServiceUnavailableError(Exception):
+    pass
+
+
+class InternalServerError(Exception):
+    pass
+
+
+class APIConnectionError(Exception):
+    pass
+
+
+class BadRequestError(Exception):
+    pass
+
+
+class WrappedAPIError(Exception):
+    """Provider variant that surfaces every failure through a single class
+    + a status_code attribute — classifier must fall back to the code."""
+
+    def __init__(self, msg: str, status_code: int):
+        super().__init__(msg)
+        self.status_code = status_code
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exc, expected_label",
+    [
+        (RateLimitError("429 too many requests"), "rate limit"),
+        (AnthropicRateLimitError("anthropic 429"), "rate limit"),
+        (AuthenticationError("invalid api key"), "auth error"),
+        (APITimeoutError("Request timed out"), "timeout"),
+        (ServiceUnavailableError("503"), "provider error"),
+        (InternalServerError("500"), "provider error"),
+        (APIConnectionError("connect failed"), "connection error"),
+        (BadRequestError("context too long"), "bad request"),
+    ],
+)
+def test_class_name_classification(exc: Exception, expected_label: str) -> None:
+    """Tier 1: each provider class-name maps to the expected bucket label."""
+    out = classify_router_error(exc)
+    assert out.startswith(f"router failed: [{expected_label}]"), out
+    # Hint must be present (after the bullet) for actionable guidance
+    assert " • " in out, f"missing hint separator: {out}"
+
+
+@pytest.mark.parametrize(
+    "code, expected_label",
+    [
+        (429, "rate limit"),
+        (401, "auth error"),
+        (403, "auth error"),
+        (408, "timeout"),
+        (500, "provider error"),
+        (502, "provider error"),
+        (503, "provider error"),
+        (599, "provider error"),
+        (400, "bad request"),
+    ],
+)
+def test_status_code_fallback_classification(code: int, expected_label: str) -> None:
+    """Tier 1: when class name is generic, status_code drives the bucket."""
+    out = classify_router_error(WrappedAPIError("opaque error", code))
+    assert out.startswith(f"router failed: [{expected_label}]"), out
+
+
+def test_budget_exceeded_gets_dedicated_bucket() -> None:
+    """Tier 1: BudgetExceeded gets the [budget exceeded] prefix + /budget reset hint."""
+    exc = BudgetExceeded("daily_tokens", "daily token cap: 100000/100000 (day: 2026-05-17)")
+    out = classify_router_error(exc)
+    assert "[budget exceeded]" in out
+    assert "daily_tokens" in out
+    assert "/budget reset" in out
+
+
+def test_unknown_exception_falls_back_to_repr() -> None:
+    """Tier 1: unmatched exception class returns the original message intact."""
+    out = classify_router_error(ValueError("something weird happened"))
+    assert out == "router failed: something weird happened"
+
+
+def test_multiline_message_is_trimmed_to_first_line() -> None:
+    """Tier 1: provider exceptions often carry multi-line JSON; only line 1 surfaces."""
+    msg = 'RateLimitError\n{"type":"error","message":"..."}\nextra'
+    out = classify_router_error(RateLimitError(msg))
+    assert "\n" not in out, f"newline leaked into user-facing text: {out!r}"
+    assert "[rate limit]" in out
+
+
+def test_very_long_message_is_truncated() -> None:
+    """Tier 1: a 500-char one-liner from a provider gets truncated with an ellipsis."""
+    huge = "x" * 500
+    out = classify_router_error(RateLimitError(huge))
+    assert out.endswith("• wait a moment then retry"), out
+    # Truncation marker must be present
+    assert "…" in out


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- ``ChatSession``'s router-loop ``except Exception`` used to surface every provider failure as ``router failed: <RawExceptionRepr>`` — typically a litellm class name followed by a multi-line JSON blob, truncated mid-sentence by the ErrorBox renderer. User saw ``router failed: RateLimitError\n{\"type\":\"err...`` with no hint about retrying.
- New ``reyn.chat.error_format.classify_router_error`` maps the common patterns to a short, actionable prefix:

  | Bucket | Trigger | Hint |
  | --- | --- | --- |
  | ``[rate limit]`` | 429 / ``RateLimit*`` | wait a moment then retry |
  | ``[provider error]`` | 5xx / ``ServiceUnavailable`` / ``APIError`` | retry or check provider status |
  | ``[auth error]`` | 401 / 403 / ``Authentication*`` | check your API key |
  | ``[timeout]`` | 408 / ``*Timeout*`` | retry or check your network |
  | ``[connection error]`` | ``Connection*`` / ``ConnectError`` | check network connectivity |
  | ``[bad request]`` | 400 / 4xx / ``BadRequest*`` | check prompt / model / context size |
  | ``[budget exceeded]`` | ``BudgetExceeded`` | try /budget reset or wait |

- Class-name matching is substring-based so subclasses (``AnthropicRateLimitError``, …) all fall into the right bucket. Status-code matching runs BEFORE the generic name fallback so a wrapper class named ``WrappedAPIError`` with ``status_code=400`` lands in ``[bad request]``, not ``[provider error]``.
- No ``litellm`` / ``httpx`` import added — keeping this layer provider-agnostic so new providers don't have to be re-imported here.
- Trim multiline messages to the first line and truncate >200 chars with an ellipsis, so the ErrorBox never carries a multi-line JSON blob from the provider.

## Why

Found by a UX exploration pass: a 429 from Anthropic surfaced as a raw class-name + JSON blob with no retry guidance. The classifier delivers a single user-readable line instead.

## Test plan

- [x] ``pytest tests/test_router_error_classify.py`` — 21 passed (8 class-name buckets + 9 status-code fallbacks + 4 edge cases)
- [x] ``pytest tests/test_session_invariants.py tests/cli/test_tui_smoke.py`` — 54 passed (no regression in session or TUI smoke)
- [x] Code review: ``BudgetExceeded`` is imported from ``reyn.budget.budget`` at module top level (already a stable dependency for session.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)