### PR TITLE
fix(tools): align invoke_action→call_mcp_tool arg key (mcp_tool_name)

### DIFF
--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -146,10 +146,13 @@ def _list_mcp_tools_args(
 def _call_mcp_tool_args(
     entry_name: str, args: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """``mcp.tool__<server>.<tool>`` → ``call_mcp_tool({server, tool, args})``.
+    """``mcp.tool__<server>.<tool>`` → ``call_mcp_tool({server, mcp_tool_name, args})``.
 
     Entry name has the form ``<server>.<tool>``. First ``.`` separates
     server from tool. The MCP tool's own args are passed under ``args``.
+    The output key is ``mcp_tool_name`` to match the ``call_mcp_tool``
+    handler's parameter schema (FP-0032). Returning ``tool`` raised
+    ``KeyError: mcp_tool_name`` in ``_handle_call_mcp_tool``.
     """
     if "." not in entry_name:
         raise UnknownActionError(
@@ -157,7 +160,7 @@ def _call_mcp_tool_args(
             "mcp.tool entry name must have form <server>.<tool>",
         )
     server, tool = entry_name.split(".", 1)
-    return {"server": server, "tool": tool, "args": dict(args)}
+    return {"server": server, "mcp_tool_name": tool, "args": dict(args)}
 
 
 def _read_memory_body_args(

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -85,16 +85,44 @@ def test_resolve_invoke_action_mcp_server_routes_to_list_tools() -> None:
 
 
 def test_resolve_invoke_action_mcp_tool_splits_server_dot_tool() -> None:
-    """Tier 2: mcp.tool__<server>.<tool> → call_mcp_tool(server, tool, args)."""
+    """Tier 2: mcp.tool__<server>.<tool> → call_mcp_tool(server, mcp_tool_name, args).
+
+    The output key MUST be ``mcp_tool_name`` (not ``tool``) to match the
+    ``call_mcp_tool`` handler's parameter schema. Returning ``tool`` here
+    raised ``KeyError: mcp_tool_name`` inside ``_handle_call_mcp_tool``
+    when invoke_action dispatched to it (= production-observed regression).
+    """
     result = resolve_invoke_action(
         "mcp.tool__brave.search", {"q": "reyn"},
     )
     assert result.target_tool_name == "call_mcp_tool"
     assert result.target_args == {
         "server": "brave",
-        "tool": "search",
+        "mcp_tool_name": "search",
         "args": {"q": "reyn"},
     }
+
+
+def test_resolve_invoke_action_mcp_tool_keys_match_call_mcp_tool_schema() -> None:
+    """Tier 2: resolved arg keys are a subset of call_mcp_tool's required schema.
+
+    Regression guard: this pins the contract that universal_dispatch's
+    output keys for ``mcp.tool__*`` match what ``call_mcp_tool``'s
+    parameter schema declares required. If either side drifts (= the
+    handler renames ``mcp_tool_name`` or the dispatcher reverts to
+    ``tool``), this test fails BEFORE the mismatch reaches production
+    as a KeyError stack trace.
+    """
+    from reyn.tools.mcp import CALL_MCP_TOOL
+
+    result = resolve_invoke_action(
+        "mcp.tool__brave.search", {"q": "reyn"},
+    )
+    required = set(CALL_MCP_TOOL.parameters.get("required", []))
+    assert required.issubset(result.target_args.keys()), (
+        f"resolver produced keys {sorted(result.target_args.keys())} "
+        f"but call_mcp_tool requires {sorted(required)}"
+    )
 
 
 def test_resolve_invoke_action_mcp_tool_missing_dot_raises() -> None:


### PR DESCRIPTION
**[e2e-coder]** —

User reported their self-made stdio MCP server returns `tool list` correctly via `list_mcp_tools` but every tool invocation fails — the router loop exhausts iterations and bails. Trace of the failing tool_call_emitted event:

```
tool_name: call_mcp_tool
arguments: {server: "outlook", tool: "mcp.tool__outlook.get_recent_emails", args: {...}}
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The `tool` key (= MCPIROp shape) and the universal-catalog-prefixed value (`mcp.tool__...`) initially looked like LLM hallucination. **It wasn't.** This was the canonical `invoke_action` dispatch path producing exactly that shape, and the handler crashing on `args["mcp_tool_name"]`.

## Root cause

`src/reyn/tools/universal_dispatch.py:_call_mcp_tool_args` (= the args transformer for `mcp.tool__<server>.<tool>` qualified names) produced:

```python
return {"server": server, "tool": tool, "args": dict(args)}
                          ^^^^^^^^^^^^
```

while `src/reyn/tools/mcp.py:_handle_call_mcp_tool` reads:

```python
mcp_tool_name = str(args["mcp_tool_name"])
                       ^^^^^^^^^^^^^^^^^^
```

→ every dispatch from `invoke_action(action_name="mcp.tool__...")` raised raw `KeyError: mcp_tool_name` inside the handler. The router loop saw an unrecoverable tool error, retried with the same canonical args, hit the iteration cap, bailed.

This is a regression from the FP-0032 / FP-0034 timing — FP-0032 renamed the handler's parameter from `tool` → `mcp_tool_name`, FP-0034 added the universal_dispatch routing table, but the resolver kept the pre-FP-0032 key.

## Fix

One-line key rename in `_call_mcp_tool_args`:

```diff
- return {"server": server, "tool": tool, "args": dict(args)}
+ return {"server": server, "mcp_tool_name": tool, "args": dict(args)}
```

## Test changes

1. **Updated** the existing Tier 2 test `test_resolve_invoke_action_mcp_tool_splits_server_dot_tool` — it had pinned the buggy `{"tool": ...}` shape, which is why the bug stayed hidden.
2. **Added** `test_resolve_invoke_action_mcp_tool_keys_match_call_mcp_tool_schema` — Tier 2 regression guard that asserts the resolver's output keys cover `CALL_MCP_TOOL.parameters` required schema. If either side drifts again, this test fails BEFORE production sees a KeyError.

## Why no fixture re-record

`grep call_mcp_tool tests/fixtures/` returned nothing — no replay fixture currently pins this path. Per replay-fixture-discipline, no `test_replay_skill_router` / `test_universal_dispatch` / `test_universal_handlers` re-record needed.

## Test plan

- [x] **Automated — `pytest tests/test_universal_dispatch.py`**: 60/60 pass.
- [x] **Adjacent — `pytest tests/test_mcp_unified.py tests/test_universal_handlers.py tests/test_replay_skill_router.py`** (= replay-fixture-discipline trio): 88 passed + 1 xfailed.
- [x] **Full suite — `pytest tests/ -x --ignore=tests/scaffold`**: 3884 passed, 11 skipped, 3 xfailed in 135s.
- [x] **Lint — `ruff check`**: clean on both touched files.
- [ ] **Manual — user verifies their self-made stdio MCP server's tools are invocable post-merge** (= the report that triggered this PR). Out of CI scope; the contract test pins the structural fix.

## Notes

- The contract-pin test references `CALL_MCP_TOOL.parameters` (the registered ToolDefinition's schema) rather than hard-coding `mcp_tool_name`, so a future field rename on either side stays self-consistent or fails loudly.
- Production-observed symptom is `router loop exceeded max iterations (5)` — distinct from the diagnostic "Connection close" path PR #245 fixed. Same family of MCP-UX fixes (#243 / #244 / #245 / this), but a different root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)