### PR TITLE
feat(chat): structured prompt + detail in intervention announce (#163)

### DIFF
--- a/src/reyn/chat/services/intervention_handler.py
+++ b/src/reyn/chat/services/intervention_handler.py
@@ -45,8 +45,20 @@ def _iv_meta(iv: UserIntervention) -> dict:
     Mirrors the module-level helper in session.py (kept in sync).
     Includes structured choice data so TUI renderers can build chip buttons
     without re-parsing the formatted text string.
+
+    Issue #163 — adds ``prompt`` and ``detail`` as structured fields so
+    the TUI widget can render visual hierarchy (= amber-bold prompt + dim
+    detail) instead of one bold amber blob.  ``OutboxMessage.text`` stays
+    a concatenated string for backward-compat (CLI Panel renderer / log
+    fallback consume it unchanged).
     """
-    out: dict = {"intervention_id": iv.id, "intervention_kind": iv.kind}
+    out: dict = {
+        "intervention_id": iv.id,
+        "intervention_kind": iv.kind,
+        "prompt": iv.prompt,
+    }
+    if iv.detail:
+        out["detail"] = iv.detail
     if iv.run_id:
         out["run_id"] = iv.run_id
         out["run_id_short"] = iv.run_id[-4:] if iv.run_id else ""

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -330,8 +330,18 @@ def _iv_meta(iv: "UserIntervention") -> dict:
 
     Includes structured choice data so TUI renderers can build chip buttons
     without re-parsing the formatted text string.
+
+    Issue #163 — adds ``prompt`` and ``detail`` as structured fields so
+    the TUI widget can render visual hierarchy (kept in sync with the
+    sibling helper in ``services/intervention_handler.py``).
     """
-    out = {"intervention_id": iv.id, "intervention_kind": iv.kind}
+    out: dict = {
+        "intervention_id": iv.id,
+        "intervention_kind": iv.kind,
+        "prompt": iv.prompt,
+    }
+    if iv.detail:
+        out["detail"] = iv.detail
     if iv.run_id:
         out["run_id"] = iv.run_id
         out["run_id_short"] = _run_short(iv.run_id)

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -258,6 +258,7 @@ class ReynTUIApp(App):
         iv_id: str,
         choices: list[tuple[str, str] | dict] | None = None,
         queued_extra: int = 0,
+        detail: str | None = None,
     ) -> None:
         """Mount an InterventionWidget inline in the conversation view.
 
@@ -285,6 +286,7 @@ class ReynTUIApp(App):
             answer_callback=_callback,
             iv_id=iv_id,
             queued_extra=queued_extra,
+            detail=detail,
         )
 
     def set_title_state(self, state: str | None) -> None:

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -456,8 +456,22 @@ class OutboxRouter:
                 queued_extra = max(0, registry.queued_count() - 1)
         except Exception:
             queued_extra = 0
+        # Issue #163: prefer the structured ``prompt`` from meta over the
+        # concatenated ``msg.text`` so the widget renders just the
+        # question (= "Permission request — web.fetch") without the
+        # bolted-on detail / choices lines. ``meta.detail`` is forwarded
+        # as a separate Label with italic-muted styling.  Old emit sites
+        # that don't set meta.prompt fall back to msg.text — backward-
+        # compat for the CLI Panel path and any legacy producers.
+        question_text = str(msg.meta.get("prompt") or msg.text)
+        detail_text = msg.meta.get("detail")
         self._app._mount_intervention(
-            conv, msg.text, iv_id, choices, queued_extra=queued_extra,
+            conv,
+            question_text,
+            iv_id,
+            choices,
+            queued_extra=queued_extra,
+            detail=str(detail_text) if detail_text else None,
         )
         # Persistent "blocked on user" indicator. The InterventionWidget is
         # mounted inline and can scroll off-screen in a long session; the

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -804,6 +804,7 @@ class ConversationView(Widget):
         answer_callback=None,
         iv_id: str = "",
         queued_extra: int = 0,
+        detail: str | None = None,
     ) -> InterventionWidget:
         self._consume_empty_hint()
         # The run is now blocked on the user's answer; "thinking…" is no
@@ -815,6 +816,7 @@ class ConversationView(Widget):
             answer_callback=answer_callback,
             iv_id=iv_id,
             queued_extra=queued_extra,
+            detail=detail,
         )
         self.mount(widget)
         # Only yank the user down to the new widget when they were

--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -93,6 +93,17 @@ class InterventionWidget(Widget):
         height: auto;
         width: 1fr;
     }
+    InterventionWidget Label.iv-detail {
+        /* Issue #163: detail is secondary copy beneath the prompt.
+           #aaaaaa on #1e1510 is ~6.3:1 (passes WCAG AA for body text).
+           Italic + slightly muted color separates the "what is being
+           asked" header from the "what specific resource" detail. */
+        color: #aaaaaa;
+        text-style: italic;
+        padding-bottom: 1;
+        height: auto;
+        width: 1fr;
+    }
     """
 
     class Answered(Message):
@@ -110,10 +121,16 @@ class InterventionWidget(Widget):
         answer_callback: Callable[[str], Awaitable[None]] | None = None,
         iv_id: str = "",
         queued_extra: int = 0,
+        detail: str | None = None,
         id: str | None = None,
     ) -> None:
         super().__init__(id=id or f"iv_{iv_id[:8]}")
         self._question = question
+        # Issue #163: detail is the secondary line (= "web fetch: <url>")
+        # rendered with the ``iv-detail`` CSS class beneath the prompt.
+        # None / empty skips the Label entirely so old callers that
+        # don't supply detail keep the prior single-line layout.
+        self._detail = detail
         # Normalise both legacy 2-tuples and richer dict shapes into a single
         # internal list-of-dicts so compose() / hotkey lookup stays uniform.
         self._choices: list[dict[str, Any]] = [
@@ -174,6 +191,14 @@ class InterventionWidget(Widget):
         yield Label(
             f"  {self._question}", classes="iv-question", markup=False,
         )
+        if self._detail:
+            # Issue #163: render detail as a separate Label with the
+            # ``iv-detail`` class (italic + muted color) so the user can
+            # visually parse "what is being asked" vs "what specific
+            # resource is involved".
+            yield Label(
+                f"  {self._detail}", classes="iv-detail", markup=False,
+            )
         if self._queued_extra > 0:
             yield Label(
                 f"  +{self._queued_extra} more pending",

--- a/tests/test_intervention_prompt_hierarchy.py
+++ b/tests/test_intervention_prompt_hierarchy.py
@@ -1,0 +1,222 @@
+"""Tier 2: intervention announce surfaces prompt + detail structurally (issue #163).
+
+Pre-fix, ``intervention_handler.announce`` concatenated ``prompt +
+detail + choices_labels`` into one ``msg.text`` string, and the TUI
+widget rendered the whole blob as a single bold-amber Label. Detail
+(e.g. ``web fetch: <url>``) and the choices hint line were visually
+indistinguishable from the prompt header, undermining the "make a quick
+approve/deny decision" UX permission prompts are supposed to enable.
+
+Fix contract:
+  1. ``OutboxMessage.meta`` carries ``prompt`` (= just the prompt
+     header) and ``detail`` (= when present) as structured fields.
+     ``msg.text`` keeps the concatenated string for backward-compat
+     (CLI Panel renderer + log fallback consume it unchanged).
+  2. ``InterventionWidget`` accepts a ``detail`` constructor kwarg and
+     renders it as a separate Label with the ``iv-detail`` CSS class
+     (italic, muted) beneath the prompt header.
+
+Tier 2 tests use the real ``InterventionHandler.announce`` against a
+real outbox queue and inspect the produced ``OutboxMessage`` shape.
+Widget rendering is exercised through ``InterventionWidget.__init__``
+state (= ``_detail`` attribute) rather than a full Textual app harness,
+which is out of Tier 2 scope.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.widgets.intervention import InterventionWidget
+from reyn.user_intervention import UserIntervention
+
+
+def _drain(q: asyncio.Queue) -> list[OutboxMessage]:
+    items: list[OutboxMessage] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+async def _announce(iv: UserIntervention) -> OutboxMessage:
+    """Run InterventionHandler.announce against a real outbox + return the msg."""
+    from reyn.chat.services.intervention_handler import InterventionHandler
+
+    q: asyncio.Queue = asyncio.Queue()
+
+    async def put(msg: OutboxMessage) -> None:
+        await q.put(msg)
+
+    handler = InterventionHandler(
+        intervention_registry=None,  # not exercised by announce()
+        journal=None,                # not exercised by announce()
+        event_log=None,               # not exercised by announce()
+        put_outbox=put,
+        append_history=lambda *_a, **_k: None,
+    )
+    await handler.announce(iv)
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    return msgs[0]
+
+
+# ── 1. announce surfaces prompt + detail in meta ───────────────────────────
+
+
+def test_announce_carries_prompt_in_meta() -> None:
+    """Tier 2: meta.prompt is just the prompt string (= no detail / choices)."""
+    iv = UserIntervention(
+        id="iv1",
+        kind="permission_request",
+        prompt="Permission request — web.fetch",
+        detail="web fetch: https://example.com",
+    )
+    msg = asyncio.run(_announce(iv))
+    assert msg.meta["prompt"] == "Permission request — web.fetch"
+
+
+def test_announce_carries_detail_in_meta() -> None:
+    """Tier 2: meta.detail carries the resource line when present."""
+    iv = UserIntervention(
+        id="iv1",
+        kind="permission_request",
+        prompt="Permission request — web.fetch",
+        detail="web fetch: https://example.com",
+    )
+    msg = asyncio.run(_announce(iv))
+    assert msg.meta["detail"] == "web fetch: https://example.com"
+
+
+def test_announce_omits_detail_when_absent() -> None:
+    """Tier 2: missing detail → meta.detail key is absent (= clean payload)."""
+    iv = UserIntervention(
+        id="iv1",
+        kind="permission_request",
+        prompt="Permission request — web.fetch",
+    )
+    msg = asyncio.run(_announce(iv))
+    assert "detail" not in msg.meta
+
+
+def test_announce_keeps_msg_text_concatenated_for_backward_compat() -> None:
+    """Tier 2: msg.text still contains prompt + detail + choices.
+
+    CLI Panel renderer and the log fallback consume msg.text and have
+    no awareness of meta.detail. Keeping the concatenated form means
+    those paths render unchanged after the fix.
+    """
+    iv = UserIntervention(
+        id="iv1",
+        kind="permission_request",
+        prompt="Permission request — web.fetch",
+        detail="web fetch: https://example.com",
+    )
+    msg = asyncio.run(_announce(iv))
+    assert "Permission request — web.fetch" in msg.text
+    assert "web fetch: https://example.com" in msg.text
+
+
+def test_announce_ask_user_prefixes_question_label() -> None:
+    """Tier 2: ask_user kind prefixes msg.text with 'Question: '.
+
+    meta.prompt holds the bare prompt — the 'Question: ' prefix is a
+    msg.text formatting concern only.
+    """
+    iv = UserIntervention(
+        id="iv1",
+        kind="ask_user",
+        prompt="What's your timezone?",
+    )
+    msg = asyncio.run(_announce(iv))
+    assert msg.text.startswith("Question: What's your timezone?")
+    # meta.prompt is the bare value — the prefix is text-formatting only.
+    assert msg.meta["prompt"] == "What's your timezone?"
+
+
+# ── 2. InterventionWidget renders detail as a separate Label ───────────────
+
+
+def test_widget_accepts_detail_kwarg() -> None:
+    """Tier 2: InterventionWidget(detail=...) stores it on _detail."""
+    widget = InterventionWidget(
+        question="Permission request — web.fetch",
+        detail="web fetch: https://example.com",
+        iv_id="iv1",
+    )
+    assert widget._detail == "web fetch: https://example.com"
+
+
+def test_widget_detail_defaults_to_none() -> None:
+    """Tier 2: no detail kwarg → _detail is None (= no extra Label).
+
+    Backward-compat for the (legacy) callers that don't supply detail
+    yet — the widget compose() path skips the iv-detail Label when None.
+    """
+    widget = InterventionWidget(question="hello", iv_id="iv1")
+    assert widget._detail is None
+
+
+# ── 3. app-level mount path threads detail through ────────────────────────
+
+
+def test_conversation_mount_intervention_accepts_detail() -> None:
+    """Tier 2: ConversationView.mount_intervention propagates detail kwarg.
+
+    Inspecting the function signature is sufficient — actual widget
+    mounting requires a Textual app harness.
+    """
+    import inspect
+
+    from reyn.chat.tui.widgets.conversation import ConversationView
+    sig = inspect.signature(ConversationView.mount_intervention)
+    assert "detail" in sig.parameters
+    # Must be a keyword-only parameter with default None to avoid
+    # breaking callers that don't pass it.
+    param = sig.parameters["detail"]
+    assert param.default is None
+
+
+def test_app_mount_intervention_accepts_detail() -> None:
+    """Tier 2: ReynTUIApp._mount_intervention takes a detail kwarg.
+
+    Same shape check as conversation — pins that the mount chain is
+    fully threaded so app_outbox can forward meta.detail.
+    """
+    import inspect
+
+    from reyn.chat.tui.app import ReynTUIApp
+    sig = inspect.signature(ReynTUIApp._mount_intervention)
+    assert "detail" in sig.parameters
+    param = sig.parameters["detail"]
+    assert param.default is None
+
+
+# ── 4. _iv_meta helpers stay in sync across modules ───────────────────────
+
+
+def test_iv_meta_helpers_emit_same_keys() -> None:
+    """Tier 2: both _iv_meta helpers (session.py + intervention_handler.py)
+    produce identical meta shape for the same intervention.
+
+    The two helpers exist as mirror copies (see docstrings); a drift
+    here means OutboxMessage.meta from the two emit sites disagree and
+    TUI consumers see inconsistent payloads.
+    """
+    from reyn.chat.services.intervention_handler import _iv_meta as handler_meta
+    from reyn.chat.session import _iv_meta as session_meta
+
+    iv = UserIntervention(
+        id="iv1",
+        kind="permission_request",
+        prompt="Permission request — web.fetch",
+        detail="web fetch: https://example.com",
+        run_id="r-abc-1234",
+        skill_name="web_fetch",
+    )
+    a = handler_meta(iv)
+    b = session_meta(iv)
+    assert a == b
+    # Spot-check the new fields land in both:
+    assert a["prompt"] == "Permission request — web.fetch"
+    assert a["detail"] == "web fetch: https://example.com"


### PR DESCRIPTION
**[e2e-coder]** —

Closes #163.

## Summary

Pre-fix, `intervention_handler.announce` concatenated `prompt + detail + choices_labels` into one `msg.text` string, and the TUI widget rendered the whole blob as a single bold-amber Label. The detail (e.g. `web fetch: <url>`) and the choices-hint line were visually indistinguishable from the prompt header — undermining the "quick approve/deny decision" UX that permission prompts are supposed to enable.

This PR adds **structured fields** to `OutboxMessage.meta` so the TUI widget can render visual hierarchy. Combines the two directions in the issue body:

- **(a)** Pass `detail` (and the bare `prompt`) in `meta` so the widget receives structured data and can render with distinct styles.
- **(b)** Chips remain the canonical source for choices — the widget no longer needs the redundant choices-hint line.

## What this changes

### `chat/services/intervention_handler.py` + `chat/session.py` — meta payload

Both mirror copies of `_iv_meta` updated in lockstep:

```python
out: dict = {
    "intervention_id": iv.id,
    "intervention_kind": iv.kind,
    "prompt": iv.prompt,           # NEW
}
if iv.detail:
    out["detail"] = iv.detail      # NEW
# … (existing run_id / skill_name / choices / suggestions)
```

`msg.text` keeps the concatenated form (prompt + detail + choices) so the CLI Panel renderer and the `_format_intervention_line` log fallback consume it **unchanged**.

### `chat/tui/widgets/intervention.py` — widget renders detail separately

- New `detail: str | None = None` constructor kwarg, stored on `_detail`.
- New CSS class `iv-detail` with italic + muted color (`#aaaaaa` on `#1e1510` ≈ 6.3:1, passes WCAG AA for body text).
- `compose()` yields a second `Label` for detail when present — between the question header and the queued-count badge.

### Mount chain threading

- `ConversationView.mount_intervention(..., detail=None)` propagates detail to the widget.
- `ReynTUIApp._mount_intervention(..., detail=None)` accepts the kwarg and forwards.
- `chat/tui/app_outbox.py` reads `msg.meta.get("prompt")` (= bare prompt header) and `msg.meta.get("detail")` (= secondary line) and passes them through. Falls back to `msg.text` when `meta.prompt` is absent (= backward-compat for legacy emit sites).

### Tests — `tests/test_intervention_prompt_hierarchy.py`

10 Tier 2 tests:

1. `announce` carries `prompt` in meta (bare value, no prefix).
2. `announce` carries `detail` in meta when present.
3. `announce` omits `detail` key when absent (= clean payload).
4. `msg.text` keeps concatenated form for backward-compat.
5. `ask_user` kind prefixes `msg.text` with "Question: " but `meta.prompt` is bare.
6. `InterventionWidget` accepts `detail` kwarg → stored on `_detail`.
7. `InterventionWidget` `_detail` defaults to None when kwarg omitted.
8. `ConversationView.mount_intervention` signature has `detail` kwarg.
9. `ReynTUIApp._mount_intervention` signature has `detail` kwarg.
10. Both `_iv_meta` mirror copies produce identical output (= drift guard).

## Test plan

- [x] **Automated — `pytest tests/test_intervention_prompt_hierarchy.py`**: 10/10 pass.
- [x] **Adjacent — intervention + session tests**: `pytest tests/test_intervention_handler_invariants.py tests/test_session_intervention_persistence.py` — all pass (= `_iv_meta` additive change doesn't break existing assertions).
- [x] **Adjacent — fixture-pinning surfaces** (per `replay-fixture-discipline` memory): `pytest tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py` → 137 passed, 1 expected xfail. No `KNOWN_STATIC_QUALIFIED_NAMES` change.
- [x] **Lint — `ruff check`**: clean on all 6 touched + 1 new file.

## Notes

- The widget-mount integration (= verifying the dim-italic detail Label actually renders in a Textual harness) is out of Tier 2 scope per testing.ja.md — Tier 2 verifies signatures and state attributes; full render verification belongs to manual TUI smoke or a Tier 3 harness if one exists.
- No new dependencies; no changes to the choices payload shape (chips remain unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)