### PR TITLE
fix(tui): dedupe noisy "nothing in-flight to cancel" lines

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -43,6 +43,11 @@ if TYPE_CHECKING:
     from reyn.chat.session import ChatSession
 
 
+# Debounce window for the "(nothing in-flight to cancel)" line — repeat
+# Ctrl+C presses within this many seconds are absorbed silently.
+_IDLE_CANCEL_DEDUP_S = 1.5
+
+
 class ReynTUIApp(App):
     """Main Textual application for `reyn chat`."""
 
@@ -123,6 +128,10 @@ class ReynTUIApp(App):
         self._outbox_task: asyncio.Task | None = None
         self._panel_visible = False
         self._cancel_event: asyncio.Event = asyncio.Event()
+        # Most-recent "(nothing in-flight to cancel)" timestamp, used to
+        # suppress repeated identical lines from accumulating in the conv
+        # log when the user mashes Ctrl+C on an idle session.
+        self._last_idle_cancel_ts: float = 0.0
         # run_id → {skill_name, agent_name, start_time, phase, phase_visits}
         self._skill_exec: dict[str, dict] = {}
         # Per-turn cost tracking (A4 — opt-in via /cost-inline)
@@ -682,9 +691,16 @@ class ReynTUIApp(App):
             and cancelled_plans == 0
             and cancelled_streams == 0
         ):
-            self._voice_status(
-                "(nothing in-flight to cancel)", style="dim #555555",
-            )
+            # Suppress repeat lines: when the user mashes Ctrl+C on an idle
+            # session, log a single "(nothing in-flight to cancel)" then
+            # debounce for ``_IDLE_CANCEL_DEDUP_S`` so subsequent presses
+            # don't litter the conv log with identical lines.
+            now = _now_monotonic()
+            if now - self._last_idle_cancel_ts > _IDLE_CANCEL_DEDUP_S:
+                self._voice_status(
+                    "(nothing in-flight to cancel)", style="dim #555555",
+                )
+                self._last_idle_cancel_ts = now
             return
         parts: list[str] = []
         if cancelled_skills:


### PR DESCRIPTION
## Summary

Every Ctrl+C on an idle session was appending a fresh dim `(nothing in-flight to cancel)` line to the conversation log, so a user mashing Ctrl+C 4× would litter the history with 4 identical lines they then had to scroll past on every recall.

Debounce by monotonic timestamp: emit at most one such line per `_IDLE_CANCEL_DEDUP_S` window (1.5 s). A deliberate Ctrl+C after the pause still produces a fresh line, so the feedback channel isn't lost — only the rapid-fire duplicates are absorbed.

## Design note (why not a transient sticky)

The first attempt was a transient `StickyStatus` (mirroring `_show_transient_status` in `OutboxRouter`). `conv.show_status` was called successfully — `_sticky()` returned the widget, `show()` ran without exception — but the sticky never rendered visibly in this code path. Possibly a layout interaction with the empty-hint Static at the bottom of `ConversationView`. The dedup approach avoids the question entirely; investigating sticky behavior in the idle-cancel path can be a separate follow-up if it's worth surfacing this with a richer affordance later.

## Test plan

- [x] Manual: `reyn chat`, mash Ctrl+C 3× rapidly → only ONE `(nothing in-flight to cancel)` line appears
- [x] Manual: wait ~2 s after the line shows, press Ctrl+C → a fresh line appears (debounce window expired)
- [x] Decision-flow Q1 (testing.ja.md): UX behavior with monotonic time → **Tier 4 → no automated test**; debounce duration is a tuning knob, not an invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)