### PR TITLE
fix(tui): unify turn-header dash colors to a single visible neutral

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -464,7 +464,7 @@ class ConversationView(Widget):
         """
         self._snap_to_bottom()
         self._consume_empty_hint()
-        self._maybe_write_header("you", "you", "bold #4abbb5", "#1f5856")
+        self._maybe_write_header("you", "you", "bold #4abbb5", "#666666")
         self._write_body(Text(text))
         self._write_log(Text(""))
 
@@ -480,7 +480,7 @@ class ConversationView(Widget):
         """
         self._consume_empty_hint()
         self.hide_status()
-        self._maybe_write_header("system", "system", "bold #888888", "#444444")
+        self._maybe_write_header("system", "system", "bold #888888", "#666666")
         for line in (msg.text or "").splitlines() or [""]:
             self._write_body(Text(line))
         self._write_log(Text(""))
@@ -500,7 +500,7 @@ class ConversationView(Widget):
         # _AMBER for agent identity (header label) — distinct from _CORAL
         # which is reserved for interactive affordances (/expand, picker
         # selection caret, panel cursor ▶) and "you are here" indicators.
-        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#5a2020")
+        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#666666")
         if msg.text:
             self._write_agent_markdown_with_fold(msg.text)
         self._write_log(Text(""))
@@ -630,7 +630,7 @@ class ConversationView(Widget):
         self._consume_empty_hint()
         label = agent_name if agent_name else "reyn"
         # Same agent-identity styling as _render_agent_markdown (_AMBER).
-        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#5a2020")
+        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#666666")
         row = StreamingRow(prefix="", id=f"stream_{msg_id[:8]}")
         self._stream_rows[msg_id] = row
         self.mount(row)


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Turn-header dash rules carried speaker-identity color tints:

- `#1f5856` (teal) for `"you"` — 2.33:1 contrast on `#111111`
- `#5a2020` (dark red) for `"reyn"` — 1.49:1 contrast
- `#444444` (grey) for `"system"` — ~1.86:1 contrast

All three landed below WCAG's 3:1 floor for decorative non-text — invisible for low-vision users and indistinguishable in greyscale. The position of the rule ("this is where a new turn starts") is the load-bearing signal; the tint adds no information given the speaker name already carries a distinct color (per #121).

## Fix

Unify all three dash colors to `#666666` — the same neutral the timestamp column uses. Above 3:1 contrast and harmonizes the whole header band (timestamp + dash rule share a tone, while the speaker name stays as the load-bearing color signal).

## Existing-test grep (per workflow lesson)

```
grep -rn "#1f5856\|#5a2020\|#444444\|dash_style" tests/
```

→ 0 hits asserting on dash color.

## Test plan

- [x] Manual: `reyn chat`, send user / agent / system (= `/help`) turns; dash rules are now clearly visible against the dark conv pane bg
- [x] Decision-flow Q1 (testing.ja.md): CSS color values → **Tier 4 → no automated test** (color-pinning would violate testing policy)

## Related

Part of the accessibility wave (companion to #181 chip focus, #182 hint contrast). Issue #180 covers the plan-runner cross-layer findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)