### PR TITLE
fix(tui): slash picker shows arg hint after space

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -295,9 +295,20 @@ class InputBar(Widget):
             picker.hide()
             return
         token = text[1:]
-        # Stop matching once the user types a space (entering args)
+        # Once the user types a space, they've entered args mode. Look up
+        # the command they picked and surface its summary as a single-row
+        # hint — the picker stays out of the keyboard path so Enter
+        # submits the typed args instead of replacing them with /cmdname.
         if " " in token:
-            picker.hide()
+            cmd_name = token.split(" ", 1)[0]
+            cmd = next(
+                (c for c in self._slash_commands if c.name == cmd_name),
+                None,
+            )
+            if cmd is not None:
+                picker.set_hint(cmd)
+            else:
+                picker.hide()
             return
         matches = [
             c for c in self._slash_commands

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -62,6 +62,12 @@ class SlashPicker(Static):
         # "+N more — keep typing to filter" footer when the picker can't
         # show every match.
         self._total_matches: int = 0
+        # Hint-only mode: when the user has typed "/<known-cmd> " (space
+        # consumed, picker selection no longer relevant), show a single
+        # informational row with the matched command's summary. ``_matches``
+        # stays empty so Enter / Tab / arrows fall through to the normal
+        # text-submit path and the user's typed args are preserved.
+        self._hint_cmd: SlashCommand | None = None
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -78,15 +84,33 @@ class SlashPicker(Static):
         self._total_matches = len(matches)
         self._matches = list(matches)[:_MAX_VISIBLE]
         self._selected = 0
+        self._hint_cmd = None
         if self._matches:
             self.add_class("visible")
         else:
             self.remove_class("visible")
         self._repaint()
 
+    def set_hint(self, cmd: SlashCommand) -> None:
+        """Show a single informational row for ``cmd`` (no selection caret).
+
+        Used after the user types ``/<cmd> `` to remind them what the
+        command does. Leaves ``_matches`` empty so the keyboard / click
+        paths gated on ``has_matches`` skip; the user keeps typing args
+        and Enter submits the typed text instead of replacing it with
+        ``/cmdname``.
+        """
+        self._matches = []
+        self._total_matches = 0
+        self._selected = 0
+        self._hint_cmd = cmd
+        self.add_class("visible")
+        self._repaint()
+
     def hide(self) -> None:
         self._matches = []
         self._selected = 0
+        self._hint_cmd = None
         self.remove_class("visible")
         self._repaint()
 
@@ -138,7 +162,10 @@ class SlashPicker(Static):
 
     def _repaint(self) -> None:
         if not self._matches:
-            self.update("")
+            if self._hint_cmd is not None:
+                self._repaint_hint()
+            else:
+                self.update("")
             return
 
         # Width for the command-name column (left)
@@ -191,3 +218,33 @@ class SlashPicker(Static):
                 style="dim #888888",
             )
         self.update(body)
+
+    def _repaint_hint(self) -> None:
+        """Render a single dim hint row showing the matched command's summary.
+
+        No selection caret — the user has already chosen the command and is
+        typing args. The picker stays out of the keyboard / click paths
+        (``_matches`` is empty) so Enter / Tab / arrows fall through to the
+        normal text-submit and history-recall behaviour.
+        """
+        cmd = self._hint_cmd
+        if cmd is None:
+            self.update("")
+            return
+        try:
+            term_w = self.app.size.width
+        except Exception:
+            term_w = 60
+        content_w = max(20, term_w - 6)
+        name = f"/{cmd.name}"
+        prefix_cells = 2 + len(name) + 2  # leading "  " + name + "  "
+        summary_budget = max(10, content_w - prefix_cells)
+        summary = cmd.summary
+        if len(summary) > summary_budget:
+            summary = summary[: max(1, summary_budget - 1)] + "…"
+        t = Text()
+        t.append("  ", style="#1a1a1a")
+        t.append(name, style="dim #888888")
+        t.append("  ")
+        t.append(summary, style="dim #888888")
+        self.update(t)

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -47,7 +47,7 @@ class SlashPicker(Static):
         padding: 0 1;
         display: none;
     }
-    SlashPicker.visible {
+    SlashPicker.visible, SlashPicker.hint-active {
         display: block;
     }
     """
@@ -73,6 +73,13 @@ class SlashPicker(Static):
 
     @property
     def visible_(self) -> bool:
+        """True iff the picker is showing selectable matches.
+
+        Hint mode (= ``/<cmd> <args>``) does NOT count as visible_ — it has
+        no selection caret and the keyboard paths skip it via has_matches.
+        Existing test contract pins "post-confirm picker is not visible_"
+        so this predicate stays matches-driven.
+        """
         return self.has_class("visible")
 
     @property
@@ -85,6 +92,7 @@ class SlashPicker(Static):
         self._matches = list(matches)[:_MAX_VISIBLE]
         self._selected = 0
         self._hint_cmd = None
+        self.remove_class("hint-active")
         if self._matches:
             self.add_class("visible")
         else:
@@ -99,12 +107,18 @@ class SlashPicker(Static):
         paths gated on ``has_matches`` skip; the user keeps typing args
         and Enter submits the typed text instead of replacing it with
         ``/cmdname``.
+
+        Display is gated by the separate ``hint-active`` CSS class — NOT
+        ``visible`` — so the matches-driven ``visible_`` predicate stays
+        false (existing test contract: "post-confirm picker is not
+        visible_").
         """
         self._matches = []
         self._total_matches = 0
         self._selected = 0
         self._hint_cmd = cmd
-        self.add_class("visible")
+        self.remove_class("visible")
+        self.add_class("hint-active")
         self._repaint()
 
     def hide(self) -> None:
@@ -112,6 +126,7 @@ class SlashPicker(Static):
         self._selected = 0
         self._hint_cmd = None
         self.remove_class("visible")
+        self.remove_class("hint-active")
         self._repaint()
 
     def move_selection(self, delta: int) -> None:


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Once the user typed `/cmd ` (space, entering args mode), `_update_picker` called `picker.hide()` and the user was left staring at a blank input with no guidance on what args `/plan` / `/skill` / `/docs-filter` etc. accept. Required them to either retry `/help` or remember.

Add a **hint-only** mode to `SlashPicker`: `set_hint(cmd)` renders a single dim row with the command name + summary, **no** selection caret, and `_matches` stays empty so the keyboard paths (Enter / Tab / arrows) all gate on `has_matches=False` and fall through to the normal text-submit. The user keeps typing args and Enter submits the typed text instead of replacing it with `/cmdname`.

`InputBar._update_picker` parses the command name from `"/<cmd> <args>"`, looks it up in `_slash_commands`:
- match → `set_hint(cmd)`
- no match → `hide()` (no misleading hint for `/foo` and friends)

## Before / After

Before (`/plan ` typed):
```
                            ← blank, no hint
  /plan
```

After:
```
┌────────────────────────────────────────────────────┐
│   /plan  Manage active plan-mode runs (list / discard / resume)  │
└────────────────────────────────────────────────────┘
  /plan
```

(Dim text, no caret — informational only.)

## Test plan

- [x] Manual: type `/plan ` → hint row shows `Manage active plan-mode runs (list / discard / resume)`
- [x] Manual: type `/plan list` → hint stays visible
- [x] Manual: press Enter on `/plan list` → dispatches as `/plan list` (NOT `/plan` alone); session prints `(no active plans)` from the real handler
- [x] Manual: type `/foo ` (unknown command + space) → picker hides; no misleading hint
- [x] Manual: type `/p` (no space, prefix only) → normal selectable picker with `▌` caret; Tab inserts `/plan` (regression check — prefix mode unchanged)
- [x] Decision-flow Q1 (testing.ja.md): UI rendering + mode-switch behavior → **Tier 4 → no automated test**; would require asserting on SlashPicker's private `_hint_cmd` / `_matches` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)