### PR TITLE
fix(tui): /attach posts a system-reply confirmation

### DIFF
--- a/src/reyn/chat/slash/agents.py
+++ b/src/reyn/chat/slash/agents.py
@@ -99,6 +99,13 @@ async def attach_cmd(session: "ChatSession", args: str) -> None:
     if name == session._registry.attached_name:
         await reply(session, f"already attached to {name!r}")
         return
+    # Surface the switch in the conv pane. Without this, ``/attach``
+    # produced no in-pane feedback — the user had to run ``/agents``
+    # to confirm the switch happened. The actual attach is still
+    # driven by the ``__attach_request__`` sentinel below; this is a
+    # separate, visible breadcrumb. (The header label refresh is
+    # blocked by a separate registry-forwarder bug — see #191.)
+    await reply(session, f"attached to {name!r}")
     # Sentinel kind — see repl._input_loop for the receiver.
     await session._put_outbox(OutboxMessage(
         kind="__attach_request__", text=name,


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``/attach <name>`` previously produced no in-pane feedback when the switch succeeded — the user had to run ``/agents`` to verify. The already-attached branch already emits a ``reply()`` of ``"already attached to <name>"``; the success branch was silent.

Add a parallel ``reply()`` before the ``__attach_request__`` sentinel so successful switches log a visible ``"attached to <name>"`` line.

```diff
     if name == session._registry.attached_name:
         await reply(session, f"already attached to {name!r}")
         return
+    await reply(session, f"attached to {name!r}")
     await session._put_outbox(OutboxMessage(
         kind="__attach_request__", text=name,
     ))
```

## Note: this does NOT fix the stale header

The header status-bar label is a separate signal that remains stale due to a registry-side forwarder bug (**issue #191** — the registry consumes the ``__attach_request__`` message without forwarding it to ``repl_outbox``, so the TUI's ``_on_attach_request`` handler never fires).

This PR only fixes the in-pane confirmation gap; the header refresh remains blocked on the cross-layer fix in #191.

## Existing-test grep (per workflow lesson)

```
grep -rn "attach_cmd\|attached to" tests/
```

→ 0 hits asserting on the reply text. No regression risk.

## Test plan

- [x] Manual: ``reyn chat`` (default attached), ``/agent new beta`` first, then ``/attach beta`` → ``"attached to 'beta'"`` line appears as a system message
- [x] Manual: ``/attach default`` while default is attached → existing ``"already attached to 'default'"`` line still works (regression check)
- [x] Decision-flow Q1 (testing.ja.md): visible feedback line → **Tier 4 → no automated test** (pinning the exact wording would be a format pin per testing policy)

## Related

Part of the 2026-05-18 multi-agent exploration. Companion to filed #191 (header refresh) and merged F1 #193 (Memory tab live refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)