### PR TITLE
fix(tui): optimistic 'thinking…' sticky on submit (close cancel→submit gap)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -563,6 +563,16 @@ class ReynTUIApp(App):
                 await self._dispatch_slash_no_session(text, conv)
         else:
             if session is not None:
+                # Optimistic sticky: the skill_runner emits its first
+                # ``status="thinking…"`` ~0.5s after submit (= when the
+                # LLM request is about to leave). Without this line the
+                # sticky bar is blank in that gap, which is most
+                # noticeable right after a Ctrl+C cancel (the user just
+                # cleared the previous spinner and wants instant
+                # confirmation the new turn is starting). When the
+                # natural ``thinking…`` message arrives, it overwrites
+                # with identical text — no flicker.
+                conv.show_status("thinking…", kind="thinking")
                 await session.submit_user_text(text)
             else:
                 from rich.text import Text as RichText


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- The skill_runner emits its first \`status="thinking…"\` only when the LLM request is about to leave — roughly half a second after the user hits Enter. Until then the sticky bar is blank.
- The gap is most noticeable right after a Ctrl+C cancel: \`action_cancel_inflight\` calls \`conv.hide_status()\` unconditionally, then the user types a new message, hits Enter, and watches a blank sticky for ~0.5s while wondering whether the new turn actually started. That's enough hesitation to start mashing Enter again.
- Fix: in the non-slash branch of \`on_input_bar_user_submitted\`, call \`conv.show_status("thinking…", kind="thinking")\` between \`render_user_message\` and \`session.submit_user_text\`. When the natural \`thinking…\` outbox message arrives, it overwrites with identical text — no flicker. Slash commands stay on the original path because they don't spawn an LLM call.

## Why TUI-only

Pure submit-path UX change in \`app.py\`. No session / skill_runner / forwarder changes.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 190 passed; no test asserted on the post-submit blank-sticky window.
- [x] **Code path verification** — the optimistic \`show_status("thinking…", kind="thinking")\` runs after \`render_user_message\` and before \`session.submit_user_text\`; the natural \`_on_status\` handler ([app_outbox.py:546](https://github.com/tya5/reyn/blob/main/src/reyn/chat/tui/app_outbox.py#L546)) routes the real \`status="thinking…"\` to the same \`show_status(...)\` call → identical text, no flicker.
- [ ] **Visual (skipped — local litellm/gemini round-trip completes in ~3s, faster than the tmux \`send-keys\` + \`capture-pane\` round-trip can reliably capture the 0.5s gap-then-fill).** Verified the code path documents the intended sequence and the natural status overwrites the optimistic one without state divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)