### PR TITLE
fix(tui): Memory tab header advertises c=copy keybinding

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -1477,7 +1477,10 @@ class RightPanel(Widget):
         if self._panel_type == "agents":
             return f"[bold {_CORAL}]Agents[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "memory":
-            return f"[bold {_CORAL}]Memory[/]  [#555555]j↓ k↑ space=open[/]"
+            return (
+                f"[bold {_CORAL}]Memory[/]"
+                f"  [#555555]j↓ k↑ space=open c=copy[/]"
+            )
         if self._panel_type == "cost":
             return f"[bold {_CORAL}]Cost[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "docs":


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``RightPanel.on_key`` handles ``c`` (= copy current view) for every tab type, but the Memory tab header hint string only listed ``j↓ k↑ space=open``. Users had no path to discover the copy key short of reading source or trying random letters.

Append ``c=copy`` to the Memory tab header, matching the disclosure pattern the Docs tab already uses (``j↓ k↑ space=open /=filter``).

## Before / After

Before: ``Memory  j↓ k↑ space=open``
After:  ``Memory  j↓ k↑ space=open c=copy``

## Existing-test grep (per workflow lesson)

```
grep -rn "j↓ k↑\|panel_header_markup\|memory.*c=copy" tests/
```

→ 0 hits asserting on the header text.

## Test plan

- [x] Manual: ``reyn chat`` → Ctrl+B → cycle to Memory → header shows ``Memory  j↓ k↑ space=open c=copy``
- [x] Decision-flow Q1 (testing.ja.md): visible hint string → **Tier 4 → no automated test** (pinning hint string would be format pin)

## Note: scope kept narrow

``c=copy`` works on every tab (Keys / Agents / Cost / Events too) but only the Memory tab was flagged in the 2026-05-18 ``/memory`` exploration. Following the CLAUDE.md "don't add features beyond what the task requires" rule, this PR only touches Memory. Other tabs' hints can follow as a separate PR if surfaced as a finding.

## Related

Part of the 2026-05-18 ``/memory`` exploration. Companion to merged F1 (#193 Memory tab live refresh) and filed #192 (ARS visibility — cross-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)