### PR TITLE
fix(tui): /agents header carries legend + column labels + compact time

### DIFF
--- a/src/reyn/chat/slash/agents.py
+++ b/src/reyn/chat/slash/agents.py
@@ -54,7 +54,16 @@ async def agents_cmd(session: "ChatSession", args: str) -> None:
         return
     attached = session._registry.attached_name
     loaded = set(session._registry.loaded_names())
-    lines = ["agents:"]
+    # Header with column labels + legend. Compact ``HH:MM`` for today's
+    # activity (vs full ``YYYY-MM-DDTHH:MM`` for older entries) keeps the
+    # column readable when most agents were active in the current session.
+    from datetime import date as _date
+
+    today = _date.today()
+    lines = [
+        "agents:  (* = attached, · = loaded, blank = not yet loaded)",
+        f"    {'name':<24} {'last_active':<17} role",
+    ]
     for n in names:
         try:
             profile = session._registry.load_profile(n)
@@ -63,10 +72,14 @@ async def agents_cmd(session: "ChatSession", args: str) -> None:
         except Exception:
             role = "(profile load failed)"
         last = session._registry.last_activity_at(n)
-        last_str = last.strftime("%Y-%m-%dT%H:%M") if last else "—"
+        if last is None:
+            last_str = "—"
+        elif last.date() == today:
+            last_str = last.strftime("%H:%M")
+        else:
+            last_str = last.strftime("%Y-%m-%d %H:%M")
         mark = "*" if n == attached else (" " if n not in loaded else "·")
         lines.append(f"  {mark} {n:<24} {last_str:<17} {role[:60]}")
-    lines.append("(* = attached, · = loaded, blank = not yet loaded)")
     await reply(session, "\n".join(lines))
 
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``/agents`` output had two readability issues:

1. The legend ``(* = attached, · = loaded, blank = not yet loaded)`` was repeated as the last line of every call — with 8+ agents it's redundant noise, and re-reading the same line at the bottom is the wrong placement (readers anchor on the header for column meaning).
2. No column header — the ``last_active`` column rendered as ``2026-05-18T14:15`` with no label to tell the reader what the ISO timestamp meant.

## Fix

- Move the legend to the first line beside the ``agents:`` banner so it reads once as a header annotation.
- Add a ``name / last_active / role`` column-label row above the entries.
- Compact ``last_active`` to ``HH:MM`` when the activity is today (= the common case in an active session) and ``YYYY-MM-DD HH:MM`` otherwise.

## Before / After

Before:
```
agents:
  * default                   2026-05-18T14:15  TUI dev role
  · alpha                     2026-05-17T09:31  experimentation
    beta                      —                 (no profile)
(* = attached, · = loaded, blank = not yet loaded)
```

After:
```
agents:  (* = attached, · = loaded, blank = not yet loaded)
    name                     last_active        role
  * default                   14:15             TUI dev role
  · alpha                     2026-05-17 09:31  experimentation
    beta                      —                 (no profile)
```

## Existing-test grep (per workflow lesson)

```
grep -rn "agents:.*attached\|last_active\|agents_cmd" tests/
```

→ 0 hits asserting on output format.

## Test plan

- [x] Manual: ``reyn chat``, ``/agents`` → header carries legend on first line, column labels on second, entries follow with compact ``HH:MM`` for today
- [x] Decision-flow Q1 (testing.ja.md): visible text format → **Tier 4 → no automated test** (pinning whitespace / exact wording would be format-pin per testing policy)

## Related

Part of the 2026-05-18 multi-agent exploration. Companion to merged O2 (#194 attach confirmation), filed #191 (header refresh — cross-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)