### PR TITLE
feat(tui): user scroll-up suppresses auto-scroll; snap back on re-engage

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -269,6 +269,70 @@ class ConversationView(Widget):
         except Exception:
             return None
 
+    def on_mount(self) -> None:
+        """Wire a scroll watcher so user scroll-up suppresses auto-scroll.
+
+        Previously the ``_user_scrolled`` flag existed but nothing ever
+        set it: every ``log.write(...)`` snapped the view back to the
+        bottom even mid-read. Watching ``scroll_y`` from a single reactive
+        callback distinguishes "user is reading old content" (= scroll_y
+        below max) from "stream just appended" (= scroll_y already at
+        max because Textual's auto_scroll moved it there). The watcher
+        only flips ``auto_scroll`` on the boundary crossing, so writes
+        during user-read keep their place and writes after user-return
+        immediately auto-scroll again.
+        """
+        log = self._log()
+        try:
+            self.watch(log, "scroll_y", self._on_log_scroll_y)
+        except Exception:
+            # If Textual's cross-widget watch API changes, fail open
+            # (= keep historic auto-scroll behaviour) rather than crash mount.
+            pass
+
+    def _snap_to_bottom(self) -> None:
+        """Force the log to the bottom and re-arm auto-scroll.
+
+        Called from "I'm re-engaging" entry points (``render_user_message``,
+        ``clear``) so the user's previous scroll-up state doesn't pin them
+        to old content after they've explicitly taken an action.
+        """
+        try:
+            log = self._log()
+        except Exception:
+            return
+        try:
+            log.auto_scroll = True
+            log.scroll_end(animate=False)
+        except Exception:
+            pass
+        self._user_scrolled = False
+
+    def _on_log_scroll_y(self, old: float, new: float) -> None:
+        """Flip ``auto_scroll`` and ``_user_scrolled`` based on at-bottom check.
+
+        The ``-1`` threshold absorbs float-coord noise from Textual's
+        scroll math; treating "within 1 cell of the bottom" as "at the
+        bottom" matches how the user perceives the boundary.
+        """
+        try:
+            log = self._log()
+        except Exception:
+            return
+        at_bottom = new >= log.max_scroll_y - 1
+        # Only re-assign when the value actually changes so we don't churn
+        # Textual's reactive system every scroll tick.
+        if at_bottom:
+            if not log.auto_scroll:
+                log.auto_scroll = True
+            if self._user_scrolled:
+                self._user_scrolled = False
+        else:
+            if log.auto_scroll:
+                log.auto_scroll = False
+            if not self._user_scrolled:
+                self._user_scrolled = True
+
     # ── empty state ───────────────────────────────────────────────────────────
 
     def _consume_empty_hint(self) -> None:
@@ -353,7 +417,14 @@ class ConversationView(Widget):
             self._write_body(text)
 
     def render_user_message(self, text: str) -> None:
-        """Render a freshly submitted user message with grouped header."""
+        """Render a freshly submitted user message with grouped header.
+
+        Submitting a message is an "I'm re-engaging" signal — even if the
+        user had previously scrolled up to read history, they now want to
+        see the conversation continue. Snap back to the bottom and re-arm
+        auto-scroll so subsequent agent reply chunks track the tail.
+        """
+        self._snap_to_bottom()
         self._consume_empty_hint()
         self._maybe_write_header("you", "you", "bold #4abbb5", "#1f5856")
         self._write_body(Text(text))
@@ -801,6 +872,14 @@ class ConversationView(Widget):
         self._turn_anchors.clear()
         self._trim_warned = False
         self._last_long_reply = None
+        # Re-arm auto-scroll: clear() puts the user back at a fresh blank
+        # log, and any prior scroll-up state is meaningless once the
+        # content it was reading is gone.
+        self._user_scrolled = False
+        try:
+            self._log().auto_scroll = True
+        except Exception:
+            pass
         # Hide sticky status
         self.hide_status()
         # Restore the empty-state hint so the next session looks fresh.

--- a/tests/cli/test_user_scroll_suppresses_auto.py
+++ b/tests/cli/test_user_scroll_suppresses_auto.py
@@ -1,0 +1,228 @@
+"""Tier 2: user scroll-up suppresses auto-scroll, snap-back on re-engage.
+
+Async-event UX audit (HIGH severity Finding F2): ``_user_scrolled`` was
+a dead flag — declared but never set. ``RichLog.auto_scroll`` defaulted
+to True, so every ``log.write(...)`` snapped the view back to the
+bottom. A user reading old history would be ripped away on every
+stream chunk, trace, or status line.
+
+The fix:
+  1. ``ConversationView.on_mount`` attaches a reactive watcher on the
+     RichLog's ``scroll_y``.
+  2. When ``scroll_y`` drops below ``max_scroll_y - 1``, ``auto_scroll``
+     flips to False and ``_user_scrolled`` flips to True.
+  3. When the user returns to (within 1 cell of) the bottom,
+     ``auto_scroll`` is re-armed and the flag clears.
+  4. ``render_user_message`` and ``clear`` explicitly snap back to the
+     bottom — those are "I'm re-engaging" actions and shouldn't keep
+     the user pinned to old content.
+
+These tests pin all three transitions plus the snap-back paths.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.text import Text
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _fill_log(log: RichLog, n_lines: int) -> None:
+    """Lay down enough content to make ``max_scroll_y`` non-zero."""
+    for i in range(n_lines):
+        log.write(Text(f"baseline {i}"))
+
+
+# ── starting state ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_initial_state_auto_scroll_on_flag_off() -> None:
+    """Tier 2: on mount, ``auto_scroll`` is True and ``_user_scrolled`` is False."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        assert log.auto_scroll is True
+        assert conv._user_scrolled is False
+
+
+# ── user scroll up → suppress ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scroll_up_disables_auto_scroll_and_sets_flag() -> None:
+    """Tier 2: when ``scroll_y`` drops below ``max_scroll_y - 1``, both flip.
+
+    Drives the scroll position directly (= simulating a mouse-wheel up)
+    and verifies the watcher kicks in.
+    """
+    app = _make_app()
+    # Tall enough that scrollback exists
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        assert log.max_scroll_y > 5, (
+            f"test setup: need scrollback (max_scroll_y={log.max_scroll_y})"
+        )
+
+        # Scroll up well past the threshold
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert log.auto_scroll is False, (
+            "auto_scroll should flip off when user scrolls above the bottom"
+        )
+        assert conv._user_scrolled is True
+
+
+# ── user scroll back to bottom → re-arm ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_returning_to_bottom_rearms_auto_scroll() -> None:
+    """Tier 2: scrolling back to the tail re-enables ``auto_scroll``."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+
+        # User scrolls up
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        assert log.auto_scroll is False
+        assert conv._user_scrolled is True
+
+        # User scrolls back to the bottom
+        log.scroll_end(animate=False)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert log.auto_scroll is True, (
+            "auto_scroll should re-arm when user returns to the tail"
+        )
+        assert conv._user_scrolled is False
+
+
+# ── writes during scroll-up don't snap back ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_during_user_scroll_preserves_position() -> None:
+    """Tier 2: ``log.write`` while user is scrolled up doesn't rip them away.
+
+    This is the user-visible behaviour the audit flagged: the dead
+    ``_user_scrolled`` flag meant every write snapped the view to the
+    bottom. With the fix, ``auto_scroll = False`` keeps the view where
+    the user put it.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+
+        # User scrolls up
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        scroll_before = log.scroll_y
+        assert scroll_before == 0
+        assert log.auto_scroll is False
+
+        # A new write arrives (= async outbox event)
+        log.write(Text("late-arriving stream chunk"))
+        await pilot.pause()
+
+        # User's scroll position must be preserved
+        assert log.scroll_y == scroll_before, (
+            f"write while user scrolled up changed scroll_y: "
+            f"before={scroll_before}, after={log.scroll_y}"
+        )
+
+
+# ── snap-back on user submit / clear ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_render_user_message_snaps_back_to_bottom() -> None:
+    """Tier 2: submitting a new message re-engages the user and snaps to tail.
+
+    A user who scrolled up to read history might submit a new message
+    while still scrolled up. The submit is an "I'm back" signal — we
+    snap to the bottom so they see their input land and the agent reply
+    track the tail.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        assert log.auto_scroll is False
+        assert conv._user_scrolled is True
+
+        conv.render_user_message("hello again")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert log.auto_scroll is True
+        assert conv._user_scrolled is False
+        # And we're (close to) the bottom — scroll_y == max_scroll_y
+        assert log.scroll_y >= log.max_scroll_y - 1
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_scroll_state() -> None:
+    """Tier 2: ``clear()`` puts the user back at a fresh blank log.
+
+    Any prior scroll-up state is meaningless once the content it was
+    reading is gone, so we re-arm ``auto_scroll`` and clear the flag.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        assert conv._user_scrolled is True
+        assert log.auto_scroll is False
+
+        conv.clear()
+        await pilot.pause()
+        assert conv._user_scrolled is False
+        assert log.auto_scroll is True


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``_user_scrolled`` was a dead flag — declared in ``__init__`` but nothing ever set it, and no path checked it. ``RichLog.auto_scroll`` defaulted to True, so every ``log.write(...)`` snapped the view back to the bottom. A user reading old history would be ripped away on every stream chunk, trace, or status line — making it functionally impossible to scroll up and read prior context during an active turn.

### Wire-up

- **``ConversationView.on_mount``** attaches a reactive watcher on the RichLog's ``scroll_y`` via Textual's ``self.watch(widget, attr, callback)`` API. Fail-open if Textual's cross-widget watch API changes — keep historic auto-scroll behaviour rather than crash mount.
- **``_on_log_scroll_y``** flips ``auto_scroll`` and ``_user_scrolled`` based on a "within 1 cell of the bottom" check. Only re-assigns when the value actually changes so the reactive system isn't churned every scroll tick.
- **``_snap_to_bottom``** helper called from ``render_user_message`` — submitting a message is an "I'm re-engaging" signal even if the user had scrolled up to read history, so we force a snap back so they see their input land and the agent reply track the tail.
- **``clear()``** re-arms ``auto_scroll`` and resets the flag — any prior scroll-up state is meaningless once the content is gone.

## Why

Async-event UX audit (HIGH severity Finding F2). The flag was scaffolded but never implemented; this PR closes that gap by wiring the load-bearing pieces (watcher + snap-back).

## Test plan

- [x] ``pytest tests/cli/test_user_scroll_suppresses_auto.py`` — 6 passed (new Tier 2 invariants):
  - Initial state: ``auto_scroll=True``, ``_user_scrolled=False``
  - Scroll to top → both flip (auto-scroll off, flag on)
  - Return to bottom → both restore
  - Write during user scroll-up preserves position (= the user-visible bug the audit flagged)
  - ``render_user_message`` snaps back + clears flag
  - ``clear()`` re-arms + clears flag
- [x] ``pytest tests/cli/`` — 124 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model / palette / sticky-timer tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)