### PR TITLE
fix(tui): events tab sorts by timestamp before windowing

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -488,7 +488,16 @@ def render_events(
     if filter_set:
         visible = [ev for ev in all_events if ev.get("type") in filter_set]
     else:
-        visible = all_events
+        visible = list(all_events)
+
+    # File-path iteration order doesn't match wall-clock: the events root
+    # holds agents/<id>/events/*.jsonl alongside direct/<id>/skill_runs/*
+    # and rglob walks alphabetically, so a stale ``direct/`` test run lands
+    # at the end of ``all_events`` and dominates the tail window even
+    # though those events are from yesterday. Sort by event timestamp
+    # (ISO-8601 strings sort chronologically) so ``visible[-tail:]``
+    # reflects recency rather than filesystem layout.
+    visible.sort(key=lambda ev: ev.get("timestamp", ""))
 
     if not visible:
         # Two distinct empty states:

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -695,6 +695,60 @@ async def test_preview_pane_shift_jk_moves_parent_tab_cursor():
         assert panel._agents_cursor == 0
 
 
+# ── test: right panel — events tab chronological sort ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_events_tab_returns_in_timestamp_order(tmp_path):
+    """Tier 2: render_events returns events sorted by timestamp.
+
+    File-path iteration order doesn't match wall-clock (e.g. ``agents/``
+    < ``direct/`` alphabetically, so a stale ``direct/`` run lands at
+    the end of all_events and dominates the tail window). Pin that the
+    tail window reflects recency rather than filesystem layout.
+    """
+    import json as _json
+
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    events_root = tmp_path / ".reyn" / "events"
+    # Two source dirs — ``agents/`` is alphabetically earlier but holds the
+    # NEWER events; ``direct/`` is alphabetically later but holds the OLDER
+    # events. The unsorted code path would surface the old ``direct/``
+    # events as the "tail" because they were extended last.
+    (events_root / "agents" / "default").mkdir(parents=True)
+    (events_root / "direct" / "stale").mkdir(parents=True)
+    (events_root / "agents" / "default" / "today.jsonl").write_text(
+        _json.dumps({
+            "type": "phase_started", "timestamp": "2026-05-18T10:00:00Z",
+            "data": {"phase": "p_today"},
+        }) + "\n",
+        encoding="utf-8",
+    )
+    (events_root / "direct" / "stale" / "old.jsonl").write_text(
+        _json.dumps({
+            "type": "phase_started", "timestamp": "2026-05-16T03:00:00Z",
+            "data": {"phase": "p_old"},
+        }) + "\n",
+        encoding="utf-8",
+    )
+
+    _, visible = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    timestamps = [ev.get("timestamp", "") for ev in visible]
+    # render_events returns the windowed slice reversed (= newest first
+    # for cursor 0 = "most recent"). The chronological-sort contract is
+    # therefore "descending in the visible list".
+    assert timestamps == sorted(timestamps, reverse=True), (
+        f"events should be in reverse-chronological order, got {timestamps!r}"
+    )
+    # The newer event (today) should be at position 0 (= newest first)
+    # regardless of which directory it came from.
+    assert visible[0]["data"]["phase"] == "p_today"
+
+
 # ── test: right panel — event filter cycling ─────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The events root holds `agents/<id>/events/*.jsonl` alongside `direct/<id>/skill_runs/*`. `_load_events_cached` walks the tree with `sorted(events_root.rglob("*.jsonl"))` which iterates in path order — so `agents/...` lands before `direct/...` regardless of when each event fired. `visible[-tail:]` then takes the alphabetically-last slice — typically yesterday's `direct/` test runs — and displays them as "the most recent events", hiding the user's current session entirely.

Sub-agent observation in this morning's exploration: with the tui-coder's default agent running an active session, the events tab still surfaced 10:17:42 timestamps from yesterday's direct test runs because they sit at the end of the path-sorted pool.

## Fix

Sort the `visible` list by event `timestamp` (ISO-8601 strings sort chronologically) before slicing `[-tail:]`. The downstream `[::-1]` (= newest first for cursor 0 = "most recent") is unchanged.

```diff
     if filter_set:
         visible = [ev for ev in all_events if ev.get("type") in filter_set]
     else:
-        visible = all_events
+        visible = list(all_events)
+
+    visible.sort(key=lambda ev: ev.get("timestamp", ""))
```

The `list(all_events)` copy avoids mutating the no-filter branch's alias (cosmetic — `all_events` is constructed fresh each call, but being explicit).

## Tests added (Tier 2)

`test_events_tab_returns_in_timestamp_order` constructs a tmp project root with two events directories — `agents/default/today.jsonl` with a 2026-05-18 event, `direct/stale/old.jsonl` with a 2026-05-16 event. Asserts that `render_events` returns them in reverse-chronological order (= newest first per the `[::-1]` contract). Without the sort, `direct/stale` would appear at the top because of alphabetical iteration.

## Existing-test grep (per workflow lesson)

```
grep -rn "render_events\|_load_events_cached" tests/
```

→ 0 hits. No existing test pins event-tab order, so this fix is regression-free for tests.

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py::test_events_tab_returns_in_timestamp_order tests/cli/test_tui_smoke.py::test_event_filter_cycling_rotates_through_groups` — 2/2 passing
- [x] Decision-flow Q1: "events tab shows the wrong slice" → user-facing UX invariant → **Tier 2**

🤖 Generated with [Claude Code](https://claude.com/claude-code)