### PR TITLE
fix(mcp): install command writes loader-ready config (closes #318, #319; warns #320)

### DIFF
--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -736,6 +736,30 @@ def _run_install_from_source(
     print(f"Scope: {scope}")
     if pre_env:
         print(f"Pre-supplied env keys: {', '.join(pre_env.keys())}")
+    # issue #320: warn when /tmp is passed as a server arg on macOS.
+    # /tmp is a symlink to /private/tmp on Darwin; the filesystem MCP
+    # server (and similar path-checking servers) resolve the configured
+    # root to its canonical path but compare LITERAL strings against
+    # tool-call arguments → 'Access denied - path outside allowed
+    # directories'. Surfacing the gotcha at install time saves a debug
+    # round later. Linux unaffected.
+    import platform as _platform  # noqa: PLC0415
+    if extra_args and _platform.system() == "Darwin":
+        tmp_args = [
+            a for a in extra_args
+            if isinstance(a, str) and (a == "/tmp" or a.startswith("/tmp/"))
+        ]
+        if tmp_args:
+            print(
+                "Warning: detected /tmp path(s) in --args on macOS: "
+                f"{tmp_args}. /tmp is a symlink to /private/tmp; some "
+                "path-checking MCP servers (e.g. filesystem) compare "
+                "literal paths and will deny tool calls that reference "
+                "/tmp/... while the configured root resolved to "
+                "/private/tmp/... — use a non-symlink path (e.g. ./.mcp-sandbox "
+                "or ~/mcp-sandbox) to avoid this.",
+                file=sys.stderr,
+            )
     print()
 
     try:

--- a/src/reyn/op_runtime/mcp_install.py
+++ b/src/reyn/op_runtime/mcp_install.py
@@ -74,8 +74,15 @@ def _scope_to_path(scope: str, project_root: Path) -> Path:
 def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:
     """Build the mcp.servers.<name> config dict from a ServerPackage raw dict.
 
-    Returns a dict with keys: command, args, and optionally env + transport.
+    Returns a dict with keys: type, command, args, and optionally env.
     The env field uses ${KEY} references only — values stay in secrets.env.
+
+    issue #318: ``type:`` is ALWAYS written (= matches the loader's
+    ``MCPClient`` expectation that ``type`` be one of
+    ``stdio | http | sse``). Pre-fix the function omitted the field
+    for the default stdio case + wrote a ``transport:`` key (not
+    ``type:``) for non-stdio — both produced configs that the loader
+    rejected with ``Unsupported MCP server type: None``.
     """
     registry_type = pkg_raw.get("registryType", "").lower()
     identifier = pkg_raw.get("identifier", "")
@@ -87,24 +94,21 @@ def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:
         args = ["-y", identifier]
         if version:
             args = ["-y", f"{identifier}@{version}"]
-        entry: dict = {"command": "npx", "args": args}
+        entry: dict = {"type": transport_type, "command": "npx", "args": args}
     elif registry_type == "pypi":
         args = [identifier]
         if version:
             args = [f"{identifier}=={version}"]
-        entry = {"command": "uvx", "args": args}
+        entry = {"type": transport_type, "command": "uvx", "args": args}
     elif registry_type == "docker":
         args = ["run", "--rm", "-i", identifier]
-        entry = {"command": "docker", "args": args}
+        entry = {"type": transport_type, "command": "docker", "args": args}
     elif registry_type == "nuget":
         args = ["tool", "run", identifier]
-        entry = {"command": "dnx", "args": args}
+        entry = {"type": transport_type, "command": "dnx", "args": args}
     else:
         # Unknown registry type: store raw info so user can fix manually
-        entry = {"command": "", "args": [identifier]}
-
-    if transport_type and transport_type != "stdio":
-        entry["transport"] = transport_type
+        entry = {"type": transport_type, "command": "", "args": [identifier]}
 
     if env_keys:
         entry["env"] = {k: f"${{{k}}}" for k in env_keys}

--- a/src/reyn/registry/source_resolver.py
+++ b/src/reyn/registry/source_resolver.py
@@ -66,22 +66,62 @@ class SourceResolution:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+# issue #319: common MCP-server-name prefixes that are stripped when
+# deriving the short config key. The MCP ecosystem widely uses
+# ``server-<name>`` (= Anthropic official) and ``mcp-server-<name>``
+# (= third-party convention). Stripping these gives a short key that
+# matches stdlib skill expectations (e.g. ``read_local_files`` looks
+# for ``mcp.servers.filesystem``, not ``mcp.servers.server-filesystem``).
+_MCP_NAME_PREFIXES = ("mcp-server-", "server-")
+
+
+def _strip_mcp_prefix(name: str) -> str:
+    """Strip common ``server-`` / ``mcp-server-`` prefixes (issue #319).
+
+    Returns the input unchanged when no prefix matches.
+    """
+    for prefix in _MCP_NAME_PREFIXES:
+        if name.startswith(prefix) and len(name) > len(prefix):
+            return name[len(prefix):]
+    return name
+
+
 def _npm_package_name(identifier: str) -> str:
     """Derive a short config key from an npm package name.
 
-    ``@modelcontextprotocol/server-filesystem`` → ``server-filesystem``
+    ``@modelcontextprotocol/server-filesystem`` → ``filesystem``
+    ``mcp-server-foo``                          → ``foo``
     ``my-mcp-server``                           → ``my-mcp-server``
+    ``@scope/plain-name``                       → ``plain-name``
+
+    issue #319: pre-fix the function returned ``server-filesystem``
+    verbatim (= the npm package's last path component). The stdlib
+    ``read_local_files`` skill expects ``mcp.servers.filesystem`` —
+    every install through this path required a manual rename. Now
+    the ecosystem-standard prefixes are stripped automatically.
     """
     if "/" in identifier:
-        return identifier.split("/")[-1]
-    return identifier
+        name = identifier.split("/")[-1]
+    else:
+        name = identifier
+    return _strip_mcp_prefix(name)
 
 
 def _pypi_package_name(identifier: str) -> str:
-    """Derive a short name from a PyPI package name."""
+    """Derive a short name from a PyPI package name.
+
+    ``mcp-server-time``  → ``time``
+    ``mcp-server-fetch`` → ``fetch``
+    ``my-mcp-tool``      → ``my-mcp-tool``
+
+    issue #319: same prefix-strip as ``_npm_package_name`` so the
+    PyPI install path produces the same canonical short names as
+    the npm path. Pre-fix ``pypi:mcp-server-time`` installed as
+    ``mcp-server-time``; now installs as ``time``.
+    """
     # Strip any version specifier
     base = re.split(r"[=><!]", identifier)[0].strip()
-    return base.replace("_", "-")
+    return _strip_mcp_prefix(base.replace("_", "-"))
 
 
 def _docker_image_name(image: str) -> str:
@@ -276,7 +316,10 @@ def _resolve_github_url(url: str) -> SourceResolution:
             }
         ]
         return SourceResolution(
-            server_name=f"server-{subdir}",
+            # issue #319: don't reintroduce the ``server-`` prefix here
+            # either — the github resolver builds the same config key
+            # the npm path produces, so the stripped form is canonical.
+            server_name=subdir,
             runtime_hint="npx",
             packages_raw=packages_raw,
             raw={"packages": packages_raw, "_source_github_url": url},

--- a/tests/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/test_mcp_install_ux_fixes_318_319_320.py
@@ -1,0 +1,227 @@
+"""Tier 2: ``reyn mcp install`` UX fixes (issues #318 + #319 + #320).
+
+Pre-fix every install via ``reyn mcp install --source ...`` produced a
+config that needed THREE manual edits before any skill could use it:
+
+  1. **#318**: add ``type: stdio`` (loader rejected without it)
+  2. **#319**: rename ``server-foo`` → ``foo`` (stdlib skills expect
+     the short form)
+  3. **#320**: on macOS, replace ``/tmp`` sandbox path with a non-
+     symlink path (server's literal-path check denies otherwise)
+
+The trio was discovered + filed in the 2026-05-20 smoke-test round
+(see ``docs/guide/for-users/popular-mcp-servers.md``'s Known Issues
+table for the workaround pattern users had to apply on every install).
+
+This file pins the post-fix behaviour so users never see those three
+gotchas again, and so a regression of any one of the three fails CI
+before reaching the docs / users.
+
+Pins (= one section per issue):
+
+  - **#318** ``_build_server_entry`` always writes ``type: <transport_type>``
+    even for the default ``stdio`` case. Pre-fix the field was omitted
+    for stdio and written under the wrong key (``transport``) for
+    non-stdio.
+  - **#319** ``_npm_package_name`` / ``_pypi_package_name`` /
+    ``_resolve_github_url`` all strip ``server-`` and ``mcp-server-``
+    prefixes from the derived short name.
+  - **#320** ``reyn mcp install`` warns on Darwin when ``--args``
+    contains ``/tmp`` paths.
+"""
+from __future__ import annotations
+
+import platform
+import subprocess
+import sys
+
+from reyn.op_runtime.mcp_install import _build_server_entry
+from reyn.registry.source_resolver import (
+    _npm_package_name,
+    _pypi_package_name,
+    _strip_mcp_prefix,
+    resolve,
+)
+
+# ── #318: type: stdio in every install ────────────────────────────────
+
+
+def test_build_server_entry_writes_type_stdio_for_npm() -> None:
+    """Tier 2: npm package entry includes ``type: stdio``.
+
+    Pre-#318 the field was omitted because the default-case branch
+    didn't write it; the loader then rejected with 'Unsupported MCP
+    server type: None'.
+    """
+    pkg_raw = {
+        "registryType": "npm",
+        "identifier": "@modelcontextprotocol/server-filesystem",
+        "version": "",
+        "transport": {"type": "stdio"},
+        "environmentVariables": [],
+    }
+    entry = _build_server_entry(pkg_raw, env_keys=[])
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "npx"
+
+
+def test_build_server_entry_writes_type_stdio_for_pypi() -> None:
+    """Tier 2: pypi package entry also gets ``type: stdio``."""
+    pkg_raw = {
+        "registryType": "pypi",
+        "identifier": "mcp-server-time",
+        "version": "",
+        "transport": {"type": "stdio"},
+        "environmentVariables": [],
+    }
+    entry = _build_server_entry(pkg_raw, env_keys=[])
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "uvx"
+
+
+def test_build_server_entry_writes_type_stdio_for_docker() -> None:
+    """Tier 2: docker registry-type also gets ``type: stdio``."""
+    pkg_raw = {
+        "registryType": "docker",
+        "identifier": "my-org/my-mcp:latest",
+        "version": "",
+        "transport": {"type": "stdio"},
+        "environmentVariables": [],
+    }
+    entry = _build_server_entry(pkg_raw, env_keys=[])
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "docker"
+
+
+def test_build_server_entry_writes_type_http_when_specified() -> None:
+    """Tier 2: explicit non-stdio transport is written under the
+    canonical ``type:`` key, NOT the pre-fix ``transport:`` key.
+    The loader reads ``type:`` and rejected ``transport:``.
+    """
+    pkg_raw = {
+        "registryType": "npm",
+        "identifier": "some/http-server",
+        "version": "",
+        "transport": {"type": "http"},
+        "environmentVariables": [],
+    }
+    entry = _build_server_entry(pkg_raw, env_keys=[])
+    assert entry["type"] == "http"
+    # Pre-fix bug: would set entry["transport"] = "http" instead.
+    assert "transport" not in entry
+
+
+# ── #319: ``server-`` and ``mcp-server-`` prefix strip ───────────────
+
+
+def test_strip_mcp_prefix_anthropic_server_dash() -> None:
+    """Tier 2: ``server-<name>`` (= Anthropic-official convention) is
+    stripped.
+    """
+    assert _strip_mcp_prefix("server-filesystem") == "filesystem"
+    assert _strip_mcp_prefix("server-memory") == "memory"
+    assert _strip_mcp_prefix("server-everything") == "everything"
+
+
+def test_strip_mcp_prefix_thirdparty_mcp_server_dash() -> None:
+    """Tier 2: ``mcp-server-<name>`` (= third-party convention) is
+    stripped (= PyPI ecosystem standard).
+    """
+    assert _strip_mcp_prefix("mcp-server-time") == "time"
+    assert _strip_mcp_prefix("mcp-server-fetch") == "fetch"
+    assert _strip_mcp_prefix("mcp-server-git") == "git"
+
+
+def test_strip_mcp_prefix_no_prefix_passthrough() -> None:
+    """Tier 2: a name without a known prefix is returned unchanged."""
+    assert _strip_mcp_prefix("custom-tool") == "custom-tool"
+    assert _strip_mcp_prefix("foo") == "foo"
+
+
+def test_strip_mcp_prefix_does_not_strip_to_empty() -> None:
+    """Tier 2: defensive — a name that IS exactly the prefix doesn't
+    get stripped to empty (= would produce an unusable config key).
+    """
+    assert _strip_mcp_prefix("server-") == "server-"
+    assert _strip_mcp_prefix("mcp-server-") == "mcp-server-"
+
+
+def test_npm_package_name_strips_prefix() -> None:
+    """Tier 2: ``_npm_package_name`` returns the stripped form."""
+    assert _npm_package_name("@modelcontextprotocol/server-filesystem") == "filesystem"
+    assert _npm_package_name("server-everything") == "everything"
+
+
+def test_pypi_package_name_strips_prefix() -> None:
+    """Tier 2: ``_pypi_package_name`` returns the stripped form."""
+    assert _pypi_package_name("mcp-server-time") == "time"
+    assert _pypi_package_name("mcp-server-fetch") == "fetch"
+
+
+def test_resolve_npm_canonical_server_name_post_319() -> None:
+    """Tier 2 (= integration): the resolver's ``server_name`` is the
+    prefix-stripped short form. Pin the install→loader→stdlib-skill
+    contract so stdlib expectations (= ``mcp.servers.filesystem``,
+    not ``mcp.servers.server-filesystem``) are met without rename.
+    """
+    r = resolve("npm:@modelcontextprotocol/server-filesystem")
+    assert r.server_name == "filesystem"
+
+
+def test_resolve_pypi_canonical_server_name_post_319() -> None:
+    """Tier 2: same for pypi path."""
+    r = resolve("pypi:mcp-server-time")
+    assert r.server_name == "time"
+
+
+def test_resolve_github_canonical_server_name_post_319() -> None:
+    """Tier 2: same for github → npm path."""
+    r = resolve(
+        "https://github.com/modelcontextprotocol/servers"
+        "/tree/main/src/filesystem",
+    )
+    assert r.server_name == "filesystem"
+
+
+# ── #320: macOS /tmp install-time warning ────────────────────────────
+
+
+def test_install_command_warns_on_tmp_args_on_darwin(tmp_path) -> None:
+    """Tier 2: on macOS, ``reyn mcp install --args /tmp/...`` emits a
+    warning explaining the symlink gotcha. Skipped on non-Darwin
+    because the warning is platform-gated.
+
+    Drives the actual CLI subprocess (= ``reyn mcp install``) with a
+    bogus source so the command errors quickly without network — we
+    only need to capture the pre-install warning, which is emitted
+    BEFORE the resolver runs.
+    """
+    if platform.system() != "Darwin":
+        import pytest
+        pytest.skip("warning is Darwin-gated by design")
+
+    # Use a known-unresolvable source so install fails fast.
+    # The warning we're checking fires BEFORE the resolver, so the
+    # subsequent install failure is irrelevant to the assertion.
+    import shutil
+    reyn_bin = shutil.which("reyn")
+    if reyn_bin is None:
+        import pytest
+        pytest.skip("reyn executable not on PATH for subprocess invocation")
+    result = subprocess.run(
+        [
+            reyn_bin, "mcp", "install",
+            "--source", "npm:nonexistent-bogus-pkg",
+            "--args", "/tmp/some-sandbox",
+            "--non-interactive",
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    combined = result.stdout + result.stderr
+    assert "/tmp" in combined
+    assert "symlink" in combined or "literal" in combined, (
+        f"expected #320 warning text; got combined output: {combined!r}"
+    )

--- a/tests/test_mcp_source_install.py
+++ b/tests/test_mcp_source_install.py
@@ -28,11 +28,16 @@ from reyn.registry.source_resolver import SourceResolution, resolve
 
 class TestSourceResolverNpm:
     def test_npm_bare_package(self):
-        """Tier 2: npm: scheme resolves a bare package name to npx runtime."""
+        """Tier 2: npm: scheme resolves a bare package name to npx runtime.
+
+        issue #319: ``server-`` prefix is stripped from the derived
+        config key so the stdlib skill expectations align without a
+        manual rename. The ``identifier`` keeps the npm-canonical name.
+        """
         r = resolve("npm:@modelcontextprotocol/server-filesystem")
         assert r.error == ""
         assert r.runtime_hint == "npx"
-        assert r.server_name == "server-filesystem"
+        assert r.server_name == "filesystem"
         assert r.packages_raw[0]["registryType"] == "npm"
         assert r.packages_raw[0]["identifier"] == "@modelcontextprotocol/server-filesystem"
         assert r.packages_raw[0]["version"] == ""
@@ -46,11 +51,15 @@ class TestSourceResolverNpm:
         assert r.packages_raw[0]["version"] == "0.6.2"
 
     def test_npm_unscoped_package(self):
-        """Tier 2: npm: scheme resolves an unscoped package."""
+        """Tier 2: npm: scheme resolves an unscoped package.
+
+        issue #319: the ``mcp-server-`` prefix is also stripped (= the
+        third-party convention).
+        """
         r = resolve("npm:mcp-server-tool")
         assert r.error == ""
         assert r.runtime_hint == "npx"
-        assert r.server_name == "mcp-server-tool"
+        assert r.server_name == "tool"
 
     def test_npm_empty_package_returns_error(self):
         """Tier 2: npm: with no package name returns error."""
@@ -112,12 +121,15 @@ class TestSourceResolverDocker:
 
 class TestSourceResolverGitHub:
     def test_github_known_repo_with_subdir(self):
-        """Tier 2: GitHub URL for known repo with src/<subdir> resolves to npm."""
+        """Tier 2: GitHub URL for known repo with src/<subdir> resolves to npm.
+
+        issue #319: same prefix-strip applies to the github→npm path.
+        """
         url = "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem"
         r = resolve(url)
         assert r.error == ""
         assert r.runtime_hint == "npx"
-        assert r.server_name == "server-filesystem"
+        assert r.server_name == "filesystem"
         assert r.packages_raw[0]["identifier"] == "@modelcontextprotocol/server-filesystem"
 
     def test_github_known_repo_with_github_subdir(self):
@@ -126,7 +138,7 @@ class TestSourceResolverGitHub:
         r = resolve(url)
         assert r.error == ""
         assert r.runtime_hint == "npx"
-        assert r.server_name == "server-github"
+        assert r.server_name == "github"
         assert r.packages_raw[0]["identifier"] == "@modelcontextprotocol/server-github"
 
     def test_github_unknown_repo_no_runtime(self):
@@ -244,14 +256,17 @@ def test_source_npm_skips_registry_and_installs(tmp_path):
     assert result["runtime"] == "npx"
     assert result["source"] == "npm:@modelcontextprotocol/server-filesystem"
 
-    # Config file written
+    # Config file written. issue #319: server key is the prefix-stripped
+    # short form. issue #318: ``type: stdio`` is present so the loader
+    # accepts the entry without manual edit.
     config_path = tmp_path / "reyn.local.yaml"
     assert config_path.exists()
     import yaml
     written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     servers = written["mcp"]["servers"]
-    assert "server-filesystem" in servers
-    entry = servers["server-filesystem"]
+    assert "filesystem" in servers
+    entry = servers["filesystem"]
+    assert entry["type"] == "stdio"
     assert entry["command"] == "npx"
     assert "@modelcontextprotocol/server-filesystem" in " ".join(str(a) for a in entry["args"])
 
@@ -358,7 +373,8 @@ def test_source_github_known_installs_npm(tmp_path):
     config_path = tmp_path / "reyn.local.yaml"
     written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     servers = written["mcp"]["servers"]
-    assert "server-filesystem" in servers
+    # issue #319: prefix-stripped short key.
+    assert "filesystem" in servers
 
 
 def test_source_missing_runtime_returns_error(tmp_path):


### PR DESCRIPTION
**[e2e-coder]** — fixes the 3 install-flow UX issues discovered in the 2026-05-20 8-server smoke-test round (PRs #321 + #324 docs). After this PR, the procedure shrinks from "install + 3 manual edits per server" to "install + done".

## Fixes

### #318 (blocker) — `type: stdio` missing → loader rejected

`_build_server_entry` omitted the field for stdio + wrote `transport:` (wrong key) for non-stdio. Loader rejected with `Unsupported MCP server type: None`. **Fix**: always write `type: <transport_type>` as the first entry key.

### #319 (papercut) — server name kept npm prefix → stdlib skill name mismatch

`server-filesystem` / `mcp-server-time` derived as-is; stdlib skills (`read_local_files` expects `mcp.servers.filesystem`) needed a manual rename per install. **Fix**: new `_strip_mcp_prefix` helper removes `server-` + `mcp-server-` from derived short names; wired into npm/pypi/github resolver paths.

### #320 (macOS UX) — /tmp symlink → filesystem server literal-path deny

Server resolves root to `/private/tmp/...` but tool-call paths come in as `/tmp/...` → "Access denied - path outside allowed directories". **Fix**: `reyn mcp install --args /tmp/...` now emits a Darwin-gated install-time warning explaining the gotcha and pointing to non-symlink alternatives.

## Verified end-to-end

```bash
reyn mcp install --source npm:@modelcontextprotocol/server-filesystem \
    --args /Users/.../.mcp-sandbox --non-interactive

# Resulting reyn.local.yaml — ready to use, no edits:
mcp:
  servers:
    filesystem:          # ← #319 prefix stripped
      type: stdio        # ← #318 type present
      command: npx
      args: [-y, '@modelcontextprotocol/server-filesystem', /Users/.../.mcp-sandbox]
```

## Test plan

- [x] **New** `tests/test_mcp_install_ux_fixes_318_319_320.py` (14 Tier 2 cases): #318 (npm/pypi/docker/non-stdio variants), #319 (`_strip_mcp_prefix` both conventions + no-prefix pass-through + empty-strip guard + all 3 resolver paths), #320 (subprocess-driven CLI Darwin warning capture)
- [x] **Updated** `tests/test_mcp_source_install.py` (4 sites): pre-#319 `server-foo` expectations flipped to `foo`; pre-#318 site asserting only `command:` extended to also assert `type: "stdio"`
- [x] Full suite: **4356 passed**, 5 skipped, 3 xfailed in 166s
- [x] `ruff check` clean

## Follow-up

After merge:
- Close #318 / #319 / #320 with "merged via PR #N" final comments
- Strip the workaround Python snippets from `docs/guide/for-users/popular-mcp-servers.md` (= ~24 snippets across 8 server sections become unneeded) — separate small docs PR

## Related

- PR #321 + #324 (= the 8-server doc that documents the workarounds being eliminated here)
- PR #266 (= original MCP integration that the install command supports)
- `docs/guide/for-skill-authors/use-an-mcp-server.ja.md` (= the documented example shape this PR now produces automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)