### PR TITLE
feat(permissions): per-gate natural-language phrasing for user prompts (#224)

### DIFF
--- a/dogfood/scripts/verify_permission_prompt_structure.py
+++ b/dogfood/scripts/verify_permission_prompt_structure.py
@@ -80,10 +80,12 @@ async def main() -> int:
     print()
 
     # Construct the UserIntervention that _prompt would build for a
-    # web.fetch request. Mirrors permissions.py:_prompt exactly.
+    # web.fetch request. Mirrors permissions.py:_prompt exactly,
+    # post-#224 natural-language phrasing (= require_web_fetch passes
+    # ``user_prompt="Allow fetching this URL?"`` to _approve).
     iv = UserIntervention(
         kind="permission.generic",
-        prompt="Permission request — web.fetch",
+        prompt="Allow fetching this URL?",
         detail="web fetch: https://example.com",
         choices=generic_yn_choices(),
         run_id="dogfood-verify-run",
@@ -98,7 +100,7 @@ async def main() -> int:
     all_ok &= _check("kind == 'intervention'", msg.kind == "intervention")
     all_ok &= _check(
         "text contains the prompt header",
-        "Permission request — web.fetch" in msg.text,
+        "Allow fetching this URL?" in msg.text,
     )
     all_ok &= _check(
         "text contains the detail line",
@@ -113,8 +115,8 @@ async def main() -> int:
     print()
     print("2. meta.prompt + meta.detail (structured TUI rendering, post-#163):")
     all_ok &= _check(
-        "meta.prompt == bare prompt header (no 'Question: ' prefix for permission kind)",
-        msg.meta.get("prompt") == "Permission request — web.fetch",
+        "meta.prompt == natural-language question (post-#224 phrasing)",
+        msg.meta.get("prompt") == "Allow fetching this URL?",
         detail=f"got: {msg.meta.get('prompt')!r}",
     )
     all_ok &= _check(

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -298,7 +298,14 @@ class PermissionResolver:
 
     # ── Core approval (non-file ops) ──────────────────────────────────────────
 
-    async def _approve(self, key: str, description: str, bus: InterventionBus) -> bool:
+    async def _approve(
+        self,
+        key: str,
+        description: str,
+        bus: InterventionBus,
+        *,
+        user_prompt: str | None = None,
+    ) -> bool:
         if self._is_config_approved(key):
             return True
         # Composite keys (e.g. "skill_router/python.safe/./mod.py:fn") accept
@@ -316,12 +323,25 @@ class PermissionResolver:
             return v
         if not self._interactive:
             return False
-        return await self._prompt(key, description, bus)
+        return await self._prompt(key, description, bus, user_prompt=user_prompt)
 
-    async def _prompt(self, key: str, description: str, bus: InterventionBus) -> bool:
+    async def _prompt(
+        self,
+        key: str,
+        description: str,
+        bus: InterventionBus,
+        *,
+        user_prompt: str | None = None,
+    ) -> bool:
+        # Issue #224: when the caller passes a user-facing question
+        # (e.g. "Allow fetching this URL?"), use it as the prompt header
+        # so light-users see a natural-language ask instead of the
+        # internal config key. Fallback "Permission request — {key}"
+        # preserves backward-compat for any caller that hasn't migrated
+        # yet (= shell / python / mcp / tool gates currently).
         iv = UserIntervention(
             kind="permission.generic",
-            prompt=f"Permission request — {key}",
+            prompt=user_prompt or f"Permission request — {key}",
             detail=description or key,
             choices=generic_yn_choices(),
         )
@@ -668,7 +688,12 @@ class PermissionResolver:
                 f"Add `permissions:\\n  shell: true` to the skill.md frontmatter."
                 f" (cmd: {cmd!r})"
             )
-        if not await self._approve("shell", f"shell command: {cmd!r}", bus):
+        if not await self._approve(
+            "shell",
+            f"shell command: {cmd!r}",
+            bus,
+            user_prompt="Allow running this shell command?",
+        ):
             raise PermissionError(f"shell access denied (cmd: {cmd!r})")
 
     async def require_mcp(
@@ -686,7 +711,12 @@ class PermissionResolver:
                 f"MCP server {server!r} not declared in skill permissions. "
                 f"Add `permissions:\\n  mcp: [{server}]` to the skill.md frontmatter."
             )
-        if not await self._approve(f"mcp.{server}", f"MCP server: {server!r}", bus):
+        if not await self._approve(
+            f"mcp.{server}",
+            f"MCP server: {server!r}",
+            bus,
+            user_prompt=f"Allow access to MCP server {server!r}?",
+        ):
             raise PermissionError(f"MCP server {server!r} access denied")
 
     async def require_mcp_install(
@@ -727,7 +757,12 @@ class PermissionResolver:
             self._persist(approval_key, True)
             return
 
-        if not await self._approve(approval_key, f"install MCP server: {server_id!r}", bus):
+        if not await self._approve(
+            approval_key,
+            f"install MCP server: {server_id!r}",
+            bus,
+            user_prompt=f"Install MCP server {server_id!r}?",
+        ):
             raise PermissionError(
                 f"MCP server install of {server_id!r} denied by user."
             )
@@ -770,7 +805,10 @@ class PermissionResolver:
             return
 
         if not await self._approve(
-            approval_key, f"drop index source: {source!r}", bus
+            approval_key,
+            f"drop index source: {source!r}",
+            bus,
+            user_prompt=f"Drop indexed source {source!r}?",
         ):
             raise PermissionError(
                 f"Index drop of '{source}' denied by user."
@@ -817,7 +855,10 @@ class PermissionResolver:
             return
 
         if not await self._approve(
-            approval_key, f"remove MCP server: {server!r}", bus,
+            approval_key,
+            f"remove MCP server: {server!r}",
+            bus,
+            user_prompt=f"Remove MCP server {server!r}?",
         ):
             raise PermissionError(
                 f"MCP server drop of {server!r} denied by user."
@@ -864,7 +905,12 @@ class PermissionResolver:
             # returns True instead of auto-denying the non-interactive branch.
             if not self._interactive and self._unsafe_python_allowed:
                 self._session.setdefault(key, True)
-            if not await self._approve(key, f"unsafe python step: {module}:{function}", bus):
+            if not await self._approve(
+                key,
+                f"unsafe python step: {module}:{function}",
+                bus,
+                user_prompt=f"Run unsafe python {module}.{function}?",
+            ):
                 raise PermissionError(
                     f"unsafe python step {module}:{function} denied by user"
                 )
@@ -878,7 +924,12 @@ class PermissionResolver:
         # siblings succeed — semantically backwards.
         if not self._interactive and self._unsafe_python_allowed:
             self._session.setdefault(key, True)
-        if not await self._approve(key, f"safe python step: {module}:{function}", bus):
+        if not await self._approve(
+            key,
+            f"safe python step: {module}:{function}",
+            bus,
+            user_prompt=f"Run python {module}.{function}?",
+        ):
             raise PermissionError(
                 f"safe python step {module}:{function} denied by user"
             )
@@ -892,7 +943,12 @@ class PermissionResolver:
                 f"tool {tool!r} not declared in skill permissions. "
                 f"Add `permissions:\\n  tool: [{tool}]` to the skill.md frontmatter."
             )
-        if not await self._approve(f"tool.{tool}", f"tool: {tool!r}", bus):
+        if not await self._approve(
+            f"tool.{tool}",
+            f"tool: {tool!r}",
+            bus,
+            user_prompt=f"Allow tool {tool!r}?",
+        ):
             raise PermissionError(f"tool {tool!r} access denied")
 
     async def require_web_fetch(self, url: str, bus: InterventionBus) -> None:
@@ -916,5 +972,10 @@ class PermissionResolver:
             raise PermissionError(
                 "web fetch denied by config (web.fetch: deny)"
             )
-        if not await self._approve("web.fetch", f"web fetch: {url}", bus):
+        if not await self._approve(
+            "web.fetch",
+            f"web fetch: {url}",
+            bus,
+            user_prompt="Allow fetching this URL?",
+        ):
             raise PermissionError("web fetch denied")

--- a/tests/test_permission_prompt_phrasing.py
+++ b/tests/test_permission_prompt_phrasing.py
@@ -1,0 +1,210 @@
+"""Tier 2: per-gate natural-language phrasing for permission prompts (#224).
+
+Pre-fix, every permission prompt header was the generic
+``"Permission request — {key}"`` form, exposing internal config keys
+(``web.fetch``, ``mcp.<server>``, ``shell``, …) as the user-facing
+prompt header. Light-users had to mentally translate a config key into
+"what is the agent asking me?".
+
+Per the issue's direction (b), each ``require_*`` method now passes
+a ``user_prompt`` argument with a natural-language question, while
+the underlying ``_approve`` / ``_prompt`` machinery preserves the
+existing ``"Permission request — {key}"`` fallback for any caller
+that hasn't migrated.
+
+This file pins:
+  1. ``_prompt`` uses ``user_prompt`` when present, falls back when None.
+  2. Each migrated ``require_*`` passes a sensible natural prompt.
+  3. The verify-script JSON shape (= production path) carries the
+     natural prompt in ``meta.prompt`` — TUI widget consumes it.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.services.intervention_handler import InterventionHandler
+from reyn.intervention_choices import generic_yn_choices
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import (
+    InterventionAnswer,
+    InterventionBus,
+    UserIntervention,
+)
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+class _RecordingBus:
+    """Captures the UserIntervention passed to request() and returns a
+    pre-set answer. Real production path; no MagicMock."""
+
+    def __init__(self, answer_id: str = "no") -> None:
+        self.captured: list[UserIntervention] = []
+        self._answer_id = answer_id
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.captured.append(iv)
+        return InterventionAnswer(text=self._answer_id, choice_id=self._answer_id)
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={},  # nothing pre-approved → goes to interactive
+        project_root=tmp_path,
+        interactive=True,
+    )
+
+
+# ── 1. _approve / _prompt accept user_prompt override ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_uses_user_prompt_when_provided(tmp_path) -> None:
+    """Tier 2: when user_prompt is passed, it becomes the prompt header."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="no")
+    await r._approve("test.key", "test description", bus, user_prompt="Allow this thing?")
+    assert len(bus.captured) == 1
+    iv = bus.captured[0]
+    assert iv.prompt == "Allow this thing?"
+    # detail still gets the description.
+    assert iv.detail == "test description"
+
+
+@pytest.mark.asyncio
+async def test_prompt_falls_back_to_key_form_when_user_prompt_none(tmp_path) -> None:
+    """Tier 2: legacy "Permission request — {key}" form preserved on omission.
+
+    Backward-compat: any caller that hasn't migrated to user_prompt= keeps
+    the original behavior. Used by tests and non-yet-migrated require_*
+    helpers (none today, but the contract is reserved).
+    """
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="no")
+    await r._approve("test.fallback", "fallback description", bus)
+    assert bus.captured[0].prompt == "Permission request — test.fallback"
+
+
+# ── 2. require_web_fetch uses natural prompt ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_require_web_fetch_prompt_is_natural(tmp_path) -> None:
+    """Tier 2: require_web_fetch passes a natural-language user_prompt."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="no")
+    try:
+        await r.require_web_fetch("https://example.com", bus)
+    except PermissionError:
+        pass  # expected — we answered "no"
+    assert len(bus.captured) == 1
+    iv = bus.captured[0]
+    assert iv.prompt == "Allow fetching this URL?"
+    # detail carries the URL so user can verify what's being fetched.
+    assert "https://example.com" in iv.detail
+    # The config key (web.fetch) is NOT in the prompt header.
+    assert "web.fetch" not in iv.prompt
+
+
+# ── 3. require_shell uses natural prompt ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_require_shell_prompt_is_natural(tmp_path) -> None:
+    """Tier 2: require_shell passes a natural-language user_prompt."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="no")
+    try:
+        await r.require_shell(PermissionDecl(shell=True), "ls -la", bus)
+    except PermissionError:
+        pass
+    assert len(bus.captured) == 1
+    iv = bus.captured[0]
+    assert iv.prompt == "Allow running this shell command?"
+    assert "ls -la" in iv.detail
+    assert "shell" not in iv.prompt.lower() or "command" in iv.prompt.lower()
+
+
+# ── 4. End-to-end announce: meta.prompt carries natural phrasing ────────
+
+
+async def _capture_announce(iv: UserIntervention) -> OutboxMessage:
+    """Run the production announce() path and capture the produced msg."""
+    captured: list[OutboxMessage] = []
+
+    async def _put(msg: OutboxMessage) -> None:
+        captured.append(msg)
+
+    handler = InterventionHandler(
+        intervention_registry=None,
+        journal=None,
+        event_log=None,
+        put_outbox=_put,
+        append_history=lambda *_a, **_k: None,
+    )
+    await handler.announce(iv)
+    assert len(captured) == 1
+    return captured[0]
+
+
+@pytest.mark.asyncio
+async def test_announce_meta_carries_natural_prompt() -> None:
+    """Tier 2: the natural prompt flows through announce() into meta.prompt.
+
+    Pins the end-to-end: TUI widget reads meta.prompt → renders as
+    amber-bold header. Light-users see "Allow fetching this URL?"
+    instead of "Permission request — web.fetch".
+    """
+    iv = UserIntervention(
+        kind="permission.generic",
+        prompt="Allow fetching this URL?",
+        detail="web fetch: https://example.com",
+        choices=generic_yn_choices(),
+        run_id="r1",
+        skill_name="chat_router",
+    )
+    msg = await _capture_announce(iv)
+    assert msg.meta["prompt"] == "Allow fetching this URL?"
+    assert msg.meta["detail"] == "web fetch: https://example.com"
+    # msg.text (CLI Panel renderer backward-compat) still has it all
+    assert "Allow fetching this URL?" in msg.text
+    assert "https://example.com" in msg.text
+
+
+# ── 5. require_mcp + require_mcp_install + require_index_drop +
+#     require_mcp_drop_server + require_tool + require_python — natural ────
+
+
+@pytest.mark.asyncio
+async def test_require_mcp_prompt_is_natural(tmp_path) -> None:
+    """Tier 2: require_mcp passes natural prompt mentioning the server name."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="no")
+    decl = PermissionDecl(allowed_mcp=["filesystem"], mcp=["filesystem"])
+    try:
+        await r.require_mcp(decl, "filesystem", bus)
+    except PermissionError:
+        pass
+    iv = bus.captured[0]
+    assert "filesystem" in iv.prompt
+    assert iv.prompt.lower().startswith("allow")  # natural-language style
+
+
+@pytest.mark.asyncio
+async def test_require_tool_prompt_is_natural(tmp_path) -> None:
+    """Tier 2: require_tool prompts use natural phrasing including the tool name."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="no")
+    decl = PermissionDecl(tool=["web_search"])
+    try:
+        await r.require_tool(decl, "web_search", bus)
+    except PermissionError:
+        pass
+    iv = bus.captured[0]
+    assert "web_search" in iv.prompt
+    assert iv.prompt.lower().startswith("allow")


### PR DESCRIPTION
**[e2e-coder]** —

Closes #224.

## Summary

Pre-fix, every permission prompt header was the generic `"Permission request — {key}"` form, exposing internal config keys (`web.fetch`, `mcp.<server>`, `shell`, …) as user-facing copy. The dogfood verification in PR #225 surfaced this as a light-user readability gap — the actual user-facing question was implicit in the detail line, not in the prompt header.

Per the #224 owner decision (direction **(b)** = per-gate phrasing tables): each `require_*` method now passes a natural-language question. The underlying `_approve` / `_prompt` machinery preserves the legacy form as a fallback for any future caller that hasn't migrated.

## What this changes

### `_approve` / `_prompt` — `user_prompt` kwarg

```python
async def _approve(
    self, key, description, bus, *, user_prompt: str | None = None,
) -> bool:
    ...
    return await self._prompt(key, description, bus, user_prompt=user_prompt)

async def _prompt(
    self, key, description, bus, *, user_prompt: str | None = None,
) -> bool:
    iv = UserIntervention(
        kind="permission.generic",
        prompt=user_prompt or f"Permission request — {key}",   # ← natural or legacy
        detail=description or key,
        choices=generic_yn_choices(),
    )
    ...
```

When `user_prompt` is None, the existing `"Permission request — {key}"` text is unchanged → any future / test caller that hasn't migrated keeps working.

### `require_*` methods — natural-language prompts

| Method | New `user_prompt` |
|---|---|
| `require_web_fetch` | `"Allow fetching this URL?"` |
| `require_shell` | `"Allow running this shell command?"` |
| `require_mcp(server)` | `"Allow access to MCP server '<server>'?"` |
| `require_mcp_install(server_id)` | `"Install MCP server '<server_id>'?"` |
| `require_index_drop(source)` | `"Drop indexed source '<source>'?"` |
| `require_mcp_drop_server(server)` | `"Remove MCP server '<server>'?"` |
| `require_tool(tool)` | `"Allow tool '<tool>'?"` |
| `require_python` (unsafe) | `"Run unsafe python <module>.<function>?"` |
| `require_python` (safe) | `"Run python <module>.<function>?"` |

The `detail` line still carries the verbose form (e.g. `"web fetch: https://example.com"`) so the user can see the exact resource without parsing the prompt header.

### `dogfood/scripts/verify_permission_prompt_structure.py`

Updated to assert the new natural-language `meta.prompt` ("Allow fetching this URL?") — still passes the 12-check production-path structure verification.

## Test plan

- [x] **Automated — `pytest tests/test_permission_prompt_phrasing.py`**: 7/7 pass.
  - `user_prompt` override sets the prompt header.
  - None → legacy "Permission request — {key}" fallback preserved.
  - require_web_fetch / require_shell / require_mcp / require_tool produce natural prompts.
  - End-to-end announce() pipeline propagates the natural prompt into `meta.prompt`.
- [x] **Adjacent — all permission tests**: `pytest tests/ -k permission` → **100 passed, 7 skipped**. No regression in the permission-resolver path.
- [x] **Adjacent — replay + universal**: `pytest tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py` → 136 passed, 1 expected xfail. No `KNOWN_STATIC_QUALIFIED_NAMES` change.
- [x] **Manual — `python dogfood/scripts/verify_permission_prompt_structure.py`** → exit 0, all 12 checks ✓, payload dump confirms `meta.prompt = "Allow fetching this URL?"`.
- [x] **Lint — `ruff check`**: clean.

## Out of scope (= deliberate)

- **Hotkey case sensitivity** ([A]/[N] requires Shift) — by-design per #224 issue body. Standard CLI convention distinguishes "persist" from "session-only" decisions. Not refiled.
- **Prompt copy in tests/test_intervention_prompt_hierarchy.py** — still uses `"Permission request — web.fetch"` as the test fixture content. That's testing the structured-fields contract from #163 with a hand-built `UserIntervention`; both legacy and new prompt forms are valid through the announce() pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)