### PR TITLE
feat(tui/intervention): source-agent threading + events tab routed render (closes #261)

### DIFF
--- a/src/reyn/chat/services/intervention_handler.py
+++ b/src/reyn/chat/services/intervention_handler.py
@@ -17,6 +17,7 @@ Design constraints (same pattern as other Wave 1/1b services):
 from __future__ import annotations
 
 import logging
+from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -33,6 +34,31 @@ if TYPE_CHECKING:
     from reyn.events.events import EventLog
 
 logger = logging.getLogger(__name__)
+
+
+# Issue #261 / #254 Phase 4 follow-up — source-agent threading.
+#
+# When ``ChatSession.handle_intervention`` takes the ``parent_delegate``
+# branch, it sets this var to the name of the agent that decided to
+# delegate (= the *upstream* / source agent, i.e. the recipient who
+# couldn't answer locally and forwarded to its parent). The downstream
+# ``user_channel.deliver`` path then reads the var inside ``_iv_meta``
+# and stamps ``meta["source_agent"]`` on the outbox message.
+#
+# Multi-hop chains (A → B → C): each ``parent_delegate`` overwrites the
+# var with the immediate delegator, so when C eventually reaches
+# ``user_channel``, ``meta["source_agent"]`` reflects B (= the direct
+# parent of C in the chain). This matches the "immediate parent only"
+# semantics noted in issue #261's "Out of scope" — multi-hop
+# breadcrumbs would be a separate feature.
+#
+# Default value is ``None`` (= no delegation chain). When ``None``, the
+# meta builder omits the ``source_agent`` key entirely, preserving the
+# Phase 2 outbox-meta-shape commitment for non-delegated paths
+# (``test_outbox_intervention_meta_shape_is_stable`` still passes).
+source_agent_var: ContextVar[str | None] = ContextVar(
+    "source_agent", default=None,
+)
 
 
 def _now_iso() -> str:
@@ -71,6 +97,13 @@ def _iv_meta(iv: UserIntervention) -> dict:
         ]
     if iv.suggestions:
         out["suggestions"] = list(iv.suggestions)
+    # Issue #261 — source_agent stamping for the parent_delegate branch.
+    # See ``source_agent_var`` module docstring above for the chain
+    # semantics. Omitted when the var is at its default (``None``) so
+    # the meta shape stays identical to the non-delegated path.
+    src = source_agent_var.get()
+    if src:
+        out["source_agent"] = src
     return out
 
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -401,6 +401,16 @@ def _iv_meta(iv: "UserIntervention") -> dict:
         ]
     if iv.suggestions:
         out["suggestions"] = list(iv.suggestions)
+    # Issue #261 — source_agent stamping for the parent_delegate branch.
+    # See ``source_agent_var`` in ``services/intervention_handler.py``
+    # for the chain semantics. Omitted when the var is at its default
+    # (``None``) so the meta shape stays identical to the non-delegated
+    # path (Phase 2 ``test_outbox_intervention_meta_shape_is_stable``
+    # contract).
+    from reyn.chat.services.intervention_handler import source_agent_var
+    src = source_agent_var.get()
+    if src:
+        out["source_agent"] = src
     return out
 
 
@@ -1951,7 +1961,21 @@ class ChatSession:
                 iv_kind=iv.kind,
                 iv_id=iv.id,
             )
-            return await parent.handle_intervention(iv)
+            # Issue #261 — stamp this agent as the source of the
+            # delegation so the parent's downstream ``user_channel``
+            # path can surface it on the outbox meta. Token-based
+            # set/reset preserves any outer-scope value (= multi-hop
+            # chains overwrite the immediate parent on each hop, then
+            # restore on return so the original caller's view is
+            # unchanged).
+            from reyn.chat.services.intervention_handler import (
+                source_agent_var,
+            )
+            token = source_agent_var.set(self.agent_name)
+            try:
+                return await parent.handle_intervention(iv)
+            finally:
+                source_agent_var.reset(token)
 
         # Branch 3: default — deliver to user via existing dispatch path.
         self._chat_events.emit(

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -270,6 +270,7 @@ class ReynTUIApp(App):
         choices: list[tuple[str, str] | dict] | None = None,
         queued_extra: int = 0,
         detail: str | None = None,
+        source_agent: str | None = None,
     ) -> None:
         """Mount an InterventionWidget inline in the conversation view.
 
@@ -298,6 +299,7 @@ class ReynTUIApp(App):
             iv_id=iv_id,
             queued_extra=queued_extra,
             detail=detail,
+            source_agent=source_agent,
         )
 
     def set_title_state(self, state: str | None) -> None:

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -466,6 +466,11 @@ class OutboxRouter:
         # compat for the CLI Panel path and any legacy producers.
         question_text = str(msg.meta.get("prompt") or msg.text)
         detail_text = msg.meta.get("detail")
+        # Issue #261 — opt-in source_agent stamped by ChatSession's
+        # parent_delegate branch (see services/intervention_handler.py
+        # ``source_agent_var``). Absent on the default user_channel
+        # path, so the existing non-delegated flow is unaffected.
+        source_agent = msg.meta.get("source_agent")
         self._app._mount_intervention(
             conv,
             question_text,
@@ -473,6 +478,7 @@ class OutboxRouter:
             choices,
             queued_extra=queued_extra,
             detail=str(detail_text) if detail_text else None,
+            source_agent=str(source_agent) if source_agent else None,
         )
         # Persistent "blocked on user" indicator. The InterventionWidget is
         # mounted inline and can scroll off-screen in a long session; the

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -903,6 +903,7 @@ class ConversationView(Widget):
         iv_id: str = "",
         queued_extra: int = 0,
         detail: str | None = None,
+        source_agent: str | None = None,
     ) -> InterventionWidget:
         self._consume_empty_hint()
         # The run is now blocked on the user's answer; "thinking…" is no
@@ -926,6 +927,7 @@ class ConversationView(Widget):
             iv_id=iv_id,
             queued_extra=queued_extra,
             detail=detail,
+            source_agent=source_agent,
         )
         self.mount(widget)
         # Only yank the user down to the new widget when they were

--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -104,6 +104,14 @@ class InterventionWidget(Widget):
         height: auto;
         width: 1fr;
     }
+    InterventionWidget Label.iv-source-agent {
+        /* Issue #261: parent-delegation breadcrumb. Dim, no italic — the
+           prompt itself is the load-bearing line; this is context. */
+        color: #888888;
+        text-style: dim;
+        height: auto;
+        width: 1fr;
+    }
     """
 
     class Answered(Message):
@@ -122,6 +130,7 @@ class InterventionWidget(Widget):
         iv_id: str = "",
         queued_extra: int = 0,
         detail: str | None = None,
+        source_agent: str | None = None,
         id: str | None = None,
     ) -> None:
         super().__init__(id=id or f"iv_{iv_id[:8]}")
@@ -131,6 +140,14 @@ class InterventionWidget(Widget):
         # None / empty skips the Label entirely so old callers that
         # don't supply detail keep the prior single-line layout.
         self._detail = detail
+        # Issue #261: when the ``parent_delegate`` branch fires on an
+        # upstream agent, the OutboxMessage carries ``source_agent``
+        # naming that agent. Render as ``[parent: <name>]`` above the
+        # prompt so the user can tell "this question came down from a
+        # parent agent" vs "the attached agent asked directly". Omitted
+        # entirely when None (= no delegation chain), matching the
+        # outbox meta opt-in shape.
+        self._source_agent = source_agent
         # Normalise both legacy 2-tuples and richer dict shapes into a single
         # internal list-of-dicts so compose() / hotkey lookup stays uniform.
         self._choices: list[dict[str, Any]] = [
@@ -188,6 +205,15 @@ class InterventionWidget(Widget):
         # visible. Default markup parsing treats them as unknown style
         # tags and silently strips them — chip labels were rendering as
         # "es", "lways", "o", "ever" with no hotkey hint.
+        if self._source_agent:
+            # Issue #261: source-agent badge for delegated prompts. Dim
+            # so the eye lands on the question first; the badge is
+            # context, not the prompt itself.
+            yield Label(
+                f"  [parent: {self._source_agent}]",
+                classes="iv-source-agent",
+                markup=False,
+            )
         yield Label(
             f"  {self._question}", classes="iv-question", markup=False,
         )

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -65,6 +65,10 @@ _EVENT_COLORS: dict[str, str] = {
     "chat_stopped":                "#dddddd",
     "user_intervention_requested": "#ffcc88",
     "user_intervention_received":  "#ffcc88",
+    # Issue #261 — routing-decision event family (amber sibling so
+    # delegation / self-answer audit trail reads as same UX category
+    # as the user_intervention_* pair).
+    "intervention_routed":         "#ffcc88",
     "postprocessor_step_failed":    "#ff6644",
     "tool_executed":               "#cc88ff",
     "web_fetch_started":           "#888888",
@@ -171,6 +175,7 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
     ("user", frozenset({
         "user_message_received",
         "user_intervention_requested", "user_intervention_received",
+        "intervention_routed",  # issue #261 — routing decisions
         "chat_started", "chat_stopped",
     })),
     # Internal routing / housekeeping events — useful for debugging multi-agent
@@ -262,6 +267,16 @@ def _event_hint(ev: dict) -> str:
         return str(d.get("question", ""))[:40]
     if t == "user_intervention_received":
         return str(d.get("answer", ""))[:40]
+    if t == "intervention_routed":
+        # Issue #261: surface the Phase 4 routing decision. Format
+        # ``<route> <iv_kind> [<iv_id>]`` — short enough to fit the
+        # events tab's narrow column, distinct enough to debug
+        # "why did this prompt go self_answer instead of user_channel"
+        # in a follow-up routing-policy expansion.
+        route = str(d.get("route", "?"))
+        iv_kind = str(d.get("iv_kind", "?"))
+        iv_id_short = str(d.get("iv_id", ""))[:8]
+        return f"{route} {iv_kind} [{iv_id_short}]"
     if t in ("sandboxed_exec_started", "sandboxed_exec_completed"):
         argv = d.get("argv") or []
         cmd = " ".join(str(a) for a in argv[:3])

--- a/tests/cli/test_intervention_routed_render.py
+++ b/tests/cli/test_intervention_routed_render.py
@@ -1,0 +1,85 @@
+"""Tier 2: events tab renders ``intervention_routed`` events with route + kind + iv_id.
+
+Issue #261 — Phase 4 emits ``intervention_routed`` from
+``ChatSession.handle_intervention``'s three branches (self_answer /
+parent_delegate / user_channel). The events tab surfaces those as
+one-line entries so the user can audit routing decisions.
+
+This test pins the public ``_event_hint`` formatter (= the function
+``render_events`` consumes for each event row).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.right_panel.events_tab import (
+    _EVENT_COLORS,
+    _FILTER_GROUPS,
+    _event_hint,
+)
+
+
+def _event(route: str, kind: str, iv_id: str) -> dict:
+    return {
+        "type": "intervention_routed",
+        "data": {"route": route, "iv_kind": kind, "iv_id": iv_id},
+    }
+
+
+def test_event_hint_renders_route_kind_short_id() -> None:
+    """Tier 2: hint string includes route, iv_kind, and short iv_id."""
+    hint = _event_hint(_event("user_channel", "ask_user", "iv-abcd1234"))
+    assert "user_channel" in hint
+    assert "ask_user" in hint
+    # Short-form iv_id (first 8 chars) appears in brackets.
+    assert "iv-abcd1" in hint
+
+
+def test_event_hint_handles_each_route_branch() -> None:
+    """Tier 2: all 3 Phase 4 routes render distinct hints (no fallthrough)."""
+    seen: set[str] = set()
+    for route in ("self_answer", "parent_delegate", "user_channel"):
+        hint = _event_hint(_event(route, "ask_user", "iv-1"))
+        assert route in hint, (
+            f"hint must include route name {route!r}; got {hint!r}"
+        )
+        seen.add(hint)
+    # All 3 produce distinct hints (= same iv_id / kind, route differs).
+    assert len(seen) == 3
+
+
+def test_event_hint_handles_missing_fields_safely() -> None:
+    """Tier 2: missing route / iv_kind / iv_id don't raise; use ``?`` fallback."""
+    hint = _event_hint({"type": "intervention_routed", "data": {}})
+    # ``?`` placeholders are present for route and iv_kind.
+    assert "?" in hint
+
+
+def test_event_color_registered_for_intervention_routed() -> None:
+    """Tier 2: color palette includes ``intervention_routed`` (= rendered, not
+    fallthrough-grey).
+
+    Defends against a refactor that adds the formatter but forgets the
+    color entry — the event would still render but with the default
+    dim grey, hiding it visually next to the colourful neighbours.
+    """
+    assert "intervention_routed" in _EVENT_COLORS
+    # Same amber family as the existing user_intervention_* pair (= UX
+    # consistency — all "user gate" events share a colour).
+    assert _EVENT_COLORS["intervention_routed"] == _EVENT_COLORS[
+        "user_intervention_requested"
+    ]
+
+
+def test_filter_user_group_includes_intervention_routed() -> None:
+    """Tier 2: the ``user`` filter group covers the new event type so a
+    user filtering for human-touchpoint events sees routing decisions
+    alongside intervention requests / receipts.
+    """
+    user_group = next(s for label, s in _FILTER_GROUPS if label == "user")
+    assert "intervention_routed" in user_group

--- a/tests/cli/test_intervention_widget_source_agent.py
+++ b/tests/cli/test_intervention_widget_source_agent.py
@@ -1,0 +1,127 @@
+"""Tier 2: InterventionWidget renders source-agent badge when provided.
+
+Issue #261 — when the outbox meta carries ``source_agent`` (= the
+``parent_delegate`` branch fired upstream), the widget surfaces it as
+a ``[parent: <name>]`` line so the user can tell a prompt arrived via
+delegation rather than from the locally-attached agent.
+
+When ``source_agent=None`` (= default, non-delegated path), the badge
+is omitted entirely — keeping the prior layout untouched for the
+common case.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.widgets import Label
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_widget_omits_source_agent_label_by_default() -> None:
+    """Tier 2: no ``source_agent`` → no parent badge in the widget DOM."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_intervention(
+            question="Continue?", choices=None, iv_id="iv-1",
+        )
+        await pilot.pause()
+
+        # No Label with class iv-source-agent should be present in the
+        # mounted widget tree.
+        labels = list(app.query("Label.iv-source-agent"))
+        assert labels == [], (
+            f"no source-agent labels expected when source_agent=None; "
+            f"got {len(labels)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_widget_renders_source_agent_label_when_provided() -> None:
+    """Tier 2: source_agent="planner" → "[parent: planner]" label rendered."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_intervention(
+            question="Continue?",
+            choices=None,
+            iv_id="iv-2",
+            source_agent="planner",
+        )
+        await pilot.pause()
+
+        labels = list(app.query("Label.iv-source-agent"))
+        assert len(labels) == 1, (
+            f"expected exactly 1 source-agent label; got {len(labels)}"
+        )
+        text = str(labels[0].render())
+        assert "parent: planner" in text, (
+            f"label must read '[parent: planner]'; got {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_widget_source_agent_label_precedes_question() -> None:
+    """Tier 2: badge renders BEFORE the question label (= header position).
+
+    Order matters for the visual hierarchy: the user should read the
+    delegation breadcrumb first, then the question itself — analogous
+    to how email shows the "From:" header above the body.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_intervention(
+            question="Continue?",
+            choices=None,
+            iv_id="iv-3",
+            source_agent="planner",
+        )
+        await pilot.pause()
+
+        widget = app.query_one(f"#iv_{'iv-3'[:8]}")
+        # Walk the widget's children in compose order. The
+        # iv-source-agent label must appear before the iv-question label.
+        labels = [
+            c for c in widget.walk_children()
+            if isinstance(c, Label)
+        ]
+        src_idx = next(
+            (i for i, lab in enumerate(labels)
+             if "iv-source-agent" in lab.classes),
+            -1,
+        )
+        q_idx = next(
+            (i for i, lab in enumerate(labels)
+             if "iv-question" in lab.classes),
+            -1,
+        )
+        assert src_idx >= 0 and q_idx >= 0, (
+            f"both labels expected; src={src_idx} q={q_idx} "
+            f"labels={[(i, list(l.classes)) for i, l in enumerate(labels)]!r}"
+        )
+        assert src_idx < q_idx, (
+            f"source-agent label must precede question label in "
+            f"compose order; src={src_idx} q={q_idx}"
+        )

--- a/tests/test_intervention_source_agent.py
+++ b/tests/test_intervention_source_agent.py
@@ -1,0 +1,101 @@
+"""Tier 2: ``OutboxMessage(kind="intervention").meta["source_agent"]`` opt-in.
+
+Phase 4 follow-up (issue #261) — when ``ChatSession.handle_intervention``
+takes the ``parent_delegate`` branch, the downstream ``user_channel``
+emit must stamp ``meta["source_agent"]`` with the delegating agent's
+name so the TUI can render a ``[parent: <name>]`` badge.
+
+Phase 2 commitment (issue #254 alignment, `test_outbox_intervention_
+meta_shape_is_stable`) must still pass — ``source_agent`` is **opt-in**:
+the key is omitted from meta when the delegation branch did not fire.
+
+This test drives ``_iv_meta`` directly with the ``source_agent_var``
+ContextVar set / unset, pinning the meta shape contract without
+needing to spin up the full Phase 4 routing flow (= multi-session
+agent factory, parent resolution policy, etc. — those are exercised
+by ``test_intervention_agent_routing.py``).
+"""
+from __future__ import annotations
+
+import sys
+from contextvars import copy_context
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.services.intervention_handler import (
+    _iv_meta,
+    source_agent_var,
+)
+from reyn.user_intervention import UserIntervention
+
+
+def test_iv_meta_omits_source_agent_when_var_is_default() -> None:
+    """Tier 2: default (no delegation) → ``source_agent`` key not in meta."""
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    meta = _iv_meta(iv)
+    assert "source_agent" not in meta, (
+        f"source_agent must be omitted by default; got {meta!r}"
+    )
+
+
+def test_iv_meta_stamps_source_agent_when_var_is_set() -> None:
+    """Tier 2: ``source_agent_var`` set → meta["source_agent"] == that value.
+
+    Drive the test in a child context so the var change doesn't leak
+    to sibling tests.
+    """
+    def _within_ctx() -> dict:
+        source_agent_var.set("agent-A")
+        return _iv_meta(UserIntervention(kind="ask_user", prompt="Q?"))
+
+    ctx = copy_context()
+    meta = ctx.run(_within_ctx)
+    assert meta.get("source_agent") == "agent-A", (
+        f"source_agent must be stamped when var is set; got {meta!r}"
+    )
+
+
+def test_iv_meta_does_not_leak_var_across_contexts() -> None:
+    """Tier 2: setting the var in one context does NOT bleed to another.
+
+    Defends against a regression that uses module-level state instead
+    of ContextVar (= concurrent sessions / interleaved tests would
+    cross-contaminate).
+    """
+    def _set_in_ctx() -> None:
+        source_agent_var.set("agent-A")
+
+    set_ctx = copy_context()
+    set_ctx.run(_set_in_ctx)
+
+    # Back on the outer context — var should still be at default.
+    assert source_agent_var.get() is None, (
+        f"var must not leak from child context; got {source_agent_var.get()!r}"
+    )
+
+    meta = _iv_meta(UserIntervention(kind="ask_user", prompt="Q?"))
+    assert "source_agent" not in meta
+
+
+def test_phase2_meta_shape_invariant_preserved_when_no_source_agent() -> None:
+    """Tier 2: Phase 2 commitment — meta key set without ``source_agent``
+    is unchanged from the pre-#261 shape.
+
+    Pin the required-key set so a future refactor that turns
+    ``source_agent`` into a required key (= regression) fails here.
+    Mirrors ``test_outbox_intervention_meta_shape_is_stable`` in
+    ``test_intervention_bus_protocols.py`` for the source_agent
+    specific axis.
+    """
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    meta = _iv_meta(iv)
+    required = {"intervention_id", "intervention_kind", "prompt"}
+    assert required.issubset(set(meta.keys())), (
+        f"required Phase 2 keys missing; got {set(meta.keys())!r}"
+    )
+    # And the optional source_agent key is NOT present on the
+    # default path.
+    assert "source_agent" not in meta


### PR DESCRIPTION
**[tui-coder]** —

Closes #261 — three-piece TUI surface for the Phase 4 routing decision \`ChatSession.handle_intervention\` already makes (self_answer / parent_delegate / user_channel, PR #260).

## 1. \`source_agent\` ContextVar threading (opt-in meta key)

New \`source_agent_var: ContextVar[str | None]\` in \`chat/services/intervention_handler.py\`. \`handle_intervention\`'s \`parent_delegate\` branch sets it to \`self.agent_name\` before the recursive \`parent.handle_intervention(iv)\` call, with token-based reset so multi-hop chains preserve outer-scope semantics and non-delegated callers see no behavioural change.

Both \`_iv_meta()\` helpers (session.py + intervention_handler.py — kept in sync by hand) read the var and stamp \`meta["source_agent"]\` only when non-None. Phase 2 commitment (\`test_outbox_intervention_meta_shape_is_stable\`) holds because the key is omitted on the default path.

## 2. Events tab — \`intervention_routed\` row formatter

\`_event_hint\` formats the event as \`<route> <iv_kind> [<iv_id_short>]\`. Added to the \`user\` filter group + amber colour family (\`#ffcc88\`, same as \`user_intervention_*\` siblings).

## 3. InterventionWidget — source-agent badge

New \`source_agent\` ctor kwarg threaded through \`mount_intervention\` and \`_mount_intervention\`. Renders a dim \`[parent: <name>]\` label above the question when set; omitted when \`None\`. New CSS class \`Label.iv-source-agent\` (dim, no italic) so the badge reads as context, not a competing focus point.

## Why cross-layer

The dispatch issue #261 explicitly bundles the OS-side stamp + 2 TUI-side renders, since piece (1) is the upstream-side enabler for (3) — separating into 2 PRs would land a TUI consumer for a meta key that doesn't exist yet. Cross-layer touch is scoped to one ContextVar + 2 mirrored \`_iv_meta\` updates; no schema / event-emit / outbox-routing change.

## Test plan

- [x] **Tier 2 contract — meta opt-in** (\`tests/test_intervention_source_agent.py\`, 4 cases):
  - default (no delegation) → \`source_agent\` key absent
  - var set → meta carries the stamped value
  - ContextVar isolation across copy_context (= no cross-test leak)
  - Phase 2 required-key invariant preserved
- [x] **Tier 2 contract — events tab render** (\`tests/cli/test_intervention_routed_render.py\`, 5 cases):
  - hint includes route + iv_kind + iv_id_short
  - all 3 routes produce distinct hints
  - missing-field safe fallback
  - color registered (= matches \`user_intervention_*\`)
  - included in \`user\` filter group
- [x] **Tier 2 contract — widget render** (\`tests/cli/test_intervention_widget_source_agent.py\`, 3 cases):
  - default → no \`iv-source-agent\` label in DOM
  - source_agent set → exactly 1 label rendered with \`[parent: <name>]\`
  - badge precedes the question label in compose order
- [x] **Existing tests** — 288 intervention-touching + 3975 broad regression pass.
- [x] **Phase 2 commitment** — \`test_outbox_intervention_meta_shape_is_stable\` (PR #258) continues to pass — \`source_agent\` is an optional addition, not a required-key change.

## Out of scope (per #261)

- Routing policy expansions (= actual \`_try_self_answer\` / \`_resolve_parent_agent\` overrides for specific kinds) land as follow-up PRs from e2e-coder / dogfood-coder.
- WAL persistence for \`intervention_routed\` is a separate decision.
- Multi-hop chain breadcrumbs (= "from grandparent C → parent B → me") — current impl stamps the immediate parent only, per #261's stated phase-1 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)