### PR TITLE
docs(mcp): popular-local-servers smoke-test procedure + scripts/mcp_smoke.py runner

### DIFF
--- a/docs/guide/for-users/popular-mcp-servers.md
+++ b/docs/guide/for-users/popular-mcp-servers.md
@@ -1,0 +1,272 @@
+# Popular local MCP servers — smoke-test procedure
+
+A copy-paste-runnable procedure for verifying four popular MCP servers
+with Reyn locally:
+
+- [filesystem](#filesystem) — sandboxed file read/write
+- [memory](#memory) — knowledge-graph KV (persists across calls)
+- [time](#time) — timezone-aware current time / conversion
+- [everything](#everything) — demo kitchen-sink covering protocol primitives
+
+Each section captures the install command, the workarounds needed
+(see [Known issues](#known-issues) at the bottom), and a minimal
+smoke test that confirms the server is reachable from Reyn's MCP
+client. Verified 2026-05-20 against Reyn HEAD on macOS (Darwin 25.x).
+
+## Prerequisites
+
+- `node` + `npx` (most servers are npm packages)
+- `uv` + `uvx` (= some servers are Python; install via `brew install uv`)
+- Reyn installed with the `[mcp]` extra: `pip install -e ".[mcp]"`
+- A reusable smoke runner: `scripts/mcp_smoke.py` (in-tree)
+
+The smoke runner bypasses the skill / agent / permissions layer and
+goes straight to `reyn.mcp_client.MCPClient`. Use it for connectivity
++ tool-discovery + invocation sanity. For full integration tests
+(skill → permissions → mcp op → result) see the filesystem section.
+
+```bash
+# usage
+python scripts/mcp_smoke.py <server-name>                       # list tools
+python scripts/mcp_smoke.py <server-name> <tool> '<json-args>'  # call tool
+```
+
+---
+
+## filesystem
+
+Read / write files under a configured sandbox root. Most useful + safest local server.
+
+### Install
+
+```bash
+reyn mcp install --source npm:@modelcontextprotocol/server-filesystem \
+    --args "/Users/<you>/Workspace/<project>/.mcp-sandbox" \
+    --non-interactive
+```
+
+**Apply workarounds** (see [#318](https://github.com/tya5/reyn/issues/318) + [#319](https://github.com/tya5/reyn/issues/319) + [#320](https://github.com/tya5/reyn/issues/320)):
+
+```python
+# Add type: stdio + rename to short name. Run from project root.
+python - <<'PY'
+import yaml
+with open("reyn.local.yaml") as f: cfg = yaml.safe_load(f)
+fs = cfg["mcp"]["servers"].pop("server-filesystem")
+fs["type"] = "stdio"
+cfg["mcp"]["servers"]["filesystem"] = {"type": fs.pop("type"), **fs}
+with open("reyn.local.yaml", "w") as f: yaml.safe_dump(cfg, f, sort_keys=False)
+PY
+```
+
+> **macOS users**: avoid `/tmp` as the sandbox root — it's a symlink to
+> `/private/tmp` and the server compares literal paths. Use a path
+> inside the project (e.g. `./.mcp-sandbox`) or your home directory.
+
+### Pre-approve + smoke
+
+```bash
+mkdir -p .mcp-sandbox && echo "hello mcp" > .mcp-sandbox/x.txt
+echo 'mcp.filesystem: true' >> .reyn/approvals.yaml
+
+# Direct client smoke
+python scripts/mcp_smoke.py filesystem read_text_file '{"path": ".mcp-sandbox/x.txt"}'
+
+# End-to-end (skill → permissions → mcp op)
+reyn run read_local_files '.mcp-sandbox/x.txt の内容を教えて'
+```
+
+Expected: agent returns the file content; events log shows
+`act_executed` with `op_kinds: ["mcp"]` and `status: "ok"`.
+
+---
+
+## memory
+
+Knowledge-graph KV server. Entities + observations + relations persist
+across calls within one server lifetime (in-memory; restart resets).
+
+### Install
+
+```bash
+reyn mcp install --source npm:@modelcontextprotocol/server-memory --non-interactive
+```
+
+Same workarounds as filesystem (#318 + #319):
+
+```python
+python - <<'PY'
+import yaml
+with open("reyn.local.yaml") as f: cfg = yaml.safe_load(f)
+fs = cfg["mcp"]["servers"].pop("server-memory")
+fs["type"] = "stdio"
+cfg["mcp"]["servers"]["memory"] = {"type": fs.pop("type"), **fs}
+with open("reyn.local.yaml", "w") as f: yaml.safe_dump(cfg, f, sort_keys=False)
+PY
+```
+
+### Smoke
+
+```bash
+# List tools (= 9 KV / graph primitives)
+python scripts/mcp_smoke.py memory
+
+# Create an entity
+python scripts/mcp_smoke.py memory create_entities '{
+  "entities": [
+    {"name": "Reyn", "entityType": "project",
+     "observations": ["agent OS for LLM-driven workflows"]}
+  ]
+}'
+
+# Search for it
+python scripts/mcp_smoke.py memory search_nodes '{"query": "Reyn"}'
+```
+
+Expected: second call's `structuredContent.entities` contains the
+"Reyn" entity created by the first call.
+
+### Tools surfaced
+
+`create_entities` / `create_relations` / `add_observations` /
+`delete_*` / `read_graph` / `search_nodes` / `open_nodes`.
+
+---
+
+## time
+
+Timezone-aware time queries. Python-based (uvx), so requires `uv`
+installed first.
+
+### Prerequisite
+
+```bash
+brew install uv     # adds uvx as the runtime
+```
+
+### Install
+
+```bash
+reyn mcp install --source pypi:mcp-server-time --non-interactive
+```
+
+> The npm registry has **no** `@modelcontextprotocol/server-time` —
+> the official time server is a Python package at
+> [pypi.org/project/mcp-server-time](https://pypi.org/project/mcp-server-time).
+> Install via the `pypi:` source specifier.
+
+Same workarounds (#318 + #319; the auto-derived name is
+`mcp-server-time`):
+
+```python
+python - <<'PY'
+import yaml
+with open("reyn.local.yaml") as f: cfg = yaml.safe_load(f)
+fs = cfg["mcp"]["servers"].pop("mcp-server-time")
+fs["type"] = "stdio"
+cfg["mcp"]["servers"]["time"] = {"type": fs.pop("type"), **fs}
+with open("reyn.local.yaml", "w") as f: yaml.safe_dump(cfg, f, sort_keys=False)
+PY
+```
+
+### Smoke
+
+```bash
+python scripts/mcp_smoke.py time get_current_time '{"timezone": "Asia/Tokyo"}'
+```
+
+Expected: `content[0].text` contains `{"timezone": "Asia/Tokyo",
+"datetime": "<ISO 8601>", "day_of_week": "...", "is_dst": false}`.
+
+### Tools surfaced
+
+`get_current_time` / `convert_time`.
+
+---
+
+## everything
+
+Demo "kitchen sink" server covering most MCP protocol primitives.
+Useful for sanity-checking tool-discovery + structured-content +
+long-running ops + sampling, all in one server.
+
+### Install
+
+```bash
+reyn mcp install --source npm:@modelcontextprotocol/server-everything --non-interactive
+```
+
+Same workarounds (#318 + #319):
+
+```python
+python - <<'PY'
+import yaml
+with open("reyn.local.yaml") as f: cfg = yaml.safe_load(f)
+fs = cfg["mcp"]["servers"].pop("server-everything")
+fs["type"] = "stdio"
+cfg["mcp"]["servers"]["everything"] = {"type": fs.pop("type"), **fs}
+with open("reyn.local.yaml", "w") as f: yaml.safe_dump(cfg, f, sort_keys=False)
+PY
+```
+
+### Smoke
+
+```bash
+# Tool discovery
+python scripts/mcp_smoke.py everything
+
+# Sum
+python scripts/mcp_smoke.py everything get-sum '{"a": 17, "b": 25}'
+
+# Echo
+python scripts/mcp_smoke.py everything echo '{"message": "hello from reyn smoke"}'
+```
+
+Expected: `content[0].text` carries the computed sum / echoed message.
+
+### Tools surfaced
+
+`echo` / `get-sum` / `get-env` / `get-tiny-image` /
+`get-annotated-message` / `get-structured-content` /
+`get-resource-links` / `get-resource-reference` / `gzip-file-as-resource` /
+`toggle-simulated-logging` / `toggle-subscriber-updates` /
+`trigger-long-running-operation` / `simulate-research-query`.
+
+`trigger-long-running-operation` is especially useful for testing
+[PR #266](https://github.com/tya5/reyn/pull/266)'s MCP progress
+callback wire — it emits `notifications/progress` during execution.
+
+---
+
+## Known issues
+
+Encountered during this smoke-test round (2026-05-20):
+
+| Issue | Symptom | Workaround |
+|---|---|---|
+| [#318](https://github.com/tya5/reyn/issues/318) | `reyn mcp install` omits `type: stdio` → loader fails with `Unsupported MCP server type: None` | Add `type: stdio` to the server entry post-install (see snippets above) |
+| [#319](https://github.com/tya5/reyn/issues/319) | Auto-derived server name keeps `server-` / `mcp-server-` prefix → stdlib skill expecting short name (e.g. `filesystem`) fails to find it | Rename the YAML key to the short form post-install |
+| [#320](https://github.com/tya5/reyn/issues/320) | macOS `/tmp` symlink resolves to `/private/tmp` → server's literal path check denies `read_text_file` | Use a sandbox path outside `/tmp` (= project dir or home dir) |
+
+The Python snippet in each section bakes in the #318 + #319
+workarounds. #320 affects only the filesystem server's sandbox root.
+
+---
+
+## Adding more servers
+
+The same procedure works for any stdio-transport MCP server:
+
+1. `reyn mcp install --source npm:<pkg>` (or `pypi:<pkg>` for Python)
+2. Apply the #318 + #319 workaround Python snippet (= add `type: stdio`,
+   rename to a stable short key)
+3. `python scripts/mcp_smoke.py <name>` to list tools
+4. `python scripts/mcp_smoke.py <name> <tool> '<args>'` to verify a call
+
+If the server requires credentials, use `reyn mcp set-secret <name>
+<KEY>` and reference the secret in the YAML's `env:` block (see
+`docs/guide/for-skill-authors/use-an-mcp-server.ja.md` for the full
+secret-handling shape).
+
+When all 3 install-flow issues (#318 / #319 / #320) close, the
+procedure shrinks to: `reyn mcp install ...` + `python scripts/mcp_smoke.py ...`.

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Direct-call MCP smoke test runner.
+
+Bypasses the skill / agent layer. Loads reyn.local.yaml's mcp.servers
+entry by name, opens an MCPClient, lists tools, and (optionally) calls
+one tool with the given args. Useful for confirming server install +
+basic connectivity without engaging permissions / skill dispatch.
+
+Usage:
+
+    python scripts/mcp_smoke.py <server-name>
+        # → lists tools
+
+    python scripts/mcp_smoke.py <server-name> <tool> <json-args>
+        # → calls tool with args, prints result
+
+Example:
+
+    python scripts/mcp_smoke.py memory read_graph '{}'
+    python scripts/mcp_smoke.py time get_current_time '{"timezone": "Asia/Tokyo"}'
+
+issue #318 / #319 workaround note: when calling this script against a
+freshly-installed server, edit reyn.local.yaml to (a) add `type: stdio`
+and (b) rename the auto-generated `server-foo` key to a stable short
+name. See issues for repro details.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+async def _run() -> int:
+    argv = sys.argv[1:]
+    if not argv:
+        print(__doc__)
+        return 2
+
+    server_name = argv[0]
+    tool_name = argv[1] if len(argv) > 1 else None
+    args_json = argv[2] if len(argv) > 2 else "{}"
+
+    config_path = Path("reyn.local.yaml")
+    if not config_path.exists():
+        print(f"error: {config_path} not found in CWD", file=sys.stderr)
+        return 2
+
+    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    servers = (cfg or {}).get("mcp", {}).get("servers", {})
+    if server_name not in servers:
+        print(f"error: server {server_name!r} not in reyn.local.yaml", file=sys.stderr)
+        print(f"available: {sorted(servers)}", file=sys.stderr)
+        return 2
+
+    from reyn.mcp_client import MCPClient
+
+    client = MCPClient(servers[server_name])
+    try:
+        await client.initialize()
+        if tool_name is None:
+            tools = await client.list_tools()
+            for t in tools:
+                print(f"- {t.get('name')}: {(t.get('description') or '').splitlines()[0][:90]}")
+            return 0
+        try:
+            args = json.loads(args_json)
+        except json.JSONDecodeError as exc:
+            print(f"error: invalid json args: {exc}", file=sys.stderr)
+            return 2
+        result = await client.call_tool(tool_name, args)
+        print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        return 0
+    finally:
+        await client.close()
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**[e2e-coder]** — captures the e2e smoke-test round of 4 popular MCP servers (filesystem / memory / time / everything) as a runnable user-facing procedure doc + a reusable direct-call smoke runner.

## Summary

- **`scripts/mcp_smoke.py`** — direct-call MCP smoke runner, bypasses skill / agent / permissions layer. Goes straight to `MCPClient` for connectivity + tool-discovery + invocation sanity. Usage: `python scripts/mcp_smoke.py <server> [<tool> <json>]`.
- **`docs/guide/for-users/popular-mcp-servers.md`** — per-server section with: install command, post-install workaround snippet (#318/#319/#320), smoke test, expected output, tools surfaced.

## Verified 2026-05-20 (macOS Darwin 25.x, Reyn HEAD)

| Server | Path | Verified |
|---|---|---|
| filesystem | direct client + `read_local_files` stdlib skill (= permissions + skill + op_runtime end-to-end) | ✓ |
| memory | `create_entities` → `search_nodes` (= multi-call persistence) | ✓ |
| time | `get_current_time` Asia/Tokyo (= uvx runtime) | ✓ |
| everything | `get-sum` + `echo` (= multi-tool discovery) | ✓ |

## Issues found + filed in same round

| # | Title | Severity |
|---|---|---|
| #318 | `reyn mcp install` omits `type: stdio` → loader fails | **blocker** for install→run flow |
| #319 | `reyn mcp install` keeps `server-` prefix → stdlib skill name mismatch | UX papercut |
| #320 | macOS `/tmp` symlink → MCP filesystem server literal-path deny | macOS UX papercut |

The doc's Python workaround snippet in each section bakes in #318 + #319. The filesystem section's "macOS users" callout addresses #320.

## When the 3 issues close

The procedure shrinks to one install command + one smoke command per server. The doc's "Adding more servers" section is written assuming that future shape — only the "Known issues" table needs to be marked obsolete.

## Test plan

- [x] Each of 4 servers verified end-to-end on macOS (Darwin 25.x, Reyn HEAD post-PR #316)
- [x] Direct client + ChatSession-mediated (filesystem) both pinned
- [x] `scripts/mcp_smoke.py` is `python3 scripts/mcp_smoke.py memory` etc. runnable from project root
- [x] Doc is copy-paste-runnable for each server section

## Related

- #318 / #319 / #320 (= UX issues this doc currently works around)
- PR #266 (= MCP progress + timeout wire that the procedures validate)
- PR #316 (= MCP iv lift; full integration coverage now available)
- `docs/guide/for-skill-authors/use-an-mcp-server.ja.md` (= author-side doc; this PR adds the user-side counterpart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)