### PR TITLE
fix(planner): detect-and-retry on plan-step empty stop — ENV-var opt-in, closes B42-NF-W6-1

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -86,6 +86,24 @@ _PLAN_MAX_STEPS = 7
 # Overridable via ``reyn.yaml plan.retry_limit``.
 _PLAN_STEP_RETRY_LIMIT = 3
 
+# B42-NF-W6-1: continuation directive passed to RouterLoop's empty-stop
+# retry path. RouterLoop only consults this when the
+# ``REYN_EMPTY_STOP_RETRY=1`` env var is set, so the production code wires
+# the directive in unconditionally but no runtime behaviour changes
+# unless the operator opts in. The wording follows the existing plan-step
+# system prompt voice ("report what this step found") and adds an
+# explicit imperative trailer that trace-patch-replay confirmed flips
+# the post-tool empty-stop attractor (= 0/10 → 10/10 narration recovery
+# on the W6-S1 plan step). Cross-provider issue (= documented for Gemini,
+# Claude, GPT) — see Anthropic handling-stop-reasons docs + Hermes-agent
+# #9400 for prior art.
+_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE = (
+    "Now write your step report. Summarise the relevant content from the "
+    "tool result above in 2-5 paragraphs, citing concrete details (file "
+    "paths, header names, function names, line numbers, exact values). "
+    "Do not call another tool. Write the report text now."
+)
+
 # Exception types that must NOT be retried and must be re-raised to their
 # own safety-layer ask/abort path. Retrying them would cause double-ask or
 # bypass budget enforcement invariants.
@@ -861,6 +879,10 @@ async def execute_plan(
                 # 3 plan invocations because steps re-emitted plan).
                 exclude_tools={"plan"},
                 memo_provider=memo_provider,
+                # B42-NF-W6-1: directive used when ``REYN_EMPTY_STOP_RETRY=1``
+                # is set (= operator opt-in). Production wiring lands in the
+                # codebase but no default behaviour change.
+                empty_stop_retry_directive=_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE,
             )
             # FP-0031-C: auto-retry on transient step failures.
             # FP-0031-D: when retry budget is exhausted, ask the user via
@@ -939,6 +961,9 @@ async def execute_plan(
                             system_prompt_override=sys_prompt,
                             exclude_tools={"plan"},
                             memo_provider=memo_provider,
+                            # B42-NF-W6-1: same directive as the initial
+                            # sub_loop construction above.
+                            empty_stop_retry_directive=_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE,
                         )
                         continue
                     # FP-0031-D: retry budget exhausted — ask user for extension.

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1068,6 +1068,7 @@ class RouterLoop:
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
+        llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
     ):
         self.host = host
         self.chain_id = chain_id
@@ -1115,6 +1116,12 @@ class RouterLoop:
         # process — the directive plumbing lands in the codebase but no
         # default runtime behaviour change.
         self._empty_stop_retry_directive = empty_stop_retry_directive
+        # Tier 2 test seam: when set, ``run()`` calls this callable instead of
+        # the module-level ``call_llm_tools``. Allows real-fake injection
+        # (= scripted async callable) without ``unittest.mock.patch`` — per
+        # testing.ja.md hard rule that forbids ``MagicMock / AsyncMock /
+        # patch``. Production callers leave this as ``None``.
+        self._llm_caller = llm_caller
         self._catalog: dict[str, dict] = {}  # populated per run()
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
@@ -1459,7 +1466,12 @@ class RouterLoop:
                     )
                     result = memo
             if result is None:
-                result = await call_llm_tools(
+                # Tier 2 testability: tests inject a real-fake callable via
+                # ``_llm_caller`` (= no unittest.mock.patch needed). None
+                # falls through to the module-level ``call_llm_tools`` so
+                # production callers don't have to know about the seam.
+                _llm = self._llm_caller or call_llm_tools
+                result = await _llm(
                     model=resolved_model,
                     messages=messages,
                     tools=tools,

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -1066,6 +1067,7 @@ class RouterLoop:
         exclude_tools: set[str] | None = None,
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
+        empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
     ):
         self.host = host
         self.chain_id = chain_id
@@ -1101,6 +1103,18 @@ class RouterLoop:
         self._memo_provider = memo_provider
         # FP-0024-A: BM25 skill pre-filter config. None = use OS defaults.
         self._skill_search_config = skill_search_config
+        # B42-NF-W6-1: directive used as a continuation prompt when an empty
+        # stop is detected after a tool-call round. None (= default) preserves
+        # the existing chat-router "observe + surface" policy. The plan
+        # executor passes a plan-step-appropriate directive ("now report what
+        # you found") so the post-tool empty-stop attractor that hits 10/10
+        # on Gemini 2.5 Flash Lite (and is documented across providers — see
+        # platform.claude.com handling-stop-reasons docs) can be broken with
+        # one retry. Even when set, the actual retry behaviour is gated by
+        # the ``REYN_EMPTY_STOP_RETRY`` env var so operators opt in per
+        # process — the directive plumbing lands in the codebase but no
+        # default runtime behaviour change.
+        self._empty_stop_retry_directive = empty_stop_retry_directive
         self._catalog: dict[str, dict] = {}  # populated per run()
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
@@ -1408,6 +1422,13 @@ class RouterLoop:
         #   invoked at least one tool (including non-catalog tools).
         _routing_decided_fired: bool = False
         _tool_calls_attempted: int = 0
+        # B42-NF-W6-1: empty-stop retry counter. The empty-stop handler
+        # consults this before injecting a continuation prompt + looping,
+        # so retries are bounded at 1 per turn (= no infinite loops if
+        # the LLM keeps returning empty stops even with the continuation
+        # prompt; the second empty stop falls through to the standard
+        # "observe + surface" path).
+        _empty_stop_retries: int = 0
 
         for _iteration in range(self.max_iterations):
             resolved_model = host.resolve_model(self.router_model)
@@ -1748,6 +1769,16 @@ class RouterLoop:
             # This is a provider-level glitch (observed at ~50% rate with weak
             # models — B7-G12 measurement).  Reyn does NOT retry, change context,
             # or switch models.  Responsibility: observe + surface to user.
+            #
+            # B42-NF-W6-1: when a continuation directive is configured AND the
+            # ``REYN_EMPTY_STOP_RETRY`` env var opts in, attempt ONE retry per
+            # turn with the directive appended as a synthetic user message
+            # before re-entering the loop. The retry path matches the
+            # Anthropic-recommended "continuation prompts as last resort"
+            # pattern (= platform.claude.com handling-stop-reasons docs) and
+            # the Hermes-agent #9400 community implementation. Without the
+            # env var, behaviour is unchanged from the original "observe +
+            # surface" policy.
             if _is_empty_router_response(result):
                 # P6: emit audit event — state change must be observable.
                 self.host.events.emit(
@@ -1760,6 +1791,25 @@ class RouterLoop:
                     caller_hint="router",
                     model=host.resolve_model(self.router_model),
                 )
+                # B42-NF-W6-1 detect-and-retry: env-var-gated, directive-gated,
+                # max 1 retry per turn. Trace-patch-replay verified 0/10 →
+                # 10/10 narration recovery on the W6-S1 plan-step empty stop.
+                if (
+                    self._empty_stop_retry_directive
+                    and _empty_stop_retries < 1
+                    and os.environ.get("REYN_EMPTY_STOP_RETRY") == "1"
+                ):
+                    _empty_stop_retries += 1
+                    messages.append({
+                        "role": "user",
+                        "content": self._empty_stop_retry_directive,
+                    })
+                    self.host.events.emit(
+                        "router_empty_response_retry_injected",
+                        directive_length=len(self._empty_stop_retry_directive),
+                        chain_id=self.chain_id,
+                    )
+                    continue  # re-enter the loop with the directive in messages
                 lang = getattr(host, "output_language", None)
                 failure_text = _EMPTY_RESPONSE_MSG.get(
                     lang, _EMPTY_RESPONSE_MSG["en"]

--- a/tests/test_router_loop_empty_stop_retry.py
+++ b/tests/test_router_loop_empty_stop_retry.py
@@ -23,26 +23,28 @@ References:
 - Hermes-agent #9400 — community implementation of the same pattern.
 - B42-NF-W6-1 trace-patch-replay evidence (0/10 baseline → 10/10 patched
   on the W6-S1 plan-step empty-stop attractor).
+
+testing.ja.md compliance:
+- Uses ``llm_caller=`` injection (= constructor seam on RouterLoop) instead
+  of ``unittest.mock.patch``. The injected ``_ScriptedLLM`` is a real
+  callable class with ``async def __call__``; signature drift would raise
+  TypeError, unlike a mock that silently accepts anything.
+- ``pytest.monkeypatch`` is used only for env-var setup (= acceptable per
+  the policy's distinction between fake-collaborator mocking and reversible
+  env / module-attribute setup).
 """
 from __future__ import annotations
-
-from unittest.mock import patch
 
 import pytest
 
 from reyn.chat.router_loop import RouterLoop
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
-
-# Reuse FakeRouterHost / _ScriptedLLM / text_result / tool_result from the
-# canonical RouterLoop test module — real classes (= no Mock / AsyncMock).
-from tests.test_router_loop import (  # noqa: E402
+from tests.test_router_loop import (
     FakeRouterHost,
     _ScriptedLLM,
     text_result,
-    tool_result,
 )
-
 
 _DIRECTIVE = (
     "Now write your step report. Summarise the relevant content from "
@@ -60,12 +62,18 @@ def _empty_stop_result() -> LLMToolCallResult:
     )
 
 
-def _make_loop(host: FakeRouterHost, directive: str | None) -> RouterLoop:
+def _make_loop(
+    host: FakeRouterHost,
+    directive: str | None,
+    *,
+    llm_caller,
+) -> RouterLoop:
     return RouterLoop(
         host=host,
         chain_id="chain-empty-stop-test",
         max_iterations=5,
         empty_stop_retry_directive=directive,
+        llm_caller=llm_caller,
     )
 
 
@@ -81,13 +89,10 @@ async def test_retry_path_injects_user_msg_when_env_var_set(monkeypatch):
     """
     monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
     host = FakeRouterHost()
-    loop = _make_loop(host, _DIRECTIVE)
-
-    # Script: empty stop → (retry) → text reply
     scripted = _ScriptedLLM([_empty_stop_result(), text_result("recovered")])
+    loop = _make_loop(host, _DIRECTIVE, llm_caller=scripted)
 
-    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
-        await loop.run("test", [])
+    await loop.run("test", [])
 
     # Two LLM calls (= 1 initial + 1 retry)
     assert scripted.call_count == 2
@@ -114,12 +119,10 @@ async def test_no_retry_when_env_var_unset(monkeypatch):
     """
     monkeypatch.delenv("REYN_EMPTY_STOP_RETRY", raising=False)
     host = FakeRouterHost()
-    loop = _make_loop(host, _DIRECTIVE)
-
     scripted = _ScriptedLLM([_empty_stop_result()])
+    loop = _make_loop(host, _DIRECTIVE, llm_caller=scripted)
 
-    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
-        await loop.run("test", [])
+    await loop.run("test", [])
 
     # Only 1 LLM call (= no retry).
     assert scripted.call_count == 1
@@ -143,12 +146,10 @@ async def test_no_retry_when_directive_is_none(monkeypatch):
     """
     monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
     host = FakeRouterHost()
-    loop = _make_loop(host, None)  # no directive
-
     scripted = _ScriptedLLM([_empty_stop_result()])
+    loop = _make_loop(host, None, llm_caller=scripted)  # no directive
 
-    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
-        await loop.run("test", [])
+    await loop.run("test", [])
 
     assert scripted.call_count == 1
     assert host.outbox[0]["meta"]["source"] == "router_empty_response"
@@ -167,13 +168,11 @@ async def test_retry_bounded_to_one_per_turn(monkeypatch):
     """
     monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
     host = FakeRouterHost()
-    loop = _make_loop(host, _DIRECTIVE)
-
     # Script: empty stop → empty stop on retry → loop must surface failure.
     scripted = _ScriptedLLM([_empty_stop_result(), _empty_stop_result()])
+    loop = _make_loop(host, _DIRECTIVE, llm_caller=scripted)
 
-    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
-        await loop.run("test", [])
+    await loop.run("test", [])
 
     # Exactly 2 LLM calls (= 1 initial + 1 retry, then surface).
     assert scripted.call_count == 2
@@ -192,7 +191,13 @@ async def test_retry_bounded_to_one_per_turn(monkeypatch):
 
 
 class _MessageCapturingScripted:
-    """Real callable that records each call's messages snapshot."""
+    """Real callable that records each call's messages snapshot.
+
+    Same shape as _ScriptedLLM (= real class with async __call__, signature
+    drift raises TypeError) but additionally captures the messages list each
+    time the callable is invoked. Per testing.ja.md this is an acceptable
+    real-fake pattern — no unittest.mock.* involved.
+    """
 
     def __init__(self, script):
         self._script = list(script)
@@ -215,12 +220,10 @@ async def test_retry_injects_directive_verbatim(monkeypatch):
     """
     monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
     host = FakeRouterHost()
-    loop = _make_loop(host, _DIRECTIVE)
-
     spy = _MessageCapturingScripted([_empty_stop_result(), text_result("ok")])
+    loop = _make_loop(host, _DIRECTIVE, llm_caller=spy)
 
-    with patch("reyn.chat.router_loop.call_llm_tools", spy):
-        await loop.run("user query", [])
+    await loop.run("user query", [])
 
     assert spy.call_count == 2
     retry_msgs = spy.messages_per_call[1]
@@ -247,12 +250,10 @@ async def test_empty_stop_event_still_emitted_on_retry_path(monkeypatch):
     """
     monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
     host = FakeRouterHost()
-    loop = _make_loop(host, _DIRECTIVE)
-
     scripted = _ScriptedLLM([_empty_stop_result(), text_result("recovered")])
+    loop = _make_loop(host, _DIRECTIVE, llm_caller=scripted)
 
-    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
-        await loop.run("test", [])
+    await loop.run("test", [])
 
     emitted = [e["type"] for e in host._events.emitted]
     assert "router_empty_response_detected" in emitted

--- a/tests/test_router_loop_empty_stop_retry.py
+++ b/tests/test_router_loop_empty_stop_retry.py
@@ -1,0 +1,262 @@
+"""Tier 2: RouterLoop empty-stop retry with continuation directive (B42-NF-W6-1).
+
+Pinned invariants:
+
+- When ``empty_stop_retry_directive`` is set AND ``REYN_EMPTY_STOP_RETRY=1``,
+  an empty-stop response (= finish_reason=stop, no content, no tool_calls)
+  triggers ONE retry. Before the retry, a synthetic ``role="user"`` message
+  carrying the directive is appended to the messages list.
+- When the env var is unset, the directive is plumbed in but ignored — the
+  loop falls through to the existing "observe + surface" path (= no behaviour
+  change for the default chat-router policy).
+- When the directive is None, the env var is also ignored — no retry attempt
+  even with the env var set.
+- Retries are bounded at 1 per turn: a second empty-stop in the same turn
+  falls through to the surface path (= no infinite retries when the
+  attractor is unbreakable).
+- A ``router_empty_response_retry_injected`` audit event is emitted on the
+  retry path so the P6 audit trail records the intervention.
+
+References:
+- Anthropic ``handling-stop-reasons`` docs (= "continuation prompts as a
+  last resort" — official recommendation).
+- Hermes-agent #9400 — community implementation of the same pattern.
+- B42-NF-W6-1 trace-patch-replay evidence (0/10 baseline → 10/10 patched
+  on the W6-S1 plan-step empty-stop attractor).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+
+# Reuse FakeRouterHost / _ScriptedLLM / text_result / tool_result from the
+# canonical RouterLoop test module — real classes (= no Mock / AsyncMock).
+from tests.test_router_loop import (  # noqa: E402
+    FakeRouterHost,
+    _ScriptedLLM,
+    text_result,
+    tool_result,
+)
+
+
+_DIRECTIVE = (
+    "Now write your step report. Summarise the relevant content from "
+    "the tool result above. Do not call another tool. Write the report now."
+)
+
+
+def _empty_stop_result() -> LLMToolCallResult:
+    """An empty-stop result — what the attractor produces."""
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[],
+        finish_reason="stop",
+        usage=TokenUsage(prompt_tokens=100, completion_tokens=0),
+    )
+
+
+def _make_loop(host: FakeRouterHost, directive: str | None) -> RouterLoop:
+    return RouterLoop(
+        host=host,
+        chain_id="chain-empty-stop-test",
+        max_iterations=5,
+        empty_stop_retry_directive=directive,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env var ON + directive set → retry with injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_path_injects_user_msg_when_env_var_set(monkeypatch):
+    """Tier 2 (B42-NF-W6-1): when env var set AND directive set AND empty
+    stop occurs, the loop appends a synthetic user message and retries.
+    """
+    monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
+    host = FakeRouterHost()
+    loop = _make_loop(host, _DIRECTIVE)
+
+    # Script: empty stop → (retry) → text reply
+    scripted = _ScriptedLLM([_empty_stop_result(), text_result("recovered")])
+
+    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
+        await loop.run("test", [])
+
+    # Two LLM calls (= 1 initial + 1 retry)
+    assert scripted.call_count == 2
+    # Outbox carries the recovered text — NOT the empty-response fallback.
+    assert len(host.outbox) == 1
+    assert host.outbox[0]["text"] == "recovered"
+    # Audit event was emitted for the retry.
+    emitted = [e["type"] for e in host._events.emitted]
+    assert "router_empty_response_detected" in emitted
+    assert "router_empty_response_retry_injected" in emitted
+
+
+# ---------------------------------------------------------------------------
+# Env var unset → no retry, existing behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_env_var_unset(monkeypatch):
+    """Tier 2 (regression guard): without ``REYN_EMPTY_STOP_RETRY=1``, the
+    directive is ignored and the loop falls through to the existing
+    "observe + surface" path (= empty-response fallback message in
+    outbox, no second LLM call).
+    """
+    monkeypatch.delenv("REYN_EMPTY_STOP_RETRY", raising=False)
+    host = FakeRouterHost()
+    loop = _make_loop(host, _DIRECTIVE)
+
+    scripted = _ScriptedLLM([_empty_stop_result()])
+
+    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
+        await loop.run("test", [])
+
+    # Only 1 LLM call (= no retry).
+    assert scripted.call_count == 1
+    # Outbox has the empty-response fallback message.
+    assert len(host.outbox) == 1
+    assert host.outbox[0]["meta"]["source"] == "router_empty_response"
+    # No retry injection event.
+    emitted = [e["type"] for e in host._events.emitted]
+    assert "router_empty_response_retry_injected" not in emitted
+
+
+# ---------------------------------------------------------------------------
+# Env var set but directive None → no retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_directive_is_none(monkeypatch):
+    """Tier 2: env var set but directive None (= chat router default
+    construction) → no retry, existing observe+surface path runs.
+    """
+    monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
+    host = FakeRouterHost()
+    loop = _make_loop(host, None)  # no directive
+
+    scripted = _ScriptedLLM([_empty_stop_result()])
+
+    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
+        await loop.run("test", [])
+
+    assert scripted.call_count == 1
+    assert host.outbox[0]["meta"]["source"] == "router_empty_response"
+
+
+# ---------------------------------------------------------------------------
+# Bounded retries — second empty stop falls through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_bounded_to_one_per_turn(monkeypatch):
+    """Tier 2: when the retry ALSO produces an empty stop, the second
+    occurrence falls through to the surface path. Prevents infinite
+    retries when the attractor is unbreakable.
+    """
+    monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
+    host = FakeRouterHost()
+    loop = _make_loop(host, _DIRECTIVE)
+
+    # Script: empty stop → empty stop on retry → loop must surface failure.
+    scripted = _ScriptedLLM([_empty_stop_result(), _empty_stop_result()])
+
+    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
+        await loop.run("test", [])
+
+    # Exactly 2 LLM calls (= 1 initial + 1 retry, then surface).
+    assert scripted.call_count == 2
+    # Outbox has the empty-response fallback (= surfaced after retry failed).
+    assert len(host.outbox) == 1
+    assert host.outbox[0]["meta"]["source"] == "router_empty_response"
+    # Exactly ONE retry injection event recorded (= bound enforced).
+    emitted = [e["type"] for e in host._events.emitted]
+    retry_count = emitted.count("router_empty_response_retry_injected")
+    assert retry_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Retry path injects the directive content verbatim
+# ---------------------------------------------------------------------------
+
+
+class _MessageCapturingScripted:
+    """Real callable that records each call's messages snapshot."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.call_count = 0
+        self.messages_per_call: list[list[dict]] = []
+
+    async def __call__(self, **kwargs):
+        msgs = kwargs.get("messages") or []
+        self.messages_per_call.append([dict(m) for m in msgs])
+        result = self._script[self.call_count]
+        self.call_count += 1
+        return result
+
+
+@pytest.mark.asyncio
+async def test_retry_injects_directive_verbatim(monkeypatch):
+    """Tier 2: the directive string is appended verbatim as a
+    ``role="user"`` message in the retry call's messages — no rewriting
+    or wrapping by RouterLoop.
+    """
+    monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
+    host = FakeRouterHost()
+    loop = _make_loop(host, _DIRECTIVE)
+
+    spy = _MessageCapturingScripted([_empty_stop_result(), text_result("ok")])
+
+    with patch("reyn.chat.router_loop.call_llm_tools", spy):
+        await loop.run("user query", [])
+
+    assert spy.call_count == 2
+    retry_msgs = spy.messages_per_call[1]
+    directive_msgs = [
+        m for m in retry_msgs
+        if m.get("role") == "user" and m.get("content") == _DIRECTIVE
+    ]
+    assert len(directive_msgs) == 1, (
+        f"expected 1 directive user msg in retry, got {len(directive_msgs)}; "
+        f"roles in retry: {[m.get('role') for m in retry_msgs]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retry path preserves the existing audit chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_stop_event_still_emitted_on_retry_path(monkeypatch):
+    """Tier 2: the existing ``router_empty_response_detected`` audit event
+    is emitted BEFORE the retry path forks, so the P6 audit trail records
+    that an empty stop occurred regardless of recovery success.
+    """
+    monkeypatch.setenv("REYN_EMPTY_STOP_RETRY", "1")
+    host = FakeRouterHost()
+    loop = _make_loop(host, _DIRECTIVE)
+
+    scripted = _ScriptedLLM([_empty_stop_result(), text_result("recovered")])
+
+    with patch("reyn.chat.router_loop.call_llm_tools", scripted):
+        await loop.run("test", [])
+
+    emitted = [e["type"] for e in host._events.emitted]
+    assert "router_empty_response_detected" in emitted
+    # Event order: detected first, then retry injected
+    idx_detected = emitted.index("router_empty_response_detected")
+    idx_injected = emitted.index("router_empty_response_retry_injected")
+    assert idx_detected < idx_injected


### PR DESCRIPTION
**[dogfood-coder]** — fix B42-NF-W6-1 (HIGH) plan-step narration empty-stop. **ENV-var opt-in** (`REYN_EMPTY_STOP_RETRY=1`); default behaviour unchanged.

## Problem

B42 W6 plan_mode trio (s1-s3) showed user-visible "I can't access the documents" failure across 3 chain_ids. Trace replay on the W6-S1 step LLM post-tool call:

- N=10 baseline: **10/10 EMPTY_STOP** (= finish_reason=stop, content=None, completion_tokens=0)
- Verified raw upstream: same finish_reason via direct Gemini API call (= LiteLLM normalization / MALFORMED hypothesis falsified)
- max_completion_tokens not the issue (= verified by explicit raw-response inspection)

## Cross-provider documentation (= not Gemini-specific)

- **Anthropic** `handling-stop-reasons` docs: explicitly recommends "continuation prompts as a last resort" for this pattern
- **Hermes-agent #9400**: direct precedent for detect-and-inject implementation
- **vercel/ai #4126**: same pattern on Google Vertex + OpenAI
- **openclaw #71880**: Claude Opus 4.6/4.7 "false-success empty terminal turns"

## Fix

**Detect-and-retry with continuation prompt**, ENV-var-gated:

1. RouterLoop gets `empty_stop_retry_directive: str | None` constructor param + reads `REYN_EMPTY_STOP_RETRY=1` env var at runtime
2. On empty-stop: if env var set AND directive set AND <1 retry in this turn → append synthetic `role="user"` directive msg, retry once
3. Retry bounded at 1 per turn (= 2nd empty stop falls through to existing observe+surface)
4. `planner.py` passes `_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE` to both sub_loop construction sites
5. Audit event `router_empty_response_retry_injected` emitted (= P6 chain)

## Trace-patch-replay verification (= `feedback_verify_fix_via_replay_before_land` discipline)

| variant | recovery |
|---|---|
| baseline | 0/10 (0%) |
| SP injection | 5/10 (50%) |
| append text to tool result | 0/10 (0%) |
| truncate content | 0/5 (0%) |
| drop `_g12_signal` | 2/10 (20%) |
| strong imperative SP | 1/10 (10%) |
| **synthetic user-msg retry** | **10/10 (100%)** |

Content quality verified by spot-check (= 371-token / 2000-char accurate summary of permission-model.md, not hollow inflation).

## Test plan

- [x] 6 new Tier 2 tests pass (`test_router_loop_empty_stop_retry.py`)
- [x] 351/351 plan / router_loop / planner regression
- [x] Trace-patch-replay 0% → 100% (= primary data, not extrapolation)
- [x] Cross-provider documentation cited (= Anthropic + Hermes-agent + Vercel + openclaw)
- [x] ENV var unset = no behaviour change (= regression test pins this)
- [x] Default chat router empty-stop policy preserved (= directive None path pinned)

## Design notes

Initial design (= always-inject after every tool round) was discarded after user review surfaced semantic concerns ("duplicate of `_g12_signal` / `_post_text`, OS one-shot policy inconsistency"). Replaced with env-var-gated retry which matches Anthropic/Hermes-agent community pattern + lands no default behaviour change.

## Related

- Anthropic `handling-stop-reasons` — official continuation-prompt recommendation
- Hermes-agent #9400 — community precedent for the pattern
- PR #221 / PR #207 — same envelope-layer family at different layers
- B42 NF-W6-B42-1 retrospective entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)