### PR TITLE
TUI: leave breadcrumb in conv log when ErrorBox dismissed (F2)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -883,14 +883,40 @@ class ConversationView(Widget):
         return bool(self._error_boxes)
 
     def dismiss_last_error(self) -> None:
-        """Remove the most recently mounted ErrorBox (idempotent if already removed)."""
+        """Remove the most recently mounted ErrorBox + leave a breadcrumb.
+
+        UX wave F2: previously Esc removed the ErrorBox entirely with no
+        trace — scrolling up later showed only the user's unanswered
+        message and the failure context was gone. Now we write a dim
+        one-line breadcrumb to the conv log so the dismissed failure
+        stays visible in scroll history. ``(see events)`` is appended
+        only when the error originated from a skill / run (= the same
+        ``has_trace`` gate the ErrorBox's own ``.eb-hint`` label uses).
+        """
         while self._error_boxes:
             box = self._error_boxes.pop()
+            # Capture the summary BEFORE removal — `box` is invalidated
+            # by `remove()` and we still want to write the breadcrumb
+            # even if removal raises (= the widget was already gone).
+            first_line, _sep, _rest = (getattr(box, "_message", "") or "").partition("\n")
+            if len(first_line) > 72:
+                summary = first_line[:71] + "…"
+            else:
+                summary = first_line
+            has_trace = bool(
+                getattr(box, "_skill_name", "") or getattr(box, "_run_id_short", "")
+            )
             try:
                 box.remove()
-                return
             except Exception:
                 continue  # already removed, try next
+            trailer = " (see events)" if has_trace else ""
+            from rich.text import Text as _RichText
+            self._write_log(_RichText(
+                f"  ✗ {summary} (dismissed){trailer}",
+                style="dim #555555",
+            ))
+            return
 
     # ── intervention mounting ─────────────────────────────────────────────────
 


### PR DESCRIPTION
**[tui-coder]** — UX wave finding F2 (P2/M/score=1.0 from triage). 7 of 8 planned PRs.

## Observation

Pressing Esc in `dismiss_last_error` removed the ErrorBox widget entirely — scrolling up later showed only the user's unanswered message with zero indication that the request had failed. The failure context vanished from history; a user reviewing what happened earlier in a session got a misleading "this turn returned nothing" impression.

## Fix

Capture the box's first-line message + `has_trace` flag (= same gate the ErrorBox's own `.eb-hint` Label uses for "Ctrl+B → events for full trace") BEFORE removal, then write a dim one-line breadcrumb to the RichLog:

```
  ✗ <summary> (dismissed)
  ✗ <summary> (dismissed) (see events)   ← when skill/run-id present
```

72-char truncation matches the existing header cap so verbose router errors don't bloat the scroll.

## Visual

Before (post-Esc, no trace of the failure):
```
  20:11  ▶ you ─────
         /attach



  Type / for commands  ·  /help for a guide
```

After (Esc dismisses the box but leaves a breadcrumb):
```
  20:11  ▶ you ─────
         /attach

    ✗ usage: /attach <name> (dismissed)



  Type / for commands  ·  /help for a guide
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/conversation.py` | `dismiss_last_error` captures `_message` / `_skill_name` / `_run_id_short` before `box.remove()` and writes a dim `_write_log` breadcrumb with optional `(see events)` trailer |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat` → `/attach` (no arg) → ErrorBox `│ ✗ usage: /attach <name>  ▶` mounted; Esc → box disappears, dim `  ✗ usage: /attach <name> (dismissed)` line stays in scroll history. No `(see events)` trailer (= correct gating — slash error has no skill / run id).
- [x] `python -m pytest tests/cli/test_error_box_left_bar.py` — 3 passed (= ErrorBox mount surface intact).
- [x] `ruff check src/reyn/chat/tui/widgets/conversation.py` — clean (pre-push 実走済).
- [x] (skipped — live router error needed) breadcrumb with `(see events)` trailer for skill / run-id ErrorBoxes. `has_trace` gate uses the same `_skill_name` / `_run_id_short` attribute pair that `ErrorBox.compose()` already conditions its hint Label on, so the trailer rendering is purely conditional on attributes set at mount time.

## Scope guard

**NOT in scope**:
- F5 ErrorBox stack collapse — separate, was dropped from top-8 wave (P3/M).
- A "restore breadcrumb to box" undo — not requested; the breadcrumb itself is the permanent record.
- Persist breadcrumbs across sessions / events tab — relies on restore-replay path (= F11 cross-layer parking lot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)