### PR TITLE
fix(tui): surface Ctrl+C cancel hint inside the thinking sticky

### DIFF
--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -62,6 +62,7 @@ class StickyStatus(Static):
     def __init__(self, *, id: str | None = None) -> None:
         super().__init__("", id=id)
         self._active: bool = False
+        self._kind: str = "thinking"
         self._glyph: str = _GLYPHS["thinking"]
         self._body: str = ""
         self._start: float = 0.0
@@ -74,7 +75,8 @@ class StickyStatus(Static):
 
     def show(self, text: str, kind: str = "thinking") -> None:
         """Activate the status bar with the given body text and glyph kind."""
-        self._glyph = _GLYPHS.get(kind, _GLYPHS["thinking"])
+        self._kind = kind if kind in _GLYPHS else "thinking"
+        self._glyph = _GLYPHS[self._kind]
         self._start = time.monotonic()
         self._active = True
         self.add_class("active")
@@ -103,4 +105,6 @@ class StickyStatus(Static):
         t.append(self._glyph + " ", style=_CORAL)
         t.append(self._body, style="dim italic")
         t.append(f" · {elapsed:.1f}s", style="dim italic")
+        if self._kind == "thinking":
+            t.append("  · Ctrl+C cancel", style="dim italic")
         self.update(t)


### PR DESCRIPTION
## Summary

While waiting for the first LLM chunk the sticky bar reads `⟳ thinking… · 1.2s` with no indication that Ctrl+C cancels the in-flight call. A first-run user has no way to discover the cancel key — the footer hint (now 72 cells, see PR #140) doesn't list Ctrl+C either, and the Keys tab is one Ctrl+B away.

Append `  · Ctrl+C cancel` to the sticky only when `kind == "thinking"` so it shows exactly when cancelling makes sense. Other kinds (`general`, `tool`, `error`) stay unchanged.

## Before / After

Before (thinking phase):
```
⟳ thinking… · 1.2s
```

After:
```
⟳ thinking… · 1.2s  · Ctrl+C cancel
```

Total ≈37 cells — fits comfortably in 80-col.

## Test plan

- [x] Manual: `reyn chat`, send a prompt that triggers a slow reply, observe sticky shows `· Ctrl+C cancel` during thinking phase
- [x] Manual: press Ctrl+C while sticky is up → cancel fires (verified via existing `on_input_bar_cancel_in_flight` path)
- [x] Manual: verify hint disappears when streaming starts (sticky hides) and stays hidden in idle
- [x] Manual: verify at 80-col, the line fits without wrap
- [x] Decision-flow Q1 (testing.ja.md): visual format + "this commit author would notice" → **Tier 4 → no automated test**; manual repro above. Private-state `_kind` field is internal-only (not asserted in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)