### PR TITLE
feat(intervention): Agent (ChatSession) as RequestBus subscriber (Phase 3 of #254)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -193,6 +193,32 @@ class RouterCapExceeded(Exception):
         self.last_reason = last_reason
 
 
+class AgentRequestBus:
+    """``RequestBus`` adapter that subscribes to a ChatSession (= Agent).
+
+    issue #254 Phase 3: OS-layer callers (= ``handle_limit_exceeded``,
+    permission gates, ``ask_user`` op) hold a ``RequestBus``-typed
+    reference; this adapter forwards ``request(iv)`` to the Agent's
+    ``handle_intervention(iv)`` so the Agent owns the routing decision.
+
+    Phase 3 ships behaviour parity (= ``handle_intervention`` just
+    forwards to ``_dispatch_intervention``); Phase 4 will add
+    ``self_answer`` / ``parent_delegate`` branches on the Agent side
+    without changing this adapter's surface.
+
+    The adapter satisfies the ``RequestBus`` runtime_checkable Protocol
+    so OS code typed against ``bus: RequestBus`` (or the legacy
+    ``InterventionBus`` alias) accepts it without further wiring.
+    """
+
+    def __init__(self, session: "ChatSession") -> None:
+        self._session = session
+
+    async def request(self, iv: "UserIntervention") -> "InterventionAnswer":
+        """``RequestBus.request`` — delegate to the Agent's intervention handler."""
+        return await self._session.handle_intervention(iv)
+
+
 class ChatInterventionBus:
     """``UserChannel`` implementation that routes through ChatSession's
     outbox/inbox to the attached TUI listener.
@@ -1865,6 +1891,51 @@ class ChatSession:
                     return await override.request(iv)
         # Default: route through the regular InterventionHandler.
         return await self._intervention_handler.dispatch(iv)
+
+    # ── Agent-layer intervention entry point (issue #254 Phase 3) ───────────
+
+    async def handle_intervention(self, iv: UserIntervention) -> InterventionAnswer:
+        """Agent-layer entry point for incoming intervention requests.
+
+        This is the Agent's ``RequestBus`` subscriber-side handler.
+        Conceptually the Agent decides what to do with the request:
+
+          - **self_answer**: agent has a policy that answers without
+            consulting the user (e.g. "I've already extended this limit
+            5 times, refuse")
+          - **parent_agent.delegate**: forward to a chain-upstream agent
+            so the originating user-facing agent owns the decision
+          - **user_channel.deliver**: route the prompt to the agent's
+            attached user surface (TUI / stdin / A2A peer)
+
+        Phase 3 ships ONLY behaviour parity (= forward unconditionally to
+        the existing ``_dispatch_intervention`` path, which already
+        encodes the chain-override → channel.deliver routing for A2A
+        async tasks + ChatInterventionBus fall-through for the default
+        TUI path). Phase 4 will add ``self_answer`` / ``parent_delegate``
+        branches to this method.
+
+        Callers that obtain a ``RequestBus``-typed view of an Agent use
+        ``ChatSession.as_request_bus()`` (which returns an
+        ``AgentRequestBus`` adapter forwarding ``request(iv)`` here).
+        """
+        return await self._dispatch_intervention(iv)
+
+    def as_request_bus(self) -> "AgentRequestBus":
+        """Return a ``RequestBus``-typed adapter for this ChatSession.
+
+        OS-layer callers (= ``handle_limit_exceeded``, permission gates,
+        ``ask_user`` op) can hold an ``AgentRequestBus`` without
+        importing ChatSession or knowing about the Agent's downstream
+        routing choices. The adapter forwards ``request(iv)`` to
+        ``handle_intervention(iv)``.
+
+        issue #254 Phase 3 — the type-level realisation of the [A]
+        contract from Phase 2: OS owns a ``RequestBus``, the bus is
+        backed by an Agent (= ChatSession), the Agent owns the routing
+        decision and the downstream ``UserChannel`` selection.
+        """
+        return AgentRequestBus(self)
 
     async def _ask_budget_extension(
         self,

--- a/tests/test_intervention_agent_subscriber.py
+++ b/tests/test_intervention_agent_subscriber.py
@@ -1,0 +1,261 @@
+"""Tier 2: Agent (ChatSession) as RequestBus subscriber (issue #254 Phase 3).
+
+Pins Phase 3's behaviour-parity introduction of the Agent-layer
+intervention handler:
+
+  - ``ChatSession.handle_intervention(iv)`` is the Agent's entry point
+    for incoming intervention requests. Phase 3 ships pure forward-only
+    behaviour (= delegates to ``_dispatch_intervention``); Phase 4 will
+    add ``self_answer`` / ``parent_delegate`` branches without changing
+    this surface.
+  - ``ChatSession.as_request_bus()`` returns an ``AgentRequestBus``
+    adapter that satisfies the ``RequestBus`` Protocol from Phase 2.
+    OS-layer callers (= ``handle_limit_exceeded``, permission gates,
+    ``ask_user`` op) hold this adapter without importing ChatSession.
+  - ``AgentRequestBus.request(iv)`` forwards to
+    ``ChatSession.handle_intervention(iv)`` — pinning the wire from
+    OS [A] contract → Agent layer → downstream channel selection.
+
+End-to-end behaviour parity is verified via the existing dispatch path
+(= the same ``_dispatch_intervention`` that PR #255 / #258 covered);
+Phase 3 only adds the Agent-layer NAME for the same code path, so
+existing subscriber-guard / outbox / chain-override semantics are
+re-verified through the new entry-point.
+
+No mocks. Real ChatSession, real adapter.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import AgentRequestBus, ChatSession
+from reyn.user_intervention import (
+    InterventionAnswer,
+    InterventionBus,
+    RequestBus,
+    UserIntervention,
+)
+
+# ── 1. ChatSession.handle_intervention exists and is the canonical
+#      Agent-layer entry point ────────────────────────────────────────────
+
+
+def test_chat_session_has_handle_intervention_method() -> None:
+    """Tier 2: ChatSession exposes ``handle_intervention(iv)`` as the
+    Agent's intervention entry point.
+    """
+    assert hasattr(ChatSession, "handle_intervention")
+    method = ChatSession.handle_intervention
+    assert inspect.iscoroutinefunction(method)
+
+
+def test_handle_intervention_signature_is_iv_to_answer() -> None:
+    """Tier 2: signature is ``handle_intervention(self, iv) -> ...``.
+
+    Pinning the shape so a future refactor cannot quietly change the
+    contract from underneath OS callers.
+    """
+    sig = inspect.signature(ChatSession.handle_intervention)
+    params = list(sig.parameters.keys())
+    assert params == ["self", "iv"]
+
+
+def test_handle_intervention_forwards_to_dispatch_intervention() -> None:
+    """Tier 2: Phase 3 ships behaviour parity — the Agent layer just
+    forwards to the existing ``_dispatch_intervention`` path so the
+    chain-override / TUI fall-through routing keeps working unchanged.
+
+    Verified via source inspection (= the body MUST delegate to
+    ``self._dispatch_intervention(iv)`` in Phase 3). Phase 4 will add
+    self_answer / parent_delegate branches, at which point this test
+    is updated to assert the forward-path remains as one of multiple
+    branches.
+    """
+    src = inspect.getsource(ChatSession.handle_intervention)
+    assert "self._dispatch_intervention(iv)" in src, (
+        "Phase 3 handle_intervention must delegate to "
+        "_dispatch_intervention for behaviour parity"
+    )
+
+
+# ── 2. AgentRequestBus adapter satisfies the RequestBus protocol ───────
+
+
+def test_agent_request_bus_satisfies_request_bus_protocol() -> None:
+    """Tier 2: an AgentRequestBus instance satisfies the runtime_checkable
+    RequestBus Protocol — OS callers typed against ``bus: RequestBus``
+    accept it directly.
+    """
+    session = ChatSession(agent_name="t")
+    bus = AgentRequestBus(session)
+    assert isinstance(bus, RequestBus)
+
+
+def test_agent_request_bus_also_satisfies_legacy_intervention_bus_alias() -> None:
+    """Tier 2: backwards-compat — OS callers typed against the legacy
+    ``InterventionBus`` name still accept an AgentRequestBus because
+    ``InterventionBus`` is an alias of ``RequestBus`` (Phase 2 invariant).
+    """
+    session = ChatSession(agent_name="t")
+    bus = AgentRequestBus(session)
+    assert isinstance(bus, InterventionBus)
+
+
+def test_agent_request_bus_request_signature_is_iv_to_answer() -> None:
+    """Tier 2: AgentRequestBus.request shape is ``(iv) -> InterventionAnswer``."""
+    sig = inspect.signature(AgentRequestBus.request)
+    params = list(sig.parameters.keys())
+    assert params == ["self", "iv"]
+
+
+# ── 3. as_request_bus() factory returns an AgentRequestBus ─────────────
+
+
+def test_as_request_bus_returns_agent_request_bus() -> None:
+    """Tier 2: ChatSession.as_request_bus() returns an AgentRequestBus
+    bound to this session (= the canonical way for OS callers to get a
+    RequestBus-typed reference without importing AgentRequestBus directly).
+    """
+    session = ChatSession(agent_name="t")
+    bus = session.as_request_bus()
+    assert isinstance(bus, AgentRequestBus)
+    assert isinstance(bus, RequestBus)
+
+
+def test_as_request_bus_returns_fresh_adapter_each_call() -> None:
+    """Tier 2: as_request_bus() is a factory — each call returns a new
+    adapter (= no global state, no caching surprises).
+
+    The adapters are equivalent (all forward to the same session.handle_intervention)
+    but distinct objects so OS callers can safely hold their own.
+    """
+    session = ChatSession(agent_name="t")
+    bus1 = session.as_request_bus()
+    bus2 = session.as_request_bus()
+    assert bus1 is not bus2
+    # Both reference the same session.
+    assert bus1._session is bus2._session is session
+
+
+# ── 4. End-to-end: AgentRequestBus.request → session.handle_intervention
+#      → existing dispatch path (= behaviour parity) ───────────────────
+
+
+def test_agent_request_bus_request_reaches_session_handle_intervention(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: OS-layer call to ``agent_request_bus.request(iv)`` reaches
+    ``session.handle_intervention(iv)`` which reaches the existing
+    ``_dispatch_intervention`` path — confirms the wire end-to-end.
+
+    Uses the Phase 1 subscriber-presence guard: no listener registered,
+    so ``_dispatch_intervention`` short-circuits to an empty answer.
+    The test asserts the short-circuit IS observed via the new entry
+    point — proving the wiring is complete.
+    """
+    session = ChatSession(agent_name="t")
+    # Deliberately no register_intervention_listener — Phase 1 guard
+    # short-circuits the dispatch, returning empty answer.
+    bus = session.as_request_bus()
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+
+    answer = asyncio.run(bus.request(iv))
+    assert isinstance(answer, InterventionAnswer)
+    # Phase 1 short-circuit returns empty answer.
+    assert answer.text == ""
+    assert answer.choice_id is None
+
+
+def test_agent_request_bus_request_with_registered_listener_round_trip(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: with a listener registered, the request flows through
+    handle_intervention → _dispatch_intervention → registry, and a
+    test-driven deliver_answer resolves the future.
+
+    Verifies the Agent-layer entry point doesn't bypass the registry —
+    the same dispatch path used pre-Phase-3 keeps working when invoked
+    through the new RequestBus surface.
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener("test")
+
+    bus = session.as_request_bus()
+
+    async def _drive() -> InterventionAnswer:
+        # Construct iv inside the running loop so its Future binds to
+        # the same loop the registry awaits in.
+        iv = UserIntervention(kind="ask_user", prompt="Q?")
+        # Start the request in the background and resolve it via the
+        # session's existing deliver_answer surface — same shape that
+        # session-intervention tests use.
+        task = asyncio.ensure_future(bus.request(iv))
+        # Yield twice so the registry enqueues + waits.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        ok = await session._deliver_answer_to(iv, "hello")
+        assert ok is True
+        return await task
+
+    answer = asyncio.run(_drive())
+    assert answer.text == "hello"
+
+
+# ── 5. session._interventions attribute path is stable (tui-coder Q2) ──
+
+
+def test_session_interventions_attribute_path_is_stable_in_phase3() -> None:
+    """Tier 2: ChatSession._interventions remains the canonical reference
+    to the InterventionRegistry — tui-coder Q2 commitment from issue
+    #254 alignment.
+
+    Phase 3 introduces the Agent-layer entry point + AgentRequestBus
+    adapter but does NOT move ownership of the registry. TUI continues
+    to read ``session._interventions.queued_count()`` etc. without any
+    import / call site change. If a future phase moves the registry into
+    a sub-component, ``session._interventions`` must remain a proxy.
+    """
+    from reyn.chat.services.intervention_registry import InterventionRegistry
+
+    session = ChatSession(agent_name="t")
+    assert hasattr(session, "_interventions")
+    assert isinstance(session._interventions, InterventionRegistry)
+    # The registry is still enforcing the Phase 1 subscriber guard.
+    assert session._interventions._enforce_listener_presence is True
+
+
+# ── 6. handle_intervention preserves the chain-override path ───────────
+
+
+def test_handle_intervention_respects_chain_override(tmp_path: Path) -> None:
+    """Tier 2: when an InterventionBus override is registered for a
+    chain_id, ``handle_intervention`` honours it (= Phase 3 delegates
+    to _dispatch_intervention which performs the override lookup).
+
+    This is the path used by A2A async-mode tasks — Phase 3 must NOT
+    bypass it.
+    """
+    session = ChatSession(agent_name="t")
+
+    captured: list[UserIntervention] = []
+
+    class _StubOverrideBus:
+        async def request(self, iv: UserIntervention) -> InterventionAnswer:
+            captured.append(iv)
+            return InterventionAnswer(text="from-override", choice_id=None)
+
+    # Register the override AND simulate the running_skills_chain wiring
+    # so the chain_id lookup in _dispatch_intervention finds the override.
+    session.register_intervention_override("chain-X", _StubOverrideBus())
+    session.running_skills_chain["run-1"] = "chain-X"
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?", run_id="run-1")
+    answer = asyncio.run(session.handle_intervention(iv))
+
+    assert answer.text == "from-override"
+    assert len(captured) == 1
+    assert captured[0] is iv


### PR DESCRIPTION
**[e2e-coder]** — Phase 3 of #254.

Refs #254. Depends on PR #255 (Phase 1 subscriber-presence guard) + PR #258 (Phase 2 bus interface split), both merged.

## What this PR does

Introduces the **Agent-layer entry point** for intervention requests + the **`RequestBus` adapter** that subscribes the Agent to OS-side bus calls. Phase 3 ships **ONLY behaviour parity** — the new surface is in place but forwards unconditionally to the existing `_dispatch_intervention` path so chain-override / TUI fall-through / Phase 1 subscriber-guard semantics are unchanged.

### New surface on ChatSession

```python
async def handle_intervention(self, iv) -> InterventionAnswer:
    # Phase 3: forward-only (behaviour parity)
    # Phase 4 will branch: self_answer / parent_delegate / user_channel
    return await self._dispatch_intervention(iv)

def as_request_bus(self) -> AgentRequestBus:
    return AgentRequestBus(self)
```

### New adapter class

```python
class AgentRequestBus:
    # Satisfies RequestBus (Phase 2 Protocol) + legacy InterventionBus alias
    def __init__(self, session: ChatSession) -> None:
        self._session = session

    async def request(self, iv) -> InterventionAnswer:
        return await self._session.handle_intervention(iv)
```

## Architectural significance

Phase 3 realises the **[A] OS↔Agent contract** wire from issue #254's end-state diagram:

```
OS layer (handle_limit_exceeded / permission gate / ask_user op)
   │  RequestBus.request(iv)   ← Phase 2 Protocol, OS knows only this
   ▼
AgentRequestBus  (= Phase 3 adapter)
   │  forwards to session.handle_intervention(iv)
   ▼
ChatSession.handle_intervention(iv)  (= the Agent)
   │  Phase 3: forward to _dispatch_intervention (= behaviour parity)
   │  Phase 4: self_answer | parent_delegate | user_channel.deliver
   ▼
(existing dispatch path, unchanged)
```

Phase 4 will add the routing-decision branches on `handle_intervention` without changing this PR's surface — the Agent-layer entry point is the stable contract from here on.

## tui-coder Q2 commitment (`session._interventions` attribute path)

The registry stays at `session._interventions` — the Agent-layer surface sits BESIDE it, not above it. TUI's `session._interventions.queued_count()` read path is unchanged. Pinned by `test_session_interventions_attribute_path_is_stable_in_phase3`.

## Phase 3 contract test coverage (12 tests)

| # | Test | Pins |
|---|---|---|
| 1 | `test_chat_session_has_handle_intervention_method` | method exists + is async |
| 2 | `test_handle_intervention_signature_is_iv_to_answer` | signature shape |
| 3 | `test_handle_intervention_forwards_to_dispatch_intervention` | Phase 3 behaviour parity (source-level delegation pin) |
| 4 | `test_agent_request_bus_satisfies_request_bus_protocol` | adapter implements RequestBus |
| 5 | `test_agent_request_bus_also_satisfies_legacy_intervention_bus_alias` | backwards-compat |
| 6 | `test_agent_request_bus_request_signature_is_iv_to_answer` | adapter signature |
| 7 | `test_as_request_bus_returns_agent_request_bus` | factory return type |
| 8 | `test_as_request_bus_returns_fresh_adapter_each_call` | no global state |
| 9 | `test_agent_request_bus_request_reaches_session_handle_intervention` | end-to-end short-circuit via Phase 1 guard |
| 10 | `test_agent_request_bus_request_with_registered_listener_round_trip` | end-to-end with deliver_answer |
| 11 | `test_session_interventions_attribute_path_is_stable_in_phase3` | **tui-coder Q2 commitment** |
| 12 | `test_handle_intervention_respects_chain_override` | A2A path preservation |

## Files touched

| File | Δ | Notes |
|---|---|---|
| `src/reyn/chat/session.py` | +72 / -0 | Add `AgentRequestBus` class + `handle_intervention` method + `as_request_bus` factory on ChatSession. No existing logic changed. |
| `tests/test_intervention_agent_subscriber.py` | +260 | New, 12 Tier 2 tests |

## Test plan

- [x] **Automated — `pytest tests/test_intervention_agent_subscriber.py`**: 12/12 pass。
- [x] **Adjacent — `pytest tests/test_intervention_subscriber_guard.py tests/test_intervention_bus_protocols.py tests/test_intervention_resume_e2e.py tests/test_session_intervention_persistence.py tests/test_intervention_restore.py tests/test_durable_answer_buffer.py tests/test_fp0001_session_override.py tests/test_session_invariants.py tests/test_chat_router_i18n.py`** (= Phase 1 + 2 contract + session-intervention test 群): full pass。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --ignore=tests/test_a2a_sync_async_escalation.py --timeout=30`**: 3966 passed, 11 skipped, 3 xfailed in 146s。 (`test_a2a_sync_async_escalation.py` の skip は PR #253 由来 fastapi env gap で本 PR 起因ではない)
- [x] **Lint — `ruff check`**: clean on both touched files。
- [ ] **Manual — TUI / a2a で intervention prompt が今まで通り user に届くこと**: Phase 3 は behaviour parity を保証する forward-only 実装のため runtime 不変、 ただし tui-coder の念のための smoke check は valuable。

## Phase 4 への bridge

`handle_intervention(iv)` の本体が Phase 4 で 3 択 routing を持つ:

```python
async def handle_intervention(self, iv: UserIntervention) -> InterventionAnswer:
    # Phase 4 (planned):
    if self._should_self_answer(iv):
        return self._self_answer(iv)
    if self._has_parent_agent(iv):
        return await self._parent_agent.handle_intervention(iv)
    # Default: deliver via the existing dispatch path (Phase 3 sole branch)
    return await self._dispatch_intervention(iv)
```

Phase 4 PR では `_should_self_answer` / `_has_parent_agent` の policy 設計 + per-kind routing config + Tier 2 で各 branch を pin、 という形になる予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)