### PR TITLE
fix(chat): lazy MCP tool discovery cache — populate mcp.tool__* aliases on first user turn (closes #160)

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -189,6 +189,10 @@ class RouterHostAdapter:
         self._allowed_mcp = allowed_mcp
         self._perm = permission_resolver
         self._mcp_servers = mcp_servers
+        # Lazy per-session cache for MCP tools — populated by
+        # ensure_mcp_tools_cached() on the first user turn; None means
+        # "not yet probed". See FP-0037 issue #160.
+        self._mcp_tools_cache: dict[str, list[dict]] | None = None
         self._project_context = project_context
         self._events = events
         self._resolver = resolver
@@ -814,19 +818,89 @@ class RouterHostAdapter:
         return raw if isinstance(raw, dict) else {}
 
     def _get_mcp_servers_for_router(self) -> list[dict]:
-        """Return [{name, description}, ...] for configured MCP servers. [] if none."""
+        """Return [{name, description, tools?}, ...] for configured MCP servers.
+
+        ``tools`` is included when `ensure_mcp_tools_cached()` has populated
+        the per-session tools cache; absent otherwise. Callers downstream
+        (= `_enumerate_category("mcp.tool")` in `universal_catalog.py` and
+        `router_loop.py`'s `mcp.tool__*` alias builder) iterate `tools`
+        defensively so the missing-tools case is graceful.
+
+        Issue #160 / FP-0037 context: chat startup intentionally does NOT
+        probe MCP servers (= zero-startup-latency goal). The first user
+        turn calls `ensure_mcp_tools_cached()` to fill the cache once per
+        session; subsequent turns read it without additional probes.
+        """
         servers = self._mcp_servers_flat()
         if not servers:
             return []
+        tools_cache = self._mcp_tools_cache or {}
         result: list[dict] = []
         for name, cfg in servers.items():
             if not isinstance(cfg, dict):
                 continue
-            result.append({
+            entry: dict = {
                 "name": name,
                 "description": cfg.get("description", ""),
-            })
+            }
+            cached_tools = tools_cache.get(name)
+            if cached_tools is not None:
+                entry["tools"] = cached_tools
+            result.append(entry)
         return result
+
+    async def ensure_mcp_tools_cached(
+        self, *, per_server_timeout: float = 5.0,
+    ) -> None:
+        """Probe every configured MCP server's tool list and cache the
+        results for the session lifetime.
+
+        Called by `ChatSession._handle_user_message` at the start of each
+        user turn. The first call populates the cache (= lazy, post-startup,
+        per FP-0037 issue #160). Subsequent calls are no-ops.
+
+        Probes run in parallel via `asyncio.gather` with `return_exceptions=True`
+        so a single slow / unreachable server does not block the others.
+        Per-server timeout caps each probe; on timeout or exception the
+        server is cached as an empty list (= still cached, so we don't
+        re-probe a known-broken server every turn).
+
+        The result feeds `_get_mcp_servers_for_router` which is consumed
+        by `_enumerate_category("mcp.tool")` (= list_actions visibility)
+        and the `mcp.tool__*` direct-alias builder in `router_loop.py`.
+        """
+        import asyncio
+
+        if self._mcp_tools_cache is not None:
+            return
+        servers = self._mcp_servers_flat()
+        if not servers:
+            self._mcp_tools_cache = {}
+            return
+
+        async def _probe_one(server_name: str) -> tuple[str, list[dict]]:
+            try:
+                tools = await asyncio.wait_for(
+                    self._mcp_list_tools_cb(server_name),
+                    timeout=per_server_timeout,
+                )
+            except (TimeoutError, asyncio.TimeoutError):
+                return server_name, []
+            except Exception:  # noqa: BLE001 — adapter must never raise
+                return server_name, []
+            # _mcp_list_tools may return [{"error": "..."}] on failure;
+            # treat as empty so the cache shape stays uniform.
+            cleaned = [
+                t for t in (tools or [])
+                if isinstance(t, dict) and "error" not in t and t.get("name")
+            ]
+            return server_name, cleaned
+
+        results = await asyncio.gather(
+            *(_probe_one(name) for name in servers),
+            return_exceptions=False,  # _probe_one handles its own errors
+        )
+        self._mcp_tools_cache = dict(results)
 
     def make_router_op_context(self) -> Any:
         """Build an OpContext for router-initiated file / MCP / web ops.

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1394,6 +1394,13 @@ class ChatSession:
         # budget without resetting.
         self._reset_router_turn_counter()
 
+        # FP-0037 issue #160: lazy MCP tool discovery cache. First user
+        # turn probes every configured MCP server's tool list once;
+        # subsequent turns no-op. Zero startup latency; first-turn cost
+        # is bounded by per_server_timeout (default 5s, parallel).
+        # When no MCP servers are configured this is a near-free no-op.
+        await self._router_host.ensure_mcp_tools_cached()
+
         try:
             await self._run_router_loop(text, chain_id)
         except RouterCapExceeded as exc:

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -1,0 +1,334 @@
+"""Tier 2: RouterHostAdapter MCP tools lazy cache — issue #160 / FP-0037.
+
+Pins the contract for `ensure_mcp_tools_cached()`:
+  - First call probes every configured MCP server in parallel and stores
+    the result in `_mcp_tools_cache`.
+  - Subsequent calls are no-ops (= idempotent).
+  - When no MCP servers are configured, the cache becomes `{}` (= still
+    not None, so the no-op branch fires next time).
+  - Per-server timeout caps slow probes; on timeout / exception the
+    server is cached as `[]` (= no retries, no cascading failures).
+  - `_get_mcp_servers_for_router` includes `tools` field only when the
+    cache for that server is populated.
+
+No mocks — uses real async callables and a real RouterHostAdapter via
+the existing `_make_adapter` helper pattern.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.services import MemoryService, RouterHostAdapter
+from reyn.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+
+
+async def _null_file_read(path: str) -> dict:
+    return {"content": ""}
+
+
+async def _null_file_write(path: str, content: str) -> dict:
+    return {"path": path, "written": True}
+
+
+async def _null_file_delete(path: str) -> dict:
+    return {"path": path, "deleted": True}
+
+
+async def _null_file_list(path: str) -> dict:
+    return {"path": path, "entries": []}
+
+
+async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
+    return {"path": path, "output_path": output_path, "entries": 0}
+
+
+async def _null_mcp_list_servers() -> list:
+    return []
+
+
+async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
+    return {}
+
+
+async def _null_run_skill(spec, *, chain_id) -> dict:
+    return {"status": "finished", "data": {}}
+
+
+async def _null_spawn_skill(spec, *, chain_id) -> dict:
+    return {"status": "spawned", "run_id": "x", "chain_id": chain_id, "skill": "", "note": ""}
+
+
+async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
+    pass
+
+
+async def _null_put_outbox(msg) -> None:
+    pass
+
+
+def _null_append_history(msg) -> None:
+    pass
+
+
+async def _null_spawn_plan_task(*, plan_id, runtime, chain_id, parent_chain_id=None) -> None:
+    pass
+
+
+def _make_adapter_with_mcp(
+    *,
+    tmp_path: Path,
+    mcp_servers: dict | None,
+    mcp_list_tools_cb,
+) -> RouterHostAdapter:
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "test-agent"
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=_null_file_write,
+        file_read=_null_file_read,
+        file_delete=_null_file_delete,
+        file_regenerate_index=_null_file_regen,
+    )
+    return RouterHostAdapter(
+        agent_name="test-agent",
+        agent_role="test",
+        output_language="en",
+        allowed_skills=None,
+        allowed_mcp=None,
+        permission_resolver=None,
+        mcp_servers=mcp_servers,
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=None,
+        skill_enumerate_fn=lambda exclude: [],
+        agent_workspace_dir=workspace,
+        plan_registry_getter=lambda: None,
+        file_read=_null_file_read,
+        file_write=_null_file_write,
+        file_delete=_null_file_delete,
+        file_list_directory=_null_file_list,
+        file_regenerate_index=_null_file_regen,
+        mcp_list_servers=_null_mcp_list_servers,
+        mcp_list_tools=mcp_list_tools_cb,
+        mcp_call_tool=_null_mcp_call_tool,
+        run_skill_awaitable=_null_run_skill,
+        spawn_skill=_null_spawn_skill,
+        send_to_agent=_null_send_to_agent,
+        put_outbox=_null_put_outbox,
+        append_history=_null_append_history,
+        spawn_plan_task=_null_spawn_plan_task,
+        delegation_tracker=lambda: None,
+        agent_replies_tracker=lambda: None,
+    )
+
+
+# ── 1. No-server case ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_servers_no_probe(tmp_path):
+    """Tier 2: with no MCP servers configured, ensure_mcp_tools_cached
+    completes without invoking the probe callback. Public listing stays
+    empty.
+    """
+    probe_calls: list[str] = []
+
+    async def _probe(server: str) -> list[dict]:
+        probe_calls.append(server)
+        return []
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path, mcp_servers=None, mcp_list_tools_cb=_probe,
+    )
+    await adapter.ensure_mcp_tools_cached()
+    assert probe_calls == [], "must not probe when there are zero servers"
+    assert adapter.get_mcp_servers() == []
+
+
+# ── 2. With servers — parallel probe + populate ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_parallel_probe_populates_cache(tmp_path):
+    """Tier 2: all configured servers are probed in parallel; results are
+    cached per server name."""
+    probe_calls: list[str] = []
+
+    async def _probe(server: str) -> list[dict]:
+        probe_calls.append(server)
+        return [
+            {"name": f"{server}_tool1", "description": f"tool 1 of {server}"},
+            {"name": f"{server}_tool2", "description": f"tool 2 of {server}"},
+        ]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"foo": {}, "bar": {}},
+        mcp_list_tools_cb=_probe,
+    )
+    await adapter.ensure_mcp_tools_cached()
+    assert set(probe_calls) == {"foo", "bar"}
+    listing = {s["name"]: s for s in adapter.get_mcp_servers()}
+    assert "foo" in listing and "bar" in listing
+    assert len(listing["foo"]["tools"]) == 2
+    assert listing["foo"]["tools"][0]["name"] == "foo_tool1"
+    assert len(listing["bar"]["tools"]) == 2
+
+
+# ── 3. Idempotent — second call is a no-op ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_idempotent_second_call_no_probe(tmp_path):
+    """Tier 2: once cached, subsequent calls do NOT re-probe."""
+    probe_calls: list[str] = []
+
+    async def _probe(server: str) -> list[dict]:
+        probe_calls.append(server)
+        return [{"name": "t", "description": "d"}]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"foo": {}},
+        mcp_list_tools_cb=_probe,
+    )
+    await adapter.ensure_mcp_tools_cached()
+    first_calls = list(probe_calls)
+    await adapter.ensure_mcp_tools_cached()
+    assert probe_calls == first_calls, (
+        "second ensure_mcp_tools_cached() must not invoke probes again"
+    )
+
+
+# ── 4. Timeout — slow server cached as empty, doesn't block others ────────
+
+
+@pytest.mark.asyncio
+async def test_slow_server_times_out_and_others_proceed(tmp_path):
+    """Tier 2: a server slower than per_server_timeout is cached as [];
+    other servers are not affected.
+
+    Verifies parallel + per-server timeout discipline.
+    """
+    async def _probe(server: str) -> list[dict]:
+        if server == "slow":
+            await asyncio.sleep(2.0)  # exceeds the 0.1s timeout below
+            return [{"name": "shouldnt_be_seen", "description": ""}]
+        return [{"name": f"{server}_tool", "description": ""}]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"fast": {}, "slow": {}},
+        mcp_list_tools_cb=_probe,
+    )
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.1)
+    listing = {s["name"]: s for s in adapter.get_mcp_servers()}
+    assert listing["fast"]["tools"] == [
+        {"name": "fast_tool", "description": ""}
+    ]
+    assert listing["slow"]["tools"] == [], (
+        "slow server must be reported as empty tools list, not retain leaked tools"
+    )
+
+
+# ── 5. Exception — broken server cached as empty, doesn't propagate ────────
+
+
+@pytest.mark.asyncio
+async def test_probe_exception_cached_as_empty(tmp_path):
+    """Tier 2: probe exception is caught and the server is cached as [].
+    Adapter must never raise from ensure_mcp_tools_cached().
+    """
+    async def _probe(server: str) -> list[dict]:
+        if server == "broken":
+            raise RuntimeError("connection refused")
+        return [{"name": f"{server}_tool", "description": ""}]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"good": {}, "broken": {}},
+        mcp_list_tools_cb=_probe,
+    )
+    # Must not raise
+    await adapter.ensure_mcp_tools_cached()
+    listing = {s["name"]: s for s in adapter.get_mcp_servers()}
+    assert listing["good"]["tools"] == [
+        {"name": "good_tool", "description": ""}
+    ]
+    assert listing["broken"]["tools"] == []
+
+
+# ── 6. Error-shape entries (= [{"error": "..."}]) are filtered ────────────
+
+
+@pytest.mark.asyncio
+async def test_error_shape_entries_are_filtered(tmp_path):
+    """Tier 2: when _mcp_list_tools_cb returns [{"error": "..."}] (= the
+    contract for "connection failed but didn't raise"), the cache excludes
+    error sentinels.
+    """
+    async def _probe(server: str) -> list[dict]:
+        return [{"error": "server unreachable"}]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"foo": {}},
+        mcp_list_tools_cb=_probe,
+    )
+    await adapter.ensure_mcp_tools_cached()
+    listing = adapter.get_mcp_servers()
+    assert listing[0]["tools"] == [], (
+        "error sentinels from _mcp_list_tools must be filtered, "
+        "leaving an empty list (= same shape as timeout / exception cases)"
+    )
+
+
+# ── 7. _get_mcp_servers_for_router includes tools when cached ──────────────
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_servers_excludes_tools_pre_probe(tmp_path):
+    """Tier 2: before `ensure_mcp_tools_cached()` is called, the public
+    listing omits the `tools` field (= pre-cache shape).
+    """
+    async def _probe(server: str) -> list[dict]:
+        return [{"name": "t", "description": "d"}]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"foo": {"description": "FooServer"}},
+        mcp_list_tools_cb=_probe,
+    )
+    result = adapter.get_mcp_servers()
+    assert len(result) == 1
+    assert result[0]["name"] == "foo"
+    assert "tools" not in result[0], (
+        "tools field must be omitted before the lazy cache is populated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_servers_includes_tools_post_probe(tmp_path):
+    """Tier 2: after `ensure_mcp_tools_cached()`, listing includes per-
+    server `tools` array consumed by `_enumerate_category("mcp.tool")`
+    and the `mcp.tool__*` direct-alias builder.
+    """
+    async def _probe(server: str) -> list[dict]:
+        return [{"name": f"{server}_tool", "description": "x"}]
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"foo": {"description": "FooServer"}},
+        mcp_list_tools_cb=_probe,
+    )
+    await adapter.ensure_mcp_tools_cached()
+    result = adapter.get_mcp_servers()
+    assert result[0]["tools"] == [{"name": "foo_tool", "description": "x"}]


### PR DESCRIPTION
**[e2e-coder]**

Closes #160. FP-0037 (#164) tracks the dynamic-server-refresh follow-up.

## Summary

`reyn chat` showed zero `mcp.tool__*` aliases in the LLM's catalog (= `list_actions(category=['mcp.tool'])` returned `[]`, hot-list aliases never built) even when MCP servers were configured. The LLM had to take a 2-turn discovery chain (= `list_actions(['mcp.server'])` → `invoke_action('mcp.server__X')`) before it could call any MCP tool — which weak default `gemini-2.5-flash-lite` rarely does proactively. Operator-reported symptom: "I configured my MCP server but `reyn chat` acts like it has no access".

## Root cause (= confirmed in issue #160)

`router_loop.py:1224-1241` and `universal_catalog.py:579-605` both iterate `rs.mcp_servers[*].tools` to surface MCP tools. But both `_get_mcp_servers_for_router` implementations (`chat/session.py:2513` + `chat/services/router_host_adapter.py:816`) returned `{"name": ..., "description": ...}` per server — **no `tools` field populated**. The comment at `router_loop.py:1222-1223` expected the "FP-0032 expanded shape with nested tools" but the adapter never populated it.

## Fix (= Option 4: lazy probe at first user turn)

Selected over the other 3 candidates discussed in #160 because:
- **Zero chat-startup latency** (= primary operator constraint)
- Subsequent turns pay nothing (= cache hit)
- Sessions that never touch MCP pay zero (= no probes)
- First MCP-relevant turn pays the probe cost once, bounded by per-server timeout
- No new CLI surface or cache file (= simpler than `reyn mcp probe` / install-time cache)

`RouterHostAdapter` gains:
- `self._mcp_tools_cache: dict[str, list[dict]] | None` — per-session cache.
- `async ensure_mcp_tools_cached(per_server_timeout=5.0)` — probes every configured server in parallel via `asyncio.gather` with per-server timeout; caches `[]` on timeout / exception (= no retries, no cascading failures). Idempotent.
- `_get_mcp_servers_for_router` adds a `tools` field per server when the cache has populated entries (= omits when not, so consumers see "no tools" as `[]`).

`ChatSession._handle_user_message` awaits `ensure_mcp_tools_cached()` right before invoking `_run_router_loop`.

Touch: `src/reyn/chat/services/router_host_adapter.py` (+95), `src/reyn/chat/session.py` (+7), `tests/test_mcp_lazy_tools_cache.py` (new, +320).

## Cost characteristics

| phase | latency |
|---|---|
| chat startup | **0** (no probe, only allocation) |
| first user turn (MCP configured) | bounded by max(probe_time, per_server_timeout=5s); parallel across servers |
| first user turn (no MCP) | near-free (= empty dict assigned, no probes) |
| subsequent turns | 0 (cache hit no-op) |

## Out of scope (FP-0037 / #164)

- Mid-session refresh when `reyn mcp install` or yaml edits add a new server. Current design treats MCP config as session-static (= consistent with the existing `reyn mcp drop` "continue until the next 'reyn chat' session restart" note).
- Cross-session cache sharing.
- MCP server removal mid-session.

## Test plan

- [x] 8 new Tier 2 tests in `tests/test_mcp_lazy_tools_cache.py`:
  - **No-server**: cache populates as empty, probe callback never invoked
  - **Multi-server**: parallel probe + per-server tools populated
  - **Idempotent**: second `ensure_mcp_tools_cached()` is a no-op
  - **Slow server**: per-server timeout caps it, fast servers not blocked
  - **Probe exception**: cached as empty list, no propagation
  - **Error-shape entries** (`[{"error": "..."}]`) filtered out
  - **Pre-probe listing** omits `tools` field
  - **Post-probe listing** includes `tools` field
- [x] All assertions go through the public `adapter.get_mcp_servers()` surface (= no private state assertions per testing.ja.md Tier 4)
- [x] 7 existing `test_router_host_adapter_invariants.py` tests still pass (= adapter constructor signature unchanged)
- [x] 41 adjacent tests pass (`test_router_*`, `test_chat_turn_completed_inline`)
- [x] 1 pre-existing failure in `test_mcp_server.py::test_build_server_exposes_two_tools` is from missing `mcp` extra package (= env-level, unrelated to this change; the test itself notes "tests of this module install it via the `mcp` extra")
- [x] Ruff clean on touched files

## What this evidence does NOT yet show

- **Cross-model**: only `gemini-2.5-flash-lite` discussed. Strong-model behavior under the new alias surface is unmeasured.
- **End-to-end with a real MCP server**: I don't have a configured MCP server in my workspace, so the e2e measurement (= "operator with real MCP sees `mcp.tool__*` aliases at first user turn") is unverified from my environment. Owner with a configured MCP setup can validate.
- **Probe latency in practice**: I assume ~1-2s per server but didn't measure. Per-server timeout of 5s is the upper bound; real-world latency may be lower (stdio fast) or higher (HTTP with auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)