### PR TITLE
OAuth device-grant UX P2: spinner + slow_down notice + Ctrl+C hint (#291)

### DIFF
--- a/src/reyn/cli/commands/auth.py
+++ b/src/reyn/cli/commands/auth.py
@@ -15,6 +15,13 @@ import sys
 import webbrowser
 from datetime import datetime
 
+# Spinner frame strings — fixed width (3 chars) so successive ``\r``-anchored
+# redraws fully overwrite the previous frame without leaving residue. The
+# empty-trailer frame ("   ") creates a brief visual pause that confirms
+# the animation is still running rather than freezing on three dots.
+_SPINNER_FRAMES = (".  ", ".. ", "...", "   ")
+_SPINNER_INTERVAL_SECONDS = 0.5
+
 
 def register(sub) -> None:
     p = sub.add_parser("auth", help="Manage OAuth credentials (login, list, revoke)")
@@ -157,7 +164,53 @@ def _print_user_action(info: dict) -> None:
 
     _open_browser_or_skip(url_to_show)
 
-    print("Waiting for approval...", file=sys.stderr)
+    # The Ctrl+C hint is part of the static line so non-TTY contexts
+    # (= pipe, CI capture) still see it — ``_animated_wait`` on TTY
+    # adds the spinner on the next line.
+    print("Waiting for approval (Ctrl+C to cancel)...", file=sys.stderr)
+
+
+async def _animated_wait(seconds: float) -> None:
+    """Show an animated dot spinner on stderr for *seconds*.
+
+    The spinner cycles through ``_SPINNER_FRAMES`` every
+    ``_SPINNER_INTERVAL_SECONDS``, using ``\\r`` to overwrite the
+    previous frame on the same line. Two-space indent matches the
+    other CLI bullets (= the box drawing + expires_in lines) so the
+    spinner reads as "this is the same flow, still waiting".
+
+    Falls back to a plain ``asyncio.sleep`` when stderr is not a TTY
+    (= CI, pipes, log capture) — animation is noise in those contexts.
+    """
+    if not sys.stderr.isatty():
+        await asyncio.sleep(seconds)
+        return
+
+    idx = 0
+    elapsed = 0.0
+    while elapsed < seconds:
+        frame = _SPINNER_FRAMES[idx % len(_SPINNER_FRAMES)]
+        print(f"\r  {frame}", end="", file=sys.stderr, flush=True)
+        await asyncio.sleep(_SPINNER_INTERVAL_SECONDS)
+        elapsed += _SPINNER_INTERVAL_SECONDS
+        idx += 1
+
+
+def _print_slow_down_notice(new_interval: float) -> None:
+    """Surface the OAuth server's slow_down hint to the user.
+
+    Clears the spinner line first (TTY only) so the notice prints
+    cleanly, then logs the new interval as a permanent line. The
+    spinner resumes on the next ``_animated_wait`` cycle below.
+    """
+    if sys.stderr.isatty():
+        # 60 chars is enough to clear the spinner + any slow_down residue
+        # without making the line jitter on narrow terminals.
+        print("\r" + " " * 60 + "\r", end="", file=sys.stderr, flush=True)
+    print(
+        f"  Server requested slower polling — interval now {new_interval:.0f}s.",
+        file=sys.stderr,
+    )
 
 
 def run_login(args: argparse.Namespace) -> None:
@@ -192,10 +245,18 @@ def run_login(args: argparse.Namespace) -> None:
                 provider_cfg,
                 events=events,
                 on_user_action=_print_user_action,
+                wait_fn=_animated_wait,
+                on_slow_down=_print_slow_down_notice,
             )
         except DeviceGrantError as exc:
+            # Terminate the spinner line cleanly before printing the error
+            # (otherwise the error overlays the last spinner frame on TTY).
+            if sys.stderr.isatty():
+                print("", file=sys.stderr)
             print(f"Authentication failed: {exc}", file=sys.stderr)
             sys.exit(2)
+        if sys.stderr.isatty():
+            print("", file=sys.stderr)
         save_oauth_token(key, token)
         print(
             f"Saved OAuth token under key {key!r}. "

--- a/src/reyn/secrets/oauth.py
+++ b/src/reyn/secrets/oauth.py
@@ -29,7 +29,7 @@ import json
 import os
 import stat
 import warnings
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -593,6 +593,8 @@ async def device_grant_flow(
     events: Any = None,  # EventLog | None
     http_client: Any = None,  # httpx.AsyncClient | None
     on_user_action: Callable[[dict], None] | None = None,
+    wait_fn: Callable[[float], Awaitable[None]] | None = None,
+    on_slow_down: Callable[[float], None] | None = None,
     poll_interval_override: float | None = None,  # for tests
     deadline_override: float | None = None,  # max wall-clock seconds (for tests)
 ) -> OAuthToken:
@@ -696,10 +698,19 @@ async def device_grant_flow(
                 pass
 
         # ── Step 4: poll loop (wrapped in deadline) ──────────────────────
+        # ``wait_fn`` lets the caller substitute the inter-poll sleep with
+        # an animated indicator (= CLI spinner). Falling back to
+        # ``asyncio.sleep`` preserves the pre-Component-C-P2 behaviour.
+        # ``on_slow_down`` fires when the server returns the
+        # ``slow_down`` error so the caller can surface the new interval
+        # to the user (= avoids silent back-off, RFC 8628 §3.5).
         async def _poll_loop() -> OAuthToken:
             nonlocal poll_interval
             while True:
-                await asyncio.sleep(poll_interval)
+                if wait_fn is not None:
+                    await wait_fn(poll_interval)
+                else:
+                    await asyncio.sleep(poll_interval)
                 status, body = await _poll_token(provider, device_code, http_client)
 
                 if status == 200 and body.get("access_token"):
@@ -714,6 +725,11 @@ async def device_grant_flow(
                 elif status == 400 and error_code == "slow_down":
                     # Server instructs us to back off.
                     poll_interval += _SLOW_DOWN_INCREMENT
+                    if on_slow_down is not None:
+                        try:
+                            on_slow_down(poll_interval)
+                        except Exception:  # noqa: BLE001 — UX hint must not break flow
+                            pass
                     continue
                 elif status == 400 and error_code == "access_denied":
                     raise DeviceGrantError(

--- a/tests/cli/test_auth_login_ux_p2.py
+++ b/tests/cli/test_auth_login_ux_p2.py
@@ -1,0 +1,209 @@
+"""Tier 2: `reyn auth login` device-grant UX P2 (issue #291 Priority 2).
+
+Pins:
+
+  1. ``_animated_wait`` produces spinner frames on TTY and degrades to
+     a plain sleep on non-TTY (= log captures stay clean).
+  2. ``_print_slow_down_notice`` emits a human-readable line about the
+     new poll interval (= surfaces the OAuth server's slow_down hint
+     that was previously absorbed silently).
+  3. ``_print_user_action`` includes the ``Ctrl+C to cancel`` hint in
+     the waiting line so users on non-TTY (= no spinner) still see how
+     to abort.
+
+All tests spy via direct attribute substitution / recording lambdas —
+no ``unittest.mock`` per ``docs/deep-dives/contributing/testing.ja.md``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.cli.commands import auth as auth_mod
+
+# ── _animated_wait ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_animated_wait_emits_multiple_spinner_frames_on_tty(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: TTY stderr → multiple `\\r`-anchored frames printed.
+
+    Patches ``_SPINNER_INTERVAL_SECONDS`` down to 0.01s so the test runs
+    in <50ms while still exercising the frame-cycling loop.
+    """
+
+    class _TTYStream:
+        def __init__(self) -> None:
+            self.buf: list[str] = []
+
+        def isatty(self) -> bool:
+            return True
+
+        def write(self, s: str) -> int:
+            self.buf.append(s)
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+    fake_stderr = _TTYStream()
+    monkeypatch.setattr(sys, "stderr", fake_stderr)
+    monkeypatch.setattr(auth_mod, "_SPINNER_INTERVAL_SECONDS", 0.01)
+
+    await auth_mod._animated_wait(0.05)
+
+    # Every frame write contains a `\r` followed by the indent + frame char.
+    frame_writes = [s for s in fake_stderr.buf if s.startswith("\r")]
+    # Expect at least 3 frames in a 0.05s window with 0.01s interval.
+    assert len(frame_writes) >= 3
+    # At least one of the cycled frames should be visible (dots accumulate).
+    joined = "".join(frame_writes)
+    assert "." in joined
+
+
+@pytest.mark.asyncio
+async def test_animated_wait_no_animation_on_non_tty(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: non-TTY stderr → no spinner output, just a plain sleep.
+
+    Verifies (a) stderr capture has zero spinner-shaped writes, and (b)
+    the call completes in roughly the requested duration via a recorded
+    asyncio.sleep call (= we don't actually let it sleep — we spy).
+    """
+
+    class _NonTTYStream:
+        def __init__(self) -> None:
+            self.buf: list[str] = []
+
+        def isatty(self) -> bool:
+            return False
+
+        def write(self, s: str) -> int:
+            self.buf.append(s)
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+    fake_stderr = _NonTTYStream()
+    monkeypatch.setattr(sys, "stderr", fake_stderr)
+
+    sleep_calls: list[float] = []
+
+    async def _recording_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(auth_mod.asyncio, "sleep", _recording_sleep)
+
+    await auth_mod._animated_wait(5.0)
+
+    # Single asyncio.sleep call equal to the requested duration.
+    assert sleep_calls == [5.0]
+    # No spinner output at all.
+    assert fake_stderr.buf == []
+
+
+# ── _print_slow_down_notice ─────────────────────────────────────────────────
+
+
+def test_print_slow_down_notice_announces_new_interval(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: notice line includes the new interval rounded to a whole second.
+
+    The exact phrasing ("Server requested slower polling — interval now Xs.")
+    is pinned because the user has to understand that polling continues but
+    slower; a vague message would leave them wondering whether to abort.
+    """
+
+    class _NonTTYStream:
+        def isatty(self) -> bool:
+            return False
+
+        def write(self, s: str) -> int:
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+    monkeypatch.setattr(sys, "stderr", _NonTTYStream())
+
+    captured: list[str] = []
+
+    class _CapturedStream(_NonTTYStream):
+        def write(self, s: str) -> int:
+            captured.append(s)
+            return len(s)
+
+    monkeypatch.setattr(sys, "stderr", _CapturedStream())
+
+    auth_mod._print_slow_down_notice(10.0)
+
+    joined = "".join(captured)
+    assert "Server requested slower polling" in joined
+    assert "10" in joined
+
+
+def test_print_slow_down_notice_clears_spinner_on_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: TTY stderr → notice emits a `\\r` + spaces clear sequence
+    before the message (= overwrites residual spinner glyphs)."""
+
+    captured: list[str] = []
+
+    class _TTYStream:
+        def isatty(self) -> bool:
+            return True
+
+        def write(self, s: str) -> int:
+            captured.append(s)
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+    monkeypatch.setattr(sys, "stderr", _TTYStream())
+
+    auth_mod._print_slow_down_notice(15.0)
+
+    joined = "".join(captured)
+    # Clear sequence: a `\r` precedes the spaces precedes another `\r`.
+    assert "\r" in joined
+    assert "Server requested slower polling" in joined
+
+
+# ── _print_user_action — Ctrl+C hint ────────────────────────────────────────
+
+
+def test_print_user_action_includes_ctrl_c_hint(
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the waiting line carries the `Ctrl+C to cancel` hint so
+    non-TTY contexts (= where the spinner is silent) still surface the
+    cancel mechanism."""
+    monkeypatch.setattr(auth_mod, "_open_browser_or_skip", lambda _url: None)
+
+    info = {
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://example.com/device",
+        "expires_in": 600,
+    }
+    auth_mod._print_user_action(info)
+
+    err = capsys.readouterr().err
+    assert "Ctrl+C to cancel" in err
+    assert "Waiting for approval" in err

--- a/tests/test_fp0016_c_device_grant.py
+++ b/tests/test_fp0016_c_device_grant.py
@@ -361,7 +361,145 @@ async def test_device_grant_flow_emits_events() -> None:
     assert isinstance(completed.data["scopes"], list)
 
 
-# ── Test 8: client_secret in polling POST body ───────────────────────────
+# ── Test 8a: wait_fn callback (issue #291 P2) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_device_grant_flow_invokes_wait_fn_between_polls() -> None:
+    """Tier 2: ``wait_fn`` substitutes for ``asyncio.sleep`` between polls.
+
+    Issue #291 P2: the CLI uses ``wait_fn`` to drive an animated spinner
+    while the loop waits. This test verifies (a) ``wait_fn`` is called
+    once per poll cycle with the current ``poll_interval``, and (b) the
+    flow still completes correctly.
+    """
+    poll_responses: deque = deque([
+        httpx.Response(400, json={"error": "authorization_pending"}),
+        httpx.Response(200, json=_token_success_response()),
+    ])
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == _DEVICE_URL:
+            return httpx.Response(200, json=_device_auth_response())
+        return poll_responses.popleft()
+
+    wait_calls: list[float] = []
+
+    async def _recorder(seconds: float) -> None:
+        wait_calls.append(seconds)
+        # No real sleep — keep the test fast.
+
+    provider = _make_provider()
+    client = _mock_transport(_handler)
+    try:
+        token = await device_grant_flow(
+            provider,
+            http_client=client,
+            wait_fn=_recorder,
+            poll_interval_override=0.01,
+        )
+    finally:
+        await client.aclose()
+
+    assert token.access_token == "AT_x"
+    # Two poll cycles: pending + success → 2 wait_fn calls.
+    assert len(wait_calls) == 2
+    # First call uses the initial override interval.
+    assert wait_calls[0] == 0.01
+
+
+# ── Test 8b: on_slow_down callback (issue #291 P2) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_device_grant_flow_invokes_on_slow_down_with_new_interval() -> None:
+    """Tier 2: server returns ``slow_down`` → ``on_slow_down`` fires with
+    the post-increment poll interval (= the value the next sleep will
+    actually use).
+
+    Issue #291 P2: surfaces the OAuth server's back-off request to the
+    user instead of absorbing it silently. We bypass the real sleep via
+    ``wait_fn`` so the test stays fast (otherwise the 5 s
+    ``_SLOW_DOWN_INCREMENT`` would make this slow).
+    """
+    poll_responses: deque = deque([
+        httpx.Response(400, json={"error": "slow_down"}),
+        httpx.Response(200, json=_token_success_response()),
+    ])
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == _DEVICE_URL:
+            return httpx.Response(200, json=_device_auth_response())
+        return poll_responses.popleft()
+
+    slow_down_calls: list[float] = []
+
+    def _on_slow_down(new_interval: float) -> None:
+        slow_down_calls.append(new_interval)
+
+    async def _fast_wait(_seconds: float) -> None:
+        return None  # skip the real sleep
+
+    provider = _make_provider()
+    client = _mock_transport(_handler)
+    try:
+        await device_grant_flow(
+            provider,
+            http_client=client,
+            wait_fn=_fast_wait,
+            on_slow_down=_on_slow_down,
+            poll_interval_override=0.01,
+        )
+    finally:
+        await client.aclose()
+
+    # Single slow_down notice fired.
+    assert len(slow_down_calls) == 1
+    # The reported interval is post-increment (= initial 0.01 + 5.0).
+    assert slow_down_calls[0] == pytest.approx(5.01, abs=0.001)
+
+
+@pytest.mark.asyncio
+async def test_device_grant_flow_on_slow_down_exception_is_swallowed() -> None:
+    """Tier 2: a faulty ``on_slow_down`` callback must not abort the flow.
+
+    Issue #291 P2: UX hints are best-effort — a buggy CLI hook
+    (= raising inside the callback) should not break the auth flow.
+    """
+    poll_responses: deque = deque([
+        httpx.Response(400, json={"error": "slow_down"}),
+        httpx.Response(200, json=_token_success_response()),
+    ])
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == _DEVICE_URL:
+            return httpx.Response(200, json=_device_auth_response())
+        return poll_responses.popleft()
+
+    def _broken(_new_interval: float) -> None:
+        raise RuntimeError("ui crashed")
+
+    async def _fast_wait(_seconds: float) -> None:
+        return None
+
+    provider = _make_provider()
+    client = _mock_transport(_handler)
+    try:
+        token = await device_grant_flow(
+            provider,
+            http_client=client,
+            wait_fn=_fast_wait,
+            on_slow_down=_broken,
+            poll_interval_override=0.01,
+        )
+    finally:
+        await client.aclose()
+
+    # Flow completed despite the callback raising.
+    assert token.access_token == "AT_x"
+
+
+# ── Test 9: client_secret in polling POST body ───────────────────────────
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — Closes Priority 2 of #291. Stacked on #294 (= base branch is `feat/oauth-device-grant-ux-p1`); merge after #294 lands.

## Summary

- ✅ **Animated dot spinner** during the poll wait (= TTY only; non-TTY falls back to plain `asyncio.sleep`)
- ✅ **`slow_down` server hint surfaced** to the user (= previously absorbed silently in `_poll_loop`)
- ✅ **`Ctrl+C to cancel` hint** in the Waiting line (= visible even on non-TTY where the spinner is silent)

## Visual

Static line + spinner cycling below it (TTY):
```
Waiting for approval (Ctrl+C to cancel)...
  ...
```
(`...` cycles `.   ` → `..  ` → `... ` → `    ` every 0.5s, redrawn via `\r`.)

On `slow_down` from the OAuth server:
```
Waiting for approval (Ctrl+C to cancel)...
  Server requested slower polling — interval now 10s.
  ...
```
(The slow_down line becomes a permanent log entry; spinner resumes below.)

Non-TTY (= CI / pipe / log capture): no spinner output, only the static line + slow_down notice if it fires.

## Changes

| file | change |
|---|---|
| `src/reyn/cli/commands/auth.py` | `_animated_wait` + `_print_slow_down_notice` new / Ctrl+C hint in `_print_user_action` / `run_login` wires new callbacks + post-flow newline |
| `src/reyn/secrets/oauth.py` | `device_grant_flow` extended with `wait_fn` + `on_slow_down` callbacks (additive, defaults preserve pre-P2 behavior) |
| `tests/cli/test_auth_login_ux_p2.py` | 5 Tier 2 cases — TTY spinner frames / non-TTY skip / slow_down notice / clear-sequence / Ctrl+C hint |
| `tests/test_fp0016_c_device_grant.py` | 3 Tier 2 cases added — wait_fn invocation / on_slow_down call / on_slow_down exception swallowed |

## Test plan

- [x] `python -m pytest tests/cli/test_auth_login_ux_p2.py` — 5 passed (= new P2 CLI surface)
- [x] `python -m pytest tests/test_fp0016_c_device_grant.py` — 11 passed (= 3 new + 8 existing; pre-P2 success / access_denied / expired / slow_down / deadline / events / client_secret 全 green)
- [x] `python -m pytest tests/test_fp0016_c_device_grant.py tests/cli/test_auth_login_ux_p2.py tests/cli/test_auth_login_ux.py tests/test_fp0016_c_auth_cli.py tests/test_fp0016_b_oauth_refresh.py` — 56 passed (= P1 + P2 + 既存全集計)
- [x] `ruff check` — clean (= pre-push 実走済)
- [x] Manual visual: `_print_user_action` + `_print_slow_down_notice` の non-TTY 出力で 「Waiting for approval (Ctrl+C to cancel)...」 + 「Server requested slower polling — interval now 10s.」 確認
- [x] (skipped — 実 OAuth provider 連携必要) Real spinner animation in interactive terminal = `_animated_wait` の TTY 分岐は spy test (= `_TTYStream.write` 経由 `\r` writes ≥3) で等価カバレッジ。実 terminal での動作は `_SPINNER_FRAMES` の cycle ロジックが pure data なので decoupled。
- [x] (skipped — 実 OAuth provider 連携必要) Real `slow_down` from provider = `httpx.MockTransport` で 400/slow_down → 200 success の transition を返すカナリアフローで `on_slow_down` 呼び出しを recorder lambda で確認 (3 Tier 2 cases)。

## Scope guard

**NOT in scope** (= Priority 3、 separate follow-up):
- scope advertisement (= `Requesting scopes: ...` 事前表示)
- `OAuthRefreshError(re_auth_required=True)` の friendly re-auth surface 昇格
- `reyn auth list` 3-state 化 (= `expired` / `near-expiry` / `valid`)

**Stacked PR**: base = `feat/oauth-device-grant-ux-p1` (= #294)。 #294 merge 後に main を base に rebase + this PR merge の順。

## Calibration matrix self-check

| trigger | 適用 | 根拠 |
|---|---|---|
| 構造的 wiring (= `wait_fn` + `on_slow_down` callbacks の OS 側受け入れ + CLI 側 wire) | Tier 2 同梱 ✅ | permanent UX contract、 後 session が同 PR review で defense する根拠 |
| spy 必要時 (= sys.stderr / asyncio.sleep / on_slow_down 関数差し替え) | direct attribute substitution ✅ | `_TTYStream` / `_NonTTYStream` クラス + `monkeypatch.setattr(auth_mod.asyncio, "sleep", ...)` で MagicMock 不使用 |
| `ruff check --fix` pre-push | ✅ 実走済 |

Pre-`gh pr create` checklist 4 items 全 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)