### PR TITLE
fix(tui): conv-pane RichLog must not steal focus from input bar

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -164,7 +164,17 @@ class ConversationView(Widget):
     # ── composition ──────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
-        yield RichLog(highlight=False, markup=False, wrap=True, max_lines=5000, id="log")
+        # ``can_focus = False`` is the load-bearing piece: RichLog inherits
+        # ``can_focus = True`` from ScrollView, so a stray click on the conv
+        # pane (or Shift+Tab from the input bar) silently shifts focus here.
+        # The log is append-only and accepts no typed input, so the user then
+        # types into nothing until they click the input bar again. Ctrl+P/N
+        # turn-nav already calls ``log.scroll_to`` without needing focus, so
+        # disabling focus loses no real capability.
+        log = RichLog(highlight=False, markup=False, wrap=True,
+                      max_lines=5000, id="log")
+        log.can_focus = False
+        yield log
         # B5: empty-state hint, removed on first message
         yield Static(
             "  Type [bold]/[/] for commands  ·  [bold]Ctrl+B[/] panel  ·  "

--- a/tests/cli/test_richlog_no_focus_steal.py
+++ b/tests/cli/test_richlog_no_focus_steal.py
@@ -1,0 +1,131 @@
+"""Tier 2: conv-pane RichLog does not steal focus from the input bar.
+
+RichLog inherits ``can_focus = True`` from Textual's ``ScrollView``, so
+the default behaviour is to gain focus on click (or via Shift+Tab from
+the input bar). Once that happens the log absorbs no typed input — the
+user types their next message into a dead widget. This bug was visible
+in two separate paths in the UX audit:
+
+  • Mouse click on a previous reply silently kills typing.
+  • Shift+Tab from the input bar lands in RichLog, silently kills typing.
+
+The fix sets ``can_focus = False`` on the RichLog instance. Turn
+navigation (Ctrl+P/N) calls ``log.scroll_to`` without needing focus, so
+disabling focus loses no real capability. Both bug paths reduce to
+"focus stays on InputBar after the action".
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog, TextArea
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView, InputBar
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_conv_richlog_is_not_focusable() -> None:
+    """The conv-pane RichLog must declare ``can_focus = False``.
+
+    Pinned at the instance level (not the class level — the right-panel
+    preview RichLog stays focusable for j/k scrolling).
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one("#log", RichLog)
+        assert log.can_focus is False, (
+            f"conv RichLog must not be focusable; got can_focus={log.can_focus}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clicking_conv_pane_does_not_steal_focus_from_input() -> None:
+    """Mouse click on the conv pane keeps focus on the input TextArea."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        # Confirm starting state: TextArea has focus
+        ta = app.query_one("#input", TextArea)
+        assert app.focused is ta, (
+            f"input area should have initial focus; got {app.focused}"
+        )
+
+        # Simulate click on the conv pane
+        await pilot.click("#conversation")
+        await pilot.pause()
+
+        # Focus must NOT have moved into the RichLog
+        log = app.query_one("#log", RichLog)
+        assert app.focused is not log, (
+            "RichLog stole focus on click — this is the bug the fix addresses"
+        )
+
+
+@pytest.mark.asyncio
+async def test_shift_tab_from_input_does_not_land_in_richlog() -> None:
+    """Shift+Tab from the input bar must not focus the conv RichLog.
+
+    With ``can_focus = False``, Textual's DOM walker skips the RichLog and
+    either wraps around or lands on the next focusable peer. Either way
+    the user's typing remains routable.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click("#input")
+        await pilot.press("shift+tab")
+        await pilot.pause()
+
+        log = app.query_one("#log", RichLog)
+        assert app.focused is not log, (
+            f"Shift+Tab landed on RichLog; got focus on {app.focused}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ctrl_p_turn_nav_still_scrolls_without_focus() -> None:
+    """Ctrl+P/N turn-nav must continue to work even though RichLog can't focus.
+
+    Defensive check: the existing nav path uses ``log.scroll_to`` which
+    operates on the widget directly rather than via the focused widget,
+    so disabling focus is invisible to the nav. Pins this so a future
+    refactor of the nav doesn't reintroduce a focus dependency.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Lay down two turn headers so anchors exist
+        conv._maybe_write_header("user", "you ", "bold", "dim")
+        conv._maybe_write_header("reyn", "reyn", "bold", "dim")
+        await pilot.pause()
+        assert len(conv._turn_anchors) >= 1
+
+        # jump_prev_turn must not raise even without RichLog focus
+        conv.jump_prev_turn()
+        conv.jump_next_turn()
+        await pilot.pause()
+        # Focus stays on the input area
+        ta = app.query_one("#input", TextArea)
+        assert app.focused is ta or app.focused is None, (
+            f"focus should not have leaked off the input; got {app.focused}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Two HIGH-severity UX audit findings collapse to a single root cause: the conv-pane RichLog inherits ``can_focus = True`` from Textual's ScrollView, so it silently gains focus on click or via Shift+Tab from the input bar. Once that happens the log absorbs no typed input — the user's next keystroke goes nowhere until they click the input bar again.

- **Mouse F2 (HIGH)** Clicking on a previous reply to read/select silently kills typing.
- **Focus F1 (HIGH)** Shift+Tab from the input bar lands on the RichLog, silently killing typing.

The fix is one line of behaviour: set ``can_focus = False`` on the RichLog instance. Turn navigation (Ctrl+P/N) calls ``log.scroll_to`` directly without relying on the focused widget, so disabling focus loses no real capability. The right-panel preview RichLog stays focusable for j/k scrolling — only the conv-pane log is affected.

## Why

Both findings come from the same instance attribute. Fixing them separately would duplicate the regression test and risk one path being fixed while the other regresses.

## Test plan

- [x] ``pytest tests/cli/test_richlog_no_focus_steal.py`` — 4 passed (new Tier 2 invariants):
  1. Conv RichLog declares ``can_focus = False`` at the instance level
  2. Clicking the conv pane does NOT move focus off the input area
  3. Shift+Tab from the input bar does NOT land on the RichLog
  4. Ctrl+P/N turn-nav still scrolls without RichLog focus
- [x] ``pytest tests/cli/`` — 42 passed (no regression in existing TUI smoke / cost-suffix tests)
- [x] Code review: instance-level override (``log.can_focus = False`` after construction) leaves the class default intact, so the right-panel preview RichLog stays focusable. Verified via ``inspect`` that Textual ``RichLog.__init__`` does not accept ``can_focus`` as a kwarg, so the post-construction set is the correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)