### PR TITLE
fix(describe_action): append _post_text directive outside JSON to close empty-stop

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1699,10 +1699,25 @@ class RouterLoop:
                     "tool_calls": tool_calls,
                 })
                 for tc, r in zip(tool_calls, tool_results):
+                    # B41-NF-W7-1: tool handlers may attach `_post_text` to
+                    # the result dict to surface a textual directive after
+                    # the JSON-serialised content (= a place the LLM reads
+                    # as instruction, not as part of the structured data).
+                    # The field is stripped before JSON serialisation and
+                    # appended outside the JSON body. P3-clean: OS handles
+                    # the serialisation contract, tool handler declares
+                    # intent via an optional field.
+                    post_text: str | None = None
+                    if isinstance(r, dict) and isinstance(r.get("_post_text"), str):
+                        post_text = r["_post_text"]
+                        r = {k: v for k, v in r.items() if k != "_post_text"}
+                    content_str = json.dumps(r, default=str)
+                    if post_text:
+                        content_str = f"{content_str}\n\n---\n{post_text}"
                     messages.append({
                         "role": "tool",
                         "tool_call_id": tc["id"],
-                        "content": json.dumps(r, default=str),
+                        "content": content_str,
                     })
                 continue
 

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -871,6 +871,18 @@ async def _handle_describe_action(
             "category": target.category,
             "purity": target.purity,
         },
+        # B41-NF-W7-1: post-call directive appended outside the JSON
+        # tool-result by the router-loop message-construction layer so the
+        # LLM sees a textual instruction after the metadata. Without this,
+        # follow-up queries that call describe_action (e.g. "tell me more
+        # about the simplest one") trigger 10/10 empty-stop in N=10 replay
+        # because the LLM treats the structured metadata as a self-contained
+        # answer. Variant F patch test (= directive appended outside the
+        # JSON) yielded 1/10 empty-stop on the same trace.
+        "_post_text": (
+            "The action metadata is above. The user is waiting for your "
+            "natural-language reply explaining this action. Write the reply now."
+        ),
     }
 
 

--- a/tests/test_describe_action_post_text.py
+++ b/tests/test_describe_action_post_text.py
@@ -1,0 +1,146 @@
+"""Tier 2: describe_action `_post_text` convention (B41-NF-W7-1 fix).
+
+Pinned invariants:
+
+- ``_handle_describe_action`` returns a ``_post_text`` field whose value is
+  the directive appended after the JSON body by the router-loop
+  message-construction layer.
+- The router-loop tool-result serialisation appends ``_post_text`` outside
+  the JSON content (= a textual instruction location the LLM reads as
+  guidance, not as part of the structured metadata) and strips the field
+  before JSON serialisation so the JSON body itself does not carry it.
+
+Reference: B41-NF-W7-1 retrospective + W7-S2 patch-isolation Variant F
+(= 10/10 → 1/10 empty-stop reduction with directive appended outside JSON).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import _handle_describe_action
+
+
+class _FakeEvents:
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+class _FakeHost:
+    def __init__(self, skills):
+        self._skills = skills
+
+    def list_available_skills(self):
+        return list(self._skills)
+
+
+def _make_ctx(skills=None):
+    rs = RouterCallerState(host=_FakeHost(skills or []))
+    return ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=rs,
+    )
+
+
+def _describe(qualified_name: str, ctx: ToolContext) -> dict:
+    return asyncio.run(_handle_describe_action(
+        {"action_name": qualified_name}, ctx,
+    ))
+
+
+def test_describe_action_returns_post_text_field():
+    """Tier 2: describe_action result carries a non-empty ``_post_text`` string."""
+    ctx = _make_ctx()
+    out = _describe("file__read", ctx)
+    assert "_post_text" in out
+    assert isinstance(out["_post_text"], str)
+    assert out["_post_text"].strip()
+
+
+def test_describe_action_post_text_references_reply_directive():
+    """Tier 2: post_text content directs the LLM to write a reply.
+
+    Pins the directive semantic (= "write the reply now") without locking
+    the exact wording — the substring "reply" is enough to confirm intent.
+    """
+    ctx = _make_ctx()
+    out = _describe("web__search", ctx)
+    assert "reply" in out["_post_text"].lower()
+
+
+def test_describe_action_other_fields_unchanged_by_post_text():
+    """Tier 2: adding ``_post_text`` does not displace the existing contract.
+
+    The pre-B41 fields (``qualified_name``, ``description``,
+    ``input_schema``, ``metadata``) must all remain present so callers that
+    consume describe_action programmatically keep working.
+    """
+    ctx = _make_ctx()
+    out = _describe("file__write", ctx)
+    for key in ("qualified_name", "description", "input_schema", "metadata"):
+        assert key in out, f"missing field: {key}"
+
+
+# ── router_loop tool-result serialisation: _post_text appended outside JSON ──
+
+
+def _construct_tool_message_content(r: dict) -> str:
+    """Inline duplication of the router_loop tool-result serialisation step.
+
+    Mirrors the production code in src/reyn/chat/router_loop.py around the
+    ``messages.append({"role": "tool", ...})`` block: strip ``_post_text``
+    from the dict, JSON-serialise the remainder, then append the directive
+    outside the JSON body separated by ``\\n\\n---\\n``.
+    """
+    post_text: str | None = None
+    if isinstance(r, dict) and isinstance(r.get("_post_text"), str):
+        post_text = r["_post_text"]
+        r = {k: v for k, v in r.items() if k != "_post_text"}
+    content_str = json.dumps(r, default=str)
+    if post_text:
+        content_str = f"{content_str}\n\n---\n{post_text}"
+    return content_str
+
+
+def test_serialisation_strips_post_text_from_json_body():
+    """Tier 2: ``_post_text`` does not leak into the JSON body."""
+    r = {"qualified_name": "x", "_post_text": "directive"}
+    content = _construct_tool_message_content(r)
+    json_part, _, _ = content.partition("\n\n---\n")
+    body = json.loads(json_part)
+    assert "_post_text" not in body
+    assert body["qualified_name"] == "x"
+
+
+def test_serialisation_appends_post_text_outside_json():
+    """Tier 2: directive is appended after the JSON body, separated by ``---``."""
+    r = {"qualified_name": "x", "_post_text": "the directive"}
+    content = _construct_tool_message_content(r)
+    assert content.endswith("\n\n---\nthe directive")
+
+
+def test_serialisation_noop_when_post_text_absent():
+    """Tier 2: dict without ``_post_text`` produces pure-JSON content (no suffix)."""
+    r = {"qualified_name": "x", "description": "d"}
+    content = _construct_tool_message_content(r)
+    parsed = json.loads(content)
+    assert parsed == r
+    assert "---" not in content
+
+
+def test_serialisation_noop_when_post_text_non_string():
+    """Tier 2: non-string ``_post_text`` values are ignored (defensive).
+
+    Defensive against accidental dict / list / None values from future
+    handlers; the field type contract is ``str``, anything else falls
+    through to the no-op path.
+    """
+    r = {"qualified_name": "x", "_post_text": 12345}
+    content = _construct_tool_message_content(r)
+    parsed = json.loads(content)
+    assert parsed.get("_post_text") == 12345  # Kept inside JSON (no strip)
+    assert "---" not in content


### PR DESCRIPTION
**[dogfood-coder]** — fix B41-NF-W7-1 (MED): describe_action result empty-stop.

## Problem (= B41 W7-S2)

Follow-up query 「Tell me more about the simplest one」 で LLM が `describe_action(skill__direct_llm)` を呼ぶと、 metadata 受領後 0-token finish=stop。 N=10 patch-isolation で 10/10 empty stop。

Pre-existing latent (= B40 v2 / G12 fix どちらも root cause 除外、 deeper design issue per care-boundary §3)。

## Fix design

`_handle_describe_action` の return dict に `_post_text` field 追加 + router_loop の tool-result serialization layer で `_post_text` を JSON 外 `\n\n---\n<text>` として append。 LLM は JSON 内 field を metadata と認識、 JSON 外 text を instruction として読む (= patch test で経験的に判明)。

P3-clean: OS が serialization 契約を持つ、 tool handler は optional field で intent 宣言、 再利用可能。

## Patch isolation evidence

| Variant | empty stop rate (N=10) |
|---|---|
| Baseline (current G12 signal あり) | 10/10 |
| Variant A: `_reply_hint` JSON field | 10/10 (= JSON field は metadata 扱い) |
| Variant B: stronger G12 signal | 10/10 |
| Variant C: directive prefix BEFORE JSON | 7/10 |
| **Variant F: directive AFTER JSON outside body** | **1/10** ✓ |
| Variant G: shorter wording | 8/10 |

採用 wording: `"The action metadata is above. The user is waiting for your natural-language reply explaining this action. Write the reply now."`

## Verify

- Live W7-S2 retest: T2 で **NL reply 生成成功** (empty stop なし)
- 7 new Tier 2 tests (= `_post_text` 存在 / directive 内容 / 既存 contract 維持 / serialization 4 invariants)
- 既存 `test_describe_action_resource_schemas` 14 passed
- Full pytest **3860 passed**, 5 skipped, 3 xfailed (0 regression)
- ruff clean

## Files

- `src/reyn/tools/universal_catalog.py`: `_handle_describe_action` に `_post_text` field
- `src/reyn/chat/router_loop.py`: tool-result serialization で `_post_text` strip + append outside JSON
- `tests/test_describe_action_post_text.py`: 7 Tier 2

## Test plan (author checklist)

- [x] pytest tests/test_describe_action_post_text.py — 7 passed
- [x] pytest tests/test_describe_action_resource_schemas.py — 14 passed (regression guard)
- [x] Full pytest — 3860 passed, 0 regression
- [x] ruff clean
- [x] Live verify W7-S2 = NL reply (= empty stop closed)
- [x] Patch-isolation evidence table (6 variants × N=10) → Variant F 1/10 wins

## Notes for reviewer

- B41-NF-W7-1 (MED) carry-over from PR #190 retrospective
- `_post_text` convention は再利用可能 (= 他 tool が 「結果を narrate させたい」 時の generic mechanism)
- Variant F は N=10 で 1/10 residual stop、 完全 0/10 ではない (= 残 10% は別 attractor、 別 batch で観察)
- P3-clean: OS serialization 拡張、 tool handler はマーカ宣言のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)