### PR TITLE
feat(mcp): wire progress_callback + per-call timeout for long-running tool calls (issue #264 (a)+(b))

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -654,6 +654,7 @@ mcp:
 | `env` | map[string,string] | stdio（任意） | 起動プロセスへの追加環境変数。値は `${VAR}` 展開に対応。 |
 | `url` | string | http, sse | エンドポイント URL。 |
 | `headers` | map[string,string] | http, sse（任意） | 静的リクエストヘッダー。値は `${VAR}` 展開に対応。 |
+| `call_timeout_seconds` | float | すべて（任意） | MCP SDK の `read_timeout_seconds` に渡される per-call リクエストタイムアウト。 未設定の場合は SDK デフォルトが適用される（= Reyn 側で override しない、 transport-specific の SDK timeout が支配）。 特定 server が遅いと分かっている場合、 あるいは速い + fail-fast したい場合に設定する。 `timeout` (= `type: http` の HTTP transport connect timeout) とは独立。 |
 
 サーバーは設定ソースをまたいでマージされます: `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml`。マージは `mcp.servers` キーの shallow union です。マシンごとの `reyn.local.yaml` が残りを再宣言せずに単一サーバーを追加・上書きできます。
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -670,6 +670,7 @@ mcp:
 | `env` | map[string,string] | stdio (optional) | Extra environment variables for the spawned process. Values support `${VAR}` expansion. |
 | `url` | string | http, sse | Endpoint URL. |
 | `headers` | map[string,string] | http, sse (optional) | Static request headers. Values support `${VAR}` expansion. |
+| `call_timeout_seconds` | float | all (optional) | Per-call request timeout passed to the MCP SDK's `read_timeout_seconds`. Unset → SDK default applies (= no Reyn-level override; the SDK's transport-specific timeout governs). Set when a specific server is known to be slow or known to be quick + you want `fail-fast`. Independent of `timeout` (which is the HTTP transport's connect timeout for `type: http`). |
 
 `${VAR}` in any string value is expanded from `os.environ` at startup (after `~/.reyn/secrets.env` is loaded). Missing variables expand to `""` and emit a runtime warning. Use `reyn secret set` to store values in `~/.reyn/secrets.env` — never paste tokens into `reyn.yaml` directly.
 

--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -117,6 +117,97 @@ class ChatEventForwarder:
         """
         self._enqueue("detail: ", source_run_id=data.get("run_id"))
 
+    def on_mcp_progress(self, data: dict) -> None:
+        """MCP tool emitted a progress notification — surface in sticky status.
+
+        issue #264: MCP servers can stream ``notifications/progress`` while
+        a tool call is in flight. Pre-#264 these were silently dropped
+        because the Reyn client didn't pass a ``progress_callback`` to the
+        SDK. Now the op handler wires the callback, emits ``mcp_progress``
+        events, and this forwarder converts each event into a
+        ``OutboxMessage(kind="status")`` with ``meta.source="mcp"`` so the
+        TUI sticky bar shows "what is the MCP server doing right now".
+
+        Per the issue #264 owner decision (lead-coder + tui-coder alignment):
+        ``kind="status"`` is the canonical surface for "long-running external
+        operation visibility"; the ``meta.source`` discriminator lets future
+        per-source styling decisions land without changing the kind.
+
+        The β fallback path (= route through ``set_detail`` via
+        ``kind="trace"``) remains a future option if dogfood observes
+        sticky overwrite issues between MCP progress and LLM "thinking"
+        — empirical fallback path documented on issue #264.
+        """
+        server = data.get("server") or "?"
+        tool = data.get("tool") or "?"
+        progress = data.get("progress")
+        total = data.get("total")
+        message = data.get("message")
+
+        text = self._format_mcp_progress(server, tool, progress, total, message)
+
+        meta: dict = {
+            "source": "mcp",
+            "server": server,
+            "tool": tool,
+        }
+        if progress is not None:
+            meta["progress"] = progress
+        if total is not None:
+            meta["total"] = total
+        if message:
+            meta["progress_text"] = message
+        source_run_id = data.get("run_id")
+        if source_run_id:
+            meta["run_id"] = source_run_id
+            meta["run_id_short"] = source_run_id[-4:]
+
+        try:
+            self.outbox.put_nowait(
+                OutboxMessage(kind="status", text=text, meta=meta),
+            )
+        except asyncio.QueueFull:
+            pass
+
+    @staticmethod
+    def _format_mcp_progress(
+        server: str,
+        tool: str,
+        progress: object,
+        total: object,
+        message: object,
+    ) -> str:
+        """Build the human-readable sticky-status text for an MCP progress event.
+
+        Branches:
+          - progress + total both numeric and total > 0 → percentage
+          - progress numeric, total absent / zero → raw progress value
+          - neither → bare ``[mcp/<server>] <tool>`` indicator
+          - message present → appended as ``· <message>``
+
+        Pure formatter so tests can pin the rendering without mounting a forwarder.
+        """
+        head = f"[mcp/{server}] {tool}"
+        body = ""
+        try:
+            prog_f = float(progress) if progress is not None else None
+        except (TypeError, ValueError):
+            prog_f = None
+        try:
+            tot_f = float(total) if total is not None else None
+        except (TypeError, ValueError):
+            tot_f = None
+        if prog_f is not None and tot_f is not None and tot_f > 0:
+            pct = (prog_f / tot_f) * 100
+            body = f" · {pct:.0f}%"
+        elif prog_f is not None:
+            # Indeterminate total — show raw progress value as-is.
+            body = f" · progress={prog_f:g}"
+        text = head + body
+        if message:
+            text += f" · {message}"
+        return text
+
     def on_act_executed(self, data: dict) -> None:
         """Control IR ops just ran — show a short summary as detail.
 

--- a/src/reyn/mcp_client.py
+++ b/src/reyn/mcp_client.py
@@ -144,14 +144,38 @@ class MCPClient:
         self._session = session
         self._initialized = True
 
-    async def call_tool(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+    async def call_tool(
+        self,
+        name: str,
+        args: dict[str, Any],
+        *,
+        progress_callback: Any = None,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, Any]:
         """Call ``name`` on the server with ``args``. Returns a dict
         shaped to match what ``op_runtime/mcp.py`` consumes:
         ``{"content": [...], "isError": bool, "structuredContent": ... | None}``.
+
+        Optional kwargs (issue #264 — wire SDK long-running support):
+
+          - ``progress_callback``: async ``(progress: float, total: float | None,
+            message: str | None) -> None`` that the MCP SDK invokes when the
+            server emits a ``notifications/progress`` for this call. Default
+            ``None`` matches pre-#264 behaviour (= no progress visibility).
+          - ``timeout_seconds``: float; if set, converts to ``timedelta`` and
+            passes as ``read_timeout_seconds`` to the SDK so the call fails
+            fast on a stuck server. Default ``None`` keeps the SDK's own
+            transport-level default.
         """
         await self.initialize()
+        kwargs: dict[str, Any] = {}
+        if progress_callback is not None:
+            kwargs["progress_callback"] = progress_callback
+        if timeout_seconds is not None:
+            from datetime import timedelta
+            kwargs["read_timeout_seconds"] = timedelta(seconds=timeout_seconds)
         try:
-            result = await self._session.call_tool(name, args or {})
+            result = await self._session.call_tool(name, args or {}, **kwargs)
         except Exception as exc:
             raise MCPError(f"MCP tools/call error: {exc}") from exc
         return _result_to_dict(result)

--- a/src/reyn/op_runtime/mcp.py
+++ b/src/reyn/op_runtime/mcp.py
@@ -46,9 +46,48 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
                     "tool": op.tool, "error": str(exc)}
     client = ctx.mcp_clients[op.server]
 
+    # issue #264 — wire MCP SDK progress + per-call timeout:
+    #
+    #   progress: forward server-emitted notifications/progress as
+    #   ``mcp_progress`` events so the ChatEventForwarder can surface
+    #   them in the TUI sticky status (= long-running MCP call
+    #   visibility, the A2A PR #253 analogue for the client side).
+    #
+    #   timeout: per-server ``call_timeout_seconds`` from the raw config
+    #   dict; absent → SDK default applies (= no behaviour change for
+    #   existing configs that omit the key).
+    server_name = op.server
+    tool_name = op.tool
+
+    async def _on_progress(
+        progress: float, total: float | None, message: str | None,
+    ) -> None:
+        ctx.events.emit(
+            "mcp_progress",
+            server=server_name,
+            tool=tool_name,
+            progress=progress,
+            total=total,
+            message=message,
+        )
+
+    call_timeout = None
+    try:
+        ct = expanded.get("call_timeout_seconds")
+        if ct is not None:
+            call_timeout = float(ct)
+            if call_timeout <= 0:
+                call_timeout = None
+    except (TypeError, ValueError):
+        call_timeout = None
+
     ctx.events.emit("mcp_called", server=op.server, tool=op.tool, args=op.args)
     try:
-        result = await client.call_tool(op.tool, op.args)
+        result = await client.call_tool(
+            op.tool, op.args,
+            progress_callback=_on_progress,
+            timeout_seconds=call_timeout,
+        )
     except MCPError as exc:
         ctx.events.emit("mcp_failed", server=op.server, tool=op.tool, error=str(exc))
         return {"kind": "mcp", "status": "error", "server": op.server,

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -1,0 +1,479 @@
+"""Tier 2: MCP long-running tool call — progress callback + per-call
+timeout wire-up (issue #264 (a)+(b)).
+
+Pins the contract that the MCP SDK's ``progress_callback`` and
+``read_timeout_seconds`` features — which were present at the SDK
+level but unused by the Reyn integration before this PR — are now
+forwarded end-to-end:
+
+  1. ``MCPClient.call_tool`` accepts ``progress_callback`` /
+     ``timeout_seconds`` kwargs and passes them to the SDK session.
+  2. ``op_runtime.mcp._execute`` builds a progress callback that emits
+     ``mcp_progress`` events on the run's EventLog so subscribers can
+     observe what the MCP server is doing.
+  3. ``op_runtime.mcp._execute`` reads ``call_timeout_seconds`` from the
+     server's raw config dict (the per-server entry under
+     ``mcp.servers.<name>``) and forwards it to ``MCPClient.call_tool``.
+  4. ``ChatEventForwarder.on_mcp_progress`` converts an ``mcp_progress``
+     event into an ``OutboxMessage(kind="status")`` with
+     ``meta.source="mcp"`` per the issue #264 owner-decision shape.
+
+The outbox shape pin (kind / required meta keys) is the issue #264
+analogue of PR #258's
+``test_outbox_intervention_meta_shape_is_stable``: shape stability is
+inscribed at PR-landing time so a future refactor cannot drift the TUI
+contract silently.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from reyn.chat.forwarder import ChatEventForwarder
+from reyn.chat.outbox import OutboxMessage
+from reyn.events.events import EventLog
+from reyn.mcp_client import MCPClient
+from reyn.schemas.models import MCPIROp
+
+# ── 1. MCPClient.call_tool signature accepts the new kwargs ────────────
+
+
+def test_call_tool_signature_accepts_progress_callback_and_timeout() -> None:
+    """Tier 2: the public surface gains keyword-only ``progress_callback`` and
+    ``timeout_seconds`` parameters. issue #264 (a)+(b).
+    """
+    sig = inspect.signature(MCPClient.call_tool)
+    params = sig.parameters
+    assert "progress_callback" in params
+    assert "timeout_seconds" in params
+    assert params["progress_callback"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["timeout_seconds"].kind == inspect.Parameter.KEYWORD_ONLY
+    # Default-None preserves pre-#264 behaviour for callers that don't pass them.
+    assert params["progress_callback"].default is None
+    assert params["timeout_seconds"].default is None
+
+
+def test_call_tool_passes_progress_callback_and_timedelta_to_sdk_session() -> None:
+    """Tier 2: when both kwargs are set, ``MCPClient.call_tool`` forwards them
+    to ``self._session.call_tool`` using the SDK's parameter names
+    (``progress_callback`` and ``read_timeout_seconds`` as a ``timedelta``).
+    """
+    captured: dict[str, Any] = {}
+
+    class _FakeResult:
+        content: list = []
+        isError: bool = False
+        structuredContent: Any = None
+        meta: Any = None
+
+        def model_dump(self, mode: str = "json") -> dict:
+            return {"content": [], "isError": False}
+
+    class _FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> _FakeResult:
+            captured["name"] = name
+            captured["arguments"] = arguments
+            captured["kwargs"] = kwargs
+            return _FakeResult()
+
+    # Hand-construct a half-initialised client that bypasses the real
+    # transport. The signature accepts a config dict + sets internal
+    # state directly so we don't have to spawn a subprocess.
+    client = MCPClient({"type": "stdio", "command": "/bin/true"})
+    client._initialized = True
+    client._session = _FakeSession()
+
+    async def _on_progress(progress: float, total: float | None, msg: str | None) -> None:
+        return None
+
+    asyncio.run(
+        client.call_tool(
+            "demo",
+            {"x": 1},
+            progress_callback=_on_progress,
+            timeout_seconds=4.5,
+        ),
+    )
+
+    assert captured["name"] == "demo"
+    assert captured["arguments"] == {"x": 1}
+    assert captured["kwargs"].get("progress_callback") is _on_progress
+    read_to = captured["kwargs"].get("read_timeout_seconds")
+    assert isinstance(read_to, timedelta)
+    assert read_to == timedelta(seconds=4.5)
+
+
+def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
+    """Tier 2: with default-None kwargs, neither ``progress_callback`` nor
+    ``read_timeout_seconds`` is added to the SDK call — preserves
+    pre-#264 behaviour exactly so configs that omit the new keys see
+    no observable change.
+    """
+    captured: dict[str, Any] = {}
+
+    class _FakeResult:
+        def model_dump(self, mode: str = "json") -> dict:
+            return {"content": [], "isError": False}
+
+    class _FakeSession:
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> _FakeResult:
+            captured["kwargs"] = kwargs
+            return _FakeResult()
+
+    client = MCPClient({"type": "stdio", "command": "/bin/true"})
+    client._initialized = True
+    client._session = _FakeSession()
+
+    asyncio.run(client.call_tool("demo", {"x": 1}))
+
+    assert "progress_callback" not in captured["kwargs"]
+    assert "read_timeout_seconds" not in captured["kwargs"]
+
+
+# ── 2. op_runtime.mcp emits mcp_progress events from the SDK callback ──
+
+
+def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
+    """Tier 2: ``_execute`` builds an ``async _on_progress`` callback that,
+    when invoked by the MCP SDK, emits an ``mcp_progress`` event on the
+    run's EventLog with structured fields the forwarder consumes.
+    """
+    from reyn.op_runtime import mcp as mcp_op_handler
+
+    captured_callback: dict[str, Any] = {}
+
+    class _FakeResult:
+        def model_dump(self, mode: str = "json") -> dict:
+            return {"content": [], "isError": False}
+
+    class _CapturingSession:
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> _FakeResult:
+            # Capture the callback the op handler passed; the SDK would
+            # invoke this with (progress, total, message) when the server
+            # sends notifications/progress.
+            captured_callback["cb"] = kwargs.get("progress_callback")
+            captured_callback["read_timeout_seconds"] = kwargs.get(
+                "read_timeout_seconds",
+            )
+            # Simulate two progress notifications mid-call.
+            cb = kwargs.get("progress_callback")
+            if cb is not None:
+                await cb(0.25, 1.0, "starting")
+                await cb(1.0, 1.0, "done")
+            return _FakeResult()
+
+    # Build a minimal OpContext.
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    ctx = OpContext(
+        workspace=None,  # type: ignore[arg-type]
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        mcp_servers={"demo": {"type": "stdio", "command": "/bin/true"}},
+        mcp_clients={},
+    )
+    # Pre-install a fake client so MCPClient construction is skipped.
+    client = MCPClient({"type": "stdio", "command": "/bin/true"})
+    client._initialized = True
+    client._session = _CapturingSession()
+    ctx.mcp_clients["demo"] = client
+
+    op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
+    asyncio.run(mcp_op_handler._execute(op, ctx))
+
+    # Two mcp_progress events should have been emitted with the
+    # structured fields the forwarder consumes.
+    progress_events = [
+        e.model_dump(mode="json") for e in events.all()
+        if e.type == "mcp_progress"
+    ]
+    assert len(progress_events) == 2
+    first = progress_events[0]
+    assert first["data"]["server"] == "demo"
+    assert first["data"]["tool"] == "thing"
+    assert first["data"]["progress"] == 0.25
+    assert first["data"]["total"] == 1.0
+    assert first["data"]["message"] == "starting"
+    last = progress_events[-1]
+    assert last["data"]["progress"] == 1.0
+    assert last["data"]["message"] == "done"
+
+
+def test_op_handler_reads_call_timeout_from_server_config() -> None:
+    """Tier 2: when ``mcp.servers.<name>.call_timeout_seconds`` is set, the
+    op handler reads it from the raw config dict and forwards as
+    ``timeout_seconds`` to ``MCPClient.call_tool`` (which converts to
+    ``timedelta`` and passes as ``read_timeout_seconds`` to the SDK).
+    """
+    from reyn.op_runtime import mcp as mcp_op_handler
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResult:
+        def model_dump(self, mode: str = "json") -> dict:
+            return {"content": [], "isError": False}
+
+    class _CapturingSession:
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> _FakeResult:
+            captured["read_timeout_seconds"] = kwargs.get(
+                "read_timeout_seconds",
+            )
+            return _FakeResult()
+
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    ctx = OpContext(
+        workspace=None,  # type: ignore[arg-type]
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        mcp_servers={
+            "demo": {
+                "type": "stdio",
+                "command": "/bin/true",
+                "call_timeout_seconds": 7.5,
+            },
+        },
+        mcp_clients={},
+    )
+    client = MCPClient(
+        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 7.5},
+    )
+    client._initialized = True
+    client._session = _CapturingSession()
+    ctx.mcp_clients["demo"] = client
+
+    op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
+    asyncio.run(mcp_op_handler._execute(op, ctx))
+
+    read_to = captured["read_timeout_seconds"]
+    assert isinstance(read_to, timedelta)
+    assert read_to == timedelta(seconds=7.5)
+
+
+def test_op_handler_treats_missing_or_invalid_call_timeout_as_unset() -> None:
+    """Tier 2: when the config omits ``call_timeout_seconds`` OR sets it
+    to a non-positive / non-numeric value, the op handler forwards
+    ``timeout_seconds=None`` so the SDK default applies.
+
+    Pinning the defensive handling here avoids surprising fail-fasts
+    from typos like ``call_timeout_seconds: -1`` or ``"slow"``.
+    """
+    from reyn.op_runtime import mcp as mcp_op_handler
+
+    cases: list[dict[str, Any]] = [
+        {"type": "stdio", "command": "/bin/true"},  # missing key
+        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 0},
+        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": -1},
+        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": "slow"},
+    ]
+    for cfg in cases:
+        captured: dict[str, Any] = {}
+
+        class _FakeResult:
+            def model_dump(self, mode: str = "json") -> dict:
+                return {"content": [], "isError": False}
+
+        class _CapturingSession:
+            async def call_tool(
+                self,
+                name: str,
+                arguments: dict[str, Any] | None = None,
+                **kwargs: Any,
+            ) -> _FakeResult:
+                captured["kwargs"] = kwargs
+                return _FakeResult()
+
+        from reyn.op_runtime.context import OpContext
+        from reyn.permissions.permissions import PermissionDecl
+
+        events = EventLog()
+        ctx = OpContext(
+            workspace=None,  # type: ignore[arg-type]
+            events=events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=None,
+            mcp_servers={"demo": cfg},
+            mcp_clients={},
+        )
+        client = MCPClient(cfg)
+        client._initialized = True
+        client._session = _CapturingSession()
+        ctx.mcp_clients["demo"] = client
+
+        op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
+        asyncio.run(mcp_op_handler._execute(op, ctx))
+
+        # SDK was called with no read_timeout_seconds → default applies.
+        assert "read_timeout_seconds" not in captured["kwargs"], (
+            f"cfg {cfg!r} should NOT yield read_timeout_seconds (= unset → SDK default), "
+            f"got kwargs={captured['kwargs']}"
+        )
+
+
+# ── 3. ChatEventForwarder.on_mcp_progress turns events into outbox msgs ─
+
+
+def test_forwarder_on_mcp_progress_emits_status_outbox_message() -> None:
+    """Tier 2: an ``mcp_progress`` event flows through ``ChatEventForwarder``
+    into an ``OutboxMessage(kind="status")`` with ``meta.source="mcp"``
+    and the structured fields the TUI sticky renderer consumes.
+    """
+    outbox: asyncio.Queue[OutboxMessage] = asyncio.Queue(maxsize=10)
+    forwarder = ChatEventForwarder("demo_skill", outbox)
+
+    forwarder.on_mcp_progress({
+        "server": "fs",
+        "tool": "read_file",
+        "progress": 0.5,
+        "total": 1.0,
+        "message": "reading bytes",
+        "run_id": "abc123",
+    })
+
+    msg = outbox.get_nowait()
+    assert msg.kind == "status"
+    # Sticky text: percentage + message + run-id tag in meta.
+    assert "[mcp/fs] read_file" in msg.text
+    assert "50%" in msg.text
+    assert "reading bytes" in msg.text
+
+    # Required meta keys per the issue #264 owner-decision shape.
+    assert msg.meta["source"] == "mcp"
+    assert msg.meta["server"] == "fs"
+    assert msg.meta["tool"] == "read_file"
+    assert msg.meta["progress"] == 0.5
+    assert msg.meta["total"] == 1.0
+    assert msg.meta["progress_text"] == "reading bytes"
+    assert msg.meta["run_id"] == "abc123"
+    assert msg.meta["run_id_short"] == "c123"
+
+
+def test_forwarder_on_mcp_progress_handles_indeterminate_total() -> None:
+    """Tier 2: when the server emits progress without a total (= no known
+    upper bound), the status text shows the raw value rather than a
+    misleading percentage.
+    """
+    outbox: asyncio.Queue[OutboxMessage] = asyncio.Queue(maxsize=10)
+    forwarder = ChatEventForwarder("demo_skill", outbox)
+
+    forwarder.on_mcp_progress({
+        "server": "scraper",
+        "tool": "fetch",
+        "progress": 42,
+        "total": None,
+        "message": None,
+    })
+
+    msg = outbox.get_nowait()
+    assert msg.kind == "status"
+    assert "[mcp/scraper] fetch" in msg.text
+    assert "progress=42" in msg.text
+    assert "total" not in msg.meta or msg.meta.get("total") is None
+
+
+def test_forwarder_on_mcp_progress_dispatch_via_call_routes_event_type() -> None:
+    """Tier 2: an ``mcp_progress`` event delivered via the forwarder's
+    ``__call__`` dispatch (= the actual subscriber call path used by
+    EventLog.emit subscribers) reaches ``on_mcp_progress``.
+
+    Verifies the type-suffix dispatcher (``getattr(self, f"on_{event.type}")``)
+    matches "mcp_progress" → ``on_mcp_progress``.
+    """
+    from reyn.schemas.models import Event
+
+    outbox: asyncio.Queue[OutboxMessage] = asyncio.Queue(maxsize=10)
+    forwarder = ChatEventForwarder("demo_skill", outbox)
+
+    event = Event(
+        type="mcp_progress",
+        data={
+            "server": "fs",
+            "tool": "read",
+            "progress": 1.0,
+            "total": 1.0,
+        },
+    )
+    forwarder(event)
+
+    msg = outbox.get_nowait()
+    assert msg.kind == "status"
+    assert msg.meta["source"] == "mcp"
+
+
+# ── 4. Outbox shape stability commitment (issue #264 owner decision) ───
+
+
+def test_mcp_progress_outbox_meta_required_keys_are_stable() -> None:
+    """Tier 2: the ``kind="status"`` + ``meta.source="mcp"`` shape used for
+    MCP progress notifications has stable required keys per the issue
+    #264 owner decision. This is the issue #264 analogue of PR #258's
+    ``test_outbox_intervention_meta_shape_is_stable`` — pinning the TUI
+    contract at PR landing time.
+
+    Required keys: ``source`` / ``server`` / ``tool``. Optional fields
+    (``progress`` / ``total`` / ``progress_text`` / ``run_id`` /
+    ``run_id_short``) are added when the underlying event carries them.
+    """
+    outbox: asyncio.Queue[OutboxMessage] = asyncio.Queue(maxsize=10)
+    forwarder = ChatEventForwarder("demo_skill", outbox)
+
+    # Minimal event: only server + tool.
+    forwarder.on_mcp_progress({"server": "fs", "tool": "ls"})
+    msg = outbox.get_nowait()
+    assert msg.kind == "status"
+    assert set(msg.meta.keys()) >= {"source", "server", "tool"}, (
+        f"required meta keys are source/server/tool, got: {sorted(msg.meta.keys())}"
+    )
+    assert msg.meta["source"] == "mcp"
+    # Optional fields absent on minimal events.
+    for opt in ("progress", "total", "progress_text", "run_id", "run_id_short"):
+        assert opt not in msg.meta or msg.meta[opt] is None or msg.meta[opt] == 0
+
+
+# ── 5. SDK-passing grep-pin (= belt-and-suspenders against future drift) ─
+
+
+def test_mcp_client_call_tool_forwards_progress_and_timeout_kwargs() -> None:
+    """Tier 2: source-level pin that ``MCPClient.call_tool`` constructs the
+    SDK kwargs from ``progress_callback`` / ``timeout_seconds``. Catches
+    a future refactor that quietly drops the kwargs without noticing
+    the round-trip tests still pass (= belt-and-suspenders for the
+    behavioural test above).
+    """
+    src = inspect.getsource(MCPClient.call_tool)
+    # Both kwargs must appear in the SDK kwargs builder.
+    assert "progress_callback" in src
+    assert "read_timeout_seconds" in src
+    assert "timedelta" in src, (
+        "timeout_seconds must be converted to a timedelta before the SDK call"
+    )


### PR DESCRIPTION
**[e2e-coder]** — issue #264 (a)+(b) — owner-decision accepted path.

Refs #264. Depends on no prior PR in the #264 chain. (c) sync→Task escalation deferred per owner-decision, gated on post-merge empirical observation.

## Problem

Pre-#264 the Reyn MCP integration didn't pass `progress_callback` / `read_timeout_seconds` to the underlying MCP SDK `call_tool`, so:

1. **Long-running MCP tool calls left the TUI silent** — no progress visibility, the client-side analogue of the problem PR #253 solved for A2A.
2. **Per-server fail-fast was unavailable** — only the SDK transport default applied; configs couldn't override.

## Architecture

```
MCP server emits notifications/progress (SDK-level)
   │
   ▼
MCPClient.call_tool (kwargs forwarded to SDK session)
   │
   ▼
op_runtime/mcp._execute (builds async _on_progress callback)
   │  ctx.events.emit("mcp_progress", server, tool, progress, total, message)
   ▼
EventLog subscribers (including ChatEventForwarder)
   │
   ▼
ChatEventForwarder.on_mcp_progress (= subscriber-via-getattr dispatch)
   │  put OutboxMessage(kind="status", meta={"source": "mcp", ...})
   ▼
TUI sticky status bar — user sees "[mcp/<server>] <tool> · 45%"
```

## What this PR ships

### Production (3 files)

- **`src/reyn/mcp_client.py`**: `MCPClient.call_tool` gains keyword-only `progress_callback` and `timeout_seconds` kwargs. Default-None preserves pre-#264 behaviour for callers that don't pass them. `timeout_seconds` converts to `timedelta` and forwards as `read_timeout_seconds` per the MCP SDK signature.
- **`src/reyn/op_runtime/mcp.py`**: `_execute` builds an async `_on_progress(progress, total, message)` callback that emits `mcp_progress` events on the run's EventLog, and reads `call_timeout_seconds` from the server's raw config dict. Defensive against typos (missing key / non-positive / non-numeric → SDK default).
- **`src/reyn/chat/forwarder.py`**: `ChatEventForwarder.on_mcp_progress` converts events into `OutboxMessage(kind="status")` with `meta.source="mcp"`. Text formatter handles three branches: known total → percentage, indeterminate total → raw value, no progress → bare indicator. Optional message suffix.

### Docs (2 files)

- **`docs/reference/config/reyn-yaml.md` + `.ja.md`**: document the new `mcp.<server>.call_timeout_seconds` config key, explicitly distinguishing it from the existing `timeout` (http-transport connect timeout).

### Tier 2 contract test (`tests/test_mcp_progress_and_timeout.py`, 11 tests)

| # | Test | Pins |
|---|---|---|
| 1 | `test_call_tool_signature_accepts_progress_callback_and_timeout` | API shape |
| 2 | `test_call_tool_passes_progress_callback_and_timedelta_to_sdk_session` | SDK kwarg forwarding |
| 3 | `test_call_tool_omits_kwargs_when_none_for_backwards_compat` | **Backwards-compat 100% for unchanged configs** |
| 4 | `test_op_handler_progress_callback_emits_mcp_progress_event` | Event emit chain |
| 5 | `test_op_handler_reads_call_timeout_from_server_config` | Config-to-SDK plumbing |
| 6 | `test_op_handler_treats_missing_or_invalid_call_timeout_as_unset` | **Defensive: 4 invalid-config cases all fall back to SDK default** |
| 7 | `test_forwarder_on_mcp_progress_emits_status_outbox_message` | Outbox shape (= issue #264 owner-decision pin) |
| 8 | `test_forwarder_on_mcp_progress_handles_indeterminate_total` | No-total branch shows raw value |
| 9 | `test_forwarder_on_mcp_progress_dispatch_via_call_routes_event_type` | EventLog subscriber → `on_mcp_progress` routing |
| 10 | `test_mcp_progress_outbox_meta_required_keys_are_stable` | **Issue #264 outbox shape commitment** (= analogue of PR #258's `test_outbox_intervention_meta_shape_is_stable`) |
| 11 | `test_mcp_client_call_tool_forwards_progress_and_timeout_kwargs` | Source-level grep-pin against future drift |

## Owner-decision scope guard compliance

Per lead-coder's #264 owner decision (https://github.com/tya5/reyn/issues/264#issuecomment-4488440767 + re-confirm):

| Scope guard | Where pinned |
|---|---|
| **backwards-compat 100% 維持** (SDK default 維持) | Test #3 (no-kwargs path) + Test #6 (missing/invalid config → no SDK-level passing) |
| **`OutboxMessage(kind="status")` shape commitment** | Test #7 + #10 (required keys / kind / source) |
| **MCP server name / tool name の skill-specific hardcode 禁止 (P7)** | Server / tool / progress all flow through ctx.events / meta as data; no string literals in OS code |
| **progress event の audit chain landing (P6)** | events.jsonl emit via `ctx.events.emit("mcp_progress", ...)` — verified in test #4 + #5 |

## β fallback path — not landed, but inscribed

tui-coder's β option (= route via `kind="trace"` + `set_detail` to avoid sticky overwrite vs LLM `thinking`) remains a future option per their empirical-fallback handoff. Owner decision: ship `kind="status"` first + revisit if dogfood observes the conflict. Documented inline in `on_mcp_progress` docstring so future readers can find the path.

## Test plan

- [x] **Automated — `pytest tests/test_mcp_progress_and_timeout.py`**: 11/11 pass。
- [x] **Adjacent — `pytest tests/test_mcp_client.py tests/test_mcp_unified.py tests/test_mcp_client_stderr_capture.py tests/test_mcp_lazy_tools_cache.py`** (= MCP client + recent MCP-surface fixes from PR #243/#244/#245): full pass。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --ignore=tests/test_a2a_sync_async_escalation.py --timeout=30`**: 4005 passed, 11 skipped, 3 xfailed in 139s (= +11 new tests from this PR vs main)。 `test_a2a_sync_async_escalation.py` の skip は PR #253 由来 fastapi env gap で本 PR 起因ではない。
- [x] **Lint — `ruff check`**: clean on all touched files。
- [ ] **Manual TUI verify — sticky-conflict empirical check** (owner-decision Manual scope clarification per issue #264 comment):
  - [ ] MCP tool call (= long-running、 progress notification あり) を sync mode で fire
  - [ ] 同時に LLM が router_loop で thinking sticky 表示中であること
  - [ ] MCP progress notification 受信時に sticky が overwrite される / 別 surface に流れる / 共存 の挙動を観察
  - [ ] MCP 完了時に LLM thinking sticky が **戻る or 維持される** ことを confirm
  - [ ] 戻らない場合は PR review で β 採用 revise 議論 (= owner-decision option A path)

I (e2e-coder) don't fire TUI in this env, so the Manual verify needs tui-coder / user. Marking as **owner-decision-waivered** per the calibration of PR #246 / PR #258 (= reviewer-side acknowledgement that the manual item is out-of-reach for the author).

## (c) follow-up tracker

Per owner-decision, (c) sync→Task escalation = MCP-side router_loop wait protocol change is **deferred**. I'll file the follow-up issue when:
1. This PR merges
2. ~1-2 weeks of dogfood data accumulate to inform the design
3. tui-coder Phase 4 sub-issue (= #261 source_agent + events tab) lands so the trace-channel surface is ready if β fallback is needed

## Related

- PR #253 (= A2A sync→Task escalation、 構造的 sibling — A2A is Reyn-as-server, MCP is Reyn-as-client, mirror shapes)
- PR #245 (= MCP stdio stderr capture、 同 client surface 改善 chain)
- PR #243 / #244 (= asyncio.timeout sweep、 timeout 系の直近 improvement)
- issue #254 5-phase refactor (= AST walker grep-pin + Tier 2 shape stability pattern、 本 PR の test #11 + #10 で再活用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)