### PR TITLE
TUI/web: #276 Phase B (2/5) — answer_intervention WS message type

### DIFF
--- a/src/reyn/chat/tui/ws_client.py
+++ b/src/reyn/chat/tui/ws_client.py
@@ -101,6 +101,28 @@ class _WSSessionProxy:
         """
         self._intervention_listener_id = listener_id
 
+    async def _maybe_answer_oldest_intervention(self, text: str) -> None:
+        """Issue #276 Phase B (2/5): send an ``answer_intervention`` WS frame.
+
+        Mirrors :py:meth:`ChatSession._maybe_answer_oldest_intervention`
+        from the TUI's intervention-widget callback path: when the
+        user clicks a chip or types a free-text answer, the widget's
+        ``answer_callback`` calls this with the chosen string.
+        Server-side handler resolves the head intervention + delivers
+        the answer via the existing
+        ``InterventionHandler.maybe_answer`` path; the matching
+        choice-vs-text dispatch is identical to local mode. Status
+        flows back as the next outbox frame.
+
+        Without this method the TUI's ``_mount_intervention``
+        callback raised ``AttributeError`` in remote mode when the
+        user clicked a chip or submitted a free-text answer (= Phase
+        A regression caught during Phase B answer testing). Returns
+        ``None`` — authoritative outcome arrives as a server-side
+        outbox frame.
+        """
+        await self._send_fn({"type": "answer_intervention", "text": text})
+
     async def cancel_inflight(self) -> None:
         """Issue #276 Phase B: send a ``cancel_inflight`` WS frame.
 

--- a/src/reyn/web/ws/chat.py
+++ b/src/reyn/web/ws/chat.py
@@ -209,12 +209,54 @@ async def ws_chat(websocket: WebSocket, agent_name: str) -> None:
                         "cancelled_plans": cancelled_plans,
                     },
                 }))
+            elif msg_type == "answer_intervention":
+                # Issue #276 Phase B (2/5): remote intervention answer.
+                # The TUI in ``--connect`` mode routes intervention-
+                # widget answer_callback → proxy → here. Server runs
+                # ``session._maybe_answer_oldest_intervention(text)``
+                # which dispatches via the existing
+                # ``InterventionHandler.maybe_answer`` (= matches
+                # chip-button labels + free-text against the head
+                # pending intervention's choices, same as local TUI).
+                text = str(payload.get("text", "")).strip()
+                if not text:
+                    await websocket.send_text(json.dumps({
+                        "kind": "error",
+                        "text": "answer_intervention requires non-empty 'text'.",
+                        "meta": {},
+                    }))
+                    continue
+                try:
+                    answered = await session._maybe_answer_oldest_intervention(
+                        text,
+                    )
+                except Exception as exc:
+                    logger.exception("answer_intervention failed")
+                    await websocket.send_text(json.dumps({
+                        "kind": "error",
+                        "text": f"answer_intervention failed: {exc}",
+                        "meta": {},
+                    }))
+                    continue
+                if not answered:
+                    # No pending intervention matched. Local
+                    # ``_maybe_answer_oldest_intervention`` returns
+                    # False silently when there's nothing to answer
+                    # (= user typed text without an active prompt);
+                    # we surface a status frame in the remote case
+                    # so the conv pane gets explicit feedback.
+                    await websocket.send_text(json.dumps({
+                        "kind": "status",
+                        "text": "(no pending intervention to answer)",
+                        "meta": {"$answer_ack": True, "answered": False},
+                    }))
             else:
                 # Unknown message type — echo an error but keep the connection.
                 await websocket.send_text(json.dumps({
                     "kind": "error",
                     "text": f"Unknown message type {msg_type!r}. "
-                    "Expected 'user_message' or 'cancel_inflight'.",
+                    "Expected 'user_message', 'cancel_inflight', "
+                    "or 'answer_intervention'.",
                     "meta": {},
                 }))
 

--- a/tests/cli/test_ws_client_phase_b_answer.py
+++ b/tests/cli/test_ws_client_phase_b_answer.py
@@ -1,0 +1,85 @@
+"""Tier 2: ``_WSSessionProxy._maybe_answer_oldest_intervention`` — issue #276 Phase B (2/5).
+
+Pins the wire-protocol shape for the answer-intervention path. The
+TUI's ``_mount_intervention`` callback path calls
+``session._maybe_answer_oldest_intervention(answer)`` for both chip-
+button labels and free-text answers — the proxy must accept the same
+API + forward over WS.
+
+Spies via a recording async lambda — no ``unittest.mock`` per
+``docs/deep-dives/contributing/testing.ja.md``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.ws_client import _WSSessionProxy
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_answer_intervention_sends_wire_frame() -> None:
+    """Tier 2: ``_maybe_answer_oldest_intervention`` sends
+    ``{"type": "answer_intervention", "text": <answer>}``.
+
+    The server-side handler routes on ``payload["type"]`` so the
+    shape is the load-bearing contract.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    await proxy._maybe_answer_oldest_intervention("Yes")
+
+    assert len(sent) == 1
+    assert sent[0] == {"type": "answer_intervention", "text": "Yes"}
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_answer_intervention_preserves_free_text() -> None:
+    """Tier 2: free-text answers (= not chip labels) pass through
+    verbatim.
+
+    The server's ``_intervention_handler.maybe_answer`` does the
+    chip-label-vs-free-text dispatch (matches against the head
+    intervention's ``choices``); the client just forwards whatever
+    the user typed / clicked. Verifies UTF-8 + whitespace + multi-
+    word strings are not mangled in transit.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    answer = "  はい、 詳細は context.md を見てください  "
+    await proxy._maybe_answer_oldest_intervention(answer)
+
+    assert sent[0]["text"] == answer
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_answer_intervention_returns_none() -> None:
+    """Tier 2: returns ``None`` — actual answer-delivery outcome is
+    async server-side.
+
+    Mirrors the local ``ChatSession._maybe_answer_oldest_intervention``
+    return shape from the *TUI's* point of view: the local method
+    returns bool, but the TUI's ``_mount_intervention`` callback
+    doesn't use the return value (just calls + awaits). The remote
+    proxy matches that effective shape.
+    """
+    async def _noop(_payload: dict) -> None:
+        return None
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_noop)
+    result = await proxy._maybe_answer_oldest_intervention("ok")
+    assert result is None


### PR DESCRIPTION
**[tui-coder]** — Closes #276 Phase B step 2 of 5. Chip-button + free-text intervention answer over WS. Stacked on #333 (= Phase B 1/5).

## Why this is load-bearing

Phase A's ``_mount_intervention._callback`` in ``src/reyn/chat/tui/app.py:323`` calls ``session._maybe_answer_oldest_intervention(answer)`` unconditionally. In ``--connect`` mode the proxy didn't expose the method → ``AttributeError`` when the user clicked a chip / typed a free-text answer to an intervention. Without this PR, the thin client silently crashes on any remote intervention answer.

## Wire-protocol contract

Client → Server:
```json
{"type": "answer_intervention", "text": "Yes"}
```

Server → Client (when no pending intervention matched):
```json
{
  "kind": "status",
  "text": "(no pending intervention to answer)",
  "meta": {"$answer_ack": true, "answered": false}
}
```

When the answer IS delivered (= happy path), the server emits the existing ``intervention_resolved`` outbox frame which the TUI already handles. No new outbox kind needed.

## Files

| layer | change |
|---|---|
| Client (`src/reyn/chat/tui/ws_client.py`) | `_WSSessionProxy._maybe_answer_oldest_intervention(text)` sends `{"type": "answer_intervention", "text": ...}` |
| Server (`src/reyn/web/ws/chat.py`) | new `msg_type == "answer_intervention"` branch — validates non-empty text, calls `session._maybe_answer_oldest_intervention(text)` (= reuses existing local dispatch path), emits status frame on no-match |

## Test plan

- [x] `python -m pytest tests/cli/test_ws_client_phase_a.py tests/cli/test_ws_client_phase_b_cancel.py tests/cli/test_ws_client_phase_b_answer.py` — 18 passed (= 13 Phase A + 2 cancel + 3 answer cases)
- [x] `ruff check` on all modified files — clean (pre-push 実走済)
- [x] (skipped — honest scope narrow) Manual server-side end-to-end with a generated intervention. Requires standing up `reyn web` + a skill that calls `ask_user` + `reyn chat --connect` + clicking the resulting chip. The wire-protocol shape is pinned by the client-side test (= what the server *must* accept); the server-side answer-delivery path reuses the existing local `InterventionHandler.maybe_answer` which is already exercised in local mode.

## Honest scope narrow

End-to-end testing of the answer-delivery happy path needs a real intervention to be generated by the remote agent. That's a multi-step setup (= skill that calls `ask_user` or chip-button prompt) beyond the simple Ctrl+C verification PR 1/5 used. Documenting this as the test-plan skip rather than blocking the PR — the server side reuses the existing local `_maybe_answer_oldest_intervention` path so the dispatch logic is identical to local mode (= already manually verified in local-mode use).

## Stacked PR

Base = `feat/tui-276-phase-b-cancel-inflight` (= #333). Merge after #333 lands.

## Scope guard

**NOT in scope** (= rest of Phase B, separate PRs):
- list_interventions (queued_count surface for the `+N more pending` badge)
- list_agents (`/agents` slash)
- attach_agent (`/attach <name>` slash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)