### PR TITLE
feat(intervention): Agent routing logic — self_answer / parent_delegate / user_channel (Phase 4 of #254)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1898,28 +1898,106 @@ class ChatSession:
         """Agent-layer entry point for incoming intervention requests.
 
         This is the Agent's ``RequestBus`` subscriber-side handler.
-        Conceptually the Agent decides what to do with the request:
+        Phase 4 implements the 3-way routing decision the Agent makes
+        on every incoming request:
 
-          - **self_answer**: agent has a policy that answers without
-            consulting the user (e.g. "I've already extended this limit
-            5 times, refuse")
-          - **parent_agent.delegate**: forward to a chain-upstream agent
-            so the originating user-facing agent owns the decision
-          - **user_channel.deliver**: route the prompt to the agent's
-            attached user surface (TUI / stdin / A2A peer)
+          1. **self_answer** (= ``_try_self_answer`` hook): the agent
+             has a policy that answers without consulting the user
+             (e.g. "I've already extended this limit 5 times, refuse").
+             Default policy is None — no self-answer — so the request
+             falls through. Future incremental PRs add per-kind
+             policies (e.g. "max_phase_visits hit + N prior extensions
+             → refuse silently") via subclassing or config-driven
+             policy injection.
+          2. **parent_agent.delegate** (= ``_resolve_parent_agent`` hook):
+             forward to a chain-upstream agent so the originating
+             user-facing agent owns the decision. Default returns None
+             — no parent resolution — so the request falls through.
+             Phase 5+ adds the chain-walk via the running_skills_chain
+             registry + an agent-lookup factory.
+          3. **user_channel.deliver** (= default branch): route the
+             prompt through ``_dispatch_intervention``, which preserves
+             the chain-override path (A2A peer) + the regular
+             ``InterventionHandler.dispatch`` (TUI) fall-through. This
+             is the only branch active by default in Phase 4, so the
+             behaviour is identical to Phase 3 for unmodified agents.
 
-        Phase 3 ships ONLY behaviour parity (= forward unconditionally to
-        the existing ``_dispatch_intervention`` path, which already
-        encodes the chain-override → channel.deliver routing for A2A
-        async tasks + ChatInterventionBus fall-through for the default
-        TUI path). Phase 4 will add ``self_answer`` / ``parent_delegate``
-        branches to this method.
+        Each branch emits an ``intervention_routed`` event so observers
+        (= TUI events tab, debug traces, future routing-policy A/B
+        analysis) can see which routing decision fired without
+        instrumenting the hook implementations themselves.
 
         Callers that obtain a ``RequestBus``-typed view of an Agent use
         ``ChatSession.as_request_bus()`` (which returns an
         ``AgentRequestBus`` adapter forwarding ``request(iv)`` here).
         """
+        # Branch 1: self_answer policy.
+        self_ans = await self._try_self_answer(iv)
+        if self_ans is not None:
+            self._chat_events.emit(
+                "intervention_routed",
+                route="self_answer",
+                iv_kind=iv.kind,
+                iv_id=iv.id,
+            )
+            return self_ans
+
+        # Branch 2: parent-agent delegation.
+        parent = self._resolve_parent_agent(iv)
+        if parent is not None:
+            self._chat_events.emit(
+                "intervention_routed",
+                route="parent_delegate",
+                iv_kind=iv.kind,
+                iv_id=iv.id,
+            )
+            return await parent.handle_intervention(iv)
+
+        # Branch 3: default — deliver to user via existing dispatch path.
+        self._chat_events.emit(
+            "intervention_routed",
+            route="user_channel",
+            iv_kind=iv.kind,
+            iv_id=iv.id,
+        )
         return await self._dispatch_intervention(iv)
+
+    async def _try_self_answer(
+        self, iv: UserIntervention,
+    ) -> InterventionAnswer | None:
+        """Hook for self-answer routing policies (issue #254 Phase 4).
+
+        Return an ``InterventionAnswer`` to bypass the user and resolve
+        the request from agent-internal state; return ``None`` to fall
+        through to subsequent routing branches.
+
+        Default implementation returns ``None`` (= no self-answer
+        policy). Subclasses or future config-driven policy injection
+        override this to encode per-kind policies. The default keeps
+        Phase 4 behaviour identical to Phase 3 for unmodified agents.
+
+        Examples of future overrides (NOT in this PR):
+          - "max_phase_visits limit hit + we've already auto-extended
+            ``N`` times this chain → refuse with text='no'"
+          - "permission.shell on a command in the always-allow set →
+            return InterventionAnswer(choice_id='always')"
+        """
+        return None
+
+    def _resolve_parent_agent(
+        self, iv: UserIntervention,
+    ) -> "ChatSession | None":
+        """Hook for parent-agent delegation routing (issue #254 Phase 4).
+
+        Return a ChatSession to forward the request to a chain-upstream
+        agent; return ``None`` to fall through to user_channel delivery.
+
+        Default implementation returns ``None`` (= no parent resolution).
+        Phase 5+ will walk ``running_skills_chain`` to find the
+        originating agent and look it up via an agent-registry factory;
+        Phase 4 only establishes the routing branch.
+        """
+        return None
 
     def as_request_bus(self) -> "AgentRequestBus":
         """Return a ``RequestBus``-typed adapter for this ChatSession.

--- a/tests/test_intervention_agent_routing.py
+++ b/tests/test_intervention_agent_routing.py
@@ -1,0 +1,321 @@
+"""Tier 2: Agent routing logic for intervention requests (issue #254 Phase 4).
+
+Pins the 3-way routing decision the Agent makes in
+``ChatSession.handle_intervention(iv)``:
+
+  1. ``self_answer`` (= ``_try_self_answer`` hook returns non-None)
+  2. ``parent_agent.delegate`` (= ``_resolve_parent_agent`` hook returns
+     a ChatSession)
+  3. ``user_channel.deliver`` (= default, falls through to
+     ``_dispatch_intervention``)
+
+Phase 4 ships the routing **scaffold**: hooks return None by default,
+so all requests go to the user_channel branch (= behaviour parity with
+Phase 3). Subclasses override the hooks to enable per-kind / per-context
+policies — Phase 4 verifies the wire works, not specific policies.
+
+Each branch emits an ``intervention_routed`` event for observability;
+the Phase 4 sub-issue (= dispatched by tui-coder) will surface the
+event in the TUI events tab.
+
+No mocks. Real ChatSession + subclass overrides for the hook tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import AgentRequestBus, ChatSession
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+# ── 1. Hook methods exist with the canonical signatures ────────────────
+
+
+def test_try_self_answer_hook_exists() -> None:
+    """Tier 2: ChatSession exposes ``_try_self_answer(iv) -> Answer|None``
+    as the self-answer routing hook.
+    """
+    assert hasattr(ChatSession, "_try_self_answer")
+    assert inspect.iscoroutinefunction(ChatSession._try_self_answer)
+    sig = inspect.signature(ChatSession._try_self_answer)
+    assert list(sig.parameters.keys()) == ["self", "iv"]
+
+
+def test_resolve_parent_agent_hook_exists() -> None:
+    """Tier 2: ChatSession exposes ``_resolve_parent_agent(iv) -> ChatSession|None``
+    as the parent-delegate routing hook.
+
+    Synchronous (not async) — chain-walk lookups don't need to await.
+    """
+    assert hasattr(ChatSession, "_resolve_parent_agent")
+    assert not inspect.iscoroutinefunction(ChatSession._resolve_parent_agent)
+    sig = inspect.signature(ChatSession._resolve_parent_agent)
+    assert list(sig.parameters.keys()) == ["self", "iv"]
+
+
+def test_default_hooks_return_none() -> None:
+    """Tier 2: default implementations return None — Phase 4 ships pure
+    scaffold, no kind-specific policies enabled out-of-the-box.
+    """
+    session = ChatSession(agent_name="t")
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+
+    async def _check_self_answer() -> InterventionAnswer | None:
+        return await session._try_self_answer(iv)
+
+    assert asyncio.run(_check_self_answer()) is None
+    assert session._resolve_parent_agent(iv) is None
+
+
+# ── 2. Default routing — user_channel branch fires ─────────────────────
+
+
+def test_default_routing_fires_user_channel_branch(tmp_path: Path) -> None:
+    """Tier 2: with default hooks (= both return None), an unhandled
+    intervention falls through to ``_dispatch_intervention``.
+
+    The Phase 1 subscriber guard short-circuits when no listener is
+    registered, so the round-trip returns an empty answer — used here
+    to verify the branch was actually taken (= the answer's emptiness
+    is observable only if dispatch was reached).
+    """
+    session = ChatSession(agent_name="t")
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+
+    answer = asyncio.run(session.handle_intervention(iv))
+    # Phase 1 guard short-circuit reached → user_channel branch fired.
+    assert answer.text == ""
+    assert answer.choice_id is None
+
+
+def test_default_routing_emits_user_channel_event(tmp_path: Path) -> None:
+    """Tier 2: the user_channel branch emits ``intervention_routed`` with
+    ``route="user_channel"`` so observers (= TUI events tab, debug
+    traces, future routing-policy analysis) can see the decision.
+    """
+    session = ChatSession(agent_name="t")
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+
+    asyncio.run(session.handle_intervention(iv))
+
+    # session._chat_events is the EventLog used for chat-side events.
+    events = [
+        e for e in session._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert events, "intervention_routed event must fire on each handle_intervention call"
+    payload = events[-1]["data"]
+    assert payload["route"] == "user_channel"
+    assert payload["iv_kind"] == "ask_user"
+    assert payload["iv_id"] == iv.id
+
+
+# ── 3. self_answer branch — fires when _try_self_answer returns answer ──
+
+
+class _SelfAnsweringSession(ChatSession):
+    """Subclass that always self-answers with a fixed answer."""
+
+    async def _try_self_answer(self, iv: UserIntervention) -> InterventionAnswer | None:
+        return InterventionAnswer(text="self-policy", choice_id="self")
+
+
+def test_self_answer_branch_returns_directly_without_dispatch() -> None:
+    """Tier 2: when ``_try_self_answer`` returns a non-None answer, the
+    handler returns it immediately without invoking
+    ``_dispatch_intervention`` — the user surface is never touched.
+    """
+    session = _SelfAnsweringSession(agent_name="t")
+    iv = UserIntervention(kind="permission.shell", prompt="Run ls?")
+
+    answer = asyncio.run(session.handle_intervention(iv))
+    assert answer.text == "self-policy"
+    assert answer.choice_id == "self"
+
+    # And the registry queue must be untouched — no prompt was enqueued.
+    assert session._interventions.queued_count() == 0
+
+
+def test_self_answer_branch_emits_self_answer_event() -> None:
+    """Tier 2: the self_answer branch emits ``intervention_routed`` with
+    ``route="self_answer"``.
+    """
+    session = _SelfAnsweringSession(agent_name="t")
+    iv = UserIntervention(kind="permission.shell", prompt="Run ls?")
+
+    asyncio.run(session.handle_intervention(iv))
+
+    events = [
+        e for e in session._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert events
+    payload = events[-1]["data"]
+    assert payload["route"] == "self_answer"
+    assert payload["iv_kind"] == "permission.shell"
+
+
+# ── 4. parent_delegate branch — fires when _resolve_parent_agent
+#      returns a session ─────────────────────────────────────────────────
+
+
+class _DelegatingSession(ChatSession):
+    """Subclass that delegates all interventions to a designated parent
+    session. Used to verify the parent_delegate routing branch.
+    """
+
+    def set_parent(self, parent: ChatSession) -> None:
+        self._parent_session = parent
+
+    def _resolve_parent_agent(self, iv: UserIntervention) -> ChatSession | None:
+        return getattr(self, "_parent_session", None)
+
+
+def test_parent_delegate_branch_forwards_to_parent() -> None:
+    """Tier 2: when ``_resolve_parent_agent`` returns a parent session,
+    the handler forwards the intervention to ``parent.handle_intervention``
+    and returns the parent's decision verbatim.
+
+    Verified via a parent that self-answers — the chain is
+    child.handle_intervention → parent.handle_intervention →
+    parent._try_self_answer.
+    """
+    parent = _SelfAnsweringSession(agent_name="parent")
+    child = _DelegatingSession(agent_name="child")
+    child.set_parent(parent)
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    answer = asyncio.run(child.handle_intervention(iv))
+
+    # Parent self-answered, child received that answer back.
+    assert answer.text == "self-policy"
+    assert answer.choice_id == "self"
+
+
+def test_parent_delegate_branch_emits_parent_delegate_event() -> None:
+    """Tier 2: the parent_delegate branch on the child emits
+    ``intervention_routed`` with ``route="parent_delegate"`` BEFORE
+    forwarding. The parent's own routing decision generates a separate
+    event on the parent's chat_events log.
+    """
+    parent = _SelfAnsweringSession(agent_name="parent")
+    child = _DelegatingSession(agent_name="child")
+    child.set_parent(parent)
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    asyncio.run(child.handle_intervention(iv))
+
+    child_events = [
+        e for e in child._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert child_events
+    assert child_events[-1]["data"]["route"] == "parent_delegate"
+
+    parent_events = [
+        e for e in parent._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert parent_events
+    # Parent's self_answer hook fired on its own intervention_routed event.
+    assert parent_events[-1]["data"]["route"] == "self_answer"
+
+
+# ── 5. Branch precedence: self_answer > parent_delegate > user_channel ──
+
+
+class _SelfAndParentSession(_DelegatingSession):
+    """Subclass that BOTH self-answers AND has a parent. Used to verify
+    self_answer takes precedence (= the agent decides itself before
+    consulting upstream).
+    """
+
+    async def _try_self_answer(self, iv: UserIntervention) -> InterventionAnswer | None:
+        return InterventionAnswer(text="child-self", choice_id="child")
+
+
+def test_self_answer_takes_precedence_over_parent_delegate() -> None:
+    """Tier 2: when both hooks could fire, ``_try_self_answer`` runs
+    first — the agent decides itself rather than consulting upstream.
+    This encodes "the agent has its own will" per the Reyn peer-to-peer
+    design (issue #254 design discussion log).
+    """
+    parent = _SelfAnsweringSession(agent_name="parent")
+    child = _SelfAndParentSession(agent_name="child")
+    child.set_parent(parent)
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    answer = asyncio.run(child.handle_intervention(iv))
+
+    # Child self-answered, parent was never consulted.
+    assert answer.text == "child-self"
+    assert answer.choice_id == "child"
+
+    # And the parent's chat_events has NO intervention_routed event
+    # (= parent's handle_intervention was never invoked).
+    parent_events = [
+        e for e in parent._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert not parent_events
+
+
+# ── 6. Behaviour parity: existing dispatch path still works through
+#      the new routing scaffold ──────────────────────────────────────────
+
+
+def test_chain_override_still_works_through_user_channel_branch(tmp_path: Path) -> None:
+    """Tier 2: the A2A peer override registered via
+    ``register_intervention_override`` reaches the override bus through
+    the user_channel branch (= default, no hooks override). Phase 4
+    must not break this path.
+    """
+    session = ChatSession(agent_name="t")
+
+    captured: list[UserIntervention] = []
+
+    class _StubOverrideBus:
+        async def request(self, iv: UserIntervention) -> InterventionAnswer:
+            captured.append(iv)
+            return InterventionAnswer(text="from-override", choice_id=None)
+
+    session.register_intervention_override("chain-X", _StubOverrideBus())
+    session.running_skills_chain["run-1"] = "chain-X"
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?", run_id="run-1")
+    answer = asyncio.run(session.handle_intervention(iv))
+
+    assert answer.text == "from-override"
+    assert len(captured) == 1
+
+    # And the routing event records the user_channel branch fired
+    # (the chain-override resolution happens INSIDE _dispatch_intervention,
+    # which is reached via the user_channel branch).
+    events = [
+        e for e in session._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert events
+    assert events[-1]["data"]["route"] == "user_channel"
+
+
+# ── 7. RequestBus adapter — Phase 4 routing visible through the adapter ──
+
+
+def test_self_answer_visible_through_request_bus_adapter() -> None:
+    """Tier 2: an OS caller that holds the ``RequestBus`` adapter sees
+    the self_answer policy fire — the adapter is fully transparent to
+    the routing decision happening behind it.
+    """
+    session = _SelfAnsweringSession(agent_name="t")
+    bus = session.as_request_bus()
+    assert isinstance(bus, AgentRequestBus)
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    answer = asyncio.run(bus.request(iv))
+
+    assert answer.text == "self-policy"
+    assert answer.choice_id == "self"


### PR DESCRIPTION
**[e2e-coder]** — Phase 4 of #254.

Refs #254. Depends on PR #255 (Phase 1), PR #258 (Phase 2), PR #259 (Phase 3) — all merged.

## What this PR does

Fills in the Agent-layer routing **scaffold** introduced as a forward-only delegate in Phase 3. `ChatSession.handle_intervention` now makes a 3-way decision on each incoming intervention request:

```python
async def handle_intervention(self, iv):
    # 1. self_answer policy
    self_ans = await self._try_self_answer(iv)
    if self_ans is not None:
        self._chat_events.emit("intervention_routed", route="self_answer", ...)
        return self_ans

    # 2. parent-agent delegation
    parent = self._resolve_parent_agent(iv)
    if parent is not None:
        self._chat_events.emit("intervention_routed", route="parent_delegate", ...)
        return await parent.handle_intervention(iv)

    # 3. user_channel (default) — existing dispatch path
    self._chat_events.emit("intervention_routed", route="user_channel", ...)
    return await self._dispatch_intervention(iv)
```

## Conservative scope (= owner-decision waiver)

Per lead-coder's Phase 4 owner-decision guidance:

> **Phase 4 routing policy**: 「per-kind policy で `self_answer` 可能性」 は Reyn agent 思想の発露として valuable だが、 **初期 conservative (= 全 kind を `user_channel.deliver` に通すだけ) で behavior parity 確保**、 self_answer expansion は phase 4 完了後 別 PR で incremental

→ Both hooks return None by default. Behaviour is **identical to Phase 3** for unmodified agents. The 3-branch shape is in place; subclasses / future config-driven policy injection enable specific per-kind policies in follow-up PRs.

## Observability hook (= consumed by Phase 4 sub-issue)

Each branch emits `intervention_routed` with `route` / `iv_kind` / `iv_id`. This is the event the **Phase 4 sub-issue** (tui-coder dispatched from #254 design alignment) will surface in the TUI events tab + intervention widget source-agent label.

Filing the sub-issue is part of Phase 4 post-merge follow-up (= per tui-coder commitment).

## "The agent has its own will" — branch precedence pin

Pre-checked branch order = `self_answer` → `parent_delegate` → `user_channel`. The agent decides before consulting upstream, mirroring the Reyn peer-to-peer encoding from the issue #254 design discussion (= "agent が問い合わせるかどうかという意思を持つ").

Pinned by `test_self_answer_takes_precedence_over_parent_delegate` (= a child session with both hooks enabled self-answers without ever invoking the parent's handle_intervention).

## Hook surface

```python
async def _try_self_answer(self, iv) -> InterventionAnswer | None:
    """Default: None (= no self-answer policy)."""
    return None

def _resolve_parent_agent(self, iv) -> ChatSession | None:
    """Default: None (= no parent resolution).
    Phase 5+ will walk running_skills_chain to find chain origin."""
    return None
```

Subclasses override these to encode policies. Examples (NOT in this PR, listed for design clarity):

- `_try_self_answer` for `permission.shell` when the command is in an always-allow set → return `InterventionAnswer(choice_id="always")` without prompting
- `_try_self_answer` for `safety.limit.max_phase_visits` when we've auto-extended 5 times this chain → return `InterventionAnswer(text="no")` to short-circuit infinite extension loops
- `_resolve_parent_agent` for sub-agent runs spawned via `delegate_to_agent` → return the originating agent so user-facing prompts surface in the right TUI

## Phase 4 contract test coverage (12 tests, `tests/test_intervention_agent_routing.py`)

| # | Test | Pins |
|---|---|---|
| 1 | `test_try_self_answer_hook_exists` | hook signature `(iv) -> Answer\|None`, async |
| 2 | `test_resolve_parent_agent_hook_exists` | hook signature `(iv) -> ChatSession\|None`, sync |
| 3 | `test_default_hooks_return_none` | scaffold ships pure no-op default |
| 4 | `test_default_routing_fires_user_channel_branch` | default = user_channel branch (via Phase 1 short-circuit) |
| 5 | `test_default_routing_emits_user_channel_event` | event payload shape |
| 6 | `test_self_answer_branch_returns_directly_without_dispatch` | self_answer bypasses _dispatch_intervention + registry |
| 7 | `test_self_answer_branch_emits_self_answer_event` | event payload shape on self_answer branch |
| 8 | `test_parent_delegate_branch_forwards_to_parent` | parent_delegate invokes `parent.handle_intervention` |
| 9 | `test_parent_delegate_branch_emits_parent_delegate_event` | both child and parent emit their own routing events |
| 10 | `test_self_answer_takes_precedence_over_parent_delegate` | **"agent has its own will"** precedence |
| 11 | `test_chain_override_still_works_through_user_channel_branch` | A2A peer override path preserved |
| 12 | `test_self_answer_visible_through_request_bus_adapter` | end-to-end via AgentRequestBus |

## Files touched

| File | Δ | Notes |
|---|---|---|
| `src/reyn/chat/session.py` | +99 / -16 | Replace Phase 3's forward-only handle_intervention with the 3-branch routing decision. Add `_try_self_answer` and `_resolve_parent_agent` hooks (default None). |
| `tests/test_intervention_agent_routing.py` | +316 | New, 12 Tier 2 tests + subclass test helpers |

## Test plan

- [x] **Automated — `pytest tests/test_intervention_agent_routing.py`**: 12/12 pass。
- [x] **Adjacent — `pytest tests/test_intervention_agent_subscriber.py tests/test_intervention_subscriber_guard.py tests/test_intervention_bus_protocols.py tests/test_intervention_resume_e2e.py tests/test_session_intervention_persistence.py tests/test_intervention_restore.py tests/test_durable_answer_buffer.py tests/test_fp0001_session_override.py tests/test_session_invariants.py tests/test_chat_router_i18n.py`** (= Phase 1-3 contract + all session-intervention tests): full pass。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --ignore=tests/test_a2a_sync_async_escalation.py --timeout=30`**: 3978 passed, 11 skipped, 3 xfailed in 143s。 (`test_a2a_sync_async_escalation.py` の skip は PR #253 由来 fastapi env gap で本 PR 起因ではない)
- [x] **Lint — `ruff check`**: clean on both touched files。
- [ ] **Manual — TUI / a2a で intervention prompt が今まで通り user に届くこと**: Phase 4 default routes everything to user_channel branch (= behaviour parity with Phase 3 confirmed by test #11). tui-coder の念のための smoke check は valuable。

## Phase 5 への bridge + Phase 4 sub-issue

**Phase 5 (final cleanup)** scope (= next/last):
- Remove legacy `InterventionBus` alias from `__all__` (deprecation cycle)
- Migrate OS callers to import `RequestBus` directly
- Documentation pass: `docs/concepts/` / `docs/reference/` reflect new layer split

**Phase 4 TUI sub-issue** (= tui-coder commitment from #254 alignment):
- Surface `intervention_routed` event in TUI events tab
- Add `source_agent` to `OutboxMessage.meta` when parent_delegate path fires
- Intervention widget source-agent label

I'll file the sub-issue after this PR merges, with the `[e2e-coder]` body prefix and "Phase 4 → TUI surface split" label so tui-coder can pick it up via broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)