### PR TITLE
TUI: clear conv pane + divider on /attach (F13)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -193,6 +193,13 @@ class OutboxRouter:
         about WHICH agent is actively running. Any pending transient
         auto-hide timer is cancelled too — the new agent should not
         inherit a ghost timer from the old one's flow.
+
+        Additionally clears the conversation log (= ``conv.clear()``)
+        and writes a dim divider line naming the freshly attached
+        agent. Previously only the header label updated, leaving the
+        old agent's transcript fully visible — visually two agents'
+        conversations blended into one scroll history and the user
+        couldn't tell where one ended and the next began.
         """
         app = self._app
         new_name = msg.text
@@ -201,6 +208,12 @@ class OutboxRouter:
             header.refresh_status(agent_name=new_name)
             self._cancel_transient_timer()
             conv.hide_status()
+            conv.clear()
+            from rich.text import Text as _RichText
+            conv._write_log(_RichText(
+                f"── attached to {new_name} ──",
+                style="dim #555555",
+            ))
 
     def _on_matrix(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,


### PR DESCRIPTION
**[tui-coder]** — UX wave finding F13 (P1/S/score=3.0 from triage). 2 of 8 planned PRs in #291-followup TUI UX wave.

## Observation

After `/attach <other_agent>`, the header label updates to the new agent's name, but the conv pane keeps the previous agent's full transcript visible — no clear, no divider. Two agents' conversations blend into one scroll history, and the user can't tell which earlier turn belonged to which agent.

`src/reyn/chat/tui/app_outbox.py:185-203` `_on_attach_request` only called `header.refresh_status()` + `conv.hide_status()` + transient-timer cancel.

## Fix

After the existing header refresh, call `conv.clear()` (= the same path Ctrl+L uses; resets log + stream rows + skill rows + error boxes + turn anchors, restores empty-state hint). Then write a dim divider line into the now-empty log:

```
── attached to test219 ──
```

`clear()` already re-shows the empty-state hint, so the new agent starts from the same "type / for commands" baseline as a fresh launch. The divider is a permanent breadcrumb for where the switch happened.

## Visual

Before `/attach test219`:
```
   Reyn                  default  │  standard  │  …
─────────────────────
  > previous turn 1
  agent: previous reply 1
  > previous turn 2
  agent: previous reply 2
  ...
```

After (header switches, divider added, empty hint re-shown):
```
   Reyn                  test219  │  standard  │  …
─────────────────────
  ── attached to test219 ──



    Type / for commands  ·  /help for a guide
    ...
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app_outbox.py` | `_on_attach_request` calls `conv.clear()` + writes dim divider Text |

## Test plan

- [x] Manual: `OPENAI_API_KEY=dummy reyn chat` (default agent) in tmux MCP → `/attach test219` Enter — verified header switches to `test219`, conv pane clears, dim `── attached to test219 ──` divider visible at top, empty-hint re-shows.
- [x] `ruff check src/reyn/chat/tui/app_outbox.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test pinning the divider string — `── attached to <name> ──` is UX formatting that should stay free to tweak. Manual visual is the contract per `docs/deep-dives/contributing/testing.ja.md` §6.4.
- [x] (skipped — implicit) regression of Ctrl+L clear behaviour — `clear()` is the same method Ctrl+L invokes, no path change.

## Scope guard

**NOT in scope**:
- new-agent placeholder content (= startup banner for the attached agent) — out of scope, the empty hint already says "Type / for commands"
- attach history audit (= log of all prior attaches in a session) — separate UX, not in F13

🤖 Generated with [Claude Code](https://claude.com/claude-code)