### PR TITLE
feat(tui): hanging indent for message bodies so wraps nest under headers

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -39,7 +39,9 @@ from __future__ import annotations
 import time
 
 from rich.cells import cell_len
+from rich.console import RenderableType
 from rich.markdown import Markdown as RichMarkdown
+from rich.padding import Padding
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -68,6 +70,14 @@ _RECENT_REPLIES_MAX = 10
 # cross the boundary don't break Ctrl+P/N navigation.
 _RICHLOG_MAX_LINES = 20_000
 _NAME_COL_COLS = 4  # display-cell width reserved for the speaker label column
+# Hanging indent for message bodies (= the lines under each header). The
+# header is ``HH:MM  reyn ───`` — 5 (timestamp) + 2 (gap) = 7 cells before
+# the name column starts. Indenting the body to column 7 visually nests
+# replies under their author's name and, crucially, makes wrap continuations
+# of a long body line visually distinct from the start of a new turn
+# (which begins at column 0). Without this, a wrapped URL or code-line
+# looks identical to a new ``HH:MM …`` header on a quick scan.
+_BODY_INDENT_COLS = 7
 
 
 def _pad_to_cells(s: str, target_cells: int) -> str:
@@ -87,6 +97,16 @@ def _pad_to_cells(s: str, target_cells: int) -> str:
     if width >= target_cells:
         return s
     return s + " " * (target_cells - width)
+
+
+def _indent_body(renderable: RenderableType) -> RenderableType:
+    """Wrap ``renderable`` in a left-only Padding for the body indent column.
+
+    Used at every body write site (agent markdown, user text, system text,
+    fallback formatted lines). Header writes intentionally bypass this
+    helper so the timestamp / name / dash rule stay anchored at column 0.
+    """
+    return Padding(renderable, (0, 0, 0, _BODY_INDENT_COLS))
 
 
 def _msg_header(label: str, name_style: str, dash_style: str) -> Text:
@@ -330,13 +350,13 @@ class ConversationView(Widget):
         text = _format_message(msg)
         if text is not None:
             self._consume_empty_hint()
-            self._write_log(text)
+            self._write_body(text)
 
     def render_user_message(self, text: str) -> None:
         """Render a freshly submitted user message with grouped header."""
         self._consume_empty_hint()
         self._maybe_write_header("you", "you", "bold #4abbb5", "#1f5856")
-        self._write_log(Text(text))
+        self._write_body(Text(text))
         self._write_log(Text(""))
 
     def _render_system_message(self, msg: OutboxMessage) -> None:
@@ -352,9 +372,8 @@ class ConversationView(Widget):
         self._consume_empty_hint()
         self.hide_status()
         self._maybe_write_header("system", "system", "bold #888888", "#444444")
-        log = self._log()
         for line in (msg.text or "").splitlines() or [""]:
-            log.write(Text(line))
+            self._write_body(Text(line))
         self._write_log(Text(""))
 
     def _render_agent_markdown(self, msg: OutboxMessage) -> None:
@@ -401,14 +420,14 @@ class ConversationView(Widget):
         had_prev_fold = self._last_long_reply is not None
         lines = text.split("\n")
         if len(lines) <= _FOLD_THRESHOLD_LINES:
-            log.write(RichMarkdown(text))
+            self._write_body(RichMarkdown(text))
             if had_prev_fold:
                 self._write_fold_expired_marker()
             self._last_long_reply = None
             return
         preview = "\n".join(lines[:_FOLD_THRESHOLD_LINES])
         remaining = len(lines) - _FOLD_THRESHOLD_LINES
-        log.write(RichMarkdown(preview))
+        self._write_body(RichMarkdown(preview))
         hint = Text()
         hint.append(
             f"  [ … {remaining} more lines · type ",
@@ -446,7 +465,7 @@ class ConversationView(Widget):
         marker = Text()
         marker.append("  ↓ expanded", style=f"dim {_CORAL}")
         log.write(marker)
-        log.write(RichMarkdown(self._last_long_reply))
+        self._write_body(RichMarkdown(self._last_long_reply))
         log.write(Text(""))
         self._last_long_reply = None
         return True
@@ -481,6 +500,16 @@ class ConversationView(Widget):
     def _write_log(self, text: Text) -> None:
         log = self._log()
         log.write(text)
+
+    def _write_body(self, renderable: RenderableType) -> None:
+        """Append a body renderable at the hanging-indent column.
+
+        Wraps ``renderable`` in left-only ``Padding`` so wrap continuations
+        line up under the speaker name and stay visually distinct from the
+        column-0 turn header. Used for agent markdown, user / system text,
+        and any other content that belongs "under" the most recent header.
+        """
+        self._log().write(_indent_body(renderable))
 
     # ── streaming support ─────────────────────────────────────────────────────
 

--- a/tests/cli/test_body_hanging_indent.py
+++ b/tests/cli/test_body_hanging_indent.py
@@ -1,0 +1,205 @@
+"""Tier 2: message bodies render at the hanging-indent column.
+
+Before this fix, ``RichLog(wrap=True)`` wrapped long lines without any
+leading indent. A continuation of a long URL or code line started at
+column 0 — the same column as a new ``HH:MM …`` header — so the eye
+could not tell them apart. The fix wraps every body write site in
+``Padding(.., (0, 0, 0, _BODY_INDENT_COLS))`` (= 7-cell left indent)
+so both the first body line AND its wrapped continuation sit under the
+speaker name, leaving the header anchored at column 0.
+
+These tests inspect the rendered RichLog Strips (= what the user
+actually sees on screen) for body lines vs header lines, so a future
+refactor that drops the indent or accidentally applies it to headers
+would surface immediately.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.conversation import _BODY_INDENT_COLS
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _line_text(log: RichLog, index: int) -> str:
+    """Plain-text projection of a single RichLog line."""
+    strip = log.lines[index]
+    return "".join(seg.text for seg in strip)
+
+
+def _find_first_line_containing(log: RichLog, needle: str) -> int:
+    for i, strip in enumerate(log.lines):
+        text = "".join(seg.text for seg in strip)
+        if needle in text:
+            return i
+    raise AssertionError(f"text {needle!r} never appeared in RichLog")
+
+
+# ── body indent applied to common write paths ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_message_body_is_indented() -> None:
+    """``render_user_message`` writes its body at the hanging-indent column.
+
+    The header (``HH:MM  you  ───``) stays at column 0; the body line
+    "hello world" starts at column 7 so a wrap continuation visually
+    nests under the name column.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv.render_user_message("hello world")
+        await pilot.pause()
+
+        idx = _find_first_line_containing(log, "hello world")
+        body = _line_text(log, idx)
+        assert body.startswith(" " * _BODY_INDENT_COLS), (
+            f"user body must start at indent col {_BODY_INDENT_COLS}; got {body!r}"
+        )
+        assert "hello world" in body
+
+
+@pytest.mark.asyncio
+async def test_agent_markdown_body_is_indented() -> None:
+    """Agent markdown turns render their content at the indent column."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        msg = OutboxMessage(kind="agent", text="this is the agent body line")
+        conv.render_message(msg)
+        await pilot.pause()
+
+        idx = _find_first_line_containing(log, "this is the agent body line")
+        body = _line_text(log, idx)
+        assert body.startswith(" " * _BODY_INDENT_COLS), (
+            f"agent body must start at indent col {_BODY_INDENT_COLS}; got {body!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_message_body_is_indented() -> None:
+    """``/slash`` output rendered as system kind also gets indented."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        msg = OutboxMessage(kind="system", text="line a\nline b\nline c")
+        conv.render_message(msg)
+        await pilot.pause()
+
+        for needle in ("line a", "line b", "line c"):
+            idx = _find_first_line_containing(log, needle)
+            body = _line_text(log, idx)
+            assert body.startswith(" " * _BODY_INDENT_COLS), (
+                f"system line {needle!r} not indented; got {body!r}"
+            )
+
+
+# ── header lines stay at column 0 ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_header_line_is_not_indented() -> None:
+    """The timestamp + speaker label header stays at column 0.
+
+    This is the load-bearing distinction the fix delivers: header at
+    column 0, body at column ``_BODY_INDENT_COLS``. Without it the wrap
+    continuation of a body line and the start of a new header become
+    visually identical.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv.render_user_message("payload")
+        await pilot.pause()
+
+        # The header line is the one that has the dash rule (── chars).
+        # Find it and assert it starts at column 0.
+        header_idx = _find_first_line_containing(log, "─")
+        header = _line_text(log, header_idx)
+        assert not header.startswith(" "), (
+            f"header line must NOT be indented (column-0 anchor); got {header!r}"
+        )
+
+
+# ── wrap continuation also indented (the user-visible bug) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_long_user_line_wrap_continuation_is_indented() -> None:
+    """Wrap continuation of a long body line lands at the indent column.
+
+    This is the user-visible behaviour the agent's UX audit flagged:
+    a long URL or code line that wraps used to put the continuation at
+    column 0, indistinguishable from a new header.
+    """
+    app = _make_app()
+    # Narrow terminal forces a wrap on a moderate-length payload.
+    async with app.run_test(headless=True, size=(40, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # ~60 chars — well past the 40-cell terminal so it wraps.
+        long_payload = "abcdefghij" * 6
+        conv.render_user_message(long_payload)
+        await pilot.pause()
+
+        # First body line should be the one containing the start of payload.
+        first_body_idx = _find_first_line_containing(log, "abcdefghij")
+        first_body = _line_text(log, first_body_idx)
+        assert first_body.startswith(" " * _BODY_INDENT_COLS), first_body
+
+        # If wrap fired, the next line should also lead with the indent.
+        if first_body_idx + 1 < len(log.lines):
+            cont = _line_text(log, first_body_idx + 1)
+            stripped = cont.strip()
+            if stripped:  # non-empty continuation
+                assert cont.startswith(" " * _BODY_INDENT_COLS), (
+                    f"wrap continuation must also be indented; got {cont!r}"
+                )
+
+
+# ── constant invariant ───────────────────────────────────────────────────────
+
+
+def test_body_indent_constant_matches_header_name_column() -> None:
+    """``_BODY_INDENT_COLS`` aligns with where the name column starts.
+
+    Header layout: ``HH:MM`` (5) + 2-space gap = 7 cells before the
+    name. The body indent must match so wrapped content nests under
+    the name. If either constant moves, the other must too.
+    """
+    assert _BODY_INDENT_COLS == 7


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``RichLog(wrap=True)`` wrapped long body lines without any leading indent, so the continuation of a long URL or code line started at column 0 — the same column as a new ``HH:MM …`` header. On a quick scan the user could not tell wrap-continuations from new turns: a single multi-line agent reply looked like several distinct turns.

Wrap every body write site in left-only ``rich.padding.Padding`` at ``_BODY_INDENT_COLS`` (= 7 cells, aligning under the name column). Both the first body line AND any wrap continuations now sit at column 7, leaving the timestamp + speaker label anchored at column 0.

### Before / After

Before (wrap continuation at col 0, indistinguishable from a new header):
```
14:32  reyn ──────────────────
this is a long agent reply that wraps
14:32  you  ──────────────────       ← was this a new turn? or a wrap?
```

After (wrap continuation at col 7, clearly nested under reyn's name):
```
14:32  reyn ──────────────────
       this is a long agent reply
       that wraps
14:32  you  ──────────────────       ← unambiguously a new turn
```

### Affected write sites
- ``render_user_message`` (user text)
- ``_render_agent_markdown`` body (via fold helper)
- ``_render_system_message`` (per-line text)
- ``render_message`` fallback for unknown kinds
- ``_write_agent_markdown_with_fold`` (preview + full)
- ``expand_last_reply`` (full body flush)

### Intentionally unchanged
- ``_msg_header`` writes — headers anchor the eye at column 0
- Fold hint, expired marker, "↓ expanded" marker — already lead with their own ``"  "`` whitespace; further indent would push them to column 9
- Cost suffix — uses ``expand=True`` for right-alignment, no left pad

## Why

Visual / typography UX audit (MED severity Finding F3). The default Rich+Textual wrap had no hanging-indent affordance and silently degraded scan-ability whenever a body line exceeded pane width.

## Test plan

- [x] ``pytest tests/cli/test_body_hanging_indent.py`` — 6 passed (new Tier 2 invariants):
  - user / agent / system body lines all start at ``_BODY_INDENT_COLS``
  - header line (containing ``─``) stays at column 0
  - wrap continuation of a long user line on a narrow 40-col terminal is also indented (= the user-visible behaviour the audit flagged)
  - ``_BODY_INDENT_COLS`` constant pinned at 7 (= ``HH:MM`` + gap)
- [x] ``pytest tests/cli/`` — 78 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring tests)
- [x] Code review: code blocks inside Markdown bodies still render correctly via ``Padding(RichMarkdown(text), ...)`` — verified via standalone Rich console render with ``width=60``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)