### PR TITLE
feat(tui): render sub-skill rows nested under their parent (closes #210)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -374,6 +374,12 @@ class ReynTUIApp(App):
                 # that's still running when the user types another
                 # message keeps the message that actually started it.
                 "triggered_by": self._latest_user_message,
+                # Stamped by ChatEventForwarder._enqueue (PR #198) on
+                # every sub-skill trace. Empty when this is a root
+                # skill. Used by the conv pane (issue #210 child row
+                # indent) and the right-panel agents tab (RichTree
+                # nesting under parent).
+                "parent_run_id": msg.meta.get("parent_run_id", ""),
             }
             self._skill_exec[run_id] = existing
             # Mirror to the persistent map so recent_skill (= post-skill_done)
@@ -421,7 +427,11 @@ class ReynTUIApp(App):
         if text.startswith("phase started: "):
             phase = text[len("phase started: "):].strip()
             # Lazy-create the row if first trace
-            conv.start_skill_row(run_id, skill_name)
+            conv.start_skill_row(
+                run_id,
+                skill_name,
+                parent_run_id=msg.meta.get("parent_run_id", ""),
+            )
             # Track phase visit count from existing exec state
             existing = self._skill_exec.get(run_id) or {}
             visit = int(existing.get("phase_visits", 0)) + 1
@@ -449,7 +459,11 @@ class ReynTUIApp(App):
             # If no row exists yet (edge case: a malformed forwarder
             # delivered phase_completed before phase_started), lazy-mount
             # to keep behaviour robust.
-            conv.start_skill_row(run_id, skill_name)
+            conv.start_skill_row(
+                run_id,
+                skill_name,
+                parent_run_id=msg.meta.get("parent_run_id", ""),
+            )
             visit = int(existing.get("phase_visits", 1)) or 1
             conv.update_skill_phase(run_id, transition, visit=visit)
             self._last_focal_tab = "agents"

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -728,20 +728,38 @@ class ConversationView(Widget):
 
     # ── skill activity rows (C1+A1) ──────────────────────────────────────────
 
-    def start_skill_row(self, run_id: str, skill_name: str) -> SkillActivityRow:
+    def start_skill_row(
+        self,
+        run_id: str,
+        skill_name: str,
+        *,
+        parent_run_id: str = "",
+    ) -> SkillActivityRow:
         """Mount (or return existing) SkillActivityRow for a skill run.
 
         Suppresses the noisy `· phase started: …` trace stream by giving it
         a single ambient widget that updates in-place.
+
+        ``parent_run_id`` (issue #210): when non-empty AND a row for that
+        parent is currently mounted, the new row renders with a ``  └─ ``
+        prefix so sub-skill spawns visibly nest under their parent in the
+        conv pane. If the parent's row has already finished (= rotated
+        out of ``_skill_rows``) the child renders as a normal root row —
+        an orphaned ``└─`` connector pointing at a vanished line would
+        be more confusing than no indent at all.
         """
         existing = self._skill_rows.get(run_id)
         if existing is not None:
             return existing
         self._consume_empty_hint()
+        label_prefix = ""
+        if parent_run_id and parent_run_id in self._skill_rows:
+            label_prefix = "  └─ "
         row = SkillActivityRow(
             run_id=run_id,
             skill_name=skill_name,
             id=f"skillrow_{run_id[:8]}",
+            label_prefix=label_prefix,
         )
         self._skill_rows[run_id] = row
         self.mount(row)

--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -525,7 +525,22 @@ def render_agents(
             return ("  ", "")
 
         if agent_skills:
-            for run_id, info in agent_skills:
+            # Topological order: roots first, then children. Issue #210
+            # nests sub-skill rows under their parent's RichTree node when
+            # the parent is also a currently-running skill (= still in
+            # ``exec_state``). Parent finished / parent on a different
+            # agent → render the child as a root row to avoid an
+            # orphaned tree branch pointing at nothing. The OS only
+            # stamps ``parent_run_id`` for **direct** parents (no
+            # multi-hop lineage), so a single roots-then-children pass
+            # is sufficient.
+            agent_skill_ids = {rid for rid, _info in agent_skills}
+            nodes_by_run_id: dict[str, Any] = {}
+
+            def _emit_skill_row(
+                run_id: str, info: dict, parent_node: Any,
+            ) -> None:
+                nonlocal y_counter
                 elapsed = int(now - info.get("start_time", now))
                 pfx, name_style = _cursor_prefix(len(flat_items))
                 skill_label = RichText()
@@ -544,10 +559,11 @@ def render_agents(
                     info.get("skill_name", "?"),
                     style=name_style or "#dddddd",
                 )
-                skill_node = tree.add(skill_label)
-                # Record the y of this item's selectable row, then bump
-                # past the skill row (and an optional phase child row).
+                skill_node = parent_node.add(skill_label)
+                nodes_by_run_id[run_id] = skill_node
                 item_ys.append(y_counter)
+                # Track the y advance: one for the skill row, plus one for
+                # the optional phase child below.
                 y_counter += 1
 
                 phase = info.get("phase", "")
@@ -572,7 +588,29 @@ def render_agents(
                     # Empty string when unknown (= e.g. session restored
                     # from disk, or skill spawned by a non-chat caller).
                     "triggered_by": info.get("triggered_by", ""),
+                    # Issue #210: surface parent linkage in flat_items so
+                    # the preview pane / future actions can route by it.
+                    "parent_run_id": info.get("parent_run_id", ""),
                 })
+
+            # Pass 1: root skills (no parent OR parent not on this agent
+            # / already finished).
+            roots: list[tuple[str, dict]] = []
+            children: list[tuple[str, dict]] = []
+            for run_id, info in agent_skills:
+                parent_id = info.get("parent_run_id", "")
+                if parent_id and parent_id in agent_skill_ids:
+                    children.append((run_id, info))
+                else:
+                    roots.append((run_id, info))
+            for run_id, info in roots:
+                _emit_skill_row(run_id, info, tree)
+            # Pass 2: children nest under their parent's skill_node.
+            for run_id, info in children:
+                parent_node = nodes_by_run_id.get(
+                    info.get("parent_run_id", ""), tree,
+                )
+                _emit_skill_row(run_id, info, parent_node)
 
         # Plan-mode (ADR-0022 / 0023). Surfaced as a sibling of running
         # skills — same agent can simultaneously run skills + plans.

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -77,11 +77,19 @@ class SkillActivityRow(Widget):
         run_id: str,
         skill_name: str,
         id: str | None = None,
+        label_prefix: str = "",
     ) -> None:
         super().__init__(id=id)
         self._run_id = run_id
         self._skill_name = skill_name
         self._short_id = run_id[:4]
+        # ``label_prefix`` (e.g. ``"  └─ "``) renders before the spinner /
+        # ✓ glyph so a sub-skill row visibly nests under its parent in
+        # the conv pane. Empty (= root skill) keeps the original layout.
+        # Parents and children share the same widget — only the prefix
+        # differs — so spinner / detail / finish styling stay consistent
+        # across the hierarchy.
+        self._label_prefix = label_prefix
 
         # Running state
         self._phase: str = ""
@@ -188,6 +196,8 @@ class SkillActivityRow(Widget):
 
     def _build_running(self) -> Text:
         t = Text()
+        if self._label_prefix:
+            t.append(self._label_prefix, style="dim #666666")
         # Animated braille spinner — replaces the static ▶ so "still
         # alive" is obvious even when the response was streamed and the
         # user is wondering "is this skill still doing things?".
@@ -228,6 +238,8 @@ class SkillActivityRow(Widget):
 
     def _build_finished(self) -> Text:
         t = Text()
+        if self._label_prefix:
+            t.append(self._label_prefix, style="dim #666666")
         if self._success:
             t.append("✓ ", style="bold green")
             t.append(

--- a/tests/cli/test_agents_tab_subskill_nesting.py
+++ b/tests/cli/test_agents_tab_subskill_nesting.py
@@ -1,0 +1,143 @@
+"""Tier 2: render_agents nests sub-skill rows under their parent.
+
+Issue #210 — the OS-side ``parent_run_id`` stamp (PR #198) already lands
+on every sub-skill trace's ``OutboxMessage.meta``; the TUI consumes it
+when building the right-panel agents tree.
+
+Contract pinned here (public surface of ``render_agents``):
+
+1. ``flat_items`` carries ``parent_run_id`` for every running_skill entry.
+2. A skill with ``parent_run_id`` matching another running skill's
+   ``run_id`` (on the same agent) is rendered as a *child* of that
+   parent — verified via flat_items ordering (parent emits first) and
+   the absence of duplicate roots.
+3. Children whose parent is NOT among the running skills (= parent
+   already finished, or on a different agent) gracefully fall back to
+   root rendering — no crash, no orphan.
+
+Cursor / item_ys logic is exercised but specific y-coordinates are not
+pinned (algorithm-level layout per testing.ja.md).
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _make_registry(tmp_path):
+    from reyn.chat.registry import AgentRegistry
+
+    def _factory(profile):
+        return object()
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=None,
+    )
+
+
+def _exec_entry(skill_name: str, parent_run_id: str = ""):
+    return {
+        "skill_name": skill_name,
+        "agent_name": "default",
+        "start_time": time.monotonic(),
+        "phase": "phase_a",
+        "phase_visits": 1,
+        "triggered_by": "test",
+        "parent_run_id": parent_run_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_running_skill_items_carry_parent_run_id_field(tmp_path):
+    """Tier 2: ``running_skill`` flat_items expose ``parent_run_id``."""
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {"r-A": _exec_entry("root_skill", parent_run_id="")}
+
+    _, flat_items, _ = render_agents(registry, exec_state, cursor=0)
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    assert len(skill_items) == 1
+    assert "parent_run_id" in skill_items[0]
+    assert skill_items[0]["parent_run_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_parent_emits_before_child_in_flat_items(tmp_path):
+    """Tier 2: a child references its parent and the parent emits first.
+
+    Pins the topological-order contract: roots first, then children.
+    Without it, cursor navigation could land on a child before its
+    parent is even visible in the flat list.
+    """
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    # Insert child BEFORE parent in the dict to verify ordering is not
+    # accidental (dict iteration order would put child first).
+    exec_state = {
+        "r-B": _exec_entry("child_skill", parent_run_id="r-A"),
+        "r-A": _exec_entry("root_skill"),
+    }
+
+    _, flat_items, _ = render_agents(registry, exec_state, cursor=0)
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    run_ids_in_order = [i["run_id"] for i in skill_items]
+    assert run_ids_in_order.index("r-A") < run_ids_in_order.index("r-B"), (
+        f"parent r-A must emit before child r-B; got {run_ids_in_order!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_orphan_child_falls_back_to_root_render(tmp_path):
+    """Tier 2: a child whose ``parent_run_id`` is not in exec_state still renders.
+
+    Edge case: the parent has already finished (rotated out of
+    ``_skill_exec``) but the child trace still carries the parent id.
+    The render must not crash and must still surface the child somewhere
+    — falling back to root-row rendering is the contract.
+    """
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {
+        "r-B": _exec_entry("orphan_child", parent_run_id="r-A-finished"),
+    }
+
+    _, flat_items, _ = render_agents(registry, exec_state, cursor=0)
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    assert len(skill_items) == 1
+    assert skill_items[0]["run_id"] == "r-B"
+
+
+@pytest.mark.asyncio
+async def test_two_children_one_parent_all_emit(tmp_path):
+    """Tier 2: multiple children of the same parent all appear in flat_items.
+
+    Pins that the topological pass doesn't accidentally drop siblings
+    (= a "second child overwrites first" bug would corrupt navigation).
+    """
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {
+        "r-A": _exec_entry("root_skill"),
+        "r-B1": _exec_entry("child_one", parent_run_id="r-A"),
+        "r-B2": _exec_entry("child_two", parent_run_id="r-A"),
+    }
+
+    _, flat_items, _ = render_agents(registry, exec_state, cursor=0)
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    run_ids = {i["run_id"] for i in skill_items}
+    assert run_ids == {"r-A", "r-B1", "r-B2"}
+    # Item count must equal flat_items length for the parent + 2 children.
+    # (Other agents may add their own rows but with one agent and three
+    # skills, we expect exactly 3 running_skill entries.)
+    assert len(skill_items) == 3


### PR DESCRIPTION
**[tui-coder]** —

Closes #210.

## Summary

OS-side wiring for sub-skill parent linkage was completed by PR #198 (issue #134) — every sub-skill \`OutboxMessage\` now carries \`meta["parent_run_id"]\` pointing at its spawner. The TUI was discarding that field, so a skill that called \`run_skill\` produced two visually unrelated rows in the conv pane and the right-panel agents tab; the user couldn't tell that the inner skill was a child of the outer.

This PR consumes \`parent_run_id\` in four places — all TUI-local, no OS / forwarder changes:

1. **\`SkillActivityRow\`** gains a \`label_prefix\` constructor arg. Running and finished render paths both prepend it before the spinner / ✓ glyph, so a child row starts with \`  └─ \` and visually nests under its parent in the conv pane.
2. **\`ConversationView.start_skill_row\`** accepts \`parent_run_id\` and computes \`label_prefix\` from it. If the parent row is no longer mounted (= parent finished before the child trace arrived), the child falls back to root-style rendering — an orphan \`└─\` pointing at a vanished line would be more confusing than no indent.
3. **\`render_agents\`** (right-panel agents tab) does a roots-then-children pass over \`exec_state\`: roots emit first under the agent's tree, children emit as RichTree sub-nodes of their parent's \`skill_node\`. \`flat_items\` carries \`parent_run_id\` so the preview pane / future actions can route by it.
4. **\`ReynTUIApp._update_skill_exec\`** stores \`parent_run_id\` in the per-run dict so the right-panel can read it without re-parsing meta.

## Scope

Per the issue: direct-parent linkage only (no multi-hop / grandparent). The OS only stamps the immediate parent, so a single roots-then-children pass is sufficient.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_agents_tab_subskill_nesting.py\`, 4 cases:
  - \`flat_items\` carries \`parent_run_id\` for every running_skill entry
  - parent emits before child in flat_items (even when child precedes parent in dict insertion order)
  - orphan child (= parent not in exec_state) falls back to root rendering, no crash
  - 2 children of 1 parent all appear in flat_items
- [x] **Existing tests** — \`pytest tests/cli/\` 194 passed (190 + 4 new).
- [x] **Manual smoke** — tmux: \`reyn chat\` → \`hello world\` → reply lands → Ctrl+B → switch to agents tab (Ctrl+W ×2). Render is clean, no errors. \`▶ default ◐ ready\` + recent skills show as before.
- [ ] **Manual (skipped — requires invoking a skill that calls \`run_skill\` Control IR op; no easy one-liner repro in the bundled stdlib):** trigger a sub-skill spawn and observe the child row rendering with the \`└─\` indent in conv pane + as a nested RichTree node in agents tab. Verified structurally via the Tier 2 tests above and the topological pass logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)