### PR TITLE
fix(tui): cost suffix uses unambiguous-width separator (│ not ·)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -32,7 +32,7 @@ Turn navigation (B4):
 
 Cost suffix (A4):
   When the App enables cost-inline mode, _render_agent_cost_suffix() is
-  called after a turn ends and writes a dim "⌁ Δ tokens · $0.XXXX" line.
+  called after a turn ends and writes a dim "⌁ Δ tokens │ $0.XXXX" line.
 """
 from __future__ import annotations
 
@@ -786,9 +786,16 @@ class ConversationView(Widget):
         right-aligns when the renderer is told a width to fill, and
         ``RichLog.write`` defaults to ``expand=False`` — without
         ``expand=True`` the suffix silently renders at column 0.
+
+        Separator is ``│`` (U+2502, narrow, unambiguous width) rather than
+        ``·`` (U+00B7, East Asian Width "Ambiguous") so Rich's cell-width
+        accounting matches what the terminal actually paints — the previous
+        ``·`` rendered as 2 cells on some terminals, pushing the elapsed
+        tail past the right edge and clipping ``14.3s`` to ``·`` alone.
+        Matches the header's existing ``│`` separator for visual consistency.
         """
         t = Text(
-            f"⌁ {tokens}t · ${cost_usd:.4f} · {elapsed_s:.1f}s",
+            f"⌁ {tokens}t │ ${cost_usd:.4f} │ {elapsed_s:.1f}s",
             style="dim #666666",
             justify="right",
         )

--- a/tests/cli/test_cost_suffix_right_align.py
+++ b/tests/cli/test_cost_suffix_right_align.py
@@ -74,7 +74,7 @@ async def test_render_cost_suffix_is_right_aligned():
 
         # Right-alignment proof: the line is much wider than the suffix itself,
         # and the suffix sits in the rightmost portion of that width.
-        suffix_visible = "⌁ 100t · $0.0050 · 1.2s"
+        suffix_visible = "⌁ 100t │ $0.0050 │ 1.2s"
         # The rendered line should be padded out to the log content width,
         # which (at size=(120, 30) with no right panel open) is well wider
         # than the suffix. We assert the suffix is in the right half.


### PR DESCRIPTION
**[tui-coder]** —

## Summary

`render_cost_suffix` used `·` (U+00B7 MIDDLE DOT) as the separator between tokens / cost / elapsed:

```python
f"⌁ {tokens}t · ${cost_usd:.4f} · {elapsed_s:.1f}s"
```

`·`'s East Asian Width property is **Ambiguous** — Rich's `cell_len` returns 1 but some terminals (any with locale-driven CJK detection or `ambiguous=2` config) paint it at 2 cells. The cell-accounting mismatch pushes the rendered line past the right edge under `expand=True` `justify="right"`, so the elapsed tail (`14.3s`) gets clipped and the user sees a dangling `·` alone at the right margin.

Switch to `│` (U+2502 BOX DRAWINGS LIGHT VERTICAL, narrow / unambiguous) — same character the header status bar already uses (`default │ standard │ 256,014 tok │ $0.0262`), so the suffix and header now share a visual rhythm.

## Before / After

Before (narrow/CJK terminal):
```
                                                     ⌁ 7591t · $0.0008 ·
```
(elapsed `14.3s` clipped past right edge)

After:
```
                                              ⌁ 7591t │ $0.0008 │ 14.3s
```

## Existing-test grep (per workflow lesson)

```
grep -rn "render_cost_suffix\|cost_suffix\|cost-inline" tests/
```

→ `tests/cli/test_cost_suffix_right_align.py` asserts on substring presence (`100t`, `$0.0050`, `1.2s`) and right-alignment idx; doesn't assert on the specific separator glyph. The local-variable `suffix_visible` was updated to match the new rendered text for clarity. Tests pass both before and after.

## Test plan

- [x] `pytest tests/cli/test_cost_suffix_right_align.py` — 2/2 passing (both pre-change and post-change variants)
- [x] Decision-flow Q1 (testing.ja.md): unicode width / visual format → existing test pin is appropriate (separator glyph not asserted; substring + right-alignment idx are stable contracts). No new test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)