### PR TITLE
fix(tui): preserve hotkey brackets in intervention chip labels

### DIFF
--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any, Awaitable, Callable
 
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.message import Message
 from textual.widget import Widget
@@ -161,11 +162,19 @@ class InterventionWidget(Widget):
         return f"[{hotkey}] {label}"
 
     def compose(self) -> ComposeResult:
-        yield Label(f"  {self._question}", classes="iv-question")
+        # ``markup=False`` on the question Label and ``Text(...)`` wrapping
+        # on chip Buttons keeps the literal "[y]" / "[A]" hotkey brackets
+        # visible. Default markup parsing treats them as unknown style
+        # tags and silently strips them — chip labels were rendering as
+        # "es", "lways", "o", "ever" with no hotkey hint.
+        yield Label(
+            f"  {self._question}", classes="iv-question", markup=False,
+        )
         if self._queued_extra > 0:
             yield Label(
                 f"  +{self._queued_extra} more pending",
                 classes="iv-queued",
+                markup=False,
             )
         if self._choices:
             with Widget(classes="iv-chips"):
@@ -175,15 +184,20 @@ class InterventionWidget(Widget):
                     display = self._format_chip_label(label, hotkey)
                     variant = "primary" if choice["default"] else "default"
                     yield Button(
-                        display,
+                        Text(display),
                         id=f"chip_{choice['id']}",
                         variant=variant,
                     )
                 # "free response" chip always at end
-                yield Button("free response…", id="chip__free", variant="default")
+                yield Button(
+                    Text("free response…"),
+                    id="chip__free",
+                    variant="default",
+                )
             yield Label(
                 "↓ type a free answer in the chat input below, or click a button",
                 classes="iv-hint",
+                markup=False,
             )
         else:
             yield Input(placeholder="type your answer…", id="iv_input")

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -361,6 +361,42 @@ async def test_intervention_mounts_in_conversation():
 
 
 @pytest.mark.asyncio
+async def test_intervention_chip_preserves_hotkey_brackets():
+    """Tier 2: chip labels render with hotkey brackets intact.
+
+    Default Textual Label / Button parses Rich markup, so "[y]es" is
+    treated as a (malformed) style tag and the "[y]" is silently
+    dropped — chips end up displayed as "es", "lws", "o", "ever" with
+    no hotkey hint, violating the producer's "[h] hint" convention.
+    """
+    from textual.widgets import Button
+
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_intervention(
+            question="Allow?",
+            choices=[
+                {"label": "[y]es", "id": "yes", "hotkey": "y"},
+                {"label": "[A]lways", "id": "always", "hotkey": "A"},
+                {"label": "[n]o", "id": "no", "hotkey": "n"},
+            ],
+            answer_callback=None,
+            iv_id="iv_markup",
+        )
+        await pilot.pause()
+        yes_btn = app.query_one("#chip_yes", Button)
+        always_btn = app.query_one("#chip_always", Button)
+        no_btn = app.query_one("#chip_no", Button)
+        # ``Button.label`` is a Rich-rendered ``Text`` object; ``plain``
+        # gives the visible characters minus any style tagging.
+        assert "[y]es" in yes_btn.label.plain
+        assert "[A]lways" in always_btn.label.plain
+        assert "[n]o" in no_btn.label.plain
+
+
+@pytest.mark.asyncio
 async def test_intervention_free_text_answer():
     """InterventionWidget with free-text input calls callback on submit."""
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Textual's `Label` and `Button` parse Rich markup by default. Chip labels like `[y]es`, `[A]lways`, `[n]o`, `[N]ever` — produced by the existing `intervention_choices` factories — were being treated as (malformed) style tags and the `[y]` / `[A]` / `[n]` / `[N]` prefixes silently stripped. Chips displayed as `es`, `lways`, `o`, `ever` with **no hotkey hint visible**, even though the hotkey-press path still worked.

This is paired with #165 (chip-click deadlock) — both flow from the same producer convention (hotkey embedded in the label as `[h]label`) and both undermined the permission-prompt UX in different ways.

## Fix

- `Label(..., markup=False)` for the question / queued / hint Labels (preserves any literal brackets the producer emits)
- `Button(Text(display), ...)` for chip buttons (`Text` bypasses markup parsing)

## Tests added (Tier 2)

`test_intervention_chip_preserves_hotkey_brackets` mounts an intervention with `[y]es`, `[A]lways`, `[n]o` chips and asserts the visible label retains the `[h]` prefix. Default markup parsing would have failed this immediately.

## Existing-test grep (per workflow lesson)

```
grep -rn "chip_\|Button.*label\|markup" tests/cli/
```

Existing tests didn't inspect chip label rendering — only the click / submit path. The new test fills the gap.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py::test_intervention_chip_preserves_hotkey_brackets tests/cli/test_tui_smoke.py::test_intervention_mounts_in_conversation tests/cli/test_tui_smoke.py::test_intervention_free_text_answer tests/cli/test_focus_restore.py` — 6/6 passing
- [x] Decision-flow Q1 (testing.ja.md): user-facing UX invariant (hotkey hint must be visible) → **Tier 2** (permanent contract)

## Note

The deeper concern about prompt / detail / choices all rendering in one amber-bold Label with no semantic hierarchy is filed as issue #163 — that one requires `msg.meta` plumbing changes outside the TUI scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)