### PR TITLE
fix(tui): split memory tab empty-state hint into 2 short lines

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -43,8 +43,15 @@ def render_memory(
     def _render_scope(entries: list, label: str, label_color: str) -> None:
         lines.append(f"[bold {label_color}]  {_esc(label)}[/]")
         if not entries:
+            # Two short lines instead of one long one — the previous
+            # single line ``(empty — ask reyn to "remember <fact>")``
+            # (45 cells incl. indent) clipped to ``(empty — ask reyn to
+            # "re…`` at the default 33%-panel content width (~22 cells).
+            # Splitting preserves both the "empty" signal and the
+            # call-to-action and survives narrow panes.
+            lines.append("[#555555]    (empty)[/]")
             lines.append(
-                "[#555555]    (empty — ask reyn to \"remember <fact>\")[/]"
+                "[#555555]    try: \"remember <fact>\"[/]"
             )
             lines.append("")
             return


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The previous single line ``(empty — ask reyn to "remember <fact>")`` (45 cells incl. indent) clipped to ``(empty — ask reyn to "re…`` at the default 33%-panel content width (~22 cells). The "call to action" half of the hint was reliably hidden, leaving the user with only a truncated ``(empty)`` and an open quote.

## Fix

Split into two short lines:

```
(empty)
try: "remember <fact>"
```

Both fit at narrow panes; preserves the empty signal AND the actionable suggestion.

## Existing-test grep (per workflow lesson)

```
grep -rn "remember <fact>\|empty.*memory" tests/
```

→ 0 hits asserting on the hint text.

## Test plan

- [x] Manual: ``reyn chat`` on a fresh agent (no memory entries), Ctrl+B → Memory tab → both ``(empty)`` and ``try: "remember <fact>"`` visible at default 33% panel width
- [x] Decision-flow Q1 (testing.ja.md): visible hint text → **Tier 4 → no automated test** (pinning hint wording would be format pin)

## Related

Part of the 2026-05-18 ``/memory`` exploration. Companion to merged F1 (#193 live refresh), F3 (#195 c=copy hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)