### PR TITLE
fix(tui): re-clamp panel width on terminal resize (R1-3, P1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -177,6 +177,46 @@ class RightPanel(Widget):
     def on_mount(self) -> None:
         self.set_interval(_REFRESH_INTERVAL, self._refresh_live)
 
+    def on_resize(self, event) -> None:
+        """Re-clamp ``_panel_width`` when the terminal window resizes.
+
+        Without this, ``_panel_width`` (an absolute column count cached
+        on h / l) survives a terminal shrink unchanged — a 145-col
+        panel on a 220-col terminal stayed at 145 cols after a
+        ``tmux resize-window -x 80``, overflowing the new 80-col
+        window and crushing the conv pane to ~0 cols. The user
+        couldn't see chat output until they reopened the panel
+        manually.
+
+        Clamp against the freshly-computed max (= 66 % of the new
+        terminal width, floor 40 cols) so the panel always stays
+        inside the terminal. Skip the work when the panel hasn't been
+        resized yet (= ``_panel_width == 0`` means it's still using
+        the CSS default of 33 % and Textual will reflow it
+        automatically).
+        """
+        del event  # unused; we re-read app.size below
+        if self._panel_width == 0:
+            return
+        max_width = self._max_panel_width()
+        if self._panel_width > max_width:
+            self._panel_width = max_width
+            try:
+                self.styles.width = self._panel_width
+            except Exception as exc:
+                logger.warning(
+                    "right_panel on_resize re-clamp failed: %s", exc,
+                )
+
+    def _max_panel_width(self) -> int:
+        """Return the upper bound for ``_panel_width`` against the current terminal.
+
+        66 % of terminal width, floor 40 cols (= same formula
+        ``_panel_resize`` uses). Centralised so the resize handler and
+        the manual resize path can't drift apart.
+        """
+        return max(40, int((self.app.size.width or 120) * 0.66))
+
     # ── focus indicator (X-focused on _PanelTop when tabs hold focus) ───────
 
     def on_descendant_focus(self, event) -> None:
@@ -280,7 +320,7 @@ class RightPanel(Widget):
     def _panel_resize(self, delta: int) -> None:
         if self._panel_width == 0:
             self._panel_width = self.size.width or 40
-        max_width = max(40, int((self.app.size.width or 120) * 0.66))
+        max_width = self._max_panel_width()
         # Min width is sized so the full 6-tab bar
         # (Keys/Events/Agents/Memory/Cost/Docs ≈ 36 cells incl. margins)
         # always fits. Below this the Textual Tabs widget silently scrolls

--- a/tests/cli/test_panel_width_reclamp_on_terminal_resize.py
+++ b/tests/cli/test_panel_width_reclamp_on_terminal_resize.py
@@ -1,0 +1,119 @@
+"""Tier 2: RightPanel re-clamps _panel_width when the terminal resizes.
+
+Pre-fix bug: ``_panel_width`` (the absolute column count cached on
+``h`` / ``l``) survived terminal shrinks unchanged. A user who had
+expanded the panel to ~145 cols on a 220-col terminal and then ran
+``tmux resize-window -x 80`` was left with a 145-col panel overflowing
+the 80-col window, crushing the conv pane to ~0 cols of usable space.
+
+The fix routes terminal resize events through ``on_resize`` which
+re-clamps against ``_max_panel_width()`` (= 66 % of new terminal
+width, floor 40 cols).
+
+This test pins the contract via direct attribute substitution (per
+testing.ja.md "no MagicMock"):
+
+1. Resize that SHRINKS the terminal below the cached panel width →
+   ``_panel_width`` is clamped down to the new ceiling.
+2. Resize that GROWS the terminal → cached width is preserved (no
+   spurious re-expansion).
+3. Pre-resize panel still at CSS default (``_panel_width == 0``) →
+   handler skips work (= Textual reflows the 33 % default for free).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import RightPanel
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _stub_max_width(panel: RightPanel, value: int) -> None:
+    """Pin ``_max_panel_width`` to ``value`` so the test doesn't depend on
+    the actual Textual ``app.size.width`` (= sometimes 0 in headless mode
+    and the formula floors at 40).
+    """
+    def _fake() -> int:
+        return value
+
+    panel._max_panel_width = _fake  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_terminal_shrink_clamps_cached_panel_width() -> None:
+    """Tier 2: cached width above the new max is clamped to the new ceiling."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._panel_width = 145  # type: ignore[attr-defined]
+
+        # Simulate terminal shrink: max drops to 52 cols (= 66% of 80).
+        _stub_max_width(panel, 52)
+        panel.on_resize(event=None)  # the handler ignores the event arg
+
+        assert panel._panel_width == 52, (
+            f"on_resize must clamp _panel_width down to the new max; "
+            f"got {panel._panel_width}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_grow_preserves_cached_panel_width() -> None:
+    """Tier 2: cached width below the new max is preserved as-is."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._panel_width = 60  # type: ignore[attr-defined]
+
+        # Simulate terminal grow: max rises to 132 cols (= 66% of 200).
+        _stub_max_width(panel, 132)
+        panel.on_resize(event=None)
+
+        assert panel._panel_width == 60, (
+            f"on_resize must NOT re-expand a smaller cached width; "
+            f"got {panel._panel_width}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_panel_at_css_default_is_left_alone() -> None:
+    """Tier 2: ``_panel_width == 0`` (= CSS-default 33%) skips the re-clamp.
+
+    Defends against an over-broad handler that would set the panel to
+    the new max even when the user hadn't manually resized — that would
+    silently move them off the CSS default, breaking the "cold-start
+    width" contract.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        # _panel_width default is 0 (= CSS-managed)
+        assert panel._panel_width == 0
+
+        _stub_max_width(panel, 52)
+        panel.on_resize(event=None)
+
+        # Still 0 — Textual handles the CSS-default reflow on its own.
+        assert panel._panel_width == 0, (
+            f"on_resize must not touch the CSS-default panel; "
+            f"got {panel._panel_width}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

Closes R1-3 (TUI Right Panel exploration finding, P1).

## Summary

\`_panel_width\` (the absolute column count cached on h / l) survived terminal shrinks unchanged. A user who had expanded the panel to ~145 cols on a 220-col terminal and then ran \`tmux resize-window -x 80\` was left with a 145-col panel overflowing the 80-col window, crushing the conv pane to ~0 cols — chat output invisible until they reopened the panel manually.

Add \`RightPanel.on_resize\` that re-clamps \`_panel_width\` against \`_max_panel_width()\` (= 66 % of the new terminal width, floor 40 cols) and writes the new bound back to \`self.styles.width\`. Skip when \`_panel_width == 0\` so the CSS-default 33 % panel keeps reflowing on its own.

Side benefit: extracted the 66 %-of-terminal max-width formula into \`_max_panel_width()\` so the resize handler and the manual h / l path can't drift apart.

## Why TUI-only

Pure event-handler addition + helper extraction inside \`RightPanel\`. No event schema / outbox / OS changes.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_panel_width_reclamp_on_terminal_resize.py\`, 3 cases:
  - terminal shrink clamps cached width down to the new ceiling
  - terminal grow preserves cached width (= no spurious re-expansion)
  - panel still at CSS-default (\`_panel_width == 0\`) is left alone
  Spies stub \`_max_panel_width\` via direct attribute substitution (per testing.ja.md, no MagicMock).
- [x] **Existing tests** — \`pytest tests/cli/\` 207 passed (204 base + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)