### PR TITLE
fix(tui): off-load /copy subprocess to executor so outbox loop never blocks

### DIFF
--- a/src/reyn/chat/tui/_clipboard.py
+++ b/src/reyn/chat/tui/_clipboard.py
@@ -28,6 +28,10 @@ def copy_to_clipboard(text: str) -> tuple[bool, str]:
     Looked up via ``shutil.which`` so the user only needs one of the
     binaries on PATH. We avoid hard-coding the OS because users may run,
     e.g., xclip inside a Linux VM regardless of the host platform.
+
+    BLOCKING: ``subprocess.run`` is synchronous and can hold the calling
+    thread for up to ~2 s (timeout). Callers inside an async event loop
+    should use :func:`copy_to_clipboard_async` instead.
     """
     import shutil
     import subprocess
@@ -49,4 +53,20 @@ def copy_to_clipboard(text: str) -> tuple[bool, str]:
     return False, ""
 
 
-__all__ = ["copy_to_clipboard"]
+async def copy_to_clipboard_async(text: str) -> tuple[bool, str]:
+    """Async variant — off-loads :func:`copy_to_clipboard` to a thread executor.
+
+    The blocking subprocess (timeout=2 s) runs on the default executor so
+    the event loop stays free to drain other outbox events (streaming
+    chunks, status messages, traces). Without this off-load, a single
+    ``/copy`` could freeze the TUI for up to 2 seconds per clipboard
+    tool attempted.
+
+    Returns the same ``(ok, tool_label)`` shape as the sync version.
+    """
+    import asyncio
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, copy_to_clipboard, text)
+
+
+__all__ = ["copy_to_clipboard", "copy_to_clipboard_async"]

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -303,7 +303,30 @@ class OutboxRouter:
                 )
             return
 
-        ok, label = _copy_to_clipboard(text)
+        # Off-load the blocking ``subprocess.run`` (up to 2 s per tool tried)
+        # to a thread executor so the outbox loop stays free to drain other
+        # events. Without this, ``/copy`` mid-stream could freeze the TUI
+        # for up to 2 s — streaming chunks would back up in the queue and
+        # all unblock in a burst at the end. Surface an instant "copying…"
+        # placeholder so the user sees their action register immediately;
+        # the worker overwrites it with the success / failure status on
+        # completion (each ``_show_transient_status`` cancels the prior
+        # auto-hide timer, so the placeholder never out-lives the result).
+        self._show_transient_status(conv, "copying…", duration=10.0)
+        asyncio.create_task(self._finish_copy_async(conv, text, n))
+
+    async def _finish_copy_async(
+        self, conv: ConversationView, text: str, n: int,
+    ) -> None:
+        """Background worker for /copy — runs subprocess off the event loop."""
+        from ._clipboard import copy_to_clipboard_async
+        try:
+            ok, label = await copy_to_clipboard_async(text)
+        except Exception as exc:
+            self._show_transient_status(
+                conv, f"copy failed: {exc}", kind="error",
+            )
+            return
         if ok:
             n_chars = len(text)
             tag = "latest" if n == 1 else f"#{n}"

--- a/tests/cli/test_clipboard_non_blocking.py
+++ b/tests/cli/test_clipboard_non_blocking.py
@@ -1,0 +1,172 @@
+"""Tier 2: /copy off-loads its blocking subprocess to a thread executor.
+
+Streaming / perf UX audit (MED severity Finding F3): the ``/copy``
+handler called ``_copy_to_clipboard(text)`` synchronously inside the
+async outbox loop. ``copy_to_clipboard`` uses ``subprocess.run(...,
+timeout=2.0)`` — a blocking call. During that window, the outbox
+``await repl_outbox.get()`` was suspended and no streaming chunks,
+status messages, or trace events processed. ``/copy`` mid-stream could
+freeze the TUI for up to ~2 seconds, then unblock in a burst.
+
+The fix:
+  1. ``copy_to_clipboard_async`` wraps the sync helper with
+     ``loop.run_in_executor(None, ...)`` so the blocking subprocess
+     runs on a worker thread.
+  2. ``_on_copy_last_reply`` dispatches the work via ``asyncio.create_task``
+     and returns synchronously. A "copying…" placeholder transient
+     gives the user instant feedback; ``_finish_copy_async`` overwrites
+     it with the success / failure result on completion.
+
+Tests pin:
+  - The async helper exists and is awaitable, returning the same shape.
+  - ``_on_copy_last_reply`` returns synchronously (= no ``await``); the
+    actual blocking work is scheduled for later.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui import _clipboard
+from reyn.chat.tui._clipboard import copy_to_clipboard_async
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.app_outbox import OutboxRouter
+from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── async helper contract ────────────────────────────────────────────────────
+
+
+def test_copy_to_clipboard_async_is_awaitable_coroutine() -> None:
+    """Tier 1: the async helper is a coroutine function with the same return shape."""
+    assert inspect.iscoroutinefunction(copy_to_clipboard_async), (
+        "copy_to_clipboard_async must be ``async def`` so callers can ``await`` it"
+    )
+
+
+def test_copy_to_clipboard_async_returns_tuple_shape() -> None:
+    """Tier 2: ``await``-ing the helper produces a ``(bool, str)`` tuple.
+
+    Drives the helper with empty text against the executor. If no clipboard
+    tool is on PATH, returns ``(False, "")``; if one is, returns ``(True,
+    "<label>")``. Either way the shape is the contract.
+    """
+    out = asyncio.run(copy_to_clipboard_async(""))
+    assert isinstance(out, tuple) and len(out) == 2
+    ok, label = out
+    assert isinstance(ok, bool)
+    assert isinstance(label, str)
+
+
+# ── handler does not block the outbox loop ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_copy_last_reply_returns_synchronously() -> None:
+    """Tier 2: the handler is sync and returns immediately, no awaiting subprocess.
+
+    The handler used to hold the outbox loop for up to 2 s while
+    ``subprocess.run`` ran. After the fix, it parses + arms a placeholder
+    + schedules a worker, then returns. We verify the method itself is
+    sync (= ``not iscoroutinefunction``) — the OutboxRouter dispatcher
+    relies on this contract.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        # Lay down a reply so /copy has something to fetch
+        conv._write_agent_markdown_with_fold("hello reply")
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        assert not inspect.iscoroutinefunction(router._on_copy_last_reply), (
+            "_on_copy_last_reply must stay sync — the OutboxRouter dispatch loop "
+            "calls handlers without await"
+        )
+
+        # Drive the handler; it must complete without raising
+        router._on_copy_last_reply(
+            OutboxMessage(kind="__copy_last_reply__", text=""),
+            conv, header,
+        )
+        # And a worker should have been scheduled — but we can't easily count
+        # tasks portably; rely on the structural assertion above.
+
+
+@pytest.mark.asyncio
+async def test_finish_copy_async_overwrites_placeholder_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the worker replaces the "copying…" placeholder with the result.
+
+    Monkey-patches ``copy_to_clipboard`` (NOT ``unittest.mock`` — just a
+    direct attribute substitution via pytest's ``monkeypatch`` fixture)
+    so the test doesn't depend on a real ``pbcopy`` / ``xclip`` being on
+    PATH or actually mutating the system clipboard.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        captured: list[str] = []
+
+        def _fake_copy(text: str) -> tuple[bool, str]:
+            captured.append(text)
+            return (True, "fake-clipboard")
+
+        monkeypatch.setattr(_clipboard, "copy_to_clipboard", _fake_copy)
+
+        router = OutboxRouter(app)
+        await router._finish_copy_async(conv, "payload-xyz", n=2)
+        await pilot.pause()
+
+        # The fake was invoked with the exact text
+        assert captured == ["payload-xyz"]
+        # And a sticky should now be visible (the success transient)
+        # — we can't easily read the sticky text without more plumbing,
+        # but a follow-up _show_transient_status would have armed a fresh
+        # timer, so the router's handle field is set.
+        assert router._transient_status_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_finish_copy_async_surfaces_failure_when_no_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: missing-tool path surfaces the install-hint, doesn't crash."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        def _fake_copy(_text: str) -> tuple[bool, str]:
+            return (False, "")
+
+        monkeypatch.setattr(_clipboard, "copy_to_clipboard", _fake_copy)
+
+        router = OutboxRouter(app)
+        await router._finish_copy_async(conv, "anything", n=1)
+        await pilot.pause()
+        # No crash, and a transient was armed (= failure status visible)
+        assert router._transient_status_timer is not None


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``_on_copy_last_reply`` called ``_copy_to_clipboard(text)`` synchronously inside the async outbox loop. ``copy_to_clipboard`` uses ``subprocess.run(..., timeout=2.0)`` — a blocking call. During that window the outbox ``await repl_outbox.get()`` was suspended and **no streaming chunks, status messages, or trace events could process**. A ``/copy`` fired mid-stream froze the visible TUI for up to ~2 seconds per clipboard tool tried, then unblocked in a burst.

## Fix

Off-load the work without changing the user-visible flow:

- New **``copy_to_clipboard_async``** in ``_clipboard.py`` wraps the sync helper with ``loop.run_in_executor(None, ...)`` so the blocking subprocess runs on a worker thread. Same ``(ok, label)`` shape; sync version stays available for callers outside an event loop.
- **``_on_copy_last_reply`` stays sync** (= the OutboxRouter dispatcher contract). It parses the arg, fetches the reply text, then arms a ``"copying…"`` placeholder transient and ``asyncio.create_task``s the new ``_finish_copy_async`` worker. The handler returns immediately.
- **``_finish_copy_async``** awaits the executor and overwrites the placeholder with the success / failure status. ``_show_transient_status`` already cancels prior auto-hide timers, so the placeholder never out-lives the result.

After the fix the outbox loop keeps draining while the subprocess runs; streaming chunks no longer back up mid-``/copy``.

## Why

Streaming / perf UX audit (MED severity Finding F3). The blocking subprocess inside the async loop was the only handler that could stall the entire event flow — fixing it removes a real dogfood foot-gun.

## Test plan

- [x] ``pytest tests/cli/test_clipboard_non_blocking.py`` — 5 passed (new Tier 1 + Tier 2 invariants):
  - ``copy_to_clipboard_async`` is a coroutine function returning ``(bool, str)``
  - ``_on_copy_last_reply`` is NOT a coroutine function — preserves dispatcher contract
  - Success path: worker invokes the underlying sync helper with the exact text and arms a success transient
  - No-tool path: worker surfaces the install hint and doesn't crash
  - Tests use ``pytest.monkeypatch.setattr`` to substitute the underlying ``copy_to_clipboard`` (NOT ``unittest.mock`` — direct attribute substitution, allowed per the testing policy)
- [x] ``pytest tests/cli/`` — 129 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model / palette / sticky-timer / streaming-perf tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)