### PR TITLE
feat(intervention): PendingIntervention origin-pin + stall + redirect (issue #268 Phase 1, #270 First instance)

### DIFF
--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -71,6 +71,14 @@ class InterventionRegistry:
         # issue #254 Phase 1: listener-presence guard against forever-await.
         self._enforce_listener_presence = enforce_listener_presence
         self._listeners: set[str] = set()
+        # issue #268 Phase 1: stalled queue — iv whose origin channel
+        # closed while the iv was unresolved. Other channels can
+        # observe / discard / claim entries here via the ChatSession
+        # API; the iv's future stays unresolved until a claim moves it
+        # back to ``_active`` for a new origin channel or a discard
+        # cancels it. ``_active`` and ``_stalled`` are mutually
+        # exclusive — an iv is in one or the other, never both.
+        self._stalled: dict[str, UserIntervention] = {}
 
     # ── Listener registration (issue #254 Phase 1) ───────────────────────────
 
@@ -98,6 +106,92 @@ class InterventionRegistry:
     def listener_count(self) -> int:
         """Return the number of currently-registered listeners."""
         return len(self._listeners)
+
+    # ── Stalled queue operations (issue #268 Phase 1) ────────────────────────
+
+    def mark_stalled(self, iv_id: str) -> bool:
+        """Move *iv_id* from ``_active`` to ``_stalled``.
+
+        Called by ``ChatSession.handle_intervention`` when the iv's
+        ``origin_channel_id`` no longer maps to a registered listener
+        (= origin channel closed). Returns True iff the iv was in
+        ``_active`` and is now in ``_stalled``.
+
+        The iv's future stays unresolved. The stalled iv can be
+        observed (``list_stalled``), discarded (``discard_stalled``),
+        or claimed (``claim_stalled``) by other channels.
+        """
+        iv = self._active.pop(iv_id, None)
+        if iv is None:
+            return False
+        try:
+            self._order.remove(iv_id)
+        except ValueError:
+            pass
+        self._stalled[iv_id] = iv
+        return True
+
+    def list_stalled(self) -> list[UserIntervention]:
+        """Return all stalled interventions (= origin channel closed).
+
+        Read-only snapshot — caller iterates without holding the
+        registry's internal collection. Used by
+        ``ChatSession.list_stalled_interventions`` for the cross-channel
+        observe surface.
+        """
+        return list(self._stalled.values())
+
+    def stalled_count(self) -> int:
+        """Return the number of stalled interventions."""
+        return len(self._stalled)
+
+    def get_stalled(self, iv_id: str) -> UserIntervention | None:
+        """O(1) lookup of a stalled iv by id."""
+        return self._stalled.get(iv_id)
+
+    def discard_stalled(self, iv_id: str) -> bool:
+        """Cancel a stalled iv — set its future to an empty answer +
+        remove from the stalled queue.
+
+        Returns True iff the iv was in ``_stalled`` and was discarded
+        (= the future was either resolved with an empty answer or
+        cancelled). Matches the existing cancellation contract
+        (``InterventionAnswer(text="")``) so awaiters interpret the
+        outcome as a refusal.
+        """
+        iv = self._stalled.pop(iv_id, None)
+        if iv is None:
+            return False
+        if iv.future is not None and not iv.future.done():
+            try:
+                iv.future.set_result(InterventionAnswer(text=""))
+            except Exception:  # noqa: BLE001 — best-effort
+                # Future may be bound to a dead loop; cancel as fallback.
+                try:
+                    iv.future.cancel()
+                except Exception:  # noqa: BLE001
+                    pass
+        return True
+
+    def claim_stalled(self, iv_id: str, new_origin_channel_id: str) -> UserIntervention | None:
+        """Reactivate a stalled iv with a new origin channel.
+
+        Moves the iv from ``_stalled`` back to ``_active`` (= head of
+        the active queue, ready for re-dispatch), updates its
+        ``origin_channel_id`` to the caller's channel. Returns the iv
+        on success so the caller can drive the re-dispatch (= call
+        ``dispatch(iv)`` again to deliver to the new origin).
+
+        Returns ``None`` when ``iv_id`` is not in ``_stalled``.
+        """
+        iv = self._stalled.pop(iv_id, None)
+        if iv is None:
+            return None
+        iv.origin_channel_id = new_origin_channel_id
+        # NB: we don't re-enqueue into _active here — let the caller
+        # call dispatch() so the normal flow (= announce / await)
+        # applies. Returning the iv signals "ready to dispatch again".
+        return iv
 
     # ── Bus interface (called by ChatInterventionBus from skills) ────────────
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -193,6 +193,54 @@ class RouterCapExceeded(Exception):
         self.last_reason = last_reason
 
 
+@dataclass(frozen=True)
+class PendingOpView:
+    """Read-only view of a pending / stalled operation surfaced across channels
+    (= issue #268 Phase 1, #270 umbrella vocabulary).
+
+    First instance carries ``UserIntervention`` data; Phase B refactor
+    (= #270) generalises this dataclass to also describe MCP pending
+    calls / peer-delegation pending operations. The ``kind`` field is
+    the discriminator. Field shape is **pinned at Phase A landing**
+    per tui-coder commitment so the TUI Pending tab + ``/pending``
+    slash command code path doesn't churn as new kinds land.
+
+    Pinned fields (= TUI consume contract):
+      - ``id``: stable identifier (= iv.id for interventions)
+      - ``kind``: discriminator (= "intervention" for now, future
+        "mcp_call" / "peer_delegate")
+      - ``origin_channel_id``: where the op originated (= "tui:..." /
+        "a2a:..." etc.)
+      - ``created_at``: ISO timestamp string for age-rendering
+      - ``summary``: short human-readable description (= iv.prompt
+        first line for interventions)
+      - ``detail``: optional second line (= iv.detail for interventions)
+    """
+    id: str
+    kind: str
+    origin_channel_id: str
+    created_at: str
+    summary: str
+    detail: str = ""
+
+    @classmethod
+    def from_intervention(cls, iv: "UserIntervention") -> "PendingOpView":
+        """Build a view from a ``UserIntervention``. ``created_at`` is
+        the current time at view construction since iv doesn't carry
+        its own timestamp; the TUI uses this for relative age display
+        even though it's a view-time stamp.
+        """
+        from datetime import datetime, timezone  # noqa: PLC0415
+        return cls(
+            id=iv.id,
+            kind="intervention",
+            origin_channel_id=iv.origin_channel_id or "",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            summary=iv.prompt,
+            detail=iv.detail or "",
+        )
+
+
 class AgentRequestBus:
     """``RequestBus`` adapter that subscribes to a ChatSession (= Agent).
 
@@ -1889,8 +1937,95 @@ class ChatSession:
         self._interventions.register_listener(listener_id)
 
     def unregister_intervention_listener(self, listener_id: str) -> None:
-        """Remove *listener_id* from the active set. Idempotent."""
+        """Remove *listener_id* from the active set. Idempotent.
+
+        issue #268 Phase 1: when a listener closes (= channel goes
+        away), any iv whose ``origin_channel_id`` equals this
+        ``listener_id`` will be observable in the stalled queue via
+        ``list_stalled_interventions``. The unregister itself does
+        NOT move active ivs to stalled — only the next
+        ``handle_intervention`` call (= a fresh iv from a still-running
+        skill) sees the change. For existing in-flight ivs that lose
+        their origin, the agent layer handles them through
+        ``handle_intervention``'s origin-pin check on its next pass.
+        """
         self._interventions.unregister_listener(listener_id)
+
+    # ── Cross-channel pending-op operations (issue #268 Phase 1) ──────────
+
+    def list_stalled_interventions(self) -> "list[PendingOpView]":
+        """Return a snapshot of all stalled interventions.
+
+        issue #268 Phase 1: any channel can call this to inspect the
+        agent's outstanding interventions whose origin channel closed.
+        The returned ``PendingOpView`` items carry enough info for the
+        TUI Pending tab + slash command to render + dispatch
+        discard/claim operations without exposing the underlying
+        ``UserIntervention`` object (= internal-only).
+
+        Read-only — caller iterates the returned list without holding
+        any registry-internal collection.
+        """
+        return [
+            PendingOpView.from_intervention(iv)
+            for iv in self._interventions.list_stalled()
+        ]
+
+    async def discard_pending_intervention(
+        self, iv_id: str, *, reason: str = "user_discarded",
+    ) -> bool:
+        """Discard a stalled intervention — cancel its future, remove
+        from the queue.
+
+        Returns True iff the iv was in the stalled queue and was
+        discarded. The future is resolved with an empty
+        ``InterventionAnswer`` so the awaiter sees a refusal.
+
+        issue #268 Phase 1: cross-channel discard. Used by a different
+        channel than the original origin to say "no one will answer,
+        give up". Future expansion (= per-kind discard hooks) can
+        plug into the policy layer at ``handle_intervention``.
+        """
+        ok = self._interventions.discard_stalled(iv_id)
+        if ok:
+            self._chat_events.emit(
+                "pending_intervention_discarded",
+                iv_id=iv_id,
+                reason=reason,
+            )
+        return ok
+
+    async def claim_pending_intervention(
+        self, iv_id: str, new_channel_id: str,
+    ) -> "PendingOpView | None":
+        """Claim a stalled intervention — rebind origin to the caller's
+        channel + re-dispatch through the active path.
+
+        Returns the ``PendingOpView`` of the claimed iv on success, or
+        ``None`` when ``iv_id`` is not in the stalled queue.
+
+        issue #268 Phase 1: cross-channel claim. The caller takes
+        responsibility for resolving the iv via its own input
+        surface. After claim:
+          - iv.origin_channel_id is updated to ``new_channel_id``
+          - the iv is removed from the stalled queue
+          - the dispatch path runs (= `_dispatch_intervention`)
+        """
+        iv = self._interventions.claim_stalled(iv_id, new_channel_id)
+        if iv is None:
+            return None
+        self._chat_events.emit(
+            "pending_intervention_claimed",
+            iv_id=iv_id,
+            new_origin_channel_id=new_channel_id,
+        )
+        # Re-dispatch on the new channel. We schedule this in the
+        # background so the caller of claim doesn't await the full
+        # iv resolution — the iv.future will resolve when the new
+        # channel's listener calls deliver_answer, independent of this
+        # method's return.
+        asyncio.ensure_future(self._dispatch_intervention(iv))
+        return PendingOpView.from_intervention(iv)
 
     async def _dispatch_intervention(self, iv: UserIntervention) -> InterventionAnswer:
         """Thin wrapper → InterventionHandler.dispatch.
@@ -1984,7 +2119,46 @@ class ChatSession:
             finally:
                 source_agent_var.reset(token)
 
-        # Branch 3: default — deliver to user via existing dispatch path.
+        # Branch 3: user_channel — origin-pin check + dispatch or stall.
+        # issue #268 Phase 1: when the iv carries an explicit
+        # ``origin_channel_id`` that no longer maps to a registered
+        # listener (= the origin channel closed since the iv was
+        # created), park the iv in the stalled queue instead of
+        # delivering it to a different channel. Other channels
+        # observe / discard / claim via the cross-channel API
+        # (``list_stalled_interventions`` / ``discard_pending_intervention``
+        # / ``claim_pending_intervention``).
+        #
+        # Backwards-compat: iv with ``origin_channel_id=None`` (= legacy
+        # default) skips the stall check entirely and goes through the
+        # existing dispatch path unchanged.
+        if (
+            iv.origin_channel_id is not None
+            and iv.origin_channel_id not in self._interventions._listeners
+        ):
+            self._chat_events.emit(
+                "intervention_routed",
+                route="user_channel_stalled",
+                iv_kind=iv.kind,
+                iv_id=iv.id,
+                origin_channel_id=iv.origin_channel_id,
+            )
+            # Park in stalled queue. The iv has to be in _active first
+            # so mark_stalled can move it; if it's not, add it via the
+            # registry's _stalled directly (= bypass _active path
+            # because no listener is going to drain it).
+            self._interventions._stalled[iv.id] = iv
+            # Block on the iv's future — claim_pending_intervention /
+            # discard_pending_intervention will resolve / cancel it
+            # eventually. If neither happens, the awaiter (= safety
+            # limit handler with ask_timeout=0) waits indefinitely,
+            # which is the intended behaviour for "stall pending
+            # user action across channels".
+            try:
+                return await iv.future
+            except asyncio.CancelledError:
+                return InterventionAnswer(text="")
+
         self._chat_events.emit(
             "intervention_routed",
             route="user_channel",

--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -79,6 +79,15 @@ class UserIntervention:
     suggestions: list[str] = field(default_factory=list)               # ask_user only
     run_id: str | None = None
     skill_name: str | None = None
+    # issue #268: identifies the channel that initiated this intervention
+    # (= "tui:<session>" / "a2a:<run_id>" / etc.). When the origin channel
+    # closes while the iv is unresolved, the iv becomes **stalled** in
+    # the agent layer — other channels can observe / discard / claim it
+    # via ``ChatSession.list_stalled_interventions`` /
+    # ``discard_pending_intervention`` / ``claim_pending_intervention``.
+    # ``None`` (= legacy default) skips the origin-pin routing entirely
+    # so existing in-tree callers + tests see no change in behaviour.
+    origin_channel_id: str | None = None
     id: str = field(default_factory=lambda: uuid.uuid4().hex)
     future: asyncio.Future = field(default=None)  # type: ignore[assignment]
 
@@ -95,7 +104,7 @@ class UserIntervention:
         unchanged through ``AgentSnapshot.outstanding_interventions`` and
         the WAL ``intervention_dispatched.iv_dict`` field.
         """
-        return {
+        out: dict = {
             "kind": self.kind,
             "prompt": self.prompt,
             "detail": self.detail,
@@ -108,6 +117,9 @@ class UserIntervention:
             "skill_name": self.skill_name,
             "id": self.id,
         }
+        if self.origin_channel_id is not None:
+            out["origin_channel_id"] = self.origin_channel_id
+        return out
 
     @classmethod
     def from_dict(cls, data: dict) -> "UserIntervention":
@@ -131,6 +143,7 @@ class UserIntervention:
             suggestions=list(data.get("suggestions") or []),
             run_id=data.get("run_id"),
             skill_name=data.get("skill_name"),
+            origin_channel_id=data.get("origin_channel_id"),
             id=data.get("id") or uuid.uuid4().hex,
         )
 

--- a/tests/test_pending_intervention_268.py
+++ b/tests/test_pending_intervention_268.py
@@ -1,0 +1,509 @@
+"""Tier 2: PendingIntervention origin-pin + stall + redirect
+(issue #268 Phase 1, #270 umbrella First instance).
+
+Pins the cross-channel intervention routing introduced by #268:
+
+  - iv carries ``origin_channel_id`` (= "tui:..." / "a2a:..." / etc.).
+  - ``ChatSession.handle_intervention`` checks if the origin channel
+    is still registered as a listener; if not, the iv is parked in
+    the stalled queue instead of being delivered to a different
+    channel.
+  - Cross-channel operations: ``list_stalled_interventions`` (read),
+    ``discard_pending_intervention`` (cancel future), and
+    ``claim_pending_intervention`` (rebind origin + re-dispatch).
+  - ``PendingOpView`` field shape is **pinned at Phase A landing** per
+    tui-coder commitment so the TUI Pending tab + ``/pending`` slash
+    command consume contract stays stable as future kinds (= MCP
+    pending call, peer_delegate) land.
+
+Pins:
+
+  1. ``UserIntervention.origin_channel_id`` field default + to_dict /
+     from_dict preservation.
+  2. handle_intervention origin-pin check stalls when origin is
+     unregistered; existing dispatch path runs when origin is
+     registered (or ``origin_channel_id=None``).
+  3. Stalled queue API: list_stalled / get_stalled / stalled_count /
+     discard_stalled / claim_stalled all behave as documented.
+  4. ChatSession session-level operations dispatch to registry
+     correctly + emit audit events.
+  5. PendingOpView field shape is the documented set; from_intervention
+     populates from iv correctly.
+  6. Backwards-compat: iv with ``origin_channel_id=None`` follows the
+     pre-#268 dispatch path unchanged.
+
+No mocks. Real ChatSession + real InterventionRegistry.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import datetime
+
+import pytest
+
+from reyn.chat.services.intervention_registry import InterventionRegistry
+from reyn.chat.session import ChatSession, PendingOpView
+from reyn.user_intervention import (
+    InterventionAnswer,
+    UserIntervention,
+)
+
+# ── 1. UserIntervention origin_channel_id field ───────────────────────
+
+
+def test_user_intervention_default_origin_channel_id_is_none() -> None:
+    """Tier 2: backwards-compat — existing callers that don't pass
+    ``origin_channel_id`` see ``None``, no stall routing applies.
+    """
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    assert iv.origin_channel_id is None
+
+
+def test_user_intervention_origin_channel_id_round_trips_through_dict() -> None:
+    """Tier 2: to_dict + from_dict preserve origin_channel_id.
+
+    Used by AgentSnapshot persistence (= issue #254 Phase 1 + #267
+    Gap 5 Phase 1) so a restart can replay the iv's origin binding.
+    """
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt="Q?",
+        origin_channel_id="tui:session-abc",
+    )
+    restored = UserIntervention.from_dict(iv.to_dict())
+    assert restored.origin_channel_id == "tui:session-abc"
+
+
+def test_user_intervention_to_dict_omits_origin_when_none() -> None:
+    """Tier 2: legacy ivs (= no origin) don't grow a new top-level key
+    in their dict form, keeping snapshot files smaller + back-compatible.
+    """
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    d = iv.to_dict()
+    assert "origin_channel_id" not in d
+
+
+# ── 2. InterventionRegistry stalled queue operations ──────────────────
+
+
+def test_registry_mark_stalled_moves_iv_from_active_to_stalled() -> None:
+    """Tier 2: ``mark_stalled(iv_id)`` moves an active iv to the
+    stalled queue, removing it from active + order tracking.
+    """
+    async def _no_announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(
+        on_announce=_no_announce, enforce_listener_presence=False,
+    )
+
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    reg._active[iv.id] = iv
+    reg._order.append(iv.id)
+
+    assert reg.mark_stalled(iv.id) is True
+    assert iv.id not in reg._active
+    assert iv.id not in reg._order
+    assert reg.get_stalled(iv.id) is iv
+    assert reg.stalled_count() == 1
+
+
+def test_registry_mark_stalled_returns_false_when_iv_not_active() -> None:
+    """Tier 2: mark_stalled is idempotent / safe — unknown iv_id
+    returns False without raising.
+    """
+    async def _no_announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(on_announce=_no_announce)
+    assert reg.mark_stalled("nonexistent") is False
+
+
+def test_registry_list_stalled_returns_snapshot() -> None:
+    """Tier 2: list_stalled returns a list (not a live reference) so
+    iteration is safe across concurrent mutations.
+    """
+    async def _no_announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(on_announce=_no_announce)
+    iv1 = UserIntervention(kind="ask_user", prompt="Q1?")
+    iv2 = UserIntervention(kind="permission.shell", prompt="Run cmd?")
+    reg._stalled[iv1.id] = iv1
+    reg._stalled[iv2.id] = iv2
+
+    items = reg.list_stalled()
+    assert len(items) == 2
+    # Mutating the registry doesn't affect the returned snapshot.
+    reg._stalled.pop(iv1.id)
+    assert len(items) == 2
+
+
+def test_registry_discard_stalled_resolves_future_with_empty_answer() -> None:
+    """Tier 2: discard_stalled resolves the iv's future with an empty
+    InterventionAnswer + removes from the queue. Awaiters see this
+    as a refusal (= existing cancellation contract).
+    """
+    async def _no_announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(on_announce=_no_announce)
+
+    async def _drive() -> InterventionAnswer:
+        iv = UserIntervention(kind="ask_user", prompt="Q?")
+        reg._stalled[iv.id] = iv
+        # Discard from another "channel".
+        assert reg.discard_stalled(iv.id) is True
+        assert iv.id not in reg._stalled
+        return await iv.future
+
+    answer = asyncio.run(_drive())
+    assert isinstance(answer, InterventionAnswer)
+    assert answer.text == ""
+
+
+def test_registry_claim_stalled_rebinds_origin_and_returns_iv() -> None:
+    """Tier 2: claim_stalled removes from stalled queue, updates
+    origin_channel_id, returns the iv so the caller can re-dispatch.
+    """
+    async def _no_announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(on_announce=_no_announce)
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt="Q?",
+        origin_channel_id="tui:closed-session",
+    )
+    reg._stalled[iv.id] = iv
+
+    claimed = reg.claim_stalled(iv.id, "tui:new-session")
+    assert claimed is iv
+    assert claimed.origin_channel_id == "tui:new-session"
+    assert iv.id not in reg._stalled
+
+
+def test_registry_claim_stalled_returns_none_when_not_stalled() -> None:
+    """Tier 2: claim_stalled on unknown id returns None — safe / no raise."""
+    async def _no_announce(iv: UserIntervention) -> None:
+        return None
+
+    reg = InterventionRegistry(on_announce=_no_announce)
+    assert reg.claim_stalled("nonexistent", "tui:session") is None
+
+
+# ── 3. ChatSession handle_intervention origin-pin routing ─────────────
+
+
+def test_handle_intervention_with_no_origin_uses_existing_path() -> None:
+    """Tier 2: backwards-compat — iv with origin_channel_id=None
+    follows the pre-#268 dispatch path (= no stall check).
+
+    With Phase 1 subscriber-guard (no listener registered) the
+    dispatch short-circuits to empty answer; we verify the path
+    reached the short-circuit rather than the stall queue.
+    """
+    session = ChatSession(agent_name="test")
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    # No origin_channel_id, no listener.
+
+    answer = asyncio.run(session.handle_intervention(iv))
+    assert isinstance(answer, InterventionAnswer)
+    assert answer.text == ""  # Phase 1 short-circuit
+    # Did NOT land in stalled queue (= origin-pin doesn't trigger).
+    assert iv.id not in session._interventions._stalled
+
+
+def test_handle_intervention_with_registered_origin_uses_dispatch_path() -> None:
+    """Tier 2: when origin_channel_id is registered as a listener,
+    the dispatch path runs (= origin alive → not stalled).
+    """
+    session = ChatSession(agent_name="test")
+    session.register_intervention_listener("tui:session-a")
+
+    async def _drive() -> tuple[InterventionAnswer, str]:
+        # iv created INSIDE the running loop so its future binds to
+        # the same loop the registry awaits in (= mirrors the pattern
+        # used elsewhere in #254 tests).
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="Q?",
+            origin_channel_id="tui:session-a",
+        )
+        task = asyncio.ensure_future(session.handle_intervention(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # Resolve via deliver (= simulating tui input).
+        await session._deliver_answer_to(iv, "answer-from-origin")
+        result = await task
+        return result, iv.id
+
+    answer, iv_id = asyncio.run(_drive())
+    assert answer.text == "answer-from-origin"
+    # Not in stalled queue.
+    assert iv_id not in session._interventions._stalled
+
+
+def test_handle_intervention_with_closed_origin_parks_in_stalled_queue() -> None:
+    """Tier 2: when origin_channel_id is NOT in the listener set,
+    handle_intervention parks the iv in stalled queue + awaits.
+
+    Verified by:
+      - iv lands in session._interventions._stalled
+      - handle_intervention is awaiting (= doesn't return until
+        future resolves via discard / claim)
+    """
+    session = ChatSession(agent_name="test")
+    # Register a different listener — origin won't match.
+    session.register_intervention_listener("tui:current-session")
+
+    async def _drive() -> InterventionAnswer:
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="Q?",
+            origin_channel_id="tui:closed-session",  # not registered
+        )
+        task = asyncio.ensure_future(session.handle_intervention(iv))
+        # Yield twice so handle_intervention reaches the await on iv.future.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # iv must be in the stalled queue.
+        assert iv.id in session._interventions._stalled
+        assert not task.done()
+        # Discard to unblock the test.
+        ok = await session.discard_pending_intervention(iv.id)
+        assert ok is True
+        return await task
+
+    answer = asyncio.run(_drive())
+    assert answer.text == ""  # Discarded → empty answer
+
+
+def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
+    """Tier 2: when origin-pin stalls the iv, the audit event
+    ``intervention_routed{route="user_channel_stalled"}`` is emitted,
+    distinct from the regular ``"user_channel"`` route event.
+    """
+    session = ChatSession(agent_name="test")
+    session.register_intervention_listener("tui:current")
+
+    async def _drive() -> None:
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="Q?",
+            origin_channel_id="tui:closed",
+        )
+        task = asyncio.ensure_future(session.handle_intervention(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await session.discard_pending_intervention(iv.id)
+        await task
+
+    asyncio.run(_drive())
+
+    routed_events = [
+        e for e in session._chat_events.to_json()
+        if e.get("type") == "intervention_routed"
+    ]
+    assert routed_events
+    last = routed_events[-1]["data"]
+    assert last["route"] == "user_channel_stalled"
+    assert last["origin_channel_id"] == "tui:closed"
+
+
+# ── 4. ChatSession cross-channel operations ───────────────────────────
+
+
+def test_list_stalled_interventions_returns_pending_op_views() -> None:
+    """Tier 2: list_stalled_interventions returns a list of
+    PendingOpView with the documented field shape.
+    """
+    session = ChatSession(agent_name="test")
+    session.register_intervention_listener("tui:current")
+
+    async def _drive() -> list[PendingOpView]:
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="What's your name?",
+            detail="for greeting",
+            origin_channel_id="tui:closed",
+        )
+        task = asyncio.ensure_future(session.handle_intervention(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        views = session.list_stalled_interventions()
+        # Clean up.
+        await session.discard_pending_intervention(iv.id)
+        await task
+        return views
+
+    views = asyncio.run(_drive())
+    assert len(views) == 1
+    v = views[0]
+    assert isinstance(v, PendingOpView)
+    assert v.kind == "intervention"
+    assert v.origin_channel_id == "tui:closed"
+    assert v.summary == "What's your name?"
+    assert v.detail == "for greeting"
+
+
+def test_discard_pending_intervention_emits_audit_event_on_success() -> None:
+    """Tier 2: discard_pending_intervention emits
+    ``pending_intervention_discarded`` audit event for the P6 audit
+    trail when the iv was actually discarded.
+    """
+    session = ChatSession(agent_name="test")
+    session.register_intervention_listener("tui:current")
+
+    async def _drive() -> None:
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="Q?",
+            origin_channel_id="tui:closed",
+        )
+        task = asyncio.ensure_future(session.handle_intervention(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        ok = await session.discard_pending_intervention(
+            iv.id, reason="test_explicit_reason",
+        )
+        assert ok is True
+        await task
+
+    asyncio.run(_drive())
+
+    discarded = [
+        e for e in session._chat_events.to_json()
+        if e.get("type") == "pending_intervention_discarded"
+    ]
+    assert discarded
+    assert discarded[-1]["data"]["reason"] == "test_explicit_reason"
+
+
+def test_discard_pending_intervention_returns_false_for_unknown_id() -> None:
+    """Tier 2: discard on unknown id is safe + returns False without
+    raising or emitting an event.
+    """
+    session = ChatSession(agent_name="test")
+
+    async def _drive() -> bool:
+        return await session.discard_pending_intervention("nonexistent")
+
+    ok = asyncio.run(_drive())
+    assert ok is False
+
+
+def test_claim_pending_intervention_rebinds_origin_and_returns_view() -> None:
+    """Tier 2: claim updates origin_channel_id to caller's channel +
+    returns the PendingOpView reflecting the new state.
+
+    Lifecycle:
+      - stalled iv parked with origin "tui:closed"
+      - claim called from "tui:claimer" → rebind + returns view
+      - claim spawns a background _dispatch_intervention for the
+        rebound iv; we deliver an answer via the new channel to
+        complete the lifecycle cleanly
+    """
+    session = ChatSession(agent_name="test")
+    session.register_intervention_listener("tui:current")
+    session.register_intervention_listener("tui:claimer")
+
+    async def _drive() -> "PendingOpView | None":
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="Q?",
+            origin_channel_id="tui:closed",
+        )
+        task = asyncio.ensure_future(session.handle_intervention(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # Sanity: iv is in stalled queue.
+        assert iv.id in session._interventions._stalled
+        # Claim from a different channel.
+        view = await session.claim_pending_intervention(
+            iv.id, "tui:claimer",
+        )
+        # claim removed iv from _stalled + scheduled a re-dispatch
+        # task. Resolve via deliver_answer so the awaited future
+        # resolves and both tasks complete.
+        await asyncio.sleep(0)
+        await session._deliver_answer_to(iv, "from-claimer")
+        await task
+        return view
+
+    view = asyncio.run(_drive())
+    assert view is not None
+    assert view.origin_channel_id == "tui:claimer"
+
+
+def test_claim_pending_intervention_returns_none_for_unknown_id() -> None:
+    """Tier 2: claim on unknown id returns None, no exception."""
+    session = ChatSession(agent_name="test")
+
+    async def _drive() -> "PendingOpView | None":
+        return await session.claim_pending_intervention(
+            "nonexistent", "tui:claimer",
+        )
+
+    result = asyncio.run(_drive())
+    assert result is None
+
+
+# ── 5. PendingOpView shape pin (= tui-coder commitment) ───────────────
+
+
+def test_pending_op_view_has_documented_field_shape() -> None:
+    """Tier 2: PendingOpView carries exactly the documented fields.
+
+    Per tui-coder's #270 framework commitment, the field shape is
+    pinned at Phase A landing so the TUI Pending tab + ``/pending``
+    slash command code path doesn't churn as new kinds land.
+    """
+    # All required + optional fields present + type-checkable.
+    fields = inspect.signature(PendingOpView).parameters
+    expected = {"id", "kind", "origin_channel_id", "created_at", "summary", "detail"}
+    assert set(fields.keys()) == expected, (
+        f"PendingOpView fields drifted from the Phase A commitment: "
+        f"got {set(fields.keys())}, expected {expected}"
+    )
+
+
+def test_pending_op_view_from_intervention_populates_all_fields() -> None:
+    """Tier 2: from_intervention populates every documented field
+    from the source iv.
+    """
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt="What's your name?",
+        detail="for greeting",
+        origin_channel_id="tui:abc",
+    )
+    view = PendingOpView.from_intervention(iv)
+    assert view.id == iv.id
+    assert view.kind == "intervention"
+    assert view.origin_channel_id == "tui:abc"
+    # created_at is ISO-formatted (= parseable).
+    assert datetime.fromisoformat(view.created_at)
+    assert view.summary == "What's your name?"
+    assert view.detail == "for greeting"
+
+
+def test_pending_op_view_is_immutable() -> None:
+    """Tier 2: PendingOpView is frozen — callers cannot mutate the
+    view, ensuring TUI / slash callers don't accidentally corrupt
+    each other's references.
+    """
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    view = PendingOpView.from_intervention(iv)
+    with pytest.raises(Exception):
+        view.summary = "changed"  # type: ignore[misc]
+
+
+def test_pending_op_view_handles_iv_without_origin_channel() -> None:
+    """Tier 2: from_intervention tolerates ``origin_channel_id=None``
+    by rendering the field as empty string (= clean display in TUI).
+    """
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    view = PendingOpView.from_intervention(iv)
+    assert view.origin_channel_id == ""


### PR DESCRIPTION
**[e2e-coder]** — issue #268 Phase 1 — **#270 umbrella First instance**.

Refs #268. Builds on #267 Gap 5 Phase 1 (PR #273) + #269 Phase 1 (PR #274) — both merged. Future Gap 5 Phase 2 + #269 Phase 2 integrations refine but don't gate this PR.

## Problem

Pre-#268 the chat-side intervention routing was **per-chain mutually exclusive**: an iv either went to the TUI (= via outbox) OR to an A2A peer's webhook (= via override), never both. The user-discussion 2026-05-20 surfaced 3 painful UX scenarios:

| Case | Pain |
|---|---|
| A: A2A start → TUI 監視 | iv invisible to TUI even though same user is watching |
| **B: peer crash → TUI 復帰** | **iv lost** — orphaned task hangs, user must cancel |
| C: TUI + A2A 並列同時操作 | iv silos, no cross-channel coordination |

User proposed the corrective design (= adopted in #268 rewrite):
- iv pinned to its **origin channel** (= no implicit fan-out, no race)
- origin closed → iv **stalls** at agent layer (= observable, not lost)
- other channels can **observe / discard / claim** stalled iv (= explicit user agency)

## What Phase 1 ships

| Layer | Change |
|---|---|
| `UserIntervention` | new `origin_channel_id: str \| None = None` field + to_dict/from_dict preservation |
| `InterventionRegistry` | new `_stalled` queue + mark_stalled / list_stalled / get_stalled / stalled_count / discard_stalled / claim_stalled |
| `ChatSession.handle_intervention` Branch 3 | origin-pin check: closed origin → stall path + emit `intervention_routed{route="user_channel_stalled"}` event; else existing dispatch |
| `ChatSession` cross-channel ops | list_stalled_interventions / discard_pending_intervention / claim_pending_intervention + P6 audit events |
| `PendingOpView` (new) | shared vocabulary, frozen dataclass, fields pinned per #270 + tui-coder commitment |

### `PendingOpView` field shape (= pinned at Phase A landing)

Per tui-coder's commitment in #270 framework discussion + Phase A handoff promise, the field shape is **inscribed in this PR** so the TUI Pending tab + `/pending` slash command consume contract stays stable as future kinds land:

```python
@dataclass(frozen=True)
class PendingOpView:
    id: str
    kind: str  # "intervention" (= this PR), future "mcp_call" / "peer_delegate"
    origin_channel_id: str
    created_at: str
    summary: str
    detail: str = ""
```

Phase B refactor (= #270) will lift this to a shared module + extend `kind` discriminator. Phase 1 lives inline in `session.py`.

## Backwards-compat

iv with `origin_channel_id=None` (= **all existing in-tree callers**, since no caller stamps the field yet) skips the stall check entirely and uses the existing dispatch path unchanged.

Verified by `test_handle_intervention_with_no_origin_uses_existing_path` + existing Phase 1-4 tests all still passing (= 32 adjacent + full suite 4099 baseline maintained).

Bus-side stamping (= `ChatInterventionBus` / `A2AInterventionBus` setting `iv.origin_channel_id` automatically) is **Phase 2** of #268 — Phase 1 establishes the mechanism + APIs, Phase 2 wires the buses + adds the TUI surface (= tui-coder pickup per #270 commitment).

## Tier 2 contract test (22 tests, `tests/test_pending_intervention_268.py`)

| Section | Coverage |
|---|---|
| iv field | default + round-trip + dict omission when None (3 tests) |
| Registry stalled ops | mark / list / get / discard / claim correctness + safety on unknown id (6 tests) |
| handle_intervention | no-origin / registered origin / closed origin paths + audit event emission (4 tests) |
| Session ops | list / discard / claim + audit events + error cases (5 tests) |
| PendingOpView | field shape pin / immutability / iv binding / None origin handling (4 tests) |

## Test plan

- [x] **Automated — `pytest tests/test_pending_intervention_268.py`**: 22/22 pass。
- [x] **Adjacent — `pytest tests/test_intervention_subscriber_guard.py tests/test_intervention_agent_subscriber.py tests/test_intervention_agent_routing.py`** (= Phase 1-4 intervention routing): 32/32 pass, no regression。
- [x] **Full suite — `pytest tests/ --ignore=tests/scaffold --timeout=30`**: 4121 passed, 5 skipped, 3 xfailed in 149s (= +22 from this PR)。
- [x] **Lint — `ruff check`**: clean on all touched files。
- [ ] **Manual** — none required for Phase 1 (= bus-side stamping deferred to Phase 2, no observable behaviour change for existing callers). Once Phase 2 lands, a `Manual TUI verify` will check the Pending tab / `/pending` slash command surfaces.

## Architecture summary (= cluster status post-this-PR)

```
#267 Gap 3 Z-b (PR #272 merged) ✓
#267 Gap 5 Phase 1 (PR #273 merged) ✓ ← prerequisite of prerequisites
#269 Phase 1 (PR #274 merged) ✓ ← cross-cutting channel state vocabulary
#268 Phase 1 (this PR) ← #270 umbrella First instance
   ↓
[Track 1 follow-ups]
- #268 Phase 2: bus-side stamping (ChatInterventionBus / A2AInterventionBus)
  + TUI surface (tui-coder dispatch per #270 commitment)
- Gap 5 Phase 2: half-restore re-bind (= restored iv ↔ RunEntry pairing)
- #269 Phase 2: RunEntry.channel_state integration + caller-side use

[Track 2 still pending]
- #267 Gap 4 (iv kind partial coverage)
- #267 Gap 2 (webhook trigger expansion, uses #269 ack)
- #271 M1+M2 (MCP server outbound + cancellation, = Track 2 mirror)
- #271 M3 (MCP capability advertising, = #267 Z-b mirror)

[Phase B per #270]
- MCP pending-call instance (= #264 (c) escalation)
- Generic abstraction refactor (= lift PendingOpView + ops to shared module)
```

## Related

- #268 — this PR
- #270 umbrella — First instance, Phase B is the generic abstraction refactor
- #267 Gap 5 Phase 1 PR #273 — RunRegistry persist (prerequisite)
- #269 Phase 1 PR #274 — channel state vocabulary (cross-cutting)
- #261 → PR #262 — Phase 4 TUI follow-up (= source_agent meta) — pattern this PR builds on

🤖 Generated with [Claude Code](https://claude.com/claude-code)