### PR TITLE
fix(dogfood): wipe per-agent history.jsonl in _wipe_scenario_state — close fresh-mode contract gap

### DIFF
--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -349,6 +349,14 @@ def _build_live_runner(agent_name: str):
       events contain only the events from that scenario's turns.
     - Wipes state/action_usage.jsonl before each scenario so hot-list
       frequency counters don't bleed across scenarios.
+    - Wipes agents/<name>/history.jsonl before each scenario so chat
+      history from prior scenarios is not injected into the LLM's
+      messages. Without this, ChatSession.load_history() (called by the
+      session factory) loads the accumulated history-jsonl from disk,
+      and scenario N sees scenario 1..N-1's user/assistant turns in its
+      context — defeating the "fresh per scenario" guarantee. The
+      dogfood_fresh_reset.sh script explicitly defers per-agent history
+      wipe to callers (= the runner is the caller); this is that wipe.
     - Drops the cached ChatSession from the registry between scenarios so
       the session's in-memory EventLog starts empty each time.
 
@@ -456,6 +464,15 @@ def _build_live_runner(agent_name: str):
         # Wipe action_usage ledger to prevent hot-list bleed across scenarios.
         action_usage_path = project_root / ".reyn" / "state" / "action_usage.jsonl"
         action_usage_path.unlink(missing_ok=True)
+        # Wipe per-agent chat history so prior scenarios' user/assistant
+        # turns are NOT injected into the LLM context for this scenario.
+        # ChatSession.load_history() (called by the session factory) reads
+        # this file unconditionally; without the wipe, scenario N sees
+        # scenarios 1..N-1's messages. dogfood_fresh_reset.sh intentionally
+        # defers this wipe to callers because it requires knowing the
+        # agent name (which the script doesn't); the runner has it.
+        history_path = project_root / ".reyn" / "agents" / agent_name / "history.jsonl"
+        history_path.unlink(missing_ok=True)
 
     def _collect_events(registry: AgentRegistry) -> list[dict]:
         """Harvest events emitted during the scenario from the EventStore."""

--- a/tests/test_fp0036_live_runner.py
+++ b/tests/test_fp0036_live_runner.py
@@ -10,6 +10,10 @@ Covers:
   4. Failure isolation: a scenario that fails during execution yields a
      ScenarioRunResult with events_outcome="blocked" and does NOT propagate
      as a Python exception out of the runner.
+  5. History isolation: chat history written by a prior scenario does not
+     leak into the next scenario's LLM context. The runner wipes
+     .reyn/agents/<name>/history.jsonl before each scenario so that
+     ChatSession.load_history() returns empty for scenario N.
 
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No unittest.mock.MagicMock / AsyncMock.  `patch` used only to replace
@@ -303,3 +307,77 @@ async def test_failure_isolation_returns_blocked_not_exception(tmp_path, monkeyp
     assert result.detail.get("stage") == "ensure_running", (
         f"Expected stage='ensure_running', got {result.detail!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: history isolation — pre-existing history.jsonl is wiped per scenario
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_jsonl_wiped_before_scenario(tmp_path, monkeypatch):
+    """Tier 2: history isolation — chat history from a prior session does not
+    leak into the next scenario's LLM context.
+
+    Regression guard for the 2026-05-17 dogfood runner gap: before this
+    fix, `_wipe_scenario_state` cleaned events and action_usage but left
+    `.reyn/agents/<name>/history.jsonl` on disk. `ChatSession.load_history()`
+    (called by the session factory) reads that file unconditionally, so
+    scenario N inside a single `reyn dogfood run` saw scenarios 1..N-1's
+    user/assistant turns in its `messages[]` — defeating "fresh per
+    scenario". This test pins the wipe.
+
+    Strategy:
+    1. Pre-create a `history.jsonl` with stale entries before running
+       any scenario.
+    2. Run a scenario via the runner_fn.
+    3. Assert the file was wiped (= no longer exists) before the session
+       loaded it. We verify by checking that the scenario's LLM call
+       received messages without the stale entries.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # Pre-populate history.jsonl with stale entries that should NOT be
+    # visible to the scenario's LLM call.
+    agent_dir = tmp_path / ".reyn" / "agents" / "default"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    history_path = agent_dir / "history.jsonl"
+    stale_entries = [
+        '{"role": "user", "content": "STALE FROM PRIOR SESSION", "meta": {}}',
+        '{"role": "assistant", "content": "stale reply", "meta": {}}',
+    ]
+    history_path.write_text("\n".join(stale_entries) + "\n", encoding="utf-8")
+    assert history_path.exists(), "Precondition: history.jsonl seeded on disk."
+
+    # Capture the messages the LLM sees on each call.
+    captured_messages: list = []
+
+    async def capturing_llm(**kw):
+        captured_messages.append(kw.get("messages") or [])
+        return _text_result("Fresh reply.")
+
+    runner_fn = _make_live_runner_fn(tmp_path, agent_name="default")
+    assert runner_fn is not None
+
+    scenario = _make_scenario("hist-s1", input_text="What is fresh?")
+
+    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=capturing_llm):
+        result = await runner_fn(scenario)
+
+    # The LLM must NOT have seen any of the stale entries in any call.
+    # (Cannot assert history_path absence after the run because the session
+    # appends each new turn to history.jsonl as it executes — the file is
+    # recreated by the live run itself. The invariant we care about is
+    # that the LLM messages were not pre-populated with stale content.)
+    assert captured_messages, "Precondition: LLM must have been invoked at least once."
+    stale_marker = "STALE FROM PRIOR SESSION"
+    for i, msgs in enumerate(captured_messages):
+        for m in msgs:
+            content = m.get("content") or ""
+            if isinstance(content, str):
+                assert stale_marker not in content, (
+                    f"Stale history bled into LLM call {i}: message content "
+                    f"contained {stale_marker!r}. Wipe failed."
+                )
+
+    assert result.scenario_id == "hist-s1"


### PR DESCRIPTION
**[e2e-coder]**

## Summary

`reyn dogfood run` design intent (= `runner.py:45-49` + `dogfood-discipline §6.7`): each scenario starts with no carry-over state — including chat history. Today only `events/chat/` + `action_usage.jsonl` are wiped per scenario; **`.reyn/agents/<name>/history.jsonl` survives**, so scenario N inside a single run sees scenarios 1..N-1's user/assistant turns in its LLM messages.

## Root cause

`_wipe_scenario_state` in `src/reyn/cli/commands/dogfood.py:449-459` cleans events + action_usage but skips history.jsonl. `ChatSession.load_history()` (= called by the session factory on every `ensure_running`) reads that file unconditionally → fresh-per-scenario guarantee is silently violated.

The fresh-reset shell script (`scripts/dogfood_fresh_reset.sh:17-18`) explicitly defers per-agent history wipe to "callers" because it doesn't know the agent name. The runner does know — `agent_name` is the `--agent` argument — but the wipe was never wired up.

E2e-coder probe (2026-05-17): a "fresh" N=5 file-summarize probe actually produced msgs=22-25 instead of the expected msgs=2, with "failure modes" (= "I already summarized") being rational LLM replies to the accumulated history.

## Fix

Add `history.jsonl.unlink(missing_ok=True)` to `_wipe_scenario_state`, scoped to `agent_name`. Mirrors the existing per-agent events/chat wipe; does not affect other agents' history.

Touch: `src/reyn/cli/commands/dogfood.py` (+17 lines incl. docstring), `tests/test_fp0036_live_runner.py` (+78 lines = Test 5).

## Test plan

- [x] R5 added in `test_fp0036_live_runner.py` (`test_history_jsonl_wiped_before_scenario`) — seeds `history.jsonl` with `STALE FROM PRIOR SESSION` marker, runs scenario, asserts the marker does not appear in any captured LLM call's messages
- [x] 5/5 live_runner tests pass + 28/28 adjacent dogfood tests (`test_dogfood_fresh_mode`, `test_dogfood_trace_tool`)
- [x] Ruff clean on touched files
- [x] No skill-specific strings added to OS code (P7) — `_wipe_scenario_state` references only `agent_name` (argument) and standard path components

## Out of scope

- The fresh-reset shell script itself remains unchanged — it intentionally doesn't know agent names; the runner is the correct layer for per-agent wipe.
- This fix is for `_wipe_scenario_state` only. `reyn chat --no-history` flag (= general-purpose debug affordance, symmetric with `--no-restore`) is a separate concern not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)