### PR TITLE
fix(tui): /attach <missing> suggests /agent new, not CLI shell form

### DIFF
--- a/src/reyn/chat/slash/agents.py
+++ b/src/reyn/chat/slash/agents.py
@@ -104,9 +104,12 @@ async def attach_cmd(session: "ChatSession", args: str) -> None:
         await reply_error(session, _NO_REGISTRY_ATTACH)
         return
     if not session._registry.exists(name):
+        # The user is already in the TUI — direct them at the slash form,
+        # not the CLI shell command, so they don't have to drop out of
+        # chat to create the agent.
         await reply_error(
             session,
-            f"agent {name!r} not found; create with `reyn agent new {name}`",
+            f"agent {name!r} not found; use /agent new {name} to create it",
         )
         return
     if name == session._registry.attached_name:


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- \`/attach <unknown-agent>\` error read \`✗ agent '<X>' not found; create with \\\`reyn agent new <X>\\\`\` — telling the user to drop out of the TUI, open a shell, and find the entrypoint. The TUI itself ships \`/agent new <name>\` (added in PR #200), so the in-pane error should suggest the slash form.
- One-line wording change in \`src/reyn/chat/slash/agents.py\`. CLI guidance in \`cli/commands/chat.py\` and \`mcp_server.py\` is unchanged — those run outside the TUI and \`reyn agent new\` is the correct hint there.

## Why TUI-only

Pure user-facing string change in the slash handler. No control-flow change.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 190 passed; no test asserted on the old string (\`grep "reyn agent new" tests/\` → 0 hits).
- [x] **Manual repro** — tmux: \`reyn chat\` → \`/attach nonexistent_xyz<Enter>\` → ErrorBox header now reads \`✗ agent 'nonexistent_xyz' not found; use /agent new nonexistent_xyz to create it\` (slash form, not CLI form).
- [x] **Scope check** — \`grep "reyn agent new" src/\` shows the remaining call sites are CLI / MCP server contexts that legitimately point at the shell command; only the TUI slash path is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)