### PR TITLE
fix(describe_action): surface per-resource description — closes B42-NF-W7-1 mid-chain empty-stop

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -862,9 +862,24 @@ async def _handle_describe_action(
         else dict(target.parameters)
     )
 
+    # B42-NF-W7-1: prefer the per-resource description over the dispatcher's
+    # generic description (= ``invoke_skill`` / ``delegate_to_agent`` /
+    # ``call_mcp_tool`` instruction text). Without this, describe_action on
+    # a skill__/agent.peer__/mcp.tool__ resource returns the dispatcher's
+    # "how to invoke a skill" wording instead of the resource's actual
+    # description — the LLM has nothing meaningful to relay and empty-stops
+    # on pronoun-followups like "tell me more about the simplest one"
+    # (N=10 trace replay: 9/10 empty → 0/10 empty after substituting the
+    # actual skill.md description).
+    resource_desc = _resource_description(qualified_name, ctx, registry)
+    description = (
+        resource_desc if resource_desc is not None
+        else target.description
+    )
+
     return {
         "qualified_name": qualified_name,
-        "description": target.description,
+        "description": description,
         "input_schema": input_schema,
         "metadata": {
             "target_tool_name": resolved.target_tool_name,
@@ -993,6 +1008,113 @@ def _resource_input_schema(
     # mismatch (memory.entry's transform sends {name} but read_memory_body
     # wants {layer, slug}); fall back to target.parameters so the LLM at
     # least sees the dispatcher's shape and can recover via list_actions.
+    return None
+
+
+def _resource_description(
+    qualified_name: str,
+    ctx: ToolContext,
+    registry: Any,
+) -> "str | None":
+    """Return the per-resource description for a resource-category action,
+    or ``None`` for operation categories (= caller falls back to
+    ``target.description``, which is the correct text for operation
+    categories whose target IS the action).
+
+    Mirrors ``_resource_input_schema`` for the description field. B42-NF-W7-1
+    fix: without per-resource descriptions, describe_action on a resource
+    returns the dispatcher's generic instruction text — uninformative for
+    the LLM trying to narrate "tell me more about <resource>".
+
+    Covered (= same set as ``_resource_input_schema``):
+      - ``skill__<name>`` — pulls ``description`` from
+        ``ctx.router_state.host.list_available_skills()``.
+      - ``agent.peer__<name>`` — pulls ``description`` from
+        ``ctx.router_state.host.list_available_agents()``.
+      - ``mcp.tool__<server>.<tool>`` — pulls ``description`` from the
+        tool's MCP-server entry (FP-0032 expanded shape).
+      - ``mcp.server__<name>`` — pulls server-level ``description`` from
+        ``ctx.router_state.mcp_servers``.
+      - ``rag.corpus__<name>`` — None (no per-corpus description surface
+        today; caller falls back to the ``recall`` tool description).
+      - ``memory.entry__<name>`` — None (memory entries don't carry a
+        description; caller falls back to ``read_memory_body``).
+
+    Returns ``None`` for unrecognised categories or when per-resource
+    metadata isn't reachable (= test sites with stub router_state, etc.).
+    """
+    rs = getattr(ctx, "router_state", None)
+
+    try:
+        category, entry_name = split_qualified_name(qualified_name)
+    except ValueError:
+        return None
+
+    if category == "skill":
+        host = getattr(rs, "host", None) if rs is not None else None
+        if host is None or not hasattr(host, "list_available_skills"):
+            return None
+        try:
+            for skill in host.list_available_skills():
+                if not isinstance(skill, Mapping):
+                    continue
+                if skill.get("name") == entry_name:
+                    desc = skill.get("description")
+                    return str(desc) if desc else None
+        except Exception:
+            return None
+        return None
+
+    if category == "agent.peer":
+        host = getattr(rs, "host", None) if rs is not None else None
+        if host is None or not hasattr(host, "list_available_agents"):
+            return None
+        try:
+            for agent in host.list_available_agents():
+                if not isinstance(agent, Mapping):
+                    continue
+                if agent.get("name") == entry_name:
+                    desc = agent.get("description") or agent.get("role")
+                    return str(desc) if desc else None
+        except Exception:
+            return None
+        return None
+
+    if category == "mcp.tool":
+        mcp_servers = (
+            getattr(rs, "mcp_servers", None) if rs is not None else None
+        )
+        if not mcp_servers or "." not in entry_name:
+            return None
+        server_name, tool_name = entry_name.split(".", 1)
+        for srv in mcp_servers:
+            if not isinstance(srv, Mapping):
+                continue
+            if srv.get("name") != server_name:
+                continue
+            for t in (srv.get("tools") or []):
+                if not isinstance(t, Mapping):
+                    continue
+                if t.get("name") != tool_name:
+                    continue
+                desc = t.get("description")
+                return str(desc) if desc else None
+            return None
+        return None
+
+    if category == "mcp.server":
+        mcp_servers = (
+            getattr(rs, "mcp_servers", None) if rs is not None else None
+        )
+        if not mcp_servers:
+            return None
+        for srv in mcp_servers:
+            if isinstance(srv, Mapping) and srv.get("name") == entry_name:
+                desc = srv.get("description")
+                return str(desc) if desc else None
+        return None
+
+    # rag.corpus / memory.entry / unknown — fall through to target.description
     return None
 
 

--- a/tests/test_describe_action_resource_description.py
+++ b/tests/test_describe_action_resource_description.py
@@ -1,0 +1,227 @@
+"""Tier 2: describe_action returns per-resource description (B42-NF-W7-1).
+
+Companion to ``test_describe_action_resource_schemas.py`` (= D2-full
+input_schema fix). The D2-full work covered ``input_schema`` only and
+left the ``description`` field defaulting to the dispatcher's generic
+description (= "Run a skill from the registered list. The 'name'
+parameter MUST be..." for ``invoke_skill`` etc.).
+
+The B42 W7-S2 trace ("Tell me more about the simplest one") confirmed
+the empty-stop mechanism: when describe_action returns the dispatcher's
+generic description instead of the resource's actual one, the LLM has
+nothing meaningful to relay and produces an empty reply. N=10
+trace-patch-replay: 9/10 empty → 0/10 empty after substituting the
+actual ``skill.md`` description.
+
+These tests pin:
+
+- ``skill__X``      → description from ``list_available_skills`` entry.
+- ``agent.peer__X`` → description (or role fallback) from
+                      ``list_available_agents`` entry.
+- ``mcp.tool__X.Y`` → per-tool description from ``mcp_servers``.
+- ``mcp.server__X`` → server-level description from ``mcp_servers``.
+- Operation categories fall through to ``target.description`` unchanged.
+- Missing per-resource description falls through to ``target.description``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import _handle_describe_action
+
+
+class _FakeEvents:
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+class _FakeHost:
+    """Minimal host returning enriched skill / agent lists."""
+
+    def __init__(self, skills=None, agents=None):
+        self._skills = skills or []
+        self._agents = agents or []
+
+    def list_available_skills(self):
+        return list(self._skills)
+
+    def list_available_agents(self):
+        return list(self._agents)
+
+
+def _make_ctx(skills=None, agents=None, mcp_servers=None):
+    rs = RouterCallerState(
+        host=_FakeHost(skills=skills, agents=agents),
+        mcp_servers=mcp_servers,
+    )
+    return ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=rs,
+    )
+
+
+def _describe(qualified_name: str, ctx: ToolContext) -> dict:
+    return asyncio.run(_handle_describe_action(
+        {"action_name": qualified_name}, ctx,
+    ))
+
+
+# ── skill__X ────────────────────────────────────────────────────────────
+
+
+def test_skill_describe_returns_skill_description():
+    """Tier 2 (B42-NF-W7-1): describe_action(skill__X) returns the SKILL's
+    description (= skill.md frontmatter), NOT invoke_skill's dispatcher
+    instructions.
+    """
+    actual_desc = (
+        "Catalogue-gap fallback: hand a single-shot natural-language task "
+        "straight to the LLM and return its answer verbatim."
+    )
+    ctx = _make_ctx(skills=[
+        {"name": "direct_llm", "description": actual_desc},
+    ])
+    out = _describe("skill__direct_llm", ctx)
+    assert out["description"] == actual_desc
+    # Sanity: the dispatcher description string must NOT have leaked.
+    assert "Run a skill from the registered list" not in out["description"]
+
+
+def test_skill_describe_missing_description_falls_back_to_dispatcher():
+    """Tier 2: skill entry without ``description`` falls back to
+    ``invoke_skill``'s description (= preserves D2-full pre-existing
+    behavior; the LLM at least sees the dispatcher contract).
+    """
+    ctx = _make_ctx(skills=[
+        {"name": "no_desc_skill"},  # No description field
+    ])
+    out = _describe("skill__no_desc_skill", ctx)
+    # invoke_skill's dispatcher description (= the pre-B42 fallback)
+    assert "Run a skill" in out["description"] or "skill" in out["description"].lower()
+
+
+def test_skill_describe_unknown_skill_falls_back_to_dispatcher():
+    """Tier 2: querying a skill not in list_available_skills falls back to
+    ``invoke_skill``'s description (caller falls through error response;
+    if reached the dispatcher fallback, the contract is preserved).
+    """
+    ctx = _make_ctx(skills=[
+        {"name": "other_skill", "description": "Other"},
+    ])
+    out = _describe("skill__unknown_skill", ctx)
+    # The unknown-action error response carries no `description` field —
+    # it's a §D12 error response with `error_kind` / `suggestions`. Pin
+    # that contract here so the fallback distinction is unambiguous.
+    # If the response IS the error shape, we're done; if it carries a
+    # description field, it must be the dispatcher fallback (not None).
+    if "description" in out:
+        assert out["description"]
+
+
+# ── agent.peer__X ───────────────────────────────────────────────────────
+
+
+def test_agent_peer_describe_returns_agent_description():
+    """Tier 2 (B42-NF-W7-1): describe_action(agent.peer__X) returns the
+    AGENT's description / role, not delegate_to_agent's dispatcher text.
+    """
+    actual_desc = "Researches topics by querying multiple sources."
+    ctx = _make_ctx(agents=[
+        {"name": "researcher", "description": actual_desc},
+    ])
+    out = _describe("agent.peer__researcher", ctx)
+    assert out["description"] == actual_desc
+
+
+def test_agent_peer_describe_falls_back_to_role_when_no_description():
+    """Tier 2: agent entry without ``description`` uses ``role`` as fallback
+    (= the role field is the agent profile's human-readable summary).
+    """
+    ctx = _make_ctx(agents=[
+        {"name": "writer", "role": "Drafts and revises article copy."},
+    ])
+    out = _describe("agent.peer__writer", ctx)
+    assert out["description"] == "Drafts and revises article copy."
+
+
+def test_agent_peer_describe_missing_both_falls_back_to_dispatcher():
+    """Tier 2: agent with neither ``description`` nor ``role`` falls back to
+    delegate_to_agent's dispatcher description.
+    """
+    ctx = _make_ctx(agents=[
+        {"name": "ghost"},
+    ])
+    out = _describe("agent.peer__ghost", ctx)
+    # Some non-empty fallback (= dispatcher's description, whatever its wording)
+    assert out.get("description")
+
+
+# ── mcp.tool__server.tool ───────────────────────────────────────────────
+
+
+def test_mcp_tool_describe_returns_tool_description():
+    """Tier 2 (B42-NF-W7-1): describe_action(mcp.tool__server.tool) returns
+    the MCP tool's declared description, not call_mcp_tool's dispatcher text.
+    """
+    actual_desc = "Search GitHub pull requests matching a query."
+    ctx = _make_ctx(mcp_servers=[
+        {
+            "name": "github",
+            "tools": [
+                {"name": "search_pull_requests", "description": actual_desc},
+            ],
+        },
+    ])
+    out = _describe("mcp.tool__github.search_pull_requests", ctx)
+    assert out["description"] == actual_desc
+
+
+def test_mcp_tool_describe_missing_description_falls_back():
+    """Tier 2: MCP tool without ``description`` field falls back to
+    call_mcp_tool's dispatcher description.
+    """
+    ctx = _make_ctx(mcp_servers=[
+        {
+            "name": "github",
+            "tools": [{"name": "ping"}],
+        },
+    ])
+    out = _describe("mcp.tool__github.ping", ctx)
+    # Some non-empty fallback expected
+    assert out.get("description")
+
+
+# ── mcp.server__X ───────────────────────────────────────────────────────
+
+
+def test_mcp_server_describe_returns_server_description():
+    """Tier 2 (B42-NF-W7-1): describe_action(mcp.server__X) returns the
+    server's description, not list_mcp_tools' dispatcher text.
+    """
+    actual_desc = "GitHub MCP server — search/comment/PR ops."
+    ctx = _make_ctx(mcp_servers=[
+        {"name": "github", "description": actual_desc, "tools": []},
+    ])
+    out = _describe("mcp.server__github", ctx)
+    assert out["description"] == actual_desc
+
+
+# ── operation categories (regression guard) ─────────────────────────────
+
+
+def test_operation_describe_unchanged_by_resource_description_fix():
+    """Tier 2 (regression guard): operation-category actions (file__read,
+    web__fetch, etc.) continue to use ``target.description`` — the fix
+    must not change their resolution path.
+    """
+    ctx = _make_ctx()
+    out = _describe("file__read", ctx)
+    # The file__read tool description must be non-empty and is the
+    # operation's own description (not a resource-category fallback).
+    assert out["description"]
+    # And it shouldn't accidentally pull from the (empty) skills list.
+    assert "Catalogue-gap fallback" not in out["description"]


### PR DESCRIPTION
**[dogfood-coder]** — fix B42-NF-W7-1 (HIGH).

## Problem

B42 W7-S2 ("Tell me more about the simplest one") shows 9/10 empty stops at T2 on N=10 trace replay. Root cause:

`_handle_describe_action` at `src/reyn/tools/universal_catalog.py:867` returns `target.description`. For resource-category actions (`skill__X` / `agent.peer__X` / `mcp.tool__X.Y` / `mcp.server__X`), `target` is the generic dispatcher (`invoke_skill` / `delegate_to_agent` / `call_mcp_tool` / `list_mcp_tools`), so `target.description` is the dispatcher's "how to invoke" instructions — NOT the resource's actual description.

**Example (B42 trace)**:
- describe_action(`skill__direct_llm`) returned: *"Run a skill from the registered list. The 'name' parameter MUST be..."*
- direct_llm's actual frontmatter description: *"Catalogue-gap fallback: hand a single-shot natural-language task..."*
- LLM had nothing meaningful about direct_llm to relay → empty stop

## Fix

FP-0034 D2-full (#119) already surfaces per-resource `input_schema` via `_resource_input_schema()`. Mirror that pattern for `description`: add `_resource_description()` covering skill / agent.peer / mcp.tool / mcp.server, falling through to `target.description` otherwise.

## Verification (trace-patch-replay before land per `feedback_verify_fix_via_replay_before_land`)

`scripts/llm_replay.py --patch` on the actual W7-S2 T2 LLM trace, N=10 each:

| | Baseline (no patch) | Patched (actual description) |
|---|---|---|
| Empty stops (0 content + 0 tool_calls) | **9/10 (90%)** | **0/10 (0%)** |
| Substantive content | 1/10 (308 chars) | 8/10 (87-354 chars) |
| Follow-up tool_calls | 0/10 | 2/10 |

The patch substitutes `messages[5].content` to inject direct_llm's actual description, simulating post-fix dispatch shape. 0/10 result confirms the empty-stop attractor closes by per-resource description surfacing alone.

## Test plan

- [x] 10 new Tier 2 tests pass (`test_describe_action_resource_description.py`)
- [x] Existing tests pass: `test_describe_action_post_text.py`, `test_describe_action_resource_schemas.py`, `test_universal_catalog.py` (82/82)
- [x] Wider regression: `test_router_tools.py`, `test_universal_dispatch.py` (78/78)
- [x] trace-patch-replay verification: 9/10 → 0/10 empty rate
- [x] `_resource_description()` covers skill / agent.peer / mcp.tool / mcp.server (= same set as `_resource_input_schema()`); rag.corpus / memory.entry intentionally None (= no per-resource description surface today, dispatcher fallback preserved)

## Related

- FP-0034 D2-full (#119): companion fix for `input_schema` — same gap; `description` field was missed at D2-full.
- PR #221: `_post_text` directive on describe_action — works for direct concept queries but didn't close pronoun-followups because the underlying description was wrong.
- B42 retrospective NF-W7-B42-1: this PR closes that finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)