### PR TITLE
fix(tui): persistent "⚑ awaiting your answer" sticky during intervention

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -459,6 +459,20 @@ class OutboxRouter:
         self._app._mount_intervention(
             conv, msg.text, iv_id, choices, queued_extra=queued_extra,
         )
+        # Persistent "blocked on user" indicator. The InterventionWidget is
+        # mounted inline and can scroll off-screen in a long session; the
+        # sticky stays at the bottom of the conv pane so the user can't
+        # lose the "agent is waiting for me" signal by scrolling up to
+        # review prior turns. Shown AFTER ``_mount_intervention`` because
+        # ``conv.mount_intervention`` internally calls ``hide_status`` to
+        # clear any prior thinking spinner — showing before that would be
+        # silently undone. Cleared on resolution (_on_intervention_resolved).
+        # General-kind so no ⟳ spinner / elapsed timer appears — the agent
+        # is paused, not working.
+        try:
+            conv.show_status("⚑ awaiting your answer", kind="general")
+        except Exception:
+            pass
         # Out-of-band signals: the agent is hard-blocked on a human answer,
         # so a user in a background terminal tab needs to know to come
         # back. The terminal title flips visible in the tab bar; the BEL
@@ -477,7 +491,15 @@ class OutboxRouter:
         calls ``self.remove()``.  The text-input path (Enter in the InputBar)
         routes through session._deliver_answer_to without touching the widget,
         so we need this outbox message to clean up the orphaned widget.
+
+        Also clears the "⚑ awaiting your answer" sticky set by
+        ``_on_intervention`` — both resolution paths flow through this
+        outbox message, so it's the single dismissal point.
         """
+        try:
+            conv.hide_status()
+        except Exception:
+            pass
         iv_id = msg.meta.get("iv_id", "")
         widget_id = f"iv_{iv_id[:8]}"
         try:

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -92,6 +92,16 @@ class StickyStatus(Static):
         self._active = False
         self.remove_class("active")
 
+    def snapshot(self) -> dict:
+        """Return the current display state for inspection by callers / tests.
+
+        Exposes ``{"active": bool, "body": str, "kind": str}`` so callers
+        (and Tier 2 tests) can verify the sticky's state through a public
+        surface rather than reading the ``_active`` / ``_body`` / ``_kind``
+        private attributes directly (= ``testing.ja.md`` anti-pattern).
+        """
+        return {"active": self._active, "body": self._body, "kind": self._kind}
+
     # ── internal ──────────────────────────────────────────────────────────────
 
     def _tick(self) -> None:

--- a/tests/cli/test_out_of_band_signals.py
+++ b/tests/cli/test_out_of_band_signals.py
@@ -138,6 +138,62 @@ async def test_intervention_mount_sets_awaiting_and_rings_bell() -> None:
         )
 
 
+# ── intervention persists "awaiting" sticky until resolved ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_intervention_mount_shows_awaiting_sticky() -> None:
+    """Tier 2: ``_on_intervention`` shows a persistent "awaiting answer"
+    sticky; ``_on_intervention_resolved`` hides it.
+
+    The InterventionWidget is mounted inline in the conv pane and can
+    scroll off-screen in a long session — without a sticky at the
+    bottom, a user scrolled up to review prior turns loses the
+    "agent is waiting for me" signal. The sticky is general-kind so
+    no thinking spinner / elapsed timer is shown (the agent is paused,
+    not working).
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        app._get_session = lambda: None  # type: ignore[method-assign]
+        _instrument_alert(app)
+        router = OutboxRouter(app)
+
+        # Mount intervention → sticky shows
+        router._on_intervention(
+            OutboxMessage(
+                kind="intervention",
+                text="proceed?",
+                meta={"intervention_id": "iv1"},
+            ),
+            conv, header,
+        )
+        await pilot.pause()
+        sticky = conv._sticky()
+        assert sticky is not None
+        assert sticky._active, "sticky must be active while intervention pending"
+        assert "awaiting" in sticky._body.lower(), (
+            f"sticky body must signal awaiting state; got {sticky._body!r}"
+        )
+
+        # Resolve → sticky hides
+        router._on_intervention_resolved(
+            OutboxMessage(
+                kind="intervention_resolved",
+                text="",
+                meta={"iv_id": "iv1"},
+            ),
+            conv, header,
+        )
+        await pilot.pause()
+        assert not sticky._active, (
+            "sticky must be cleared once the intervention is resolved"
+        )
+
+
 # ── error triggers both signals ──────────────────────────────────────────────
 
 

--- a/tests/cli/test_out_of_band_signals.py
+++ b/tests/cli/test_out_of_band_signals.py
@@ -174,9 +174,10 @@ async def test_intervention_mount_shows_awaiting_sticky() -> None:
         await pilot.pause()
         sticky = conv._sticky()
         assert sticky is not None
-        assert sticky._active, "sticky must be active while intervention pending"
-        assert "awaiting" in sticky._body.lower(), (
-            f"sticky body must signal awaiting state; got {sticky._body!r}"
+        state = sticky.snapshot()
+        assert state["active"], "sticky must be active while intervention pending"
+        assert "awaiting" in state["body"].lower(), (
+            f"sticky body must signal awaiting state; got {state['body']!r}"
         )
 
         # Resolve → sticky hides
@@ -189,7 +190,7 @@ async def test_intervention_mount_shows_awaiting_sticky() -> None:
             conv, header,
         )
         await pilot.pause()
-        assert not sticky._active, (
+        assert not sticky.snapshot()["active"], (
             "sticky must be cleared once the intervention is resolved"
         )
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary

When an intervention mounted, `conv.hide_status()` cleared the `⟳ thinking…` sticky and the conversation pane went silent except for the inline `InterventionWidget`. The widget has a coral border (visible) but scrolls off-screen as soon as the user navigates up to review prior turns — at which point the "agent is waiting for me" signal is invisible until the user scrolls back down.

The terminal title flips to `reyn — awaiting answer` (#131) but that's only visible as a window tab label and useless for users focused inside the TUI.

## Fix

Show a persistent `⚑ awaiting your answer` sticky after the widget mounts, cleared on resolution (`_on_intervention_resolved`). The sticky is docked to the bottom of the conv pane so it survives scroll, and uses `kind="general"` so no `⟳` spinner / elapsed timer appears — the agent is paused, not working.

## Subtle ordering

`conv.mount_intervention` internally calls `hide_status` to clear any prior thinking spinner. So the new `show_status` MUST come AFTER `_mount_intervention` — showing before would be silently undone the moment `mount_intervention` runs. Doc-commented at the call site so a future refactor doesn't accidentally reorder.

This was the same `kind="general"` sticky-render concern that bit PR #146 / Issue #156 follow-up and PR #173's H2 turn-nav flash. Investigating with concrete test infrastructure here showed the bug there was orthogonal — the hide-after-show race — and not a Textual issue with the general kind itself. **Worth a follow-up pass at PR #146's dedup-vs-sticky and PR #173's log-vs-sticky pivots** to see if they can recover the sticky approach now that the race is understood.

## Tests added (Tier 2)

`test_intervention_mount_shows_awaiting_sticky` pins:
- After `_on_intervention` → `sticky._active is True` and `"awaiting" in sticky._body.lower()`
- After `_on_intervention_resolved` → `sticky._active is False`

## Existing-test grep (per workflow lesson)

```
grep -rn "_on_intervention\b\|_on_intervention_resolved" tests/
```

→ existing intervention tests in `test_out_of_band_signals.py` cover title + bell only, not sticky state. New test added alongside as Tier 2.

## Test plan

- [x] `pytest tests/cli/test_out_of_band_signals.py` — 7/7 passing (6 prior + 1 new)
- [x] Decision-flow Q1 (testing.ja.md): persistent user-facing UX invariant ("agent blocked must be visible at all times") → **Tier 2**

🤖 Generated with [Claude Code](https://claude.com/claude-code)