### PR TITLE
fix(chat,oauth): preventive asyncio.wait_for → asyncio.timeout sweep for anyio-touching paths

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2121,11 +2121,18 @@ class ChatSession:
                     msg_id, exc,
                 )
             remaining = max(0.1, deadline_monotonic - _time.monotonic())
+            # ``asyncio.timeout()`` (Python 3.11+) instead of
+            # ``asyncio.wait_for`` because ``_handle_skill_completed``
+            # drives a router LLM turn (= litellm → httpx async →
+            # internal anyio cancel scopes). If wait_for wraps the
+            # coroutine in a new task and the timeout fires mid-LLM
+            # call, the httpx cleanup runs in a different task than
+            # the entry → ``RuntimeError: Attempted to exit cancel
+            # scope in a different task...``. ``asyncio.timeout()``
+            # is a task-local deadline so the cleanup stays in-task.
             try:
-                await asyncio.wait_for(
-                    self._handle_skill_completed(payload),
-                    timeout=remaining,
-                )
+                async with asyncio.timeout(remaining):
+                    await self._handle_skill_completed(payload)
             except asyncio.TimeoutError:
                 drained_ok = False
                 break

--- a/src/reyn/secrets/oauth.py
+++ b/src/reyn/secrets/oauth.py
@@ -729,8 +729,17 @@ async def device_grant_flow(
                         error_code=error_code or None,
                     )
 
+        # ``asyncio.timeout()`` instead of ``asyncio.wait_for`` because the
+        # latter can wrap the awaited coroutine in a new asyncio.Task and
+        # ``_poll_loop`` issues HTTP requests via ``httpx.AsyncClient``,
+        # which opens anyio cancel scopes internally. On timeout
+        # cancellation, the cleanup would run in a different task than
+        # the entry → ``RuntimeError: Attempted to exit cancel scope in
+        # a different task...``. ``asyncio.timeout()`` is a task-local
+        # deadline (= no task wrap) and httpx unwinds cleanly.
         try:
-            token = await asyncio.wait_for(_poll_loop(), timeout=deadline_seconds)
+            async with asyncio.timeout(deadline_seconds):
+                token = await _poll_loop()
         except asyncio.TimeoutError:
             raise DeviceGrantError(
                 f"Device grant for {provider.name!r} timed out after "


### PR DESCRIPTION
**[e2e-coder]** —

Follow-up to PR #243 (= MCP lazy probe task-identity fix). Per the "類似案件" audit asked for after #243, I checked every `asyncio.wait_for` site in the codebase for the same anyio-cancel-scope class of risk.

## Audit summary (= all 10 `asyncio.wait_for` usages)

| Site | wrapped coroutine | anyio risk | action |
|---|---|---|---|
| `chat/services/router_host_adapter.py:883` | MCP SDK callback | high | **fixed in PR #243** |
| **`secrets/oauth.py:733`** | `_poll_loop` → `httpx.AsyncClient` | medium-high | **THIS PR** |
| **`chat/session.py:2125`** | `_handle_skill_completed` → router LLM → litellm/httpx | medium | **THIS PR** |
| `tui/voice.py:257/360/440` | `asyncio.to_thread(sync_fn)` | low (no anyio) | skip |
| `web/ws/chat.py:102` | `asyncio.Queue.get` | low | skip |
| `safety/limit_handler.py:191` | `bus.request` (futures) | low | skip |
| `op_runtime/shell.py:69` | `subprocess.communicate` | low | skip |
| `cron/scheduler.py:121` | `asyncio.gather` | low | skip |

The 6 "skip" sites wrap pure-asyncio primitives (= threads, queues, subprocess, gather) with no anyio dependency. Safe as-is.

## Fix

Same shape as PR #243 — replace `asyncio.wait_for` (= can wrap inner coroutine in a new asyncio.Task, breaking anyio's `current_task()` check on cleanup) with `asyncio.timeout(seconds)` context manager (= task-local deadline, cancellation in same task, anyio scope unwinds cleanly).

### `secrets/oauth.py:733`

```python
# before
try:
    token = await asyncio.wait_for(_poll_loop(), timeout=deadline_seconds)
# after
try:
    async with asyncio.timeout(deadline_seconds):
        token = await _poll_loop()
```

`_poll_loop` issues HTTP requests via `httpx.AsyncClient`, which opens anyio cancel scopes for connection-pool lifecycle. Triggered when a device-grant flow deadlines (= default 600s); rare path but the exact same task-identity error PR #243 fixed for MCP would surface.

### `chat/session.py:2125`

```python
# before
try:
    await asyncio.wait_for(
        self._handle_skill_completed(payload), timeout=remaining,
    )
# after
try:
    async with asyncio.timeout(remaining):
        await self._handle_skill_completed(payload)
```

`_handle_skill_completed` drives a router LLM turn via litellm → httpx async → internal anyio scopes. Inbox drain timeout firing mid-LLM-call would trigger the same class of error.

Both edits preserve the existing `asyncio.TimeoutError` catch shape and caller-visible semantics. Only the cancellation plumbing changes.

## Test plan

- [x] **Adjacent — oauth + device-grant tests**: `pytest tests/test_fp0016_b_oauth_refresh.py tests/test_fp0016_c_device_grant.py` → 38/38 pass (= same `TimeoutError` contract preserved).
- [x] **Adjacent — drain inbox tests**: `pytest tests/test_mcp_server.py -k drain` → 2/2 pass.
- [x] **Adjacent — lazy probe regression check (PR #243)**: `pytest tests/test_mcp_lazy_tools_cache.py` → 9/9 pass.
- [x] **Lint — `ruff check`**: clean on both touched files.

## Why preventive

Neither path has been reported by users, but both wrap httpx-using coroutines where the failure mode is the exact same anyio task-identity error PR #243 fixed for MCP. Cost: 2 textual edits. Benefit: forecloses a class of latent reports before they hit a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)