### PR TITLE
feat(a2a): capability claim re-elevation streaming + pushNotifications (issue #267 Gap 3 Z-c)

### DIFF
--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -93,31 +93,29 @@ def _build_agent_card(agent_name: str, role: str, base_url: str) -> dict:
       * ``name`` — the Reyn agent name (= addressable identity).
       * ``description`` — the agent's ``role`` text from profile.yaml.
       * ``url`` — the JSON-RPC endpoint to POST to.
-      * ``capabilities`` — issue #267 Gap 3 Z-b interim disclosure:
-        ``streaming`` and ``pushNotifications`` are currently advertised
-        as ``False`` to honestly reflect the **partial implementation
-        state**, not the FP-0001 design intent. Concretely:
+      * ``capabilities`` — issue #267 Gap 3 Z-c re-elevation. With
+        Gap 1 (= SSE producer wiring, PR #288) and Gap 2 (= webhook
+        trigger expansion, PR #286) both landed, the two surfaces now
+        produce events backing the claims. Re-elevated to ``True``:
 
-          - ``streaming``: SSE endpoint exists (``GET /a2a/tasks/{run_id}/events``)
-            but ``RunRegistry.append_event`` has no in-tree producer
-            (= history_events stays empty in production), so streaming
-            never delivers in-flight events. Claim was ``True`` pre-#267
-            but the empty stream was misleading. issue #267 Gap 1 tracks
-            the producer-wiring work; this claim flips back to ``True``
-            via Gap 3 Z-a once SSE is functional.
-          - ``pushNotifications``: webhook fires on exactly three
-            triggers (= ``completed`` / ``failed`` / ``input-required``).
-            spec-conformance-strict peers reading the ``True`` claim
-            would expect notifications for any state change, which we
-            don't deliver. issue #267 Gap 2 tracks the trigger
-            expansion; same Gap 3 Z-a re-evaluation criteria.
+          - ``streaming``: ``GET /a2a/tasks/{run_id}/events`` SSE stream
+            backed by ``_A2AProgressBridge`` fan-out into
+            ``RunEntry.history_events`` (PR #288) +
+            ``A2AInterventionBus.deliver`` appending input-required
+            events (= peers see lifecycle + ask_user inline).
+          - ``pushNotifications``: webhook fires on lifecycle events
+            (= phase_started / llm_called / act_executed via PR #286)
+            plus the original ``completed`` / ``failed`` /
+            ``input-required`` triggers. The two-sink bridge means
+            webhook and SSE consumers see identical payloads.
 
         ``stateTransitionHistory`` remains ``False`` (= no plans to
-        implement). The interim ``False`` state is **honest
-        disclosure**: peers can rely on what we declare. Existing
-        webhook-using peers can still POST + receive on the three
-        trigger events; the capability advertising doesn't gate
-        functionality, only the spec-level negotiation.
+        implement). Each claim is pinned to an in-source wire by the
+        Tier 2 contract test so a future refactor that removes the
+        producer without flipping the claim back fails immediately —
+        same pattern as PR #284's MCP capability/wire AST-pin
+        calibration (= prevents the #267 Z-b "claim/reality mismatch"
+        regression by construction).
       * ``skills`` — A2A's ``skill`` is an outward-facing capability,
         not Reyn's internal skill graph. We expose a single coarse-
         grained skill (``chat``) since each Reyn agent's actual
@@ -132,13 +130,14 @@ def _build_agent_card(agent_name: str, role: str, base_url: str) -> dict:
         "version": _REYN_A2A_VERSION,
         "protocolVersion": _A2A_PROTOCOL_VERSION,
         "capabilities": {
-            # issue #267 Gap 3 Z-b: interim ``False`` until implementation
-            # catches up (= Gap 1 SSE producer / Gap 2 webhook trigger
-            # expansion). See docstring above for the full disclosure
-            # rationale. Gap 3 Z-a will re-evaluate flipping these back
-            # to ``True`` once Gap 1 + Gap 2 land.
-            "streaming": False,
-            "pushNotifications": False,
+            # issue #267 Gap 3 Z-c re-elevation: Gap 1 (PR #288 SSE
+            # producer) + Gap 2 (PR #286 webhook trigger expansion)
+            # both landed → claims backed by in-source wires.
+            # Tier 2 contract test pins each claim to its wire so a
+            # regression flipping these back to False without removing
+            # the producer (or vice versa) fails immediately.
+            "streaming": True,
+            "pushNotifications": True,
             "stateTransitionHistory": False,
         },
         "defaultInputModes": ["text/plain"],

--- a/tests/test_a2a_capability_claim_interim.py
+++ b/tests/test_a2a_capability_claim_interim.py
@@ -1,42 +1,42 @@
-"""Tier 2: A2A Agent Card capability claim — issue #267 Gap 3 Z-b interim disclosure.
+"""Tier 2: A2A Agent Card capability claim — issue #267 Gap 3 Z-c re-elevation.
 
-Pure-Python test that pins the interim ``False`` state of the
-``streaming`` and ``pushNotifications`` capabilities without booting
-FastAPI / TestClient. Calls ``_build_agent_card`` directly so the
-check runs in any environment (= the broader test_a2a.py /
-test_fp0001_a2a_endpoints.py tests need the optional ``fastapi``
-extra; this file does not).
+With Gap 1 (= SSE producer wiring, PR #288) and Gap 2 (= webhook
+trigger expansion, PR #286) both landed, ``streaming`` +
+``pushNotifications`` flip back to ``True`` (= reversing PR #272's
+Gap 3 Z-b interim disclosure). Each claim is now pinned to the
+in-source wire that backs it, mirroring PR #284's MCP capability/wire
+AST-pin pattern (= prevents the #267 Z-b "claim/reality mismatch"
+regression by construction).
+
+Calibration constraint (= same as PR #284 M3): every declared
+``True`` capability must derive from a concrete in-source wire. Tests
+below pin BOTH the declaration AND the wire, so a future PR that
+removes one without the other fails immediately.
 
 Pins:
 
-  1. ``streaming`` is ``False`` (= issue #267 Gap 1 SSE producer not
-     wired, history_events stays empty in production).
-  2. ``pushNotifications`` is ``False`` (= issue #267 Gap 2 webhook
-     trigger limited to completed / failed / input-required, claiming
-     ``True`` would mislead spec-conformance-strict peers).
-  3. ``stateTransitionHistory`` is ``False`` (= no plans to implement,
-     unchanged from FP-0001).
-  4. Required Agent Card fields stay shape-stable (= name / description
-     / url / version / protocolVersion / capabilities / defaultInputModes
-     / defaultOutputModes / skills) so the Gap 3 Z-b change is a
-     **value flip only**, not a schema change.
+  1. ``streaming`` is ``True`` + backed by ``_A2AProgressBridge``
+     appending to ``run_registry.history_events`` (Gap 1 PR #288).
+  2. ``pushNotifications`` is ``True`` + backed by the lifecycle
+     webhook fire path (Gap 2 PR #286) + the original 3 terminal
+     triggers in ``_handle_async_mode._run`` + ``A2AInterventionBus``.
+  3. ``stateTransitionHistory`` stays ``False`` (= unchanged from
+     FP-0001, no plans to implement).
+  4. Required Agent Card fields stay shape-stable.
 
-Gap 3 Z-a (= flip ``True`` back) lands once Gap 1 + Gap 2 close; at
-that point this test's expected values flip to ``True`` and reference
-the Gap-completion PRs.
+Pure-Python tests — call ``_build_agent_card`` directly so the check
+runs in any environment.
 """
 from __future__ import annotations
+
+import inspect
 
 import pytest
 
 
 def _maybe_skip_if_router_unavailable() -> None:
-    """Skip when ``reyn.web.routers.a2a`` can't import.
-
-    The module pulls in fastapi at top-level (= ``from fastapi import
-    APIRouter, ...``); environments without the optional extra simply
-    skip. CI has fastapi installed; local dev may not. issue #253
-    introduced the dependency.
+    """Skip when ``reyn.web.routers.a2a`` can't import (= optional
+    fastapi extra missing). CI has it; local dev may not.
     """
     try:
         import reyn.web.routers.a2a  # noqa: F401
@@ -44,42 +44,96 @@ def _maybe_skip_if_router_unavailable() -> None:
         pytest.skip(f"reyn.web.routers.a2a unavailable: {exc}")
 
 
-def test_agent_card_streaming_is_false_until_gap1_lands() -> None:
-    """Tier 2: ``streaming`` capability is False (= issue #267 Gap 3 Z-b).
+# ── 1. streaming = True + backed by producer wire ────────────────────
 
-    SSE endpoint exists at GET /a2a/tasks/{run_id}/events but
-    history_events has no in-tree producer, so streaming never delivers
-    in-flight events. Claiming True would mislead spec-conformance peers.
-    Gap 3 Z-a flips this back to True once Gap 1 wires the producer.
+
+def test_agent_card_streaming_is_true_after_gap1_lands() -> None:
+    """Tier 2: ``streaming`` capability is True (= issue #267 Gap 3
+    Z-c re-elevation). Backed by ``_A2AProgressBridge``'s SSE sink
+    landed in PR #288.
     """
     _maybe_skip_if_router_unavailable()
     from reyn.web.routers.a2a import _build_agent_card
 
     card = _build_agent_card("test_agent", "test role", "http://localhost/a2a")
-    assert card["capabilities"]["streaming"] is False
+    assert card["capabilities"]["streaming"] is True
 
 
-def test_agent_card_push_notifications_is_false_until_gap2_lands() -> None:
-    """Tier 2: ``pushNotifications`` capability is False (= issue #267
-    Gap 3 Z-b).
+def test_streaming_claim_backed_by_append_event_call_site() -> None:
+    """Tier 2: pin the in-source wire backing ``streaming=True``. The
+    producer call site is ``_A2AProgressBridge._send`` (= PR #288)
+    calling ``run_registry.append_event(...)``. AST-search confirms
+    the wire still exists so a refactor removing the producer fails
+    this test alongside the Z-c claim test.
+    """
+    _maybe_skip_if_router_unavailable()
+    from reyn.web.routers import a2a as a2a_router
 
-    Webhook fires on exactly three triggers (completed / failed /
-    input-required). Claiming True would imply support for arbitrary
-    state-change notifications, which we don't deliver. Gap 3 Z-a
-    flips this back to True once Gap 2 expands the trigger set.
+    bridge_src = inspect.getsource(a2a_router._A2AProgressBridge)
+    assert "append_event" in bridge_src, (
+        "_A2AProgressBridge no longer calls run_registry.append_event — "
+        "the streaming capability claim is now unbacked (= #267 Z-b "
+        "style claim/reality mismatch). Either restore the wire or "
+        "flip the claim back to False."
+    )
+
+
+# ── 2. pushNotifications = True + backed by webhook fire wires ───────
+
+
+def test_agent_card_push_notifications_is_true_after_gap2_lands() -> None:
+    """Tier 2: ``pushNotifications`` capability is True (= issue #267
+    Gap 3 Z-c re-elevation). Backed by the lifecycle webhook fire
+    path landed in PR #286 + the original 3 terminal triggers.
     """
     _maybe_skip_if_router_unavailable()
     from reyn.web.routers.a2a import _build_agent_card
 
     card = _build_agent_card("test_agent", "test role", "http://localhost/a2a")
-    assert card["capabilities"]["pushNotifications"] is False
+    assert card["capabilities"]["pushNotifications"] is True
+
+
+def test_push_notifications_claim_backed_by_webhook_post_call_sites() -> None:
+    """Tier 2: pin the in-source wires backing ``pushNotifications=True``.
+    Two surfaces must call ``post_webhook``:
+
+      - ``_A2AProgressBridge._send`` (= PR #286 lifecycle fire)
+      - ``_handle_async_mode._run`` (= original completed / failed
+        terminal fires)
+      - ``A2AInterventionBus.deliver`` (= original input-required
+        terminal fire, in src/reyn/web/a2a_intervention.py)
+
+    AST-search for ``post_webhook`` references confirms the wires still
+    exist. A refactor removing them fails this test alongside the Z-c
+    claim test.
+    """
+    _maybe_skip_if_router_unavailable()
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent / "src" / "reyn" / "web"
+    a2a_router_src = (repo_root / "routers" / "a2a.py").read_text(
+        encoding="utf-8",
+    )
+    bus_src = (repo_root / "a2a_intervention.py").read_text(encoding="utf-8")
+
+    assert "post_webhook" in a2a_router_src, (
+        "src/reyn/web/routers/a2a.py no longer calls post_webhook — "
+        "pushNotifications claim is unbacked."
+    )
+    assert "post_webhook" in bus_src, (
+        "src/reyn/web/a2a_intervention.py no longer calls post_webhook "
+        "— pushNotifications claim is unbacked for the iv surface."
+    )
+
+
+# ── 3. stateTransitionHistory unchanged ─────────────────────────────
 
 
 def test_agent_card_state_transition_history_stays_false() -> None:
     """Tier 2: ``stateTransitionHistory`` capability remains False
     (= unchanged from FP-0001, no plans to implement).
 
-    Catches any accidental flip during the Gap 3 Z-b adjustment.
+    Catches any accidental flip during the Z-c adjustment.
     """
     _maybe_skip_if_router_unavailable()
     from reyn.web.routers.a2a import _build_agent_card
@@ -88,13 +142,14 @@ def test_agent_card_state_transition_history_stays_false() -> None:
     assert card["capabilities"]["stateTransitionHistory"] is False
 
 
-def test_agent_card_required_fields_shape_stable_through_gap3_zb() -> None:
-    """Tier 2: Gap 3 Z-b is a **value flip only**, not a schema change.
+# ── 4. Card shape stability ──────────────────────────────────────────
 
-    Required Agent Card fields stay present with their expected shape
-    so peer clients reading the card parse it the same way. Pinning
-    this guards against accidental schema drift bundled into the value
-    flip.
+
+def test_agent_card_required_fields_shape_stable_through_gap3_zc() -> None:
+    """Tier 2: Z-c re-elevation is a **value flip only**, not a schema
+    change. Required Agent Card fields stay present with their
+    expected shape so peer clients reading the card parse it the same
+    way.
     """
     _maybe_skip_if_router_unavailable()
     from reyn.web.routers.a2a import _build_agent_card
@@ -110,7 +165,7 @@ def test_agent_card_required_fields_shape_stable_through_gap3_zb() -> None:
     assert "version" in card
     assert "protocolVersion" in card
 
-    # Capabilities map shape (3 boolean fields, all False post-Z-b)
+    # Capabilities map shape (3 boolean fields)
     caps = card["capabilities"]
     assert isinstance(caps, dict)
     assert set(caps.keys()) == {

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -203,19 +203,19 @@ def test_stream_task_events_returns_not_found_for_missing_run() -> None:
 
 
 def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> None:
-    """Tier 2: Agent Card capabilities currently advertise the interim
-    state from issue #267 Gap 3 Z-b:
+    """Tier 2: Agent Card capabilities advertise:
 
-      - streaming: False (= SSE producer not wired, history_events empty)
-      - pushNotifications: False (= webhook fires only on 3 lifecycle events)
+      - streaming: True (= issue #267 Gap 1 SSE producer wired in PR #288)
+      - pushNotifications: True (= issue #267 Gap 2 webhook trigger
+        expansion landed in PR #286)
       - stateTransitionHistory: False (= no plans to implement)
 
-    FP-0001 originally flipped streaming + pushNotifications to True for
-    the design intent, but the implementation gaps (= issue #267 Gap 1 +
-    Gap 2) make those claims misleading. Gap 3 Z-b is the interim
-    honest disclosure; Gap 3 Z-a will flip them back to True once Gap 1
-    + Gap 2 land. Test name kept for git-blame continuity with the
-    FP-0001 history.
+    History: FP-0001 originally claimed both ``True`` but the producers
+    were missing; PR #272 (Gap 3 Z-b) flipped them to ``False`` as an
+    interim honest disclosure while Gap 1+2 work landed; this PR
+    (= Gap 3 Z-c) flips them back to ``True`` now that the producers
+    are wired. Each claim is pinned to its concrete in-source wire by
+    ``tests/test_a2a_capability_claim_interim.py``.
     """
     from fastapi.testclient import TestClient
 
@@ -259,13 +259,13 @@ def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> Non
         r = client.get("/a2a/agents/demo/.well-known/agent-card.json")
         assert r.status_code == 200, r.text
         caps = r.json()["capabilities"]
-        assert caps["streaming"] is False, (
-            "streaming must be False until issue #267 Gap 1 lands "
-            "(= SSE producer wiring). Gap 3 Z-b interim disclosure."
+        assert caps["streaming"] is True, (
+            "streaming must be True after issue #267 Gap 1 SSE producer "
+            "wiring (PR #288). Gap 3 Z-c re-elevation."
         )
-        assert caps["pushNotifications"] is False, (
-            "pushNotifications must be False until issue #267 Gap 2 lands "
-            "(= webhook trigger expansion). Gap 3 Z-b interim disclosure."
+        assert caps["pushNotifications"] is True, (
+            "pushNotifications must be True after issue #267 Gap 2 "
+            "webhook trigger expansion (PR #286). Gap 3 Z-c re-elevation."
         )
         assert caps["stateTransitionHistory"] is False, "stateTransitionHistory must remain False"
     finally:

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -143,10 +143,11 @@ def test_agent_card_returns_canonical_shape(tmp_path):
     returns an A2A-compliant Agent Card with the agent's role as
     description and the JSON-RPC endpoint URL.
 
-    Capabilities: issue #267 Gap 3 Z-b interim disclosure (= streaming
-    + pushNotifications both ``False`` until Gap 1 SSE producer wiring
-    + Gap 2 webhook trigger expansion land; then Gap 3 Z-a re-flips
-    them to ``True``).
+    Capabilities: issue #267 Gap 3 Z-c re-elevation (= streaming +
+    pushNotifications both ``True`` after Gap 1 SSE producer wiring
+    PR #288 + Gap 2 webhook trigger expansion PR #286 landed; each
+    claim is pinned to its in-source wire in
+    ``tests/test_a2a_capability_claim_interim.py``).
     """
     client, _ = _client_with_registry(tmp_path, [("default", "general assistant")])
     try:
@@ -161,11 +162,11 @@ def test_agent_card_returns_canonical_shape(tmp_path):
         # Endpoint URL points at the JSON-RPC handler for THIS agent.
         assert card["url"].endswith("/a2a/agents/default")
 
-        # Capabilities advertised: issue #267 Gap 3 Z-b interim
-        # disclosure — both False until impl gaps close.
+        # Capabilities advertised: issue #267 Gap 3 Z-c re-elevation
+        # — both True after Gap 1 + Gap 2 closed.
         caps = card["capabilities"]
-        assert caps["streaming"] is False
-        assert caps["pushNotifications"] is False
+        assert caps["streaming"] is True
+        assert caps["pushNotifications"] is True
         assert caps["stateTransitionHistory"] is False
 
         # Modes + skills shape (peers parse these to capability-negotiate).


### PR DESCRIPTION
**[e2e-coder]** — #267 Gap 3 Z-c: closes the Z-b/Z-c interim ↔ re-elevation cycle. PR #272 (Z-b) honestly downgraded `streaming` + `pushNotifications` to `False` because the producers were missing; with Gap 1 (PR #288) and Gap 2 (PR #286) both landed, the producers exist and the claims flip back to `True`.

## Summary

Three booleans change, each one paired with a Tier 2 wire pin:

| Claim | New | Backed by |
|---|---|---|
| `streaming` | `False` → **`True`** | `_A2AProgressBridge.append_event` (PR #288) + `A2AInterventionBus.deliver` history append |
| `pushNotifications` | `False` → **`True`** | `_A2AProgressBridge.post_webhook` (PR #286) + terminal triggers in `_handle_async_mode._run` + `A2AInterventionBus.deliver` |
| `stateTransitionHistory` | `False` | unchanged (no plans to implement) |

## Calibration: claim ↔ wire AST/inspect pin

Mirrors PR #284 (MCP M3 capability advertising). Every declared `True` capability is paired with an in-source wire that the test checks via `inspect.getsource` / file read. So a future PR that removes a producer without flipping the claim back fails immediately — same #267 Z-b "claim/reality mismatch" prevention by construction.

## Files changed

- `src/reyn/web/routers/a2a.py:_build_agent_card`: 2 booleans flipped + docstring rewritten to document Z-c rationale instead of Z-b interim
- `tests/test_a2a_capability_claim_interim.py`: rewritten for Z-c (= add wire pins)
- `tests/test_fp0001_a2a_endpoints.py`: 2 expected-value flips, docstring updated with PR-#286/#288 cross-refs
- `tests/web/test_a2a.py`: same value flip in the canonical-shape test

## Test plan

- [x] Tier 2 contract test (Z-c): claim values + wire backing for each True capability + `stateTransitionHistory` unchanged + Agent Card shape stability
- [x] Updated 2 existing tests that asserted Z-b interim values
- [x] A2A region regression (Gap 1 / Gap 2 / Gap 4 / bus stamping): 42 + adjacent tests pass
- [x] Full suite: **4254 passed, 5 skipped, 3 xfailed** in 157s
- [x] `ruff check` clean

## #267 cluster status post-merge

- Gap 1 ✓ (PR #288)
- Gap 2 ✓ (PR #286)
- Gap 3 Z-c ✓ this PR
- Gap 4 ✓ (PR #285)
- Gap 5 Phase 1 ✓ (PR #273)
- Gap 5 Phase 2 ⏳ — RunRegistry ↔ ChatSession iv re-bind on restart; owner-decision pending on skill resumption semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)