### PR TITLE
TUI: /quit + /exit as registry commands (palette + /help visible) (P3)

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -146,6 +146,7 @@ from reyn.chat.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.chat.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.chat.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.chat.slash import plan as _plan_mod  # noqa: E402, F401
+from reyn.chat.slash import quit as _quit_mod  # noqa: E402, F401
 from reyn.chat.slash import reset as _reset_mod  # noqa: E402, F401
 from reyn.chat.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.chat.slash import skills as _skills_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/help.py
+++ b/src/reyn/chat/slash/help.py
@@ -5,12 +5,12 @@ import textwrap
 
 from reyn.chat.slash import REGISTRY, reply, slash
 
-# Built-ins handled outside the registry (intercepted by the TUI / REPL
-# before reaching session._maybe_handle_slash). Listed here for discoverability.
-_BUILTIN_HINTS: list[tuple[str, str]] = [
-    ("quit", "Exit the chat (alias: /exit, Ctrl+D)"),
-    ("exit", "Exit the chat (alias: /quit, Ctrl+D)"),
-]
+# Built-ins handled outside the registry. ``/quit`` + ``/exit`` were
+# previously here but moved into ``reyn.chat.slash.quit`` (= wave-2 P3)
+# so the slash palette can match them on ``/q`` / ``/ex`` prefixes.
+# Keep this list as the future home for any TUI-intercepted commands
+# that genuinely cannot land in the registry.
+_BUILTIN_HINTS: list[tuple[str, str]] = []
 
 # Target line width for pre-wrapping. The TUI body adds a 7-cell left
 # Padding (``_BODY_INDENT_COLS`` in conversation.py) AND the conv pane

--- a/src/reyn/chat/slash/quit.py
+++ b/src/reyn/chat/slash/quit.py
@@ -1,0 +1,43 @@
+"""``/quit`` (and ``/exit`` alias) — exit the chat from inside the TUI.
+
+Wave-2 finding P3. Previously these were tracked only in ``help.py``'s
+``_BUILTIN_HINTS`` because the TUI / REPL intercepted them before the
+slash registry ever saw them — but the slash *palette* reads from the
+registry, so typing ``/q`` (looking for ``/quit``) produced an empty
+picker. Users who knew ``/quit`` existed from ``/help`` couldn't
+discover it through the palette autocomplete that they'd just learned
+from ``/help`` itself.
+
+Register both names as registry commands. Each sends a sentinel
+``OutboxMessage(kind="__quit__")`` that ``app_outbox._on_quit`` routes
+to the App's existing ``action_quit_tui`` coroutine — the same path
+Ctrl+D fires, so the shutdown semantics stay identical.
+
+Two separate ``@slash`` registrations (not the ``aliases=`` field)
+because the palette's prefix-match loop reads ``c.name`` only — an
+alias entry would not surface on ``/ex`` input. Two separate
+canonical commands cost nothing schema-wise and give both names
+first-class palette + ``/help`` visibility.
+"""
+from __future__ import annotations
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import slash
+
+
+async def _quit_handler(session: "object", args: str) -> None:
+    """Dispatch the quit sentinel to the TUI / REPL outbox.
+
+    ``args`` is ignored — quit takes no arguments. A future "exit with
+    summary" or "exit code" feature could read it; for now any value
+    is silently discarded, mirroring how Ctrl+D ignores any in-flight
+    input.
+    """
+    await session._put_outbox(OutboxMessage(kind="__quit__", text=""))
+
+
+# Both names get a registry entry. Using two ``@slash``-style
+# registrations keeps the palette's ``c.name.startswith(token)`` filter
+# happy for either ``/q`` or ``/ex`` prefixes.
+slash("quit", summary="Exit the chat (alias: /exit, Ctrl+D)")(_quit_handler)
+slash("exit", summary="Exit the chat (alias: /quit, Ctrl+D)")(_quit_handler)

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -651,11 +651,14 @@ class ReynTUIApp(App):
         session = self._get_session()
 
         if text.startswith("/"):
-            # Handle /quit and /exit locally
-            cmd_body = text[1:].split()[0] if len(text) > 1 else ""
-            if cmd_body in {"quit", "exit"}:
-                await self.action_quit_tui()
-                return
+            # ``/quit`` / ``/exit`` previously had a hard-coded intercept
+            # here that short-circuited to ``action_quit_tui`` before the
+            # registry dispatch. Wave-2 P3 moved them into the registry
+            # (``reyn.chat.slash.quit``) so they surface in the palette
+            # + ``/help``; the registry handler emits ``__quit__`` and
+            # ``app_outbox._on_quit`` runs the same shutdown. Removing
+            # the intercept keeps a single source of truth for the slash
+            # dispatch path.
             # Dispatch to session._maybe_handle_slash (which uses registry)
             if session is not None:
                 await session._maybe_handle_slash(text)

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -61,6 +61,7 @@ class OutboxRouter:
         # Methods on `self` are bound, so we can reference them directly.
         self.HANDLERS: dict[str, Callable[..., str | None]] = {
             "__end__":                  self._on_end,
+            "__quit__":                 self._on_quit,
             "__attach_request__":       self._on_attach_request,
             "__matrix__":               self._on_matrix,
             "__donut__":                self._on_donut,
@@ -181,6 +182,21 @@ class OutboxRouter:
         """
         conv.hide_status()
         return _STOP
+
+    def _on_quit(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """`__quit__` — /quit or /exit slash; trigger the same shutdown
+        path as Ctrl+D.
+
+        Wave-2 finding P3: the slash command palette previously had no
+        ``/quit`` / ``/exit`` entry because the historical implementation
+        intercepted them outside the registry. Routing through the
+        sentinel here keeps the shutdown semantics identical to the
+        Ctrl+D path (= the App's existing ``action_quit_tui`` does the
+        graceful teardown + WAL flush).
+        """
+        self._app.call_later(self._app.action_quit_tui)
 
     def _on_attach_request(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,


### PR DESCRIPTION
**[tui-coder]** — Wave-2 finding P3 (P2/S/score=2.0). 2 of 6 planned wave-2 PRs.

## Observation

`/quit` and `/exit` were tracked only in `_BUILTIN_HINTS` in `src/reyn/chat/slash/help.py` because the TUI intercepted them in `on_input_bar_user_submitted` (`src/reyn/chat/tui/app.py:653-658`) BEFORE the slash registry ever saw them. But the slash *palette* reads from the registry, so typing `/q` or `/ex` looking for them produced an empty picker — users who knew `/quit` existed from `/help` couldn't discover it through the palette autocomplete they'd just learned from `/help` itself.

## Fix

Land both as first-class registry commands so they surface in palette + `/help` via the same code path every other slash uses.

- **New** `src/reyn/chat/slash/quit.py` — single `_quit_handler` registered under both `quit` and `exit` names. Two separate `@slash` registrations (NOT the `aliases=` field) because the palette filter reads `c.name.startswith(token)` only — alias entries would not surface on `/ex`.
- Handler emits `OutboxMessage(kind="__quit__", text="")`.
- `app_outbox.py` adds `"__quit__": self._on_quit` mapping → `self._app.call_later(self._app.action_quit_tui)`. Same shutdown path Ctrl+D fires (= WAL flush + agent persistence unchanged).
- **Removed** the TUI's hard-coded `cmd_body in {"quit", "exit"}` intercept: `/quit` flows through the standard registry dispatch like every other slash. Single source of truth.
- `help.py` `_BUILTIN_HINTS` emptied (kept as a future home for any genuinely TUI-only intercepts) since `/quit` + `/exit` now come from the registry walk.

## Visual

Type `/q`:
```
 ┌─────────────────────────────────────────────┐
 │ ▌ /quit  Exit the chat (alias: /exit, Ctrl+D)│
 └─────────────────────────────────────────────┘
  /q
```

Type `/ex` (both /exit and /expand match — both legitimate):
```
 ┌─────────────────────────────────────────────┐
 │ ▌ /exit    Exit the chat (alias: /quit, Ctrl+D)│
 │   /expand  Show full content of the last folded agent reply │
 └─────────────────────────────────────────────┘
  /ex
```

Submit `/quit` → TUI exits cleanly to shell.

## Files

| file | change |
|---|---|
| `src/reyn/chat/slash/quit.py` | new — `_quit_handler` + two `@slash` registrations (quit / exit) |
| `src/reyn/chat/slash/__init__.py` | import + register the new module |
| `src/reyn/chat/slash/help.py` | `_BUILTIN_HINTS` emptied (entries now in registry); kept as scaffold for future TUI-only intercepts |
| `src/reyn/chat/tui/app.py` | remove the `cmd_body in {"quit", "exit"}` intercept; let registry dispatch run |
| `src/reyn/chat/tui/app_outbox.py` | new `__quit__` outbox kind → `_on_quit` calls `action_quit_tui` |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat` → type `/q` → picker shows `▌ /quit ...` ✓
- [x] Manual: type `/ex` → picker shows `▌ /exit` + `/expand` (both legitimate prefix matches) ✓
- [x] Manual: submit `/quit` Enter → TUI exits cleanly to shell (= same as Ctrl+D) ✓
- [x] `ruff check src/reyn/chat/slash/quit.py src/reyn/chat/slash/__init__.py src/reyn/chat/slash/help.py src/reyn/chat/tui/app.py src/reyn/chat/tui/app_outbox.py` — clean.
- [x] (skipped — REPL surface) REPL `/quit` handling — REPL has its own intercept at `src/reyn/chat/repl.py:66-68` that's unchanged by this PR; CUI mode quit still works as before.

## Scope guard

**NOT in scope**:
- New shutdown-time behaviors (e.g. `/quit save-and-exit`) — `_quit_handler` ignores args, mirroring Ctrl+D
- REPL refactor to use registry dispatch — out of wave-2 scope
- Help footer / `/help` formatting (= P5 dropped from wave-2 top-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)