### PR TITLE
fix(router/memory): seed memory.entry hot-list aliases + fix dispatch transform shape

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -587,7 +587,88 @@ def _resource_alias_metadata(
         )
         return description, schema
 
+    if category == "memory.entry":
+        # E2e-coder 2026-05-17 N4 probe: memory.entry__<slug> aliases were
+        # previously marked unhandled because _read_memory_body_args sent
+        # {name: slug} while read_memory_body required {layer, slug} — that
+        # transform is now fixed (universal_dispatch.py) to send the
+        # canonical {layer: "shared", slug} pair, so the alias can be
+        # surfaced with an empty input schema (the qualified name encodes
+        # the slug; layer defaults to "shared").
+        meta = (skill_metadata_lookup or {}).get(qualified_name) or {}
+        desc_body = meta.get("description") or f"shared memory entry {entry_name!r}"
+        description = (
+            f"Read the body of shared memory entry {entry_name!r}. "
+            f"{desc_body}"
+        )
+        params = {"type": "object", "properties": {}, "required": []}
+        return description, params
+
     return None
+
+
+def _enumerate_shared_memory_entries(host: Any) -> dict[str, dict]:
+    """List shared memory entries as ``memory.entry__<slug>`` → metadata.
+
+    Scans the shared memory layer's directory (= ``<cwd>/.reyn/memory``) for
+    ``*.md`` files, ignoring the ``MEMORY.md`` index. The returned mapping is
+    keyed by qualified action name so the caller can:
+
+      - extend the hot-list seed (so the alias appears in ``tools=`` without
+        the LLM running a discovery ``list_actions(category=['memory.entry'])``
+        first), and
+      - populate the alias metadata lookup so ``_resource_alias_metadata``
+        renders a human description from the entry's frontmatter rather
+        than a generic placeholder.
+
+    Returns an empty dict when the layer's directory is absent, a host
+    method is missing, or the filesystem read raises — this surface is
+    advisory (= a missing entry just means the LLM has to discover it via
+    ``list_actions``), so failures are silently absorbed rather than raised.
+
+    Used by 2026-05-17 N4 fix; see project memory entry for context.
+    """
+    out: dict[str, dict] = {}
+    memory_dir_fn = getattr(host, "memory_dir", None)
+    if memory_dir_fn is None:
+        return out
+    try:
+        mem_dir = Path(memory_dir_fn("shared"))
+    except Exception:
+        return out
+    if not mem_dir.is_dir():
+        return out
+    for md_file in sorted(mem_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+        slug = md_file.stem
+        meta: dict = {"description": f"shared memory entry {slug!r}"}
+        # Best-effort frontmatter parse to surface the user-facing
+        # "description" field. Files without a parseable frontmatter
+        # fall back to the generic placeholder above.
+        try:
+            text = md_file.read_text(encoding="utf-8")
+            stripped = _strip_frontmatter(text)
+            if stripped != text:
+                # frontmatter present; extract description line
+                lines = text.split("\n")
+                in_fm = False
+                for line in lines:
+                    s = line.strip()
+                    if s == "---":
+                        if in_fm:
+                            break
+                        in_fm = True
+                        continue
+                    if in_fm and s.startswith("description:"):
+                        desc = s.split(":", 1)[1].strip()
+                        if desc:
+                            meta["description"] = desc
+                        break
+        except OSError:
+            pass
+        out[f"memory.entry__{slug}"] = meta
+    return out
 
 
 def _drop_required_field(params: dict, field_name: str) -> dict:
@@ -999,6 +1080,22 @@ class RouterLoop:
                     if _seed_cfg == "default"
                     else (list(_seed_cfg) if isinstance(_seed_cfg, list) else [])
                 )
+                # N4 (2026-05-17): seed shared memory entries dynamically so
+                # the LLM can read user-saved memory in a fresh session
+                # without first running list_actions(category=['memory.entry']).
+                # Without this, cross-session memory retrieval requires a
+                # discovery step the weak default model rarely takes.
+                # Populates skill_metadata_lookup so the alias gets a
+                # human-readable description (= the entry's frontmatter
+                # `description`).
+                _memory_entries = _enumerate_shared_memory_entries(host)
+                for _qn, _meta in _memory_entries.items():
+                    if _qn not in _seed:
+                        _seed.append(_qn)
+                    # _skill_meta_map is reused as a generic
+                    # qualified-name → metadata lookup; see
+                    # _resource_alias_metadata's memory.entry branch.
+                    _skill_meta_map.setdefault(_qn, _meta)
                 _top_names = _tracker.get_top_n(_n, _seed)
                 if _top_names:
                     _hot_list_aliases = _build_hot_list_aliases(

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -165,11 +165,19 @@ def _call_mcp_tool_args(
 def _read_memory_body_args(
     entry_name: str, args: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """``memory.entry__<name>`` → ``read_memory_body({name})``.
+    """``memory.entry__<name>`` → ``read_memory_body({layer, slug})``.
 
     D19 resource invoke: invoking a memory entry returns its body.
+
+    The qualified-name format ``memory.entry__<slug>`` does not encode a
+    layer; we default to "shared" because that is what the
+    ``memory.operation__remember_shared`` write surface produces, and
+    therefore what users encounter from natural-language "remember X"
+    requests (= e2e-coder 2026-05-17 N4 probe). Agent-layer entries
+    require a separate alias namespace (= follow-up if a real probe
+    surfaces the gap).
     """
-    return {"name": entry_name}
+    return {"layer": "shared", "slug": entry_name}
 
 
 def _recall_single_source_args(

--- a/tests/test_memory_entry_hot_list_alias.py
+++ b/tests/test_memory_entry_hot_list_alias.py
@@ -1,0 +1,211 @@
+"""Tier 2 tests for memory.entry hot-list alias surfacing (2026-05-17 N4).
+
+When a user saves a memory entry via ``memory.operation__remember_shared``,
+the file lands at ``<cwd>/.reyn/memory/<slug>.md``. In a fresh subsequent
+session, the LLM needs to be able to read that entry without first running
+``list_actions(category=['memory.entry'])`` — the weak default model rarely
+takes that discovery step proactively (= empirical observation, e2e-coder
+N4-d probe).
+
+This is accomplished by:
+
+1. ``_enumerate_shared_memory_entries(host)`` — scans the shared-layer
+   directory and returns ``{memory.entry__<slug>: {description}}`` from
+   each entry's frontmatter.
+2. The router's hot-list-seed builder extends the static seed with these
+   discovered names so the aliases appear in ``tools=`` at session start.
+3. ``_resource_alias_metadata`` renders a human description from the
+   entry's frontmatter when the alias is exposed.
+4. ``_read_memory_body_args`` in ``universal_dispatch`` was updated to
+   emit ``{layer: "shared", slug}`` instead of ``{name}``, matching the
+   target ``read_memory_body`` parameter shape (= the dispatch shape
+   mismatch documented in the prior memory-entry deferred entry).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.router_loop import (
+    _enumerate_shared_memory_entries,
+    _resource_alias_metadata,
+)
+from reyn.tools.universal_dispatch import _read_memory_body_args
+
+
+class _FakeHost:
+    def __init__(self, mem_dir: Path | None) -> None:
+        self._mem_dir = mem_dir
+
+    def memory_dir(self, layer: str) -> str:
+        if layer == "shared" and self._mem_dir is not None:
+            return str(self._mem_dir)
+        return ""
+
+
+# ── _enumerate_shared_memory_entries ────────────────────────────────────────
+
+
+def test_enumerate_returns_entries_keyed_by_qualified_name(tmp_path):
+    """Tier 2: each .md file under shared/ produces a memory.entry__<slug> key."""
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "user_project_phoenix.md").write_text(
+        "---\nname: Project Phoenix\ndescription: User is working on Phoenix.\ntype: project\n---\n\nbody",
+        encoding="utf-8",
+    )
+    (mem_dir / "user_language_python.md").write_text(
+        "---\nname: Python\ndescription: User writes Python 3.12.\ntype: project\n---\n\nbody",
+        encoding="utf-8",
+    )
+    host = _FakeHost(mem_dir)
+
+    result = _enumerate_shared_memory_entries(host)
+
+    assert set(result.keys()) == {
+        "memory.entry__user_project_phoenix",
+        "memory.entry__user_language_python",
+    }
+
+
+def test_enumerate_extracts_description_from_frontmatter(tmp_path):
+    """Tier 2: frontmatter's ``description`` field surfaces as the alias description."""
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "user_project_phoenix.md").write_text(
+        "---\nname: Project Phoenix\ndescription: User is working on Phoenix with Python 3.12.\ntype: project\n---\n\nbody",
+        encoding="utf-8",
+    )
+    host = _FakeHost(mem_dir)
+
+    result = _enumerate_shared_memory_entries(host)
+
+    assert result["memory.entry__user_project_phoenix"]["description"] == (
+        "User is working on Phoenix with Python 3.12."
+    )
+
+
+def test_enumerate_skips_memory_index(tmp_path):
+    """Tier 2: ``MEMORY.md`` is the index, not an entry — must not be aliased."""
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").write_text("# Memory Index\n", encoding="utf-8")
+    (mem_dir / "entry.md").write_text(
+        "---\nname: x\ndescription: y\ntype: project\n---\n\nbody",
+        encoding="utf-8",
+    )
+    host = _FakeHost(mem_dir)
+
+    result = _enumerate_shared_memory_entries(host)
+
+    assert "memory.entry__MEMORY" not in result
+    assert "memory.entry__entry" in result
+
+
+def test_enumerate_returns_empty_when_memory_dir_absent(tmp_path):
+    """Tier 2: no shared memory dir → empty dict, no exception (cold-start case)."""
+    host = _FakeHost(tmp_path / "no_such_dir")
+
+    result = _enumerate_shared_memory_entries(host)
+
+    assert result == {}
+
+
+def test_enumerate_returns_empty_when_host_lacks_memory_dir():
+    """Tier 2: a host without ``memory_dir`` (= legacy / mock) returns empty, no crash."""
+
+    class _HostNoMemoryDir:
+        pass
+
+    result = _enumerate_shared_memory_entries(_HostNoMemoryDir())
+
+    assert result == {}
+
+
+def test_enumerate_handles_missing_frontmatter_gracefully(tmp_path):
+    """Tier 2: an entry without frontmatter still yields a qualified name, with a generic description."""
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "plain.md").write_text("just text, no frontmatter", encoding="utf-8")
+    host = _FakeHost(mem_dir)
+
+    result = _enumerate_shared_memory_entries(host)
+
+    assert "memory.entry__plain" in result
+    # Falls back to the placeholder generic description.
+    assert "plain" in result["memory.entry__plain"]["description"]
+
+
+# ── _resource_alias_metadata: memory.entry case ─────────────────────────────
+
+
+def test_resource_alias_memory_entry_renders_description():
+    """Tier 2: memory.entry alias surfaces with the user-supplied description."""
+    skill_meta = {
+        "memory.entry__user_project_phoenix": {
+            "description": "User is working on Phoenix with Python 3.12.",
+        },
+    }
+
+    result = _resource_alias_metadata(
+        "memory.entry__user_project_phoenix",
+        skill_metadata_lookup=skill_meta,
+        mcp_tool_lookup=None,
+    )
+
+    assert result is not None
+    description, params = result
+    assert "user_project_phoenix" in description
+    assert "User is working on Phoenix with Python 3.12." in description
+
+
+def test_resource_alias_memory_entry_has_empty_params():
+    """Tier 2: memory.entry alias takes no args — the slug is encoded in the alias name."""
+    result = _resource_alias_metadata(
+        "memory.entry__foo",
+        skill_metadata_lookup={"memory.entry__foo": {"description": "any"}},
+        mcp_tool_lookup=None,
+    )
+
+    assert result is not None
+    _, params = result
+    assert params == {"type": "object", "properties": {}, "required": []}
+
+
+def test_resource_alias_memory_entry_without_meta_still_resolves():
+    """Tier 2: a memory.entry alias must surface even when no metadata is plumbed,
+    so the LLM still discovers the action; description falls back to a placeholder."""
+    result = _resource_alias_metadata(
+        "memory.entry__orphan",
+        skill_metadata_lookup=None,
+        mcp_tool_lookup=None,
+    )
+
+    assert result is not None
+    description, params = result
+    assert "orphan" in description
+    assert params["properties"] == {}
+
+
+# ── _read_memory_body_args transform ────────────────────────────────────────
+
+
+def test_read_memory_body_args_sends_canonical_layer_slug_pair():
+    """Tier 2 contract: transform output must match ``read_memory_body`` parameters
+    (= ``{layer, slug}``). Previously sent ``{name}``, causing dispatch failure when
+    a memory.entry alias was invoked (= the 'pre-existing dispatch shape mismatch'
+    deferred in FP-0034 D2-full).
+    """
+    args = _read_memory_body_args("user_project_phoenix", {})
+
+    assert args == {"layer": "shared", "slug": "user_project_phoenix"}
+
+
+def test_read_memory_body_args_ignores_caller_args():
+    """Tier 2: extra caller-supplied args are not forwarded — the alias is curried,
+    the qualified name supplies the only routing info needed."""
+    args = _read_memory_body_args("some_slug", {"unrelated": "value"})
+
+    assert "unrelated" not in args
+    assert args == {"layer": "shared", "slug": "some_slug"}

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -104,13 +104,18 @@ def test_resolve_invoke_action_mcp_tool_missing_dot_raises() -> None:
 
 
 def test_resolve_invoke_action_memory_entry_routes_to_read_body() -> None:
-    """Tier 2: memory.entry__<name> → read_memory_body(name).
+    """Tier 2: memory.entry__<slug> → read_memory_body({layer: shared, slug}).
 
     §D19 resource invoke: invoking a memory entry returns its body.
+
+    Post-N4 (2026-05-17): the transform was updated to emit the canonical
+    ``{layer, slug}`` pair that ``read_memory_body`` requires. The previous
+    ``{name}`` shape caused dispatch failure when memory.entry aliases were
+    invoked (= the pre-existing shape mismatch surfaced by N4-d).
     """
     result = resolve_invoke_action("memory.entry__pref_dates", {})
     assert result.target_tool_name == "read_memory_body"
-    assert result.target_args == {"name": "pref_dates"}
+    assert result.target_args == {"layer": "shared", "slug": "pref_dates"}
 
 
 def test_resolve_invoke_action_rag_corpus_curries_single_source() -> None:
@@ -187,7 +192,7 @@ def test_invoke_action_with_none_args_treats_as_empty() -> None:
     """Tier 2: passing args=None is equivalent to args={}."""
     result = resolve_invoke_action("memory.entry__foo", None)
     assert result.target_tool_name == "read_memory_body"
-    assert result.target_args == {"name": "foo"}
+    assert result.target_args == {"layer": "shared", "slug": "foo"}
 
 
 # ── 3. UnknownActionError + §D12 error response shape ─────────────────────


### PR DESCRIPTION
## Summary

E2e-coder N4 (multi-turn memory persistence) probe surfaced a major UX gap: explicit "Please remember X" wrote the entry correctly, but a fresh subsequent session could not retrieve it because the weak default model (\`gemini-2.5-flash-lite\`) didn't run \`list_actions(category=['memory.entry'])\` to discover what entries existed.

This PR fixes two coupled defects:

1. **Dispatch shape mismatch** (universal_dispatch.py): \`_read_memory_body_args\` emitted \`{name: slug}\` but \`read_memory_body\` requires \`{layer, slug}\`. The memory.entry__X route was explicitly marked "unhandled" in \`_resource_alias_metadata\` and excluded from FP-0034 D2-full as deferred work. Transform now emits \`{layer: "shared", slug}\` (qualified name doesn't encode a layer; "shared" matches the write surface).
2. **Hot-list alias surfacing** (router_loop.py): added memory.entry branch to \`_resource_alias_metadata\` so the alias surfaces with the entry's frontmatter description and an empty input schema. Added \`_enumerate_shared_memory_entries(host)\` which scans \`.reyn/memory/*.md\` at session start and seeds the discovered \`memory.entry__<slug>\` names into the hot-list.

## Empirical verification

Manual dogfood, fresh \`.reyn/\` with planted memory file (= simulating "Please remember the phoenix project" from a prior session), weak \`gemini-2.5-flash-lite\`, probe \`What is my project name?\`:

**Before:**
> "I am a Reyn agent. ... What is the path to your project's root directory?"

**After:**
> "Your project name is Phoenix."

\`tools=\` now exposes \`memory.entry__user_project_phoenix\` as a hot-list alias alongside \`memory.operation__remember_shared\`. The LLM reads the entry in one step without a discovery turn.

## Diff scope

- \`src/reyn/chat/router_loop.py\` — \`_enumerate_shared_memory_entries\` helper (~70 LOC) + \`_resource_alias_metadata\` memory.entry case (~18 LOC) + hot-list seed extension at the alias-build site (~12 LOC). 97 lines added net.
- \`src/reyn/tools/universal_dispatch.py\` — \`_read_memory_body_args\` transform shape fix (~10 LOC delta).
- \`tests/test_memory_entry_hot_list_alias.py\` (new) — 11 Tier 2 tests.
- \`tests/test_universal_dispatch.py\` — 2 existing tests updated for the new transform shape; docstrings record the rationale.

## Test plan

- [x] New Tier 2 tests pass: \`pytest tests/test_memory_entry_hot_list_alias.py\` → 11 pass
- [x] Updated dispatch tests pass: \`pytest tests/test_universal_dispatch.py\` → 70 pass
- [x] Full suite regression: 3472 pass / 11 skipped / 2 xfailed. The 2 failures (\`test_config_mcp_headers\`) are **pre-existing on \`main\`** (\`mcp\` extra dep ModuleNotFoundError), confirmed by checking out main and rerunning. No N4-induced regression.
- [x] Empirical end-to-end: weak model now answers cross-session memory question correctly (= "Your project name is Phoenix") instead of asking for the project path.
- [ ] Reviewer to confirm hot-list seed extension behaviour is acceptable when a user has many memory entries (= performance / token budget). Current implementation adds every shared entry; the existing hot-list machinery already caps total alias count via \`_ar_cfg.hot_list_n\`, so excess entries fall out naturally.
- [ ] Reviewer to confirm "shared" default is right for memory.entry__X aliases; agent-layer memory.entry aliases are a follow-up (= unclear UX value until a real probe surfaces the need).

## Related

- E2e-coder N4-d probe — surfaced the defect
- Prior project memory \`hot-list-alias-empty-schema\` deferred this exact shape mismatch ("memory.entry__X is excluded from D2-full because the existing \`_read_memory_body_args\` transform sends \`{name: entry}\` while the target \`read_memory_body\` parameters require \`{layer, slug}\`. Pre-existing dispatch shape mismatch — surface as a separate fix when a real-call regression appears."). N4-d is the "real-call regression" that surfaced it.
- FP-0034 D2-full (PR #117 / #119 / commit \`a1a5093a\`) — landed hot-list aliases for skill / mcp.tool / mcp.server / agent.peer / rag.corpus. This PR closes the deferred memory.entry case.
- PR #129 / #130 / #133 / #136 (open, separate scopes) — same e2e-coder session, sibling fixes from G31 / N1 / N5 / N3 probes.

[e2e-coder]