### PR TITLE
feat(chat): act_executed op_kinds (#161 #3) + ActionUsageTracker hot_list_updated emit (#192)

### DIFF
--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -97,13 +97,37 @@ class ChatEventForwarder:
         ``op_count`` from the event payload is the count of ops in that
         batch. Useful as a "the skill is actively working" signal during
         heavy preprocessor turns.
+
+        Issue #161 finding #3: when ``op_kinds`` is present, surface the
+        distinct kinds in parentheses so the user can tell "parent ran
+        a write_file batch" vs "parent spawned a sub-skill". Without
+        this distinction every ``act: N ops`` looked identical.
         """
         op_count = data.get("op_count")
-        if op_count:
-            self._enqueue(
-                f"detail: act: {op_count} op{'s' if op_count != 1 else ''}",
-                source_run_id=data.get("run_id"),
-            )
+        if not op_count:
+            return
+        op_kinds = data.get("op_kinds") or []
+        # De-duplicate while preserving first-occurrence order so the
+        # detail reads naturally (e.g. ``run_skill, write_file`` rather
+        # than ``run_skill, run_skill, write_file``). Bounded to the
+        # first 3 distinct kinds with a tail ellipsis so the line stays
+        # short even on large batches.
+        seen: list[str] = []
+        for k in op_kinds:
+            if k and k not in seen:
+                seen.append(k)
+            if len(seen) >= 4:
+                break
+        kinds_suffix = ""
+        if seen:
+            display = seen[:3]
+            tail = "…" if len(seen) > 3 else ""
+            kinds_suffix = f" ({', '.join(display)}{tail})"
+        self._enqueue(
+            f"detail: act: {op_count} op{'s' if op_count != 1 else ''}"
+            f"{kinds_suffix}",
+            source_run_id=data.get("run_id"),
+        )
 
     def _enqueue(self, text: str, *, source_run_id: str | None = None) -> None:
         # Fire-and-forget: trace messages are advisory, never block the skill.

--- a/src/reyn/chat/lifecycle_forwarder.py
+++ b/src/reyn/chat/lifecycle_forwarder.py
@@ -37,6 +37,31 @@ class ChatLifecycleForwarder:
         if handler:
             handler(event.data)
 
+    # ── Hot list (issue #192) ────────────────────────────────────────────
+
+    def on_hot_list_updated(self, data: dict) -> None:
+        """Forward the new full ranking to the outbox as a structured signal.
+
+        Emits ``OutboxMessage(kind="hot_list_updated", text="",
+        meta={"ranking": [...]})`` carrying the full sorted ranking
+        ``[{qualified_name, freq, last_ts}, ...]``. The Memory tab (=
+        tui-coder follow-up) subscribes to this kind to refresh its
+        per-entry "hot" badges / sub-section without polling.
+
+        ``text`` is empty because this is a data signal, not a display
+        line — the conv pane's ``_format_message`` falls through to its
+        unknown-kind handler which is suppressed for non-display kinds.
+        """
+        ranking = data.get("ranking") or []
+        try:
+            self.outbox.put_nowait(OutboxMessage(
+                kind="hot_list_updated",
+                text="",
+                meta={"ranking": list(ranking)},
+            ))
+        except asyncio.QueueFull:
+            pass
+
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
     def on_compaction_completed(self, data: dict) -> None:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -600,8 +600,21 @@ class ChatSession:
         ):
             try:
                 from reyn.tools.action_usage_tracker import ActionUsageTracker
+                # Issue #192: wire a callback that emits ``hot_list_updated``
+                # on every reorder of the ranking. Lambda defers
+                # ``self._chat_events`` resolution to call time (it's
+                # constructed below at the EventLog init); record() runs
+                # only during user turns, well after construction completes.
+                def _on_hot_list_changed(ranking: list[dict]) -> None:
+                    try:
+                        self._chat_events.emit(
+                            "hot_list_updated", ranking=ranking,
+                        )
+                    except Exception:
+                        pass
                 self._action_usage_tracker = ActionUsageTracker(
                     persist_path=Path(".reyn") / "state" / "action_usage.jsonl",
+                    on_ranking_changed=_on_hot_list_changed,
                 )
             except Exception:
                 self._action_usage_tracker = None

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1063,7 +1063,12 @@ def _format_message(msg: OutboxMessage) -> Text | None:
     body = f"{meta_pfx}{msg.text}"
 
     if msg.kind in {"__end__", "__attach_request__", "intervention",
-                    "agent", "system", "status", "error", "trace", "skill_done"}:
+                    "agent", "system", "status", "error", "trace", "skill_done",
+                    # Issue #192: hot_list_updated is a data signal (= meta
+                    # carries the full ranking); no display copy in the conv
+                    # pane. Consumed by the Memory tab augmentation
+                    # (tui-coder follow-up).
+                    "hot_list_updated"}:
         return None
     # Unknown kind — show raw with subtle prefix
     t = Text()

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -414,6 +414,7 @@ class PhaseExecutor:
                 "act_executed",
                 phase=phase,
                 op_count=len(act.ops),
+                op_kinds=[op.kind for op in act.ops],
                 act_turn=act_turn_count,
                 ops=[op.model_dump() for op in act.ops],
                 results=ir_results,

--- a/src/reyn/tools/action_usage_tracker.py
+++ b/src/reyn/tools/action_usage_tracker.py
@@ -32,6 +32,7 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Callable
 
 # OS default seed: universal file/web ops + Reyn flagship skills.
 # Referenced by ActionRetrievalConfig when hot_list_seed="default".
@@ -75,11 +76,26 @@ class ActionUsageTracker:
     No locking is applied; callers must not share instances across threads.
     """
 
-    def __init__(self, persist_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        persist_path: Path | None = None,
+        *,
+        on_ranking_changed: Callable[[list[dict]], None] | None = None,
+    ) -> None:
         # in-memory state
         self._freq: dict[str, int] = {}       # qualified_name → event count
         self._last_ts: dict[str, float] = {}  # qualified_name → latest event timestamp
         self._persist_path = persist_path
+        # Issue #192: optional callback fired when the full sorted ranking
+        # order changes after a record(). Caller wires this to emit a
+        # ``hot_list_updated`` event so the TUI can refresh its Memory
+        # tab augmentation without periodic polling. None = no callback.
+        # Diff granularity is the QUALIFIED-NAME ORDER — score-only
+        # changes within a stable order (e.g. the top item's freq bumps
+        # but everything stays in place) do NOT fire, so the consumer
+        # only sees re-rendering signals.
+        self._on_ranking_changed = on_ranking_changed
+        self._prior_ranking_order: list[str] | None = None
         if persist_path is not None:
             self._load_from_disk()
 
@@ -188,6 +204,14 @@ class ActionUsageTracker:
 
         Updates in-memory freq + recency, then appends to JSONL if
         persist_path is configured.
+
+        Issue #192: when ``on_ranking_changed`` is set and the new full
+        sorted ranking order differs from the cached prior order, the
+        callback is fired with the full ranking ``[{qualified_name,
+        freq, last_ts}, ...]``. Score-only changes (= same order) do
+        not fire — the UI only re-renders on visible reorderings.
+        Callback failures are swallowed; record() must never crash
+        because the observer raised.
         """
         ts = time.time()
         self._freq[qualified_name] = self._freq.get(qualified_name, 0) + 1
@@ -195,6 +219,36 @@ class ActionUsageTracker:
         if prev is None or ts > prev:
             self._last_ts[qualified_name] = ts
         self._append_to_disk(qualified_name, ts)
+        if self._on_ranking_changed is not None:
+            ranking = self.full_ranking()
+            new_order = [r["qualified_name"] for r in ranking]
+            if new_order != self._prior_ranking_order:
+                self._prior_ranking_order = new_order
+                try:
+                    self._on_ranking_changed(ranking)
+                except Exception:
+                    pass  # advisory only; never crash record()
+
+    def full_ranking(self) -> list[dict]:
+        """Return the full sorted ranking with freq + last_ts per entry.
+
+        Sorted by the same score formula ``get_top_n`` uses (= freq *
+        (1 + 1/(1+age_days))) descending, with qualified_name ascending
+        as the tie-breaker. Caller consumes this for full-ranking
+        rendering (= Memory tab augmentation per issue #192).
+        """
+        now = time.time()
+        scored: list[tuple[float, str, int, float]] = []
+        for qn, freq in self._freq.items():
+            last = self._last_ts.get(qn, now)
+            age_days = max(0.0, (now - last) / _SECONDS_PER_DAY)
+            score = freq * (1.0 + 1.0 / (1.0 + age_days))
+            scored.append((score, qn, freq, last))
+        scored.sort(key=lambda pair: (-pair[0], pair[1]))
+        return [
+            {"qualified_name": qn, "freq": freq, "last_ts": last_ts}
+            for _, qn, freq, last_ts in scored
+        ]
 
     def get_top_n(self, n: int, seed: list[str]) -> list[str]:
         """Return up to *n* qualified_names, freq+recency ranked, with seed fill.

--- a/tests/test_act_executed_op_kinds.py
+++ b/tests/test_act_executed_op_kinds.py
@@ -1,0 +1,128 @@
+"""Tier 2: act_executed carries op_kinds + forwarder surfaces them (#161 #3).
+
+Pre-fix the ``act_executed`` event payload only carried ``op_count``,
+so the per-skill forwarder emitted a generic ``⤷ act: 2 ops`` detail
+line with no signal about which op kinds ran. The user could not
+distinguish "parent ran a file-write batch" from "parent spawned a
+sub-skill" — both looked identical on the parent's SkillActivityRow.
+
+Fix (= direction (d) from the #161 owner decision):
+  1. ``PhaseExecutor`` includes ``op_kinds: list[str]`` in the
+     ``act_executed`` payload (additive — no schema bump for
+     subscribers that read other fields).
+  2. ``ChatEventForwarder.on_act_executed`` reads ``op_kinds`` and
+     appends a parenthetical "(run_skill, write_file)" to the detail
+     text. De-duplicates while preserving first-occurrence order,
+     truncates to first 3 with ``…`` so the line stays short.
+
+This test file pins the forwarder side — the kernel-side emit shape
+is exercised through end-to-end tests; here we only verify that the
+forwarder consumes the new field correctly and that the legacy
+``op_kinds``-absent payload still works.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.chat.forwarder import ChatEventForwarder
+from reyn.schemas.models import Event
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+def test_act_executed_with_op_kinds_surfaces_distinct_kinds() -> None:
+    """Tier 2: op_kinds list → "(run_skill, write_file)" suffix on detail."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("router", q, run_id="r-1")
+    fwd(Event(
+        type="act_executed",
+        data={
+            "op_count": 2,
+            "op_kinds": ["run_skill", "write_file"],
+            "run_id": "r-1",
+        },
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert "act: 2 ops" in msgs[0].text
+    assert "(run_skill, write_file)" in msgs[0].text
+
+
+def test_act_executed_deduplicates_repeated_kinds() -> None:
+    """Tier 2: repeated kinds collapse to first occurrence ("a, b" not "a, a, b")."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="r-1")
+    fwd(Event(
+        type="act_executed",
+        data={
+            "op_count": 3,
+            "op_kinds": ["run_skill", "run_skill", "write_file"],
+        },
+    ))
+    msgs = _drain(q)
+    # "run_skill, write_file" — not "run_skill, run_skill, write_file"
+    text = msgs[0].text
+    assert text.count("run_skill") == 1
+    assert "write_file" in text
+
+
+def test_act_executed_truncates_to_three_kinds_with_ellipsis() -> None:
+    """Tier 2: more than 3 distinct kinds → first 3 + "…" tail.
+
+    Keeps the detail line short on heavy batches; the full op list is
+    still in the event payload for the Events tab.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="r-1")
+    fwd(Event(
+        type="act_executed",
+        data={
+            "op_count": 5,
+            "op_kinds": ["a", "b", "c", "d", "e"],
+        },
+    ))
+    msgs = _drain(q)
+    text = msgs[0].text
+    assert "(a, b, c…)" in text
+    # "d" and "e" must NOT appear inside the parenthetical (the bare
+    # word "detail" naturally contains 'd', so we constrain the check
+    # to the parens substring).
+    parens = text[text.index("(") : text.index(")") + 1]
+    assert "d" not in parens
+    assert "e" not in parens
+
+
+def test_act_executed_without_op_kinds_unchanged() -> None:
+    """Tier 2: pre-fix payload (no op_kinds key) still emits a usable detail.
+
+    Backward-compat: events generated before this PR (= replay fixtures,
+    pre-rollout sessions resumed mid-flight) carry no op_kinds. Forwarder
+    must still emit "act: N ops" without the parenthetical.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="r-1")
+    fwd(Event(type="act_executed", data={"op_count": 2}))
+    msgs = _drain(q)
+    assert msgs[0].text == "detail: act: 2 ops"
+
+
+def test_act_executed_empty_op_kinds_falls_back_to_count_only() -> None:
+    """Tier 2: empty list behaves like missing field (= count-only output).
+
+    Defensive against producers that might emit op_kinds=[] for zero-op
+    batches; we still want a clean detail line.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="r-1")
+    fwd(Event(
+        type="act_executed",
+        data={"op_count": 1, "op_kinds": []},
+    ))
+    msgs = _drain(q)
+    assert msgs[0].text == "detail: act: 1 op"

--- a/tests/test_hot_list_updated_emit.py
+++ b/tests/test_hot_list_updated_emit.py
@@ -1,0 +1,172 @@
+"""Tier 2: ActionUsageTracker emits hot_list_updated on reorder + forwarder routes (#192).
+
+Pre-fix the hot list ran silently inside ChatSession — TUI had no
+signal when ARS routing decisions changed (= which skills/memory
+entries are currently "hot"). Per the #192 owner decisions:
+
+  - Q1 (b): emit only when the full sorted **order** changes (not on
+    every record() — score-only changes within a stable order do not
+    fire).
+  - Q2: payload carries the **full** ranking
+    ``[{qualified_name, freq, last_ts}, ...]``, not just top-N.
+  - Q3: TUI consumes via the existing ChatLifecycleForwarder pattern
+    so the Memory tab augmentation can subscribe without polling.
+
+This file pins:
+  1. ``ActionUsageTracker`` fires the ``on_ranking_changed`` callback
+     when the qualified-name order reorders.
+  2. The callback receives the full sorted ranking with freq + last_ts.
+  3. Score-only changes within a stable order do NOT re-fire.
+  4. ``ChatLifecycleForwarder.on_hot_list_updated`` forwards the
+     payload to the outbox as
+     ``OutboxMessage(kind="hot_list_updated", meta={"ranking": [...]})``.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from reyn.chat.lifecycle_forwarder import ChatLifecycleForwarder
+from reyn.schemas.models import Event
+from reyn.tools.action_usage_tracker import ActionUsageTracker
+
+# ── 1. Tracker fires callback on reorder ──────────────────────────────────
+
+
+def test_tracker_fires_callback_on_first_record() -> None:
+    """Tier 2: first record() fires the callback (= ranking goes [] → [name])."""
+    seen: list[list[dict]] = []
+    tracker = ActionUsageTracker(
+        on_ranking_changed=lambda r: seen.append(r),
+    )
+    tracker.record("file__read")
+    assert len(seen) == 1
+    assert seen[0][0]["qualified_name"] == "file__read"
+    assert seen[0][0]["freq"] == 1
+    assert isinstance(seen[0][0]["last_ts"], float)
+
+
+def test_tracker_fires_callback_on_reorder() -> None:
+    """Tier 2: callback fires when the qualified-name order changes."""
+    seen: list[list[dict]] = []
+    tracker = ActionUsageTracker(
+        on_ranking_changed=lambda r: seen.append(r),
+    )
+    # Establish initial order: A on top.
+    tracker.record("file__a")
+    tracker.record("file__a")
+    tracker.record("file__b")
+    initial_calls = len(seen)
+    initial_order = [r["qualified_name"] for r in seen[-1]]
+    assert initial_order == ["file__a", "file__b"]
+
+    # Promote B by recording it several times — when B's score
+    # overtakes A, the order flips and a new callback fires.
+    tracker.record("file__b")
+    tracker.record("file__b")
+    # Should have fired again (= the top-1 changed from A to B).
+    assert len(seen) > initial_calls
+    new_order = [r["qualified_name"] for r in seen[-1]]
+    assert new_order == ["file__b", "file__a"]
+
+
+def test_tracker_does_not_fire_on_score_only_change() -> None:
+    """Tier 2: bumping freq when order is unchanged does NOT re-fire.
+
+    Q1 (b) semantics: the diff granularity is qualified-name order.
+    Score-only changes within a stable order (= top item gets recorded
+    again) must not produce a re-render signal — that would defeat
+    the purpose of deduplication.
+    """
+    seen: list[list[dict]] = []
+    tracker = ActionUsageTracker(
+        on_ranking_changed=lambda r: seen.append(r),
+    )
+    # First record: order = [a]. Fires once.
+    tracker.record("a")
+    initial = len(seen)
+    # Subsequent records of the same name: freq bumps but order stays [a].
+    tracker.record("a")
+    tracker.record("a")
+    tracker.record("a")
+    assert len(seen) == initial, (
+        "score-only bumps must not re-fire the ranking callback"
+    )
+
+
+def test_tracker_no_callback_when_none_passed() -> None:
+    """Tier 2: tracker without callback simply records (= backward-compat)."""
+    tracker = ActionUsageTracker()  # no callback
+    tracker.record("file__read")  # must not raise
+    assert tracker._freq["file__read"] == 1
+
+
+def test_tracker_swallows_callback_exceptions() -> None:
+    """Tier 2: a raising callback must not crash record().
+
+    The tracker is on the hot path of every router turn; an observer
+    failure must stay advisory.
+    """
+    def _boom(_ranking):
+        raise RuntimeError("test")
+
+    tracker = ActionUsageTracker(on_ranking_changed=_boom)
+    tracker.record("file__a")  # must not raise
+
+
+def test_full_ranking_includes_freq_and_last_ts() -> None:
+    """Tier 2: full_ranking() returns full sorted list with metadata."""
+    tracker = ActionUsageTracker()
+    tracker.record("a")
+    tracker.record("b")
+    tracker.record("a")  # a now has freq=2
+    ranking = tracker.full_ranking()
+    assert len(ranking) == 2
+    assert ranking[0]["qualified_name"] == "a"  # freq=2 outranks freq=1
+    assert ranking[0]["freq"] == 2
+    assert ranking[1]["qualified_name"] == "b"
+    assert ranking[1]["freq"] == 1
+    for r in ranking:
+        assert isinstance(r["last_ts"], float)
+
+
+# ── 2. ChatLifecycleForwarder routes to outbox ────────────────────────────
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+def test_lifecycle_forwarder_forwards_hot_list_updated() -> None:
+    """Tier 2: on_hot_list_updated → OutboxMessage(kind=hot_list_updated)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="hot_list_updated",
+        data={"ranking": [
+            {"qualified_name": "file__read", "freq": 5, "last_ts": time.time()},
+            {"qualified_name": "web__search", "freq": 2, "last_ts": time.time()},
+        ]},
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].kind == "hot_list_updated"
+    assert msgs[0].text == ""  # data signal, not display
+    ranking = msgs[0].meta["ranking"]
+    assert len(ranking) == 2
+    assert ranking[0]["qualified_name"] == "file__read"
+    assert ranking[0]["freq"] == 5
+
+
+def test_lifecycle_forwarder_empty_ranking_ok() -> None:
+    """Tier 2: empty / missing ranking still emits with [] (= signals reset)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="hot_list_updated", data={}))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].meta["ranking"] == []


### PR DESCRIPTION
**[e2e-coder]** —

Addresses **#161 finding #3** and **closes #192** (OS + signal-routing scope; Memory tab augmentation per #192 Q3 stays a tui-coder follow-up).

Two related changes bundled — both touch the chat-layer forwarder + add OS-side signal emission for cross-layer TUI consumption. Branch named after the first issue but commits cover both.

---

## Part A — #161 finding #3: act_executed carries op_kinds

Per the #161 owner decision (direction **(d)**): the previous `act_executed` payload only carried `op_count`, so the per-skill forwarder emitted a generic `⤷ act: 2 ops` detail line with no signal about which op kinds ran. Additive — no schema bump for subscribers reading other fields.

### Changes

- `src/reyn/kernel/phase_executor.py` — emit gains `op_kinds=[op.kind for op in act.ops]`. The full `ops=...` dump already carried `kind`; `op_kinds` is a flat convenience field.
- `src/reyn/chat/forwarder.py` — `on_act_executed` reads `op_kinds` and appends a parenthetical `"(run_skill, write_file)"` to the detail line. De-duplicates while preserving first-occurrence order, truncates to first 3 distinct kinds with a `…` tail.

### Tests — `tests/test_act_executed_op_kinds.py` (5)

1. Distinct kinds rendered: `act: 2 ops (run_skill, write_file)`.
2. Dedup: `[a, a, b]` → `(a, b)`.
3. Truncation: 5 distinct → `(a, b, c…)`.
4. Backward-compat: no `op_kinds` key → `act: N ops` (no parenthetical).
5. Empty `op_kinds=[]` → same fallback.

---

## Part B — #192: ActionUsageTracker emits hot_list_updated on reorder

Per the #192 owner decisions:
- **Q1 (b)**: emit only when the qualified-name **order** changes (= score-only bumps within a stable order do NOT fire).
- **Q2**: full ranking `[{qualified_name, freq, last_ts}, ...]` (= not top-N).
- **Q3**: route via the existing `ChatLifecycleForwarder` (= sibling pattern of the #162 compaction marker); Memory tab augmentation is a separate tui-coder follow-up.

### Changes

- `src/reyn/tools/action_usage_tracker.py` — `ActionUsageTracker` gains an optional `on_ranking_changed` callback. `record()` compares the new qualified-name order against the cached prior order; on diff, fires the callback with the full ranking. Callback exceptions are swallowed (= hot path of every router turn stays safe). New `full_ranking()` public helper for direct polling consumers.
- `src/reyn/chat/session.py` — wires the callback at `ChatSession.__init__` so `record()` triggers `self._chat_events.emit("hot_list_updated", ranking=...)`. Lambda defers `self._chat_events` resolution to call time (= the EventLog is constructed later in `__init__` at line 713; `record()` only runs during user turns).
- `src/reyn/chat/lifecycle_forwarder.py` — new `on_hot_list_updated` handler that forwards the ranking to the outbox as `OutboxMessage(kind="hot_list_updated", text="", meta={"ranking": [...]})`.
- `src/reyn/chat/tui/widgets/conversation.py` — add `"hot_list_updated"` to the suppressed-kinds list so the unknown-kind raw-print fallback doesn't render an empty `[hot_list_updated]` line.

### Tests — `tests/test_hot_list_updated_emit.py` (8)

1. First record() fires the callback (= ranking `[]` → `[name]`).
2. Reorder fires (= top-1 changes from A to B after enough B records).
3. Score-only stable order does **NOT** re-fire.
4. No-callback construction is backward-compat (= `record()` works without the kwarg).
5. Callback exceptions are swallowed (`_boom` raises → `record()` does not crash).
6. `full_ranking()` returns sorted full list with `freq` + `last_ts`.
7. `ChatLifecycleForwarder.on_hot_list_updated` → `OutboxMessage(kind="hot_list_updated", meta={"ranking": [...]})`.
8. Empty / missing ranking → empty list in meta.

---

## Test plan

- [x] **Automated — `pytest tests/test_act_executed_op_kinds.py tests/test_hot_list_updated_emit.py`**: 5 + 8 = 13/13 pass.
- [x] **Adjacent — `pytest tests/test_chat_lifecycle_forwarder.py tests/test_sub_skill_run_id_attribution.py tests/cli/test_skill_in_phase_detail.py tests/test_router_loop_routing_decided.py tests/test_chat_turn_completed_inline.py tests/test_hot_list_seed_default.py tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py`**: all pass (= 156 + 1 expected xfail). No `KNOWN_STATIC_QUALIFIED_NAMES` change.
- [x] **Lint — `ruff check`**: clean across all 7 touched files + 2 new test files.

## Out of scope (= follow-up)

- **#161 finding #2** — TUI render of `parent_run_id` nesting. Split as **#210** (TUI-only sub-issue ready for tui-coder pickup; OS-side `parent_run_id` was wired in PR #198).
- **#192 Memory tab augmentation** — per Q3, the Memory tab badges / sub-section consume the `hot_list_updated` outbox kind. Strict TUI scope, ready for tui-coder pickup once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)