### PR TITLE
TUI: surface --no-restore warning into conversation pane (F12)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -116,6 +116,7 @@ class ReynTUIApp(App):
         model: str = "",
         budget_tracker=None,
         banner: bool = False,
+        no_restore: bool = False,
     ) -> None:
         super().__init__()
         self.register_theme(self._REYN_THEME)
@@ -125,6 +126,7 @@ class ReynTUIApp(App):
         self._model = model
         self._budget_tracker = budget_tracker
         self._banner = banner
+        self._no_restore = no_restore
         self._outbox_task: asyncio.Task | None = None
         self._panel_visible = False
         self._cancel_event: asyncio.Event = asyncio.Event()
@@ -240,6 +242,21 @@ class ReynTUIApp(App):
                 conv._write_log(rt)
             conv._write_log(Text("  Gives you the reins.", style="dim #555555"))
             conv._write_log(Text("─" * 38, style="#2a2a2a"))
+
+        # ``--no-restore`` was previously surfaced only via a stderr print
+        # from the CLI entry point, which the TUI overlay completely hides.
+        # Echo the same reassurance into the conversation pane so the
+        # operator can confirm the flag took effect even after the TUI is
+        # already in the foreground. Amber styling matches other
+        # advisory-but-non-fatal lines (= header `[N pending]` badge).
+        if self._no_restore:
+            conv = self.query_one("#conversation", ConversationView)
+            from rich.text import Text as _RichText
+            conv._write_log(_RichText(
+                "⚠ --no-restore: in-flight skill state was NOT loaded this run. "
+                "Restart without --no-restore to resume.",
+                style="#d4a017",
+            ))
 
         # Start outbox subscription if registry is available
         if self._agent_registry is not None:
@@ -1395,6 +1412,7 @@ async def run_tui(
     model: str = "",
     budget_tracker=None,
     banner: bool = False,
+    no_restore: bool = False,
 ) -> None:
     """Entry point called from cli/commands/chat.py when TUI mode is selected."""
     app = ReynTUIApp(
@@ -1403,5 +1421,6 @@ async def run_tui(
         model=model,
         budget_tracker=budget_tracker,
         banner=banner,
+        no_restore=no_restore,
     )
     await app.run_async()

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -354,6 +354,7 @@ def run(args: argparse.Namespace) -> None:
                 model=model,
                 budget_tracker=budget_tracker,
                 banner=getattr(args, "banner", False),
+                no_restore=skip_restore,
             )
 
         run_async(_main_tui())


### PR DESCRIPTION
**[tui-coder]** — UX wave finding F12 (P1/S/score=3.0 from triage). 1 of 8 planned PRs.

## Observation

`reyn chat --no-restore` prints `⚠ --no-restore: skill state on disk is NOT loaded...` to stderr from `cli/commands/chat.py:323-328`. Once Textual takes over the terminal (alt screen), that pre-TUI line is hidden — the operator can't confirm the flag took effect, and can't recall why in-flight skills are missing from the agents tab.

## Fix

Wire `skip_restore` through `run_tui` → `ReynTUIApp(no_restore=...)`, and in `on_mount` write an amber dim-style warning line to the conversation pane via the same `conv._write_log` path the banner uses.

```
⚠ --no-restore: in-flight skill state was NOT loaded this run. Restart without --no-restore to resume.
```

Amber styling (`#d4a017`) matches the existing `[N pending]` header badge (= advisory-but-non-fatal). The stderr print stays — it remains visible in `--cui` mode and in edge-case CLI flows where the TUI never mounts.

## Visual

`reyn chat --no-restore`:
```
   Reyn                                                 default  │  standard  │  ...
────────────────────────────────────────────────────────────────────────────────
  ⚠ --no-restore: in-flight skill state was NOT loaded this run. Restart without --no-restore to resume.



    Type / for commands  ·  /help for a guide
    ...
```

`reyn chat` (no flag) — pane starts clean as before, no warning line.

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | `ReynTUIApp.__init__` adds `no_restore: bool = False` / `on_mount` writes amber warning when set / `run_tui` propagates the flag |
| `src/reyn/cli/commands/chat.py` | `_main_tui` passes `no_restore=skip_restore` into `run_tui` |

## Test plan

- [x] Manual: `OPENAI_API_KEY=dummy reyn chat --no-restore` in tmux MCP — amber warning visible at top of conv pane on mount.
- [x] Manual: `OPENAI_API_KEY=dummy reyn chat` (no flag) — no warning line, pane starts clean.
- [x] `ruff check src/reyn/chat/tui/app.py src/reyn/cli/commands/chat.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test for the warning string — would pin a UX-formatting that should stay free to tweak. Manual visual is the contract per `docs/deep-dives/contributing/testing.ja.md` §6.4.
- [x] (skipped — Tier 4 risk) regression test for the no-flag path — same reason. Manual visual covers it.
- [x] (skipped — implicit) existing `tests/cli/test_empty_hint_discoverability.py` — empty hint is on a separate Static widget, not the RichLog where the warning is written. No interaction expected.

## Scope guard

**NOT in scope**:
- restore replay of past conversations on startup (= F11 / L cost cross-layer parking lot — `ChatMessage → OutboxMessage` 変換 with session/history surface)
- `/restart` slash command equivalent to `--reset` flag (= F14 separate, M cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)