### PR TITLE
fix(tui): wire SlashCommand.completer into the picker

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -322,15 +322,26 @@ class InputBar(Widget):
         # hint — the picker stays out of the keyboard path so Enter
         # submits the typed args instead of replacing them with /cmdname.
         if " " in token:
-            cmd_name = token.split(" ", 1)[0]
+            cmd_name, _, arg_partial = token.partition(" ")
             cmd = next(
                 (c for c in self._slash_commands if c.name == cmd_name),
                 None,
             )
-            if cmd is not None:
-                picker.set_hint(cmd)
-            else:
+            if cmd is None:
                 picker.hide()
+                return
+            # If the command supplies a CompleterFn, run it and surface
+            # filtered matches (e.g. /attach <name> → agent names). Falls
+            # back to plain hint when there's no completer or no session.
+            completions = (
+                self._run_completer(cmd, arg_partial)
+                if cmd.completer is not None
+                else None
+            )
+            if completions:
+                picker.set_completions(cmd, completions)
+            else:
+                picker.set_hint(cmd)
             return
         matches = [
             c for c in self._slash_commands
@@ -339,6 +350,31 @@ class InputBar(Widget):
         # Sort by name length then alpha so closer prefix shows first
         matches.sort(key=lambda c: (len(c.name), c.name))
         picker.set_matches(matches)
+
+    def _run_completer(
+        self, cmd: SlashCommand, arg_partial: str,
+    ) -> list[str]:
+        """Resolve ``cmd.completer(session)`` and prefix-filter by partial.
+
+        Reaches up to ``self.app`` to fetch the active session — a small
+        layer leak that avoids threading a session-getter through every
+        widget constructor for the single arg-completion path. Returns
+        an empty list (= caller falls back to plain hint mode) on any
+        exception so a broken completer can't break the picker.
+        """
+        try:
+            session = self.app._get_session()  # type: ignore[attr-defined]
+        except Exception:
+            return []
+        if session is None or cmd.completer is None:
+            return []
+        try:
+            all_completions = cmd.completer(session)
+        except Exception:
+            return []
+        if arg_partial:
+            return [c for c in all_completions if c.startswith(arg_partial)]
+        return list(all_completions)
 
     def _confirm_picker(self, picker: SlashPicker, ta: TextArea) -> None:
         cmd = picker.selected_command()

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -68,6 +68,12 @@ class SlashPicker(Static):
         # stays empty so Enter / Tab / arrows fall through to the normal
         # text-submit path and the user's typed args are preserved.
         self._hint_cmd: SlashCommand | None = None
+        # Optional completion strings rendered below the hint row when the
+        # command supplies a CompleterFn (e.g. /attach surfacing agent
+        # names). Same informational-only contract as hint mode — no
+        # selection caret, no keyboard intercept.
+        self._completions: list[str] = []
+        self._total_completions: int = 0
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -92,6 +98,8 @@ class SlashPicker(Static):
         self._matches = list(matches)[:_MAX_VISIBLE]
         self._selected = 0
         self._hint_cmd = None
+        self._completions = []
+        self._total_completions = 0
         self.remove_class("hint-active")
         if self._matches:
             self.add_class("visible")
@@ -117,6 +125,29 @@ class SlashPicker(Static):
         self._total_matches = 0
         self._selected = 0
         self._hint_cmd = cmd
+        self._completions = []
+        self._total_completions = 0
+        self.remove_class("visible")
+        self.add_class("hint-active")
+        self._repaint()
+
+    def set_completions(
+        self, cmd: SlashCommand, completions: list[str],
+    ) -> None:
+        """Show ``cmd``'s hint plus a list of arg-name completions.
+
+        Like ``set_hint`` but additionally renders the strings returned by
+        ``cmd.completer(session)`` (already prefix-filtered upstream) as
+        dim rows below the summary. Still informational only — no
+        selection caret, no keyboard intercept; the user reads, types,
+        and Enter submits the typed text.
+        """
+        self._matches = []
+        self._total_matches = 0
+        self._selected = 0
+        self._hint_cmd = cmd
+        self._total_completions = len(completions)
+        self._completions = list(completions)[:_MAX_VISIBLE]
         self.remove_class("visible")
         self.add_class("hint-active")
         self._repaint()
@@ -125,6 +156,8 @@ class SlashPicker(Static):
         self._matches = []
         self._selected = 0
         self._hint_cmd = None
+        self._completions = []
+        self._total_completions = 0
         self.remove_class("visible")
         self.remove_class("hint-active")
         self._repaint()
@@ -262,4 +295,19 @@ class SlashPicker(Static):
         t.append(name, style="dim #888888")
         t.append("  ")
         t.append(summary, style="dim #888888")
+        # Completion rows (if the command supplied a CompleterFn — e.g.
+        # /attach surfacing agent names). Indented under the hint row,
+        # one per line, dim, informational only.
+        if self._completions:
+            indent = " " * (2 + len(name) + 2)
+            for c in self._completions:
+                t.append("\n")
+                t.append(indent + c, style="dim #888888")
+            hidden = self._total_completions - len(self._completions)
+            if hidden > 0:
+                t.append("\n")
+                t.append(
+                    indent + f"+{hidden} more — keep typing to filter",
+                    style="dim #555555",
+                )
         self.update(t)


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The `CompleterFn` field on `SlashCommand` was declared and `/attach` registered `_attach_completer` (= return known agent names), but the infrastructure was half-built: `InputBar._update_picker` hid the picker on space and never read `cmd.completer`, so Tab after `/attach ` gave nothing — the user had to know agent names by memory or run `/agents` first.

Wire it. After `/<cmd> <arg-partial>` is detected:
- if `cmd.completer is not None`: run it via `self.app._get_session()` and prefix-filter by `arg_partial`
- non-empty completion list → `SlashPicker.set_completions(cmd, [...])` renders the existing hint row + dim completion rows below it
- empty / no completer / no session → falls back to `set_hint(cmd)` as before (regression-free for non-completer commands)

Completions stay informational only (no selection caret, no keyboard intercept), matching the `hint-active` class contract added in #155 — so existing `visible_` test contract is untouched.

## Before / After

Before (`/attach ` typed):
```
                    ← no hint, no completions
  /attach
```

After:
```
┌────────────────────────────────────────────────────┐
│   /attach  Switch attached agent: /attach <name>   │
│            default                                 │
│            alice                                   │
│            bob                                     │
└────────────────────────────────────────────────────┘
  /attach
```

Prefix-filters as the user types more (`/attach al` → only `alice`). Falls back to plain hint when nothing matches.

## Implementation notes

- `SlashPicker.set_completions(cmd, list[str])` is a new method that mirrors `set_hint`: adds `hint-active` class, leaves `_matches` empty so keyboard paths (`Enter` / `Tab` / arrows) all gate on `has_matches=False` and pass through to text-submit.
- `_repaint_hint` was extended to render `_completions` (already prefix-filtered upstream) under the hint row with the same indent as the summary.
- `InputBar._run_completer` reaches up to `self.app._get_session()` — small layer leak but the alternative (threading a session-getter through widget construction) is more code for a single arg-completion call. Wrapped in try/except so a broken completer can't break the picker.

## Existing-test grep (per workflow lesson from #143 / #155)

```
grep -rn "completer\|set_matches\|set_hint\|set_completions\|picker.visible_" tests/
```

- Matches: 6 in `test_tui_smoke.py`, 4 in `test_slash_picker_click.py`. Used `set_matches` and `picker.visible_` — both untouched semantically; `set_completions` is new and doesn't conflict.
- Local run: `pytest tests/cli/test_tui_smoke.py tests/cli/test_slash_picker_click.py` → **41/41 passing**.

## Test plan

- [x] Manual: `/attach ` (with space) → picker shows `/attach` hint + `default` agent name underneath
- [x] Manual: `/attach d` → still shows `default` (prefix match)
- [x] Manual: `/attach z` → falls back to hint only (= "no completion matches z")
- [x] Manual: `/plan ` (no completer registered) → hint only, no completions row — regression check ✓
- [x] Manual: `/p` (prefix selection mode) → normal selectable picker with `▌` caret — regression check ✓
- [x] Existing 41 picker tests passing locally
- [x] Decision-flow Q1 (testing.ja.md): UI rendering + completer dispatch → **Tier 4 → no automated test**; existing test grep returned 0 contract-breaking hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)