### PR TITLE
fix(tui): footer hint fits 80-col terminals

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -379,12 +379,11 @@ class InputBar(Widget):
     # ── hint rendering ────────────────────────────────────────────────────────
 
     def _build_hint(self) -> str:
-        # Stays on one line (~84 cols). Dropped Ctrl+O / Ctrl+R / Ctrl+\
-        # / Ctrl+C — all visible in the Keys tab, all infrequent or
-        # discoverable on demand. Ctrl+P/N turn was missing from every
-        # user-facing surface above the fold; that's the whole point of
-        # this hint. Ctrl+B panel stays so users can find the Keys tab.
+        # Fits in 80 cols (= 72 cells incl. 2-space left margin) so the
+        # tail "Ctrl+P/N turn" doesn't get clipped on default terminals.
+        # Dropped Ctrl+J nl in addition to Ctrl+O / Ctrl+R / Ctrl+\ /
+        # Ctrl+C — all remain discoverable via the Keys tab (Ctrl+B).
         return (
-            "  Enter send │ Ctrl+J nl │ Ctrl+D quit │ Ctrl+L clear │ "
+            "  Enter send │ Ctrl+D quit │ Ctrl+L clear │ "
             "Ctrl+B panel │ Ctrl+P/N turn"
         )


### PR DESCRIPTION
## Summary

The footer hint was 84 cells, so the tail `Ctrl+P/N turn` got clipped on default 80-col terminals — the very key the hint was added to surface (per existing inline comment) was the one hidden. Drop `Ctrl+J nl │ ` to bring the line to 72 cells; newline remains discoverable via the Keys tab (Ctrl+B).

## Before / After (80x24 terminal)

Before:
```
    Enter send │ Ctrl+J nl │ Ctrl+D quit │ Ctrl+L clear │ Ctrl+B panel │ Ctrl+P
```
(tail `/N turn` clipped)

After:
```
    Enter send │ Ctrl+D quit │ Ctrl+L clear │ Ctrl+B panel │ Ctrl+P/N turn
```

## Test plan

- [x] Manual: `reyn chat` in 80x24 tmux pane → footer fits, `Ctrl+P/N turn` fully visible
- [x] Manual: `reyn chat` in 100x24 tmux pane → no regression, footer reads identically
- [x] Decision-flow Q1 (testing.ja.md): "only the commit author would notice" + visual format → **Tier 4 → no automated test**; manual repro recorded above

🤖 Generated with [Claude Code](https://claude.com/claude-code)