### PR TITLE
fix(tui): raise right-panel minimum width to fit the full tab bar (R1-1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -281,12 +281,21 @@ class RightPanel(Widget):
         if self._panel_width == 0:
             self._panel_width = self.size.width or 40
         max_width = max(40, int((self.app.size.width or 120) * 0.66))
-        new_width = max(24, min(max_width, self._panel_width + delta))
+        # Min width is sized so the full 6-tab bar
+        # (Keys/Events/Agents/Memory/Cost/Docs ≈ 36 cells incl. margins)
+        # always fits. Below this the Textual Tabs widget silently scrolls
+        # the right-most tabs out of view with no overflow marker, leaving
+        # the user no way to tell which tabs exist by glancing at the
+        # bar — Ctrl+W still cycles them but the visible set was a
+        # misleading subset. Bumped from 24 → 36 to guarantee the bar
+        # acts as a complete navigation surface at every width.
+        _MIN_WIDTH = 36
+        new_width = max(_MIN_WIDTH, min(max_width, self._panel_width + delta))
         # Flash the new width in the conv sticky bar so the user sees
         # something changed (and learns the bounds via the at-min /
         # at-max suffix). Skip the flash on no-op clamps to avoid the
         # impression that the keystroke was lost when nothing moved.
-        at_min = new_width == 24
+        at_min = new_width == _MIN_WIDTH
         at_max = new_width == max_width
         clamp_hint = (
             " (min)" if at_min and delta < 0


### PR DESCRIPTION
**[tui-coder]** —

Closes R1-1 (TUI Right Panel exploration finding).

## Summary

- The 6 tab labels (Keys / Events / Agents / Memory / Cost / Docs) plus their per-tab margin sum to ~36 cells. The previous 24-col minimum let the Textual \`Tabs\` widget silently scroll the right-most tabs out of view with no overflow marker, leaving the user no way to tell which tabs exist by glancing at the bar — Ctrl+W still cycled them but the visible set was a misleading subset.
- Fix: raise \`_panel_resize\` minimum from 24 → 36. The existing \`(min)\` flash hint naturally reports the new bound.

## Tradeoff

Operators who pinned the panel to 24 cols can no longer do so — they're now bounded at 36 cols. Mitigation: 36 is still narrower than the default starting size on typical 120-col terminals (= 40 cols, 33%), so cold-start UX is unchanged. The bar now acts as a complete navigation surface at every reachable width, which is the higher-value property given Ctrl+W cycling presumes the user can see what they're cycling toward.

## Why TUI-only

Pure resize-clamp constant change in \`RightPanel._panel_resize\`. No widget composition / event routing changes.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 199 passed; no test pinned the old 24-col bound (\`grep -rn "max.*24\|MIN.*24\|24" tests/\` → 0 hits in relevant scope).
- [x] **Code path verification** — the at-min flash hint now references the same constant via \`_MIN_WIDTH\` local, so the displayed \`(min)\` label stays accurate. No state survives the clamp boundary change.
- [x] **Manual visual** — tmux: \`reyn chat\` → Ctrl+B (open) → Ctrl+O (focus) → \`l\` ×20 (shrink). Observed: clamp at 36 cols, conv pane shows \`● panel: 36 col (min) · 1.0s\` flash, all 6 tabs (Keys Events Agents Memory Cost Docs) remain visible in the panel header at the min width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)