### PR TITLE
polish(tui): lifecycle markers render as dim inline divider, not system block

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -136,6 +136,41 @@ def _msg_header(label: str, name_style: str, dash_style: str) -> Text:
     return t
 
 
+def _is_lifecycle_marker(text: str) -> bool:
+    """Heuristic: ``ChatLifecycleForwarder`` marker text starts with ``[↑``
+    and ends with ``]``, and is single-line.
+
+    Lifecycle markers (= compaction, future attach-budget signals) are
+    state-change announcements, not speech — rendering them as a full
+    speaker-tagged system block (= timestamp + ``· system`` header + dash
+    rule + indented body) gives them more visual weight than they
+    deserve. The conv pane routes them through ``_render_lifecycle_marker``
+    so they appear as a dim inline divider, matching the date-separator
+    style.
+    """
+    t = text.strip()
+    return t.startswith("[↑") and t.endswith("]") and "\n" not in t
+
+
+def _render_lifecycle_marker(text: str) -> Text:
+    """Dim ``── ↑ <body> ────…`` inline divider for a lifecycle marker.
+
+    Shape mirrors ``_date_separator`` — same total cell width (``_DASH_TOTAL``)
+    and same ``dim #666666`` styling so the visual rhythm stays consistent
+    with day-boundary markers and other inline dividers.
+    """
+    stripped = text.strip().lstrip("[").rstrip("]").strip()
+    label = f" {stripped} "
+    t = Text()
+    lead_dashes = 2
+    label_cells = cell_len(label)
+    trail_dashes = max(1, _DASH_TOTAL - lead_dashes - label_cells)
+    t.append("─" * lead_dashes, style="dim #666666")
+    t.append(label, style="dim #666666")
+    t.append("─" * trail_dashes, style="dim #666666")
+    return t
+
+
 def _date_separator(date_str: str) -> Text:
     """Dim ``── YYYY-MM-DD ───…`` line for day boundaries between turns.
 
@@ -486,14 +521,22 @@ class ConversationView(Widget):
         when running multiple commands in a row.
 
         Rendered as plain text (newlines preserved, no Markdown) under a
-        neutral ``system`` header in dim grey.
+        neutral ``system`` header in dim grey. **Exception**: lifecycle
+        markers (= ``[↑ ... ]`` shape from ``ChatLifecycleForwarder``)
+        skip the speaker header and render as a dim inline divider —
+        they're state-change announcements, not speech, and don't
+        deserve the same visual weight as a slash-command output.
         """
         self._consume_empty_hint()
         self.hide_status()
+        text = msg.text or ""
+        if _is_lifecycle_marker(text):
+            self._write_log(_render_lifecycle_marker(text))
+            return
         self._maybe_write_header(
             "system", f"{_GLYPH_SYSTEM} system", "bold #888888", "#666666",
         )
-        for line in (msg.text or "").splitlines() or [""]:
+        for line in text.splitlines() or [""]:
             self._write_body(Text(line))
         self._write_log(Text(""))
 

--- a/tests/cli/test_lifecycle_marker_render.py
+++ b/tests/cli/test_lifecycle_marker_render.py
@@ -1,0 +1,189 @@
+"""Tier 2: lifecycle markers render as a dim inline divider, not a system block.
+
+``ChatLifecycleForwarder`` (added in PR #201 to close #162) emits markers
+shaped like ``[↑ 3 turns compacted]`` as ``system``-kind outbox messages.
+Without polish they go through the same path as a slash-command output —
+timestamped ``· system`` header + dash rule + indented body — which is
+heavier than warranted for an advisory state-change announcement.
+
+These tests pin the contract that:
+
+1. The marker-detection heuristic only fires on the actual marker shape
+   (= ``[↑ ... ]``, single line); regular system messages are unaffected.
+2. The rendered marker uses the inline-divider style — ``dim #666666``,
+   total cell width matches ``_DASH_TOTAL`` (same as ``_date_separator``).
+3. ``_render_system_message`` routes markers through the divider helper
+   and skips the ``· system`` speaker header.
+4. Non-marker system messages still get the full system-block treatment.
+
+The contrast / lighter-weight rendering ask came from the issue #162
+follow-up — e2e-coder noted "dim-styling refinement は別 polish" when
+landing the base ChatLifecycleForwarder fix.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from rich.cells import cell_len
+from textual.widgets import RichLog
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.conversation import (
+    _DASH_TOTAL,
+    _is_lifecycle_marker,
+    _render_lifecycle_marker,
+)
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _log_text(log: RichLog) -> str:
+    """Concat all strip text in the RichLog for substring searches."""
+    return "\n".join("".join(seg.text for seg in strip) for strip in log.lines)
+
+
+# ---------------------------------------------------------------------------
+# 1. Detection heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_is_lifecycle_marker_matches_compaction_shape():
+    """Tier 2: ``[↑ N turns compacted]`` is detected as a lifecycle marker."""
+    assert _is_lifecycle_marker("[↑ 3 turns compacted]")
+    assert _is_lifecycle_marker("[↑ 1 turn compacted]")
+    # Leading / trailing whitespace tolerated (forwarder emits clean text
+    # but the detector should not be brittle against that).
+    assert _is_lifecycle_marker("  [↑ 5 turns compacted]  ")
+
+
+def test_is_lifecycle_marker_rejects_regular_system_messages():
+    """Tier 2: regular system content does NOT match the marker heuristic.
+
+    Slash-command output (``/help``, ``/keys``, multi-line plan dumps)
+    must continue to render through the full system block.
+    """
+    assert not _is_lifecycle_marker("hello")
+    assert not _is_lifecycle_marker("")
+    # Multi-line content — even if it starts with ``[↑`` — is not a
+    # marker. The forwarder always emits a single-line shape.
+    assert not _is_lifecycle_marker("[↑ header]\nbody line")
+    # Plain bracketed content without the up-arrow glyph.
+    assert not _is_lifecycle_marker("[plain bracketed]")
+    # /help-style output that happens to mention compaction in body.
+    assert not _is_lifecycle_marker("compaction triggered")
+
+
+# ---------------------------------------------------------------------------
+# 2. Rendering contract — width / style
+# ---------------------------------------------------------------------------
+
+
+def test_render_lifecycle_marker_width_matches_dash_total():
+    """Tier 2: rendered marker spans ``_DASH_TOTAL`` cells.
+
+    Same width contract as ``_date_separator`` — the visual rhythm of
+    inline dividers (date + lifecycle) must match so they read as a
+    single category, not as visually competing rules.
+    """
+    rendered = _render_lifecycle_marker("[↑ 3 turns compacted]")
+    assert cell_len(rendered.plain) == _DASH_TOTAL, (
+        f"marker width must equal _DASH_TOTAL={_DASH_TOTAL}, "
+        f"got {cell_len(rendered.plain)} for {rendered.plain!r}"
+    )
+
+
+def test_render_lifecycle_marker_uses_dim_style():
+    """Tier 2: every span in the rendered marker carries ``dim`` styling.
+
+    The pre-polish state used ``· system`` header in bold — these
+    markers are advisory, not speaker-tagged, so the entire run must
+    be dim. We don't pin the exact colour string (algorithm-level
+    detail per testing.ja.md) — only that ``dim`` is present.
+    """
+    rendered = _render_lifecycle_marker("[↑ 3 turns compacted]")
+    for _start, _end, style in rendered.spans:
+        # Rich Style objects stringify to include "dim" when set.
+        assert "dim" in str(style).lower(), (
+            f"non-dim span found in marker: {style!r}"
+        )
+
+
+def test_render_lifecycle_marker_preserves_label_text():
+    """Tier 2: the marker body (between brackets) survives into the render."""
+    rendered = _render_lifecycle_marker("[↑ 7 turns compacted]")
+    assert "↑ 7 turns compacted" in rendered.plain
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end routing through _render_system_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_marker_skips_system_speaker_header():
+    """Tier 2: a marker system message lands in the log WITHOUT ``· system`` header.
+
+    The pre-polish path emitted a full speaker header block; the polish
+    routes markers through ``_render_lifecycle_marker`` directly so the
+    only line added is the inline divider.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        msg = OutboxMessage(kind="system", text="[↑ 3 turns compacted]")
+        conv._render_system_message(msg)
+        await pilot.pause()
+
+        rendered = _log_text(log)
+        # The marker body lands.
+        assert "↑ 3 turns compacted" in rendered
+        # The ``· system`` speaker tag does NOT — that would be the
+        # heavy pre-polish path leaking through.
+        assert "· system" not in rendered, (
+            f"lifecycle marker leaked the system speaker header:\n{rendered}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_regular_system_message_still_uses_speaker_header():
+    """Tier 2: non-marker system messages keep the full ``· system`` header.
+
+    Defends against the detector being too greedy and accidentally
+    stripping headers from slash-command output.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        msg = OutboxMessage(
+            kind="system",
+            text="usage: /help [topic]\n  topics: keys, commands",
+        )
+        conv._render_system_message(msg)
+        await pilot.pause()
+
+        rendered = _log_text(log)
+        assert "· system" in rendered, (
+            f"regular system message lost its speaker header:\n{rendered}"
+        )
+        assert "usage: /help" in rendered


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- Lifecycle markers from `ChatLifecycleForwarder` (e.g. `[↑ 3 turns compacted]`, added in #201 to close #162) currently render through the standard `system`-kind path: timestamped `· system` speaker header + dash rule + indented body. That's heavier than warranted for an advisory state-change announcement which is neither speech nor command output. e2e-coder explicitly called out dim-styling refinement as out of scope for #201's base fix.
- Add `_is_lifecycle_marker()` + `_render_lifecycle_marker()` helpers in `conversation.py` that detect the `[↑ ... ]` single-line shape and render it as a dim `── ↑ <body> ────…` inline divider matching `_date_separator` (same `dim #666666` styling, same `_DASH_TOTAL=38` width).
- Route `_render_system_message` through the new helpers when the marker shape matches; regular system messages (slash-command output, multi-line plans) keep the existing speaker-tagged path.

## Why this is TUI-only

Pure rendering polish in `conversation.py` — no skill / OS / event contract changes. The forwarder's outbox message kind stays `system` and its text shape stays `[↑ N turns compacted]`; only the conv pane's interpretation of that shape is sharpened.

## Test plan

- [x] **Tier 2 contract tests** — `tests/cli/test_lifecycle_marker_render.py`, 7 cases:
  - Detection heuristic accepts compaction-shape markers, rejects multi-line / plain-bracketed / plain-text content
  - Rendered marker width equals `_DASH_TOTAL`
  - Every span carries `dim` styling
  - Marker body text survives the render
  - End-to-end: `_render_system_message(marker)` writes the divider with no `· system` speaker tag in the log
  - End-to-end: `_render_system_message(non-marker)` still emits the full `· system` header
- [x] **Manual**: `python -m pytest tests/cli/ -x` — 190 passed in 31.5s (no regressions on neighbouring rendering tests)
- [x] **Manual**: `python -m pytest tests/test_chat_lifecycle_forwarder.py` — 6 passed; the forwarder's emission contract (= shape of the marker text) is unchanged
- [ ] **Visual (skipped — pre-merge tmux smoke not run; marker only fires after a real compaction event)**: dim divider renders without a `· system` header on a 120×30 conv pane after a compaction. Pinned by the Tier 2 end-to-end tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)