### PR TITLE
fix(chat): stamp source run_id on every event so sub-skill traces don't hijack parent row (#134)

### DIFF
--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -37,14 +37,17 @@ class ChatEventForwarder:
     def on_phase_started(self, data: dict) -> None:
         phase = data.get("phase", "?")
         # No [skill_name] prefix — renderer prepends it from meta provenance.
-        self._enqueue(f"phase started: {phase}")
+        self._enqueue(f"phase started: {phase}", source_run_id=data.get("run_id"))
 
     def on_phase_completed(self, data: dict) -> None:
         phase = data.get("phase", "?")
         nxt = data.get("next", "?")
         conf = data.get("confidence")
         suffix = f"  (confidence={conf})" if conf is not None else ""
-        self._enqueue(f"{phase} → {nxt}{suffix}")
+        self._enqueue(
+            f"{phase} → {nxt}{suffix}",
+            source_run_id=data.get("run_id"),
+        )
 
     # ── Workflow terminal events (FP-0011 / FP-0012) ─────────────────────
     # FP-0011 removed skill_narrator and the `skill_done` outbox kind that
@@ -55,10 +58,10 @@ class ChatEventForwarder:
     # call finish_skill_row without changing the outbox contract.
 
     def on_workflow_finished(self, data: dict) -> None:
-        self._enqueue("skill done: finished")
+        self._enqueue("skill done: finished", source_run_id=data.get("run_id"))
 
     def on_workflow_aborted(self, data: dict) -> None:
-        self._enqueue("skill done: aborted")
+        self._enqueue("skill done: aborted", source_run_id=data.get("run_id"))
 
     # ── In-phase detail signals (skill internal progress) ────────────────────
     # Without these, the SkillActivityRow showed only the phase name
@@ -76,7 +79,7 @@ class ChatEventForwarder:
         the response arrives or the phase advances.
         """
         model = data.get("model") or "?"
-        self._enqueue(f"detail: llm: {model}")
+        self._enqueue(f"detail: llm: {model}", source_run_id=data.get("run_id"))
 
     def on_llm_response_received(self, data: dict) -> None:
         """LLM call finished — clear the detail (= we're between calls).
@@ -85,7 +88,7 @@ class ChatEventForwarder:
         after the response arrived, misleading users about whether the
         model is still working.
         """
-        self._enqueue("detail: ")
+        self._enqueue("detail: ", source_run_id=data.get("run_id"))
 
     def on_act_executed(self, data: dict) -> None:
         """Control IR ops just ran — show a short summary as detail.
@@ -97,14 +100,32 @@ class ChatEventForwarder:
         """
         op_count = data.get("op_count")
         if op_count:
-            self._enqueue(f"detail: act: {op_count} op{'s' if op_count != 1 else ''}")
+            self._enqueue(
+                f"detail: act: {op_count} op{'s' if op_count != 1 else ''}",
+                source_run_id=data.get("run_id"),
+            )
 
-    def _enqueue(self, text: str) -> None:
+    def _enqueue(self, text: str, *, source_run_id: str | None = None) -> None:
         # Fire-and-forget: trace messages are advisory, never block the skill.
+        #
+        # Issue #134 — sub-skill attribution: prefer the event's own
+        # ``run_id`` (= the skill run that actually emitted the event)
+        # over ``self.run_id`` (= the run that constructed this
+        # forwarder).  When the two differ, stamp ``parent_run_id`` so
+        # TUI consumers can render nested rows.  Falls back to the
+        # forwarder's own run_id when the event carries none (= pre-
+        # issue-#134 emit sites + non-runtime events).
+        effective_run_id = source_run_id or self.run_id
         meta: dict = {"skill_name": self.skill_name}
-        if self.run_id:
-            meta["run_id"] = self.run_id
-            meta["run_id_short"] = self.run_id[-4:]
+        if effective_run_id:
+            meta["run_id"] = effective_run_id
+            meta["run_id_short"] = effective_run_id[-4:]
+        if (
+            source_run_id is not None
+            and self.run_id is not None
+            and source_run_id != self.run_id
+        ):
+            meta["parent_run_id"] = self.run_id
         try:
             self.outbox.put_nowait(OutboxMessage(kind="trace", text=text, meta=meta))
         except asyncio.QueueFull:

--- a/src/reyn/events/events.py
+++ b/src/reyn/events/events.py
@@ -16,6 +16,7 @@ class EventLog:
         subscribers: list[Callable[[Event], None]] | None = None,
         *,
         agent_id: str | None = None,
+        run_id: str | None = None,
     ) -> None:
         self._events: list[Event] = []
         self._subscribers: list[Callable[[Event], None]] = list(subscribers or [])
@@ -23,6 +24,13 @@ class EventLog:
         # payload when set. None preserves prior behaviour for callers
         # (= tests + emit_cli_event) that don't have a session identity.
         self._agent_id = agent_id
+        # Issue #134: run_id is auto-injected into every event payload
+        # when set, mirroring the agent_id pattern. The skill run that
+        # emits the event is recorded so that subscribers (= forwarder /
+        # TUI) can distinguish events from a parent skill versus a
+        # sub-skill spawned via the ``run_skill`` op (which currently
+        # inherits the parent's subscriber list).
+        self._run_id = run_id
 
     @property
     def subscribers(self) -> list[Callable[[Event], None]]:
@@ -38,6 +46,11 @@ class EventLog:
         """
         return self._agent_id
 
+    @property
+    def run_id(self) -> str | None:
+        """The run_id this EventLog stamps onto emitted events (issue #134)."""
+        return self._run_id
+
     def add_subscriber(self, fn: Callable[[Event], None]) -> None:
         self._subscribers.append(fn)
 
@@ -49,6 +62,12 @@ class EventLog:
         # the upstream origin's identity).
         if self._agent_id and "agent_id" not in data:
             data = {**data, "agent_id": self._agent_id}
+        # Issue #134: stamp run_id with the same caller-wins convention
+        # as agent_id. Lets subscribers route events to the correct
+        # skill row when a child skill spawned via ``run_skill`` shares
+        # the parent's subscriber list.
+        if self._run_id and "run_id" not in data:
+            data = {**data, "run_id": self._run_id}
         event = Event(type=type, data=data)
         self._events.append(event)
         for sub in self._subscribers:

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -84,7 +84,7 @@ class OSRuntime:
         self._chain_id = chain_id
         self._budget_tracker = budget_tracker
         self._budget_skill_name = skill_name or skill.name
-        self.events = EventLog(subscribers=subscribers)
+        self.events = EventLog(subscribers=subscribers, run_id=run_id)
         self.workspace = Workspace(
             self.events,
             permission_resolver=permission_resolver,

--- a/tests/test_sub_skill_run_id_attribution.py
+++ b/tests/test_sub_skill_run_id_attribution.py
@@ -1,0 +1,160 @@
+"""Tier 2: sub-skill phase events carry the child's run_id (issue #134).
+
+When skill A spawns skill B via the ``run_skill`` Control IR op, B's
+OSRuntime inherits A's subscriber list (= ``op_runtime/run_skill.py``
+passes ``subscribers=ctx.subscribers`` so the chat outbox keeps receiving
+trace updates from inside the sub-skill).  Pre-fix, every event flowing
+through that shared ChatEventForwarder got stamped with the parent's
+``run_id`` because the forwarder hardcoded ``self.run_id`` into outbox
+metadata.  The TUI keyed SkillActivityRow by ``meta["run_id"]`` and
+therefore wrote B's phase names into A's row.
+
+The MVP fix pins three contracts:
+
+  1. ``EventLog(run_id=...)`` stamps ``run_id`` into every emitted
+     event's data (caller-wins convention mirrors agent_id).
+  2. ``OSRuntime`` passes its own ``run_id`` when constructing
+     ``EventLog`` so per-run identity flows with the event.
+  3. ``ChatEventForwarder._enqueue`` prefers the event's own ``run_id``
+     over the forwarder's, and stamps ``parent_run_id = self.run_id``
+     when the two differ — letting downstream consumers attribute the
+     event to the correct skill row.
+
+TUI render-side improvements (nested rows, label prefixes) are a
+separate follow-up; this test file pins the wire-level data only.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.chat.forwarder import ChatEventForwarder
+from reyn.events.events import EventLog
+from reyn.schemas.models import Event
+
+# ── 1. EventLog stamps run_id ─────────────────────────────────────────────
+
+
+def test_event_log_stamps_run_id() -> None:
+    """Tier 2: EventLog(run_id='X') auto-injects 'run_id': 'X' into emit data."""
+    log = EventLog(run_id="run-A")
+    evt = log.emit("phase_started", phase="resolve")
+    assert evt.data["run_id"] == "run-A"
+    assert evt.data["phase"] == "resolve"
+
+
+def test_event_log_caller_run_id_wins() -> None:
+    """Tier 2: caller-supplied run_id in emit() takes precedence.
+
+    Matches the existing agent_id contract — delegation flows can
+    preserve the upstream origin's identity by passing run_id explicitly.
+    """
+    log = EventLog(run_id="forwarder-run")
+    evt = log.emit("phase_started", phase="resolve", run_id="explicit-run")
+    assert evt.data["run_id"] == "explicit-run"
+
+
+def test_event_log_no_run_id_unchanged() -> None:
+    """Tier 2: when EventLog has no run_id, emit data is not augmented.
+
+    Backward-compat: every existing test that constructs EventLog
+    without ``run_id`` continues to emit without a run_id key.
+    """
+    log = EventLog()
+    evt = log.emit("phase_started", phase="resolve")
+    assert "run_id" not in evt.data
+
+
+# ── 2. ChatEventForwarder routes by event's run_id ────────────────────────
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+def test_forwarder_uses_event_run_id_when_present() -> None:
+    """Tier 2: event.data.run_id wins over forwarder's run_id (= sub-skill case).
+
+    Child skill emitting through a shared forwarder must NOT clobber
+    its identity with the parent's run_id.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("router", q, run_id="parent-run")
+    fwd(Event(type="phase_started", data={"phase": "code_review", "run_id": "child-run"}))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].meta["run_id"] == "child-run"
+    assert msgs[0].meta["run_id_short"] == "-run"
+
+
+def test_forwarder_stamps_parent_run_id_when_differs() -> None:
+    """Tier 2: when event and forwarder run_id differ, parent_run_id is set.
+
+    Issue #134 contract: TUI consumers read parent_run_id to render
+    nested rows / lineage hints.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("router", q, run_id="parent-run")
+    fwd(Event(type="phase_started", data={"phase": "p", "run_id": "child-run"}))
+    msgs = _drain(q)
+    assert msgs[0].meta["parent_run_id"] == "parent-run"
+
+
+def test_forwarder_no_parent_run_id_when_same_run() -> None:
+    """Tier 2: when event run_id == forwarder run_id, parent_run_id is omitted.
+
+    Same-run events do not need the nesting marker — only cross-run
+    events do.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="run-A")
+    fwd(Event(type="phase_started", data={"phase": "p", "run_id": "run-A"}))
+    msgs = _drain(q)
+    assert "parent_run_id" not in msgs[0].meta
+
+
+def test_forwarder_falls_back_to_self_run_id_when_event_lacks() -> None:
+    """Tier 2: events without run_id fall back to forwarder's run_id.
+
+    Backward-compat: existing test sites that emit raw events without
+    run_id continue to land on the forwarder's run_id (= prior behavior).
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="run-A")
+    fwd(Event(type="phase_started", data={"phase": "p"}))
+    msgs = _drain(q)
+    assert msgs[0].meta["run_id"] == "run-A"
+    assert "parent_run_id" not in msgs[0].meta
+
+
+def test_forwarder_act_executed_routes_by_event_run_id() -> None:
+    """Tier 2: detail-emitting handlers also honor the event's run_id.
+
+    The on_act_executed handler must thread source_run_id through
+    _enqueue so detail rows attach to the correct skill row.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("router", q, run_id="parent-run")
+    fwd(Event(
+        type="act_executed",
+        data={"op_count": 2, "run_id": "child-run"},
+    ))
+    msgs = _drain(q)
+    assert msgs[0].meta["run_id"] == "child-run"
+    assert msgs[0].meta["parent_run_id"] == "parent-run"
+
+
+def test_forwarder_workflow_finished_routes_by_event_run_id() -> None:
+    """Tier 2: workflow terminal events also honor the event's run_id.
+
+    Sub-skill completion must land on the child row, not the parent's.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("router", q, run_id="parent-run")
+    fwd(Event(type="workflow_finished", data={"run_id": "child-run"}))
+    msgs = _drain(q)
+    assert msgs[0].meta["run_id"] == "child-run"
+    assert msgs[0].meta["parent_run_id"] == "parent-run"


### PR DESCRIPTION
**[e2e-coder]** —

Closes #134.

## Summary

When skill A spawns skill B via the `run_skill` Control IR op, the TUI's SkillActivityRow for A starts displaying B's phase names — making A look like it's executing B's phases, with no visual cue that a sub-skill is running. Root cause is a 5-step chain in the issue body; this PR lands the **MVP-3 fix** the issue explicitly recommends (= steps 1–3, wire-level only). TUI render improvements (nested rows / `└─` label prefix) are a separate follow-up for tui-coder.

## What this changes

### 1. `events/events.py` — `EventLog(run_id=...)`

`EventLog` gains a `run_id` constructor kwarg, mirroring the existing `agent_id` pattern. `emit()` auto-injects it into every event's `data` with the same caller-wins convention — delegation flows can preserve the upstream origin's run_id by passing it explicitly to `emit()`.

### 2. `kernel/runtime.py` — pass `run_id` to EventLog

`OSRuntime` now constructs its `EventLog` as `EventLog(subscribers=..., run_id=run_id)` so per-run identity travels with every event the runtime emits.

### 3. `chat/forwarder.py` — route by event's own run_id

`ChatEventForwarder._enqueue` now takes an optional `source_run_id` kwarg. Each `on_*` handler reads `data.get("run_id")` and threads it through. The meta written to the outbox:

- `run_id = source_run_id or self.run_id` (= prefer the event's own identity)
- `parent_run_id = self.run_id` only when `source_run_id` differs from `self.run_id` (= cross-run marker for downstream consumers)

Backward-compat: events without `run_id` (= existing non-runtime emit sites) fall back to `self.run_id`, matching the prior behavior.

## Post-fix UX delta

Before: skill A's row shows A's phases, then suddenly shows B's phases when B is spawned, then back to A's. One row, two identities.

After: skill A's row shows A's phases. When B starts emitting events, the TUI sees `meta.run_id == B.run_id` and mounts a separate row for B. The user can now tell two skills are running side-by-side. The `parent_run_id` meta is stamped but **not yet consumed** — the TUI render follow-up will use it to render nested / indented rows.

## Test plan

- [x] **Automated — `pytest tests/test_sub_skill_run_id_attribution.py`**: 9/9 pass.
  - EventLog stamps run_id; caller-wins; None case unchanged.
  - Forwarder prefers event run_id; stamps parent_run_id only when differs; same-run path omits parent_run_id; falls back to self.run_id when event lacks one.
  - `on_act_executed` and `on_workflow_finished` also honor the event's run_id (= detail + terminal handlers route correctly).
- [x] **Adjacent — backward-compat tests**: `pytest tests/test_skill_runner_aborted_trace.py tests/cli/test_skill_in_phase_detail.py tests/cli/test_phase_completed_visible.py` → all pass. These existing tests construct events WITHOUT `run_id` in data; the fallback path keeps them stable.
- [x] **Adjacent — fixture-pinning surfaces** (per `replay-fixture-discipline` memory): `pytest tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py` → 144 passed, 1 expected xfail. No `KNOWN_STATIC_QUALIFIED_NAMES` change in this PR, so no ARS-block invalidation.
- [x] **Lint — `ruff check`**: clean.

## Out of scope (= follow-up for tui-coder)

The issue lists step 4 (TUI render):

- `chat/tui/app.py:_handle_trace_for_skill_row` reading `parent_run_id` to mount nested rows
- `chat/tui/widgets/skill_activity.py` adding indent / label_prefix support

These don't need OS-layer plumbing now that the metadata flows correctly — they're pure TUI rendering changes. Filing a follow-up issue if useful, or tui-coder can pick up directly from this PR's `parent_run_id` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)