### PR TITLE
fix(tui): surface phase_completed transition on SkillActivityRow

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -347,8 +347,12 @@ class ReynTUIApp(App):
 
         Recognised text patterns from ChatEventForwarder:
           - "phase started: <phase_name>" → start row (if missing) + set_phase
-          - "<phase> → <next> ..."         → ignored (phase-completed details
-            are visible in the right panel events tab)
+          - "<phase> → <next> ..."         → phase_completed transition. The
+            outgoing phase's LLM call may take 10-30 s before the next
+            ``phase started`` arrives; without this branch the row would
+            stay on the OLD phase name the whole time, making the skill
+            look stuck. Show ``<phase> → <next>`` so the user can see the
+            handoff is in flight.
           - "skill done: <status>"         → finish row (FP-0011/FP-0012)
         """
         run_id = msg.meta.get("run_id", "")
@@ -364,6 +368,23 @@ class ReynTUIApp(App):
             existing = self._skill_exec.get(run_id) or {}
             visit = int(existing.get("phase_visits", 0)) + 1
             conv.update_skill_phase(run_id, phase, visit=visit)
+            self._last_focal_tab = "agents"
+        elif " → " in text and not text.startswith("skill done: "):
+            # phase_completed trace: ``<phase> → <next>(  (confidence=X))?``
+            # Strip the optional confidence suffix and display the bare
+            # transition so the row reflects "old phase has handed off to
+            # next" until the next ``phase started`` arrives. The visit
+            # count is left at the existing exec state (= the just-
+            # finished phase's visit) so the badge doesn't bump too
+            # early.
+            transition = text.split("  (confidence=", 1)[0].strip()
+            existing = self._skill_exec.get(run_id) or {}
+            # If no row exists yet (edge case: a malformed forwarder
+            # delivered phase_completed before phase_started), lazy-mount
+            # to keep behaviour robust.
+            conv.start_skill_row(run_id, skill_name)
+            visit = int(existing.get("phase_visits", 1)) or 1
+            conv.update_skill_phase(run_id, transition, visit=visit)
             self._last_focal_tab = "agents"
         elif text.startswith("skill done: "):
             # FP-0011: skill_narrator removed → skill_done outbox kind gone.

--- a/tests/cli/test_phase_completed_visible.py
+++ b/tests/cli/test_phase_completed_visible.py
@@ -1,0 +1,208 @@
+"""Tier 2: ``phase_completed`` traces update the SkillActivityRow.
+
+Skill-execution UX audit (HIGH severity Finding F1):
+``ChatEventForwarder.on_phase_completed`` enqueues ``"<phase> → <next>
+(confidence=X)"`` trace messages, but the TUI's
+``_handle_trace_for_skill_row`` only matched ``"phase started: "`` and
+``"skill done: "`` prefixes — the transition text was silently dropped.
+
+Between ``phase A completed`` and ``phase B started``, the outgoing
+phase's LLM call can take 10–30 s. During that window the row showed
+the OLD phase name (or a stale phase from earlier), making the skill
+look stuck. The fix routes the transition into ``update_skill_phase``
+with the parsed ``"<phase> → <next>"`` label so the user sees the
+handoff is in flight.
+
+These tests pin the parsing + dispatch contract by instrumenting
+``conv.update_skill_phase`` via direct attribute substitution.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _instrument_update(conv: ConversationView):
+    """Capture calls to ``update_skill_phase`` (run_id, phase, visit)."""
+    captured: list[tuple[str, str, int]] = []
+
+    def _fake(run_id: str, phase: str, visit: int = 1) -> None:
+        captured.append((run_id, phase, visit))
+
+    conv.update_skill_phase = _fake  # type: ignore[method-assign]
+    return captured
+
+
+# ── transition trace updates the row ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_phase_completed_trace_shows_transition_label() -> None:
+    """Tier 2: ``"<phase> → <next>"`` updates the row with the transition string.
+
+    The row should land on ``"plan → review"`` so the user sees the
+    handoff is happening rather than staring at ``"plan"`` for 30 s.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        captured = _instrument_update(conv)
+
+        msg = OutboxMessage(
+            kind="trace",
+            text="plan → review",
+            meta={"skill_name": "code_review", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+
+        assert captured, "no update_skill_phase call captured"
+        run_id, phase, _visit = captured[-1]
+        assert run_id == "r1"
+        assert phase == "plan → review", (
+            f"transition label wrong: got {phase!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_phase_completed_strips_confidence_suffix() -> None:
+    """Tier 2: ``"  (confidence=0.9)"`` suffix is stripped from the row label.
+
+    The confidence value is visible in the right-panel events tab and
+    is high-detail; the conv-pane row should stay terse.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        captured = _instrument_update(conv)
+
+        msg = OutboxMessage(
+            kind="trace",
+            text="plan → review  (confidence=0.9)",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+
+        assert captured
+        _, phase, _ = captured[-1]
+        assert phase == "plan → review", (
+            f"confidence suffix not stripped: got {phase!r}"
+        )
+
+
+# ── visit count preserved across transition ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_phase_completed_keeps_existing_visit_count() -> None:
+    """Tier 2: the transition reuses the just-finished phase's visit count.
+
+    The next ``phase started`` will increment to the new phase's visit
+    via the existing ``+1`` logic. Bumping during the transition would
+    desync the badge from the user's mental model ("how many times has
+    the skill cycled through phase X?").
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        captured = _instrument_update(conv)
+
+        # Prime exec state with a visit count
+        app._skill_exec["r1"] = {"phase_visits": 3, "skill_name": "s"}
+
+        msg = OutboxMessage(
+            kind="trace",
+            text="plan → review",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+
+        assert captured
+        _, _, visit = captured[-1]
+        assert visit == 3, (
+            f"transition must reuse current visit count; got {visit}"
+        )
+
+
+# ── phase_started still works (regression guard) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_phase_started_still_increments_visit() -> None:
+    """Tier 2: the existing ``phase started:`` branch is unchanged.
+
+    Defence against the new ``" → "`` branch accidentally catching
+    ``phase started`` lines if the parsing order ever shifts.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        captured = _instrument_update(conv)
+
+        app._skill_exec["r1"] = {"phase_visits": 2, "skill_name": "s"}
+
+        msg = OutboxMessage(
+            kind="trace",
+            text="phase started: review",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+
+        assert captured
+        _, phase, visit = captured[-1]
+        assert phase == "review"
+        assert visit == 3, "phase_started must continue to bump visit by 1"
+
+
+# ── skill done: pattern is NOT treated as a transition ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_done_branch_does_not_run_transition_path() -> None:
+    """Tier 2: ``"skill done: …"`` text is handled by the dedicated branch.
+
+    The new transition branch keys on ``" → "`` substring; a
+    pathological skill-done text containing that substring would
+    otherwise route to the wrong handler. The explicit
+    ``not text.startswith("skill done: ")`` guard prevents that.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        captured = _instrument_update(conv)
+
+        # Pin: skill_done text shouldn't accidentally trigger update_skill_phase
+        msg = OutboxMessage(
+            kind="trace",
+            text="skill done: finished",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+        # No transition call should have happened — done is handled by
+        # finish_skill_row, which we didn't instrument here.
+        assert captured == [], (
+            f"skill done leaked into the transition branch: {captured}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``ChatEventForwarder.on_phase_completed`` enqueues a ``"<phase> → <next>  (confidence=X)"`` trace whenever the OS transitions phases, but ``_handle_trace_for_skill_row`` only matched ``"phase started: "`` and ``"skill done: "`` — the transition text was silently dropped.

Between phase A's ``phase_completed`` event and phase B's ``phase_started``, the outgoing phase's LLM call (judge / preprocess / context-build) can take **10–30 seconds**. During that whole window the row showed the OLD phase name, making any non-trivial skill look stuck — the spinner kept spinning on a label that was wrong.

## Fix

Route the transition into ``update_skill_phase`` with the parsed ``"<phase> → <next>"`` label so the row reflects the handoff is in flight:

- **Confidence suffix stripped** (``"  (confidence=0.9)"``) to keep the conv-pane row terse; full detail stays in the right-panel events tab.
- **Visit count left at the just-finished phase's value** — the next ``phase started`` will increment it via the existing ``+1`` logic, so the badge stays in sync with the user's mental model.
- **Lazy-create the row** if a malformed forwarder ever delivers ``phase_completed`` before ``phase_started``.

Guarded against catching ``"skill done: …"`` text by an explicit ``not text.startswith("skill done: ")`` check on the new branch — that path remains owned by the dedicated finish handler.

### Before / After

Before:
```
14:32  reyn ──────────────
       ⠙ code_review#abcd  · plan  ●○○○  18.2s
                            ^^^^ ← stale; phase actually transitioning to "review" for ~15s already
```

After:
```
14:32  reyn ──────────────
       ⠙ code_review#abcd  · plan → review  ●○○○  18.2s
                            ^^^^^^^^^^^^^^ ← user sees handoff in flight
```

## Why

Skill-execution UX audit (HIGH severity Finding F1). The 10–30 s mid-transition visibility gap was the #1 "is the skill stuck?" failure mode in dogfood.

## Test plan

- [x] ``pytest tests/cli/test_phase_completed_visible.py`` — 5 passed (new Tier 2 invariants):
  - ``"plan → review"`` updates the row label
  - ``"plan → review  (confidence=0.9)"`` strips the confidence suffix
  - The transition reuses the current visit count (= no early bump)
  - ``"phase started: …"`` still bumps visit by 1 (regression guard)
  - ``"skill done: finished"`` does NOT route through the new branch
- [x] ``pytest tests/cli/`` — 152 passed (no regression in existing TUI smoke / cost-suffix / fold-stash / anchor / focus-steal / header-align / copy-ring / hanging-indent / error-box / focus-restore / slash-click / header-model / palette / sticky-timer / streaming-perf / stream-msgid / right-panel-refresh / scroll-suppression / intervention-scroll / out-of-band-signals tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)