### PR TITLE
feat(tui): make side-panel discoverable from empty-state hint

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -165,10 +165,15 @@ class ConversationView(Widget):
 
     def compose(self) -> ComposeResult:
         yield RichLog(highlight=False, markup=False, wrap=True, max_lines=5000, id="log")
-        # B5: empty-state hint, removed on first message
+        # B5: empty-state hint, removed on first message.
+        # The hint is the first thing a new user sees, so it has to do double
+        # duty: announce the core key-binds AND describe the side panel — the
+        # most sophisticated piece of the TUI, which is hidden by default and
+        # otherwise has zero discoverability on first run.
         yield Static(
-            "  Type [bold]/[/] for commands  ·  [bold]Ctrl+B[/] panel  ·  "
-            "[bold]Ctrl+L[/] clear  ·  ↑ history  ·  [bold]Ctrl+P/N[/] turn",
+            "  Type [bold]/[/] for commands  ·  [bold]/help[/] for a guide\n"
+            "  [bold]Ctrl+B[/] side panel ([dim]keys · events · agents · memory · cost · docs[/])  ·  "
+            "[bold]Ctrl+L[/] clear  ·  [bold]Ctrl+P/N[/] turn",
             id="empty-hint",
             markup=True,
         )

--- a/tests/cli/test_empty_hint_discoverability.py
+++ b/tests/cli/test_empty_hint_discoverability.py
@@ -1,0 +1,81 @@
+"""Tier 2: empty-state hint surfaces the side-panel tabs by name.
+
+The right panel (Keys / Events / Agents / Memory / Cost / Docs) is
+``display: none`` by default. Before this fix, the only on-screen cue
+was the footer's terse ``Ctrl+B panel`` — a new user with no prior
+context could not tell what the panel even contains, so the entire
+right-panel subsystem was zero-discoverability on first launch.
+
+Pins the contract that the empty-state hint:
+  1. Names the slash mechanic (``/`` opens the command picker)
+  2. Names the help command explicitly (``/help`` for orientation)
+  3. Describes the side panel by enumerating its tabs
+
+This is the first thing a new user sees; a future refactor that drops
+back to ``Ctrl+B panel`` alone will regress discoverability silently.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import Static
+
+from reyn.chat.tui.app import ReynTUIApp
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_hint_names_side_panel_and_tabs() -> None:
+    """Empty-state hint enumerates the panel tabs by name."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        hint = app.query_one("#empty-hint", Static)
+        text = str(hint.render())
+
+        # Core mechanics
+        assert "/" in text, text
+        assert "/help" in text, text
+        assert "Ctrl+B" in text, text
+
+        # Panel discoverability — at least the key word + 2 tab names
+        assert "side panel" in text.lower(), (
+            f"hint must say 'side panel' for discoverability; got: {text!r}"
+        )
+        # Tabs — assert on at least three to defend against accidental dropouts
+        for tab in ("keys", "events", "docs"):
+            assert tab in text.lower(), f"tab {tab!r} missing from hint: {text!r}"
+
+
+@pytest.mark.asyncio
+async def test_empty_hint_hides_after_first_message() -> None:
+    """Existing contract: hint hides after first message (not a regression)."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        hint = app.query_one("#empty-hint", Static)
+        assert not hint.has_class("hidden")
+
+        conv = app.query_one("#conversation", ConversationView)
+        conv.render_message(OutboxMessage(kind="user", text="hi"))
+        await pilot.pause()
+
+        assert hint.has_class("hidden"), "hint should hide on first message"


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- The right panel (Keys / Events / Agents / Memory / Cost / Docs) is ``display: none`` by default; the only on-screen cue was the footer's terse ``Ctrl+B panel``. A new user with no prior context could not tell the panel even existed, let alone what it contained — the entire right-panel subsystem was zero-discoverability on first launch.
- Expand the conversation pane's empty-state hint to do double duty: announce the core key-binds AND enumerate the panel tabs by name. The hint is the first thing a new user sees, so naming the tabs there short-circuits a long discovery journey through ``/help`` or the footer.
- Also call out ``/help`` explicitly alongside the slash mechanic so users know there's a guide command and not just an opaque picker.

## Before / After

Before:
```
  Type / for commands  ·  Ctrl+B panel  ·  Ctrl+L clear  ·  ↑ history  ·  Ctrl+P/N turn
```

After:
```
  Type / for commands  ·  /help for a guide
  Ctrl+B side panel (keys · events · agents · memory · cost · docs)  ·  Ctrl+L clear  ·  Ctrl+P/N turn
```

## Why

Found by a first-run UX exploration pass. The right panel is the most sophisticated piece of the TUI, and the prior hint gave a brand-new user no way to know it contained a keys reference, events log, docs browser, etc.

## Test plan

- [x] ``pytest tests/cli/test_empty_hint_discoverability.py`` — 2 passed (new tests)
- [x] ``pytest tests/cli/`` — 40 passed (no regression in existing TUI smoke / cost-suffix tests)
- [x] Manual reasoning: hint wraps to 2 lines on terminals narrower than ~110 cols, which the Static widget handles cleanly because it inherits the conv pane's wrap; existing `#empty-hint` CSS has no fixed height constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)