### PR TITLE
TUI: cost_tab footer /budget reset clarification hint (F9)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -390,6 +390,18 @@ def render_cost(
     else:
         lines.append("[#555555]    (no model data yet)[/]")
 
+    # Footer hint: ``/budget reset`` only clears per-agent + per-chain
+    # counters used by the safety hard-stop rate limiter. The TODAY /
+    # ALL TIME / BY MODEL totals shown above are recomputed from the
+    # event log on every render, so they survive ``/budget reset``.
+    # Users who run reset expecting "all the numbers go to zero" need
+    # this distinction surfaced once, where they can see it.
+    lines.append("")
+    lines.append(
+        "[#555555]  /budget reset clears per-agent counters "
+        "(daily totals persist — they come from the event log)[/]"
+    )
+
     return "\n".join(lines)
 
 


### PR DESCRIPTION
**[tui-coder]** — UX wave parking-lot finding F9 (P3/S/score=1.0). 3 of 5 planned parking-lot PRs.

## Observation

``/budget reset`` only clears per-agent + per-chain counters used by the safety rate-limiter (see `src/reyn/budget/budget.py`). The TODAY / ALL TIME / BY MODEL totals shown in the Cost tab are recomputed from the event log on every render, so they survive ``/budget reset``. Users who run reset expecting "all the numbers go to zero" found nothing changes and were confused. The reset confirmation reply mentions this in passing, but the Cost tab UI itself doesn't.

## Fix

Add a one-line dim footer at the bottom of the Cost tab:

```
  /budget reset clears per-agent counters (daily totals persist —
  they come from the event log)
```

Calibrates the user's expectation at the place they'd look right after running reset.

## Visual

Cost tab bottom (after BY MODEL section):
```
  BY MODEL
  gemini-2.5-flash-lite        30,189 tok …

  /budget reset clears per-agent counters …
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/right_panel/cost_tab.py` | append blank line + footer hint after BY MODEL section in `render_cost` |

## Test plan

- [x] Manual: tmux MCP — `reyn chat` → Ctrl+B → cycle Ctrl+W ×4 to Cost tab — footer hint visible at bottom below BY MODEL, dim grey (reads as advisory, not section header).
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/cost_tab.py` — clean.

## Scope guard

**NOT in scope**:
- Per-section reset commands (e.g. `/budget reset daily`) — out of wave scope, separate UX
- Auto-clear event log on reset — drops audit log (= F11-style cross-layer concern, parking lot)
- Reset confirmation UI revamp — `/budget reset` is the existing slash; only the Cost tab footer changes here

🤖 Generated with [Claude Code](https://claude.com/claude-code)