### PR TITLE
fix(tui): turn-nav anchors survive RichLog ring-buffer trim

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -56,6 +56,12 @@ from .streaming_row import StreamingRow
 _DASH_TOTAL = 38  # matches the banner separator width
 _GROUP_WINDOW_S = 60.0  # consecutive turns within this window share a header
 _FOLD_THRESHOLD_LINES = 30  # B3: agent replies above this fold inline
+# RichLog ring-buffer size. Bumped from the historical 5000 → 20000 to push
+# the truncation boundary well past realistic session lengths (~400-800
+# turns at typical reply sizes). Storage stays modest at average line width;
+# turn anchors below are drop-aware so even pathological sessions that DO
+# cross the boundary don't break Ctrl+P/N navigation.
+_RICHLOG_MAX_LINES = 20_000
 
 
 def _msg_header(label: str, name_style: str, dash_style: str) -> Text:
@@ -147,8 +153,17 @@ class ConversationView(Widget):
         self._last_speaker_at: float = 0.0
         # Empty-state (B5)
         self._has_first_message = False
-        # Turn navigation (B4) — log line indexes where each agent turn begins
+        # Turn navigation (B4) — absolute line positions for each turn header.
+        # "Absolute" = ``log._start_line + len(log.lines)`` at write time, NOT
+        # the bare ``len(log.lines)`` value. RichLog uses a ring buffer; once
+        # the session crosses _RICHLOG_MAX_LINES, ``log._start_line`` grows
+        # and ``log.lines`` shifts. Bare-index anchors silently rot the moment
+        # the first line is dropped; absolute positions stay stable and we
+        # convert back to the current ``log.lines`` index on read.
         self._turn_anchors: list[int] = []
+        # One-shot flag so the "earlier history trimmed" warning fires at most
+        # once per session (= the first time Ctrl+P/N is used after trim).
+        self._trim_warned = False
         # B3 — full text of the last truncated agent reply (or None when the
         # most recent reply fit within _FOLD_THRESHOLD_LINES).
         self._last_long_reply: str | None = None
@@ -164,7 +179,8 @@ class ConversationView(Widget):
     # ── composition ──────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
-        yield RichLog(highlight=False, markup=False, wrap=True, max_lines=5000, id="log")
+        yield RichLog(highlight=False, markup=False, wrap=True,
+                      max_lines=_RICHLOG_MAX_LINES, id="log")
         # B5: empty-state hint, removed on first message
         yield Static(
             "  Type [bold]/[/] for commands  ·  [bold]Ctrl+B[/] panel  ·  "
@@ -212,7 +228,7 @@ class ConversationView(Widget):
             # results. Ctrl+P / Ctrl+N then walk through every header in
             # order, which matches the user's mental model of "jump to
             # the previous turn" better than "jump only to agent replies".
-            self._turn_anchors.append(len(log.lines))
+            self._turn_anchors.append(self._absolute_line_position(log))
             # Cap to last 200 to avoid unbounded growth (long sessions)
             if len(self._turn_anchors) > 200:
                 self._turn_anchors = self._turn_anchors[-200:]
@@ -567,14 +583,65 @@ class ConversationView(Widget):
         """Scroll the log to the next agent turn anchor."""
         self._jump_to_relative_anchor(+1)
 
+    @staticmethod
+    def _absolute_line_position(log: RichLog) -> int:
+        """Return the absolute write-position (drop-aware) for the next line.
+
+        ``log._start_line`` is RichLog's cumulative dropped-lines counter
+        (private but stable). Combined with ``len(log.lines)``, it yields
+        a monotonic absolute index that survives the ring-buffer trim —
+        unlike the bare ``len(log.lines)`` value, which silently rebases
+        the moment ``max_lines`` is exceeded.
+        """
+        return getattr(log, "_start_line", 0) + len(log.lines)
+
+    def _resolve_anchors_to_current_view(self, log: RichLog) -> list[int]:
+        """Project stored absolute anchors back into current ``log.lines`` indexes.
+
+        Anchors whose target line has been trimmed (= ``absolute - start < 0``)
+        are silently dropped: jumping to a turn that no longer exists in the
+        log would scroll to whatever line happens to occupy that slot now,
+        which is exactly the bug the bare-index version exhibited.
+        """
+        start = getattr(log, "_start_line", 0)
+        return [a - start for a in self._turn_anchors if a - start >= 0]
+
+    def _maybe_warn_about_trimmed_history(self, log: RichLog) -> None:
+        """Surface a one-shot dim status when older history has been trimmed.
+
+        We only fire once per session — repeated Ctrl+P presses past the
+        top would otherwise spam the sticky status with the same message.
+        ``/clear`` resets the flag so a fresh session can warn again.
+        """
+        if self._trim_warned:
+            return
+        start = getattr(log, "_start_line", 0)
+        if start <= 0:
+            return
+        self._trim_warned = True
+        sticky = self._sticky()
+        if sticky is not None:
+            try:
+                sticky.show(
+                    f"↑ earlier history trimmed ({start:,} lines)",
+                    kind="general",
+                )
+            except Exception:
+                pass
+
     def _jump_to_relative_anchor(self, delta: int) -> None:
         if not self._turn_anchors:
             return
         log = self._log()
+        anchors = self._resolve_anchors_to_current_view(log)
+        if not anchors:
+            self._maybe_warn_about_trimmed_history(log)
+            return
+        # If the trim swallowed some anchors, surface that to the user.
+        if len(anchors) < len(self._turn_anchors):
+            self._maybe_warn_about_trimmed_history(log)
         # Find the nearest anchor >= or <= current scroll y
         cur_y = log.scroll_y
-        # Pick the most recent one before/after cur_y
-        anchors = self._turn_anchors
         if delta < 0:
             target = None
             for a in reversed(anchors):
@@ -610,6 +677,7 @@ class ConversationView(Widget):
         self._last_speaker = ""
         self._last_speaker_at = 0.0
         self._turn_anchors.clear()
+        self._trim_warned = False
         self._last_long_reply = None
         # Hide sticky status
         self.hide_status()

--- a/tests/cli/test_turn_anchors_survive_trim.py
+++ b/tests/cli/test_turn_anchors_survive_trim.py
@@ -1,0 +1,176 @@
+"""Tier 2: turn-nav anchors survive RichLog ring-buffer truncation.
+
+Before this fix ``_turn_anchors`` stored bare ``len(log.lines)`` values
+at write time. RichLog uses a ring buffer; the moment a session crosses
+``max_lines`` the buffer trims the oldest lines and rebases
+``log.lines``. Stored anchors silently rotted — Ctrl+P/N would land on
+whatever line happened to occupy the original slot, not the actual
+turn header.
+
+The fix stores absolute write-positions
+(``log._start_line + len(log.lines)``) and projects them back to current
+``log.lines`` indexes on read, dropping anchors whose targets have been
+trimmed. This test pins:
+  1. Anchors written before trim survive a forced ring-buffer trim
+  2. Anchors whose target was trimmed are silently filtered (= jump
+     still works, picks the nearest surviving anchor)
+  3. ``/clear`` resets the trim-warning latch so subsequent trims warn again
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.text import Text
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _force_trim(log: RichLog, lines_to_drop: int) -> None:
+    """Force RichLog to behave as if ``lines_to_drop`` lines have been trimmed.
+
+    The unit tests don't actually write 20,000+ lines into the log; they
+    just nudge the public-effect of trim — ``_start_line`` going up while
+    ``log.lines`` stays trimmed — by writing a few lines and then mutating
+    ``_start_line`` directly. RichLog reads ``_start_line`` to compute
+    drops, so this mirrors what happens organically at scale.
+    """
+    # Ensure there are some lines first
+    for i in range(5):
+        log.write(Text(f"baseline line {i}"))
+    # Simulate that ``lines_to_drop`` older lines have already been ring-buffered out
+    log._start_line = lines_to_drop
+
+
+@pytest.mark.asyncio
+async def test_anchor_survives_partial_trim_and_projects_correctly() -> None:
+    """An anchor whose line is still in the buffer after partial trim resolves correctly.
+
+    Sets up an anchor at a high absolute position (after baseline content
+    is in the log), then simulates a partial trim that removes some earlier
+    lines but leaves the anchor's target within the live buffer. The
+    anchor must project to ``absolute - start_line``.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # Lay down baseline content so the header anchor lands at a non-zero
+        # absolute position.
+        for i in range(20):
+            log.write(Text(f"baseline {i}"))
+        await pilot.pause()
+
+        # Now record a header anchor.
+        conv._maybe_write_header("user", "you ", "bold", "dim")
+        await pilot.pause()
+        assert len(conv._turn_anchors) == 1
+        anchor_abs = conv._turn_anchors[0]
+        assert anchor_abs >= 20, f"expected anchor past baseline, got {anchor_abs}"
+
+        # Simulate a trim that pushes _start_line up by less than the anchor.
+        log._start_line += 5
+
+        # Stored anchor stays constant (= absolute storage).
+        assert conv._turn_anchors[0] == anchor_abs
+
+        # Projection subtracts the trim offset.
+        resolved = conv._resolve_anchors_to_current_view(log)
+        assert resolved == [anchor_abs - 5], (
+            f"projection wrong after partial trim; got {resolved}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_anchor_dropped_when_target_trimmed() -> None:
+    """An anchor whose line was trimmed out of the buffer is filtered."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # Write a header at absolute position N.
+        conv._maybe_write_header("user", "you ", "bold", "dim")
+        await pilot.pause()
+        anchor = conv._turn_anchors[0]
+
+        # Trim past the anchor — its target line has been ring-buffered out.
+        log._start_line = anchor + 10
+
+        resolved = conv._resolve_anchors_to_current_view(log)
+        assert resolved == [], (
+            f"trimmed anchor must be filtered; got {resolved}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_jump_no_crash_when_all_anchors_trimmed() -> None:
+    """Ctrl+P/N with every anchor trimmed must not raise (only warn)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._maybe_write_header("user", "you ", "bold", "dim")
+        conv._maybe_write_header("reyn", "reyn", "bold", "dim")
+        await pilot.pause()
+        # Force trim to push every anchor out of range
+        log._start_line = 999_999
+
+        # Must not raise
+        conv.jump_prev_turn()
+        conv.jump_next_turn()
+        await pilot.pause()
+        # And the one-shot warning latched
+        assert conv._trim_warned
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_trim_warn_latch() -> None:
+    """``/clear`` (or Ctrl+L) lets the trim warning fire again next session."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        conv._maybe_write_header("user", "you ", "bold", "dim")
+        await pilot.pause()
+        log._start_line = 999_999
+        conv.jump_prev_turn()
+        assert conv._trim_warned
+
+        conv.clear()
+        assert not conv._trim_warned, "clear() must reset the trim-warned latch"
+
+
+@pytest.mark.asyncio
+async def test_richlog_max_lines_is_at_least_20000() -> None:
+    """Pin the bumped buffer size — guards against accidental regression to 5000."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        log = app.query_one("#log", RichLog)
+        assert log.max_lines is not None and log.max_lines >= 20_000, (
+            f"RichLog max_lines should be ≥ 20000, got {log.max_lines}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Two coupled HIGH-severity findings from the long-session UX exploration pass: ``_turn_anchors`` storing bare ``len(log.lines)`` values silently rotted the moment RichLog's ring buffer trimmed any older lines, AND there was no on-screen indicator that trimming had happened. Together they meant a 500-turn dogfood session navigated to blank space or the wrong reply when the user hit Ctrl+P.

### What changed

- **Anchors are now absolute write-positions** (``log._start_line + len(log.lines)``) rather than the relative ``len(log.lines)`` slot. ``log._start_line`` is RichLog's cumulative dropped-lines counter — private but stable.
- ``_resolve_anchors_to_current_view`` projects stored anchors back to current ``log.lines`` indexes on read. Anchors whose targets have been trimmed are silently filtered, so a jump never lands on the wrong row.
- ``RichLog.max_lines`` bumped from 5000 → 20000 to push the trim boundary well past realistic session lengths (~400–800 turns at typical reply sizes). Storage stays modest (~2 MB at average line width).
- One-shot dim ``↑ earlier history trimmed (N lines)`` sticky status fires the first time Ctrl+P/N is used after the buffer has trimmed, so users with pathologically long sessions can see WHY some turn anchors are no longer reachable. ``/clear`` resets the latch.

### Why

- **Scl F1** (HIGH): RichLog truncates oldest lines with no on-screen indicator; users lost earlier history without warning.
- **Scl F3** (HIGH): ``_turn_anchors`` stored absolute line indexes that became wrong after truncation; Ctrl+P/N jumped to wrong turns.

Both share a root cause (no truncation-awareness in ConversationView) and the fix touches a single file, so I'm landing them together.

## Test plan

- [x] ``pytest tests/cli/test_turn_anchors_survive_trim.py`` — 5 passed (new Tier 2 invariants)
- [x] ``pytest tests/cli/`` — 43 passed (no regression in existing TUI smoke / cost-suffix / fold-stash sibling tests)
- [x] Manual reasoning: ``_start_line`` is the same attribute Textual reads internally (RichLog.write at site of truncation increments it), so coupling to it is no more fragile than any other read of Textual private state already in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)