### PR TITLE
feat(tui): SlashPicker rows are clickable — Slack/Discord muscle memory

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -316,6 +316,24 @@ class InputBar(Widget):
         ta.move_cursor((0, len(new_text)))
         picker.hide()
 
+    def on_slash_picker_clicked(self, event: SlashPicker.Clicked) -> None:
+        """Click on a picker row — insert the highlighted command.
+
+        The picker's ``on_click`` already moved its own ``_selected`` to
+        the clicked row before posting the message, so this just routes
+        the existing confirm path. Mirrors the Tab key flow exactly:
+        ``/<name> `` lands in the TextArea with the cursor past the
+        trailing space, and the picker hides itself.
+        """
+        picker = self._picker()
+        ta = self._textarea()
+        if picker is not None and ta is not None:
+            self._confirm_picker(picker, ta)
+            # Re-focus the TextArea — the click may have implicitly
+            # shifted focus context even though SlashPicker is
+            # ``can_focus = False``, and the user expects to keep typing.
+            ta.focus()
+
     # ── submit / history ─────────────────────────────────────────────────────
 
     def _submit(self, ta: TextArea) -> None:

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -16,6 +16,7 @@ re-renders itself.
 from __future__ import annotations
 
 from rich.text import Text
+from textual.message import Message
 from textual.widgets import Static
 
 from reyn.chat.slash import SlashCommand
@@ -26,6 +27,15 @@ _MAX_VISIBLE = 8
 
 class SlashPicker(Static):
     """Inline list of slash-command matches shown above the TextArea."""
+
+    class Clicked(Message):
+        """Posted when the user clicks one of the picker rows.
+
+        ``InputBar`` listens for this and calls ``_confirm_picker`` to
+        insert the highlighted command — matching the keyboard Tab path.
+        The picker stays ``can_focus = False`` so the click does not
+        steal focus from the TextArea (the user keeps typing args).
+        """
 
     DEFAULT_CSS = """
     SlashPicker {
@@ -91,6 +101,38 @@ class SlashPicker(Static):
         if not self._matches:
             return None
         return self._matches[self._selected]
+
+    def select_at_y(self, content_y: int) -> bool:
+        """Move the selection to the row at ``content_y`` (content-coord).
+
+        ``content_y`` is the y-offset within the widget's content region
+        (excluding border / padding). Returns True when the offset hit
+        a valid match row; False when it landed on the "+N more" footer,
+        a blank line, or beyond the visible matches.
+        """
+        if 0 <= content_y < len(self._matches):
+            self._selected = content_y
+            self._repaint()
+            return True
+        return False
+
+    # ── mouse ────────────────────────────────────────────────────────────────
+
+    def on_click(self, event) -> None:
+        """Click on a row — confirm it.
+
+        Slack/Discord muscle memory: clicking a suggestion inserts it.
+        We compute the row from the content-relative offset (so the
+        border + padding don't shift the math), update the selection,
+        and post a ``Clicked`` message for InputBar to act on. The
+        picker stays ``can_focus = False`` so focus does not move off
+        the TextArea — the user can immediately type args.
+        """
+        offset = event.get_content_offset(self)
+        if offset is None:
+            return
+        if self.select_at_y(offset.y):
+            self.post_message(self.Clicked())
 
     # ── rendering ─────────────────────────────────────────────────────────────
 

--- a/tests/cli/test_slash_picker_click.py
+++ b/tests/cli/test_slash_picker_click.py
@@ -1,0 +1,176 @@
+"""Tier 2: SlashPicker rows are clickable — Slack/Discord muscle memory.
+
+Mouse-interaction UX audit (MED severity Finding F3): the picker
+rendered every row as a flat ``Text`` inside one ``Static`` widget,
+so clicks fell through to a no-op handler. Users with Slack/Discord
+muscle memory clicked a suggestion expecting it to be inserted; nothing
+happened.
+
+The fix:
+  1. ``SlashPicker.on_click`` maps the click's content-relative y-offset
+     to a row index and updates ``_selected``.
+  2. Posts a ``SlashPicker.Clicked`` message.
+  3. ``InputBar.on_slash_picker_clicked`` routes through the existing
+     ``_confirm_picker`` so the keyboard path and mouse path produce
+     byte-identical results.
+
+These tests pin both layers — picker-level row mapping + InputBar
+end-to-end insertion via pilot.click.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import TextArea
+
+from reyn.chat.slash import SlashCommand
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _candidates(n: int) -> list[SlashCommand]:
+    async def _noop(_session, _args: str) -> None:
+        return None
+    return [
+        SlashCommand(name=f"cmd{i}", summary=f"summary {i}", handler=_noop)
+        for i in range(n)
+    ]
+
+
+# ── picker-level: select_at_y ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_select_at_y_moves_selection_to_clicked_row() -> None:
+    """Tier 2: ``select_at_y`` moves ``_selected`` to the given row.
+
+    Validates the y-to-row mapping in isolation, without depending on
+    pilot click coordinate translation.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_matches(_candidates(5))
+        await pilot.pause()
+        assert picker._selected == 0
+
+        # Hit row 3 directly
+        assert picker.select_at_y(3) is True
+        assert picker._selected == 3
+        assert picker.selected_command().name == "cmd3"
+
+        # Hit row 0 — back to top
+        assert picker.select_at_y(0) is True
+        assert picker._selected == 0
+
+
+@pytest.mark.asyncio
+async def test_select_at_y_rejects_out_of_range() -> None:
+    """Tier 2: clicks below the last row (e.g. on "+N more" footer) return False."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_matches(_candidates(3))
+        await pilot.pause()
+
+        # Beyond the last row → no change, returns False
+        assert picker.select_at_y(99) is False
+        assert picker.select_at_y(3) is False     # one past last (idx 2)
+        assert picker._selected == 0
+
+
+@pytest.mark.asyncio
+async def test_select_at_y_no_op_when_empty() -> None:
+    """Tier 2: with no matches loaded, any click is a no-op."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        # No matches set → empty
+        assert picker.select_at_y(0) is False
+
+
+# ── InputBar wiring: clicked message → confirm path ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_picker_clicked_message_routes_to_confirm_picker() -> None:
+    """Tier 2: posting ``SlashPicker.Clicked`` inserts ``/<name> `` into the TextArea.
+
+    Drives the message-handler path directly without relying on pixel
+    click coordinates — that's covered by the picker-level tests above.
+    Pins the contract that mouse and keyboard go through the same
+    ``_confirm_picker`` so a future refactor of the keyboard path
+    automatically inherits the mouse fix.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click("#input")
+        await pilot.press("slash", "l", "i")        # type "/li"
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        assert picker.has_matches
+        # Move selection to second match so we test the "selected != 0" case
+        if len(picker._matches) > 1:
+            picker.move_selection(+1)
+            expected = picker._matches[1].name
+        else:
+            expected = picker._matches[0].name
+
+        picker.post_message(SlashPicker.Clicked())
+        await pilot.pause()
+
+        ta = app.query_one("#input", TextArea)
+        assert ta.text == f"/{expected} ", (
+            f"expected /<{expected}> in textarea; got {ta.text!r}"
+        )
+        # Picker hides after confirm
+        assert not picker.visible_
+
+
+@pytest.mark.asyncio
+async def test_picker_click_keeps_focus_on_input() -> None:
+    """Tier 2: after a row click, focus must still be on the TextArea.
+
+    The user clicked to *select a command* — not to focus the picker
+    (which is ``can_focus = False``). The mouse path must end with the
+    TextArea ready to accept the rest of the typed args.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.click("#input")
+        ta = app.query_one("#input", TextArea)
+        assert app.focused is ta
+
+        await pilot.press("slash", "l")
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        assert picker.has_matches
+
+        # Post a click message — handler should re-focus the TextArea
+        picker.post_message(SlashPicker.Clicked())
+        await pilot.pause()
+
+        assert app.focused is ta, (
+            f"input focus lost after picker click; got {app.focused}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The picker rendered every row as a flat ``Text`` inside one ``Static`` widget; clicks on a row had no handler and silently fell through. Users with Slack/Discord muscle memory clicked a suggestion expecting it to be inserted, watched nothing happen, and had to fall back to ↑/↓ + Tab.

Add a mouse path that mirrors the keyboard path exactly:

1. ``SlashPicker.on_click`` maps the click's content-relative y-offset (via ``event.get_content_offset(self)`` so border + padding don't skew the math) to a row index and updates ``_selected``.
2. Posts a new ``SlashPicker.Clicked`` message.
3. ``InputBar.on_slash_picker_clicked`` routes through the existing ``_confirm_picker`` so the mouse and keyboard paths produce byte-identical results — including the trailing space and cursor-past-space positioning.

The picker stays ``can_focus = False`` so the click does not steal focus from the TextArea; the handler re-focuses the input as a belt + braces guard since the click could implicitly shift focus context. Clicks below the last row (e.g. on the "+N more" footer) return ``False`` from ``select_at_y`` and the message is not posted — nothing happens, matching the "row missed" UX.

## Why

Mouse-interaction UX audit (MED severity Finding F3). Slack/Discord behaviour is a strong user expectation; the existing keyboard-only path forced an unnecessary mode shift for users in the middle of mouse interaction.

## Test plan

- [x] ``pytest tests/cli/test_slash_picker_click.py`` — 5 passed:
  - ``select_at_y`` updates ``_selected`` for valid rows (0..N-1)
  - Out-of-range (``y=99`` / ``y=N``) and empty-picker cases are silent no-ops
  - Posting ``Clicked`` inserts ``/<name> `` and hides the picker (mouse path = keyboard path)
  - Input focus survives the click (= keep typing args)
- [x] ``pytest tests/cli/`` — 77 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)