### PR TITLE
fix(tui): /help and /skills pre-wrap with hanging indent

### DIFF
--- a/src/reyn/chat/slash/help.py
+++ b/src/reyn/chat/slash/help.py
@@ -36,7 +36,6 @@ async def help_cmd(session: "object", args: str) -> None:
     # the summary align to this column so they read as continuations
     # rather than orphan commands.
     data_col = 2 + 1 + name_w + 2
-    summary_width = max(20, _TARGET_WIDTH - data_col)
     indent = " " * data_col
 
     lines = ["Slash commands:"]

--- a/src/reyn/chat/slash/help.py
+++ b/src/reyn/chat/slash/help.py
@@ -1,6 +1,8 @@
 """/help — list all available slash commands with one-line summaries."""
 from __future__ import annotations
 
+import textwrap
+
 from reyn.chat.slash import REGISTRY, reply, slash
 
 # Built-ins handled outside the registry (intercepted by the TUI / REPL
@@ -9,6 +11,14 @@ _BUILTIN_HINTS: list[tuple[str, str]] = [
     ("quit", "Exit the chat (alias: /exit, Ctrl+D)"),
     ("exit", "Exit the chat (alias: /quit, Ctrl+D)"),
 ]
+
+# Target line width for pre-wrapping. The TUI body adds a 7-cell left
+# Padding (``_BODY_INDENT_COLS`` in conversation.py) AND the conv pane
+# / RichLog have their own ~3-cell horizontal padding+scrollbar overhead;
+# 65 = 80-col terminal minus the combined ~15-cell budget. Wider terminals
+# leave whitespace on the right (harmless); narrower terminals will still
+# RichLog-wrap on top of our pre-wrap.
+_TARGET_WIDTH = 65
 
 
 @slash("help", summary="Show this list of slash commands")
@@ -21,14 +31,31 @@ async def help_cmd(session: "object", args: str) -> None:
     rows.extend(_BUILTIN_HINTS)
     rows.sort(key=lambda r: r[0])
 
-    width = max((len(name) for name, _ in rows), default=8)
+    name_w = max((len(name) for name, _ in rows), default=8)
+    # Data column starts after "  /" + name + "  ". Wrap continuations of
+    # the summary align to this column so they read as continuations
+    # rather than orphan commands.
+    data_col = 2 + 1 + name_w + 2
+    summary_width = max(20, _TARGET_WIDTH - data_col)
+    indent = " " * data_col
+
     lines = ["Slash commands:"]
     for name, summary in rows:
-        lines.append(f"  /{name:<{width}}  {summary}")
+        prefix = f"  /{name:<{name_w}}  "
+        wrapped = textwrap.fill(
+            summary,
+            width=_TARGET_WIDTH,
+            initial_indent=prefix,
+            subsequent_indent=indent,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ) if len(prefix) + len(summary) > _TARGET_WIDTH else prefix + summary
+        lines.append(wrapped)
     lines.append("")
-    lines.append(
+    footer = (
         "Type / to open the command palette. Tab inserts the highlighted "
         "command (and keeps the cursor); Enter inserts + submits."
     )
+    lines.append(textwrap.fill(footer, width=_TARGET_WIDTH))
 
     await reply(session, "\n".join(lines))

--- a/src/reyn/chat/slash/skills.py
+++ b/src/reyn/chat/slash/skills.py
@@ -1,9 +1,14 @@
 """/skills slash command."""
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 from reyn.chat.slash import reply, slash
+
+# See help.py for rationale — 65 = common 80-col terminal minus the
+# combined body indent (7) + conv pane / RichLog padding overhead.
+_TARGET_WIDTH = 65
 
 
 def _list_skills(root: Path) -> list[str]:
@@ -33,8 +38,25 @@ async def skills_cmd(session: "object", args: str) -> None:
 
     lines: list[str] = ["available skills:"]
     for label, names in sources:
-        if names:
-            lines.append(f"  {label}: " + ", ".join(names))
+        if not names:
+            continue
+        prefix = f"  {label}: "
+        body = ", ".join(names)
+        if len(prefix) + len(body) <= _TARGET_WIDTH:
+            lines.append(prefix + body)
+        else:
+            # Hanging indent: wrap continuations under the comma-list so
+            # the source label stays anchored and the long list doesn't
+            # break to column 0 mid-word.
+            wrapped = textwrap.fill(
+                body,
+                width=_TARGET_WIDTH,
+                initial_indent=prefix,
+                subsequent_indent=" " * len(prefix),
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+            lines.append(wrapped)
     if len(lines) == 1:
         lines.append("  (none found)")
 


### PR DESCRIPTION
**[tui-coder]** — 

## Summary

Long command summaries (e.g. `/copy` at 62 chars) and the `/skills` comma-list overflow the conv pane's effective content width (~65 cells at an 80-col terminal after body padding + RichLog padding). RichLog wrapped each row at the pane edge but the wrap continuation reverted to column 0 of the body area — so `/copy list)` looked like an orphan command on its own row rather than a continuation of `/copy`'s summary.

Pre-wrap with `textwrap.fill`, anchoring `subsequent_indent` to the data column (= after the command-name column). The output now reads as a clean two-column table whose long rows wrap visibly under their summary start, not at the left margin.

## Before / After (80-col terminal)

Before:
```
  /copy         Copy an agent reply to the clipboard (/copy [N] or
/copy list)                                                          ← orphan-looking
  /cost         Quick token + USD cost summary for this agent
```

After:
```
  /copy         Copy an agent reply to the clipboard (/copy [N]
                or /copy list)                                       ← clearly a continuation
  /cost         Quick token + USD cost summary for this agent
```

Same treatment for `/skills` — its comma-separated lists wrap with hanging indent under the `stdlib:` / `project:` / `local:` label.

## Implementation notes

- Hardcoded `_TARGET_WIDTH = 65` (= 80 − 7 body indent − ~8 cells of RichLog padding/scrollbar overhead). Slash commands don't have access to terminal width at execution time. Wider terminals leave whitespace on the right (harmless); narrower terminals will still RichLog-wrap on top of the pre-wrap.
- `break_long_words=False` and `break_on_hyphens=False` keep command tokens like `<plan_id>` and `--from` intact.

## Test plan

- [x] Manual: `reyn chat` at 80-col, `/help` → long rows (`/answer`, `/budget`, `/copy`, `/plan`, `/tasks`) wrap with hanging indent under the summary column
- [x] Manual: `/skills` → stdlib list (15+ entries) wraps under `stdlib: `
- [x] Manual: 120-col → renders correctly with extra whitespace on the right (no regression)
- [x] Decision-flow Q1 (testing.ja.md): visual format → **Tier 4 → no automated test**; `_TARGET_WIDTH` is a tuning knob, not an invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)