### PR TITLE
fix(tui): prefix turn-header speakers with non-color identity glyph

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -58,6 +58,14 @@ from .streaming_row import StreamingRow
 
 _DASH_TOTAL = 38  # matches the banner separator width
 _GROUP_WINDOW_S = 60.0  # consecutive turns within this window share a header
+# Speaker-identity glyphs prepended to header labels — non-color cue so
+# turn boundaries stay legible in greyscale / for color-blind users.
+# The header name color (cyan / amber / grey) is still the primary
+# signal; the glyph is a redundant shape signal so neither channel
+# alone is load-bearing.
+_GLYPH_USER = "▶"
+_GLYPH_AGENT = "◆"
+_GLYPH_SYSTEM = "·"
 _FOLD_THRESHOLD_LINES = 30  # B3: agent replies above this fold inline
 # /copy ring-buffer depth. Far enough back that the user can grab "the
 # reply two turns ago" — the typical "wait, that one was useful" recovery
@@ -464,7 +472,9 @@ class ConversationView(Widget):
         """
         self._snap_to_bottom()
         self._consume_empty_hint()
-        self._maybe_write_header("you", "you", "bold #4abbb5", "#666666")
+        self._maybe_write_header(
+            "you", f"{_GLYPH_USER} you", "bold #4abbb5", "#666666",
+        )
         self._write_body(Text(text))
         self._write_log(Text(""))
 
@@ -480,7 +490,9 @@ class ConversationView(Widget):
         """
         self._consume_empty_hint()
         self.hide_status()
-        self._maybe_write_header("system", "system", "bold #888888", "#666666")
+        self._maybe_write_header(
+            "system", f"{_GLYPH_SYSTEM} system", "bold #888888", "#666666",
+        )
         for line in (msg.text or "").splitlines() or [""]:
             self._write_body(Text(line))
         self._write_log(Text(""))
@@ -500,7 +512,9 @@ class ConversationView(Widget):
         # _AMBER for agent identity (header label) — distinct from _CORAL
         # which is reserved for interactive affordances (/expand, picker
         # selection caret, panel cursor ▶) and "you are here" indicators.
-        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#666666")
+        self._maybe_write_header(
+            "reyn", f"{_GLYPH_AGENT} {label}", "bold " + _AMBER, "#666666",
+        )
         if msg.text:
             self._write_agent_markdown_with_fold(msg.text)
         self._write_log(Text(""))
@@ -630,7 +644,9 @@ class ConversationView(Widget):
         self._consume_empty_hint()
         label = agent_name if agent_name else "reyn"
         # Same agent-identity styling as _render_agent_markdown (_AMBER).
-        self._maybe_write_header("reyn", label, "bold " + _AMBER, "#666666")
+        self._maybe_write_header(
+            "reyn", f"{_GLYPH_AGENT} {label}", "bold " + _AMBER, "#666666",
+        )
         row = StreamingRow(prefix="", id=f"stream_{msg_id[:8]}")
         self._stream_rows[msg_id] = row
         self.mount(row)


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Speaker labels `you` / `reyn` / `system` relied purely on color (`#4abbb5` / `#d4945a` / `#888888`) to distinguish themselves. In greyscale or for color-blind users those three resolve to greyscale values 152 / 160 / 136 — a max 1.36:1 pairwise contrast, indistinguishable without color vision.

Prepend a fixed glyph per speaker:

```
  ▶ you ───────────…
  ◆ reyn ──────────…
  · system ────────…
```

The glyph carries a non-color shape signal so the speaker is identifiable even when color is lost. The header color stays as the primary affordance for sighted users; the glyph is redundant signal.

## Before / After

Before (visual):
```
  23:04  you ─────────
         sa
  23:04  reyn ────────
         It looks like ...
  23:04  system ──────
         Slash commands:
```

After:
```
  23:04  ▶ you ───────
         sa
  23:04  ◆ reyn ──────
         It looks like ...
  23:04  · system ────
         Slash commands:
```

## Existing-test grep (per workflow lesson)

```
grep -nE "(sticky|widget|conv|app|registry)\._[a-z]" tests/<edited>
```

→ N/A (no test edits).

```
grep -rn "_msg_header\|_maybe_write_header\|speaker label" tests/
```

→ 0 hits asserting on header text content.

## Test plan

- [x] Manual: `reyn chat`, exchange user / agent turns + `/help` → all three header types render with their speaker-identity glyph
- [x] `pytest tests/cli/test_tui_smoke.py tests/cli/test_focus_restore.py tests/cli/test_palette_semantic_split.py` — 48/48 passing (header grouping / dash alignment / palette invariants all preserved)
- [x] Decision-flow Q1 (testing.ja.md): visual format / glyph placement → **Tier 4 → no automated test** (pinning the exact glyph would violate testing policy "exact whitespace / formatting")

## Related

Final piece of the accessibility wave from 2026-05-18 exploration. Companion to merged #181 (chip focus), #182 (hint contrast), #184 (dash unify), pending #186 (thinking-glyph amber on 8-color terms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)