### PR TITLE
fix(eval): make spec_path optional in output schemas — closes B43-B46 4x recurring schema-validation failure

### DIFF
--- a/src/reyn/stdlib/skills/eval/artifacts/eval_result_raw.yaml
+++ b/src/reyn/stdlib/skills/eval/artifacts/eval_result_raw.yaml
@@ -58,4 +58,4 @@ schema:
         Status returned by the target skill's run, copied from
         case_run_result. The postprocessor uses this to short-circuit
         scoring when the target run did not finish.
-  required: [criteria_results, weakest_phase, spec_path, summary, run_status]
+  required: [criteria_results, weakest_phase, summary, run_status]

--- a/src/reyn/stdlib/skills/eval/skill.md
+++ b/src/reyn/stdlib/skills/eval/skill.md
@@ -36,7 +36,7 @@ postprocessor:
       weakest_phase:    {type: string}
       spec_path:        {type: string}
       summary:          {type: string}
-    required: [passed, overall_score, passed_criteria, total_criteria, weakest_phase, spec_path, summary]
+    required: [passed, overall_score, passed_criteria, total_criteria, weakest_phase, summary]
   steps:
     - type: python
       module: ./postprocessor.py
@@ -44,7 +44,7 @@ postprocessor:
       into: data
       output_schema:
         type: object
-        required: [passed_criteria, total_criteria, overall_score, passed, weakest_phase, spec_path, summary]
+        required: [passed_criteria, total_criteria, overall_score, passed, weakest_phase, summary]
         properties:
           passed_criteria: {type: integer, minimum: 0}
           total_criteria:  {type: integer, minimum: 0}

--- a/tests/test_eval_skill_spec_path_optional.py
+++ b/tests/test_eval_skill_spec_path_optional.py
@@ -1,0 +1,138 @@
+"""Tier 2: eval skill output schema does NOT require ``spec_path``.
+
+Pinned invariants:
+
+- ``eval_result_raw`` artifact schema accepts payloads that omit
+  ``spec_path`` (e.g. when the LLM was given a scenario user-prompt
+  with no spec.md reference). Before the fix, the LLM emitted
+  ``spec_path: null`` → schema validation rejected the whole eval
+  output → ``skill_run_failed``. Observed B43/B44/B45/B46 = 4
+  consecutive dogfood batches.
+- The caller-facing ``eval_result`` final_output schema in skill.md
+  matches: ``spec_path`` is a pass-through reference field, not a
+  required computation field. Postprocessor (``compute_eval_score``)
+  does not read it — verified by inspecting ``postprocessor.py``.
+- Other required fields stay required (= regression guard against
+  accidentally dropping ``summary`` / ``criteria_results`` etc.).
+
+testing.ja.md compliance:
+- No mocks. Schema YAML is parsed directly with ``yaml.safe_load``.
+- No private-state assertions.
+- No algorithm pinning — the test verifies *which fields are
+  required*, not implementation details of how the schema is
+  enforced.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EVAL_SKILL_DIR = _REPO_ROOT / "src" / "reyn" / "stdlib" / "skills" / "eval"
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _parse_skill_md_frontmatter(skill_md_path: Path) -> dict:
+    """Read the YAML frontmatter from skill.md (= between the leading
+    --- markers)."""
+    text = skill_md_path.read_text(encoding="utf-8")
+    parts = text.split("---", 2)
+    # Frontmatter is parts[1] (parts[0] is "" before the first ---).
+    return yaml.safe_load(parts[1])
+
+
+# ---------------------------------------------------------------------------
+# eval_result_raw schema
+# ---------------------------------------------------------------------------
+
+
+def test_eval_result_raw_does_not_require_spec_path():
+    """Tier 2 (B46-fix): the LLM-authored raw artifact schema must
+    NOT require ``spec_path``. The field stays in ``properties`` (=
+    LLM may still pass it through when known) but is no longer
+    required for validation to pass."""
+    raw_yaml = _load_yaml(_EVAL_SKILL_DIR / "artifacts" / "eval_result_raw.yaml")
+    required = raw_yaml["schema"].get("required", [])
+    assert "spec_path" not in required, (
+        f"spec_path must NOT be in eval_result_raw.required. "
+        f"Currently: {required}. See B43-B46 retrospective — eval "
+        f"skill_run_failed in 4 consecutive batches because LLM "
+        f"emitted spec_path=null when the scenario user-prompt did "
+        f"not supply a spec path."
+    )
+    # Field still discoverable to the LLM (= LLM can fill it when known).
+    assert "spec_path" in raw_yaml["schema"]["properties"]
+
+
+def test_eval_result_raw_keeps_other_required_fields():
+    """Tier 2: regression guard — relaxing spec_path must not
+    accidentally drop other required fields. ``criteria_results``,
+    ``weakest_phase``, ``summary``, ``run_status`` remain required
+    because the postprocessor and caller-facing contract depend on
+    them."""
+    raw_yaml = _load_yaml(_EVAL_SKILL_DIR / "artifacts" / "eval_result_raw.yaml")
+    required = set(raw_yaml["schema"].get("required", []))
+    for field in ("criteria_results", "weakest_phase", "summary", "run_status"):
+        assert field in required, (
+            f"{field} must remain required in eval_result_raw — "
+            f"postprocessor / caller-facing contract depends on it. "
+            f"Currently required: {required}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# skill.md final_output_schema + postprocessor python step output_schema
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_final_output_does_not_require_spec_path():
+    """Tier 2: caller-facing eval_result final_output_schema in
+    skill.md must NOT require spec_path. Matches the
+    eval_result_raw relaxation — spec_path is pass-through, not
+    load-bearing for scoring."""
+    fm = _parse_skill_md_frontmatter(_EVAL_SKILL_DIR / "skill.md")
+    output_schema = fm["postprocessor"]["output_schema"]
+    required = output_schema.get("required", [])
+    assert "spec_path" not in required, (
+        f"final_output_schema.required must NOT include spec_path. "
+        f"Currently: {required}"
+    )
+    # The field stays declared (= callers that pass it through still
+    # see it in the schema).
+    assert "spec_path" in output_schema["properties"]
+
+
+def test_skill_md_postprocessor_step_does_not_require_spec_path():
+    """Tier 2: the python postprocessor step's output_schema must
+    also drop spec_path from required — it would otherwise fail
+    independently of the final_output check above. Belt-and-braces:
+    both schemas must agree."""
+    fm = _parse_skill_md_frontmatter(_EVAL_SKILL_DIR / "skill.md")
+    steps = fm["postprocessor"]["steps"]
+    py_step = next(s for s in steps if s["type"] == "python")
+    required = py_step["output_schema"].get("required", [])
+    assert "spec_path" not in required, (
+        f"postprocessor step output_schema.required must NOT include "
+        f"spec_path. Currently: {required}"
+    )
+
+
+def test_skill_md_final_output_keeps_other_required_fields():
+    """Tier 2: regression guard for the caller-facing schema.
+    Scoring fields (``passed`` / ``overall_score`` / ``passed_criteria``
+    / ``total_criteria``) and prose contract fields (``weakest_phase``
+    / ``summary``) remain required."""
+    fm = _parse_skill_md_frontmatter(_EVAL_SKILL_DIR / "skill.md")
+    required = set(fm["postprocessor"]["output_schema"].get("required", []))
+    for field in (
+        "passed", "overall_score", "passed_criteria", "total_criteria",
+        "weakest_phase", "summary",
+    ):
+        assert field in required, (
+            f"{field} must remain required in final_output_schema. "
+            f"Currently: {required}"
+        )


### PR DESCRIPTION
**[dogfood-coder]** — eval skill output schemas required \`spec_path\`, but when scenarios invoke eval without supplying a spec.md path (= ad-hoc eval requests, the common case) the LLM emits \`null\` and validation rejects the whole eval output → \`skill_run_failed\`. Observed in dogfood B43/B44/B45/B46 as \`eval_run_direct_llm\` R verdict across 4 consecutive batches.

## Root cause

\`spec_path\` is a pass-through reference field — postprocessor \`compute_eval_score\` does not read it. Marking it required forced the LLM to fabricate a value or fail; both bad.

## Fix

Drop \`spec_path\` from \`required\` in 3 schemas:
- \`eval_result_raw.yaml\` (LLM-authored raw artifact)
- \`skill.md\` postprocessor python step \`output_schema\`
- \`skill.md\` caller-facing eval_result \`output_schema\`

Field stays in \`properties\` so callers can still pass it through when known.

## Test plan

- [x] 5 new Tier 2 tests pin \`spec_path\` NOT in required across all 3 schemas + other required fields remain (= regression guard)
- [x] 122 existing eval-related tests still pass (\`pytest -k eval\`)
- [ ] B47 dogfood batch will verify \`eval_run_direct_llm\` scenario no longer hits the validation failure (= primary end-to-end check)

## References

- B43 retrospective NF list: eval postprocessor schema validation persist
- B45 retrospective W2 NF: eval spec_path=None schema validation failure (HIGH, recurring)
- B46 retrospective W2 NF: same, 4-batch recurring
- B46 PR #322 carry-over → user pushback "既知不具合を残したまま次batch進めることは禁止" → \`feedback_no_batch_with_known_bugs\` memory established

🤖 Generated with [Claude Code](https://claude.com/claude-code)