### PR TITLE
fix(router): split routing_decided.source into ars_direct vs hot_list_alias (#241)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1612,8 +1612,19 @@ class RouterLoop:
                             )
                             _rd_source = "invoke_action"
                         elif "__" in _rd_name:
+                            # Issue #241: distinguish "real hot-list alias the
+                            # LLM correctly used" (= name actually surfaced in
+                            # tools[]) from "ARS-only direct call the salvage
+                            # path covers" (= name appeared only in the
+                            # invoke_action.description ARS block, salvaged
+                            # by PR #240). Pre-#241, both cases were tagged
+                            # ``"hot_list_alias"`` regardless, muddying the
+                            # audit chain for downstream readers (B42 W5-S6).
                             _rd_action = _rd_name
-                            _rd_source = "hot_list_alias"
+                            if _rd_name in self._catalog:
+                                _rd_source = "hot_list_alias"
+                            else:
+                                _rd_source = "ars_direct"
                         else:
                             continue  # non-catalog tool — skip
                         if not _rd_action:

--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -360,3 +360,73 @@ def test_routing_decided_skipped_when_action_name_empty():
         f"routing_decided must NOT fire when action_name is absent/empty, "
         f"but got: {events}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 (issue #241): qualified-name direct call NOT in tools[] → "ars_direct"
+# ---------------------------------------------------------------------------
+
+
+def test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name():
+    """Tier 2: a qualified name not in catalog tags ``source="ars_direct"``.
+
+    Issue #241: distinguish "the alias was a real hot-list entry the LLM
+    used correctly" (= name actually surfaced in tools[]) from "the LLM
+    picked a name from ARS text and called it directly" (= name appeared
+    only in invoke_action.description's ARS block). Pre-#241 the label
+    was unconditionally ``"hot_list_alias"`` for any ``__``-containing
+    direct call, regardless of catalog landing.
+
+    Uses ``bogus_category__action`` — unresolvable via universal_dispatch,
+    so the #229 salvage is a no-op and we still get the dispatcher's
+    standard ``unknown_tool`` error path. The label is the only thing
+    being verified here; the error outcome is incidental.
+    """
+    host = _FakeRouterHost(universal_wrappers_enabled=True)
+    _run_with_llm_sequence(
+        host,
+        [
+            _tool_result([{"name": "bogus_category__action", "args": {}}]),
+            _text_result("done"),
+        ],
+    )
+    events = _routing_decided_events(host)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["action_name"] == "bogus_category__action"
+    assert ev["source"] == "ars_direct", (
+        f"Expected source='ars_direct' for qualified name not in catalog, "
+        f"got {ev['source']!r}"
+    )
+
+
+def test_routing_decided_source_hot_list_alias_only_when_in_catalog():
+    """Tier 2: ``source="hot_list_alias"`` requires name to be in tools[].
+
+    Pin the discriminator: with a tracker pre-loaded for ``skill__bar``,
+    the alias IS in tools[] → ``"hot_list_alias"`` (already covered by
+    ``test_routing_decided_emitted_for_hot_list_alias``). Without a
+    tracker, the same name would tag ``"ars_direct"`` (= #241 split).
+    """
+    # Same skill name, same call shape, but no tracker → skill__bar NOT
+    # surfaced as a hot-list alias → NOT in tools[] / self._catalog.
+    host = _FakeRouterHost(
+        universal_wrappers_enabled=True,
+        tracker=None,
+        skills=[{"name": "bar", "short_description": "bar skill"}],
+    )
+    _run_with_llm_sequence(
+        host,
+        [
+            _tool_result([{"name": "skill__bar", "args": {}}]),
+            _text_result("done"),
+        ],
+    )
+    events = _routing_decided_events(host)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["action_name"] == "skill__bar"
+    assert ev["source"] == "ars_direct", (
+        f"Without hot-list landing, source must be 'ars_direct' not "
+        f"'hot_list_alias' (issue #241); got {ev['source']!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** —

Closes #241. Audit/debug wording follow-up to PR #240 (= #229 dispatcher salvage); per lead-coder direction this lands as a separate small PR.

## Summary

Pre-fix, `routing_decided.source` was unconditionally tagged `"hot_list_alias"` for any `__`-containing direct call, regardless of whether the qualified name actually landed in `tools[]`. This muddied the audit chain (= PR #227's NF-W5-B42-1 initial attribution to commit `9a452bbf` was partly enabled by this mislabel — a reader inferring "the alias was a real hot-list entry the LLM used correctly" was wrong half the time).

## New label semantics

| LLM emit shape | Name in `tools[]` / `self._catalog`? | Source label |
|---|---|---|
| `function_call.name = "invoke_action"`, `args.action_name = X` | n/a — LLM wrapped via universal_action | `"invoke_action"` |
| `function_call.name = X` (qualified), X **in** `tools[]` | yes (= real hot-list alias the LLM used directly) | `"hot_list_alias"` |
| `function_call.name = X` (qualified), X **not** in `tools[]` | no — picked from ARS block text; salvaged via PR #240 | `"ars_direct"` (NEW) |

## Implementation

Single conditional inside the existing `"__" in _rd_name` branch at `router_loop.py` `_dispatch_one_tool_call`:

```python
elif "__" in _rd_name:
    _rd_action = _rd_name
    if _rd_name in self._catalog:
        _rd_source = "hot_list_alias"
    else:
        _rd_source = "ars_direct"
```

No schema change to `routing_decided` event payload itself; downstream consumers that filter on `source` see a new value but no shape rev. Old `"hot_list_alias"` callers continue to fire for the correct subset (= alias was actually in tools[]); the previously-mistagged direct calls now correctly surface as `"ars_direct"`.

## Why this matters for dogfood retrospectives

Downstream NF investigators (= sandbox_2 for B43+) can now read `routing_decided.source` directly to triage whether a failed direct-call invocation was:

- **`"hot_list_alias"`**: the alias was correctly surfaced and the LLM used the right name — investigate downstream handler.
- **`"ars_direct"`**: the LLM picked the name from ARS text (= salvageable case PR #240 handles, OR genuinely unresolvable). If `direct_alias_call_salvaged` audit event also fired, the call succeeded post-salvage; if not, the name was bogus.

That triage path was impossible pre-#241 because both cases looked identical in the event log.

## Test plan

- [x] **Automated — `pytest tests/test_router_loop_routing_decided.py`**: 7/7 pass.
  - `test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name` (NEW): bogus qualified name → `source="ars_direct"`.
  - `test_routing_decided_source_hot_list_alias_only_when_in_catalog` (NEW): same skill name flips between `ars_direct` (no tracker → not in tools[]) and `hot_list_alias` (tracker pre-loaded → in tools[]).
  - Existing tests unchanged: hot-list-alias-with-tracker continues to assert `hot_list_alias`; error-outcome test doesn't assert source so still passes.
- [x] **Adjacent — `pytest tests/test_dispatcher_fallback_ars_direct_call.py tests/test_replay_skill_router.py tests/test_universal_dispatch.py tests/test_universal_handlers.py`**: 135 passed, 1 expected xfail. No replay fixture invalidation (= no ARS-block text or KNOWN_STATIC_QUALIFIED_NAMES change).
- [x] **Lint — `ruff check`**: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)