### PR TITLE
fix(tui): Ctrl+L also removes leftover ErrorBox widgets

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1024,6 +1024,16 @@ class ConversationView(Widget):
         for row in list(self._skill_rows.values()):
             row.finish(success=True, reason="cleared")
         self._skill_rows.clear()
+        # Remove any leftover ErrorBox widgets. They mount as children of
+        # the conv pane (not lines in the RichLog), so ``_log().clear()``
+        # above doesn't touch them — without this loop the boxes float on
+        # an otherwise-blank conv pane until the user hits Esc per box.
+        for box in self._error_boxes:
+            try:
+                box.remove()
+            except Exception:
+                pass
+        self._error_boxes.clear()
         # Reset header-grouping + turn anchors + fold stash
         self._last_speaker = ""
         self._last_speaker_at = 0.0


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- ErrorBox widgets mount as children of the conv pane (not lines in the RichLog), so \`_log().clear()\` in \`ConversationView.clear()\` didn't touch them. After Ctrl+L the pane went blank but every undismissed ErrorBox floated on the empty pane until the user pressed Esc per box (= confusing residue, looks like a render glitch).
- Fix: mirror the existing skill-row cleanup loop — iterate \`_error_boxes\`, call \`box.remove()\`, and clear the list. Errors are swallowed defensively, same shape as \`dismiss_last_error\`.

## Why TUI-only

Pure conv-pane widget bookkeeping. No outbox / session / events plumbing changes.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 190 passed.
- [x] **Manual repro (single error)** — tmux: \`/attach<Enter>\` produces ErrorBox → Ctrl+L → both the log and the ErrorBox cleared, empty-hint restored ✅
- [x] **Manual repro (multi error)** — same session: \`/attach<Enter>\` twice produces 2 stacked ErrorBoxes → Ctrl+L → all cleared ✅
- [x] **Regression** — \`/attach<Enter>\` → Esc → ErrorBox dismisses (the original keyboard path still works) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)