### PR TITLE
TUI: persist /cost-inline toggle to .reyn/tui_prefs.json (F10)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -195,6 +195,15 @@ class ReynTUIApp(App):
 
         inputbar.focus_input()
 
+        # Restore persisted TUI prefs (= /cost-inline state etc.) from
+        # ``<project_root>/.reyn/tui_prefs.json``. Defaults stay in-code
+        # when the file is absent / malformed (= first launch, fresh
+        # project). F10: previously /cost-inline reset to "off" on
+        # every restart because no persistence existed.
+        from reyn.chat.tui.prefs import load_tui_prefs
+        prefs = load_tui_prefs(self._project_root_path())
+        self._cost_inline_enabled = bool(prefs.get("cost_inline", False))
+
         # issue #254 Phase 1: declare ourselves as the intervention listener
         # for the attached session. Without this, ``ChatSession`` constructed
         # with ``enforce_listener_presence=True`` would short-circuit
@@ -1440,6 +1449,20 @@ class ReynTUIApp(App):
         if self._agent_registry is None:
             return None
         return self._agent_registry.attached_session()
+
+    def _project_root_path(self) -> Path | None:
+        """Return the attached registry's project root, or None.
+
+        Used by ``prefs.load_tui_prefs`` / ``prefs.save_tui_prefs`` to
+        locate ``<project_root>/.reyn/tui_prefs.json``. Defensive: the
+        registry may be missing the ``_project_root`` attribute on
+        certain test / remote-mode bootstrap paths, in which case the
+        prefs file falls back to "no persistence" — toggle state still
+        works in memory.
+        """
+        if self._agent_registry is None:
+            return None
+        return getattr(self._agent_registry, "_project_root", None)
 
 
 async def run_tui(

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -235,7 +235,10 @@ class OutboxRouter:
         """`__cost_inline_toggle__` — /cost-inline slash command sets this.
 
         Body text is "on" / "off" / empty (toggle). Shows a 2.5 s sticky
-        status indicating the new state.
+        status indicating the new state. F10: also persists the new
+        state to ``.reyn/tui_prefs.json`` so the next ``reyn chat``
+        starts with the user's last choice instead of always reverting
+        to off.
         """
         app = self._app
         want = (msg.text or "").strip().lower()
@@ -247,6 +250,15 @@ class OutboxRouter:
             app._cost_inline_enabled = not app._cost_inline_enabled
         state = "on" if app._cost_inline_enabled else "off"
         self._show_transient_status(conv, f"cost-inline {state}", duration=2.5)
+        # Persist the new state — additive merge, so unknown future
+        # pref keys round-trip untouched. Failure is silent (= file
+        # write errors don't break the toggle itself).
+        from reyn.chat.tui.prefs import load_tui_prefs, save_tui_prefs
+        root = app._project_root_path()
+        if root is not None:
+            prefs = load_tui_prefs(root)
+            prefs["cost_inline"] = app._cost_inline_enabled
+            save_tui_prefs(root, prefs)
 
     def _on_expand_last_reply(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/prefs.py
+++ b/src/reyn/chat/tui/prefs.py
@@ -1,0 +1,93 @@
+"""TUI user preferences persisted to ``<project_root>/.reyn/tui_prefs.json``.
+
+Why a dedicated module:
+
+  - The TUI has a small number of opt-in flags (``/cost-inline``, future
+    candidates: default panel tab, banner on/off, etc.) that should
+    survive a ``reyn chat`` restart. A flat JSON file under
+    ``.reyn/`` is the lowest-friction store (= human-readable, single
+    file per project, no schema migrations needed for additive fields).
+  - Centralising the load/save here keeps the toggle handlers in
+    ``app_outbox.py`` lean: one ``save_tui_prefs(project_root,
+    prefs_dict)`` call after mutating, instead of inlining open/json
+    boilerplate in every handler.
+
+The JSON shape is intentionally a flat dict — additive keys are
+forward-compatible (= an older reyn build reads + writes back
+unknown keys unchanged), no migration ceremony required.
+"""
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+from typing import Any
+
+
+def _prefs_path(project_root: Path) -> Path:
+    return project_root / ".reyn" / "tui_prefs.json"
+
+
+def load_tui_prefs(project_root: Path | None) -> dict[str, Any]:
+    """Read ``tui_prefs.json``; return ``{}`` when missing / malformed.
+
+    Defensive: a corrupt file (= JSON parse error, non-object root)
+    degrades to an empty prefs dict with a warning. Toggle state
+    falls back to the in-code default, no crash on first launch or
+    if the file is hand-edited badly.
+    """
+    if project_root is None:
+        return {}
+    path = _prefs_path(project_root)
+    if not path.exists():
+        return {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        warnings.warn(
+            f"Could not read TUI prefs at {path}: {exc}",
+            UserWarning,
+            stacklevel=2,
+        )
+        return {}
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        warnings.warn(
+            f"TUI prefs at {path} is not valid JSON ({exc}); ignoring.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return {}
+    if not isinstance(data, dict):
+        warnings.warn(
+            f"TUI prefs at {path} must be a JSON object, got "
+            f"{type(data).__name__}; ignoring.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return {}
+    return data
+
+
+def save_tui_prefs(project_root: Path | None, prefs: dict[str, Any]) -> None:
+    """Write ``prefs`` to ``tui_prefs.json``. Silent on best-effort failure.
+
+    A failed write (= read-only FS, permissions) doesn't break the TUI
+    — the toggle still applies in-memory; only the persistence fails.
+    """
+    if project_root is None:
+        return
+    path = _prefs_path(project_root)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(prefs, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        warnings.warn(
+            f"Could not write TUI prefs to {path}: {exc}",
+            UserWarning,
+            stacklevel=2,
+        )


### PR DESCRIPTION
**[tui-coder]** — UX wave parking-lot finding F10 (P3/M/score=0.5). 5 of 5 planned parking-lot PRs — closes the parking-lot batch.

## Observation

``/cost-inline`` toggled an in-memory ``_cost_inline_enabled`` bool on ``ReynTUIApp`` (default False per `src/reyn/chat/tui/app.py:140`). Every ``reyn chat`` restart reverted the toggle to off even if the user had explicitly set it on the previous session. No way to make it stick short of an ``input()`` wrapper in shell rc, which TUI users don't have.

## Fix

Small ``src/reyn/chat/tui/prefs.py`` module — ``load_tui_prefs`` / ``save_tui_prefs`` read/write ``<project_root>/.reyn/tui_prefs.json``. Flat JSON dict, additive keys round-trip unchanged so future prefs (default panel tab, banner default, …) land without migration ceremony.

Wire:
- ``on_mount`` calls ``load_tui_prefs(self._project_root_path())`` and restores ``_cost_inline_enabled`` from the ``cost_inline`` key (defaults to False, preserving first-launch behaviour).
- ``_on_cost_inline_toggle`` calls ``save_tui_prefs`` after applying the user's "on" / "off" / toggle. Failure is silent (= read-only FS, permissions) — the in-memory toggle still applies for the current session, only persistence fails.
- New ``ReynTUIApp._project_root_path()`` helper centralises the ``registry._project_root`` getattr so prefs loaders / future consumers don't reach into private attributes ad-hoc.

Defensive degradation:
- File missing → empty dict → defaults stay (= first launch unchanged)
- Malformed JSON / non-dict root → warning + empty dict (= bad hand-edit doesn't break the TUI)
- Write failure → warning + in-memory state still works

## Visual / Behaviour

Session 1:
```
> /cost-inline on
  cost-inline on            ← transient status (existing)
```
On disk now:
```
.reyn/tui_prefs.json:
  { "cost_inline": true }
```

Session 2 (restart):
```
(TUI mounts with _cost_inline_enabled = True restored from disk)
> /cost-inline           ← bare = toggle
  cost-inline off          ← flipped from the restored true
```
On disk:
```
.reyn/tui_prefs.json:
  { "cost_inline": false }
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/prefs.py` | new module — load_tui_prefs + save_tui_prefs, defensive JSON IO with warnings on bad files |
| `src/reyn/chat/tui/app.py` | `on_mount` restores `_cost_inline_enabled` from prefs + new `_project_root_path()` helper for centralised access |
| `src/reyn/chat/tui/app_outbox.py` | `_on_cost_inline_toggle` saves the new state via `save_tui_prefs` after applying the toggle |

## Test plan

- [x] Manual: `OPENAI_API_KEY=dummy reyn chat` → `/cost-inline on` → `.reyn/tui_prefs.json` = `{"cost_inline": true}` (verified via `cat`).
- [x] Manual: Ctrl+D + relaunch → bare `/cost-inline` (= toggle) → file becomes `{"cost_inline": false}` (= the toggle flipped the *restored* True, confirming restore path works).
- [x] `ruff check src/reyn/chat/tui/prefs.py src/reyn/chat/tui/app.py src/reyn/chat/tui/app_outbox.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test for the JSON shape — the additive-key contract is a forward-compatibility design choice, not a load-bearing invariant; manual restart-restore is the contract.

## Scope guard

**NOT in scope**:
- Per-agent prefs (= same toggle setting across all agents on this project root; future feature if we ever need per-agent persistence).
- TUI prefs UI panel — file is human-readable JSON, hand-edit is acceptable; a UI add would be its own wave finding.
- Banner / panel-default-tab persistence — F10 only persists `cost_inline`; the prefs format is forward-compatible so future flags can land additively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Parking-lot wave summary

| # | Finding | PR |
|---|---|---|
| 1 | F14 `/reset` slash command | #311 |
| 2 | F8 cost tab litellm estimate disclaimer | #312 |
| 3 | F9 cost_tab footer `/budget reset` hint | #314 |
| 4 | F5 ErrorBox stack collapse (cap 3) | #315 |
| 5 | F10 `/cost-inline` persistence (this PR) | this |

Cross-layer items (= **not** for active landing per [[workflow_tui_ux_exploration]] + leader ack):
- F11 history replay on restart — consumer landing 待ち
- F15 scroll-to-bottom on replay (depends on F11)