### PR TITLE
TUI: cost tab litellm estimate disclaimer (F8)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -255,6 +255,18 @@ def render_cost(
                 "right_panel cost: read of %s failed: %s", jsonl, exc,
             )
 
+    # Disclaimer line — costs displayed are client-side estimates derived
+    # from litellm's pricing DB at LLM-call time. They may diverge from
+    # the actual amount billed by the upstream provider (= rate changes
+    # between call time and the bill cycle, special pricing tiers,
+    # unmetered features, etc.) and from any proxy-side accounting.
+    # Surfacing this once at the top of the Cost tab prevents the user
+    # from treating the displayed cents as a billing-authoritative source.
+    lines.append(
+        "[#555555]  (litellm estimate — may differ from actual provider billing)[/]"
+    )
+    lines.append("")
+
     # ── TODAY ────────────────────────────────────────────────────────
     lines.append("[bold #aaaaaa]  TODAY[/]")
     if today["calls"] == 0:


### PR DESCRIPTION
**[tui-coder]** — UX wave parking-lot finding F8 (P3/S/score=1.0). 2 of 5 planned parking-lot PRs.

## Observation

The Cost tab's TODAY / ALL TIME / BY MODEL / BY AGENT sections and the header `$X` counter have no visible signal that the displayed cents are *client-side estimates* derived from litellm's pricing DB at LLM-call time. Users treating the number as billing-authoritative get surprised when the provider bill diverges (rate changes between call time and bill cycle, special pricing tiers, unmetered features, proxy-side accounting differences).

## Fix

Add a single dim disclaimer line at the very top of the Cost tab, above the TODAY section:

```
  (litellm estimate — may differ from actual provider billing)
```

One-time visual cue per tab open. Header counter unchanged (= adding the disclaimer there would consume scarce header width); the Cost tab is the natural place for a user investigating their costs to read it.

## Visual

Cost tab after fix (with existing F6 BY MODEL prefix-strip also live):
```
Cost  j↓ k↑
─────────────────────────────────────────────
  (litellm estimate — may differ from actu…
                                       ↑ panel-width truncation, full text on wider geometries

  TODAY
    (no calls today)

  ALL TIME
    tokens  30,189
    ...
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/right_panel/cost_tab.py` | append disclaimer line + blank line before the TODAY header in `render_cost` |

## Test plan

- [x] Manual: tmux MCP — `reyn chat` → Ctrl+B → cycle Ctrl+W ×4 to Cost tab — disclaimer line visible at top, above TODAY.
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/cost_tab.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test pinning the disclaimer string — UX formatting that should stay free to tweak.

## Scope guard

**NOT in scope**:
- Header counter disclaimer (= scarce horizontal width; the Cost tab is the canonical investigation surface)
- Per-cost-line "(est.)" inline markers — visually noisy, the top-of-tab disclaimer covers the case once
- Per-model overrides (e.g. "provider X bills differently") — relies on pricing DB which is litellm's domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)