### PR TITLE
TUI: /reset slash command for in-TUI state reset (F14)

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -146,6 +146,7 @@ from reyn.chat.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.chat.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.chat.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.chat.slash import plan as _plan_mod  # noqa: E402, F401
+from reyn.chat.slash import reset as _reset_mod  # noqa: E402, F401
 from reyn.chat.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.chat.slash import skills as _skills_mod  # noqa: E402, F401
 from reyn.chat.slash import tasks as _tasks_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/reset.py
+++ b/src/reyn/chat/slash/reset.py
@@ -1,0 +1,72 @@
+"""``/reset`` — wipe in-flight skill state from inside the TUI.
+
+The pre-existing ``reyn chat --reset`` CLI flag prompts for confirmation
+via ``input()`` BEFORE the TUI mounts, so users who realise mid-session
+they want a reset have no in-app affordance — they have to ``Ctrl+D``,
+restart with ``--reset``, answer the prompt at the bare terminal, then
+get the TUI back. UX wave finding F14.
+
+Two-step confirmation pattern (= no Textual ModalScreen / new widget
+needed; the simplest path to a TUI-native flow):
+
+  /reset            → prints the warning + asks user to type
+                      ``/reset confirm`` to proceed.
+  /reset confirm    → calls ``_reset_project_state(confirm=False)``
+                      and reports the outcome.
+
+The CLI flag stays — ``--cui`` mode (no TUI) and external-script
+invocations still rely on it. This is a *parallel* affordance, not a
+replacement.
+"""
+from __future__ import annotations
+
+from reyn.chat.slash import reply, reply_error, slash
+
+
+@slash(
+    "reset",
+    summary="Reset in-flight skill state (snapshots + WAL; audit logs preserved)",
+)
+async def reset_cmd(session: "object", args: str) -> None:
+    token = args.strip().lower()
+    if token != "confirm":
+        await reply(
+            session,
+            "⚠ This will delete all in-flight skill state "
+            "(snapshots + WAL). Audit logs are preserved.\n"
+            "Type `/reset confirm` to proceed, or anything else to abort.",
+        )
+        return
+
+    registry = getattr(session, "_registry", None)
+    if registry is None:
+        await reply_error(
+            session,
+            "registry not wired; /reset only works in `reyn chat`",
+        )
+        return
+    project_root = getattr(registry, "_project_root", None)
+    if project_root is None:
+        await reply_error(
+            session,
+            "registry has no _project_root; /reset cannot locate state directory",
+        )
+        return
+
+    # Lazy import so the slash registry doesn't pull the CLI module on every
+    # session bootstrap (slash dispatch happens far more often than reset).
+    from reyn.cli.commands.chat import _reset_project_state
+
+    proceeded = _reset_project_state(project_root, confirm=False)
+    if proceeded:
+        await reply(
+            session,
+            "✓ State reset complete. Snapshots + WAL removed; audit logs "
+            "preserved. Restart `reyn chat` for the changes to fully apply "
+            "to the active session.",
+        )
+    else:
+        # _reset_project_state only returns False when confirm=True and the
+        # interactive prompt is declined — we passed confirm=False, so this
+        # branch shouldn't normally hit. Guarded for defence in depth.
+        await reply_error(session, "Reset did not proceed (unexpected).")


### PR DESCRIPTION
**[tui-coder]** — UX wave parking-lot finding F14 (P2/M/score=1.0). Restart of the wave after lead-coder ack'd the parking-lot triage. 1 of 5 planned parking-lot PRs.

## Observation

The pre-existing ``reyn chat --reset`` CLI flag prompts via ``input()`` in ``src/reyn/cli/commands/chat.py:131-140`` BEFORE the TUI mounts. Users who realise mid-session they want a reset have no in-app affordance — they have to Ctrl+D, restart with ``--reset``, answer at the bare terminal, then get the TUI back.

## Fix

Add ``/reset`` slash command with a two-step confirmation pattern (no Textual ModalScreen / new widget needed — simplest path to a TUI-native flow):

```
/reset            → ⚠ This will delete all in-flight skill state
                     (snapshots + WAL). Audit logs are preserved.
                     Type `/reset confirm` to proceed, or anything
                     else to abort.

/reset confirm    → ✓ State reset complete. Snapshots + WAL removed;
                     audit logs preserved. Restart `reyn chat` for
                     the changes to fully apply to the active session.
```

Re-uses the existing ``_reset_project_state(project_root, confirm=False)`` helper from ``cli/commands/chat.py:114`` so the wipe semantics stay identical to the CLI flag (= same files removed, same audit-log preservation). Access path: ``session._registry._project_root``.

CLI ``--reset`` flag stays — ``--cui`` mode (no TUI) and external-script invocations still rely on it. This is a *parallel* affordance, not a replacement.

## Visual

Step 1 (`/reset`):
```
  20:22  ▶ you ─────────────────────────
         /reset

  20:22  · system ──────────────────────
         ⚠ This will delete all in-flight skill state (snapshots + WAL). Audit logs are preserved.
         Type `/reset confirm` to proceed, or anything else to abort.
```

Step 2 (`/reset confirm`):
```
  20:23  ▶ you ─────────────────────────
         /reset confirm

  20:23  · system ──────────────────────
         ✓ State reset complete. Snapshots + WAL removed; audit logs preserved. Restart `reyn chat`
         for the changes to fully apply to the active session.
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/slash/reset.py` | new — 2-step confirmation handler, defers actual wipe to `_reset_project_state(confirm=False)` |
| `src/reyn/chat/slash/__init__.py` | import the new module to trigger registration |

## Test plan

- [x] Manual: `OPENAI_API_KEY=dummy reyn chat` in tmux MCP → `/reset` Enter → warning system line displayed in conv pane.
- [x] Manual: `/reset confirm` Enter → success system line + state wiped (= verified visually).
- [x] `ruff check src/reyn/chat/slash/reset.py src/reyn/chat/slash/__init__.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test for the slash output strings — UX formatting that should stay free to tweak. Manual visual is the contract per `docs/deep-dives/contributing/testing.ja.md` §6.4.
- [x] (skipped — implicit) `--reset` CLI flag regression — flag wiring in `chat.py:241-248` is untouched, no behavior change to the non-TUI path.

## Scope guard

**NOT in scope**:
- Textual ModalScreen Y/N dialog (= the 2-step text confirmation pattern is simpler + matches CLI conventions like `git reset --hard ` style "type the command again" affordances)
- Reset specific subsystems (e.g. `/reset memory`, `/reset budget`) — could be a follow-up; the agent's report didn't ask for granular scopes.
- Auto-restart of the session after `/reset confirm` — out of scope, message tells the user to restart manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)