### PR TITLE
refactor(tui): drop SkillActivityRow.set_progress dead code (#161 finding #1)

### DIFF
--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -8,7 +8,7 @@ Design:
 
   Rendering during run::
 
-      ▶ skill_name#abcd  · current_phase  ●●○  2.1s
+      ▶ skill_name#abcd  · current_phase  2.1s
 
   Rendering after finish(success=True, reason="3 phases")::
 
@@ -21,7 +21,6 @@ Design:
 Caller contract:
   - Instantiate with run_id + skill_name.
   - Call set_phase() as each OS transition fires.
-  - Call set_progress() when step counts are known.
   - Call finish() once on skill completion or abort.
   - No messages are posted; caller owns lifetime and mounting.
 """
@@ -86,7 +85,6 @@ class SkillActivityRow(Widget):
         # Running state
         self._phase: str = ""
         self._visit: int = 1
-        self._progress: tuple[int, int] | None = None  # (current, total)
         # Optional in-phase detail (= what's happening WITHIN the phase right
         # now — "calling llm", "running act op", etc.). Without this the row
         # showed only the phase name during a 10–30 s LLM call inside that
@@ -146,11 +144,6 @@ class SkillActivityRow(Widget):
         self._detail = detail
         self._refresh()
 
-    def set_progress(self, current: int, total: int) -> None:
-        """Set progress dot counts (e.g. 2 of 3 steps done)."""
-        self._progress = (current, total)
-        self._refresh()
-
     def finish(self, success: bool = True, reason: str = "") -> None:
         """Transition to the completed line and stop the timer."""
         if self._finished:
@@ -175,17 +168,6 @@ class SkillActivityRow(Widget):
         secs = time.monotonic() - self._start
         return f"{secs:.1f}s"
 
-    def _dots(self) -> str:
-        """Build progress dots string, e.g. '●●○'."""
-        if self._progress is None:
-            return ""
-        current, total = self._progress
-        if total <= 0:
-            return ""
-        filled = min(current, total)
-        empty = total - filled
-        return "●" * filled + "○" * empty
-
     def _build_running(self) -> Text:
         t = Text()
         # Animated braille spinner — replaces the static ▶ so "still
@@ -201,10 +183,6 @@ class SkillActivityRow(Widget):
             t.append(self._phase, style=f"italic {_CORAL}")
             if self._visit > 1:
                 t.append(f" v{self._visit}", style="dim")
-        # progress dots
-        dots = self._dots()
-        if dots:
-            t.append(f"  {dots}", style="dim")
         # Elapsed — colour-coded so a slow / stuck skill stands out:
         #   < 30 s → dim (= normal)
         #   30–60s → amber (= "taking a while")


### PR DESCRIPTION
**[e2e-coder]** —

Addresses #161 (finding #1 — direction **(c)** per lead-coder owner decision). #2 stays open pending TUI-render sub-issue split; #3 (op_kinds in `act_executed`) is a separate follow-up PR.

## Summary

`SkillActivityRow.set_progress(current, total)` exists with `●●○` dot rendering, but `grep -rn "set_progress" src/reyn/chat/` returns only the definition and its docstring — no caller in TUI / forwarder / app ever invokes it. The owner decision was to delete the dead code rather than wire it up, because:

- Plan progress is already conveyed by the existing sticky `plan step N/M done` (`chat/planner.py:1023`).
- Wiring the dots would need either a fictional plan-level row (over-design) or a confusing graft onto the router row.
- CLAUDE.md "don't add features beyond what the task requires" + "no half-finished implementations" → cleanup is the responsible choice.

## What this removes

- `SkillActivityRow.set_progress(current, total)` method
- `self._progress: tuple[int, int] | None` state attribute
- `SkillActivityRow._dots()` helper
- The dots branch inside `_build_running()` that appended `  ●●○` to the running line
- Docstring line "Call set_progress() when step counts are known."
- "●●○  " from the rendered example in the module docstring

No behavior change for any current code path — the feature was unreachable.

## Test plan

- [x] **`grep -rn set_progress src/reyn/chat/`**: now returns nothing (= dead code excised).
- [x] **Adjacent — `pytest tests/cli/test_skill_in_phase_detail.py tests/cli/test_phase_completed_visible.py tests/test_skill_runner_aborted_trace.py tests/test_sub_skill_run_id_attribution.py tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py`**: 144 passed, 1 expected xfail. No test referenced `set_progress` / `_progress` / `_dots`.
- [x] **Lint — `ruff check`**: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)