### PR TITLE
fix(tui): intervention chip Tab focus has non-color shape cue

### DIFF
--- a/src/reyn/chat/tui/theme.tcss
+++ b/src/reyn/chat/tui/theme.tcss
@@ -137,6 +137,11 @@ InterventionWidget Button:hover {
 }
 
 InterventionWidget Button:focus {
+    /* Reverse video gives a shape cue (= whole chip flips fg/bg) so
+       Tab-focus is identifiable in greyscale / for color-blind users —
+       the previous "background lightens slightly" cue was a 1.28:1
+       contrast change relative to the hover state, indistinguishable
+       without color vision. */
     background: #e0664e;
-    text-style: bold;
+    text-style: bold reverse;
 }


### PR DESCRIPTION
**[tui-coder]** —

## Summary

`InterventionWidget Button:focus` changed only background color (`#c8553d` → `#e0664e` — a 1.28:1 contrast change vs hover) plus `text-style: bold`. Tab-navigating the chip row was indistinguishable in greyscale or for color-blind users — the focus indicator was purely color-driven, undermining the keyboard-only path the intervention prompt is supposed to support.

## Fix

Add `reverse` to the focus text-style. The whole chip flips fg/bg on focus — a strong shape cue that survives color-vision loss AND any 8-color terminal fallback. Hover stays as just the background change (= weaker, color-only cue is acceptable for mouse-over since the cursor itself is the primary signal).

```diff
 InterventionWidget Button:focus {
     background: #e0664e;
-    text-style: bold;
+    text-style: bold reverse;
 }
```

## Existing-test grep (per workflow lesson)

```
grep -rn "Button:focus\|chip.*focus\|button.*focus" tests/
```

→ `test_focus_restore.py` covers the focus-RESTORE path (= where focus lands after intervention dismiss); doesn't assert on focus visual styling. No regression risk.

## Test plan

- [x] Manual: trigger intervention prompt with `permission`-style ask (or via test path that mounts chips). Press Tab → focused chip's fg/bg invert, clearly distinct from neighbors
- [x] Manual: take a screenshot and apply a greyscale filter — focused chip remains identifiable (= the inverted-video cue survives without color)
- [x] Decision-flow Q1 (testing.ja.md): CSS visual rule → **Tier 4 → no automated test**; asserting on CSS state would pin presentation per testing policy

## Related

This is the first batch of an accessibility wave from the 2026-05-18 exploration. Issue #180 covers cross-layer plan-runner findings; remaining TUI-internal items (hint contrast, dash rules, greyscale speaker labels, 8-color thinking glyph) follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)