### PR TITLE
feat(tui): surface in-phase detail (llm / act ops) on SkillActivityRow

### DIFF
--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -60,6 +60,45 @@ class ChatEventForwarder:
     def on_workflow_aborted(self, data: dict) -> None:
         self._enqueue("skill done: aborted")
 
+    # ── In-phase detail signals (skill internal progress) ────────────────────
+    # Without these, the SkillActivityRow showed only the phase name
+    # during long LLM calls or heavy Control IR runs — a 10–30 s blank
+    # window where the user couldn't tell "still working" from "stuck".
+    # The ``detail: ...`` prefix is consumed by the TUI's trace handler
+    # and routed to ``ConversationView.update_skill_detail`` which
+    # appends a dim ``⤷ <text>`` segment to the row. Cleared by the
+    # next ``phase_started``.
+
+    def on_llm_called(self, data: dict) -> None:
+        """LLM call started — surface the model name as detail.
+
+        Fires once per LLM call; the row shows ``⤷ llm: <model>`` until
+        the response arrives or the phase advances.
+        """
+        model = data.get("model") or "?"
+        self._enqueue(f"detail: llm: {model}")
+
+    def on_llm_response_received(self, data: dict) -> None:
+        """LLM call finished — clear the detail (= we're between calls).
+
+        Without this the row would keep showing ``⤷ llm: <model>`` long
+        after the response arrived, misleading users about whether the
+        model is still working.
+        """
+        self._enqueue("detail: ")
+
+    def on_act_executed(self, data: dict) -> None:
+        """Control IR ops just ran — show a short summary as detail.
+
+        ``act_executed`` fires after a batch of ops complete; the
+        ``op_count`` from the event payload is the count of ops in that
+        batch. Useful as a "the skill is actively working" signal during
+        heavy preprocessor turns.
+        """
+        op_count = data.get("op_count")
+        if op_count:
+            self._enqueue(f"detail: act: {op_count} op{'s' if op_count != 1 else ''}")
+
     def _enqueue(self, text: str) -> None:
         # Fire-and-forget: trace messages are advisory, never block the skill.
         meta: dict = {"skill_name": self.skill_name}

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -402,6 +402,15 @@ class ReynTUIApp(App):
             visit = int(existing.get("phase_visits", 0)) + 1
             conv.update_skill_phase(run_id, phase, visit=visit)
             self._last_focal_tab = "agents"
+        elif text.startswith("detail: "):
+            # In-phase detail (llm call / act batch / etc). Append a dim
+            # ``⤷ <detail>`` segment to the row so the user sees the
+            # skill is actively working rather than wondering if it's
+            # stuck on the phase name. An empty detail (``"detail: "``)
+            # clears the segment — that's how the forwarder signals
+            # "llm call finished; we're between events".
+            detail = text[len("detail: "):]
+            conv.update_skill_detail(run_id, detail)
         elif text.startswith("skill done: "):
             # FP-0011: skill_narrator removed → skill_done outbox kind gone.
             # ChatEventForwarder now forwards workflow_finished / workflow_aborted

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -655,6 +655,17 @@ class ConversationView(Widget):
         if row is not None:
             row.set_phase(phase, visit=visit)
 
+    def update_skill_detail(self, run_id: str, detail: str) -> None:
+        """Update the row's in-phase detail (=``⤷ <detail>`` segment).
+
+        No-op if the row isn't mounted yet (a detail trace can arrive
+        before the first ``phase_started``; the row will be lazy-mounted
+        on the next phase event and will pick up subsequent details).
+        """
+        row = self._skill_rows.get(run_id)
+        if row is not None:
+            row.set_detail(detail)
+
     def finish_skill_row(
         self, run_id: str, *, success: bool = True, reason: str = "",
     ) -> None:

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -87,6 +87,13 @@ class SkillActivityRow(Widget):
         self._phase: str = ""
         self._visit: int = 1
         self._progress: tuple[int, int] | None = None  # (current, total)
+        # Optional in-phase detail (= what's happening WITHIN the phase right
+        # now — "calling llm", "running act op", etc.). Without this the row
+        # showed only the phase name during a 10–30 s LLM call inside that
+        # phase, with no signal whether the skill was making progress or
+        # stuck. The detail is replaced each event and cleared on phase
+        # change (= the new phase's detail context starts fresh).
+        self._detail: str = ""
 
         # Finish state
         self._finished = False
@@ -116,9 +123,27 @@ class SkillActivityRow(Widget):
     # ── Public API ─────────────────────────────────────────────────────────────
 
     def set_phase(self, phase: str, visit: int = 1) -> None:
-        """Update the currently active phase name (and visit count)."""
+        """Update the currently active phase name (and visit count).
+
+        Also clears any in-phase detail — the previous phase's "llm:
+        <model>" / "act: <op>" context is no longer relevant once the
+        phase advances.
+        """
         self._phase = phase
         self._visit = visit
+        self._detail = ""
+        self._refresh()
+
+    def set_detail(self, detail: str) -> None:
+        """Update the in-phase detail text shown after the elapsed counter.
+
+        Detail is ephemeral: each call replaces the previous text, and
+        ``set_phase`` clears it on phase advance. Empty string hides
+        the detail segment. Typical sources: forwarder ``on_llm_called``
+        (= ``"llm: <model>"``) or ``on_act_executed``
+        (= ``"act: <N> ops"``).
+        """
+        self._detail = detail
         self._refresh()
 
     def set_progress(self, current: int, total: int) -> None:
@@ -192,6 +217,13 @@ class SkillActivityRow(Widget):
         else:
             elapsed_style = "dim"
         t.append(f"  {secs:.1f}s", style=elapsed_style)
+        # In-phase detail ("llm: opus-4-5", "act: 3 ops", etc.). Dim so
+        # it doesn't compete with the phase name, separated from elapsed
+        # by ``  ⤷`` so the eye can grok "this is the inner-most thing
+        # happening right now".
+        if self._detail:
+            t.append("  ⤷ ", style="dim")
+            t.append(self._detail, style="dim")
         return t
 
     def _build_finished(self) -> Text:

--- a/tests/cli/test_skill_in_phase_detail.py
+++ b/tests/cli/test_skill_in_phase_detail.py
@@ -1,0 +1,234 @@
+"""Tier 2: SkillActivityRow surfaces in-phase detail signals.
+
+Skill-execution UX audit (MED severity Finding F4): all tool ops inside
+a skill were silent. ``ChatEventForwarder`` only forwarded
+``phase_started`` / ``phase_completed`` / ``workflow_finished`` /
+``workflow_aborted``. Long LLM calls or heavy Control IR batches
+inside a phase produced no user-visible signal — the row spinner
+just kept spinning on the phase name for 10–30 s with no indication
+of whether the skill was making progress or stuck.
+
+The fix wires three additional event handlers in the forwarder:
+
+  • ``on_llm_called``          → ``"detail: llm: <model>"``
+  • ``on_llm_response_received`` → ``"detail: "`` (= clear)
+  • ``on_act_executed``        → ``"detail: act: N op(s)"``
+
+The TUI's ``_handle_trace_for_skill_row`` recognises the ``"detail: "``
+prefix and routes it to ``ConversationView.update_skill_detail`` which
+calls ``SkillActivityRow.set_detail`` — appending a dim ``⤷ <detail>``
+segment to the row. ``set_phase`` clears the detail on phase advance
+(new phase = fresh context).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.forwarder import ChatEventForwarder
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── Forwarder emissions ──────────────────────────────────────────────────────
+
+
+def _drain(queue: asyncio.Queue) -> list[OutboxMessage]:
+    out: list[OutboxMessage] = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+def test_forwarder_emits_llm_called_detail() -> None:
+    """Tier 1: ``on_llm_called`` enqueues ``"detail: llm: <model>"``."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="r1")
+    fwd.on_llm_called({"model": "opus-4-5", "phase": "p"})
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].kind == "trace"
+    assert msgs[0].text == "detail: llm: opus-4-5"
+    assert msgs[0].meta.get("run_id") == "r1"
+
+
+def test_forwarder_emits_clear_on_llm_response() -> None:
+    """Tier 1: ``on_llm_response_received`` enqueues a blank detail.
+
+    Empty payload after the prefix signals the TUI to clear the
+    ``⤷ llm: …`` segment so the row doesn't lie about an in-flight
+    call after the response has actually arrived.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="r1")
+    fwd.on_llm_response_received({"model": "opus-4-5"})
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].text == "detail: "
+
+
+def test_forwarder_emits_act_executed_count() -> None:
+    """Tier 1: ``on_act_executed`` enqueues an op-count summary."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="r1")
+    fwd.on_act_executed({"op_count": 3, "phase": "p"})
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].text == "detail: act: 3 ops"
+
+
+def test_forwarder_act_executed_singular_one_op() -> None:
+    """Tier 1: ``on_act_executed`` with op_count=1 uses singular ``op`` not ``ops``."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="r1")
+    fwd.on_act_executed({"op_count": 1, "phase": "p"})
+    msgs = _drain(q)
+    assert msgs[0].text == "detail: act: 1 op"
+
+
+def test_forwarder_act_executed_drops_zero_op_count() -> None:
+    """Tier 1: ``op_count`` 0 or missing → no detail emitted (= noise filter)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="r1")
+    fwd.on_act_executed({"op_count": 0, "phase": "p"})
+    fwd.on_act_executed({"phase": "p"})  # missing op_count
+    assert _drain(q) == []
+
+
+# ── SkillActivityRow set_detail ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_detail_appears_in_rendered_row() -> None:
+    """Tier 2: ``set_detail(text)`` puts ``⤷ <text>`` into the rendered row."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row("r1", "my_skill")
+        row.set_phase("plan", visit=1)
+        row.set_detail("llm: opus-4-5")
+        await pilot.pause()
+
+        plain = row._build_running().plain
+        assert "⤷ llm: opus-4-5" in plain, (
+            f"detail must appear after elapsed; got {plain!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_phase_clears_detail() -> None:
+    """Tier 2: advancing to a new phase clears any prior detail.
+
+    The previous phase's ``llm: <model>`` / ``act: N op`` context is
+    irrelevant once we transition. Without this, the row would carry a
+    stale detail tag into the new phase.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row("r1", "my_skill")
+        row.set_phase("plan", visit=1)
+        row.set_detail("llm: opus-4-5")
+        await pilot.pause()
+
+        row.set_phase("review", visit=1)
+        await pilot.pause()
+
+        plain = row._build_running().plain
+        assert "⤷" not in plain, (
+            f"phase advance must clear detail; got {plain!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_detail_empty_string_hides_segment() -> None:
+    """Tier 2: ``set_detail('')`` (the clear-detail signal) hides the segment."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row("r1", "my_skill")
+        row.set_phase("plan", visit=1)
+        row.set_detail("llm: opus")
+        row.set_detail("")  # clear
+        await pilot.pause()
+
+        plain = row._build_running().plain
+        assert "⤷" not in plain
+
+
+# ── TUI dispatcher routes "detail: " to update_skill_detail ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_trace_handler_routes_detail_prefix() -> None:
+    """Tier 2: ``"detail: <text>"`` trace calls ``update_skill_detail``.
+
+    Captures the call via direct attribute substitution (no
+    ``unittest.mock`` per the testing policy) so the test pins the
+    dispatch path independently of the SkillActivityRow render.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        captured: list[tuple[str, str]] = []
+
+        def _fake(run_id: str, detail: str) -> None:
+            captured.append((run_id, detail))
+
+        conv.update_skill_detail = _fake  # type: ignore[method-assign]
+
+        msg = OutboxMessage(
+            kind="trace",
+            text="detail: llm: opus-4-5",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+
+        assert captured == [("r1", "llm: opus-4-5")]
+
+
+@pytest.mark.asyncio
+async def test_trace_handler_routes_empty_detail_clear() -> None:
+    """Tier 2: ``"detail: "`` (empty payload) routes the clear signal through."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        captured: list[tuple[str, str]] = []
+
+        def _fake(run_id: str, detail: str) -> None:
+            captured.append((run_id, detail))
+
+        conv.update_skill_detail = _fake  # type: ignore[method-assign]
+
+        msg = OutboxMessage(
+            kind="trace",
+            text="detail: ",
+            meta={"skill_name": "s", "run_id": "r1"},
+        )
+        app._handle_trace_for_skill_row(conv, msg)
+
+        assert captured == [("r1", "")]


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``ChatEventForwarder`` only handled ``phase_started`` / ``phase_completed`` / ``workflow_finished`` / ``workflow_aborted``. Tool ops inside a phase (LLM calls, Control IR ``act`` batches) were silent — long preprocessor runs or slow models produced a **10–30 s blank window** where the spinner just kept spinning on the phase name with no indication of whether the skill was making progress or stuck.

## Fix

Wire three additional handlers in the forwarder. Each emits a ``"detail: <text>"`` trace; the TUI's ``_handle_trace_for_skill_row`` routes the prefix to ``ConversationView.update_skill_detail`` which calls ``SkillActivityRow.set_detail`` — appending a dim ``  ⤷ <text>`` segment after the elapsed counter.

| Event | Trace |
| --- | --- |
| ``on_llm_called`` | ``"detail: llm: <model>"`` |
| ``on_llm_response_received`` | ``"detail: "`` (clear — between calls) |
| ``on_act_executed`` | ``"detail: act: N op(s)"`` |

``set_phase`` clears the detail on phase advance so the previous phase's context never leaks into the new one. ``op_count <= 0`` or missing is a silent no-op so a forwarder noise event can't pollute the row.

### Before / After

Before (silent 18 seconds):
```
14:32  reyn ──────────────
       ⠙ code_review#abcd  · plan v2  ●●○  18.4s
                                              ↑ user wonders "is the skill stuck?"
```

After (active signal):
```
14:32  reyn ──────────────
       ⠙ code_review#abcd  · plan v2  ●●○  18.4s  ⤷ llm: opus-4-5
                                                    ↑ user sees model is being called
```

## Why

Skill-execution UX audit (MED severity Finding F4). The blank-window-during-LLM-call was the second-most-common "is the skill stuck?" failure mode in dogfood, after the phase-completed transition gap fixed in #132.

## Test plan

- [x] ``pytest tests/cli/test_skill_in_phase_detail.py`` — 10 passed (new Tier 1 + Tier 2 invariants):
  - Forwarder emits ``"detail: llm: <model>"`` on ``on_llm_called``
  - Forwarder emits ``"detail: "`` (clear) on ``on_llm_response_received``
  - Forwarder emits ``"detail: act: N ops"`` on ``on_act_executed``, plural-aware
  - ``op_count <= 0`` or missing is a silent no-op
  - ``set_detail`` puts ``⤷ <text>`` in the rendered row
  - ``set_phase`` clears the detail on phase advance
  - ``set_detail('')`` hides the segment
  - TUI dispatcher routes ``"detail: <text>"`` → ``update_skill_detail(run_id, text)``
  - TUI dispatcher routes ``"detail: "`` clear signal through correctly
- [x] ``pytest tests/cli/`` — 163 passed (no regression in existing TUI smoke / phase-completed / out-of-band-signals / sticky-timer / streaming-perf / stream-msgid / right-panel-refresh / scroll-suppression / intervention-scroll / keys-tab-panel-bindings tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)