### PR TITLE
fix(tui): cost-tab token breakdown wraps to a second line

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -27,7 +27,20 @@ def _cost_str(bucket: dict) -> str:
 
 
 def _tok(p: int, c: int) -> str:
-    return f"[#dddddd]{p + c:,}[/] [#555555]({p:,}p + {c:,}c)[/]"
+    """Render token total + prompt/completion breakdown across two lines.
+
+    At a 33%-width panel (~22 cells of content area), the previous
+    single-line format ``{total:,} ({p:,}p + {c:,}c)`` reliably clipped
+    the breakdown — e.g. ``3,932 (3,…``. Split into two lines so the
+    breakdown wraps under the value column instead of overflowing.
+    Large totals (1M+ tokens) may still exceed the breakdown line at
+    very narrow widths; accepted trade-off — the total is the
+    load-bearing number and stays visible on line 1.
+    """
+    return (
+        f"[#dddddd]{p + c:,}[/]\n"
+        f"[#555555]      ({p:,}p + {c:,}c)[/]"
+    )
 
 
 def _sparkline(values: list[float], width: int = 32) -> str:


### PR DESCRIPTION
**[tui-coder]** —

## Summary

At a 33%-width right panel (~22 cells of content area), the single-line format `{total:,} ({p:,}p + {c:,}c)` reliably clipped the breakdown:

```
    tokens  3,932 (3,…
    tokens  11,812 (1…
```

Split `_tok` into two lines so the breakdown drops below the value column with a 6-cell indent, keeping the load-bearing total visible on line 1 even at extreme token counts.

## Before / After

Before (33%-panel cost tab):
```
    tokens  3,932 (3,…
    cost    $0.0009
```

After:
```
    tokens  3,932
          (3,932p + 0c)
    cost    $0.0009
```

## Trade-off

Large totals (1 M+) may still exceed the breakdown line at the very narrowest panel widths (= 6-cell indent + `(1,234,567p + 34,567c)` = 28 cells, panel content ~22). Accepted trade-off — the total is the primary number and stays readable on line 1 regardless; the breakdown is supplementary.

A future tier could compute available width from `self.size.width` and switch to compact format (`1.2M (1.2Mp + 35c)`) at extreme widths; out of scope here.

## Existing-test grep (per workflow lesson)

```
grep -rn "_tok\|cost_tab" tests/
```

→ 0 hits for cost-tab visual output.

## Test plan

- [x] Manual: `reyn chat` 80x30, send a turn, Ctrl+B then Ctrl+W cycle to Cost tab → `tokens 7,867` on line 1, `      (7,555p + 312c)` on line 2 — no clipping
- [x] Manual: ALL TIME section same 2-line layout
- [x] Decision-flow Q1 (testing.ja.md): visual format / panel-width fit → **Tier 4 → no automated test**; pinning exact whitespace would be Tier 4 violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)