### PR TITLE
test(universal_dispatch): pin resolver→target schema contract across all 26 routes

### DIFF
--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -522,3 +522,136 @@ def test_agent_peer_translator_caller_supplies_request_directly() -> None:
     translated = resolved.target_args
     assert translated["to"] == "analyst"
     assert translated["request"] == "Run the numbers."
+
+
+# ── 6. Schema-cross-reference contract pin (regression guard) ────────────
+#
+# The mcp.tool routing regression (PR #246) escaped because the resolver
+# emitted ``tool`` while the target handler read ``mcp_tool_name``, and
+# the existing test happened to PIN the buggy shape. The fix added a
+# point-in-time assertion that the resolver's output keys cover
+# call_mcp_tool's required schema. This section generalises that
+# contract across EVERY routing entry — for each route, we verify:
+#
+#   (a) the target tool exists in get_default_registry() (catches
+#       rename / removal of the target without a routing-table update),
+#   (b) with a representative caller-args payload, the resolver's
+#       output keys cover the target's required schema (catches a
+#       key-name mismatch like the PR #246 regression at test time).
+#
+# The samples below mirror the canonical LLM invocation shape per
+# category (= what the universal-catalog wrappers instruct the LLM to
+# supply). Adding a new routing entry without a sample here will fail
+# the inventory-coverage test below, forcing the author to declare an
+# explicit contract for the new route.
+
+# Representative ``(qualified_name, caller_args)`` per routing entry.
+# Keys reflect what the LLM would emit for that action; the resolver
+# is responsible for shaping them to the target's required schema.
+_ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
+    # Resource categories (= _RESOURCE_RULES)
+    ("skill__code_review", {"input": {"type": "x", "data": {}}}),
+    ("agent.peer__planner", {"message": "hi", "request": "hi"}),
+    ("mcp.server__brave", {}),
+    ("mcp.tool__brave.search", {"q": "reyn"}),
+    ("memory.entry__pref_dates", {}),
+    ("rag.corpus__notes", {"query": "what"}),
+    # Operation categories (= _OPERATION_RULES) — passthrough transformers,
+    # so the caller args must already include the target's required keys.
+    ("file__read",   {"path": "a.txt"}),
+    ("file__write",  {"path": "a.txt", "content": "x"}),
+    ("file__delete", {"path": "a.txt"}),
+    ("file__list",   {"path": "."}),
+    ("file__grep",   {"pattern": "x"}),
+    ("file__glob",   {"pattern": "*.py"}),
+    ("file__edit",   {"path": "a", "old_string": "b", "new_string": "c"}),
+    ("web__search",  {"query": "x"}),
+    ("web__fetch",   {"url": "https://x"}),
+    ("memory.operation__remember_shared",
+     {"slug": "s", "name": "n", "description": "d", "type": "user", "body": "b"}),
+    ("memory.operation__remember_agent",
+     {"slug": "s", "name": "n", "description": "d", "type": "user", "body": "b"}),
+    ("memory.operation__forget", {"layer": "shared", "slug": "s"}),
+    ("reyn.source__read", {"path": "a"}),
+    ("reyn.source__list", {"path": "."}),
+    ("reyn.source__glob", {"pattern": "*.py"}),
+    ("reyn.source__grep", {"pattern": "x"}),
+    ("rag.operation__recall",      {"query": "q", "sources": ["s"]}),
+    ("rag.operation__drop_source", {"source": "s"}),
+    ("mcp.operation__drop_server", {"server": "x"}),
+    ("exec__sandboxed_exec",       {"argv": ["echo", "hi"]}),
+]
+
+
+@pytest.mark.parametrize("qualified_name,caller_args", _ROUTE_CONTRACT_SAMPLES)
+def test_resolver_target_exists_and_args_cover_required_schema(
+    qualified_name: str, caller_args: dict[str, Any],
+) -> None:
+    """Tier 2: every routing entry produces args satisfying the target's required schema.
+
+    Regression guard for the FP-0032 / FP-0034 class of drift (= the PR
+    #246 mcp.tool key mismatch). For each route, the resolver must:
+
+      (a) point at a target_tool_name that exists in the unified
+          registry (= catches rename / removal of the target),
+      (b) given a representative LLM-style caller_args payload, emit
+          a target_args dict whose keys cover the target's required
+          schema (= catches a name mismatch like ``tool`` vs
+          ``mcp_tool_name`` BEFORE it surfaces as a raw KeyError stack
+          trace in production).
+
+    Sample inputs reflect what the universal-catalog wrappers instruct
+    the LLM to supply per category. They are NOT exhaustive coverage of
+    every arg shape the LLM might emit — they pin the canonical shape
+    so a drift on either side fails the test at the routing wire.
+    """
+    from reyn.tools import get_default_registry
+
+    result = resolve_invoke_action(qualified_name, caller_args)
+    registry = get_default_registry()
+    target = registry.lookup(result.target_tool_name)
+    assert target is not None, (
+        f"routing entry for {qualified_name!r} targets "
+        f"{result.target_tool_name!r}, which is not in the registry"
+    )
+    required = set(target.parameters.get("required", []))
+    produced = set(result.target_args.keys())
+    missing = required - produced
+    assert not missing, (
+        f"resolver for {qualified_name!r} produced keys {sorted(produced)} "
+        f"but target {result.target_tool_name!r} requires {sorted(required)}; "
+        f"missing: {sorted(missing)}"
+    )
+
+
+def test_route_contract_samples_cover_every_routing_entry() -> None:
+    """Tier 2: every entry in the routing tables has a contract sample.
+
+    Adding a new resource category or operation rule without a sample
+    in ``_ROUTE_CONTRACT_SAMPLES`` would silently bypass the contract
+    pin above. This test fails the moment a new route is introduced
+    without an explicit sample declaration.
+    """
+    from reyn.tools.universal_dispatch import (
+        _OPERATION_RULES,
+        _RESOURCE_RULES,
+    )
+
+    sample_names = {name for name, _ in _ROUTE_CONTRACT_SAMPLES}
+
+    # Operation rules: each key is a full qualified name.
+    operation_names = set(_OPERATION_RULES.keys())
+    missing_ops = operation_names - sample_names
+    assert not missing_ops, (
+        f"operation rules without a contract sample: {sorted(missing_ops)}"
+    )
+
+    # Resource rules: each key is a category. We require at least one
+    # sample qualified-name per category.
+    sample_categories = {name.split("__", 1)[0] for name in sample_names}
+    resource_categories = set(_RESOURCE_RULES.keys())
+    missing_resources = resource_categories - sample_categories
+    assert not missing_resources, (
+        f"resource categories without a contract sample: "
+        f"{sorted(missing_resources)}"
+    )


### PR DESCRIPTION
**[e2e-coder]** —

Follow-up to PR #246 per lead-coder broker request. The mcp.tool regression there escaped because the resolver emitted `tool` while the target handler read `mcp_tool_name`, and the existing test happened to PIN the buggy shape. PR #246 fixed the immediate bug and added a single-route contract pin (= "resolver output keys cover call_mcp_tool's required schema"). This PR generalises that pin across **every** routing entry in `universal_dispatch.py`.

## What this changes

**Test-side only — no production code touched.**

Adds a parametrized Tier 2 test in `tests/test_universal_dispatch.py`:

```python
@pytest.mark.parametrize("qualified_name,caller_args", _ROUTE_CONTRACT_SAMPLES)
def test_resolver_target_exists_and_args_cover_required_schema(...)
```

For each of the 26 routing entries, the test verifies:

(a) **target tool exists** in `get_default_registry()` — catches a rename / removal of the target without a routing-table update.

(b) **resolver output keys ⊇ target required** — catches a key-name mismatch (= the PR #246 class of regression) BEFORE it surfaces as a raw KeyError stack trace in production.

Plus an inventory-coverage test (`test_route_contract_samples_cover_every_routing_entry`) that fails the moment a new route is added without an explicit contract sample — so the guard stays exhaustive over time as `_OPERATION_RULES` / `_RESOURCE_RULES` grow.

## Coverage matrix

| Category | Routes covered | Transformer |
|---|---|---|
| Resource — skill | `skill__*` (1 sample) | `_invoke_skill_args` |
| Resource — agent.peer | `agent.peer__*` (1 sample) | `_delegate_to_agent_args` |
| Resource — mcp.server | `mcp.server__*` (1 sample) | `_list_mcp_tools_args` |
| Resource — mcp.tool | `mcp.tool__*` (1 sample) | `_call_mcp_tool_args` |
| Resource — memory.entry | `memory.entry__*` (1 sample) | `_read_memory_body_args` |
| Resource — rag.corpus | `rag.corpus__*` (1 sample) | `_recall_single_source_args` |
| Operation — file | read / write / delete / list / grep / glob / edit (7 samples) | `_passthrough_args` |
| Operation — web | search / fetch (2 samples) | `_passthrough_args` |
| Operation — memory.operation | remember_shared / remember_agent / forget (3 samples) | `_passthrough_args` |
| Operation — reyn.source | read / list / glob / grep (4 samples) | `_passthrough_args` |
| Operation — rag.operation | recall / drop_source (2 samples) | `_passthrough_args` |
| Operation — mcp.operation | drop_server (1 sample) | `_passthrough_args` |
| Operation — exec | sandboxed_exec (1 sample) | `_passthrough_args` |
| **Total** | **26 routes** | **7 transformer types** |

`_ROUTE_CONTRACT_SAMPLES` lives in the test module as an explicit data table — each sample reflects the canonical LLM-style invocation shape per category. This is what the universal-catalog wrappers instruct the LLM to supply.

## What this CATCHES going forward

Concrete regression classes this pin will fail:

1. **Resolver output key rename / typo** (= the PR #246 bug) — e.g. someone renames `_call_mcp_tool_args`'s output from `mcp_tool_name` back to `tool` without updating the handler. Now this test fails at the route's row.
2. **Target tool renamed without routing-table update** — e.g. `read_file` → `file_read` ToolDefinition rename without touching `_OPERATION_RULES`. Now `registry.lookup` returns None, test fails.
3. **Target tool's required schema gains a new field that the resolver doesn't supply** — e.g. `read_file` adds `encoding` to required without updating the passthrough sample. Test fails at the route's row.
4. **New routing entry added without a contract sample** — the inventory test fails, forcing an explicit declaration.

## What this does NOT catch (= intentional scope)

- **Passthrough routes don't verify LLM-side responsibility**: if the LLM omits a required key from a `file__read` call, that's an LLM-emit-time fail, not a routing-wire fail. This test only pins the wire.
- **Per-route value semantics**: existing per-route spot tests still pin specific value shapes (e.g. that `mcp.tool__brave.search` produces `mcp_tool_name="search"`). The new parametrized test is a structural cover, not a value-equality cover.

## Test plan

- [x] **Automated — `pytest tests/test_universal_dispatch.py`**: 87/87 pass (= +27 vs main: 26 parametrized + 1 inventory).
- [x] **Adjacent — `pytest tests/test_mcp_unified.py tests/test_universal_handlers.py tests/test_replay_skill_router.py`** (= replay-fixture-discipline trio): 88 passed + 1 xfailed.
- [x] **Full suite — `pytest tests/ -x --ignore=tests/scaffold`**: 3911 passed, 11 skipped, 3 xfailed in 136s.
- [x] **Lint — `ruff check tests/test_universal_dispatch.py`**: clean.

## Notes

- No fixture re-record needed (= test-only changes, no resolver / handler / registry shape changes).
- Sample input data avoids any optional fields not present in the target's `required` list — keeps the test focused on the WIRE contract, not on optional-arg passthrough.
- The two redundant pieces of coverage (= the existing `test_resolve_invoke_action_mcp_tool_keys_match_call_mcp_tool_schema` from PR #246 and the new generic parametrized test) are retained intentionally: the former pins the specific failure mode that motivated the pattern; the latter generalises it. Both stay green or break for distinct reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)