### PR TITLE
fix(tui): thinking sticky glyph uses _AMBER, not _CORAL

### DIFF
--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -19,7 +19,7 @@ import time
 from rich.text import Text
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL
+from reyn.chat.tui._palette import _AMBER, _CORAL
 
 _TICK_INTERVAL_S = 0.1  # elapsed timer refresh rate
 
@@ -102,7 +102,15 @@ class StickyStatus(Static):
     def _repaint(self) -> None:
         elapsed = max(0.1, time.monotonic() - self._start)
         t = Text()
-        t.append(self._glyph + " ", style=_CORAL)
+        # On 8-color terminals, hex _CORAL (#C8553D) degrades to ANSI bright
+        # red — confusable with error indicators. The thinking sticky shows
+        # while the agent is working, so route its glyph through _AMBER
+        # (which degrades to ANSI yellow / bright yellow) — neutrally
+        # signalling "in progress" rather than "alert". Other kinds (tool,
+        # general) keep _CORAL since they're typically transient flashes,
+        # not the load-bearing "is the agent working?" indicator.
+        glyph_color = _AMBER if self._kind == "thinking" else _CORAL
+        t.append(self._glyph + " ", style=glyph_color)
         t.append(self._body, style="dim italic")
         t.append(f" · {elapsed:.1f}s", style="dim italic")
         if self._kind == "thinking":


### PR DESCRIPTION
**[tui-coder]** —

## Summary

On 8-color terminals (`TERM=xterm`, `COLORTERM` unset), hex `_CORAL` (`#C8553D`) degrades to ANSI bright red (`[91m`) — visually identical to the error indicator (`#cc5555`). The thinking sticky's `⟳` glyph rendered in red while the agent was just working, signalling "alert/error" instead of "in progress".

Route the thinking-kind glyph through `_AMBER` (`#d4945a`), which degrades to ANSI yellow / bright yellow — neutrally signalling "in progress". Other kinds (`tool` / `general`) keep `_CORAL` since they're typically transient flashes, not the load-bearing "is the agent working?" indicator.

## Visual rationale

Reyn's palette (per `_palette.py` + #121 split):
- `_CORAL` = interactive affordance / "you are here"
- `_AMBER` = agent identity (used for `reyn` header label and streaming cursor)

The thinking sticky fires while the AGENT is working. Routing it through `_AMBER` aligns its color signal with "agent activity in progress" — visually consistent with the agent header band that's already amber.

## Existing-test grep (per workflow lesson)

```
grep -rn "_CORAL\|sticky.*glyph\|⟳" tests/
```

→ `tests/cli/test_palette_semantic_split.py` pins `_AMBER != _CORAL` (= invariant from #121). Doesn't assert on which kind uses which — orthogonal contract.

```
grep -nE "(sticky|widget|conv|app|registry)\._[a-z]" tests/<edited>
```

→ N/A (no test edits).

## Test plan

- [x] `pytest tests/cli/test_palette_semantic_split.py tests/cli/test_tui_smoke.py` — 45/45 passing
- [x] Decision-flow Q1 (testing.ja.md): CSS color value → **Tier 4 → no automated test** (color-pinning would violate the testing policy)

## Related

Part of the accessibility wave from the 2026-05-18 exploration. Companion to merged #181 (chip focus shape), #182 (hint contrast), #184 (dash unify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)