### PR TITLE
docs(dogfood-discipline): add Principle 17 — single-defect investigation loop

### DIFF
--- a/docs/deep-dives/contributing/dogfood-discipline.ja.md
+++ b/docs/deep-dives/contributing/dogfood-discipline.ja.md
@@ -368,6 +368,76 @@ Skip:
 
 本原則は 原則 11 (= predict before observing) + 原則 batch 19 (= pre-retrospective discipline) と pair で **agent self-discipline 3 段 ladder**: predict (prelude) → audit before retrospective (= batch 19) → audit before fix (= batch 22)。
 
+### 原則 17 (candidate): 単一 defect の investigation loop
+
+> Status: 2026-05-17 e2e-coder 探索 session で lift (= G31 三成分分解 + N1 / N3 / N4 / N5 probe、 5 PR landed)。 Section 2 の batch 形式 loop と並行する 「**light-user dogfood で偶発的に見つけた 1 defect 用の縮小版 loop**」 として記述。
+
+**いつ使うか.** ユーザに見える symptom が 1 つ surface した (= 「memory entry を保存したのに project path を聞き返される」、 「skill spawn の acknowledgment が出ない」、 「404 reply が bare」)。 1 シナリオ、 1 つの推定 root cause、 1 つの fix / reject。
+
+Section 2 の batch loop は固定シナリオ集合での multi-scenario regression sweep 用。 この loop は **light user として `reyn chat` を触っていて rough edge に当たった session の opportunistic 探索** 用。 観測 infra (= `REYN_LLM_TRACE_DUMP` / `scripts/llm_replay.py`) は共通; 違いは **scope、 N、 reporting cadence**。
+
+**7 ステップ loop:**
+
+1. **symptom を手動再現.** 1 user message を `reyn chat --cui` に pipe、 `REYN_LLM_TRACE_DUMP=<path>` で trace 取得、 agent reply を観察。 light user 自然な phrasing (= "Read the file ./nonexistent.md and tell me what it says"、 "trigger file_not_found path" ではない)。 再現しない場合は N=3-5 に escalate して stochastic rate を確認してから先へ。
+
+2. **測る前に観測を decompose.** light-user probe で surface する "defect" は umbrella に 2-3 個の separable signal が collapsed されていることが多い。 motivate した specific observation を列挙し、 各 signal について **"競合製品も同じ signal を出すか?"** を問う。 yes なら expected behaviour であって defect ではない — target metric から除外する。 (G31 case study: umbrella + specific を conflate して ~430 weak calls 浪費後に分解で surface。 user-side memory `feedback_separate_leak_types_before_measuring.md` 参照。)
+
+3. **patch する前に variant ladder を設計.** 各候補 fix に短い tag と 1 行 hypothesis を割り当てる。 cross-PR 参照のため命名規約を予約:
+
+   | Tag prefix | 触る layer | 典型 scope |
+   |---|---|---|
+   | **α** | SP-level behavioral rule | 「X-shape の質問では Y する」 — overfit risk 高 |
+   | **β** | SP-level identifier 置換 | 「SP 内の Z を W に rename」 |
+   | **γ** | SP-level section 削除 | 「`## Categories` block を削除」 |
+   | **δ** | SP-level 追加 | 「1 行 anchor を append」 |
+   | **ε** | tool-array description / shape | 「invoke_action description を N 字に trim」 |
+   | **H** | structural ablation (= tool array 手術) | 「4 wrapper 削除」、 「全 tool を verb-form rename」 |
+   | **ζ** | chat-layer pre-LLM intercept | 「regex で質問形状検出、 user msg 書換」 |
+
+   design 時点で ladder を網羅: 任意の variant を patch する前に β/δ/γ/α/ε/H/ζ 候補を列挙、 seed が真にどの layer に居るか見極める。
+
+4. **N=10 で captured trace に対し patch-verify.** 探索 standard は cell あたり N=10 — Section 5 の N=5 stability 要件 (= production regression sweep 用) と異なる。 N=10 が variant 比較に適する理由:
+
+   - variant 間の effect size は ~30% (80%+ ではない) のことが多く、 N=5 は underpowered
+   - 並列 batch (= `ThreadPoolExecutor` 経由 `scripts/llm_replay.py --patch` の subprocess) で 200 calls が ~50s で完了、 cost は bounded
+   - 7-10 variants × baseline × 3-4 scenarios = 1 ターミナル画面に収まる matrix size
+
+   N=5 は **隣接シナリオの regression check** 用 (= 「この variant が無関係 routing を壊さないか」)、 N=10 は **primary target metric** 用 (= 「variant が数字を動かしたか」)。
+
+5. **narrow regex で output を classify.** 分離した signal (= step 2) ごとに 1 regex。 まず baseline サンプルで false positive を check。 1 investigation で 4-6 dimension を上限に — それ以上は step 2 の decomposition が緩い兆候。 e2e-coder G31 の例:
+
+   ```python
+   prefix_leak = re.search(r"`?(skill__|file__|web__|memory\.|...)", reply)
+   router_meta = re.search(r"\b(list_actions|invoke_action|describe_action|...)\b", reply)
+   cap_enum    = re.search(r"(i can help|file operations|web access|...)", reply, re.I)
+   ```
+
+   per-run + Σ aggregate を variant ごとに print。 reviewer が読む artifact は Σ matrix、 per-run table は audit trail。
+
+6. **variant ごとに thesis 整合で採用判断.** **採用条件**は以下を AND で満たす:
+   - target metric が primary シナリオで 絶対値 ≥30% 動く (= 6/10 → ≤4/10)
+   - 隣接シナリオを regress しない (= routing-baseline の tool-call 率が ≥9/10 を維持)
+   - shape が non-overfit (= variant の logic が「テスト時に使った特定の質問 phrasing」 を encode していない)
+
+   variant が前 2 条件のみ満たし 3 つ目で外れる場合 — 例: 1 質問 shape を suppress するが無関係 questions に bleed する SP rule — **reject** + rejection log。 投資単位は investigation 全体の up/down ではなく **variant 単位の採用判断**。
+
+7. **rejection を "Do not redo these experiments" journal に記録.** reject された variant ごとに 1 行: tag、 scope、 baseline → variant 数字 (= 各 dimension)、 1 行 reject 理由。 future session は同 hypothesis を再提案する前にこの list を読む。 G31 deep-dive journal (`2026-05-17-g31-three-component-decomposition.md`) が prototype — 10 hypothesis 各 number-backed reject 理由付きで、 次 session は ~400 weak calls 無駄を skip 可能。
+
+**loop の output はどちらか:**
+
+- 採用 variant を持つ単一の小規模 PR、 PR 本文の "candidates considered" section に reject 候補を要約
+- journal entry + giveup-tracker addendum で 「採用 variant なし、 この layer では fixable defect ではない (policy-accepted)」 と documentation
+
+両方とも valid outcome。 loop の job は **その選択を audit 可能にすること**。
+
+**cross-session footprint.** この loop は e2e-coder role の primary mode (= role 規律は user-side memory `feedback_pr_workflow_for_e2e_coder.md`)。 規律サマリ:
+
+- 全 PR / issue コメントに `[e2e-coder]` prefix (= cross-session signal、 同 `gh` user で lead-coder / e2e-coder / per-PR coders を authenticate しているため)
+- pull main + 頻繁 rebase (= 主要 refactor wave 中 main は速く動く、 stale-base PR は merge ではなく cherry-pick される)
+- self-merge 禁止; reviewer (= lead) が scope と timing を決定
+
+この loop なしの代替は、 e2e-coder session の default だった 「先に fix 実装、 post-hoc verify」 — 多くの場合 variant ladder (= step 3) が enumerate されないまま不正な fix が land する。
+
 ---
 
 ## 4. common patterns / anti-patterns

--- a/docs/deep-dives/contributing/dogfood-discipline.md
+++ b/docs/deep-dives/contributing/dogfood-discipline.md
@@ -368,6 +368,76 @@ Skip for: simple structural / wiring / null-safety bugs where the trace already 
 
 This principle pairs with principle 11 (= predict before observing) and principle batch 19 (= pre-retrospective discipline) to form a three-stage agent-self-discipline ladder: predict (prelude) → audit before retrospective (= batch 19) → audit before fix (= batch 22).
 
+### Principle 17 (candidate): Single-defect investigation loop
+
+> Status: lifted from 2026-05-17 e2e-coder exploration session (= G31 decomposition + N1 / N3 / N4 / N5 probes, 5 PRs landed). Complements Section 2's batch-format loop with a tighter loop for **one user-visible defect found by light-user dogfood**, where running a full multi-scenario batch is too heavy.
+
+**When this applies.** A single user-visible symptom surfaced (= "agent asks for project path even though I saved a memory entry", "agent doesn't acknowledge skill spawn", "404 reply is bare"). One scenario, one suspected root cause, one fix or rejection.
+
+The batch loop in Section 2 is calibrated for multi-scenario regression sweeps with a fixed scenario set. This loop is calibrated for **opportunistic exploration** by a session that just hit a rough edge while using `reyn chat` as a light user. The two loops share the same observation infra (= `REYN_LLM_TRACE_DUMP`, `scripts/llm_replay.py`); they differ on **scope, N, and reporting cadence**.
+
+**The 7-step loop:**
+
+1. **Reproduce the symptom manually.** Pipe a single user message through `reyn chat --cui` with `REYN_LLM_TRACE_DUMP=<path>` and observe the agent's reply. Phrase the message the way an actual light user would (= "Read the file ./nonexistent.md and tell me what it says", not "trigger file_not_found path"). If the symptom doesn't reproduce, escalate to N=3-5 and look for stochastic rate before continuing.
+
+2. **Decompose the observation before measuring.** Most "defects" surfaced by light-user probes are actually 2-3 separable signals collapsed under one umbrella. List the *specific* observations that motivated the report, then ask **"would a well-designed competing product also produce this signal?"** for each. If yes, that signal is expected behaviour, not a defect — exclude it from your target metric. (See user-side memory `feedback_separate_leak_types_before_measuring.md` for the G31 case study where conflating umbrella + specific signals burned ~430 weak calls before the decomposition surfaced.)
+
+3. **Design a variant ladder before patching.** Name each candidate fix with a short tag and a one-line hypothesis. Reserve names so cross-PR references stay readable:
+
+   | Tag prefix | Layer the variant touches | Typical scope |
+   |---|---|---|
+   | **α** | SP-level behavioral rule | "for X-shaped questions, do Y" — high overfit risk |
+   | **β** | SP-level identifier replacement | "rename Z to W in the SP text" |
+   | **γ** | SP-level section removal | "delete the `## Categories` block" |
+   | **δ** | SP-level addition | "append a 1-line anchor" |
+   | **ε** | tool-array description / shape | "trim invoke_action description to N chars" |
+   | **H** | structural ablation (= tool array surgery) | "delete the 4 wrappers", "rename all tools to verb-form" |
+   | **ζ** | chat-layer pre-LLM intercept | "regex-detect question shape, rewrite user msg" |
+
+   Treat the ladder as exhaustive at design time: enumerate β/δ/γ/α/ε/H/ζ candidates before patching any, so you can spot which layer the seed actually lives in.
+
+4. **Patch-verify with N=10 against the captured trace.** The exploratory standard is N=10 per cell — different from Section 5's N=5 stability requirement, which is calibrated for production regression sweeps. N=10 is right for variant comparison because:
+
+   - effect sizes between variants are often ~30% (not 80%+), so N=5 is underpowered
+   - parallel batches (= `ThreadPoolExecutor` over `scripts/llm_replay.py --patch` subprocess calls) finish 200 calls in ~50s, so the cost is bounded
+   - 7-10 variants × baseline × 3-4 scenarios = matrix small enough to fit one terminal screen
+
+   Reserve N=5 for the regression check on **adjacent scenarios** (= "does this variant break unrelated routing?") and N=10 for the **primary target metric** (= "did the variant move the number").
+
+5. **Classify outputs with narrow regex.** Write one regex per separated signal (= step 2). Test on baseline samples first to catch false positives. Cap classification at 4-6 dimensions per investigation; more dimensions usually means the decomposition in step 2 wasn't tight enough. Examples from e2e-coder G31:
+
+   ```python
+   prefix_leak = re.search(r"`?(skill__|file__|web__|memory\.|...)", reply)
+   router_meta = re.search(r"\b(list_actions|invoke_action|describe_action|...)\b", reply)
+   cap_enum    = re.search(r"(i can help|file operations|web access|...)", reply, re.I)
+   ```
+
+   Print per-run + Σ aggregate for each variant. The Σ matrix is the artifact reviewers read; the per-run table is the audit trail.
+
+6. **Decide adoption per variant against the thesis.** A variant is **adoptable** only if:
+   - it moves the target metric by ≥30% absolute (= 6/10 → ≤4/10) on the primary scenario
+   - it does NOT regress adjacent scenarios (= tool-call rate on routing-baseline stays ≥9/10)
+   - its shape is non-overfit (= the variant's logic does not encode the specific question phrasing it was tested on)
+
+   If a variant only meets the first two but fails the third — for instance, an SP rule that suppresses one question shape but bleeds onto unrelated questions — **reject** and log the rejection. Per-variant adoption decisions, not whole-investigation up/down votes, are the unit of work.
+
+7. **Record rejections in a "Do not redo these experiments" journal.** Every rejected variant gets a row with: tag, scope, baseline → variant number on each dimension, one-line reject reason. Future sessions read this list before re-proposing the same hypothesis. The G31 deep-dive journal entry (`2026-05-17-g31-three-component-decomposition.md`) is the prototype — 10 hypotheses, each with number-backed reject reason, lets the next session skip ~400 wasted weak calls.
+
+**Output of this loop is one of:**
+
+- A single small PR carrying the adopted variant, with the rejected variants summarised in the PR body's "candidates considered" section.
+- A journal entry + giveup-tracker addendum documenting why no variant was adopted (= policy-accepted, not a fixable defect at this layer).
+
+Both are valid outcomes. The loop's job is to make the choice between them auditable.
+
+**Cross-session footprint.** This loop is the e2e-coder role's primary mode (= the role description in user-side memory `feedback_pr_workflow_for_e2e_coder.md`). The role's discipline is captured by:
+
+- `[e2e-coder]` prefix on every PR / issue comment (= cross-session signal, since the same `gh` user authenticates lead-coder, e2e-coder, and per-PR coders)
+- pull main + rebase frequently (= main moves fast during active refactor waves; stale-base PRs get cherry-picked instead of merged)
+- never self-merge; reviewer (= lead) decides scope and timing
+
+Without this loop the alternative is what e2e-coder sessions used to default to: implement a fix first, then verify post-hoc. That pattern lands the wrong fix more often than not because the variant ladder (= step 3) was never enumerated.
+
 ---
 
 ## 4. Common patterns and anti-patterns


### PR DESCRIPTION
## Summary

Captures the e2e-coder exploration loop lifted from the 2026-05-17 session (= G31 three-component decomposition + N1 / N3 / N4 / N5 probes, 5 PRs landed). Complements Section 2's batch-format loop with a tighter loop for **one user-visible defect found by light-user dogfood**, where running a full multi-scenario batch is too heavy.

The new principle (= 17 in the candidate series) covers what the existing docs don't:

| Element | Existing coverage | This PR adds |
|---|---|---|
| **One-scenario test methodology** | △ batch-format only (A1-A5) | explicit 7-step single-defect loop |
| **Context analysis (decompose before measuring)** | ◯ via Principle 4 / 16 | explicit step 2: "would a well-designed competing product also produce this signal?" |
| **Patch A/B isolation (variant ladder)** | △ \`--patch\` tool documented, methodology missing | reserved tag prefixes (α / β / γ / δ / ε / H / ζ) so cross-PR references stay readable |
| **Test count (N)** | ◯ N=5 stability, N=10 release-gate documented | N=10 as **exploratory variant-comparison standard** (different rationale than the production stability N=5) |

Two artifacts updated symmetrically:

- \`docs/deep-dives/contributing/dogfood-discipline.md\` — Principle 17 (English)
- \`docs/deep-dives/contributing/dogfood-discipline.ja.md\` — 原則 17 (Japanese mirror)

70 lines added per file.

## Why now

The 2026-05-17 e2e-coder session ran the loop end-to-end on G31 + 4 N-probes and landed 5 PRs (#129 / #130 / #133 / #136 / #138, plus #105 cherry-picked). The loop's steps were captured in user-side memory but **not in repo docs** — meaning every new e2e-coder session re-derives them from scratch. This PR closes that gap.

## Test plan

- [x] Manual: read both EN and JA files; structure intact (= Principle 1-17 monotone, Section 4 follows at line 443 in both files)
- [x] Visual: \`grep -E '^### Principle [0-9]+'\` confirms numbering symmetry between EN and JA
- [x] No source / test code changed — docs-only PR
- [ ] Reviewer to confirm Principle 17's "when this applies" is calibrated correctly (= the boundary between this loop and Section 2's batch loop)
- [ ] Reviewer to confirm the reserved tag prefixes (α / β / γ / δ / ε / H / ζ) are not in conflict with any existing tag conventions

## Related

- 2026-05-17 e2e-coder session — the dogfood evidence for this principle
- \`docs/deep-dives/journal/dogfood/2026-05-17-g31-three-component-decomposition.md\` — concrete worked example referenced from the principle text
- User-side memory \`feedback_separate_leak_types_before_measuring.md\` — the methodology lesson that motivated the "decompose before measuring" step

[e2e-coder]