### PR TITLE
fix(a2a): lower capability claim to honest interim state — Gap 3 Z-b (refs #267)

### DIFF
--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -93,9 +93,31 @@ def _build_agent_card(agent_name: str, role: str, base_url: str) -> dict:
       * ``name`` — the Reyn agent name (= addressable identity).
       * ``description`` — the agent's ``role`` text from profile.yaml.
       * ``url`` — the JSON-RPC endpoint to POST to.
-      * ``capabilities`` — streaming and pushNotifications are now True
-        (= FP-0001 adds async task lifecycle + SSE + webhook support).
-        ``stateTransitionHistory`` remains False (= no plans to implement).
+      * ``capabilities`` — issue #267 Gap 3 Z-b interim disclosure:
+        ``streaming`` and ``pushNotifications`` are currently advertised
+        as ``False`` to honestly reflect the **partial implementation
+        state**, not the FP-0001 design intent. Concretely:
+
+          - ``streaming``: SSE endpoint exists (``GET /a2a/tasks/{run_id}/events``)
+            but ``RunRegistry.append_event`` has no in-tree producer
+            (= history_events stays empty in production), so streaming
+            never delivers in-flight events. Claim was ``True`` pre-#267
+            but the empty stream was misleading. issue #267 Gap 1 tracks
+            the producer-wiring work; this claim flips back to ``True``
+            via Gap 3 Z-a once SSE is functional.
+          - ``pushNotifications``: webhook fires on exactly three
+            triggers (= ``completed`` / ``failed`` / ``input-required``).
+            spec-conformance-strict peers reading the ``True`` claim
+            would expect notifications for any state change, which we
+            don't deliver. issue #267 Gap 2 tracks the trigger
+            expansion; same Gap 3 Z-a re-evaluation criteria.
+
+        ``stateTransitionHistory`` remains ``False`` (= no plans to
+        implement). The interim ``False`` state is **honest
+        disclosure**: peers can rely on what we declare. Existing
+        webhook-using peers can still POST + receive on the three
+        trigger events; the capability advertising doesn't gate
+        functionality, only the spec-level negotiation.
       * ``skills`` — A2A's ``skill`` is an outward-facing capability,
         not Reyn's internal skill graph. We expose a single coarse-
         grained skill (``chat``) since each Reyn agent's actual
@@ -110,8 +132,13 @@ def _build_agent_card(agent_name: str, role: str, base_url: str) -> dict:
         "version": _REYN_A2A_VERSION,
         "protocolVersion": _A2A_PROTOCOL_VERSION,
         "capabilities": {
-            "streaming": True,
-            "pushNotifications": True,
+            # issue #267 Gap 3 Z-b: interim ``False`` until implementation
+            # catches up (= Gap 1 SSE producer / Gap 2 webhook trigger
+            # expansion). See docstring above for the full disclosure
+            # rationale. Gap 3 Z-a will re-evaluate flipping these back
+            # to ``True`` once Gap 1 + Gap 2 land.
+            "streaming": False,
+            "pushNotifications": False,
             "stateTransitionHistory": False,
         },
         "defaultInputModes": ["text/plain"],

--- a/tests/test_a2a_capability_claim_interim.py
+++ b/tests/test_a2a_capability_claim_interim.py
@@ -1,0 +1,132 @@
+"""Tier 2: A2A Agent Card capability claim — issue #267 Gap 3 Z-b interim disclosure.
+
+Pure-Python test that pins the interim ``False`` state of the
+``streaming`` and ``pushNotifications`` capabilities without booting
+FastAPI / TestClient. Calls ``_build_agent_card`` directly so the
+check runs in any environment (= the broader test_a2a.py /
+test_fp0001_a2a_endpoints.py tests need the optional ``fastapi``
+extra; this file does not).
+
+Pins:
+
+  1. ``streaming`` is ``False`` (= issue #267 Gap 1 SSE producer not
+     wired, history_events stays empty in production).
+  2. ``pushNotifications`` is ``False`` (= issue #267 Gap 2 webhook
+     trigger limited to completed / failed / input-required, claiming
+     ``True`` would mislead spec-conformance-strict peers).
+  3. ``stateTransitionHistory`` is ``False`` (= no plans to implement,
+     unchanged from FP-0001).
+  4. Required Agent Card fields stay shape-stable (= name / description
+     / url / version / protocolVersion / capabilities / defaultInputModes
+     / defaultOutputModes / skills) so the Gap 3 Z-b change is a
+     **value flip only**, not a schema change.
+
+Gap 3 Z-a (= flip ``True`` back) lands once Gap 1 + Gap 2 close; at
+that point this test's expected values flip to ``True`` and reference
+the Gap-completion PRs.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _maybe_skip_if_router_unavailable() -> None:
+    """Skip when ``reyn.web.routers.a2a`` can't import.
+
+    The module pulls in fastapi at top-level (= ``from fastapi import
+    APIRouter, ...``); environments without the optional extra simply
+    skip. CI has fastapi installed; local dev may not. issue #253
+    introduced the dependency.
+    """
+    try:
+        import reyn.web.routers.a2a  # noqa: F401
+    except ImportError as exc:
+        pytest.skip(f"reyn.web.routers.a2a unavailable: {exc}")
+
+
+def test_agent_card_streaming_is_false_until_gap1_lands() -> None:
+    """Tier 2: ``streaming`` capability is False (= issue #267 Gap 3 Z-b).
+
+    SSE endpoint exists at GET /a2a/tasks/{run_id}/events but
+    history_events has no in-tree producer, so streaming never delivers
+    in-flight events. Claiming True would mislead spec-conformance peers.
+    Gap 3 Z-a flips this back to True once Gap 1 wires the producer.
+    """
+    _maybe_skip_if_router_unavailable()
+    from reyn.web.routers.a2a import _build_agent_card
+
+    card = _build_agent_card("test_agent", "test role", "http://localhost/a2a")
+    assert card["capabilities"]["streaming"] is False
+
+
+def test_agent_card_push_notifications_is_false_until_gap2_lands() -> None:
+    """Tier 2: ``pushNotifications`` capability is False (= issue #267
+    Gap 3 Z-b).
+
+    Webhook fires on exactly three triggers (completed / failed /
+    input-required). Claiming True would imply support for arbitrary
+    state-change notifications, which we don't deliver. Gap 3 Z-a
+    flips this back to True once Gap 2 expands the trigger set.
+    """
+    _maybe_skip_if_router_unavailable()
+    from reyn.web.routers.a2a import _build_agent_card
+
+    card = _build_agent_card("test_agent", "test role", "http://localhost/a2a")
+    assert card["capabilities"]["pushNotifications"] is False
+
+
+def test_agent_card_state_transition_history_stays_false() -> None:
+    """Tier 2: ``stateTransitionHistory`` capability remains False
+    (= unchanged from FP-0001, no plans to implement).
+
+    Catches any accidental flip during the Gap 3 Z-b adjustment.
+    """
+    _maybe_skip_if_router_unavailable()
+    from reyn.web.routers.a2a import _build_agent_card
+
+    card = _build_agent_card("test_agent", "test role", "http://localhost/a2a")
+    assert card["capabilities"]["stateTransitionHistory"] is False
+
+
+def test_agent_card_required_fields_shape_stable_through_gap3_zb() -> None:
+    """Tier 2: Gap 3 Z-b is a **value flip only**, not a schema change.
+
+    Required Agent Card fields stay present with their expected shape
+    so peer clients reading the card parse it the same way. Pinning
+    this guards against accidental schema drift bundled into the value
+    flip.
+    """
+    _maybe_skip_if_router_unavailable()
+    from reyn.web.routers.a2a import _build_agent_card
+
+    card = _build_agent_card("test_agent", "test role", "http://localhost/a2a")
+
+    # Identity + endpoint
+    assert card["name"] == "test_agent"
+    assert card["description"] == "test role"
+    assert card["url"] == "http://localhost/a2a"
+
+    # Version negotiation
+    assert "version" in card
+    assert "protocolVersion" in card
+
+    # Capabilities map shape (3 boolean fields, all False post-Z-b)
+    caps = card["capabilities"]
+    assert isinstance(caps, dict)
+    assert set(caps.keys()) == {
+        "streaming",
+        "pushNotifications",
+        "stateTransitionHistory",
+    }
+    assert all(isinstance(v, bool) for v in caps.values())
+
+    # Modes (= peers parse for IO negotiation)
+    assert "text/plain" in card["defaultInputModes"]
+    assert "text/plain" in card["defaultOutputModes"]
+
+    # Skills (= A2A's outward capability, opaque to Reyn skill catalogue)
+    assert isinstance(card["skills"], list)
+    assert len(card["skills"]) >= 1
+    chat_skill = next(s for s in card["skills"] if s["id"] == "chat")
+    assert "name" in chat_skill
+    assert "description" in chat_skill

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -203,8 +203,20 @@ def test_stream_task_events_returns_not_found_for_missing_run() -> None:
 
 
 def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> None:
-    """Tier 2: FP-0001 flips Agent Card capabilities to streaming=True and
-    pushNotifications=True. stateTransitionHistory stays False."""
+    """Tier 2: Agent Card capabilities currently advertise the interim
+    state from issue #267 Gap 3 Z-b:
+
+      - streaming: False (= SSE producer not wired, history_events empty)
+      - pushNotifications: False (= webhook fires only on 3 lifecycle events)
+      - stateTransitionHistory: False (= no plans to implement)
+
+    FP-0001 originally flipped streaming + pushNotifications to True for
+    the design intent, but the implementation gaps (= issue #267 Gap 1 +
+    Gap 2) make those claims misleading. Gap 3 Z-b is the interim
+    honest disclosure; Gap 3 Z-a will flip them back to True once Gap 1
+    + Gap 2 land. Test name kept for git-blame continuity with the
+    FP-0001 history.
+    """
     from fastapi.testclient import TestClient
 
     from reyn.budget.budget import BudgetTracker, CostConfig
@@ -247,8 +259,14 @@ def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> Non
         r = client.get("/a2a/agents/demo/.well-known/agent-card.json")
         assert r.status_code == 200, r.text
         caps = r.json()["capabilities"]
-        assert caps["streaming"] is True, "streaming must be True after FP-0001"
-        assert caps["pushNotifications"] is True, "pushNotifications must be True after FP-0001"
+        assert caps["streaming"] is False, (
+            "streaming must be False until issue #267 Gap 1 lands "
+            "(= SSE producer wiring). Gap 3 Z-b interim disclosure."
+        )
+        assert caps["pushNotifications"] is False, (
+            "pushNotifications must be False until issue #267 Gap 2 lands "
+            "(= webhook trigger expansion). Gap 3 Z-b interim disclosure."
+        )
         assert caps["stateTransitionHistory"] is False, "stateTransitionHistory must remain False"
     finally:
         app.dependency_overrides.clear()

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -141,8 +141,12 @@ def test_a2a_routes_mounted() -> None:
 def test_agent_card_returns_canonical_shape(tmp_path):
     """Tier 2: GET /a2a/agents/{name}/.well-known/agent-card.json
     returns an A2A-compliant Agent Card with the agent's role as
-    description and the JSON-RPC endpoint URL, and FP-0001 capabilities
-    (streaming=True, pushNotifications=True).
+    description and the JSON-RPC endpoint URL.
+
+    Capabilities: issue #267 Gap 3 Z-b interim disclosure (= streaming
+    + pushNotifications both ``False`` until Gap 1 SSE producer wiring
+    + Gap 2 webhook trigger expansion land; then Gap 3 Z-a re-flips
+    them to ``True``).
     """
     client, _ = _client_with_registry(tmp_path, [("default", "general assistant")])
     try:
@@ -157,10 +161,12 @@ def test_agent_card_returns_canonical_shape(tmp_path):
         # Endpoint URL points at the JSON-RPC handler for THIS agent.
         assert card["url"].endswith("/a2a/agents/default")
 
-        # Capabilities advertised: streaming + push are True (FP-0001).
+        # Capabilities advertised: issue #267 Gap 3 Z-b interim
+        # disclosure — both False until impl gaps close.
         caps = card["capabilities"]
-        assert caps["streaming"] is True
-        assert caps["pushNotifications"] is True
+        assert caps["streaming"] is False
+        assert caps["pushNotifications"] is False
+        assert caps["stateTransitionHistory"] is False
 
         # Modes + skills shape (peers parse these to capability-negotiate).
         assert "text/plain" in card["defaultInputModes"]


### PR DESCRIPTION
**[e2e-coder]** — issue #267 Gap 3 Z-b — owner-decision-accepted interim mitigation, quickwin landing.

Refs #267.

## Problem

Reyn's Agent Card (= `/a2a/agents/<name>/.well-known/agent-card.json`) has advertised the following since FP-0001:

```json
"capabilities": {"streaming": true, "pushNotifications": true, ...}
```

But the implementation has gaps documented in #267:

- **streaming claim**: SSE endpoint `GET /a2a/tasks/{run_id}/events` exists, but `RunRegistry.append_event` has **no in-tree producer** (= history_events stays empty in production). Streaming never delivers in-flight events; SSE consumers see only `event: end` at terminal status. (= #267 Gap 1)
- **pushNotifications claim**: webhook fires on exactly three triggers (`completed` / `failed` / `input-required`). spec-conformance-strict peers reading `true` would expect notifications for any state change, which we don't deliver. (= #267 Gap 2)

Both claims are misleading until those gaps close.

## Owner-decision-accepted mitigation (Gap 3 Z-b)

Per lead-coder's #267 owner decision:

> **Z-b 採用** (= 暫定 `streaming: false` / `pushNotifications: "limited"` 等 custom string で claim 下げ):
> - 1 ファイル 2 行 + 1 line test = trivial size
> - 「claim vs reality」 gap を **immediate 解消**、 spec-conformance 派 peer client 来訪時の broken perception 回避
> - Gap 1 + 2 完成後に Z-a (= 実装追いつかせ) で claim 再 true、 sequence 明確

This PR ships Z-b. Both capabilities flip to `false`:

```json
"capabilities": {"streaming": false, "pushNotifications": false, "stateTransitionHistory": false}
```

`pushNotifications` is set to `false` (not a custom string like `"limited"`) for A2A spec conformance — capability fields are conventionally boolean. Honest disclosure: peers can rely on what we declare, existing webhook-using peers can still POST + receive on the three trigger events (= capability advertising doesn't gate functionality, only the spec-level negotiation).

## Re-evaluation path (Z-a)

Gap 3 Z-a is gated on Gap 1 + Gap 2 completion:

- Gap 1 lands → SSE producer wires history_events → `streaming` flips back to `true`
- Gap 2 lands → webhook trigger expands → `pushNotifications` flips back to `true`

The Gap 3 Z-a PR will be the symmetric flip with the Gap-completion PRs as evidence.

## Changes

| File | Δ | Notes |
|---|---|---|
| `src/reyn/web/routers/a2a.py` | +27 / -3 | Capability values flip + inline comment + extended `_build_agent_card` docstring documenting the Gap 3 Z-b rationale |
| `tests/test_fp0001_a2a_endpoints.py` | +14 / -3 | Update existing assertion to interim state. Test name kept for git-blame continuity with FP-0001 history. |
| `tests/web/test_a2a.py` | +9 / -4 | Update existing assertion to interim state |
| `tests/test_a2a_capability_claim_interim.py` | +127 (new) | 4 Tier 2 tests pinning interim state via direct `_build_agent_card` call (= fastapi-free, runs in any env including local dev without `[web]` extra) |

## Tier 2 contract test (4 tests, new file)

| Test | Pins |
|---|---|
| `test_agent_card_streaming_is_false_until_gap1_lands` | streaming: False (= Gap 1 gates re-flip) |
| `test_agent_card_push_notifications_is_false_until_gap2_lands` | pushNotifications: False (= Gap 2 gates re-flip) |
| `test_agent_card_state_transition_history_stays_false` | unchanged, regression guard |
| `test_agent_card_required_fields_shape_stable_through_gap3_zb` | **Schema unchanged** — Gap 3 Z-b is value-flip only, not a schema change |

Each test docstring links to the specific Gap that gates the re-flip, so future readers (= Gap 1 / Gap 2 PR authors) know what test to update when they land their work.

## Test plan

- [x] **Automated — `pytest tests/test_a2a_capability_claim_interim.py`**: 4/4 pass。
- [x] **Adjacent — `pytest tests/test_fp0001_a2a_endpoints.py tests/web/test_a2a.py`** (= updated existing tests): 全件 pass。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --timeout=30`**: 4084 passed, 5 skipped, 3 xfailed in 168s。 (fastapi 入って a2a 系 fully runnable に。 +4 = new test file)
- [x] **Lint — `ruff check`**: clean on all changed files。
- [ ] **Manual** — none (= value-flip only、 schema 不変、 既存 webhook flow に影響なし)。

## Related

- #267 Gap 1 (= SSE producer wiring) / Gap 2 (= webhook trigger 拡張) — Z-a 再 flip の prerequisite
- #267 Gap 5 / Gap 4 — 既 accept、 別 PR で着手予定
- #271 M3 (= MCP server capability advertising) — A2A Z-b と同 calibration、 並列 mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)