### PR TITLE
fix(tui): remove 200-entry cap on _turn_anchors (L1-3+L2-5)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -454,9 +454,19 @@ class ConversationView(Widget):
             # order, which matches the user's mental model of "jump to
             # the previous turn" better than "jump only to agent replies".
             self._turn_anchors.append(self._absolute_line_position(log))
-            # Cap to last 200 to avoid unbounded growth (long sessions)
-            if len(self._turn_anchors) > 200:
-                self._turn_anchors = self._turn_anchors[-200:]
+            # No cap. The previous 200-entry cap silently dropped the
+            # oldest anchors in long sessions, so Ctrl+P/N's "N / M"
+            # readout showed an M smaller than the real turn count and
+            # the user thought they had walked the entire history when
+            # they had not. ``_resolve_anchors_to_current_view`` already
+            # filters anchors whose line position fell below
+            # ``log._start_line`` (= dropped by the RichLog ring
+            # buffer), so the effective navigation list stays bounded
+            # by ``_RICHLOG_MAX_LINES`` / typical-lines-per-turn even
+            # though the raw ``_turn_anchors`` list grows unbounded.
+            # The raw list cost is ~8 bytes per turn — a 24h session
+            # generating one turn per second is ~700 KB, negligible
+            # next to the RichLog itself.
             log.write(_msg_header(label_text, name_style, dash_style))
         self._last_speaker = speaker
         self._last_speaker_at = now

--- a/tests/cli/test_turn_anchors_no_cap.py
+++ b/tests/cli/test_turn_anchors_no_cap.py
@@ -1,0 +1,110 @@
+"""Tier 2: turn-anchor list is no longer capped at 200 entries.
+
+The previous wiring dropped anchors silently once
+``len(_turn_anchors) > 200``, so Ctrl+P / Ctrl+N's "N / M" readout
+showed an M smaller than the real turn count in long sessions and
+the user thought they had walked the entire history when they had
+not. ``_resolve_anchors_to_current_view`` already filters anchors
+whose line position fell below ``log._start_line`` (= dropped by
+the RichLog ring buffer), so the raw list growing past 200 doesn't
+break navigation.
+
+Pinned via the public ``_resolve_anchors_to_current_view`` surface
+(= the function ``jump_prev_turn`` / ``jump_next_turn`` consume),
+not the raw private ``_turn_anchors`` list. Drives the writer at
+the production write-site (``_maybe_write_header``) by issuing the
+``user`` / ``agent`` toggle that triggers anchor recording.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _push_alternating_speakers(conv: ConversationView, n: int) -> None:
+    """Drive ``_maybe_write_header`` n times via alternating user/agent renders.
+
+    ``render_user_message`` and ``_render_agent_markdown`` (via the
+    ``agent`` kind) each call ``_maybe_write_header`` which only writes
+    a new header when the speaker changes or the 60-second gap fires.
+    Alternating the two paths forces a speaker change on every
+    iteration → new anchor every time.
+    """
+    for i in range(n):
+        if i % 2 == 0:
+            conv.render_user_message(f"user-{i}")
+        else:
+            conv.render_message(OutboxMessage(kind="agent", text=f"agent-{i}"))
+
+
+@pytest.mark.asyncio
+async def test_turn_anchor_list_grows_past_200_entries() -> None:
+    """Tier 2: pushing 250 alternating turns yields >= 250 anchors.
+
+    The previous 200-cap would have trimmed the list to exactly 200;
+    this asserts the cap is gone via the resolved-anchors helper
+    (= the public surface the navigation code reads).
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        _push_alternating_speakers(conv, 250)
+        await pilot.pause()
+
+        log = conv._log()
+        resolved = conv._resolve_anchors_to_current_view(log)
+        # ``resolved`` excludes any anchors that fell out of the
+        # RichLog ring buffer's current view. At 250 short messages
+        # we're well under the 20,000-line buffer, so every anchor
+        # should remain resolvable.
+        assert len(resolved) >= 250, (
+            f"resolved anchors should reflect all 250 turns; got "
+            f"{len(resolved)}. Previous 200-cap would have produced "
+            f"exactly 200."
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolved_anchor_count_matches_pushed_turn_count() -> None:
+    """Tier 2: every pushed turn produces exactly one resolvable anchor.
+
+    Pins the 1:1 invariant in the comfortable zone (= well below the
+    RichLog ring-buffer limit). A future refactor that dropped anchors
+    on a different non-cap path (e.g. dedup by line position) would
+    regress here.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        _push_alternating_speakers(conv, 50)
+        await pilot.pause()
+
+        log = conv._log()
+        resolved = conv._resolve_anchors_to_current_view(log)
+        assert len(resolved) == 50, (
+            f"50 turns should produce exactly 50 resolved anchors; "
+            f"got {len(resolved)}"
+        )


### PR DESCRIPTION
**[tui-coder]** —

Closes L1-3 + L2-5 (two TUI Long-session resilience exploration findings from independent sub-agents identifying the same root).

## Summary

\`_maybe_write_header\` capped \`_turn_anchors\` at 200 entries, silently dropping the oldest on long sessions. Ctrl+P / Ctrl+N's "↑ turn N / M" readout then showed an M smaller than the real turn count — the user thought they had walked the entire history when they had only walked the last 200 turns. The cap had no signal attached (= unlike \`_maybe_warn_about_trimmed_history\` for the ring-buffer trim).

Remove the cap entirely. \`_resolve_anchors_to_current_view\` already filters anchors whose line position fell below \`log._start_line\` (= dropped by the RichLog ring buffer), so the effective navigation list stays bounded by \`_RICHLOG_MAX_LINES\` / typical-lines-per-turn even though the raw \`_turn_anchors\` list grows unbounded. Raw cost ~8 bytes per turn — a 24h session at 1 turn/sec is ~700 KB, negligible next to the RichLog itself.

## Why TUI-only

Single-block deletion + comment in \`_maybe_write_header\`. No event / outbox / session changes.

## Test plan

- [x] **Tier 2 contract tests** — \`tests/cli/test_turn_anchors_no_cap.py\`, 2 cases:
  - 250 alternating user / agent turns yield ≥250 resolved anchors (= previous cap would have produced exactly 200; the public \`_resolve_anchors_to_current_view\` surface is exercised, not the raw \`_turn_anchors\` list)
  - 50-turn 1:1 invariant pin, defends against a refactor that drops anchors on a different non-cap path
- [x] **Existing tests** — \`pytest tests/cli/\` 221 passed (219 base + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)