### PR TITLE
fix(tui): collapse today's timestamps in agents tab recent rows (R3-1, P1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import time as _time
+from datetime import date as _date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +12,26 @@ from rich.text import Text as RichText
 from rich.tree import Tree as RichTree
 
 from .base import _CORAL, logger
+
+
+def _compact_ts(ts: str) -> str:
+    """Return a short timestamp string for the recent-skill row.
+
+    ``ts`` is the raw form persisted by the event store (= e.g.
+    ``"2026-05-19 07:15:42"`` from ``isoformat()[:19].replace("T", " ")``).
+    A 19-char timestamp on every recent row wrapped the entire line to
+    4-5 panel rows at the default 33 % panel width; collapsing today's
+    date to ``HH:MM:SS`` recovers 11 cells per row and keeps the line on
+    a single panel line. Older runs keep the full ``YYYY-MM-DD HH:MM:SS``
+    so day-level context is still visible when scrolling history.
+    """
+    if not ts or len(ts) < 10:
+        return ts
+    today_iso = _date.today().isoformat()
+    if ts.startswith(today_iso):
+        # Skip the leading date + the single space, keep ``HH:MM:SS``.
+        return ts[11:]
+    return ts
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry
@@ -709,7 +730,7 @@ def render_agents(
                 elif status != "ok":
                     line.append(f"  ({status})", style="#aa6655")
                 if s["ts"]:
-                    line.append(f"  {s['ts']}", style="#444444")
+                    line.append(f"  {_compact_ts(s['ts'])}", style="#444444")
                 recent_node.add(line)
                 item_ys.append(y_counter)
                 y_counter += 1
@@ -735,7 +756,7 @@ def render_agents(
                 elif p["status"] == "partial":
                     line.append(f"  ({p['n_failed']} failed)", style="#aa6655")
                 if p["ts"]:
-                    line.append(f"  {p['ts']}", style="#444444")
+                    line.append(f"  {_compact_ts(p['ts'])}", style="#444444")
                 node = recent_node.add(line)
                 item_ys.append(y_counter)
                 y_counter += 1

--- a/tests/cli/test_agents_tab_compact_ts.py
+++ b/tests/cli/test_agents_tab_compact_ts.py
@@ -1,0 +1,57 @@
+"""Tier 2: agents tab recent-row timestamp collapses to time-only when today.
+
+A typical recent-skill row at default 33 % panel width was
+``  ✓ direct_llm  6.5s  2026-05-19 07:15:42`` (~38 cells). At ~28
+content cells, this wrapped to 4-5 lines per row and made the tab
+nearly unreadable. The fix uses ``_compact_ts`` to drop the date
+portion for today's runs (= recovers 11 cells per row), keeping
+older runs' full ``YYYY-MM-DD HH:MM:SS`` for cross-day context.
+
+Contract pinned:
+
+1. Today's timestamp collapses to ``HH:MM:SS``.
+2. Non-today timestamps render unchanged (= full date-time string).
+3. Edge cases — empty / malformed input — pass through without
+   raising.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.right_panel.agents_tab import _compact_ts
+
+
+def test_today_timestamp_collapses_to_time_only() -> None:
+    """Tier 2: today's ``YYYY-MM-DD HH:MM:SS`` collapses to ``HH:MM:SS``."""
+    today = date.today().isoformat()
+    out = _compact_ts(f"{today} 07:15:42")
+    assert out == "07:15:42", out
+
+
+def test_yesterday_timestamp_renders_unchanged() -> None:
+    """Tier 2: non-today timestamps keep the full ``YYYY-MM-DD HH:MM:SS`` form.
+
+    The compaction is opt-in for today only — older runs need the
+    date context so the user can tell same-day from cross-day history.
+    """
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    full = f"{yesterday} 07:15:42"
+    assert _compact_ts(full) == full
+
+
+def test_empty_string_passes_through() -> None:
+    """Tier 2: edge case — empty input is returned unchanged."""
+    assert _compact_ts("") == ""
+
+
+def test_short_string_passes_through() -> None:
+    """Tier 2: edge case — too-short strings don't crash, return as-is."""
+    assert _compact_ts("foo") == "foo"
+    # 9 chars — one short of the 10-char ``YYYY-MM-DD`` minimum prefix.
+    assert _compact_ts("2026-05-1") == "2026-05-1"


### PR DESCRIPTION
**[tui-coder]** —

Closes R3-1 (TUI Right Panel exploration finding, P1).

## Summary

A typical recent-skill row at default 33 % panel width was \`  ✓ direct_llm  6.5s  2026-05-19 07:15:42\` (~38 cells). The \`render_agents\` output uses Rich's \`Tree\` renderer (not the string-based per-line truncation in \`_PanelContent.render()\`), so at ~28 panel content cells each row wrapped to 4-5 lines — the entire "recent" section became a wall of broken text.

Extract \`_compact_ts\`: when the timestamp begins with today's \`YYYY-MM-DD\`, strip the date prefix to keep just \`HH:MM:SS\`. Older runs render the full \`YYYY-MM-DD HH:MM:SS\` so cross-day context survives.

A today-row now reads \`  ✓ direct_llm  6.5s  07:15:42\` (~27 cells) and fits a single panel line at the default width.

Also applied to recent-plan rows (same wrap issue, same fix).

## Why TUI-only

Pure rendering helper in \`agents_tab.py\`. No event store / forwarder changes — the raw \`ts\` field is the same upstream string.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_agents_tab_compact_ts.py\`, 4 cases:
  - today's timestamp collapses to \`HH:MM:SS\`
  - non-today (yesterday) timestamp renders unchanged (= full date string)
  - empty input passes through
  - sub-10-char input doesn't crash
- [x] **Existing tests** — \`pytest tests/cli/\` 211 passed (207 base + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)