### PR TITLE
TUI: Keys tab — j/k/space/c surface as PANEL-universal (K1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -27,12 +27,23 @@ _KEY_PRETTY: dict[str, str] = {
     "up": "↑", "down": "↓", "left": "←", "right": "→",
 }
 _CONVERSATION_KEYS = {"ctrl+p", "ctrl+n", "ctrl+shift+n", "ctrl+shift+p"}
+# ``j`` / ``k`` / ``space`` / ``c`` are routed via ``RightPanel.on_key``
+# (not ``app.BINDINGS``) and dispatch per-tab inside the panel handler,
+# so they are panel-universal — not docs-only. Wave-2 K1: previously
+# they lived in ``_DOCS_KEYS`` which labelled them "DOCS (gated)" in
+# the Keys tab even though they scroll any tab (events / agents /
+# memory / docs / pending / cost) and toggle the preview pane on
+# whichever tab is active. ``c`` is the generic "copy current view"
+# action with pending-tab override (= claim); listing it under PANEL
+# matches its dominant meaning.
 _PANEL_KEYS = {
     "ctrl+o", "ctrl+w", "ctrl+shift+o", "ctrl+shift+w", "tab", "shift+tab",
-    "h", "l",
+    "h", "l", "j", "k", "space", "c",
 }
 _EVENTS_KEYS = {"f", "t"}
-_DOCS_KEYS = {"j", "k", "space", "/"}
+# ``/`` stays DOCS-only — it opens the docs name filter, no other tab
+# consumes it.
+_DOCS_KEYS = {"/"}
 _GROUP_ORDER = [
     "GLOBAL", "INPUT", "CONVERSATION", "PANEL",
     "EVENTS (gated)", "DOCS (gated)", "OTHER",
@@ -105,17 +116,24 @@ def render_keys(app: "App") -> str:
         seen.add(b.key)
         groups["INPUT"].append((_pretty_key(b.key), b.description))
 
-    # Right-panel resize keys (h / l) are handled via ``RightPanel.on_key``
-    # rather than a declared ``Binding`` object, so the BINDINGS iterations
-    # above never see them and the Keys tab silently omitted them. Surface
-    # them explicitly so the user can discover panel resize without
-    # reading the source.
-    if "h" not in seen:
-        groups["PANEL"].append((_pretty_key("h"), "Widen panel"))
-        seen.add("h")
-    if "l" not in seen:
-        groups["PANEL"].append((_pretty_key("l"), "Narrow panel"))
-        seen.add("l")
+    # Right-panel keys handled via ``RightPanel.on_key`` (not declared
+    # ``Binding`` objects) are invisible to the BINDINGS iterations above.
+    # Surface them explicitly so the user can discover them without
+    # reading the source. K1 (wave-2): expanded the panel-universal set
+    # to include j / k / space / c, which previously either lived under
+    # DOCS-only or were missing entirely despite working on every tab.
+    _PANEL_EXPLICIT: list[tuple[str, str]] = [
+        ("h", "Widen panel"),
+        ("l", "Narrow panel"),
+        ("j", "Scroll down (current tab)"),
+        ("k", "Scroll up (current tab)"),
+        ("space", "Toggle preview pane"),
+        ("c", "Copy current view (pending tab: claim cursor)"),
+    ]
+    for key, desc in _PANEL_EXPLICIT:
+        if key not in seen:
+            groups["PANEL"].append((_pretty_key(key), desc))
+            seen.add(key)
 
     lines: list[str] = []
     # Key column width: max key length within the group, capped at 6


### PR DESCRIPTION
**[tui-coder]** — Wave-2 finding K1 (P2/S/score=2.0). 3 of 6 planned wave-2 PRs.

## Observation

`j`, `k`, `space` worked on every right-panel tab (events / agents / memory / docs / pending / cost) via `RightPanel.on_key` — they scroll the current tab's list or toggle the preview pane. `c` was the generic "copy current view" with a pending-tab override (= claim cursor). But `keys_tab.py:35` classified the first three as `_DOCS_KEYS` (= surfaced under "DOCS (gated)" if any iteration reached them) and `c` was completely absent from the tab.

Users on Events / Agents / Memory who used j/k to scroll never saw it documented for their tab. The copy affordance was invisible to anyone who didn't read the source.

## Fix

Move `j` / `k` / `space` from `_DOCS_KEYS` to `_PANEL_KEYS` (= correct the latent classifier mislabel), add `c` to the same set, and mirror the existing `h`/`l` explicit-add pattern in `render_keys` to actually surface them in the Keys tab output.

`/` stays in `_DOCS_KEYS` since it opens the docs filter and no other tab consumes it.

## Visual

Before (sub-agent report):
```
[PANEL]
⌃O      Focus panel
⌃W      Next tab
⌃⇧W     Prev tab
⌃⇧O     Prev tab (alt)
h       Widen panel
l       Narrow panel

[DOCS (gated)]
... (would label j/k/space here if visible)
```

After:
```
[PANEL]
⌃O      Focus panel
⌃W      Next tab
⌃⇧W     Prev tab
⌃⇧O     Prev tab (alt)
h       Widen panel
l       Narrow panel
j       Scroll down (current tab)
k       Scroll up (current tab)
Space   Toggle preview pane
c       Copy current view (pending tab: claim cursor)
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/right_panel/keys_tab.py` | `_PANEL_KEYS` extended with j/k/space/c; `_DOCS_KEYS` narrowed to {"/"}; `render_keys` `_PANEL_EXPLICIT` list adds new visible entries with descriptions |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat` → Ctrl+B → Keys tab — verified PANEL group shows `j`, `k`, `Space`, `c` with descriptions; DOCS (gated) section absent when no DOCS-specific binding iterates.
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/keys_tab.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test pinning exact descriptions — UX formatting that should stay free to tweak.

## Scope guard

**NOT in scope**:
- Pending-tab specific keys (`d`=discard) — pending-only, would need a separate `_PENDING_KEYS` group; the agent didn't flag it as a finding so leaving for a future wave.
- New keybindings — K1 is purely about labelling existing ones correctly.
- Footer hint / empty-state hint updates (= K4 / K5, separate PRs in this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)