### PR TITLE
feat(chat): surface compaction events to conv pane via ChatLifecycleForwarder (#162)

### DIFF
--- a/src/reyn/chat/lifecycle_forwarder.py
+++ b/src/reyn/chat/lifecycle_forwarder.py
@@ -1,0 +1,66 @@
+"""ChatLifecycleForwarder — session-scoped event subscriber for non-skill events.
+
+Sibling of :class:`reyn.chat.forwarder.ChatEventForwarder`.  Where the
+skill forwarder bridges per-skill events (``phase_*`` / ``workflow_*`` /
+``llm_*`` / ``act_executed``) into the chat outbox, this forwarder
+bridges **session-level lifecycle events** that are not tied to a
+specific skill run:
+
+  * ``compaction_completed`` (issue #162) — head/body/tail compaction
+    just replaced N early-session turns with a rolling summary. Without
+    a marker the user has no signal that pre-seq-M turns are now a
+    summarised proxy.
+
+Designed for growth — additional lifecycle handlers (attach / detach
+notifications, budget warnings, session-level errors) can land here
+without expanding the skill forwarder's per-skill contract.
+
+Wired up in :class:`reyn.chat.session.ChatSession` via
+``self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class ChatLifecycleForwarder:
+    """Callable subscriber that bridges session-level events into the outbox."""
+
+    def __init__(self, outbox: asyncio.Queue) -> None:
+        self.outbox = outbox
+
+    def __call__(self, event: Event) -> None:
+        handler = getattr(self, f"on_{event.type}", None)
+        if handler:
+            handler(event.data)
+
+    # ── Compaction (issue #162) ──────────────────────────────────────────
+
+    def on_compaction_completed(self, data: dict) -> None:
+        """Surface a ``[↑ N turns compacted]`` marker in the conv pane.
+
+        ``new_turn_count`` is the count of turns replaced by the rolling
+        summary.  Falls back to a generic marker when the field is
+        absent (= forward-compat with future event-shape variations).
+        """
+        count = data.get("new_turn_count")
+        if count:
+            text = f"[↑ {count} turn{'s' if count != 1 else ''} compacted]"
+        else:
+            text = "[↑ history compacted]"
+        self._enqueue(text)
+
+    def _enqueue(self, text: str) -> None:
+        # Fire-and-forget: lifecycle markers are advisory, never block the
+        # session loop. Uses ``kind="system"`` so the conv pane's
+        # ``_render_system_message`` path styles it as a dim marker line.
+        try:
+            self.outbox.put_nowait(OutboxMessage(kind="system", text=text))
+        except asyncio.QueueFull:
+            pass
+
+
+__all__ = ["ChatLifecycleForwarder"]

--- a/src/reyn/chat/services/compaction_controller.py
+++ b/src/reyn/chat/services/compaction_controller.py
@@ -216,9 +216,10 @@ class CompactionController:
             },
         }
 
+        new_turn_count = len(candidates)
         self._events.emit(
             "compaction_started",
-            new_turn_count=len(candidates),
+            new_turn_count=new_turn_count,
             covers_through_seq=candidates[-1].seq,
             had_previous=previous_summary is not None,
         )
@@ -240,6 +241,7 @@ class CompactionController:
         self._append_history(summary_msg)
         self._events.emit(
             "compaction_completed",
+            new_turn_count=new_turn_count,
             covers_through_seq=covers,
             section_lengths={
                 k: len(v) if isinstance(v, list) else len(str(v))

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -714,6 +714,13 @@ class ChatSession:
             subscribers=[self._event_store],
             agent_id=self._agent_id,  # FP-0016 E: auto-inject agent_id into every event
         )
+        # Issue #162: surface session-level lifecycle events (compaction
+        # today; attach/detach + budget warnings as growth) into the
+        # conv pane via OutboxMessage(kind="system"). Sibling of the
+        # per-skill ChatEventForwarder; both subscribe to event logs but
+        # at different scopes.
+        from reyn.chat.lifecycle_forwarder import ChatLifecycleForwarder
+        self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))
 
         # PR-refactor-session-1 wave 3 PR1: per-session budget adapter.
         # Absorbs total_usage / total_cost_usd / router-cap state that

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -1,0 +1,114 @@
+"""Tier 2: ChatLifecycleForwarder bridges session-level events → outbox (issue #162).
+
+When ``CompactionController`` finishes collapsing N early-session turns
+into a rolling summary, the conv pane previously showed nothing — users
+had no signal that early turns had been replaced. This forwarder is a
+session-scoped sibling of ``ChatEventForwarder`` (= per-skill) that
+pushes a ``[↑ N turns compacted]`` system marker into the outbox so the
+conversation pane's ``_render_system_message`` path can display it.
+
+Pins:
+  1. ``compaction_completed`` event → ``OutboxMessage(kind="system",
+     text="[↑ N turns compacted]")``.
+  2. Pluralisation: ``N=1`` → "1 turn", ``N>1`` → "N turns".
+  3. Missing ``new_turn_count`` falls back to a generic marker (=
+     forward-compat with event-shape variation).
+  4. Unrelated event types are dropped (= no spurious outbox writes).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.chat.lifecycle_forwarder import ChatLifecycleForwarder
+from reyn.schemas.models import Event
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+def test_compaction_completed_emits_system_marker() -> None:
+    """Tier 2: compaction_completed with new_turn_count writes [↑ N turns compacted]."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="compaction_completed",
+        data={"new_turn_count": 8, "covers_through_seq": 42},
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].kind == "system"
+    assert msgs[0].text == "[↑ 8 turns compacted]"
+
+
+def test_compaction_singular_turn_uses_singular_label() -> None:
+    """Tier 2: pluralisation — 1 turn is singular."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="compaction_completed",
+        data={"new_turn_count": 1, "covers_through_seq": 5},
+    ))
+    msgs = _drain(q)
+    assert msgs[0].text == "[↑ 1 turn compacted]"
+
+
+def test_compaction_missing_count_uses_generic_marker() -> None:
+    """Tier 2: forward-compat fallback when new_turn_count is absent.
+
+    Future event-shape variations (= compaction subtypes that don't
+    expose a turn count) still surface a marker rather than silently
+    dropping the signal.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_completed", data={}))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].text == "[↑ history compacted]"
+
+
+def test_compaction_zero_count_uses_generic_marker() -> None:
+    """Tier 2: a 0-count event is treated as missing (= no useful marker).
+
+    Prevents spurious "[↑ 0 turns compacted]" if a future emit site
+    fires with new_turn_count=0.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_completed", data={"new_turn_count": 0}))
+    msgs = _drain(q)
+    assert msgs[0].text == "[↑ history compacted]"
+
+
+def test_unrelated_event_is_dropped() -> None:
+    """Tier 2: events with no matching on_<type> handler don't write to outbox.
+
+    Lifecycle forwarder shares the EventLog subscriber slot with the
+    session's per-skill chat events — it must NOT echo phase / llm /
+    skill events into the outbox (those are the per-skill forwarder's
+    job).
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="phase_started", data={"phase": "resolve"}))
+    fwd(Event(type="llm_called", data={"model": "gemini-2.5-flash-lite"}))
+    fwd(Event(type="user_message_received", data={"text": "hi"}))
+    assert _drain(q) == []
+
+
+def test_compaction_started_is_not_surfaced() -> None:
+    """Tier 2: compaction_started doesn't emit a marker (= only completed does).
+
+    A compaction may abort mid-run; surfacing the marker on completion
+    only guarantees the user signal corresponds to a real summary
+    landing in history.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_started", data={"new_turn_count": 8}))
+    assert _drain(q) == []


### PR DESCRIPTION
**[e2e-coder]** —

Closes #162.

## Summary

When `CompactionController` replaces N early-session turns with a rolling summary, the conv pane previously showed nothing — users actively lost information about what the LLM was actually seeing (summary proxy vs original turns). The fix is cross-layer because `ChatEventForwarder` is per-skill (= constructor takes `skill_name`), but compaction is a session-level controller.

This PR lands **option (b)** from the issue body — a new `ChatLifecycleForwarder` sibling of the per-skill forwarder, scoped to session-level lifecycle events. Designed for growth: future session-level signals (attach / detach notifications, budget warnings, session-level errors) can attach handlers here without expanding the per-skill forwarder's contract.

## What this changes

### `src/reyn/chat/lifecycle_forwarder.py` (new)

`ChatLifecycleForwarder` — callable subscriber matching the `__call__` + `on_<event_type>` dispatch pattern that `ChatEventForwarder` already uses.

- `on_compaction_completed(data)` → pushes `OutboxMessage(kind="system", text="[↑ N turns compacted]")` to the outbox. Conv pane already routes `kind="system"` to `_render_system_message` (`chat/tui/widgets/conversation.py:447`), so no TUI changes needed for MVP.
- Pluralisation: `N=1` → "1 turn", `N>1` → "N turns".
- Missing or zero `new_turn_count` → generic `"[↑ history compacted]"` fallback (forward-compat with future event shape variations).
- All other event types are dropped (= the per-skill forwarder remains the only consumer for `phase_*` / `llm_*` / `act_executed`).

### `src/reyn/chat/session.py` — register subscriber

`self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))` right after the EventLog is constructed. Sibling to the per-skill forwarder wiring; no existing contract changed.

### `src/reyn/chat/services/compaction_controller.py` — additive payload

`compaction_completed` event now carries `new_turn_count` alongside the existing `covers_through_seq` and `section_lengths`. This matches the shape `compaction_started` already used. The marker only fires on the **completed** path (= guaranteed real summary in history) — the abort path emits `compaction_aborted` instead and produces no marker.

### `tests/test_chat_lifecycle_forwarder.py` (new) — 6 Tier 2 tests

Pins:
1. `compaction_completed` → `kind="system"`, exact marker text.
2. Pluralisation (1 turn vs N turns).
3. Missing `new_turn_count` → generic fallback.
4. Zero count → generic fallback (= no spurious "0 turns" marker).
5. Unrelated event types (`phase_started` / `llm_called` / `user_message_received`) are dropped — does NOT compete with the per-skill forwarder.
6. `compaction_started` is NOT surfaced (= only completion fires the marker).

## Test plan

- [x] **Automated — `pytest tests/test_chat_lifecycle_forwarder.py`**: 6/6 pass.
- [x] **Adjacent — compaction + session tests**: `pytest tests/test_compaction_controller_invariants.py tests/test_chat_compactor_postprocessor.py tests/test_sub_skill_run_id_attribution.py` — all pass (= additive `new_turn_count` field doesn't break existing assertions; previous PR #198 untouched).
- [x] **Adjacent — fixture-pinning surfaces** (per `replay-fixture-discipline` memory): `pytest tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py` → 145 passed, 1 expected xfail. No `KNOWN_STATIC_QUALIFIED_NAMES` change, so no ARS-block invalidation.
- [x] **Lint — `ruff check`**: clean on all touched files.

## Notes

- The issue's 3 directions: (a) extend per-skill forwarder — awkward fit, the forwarder is per-skill scoped; (c) direct outbox emit from CompactionController — tighter coupling, harder to extend. Picked (b) per the "room for growth" criterion.
- Dim-styling refinement (if the conv pane's `_render_system_message` default styling isn't dim enough for compaction markers) is a separate tui-coder follow-up — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)