### PR TITLE
fix(tui): Esc clears typo-shaped slash prefix (no-match case)

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -246,16 +246,32 @@ class InputBar(Widget):
     def dismiss_slash_prefix(self) -> bool:
         """Hide the picker and clear the slash prefix it was tracking.
 
-        Returns True if the picker was actually visible (and got dismissed),
-        False otherwise. The App's ``action_cancel_inflight`` calls this
-        as an early branch on Ctrl+C so an open picker dismisses instead
-        of producing a misleading "nothing in-flight" message.
+        Returns True if there was a slash-entry state to abandon (and it
+        got cleared). The App's ``action_cancel_inflight`` calls this as
+        an early branch on Ctrl+C so an open picker dismisses instead of
+        producing a misleading "nothing in-flight" message.
+
+        Trigger surface — clear in any of these states:
+          * picker has matches and is ``visible_`` (= the user is still
+            choosing a command — original Slack/Discord-style dismiss)
+          * the buffer holds a typo-shaped slash prefix (= ``/<token>``
+            with no space/newline) that produced **zero** matches and
+            therefore left ``picker.visible_`` false. Without this case,
+            ``/attch<Esc>`` was a silent no-op and the stale prefix
+            concatenated with the user's next keystrokes into garbage
+            like ``/attch/attach default``.
         """
-        picker = self._picker()
-        if picker is None or not picker.visible_:
-            return False
-        picker.hide()
         ta = self._textarea()
+        text = ta.text if ta is not None else ""
+        in_slash_prefix = (
+            text.startswith("/") and " " not in text and "\n" not in text
+        )
+        picker = self._picker()
+        picker_visible = picker is not None and picker.visible_
+        if not picker_visible and not in_slash_prefix:
+            return False
+        if picker is not None:
+            picker.hide()
         if ta is not None:
             ta.load_text("")
         return True


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- \`/attch<Esc>\` was a silent no-op: \`dismiss_slash_prefix\` returned early when \`picker.visible_\` was false, but a typo'd slash prefix produces **zero matches** and toggles \`visible_\` to false. The stale prefix stayed in the TextArea, and the next keystrokes concatenated onto it (\`/attch/attach default\` got submitted as one garbled command).
- Fix: broaden the trigger surface in \`dismiss_slash_prefix\` to also clear when the buffer is in **slash-prefix-shape** (= text starts with \`/\`, contains no space or newline). The visible-picker path is preserved for the original Slack/Discord-style dismiss.

## Why TUI-only

Pure input-bar widget logic — no slash registry / session / outbox changes. Existing tests on the picker-visible path still pass; the new path only fires when the picker is invisible AND the buffer is mid-slash-entry.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 190 passed; specifically \`test_slash_picker_escape_dismisses\` (\`/l<Esc>\` → cleared, picker had matches) still green via the visible-picker branch.
- [x] **Manual repro (fixed)** — tmux: \`reyn chat\` → type \`/attch\` (picker disappears, no matches) → Esc → buffer cleared ✅
- [x] **Manual regression** — same session: type \`/h\` (picker shows \`/help\` match) → Esc → buffer cleared, picker dismissed ✅
- [x] **Manual scope check** — type \`hello\` (non-slash) → Esc → buffer kept ✅ (only slash-shaped text is targeted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)