### PR TITLE
fix(tui): Memory tab refreshes live so saved/deleted entries appear

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -48,7 +48,12 @@ _PANEL_LABELS: dict[str, str] = {
     "docs":    "Docs",
 }
 
-_LIVE_PANELS = {"events", "agents", "cost"}
+# Tabs that re-render on the periodic ``_REFRESH_INTERVAL`` tick so newly
+# arrived data shows up without the user having to switch tabs away and
+# back. Memory was missing — when reyn saved or deleted an entry mid-
+# session it stayed invisible in the Memory tab until next refresh
+# trigger (= manual tab switch).
+_LIVE_PANELS = {"events", "agents", "cost", "memory"}
 _REFRESH_INTERVAL = 2.0
 
 

--- a/tests/cli/test_right_panel_refresh_gated.py
+++ b/tests/cli/test_right_panel_refresh_gated.py
@@ -118,10 +118,13 @@ async def test_refresh_live_invalidates_when_visible_and_live_tab() -> None:
 async def test_refresh_live_skips_non_live_tabs_even_when_visible() -> None:
     """Tier 2: the existing ``_LIVE_PANELS`` gate still applies when visible.
 
-    Tabs like ``keys`` / ``docs`` / ``memory`` are content-static (or
-    only change on user interaction); periodic re-invalidation would
-    waste paint cycles for no signal. The visibility gate is additive
-    — it tightens the filter, doesn't replace it.
+    Tabs like ``keys`` / ``docs`` are content-static (only change on
+    code or user interaction); periodic re-invalidation would waste
+    paint cycles for no signal. ``memory`` was previously static but
+    is now live (saves / deletes during a session need to surface
+    without a manual tab swap — see :func:`...test_memory_panel_refreshes_live`).
+    The visibility gate is additive — it tightens the filter, doesn't
+    replace it.
     """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
@@ -137,4 +140,31 @@ async def test_refresh_live_skips_non_live_tabs_even_when_visible() -> None:
 
         assert calls == [], (
             "non-live tab must still skip invalidation even when visible"
+        )
+
+
+@pytest.mark.asyncio
+async def test_memory_panel_refreshes_live_when_visible() -> None:
+    """Tier 2: the Memory tab is in ``_LIVE_PANELS`` so it refreshes on tick.
+
+    Memory entries are saved / deleted mid-session (= the agent's
+    ``remember`` tool or ``/memory`` slash commands). Without periodic
+    refresh, new entries are invisible in the Memory tab until the user
+    swaps to another tab and back. Pins membership in ``_LIVE_PANELS``
+    so a future refactor doesn't silently regress.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel.display = True
+        await pilot.pause()
+        panel._panel_type = "memory"  # in _LIVE_PANELS
+
+        calls = _instrument_invalidate(panel)
+        panel._refresh_live()
+        panel._refresh_live()
+
+        assert len(calls) == 2, (
+            f"memory tab must invalidate on the live tick; got {len(calls)} calls"
         )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``_LIVE_PANELS = {"events", "agents", "cost"}`` excluded ``memory``, so the 2 s periodic ``_refresh_live`` tick never re-rendered the Memory tab. New entries (from the agent's ``remember`` tool or future ``/memory save``) stayed invisible until the user swapped to a different tab and back — a silent stale state at every mid-session save / delete.

## Fix

Add ``"memory"`` to ``_LIVE_PANELS``. The existing visibility gate (``_panel_visible`` check) stays in place — refresh only fires when the panel is open, so background sessions don't burn cycles re-rendering hidden tabs.

```diff
- _LIVE_PANELS = {"events", "agents", "cost"}
+ _LIVE_PANELS = {"events", "agents", "cost", "memory"}
```

## Tests added (Tier 2)

`test_memory_panel_refreshes_live_when_visible` pins membership in ``_LIVE_PANELS`` so a future refactor that drops the entry fails loudly. The neighbouring ``test_refresh_live_skips_non_live_tabs_even_when_visible`` docstring is updated to drop ``memory`` from its "content-static tab" example list (= ``keys`` / ``docs`` stay; ``memory`` was the wrong category).

## Existing-test grep (per workflow lesson)

```
grep -rn "_LIVE_PANELS\|memory.*live" tests/
```

→ Found ``test_right_panel_refresh_gated.py:121`` which listed ``memory`` as a content-static tab — that docstring was wrong about memory and is updated to match the new contract.

```
grep -nE "(sticky|widget|conv|app|registry)\._[a-z]" tests/<edited>
```

→ Uses ``panel._panel_type`` and ``panel.display`` — same public-ish surface as the neighbouring tests; consistent with existing pattern. No new private-state assertions introduced by this PR.

## Test plan

- [x] ``pytest tests/cli/test_right_panel_refresh_gated.py`` — 4/4 passing (3 existing + 1 new)
- [x] Decision-flow Q1 (testing.ja.md): user-facing UX invariant ("Memory tab must reflect saves without manual tab swap") → **Tier 2**

## Related

Part of the 2026-05-18 ``/memory`` exploration wave. Companion to filed issues #191 (header refresh after /attach) and #192 (ARS / hot-list visibility — cross-layer). Other in-flight TUI-internal items follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)