### PR TITLE
feat(chat): ChatInterventionBus stamping + dispatch-level stall check (#268 Phase 2 continuation)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -193,6 +193,16 @@ class RouterCapExceeded(Exception):
         self.last_reason = last_reason
 
 
+# issue #268 Phase 2 continuation: canonical channel identifier for
+# chat-side interventions (= matches the listener_id that
+# ``ChatTUIApp.on_mount`` registers in src/reyn/chat/tui/app.py).
+# Production ChatInterventionBus instances stamp ivs with this id so
+# the agent layer's origin-pin check + cross-channel observe / claim
+# routing work end-to-end for TUI-initiated tasks. Module-level so
+# tests can import + assert against a single source of truth.
+DEFAULT_CHAT_CHANNEL_ID = "tui"
+
+
 @dataclass(frozen=True)
 class PendingOpView:
     """Read-only view of a pending / stalled operation surfaced across channels
@@ -286,15 +296,71 @@ class ChatInterventionBus:
     for Phase 5 removal).
     """
 
-    def __init__(self, session: "ChatSession", run_id: str | None, skill_name: str | None) -> None:
+    def __init__(
+        self,
+        session: "ChatSession",
+        run_id: str | None,
+        skill_name: str | None,
+        *,
+        channel_id: str | None = None,
+    ) -> None:
         self._session = session
         self._run_id = run_id
         self._skill_name = skill_name
+        # issue #268 Phase 2 continuation: optional channel_id stamping.
+        # Production wiring (= ChatSession._build_intervention_bus_for_skill)
+        # passes the session's canonical channel_id (e.g. "tui") so
+        # skill-emitted ivs carry provenance for cross-channel routing.
+        # Test fixtures that construct ChatInterventionBus directly
+        # without passing channel_id see unchanged behaviour (= no
+        # stamping → no stall check → existing dispatch path).
+        self._channel_id = channel_id
+
+    @property
+    def channel_id(self) -> str | None:
+        """Configured channel identifier for issue #268 origin-pin
+        routing. ``None`` means stamping is disabled for this instance
+        (= test-fixture default that doesn't engage the new mechanism).
+        """
+        return self._channel_id
 
     async def deliver(self, iv: "UserIntervention") -> "InterventionAnswer":
         """``UserChannel.deliver`` — route the prompt to ChatSession's
         outbox/inbox so the attached TUI surfaces it to the user.
+
+        issue #268 Phase 2 continuation: when this bus was constructed
+        with a ``channel_id`` AND no chain-override is active for the
+        iv's run, stamp ``iv.origin_channel_id`` so the agent layer
+        can attribute the iv to this channel for cross-channel
+        observe / discard / claim routing. The override-aware skip
+        matters because the SAME ChatInterventionBus instance services
+        A2A-spawned skills (= ``_build_agent`` constructs one per
+        skill spawn regardless of caller), and A2AInterventionBus needs
+        a clean slot to stamp ``a2a:<run_id>`` downstream. Respects
+        pre-existing stamping (= upstream-set origin wins for
+        multi-hop delegation provenance).
         """
+        # issue #268 Phase 2 continuation: stamp origin channel for
+        # cross-channel routing (only when configured AND no chain
+        # override is going to claim this iv first). Use the bus's
+        # captured ``_run_id`` for the override lookup since
+        # ``iv.run_id`` isn't filled in until below.
+        if self._channel_id is not None and iv.origin_channel_id is None:
+            override_active = False
+            run_id_for_lookup = iv.run_id or self._run_id
+            if (
+                run_id_for_lookup is not None
+                and self._session._intervention_overrides
+            ):
+                chain_id = self._session.running_skills_chain.get(
+                    run_id_for_lookup,
+                )
+                if chain_id is not None:
+                    override_active = (
+                        chain_id in self._session._intervention_overrides
+                    )
+            if not override_active:
+                iv.origin_channel_id = self._channel_id
         if iv.run_id is None:
             iv.run_id = self._run_id
         if not iv.skill_name:
@@ -1025,6 +1091,7 @@ class ChatSession:
             # to what session._mcp_call_tool wires manually today.
             intervention_bus_factory=lambda: ChatInterventionBus(
                 self, run_id=None, skill_name="chat_router",
+                channel_id=DEFAULT_CHAT_CHANNEL_ID,
             ),
         )
 
@@ -1147,7 +1214,10 @@ class ChatSession:
         never imports ChatInterventionBus or holds a session reference.
         """
         return self._build_agent(
-            intervention_bus=ChatInterventionBus(self, run_id, skill_name),
+            intervention_bus=ChatInterventionBus(
+                self, run_id, skill_name,
+                channel_id=DEFAULT_CHAT_CHANNEL_ID,
+            ),
             mcp_servers=self._mcp_servers,
             subscribers=subscribers,
         )
@@ -2033,6 +2103,13 @@ class ChatSession:
         ChatInterventionBus, _handle_chat_limit_checkpoint, and
         _ask_budget_extension all call this method directly; keeping it
         as a session-level entry keeps those call sites stable.
+
+        issue #268 Phase 2 continuation: the origin-pin check (= stall
+        when iv.origin_channel_id is set but the listener has gone)
+        lives here so it fires for ALL iv flows, not just the
+        handle_intervention path. The check sits AFTER the chain-override
+        check so A2A-spawned ivs go to the A2A peer even if the local
+        TUI listener is absent.
         """
         # FP-0001: chain_id-scoped override path (A2A async tasks).
         if iv.run_id is not None and self._intervention_overrides:
@@ -2041,6 +2118,30 @@ class ChatSession:
                 override = self._intervention_overrides.get(chain_id)
                 if override is not None:
                     return await override.request(iv)
+        # issue #268 Phase 2 continuation: origin-pin stall check.
+        # When the iv carries an explicit ``origin_channel_id`` whose
+        # listener is no longer present (= the origin channel closed
+        # mid-call), park the iv in the stalled queue instead of
+        # delivering to a fall-through listener. Other channels
+        # observe / claim / discard via the cross-channel API. ivs
+        # without ``origin_channel_id`` (= legacy default or
+        # override-active spawn) skip this check.
+        if (
+            iv.origin_channel_id is not None
+            and iv.origin_channel_id not in self._interventions._listeners
+        ):
+            self._chat_events.emit(
+                "intervention_routed",
+                route="user_channel_stalled",
+                iv_kind=iv.kind,
+                iv_id=iv.id,
+                origin_channel_id=iv.origin_channel_id,
+            )
+            self._interventions._stalled[iv.id] = iv
+            try:
+                return await iv.future
+            except asyncio.CancelledError:
+                return InterventionAnswer(text="")
         # Default: route through the regular InterventionHandler.
         return await self._intervention_handler.dispatch(iv)
 
@@ -2119,46 +2220,14 @@ class ChatSession:
             finally:
                 source_agent_var.reset(token)
 
-        # Branch 3: user_channel — origin-pin check + dispatch or stall.
-        # issue #268 Phase 1: when the iv carries an explicit
-        # ``origin_channel_id`` that no longer maps to a registered
-        # listener (= the origin channel closed since the iv was
-        # created), park the iv in the stalled queue instead of
-        # delivering it to a different channel. Other channels
-        # observe / discard / claim via the cross-channel API
-        # (``list_stalled_interventions`` / ``discard_pending_intervention``
-        # / ``claim_pending_intervention``).
-        #
-        # Backwards-compat: iv with ``origin_channel_id=None`` (= legacy
-        # default) skips the stall check entirely and goes through the
-        # existing dispatch path unchanged.
-        if (
-            iv.origin_channel_id is not None
-            and iv.origin_channel_id not in self._interventions._listeners
-        ):
-            self._chat_events.emit(
-                "intervention_routed",
-                route="user_channel_stalled",
-                iv_kind=iv.kind,
-                iv_id=iv.id,
-                origin_channel_id=iv.origin_channel_id,
-            )
-            # Park in stalled queue. The iv has to be in _active first
-            # so mark_stalled can move it; if it's not, add it via the
-            # registry's _stalled directly (= bypass _active path
-            # because no listener is going to drain it).
-            self._interventions._stalled[iv.id] = iv
-            # Block on the iv's future — claim_pending_intervention /
-            # discard_pending_intervention will resolve / cancel it
-            # eventually. If neither happens, the awaiter (= safety
-            # limit handler with ask_timeout=0) waits indefinitely,
-            # which is the intended behaviour for "stall pending
-            # user action across channels".
-            try:
-                return await iv.future
-            except asyncio.CancelledError:
-                return InterventionAnswer(text="")
-
+        # Branch 3: user_channel — emit route decision + delegate to
+        # ``_dispatch_intervention``. issue #268 Phase 2 continuation
+        # moved the origin-pin stall check INTO ``_dispatch_intervention``
+        # so it fires uniformly for the bus-emit path too (= skill
+        # ask_user via ChatInterventionBus.deliver bypasses
+        # ``handle_intervention``); when the check fires, it emits its
+        # own ``user_channel_stalled`` event so the audit trail remains
+        # decisive (= one event per actual outcome).
         self._chat_events.emit(
             "intervention_routed",
             route="user_channel",
@@ -3152,7 +3221,10 @@ class ChatSession:
         op = MCPIROp(kind="mcp", server=server, tool=tool, args=args)
         ctx = self._make_router_op_context()
         # MCP handler requires intervention_bus; wire the session's bus
-        ctx.intervention_bus = ChatInterventionBus(self, run_id=None, skill_name="chat_router")
+        ctx.intervention_bus = ChatInterventionBus(
+            self, run_id=None, skill_name="chat_router",
+            channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
         # Narrow mcp scope to just this server while preserving file perms from the
         # populated decl. PermissionDecl.mcp must include the server for require_mcp to pass.
         ctx.permission_decl = PermissionDecl(

--- a/tests/test_chat_bus_stamping_268_continued.py
+++ b/tests/test_chat_bus_stamping_268_continued.py
@@ -1,0 +1,434 @@
+"""Tier 2: ChatInterventionBus stamping (issue #268 Phase 2 continuation).
+
+PR #281 wired A2AInterventionBus to stamp ``iv.origin_channel_id``
+during ``deliver`` + register its channel_id as a listener through
+``send_to_agent_impl``. This PR ships the TUI-side parity:
+ChatInterventionBus also stamps when constructed with an explicit
+``channel_id``.
+
+Design choice (= why optional rather than always-on):
+
+Test fixtures construct ``ChatInterventionBus(session, run_id,
+skill_name)`` directly across ~6 files. Always-on stamping would
+require every fixture to ALSO register the matching channel_id as a
+listener — otherwise the new origin-pin check stalls. Optional
+``channel_id`` parameter keeps existing fixtures unchanged (= no
+stamping → no behaviour change) and lets production sites
+explicitly opt in via the new module-level
+``DEFAULT_CHAT_CHANNEL_ID`` constant.
+
+Pins:
+
+  1. ChatInterventionBus default constructor signature (= without
+     ``channel_id``) preserves pre-#268 behaviour: no stamping.
+  2. With ``channel_id="<id>"``, ``deliver`` stamps
+     ``iv.origin_channel_id`` if it's None.
+  3. Pre-set ``iv.origin_channel_id`` is preserved (= upstream
+     multi-hop delegation provenance wins).
+  4. ``channel_id`` property returns the configured value (or None).
+  5. ``DEFAULT_CHAT_CHANNEL_ID`` is "tui" (= matches what
+     ``ChatTUIApp.on_mount`` registers as listener_id).
+  6. All 3 production ChatInterventionBus construction sites pass
+     ``DEFAULT_CHAT_CHANNEL_ID``.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+from reyn.chat.session import (
+    DEFAULT_CHAT_CHANNEL_ID,
+    ChatInterventionBus,
+    ChatSession,
+)
+from reyn.user_intervention import (
+    InterventionAnswer,
+    UserIntervention,
+)
+
+# ── 1. Default constructor: no stamping (backwards-compat) ────────────
+
+
+def test_chat_bus_without_channel_id_does_not_stamp(tmp_path: Path) -> None:
+    """Tier 2: ``ChatInterventionBus(session, run_id, skill_name)`` —
+    without ``channel_id`` arg — does NOT stamp ``iv.origin_channel_id``.
+
+    Preserves existing test fixture compatibility (= ~6 fixtures
+    construct without channel_id; they need iv to dispatch normally
+    against their "test" listener registration).
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener("test")
+    bus = ChatInterventionBus(session, run_id="r1", skill_name="demo")
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # Resolve so deliver returns.
+        await session._deliver_answer_to(iv, "ok")
+        await task
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped is None, (
+        "ChatInterventionBus without channel_id arg must NOT stamp"
+    )
+
+
+# ── 2. With channel_id: stamps when unset ─────────────────────────────
+
+
+def test_chat_bus_with_channel_id_stamps_when_iv_origin_is_none(tmp_path: Path) -> None:
+    """Tier 2: production-shape construction (= ``channel_id="tui"``)
+    stamps ``iv.origin_channel_id`` to the configured value when the
+    iv came in without one (= the common case for skill-emitted ivs).
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener("tui")
+    bus = ChatInterventionBus(
+        session, run_id="r1", skill_name="demo", channel_id="tui",
+    )
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await session._deliver_answer_to(iv, "ok")
+        await task
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped == "tui"
+
+
+def test_chat_bus_with_channel_id_respects_preexisting_origin(tmp_path: Path) -> None:
+    """Tier 2: when an iv arrives with ``origin_channel_id`` already
+    set (= e.g. upstream delegation), the bus does NOT overwrite.
+    Symmetric with the A2AInterventionBus rule (PR #281).
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener("upstream:hop")
+    bus = ChatInterventionBus(
+        session, run_id="r1", skill_name="demo", channel_id="tui",
+    )
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="?",
+            origin_channel_id="upstream:hop",
+        )
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await session._deliver_answer_to(iv, "ok")
+        await task
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped == "upstream:hop"
+
+
+# ── 3. channel_id property ───────────────────────────────────────────
+
+
+def test_chat_bus_channel_id_property_returns_configured_value() -> None:
+    """Tier 2: ``ChatInterventionBus.channel_id`` returns the value
+    passed at construction, or None when unset.
+    """
+    session = ChatSession(agent_name="t")
+    bus_with = ChatInterventionBus(
+        session, run_id=None, skill_name=None, channel_id="tui",
+    )
+    assert bus_with.channel_id == "tui"
+
+    bus_without = ChatInterventionBus(
+        session, run_id=None, skill_name=None,
+    )
+    assert bus_without.channel_id is None
+
+
+# ── 4. DEFAULT_CHAT_CHANNEL_ID is "tui" ──────────────────────────────
+
+
+def test_default_chat_channel_id_constant_is_tui() -> None:
+    """Tier 2: the module-level constant matches what
+    ``src/reyn/chat/tui/app.py:on_mount`` registers as the listener_id.
+
+    If either side drifts, this test catches the mismatch immediately.
+    """
+    assert DEFAULT_CHAT_CHANNEL_ID == "tui"
+
+
+def test_tui_on_mount_registers_default_chat_channel_id_listener() -> None:
+    """Tier 2: ChatTUIApp.on_mount source carries the literal "tui"
+    string for ``register_intervention_listener``, matching
+    ``DEFAULT_CHAT_CHANNEL_ID``.
+
+    AST grep keeps this aligned without booting a real TUI.
+    """
+    from reyn.chat.tui import app as tui_app
+
+    src = inspect.getsource(tui_app)
+    # ChatTUIApp.on_mount calls
+    # session.register_intervention_listener("tui").
+    assert 'register_intervention_listener("tui")' in src, (
+        "ChatTUIApp.on_mount must register listener_id == "
+        "DEFAULT_CHAT_CHANNEL_ID. If you renamed one, rename both."
+    )
+
+
+# ── 5. Production construction sites pass channel_id ─────────────────
+
+
+def test_all_production_chat_bus_constructions_pass_channel_id() -> None:
+    """Tier 2: every in-tree ``ChatInterventionBus(...)`` construction
+    in ``src/reyn/chat/session.py`` passes ``channel_id`` so the
+    stamping is engaged uniformly across:
+
+      - chat router op bus factory
+      - skill-spawn bus
+      - MCP-call-from-chat ad-hoc bus
+
+    The AST-walk grep makes the contract enforceable so a future
+    refactor that adds a new construction site without ``channel_id``
+    fails this test before merging.
+    """
+    import ast
+
+    src_path = Path(__file__).parent.parent / "src" / "reyn" / "chat" / "session.py"
+    tree = ast.parse(src_path.read_text(encoding="utf-8"))
+
+    chat_bus_calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match ChatInterventionBus(...) — either bare name or
+        # attribute access.
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "ChatInterventionBus":
+            chat_bus_calls.append(node)
+        elif isinstance(func, ast.Attribute) and func.attr == "ChatInterventionBus":
+            chat_bus_calls.append(node)
+
+    assert chat_bus_calls, (
+        "Test bug — expected at least one ChatInterventionBus call site "
+        "in session.py"
+    )
+
+    missing_channel_id = []
+    for call in chat_bus_calls:
+        kw_names = {kw.arg for kw in call.keywords if kw.arg}
+        if "channel_id" not in kw_names:
+            missing_channel_id.append(call.lineno)
+
+    assert not missing_channel_id, (
+        f"ChatInterventionBus construction sites at lines "
+        f"{missing_channel_id} are missing the ``channel_id`` kwarg. "
+        f"Production sites must pass DEFAULT_CHAT_CHANNEL_ID for "
+        f"#268 Phase 2 stamping to engage."
+    )
+
+
+# ── 6. End-to-end: stamped iv routes through dispatch when listener present ──
+
+
+def test_end_to_end_stamped_iv_with_matching_listener_dispatches(tmp_path: Path) -> None:
+    """Tier 2: when a production-shape bus stamps "tui" + the TUI
+    listener is registered, handle_intervention's origin-pin check
+    passes + the iv dispatches normally.
+
+    Verifies the production wiring is internally consistent (=
+    DEFAULT_CHAT_CHANNEL_ID + ChatTUIApp.on_mount + handle_intervention
+    Branch 3 all agree).
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    bus = ChatInterventionBus(
+        session, run_id="r1", skill_name="demo",
+        channel_id=DEFAULT_CHAT_CHANNEL_ID,
+    )
+
+    async def _drive() -> InterventionAnswer:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # iv must NOT be stalled (= origin in listeners → dispatch path)
+        assert iv.id not in session._interventions._stalled
+        await session._deliver_answer_to(iv, "ok")
+        return await task
+
+    answer = asyncio.run(_drive())
+    assert answer.text == "ok"
+
+
+def test_end_to_end_stamped_iv_without_listener_stalls(tmp_path: Path) -> None:
+    """Tier 2: when a production-shape bus stamps "tui" + the "tui"
+    listener is NOT registered, the iv stalls.
+
+    This is the new behaviour the stamping enables: a stamped iv in
+    a session without the matching listener becomes observable in
+    ``list_stalled_interventions`` instead of hanging forever in the
+    handler.
+
+    The test only registers a different listener (= simulating "no
+    real TUI but some other listener active for unrelated reasons")
+    so the Phase 1 subscriber-presence guard doesn't kick in for the
+    short-circuit path.
+
+    The actual stall check fires in ``_dispatch_intervention`` (=
+    moved there from handle_intervention so bus.deliver also benefits
+    — issue #268 Phase 2 continuation).
+    """
+    session = ChatSession(agent_name="t")
+    # Register a NON-tui listener — passes Phase 1 guard but doesn't
+    # match the bus's channel_id stamp.
+    session.register_intervention_listener("other")
+    bus = ChatInterventionBus(
+        session, run_id="r1", skill_name="demo",
+        channel_id=DEFAULT_CHAT_CHANNEL_ID,
+    )
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        task = asyncio.ensure_future(bus.deliver(iv))
+        # Let deliver progress to the await point.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # iv must be in stalled queue.
+        assert iv.id in session._interventions._stalled
+        # Clean up.
+        await session.discard_pending_intervention(iv.id)
+        await task
+
+    asyncio.run(_drive())
+
+
+# ── 7. Override-aware stamping skip (A2A-spawned skill case) ───────
+
+
+def test_chat_bus_skips_stamping_when_chain_override_active(tmp_path: Path) -> None:
+    """Tier 2: when a chain override is registered for the iv's run_id
+    chain (= A2A async task path), ChatInterventionBus does NOT stamp.
+    The downstream override bus (A2AInterventionBus) gets a clean
+    ``origin_channel_id=None`` slot to stamp ``a2a:<run_id>`` instead.
+
+    Critical correctness contract: WITHOUT this skip, A2A-spawned skill
+    ivs would carry ``origin_channel_id="tui"`` (= bus default), then
+    in _dispatch_intervention the override path runs FIRST (= delivers
+    to A2A peer correctly), but the iv body that the peer sees has
+    "tui" as the origin — a wrong provenance claim. The peer's ack /
+    observe / claim machinery (= future Phase) would route based on
+    that wrong origin.
+    """
+    session = ChatSession(agent_name="t")
+
+    # Simulate A2A-style override registration for chain "chain-A2A".
+    class _CapturingOverride:
+        def __init__(self) -> None:
+            self.received: list[UserIntervention] = []
+
+        async def request(self, iv: UserIntervention) -> InterventionAnswer:
+            self.received.append(iv)
+            return InterventionAnswer(text="from-override")
+
+    override = _CapturingOverride()
+    session.register_intervention_override("chain-A2A", override)
+    # Wire run_id → chain mapping so _dispatch_intervention can resolve.
+    session.running_skills_chain["run-A2A"] = "chain-A2A"
+
+    bus = ChatInterventionBus(
+        session, run_id="run-A2A", skill_name="demo",
+        channel_id=DEFAULT_CHAT_CHANNEL_ID,
+    )
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        answer = await bus.deliver(iv)
+        assert answer.text == "from-override"
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped is None, (
+        f"ChatInterventionBus must NOT stamp origin_channel_id when "
+        f"chain override is active (got {stamped!r}); leave the slot "
+        f"clean so A2AInterventionBus.deliver downstream can stamp "
+        f"the correct a2a:<run_id> value."
+    )
+    # And the override actually saw the iv.
+    assert len(override.received) == 1
+
+
+def test_chat_bus_stamps_when_no_chain_override_active(tmp_path: Path) -> None:
+    """Tier 2: when no chain override exists for the iv's run_id (=
+    TUI-only path), stamping engages normally. Differentiates against
+    the override-active branch.
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener("tui")
+    bus = ChatInterventionBus(
+        session, run_id="run-TUI", skill_name="demo",
+        channel_id=DEFAULT_CHAT_CHANNEL_ID,
+    )
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await session._deliver_answer_to(iv, "ok")
+        await task
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped == "tui"
+
+
+# ── 8. Phase 1 mechanism now fires for bus path too ──────────────────
+
+
+def test_dispatch_intervention_stall_check_fires_from_bus_path(tmp_path: Path) -> None:
+    """Tier 2: the origin-pin stall check moved from
+    ``handle_intervention`` Branch 3 into ``_dispatch_intervention`` so
+    bus.deliver path benefits too.
+
+    Verifies the move directly: invoking ``_dispatch_intervention``
+    with a stamped iv whose listener is absent puts the iv in the
+    stalled queue + emits a ``user_channel_stalled`` route event.
+    """
+    session = ChatSession(agent_name="t")
+    session.register_intervention_listener("other")
+
+    routed_events: list[dict] = []
+
+    def _capture(ev) -> None:
+        if ev.type == "intervention_routed":
+            routed_events.append(dict(ev.data))
+
+    session._chat_events.add_subscriber(_capture)
+
+    async def _drive() -> None:
+        iv = UserIntervention(
+            kind="ask_user", prompt="?",
+            origin_channel_id="tui",  # stamped origin not in listeners
+        )
+        task = asyncio.ensure_future(session._dispatch_intervention(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert iv.id in session._interventions._stalled
+        await session.discard_pending_intervention(iv.id)
+        await task
+
+    asyncio.run(_drive())
+
+    stalled = [
+        e for e in routed_events
+        if e.get("route") == "user_channel_stalled"
+    ]
+    assert len(stalled) == 1
+    assert stalled[0]["origin_channel_id"] == "tui"


### PR DESCRIPTION
**[e2e-coder]** — Phase 2 continuation of #268. PR #281 wired A2AInterventionBus to stamp + register; this PR ships the TUI-side parity AND moves the stall check into `_dispatch_intervention` so the mechanism fires for the bus-emit path too (= the skill `ask_user` flow that bypasses `handle_intervention`).

## Summary

- **Stamping wired on TUI side**: `ChatInterventionBus` gains optional `channel_id` constructor param + property. Stamping engages when configured; pre-existing fixture constructors (= ~6 test files calling `ChatInterventionBus` directly without listener wiring) remain unchanged.
- **`DEFAULT_CHAT_CHANNEL_ID = "tui"`** module constant aligns the production wiring with `ChatTUIApp.on_mount`'s listener_id registration.
- **Production sites pass `channel_id`**: all 3 in-tree `ChatInterventionBus(...)` construction sites in `session.py` (chat router op bus factory, skill-spawn bus, MCP-call-from-chat ad-hoc bus) thread the constant. AST-walk grep test enforces this contract.
- **Override-aware skip**: `ChatInterventionBus.deliver` checks for a chain override on the iv's run_id before stamping. When an A2A async-task override is active, stamping is SKIPPED — `A2AInterventionBus.deliver` downstream stamps the correct `a2a:<run_id>` value into a clean slot.
- **Stall check moved to `_dispatch_intervention`**: the origin-pin check used to live in `handle_intervention` Branch 3, but the skill bus-emit path goes `bus.deliver → _dispatch_intervention` without passing through `handle_intervention`. Moving the check (= after chain-override resolution, before `InterventionHandler.dispatch`) makes the Phase 1 machinery actually fire for the production user case.

## Why bundled with the architectural correction

The stamping field alone is dormant without the dispatch-level check; landing stamping without moving the check would mean the field gets attached but never observed for the user-visible scenario (= TUI closes mid-call → next iv would hang instead of stalling). Reviewers would rightly ask why bother. Both belong in one PR to deliver an actually-firing mechanism end-to-end.

## Test plan

- [x] Tier 2 contract test (12 cases): default-no-stamp / configured-stamping / preexisting-origin-preserved / `channel_id` property / `DEFAULT_CHAT_CHANNEL_ID == "tui"` / TUI on_mount listener AST grep / production construction sites AST pin / end-to-end dispatch when matching listener / end-to-end stall when listener absent / override-aware skip (A2A case) / no-override-stamping differentiation / `_dispatch_intervention` stall check fires from bus path
- [x] Adjacent intervention test suites (`test_pending_intervention_268.py`, `test_a2a_bus_stamping_268_phase2.py`, `test_intervention_subscriber_guard.py`, `test_intervention_agent_routing.py`, `test_intervention_bus_protocols.py`, `test_intervention_agent_subscriber.py`, `test_intervention_legacy_alias_deprecated.py`): 78 passed, no regression
- [x] Full suite: **4199 passed, 5 skipped, 3 xfailed** in 158s
- [x] `ruff check` clean on changed files
- [x] No fixture changes needed — optional `channel_id` keeps test construction sites on the no-stamp path

## Architectural context

Together with PR #275 (Phase 1 = field + queue + cross-channel API), PR #281 (Phase 2 A2A bus stamping + listener lifecycle), and PR #280 (TUI pending tab + slash + badge), this PR completes the bus-side wiring so the Phase 1 stall machinery now actually fires for the user-visible TUI-close-mid-call scenario. Remaining #268 follow-ups (= MCP bus equivalent under #270 umbrella) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)