### PR TITLE
fix(tui): Ctrl+C cancel stops SkillActivityRow spinners + clears agents tab

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -683,6 +683,23 @@ class ReynTUIApp(App):
                 task.cancel()
                 cancelled_plans += 1
 
+        # Stop any SkillActivityRow spinners + clear the right-panel agents
+        # tab. ``task.cancel()`` only stops the asyncio producer; no
+        # ``workflow_finished`` / ``workflow_aborted`` trace is forwarded
+        # after cancel, so without this loop the rows spin forever and the
+        # agents tab shows ``● running`` indefinitely (~minutes observed).
+        # Snapshot the keys first — ``finish_skill_row`` mutates _skill_rows.
+        if conv is not None and self._skill_exec:
+            for run_id in list(self._skill_exec.keys()):
+                try:
+                    conv.finish_skill_row(
+                        run_id, success=False, reason="cancelled",
+                    )
+                except Exception:
+                    pass
+                self._skill_exec.pop(run_id, None)
+            self._push_exec_state()
+
         # Seal any orphan streaming rows. The router cancel above stops the
         # producer but no `__stream_end__` is emitted, so the StreamingRow's
         # blinking cursor would otherwise persist forever. Snapshot first —


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- \`task.cancel()\` in \`action_cancel_inflight\` stops the asyncio producer but no \`workflow_finished\` / \`workflow_aborted\` trace is forwarded back, so every \`SkillActivityRow\` in \`_skill_rows\` keeps spinning and the right-panel agents tab keeps showing \`● running\` (sub-agent observed up to ~160s of divergence between "I cancelled" and the visible \"still running\" state).
- Fix: after the asyncio cancel loop, iterate \`_skill_exec\` and call \`conv.finish_skill_row(run_id, success=False, reason="cancelled")\` + \`_skill_exec.pop(run_id, None)\` + \`_push_exec_state()\`. This mirrors the cleanup the success path runs on \`skill done: <status>\` (app.py:461, 483, 484).

## Why TUI-only

Cleanup happens in the TUI app's cancel handler against state the TUI already owns (\`_skill_rows\` / \`_skill_exec\`). No session / skill_runner / events plumbing changes — those layers already stop producing trace events when the asyncio task gets cancelled; this PR just consumes that silence correctly.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 190 passed; no regression in cancel-related smoke tests.
- [x] **Manual repro** — tmux: \`reyn chat\` → send a long-form prompt → wait until the agents tab shows \`▶ default ● running\` with the active \`[ Xs] direct_llm\` row → Ctrl+C → agents tab transitions to \`◐ ready\` with no active rows; conv pane shows the cancel summary. End state is clean (= no zombie spinner). Verified across multiple runs; in some runs the LLM completed naturally before Ctrl+C reached it (= timing race against direct_llm's typical ~5s runtime), but the cleanup path is the same shape as the success-path cleanup so the cancel-while-mid-flight outcome inherits the same end state.
- [x] **Manual scope check** — Ctrl+C with no skill in flight still produces the existing \`(nothing in-flight to cancel)\` message (the new loop is gated on \`self._skill_exec\` being non-empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)