### PR TITLE
fix(tui): restore focus to input after Esc / intervention dismissal

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -325,6 +325,17 @@ class OutboxRouter:
             widget.remove()
         except Exception:
             pass
+        # Mirror InterventionWidget._submit's focus restoration. The
+        # text-input path resolves the intervention from the InputBar's
+        # ``on_submitted`` handler so the user's focus is already there
+        # in the common case — but if the user clicked into the panel or
+        # tabbed away while waiting for confirmation, the widget removal
+        # would otherwise leak focus to a non-editable peer.
+        try:
+            from .widgets import InputBar
+            self._app.query_one("#inputbar", InputBar).focus_input()
+        except Exception:
+            pass
 
     def _on_status(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -248,3 +248,14 @@ class InterventionWidget(Widget):
         self.post_message(self.Answered(iv_id=self._iv_id, answer=answer))
         # Remove ourselves from the conversation view
         self.remove()
+        # Restore focus to the input bar. Without an explicit call here
+        # Textual's auto-focus-walker picks the next focusable widget in
+        # DOM order on removal — often a non-editable widget (a child of
+        # ConversationView, or the right panel if it's open), which
+        # leaves the user typing into nothing. The input bar is the only
+        # widget that the user can keep going from.
+        try:
+            from .input_bar import InputBar  # late import → avoid cycle
+            self.app.query_one("#inputbar", InputBar).focus_input()
+        except Exception:
+            pass

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -318,6 +318,21 @@ class RightPanel(Widget):
             event.prevent_default()
             event.stop()
             self.cycle(-1)
+        elif event.key == "escape":
+            # Esc inside the panel returns focus to the input bar — the
+            # standard "back out of a sub-context" affordance. Without
+            # this, the panel was a Tab/Shift+Tab focus trap (those keys
+            # cycle tabs, never exit), and Esc was a silent no-op because
+            # the App's escape binding is gated by ``check_action`` which
+            # returns False when nothing else (recording, error box) is
+            # interceptable. Tab cycling stays; this is purely the exit.
+            event.prevent_default()
+            event.stop()
+            from .. import InputBar  # late import → avoid cycle
+            try:
+                self.app.query_one("#inputbar", InputBar).focus_input()
+            except Exception:
+                pass
         elif event.key == "space":
             # Space is a uniform preview toggle: works on any tab when
             # focus is anywhere inside the right panel (tabs included).

--- a/tests/cli/test_focus_restore.py
+++ b/tests/cli/test_focus_restore.py
@@ -1,0 +1,170 @@
+"""Tier 2: focus restoration paths after Esc / intervention dismissal.
+
+Two MED-severity findings from the focus-management UX audit collapsed
+to "focus needs an explicit hand-off; without it Textual's auto-walker
+lands on a non-editable widget and the user types into nothing":
+
+  • Focus F3 — Esc inside the right panel was a silent no-op. Tab and
+    Shift+Tab cycle panel tabs (= focus trap), and the App's escape
+    binding is gated by ``check_action`` which returns False when no
+    error box / voice recording is interceptable.
+
+  • Focus F4 — InterventionWidget.remove() left focus on whatever DOM
+    walker picked next (commonly a child of ConversationView or, when
+    the panel was open, a panel tab strip), neither of which accept
+    typed input.
+
+These tests pin both fixes by exercising the user-visible flow with
+the headless ``Pilot`` and asserting that focus lands on the input
+TextArea after each action.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import TextArea
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── Focus F3 — Esc in right panel restores focus to input ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_escape_from_right_panel_focuses_input() -> None:
+    """Esc inside the right panel returns focus to the input TextArea.
+
+    Reproduces the previous trap: the user opens the panel, focus moves
+    into it, and the standard "back out" key (Esc) used to do nothing.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+
+        # Open the panel + focus it
+        await pilot.press("ctrl+b")     # toggle visible
+        await pilot.pause()
+        await pilot.press("ctrl+o")     # focus into the panel
+        await pilot.pause()
+
+        # Sanity: focus is no longer on the input TextArea
+        ta = app.query_one("#input", TextArea)
+        assert app.focused is not ta, (
+            "test setup failed: focus did not move into the right panel"
+        )
+
+        # Esc → focus must return to input
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.focused is ta, (
+            f"Esc from right panel did not restore input focus; got {app.focused}"
+        )
+
+
+# ── Focus F4 — InterventionWidget removal restores focus to input ────────────
+
+
+@pytest.mark.asyncio
+async def test_intervention_widget_submit_restores_input_focus() -> None:
+    """After ``InterventionWidget._submit`` removes itself, focus is on input.
+
+    The chip-button submit path explicitly calls ``focus_input()`` after
+    ``self.remove()``. Without that, Textual's auto-focus walker can
+    land on a peer widget (most often a child of ConversationView) and
+    silently kill typing.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        callback_calls: list[str] = []
+
+        async def _callback(answer: str) -> None:
+            callback_calls.append(answer)
+
+        widget = conv.mount_intervention(
+            question="proceed?",
+            choices=None,
+            answer_callback=_callback,
+            iv_id="iv_focus_test",
+        )
+        await pilot.pause()
+        assert widget is not None
+
+        # Submit the intervention with free-text answer
+        await widget._submit("yes")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert callback_calls == ["yes"]
+
+        # Focus must be on the input TextArea after submit + remove
+        ta = app.query_one("#input", TextArea)
+        assert app.focused is ta, (
+            f"intervention submit did not restore input focus; "
+            f"got focus on {app.focused}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_intervention_resolved_handler_restores_input_focus() -> None:
+    """The text-input route ``_on_intervention_resolved`` also restores focus.
+
+    Mirrors the chip-button path: when the user answers an intervention
+    by typing into the InputBar (Enter routes through the session, not
+    through ``_submit``), the resolved outbox message removes the widget
+    and must hand focus back the same way.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+
+        async def _callback(_answer: str) -> None:
+            pass
+
+        conv.mount_intervention(
+            question="proceed?",
+            choices=None,
+            answer_callback=_callback,
+            iv_id="iv_xyz12345",
+        )
+        await pilot.pause()
+
+        # Drive the resolved handler directly — that's the path the
+        # session/outbox flow takes after text-input delivery.
+        router = OutboxRouter(app)
+        router._on_intervention_resolved(
+            OutboxMessage(kind="intervention_resolved", text="", meta={"iv_id": "xyz12345"}),
+            conv, header,
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        ta = app.query_one("#input", TextArea)
+        assert app.focused is ta, (
+            f"intervention_resolved did not restore input focus; got {app.focused}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Two MED-severity findings from the focus-management UX audit collapse to the same root cause: focus needs an explicit hand-off after a sub-context exits, otherwise Textual's auto-walker lands on a non-editable peer and the user types into nothing.

### Focus F3 — Esc in right panel was a silent no-op
- ``RightPanel.on_key`` already hard-intercepts Tab / Shift+Tab to cycle panel tabs (= a Tab focus trap).
- The App's escape binding is gated by ``check_action`` which returns False when no error box / voice recording is interceptable, so Esc was swallowed without doing anything.
- Add an ``escape`` case to ``RightPanel.on_key`` that focuses the InputBar via the established late-import-of-InputBar pattern used by ``_prefill_docs_filter``.

### Focus F4 — InterventionWidget removal leaked focus
- Both removal paths (``InterventionWidget._submit`` chip-button submit + ``_on_intervention_resolved`` outbox-router text-input submit) called ``widget.remove()`` and let Textual's auto-walker pick the next focusable peer — commonly a child of ``ConversationView`` or, when the right panel was open, a panel tab strip. Neither accepts typed input.
- Add an explicit ``InputBar.focus_input()`` call after each removal site, via the same late-import pattern. Wrapped in ``try/except`` because by removal-time the widget could be on a screen mid-teardown.

## Test plan

- [x] ``pytest tests/cli/test_focus_restore.py`` — 3 passed (new Tier 2 invariants):
  - Esc inside the panel restores focus to the input TextArea
  - ``InterventionWidget._submit`` (chip-button path) restores focus
  - ``_on_intervention_resolved`` (text-input path) restores focus
- [x] ``pytest tests/cli/`` — 70 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)