### PR TITLE
TUI/web: #276 Phase B (1/5) — cancel_inflight WS message type

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -793,6 +793,45 @@ class ReynTUIApp(App):
             )
             return
 
+        # Issue #276 Phase B: remote (``--connect``) mode delegates the
+        # cancel to the server. The ``_WSSessionProxy`` exposes
+        # ``cancel_inflight()`` which fires a WS frame; the server-side
+        # endpoint iterates the real ``session.running_skills`` /
+        # ``running_plans`` and emits a ``status`` outbox back with the
+        # "✗ cancelled N skill + M plan" summary. The local proxy's
+        # ``running_skills`` / ``running_plans`` dicts are always empty
+        # (state lives server-side), so the legacy iteration below
+        # would be a no-op and we'd report "(nothing in-flight to
+        # cancel)" even when the remote agent is mid-call. Detect the
+        # proxy by the registry holding a ``_ws`` attribute — only the
+        # WS client (``_WSRegistry``) sets that; local AgentRegistry
+        # doesn't.
+        is_remote_proxy = getattr(self._agent_registry, "_ws", None) is not None
+        remote_cancel = getattr(session, "cancel_inflight", None)
+        if is_remote_proxy and callable(remote_cancel):
+            asyncio.create_task(remote_cancel())
+            # Optimistic local feedback — the authoritative summary
+            # arrives as a ``status`` outbox frame from the server.
+            self._voice_status(
+                "cancel sent to remote — awaiting confirmation",
+                style="dim #aa6666",
+            )
+            # Seal any locally-tracked skill-activity rows so their
+            # spinners stop immediately (the remote will send
+            # ``trace`` workflow_aborted events shortly but the
+            # visible spinner shouldn't keep ticking in the meantime).
+            if conv is not None and self._skill_exec:
+                for run_id in list(self._skill_exec.keys()):
+                    try:
+                        conv.finish_skill_row(
+                            run_id, success=False, reason="cancelled (remote)",
+                        )
+                    except Exception:
+                        pass
+                    self._skill_exec.pop(run_id, None)
+                self._push_exec_state()
+            return
+
         cancelled_skills = 0
         for task in list(getattr(session, "running_skills", {}).values()):
             if not task.done():

--- a/src/reyn/chat/tui/ws_client.py
+++ b/src/reyn/chat/tui/ws_client.py
@@ -82,6 +82,42 @@ class _WSSessionProxy:
         """
         await self._send_fn({"type": "user_message", "text": text})
 
+    def register_intervention_listener(self, listener_id: str) -> None:
+        """No-op stub for the TUI's ``on_mount`` listener registration.
+
+        The local ``ChatSession`` uses this to declare which UI surface
+        consumes intervention prompts (= local TUI vs MCP vs A2A). In
+        remote (``--connect``) mode the server-side session handles its
+        own listener registration; the thin client doesn't need to
+        coordinate. Recording the listener id keeps the API shape
+        compatible without adding a round-trip to the server.
+
+        Phase A omitted this method which crashed
+        ``ReynTUIApp.on_mount`` on first ``--connect`` launch (= this
+        was a Phase A regression caught during Phase B integration
+        testing). Phase B adds it as a no-op so the proxy can be
+        mounted; future phases may grow a server-side listener
+        registration if needed.
+        """
+        self._intervention_listener_id = listener_id
+
+    async def cancel_inflight(self) -> None:
+        """Issue #276 Phase B: send a ``cancel_inflight`` WS frame.
+
+        The proxy holds no real ``running_skills`` / ``running_plans``
+        — that state lives on the server. The TUI delegates Ctrl+C to
+        this method when ``--connect`` mode is detected, and the
+        server-side endpoint (= ``src/reyn/web/ws/chat.py``) iterates
+        its session's running tasks + emits a ``status`` outbox with
+        the same "✗ cancelled N skill + M plan" summary local mode
+        produces.
+
+        Returns immediately after the WS send — actual cancellation
+        is async on the server, the visible result arrives via the
+        next inbound ``status`` frame.
+        """
+        await self._send_fn({"type": "cancel_inflight"})
+
 
 class _WSRegistry:
     """Minimal AgentRegistry-shaped object backing the TUI in ``--connect`` mode.

--- a/src/reyn/web/ws/chat.py
+++ b/src/reyn/web/ws/chat.py
@@ -161,11 +161,60 @@ async def ws_chat(websocket: WebSocket, agent_name: str) -> None:
                 text = str(payload.get("text", "")).strip()
                 if text:
                     await session.submit_user_text(text)
+            elif msg_type == "cancel_inflight":
+                # Issue #276 Phase B: remote Ctrl+C. Iterate the
+                # session's running_skills / running_plans and call
+                # ``.cancel()`` on each — mirrors what
+                # ``app.action_cancel_inflight`` does for the local
+                # session. The TUI thin client side delegates here
+                # because the proxy's local ``running_skills`` /
+                # ``running_plans`` dicts are empty (server-side state
+                # isn't replicated). Reports the result back as a
+                # ``status`` outbox so the conv pane gets the same
+                # "✗ cancelled N skill + M plan" summary local mode
+                # shows.
+                cancelled_skills = 0
+                for task in list(getattr(session, "running_skills", {}).values()):
+                    if not task.done():
+                        task.cancel()
+                        cancelled_skills += 1
+                cancelled_plans = 0
+                for task in list(getattr(session, "running_plans", {}).values()):
+                    if not task.done():
+                        task.cancel()
+                        cancelled_plans += 1
+                if cancelled_skills == 0 and cancelled_plans == 0:
+                    summary = "(nothing in-flight on remote to cancel)"
+                else:
+                    parts: list[str] = []
+                    if cancelled_skills:
+                        parts.append(
+                            f"{cancelled_skills} skill"
+                            f"{'s' if cancelled_skills != 1 else ''}"
+                        )
+                    if cancelled_plans:
+                        parts.append(
+                            f"{cancelled_plans} plan"
+                            f"{'s' if cancelled_plans != 1 else ''}"
+                        )
+                    summary = f"✗ cancelled {' + '.join(parts)}"
+                # Push as a status frame the TUI will surface via its
+                # OutboxRouter ``status`` handler.
+                await websocket.send_text(json.dumps({
+                    "kind": "status",
+                    "text": summary,
+                    "meta": {
+                        "$cancel_ack": True,
+                        "cancelled_skills": cancelled_skills,
+                        "cancelled_plans": cancelled_plans,
+                    },
+                }))
             else:
                 # Unknown message type — echo an error but keep the connection.
                 await websocket.send_text(json.dumps({
                     "kind": "error",
-                    "text": f"Unknown message type {msg_type!r}. Expected 'user_message'.",
+                    "text": f"Unknown message type {msg_type!r}. "
+                    "Expected 'user_message' or 'cancel_inflight'.",
                     "meta": {},
                 }))
 

--- a/tests/cli/test_ws_client_phase_b_cancel.py
+++ b/tests/cli/test_ws_client_phase_b_cancel.py
@@ -1,0 +1,58 @@
+"""Tier 2: ``_WSSessionProxy.cancel_inflight`` — issue #276 Phase B.
+
+Pins the wire-protocol shape that ``app.action_cancel_inflight``
+delegates to in ``--connect`` mode. The server-side endpoint
+(``src/reyn/web/ws/chat.py``) routes on ``payload["type"]`` so the
+shape is the load-bearing contract.
+
+Spies via a recording async lambda — no ``unittest.mock`` per
+``docs/deep-dives/contributing/testing.ja.md``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.ws_client import _WSSessionProxy
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_cancel_inflight_sends_wire_frame() -> None:
+    """Tier 2: ``cancel_inflight`` sends ``{"type": "cancel_inflight"}``.
+
+    No text payload — the server-side handler iterates its session's
+    running_skills + running_plans and emits the result as a status
+    outbox; the client doesn't need to enumerate anything.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    await proxy.cancel_inflight()
+
+    assert len(sent) == 1
+    assert sent[0] == {"type": "cancel_inflight"}
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_cancel_inflight_returns_none() -> None:
+    """Tier 2: returns ``None`` — actual cancellation is async server-side.
+
+    Callers (= ``app.action_cancel_inflight``) optimistically show a
+    "cancel sent" status; the authoritative count arrives on the next
+    inbound status frame.
+    """
+    async def _noop(_payload: dict) -> None:
+        return None
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_noop)
+    result = await proxy.cancel_inflight()
+    assert result is None


### PR DESCRIPTION
**[tui-coder]** — Closes #276 Phase B step 1 of 5. Remote ``Ctrl+C`` for ``reyn chat --connect``.

Following the user-initiated reopen of #276 (auto-closed by PR #282 Phase A's `Closes #276 Phase A` header — GitHub ignored the "Phase A" qualifier), Phase B begins. 5 message types total, each shipped as a separate PR per the issue body table.

## What's in this PR

| Layer | Change |
|---|---|
| Server (`src/reyn/web/ws/chat.py`) | new `msg_type == "cancel_inflight"` branch — iterates `session.running_skills` + `session.running_plans`, calls `.cancel()` on each, emits a `status` outbox with `✗ cancelled N skill + M plan` (or `(nothing in-flight on remote to cancel)`). `meta.$cancel_ack` carries structured counts. |
| Client (`src/reyn/chat/tui/ws_client.py`) | `_WSSessionProxy.cancel_inflight()` sends `{"type": "cancel_inflight"}`. `register_intervention_listener` no-op added — **fixes a Phase A regression** where `on_mount` crashed with `AttributeError` on first `--connect` launch. |
| Client wire (`src/reyn/chat/tui/app.py`) | `action_cancel_inflight` detects remote mode via `registry._ws` presence + delegates to `session.cancel_inflight()`. Optimistic local feedback `cancel sent to remote — awaiting confirmation` + seal local `_skill_exec` SkillActivityRow spinners. |

## Wire-protocol contract (= the load-bearing surface)

Client → Server:
```json
{"type": "cancel_inflight"}
```

Server → Client:
```json
{
  "kind": "status",
  "text": "✗ cancelled 1 skill",
  "meta": {"$cancel_ack": true, "cancelled_skills": 1, "cancelled_plans": 0}
}
```
or for empty case:
```json
{
  "kind": "status",
  "text": "(nothing in-flight on remote to cancel)",
  "meta": {"$cancel_ack": true, "cancelled_skills": 0, "cancelled_plans": 0}
}
```

## Phase A regression caught

`_WSSessionProxy` was missing `register_intervention_listener` — `ReynTUIApp.on_mount` calls it on the session unconditionally and crashed with `AttributeError` immediately after `--connect` succeeded. Added as a no-op (records listener id locally; the server-side session handles its own listener registration). This is an honest-scope-narrow disclosure: the regression was caught during Phase B integration testing, the fix lives in this PR because without it manual verification of `cancel_inflight` was impossible.

## Test plan

- [x] `python -m pytest tests/cli/test_ws_client_phase_a.py tests/cli/test_ws_client_phase_b_cancel.py` — 15 passed (= 13 Phase A + 2 Phase B cancel cases).
- [x] `ruff check` on all modified files — clean (pre-push 実走済).
- [x] Manual end-to-end: tmux MCP — start `reyn web --host 127.0.0.1 --port 9876` (server pane) + `reyn chat --connect ws://127.0.0.1:9876` (client pane) → Ctrl+C idle → conv pane shows `cancel sent to remote — awaiting confirmation` (optimistic local) + `⟳ (nothing in-flight on remote to cancel)` (server status frame via sticky-status surface).
- [x] (skipped — heavy bootstrap) Automated server-side WS test with running task being cancelled. Would require standing up a full FastAPI TestClient WS connection + creating a real AgentRegistry + running task fixture. The wire-protocol shape is pinned by the client-side test (= what the server *must* accept); the cancel iteration mirrors the local TUI's `action_cancel_inflight` which is already exercised by local-mode use.

## Scope guard

**NOT in scope** (= rest of Phase B, separate PRs):
- answer_intervention (free-text intervention answer; `/answer <id> <text>` slash + intervention widget free-text path)
- list_interventions (queued_count surface for `+N more pending` widget)
- list_agents (`/agents` slash)
- attach_agent (`/attach <name>` slash, remote-side switch)

**NOT in scope** (= Phase C):
- Right panel data sources (= scoped disable v1 per owner decision — already in place via `remote_mode` Pending tab path etc.)

## Calibration matrix self-check

| trigger | 適用 | 根拠 |
|---|---|---|
| 構造的 wiring (= new WS message type, both sides) | Tier 2 client-side ✅ / server-side documented skip | client tests cover wire shape; server WS handler needs heavy bootstrap, documented as honest-scope narrow |
| spy 必要時 | direct attribute substitution ✅ | recording async lambdas, no MagicMock |
| sub-agent finding source | N/A | self-initiated implementation, no sub-agent claim to verify |
| ruff pre-push | ✅ 実走済 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)