### PR TITLE
TUI: Esc dismisses slash picker before ErrorBox (P2)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1365,21 +1365,36 @@ class ReynTUIApp(App):
         )
 
     def action_voice_cancel(self) -> None:
-        """Esc — cancel voice recording, dismiss ErrorBox, or close panel.
+        """Esc — cancel voice recording, dismiss slash picker / ErrorBox, or close panel.
 
         Priority:
           1. If recording → cancel recording.
-          2. Else if ErrorBoxes visible → dismiss the topmost one.
-          3. Else if side panel is visible → close it.
+          2. **Else if InputBar is in slash-entry → dismiss picker + clear**
+             prefix (= wave-2 P2). Previously this was unreachable when
+             an ErrorBox was also mounted because ``check_action`` claimed
+             Esc on behalf of step 3 and the user had to press Esc twice
+             (once for ErrorBox, again for picker). Picker first matches
+             the user's mental model (= the picker is the foreground UI
+             they're actively interacting with) and lets a stale
+             ErrorBox wait one more keypress.
+          3. Else if ErrorBoxes visible → dismiss the topmost one.
+          4. Else if side panel is visible → close it.
 
         Gated by check_action so this never fires when no condition holds
-        (allowing InputBar's own Esc binding to handle slash-picker dismissal).
+        (allowing InputBar's own Esc binding to handle slash-picker
+        dismissal in the no-other-overlay case).
         """
         if self._voice_input is not None and self._voice_input.is_recording:
             self._voice_input.cancel()
             self._voice_set_input_locked(False)
             self._voice_status("✗ recording cancelled", style="dim #555555")
             return
+        try:
+            input_bar = self.query_one("#inputbar", InputBar)
+            if input_bar.dismiss_slash_prefix():
+                return
+        except Exception:
+            pass
         try:
             conv = self.query_one("#conversation", ConversationView)
             if conv.has_error_boxes():
@@ -1424,9 +1439,13 @@ class ReynTUIApp(App):
                 return False
         if action == "voice_cancel":
             # Intercept Esc when there's an overlay/recording to dismiss:
-            # voice recording, ErrorBoxes, or the side panel. Without any
-            # of those, Esc falls through so InputBar can handle the
-            # slash-picker dismissal.
+            # voice recording, ErrorBoxes, or the side panel. The slash
+            # picker / prefix case is intentionally handled by
+            # InputBar's own Esc binding when no other overlay is
+            # present (= simpler dispatch path); when an ErrorBox is
+            # also live the app claims Esc here and ``action_voice_cancel``
+            # dismisses the picker first (= wave-2 P2 fix) before the
+            # ErrorBox.
             if self._voice_input is not None and self._voice_input.is_recording:
                 return True
             if self._panel_visible:


### PR DESCRIPTION
**[tui-coder]** — Wave-2 finding P2 (P1/M/score=1.5). 6 of 6 planned wave-2 PRs — closes the wave.

## Observation

With both an ErrorBox mounted AND the slash picker open simultaneously (e.g. user typed `/attach` Enter → ErrorBox, then `/co<typo>` → picker showing matches), pressing Esc dismissed the ErrorBox while leaving the picker open. The user had to press Esc a second time to clear the picker.

**Why**: `check_action` for `voice_cancel` returned True when an ErrorBox was mounted (`src/reyn/chat/tui/app.py:1425`), so the app claimed Esc, and `action_voice_cancel` ran its ErrorBox-dismiss branch BEFORE the InputBar could see the key. The picker / slash-prefix handling lived only in InputBar's own `action_dismiss_picker`, which is reached only when the app fall-through path runs (= no overlay claims Esc).

## Reproduction (= verified before fix)

1. Launch `reyn chat`
2. Type `/attach` Enter → ErrorBox `│ ✗ usage: /attach <name>  ▶` mounts
3. Type `/co` → picker shows 3 matches (copy / cost / cost-inline)
4. Press Esc once → picker stays, ErrorBox dismisses with `(dismissed)` breadcrumb
5. Press Esc again → picker dismisses

## Fix

Reorder `action_voice_cancel` so the slash-prefix dismissal runs **before** the ErrorBox dismissal. The picker is the foreground UI the user is actively interacting with — dismissing it first matches the mental model, and lets a stale ErrorBox wait one more keypress.

```
Priority (new):
  1. Voice recording → cancel recording
  2. **InputBar slash-entry → dismiss picker + clear prefix**   ← NEW
  3. ErrorBox visible → dismiss topmost (writes "(dismissed)" breadcrumb per F2)
  4. Side panel visible → close panel
```

`check_action` semantics unchanged: still returns True on overlay/recording presence, so the app continues to claim Esc when there's something to act on. The new step 2 inserts the picker check inside the app's handler rather than via the InputBar fall-through path.

## Visual

After fix (with the same repro):
- Step 4 (Esc once) → **picker + input clear in one press**, ErrorBox remains visible at footer
- Step 5 (Esc twice) → ErrorBox dismisses with `(dismissed)` breadcrumb (= F2 path)

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | `action_voice_cancel` adds picker-first branch via `input_bar.dismiss_slash_prefix()` before ErrorBox; `check_action` comment updated to explain the new ordering |

## Test plan

- [x] Manual: tmux MCP — full repro with both ErrorBox + picker active → Esc once → picker clears, ErrorBox remains; Esc twice → both clear.
- [x] Manual: regression check with picker only (no ErrorBox) → Esc once → picker dismisses (= InputBar fall-through path unchanged).
- [x] `ruff check src/reyn/chat/tui/app.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) automated test pinning the ordering — would couple to widget mount/dismiss internals.

## Scope guard

**NOT in scope**:
- Voice + picker case (= voice recording still wins per design — recording is the most ephemeral state).
- Shift+Esc "dismiss all" shortcut (= dropped from triage, P3-class).
- Reordering between ErrorBox and panel-close — out of P2 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Wave-2 summary (this is the last PR)

| Rank | Finding | PR |
|---|---|---|
| 1 | P1 slash palette alphabetical sort | #323 |
| 2 | P3 /quit /exit registry-visible | #325 |
| 3 | K1 Keys tab j/k/space/c PANEL-universal | #326 |
| 4 | K3 Esc binding description (source-level) | #327 |
| 5 | K4 footer Ctrl+C cancel | #328 |
| 6 | P2 Esc picker dismiss in 1 press (this PR) | this |

Parking lot (= dropped from top-6, candidates for follow-up "parking lot も" drain):
- P4 subcommand completion enumeration (P3/L)
- P5 /help wraps off-screen (P3/M)
- K2 ctrl+shift+n/p phantom binding cleanup (P3/S)
- K5 Ctrl+O focus hint visibility (P3/S)
- S3 clear() StreamingRow remove() leak (P3/S)
- S4 Ctrl+C misses orphan StreamingRow (P2/M — connected to S3)
- S5 _last_long_reply single-slot fold stash (P3/S)

Cross-layer (= leader 相談事項、 私 not in scope):
- S1 streaming pipeline dead code in local mode (cross-layer)
- S2 kind="agent" rendering investigation (cross-layer; possible timing artifact with sandbox_2 proxy mismatch window)