### PR TITLE
fix(tui): ErrorBox suppresses 'events' hint when there is no trace

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -131,6 +131,13 @@ class ErrorBox(Widget):
     def compose(self) -> ComposeResult:
         yield Label(self._header_text(), classes="eb-header")
 
+        # The trace hint only makes sense when this error came from a
+        # skill / op run — slash-command usage errors (= no skill_name,
+        # no run_id_short) don't emit events, so pointing the user at
+        # ``Ctrl+B → events`` would send them to a tab that has no row
+        # for the failure they just saw.
+        has_trace = bool(self._skill_name or self._run_id_short)
+
         if self._details:
             lines = self._details.splitlines()
             visible = lines[:5]
@@ -139,12 +146,18 @@ class ErrorBox(Widget):
             if overflow > 0:
                 detail_text += f"\n… {overflow} more"
             yield Static(detail_text, classes="eb-details")
-            yield Label("Ctrl+B → events for full trace", classes="eb-hint")
+            if has_trace:
+                yield Label(
+                    "Ctrl+B → events for full trace", classes="eb-hint",
+                )
         else:
             # No details supplied — fall back to the full (untruncated) message
             # so long errors are still readable when the box is expanded.
             yield Static(self._message, classes="eb-details")
-            yield Label("Ctrl+B → events for full trace", classes="eb-hint")
+            if has_trace:
+                yield Label(
+                    "Ctrl+B → events for full trace", classes="eb-hint",
+                )
 
     # ── interaction ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- ErrorBox unconditionally rendered \`Ctrl+B → events for full trace\` in its expanded body — but slash-command usage errors (e.g. \`/attach<Enter>\` → \`✗ usage: /attach <name>\`) are emitted via \`reply_error\` and **do not produce events** (the events log only records skill / op activity). A user following that hint switched to the events tab and found nothing about the error they just saw — misleading.
- Fix: gate the hint on \`has_trace = bool(self._skill_name or self._run_id_short)\`. Both fields are empty on slash errors (\`OutboxMessage.meta\` has no \`skill_name\` / \`run_id_short\`); skill / op failures carry at least one of them and keep the hint.

## Why TUI-only

Pure ErrorBox \`compose()\` change — no signature update on the constructor or any callers. The inference is intrinsic to the data the widget already holds.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 190 passed; no test asserted on the hint label (\`grep eb-hint tests/\` → 0 hits) so this is a safe expansion of behaviour.
- [x] **Manual repro (negative path)** — tmux: \`reyn chat\` → \`/attach<Enter>\` → ErrorBox \`✗ usage: /attach <name>\` mounts; expanded body no longer carries the misleading \`Ctrl+B → events\` line (skill_name/run_id both empty)
- [ ] **Manual (positive path, skipped — no easy way to provoke a real skill error without an end-to-end LLM tool-call failure):** an ErrorBox produced from a skill/op failure (\`skill_name\` or \`run_id_short\` non-empty) still shows the hint. Verified by reading: the boolean gate is \`bool(self._skill_name or self._run_id_short)\`, so a non-empty value flows through to the original Label code path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)