### PR TITLE
feat(intervention): subscriber-presence guard on InterventionRegistry (Phase 1 of #254)

### DIFF
--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -37,11 +37,67 @@ class InterventionRegistry:
         self,
         *,
         on_announce: Callable[[UserIntervention], Awaitable[None]],
+        enforce_listener_presence: bool = False,
     ) -> None:
+        """Construct an InterventionRegistry.
+
+        Parameters
+        ----------
+        on_announce:
+            Async callback invoked when an intervention is ready to be shown
+            to the user. The session supplies its ``_announce_intervention``
+            method here; tests supply a mock.
+        enforce_listener_presence:
+            When True, ``dispatch()`` short-circuits with an empty
+            ``InterventionAnswer`` if no listener is registered (= "no one
+            will call ``deliver_answer``, prompt would hang forever"). Caller
+            interprets the empty answer as a refusal — matching the existing
+            cancellation contract — and falls through to its legacy abort
+            path. Default False preserves the pre-issue-#254 behaviour for
+            direct registry users (= tests at this layer that construct a
+            registry without a real listener and feed answers manually via
+            ``deliver_answer``).
+
+            ChatSession (and any future top-level entry that owns its own
+            listener wiring) opts in via this flag so a missing listener
+            (= headless deploy, test without TUI mount, A2A peer offline)
+            fails closed instead of waiting on an unresolvable future.
+            issue #254 Phase 1.
+        """
         self._on_announce = on_announce
         self._active: dict[str, UserIntervention] = {}
         # Preserves FIFO emission order; gives head-of-queue semantics.
         self._order: deque[str] = deque()
+        # issue #254 Phase 1: listener-presence guard against forever-await.
+        self._enforce_listener_presence = enforce_listener_presence
+        self._listeners: set[str] = set()
+
+    # ── Listener registration (issue #254 Phase 1) ───────────────────────────
+
+    def register_listener(self, listener_id: str) -> None:
+        """Mark *listener_id* as actively able to resolve interventions.
+
+        A listener is any entity that has committed to eventually calling
+        ``deliver_answer`` for queued interventions — in practice the
+        attached TUI app, an A2A peer override, or a test fixture that
+        will drive ``_maybe_answer_oldest_intervention`` manually. The
+        registry uses the set's emptiness to decide whether ``dispatch``
+        should short-circuit (when ``enforce_listener_presence=True``).
+        Calling twice with the same id is idempotent.
+        """
+        self._listeners.add(listener_id)
+
+    def unregister_listener(self, listener_id: str) -> None:
+        """Remove *listener_id* from the active set. Idempotent."""
+        self._listeners.discard(listener_id)
+
+    def has_active_listener(self) -> bool:
+        """Return True iff at least one listener is currently registered."""
+        return bool(self._listeners)
+
+    def listener_count(self) -> int:
+        """Return the number of currently-registered listeners."""
+        return len(self._listeners)
 
     # ── Bus interface (called by ChatInterventionBus from skills) ────────────
 
@@ -53,7 +109,19 @@ class InterventionRegistry:
         dangling queue entries.  On ``asyncio.CancelledError`` the future is
         cancelled and an empty ``InterventionAnswer`` is returned to the
         caller (same contract as the original ``_dispatch_intervention``).
+
+        issue #254 Phase 1: when ``enforce_listener_presence=True`` was set
+        at construction AND no listener is registered, return an empty
+        ``InterventionAnswer`` immediately instead of enqueuing + awaiting
+        an unresolvable future. The caller (= ``handle_limit_exceeded`` /
+        permission gate) sees this as a refusal and falls through to abort,
+        matching the existing cancellation contract.
         """
+        if self._enforce_listener_presence and not self._listeners:
+            # No listener will call deliver_answer → prompt would hang
+            # forever. Match the cancellation contract: return empty answer
+            # so the caller treats it as a refusal.
+            return InterventionAnswer(text="")
         self._active[iv.id] = iv
         self._order.append(iv.id)
         try:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -790,6 +790,12 @@ class ChatSession:
         )
         self._interventions = InterventionRegistry(
             on_announce=self._announce_intervention,
+            # issue #254 Phase 1: fail-closed when no listener is wired
+            # (= no TUI mounted, no A2A override, no test fixture
+            # registered). Without this, ``handle_limit_exceeded`` with
+            # ``ask_timeout_seconds=0`` would await an unresolvable future
+            # in test / headless contexts.
+            enforce_listener_presence=True,
         )
 
         # FP-0019 Wave 2 part 1: InterventionHandler — ask_user dispatch service.
@@ -1800,6 +1806,27 @@ class ChatSession:
     def unregister_intervention_override(self, chain_id: str) -> None:
         """Remove an override. Idempotent."""
         self._intervention_overrides.pop(chain_id, None)
+
+    # ── Listener registration (issue #254 Phase 1) ──────────────────────────
+
+    def register_intervention_listener(self, listener_id: str) -> None:
+        """Declare that *listener_id* will route user answers back into
+        the session (= call ``_maybe_answer_oldest_intervention`` /
+        ``_deliver_answer_to`` when the user responds).
+
+        Without an active listener, ``_dispatch_intervention`` would
+        enqueue a prompt that nothing will resolve — under
+        ``ask_timeout_seconds=0`` that turns into an infinite await.
+        Callers in real entry points register on mount (TUI app on
+        compose, A2A async-task wiring, etc.); tests register a
+        placeholder when they intend to drive the answer themselves via
+        ``_maybe_answer_oldest_intervention``. issue #254 Phase 1.
+        """
+        self._interventions.register_listener(listener_id)
+
+    def unregister_intervention_listener(self, listener_id: str) -> None:
+        """Remove *listener_id* from the active set. Idempotent."""
+        self._interventions.unregister_listener(listener_id)
 
     async def _dispatch_intervention(self, iv: UserIntervention) -> InterventionAnswer:
         """Thin wrapper → InterventionHandler.dispatch.

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -193,6 +193,17 @@ class ReynTUIApp(App):
 
         inputbar.focus_input()
 
+        # issue #254 Phase 1: declare ourselves as the intervention listener
+        # for the attached session. Without this, ``ChatSession`` constructed
+        # with ``enforce_listener_presence=True`` would short-circuit
+        # ``_dispatch_intervention`` and prompts would never reach the TUI.
+        # ``_get_session()`` may return None during early lifecycle (no
+        # session yet attached); the answer-input path will re-register
+        # on session attach if that becomes a real case.
+        session = self._get_session()
+        if session is not None:
+            session.register_intervention_listener("tui")
+
         # Optional ASCII banner (neofetch style): gradient logo left, agent
         # info right. Off by default — daily use should focus the input bar
         # instantly. Opt-in via `reyn chat --banner` (see cli/commands/chat.py).

--- a/tests/test_durable_answer_buffer.py
+++ b/tests/test_durable_answer_buffer.py
@@ -189,11 +189,16 @@ def test_journal_consume_is_idempotent(tmp_path: Path):
 
 
 def _make_session(tmp_path: Path, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+    """issue #254 Phase 1: register a placeholder listener so the registry's
+    ``enforce_listener_presence=True`` short-circuit does not fire.
+    """
+    session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
+    session.register_intervention_listener("test")
+    return session
 
 
 def test_session_restore_rehydrates_buffered_answers(tmp_path: Path, monkeypatch):

--- a/tests/test_fp0001_session_override.py
+++ b/tests/test_fp0001_session_override.py
@@ -82,12 +82,20 @@ class _RecordingHandler:
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> ChatSession:
-    """Build a ChatSession with I/O redirected to tmp_path."""
-    return ChatSession(
+    """Build a ChatSession with I/O redirected to tmp_path.
+
+    issue #254 Phase 1: register a placeholder listener so the registry's
+    ``enforce_listener_presence=True`` short-circuit does not fire — these
+    tests exercise the chain-scoped override path and may dispatch to the
+    fallback registry path when no override is set.
+    """
+    session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}_state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
+    session.register_intervention_listener("test")
+    return session
 
 
 def _make_iv(*, run_id: str | None = None, prompt: str = "Q?") -> UserIntervention:
@@ -104,7 +112,7 @@ def _build_registry(tmp_path: Path, agent_specs: list[tuple[str, str]]) -> Agent
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        session = ChatSession(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -112,6 +120,8 @@ def _build_registry(tmp_path: Path, agent_specs: list[tuple[str, str]]) -> Agent
             state_log=state_log,
             snapshot_path=agent_dir / "state" / "snapshot.json",
         )
+        session.register_intervention_listener("test")
+        return session
 
     registry = AgentRegistry(
         project_root=tmp_path,

--- a/tests/test_intervention_restore.py
+++ b/tests/test_intervention_restore.py
@@ -32,12 +32,19 @@ from reyn.events.state_log import StateLog
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via public kwargs."""
-    return ChatSession(
+    """Build a ChatSession redirected to ``tmp_path`` via public kwargs.
+
+    issue #254 Phase 1: register a placeholder listener so the registry's
+    ``enforce_listener_presence=True`` short-circuit does not fire — these
+    tests exercise restore + answer paths, acting as their own listener.
+    """
+    session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
+    session.register_intervention_listener("test")
+    return session
 
 
 def _snapshot_with_intervention(
@@ -96,6 +103,7 @@ async def test_registry_restore_all_includes_outstanding_interventions(tmp_path,
     # consistent with how the chat REPL builds them in production.
     def _factory(profile: AgentProfile):
         s = ChatSession(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
         return s
     registry = AgentRegistry(
         project_root=tmp_path,

--- a/tests/test_intervention_resume_e2e.py
+++ b/tests/test_intervention_resume_e2e.py
@@ -48,12 +48,20 @@ from reyn.user_intervention import (
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via public kwargs."""
-    return ChatSession(
+    """Build a ChatSession redirected to ``tmp_path`` via public kwargs.
+
+    issue #254 Phase 1: register a placeholder listener so the registry's
+    ``enforce_listener_presence=True`` short-circuit does not fire — these
+    tests drive ``_maybe_answer_oldest_intervention`` manually and are
+    effectively their own listener.
+    """
+    session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
+    session.register_intervention_listener("test")
+    return session
 
 
 def _snapshot_with_intervention(

--- a/tests/test_intervention_subscriber_guard.py
+++ b/tests/test_intervention_subscriber_guard.py
@@ -1,0 +1,285 @@
+"""Tier 2: InterventionRegistry subscriber-presence guard (issue #254 Phase 1).
+
+When ``enforce_listener_presence=True`` is set at construction AND no
+listener is registered, ``dispatch()`` returns an empty
+``InterventionAnswer`` immediately instead of awaiting an unresolvable
+future. This is the structural fix that unblocks ``safety.on_limit.mode``
+default = ``interactive`` + ``ask_timeout_seconds=0`` (= "wait forever
+for a human reply") on test / headless paths where no UI listener is
+attached.
+
+Pins:
+  1. Default (``enforce_listener_presence=False``) preserves legacy
+     forever-await behaviour (= what existing low-level registry tests
+     rely on).
+  2. Enforced mode with zero listeners short-circuits to empty answer.
+  3. Enforced mode with one+ listeners awaits as normal.
+  4. Register / unregister round-trip restores short-circuit behaviour.
+  5. ChatSession constructs the registry in enforced mode and exposes
+     ``register_intervention_listener`` / ``unregister_intervention_listener``
+     wrappers.
+  6. End-to-end: a ChatSession that hits a safety limit under
+     ``interactive`` + ``ask_timeout_seconds=0`` with no listener returns
+     immediately (no hang) and lets the caller fall through to its
+     legacy abort path.
+
+No mocks. Real registry, real ChatSession.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.budget.budget import BudgetTracker, CostConfig
+from reyn.chat.services.intervention_registry import InterventionRegistry
+from reyn.chat.session import ChatSession
+from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+# ── 1. Default (legacy) — no enforcement ────────────────────────────────
+
+
+def test_default_constructor_does_not_enforce_listener_presence() -> None:
+    """Tier 2: default ``enforce_listener_presence=False`` preserves
+    the pre-issue-#254 contract — dispatch awaits the future regardless
+    of listener registration.
+
+    Direct-registry tests (= ``test_intervention_handler_invariants.py``
+    et al) construct registries with no listener and rely on this
+    forever-await semantics; opt-in flag preserves them.
+    """
+    announce_calls: list[str] = []
+
+    async def _announce(iv: UserIntervention) -> None:
+        announce_calls.append(iv.id)
+
+    reg = InterventionRegistry(on_announce=_announce)
+    assert reg.listener_count() == 0
+    assert reg.has_active_listener() is False
+
+    # In default mode, dispatch will enqueue + announce + await. Without
+    # an external resolver, the await would block forever — so we only
+    # verify that the dispatch DID enqueue rather than short-circuiting.
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    iv.future = asyncio.get_event_loop().create_future() \
+        if hasattr(asyncio, "get_event_loop") else None
+
+    async def _drive() -> None:
+        loop = asyncio.get_running_loop()
+        iv.future = loop.create_future()
+        task = asyncio.ensure_future(reg.dispatch(iv))
+        # Let the dispatch coroutine reach its await.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # Verify it enqueued (= did NOT short-circuit).
+        assert reg.queued_count() == 1, (
+            "default mode must enqueue + await, not short-circuit"
+        )
+        # Resolve the future manually so the task can clean up.
+        iv.future.set_result(InterventionAnswer(text="ok"))
+        answer = await task
+        assert answer.text == "ok"
+        assert announce_calls == [iv.id], "announce must fire in default mode"
+
+    asyncio.run(_drive())
+
+
+# ── 2. Enforced mode with zero listeners short-circuits ────────────────
+
+
+def test_enforced_mode_with_no_listener_short_circuits_with_empty_answer() -> None:
+    """Tier 2: when enforcement is on AND no listener is registered,
+    dispatch returns ``InterventionAnswer(text="")`` immediately —
+    matching the cancellation contract so callers fall through to
+    refusal / abort.
+    """
+    async def _announce(iv: UserIntervention) -> None:
+        pytest.fail("announce must NOT fire when no listener short-circuits")
+
+    reg = InterventionRegistry(
+        on_announce=_announce, enforce_listener_presence=True,
+    )
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+
+    async def _drive() -> InterventionAnswer:
+        return await reg.dispatch(iv)
+
+    answer = asyncio.run(_drive())
+    assert isinstance(answer, InterventionAnswer)
+    assert answer.text == ""
+    assert answer.choice_id is None
+    # Queue must be left empty — short-circuit happens BEFORE enqueue.
+    assert reg.queued_count() == 0
+
+
+# ── 3. Enforced mode with a listener awaits as normal ──────────────────
+
+
+def test_enforced_mode_with_registered_listener_dispatches_normally() -> None:
+    """Tier 2: with at least one listener registered, dispatch behaves
+    identically to the default (= enqueue + announce + await for
+    deliver_answer to resolve).
+    """
+    announce_calls: list[str] = []
+
+    async def _announce(iv: UserIntervention) -> None:
+        announce_calls.append(iv.id)
+
+    reg = InterventionRegistry(
+        on_announce=_announce, enforce_listener_presence=True,
+    )
+    reg.register_listener("tui")
+    assert reg.has_active_listener() is True
+    assert reg.listener_count() == 1
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+
+    async def _drive() -> None:
+        loop = asyncio.get_running_loop()
+        iv.future = loop.create_future()
+        task = asyncio.ensure_future(reg.dispatch(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert reg.queued_count() == 1
+        assert announce_calls == [iv.id]
+        # Resolve so the task can finish.
+        ok = await reg.deliver_answer(iv, "hi")
+        assert ok is True
+        result = await task
+        assert result.text == "hi"
+
+    asyncio.run(_drive())
+
+
+# ── 4. Register / unregister round-trip ────────────────────────────────
+
+
+def test_register_unregister_listener_round_trip() -> None:
+    """Tier 2: register adds, unregister removes, both are idempotent
+    and ``has_active_listener`` tracks the set's emptiness.
+    """
+    async def _announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(
+        on_announce=_announce, enforce_listener_presence=True,
+    )
+
+    # Initial: empty.
+    assert reg.has_active_listener() is False
+
+    # Register two distinct listeners.
+    reg.register_listener("tui")
+    reg.register_listener("slash")
+    assert reg.listener_count() == 2
+    assert reg.has_active_listener() is True
+
+    # Re-register same id: idempotent.
+    reg.register_listener("tui")
+    assert reg.listener_count() == 2
+
+    # Unregister one.
+    reg.unregister_listener("tui")
+    assert reg.listener_count() == 1
+    assert reg.has_active_listener() is True
+
+    # Unregister unknown: idempotent (no raise).
+    reg.unregister_listener("nonexistent")
+    assert reg.listener_count() == 1
+
+    # Unregister the last one: short-circuit re-enabled.
+    reg.unregister_listener("slash")
+    assert reg.has_active_listener() is False
+
+
+def test_unregistering_after_register_re_enables_short_circuit() -> None:
+    """Tier 2: dispatch short-circuits again once the last listener
+    unregisters (= "TUI unmounted, no one is listening anymore").
+    """
+    async def _announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(
+        on_announce=_announce, enforce_listener_presence=True,
+    )
+    reg.register_listener("tui")
+    reg.unregister_listener("tui")
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    answer = asyncio.run(reg.dispatch(iv))
+    assert answer.text == ""
+
+
+# ── 5. ChatSession exposes the wrappers and opts into enforcement ──────
+
+
+def test_chat_session_constructs_registry_in_enforced_mode(tmp_path: Path) -> None:
+    """Tier 2: a fresh ChatSession has the registry in enforcement mode
+    AND starts with zero listeners (= test / headless contexts get the
+    short-circuit by default).
+    """
+    session = ChatSession(agent_name="test_agent")
+    # Internal attribute access is acceptable here because we are pinning
+    # the wiring invariant the entry-point relies on. The public surface
+    # ``register_intervention_listener`` is what callers use.
+    assert session._interventions._enforce_listener_presence is True
+    assert session._interventions.has_active_listener() is False
+
+
+def test_chat_session_register_intervention_listener_round_trip() -> None:
+    """Tier 2: ChatSession's public register / unregister thin wrappers
+    update the registry's listener set.
+    """
+    session = ChatSession(agent_name="test_agent")
+
+    session.register_intervention_listener("tui")
+    assert session._interventions.has_active_listener() is True
+
+    session.unregister_intervention_listener("tui")
+    assert session._interventions.has_active_listener() is False
+
+
+# ── 6. End-to-end: limit hit under interactive + timeout=0 + no listener ──
+
+
+def test_safety_limit_under_interactive_no_timeout_no_listener_no_hang(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the exact scenario that motivated issue #254 — a chat
+    session hits a safety limit while running ``mode=interactive`` +
+    ``ask_timeout_seconds=0``, with no UI listener attached. Pre-Phase 1
+    this hung indefinitely awaiting the future. Phase 1: dispatch
+    short-circuits, ``handle_limit_exceeded`` sees an empty answer,
+    treats it as refusal, the caller raises ``RouterCapExceeded``, and
+    ``_handle_user_message`` emits its fallback message and returns.
+
+    The test asserts the run completes within a small wall-clock budget
+    — a 5s ceiling is generous; pre-fix the same path waited the entire
+    pytest-timeout window.
+    """
+    safety = SafetyConfig(
+        loop=LoopConfig(max_router_calls_per_turn=3),
+        on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
+    )
+    session = ChatSession(
+        agent_name="test_agent",
+        output_language="ja",
+        budget_tracker=BudgetTracker(CostConfig()),
+        safety=safety,
+    )
+    # DELIBERATELY do not register a listener — that is the test condition.
+
+    # Pre-spend the router budget so the next call hits the cap.
+    session._router_invocations_this_turn = 3
+    session._router_last_reason = "out_of_scope"
+
+    async def _drive() -> None:
+        # Must complete promptly — pre-Phase 1 this awaited forever.
+        await asyncio.wait_for(
+            session._handle_user_message("こんにちは", chain_id="chain-no-listener"),
+            timeout=5.0,
+        )
+
+    asyncio.run(_drive())

--- a/tests/test_session_intervention_persistence.py
+++ b/tests/test_session_intervention_persistence.py
@@ -35,12 +35,20 @@ from reyn.user_intervention import (
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via public kwargs."""
-    return ChatSession(
+    """Build a ChatSession redirected to ``tmp_path`` via public kwargs.
+
+    issue #254 Phase 1: register a placeholder listener so the registry's
+    ``enforce_listener_presence=True`` short-circuit does not fire — these
+    tests dispatch interventions and verify WAL persistence, treating the
+    test itself as the listener that will resolve via ``deliver_answer``.
+    """
+    session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
+    session.register_intervention_listener("test")
+    return session
 
 
 def _iv(*, run_id: str | None = None, choices: list[InterventionChoice] | None = None,

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -131,15 +131,23 @@ def _make_session(
     chain_timeout_seconds: float = 60.0,
     registry: _FakeRegistry | None = None,
 ) -> ChatSession:
-    """Build a ChatSession with WAL + per-test snapshot path via public kwargs."""
+    """Build a ChatSession with WAL + per-test snapshot path via public kwargs.
+
+    issue #254 Phase 1: register a placeholder listener so the registry's
+    ``enforce_listener_presence=True`` short-circuit does not fire — these
+    tests exercise the chat-side intervention flow and resolve answers
+    via ``deliver_answer`` themselves.
+    """
     safety = SafetyConfig(timeout=TimeoutConfig(chain_seconds=chain_timeout_seconds))
-    return ChatSession(
+    session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         safety=safety,
         registry=registry,
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
+    session.register_intervention_listener("test")
+    return session
 
 
 def _wal_events(tmp_path: Path) -> list[dict]:


### PR DESCRIPTION
**[e2e-coder]** — Phase 1 of #254.

Refs #254 (architectural refactor: Agent-mediated intervention routing).

## Problem

`safety.on_limit.mode` default を `interactive` + `ask_timeout=0` に反転しようとした際、 ChatSession 系の test が永続 hang する root cause を発見:

- `ChatSession._handle_chat_limit_checkpoint` が常に `_ChatLimitBus` wrapper を `handle_limit_exceeded` の `bus` 引数に渡す
- `bus is None` の短絡は発火しない (= bus は存在する)
- 中身は最終的に `InterventionRegistry.dispatch(iv)` で `iv.future` を await
- prod TUI なら subscriber が `deliver_answer` を呼んで future を resolve するので OK
- test / headless では誰も `deliver_answer` を呼ばない → forever await

この hang は `safety.on_limit.mode=interactive` の default 解禁を妨げており、 issue #254 で議論した architectural refactor の motivating problem。

## What this changes (Phase 1 scope)

**Opt-in fail-fast guard を `InterventionRegistry` に追加**。 Public API は変えず、 既存 caller / bus impl は unchanged。 ChatSession だけが新 flag を opt-in、 TUI が listener として self-register する。

### Production code (3 ファイル)

- `src/reyn/chat/services/intervention_registry.py` (+68 行):
  - 新 optional constructor flag `enforce_listener_presence` (default `False`)
  - 新 API: `register_listener(id)` / `unregister_listener(id)` / `has_active_listener()` / `listener_count()`、 すべて idempotent
  - `dispatch()`: enforcement on AND empty listener set なら **`InterventionAnswer(text="")` を即 return** (= cancellation contract と shape 一致、 caller は `user_refused` 経路に合流)
- `src/reyn/chat/session.py` (+27 行):
  - registry を `enforce_listener_presence=True` で構築
  - 新 thin wrapper `register_intervention_listener` / `unregister_intervention_listener`
- `src/reyn/chat/tui/app.py` (+11 行):
  - `on_mount` で `session.register_intervention_listener("tui")` 呼出 (= prod TUI 経路が listener 不在に短絡されないよう保証)

### Test fixtures (6 ファイル)

既存 `_make_session` helper 6 件に `session.register_intervention_listener("test")` 追加。 これらの test は `_maybe_answer_oldest_intervention` を test 内で manual に呼んで answer を resolve する shape、 つまり test 自身が listener として振る舞う前提だったので、 明示的に listener 化することで Phase 1 guard を通過する。

### New Tier 2 tests (`tests/test_intervention_subscriber_guard.py`, +259 行 / 8 tests)

| # | Test | Pins |
|---|---|---|
| 1 | `test_default_constructor_does_not_enforce_listener_presence` | 既存の direct-registry test が壊れないこと (`enforce_listener_presence=False` default で legacy await 維持) |
| 2 | `test_enforced_mode_with_no_listener_short_circuits_with_empty_answer` | core 不変条件 |
| 3 | `test_enforced_mode_with_registered_listener_dispatches_normally` | listener 居れば従来通り |
| 4 | `test_register_unregister_listener_round_trip` | API idempotent + 数え方 |
| 5 | `test_unregistering_after_register_re_enables_short_circuit` | listener が unmount したら再び短絡 |
| 6 | `test_chat_session_constructs_registry_in_enforced_mode` | ChatSession の wiring |
| 7 | `test_chat_session_register_intervention_listener_round_trip` | session 公開 API |
| 8 | `test_safety_limit_under_interactive_no_timeout_no_listener_no_hang` | **end-to-end no-hang**: `interactive` + `ask_timeout=0` + listener 不在で 5s 内に完了 (= 本 PR の motivating scenario) |

## Why short-circuit instead of timeout

短絡 shape は **既存の cancellation contract と同型**:
```python
# 既存 (asyncio.wait_for cancel 時の registry.dispatch except clause)
except asyncio.CancelledError:
    return InterventionAnswer(text="")
```
caller (`handle_limit_exceeded`) は `getattr(answer, "choice_id", None)` が None なら user_refused 扱い → caller の abort path にそのまま flow。 timeout を増設する必要なし。

## Backwards compatibility

- 既存 caller / bus impl: **unchanged** (`InterventionBus` interface 不変)
- 既存 outbox shape: **unchanged** (= tui-coder confirmation 済)
- 既存 `session._interventions` attribute path: **unchanged**
- 直接 registry を構築する test (= `test_intervention_handler_invariants.py` 等): **unchanged** (= default False で legacy behavior)
- 公開 API には新 method 4 件追加のみ、 削除 / rename ゼロ

## What this does NOT change

- `InterventionBus` interface (= Phase 2 で `RequestBus` / `UserChannel` に split 予定、 本 PR では touch せず)
- caller 側の `bus: InterventionBus` 引数 (= Phase 3 で `ask_user()` 経由化、 本 PR では touch せず)
- Agent layer の introduction (= Phase 3 以降)
- `safety.on_limit.mode` default の反転 (= 本 PR merge 後に別 PR で着地、 これが Phase 1 完了の immediate value)

## Test plan

- [x] **Automated — `pytest tests/test_intervention_subscriber_guard.py`**: 8/8 pass。
- [x] **Adjacent — affected session intervention test 群**: `pytest tests/test_intervention_resume_e2e.py tests/test_session_intervention_persistence.py tests/test_intervention_restore.py tests/test_durable_answer_buffer.py tests/test_fp0001_session_override.py tests/test_session_invariants.py tests/test_fp0001_e2e_ask_user_roundtrip.py tests/test_chat_router_i18n.py` → 68 pass + 1 skipped。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --ignore=tests/test_a2a_sync_async_escalation.py`**: 3941 passed, 11 skipped, 3 xfailed in 138s。 (`test_a2a_sync_async_escalation.py` is skipped due to local venv missing `fastapi` — PR #253 由来の preexisting env gap、 本 PR 起因ではない)
- [x] **Lint — `ruff check`**: clean on all 10 changed files。
- [x] **End-to-end no-hang scenario**: test #8 で `interactive` + `ask_timeout=0` + listener 不在の chat session が 5s 以内に完了することを pin (pre-Phase 1 は forever await)。
- [ ] **Manual — TUI で interactive prompt が今まで通り user に届くこと**: prod TUI 起動 + 安全上限を意図的に hit させて intervention widget が表示され yes/no で extend できることを user で確認。 (= e2e-coder の env では TUI を fire しないので user の手動 verify、 PR #246 と同じ split)

## Related

- issue #254 — Architectural refactor for Agent-mediated intervention routing (= 本 PR は Phase 1 / 5)
- FP-0005 — `handle_limit_exceeded` (= 短絡の合流先 `user_refused` reason)
- FP-0001 / FP-0003 — InterventionBus / `_ask_budget_extension` (= 歴史的経緯)

## Phase 2 への bridge

Phase 1 で生まれた API (`enforce_listener_presence` flag、 `register_listener` 系) は Phase 2 の `RequestBus` interface 設計で **そのまま contract として再利用** される予定 (= [A] OS↔Agent の subscriber 検出を Phase 1 の listener API で実装、 Phase 2 ではそれを `RequestBus.subscribers` として明示的にする shape)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)