### PR TITLE
TUI: render unknown slash commands as ErrorBox (F1)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2848,8 +2848,12 @@ class ChatSession:
         slash_cmd = REGISTRY.get(cmd)
         if slash_cmd is None:
             known = ", ".join(f"/{n}" for n in REGISTRY.names())
+            # ``kind="error"`` so the TUI mounts an ErrorBox (= red ✗ icon,
+            # collapsible, Esc-to-dismiss). The previous ``kind="system"``
+            # rendered as a dim grey line indistinguishable from a successful
+            # slash-command reply — a typo'd command silently looked OK.
             await self._put_outbox(OutboxMessage(
-                kind="system",
+                kind="error",
                 text=f"unknown command /{cmd}; try: {known}",
             ))
             return True


### PR DESCRIPTION
**[tui-coder]** — UX wave finding F1 (P2/S/score=2.0 from triage). 3 of 8 planned PRs.

## Observation

`_maybe_handle_slash` in `src/reyn/chat/session.py:2849-2854` posted unknown commands with `kind="system"`, which renders as a dim grey line under a `· system` header — visually indistinguishable from a successful slash-command reply. Typo'd `/foober` looked just like `/help` returning info; user had to read the line carefully to notice the failure.

## Fix

Switch the unknown-command branch to `kind="error"` (1-line change). The TUI's `_on_error` handler mounts an ErrorBox (red ✗ icon, collapsible, Esc-to-dismiss) — the same widget used for router failures, /attach errors, etc. The error message text itself is unchanged; only the routing kind switches.

## Visual

Before (`kind="system"` — dim grey, easy to miss):
```
  · system — unknown command /foobar; try: /agent, ...
```

After (`kind="error"` — red ✗ in ErrorBox):
```
 │ ✗ unknown command /foobar; try: /agent, /agents, /answer, /attach, /budge…  ▶
```

(Press `▶` or expand for full known-commands list; Esc dismisses.)

## Files

| file | change |
|---|---|
| `src/reyn/chat/session.py` | `_maybe_handle_slash` unknown-cmd path: `kind="system"` → `kind="error"` + comment explaining the routing change |

## Test plan

- [x] Manual: `OPENAI_API_KEY=dummy reyn chat` in tmux MCP → type `/foobar` Enter — verified ErrorBox `│ ✗ unknown command /foobar; try: ...  ▶` appears at conv footer.
- [x] `ruff check src/reyn/chat/session.py` — clean.
- [x] `grep -rn "unknown command /" tests/` — 0 hits, so no existing test pinned the prior `kind="system"` routing; no regression suite to update.
- [x] (skipped — Tier 4 risk) automated test for the new kind="error" routing — would pin a UX-formatting that should stay free to tweak. Manual visual is the contract per `docs/deep-dives/contributing/testing.ja.md` §6.4.

## Scope guard

**NOT in scope**:
- The other ErrorBox UX improvements from the same UX wave (= F3 ErrorBox hint truncation, F2 dismissed ErrorBox breadcrumb, F5 ErrorBox stack collapse) — separate PRs in this wave.
- "Did you mean: /foober?" auto-suggest based on Levenshtein distance — not in the wave triage; would be a P3 polish on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)