### PR TITLE
fix(op_runtime/file): surface not_found as error+suggestions; fix glob_files dir-starvation

### DIFF
--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -14,6 +14,26 @@ from .context import OpContext
 _WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index"})
 _READ_OPS = frozenset({"read", "glob", "grep"})
 
+# Max nearby-file suggestions returned on a not_found error. Mirrors the
+# ~8-suggestion shape that invoke_action's UnknownActionError emits so the
+# LLM's "did you mean X" narration looks the same across both surfaces.
+_NOT_FOUND_SUGGESTIONS_LIMIT = 8
+
+
+def _nearby_files(ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LIMIT) -> list[str]:
+    """List sibling files under the parent of *path*, for use as not_found suggestions.
+
+    Returns project-relative paths from ``Workspace.glob_files``. Empty list
+    when the parent dir doesn't exist, permission is denied, or the glob
+    yields nothing — never raises.
+    """
+    parent = str(Path(path).parent) if str(Path(path).parent) not in ("", ".") else "."
+    pattern = f"{parent}/*" if parent != "." else "*"
+    try:
+        return ws.glob_files(pattern, max_results=max_results)
+    except (PermissionError, OSError):
+        return []
+
 
 async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "control_ir"]) -> dict:
     # Permission check (single point for both frontends). For
@@ -38,7 +58,19 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
 
     if op.op == "read":
         content, found = ctx.workspace.read_file(op.path)
-        if found and (op.offset is not None or op.limit is not None):
+        if not found:
+            suggestions = _nearby_files(ctx.workspace, op.path)
+            ctx.events.emit("tool_executed", op="read_file", path=op.path, found=False)
+            return {
+                "kind": "file",
+                "op": "read",
+                "path": op.path,
+                "status": "not_found",
+                "error": f"file not found: {op.path}",
+                "suggestions": suggestions,
+                "content": "",
+            }
+        if op.offset is not None or op.limit is not None:
             lines = content.splitlines(keepends=True)
             start = op.offset or 0
             sliced = lines[start:start + op.limit] if op.limit is not None else lines[start:]
@@ -48,7 +80,7 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
             "kind": "file",
             "op": "read",
             "path": op.path,
-            "status": "ok" if found else "not_found",
+            "status": "ok",
             "content": content,
         }
 
@@ -175,7 +207,15 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
 
     content, found = ctx.workspace.read_file(op.path)
     if not found:
-        return {"kind": "file", "op": "edit", "status": "not_found", "path": op.path}
+        suggestions = _nearby_files(ctx.workspace, op.path)
+        return {
+            "kind": "file",
+            "op": "edit",
+            "path": op.path,
+            "status": "not_found",
+            "error": f"file not found: {op.path}",
+            "suggestions": suggestions,
+        }
 
     count = content.count(op.old_string)
     if count == 0:

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -122,17 +122,24 @@ class Workspace:
                     raise PermissionError(
                         f"glob not permitted: {pattern!r} (outside project, no read permission)"
                     )
-            raw = sorted(_glob.glob(pattern, recursive=True))[:max_results]
-            return [m for m in raw if Path(m).is_file()]
+            # Filter for files BEFORE applying max_results; otherwise a glob
+            # whose first max_results matches are directories (common at the
+            # project root: .claude, .git, .github, .reyn, .venv, ...) silently
+            # truncates the file list to ~zero.
+            raw = sorted(_glob.glob(pattern, recursive=True))
+            files = [m for m in raw if Path(m).is_file()]
+            return files[:max_results]
 
+        # Same fix for the relative-path branch: filter to files first, then
+        # cap at max_results.
         ws_matches = sorted(self.base_dir.glob(pattern))
+        files_only = [m for m in ws_matches if m.is_file()]
         result = []
-        for m in ws_matches[:max_results]:
-            if m.is_file():
-                try:
-                    result.append(str(m.relative_to(self.base_dir)))
-                except ValueError:
-                    pass
+        for m in files_only[:max_results]:
+            try:
+                result.append(str(m.relative_to(self.base_dir)))
+            except ValueError:
+                pass
         return result
 
     def store_artifact(

--- a/tests/test_op_runtime_file_not_found_suggestions.py
+++ b/tests/test_op_runtime_file_not_found_suggestions.py
@@ -1,0 +1,200 @@
+"""Tests for file__read / file__edit not_found envelope shape.
+
+When a file doesn't exist, the op result includes an ``error`` string and a
+``suggestions`` list of sibling files under the same parent — matching the
+shape of invoke_action's UnknownActionError so the LLM produces "did you mean
+X" narration for missing files the same way it does for missing actions.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.op_runtime.context import OpContext
+from reyn.op_runtime.file import handle
+from reyn.permissions.permissions import PermissionDecl
+from reyn.schemas.models import FileIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _make_ctx(tmp_path: Path) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,  # skip op-level perm; covered in test_op_runtime_file_permissions.py
+        skill_name="test_skill",
+    )
+
+
+def _read(path: str) -> FileIROp:
+    return FileIROp(kind="file", op="read", path=path)
+
+
+def _edit(path: str, *, old: str = "x", new: str = "y") -> FileIROp:
+    return FileIROp(kind="file", op="edit", path=path, old_string=old, new_string=new)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── read not_found envelope ────────────────────────────────────────────────────
+
+
+def test_read_not_found_returns_error_and_suggestions(tmp_path, monkeypatch):
+    """Tier 2: file__read of a missing file in a populated parent dir returns
+    status='not_found' plus ``error`` string and ``suggestions`` list."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alpha.md").write_text("alpha", encoding="utf-8")
+    (tmp_path / "beta.md").write_text("beta", encoding="utf-8")
+    (tmp_path / "gamma.md").write_text("gamma", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_read("nonexistent.md"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert result["op"] == "read"
+    assert result["path"] == "nonexistent.md"
+    # error string present (matches invoke_action UnknownActionError shape)
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+    # content kept for backward-compat (callers that read it pre-this-change)
+    assert result["content"] == ""
+    # suggestions populated from parent dir (no fuzzy match, just listing)
+    assert "suggestions" in result
+    suggestion_names = {Path(p).name for p in result["suggestions"]}
+    assert suggestion_names >= {"alpha.md", "beta.md", "gamma.md"}
+
+
+def test_read_not_found_empty_dir_returns_empty_suggestions(tmp_path, monkeypatch):
+    """Tier 2: suggestions is an empty list (not missing key) when parent has no siblings."""
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path)
+
+    result = _run(handle(_read("nowhere.md"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert result["suggestions"] == []
+
+
+def test_read_not_found_capped_at_limit(tmp_path, monkeypatch):
+    """Tier 2: suggestions list does not exceed _NOT_FOUND_SUGGESTIONS_LIMIT (8)."""
+    monkeypatch.chdir(tmp_path)
+    for i in range(20):
+        (tmp_path / f"file{i:02d}.md").write_text("x", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_read("missing.md"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert len(result["suggestions"]) <= 8
+
+
+def test_read_ok_still_returns_ok_shape(tmp_path, monkeypatch):
+    """Tier 2: existing file read path returns status='ok' with content; no error or suggestions field bloat."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "exists.md").write_text("hello", encoding="utf-8")
+    ctx = _make_ctx(tmp_path)
+
+    result = _run(handle(_read("exists.md"), ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["content"] == "hello"
+    assert "error" not in result
+    assert "suggestions" not in result
+
+
+# ── edit not_found envelope ────────────────────────────────────────────────────
+
+
+def test_edit_not_found_returns_error_and_suggestions(tmp_path, monkeypatch):
+    """Tier 2: file__edit on a missing file returns the same error+suggestions shape as read."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "existing.py").write_text("pass", encoding="utf-8")
+    (tmp_path / "other.py").write_text("pass", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_edit("missing.py", old="foo", new="bar"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert result["op"] == "edit"
+    assert result["path"] == "missing.py"
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+    assert "suggestions" in result
+    suggestion_names = {Path(p).name for p in result["suggestions"]}
+    assert suggestion_names >= {"existing.py", "other.py"}
+
+
+def test_edit_existing_file_unchanged(tmp_path, monkeypatch):
+    """Tier 2: edit on an existing file follows the existing code path (no error/suggestions injected)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "file.py").write_text("foo bar foo", encoding="utf-8")
+    ctx = _make_ctx(tmp_path)
+
+    result = _run(handle(_edit("file.py", old="foo", new="baz"), ctx, "control_ir"))
+
+    # old_string appears twice, replace_all not set → error (= existing behaviour)
+    assert result["status"] == "error"
+    assert result["op"] == "edit"
+    # Pre-existing error path doesn't carry our new fields
+    assert "suggestions" not in result
+
+
+# ── parent-dir edge cases ──────────────────────────────────────────────────────
+
+
+def test_read_not_found_in_nested_missing_dir(tmp_path, monkeypatch):
+    """Tier 2: missing parent dir → suggestions empty, no crash."""
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path)
+
+    result = _run(handle(_read("nonexistent_dir/file.md"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert result["suggestions"] == []
+
+
+def test_read_not_found_in_nested_existing_dir(tmp_path, monkeypatch):
+    """Tier 2: parent dir exists with siblings → those siblings are suggested."""
+    monkeypatch.chdir(tmp_path)
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    (sub / "sibling1.txt").write_text("a", encoding="utf-8")
+    (sub / "sibling2.txt").write_text("b", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_read("subdir/missing.txt"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    suggestion_names = {Path(p).name for p in result["suggestions"]}
+    assert suggestion_names >= {"sibling1.txt", "sibling2.txt"}
+
+
+def test_suggestions_not_starved_by_dirs(tmp_path, monkeypatch):
+    """Tier 2 regression guard: ``Workspace.glob_files`` pre-fix sliced the
+    result list before filtering for files, so a parent dir whose first
+    ``max_results`` entries were directories produced almost no suggestions.
+
+    With ~10 hidden dirs (matching the project-root case .claude/.git/.github/
+    .reyn/.venv/...) and 5 real files, the suggestions must still surface
+    the files, not be starved out by the dirs.
+    """
+    monkeypatch.chdir(tmp_path)
+    for i in range(10):
+        (tmp_path / f".hiddendir{i:02d}").mkdir()
+    for name in ("alpha.md", "beta.md", "gamma.md", "delta.md", "epsilon.md"):
+        (tmp_path / name).write_text("x", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_read("missing.md"), ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    names = {Path(p).name for p in result["suggestions"]}
+    assert names >= {"alpha.md", "beta.md", "gamma.md", "delta.md", "epsilon.md"}


### PR DESCRIPTION
## Summary

E2e-coder N1 (error surfacing) probe surfaced a real defect: when \`file__read\` or \`file__edit\` is called on a missing path, the result envelope previously was \`{status: ok, data: {status: not_found, content: ""}}\` — the LLM saw outer \`status: ok\` and interpreted it as "tool ran fine, file just empty", producing bare "couldn't find" narration with no "did you mean X" affordance.

This PR aligns the file ops' not_found envelope with the shape \`invoke_action\`'s \`UnknownActionError\` already uses (= explicit \`error\` string + \`suggestions\` list of nearby files). LLM narration now mentions the error explicitly and references suggested alternatives.

While implementing, surfaced a parallel bug in \`Workspace.glob_files\`: the result list was sliced to \`max_results\` BEFORE filtering for files, so a parent dir whose first \`max_results\` entries were directories (project root: \`.claude\` / \`.git\` / \`.github\` / \`.reyn\` / \`.venv\` / ...) yielded almost no file matches. Filter first, then cap. Fixed in the same PR because the not_found suggestions depend on it; it also independently improves \`file__glob\` accuracy.

## Empirical verification

Manual dogfood, fresh \`.reyn/\`, weak \`gemini-2.5-flash-lite\`, probe \`Read the file ./nonexistent-12345.md and tell me what it says.\`:

**Before:**
> "I was unable to find the file \`./nonexistent-12345.md\`. It seems to not exist."

**After:**
> "I encountered an error: file not found: ./nonexistent-12345.md. It seems the file you're trying to access doesn't exist. Would you like me to try reading one of the suggested files instead?"

The tool envelope returned to the LLM after the fix carries 8 sibling files (\`.gitignore\`, \`CHANGELOG.md\`, \`CLAUDE.md\`, \`CODE_OF_CONDUCT.md\`, \`CONTRIBUTING.md\`, \`LICENSE\`, \`Makefile\`, \`README.md\`) under \`suggestions\`. Light-user UX gain: the agent now flags the error explicitly and offers a recovery path; previously it stopped at "couldn't find" with no follow-through.

## Diff scope (3 files)

- **\`src/reyn/op_runtime/file.py\`** — \`read\` and \`edit\` not_found branches now return \`{status: "not_found", error: <str>, suggestions: [...], content: ""}\` (read) / \`{...edit...}\`. Helper \`_nearby_files\` lists up to 8 siblings via \`Workspace.glob_files\`. \`status: "not_found"\` retained for backward-compat with existing callers.
- **\`src/reyn/workspace/workspace.py\`** — \`glob_files\` filters to files BEFORE slicing to \`max_results\`. Both absolute-path and relative-path branches.
- **\`tests/test_op_runtime_file_not_found_suggestions.py\`** (new) — 9 Tier 2 tests covering both ops, both shapes, edge cases (empty parent dir, deeply nested missing dir, suggestions cap, and the dir-starvation regression guard for the glob_files fix).

Backward-compat: existing callers (\`src/reyn/chat/session.py:_file_read\` and \`src/reyn/reporters/console.py\`) check \`status == "not_found"\` and continue to work unchanged. The new \`error\` and \`suggestions\` fields are additive.

## Audit of adjacent surfaces (= horizontal application)

Audited other op handlers for the same shape mismatch (= "operation succeeded but in-data status indicates failure, with no LLM-actionable suggestion field"):

| Handler | Current state | In this PR? |
|---|---|---|
| \`file__read\` / \`file__edit\` | not_found w/o error+suggestions | **✅ fixed** |
| \`memory.entry__read\` (\`read_memory_body\`) | \`{error: "memory entry not found"}\` — has error, no suggestions | follow-up |
| \`memory.entry__forget\` | same shape | follow-up |
| \`mcp_drop_server\` | \`{status: not_found}\` — no error string, no suggestions | follow-up |
| \`reyn_src_read\` / \`reyn_src_list\` | has error, no suggestions | follow-up |
| \`web__fetch\` / \`mcp.tool__*\` | has error; "similar URL" / "similar MCP tool" not naturally definable | N/A |

The follow-up candidates are deferred because (a) they weren't directly observed in an e2e probe (= we shouldn't paper over unmeasured cases per \`[[separate-leak-types-before-measuring]]\`), and (b) the \`memory.entry\` paths need a shared helper across two call sites (\`router_loop._read_memory_body\` and \`tools/memory.py\` fallback) which is a larger refactor. Open as a sibling PR when a real probe surfaces the gap.

## Test plan

- [x] \`pytest tests/test_op_runtime_file_not_found_suggestions.py\` → 9 pass
- [x] \`pytest tests/test_op_runtime_file_permissions.py\` → 57 pass (no regression on existing file-op semantics)
- [x] \`pytest -k 'session or router_loop'\` → 137 pass (no regression on consumers of the new envelope)
- [x] Manual dogfood: \`echo 'Read the file ./nonexistent-12345.md...' | reyn chat --cui\` produces an LLM reply that mentions the error and references the suggestions
- [ ] Reviewer to confirm follow-up scope (= memory.entry / mcp_drop_server / reyn_src) is appropriate to defer

## Related

- E2e-coder N1 (error-surfacing) probe — discovered the defect
- \`invoke_action\` \`UnknownActionError\` (\`src/reyn/tools/universal_catalog.py:_build_error_response\`) — the shape this PR aligns to
- giveup-tracker G12 family — error-narration optimism-bias is in the adjacent attractor space; this PR materially reduces one of its precursors (= empty-content-looks-ok)
- PR #129 (open, separate scope) — G31 three-component decomposition; same e2e-coder session

[e2e-coder]