### PR TITLE
feat(a2a): webhook dead-channel detection via ChannelState wire (issue #269 Phase 2)

### DIFF
--- a/src/reyn/web/a2a_intervention.py
+++ b/src/reyn/web/a2a_intervention.py
@@ -137,17 +137,46 @@ class A2AInterventionBus:
                 "failed for run %r", self._run_id,
             )
 
-        # Webhook POST (issue #267 Gap 2). Best-effort, opt-in.
+        # Webhook POST (issue #267 Gap 2 + issue #269 Phase 2). Best-
+        # effort, opt-in. Liveness-gated: skip the post if the
+        # per-run ChannelState says the webhook URL is dead (=
+        # consecutive 5xx / timeout / 4xx beyond threshold). Update
+        # the state after each attempt so subsequent fires (= terminal
+        # completed / failed, and _A2AProgressBridge progress events)
+        # share the dead-channel inference.
         if entry.webhook_url:
+            channel_state = self._registry.webhook_channel_state(self._run_id)
+            if channel_state is not None and not channel_state.is_alive():
+                logger.warning(
+                    "A2AInterventionBus.on_dispatch: webhook channel "
+                    "for run %r is dead (= %d consecutive failures); "
+                    "skipping POST", self._run_id,
+                    channel_state.delivery_failures,
+                )
+                return
             from reyn.web.notifications import post_webhook  # noqa: PLC0415
 
             try:
-                await post_webhook(entry.webhook_url, payload)
-            except Exception:  # noqa: BLE001
+                result = await post_webhook(entry.webhook_url, payload)
+            except Exception as exc:  # noqa: BLE001
                 logger.exception(
-                    "A2AInterventionBus.on_dispatch: webhook POST failed "
+                    "A2AInterventionBus.on_dispatch: webhook POST raised "
                     "for run %r url=%s", self._run_id, entry.webhook_url,
                 )
+                # post_webhook's internal retry / error handling normally
+                # converts exceptions into a DeliveryResult; a raise here
+                # means a defensive path failed. Record as retryable so
+                # the state machine accounts for the attempt.
+                from reyn.chat.channel_state import (  # noqa: PLC0415
+                    DeliveryOutcome,
+                    DeliveryResult,
+                )
+                result = DeliveryResult(
+                    outcome=DeliveryOutcome.RETRYABLE_FAILURE,
+                    error=str(exc),
+                )
+            if channel_state is not None:
+                channel_state.record_attempt(result)
 
 
 __all__ = ["A2AInterventionBus"]

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -805,15 +805,39 @@ class _A2AProgressBridge:
             self._run_registry.append_event(self._run_id, payload)
         except Exception:  # noqa: BLE001 — sse buffer is best-effort
             pass
-        # Sink 2: webhook POST (opt-in). Each sink swallows its own
-        # transport error independently so one failure doesn't suppress
-        # the other.
+        # Sink 2: webhook POST (opt-in + liveness-gated, issue #269
+        # Phase 2). Skip if the per-run ChannelState marked the URL
+        # dead from earlier sustained failures; record each attempt
+        # outcome so subsequent fires (= more progress events,
+        # terminal completed / failed) share the inference.
         if self._webhook_url is not None:
+            # Defensive getattr so stub registries (= test fakes that
+            # only implement append_event) still work with the bridge.
+            channel_state = None
+            get_state = getattr(
+                self._run_registry, "webhook_channel_state", None,
+            )
+            if get_state is not None:
+                try:
+                    channel_state = get_state(self._run_id)
+                except Exception:  # noqa: BLE001
+                    channel_state = None
+            if channel_state is not None and not channel_state.is_alive():
+                return
+            from reyn.chat.channel_state import (  # noqa: PLC0415
+                DeliveryOutcome,
+                DeliveryResult,
+            )
             from reyn.web.notifications import post_webhook  # noqa: PLC0415
             try:
-                await post_webhook(self._webhook_url, payload)
-            except Exception:  # noqa: BLE001 — progress is best-effort
-                return
+                result = await post_webhook(self._webhook_url, payload)
+            except Exception as exc:  # noqa: BLE001 — progress is best-effort
+                result = DeliveryResult(
+                    outcome=DeliveryOutcome.RETRYABLE_FAILURE,
+                    error=str(exc),
+                )
+            if channel_state is not None:
+                channel_state.record_attempt(result)
 
 
 async def _handle_async_mode(

--- a/src/reyn/web/run_registry.py
+++ b/src/reyn/web/run_registry.py
@@ -38,6 +38,10 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.chat.channel_state import ChannelState
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +53,10 @@ class RunEntry:
     issue #292 (α): ``pending_intervention`` and ``question`` fields
     removed — iv state lives in ``ChatSession._interventions``. This
     entry only carries A2A-task-wrapper state.
+
+    issue #269 Phase 2: ``_webhook_channel_state`` (private, lazy-init)
+    tracks dead-channel detection for the registered ``webhook_url``.
+    See ``RunRegistry.webhook_channel_state``.
     """
     run_id: str
     agent_name: str
@@ -61,6 +69,12 @@ class RunEntry:
     history_events: list[dict] = field(default_factory=list)
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    # issue #269 Phase 2: per-run webhook liveness state. In-memory
+    # only (not persisted) — restart starts fresh, which matches the
+    # peer's expectation that a server restart resets retry counters.
+    _webhook_channel_state: "ChannelState | None" = field(
+        default=None, repr=False,
+    )
 
     def to_public_dict(self) -> dict:
         """JSON-safe shape for GET /a2a/tasks/{run_id} responses.
@@ -301,6 +315,34 @@ class RunRegistry:
     def remove(self, run_id: str) -> None:
         if self._runs.pop(run_id, None) is not None:
             self._persist()
+
+    def webhook_channel_state(
+        self, run_id: str,
+    ) -> "ChannelState | None":
+        """Get-or-create the ``ChannelState`` for this run's webhook URL.
+
+        Returns ``None`` when the run has no ``webhook_url`` set (=
+        peer never registered a callback URL → there's no channel to
+        track). Otherwise lazy-initialises a ``ChannelState`` with
+        ``channel_id="webhook:<run_id>"`` on first access.
+
+        In-memory only — not persisted across process restart, which
+        matches the peer's expectation that a restart resets retry
+        counters. Callers (= ``A2AInterventionBus.on_dispatch``,
+        ``_A2AProgressBridge._send``) check ``is_alive()`` before each
+        fire and call ``record_attempt(result)`` after.
+
+        issue #269 Phase 2.
+        """
+        entry = self._runs.get(run_id)
+        if entry is None or entry.webhook_url is None:
+            return None
+        if entry._webhook_channel_state is None:
+            from reyn.chat.channel_state import ChannelState  # noqa: PLC0415
+            entry._webhook_channel_state = ChannelState(
+                channel_id=f"webhook:{run_id}",
+            )
+        return entry._webhook_channel_state
 
 
 __all__ = ["RunEntry", "RunRegistry"]

--- a/tests/test_channel_state_webhook_wire_269.py
+++ b/tests/test_channel_state_webhook_wire_269.py
@@ -1,0 +1,370 @@
+"""Tier 2: ChannelState webhook wire (issue #269 Phase 2).
+
+Pre-#269 Phase 2 (= up to PR #274): ``ChannelState`` /
+``DeliveryResult`` / ``RetryPolicy`` vocabulary existed but no
+production code path instantiated ``ChannelState``. Outbound webhooks
+fired indefinitely even when the peer's URL kept returning 5xx /
+timing out → wasted retries + log noise.
+
+This file pins Phase 2 wire: per-``RunEntry`` ``ChannelState``
+tracks consecutive webhook failures and short-circuits subsequent
+fires once the threshold is crossed.
+
+Two production call sites updated by this PR:
+
+  - ``A2AInterventionBus.on_dispatch`` — fires the input-required
+    payload to the peer's webhook on each iv dispatch.
+  - ``_A2AProgressBridge._send`` — fires the in-progress payloads
+    for each tracked chat event (phase / llm / act).
+
+Both share the same ``RunRegistry.webhook_channel_state(run_id)``
+ChannelState instance so an alternating sequence (input-required →
+progress → completed) participates in one dead-channel inference.
+
+Pins:
+
+  1. ``RunRegistry.webhook_channel_state`` returns None when the
+     RunEntry has no ``webhook_url`` (= peer didn't opt in to push).
+  2. Returns a lazy-initialised ``ChannelState`` keyed by
+     ``f"webhook:{run_id}"`` when ``webhook_url`` is set; subsequent
+     calls return the same instance.
+  3. ``A2AInterventionBus.on_dispatch`` calls ``record_attempt``
+     after each ``post_webhook`` invocation, and skips the post
+     entirely when ``is_alive()`` returns False.
+  4. ``_A2AProgressBridge._send`` mirrors the same gating.
+  5. Both sites share the channel state instance — alternating
+     dispatches accrue failures in one counter.
+  6. After ``failure_threshold`` consecutive ``RETRYABLE_FAILURE``
+     outcomes, the channel is dead; subsequent fires are skipped.
+  7. A single ``SUCCESS`` resets the failure counter (= a transient
+     5xx wave that recovers leaves the channel alive).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
+
+from reyn.chat.channel_state import (  # noqa: E402
+    ChannelState,
+    DeliveryOutcome,
+    DeliveryResult,
+)
+from reyn.events.events import EventLog  # noqa: E402
+from reyn.user_intervention import UserIntervention  # noqa: E402
+from reyn.web.a2a_intervention import A2AInterventionBus  # noqa: E402
+from reyn.web.run_registry import RunRegistry  # noqa: E402
+
+# ── 1. RunRegistry.webhook_channel_state lifecycle ─────────────────────
+
+
+def test_webhook_channel_state_returns_none_when_no_webhook_url() -> None:
+    """Tier 2: peer that didn't register a webhook URL has no channel
+    to track. ``webhook_channel_state`` returns None.
+    """
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A", webhook_url=None,
+    )
+    assert registry.webhook_channel_state(entry.run_id) is None
+
+
+def test_webhook_channel_state_returns_none_for_unknown_run_id() -> None:
+    """Tier 2: defensive — unknown run_id returns None, no KeyError."""
+    registry = RunRegistry()
+    assert registry.webhook_channel_state("no-such-run") is None
+
+
+def test_webhook_channel_state_lazy_init_keyed_by_webhook_prefix() -> None:
+    """Tier 2: first access on a RunEntry with a webhook URL creates
+    a fresh ``ChannelState`` with ``channel_id="webhook:<run_id>"``.
+    Subsequent calls return the same instance (= no re-init).
+    """
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+    state_a = registry.webhook_channel_state(entry.run_id)
+    state_b = registry.webhook_channel_state(entry.run_id)
+    assert isinstance(state_a, ChannelState)
+    assert state_a is state_b
+    assert state_a.channel_id == f"webhook:{entry.run_id}"
+
+
+# ── 2. A2AInterventionBus.on_dispatch gates on is_alive ────────────────
+
+
+def test_a2a_bus_on_dispatch_skips_post_when_channel_dead(
+    monkeypatch,
+) -> None:
+    """Tier 2: when the per-run ``ChannelState.is_alive()`` returns
+    False (= prior dispatches accumulated ``failure_threshold``
+    consecutive failures), ``on_dispatch`` does NOT call
+    ``post_webhook``. The SSE history append still runs (= local
+    sink, independent of webhook).
+    """
+    posted: list = []
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+        return DeliveryResult(outcome=DeliveryOutcome.SUCCESS)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+
+    # Pre-mark channel state dead via direct failure accumulation.
+    state = registry.webhook_channel_state(entry.run_id)
+    for _ in range(3):
+        state.record_attempt(
+            DeliveryResult(outcome=DeliveryOutcome.RETRYABLE_FAILURE),
+        )
+    assert not state.is_alive()
+
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    # No webhook call attempted.
+    assert posted == []
+    # SSE buffer still appended (= local sink independent).
+    assert len(registry.get(entry.run_id).history_events) == 1
+
+
+def test_a2a_bus_on_dispatch_records_success(monkeypatch) -> None:
+    """Tier 2: successful ``post_webhook`` updates the channel state
+    via ``record_attempt`` — failures reset to 0, last_ack advances.
+    """
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        return DeliveryResult(outcome=DeliveryOutcome.SUCCESS)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    state = registry.webhook_channel_state(entry.run_id)
+    assert state.delivery_failures == 0
+    assert state.delivery_attempts_total == 1
+    assert state.last_ack_at is not None
+    assert state.is_alive()
+
+
+def test_a2a_bus_on_dispatch_accumulates_consecutive_failures(
+    monkeypatch,
+) -> None:
+    """Tier 2: ``RETRYABLE_FAILURE`` results from ``post_webhook``
+    increment ``delivery_failures`` via ``record_attempt``. After
+    ``failure_threshold`` consecutive failures the channel is dead
+    and subsequent fires are skipped.
+    """
+    call_count = {"n": 0}
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        call_count["n"] += 1
+        return DeliveryResult(outcome=DeliveryOutcome.RETRYABLE_FAILURE)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    async def _drive() -> None:
+        # 3 consecutive failures (= failure_threshold default).
+        for _ in range(3):
+            iv = UserIntervention(kind="ask_user", prompt="?")
+            await bus.on_dispatch(iv)
+        # 4th attempt: channel is dead, post_webhook NOT called.
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    state = registry.webhook_channel_state(entry.run_id)
+    assert state.delivery_failures == 3  # threshold hit
+    assert not state.is_alive()
+    assert call_count["n"] == 3  # 4th call was skipped
+
+
+def test_a2a_bus_on_dispatch_success_resets_failure_counter(
+    monkeypatch,
+) -> None:
+    """Tier 2: a transient wave of failures followed by a success
+    resets ``delivery_failures`` to 0 — the channel is alive again.
+    """
+    outcomes = [
+        DeliveryOutcome.RETRYABLE_FAILURE,
+        DeliveryOutcome.RETRYABLE_FAILURE,
+        DeliveryOutcome.SUCCESS,
+    ]
+    call_count = {"n": 0}
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        outcome = outcomes[call_count["n"]]
+        call_count["n"] += 1
+        return DeliveryResult(outcome=outcome)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    async def _drive() -> None:
+        for _ in range(3):
+            iv = UserIntervention(kind="ask_user", prompt="?")
+            await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    state = registry.webhook_channel_state(entry.run_id)
+    # First two failures accrued, then SUCCESS reset to 0.
+    assert state.delivery_failures == 0
+    assert state.delivery_attempts_total == 3
+    assert state.is_alive()
+
+
+# ── 3. _A2AProgressBridge._send shares the same channel state ──────────
+
+
+def test_progress_bridge_send_gates_on_is_alive(monkeypatch) -> None:
+    """Tier 2: ``_A2AProgressBridge._send`` shares the per-run
+    ChannelState with ``A2AInterventionBus``. A dead channel from
+    earlier on_dispatch failures means progress events skip the
+    webhook fire too.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    posted: list = []
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        posted.append((url, payload))
+        return DeliveryResult(outcome=DeliveryOutcome.SUCCESS)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+
+    # Pre-mark dead via the bus's accumulation.
+    state = registry.webhook_channel_state(entry.run_id)
+    for _ in range(3):
+        state.record_attempt(
+            DeliveryResult(outcome=DeliveryOutcome.RETRYABLE_FAILURE),
+        )
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id=entry.run_id,
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+        run_registry=registry,
+    )
+
+    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+
+    assert posted == [], (
+        "bridge should skip webhook POST when shared ChannelState says dead"
+    )
+    # SSE buffer still appended.
+    assert len(registry.get(entry.run_id).history_events) == 1
+
+
+def test_bus_and_bridge_share_the_same_channel_state(monkeypatch) -> None:
+    """Tier 2: both sites must update the SAME ``ChannelState``
+    instance so an alternating sequence (= bus input-required, then
+    bridge progress, then bus completed) feeds one consecutive-failure
+    counter — not three separate counters that never hit threshold.
+    """
+    from reyn.web.routers.a2a import _A2AProgressBridge
+
+    async def _fake_post(url: str, payload: dict):  # noqa: ANN202
+        return DeliveryResult(outcome=DeliveryOutcome.RETRYABLE_FAILURE)
+
+    import reyn.web.notifications as notifications_mod
+    monkeypatch.setattr(notifications_mod, "post_webhook", _fake_post)
+
+    registry = RunRegistry()
+    entry = registry.create(
+        agent_name="demo", chain_id="chain-A",
+        webhook_url="https://peer.test/hook",
+    )
+
+    bus = A2AInterventionBus(run_id=entry.run_id, registry=registry)
+
+    class _FakeSession:
+        _chat_events = EventLog()
+
+    bridge = _A2AProgressBridge(
+        session=_FakeSession(),
+        run_id=entry.run_id,
+        webhook_url="https://peer.test/hook",
+        agent_name="demo",
+        run_registry=registry,
+    )
+
+    async def _drive() -> None:
+        # Bus fires 1 failure → state.delivery_failures = 1
+        iv = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv)
+        # Bridge fires 1 failure → state.delivery_failures = 2 (shared)
+        await bridge._send(1, "phase_started", "phase: planning")
+        # Bus fires 1 more → state.delivery_failures = 3 = threshold
+        iv2 = UserIntervention(kind="ask_user", prompt="?")
+        await bus.on_dispatch(iv2)
+
+    asyncio.run(_drive())
+
+    state = registry.webhook_channel_state(entry.run_id)
+    assert state.delivery_failures == 3, (
+        f"bus + bridge must share ChannelState; got {state.delivery_failures} "
+        f"(expected 3 from alternating 1+1+1 failures across both sites)"
+    )
+    assert not state.is_alive()
+
+
+# Silence pytest unused-import; kept for parity / future extension.
+_ = Path


### PR DESCRIPTION
**[e2e-coder]** — #269 Phase 2: wires the ChannelState vocabulary that PR #274 shipped as types-only. Per-``RunEntry`` ``ChannelState`` tracks consecutive webhook failures and short-circuits subsequent fires once the threshold is crossed.

## Why now

Pre-PR: ``ChannelState`` / ``DeliveryResult`` / ``RetryPolicy`` existed in source but **no production code path instantiated them**. Outbound webhooks fired indefinitely against URLs that kept 5xx-ing / timing out. With α refactor (PR #300) settled and `_A2AProgressBridge` firing per-event progress webhooks (PR #286/#288), the number of fires per A2A run grew — a wasted-retry storm became proportionally more visible.

Scope narrowed by α: the original #269 Phase 2 framing included cross-channel `channel_is_alive` for iv stall routing, which α dissolved structurally (= ivs are ChatSession-owned, R-D12 covers restart). Remaining production-useful wire = **webhook dead-channel detection**.

## Summary

- `RunEntry`: new private `_webhook_channel_state` field. In-memory only (restart resets counters — matches peer's mental model).
- `RunRegistry.webhook_channel_state(run_id) -> ChannelState | None`: get-or-create. None when no `webhook_url`. Lazy-init keyed by `f"webhook:{run_id}"`.
- `A2AInterventionBus.on_dispatch`: liveness-gated webhook fire. `is_alive()` check before post; `record_attempt(result)` after.
- `_A2AProgressBridge._send`: same gating + recording, sharing the SAME ChannelState instance. Defensive `getattr` so test fake registries (= sse-only stubs) still work.

Both production call sites share the channel state via the per-run registry lookup so an alternating sequence (= bus input-required → bridge progress → bus completed) feeds ONE consecutive-failure counter.

## Test plan

- [x] Tier 2 contract test (9 cases): lifecycle / gating / recording / shared-instance enforcement
- [x] Adjacent A2A region (8 files / 84 tests): all pass
- [x] Full suite: 4324 passed, 5 skipped, 3 xfailed (= 1 unrelated flake in `tests/cli/test_header_clock_compact.py` triggered by 20:00-hour clock display; orthogonal to this PR)
- [x] `ruff check` clean

## Related

- PR #274 (= #269 Phase 1, ack vocabulary shipped without wire)
- PR #286 / #288 (= #267 Gap 2 / Gap 1 webhook + SSE producers — the surfaces this PR gates)
- PR #300 (= #292 α refactor; dissolved the iv-side `channel_is_alive` requirement, narrowing #269 Phase 2 scope to webhook-only)
- #269 issue body Phase 2 → focus refined to "webhook dead-channel detection" (= iv stall part subsumed by α)

🤖 Generated with [Claude Code](https://claude.com/claude-code)