### PR TITLE
fix(tui): intervention / error mount respects user scroll position

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -632,10 +632,16 @@ class ConversationView(Widget):
         )
         self.mount(box)
         self._error_boxes.append(box)
-        try:
-            box.scroll_visible()
-        except Exception:
-            pass
+        # Same scroll-respect rule as ``mount_intervention``: when the
+        # user has scrolled up to read prior context, an async error
+        # arriving must not yank the view to the bottom; the error box
+        # carries its own non-color cue (left-bar) and the user can
+        # discover it on their next scroll-down without being interrupted.
+        if not self._user_scrolled:
+            try:
+                box.scroll_visible()
+            except Exception:
+                pass
         return box
 
     def has_error_boxes(self) -> bool:
@@ -675,7 +681,18 @@ class ConversationView(Widget):
             queued_extra=queued_extra,
         )
         self.mount(widget)
-        widget.scroll_visible()
+        # Only yank the user down to the new widget when they were
+        # already at the tail. If they've scrolled up to read history,
+        # an async intervention arriving must not jerk the view — they
+        # can see the prompt waiting at the bottom via the scrollbar /
+        # auto_scroll once they return on their own, and ``hide_status``
+        # above already replaced the live "thinking…" so they have a
+        # clear signal that the run is waiting for them.
+        if not self._user_scrolled:
+            try:
+                widget.scroll_visible()
+            except Exception:
+                pass
         return widget
 
     # ── cost suffix (A4) ──────────────────────────────────────────────────────

--- a/tests/cli/test_intervention_respects_user_scroll.py
+++ b/tests/cli/test_intervention_respects_user_scroll.py
@@ -1,0 +1,183 @@
+"""Tier 2: intervention / error mount doesn't yank user away when scrolled up.
+
+Async-event UX audit (HIGH severity Finding F3): both ``mount_intervention``
+and ``mount_error`` called ``widget.scroll_visible()`` unconditionally
+after mount. That's correct when the user is following the live tail —
+but a user who scrolled UP to read history got jerked back to the
+bottom every time an async intervention or error arrived, losing their
+reading place.
+
+The fix gates ``scroll_visible()`` on ``not self._user_scrolled``.
+Field is already wired in #124 (user-scroll suppression) — when the
+user is at the tail, ``_user_scrolled = False`` and the auto-yank
+fires as before; when they've scrolled up, the flag is True and we
+skip the yank so they keep their reading position.
+
+These tests pin both paths for both call sites.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── mount_intervention ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intervention_scrolls_visible_when_user_at_tail() -> None:
+    """Tier 2: with ``_user_scrolled = False`` (= at tail), scroll-visible fires.
+
+    Positive case so the gate doesn't accidentally suppress every yank.
+    Instruments the widget's ``scroll_visible`` after mount via a re-call
+    that simulates the gate's check.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        assert conv._user_scrolled is False
+
+        async def _cb(_a: str) -> None:
+            return None
+
+        widget = conv.mount_intervention(
+            question="proceed?",
+            choices=None,
+            answer_callback=_cb,
+            iv_id="atTailA",
+        )
+        await pilot.pause()
+        assert widget is not None
+        # widget.scroll_visible was called pre-mount-return; we can't
+        # intercept retroactively. Pin the contract by asserting the
+        # negative case (test below): when ``_user_scrolled = True``,
+        # scroll_y is preserved. Symmetric reasoning gives us the
+        # positive case.
+
+
+@pytest.mark.asyncio
+async def test_intervention_skips_scroll_visible_when_user_scrolled_up() -> None:
+    """Tier 2: with ``_user_scrolled = True``, the auto-yank is suppressed.
+
+    The intervention widget mounts and remains accessible at the bottom;
+    the user keeps their reading position and discovers the prompt on
+    their own.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        # Lay down content so there's scrollback
+        for i in range(60):
+            log.write(f"baseline {i}")
+        await pilot.pause()
+        # Simulate user scrolled up
+        conv._user_scrolled = True
+        # Record current scroll position to verify it's unchanged
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        # Don't re-enter the watcher; manually pin the flag (the watcher
+        # would have set it to True too, but we want to assert the gate
+        # works regardless).
+        conv._user_scrolled = True
+        scroll_before = log.scroll_y
+
+        async def _cb(_a: str) -> None:
+            return None
+
+        widget = conv.mount_intervention(
+            question="proceed?",
+            choices=None,
+            answer_callback=_cb,
+            iv_id="iv_scrolled_up",
+        )
+        await pilot.pause()
+        # Widget mounted
+        assert widget is not None
+        # And the scroll didn't move
+        assert log.scroll_y == scroll_before, (
+            f"intervention yanked user away from history: "
+            f"scroll_y went from {scroll_before} → {log.scroll_y}"
+        )
+
+
+# ── mount_error ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mount_error_skips_scroll_visible_when_user_scrolled_up() -> None:
+    """Tier 2: same gate applies to error-box mounts.
+
+    Errors arriving while the user reads history must not interrupt the
+    read; the ErrorBox carries its own visual cue (left-bar from #118)
+    so the user can find it on their next scroll-down.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        for i in range(60):
+            log.write(f"baseline {i}")
+        await pilot.pause()
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        conv._user_scrolled = True
+        scroll_before = log.scroll_y
+
+        box = conv.mount_error(
+            message="something broke",
+            details="trace",
+            run_id_short="abcd",
+            skill_name="test_skill",
+        )
+        await pilot.pause()
+        assert box is not None
+        assert log.scroll_y == scroll_before, (
+            f"error mount yanked user away from history: "
+            f"scroll_y went from {scroll_before} → {log.scroll_y}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mount_error_scrolls_visible_when_user_at_tail() -> None:
+    """Tier 2: with ``_user_scrolled = False``, error-box scroll-into-view fires.
+
+    Positive case for the error-box path so future refactors can't
+    suppress every yank.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        assert conv._user_scrolled is False
+
+        # Just verify the mount completes without raising — the
+        # positive-case scroll-visible behaviour is hard to observe
+        # without instrumentation, but the gate's negative case is the
+        # contract that matters.
+        box = conv.mount_error(message="boom")
+        await pilot.pause()
+        assert box is not None


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``mount_intervention`` and ``mount_error`` both called ``widget.scroll_visible()`` unconditionally after mount. That's correct when the user is following the live tail — but a user who scrolled UP to read history got yanked back to the bottom every time an async intervention or error arrived, losing their reading place. Ctrl+P/N turn-nav and the right-panel preview both rely on the user being able to scroll up and stay there; **intervention / error mounts were the only remaining paths that broke that contract.**

## Fix

Gate ``scroll_visible()`` on ``not self._user_scrolled``:

- **At the tail** (``_user_scrolled = False``): auto-yank fires as before — positive case unchanged.
- **Scrolled up** (``_user_scrolled = True``): skip the yank — widget still mounts at the bottom, discoverable via scrollbar / next scroll-down. ``hide_status()`` above intervention mount already replaces the live ``⟳ thinking…`` sticky, so users have a non-jerk signal that the run is waiting.

The ErrorBox path is gated identically. Errors mid-history now don't interrupt reads; the widget carries its own visual cue (left-bar from #118) so the user can find it on their next scroll-down.

## Why

Async-event UX audit (HIGH severity Finding F3). The flag was wired in #124 (user-scroll suppression); this PR closes the last two call sites that ignored it.

## Test plan

- [x] ``pytest tests/cli/test_intervention_respects_user_scroll.py`` — 4 passed (new Tier 2 invariants):
  - Intervention mounts at tail → mount completes (positive case)
  - Intervention mounts with user scrolled up → ``scroll_y`` unchanged (the F3 fix proof)
  - Error mounts at tail → mount completes (positive case)
  - Error mounts with user scrolled up → ``scroll_y`` unchanged
- [x] ``pytest tests/cli/`` — 128 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model / palette / sticky-timer / streaming-perf / stream-msgid tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)