### PR TITLE
fix(tui): backlog signal when intervention / error mounts mid-scroll (L2-3)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -827,11 +827,18 @@ class ConversationView(Widget):
         skill_name: str = "",
     ) -> ErrorBox:
         self._consume_empty_hint()
-        # Hide any sticky "thinking…" — the turn is over (it failed).
-        # Otherwise the elapsed counter keeps incrementing forever next
-        # to a stale message, e.g. "⟳ thinking · 87.4s" while the
-        # ErrorBox below already shows "router failed".
-        self.hide_status()
+        # Replace the sticky "thinking…" — the turn is over (it failed).
+        # When the user is at the tail, a bare ``hide_status`` is enough
+        # (they'll see the ErrorBox the next render tick). When they're
+        # scrolled up reading history, the sticky vanishing was their
+        # only feedback that something happened — leave a "✗ error
+        # below ↓" cue so they know to scroll down. The next user
+        # submit clears it via ``on_input_bar_user_submitted``'s own
+        # ``show_status("thinking…")``.
+        if self._user_scrolled:
+            self.show_status("✗ error below ↓", kind="general")
+        else:
+            self.hide_status()
         box = ErrorBox(
             message=message,
             details=details,
@@ -880,8 +887,19 @@ class ConversationView(Widget):
     ) -> InterventionWidget:
         self._consume_empty_hint()
         # The run is now blocked on the user's answer; "thinking…" is no
-        # longer accurate, hide the live counter while we wait.
-        self.hide_status()
+        # longer accurate. When the user is at the tail they'll see the
+        # widget on the next render — bare ``hide_status`` suffices.
+        # When they're scrolled up, the sticky was their only signal
+        # something was happening, and ``hide_status`` would silently
+        # erase it. Replace with a "⚑ intervention below ↓" cue so the
+        # user knows the run is waiting for them. The natural
+        # ``intervention_resolved`` outbox handler (in app_outbox.py)
+        # calls ``hide_status`` on both answer paths, so the cue clears
+        # itself when the user responds.
+        if self._user_scrolled:
+            self.show_status("⚑ intervention below ↓", kind="general")
+        else:
+            self.hide_status()
         widget = InterventionWidget(
             question=question,
             choices=choices,
@@ -893,11 +911,9 @@ class ConversationView(Widget):
         self.mount(widget)
         # Only yank the user down to the new widget when they were
         # already at the tail. If they've scrolled up to read history,
-        # an async intervention arriving must not jerk the view — they
-        # can see the prompt waiting at the bottom via the scrollbar /
-        # auto_scroll once they return on their own, and ``hide_status``
-        # above already replaced the live "thinking…" so they have a
-        # clear signal that the run is waiting for them.
+        # the sticky just got replaced with "⚑ intervention below ↓"
+        # (above) so they have a clear signal the run is waiting; the
+        # widget itself becomes visible on their next scroll-down.
         if not self._user_scrolled:
             try:
                 widget.scroll_visible()

--- a/tests/cli/test_mid_scroll_intervention_signal.py
+++ b/tests/cli/test_mid_scroll_intervention_signal.py
@@ -1,0 +1,138 @@
+"""Tier 2: mount_intervention / mount_error preserve a backlog signal when mid-scroll.
+
+When the user has scrolled up to read history (``_user_scrolled=True``)
+and an intervention or error arrives, the previous wiring called
+``hide_status()`` unconditionally — the live "thinking…" sticky just
+vanished and the user had no on-screen signal that anything was
+waiting at the bottom.
+
+The fix swaps the bare ``hide_status()`` for a directional sticky
+("⚑ intervention below ↓" / "✗ error below ↓") only when mid-scroll.
+At the tail, ``hide_status()`` keeps firing because the widget itself
+will be visible on the next render tick.
+
+Contract pinned:
+
+1. mount_intervention at tail → ``hide_status`` fires (= no
+   backlog signal, widget itself is visible).
+2. mount_intervention mid-scroll → sticky shows "intervention below"
+   directional cue.
+3. mount_error at tail → ``hide_status`` fires.
+4. mount_error mid-scroll → sticky shows "error below" cue.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _sticky_text(conv: ConversationView) -> str:
+    """Return the current sticky body text via the public snapshot."""
+    sticky = conv._sticky()
+    if sticky is None:
+        return ""
+    return sticky.snapshot().get("body", "") or ""
+
+
+@pytest.mark.asyncio
+async def test_intervention_mount_at_tail_clears_sticky() -> None:
+    """Tier 2: mount_intervention when at-tail → sticky goes empty (no signal)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.show_status("thinking…", kind="thinking")
+        await pilot.pause()
+        assert "thinking" in _sticky_text(conv)
+
+        # at-tail = conv starts with no manual scroll, so the mid-scroll
+        # branch should not fire. We don't pre-assert on the private
+        # ``_user_scrolled`` flag (testing.ja.md "never assert on
+        # private state"); the contract is the sticky body text below.
+        conv.mount_intervention(
+            question="Continue?", choices=None, iv_id="iv-abc",
+        )
+        await pilot.pause()
+
+        # No directional cue — the widget itself is visible at the tail.
+        assert "below" not in _sticky_text(conv)
+
+
+@pytest.mark.asyncio
+async def test_intervention_mount_mid_scroll_shows_directional_cue() -> None:
+    """Tier 2: mount_intervention while mid-scroll → sticky shows "intervention below"."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv._user_scrolled = True  # simulate user-up scroll
+
+        conv.mount_intervention(
+            question="Continue?", choices=None, iv_id="iv-xyz",
+        )
+        await pilot.pause()
+
+        body = _sticky_text(conv)
+        assert "intervention" in body, (
+            f"mid-scroll intervention must surface a directional cue; got {body!r}"
+        )
+        # Down-arrow hints "below" is reachable by scrolling.
+        assert "↓" in body or "below" in body, body
+
+
+@pytest.mark.asyncio
+async def test_error_mount_at_tail_clears_sticky() -> None:
+    """Tier 2: mount_error when at-tail → no backlog signal."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.show_status("thinking…", kind="thinking")
+        await pilot.pause()
+
+        # at-tail: same rationale as the intervention-at-tail test above —
+        # no private-state precondition assert, contract is sticky body.
+        conv.mount_error(message="boom", details="")
+        await pilot.pause()
+
+        body = _sticky_text(conv)
+        assert "below" not in body, (
+            f"at-tail error mount must not leave a directional cue; got {body!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_error_mount_mid_scroll_shows_directional_cue() -> None:
+    """Tier 2: mount_error while mid-scroll → sticky shows "error below"."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv._user_scrolled = True
+
+        conv.mount_error(message="boom", details="")
+        await pilot.pause()
+
+        body = _sticky_text(conv)
+        assert "error" in body, (
+            f"mid-scroll error mount must surface a directional cue; got {body!r}"
+        )
+        assert "↓" in body or "below" in body, body


### PR DESCRIPTION
**[tui-coder]** —

Closes L2-3 (TUI Long-session resilience exploration finding).

## Summary

When the user had scrolled up to read history (\`_user_scrolled=True\`) and an intervention or error arrived, \`mount_intervention\` / \`mount_error\` both called \`hide_status()\` unconditionally — the live "thinking…" sticky vanished and the user had no on-screen signal that anything was waiting at the bottom.

Replace the bare \`hide_status()\` with a directional sticky when mid-scroll:

- intervention → "⚑ intervention below ↓"
- error → "✗ error below ↓"

At-tail mounts keep the original \`hide_status()\` — the widget itself is the visible signal on the next render tick. For interventions, the existing \`_on_intervention_resolved\` handler already calls \`hide_status\` on both answer paths, so the cue clears itself when the user responds. Error cue clears on the next user submit via \`on_input_bar_user_submitted\`'s own \`show_status("thinking…")\` overwrite.

## Why TUI-only

Two-line guard in \`mount_intervention\` / \`mount_error\`. No event / outbox / session changes.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_mid_scroll_intervention_signal.py\`, 4 cases:
  - intervention at-tail → sticky shows no directional cue
  - intervention mid-scroll → sticky body contains "intervention" and "↓" / "below"
  - error at-tail → no directional cue
  - error mid-scroll → sticky body contains "error" and "↓" / "below"
  Sticky read via the existing public \`snapshot()\` method (no private-state assert per testing.ja.md). The single mid-scroll setup (\`conv._user_scrolled = True\`) is the only way to simulate user-up scroll in headless mode — analogous to setup-only attribute writes already established in the test base.
- [x] **Existing tests** — \`pytest tests/cli/\` 223 passed (219 base + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)