### PR TITLE
feat(a2a): persist RunRegistry to snapshot file across process restarts (issue #267 Gap 5 Phase 1)

### DIFF
--- a/src/reyn/web/run_registry.py
+++ b/src/reyn/web/run_registry.py
@@ -1,4 +1,4 @@
-"""A2A task lifecycle registry (FP-0001).
+"""A2A task lifecycle registry (FP-0001 + issue #267 Gap 5 persistence).
 
 Tracks asyncio.Task instances spawned by POST /a2a/agents/<name> async-mode
 calls. Each entry carries status, any pending ask_user intervention,
@@ -6,14 +6,45 @@ a webhook URL for push notifications, and a buffered event history
 for SSE replay. Concurrent access by FastAPI request handlers is
 serialised by ``RunRegistry`` internally; do NOT call from outside
 the asyncio event loop.
+
+Persistence (issue #267 Gap 5):
+
+When ``RunRegistry`` is constructed with a ``persist_path``, every
+mutation rewrites the file atomically (= tmp file + ``Path.replace()``)
+so a server-process restart can reload the registry from disk. This
+closes the 「ChatSession side outstanding_interventions is persisted by
+PR-intervention-link L2-L6 but RunRegistry side is in-memory only」
+gap that left A2A peer routing half-restored on restart.
+
+What persists:
+  - run_id, agent_name, chain_id, status, question, result, error
+  - webhook_url, history_events, created_at, updated_at
+  - pending_intervention (= via UserIntervention.to_dict, future excluded)
+
+What does NOT persist (= volatile, restored as ``None`` / dropped):
+  - asyncio.Task reference (= bound to the process that died)
+  - UserIntervention.future (= fresh future allocated on from_dict)
+
+Restore semantics (= what the rebuilt ``RunEntry`` looks like after a
+process restart):
+  - All public state fields restored from JSON
+  - ``task`` is ``None`` (= caller can re-spawn if applicable, but the
+    original skill execution is gone with the prior process)
+  - ``pending_intervention``: if present, restored ``UserIntervention``
+    with a fresh future. The full rebind to the ChatSession side iv
+    (= so peer answers reach the ChatSession's restored
+    InterventionRegistry queue) is a Gap 5 Phase 2 follow-up; this
+    PR ships the persistence infrastructure alone.
 """
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,18 +85,169 @@ class RunEntry:
             "updated_at": self.updated_at.isoformat(),
         }
 
+    def to_persist_dict(self) -> dict:
+        """Persistence-safe shape (issue #267 Gap 5).
+
+        Includes more fields than ``to_public_dict`` because the
+        registry's own restore path needs them: webhook_url for
+        post-restart peer notifications, history_events for SSE
+        replay continuity, pending_intervention (via
+        ``UserIntervention.to_dict``) so the peer-binding can be
+        re-established by a Gap 5 Phase 2 follow-up.
+
+        Excludes volatile fields:
+          - ``task``: asyncio.Task is bound to the dead process
+          - ``pending_intervention.future``: re-allocated on from_dict
+        """
+        out: dict = {
+            "run_id": self.run_id,
+            "agent_name": self.agent_name,
+            "chain_id": self.chain_id,
+            "status": self.status,
+            "question": self.question,
+            "result": self.result,
+            "error": self.error,
+            "webhook_url": self.webhook_url,
+            "history_events": list(self.history_events),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        }
+        if self.pending_intervention is not None:
+            out["pending_intervention"] = self.pending_intervention.to_dict()
+        return out
+
+    @classmethod
+    def from_persist_dict(cls, data: dict) -> "RunEntry":
+        """Inverse of ``to_persist_dict`` (issue #267 Gap 5).
+
+        Rebuilds a ``RunEntry`` from the persistence snapshot:
+          - ``task`` set to ``None`` (= cannot resurrect dead asyncio.Task)
+          - ``pending_intervention``: if present in data, re-create
+            ``UserIntervention`` via ``from_dict`` (= fresh future)
+          - timestamps parsed from ISO strings; tolerate missing or
+            malformed fields by falling back to ``now()`` so a
+            corrupt snapshot doesn't poison the restore loop
+        """
+        # Lazy import to avoid circular dependency.
+        from reyn.user_intervention import UserIntervention
+
+        iv = None
+        iv_data = data.get("pending_intervention")
+        if iv_data:
+            iv = UserIntervention.from_dict(iv_data)
+
+        def _parse_ts(value: object) -> datetime:
+            if isinstance(value, str):
+                try:
+                    return datetime.fromisoformat(value)
+                except ValueError:
+                    pass
+            return datetime.now(timezone.utc)
+
+        return cls(
+            run_id=str(data.get("run_id", "")),
+            agent_name=str(data.get("agent_name", "")),
+            chain_id=str(data.get("chain_id", "")),
+            status=str(data.get("status", "running")),
+            question=data.get("question"),
+            pending_intervention=iv,
+            result=data.get("result"),
+            error=data.get("error"),
+            webhook_url=data.get("webhook_url"),
+            task=None,
+            history_events=list(data.get("history_events") or []),
+            created_at=_parse_ts(data.get("created_at")),
+            updated_at=_parse_ts(data.get("updated_at")),
+        )
+
 
 class RunRegistry:
     """In-memory ``run_id`` → ``RunEntry`` map for A2A async tasks.
 
     Single instance per Reyn server (attached to ``app.state.run_registry``
-    by ``reyn.web.server``). Lifetime = process lifetime; the registry is
-    intentionally not persisted (= crash-recovery for A2A async tasks is a
-    follow-up FP).
+    by ``reyn.web.server``).
+
+    Persistence (issue #267 Gap 5): when constructed with a non-None
+    ``persist_path``, every mutation atomically rewrites the file so a
+    server-process restart can reload via ``__init__`` (which calls
+    ``_restore_from`` if the file exists). Default ``None`` preserves
+    pre-#267 in-memory-only behaviour for tests and direct callers
+    that don't need persistence.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, persist_path: Path | None = None) -> None:
         self._runs: dict[str, RunEntry] = {}
+        self._persist_path: Path | None = (
+            Path(persist_path) if persist_path is not None else None
+        )
+        if self._persist_path is not None and self._persist_path.exists():
+            self._restore_from(self._persist_path)
+
+    # ── persistence (issue #267 Gap 5) ─────────────────────────────────────
+
+    def _persist(self) -> None:
+        """Atomically rewrite the snapshot file after a mutation.
+
+        Snapshot shape: ``{run_id: entry.to_persist_dict(), ...}``. The
+        atomic-rename pattern (= tmp file + ``Path.replace()``) avoids
+        a half-written file being read by a concurrent restore.
+        Persistence failures are logged but never re-raised — the
+        registry stays usable even if the disk is full / read-only;
+        restart will see whatever the last successful snapshot was.
+        """
+        if self._persist_path is None:
+            return
+        try:
+            self._persist_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                run_id: entry.to_persist_dict()
+                for run_id, entry in self._runs.items()
+            }
+            tmp = self._persist_path.with_suffix(self._persist_path.suffix + ".tmp")
+            tmp.write_text(json.dumps(payload), encoding="utf-8")
+            tmp.replace(self._persist_path)
+        except OSError as exc:  # noqa: BLE001 — persistence is best-effort
+            logger.warning(
+                "RunRegistry persist failed: path=%s exc=%s",
+                self._persist_path, exc,
+            )
+
+    def _restore_from(self, path: Path) -> None:
+        """Repopulate ``self._runs`` from the snapshot file.
+
+        Tolerates a corrupt or partial file by logging a warning and
+        leaving the registry empty rather than crashing — a fresh
+        server can still accept new tasks; only resurrection fails.
+        """
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "RunRegistry restore failed (= empty registry will be used): "
+                "path=%s exc=%s", path, exc,
+            )
+            return
+        if not isinstance(data, dict):
+            logger.warning(
+                "RunRegistry snapshot is not a dict (= empty registry will "
+                "be used): path=%s type=%s", path, type(data).__name__,
+            )
+            return
+        for run_id, entry_data in data.items():
+            if not isinstance(entry_data, dict):
+                continue
+            try:
+                entry = RunEntry.from_persist_dict(entry_data)
+            except Exception as exc:  # noqa: BLE001 — skip corrupt entries
+                logger.warning(
+                    "RunRegistry skipping corrupt entry run_id=%s exc=%s",
+                    run_id, exc,
+                )
+                continue
+            self._runs[str(run_id)] = entry
+
+    # ── core CRUD (= mutations call _persist on success) ───────────────────
 
     def create(
         self,
@@ -83,6 +265,7 @@ class RunRegistry:
             webhook_url=webhook_url,
         )
         self._runs[run_id] = entry
+        self._persist()
         return entry
 
     def get(self, run_id: str) -> RunEntry | None:
@@ -119,11 +302,13 @@ class RunRegistry:
         if error is not None:
             entry.error = error
         entry.updated_at = datetime.now(timezone.utc)
+        self._persist()
         return entry
 
     def attach_task(self, run_id: str, task: asyncio.Task) -> None:
         if entry := self._runs.get(run_id):
             entry.task = task
+        # NB: task is volatile (= not persisted), no _persist() call.
 
     def answer_intervention(self, run_id: str, answer: "InterventionAnswer") -> bool:
         """Deliver ``answer`` to the run's pending intervention.
@@ -144,6 +329,7 @@ class RunRegistry:
         entry.question = None
         entry.status = "running"
         entry.updated_at = datetime.now(timezone.utc)
+        self._persist()
         return True
 
     def cancel(self, run_id: str) -> bool:
@@ -156,6 +342,7 @@ class RunRegistry:
             entry.task.cancel()
         entry.status = "cancelled"
         entry.updated_at = datetime.now(timezone.utc)
+        self._persist()
         return True
 
     def append_event(self, run_id: str, event: dict) -> None:
@@ -163,9 +350,11 @@ class RunRegistry:
         entry = self._runs.get(run_id)
         if entry is not None:
             entry.history_events.append(event)
+            self._persist()
 
     def remove(self, run_id: str) -> None:
-        self._runs.pop(run_id, None)
+        if self._runs.pop(run_id, None) is not None:
+            self._persist()
 
 
 __all__ = ["RunEntry", "RunRegistry"]

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -81,9 +81,19 @@ def _make_cron_runner():
 async def _lifespan(app: FastAPI):
     # ── Startup ──
 
-    # FP-0001: RunRegistry singleton — process-wide task lifecycle tracking.
+    # FP-0001 + issue #267 Gap 5: RunRegistry singleton — process-wide
+    # task lifecycle tracking with snapshot persistence so a process
+    # restart preserves A2A async-task state (= the structural gap that
+    # left A2A peer routing half-restored against the ChatSession-side
+    # outstanding_interventions persistence wired by PR-intervention-link
+    # L2-L6). Snapshot path follows the convention established by
+    # ChatSession's per-agent snapshot.json: server-level state lives at
+    # ``.reyn/state/run_registry.json``.
+    from pathlib import Path  # noqa: PLC0415
+
     from reyn.web.run_registry import RunRegistry
-    app.state.run_registry = RunRegistry()
+    persist_path = Path(".reyn") / "state" / "run_registry.json"
+    app.state.run_registry = RunRegistry(persist_path=persist_path)
 
     # FP-0009 B: cron scheduler — start only if reyn.yaml has any enabled
     # cron jobs.  Failures are caught so a misconfigured cron block does

--- a/tests/test_run_registry_persist.py
+++ b/tests/test_run_registry_persist.py
@@ -1,0 +1,361 @@
+"""Tier 2: RunRegistry persistence — issue #267 Gap 5 Phase 1.
+
+Pins the persistence contract added to ``RunRegistry`` so a server-
+process restart can reload the A2A async-task lifecycle state instead
+of losing it to in-memory volatility (= the structural prerequisite
+for #270 pending-op framework's MCP-side restart behaviour + closes
+the gap that left A2A peer routing half-restored in #268's
+origin-pinned model).
+
+Pins:
+
+  1. ``persist_path=None`` (default) preserves pre-#267 in-memory-only
+     behaviour — no disk writes, restore is a no-op.
+  2. With ``persist_path=...`` set, every mutation (create / update /
+     attach_task is volatile / answer_intervention / cancel /
+     append_event / remove) writes the snapshot atomically.
+  3. The atomic-rename pattern (= tmp file + ``replace()``) avoids a
+     half-written file being read by a concurrent restore.
+  4. Round-trip preserves the JSON-safe fields verbatim, including
+     pending_intervention via ``UserIntervention.to_dict``.
+  5. Restored entries have ``task=None`` (= cannot resurrect dead
+     ``asyncio.Task``).
+  6. Restored ``pending_intervention`` has a **fresh future** so a new
+     awaiter can pick it up (= ``UserIntervention.from_dict`` allocates
+     a new future via ``__post_init__``).
+  7. Corrupt / malformed snapshot file is tolerated — registry starts
+     empty + warns rather than crashing.
+
+No mocks. Real ``RunRegistry`` writes + reads on tmp_path.
+
+Tier 2 — not a Tier-3 LLM-replay test, no scaffold churn expected.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+from reyn.web.run_registry import RunEntry, RunRegistry
+
+# ── 1. Default (no persist_path) — legacy in-memory behaviour ──────────
+
+
+def test_default_construction_does_not_persist_to_disk(tmp_path: Path) -> None:
+    """Tier 2: ``RunRegistry()`` without ``persist_path`` is in-memory only.
+
+    Mutations succeed but no file is written. Important for tests +
+    direct callers that don't need persistence and shouldn't pay the
+    disk-IO cost.
+    """
+    registry = RunRegistry()
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+    assert entry.run_id in {e.run_id for e in registry.list()}
+
+    # No file should appear under tmp_path because we didn't supply
+    # persist_path.
+    assert list(tmp_path.iterdir()) == []
+
+
+# ── 2. Persist + restore round-trip (= core contract) ───────────────────
+
+
+def test_create_writes_snapshot_to_persist_path(tmp_path: Path) -> None:
+    """Tier 2: ``create()`` triggers an atomic snapshot write.
+
+    The snapshot file appears with the entry's data after a single
+    ``create()`` call.
+    """
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    entry = registry.create(
+        agent_name="demo",
+        chain_id="chain-A",
+        webhook_url="http://peer.example/webhook",
+    )
+
+    assert persist_path.exists()
+    data = json.loads(persist_path.read_text(encoding="utf-8"))
+    assert entry.run_id in data
+    assert data[entry.run_id]["agent_name"] == "demo"
+    assert data[entry.run_id]["chain_id"] == "chain-A"
+    assert data[entry.run_id]["status"] == "running"
+    assert data[entry.run_id]["webhook_url"] == "http://peer.example/webhook"
+
+
+def test_restore_from_existing_snapshot_repopulates_runs(tmp_path: Path) -> None:
+    """Tier 2: when an existing snapshot file is present at construction,
+    the registry reloads the entries.
+
+    This is the central contract — process restart can pick up where
+    it left off instead of starting from an empty registry.
+    """
+    persist_path = tmp_path / "run_registry.json"
+    # Phase 1: populate + close (= process death simulation).
+    registry_a = RunRegistry(persist_path=persist_path)
+    entry = registry_a.create(agent_name="demo", chain_id="chain-A")
+    registry_a.update(entry.run_id, status="input-required", question="Continue?")
+    registry_a.append_event(entry.run_id, {"type": "phase", "name": "greet"})
+
+    # Phase 2: fresh registry from same path (= post-restart).
+    registry_b = RunRegistry(persist_path=persist_path)
+    restored = registry_b.get(entry.run_id)
+    assert restored is not None
+    assert restored.agent_name == "demo"
+    assert restored.chain_id == "chain-A"
+    assert restored.status == "input-required"
+    assert restored.question == "Continue?"
+    assert restored.history_events == [{"type": "phase", "name": "greet"}]
+
+
+def test_restored_entry_has_task_none(tmp_path: Path) -> None:
+    """Tier 2: restored ``RunEntry.task`` is ``None`` — the asyncio.Task
+    was bound to the dead process and cannot be resurrected.
+    Caller code that wants to re-spawn must do so explicitly.
+    """
+    persist_path = tmp_path / "run_registry.json"
+    registry_a = RunRegistry(persist_path=persist_path)
+    entry = registry_a.create(agent_name="demo", chain_id="chain-A")
+
+    # Attach a fake task to simulate live-process state.
+    loop = asyncio.new_event_loop()
+    try:
+        async def _noop() -> None:
+            return None
+
+        task = loop.create_task(_noop())
+        registry_a.attach_task(entry.run_id, task)
+        # Drive it to completion so it's not pending when we drop the loop.
+        loop.run_until_complete(task)
+    finally:
+        loop.close()
+
+    # Restart: restored entry must have task=None.
+    registry_b = RunRegistry(persist_path=persist_path)
+    restored = registry_b.get(entry.run_id)
+    assert restored is not None
+    assert restored.task is None
+
+
+def test_restored_pending_intervention_has_fresh_future(tmp_path: Path) -> None:
+    """Tier 2: when a ``pending_intervention`` was active at snapshot time,
+    the restored entry's iv carries a **fresh future** (= the original
+    future was volatile and bound to the dead awaiter).
+
+    Verifies the from_dict path on UserIntervention preserves the iv
+    metadata while reallocating the Future. Allows a future Gap 5
+    Phase 2 re-bind step to attach a new awaiter.
+    """
+    persist_path = tmp_path / "run_registry.json"
+    registry_a = RunRegistry(persist_path=persist_path)
+    entry = registry_a.create(agent_name="demo", chain_id="chain-A")
+
+    # Attach a pending intervention with a resolved-in-prior-process future
+    # (= simulate "the prior process did set_result before crash").
+    loop = asyncio.new_event_loop()
+    try:
+        async def _populate() -> None:
+            iv = UserIntervention(
+                kind="ask_user",
+                prompt="What is your name?",
+                detail="for greeting",
+            )
+            registry_a.update(
+                entry.run_id,
+                status="input-required",
+                question=iv.prompt,
+                pending_intervention=iv,
+            )
+
+        loop.run_until_complete(_populate())
+    finally:
+        loop.close()
+
+    # Restart: restored iv must have a fresh, unresolved future.
+    registry_b = RunRegistry(persist_path=persist_path)
+    restored = registry_b.get(entry.run_id)
+    assert restored is not None
+    assert restored.pending_intervention is not None
+    iv = restored.pending_intervention
+    assert iv.kind == "ask_user"
+    assert iv.prompt == "What is your name?"
+    assert iv.detail == "for greeting"
+    # Fresh future: not yet resolved.
+    assert iv.future is not None
+    assert not iv.future.done()
+
+
+# ── 3. All mutations persist (= regression guards) ─────────────────────
+
+
+def test_update_persists_status_change(tmp_path: Path) -> None:
+    """Tier 2: ``update()`` writes a fresh snapshot reflecting the new state."""
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    registry.update(entry.run_id, status="completed", result="all done")
+    data = json.loads(persist_path.read_text(encoding="utf-8"))
+    assert data[entry.run_id]["status"] == "completed"
+    assert data[entry.run_id]["result"] == "all done"
+
+
+def test_append_event_persists_history(tmp_path: Path) -> None:
+    """Tier 2: ``append_event()`` includes the new event in the snapshot."""
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    registry.append_event(entry.run_id, {"type": "phase", "name": "act"})
+    registry.append_event(entry.run_id, {"type": "phase", "name": "decide"})
+
+    data = json.loads(persist_path.read_text(encoding="utf-8"))
+    assert data[entry.run_id]["history_events"] == [
+        {"type": "phase", "name": "act"},
+        {"type": "phase", "name": "decide"},
+    ]
+
+
+def test_cancel_persists_cancelled_status(tmp_path: Path) -> None:
+    """Tier 2: ``cancel()`` snapshots the ``cancelled`` status."""
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    assert registry.cancel(entry.run_id) is True
+    data = json.loads(persist_path.read_text(encoding="utf-8"))
+    assert data[entry.run_id]["status"] == "cancelled"
+
+
+def test_remove_drops_entry_from_snapshot(tmp_path: Path) -> None:
+    """Tier 2: ``remove()`` rewrites the snapshot without the entry."""
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    entry_a = registry.create(agent_name="demo-a", chain_id="chain-A")
+    entry_b = registry.create(agent_name="demo-b", chain_id="chain-B")
+
+    registry.remove(entry_a.run_id)
+    data = json.loads(persist_path.read_text(encoding="utf-8"))
+    assert entry_a.run_id not in data
+    assert entry_b.run_id in data
+
+
+def test_answer_intervention_persists_cleared_state(tmp_path: Path) -> None:
+    """Tier 2: ``answer_intervention()`` clears pending fields + persists."""
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    loop = asyncio.new_event_loop()
+    try:
+        async def _drive() -> None:
+            iv = UserIntervention(kind="ask_user", prompt="?")
+            registry.update(
+                entry.run_id,
+                status="input-required",
+                question="?",
+                pending_intervention=iv,
+            )
+            registry.answer_intervention(
+                entry.run_id, InterventionAnswer(text="ok"),
+            )
+
+        loop.run_until_complete(_drive())
+    finally:
+        loop.close()
+
+    data = json.loads(persist_path.read_text(encoding="utf-8"))
+    assert data[entry.run_id]["status"] == "running"
+    assert data[entry.run_id]["question"] is None
+    assert "pending_intervention" not in data[entry.run_id]
+
+
+# ── 4. Atomic write (= no partial file on crash mid-write) ──────────────
+
+
+def test_persist_uses_atomic_rename(tmp_path: Path) -> None:
+    """Tier 2: the snapshot writer goes via a ``.tmp`` file + atomic
+    ``Path.replace()`` so a concurrent restore can't read a half-
+    written file.
+
+    Verified by checking the absence of stale ``.tmp`` files after a
+    successful write (= replace removed the tmp).
+    """
+    persist_path = tmp_path / "run_registry.json"
+    registry = RunRegistry(persist_path=persist_path)
+    registry.create(agent_name="demo", chain_id="chain-A")
+
+    assert persist_path.exists()
+    # No leftover .tmp file.
+    assert not persist_path.with_suffix(persist_path.suffix + ".tmp").exists()
+
+
+# ── 5. Tolerant of missing / corrupt snapshot ──────────────────────────
+
+
+def test_restore_from_missing_file_yields_empty_registry(tmp_path: Path) -> None:
+    """Tier 2: construction with a non-existent ``persist_path`` leaves
+    the registry empty (= no crash, fresh server starts cleanly).
+    Subsequent mutations create the file.
+    """
+    persist_path = tmp_path / "does_not_exist.json"
+    registry = RunRegistry(persist_path=persist_path)
+    assert registry.list() == []
+    assert not persist_path.exists()
+
+    # First mutation should create the file.
+    registry.create(agent_name="demo", chain_id="chain-A")
+    assert persist_path.exists()
+
+
+def test_restore_from_corrupt_json_yields_empty_registry(tmp_path: Path) -> None:
+    """Tier 2: a corrupt snapshot (= invalid JSON) doesn't crash the
+    server — registry starts empty + a warning is logged. Recovery
+    path: any new mutation will overwrite with a fresh well-formed
+    snapshot.
+    """
+    persist_path = tmp_path / "corrupt.json"
+    persist_path.write_text("not valid json {{{", encoding="utf-8")
+
+    registry = RunRegistry(persist_path=persist_path)
+    assert registry.list() == []
+
+
+def test_restore_from_non_dict_yields_empty_registry(tmp_path: Path) -> None:
+    """Tier 2: a snapshot whose top-level JSON is not a dict (e.g. an
+    array or string) is treated as corrupt — empty registry, no
+    crash. Defensive against accidental file overwrites.
+    """
+    persist_path = tmp_path / "wrong_shape.json"
+    persist_path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    registry = RunRegistry(persist_path=persist_path)
+    assert registry.list() == []
+
+
+def test_restore_skips_corrupt_entries_keeping_valid_ones(tmp_path: Path) -> None:
+    """Tier 2: when one entry in the snapshot is malformed but others
+    are well-formed, the valid ones still restore. Per-entry resilience
+    avoids one corrupt iv data losing the whole registry.
+    """
+    persist_path = tmp_path / "partial_corrupt.json"
+    persist_path.write_text(
+        json.dumps({
+            "good_run": {
+                "run_id": "good_run",
+                "agent_name": "demo",
+                "chain_id": "chain-A",
+                "status": "running",
+                "history_events": [],
+                "created_at": "2026-05-20T00:00:00+00:00",
+                "updated_at": "2026-05-20T00:00:00+00:00",
+            },
+            "bad_run": "this should be a dict but is a string",
+        }),
+        encoding="utf-8",
+    )
+
+    registry = RunRegistry(persist_path=persist_path)
+    assert registry.get("good_run") is not None
+    assert registry.get("bad_run") is None


### PR DESCRIPTION
**[e2e-coder]** — issue #267 Gap 5 Phase 1 — HIGH priority architectural cluster prerequisite.

Refs #267 Gap 5. Phase 2 (= ChatSession-iv ↔ RunEntry re-bind on restart) is a follow-up that closes the half-restore problem.

## Problem

Pre-#267 `RunRegistry` is pure in-memory dict: server process restart → all A2A async-task lifecycle state lost (= `status` / `pending_intervention` / `webhook_url` / `history_events`). This left A2A peer routing **half-restored** against the ChatSession side `outstanding_interventions` that PR-intervention-link L2-L6 already persists via `AgentSnapshot`:

| Surface | Persists? | Restart behaviour |
|---|---|---|
| ChatSession `_interventions` queue | ✓ via `AgentSnapshot.outstanding_interventions` | Re-enqueued on restore, fresh future allocated |
| **`RunRegistry` per-task state** | **✗ in-memory only** | **Lost** — peer's `POST /a2a/agents/<name> {task_id, answer}` returns `False` (= "no pending iv") |

Architectural cluster (= issue #267 / #268 / #269 / #270 / #271) lists Gap 5 as a **prerequisite of prerequisites**: #270's pending-op framework MCP-side stall + redirect, #268's origin-pinned + stall + redirect, #269's outbound notification ack all require RunRegistry to be persistent.

## What Phase 1 ships

Pure **infrastructure** — snapshot file at `.reyn/state/run_registry.json`, atomic-rewrite on each mutation, restored at `__init__`. **The half-restore problem (= ChatSession-iv ↔ RunEntry re-binding on restart) is deferred to Phase 2.** Phase 1 alone unblocks the prerequisite.

### `RunEntry` additions

```python
def to_persist_dict(self) -> dict:
    """Persistence-safe shape (= drops volatile task + iv.future,
    iv via UserIntervention.to_dict)."""

@classmethod
def from_persist_dict(cls, data: dict) -> "RunEntry":
    """Inverse — task=None, iv re-allocated with fresh future."""
```

### `RunRegistry` additions

```python
def __init__(self, *, persist_path: Path | None = None) -> None:
    # default None preserves pre-#267 in-memory-only behaviour
    if persist_path is not None and persist_path.exists():
        self._restore_from(persist_path)
```

All mutations (`create` / `update` / `answer_intervention` / `cancel` / `append_event` / `remove`) call `_persist` after success. `attach_task` is volatile by design — no `_persist` call (= asyncio.Task can't survive restart anyway).

Atomic-rename pattern (= tmp file + `Path.replace()`) avoids half-written file being read by concurrent restore. Persistence failures logged at WARNING, never re-raised — registry stays usable even if disk is full / read-only.

### Production wiring

```python
# web/server.py lifespan startup
persist_path = Path(".reyn") / "state" / "run_registry.json"
app.state.run_registry = RunRegistry(persist_path=persist_path)
```

Path convention mirrors `ChatSession`'s per-agent `.reyn/agents/<name>/state/snapshot.json` — server-level state lives at the project-root `.reyn/state/` directory.

### Restore semantics

Per-field behaviour on restart:

| Field | Restore behaviour |
|---|---|
| `run_id`, `agent_name`, `chain_id`, `status`, `question`, `result`, `error`, `webhook_url` | ✓ from JSON verbatim |
| `history_events` | ✓ from JSON (list of dicts) |
| `created_at`, `updated_at` | ✓ ISO timestamps, fallback to `now()` if malformed |
| `pending_intervention` | ✓ via `UserIntervention.from_dict`, **fresh future** (= original was volatile) |
| `task` (asyncio.Task) | ✗ **None** — caller must explicitly re-spawn if applicable |

## Tier 2 contract test (15 tests, `tests/test_run_registry_persist.py`)

| Category | Tests |
|---|---|
| Default (legacy in-memory) | `test_default_construction_does_not_persist_to_disk` |
| Persist + restore round-trip | `test_create_writes_snapshot_to_persist_path`, `test_restore_from_existing_snapshot_repopulates_runs`, `test_restored_entry_has_task_none`, `test_restored_pending_intervention_has_fresh_future` |
| Per-mutation persist | `test_update_persists_status_change`, `test_append_event_persists_history`, `test_cancel_persists_cancelled_status`, `test_remove_drops_entry_from_snapshot`, `test_answer_intervention_persists_cleared_state` |
| Atomic write | `test_persist_uses_atomic_rename` |
| Resilience | `test_restore_from_missing_file_yields_empty_registry`, `test_restore_from_corrupt_json_yields_empty_registry`, `test_restore_from_non_dict_yields_empty_registry`, `test_restore_skips_corrupt_entries_keeping_valid_ones` |

## Test plan

- [x] **Automated — `pytest tests/test_run_registry_persist.py`**: 15/15 pass。
- [x] **Adjacent — `pytest tests/test_fp0001_a2a_endpoints.py tests/web/test_a2a.py tests/test_a2a_sync_async_escalation.py`** (= existing A2A surface tests): 29 passed + 1 skipped, no regression。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --timeout=30`**: 4095 passed, 5 skipped, 3 xfailed in 149s (= +11 from new test file)。
- [x] **Lint — `ruff check`**: clean on all touched files。
- [ ] **Manual** — none required (= persistence is additive; production server picks up the new path automatically. Existing in-memory-only consumers that pass `RunRegistry()` without `persist_path` see no change).

## Phase 2 preview

After this PR lands, Phase 2 closes the half-restore loop:
- On `ChatSession.restore_state`, find restored iv entries with `run_id` matching a `RunEntry.pending_intervention`
- Re-bind: replace `RunEntry.pending_intervention` with the ChatSession-side fresh iv, so the peer's POST answer reaches the right awaiter
- Optionally fire a webhook with `status="restored"` so the peer knows the world has changed + can re-query

That work depends on Phase 1's persistence infrastructure being in place + needs cross-coordination with ChatSession restore lifecycle. Filed as Phase 2 of Gap 5 once Phase 1 lands.

## Related

- #267 Gap 5 — this PR
- #268 (= origin-pinned + stall + redirect) — depends on this Phase 1 + Phase 2 for restart-safe origin tracking
- #269 (= outbound notification ack) — channel liveness state benefits from persistence
- #270 (= pending-op umbrella) — Gap 5 is "prerequisite of prerequisites" per architectural cluster sequence
- #271 (= Reyn-as-MCP-server outbound) — independent but parallel cluster work
- PR #255 / #258 / #259 / #260 / #263 (= issue #254 5-phase intervention routing refactor; this PR completes the persistence symmetry the L2-L6 work started)

🤖 Generated with [Claude Code](https://claude.com/claude-code)