### PR TITLE
tool: dogfood batch dispatch + aggregate bundle — script-drives the dispatch + retrospective pipeline

### DIFF
--- a/scripts/dogfood_aggregate.py
+++ b/scripts/dogfood_aggregate.py
@@ -1,0 +1,280 @@
+"""Aggregate dogfood batch results — produce aggregate.json + a
+past-batch comparison table for the retrospective.md.
+
+Consumes the per-worker JSON files written under
+``<journal_dir>/workers/results-worker-{N}.json`` plus the past-batch
+aggregate.json files declared in the YAML batch config (see
+``dogfood_batch_config.py``). Emits:
+
+  - ``<journal_dir>/aggregate.json``: verdict_totals + per-worker
+    breakdown + delta_vs_<prev_batch> + env_settings, in the same
+    shape the existing B42 / B43 aggregates use.
+  - stdout markdown table: past-batch comparison (= the row a
+    retrospective.md typically opens with).
+
+Usage::
+
+    python scripts/dogfood_aggregate.py --config batch.yaml [--write]
+
+  Without ``--write``, the aggregate.json content is printed to stdout
+  as JSON (= dry-run). With ``--write``, it's persisted to the
+  journal_dir alongside the worker files.
+
+Tier 2 testing seam: ``load_worker_results``, ``compute_totals``,
+``build_aggregate``, and ``render_comparison_table`` are independent
+pure functions consumed by ``test_dogfood_aggregate.py``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from dogfood_batch_config import (  # noqa: E402
+    BatchConfig,
+    PastBatch,
+    load_batch_config,
+)
+
+
+def _normalise_verdicts(raw: dict[str, Any] | None) -> dict[str, int]:
+    """Worker JSONs use either ``verdicts`` (= V/I/R/B keys) or
+    ``counts`` (= same shape). Some B42 files spell out
+    ``verified``/``inconclusive``. Normalise to V/I/R/B integers."""
+    if raw is None:
+        return {"V": 0, "I": 0, "R": 0, "B": 0}
+    long_to_short = {
+        "verified": "V", "inconclusive": "I",
+        "refuted": "R", "blocked": "B",
+    }
+    out = {"V": 0, "I": 0, "R": 0, "B": 0}
+    for k, v in raw.items():
+        key = long_to_short.get(k, k.upper() if len(k) == 1 else k)
+        if key in out:
+            out[key] = int(v)
+    return out
+
+
+def load_worker_results(journal_dir: Path) -> dict[str, dict[str, Any]]:
+    """Read every ``results-worker-*.json`` under ``<journal>/workers/``
+    and return a dict mapping worker name (= e.g. ``"W1"``) to the
+    parsed JSON. Missing files surface a clean error so the user
+    knows which worker is incomplete."""
+    workers_dir = journal_dir / "workers"
+    if not workers_dir.is_dir():
+        raise FileNotFoundError(f"workers dir not found: {workers_dir}")
+    out: dict[str, dict[str, Any]] = {}
+    for p in sorted(workers_dir.glob("results-worker-*.json")):
+        stem = p.stem  # results-worker-1
+        try:
+            n = int(stem.rsplit("-", 1)[1])
+        except ValueError:
+            continue
+        try:
+            data = json.loads(p.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{p}: not valid JSON ({exc})") from exc
+        out[f"W{n}"] = data
+    if not out:
+        raise FileNotFoundError(
+            f"no results-worker-*.json files in {workers_dir}"
+        )
+    return out
+
+
+def compute_totals(
+    worker_results: dict[str, dict[str, Any]],
+) -> dict[str, int]:
+    """Sum the V/I/R/B verdict counts across all workers. Tolerates
+    the long-form (``verified`` etc.) and short-form (``V`` etc.) keys
+    that historic B42 / B43 results have used."""
+    totals = {"V": 0, "I": 0, "R": 0, "B": 0}
+    for w in worker_results.values():
+        raw = w.get("verdicts") or w.get("counts")
+        counts = _normalise_verdicts(raw)
+        for k in totals:
+            totals[k] += counts[k]
+    return totals
+
+
+def _past_totals(past: PastBatch) -> dict[str, int]:
+    path = Path(past.aggregate_path)
+    if not path.is_file():
+        return {"V": 0, "I": 0, "R": 0, "B": 0}
+    data = json.loads(path.read_text())
+    return _normalise_verdicts(data.get("verdict_totals"))
+
+
+def build_aggregate(
+    config: BatchConfig,
+    worker_results: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Construct the aggregate.json dict.
+
+    Includes verdict_totals + per-worker breakdown + env_settings +
+    delta_vs_<each past batch>. Matches the shape established by B42
+    / B43 aggregate.json so downstream consumers (= retrospective.md
+    rendering, batch_dispatch citing past verdicts) keep working.
+    """
+    totals = compute_totals(worker_results)
+    n_total = sum(totals.values())
+    workers_section: dict[str, Any] = {}
+    for w_spec in config.workers:
+        wr = worker_results.get(w_spec.name)
+        if wr is None:
+            workers_section[w_spec.name] = {
+                "scenarios": w_spec.n_scenarios,
+                "missing": True,
+            }
+            continue
+        counts = _normalise_verdicts(wr.get("verdicts") or wr.get("counts"))
+        workers_section[w_spec.name] = {
+            "scenarios": w_spec.n_scenarios,
+            "v": counts["V"], "i": counts["I"],
+            "r": counts["R"], "b": counts["B"],
+            "scenario_set": w_spec.scenario_set,
+        }
+    delta: dict[str, dict[str, Any]] = {}
+    for pb in config.past_batches:
+        pt = _past_totals(pb)
+        delta[f"delta_vs_{pb.name.lower()}"] = {
+            f"{pb.name.lower()}_v": pt["V"],
+            f"{config.batch.name.lower()}_v": totals["V"],
+            "delta_v": totals["V"] - pt["V"],
+        }
+    return {
+        "batch": config.batch.name,
+        "date": config.batch.date,
+        "head_at_dispatch": config.batch.head,
+        "scenarios_total": n_total,
+        "verdict_totals": {
+            "verified": totals["V"],
+            "inconclusive": totals["I"],
+            "refuted": totals["R"],
+            "blocked": totals["B"],
+        },
+        "verified_rate": round(totals["V"] / n_total, 3) if n_total else 0.0,
+        "env_settings": {
+            **{k: v for k, v in config.batch.env_vars.items()},
+            **{f"user_param_{k}": v for k, v in config.batch.user_params.items()},
+        },
+        **delta,
+        "workers": workers_section,
+    }
+
+
+def render_comparison_table(
+    config: BatchConfig,
+    aggregate: dict[str, Any],
+) -> str:
+    """Markdown comparison table the retrospective.md typically opens
+    with — one row per worker, columns for each past batch's V count
+    plus the new batch's V count + ΔvsPrev.
+    """
+    # Header
+    past_names = [pb.name for pb in config.past_batches]
+    headers = ["Worker", "Scenario set"]
+    headers.extend(f"{n} V" for n in past_names)
+    headers.append(f"{config.batch.name} V")
+    if past_names:
+        headers.append(f"Δvs{past_names[0]}")
+
+    # Width sizing
+    widths = [len(h) for h in headers]
+
+    rows: list[list[str]] = []
+    for w_spec in config.workers:
+        ws = aggregate["workers"].get(w_spec.name, {})
+        v_now = ws.get("v", 0)
+        n_total = ws.get("scenarios", w_spec.n_scenarios)
+        row = [w_spec.name, w_spec.scenario_set]
+        # Past-batch V counts for this worker
+        prev_v: int | None = None
+        for pb in config.past_batches:
+            pt = _past_verdicts_for_worker(pb, w_spec.name)
+            if pt is None:
+                row.append("?")
+                continue
+            row.append(f"{pt['V']}/{pt['total']}")
+            if prev_v is None:
+                prev_v = pt["V"]
+        row.append(f"{v_now}/{n_total}")
+        if past_names:
+            if prev_v is not None:
+                delta_v = v_now - prev_v
+                row.append(("+" if delta_v >= 0 else "") + str(delta_v))
+            else:
+                row.append("?")
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+        rows.append(row)
+
+    sep_line = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
+    header_line = "| " + " | ".join(
+        h.ljust(widths[i]) for i, h in enumerate(headers)
+    ) + " |"
+    row_lines = [
+        "| " + " | ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)) + " |"
+        for row in rows
+    ]
+    return "\n".join([header_line, sep_line, *row_lines])
+
+
+def _past_verdicts_for_worker(pb: PastBatch, worker_name: str) -> dict[str, int] | None:
+    """Extract V + scenarios total for the named worker from a past
+    batch's aggregate.json. Returns None if the past file doesn't have
+    the worker (= e.g. scenario set changed between batches)."""
+    path = Path(pb.aggregate_path)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except Exception:  # noqa: BLE001
+        return None
+    workers = data.get("workers") or {}
+    for key, val in workers.items():
+        if key.startswith(worker_name + "_") or key == worker_name:
+            return {
+                "V": int(val.get("v") or val.get("V") or 0),
+                "total": int(val.get("scenarios") or 0),
+            }
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--config", required=True, type=Path,
+        help="YAML batch config (see dogfood_batch_config.py).",
+    )
+    p.add_argument(
+        "--write", action="store_true",
+        help="Persist aggregate.json to journal_dir. Without it, "
+        "the aggregate JSON is printed to stdout.",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_batch_config(args.config)
+    journal = Path(config.journal_dir)
+    worker_results = load_worker_results(journal)
+    aggregate = build_aggregate(config, worker_results)
+    if args.write:
+        out_path = journal / "aggregate.json"
+        out_path.write_text(json.dumps(aggregate, indent=2, ensure_ascii=False) + "\n")
+        print(f"[aggregate] wrote {out_path}", file=sys.stderr)
+    else:
+        print(json.dumps(aggregate, indent=2, ensure_ascii=False))
+    print("\n--- Comparison table ---\n", file=sys.stderr)
+    print(render_comparison_table(config, aggregate))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dogfood_batch_config.py
+++ b/scripts/dogfood_batch_config.py
@@ -1,0 +1,139 @@
+"""Shared types + YAML loader for dogfood batch tools.
+
+``dogfood_batch_dispatch.py`` and ``dogfood_aggregate.py`` both consume
+the same YAML batch config — this module defines the schema and the
+load path once so the two tools stay consistent.
+
+Config shape (YAML)::
+
+    batch:
+      name: B44
+      date: 2026-05-21
+      head: e96d479f
+      env_vars:
+        REYN_EMPTY_STOP_RETRY: "1"
+      user_params:
+        hot_list_n: 10
+        models_tier: flash-lite
+      hard_caps:
+        tool_uses: 50
+        wall_clock_min: 15
+
+    workers:
+      - name: W1
+        scenario_set: chat_router_smoke.yaml
+        scenario_set_path: dogfood/scenarios/chat_router_smoke.yaml
+        port: 8231
+        n_scenarios: 7
+        worktree: /tmp/reyn-worktrees/b44-1
+        agent_prefix: dogfood-b44-1-s
+      ...
+
+    past_batches:
+      - name: B43
+        aggregate_path: docs/deep-dives/journal/dogfood/2026-05-20-batch-43-post-empty-stop-retry/aggregate.json
+      - name: B42
+        aggregate_path: docs/deep-dives/journal/dogfood/2026-05-19-batch-42-b40-v2-cumulative/aggregate.json
+
+    journal_dir: docs/deep-dives/journal/dogfood/2026-05-21-batch-44-...
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class BatchMeta:
+    name: str
+    date: str
+    head: str
+    env_vars: dict[str, str] = field(default_factory=dict)
+    user_params: dict[str, Any] = field(default_factory=dict)
+    hard_caps: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorkerSpec:
+    name: str
+    scenario_set: str
+    scenario_set_path: str
+    port: int
+    n_scenarios: int
+    worktree: str
+    agent_prefix: str
+
+
+@dataclass(frozen=True)
+class PastBatch:
+    name: str
+    aggregate_path: str
+
+
+@dataclass(frozen=True)
+class BatchConfig:
+    batch: BatchMeta
+    workers: tuple[WorkerSpec, ...]
+    past_batches: tuple[PastBatch, ...]
+    journal_dir: str
+
+
+def load_batch_config(path: Path) -> BatchConfig:
+    """Parse the YAML config into a typed BatchConfig.
+
+    Validates required keys at every level. ValueError on missing fields
+    so the caller sees a clean error instead of a downstream KeyError.
+    """
+    raw = yaml.safe_load(path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"config root must be a mapping; got {type(raw).__name__}")
+    for top_key in ("batch", "workers", "past_batches", "journal_dir"):
+        if top_key not in raw:
+            raise ValueError(f"config missing required top-level key: {top_key!r}")
+
+    batch_raw = raw["batch"]
+    for key in ("name", "date", "head"):
+        if key not in batch_raw:
+            raise ValueError(f"batch.{key} is required")
+    batch = BatchMeta(
+        name=batch_raw["name"],
+        date=batch_raw["date"],
+        head=batch_raw["head"],
+        env_vars=dict(batch_raw.get("env_vars") or {}),
+        user_params=dict(batch_raw.get("user_params") or {}),
+        hard_caps=dict(batch_raw.get("hard_caps") or {}),
+    )
+
+    workers_raw = raw["workers"]
+    if not workers_raw:
+        raise ValueError("workers must be non-empty")
+    workers: list[WorkerSpec] = []
+    for i, w in enumerate(workers_raw):
+        for key in ("name", "scenario_set", "scenario_set_path", "port",
+                    "n_scenarios", "worktree", "agent_prefix"):
+            if key not in w:
+                raise ValueError(f"workers[{i}].{key} is required")
+        workers.append(WorkerSpec(
+            name=w["name"],
+            scenario_set=w["scenario_set"],
+            scenario_set_path=w["scenario_set_path"],
+            port=int(w["port"]),
+            n_scenarios=int(w["n_scenarios"]),
+            worktree=w["worktree"],
+            agent_prefix=w["agent_prefix"],
+        ))
+
+    past_batches = tuple(
+        PastBatch(name=p["name"], aggregate_path=p["aggregate_path"])
+        for p in (raw.get("past_batches") or [])
+    )
+
+    return BatchConfig(
+        batch=batch,
+        workers=tuple(workers),
+        past_batches=past_batches,
+        journal_dir=raw["journal_dir"],
+    )

--- a/scripts/dogfood_batch_dispatch.py
+++ b/scripts/dogfood_batch_dispatch.py
@@ -1,0 +1,259 @@
+"""Worker prompt generator + worktree setup for dogfood batch dispatch.
+
+Reads a YAML batch config (see ``dogfood_batch_config.py``) and emits:
+  - one markdown worker prompt per worker (= the same shape past
+    sandbox_2 sessions hand-rolled in chat at dispatch time);
+  - prepares git worktrees + reyn.local.yaml under each worker's
+    ``worktree`` path (= ready for ``reyn web`` start).
+
+Usage::
+
+    python scripts/dogfood_batch_dispatch.py --config batch.yaml [--prompts-dir <dir>]
+
+  Without ``--prompts-dir`` the prompts are printed to stdout (one per
+  worker, separated by ``--- WORKER N ---`` markers). With the flag,
+  one file per worker is written to that directory.
+
+Worktree + reyn.local.yaml setup is OPT-IN via ``--setup-worktrees``:
+  - Without the flag, the script only emits prompts (= dry run, no
+    filesystem mutation outside the prompts dir).
+  - With the flag, git worktrees are created at the configured paths +
+    reyn.local.yaml copied from the repo root + ``models.strong``
+    forced to flash-lite (= feedback_no_strong_model compliance).
+
+Per-batch past-batch verdict citation: the prompts include the
+worker's prior verdicts pulled from the most recent ``past_batches``
+entry (= the one listed FIRST in the config). This eliminates the
+manual paste step that previously took ~10-15 min per batch dispatch.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# scripts/ is on the script's path naturally; this import works for
+# both ``python scripts/dogfood_batch_dispatch.py`` invocation styles.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from dogfood_batch_config import (  # noqa: E402
+    BatchConfig,
+    WorkerSpec,
+    load_batch_config,
+)
+
+
+def _past_verdicts_for_worker(
+    config: BatchConfig, worker_name: str,
+) -> dict[str, dict[str, int]]:
+    """Pull per-batch verdicts for ``worker_name`` from each past batch's
+    aggregate.json. Skip past batches that don't have the worker listed.
+
+    Returns a dict mapping past-batch name → {V, I, R, B} counts.
+    """
+    out: dict[str, dict[str, int]] = {}
+    for pb in config.past_batches:
+        path = Path(pb.aggregate_path)
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except Exception:  # noqa: BLE001
+            continue
+        workers = data.get("workers") or {}
+        # past aggregate keys typically look like "W1_chat_router_smoke";
+        # match by the leading "W<n>" prefix to tolerate the suffix.
+        match = None
+        for key, val in workers.items():
+            if key.startswith(worker_name + "_") or key == worker_name:
+                match = val
+                break
+        if match is None:
+            continue
+        out[pb.name] = {
+            "V": int(match.get("v") or match.get("V") or 0),
+            "I": int(match.get("i") or match.get("I") or 0),
+            "R": int(match.get("r") or match.get("R") or 0),
+            "B": int(match.get("b") or match.get("B") or 0),
+        }
+    return out
+
+
+def render_worker_prompt(config: BatchConfig, worker: WorkerSpec) -> str:
+    """Compose the markdown worker prompt.
+
+    Matches the structure the sandbox_2 session has been hand-rolling
+    for B42 / B43: setup commands, run instructions, past-batch
+    verdict citation, deliverable spec, hard caps.
+    """
+    env_block = " ".join(
+        f"{k}={v!s}" for k, v in sorted(config.batch.env_vars.items())
+    )
+    past_table = _past_verdicts_for_worker(config, worker.name)
+    if past_table:
+        past_rows = "\n".join(
+            f"| {pb_name} | {counts['V']}/{worker.n_scenarios} | "
+            f"{counts['I']} | {counts['R']} | {counts['B']} |"
+            for pb_name, counts in past_table.items()
+        )
+        past_section = (
+            "## Past-batch verdicts (= primary data, cite verbatim)\n\n"
+            "| Batch | V | I | R | B |\n"
+            "|-------|---|---|---|---|\n"
+            f"{past_rows}\n"
+        )
+    else:
+        past_section = (
+            "## Past-batch verdicts\n\n"
+            "(no past batches found in config for this worker)\n"
+        )
+    tool_uses_cap = config.batch.hard_caps.get("tool_uses", 50)
+    wall_cap = config.batch.hard_caps.get("wall_clock_min", 15)
+    deliverable_path = (
+        f"{config.journal_dir}/workers/results-worker-"
+        f"{worker.name.lstrip('W')}.json"
+    )
+
+    return f"""{config.batch.name} worker {worker.name} — run `{worker.scenario_set_path}` ({worker.n_scenarios} scenarios), emit results JSON.
+
+## Setup
+
+```bash
+cd {worker.worktree}
+rm -rf .reyn/agents .reyn/state .reyn/events .reyn/action_index .reyn/llm_trace.jsonl 2>/dev/null
+{env_block} \\
+  REYN_LLM_TRACE_DUMP=$(pwd)/.reyn/llm_trace.jsonl \\
+  nohup /Users/yasudatetsuya/Workspace/junk/claude_sandbox/sandbox_2/venv/bin/reyn web \\
+    --port {worker.port} --log-level warning > /tmp/b{config.batch.name.lstrip('B')}-{worker.name.lstrip('W')}-server.log 2>&1 &
+sleep 4
+curl -s -o /dev/null -w "%{{http_code}}\\n" http://localhost:{worker.port}/health  # must be 200
+```
+
+## Run scenarios
+
+For each of the {worker.n_scenarios} scenarios in `{worker.scenario_set_path}`:
+1. Create a fresh agent: `reyn agent new {worker.agent_prefix}<i>` (i=1..{worker.n_scenarios})
+2. POST the scenario's user prompt to `http://localhost:{worker.port}/a2a/agents/{worker.agent_prefix}<i>` (JSON-RPC `message/send`)
+3. Capture reply text + http_status + events.jsonl path
+
+## Verdict rules
+
+- **V (verified)**: rubric items all met + events_pass=true
+- **I (inconclusive)**: rubric partial OR skill failed for env reason (allow-unsafe-python etc.)
+- **R (refuted)**: rubric not met
+- **B (blocked)**: scenario didn't run end-to-end
+
+{past_section}
+
+## User params (= hold constant for apples-to-apples)
+
+{json.dumps(config.batch.user_params, indent=2)}
+
+## Deliverable
+
+Write `{deliverable_path}` with this shape:
+
+```json
+{{
+  "batch": "{config.batch.name}", "worker": {worker.name.lstrip('W')},
+  "head": "{config.batch.head}", "date": "{config.batch.date}",
+  "scenario_set": "{worker.scenario_set}",
+  "env_vars": {json.dumps(config.batch.env_vars)},
+  "user_params": {json.dumps(config.batch.user_params)},
+  "verdicts": {{"V": ?, "I": ?, "R": ?, "B": ?}},
+  "vs_past": {{...}},
+  "scenarios": [{{...}}, ...],
+  "new_findings": [...]
+}}
+```
+
+## Hard caps (= feedback_subagent_scope_bounding)
+
+- **≤{tool_uses_cap} tool uses**
+- **≤{wall_cap} min wall-clock**
+- 1 deliverable: results-worker-{worker.name.lstrip('W')}.json
+- NO findings.md, NO retrospective (= main agent aggregates)
+- NO strong model use (= verify reyn.local.yaml strong=flash-lite)
+
+When done, report in <100 words: V/I/R/B counts + 1-line per-scenario verdict + 1-line vs-past delta. Then STOP.
+"""
+
+
+def setup_worktree(worker: WorkerSpec, head: str, repo_root: Path) -> None:
+    """Create the git worktree at the configured path and prep
+    reyn.local.yaml with flash-lite-only tiers.
+
+    Idempotent: if the worktree already exists, leaves it in place
+    (= caller can re-run dispatch without re-cloning).
+    """
+    wt = Path(worker.worktree)
+    if not wt.is_dir():
+        subprocess.run(
+            ["git", "worktree", "add", str(wt), head],
+            cwd=repo_root, check=True,
+        )
+    # Copy reyn.local.yaml + force flash-lite on all tiers
+    src = repo_root / "reyn.local.yaml"
+    if not src.is_file():
+        return  # nothing to copy
+    dst = wt / "reyn.local.yaml"
+    shutil.copy(src, dst)
+    text = dst.read_text()
+    # Force strong tier to flash-lite (= feedback_no_strong_model)
+    text = text.replace(
+        "strong:   openai/gemini-2.5-flash\n",
+        "strong:   openai/gemini-2.5-flash-lite\n",
+    )
+    dst.write_text(text)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--config", required=True, type=Path,
+        help="YAML batch config (see dogfood_batch_config.py).",
+    )
+    p.add_argument(
+        "--prompts-dir", type=Path, default=None,
+        help="Write one prompt file per worker into this directory. "
+        "Without it, prompts print to stdout.",
+    )
+    p.add_argument(
+        "--setup-worktrees", action="store_true",
+        help="Create git worktrees + copy reyn.local.yaml. Without "
+        "this flag the script is dry-run (= prompts only).",
+    )
+    p.add_argument(
+        "--repo-root", type=Path, default=Path.cwd(),
+        help="Repo root for worktree creation (default: cwd).",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_batch_config(args.config)
+    if args.setup_worktrees:
+        for w in config.workers:
+            setup_worktree(w, config.batch.head, args.repo_root)
+            print(f"[setup] worktree ready: {w.worktree}", file=sys.stderr)
+    if args.prompts_dir:
+        args.prompts_dir.mkdir(parents=True, exist_ok=True)
+        for w in config.workers:
+            prompt = render_worker_prompt(config, w)
+            (args.prompts_dir / f"worker-{w.name}.md").write_text(prompt)
+            print(f"[prompt] {w.name} → {args.prompts_dir}/worker-{w.name}.md",
+                  file=sys.stderr)
+    else:
+        for w in config.workers:
+            print(f"--- WORKER {w.name} ---")
+            print(render_worker_prompt(config, w))
+            print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dogfood_batch_tools.py
+++ b/tests/test_dogfood_batch_tools.py
@@ -1,0 +1,311 @@
+"""Tier 2: dogfood_batch_dispatch + dogfood_aggregate.
+
+Pinned invariants for the (1)+(2) bundle:
+
+- ``load_batch_config`` parses the full YAML schema, validates
+  required keys, defaults ``parallel`` etc.
+- ``render_worker_prompt`` produces a non-empty markdown body that
+  includes the worker's port, scenario set path, env_vars, user_params,
+  past-batch verdict table, hard caps, and deliverable path.
+- ``load_worker_results`` reads all ``results-worker-*.json`` under a
+  journal dir + returns them keyed by worker name (W1, W2, ...).
+- ``compute_totals`` normalises long-form (``verified``) AND short-form
+  (``V``) verdict counts (= historic B42 used long, B43 short).
+- ``build_aggregate`` produces the expected aggregate.json shape with
+  verdict_totals + per-worker breakdown + env_settings + delta_vs_<prev>.
+
+End-to-end smoke: the script also verifies build_aggregate against the
+real B43 journal in the repo (= scenarios_total=54, verified=22 per
+PR #278). That regression guard ensures the tools agree with the
+existing batch retrospectives.
+
+testing.ja.md compliance: no ``unittest.mock.patch``; uses real
+filesystem fixtures via tmp_path + reads the committed B43 journal.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from dogfood_aggregate import (  # noqa: E402
+    _normalise_verdicts,
+    build_aggregate,
+    compute_totals,
+    load_worker_results,
+)
+from dogfood_batch_config import load_batch_config  # noqa: E402
+from dogfood_batch_dispatch import render_worker_prompt  # noqa: E402
+
+REPO_ROOT = Path(__file__).parent.parent
+B43_JOURNAL = (
+    REPO_ROOT
+    / "docs/deep-dives/journal/dogfood/2026-05-20-batch-43-post-empty-stop-retry"
+)
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "batch.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _minimal_config_yaml(tmp_path: Path, journal_dir: Path) -> str:
+    return f"""
+batch:
+  name: B99
+  date: 2026-06-01
+  head: deadbeef
+  env_vars:
+    REYN_EMPTY_STOP_RETRY: "1"
+  user_params:
+    hot_list_n: 10
+  hard_caps:
+    tool_uses: 50
+    wall_clock_min: 15
+
+workers:
+  - name: W1
+    scenario_set: smoke.yaml
+    scenario_set_path: dogfood/scenarios/smoke.yaml
+    port: 8231
+    n_scenarios: 7
+    worktree: /tmp/reyn-worktrees/b99-1
+    agent_prefix: dogfood-b99-1-s
+
+past_batches:
+  - name: B43
+    aggregate_path: {B43_JOURNAL / "aggregate.json"}
+
+journal_dir: {journal_dir}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Config parsing (shared by both tools)
+# ---------------------------------------------------------------------------
+
+
+def test_load_batch_config_round_trips_required_fields(tmp_path):
+    """Tier 2: well-formed config parses without loss."""
+    cfg_path = _write_config(
+        tmp_path, _minimal_config_yaml(tmp_path, tmp_path / "journal"),
+    )
+    cfg = load_batch_config(cfg_path)
+    assert cfg.batch.name == "B99"
+    assert cfg.batch.head == "deadbeef"
+    assert cfg.batch.env_vars["REYN_EMPTY_STOP_RETRY"] == "1"
+    assert cfg.workers[0].name == "W1"
+    assert cfg.workers[0].port == 8231
+    assert cfg.workers[0].n_scenarios == 7
+    assert cfg.past_batches[0].name == "B43"
+
+
+def test_load_batch_config_rejects_missing_required_key(tmp_path):
+    cfg_path = _write_config(tmp_path, """
+batch:
+  date: 2026-06-01
+  head: x
+workers:
+  - {name: W1, scenario_set: s, scenario_set_path: p, port: 1,
+     n_scenarios: 1, worktree: /tmp/x, agent_prefix: y}
+past_batches: []
+journal_dir: /tmp/j
+""")  # missing batch.name
+    with pytest.raises(ValueError, match="batch.name"):
+        load_batch_config(cfg_path)
+
+
+def test_load_batch_config_rejects_empty_workers(tmp_path):
+    cfg_path = _write_config(tmp_path, """
+batch: {name: B, date: d, head: h}
+workers: []
+past_batches: []
+journal_dir: /tmp/j
+""")
+    with pytest.raises(ValueError, match="workers"):
+        load_batch_config(cfg_path)
+
+
+# ---------------------------------------------------------------------------
+# Verdict normalisation (= historic B42 long-form vs B43 short-form)
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_verdicts_handles_short_form_v_i_r_b():
+    out = _normalise_verdicts({"V": 5, "I": 2, "R": 3, "B": 1})
+    assert out == {"V": 5, "I": 2, "R": 3, "B": 1}
+
+
+def test_normalise_verdicts_handles_long_form_verified_etc():
+    out = _normalise_verdicts(
+        {"verified": 7, "inconclusive": 1, "refuted": 2, "blocked": 0},
+    )
+    assert out == {"V": 7, "I": 1, "R": 2, "B": 0}
+
+
+def test_normalise_verdicts_treats_missing_as_zero():
+    assert _normalise_verdicts({}) == {"V": 0, "I": 0, "R": 0, "B": 0}
+    assert _normalise_verdicts(None) == {"V": 0, "I": 0, "R": 0, "B": 0}
+
+
+# ---------------------------------------------------------------------------
+# Worker result loading + totals
+# ---------------------------------------------------------------------------
+
+
+def test_load_worker_results_reads_existing_b43_journal():
+    """Tier 2 (regression guard against committed data): the real B43
+    journal in this repo loads to 7 workers (= W1..W7).
+    """
+    results = load_worker_results(B43_JOURNAL)
+    assert set(results.keys()) == {f"W{i}" for i in range(1, 8)}
+
+
+def test_compute_totals_matches_b43_published_aggregate():
+    """Tier 2: aggregating the real B43 worker files reproduces the
+    same V=22 / I=12 / R=20 / B=0 totals the published B43
+    aggregate.json (= PR #278) declares. Detects future drift if
+    someone edits either side without updating the other.
+    """
+    results = load_worker_results(B43_JOURNAL)
+    totals = compute_totals(results)
+    assert totals == {"V": 22, "I": 12, "R": 20, "B": 0}
+
+
+def test_load_worker_results_raises_on_missing_dir(tmp_path):
+    """Tier 2: missing workers/ dir → clean FileNotFoundError instead
+    of a downstream parse-related exception that masks the real
+    cause."""
+    with pytest.raises(FileNotFoundError, match="workers"):
+        load_worker_results(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Aggregate construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_aggregate_against_b43_real_journal(tmp_path):
+    """Tier 2 end-to-end: feed the real B43 journal into the new tool
+    + verify the output aggregate.json has the same headline numbers
+    as the published one (V=22, rate≈0.407, B=0). Detects any future
+    semantic drift in the aggregate shape.
+    """
+    cfg_yaml = f"""
+batch:
+  name: B43_repro
+  date: 2026-05-20
+  head: e96d479f
+  env_vars:
+    REYN_EMPTY_STOP_RETRY: "1"
+  user_params:
+    hot_list_n: 10
+
+workers:
+  - {{name: W1, scenario_set: chat_router_smoke.yaml,
+     scenario_set_path: dogfood/scenarios/chat_router_smoke.yaml,
+     port: 8231, n_scenarios: 7,
+     worktree: /tmp/reyn-worktrees/b43-1, agent_prefix: dogfood-b43-1-s}}
+  - {{name: W2, scenario_set: stdlib_skills_core.yaml,
+     scenario_set_path: dogfood/scenarios/stdlib_skills_core.yaml,
+     port: 8232, n_scenarios: 9,
+     worktree: /tmp/reyn-worktrees/b43-2, agent_prefix: dogfood-b43-2-s}}
+  - {{name: W3, scenario_set: control_ir_ops.yaml,
+     scenario_set_path: dogfood/scenarios/control_ir_ops.yaml,
+     port: 8233, n_scenarios: 9,
+     worktree: /tmp/reyn-worktrees/b43-3, agent_prefix: dogfood-b43-3-s}}
+  - {{name: W4, scenario_set: permissions_and_safety.yaml,
+     scenario_set_path: dogfood/scenarios/permissions_and_safety.yaml,
+     port: 8234, n_scenarios: 8,
+     worktree: /tmp/reyn-worktrees/b43-4, agent_prefix: dogfood-b43-4-s}}
+  - {{name: W5, scenario_set: multi_agent_and_mcp,
+     scenario_set_path: dogfood/scenarios/multi_agent_and_mcp.yaml,
+     port: 8235, n_scenarios: 7,
+     worktree: /tmp/reyn-worktrees/b43-5, agent_prefix: dogfood-b43-5-s}}
+  - {{name: W6, scenario_set: plan_mode_fp_0011_mixed,
+     scenario_set_path: dogfood/scenarios/plan_mode.yaml,
+     port: 8236, n_scenarios: 7,
+     worktree: /tmp/reyn-worktrees/b43-6, agent_prefix: dogfood-b43-6-s}}
+  - {{name: W7, scenario_set: long_session_v1.yaml,
+     scenario_set_path: dogfood/scenarios/long_session_v1.yaml,
+     port: 8237, n_scenarios: 7,
+     worktree: /tmp/reyn-worktrees/b43-7, agent_prefix: dogfood-b43-7-s}}
+
+past_batches: []
+journal_dir: {B43_JOURNAL}
+"""
+    cfg_path = _write_config(tmp_path, cfg_yaml)
+    config = load_batch_config(cfg_path)
+    results = load_worker_results(Path(config.journal_dir))
+    aggregate = build_aggregate(config, results)
+    assert aggregate["scenarios_total"] == 54
+    assert aggregate["verdict_totals"]["verified"] == 22
+    assert aggregate["verdict_totals"]["blocked"] == 0
+    assert round(aggregate["verified_rate"], 3) == round(22 / 54, 3)
+
+
+# ---------------------------------------------------------------------------
+# Worker prompt rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_worker_prompt_includes_port_and_paths(tmp_path):
+    """Tier 2: rendered prompt contains the worker's port, scenario
+    set path, deliverable path. These are the load-bearing fields the
+    sub-agent reads to execute the dispatch."""
+    cfg_path = _write_config(
+        tmp_path, _minimal_config_yaml(tmp_path, tmp_path / "journal"),
+    )
+    config = load_batch_config(cfg_path)
+    prompt = render_worker_prompt(config, config.workers[0])
+    assert "8231" in prompt
+    assert "dogfood/scenarios/smoke.yaml" in prompt
+    assert "results-worker-1.json" in prompt
+    assert "B99" in prompt
+
+
+def test_render_worker_prompt_cites_past_verdicts(tmp_path):
+    """Tier 2: the prompt includes past-batch verdicts pulled from the
+    referenced aggregate.json. This is the manual citation step the
+    tool eliminates — the source must be the file, not a hardcoded
+    string."""
+    cfg_path = _write_config(
+        tmp_path, _minimal_config_yaml(tmp_path, tmp_path / "journal"),
+    )
+    config = load_batch_config(cfg_path)
+    prompt = render_worker_prompt(config, config.workers[0])
+    # B43 W1 had V=3 per the published aggregate; the prompt should cite it
+    assert "B43" in prompt
+    assert "3" in prompt  # the V count for W1 in B43
+
+
+def test_render_worker_prompt_includes_hard_caps(tmp_path):
+    """Tier 2: hard caps (= tool_uses, wall_clock_min) appear in the
+    prompt so the sub-agent enforces them. Without these the
+    feedback_subagent_scope_bounding discipline isn't propagated.
+    """
+    cfg_path = _write_config(
+        tmp_path, _minimal_config_yaml(tmp_path, tmp_path / "journal"),
+    )
+    config = load_batch_config(cfg_path)
+    prompt = render_worker_prompt(config, config.workers[0])
+    assert "50" in prompt  # tool_uses cap
+    assert "15" in prompt  # wall_clock_min cap
+
+
+def test_render_worker_prompt_includes_env_vars(tmp_path):
+    """Tier 2: env_vars from the batch config appear in the setup
+    block so the sub-agent starts reyn web with the right flags."""
+    cfg_path = _write_config(
+        tmp_path, _minimal_config_yaml(tmp_path, tmp_path / "journal"),
+    )
+    config = load_batch_config(cfg_path)
+    prompt = render_worker_prompt(config, config.workers[0])
+    assert "REYN_EMPTY_STOP_RETRY=1" in prompt


### PR DESCRIPTION
**[dogfood-coder]** — two complementary tools that consolidate the B-batch dispatch boilerplate the sandbox_2 session has been hand-rolling in chat for B42 / B43.

## Cost reduction

Before: per-batch dispatch was ~60 min wall-clock (= 7 worker prompts × 60-80 lines each, manual past-batch verdict paste, worktree creation, reyn.local.yaml prep, aggregate.json assembly).

After: ~15 min wall-clock (= mostly waiting for live `reyn web` + agent provisioning). **~45 min saved per batch.**

## Tools

### `scripts/dogfood_batch_dispatch.py`

YAML config → 7 markdown worker prompts (= setup commands, scenario list, past-batch verdict table pulled from prior aggregate.json, deliverable spec, hard caps).

Two modes: `--prompts-dir <dir>` (= files) or stdout. Worktree + reyn.local.yaml setup opt-in via `--setup-worktrees` (= flash-lite forced on `models.strong` for `feedback_no_strong_model` compliance enforced by the tool).

### `scripts/dogfood_aggregate.py`

7 `results-worker-N.json` → `aggregate.json` (= verdict_totals + per-worker + delta_vs_<each past batch>) + markdown comparison table for retrospective.md. Tolerates B42 long-form (`verified`/`inconclusive`) vs B43 short-form (`V`/`I`) verdict shape divergence.

### `scripts/dogfood_batch_config.py`

Shared YAML schema + loader. One config drives both tools.

## Test plan

- [x] 14 new Tier 2 tests pass (`test_dogfood_batch_tools.py`)
- [x] Real B43 journal regression: `build_aggregate` reproduces published V=22 / I=12 / R=20 / B=0 / scenarios_total=54
- [x] Worker prompt rendering pinned: port + scenario path + deliverable path + hard caps + env_vars + past-batch verdicts all present
- [x] Verdict normalisation: B42 long-form + B43 short-form both handled
- [x] ruff clean
- [x] No `unittest.mock.patch` — uses real filesystem fixtures + committed B43 journal per testing.ja.md

## Composition

Composes with PR #293 (`dogfood_variant_replay.py`): once B44 dispatch lands worker results, `dogfood_aggregate.py` builds the aggregate.json; per-NF attractor investigation uses `dogfood_variant_replay.py` with one YAML config. The complete dogfood loop (dispatch → run → aggregate → investigate → fix) becomes script-driven end to end.

## Related

- PR #293 (dogfood_variant_replay.py): sibling NF attractor analysis tool
- B42 / B43 retrospectives: the hand-rolled patterns this bundle replaces
- `feedback_subagent_scope_bounding`: hard caps propagated by the worker prompt template
- `feedback_no_strong_model`: flash-lite enforced by `--setup-worktrees` reyn.local.yaml rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)