### PR TITLE
feat(tui): /copy can target older replies via bounded ring buffer

### DIFF
--- a/src/reyn/chat/slash/copy.py
+++ b/src/reyn/chat/slash/copy.py
@@ -1,17 +1,25 @@
-"""/copy — copy the last agent reply to the system clipboard.
+"""/copy — copy an agent reply to the system clipboard.
 
 The TUI captures mouse events for its own widget interactions, which breaks
 terminal-native click-and-drag selection. Most terminals offer a modifier-
 key bypass (Option/Fn/Shift drag) but that's an awkward two-handed gesture
-when you just want to grab the last response.
+when you just want to grab a response.
 
-This command sends a sentinel ``__copy_last_reply__`` OutboxMessage; the TUI
-app intercepts it, fetches ``ConversationView.last_reply_text()``, and pipes
-the text to the platform clipboard (`pbcopy` / `xclip` / `wl-copy` / `clip`).
+ConversationView keeps a bounded ring of the most recent agent replies, so
+this command can target older ones too — not just the latest. The argument
+selects which reply (1 = newest, 2 = one before that, …).
+
+This command sends a sentinel ``__copy_last_reply__`` OutboxMessage with the
+parsed argument in ``text``; the TUI app intercepts it, fetches the right
+reply via ``ConversationView.reply_at(n)``, and pipes to the platform
+clipboard (``pbcopy`` / ``xclip`` / ``wl-copy`` / ``clip``).
 
 Usage::
 
     /copy            # copy the most recent agent reply
+    /copy 2          # copy the reply before that (one turn back)
+    /copy 3          # ... two turns back
+    /copy list       # show what's currently buffered
 """
 from __future__ import annotations
 
@@ -19,6 +27,10 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.chat.slash import slash
 
 
-@slash("copy", summary="Copy the last agent reply to the system clipboard")
+@slash("copy", summary="Copy an agent reply to the clipboard (/copy [N] or /copy list)")
 async def copy_cmd(session: "object", args: str) -> None:
-    await session._put_outbox(OutboxMessage(kind="__copy_last_reply__", text=""))
+    # Forward the raw arg; the TUI handler validates and surfaces errors so
+    # we don't duplicate the parsing logic across the slash + outbox layers.
+    await session._put_outbox(OutboxMessage(
+        kind="__copy_last_reply__", text=(args or "").strip(),
+    ))

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -187,23 +187,75 @@ class OutboxRouter:
     def _on_copy_last_reply(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
     ) -> None:
-        """`__copy_last_reply__` — /copy slash; pipe last reply to OS clipboard.
+        """`__copy_last_reply__` — /copy slash; pipe a buffered reply to OS clipboard.
+
+        ``msg.text`` carries the parsed slash argument:
+          - empty           → copy the latest reply (= ``reply_at(1)``)
+          - ``"list"``      → show how many replies are buffered + dim hint
+          - integer N >= 1  → copy ``reply_at(N)`` (N = 1 is newest)
+          - anything else   → surface a usage hint and stop
 
         Workaround for the TUI's mouse-capture preventing native click-and-
         drag selection. Tries platform-native binaries in order; if none
         succeed, surfaces a status line so the user knows the workaround
         wasn't available.
         """
-        text = conv.last_reply_text()
-        if not text:
-            conv.show_status("nothing to copy yet", kind="general")
-            self._app.set_timer(2.0, conv.hide_status)
+        arg = (msg.text or "").strip()
+
+        if arg.lower() == "list":
+            count = conv.recent_reply_count()
+            if count == 0:
+                conv.show_status("no replies buffered yet", kind="general")
+            else:
+                conv.show_status(
+                    f"{count} reply{'s' if count != 1 else ''} buffered "
+                    f"— /copy 1..{count}",
+                    kind="general",
+                )
+            self._app.set_timer(2.5, conv.hide_status)
             return
+
+        # Parse N. Empty → latest (n=1); digits → that index. Anything else
+        # is a typo — surface the usage hint rather than silently copying
+        # the latest, since that would mask the user's mistake.
+        if arg == "":
+            n = 1
+        elif arg.isdigit():
+            n = int(arg)
+            if n <= 0:
+                conv.show_status(
+                    "/copy index must be ≥ 1 (1 = newest)", kind="error",
+                )
+                self._app.set_timer(2.5, conv.hide_status)
+                return
+        else:
+            conv.show_status(
+                "usage: /copy [N] or /copy list", kind="error",
+            )
+            self._app.set_timer(2.5, conv.hide_status)
+            return
+
+        text = conv.reply_at(n)
+        if text is None:
+            buffered = conv.recent_reply_count()
+            if buffered == 0:
+                conv.show_status("nothing to copy yet", kind="general")
+            else:
+                conv.show_status(
+                    f"reply {n} not in buffer "
+                    f"(only {buffered} available — /copy list)",
+                    kind="error",
+                )
+            self._app.set_timer(2.5, conv.hide_status)
+            return
+
         ok, label = _copy_to_clipboard(text)
         if ok:
             n_chars = len(text)
+            tag = "latest" if n == 1 else f"#{n}"
             conv.show_status(
-                f"copied {n_chars} chars via {label}", kind="general",
+                f"copied reply {tag} ({n_chars} chars) via {label}",
+                kind="general",
             )
         else:
             conv.show_status(

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -56,6 +56,10 @@ from .streaming_row import StreamingRow
 _DASH_TOTAL = 38  # matches the banner separator width
 _GROUP_WINDOW_S = 60.0  # consecutive turns within this window share a header
 _FOLD_THRESHOLD_LINES = 30  # B3: agent replies above this fold inline
+# /copy ring-buffer depth. Far enough back that the user can grab "the
+# reply two turns ago" — the typical "wait, that one was useful" recovery
+# pattern — without growing memory unboundedly across long sessions.
+_RECENT_REPLIES_MAX = 10
 # RichLog ring-buffer size. Bumped from the historical 5000 → 20000 to push
 # the truncation boundary well past realistic session lengths (~400-800
 # turns at typical reply sizes). Storage stays modest at average line width;
@@ -167,10 +171,14 @@ class ConversationView(Widget):
         # B3 — full text of the last truncated agent reply (or None when the
         # most recent reply fit within _FOLD_THRESHOLD_LINES).
         self._last_long_reply: str | None = None
-        # Full text of the most recent agent reply (any length). Consumed by
-        # the /copy slash command so users don't have to fight the TUI's
-        # mouse-capture to grab text out of the log.
-        self._last_reply_full: str | None = None
+        # Recent agent replies (newest last), capped at ``_RECENT_REPLIES_MAX``.
+        # Consumed by the /copy slash command — users can grab the latest reply
+        # (``/copy``) or any of the last N (``/copy 2``, ``/copy 3``, …) without
+        # fighting the TUI's mouse-capture to drag-select text out of the log.
+        # Single-slot storage silently lost every prior reply on each new turn;
+        # a bounded ring keeps the immediate history reachable without growing
+        # memory unboundedly across long sessions.
+        self._recent_replies: list[str] = []
         # Track whether user has scrolled up (suppress auto-scroll while scrolled)
         self._user_scrolled = False
         # Issue 5 — track mounted ErrorBoxes for Escape-to-dismiss
@@ -349,12 +357,14 @@ class ConversationView(Widget):
         self._last_long_reply so expand_last_reply() can flush the rest.
         Replies that fit are rendered as-is and clear any pending fold.
 
-        Side effect: stores ``text`` in ``self._last_reply_full`` so the
-        /copy slash command can hand it to the system clipboard (no need
-        to fight TUI mouse-capture for selection).
+        Side effect: appends ``text`` to ``self._recent_replies`` (capped
+        at ``_RECENT_REPLIES_MAX``) so the /copy slash command can hand
+        any of the last N replies to the system clipboard.
         """
         # Always remember the full text — independent of fold thresholds.
-        self._last_reply_full = text
+        self._recent_replies.append(text)
+        if len(self._recent_replies) > _RECENT_REPLIES_MAX:
+            self._recent_replies = self._recent_replies[-_RECENT_REPLIES_MAX:]
         log = self._log()
         # Detect that a prior fold is about to be invalidated. The single-slot
         # ``_last_long_reply`` is replaced (or cleared) by every new agent
@@ -424,7 +434,22 @@ class ConversationView(Widget):
         Used by the /copy slash command. Returns None when there has been no
         agent reply in this session yet.
         """
-        return self._last_reply_full
+        return self._recent_replies[-1] if self._recent_replies else None
+
+    def reply_at(self, n: int) -> str | None:
+        """Return the n-th most recent agent reply (1-indexed; n=1 is latest).
+
+        Returns None when ``n`` is out of range (≤ 0 or beyond the buffered
+        history). The /copy slash uses this to surface older replies that the
+        single-slot predecessor silently lost on every new turn.
+        """
+        if n <= 0 or n > len(self._recent_replies):
+            return None
+        return self._recent_replies[-n]
+
+    def recent_reply_count(self) -> int:
+        """Number of agent replies currently held in the /copy ring buffer."""
+        return len(self._recent_replies)
 
     def _write_log(self, text: Text) -> None:
         log = self._log()

--- a/tests/cli/test_copy_reply_ring_buffer.py
+++ b/tests/cli/test_copy_reply_ring_buffer.py
@@ -1,0 +1,142 @@
+"""Tier 2: /copy ring buffer holds the last N agent replies addressable by index.
+
+Before this fix ``ConversationView`` stored only the latest agent reply
+in a single slot, so users who wanted to grab the reply from one turn
+ago had no path — drag-select is blocked by Textual mouse-capture and
+``/copy`` always returned the most recent text. This pins the new
+contract:
+
+  1. ``_recent_replies`` is a bounded ring (≤ ``_RECENT_REPLIES_MAX``).
+  2. ``last_reply_text()`` still returns the newest reply (backwards compat
+     for the existing TUI handler and any external consumers).
+  3. ``reply_at(n)`` is 1-indexed: n=1 = newest, n=2 = one before, etc.
+  4. ``reply_at(n)`` returns None for out-of-range (≤ 0 or beyond buffered).
+  5. ``recent_reply_count()`` is the buffer depth.
+
+Plus end-to-end smoke that the slash command routes the optional index
+arg through the outbox sentinel to the TUI handler.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.conversation import _RECENT_REPLIES_MAX
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ring_starts_empty() -> None:
+    """No replies yet → accessors return None / 0."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        assert conv.last_reply_text() is None
+        assert conv.reply_at(1) is None
+        assert conv.recent_reply_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_recent_replies_addressable_by_one_indexed_recency() -> None:
+    """Three replies → reply_at(1) newest, reply_at(2) second-newest, …."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv._write_agent_markdown_with_fold("reply A")
+        conv._write_agent_markdown_with_fold("reply B")
+        conv._write_agent_markdown_with_fold("reply C")
+        await pilot.pause()
+
+        assert conv.recent_reply_count() == 3
+        assert conv.last_reply_text() == "reply C"
+        assert conv.reply_at(1) == "reply C"
+        assert conv.reply_at(2) == "reply B"
+        assert conv.reply_at(3) == "reply A"
+        # Out-of-range
+        assert conv.reply_at(4) is None
+        assert conv.reply_at(0) is None
+        assert conv.reply_at(-1) is None
+
+
+@pytest.mark.asyncio
+async def test_ring_caps_at_max_drops_oldest() -> None:
+    """Replies past ``_RECENT_REPLIES_MAX`` push the oldest out."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Push 5 more than the cap.
+        for i in range(_RECENT_REPLIES_MAX + 5):
+            conv._write_agent_markdown_with_fold(f"reply {i}")
+        await pilot.pause()
+
+        assert conv.recent_reply_count() == _RECENT_REPLIES_MAX
+        # The newest survives; the oldest 5 are gone.
+        assert conv.reply_at(1) == f"reply {_RECENT_REPLIES_MAX + 4}"
+        assert conv.reply_at(_RECENT_REPLIES_MAX) == "reply 5"
+        # Stuff that fell off
+        assert conv.reply_at(_RECENT_REPLIES_MAX + 1) is None
+
+
+@pytest.mark.asyncio
+async def test_last_reply_text_returns_newest_for_back_compat() -> None:
+    """Backwards-compat: ``last_reply_text()`` is still the newest reply.
+
+    External consumers (existing TUI handler, future slash commands)
+    must keep working without a per-call N argument when they just want
+    "the most recent thing".
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv._write_agent_markdown_with_fold("first")
+        conv._write_agent_markdown_with_fold("second")
+        await pilot.pause()
+        assert conv.last_reply_text() == "second"
+
+
+def test_slash_copy_forwards_arg_to_outbox_sentinel() -> None:
+    """Tier 1: ``/copy 2`` produces an outbox sentinel carrying ``"2"`` in ``text``.
+
+    Decouples the slash layer from the parsing logic that lives in the
+    outbox handler — slash just forwards the trimmed arg.
+    """
+    import asyncio
+
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.slash.copy import copy_cmd
+
+    sent: list[OutboxMessage] = []
+
+    class _FakeSession:
+        async def _put_outbox(self, msg: OutboxMessage) -> None:
+            sent.append(msg)
+
+    asyncio.run(copy_cmd(_FakeSession(), "  2  "))
+    asyncio.run(copy_cmd(_FakeSession(), "list"))
+    asyncio.run(copy_cmd(_FakeSession(), ""))
+
+    assert len(sent) == 3
+    assert all(m.kind == "__copy_last_reply__" for m in sent)
+    assert sent[0].text == "2"        # whitespace trimmed
+    assert sent[1].text == "list"
+    assert sent[2].text == ""         # empty → handler picks "latest"


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``/copy`` used to grab only the most recent agent reply because ``ConversationView`` stored that text in a single slot — overwritten on every new turn. Users who realised a reply two turns ago was useful had no path to retrieve it: drag-select is blocked by Textual's mouse capture and ``/copy`` always pointed at the newest text.

Switch the storage to a bounded ring (``_recent_replies``, capped at ``_RECENT_REPLIES_MAX = 10``) and extend ``/copy`` with an optional argument:

| Command | Effect |
| --- | --- |
| ``/copy`` | copy the most recent reply (existing behaviour) |
| ``/copy 2`` | copy the reply before that (one turn back) |
| ``/copy 3`` | ... two turns back, up to the buffer depth |
| ``/copy list`` | show how many replies are buffered |

### Why

Mouse-interaction UX audit (HIGH severity Finding F1). The single-slot design silently lost every prior reply on each turn, with no way to recover unless the user happened to type ``/copy`` immediately. The ring buffer keeps the realistic recovery window reachable while bounding memory.

### Public surface on ``ConversationView``

- ``last_reply_text()`` — newest (backwards-compat for the existing TUI handler / future external consumers)
- ``reply_at(n)`` — 1-indexed by recency; returns None if out of range
- ``recent_reply_count()`` — current buffer depth

Slash command forwards the trimmed arg verbatim through the existing ``__copy_last_reply__`` sentinel; the TUI handler validates / parses / surfaces usage hints so the slash layer stays decoupled from the parsing logic. Typos surface as an inline error rather than silently copying the latest reply (which would mask the mistake).

## Test plan

- [x] ``pytest tests/cli/test_copy_reply_ring_buffer.py`` — 5 passed (new Tier 1 + Tier 2 invariants):
  - empty ring → all accessors return None / 0
  - 3 replies → ``reply_at(1..3)`` hits the right text; out-of-range = None
  - buffer caps at ``_RECENT_REPLIES_MAX``, drops oldest
  - ``last_reply_text()`` still returns newest (backwards compat)
  - slash forwards trimmed arg through outbox sentinel (3 forms: ``"2"`` / ``"list"`` / empty)
- [x] ``pytest tests/cli/`` — 58 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)