### PR TITLE
feat(tui): add left-bar to ErrorBox for non-color accessibility channel

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -40,6 +40,12 @@ class ErrorBox(Widget):
         height: auto;
         margin: 0;
         padding: 0;
+        /* Left bar — a non-color channel for "this is an error". Color alone
+           (``#cc5555`` on a dark pane, ~3.5:1 contrast vs the surroundings)
+           is right at the WCAG AA threshold for large text and below for
+           small text. The vertical bar gives the eye a shape / position
+           cue that survives quick scrolling and color-blind users. */
+        border-left: solid #cc5555;
     }
     /* Header line — always visible */
     ErrorBox Label.eb-header {

--- a/tests/cli/test_error_box_left_bar.py
+++ b/tests/cli/test_error_box_left_bar.py
@@ -1,0 +1,120 @@
+"""Tier 2: ErrorBox carries a non-color (shape) channel for accessibility.
+
+Visual UX audit (MED severity Finding F5): the only signal that a
+mounted ErrorBox was an *error* was the ``#cc5555`` red text colour.
+On a dark pane the contrast ratio sits around 3.5:1 — right at the
+WCAG AA threshold for large text and below for normal text — so an
+error scrolled past quickly or read by a color-blind user blends into
+the surrounding ``dim`` greys.
+
+Adding a vertical ``border-left`` gives a shape / position cue that
+survives the failure modes the colour does not. This test pins the
+contract that future CSS refactors cannot silently drop the bar.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.error_box import ErrorBox
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_error_box_declares_left_border() -> None:
+    """An ErrorBox mounted in the conv pane has a coloured left border.
+
+    Pinned at the computed-styles level so a refactor that moves the rule
+    out of ``DEFAULT_CSS`` (and forgets to re-add it elsewhere) fails fast.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(
+            message="something broke",
+            details="line 1\nline 2",
+            run_id_short="abcd",
+            skill_name="test_skill",
+        )
+        await pilot.pause()
+
+        box = conv.query_one(ErrorBox)
+        border = box.styles.border_left
+        # ``styles.border_left`` is a (style, Color) tuple. ``None`` /
+        # ``("none", ...)`` would both indicate the bar is gone.
+        assert border is not None, "border_left must be set"
+        style, _color = border
+        assert style and style != "none", (
+            f"border_left style must be non-none (got {style!r})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_error_box_border_color_matches_header_red() -> None:
+    """The left bar uses the same hue family as the header text.
+
+    Visual consistency check: the bar is the *non-color* channel, but
+    when colour IS available it must agree with the header — otherwise
+    the eye reads two competing red signals.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="boom")
+        await pilot.pause()
+
+        box = conv.query_one(ErrorBox)
+        _style, color = box.styles.border_left
+        # ``#cc5555`` = (204, 85, 85). Allow ±20 per channel so a future
+        # palette nudge to a slightly different red doesn't break the test
+        # while still catching e.g. an accidental switch to coral or grey.
+        r, g, b = color.rgb
+        assert r >= 180, f"border red channel weak: {color.rgb}"
+        assert g <= 110, f"border green channel too high (not red?): {color.rgb}"
+        assert b <= 110, f"border blue channel too high (not red?): {color.rgb}"
+
+
+@pytest.mark.asyncio
+async def test_error_box_left_bar_visible_in_render() -> None:
+    """The border actually renders — Textual reserves a column for it.
+
+    Sanity check beyond the styles property: the widget's region must
+    include the 1-cell border on its left edge. Without the border the
+    widget's outer width would equal its content width; with the border
+    it's at least content + 1.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="boom")
+        await pilot.pause()
+
+        box = conv.query_one(ErrorBox)
+        # ``virtual_size`` / ``outer_size`` differ from ``content_size``
+        # by the border + padding. Asserting outer ≥ content + 1 covers
+        # the border-left without depending on Textual's exact API name.
+        outer = box.outer_size
+        content = box.content_size
+        assert outer.width >= content.width + 1, (
+            f"outer width must be ≥ content + 1 for border; "
+            f"got outer={outer.width}, content={content.width}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The only signal that an in-flow ErrorBox was an *error* was the ``#cc5555`` red text colour. On a dark pane the contrast ratio sits around 3.5:1 — right at the WCAG AA threshold for large text and below for normal text — so an error scrolled past quickly or read by a color-blind user blends into the surrounding ``dim`` greys, especially when an amber-glowing SkillActivityRow sits next to it.

Add ``border-left: solid #cc5555`` to the ErrorBox CSS so the widget carries a *shape* / *position* cue independent of hue. The border reserves 1 cell on the left edge and uses the same red family as the header text — so when colour IS available, the two reds reinforce each other rather than competing for the user's attention.

### Why

Visual UX audit (MED severity Finding F5). The previous single-channel design (= colour alone) failed three real-world conditions: quick scrolling, low-contrast terminal themes, color-blind users. The bar is the cheapest fix that adds an orthogonal channel.

## Test plan

- [x] ``pytest tests/cli/test_error_box_left_bar.py`` — 3 passed:
  - ``styles.border_left`` is set and non-``"none"`` (CSS-level contract)
  - Border colour stays in the red family (R≥180, G≤110, B≤110) — guards against an accidental swap to coral / grey
  - ``outer_size.width >= content_size.width + 1`` (render-level proof the border actually consumes its column)
- [x] ``pytest tests/cli/`` — 75 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)