### PR TITLE
feat(tui): split _CORAL — _AMBER for agent identity, coral for actions

### DIFF
--- a/src/reyn/chat/tui/_palette.py
+++ b/src/reyn/chat/tui/_palette.py
@@ -4,7 +4,15 @@ Single source of truth for the coral primary + the dim greys used across
 widgets. Re-themeing means editing this file, not 7 widget modules.
 
 Naming convention:
-- ``_CORAL`` — primary accent (matches ``Theme(primary=...)``)
+- ``_CORAL`` — interactive / "you are here" affordance accent
+  (matches ``Theme(primary=...)``). Use for: action hints, cursor
+  indicators (▶ on a focused row, ▌ on selected picker rows), panel
+  tab labels, status glyphs.
+- ``_AMBER`` — agent identity accent. Use for: agent header label, the
+  streaming cursor (▍), and the intervention prefix (``<name> asks``).
+  Distinct from coral so the eye can immediately tell "this names the
+  agent" from "you can act here / your cursor is here". Coral and
+  amber share a warm hue family so the two reads still feel cohesive.
 - ``_BG_*``  — surface fills
 - ``_BORDER_*`` — border / divider colours
 - ``_TEXT_*`` — text colour ramps from dimmest to brightest
@@ -13,6 +21,12 @@ from __future__ import annotations
 
 # Primary accent — keep in sync with reyn.chat.tui.app.ReynTUIApp._REYN_THEME
 _CORAL = "#C8553D"
+# Agent-identity accent. Warm amber, distinct enough from _CORAL that the
+# eye reads "agent name / agent stream" as a separate signal from "you
+# can act / your cursor is here". Picked on the same hue arc as _CORAL
+# (= no jarring colour shift), but with notably lower saturation + a
+# yellow lean so the two reads don't merge in dim light.
+_AMBER = "#d4945a"
 
 # Surfaces
 _BG_PANEL = "#111111"     # right panel + tabs background
@@ -31,6 +45,7 @@ _TEXT_BRIGHT = "#dddddd"    # primary content
 
 __all__ = [
     "_CORAL",
+    "_AMBER",
     "_BG_PANEL",
     "_BG_HEADER",
     "_BORDER_DIM",

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -48,7 +48,7 @@ from textual.widget import Widget
 from textual.widgets import RichLog, Static
 
 from reyn.chat.outbox import OutboxMessage
-from reyn.chat.tui._palette import _CORAL
+from reyn.chat.tui._palette import _AMBER, _CORAL
 
 from .error_box import ErrorBox
 from .intervention import InterventionWidget
@@ -388,7 +388,10 @@ class ConversationView(Widget):
         self.hide_status()  # turn finished — clear "thinking…" sticky
         meta_pfx = _meta_prefix(msg.meta)
         label = f"reyn  {meta_pfx}".rstrip() if meta_pfx else "reyn"
-        self._maybe_write_header("reyn", label, "bold " + _CORAL, "#5a2020")
+        # _AMBER for agent identity (header label) — distinct from _CORAL
+        # which is reserved for interactive affordances (/expand, picker
+        # selection caret, panel cursor ▶) and "you are here" indicators.
+        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#5a2020")
         if msg.text:
             self._write_agent_markdown_with_fold(msg.text)
         self._write_log(Text(""))
@@ -517,7 +520,8 @@ class ConversationView(Widget):
         """Start a streaming agent message row. Returns the row widget."""
         self._consume_empty_hint()
         label = agent_name if agent_name else "reyn"
-        self._maybe_write_header("reyn", label, "bold " + _CORAL, "#5a2020")
+        # Same agent-identity styling as _render_agent_markdown (_AMBER).
+        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#5a2020")
         row = StreamingRow(prefix="", id=f"stream_{msg_id[:8]}")
         self._stream_rows[msg_id] = row
         self.mount(row)
@@ -832,6 +836,8 @@ def _format_message(msg: OutboxMessage) -> Text | None:
 def _format_intervention_line(msg: OutboxMessage) -> Text:
     """Fallback inline line for intervention when no widget callback set."""
     t = Text()
-    t.append("  Aria asks  ", style="bold " + _CORAL)
+    # Intervention prefix is agent-identity (= the agent asking a question),
+    # so it matches the agent header colour (_AMBER), not the action colour.
+    t.append("  Aria asks  ", style="bold " + _AMBER)
     t.append(msg.text, style="#ffcc88")
     return t

--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -34,7 +34,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL
+from reyn.chat.tui._palette import _AMBER
 
 _RENDER_INTERVAL_MS = 16  # ~60 fps max
 _RENDER_INTERVAL_S = _RENDER_INTERVAL_MS / 1000
@@ -117,7 +117,7 @@ class StreamingRow(Widget):
 
     def _build_renderable(self) -> Text:
         t = Text()
-        t.append(self._prefix, style="bold " + _CORAL)
+        t.append(self._prefix, style="bold " + _AMBER)
         t.append("".join(self._chunks))
         if not self._sealed:
             idle = (monotonic() - self._last_chunk_at) if self._last_chunk_at != 0.0 else 0.0
@@ -125,7 +125,7 @@ class StreamingRow(Widget):
                 t.append(" …", style="dim")
             else:
                 if self._cursor_visible:
-                    t.append("▍", style="bold " + _CORAL)
+                    t.append("▍", style="bold " + _AMBER)
                 else:
                     t.append(" ")
         return t
@@ -146,7 +146,7 @@ class StreamingRow(Widget):
             prefix_widget = Static(id="sealed_prefix")
             md_widget = Markdown(full, id="sealed_markdown")
             self.mount(prefix_widget, md_widget)
-            prefix_widget.update(Text(self._prefix, style="bold " + _CORAL))
+            prefix_widget.update(Text(self._prefix, style="bold " + _AMBER))
         except Exception:
             # Graceful fallback: freeze raw Rich text in the existing Static.
             if self._static is not None:

--- a/tests/cli/test_palette_semantic_split.py
+++ b/tests/cli/test_palette_semantic_split.py
@@ -1,0 +1,218 @@
+"""Tier 2: palette splits coral into action-affordance vs amber agent-identity.
+
+Visual UX audit (HIGH severity Finding F1): a single ``_CORAL`` accent
+was used for agent identity (header label, streaming cursor,
+intervention prefix), interactive affordances (``/expand`` hint, picker
+selection caret, panel cursor ``▶``), and status glyphs. The eye saw
+coral everywhere with no semantic rule.
+
+The split:
+
+  • ``_AMBER`` = agent identity (header label, streaming cursor ``▍``,
+    intervention "Aria asks" prefix). One read: "this names the agent".
+  • ``_CORAL`` = interactive affordance / "you are here" (``/expand``
+    hint, fold markers, picker selection caret, panel cursor ``▶``).
+    One read: "you can act here / your cursor is here".
+
+These tests pin both reads — palette values exist and are distinct, and
+the load-bearing render paths (agent header, streaming cursor, fold
+hint) use the right one of the two.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.color import Color as _RichColor
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui._palette import _AMBER, _CORAL
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── palette: two distinct named colours ──────────────────────────────────────
+
+
+def test_amber_and_coral_are_distinct() -> None:
+    """Palette declares both names and they must not collide.
+
+    A drift back to a single accent (``_AMBER = _CORAL``) would silently
+    undo the entire semantic split, so pin the inequality.
+    """
+    assert _AMBER != _CORAL, (
+        f"_AMBER and _CORAL must be distinct hex strings; got both = {_AMBER!r}"
+    )
+    # Both must be valid hex colour strings
+    assert _AMBER.startswith("#") and len(_AMBER) == 7
+    assert _CORAL.startswith("#") and len(_CORAL) == 7
+
+
+def test_amber_is_in_warm_hue_family() -> None:
+    """Amber should sit in a warm hue family (R dominant, B muted).
+
+    Defence against a future palette nudge accidentally swapping amber
+    for a cool hue (teal / blue) that would conflict with the user
+    header colour and confuse the agent-identity read.
+    """
+    r, g, b = _RichColor.parse(_AMBER).triplet
+    assert r >= g >= b, f"_AMBER must be warm (R≥G≥B); got rgb={r},{g},{b}"
+    assert r >= 180, f"_AMBER red channel weak: {r}"
+    assert b <= 140, f"_AMBER blue channel too high (not warm): {b}"
+
+
+# ── agent-identity sites use _AMBER ──────────────────────────────────────────
+
+
+def _find_first_with(strips, predicate) -> str:
+    """Locate the first strip whose text passes ``predicate``; return its segs."""
+    for strip in strips:
+        text = "".join(seg.text for seg in strip)
+        if predicate(text):
+            return strip
+    raise AssertionError("no strip matched predicate")
+
+
+@pytest.mark.asyncio
+async def test_agent_header_label_renders_with_amber() -> None:
+    """The agent header label ``reyn`` carries the _AMBER colour.
+
+    Checks the rendered Strip segments (= what hits the terminal) so a
+    drift in the colour constant or a regression of the style string
+    surfaces immediately.
+    """
+    from textual.widgets import RichLog
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # Render an agent message so the "reyn" label appears in a header
+        conv.render_message(OutboxMessage(kind="agent", text="hi"))
+        await pilot.pause()
+
+        # Find the strip containing "reyn" (the speaker label)
+        strip = None
+        for s in log.lines:
+            text = "".join(seg.text for seg in s)
+            if "reyn" in text and "─" in text:
+                strip = s
+                break
+        assert strip is not None, "agent header strip not found"
+
+        # The segment containing 'reyn' must carry the amber colour
+        amber_lower = _AMBER.lower()
+        found = False
+        for seg in strip:
+            if "reyn" in seg.text and seg.style is not None:
+                style_str = str(seg.style).lower()
+                if amber_lower in style_str:
+                    found = True
+                    break
+        assert found, (
+            f"agent label 'reyn' must use _AMBER ({_AMBER}); "
+            f"got segments={[(s.text, str(s.style)) for s in strip]}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_streaming_cursor_uses_amber() -> None:
+    """The streaming cursor ▍ (= agent producing) uses _AMBER, not _CORAL.
+
+    The cursor is an agent-identity signal — it tells the user the
+    agent is mid-utterance. Pinning it to amber keeps the agent-identity
+    family consistent (header + cursor read as one signal).
+    """
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        row = conv.begin_stream("test_stream_amber", "reyn")
+        row.append("partial")
+        await pilot.pause()
+
+        rendered = row._build_renderable()
+        amber_lower = _AMBER.lower()
+        coral_lower = _CORAL.lower()
+        # Walk every span; find ones carrying the cursor or the prefix.
+        styles_used = []
+        for span in rendered.spans:
+            style_str = str(span.style).lower()
+            styles_used.append(style_str)
+        joined = " | ".join(styles_used)
+        assert amber_lower in joined, (
+            f"streaming row styles must include _AMBER ({_AMBER}); got {joined}"
+        )
+        assert coral_lower not in joined, (
+            f"streaming row must NOT use _CORAL (= action colour); got {joined}"
+        )
+
+
+# ── action sites stay on _CORAL ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fold_hint_uses_coral_action_colour() -> None:
+    """The ``/expand`` fold hint stays on _CORAL — it's an action affordance.
+
+    Defence against an over-eager refactor that swept every coral to
+    amber: the action / cursor channel must keep its distinct hue, or
+    the semantic split collapses back to a single accent.
+    """
+    from textual.widgets import RichLog
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # Trigger fold with a long reply (> _FOLD_THRESHOLD_LINES)
+        long_text = "\n".join(f"line {i}" for i in range(60))
+        conv._write_agent_markdown_with_fold(long_text)
+        await pilot.pause()
+
+        # Find the fold hint strip
+        hint_strip = None
+        for s in log.lines:
+            text = "".join(seg.text for seg in s)
+            if "/expand" in text or "more lines" in text:
+                hint_strip = s
+                break
+        assert hint_strip is not None, "fold hint strip not found"
+
+        coral_lower = _CORAL.lower()
+        amber_lower = _AMBER.lower()
+        any_coral = any(
+            coral_lower in (str(seg.style).lower() if seg.style else "")
+            for seg in hint_strip
+        )
+        any_amber = any(
+            amber_lower in (str(seg.style).lower() if seg.style else "")
+            for seg in hint_strip
+        )
+        assert any_coral, (
+            f"fold hint must use _CORAL ({_CORAL}); "
+            f"got segs={[(s.text, str(s.style)) for s in hint_strip]}"
+        )
+        assert not any_amber, (
+            f"fold hint must NOT use _AMBER (= agent identity); "
+            f"got segs={[(s.text, str(s.style)) for s in hint_strip]}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

A single ``_CORAL`` was overloaded across **agent identity** (header label, streaming cursor, intervention "Aria asks" prefix), **interactive affordances** (``/expand`` hint, fold markers, picker selection caret, panel cursor ``▶``), **AND status glyphs** (sticky status, skill spinner, panel tab headers). The eye saw coral everywhere and learned no rule for what coral meant — agent name and "you can act here" read identically.

Introduce ``_AMBER = #d4945a`` as a second accent and reserve it for agent identity. Reads collapse to two clean rules:

| Token | Meaning | Sites |
| --- | --- | --- |
| ``_AMBER`` | **agent identity** | ConversationView agent header (``reyn``) · StreamingRow prefix + cursor ``▍`` · Intervention "Aria asks" prefix |
| ``_CORAL`` | **action / "you are here"** *(unchanged)* | ``/expand`` hint · "↓ expanded" / fold-cleared markers · SlashPicker caret ``▌`` · right-panel cursor ``▶`` and tab headers · sticky status / skill activity glyphs |

Coral and amber share a warm hue family (R-dominant) so the visual feel stays cohesive, but amber's yellow lean + lower saturation produces a clear "this is who" vs "this is where you can act" distinction even in dim light.

## Scope policy

**Minimum-touch split.** Only the 3 load-bearing agent-identity sites change colour; every other coral usage stays put. The change reads as "agent name pulled out of the sea of coral", not "the whole UI got re-themed". This deliberately leaves status glyphs / panel tabs / cursors on coral — broadening the split further would mean re-validating 8+ widgets and risk introducing a third semantic category before the two-way split has been seen in dogfood.

## Why

Visual UX audit (HIGH severity Finding F1). The single-accent design was the largest remaining UX debt; without a semantic split the eye can't form a mental rule for what coral signifies and treats every coral mark as equally salient.

## Test plan

- [x] ``pytest tests/cli/test_palette_semantic_split.py`` — 5 passed (new Tier 2 invariants):
  - ``_AMBER`` and ``_CORAL`` are distinct hex strings
  - ``_AMBER`` sits in the warm hue family (R ≥ G ≥ B; R ≥ 180; B ≤ 140) — guards against an accidental swap to a cool hue
  - Agent header label segment carries ``_AMBER`` in its rendered style
  - StreamingRow uses ``_AMBER`` and does NOT leak ``_CORAL``
  - Fold hint stays on ``_CORAL`` and does NOT leak ``_AMBER`` (= action / agent-identity channels stay separate)
- [x] ``pytest tests/cli/`` — 113 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)