### PR TITLE
feat(tui): trim model date suffix from header and dim the field

### DIFF
--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -9,6 +9,7 @@ per second from on_mount.
 """
 from __future__ import annotations
 
+import re
 import time
 from dataclasses import dataclass
 
@@ -17,6 +18,37 @@ from textual.app import ComposeResult
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Label
+
+
+# Trailing date suffix on a model id: ``-YYYYMMDD`` (8 digits) or the
+# ``-YYYY-MM-DD`` form. Both rotate per release and add 9-11 cells to
+# the header without changing within a session. Stripping them recovers
+# ~25 cells of header width on a narrow terminal — the cost / token
+# counters and the clock canary fit again without truncation.
+_MODEL_DATE_SUFFIX = re.compile(r"-(?:\d{8}|\d{4}-\d{1,2}-\d{1,2})$")
+_MODEL_LATEST_SUFFIX = re.compile(r"-latest$")
+
+
+def _shorten_model_id(model: str) -> str:
+    """Return ``model`` with trailing date / ``-latest`` suffix stripped.
+
+    Conservative: keeps the provider prefix (``claude-``, ``gpt-``, …) and
+    everything up to the version segment so the user can still tell what
+    family is active. Only strips the universally redundant tail.
+
+    Examples::
+
+        claude-opus-4-5-20251101    → claude-opus-4-5
+        claude-3-7-sonnet-20250219  → claude-3-7-sonnet
+        gpt-4o-2024-08-06           → gpt-4o
+        gemini-1.5-flash-latest     → gemini-1.5-flash
+        claude-sonnet-4-6           → claude-sonnet-4-6 (untouched)
+    """
+    if not model:
+        return model
+    stripped = _MODEL_DATE_SUFFIX.sub("", model)
+    stripped = _MODEL_LATEST_SUFFIX.sub("", stripped)
+    return stripped or model  # paranoia: never return empty
 
 
 class ReynHeader(Widget):
@@ -89,12 +121,24 @@ class ReynHeader(Widget):
             pass
 
     def _format_status(self) -> Text:
-        """Build the right-side status as a Rich Text with dim │ separators."""
-        parts: list[str] = []
+        """Build the right-side status as a Rich Text with dim │ separators.
+
+        Field layout (left → right):
+          agent_name │ model │ tokens │ cost │ clock
+
+        ``model`` is rendered DIM and date-suffix-stripped (e.g.
+        ``claude-opus-4-5-20251101`` → ``claude-opus-4-5``). It rarely
+        changes within a session, so de-emphasising it keeps the user's
+        eye on the per-turn metrics that DO change — tokens, cost, and
+        the clock canary at the right edge.
+        """
+        # (text, style) tuples — style=None falls back to the widget's
+        # default text color (#aaaaaa, see DEFAULT_CSS above).
+        parts: list[tuple[str, str | None]] = []
         if self._agent_name:
-            parts.append(self._agent_name)
+            parts.append((self._agent_name, None))
         if self._model:
-            parts.append(self._model)
+            parts.append((_shorten_model_id(self._model), "dim #888888"))
         tok_str = f"{self._tokens_today:,}"
         if self._tokens_cap is not None:
             tok_str += f" / {self._tokens_cap:,}"
@@ -106,16 +150,19 @@ class ReynHeader(Widget):
         cost_str = f"${self._cost_usd:.4f}"
         if self._cost_cap is not None:
             cost_str += f" / ${self._cost_cap:.2f}"
-        parts.append(tok_str)
-        parts.append(cost_str)
+        parts.append((tok_str, None))
+        parts.append((cost_str, None))
         # Clock always present, last — the canary for "is the UI frozen?"
-        parts.append(self._now_text())
+        parts.append((self._now_text(), None))
 
         out = Text()
-        for i, p in enumerate(parts):
+        for i, (text, style) in enumerate(parts):
             if i > 0:
                 out.append("  │  ", style="dim #555555")
-            out.append(p)
+            if style is None:
+                out.append(text)
+            else:
+                out.append(text, style=style)
         return out
 
     def refresh_status(

--- a/tests/cli/test_header_model_shortening.py
+++ b/tests/cli/test_header_model_shortening.py
@@ -1,0 +1,155 @@
+"""Tier 1 + Tier 2: header trims model-id date suffix and dims the field.
+
+Visual UX audit (MED severity Finding F4): the model field
+(e.g. ``claude-opus-4-5-20251101``) is a long machine-readable identifier
+that rarely changes within a session, but it sat between ``agent_name``
+and the metrics that DO change every turn — eating ~25 horizontal cells
+and pushing the clock canary off the right edge on narrow terminals.
+
+The fix:
+
+  1. Strip the universally redundant trailing date suffix
+     (``-YYYYMMDD`` 8 digits or ``-YYYY-MM-DD``) and ``-latest``.
+  2. Render the model field DIM so the user's eye gravitates to the
+     per-turn metrics (tokens / cost / clock).
+
+Tier 1: pure-function test of ``_shorten_model_id`` across the common
+provider id shapes. Tier 2: header status integration — model variants
+appear in the status text in the expected shortened form.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ReynHeader
+from reyn.chat.tui.widgets.header import _shorten_model_id
+
+
+# ── Tier 1: pure-function bucket coverage ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        # Anthropic 8-digit-date form
+        ("claude-opus-4-5-20251101",       "claude-opus-4-5"),
+        ("claude-3-7-sonnet-20250219",     "claude-3-7-sonnet"),
+        ("claude-haiku-4-5-20251001",      "claude-haiku-4-5"),
+        # OpenAI YYYY-MM-DD form
+        ("gpt-4o-2024-08-06",              "gpt-4o"),
+        ("gpt-4-turbo-2024-04-09",         "gpt-4-turbo"),
+        # Google -latest suffix
+        ("gemini-1.5-flash-latest",        "gemini-1.5-flash"),
+        ("gemini-2.0-pro-latest",          "gemini-2.0-pro"),
+        # No-suffix cases — passthrough
+        ("claude-sonnet-4-6",              "claude-sonnet-4-6"),
+        ("gpt-3.5-turbo",                  "gpt-3.5-turbo"),
+        ("ollama/llama3",                  "ollama/llama3"),
+        # Empty
+        ("",                                ""),
+        # Pathological — version-looking tail that is NOT a date
+        ("model-2024",                     "model-2024"),  # 4 digits, not 8
+        ("claude-3-5",                     "claude-3-5"),  # version, not date
+    ],
+)
+def test_shorten_model_id_buckets(model: str, expected: str) -> None:
+    """Tier 1: each provider-shape maps to the expected shortened form."""
+    assert _shorten_model_id(model) == expected, (
+        f"_shorten_model_id({model!r}) wrong: got {_shorten_model_id(model)!r}, "
+        f"expected {expected!r}"
+    )
+
+
+def test_shorten_never_returns_empty_for_non_empty_input() -> None:
+    """Tier 1: paranoia — if a future pattern would strip everything, fall back to raw."""
+    # Any single-token model id with no separator should pass through untouched.
+    assert _shorten_model_id("opus") == "opus"
+    assert _shorten_model_id("a") == "a"
+
+
+# ── Tier 2: header integration ───────────────────────────────────────────────
+
+
+def _make_app(model: str) -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="aria",
+        model=model,
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_header_status_shortens_anthropic_date_suffix() -> None:
+    """Tier 2: ``claude-opus-4-5-20251101`` renders as ``claude-opus-4-5`` in the header."""
+    app = _make_app("claude-opus-4-5-20251101")
+    async with app.run_test(headless=True, size=(180, 30)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        text = str(header._format_status())
+        assert "claude-opus-4-5" in text
+        # The date suffix must NOT appear
+        assert "20251101" not in text, (
+            f"date suffix leaked into header: {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_header_status_shortens_openai_dashed_date() -> None:
+    """Tier 2: ``gpt-4o-2024-08-06`` renders as ``gpt-4o``."""
+    app = _make_app("gpt-4o-2024-08-06")
+    async with app.run_test(headless=True, size=(180, 30)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        text = str(header._format_status())
+        assert "gpt-4o" in text
+        assert "2024-08-06" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_header_status_strips_latest_suffix() -> None:
+    """Tier 2: ``gemini-1.5-flash-latest`` renders as ``gemini-1.5-flash``."""
+    app = _make_app("gemini-1.5-flash-latest")
+    async with app.run_test(headless=True, size=(180, 30)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        text = str(header._format_status())
+        assert "gemini-1.5-flash" in text
+        assert "-latest" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_header_status_passthrough_for_undated_models() -> None:
+    """Tier 2: models without a date suffix render unchanged."""
+    app = _make_app("claude-sonnet-4-6")
+    async with app.run_test(headless=True, size=(180, 30)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        text = str(header._format_status())
+        assert "claude-sonnet-4-6" in text
+
+
+@pytest.mark.asyncio
+async def test_header_status_still_contains_agent_and_metrics() -> None:
+    """Tier 2: shortening doesn't drop other fields (agent, tokens, cost, clock).
+
+    Regression check that the refactor of ``_format_status`` from a flat
+    list to a list-of-tuples didn't accidentally swallow a part.
+    """
+    app = _make_app("claude-opus-4-5-20251101")
+    async with app.run_test(headless=True, size=(180, 30)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        text = str(header._format_status())
+        assert "aria" in text                  # agent_name
+        assert "tok" in text                   # tokens
+        assert "$" in text                     # cost
+        assert ":" in text                     # clock (HH:MM:SS)


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The header packed five fields on one line: ``agent_name │ model │ tokens │ cost │ clock``. The ``model`` field — e.g. ``claude-opus-4-5-20251101`` — is a long machine-readable identifier that rarely changes within a session but sat between ``agent_name`` and the per-turn metrics, eating ~25 horizontal cells. On narrow terminals the clock (the UI-freeze canary) wrapped or truncated, hiding the most important sign of liveness.

### Two changes

1. **``_shorten_model_id``** strips the universally redundant trailing suffix:

   | Pattern | Example |
   | --- | --- |
   | ``-YYYYMMDD`` (8-digit Anthropic) | ``claude-opus-4-5-20251101`` → ``claude-opus-4-5`` |
   | ``-YYYY-MM-DD`` (OpenAI dashed) | ``gpt-4o-2024-08-06`` → ``gpt-4o`` |
   | ``-latest`` (Google rolling) | ``gemini-1.5-flash-latest`` → ``gemini-1.5-flash`` |

   Provider prefix + version tokens stay so users can still tell ``claude-opus-4-5`` from ``claude-sonnet-4-6``. Conservative: ``claude-sonnet-4-6``, ``gpt-3.5-turbo``, ``ollama/llama3`` pass through untouched. Version-looking tails that are NOT dates (``claude-3-5``, ``model-2024`` with only 4 digits) also pass through.

2. **Dim the model part** (``dim #888888``) so the user's eye gravitates to the per-turn metrics that DO change every turn — tokens, cost, the clock. ``_format_status`` switches from a flat ``list[str]`` to ``list[tuple[str, style|None]]`` so per-part styling is per-tuple.

### Why

Visual UX audit (MED severity Finding F4). The previous combined field set could push the clock canary off the right edge of a 100-col terminal — exactly the wrong UX trade because the clock is the only visible signal that the UI hasn't frozen.

## Test plan

- [x] ``pytest tests/cli/test_header_model_shortening.py`` — 19 passed:
  - 13-case Tier 1 parametric covering Anthropic / OpenAI / Google / passthrough / pathological inputs
  - empty-input and single-token paranoia
  - 5 Tier 2 integration tests against the live header status text (Anthropic date / OpenAI dashed date / Google ``-latest`` / undated passthrough / other-fields-survived)
- [x] ``pytest tests/cli/`` — 91 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent tests)
- [x] Code review: existing ``test_tui_smoke.py::test_header_shows_agent_and_model`` uses ``model="gemini-test"`` which has no date suffix — passes through the shortening unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)