### PR TITLE
fix(dogfood/long_session): wait for skill_run_completed before next turn

### DIFF
--- a/scripts/dogfood_long_session.py
+++ b/scripts/dogfood_long_session.py
@@ -145,6 +145,114 @@ def _extract_reply(body: dict) -> tuple[str | None, str | None]:
     return reply_text, None
 
 
+# ── B-#2 (B41-NF-W7-2): wait-for-skill-completion semantics ─────────────────
+#
+# When a turn's A2A POST returns a spawn-ack reply (= the router exited the
+# loop on skill spawn before the skill itself completed), the long-session
+# driver previously moved on to the next turn immediately. For skills whose
+# completion latency exceeds the HTTP timeout (e.g. read_local_files at 69.5s
+# in B41 W7-S5), this lost the actual skill output and recorded only the
+# 69-char spawn-ack as the turn reply. Subsequent turns then had no skill
+# output in their context and degraded into inline-only routing.
+#
+# Fix: detect spawn-ack reply by substring, then poll the agent's events
+# file for ``skill_completion_injected`` (= router completed narration) up
+# to a configurable deadline. If found, re-extract the actual narration
+# from agent history.jsonl as the turn reply.
+
+_SPAWN_ACK_MARKERS = (
+    # Substring-level detection so minor OS wording tweaks don't break the
+    # match. See `_SPAWN_ACK_MSG` in src/reyn/chat/router_loop.py for the
+    # canonical en/ja forms.
+    "is running in the background",
+    "バックグラウンドで実行しています",
+)
+
+
+def _is_spawn_ack(reply_text: str) -> bool:
+    """Return True when *reply_text* looks like the router's skill-spawn-ack."""
+    if not reply_text:
+        return False
+    return any(marker in reply_text for marker in _SPAWN_ACK_MARKERS)
+
+
+def _wait_for_skill_completion(
+    events_path: Path,
+    *,
+    since_ts: float,
+    deadline_s: float,
+    poll_interval_s: float = 0.5,
+) -> bool:
+    """Poll *events_path* for a ``skill_completion_injected`` event newer than
+    *since_ts*, returning True once observed or False after *deadline_s*.
+
+    The events file is append-only JSONL written by the chat session; the
+    driver's role here is read-only observation. Returns False on file
+    absence (= agent may not have emitted any events yet — caller decides
+    whether to keep waiting).
+    """
+    end_ts = time.time() + deadline_s
+    while time.time() < end_ts:
+        events = _read_events(events_path) if events_path.exists() else []
+        for ev in events:
+            if ev.get("type") != "skill_completion_injected":
+                continue
+            ev_ts = ev.get("timestamp")
+            if ev_ts is None:
+                continue
+            # Events timestamps are ISO-8601 with timezone; convert to unix.
+            try:
+                ev_ts_unix = _iso_to_unix(ev_ts)
+            except ValueError:
+                continue
+            if ev_ts_unix >= since_ts:
+                return True
+        time.sleep(poll_interval_s)
+    return False
+
+
+def _iso_to_unix(iso_ts: str) -> float:
+    """Convert an ISO-8601 timestamp (with timezone) to unix seconds."""
+    # ``datetime.fromisoformat`` handles "+09:00" style offsets natively in
+    # 3.11+. The events log writer uses ``isoformat()`` on a tz-aware datetime.
+    import datetime as _dt
+    return _dt.datetime.fromisoformat(iso_ts).timestamp()
+
+
+def _read_latest_assistant_text(history_path: Path) -> str | None:
+    """Return the text of the last ``role=assistant`` entry in *history_path*.
+
+    Used post-skill-completion to recover the router's narration that was
+    produced after the original HTTP response returned with spawn-ack only.
+    Returns None when no assistant entry is present or the file is missing.
+    """
+    if not history_path.exists():
+        return None
+    try:
+        text = history_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    latest: str | None = None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if rec.get("role") != "assistant":
+            continue
+        content = rec.get("content")
+        if isinstance(content, str) and content.strip():
+            latest = content
+    return latest
+
+
+def _history_path(reyn_root: Path, agent_name: str) -> Path:
+    return reyn_root / "agents" / agent_name / "history.jsonl"
+
+
 # ── Events log reader ───────────────────────────────────────────────────────
 
 def _events_dir(reyn_root: Path, agent_name: str) -> Path:
@@ -243,6 +351,7 @@ def run_scenario(
     timeout: float,
     reyn_root: Path,
     turn_sleep: float = 0.5,
+    skill_completion_timeout: float = 180.0,
 ) -> dict:
     """
     Execute one scenario: send prompts in order to the A2A endpoint,
@@ -303,6 +412,44 @@ def run_scenario(
                 })
             else:
                 reply_text = reply_text or ""
+                # B-#2 (B41-NF-W7-2) wait-for-skill-completion: when the
+                # router returned a spawn-ack (= it exited the loop before
+                # the spawned skill finished), poll the events log for
+                # ``skill_completion_injected`` and re-read the router
+                # narration from the agent's history. Falls back to the
+                # original spawn-ack reply on timeout so the turn metric is
+                # never lost.
+                if _is_spawn_ack(reply_text):
+                    events_file_for_wait = _latest_events_file(agent_name, reyn_root)
+                    completed = False
+                    if events_file_for_wait is not None:
+                        completed = _wait_for_skill_completion(
+                            events_file_for_wait,
+                            since_ts=t0,
+                            deadline_s=skill_completion_timeout,
+                        )
+                    if completed:
+                        # Brief settle window for the router narration turn
+                        # to land in history.jsonl after the
+                        # skill_completion_injected event fires.
+                        time.sleep(0.5)
+                        narrated = _read_latest_assistant_text(
+                            _history_path(reyn_root, agent_name)
+                        )
+                        if narrated and narrated.strip() and not _is_spawn_ack(narrated):
+                            reply_text = narrated
+                            turn_rec["spawn_ack_resolved"] = True
+                        else:
+                            turn_rec["spawn_ack_resolved"] = False
+                            turn_rec["spawn_ack_resolved_reason"] = (
+                                "no narrated assistant message found"
+                            )
+                    else:
+                        turn_rec["spawn_ack_resolved"] = False
+                        turn_rec["spawn_ack_resolved_reason"] = (
+                            f"timeout after {skill_completion_timeout}s "
+                            "waiting for skill_completion_injected"
+                        )
                 empty = not reply_text.strip()
                 turn_rec.update({
                     "status": "ok" if http_status < 400 else f"http_{http_status}",
@@ -562,6 +709,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--turn-sleep", type=float, default=0.5, metavar="SEC",
         help="Sleep between turns in seconds (default: 0.5). Simulates human pace.",
     )
+    p.add_argument(
+        "--skill-completion-timeout", type=float, default=180.0, metavar="SEC",
+        help=(
+            "When the A2A POST returns a skill spawn-ack, wait up to this many "
+            "seconds for the background skill's completion narration before "
+            "moving to the next turn (default: 180). Setting to 0 disables the "
+            "wait (= record the spawn-ack reply verbatim, restoring pre-B41 "
+            "behavior). B41-NF-W7-2."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -674,6 +831,7 @@ def main(argv: list[str] | None = None) -> int:
                 timeout=args.timeout,
                 reyn_root=reyn_root,
                 turn_sleep=args.turn_sleep,
+                skill_completion_timeout=args.skill_completion_timeout,
             )
             result["shot"] = shot_idx
             all_results.append(result)

--- a/tests/test_dogfood_long_session_skill_wait.py
+++ b/tests/test_dogfood_long_session_skill_wait.py
@@ -1,0 +1,215 @@
+"""Tier 2: dogfood_long_session driver wait-for-skill-completion semantics
+(B41-NF-W7-2 fix).
+
+Pinned invariants:
+
+- ``_is_spawn_ack`` detects the en + ja router spawn-ack reply forms via
+  substring match (= robust to minor OS wording tweaks).
+- ``_wait_for_skill_completion`` polls a real on-disk events JSONL file for
+  a ``skill_completion_injected`` event newer than the supplied ``since_ts``,
+  returning True on first match or False after the deadline.
+- ``_read_latest_assistant_text`` returns the content of the most recent
+  ``role=assistant`` history.jsonl record (= the router narration emitted
+  after the spawned skill completes), or None when no such record exists.
+
+Reference: B41 W7-S5 patch-isolation evidence (agent 3 timing analysis) +
+B41-NF-W7-2 carry-over finding.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not on sys.path during normal test discovery; add it lazily so
+# the driver module is importable without restructuring the dogfood scripts.
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from dogfood_long_session import (  # noqa: E402
+    _is_spawn_ack,
+    _iso_to_unix,
+    _read_latest_assistant_text,
+    _wait_for_skill_completion,
+)
+
+# ---------------------------------------------------------------------------
+# _is_spawn_ack
+# ---------------------------------------------------------------------------
+
+
+def test_is_spawn_ack_detects_english_form():
+    """Tier 2: English spawn-ack form is detected by substring."""
+    msg = "Skill is running in the background. Use `/tasks` to monitor progress."
+    assert _is_spawn_ack(msg) is True
+
+
+def test_is_spawn_ack_detects_japanese_form():
+    """Tier 2: Japanese spawn-ack form is detected by substring."""
+    msg = "スキルをバックグラウンドで実行しています。 `/tasks` で進行状況を確認できます。"
+    assert _is_spawn_ack(msg) is True
+
+
+def test_is_spawn_ack_rejects_unrelated_reply():
+    """Tier 2: ordinary assistant reply is not flagged as spawn-ack."""
+    assert _is_spawn_ack("The answer is 42.") is False
+
+
+def test_is_spawn_ack_rejects_empty():
+    """Tier 2: empty / falsy reply is not flagged."""
+    assert _is_spawn_ack("") is False
+    assert _is_spawn_ack(None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_skill_completion
+# ---------------------------------------------------------------------------
+
+
+def _write_event(path: Path, event_type: str, ts_iso: str) -> None:
+    """Append a minimal JSONL event record."""
+    record = {"type": event_type, "timestamp": ts_iso, "data": {}}
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def test_wait_for_skill_completion_returns_true_when_event_present(tmp_path: Path):
+    """Tier 2: completion event newer than since_ts → return True immediately."""
+    events_file = tmp_path / "events.jsonl"
+    # Event timestamp is 1s in the past relative to now; since_ts is 60s ago.
+    now = time.time()
+    since_ts = now - 60.0
+    event_ts_unix = now - 1.0
+    import datetime as dt
+    event_ts_iso = dt.datetime.fromtimestamp(event_ts_unix, tz=dt.timezone.utc).isoformat()
+    _write_event(events_file, "skill_completion_injected", event_ts_iso)
+
+    result = _wait_for_skill_completion(
+        events_file, since_ts=since_ts, deadline_s=2.0, poll_interval_s=0.1
+    )
+    assert result is True
+
+
+def test_wait_for_skill_completion_returns_false_on_deadline(tmp_path: Path):
+    """Tier 2: no completion event before deadline → return False."""
+    events_file = tmp_path / "events.jsonl"
+    events_file.touch()
+    result = _wait_for_skill_completion(
+        events_file, since_ts=time.time(), deadline_s=0.3, poll_interval_s=0.05
+    )
+    assert result is False
+
+
+def test_wait_for_skill_completion_ignores_older_events(tmp_path: Path):
+    """Tier 2: completion event predating since_ts is not counted."""
+    events_file = tmp_path / "events.jsonl"
+    now = time.time()
+    since_ts = now  # now
+    import datetime as dt
+    older_ts_iso = dt.datetime.fromtimestamp(now - 30.0, tz=dt.timezone.utc).isoformat()
+    _write_event(events_file, "skill_completion_injected", older_ts_iso)
+
+    result = _wait_for_skill_completion(
+        events_file, since_ts=since_ts, deadline_s=0.3, poll_interval_s=0.05
+    )
+    assert result is False
+
+
+def test_wait_for_skill_completion_ignores_other_event_types(tmp_path: Path):
+    """Tier 2: only ``skill_completion_injected`` triggers the wait release."""
+    events_file = tmp_path / "events.jsonl"
+    now = time.time()
+    since_ts = now - 60.0
+    import datetime as dt
+    ev_ts_iso = dt.datetime.fromtimestamp(now - 1.0, tz=dt.timezone.utc).isoformat()
+    # Different event types should not satisfy the wait.
+    _write_event(events_file, "skill_run_spawned", ev_ts_iso)
+    _write_event(events_file, "routing_decided", ev_ts_iso)
+
+    result = _wait_for_skill_completion(
+        events_file, since_ts=since_ts, deadline_s=0.3, poll_interval_s=0.05
+    )
+    assert result is False
+
+
+def test_wait_for_skill_completion_missing_file_returns_false(tmp_path: Path):
+    """Tier 2: events file absence at deadline → return False (= no error raised)."""
+    events_file = tmp_path / "does_not_exist.jsonl"
+    result = _wait_for_skill_completion(
+        events_file, since_ts=time.time(), deadline_s=0.1, poll_interval_s=0.05
+    )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _read_latest_assistant_text
+# ---------------------------------------------------------------------------
+
+
+def test_read_latest_assistant_text_returns_last_assistant_entry(tmp_path: Path):
+    """Tier 2: returns content of the latest ``role=assistant`` history line."""
+    history = tmp_path / "history.jsonl"
+    history.write_text(
+        "\n".join([
+            json.dumps({"role": "user", "content": "hello"}),
+            json.dumps({"role": "assistant", "content": "older assistant text"}),
+            json.dumps({"role": "user", "content": "follow-up"}),
+            json.dumps({"role": "assistant", "content": "the latest narration"}),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    assert _read_latest_assistant_text(history) == "the latest narration"
+
+
+def test_read_latest_assistant_text_missing_file_returns_none(tmp_path: Path):
+    """Tier 2: missing history file → None (no exception)."""
+    assert _read_latest_assistant_text(tmp_path / "absent.jsonl") is None
+
+
+def test_read_latest_assistant_text_no_assistant_returns_none(tmp_path: Path):
+    """Tier 2: history with only user entries → None."""
+    history = tmp_path / "history.jsonl"
+    history.write_text(
+        json.dumps({"role": "user", "content": "only user msg"}) + "\n",
+        encoding="utf-8",
+    )
+    assert _read_latest_assistant_text(history) is None
+
+
+def test_read_latest_assistant_text_skips_blank_content(tmp_path: Path):
+    """Tier 2: blank-only assistant entries are skipped (= prior non-blank wins)."""
+    history = tmp_path / "history.jsonl"
+    history.write_text(
+        "\n".join([
+            json.dumps({"role": "assistant", "content": "real narration"}),
+            json.dumps({"role": "assistant", "content": "   "}),
+            json.dumps({"role": "assistant", "content": ""}),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    assert _read_latest_assistant_text(history) == "real narration"
+
+
+# ---------------------------------------------------------------------------
+# _iso_to_unix (= small but kept-honest helper)
+# ---------------------------------------------------------------------------
+
+
+def test_iso_to_unix_handles_timezone_offset():
+    """Tier 2: ISO-8601 with explicit offset round-trips to unix seconds."""
+    # 2026-05-18T22:25:53.453696+09:00 == 2026-05-18T13:25:53.453696Z
+    ts = _iso_to_unix("2026-05-18T22:25:53.453696+09:00")
+    # Re-construct same ISO and compare timestamps within 1 ms
+    import datetime as dt
+    expected = dt.datetime(2026, 5, 18, 13, 25, 53, 453696, tzinfo=dt.timezone.utc).timestamp()
+    assert abs(ts - expected) < 1e-3
+
+
+def test_iso_to_unix_rejects_unparseable():
+    """Tier 2: malformed ISO raises ValueError (= caller is expected to skip)."""
+    with pytest.raises(ValueError):
+        _iso_to_unix("not-a-timestamp")


### PR DESCRIPTION
**[dogfood-coder]** — fix B41-NF-W7-2 (MED): long-session driver lacks wait-for-skill-completed semantics.

## Problem (= B41 W7-S5 finding)

`scripts/dogfood_long_session.py` driver は per-turn `_post_json()` HTTP response が戻ったら即次 turn に進む。 A2A server 側は `MessageBus.request` で running_skills が quiescent になるまで wait するが、 driver の `--timeout` (default 90s) が deadline になる。 B41 W7-S5 の `read_local_files` skill は LLM call 累積 69.5s 要した結果、 driver の poll cycle が skill 完走前に T1 を抜けて T2 を POST、 T1 reply に **69-char の spawn-ack** だけ記録された (= 真の skill output 失われ、 後続 turn 文脈で degrade)。

Pre-existing latent (= B40 v2 / session isolation fix と無関係、 driver 自身の semantics gap)。

## Fix

`scripts/dogfood_long_session.py` で post-HTTP の wait-for-skill-completion semantics 追加。 4 pure helpers + `run_scenario` 統合:

1. **`_is_spawn_ack(text)`**: en / ja substring 検出 (= robust to OS wording tweaks)
2. **`_wait_for_skill_completion(events_path, since_ts, deadline_s)`**: events JSONL を poll、 `skill_completion_injected` event を since_ts 以降で観測したら True
3. **`_read_latest_assistant_text(history_path)`**: agent history.jsonl から最新 `role=assistant` content 抽出 (= 完走後 router の narration)
4. **`_iso_to_unix(iso)`**: ISO-8601 timestamp parse helper

`run_scenario` flow:
- HTTP POST 戻り → reply が spawn-ack なら events を poll
- `skill_completion_injected` 観測 → 0.5s settle → history.jsonl 再読 → narration が non-spawn-ack なら reply 差し替え + `spawn_ack_resolved=True` 記録
- timeout なら `spawn_ack_resolved=False` で原 spawn-ack 維持 (= metric 失わず)

新 CLI flag `--skill-completion-timeout` (default 180s、 0 で disable)。

## Tests

15 Tier 2 invariants (`tests/test_dogfood_long_session_skill_wait.py`):
- `_is_spawn_ack` ×4 (en / ja / unrelated / empty)
- `_wait_for_skill_completion` ×5 (event present / deadline / older filtered / wrong type filtered / missing file)
- `_read_latest_assistant_text` ×4 (latest entry / missing file / no assistant / skip blank)
- `_iso_to_unix` ×2 (offset parse / unparseable)

実 tmp_path + 実 JSONL file 使用 (= per testing.md no-Mock policy)、 no private state assertion、 invariant-level granularity。

## Verify

- 15 new Tier 2 tests pass
- Full pytest **3817 passed**, 5 skipped, 3 xfailed (= 0 regression)
- ruff clean
- Smoke test: en/ja spawn-ack 両形式 detection + ISO timestamp round-trip 確認

## Test plan (author checklist)

- [x] `pytest tests/test_dogfood_long_session_skill_wait.py` — 15 passed
- [x] Full `pytest tests/` — 3817 passed, 0 regression
- [x] `ruff check` — clean
- [x] Helpers as pure functions for Tier 2 testability (= no Mock, no private state assertion per testing.md)
- [x] CLI flag `--skill-completion-timeout` added with default 180s + `0=disable` opt-out
- [x] spawn_ack_resolved metric recorded in turn dict (= subsequent analysis 可)

## Notes for reviewer

- B41-NF-W7-2 (MED) carry-over from PR #190 retrospective
- Driver-level fix (= `scripts/`)、 OS code 不変 — care boundary §6.6 (long-lived session pattern) 内
- Live verify (W7-S5 end-to-end) は scope 外、 tests + smoke で structural confidence。 leader が必要なら別途 dogfood batch で集計 verify
- spawn-ack 検出は substring match (`is running in the background` / `バックグラウンドで実行しています`); OS の `_SPAWN_ACK_MSG` 定数が変わった場合は wording sync が必要 (= Tier 2 test がここを pin)

## References

- B41 retrospective: \`docs/deep-dives/journal/dogfood/2026-05-18-batch-41-b40-v2-full-retest/retrospective.md\` §5 (carry-over B41-NF-W7-2)
- Agent 3 timing analysis (B41 W7-S5): T1 read_local_files 69.5s 内訳 + driver 60s poll boundary
- Care boundary: \`docs/deep-dives/contributing/dogfood-discipline.md\` §6.6 long-lived session pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)