### PR TITLE
TUI: cap ErrorBox stack at 3, roll older to breadcrumb (F5)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -77,6 +77,11 @@ _RECENT_REPLIES_MAX = 10
 # turn anchors below are drop-aware so even pathological sessions that DO
 # cross the boundary don't break Ctrl+P/N navigation.
 _RICHLOG_MAX_LINES = 20_000
+# Cap on simultaneously-mounted ErrorBox widgets. Past this, the oldest
+# rolls into a dim ``_write_log`` breadcrumb (= same shape as the F2
+# Esc-dismissed breadcrumb) so the footer area can't pile up under a
+# burst of failures (e.g. proxy down + multiple retries).
+_MAX_VISIBLE_ERROR_BOXES = 3
 _NAME_COL_COLS = 4  # display-cell width reserved for the speaker label column
 # Hanging indent for message bodies (= the lines under each header). The
 # header is ``HH:MM  reyn ───`` — 5 (timestamp) + 2 (gap) = 7 cells before
@@ -846,6 +851,37 @@ class ConversationView(Widget):
         skill_name: str = "",
     ) -> ErrorBox:
         self._consume_empty_hint()
+        # F5: cap the live stack. When more than _MAX_VISIBLE_ERROR_BOXES
+        # mounted boxes pile up under the conv pane, the oldest get
+        # "rolled" into a dim breadcrumb in the RichLog and removed from
+        # the DOM. This matches the F2 pattern for ESC-dismissed
+        # ErrorBoxes (same summary + has_trace gating, same dim style)
+        # so the conv log carries a coherent "✗ … (state)" record
+        # regardless of whether the box was dismissed by user or
+        # auto-evicted by stack pressure.
+        from rich.text import Text as _RichText
+        while len(self._error_boxes) >= _MAX_VISIBLE_ERROR_BOXES:
+            oldest = self._error_boxes.pop(0)
+            old_first, _sep, _rest = (
+                getattr(oldest, "_message", "") or ""
+            ).partition("\n")
+            if len(old_first) > 72:
+                old_summary = old_first[:71] + "…"
+            else:
+                old_summary = old_first
+            old_has_trace = bool(
+                getattr(oldest, "_skill_name", "")
+                or getattr(oldest, "_run_id_short", "")
+            )
+            try:
+                oldest.remove()
+            except Exception:
+                pass
+            old_trailer = " (see events)" if old_has_trace else ""
+            self._write_log(_RichText(
+                f"  ✗ {old_summary} (rolled to log){old_trailer}",
+                style="dim #555555",
+            ))
         # Replace the sticky "thinking…" — the turn is over (it failed).
         # When the user is at the tail, a bare ``hide_status`` is enough
         # (they'll see the ErrorBox the next render tick). When they're


### PR DESCRIPTION
**[tui-coder]** — UX wave parking-lot finding F5 (P3/M/score=0.5). 4 of 5 planned parking-lot PRs.

## Observation

Each ``kind="error"`` outbox mounted a new ErrorBox below the previous via ``mount_error`` (`src/reyn/chat/tui/widgets/conversation.py:840-868`). With two or more failures (proxy down + multiple retries, typo'd slash followed by a real error) the boxes piled at the conv footer where only the bottom-most header stayed fully visible — older boxes got pushed up and partially clipped, and each Esc dismissed only one.

## Fix

Cap the simultaneously-mounted stack at ``_MAX_VISIBLE_ERROR_BOXES`` (=3). When ``mount_error`` would exceed the cap, the oldest box gets rolled into a dim breadcrumb in the RichLog and removed from the DOM:

```
  ✗ <summary> (rolled to log)
  ✗ <summary> (rolled to log) (see events)   ← when skill/run-id present
```

Same shape as the F2 ESC-dismissed breadcrumb (= `(dismissed)` / `(rolled to log)` distinguish the two paths; both summaries use 72-char truncation, both honour the `has_trace` gate). Dismissed and auto-rolled errors now both surface as `✗ …` lines in the conv log — coherent record regardless of how the box left the live stack.

## Visual

Before (4 errors mounted → all 4 stack, oldest partially clipped):
```
 │ ✗ usage: /attach <name>  ▶
 │ ✗ usage: /attach <name>  ▶  ← clipped/hidden by footer
 │ ✗ usage: /attach <name>  ▶  ← clipped/hidden by footer
 │ ✗ usage: /attach <name>  ▶
```

After (4th mount evicts 1st → 3 boxes + 1 breadcrumb):
```
    ✗ usage: /attach <name> (rolled to log)
                                     ↑ in conv log
 │ ✗ usage: /attach <name>  ▶
 │ ✗ usage: /attach <name>  ▶
 │ ✗ usage: /attach <name>  ▶        ← 3 most recent mounted
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/conversation.py` | new `_MAX_VISIBLE_ERROR_BOXES = 3` constant + `mount_error` evicts oldest via the F2 breadcrumb pattern (`✗ <summary> (rolled to log)`) when the stack would exceed the cap |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat` → `/attach` Enter ×4 rapidly → conv footer shows the 3 most-recent ErrorBoxes mounted; conv log shows `  ✗ usage: /attach <name> (rolled to log)` for the 4th (= 1st mounted, evicted on 4th mount).
- [x] `ruff check src/reyn/chat/tui/widgets/conversation.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test for the cap behavior — would pin `_MAX_VISIBLE_ERROR_BOXES = 3` and the breadcrumb format. Manual visual is the contract per `docs/deep-dives/contributing/testing.ja.md` §6.4.

## Scope guard

**NOT in scope**:
- Shift+Esc "dismiss all" shortcut — separate UX, the agent's report mentioned it as an alternative; the eviction pattern is simpler and covers the actual failure mode.
- Per-error timer auto-dismiss — would interact poorly with users actively reading; eviction-by-pressure is the user-action-pull rather than a time-push.
- Configurable cap — `_MAX_VISIBLE_ERROR_BOXES = 3` is hard-coded; if a user wants more visible they can scroll up to see the rolled breadcrumbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)