### PR TITLE
fix(tui): events ↳ reply preview truncates by cell width (CJK) (R3-5)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -4,7 +4,31 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from rich.cells import cell_len
+
 from .base import _CORAL, _esc, logger
+
+
+def _truncate_to_cells(s: str, max_cells: int) -> tuple[str, bool]:
+    """Truncate ``s`` to fit within ``max_cells`` display columns.
+
+    Returns ``(truncated_string, was_truncated)``. CJK characters consume
+    2 cells each so a naive ``s[:N]`` overshoots the column budget by
+    roughly 2× for full-width content. ``rich.cells.cell_len`` is
+    East-Asian-Width aware and matches what Textual will actually
+    render.
+    """
+    if cell_len(s) <= max_cells:
+        return s, False
+    out_chars: list[str] = []
+    used = 0
+    for ch in s:
+        w = cell_len(ch)
+        if used + w > max_cells:
+            break
+        out_chars.append(ch)
+        used += w
+    return "".join(out_chars), True
 
 _EVENT_COLORS: dict[str, str] = {
     "phase_started":               "#44cc88",
@@ -560,7 +584,15 @@ def render_events(
                 if reply is None:
                     lines.append("[#444444]       ↳ [/][#555555](awaiting…)[/]")
                 else:
-                    short = _esc(reply[:72]) + ("…" if len(reply) > 72 else "")
+                    # Cell-width truncate (not ``[:72]``) so CJK / wide
+                    # characters obey the 40-cell preview budget instead
+                    # of overflowing to ~80 cells and wrapping the
+                    # ``↳`` line across 2-3 panel rows. 40 cells matches
+                    # the ``_event_hint`` cap used elsewhere in this
+                    # file and fits the 36-col panel min with the 7-cell
+                    # ``↳`` indent.
+                    truncated, was_truncated = _truncate_to_cells(reply, 40)
+                    short = _esc(truncated) + ("…" if was_truncated else "")
                     lines.append(f"[#444444]       ↳ [/][#777777]{short}[/]")
 
     del filter_name

--- a/tests/cli/test_events_reply_cell_truncate.py
+++ b/tests/cli/test_events_reply_cell_truncate.py
@@ -1,0 +1,81 @@
+"""Tier 2: events tab ``↳ <reply>`` preview truncates by cell width, not char count.
+
+The previous implementation sliced replies with ``reply[:72]`` — Python
+character count, NOT terminal cell width. CJK and other East-Asian-Wide
+characters consume 2 cells each, so a 72-char Japanese reply rendered
+at ~144 cells and wrapped across 2-3 panel rows.
+
+The fix uses ``_truncate_to_cells`` (East-Asian-Width aware via
+``rich.cells.cell_len``) to cap the preview at 40 cells. This test
+pins the helper's contract directly — the rendering integration is
+already exercised by the events-tab smoke paths.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from rich.cells import cell_len
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.right_panel.events_tab import _truncate_to_cells
+
+
+def test_short_ascii_passes_through_untruncated() -> None:
+    """Tier 2: input <= cap is returned unchanged with was_truncated=False."""
+    out, truncated = _truncate_to_cells("hello world", 40)
+    assert out == "hello world"
+    assert truncated is False
+
+
+def test_long_ascii_truncates_to_cap_cells() -> None:
+    """Tier 2: ASCII input longer than cap is sliced to exactly cap cells."""
+    src = "x" * 80
+    out, truncated = _truncate_to_cells(src, 40)
+    assert cell_len(out) == 40
+    assert truncated is True
+
+
+def test_cjk_truncates_at_cell_boundary_not_char_count() -> None:
+    """Tier 2: CJK reply caps at the cell budget (= half the char count).
+
+    The pre-fix bug: ``reply[:72]`` allowed 72 CJK chars × 2 cells = 144
+    cells through, wrapping the preview line. The new helper must cap
+    a long CJK string at <= 40 cells regardless of char count.
+    """
+    # 50 CJK chars (= 100 cells if unbounded)
+    src = "あいうえお" * 10
+    out, truncated = _truncate_to_cells(src, 40)
+    assert cell_len(out) <= 40, (
+        f"CJK truncation must respect cell budget; got {cell_len(out)} "
+        f"cells from {out!r}"
+    )
+    assert truncated is True
+    # And the slice happens at a char boundary (no half-glyph).
+    assert all(ord(ch) > 0x7F for ch in out), out
+
+
+def test_mixed_ascii_and_cjk_respects_cell_budget() -> None:
+    """Tier 2: mixed-width content is truncated by cumulative cell count.
+
+    Defends against a regression where the helper assumed uniform width.
+    """
+    # 4 ASCII (4 cells) + 30 CJK (60 cells) = 64 cells total.
+    src = "ABCD" + ("漢" * 30)
+    out, truncated = _truncate_to_cells(src, 40)
+    assert cell_len(out) <= 40
+    assert truncated is True
+    # The first 4 ASCII chars survive (= the helper isn't blindly
+    # truncating at byte 40 or similar).
+    assert out.startswith("ABCD"), out
+
+
+def test_empty_input_returns_empty_no_truncation() -> None:
+    """Tier 2: edge — empty string is passed through unchanged."""
+    out, truncated = _truncate_to_cells("", 40)
+    assert out == ""
+    assert truncated is False


### PR DESCRIPTION
**[tui-coder]** —

Closes R3-5 (TUI Right Panel exploration finding).

## Summary

\`render_events\` rendered the per-turn preview line (\`↳ <reply>\`) using \`reply[:72]\` — Python char count, not terminal cell width. CJK and other East-Asian-Wide characters consume 2 cells each, so a 72-char Japanese reply produced ~144 cells of output and the \`↳\` line wrapped across 2-3 panel rows instead of staying on a single preview line.

Extract \`_truncate_to_cells\` (East-Asian-Width aware via \`rich.cells.cell_len\`) and cap the preview at 40 cells. The 40-cell budget matches \`_event_hint\` (used elsewhere in the same file) and fits the 36-col panel min with the 7-cell \`↳\` indent.

## Why TUI-only

Pure rendering helper change in \`events_tab.py\`. No event schema / forwarder / outbox changes — same upstream \`reply\` string, just sliced at a cell-aware boundary.

## Note: R3-3 (Memory tab `c=copy` truncate) — resolved by PR #232

The original exploration listed R3-3 (Memory tab header `c=copy` cut at default width) as a separate finding. With PR #232 raising the panel minimum from 24 → 36 cells, the 31-cell Memory header now fits with 3 cells of slack. No standalone PR needed.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_events_reply_cell_truncate.py\`, 5 cases:
  - short ASCII passes through unchanged
  - long ASCII truncates to exactly the cap
  - CJK truncates at cell boundary (no half-glyph, no overshoot)
  - mixed ASCII+CJK respects cumulative cell count
  - empty input edge case
- [x] **Existing tests** — \`pytest tests/cli/\` 204 passed (199 base + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)