### PR TITLE
docs+fix(a2a, describe_action): post-merge review notes from #248 + #253

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -1026,19 +1026,33 @@ def _resource_description(
     returns the dispatcher's generic instruction text — uninformative for
     the LLM trying to narrate "tell me more about <resource>".
 
-    Covered (= same set as ``_resource_input_schema``):
+    Covered (= categories with per-resource description metadata on the
+    host side):
       - ``skill__<name>`` — pulls ``description`` from
         ``ctx.router_state.host.list_available_skills()``.
-      - ``agent.peer__<name>`` — pulls ``description`` from
-        ``ctx.router_state.host.list_available_agents()``.
+      - ``agent.peer__<name>`` — pulls ``description`` (or ``role``
+        fallback) from ``ctx.router_state.host.list_available_agents()``.
       - ``mcp.tool__<server>.<tool>`` — pulls ``description`` from the
         tool's MCP-server entry (FP-0032 expanded shape).
       - ``mcp.server__<name>`` — pulls server-level ``description`` from
         ``ctx.router_state.mcp_servers``.
-      - ``rag.corpus__<name>`` — None (no per-corpus description surface
-        today; caller falls back to the ``recall`` tool description).
-      - ``memory.entry__<name>`` — None (memory entries don't carry a
-        description; caller falls back to ``read_memory_body``).
+
+    Falls through to ``target.description`` (= caller default) for:
+      - ``rag.corpus__<name>`` — no per-corpus description metadata
+        surface today; caller falls back to the ``recall`` tool
+        description (= acceptable generic context for LLM narration).
+      - ``memory.entry__<name>`` — memory entries don't carry description
+        fields; caller falls back to ``read_memory_body`` description.
+      - Operation categories (= ``file__/web__/exec__/...``): the target
+        ToolDefinition IS the action, so ``target.description`` is
+        already the correct per-action text.
+
+    Coverage delta vs ``_resource_input_schema``: that helper covers
+    5 categories (skill / agent.peer / mcp.server / **rag.corpus** /
+    mcp.tool). This helper covers 4 (= same set minus rag.corpus) because
+    the host-side per-corpus description surface doesn't exist; if a
+    ``list_available_corpora()`` surface is added later, this helper
+    should grow a matching branch.
 
     Returns ``None`` for unrecognised categories or when per-resource
     metadata isn't reachable (= test sites with stub router_state, etc.).

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -408,24 +408,25 @@ async def _escalate_to_task(
     """
     from reyn.chat.session import _new_chain_id  # noqa: PLC0415
 
-    # Use the skill's run_id as the task_id so polling GET /a2a/tasks/{id}
-    # naturally aligns with the running skill identity. When multiple
-    # skills are in flight (rare; the LLM normally spawns at most one per
-    # turn), use the first — the others remain trackable via session
-    # state but only the headline gets the task envelope.
-    task_id = running_skill_run_ids[0]
+    # The skill's run_id is what the monitor uses internally to detect
+    # completion (= it polls session.running_skills[skill_run_id]). When
+    # multiple skills are in flight (rare; the LLM normally spawns at most
+    # one per turn), the monitor watches the first — the others remain
+    # trackable via session state but only the headline gets the task
+    # envelope.
+    skill_run_id = running_skill_run_ids[0]
     chain_id = _new_chain_id()
 
-    # Register the entry so the GET /a2a/tasks/{run_id} endpoint can
-    # serve status. We pre-create with the skill's run_id to keep the
-    # caller-visible id stable across the escalation boundary.
+    # Allocate a fresh RunRegistry entry. The entry.run_id is a NEW uuid
+    # (distinct from the skill's run_id) that becomes the caller-facing
+    # task id polled via ``GET /a2a/tasks/{entry.run_id}``. This indirection
+    # is intentional: the A2A task lifecycle (= caller-facing) is owned by
+    # the RunRegistry; the skill's run_id (= OS-internal) stays inside the
+    # monitor's await-loop and never leaks to the caller.
     entry = run_registry.create(
         agent_name=agent_name,
         chain_id=chain_id,
     )
-    # The run_registry assigns its own uuid; record the skill run_id in
-    # the entry's chain_id field so a monitor task can correlate. The
-    # caller-facing task id remains entry.run_id (= polled via /a2a/tasks).
     monitor_task_id = entry.run_id
 
     async def _monitor() -> None:
@@ -436,16 +437,33 @@ async def _escalate_to_task(
         narration is consumed and emitted as a router reply. The reply
         text becomes the Task ``result`` field, available on subsequent
         ``GET /a2a/tasks/{id}`` calls.
+
+        On deadline expiry (= the skill is still running after the
+        monitor's wait window), the entry is marked ``status="timeout"``
+        rather than ``"completed"`` so the caller doesn't conflate "we
+        gave up waiting" with "the skill produced a real result". Plain
+        success path remains ``status="completed"``.
         """
         try:
             # Wait until the running skill's asyncio task is done, plus a
             # final pump pass to consume the skill_completion_injected
-            # inbox message and surface the narration. send_to_agent_impl
-            # with kind="user" and a synthetic ping text wakes the loop
-            # so it can drain the queued completion message.
+            # inbox message and surface the narration.
             session = await _get_session_for_monitor(registry, agent_name)
-            await _await_skill_completion(session, task_id, deadline_s=600.0)
-            narration = _harvest_completion_narration(session, task_id)
+            completed = await _await_skill_completion(
+                session, skill_run_id, deadline_s=600.0,
+            )
+            if not completed:
+                run_registry.update(
+                    monitor_task_id,
+                    status="timeout",
+                    error=(
+                        f"skill {skill_run_id} did not complete within "
+                        f"the monitor deadline; the underlying skill "
+                        f"task continues in the session"
+                    ),
+                )
+                return
+            narration = _harvest_completion_narration(session, skill_run_id)
             run_registry.update(
                 monitor_task_id,
                 status="completed",
@@ -480,7 +498,7 @@ async def _get_session_for_monitor(registry, agent_name: str):
 
 async def _await_skill_completion(
     session, skill_run_id: str, *, deadline_s: float = 600.0,
-) -> None:
+) -> bool:
     """Poll ``session.running_skills`` until ``skill_run_id`` is no longer
     active, OR the deadline fires.
 
@@ -488,6 +506,13 @@ async def _await_skill_completion(
     skill reached a terminal state (success / error / interrupted). After
     that, a final session iteration drains the queued ``skill_completed``
     inbox entry so the narration LLM turn fires.
+
+    Returns ``True`` when the skill task reached terminal state within
+    the deadline (= caller can safely harvest narration); ``False`` when
+    the deadline expired with the task still running (= caller should
+    mark the run_registry entry as ``status="timeout"`` rather than
+    ``"completed"`` to avoid conflating "we gave up waiting" with a real
+    completion).
     """
     deadline = asyncio.get_event_loop().time() + deadline_s
     while True:
@@ -496,7 +521,7 @@ async def _await_skill_completion(
         if task is None or task.done():
             break
         if asyncio.get_event_loop().time() >= deadline:
-            return
+            return False
         await asyncio.sleep(0.5)
     # Final inbox drain: pump iterations until quiescent so the
     # skill_completion_injected inbox entry is consumed and the
@@ -505,6 +530,7 @@ async def _await_skill_completion(
         if session.inbox.empty():
             break
         await session.run_one_iteration()
+    return True
 
 
 def _harvest_completion_narration(session, skill_run_id: str) -> str:

--- a/tests/test_a2a_sync_async_escalation.py
+++ b/tests/test_a2a_sync_async_escalation.py
@@ -11,9 +11,11 @@ Pinned invariants:
 - The escalation only fires when ``partial=True`` AND
   ``running_skill_run_ids`` is non-empty. Plain partial (= timeout
   without skill in flight) still returns a Message envelope per spec.
-- ``_await_skill_completion`` returns once the supplied skill's
-  asyncio.Task is done (= terminal state) and drains any queued inbox
-  messages so the narration LLM turn can fire.
+- ``_await_skill_completion`` returns ``True`` once the supplied
+  skill's asyncio.Task is done (= terminal state) within the deadline,
+  draining any queued inbox messages so the narration LLM turn can
+  fire. Returns ``False`` on deadline expiry so the caller can mark
+  the entry ``status="timeout"`` (distinct from a real completion).
 - ``_harvest_completion_narration`` returns the latest router-narration
   text following a ``meta.source="skill_completion"`` injection for the
   matching run_id; falls through to the latest non-spawn-ack agent
@@ -75,8 +77,10 @@ class _Session:
 
 
 @pytest.mark.asyncio
-async def test_await_skill_completion_returns_when_task_done():
-    """Tier 2: returns once the skill's asyncio.Task transitions to done()."""
+async def test_await_skill_completion_returns_true_when_task_done():
+    """Tier 2: returns True once the skill's asyncio.Task transitions to
+    done() within the deadline (= caller can safely harvest narration).
+    """
     finished_event = asyncio.Event()
 
     async def _skill_body() -> None:
@@ -92,35 +96,43 @@ async def test_await_skill_completion_returns_when_task_done():
 
     asyncio.create_task(_trigger())
 
-    await asyncio.wait_for(
+    result = await asyncio.wait_for(
         _await_skill_completion(session, "run-1", deadline_s=2.0),
         timeout=3.0,
     )
+    assert result is True
     assert task.done()
 
 
 @pytest.mark.asyncio
-async def test_await_skill_completion_returns_immediately_when_no_such_run_id():
-    """Tier 2: unknown run_id → return immediately (no hang).
+async def test_await_skill_completion_returns_true_immediately_when_no_such_run_id():
+    """Tier 2: unknown run_id → return True immediately (no hang).
 
     Defensive: the run may have completed before the monitor task got
     scheduled, in which case the entry is already gone from
-    ``running_skills``. Must not hang waiting for a phantom task.
+    ``running_skills``. Must not hang waiting for a phantom task. The
+    completed-before-monitor case is semantically a success (= we
+    skipped the wait but the run did finish), so True is correct.
     """
     session = _Session(running_skills={})
     # Should complete well under the deadline
-    await asyncio.wait_for(
+    result = await asyncio.wait_for(
         _await_skill_completion(session, "phantom", deadline_s=1.0),
         timeout=2.0,
     )
+    assert result is True
 
 
 @pytest.mark.asyncio
-async def test_await_skill_completion_deadline_caps_wait():
-    """Tier 2: deadline fires before task.done() → return without raising.
+async def test_await_skill_completion_returns_false_on_deadline():
+    """Tier 2 (Note 2 reliability fix): deadline fires before task.done()
+    → return False so the caller can mark the run_registry entry
+    ``status="timeout"`` rather than ``"completed"``.
 
-    The monitor is non-blocking (= we don't want the task envelope's
-    background runner to hang forever if the skill genuinely wedges).
+    Without this distinction, a long-running skill that exceeds the
+    monitor's wait window would be reported as completed with empty
+    narration — conflating "we gave up waiting" with a real completion
+    result.
     """
     never = asyncio.Event()  # never set
     async def _stuck() -> None:
@@ -128,11 +140,11 @@ async def test_await_skill_completion_deadline_caps_wait():
     task = asyncio.create_task(_stuck())
     session = _Session(running_skills={"run-x": task})
 
-    # Should return within the deadline plus a small grace.
-    await asyncio.wait_for(
+    result = await asyncio.wait_for(
         _await_skill_completion(session, "run-x", deadline_s=0.2),
         timeout=1.0,
     )
+    assert result is False
     task.cancel()
     try:
         await task


### PR DESCRIPTION
**[dogfood-coder]** — bundled follow-up to lead-coder's optional notes on the merged PRs #248 and #253.

## Changes

### (a) PR #248 — docstring coverage claim accuracy (doc only)

`_resource_description` docstring claimed coverage = same set as `_resource_input_schema`, but actually:
- `_resource_input_schema`: 5 categories (skill / agent.peer / mcp.server / **rag.corpus** / mcp.tool)
- `_resource_description`: 4 categories (skill / agent.peer / mcp.tool / mcp.server)

`rag.corpus` is intentionally absent because no per-corpus description metadata surface exists today on the host. Rewrite the docstring to state the actual covered set + fall-through cases (rag.corpus / memory.entry / operation categories) + coverage delta note. **No behavior change.**

### (b) PR #253 Note 1 — `_escalate_to_task` comment ↔ implementation

Original comment said "Use the skill's run_id as the task_id" but the implementation allocates a fresh uuid via `run_registry.create()`. Rename local `task_id` → `skill_run_id` and rewrite surrounding comments to describe the indirection accurately: caller-facing task id = `entry.run_id`; OS-internal skill run_id = `running_skill_run_ids[0]`. **No behavior change.**

### (c) PR #253 Note 2 — `status="timeout"` distinct from `"completed"` (reliability)

Before: `_await_skill_completion()` returned `None` on both terminal completion AND deadline expiry. `_monitor()` then set `status="completed"` with empty narration in the deadline case — misleadingly conflating "we gave up waiting" with a real completion.

After:
- `_await_skill_completion()` returns `bool` — True on terminal completion, False on deadline expiry
- `_monitor()` reads bool: True → `status="completed"`; False → `status="timeout"` with explicit error message

This is a **behavior change** for the rare deadline-expiry path (= skill runs >600s). The caller polling `GET /a2a/tasks/{id}` will see `status="timeout"` rather than a false `"completed"`.

## Test plan

- [x] 10 Tier 2 tests pass in `test_a2a_sync_async_escalation.py` (incl. new `test_await_skill_completion_returns_false_on_deadline`)
- [x] 10 Tier 2 tests pass in `test_describe_action_resource_description.py` (unchanged)
- [x] Wider regression: 170 passed across `test_a2a_handler_invariants` + `test_mcp_server` + `test_universal_catalog` + `test_universal_dispatch` + `tests/web/test_a2a.py`
- [x] No behavior change for sync path / Message envelope return / running_skill_run_ids surface

## Out of scope

- PR #253 Note 3 (multiple running skills first-only) — acknowledged as known limitation, deferred to future iteration if probe surfaces.
- PR #253 Note 4 (Test plan format) — already internalized; this PR's Test plan follows the `- [x] (skipped — <reason>)` rule from the start.

## Related

- PR #248 (merged): `_resource_description` introduction.
- PR #253 (merged): A2A sync→Task auto-escalation.
- lead-coder review comments on both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)