### PR TITLE
feat(tui): Memory tab 'Hot now' section consumes hot_list_updated (closes #192)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -80,6 +80,7 @@ class OutboxRouter:
             # trace text from ChatEventForwarder (workflow_finished /
             # workflow_aborted events) and handled in app._handle_trace_for_skill_row.
             "error":                    self._on_error,
+            "hot_list_updated":         self._on_hot_list_updated,
         }
 
     # ── transient sticky helpers ──────────────────────────────────────────────
@@ -573,6 +574,36 @@ class OutboxRouter:
         # Reset on the next user submit.
         self._app.set_title_state("error")
         self._app.alert()
+
+    def _on_hot_list_updated(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """`hot_list_updated` — refresh the app's cached hot-list ranking.
+
+        The forwarder emits this whenever the qualified-name **order**
+        changes (= ``ActionUsageTracker.record()`` detects a top-N diff;
+        score-only bumps within a stable order are suppressed upstream).
+        The Memory tab reads the cached ranking when it next paints
+        ("Hot now" sub-section), so we trigger a panel refresh here
+        instead of waiting for the user to switch tabs.
+
+        ``meta["ranking"]`` is a list of dicts
+        ``[{"qualified_name": str, "freq": int, "last_ts": str}, ...]``,
+        full ranking (= not top-N). Missing / malformed → empty list.
+        """
+        raw = msg.meta.get("ranking") if msg.meta else None
+        ranking = list(raw) if isinstance(raw, list) else []
+        # Push to the right panel's cache. ``update_hot_list`` triggers
+        # an invalidate only when the Memory tab is currently visible —
+        # other tabs see the new ranking the next time the user
+        # switches to Memory (state is already cached on the panel).
+        try:
+            from .widgets import RightPanel
+            self._app.query_one(
+                "#right_panel", RightPanel,
+            ).update_hot_list(ranking)
+        except Exception:
+            pass
 
 
 __all__ = ["OutboxRouter"]

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -137,6 +137,14 @@ class RightPanel(Widget):
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
+        # Latest ARS hot-list ranking from ChatLifecycleForwarder (issue
+        # #192). ``[{"qualified_name": str, "freq": int, "last_ts": str},
+        # ...]`` full ranking. Fed by ``update_hot_list`` (= driven from
+        # ``OutboxRouter._on_hot_list_updated``). The Memory tab renders
+        # a "Hot now" sub-section above SHARED / AGENT scopes when the
+        # list is non-empty; otherwise the section is omitted entirely
+        # so the existing layout is unchanged on cold-start.
+        self._hot_list_ranking: list[dict] = []
         # y-coord (0-indexed line) of each memory entry's name row in the
         # rendered output. Populated by `render_memory`; used by
         # `_scroll_memory_into_view` to keep the cursor visible as j/k
@@ -254,6 +262,19 @@ class RightPanel(Widget):
         """
         self._exec_state = dict(state)
         if self._panel_type == "agents":
+            self._invalidate()
+
+    def update_hot_list(self, ranking: list[dict]) -> None:
+        """Receive the latest ARS hot-list ranking from the TUI app.
+
+        Called from ``OutboxRouter._on_hot_list_updated`` whenever the
+        forwarder emits a ``hot_list_updated`` outbox message (= the
+        qualified-name order changed). Triggers a re-render only when
+        the Memory tab is visible — the cached ranking is consumed on
+        the next paint of any other tab via the same field.
+        """
+        self._hot_list_ranking = list(ranking)
+        if self._panel_type == "memory":
             self._invalidate()
 
     def _panel_resize(self, delta: int) -> None:
@@ -1542,7 +1563,9 @@ class RightPanel(Widget):
                 return rendered
             if self._panel_type == "memory":
                 rendered, flat_entries, entry_ys = render_memory(
-                    self._project_root, cursor=self._memory_cursor,
+                    self._project_root,
+                    cursor=self._memory_cursor,
+                    hot_list=self._hot_list_ranking,
                 )
                 self._memory_entries = flat_entries
                 self._memory_entry_ys = entry_ys

--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -14,10 +14,14 @@ _TYPE_COLORS: dict[str, str] = {
 }
 
 
+_HOT_LIST_MAX_VISIBLE = 8
+
+
 def render_memory(
     project_root: Path | None,
     *,
     cursor: int = 0,
+    hot_list: list[dict] | None = None,
 ) -> tuple[str, list[Any], list[int]]:
     """Return Rich markup + the flat ordered list of MemoryEntry items
     + the y-coordinate (= 0-indexed line number) of each entry's name row.
@@ -30,6 +34,14 @@ def render_memory(
     the rendered output. Section labels, per-type subheaders and blank
     separators all bump the y, so the orchestrator can't predict it
     arithmetically — we record it here, where the structure is known.
+
+    ``hot_list`` (issue #192): the latest ARS qualified-name ranking
+    from ``ChatLifecycleForwarder.on_hot_list_updated``. When non-empty,
+    a "Hot now" sub-section renders above SHARED / AGENT scopes so the
+    user can see why the router preferred skill X over Y on the last
+    turn. The hot list is **not** part of ``flat_entries`` — entries
+    listed there are MemoryEntry items, and the hot list carries
+    qualified action names which are a different kind of object.
     """
     if project_root is None:
         return "[#555555]  (no project root)[/]", [], []
@@ -39,6 +51,32 @@ def render_memory(
     lines: list[str] = []
     flat_entries: list[Any] = []
     entry_ys: list[int] = []
+
+    # Hot now section (issue #192). Renders only when the list is
+    # populated — keeps the cold-start layout (= no router activity
+    # yet) untouched. Capped at _HOT_LIST_MAX_VISIBLE so a long
+    # ranking doesn't push the SHARED / AGENT entries off the top
+    # of a narrow panel.
+    if hot_list:
+        lines.append(f"[bold #ffaa44]  HOT NOW[/]")
+        for entry in hot_list[:_HOT_LIST_MAX_VISIBLE]:
+            try:
+                name = str(entry.get("qualified_name", ""))
+                freq = int(entry.get("freq", 0))
+            except (AttributeError, ValueError, TypeError):
+                continue
+            if not name:
+                continue
+            lines.append(
+                f"[#ffaa44]    🔥 [/][#dddddd]{_esc(name)}[/]  "
+                f"[#666666]×{freq}[/]"
+            )
+        overflow = len(hot_list) - _HOT_LIST_MAX_VISIBLE
+        if overflow > 0:
+            lines.append(
+                f"[#555555]    … {overflow} more[/]"
+            )
+        lines.append("")
 
     def _render_scope(entries: list, label: str, label_color: str) -> None:
         lines.append(f"[bold {label_color}]  {_esc(label)}[/]")

--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -58,7 +58,7 @@ def render_memory(
     # ranking doesn't push the SHARED / AGENT entries off the top
     # of a narrow panel.
     if hot_list:
-        lines.append(f"[bold #ffaa44]  HOT NOW[/]")
+        lines.append("[bold #ffaa44]  HOT NOW[/]")
         for entry in hot_list[:_HOT_LIST_MAX_VISIBLE]:
             try:
                 name = str(entry.get("qualified_name", ""))

--- a/tests/cli/test_memory_tab_hot_list.py
+++ b/tests/cli/test_memory_tab_hot_list.py
@@ -1,0 +1,130 @@
+"""Tier 2: Memory tab renders a "Hot now" sub-section when hot_list is non-empty.
+
+Issue #192 — ``ChatLifecycleForwarder.on_hot_list_updated`` (PR #211)
+emits ``OutboxMessage(kind="hot_list_updated", text="",
+meta={"ranking": [{qualified_name, freq, last_ts}, ...]})`` whenever
+``ActionUsageTracker.record()`` detects a qualified-name order change.
+The Memory tab surfaces the latest ranking as a "Hot now" sub-section
+above SHARED / AGENT scopes.
+
+Contract pinned here:
+
+1. Empty / missing ``hot_list`` → no "HOT NOW" header in the rendered
+   output (= cold-start layout unchanged).
+2. Non-empty ``hot_list`` → "HOT NOW" header appears + each entry's
+   qualified_name + freq lands in the output.
+3. ``flat_entries`` is NOT polluted with hot-list rows (they are
+   action qualified-names, not MemoryEntry items — they shouldn't
+   participate in j/k cursor navigation over memory).
+4. Malformed entries (missing keys / wrong types) are skipped, not
+   crashed-on.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _project_with_empty_memory(tmp_path: Path) -> Path:
+    """Build a minimum project root the renderer can walk."""
+    (tmp_path / ".reyn" / "memory").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_no_hot_list_omits_hot_now_section(tmp_path):
+    """Tier 2: empty hot_list keeps the existing layout untouched."""
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=None,
+    )
+    assert "HOT NOW" not in rendered
+
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=[],
+    )
+    assert "HOT NOW" not in rendered
+
+
+def test_hot_list_renders_qualified_name_and_freq(tmp_path):
+    """Tier 2: each ranking entry's name + freq surface in the rendered output."""
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    hot = [
+        {"qualified_name": "skill__direct_llm", "freq": 7, "last_ts": "..."},
+        {"qualified_name": "skill__eval", "freq": 3, "last_ts": "..."},
+    ]
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=hot,
+    )
+    assert "HOT NOW" in rendered
+    assert "skill__direct_llm" in rendered
+    assert "skill__eval" in rendered
+    # The frequency markers should be present (the exact formatting is
+    # not pinned — only that the count is visible somewhere).
+    assert "×7" in rendered
+    assert "×3" in rendered
+
+
+def test_hot_list_does_not_populate_flat_entries(tmp_path):
+    """Tier 2: hot-list rows are not memory entries → not in flat_entries.
+
+    ``flat_entries`` drives j/k cursor navigation over MemoryEntry items.
+    Hot-list rows are action qualified-names (not MemoryEntry), so they
+    must NOT participate in that cursor or the Enter→preview integration
+    will receive a dict where it expects a MemoryEntry.
+    """
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    hot = [{"qualified_name": "skill__direct_llm", "freq": 1, "last_ts": ""}]
+    _rendered, flat_entries, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=hot,
+    )
+    # Empty project memory + 1 hot row → flat_entries stays empty.
+    assert flat_entries == []
+
+
+def test_hot_list_skips_malformed_entries_without_crashing(tmp_path):
+    """Tier 2: missing-keys / wrong-types entries don't crash the render.
+
+    The forwarder normalises shape but a partial-roll out (= older OS
+    image emitting a thin payload) shouldn't take down the Memory tab.
+    """
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    hot = [
+        {"qualified_name": "skill__direct_llm", "freq": 5, "last_ts": ""},
+        {"qualified_name": "", "freq": 1},          # empty name → skipped
+        {"freq": 1},                                 # missing name → skipped
+        {"qualified_name": "skill__eval", "freq": "not-an-int"},  # bad type → skipped
+        "not-a-dict",                                # bad shape → skipped
+    ]
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=hot,
+    )
+    assert "HOT NOW" in rendered
+    assert "skill__direct_llm" in rendered
+    # Malformed entries are skipped (they should NOT appear in output).
+    # The only successfully-rendered entry stays visible.
+    assert "skill__eval" not in rendered
+
+
+def test_hot_list_overflow_marker(tmp_path):
+    """Tier 2: ranking longer than the visible cap shows ``… N more``."""
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    hot = [
+        {"qualified_name": f"skill__entry_{i}", "freq": 10 - i, "last_ts": ""}
+        for i in range(12)
+    ]
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=hot,
+    )
+    # 12 entries; cap is 8 in the renderer → 4 should be hidden.
+    assert "more" in rendered


### PR DESCRIPTION
**[tui-coder]** —

Closes #192.

## Summary

OS-side wiring for the ARS hot-list signal landed in PR #211 — \`ChatLifecycleForwarder.on_hot_list_updated\` emits \`OutboxMessage(kind="hot_list_updated", text="", meta={"ranking": [{qualified_name, freq, last_ts}, ...]})\` whenever \`ActionUsageTracker.record()\` detects a qualified-name order change (= score-only bumps within a stable order are suppressed upstream).

This PR adds the TUI consumer — four small pieces:

1. **\`OutboxRouter._on_hot_list_updated\`** caches the ranking on the RightPanel via the new \`update_hot_list\` method.
2. **\`RightPanel.update_hot_list\`** stores the latest ranking and invalidates the panel only when the Memory tab is currently visible (= same pattern as \`update_exec_state\`).
3. **\`render_memory\`** gains an optional \`hot_list\` parameter. When non-empty, a "HOT NOW" sub-section renders above SHARED / AGENT scopes with \`🔥 <qualified_name>  ×<freq>\` rows. Cap of 8 visible + \`… N more\` overflow marker. Cold-start layout preserved when the list is empty.
4. Hot-list rows are **NOT** part of \`flat_entries\` — they are action qualified-names, not MemoryEntry items, so they don't participate in j/k cursor navigation over memory entries.

## Why TUI-only

OS-side already emits the signal (PR #211). No forwarder / session / tracker changes. Pure consumer.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_memory_tab_hot_list.py\`, 5 cases:
  - Empty / missing \`hot_list\` → no "HOT NOW" section (cold-start unchanged)
  - Non-empty list → "HOT NOW" header + qualified_name + freq visible
  - \`flat_entries\` stays free of hot-list rows
  - Malformed entries (missing keys / wrong types / non-dict) skipped, no crash
  - Ranking longer than the cap → \`… N more\` overflow marker
- [x] **Existing tests** — \`pytest tests/cli/\` 195 passed (190 + 5 new).
- [x] **Manual end-to-end** — tmux: \`reyn chat\` → Memory tab via Ctrl+B/Ctrl+W (cold start: no HOT NOW section ✓) → send \`hello\`, then \`remember "test note for hot list"\` → Memory tab now shows HOT NOW with 7 entries (\`🔥 skill__direct_llm\`, \`🔥 file__read ×4\`, \`🔥 skill__word_stats_demo\`, \`🔥 exec__sandbox\`, …) above the freshly-saved SHARED [USER] entry. Layout intact, no overlap, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)