### PR TITLE
fix(chat/mcp): use asyncio.timeout in lazy probe to avoid anyio task-identity error

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -879,11 +879,21 @@ class RouterHostAdapter:
             return
 
         async def _probe_one(server_name: str) -> tuple[str, list[dict]]:
+            # ``asyncio.timeout()`` (Python 3.11+) instead of
+            # ``asyncio.wait_for`` because the latter wraps the awaited
+            # coroutine in a new asyncio.Task in some scenarios. When that
+            # inner task is cancelled mid-``MCPClient.initialize`` (= the
+            # underlying mcp SDK opens anyio cancel scopes inside an
+            # AsyncExitStack), the cleanup ends up running in a different
+            # task than the one that entered the scope, producing
+            # ``RuntimeError: Attempted to exit cancel scope in a different
+            # task than it was entered in``. ``asyncio.timeout()`` is a
+            # task-local deadline (= no task wrap) and cancellation is
+            # raised at the awaiter in the SAME task, so the AsyncExitStack
+            # unwinds correctly.
             try:
-                tools = await asyncio.wait_for(
-                    self._mcp_list_tools_cb(server_name),
-                    timeout=per_server_timeout,
-                )
+                async with asyncio.timeout(per_server_timeout):
+                    tools = await self._mcp_list_tools_cb(server_name)
             except (TimeoutError, asyncio.TimeoutError):
                 return server_name, []
             except Exception:  # noqa: BLE001 — adapter must never raise

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -332,3 +332,69 @@ async def test_get_mcp_servers_includes_tools_post_probe(tmp_path):
     await adapter.ensure_mcp_tools_cached()
     result = adapter.get_mcp_servers()
     assert result[0]["tools"] == [{"name": "foo_tool", "description": "x"}]
+
+
+# ── 8. Task-identity safety on timeout (= user-observed anyio error fix) ───
+#
+# When a probe coroutine opens an AsyncExitStack (= what
+# ``MCPClient.initialize()`` does under the hood; the stack wraps the
+# stdio_client / streamablehttp_client transport and the mcp SDK's
+# ClientSession), the cleanup runs on cancellation. Pre-fix this used
+# ``asyncio.wait_for`` which wraps the awaited coroutine in a new asyncio
+# task in some scenarios. The anyio cancel scopes inside the mcp SDK
+# checked current_task() at __aexit__ and raised
+# ``RuntimeError: Attempted to exit cancel scope in a different task
+# than it was entered in``. ``asyncio.timeout()`` is a task-local
+# deadline — cancellation is raised at the awaiter in the SAME task —
+# so the AsyncExitStack unwinds cleanly.
+
+
+@pytest.mark.asyncio
+async def test_timeout_does_not_leak_cancel_scope_error_on_async_exit_stack(tmp_path):
+    """Tier 2: a probe holding an AsyncExitStack across a timeout
+    survives cancellation without raising a ``RuntimeError: Attempted
+    to exit cancel scope in a different task...``.
+
+    Simulates the production path where ``MCPClient.initialize()``
+    opens an ``AsyncExitStack`` (and the mcp SDK opens anyio cancel
+    scopes inside it). With ``asyncio.wait_for`` (pre-fix), the
+    cleanup ran in a different task and the RuntimeError leaked. With
+    ``asyncio.timeout()`` (post-fix), cleanup runs in the same task
+    and the stack closes cleanly — the timeout path just caches ``[]``.
+    """
+    from contextlib import AsyncExitStack
+
+    entered_tasks: list[object] = []
+    exited_tasks: list[object] = []
+
+    async def _slow_probe(server: str) -> list[dict]:
+        stack = AsyncExitStack()
+        await stack.__aenter__()
+        entered_tasks.append(asyncio.current_task())
+        try:
+            # Sleep past the per-server timeout to force cancellation
+            # mid-AsyncExitStack hold.
+            await asyncio.sleep(2.0)
+        finally:
+            exited_tasks.append(asyncio.current_task())
+            await stack.aclose()
+        return []
+
+    adapter = _make_adapter_with_mcp(
+        tmp_path=tmp_path,
+        mcp_servers={"slow": {}},
+        mcp_list_tools_cb=_slow_probe,
+    )
+    # If asyncio.wait_for were still in use, this call would either
+    # raise or log a RuntimeError when the stack cleanup ran in a
+    # different task than the entry. asyncio.timeout() keeps the entry
+    # and exit on the same task.
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    assert entered_tasks == exited_tasks, (
+        "AsyncExitStack must enter and exit in the SAME asyncio.Task; "
+        f"entered={entered_tasks!r} exited={exited_tasks!r}"
+    )
+    listing = {s["name"]: s for s in adapter.get_mcp_servers()}
+    assert listing["slow"]["tools"] == [], (
+        "slow server must be cached as [] after timeout"
+    )


### PR DESCRIPTION
**[e2e-coder]** —

User observed `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in` when an MCP server failed to handshake within the lazy probe timeout (= 5s default in `ensure_mcp_tools_cached`). Investigation pinpoints a known interaction between `asyncio.wait_for` and the anyio cancel scopes that the mcp SDK uses internally.

## Root cause

`asyncio.wait_for(coro, timeout)` wraps the awaited coroutine in a new `asyncio.Task` in some scenarios. The mcp SDK's `ClientSession` opens anyio cancel scopes inside an `AsyncExitStack` during `MCPClient.initialize()`. `anyio.CancelScope.__exit__` verifies that `current_task()` matches the task that entered the scope; on timeout cancellation the cleanup ended up in a different task than the entry → `RuntimeError`.

This is a known mcp-python interaction pattern documented across multiple GitHub issues in the upstream MCP SDK and python-anyio.

## Fix

`asyncio.timeout(seconds)` (= Python 3.11+ context manager) is a **task-local deadline**: cancellation is raised at the awaiter in the SAME task. The `AsyncExitStack` unwinds in the same task it was entered in — no anyio mismatch.

```python
# Pre-fix
try:
    tools = await asyncio.wait_for(
        self._mcp_list_tools_cb(server_name),
        timeout=per_server_timeout,
    )

# Post-fix
try:
    async with asyncio.timeout(per_server_timeout):
        tools = await self._mcp_list_tools_cb(server_name)
```

`pyproject.toml` already pins `requires-python = ">=3.11"`, so `asyncio.timeout` is universally available (= no version branching needed).

## Test plan

- [x] **Automated — `pytest tests/test_mcp_lazy_tools_cache.py`**: 9/9 pass.
  - 1 new Tier 2 test (`test_timeout_does_not_leak_cancel_scope_error_on_async_exit_stack`): simulates a probe that opens an `AsyncExitStack` across a timeout, asserts `entered_task == exited_task`, verifies the slow server is cached as `[]` cleanly.
  - 8 existing tests (no-servers, parallel populate, idempotent, slow timeout, exception cached, error-shape filter, pre-probe / post-probe listing) — unchanged behavior, just task-safer plumbing.
- [x] **Lint — `ruff check`**: clean.

## User-visible repro

User running a self-made stdio MCP server reported `MCP initialize failed: Connection close` followed by the cancel-scope `RuntimeError` propagating up. With this fix the same slow-handshake scenario instead times out cleanly (= server cached as `[]`, no RuntimeError leak). The underlying "self-made server quit during handshake" issue is separate and best diagnosed by running the server outside reyn with stderr captured.

## Notes

- `MCPClient` itself doesn't need changes — the fix is one level up at the lazy probe boundary which is what cancels the inner stack.
- A possible future polish: improve the lazy probe to log the server's error message rather than swallowing to `[]` (= referenced as "副次的 UX gap" in earlier broker discussion). Separate small PR if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)