### PR TITLE
fix(tui): Keys tab surfaces h / l panel-resize shortcuts (R1-4)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -105,6 +105,18 @@ def render_keys(app: "App") -> str:
         seen.add(b.key)
         groups["INPUT"].append((_pretty_key(b.key), b.description))
 
+    # Right-panel resize keys (h / l) are handled via ``RightPanel.on_key``
+    # rather than a declared ``Binding`` object, so the BINDINGS iterations
+    # above never see them and the Keys tab silently omitted them. Surface
+    # them explicitly so the user can discover panel resize without
+    # reading the source.
+    if "h" not in seen:
+        groups["PANEL"].append((_pretty_key("h"), "Widen panel"))
+        seen.add("h")
+    if "l" not in seen:
+        groups["PANEL"].append((_pretty_key("l"), "Narrow panel"))
+        seen.add("l")
+
     lines: list[str] = []
     # Key column width: max key length within the group, capped at 6
     # (longest pretty key is ⇧Tab / Enter / Space = 5 chars + 1 pad).

--- a/tests/cli/test_keys_tab_panel_bindings.py
+++ b/tests/cli/test_keys_tab_panel_bindings.py
@@ -140,6 +140,73 @@ async def test_keys_tab_groups_panel_keys_under_panel_section() -> None:
         )
 
 
+@pytest.mark.asyncio
+async def test_keys_tab_renders_h_l_resize_keys() -> None:
+    """Tier 2: ``h`` (widen panel) and ``l`` (narrow panel) appear in the rendered output.
+
+    These keys are handled via ``RightPanel.on_key`` rather than declared
+    ``Binding`` objects, so the binding-iteration paths in ``render_keys``
+    never see them. ``render_keys`` appends synthetic entries explicitly
+    so the user can discover panel resize without reading the source.
+
+    Defends against a future refactor that drops the synthetic append
+    (= the symptom would be a silent regression in discoverability).
+    """
+    app = ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        rendered = render_keys(app)
+
+        # Synthetic entries: bare ``h`` / ``l`` (single-letter keys keep
+        # their literal form through ``_pretty_key``).
+        assert "Widen panel" in rendered, (
+            f"Keys tab must render the 'Widen panel' (h) description; got:\n{rendered}"
+        )
+        assert "Narrow panel" in rendered, (
+            f"Keys tab must render the 'Narrow panel' (l) description; got:\n{rendered}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_h_l_resize_keys_group_under_panel_section() -> None:
+    """Tier 2: ``h`` and ``l`` resize keys land in the PANEL group.
+
+    Same intent as the ``ctrl+w`` family test above — guard against a
+    future refactor that drops them into ``OTHER`` or a different group.
+    """
+    app = ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        rendered = render_keys(app)
+
+        panel_idx = rendered.find("[PANEL]")
+        widen_idx = rendered.find("Widen panel")
+        narrow_idx = rendered.find("Narrow panel")
+        assert panel_idx >= 0, "[PANEL] group header missing"
+        # Next group after PANEL is the one that follows in _GROUP_ORDER.
+        # Easier: just assert both Widen/Narrow appear AFTER the PANEL
+        # header, since render_keys emits group headers in _GROUP_ORDER
+        # and we don't want to over-pin the exact next-header label.
+        assert widen_idx > panel_idx, (
+            f"'Widen panel' (h) must render under the PANEL group; "
+            f"panel_idx={panel_idx} widen_idx={widen_idx}"
+        )
+        assert narrow_idx > panel_idx, (
+            f"'Narrow panel' (l) must render under the PANEL group; "
+            f"panel_idx={panel_idx} narrow_idx={narrow_idx}"
+        )
+
+
 # ── check_action gating preserves the panel-visibility contract ─────────────
 
 


### PR DESCRIPTION
**[tui-coder]** —

Closes R1-4 (TUI Right Panel exploration finding).

## Summary

The right panel's \`h\` (widen) and \`l\` (narrow) shortcuts are handled via \`RightPanel.on_key\` rather than declared \`Binding\` objects, so \`render_keys\` — which iterates \`app.BINDINGS\` + \`InputBar.BINDINGS\` — silently omitted them. A user had zero in-app signal that the panel was resizable until they read the source or got told.

Fix: append two synthetic entries to the PANEL group inside \`render_keys\` after the binding loops, gated on \`seen\` so a future real Binding for h / l doesn't double-insert.

## Why TUI-only

Pure renderer change in \`keys_tab.py\`. No keybinding wiring change (= keep the existing \`on_key\` dispatch).

## Test plan

- [x] **Existing tests** — \`pytest tests/cli/\` 199 passed (includes \`test_keys_tab_panel_bindings.py\` 7/7); no test asserted "h / l absent from Keys tab", so the additive surface change is safe.
- [x] **Manual visual** — tmux: \`reyn chat\` → Ctrl+B → Ctrl+O → j ×30 (scroll Keys tab to PANEL section) → observed:
  \`\`\`
  [PANEL]
     ⌃O    Focus panel
     ⌃W    Next tab
     ⌃⇧W   Prev tab
     ⌃⇧O   Prev tab (alt)
     h     Widen panel
     l     Narrow panel
  \`\`\`
  Both \`h\` and \`l\` now appear with their descriptions and column alignment matches the existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)