### PR TITLE
fix(tui): truncate long slash-picker summaries to one row

### DIFF
--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -145,6 +145,19 @@ class SlashPicker(Static):
         max_name_len = max(len(c.name) for c in self._matches)
         name_col = max(max_name_len + 1, 12)
 
+        # Truncate summary so each row stays on one visual line. Row layout
+        # inside the picker box: caret(2) + name(name_col) + sep(2) + summary.
+        # self.content_size lags during resize, so derive width from app.size
+        # (live terminal width) minus the picker's overhead: border(2) +
+        # padding(2) + an extra 2-cell margin (Textual sometimes wraps at the
+        # boundary even when widths nominally match).
+        try:
+            term_w = self.app.size.width
+        except Exception:
+            term_w = 60
+        content_w = max(20, term_w - 6)
+        summary_budget = max(10, content_w - (2 + name_col + 2))
+
         body = Text()
         for i, cmd in enumerate(self._matches):
             is_sel = i == self._selected
@@ -156,9 +169,12 @@ class SlashPicker(Static):
             name = f"/{cmd.name}".ljust(name_col)
             row.append(name, style=f"bold {_CORAL}" if is_sel else "#dddddd")
             row.append("  ")
-            # Summary
+            # Summary (truncated to fit the row)
+            summary = cmd.summary
+            if len(summary) > summary_budget:
+                summary = summary[: max(1, summary_budget - 1)] + "…"
             row.append(
-                cmd.summary,
+                summary,
                 style="#bbbbbb" if is_sel else "dim #888888",
             )
             if i > 0:


### PR DESCRIPTION
## Summary

Long summaries (notably `/copy` at 62 chars: `Copy an agent reply to the clipboard (/copy [N] or /copy list)`) overflowed the picker width and wrapped to a second row, breaking the uniform 1-row-per-command layout and pushing other matches off-screen.

Truncate per-row with `…` based on the live terminal width. Short summaries are unaffected; wide terminals still show the full text.

## Before / After (80x24)

Before:
```
┌─────────────────────────────────────────────┐
│ ▌ /copy         Copy an agent reply to the  │
│ clipboard (/copy [N] or /copy list)         │
│   /cost         Quick token + USD cost ...  │
└─────────────────────────────────────────────┘
```

After:
```
┌─────────────────────────────────────────────┐
│ ▌ /copy         Copy an agent reply to the clipboard (/copy [N] or /copy …  │
│   /cost         Quick token + USD cost summary for this agent              │
│   /cost-inline  Toggle per-turn cost suffix in conversation                │
└─────────────────────────────────────────────┘
```

## Implementation notes

- Uses `self.app.size.width` (live terminal width). `self.content_size` was tried first but lags during resize — repaint after `tmux resize-window` rendered with stale widths.
- 2-cell safety margin on top of the picker's border(2)+padding(2) — Textual was wrapping at the exact-width boundary in practice.

## Test plan

- [x] Manual: `reyn chat` at 60-col, type `/co` → all 3 rows fit single-line, truncated with `…`
- [x] Manual: 80-col → `/copy` row fits one line, truncated mid-summary with `…`
- [x] Manual: 120-col → `/copy` summary shown in full (no `…`, no regression)
- [x] Manual: short summaries (`/help`, `/exit`, `/cost-inline`) unaffected at all widths
- [x] Decision-flow Q1 (testing.ja.md): visual format → **Tier 4 → no automated test**. The truncation budget formula is implementation detail subject to tuning, asserting it would pin internals (Tier 4 violation per "アルゴリズムの固定").

🤖 Generated with [Claude Code](https://claude.com/claude-code)