### PR TITLE
fix(op_runtime/run_skill): resolve `<name>/skill.md` reference shape via stdlib paths

### DIFF
--- a/src/reyn/op_runtime/run_skill.py
+++ b/src/reyn/op_runtime/run_skill.py
@@ -14,6 +14,52 @@ from .context import OpContext
 _log = logging.getLogger(__name__)
 
 
+def _resolve_skill_ref(skill_ref: str) -> tuple[str, Path, str | None]:
+    """Resolve a sub-skill reference to ``(skill_md_path, path_for_hash, skill_root)``.
+
+    Accepts three reference shapes on the ``op.skill`` field:
+
+    1. **Bare name** — e.g. ``"direct_llm"``. Resolved via
+       ``resolve_skill_path`` search order (reyn/local → reyn/project →
+       stdlib/skills).
+    2. **Short ``<name>/skill.md``** — e.g. ``"direct_llm/skill.md"``.
+       B41-NF-S7-1: eval router LLMs construct this shape when describing a
+       stdlib skill (= ``target_skill_path`` field name implies a path so the
+       LLM appends ``/skill.md`` to the bare name). Without this fallback every
+       such invocation hits ``FileNotFoundError`` relative to CWD. Resolved
+       by stripping the trailing ``/skill.md`` and applying
+       ``resolve_skill_path`` to the leading segment; on resolution miss the
+       literal-path interpretation is preserved for pre-B41 callers who
+       genuinely pass a 2-segment relative path.
+    3. **Multi-segment literal path** — e.g.
+       ``"reyn/local/my_app/skill.md"``. Passed through to
+       ``load_dsl_skill`` as written.
+    """
+    from reyn.skill.skill_paths import resolve_skill_path
+
+    parts = skill_ref.split("/")
+    if "/" not in skill_ref and not skill_ref.endswith(".md"):
+        # form 1
+        skill_dir, inferred_root = resolve_skill_path(skill_ref)
+        skill_md_path = str(skill_dir / "skill.md")
+        path_for_hash = skill_dir / "skill.md"
+        skill_root = str(inferred_root) if inferred_root else None
+        return skill_md_path, path_for_hash, skill_root
+    if len(parts) == 2 and parts[1] == "skill.md" and parts[0]:
+        # form 2: ``<name>/skill.md`` — try stdlib resolution by the
+        # leading segment first.
+        try:
+            skill_dir, inferred_root = resolve_skill_path(parts[0])
+            skill_md_path = str(skill_dir / "skill.md")
+            path_for_hash = skill_dir / "skill.md"
+            skill_root = str(inferred_root) if inferred_root else None
+            return skill_md_path, path_for_hash, skill_root
+        except FileNotFoundError:
+            pass  # fall through to form 3 literal-path interpretation
+    # form 3
+    return skill_ref, Path(skill_ref), None
+
+
 def _compute_skill_hash(skill_path: Path) -> str:
     """Return the sha256 hex digest of a skill.md file's raw bytes.
 
@@ -33,7 +79,6 @@ def _compute_skill_hash(skill_path: Path) -> str:
 
 async def handle(op: RunSkillIROp, ctx: OpContext, caller: Literal["preprocessor", "control_ir"]) -> dict:
     from reyn.compiler import load_dsl_skill
-    from reyn.skill.skill_paths import resolve_skill_path
     from reyn.skill.sub_skill_runner import invoke_sub_skill
 
     # Resolve sub-skill: prefer preloaded preprocessor sub-skills (set up at compile time)
@@ -44,16 +89,7 @@ async def handle(op: RunSkillIROp, ctx: OpContext, caller: Literal["preprocessor
 
     skill_md_path_for_hash: Path | None = None
     if sub_skill is None:
-        skill_ref = op.skill
-        if "/" not in skill_ref and not skill_ref.endswith(".md"):
-            skill_dir, inferred_root = resolve_skill_path(skill_ref)
-            skill_md_path = str(skill_dir / "skill.md")
-            skill_md_path_for_hash = skill_dir / "skill.md"
-            skill_root = str(inferred_root) if inferred_root else None
-        else:
-            skill_md_path = skill_ref
-            skill_md_path_for_hash = Path(skill_ref)
-            skill_root = None
+        skill_md_path, skill_md_path_for_hash, skill_root = _resolve_skill_ref(op.skill)
         sub_skill = load_dsl_skill(skill_md_path, skill_root=skill_root)
     else:
         # Pre-loaded preprocessor sub-skill: derive path from the skill spec if

--- a/src/reyn/stdlib/skills/eval/artifacts/eval_case_input.yaml
+++ b/src/reyn/stdlib/skills/eval/artifacts/eval_case_input.yaml
@@ -14,7 +14,12 @@ schema:
       description: Path to the eval.md spec file (for reference in the output).
     target_skill_path:
       type: string
-      description: Path to the target skill's skill.md file.
+      description: |
+        Reference to the target skill. Three accepted forms:
+        - bare skill name: "direct_llm" (resolves via reyn/local → reyn/project → stdlib/skills)
+        - short qualified: "direct_llm/skill.md" (same resolution applied to the leading segment)
+        - explicit relative path: "reyn/local/my_app/skill.md" (passed through as-is)
+        Prefer the bare name for stdlib skills.
     skill_root:
       type: string
       description: Skill-tree root to use when loading the target skill. Defaults to the skill's parent directory.

--- a/tests/test_run_skill_ref_resolution.py
+++ b/tests/test_run_skill_ref_resolution.py
@@ -1,0 +1,138 @@
+"""Tier 2: run_skill op `op.skill` reference resolution (B41-NF-S7-1 fix).
+
+Pinned invariants:
+
+- Bare skill name resolves via ``resolve_skill_path`` search order
+  (reyn/local → reyn/project → stdlib/skills). [pre-existing behavior]
+- Short ``<name>/skill.md`` reference resolves the leading segment via the
+  same search order. [B41 fix — eval router LLMs construct this shape when
+  describing a stdlib skill via the ``target_skill_path`` field name; the
+  pre-fix runtime treated it as a CWD-relative literal and failed.]
+- Multi-segment literal paths (e.g. ``reyn/local/my_app/skill.md``) pass
+  through unchanged. [pre-existing behavior]
+- Unknown leading segment in ``<name>/skill.md`` falls through to literal
+  path interpretation (= preserves any pre-B41 caller that genuinely passes
+  a 2-segment relative path that happens to look like the new shape).
+
+Reference: B41-NF-S7-1 retrospective + W2-S7 patch-isolation evidence.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.op_runtime.run_skill import _resolve_skill_ref
+from reyn.skill.skill_paths import SkillNotFoundError, stdlib_root
+
+# ---------------------------------------------------------------------------
+# Form 1: bare skill name (pre-existing behavior, regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_skill_name_resolves_via_stdlib():
+    """Tier 2: bare name like 'direct_llm' resolves to stdlib skill dir."""
+    skill_md_path, path_for_hash, skill_root = _resolve_skill_ref("direct_llm")
+
+    sl = stdlib_root()
+    expected_dir = sl / "skills" / "direct_llm"
+    assert skill_md_path == str(expected_dir / "skill.md")
+    assert path_for_hash == expected_dir / "skill.md"
+    assert skill_root == str(sl)
+
+
+def test_unknown_bare_skill_name_raises():
+    """Tier 2: bare name that doesn't exist anywhere raises SkillNotFoundError."""
+    with pytest.raises(SkillNotFoundError):
+        _resolve_skill_ref("definitely_does_not_exist_xyz")
+
+
+# ---------------------------------------------------------------------------
+# Form 2: short <name>/skill.md (B41 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_short_name_with_skill_md_resolves_via_stdlib():
+    """Tier 2 (B41-NF-S7-1): '<stdlib_name>/skill.md' resolves leading segment.
+
+    The eval router LLM constructs paths like 'direct_llm/skill.md' when
+    the target_skill_path field name implies a path is expected. Pre-B41,
+    this triggered a CWD-relative FileNotFoundError. Post-fix, the leading
+    segment is resolved via stdlib paths.
+    """
+    skill_md_path, path_for_hash, skill_root = _resolve_skill_ref("direct_llm/skill.md")
+
+    sl = stdlib_root()
+    expected_dir = sl / "skills" / "direct_llm"
+    assert skill_md_path == str(expected_dir / "skill.md")
+    assert path_for_hash == expected_dir / "skill.md"
+    assert skill_root == str(sl)
+
+
+def test_short_name_with_skill_md_falls_through_when_unknown(tmp_path: Path, monkeypatch):
+    """Tier 2: '<unknown_name>/skill.md' falls through to literal path interpretation.
+
+    Preserves any pre-B41 caller that genuinely passed a 2-segment relative
+    path whose leading segment happens not to resolve via the stdlib search
+    order. The caller's literal-path interpretation is then attempted by
+    ``load_dsl_skill`` (not exercised by this unit) and will surface a
+    FileNotFoundError if the literal path also doesn't exist.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    skill_md_path, path_for_hash, skill_root = _resolve_skill_ref("not_a_skill/skill.md")
+
+    assert skill_md_path == "not_a_skill/skill.md"
+    assert path_for_hash == Path("not_a_skill/skill.md")
+    assert skill_root is None
+
+
+# ---------------------------------------------------------------------------
+# Form 3: multi-segment literal path (pre-existing behavior, regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_multi_segment_literal_path_passes_through():
+    """Tier 2: 'reyn/local/my_app/skill.md' passes through unchanged.
+
+    Pre-existing behavior for explicit paths that traverse the reyn tree.
+    The literal path is passed to load_dsl_skill which validates existence
+    at load time.
+    """
+    ref = "reyn/local/my_app/skill.md"
+    skill_md_path, path_for_hash, skill_root = _resolve_skill_ref(ref)
+
+    assert skill_md_path == ref
+    assert path_for_hash == Path(ref)
+    assert skill_root is None
+
+
+def test_three_segment_path_treated_as_literal():
+    """Tier 2: paths with 3+ segments are NOT subject to form-2 fallback.
+
+    Only ``<name>/skill.md`` (exactly 2 segments) is recognized as the
+    LLM-friendly short form. Longer paths are treated as explicit literals
+    so resolution behavior remains deterministic for callers that pass
+    workspace-relative paths.
+    """
+    ref = "some/nested/dir/skill.md"
+    skill_md_path, path_for_hash, skill_root = _resolve_skill_ref(ref)
+
+    assert skill_md_path == ref
+    assert path_for_hash == Path(ref)
+    assert skill_root is None
+
+
+def test_path_ending_skill_md_but_not_two_segments():
+    """Tier 2: 'skill.md' alone (no slash) is treated as a literal path.
+
+    Although ``skill_ref.endswith('.md')`` is True, the bare ``skill.md``
+    string has no leading skill-name segment, so it cannot resolve via
+    stdlib. The literal-path branch handles it (and ``load_dsl_skill``
+    will fail with FileNotFoundError if no such file exists in CWD).
+    """
+    ref = "skill.md"
+    skill_md_path, path_for_hash, skill_root = _resolve_skill_ref(ref)
+
+    assert skill_md_path == ref
+    assert skill_root is None


### PR DESCRIPTION
**[dogfood-coder]** — fix B41-NF-S7-1 (HIGH): eval `run_skill` cannot resolve relative skill paths.

## Problem (= B41 W2-S7 finding)

B41 retest 中、 W2-S7 (eval_run_direct_llm scenario) で routing は B40 v2 fix で正常に `skill__eval` に到達するようになったが、 内部 `run_skill` op が **target_skill_path = "direct_llm/skill.md"** を CWD-relative literal path として扱い `FileNotFoundError` で fail。

LLM が `target_skill_path` field name の意味から path 形式を期待して、 bare skill name `direct_llm` の代わりに `direct_llm/skill.md` を construct する pattern。 stdlib skill 解決 fallback がないため、 CWD に該当ファイルなし → fail。

Pre-existing latent bug (= patch-isolated B40 v2 revert simulate でも routing は同じ → eval は B40 v2 が「正しく到達」 させただけ、 path resolution gap は B40 v2 と無関係)。

## Fix

`src/reyn/op_runtime/run_skill.py` の resolution logic を pure helper `_resolve_skill_ref()` に refactor + 3 forms 受容:

1. **Bare name** (= `"direct_llm"`) — `resolve_skill_path` search order (pre-existing)
2. **Short `<name>/skill.md`** (= `"direct_llm/skill.md"`) — **NEW**: 先頭 segment を stdlib resolution で解決、 fail 時のみ literal-path interpretation に fallback (= pre-B41 caller の 2-segment relative path 互換維持)
3. **Multi-segment literal path** (= `"reyn/local/my_app/skill.md"`) — pass-through (pre-existing)

加えて `src/reyn/stdlib/skills/eval/artifacts/eval_case_input.yaml` の `target_skill_path` description に 3 accepted forms を明記 (= prompt-layer LLM hint、 future LLM が bare name を選びやすく)。

## Verify

**Live verify** (= W2-S7 prompt re-run on fix branch):
- `routing_decided{skill__eval}` ✓
- `skill_run_spawned{eval}` ✓
- **sub-skill `direct_llm` の `workflow_started` + `workflow_finished` events 出現** ← stdlib resolution 経由で load 成功
- **`FileNotFoundError: 'direct_llm/skill.md'` 不発** (= B41 元 bug 解消)
- eval 自体は postprocessor schema validation で fail (= 別 carry-over、 本 PR scope 外)

## Tests

- `tests/test_run_skill_ref_resolution.py` — **7 Tier 2 invariants**:
  - form 1 (bare name) regression guard
  - form 2 (short `<name>/skill.md`) — B41 fix
  - form 2 unknown-name fallthrough (= preserves pre-B41 callers)
  - form 3 (multi-segment literal) regression guard
  - 3-segment literal not subject to form-2 fallback (= deterministic boundary)
  - `skill.md` alone (= bare `.md` with no leading segment) → literal
  - Unknown bare name raises `SkillNotFoundError`
- Full pytest: **3802 passed**, 5 skipped, 3 xfailed (= 0 regression)
- ruff: clean

## Test plan (author checklist)

- [x] `pytest tests/test_run_skill_ref_resolution.py` — 7 passed
- [x] Full `pytest tests/` — 3802 passed, 0 regression
- [x] `ruff check` — clean
- [x] Live verify W2-S7 scenario end-to-end (= FileNotFoundError 不発確認)
- [x] Helper `_resolve_skill_ref()` extracted as pure function for Tier 2 testability (= no Mock, no private state assertion per testing.md)
- [x] eval input schema description updated (= prompt-layer hint for future LLMs)

## Notes for reviewer

- B41-NF-S7-1 (HIGH) carry-over from PR #190 retrospective
- This is **structural fix** at OS op-runtime layer (per care-boundary.md §3 pre-call structural responsibility); not a Reyn behavioral rescue
- W2-S7 eval scenario が完全に V verdict に到達するには別の修正 (= postprocessor output schema 整合) も必要、 本 PR scope 外で B42 carry-over
- form-2 fallback は LLM-friendly affordance、 form-3 (3+ segment literal) は untouched で deterministic boundary 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)