### PR TITLE
OAuth device-grant UX P3: scope advertisement + auth list 3-state (#291)

### DIFF
--- a/src/reyn/cli/commands/auth.py
+++ b/src/reyn/cli/commands/auth.py
@@ -122,6 +122,28 @@ def _open_browser_or_skip(url: str) -> None:
         pass
 
 
+def _print_scope_advertisement(provider_cfg) -> None:
+    """Print the OAuth scopes this device-grant flow is about to request.
+
+    Issue #291 Priority 3 #7: previously reyn silently sent ``scope=...``
+    to the provider's device_authorization endpoint with no client-side
+    visibility. The provider's consent screen still lists scopes, but
+    surfacing them in the CLI first gives the user a chance to abort
+    before any network round-trip — and creates a paper trail in shell
+    history / CI logs of exactly what was requested.
+
+    Skips silently when ``provider.scopes`` is empty (= provider does
+    not request any scopes, or the user is using a public-API token).
+    """
+    scopes = getattr(provider_cfg, "scopes", None) or []
+    if not scopes:
+        return
+    print(
+        f"Requesting scopes for {provider_cfg.name!r}: {', '.join(scopes)}",
+        file=sys.stderr,
+    )
+
+
 def _print_user_action(info: dict) -> None:
     """Display the device code + verification URI for the user to act on.
 
@@ -239,6 +261,8 @@ def run_login(args: argparse.Namespace) -> None:
     key = args.save_as or args.provider
     events = EventLog()
 
+    _print_scope_advertisement(provider_cfg)
+
     async def _run() -> None:
         try:
             token = await device_grant_flow(
@@ -271,6 +295,27 @@ def run_login(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _classify_token_status(delta_seconds: float) -> str:
+    """Map an ``expires_at - now`` delta (seconds) to a 3-state label.
+
+    Issue #291 Priority 3 #9: previously the 2-state label ``valid`` /
+    ``near-expiry`` collapsed ``expired`` (= already past) into the same
+    bucket as ``near-expiry`` (= about to expire), making it impossible
+    to distinguish "needs refresh now" from "needs re-auth now" from
+    the list output.
+
+    The thresholds match the OAuth refresh buffer (``oauth.py:_REFRESH_BUFFER_SECONDS``):
+      - ``expired`` :  delta <  0    (= past the expires_at timestamp)
+      - ``near-expiry`` : 0 ≤ delta < 60   (= within refresh-on-next-use window)
+      - ``valid`` : delta ≥ 60   (= no refresh needed yet)
+    """
+    if delta_seconds < 0:
+        return "expired"
+    if delta_seconds < 60:
+        return "near-expiry"
+    return "valid"
+
+
 def run_list(args: argparse.Namespace) -> None:
     """List token keys in the OAuth store. Values are never printed."""
     from reyn.secrets import list_oauth_token_keys, load_oauth_token
@@ -286,7 +331,7 @@ def run_list(args: argparse.Namespace) -> None:
             print(f"  {key}: <malformed>")
             continue
         delta = token.expires_at - now
-        status = "valid" if delta.total_seconds() > 60 else "near-expiry"
+        status = _classify_token_status(delta.total_seconds())
         print(f"  {key}: {status}, expires {token.expires_at.isoformat()}")
 
 

--- a/tests/cli/test_auth_login_ux_p3.py
+++ b/tests/cli/test_auth_login_ux_p3.py
@@ -1,0 +1,187 @@
+"""Tier 2: `reyn auth login` device-grant UX P3 (issue #291 Priority 3).
+
+Pins:
+
+  1. ``_print_scope_advertisement`` prints the configured scopes before
+     the device_authorization POST (= user sees what permissions reyn
+     is about to ask for, can abort before any network round-trip).
+  2. ``_classify_token_status`` returns ``expired`` / ``near-expiry``
+     / ``valid`` matching the OAuth refresh buffer threshold (60 s).
+  3. ``run_list`` surfaces the 3-state classification end-to-end with
+     fixture tokens written to a tmp_path OAuth store.
+
+P3 #8 (re-auth surface elevation) is deferred — see PR #298 body for
+the documented dependency on ``get_valid_token`` consumer wire-up.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.cli.commands import auth as auth_mod
+
+# ── _print_scope_advertisement ──────────────────────────────────────────────
+
+
+class _ProviderStub:
+    """Bare-minimum stand-in for OAuthProviderConfig — only attributes
+    ``_print_scope_advertisement`` reads. Avoids importing the heavy
+    config module in this unit test."""
+
+    def __init__(self, name: str, scopes: list[str]) -> None:
+        self.name = name
+        self.scopes = scopes
+
+
+def test_scope_advertisement_lists_configured_scopes(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2: provider with scopes → comma-joined list printed to stderr."""
+    provider = _ProviderStub("github", ["repo", "read:user"])
+    auth_mod._print_scope_advertisement(provider)
+
+    err = capsys.readouterr().err
+    assert "Requesting scopes for 'github'" in err
+    assert "repo" in err
+    assert "read:user" in err
+
+
+def test_scope_advertisement_skips_when_no_scopes(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2: empty scopes list → no output (= provider does not
+    request anything, advertising would be noise)."""
+    provider = _ProviderStub("public_api", [])
+    auth_mod._print_scope_advertisement(provider)
+
+    assert capsys.readouterr().err == ""
+
+
+def test_scope_advertisement_handles_missing_scopes_attr(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2: defensive — ``provider.scopes`` missing → no crash, no print."""
+
+    class _BareProvider:
+        name = "minimal"
+
+    auth_mod._print_scope_advertisement(_BareProvider())
+    assert capsys.readouterr().err == ""
+
+
+# ── _classify_token_status ──────────────────────────────────────────────────
+
+
+def test_classify_token_status_expired() -> None:
+    """Tier 2: negative delta → ``expired`` (= past expires_at)."""
+    assert auth_mod._classify_token_status(-1.0) == "expired"
+    assert auth_mod._classify_token_status(-3600.0) == "expired"
+
+
+def test_classify_token_status_near_expiry() -> None:
+    """Tier 2: delta in [0, 60) → ``near-expiry`` (= refresh window).
+
+    The 60 s threshold matches ``oauth.py:_REFRESH_BUFFER_SECONDS`` — a
+    token within 60 s of expiry will refresh on next ``get_valid_token``
+    call, so flagging it explicitly helps users predict behavior.
+    """
+    assert auth_mod._classify_token_status(0.0) == "near-expiry"
+    assert auth_mod._classify_token_status(30.0) == "near-expiry"
+    assert auth_mod._classify_token_status(59.999) == "near-expiry"
+
+
+def test_classify_token_status_valid() -> None:
+    """Tier 2: delta >= 60 → ``valid`` (= no refresh needed)."""
+    assert auth_mod._classify_token_status(60.0) == "valid"
+    assert auth_mod._classify_token_status(3600.0) == "valid"
+    assert auth_mod._classify_token_status(86400.0) == "valid"
+
+
+# ── run_list end-to-end with 3-state fixtures ───────────────────────────────
+
+
+def _write_token_fixture(
+    store_path: Path, key: str, expires_at: datetime,
+) -> None:
+    """Write a minimal OAuthToken JSON to *store_path* under *key*."""
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict = {}
+    if store_path.exists():
+        existing = json.loads(store_path.read_text())
+    existing[key] = {
+        "access_token": "AT_x",
+        "refresh_token": "RT_x",
+        "token_uri": "https://example.com/token",
+        "client_id": "cid",
+        "expires_at": expires_at.isoformat(),
+        "scopes": ["repo"],
+        "client_secret": None,
+    }
+    store_path.write_text(json.dumps(existing, sort_keys=True))
+    store_path.chmod(0o600)
+
+
+def test_run_list_surfaces_all_three_states(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2: three fixture tokens (expired / near-expiry / valid) →
+    each labelled with the correct status in the output.
+
+    Issue #291 P3 #9: previously the 2-state label collapsed
+    ``expired`` into ``near-expiry``, so an oncall user reading the
+    list could not tell whether the next API call would refresh
+    (= recoverable) or fail with re-auth (= needs human action)."""
+    store = tmp_path / "oauth_tokens.json"
+    monkeypatch.setenv("REYN_OAUTH_TOKENS_PATH", str(store))
+
+    now = datetime.now().astimezone()
+    _write_token_fixture(store, "expired_gh", now - timedelta(hours=1))
+    _write_token_fixture(store, "near_gh", now + timedelta(seconds=30))
+    _write_token_fixture(store, "valid_gh", now + timedelta(hours=1))
+
+    args = argparse.Namespace()
+    auth_mod.run_list(args)
+
+    out = capsys.readouterr().out
+    # Each fixture key appears with its corresponding state.
+    assert "expired_gh: expired" in out
+    assert "near_gh: near-expiry" in out
+    assert "valid_gh: valid" in out
+
+
+def test_run_list_expired_is_distinct_from_near_expiry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2: regression guard — ``expired`` must NOT be labelled
+    ``near-expiry`` (= the pre-P3 2-state behavior would conflate them,
+    masking the recoverability distinction)."""
+    store = tmp_path / "oauth_tokens.json"
+    monkeypatch.setenv("REYN_OAUTH_TOKENS_PATH", str(store))
+
+    now = datetime.now().astimezone()
+    _write_token_fixture(store, "stale", now - timedelta(days=1))
+
+    auth_mod.run_list(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    assert "stale: expired" in out
+    assert "stale: near-expiry" not in out
+
+
+# Notes on timezone-naive expires_at: ``OAuthToken.from_dict`` accepts the
+# stored ISO string verbatim. The fixtures above use timezone-aware
+# `now.astimezone()` so the `expires_at - now` arithmetic in `run_list`
+# (which converts via `now = datetime.now().astimezone()`) matches.


### PR DESCRIPTION
**[tui-coder]** — Closes Priority 3 items #7 + #9 of #291. Item #8 deferred — see "Deferred" section.

Stacked on #297 (= base = `feat/oauth-device-grant-ux-p2`); merge after #297 lands.

## Summary

P3 #7 — **scope advertisement**:
- ✅ `Requesting scopes for 'github': repo, read:user` printed before the device_authorization POST
- ✅ Skips when scopes list is empty (= public-API providers / minimal config)

P3 #9 — **auth list 3-state**:
- ✅ `expired` (= delta < 0) — needs re-auth, refresh will fail
- ✅ `near-expiry` (= 0 ≤ delta < 60s) — refresh on next API call
- ✅ `valid` (= delta ≥ 60s) — no refresh needed

P3 #8 — **re-auth surface elevation**: **deferred** (= see Deferred section below)

## Visual

Before P3 #7 (= pre-PR):
```
(no scope visibility — user must check reyn.yaml or provider's consent screen)
To authenticate:
  ...
```

After P3 #7:
```
Requesting scopes for 'github': repo, read:user

To authenticate:
  ...
```

`reyn auth list` Before P3 #9:
```
  github_main: valid, expires 2026-05-20T14:00:00+09:00
  github_stale: near-expiry, expires 2026-05-19T03:00:00+09:00   ← expired collapsed
```

After P3 #9:
```
  github_main: valid, expires 2026-05-20T14:00:00+09:00
  github_almost: near-expiry, expires 2026-05-20T13:15:30+09:00
  github_stale: expired, expires 2026-05-19T03:00:00+09:00       ← distinguished
```

## Changes

| file | change |
|---|---|
| `src/reyn/cli/commands/auth.py` | `_print_scope_advertisement` + `_classify_token_status` new / `run_login` invokes scope advertisement before `device_grant_flow` / `run_list` uses 3-state classifier |
| `tests/cli/test_auth_login_ux_p3.py` | 8 Tier 2 cases — scope advertisement (3 boundary cases) + classifier (3 boundary cases) + run_list end-to-end (3-state surfacing + expired ≠ near-expiry regression guard) |

## Deferred — P3 #8 (re-auth surface elevation)

Issue #291 P3 #8 documented dependency: ``依存: get_valid_token consumer がまだ wire 中なので、 そちらの landing 後``.

**Confirmed**: ``grep -rn "get_valid_token" src/`` returns hits only inside `src/reyn/secrets/oauth.py` itself. Zero consumers exist in src/ today (= no MCP / A2A / op-runtime path is wired to call `get_valid_token`).

Implementing a friendly re-auth surface helper without a caller would create dead code that can't be validated against a real use-case — the shape of the surface (= exception → user-facing message + suggested command) depends on where the catch happens (= async op handler? sync CLI dispatch? Phase Preprocessor?). Better to land #8 alongside the first consumer wire-up so the surface is shaped by the actual call site needs.

**Acceptance check**: when the first `get_valid_token` consumer lands, open a follow-up PR (= "#291 P3 #8") that wires the friendly surface in the same module as the consumer. Until then, the exception's `re_auth_required` flag + the existing exception message (`re-auth required (run 'reyn auth login <provider>')`, `oauth.py:319-326`) carry the contract.

## Test plan

- [x] `python -m pytest tests/cli/test_auth_login_ux_p3.py` — 8 passed
- [x] `python -m pytest tests/cli/test_auth_login_ux_p3.py tests/cli/test_auth_login_ux_p2.py tests/cli/test_auth_login_ux.py tests/test_fp0016_c_device_grant.py tests/test_fp0016_c_auth_cli.py tests/test_fp0016_b_oauth_refresh.py` — 64 passed (= P1 + P2 + P3 + 既存 OAuth surface 全 green)
- [x] `ruff check` — clean (pre-push 実走済)
- [x] Manual visual: `_print_scope_advertisement` 出力で `Requesting scopes for 'github': repo, read:user` 確認
- [x] (skipped — 実 OAuth provider 連携必要) `reyn auth login` 実走 end-to-end = `_print_scope_advertisement` は pure data flow なので spy test で等価カバレッジ。 `run_list` の 3-state は fixture token store で end-to-end 検証済。
- [x] (skipped — 実 OAuth provider 連携必要) Re-auth surface = P3 #8 deferred per Deferred section。

## Scope guard

**NOT in scope**:
- P3 #8 (re-auth surface elevation) — deferred, see Deferred section
- Refresh token rotation atomic write (= 別 reliability hardening 軸、 separate issue 候補)
- TUI 側 OAuth UI (= 現状 CLI 専用、 TUI 統合は `reyn auth login` を spawn する形)

**Stacked PR**: base = `feat/oauth-device-grant-ux-p2` (= #297)。 #297 merge 後に main を base に rebase。

## Calibration matrix self-check

| trigger | 適用 | 根拠 |
|---|---|---|
| 構造的 wiring (= scope advertisement の `run_login` 早期注入 + `_classify_token_status` helper の `run_list` 経由) | Tier 2 同梱 ✅ | permanent UX contract、 後 session が review で defense する根拠は test |
| spy 必要時 (= `_ProviderStub` で OAuthProviderConfig 代替 / `monkeypatch.setenv` で REYN_OAUTH_TOKENS_PATH 切替) | direct attribute substitution ✅ | minimal stub class + fixture file 経由で MagicMock 不使用 |
| `ruff check --fix` pre-push | ✅ 実走済 |

Pre-`gh pr create` checklist 4 items 全 pass。

#291 Priority 1 (#294) + Priority 2 (#297) + Priority 3 (本 PR #?, #8 除く) で issue #291 の core UX hardening 完了。 #8 は consumer wire-up landing 後の follow-up で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)