### PR TITLE
docs(tools): close stale ADR-0026 M4 deferred markers + pin coarse-kind dispatch (FP-0039)

### DIFF
--- a/src/reyn/tools/catalog.py
+++ b/src/reyn/tools/catalog.py
@@ -3,37 +3,25 @@
 Covers the 4 catalog-browse capabilities:
   list_skills, describe_skill, list_agents, describe_agent.
 
-Type C closure: both router and phase are allowed (gates.phase="allow"),
-enabling skill-author phases to browse the registry in M4. Phase-side
-dispatch wiring (= injecting these tools into Control IR
-available_control_ops) is deferred to M4.
+Type C closure: both router and phase are allowed (gates.phase="allow").
+The phase=allow gate is a metadata closure — phase Control IR currently
+emits only coarse op.kind values defined in OP_KIND_MODEL_MAP, and the
+fine-grained catalog names (``list_skills`` / ``describe_skill`` /
+``list_agents`` / ``describe_agent``) are not in that map, so the phase
+path of these handlers is unreachable today.  Reachable phase invocation
+would require a separate Control IR schema migration to fine-grained
+``op.kind`` values (out of scope for ADR-0026 M4).
 
-Design-revisit finding (M4 requirement):
-  Each handler requires access to the session-scoped registries
-  (skill registry → list_available_skills / describe_skill; agent
-  registry → list_available_agents / describe_agent). These are
-  supplied by RouterLoopHost and are NOT reachable from ToolContext
-  today. Concretely:
+Router-side dispatch (post-FP-0039 audit, 2026-05-18):
+  Each handler delegates to a session-scoped function bound on
+  ``ctx.router_state`` (``list_skills_fn`` / ``describe_skill_fn`` /
+  ``list_agents_fn`` / ``describe_agent_fn``).  RouterLoop populates
+  these from its own bound methods at dispatch time — see
+  ``router_host_adapter.py`` for the typed wiring.
 
-    * router caller: RouterLoop.host.list_available_skills() /
-                     RouterLoop.host.list_available_agents()
-    * phase caller:  OpContext does not expose a skill/agent registry
-                     at all.
-
-  A typed RouterCallerState / PhaseCallerState sub-object on
-  ToolContext (ADR-0026 Open Question #3) is the clean path. That
-  sub-object has landed in M4 Phase 2. Production population of
-  RouterCallerState.skill_registry / agent_registry fields (=
-  router_loop wiring) is M4 Phase 3. Until Phase 3, these handlers
-  raise NotImplementedError.
-
-  RouterLoop continues to dispatch list_skills / describe_skill /
-  list_agents / describe_agent via the existing
-  ``if name == "list_skills"`` branches in router_loop.py
-  (_invoke_router_tool). The ToolDefinitions here serve M3's goal:
-  description + parameters + gates registered in the unified registry
-  for render / gate / drift checks. M4 Phase 3 will wire the handlers
-  to consume RouterCallerState.skill_registry / agent_registry.
+  Pre-Phase-3 ``if name == "list_skills"`` literal branches in
+  router_loop.py have been removed; the registry handler is the
+  single dispatch path.
 
 Description strings are byte-identical to the ToolSpec literals in
 src/reyn/chat/router_tools.py lines 250–324 (Wave 2 validation target).
@@ -77,7 +65,7 @@ _LIST_SKILLS_PARAMETERS: dict[str, Any] = {
 
 
 async def _handle_list_skills(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Delegate to RouterCallerState.list_skills_fn (M4 Phase 3 wiring).
+    """Delegate to RouterCallerState.list_skills_fn.
 
     The caller (= RouterLoop) populates router_state.list_skills_fn with
     a bound method (= RouterLoop._list_skills) at dispatch time. This
@@ -134,7 +122,7 @@ _DESCRIBE_SKILL_PARAMETERS: dict[str, Any] = {
 
 
 async def _handle_describe_skill(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Delegate to RouterCallerState.describe_skill_fn (M4 Phase 3 wiring).
+    """Delegate to RouterCallerState.describe_skill_fn.
 
     The caller (= RouterLoop) populates router_state.describe_skill_fn with
     a bound method (= RouterLoop._describe_skill) at dispatch time. This
@@ -188,7 +176,7 @@ _LIST_AGENTS_PARAMETERS: dict[str, Any] = {
 
 
 async def _handle_list_agents(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Delegate to RouterCallerState.list_agents_fn (M4 Phase 3 wiring).
+    """Delegate to RouterCallerState.list_agents_fn.
 
     The caller (= RouterLoop) populates router_state.list_agents_fn with
     a bound method (= RouterLoop._list_agents) at dispatch time. This
@@ -243,7 +231,7 @@ _DESCRIBE_AGENT_PARAMETERS: dict[str, Any] = {
 
 
 async def _handle_describe_agent(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Delegate to RouterCallerState.describe_agent_fn (M4 Phase 3 wiring).
+    """Delegate to RouterCallerState.describe_agent_fn.
 
     The caller (= RouterLoop) populates router_state.describe_agent_fn with
     a bound method (= RouterLoop._describe_agent) at dispatch time. This

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -5,15 +5,19 @@ Phase-side `run_skill` op kind continues to work via OP_KIND_MODEL_MAP
 backward-compat (= ADR-0026 Open Q #7 hybrid recommendation: alias
 preserved + deprecation in a later release).
 
-M4 Phase 3 status (schema_enricher landed; handler activation pending):
-  schema_enricher (_enrich_router_schema) is now wired into the
-  INVOKE_SKILL ToolDefinition. render_for_router(state=...) injects the
-  `name` enum from RouterCallerState.available_skills per-call, matching
-  the prior inline literal in router_tools.py.
-
-  Handler activation (= replacing the existing legacy adapter with a
-  unified-registry dispatch path) requires RouterCallerState.run_skill_fn
-  which was not added in Wave 1. Handler activation is deferred to Phase 3.5.
+Dispatch status (post-FP-0039 audit, 2026-05-18):
+  - schema_enricher (_enrich_router_schema) is wired into the INVOKE_SKILL
+    ToolDefinition.  render_for_router(state=...) injects the `name` enum
+    from RouterCallerState.available_skills per-call.
+  - The coarse phase-side counterpart ``RUN_SKILL_OP`` (kind="run_skill")
+    is wired end-to-end through ``invoke_tool(get_default_registry(), ...)``
+    in ``ControlIRExecutor._invoker``, delegating to
+    ``op_runtime/run_skill.py:handle``.
+  - Router-side INVOKE_SKILL handler dispatch still goes through the
+    legacy adapter in router_loop.py rather than ``invoke_tool``.  Moving
+    that path to the unified registry would require surfacing
+    ``run_skill_fn`` on RouterCallerState — a follow-up if router-side
+    unification becomes load-bearing.
 
 Per-call enum enrichment:
   The `name` field in _INVOKE_SKILL_PARAMETERS is a plain string (no enum).

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -10,25 +10,22 @@ Three capabilities are registered here:
 Per ADR-0026 Open Q #6, router-side fine-grained names are canonical:
 call_mcp_tool / list_mcp_servers / list_mcp_tools / describe_mcp_tool.
 
-## Phase-side dispatch status (M3 metadata-only)
+## Phase-side dispatch status (post-FP-0039 audit, 2026-05-18)
 
-All three ToolDefinitions have gates.phase="allow", which closes the
-Type C gap at the *metadata* level: the registry declares them available
-to phase, and render_for_phase() will include them in available_control_ops.
+All four ToolDefinitions have gates.phase="allow".  The coarse-kind path
+(= ``op.kind="mcp"`` → CALL_MCP_TOOL semantics via MCPIROp) is wired
+end-to-end through ``invoke_tool(get_default_registry(), op.kind, ...)``
+in ``ControlIRExecutor._invoker``.
 
-However, the phase-side Control IR executor does not yet consume the
-unified registry for dispatch. Phase-side wiring for list_mcp_servers and
-list_mcp_tools is deferred to M4 (the op_runtime dispatcher currently only
-handles the "mcp" kind via MCPIROp which maps to call_mcp_tool semantics).
-
-CALL_MCP_TOOL is already wired end-to-end because it maps 1-to-1 to the
-existing op_runtime/mcp.py "mcp" kind handler via MCPIROp.
-
-For LIST_MCP_SERVERS and LIST_MCP_TOOLS: the ToolDefinition is registered
-with gates.phase="allow" (closing the Type C metadata gap), but phase-side
-Control IR execution of these ops is not yet plumbed — a phase that emits
-list_mcp_servers / list_mcp_tools control_ir ops will not be dispatched by
-the current executor. That dispatch wiring is the M4 task.
+The fine-grained discovery names (``list_mcp_servers`` / ``list_mcp_tools``
+/ ``describe_mcp_tool``) are NOT in ``OP_KIND_MODEL_MAP``, so phase Control
+IR cannot emit them today.  Their phase=allow gate is a metadata closure:
+the registry advertises them as phase-eligible (consumed by future
+``render_for_phase()`` enumerations), but the phase paths in the handlers
+below are unreachable until a separate FP migrates Control IR schema to
+fine-grained ``op.kind`` values.  The handlers therefore keep clear
+"not yet wired" error stubs as defensive guards for any caller that
+manages to bypass the schema-level rejection.
 
 ## Router-side dispatch
 
@@ -138,8 +135,10 @@ async def _handle_list_mcp_servers(
     """Adapter for list_mcp_servers.
 
     Router path: delegates to host.mcp_list_servers() via ctx.router_state.
-    Phase path: registered with gates.phase=allow (Type C metadata closure),
-    but phase-side Control IR executor wiring is deferred to M4.
+    Phase path: registered with gates.phase=allow (Type C metadata closure)
+    but unreachable today — phase Control IR emits only coarse op.kind
+    values defined in OP_KIND_MODEL_MAP, and ``list_mcp_servers`` is not
+    in that map.  See module docstring for the full status.
 
     The router_state is expected to carry a host object with an async
     mcp_list_servers() method (= RouterHostAdapter or compatible).
@@ -149,12 +148,14 @@ async def _handle_list_mcp_servers(
         result = await host.mcp_list_servers()
         return {"servers": result}
 
-    # Phase path — M4 will wire phase-side execution; for now surface a
-    # clear error so any premature phase invocation is immediately visible.
+    # Phase path — unreachable in normal flow; defensive guard for any
+    # caller that bypasses Control IR schema rejection.
     return {
         "error": (
-            "list_mcp_servers phase-side dispatch not yet wired "
-            "(M4 task). ToolDefinition registered for metadata closure only."
+            "list_mcp_servers has no phase-side dispatch path. "
+            "Phase Control IR emits only coarse op.kind values; "
+            "fine-grained MCP discovery from phase requires a separate "
+            "Control IR schema migration (out of scope for ADR-0026 M4)."
         )
     }
 
@@ -165,8 +166,8 @@ async def _handle_list_mcp_tools(
     """Adapter for list_mcp_tools.
 
     Router path: delegates to host.mcp_list_tools(server) via ctx.router_state.
-    Phase path: registered with gates.phase=allow (Type C metadata closure),
-    but phase-side Control IR executor wiring is deferred to M4.
+    Phase path: registered with gates.phase=allow (Type C metadata closure)
+    but unreachable today — see module docstring for full status.
 
     FP-0032: returns ``mcp_tools`` key (not ``tools``) to avoid structural
     collision with OpenAI tool-definition shape. Each entry is trimmed to
@@ -188,8 +189,10 @@ async def _handle_list_mcp_tools(
 
     return {
         "error": (
-            "list_mcp_tools phase-side dispatch not yet wired "
-            "(M4 task). ToolDefinition registered for metadata closure only."
+            "list_mcp_tools has no phase-side dispatch path. "
+            "Phase Control IR emits only coarse op.kind values; "
+            "fine-grained MCP discovery from phase requires a separate "
+            "Control IR schema migration (out of scope for ADR-0026 M4)."
         )
     }
 
@@ -370,7 +373,8 @@ async def _handle_describe_mcp_tool(
     then filters to the requested mcp_tool_name. The dotted form
     ``<server>.<tool>`` is resolved to the bare tool name for the lookup.
 
-    Phase path: deferred to M4 (metadata closure only — same as list_mcp_tools).
+    Phase path: metadata closure only — same as list_mcp_tools. See module
+    docstring for full status.
     """
     if ctx.caller_kind == "router":
         host = _require_host(ctx)
@@ -394,8 +398,10 @@ async def _handle_describe_mcp_tool(
 
     return {
         "error": (
-            "describe_mcp_tool phase-side dispatch not yet wired "
-            "(M4 task). ToolDefinition registered for metadata closure only."
+            "describe_mcp_tool has no phase-side dispatch path. "
+            "Phase Control IR emits only coarse op.kind values; "
+            "fine-grained MCP discovery from phase requires a separate "
+            "Control IR schema migration (out of scope for ADR-0026 M4)."
         )
     }
 

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -9,13 +9,20 @@ Five capabilities migrated from chat/router_tools.py ToolSpec literals:
 
 All five carry gates(router="allow", phase="allow") — this is the
 Type C closure for memory write (ADR-0026 §1, §3): the capabilities
-were previously router-only; setting phase="allow" closes the gap so
-phase-side Control IR can invoke them once M4 wires the phase dispatch
-path to consume the registry.
+were previously router-only; phase="allow" is registered as a metadata
+closure so the registry advertises memory write as phase-eligible.
 
-Phase-side dispatch wiring deferred to M4. ToolDefinitions are
-registered and gates are open, but the ControlIRExecutor does not yet
-consume the registry; M4 closes this final step.
+Status (post-FP-0039 audit, 2026-05-18): coarse-kind phase dispatch
+(= file / mcp / run_skill / shell / lint / ask_user / web_fetch /
+web_search / mcp_install / recall / sandboxed_exec) is wired through
+``invoke_tool(get_default_registry(), op.kind, ...)`` in
+``ControlIRExecutor._invoker``.  The fine-grained memory names
+(``list_memory`` / ``read_memory_body`` / ``remember_*`` / ``forget_memory``)
+are NOT in ``OP_KIND_MODEL_MAP``, so phase Control IR cannot emit them
+today — the phase=allow gate is reachable only if Control IR schema is
+later migrated to accept fine-grained ``op.kind`` values (= a separate
+future FP).  Until then these registrations function as documentation +
+defensive guards, not as live phase-dispatch paths.
 
 MemoryService access path — design-revisit finding:
   ToolContext.workspace is a reyn.workspace.Workspace instance which
@@ -24,12 +31,11 @@ MemoryService access path — design-revisit finding:
   injected file-op callbacks). The handlers below duplicate the
   router_loop.py logic directly against workspace file primitives —
   they use ctx.workspace.read_file / write_file / delete_file — rather
-  than routing through MemoryService. This is the correct short-term
-  strategy during M3; M4 cleanup should either:
+  than routing through MemoryService. If fine-grained phase dispatch
+  ever lands, follow-up work should either:
     (a) surface MemoryService (or equivalent callbacks) on ToolContext, or
     (b) inline workspace-level file ops as the canonical implementation
         and remove the MemoryService indirection.
-  Until M4 this duplication is intentional and documented here.
 """
 from __future__ import annotations
 
@@ -179,11 +185,11 @@ def _memory_dir(workspace_base: Path, state_dir: Path, layer: str) -> Path:
     layer="agent"  → not resolved here (agent dir unknown without ToolContext
                      phase_state; returns state_dir/memory as fallback).
 
-    Design-revisit (M4): phase_state should carry agent_workspace_dir so the
+    Design-revisit: phase_state should carry agent_workspace_dir so the
     "agent" layer resolves correctly for phase-side callers. Router-side callers
-    receive this via ctx.router_state (not yet populated in M3). For now the
-    agent layer always resolves relative to .reyn/agents/ using the agent name
-    from phase_state or router_state if available, falling back to state_dir.
+    receive this via ctx.router_state. For now the agent layer always resolves
+    relative to .reyn/agents/ using the agent name from phase_state or
+    router_state if available, falling back to state_dir.
     """
     if layer == "shared":
         return state_dir / "memory"

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -1,0 +1,120 @@
+"""Tier 2: phase Control IR coarse op.kind → registry dispatch coverage.
+
+Post-FP-0039 audit pin (2026-05-18). Confirms that every coarse op kind
+``ControlIRExecutor._invoker`` actually routes through the unified
+ToolRegistry (= ``invoke_tool(get_default_registry(), op.kind, ...)``)
+has a ToolDefinition with ``gates.phase="allow"``. If a future PR adds a
+coarse op kind to ``OP_KIND_MODEL_MAP`` but forgets the registry entry,
+the kind silently falls back to the legacy ``execute_op`` path and the
+ADR-0026 M4 unification claim regresses unnoticed.
+
+The 11 kinds pinned here are the ones FP-0039 §S1 audit found wired:
+file / mcp / run_skill / shell / lint / ask_user / web_fetch /
+web_search / mcp_install / recall / sandboxed_exec. The 6 RAG / internal
+kinds (embed / index_* / judge_output / skill_resolve) intentionally
+stay on the legacy path and are documented in this test's expected-
+legacy set so adding them later is an explicit change, not a silent one.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.op_runtime.registry import OP_KIND_MODEL_MAP
+from reyn.tools import get_default_registry
+
+# Coarse op kinds the FP-0039 audit confirmed dispatch through the
+# unified registry. Adding a kind here is a deliberate claim that
+# control_ir_executor.py routes via invoke_tool(_registry, op.kind, ...)
+# for it.
+_REGISTRY_WIRED_KINDS: frozenset[str] = frozenset({
+    "ask_user",
+    "file",
+    "lint",
+    "mcp",
+    "mcp_install",
+    "recall",
+    "run_skill",
+    "sandboxed_exec",
+    "shell",
+    "web_fetch",
+    "web_search",
+})
+
+# Coarse op kinds that intentionally still dispatch via the legacy
+# op_runtime/<kind>.py path (= ControlIRExecutor._invoker hits the
+# execute_op fallback because the registry lookup returns None).
+# These are RAG plumbing + internal kernel ops that have no
+# router-side analog and don't benefit from the registry unification.
+_LEGACY_ONLY_KINDS: frozenset[str] = frozenset({
+    "embed",
+    "index_drop",
+    "index_query",
+    "index_write",
+    "judge_output",
+    "skill_resolve",
+})
+
+
+def test_op_kind_partition_is_total() -> None:
+    """Tier 2: every kind in OP_KIND_MODEL_MAP is in exactly one set.
+
+    Catches the regression where a new coarse op kind is added to
+    OP_KIND_MODEL_MAP without classifying it as wired vs legacy. Forces
+    the author of the new kind to decide explicitly.
+    """
+    all_kinds = frozenset(OP_KIND_MODEL_MAP.keys())
+    classified = _REGISTRY_WIRED_KINDS | _LEGACY_ONLY_KINDS
+    missing = all_kinds - classified
+    extra = classified - all_kinds
+    assert not missing, (
+        f"OP_KIND_MODEL_MAP has kinds not classified here: {sorted(missing)}. "
+        f"Add to _REGISTRY_WIRED_KINDS or _LEGACY_ONLY_KINDS based on "
+        f"whether the kind has a phase=allow ToolDefinition."
+    )
+    assert not extra, (
+        f"Classified kinds not in OP_KIND_MODEL_MAP: {sorted(extra)}. "
+        f"Stale entry — remove from the partition sets."
+    )
+    assert _REGISTRY_WIRED_KINDS.isdisjoint(_LEGACY_ONLY_KINDS), (
+        f"Overlap between wired and legacy sets: "
+        f"{sorted(_REGISTRY_WIRED_KINDS & _LEGACY_ONLY_KINDS)}"
+    )
+
+
+@pytest.mark.parametrize("kind", sorted(_REGISTRY_WIRED_KINDS))
+def test_wired_kind_has_phase_allow_registry_entry(kind: str) -> None:
+    """Tier 2: each wired coarse kind has a registry entry with phase=allow.
+
+    Without this gate, ``ControlIRExecutor._invoker`` would skip the
+    registry path and fall through to the legacy ``execute_op``,
+    breaking the ADR-0026 M4 unification claim for the kind.
+    """
+    reg = get_default_registry()
+    td = reg.lookup(kind)
+    assert td is not None, (
+        f"coarse op.kind={kind!r} has no registry entry — "
+        f"control_ir_executor.py will fall through to execute_op "
+        f"(legacy path). Register a ToolDefinition in reyn/tools/."
+    )
+    assert td.gates.phase == "allow", (
+        f"coarse op.kind={kind!r} has gates.phase={td.gates.phase!r}; "
+        f"must be 'allow' for ControlIRExecutor._invoker to dispatch "
+        f"through the unified registry."
+    )
+
+
+@pytest.mark.parametrize("kind", sorted(_LEGACY_ONLY_KINDS))
+def test_legacy_kind_stays_unregistered(kind: str) -> None:
+    """Tier 2: each legacy-only coarse kind has no registry entry.
+
+    If a registry entry is added without updating _LEGACY_ONLY_KINDS,
+    that's a meaningful architectural move (= the kind has joined the
+    unified dispatch path). Force the change to be explicit.
+    """
+    reg = get_default_registry()
+    td = reg.lookup(kind)
+    assert td is None, (
+        f"coarse op.kind={kind!r} now has a registry entry — if intentional, "
+        f"move it from _LEGACY_ONLY_KINDS to _REGISTRY_WIRED_KINDS in this "
+        f"test (a deliberate change, not a silent one)."
+    )


### PR DESCRIPTION
**[e2e-coder]** —

Closes #172.

## Summary

FP-0039 (#172) asked for ADR-0026 M4 closeout — finish phase-side dispatch wiring for memory / mcp / invoke_skill / catalog tools. The issue author hinted: *"S1 alone might surface that the gap is smaller than the docstrings suggest. If so, this FP becomes mostly S3."*

S1 audit confirmed that hint: the M4 coarse-kind phase dispatch path is **already complete**. All 11 coarse op kinds that the FP scope references (= `file` / `mcp` / `run_skill` / `shell` / `lint` / `ask_user` / `web_fetch` / `web_search` / `mcp_install` / `recall` / `sandboxed_exec`) dispatch through `invoke_tool(get_default_registry(), op.kind, ...)` in `ControlIRExecutor._invoker` (= `src/reyn/kernel/control_ir_executor.py:390-404`). The remaining `"deferred to M4"` / `"M4 task"` markers in 4 modules described an aspirational future where phase Control IR emits **fine-grained** `op.kind` values — that requires a separate Control IR schema migration (= expanding `OP_KIND_MODEL_MAP`), which is out of scope for ADR-0026 M4.

This PR therefore lands **S3 only** (= comment hygiene) plus a regression test that pins the dispatch coverage so future PRs can't silently regress the unification claim.

## S1 audit table (= phase op.kind → registry coverage)

| op.kind | Registry phase=allow | Status |
|---|---|---|
| `ask_user` / `file` / `lint` / `mcp` / `mcp_install` / `recall` / `run_skill` / `sandboxed_exec` / `shell` / `web_fetch` / `web_search` | ✓ | Wired through `invoke_tool` |
| `embed` / `index_drop` / `index_query` / `index_write` / `judge_output` / `skill_resolve` | ✗ (not registered) | Legacy `execute_op` fallback — intentional, out of FP-0039 scope |

## What this PR changes

### `src/reyn/tools/memory.py`
Module docstring + `_memory_dir` revisit note: replace `"deferred to M4"` framing with status-as-of-2026-05-18: fine-grained memory names have `phase=allow` as metadata closure, but phase Control IR can't emit them today (= they're not in `OP_KIND_MODEL_MAP`).

### `src/reyn/tools/mcp.py`
- Module docstring: rewrite `"Phase-side dispatch status (M3 metadata-only)"` section to reflect actual state (= coarse `mcp` wired ✓; fine `list_mcp_*` / `describe_mcp_tool` unreachable from phase today).
- `_handle_list_mcp_servers` / `_handle_list_mcp_tools` / `_handle_describe_mcp_tool`: the `"...phase-side dispatch not yet wired (M4 task)..."` error stubs become `"...has no phase-side dispatch path. Phase Control IR emits only coarse op.kind values..."` — describing the actual architecture, not pretending work is imminent.

### `src/reyn/tools/invoke_skill.py`
Module docstring: replace `"M4 Phase 3 status / Handler activation deferred to Phase 3.5"` with status: coarse `RUN_SKILL_OP` wired end-to-end ✓; router-side `INVOKE_SKILL` still on legacy adapter (= follow-up if router-side unification becomes load-bearing).

### `src/reyn/tools/catalog.py`
- Module docstring: handlers already delegate to `ctx.router_state.<*>_fn` (= wiring is done, not deferred). Replace the stale `"M4 Phase 3 will wire"` paragraph with declarative status.
- Per-handler docstring strip: `"(M4 Phase 3 wiring)"` → removed (= the wiring is the steady state now, not a future task).

### `tests/test_phase_dispatch_registry_coverage.py` (new)
18 Tier 2 tests pinning the audit findings:
- `test_op_kind_partition_is_total` — every kind in `OP_KIND_MODEL_MAP` is in exactly one of `_REGISTRY_WIRED_KINDS` / `_LEGACY_ONLY_KINDS` (= forces explicit classification when a new kind is added).
- `test_wired_kind_has_phase_allow_registry_entry[kind]` — parametrized over the 11 wired kinds.
- `test_legacy_kind_stays_unregistered[kind]` — parametrized over the 6 legacy-only kinds (= forces deliberate change when a legacy kind joins the unified path).

## Test plan

- [x] **Automated — `pytest tests/test_phase_dispatch_registry_coverage.py`**: 18/18 pass.
- [x] **Adjacent — `pytest tests/test_replay_skill_router.py tests/test_router_loop_routing_decided.py tests/test_router_invoke_skill_enum.py tests/test_router_tools_universal_wrappers.py tests/test_universal_catalog.py tests/test_chat_turn_completed_inline.py`**: 132 passed, 1 xfailed (= existing `list_actions_discovery` G12 V1-INNER limit from #158). Per the prior `replay-fixture-discipline` memory: I pre-checked `grep -rn "KNOWN_STATIC_QUALIFIED_NAMES" tests/` — this PR does NOT touch `KNOWN_STATIC_QUALIFIED_NAMES` or the ARS-block surface, so no fixture invalidation.
- [x] **Lint — `ruff check`**: clean on all 5 touched files.
- [x] **Audit reproducibility**: the `_REGISTRY_WIRED_KINDS` set in the new test matches the registry-state introspection script that produced the audit table above.

## Notes

- No behavioral change. Pure docstring + new test.
- The 6 legacy-only kinds (`embed` / `index_*` / `judge_output` / `skill_resolve`) staying off the registry is intentional per the audit; if a future FP unifies them, the test forces an explicit set update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)