### PR TITLE
feat(tui): reyn chat --connect <ws-url> — TUI thin client mode (#276 Phase A)

### DIFF
--- a/src/reyn/chat/tui/ws_client.py
+++ b/src/reyn/chat/tui/ws_client.py
@@ -1,0 +1,258 @@
+"""WebSocket client adapter for ``reyn chat --connect``.
+
+Issue #276 Phase A — proof-of-concept WS thin client. Connects to a
+running ``reyn web`` server's ``/ws/chat/{agent_name}`` endpoint and
+exposes:
+
+- :class:`_WSRegistry` — a minimal AgentRegistry shape (= just enough
+  attributes for ``ReynTUIApp._outbox_loop`` and ``_get_session`` to
+  function). Drains the WS connection in a background task and pushes
+  reconstructed ``OutboxMessage`` items onto its ``repl_outbox`` queue.
+- :class:`_WSSessionProxy` — a minimal ChatSession shape exposing the
+  TUI's submit / session-attribute paths the foreground code touches
+  on user input. Phase B will expand this with intervention answer /
+  cancel / list-agents support.
+
+Phase A scope is intentionally tight: chat round-trip (= user submit
+→ remote turn → frames stream back) works; right-panel features that
+read local files (events / memory / agents / cost / docs) show
+empty / "remote — limited" placeholders via the existing
+``--connect`` integration on each tab (e.g. Pending tab's
+``remote_mode`` from issue #277).
+
+Server-side WS protocol is the existing ``src/reyn/web/ws/chat.py``
+endpoint — no server changes required for Phase A.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from urllib.parse import urljoin
+
+from reyn.chat.outbox import OutboxMessage
+
+logger = logging.getLogger(__name__)
+
+
+# Server forwards these kinds (= matches ``_FORWARDED_KINDS`` in
+# ``src/reyn/web/ws/chat.py``). Plus the keepalive synthetic status.
+# The TUI's OutboxRouter already dispatches on these.
+_KNOWN_KINDS = frozenset({
+    "agent", "status", "error", "intervention", "trace", "skill_done",
+})
+
+
+class _WSSessionProxy:
+    """Minimal ChatSession-shaped object backing the TUI in ``--connect`` mode.
+
+    The TUI reads ``agent_name`` (for header / Pending tab claim
+    channel id construction) and calls ``submit_user_text(text)`` on
+    user input. Everything else is intentionally absent for Phase A
+    — accesses fall through to ``None`` / ``AttributeError`` which
+    the TUI already handles defensively (Pending tab, intervention
+    queued_count, etc. show empty / placeholder).
+
+    Phase B will widen this proxy: ``running_skills`` / ``_interventions`` /
+    ``_maybe_answer_oldest_intervention`` / ``_registry`` / etc., each
+    backed by an additional client→server message type that the
+    server-side WS endpoint will need to gain.
+    """
+
+    def __init__(self, agent_name: str, send_fn) -> None:
+        # ``send_fn`` is an async callable that sends a JSON-encoded
+        # client→server message. Owned by the registry — passed in
+        # so the proxy doesn't need a reference to the WebSocket.
+        self.agent_name = agent_name
+        self._send_fn = send_fn
+        # The TUI inspects these attributes via ``getattr(..., None)``
+        # in several paths. Setting them to None keeps Phase A read
+        # surfaces from raising — they each render the
+        # "limited / remote" placeholder downstream.
+        self._interventions = None
+        self.running_skills: dict = {}
+        self.running_plans: dict = {}
+
+    async def submit_user_text(self, text: str) -> None:
+        """Send a ``user_message`` WS frame.
+
+        Mirrors :py:meth:`ChatSession.submit_user_text` from the TUI's
+        point of view — kicks off a turn on the remote agent.
+        """
+        await self._send_fn({"type": "user_message", "text": text})
+
+
+class _WSRegistry:
+    """Minimal AgentRegistry-shaped object backing the TUI in ``--connect`` mode.
+
+    The TUI's outbox loop reads from ``self.repl_outbox`` (an
+    asyncio.Queue of OutboxMessage). We populate that queue from
+    WS receive frames in :meth:`_receive_loop`. The TUI's
+    ``_get_session`` calls :meth:`attached_session`; we return the
+    cached :class:`_WSSessionProxy`.
+
+    ``_project_root`` is set so existing TUI paths that read it (e.g.
+    Right Panel tab data sources) don't crash — they each have their
+    own remote-mode handling that surfaces empty / placeholder
+    content because the underlying data lives on the server.
+    """
+
+    def __init__(
+        self,
+        agent_name: str,
+        websocket,
+        *,
+        project_root,
+    ) -> None:
+        self._agent_name = agent_name
+        self._ws = websocket
+        self._project_root = project_root
+        self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        self._receive_task: asyncio.Task | None = None
+        # Build the session proxy — pass send_fn that goes through the
+        # registry-owned websocket.
+        self._session = _WSSessionProxy(
+            agent_name=agent_name, send_fn=self._send,
+        )
+
+    async def _send(self, payload: dict) -> None:
+        """Send a JSON-encoded message to the server."""
+        try:
+            await self._ws.send(json.dumps(payload, ensure_ascii=False))
+        except Exception as exc:
+            logger.warning("ws_client: send failed: %s", exc)
+
+    def attached_session(self):
+        """Return the WS-backed session proxy (= used by ``app._get_session``)."""
+        return self._session
+
+    def start(self) -> None:
+        """Kick off the background WS receive loop."""
+        if self._receive_task is None:
+            self._receive_task = asyncio.create_task(self._receive_loop())
+
+    async def shutdown(self) -> None:
+        """Cancel the receive loop + close the WS — called on TUI exit."""
+        if self._receive_task and not self._receive_task.done():
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        try:
+            await self._ws.close()
+        except Exception:
+            pass
+        # Wake up the outbox loop one last time so it can break out.
+        await self.repl_outbox.put(OutboxMessage(kind="__end__", text=""))
+
+    async def _receive_loop(self) -> None:
+        """Drain the WS, parse each frame into OutboxMessage, enqueue."""
+        try:
+            async for raw in self._ws:
+                msg = _parse_frame(raw)
+                if msg is None:
+                    continue
+                await self.repl_outbox.put(msg)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Surface a single error frame so the user can see why the
+            # stream stopped (= not silent freeze).
+            logger.warning("ws_client: receive loop ended: %s", exc)
+            await self.repl_outbox.put(OutboxMessage(
+                kind="error",
+                text=f"connection lost: {exc}",
+                meta={"source": "ws_client"},
+            ))
+
+
+def _parse_frame(raw) -> OutboxMessage | None:
+    """Reconstruct an :class:`OutboxMessage` from a server WS frame.
+
+    Server frames are JSON ``{"kind", "text", "meta"}`` per
+    ``src/reyn/web/ws/chat.py``. Keepalive pings carry ``meta.$keepalive``
+    and ``text=""``; we drop those (= no user-visible effect).
+    """
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning("ws_client: malformed frame: %s", exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    kind = str(payload.get("kind", ""))
+    text = str(payload.get("text", ""))
+    meta = payload.get("meta") or {}
+    if not isinstance(meta, dict):
+        meta = {}
+    # Drop keepalive pings — the WS endpoint sends them every 30 s
+    # when no real outbox traffic flows, marked via ``meta.$keepalive``.
+    if meta.get("$keepalive"):
+        return None
+    # Pass through unknown kinds too — the TUI's OutboxRouter default
+    # branch will render them via plain Rich text. Future server-side
+    # kinds (= mcp_progress etc.) flow naturally.
+    if kind not in _KNOWN_KINDS:
+        logger.debug("ws_client: forwarding unknown kind %r", kind)
+    return OutboxMessage(kind=kind, text=text, meta=meta)
+
+
+def _build_ws_url(base: str, agent_name: str) -> str:
+    """Convert ``ws://host[:port][/]`` + agent name → full ``/ws/chat/<agent>`` URL.
+
+    Accepts a host-style base (= ``ws://localhost:8080``) plus the
+    positional ``agent_name`` from the CLI. The user supplies the
+    endpoint host; the WS path is internal.
+    """
+    if not base.endswith("/"):
+        base = base + "/"
+    return urljoin(base, f"ws/chat/{agent_name}")
+
+
+async def connect(
+    base_url: str, agent_name: str, *, project_root,
+) -> _WSRegistry:
+    """Open a WS connection to a running ``reyn web`` server.
+
+    Raises :class:`ImportError` with a friendly message when the
+    ``websockets`` package isn't installed (= ``pip install reyn[web]``).
+    Raises :class:`ConnectionError` with the underlying cause on
+    failed handshake / unreachable host so the CLI can print a
+    one-line diagnostic instead of a stack trace.
+    """
+    try:
+        import websockets  # noqa: F401
+        from websockets.asyncio.client import connect as ws_connect
+    except ImportError as exc:
+        raise ImportError(
+            "reyn chat --connect requires the 'websockets' package; "
+            "install with: pip install -e '.[web]'"
+        ) from exc
+
+    url = _build_ws_url(base_url, agent_name)
+    try:
+        ws = await ws_connect(url)
+    except Exception as exc:
+        raise ConnectionError(
+            f"failed to connect to {url}: {exc}"
+        ) from exc
+    reg = _WSRegistry(agent_name, ws, project_root=project_root)
+    reg.start()
+    print(
+        f"connected to {url}",
+        file=sys.stderr,
+    )
+    return reg
+
+
+__all__ = [
+    "connect",
+    "_WSRegistry",
+    "_WSSessionProxy",
+    "_parse_frame",
+    "_build_ws_url",
+]

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -88,6 +88,25 @@ def register(sub) -> None:
             "for dogfood / scripted runs against fresh .reyn/ workspaces."
         ),
     )
+    # Issue #276 Phase A — TUI thin client mode connecting to a remote
+    # `reyn web` server. When set, the local ChatSession / AgentRegistry
+    # / state restore are skipped; the TUI streams from
+    # ``ws://<host>[:port]/ws/chat/<agent>``. Right panel features that
+    # depend on local files (events / memory / pending) render
+    # "remote — limited" placeholders per #276 Phase C-(b) scoped
+    # disable; full parity via REST is future work (Phase C-(a)).
+    p.add_argument(
+        "--connect",
+        metavar="WS_URL",
+        default=None,
+        help=(
+            "Connect to a remote `reyn web` server over WebSocket "
+            "(e.g. --connect ws://localhost:8080). The positional "
+            "agent_name selects which agent on the server. Requires "
+            "`pip install reyn[web]`. Right panel features that need "
+            "local file access render in 'remote — limited' v1 mode."
+        ),
+    )
     add_common_args(p)
     p.set_defaults(func=run)
 
@@ -141,7 +160,66 @@ def _reset_project_state(project_root: Path, *, confirm: bool = True) -> bool:
     return True
 
 
+def _run_connect_mode(args: argparse.Namespace, base_url: str) -> None:
+    """Issue #276 Phase A — connect to a remote `reyn web` server.
+
+    Skips local ChatSession / AgentRegistry / state restore. The TUI
+    streams frames from ``ws://<host>[:port]/ws/chat/<agent_name>``;
+    user input is forwarded to the server as ``user_message`` frames.
+
+    Right-panel features that need local file access (events / memory
+    / pending) surface "remote — limited" placeholders via each tab's
+    existing remote-mode handling (e.g. PR #280 Pending tab
+    ``remote_mode=True``). Phase C-(a) future iteration via REST
+    will lift the limit; v1 takes the scoped-disable path per the
+    #276 owner decision.
+    """
+    from reyn.chat.tui.app import run_tui
+    from reyn.chat.tui.ws_client import connect as ws_connect
+    from reyn.llm.llm import run_async
+
+    agent_name = args.agent_name or "default"
+    # No project root probe — remote mode doesn't read local .reyn/
+    # state. Use cwd so any path-shaped attribute access on the
+    # registry resolves to *something* sensible.
+    project_root = Path.cwd()
+
+    async def _main() -> None:
+        try:
+            registry = await ws_connect(
+                base_url, agent_name, project_root=project_root,
+            )
+        except ImportError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        except ConnectionError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(2)
+        try:
+            await run_tui(
+                registry,
+                agent_name=agent_name,
+                # Model / budget unknown in remote mode — the server
+                # owns them. Show empty fields rather than guessing.
+                model="",
+                budget_tracker=None,
+                banner=getattr(args, "banner", False),
+            )
+        finally:
+            await registry.shutdown()
+
+    run_async(_main())
+
+
 def run(args: argparse.Namespace) -> None:
+    # Issue #276 Phase A — TUI thin client mode short-circuits before
+    # any local session / state setup. Bifurcates at the top of run()
+    # so the local-mode block stays untouched (= backwards-compat 100%).
+    connect_url = getattr(args, "connect", None)
+    if connect_url:
+        _run_connect_mode(args, connect_url)
+        return
+
     from reyn.budget.budget import BudgetTracker
     from reyn.chat.profile import AgentProfile
     from reyn.chat.registry import DEFAULT_AGENT_NAME, AgentRegistry

--- a/tests/cli/test_ws_client_phase_a.py
+++ b/tests/cli/test_ws_client_phase_a.py
@@ -40,7 +40,6 @@ from reyn.chat.tui.ws_client import (
     _WSSessionProxy,
 )
 
-
 # ── _parse_frame ─────────────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_ws_client_phase_a.py
+++ b/tests/cli/test_ws_client_phase_a.py
@@ -1,0 +1,200 @@
+"""Tier 2: WS client frame parser + URL builder + session proxy submit.
+
+Issue #276 Phase A (= TUI thin client `--connect ws://...` proof of
+concept). Pins the public surface of ``reyn.chat.tui.ws_client``
+without standing up a real WebSocket server (= server side is the
+existing ``reyn web`` endpoint, no changes needed for Phase A).
+
+Contract pinned:
+
+1. ``_parse_frame`` reconstructs an ``OutboxMessage`` from a JSON
+   server frame matching the existing ``src/reyn/web/ws/chat.py``
+   protocol — ``{kind, text, meta}`` round-trips faithfully.
+2. ``_parse_frame`` returns None on:
+   - malformed JSON (no crash)
+   - non-dict payload
+   - keepalive ping (= ``meta.$keepalive`` true)
+3. Unknown ``kind`` values pass through unfiltered (= future
+   ``mcp_progress`` / ``peer_delegate_resolved`` etc. flow naturally).
+4. ``_build_ws_url`` constructs the ``/ws/chat/<agent>`` path from a
+   host-style base + agent name (trailing-slash idempotent).
+5. ``_WSSessionProxy.submit_user_text`` sends the wire-protocol
+   ``user_message`` JSON via the injected send fn (= no MagicMock,
+   just a recording lambda).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.ws_client import (
+    _build_ws_url,
+    _parse_frame,
+    _WSSessionProxy,
+)
+
+
+# ── _parse_frame ─────────────────────────────────────────────────────────────
+
+
+def test_parse_frame_reconstructs_outbox_message_basic_shape() -> None:
+    """Tier 2: ``{kind, text, meta}`` JSON → OutboxMessage with same values."""
+    frame = json.dumps({
+        "kind": "agent",
+        "text": "hello world",
+        "meta": {"chain_id": "c1"},
+    })
+    msg = _parse_frame(frame)
+    assert msg is not None
+    assert msg.kind == "agent"
+    assert msg.text == "hello world"
+    assert msg.meta == {"chain_id": "c1"}
+
+
+def test_parse_frame_intervention_meta_preserves_full_shape() -> None:
+    """Tier 2: intervention frames carry the full TUI-consumed meta shape
+    intact (= the contract from #258 Phase 2 / #261 source_agent /
+    #277 PendingOpView, transmitted over the wire identically)."""
+    frame = json.dumps({
+        "kind": "intervention",
+        "text": "Permission request",
+        "meta": {
+            "intervention_id": "iv-abcd",
+            "prompt": "Allow exec?",
+            "detail": "/bin/ls",
+            "choices": [{"label": "Yes", "id": "y", "hotkey": "y"}],
+            "source_agent": "planner",  # #261 opt-in
+        },
+    })
+    msg = _parse_frame(frame)
+    assert msg is not None
+    assert msg.meta["intervention_id"] == "iv-abcd"
+    assert msg.meta["source_agent"] == "planner"
+    assert msg.meta["choices"][0]["label"] == "Yes"
+
+
+def test_parse_frame_keepalive_returns_none() -> None:
+    """Tier 2: server keepalive pings (= ``meta.$keepalive: true``) are dropped."""
+    frame = json.dumps({
+        "kind": "status",
+        "text": "",
+        "meta": {"$keepalive": True},
+    })
+    assert _parse_frame(frame) is None
+
+
+def test_parse_frame_malformed_json_returns_none() -> None:
+    """Tier 2: invalid JSON doesn't crash — return None, log a warning."""
+    assert _parse_frame("{not json") is None
+
+
+def test_parse_frame_non_dict_payload_returns_none() -> None:
+    """Tier 2: top-level list / string / number payloads → None."""
+    assert _parse_frame(json.dumps(["not", "a", "dict"])) is None
+    assert _parse_frame(json.dumps("just-a-string")) is None
+    assert _parse_frame(json.dumps(42)) is None
+
+
+def test_parse_frame_unknown_kind_passes_through() -> None:
+    """Tier 2: future kinds (= e.g. ``mcp_progress``) flow without filter.
+
+    The server may add new kinds before the TUI catches up; the WS
+    client must not silently drop them. The TUI's OutboxRouter
+    default branch will render them as plain text.
+    """
+    frame = json.dumps({
+        "kind": "mcp_progress",
+        "text": "fetching…",
+        "meta": {"server": "web-search", "progress_pct": 45},
+    })
+    msg = _parse_frame(frame)
+    assert msg is not None
+    assert msg.kind == "mcp_progress"
+
+
+def test_parse_frame_handles_bytes_input() -> None:
+    """Tier 2: websockets may yield ``bytes`` for binary frames — decode + parse."""
+    payload = json.dumps({"kind": "agent", "text": "ok", "meta": {}})
+    msg = _parse_frame(payload.encode("utf-8"))
+    assert msg is not None
+    assert msg.kind == "agent"
+
+
+def test_parse_frame_missing_meta_defaults_to_empty_dict() -> None:
+    """Tier 2: a frame without ``meta`` builds a message with ``meta={}``."""
+    frame = json.dumps({"kind": "agent", "text": "hi"})
+    msg = _parse_frame(frame)
+    assert msg is not None
+    assert msg.meta == {}
+
+
+# ── _build_ws_url ────────────────────────────────────────────────────────────
+
+
+def test_build_ws_url_appends_ws_chat_path() -> None:
+    """Tier 2: host base + agent name → full ``/ws/chat/<agent>`` URL."""
+    url = _build_ws_url("ws://localhost:8080", "default")
+    assert url == "ws://localhost:8080/ws/chat/default"
+
+
+def test_build_ws_url_idempotent_on_trailing_slash() -> None:
+    """Tier 2: trailing / on the base is tolerated (= no double slash)."""
+    url = _build_ws_url("ws://localhost:8080/", "research")
+    assert url == "ws://localhost:8080/ws/chat/research"
+
+
+def test_build_ws_url_supports_wss_scheme() -> None:
+    """Tier 2: secure ``wss://`` bases work the same shape as ``ws://``."""
+    url = _build_ws_url("wss://reyn.example.com", "agent-1")
+    assert url == "wss://reyn.example.com/ws/chat/agent-1"
+
+
+# ── _WSSessionProxy ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_submit_sends_user_message_frame() -> None:
+    """Tier 2: ``submit_user_text`` sends the wire-protocol JSON frame
+    via the injected send fn.
+
+    Spies via direct attribute substitution / recording lambda (= no
+    MagicMock per testing.ja.md). The server-side endpoint
+    (``src/reyn/web/ws/chat.py``) dispatches on
+    ``payload["type"] == "user_message"`` so the shape is the
+    load-bearing contract.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    await proxy.submit_user_text("hello world")
+
+    assert len(sent) == 1
+    assert sent[0]["type"] == "user_message"
+    assert sent[0]["text"] == "hello world"
+
+
+def test_session_proxy_exposes_attrs_tui_reads_defensively() -> None:
+    """Tier 2: TUI reads ``agent_name`` / ``running_skills`` / ``_interventions``
+    on the session — proxy provides safe defaults so no AttributeError.
+
+    These attributes are accessed in multiple TUI paths
+    (header / Pending tab / cancel handler etc.); the Phase A proxy
+    returns empty / None so each consumer sees the same shape as
+    "session attached, but nothing in flight". Phase B widens the
+    proxy to round-trip these to / from the server.
+    """
+    proxy = _WSSessionProxy(agent_name="default", send_fn=lambda _: None)
+    assert proxy.agent_name == "default"
+    assert proxy.running_skills == {}
+    assert proxy.running_plans == {}
+    assert proxy._interventions is None


### PR DESCRIPTION
**[tui-coder]** —

Closes #276 Phase A — `reyn chat --connect` revival (= positioning doc update 4 scope-out reversal per owner decision).

## What this PR delivers (= Phase A PoC scope)

- **`--connect ws://host[:port]`** flag on `reyn chat`. Positional `agent_name` selects which agent on the remote `reyn web` server.
- **`src/reyn/chat/tui/ws_client.py`** — minimal WS client adapter:
  - `_WSRegistry` exposes the AgentRegistry shape (= `repl_outbox` queue + `_project_root`) so `ReynTUIApp._outbox_loop` runs unchanged.
  - `_WSSessionProxy` exposes the minimal ChatSession shape (`agent_name`, `running_skills`, `running_plans`, `_interventions=None`, `submit_user_text(text)`).
  - `_parse_frame` reconstructs `OutboxMessage` from the existing `src/reyn/web/ws/chat.py` server protocol (= keepalive drop, malformed-JSON tolerated, unknown kinds pass through).
  - `_build_ws_url(base, agent)` constructs `ws://host/ws/chat/<agent>`.
- **`_run_connect_mode`** bifurcates at the top of `chat.py:run()` so the local-mode block is untouched (= backwards-compat 100%).
- **`websockets` lazy-imported** with a `pip install reyn[web]` ImportError so users without the web extras see a one-line diagnostic.

## Right panel coordination

- Right-panel features that need local file access fall through to their existing empty-state placeholders.
- Pending tab's `remote_mode=True` path (= PR #280) fires when `session is None`, surfacing the "remote — limited" placeholder per #277 + #276 Phase C-(b).

**Server-side: no changes required** — the existing `/ws/chat/{agent_name}` endpoint already speaks the protocol Phase A consumes.

## Out of scope (= Phase B per #276 plan)

- `cancel_inflight` / `answer_intervention` / `list_interventions` / `list_agents` / `attach_agent` message types
- `WSSessionProxy` widening to round-trip `_maybe_answer_oldest_intervention`
- Right panel REST data sources (= Phase C-(a))

## Test plan

- [x] **Tier 2 contract tests** — `tests/cli/test_ws_client_phase_a.py`, 13 cases across 5 axes:
  - `_parse_frame` reconstruction (basic / intervention full #258/#261/#277 meta / missing-meta default / bytes input)
  - `_parse_frame` defensive returns (malformed JSON / non-dict / keepalive)
  - `_parse_frame` unknown-kind pass-through (= future server kinds OK)
  - `_build_ws_url` (basic / trailing-slash / wss://)
  - `_WSSessionProxy.submit_user_text` sends the wire-protocol JSON + defensive attribute surface
- [x] **Existing tests** — `pytest tests/cli/` 271 passed (258 base + 13 new).
- [x] **Code path verification** — `_outbox_loop` reads from `app._agent_registry.repl_outbox` unchanged; `_WSRegistry` populates that queue from receive frames; OutboxRouter dispatch is protocol-agnostic (= same shape as local mode).
- [ ] **Manual visual (skipped — `pip install reyn[web]` + running `reyn web` server required for true end-to-end; not in pre-merge env)**: launch `reyn web --host 127.0.0.1`, in another shell `reyn chat default --connect ws://127.0.0.1:8080`, send a message, observe agent reply streamed back.

## Related

- #276 (= autonomous continuation gaps umbrella, Phase A dispatch via owner decision)
- #277 / PR #280 (= Pending tab `remote_mode` integration, bilateral coordination)
- positioning commits `8c5462bc` / `ee9ea73d` (= past scope-out, reversed by #276 owner decision)
- `src/reyn/web/ws/chat.py` (= server endpoint, unchanged in Phase A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)