### PR TITLE
fix(tui): flash "↑ turn N / M" line on Ctrl+P/N turn-nav

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -202,6 +202,10 @@ class ConversationView(Widget):
         # Header-grouping state (B1)
         self._last_speaker: str = ""
         self._last_speaker_at: float = 0.0
+        # Last turn-flash position written by ``_flash_turn_position`` —
+        # (n, total) tuple. Used to suppress duplicate "↑ turn N / M"
+        # log lines when the user mashes Ctrl+P/N within the same anchor.
+        self._last_turn_flash: tuple[int, int] | None = None
         # Empty-state (B5)
         self._has_first_message = False
         # Turn navigation (B4) — absolute line positions for each turn header.
@@ -883,6 +887,30 @@ class ConversationView(Widget):
             log.scroll_to(y=target, animate=False)
         except Exception:
             pass
+        # Show "turn N / M" feedback so users in long sessions can tell
+        # where they are. Without this Ctrl+P/N scrolls silently and a
+        # 90-turn history is just a parade of "21:55" headers with no
+        # cursor signal. (StickyStatus with kind="general" was the
+        # intuitive surface but doesn't render reliably from this code
+        # path — open question, see workload notes; the log marker is
+        # the working compromise.)
+        try:
+            idx = anchors.index(target)
+        except ValueError:
+            return
+        self._flash_turn_position(idx + 1, len(anchors))
+
+    def _flash_turn_position(self, n: int, total: int) -> None:
+        """Write a dim ``↑ turn N / M`` line to the conv log.
+
+        Deduped by ``_last_turn_flash`` so rapid Ctrl+P/N presses that
+        land on the same anchor don't spam the log with identical lines.
+        Cleared on Ctrl+L so post-clear navigation flashes fresh.
+        """
+        if self._last_turn_flash == (n, total):
+            return
+        self._last_turn_flash = (n, total)
+        self._write_log(Text(f"  ↑ turn {n} / {total}", style="dim italic #666666"))
 
     def clear(self) -> None:
         """Ctrl+L: clear the log + reset state. Does not affect engine state."""
@@ -897,6 +925,7 @@ class ConversationView(Widget):
         # Reset header-grouping + turn anchors + fold stash
         self._last_speaker = ""
         self._last_speaker_at = 0.0
+        self._last_turn_flash = None
         self._turn_anchors.clear()
         self._trim_warned = False
         self._last_long_reply = None


### PR DESCRIPTION
**[tui-coder]** —

## Summary

`Ctrl+P` / `Ctrl+N` scrolled the conv log silently — no sticky-status, no indicator, no highlight on the landed turn header. In a 90-turn session users couldn't tell where they were or how many turns remained above/below the current view.

Write a dim `↑ turn N / M` line to the conv log after each `_jump_to_relative_anchor`. Deduped by `_last_turn_flash` so rapid Ctrl+P/N within the same anchor doesn't spam the log with identical lines; cleared on `Ctrl+L` so post-clear nav flashes fresh.

## Before / After

Before:
```
  21:55  you  ──────────────────────────
         hi
  (Ctrl+P) — silently scrolls, no signal of where you are
```

After:
```
  21:55  you  ──────────────────────────
         hi
  (Ctrl+P)
    ↑ turn 1 / 4
```

## Trade-off note

`StickyStatus` with `kind="general"` was the intuitive surface (transient, no log pollution) but doesn't render reliably from this code path — observed during this fix work AND during PR #146 / Issue #156 investigation (compaction-marker work pivoted to dedup for the same reason). Same infrastructure question; documented in [workload notes](workload_session_lessons.md). The log marker is the working compromise pending sticky-render investigation.

## Existing-test grep (per workflow lesson)

```
grep -rn "_jump_to_relative_anchor\|jump_prev_turn\|jump_next_turn" tests/
```

→ 4 hits in `test_richlog_no_focus_steal.py` / `test_turn_anchors_survive_trim.py`. Both only assert that the methods don't raise — neither asserts on log content. Local run: 9/9 passing.

## Test plan

- [x] Manual: `reyn chat`, send 2 turns ("say ok", "say done") → 4 anchors. Press Ctrl+P → `↑ turn 1 / 4` line appears (dim italic)
- [x] Manual: Ctrl+P repeatedly on same anchor → no duplicate flash (dedup works)
- [x] Manual: Ctrl+N to move down → new `↑ turn N / 4` for the new position
- [x] Manual: Ctrl+L clear → next Ctrl+P after new turns flashes fresh (state reset)
- [x] `pytest tests/cli/test_richlog_no_focus_steal.py tests/cli/test_turn_anchors_survive_trim.py` — 9/9 passing
- [x] Decision-flow Q1 (testing.ja.md): visual format / log content placement → **Tier 4 → no automated test**; would pin presentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)