### PR TITLE
TUI: cancel-when-idle hint with ✗ glyph + /list pointer (F4)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from reyn.chat.session import ChatSession
 
 
-# Debounce window for the "(nothing in-flight to cancel)" line — repeat
+# Debounce window for the "nothing-in-flight cancel" line — repeat
 # Ctrl+C presses within this many seconds are absorbed silently.
 _IDLE_CANCEL_DEDUP_S = 1.5
 
@@ -128,7 +128,7 @@ class ReynTUIApp(App):
         self._outbox_task: asyncio.Task | None = None
         self._panel_visible = False
         self._cancel_event: asyncio.Event = asyncio.Event()
-        # Most-recent "(nothing in-flight to cancel)" timestamp, used to
+        # Most-recent "nothing-in-flight cancel" timestamp, used to
         # suppress repeated identical lines from accumulating in the conv
         # log when the user mashes Ctrl+C on an idle session.
         self._last_idle_cancel_ts: float = 0.0
@@ -781,13 +781,23 @@ class ReynTUIApp(App):
             and cancelled_streams == 0
         ):
             # Suppress repeat lines: when the user mashes Ctrl+C on an idle
-            # session, log a single "(nothing in-flight to cancel)" then
+            # session, log a single "nothing-in-flight cancel" then
             # debounce for ``_IDLE_CANCEL_DEDUP_S`` so subsequent presses
             # don't litter the conv log with identical lines.
             now = _now_monotonic()
             if now - self._last_idle_cancel_ts > _IDLE_CANCEL_DEDUP_S:
+                # ``✗`` prefix gives the line a glyph that matches the
+                # other ``✗``-led cancellation / error feedback (= the
+                # ``✗ cancelled N skill…`` summary below), and the
+                # ``try /list`` tail tells the user how to verify
+                # nothing's actually stuck (= the most common "wait,
+                # did it really do nothing?" reaction to a no-op
+                # cancel). The previous bare ``(nothing in-flight to
+                # cancel)`` parenthetical had neither cue and read
+                # like an unimportant aside.
                 self._voice_status(
-                    "(nothing in-flight to cancel)", style="dim #555555",
+                    "✗ nothing in-flight to cancel — try /list to see active runs",
+                    style="dim #555555",
                 )
                 self._last_idle_cancel_ts = now
             return


### PR DESCRIPTION
**[tui-coder]** — UX wave finding F4 (P3/S/score=1.0 from triage). 8 of 8 planned PRs — closes the wave.

## Observation

The idle Ctrl+C path logged ``(nothing in-flight to cancel)`` as a bare dim grey parenthetical — no glyph, no recovery hint. Users who pressed Ctrl+C "just in case" had no signal that the line was a state report (vs an aside) and no easy way to verify nothing was actually stuck.

## Fix

Two minimal changes, debounce preserved:

1. **``✗`` glyph prefix** matches the ``✗ cancelled N skill…`` line emitted by successful cancels, so the conv pane carries a consistent "✗ = cancel-related" visual rhythm.

2. **``— try /list to see active runs`` tail** points at the slash command that actually lists running skills / pending interventions (registered in `src/reyn/chat/slash/chat.py:21` as ``/list``). Users who weren't sure "did it really do nothing?" can verify in one keystroke.

Debounce (``_IDLE_CANCEL_DEDUP_S = 1.5``) and the ``_last_idle_cancel_ts`` book-keeping are unchanged, so mashing Ctrl+C still collapses to one line per 1.5 s window.

## Visual

Before (idle Ctrl+C):
```
  (nothing in-flight to cancel)
```

After:
```
  ✗ nothing in-flight to cancel — try /list to see active runs
```

Mashing Ctrl+C 3× within ~600 ms still produces only one line (debounce window unchanged).

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | `cancel_inflight` idle branch: message text updated + 3 comment refs to the old string sync'd ("nothing-in-flight cancel") |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat`, idle Ctrl+C → `  ✗ nothing in-flight to cancel — try /list to see active runs` (dim) in conv log.
- [x] Manual: mash Ctrl+C 3× rapidly → only one new line (debounce verified preserved).
- [x] `grep -rn "nothing in-flight to cancel" tests/` — 0 hits, no test pins the prior string.
- [x] `ruff check src/reyn/chat/tui/app.py` — clean (pre-push 実走済).

## Scope guard

**NOT in scope**:
- New `/list` command behavior — already exists, just referenced
- Auto-open right panel `agents` tab on Ctrl+C — separate UX, not in this wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Wave summary (this is the last PR)

#291-followup TUI UX exploration wave triage produced 13 TUI-internal findings; top-8 by P / cost score landed as 8 separate PRs:

| Rank | Finding | PR | Status |
|---|---|---|---|
| 1 | F12 `--no-restore` warning to TUI pane | #301 | open |
| 2 | F13 `/attach` clear conv pane + divider | #303 | open |
| 3 | F1 unknown slash → ErrorBox | #304 | open |
| 4 | F3 ErrorBox `• hint` preservation | #305 | open |
| 5 | F6 Cost tab strip proxy prefix | #307 | open |
| 6 | F7 Header budget cap key fix | #308 | open |
| 7 | F2 dismissed ErrorBox breadcrumb | #309 | open |
| 8 | F4 cancel-when-idle hint (this PR) | this | open |

Parking lot (cross-layer / dropped):
- F11 history replay on restart (= L cost, requires session/history → outbox conversion path)
- F15 scroll-to-bottom on replay (= depends on F11)
- F5 ErrorBox stack collapse (= P3/M, dropped from top-8)
- F10 `/cost-inline` persistence (= P3/M, dropped from top-8)
- F8 cost disclaimer / F9 budget reset hint / F14 `/reset` slash (= P3/P2/P2, dropped from top-8)