### PR TITLE
refactor(intervention): A2A iv bypass → ChatSession-owned with observer side effects (issue #292 α)

### DIFF
--- a/src/reyn/chat/services/intervention_handler.py
+++ b/src/reyn/chat/services/intervention_handler.py
@@ -163,7 +163,13 @@ class InterventionHandler:
             return False
         return await self.deliver_answer_to(head, text)
 
-    async def deliver_answer_to(self, iv: UserIntervention, text: str) -> bool:
+    async def deliver_answer_to(
+        self,
+        iv: UserIntervention,
+        text: str,
+        *,
+        choice_id_override: str | None = None,
+    ) -> bool:
         """Resolve ``iv`` with ``text``, append a user-history entry, emit the
         ``user_answered_intervention`` event.
 
@@ -176,7 +182,9 @@ class InterventionHandler:
         """
         if iv.future.done():
             return False
-        resolved = await self._registry.deliver_answer(iv, text)
+        resolved = await self._registry.deliver_answer(
+            iv, text, choice_id_override=choice_id_override,
+        )
         if not resolved and iv.choices:
             # No-match path: surface hint, but consume the input so the
             # router doesn't run on a stray hotkey-attempt.
@@ -190,7 +198,16 @@ class InterventionHandler:
         if not resolved:
             return False
         # Successfully resolved: append history + emit audit event.
-        choice = match_choice(text, iv.choices) if iv.choices else None
+        # issue #292 (α): peer-provided choice_id_override is the
+        # authoritative choice for audit; otherwise match_choice on
+        # text gives the same result as the resolved registry entry.
+        if choice_id_override is not None:
+            choice = next(
+                (c for c in iv.choices if c.id == choice_id_override),
+                None,
+            )
+        else:
+            choice = match_choice(text, iv.choices) if iv.choices else None
         self._append_history(
             "user",
             text,

--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -268,7 +268,13 @@ class InterventionRegistry:
 
     # ── Resolution (called by user input router) ─────────────────────────────
 
-    async def deliver_answer(self, iv: UserIntervention, text: str) -> bool:
+    async def deliver_answer(
+        self,
+        iv: UserIntervention,
+        text: str,
+        *,
+        choice_id_override: str | None = None,
+    ) -> bool:
         """Resolve *iv* with *text*.
 
         Returns
@@ -279,17 +285,35 @@ class InterventionRegistry:
             Not consumed — either the future was already done, or choices were
             present but the user's text did not match any hotkey (re-prompt
             path; the caller may surface a hint to the user).
+
+        ``choice_id_override``: when set (= peer-provided structured
+        answer, e.g. A2A POST with explicit ``choice_id`` per PR #285
+        Gap 4), bypass ``match_choice`` and resolve directly with the
+        supplied choice id. Validates the id against ``iv.choices`` so
+        a malformed peer payload still falls into the unrecognised-
+        choice path. issue #292 (α): added so the peer-answer route
+        can reach this single resolution path without losing the
+        choice_id semantics PR #285 wired through.
         """
         if iv.future.done():
             return False
         if iv.choices:
-            choice = match_choice(text, iv.choices)
-            if choice is None:
-                # Unrecognised hotkey — do NOT resolve; let the caller handle
-                # the re-prompt hint.  Return False so the session knows not
-                # to suppress a fresh router turn.
-                return False
-            answer = InterventionAnswer(text=text, choice_id=choice.id)
+            if choice_id_override is not None:
+                # Peer supplied choice_id explicitly; verify it's valid.
+                valid_ids = {c.id for c in iv.choices}
+                if choice_id_override not in valid_ids:
+                    return False
+                answer = InterventionAnswer(
+                    text=text, choice_id=choice_id_override,
+                )
+            else:
+                choice = match_choice(text, iv.choices)
+                if choice is None:
+                    # Unrecognised hotkey — do NOT resolve; let the caller handle
+                    # the re-prompt hint.  Return False so the session knows not
+                    # to suppress a fresh router turn.
+                    return False
+                answer = InterventionAnswer(text=text, choice_id=choice.id)
         else:
             answer = InterventionAnswer(text=text)
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1989,9 +1989,63 @@ class ChatSession:
         """Thin wrapper → InterventionHandler.maybe_answer."""
         return await self._intervention_handler.maybe_answer(text)
 
-    async def _deliver_answer_to(self, iv: UserIntervention, text: str) -> bool:
-        """Thin wrapper → InterventionHandler.deliver_answer_to."""
-        return await self._intervention_handler.deliver_answer_to(iv, text)
+    async def _deliver_answer_to(
+        self,
+        iv: UserIntervention,
+        text: str,
+        *,
+        choice_id_override: str | None = None,
+    ) -> bool:
+        """Thin wrapper → InterventionHandler.deliver_answer_to.
+
+        ``choice_id_override`` is forwarded so peer-side callers (= A2A
+        POST answer with explicit choice_id per PR #285 Gap 4) can bypass
+        the TUI's text-based match_choice. issue #292 (α).
+        """
+        return await self._intervention_handler.deliver_answer_to(
+            iv, text, choice_id_override=choice_id_override,
+        )
+
+    async def answer_pending_intervention(
+        self,
+        run_id: str,
+        answer: "InterventionAnswer",
+    ) -> bool:
+        """Deliver ``answer`` to the outstanding intervention for ``run_id``.
+
+        Authoritative entry point for peer answer delivery (= A2A POST
+        ``{task_id, answer}`` → ``_handle_answer_injection`` → here).
+        issue #292 (α): replaces the pre-#292
+        ``RunRegistry.answer_intervention`` path. Under α, the A2A
+        override is a side-effect observer and the iv lives in
+        ``_interventions._active`` like a TUI iv, so the answer
+        delivery uses the same handler path the TUI uses
+        (``deliver_answer_to``). R-D12's persistent answer buffer
+        applies automatically.
+
+        Looks up the iv by ``run_id`` in active interventions; for
+        the peer-answer case there's typically one iv per run (skills
+        await serially). Delegates to the handler so history +
+        ``user_answered_intervention`` event + outbox cleanup all fire
+        the same way as TUI answers — observers on the audit trail
+        see a consistent shape regardless of answer origin.
+
+        Returns True when the future was resolved; False for unknown
+        run_id, already-answered iv, malformed ``choice_id``, or no
+        matching iv. Callers translate False into a
+        ``{"answered": false, "reason": ...}`` peer response.
+        """
+        for iv in self._interventions.list_active():
+            if iv.run_id != run_id:
+                continue
+            if iv.future.done():
+                return False
+            return await self._deliver_answer_to(
+                iv,
+                answer.text,
+                choice_id_override=answer.choice_id,
+            )
+        return False
 
     async def _announce_intervention(self, iv: UserIntervention) -> None:
         """Thin wrapper → InterventionHandler.announce."""
@@ -2133,16 +2187,40 @@ class ChatSession:
         when iv.origin_channel_id is set but the listener has gone)
         lives here so it fires for ALL iv flows, not just the
         handle_intervention path. The check sits AFTER the chain-override
-        check so A2A-spawned ivs go to the A2A peer even if the local
-        TUI listener is absent.
+        notification so A2A peers still see the iv's input-required
+        signal even if the local TUI listener is absent.
+
+        issue #292 (α): chain overrides now run as **side-effect
+        observers** (= notify A2A peer surfaces, write history, post
+        webhook) BEFORE the regular dispatch path, instead of replacing
+        it. The iv always flows through ``InterventionHandler.dispatch``
+        so it lands in ``_interventions._active`` + WAL +
+        ``outstanding_interventions`` + becomes eligible for R-D12's
+        persistent answer buffer. Pre-#292, the override replaced
+        dispatch and A2A ivs were invisible to ChatSession's iv
+        machinery — fixed structurally here, not patched.
         """
-        # FP-0001: chain_id-scoped override path (A2A async tasks).
+        # FP-0001 / issue #292: chain_id-scoped override notification
+        # (A2A async tasks). The override is now an OBSERVER that runs
+        # side effects (= webhook / SSE / RunRegistry status mirror)
+        # alongside the normal dispatch — NOT a bypass replacement.
+        # Notify before dispatch so the peer learns input-required
+        # before the awaiter (= handler.dispatch) blocks the iv future.
         if iv.run_id is not None and self._intervention_overrides:
             chain_id = self.running_skills_chain.get(iv.run_id)
             if chain_id is not None:
                 override = self._intervention_overrides.get(chain_id)
                 if override is not None:
-                    return await override.request(iv)
+                    try:
+                        await override.on_dispatch(iv)
+                    except Exception:  # noqa: BLE001 — side effects are best-effort
+                        # Override notification must NOT block dispatch.
+                        # A failed webhook / SSE append / status mirror
+                        # is logged elsewhere; dispatch proceeds.
+                        logger.exception(
+                            "intervention override on_dispatch raised "
+                            "(chain_id=%s iv_id=%s)", chain_id, iv.id,
+                        )
         # issue #268 Phase 2 continuation: origin-pin stall check.
         # When the iv carries an explicit ``origin_channel_id`` whose
         # listener is no longer present (= the origin channel closed

--- a/src/reyn/web/a2a_intervention.py
+++ b/src/reyn/web/a2a_intervention.py
@@ -1,30 +1,46 @@
-"""A2AInterventionBus — ``UserChannel`` implementation backed by
-``RunRegistry`` (FP-0001).
+"""A2AInterventionBus — A2A peer-facing **side-effect observer** for
+ivs that arise on async-mode tasks.
 
-When a skill running under an A2A async-mode task fires ``ask_user``,
-this channel publishes the prompt to the run's RunEntry (= status
-changes to ``input-required``, the question text and the IV are stored),
-optionally fires a webhook to notify the peer, then awaits the IV's
-``future`` until the peer POSTs an answer via
-``POST /a2a/agents/<name> {task_id, answer}``.
+issue #292 (α refactor): pre-#292 this class **owned** the iv lifecycle
+when registered as a chain override — ``_dispatch_intervention``
+replaced its normal handler-dispatch path with ``override.request(iv)``
+and the bus awaited ``iv.future`` directly. The iv lived in this bus +
+``RunRegistry.pending_intervention`` only; it never entered
+``ChatSession._interventions._active`` or the WAL / snapshot persistence
+channels. On restart, the bus coroutine died and the restored iv was
+orphaned — no in-process awaiter, no R-D12 buffer eligibility, no
+``SkillResumeCoordinator`` integration. See issue #292 body for the
+full analysis.
+
+Post-α this class is a **side-effect observer**: ``on_dispatch(iv)``
+is invoked by ``ChatSession._dispatch_intervention`` BEFORE
+``InterventionHandler.dispatch`` runs. The bus:
+
+  - Mirrors ``status="input-required"`` on the RunEntry so polling
+    peers see the prompt is pending.
+  - Appends the input-required payload to ``RunEntry.history_events``
+    so the SSE stream surfaces the prompt (issue #267 Gap 1).
+  - POSTs the same payload to the peer's ``webhook_url`` if registered
+    (issue #267 Gap 2 + Gap 4 ``kind`` / ``choices`` / ``detail`` shape).
+  - Does NOT await ``iv.future``. The handler awaits it on behalf of
+    the skill; the bus has no in-process answer-resolution role.
+
+Peer answers arrive via the A2A router's ``POST /a2a/agents/<name>
+{task_id, answer}`` → ``ChatSession.answer_pending_intervention`` →
+``handler.deliver_answer_to`` (= same path the TUI uses). The iv future
+is resolved by the handler; the bus is unaware. R-D12's persistent
+answer buffer captures the answer if a crash intervenes before the
+skill consumes it, so restart-resume picks up cleanly.
 
 Wired by ``mcp_server.send_to_agent_impl`` through
 ``ChatSession.register_intervention_override(chain_id, bus)``.
 
-Phase 2 (issue #254) — responsibility scope:
-
-  - ⭕ in-scope: deliver ``ask_user`` prompts to the A2A peer (= the
-    physical user surface for an async-mode A2A run) and receive the
-    peer's answer.  ``deliver`` is the canonical method; ``request``
-    is a Phase 2 backward-compat alias.
-  - ❌ out-of-scope: skill completion narration, intermediate progress
-    narration, direct writes to ``RunRegistry`` for run-lifecycle
-    events.  Those flow through PR #253's ``_handle_message_send``
-    auto-escalation path (sync→Task envelope on running-skill timeout)
-    and the OS's ``_handle_skill_completed`` event chain, both of which
-    are independent of this channel.  In particular this module MUST
-    NOT import ``_handle_skill_completed`` — pinned by Tier 2 test
-    (``tests/test_intervention_bus_protocols.py``).
+Scope guard:
+  - ⭕ in-scope: notify A2A peer of input-required state via webhook +
+    SSE buffer + RunEntry status mirror.
+  - ❌ out-of-scope: iv ownership (= ChatSession owns it post-α),
+    iv.future resolution (= handler does it), skill completion
+    narration (= flows through ``_handle_skill_completed``).
 """
 from __future__ import annotations
 
@@ -32,14 +48,17 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from reyn.user_intervention import InterventionAnswer, UserIntervention
+    from reyn.user_intervention import UserIntervention
     from reyn.web.run_registry import RunRegistry
 
 logger = logging.getLogger(__name__)
 
 
 class A2AInterventionBus:
-    """Per-task ``UserChannel`` that routes ``ask_user`` via RunRegistry."""
+    """Per-task A2A-side iv side-effect observer (post-α refactor).
+
+    issue #292 (α): no longer an iv owner; pure side-effect emitter.
+    """
 
     def __init__(self, run_id: str, registry: "RunRegistry") -> None:
         self._run_id = run_id
@@ -50,26 +69,31 @@ class A2AInterventionBus:
         """Stable channel identifier for issue #268 origin-pin routing.
 
         Format: ``a2a:<run_id>``. Used by:
-          - bus stamping of ``iv.origin_channel_id`` on each ``deliver``
-            (= so the iv carries provenance for cross-channel observe /
-            discard / claim)
-          - listener registration in ``_handle_async_mode._run`` so the
-            ``ChatSession.handle_intervention`` origin-pin check sees
-            this channel as alive while the A2A task is running
+          - bus stamping of ``iv.origin_channel_id`` on each ``on_dispatch``
+          - listener registration in ``send_to_agent_impl`` so the
+            agent's origin-pin check sees this channel as alive while
+            the A2A task is running.
         """
         return f"a2a:{self._run_id}"
 
-    async def deliver(self, iv: "UserIntervention") -> "InterventionAnswer":
-        """``UserChannel.deliver`` — route the prompt to the A2A peer
-        via RunRegistry + optional webhook, then block until the peer's
-        POST resolves ``iv.future``.
+    async def on_dispatch(self, iv: "UserIntervention") -> None:
+        """Fire A2A peer-facing side effects when ``iv`` is about to be
+        dispatched by the agent.
 
-        issue #268 Phase 2: stamps ``iv.origin_channel_id`` so the
-        agent layer can later attribute the iv to this A2A task (=
-        used by stall detection + cross-channel observe / claim).
-        Pre-existing stamping (= if a caller already set the field)
-        is respected — overwrite would clobber an explicit origin
-        from an upstream layer.
+        Called by ``ChatSession._dispatch_intervention`` for each iv
+        whose chain has this bus registered as an override. Runs
+        BEFORE ``InterventionHandler.dispatch`` so the peer learns
+        input-required before the awaiter blocks.
+
+        Side effects (each best-effort; failures logged, never raised):
+          1. Stamp ``iv.origin_channel_id`` with ``a2a:<run_id>`` (= for
+             #268 cross-channel routing).
+          2. Mirror ``status="input-required"`` on the RunEntry.
+          3. Append the input-required payload to
+             ``RunEntry.history_events`` for SSE replay (issue #267
+             Gap 1, payload shape per Gap 4).
+          4. POST the same payload to ``webhook_url`` if configured
+             (issue #267 Gap 2).
         """
         # issue #268 Phase 2: stamp origin channel for cross-channel routing.
         if iv.origin_channel_id is None:
@@ -77,32 +101,19 @@ class A2AInterventionBus:
 
         entry = self._registry.get(self._run_id)
         if entry is None:
-            raise RuntimeError(
-                f"A2AInterventionBus: run {self._run_id!r} not in registry"
+            logger.warning(
+                "A2AInterventionBus.on_dispatch: run %r not in registry "
+                "(= iv side effects skipped; dispatch will continue)",
+                self._run_id,
             )
+            return
 
-        # Publish: status=input-required + question + IV reference so
-        # POST /a2a/agents/<name> {task_id, answer} can resolve via
-        # RunRegistry.answer_intervention.
-        self._registry.update(
-            self._run_id,
-            status="input-required",
-            question=iv.prompt,
-            pending_intervention=iv,
-        )
+        # Mirror status. Post-α the iv itself lives in ChatSession's
+        # outstanding_interventions; we only reflect the high-level
+        # state on the RunEntry for peer polling visibility.
+        self._registry.update(self._run_id, status="input-required")
 
-        # Build the canonical input-required payload once + fan out to
-        # both A2A peer surfaces (issue #267 Gap 1 + Gap 4):
-        #
-        #   - SSE buffer (always): append to RunEntry.history_events so
-        #     ``GET /a2a/tasks/{run_id}/events`` streams the prompt to a
-        #     peer that connected via SSE.
-        #   - Webhook POST (opt-in): same payload pushed to webhook_url
-        #     when registered. ``kind`` + ``choices`` (Gap 4) let the
-        #     peer render structured affordance (= permission yes/no/always
-        #     hotkeys) instead of guessing from prompt text. ``detail`` is
-        #     included when present so the peer has the same context the
-        #     in-process TUI surfaces below the prompt.
+        # Build the canonical input-required payload (issue #267 Gap 4 shape).
         payload: dict = {
             "run_id": self._run_id,
             "status": "input-required",
@@ -117,32 +128,26 @@ class A2AInterventionBus:
         if iv.detail:
             payload["detail"] = iv.detail
 
+        # SSE buffer append (issue #267 Gap 1). Best-effort.
         try:
             self._registry.append_event(self._run_id, payload)
-        except Exception:  # noqa: BLE001 — sse buffer is best-effort
-            pass
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "A2AInterventionBus.on_dispatch: history_events append "
+                "failed for run %r", self._run_id,
+            )
 
+        # Webhook POST (issue #267 Gap 2). Best-effort, opt-in.
         if entry.webhook_url:
-            from reyn.web.notifications import post_webhook
+            from reyn.web.notifications import post_webhook  # noqa: PLC0415
 
-            await post_webhook(entry.webhook_url, payload)
-
-        # Block until the peer POSTs an answer (= registry.answer_intervention
-        # resolves iv.future).
-        answer = await iv.future
-        return answer
-
-    async def request(self, iv: "UserIntervention") -> "InterventionAnswer":
-        """``RequestBus.request`` — Phase 2 backward-compat alias.
-
-        Existing callers wired through
-        ``ChatSession.register_intervention_override`` still receive
-        this class typed as ``InterventionBus`` and invoke ``request``.
-        Delegates to ``deliver`` so the underlying behaviour is
-        unchanged.  Phase 3 will route OS-level requests through the
-        Agent, which will call ``deliver`` directly.
-        """
-        return await self.deliver(iv)
+            try:
+                await post_webhook(entry.webhook_url, payload)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "A2AInterventionBus.on_dispatch: webhook POST failed "
+                    "for run %r url=%s", self._run_id, entry.webhook_url,
+                )
 
 
 __all__ = ["A2AInterventionBus"]

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -343,7 +343,9 @@ async def _handle_message_send(
     # ── Mode 1: answer injection ──────────────────────────────────────────
     task_id = params.get("task_id")
     if task_id and isinstance(task_id, str):
-        return await _handle_answer_injection(req_id, task_id, params, run_registry)
+        return await _handle_answer_injection(
+            req_id, task_id, params, registry, run_registry,
+        )
 
     # ── Shared: extract text from message parts ───────────────────────────
     message = params.get("message")
@@ -594,12 +596,14 @@ async def _handle_answer_injection(
     req_id: Any,
     task_id: str,
     params: dict,
+    registry,
     run_registry,
 ) -> dict:
     """Deliver an answer to a pending ask_user intervention on an async task.
 
     Extracts text from ``params.message.parts`` (same as normal send),
-    then calls ``run_registry.answer_intervention``.
+    then routes to ``ChatSession.answer_pending_intervention`` (= issue
+    #292 α path).
 
     issue #267 Gap 4: also extracts ``choice_id`` for closed-set prompts
     (= permission.* / safety.limit.*). Resolution order, top → bottom:
@@ -609,6 +613,15 @@ async def _handle_answer_injection(
          structured-metadata channel.
 
     Free-text ``ask_user`` answers omit ``choice_id`` and travel unchanged.
+
+    issue #292 (α): pre-#292 this called
+    ``run_registry.answer_intervention`` which resolved a separate iv
+    future owned by RunRegistry. Post-α, the iv lives in ChatSession's
+    ``_interventions._active`` and the agent's
+    ``answer_pending_intervention`` is the single authoritative entry
+    point — R-D12's persistent answer buffer applies automatically so
+    a restart between peer-POST and skill-resume is now survivable.
+    The RunEntry is only consulted to find the owning agent.
     """
     from reyn.user_intervention import InterventionAnswer  # noqa: PLC0415
 
@@ -632,18 +645,40 @@ async def _handle_answer_injection(
     if isinstance(top_choice, str) and top_choice:
         choice_id = top_choice
 
+    # Look up the owning agent via RunEntry → load ChatSession →
+    # authoritative answer delivery.
+    entry = run_registry.get(task_id)
+    if entry is None:
+        return _jsonrpc_result(req_id, {
+            "task_id": task_id, "answered": False, "reason": "not found",
+        })
+
+    try:
+        session = registry.get_or_load(entry.agent_name)
+    except Exception:  # noqa: BLE001 — defensive (agent missing / load failure)
+        logger.exception(
+            "answer_injection: failed to load agent %r for task %r",
+            entry.agent_name, task_id,
+        )
+        return _jsonrpc_result(req_id, {
+            "task_id": task_id, "answered": False,
+            "reason": "agent unavailable",
+        })
+
     answer = InterventionAnswer(text=answer_text, choice_id=choice_id)
-    delivered = run_registry.answer_intervention(task_id, answer)
+    delivered = await session.answer_pending_intervention(task_id, answer)
 
     if delivered:
+        # Mirror status back to "running" on the RunEntry for peer
+        # polling. The actual iv resolution already happened in
+        # ChatSession; this is just the public-status mirror.
+        run_registry.update(task_id, status="running")
         result = {"task_id": task_id, "answered": True}
     else:
-        entry = run_registry.get(task_id)
-        if entry is None:
-            reason = "not found"
-        else:
-            reason = "already answered or no pending intervention"
-        result = {"task_id": task_id, "answered": False, "reason": reason}
+        result = {
+            "task_id": task_id, "answered": False,
+            "reason": "already answered or no pending intervention",
+        }
 
     return _jsonrpc_result(req_id, result)
 

--- a/src/reyn/web/run_registry.py
+++ b/src/reyn/web/run_registry.py
@@ -1,40 +1,33 @@
 """A2A task lifecycle registry (FP-0001 + issue #267 Gap 5 persistence).
 
 Tracks asyncio.Task instances spawned by POST /a2a/agents/<name> async-mode
-calls. Each entry carries status, any pending ask_user intervention,
-a webhook URL for push notifications, and a buffered event history
-for SSE replay. Concurrent access by FastAPI request handlers is
-serialised by ``RunRegistry`` internally; do NOT call from outside
-the asyncio event loop.
+calls. Each entry carries A2A-task-wrapper-owned state (status, result,
+error, webhook URL, SSE event buffer). Concurrent access by FastAPI
+request handlers is serialised by ``RunRegistry`` internally; do NOT
+call from outside the asyncio event loop.
 
 Persistence (issue #267 Gap 5):
 
 When ``RunRegistry`` is constructed with a ``persist_path``, every
 mutation rewrites the file atomically (= tmp file + ``Path.replace()``)
-so a server-process restart can reload the registry from disk. This
-closes the 「ChatSession side outstanding_interventions is persisted by
-PR-intervention-link L2-L6 but RunRegistry side is in-memory only」
-gap that left A2A peer routing half-restored on restart.
+so a server-process restart can reload the registry from disk.
+
+Persistence boundary (= issue #292 α refactor):
+
+Pre-#292, ``RunEntry`` also persisted ``pending_intervention`` (= the
+full ``UserIntervention`` object). That field has been **removed**:
+the iv is owned by ``ChatSession._interventions`` (= same machinery
+TUI ivs use, including R-D12's persistent answer buffer). What
+``RunRegistry`` persists is only the A2A-task-wrapper state.
 
 What persists:
-  - run_id, agent_name, chain_id, status, question, result, error
+  - run_id, agent_name, chain_id, status, result, error
   - webhook_url, history_events, created_at, updated_at
-  - pending_intervention (= via UserIntervention.to_dict, future excluded)
 
 What does NOT persist (= volatile, restored as ``None`` / dropped):
   - asyncio.Task reference (= bound to the process that died)
-  - UserIntervention.future (= fresh future allocated on from_dict)
-
-Restore semantics (= what the rebuilt ``RunEntry`` looks like after a
-process restart):
-  - All public state fields restored from JSON
-  - ``task`` is ``None`` (= caller can re-spawn if applicable, but the
-    original skill execution is gone with the prior process)
-  - ``pending_intervention``: if present, restored ``UserIntervention``
-    with a fresh future. The full rebind to the ChatSession side iv
-    (= so peer answers reach the ChatSession's restored
-    InterventionRegistry queue) is a Gap 5 Phase 2 follow-up; this
-    PR ships the persistence infrastructure alone.
+  - pending iv state (= owned by ChatSession; queried at request time
+    rather than mirrored here)
 """
 from __future__ import annotations
 
@@ -45,23 +38,22 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class RunEntry:
-    """One A2A async task. Mutable; ``RunRegistry`` owns lifecycle."""
+    """One A2A async task. Mutable; ``RunRegistry`` owns lifecycle.
+
+    issue #292 (α): ``pending_intervention`` and ``question`` fields
+    removed — iv state lives in ``ChatSession._interventions``. This
+    entry only carries A2A-task-wrapper state.
+    """
     run_id: str
     agent_name: str
     chain_id: str
     status: str = "running"
-    question: str | None = None
-    pending_intervention: "UserIntervention | None" = None
     result: str | None = None
     error: str | None = None
     webhook_url: str | None = None
@@ -72,13 +64,12 @@ class RunEntry:
 
     def to_public_dict(self) -> dict:
         """JSON-safe shape for GET /a2a/tasks/{run_id} responses.
-        Drops asyncio.Task and UserIntervention (= internal-only)."""
+        Drops asyncio.Task (= internal-only)."""
         return {
             "run_id": self.run_id,
             "agent_name": self.agent_name,
             "chain_id": self.chain_id,
             "status": self.status,
-            "question": self.question,
             "result": self.result,
             "error": self.error,
             "created_at": self.created_at.isoformat(),
@@ -86,25 +77,21 @@ class RunEntry:
         }
 
     def to_persist_dict(self) -> dict:
-        """Persistence-safe shape (issue #267 Gap 5).
+        """Persistence-safe shape (issue #267 Gap 5 + issue #292 α).
 
-        Includes more fields than ``to_public_dict`` because the
-        registry's own restore path needs them: webhook_url for
-        post-restart peer notifications, history_events for SSE
-        replay continuity, pending_intervention (via
-        ``UserIntervention.to_dict``) so the peer-binding can be
-        re-established by a Gap 5 Phase 2 follow-up.
+        Includes webhook_url + history_events for post-restart peer
+        notification + SSE replay continuity. iv state (formerly
+        ``pending_intervention``) is owned by ChatSession and persisted
+        via AgentSnapshot — see issue #292 body for the layering.
 
         Excludes volatile fields:
           - ``task``: asyncio.Task is bound to the dead process
-          - ``pending_intervention.future``: re-allocated on from_dict
         """
-        out: dict = {
+        return {
             "run_id": self.run_id,
             "agent_name": self.agent_name,
             "chain_id": self.chain_id,
             "status": self.status,
-            "question": self.question,
             "result": self.result,
             "error": self.error,
             "webhook_url": self.webhook_url,
@@ -112,29 +99,16 @@ class RunEntry:
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
         }
-        if self.pending_intervention is not None:
-            out["pending_intervention"] = self.pending_intervention.to_dict()
-        return out
 
     @classmethod
     def from_persist_dict(cls, data: dict) -> "RunEntry":
-        """Inverse of ``to_persist_dict`` (issue #267 Gap 5).
+        """Inverse of ``to_persist_dict``.
 
-        Rebuilds a ``RunEntry`` from the persistence snapshot:
-          - ``task`` set to ``None`` (= cannot resurrect dead asyncio.Task)
-          - ``pending_intervention``: if present in data, re-create
-            ``UserIntervention`` via ``from_dict`` (= fresh future)
-          - timestamps parsed from ISO strings; tolerate missing or
-            malformed fields by falling back to ``now()`` so a
-            corrupt snapshot doesn't poison the restore loop
+        Rebuilds a ``RunEntry`` from the persistence snapshot. Tolerant
+        of pre-#292 snapshots that included ``pending_intervention`` /
+        ``question`` keys (= silently ignored, the iv is restored via
+        ChatSession's AgentSnapshot instead).
         """
-        # Lazy import to avoid circular dependency.
-        from reyn.user_intervention import UserIntervention
-
-        iv = None
-        iv_data = data.get("pending_intervention")
-        if iv_data:
-            iv = UserIntervention.from_dict(iv_data)
 
         def _parse_ts(value: object) -> datetime:
             if isinstance(value, str):
@@ -149,8 +123,6 @@ class RunEntry:
             agent_name=str(data.get("agent_name", "")),
             chain_id=str(data.get("chain_id", "")),
             status=str(data.get("status", "running")),
-            question=data.get("question"),
-            pending_intervention=iv,
             result=data.get("result"),
             error=data.get("error"),
             webhook_url=data.get("webhook_url"),
@@ -281,22 +253,18 @@ class RunRegistry:
         run_id: str,
         *,
         status: str | None = None,
-        question: str | None = None,
-        pending_intervention: "UserIntervention | None" = None,
         result: str | None = None,
         error: str | None = None,
     ) -> RunEntry | None:
+        """Update task-wrapper state. issue #292 (α): ``question`` and
+        ``pending_intervention`` params removed — iv lifecycle is owned
+        by ChatSession.
+        """
         entry = self._runs.get(run_id)
         if entry is None:
             return None
         if status is not None:
             entry.status = status
-        if question is not None:
-            entry.question = question
-        # pending_intervention can be set to None explicitly (= clearing)
-        if pending_intervention is not None or status == "running":
-            # status="running" after answer → also clear pending fields
-            entry.pending_intervention = pending_intervention
         if result is not None:
             entry.result = result
         if error is not None:
@@ -309,28 +277,6 @@ class RunRegistry:
         if entry := self._runs.get(run_id):
             entry.task = task
         # NB: task is volatile (= not persisted), no _persist() call.
-
-    def answer_intervention(self, run_id: str, answer: "InterventionAnswer") -> bool:
-        """Deliver ``answer`` to the run's pending intervention.
-
-        Returns True iff the intervention was resolved (= run exists,
-        has a pending intervention whose future isn't already done).
-        After delivery, ``status`` returns to 'running' and ``question``
-        is cleared.
-        """
-        entry = self._runs.get(run_id)
-        if entry is None or entry.pending_intervention is None:
-            return False
-        iv = entry.pending_intervention
-        if iv.future.done():
-            return False
-        iv.future.set_result(answer)
-        entry.pending_intervention = None
-        entry.question = None
-        entry.status = "running"
-        entry.updated_at = datetime.now(timezone.utc)
-        self._persist()
-        return True
 
     def cancel(self, run_id: str) -> bool:
         """Cancel the task if running; mark status='cancelled'.

--- a/tests/test_a2a_bus_stamping_268_phase2.py
+++ b/tests/test_a2a_bus_stamping_268_phase2.py
@@ -73,11 +73,11 @@ def test_a2a_intervention_bus_channel_id_reflects_run_id() -> None:
 # ── 2. deliver stamps iv.origin_channel_id ────────────────────────────
 
 
-def test_deliver_stamps_origin_channel_id_when_unset() -> None:
-    """Tier 2: ``deliver`` sets ``iv.origin_channel_id`` to the bus's
-    ``channel_id`` when the iv was created without one (= the typical
-    case for skill-emitted ivs that don't know which channel they're
-    being delivered to).
+def test_on_dispatch_stamps_origin_channel_id_when_unset() -> None:
+    """Tier 2: ``on_dispatch`` sets ``iv.origin_channel_id`` to the bus's
+    ``channel_id`` when the iv was created without one. issue #292
+    α: renamed from ``deliver`` to ``on_dispatch`` — semantics
+    (side-effect observer) preserved for the stamping contract.
     """
     registry = RunRegistry()
     entry = registry.create(agent_name="demo", chain_id="chain-A")
@@ -85,23 +85,17 @@ def test_deliver_stamps_origin_channel_id_when_unset() -> None:
 
     async def _drive() -> str | None:
         iv = UserIntervention(kind="ask_user", prompt="?")
-        # Schedule deliver, resolve the iv's future to let deliver return.
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="ok"))
-        await task
+        await bus.on_dispatch(iv)
         return iv.origin_channel_id
 
     stamped = asyncio.run(_drive())
     assert stamped == f"a2a:{entry.run_id}"
 
 
-def test_deliver_respects_preexisting_origin_channel_id() -> None:
+def test_on_dispatch_respects_preexisting_origin_channel_id() -> None:
     """Tier 2: when an iv arrives with ``origin_channel_id`` already
-    set (= e.g. an upstream agent's bus already stamped it for
-    multi-hop delegation), ``deliver`` does NOT overwrite. Preserves
-    the origin's provenance for cross-channel routing decisions.
+    set (= e.g. upstream multi-hop delegation), ``on_dispatch`` does
+    NOT overwrite.
     """
     registry = RunRegistry()
     entry = registry.create(agent_name="demo", chain_id="chain-A")
@@ -113,11 +107,7 @@ def test_deliver_respects_preexisting_origin_channel_id() -> None:
             prompt="?",
             origin_channel_id="upstream:custom",
         )
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="ok"))
-        await task
+        await bus.on_dispatch(iv)
         return iv.origin_channel_id
 
     stamped = asyncio.run(_drive())

--- a/tests/test_a2a_iv_kind_choices_267_gap4.py
+++ b/tests/test_a2a_iv_kind_choices_267_gap4.py
@@ -80,11 +80,7 @@ def test_webhook_payload_includes_kind_and_choices(monkeypatch) -> None:
                 InterventionChoice(id="no", label="[N]o", hotkey="n"),
             ],
         )
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="yes", choice_id="yes"))
-        await task
+        await bus.on_dispatch(iv)
 
     asyncio.run(_drive())
 
@@ -130,11 +126,7 @@ def test_webhook_payload_omits_detail_when_empty(monkeypatch) -> None:
             prompt="What's your name?",
             detail="",  # empty
         )
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="alice"))
-        await task
+        await bus.on_dispatch(iv)
 
     asyncio.run(_drive())
 
@@ -170,11 +162,7 @@ def test_webhook_payload_free_text_ask_user_has_empty_choices(monkeypatch) -> No
 
     async def _drive() -> None:
         iv = UserIntervention(kind="ask_user", prompt="Free text?")
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="ok"))
-        await task
+        await bus.on_dispatch(iv)
 
     asyncio.run(_drive())
 
@@ -192,223 +180,142 @@ def test_webhook_payload_free_text_ask_user_has_empty_choices(monkeypatch) -> No
 # ── 2. Inbound choice_id extraction ───────────────────────────────────
 
 
-def test_handle_answer_injection_extracts_top_level_choice_id() -> None:
-    """Tier 2: ``params.choice_id`` (= top-level convenience) is extracted
-    and passed into ``InterventionAnswer.choice_id``.
+class _FakeAgentRegistry:
+    """Minimal stub — ``_handle_answer_injection`` only calls
+    ``get_or_load(name)``. Returns a captured ChatSession-shape stub.
+    """
+
+    def __init__(self, session) -> None:
+        self._session = session
+
+    def get_or_load(self, name: str):  # noqa: ANN202
+        return self._session
+
+
+class _FakeChatSession:
+    """Captures ``answer_pending_intervention`` calls. issue #292 (α):
+    the iv future is owned by ChatSession; the router calls this method
+    instead of ``RunRegistry.answer_intervention`` (= removed).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, InterventionAnswer]] = []
+        # Configurable return for the "already answered" path.
+        self.return_value = True
+
+    async def answer_pending_intervention(
+        self, run_id: str, answer: InterventionAnswer,
+    ) -> bool:
+        self.calls.append((run_id, answer))
+        return self.return_value
+
+
+def _run_answer_injection(*, params: dict, run_id: str) -> _FakeChatSession:
+    """Drive ``_handle_answer_injection`` with a real RunRegistry and
+    fake agent registry, return the captured FakeChatSession.
     """
     from reyn.web.routers.a2a import _handle_answer_injection
 
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-A")
-    iv = UserIntervention(
-        kind="permission.confirm",
-        prompt="?",
-        choices=[
-            InterventionChoice(id="yes", label="[Y]", hotkey="y"),
-            InterventionChoice(id="no", label="[N]", hotkey="n"),
-        ],
-    )
-    registry.update(
-        entry.run_id,
-        status="input-required",
-        pending_intervention=iv,
-    )
+    run_registry = RunRegistry()
+    # Inject a pre-existing RunEntry so the router can find the agent.
+    run_registry.create(agent_name="demo", chain_id="chain-A")
+    # Map run_id to the test's chosen value.
+    list(run_registry._runs.values())[0].run_id = run_id  # noqa: SLF001
+    run_registry._runs = {run_id: list(run_registry._runs.values())[0]}  # noqa: SLF001
 
-    captured: list[InterventionAnswer] = []
-    original_answer = registry.answer_intervention
-
-    def _capture(task_id: str, answer: InterventionAnswer):  # noqa: ANN202
-        captured.append(answer)
-        return original_answer(task_id, answer)
-
-    registry.answer_intervention = _capture  # type: ignore[method-assign]
+    session = _FakeChatSession()
+    agent_registry = _FakeAgentRegistry(session)
 
     asyncio.run(
         _handle_answer_injection(
             req_id=1,
-            task_id=entry.run_id,
-            params={
-                "task_id": entry.run_id,
-                "choice_id": "yes",
-                "message": {"parts": [{"type": "text", "text": "yes"}]},
-            },
-            run_registry=registry,
+            task_id=run_id,
+            params=params,
+            registry=agent_registry,
+            run_registry=run_registry,
         )
     )
+    return session
 
-    assert len(captured) == 1
-    assert captured[0].text == "yes"
-    assert captured[0].choice_id == "yes"
+
+def test_handle_answer_injection_extracts_top_level_choice_id() -> None:
+    """Tier 2: ``params.choice_id`` (= top-level convenience) is extracted
+    and passed into ``InterventionAnswer.choice_id`` for the
+    ChatSession-side delivery (issue #292 α).
+    """
+    session = _run_answer_injection(
+        run_id="run-tlc",
+        params={
+            "task_id": "run-tlc",
+            "choice_id": "yes",
+            "message": {"parts": [{"type": "text", "text": "yes"}]},
+        },
+    )
+    assert len(session.calls) == 1
+    delivered_run_id, answer = session.calls[0]
+    assert delivered_run_id == "run-tlc"
+    assert answer.text == "yes"
+    assert answer.choice_id == "yes"
 
 
 def test_handle_answer_injection_extracts_message_metadata_choice_id() -> None:
-    """Tier 2: ``params.message.metadata.choice_id`` (= A2A-spec-conforming
-    structured channel) is extracted when top-level absent.
+    """Tier 2: ``params.message.metadata.choice_id`` is extracted when
+    top-level absent.
     """
-    from reyn.web.routers.a2a import _handle_answer_injection
-
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-A")
-    iv = UserIntervention(
-        kind="permission.confirm", prompt="?",
-        choices=[InterventionChoice(id="always", label="[A]", hotkey="a")],
-    )
-    registry.update(
-        entry.run_id, status="input-required", pending_intervention=iv,
-    )
-
-    captured: list[InterventionAnswer] = []
-    original_answer = registry.answer_intervention
-
-    def _capture(task_id, answer):  # noqa: ANN202
-        captured.append(answer)
-        return original_answer(task_id, answer)
-
-    registry.answer_intervention = _capture  # type: ignore[method-assign]
-
-    asyncio.run(
-        _handle_answer_injection(
-            req_id=1,
-            task_id=entry.run_id,
-            params={
-                "task_id": entry.run_id,
-                "message": {
-                    "parts": [{"type": "text", "text": "a"}],
-                    "metadata": {"choice_id": "always"},
-                },
+    session = _run_answer_injection(
+        run_id="run-md",
+        params={
+            "task_id": "run-md",
+            "message": {
+                "parts": [{"type": "text", "text": "a"}],
+                "metadata": {"choice_id": "always"},
             },
-            run_registry=registry,
-        )
+        },
     )
-
-    assert captured[0].choice_id == "always"
-    assert captured[0].text == "a"
+    assert session.calls[0][1].choice_id == "always"
+    assert session.calls[0][1].text == "a"
 
 
 def test_handle_answer_injection_top_level_wins_over_metadata() -> None:
-    """Tier 2: when both top-level ``params.choice_id`` AND
-    ``params.message.metadata.choice_id`` are present, top-level wins
-    (= explicit-most call shape wins by convention).
-    """
-    from reyn.web.routers.a2a import _handle_answer_injection
-
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-A")
-    iv = UserIntervention(
-        kind="permission.confirm", prompt="?",
-        choices=[
-            InterventionChoice(id="yes", label="[Y]", hotkey="y"),
-            InterventionChoice(id="no", label="[N]", hotkey="n"),
-        ],
-    )
-    registry.update(
-        entry.run_id, status="input-required", pending_intervention=iv,
-    )
-
-    captured: list[InterventionAnswer] = []
-    original_answer = registry.answer_intervention
-
-    def _capture(task_id, answer):  # noqa: ANN202
-        captured.append(answer)
-        return original_answer(task_id, answer)
-
-    registry.answer_intervention = _capture  # type: ignore[method-assign]
-
-    asyncio.run(
-        _handle_answer_injection(
-            req_id=1,
-            task_id=entry.run_id,
-            params={
-                "task_id": entry.run_id,
-                "choice_id": "yes",
-                "message": {
-                    "parts": [{"type": "text", "text": "yes"}],
-                    "metadata": {"choice_id": "no"},
-                },
+    """Tier 2: when both are present, top-level wins."""
+    session = _run_answer_injection(
+        run_id="run-prec",
+        params={
+            "task_id": "run-prec",
+            "choice_id": "yes",
+            "message": {
+                "parts": [{"type": "text", "text": "yes"}],
+                "metadata": {"choice_id": "no"},
             },
-            run_registry=registry,
-        )
+        },
     )
-
-    assert captured[0].choice_id == "yes"
+    assert session.calls[0][1].choice_id == "yes"
 
 
 def test_handle_answer_injection_omits_choice_id_for_free_text() -> None:
-    """Tier 2: free-text ``ask_user`` answer (= no ``choice_id`` in
-    params) results in ``InterventionAnswer(text=..., choice_id=None)``
-    — pre-Gap-4 behaviour preserved.
-    """
-    from reyn.web.routers.a2a import _handle_answer_injection
-
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-A")
-    iv = UserIntervention(kind="ask_user", prompt="?")
-    registry.update(
-        entry.run_id, status="input-required", pending_intervention=iv,
+    """Tier 2: free-text ``ask_user`` answer → ``choice_id=None``."""
+    session = _run_answer_injection(
+        run_id="run-free",
+        params={
+            "task_id": "run-free",
+            "message": {"parts": [{"type": "text", "text": "alice"}]},
+        },
     )
-
-    captured: list[InterventionAnswer] = []
-    original_answer = registry.answer_intervention
-
-    def _capture(task_id, answer):  # noqa: ANN202
-        captured.append(answer)
-        return original_answer(task_id, answer)
-
-    registry.answer_intervention = _capture  # type: ignore[method-assign]
-
-    asyncio.run(
-        _handle_answer_injection(
-            req_id=1,
-            task_id=entry.run_id,
-            params={
-                "task_id": entry.run_id,
-                "message": {"parts": [{"type": "text", "text": "alice"}]},
-            },
-            run_registry=registry,
-        )
-    )
-
-    assert captured[0].text == "alice"
-    assert captured[0].choice_id is None
+    assert session.calls[0][1].text == "alice"
+    assert session.calls[0][1].choice_id is None
 
 
 def test_handle_answer_injection_ignores_non_string_choice_id() -> None:
-    """Tier 2: defensive — non-string ``choice_id`` (= e.g. peer sent
-    a number or null) is ignored, falls through to None. Avoids
-    propagating malformed peer input into the answer record.
-    """
-    from reyn.web.routers.a2a import _handle_answer_injection
-
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-A")
-    iv = UserIntervention(kind="ask_user", prompt="?")
-    registry.update(
-        entry.run_id, status="input-required", pending_intervention=iv,
-    )
-
-    captured: list[InterventionAnswer] = []
-    original_answer = registry.answer_intervention
-
-    def _capture(task_id, answer):  # noqa: ANN202
-        captured.append(answer)
-        return original_answer(task_id, answer)
-
-    registry.answer_intervention = _capture  # type: ignore[method-assign]
-
-    asyncio.run(
-        _handle_answer_injection(
-            req_id=1,
-            task_id=entry.run_id,
-            params={
-                "task_id": entry.run_id,
-                "choice_id": 42,  # non-string
-                "message": {
-                    "parts": [{"type": "text", "text": "x"}],
-                    "metadata": {"choice_id": None},  # also non-string
-                },
+    """Tier 2: non-string ``choice_id`` is ignored → choice_id=None."""
+    session = _run_answer_injection(
+        run_id="run-bad",
+        params={
+            "task_id": "run-bad",
+            "choice_id": 42,  # non-string
+            "message": {
+                "parts": [{"type": "text", "text": "x"}],
+                "metadata": {"choice_id": None},  # also non-string
             },
-            run_registry=registry,
-        )
+        },
     )
-
-    assert captured[0].choice_id is None
+    assert session.calls[0][1].choice_id is None

--- a/tests/test_a2a_sse_producer_267_gap1.py
+++ b/tests/test_a2a_sse_producer_267_gap1.py
@@ -258,11 +258,11 @@ def test_webhook_sink_failure_does_not_block_sse(monkeypatch) -> None:
 # ── 5. A2AInterventionBus.deliver appends input-required ──────────────
 
 
-def test_a2a_intervention_bus_deliver_appends_input_required_to_history() -> None:
-    """Tier 2: ``A2AInterventionBus.deliver`` appends the
-    input-required payload to RunEntry.history_events BEFORE the
-    (optional) webhook POST. SSE consumers see ask_user prompts inline
-    with the progress stream.
+def test_a2a_intervention_bus_on_dispatch_appends_input_required_to_history() -> None:
+    """Tier 2: ``A2AInterventionBus.on_dispatch`` appends the
+    input-required payload to RunEntry.history_events. SSE consumers
+    see ask_user prompts inline with the progress stream. issue #292
+    α: renamed from ``deliver`` to ``on_dispatch``.
     """
     registry = RunRegistry()
     entry = registry.create(
@@ -277,11 +277,7 @@ def test_a2a_intervention_bus_deliver_appends_input_required_to_history() -> Non
             prompt="Allow read?",
             choices=[InterventionChoice(id="yes", label="[Y]", hotkey="y")],
         )
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="yes", choice_id="yes"))
-        await task
+        await bus.on_dispatch(iv)
 
     asyncio.run(_drive())
 
@@ -311,11 +307,7 @@ def test_a2a_intervention_bus_appends_history_even_without_webhook() -> None:
 
     async def _drive() -> None:
         iv = UserIntervention(kind="ask_user", prompt="?")
-        task = asyncio.ensure_future(bus.deliver(iv))
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        iv.future.set_result(InterventionAnswer(text="ok"))
-        await task
+        await bus.on_dispatch(iv)
 
     asyncio.run(_drive())
     assert len(registry.get(entry.run_id).history_events) == 1

--- a/tests/test_chat_bus_stamping_268_continued.py
+++ b/tests/test_chat_bus_stamping_268_continued.py
@@ -319,27 +319,31 @@ def test_chat_bus_skips_stamping_when_chain_override_active(tmp_path: Path) -> N
     ``origin_channel_id=None`` slot to stamp ``a2a:<run_id>`` instead.
 
     Critical correctness contract: WITHOUT this skip, A2A-spawned skill
-    ivs would carry ``origin_channel_id="tui"`` (= bus default), then
-    in _dispatch_intervention the override path runs FIRST (= delivers
-    to A2A peer correctly), but the iv body that the peer sees has
-    "tui" as the origin — a wrong provenance claim. The peer's ack /
+    ivs would carry ``origin_channel_id="tui"`` (= bus default) and the
+    A2A observer's ``on_dispatch`` would see a pre-stamped iv → could
+    not assign the correct ``a2a:<run_id>`` origin → peer's ack /
     observe / claim machinery (= future Phase) would route based on
-    that wrong origin.
+    the wrong origin.
+
+    issue #292 (α): the override is a side-effect observer with
+    ``on_dispatch`` (= not ``request``). The skip-stamping logic is
+    unchanged: ChatInterventionBus.deliver inspects whether an
+    override is registered for the chain and skips its stamp if so,
+    leaving the slot clean for the observer.
     """
     session = ChatSession(agent_name="t")
+    session.register_intervention_listener("test")
 
-    # Simulate A2A-style override registration for chain "chain-A2A".
-    class _CapturingOverride:
+    # Simulate A2A-style override observer for chain "chain-A2A".
+    class _CapturingObserver:
         def __init__(self) -> None:
             self.received: list[UserIntervention] = []
 
-        async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        async def on_dispatch(self, iv: UserIntervention) -> None:
             self.received.append(iv)
-            return InterventionAnswer(text="from-override")
 
-    override = _CapturingOverride()
+    override = _CapturingObserver()
     session.register_intervention_override("chain-A2A", override)
-    # Wire run_id → chain mapping so _dispatch_intervention can resolve.
     session.running_skills_chain["run-A2A"] = "chain-A2A"
 
     bus = ChatInterventionBus(
@@ -349,18 +353,26 @@ def test_chat_bus_skips_stamping_when_chain_override_active(tmp_path: Path) -> N
 
     async def _drive() -> str | None:
         iv = UserIntervention(kind="ask_user", prompt="?")
-        answer = await bus.deliver(iv)
-        assert answer.text == "from-override"
+
+        async def _resolve() -> None:
+            await asyncio.sleep(0.05)
+            iv.future.set_result(InterventionAnswer(text="from-handler"))
+
+        resolver = asyncio.create_task(_resolve())
+        try:
+            await bus.deliver(iv)
+        finally:
+            resolver.cancel()
         return iv.origin_channel_id
 
     stamped = asyncio.run(_drive())
     assert stamped is None, (
         f"ChatInterventionBus must NOT stamp origin_channel_id when "
-        f"chain override is active (got {stamped!r}); leave the slot "
-        f"clean so A2AInterventionBus.deliver downstream can stamp "
-        f"the correct a2a:<run_id> value."
+        f"a chain override observer is active (got {stamped!r}); the "
+        f"slot stays clean so the A2A observer can stamp "
+        f"a2a:<run_id> downstream."
     )
-    # And the override actually saw the iv.
+    # Observer was notified as a side effect (= α decorator semantics).
     assert len(override.received) == 1
 
 

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -278,12 +278,15 @@ def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> Non
 
 
 def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
-    """Tier 2: POST /a2a/agents/{name} with params.task_id set delivers an
-    InterventionAnswer to the run's pending_intervention and returns
-    {"answered": True} when the intervention is active.
+    """Tier 2: POST /a2a/agents/{name} with params.task_id set delivers
+    an InterventionAnswer to the agent's pending intervention and
+    returns ``{"answered": True}``.
 
-    We populate a pending intervention by hand (using UserIntervention +
-    asyncio.Future) without going through the full async stack.
+    issue #292 (α): iv lives in ``ChatSession._interventions._active``,
+    NOT in ``RunEntry.pending_intervention`` (removed). We seed the iv
+    directly into the agent's intervention registry; the router looks
+    up the agent via the RunEntry's ``agent_name`` and calls
+    ``ChatSession.answer_pending_intervention``.
     """
     from fastapi.testclient import TestClient
 
@@ -321,17 +324,24 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
     run_registry = RunRegistry()
     entry = run_registry.create(agent_name="demo", chain_id="chain-iv")
 
-    # Populate a pending intervention on the entry.
+    # Seed the iv directly into the agent's outstanding intervention
+    # queue (= post-α: ChatSession owns iv state). Use the same loop
+    # the TestClient will drive so the future is on the right loop.
     loop = asyncio.new_event_loop()
     try:
-        iv_future: asyncio.Future = loop.create_future()
-        iv = UserIntervention(kind="ask_user", prompt="What is your name?", future=iv_future)
-        run_registry.update(
-            entry.run_id,
-            status="input-required",
-            question=iv.prompt,
-            pending_intervention=iv,
+        session = registry.get_or_load("demo")
+        iv_future = loop.create_future()
+        iv = UserIntervention(
+            kind="ask_user",
+            prompt="What is your name?",
+            run_id=entry.run_id,
+            future=iv_future,
         )
+        # Insert into the registry's active queue (= bypasses dispatch
+        # for test setup simplicity; production goes through
+        # InterventionHandler.dispatch).
+        session._interventions._active[iv.id] = iv
+        session._interventions._order.append(iv.id)
 
         app.dependency_overrides[get_registry] = lambda: registry
         app.dependency_overrides[get_run_registry] = lambda: run_registry
@@ -359,9 +369,10 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
             assert result["task_id"] == entry.run_id
             assert result["answered"] is True
 
-            # The future must have been resolved with the answer text.
-            # (loop.run_until_complete would block; check via done() instead)
-            assert iv_future.done(), "intervention future must be resolved after answer injection"
+            # Future resolved with the answer text.
+            assert iv_future.done(), (
+                "iv future must be resolved after answer injection"
+            )
             resolved = iv_future.result()
             assert resolved.text == "Alice"
         finally:

--- a/tests/test_fp0001_a2a_intervention_bus.py
+++ b/tests/test_fp0001_a2a_intervention_bus.py
@@ -1,19 +1,35 @@
-"""Tier 1: FP-0001 A2AInterventionBus — contract tests.
+"""Tier 2: A2AInterventionBus — contract tests (post-issue-#292 α refactor).
 
-Covers:
-1. request(iv) updates the run entry: status='input-required', question=iv.prompt,
-   pending_intervention is iv
-2. Without a webhook URL, no webhook is fired (webhook_url=None)
-3. request(iv) awaits iv.future — scheduling registry.answer_intervention from
-   a separate task; assert request returns the same answer
-4. RunRegistry.answer_intervention transitions status back to 'running'
-   (verified via registry.get after request returns)
-5. Constructor raises RuntimeError when registry has no such run_id
+Pre-#292 this file pinned the bus as an iv owner: ``request(iv)``
+awaited ``iv.future`` and returned the answer; the iv was stored in
+``RunEntry.pending_intervention``. The pre-α architecture is described
+in issue #292 body (= "A2A override completely bypasses ChatSession's
+iv machinery"); see history of this file in git for the old test
+shape.
 
-For the webhook-fires path, httpx.MockTransport (real httpx client with a
-deterministic transport) is used — no MagicMock / AsyncMock / patch.
-Real RunRegistry, real UserIntervention, and real InterventionAnswer are used
-throughout.
+Post-α the bus is a **side-effect observer**: ``on_dispatch(iv)`` is
+invoked by ``ChatSession._dispatch_intervention`` for chain-registered
+overrides and runs A2A peer-facing notifications (RunRegistry status
+mirror, SSE history append, webhook POST) without taking iv
+ownership. The iv lives in ``ChatSession._interventions._active`` and
+the future is awaited by ``InterventionHandler.dispatch`` like any
+other (= TUI) iv.
+
+Pins (= α contract):
+
+  1. ``A2AInterventionBus.on_dispatch(iv)`` exists; ``request`` /
+     ``deliver`` are removed (= peer answers no longer flow through
+     the bus; they flow through ``ChatSession.answer_pending_intervention``).
+  2. ``on_dispatch`` mirrors ``status="input-required"`` on the RunEntry.
+  3. ``on_dispatch`` does NOT write ``pending_intervention`` to
+     RunEntry (= the field is dropped from RunEntry entirely).
+  4. ``on_dispatch`` does NOT await ``iv.future`` (= it returns
+     promptly so dispatch can continue to the handler).
+  5. ``on_dispatch`` posts a webhook when ``webhook_url`` is configured
+     and skips it when None.
+  6. ``on_dispatch`` is best-effort: missing RunEntry → warning log,
+     no raise. Side-effect failure (= webhook 500, broken append_event)
+     → swallowed.
 """
 from __future__ import annotations
 
@@ -23,11 +39,9 @@ import json
 import httpx
 import pytest
 
-from reyn.user_intervention import InterventionAnswer, UserIntervention
+from reyn.user_intervention import UserIntervention
 from reyn.web.a2a_intervention import A2AInterventionBus
-from reyn.web.run_registry import RunRegistry
-
-# ── helpers ────────────────────────────────────────────────────────────────────
+from reyn.web.run_registry import RunEntry, RunRegistry
 
 
 def _make_registry_with_run(
@@ -39,231 +53,243 @@ def _make_registry_with_run(
     registry = RunRegistry()
     entry = registry.create(
         agent_name=agent_name,
-        chain_id="chain-abc",
+        chain_id="test-chain",
         webhook_url=webhook_url,
     )
     return registry, entry.run_id
 
 
-def _make_iv(prompt: str = "Which environment?") -> UserIntervention:
-    return UserIntervention(kind="ask_user", prompt=prompt)
+# ── 1. API surface ─────────────────────────────────────────────────────────────
 
 
-# ── 1. request updates run entry ──────────────────────────────────────────────
+def test_bus_exposes_on_dispatch_not_request_or_deliver() -> None:
+    """Tier 2: α contract — ``on_dispatch`` is the only public method.
+    ``request`` / ``deliver`` (= pre-α names that returned an answer)
+    are removed because peer answers no longer flow through the bus.
+    """
+    registry = RunRegistry()
+    bus = A2AInterventionBus(run_id="x", registry=registry)
+    assert hasattr(bus, "on_dispatch")
+    assert not hasattr(bus, "request")
+    assert not hasattr(bus, "deliver")
 
 
-@pytest.mark.asyncio
-async def test_request_sets_input_required_status() -> None:
-    """Tier 1: request(iv) sets status='input-required' and stores question + IV."""
+def test_bus_channel_id_format_unchanged() -> None:
+    """Tier 2: ``channel_id`` is still ``a2a:<run_id>`` (= issue #268
+    contract preserved across the α refactor).
+    """
+    registry = RunRegistry()
+    bus = A2AInterventionBus(run_id="abc123", registry=registry)
+    assert bus.channel_id == "a2a:abc123"
+
+
+# ── 2. Status mirror ───────────────────────────────────────────────────────────
+
+
+def test_on_dispatch_mirrors_input_required_status() -> None:
+    """Tier 2: ``on_dispatch`` flips RunEntry.status to ``"input-required"``
+    so polling peers see the pending state. The iv itself stays in
+    ChatSession; this is a public-status mirror only.
+    """
     registry, run_id = _make_registry_with_run()
-    bus = A2AInterventionBus(run_id, registry)
-    iv = _make_iv("Pick a region")
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
 
-    # Schedule the answer delivery so request() doesn't block forever.
-    answer = InterventionAnswer(text="us-east-1")
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
 
-    async def _deliver():
-        await asyncio.sleep(0)  # yield to let request() reach the await
-        registry.answer_intervention(run_id, answer)
+    asyncio.run(_drive())
 
-    task = asyncio.create_task(_deliver())
-
-    await bus.request(iv)
-    await task
-
-    # After request() returns the entry is back to 'running' (verified in #4).
-    # Check that during the window the entry was correctly set.
-    # We capture state inside the delivery helper by inspecting before resolving.
+    assert registry.get(run_id).status == "input-required"
 
 
-@pytest.mark.asyncio
-async def test_request_stores_question_and_pending_iv() -> None:
-    """Tier 1: run entry holds question=iv.prompt and pending_intervention=iv
-    immediately after the registry.update call inside request."""
+def test_on_dispatch_does_not_write_pending_intervention_to_run_entry() -> None:
+    """Tier 2: α contract — the RunEntry has NO ``pending_intervention``
+    field. The iv lives in ChatSession's outstanding_interventions.
+    Verifies the dataclass shape change ships cleanly.
+    """
     registry, run_id = _make_registry_with_run()
-    bus = A2AInterventionBus(run_id, registry)
-    iv = _make_iv("Which env?")
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
 
-    captured_entry: dict = {}
-    answer = InterventionAnswer(text="staging")
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
 
-    async def _deliver():
-        # Yield once so request() has a chance to call registry.update.
-        await asyncio.sleep(0)
-        entry = registry.get(run_id)
-        captured_entry["status"] = entry.status
-        captured_entry["question"] = entry.question
-        captured_entry["pending_iv_is_iv"] = entry.pending_intervention is iv
-        registry.answer_intervention(run_id, answer)
-
-    task = asyncio.create_task(_deliver())
-    await bus.request(iv)
-    await task
-
-    assert captured_entry["status"] == "input-required"
-    assert captured_entry["question"] == "Which env?"
-    assert captured_entry["pending_iv_is_iv"] is True
-
-
-# ── 2. No webhook URL — no HTTP call ──────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_request_no_webhook_fires_no_http(monkeypatch) -> None:
-    """Tier 1: webhook_url=None → no HTTP call is made."""
-    registry, run_id = _make_registry_with_run(webhook_url=None)
-    bus = A2AInterventionBus(run_id, registry)
-    iv = _make_iv("No webhook test")
-    answer = InterventionAnswer(text="ok")
-
-    http_calls: list = []
-
-    # Inject a MockTransport into the notifications module path so any
-    # accidental HTTP call would be captured.  Because webhook_url is None,
-    # the import of post_webhook inside A2AInterventionBus must not be reached.
-    async def _spy_handler(request: httpx.Request) -> httpx.Response:
-        http_calls.append(request)
-        return httpx.Response(200)
-
-    async def _deliver():
-        await asyncio.sleep(0)
-        registry.answer_intervention(run_id, answer)
-
-    task = asyncio.create_task(_deliver())
-    await bus.request(iv)
-    await task
-
-    assert http_calls == [], "No HTTP call should be made when webhook_url is None"
-
-
-# ── 3. request awaits iv.future and returns correct answer ────────────────────
-
-
-@pytest.mark.asyncio
-async def test_request_awaits_future_and_returns_answer() -> None:
-    """Tier 1: request(iv) blocks on iv.future; resolving via
-    registry.answer_intervention returns the exact InterventionAnswer."""
-    registry, run_id = _make_registry_with_run()
-    bus = A2AInterventionBus(run_id, registry)
-    iv = _make_iv("What is your name?")
-    expected = InterventionAnswer(text="Reyn")
-
-    async def _deliver():
-        await asyncio.sleep(0)
-        registry.answer_intervention(run_id, expected)
-
-    task = asyncio.create_task(_deliver())
-    result = await bus.request(iv)
-    await task
-
-    assert result is expected
-
-
-# ── 4. answer_intervention restores status to 'running' ───────────────────────
-
-
-@pytest.mark.asyncio
-async def test_status_returns_to_running_after_answer() -> None:
-    """Tier 1: after request() returns, registry entry status is 'running'
-    (RunRegistry.answer_intervention restores it)."""
-    registry, run_id = _make_registry_with_run()
-    bus = A2AInterventionBus(run_id, registry)
-    iv = _make_iv()
-    answer = InterventionAnswer(text="done")
-
-    async def _deliver():
-        await asyncio.sleep(0)
-        registry.answer_intervention(run_id, answer)
-
-    task = asyncio.create_task(_deliver())
-    await bus.request(iv)
-    await task
+    asyncio.run(_drive())
 
     entry = registry.get(run_id)
-    assert entry is not None
-    assert entry.status == "running"
-    assert entry.question is None
-    assert entry.pending_intervention is None
+    assert isinstance(entry, RunEntry)
+    assert not hasattr(entry, "pending_intervention")
+    assert not hasattr(entry, "question")
 
 
-# ── 5. Unknown run_id raises RuntimeError ─────────────────────────────────────
+# ── 3. No await iv.future ──────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
-async def test_request_raises_for_unknown_run_id() -> None:
-    """Tier 1: request on a bus with a bogus run_id raises RuntimeError."""
-    registry = RunRegistry()  # empty — no entries
-    bus = A2AInterventionBus("no-such-run", registry)
-    iv = _make_iv()
+def test_on_dispatch_returns_promptly_without_awaiting_future() -> None:
+    """Tier 2: α contract — ``on_dispatch`` MUST return without
+    awaiting ``iv.future``. The handler dispatch path awaits on the
+    skill's behalf; if the bus also awaited, two awaiters would race
+    on the same future. Pin by leaving the future unresolved + asserting
+    the call returns.
+    """
+    registry, run_id = _make_registry_with_run()
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
 
-    with pytest.raises(RuntimeError, match="not in registry"):
-        await bus.request(iv)
+    async def _drive() -> bool:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        # If on_dispatch awaited iv.future, this would hang forever
+        # because no one resolves it.
+        await asyncio.wait_for(bus.on_dispatch(iv), timeout=2.0)
+        return not iv.future.done()  # future MUST still be pending
+
+    assert asyncio.run(_drive())
 
 
-# ── 6. Webhook fires before awaiting future ───────────────────────────────────
+# ── 4. Webhook fire is gated on URL ────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
-async def test_request_fires_webhook_before_awaiting_future() -> None:
-    """Tier 1: when webhook_url is set, bus fires a POST (via MockTransport)
-    before awaiting iv.future. The payload contains run_id, status, question,
-    and agent_name."""
-    webhook_calls: list[dict] = []
+def test_on_dispatch_no_webhook_when_url_unset() -> None:
+    """Tier 2: peer that didn't register a webhook URL sees zero HTTP
+    cost. We pin this by using a real httpx MockTransport that fails
+    the test if a request reaches it (= no patch, no mock).
+    """
+    posted: list[httpx.Request] = []
 
-    async def _webhook_handler(request: httpx.Request) -> httpx.Response:
-        body = json.loads(await request.aread())
-        webhook_calls.append(body)
-        return httpx.Response(200)
+    def _handler(request: httpx.Request) -> httpx.Response:
+        posted.append(request)
+        return httpx.Response(200, json={})
 
-    webhook_client = httpx.AsyncClient(
-        transport=httpx.MockTransport(_webhook_handler)
-    )
+    transport = httpx.MockTransport(_handler)
+    # Inject the transport via the reyn.web.notifications client
+    # factory — but the simplest pin is just: webhook_url=None should
+    # skip post_webhook entirely without any transport setup.
 
-    # Patch post_webhook to use our deterministic transport.
-    import reyn.web.notifications as _notif_mod
-    from reyn.web import notifications as _notif
+    registry, run_id = _make_registry_with_run(webhook_url=None)
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
 
-    _original_post_webhook = _notif.post_webhook
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
 
-    async def _patched_post_webhook(url: str, payload: dict, **kwargs):
-        await _original_post_webhook(url, payload, _http_client=webhook_client, **kwargs)
+    asyncio.run(_drive())
 
-    import reyn.web.a2a_intervention as _bus_mod
-    # We inject by temporarily replacing the post_webhook imported in the bus
-    # module's lazy import path.  Because a2a_intervention does
-    # ``from reyn.web.notifications import post_webhook`` inside the method,
-    # we patch the notifications module's attribute directly.
-    _notif_mod.post_webhook = _patched_post_webhook
+    # No webhook URL → no HTTP attempt at all.
+    assert posted == [], "no webhook URL set, but a request was made"
+
+
+def test_on_dispatch_posts_webhook_when_url_set(monkeypatch) -> None:
+    """Tier 2: with ``webhook_url`` set, ``on_dispatch`` POSTs the
+    canonical input-required payload (= issue #267 Gap 4 shape with
+    ``kind`` / ``choices`` / ``detail``).
+    """
+    posted: list[tuple[str, dict]] = []
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+        from reyn.web.notifications import DeliveryOutcome, DeliveryResult
+        return DeliveryResult(outcome=DeliveryOutcome.SUCCESS)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
 
     registry, run_id = _make_registry_with_run(
-        agent_name="my_agent",
-        webhook_url="https://peer.example.com/notify",
+        webhook_url="https://peer.test/hook",
     )
-    bus = A2AInterventionBus(run_id, registry)
-    iv = _make_iv("Deploy to prod?")
-    answer = InterventionAnswer(text="yes")
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
 
-    webhook_fired_before_future: list[bool] = []
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="Question?")
+        await bus.on_dispatch(iv)
 
-    async def _deliver():
-        await asyncio.sleep(0)
-        # At this point post_webhook has been awaited (fire-and-forget completes
-        # before iv.future is awaited by bus.request).
-        webhook_fired_before_future.append(len(webhook_calls) > 0)
-        registry.answer_intervention(run_id, answer)
+    asyncio.run(_drive())
 
-    try:
-        task = asyncio.create_task(_deliver())
-        result = await bus.request(iv)
-        await task
-    finally:
-        _notif_mod.post_webhook = _original_post_webhook
-        await webhook_client.aclose()
+    assert len(posted) == 1
+    url, payload = posted[0]
+    assert url == "https://peer.test/hook"
+    assert payload["status"] == "input-required"
+    assert payload["question"] == "Question?"
+    assert payload["kind"] == "ask_user"
 
-    assert result is answer
-    assert len(webhook_calls) == 1, "Exactly one webhook POST should be fired"
-    wc = webhook_calls[0]
-    assert wc["run_id"] == run_id
-    assert wc["status"] == "input-required"
-    assert wc["question"] == "Deploy to prod?"
-    assert wc["agent_name"] == "my_agent"
+
+# ── 5. Defensive paths ─────────────────────────────────────────────────────────
+
+
+def test_on_dispatch_unknown_run_id_logs_warning_no_raise(caplog) -> None:
+    """Tier 2: defensive — when the bus's run_id is not in the
+    registry, ``on_dispatch`` logs a warning and returns. Pre-α this
+    raised RuntimeError; α changed to warn+return because raising
+    would abort the dispatch chain and the iv would never reach the
+    handler.
+    """
+    import logging as _logging
+
+    registry = RunRegistry()  # empty
+    bus = A2AInterventionBus(run_id="ghost-run", registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        # No raise expected.
+        await bus.on_dispatch(iv)
+
+    with caplog.at_level(_logging.WARNING, logger="reyn.web.a2a_intervention"):
+        asyncio.run(_drive())
+
+    assert any(
+        "ghost-run" in record.message for record in caplog.records
+    ), "expected a warning naming the unknown run_id"
+
+
+def test_on_dispatch_webhook_failure_does_not_raise(monkeypatch) -> None:
+    """Tier 2: side-effect failure on the webhook sink is swallowed.
+    The iv must continue to ``InterventionHandler.dispatch`` even if
+    the peer's webhook server is down.
+    """
+
+    async def _failing_post(url: str, payload: dict):  # noqa: ANN202
+        raise RuntimeError("simulated peer 500")
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _failing_post)
+
+    registry, run_id = _make_registry_with_run(
+        webhook_url="https://peer.test/hook",
+    )
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        # Expect no exception to propagate.
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+
+# ── 6. SSE history append (= Gap 1 wire preserved) ─────────────────────────────
+
+
+def test_on_dispatch_appends_input_required_to_history_events() -> None:
+    """Tier 2: ``on_dispatch`` appends the input-required payload to
+    ``RunEntry.history_events`` so SSE consumers see ask_user prompts
+    inline. issue #267 Gap 1 wire preserved across the α refactor.
+    """
+    registry, run_id = _make_registry_with_run()
+    bus = A2AInterventionBus(run_id=run_id, registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    history = registry.get(run_id).history_events
+    assert len(history) == 1
+    assert history[0]["status"] == "input-required"
+    assert history[0]["kind"] == "ask_user"
+
+
+# Silence unused-import warning for httpx/json kept for parity with the
+# original FP-0001 file naming convention; they may be needed by future
+# tests that want to use httpx.MockTransport explicitly.
+_ = json
+_ = pytest

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -89,93 +89,54 @@ def test_run_registry_create_and_get():
     assert entry.run_id
     assert entry.agent_name == "myagent"
     assert entry.status == "running"
-    assert entry.question is None
     assert entry.result is None
     assert entry.error is None
+    # issue #292 (α): ``question`` field removed from RunEntry.
+    assert not hasattr(entry, "question")
 
     fetched = registry.get(entry.run_id)
     assert fetched is entry
 
 
 def test_run_registry_update_status():
-    """Tier 2c: RunRegistry.update mutates status and clears pending intervention."""
+    """Tier 2c: RunRegistry.update mutates status. issue #292 (α):
+    the ``question`` kwarg is removed — status mirror is the only
+    A2A-wrapper-owned field that mutates here.
+    """
     registry = _new_run_registry()
     entry = registry.create(agent_name="a", chain_id="c")
 
-    registry.update(entry.run_id, status="input-required", question="What next?")
+    registry.update(entry.run_id, status="input-required")
     assert registry.get(entry.run_id).status == "input-required"
-    assert registry.get(entry.run_id).question == "What next?"
 
-    # Transitioning back to running clears pending fields.
+    # Transitioning back to running.
     registry.update(entry.run_id, status="running")
     assert registry.get(entry.run_id).status == "running"
 
 
 def test_run_registry_to_public_dict_excludes_internals():
-    """Tier 2c: RunEntry.to_public_dict excludes asyncio.Task and UserIntervention."""
-    from reyn.user_intervention import UserIntervention
-
+    """Tier 2c: RunEntry.to_public_dict excludes asyncio.Task. issue
+    #292 (α): ``pending_intervention`` / ``question`` were also
+    excluded pre-α; α removes them entirely from RunEntry's data
+    shape (= they live in ChatSession).
+    """
     registry = _new_run_registry()
     entry = registry.create(agent_name="b", chain_id="c2")
-    iv = _new_intervention("continue?", run_id=entry.run_id)
-    registry.update(
-        entry.run_id,
-        status="input-required",
-        question="continue?",
-        pending_intervention=iv,
-    )
+    registry.update(entry.run_id, status="input-required")
 
     pub = entry.to_public_dict()
     assert "pending_intervention" not in pub
     assert "task" not in pub
+    assert "question" not in pub
     assert pub["status"] == "input-required"
-    assert pub["question"] == "continue?"
     assert "run_id" in pub
     assert "agent_name" in pub
 
 
-def test_run_registry_answer_intervention_resolves_future():
-    """Tier 2c: answer_intervention resolves iv.future and resets status to running."""
-    registry = _new_run_registry()
-    entry = registry.create(agent_name="c", chain_id="c3")
-    iv = _new_intervention("proceed?", run_id=entry.run_id)
-    registry.update(
-        entry.run_id,
-        status="input-required",
-        question="proceed?",
-        pending_intervention=iv,
-    )
-
-    answer = _new_answer("yes")
-
-    # answer_intervention must resolve the future synchronously (same-loop call).
-    loop = asyncio.new_event_loop()
-    try:
-        # Set the future on the same loop.
-        iv.future = loop.create_future()
-        resolved = registry.answer_intervention(entry.run_id, answer)
-        assert resolved is True
-
-        # Future is done; result is the answer.
-        assert iv.future.done()
-        assert iv.future.result() is answer
-
-        # Registry clears pending state.
-        updated = registry.get(entry.run_id)
-        assert updated.status == "running"
-        assert updated.question is None
-        assert updated.pending_intervention is None
-    finally:
-        loop.close()
-
-
-def test_run_registry_answer_intervention_returns_false_when_no_pending():
-    """Tier 2c: answer_intervention returns False if no pending intervention exists."""
-    registry = _new_run_registry()
-    entry = registry.create(agent_name="d", chain_id="c4")
-    # No pending intervention set.
-    answer = _new_answer("hello")
-    assert registry.answer_intervention(entry.run_id, answer) is False
+# Tests for ``RunRegistry.answer_intervention`` removed: post-issue-#292,
+# the method is gone and peer-answer flows go through
+# ``ChatSession.answer_pending_intervention``. See
+# tests/test_fp0001_a2a_intervention_bus.py for the post-α coverage.
 
 
 def test_run_registry_cancel_marks_cancelled():
@@ -200,82 +161,11 @@ def test_run_registry_cancel_marks_cancelled():
 # ---------------------------------------------------------------------------
 
 
-def test_a2a_intervention_bus_publishes_and_awaits():
-    """Tier 2c: A2AInterventionBus.request publishes the question to RunRegistry
-    and blocks on iv.future until answer_intervention resolves it."""
-    from reyn.user_intervention import InterventionAnswer, UserIntervention
-
-    registry = _new_run_registry()
-    entry = registry.create(agent_name="f", chain_id="c6")
-    bus = _new_a2a_bus(entry.run_id, registry)
-    answer = _new_answer("yes, proceed")
-
-    async def _run():
-        # Create the intervention inside the running loop so iv.future is
-        # bound to the correct event loop (Future is created in __post_init__
-        # via asyncio.get_running_loop()).
-        iv = UserIntervention(kind="ask_user", prompt="Is this OK?", run_id=entry.run_id)
-
-        # Deliver the answer from a concurrent task after a short yield.
-        async def _deliver():
-            await asyncio.sleep(0)  # yield to let bus.request publish first
-            registry.answer_intervention(entry.run_id, answer)
-
-        deliver_task = asyncio.create_task(_deliver())
-        received = await bus.request(iv)
-        await deliver_task
-        return received, iv
-
-    loop = asyncio.new_event_loop()
-    try:
-        received, iv = loop.run_until_complete(_run())
-    finally:
-        loop.close()
-
-    # bus.request returned the answer delivered by answer_intervention.
-    assert received is answer
-    assert received.text == "yes, proceed"
-
-    # Registry should have cleared the pending state once bus.request returned.
-    # (answer_intervention already cleared it when resolving the future.)
-    updated = registry.get(entry.run_id)
-    assert updated.pending_intervention is None
-
-
-def test_a2a_intervention_bus_sets_input_required_before_blocking():
-    """Tier 2c: A2AInterventionBus.request sets status=input-required and
-    exposes the question text BEFORE awaiting the future."""
-    from reyn.user_intervention import UserIntervention
-
-    registry = _new_run_registry()
-    entry = registry.create(agent_name="g", chain_id="c7")
-    bus = _new_a2a_bus(entry.run_id, registry)
-
-    status_at_request_time: list[str] = []
-    question_at_request_time: list[str | None] = []
-
-    async def _run():
-        # Create intervention inside the loop so Future is loop-bound.
-        iv = UserIntervention(kind="ask_user", prompt="What colour?", run_id=entry.run_id)
-
-        async def _observe_then_deliver():
-            await asyncio.sleep(0)  # yield so bus.request runs first
-            e = registry.get(entry.run_id)
-            status_at_request_time.append(e.status)
-            question_at_request_time.append(e.question)
-            registry.answer_intervention(entry.run_id, _new_answer("blue"))
-
-        asyncio.create_task(_observe_then_deliver())
-        await bus.request(iv)
-
-    loop = asyncio.new_event_loop()
-    try:
-        loop.run_until_complete(_run())
-    finally:
-        loop.close()
-
-    assert status_at_request_time == ["input-required"]
-    assert question_at_request_time == ["What colour?"]
+# Tests for A2AInterventionBus.request awaiting iv.future + question
+# field mirroring removed: post-issue-#292 the bus is a side-effect
+# observer (= ``on_dispatch``) that does not own iv resolution. Status
+# mirror behaviour is covered by
+# tests/test_fp0001_a2a_intervention_bus.py::test_on_dispatch_mirrors_input_required_status.
 
 
 # ---------------------------------------------------------------------------
@@ -486,9 +376,12 @@ def test_get_task_returns_run_entry(tmp_path, monkeypatch):
 
     # Pre-populate RunRegistry with a known entry so we can exercise
     # GET /a2a/tasks/{run_id} without needing a live async task.
+    # issue #292 (α): ``question`` is removed from the public dict —
+    # iv prompt text is exposed via the SSE stream / webhook payload
+    # (= history_events buffer), not via the GET-task endpoint.
     run_registry = RunRegistry()
     entry = run_registry.create(agent_name="default", chain_id="test-chain")
-    run_registry.update(entry.run_id, status="input-required", question="Proceed?")
+    run_registry.update(entry.run_id, status="input-required")
 
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
@@ -500,7 +393,7 @@ def test_get_task_returns_run_entry(tmp_path, monkeypatch):
         body = r.json()
         assert body["run_id"] == entry.run_id
         assert body["status"] == "input-required"
-        assert body["question"] == "Proceed?"
+        assert "question" not in body  # α: field removed
         assert body["agent_name"] == "default"
     finally:
         app.dependency_overrides.clear()

--- a/tests/test_fp0001_run_registry.py
+++ b/tests/test_fp0001_run_registry.py
@@ -157,83 +157,11 @@ async def test_attach_task_stores_task_reference() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 6: answer_intervention() resolves pending IV's future
+# Tests 6-8: removed in issue #292 (α). RunRegistry.answer_intervention is
+# gone; iv resolution lives in ChatSession.answer_pending_intervention,
+# tested in tests/test_fp0001_a2a_intervention_bus.py + the new
+# tests/test_a2a_iv_kind_choices_267_gap4.py answer-injection block.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_answer_intervention_resolves_future_and_clears_question() -> None:
-    """Tier 1: answer_intervention delivers answer to IV future; status → 'running'; question cleared."""
-    registry = _make_registry()
-    entry = _make_entry(registry)
-
-    iv = UserIntervention(kind="ask_user", prompt="What is your name?")
-    entry.pending_intervention = iv
-    entry.question = "What is your name?"
-    entry.status = "input-required"
-
-    answer = InterventionAnswer(text="hi")
-    result = registry.answer_intervention(entry.run_id, answer)
-
-    assert result is True
-    assert iv.future.done()
-    assert iv.future.result().text == "hi"
-    assert entry.pending_intervention is None
-    assert entry.question is None
-    assert entry.status == "running"
-
-
-# ---------------------------------------------------------------------------
-# Test 7: answer_intervention() returns False when no pending IV
-# ---------------------------------------------------------------------------
-
-
-def test_answer_intervention_returns_false_when_no_pending_iv() -> None:
-    """Tier 1: answer_intervention returns False when entry has no pending_intervention."""
-    registry = _make_registry()
-    entry = _make_entry(registry)
-    # No pending_intervention set (default None)
-
-    result = registry.answer_intervention(entry.run_id, InterventionAnswer(text="ignored"))
-    assert result is False
-
-
-def test_answer_intervention_returns_false_for_unknown_run_id() -> None:
-    """Tier 1: answer_intervention returns False when run_id doesn't exist."""
-    registry = _make_registry()
-    result = registry.answer_intervention("no-such-id", InterventionAnswer(text="x"))
-    assert result is False
-
-
-# ---------------------------------------------------------------------------
-# Test 8: answer_intervention() returns False when future is already done
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_answer_intervention_returns_false_on_duplicate_answer() -> None:
-    """Tier 1: answer_intervention returns False when IV future is already resolved."""
-    registry = _make_registry()
-    entry = _make_entry(registry)
-
-    iv = UserIntervention(kind="ask_user", prompt="Are you sure?")
-    entry.pending_intervention = iv
-    entry.question = "Are you sure?"
-    entry.status = "input-required"
-
-    # First answer — resolves the future
-    first_result = registry.answer_intervention(entry.run_id, InterventionAnswer(text="yes"))
-    assert first_result is True
-    assert iv.future.done()
-
-    # Re-attach the IV (as if it somehow re-appeared) but future is done
-    entry.pending_intervention = iv
-
-    # Second answer — future already done → should return False
-    second_result = registry.answer_intervention(entry.run_id, InterventionAnswer(text="no"))
-    assert second_result is False
-    # Original answer preserved
-    assert iv.future.result().text == "yes"
 
 
 # ---------------------------------------------------------------------------
@@ -335,15 +263,17 @@ def test_remove_no_op_for_unknown_run_id() -> None:
 
 @pytest.mark.asyncio
 async def test_to_public_dict_returns_json_safe_fields() -> None:
-    """Tier 1: to_public_dict() exposes run_id/agent_name/chain_id/status/question/result/error/timestamps; omits task and IV."""
+    """Tier 1: to_public_dict() exposes run_id / agent_name / chain_id
+    / status / result / error / timestamps. issue #292 (α):
+    ``question`` and ``pending_intervention`` no longer exist on
+    RunEntry (= iv lives in ChatSession).
+    """
     registry = _make_registry()
     entry = registry.create(agent_name="myagent", chain_id="chain-99", webhook_url="http://example.com")
 
-    # Attach a real task and IV to confirm they're excluded
+    # Attach a real task to confirm it's excluded.
     task = asyncio.create_task(_noop())
     registry.attach_task(entry.run_id, task)
-    iv = UserIntervention(kind="ask_user", prompt="Q?")
-    entry.pending_intervention = iv
 
     d = entry.to_public_dict()
 
@@ -352,17 +282,18 @@ async def test_to_public_dict_returns_json_safe_fields() -> None:
     assert d["agent_name"] == "myagent"
     assert d["chain_id"] == "chain-99"
     assert d["status"] == "running"
-    assert d["question"] is None
     assert d["result"] is None
     assert d["error"] is None
     assert isinstance(d["created_at"], str)
     assert isinstance(d["updated_at"], str)
 
-    # Internal-only fields must not appear
+    # Internal-only / non-public fields must not appear.
     assert "task" not in d
-    assert "pending_intervention" not in d
     assert "webhook_url" not in d
     assert "history_events" not in d
+    # α: pending_intervention / question fully removed.
+    assert "pending_intervention" not in d
+    assert "question" not in d
 
     await task  # clean up
 
@@ -379,7 +310,7 @@ def test_updated_at_advances_monotonically() -> None:
 
     t0 = entry.updated_at
 
-    registry.update(entry.run_id, status="input-required", question="Q?")
+    registry.update(entry.run_id, status="input-required")
     t1 = entry.updated_at
 
     registry.update(entry.run_id, status="running")

--- a/tests/test_fp0001_session_override.py
+++ b/tests/test_fp0001_session_override.py
@@ -41,23 +41,26 @@ from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 
 class _CaptureBus:
-    """Minimal InterventionBus fake that records calls and returns a fixed answer."""
+    """Minimal intervention observer fake (post-issue-#292 α refactor).
+
+    Records ``on_dispatch`` calls. Pre-α this class implemented
+    ``request`` which returned an ``InterventionAnswer``; post-α the
+    bus is a side-effect observer that does NOT own iv resolution —
+    ``on_dispatch`` returns None.
+    """
 
     def __init__(
         self,
         *,
-        answer: InterventionAnswer = InterventionAnswer(text="captured"),
-        raise_on_request: Exception | None = None,
+        raise_on_dispatch: Exception | None = None,
     ) -> None:
         self.calls: list[UserIntervention] = []
-        self._answer = answer
-        self._raise_on_request = raise_on_request
+        self._raise_on_dispatch = raise_on_dispatch
 
-    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+    async def on_dispatch(self, iv: UserIntervention) -> None:
         self.calls.append(iv)
-        if self._raise_on_request is not None:
-            raise self._raise_on_request
-        return self._answer
+        if self._raise_on_dispatch is not None:
+            raise self._raise_on_dispatch
 
 
 class _RecordingHandler:
@@ -211,45 +214,55 @@ async def test_dispatch_falls_through_when_no_override(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_uses_override_when_registered(tmp_path):
-    """Tier 2: _dispatch_intervention with iv.run_id whose chain_id IS registered
-    delegates to the override bus, returns the override bus's answer.
+async def test_dispatch_notifies_override_then_continues_to_handler(tmp_path):
+    """Tier 2 (= issue #292 α): _dispatch_intervention with a registered
+    override notifies the override's ``on_dispatch`` AS A SIDE EFFECT,
+    then ALWAYS continues to the default InterventionHandler.dispatch.
+    Pre-α the override REPLACED the handler; α changed it to DECORATE.
     """
     session = _make_session(tmp_path)
     run_id = "run-override"
     chain_id = "chain-with-override"
     session.running_skills_chain[run_id] = chain_id
 
-    override_bus = _CaptureBus(answer=InterventionAnswer(text="from-override"))
+    override_bus = _CaptureBus()
     session.register_intervention_override(chain_id, override_bus)
 
     iv = _make_iv(run_id=run_id)
-    answer = await session._dispatch_intervention(iv)
 
-    assert answer.text == "from-override"
+    # The handler will await iv.future. Resolve it concurrently with a
+    # known value so dispatch returns; the test pin is that the override
+    # was called AND the handler-resolved value came back.
+    async def _resolve_after_delay() -> None:
+        await asyncio.sleep(0.05)
+        iv.future.set_result(InterventionAnswer(text="from-handler"))
+
+    resolver = asyncio.create_task(_resolve_after_delay())
+    try:
+        answer = await session._dispatch_intervention(iv)
+    finally:
+        resolver.cancel()
+
+    # Override was notified.
     assert len(override_bus.calls) == 1
     assert override_bus.calls[0] is iv
-
-
-# ---------------------------------------------------------------------------
-# Test 4: default handler NOT called when override fires
-# ---------------------------------------------------------------------------
+    # Handler resolved the answer (= α decorator semantics: handler always runs).
+    assert answer.text == "from-handler"
 
 
 @pytest.mark.asyncio
-async def test_override_short_circuits_default_handler(tmp_path):
-    """Tier 2: when the override fires, the default InterventionHandler.dispatch
-    is NOT called (= short-circuit).
-
-    Observes this by wrapping the real _intervention_handler with a call-counting
-    shim (no mock — real callable wrapping real callable).
+async def test_override_does_not_short_circuit_default_handler(tmp_path):
+    """Tier 2 (= issue #292 α): the override DECORATES dispatch, it
+    does NOT replace it. This is the exact contract reversal from PR
+    pre-α: where the old test asserted "default NOT called", the new
+    test asserts "default IS called" + override is called alongside.
     """
     session = _make_session(tmp_path)
     run_id = "run-sc"
     chain_id = "chain-sc"
     session.running_skills_chain[run_id] = chain_id
 
-    override_bus = _CaptureBus(answer=InterventionAnswer(text="override-sc"))
+    override_bus = _CaptureBus()
     session.register_intervention_override(chain_id, override_bus)
 
     # Wrap the real handler's dispatch to count invocations.
@@ -263,12 +276,22 @@ async def test_override_short_circuits_default_handler(tmp_path):
     session._intervention_handler.dispatch = _counting_dispatch  # type: ignore[method-assign]
 
     iv = _make_iv(run_id=run_id)
-    answer = await session._dispatch_intervention(iv)
 
-    assert answer.text == "override-sc"
-    # Default handler's dispatch must NOT have been called.
-    assert len(dispatch_calls) == 0, (
-        f"Default handler was called {len(dispatch_calls)} time(s); expected 0"
+    async def _resolve_after_delay() -> None:
+        await asyncio.sleep(0.05)
+        iv.future.set_result(InterventionAnswer(text="from-handler"))
+
+    resolver = asyncio.create_task(_resolve_after_delay())
+    try:
+        await session._dispatch_intervention(iv)
+    finally:
+        resolver.cancel()
+
+    # α contract: BOTH ran. Override was notified AND default handler dispatched.
+    assert len(override_bus.calls) == 1
+    assert len(dispatch_calls) == 1, (
+        f"α contract: handler.dispatch must run alongside the override; "
+        f"got {len(dispatch_calls)} dispatch calls (expected 1)"
     )
 
 
@@ -286,7 +309,7 @@ async def test_dispatch_falls_through_when_run_id_is_none(tmp_path):
     session.is_attached = True
 
     chain_id = "chain-any"
-    override_bus = _CaptureBus(answer=InterventionAnswer(text="should-not-reach"))
+    override_bus = _CaptureBus()
     # Register an override (should not be reached because run_id is None).
     session.register_intervention_override(chain_id, override_bus)
 
@@ -317,7 +340,7 @@ async def test_dispatch_falls_through_when_run_id_not_in_chain(tmp_path):
     session.is_attached = True
 
     chain_id = "chain-known"
-    override_bus = _CaptureBus(answer=InterventionAnswer(text="should-not-reach"))
+    override_bus = _CaptureBus()
     session.register_intervention_override(chain_id, override_bus)
 
     # run_id is NOT in running_skills_chain.
@@ -373,7 +396,7 @@ def test_send_to_agent_impl_override_registered_and_cleaned_up(tmp_path, monkeyp
     # MessageBus in this call — the override is registered but the request
     # flow is what matters; we use a fake _handle_user_message instead to
     # keep the test deterministic).
-    override_bus = _CaptureBus(answer=InterventionAnswer(text="ok"))
+    override_bus = _CaptureBus()
 
     # Stub _handle_user_message so the session produces a synthetic reply
     # without invoking a real LLM.
@@ -423,7 +446,7 @@ def test_send_to_agent_impl_override_cleaned_up_on_exception(tmp_path, monkeypat
     registry = _build_registry(tmp_path, [("default", "")])
     session = registry.get_or_load("default")
 
-    override_bus = _CaptureBus(answer=InterventionAnswer(text="ok"))
+    override_bus = _CaptureBus()
 
     # Stub MessageBus.request to raise immediately.
     from reyn.chat.message_bus import MessageBus
@@ -468,8 +491,8 @@ def test_concurrent_send_to_agent_impl_no_override_leak(tmp_path, monkeypatch):
     registry = _build_registry(tmp_path, [("default", "")])
     session = registry.get_or_load("default")
 
-    bus_alpha = _CaptureBus(answer=InterventionAnswer(text="alpha-answer"))
-    bus_beta = _CaptureBus(answer=InterventionAnswer(text="beta-answer"))
+    bus_alpha = _CaptureBus()
+    bus_beta = _CaptureBus()
 
     # Track registration events per bus identity.
     registered: list[tuple[str, object]] = []   # (chain_id, bus)

--- a/tests/test_intervention_agent_routing.py
+++ b/tests/test_intervention_agent_routing.py
@@ -267,33 +267,47 @@ def test_self_answer_takes_precedence_over_parent_delegate() -> None:
 #      the new routing scaffold ──────────────────────────────────────────
 
 
-def test_chain_override_still_works_through_user_channel_branch(tmp_path: Path) -> None:
-    """Tier 2: the A2A peer override registered via
-    ``register_intervention_override`` reaches the override bus through
-    the user_channel branch (= default, no hooks override). Phase 4
-    must not break this path.
+def test_chain_override_is_notified_through_user_channel_branch(tmp_path: Path) -> None:
+    """Tier 2 (= issue #292 α): the A2A peer override registered via
+    ``register_intervention_override`` is notified via ``on_dispatch``
+    as a side effect during the user_channel branch. Pre-α the
+    override REPLACED the dispatch; α changed it to DECORATE — the
+    iv still flows to the default handler.
     """
     session = ChatSession(agent_name="t")
+    # The default handler awaits iv.future; register a listener so
+    # dispatch doesn't short-circuit on no-listener.
+    session.register_intervention_listener("test")
 
     captured: list[UserIntervention] = []
 
-    class _StubOverrideBus:
-        async def request(self, iv: UserIntervention) -> InterventionAnswer:
+    class _StubOverrideObserver:
+        async def on_dispatch(self, iv: UserIntervention) -> None:
             captured.append(iv)
-            return InterventionAnswer(text="from-override", choice_id=None)
 
-    session.register_intervention_override("chain-X", _StubOverrideBus())
+    session.register_intervention_override("chain-X", _StubOverrideObserver())
     session.running_skills_chain["run-1"] = "chain-X"
 
-    iv = UserIntervention(kind="ask_user", prompt="Q?", run_id="run-1")
-    answer = asyncio.run(session.handle_intervention(iv))
+    async def _drive() -> InterventionAnswer:
+        iv = UserIntervention(kind="ask_user", prompt="Q?", run_id="run-1")
 
-    assert answer.text == "from-override"
+        async def _resolve() -> None:
+            await asyncio.sleep(0.05)
+            iv.future.set_result(InterventionAnswer(text="from-handler"))
+
+        resolver = asyncio.create_task(_resolve())
+        try:
+            return await session.handle_intervention(iv)
+        finally:
+            resolver.cancel()
+
+    answer = asyncio.run(_drive())
+
+    # α: observer was notified (side effect); handler resolved the answer.
     assert len(captured) == 1
+    assert answer.text == "from-handler"
 
-    # And the routing event records the user_channel branch fired
-    # (the chain-override resolution happens INSIDE _dispatch_intervention,
-    # which is reached via the user_channel branch).
+    # Routing event records the user_channel branch fired.
     events = [
         e for e in session._chat_events.to_json()
         if e.get("type") == "intervention_routed"

--- a/tests/test_intervention_agent_subscriber.py
+++ b/tests/test_intervention_agent_subscriber.py
@@ -231,31 +231,42 @@ def test_session_interventions_attribute_path_is_stable_in_phase3() -> None:
 # ── 6. handle_intervention preserves the chain-override path ───────────
 
 
-def test_handle_intervention_respects_chain_override(tmp_path: Path) -> None:
-    """Tier 2: when an InterventionBus override is registered for a
-    chain_id, ``handle_intervention`` honours it (= Phase 3 delegates
-    to _dispatch_intervention which performs the override lookup).
-
-    This is the path used by A2A async-mode tasks — Phase 3 must NOT
-    bypass it.
+def test_handle_intervention_notifies_chain_override_observer(tmp_path: Path) -> None:
+    """Tier 2 (= issue #292 α): when a chain override is registered,
+    ``handle_intervention`` notifies it via ``on_dispatch`` AS A
+    SIDE EFFECT before continuing through the regular handler. The
+    iv future is owned by the handler post-α; the override is a
+    pure observer.
     """
     session = ChatSession(agent_name="t")
+    session.register_intervention_listener("test")
 
     captured: list[UserIntervention] = []
 
-    class _StubOverrideBus:
-        async def request(self, iv: UserIntervention) -> InterventionAnswer:
+    class _StubOverrideObserver:
+        async def on_dispatch(self, iv: UserIntervention) -> None:
             captured.append(iv)
-            return InterventionAnswer(text="from-override", choice_id=None)
 
-    # Register the override AND simulate the running_skills_chain wiring
-    # so the chain_id lookup in _dispatch_intervention finds the override.
-    session.register_intervention_override("chain-X", _StubOverrideBus())
+    session.register_intervention_override("chain-X", _StubOverrideObserver())
     session.running_skills_chain["run-1"] = "chain-X"
 
-    iv = UserIntervention(kind="ask_user", prompt="Q?", run_id="run-1")
-    answer = asyncio.run(session.handle_intervention(iv))
+    async def _drive() -> tuple[UserIntervention, InterventionAnswer]:
+        iv = UserIntervention(kind="ask_user", prompt="Q?", run_id="run-1")
 
-    assert answer.text == "from-override"
+        async def _resolve() -> None:
+            await asyncio.sleep(0.05)
+            iv.future.set_result(InterventionAnswer(text="from-handler"))
+
+        resolver = asyncio.create_task(_resolve())
+        try:
+            answer = await session.handle_intervention(iv)
+        finally:
+            resolver.cancel()
+        return iv, answer
+
+    iv, answer = asyncio.run(_drive())
+
+    # α: observer received the iv as a side effect; handler resolved the future.
     assert len(captured) == 1
     assert captured[0] is iv
+    assert answer.text == "from-handler"

--- a/tests/test_intervention_bus_protocols.py
+++ b/tests/test_intervention_bus_protocols.py
@@ -104,14 +104,20 @@ def test_chat_intervention_bus_satisfies_both_protocols(tmp_path: Path) -> None:
     assert isinstance(bus, UserChannel)
 
 
-def test_a2a_intervention_bus_satisfies_both_protocols() -> None:
-    """Tier 2: ``A2AInterventionBus`` satisfies both Protocols. Constructor
-    takes a registry handle which we pass as ``None`` here since we
-    don't invoke ``deliver`` / ``request`` in this protocol-only test.
+def test_a2a_intervention_bus_exposes_on_dispatch_post_alpha() -> None:
+    """Tier 2 (= issue #292 α): ``A2AInterventionBus`` is a side-effect
+    observer post-α; it no longer satisfies ``RequestBus`` / ``UserChannel``
+    (= those required ``request`` / ``deliver`` returning an answer).
+    The new public surface is ``on_dispatch(iv) -> None``.
     """
     bus = A2AInterventionBus(run_id="r1", registry=None)  # type: ignore[arg-type]
-    assert isinstance(bus, RequestBus)
-    assert isinstance(bus, UserChannel)
+    assert hasattr(bus, "on_dispatch")
+    assert not hasattr(bus, "request")
+    assert not hasattr(bus, "deliver")
+    # Not a RequestBus/UserChannel anymore — pre-α it was; α reclassified
+    # the bus into a different role (observer) outside those Protocols.
+    assert not isinstance(bus, RequestBus)
+    assert not isinstance(bus, UserChannel)
 
 
 # ── 3. Phase 2 backwards-compat: request delegates to deliver ──────────
@@ -159,12 +165,19 @@ def test_chat_bus_request_delegates_to_deliver() -> None:
     )
 
 
-def test_a2a_bus_request_delegates_to_deliver() -> None:
-    """Tier 2: ``A2AInterventionBus.request`` delegates to ``deliver``."""
-    src = inspect.getsource(A2AInterventionBus.request)
-    assert "self.deliver(iv)" in src, (
-        "A2AInterventionBus.request must delegate to deliver in Phase 2"
-    )
+def test_a2a_bus_only_exposes_on_dispatch_post_alpha() -> None:
+    """Tier 2 (= issue #292 α): ``A2AInterventionBus.request`` /
+    ``deliver`` were removed when the bus became a side-effect
+    observer. Pin the absence so a future refactor that re-adds them
+    fails first (= the iv ownership question is settled: ChatSession
+    owns it, the bus only emits side effects).
+    """
+    assert not hasattr(A2AInterventionBus, "request")
+    assert not hasattr(A2AInterventionBus, "deliver")
+    src = inspect.getsource(A2AInterventionBus.on_dispatch)
+    # The observer must NOT await iv.future (= that's the handler's job).
+    assert "await iv.future" not in src
+    assert "iv.future.set_result" not in src
 
 
 # ── 4. Outbox shape commitment (tui-coder Q1) ──────────────────────────

--- a/tests/test_run_registry_persist.py
+++ b/tests/test_run_registry_persist.py
@@ -95,7 +95,9 @@ def test_restore_from_existing_snapshot_repopulates_runs(tmp_path: Path) -> None
     # Phase 1: populate + close (= process death simulation).
     registry_a = RunRegistry(persist_path=persist_path)
     entry = registry_a.create(agent_name="demo", chain_id="chain-A")
-    registry_a.update(entry.run_id, status="input-required", question="Continue?")
+    # issue #292 (α): ``question`` field removed — iv state owned by
+    # ChatSession. We only mirror the public ``status`` on RunEntry.
+    registry_a.update(entry.run_id, status="input-required")
     registry_a.append_event(entry.run_id, {"type": "phase", "name": "greet"})
 
     # Phase 2: fresh registry from same path (= post-restart).
@@ -105,7 +107,6 @@ def test_restore_from_existing_snapshot_repopulates_runs(tmp_path: Path) -> None
     assert restored.agent_name == "demo"
     assert restored.chain_id == "chain-A"
     assert restored.status == "input-required"
-    assert restored.question == "Continue?"
     assert restored.history_events == [{"type": "phase", "name": "greet"}]
 
 
@@ -151,39 +152,20 @@ def test_restored_pending_intervention_has_fresh_future(tmp_path: Path) -> None:
     registry_a = RunRegistry(persist_path=persist_path)
     entry = registry_a.create(agent_name="demo", chain_id="chain-A")
 
-    # Attach a pending intervention with a resolved-in-prior-process future
-    # (= simulate "the prior process did set_result before crash").
-    loop = asyncio.new_event_loop()
-    try:
-        async def _populate() -> None:
-            iv = UserIntervention(
-                kind="ask_user",
-                prompt="What is your name?",
-                detail="for greeting",
-            )
-            registry_a.update(
-                entry.run_id,
-                status="input-required",
-                question=iv.prompt,
-                pending_intervention=iv,
-            )
+    # issue #292 (α): iv state lives in ChatSession, not RunRegistry.
+    # Restart simulation just mirrors the public status; iv restore is
+    # tested in tests/test_intervention_restore.py via AgentSnapshot.
+    registry_a.update(entry.run_id, status="input-required")
 
-        loop.run_until_complete(_populate())
-    finally:
-        loop.close()
-
-    # Restart: restored iv must have a fresh, unresolved future.
+    # Restart: restored RunEntry has the status mirror; iv state is
+    # restored separately by ChatSession's snapshot path.
     registry_b = RunRegistry(persist_path=persist_path)
     restored = registry_b.get(entry.run_id)
     assert restored is not None
-    assert restored.pending_intervention is not None
-    iv = restored.pending_intervention
-    assert iv.kind == "ask_user"
-    assert iv.prompt == "What is your name?"
-    assert iv.detail == "for greeting"
-    # Fresh future: not yet resolved.
-    assert iv.future is not None
-    assert not iv.future.done()
+    assert restored.status == "input-required"
+    # α: RunEntry no longer carries pending_intervention. iv lives in
+    # ChatSession's AgentSnapshot.outstanding_interventions.
+    assert not hasattr(restored, "pending_intervention")
 
 
 # ── 3. All mutations persist (= regression guards) ─────────────────────
@@ -241,34 +223,29 @@ def test_remove_drops_entry_from_snapshot(tmp_path: Path) -> None:
     assert entry_b.run_id in data
 
 
-def test_answer_intervention_persists_cleared_state(tmp_path: Path) -> None:
-    """Tier 2: ``answer_intervention()`` clears pending fields + persists."""
+def test_answer_status_mirror_persists(tmp_path: Path) -> None:
+    """Tier 2: post-α, ``answer_intervention`` is removed from
+    RunRegistry. The peer-answer flow lives in
+    ``_handle_answer_injection`` → ``ChatSession.answer_pending_intervention``.
+    The RunRegistry only mirrors the public ``status`` back to
+    ``"running"`` after the answer is delivered. Pin the status
+    transition persists correctly.
+    """
     persist_path = tmp_path / "run_registry.json"
     registry = RunRegistry(persist_path=persist_path)
     entry = registry.create(agent_name="demo", chain_id="chain-A")
 
-    loop = asyncio.new_event_loop()
-    try:
-        async def _drive() -> None:
-            iv = UserIntervention(kind="ask_user", prompt="?")
-            registry.update(
-                entry.run_id,
-                status="input-required",
-                question="?",
-                pending_intervention=iv,
-            )
-            registry.answer_intervention(
-                entry.run_id, InterventionAnswer(text="ok"),
-            )
-
-        loop.run_until_complete(_drive())
-    finally:
-        loop.close()
+    # Pre-answer: status is "input-required" (= mirror, set by the
+    # observer bridge when iv is dispatched).
+    registry.update(entry.run_id, status="input-required")
+    # Post-answer: router resets to "running" via the same update path.
+    registry.update(entry.run_id, status="running")
 
     data = json.loads(persist_path.read_text(encoding="utf-8"))
     assert data[entry.run_id]["status"] == "running"
-    assert data[entry.run_id]["question"] is None
+    # α: pending_intervention / question keys no longer persisted.
     assert "pending_intervention" not in data[entry.run_id]
+    assert "question" not in data[entry.run_id]
 
 
 # ── 4. Atomic write (= no partial file on crash mid-write) ──────────────


### PR DESCRIPTION
**[e2e-coder]** — issue #292 α: closes the cross-component iv ownership gap by reframing what override means.

## What this PR changes

Pre-#292, ``_dispatch_intervention``'s override branch did:

```python
if override is not None:
    return await override.request(iv)  # ← skips InterventionHandler.dispatch entirely
```

A2A async-mode ivs never entered ``InterventionRegistry._active`` / WAL / ``AgentSnapshot``. The bus owned the future. Restart → orphan: ChatSession knew nothing, RunRegistry's restored iv had a fresh future no one awaited, peer answers vanished.

α flips the override from **replace** to **decorate**:

```python
if override is not None:
    await override.on_dispatch(iv)  # ← side effect: status mirror, SSE append, webhook POST
return await self._intervention_handler.dispatch(iv)  # ← always runs
```

The iv lives in ChatSession's authoritative state. R-D12's persistent answer buffer covers restart-resume for A2A ivs the same way it covers TUI ivs — no new persistence channel.

## Summary

- ``_dispatch_intervention`` override branch: replace → decorate (`src/reyn/chat/session.py:2125`).
- ``A2AInterventionBus`` rewritten as pure observer (`src/reyn/web/a2a_intervention.py`). Public surface: ``on_dispatch(iv) -> None``. ``request`` / ``deliver`` removed. No ``await iv.future``. Side-effect failures swallowed independently so dispatch never blocks on transport.
- ``ChatSession.answer_pending_intervention(run_id, answer)`` (new): authoritative peer-answer entry point. Finds iv in ``_active`` by run_id; delegates to handler's ``deliver_answer_to`` with optional ``choice_id_override`` so Gap 4's structured-answer semantics survive.
- ``_handle_answer_injection`` (a2a router): rewired to call (3) via a registry lookup. RunEntry consulted only to find owning agent.
- ``InterventionRegistry.deliver_answer`` + ``InterventionHandler.deliver_answer_to`` gain ``choice_id_override`` kwarg (= bypasses ``match_choice`` for peer answers that already know their choice id).
- ``RunEntry``: drop ``pending_intervention`` + ``question`` fields. ``RunRegistry.update`` loses both kwargs. ``RunRegistry.answer_intervention`` removed. Pre-#292 disk snapshots restore cleanly (unknown keys ignored).

## Test sweep (= scope-of-change is substantial)

Rewrote / updated **13 test files** for α. The pattern in each is the same: the test pinned a pre-α contract that α structurally changes. Key cases:

- ``test_fp0001_a2a_intervention_bus.py``: rewritten for α (on_dispatch / no future await / no pending_intervention write).
- ``test_fp0001_session_override.py``: the most direct contract reversal — old test asserted "default handler NOT called", new test asserts "BOTH override observer + handler.dispatch run".
- ``test_fp0001_run_registry.py`` / ``test_fp0001_e2e_ask_user_roundtrip.py``: removed obsolete ``answer_intervention`` / ``question`` coverage (= duplicated by α-aware files).
- ``test_intervention_agent_routing.py`` / ``test_intervention_agent_subscriber.py``: chain-override tests renamed + rewritten for decorate semantics.
- ``test_a2a_iv_kind_choices_267_gap4.py`` (PR #285 coverage): bus method rename + swap mock target from ``run_registry.answer_intervention`` → ``ChatSession.answer_pending_intervention``.
- ``test_a2a_sse_producer_267_gap1.py`` + ``test_a2a_bus_stamping_268_phase2.py`` + ``test_chat_bus_stamping_268_continued.py``: bus method rename, drop iv.future await pattern.
- ``test_run_registry_persist.py``: drop ``pending_intervention`` persist assertions; ``answer_intervention`` test → status-mirror test.

## Test plan

- [x] Tier 2 contract test coverage updated across the 13 files above.
- [x] Full suite: **4256 passed, 5 skipped, 3 xfailed** in 156s.
- [x] ``ruff check`` clean on the full tree.

## Migration / compat

- Existing ``.reyn/state/run_registry.json`` from PR #273 era: restored cleanly (extra keys ignored).
- Peer API stability: ``POST /a2a/agents/<name> {task_id, answer}`` request + response shape unchanged. ``GET /a2a/tasks/{run_id}`` drops ``question`` from the public dict (= it was never authoritative; the prompt text is in ``history_events`` / webhook payloads now).
- Existing webhook + SSE consumers see no payload format change.

## What the α refactor unlocks

- A2A ivs are now eligible for R-D12's persistent answer buffer (= the original Gap 5 Phase 2 goal: restart-resume survival).
- A2A ivs are now visible to #268's cross-channel ``observe / discard / claim`` API (previously invisible).
- ``register_intervention_override`` has coherent semantics — name and behaviour both say "side-effect observer alongside dispatch" rather than the old "replace dispatch" hidden meaning.
- OS-Agent boundary preserved: A2A-specific concepts (webhook URL, SSE shape) stay in the A2A bus + router; ChatSession's iv model is unchanged.

## Related

- #267 Gap 5 Phase 1 (PR #273): persistence infrastructure preserved; the ``pending_intervention`` field it persisted is dropped because α makes it redundant.
- #267 Gap 5 Phase 2 (original framing): superseded by this PR.
- #267 Gap 1 / Gap 2 / Gap 4 (PRs #285 / #286 / #288): A2A peer-facing wires (SSE / webhook / iv kind+choices) all preserved + tested.
- #268 Phase 2 (PRs #275 / #281 / #283): origin-pin + cross-channel iv API now applies uniformly to A2A ivs.
- PR-intervention-link L2-L6 / R-D12: existing ChatSession-side iv lifecycle that α extends to A2A ivs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)