### PR TITLE
refactor(intervention): migrate OS callers to RequestBus + deprecate InterventionBus alias (Phase 5 of #254)

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -870,7 +870,7 @@ self_improvement:
 
 | フィールド | 型 | デフォルト | 説明 |
 |-------|------|---------|-------------|
-| `on_propose` | 文字列 | `ask_user` | 改善を適用しようとする際の動作。`ask_user` — InterventionBus 経由でユーザーに確認（安全なデフォルト）。`auto` — プロンプトをスキップして直接適用（CI / 無人実行向け）。`disabled` — `skill_improvement_dry_run` イベントをログに記録し変更を適用しない。 |
+| `on_propose` | 文字列 | `ask_user` | 改善を適用しようとする際の動作。`ask_user` — intervention `RequestBus` 経由でユーザーに確認（安全なデフォルト）。`auto` — プロンプトをスキップして直接適用（CI / 無人実行向け）。`disabled` — `skill_improvement_dry_run` イベントをログに記録し変更を適用しない。 |
 | `max_versions` | int | `10` | `.reyn/skill-versions/<name>/` に保持する `v<N>.md` スナップショットの上限。上限を超えると最古バージョンが削除されます（current バージョンは削除されません）。`0` でプルーニングを無効化。 |
 
 ## `python` ブロック

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -888,7 +888,7 @@ self_improvement:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `on_propose` | string | `ask_user` | What `skill_improver` does when about to apply improvements. `ask_user` — pause and prompt the user via the InterventionBus (safe default). `auto` — skip the prompt and apply directly (for CI / unattended runs). `disabled` — log a `skill_improvement_dry_run` event and do NOT apply changes. |
+| `on_propose` | string | `ask_user` | What `skill_improver` does when about to apply improvements. `ask_user` — pause and prompt the user via the intervention `RequestBus` (safe default). `auto` — skip the prompt and apply directly (for CI / unattended runs). `disabled` — log a `skill_improvement_dry_run` event and do NOT apply changes. |
 | `max_versions` | int | `10` | Maximum `v<N>.md` snapshots kept under `.reyn/skill-versions/<name>/`. Oldest version is deleted when the cap is exceeded (the current version is never deleted). `0` = disable pruning. |
 
 ## `python` block

--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -16,7 +16,7 @@ from reyn.kernel.runtime import OSRuntime, RunResult
 from reyn.llm.model_resolver import ModelResolver
 from reyn.permissions.permissions import PermissionResolver
 from reyn.schemas.models import Skill
-from reyn.user_intervention import InterventionBus
+from reyn.user_intervention import RequestBus
 
 if TYPE_CHECKING:
     from reyn.events.state_log import StateLog
@@ -41,7 +41,7 @@ class Agent:
         model: str,
         strict: bool = False,
         subscribers: list[Callable] | None = None,
-        intervention_bus: InterventionBus | None = None,
+        intervention_bus: RequestBus | None = None,
         shell_allowed: bool = False,
         resolver: ModelResolver | None = None,
         permission_resolver: PermissionResolver | None = None,

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -64,8 +64,8 @@ from reyn.skill.skill_paths import SkillNotFoundError, resolve_skill_path, stdli
 from reyn.skill.skill_registry import SkillRegistry
 from reyn.user_intervention import (
     InterventionAnswer,
-    InterventionBus,
     InterventionChoice,
+    RequestBus,
     UserIntervention,
 )
 
@@ -1011,7 +1011,7 @@ class ChatSession:
         # Allows A2A async-mode tasks to redirect ask_user prompts to
         # their RunRegistry-backed A2AInterventionBus while the agent's
         # default ChatInterventionBus continues to serve chat-mode interactions.
-        self._intervention_overrides: dict[str, "InterventionBus"] = {}
+        self._intervention_overrides: dict[str, "RequestBus"] = {}
 
         self._a2a_handler = A2AHandler(
             event_log=self._chat_events,
@@ -1608,7 +1608,7 @@ class ChatSession:
     def _build_agent(
         self,
         *,
-        intervention_bus: InterventionBus | None = None,
+        intervention_bus: RequestBus | None = None,
         mcp_servers: dict | None = None,
         subscribers: list | None = None,
     ) -> Agent:
@@ -1844,10 +1844,17 @@ class ChatSession:
         """Thin wrapper → InterventionHandler.announce."""
         await self._intervention_handler.announce(iv)
 
-    def register_intervention_override(self, chain_id: str, bus: "InterventionBus") -> None:
-        """Register an InterventionBus for ask_user prompts emitted by
+    def register_intervention_override(self, chain_id: str, bus: "RequestBus") -> None:
+        """Register a ``RequestBus`` for ask_user prompts emitted by
         skills spawned under this chain_id. Caller must pair with
-        unregister_intervention_override in a try/finally."""
+        ``unregister_intervention_override`` in a try/finally.
+
+        Issue #254 Phase 5: parameter type tightened from the legacy
+        ``InterventionBus`` alias to the canonical ``RequestBus`` name —
+        functionally identical since the alias points at the same
+        Protocol, but the type hint now reflects the OS↔Agent contract
+        layer the override participates in.
+        """
         self._intervention_overrides[chain_id] = bus
 
     def unregister_intervention_override(self, chain_id: str) -> None:

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -33,7 +33,7 @@ from reyn.schemas.models import (
     ControlIROp,
     ControlIROpSpec,
 )
-from reyn.user_intervention import InterventionBus
+from reyn.user_intervention import RequestBus
 from reyn.workspace.workspace import Workspace
 
 
@@ -76,7 +76,7 @@ class ControlIRExecutor:
         self,
         workspace: Workspace,
         events: EventLog,
-        intervention_bus: InterventionBus | None = None,
+        intervention_bus: RequestBus | None = None,
         shell_allowed: bool = False,
         resolver: ModelResolver | None = None,
         permission_resolver: PermissionResolver | None = None,

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from reyn.kernel.llm_call_recorder import LLMCallRecorder
     from reyn.kernel.run_state import RunState
     from reyn.schemas.models import Skill
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
 
 _log = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class PhaseExecutor:
       events             — EventLog; all state-change events emitted here.
       skill              — Skill definition (phases, permissions, graph).
       safety             — SafetyConfig; phase_seconds budget + on_limit policy.
-      intervention_bus   — InterventionBus | None; for safety-limit checkpoints.
+      intervention_bus   — RequestBus | None; for safety-limit checkpoints.
 
     Public surface: execute() → (NormalizationResult, LLMOutput, retry_count).
     """
@@ -72,7 +72,7 @@ class PhaseExecutor:
         events,
         skill: "Skill",
         safety,
-        intervention_bus: "InterventionBus | None",
+        intervention_bus: "RequestBus | None",
         run_id: str | None = None,
         strict: bool = False,
         build_frame_fn,

--- a/src/reyn/kernel/postprocessor_executor.py
+++ b/src/reyn/kernel/postprocessor_executor.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from reyn.permissions.permissions import PermissionResolver
     from reyn.python_runner import PythonRunner
     from reyn.schemas.models import PreprocessorStep, Skill
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
     from reyn.workspace.workspace import Workspace
 
 logger = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ class PostprocessorExecutor:
         resolver: "ModelResolver",
         subscribers: list,
         permission_resolver: "PermissionResolver | None" = None,
-        intervention_bus: "InterventionBus | None" = None,
+        intervention_bus: "RequestBus | None" = None,
         python_runner: "PythonRunner | None" = None,
         python_allowed_modules: list[str] | None = None,
         max_phase_visits: int = 0,

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from reyn.permissions.permissions import PermissionResolver
     from reyn.schemas.models import Phase, PreprocessorStep, Skill
     from reyn.secrets.store import ScopedSecretStore
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
     from reyn.workspace.workspace import Workspace
 
 
@@ -103,7 +103,7 @@ class PreprocessorExecutor:
         resolver: "ModelResolver",
         max_phase_visits: int = 25,
         permission_resolver: "PermissionResolver | None" = None,
-        intervention_bus: "InterventionBus | None" = None,
+        intervention_bus: "RequestBus | None" = None,
         python_runner: PythonRunner | None = None,
         python_allowed_modules: list[str] | None = None,
         caller: str = "direct",

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from reyn.permissions.permissions import PermissionResolver
     from reyn.schemas.models import CandidateOutput, Skill
     from reyn.skill.skill_registry import SkillRegistry
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
     from reyn.workspace.workspace import Workspace
 
 _log = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ class RunOrchestrator:
       preprocessor       — PreprocessorExecutor; deterministic enrichment.
       state              — RunState (Component A); mutable run-scope state.
       safety             — SafetyConfig; limit policies.
-      intervention_bus   — InterventionBus | None; safety-limit checkpoints.
+      intervention_bus   — RequestBus | None; safety-limit checkpoints.
       resume_plan        — ResumePlan | None; for forward-replay on resume.
       run_id             — str | None; identifies this run.
       parent_run_id      — str | None; for nested skill runs.
@@ -101,7 +101,7 @@ class RunOrchestrator:
         preprocessor: "PreprocessorExecutor",
         state: "RunState",
         safety: "SafetyConfig",
-        intervention_bus: "InterventionBus | None",
+        intervention_bus: "RequestBus | None",
         resume_plan: Any,
         run_id: str | None,
         parent_run_id: str | None,

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -33,7 +33,7 @@ from reyn.kernel.runtime_types import (
 from reyn.llm.model_resolver import ModelResolver
 from reyn.llm.pricing import TokenUsage
 from reyn.permissions.permissions import PermissionResolver
-from reyn.user_intervention import InterventionBus
+from reyn.user_intervention import RequestBus
 from reyn.workspace.workspace import Workspace
 
 # LoopLimitExceededError / PhaseBudgetExceededError / WorkflowAbortedError /
@@ -53,7 +53,7 @@ class OSRuntime:
         model: str,
         strict: bool = False,
         subscribers: list[Callable] | None = None,
-        intervention_bus: "InterventionBus | None" = None,
+        intervention_bus: "RequestBus | None" = None,
         run_id: str | None = None,
         shell_allowed: bool = False,
         resolver: ModelResolver | None = None,

--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
 
 
 # Default time the server blocks waiting for the agent to finish a turn
@@ -170,7 +170,7 @@ async def send_to_agent_impl(
     agent_name: str,
     message: str,
     timeout: float = DEFAULT_SEND_TIMEOUT_SECONDS,
-    intervention_override: "InterventionBus | None" = None,
+    intervention_override: "RequestBus | None" = None,
 ) -> dict:
     """Backing implementation of the ``send_to_agent`` tool.
 

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from reyn.permissions.permissions import PermissionDecl, PermissionResolver
     from reyn.schemas.models import Skill
     from reyn.secrets.store import ScopedSecretStore
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
     from reyn.workspace.workspace import Workspace
 
 
@@ -63,7 +63,7 @@ class OpContext:
     agent_id: str | None = None
 
     # User interventions (ask_user, permission prompts in PR7)
-    intervention_bus: "InterventionBus | None" = None
+    intervention_bus: "RequestBus | None" = None
     current_phase: str = ""
 
     # PR20: caller provenance threaded from the parent Agent so sub-skill

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -44,7 +44,7 @@ from reyn.intervention_choices import (
     python_choices,
 )
 from reyn.user_intervention import (
-    InterventionBus,
+    RequestBus,
     UserIntervention,
 )
 
@@ -208,8 +208,8 @@ class PermissionDecl:
 
 class PermissionResolver:
     """
-    Resolves permission requests against config, saved approvals, and an
-    `InterventionBus` for user prompts.
+    Resolves permission requests against config, saved approvals, and a
+    ``RequestBus`` for user prompts.
 
     The bus is supplied per-call (`require_*`, `startup_guard`, …) by the
     caller, since the bus is tied to the Agent that's running while the
@@ -302,7 +302,7 @@ class PermissionResolver:
         self,
         key: str,
         description: str,
-        bus: InterventionBus,
+        bus: RequestBus,
         *,
         user_prompt: str | None = None,
     ) -> bool:
@@ -329,7 +329,7 @@ class PermissionResolver:
         self,
         key: str,
         description: str,
-        bus: InterventionBus,
+        bus: RequestBus,
         *,
         user_prompt: str | None = None,
     ) -> bool:
@@ -410,7 +410,7 @@ class PermissionResolver:
         self._session[f"{skill_name}/{kind}/{p}"] = True
 
     async def _prompt_file_access(
-        self, path: str, scope: str, skill_name: str, kind: str, bus: InterventionBus,
+        self, path: str, scope: str, skill_name: str, kind: str, bus: RequestBus,
     ) -> bool:
         """Prompt the user to approve a file access. Returns True if approved.
 
@@ -450,12 +450,12 @@ class PermissionResolver:
         return False
 
     async def _prompt_file_write(
-        self, path: str, scope: str, skill_name: str, bus: InterventionBus,
+        self, path: str, scope: str, skill_name: str, bus: RequestBus,
     ) -> bool:
         return await self._prompt_file_access(path, scope, skill_name, "file.write", bus)
 
     async def startup_guard(
-        self, skill: "Skill", skill_name: str, bus: InterventionBus,
+        self, skill: "Skill", skill_name: str, bus: RequestBus,
     ) -> None:
         """
         Pre-flight permission check: scan all phase declarations, collect paths that
@@ -565,7 +565,7 @@ class PermissionResolver:
             await self._prompt_python(key, req["module"], req["function"], req["mode"], bus)
 
     async def _prompt_python(
-        self, key: str, module: str, function: str, mode: str, bus: InterventionBus,
+        self, key: str, module: str, function: str, mode: str, bus: RequestBus,
     ) -> bool:
         """Approve a python step; persist on yes."""
         if not self._interactive:
@@ -680,7 +680,7 @@ class PermissionResolver:
         return False
 
     async def require_shell(
-        self, decl: PermissionDecl, cmd: str, bus: InterventionBus,
+        self, decl: PermissionDecl, cmd: str, bus: RequestBus,
     ) -> None:
         if not decl.shell:
             raise PermissionError(
@@ -697,7 +697,7 @@ class PermissionResolver:
             raise PermissionError(f"shell access denied (cmd: {cmd!r})")
 
     async def require_mcp(
-        self, decl: PermissionDecl, server: str, bus: InterventionBus,
+        self, decl: PermissionDecl, server: str, bus: RequestBus,
     ) -> None:
         # PR37: per-agent allowlist check (narrower than project config).
         # None means no per-agent restriction; list means server must be in it.
@@ -720,7 +720,7 @@ class PermissionResolver:
             raise PermissionError(f"MCP server {server!r} access denied")
 
     async def require_mcp_install(
-        self, decl: PermissionDecl, server_id: str, bus: InterventionBus,
+        self, decl: PermissionDecl, server_id: str, bus: RequestBus,
     ) -> None:
         """Gate MCP server installation (ADR-0029).
 
@@ -768,7 +768,7 @@ class PermissionResolver:
             )
 
     async def require_index_drop(
-        self, decl: PermissionDecl, source: str, bus: InterventionBus,
+        self, decl: PermissionDecl, source: str, bus: RequestBus,
     ) -> None:
         """Gate index source drop (ADR-0033, mirrors require_mcp_install).
 
@@ -815,7 +815,7 @@ class PermissionResolver:
             )
 
     async def require_mcp_drop_server(
-        self, decl: PermissionDecl, server: str, bus: InterventionBus,
+        self, decl: PermissionDecl, server: str, bus: RequestBus,
     ) -> None:
         """Gate MCP server drop (FP-0034 §D23, mirrors require_mcp_install).
 
@@ -866,7 +866,7 @@ class PermissionResolver:
 
     async def require_python(
         self, decl: PermissionDecl, module: str, function: str,
-        bus: InterventionBus,
+        bus: RequestBus,
         skill_name: str = "",
     ) -> PythonPermission:
         """Resolve which python permission entry applies; raise if denied.
@@ -936,7 +936,7 @@ class PermissionResolver:
         return perm
 
     async def require_tool(
-        self, decl: PermissionDecl, tool: str, bus: InterventionBus,
+        self, decl: PermissionDecl, tool: str, bus: RequestBus,
     ) -> None:
         if tool not in decl.tool:
             raise PermissionError(
@@ -951,7 +951,7 @@ class PermissionResolver:
         ):
             raise PermissionError(f"tool {tool!r} access denied")
 
-    async def require_web_fetch(self, url: str, bus: InterventionBus) -> None:
+    async def require_web_fetch(self, url: str, bus: RequestBus) -> None:
         """Tier 1 gate for web_fetch — no declaration required, full 4-layer approval.
 
         FP-0022: web_fetch was previously gated only by catalog-level config

--- a/src/reyn/safety/limit_handler.py
+++ b/src/reyn/safety/limit_handler.py
@@ -32,8 +32,8 @@ from typing import Optional
 
 from reyn.config import OnLimitConfig
 from reyn.user_intervention import (
-    InterventionBus,
     InterventionChoice,
+    RequestBus,
     UserIntervention,
 )
 
@@ -101,7 +101,7 @@ def _yes_no_choices() -> list[InterventionChoice]:
 
 async def handle_limit_exceeded(
     *,
-    bus: Optional[InterventionBus],
+    bus: Optional[RequestBus],
     on_limit: OnLimitConfig,
     kind: str,
     run_id: str,

--- a/src/reyn/skill/sub_skill_runner.py
+++ b/src/reyn/skill/sub_skill_runner.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from reyn.permissions.permissions import PermissionResolver
     from reyn.schemas.models import Skill
     from reyn.secrets.store import ScopedSecretStore
-    from reyn.user_intervention import InterventionBus
+    from reyn.user_intervention import RequestBus
 
 
 @dataclass
@@ -39,7 +39,7 @@ async def invoke_sub_skill(
     model: str,
     subscribers: list,
     resolver: "ModelResolver",
-    intervention_bus: "InterventionBus | None" = None,
+    intervention_bus: "RequestBus | None" = None,
     permission_resolver: "PermissionResolver | None" = None,
     output_language: str | None = None,
     max_phase_visits: int = 25,

--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -186,12 +186,20 @@ class UserChannel(Protocol):
     async def deliver(self, iv: UserIntervention) -> InterventionAnswer: ...
 
 
-# issue #254 Phase 2: ``InterventionBus`` is retained as an alias of
-# ``RequestBus`` so existing callers / imports (= every site that types a
-# parameter as ``bus: InterventionBus`` today) keep working unchanged.
-# Phase 5 will eventually drop the alias once all callers have migrated
-# to the more precise ``RequestBus`` (or higher-level wrappers that hide
-# the bus entirely).
+# issue #254 Phase 5 (deprecated alias):
+#
+# ``InterventionBus`` was the original name for what is now ``RequestBus``
+# (= the OS↔upper-layer "send a request, await an answer" contract).
+# All in-tree production callers have migrated to ``RequestBus`` directly
+# (verified at test time by
+# ``tests/test_intervention_legacy_alias_deprecated.py``);
+# the module-level binding is retained so external code (= third-party
+# skills, plugins, restored snapshots) that imports the legacy name
+# keeps working.
+#
+# **Do not add new usage** — type new code as ``RequestBus``. The alias
+# is intentionally absent from ``__all__`` so ``from reyn.user_intervention
+# import *`` no longer pulls it.
 InterventionBus = RequestBus
 
 
@@ -276,8 +284,11 @@ class StdinInterventionBus:
 
 
 __all__ = [
+    # NB: ``InterventionBus`` (= legacy alias of ``RequestBus``) is
+    # intentionally absent from ``__all__`` as of issue #254 Phase 5.
+    # The module-level binding still exists for backwards-compat; new
+    # code should import ``RequestBus`` directly.
     "InterventionAnswer",
-    "InterventionBus",
     "InterventionChoice",
     "RequestBus",
     "StdinInterventionBus",

--- a/tests/test_intervention_bus_protocols.py
+++ b/tests/test_intervention_bus_protocols.py
@@ -292,18 +292,28 @@ def test_a2a_intervention_bus_does_not_import_skill_completed_handler() -> None:
     )
 
 
-# ── 6. Phase 2 does not change __all__ exports of legacy names ─────────
+# ── 6. __all__ exports new layer names; legacy alias dropped in Phase 5 ──
 
 
-def test_user_intervention_all_exports_include_new_and_legacy_names() -> None:
+def test_user_intervention_all_exports_include_new_layer_names() -> None:
     """Tier 2: ``__all__`` carries ``RequestBus`` and ``UserChannel`` as
-    new exports while keeping ``InterventionBus`` for backwards-compat.
-    Drop the old name only in Phase 5 cleanup.
+    the canonical new layer names.
+
+    Updated in Phase 5: ``InterventionBus`` is no longer in ``__all__``
+    (= dropped from the explicit exports, but the module-level binding
+    is retained so external code that imports the legacy name keeps
+    working). Verified by the deprecated-alias test in
+    ``tests/test_intervention_legacy_alias_deprecated.py``.
     """
     import reyn.user_intervention as mod
 
     assert "RequestBus" in mod.__all__
     assert "UserChannel" in mod.__all__
-    assert "InterventionBus" in mod.__all__, (
-        "InterventionBus must stay in __all__ for Phase 2 backwards-compat"
+    # Phase 5: InterventionBus removed from __all__ but still importable
+    # as a module attribute (= the alias binding remains).
+    assert "InterventionBus" not in mod.__all__, (
+        "InterventionBus must NOT be in __all__ post-Phase-5 (= deprecated alias)"
+    )
+    assert hasattr(mod, "InterventionBus"), (
+        "InterventionBus module-level binding must remain for backwards-compat"
     )

--- a/tests/test_intervention_legacy_alias_deprecated.py
+++ b/tests/test_intervention_legacy_alias_deprecated.py
@@ -1,0 +1,188 @@
+"""Tier 2: legacy ``InterventionBus`` alias is no longer used in OS code
+(issue #254 Phase 5 cleanup).
+
+Pins the post-Phase-5 invariants:
+
+  - ``InterventionBus`` is preserved as a module-level alias of
+    ``RequestBus`` so external callers / restored snapshots that
+    imported the legacy name keep working.
+  - The alias is absent from ``__all__`` so ``from reyn.user_intervention
+    import *`` no longer pulls it (= signals deprecation to discovery
+    tools).
+  - **No in-tree production module imports the legacy name** for type
+    hints / parameter annotations. The grep-pin walks the AST of every
+    module under ``src/reyn/`` and reports any leftover reference so
+    drift cannot land silently.
+
+The OS-layer migration completeness check is what lead-coder's Phase 5
+scope guard required (= "全 OS caller が新 ``RequestBus`` import を
+grep + Tier 2 で verify"). Phase 5 ships that verify.
+
+Channel-implementation modules (= ``chat/session.py`` /
+``web/a2a_intervention.py``) intentionally retain references in
+**docstrings** that explain the backwards-compat history. The AST
+walker ignores string literals, so docstring mentions don't trip the
+check — only actual ``Name`` / ``Attribute`` / ``Import`` / ``ImportFrom``
+nodes count.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import reyn
+
+# ── 1. Module-level alias preserved for backwards-compat ───────────────
+
+
+def test_intervention_bus_alias_still_importable() -> None:
+    """Tier 2: the legacy ``InterventionBus`` name is still importable
+    via ``from reyn.user_intervention import InterventionBus`` so
+    third-party code that pinned the old name keeps working.
+    """
+    from reyn.user_intervention import InterventionBus, RequestBus
+
+    # Alias identity: legacy name IS the new Protocol.
+    assert InterventionBus is RequestBus
+
+
+def test_intervention_bus_alias_absent_from_all() -> None:
+    """Tier 2: the legacy name is excluded from ``__all__`` so
+    star-imports + IDE discovery surface only the canonical
+    ``RequestBus`` name.
+    """
+    import reyn.user_intervention as mod
+
+    assert "InterventionBus" not in mod.__all__, (
+        "InterventionBus must be excluded from __all__ post-Phase-5"
+    )
+    assert "RequestBus" in mod.__all__
+    assert "UserChannel" in mod.__all__
+
+
+# ── 2. AST walker — finds legacy-name references in production code ────
+
+
+def _names_used_in_source(src: str) -> set[str]:
+    """Return every Name / Attribute / imported identifier referenced
+    in *src*, EXCLUDING string literals and docstrings.
+    """
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                names.add(alias.name)
+                if alias.asname:
+                    names.add(alias.asname)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+                if alias.asname:
+                    names.add(alias.asname)
+    return names
+
+
+def _reyn_src_root() -> Path:
+    """Return the path to ``src/reyn/`` (the production code tree)."""
+    return Path(inspect.getfile(reyn)).resolve().parent
+
+
+# Modules where the legacy name is intentionally kept (= the alias
+# definition site + the migration audit test itself). These are
+# allow-listed because the alias is consciously preserved as
+# backwards-compat — not a drift to clean up.
+_LEGACY_NAME_ALLOWLIST: set[str] = {
+    # The alias-definition site itself: it assigns InterventionBus = RequestBus.
+    "src/reyn/user_intervention.py",
+}
+
+
+def test_no_os_caller_uses_legacy_intervention_bus_name() -> None:
+    """Tier 2: walk every .py file under ``src/reyn/`` and assert that
+    no module references ``InterventionBus`` as a Name / Attribute /
+    Import identifier — except the alias-definition site itself.
+
+    Docstring mentions of "InterventionBus" (= explanations of the
+    backwards-compat history in ``chat/session.py`` /
+    ``web/a2a_intervention.py``) are intentionally allowed because they
+    live in string literals which the AST walker ignores. Only actual
+    code-level references count.
+
+    issue #254 Phase 5: scope guard pin per lead-coder owner-decision
+    waiver — "全 OS caller が新 ``RequestBus`` import を grep + Tier
+    2 で verify".
+    """
+    reyn_root = _reyn_src_root()
+    project_root = reyn_root.parent.parent  # .../src → project root
+    leaks: list[str] = []
+
+    for py_file in reyn_root.rglob("*.py"):
+        rel = py_file.relative_to(project_root).as_posix()
+        if rel in _LEGACY_NAME_ALLOWLIST:
+            continue
+        src = py_file.read_text(encoding="utf-8")
+        if "InterventionBus" not in src:
+            # Fast path — most files don't reference it at all.
+            continue
+        # Slower path — parse AST and check for code-level references.
+        names = _names_used_in_source(src)
+        if "InterventionBus" in names:
+            leaks.append(rel)
+
+    assert not leaks, (
+        f"Production modules still reference the legacy "
+        f"``InterventionBus`` name as code (= import / type hint / call), "
+        f"not docstring. Phase 5 requires migration to ``RequestBus``. "
+        f"Modules with leaks: {sorted(leaks)}"
+    )
+
+
+# ── 3. Documented allow-list — channel-impl docstrings remain ──────────
+
+
+def test_channel_impl_docstrings_can_still_reference_legacy_name() -> None:
+    """Tier 2: docstrings in ``chat/session.py`` and
+    ``web/a2a_intervention.py`` retain explanatory references to
+    ``InterventionBus`` for backwards-compat history.
+
+    The AST walker check above intentionally excludes docstring text,
+    so these references don't trip the leak detector. This test pins
+    that the references EXIST as expected (= verifies our allow-list
+    assumption holds — if these files ever drop the explanatory
+    docstrings, the AST-walker test in section 2 still passes but
+    we'd lose useful migration context).
+    """
+    import reyn.chat.session as chat_session
+    import reyn.web.a2a_intervention as a2a
+
+    chat_src = inspect.getsource(chat_session)
+    a2a_src = inspect.getsource(a2a)
+
+    # Each should mention InterventionBus in some explanatory context.
+    assert "InterventionBus" in chat_src, (
+        "chat/session.py docstrings should retain InterventionBus "
+        "backwards-compat history references"
+    )
+    assert "InterventionBus" in a2a_src, (
+        "web/a2a_intervention.py docstrings should retain "
+        "InterventionBus backwards-compat history references"
+    )
+
+    # And the AST walker should NOT find the name as code-level in
+    # either file (= references are docstring-only).
+    chat_names = _names_used_in_source(chat_src)
+    a2a_names = _names_used_in_source(a2a_src)
+    assert "InterventionBus" not in chat_names, (
+        "chat/session.py must not reference InterventionBus as code "
+        "(docstring-only is allowed)"
+    )
+    assert "InterventionBus" not in a2a_names, (
+        "web/a2a_intervention.py must not reference InterventionBus "
+        "as code (docstring-only is allowed)"
+    )


### PR DESCRIPTION
**[e2e-coder]** — **Phase 5 of #254 — final**.

Refs #254. Depends on PR #255 (Phase 1), PR #258 (Phase 2), PR #259 (Phase 3), PR #260 (Phase 4) — all merged. This PR closes #254.

## What this PR does

Final cleanup: migrate every in-tree OS-layer caller from the legacy `InterventionBus` name to the canonical `RequestBus`, exclude the legacy name from `__all__`, and pin migration completeness with an AST-based grep test. The alias binding itself is retained as backwards-compat for external code (third-party skills, plugins, restored snapshots).

## Migration coverage

OS-layer callers now type against `RequestBus`:

| Module | What it does |
|---|---|
| `safety/limit_handler.py` | FP-0005 safety-limit checkpoint helper |
| `permissions/permissions.py` | every `require_*` gate + `PermissionResolver` |
| `agent.py` | skill-runner Agent wrapper |
| `mcp_server.py` | A2A async-task wiring |
| `skill/sub_skill_runner.py` | sub-skill spawn |
| `kernel/runtime.py` | OSRuntime entry point |
| `kernel/run_orchestrator.py` | run() orchestration |
| `kernel/phase_executor.py` | per-phase executor |
| `kernel/preprocessor_executor.py` | preprocessor stage |
| `kernel/postprocessor_executor.py` | postprocessor stage |
| `kernel/control_ir_executor.py` | Control IR op dispatch |
| `op_runtime/context.py` | OpContext type |
| `chat/session.py` | ChatSession constructor + `register_intervention_override` + `_intervention_overrides` dict |

## Backwards-compat decision: keep the alias binding, drop from `__all__`

**Removed**: `InterventionBus` from `reyn.user_intervention.__all__`. Star-imports and IDE discovery now surface only `RequestBus` / `UserChannel`.

**Retained**: the module-level binding `InterventionBus = RequestBus`. External code that did `from reyn.user_intervention import InterventionBus` keeps working. Documented with a deprecation comment pointing to `RequestBus`.

This conservative shape avoids breaking third-party skills / plugins / restored crash snapshots that pinned the legacy name. A future hard removal can be a separate decision once we have a deprecation cycle in place.

## Phase 5 commitment from lead-coder owner-decision

> **caller migration completeness**: Phase 5 entry 前に 「全 OS caller が新 ``RequestBus`` import」 を grep + Tier 2 で verify

→ Pinned by `test_no_os_caller_uses_legacy_intervention_bus_name` — walks the AST of every `.py` under `src/reyn/` and asserts no module references `InterventionBus` as a code-level identifier (= Name / Attribute / Import / ImportFrom). The single allow-listed file is `src/reyn/user_intervention.py` itself (where the alias is defined). Drift cannot land silently because the test fails on the first stray import.

## Docs

User-facing reference docs (`docs/reference/config/reyn-yaml.md` and `.ja.md`) updated to mention `RequestBus` where the old name appeared (= the `skill_improver.on_propose` field description).

Historical docs (`docs/deep-dives/decisions/*`, `docs/deep-dives/proposals/*`, `docs/deep-dives/journal/*`) left as-is — they are frozen-in-time records of the architecture at the time of writing, and amending them is revisionism.

## Phase 5 contract test coverage (4 new tests + 1 updated)

`tests/test_intervention_legacy_alias_deprecated.py` (new):

| Test | Pins |
|---|---|
| `test_intervention_bus_alias_still_importable` | module-level binding preserved (`InterventionBus is RequestBus`) |
| `test_intervention_bus_alias_absent_from_all` | `__all__` excludes the legacy name |
| `test_no_os_caller_uses_legacy_intervention_bus_name` | **AST walker over `src/reyn/`** — no production module references `InterventionBus` as code (= owner-decision commitment) |
| `test_channel_impl_docstrings_can_still_reference_legacy_name` | pins the allow-list assumption (= docstrings in chat/session + a2a_intervention CAN still mention the legacy name for history; the AST walker correctly distinguishes string literals from code references) |

`tests/test_intervention_bus_protocols.py` (updated): the existing
`test_user_intervention_all_exports_include_new_and_legacy_names` was renamed to `test_user_intervention_all_exports_include_new_layer_names` and now asserts the OPPOSITE of the Phase 2 invariant — `InterventionBus` is no longer in `__all__` post-Phase-5, but is still available as a module attribute.

## Test plan

- [x] **Automated — `pytest tests/test_intervention_legacy_alias_deprecated.py`**: 4/4 pass。
- [x] **Adjacent — `pytest tests/test_intervention_subscriber_guard.py tests/test_intervention_bus_protocols.py tests/test_intervention_agent_subscriber.py tests/test_intervention_agent_routing.py`** (= Phase 1-4 contract tests): 49/49 pass。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --ignore=tests/test_a2a_sync_async_escalation.py --timeout=30`**: 3982 passed, 11 skipped, 3 xfailed in 147s。 (`test_a2a_sync_async_escalation.py` の skip は PR #253 由来 fastapi env gap で本 PR 起因ではない)
- [x] **Lint — `ruff check src/reyn/ tests/test_intervention_legacy_alias_deprecated.py tests/test_intervention_bus_protocols.py`**: clean。
- [ ] **Manual — TUI / a2a で intervention prompt が今まで通り user に届くこと**: Phase 5 は rename + import 整理のみで runtime behaviour 完全不変、 ただし tui-coder の念のための smoke check は valuable (= Phase 1-4 で蓄積した manual verify を最終 close するため)。

## issue #254 close

```
✓ Phase 1 (PR #255) subscriber-presence guard
✓ Default flip (PR #256) interactive + 0s
✓ Phase 2 (PR #258) RequestBus / UserChannel split
✓ Phase 3 (PR #259) Agent-layer entry point + behaviour parity
✓ Phase 4 (PR #260) routing scaffold + observability event + precedence
✓ Phase 5 (this PR) caller migration + alias deprecation + docs
```

Plus open follow-ups:
- #261 (Phase 4 sub-issue, tui-coder dispatch) — TUI surface for routing decisions (`source_agent` meta + events tab `intervention_routed` render)
- self_answer policy expansion PRs — incremental, no scope owner yet

5-day refactor across 5 PRs (= Phase 1 → 5) + 1 default flip + 4 cross-session reviews (lead / tui / dogfood) + 5 design-discussion turns on issue #254. Architecture realised the [A] OS↔Agent `RequestBus` / [B] Agent↔User `UserChannel` separation, Agent as routing decision-point, and "OS knows nothing about Agent" P7 strict reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)