### PR TITLE
feat(tui): out-of-band signals — BEL + dynamic terminal title

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -48,6 +48,14 @@ class ReynTUIApp(App):
 
     CSS_PATH = Path(__file__).parent / "theme.tcss"
 
+    # Default terminal window title — shown in the tab bar of multiplexers
+    # (tmux, iTerm2 tabs, gnome-terminal). Defaults to the class name
+    # (``"ReynTUIApp"``) if left unset, which leaks an implementation
+    # detail. ``set_title_state`` swaps this to ``reyn — awaiting answer``
+    # / ``reyn — error`` etc. so a user in a background terminal can see
+    # the state without focusing the window.
+    TITLE = "reyn"
+
     ENABLE_COMMAND_PALETTE = False
 
     BINDINGS = [
@@ -260,6 +268,35 @@ class ReynTUIApp(App):
             queued_extra=queued_extra,
         )
 
+    def set_title_state(self, state: str | None) -> None:
+        """Set the terminal window title to reflect the agent's state.
+
+        ``state`` is a short verb / noun like ``"awaiting answer"``,
+        ``"error"``, or ``None`` for idle. The title shown in the tab
+        bar becomes ``"reyn — <state>"`` (or just ``"reyn"`` for idle)
+        so a user with reyn in a background terminal tab can see the
+        state without focusing the window. Wraps ``self.title`` to
+        contain the formatting in one place and let tests assert on a
+        normalised state token.
+        """
+        try:
+            self.title = f"reyn — {state}" if state else "reyn"
+        except Exception:
+            pass
+
+    def alert(self) -> None:
+        """Fire the terminal BEL for "you need to come back" events.
+
+        Wraps ``self.bell()`` so call sites don't need to know whether
+        the platform supports it (the call is a no-op on terminals that
+        ignore ``\\a``). The helper exists so future ``/quiet`` opt-out
+        can short-circuit one place rather than every hook point.
+        """
+        try:
+            self.bell()
+        except Exception:
+            pass
+
     def _maybe_refresh_status(self, header: ReynHeader | None = None) -> None:
         """Fetch budget snapshot and update the header.
 
@@ -371,6 +408,14 @@ class ReynTUIApp(App):
             # as "skill done: <status>" so the row can stop spinning here.
             status = text[len("skill done: "):].strip()
             conv.finish_skill_row(run_id, success=(status == "finished"), reason="")
+            # Out-of-band: an aborted skill is an attention case — flash the
+            # title to "error" and ring the bell so a user with reyn in a
+            # background tab sees something happened. Successful finishes
+            # are silent here (the next agent reply / cost suffix is the
+            # in-pane signal). The title resets on the next user submit.
+            if status != "finished":
+                self.set_title_state("error")
+                self.alert()
             # Issue 2 — dim completion line in conversation log
             _existing = self._skill_exec.get(run_id) or {}
             _elapsed = _now_monotonic() - _existing.get("start_time", _now_monotonic())
@@ -439,6 +484,10 @@ class ReynTUIApp(App):
         conv.render_user_message(text)
         # A4: snapshot cost/tokens/time at turn start
         self._record_turn_start()
+        # Out-of-band: a fresh user submit clears any prior "awaiting
+        # answer" / "error" title flag — the user is back at the
+        # keyboard, so the attention signal has done its job.
+        self.set_title_state(None)
         # Remember this message so the next skill run that fires can
         # tag itself with "triggered_by". Cleared / overwritten on each
         # subsequent submit, so a long-tail skill that finishes after

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -459,6 +459,13 @@ class OutboxRouter:
         self._app._mount_intervention(
             conv, msg.text, iv_id, choices, queued_extra=queued_extra,
         )
+        # Out-of-band signals: the agent is hard-blocked on a human answer,
+        # so a user in a background terminal tab needs to know to come
+        # back. The terminal title flips visible in the tab bar; the BEL
+        # gives an audio cue. Both reset when the user submits an answer
+        # (see InputBar.UserSubmitted path → set_title_state(None)).
+        self._app.set_title_state("awaiting answer")
+        self._app.alert()
 
     def _on_intervention_resolved(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
@@ -525,6 +532,11 @@ class OutboxRouter:
         conv.hide_status()
         conv.render_message(msg)
         self._app._last_focal_tab = "events"
+        # Out-of-band: flag the terminal title and ring the bell so a
+        # user with reyn in a background tab notices something failed.
+        # Reset on the next user submit.
+        self._app.set_title_state("error")
+        self._app.alert()
 
 
 __all__ = ["OutboxRouter"]

--- a/tests/cli/test_out_of_band_signals.py
+++ b/tests/cli/test_out_of_band_signals.py
@@ -1,0 +1,238 @@
+"""Tier 2: BEL + terminal title flag "user needed" events out-of-band.
+
+Notification UX audit (HIGH severity Findings F1–F3): the TUI had no
+audio (``\\a`` BEL) or out-of-band visual signal for attention events.
+A user in another terminal tab had no way to know an intervention was
+waiting, an error fired, or a skill aborted — the only signals were
+in-pane and required the user to actively look at the TUI.
+
+The fix wires two channels for the three attention events:
+
+  1. ``self._app.bell()`` (via the ``alert()`` helper) — emits ``\\a``
+     so terminals that translate BEL to a sound / flash give an audio
+     or visual cue. No-op on quiet terminals.
+  2. ``self.title = "reyn — <state>"`` (via ``set_title_state``) —
+     surfaces in the terminal multiplexer's tab bar so a backgrounded
+     reyn window broadcasts its state.
+
+Events that trigger the signals:
+  • Intervention mount → title="awaiting answer" + bell
+  • Error mount → title="error" + bell
+  • Skill aborted (``skill done: aborted``) → title="error" + bell
+  • User submit → title resets to None (= "reyn")
+
+These tests pin all four transitions plus the default-title invariant.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.app_outbox import OutboxRouter
+from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="aria",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _instrument_alert(app: ReynTUIApp) -> list[None]:
+    """Replace ``app.alert`` with a no-op counter via direct attribute swap.
+
+    No ``unittest.mock`` per the testing policy.
+    """
+    calls: list[None] = []
+
+    def _fake() -> None:
+        calls.append(None)
+
+    app.alert = _fake  # type: ignore[method-assign]
+    return calls
+
+
+# ── default title ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_default_title_is_reyn_not_class_name() -> None:
+    """Tier 2: the default terminal title is ``"reyn"``, not ``"ReynTUIApp"``.
+
+    Textual defaults the title to the App subclass name when ``TITLE``
+    isn't set. That leaked an implementation detail to the terminal tab
+    bar. Pinning the ``TITLE`` class attribute keeps the surface clean.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        assert app.title == "reyn", (
+            f"expected default title 'reyn'; got {app.title!r}"
+        )
+
+
+# ── set_title_state helper ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_title_state_formats_consistently() -> None:
+    """Tier 2: ``set_title_state(state)`` produces ``"reyn — <state>"`` or ``"reyn"``."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        app.set_title_state("awaiting answer")
+        assert app.title == "reyn — awaiting answer"
+        app.set_title_state("error")
+        assert app.title == "reyn — error"
+        app.set_title_state(None)
+        assert app.title == "reyn"
+
+
+# ── intervention triggers both signals ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intervention_mount_sets_awaiting_and_rings_bell() -> None:
+    """Tier 2: ``_on_intervention`` flips the title AND fires the bell.
+
+    The bell is delegated to ``alert()``; instrumenting it lets us verify
+    the call without depending on terminal capabilities. The title is
+    user-visible state — assert directly on ``app.title``.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        # Stub _get_session so the queue-depth lookup doesn't crash on None
+        app._get_session = lambda: None  # type: ignore[method-assign]
+
+        alerts = _instrument_alert(app)
+        router = OutboxRouter(app)
+        router._on_intervention(
+            OutboxMessage(
+                kind="intervention",
+                text="proceed?",
+                meta={"intervention_id": "iv1"},
+            ),
+            conv, header,
+        )
+        await pilot.pause()
+
+        assert app.title == "reyn — awaiting answer", (
+            f"intervention must set the title; got {app.title!r}"
+        )
+        assert len(alerts) == 1, (
+            f"intervention must fire exactly one bell; got {len(alerts)}"
+        )
+
+
+# ── error triggers both signals ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_error_mount_sets_error_title_and_rings_bell() -> None:
+    """Tier 2: ``_on_error`` flips title to 'error' + rings bell."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+
+        alerts = _instrument_alert(app)
+        router = OutboxRouter(app)
+        router._on_error(
+            OutboxMessage(kind="error", text="boom"),
+            conv, header,
+        )
+        await pilot.pause()
+
+        assert app.title == "reyn — error"
+        assert len(alerts) == 1
+
+
+# ── user submit resets the title ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_submit_resets_title_to_idle() -> None:
+    """Tier 2: a fresh user submit clears any prior attention flag.
+
+    The user is back at the keyboard — the signal has done its job.
+    Subsequent attention events arm the flag again from idle.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        # Pretend an error / intervention already flipped the title
+        app.set_title_state("error")
+        assert app.title == "reyn — error"
+
+        # User types a fresh message — drive the submit path
+        from reyn.chat.tui.widgets import InputBar
+        app.post_message(InputBar.UserSubmitted("hello"))
+        # Pump the message queue a few times
+        for _ in range(5):
+            await pilot.pause()
+
+        assert app.title == "reyn", (
+            f"user submit must reset title to idle; got {app.title!r}"
+        )
+
+
+# ── skill aborted triggers signals; finished is silent ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_aborted_flags_error_and_rings_bell() -> None:
+    """Tier 2: ``skill done: aborted`` flips the title + rings the bell.
+
+    Success path (``skill done: finished``) stays silent — the in-pane
+    completion line and any agent reply are signal enough; users don't
+    want a bell for every successful skill.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        alerts = _instrument_alert(app)
+
+        # Aborted path
+        aborted = OutboxMessage(
+            kind="trace",
+            text="skill done: aborted",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, aborted)
+        await pilot.pause()
+        assert app.title == "reyn — error"
+        assert len(alerts) == 1
+
+        # Reset for the success path
+        app.set_title_state(None)
+        alerts.clear()
+
+        finished = OutboxMessage(
+            kind="trace",
+            text="skill done: finished",
+            meta={"skill_name": "s", "run_id": "r2"},
+        )
+        app._handle_trace_for_skill_row(conv, finished)
+        await pilot.pause()
+        # Successful finish leaves the title at "reyn" (no flag change)
+        assert app.title == "reyn"
+        assert alerts == [], (
+            f"successful finish must not ring the bell; got {len(alerts)}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Three HIGH-severity findings from the notification UX audit collapse to one root cause: the TUI had **zero out-of-band attention signals**. A user with reyn in a background terminal tab could not tell that an intervention was waiting, an error fired, or a skill aborted — every signal was in-pane and required actively looking at the TUI.

Wire two channels for "user needed" events:

| Channel | Mechanism | When it helps |
| --- | --- | --- |
| **BEL** | ``self.bell()`` (via ``alert()`` helper) emits ``\\a`` | Audio cue / visual flash on terminals that translate BEL |
| **Title** | ``self.title = "reyn — <state>"`` (via ``set_title_state``) | Tab bar in tmux / iTerm2 / gnome-terminal |

Default title is now ``"reyn"`` (was the leaking class name ``"ReynTUIApp"``).

### Hook points

| Event | Title | Bell |
| --- | --- | --- |
| ``_on_intervention`` (agent hard-blocked) | ``awaiting answer`` | ✓ |
| ``_on_error`` | ``error`` | ✓ |
| ``skill done: aborted`` | ``error`` | ✓ |
| ``skill done: finished`` | unchanged | — (silent; in-pane completion is enough) |
| User submit | ``reyn`` (idle) | — |

## Why

Notification UX audit (HIGH severity Findings F1, F2, F3 — all three resolved in this PR). The intervention case is the most painful: the skill is *hard-blocked* and the user simply must come back, but had no out-of-band signal that the wait had started. Two channels (audio + visual tab-bar) cover the realistic "user is away" failure modes.

The ``set_title_state`` + ``alert`` helpers consolidate the formatting + bell in one place so a follow-up ``/quiet`` opt-out (LOW severity F6) can short-circuit one location rather than every call site.

## Test plan

- [x] ``pytest tests/cli/test_out_of_band_signals.py`` — 6 passed (new Tier 2 invariants):
  - Default title is ``"reyn"``, not the App class name
  - ``set_title_state`` formats consistently for state / ``None``
  - Intervention mount → ``"awaiting answer"`` title + 1 bell
  - Error mount → ``"error"`` title + 1 bell
  - User submit resets title to ``"reyn"``
  - Aborted skill → ``"error"`` + 1 bell; finished skill is silent
- [x] ``pytest tests/cli/`` — 153 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model / palette / sticky-timer / streaming-perf / stream-msgid / right-panel-refresh / scroll-suppression / intervention-scroll tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)