### PR TITLE
fix(tui): Ctrl+O works when an intervention is mounted, panel closed

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1260,7 +1260,20 @@ class ReynTUIApp(App):
 
     def check_action(self, action: str, parameters):
         """Gate panel-scoped bindings to when the panel is visible/relevant."""
-        if action in {"focus_toggle_panel", "panel_next_content", "panel_prev_content"}:
+        if action == "focus_toggle_panel":
+            # Allowed when the panel is visible OR when an intervention
+            # is mounted — the action's first branch focuses the chip
+            # buttons, and gating it on panel_visible alone left users
+            # with no keyboard path to the chips when the panel was
+            # closed (forcing Ctrl+B first, then Ctrl+O).
+            if self._panel_visible:
+                return True
+            try:
+                conv = self.query_one("#conversation", ConversationView)
+                return bool(list(conv.query(InterventionWidget)))
+            except Exception:
+                return False
+        if action in {"panel_next_content", "panel_prev_content"}:
             return self._panel_visible
         if action in {"event_filter_cycle", "event_tail_cycle"}:
             if not self._panel_visible:

--- a/tests/cli/test_keys_tab_panel_bindings.py
+++ b/tests/cli/test_keys_tab_panel_bindings.py
@@ -169,3 +169,44 @@ async def test_panel_next_content_gated_on_panel_visible() -> None:
         app._panel_visible = True
         assert app.check_action("panel_next_content", None) is True
         assert app.check_action("panel_prev_content", None) is True
+
+
+@pytest.mark.asyncio
+async def test_focus_toggle_panel_allowed_when_intervention_pending() -> None:
+    """Tier 2: Ctrl+O is allowed when an intervention is mounted, even with
+    the panel hidden — the user needs a keyboard path to the chip buttons.
+
+    Previously ``focus_toggle_panel`` was gated purely on ``_panel_visible``,
+    so a user facing a permission prompt with the panel closed had to press
+    Ctrl+B first (open panel) → Ctrl+O (focus chip). The chips are the
+    primary affordance for the prompt; gating their focus on panel
+    visibility broke the keyboard-only path.
+    """
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        # No intervention, panel hidden → gated off (= existing behavior)
+        assert app._panel_visible is False
+        assert app.check_action("focus_toggle_panel", None) is False
+
+        # Mount an intervention, panel still hidden → now allowed
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_intervention(
+            question="Allow?",
+            choices=[{"label": "[y]es", "id": "yes", "hotkey": "y"}],
+            answer_callback=None,
+            iv_id="iv_test",
+        )
+        await pilot.pause()
+        assert app.check_action("focus_toggle_panel", None) is True
+
+        # Panel visible → still allowed regardless of intervention presence
+        app._panel_visible = True
+        assert app.check_action("focus_toggle_panel", None) is True


### PR DESCRIPTION
**[tui-coder]** —

## Summary

`action_focus_toggle_panel` was already wired to focus the first chip button of a pending intervention (per its own docstring: *"cycle focus: input → intervention buttons (if pending) → panel tabs → ..."*), but `check_action` gated the binding purely on `_panel_visible`. With the panel hidden (= default), Ctrl+O never fired — users facing a permission prompt with the panel closed had to Ctrl+B (open panel) → Ctrl+O (focus chip). Chips are the primary affordance for the prompt; gating their focus on panel visibility broke the keyboard-only path.

## Fix

Split the gate. `focus_toggle_panel` is now allowed when **either** the panel is visible **or** an `InterventionWidget` is mounted. The two remaining panel-cycle actions (`panel_next_content` / `panel_prev_content`) keep their original panel-visible-only gate.

```diff
-        if action in {"focus_toggle_panel", "panel_next_content", "panel_prev_content"}:
-            return self._panel_visible
+        if action == "focus_toggle_panel":
+            if self._panel_visible:
+                return True
+            try:
+                conv = self.query_one("#conversation", ConversationView)
+                return bool(list(conv.query(InterventionWidget)))
+            except Exception:
+                return False
+        if action in {"panel_next_content", "panel_prev_content"}:
+            return self._panel_visible
```

## Tests added (Tier 2)

`test_focus_toggle_panel_allowed_when_intervention_pending` pins all three states:
- No intervention, panel hidden → gated off (preserves prior behavior)
- Intervention mounted, panel still hidden → **now allowed** (the fix)
- Panel visible → always allowed (preserves)

## Existing-test grep (per workflow lesson)

```
grep -rn "focus_toggle_panel\|action_focus_toggle_panel\|check_action" tests/
```

→ `tests/cli/test_keys_tab_panel_bindings.py:test_panel_next_content_gated_on_panel_visible` covers the panel-cycle actions only — its contract is preserved by the split. Both `panel_next_content` and `panel_prev_content` stay gated on `_panel_visible` exactly as before.

## Test plan

- [x] `pytest tests/cli/test_keys_tab_panel_bindings.py tests/cli/test_focus_restore.py` — 10/10 passing
- [x] New Tier 2 test `test_focus_toggle_panel_allowed_when_intervention_pending` PASSES
- [x] Decision-flow Q1 (testing.ja.md): user-facing UX invariant ("keyboard path to chip when panel closed") → **Tier 2** (permanent contract per lead-coder calibration in PR #143 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)