### PR TITLE
OAuth device-grant UX P1: boxed user_code + expires_in + browser auto-open (#291)

### DIFF
--- a/src/reyn/cli/commands/auth.py
+++ b/src/reyn/cli/commands/auth.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
+import webbrowser
 from datetime import datetime
 
 
@@ -61,16 +63,100 @@ def _no_subcommand(args: argparse.Namespace) -> None:  # pragma: no cover
     sys.exit(1)
 
 
+def _box_user_code(code: str, *, indent: str = "     ") -> str:
+    """Render *code* inside a unicode box for visual emphasis.
+
+    Empty / missing codes degrade gracefully — the user still sees the
+    URL and a `(no user code)` placeholder so the auth flow surface
+    explains itself instead of dropping the line.
+    """
+    if not code:
+        return f"{indent}(no user code)"
+    inner = f"  {code}  "
+    border = "─" * len(inner)
+    return (
+        f"{indent}┌{border}┐\n"
+        f"{indent}│{inner}│\n"
+        f"{indent}└{border}┘"
+    )
+
+
+def _open_browser_or_skip(url: str) -> None:
+    """Offer to auto-open *url* in the user's browser.
+
+    Skips silently when:
+      - stdin is not a TTY (= pipe, script, CI run) so `input()` would
+        hang or raise EOFError.
+      - The ``REYN_AUTH_NO_BROWSER`` env var is set (= explicit opt-out
+        for users on remote shells / SSH without DISPLAY).
+
+    Otherwise prompts the user to press Enter, then calls
+    ``webbrowser.open()``. Browser-launch failures are swallowed —
+    the URL is already on screen so the manual fallback works.
+    KeyboardInterrupt during the Enter prompt propagates as cancel.
+    """
+    if not sys.stdin.isatty():
+        return
+    if os.environ.get("REYN_AUTH_NO_BROWSER"):
+        return
+    try:
+        print(
+            "Press Enter to open the URL in your browser (Ctrl+C to cancel)...",
+            end="",
+            file=sys.stderr,
+            flush=True,
+        )
+        input()
+    except EOFError:
+        return
+    try:
+        webbrowser.open(url)
+    except Exception:  # noqa: BLE001 — manual fallback URL is already printed
+        pass
+
+
 def _print_user_action(info: dict) -> None:
-    """Display the device code + verification URI for the user to act on."""
+    """Display the device code + verification URI for the user to act on.
+
+    Renders a 3-section layout:
+      1. The verification URL (preferring ``verification_uri_complete``
+         when the provider supplied one — that variant embeds the
+         user_code so a single click handles both steps).
+      2. The user_code in a unicode box (= phishing protection per RFC
+         8628 §3.3.1 still asks the user to verify the code matches
+         even when ``verification_uri_complete`` is used).
+      3. The deadline (= ``expires_in`` in minutes, when present) so
+         the user knows how long they have before the device code
+         expires server-side.
+
+    Falls through to ``_open_browser_or_skip`` which handles the
+    Enter-to-open prompt + TTY / env-var skips.
+    """
+    user_code = info.get("user_code", "")
+    verification_uri = info.get("verification_uri", "")
+    verification_uri_complete = info.get("verification_uri_complete")
+    expires_in = info.get("expires_in")
+    url_to_show = verification_uri_complete or verification_uri
+
     print(file=sys.stderr)
-    print("To authenticate, open this URL in your browser:", file=sys.stderr)
-    if info.get("verification_uri_complete"):
-        print(f"  {info['verification_uri_complete']}", file=sys.stderr)
-    else:
-        print(f"  {info['verification_uri']}", file=sys.stderr)
-        print(f"  and enter code: {info['user_code']}", file=sys.stderr)
+    print("To authenticate:", file=sys.stderr)
     print(file=sys.stderr)
+    print("  1. Open this URL in your browser:", file=sys.stderr)
+    print(f"     {url_to_show}", file=sys.stderr)
+    print(file=sys.stderr)
+    print("  2. Verify the code matches:", file=sys.stderr)
+    print(file=sys.stderr)
+    print(_box_user_code(user_code), file=sys.stderr)
+    print(file=sys.stderr)
+
+    if isinstance(expires_in, int) and expires_in > 0:
+        minutes = max(1, expires_in // 60)
+        unit = "minute" if minutes == 1 else "minutes"
+        print(f"  Code expires in {minutes} {unit}.", file=sys.stderr)
+        print(file=sys.stderr)
+
+    _open_browser_or_skip(url_to_show)
+
     print("Waiting for approval...", file=sys.stderr)
 
 

--- a/src/reyn/secrets/oauth.py
+++ b/src/reyn/secrets/oauth.py
@@ -659,9 +659,14 @@ async def device_grant_flow(
         expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
 
         # ── Step 2: notify user ──────────────────────────────────────────
+        # ``expires_in`` is surfaced so callers can show a deadline to the
+        # user (= avoids the "device code expired with no warning" UX
+        # failure mode). Existing consumers that only read ``user_code`` /
+        # ``verification_uri`` keep working — the new keys are additive.
         user_action_data: dict[str, Any] = {
             "user_code": user_code,
             "verification_uri": verification_uri,
+            "expires_in": expires_in,
         }
         if verification_uri_complete:
             user_action_data["verification_uri_complete"] = verification_uri_complete

--- a/tests/cli/test_auth_login_ux.py
+++ b/tests/cli/test_auth_login_ux.py
@@ -1,0 +1,269 @@
+"""Tier 2: `reyn auth login` device-grant UX surface (issue #291 Priority 1).
+
+Pins the new user-facing display contract for the RFC 8628 device grant
+flow's interactive step:
+
+  1. ``_box_user_code`` renders the user code inside a unicode box
+     (= visual emphasis, phishing-protection per RFC 8628 §3.3.1).
+  2. ``_print_user_action`` displays:
+       - the verification URL (prefers ``verification_uri_complete``)
+       - the boxed user_code
+       - the ``expires_in`` deadline (minutes)
+  3. ``_open_browser_or_skip`` opens the browser only when stdin is a
+     TTY and ``REYN_AUTH_NO_BROWSER`` is unset.
+
+Tests spy on ``webbrowser.open`` + ``input`` via direct attribute
+substitution (= no ``unittest.mock``; see ``docs/deep-dives/contributing/testing.ja.md``).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.cli.commands import auth as auth_mod
+
+# ── _box_user_code ──────────────────────────────────────────────────────────
+
+
+def test_box_user_code_renders_three_line_unicode_box() -> None:
+    """Tier 2: box has top border, code line, bottom border (= 3 lines)."""
+    out = auth_mod._box_user_code("ABCD-EFGH")
+    lines = out.splitlines()
+    assert len(lines) == 3
+    assert "┌" in lines[0] and "┐" in lines[0]
+    assert "ABCD-EFGH" in lines[1]
+    assert "└" in lines[2] and "┘" in lines[2]
+
+
+def test_box_user_code_border_width_matches_inner_width() -> None:
+    """Tier 2: border ── count equals the inner padded-code width.
+
+    A mismatch would visually skew the box. Tests use unicode line-
+    drawing chars so we count code points, not byte widths.
+    """
+    code = "ABCD-EFGH"
+    out = auth_mod._box_user_code(code)
+    top, mid, bot = out.splitlines()
+    # Strip the indent + corner chars to compare inner widths.
+    top_border = top.strip().strip("┌┐")
+    bot_border = bot.strip().strip("└┘")
+    mid_inner = mid.strip().strip("│")
+    assert len(top_border) == len(mid_inner)
+    assert len(bot_border) == len(mid_inner)
+
+
+def test_box_user_code_empty_falls_back_gracefully() -> None:
+    """Tier 2: empty/missing code → `(no user code)` placeholder, no crash."""
+    assert "(no user code)" in auth_mod._box_user_code("")
+
+
+# ── _print_user_action ──────────────────────────────────────────────────────
+
+
+def test_print_user_action_shows_boxed_code_and_url_and_deadline(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: stderr output contains URL, boxed code, and `Code expires in N minutes`."""
+    # Suppress the browser auto-open path (= we cover that in its own test).
+    monkeypatch.setattr(auth_mod, "_open_browser_or_skip", lambda _url: None)
+
+    info = {
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+        "expires_in": 1800,
+    }
+    auth_mod._print_user_action(info)
+
+    err = capsys.readouterr().err
+    assert "https://example.com/device" in err
+    assert "WDJB-MJHT" in err
+    assert "┌" in err and "└" in err  # box drawing present
+    assert "Code expires in 30 minutes" in err
+
+
+def test_print_user_action_prefers_verification_uri_complete(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: when ``verification_uri_complete`` is present, it is the
+    URL displayed (= single-click flow; the bare verification_uri is
+    redundant in that case)."""
+    monkeypatch.setattr(auth_mod, "_open_browser_or_skip", lambda _url: None)
+
+    info = {
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+        "verification_uri_complete": "https://example.com/device?user_code=WDJB-MJHT",
+        "expires_in": 600,
+    }
+    auth_mod._print_user_action(info)
+
+    err = capsys.readouterr().err
+    assert "https://example.com/device?user_code=WDJB-MJHT" in err
+
+
+def test_print_user_action_passes_chosen_url_to_browser_opener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the URL handed to ``_open_browser_or_skip`` matches the URL
+    rendered in the text (= preference for verification_uri_complete is
+    consistent across display + auto-open)."""
+    opened: list[str] = []
+
+    def _recorder(url: str) -> None:
+        opened.append(url)
+
+    monkeypatch.setattr(auth_mod, "_open_browser_or_skip", _recorder)
+
+    info = {
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+        "verification_uri_complete": "https://example.com/device?user_code=WDJB-MJHT",
+        "expires_in": 600,
+    }
+    auth_mod._print_user_action(info)
+
+    assert opened == ["https://example.com/device?user_code=WDJB-MJHT"]
+
+
+def test_print_user_action_omits_deadline_when_expires_in_missing(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: missing ``expires_in`` → no `Code expires in ...` line
+    (= back-compat for callers / tests on the old callback dict)."""
+    monkeypatch.setattr(auth_mod, "_open_browser_or_skip", lambda _url: None)
+
+    info = {
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+    }
+    auth_mod._print_user_action(info)
+
+    err = capsys.readouterr().err
+    assert "Code expires in" not in err
+
+
+# ── _open_browser_or_skip ───────────────────────────────────────────────────
+
+
+def test_open_browser_skips_when_stdin_not_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: non-TTY stdin (= pipe, script, CI) → no prompt, no open."""
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+
+    opened: list[str] = []
+    monkeypatch.setattr(
+        auth_mod.webbrowser, "open", lambda url: opened.append(url) or True,
+    )
+
+    auth_mod._open_browser_or_skip("https://example.com/device")
+    assert opened == []
+
+
+def test_open_browser_skips_when_env_var_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ``REYN_AUTH_NO_BROWSER`` set → user opt-out honoured."""
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    monkeypatch.setenv("REYN_AUTH_NO_BROWSER", "1")
+
+    opened: list[str] = []
+    monkeypatch.setattr(
+        auth_mod.webbrowser, "open", lambda url: opened.append(url) or True,
+    )
+
+    auth_mod._open_browser_or_skip("https://example.com/device")
+    assert opened == []
+
+
+def test_open_browser_invokes_webbrowser_open_on_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: TTY + no opt-out + Enter pressed → ``webbrowser.open(url)`` called."""
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    monkeypatch.delenv("REYN_AUTH_NO_BROWSER", raising=False)
+    # input() must return without blocking.
+    monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
+
+    opened: list[str] = []
+    monkeypatch.setattr(
+        auth_mod.webbrowser, "open", lambda url: opened.append(url) or True,
+    )
+
+    auth_mod._open_browser_or_skip("https://example.com/device")
+    assert opened == ["https://example.com/device"]
+
+
+def test_open_browser_eof_during_prompt_returns_silently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ``EOFError`` from input() (= stdin closed mid-prompt) → no
+    crash, no browser open (= manual fallback URL is already printed)."""
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    monkeypatch.delenv("REYN_AUTH_NO_BROWSER", raising=False)
+
+    def _eof_input(*_a, **_kw):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof_input)
+
+    opened: list[str] = []
+    monkeypatch.setattr(
+        auth_mod.webbrowser, "open", lambda url: opened.append(url) or True,
+    )
+
+    auth_mod._open_browser_or_skip("https://example.com/device")
+    assert opened == []
+
+
+def test_open_browser_swallows_webbrowser_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ``webbrowser.open`` raising → caller-visible no-op (URL was
+    already printed for manual fallback; UX must not crash on bad
+    headless env)."""
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    monkeypatch.delenv("REYN_AUTH_NO_BROWSER", raising=False)
+    monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
+
+    def _boom(_url: str) -> bool:
+        raise RuntimeError("no display")
+
+    monkeypatch.setattr(auth_mod.webbrowser, "open", _boom)
+
+    # No exception leaks.
+    auth_mod._open_browser_or_skip("https://example.com/device")


### PR DESCRIPTION
**[tui-coder]** — Closes Priority 1 of #291 (= 認可受け入れ UX hardening の ROI 高 3 項目).

## Summary

`reyn auth login <provider>` の device grant flow に対する user-facing 改善:

- ✅ **user_code を unicode box で強調表示** (= phishing protection per RFC 8628 §3.3.1; `verification_uri_complete` 使用時でも code を verify する step として明示)
- ✅ **`expires_in` 表示** (= 「N 分以内に承認してください」、 `Code expires in 30 minutes` 形式)
- ✅ **browser auto-open + `Press Enter to open` prompt** (= TTY 時のみ、 `REYN_AUTH_NO_BROWSER=1` opt-out + EOFError / webbrowser failure tolerant)

## Visual

Before:
```
To authenticate, open this URL in your browser:
  https://github.com/login/device?user_code=WDJB-MJHT

Waiting for approval...
```

After:
```
To authenticate:

  1. Open this URL in your browser:
     https://github.com/login/device?user_code=WDJB-MJHT

  2. Verify the code matches:

     ┌─────────────┐
     │  WDJB-MJHT  │
     └─────────────┘

  Code expires in 30 minutes.

Press Enter to open the URL in your browser (Ctrl+C to cancel)...
Waiting for approval...
```

## Changes

| file | change |
|---|---|
| `src/reyn/cli/commands/auth.py` | `_box_user_code` + `_open_browser_or_skip` 新規 / `_print_user_action` 書き直し |
| `src/reyn/secrets/auth.py` | `device_grant_flow` の `user_action_data` に `expires_in` 追加 (additive、 既存 consumer 影響なし) |
| `tests/cli/test_auth_login_ux.py` | 12 Tier 2 cases — box drawing / URL 優先 / 期限表示 / TTY skip / env-var opt-out / EOFError / webbrowser failure |

## Test plan

- [x] `python -m pytest tests/cli/test_auth_login_ux.py` — 12 passed (= 新規 Tier 2 surface 全 pin)
- [x] `python -m pytest tests/test_fp0016_c_device_grant.py tests/test_fp0016_c_auth_cli.py tests/test_fp0016_b_oauth_refresh.py` — 36 passed (= 既存 OAuth surface 無 regression)
- [x] `ruff check` — clean
- [x] Manual visual: `REYN_AUTH_NO_BROWSER=1 python -c "..."` で `verification_uri_complete` あり / なし 両方を確認 (= 上記 Before/After スクリーンショット相当)
- [x] (skipped — 実 OAuth provider 連携必要) `reyn auth login github` の実走 = リモート OAuth server を呼ぶので CI 内では実走不能。 `_print_user_action` は実 flow 内で呼ばれる関数を直接 unit test しているので等価カバレッジ。
- [x] (skipped — 実 OAuth provider 連携必要) browser auto-open の実 launch 確認 = `webbrowser.open()` を spy で代替、 `EOFError` / `RuntimeError` も recorder 経由で検証。

## Scope guard

**NOT in scope** (= Priority 2 / 3、 separate follow-up):
- spinner / dot animation during poll (= P2)
- `slow_down` user-visible feedback (= P2)
- `(Press Ctrl+C to cancel)` ヒントの Waiting 行統合 (= P2、 spinner と一緒に実装する方が自然)
- scope advertisement (= `Requesting scopes: ...` 事前表示、 P3)
- `OAuthRefreshError(re_auth_required=True)` の friendly surface 昇格 (= P3、 `get_valid_token` consumer 側 wire 後)
- `reyn auth list` の 3-state 化 (= P3)

## Calibration matrix self-check

| trigger | 適用 | 根拠 |
|---|---|---|
| 構造的 wiring (= callback contract additive change + browser opener helper) | Tier 2 同梱 ✅ | `device_grant_flow` の `user_action_data` extend + `_open_browser_or_skip` の TTY/env 分岐は permanent contract |
| spy 必要時 (= `webbrowser.open` / `input` / `sys.stdin`) | direct attribute substitution ✅ | `monkeypatch.setattr(auth_mod.webbrowser, "open", recorder)` で MagicMock 不使用 |
| `ruff check --fix` pre-push | ✅ 実走済 (= 同 PR 投入前に `ruff check` clean 確認) |

Pre-`gh pr create` checklist 4 items 全 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)