### PR TITLE
fix(tui): Esc on slash picker also clears the slash prefix

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -233,10 +233,21 @@ class InputBar(Widget):
         ta.action_cursor_down()
 
     def action_dismiss_picker(self) -> None:
-        """Escape — hide picker but keep typed text."""
+        """Escape — abandon slash entry: hide picker AND clear the prefix.
+
+        The picker is only visible when the input is ``/<name-partial>``
+        with no space or newline (see ``_update_picker``), so the entire
+        text is the slash prefix being discovered. Leaving it behind made
+        Esc feel like a no-op and forced the user to backspace before
+        typing anything else — Slack/Discord clear the prefix on Esc.
+        """
         picker = self._picker()
-        if picker is not None and picker.visible_:
-            picker.hide()
+        if picker is None or not picker.visible_:
+            return
+        picker.hide()
+        ta = self._textarea()
+        if ta is not None:
+            ta.load_text("")
 
     def action_newline(self) -> None:
         ta = self._textarea()

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -192,7 +192,14 @@ async def test_slash_picker_tab_confirms():
 
 @pytest.mark.asyncio
 async def test_slash_picker_escape_dismisses():
-    """Escape hides the picker but leaves text intact."""
+    """Escape hides the picker AND clears the slash prefix from input.
+
+    The picker is only visible while the user is typing /<name-partial>
+    (no space, no newline — see ``_update_picker``), so the entire input
+    is the slash prefix being discovered. Esc treats it as "abandon
+    slash entry" (Slack/Discord convention) — leaving "/l" behind made
+    Esc feel like a no-op.
+    """
     from textual.widgets import TextArea
 
     from reyn.chat.tui.widgets.slash_picker import SlashPicker
@@ -208,7 +215,7 @@ async def test_slash_picker_escape_dismisses():
         await pilot.pause()
         assert not picker.visible_
         ta = app.query_one("#input", TextArea)
-        assert ta.text == "/l"
+        assert ta.text == ""
 
 
 # ── test: conversation view ───────────────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — 

## Summary

The slash picker is only visible when the input is `/<name-partial>` (no space, no newline — see `_update_picker`), so the entire input text is the slash prefix being discovered. Previously `action_dismiss_picker` hid the picker but left `/h` or `/co` sitting in the input, which:

- Made Esc feel like a no-op (no visual change other than the picker box disappearing)
- Forced the user to backspace before typing anything else
- Risked sending the partial slash text as chat if Enter was pressed by mistake

Slack/Discord clear the prefix on Esc — match that.

Esc on non-slash text remains unchanged (the early-return when the picker isn't visible protects that path).

## Test plan

- [x] Manual: type `/he` → picker shows `/help`. Press Esc → picker hides AND input clears. Empty-state hint reappears.
- [x] Manual: retype `/he` after Esc → picker re-opens normally.
- [x] Manual: type plain text `hello world` (no slash, picker not visible) → press Esc → text preserved. (Regression check.)
- [x] Decision-flow Q1 (testing.ja.md): UX behavior + "this commit author would notice" → **Tier 4 → no automated test**; would have to assert TextArea internal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)