### PR TITLE
fix(router): include memory.entry names in ghost-filter to surface hot-list aliases

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -394,6 +394,7 @@ def _filter_ghost_names_by_registry(
     available_agents: "list[dict] | None",
     *,
     known_skill_names: "frozenset[str] | None" = None,
+    known_memory_entries: "frozenset[str] | None" = None,
     _warned: "set[str] | None" = None,
 ) -> "list[str]":
     """Filter hot-list names that pass structural check but don't exist in the registry.
@@ -411,10 +412,19 @@ def _filter_ghost_names_by_registry(
     - ``agent.peer__*`` → must match a name in ``available_agents``.
     - ``mcp.tool__*`` / ``mcp.server__*`` → must be a key in ``mcp_tool_map``
       (or any server name prefix for ``mcp.server__*``).
+    - ``memory.entry__*`` → must be in ``known_memory_entries`` (=
+      qualified names enumerated by ``_enumerate_shared_memory_entries``
+      at hot-list build time). When the set is None, memory.entry names
+      pass through unchecked — caller is responsible for supplying the
+      enumerated set when the seed includes dynamic memory entries.
     - Operation categories (``file__*``, ``web__*``, ``memory.operation__*``,
       ``reyn.source__*``, ``rag.operation__*``, ``mcp.operation__*``,
-      ``exec__*``, ``rag.corpus__*``, ``memory.entry__*``) → must be in
-      ``KNOWN_STATIC_QUALIFIED_NAMES`` (static op registry).
+      ``exec__*``) → must be in ``KNOWN_STATIC_QUALIFIED_NAMES`` (static
+      op registry).
+    - ``rag.corpus__*`` is currently routed through the static check; it
+      is also a dynamic category and the same fix shape as memory.entry
+      applies if its caller starts seeding dynamic corpus aliases — see
+      the PR for the memory.entry case for the pattern.
 
     Ghost names are logged once per unique name per session to stderr.
     ``_warned`` is an optional set for cross-call deduplication.
@@ -472,12 +482,22 @@ def _filter_ghost_names_by_registry(
             exists = name in known_mcp_tools
         elif category == "mcp.server":
             exists = entry_name in known_mcp_servers
+        elif category == "memory.entry":
+            # Dynamic category enumerated per-session from .reyn/memory/*.md
+            # by ``_enumerate_shared_memory_entries``. Static op registry
+            # does NOT contain user-saved memory entry slugs. When the
+            # caller passes ``known_memory_entries``, check membership;
+            # when it does not, pass through unchecked (= preserves the
+            # prior behaviour for callers that haven't been updated yet).
+            if known_memory_entries is not None:
+                exists = name in known_memory_entries
+            else:
+                exists = True
         else:
-            # Operation categories and resource categories not enumerable
-            # from session state: check static op registry.
-            # (rag.corpus / memory.entry are dynamic but not enumerable here;
-            # fall back to static check which passes them through —
-            # a conservative choice that avoids false rejections.)
+            # Operation categories not enumerable from session state:
+            # check static op registry. (``rag.corpus__*`` is also a
+            # dynamic category but no caller currently seeds it; if/when
+            # one does, mirror the memory.entry pattern above.)
             if name in static_ops:
                 exists = True
             else:
@@ -1241,6 +1261,11 @@ class RouterLoop:
                     mcp_tool_map=_mcp_tool_map or None,
                     available_agents=host.list_available_agents() or None,
                     known_skill_names=frozenset(_known_skill_names) or None,
+                    # Dynamic memory.entry__<slug> names enumerated above
+                    # from .reyn/memory/*.md. Empty set means "no entries
+                    # exist this session" — filter rejects any stale
+                    # memory.entry name still in the action_usage tracker.
+                    known_memory_entries=frozenset(_memory_entries),
                 )
                 if _top_names:
                     _hot_list_aliases = _build_hot_list_aliases(

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -394,7 +394,7 @@ def _filter_ghost_names_by_registry(
     available_agents: "list[dict] | None",
     *,
     known_skill_names: "frozenset[str] | None" = None,
-    known_memory_entries: "frozenset[str] | None" = None,
+    known_memory_entries: "frozenset[str]",
     _warned: "set[str] | None" = None,
 ) -> "list[str]":
     """Filter hot-list names that pass structural check but don't exist in the registry.
@@ -414,9 +414,8 @@ def _filter_ghost_names_by_registry(
       (or any server name prefix for ``mcp.server__*``).
     - ``memory.entry__*`` → must be in ``known_memory_entries`` (=
       qualified names enumerated by ``_enumerate_shared_memory_entries``
-      at hot-list build time). When the set is None, memory.entry names
-      pass through unchecked — caller is responsible for supplying the
-      enumerated set when the seed includes dynamic memory entries.
+      at hot-list build time). Required parameter — caller must supply
+      the enumerated set (possibly empty when no entries exist).
     - Operation categories (``file__*``, ``web__*``, ``memory.operation__*``,
       ``reyn.source__*``, ``rag.operation__*``, ``mcp.operation__*``,
       ``exec__*``) → must be in ``KNOWN_STATIC_QUALIFIED_NAMES`` (static
@@ -485,14 +484,10 @@ def _filter_ghost_names_by_registry(
         elif category == "memory.entry":
             # Dynamic category enumerated per-session from .reyn/memory/*.md
             # by ``_enumerate_shared_memory_entries``. Static op registry
-            # does NOT contain user-saved memory entry slugs. When the
-            # caller passes ``known_memory_entries``, check membership;
-            # when it does not, pass through unchecked (= preserves the
-            # prior behaviour for callers that haven't been updated yet).
-            if known_memory_entries is not None:
-                exists = name in known_memory_entries
-            else:
-                exists = True
+            # does NOT contain user-saved memory entry slugs; the caller
+            # is required to supply ``known_memory_entries`` (= empty
+            # frozenset is valid for sessions with zero entries).
+            exists = name in known_memory_entries
         else:
             # Operation categories not enumerable from session state:
             # check static op registry. (``rag.corpus__*`` is also a

--- a/tests/test_hot_list_ghost_registry_check.py
+++ b/tests/test_hot_list_ghost_registry_check.py
@@ -22,6 +22,13 @@ Test plan:
   R9. Warning logged once per unique ghost name (deduplication).
   R10. Integration: ActionUsageTracker freq-loaded jsonl with 1 valid skill +
        1 ghost skill → hot-list excludes ghost.
+  R11. memory.entry name in known_memory_entries passes through (dynamic
+       enumeration from .reyn/memory/*.md).
+  R12. memory.entry name NOT in known_memory_entries is filtered (stale name
+       from action_usage tracker after the entry was deleted).
+  R13. memory.entry pass-through when known_memory_entries=None (backwards
+       compat for callers that haven't been updated; static_ops fall-through
+       used to reject all memory.entry — this branch now passes them).
 
 No mocks. Uses real _filter_ghost_names_by_registry + real ActionUsageTracker
 + real KNOWN_STATIC_QUALIFIED_NAMES. No RouterLoop instantiation required.
@@ -308,4 +315,74 @@ def test_r10_integration_tracker_ghost_excluded_from_hot_list(tmp_path: Path) ->
     )
     assert "skill__nonexistent_xyz" not in filtered, (
         "Ghost skill not in skill_meta_map must be removed by registry check."
+    )
+
+
+# ── R11. memory.entry passes when in known_memory_entries ─────────────────────
+
+
+def test_r11_memory_entry_passes_when_in_known_set() -> None:
+    """Tier 2: memory.entry__<slug> in known_memory_entries passes the filter.
+
+    Regression guard for the 2026-05-17 N4+B38 W2 interaction: PR #138
+    seeded dynamic memory.entry aliases into the hot-list, but the B38 W2
+    ghost-filter that landed later did not know about dynamic categories.
+    Result: all memory.entry aliases were rejected via the static_ops
+    fall-through. This test pins the fix that adds the known-set check.
+    """
+    filtered = _filter_ghost_names_by_registry(
+        ["memory.entry__user_project_phoenix"],
+        skill_meta_map=None,
+        mcp_tool_map=None,
+        available_agents=None,
+        known_memory_entries=frozenset({"memory.entry__user_project_phoenix"}),
+    )
+    assert filtered == ["memory.entry__user_project_phoenix"], (
+        "memory.entry name in known set must pass the filter."
+    )
+
+
+# ── R12. memory.entry filtered when not in known_memory_entries ───────────────
+
+
+def test_r12_memory_entry_filtered_when_absent_from_known_set() -> None:
+    """Tier 2: memory.entry__<slug> NOT in known_memory_entries is filtered.
+
+    Scenario: user deleted .reyn/memory/<slug>.md between sessions, but
+    the action_usage tracker still has it from prior freq history. The
+    filter must reject the stale name so the LLM doesn't see a ghost
+    alias that would dispatch to a non-existent entry.
+    """
+    filtered = _filter_ghost_names_by_registry(
+        ["memory.entry__deleted_slug"],
+        skill_meta_map=None,
+        mcp_tool_map=None,
+        available_agents=None,
+        known_memory_entries=frozenset(),  # zero entries this session
+    )
+    assert filtered == [], (
+        "memory.entry name not in known set must be removed."
+    )
+
+
+# ── R13. memory.entry pass-through when known_memory_entries is None ──────────
+
+
+def test_r13_memory_entry_passes_when_known_set_is_none() -> None:
+    """Tier 2: when known_memory_entries=None, memory.entry names pass through.
+
+    Backwards-compat behaviour for callers that have not been updated to
+    enumerate memory entries. The prior implementation fell through to
+    static_ops which rejected ALL memory.entry names; the fix passes
+    them unchecked when the caller hasn't supplied an enumerated set.
+    """
+    filtered = _filter_ghost_names_by_registry(
+        ["memory.entry__some_slug"],
+        skill_meta_map=None,
+        mcp_tool_map=None,
+        available_agents=None,
+        # known_memory_entries omitted (= None)
+    )
+    assert filtered == ["memory.entry__some_slug"], (
+        "memory.entry name passes through when caller does not supply known set."
     )

--- a/tests/test_hot_list_ghost_registry_check.py
+++ b/tests/test_hot_list_ghost_registry_check.py
@@ -26,9 +26,6 @@ Test plan:
        enumeration from .reyn/memory/*.md).
   R12. memory.entry name NOT in known_memory_entries is filtered (stale name
        from action_usage tracker after the entry was deleted).
-  R13. memory.entry pass-through when known_memory_entries=None (backwards
-       compat for callers that haven't been updated; static_ops fall-through
-       used to reject all memory.entry — this branch now passes them).
 
 No mocks. Uses real _filter_ghost_names_by_registry + real ActionUsageTracker
 + real KNOWN_STATIC_QUALIFIED_NAMES. No RouterLoop instantiation required.
@@ -61,13 +58,21 @@ def _call_filter(
     skill_meta_map: dict | None = None,
     mcp_tool_map: dict | None = None,
     available_agents: list[dict] | None = None,
+    known_memory_entries: frozenset[str] | None = None,
 ) -> list[str]:
-    """Convenience wrapper with empty defaults."""
+    """Convenience wrapper with empty defaults.
+
+    ``known_memory_entries`` defaults to an empty frozenset (= no entries),
+    which is the realistic state for tests that aren't exercising the
+    memory.entry path. Test-internal default — the production signature
+    requires the parameter, see ``_filter_ghost_names_by_registry``.
+    """
     return _filter_ghost_names_by_registry(
         names,
         skill_meta_map=skill_meta_map,
         mcp_tool_map=mcp_tool_map,
         available_agents=available_agents,
+        known_memory_entries=known_memory_entries if known_memory_entries is not None else frozenset(),
     )
 
 
@@ -235,6 +240,7 @@ def test_r9_ghost_warning_logged_once_per_unique_name(capsys: pytest.CaptureFixt
     # First call: warning emitted.
     _filter_ghost_names_by_registry(
         [ghost], skill_meta_map=skill_meta_map, mcp_tool_map=None, available_agents=None,
+        known_memory_entries=frozenset(),
         _warned=warned,
     )
     captured = capsys.readouterr()
@@ -246,6 +252,7 @@ def test_r9_ghost_warning_logged_once_per_unique_name(capsys: pytest.CaptureFixt
     # Second call with same _warned: no additional warning.
     _filter_ghost_names_by_registry(
         [ghost], skill_meta_map=skill_meta_map, mcp_tool_map=None, available_agents=None,
+        known_memory_entries=frozenset(),
         _warned=warned,
     )
     captured2 = capsys.readouterr()
@@ -308,6 +315,7 @@ def test_r10_integration_tracker_ghost_excluded_from_hot_list(tmp_path: Path) ->
         skill_meta_map=skill_meta_map,
         mcp_tool_map=None,
         available_agents=None,
+        known_memory_entries=frozenset(),
     )
 
     assert "skill__word_stats_demo" in filtered, (
@@ -365,24 +373,3 @@ def test_r12_memory_entry_filtered_when_absent_from_known_set() -> None:
     )
 
 
-# ── R13. memory.entry pass-through when known_memory_entries is None ──────────
-
-
-def test_r13_memory_entry_passes_when_known_set_is_none() -> None:
-    """Tier 2: when known_memory_entries=None, memory.entry names pass through.
-
-    Backwards-compat behaviour for callers that have not been updated to
-    enumerate memory entries. The prior implementation fell through to
-    static_ops which rejected ALL memory.entry names; the fix passes
-    them unchecked when the caller hasn't supplied an enumerated set.
-    """
-    filtered = _filter_ghost_names_by_registry(
-        ["memory.entry__some_slug"],
-        skill_meta_map=None,
-        mcp_tool_map=None,
-        available_agents=None,
-        # known_memory_entries omitted (= None)
-    )
-    assert filtered == ["memory.entry__some_slug"], (
-        "memory.entry name passes through when caller does not supply known set."
-    )


### PR DESCRIPTION
**[e2e-coder]**

## Summary

FP-0034 §D18 spec: hot-list direct alias projection covers all 13 categories. Today only 12 work — `memory.entry__*` never reaches `tools[]`. Trace evidence: 3 entries planted, 21 tools rendered, 0 memory.entry.

## Root cause

`_filter_ghost_names_by_registry` (B38 W2) checks `static_ops` for non-skill/agent/mcp categories. `memory.entry__<slug>` is dynamic (per-session, scanned from `.reyn/memory/*.md`) and never in `KNOWN_STATIC_QUALIFIED_NAMES` → reject. PR #138 (N4) enumeration runs upstream but the filter has no signal to validate dynamic names.

User-visible symptom (weak default, fresh session + planted memory):
> Before: *"I have no memory of what you've told me. I am a large language model, and I don't have access to past conversations or personal data."*

## Fix

`_filter_ghost_names_by_registry` gets `known_memory_entries: frozenset[str]` (required, keyword-only — per review feedback, no default). Caller in `router_loop.py:1265` passes `frozenset(_memory_entries)` from the existing `_enumerate_shared_memory_entries` call.

Touch: `src/reyn/chat/router_loop.py`, `tests/test_hot_list_ghost_registry_check.py`.

## Test plan

- [x] R11/R12 added (known-set in / not-in); 12 ghost-filter tests pass (R13 dropped per review — Tier 4)
- [x] 106 adjacent tests pass (`test_memory_entry_hot_list_alias` / `test_universal_dispatch` / `test_router_loop`) — no regression
- [x] Ruff clean on touched files
- [x] **E2E re-verify** post-fix (both initial + post-review-revision):
  - tools[]: 24 (+3 `memory.entry__user_*`), 0 ghost warnings
  - LLM parallel-calls all 3 aliases in turn 1
  - Reply: *"You are working on the Phoenix project with Python 3.12. You prefer replies in Japanese. You drink black coffee with no sugar and prefer a light roast."* — all 3 entries integrated, no discovery turn

## Out of scope

`rag.corpus__*` is also a dynamic category and may have the same bug class. No trace evidence yet (no captured session exercises a seeded corpus). Same fix shape would apply — separate follow-up if/when surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)