### PR TITLE
feat(plan): plan_step context threads to spawned skill rows (#214)

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -95,6 +95,7 @@ class Agent:
         resume_plan: "Any | None" = None,
         run_id: str | None = None,
         parent_run_id: str | None = None,
+        plan_step: dict | None = None,
     ) -> RunResult:
         # On resume, callers pass the original run_id so the WAL events
         # stay scoped to the same skill run (= step events from before
@@ -145,6 +146,7 @@ class Agent:
             parent_run_id=parent_run_id,
             sandbox_config=self._sandbox_config,
             secret_store=self._secret_store,
+            plan_step=plan_step,
         )
         return await self._runtime.run(initial_input, output_language=output_language)
 

--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -28,6 +28,10 @@ class ChatEventForwarder:
         self.skill_name = skill_name
         self.outbox = outbox
         self.run_id = run_id
+        # Issue #214: track which run_ids have already received their
+        # "plan N/M" one-shot detail so we don't spam the row on every
+        # phase advance (= once per child skill at first phase_started).
+        self._plan_step_announced: set[str] = set()
 
     def __call__(self, event: Event) -> None:
         handler = getattr(self, f"on_{event.type}", None)
@@ -37,7 +41,30 @@ class ChatEventForwarder:
     def on_phase_started(self, data: dict) -> None:
         phase = data.get("phase", "?")
         # No [skill_name] prefix — renderer prepends it from meta provenance.
-        self._enqueue(f"phase started: {phase}", source_run_id=data.get("run_id"))
+        source_run_id = data.get("run_id")
+        # Issue #214: when the event carries plan_step, emit a one-shot
+        # "plan N/M" detail line for this run_id BEFORE the phase trace.
+        # The SkillActivityRow detail is replaced on the NEXT in-phase
+        # signal (on_llm_called / on_act_executed) — so the user sees
+        # "plan N/M" briefly on row mount, then it gets overwritten by
+        # real-time signals. That's the right tradeoff: plan context is
+        # most useful at row mount; once the skill is grinding, the
+        # in-phase signal carries more information.
+        plan_step = data.get("plan_step")
+        if (
+            plan_step
+            and source_run_id
+            and source_run_id not in self._plan_step_announced
+        ):
+            n_done = plan_step.get("n_done")
+            n_total = plan_step.get("n_total")
+            if n_done and n_total:
+                self._enqueue(
+                    f"detail: plan {n_done}/{n_total}",
+                    source_run_id=source_run_id,
+                )
+                self._plan_step_announced.add(source_run_id)
+        self._enqueue(f"phase started: {phase}", source_run_id=source_run_id)
 
     def on_phase_completed(self, data: dict) -> None:
         phase = data.get("phase", "?")

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -872,11 +872,25 @@ async def execute_plan(
             step_succeeded = False
             desc_preview = (step.description or step.id)[:60]
             attempt = 0
+            # Issue #214 (= #180 #2 split): set the plan_step contextvar
+            # for the duration of this step's sub-loop. The ContextVar
+            # propagates through any asyncio.Task the sub-loop spawns
+            # (= invoke_skill → skill_runner → Agent.run), so the spawned
+            # skill's OSRuntime / EventLog stamps "plan N/M" into every
+            # event and the TUI's SkillActivityRow can render the plan
+            # context as detail. ``n_done`` is the 1-based step number
+            # currently executing (= already-completed count + 1).
+            from reyn.skill._plan_step_context import set_plan_step
             while attempt <= step_retry_limit:
                 try:
-                    sub_usage = await sub_loop.run(
-                        user_text=step.description, history=[],
-                    )
+                    with set_plan_step(
+                        n_done=n_done + 1,
+                        n_total=n_total,
+                        step_id=step.id,
+                    ):
+                        sub_usage = await sub_loop.run(
+                            user_text=step.description, history=[],
+                        )
                     if sub_usage is not None:
                         total_usage.prompt_tokens += sub_usage.prompt_tokens
                         total_usage.completion_tokens += sub_usage.completion_tokens

--- a/src/reyn/chat/services/skill_runner.py
+++ b/src/reyn/chat/services/skill_runner.py
@@ -504,6 +504,11 @@ class SkillRunner:
             ],
         )
 
+        # Issue #214: forward the plan_step ContextVar so a blocking
+        # router invoke_skill inside a plan step's sub-loop stamps the
+        # spawned skill's events with the originating step.
+        from reyn.skill._plan_step_context import current_plan_step
+        _plan_step = current_plan_step()
         try:
             result = await agent.run(
                 skill, input_artifact,
@@ -511,6 +516,7 @@ class SkillRunner:
                 chain_id=chain_id,
                 skill_registry=self._get_skill_registry(),
                 state_log=self._state_log,
+                plan_step=_plan_step,
             )
         except asyncio.CancelledError:
             return {"status": "error", "data": {"error": "cancelled"}}
@@ -686,6 +692,13 @@ class SkillRunner:
         # success) produced the terminal status.
         _terminal_status: str | None = None
         _terminal_data: dict = {}
+        # Issue #214: read the plan_step ContextVar set by planner.py
+        # around the step's sub-RouterLoop. ContextVar propagates through
+        # any asyncio.Task created within the scope, so this spawn site
+        # sees the planner-set value when the skill was invoked inside a
+        # plan step. None = top-level invocation (not in a plan).
+        from reyn.skill._plan_step_context import current_plan_step
+        _plan_step = current_plan_step()
         try:
             result = await agent.run(
                 skill, input_artifact,
@@ -693,6 +706,7 @@ class SkillRunner:
                 chain_id=chain_id,
                 skill_registry=self._get_skill_registry(),
                 state_log=self._state_log,
+                plan_step=_plan_step,
             )
         except asyncio.CancelledError:
             await self._put_outbox(OutboxMessage(

--- a/src/reyn/events/events.py
+++ b/src/reyn/events/events.py
@@ -17,6 +17,7 @@ class EventLog:
         *,
         agent_id: str | None = None,
         run_id: str | None = None,
+        plan_step: dict | None = None,
     ) -> None:
         self._events: list[Event] = []
         self._subscribers: list[Callable[[Event], None]] = list(subscribers or [])
@@ -31,6 +32,15 @@ class EventLog:
         # sub-skill spawned via the ``run_skill`` op (which currently
         # inherits the parent's subscriber list).
         self._run_id = run_id
+        # Issue #214 (= #180 #2 split): plan_step is auto-injected when
+        # a skill OSRuntime is constructed within the scope of a plan
+        # step. Subscribers (= ChatEventForwarder) read ``plan_step`` on
+        # the first ``phase_started`` to render "plan N/M" detail on the
+        # SkillActivityRow, so the user can correlate a spawned skill
+        # row with the originating step. Same caller-wins convention as
+        # agent_id / run_id. Shape: {"n_done": int, "n_total": int,
+        # "step_id": str}. None = top-level (not inside a plan step).
+        self._plan_step = plan_step
 
     @property
     def subscribers(self) -> list[Callable[[Event], None]]:
@@ -51,6 +61,11 @@ class EventLog:
         """The run_id this EventLog stamps onto emitted events (issue #134)."""
         return self._run_id
 
+    @property
+    def plan_step(self) -> dict | None:
+        """The plan_step this EventLog stamps onto emitted events (issue #214)."""
+        return self._plan_step
+
     def add_subscriber(self, fn: Callable[[Event], None]) -> None:
         self._subscribers.append(fn)
 
@@ -68,6 +83,13 @@ class EventLog:
         # the parent's subscriber list.
         if self._run_id and "run_id" not in data:
             data = {**data, "run_id": self._run_id}
+        # Issue #214: stamp plan_step (= {n_done, n_total, step_id}) so
+        # ChatEventForwarder can render "plan N/M" detail on the
+        # SkillActivityRow of any skill spawned inside a plan step.
+        # Caller-wins matches the run_id / agent_id pattern — a skill
+        # explicitly emitting plan_step in data is preserved.
+        if self._plan_step and "plan_step" not in data:
+            data = {**data, "plan_step": self._plan_step}
         event = Event(type=type, data=data)
         self._events.append(event)
         for sub in self._subscribers:

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -74,6 +74,7 @@ class OSRuntime:
         parent_run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
+        plan_step: dict | None = None,
     ) -> None:
         self.skill = skill
         self.model = model
@@ -84,7 +85,9 @@ class OSRuntime:
         self._chain_id = chain_id
         self._budget_tracker = budget_tracker
         self._budget_skill_name = skill_name or skill.name
-        self.events = EventLog(subscribers=subscribers, run_id=run_id)
+        self.events = EventLog(
+            subscribers=subscribers, run_id=run_id, plan_step=plan_step,
+        )
         self.workspace = Workspace(
             self.events,
             permission_resolver=permission_resolver,

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -105,3 +105,12 @@ class OpContext:
     # ScopedSecretStore based on the sub-skill's required_credentials and
     # passes it down through Agent → OSRuntime → executors → OpContext.
     secret_store: "ScopedSecretStore | None" = None
+
+    # Issue #214 (= #180 #2 split): plan_step context for any skill spawned
+    # within a plan step's RouterLoop. ``run_skill`` op propagates this
+    # forward to the sub-skill's OSRuntime so the child EventLog stamps
+    # ``plan_step`` into every emit, letting ChatEventForwarder render
+    # "plan N/M" detail on the child's SkillActivityRow. None = top-level
+    # (= not inside a plan step). Shape: ``{"n_done": int, "n_total": int,
+    # "step_id": str}``.
+    plan_step: dict | None = None

--- a/src/reyn/op_runtime/run_skill.py
+++ b/src/reyn/op_runtime/run_skill.py
@@ -178,6 +178,9 @@ async def handle(op: RunSkillIROp, ctx: OpContext, caller: Literal["preprocessor
         # /skill list and future cascade-discard can walk the tree.
         parent_run_id=ctx.parent_skill_run_id,
         secret_store=scoped_store,
+        # Issue #214: forward plan_step so the sub-skill's EventLog
+        # stamps "plan N/M" context into every emit. None = not in a plan.
+        plan_step=ctx.plan_step,
     )
 
     # PR20: per-run events live at

--- a/src/reyn/skill/_plan_step_context.py
+++ b/src/reyn/skill/_plan_step_context.py
@@ -1,0 +1,59 @@
+"""Plan-step context var (= issue #214 split from #180 #2).
+
+When a plan step's sub-``RouterLoop`` calls ``invoke_skill``, the spawned
+skill's OSRuntime / EventLog needs to know which plan step it belongs to
+so the TUI's SkillActivityRow can render ``"plan N/M"`` detail. Threading
+that information through every intermediate layer (RouterLoop → tool
+dispatcher → SkillRunner → Agent.run) would touch many call sites for a
+single signal.
+
+A ``ContextVar`` is the right tool: planner sets it before each step's
+sub-loop runs, the spawn site reads it at ``agent.run`` construction
+time, and ``asyncio.Task`` snapshots the current context at creation so
+the var propagates through any sub-tasks the runner spawns.
+
+Public surface is the ``set_plan_step()`` context manager and the
+``current_plan_step()`` helper — direct access to the ContextVar is
+discouraged so test sites can be audited.
+"""
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Iterator
+
+# {"n_done": int, "n_total": int, "step_id": str}. None = no plan scope.
+_plan_step_var: contextvars.ContextVar[dict | None] = contextvars.ContextVar(
+    "reyn_plan_step",
+    default=None,
+)
+
+
+def current_plan_step() -> dict | None:
+    """Return the plan_step dict for the current context, or None."""
+    return _plan_step_var.get()
+
+
+@contextmanager
+def set_plan_step(
+    *, n_done: int, n_total: int, step_id: str,
+) -> Iterator[dict]:
+    """Set the plan_step for the lifetime of the ``with`` block.
+
+    ``n_done`` is 1-based (= the step number the user sees, including
+    the currently-executing one). Callers reset via the context exit;
+    no explicit unset needed.
+    """
+    payload = {
+        "n_done": int(n_done),
+        "n_total": int(n_total),
+        "step_id": str(step_id),
+    }
+    token = _plan_step_var.set(payload)
+    try:
+        yield payload
+    finally:
+        _plan_step_var.reset(token)
+
+
+__all__ = ["current_plan_step", "set_plan_step"]

--- a/src/reyn/skill/sub_skill_runner.py
+++ b/src/reyn/skill/sub_skill_runner.py
@@ -46,6 +46,7 @@ async def invoke_sub_skill(
     caller: str = "direct",
     parent_run_id: str | None = None,
     secret_store: "ScopedSecretStore | None" = None,  # NEW (FP-0016 D)
+    plan_step: dict | None = None,
 ) -> SubSkillResult:
     """Run a sub-app and return a SubSkillResult.
 
@@ -86,6 +87,7 @@ async def invoke_sub_skill(
         sub_skill, input_artifact,
         output_language=output_language,
         parent_run_id=parent_run_id,
+        plan_step=plan_step,
     )
     return SubSkillResult(
         data=run_result.data,

--- a/tests/test_plan_step_context.py
+++ b/tests/test_plan_step_context.py
@@ -1,0 +1,196 @@
+"""Tier 2: plan_step threads from planner → spawned skill → forwarder (#214).
+
+Pre-fix, a skill spawned via ``invoke_skill`` inside a plan step's
+sub-``RouterLoop`` had no way to know it belonged to "step N of M" —
+the SkillActivityRow showed ``⠋ skill_name#abcd · phase · 2.1s`` with no
+plan context. Per the owner decision direction (ii), this PR threads
+``plan_step`` through:
+
+  planner (ContextVar setter) →
+    skill_runner (ContextVar reader) →
+    Agent.run / sub_skill_runner.invoke_sub_skill →
+    OSRuntime / EventLog (caller-wins auto-injection mirror of run_id) →
+    ChatEventForwarder (one-shot ``detail: plan N/M`` on first phase_started)
+
+This file pins each link of the chain:
+
+  1. ``EventLog(plan_step=...)`` auto-injects into emit data.
+  2. ``current_plan_step()`` returns the contextvar's current value.
+  3. ``set_plan_step()`` sets + resets within the with-block scope.
+  4. ``ChatEventForwarder.on_phase_started`` emits a one-shot
+     ``detail: plan N/M`` when the event carries ``plan_step``.
+  5. Once-per-run-id de-duplication (= subsequent phase_started events
+     for the same run_id do NOT re-emit the plan detail).
+
+End-to-end planner integration is exercised by the existing
+``test_plan_multi_plan_resume_race.py`` framework, which is out of
+scope here — this file pins the unit invariants of each link.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.chat.forwarder import ChatEventForwarder
+from reyn.events.events import EventLog
+from reyn.schemas.models import Event
+from reyn.skill._plan_step_context import current_plan_step, set_plan_step
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+# ── 1. EventLog stamps plan_step ──────────────────────────────────────────
+
+
+def test_event_log_stamps_plan_step() -> None:
+    """Tier 2: EventLog(plan_step={...}) auto-injects plan_step into emit data."""
+    log = EventLog(plan_step={"n_done": 2, "n_total": 3, "step_id": "s2"})
+    evt = log.emit("phase_started", phase="resolve")
+    assert evt.data["plan_step"] == {"n_done": 2, "n_total": 3, "step_id": "s2"}
+
+
+def test_event_log_caller_plan_step_wins() -> None:
+    """Tier 2: caller-supplied plan_step takes precedence (= same pattern as run_id)."""
+    log = EventLog(plan_step={"n_done": 1, "n_total": 2, "step_id": "s1"})
+    evt = log.emit(
+        "phase_started",
+        phase="resolve",
+        plan_step={"n_done": 99, "n_total": 99, "step_id": "explicit"},
+    )
+    assert evt.data["plan_step"]["step_id"] == "explicit"
+
+
+def test_event_log_no_plan_step_unchanged() -> None:
+    """Tier 2: EventLog without plan_step does not inject the key.
+
+    Backward-compat: top-level (non-plan) invocations land with no
+    plan_step in event data, same as pre-#214.
+    """
+    log = EventLog()
+    evt = log.emit("phase_started", phase="resolve")
+    assert "plan_step" not in evt.data
+
+
+# ── 2. ContextVar helper ───────────────────────────────────────────────────
+
+
+def test_current_plan_step_default_is_none() -> None:
+    """Tier 2: outside any set_plan_step block, current_plan_step() is None."""
+    assert current_plan_step() is None
+
+
+def test_set_plan_step_scopes_to_with_block() -> None:
+    """Tier 2: set_plan_step() context manager sets + resets the var."""
+    assert current_plan_step() is None
+    with set_plan_step(n_done=2, n_total=5, step_id="s2") as payload:
+        assert current_plan_step() == payload
+        assert payload["n_done"] == 2
+        assert payload["n_total"] == 5
+        assert payload["step_id"] == "s2"
+    assert current_plan_step() is None
+
+
+def test_set_plan_step_nested_blocks_restore_outer() -> None:
+    """Tier 2: nested set_plan_step blocks restore outer scope on exit."""
+    with set_plan_step(n_done=1, n_total=3, step_id="outer"):
+        assert current_plan_step()["step_id"] == "outer"
+        with set_plan_step(n_done=2, n_total=3, step_id="inner"):
+            assert current_plan_step()["step_id"] == "inner"
+        # Inner with-block exited — outer scope restored.
+        assert current_plan_step()["step_id"] == "outer"
+    assert current_plan_step() is None
+
+
+# ── 3. Forwarder emits "plan N/M" detail on first phase_started ──────────
+
+
+def test_forwarder_emits_plan_detail_on_first_phase_started() -> None:
+    """Tier 2: phase_started with plan_step → "detail: plan N/M" trace.
+
+    The detail trace lands BEFORE the phase_started trace so the row's
+    set_detail call fires on row mount. ConversationView's existing
+    detail-routing path picks it up as `⤷ plan N/M` under the phase name.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("child", q, run_id="parent-run")
+    fwd(Event(
+        type="phase_started",
+        data={
+            "phase": "resolve",
+            "run_id": "child-run",
+            "plan_step": {"n_done": 2, "n_total": 3, "step_id": "s2"},
+        },
+    ))
+    msgs = _drain(q)
+    # 2 messages: plan detail first, then phase started.
+    assert len(msgs) == 2
+    assert msgs[0].text == "detail: plan 2/3"
+    assert msgs[0].meta["run_id"] == "child-run"
+    assert msgs[1].text == "phase started: resolve"
+
+
+def test_forwarder_plan_detail_only_once_per_run_id() -> None:
+    """Tier 2: subsequent phase_started for same run_id does NOT re-emit detail.
+
+    De-dup discipline so the row's detail doesn't get clobbered by
+    repeated "plan N/M" every phase advance — in-phase signals
+    (on_llm_called / on_act_executed) own the detail post-mount.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("child", q, run_id="parent-run")
+    plan_step = {"n_done": 2, "n_total": 3, "step_id": "s2"}
+    for phase in ("resolve", "execute", "synthesize"):
+        fwd(Event(
+            type="phase_started",
+            data={
+                "phase": phase, "run_id": "child-run", "plan_step": plan_step,
+            },
+        ))
+    msgs = _drain(q)
+    plan_detail_msgs = [m for m in msgs if "plan 2/3" in m.text]
+    assert len(plan_detail_msgs) == 1, (
+        "plan detail must fire exactly once per child run_id"
+    )
+
+
+def test_forwarder_skips_plan_detail_when_event_lacks_plan_step() -> None:
+    """Tier 2: event without plan_step → no detail emit (= backward-compat).
+
+    Top-level skill invocations / non-plan flows have plan_step=None
+    on EventLog construction. Forwarder must not synthesize a fake
+    "plan ?" line.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("s", q, run_id="r")
+    fwd(Event(type="phase_started", data={"phase": "p", "run_id": "r"}))
+    msgs = _drain(q)
+    assert all("plan" not in m.text or "plan" in m.text.split(": ", 1)[0] for m in msgs)
+    # Single phase_started trace, no detail line prepended.
+    assert len(msgs) == 1
+    assert msgs[0].text == "phase started: p"
+
+
+def test_forwarder_distinct_run_ids_each_get_their_own_detail() -> None:
+    """Tier 2: two different child run_ids each get their own one-shot detail.
+
+    Confirms the de-dup tracking is keyed by run_id (= different
+    spawned skills inside the same step both get marked correctly).
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("step", q, run_id="parent-run")
+    plan_step = {"n_done": 2, "n_total": 3, "step_id": "s2"}
+    fwd(Event(type="phase_started", data={
+        "phase": "p", "run_id": "child-A", "plan_step": plan_step,
+    }))
+    fwd(Event(type="phase_started", data={
+        "phase": "p", "run_id": "child-B", "plan_step": plan_step,
+    }))
+    msgs = _drain(q)
+    plan_detail_msgs = [m for m in msgs if "plan 2/3" in m.text]
+    assert len(plan_detail_msgs) == 2
+    assert {m.meta["run_id"] for m in plan_detail_msgs} == {"child-A", "child-B"}


### PR DESCRIPTION
**[e2e-coder]** —

Closes #214 (= #180 #2 split).

## Summary

Per the lead-coder owner decision (direction **(ii)**): mirror the PR #198 / issue #134 `run_id` identity-threading mechanism so `plan_step` travels with every event emitted by a skill spawned inside a plan step. `ChatEventForwarder` then renders `"plan N/M"` detail on the spawned skill's `SkillActivityRow` at row mount, so the user can correlate the row with the originating plan step.

The router-side spawn path (= invoke_skill router tool → SkillRunner → Agent.run) is too deep to thread a kwarg through every intermediate layer for a single signal. A **ContextVar bridge** between planner (setter) and skill_runner (reader) propagates the context through `asyncio.Task` scope without touching the intermediate layers.

## Layer wiring (10 touch points + 1 new file)

| Layer | File | Change |
|---|---|---|
| 1 | `events/events.py` | `EventLog(plan_step=...)` mirrors `agent_id` / `run_id` auto-injection (caller-wins). |
| 2 | `kernel/runtime.py` | `OSRuntime(plan_step=...)` passes through to `EventLog`. |
| 3 | `agent.py` | `Agent.run(plan_step=...)` forwards to `OSRuntime`. |
| 4 | `skill/sub_skill_runner.py` | `invoke_sub_skill(plan_step=...)` forwards to `agent.run`. |
| 5 | `op_runtime/context.py` | `OpContext.plan_step` field for phase-side reads. |
| 6 | `op_runtime/run_skill.py` | forwards `ctx.plan_step` to `invoke_sub_skill`. |
| 7 | `skill/_plan_step_context.py` (**NEW**) | `set_plan_step()` + `current_plan_step()` ContextVar bridge. |
| 8 | `chat/planner.py` | wraps each step's `sub_loop.run()` in `set_plan_step(n_done+1, n_total, step_id)`. |
| 9 | `chat/services/skill_runner.py` | `_run_one_skill` + `run_skill_awaitable` read `current_plan_step()` and forward to `agent.run`. |
| 10 | `chat/forwarder.py` | `on_phase_started` emits a one-shot `detail: plan N/M` trace BEFORE the phase trace; de-duped per `run_id`. |

## Why ContextVar bridge

The phase-side wiring (steps 5-6) covers the `run_skill` Control IR op path. The router-side wiring (steps 8-9) covers the `invoke_skill` tool path. Threading `plan_step` as a kwarg through RouterLoop → tool dispatcher → SkillRunner → `_build_agent_fn` → Agent would touch 4-5 extra layers for one signal. ContextVar:

- Set by planner at step boundary.
- Read by skill_runner at the `agent.run` spawn site.
- Propagates through `asyncio.Task` scope automatically (= Python `asyncio.Task` snapshots `contextvars.Context` on creation).
- Reset by the `with`-block exit on step completion.

Same architectural decision as how Python's `contextvars` module pairs with asyncio — set at outer scope, read at boundary, no intermediate threading.

## UX delta

Before:
```
14:32  reyn ──────────────
       ⠙ code_review#abcd  · resolve         3.1s
```
(= which step is this skill in? no idea)

After:
```
14:32  reyn ──────────────
       ⠙ code_review#abcd  · resolve         3.1s  ⤷ plan 2/3
```
(= "plan 2/3" rendered as detail on row mount; in-phase signals like `⤷ llm: gemini-2.5-flash-lite` take over once execution starts)

## Test plan

- [x] **Automated — `pytest tests/test_plan_step_context.py`**: 10/10 pass.
  - EventLog stamping (3): stamps, caller-wins, no-key passthrough.
  - ContextVar helpers (3): default None, with-block scope, nested restore.
  - Forwarder one-shot detail (4): emit on first phase_started, dedup per run_id, skip without plan_step, distinct run_ids each get own detail.
- [x] **Adjacent — plan + forwarder + run_id surfaces**: `pytest tests/test_sub_skill_run_id_attribution.py tests/test_act_executed_op_kinds.py tests/test_plan_multi_plan_resume_race.py tests/test_plan_router_narration_invariants.py tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py` → **152 passed, 1 expected xfail**. No `KNOWN_STATIC_QUALIFIED_NAMES` change.
- [x] **Lint — `ruff check`**: clean on all 10 touched + 2 new files.

## Out of scope

- TUI render of the `detail: plan N/M` trace — already routed via the existing `on_llm_called` / `on_act_executed` detail path (= the `ConversationView.update_skill_detail` method that appends `⤷ <text>` under the phase name). No TUI changes needed; the existing detail-routing handles it.
- Resume from snapshot — when `_run_resumed_skill` rehydrates a sub-skill, it does not consult the planner's ContextVar (= the planner isn't running at that moment). plan_step would have to come from the saved snapshot, which is a separate FP if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)