### PR TITLE
fix(tui): cancel orphan auto-hide timers + clear sticky on /attach

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -46,6 +46,17 @@ class OutboxRouter:
 
     def __init__(self, app: "ReynTUIApp") -> None:
         self._app = app
+        # Tracker for the single in-flight transient-status auto-hide timer.
+        # Every transient sticky status (``/cost-inline on``, ``/copy …``,
+        # ``/docs-filter …``, etc.) arms ``app.set_timer(_, conv.hide_status)``
+        # to auto-clear after ~2 s. Before this tracker, every arming created
+        # a NEW timer and the previous one kept ticking — so a user firing two
+        # transients in quick succession (or transient → live ``⟳ thinking…``)
+        # would have the old timer silently hide the LIVE indicator a couple
+        # of seconds later. Holding a single handle lets us cancel the prior
+        # timer before installing a new one, and cancel it outright when a
+        # live thinking-status arrives so it can't kill the agent's spinner.
+        self._transient_status_timer = None  # type: ignore[assignment]
         # Dispatch table — each entry maps a `msg.kind` to its handler.
         # Methods on `self` are bound, so we can reference them directly.
         self.HANDLERS: dict[str, Callable[..., str | None]] = {
@@ -70,6 +81,44 @@ class OutboxRouter:
             # workflow_aborted events) and handled in app._handle_trace_for_skill_row.
             "error":                    self._on_error,
         }
+
+    # ── transient sticky helpers ──────────────────────────────────────────────
+
+    def _cancel_transient_timer(self) -> None:
+        """Cancel any in-flight auto-hide timer for the transient sticky.
+
+        Called before arming a new one, and whenever a live thinking
+        indicator takes over the sticky (= we must not allow the old
+        auto-hide to fire and kill the live spinner).
+        """
+        timer = self._transient_status_timer
+        if timer is None:
+            return
+        try:
+            timer.stop()
+        except Exception:
+            pass
+        self._transient_status_timer = None
+
+    def _show_transient_status(
+        self,
+        conv: ConversationView,
+        text: str,
+        *,
+        kind: str = "general",
+        duration: float = 2.5,
+    ) -> None:
+        """Show a transient sticky status that auto-hides after ``duration`` s.
+
+        Single entry point for ``show + set_timer(hide)`` so the previous
+        timer (if any) is always cancelled first. The previous behaviour
+        of arming a fresh timer per call meant a transient fired right
+        before an agent reply would hide the live ``⟳ thinking…`` ~2 s
+        into the agent's run.
+        """
+        self._cancel_transient_timer()
+        conv.show_status(text, kind=kind)
+        self._transient_status_timer = self._app.set_timer(duration, conv.hide_status)
 
     # ── main loop ─────────────────────────────────────────────────────────────
 
@@ -135,12 +184,22 @@ class OutboxRouter:
     def _on_attach_request(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
     ) -> None:
-        """`__attach_request__` — agent switched; refresh header label."""
+        """`__attach_request__` — agent switched; refresh header label.
+
+        Also clears the sticky status: a ``⟳ thinking…`` left by the
+        previous agent's in-flight turn would otherwise persist with
+        the new agent's name attached in the header, confusing the user
+        about WHICH agent is actively running. Any pending transient
+        auto-hide timer is cancelled too — the new agent should not
+        inherit a ghost timer from the old one's flow.
+        """
         app = self._app
         new_name = msg.text
         if new_name and app._agent_registry is not None:
             app._agent_name = new_name
             header.refresh_status(agent_name=new_name)
+            self._cancel_transient_timer()
+            conv.hide_status()
 
     def _on_matrix(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
@@ -173,16 +232,14 @@ class OutboxRouter:
         else:
             app._cost_inline_enabled = not app._cost_inline_enabled
         state = "on" if app._cost_inline_enabled else "off"
-        conv.show_status(f"cost-inline {state}", kind="general")
-        app.set_timer(2.5, conv.hide_status)
+        self._show_transient_status(conv, f"cost-inline {state}", duration=2.5)
 
     def _on_expand_last_reply(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
     ) -> None:
         """`__expand_last_reply__` — /expand slash; flush truncated reply."""
         if not conv.expand_last_reply():
-            conv.show_status("nothing to expand", kind="general")
-            self._app.set_timer(2.0, conv.hide_status)
+            self._show_transient_status(conv, "nothing to expand", duration=2.0)
 
     def _on_copy_last_reply(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
@@ -205,14 +262,13 @@ class OutboxRouter:
         if arg.lower() == "list":
             count = conv.recent_reply_count()
             if count == 0:
-                conv.show_status("no replies buffered yet", kind="general")
+                self._show_transient_status(conv, "no replies buffered yet")
             else:
-                conv.show_status(
+                self._show_transient_status(
+                    conv,
                     f"{count} reply{'s' if count != 1 else ''} buffered "
                     f"— /copy 1..{count}",
-                    kind="general",
                 )
-            self._app.set_timer(2.5, conv.hide_status)
             return
 
         # Parse N. Empty → latest (n=1); digits → that index. Anything else
@@ -223,47 +279,44 @@ class OutboxRouter:
         elif arg.isdigit():
             n = int(arg)
             if n <= 0:
-                conv.show_status(
-                    "/copy index must be ≥ 1 (1 = newest)", kind="error",
+                self._show_transient_status(
+                    conv, "/copy index must be ≥ 1 (1 = newest)", kind="error",
                 )
-                self._app.set_timer(2.5, conv.hide_status)
                 return
         else:
-            conv.show_status(
-                "usage: /copy [N] or /copy list", kind="error",
+            self._show_transient_status(
+                conv, "usage: /copy [N] or /copy list", kind="error",
             )
-            self._app.set_timer(2.5, conv.hide_status)
             return
 
         text = conv.reply_at(n)
         if text is None:
             buffered = conv.recent_reply_count()
             if buffered == 0:
-                conv.show_status("nothing to copy yet", kind="general")
+                self._show_transient_status(conv, "nothing to copy yet")
             else:
-                conv.show_status(
+                self._show_transient_status(
+                    conv,
                     f"reply {n} not in buffer "
                     f"(only {buffered} available — /copy list)",
                     kind="error",
                 )
-            self._app.set_timer(2.5, conv.hide_status)
             return
 
         ok, label = _copy_to_clipboard(text)
         if ok:
             n_chars = len(text)
             tag = "latest" if n == 1 else f"#{n}"
-            conv.show_status(
-                f"copied reply {tag} ({n_chars} chars) via {label}",
-                kind="general",
+            self._show_transient_status(
+                conv, f"copied reply {tag} ({n_chars} chars) via {label}",
             )
         else:
-            conv.show_status(
+            self._show_transient_status(
+                conv,
                 "no clipboard tool found "
                 "(install pbcopy / xclip / wl-copy / xsel)",
                 kind="error",
             )
-        self._app.set_timer(2.5, conv.hide_status)
 
     def _on_docs_filter(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
@@ -278,8 +331,7 @@ class OutboxRouter:
         except Exception:
             pass
         msg_text = f"docs filter: {substr}" if substr else "docs filter cleared"
-        conv.show_status(msg_text, kind="general")
-        app.set_timer(2.0, conv.hide_status)
+        self._show_transient_status(conv, msg_text, duration=2.0)
 
     def _on_stream_start(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
@@ -287,7 +339,11 @@ class OutboxRouter:
         """`__stream_start__` — begin a streaming agent reply row."""
         app = self._app
         app._current_stream_id = msg.meta.get("msg_id", id(msg))
-        # Hide the "thinking…" sticky now that the reply is starting
+        # Hide the "thinking…" sticky now that the reply is starting. Cancel
+        # any pending transient timer too — a transient that fired right
+        # before the reply must not auto-hide a fresh sticky armed later
+        # in this same turn.
+        self._cancel_transient_timer()
         conv.hide_status()
         conv.begin_stream(app._current_stream_id, app._agent_name)
 
@@ -392,7 +448,13 @@ class OutboxRouter:
     def _on_status(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
     ) -> None:
-        """`status` — route to sticky bar (not the log)."""
+        """`status` — route to sticky bar (not the log).
+
+        A live ``⟳ thinking…`` must outlive any pending transient timer
+        from a slash command that fired just before this turn started —
+        otherwise the auto-hide kills the agent's spinner mid-thought.
+        """
+        self._cancel_transient_timer()
         conv.show_status(msg.text, kind="thinking")
 
     def _on_trace(

--- a/tests/cli/test_sticky_timer_cancellation.py
+++ b/tests/cli/test_sticky_timer_cancellation.py
@@ -1,0 +1,188 @@
+"""Tier 2: transient sticky status arming cancels prior auto-hide timers.
+
+Three independent HIGH-severity findings collapse to the same root
+cause — every transient sticky (``/cost-inline``, ``/copy …``,
+``/docs-filter``, …) used to ``set_timer(2.5, conv.hide_status)``
+without storing the handle, so:
+
+  • Two transients in quick succession produced two live auto-hide
+    timers; the older one fired after the newer transient finished and
+    spuriously hid whatever sticky was current then (Async F1).
+  • A transient fired right before a turn started spawned a 2.5 s
+    auto-hide that killed the live ``⟳ thinking…`` indicator (Async F4).
+  • ``/attach`` swapped the agent name but left the previous agent's
+    ``⟳ thinking…`` running, attributed to the new agent (Multi F1).
+
+The fix routes every transient through ``_show_transient_status`` so a
+single in-flight handle is kept and cancelled before a new one arms.
+Live status (``_on_status``), stream start (``_on_stream_start``), and
+agent attach (``_on_attach_request``) all explicitly cancel any pending
+transient timer too — none of those flows can be auto-hidden by a stale
+transient timer.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.app_outbox import OutboxRouter
+from reyn.chat.tui.widgets import ConversationView, ReynHeader
+from reyn.chat.tui.widgets.sticky_status import StickyStatus
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="aria",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_transients_cancel_the_first_timer() -> None:
+    """Tier 2: arming a second transient cancels the first auto-hide handle.
+
+    Without this fix, the first timer kept ticking and would have fired
+    auto-hide ~2 s into the second status's lifetime, silently clearing
+    a sticky the user still needed to see.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        router = OutboxRouter(app)
+        router._show_transient_status(conv, "first")
+        first_timer = router._transient_status_timer
+        assert first_timer is not None
+
+        router._show_transient_status(conv, "second")
+        second_timer = router._transient_status_timer
+        assert second_timer is not None
+        assert second_timer is not first_timer, (
+            "second arming must replace the timer handle, not re-use it"
+        )
+        # Verify the first timer was actually stopped. Textual's Timer.stop()
+        # sets the internal ``_active`` Event, so ``_active.is_set()`` reads
+        # True on a stopped timer (counter-intuitive but matches the
+        # implementation in textual.timer).
+        active_event = getattr(first_timer, "_active", None)
+        if active_event is not None and hasattr(active_event, "is_set"):
+            assert active_event.is_set(), (
+                "first timer's stop() should have set its _active event"
+            )
+
+
+@pytest.mark.asyncio
+async def test_live_status_cancels_pending_transient_timer() -> None:
+    """Tier 2: ``_on_status`` (live ``thinking…``) cancels any pending transient.
+
+    A transient fired right before the turn would otherwise auto-hide
+    the agent's spinner mid-thought. Cancellation is the load-bearing
+    guard against that race.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+
+        router = OutboxRouter(app)
+        # Arm a transient
+        router._show_transient_status(conv, "cost-inline on")
+        assert router._transient_status_timer is not None
+
+        # Live status arrives — must cancel the timer
+        router._on_status(
+            OutboxMessage(kind="status", text="thinking…"),
+            conv, header,
+        )
+        assert router._transient_status_timer is None
+        # And the live status is showing
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        assert sticky.has_class("active")
+
+
+@pytest.mark.asyncio
+async def test_stream_start_cancels_pending_transient_timer() -> None:
+    """Tier 2: ``__stream_start__`` cancels any pending transient timer.
+
+    The stream-start handler also calls ``hide_status()`` so the live
+    reply takes over — but cancelling the transient timer is what stops
+    the auto-hide from firing later in the same turn.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+
+        router = OutboxRouter(app)
+        router._show_transient_status(conv, "/cost-inline on")
+        assert router._transient_status_timer is not None
+
+        router._on_stream_start(
+            OutboxMessage(kind="__stream_start__", text="", meta={"msg_id": "x"}),
+            conv, header,
+        )
+        assert router._transient_status_timer is None
+
+
+@pytest.mark.asyncio
+async def test_attach_clears_sticky_and_cancels_transient() -> None:
+    """Tier 2: ``/attach`` hides the sticky AND cancels any transient timer.
+
+    A previous agent's ``⟳ thinking…`` left running after attach would
+    silently get attributed to the new agent in the header — confusing
+    the user about which agent is mid-thought.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+
+        # Simulate the old agent's live thinking — sticky is on, no timer
+        conv.show_status("thinking…", kind="thinking")
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        assert sticky.has_class("active")
+
+        # Also arm a transient (could be from a slash that fired earlier)
+        router = OutboxRouter(app)
+        router._show_transient_status(conv, "earlier transient")
+        assert router._transient_status_timer is not None
+
+        # Now /attach a new agent — must clear sticky and cancel timer
+        # Set _agent_registry to a non-None sentinel so the handler doesn't no-op
+        app._agent_registry = object()
+        router._on_attach_request(
+            OutboxMessage(kind="__attach_request__", text="bob"),
+            conv, header,
+        )
+        assert app._agent_name == "bob"
+        assert not sticky.has_class("active"), (
+            "sticky must be cleared after attach (previous agent's spinner is stale)"
+        )
+        assert router._transient_status_timer is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_transient_is_idempotent_when_no_timer() -> None:
+    """Tier 2: cancelling with no timer in flight is a silent no-op."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        router = OutboxRouter(app)
+        assert router._transient_status_timer is None
+        # Should not raise
+        router._cancel_transient_timer()
+        assert router._transient_status_timer is None


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Three independent HIGH-severity findings from the async-event and multi-agent UX explorations share **the same root cause**: every transient sticky-status arming (``/cost-inline``, ``/copy …``, ``/docs-filter``, etc.) used to call ``set_timer(2.5, conv.hide_status)`` without storing the handle. The previous auto-hide kept ticking and silently killed whatever sticky was current 2 seconds later.

### The three collisions, all visible in dogfood

| Finding | What the user sees |
| --- | --- |
| **Async F1** | Two transients in quick succession (``/cost-inline on`` then ``/copy``): the first timer fires after the second status has armed and clears it from screen. |
| **Async F4** | A transient fires right before a turn starts; ~2 s into the agent's run, the orphan timer fires and hides the live ``⟳ thinking…`` indicator. |
| **Multi F1** | ``/attach`` swaps the header label but the previous agent's ``⟳ thinking…`` keeps running, attributed to the new agent. |

## Fix

- New ``_show_transient_status`` helper on ``OutboxRouter`` is the single entry point for ``show + set_timer(hide)``. Cancels any prior handle stored on ``self._transient_status_timer`` before arming.
- Every transient call site (``_on_cost_inline_toggle``, ``_on_expand_last_reply``, all five paths inside ``_on_copy_last_reply``, ``_on_docs_filter``) routes through the helper. No call site arms its own timer.
- ``_on_status`` (live ``⟳ thinking…``) and ``_on_stream_start`` explicitly cancel any pending transient handle so a stale timer from a slash command can't auto-hide the live indicator mid-turn.
- ``_on_attach_request`` now calls ``conv.hide_status()`` **and** cancels the transient timer so the previous agent's spinner doesn't get attributed to the new one.

## Test plan

- [x] ``pytest tests/cli/test_sticky_timer_cancellation.py`` — 5 passed (new Tier 2 invariants):
  - Arming a second transient stops the first timer (first's internal ``_active`` Event becomes ``is_set()`` per Textual ``Timer.stop()``)
  - ``_on_status`` cancels any pending transient timer
  - ``_on_stream_start`` cancels any pending transient timer
  - ``_on_attach_request`` clears sticky + cancels transient timer
  - Cancelling with no timer in flight is a silent no-op
- [x] ``pytest tests/cli/`` — 118 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model / palette tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)