### PR TITLE
feat(safety): default safety.on_limit.mode to interactive with no timeout

### DIFF
--- a/docs/guide/for-skill-authors/understand-why-reyn-stops.ja.md
+++ b/docs/guide/for-skill-authors/understand-why-reyn-stops.ja.md
@@ -130,10 +130,15 @@ safety:
 
 ## limit 到達時の挙動 (`safety.on_limit`)
 
-既定の挙動: limit 到達は実行を abort します。Reyn は `RunResult` を返し、
-`status` を `loop_limit_exceeded` / `phase_budget_exceeded` /
-`budget_exceeded` のいずれかに設定し、`partial_data` には最後に完了した
-フェーズの artifact (= *「今ここまでの成果物」*) を入れます。
+既定の挙動: limit 到達時、 `ask_user` で user に延長を確認します
+(= `mode: interactive` / `ask_timeout_seconds: 0` — 無制限待機)。
+拒否 / timeout / intervention surface 不在の場合は abort、 Reyn は
+`RunResult` を返し、 `status` を `loop_limit_exceeded` /
+`phase_budget_exceeded` / `budget_exceeded` のいずれかに設定し、
+`partial_data` には最後に完了したフェーズの artifact (= *「今ここまでの
+成果物」*) を入れます。ヘッドレス path (= `bus=None` / 非 TTY stdin) は
+intervention 不要に自動的に abort 経路へ短絡するので、 `interactive`
+既定はどの環境でも安全です。
 
 挙動は `safety.on_limit.mode` で変更できます:
 
@@ -141,17 +146,17 @@ safety:
 # reyn.local.yaml
 safety:
   on_limit:
-    mode: unattended       # 既定 — 到達時に abort (旧来の挙動)
-    # mode: interactive    # ask_user で user に確認、 承認時に limit 延長して継続
+    mode: interactive      # 既定 — ask_user で user に確認、 承認時に limit 延長して継続
+    # mode: unattended     # 到達時に abort (= CI / cron / スクリプト実行向けのオプトイン)
     # mode: auto_extend    # N 回まで自動延長、 それ以降は abort
     auto_extend_times: 1   # auto_extend 時のみ参照
-    ask_timeout_seconds: 60  # interactive 時のみ参照
+    ask_timeout_seconds: 0  # interactive 時のみ参照; 0 = 無制限待機
 ```
 
 | モード | 用途 |
 |---|---|
-| `unattended` (既定) | `reyn run` / CI / スクリプト実行 — 確認できる人がいない、 fail fast 推奨 |
-| `interactive` | `reyn chat` / TUI session — ユーザーが目の前にいて判断できる |
+| `interactive` (既定) | `reyn chat` / TUI / a2a session — user が到達可能で延長判断を返せる |
+| `unattended` | CI / cron / スクリプト実行で human を待てない用途のオプトイン、 fail fast |
 | `auto_extend` | 信頼済みの長時間タスクで「N 回までは自動延長して良い」と分かっているとき |
 
 **各 limit がどの site で wiring されているか (FP-0005 Phase 2 — landing 完了):**

--- a/docs/guide/for-skill-authors/understand-why-reyn-stops.md
+++ b/docs/guide/for-skill-authors/understand-why-reyn-stops.md
@@ -132,10 +132,14 @@ approval extends the cap further.
 
 ## What happens on a limit hit (`safety.on_limit`)
 
-By default, a limit hit aborts the run. Reyn returns a `RunResult` with
-`status` set to one of `loop_limit_exceeded` / `phase_budget_exceeded` /
-`budget_exceeded`, and `partial_data` populated with the last completed
-phase artifact — *"here's what we have so far"*.
+By default, a limit hit prompts the user via `ask_user` to extend the
+limit (= `mode: interactive`, `ask_timeout_seconds: 0` — wait forever).
+Refusal / timeout / no intervention surface aborts the run with a
+`RunResult` whose `status` is one of `loop_limit_exceeded` /
+`phase_budget_exceeded` / `budget_exceeded`, and `partial_data`
+populated with the last completed phase artifact — *"here's what we
+have so far"*. Headless paths (`bus=None`, non-TTY stdin) short-circuit
+to that abort path cleanly — `interactive` is safe everywhere.
 
 You can change this with `safety.on_limit.mode`:
 
@@ -143,17 +147,17 @@ You can change this with `safety.on_limit.mode`:
 # reyn.local.yaml
 safety:
   on_limit:
-    mode: unattended       # default — abort on hit (legacy behaviour)
-    # mode: interactive    # prompt the user via ask_user; on approval extend the limit
+    mode: interactive      # default — prompt the user via ask_user; on approval extend the limit
+    # mode: unattended     # abort on hit (= opt-in for CI / cron / scripted runs that cannot pause)
     # mode: auto_extend    # auto-extend N times, then abort
     auto_extend_times: 1   # only consulted when mode == auto_extend
-    ask_timeout_seconds: 60  # only consulted when mode == interactive
+    ask_timeout_seconds: 0  # only consulted when mode == interactive; 0 = wait forever
 ```
 
 | Mode | Use case |
 |---|---|
-| `unattended` (default) | `reyn run`, CI, scripted invocations — no human to ask, fail fast |
-| `interactive` | `reyn chat`, TUI sessions — the user is sitting at the prompt and can decide |
+| `interactive` (default) | `reyn chat`, TUI / a2a sessions — the user is reachable and can decide whether to extend |
+| `unattended` | CI / cron / scripted invocations that genuinely cannot pause for a human; opt-in to skip the prompt and fail fast |
 | `auto_extend` | Trusted long-running tasks where the operator knows up front that N extensions are acceptable |
 
 **Where each mode is wired (FP-0005 Phase 2 — fully landed):**

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -184,9 +184,9 @@ safety:
     phase_seconds: 0             # Phase ごとのウォールクロックバジェット; 0 = 無制限 (--phase-budget)
     chain_seconds: 60            # デリゲート返答待機時間
   on_limit:
-    mode: unattended             # interactive | unattended | auto_extend
+    mode: interactive            # interactive | unattended | auto_extend
     auto_extend_times: 1         # （auto_extend モード）自動延長回数
-    ask_timeout_seconds: 60      # （interactive モード）ユーザープロンプトのタイムアウト
+    ask_timeout_seconds: 0       # （interactive モード）ユーザープロンプトのタイムアウト; 0 = 無制限待機
 ```
 
 ### `safety.loop` フィールド
@@ -211,9 +211,9 @@ safety:
 
 | パス | 型 | デフォルト | 説明 |
 |------|------|---------|-------------|
-| `safety.on_limit.mode` | 文字列 | `unattended` | ループ/タイムアウト上限発動時の動作。`interactive` — `ask_user` でユーザーに延長許可を確認。`unattended` — 即時中止（`reyn run` / CI のデフォルト）。`auto_extend` — `auto_extend_times` 回自動延長後に中止。 |
-| `safety.on_limit.auto_extend_times` | int | `1` | `unattended` フォールスルーまでの自動延長回数。`mode: auto_extend` 時のみ使用。 |
-| `safety.on_limit.ask_timeout_seconds` | float（秒） | `60` | `interactive` モードでユーザー返答を待機する時間。タイムアウト時は拒否として扱われ、partial data で中止。 |
+| `safety.on_limit.mode` | 文字列 | `interactive` | ループ/タイムアウト上限発動時の動作。`interactive`（デフォルト） — `ask_user` でユーザーに延長許可を確認。ヘッドレス（bus=None / 非 TTY）は自動的に abort へ短絡。`unattended` — 即時中止（CI / cron / スクリプト実行向けのオプトイン）。`auto_extend` — `auto_extend_times` 回自動延長後に中止。 |
+| `safety.on_limit.auto_extend_times` | int | `1` | abort フォールスルーまでの自動延長回数。`mode: auto_extend` 時のみ使用。 |
+| `safety.on_limit.ask_timeout_seconds` | float（秒） | `0` | `interactive` モードでユーザー返答を待機する時間。`0`（デフォルト） = 無制限待機、正の値 = ウィンドウ経過で partial data として abort。 |
 
 ## `plan` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -191,9 +191,9 @@ safety:
     phase_seconds: 0           # per-phase wall-clock budget; 0 = unlimited (--phase-budget)
     chain_seconds: 60          # wait for delegate reply before upstream error
   on_limit:
-    mode: unattended           # interactive | unattended | auto_extend
+    mode: interactive          # interactive | unattended | auto_extend
     auto_extend_times: 1       # (auto_extend mode) number of auto-extensions
-    ask_timeout_seconds: 60    # (interactive mode) user-prompt timeout
+    ask_timeout_seconds: 0     # (interactive mode) user-prompt timeout; 0 = wait forever
 ```
 
 ### `safety.loop` fields
@@ -220,9 +220,9 @@ safety:
 
 | Path | Type | Default | Description |
 |------|------|---------|-------------|
-| `safety.on_limit.mode` | string | `unattended` | What happens when a loop/timeout cap fires. `interactive` — prompt the user via `ask_user` for permission to extend. `unattended` — abort immediately (default for `reyn run` / CI). `auto_extend` — auto-extend `auto_extend_times` times then abort. |
-| `safety.on_limit.auto_extend_times` | int | `1` | Number of auto-extensions before falling through to `unattended`. Used only when `mode: auto_extend`. |
-| `safety.on_limit.ask_timeout_seconds` | float (s) | `60` | How long `interactive` mode waits for a user response. On timeout the request is treated as a refusal (abort with partial data). |
+| `safety.on_limit.mode` | string | `interactive` | What happens when a loop/timeout cap fires. `interactive` (default) — prompt the user via `ask_user` for permission to extend; headless paths short-circuit cleanly to abort. `unattended` — abort immediately on hit (opt-in for CI / cron / scripted runs that cannot pause). `auto_extend` — auto-extend `auto_extend_times` times then abort. |
+| `safety.on_limit.auto_extend_times` | int | `1` | Number of auto-extensions before falling through to abort. Used only when `mode: auto_extend`. |
+| `safety.on_limit.ask_timeout_seconds` | float (s) | `0` | How long `interactive` mode waits for a user response. `0` (default) = wait forever; positive = abort with partial data after the window elapses. |
 
 ## `plan` block
 

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -263,15 +263,18 @@ class OnLimitConfig:
 
     Reyn supports three behaviours when a safety limit fires:
 
-    - ``interactive``: pause the run, prompt the user via ``ask_user``
-      for permission to continue. On approval the limit is extended by
-      one increment; on refusal (or ask timeout) the run aborts with
-      ``RunResult.partial_data`` populated. This is the default for
-      ``reyn chat`` — the user is sitting at a TUI and can answer.
+    - ``interactive`` (= default): pause the run, prompt the user via
+      ``ask_user`` for permission to continue. On approval the limit
+      is extended by one increment; on refusal (or ask timeout) the
+      run aborts with ``RunResult.partial_data`` populated. Default
+      ``ask_timeout_seconds=0`` means "wait forever for a human
+      reply" — silently discarding mid-run state on a 60s wall clock
+      is a worse UX than holding the run open until the user returns.
 
-    - ``unattended``: abort immediately (legacy behaviour). This is the
-      default for ``reyn run`` and CI invocations — there is no user to
-      ask, so silent escalation is the safer choice.
+    - ``unattended``: abort immediately on hit. Opt-in for CI / cron
+      / scripted runs that genuinely cannot pause for a human, where
+      a hung intervention prompt would be a worse outcome than a
+      clean abort.
 
     - ``auto_extend``: auto-extend the limit ``auto_extend_times`` times
       without prompting, then fall through to ``unattended`` behaviour
@@ -286,15 +289,19 @@ class OnLimitConfig:
     pipeline.
 
     ``ask_timeout_seconds`` bounds how long ``interactive`` mode waits
-    for a user response. If the prompt is not answered within the
-    window, the request is treated as a refusal (= abort with
-    partial_data). Defaults to 60s — long enough for a human reply,
-    short enough to avoid a hung delegate / chat session.
+    for a user response. ``0`` (= default) means "wait forever";
+    positive values abort with ``partial_data`` after the window
+    elapses. Headless paths are still safe regardless of timeout:
+    ``bus=None`` (= no intervention surface, e.g. dispatch_tool /
+    scripted runs) short-circuits to abort via the ``no_bus`` reason
+    in ``handle_limit_exceeded``, and ``StdinInterventionBus`` on a
+    non-TTY raises ``EOFError`` immediately which the helper treats
+    as a refusal.
     """
 
-    mode: Literal["interactive", "unattended", "auto_extend"] = "unattended"
+    mode: Literal["interactive", "unattended", "auto_extend"] = "interactive"
     auto_extend_times: int = 1
-    ask_timeout_seconds: float = 60.0
+    ask_timeout_seconds: float = 0.0
 
 
 @dataclass

--- a/tests/test_safety_on_limit.py
+++ b/tests/test_safety_on_limit.py
@@ -45,16 +45,19 @@ def _write_yaml(path: Path, body: str) -> None:
 # ─── 1. OnLimitConfig defaults ─────────────────────────────────────────
 
 
-def test_on_limit_default_is_unattended() -> None:
-    """Tier 2: the default ``OnLimitConfig`` mode is ``unattended`` so
-    legacy callers (= every existing reyn run / chat without explicit
-    config) preserve their abort-on-limit behaviour. Opt into
-    ``interactive`` / ``auto_extend`` is explicit.
+def test_on_limit_default_is_interactive_with_no_timeout() -> None:
+    """Tier 2: the default ``OnLimitConfig`` mode is ``interactive`` with
+    ``ask_timeout_seconds=0`` so that a run on a real intervention
+    surface (= chat TUI / a2a peer) holds open for a user reply rather
+    than silently discarding mid-run state on a 60s wall clock.
+    Headless paths (``bus=None``, non-TTY stdin) still abort cleanly
+    via the ``no_bus`` / ``user_refused`` short-circuits in
+    ``handle_limit_exceeded`` — see the helper docstring.
     """
     cfg = OnLimitConfig()
-    assert cfg.mode == "unattended"
+    assert cfg.mode == "interactive"
     assert cfg.auto_extend_times == 1
-    assert cfg.ask_timeout_seconds == 60.0
+    assert cfg.ask_timeout_seconds == 0.0
 
 
 def test_on_limit_modes_constant_includes_all_three() -> None:
@@ -99,7 +102,7 @@ safety:
     mode: not-a-real-mode
 """.lstrip())
     cfg = load_config(cwd=isolated_project)
-    assert cfg.safety.on_limit.mode == "unattended"
+    assert cfg.safety.on_limit.mode == "interactive"
 
 
 def test_safety_on_limit_negative_values_clamped(
@@ -118,10 +121,10 @@ safety:
 """.lstrip())
     cfg = load_config(cwd=isolated_project)
     assert cfg.safety.on_limit.auto_extend_times == 1
-    assert cfg.safety.on_limit.ask_timeout_seconds == 60.0
+    assert cfg.safety.on_limit.ask_timeout_seconds == 0.0
 
 
-def test_safety_section_default_includes_unattended_on_limit(
+def test_safety_section_default_includes_interactive_on_limit(
     isolated_project: Path,
 ) -> None:
     """Tier 2: an empty ``safety:`` (or no safety: at all) yields a

--- a/tests/test_safety_phase2_wiring.py
+++ b/tests/test_safety_phase2_wiring.py
@@ -53,12 +53,14 @@ def _one_phase_skill() -> Skill:
 
 @pytest.mark.asyncio
 async def test_os_max_phase_visits_unattended_raises_on_hit() -> None:
-    """Tier 2: ``mode=unattended`` (= default) preserves the legacy
-    raise path: a phase entered ``max_phase_visits`` times raises
-    ``LoopLimitExceededError`` without dispatching any intervention.
+    """Tier 2: explicit ``mode=unattended`` raises ``LoopLimitExceededError``
+    on hit without dispatching any intervention. Default mode is now
+    ``interactive``, so opting into legacy abort-on-hit behaviour is
+    explicit (= the ``OnLimitConfig(mode="unattended")`` override).
     """
     rt = OSRuntime(
         _one_phase_skill(), model="stub/model", run_id="run-fp5-B-unatt",
+        safety=SafetyConfig(on_limit=OnLimitConfig(mode="unattended")),
     )
     rt._max_phase_visits = 2
 
@@ -66,7 +68,7 @@ async def test_os_max_phase_visits_unattended_raises_on_hit() -> None:
     await rt._enter_phase("greet", {"type": "greet_in", "data": {}})
     await rt._enter_phase("greet", {"type": "greet_in", "data": {}})
 
-    # Third entry: cap hit. Default unattended mode → raise.
+    # Third entry: cap hit. Unattended mode → raise.
     with pytest.raises(LoopLimitExceededError) as excinfo:
         await rt._enter_phase("greet", {"type": "greet_in", "data": {}})
     assert "max_phase_visits" in str(excinfo.value)
@@ -112,9 +114,11 @@ def _make_session(*, cap: int, on_limit: OnLimitConfig) -> ChatSession:
 
 
 def test_router_cap_unattended_raises_on_hit(tmp_path, monkeypatch) -> None:
-    """Tier 2: with default ``unattended`` mode, the router cap
+    """Tier 2: with explicit ``unattended`` mode, the router cap
     fires the legacy ``RouterCapExceeded`` raise — byte-for-byte
-    legacy behaviour.
+    legacy behaviour. Default mode is now ``interactive``; opting
+    into immediate-raise is the ``OnLimitConfig(mode="unattended")``
+    override.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(cap=2, on_limit=OnLimitConfig(mode="unattended"))
@@ -158,12 +162,14 @@ def test_router_cap_auto_extend_grants_then_aborts(
 # ─── ChatSession threads on_limit through the constructor ─────────────
 
 
-def test_chatsession_default_on_limit_is_unattended() -> None:
+def test_chatsession_default_on_limit_is_interactive() -> None:
     """Tier 2: a ChatSession without an explicit ``safety`` argument
-    defaults to ``unattended`` on_limit (= preserves legacy behaviour).
+    defaults to ``interactive`` on_limit so a TUI / a2a run holds open
+    for a user reply rather than silently discarding mid-run state.
+    See ``OnLimitConfig`` docstring for the headless safety story.
     """
     s = ChatSession(agent_name="t")
-    assert s._on_limit.mode == "unattended"
+    assert s._on_limit.mode == "interactive"
 
 
 def test_chatsession_threads_on_limit_through_constructor() -> None:

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -33,7 +33,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from reyn.chat.session import ChatSession
-from reyn.config import SafetyConfig, TimeoutConfig
+from reyn.config import OnLimitConfig, SafetyConfig, TimeoutConfig
 from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.state_log import StateLog
 from reyn.llm.llm import LLMToolCallResult
@@ -130,6 +130,7 @@ def _make_session(
     agent_name: str = "test_agent",
     chain_timeout_seconds: float = 60.0,
     registry: _FakeRegistry | None = None,
+    on_limit: OnLimitConfig | None = None,
 ) -> ChatSession:
     """Build a ChatSession with WAL + per-test snapshot path via public kwargs.
 
@@ -137,8 +138,17 @@ def _make_session(
     ``enforce_listener_presence=True`` short-circuit does not fire — these
     tests exercise the chat-side intervention flow and resolve answers
     via ``deliver_answer`` themselves.
+
+    Tests that want the legacy "abort immediately on limit hit" behaviour
+    (= chain-timeout fires + emits chain_timeout_fired) pass
+    ``on_limit=OnLimitConfig(mode="unattended")`` explicitly; otherwise
+    the default ``interactive`` + ``ask_timeout=0`` is applied and the
+    registered listener keeps the prompt awaiting forever.
     """
-    safety = SafetyConfig(timeout=TimeoutConfig(chain_seconds=chain_timeout_seconds))
+    safety_kwargs = {"timeout": TimeoutConfig(chain_seconds=chain_timeout_seconds)}
+    if on_limit is not None:
+        safety_kwargs["on_limit"] = on_limit
+    safety = SafetyConfig(**safety_kwargs)
     session = ChatSession(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
@@ -338,9 +348,16 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     peer_session = ChatSession(agent_name="slow_peer")
     registry.register("slow_peer", peer_session)
 
-    # Short timeout so it fires fast.
+    # Short timeout so it fires fast. Use unattended mode so the chain
+    # timeout fires as an abort + emits chain_timeout_fired event, rather
+    # than awaiting the new ``interactive`` default's user prompt that
+    # nothing would resolve in this test (the registered placeholder
+    # listener stays silent under ``ask_timeout=0``).
     session = _make_session(
-        tmp_path, registry=registry, chain_timeout_seconds=0.05
+        tmp_path,
+        registry=registry,
+        chain_timeout_seconds=0.05,
+        on_limit=OnLimitConfig(mode="unattended"),
     )
     session.is_attached = True
 


### PR DESCRIPTION
**[e2e-coder]** — Phase 1 immediate-value follow-up to #254 (Refs #254, depends on PR #255 = Phase 1 subscriber-presence guard).

## Why this changes the default

現状の `safety.on_limit.mode` default `unattended` は **上限 hit で実行を即 abort** する shape。 user view では:
- 途中まで完了した artifact / phase state は捨てられる
- partial_data に残るだけで run の続行はできない
- 「上限あと少しなのに、 ちょっと延ばさせて」 が UX として届かない

issue #254 の motivating problem: **「default で途中経過破棄するのは user デメリット大」** という user 論点が出発点。 出荷 default として `interactive` + `ask_timeout=0` (= 「上限来たら user に聞く、 答えるまで run を保留」) の方が peer-to-peer 思想にも合致する。

## What this PR does

production:
- `src/reyn/config.py`: `OnLimitConfig` の default を
  - `mode: "unattended"` → **`"interactive"`**
  - `ask_timeout_seconds: 60.0` → **`0.0`** (= "wait forever for a human reply")
- docstring を新挙動 + headless safety rationale 反映で書き直し

docs (en + ja):
- `docs/reference/config/reyn-yaml.md` / `.ja.md`: default value 表 + sample yaml を新値に更新
- `docs/guide/for-skill-authors/understand-why-reyn-stops.md` / `.ja.md`: 「default で abort」 から 「default で ask」 に narrative 反転、 headless 短絡の説明追加

tests:
- `tests/test_safety_on_limit.py`: default 値 assertion 3 件更新 + `test_safety_section_default_includes_unattended_on_limit` → `..._interactive_...` rename
- `tests/test_safety_phase2_wiring.py`: 2 件の docstring + 1 件 explicit `OnLimitConfig(mode=\"unattended\")` 追加 (= 旧 default behavior を試す test なので明示 opt-in)
- `tests/test_session_invariants.py`: `_make_session` に `on_limit` kwarg 追加、 `test_chain_timeout_fires_upstream_error_and_emits_event` が explicit `OnLimitConfig(mode=\"unattended\")` を passing する形に (= chain-timeout abort semantics を pin する test なので明示 opt-in)

## Headless safety story

新 default で問題が起きないことを保証する 2 層の短絡 (= `handle_limit_exceeded` + Phase 1 guard):

1. `bus=None` (= dispatch_tool / scripted runs) → `handle_limit_exceeded` 既存の `no_bus` reason で即 abort
2. `bus` 存在 + **subscriber 不在** (= test / TUI 未 mount / a2a peer offline) → **PR #255 Phase 1 guard** が `InterventionRegistry.dispatch` で短絡、 `user_refused` 経路で abort
3. `StdinInterventionBus` の non-TTY → `EOFError` → `handle_limit_exceeded` の `except Exception` で `user_refused` → abort

→ 「user 不在環境で hang」 経路は **全 close**。 prod TUI / a2a 経由で実 user が答えられる環境のみが wait-forever 挙動を享受する。

## Dependency chain

- **必須前提**: PR #255 (= Phase 1 subscriber-presence guard) merged ✓
- 本 PR 単独 merge OK、 Phase 2 (= `RequestBus` / `UserChannel` interface 分離) と独立進行

## Test plan

- [x] **Automated — targeted regression**: `pytest tests/test_safety_on_limit.py tests/test_safety_phase2_wiring.py tests/test_chat_router_i18n.py tests/test_intervention_subscriber_guard.py` → 38/38 pass。
- [x] **Adjacent — `pytest tests/test_session_invariants.py`**: 18/18 pass (`test_chain_timeout_fires_upstream_error_and_emits_event` も含む、 explicit unattended override で legacy abort 挙動を pin)。
- [x] **Full suite — running on push** (= `pytest tests/ --ignore=tests/scaffold --ignore=tests/test_a2a_sync_async_escalation.py --timeout=30`)。 `test_a2a_sync_async_escalation.py` の skip は PR #253 由来 fastapi env gap (preexisting)、 本 PR 起因ではない。
- [x] **Lint — `ruff check`**: clean。
- [ ] **Manual — prod TUI で limit hit 時に intervention prompt が表示され yes/no で延長できる**: e2e-coder env では TUI を fire しないので user / tui-coder の手動 verify、 PR #255 と同じ split 構造。

## Notes

- 既存の opt-in (= `safety.on_limit.mode: unattended` を `reyn.yaml` で書く CI / cron) は **完全に preserved**。 user が明示で opt-out したいなら旧挙動を再現可能。
- `cron` / `reyn run` / `dispatch_tool` 等の headless invocation path は `StdinInterventionBus` / `bus=None` どちらかで自動的に短絡経路に乗る (= Headless safety story 参照)。
- 本 PR は issue #254 の **immediate-value tap**、 Phase 2-5 の追加 architectural refactor は別 PR / 別 issue で incremental に進行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)