### PR TITLE
fix(tui): empty-state hint 3-line layout to stop ragged wrap at narrow conv pane (R1-2)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -324,9 +324,20 @@ class ConversationView(Widget):
         # most sophisticated piece of the TUI, which is hidden by default and
         # otherwise has zero discoverability on first run.
         yield Static(
+            # Three-line layout (each ~40-50 cells) so the hint stays
+            # legibly stacked at the narrowest reachable conv-pane
+            # width. The previous single line 2 carried the slash
+            # mechanic + tab list + keybind set on one line at ~95
+            # cells, which wrapped to 4–5 ragged lines when the right
+            # panel was expanded toward its max width and the conv pane
+            # shrank to ~50 cols. Splitting into purpose / contents /
+            # keybind preserves the side-panel discoverability the test
+            # at ``test_empty_hint_discoverability.py`` defends, while
+            # making each line short enough that wrap is at worst 2
+            # clean lines per stanza on any terminal we expect.
             "  Type [bold]/[/] for commands  ·  [bold]/help[/] for a guide\n"
-            "  [bold]Ctrl+B[/] side panel ([dim]keys · events · agents · memory · cost · docs[/])  ·  "
-            "[bold]Ctrl+L[/] clear  ·  [bold]Ctrl+P/N[/] turn",
+            "  [bold]Ctrl+B[/] side panel ·  [bold]Ctrl+L[/] clear  ·  [bold]Ctrl+P/N[/] turn\n"
+            "  [dim]panel tabs: keys · events · agents · memory · cost · docs[/]",
             id="empty-hint",
             markup=True,
         )


### PR DESCRIPTION
**[tui-coder]** —

Closes R1-2 (TUI Right Panel exploration finding).

## Summary

The empty-state hint's line 2 carried the side-panel description + tab list + Ctrl+L / Ctrl+P/N keybinds on one ~95-cell run. When the right panel was widened toward its max (66%) the conv pane shrank to ~50 cols and the hint wrapped to 4–5 ragged lines that bled into the input area.

Restructure into three short stanzas (~40–50 cells each):

\`\`\`
Type / for commands  ·  /help for a guide
Ctrl+B side panel · Ctrl+L clear  ·  Ctrl+P/N turn
panel tabs: keys · events · agents · memory · cost · docs
\`\`\`

Same information density, but lines wrap (at worst) to two clean rows each on the narrowest pane instead of one mega-line into a 5-line wrap-storm.

## Discoverability contract preserved

\`test_empty_hint_discoverability\` (Tier 2) pins that the hint mentions \`/\`, \`/help\`, \`Ctrl+B\`, \`side panel\`, plus at least 3 tab names. The new layout keeps all those keywords — test passes unmodified.

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/test_empty_hint_discoverability.py\` 2/2 pass; full \`tests/cli/\` 199 pass.
- [x] **Manual smoke** — same 3-line layout renders at default panel width, with the dim tab list on line 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)