### PR TITLE
TUI: preserve ErrorBox recovery hint when header truncates (F3)

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -73,6 +73,16 @@ class ErrorBox(Widget):
         width: 1fr;
         padding: 0 2;
     }
+    /* Inline recovery hint extracted from the message — always visible
+       (= no display:none) so users can read "• retry or check provider
+       status" without expanding. Distinct color from `.eb-hint` so it
+       reads as actionable, not just metadata. */
+    ErrorBox Label.eb-inline-hint {
+        color: #8a7a4a;
+        height: 1;
+        width: 1fr;
+        padding: 0 2;
+    }
     /* Expanded state — reveal details */
     ErrorBox.-expanded Static.eb-details {
         display: block;
@@ -97,6 +107,22 @@ class ErrorBox(Widget):
         self._run_id_short = run_id_short
         self._skill_name = skill_name
         self._expanded = False
+        # Extract trailing ``• <hint>`` from the first line so the header
+        # can truncate the detail portion without silently dropping the
+        # recovery hint — ``classify_router_error`` formats messages as
+        # ``"router failed: [bucket] <long-detail> • <hint>"`` and the
+        # previous 72-char header cap cut the ``• hint`` suffix off when
+        # the provider repr was verbose. Rendering the hint on its own
+        # always-visible label keeps the actionable signal in front of
+        # the user without requiring an expand.
+        first_line, _sep, _rest = message.partition("\n")
+        if " • " in first_line:
+            detail_part, _bullet, hint_part = first_line.partition(" • ")
+            self._inline_hint = hint_part.strip()
+            self._first_line_for_header = detail_part
+        else:
+            self._inline_hint = ""
+            self._first_line_for_header = first_line
 
     # ── header text helpers ───────────────────────────────────────────────────
 
@@ -128,8 +154,10 @@ class ErrorBox(Widget):
         # line itself is too long — for multi-line messages whose first
         # line already fits (e.g. usage strings with sub-commands below),
         # the ▶/▼ arrow alone signals "expand for more" instead of a
-        # misleading mid-sentence truncation marker.
-        first_line, sep, _rest = self._message.partition("\n")
+        # misleading mid-sentence truncation marker. The ``• <hint>``
+        # tail (when present) lives on its own ``.eb-inline-hint`` label,
+        # so don't include it in the header truncation budget.
+        first_line = self._first_line_for_header
         if len(first_line) > 72:
             msg = first_line[:71] + "…"
         else:
@@ -143,6 +171,10 @@ class ErrorBox(Widget):
 
     def compose(self) -> ComposeResult:
         yield Label(self._header_text(), classes="eb-header")
+        if self._inline_hint:
+            yield Label(
+                f"• {self._inline_hint}", classes="eb-inline-hint",
+            )
 
         # The trace hint only makes sense when this error came from a
         # skill / op run — slash-command usage errors (= no skill_name,


### PR DESCRIPTION
**[tui-coder]** — UX wave finding F3 (P2/S/score=2.0 from triage). 4 of 8 planned PRs.

## Observation

`classify_router_error` (`src/reyn/chat/error_format.py:55`) formats messages as `"router failed: [bucket] <detail> • <hint>"`. The ErrorBox header truncates the first line at 72 characters. When the provider exception repr is long (e.g. `litellm.InternalServerError: ProxyServer call failed with status 500`), the `• retry or check provider status` suffix gets silently cut — leaving the user with no actionable next step until they manually expand the box.

## Fix

Parse the `" • "` separator out of the first line in `__init__`:
- `_first_line_for_header` = the detail portion (used by the 72-char truncation)
- `_inline_hint` = the trailing recovery text (= `"retry or check provider status"`)

Add a new `eb-inline-hint` Label in `compose` that renders the hint on its own always-visible line below the header. Dim amber (`#8a7a4a`) styling distinguishes it from the existing `.eb-hint` "Ctrl+B → events" label, which stays gated by expand and only shows for skill / run-id boxes.

## Visual

Before (long router error, hint cut off):
```
 │ ✗ router failed: [openai_unavailable] litellm.InternalServerError: ProxyS…  ▶
```
(`• retry or check provider status` lost — only visible on expand, and even then sometimes wrapped in detail body.)

After (header still concise, hint always visible below):
```
 │ ✗ router failed: [openai_unavailable] litellm.InternalServerError: ProxyS…  ▶
   • retry or check provider status
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/error_box.py` | `__init__` extracts `• hint` → `_inline_hint` / `_first_line_for_header` separation / `_header_text` uses no-hint version for 72-char truncation / `compose` yields always-visible `eb-inline-hint` Label / CSS adds the new label style |

## Test plan

- [x] Unit smoke: `ErrorBox(message="router failed: [openai_unavailable] litellm.InternalServerError: ProxyServer call failed with status 500 • retry or check provider status")` → `_inline_hint = "retry or check provider status"`, `_header_text` ends `…  ▶`, hint preserved on separate label.
- [x] Unit smoke: message without `• hint` (e.g. unknown slash command, plain exceptions) → `_inline_hint = ""`, no extra label yielded, header behaviour identical to pre-fix.
- [x] `python -m pytest tests/cli/test_error_box_left_bar.py tests/test_router_error_classify.py` — 24 passed (existing ErrorBox + classify_router_error invariants intact).
- [x] `ruff check src/reyn/chat/tui/widgets/error_box.py` — clean (pre-push 実走済).
- [x] (skipped — real router error requires killing the proxy mid-session) live tmux visual with long router error. The parser is exercised end-to-end by the unit-smoke + classifier tests which verify the message format the slicer reads.

## Scope guard

**NOT in scope**:
- F2 dismissed-ErrorBox breadcrumb (= separate PR in this wave)
- F5 ErrorBox stack collapse (= separate PR candidate, was dropped from top-8 wave)
- Multi-hint messages (`• hint1 • hint2`) — the partition matches the first `" • "` and treats the rest as one hint; multi-hint would be a follow-up if `classify_router_error` ever produces them (currently single-hint only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)