### PR TITLE
fix(tui): Keys tab includes InputBar bindings under [INPUT] group

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -45,7 +45,7 @@ class InputBar(Widget):
         Binding("tab", "confirm_picker", "Confirm", priority=True, show=False),
         Binding("up", "key_up", "Up", priority=True, show=False),
         Binding("down", "key_down", "Down", priority=True, show=False),
-        Binding("escape", "dismiss_picker", "Esc", priority=True, show=False),
+        Binding("escape", "dismiss_picker", "Dismiss", priority=True, show=False),
         Binding("ctrl+j", "newline", "Newline", priority=True, show=False),
         Binding("ctrl+u", "clear_input", "Clear input", priority=True, show=False),
         Binding("ctrl+l", "clear_conversation", "Clear", priority=True, show=False),

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -24,6 +24,7 @@ _KEY_PRETTY: dict[str, str] = {
     "ctrl+shift+o": "⌃⇧O",
     "ctrl+shift+w": "⌃⇧W",
     "enter": "Enter", "tab": "Tab", "escape": "Esc", "space": "Space",
+    "up": "↑", "down": "↓", "left": "←", "right": "→",
 }
 _CONVERSATION_KEYS = {"ctrl+p", "ctrl+n", "ctrl+shift+n", "ctrl+shift+p"}
 _PANEL_KEYS = {
@@ -33,9 +34,15 @@ _PANEL_KEYS = {
 _EVENTS_KEYS = {"f", "t"}
 _DOCS_KEYS = {"j", "k", "space", "/"}
 _GROUP_ORDER = [
-    "GLOBAL", "CONVERSATION", "PANEL",
+    "GLOBAL", "INPUT", "CONVERSATION", "PANEL",
     "EVENTS (gated)", "DOCS (gated)", "OTHER",
 ]
+
+# Keys whose app-level binding is voice-mode-gated (active only during
+# recording) and whose dominant chat-time meaning lives on InputBar.
+# Surface InputBar's description for these so the Keys tab reflects what
+# the user experiences 99 % of the time, not the voice-mode override.
+_INPUT_OWNED_KEYS = {"enter", "escape", "tab", "up", "down"}
 
 
 def _key_group_for(key: str) -> str:
@@ -64,17 +71,39 @@ def _pretty_key(key: str) -> str:
 
 def render_keys(app: "App") -> str:
     """Return Rich markup listing bindings grouped by context."""
+    # Local import keeps right_panel/keys_tab decoupled from widget-init
+    # order (InputBar imports from chat.slash, which would otherwise be
+    # pulled in at module-load time).
+    from ..input_bar import InputBar
+
     groups: dict[str, list[tuple[str, str]]] = {g: [] for g in _GROUP_ORDER}
     seen: set[str] = set()
+    # App-level bindings first — they take precedence on same-key conflicts
+    # (the InputBar's ctrl+c / ctrl+d / ctrl+l shadow app's, but app's
+    # description is the load-bearing one users see in the footer hint).
+    # Exception: _INPUT_OWNED_KEYS — defer to InputBar so the listed
+    # description matches the non-voice-mode behavior.
     for raw in app.BINDINGS:
         b = raw if isinstance(raw, Binding) else Binding(*raw)
         if b.key in seen or not b.description:
+            continue
+        if b.key in _INPUT_OWNED_KEYS:
             continue
         seen.add(b.key)
         group = _key_group_for(b.key)
         if group not in groups:
             group = "OTHER"
         groups[group].append((_pretty_key(b.key), b.description))
+    # InputBar-level bindings: chat-input affordances (Enter / Tab / arrows
+    # / Esc / Ctrl+J Newline / Ctrl+U Clear input). Without surfacing
+    # these the Keys tab silently omitted "how do I insert a newline"
+    # and "how do I wipe the buffer" — both load-bearing for the input box.
+    for raw in InputBar.BINDINGS:
+        b = raw if isinstance(raw, Binding) else Binding(*raw)
+        if b.key in seen or not b.description:
+            continue
+        seen.add(b.key)
+        groups["INPUT"].append((_pretty_key(b.key), b.description))
 
     lines: list[str] = []
     # Key column width: max key length within the group, capped at 6


### PR DESCRIPTION
## Summary

`render_keys` only iterated `app.BINDINGS`, so chat-input affordances — Ctrl+J (Newline), Ctrl+U (Clear input), Tab (picker Confirm), Up/Down (picker selection / history), Esc (Dismiss picker) — were absent from the Keys tab. A user discovering bindings via Ctrl+B had no way to learn how to insert a newline or wipe the buffer.

Pull from `InputBar.BINDINGS` as a second source and surface them under a new `[INPUT]` group.

### Voice-mode override handling

`enter` / `escape` / `tab` / `up` / `down` are declared in BOTH `app.BINDINGS` (voice-mode gated) AND `InputBar.BINDINGS` (always-on). The app-level descriptions are `"Voice send"` / `"Voice cancel"` etc., which are misleading for 99 % of the time the user is just typing. These keys are claimed by InputBar via a new `_INPUT_OWNED_KEYS` set so the Keys tab reflects the dominant (non-voice) behavior.

Also tightened InputBar's Esc description from `"Esc"` (placeholder, tautological) to `"Dismiss"` so the Keys tab row reads as an action.

## Before / After (Keys tab)

Before (no [INPUT] group; Enter/Esc misclassified):
```
[GLOBAL]   ⌃D Quit  ⌃L Clear  ⌃C Cancel  ⌃B Panel  ⌃R Voice  ⌃\ Screenshot
[OTHER]    f2 Voice (alias)  Enter Voice send  Esc Voice cancel
```

After:
```
[GLOBAL]   ⌃D Quit  ⌃L Clear  ⌃C Cancel  ⌃B Panel  ⌃R Voice  ⌃\ Screenshot

[INPUT]    Enter Submit  Tab Confirm  ↑ Up  ↓ Down  Esc Dismiss
           ⌃J Newline  ⌃U Clear input
```

## Test plan

- [x] Manual: `reyn chat` → Ctrl+B → Keys tab → [INPUT] group present with Enter/Tab/↑/↓/Esc/⌃J/⌃U
- [x] Manual: scroll through panel → [OTHER] no longer contains misleading Enter/Esc rows
- [x] Manual: Ctrl+L / Ctrl+D / Ctrl+C still show in [GLOBAL] (app wins, descriptions match anyway)
- [x] Decision-flow Q1 (testing.ja.md): visual / dictionary content → **Tier 4 → no automated test**; asserting on the exact string list would pin presentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)