### PR TITLE
feat(a2a): SSE producer wiring via _A2AProgressBridge fan-out + iv history (issue #267 Gap 1)

### DIFF
--- a/src/reyn/web/a2a_intervention.py
+++ b/src/reyn/web/a2a_intervention.py
@@ -91,29 +91,40 @@ class A2AInterventionBus:
             pending_intervention=iv,
         )
 
-        # Optional webhook notification (fire-and-forget; failures logged).
-        # issue #267 Gap 4: surface iv ``kind`` + ``choices`` in the payload
-        # so peer can render structured affordance (= permission yes/no/always
-        # hotkeys) instead of guessing from prompt text. Free-text ``ask_user``
-        # still works unchanged (= ``choices`` is an empty list). ``detail``
-        # is included when present so the peer has the same context the
-        # in-process TUI surfaces below the prompt.
+        # Build the canonical input-required payload once + fan out to
+        # both A2A peer surfaces (issue #267 Gap 1 + Gap 4):
+        #
+        #   - SSE buffer (always): append to RunEntry.history_events so
+        #     ``GET /a2a/tasks/{run_id}/events`` streams the prompt to a
+        #     peer that connected via SSE.
+        #   - Webhook POST (opt-in): same payload pushed to webhook_url
+        #     when registered. ``kind`` + ``choices`` (Gap 4) let the
+        #     peer render structured affordance (= permission yes/no/always
+        #     hotkeys) instead of guessing from prompt text. ``detail`` is
+        #     included when present so the peer has the same context the
+        #     in-process TUI surfaces below the prompt.
+        payload: dict = {
+            "run_id": self._run_id,
+            "status": "input-required",
+            "question": iv.prompt,
+            "agent_name": entry.agent_name,
+            "kind": iv.kind,
+            "choices": [
+                {"id": c.id, "label": c.label, "hotkey": c.hotkey}
+                for c in iv.choices
+            ],
+        }
+        if iv.detail:
+            payload["detail"] = iv.detail
+
+        try:
+            self._registry.append_event(self._run_id, payload)
+        except Exception:  # noqa: BLE001 — sse buffer is best-effort
+            pass
+
         if entry.webhook_url:
             from reyn.web.notifications import post_webhook
 
-            payload: dict = {
-                "run_id": self._run_id,
-                "status": "input-required",
-                "question": iv.prompt,
-                "agent_name": entry.agent_name,
-                "kind": iv.kind,
-                "choices": [
-                    {"id": c.id, "label": c.label, "hotkey": c.hotkey}
-                    for c in iv.choices
-                ],
-            }
-            if iv.detail:
-                payload["detail"] = iv.detail
             await post_webhook(entry.webhook_url, payload)
 
         # Block until the peer POSTs an answer (= registry.answer_intervention

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -650,26 +650,33 @@ async def _handle_answer_injection(
 
 
 class _A2AProgressBridge:
-    """Forwards selected agent chat-events to the A2A peer via webhook
-    POST (issue #267 Gap 2).
+    """Forwards selected agent chat-events to A2A peer surfaces.
 
-    Mirrors ``mcp_server._MCPProgressBridge`` for the A2A surface: same
-    event scope (``phase_started`` / ``llm_called`` / ``act_executed``),
-    same ordinal-counter semantics. Different transport: instead of the
-    MCP protocol's ``notifications/progress``, fires a webhook POST with
-    ``status="in-progress"`` so the registered peer URL sees progression
-    beyond the terminal ``completed`` / ``failed`` webhooks.
+    Two sinks, one subscriber:
 
-    Two instances (= MCP + A2A) is below the rule-of-three threshold,
-    so we keep the bridge logic per-protocol for now. A future third
-    instance (= e.g. WebSocket / gRPC streaming) is the trigger to lift
-    the common subscribe/format/dispatch shape into a shared base.
+      - **SSE buffer** (= ``run_registry.append_event``): events land
+        in ``RunEntry.history_events`` so ``GET /a2a/tasks/{run_id}/events``
+        replays them. Always wired (issue #267 Gap 1).
+      - **Webhook POST** (= ``post_webhook``): same payload pushed to
+        the registered peer URL. Opt-in — only fires when
+        ``webhook_url`` is non-None (issue #267 Gap 2, landed in PR
+        #286 with webhook-only bridge; this revision adds the SSE
+        sink alongside).
+
+    Mirrors ``mcp_server._MCPProgressBridge`` for the event-scope side:
+    same lifecycle kinds (``phase_started`` / ``llm_called`` /
+    ``act_executed``), same ordinal counter, same message formatting.
+    Different transports. Two instances (= MCP + A2A) is below the
+    rule-of-three threshold so the bridge logic stays per-protocol;
+    a future third instance is the trigger to lift the common
+    ``subscribe / filter / format / dispatch`` shape into a shared base.
 
     Lifecycle: subscribe via ``attach()`` once, ``detach()`` in a
-    try/finally so the subscriber doesn't outlive the call. Any
-    transport error during a fire is swallowed — progress is
-    best-effort; the A2A task's final ``completed`` / ``failed``
-    webhook is the authoritative outcome signal.
+    try/finally so the subscriber doesn't outlive the call. Any sink
+    failure during a fire is swallowed independently — progress is
+    best-effort; the A2A task's terminal ``completed`` / ``failed``
+    signal (= SSE ``event: end`` + webhook POST from
+    ``_handle_async_mode._run``) is the authoritative outcome.
     """
 
     _TRACKED_EVENTS = frozenset({
@@ -683,13 +690,15 @@ class _A2AProgressBridge:
         *,
         session: "object",
         run_id: str,
-        webhook_url: str,
+        webhook_url: str | None,
         agent_name: str,
+        run_registry: "object",
     ) -> None:
         self._session = session
         self._run_id = run_id
         self._webhook_url = webhook_url
         self._agent_name = agent_name
+        self._run_registry = run_registry
         self._ordinal = 0
         self._detached = False
         self._tasks: list[asyncio.Task[None]] = []
@@ -748,8 +757,6 @@ class _A2AProgressBridge:
     async def _send(
         self, ordinal: int, event_type: str, message: str,
     ) -> None:
-        from reyn.web.notifications import post_webhook  # noqa: PLC0415
-
         payload = {
             "run_id": self._run_id,
             "status": "in-progress",
@@ -758,10 +765,21 @@ class _A2AProgressBridge:
             "message": message,
             "agent_name": self._agent_name,
         }
+        # Sink 1: SSE buffer (always). The append failure is logged
+        # implicitly and must not block the webhook fire below.
         try:
-            await post_webhook(self._webhook_url, payload)
-        except Exception:  # noqa: BLE001 — progress is best-effort
-            return
+            self._run_registry.append_event(self._run_id, payload)
+        except Exception:  # noqa: BLE001 — sse buffer is best-effort
+            pass
+        # Sink 2: webhook POST (opt-in). Each sink swallows its own
+        # transport error independently so one failure doesn't suppress
+        # the other.
+        if self._webhook_url is not None:
+            from reyn.web.notifications import post_webhook  # noqa: PLC0415
+            try:
+                await post_webhook(self._webhook_url, payload)
+            except Exception:  # noqa: BLE001 — progress is best-effort
+                return
 
 
 async def _handle_async_mode(
@@ -787,27 +805,30 @@ async def _handle_async_mode(
     bus = A2AInterventionBus(run_id, run_registry)
 
     async def _run() -> None:
-        # issue #267 Gap 2: when a webhook_url is registered, subscribe a
-        # progress bridge to the agent's chat_events for the lifetime of
-        # this call. The bridge fires intermediate ``status="in-progress"``
-        # webhooks for skill lifecycle events (= phase_started / llm_called
-        # / act_executed) so the A2A peer sees progression beyond just
-        # terminal completed / failed. Bridge attach is best-effort —
-        # failure to load the session or subscribe must NOT block the
-        # main call (= progress is decoration; the answer is the contract).
+        # issue #267 Gap 1 + Gap 2: subscribe a progress bridge to the
+        # agent's chat_events for the lifetime of this call. The bridge
+        # fans out skill lifecycle events (phase_started / llm_called /
+        # act_executed) to two sinks:
+        #   - SSE buffer (always): append to RunEntry.history_events so
+        #     GET /a2a/tasks/{run_id}/events replays progression.
+        #   - Webhook POST (opt-in): when webhook_url is registered,
+        #     same payload pushed to the peer URL.
+        # Bridge attach is best-effort — failure to load the session or
+        # subscribe must NOT block the main call (= progress is
+        # decoration; the answer is the contract).
         bridge: "_A2AProgressBridge | None" = None
-        if webhook_url:
-            try:
-                session = registry.get_or_load(agent_name)
-                bridge = _A2AProgressBridge(
-                    session=session,
-                    run_id=run_id,
-                    webhook_url=webhook_url,
-                    agent_name=agent_name,
-                )
-                bridge.attach()
-            except Exception:  # noqa: BLE001 — defensive
-                bridge = None
+        try:
+            session = registry.get_or_load(agent_name)
+            bridge = _A2AProgressBridge(
+                session=session,
+                run_id=run_id,
+                webhook_url=webhook_url,
+                agent_name=agent_name,
+                run_registry=run_registry,
+            )
+            bridge.attach()
+        except Exception:  # noqa: BLE001 — defensive
+            bridge = None
         try:
             result = await send_to_agent_impl(
                 registry,

--- a/tests/test_a2a_sse_producer_267_gap1.py
+++ b/tests/test_a2a_sse_producer_267_gap1.py
@@ -1,0 +1,363 @@
+"""Tier 2: A2A SSE producer wiring (issue #267 Gap 1).
+
+Before this PR, ``GET /a2a/tasks/{run_id}/events`` (= SSE stream)
+yielded only the terminal ``event: end`` because no in-tree code called
+``RunRegistry.append_event``. Peer connections received empty streams
+plus a single end-of-task signal — polling-equivalent with extra
+infrastructure.
+
+This PR makes two callers feed ``history_events``:
+
+  1. ``_A2AProgressBridge._send`` — phase_started / llm_called /
+     act_executed events fan out to BOTH the SSE buffer + (optionally)
+     the webhook POST. Bridge is now constructed unconditionally in
+     ``_handle_async_mode._run`` (= the webhook_url gate moved INTO
+     the bridge's per-sink dispatch).
+  2. ``A2AInterventionBus.deliver`` — the input-required payload is
+     appended to history_events BEFORE the optional webhook POST. SSE
+     consumers see ask_user prompts inline with the progress stream.
+
+Pins:
+
+  1. Bridge constructor accepts ``webhook_url=None`` + ``run_registry``.
+  2. ``_send`` appends payload to history_events on every fire.
+  3. ``_send`` only POSTs webhook when ``webhook_url`` is non-None.
+  4. SSE sink failure does NOT block webhook fire (and vice versa).
+  5. ``A2AInterventionBus.deliver`` appends input-required to
+     history_events when prompted.
+  6. Terminal events (completed / failed) still bypass history_events
+     (= SSE endpoint yields ``event: end`` on terminal status directly,
+     no double-emission).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
+
+from reyn.events.events import EventLog  # noqa: E402
+from reyn.user_intervention import (  # noqa: E402
+    InterventionAnswer,
+    InterventionChoice,
+    UserIntervention,
+)
+from reyn.web.a2a_intervention import A2AInterventionBus  # noqa: E402
+from reyn.web.run_registry import RunRegistry  # noqa: E402
+
+# ── 1. Bridge constructor accepts webhook_url=None ────────────────────
+
+
+def test_bridge_constructor_accepts_optional_webhook_url() -> None:
+    """Tier 2: ``_A2AProgressBridge`` accepts ``webhook_url=None``
+    (= the SSE-only path) without raising. Pre-Gap-1 the bridge was
+    only built when webhook_url was set, so this signature flip is the
+    contract that enables SSE-only deployments.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id="run-N",
+        webhook_url=None,  # ← optional now
+        agent_name="demo",
+        run_registry=RunRegistry(),
+    )
+    assert bridge._webhook_url is None
+
+
+# ── 2. _send appends to history_events ────────────────────────────────
+
+
+def test_send_appends_payload_to_history_events() -> None:
+    """Tier 2: ``_send`` calls ``run_registry.append_event(run_id,
+    payload)`` for every fire. This is the SSE producer wiring (= Gap 1
+    core): without it, history_events stays empty + the SSE stream
+    yields nothing.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    registry = RunRegistry()
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id=entry.run_id,
+        webhook_url=None,
+        agent_name="demo",
+        run_registry=registry,
+    )
+
+    asyncio.run(bridge._send(3, "phase_started", "phase: planning"))
+
+    refreshed = registry.get(entry.run_id)
+    assert len(refreshed.history_events) == 1
+    appended = refreshed.history_events[0]
+    assert appended == {
+        "run_id": entry.run_id,
+        "status": "in-progress",
+        "progress": 3,
+        "event": "phase_started",
+        "message": "phase: planning",
+        "agent_name": "demo",
+    }
+
+
+# ── 3. _send only POSTs webhook when configured ───────────────────────
+
+
+def test_send_skips_webhook_when_webhook_url_is_none(monkeypatch) -> None:
+    """Tier 2: with ``webhook_url=None``, ``_send`` does NOT call
+    ``post_webhook`` (= the SSE-only deployment pays zero HTTP cost).
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    posted: list = []
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id="run-N",
+        webhook_url=None,
+        agent_name="demo",
+        run_registry=RunRegistry(),
+    )
+
+    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+    assert posted == []
+
+
+def test_send_posts_webhook_when_webhook_url_set(monkeypatch) -> None:
+    """Tier 2: with ``webhook_url`` set, ``_send`` POSTs the SAME
+    payload that was appended to history_events. Pin both side
+    effects so the SSE consumer + webhook consumer see consistent
+    state.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    posted: list[tuple[str, dict]] = []
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id=entry.run_id,
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+        run_registry=registry,
+    )
+
+    asyncio.run(bridge._send(2, "llm_called", "llm: m"))
+
+    # SSE sink
+    sse = registry.get(entry.run_id).history_events
+    # Webhook sink
+    assert len(posted) == 1
+    posted_url, posted_payload = posted[0]
+    # Both sinks saw the SAME payload
+    assert sse[0] == posted_payload
+    assert posted_url == "https://peer.test/hook"
+
+
+# ── 4. Sink independence ──────────────────────────────────────────────
+
+
+def test_sse_sink_failure_does_not_block_webhook(monkeypatch) -> None:
+    """Tier 2: if ``run_registry.append_event`` raises, ``_send`` still
+    fires the webhook. Each sink swallows its own failure
+    independently.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    class _RaisingRegistry:
+        def append_event(self, run_id, event):
+            raise RuntimeError("simulated sse buffer failure")
+
+    posted: list = []
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id="run-N",
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+        run_registry=_RaisingRegistry(),
+    )
+
+    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+    # webhook still ran despite SSE failure
+    assert len(posted) == 1
+
+
+def test_webhook_sink_failure_does_not_block_sse(monkeypatch) -> None:
+    """Tier 2: inverse — if ``post_webhook`` raises, the SSE append
+    already happened (= sequential, SSE first then webhook). Confirms
+    independence in both directions.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    async def _failing_post(url: str, payload: dict):  # noqa: ANN202
+        raise RuntimeError("simulated webhook failure")
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _failing_post)
+
+    registry = RunRegistry()
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id=entry.run_id,
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+        run_registry=registry,
+    )
+
+    asyncio.run(bridge._send(1, "act_executed", "act: 2 ops"))
+
+    # SSE append succeeded despite webhook failure
+    assert len(registry.get(entry.run_id).history_events) == 1
+
+
+# ── 5. A2AInterventionBus.deliver appends input-required ──────────────
+
+
+def test_a2a_intervention_bus_deliver_appends_input_required_to_history() -> None:
+    """Tier 2: ``A2AInterventionBus.deliver`` appends the
+    input-required payload to RunEntry.history_events BEFORE the
+    (optional) webhook POST. SSE consumers see ask_user prompts inline
+    with the progress stream.
+    """
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url=None,  # no webhook = SSE-only consumer
+    )
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(
+            kind="permission.confirm",
+            prompt="Allow read?",
+            choices=[InterventionChoice(id="yes", label="[Y]", hotkey="y")],
+        )
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        iv.future.set_result(InterventionAnswer(text="yes", choice_id="yes"))
+        await task
+
+    asyncio.run(_drive())
+
+    refreshed = registry.get(entry.run_id)
+    assert len(refreshed.history_events) == 1
+    appended = refreshed.history_events[0]
+    assert appended["status"] == "input-required"
+    assert appended["kind"] == "permission.confirm"
+    assert appended["question"] == "Allow read?"
+    assert appended["choices"] == [
+        {"id": "yes", "label": "[Y]", "hotkey": "y"},
+    ]
+
+
+def test_a2a_intervention_bus_appends_history_even_without_webhook() -> None:
+    """Tier 2: ``A2AInterventionBus.deliver`` appends to history_events
+    even when ``webhook_url`` is None on the RunEntry (= the SSE-only
+    peer code path). Pre-Gap-1, no history was written at all in this
+    case → SSE stream stayed empty → the streaming claim was dead.
+    """
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url=None,
+    )
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        task = asyncio.ensure_future(bus.deliver(iv))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        iv.future.set_result(InterventionAnswer(text="ok"))
+        await task
+
+    asyncio.run(_drive())
+    assert len(registry.get(entry.run_id).history_events) == 1
+
+
+# ── 6. SSE endpoint replay sanity ─────────────────────────────────────
+
+
+def test_sse_endpoint_replays_appended_events_via_history() -> None:
+    """Tier 2: end-to-end sanity — events appended via the bridge are
+    visible through ``stream_task_events``'s history_events read. We
+    don't drive the StreamingResponse generator (= would need a full
+    ASGI stack); instead pin that the data flow lands where the
+    endpoint reads from.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    registry = RunRegistry()
+    entry = registry.create(agent_name="demo", chain_id="chain-A")
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id=entry.run_id,
+        webhook_url=None,
+        agent_name="demo",
+        run_registry=registry,
+    )
+
+    async def _drive() -> None:
+        await bridge._send(1, "phase_started", "phase: planning")
+        await bridge._send(2, "llm_called", "llm: m")
+        await bridge._send(3, "act_executed", "act: 2 ops")
+
+    asyncio.run(_drive())
+
+    refreshed = registry.get(entry.run_id)
+    # The endpoint code at line 921 reads `entry.history_events[seen:]`
+    # — confirm the slice the endpoint will replay has 3 ordered events.
+    assert [e["event"] for e in refreshed.history_events] == [
+        "phase_started", "llm_called", "act_executed",
+    ]
+    assert [e["progress"] for e in refreshed.history_events] == [1, 2, 3]

--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -42,6 +42,16 @@ from reyn.events.events import EventLog  # noqa: E402
 from reyn.schemas.models import Event  # noqa: E402
 
 
+class _FakeRunRegistry:
+    """Minimal stub for tests — captures append_event calls."""
+
+    def __init__(self) -> None:
+        self.appended: list[tuple[str, dict]] = []
+
+    def append_event(self, run_id: str, event: dict) -> None:
+        self.appended.append((run_id, event))
+
+
 def _make_bridge(*, captured_posts: list[tuple[str, dict]], events: EventLog | None = None):
     """Build a bridge with a fake session whose ``_chat_events`` is the
     given EventLog (or a fresh one). The bridge's _send is monkey-patched
@@ -61,6 +71,7 @@ def _make_bridge(*, captured_posts: list[tuple[str, dict]], events: EventLog | N
         run_id="run-X",
         webhook_url="https://peer.test/hook",
         agent_name="demo",
+        run_registry=_FakeRunRegistry(),
     )
 
     async def _capture(ordinal, event_type, message):  # noqa: ANN202
@@ -244,6 +255,7 @@ def test_send_posts_canonical_progress_payload(monkeypatch) -> None:
         run_id="run-Y",
         webhook_url="https://peer.test/hook",
         agent_name="demo",
+        run_registry=_FakeRunRegistry(),
     )
 
     asyncio.run(bridge._send(7, "phase_started", "phase: planning"))
@@ -281,6 +293,7 @@ def test_send_swallows_transport_errors(monkeypatch) -> None:
         run_id="run-Z",
         webhook_url="https://peer.test/hook",
         agent_name="demo",
+        run_registry=_FakeRunRegistry(),
     )
 
     # No exception raised, no return value used.
@@ -318,11 +331,16 @@ def test_late_event_after_detach_is_ignored() -> None:
 # ── 7. Integration: _handle_async_mode wires the bridge ────────────────
 
 
-def test_handle_async_mode_attaches_bridge_when_webhook_url_present() -> None:
-    """Tier 2: in ``_handle_async_mode._run``, when ``webhook_url`` is
-    provided, an ``_A2AProgressBridge`` is constructed + attached
-    BEFORE ``send_to_agent_impl`` is called. Verified via in-source
+def test_handle_async_mode_attaches_bridge_around_send_to_agent_impl() -> None:
+    """Tier 2: in ``_handle_async_mode._run``, ``_A2AProgressBridge``
+    is constructed + attached BEFORE ``send_to_agent_impl`` is called
+    and detached in a ``finally`` afterwards. Verified via in-source
     grep so a refactor that drops the wiring fails immediately.
+
+    After #267 Gap 1 (= SSE producer wiring), the bridge is
+    UNCONDITIONAL (no longer gated on ``webhook_url``) because the
+    SSE sink is always available — see
+    ``test_handle_async_mode_bridge_is_unconditional_after_gap1``.
     """
     import ast
     from pathlib import Path
@@ -356,20 +374,31 @@ def test_handle_async_mode_attaches_bridge_when_webhook_url_present() -> None:
     assert bridge_detach_calls >= 1
 
 
-def test_handle_async_mode_skips_bridge_when_no_webhook_url() -> None:
-    """Tier 2: in-source grep confirms the bridge construction is
-    GATED on ``webhook_url`` (= no webhook → no bridge → no event
-    subscription). The peer that doesn't register a URL sees zero
-    overhead.
+def test_handle_async_mode_bridge_is_unconditional_after_gap1() -> None:
+    """Tier 2: after #267 Gap 1 landed (= SSE producer wiring), the
+    bridge is constructed UNCONDITIONALLY in ``_handle_async_mode``.
+    The SSE sink (= ``run_registry.append_event``) always runs; the
+    webhook sink is gated INSIDE the bridge's ``_send`` instead of at
+    construction time.
+
+    Pre-Gap-1 (PR #286), the bridge was gated on ``webhook_url`` so
+    peers without a webhook paid zero overhead. Post-Gap-1, peers
+    that connect via SSE need the bridge regardless — so the gate
+    moved from construction to per-sink dispatch.
     """
     import inspect
 
     from reyn.web.routers import a2a as a2a_router
 
     src = inspect.getsource(a2a_router._handle_async_mode)
-    # The bridge construction must be inside an ``if webhook_url:`` block.
-    assert "if webhook_url:" in src
+    # Bridge is constructed once — no `if webhook_url:` guard around
+    # the construction itself.
     assert "_A2AProgressBridge(" in src
-    # And detach must run in a finally so it executes on both success
-    # and exception paths.
+    assert "bridge.attach()" in src
+    # detach must run in a finally so it executes on both success and
+    # exception paths.
     assert "bridge.detach()" in src
+    # The bridge construction is paired with run_registry (= SSE sink
+    # is wired). Pin the param presence so a refactor that drops it
+    # fails immediately.
+    assert "run_registry=run_registry" in src


### PR DESCRIPTION
**[e2e-coder]** — #267 Gap 1: makes the SSE endpoint actually produce events. Pre-PR, ``GET /a2a/tasks/{run_id}/events`` yielded only the terminal ``event: end`` because no in-tree code called ``RunRegistry.append_event`` — the streaming capability claim was dead.

## Summary

Two producers now feed ``history_events``:

1. **``_A2AProgressBridge._send``** (= PR #286's webhook bridge) fans out to two sinks per fire:
   - SSE buffer (always): ``run_registry.append_event``
   - Webhook POST (opt-in): when ``webhook_url`` is non-None
2. **``A2AInterventionBus.deliver``** builds the input-required payload ONCE and appends to ``history_events`` before the optional webhook POST. SSE consumers see ask_user prompts inline with the progress stream.

Bridge signature change:
- ``webhook_url: str`` → ``webhook_url: str | None`` (= optional)
- New required param: ``run_registry`` (= the SSE sink target)
- Bridge construction in ``_handle_async_mode._run`` is now UNCONDITIONAL — the opt-in gate moved INTO ``_send``'s per-sink dispatch.

Sink independence: each sink swallows its own failure. SSE append raising does not block webhook fire; webhook POST raising leaves the already-completed SSE append intact. Pinned by Tier 2 in both directions.

## Rule-of-three calibration

Still 2 instances (MCP progress notifications + A2A two-sink bridge), so the bridge logic stays per-protocol. A future third instance (e.g. WebSocket / gRPC streaming) triggers the lift to a shared base.

## Capability claim re-elevation deferred

PR #272 (Gap 3 Z-b) downgraded ``streaming`` + ``pushNotifications`` to false because both surfaces were dead. With Gap 1 + Gap 2 now producing, the re-elevation is the natural close — but I'm deferring to a separate small PR so the evidence-backing is clean (= one PR per change, easy to verify the flip is justified by adjacent merged work).

## Test plan

- [x] Tier 2 new file (9 cases): constructor optional webhook_url + run_registry / history_events append / webhook opt-in gate / both-sink payload consistency / sink independence in both directions / A2AInterventionBus appends input-required even without webhook / SSE endpoint replay sanity
- [x] Tier 2 updated (Gap 2 file, 3 sites): constructor signature + production gate move INTO bridge
- [x] A2A region regression (bus stamping #268 Phase 2 / capability claim interim / FP-0001 intervention bus / webhook delivery ack / iv kind coverage #267 Gap 4): **36 tests pass**
- [x] Full suite: **4252 passed, 5 skipped, 3 xfailed** in 155s
- [x] `ruff check` clean

## Related

- PR #286 (= #267 Gap 2 webhook bridge, this PR extends its bridge to fan out to SSE too)
- PR #285 (= #267 Gap 4 iv kind/choices, the payload format this PR also writes to SSE)
- PR #272 (= #267 Gap 3 Z-b capability claim interim, controls when to re-elevate)
- Gap 5 Phase 2 (RunRegistry ↔ ChatSession iv re-bind on restart) — remaining #267 item, owner-decision pending on skill resumption semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)