### PR TITLE
fix(tui): agents-tab j/k cursor lands on agent-name rows

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -443,7 +443,12 @@ def render_agents(
         # Blank separator between agent blocks (matches the interleave below).
         if agent_idx > 0:
             y_counter += 1
-        # Root label of this agent's RichTree is one line.
+        # Root label of this agent's RichTree is one line. Record its y
+        # for cursor navigation BEFORE bumping y_counter past it — j/k
+        # in the panel uses item_ys / flat_items to land the cursor on
+        # selectable rows, and the agent-name row is the most natural
+        # selectable target (= "this is the agent I want to act on").
+        agent_label_y = y_counter
         y_counter += 1
         is_attached = name == attached
         in_loaded = name in loaded
@@ -480,11 +485,32 @@ def render_agents(
             status_glyph, status_text, status_style = (
                 "○ ", "idle", "#555555",
             )
+        # Apply ``reverse`` text-style on the cursor row so it stands out
+        # without adding a column-prefix shift (= the attached ``▶ ``
+        # marker already occupies column 0). Same non-color shape-cue
+        # pattern intervention chip focus uses (PR #181).
+        is_cursor = len(flat_items) == cursor
+        cursor_suffix = " reverse" if is_cursor else ""
         label = RichText()
-        label.append("▶ " if is_attached else "  ", style="#555555")
-        label.append(name, style="bold " + _CORAL if is_attached else "#dddddd")
-        label.append("  ")
-        label.append(status_glyph + status_text, style=status_style)
+        label.append(
+            "▶ " if is_attached else "  ",
+            style="#555555" + cursor_suffix,
+        )
+        label.append(
+            name,
+            style=("bold " + _CORAL if is_attached else "#dddddd") + cursor_suffix,
+        )
+        label.append("  ", style="" + cursor_suffix)
+        label.append(
+            status_glyph + status_text, style=status_style + cursor_suffix,
+        )
+        flat_items.append({
+            "kind": "agent",
+            "name": name,
+            "attached": is_attached,
+            "loaded": in_loaded,
+        })
+        item_ys.append(agent_label_y)
 
         tree = RichTree(label, guide_style="#333333")
 

--- a/tests/cli/test_agents_tab_cursor.py
+++ b/tests/cli/test_agents_tab_cursor.py
@@ -1,0 +1,88 @@
+"""Tier 2: agents-tab j/k cursor lands on agent-name rows.
+
+Previously ``flat_items`` only included running-skill / plan / recent
+rows — agent-name rows were rendered but not selectable, so j/k did
+nothing when no skills were in flight. Pin the new contract: every
+agent gets a ``{"kind": "agent"}`` entry in flat_items keyed at the
+label's y position.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_agents_tab_includes_agent_rows_in_flat_items(tmp_path):
+    """Tier 2: every agent gets a selectable row in ``flat_items``.
+
+    Drives ``render_agents`` through a real ``AgentRegistry`` on
+    tmp_path with two agents created and no skills running — the
+    failure mode the sub-agent observed was "j/k produces no cursor
+    movement at all" because the only flat_items were skill rows and
+    there were zero skills.
+    """
+    from reyn.chat.registry import AgentRegistry
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    def _factory(profile):
+        return object()
+
+    registry = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_factory,
+        state_log=None,
+    )
+    registry.create("alpha")
+    registry.create("beta")
+
+    _, flat_items, item_ys = render_agents(
+        registry, exec_state={}, cursor=0,
+    )
+
+    agent_items = [it for it in flat_items if it.get("kind") == "agent"]
+    # ``default`` is auto-created by AgentRegistry — match what the
+    # production registry actually returns rather than just the two we
+    # asked for.
+    names = {it["name"] for it in agent_items}
+    assert {"alpha", "beta"}.issubset(names), (
+        f"both newly-created agents must appear in flat_items; got {names!r}"
+    )
+    # item_ys must match flat_items length 1:1 (= the navigation
+    # contract the parent panel relies on).
+    assert len(item_ys) == len(flat_items)
+
+
+@pytest.mark.asyncio
+async def test_agents_tab_agent_item_carries_attached_loaded_flags(tmp_path):
+    """Tier 2: ``{kind:agent}`` items carry the ``attached``/``loaded`` flags
+    so a future ``Space``/``Enter`` action can route by current state."""
+    from reyn.chat.registry import AgentRegistry
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    def _factory(profile):
+        return object()
+
+    registry = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_factory,
+        state_log=None,
+    )
+    registry.create("alpha")
+    registry.create("beta")
+
+    _, flat_items, _ = render_agents(
+        registry, exec_state={}, cursor=0,
+    )
+    agent_items = [it for it in flat_items if it.get("kind") == "agent"]
+    for it in agent_items:
+        assert "attached" in it
+        assert "loaded" in it
+        assert isinstance(it["attached"], bool)
+        assert isinstance(it["loaded"], bool)


### PR DESCRIPTION
**[tui-coder]** —

## Summary

``flat_items`` previously only collected running-skill / plan / recent rows. Agent-name rows were rendered but never added, so the j/k cursor traversal had nothing to land on when no skills were in flight — pressing j/k produced **no visible cursor movement at all**.

Append a ``{"kind": "agent", "name": ..., "attached": ..., "loaded": ...}`` entry per agent before the per-agent skill / plan / recent collection, and record the row's y in ``item_ys``. The cursor visualises with a ``reverse`` text-style on the entire label — same non-color shape cue intervention chip focus uses (PR #181) — so there's no column-prefix shift competing with the existing ``▶ `` attached marker.

The flat_items entry carries ``attached`` / ``loaded`` flags so a future Space / Enter action on an agent row can route by current state without re-reading the registry.

## Before / After

Before: panel cursor `▶` never appears on any agent row, only on running-skill rows. With no skills, j/k is silent.

After: j/k cycles through every agent name; the focused row reverses video so it's clearly selected.

## Tests added (Tier 2)

``tests/cli/test_agents_tab_cursor.py`` — 2 tests pinning:

- Every agent (= newly-created + the auto-created ``default``) appears in ``flat_items`` as ``{"kind": "agent"}``
- Each ``{kind:agent}`` entry carries ``attached`` / ``loaded`` boolean flags

Drives ``render_agents`` through a real ``AgentRegistry`` on tmp_path — no mocking of internal collaborators per testing.ja.md.

## Existing-test grep (per workflow lesson)

```
grep -rn "render_agents\|flat_items\|_agents_cursor" tests/
```

→ ``test_tui_smoke.py:793-800`` uses ``flat_items = [{"kind": "x"}, {"kind": "y"}]`` as a fake — just checks cursor index math, not the items' contents. Test passes against my change (= cursor index logic untouched).

```
grep -nE "(sticky|widget|conv|app|registry)\._[a-z]" tests/cli/test_agents_tab_cursor.py
```

→ 0 hits — uses the public ``render_agents`` API directly.

## Test plan

- [x] ``pytest tests/cli/test_agents_tab_cursor.py`` — 2/2 passing
- [x] ``pytest tests/cli/test_tui_smoke.py`` — 40/40 passing (no regression on cursor math)
- [x] Decision-flow Q1 (testing.ja.md): user-facing UX invariant ("j/k must land on agent rows") → **Tier 2**

## Related

Final piece of the 2026-05-18 multi-agent exploration. Companion to merged O2 (#194 attach confirmation), O4 (#196 /agents header), O3 (#200 /agent new), and filed #191 (header refresh — cross-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)