### PR TITLE
fix(tui): add /memory slash command (list / view <name>)

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -142,6 +142,7 @@ from reyn.chat.slash import donut as _donut_mod  # noqa: E402, F401
 from reyn.chat.slash import expand as _expand_mod  # noqa: E402, F401
 from reyn.chat.slash import help as _help_mod  # noqa: E402, F401
 from reyn.chat.slash import matrix as _matrix_mod  # noqa: E402, F401
+from reyn.chat.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.chat.slash import plan as _plan_mod  # noqa: E402, F401
 from reyn.chat.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.chat.slash import skills as _skills_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/memory.py
+++ b/src/reyn/chat/slash/memory.py
@@ -1,0 +1,127 @@
+"""/memory slash command — inspect the project memory store from chat.
+
+Read-only subcommands:
+
+  /memory list                 — list every memory entry (name + type + summary)
+  /memory view <name>          — print the full body of a single entry
+
+Deletion is intentionally NOT here yet — the memory store doesn't ship
+a tested delete helper, so wiring one through a slash would mean either
+a one-off ``Path.unlink()`` (risk of leaving the index inconsistent)
+or a cross-layer change. Leaving the surface explicit so the right
+addition is owner-directed (file an issue first).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.chat.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.chat.session import ChatSession
+
+
+_USAGE = (
+    "Usage: /memory <list|view <name>>\n"
+    "  list           — every memory entry (name, type, summary)\n"
+    "  view <name>    — full body of a single entry"
+)
+
+
+def _memory_completer(
+    session: "ChatSession", arg_partial: str = "",
+) -> list[str]:
+    """Surface memory entry names after ``/memory view ``.
+
+    Reads ``memory.list_entries()`` and returns the entry slugs. Empty
+    list for ``/memory list`` or empty args (= hint mode covers those).
+    """
+    parts = arg_partial.split()
+    sub = parts[0] if parts else ""
+    if sub != "view":
+        return []
+    try:
+        from reyn.memory import list_entries
+        entries = list_entries()
+        return [e.name for e in entries]
+    except Exception:
+        return []
+
+
+@slash(
+    "memory",
+    summary="Inspect project memory entries (list / view <name>)",
+    completer=_memory_completer,
+)
+async def memory_cmd(session: "ChatSession", args: str) -> None:
+    """Dispatch ``list`` / ``view <name>`` subcommands."""
+    parts = args.strip().split(maxsplit=1)
+    if not parts:
+        await reply(session, _USAGE)
+        return
+    sub = parts[0]
+    sub_args = parts[1] if len(parts) > 1 else ""
+    if sub == "list":
+        await _list_memory(session)
+    elif sub == "view":
+        await _view_memory(session, sub_args)
+    else:
+        await reply_error(session, _USAGE)
+
+
+async def _list_memory(session: "ChatSession") -> None:
+    """Render every memory entry as one line per row.
+
+    Sorted by name (the same order ``list_entries`` returns). Type +
+    one-line description gives the reader a scannable index without
+    having to open the side panel.
+    """
+    from reyn.memory import list_entries
+
+    entries = list_entries()
+    if not entries:
+        await reply(
+            session,
+            'no memory entries yet — try: "remember <fact>"',
+        )
+        return
+    # Column widths chosen to keep the line < 80 cells at typical
+    # name / type lengths; long descriptions truncate with an ellipsis.
+    name_w = max((len(e.name) for e in entries), default=8)
+    type_w = max((len(e.type) for e in entries), default=8)
+    lines = [f"memory entries ({len(entries)}):",
+             f"  {'name':<{name_w}}  {'type':<{type_w}}  description"]
+    for e in entries:
+        desc = e.description or ""
+        if len(desc) > 60:
+            desc = desc[:59] + "…"
+        lines.append(
+            f"  {e.name:<{name_w}}  {e.type:<{type_w}}  {desc}"
+        )
+    await reply(session, "\n".join(lines))
+
+
+async def _view_memory(session: "ChatSession", name: str) -> None:
+    """Print the full body of the named entry."""
+    name = name.strip()
+    if not name:
+        await reply_error(session, "Usage: /memory view <name>")
+        return
+    from reyn.memory import find_one, list_entries
+
+    try:
+        entry = find_one(name)
+    except Exception:
+        # Fall back to exact-name match against the list so the user
+        # gets a clean "not found" instead of a stacktrace-flavoured
+        # error from the resolver.
+        all_entries = list_entries()
+        entry = next((e for e in all_entries if e.name == name), None)
+    if entry is None:
+        await reply_error(session, f"memory entry not found: {name!r}")
+        return
+    header = f"{entry.name}  [{entry.type}]"
+    if entry.description:
+        header += f"  — {entry.description}"
+    body = entry.body or "(empty body)"
+    await reply(session, f"{header}\n\n{body}")

--- a/tests/test_slash_memory.py
+++ b/tests/test_slash_memory.py
@@ -1,0 +1,84 @@
+"""Tier 2: /memory slash command surfaces memory entries from chat.
+
+Pins the new read-only command's surface contract: the registry
+includes ``/memory``, the completer returns entry names after
+``view ``, and the list / view subcommands route to handlers that
+read through ``reyn.memory.list_entries`` / ``find_one``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.slash import REGISTRY
+from reyn.chat.slash.memory import _memory_completer
+
+
+@pytest.mark.asyncio
+async def test_memory_slash_is_registered():
+    """Tier 2: ``/memory`` is in the slash registry, summary matches contract."""
+    cmd = REGISTRY.get("memory")
+    assert cmd is not None
+    assert "list" in cmd.summary.lower()
+    assert "view" in cmd.summary.lower()
+    assert cmd.completer is not None
+
+
+@pytest.mark.asyncio
+async def test_memory_completer_returns_names_after_view(tmp_path):
+    """Tier 2: ``view <partial>`` completer returns memory entry names.
+
+    Drives the completer through a real ``list_entries`` call against
+    a tmp memory dir resolved via ``memory_dir() = Path('.reyn')/'memory'``
+    relative to cwd — no monkeypatching of internal collaborators (per
+    testing.ja.md "Use real instances or the LLMReplay Fake").
+    """
+    import os
+
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "user_role.md").write_text(
+        '---\nname: user-role\ndescription: "Who you are"\n'
+        'metadata:\n  type: user\n---\n\nBody.\n',
+        encoding="utf-8",
+    )
+    (mem_dir / "tui_workflow.md").write_text(
+        '---\nname: tui-workflow\ndescription: "How tui-coder works"\n'
+        'metadata:\n  type: feedback\n---\n\nBody.\n',
+        encoding="utf-8",
+    )
+
+    class _Session:
+        agent_name = "test"
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        result = _memory_completer(_Session(), "view ")
+        assert set(result) == {"user-role", "tui-workflow"}
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.mark.asyncio
+async def test_memory_completer_returns_empty_for_list_subcommand():
+    """Tier 2: ``list`` takes no name arg — completer returns []."""
+    class _Session:
+        agent_name = "test"
+
+    assert _memory_completer(_Session(), "list") == []
+
+
+@pytest.mark.asyncio
+async def test_memory_completer_returns_empty_when_no_subcommand():
+    """Tier 2: empty arg_partial → hint mode, no completions."""
+    class _Session:
+        agent_name = "test"
+
+    assert _memory_completer(_Session(), "") == []


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Memory entries were only inspectable via the side-panel Memory tab — typing ``/memory`` in the input was unrouted (= fell through to the LLM as plain text), and ``/memory list`` / ``/memory view`` had no registered command.

Add a new read-only ``chat/slash/memory.py``:

```
/memory list           — every entry as a 1-line row (name / type / desc)
/memory view <name>    — full body of one entry
```

Plus a completer that surfaces entry names after ``view `` so the user picks from the existing memory store rather than typing slugs from recall.

## Deliberate non-scope (= filed as future work)

- **delete**: ``reyn.memory`` ships no tested delete helper; a raw ``Path.unlink()`` from the slash would leave the index inconsistent. Filing as a follow-up issue if surfaced.
- **save**: agents already write via the ``remember`` tool; a duplicate slash path needs design (slug auto-generation, type tag, etc.).

## Tests added (Tier 2)

``tests/test_slash_memory.py`` — 4 tests pinning:

- ``/memory`` is in the slash registry with the expected summary + completer wired
- ``view <partial>`` completer reads through ``list_entries()`` against a real tmp memory dir resolved via cwd/.reyn/memory (no monkeypatching of internal collaborators per testing.ja.md)
- ``list`` / no-arg branches return ``[]`` (hint-mode fallback)

## Existing-test grep (per workflow lesson)

```
grep -rn "/memory\b\|memory_cmd\|slash.memory" tests/
```

→ 0 hits — no prior assertions on a ``/memory`` slash.

```
grep -nE "(sticky|widget|conv|app|registry)\._[a-z]" tests/test_slash_memory.py
```

→ 0 hits — no private-state assertions.

## Test plan

- [x] ``pytest tests/test_slash_memory.py`` — 4/4 passing
- [x] ``pytest tests/cli/test_tui_smoke.py`` — 40/40 passing (registry expansion regression check)
- [x] Decision-flow Q1 (testing.ja.md): user-facing UX invariant ("memory is inspectable from chat") → **Tier 2**

## Related

Part of the 2026-05-18 ``/memory`` exploration. Companion to merged F1 (#193 live refresh), F3 (#195 c=copy hint), F4 (#197 empty hint wrap), and filed #192 (ARS visibility — cross-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)