### PR TITLE
fix(tui): chip click and hotkey-press deliver hotkey, not id

### DIFF
--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -194,9 +194,24 @@ class InterventionWidget(Widget):
         if btn_id == "chip__free":
             self._show_free_input()
             return
-        # Find the choice whose chip_ prefix matches
+        # Find the choice whose chip_ prefix matches, then submit its
+        # *hotkey* — InterventionRegistry.deliver_answer routes through
+        # match_choice() which compares against hotkey, NOT id. Sending
+        # the id (e.g. "yes" instead of "y") silently fails the match,
+        # leaves iv.future unresolved, and the widget removes itself —
+        # the agent then waits forever for an answer the user already
+        # gave. Fall back to the id only when the choice has no hotkey
+        # (= producer-side anomaly; user gets the "unknown choice" hint
+        # instead of a silent deadlock).
         choice_id = btn_id.removeprefix("chip_")
-        await self._submit(choice_id)
+        choice = next(
+            (c for c in self._choices if c["id"] == choice_id),
+            None,
+        )
+        if choice is None:
+            return
+        hotkey = choice["hotkey"]
+        await self._submit(hotkey if hotkey else choice_id)
 
     async def on_key(self, event) -> None:  # textual.events.Key
         """Activate a chip when its hotkey is pressed.
@@ -218,7 +233,10 @@ class InterventionWidget(Widget):
         for choice in self._choices:
             if choice["hotkey"] and choice["hotkey"] == key_char:
                 event.stop()
-                await self._submit(choice["id"])
+                # Submit the hotkey (= what match_choice expects) rather
+                # than the id — same deadlock concern as the chip-click
+                # path. See on_button_pressed for the full rationale.
+                await self._submit(choice["hotkey"])
                 return
 
     def _show_free_input(self) -> None:

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -361,6 +361,72 @@ async def test_intervention_mounts_in_conversation():
 
 
 @pytest.mark.asyncio
+async def test_intervention_chip_click_submits_hotkey():
+    """Tier 2: chip click delivers the hotkey (not the id) so the producer
+    contract — InterventionRegistry.match_choice matches by hotkey — holds.
+
+    Sending the id (e.g. "yes" instead of "y") would silently miss
+    match_choice, leave iv.future unresolved, and the widget removes
+    itself — agent deadlocks. This test pins the chip-click → hotkey
+    contract that the bug fix introduced.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        collected: list[str] = []
+
+        async def _cb(ans: str) -> None:
+            collected.append(ans)
+
+        conv.mount_intervention(
+            question="Allow?",
+            choices=[
+                {"label": "[y]es", "id": "yes", "hotkey": "y"},
+                {"label": "[n]o", "id": "no", "hotkey": "n"},
+            ],
+            answer_callback=_cb,
+            iv_id="iv_perm",
+        )
+        await pilot.pause()
+        await pilot.click("#chip_yes")
+        await pilot.pause()
+        assert collected == ["y"], (
+            f"chip click should submit hotkey 'y' (matches match_choice), "
+            f"got {collected!r} — sending id 'yes' would deadlock the agent"
+        )
+
+
+@pytest.mark.asyncio
+async def test_intervention_chip_without_hotkey_falls_back_to_id():
+    """Tier 2: when a chip's choice has no hotkey, the click falls back
+    to submitting the id rather than producing nothing — preserves the
+    "unknown choice" hint path instead of silent deadlock.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        collected: list[str] = []
+
+        async def _cb(ans: str) -> None:
+            collected.append(ans)
+
+        conv.mount_intervention(
+            question="Pick:",
+            choices=[
+                {"label": "anonymous", "id": "anon", "hotkey": ""},
+            ],
+            answer_callback=_cb,
+            iv_id="iv_no_hotkey",
+        )
+        await pilot.pause()
+        await pilot.click("#chip_anon")
+        await pilot.pause()
+        assert collected == ["anon"]
+
+
+@pytest.mark.asyncio
 async def test_intervention_free_text_answer():
     """InterventionWidget with free-text input calls callback on submit."""
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary — silent agent deadlock

`InterventionRegistry.deliver_answer` routes through `match_choice()` which compares user text against the choice's `hotkey` field, **not** the `id`. `InterventionWidget` was submitting `choice["id"]` from both:

- chip-click path (`on_button_pressed`)
- hotkey-press path (`on_key`)

End-to-end failure flow:

1. User clicks the `[y]es` chip → `_submit("yes")`
2. `_callback("yes")` → `session._maybe_answer_oldest_intervention("yes")` → `InterventionHandler.maybe_answer("yes")` → `InterventionRegistry.deliver_answer(iv, "yes")`
3. `match_choice("yes", choices)` iterates and checks `choice.hotkey == "yes"` → **no match** (the real hotkey is `"y"`)
4. `resolved = False`; `deliver_answer_to` emits the "unknown choice; expected one of: …" status to the outbox
5. `iv.future` is **NOT set**
6. `_submit()` calls `self.remove()` and the widget disappears regardless
7. Agent waits forever — silent deadlock, no widget to re-prompt

The user sees only a transient status flash; the agent never resumes; the only escape is `Ctrl+C` and resubmit.

## Fix

Submit `choice["hotkey"]` instead of `choice["id"]`. Fall back to `id` only when `hotkey` is empty (producer-side anomaly) — that path still misses `match_choice`, but the user gets the visible "unknown choice" hint instead of a silent deadlock.

## Tests added (Tier 2)

This is a user-facing UX invariant (lead-coder's calibration in PR #143: permanent UX contracts are Tier-able, not Tier 4). New tests in `tests/cli/test_tui_smoke.py`:

- `test_intervention_chip_click_submits_hotkey` — pins the chip-click → hotkey contract
- `test_intervention_chip_without_hotkey_falls_back_to_id` — pins the fallback for hotkey-less choices

Both tests would have **caught this bug** if they had existed.

## Existing-test grep (per workflow lesson)

```
grep -rn "on_button_pressed\|chip_\|InterventionWidget\|_submit.*choice\|answer.*hotkey" tests/
```

Hits in `test_focus_restore.py` (`_submit("yes")` for `choices=None`) and `test_tui_smoke.py` (free-text path) — neither exercises the chip-click contract. The 2 new tests cover the gap.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py::test_intervention_chip_click_submits_hotkey tests/cli/test_tui_smoke.py::test_intervention_chip_without_hotkey_falls_back_to_id tests/cli/test_tui_smoke.py::test_intervention_mounts_in_conversation tests/cli/test_tui_smoke.py::test_intervention_free_text_answer tests/cli/test_focus_restore.py` — 7/7 passing locally
- [x] Decision-flow Q1 (testing.ja.md): "OS / user-facing UX invariant breaks" → **Tier 2** (permanent contract, calibrated per PR #143 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)