### PR TITLE
TUI: Esc binding description "Voice cancel" → "Dismiss / cancel" (K3)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -93,7 +93,14 @@ class ReynTUIApp(App):
         # touching the keyboard for the edit step. Gated by check_action
         # so plain Enter in the input bar still does its normal submit.
         Binding("enter", "voice_stop_and_submit", "Voice send", priority=True, show=False),
-        Binding("escape", "voice_cancel", "Voice cancel", priority=True, show=False),
+        # Esc multiplexes: cancel voice recording / dismiss ErrorBox /
+        # close right panel — see ``action_voice_cancel``. The action
+        # name is historical (= voice was the first user, the rest
+        # accreted), but the surfaced description should reflect the
+        # dominant chat-time meaning so the Keys tab doesn't tell a
+        # non-voice user "Voice cancel" for a key they use daily for
+        # dismissing errors. Wave-2 K3.
+        Binding("escape", "voice_cancel", "Dismiss / cancel", priority=True, show=False),
         Binding("ctrl+backslash", "screenshot", "Screenshot", priority=True, show=False),
     ]
 


### PR DESCRIPTION
**[tui-coder]** — Wave-2 finding K3 (P2/S/score=2.0). 4 of 6 planned wave-2 PRs.

## Observation

`app.py` line 96 declared `Binding("escape", "voice_cancel", "Voice cancel", priority=True, show=False)`. But `action_voice_cancel` actually multiplexes 3 behaviors (see `app.py:1367`):

1. If voice is recording → cancel recording
2. Else if any ErrorBox is mounted → dismiss the topmost
3. Else if the right panel is visible → close it

The "Voice cancel" label misleads any user who isn't using voice — they see a Keys-tab entry that names a feature they don't use, for a key they press daily to dismiss errors and close the panel.

## Important visibility note (= honest scope)

After implementing, smoke testing revealed the Keys tab **does NOT actually surface the app-level Esc description** — `keys_tab.py` `_INPUT_OWNED_KEYS = {"enter", "escape", ...}` defers Esc to InputBar's "Dismiss" binding instead. So this rename is a **source-of-truth correction** rather than a user-visible UX change.

Why ship it anyway:
- The description now matches what the action actually does (= future contributors reading `app.py` BINDINGS aren't misled).
- Debug tooling / Textual introspection that reads bindings sees a correct label.
- If `_INPUT_OWNED_KEYS` is ever narrowed (= surface app Esc alongside InputBar Esc), the description is already correct.

This intentionally narrows K3 from the agent's original "Keys tab shows 'Voice cancel'" claim, which my smoke test didn't reproduce.

## Fix

```python
# Before:
Binding("escape", "voice_cancel", "Voice cancel", priority=True, show=False),

# After:
Binding("escape", "voice_cancel", "Dismiss / cancel", priority=True, show=False),
# + multi-line comment explaining the multiplex action + why the
#   description uses the dominant chat-time meaning.
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | Esc binding description renamed; comment block explaining the multiplex |

## Test plan

- [x] `grep -rn "Voice cancel" src/ tests/` — only my new comment matches; no other code or tests pin the prior label.
- [x] `ruff check src/reyn/chat/tui/app.py` — clean (pre-push 実走済).
- [x] (skipped — not user-visible) tmux Keys tab capture — Esc shows under [INPUT] as "Dismiss" (InputBar binding via `_INPUT_OWNED_KEYS` deference). Re-confirmed the rename does not surface in the Keys tab today.

## Scope guard

**NOT in scope**:
- Lift Esc from `_INPUT_OWNED_KEYS` so the app description surfaces — would change Keys tab behaviour; out of K3 scope (= separate UX call about whether app-Esc or InputBar-Esc is the dominant Keys tab label).
- New Esc affordance (= e.g. close the slash picker first when both picker open + ErrorBox mounted) — out of wave-2 K3 scope.
- Footer hint addition of Esc — separate K4/K5 family (this PR is purely the rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)