### PR TITLE
fix(tui): align turn-header dash rule by terminal cell width

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import time
 
+from rich.cells import cell_len
 from rich.markdown import Markdown as RichMarkdown
 from rich.text import Text
 from textual.app import ComposeResult
@@ -56,17 +57,43 @@ from .streaming_row import StreamingRow
 _DASH_TOTAL = 38  # matches the banner separator width
 _GROUP_WINDOW_S = 60.0  # consecutive turns within this window share a header
 _FOLD_THRESHOLD_LINES = 30  # B3: agent replies above this fold inline
+_NAME_COL_COLS = 4  # display-cell width reserved for the speaker label column
+
+
+def _pad_to_cells(s: str, target_cells: int) -> str:
+    """Right-pad ``s`` with spaces so its terminal column width >= target.
+
+    ``str.ljust`` counts code points, but terminal columns count display
+    cells — a CJK character (or full-width punctuation, or an emoji)
+    occupies 2 columns per glyph. Using ``ljust(4)`` on an agent name
+    like ``"アリア"`` leaves it at 6 cells when the next column expects
+    a fixed 4-cell offset, breaking the dash-rule alignment between
+    user (``"you "``) and agent headers.
+
+    Returns ``s`` unchanged when it already meets or exceeds the target;
+    truncation would split a wide glyph and is left to the caller.
+    """
+    width = cell_len(s)
+    if width >= target_cells:
+        return s
+    return s + " " * (target_cells - width)
 
 
 def _msg_header(label: str, name_style: str, dash_style: str) -> Text:
-    """Timestamp + label + dash rule for a new message turn."""
+    """Timestamp + label + dash rule for a new message turn.
+
+    Column layout: ``HH:MM`` (5) + 2 spaces + label (>=4 cells) + 1 space +
+    dashes. The dash count flexes with the actual cell width of ``label``
+    so wide-character agent names don't push the line past _DASH_TOTAL.
+    """
     t = Text()
     t.append(time.strftime("%H:%M"), style="dim #666666")
     t.append("  ")
-    padded = label.ljust(4)  # "you " / "reyn" — fixed 4-char column
+    padded = _pad_to_cells(label, _NAME_COL_COLS)
+    name_cells = cell_len(padded)
     t.append(padded, style=name_style)
     t.append(" ")
-    dashes = max(1, _DASH_TOTAL - 5 - 2 - 4 - 1)  # = 26
+    dashes = max(1, _DASH_TOTAL - 5 - 2 - name_cells - 1)
     t.append("─" * dashes, style=dash_style)
     return t
 

--- a/tests/cli/test_msg_header_cell_align.py
+++ b/tests/cli/test_msg_header_cell_align.py
@@ -1,0 +1,139 @@
+"""Tier 1: ``_msg_header`` aligns the dash rule by terminal cell width.
+
+Before this fix the header used ``label.ljust(4)`` to reserve a fixed
+4-character name column, then a hardcoded 26-dash rule sized off that
+same constant. ``ljust`` counts Python code points, but terminal columns
+count display cells — a CJK character (or full-width punctuation, or an
+emoji) is 2 cells per glyph. An agent named ``"アリア"`` (3 code points,
+6 cells) blew past the 4-cell column and pushed the dash rule out past
+the banner width, breaking visual alignment between user and agent
+turns.
+
+The fix pads to a target *cell* count via ``rich.cells.cell_len`` and
+flexes the dash count off the actual cell width of the label.
+"""
+from __future__ import annotations
+
+import pytest
+from rich.cells import cell_len
+
+from reyn.chat.tui.widgets.conversation import (
+    _DASH_TOTAL,
+    _NAME_COL_COLS,
+    _msg_header,
+    _pad_to_cells,
+)
+
+
+# ── _pad_to_cells ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "label, target, expected_cells",
+    [
+        ("reyn", 4, 4),           # exactly fits
+        ("you", 4, 4),            # narrow ASCII, pad by 1
+        ("you ", 4, 4),           # already padded, untouched
+        ("a", 4, 4),              # heavy padding
+        ("アリア", 4, 6),         # 3 CJK glyphs = 6 cells > 4, no truncation
+        ("日本", 4, 4),           # 2 CJK glyphs = 4 cells exactly
+        ("", 4, 4),               # empty string padded to target
+    ],
+)
+def test_pad_to_cells_yields_at_least_target(label: str, target: int, expected_cells: int) -> None:
+    """Tier 1: padded string's cell width meets or exceeds the target."""
+    out = _pad_to_cells(label, target)
+    assert cell_len(out) == expected_cells, (
+        f"pad({label!r}, {target}) → {out!r} has {cell_len(out)} cells, expected {expected_cells}"
+    )
+
+
+def test_pad_to_cells_does_not_truncate_wide_strings() -> None:
+    """Tier 1: when input exceeds the target, return verbatim (no slice)."""
+    label = "アリア"  # 6 cells
+    out = _pad_to_cells(label, 4)
+    assert out == label
+
+
+# ── _msg_header ───────────────────────────────────────────────────────────────
+
+
+def _header_plain_text(label: str) -> str:
+    """Return the plain-text projection of a rendered header."""
+    return _msg_header(label, "bold", "dim").plain
+
+
+def test_narrow_label_dash_count_unchanged() -> None:
+    """Tier 1: existing 4-cell labels keep their historical 26-dash rule.
+
+    Guards the fix from accidentally changing the visual length for the
+    99% case (``"reyn"`` and ``"you "`` agents).
+    """
+    text = _header_plain_text("reyn")
+    # Layout: 'HH:MM' (5) + '  ' (2) + 'reyn' (4) + ' ' (1) + dashes
+    # _DASH_TOTAL = 38 → dashes = 38 - 5 - 2 - 4 - 1 = 26
+    assert text.count("─") == 26
+
+
+def test_short_label_padded_then_dashed_same_count() -> None:
+    """Tier 1: ``"you"`` (3 cells) is padded to 4 cells, dashes still 26."""
+    text = _header_plain_text("you")
+    assert text.count("─") == 26
+    # The padded column ends just before the dash run — find the cell width
+    # from start of the line through the space before dashes.
+    pre_dash = text.split("─", 1)[0]
+    assert cell_len(pre_dash) == 5 + 2 + 4 + 1  # HH:MM + 2sp + 4cells + 1sp
+
+
+def test_wide_cjk_label_shrinks_dash_count_to_stay_within_dash_total() -> None:
+    """Tier 1: ``"アリア"`` (6 cells) shrinks the dash count so the whole
+    line stays at or under _DASH_TOTAL cells.
+
+    Without the fix the line would have been longer than _DASH_TOTAL and
+    overrun the banner width.
+    """
+    text = _header_plain_text("アリア")
+    # name_cells = 6 → dashes = 38 - 5 - 2 - 6 - 1 = 24
+    assert text.count("─") == 24
+    # Total line cells must not exceed _DASH_TOTAL
+    assert cell_len(text) <= _DASH_TOTAL
+
+
+def test_header_cell_width_consistent_across_label_types() -> None:
+    """Tier 1: every header line has the same total cell width.
+
+    This is the user-visible alignment contract: the dash rule's right
+    edge lands at the same column whether the label is "you ", "reyn",
+    or a CJK agent name.
+    """
+    widths = {
+        cell_len(_header_plain_text(label))
+        for label in ("reyn", "you ", "you", "a", "アリア", "日本", "")
+    }
+    assert len(widths) == 1, (
+        f"header cell widths diverged across labels: {widths}"
+    )
+    # And that single width is _DASH_TOTAL
+    assert widths.pop() == _DASH_TOTAL
+
+
+def test_header_dash_count_never_negative_for_outsized_labels() -> None:
+    """Tier 1: pathologically wide labels still produce at least 1 dash.
+
+    Guards the ``max(1, ...)`` floor: a 30-cell label would otherwise
+    yield a negative dash count and crash ``"─" * n`` (Python silently
+    returns "" for n<0, which would silently break alignment instead of
+    crashing — both are bad).
+    """
+    huge = "アリア" * 5  # 30 cells
+    text = _header_plain_text(huge)
+    assert text.count("─") >= 1
+
+
+def test_name_col_cols_constant_matches_legacy_layout() -> None:
+    """Tier 1: the column constant is 4 — matches the historic ``ljust(4)``.
+
+    If this constant ever moves, the layout calc in ``_msg_header`` must
+    move with it; pin the value so a stray rename doesn't desync the two.
+    """
+    assert _NAME_COL_COLS == 4


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``_msg_header`` used ``label.ljust(4)`` to reserve a fixed 4-character name column, then a hardcoded 26-dash rule sized off that same constant. ``ljust`` counts Python code points, but terminal columns count *display cells* — a CJK character (or full-width punctuation, or an emoji) is 2 cells per glyph. An agent named ``"アリア"`` (3 code points, 6 cells) overflowed the 4-cell column and pushed the dash rule past the banner width, breaking visual alignment between user (``"you "``) and agent turns.

### What changed

- Introduce ``_pad_to_cells`` that pads by terminal display cell width via ``rich.cells.cell_len`` (already a transitive dependency through Textual; no new packages).
- Flex the dash count off ``cell_len(padded)`` so the total line stays at exactly ``_DASH_TOTAL`` cells regardless of label shape: narrow ASCII pads up to 4 cells, wide CJK leaves the label untouched and trims the dash count to compensate.

### Before / After

Narrow case (unchanged):
```
14:32  reyn ──────────────────────────  ← 4 cell label + 26 dashes = _DASH_TOTAL
```

Wide case (was broken, now correct):
```
14:32  アリア ────────────────────────  ← 6 cell label + 24 dashes = _DASH_TOTAL
```

Before the fix, the wide case rendered as ``アリア ──────────────────────────`` (6 cells + 26 dashes = 40 cells), pushing the rule 2 columns past every adjacent user header's 38-cell rule.

## Why

Visual UX audit (HIGH severity Finding F2). The user header is fixed at ``"you "`` (4 cells); when the agent's display name is CJK, the two header rules misalign by an amount equal to the agent name's cell-vs-codepoint delta. Visually distracting and ugly during long sessions.

## Test plan

- [x] ``pytest tests/cli/test_msg_header_cell_align.py`` — 14 passed (new Tier 1 contract tests):
  - 7-case parametric over narrow / wide / empty inputs of ``_pad_to_cells``
  - wide-string non-truncation
  - 4-cell legacy case dash count preserved (= 26)
  - 3-cell padded case dash count preserved (= 26)
  - 6-cell CJK case dash count = 24, total line ≤ _DASH_TOTAL
  - cross-label cell-width consistency
  - pathological 30-cell label still yields ≥ 1 dash
  - ``_NAME_COL_COLS`` constant pin
- [x] ``pytest tests/cli/`` — 52 passed (no regression in existing TUI smoke / cost-suffix tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)