### PR TITLE
feat(mcp): iv support via _MCPInterventionBus + answer_intervention tool (issue #270 Phase B)

### DIFF
--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -359,6 +359,64 @@ def build_server(
                     "additionalProperties": False,
                 },
             ),
+            Tool(
+                name="answer_intervention",
+                description=(
+                    "Deliver an answer to a pending ask_user / "
+                    "permission / safety intervention on a running "
+                    "send_to_agent call (issue #270 Phase B). "
+                    "Routes via ChatSession.answer_pending_intervention. "
+                    "Identify the iv by ``run_id`` (= surfaced in the "
+                    "progress notification that the server pushed when "
+                    "the iv was dispatched, see experimental capability "
+                    "``reyn.iv.input_required``). For choice-based "
+                    "prompts (= permission.* / safety.limit.*) pass "
+                    "``choice_id`` explicitly; for free-text ask_user "
+                    "omit it."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": (
+                                "Name of the agent that emitted the "
+                                "intervention (= the same agent_name "
+                                "used in the original send_to_agent "
+                                "call)."
+                            ),
+                        },
+                        "run_id": {
+                            "type": "string",
+                            "description": (
+                                "The iv's run_id, as surfaced in the "
+                                "input-required progress notification."
+                            ),
+                        },
+                        "text": {
+                            "type": "string",
+                            "description": (
+                                "Free-text answer body. For choice-"
+                                "based prompts, set ``choice_id`` "
+                                "below; the text becomes the human-"
+                                "readable selection label."
+                            ),
+                        },
+                        "choice_id": {
+                            "type": "string",
+                            "description": (
+                                "Optional. For closed-set prompts, "
+                                "the explicit choice id from the "
+                                "iv's choices list (e.g. ``yes`` / "
+                                "``always`` / ``no``). Omit for "
+                                "free-text ask_user answers."
+                            ),
+                        },
+                    },
+                    "required": ["agent_name", "run_id", "text"],
+                    "additionalProperties": False,
+                },
+            ),
         ]
 
     @server.call_tool()
@@ -395,12 +453,20 @@ def build_server(
             bridge = await _make_mcp_progress_bridge(
                 registry, agent_name, server,
             )
+            # issue #270 Phase B: build MCP-side iv observer. When a
+            # skill emits a UserIntervention, this bus pushes the
+            # iv payload to the peer via progress notification + lets
+            # the peer answer via the ``answer_intervention`` tool.
+            iv_bus = await _make_mcp_intervention_bus(
+                registry, agent_name, server,
+            )
             try:
                 result = await send_to_agent_impl(
                     registry,
                     agent_name=agent_name,
                     message=message,
                     timeout=timeout,
+                    intervention_override=iv_bus,
                 )
             except ValueError as e:
                 return [TextContent(type="text", text=f"error: {e}")]
@@ -417,9 +483,196 @@ def build_server(
             import json
             return [TextContent(type="text", text=json.dumps(result))]
 
+        if name == "answer_intervention":
+            import json  # noqa: PLC0415
+
+            from reyn.user_intervention import InterventionAnswer  # noqa: PLC0415
+
+            args = arguments or {}
+            agent_name = args.get("agent_name") or ""
+            run_id = args.get("run_id") or ""
+            text = args.get("text") or ""
+            choice_id_raw = args.get("choice_id")
+            choice_id: str | None = (
+                choice_id_raw if isinstance(choice_id_raw, str) and choice_id_raw
+                else None
+            )
+            if not agent_name:
+                return [TextContent(type="text", text="error: agent_name is required")]
+            if not run_id:
+                return [TextContent(type="text", text="error: run_id is required")]
+            if not registry.exists(agent_name):
+                return [TextContent(
+                    type="text",
+                    text=json.dumps({
+                        "answered": False,
+                        "reason": f"agent {agent_name!r} not found",
+                    }),
+                )]
+            try:
+                session = await _get_session(registry, agent_name)
+            except Exception as exc:  # noqa: BLE001 — defensive
+                return [TextContent(
+                    type="text",
+                    text=json.dumps({
+                        "answered": False,
+                        "reason": f"agent load failed: {exc}",
+                    }),
+                )]
+            answer = InterventionAnswer(text=text, choice_id=choice_id)
+            delivered = await session.answer_pending_intervention(run_id, answer)
+            return [TextContent(
+                type="text",
+                text=json.dumps({
+                    "answered": bool(delivered),
+                    "reason": (
+                        None if delivered else
+                        "already answered or no pending intervention"
+                    ),
+                }),
+            )]
+
         return [TextContent(type="text", text=f"error: unknown tool {name!r}")]
 
     return server
+
+
+async def _make_mcp_intervention_bus(
+    registry: "AgentRegistry",
+    agent_name: str,
+    server: "object",
+) -> "_MCPInterventionBus | None":
+    """Build an MCP iv-observer for the duration of one ``send_to_agent``
+    call (issue #270 Phase B).
+
+    issue #292 α extended to MCP: when a skill spawned via
+    ``send_to_agent_impl`` emits a ``UserIntervention``, that iv lands
+    in ``ChatSession._interventions._active`` and ``handler.dispatch``
+    awaits its future. Pre-#270 Phase B the MCP transport had no
+    observer registered as chain override → no peer-facing surface to
+    push the iv question to → the iv would hang if no TUI was
+    simultaneously attached.
+
+    This bus fills the same role ``A2AInterventionBus`` does for the
+    A2A surface: pure side-effect observer (= ``on_dispatch(iv)``
+    pushes an MCP notification carrying the iv payload; does NOT await
+    ``iv.future``). The peer answers via a separate
+    ``answer_intervention`` MCP tool call that lands at
+    ``ChatSession.answer_pending_intervention``.
+
+    Returns ``None`` when the request context is unavailable (= e.g.
+    direct test calls bypassing the MCP server). The caller (= send-
+    to-agent handler) then runs without the override, matching pre-
+    Phase-B behaviour.
+    """
+    try:
+        ctx = server.request_context  # type: ignore[attr-defined]
+    except (LookupError, AttributeError):
+        return None
+    if not registry.exists(agent_name):
+        return None
+    return _MCPInterventionBus(
+        mcp_session=ctx.session,
+        related_request_id=ctx.request_id,
+    )
+
+
+class _MCPInterventionBus:
+    """MCP-side iv side-effect observer (issue #270 Phase B).
+
+    Registered as the chain-scoped override during ``send_to_agent_impl``.
+    Mirrors ``A2AInterventionBus``'s post-α observer shape:
+
+      - ``on_dispatch(iv)`` runs as a side effect inside
+        ``ChatSession._dispatch_intervention``, BEFORE the regular
+        handler dispatch awaits ``iv.future``.
+      - Stamps ``iv.origin_channel_id`` so the agent layer can attribute
+        this iv to the MCP channel.
+      - Pushes an iv-payload notification to the MCP peer (= the
+        client that opened the ``send_to_agent`` request) so the
+        peer's UI can render the question + collect the answer.
+      - Does NOT await ``iv.future``. The handler awaits on the
+        skill's behalf; the peer answers via the
+        ``answer_intervention`` MCP tool which routes to
+        ``ChatSession.answer_pending_intervention``.
+
+    Notification transport: uses ``Session.send_progress_notification``
+    with the iv payload encoded as JSON in the ``message`` field +
+    ``progress=0.0`` / ``total=None`` (= indeterminate, per MCP spec
+    for non-numeric updates). This piggy-backs on the existing
+    progress channel rather than introducing a new notification type
+    — clients that already parse progress messages from PR #279's
+    ``_MCPProgressBridge`` see the iv as one more structured payload
+    with a recognisable ``{"type": "intervention", ...}`` shape.
+
+    The Reyn experimental capability ``reyn.iv.input_required``
+    (declared in ``serve_stdio``) advertises this shape to peers via
+    the MCP ``initialize`` response.
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_session: "object",
+        related_request_id: "str | None",
+    ) -> None:
+        self._mcp_session = mcp_session
+        self._related_request_id = related_request_id
+
+    @property
+    def channel_id(self) -> str:
+        """Stable channel identifier for issue #268 origin-pin routing.
+
+        Format: ``mcp:<request_id>``. The bus's lifetime is one
+        ``send_to_agent`` MCP call, so the channel id is unique per
+        call.
+        """
+        return f"mcp:{self._related_request_id}"
+
+    async def on_dispatch(self, iv) -> None:
+        """Side-effect observer entry point.
+
+        Stamp the iv's ``origin_channel_id`` (= for #268 cross-channel
+        routing), build the canonical input-required payload (= same
+        shape PR #285 Gap 4 standardised for A2A), and push it as a
+        progress notification. Failures are swallowed — the handler's
+        dispatch path must continue regardless of whether the peer
+        actually received the notification.
+        """
+        if iv.origin_channel_id is None:
+            iv.origin_channel_id = self.channel_id
+
+        payload = {
+            "type": "intervention",
+            "status": "input-required",
+            "run_id": iv.run_id,
+            "kind": iv.kind,
+            "question": iv.prompt,
+            "choices": [
+                {"id": c.id, "label": c.label, "hotkey": c.hotkey}
+                for c in iv.choices
+            ],
+        }
+        if iv.detail:
+            payload["detail"] = iv.detail
+
+        send_fn = getattr(
+            self._mcp_session, "send_progress_notification", None,
+        )
+        if send_fn is None:
+            return
+        import json  # noqa: PLC0415
+
+        try:
+            await send_fn(
+                progress_token=f"reyn-iv:{iv.id}",
+                progress=0.0,
+                total=None,
+                message=json.dumps(payload),
+                related_request_id=self._related_request_id,
+            )
+        except Exception:  # noqa: BLE001 — best-effort
+            return
 
 
 async def _make_mcp_progress_bridge(
@@ -627,6 +880,21 @@ async def serve_stdio(
             },
             "reyn.cancellation.cooperative": {
                 "version": 1,
+            },
+            "reyn.iv.input_required": {
+                "version": 1,
+                "transport": "progress_notification",
+                "message_format": "json",
+                "shape": {
+                    "type": "intervention",
+                    "status": "input-required",
+                    "run_id": "<string>",
+                    "kind": "<ask_user|permission.*|safety.limit.*>",
+                    "question": "<string>",
+                    "choices": "<list of {id,label,hotkey}>",
+                    "detail": "<optional string>",
+                },
+                "answer_tool": "answer_intervention",
             },
         },
     )

--- a/tests/test_mcp_iv_support_270_phase_b.py
+++ b/tests/test_mcp_iv_support_270_phase_b.py
@@ -1,0 +1,340 @@
+"""Tier 2: MCP iv support (issue #270 Phase B).
+
+Pre-#270 Phase B: Reyn-as-MCP-server's ``send_to_agent`` ran skills
+that could emit ``UserIntervention`` ivs, but the MCP transport had
+no chain-override observer registered → iv landed in ChatSession's
+``_active`` queue and would hang if no TUI was simultaneously attached
+(= the typical MCP-only deployment). The peer also had no way to
+answer.
+
+This file pins the Phase B wire (= MCP-side mirror of the A2A α path
+PR #300 established):
+
+  1. ``_MCPInterventionBus`` exists and exposes the α observer shape:
+     ``on_dispatch`` only, no ``request`` / ``deliver``, no
+     ``await iv.future``. Stamps ``iv.origin_channel_id``.
+  2. ``_make_mcp_intervention_bus`` builds a bus from the MCP request
+     context (= mcp_session + request_id). Returns None when context
+     is unavailable (= bypassed-by-test path).
+  3. ``_call_tool`` passes the bus as ``intervention_override`` so
+     ``send_to_agent_impl`` registers it on the chain.
+  4. ``on_dispatch`` pushes the canonical input-required payload via
+     ``send_progress_notification`` with JSON-encoded message (= same
+     shape PR #285 Gap 4 standardised).
+  5. New MCP tool ``answer_intervention`` accepts
+     ``{agent_name, run_id, text, choice_id?}`` and routes to
+     ``ChatSession.answer_pending_intervention``.
+  6. Experimental capability ``reyn.iv.input_required`` declared in
+     the ``initialize`` response (= mirrors PR #284's calibration
+     pattern: declared capability ↔ in-source wire AST pin).
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp", reason="MCP SDK not installed")
+
+
+# ── 1. _MCPInterventionBus α observer shape ──────────────────────────
+
+
+def test_mcp_intervention_bus_exposes_on_dispatch_not_request_or_deliver() -> None:
+    """Tier 2 α contract: ``on_dispatch`` only. No ``request`` /
+    ``deliver`` (= pre-α names that returned an answer).
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+
+    bus = _MCPInterventionBus(
+        mcp_session=None, related_request_id="rq-1",
+    )
+    assert hasattr(bus, "on_dispatch")
+    assert not hasattr(bus, "request")
+    assert not hasattr(bus, "deliver")
+
+
+def test_mcp_intervention_bus_channel_id_format() -> None:
+    """Tier 2: ``channel_id`` is ``mcp:<request_id>`` — same prefix
+    convention as A2A's ``a2a:<run_id>`` (issue #268 origin-pin
+    routing).
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+
+    bus = _MCPInterventionBus(
+        mcp_session=None, related_request_id="rq-42",
+    )
+    assert bus.channel_id == "mcp:rq-42"
+
+
+# ── 2. on_dispatch stamps + emits, never awaits future ───────────────
+
+
+def test_on_dispatch_stamps_origin_channel_id() -> None:
+    """Tier 2: ``on_dispatch`` stamps ``iv.origin_channel_id`` when
+    unset (= same contract A2AInterventionBus follows for #268).
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+    from reyn.user_intervention import UserIntervention
+
+    class _FakeSession:
+        async def send_progress_notification(self, **kwargs):  # noqa: ANN202
+            return None
+
+    bus = _MCPInterventionBus(
+        mcp_session=_FakeSession(), related_request_id="rq-1",
+    )
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(kind="ask_user", prompt="?", run_id="run-1")
+        await bus.on_dispatch(iv)
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped == "mcp:rq-1"
+
+
+def test_on_dispatch_respects_preexisting_origin() -> None:
+    """Tier 2: pre-set origin_channel_id is NOT overwritten."""
+    from reyn.mcp_server import _MCPInterventionBus
+    from reyn.user_intervention import UserIntervention
+
+    class _FakeSession:
+        async def send_progress_notification(self, **kwargs):  # noqa: ANN202
+            return None
+
+    bus = _MCPInterventionBus(
+        mcp_session=_FakeSession(), related_request_id="rq-1",
+    )
+
+    async def _drive() -> str | None:
+        iv = UserIntervention(
+            kind="ask_user", prompt="?",
+            run_id="run-1", origin_channel_id="upstream:prior",
+        )
+        await bus.on_dispatch(iv)
+        return iv.origin_channel_id
+
+    stamped = asyncio.run(_drive())
+    assert stamped == "upstream:prior"
+
+
+def test_on_dispatch_returns_without_awaiting_future() -> None:
+    """Tier 2: α contract — ``on_dispatch`` returns promptly without
+    awaiting ``iv.future``. The handler awaits on the skill's behalf.
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+    from reyn.user_intervention import UserIntervention
+
+    class _FakeSession:
+        async def send_progress_notification(self, **kwargs):  # noqa: ANN202
+            return None
+
+    bus = _MCPInterventionBus(
+        mcp_session=_FakeSession(), related_request_id="rq-1",
+    )
+
+    async def _drive() -> bool:
+        iv = UserIntervention(kind="ask_user", prompt="?", run_id="run-1")
+        # If on_dispatch awaited iv.future this would hang.
+        await asyncio.wait_for(bus.on_dispatch(iv), timeout=2.0)
+        return not iv.future.done()
+
+    assert asyncio.run(_drive())
+
+
+# ── 3. Progress notification payload shape ───────────────────────────
+
+
+def test_on_dispatch_emits_canonical_payload() -> None:
+    """Tier 2: ``on_dispatch`` calls ``send_progress_notification``
+    with the canonical input-required JSON payload (= Gap 4 shape
+    with kind / choices / detail).
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+    from reyn.user_intervention import InterventionChoice, UserIntervention
+
+    captured: list[dict] = []
+
+    class _CapturingSession:
+        async def send_progress_notification(
+            self, *, progress_token, progress, total, message,
+            related_request_id,
+        ):
+            captured.append({
+                "progress_token": progress_token,
+                "progress": progress,
+                "total": total,
+                "message": message,
+                "related_request_id": related_request_id,
+            })
+
+    bus = _MCPInterventionBus(
+        mcp_session=_CapturingSession(), related_request_id="rq-1",
+    )
+
+    async def _drive() -> None:
+        iv = UserIntervention(
+            kind="permission.confirm",
+            prompt="Allow read?",
+            detail="Path: ~/secrets",
+            choices=[
+                InterventionChoice(id="yes", label="[Y]es", hotkey="y"),
+                InterventionChoice(id="no", label="[N]o", hotkey="n"),
+            ],
+            run_id="run-1",
+        )
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["progress"] == 0.0  # indeterminate
+    assert call["total"] is None
+    assert call["related_request_id"] == "rq-1"
+    payload = json.loads(call["message"])
+    assert payload["type"] == "intervention"
+    assert payload["status"] == "input-required"
+    assert payload["run_id"] == "run-1"
+    assert payload["kind"] == "permission.confirm"
+    assert payload["question"] == "Allow read?"
+    assert payload["detail"] == "Path: ~/secrets"
+    assert payload["choices"] == [
+        {"id": "yes", "label": "[Y]es", "hotkey": "y"},
+        {"id": "no", "label": "[N]o", "hotkey": "n"},
+    ]
+
+
+def test_on_dispatch_payload_omits_detail_when_empty() -> None:
+    """Tier 2: empty ``iv.detail`` is omitted from the payload (=
+    Gap 4 contract preserved on MCP side).
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+    from reyn.user_intervention import UserIntervention
+
+    captured: list[str] = []
+
+    class _CapturingSession:
+        async def send_progress_notification(
+            self, *, progress_token, progress, total, message,
+            related_request_id,
+        ):
+            captured.append(message)
+
+    bus = _MCPInterventionBus(
+        mcp_session=_CapturingSession(), related_request_id="rq-2",
+    )
+
+    async def _drive() -> None:
+        iv = UserIntervention(
+            kind="ask_user", prompt="?", run_id="run-1", detail="",
+        )
+        await bus.on_dispatch(iv)
+
+    asyncio.run(_drive())
+
+    payload = json.loads(captured[0])
+    assert "detail" not in payload
+    assert payload["choices"] == []
+    assert payload["kind"] == "ask_user"
+
+
+def test_on_dispatch_swallows_send_failure() -> None:
+    """Tier 2: when ``send_progress_notification`` raises, ``on_dispatch``
+    returns cleanly (= side-effect failure must not block dispatch).
+    """
+    from reyn.mcp_server import _MCPInterventionBus
+    from reyn.user_intervention import UserIntervention
+
+    class _FailingSession:
+        async def send_progress_notification(self, **kwargs):  # noqa: ANN202
+            raise RuntimeError("simulated MCP transport failure")
+
+    bus = _MCPInterventionBus(
+        mcp_session=_FailingSession(), related_request_id="rq-1",
+    )
+
+    async def _drive() -> None:
+        iv = UserIntervention(kind="ask_user", prompt="?", run_id="run-1")
+        await bus.on_dispatch(iv)
+
+    # No exception escapes.
+    asyncio.run(_drive())
+
+
+# ── 4. _call_tool wires the bus + send_to_agent_impl forwards it ─────
+
+
+def test_call_tool_send_to_agent_passes_iv_bus_as_override() -> None:
+    """Tier 2 AST grep: the send_to_agent branch of _call_tool MUST
+    construct ``_make_mcp_intervention_bus`` AND pass it as
+    ``intervention_override`` to ``send_to_agent_impl``. Pin the
+    wiring so a refactor that drops it fails first.
+    """
+    from reyn import mcp_server
+
+    src = inspect.getsource(mcp_server.build_server)
+    assert "_make_mcp_intervention_bus" in src
+    assert "intervention_override=iv_bus" in src
+
+
+# ── 5. answer_intervention tool exists and routes correctly ──────────
+
+
+def test_answer_intervention_tool_is_declared() -> None:
+    """Tier 2: the ``answer_intervention`` tool is part of the MCP
+    server's tool list with the canonical input schema (=
+    ``agent_name`` / ``run_id`` / ``text`` required, ``choice_id``
+    optional).
+    """
+    from reyn import mcp_server
+
+    src = inspect.getsource(mcp_server.build_server)
+    # The tool definition must appear in build_server's source.
+    assert 'name="answer_intervention"' in src
+    assert "ChatSession.answer_pending_intervention" in src
+    # Schema sanity: required fields are listed.
+    assert '"required": ["agent_name", "run_id", "text"]' in src
+
+
+# ── 6. Experimental capability declared ──────────────────────────────
+
+
+def test_serve_stdio_declares_iv_input_required_capability() -> None:
+    """Tier 2: ``serve_stdio`` declares ``reyn.iv.input_required`` in
+    the experimental capabilities of the ``initialize`` response (=
+    PR #284's claim/wire calibration pattern: pin both sides of the
+    contract so future refactors that drop one without the other
+    fail first).
+    """
+    from reyn import mcp_server
+
+    src = inspect.getsource(mcp_server.serve_stdio)
+    assert '"reyn.iv.input_required"' in src
+    assert '"answer_tool": "answer_intervention"' in src
+
+
+def test_iv_input_required_capability_backed_by_in_source_wire() -> None:
+    """Tier 2: every declared experimental capability must derive from
+    a concrete in-source wire (= avoid the #267 Z-b "claim/reality
+    mismatch" pattern). The ``reyn.iv.input_required`` claim is
+    backed by ``_MCPInterventionBus.on_dispatch`` + the
+    ``answer_intervention`` tool dispatch. Pin both wires.
+    """
+    src_path = (
+        Path(__file__).parent.parent
+        / "src" / "reyn" / "mcp_server.py"
+    )
+    src = src_path.read_text(encoding="utf-8")
+
+    # The observer wire.
+    assert "class _MCPInterventionBus" in src
+    assert "send_progress_notification" in src
+
+    # The answer-injection wire.
+    assert 'name == "answer_intervention"' in src
+    assert "answer_pending_intervention" in src

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -504,11 +504,13 @@ def test_drain_skill_completed_inbox_preserves_other_kinds(tmp_path):
     assert leftover_payload.get("from_agent") == "peer"
 
 
-def test_build_server_exposes_two_tools(tmp_path):
-    """Tier 2: build_server registers exactly the two documented tools
-    (list_agents, send_to_agent). Acts as a P7 detection net — adding a
-    third tool here without refreshing the documented contract trips
-    this test.
+def test_build_server_exposes_documented_tools(tmp_path):
+    """Tier 2: build_server registers exactly the documented tools.
+    Acts as a P7 detection net — adding a new tool without refreshing
+    the documented contract trips this test.
+
+    issue #270 Phase B added ``answer_intervention`` (= MCP-side
+    answer-delivery wire for ivs emitted by send_to_agent skills).
     """
     from reyn.mcp_server import build_server
 
@@ -526,4 +528,4 @@ def test_build_server_exposes_two_tools(tmp_path):
     result = asyncio.run(handler(req))
     tools = result.root.tools
     names = {t.name for t in tools}
-    assert names == {"list_agents", "send_to_agent"}
+    assert names == {"list_agents", "send_to_agent", "answer_intervention"}


### PR DESCRIPTION
**[e2e-coder]** — #270 Phase B: closes the MCP-side iv gap that was the last missing surface after the A2A α refactor (PR #300).

## Why now

User asked for MCP iv support directly. Pre-PR: skill ivs emitted from MCP-driven `send_to_agent` would hang because the MCP transport had no chain-override observer registered → no peer-facing surface to push the iv question to + no inbound answer path. With α settled on A2A, the α pattern is the natural lift for MCP.

## Rule-of-three calibration

A2A α (PR #300) is instance 1. MCP α (this PR) is instance 2. Two instances of "side-effect observer + handler.dispatch owns iv future + ChatSession.answer_pending_intervention as authoritative answer path" — STILL below the rule-of-three threshold. Bus logic stays per-protocol. A future third instance (e.g. WebSocket / gRPC) is the trigger to lift the shared `subscribe / format / dispatch` shape into a base class.

## Summary

- **`_MCPInterventionBus`** (new class) — α observer for MCP. `on_dispatch(iv) -> None`, no `request` / `deliver`, no `await iv.future`. Stamps `iv.origin_channel_id = "mcp:<request_id>"`, pushes canonical input-required payload via `send_progress_notification` (JSON-encoded message, piggybacks on PR #279's progress channel).
- **`_make_mcp_intervention_bus(registry, agent_name, server)`** — factory mirroring `_make_mcp_progress_bridge`. Returns None when MCP request context is unavailable (= test-bypass path).
- **`_call_tool` send_to_agent branch** — passes the bus as `intervention_override` so `send_to_agent_impl` registers it on the chain via the same wiring A2A uses (= already there from PR #281's listener lifecycle work).
- **New MCP tool `answer_intervention`** — inputs `{agent_name, run_id, text, choice_id?}`. Routes to `ChatSession.answer_pending_intervention` via `get_or_load(agent_name)`. Returns `{"answered": bool, "reason"?: str}`. Choice-based prompts (= permission.* / safety.limit.*) pass `choice_id`; free-text omits it.
- **Experimental capability `reyn.iv.input_required`** declared in `serve_stdio`'s `initialize` response. Backing wire (= `_MCPInterventionBus.on_dispatch` + `answer_intervention` dispatch) pinned by Tier 2 grep — same calibration shape as PR #284's `reyn.progress.skill_lifecycle`.

## Notification format (= why `send_progress_notification`)

MCP spec has no first-class "ask user" notification. We piggyback on the existing progress channel:

- `progress_token = "reyn-iv:<iv.id>"`
- `progress = 0.0`, `total = None` (= indeterminate, per MCP spec convention for non-numeric updates)
- `message = json.dumps({"type": "intervention", "status": "input-required", ...})` — canonical Gap 4 payload

Clients that have already implemented PR #279's `_MCPProgressBridge` progress parser see this as one more recognised payload via the `"type"` discriminator. The experimental capability documents the shape so spec-conformant clients can negotiate.

## Test plan

- [x] Tier 2 contract test file (12 cases): α observer shape / channel_id format / origin stamping / no-await-future / canonical payload / detail omission / send-failure swallow / `_call_tool` AST pin / tool schema / capability declared + wire-backed
- [x] Existing `tests/test_mcp_server.py::test_build_server_exposes_documented_tools` updated for the new third tool
- [x] MCP region regression (4 files / 38 tests): pass
- [x] Full suite: **4340 passed, 5 skipped, 3 xfailed** in 164s (= 1 unrelated 20:00-hour clock flake in `tests/cli/test_header_clock_compact.py`, orthogonal)
- [x] `ruff check` clean

## Related

- PR #300 (= A2A α refactor, the first instance this PR mirrors)
- PR #279 (= MCP `_MCPProgressBridge`, the progress channel this PR piggybacks on)
- PR #284 (= MCP M3 capability advertising calibration this PR follows for `reyn.iv.input_required`)
- PR #285 (= Gap 4 canonical input-required payload shape this PR reuses)
- #270 umbrella (= pending operation lifecycle generalization; A2A + MCP are now both instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)