### PR TITLE
fix(tui): add /agent new <name> slash to create + attach from chat

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -132,6 +132,7 @@ async def reply_error(session: "object", text: str) -> None:
 # ── trigger registration of built-in commands ─────────────────────────────
 # Sub-modules register on import; importing them here makes the registry
 # fully populated as soon as `reyn.chat.slash` is imported.
+from reyn.chat.slash import agent as _agent_mod  # noqa: E402, F401
 from reyn.chat.slash import agents as _agents_mod  # noqa: E402, F401
 from reyn.chat.slash import budget as _budget_mod  # noqa: E402, F401
 from reyn.chat.slash import chat as _chat_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/agent.py
+++ b/src/reyn/chat/slash/agent.py
@@ -1,0 +1,77 @@
+"""/agent slash command — agent lifecycle from chat (currently: create).
+
+Sub-commands (initial scope):
+  /agent new <name>          — create a new agent and attach to it
+
+Removal / rename / role-edit are intentionally NOT here yet — the
+registry's ``remove()`` exists but cascade safety (= topology
+references, in-flight tasks) deserves explicit confirmation UX that
+isn't a one-liner. Filing as follow-ups if surfaced.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.chat.session import ChatSession
+
+
+_USAGE = (
+    "Usage: /agent new <name>\n"
+    "  new <name>   — create a new agent and attach to it\n"
+    "                 (name: 1-32 chars of [a-z0-9_-], starting with [a-z0-9])"
+)
+_NO_REGISTRY = (
+    "agent registry not wired; /agent only works in `reyn chat`"
+)
+
+
+@slash("agent", summary="Create new agent (subcommands: new <name>)")
+async def agent_cmd(session: "ChatSession", args: str) -> None:
+    """Dispatch ``/agent <sub>`` subcommands."""
+    parts = args.strip().split(maxsplit=1)
+    if not parts:
+        await reply(session, _USAGE)
+        return
+    sub = parts[0]
+    sub_args = parts[1] if len(parts) > 1 else ""
+    if sub == "new":
+        await _create_agent(session, sub_args)
+    else:
+        await reply_error(session, _USAGE)
+
+
+async def _create_agent(session: "ChatSession", name: str) -> None:
+    """Create a new agent profile and attach to it.
+
+    Uses the same ``__attach_request__`` sentinel as ``/attach`` so the
+    registry's forwarder picks up the switch (until #191 lands, the
+    header label won't refresh — same constraint as /attach).
+    """
+    name = name.strip()
+    if not name:
+        await reply_error(session, "Usage: /agent new <name>")
+        return
+    if session._registry is None:
+        await reply_error(session, _NO_REGISTRY)
+        return
+    try:
+        session._registry.create(name)
+    except FileExistsError:
+        await reply_error(
+            session,
+            f"agent {name!r} already exists; use /attach {name} instead",
+        )
+        return
+    except ValueError as exc:
+        # _validate_agent_name raises with the rule embedded — surface
+        # verbatim so the user sees exactly what's wrong with the name.
+        await reply_error(session, str(exc))
+        return
+    await reply(session, f"created agent {name!r}; attaching…")
+    await session._put_outbox(OutboxMessage(
+        kind="__attach_request__", text=name,
+    ))

--- a/tests/test_slash_agent.py
+++ b/tests/test_slash_agent.py
@@ -1,0 +1,128 @@
+"""Tier 2: /agent new <name> creates an agent and triggers attach.
+
+Pins the new command's registry membership + the create-then-attach
+behaviour against a real ``AgentRegistry`` constructed on tmp_path.
+No mocking of internal collaborators (per ``testing.ja.md`` "Use real
+instances or the LLMReplay Fake").
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import REGISTRY
+
+
+class _FakeSession:
+    """Minimal session stub for the /agent flow.
+
+    Exposes only what the slash handler reads (``_registry``,
+    ``_put_outbox``). Captures emitted outbox messages so the test can
+    assert on the ``__attach_request__`` sentinel.
+    """
+
+    def __init__(self, registry) -> None:
+        self._registry = registry
+        self.outbox_calls: list[OutboxMessage] = []
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self.outbox_calls.append(msg)
+
+
+def _build_real_registry(tmp_path: Path):
+    """Construct a real ``AgentRegistry`` rooted at tmp_path."""
+    from reyn.chat.registry import AgentRegistry
+
+    # Minimal session_factory — registry.create() doesn't invoke it,
+    # it just persists the AgentProfile to disk. The factory is for
+    # later session construction which we don't exercise here.
+    def _factory(profile):
+        return object()
+
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_factory,
+        state_log=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_is_registered():
+    """Tier 2: ``/agent`` is in the slash registry, summary mentions ``new``."""
+    cmd = REGISTRY.get("agent")
+    assert cmd is not None
+    assert "new" in cmd.summary.lower()
+
+
+@pytest.mark.asyncio
+async def test_agent_new_creates_and_emits_attach_request(tmp_path):
+    """Tier 2: ``/agent new <name>`` creates the agent and emits
+    ``__attach_request__``.
+
+    Drives the slash handler through a real registry on tmp_path so the
+    create + outbox-emit chain is exercised end-to-end.
+    """
+    from reyn.chat.slash.agent import _create_agent
+
+    registry = _build_real_registry(tmp_path)
+    session = _FakeSession(registry)
+
+    await _create_agent(session, "beta")
+
+    # Profile file landed on disk via the real registry.
+    assert registry.exists("beta"), "agent profile must persist on disk"
+    # And the attach sentinel was emitted (plus a confirmation reply
+    # before it — assert at least 1 attach_request was queued).
+    kinds = [m.kind for m in session.outbox_calls]
+    assert "__attach_request__" in kinds
+    attach_msg = next(
+        m for m in session.outbox_calls if m.kind == "__attach_request__"
+    )
+    assert attach_msg.text == "beta"
+
+
+@pytest.mark.asyncio
+async def test_agent_new_rejects_duplicate(tmp_path):
+    """Tier 2: creating an existing agent surfaces a recoverable error,
+    NOT a Python stack trace."""
+    from reyn.chat.slash.agent import _create_agent
+
+    registry = _build_real_registry(tmp_path)
+    registry.create("dup")
+
+    session = _FakeSession(registry)
+    await _create_agent(session, "dup")
+
+    # No attach should have been emitted on the failure path.
+    assert all(
+        m.kind != "__attach_request__" for m in session.outbox_calls
+    )
+    # An error outbox message should have been queued.
+    error_msgs = [m for m in session.outbox_calls if m.kind == "error"]
+    assert error_msgs, f"expected an error reply; got {session.outbox_calls}"
+
+
+@pytest.mark.asyncio
+async def test_agent_new_rejects_invalid_name(tmp_path):
+    """Tier 2: invalid names (= regex violation) surface a clean error."""
+    from reyn.chat.slash.agent import _create_agent
+
+    registry = _build_real_registry(tmp_path)
+    session = _FakeSession(registry)
+
+    # Uppercase / starts-with-hyphen / too-long all fail the regex.
+    await _create_agent(session, "BAD-Name-Mixed-Case")
+
+    assert all(
+        m.kind != "__attach_request__" for m in session.outbox_calls
+    )
+    error_msgs = [m for m in session.outbox_calls if m.kind == "error"]
+    assert error_msgs


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Creating a new agent required leaving the TUI — running ``reyn agent new <name>`` in a separate shell. The error from ``/attach <unknown>`` even pointed at that CLI command. There was no in-TUI lifecycle path.

Add a new ``chat/slash/agent.py`` with one subcommand for initial scope:

```
/agent new <name>     — create the agent profile and attach to it
```

Validates the name against the same regex ``_validate_agent_name`` already enforces. Emits the same ``__attach_request__`` sentinel ``/attach`` uses, so the registry handles the switch identically.

## Caveats

- **Header label refresh after the auto-attach remains blocked on #191** (registry forwarder bug). Same constraint as ``/attach``; in-pane confirmation reply still appears.
- **Removal / rename / role-edit intentionally NOT in scope here**. ``registry.remove()`` exists but cascade safety (topology refs, in-flight tasks) deserves explicit confirmation UX rather than a one-liner. Filing as follow-ups if surfaced.

## Tests added (Tier 2)

``tests/test_slash_agent.py`` — 4 tests pinning:

- ``/agent`` registered with the expected summary
- ``new <name>`` creates the profile via a real ``AgentRegistry`` on tmp_path AND emits ``__attach_request__``
- Duplicate name produces a recoverable error reply, no attach
- Invalid name (regex violation) produces a recoverable error reply, no attach

## Existing-test grep (per workflow lesson)

```
grep -rn "/agent\b\|agent_cmd\|slash.agent\b" tests/
```

→ 0 hits — no prior ``/agent`` slash assertions.

```
grep -nE "(sticky|widget|conv|app|registry)\._[a-z]" tests/test_slash_agent.py
```

→ 0 hits — no private-state assertions on a fake.

The test uses a ``_FakeSession`` stub exposing only the public surface (``_registry``, ``_put_outbox``) the slash handler reads, and drives a REAL ``AgentRegistry`` on tmp_path — per ``testing.ja.md`` "Use real instances or the LLMReplay Fake".

## Test plan

- [x] ``pytest tests/test_slash_agent.py`` — 4/4 passing
- [x] ``pytest tests/cli/test_tui_smoke.py`` — 40/40 passing (registry expansion regression check)
- [x] Decision-flow Q1 (testing.ja.md): user-facing UX invariant ("in-TUI agent creation") → **Tier 2**

## Related

Part of the 2026-05-18 multi-agent exploration. Companion to merged O2 (#194 attach confirmation), O4 (#196 /agents header), and filed #191 (header refresh — cross-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)