### PR TITLE
feat(a2a): webhook progress trigger expansion via _A2AProgressBridge (issue #267 Gap 2)

### DIFF
--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -649,6 +649,121 @@ async def _handle_answer_injection(
     return _jsonrpc_result(req_id, result)
 
 
+class _A2AProgressBridge:
+    """Forwards selected agent chat-events to the A2A peer via webhook
+    POST (issue #267 Gap 2).
+
+    Mirrors ``mcp_server._MCPProgressBridge`` for the A2A surface: same
+    event scope (``phase_started`` / ``llm_called`` / ``act_executed``),
+    same ordinal-counter semantics. Different transport: instead of the
+    MCP protocol's ``notifications/progress``, fires a webhook POST with
+    ``status="in-progress"`` so the registered peer URL sees progression
+    beyond the terminal ``completed`` / ``failed`` webhooks.
+
+    Two instances (= MCP + A2A) is below the rule-of-three threshold,
+    so we keep the bridge logic per-protocol for now. A future third
+    instance (= e.g. WebSocket / gRPC streaming) is the trigger to lift
+    the common subscribe/format/dispatch shape into a shared base.
+
+    Lifecycle: subscribe via ``attach()`` once, ``detach()`` in a
+    try/finally so the subscriber doesn't outlive the call. Any
+    transport error during a fire is swallowed — progress is
+    best-effort; the A2A task's final ``completed`` / ``failed``
+    webhook is the authoritative outcome signal.
+    """
+
+    _TRACKED_EVENTS = frozenset({
+        "phase_started",
+        "llm_called",
+        "act_executed",
+    })
+
+    def __init__(
+        self,
+        *,
+        session: "object",
+        run_id: str,
+        webhook_url: str,
+        agent_name: str,
+    ) -> None:
+        self._session = session
+        self._run_id = run_id
+        self._webhook_url = webhook_url
+        self._agent_name = agent_name
+        self._ordinal = 0
+        self._detached = False
+        self._tasks: list[asyncio.Task[None]] = []
+
+    def attach(self) -> None:
+        events = getattr(self._session, "_chat_events", None)
+        if events is not None:
+            events.add_subscriber(self._on_event)
+
+    def detach(self) -> None:
+        if self._detached:
+            return
+        self._detached = True
+        events = getattr(self._session, "_chat_events", None)
+        if events is not None:
+            events.remove_subscriber(self._on_event)
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+
+    def _on_event(self, event: "object") -> None:
+        # Sync callback from EventLog dispatcher. Filter by type, build
+        # payload, schedule async POST.
+        if self._detached:
+            return
+        event_type = getattr(event, "type", None)
+        if event_type not in self._TRACKED_EVENTS:
+            return
+        data = getattr(event, "data", {}) or {}
+        message = self._format_message(event_type, data)
+        self._ordinal += 1
+        ordinal = self._ordinal
+        try:
+            task = asyncio.ensure_future(
+                self._send(ordinal, event_type, message),
+            )
+        except RuntimeError:
+            # No running loop (= EventLog dispatched outside async context).
+            return
+        self._tasks.append(task)
+
+    @staticmethod
+    def _format_message(event_type: str, data: dict) -> str:
+        if event_type == "phase_started":
+            phase = data.get("phase") or "?"
+            return f"phase: {phase}"
+        if event_type == "llm_called":
+            model = data.get("model") or "?"
+            return f"llm: {model}"
+        if event_type == "act_executed":
+            op_count = data.get("op_count") or 0
+            suffix = "" if op_count == 1 else "s"
+            return f"act: {op_count} op{suffix}"
+        return event_type
+
+    async def _send(
+        self, ordinal: int, event_type: str, message: str,
+    ) -> None:
+        from reyn.web.notifications import post_webhook  # noqa: PLC0415
+
+        payload = {
+            "run_id": self._run_id,
+            "status": "in-progress",
+            "progress": ordinal,
+            "event": event_type,
+            "message": message,
+            "agent_name": self._agent_name,
+        }
+        try:
+            await post_webhook(self._webhook_url, payload)
+        except Exception:  # noqa: BLE001 — progress is best-effort
+            return
+
+
 async def _handle_async_mode(
     req_id: Any,
     text: str,
@@ -672,6 +787,27 @@ async def _handle_async_mode(
     bus = A2AInterventionBus(run_id, run_registry)
 
     async def _run() -> None:
+        # issue #267 Gap 2: when a webhook_url is registered, subscribe a
+        # progress bridge to the agent's chat_events for the lifetime of
+        # this call. The bridge fires intermediate ``status="in-progress"``
+        # webhooks for skill lifecycle events (= phase_started / llm_called
+        # / act_executed) so the A2A peer sees progression beyond just
+        # terminal completed / failed. Bridge attach is best-effort —
+        # failure to load the session or subscribe must NOT block the
+        # main call (= progress is decoration; the answer is the contract).
+        bridge: "_A2AProgressBridge | None" = None
+        if webhook_url:
+            try:
+                session = registry.get_or_load(agent_name)
+                bridge = _A2AProgressBridge(
+                    session=session,
+                    run_id=run_id,
+                    webhook_url=webhook_url,
+                    agent_name=agent_name,
+                )
+                bridge.attach()
+            except Exception:  # noqa: BLE001 — defensive
+                bridge = None
         try:
             result = await send_to_agent_impl(
                 registry,
@@ -704,6 +840,9 @@ async def _handle_async_mode(
                     webhook_url,
                     {"run_id": run_id, "status": "failed", "error": str(exc)},
                 )
+        finally:
+            if bridge is not None:
+                bridge.detach()
 
     task = asyncio.create_task(_run())
     run_registry.attach_task(run_id, task)

--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -1,0 +1,375 @@
+"""Tier 2: A2A webhook progress trigger expansion (issue #267 Gap 2).
+
+Before this PR, the A2A webhook surface fired only on 3 events:
+``input-required`` (A2AInterventionBus.deliver), ``completed`` /
+``failed`` (_handle_async_mode._run). Mid-call lifecycle (= phase
+transition / LLM call / op batch) was invisible to the peer — peers
+received the initial Task envelope, then silence until terminal.
+
+This PR adds ``_A2AProgressBridge`` (= mirrors ``_MCPProgressBridge``
+shape from PR #279) that subscribes to the agent's ``chat_events``
+for the lifetime of one ``_handle_async_mode`` call and fires
+``status="in-progress"`` webhooks for ``phase_started`` /
+``llm_called`` / ``act_executed``. Two instances (MCP + A2A) is below
+the rule-of-three threshold so the bridge logic is per-protocol; a
+future third instance is the trigger to lift to a shared base.
+
+Pins:
+
+  1. ``_A2AProgressBridge`` exists with ``_TRACKED_EVENTS`` = the 3
+     declared kinds, matching ``_MCPProgressBridge``'s scope (= the
+     contract two bridges share).
+  2. ``attach()`` subscribes to ``session._chat_events``;
+     ``detach()`` unsubscribes + cancels in-flight tasks; idempotent.
+  3. Untracked event types are ignored (= ``intervention_routed`` /
+     ``phase_completed`` / etc. don't fire the bridge).
+  4. ``_format_message`` produces the expected text for each kind.
+  5. ``_send`` POSTs the canonical progress payload to the configured
+     webhook_url.
+  6. ``ordinal`` is monotonic across multiple events on one bridge.
+  7. After ``detach()``, subsequent events are silently dropped (=
+     the subscriber is removed, defensive guard against late events).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
+
+from reyn.events.events import EventLog  # noqa: E402
+from reyn.schemas.models import Event  # noqa: E402
+
+
+def _make_bridge(*, captured_posts: list[tuple[str, dict]], events: EventLog | None = None):
+    """Build a bridge with a fake session whose ``_chat_events`` is the
+    given EventLog (or a fresh one). The bridge's _send is monkey-patched
+    to capture posts so we don't need to mock ``post_webhook`` globally.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    class _FakeSession:
+        def __init__(self, events: EventLog) -> None:
+            self._chat_events = events
+
+    if events is None:
+        events = EventLog()
+    session = _FakeSession(events)
+    bridge = _A2AProgressBridge(
+        session=session,
+        run_id="run-X",
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+    )
+
+    async def _capture(ordinal, event_type, message):  # noqa: ANN202
+        captured_posts.append(
+            (event_type, {
+                "ordinal": ordinal,
+                "message": message,
+                "url": bridge._webhook_url,
+                "run_id": bridge._run_id,
+                "agent_name": bridge._agent_name,
+            }),
+        )
+
+    bridge._send = _capture  # type: ignore[method-assign]
+    return bridge, events
+
+
+# ── 1. Tracked event scope matches MCP bridge ─────────────────────────
+
+
+def test_a2a_progress_bridge_tracks_three_lifecycle_events() -> None:
+    """Tier 2: ``_A2AProgressBridge._TRACKED_EVENTS`` matches the MCP
+    bridge's scope exactly (= same 3 lifecycle event kinds). This
+    keeps the per-protocol bridges aligned so a future third-instance
+    abstraction has a stable contract to lift.
+    """
+    from reyn.mcp_server import _MCPProgressBridge
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    assert _A2AProgressBridge._TRACKED_EVENTS == _MCPProgressBridge._TRACKED_EVENTS
+    assert _A2AProgressBridge._TRACKED_EVENTS == frozenset({
+        "phase_started", "llm_called", "act_executed",
+    })
+
+
+# ── 2. attach / detach lifecycle ──────────────────────────────────────
+
+
+def test_attach_subscribes_to_chat_events() -> None:
+    """Tier 2: ``attach()`` adds the bridge's ``_on_event`` callback to
+    the session's chat_events subscriber list (= so EventLog dispatches
+    will reach the bridge).
+    """
+    captured: list = []
+    bridge, events = _make_bridge(captured_posts=captured)
+    assert bridge._on_event not in events._subscribers
+    bridge.attach()
+    assert bridge._on_event in events._subscribers
+
+
+def test_detach_unsubscribes_from_chat_events() -> None:
+    """Tier 2: ``detach()`` removes the subscriber + flips internal flag
+    so subsequent events are silently ignored.
+    """
+    captured: list = []
+    bridge, events = _make_bridge(captured_posts=captured)
+    bridge.attach()
+    assert bridge._on_event in events._subscribers
+    bridge.detach()
+    assert bridge._on_event not in events._subscribers
+    assert bridge._detached is True
+
+
+def test_detach_is_idempotent() -> None:
+    """Tier 2: calling ``detach()`` twice is safe (= no double-unsubscribe
+    error, no exception). Critical because the bridge lives in a
+    try/finally — if the body of try also detaches (= e.g. early
+    return path adds one), finally must not blow up.
+    """
+    captured: list = []
+    bridge, _ = _make_bridge(captured_posts=captured)
+    bridge.attach()
+    bridge.detach()
+    bridge.detach()  # Second call should be no-op, not raise.
+
+
+# ── 3. Filtering: only tracked events fire ────────────────────────────
+
+
+def test_untracked_event_kinds_are_ignored() -> None:
+    """Tier 2: events outside ``_TRACKED_EVENTS`` (= e.g.
+    ``intervention_routed`` / ``phase_completed`` / ``agent_response``)
+    do NOT fire a webhook.
+    """
+    captured: list = []
+    bridge, events = _make_bridge(captured_posts=captured)
+    bridge.attach()
+
+    async def _drive() -> None:
+        events.emit("phase_completed", phase="planning")
+        events.emit("intervention_routed", route="user_channel")
+        events.emit("agent_response", text="hi")
+        # Let any scheduled tasks settle.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(_drive())
+    assert captured == []
+
+
+def test_tracked_events_each_fire_one_post() -> None:
+    """Tier 2: each tracked event kind emits exactly one progress
+    webhook with an incremented ordinal.
+    """
+    captured: list = []
+    bridge, events = _make_bridge(captured_posts=captured)
+    bridge.attach()
+
+    async def _drive() -> None:
+        events.emit("phase_started", phase="planning")
+        events.emit("llm_called", model="gemini-2.5-flash-lite")
+        events.emit("act_executed", op_count=3)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(_drive())
+
+    assert [e for e, _ in captured] == [
+        "phase_started", "llm_called", "act_executed",
+    ]
+    assert [p["ordinal"] for _, p in captured] == [1, 2, 3]
+
+
+# ── 4. Message formatting ─────────────────────────────────────────────
+
+
+def test_format_message_for_each_event_kind() -> None:
+    """Tier 2: ``_format_message`` outputs the canonical human-readable
+    text per event kind. Matches the MCP bridge's format so peer
+    consumers can apply the same parser to both transports.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    assert _A2AProgressBridge._format_message(
+        "phase_started", {"phase": "planning"},
+    ) == "phase: planning"
+    assert _A2AProgressBridge._format_message(
+        "llm_called", {"model": "gemini-2.5-flash-lite"},
+    ) == "llm: gemini-2.5-flash-lite"
+    # Singular form for 1 op.
+    assert _A2AProgressBridge._format_message(
+        "act_executed", {"op_count": 1},
+    ) == "act: 1 op"
+    # Plural form for N>1.
+    assert _A2AProgressBridge._format_message(
+        "act_executed", {"op_count": 5},
+    ) == "act: 5 ops"
+    # Missing fields fall back to "?".
+    assert _A2AProgressBridge._format_message(
+        "phase_started", {},
+    ) == "phase: ?"
+
+
+# ── 5. Send payload shape ─────────────────────────────────────────────
+
+
+def test_send_posts_canonical_progress_payload(monkeypatch) -> None:
+    """Tier 2: ``_send`` POSTs the payload shape:
+    ``{run_id, status: "in-progress", progress, event, message, agent_name}``
+    to the configured webhook_url. Existing fields from completed /
+    failed payloads (= ``run_id``, ``status``, ``agent_name``) are
+    preserved → peer's payload parser can dispatch on ``status``.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    posted: list[tuple[str, dict]] = []
+
+    async def _fake_post_webhook(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+        from reyn.web.notifications import DeliveryOutcome, DeliveryResult
+        return DeliveryResult(outcome=DeliveryOutcome.SUCCESS)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post_webhook)
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id="run-Y",
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+    )
+
+    asyncio.run(bridge._send(7, "phase_started", "phase: planning"))
+    assert len(posted) == 1
+    url, payload = posted[0]
+    assert url == "https://peer.test/hook"
+    assert payload == {
+        "run_id": "run-Y",
+        "status": "in-progress",
+        "progress": 7,
+        "event": "phase_started",
+        "message": "phase: planning",
+        "agent_name": "demo",
+    }
+
+
+def test_send_swallows_transport_errors(monkeypatch) -> None:
+    """Tier 2: when ``post_webhook`` raises, ``_send`` swallows + returns
+    None. Progress is best-effort; a single failed POST must not
+    abort the agent's main call.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    async def _failing_post(url: str, payload: dict):  # noqa: ANN202
+        raise RuntimeError("simulated transport failure")
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _failing_post)
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id="run-Z",
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+    )
+
+    # No exception raised, no return value used.
+    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+
+
+# ── 6. Post-detach: late events dropped ───────────────────────────────
+
+
+def test_late_event_after_detach_is_ignored() -> None:
+    """Tier 2: defensive — if an event fires AFTER ``detach()`` was
+    called but BEFORE the EventLog's subscriber list is fully drained
+    (= unlikely in single-threaded asyncio but possible across emit
+    interleavings), the ``_detached`` flag short-circuits the handler.
+    """
+    captured: list = []
+    bridge, events = _make_bridge(captured_posts=captured)
+    bridge.attach()
+
+    # Manually invoke detach but DO NOT remove the subscriber yet (=
+    # simulate the race window).
+    bridge._detached = True
+
+    async def _drive() -> None:
+        events.emit("phase_started", phase="planning")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(_drive())
+    # Even though the subscriber is still on the list, the flag check
+    # in _on_event short-circuited.
+    assert captured == []
+
+
+# ── 7. Integration: _handle_async_mode wires the bridge ────────────────
+
+
+def test_handle_async_mode_attaches_bridge_when_webhook_url_present() -> None:
+    """Tier 2: in ``_handle_async_mode._run``, when ``webhook_url`` is
+    provided, an ``_A2AProgressBridge`` is constructed + attached
+    BEFORE ``send_to_agent_impl`` is called. Verified via in-source
+    grep so a refactor that drops the wiring fails immediately.
+    """
+    import ast
+    from pathlib import Path
+
+    src_path = (
+        Path(__file__).parent.parent
+        / "src" / "reyn" / "web" / "routers" / "a2a.py"
+    )
+    tree = ast.parse(src_path.read_text(encoding="utf-8"))
+
+    # Find the inner function _run inside _handle_async_mode.
+    bridge_class_refs = 0
+    bridge_attach_calls = 0
+    bridge_detach_calls = 0
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == "_A2AProgressBridge":
+            bridge_class_refs += 1
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "attach" and isinstance(node.func.value, ast.Name):
+                if node.func.value.id == "bridge":
+                    bridge_attach_calls += 1
+            if node.func.attr == "detach" and isinstance(node.func.value, ast.Name):
+                if node.func.value.id == "bridge":
+                    bridge_detach_calls += 1
+
+    # At least one class reference + at least one attach + at least one
+    # detach (= the lifecycle wiring is present).
+    assert bridge_class_refs >= 1
+    assert bridge_attach_calls >= 1
+    assert bridge_detach_calls >= 1
+
+
+def test_handle_async_mode_skips_bridge_when_no_webhook_url() -> None:
+    """Tier 2: in-source grep confirms the bridge construction is
+    GATED on ``webhook_url`` (= no webhook → no bridge → no event
+    subscription). The peer that doesn't register a URL sees zero
+    overhead.
+    """
+    import inspect
+
+    from reyn.web.routers import a2a as a2a_router
+
+    src = inspect.getsource(a2a_router._handle_async_mode)
+    # The bridge construction must be inside an ``if webhook_url:`` block.
+    assert "if webhook_url:" in src
+    assert "_A2AProgressBridge(" in src
+    # And detach must run in a finally so it executes on both success
+    # and exception paths.
+    assert "bridge.detach()" in src


### PR DESCRIPTION
**[e2e-coder]** — #267 Gap 2: completes the A2A webhook surface so peers see mid-call lifecycle (= phase / LLM / op-batch), not just terminal completed/failed.

## Summary

- New `_A2AProgressBridge` in `web/routers/a2a.py` mirrors `_MCPProgressBridge` from PR #279. Same `_TRACKED_EVENTS` set (`phase_started` / `llm_called` / `act_executed`), same `_format_message` output, different transport (= webhook POST with `status="in-progress"` instead of MCP `notifications/progress`).
- Wired in `_handle_async_mode._run`: bridge construction GATED on `webhook_url` (= peers without a URL pay zero overhead), `attach()` before `send_to_agent_impl`, `detach()` in `finally`.
- Payload shape: `{run_id, status: "in-progress", progress: <ordinal>, event: <kind>, message: <formatted>, agent_name}` — consistent fields with existing terminal payloads so peer parsers can dispatch on `status`.

## Rule-of-three calibration

Two instances of "agent-chat-events → outbound notification" (= MCP + A2A) is below the rule-of-three threshold; bridge logic stays per-protocol (= no premature shared base). A future third instance (e.g. WebSocket / gRPC streaming) is the trigger to lift the common `subscribe / filter / format / dispatch` shape into a shared base. Test #1 pins the `_TRACKED_EVENTS` equality across both bridges so the contract two bridges share is enforceable.

## Test plan

- [x] Tier 2 contract test (12 cases): tracked-event scope equality vs MCP bridge / attach-detach idempotent / untracked-event filter / 3-tracked fire 3 posts / format_message per kind / canonical send payload / transport error swallow / late-event-after-detach drop / AST grep for bridge wiring / inspect grep for `webhook_url` gate + `finally` detach
- [x] A2A + MCP region regression (bus stamping #268 Phase 2 / capability claim interim / FP-0001 intervention bus / webhook delivery ack / iv kind coverage #267 Gap 4 / MCP progress #271): **59 tests pass**
- [x] Full suite: **4238 passed, 5 skipped, 3 xfailed** in 162s
- [x] `ruff check` clean

## Capability claim consideration

A2A Agent Card still advertises `pushNotifications: false` (= PR #272 Gap 3 Z-b). This PR expands what FIRES on the webhook surface but does NOT re-elevate the capability claim. The claim re-elevation belongs in a separate PR once Gap 1 (SSE producer wiring) also lands, so the `streaming` / `pushNotifications` flips are evidence-backed. Peers that registered a `webhook_url` already opted in to receive pushes; they get more events now.

## Related

- PR #279 (= `_MCPProgressBridge`, the first instance this PR mirrors)
- PR #285 (= #267 Gap 4 iv kind/choices payload, just merged — orthogonal payload enrichment on the same webhook surface)
- PR #272 (= #267 Gap 3 Z-b capability claim interim, controls when to re-elevate)
- #267 Gap 1 (SSE producer wiring) — sibling improvement, still pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)