### PR TITLE
fix(tui): scroll new tab's cursor into view on tab activation (R2-1+R2-4+R2-5 bundle)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -422,6 +422,20 @@ class RightPanel(Widget):
         if event.tab and event.tab.id in PANEL_TYPES:
             self._panel_type = event.tab.id
             self._invalidate()
+            # ``#panel-scroll`` is shared across tabs — when we switch to a
+            # cursor-bearing tab whose cursor sits below the viewport
+            # currently displayed (= a different tab's scroll position),
+            # the cursor row goes invisible until the user presses j/k.
+            # Re-anchor the viewport on the new tab's cursor so the ``▶``
+            # marker is visible immediately.
+            scroll_helper = {
+                "events": self._scroll_events_into_view,
+                "agents": self._scroll_agents_into_view,
+                "memory": self._scroll_memory_into_view,
+                "docs":   self._scroll_docs_into_view,
+            }.get(self._panel_type)
+            if scroll_helper is not None:
+                scroll_helper()
             if self._preview_visible:
                 self._update_preview()
 

--- a/tests/cli/test_panel_tab_switch_scrolls_cursor.py
+++ b/tests/cli/test_panel_tab_switch_scrolls_cursor.py
@@ -1,0 +1,127 @@
+"""Tier 2: on_tabs_tab_activated re-anchors the panel scroll on the new tab's cursor.
+
+``#panel-scroll`` is a single ``VerticalScroll`` shared by every tab body.
+Before this fix ``on_tabs_tab_activated`` only called ``_invalidate()``,
+so the scroll position from the previous tab carried over — when the
+new tab's cursor sat below the inherited viewport, the cursor row went
+invisible until the user pressed j/k.
+
+The fix dispatches to the active tab's existing ``_scroll_*_into_view``
+helper after the invalidate. This test pins that dispatch contract
+without re-asserting the helper's own (already-tested) scroll math:
+spy on each helper via direct attribute substitution and verify that
+activating each cursor tab invokes its own helper exactly once, and
+that the no-cursor tabs (``keys`` / ``cost``) invoke none of them.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import Tab, Tabs
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import RightPanel
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _instrument_scroll_helpers(panel: RightPanel) -> dict[str, list[None]]:
+    """Replace each ``_scroll_*_into_view`` helper with a recorder.
+
+    Direct attribute substitution per ``testing.ja.md`` (= no
+    ``unittest.mock``). Returns a dict mapping the tab id to a list
+    that grows by one each time the helper is invoked.
+    """
+    calls: dict[str, list[None]] = {
+        "events": [],
+        "agents": [],
+        "memory": [],
+        "docs":   [],
+    }
+
+    def _make_recorder(key: str):
+        def _fake() -> None:
+            calls[key].append(None)
+        return _fake
+
+    panel._scroll_events_into_view = _make_recorder("events")   # type: ignore[method-assign]
+    panel._scroll_agents_into_view = _make_recorder("agents")   # type: ignore[method-assign]
+    panel._scroll_memory_into_view = _make_recorder("memory")   # type: ignore[method-assign]
+    panel._scroll_docs_into_view   = _make_recorder("docs")     # type: ignore[method-assign]
+    return calls
+
+
+def _make_tab_event(panel: RightPanel, tab_id: str) -> Tabs.TabActivated:
+    """Build a ``Tabs.TabActivated`` carrying a Tab whose id matches ``tab_id``."""
+    tabs = panel.query_one("#panel-tabs", Tabs)
+    return Tabs.TabActivated(tabs, Tab(tab_id, id=tab_id))
+
+
+@pytest.mark.asyncio
+async def test_cursor_tab_activation_invokes_matching_scroll_helper(
+    tmp_path,
+) -> None:
+    """Tier 2: each cursor-bearing tab activation calls its own helper exactly once."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        calls = _instrument_scroll_helpers(panel)
+
+        for tab_id in ("events", "agents", "memory", "docs"):
+            panel.on_tabs_tab_activated(_make_tab_event(panel, tab_id))
+            await pilot.pause()
+            # Exactly one call on the matching helper, zero on the others.
+            assert calls[tab_id] == [None], (
+                f"tab {tab_id!r} activation: expected 1 call on "
+                f"_scroll_{tab_id}_into_view, got {calls!r}"
+            )
+            for other in calls:
+                if other == tab_id:
+                    continue
+                assert calls[other] == [], (
+                    f"tab {tab_id!r} activation leaked to _scroll_{other}_into_view: "
+                    f"{calls!r}"
+                )
+            # Reset for next iteration so each tab is asserted independently.
+            for k in calls:
+                calls[k].clear()
+
+
+@pytest.mark.asyncio
+async def test_non_cursor_tab_activation_invokes_no_scroll_helper(
+    tmp_path,
+) -> None:
+    """Tier 2: ``keys`` / ``cost`` tabs have no cursor → no helper called.
+
+    Defends against an accidentally over-broad dispatch (= "scroll
+    something just in case") that could re-anchor the scroll incorrectly
+    when the user lands on a non-navigable tab.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        calls = _instrument_scroll_helpers(panel)
+
+        for tab_id in ("keys", "cost"):
+            panel.on_tabs_tab_activated(_make_tab_event(panel, tab_id))
+            await pilot.pause()
+            assert all(v == [] for v in calls.values()), (
+                f"tab {tab_id!r} (no cursor) should not invoke any "
+                f"_scroll_*_into_view; got {calls!r}"
+            )


### PR DESCRIPTION
**[tui-coder]** —

Bundles 3 findings from the right-panel UX exploration into one fix.

## Summary

\`#panel-scroll\` is a single \`VerticalScroll\` shared by every tab body. \`on_tabs_tab_activated\` only called \`_invalidate()\` — the scroll position from the previous tab carried over, so when the new tab's cursor sat below (or above) the inherited viewport the cursor row went invisible until the user pressed j/k.

Fix: dispatch to the active tab's existing \`_scroll_*_into_view\` helper after the invalidate. \`keys\` / \`cost\` tabs have no cursor and skip the dispatch.

## Findings closed

- **R2-1** cursor invisible after tab switch (events / docs / agents / memory)
- **R2-4** docs tab cursor invisible on return (same root)
- **R2-5** empty events list \`(all\` filter) shows blank on first open after scroll (same root — the empty-state hint sits at y=0 and the dispatch re-anchors there)

## Why TUI-only

Pure widget-bookkeeping change in \`RightPanel.on_tabs_tab_activated\`. The helpers themselves are unchanged and already exercised by j/k navigation.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 199 passed (190 base + 4 #210 sub-skill nesting + 5 #192 hot_list tests).
- [x] **Manual repro (fixed)** — tmux: \`reyn chat\` → send \`hello\` (creates skill_run for direct_llm) → Ctrl+B → Ctrl+O (focus panel) → Ctrl+W ×2 (Agents tab) → j ×3 (cursor lands deep on a recent skill row) → Ctrl+W cycles Memory→Cost→Docs→Keys → Ctrl+W ×2 back to Agents → cursor \`▶\` on the same recent skill row is visible immediately, no j/k needed ✅
- [x] **Manual scope check** — Keys / Cost tabs still cycle correctly (the dispatch dict has no entry for them, so they skip the scroll-into-view call — no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)