### PR TITLE
TUI: slash palette alphabetical sort (P1)

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -363,8 +363,14 @@ class InputBar(Widget):
             c for c in self._slash_commands
             if c.name.startswith(token)
         ]
-        # Sort by name length then alpha so closer prefix shows first
-        matches.sort(key=lambda c: (len(c.name), c.name))
+        # Alphabetical so muscle memory built from /help (which lists
+        # alphabetically) transfers to the picker. The previous
+        # ``(len(name), name)`` ordering pushed common-but-longer
+        # commands like /attach, /budget, /cancel below shorter ones
+        # like /copy, /cost, /help on the empty-token open — a user
+        # who stopped reading after the first few rows never saw the
+        # high-value entries.
+        matches.sort(key=lambda c: c.name)
         picker.set_matches(matches)
 
     def _run_completer(


### PR DESCRIPTION
**[tui-coder]** — Wave-2 finding P1 (P2/S/score=2.0). 1 of 6 planned wave-2 PRs.

## Observation

`input_bar.py:367` sorts palette matches by `(len(c.name), c.name)`. On the empty-token open (= user types just `/`), the first 8 visible rows are the shortest commands — `/copy`, `/cost`, `/help`, `/list`, `/plan`, `/agent`, `/reset`, `/skill`. High-value entries `/attach`, `/budget`, `/cancel`, `/memory`, `/pending` etc. get pushed below the `+12 more` footer. A user who stops scanning at the first wave never discovers them.

## Fix

Switch to pure alphabetical (`key=lambda c: c.name`). Matches the order `/help` already uses, so muscle memory transfers in both directions.

## Visual

Before (length-first):
```
/copy   /cost   /help   /list   /plan   /agent  /reset  /skill   +12 more
```

After (alphabetical):
```
/agent  /agents /answer /attach /budget /cancel /copy   /cost   +12 more
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/input_bar.py` | `matches.sort` key changed from `(len(c.name), c.name)` to `c.name` + comment explaining the muscle-memory rationale |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat` → type `/` → picker rows alphabetical (`/agent /agents /answer /attach /budget /cancel /copy /cost +12 more`).
- [x] `ruff check src/reyn/chat/tui/widgets/input_bar.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test pinning row order — UX preference, should stay free to tweak.

## Scope guard

**NOT in scope**:
- Picker height / row count tweaks
- Filter / fuzzy match changes
- Subcommand enumeration (= P4 dropped from wave-2 top-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)