### PR TITLE
fix(tui): ErrorBox header truncates on first line, not total length

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -111,7 +111,17 @@ class ErrorBox(Widget):
     def _header_text(self) -> str:
         prefix = self._prefix()
         arrow = "▼" if self._expanded else "▶"
-        msg = self._message[:72] + "…" if len(self._message) > 72 else self._message
+        # Header is a 1-line Label, so use the first message line as the
+        # synopsis. Only append the "…" overflow indicator when that first
+        # line itself is too long — for multi-line messages whose first
+        # line already fits (e.g. usage strings with sub-commands below),
+        # the ▶/▼ arrow alone signals "expand for more" instead of a
+        # misleading mid-sentence truncation marker.
+        first_line, sep, _rest = self._message.partition("\n")
+        if len(first_line) > 72:
+            msg = first_line[:71] + "…"
+        else:
+            msg = first_line
         if prefix:
             return f"✗ {prefix}: {msg}  {arrow}"
         return f"✗ {msg}  {arrow}"


### PR DESCRIPTION
## Summary

`ErrorBox._header_text` decided whether to show the `…` overflow indicator by inspecting the entire message length:

```python
msg = self._message[:72] + "…" if len(self._message) > 72 else self._message
```

For multi-line usage strings (the canonical case being `/plan badcmd`) whose first line just happened to fit under 72 chars, the user saw a misleading `…` after a complete synopsis line, suggesting that the synopsis itself was cut off when in reality it was the sub-command details on the next lines.

Partition on the first newline; only append `…` when the synopsis line itself is too long. Multi-line messages with a short-enough first line now show the synopsis verbatim. The `▶` arrow alone signals "there's more on expand" — that's its job.

## Before / After

Trigger: `/plan badcmd` (the message is a multi-line usage string)

Before:
```
✗ Usage: /plan <list|discard <plan_id>|resume <plan_id> --from <step_id>>…  ▶
```
(misleading `…` — the first line wasn't actually cut)

After:
```
✗ Usage: /plan <list|discard <plan_id>|resume <plan_id> --from <step_id>>  ▶
```

## Test plan

- [x] Manual: `reyn chat`, run `/plan badcmd` → ErrorBox header shows full first-line synopsis with no `…`; clicking expands to show all 5 lines of `_USAGE`
- [x] Decision-flow Q1 (testing.ja.md): visual format → **Tier 4 → no automated test**; asserting on the exact `_header_text` string would pin a format that's subject to UX tuning.

## Note on the `▶` arrow visibility

At 80-col terminal width the `▶` arrow itself can be truncated by Textual's Label rendering when the message reaches max width — this PR doesn't address that; users can still click anywhere on the visible error line to expand (existing behavior). Surfacing the arrow more robustly is a separate finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)