### PR TITLE
feat(router_loop): ENV-gated spawn-ack-to-LLM path — closes NF-W7-B43-2

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -72,6 +72,34 @@ _SPAWN_ACK_MSG: dict[str, str] = {
 }
 
 
+# NF-W7-B43-2: positive directive injected into the spawn-ack tool_result
+# content. Replaces the previous OS-synthetic spawn-ack outbox push +
+# early-exit pattern with the standard tool_call → tool_result → LLM
+# continuation pattern (= aligned with Claude / GPT competitor designs).
+#
+# Why directive, not bare status:
+#   - Trace-patch-replay N=10 (= 5 variant ablation, 2026-05-20):
+#       Variant A (bare status, no directive):      1/10 ACK, 8/10 EMPTY, 0/10 HALLUCINATE
+#       Variant B (negative directive "don't"):     0/10 ACK, 10/10 EMPTY
+#       Variant D (positive "write short reply"):   7/10 ACK, 3/10 EMPTY, **0/10 HALLUCINATE**
+#   - H3 hallucination defense (= B32 W3 S1 race) preserved across all
+#     variants thanks to "do not include skill output" framing.
+#   - Variant D (= "1-2 sentences confirm" voice) ACK 7/10 baseline;
+#     remaining 3/10 EMPTY covered by PR #265 retry mechanism
+#     (REYN_EMPTY_STOP_RETRY=1).
+#
+# The directive is appended to the tool_result body using the same
+# ``\n\n---\n`` separator pattern as PR #221's ``_post_text`` (= LLM
+# reads it as a textual instruction following the JSON status block).
+_SPAWN_ACK_TOOL_DIRECTIVE = (
+    "The skill has been spawned and is running in the background. "
+    "Write a short reply to the user (1-2 sentences) confirming the "
+    "skill has been started. The actual result will arrive in a "
+    "subsequent turn as a [task_completed] message — do not include "
+    "any skill output here, only the status confirmation."
+)
+
+
 def _strip_frontmatter(content: str) -> str:
     """Remove a leading YAML frontmatter block (``---\\n...\\n---\\n``) from
     a memory file's text and return the body alone.
@@ -1686,34 +1714,21 @@ class RouterLoop:
                 # same "Understood" hallucination under gemini-2.5-flash,
                 # confirming this is OS-layer, not LLM-layer).
                 #
-                # Mechanism: when invoke_skill / invoke_action (= FP-0034
-                # universal catalog dispatches that spawn a background skill
-                # via spawn_for_router) returns status="spawned", continuing
-                # the loop appends the spawn-ack as role=tool. The
-                # (answered) workaround in llm.py:821 then injects a
-                # user-role prompt, causing the LLM to compose a final
-                # reply before the skill output is available — producing
-                # the generic "Understood" / "I will notify you" output
-                # observed in B32.
-                #
-                # Fix: exit on spawn-ack so _handle_skill_completed
-                # re-engages the router with the real skill output via the
-                # [task_completed] inbox message. This is exactly the
-                # invoke_skill / invoke_action analogue of the existing
-                # async_count exit for delegate_to_agent (= adjacent
-                # FP-0012 spawn-ack pattern).
-                #
-                # NOTE: dispatch_tool wraps invoker results as
-                # ``{"status": "ok", "data": <inner_result>}``. The inner
-                # result (= spawn-ack from spawn_for_router) has
-                # ``status="spawned"`` nested under "data". The check
-                # below covers both wrapped and unwrapped shapes.
-                #
-                # This check runs AFTER routing_decided so that the P6
-                # audit event still fires even on the early-exit path.
-                _spawn_ack_count = sum(
-                    1
-                    for tc, r in zip(tool_calls, tool_results)
+                # NF-W7-B43-2 (2026-05-20): the OS-synthetic spawn-ack
+                # message itself became an in-context-learning attractor —
+                # multi-turn conversations accumulated the literal text in
+                # the assistant slot, and weak LLMs echoed it in
+                # subsequent turns (10/10 deterministic in trace-patch-
+                # replay). The env-gated alternative path below switches
+                # to the standard role=tool + LLM-composed reply pattern
+                # (= Claude / GPT alignment) with H3 hallucination
+                # defense via a tool_result directive (= PR #221
+                # ``_post_text`` mechanism). Default behaviour is
+                # unchanged; ``REYN_SPAWN_ACK_TO_LLM=1`` opts in to the
+                # new pattern.
+                _spawn_ack_indices: list[int] = [
+                    i
+                    for i, (tc, r) in enumerate(zip(tool_calls, tool_results))
                     if (
                         tc["function"]["name"] in ("invoke_skill", "invoke_action")
                         and isinstance(r, dict)
@@ -1725,26 +1740,47 @@ class RouterLoop:
                             )
                         )
                     )
-                )
-                if _spawn_ack_count:
+                ]
+                if _spawn_ack_indices:
                     host.events.emit(
                         "invoke_skill_spawn_ack_exit",
-                        spawn_ack_count=_spawn_ack_count,
+                        spawn_ack_count=len(_spawn_ack_indices),
                         chain_id=self.chain_id,
                     )
-                    # OS-level synthetic spawn-ack — see _SPAWN_ACK_MSG
-                    # rationale. Without this, the H3 early-exit leaves
-                    # the user with no feedback until [task_completed]
-                    # arrives.  Deterministic (= not LLM-composed) so the
-                    # B32 W3 S1 hallucination race cannot re-emerge.
-                    lang = getattr(host, "output_language", None)
-                    ack_text = _SPAWN_ACK_MSG.get(lang, _SPAWN_ACK_MSG["en"])
-                    await host.put_outbox(
-                        kind="agent",
-                        text=ack_text,
-                        meta={"chain_id": self.chain_id, "source": "spawn_ack"},
-                    )
-                    return self._total_usage
+                    if os.environ.get("REYN_SPAWN_ACK_TO_LLM") == "1":
+                        # NF-W7-B43-2 opt-in path: annotate each spawn-ack
+                        # tool_result with the directive via ``_post_text``
+                        # so the existing PR #221 serialisation layer below
+                        # appends it outside the JSON body with the standard
+                        # ``\n\n---\n`` separator. The loop continues
+                        # normally — the next LLM iteration composes the
+                        # user-facing reply (= 7/10 ACK in N=10 trace
+                        # replay) with H3 hallucination defense (= 0/10
+                        # hallucinate via the directive wording). Residual
+                        # 3/10 EMPTY is covered by PR #265 / PR #287's
+                        # ``REYN_EMPTY_STOP_RETRY=1`` retry mechanism.
+                        for idx in _spawn_ack_indices:
+                            r = tool_results[idx]
+                            if isinstance(r, dict):
+                                r["_post_text"] = _SPAWN_ACK_TOOL_DIRECTIVE
+                        # Fall through to the standard
+                        # ``messages.append(...)`` block below.
+                    else:
+                        # Default (= pre-NF-W7-B43-2) behaviour: OS pushes
+                        # the deterministic spawn-ack text to the outbox
+                        # and exits the loop. Preserves the existing
+                        # contract (= ``meta.source="spawn_ack"``
+                        # downstream consumers, no LLM composition for
+                        # this turn). The in-context-learning attractor
+                        # the new path closes is still present here.
+                        lang = getattr(host, "output_language", None)
+                        ack_text = _SPAWN_ACK_MSG.get(lang, _SPAWN_ACK_MSG["en"])
+                        await host.put_outbox(
+                            kind="agent",
+                            text=ack_text,
+                            meta={"chain_id": self.chain_id, "source": "spawn_ack"},
+                        )
+                        return self._total_usage
                 # No delegation — accumulate messages for next iteration.
                 # Use deduped tool_calls so the assistant message and tool
                 # result messages stay in sync (matching tool_call_ids).

--- a/tests/test_router_loop_spawn_ack_to_llm.py
+++ b/tests/test_router_loop_spawn_ack_to_llm.py
@@ -1,0 +1,289 @@
+"""Tier 2: RouterLoop spawn-ack-to-LLM env-gated path (NF-W7-B43-2 fix).
+
+Pinned invariants:
+
+- When ``REYN_SPAWN_ACK_TO_LLM=1`` is set AND a tool_call returned a
+  spawn-ack (= ``status="spawned"`` from invoke_skill / invoke_action),
+  the loop:
+    1. emits ``invoke_skill_spawn_ack_exit`` event (= P6 audit, same
+       as the default path);
+    2. annotates the spawn-ack tool_result with the
+       ``_SPAWN_ACK_TOOL_DIRECTIVE`` via ``_post_text``;
+    3. continues the loop (= does NOT early-exit, does NOT push an
+       OS-synthetic spawn-ack to outbox).
+- When the env var is unset, the existing default path runs: OS
+  pushes the deterministic ``_SPAWN_ACK_MSG`` to outbox and exits
+  the loop. No directive injection on tool_result.
+- ``_SPAWN_ACK_TOOL_DIRECTIVE`` is a non-empty string mentioning
+  "skill" (= context) and "do not include" (= H3 hallucination
+  defense), distinct from the chat-router empty-stop retry directive
+  in shape and intent.
+
+References:
+- NF-W7-B43-2 root cause: B43 W7-S7 leak attractor (= 10/10
+  deterministic in trace-patch-replay; LLM echoed
+  ``_SPAWN_ACK_MSG`` literal from history's assistant slot).
+- N=10 directive variant ablation (2026-05-20): Variant D
+  positive-framing directive: 7/10 ACK, 3/10 EMPTY, 0/10
+  HALLUCINATE. Bare status + retry-only re-introduces H3 race
+  (= 5/10 HALLUCINATE in N=10 Variant F).
+- Anthropic ``handling-stop-reasons`` docs + PR #265 / PR #287's
+  ``REYN_EMPTY_STOP_RETRY=1`` covers the residual 3/10 EMPTY rate
+  for the spawn-ack-to-LLM opt-in.
+
+testing.ja.md compliance:
+- Uses the ``llm_caller=`` injection seam (= PR #265 revision) +
+  ``pytest.monkeypatch`` for env var setup. No ``unittest.mock.patch``.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import (
+    _SPAWN_ACK_MSG,
+    _SPAWN_ACK_TOOL_DIRECTIVE,
+    RouterLoop,
+)
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import (
+    FakeRouterHost,
+    _ScriptedLLM,
+    text_result,
+    tool_result,
+)
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+# ---------------------------------------------------------------------------
+# Spy host that records tool_result mutations (= _post_text injection)
+# ---------------------------------------------------------------------------
+
+
+class _MessageCapturingScripted:
+    """Captures the messages list per LLM call so the test can inspect
+    what the LLM saw on its second turn (= post-spawn-ack continuation)."""
+
+    def __init__(self, script: list[LLMToolCallResult]):
+        self._script = list(script)
+        self.call_count = 0
+        self.messages_per_call: list[list[dict]] = []
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        msgs = kwargs.get("messages") or []
+        self.messages_per_call.append([dict(m) for m in msgs])
+        result = self._script[self.call_count]
+        self.call_count += 1
+        return result
+
+
+def _make_spawn_ack_host() -> FakeRouterHost:
+    """Build a host whose invoke_skill returns a spawn-ack on call."""
+    host = FakeRouterHost(skills=[{"name": "some_skill", "category": "general"}])
+
+    async def fake_spawn(**kwargs):
+        return {
+            "status": "spawned",
+            "run_id": "20260520T000000Z_some_skill_aaaa",
+            "chain_id": kwargs.get("chain_id", ""),
+            "skill": kwargs.get("skill", ""),
+            "note": "Running in the background.",
+        }
+
+    host.run_skill_awaitable = fake_spawn
+    return host
+
+
+def _make_loop_with_llm_caller(host: FakeRouterHost, llm_caller) -> RouterLoop:
+    return RouterLoop(
+        host=host, chain_id="chain-spawn-ack-test",
+        max_iterations=5, llm_caller=llm_caller,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Directive constant shape
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_ack_tool_directive_is_non_empty_string():
+    """Tier 2: directive must be a non-empty string."""
+    assert isinstance(_SPAWN_ACK_TOOL_DIRECTIVE, str)
+    assert _SPAWN_ACK_TOOL_DIRECTIVE.strip()
+
+
+def test_spawn_ack_tool_directive_signals_spawn_context_and_h3_defense():
+    """Tier 2 (NF-W7-B43-2): the directive content must signal both the
+    spawn context (= "skill" / "spawned") AND the H3 hallucination
+    defense (= "do not include" + "skill output"). N=10 variant
+    ablation showed positive framing + skill-output exclusion is what
+    flips ACK rate from 0-10% to 70% while keeping HALLUCINATE at 0%.
+    """
+    directive = _SPAWN_ACK_TOOL_DIRECTIVE.lower()
+    assert "skill" in directive
+    assert "spawn" in directive or "running" in directive or "background" in directive
+    assert "do not include" in directive or "do not predict" in directive
+    assert "skill output" in directive or "the result" in directive
+
+
+def test_spawn_ack_tool_directive_distinct_from_outbox_message():
+    """Tier 2: directive is for LLM consumption in tool_result; it
+    differs from ``_SPAWN_ACK_MSG`` (= the user-visible deterministic
+    text used in the default outbox-push path). The two constants
+    must NOT alias to the same string — they live in different
+    channels with different audiences.
+    """
+    assert _SPAWN_ACK_TOOL_DIRECTIVE != _SPAWN_ACK_MSG["en"]
+    assert _SPAWN_ACK_TOOL_DIRECTIVE != _SPAWN_ACK_MSG["ja"]
+
+
+# ---------------------------------------------------------------------------
+# Env-gated behaviour: opt-in path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_ack_to_llm_env_on_continues_loop_with_directive(monkeypatch):
+    """Tier 2 (NF-W7-B43-2): when ``REYN_SPAWN_ACK_TO_LLM=1``, the
+    router does NOT push ``_SPAWN_ACK_MSG`` to outbox + does NOT
+    early-exit. Instead, the spawn-ack tool_result is annotated with
+    the directive and the loop continues to the next LLM call.
+
+    Pins:
+      - LLM called exactly TWICE (= round 1 spawn-ack + round 2
+        LLM-composed reply); default path would be 1 call.
+      - Outbox final message is the LLM-composed text (= "ack reply"
+        from round 2), NOT the OS-synthetic ``_SPAWN_ACK_MSG``.
+      - The ``meta.source`` on the outbox message is NOT "spawn_ack"
+        (= it's a regular LLM agent reply now).
+      - The round-2 LLM call's tool message includes
+        ``_SPAWN_ACK_TOOL_DIRECTIVE`` text in its content (= injected
+        via ``_post_text`` after the JSON body).
+    """
+    monkeypatch.setenv("REYN_SPAWN_ACK_TO_LLM", "1")
+    host = _make_spawn_ack_host()
+    rounds = [
+        tool_result([{"name": "invoke_skill", "args": {
+            "name": "some_skill",
+            "input": {"type": "test", "data": {}},
+        }}]),
+        text_result("Skill started; awaiting result."),
+    ]
+    spy = _MessageCapturingScripted(rounds)
+    loop = _make_loop_with_llm_caller(host, spy)
+
+    await loop.run("run skill", [])
+
+    assert spy.call_count == 2, (
+        f"Expected 2 LLM calls in opt-in path (round 1 spawn-ack + "
+        f"round 2 LLM-composed reply); got {spy.call_count}"
+    )
+    # Round-2 messages must contain the directive (appended via
+    # ``_post_text`` outside the tool result's JSON body).
+    round2_msgs = spy.messages_per_call[1]
+    tool_msgs = [m for m in round2_msgs if m.get("role") == "tool"]
+    assert tool_msgs, "round 2 must carry the spawn-ack tool_result"
+    tool_content = tool_msgs[0].get("content", "")
+    assert _SPAWN_ACK_TOOL_DIRECTIVE in tool_content, (
+        "tool_result content must include the directive via _post_text"
+    )
+    # Outbox: only the LLM-composed reply, no OS-synthetic spawn-ack.
+    assert len(host.outbox) == 1
+    out = host.outbox[0]
+    assert out["text"] == "Skill started; awaiting result."
+    assert out["meta"].get("source") != "spawn_ack"
+
+
+@pytest.mark.asyncio
+async def test_spawn_ack_to_llm_env_off_keeps_default_outbox_path(monkeypatch):
+    """Tier 2 (regression guard): without
+    ``REYN_SPAWN_ACK_TO_LLM=1``, the default behaviour runs — OS pushes
+    ``_SPAWN_ACK_MSG`` to outbox + early-exits. The LLM is called only
+    once (= round 1), no directive injection happens.
+    """
+    monkeypatch.delenv("REYN_SPAWN_ACK_TO_LLM", raising=False)
+    host = _make_spawn_ack_host()
+    rounds = [
+        tool_result([{"name": "invoke_skill", "args": {
+            "name": "some_skill",
+            "input": {"type": "test", "data": {}},
+        }}]),
+    ]
+    scripted = _ScriptedLLM(rounds)
+    loop = _make_loop_with_llm_caller(host, scripted)
+
+    await loop.run("run skill", [])
+
+    assert scripted.call_count == 1, (
+        f"Default path: exactly 1 LLM call (early-exit on spawn-ack); "
+        f"got {scripted.call_count}"
+    )
+    # Outbox holds the OS-synthetic spawn-ack with meta.source="spawn_ack"
+    assert len(host.outbox) == 1
+    out = host.outbox[0]
+    assert out["text"] == _SPAWN_ACK_MSG["en"]
+    assert out["meta"].get("source") == "spawn_ack"
+
+
+@pytest.mark.asyncio
+async def test_invoke_skill_spawn_ack_exit_event_fires_in_both_paths(monkeypatch):
+    """Tier 2 (P6 audit guard): the
+    ``invoke_skill_spawn_ack_exit`` event must fire regardless of
+    env var state. Audit trail is invariant across the path switch.
+    """
+    # Path 1: opt-in
+    monkeypatch.setenv("REYN_SPAWN_ACK_TO_LLM", "1")
+    host1 = _make_spawn_ack_host()
+    rounds1 = [
+        tool_result([{"name": "invoke_skill", "args": {
+            "name": "some_skill",
+            "input": {"type": "test", "data": {}},
+        }}]),
+        text_result("ack"),
+    ]
+    loop1 = _make_loop_with_llm_caller(host1, _ScriptedLLM(rounds1))
+    await loop1.run("run skill", [])
+    events1 = [e for e in host1._events.emitted if e["type"] == "invoke_skill_spawn_ack_exit"]
+    assert len(events1) == 1, "opt-in path must emit the audit event"
+
+    # Path 2: default
+    monkeypatch.delenv("REYN_SPAWN_ACK_TO_LLM", raising=False)
+    host2 = _make_spawn_ack_host()
+    rounds2 = [
+        tool_result([{"name": "invoke_skill", "args": {
+            "name": "some_skill",
+            "input": {"type": "test", "data": {}},
+        }}]),
+    ]
+    loop2 = _make_loop_with_llm_caller(host2, _ScriptedLLM(rounds2))
+    await loop2.run("run skill", [])
+    events2 = [e for e in host2._events.emitted if e["type"] == "invoke_skill_spawn_ack_exit"]
+    assert len(events2) == 1, "default path must also emit the audit event"
+
+
+@pytest.mark.asyncio
+async def test_spawn_ack_directive_not_injected_in_default_path(monkeypatch):
+    """Tier 2 (regression guard): default path does NOT inject the
+    directive into tool_result content. Without env opt-in, the
+    spawn-ack tool message stays in the original shape that
+    downstream OS / history persistence has always expected.
+    """
+    monkeypatch.delenv("REYN_SPAWN_ACK_TO_LLM", raising=False)
+    host = _make_spawn_ack_host()
+    rounds = [
+        tool_result([{"name": "invoke_skill", "args": {
+            "name": "some_skill",
+            "input": {"type": "test", "data": {}},
+        }}]),
+    ]
+    scripted = _ScriptedLLM(rounds)
+    loop = _make_loop_with_llm_caller(host, scripted)
+    await loop.run("run skill", [])
+
+    # Default path's only outbox message is OS-synthetic — directive
+    # text doesn't show up anywhere user-visible.
+    assert all(_SPAWN_ACK_TOOL_DIRECTIVE not in m["text"] for m in host.outbox)


### PR DESCRIPTION
**[dogfood-coder]** — fix B43-NF-W7-2 spawn-ack leak attractor. **ENV-var opt-in** (`REYN_SPAWN_ACK_TO_LLM=1`); default behaviour unchanged.

## Problem

B43 W7-S7 — multi-turn conversation accumulated 5 `_SPAWN_ACK_MSG` literals in the LLM's history assistant slot. Weak LLM (gemini-2.5-flash-lite) learned to echo that exact string as content reply (= **10/10 deterministic in N=10 trace-patch-replay**), masquerading as a real spawn-ack without actually spawning anything.

## Architectural framing

| | Reyn (pre-fix) | Competitors (Claude/GPT) |
|---|---|---|
| invoke_skill tool_call | router early-exits | router gets tool_result, LLM continues |
| spawn-ack | OS pushes synthetic text → outbox | LLM composes user-facing reply |

Reyn's unique pattern was introduced in B32 §4.2 to defend against the H3 hallucination race. The pattern worked but seeded the new attractor.

## Fix — ENV-gated alternative path

`REYN_SPAWN_ACK_TO_LLM=1` opts into the standard competitor pattern:
1. Router detects spawn-ack on tool_result
2. **Annotates tool_result with `_SPAWN_ACK_TOOL_DIRECTIVE` via `_post_text`** (= PR #221 mechanism)
3. **Continues the loop** (= no early-exit, no OS-synthetic outbox push)
4. LLM composes a short reply via the directive ("Skill started; awaiting result." style)

Directive preserves H3 hallucination defense through positive framing + explicit skill-output exclusion.

## Trace-patch-replay verification (5 variants, N=10)

| variant | ACK | EMPTY | HALLUCINATE |
|---|---|---|---|
| A bare status (no directive) | 1 | 8 | 0 |
| B negative directive | 0 | 10 | 0 |
| C strong negative | 0 | 10 | 0 |
| **D positive directive (chosen)** | **7** | 3 | **0** |
| E positive short | 4 | 6 | 0 |
| F bare + retry-only | 0 | 0 | **5 (race re-emerges)** |

**Key finding**: retry-only (Variant F) **re-introduces H3 hallucination at 5/10** because the retry directive ("address the user's question") is semantically detached from spawn context — LLM interprets as "answer the question yourself". Spawn-ack-specific directive in tool_result (Variant D) is necessary, not optional.

Residual 30% EMPTY on Variant D is naturally covered by PR #265 / PR #287's `REYN_EMPTY_STOP_RETRY=1` (= the two env vars compose).

## Test plan

- [x] 7 new Tier 2 tests pass (`test_router_loop_spawn_ack_to_llm.py`)
- [x] Wider regression 132/132 (plan / router_loop / planner / chat_router / spawn_ack)
- [x] Existing default-path tests pass unchanged (`test_router_loop_chatsession.py::test_user_message_invoke_skill_e2e`, `test_router_loop_spawn_ack_message.py`)
- [x] ruff clean
- [x] No `unittest.mock.patch` — uses `llm_caller=` injection seam + `pytest.monkeypatch` per testing.ja.md
- [x] P6 audit event `invoke_skill_spawn_ack_exit` fires in BOTH paths

## Composition with prior PRs

- PR #221 (`_post_text` mechanism): reused for directive injection
- PR #265 (planner empty-stop retry): covers residual EMPTY
- PR #287 (chat-router empty-stop retry): same retry path applies
- All share `REYN_*` env-var opt-in convention

## Related

- B43 retrospective PR #278 (merged): identified NF-W7-B43-2 as high-priority TBD
- B43-NF-W7-2 attractor analysis (= this session, 5-variant ablation)
- Anthropic `handling-stop-reasons` docs
- B32 W3 §4.2 H3 hallucination race (= original Reyn defense pattern motivation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)