### PR TITLE
TUI/web: #276 Phase B (3/5) — list_interventions via queued_count meta

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -490,12 +490,27 @@ class OutboxRouter:
         # Best-effort queue depth — the registry owns the canonical count;
         # any failure (no session attached, attribute missing on a stubbed
         # session in tests) falls back to 0 so we never break the mount.
+        #
+        # Issue #276 Phase B (3/5): in ``--connect`` mode the proxy's
+        # ``_interventions`` is None, so the registry-based path below
+        # collapses to 0 even when the remote server has multiple
+        # queued interventions. The WS server inlines ``queued_count``
+        # into the intervention frame's meta (= ``web/ws/chat.py``
+        # ``_serialize`` augmentation) — read from there as a fallback
+        # so the ``+N more pending`` badge stays accurate in remote
+        # mode.
         queued_extra = 0
         try:
             session = self._app._get_session()
             registry = getattr(session, "_interventions", None) if session else None
             if registry is not None:
                 queued_extra = max(0, registry.queued_count() - 1)
+            else:
+                # Remote-mode fallback — meta.queued_count was set by
+                # the WS server forwarder.
+                meta_count = msg.meta.get("queued_count")
+                if isinstance(meta_count, int):
+                    queued_extra = max(0, meta_count - 1)
         except Exception:
             queued_extra = 0
         # Issue #163: prefer the structured ``prompt`` from meta over the

--- a/src/reyn/chat/tui/ws_client.py
+++ b/src/reyn/chat/tui/ws_client.py
@@ -101,6 +101,28 @@ class _WSSessionProxy:
         """
         self._intervention_listener_id = listener_id
 
+    async def _maybe_answer_oldest_intervention(self, text: str) -> None:
+        """Issue #276 Phase B (2/5): send an ``answer_intervention`` WS frame.
+
+        Mirrors :py:meth:`ChatSession._maybe_answer_oldest_intervention`
+        from the TUI's intervention-widget callback path: when the
+        user clicks a chip or types a free-text answer, the widget's
+        ``answer_callback`` calls this with the chosen string.
+        Server-side handler resolves the head intervention + delivers
+        the answer via the existing
+        ``InterventionHandler.maybe_answer`` path; the matching
+        choice-vs-text dispatch is identical to local mode. Status
+        flows back as the next outbox frame.
+
+        Without this method the TUI's ``_mount_intervention``
+        callback raised ``AttributeError`` in remote mode when the
+        user clicked a chip or submitted a free-text answer (= Phase
+        A regression caught during Phase B answer testing). Returns
+        ``None`` — authoritative outcome arrives as a server-side
+        outbox frame.
+        """
+        await self._send_fn({"type": "answer_intervention", "text": text})
+
     async def cancel_inflight(self) -> None:
         """Issue #276 Phase B: send a ``cancel_inflight`` WS frame.
 

--- a/src/reyn/web/ws/chat.py
+++ b/src/reyn/web/ws/chat.py
@@ -209,12 +209,54 @@ async def ws_chat(websocket: WebSocket, agent_name: str) -> None:
                         "cancelled_plans": cancelled_plans,
                     },
                 }))
+            elif msg_type == "answer_intervention":
+                # Issue #276 Phase B (2/5): remote intervention answer.
+                # The TUI in ``--connect`` mode routes intervention-
+                # widget answer_callback → proxy → here. Server runs
+                # ``session._maybe_answer_oldest_intervention(text)``
+                # which dispatches via the existing
+                # ``InterventionHandler.maybe_answer`` (= matches
+                # chip-button labels + free-text against the head
+                # pending intervention's choices, same as local TUI).
+                text = str(payload.get("text", "")).strip()
+                if not text:
+                    await websocket.send_text(json.dumps({
+                        "kind": "error",
+                        "text": "answer_intervention requires non-empty 'text'.",
+                        "meta": {},
+                    }))
+                    continue
+                try:
+                    answered = await session._maybe_answer_oldest_intervention(
+                        text,
+                    )
+                except Exception as exc:
+                    logger.exception("answer_intervention failed")
+                    await websocket.send_text(json.dumps({
+                        "kind": "error",
+                        "text": f"answer_intervention failed: {exc}",
+                        "meta": {},
+                    }))
+                    continue
+                if not answered:
+                    # No pending intervention matched. Local
+                    # ``_maybe_answer_oldest_intervention`` returns
+                    # False silently when there's nothing to answer
+                    # (= user typed text without an active prompt);
+                    # we surface a status frame in the remote case
+                    # so the conv pane gets explicit feedback.
+                    await websocket.send_text(json.dumps({
+                        "kind": "status",
+                        "text": "(no pending intervention to answer)",
+                        "meta": {"$answer_ack": True, "answered": False},
+                    }))
             else:
                 # Unknown message type — echo an error but keep the connection.
                 await websocket.send_text(json.dumps({
                     "kind": "error",
                     "text": f"Unknown message type {msg_type!r}. "
-                    "Expected 'user_message' or 'cancel_inflight'.",
+                    "Expected 'user_message', 'cancel_inflight', "
+                    "or 'answer_intervention'.",
                     "meta": {},
                 }))
 

--- a/src/reyn/web/ws/chat.py
+++ b/src/reyn/web/ws/chat.py
@@ -52,13 +52,33 @@ _FORWARDED_KINDS = frozenset({
 })
 
 
-def _serialize(msg) -> str:
-    """Serialize an OutboxMessage to a JSON string for the WS wire."""
+def _serialize(msg, *, session=None) -> str:
+    """Serialize an OutboxMessage to a JSON string for the WS wire.
+
+    Issue #276 Phase B (3/5): when forwarding a ``kind="intervention"``
+    frame, augment the meta with ``queued_count`` read from the
+    session's ``_interventions`` registry. The TUI in ``--connect``
+    mode has no local registry (= the proxy's ``_interventions`` is
+    ``None``) so its ``+N more pending`` badge collapsed to 0 even
+    when the server held multiple queued items. Inlining the count
+    on the way out keeps the TUI's existing ``meta.queued_count``
+    fallback path (see ``app_outbox._on_intervention``) populated
+    end-to-end without touching the OS-side
+    ``InterventionHandler._iv_meta``.
+    """
+    meta = dict(msg.meta or {})
+    if msg.kind == "intervention" and session is not None:
+        try:
+            registry = getattr(session, "_interventions", None)
+            if registry is not None and "queued_count" not in meta:
+                meta["queued_count"] = registry.queued_count()
+        except Exception:
+            pass
     return json.dumps(
         {
             "kind": msg.kind,
             "text": msg.text,
-            "meta": msg.meta or {},
+            "meta": meta,
         },
         ensure_ascii=False,
     )
@@ -135,7 +155,7 @@ async def ws_chat(websocket: WebSocket, agent_name: str) -> None:
                     pass
                 return
             try:
-                await websocket.send_text(_serialize(msg))
+                await websocket.send_text(_serialize(msg, session=session))
             except Exception:
                 return
 

--- a/tests/cli/test_ws_client_phase_b_answer.py
+++ b/tests/cli/test_ws_client_phase_b_answer.py
@@ -1,0 +1,85 @@
+"""Tier 2: ``_WSSessionProxy._maybe_answer_oldest_intervention`` — issue #276 Phase B (2/5).
+
+Pins the wire-protocol shape for the answer-intervention path. The
+TUI's ``_mount_intervention`` callback path calls
+``session._maybe_answer_oldest_intervention(answer)`` for both chip-
+button labels and free-text answers — the proxy must accept the same
+API + forward over WS.
+
+Spies via a recording async lambda — no ``unittest.mock`` per
+``docs/deep-dives/contributing/testing.ja.md``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.ws_client import _WSSessionProxy
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_answer_intervention_sends_wire_frame() -> None:
+    """Tier 2: ``_maybe_answer_oldest_intervention`` sends
+    ``{"type": "answer_intervention", "text": <answer>}``.
+
+    The server-side handler routes on ``payload["type"]`` so the
+    shape is the load-bearing contract.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    await proxy._maybe_answer_oldest_intervention("Yes")
+
+    assert len(sent) == 1
+    assert sent[0] == {"type": "answer_intervention", "text": "Yes"}
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_answer_intervention_preserves_free_text() -> None:
+    """Tier 2: free-text answers (= not chip labels) pass through
+    verbatim.
+
+    The server's ``_intervention_handler.maybe_answer`` does the
+    chip-label-vs-free-text dispatch (matches against the head
+    intervention's ``choices``); the client just forwards whatever
+    the user typed / clicked. Verifies UTF-8 + whitespace + multi-
+    word strings are not mangled in transit.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    answer = "  はい、 詳細は context.md を見てください  "
+    await proxy._maybe_answer_oldest_intervention(answer)
+
+    assert sent[0]["text"] == answer
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_answer_intervention_returns_none() -> None:
+    """Tier 2: returns ``None`` — actual answer-delivery outcome is
+    async server-side.
+
+    Mirrors the local ``ChatSession._maybe_answer_oldest_intervention``
+    return shape from the *TUI's* point of view: the local method
+    returns bool, but the TUI's ``_mount_intervention`` callback
+    doesn't use the return value (just calls + awaits). The remote
+    proxy matches that effective shape.
+    """
+    async def _noop(_payload: dict) -> None:
+        return None
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_noop)
+    result = await proxy._maybe_answer_oldest_intervention("ok")
+    assert result is None

--- a/tests/web/test_ws_chat_serialize_queued_count.py
+++ b/tests/web/test_ws_chat_serialize_queued_count.py
@@ -1,0 +1,92 @@
+"""Tier 2: ``_serialize`` augments intervention meta with queued_count.
+
+Issue #276 Phase B (3/5). The WS server adds ``queued_count`` to
+forwarded ``kind="intervention"`` frames so the TUI in ``--connect``
+mode can populate its ``+N more pending`` badge from meta when the
+proxy's local ``_interventions`` registry is absent.
+
+Pins the augmentation contract via direct calls to ``_serialize``
+with a stub session — no FastAPI / WebSocket bootstrap needed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+fastapi = pytest.importorskip("fastapi", reason="fastapi not installed")
+from reyn.chat.outbox import OutboxMessage  # noqa: E402
+from reyn.web.ws.chat import _serialize  # noqa: E402
+
+
+class _StubRegistry:
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def queued_count(self) -> int:
+        return self._count
+
+
+class _StubSession:
+    def __init__(self, count: int) -> None:
+        self._interventions = _StubRegistry(count)
+
+
+def test_serialize_intervention_inlines_queued_count_from_session() -> None:
+    """Tier 2: intervention kind + session with registry → meta gains
+    ``queued_count``."""
+    msg = OutboxMessage(
+        kind="intervention",
+        text="Permission request",
+        meta={"intervention_id": "iv-abc", "prompt": "OK?"},
+    )
+    payload = json.loads(_serialize(msg, session=_StubSession(count=3)))
+    assert payload["meta"]["queued_count"] == 3
+    # Existing meta keys preserved.
+    assert payload["meta"]["intervention_id"] == "iv-abc"
+    assert payload["meta"]["prompt"] == "OK?"
+
+
+def test_serialize_non_intervention_kinds_not_augmented() -> None:
+    """Tier 2: ``status`` / ``agent`` / ``error`` etc. don't get the
+    augmentation. The ``queued_count`` field is intervention-specific
+    metadata; spraying it on every frame would bloat the wire +
+    confuse downstream consumers."""
+    for kind in ("status", "agent", "error", "trace"):
+        msg = OutboxMessage(kind=kind, text="x", meta={})
+        payload = json.loads(_serialize(msg, session=_StubSession(count=5)))
+        assert "queued_count" not in payload["meta"], kind
+
+
+def test_serialize_no_session_or_missing_registry_is_noop() -> None:
+    """Tier 2: ``session=None`` or session without ``_interventions``
+    → no augmentation, no crash. Defensive — keeps the WS forwarder
+    robust against test stubs / mid-shutdown sessions."""
+    msg = OutboxMessage(kind="intervention", text="x", meta={})
+    payload_no_session = json.loads(_serialize(msg, session=None))
+    assert "queued_count" not in payload_no_session["meta"]
+
+    class _NoRegistrySession:
+        _interventions = None
+
+    payload_no_reg = json.loads(_serialize(msg, session=_NoRegistrySession()))
+    assert "queued_count" not in payload_no_reg["meta"]
+
+
+def test_serialize_intervention_preserves_caller_supplied_queued_count() -> None:
+    """Tier 2: when the caller already populated ``queued_count`` (e.g.
+    a future OS-side _iv_meta refactor inlines it), the augmentation
+    doesn't overwrite the existing value."""
+    msg = OutboxMessage(
+        kind="intervention",
+        text="x",
+        meta={"queued_count": 7},
+    )
+    payload = json.loads(_serialize(msg, session=_StubSession(count=99)))
+    assert payload["meta"]["queued_count"] == 7


### PR DESCRIPTION
**[tui-coder]** — Closes #276 Phase B step 3 of 5. Restores the ``+N more pending`` badge on remote-mode interventions. Stacked on #334 (= Phase B 2/5).

## What broke in --connect mode

`app_outbox._on_intervention` reads `queued_extra` from `session._interventions.queued_count() - 1`. In remote mode the proxy's `_interventions` is `None`, so the badge always collapsed to 0 even when the server had queued items behind the head intervention. Users with multi-intervention flows lost the "there are more questions waiting" signal.

## Approach (= no new RPC type, no OS-side touch)

Forward the count over the wire by augmenting the meta of existing `intervention` frames.

- **Server side** (`src/reyn/web/ws/chat.py`): `_serialize` gains a session-aware augmentation — for `kind="intervention"` frames it inlines `session._interventions.queued_count()` into `meta.queued_count` (idempotent — preserves caller-supplied values).
- **Client side** (`src/reyn/chat/tui/app_outbox.py`): when the local registry is absent (= remote mode), read `msg.meta.queued_count` as a fallback. Same `max(0, count - 1)` formula as local.

## Files

| layer | change |
|---|---|
| Server (`src/reyn/web/ws/chat.py`) | `_serialize(msg, *, session=None)` augments intervention meta; send-loop passes `session=session` |
| Client (`src/reyn/chat/tui/app_outbox.py`) | `_on_intervention` fallback reads `msg.meta.queued_count` when local registry None |
| Tests (`tests/web/test_ws_chat_serialize_queued_count.py`) | 4 Tier 2 cases |

## Test plan

- [x] `python -m pytest tests/cli/test_ws_client_phase_a.py tests/cli/test_ws_client_phase_b_cancel.py tests/cli/test_ws_client_phase_b_answer.py tests/web/test_ws_chat_serialize_queued_count.py` — 22 passed (= 13 Phase A + 2 cancel + 3 answer + 4 queued_count)
- [x] `ruff check` on all modified files — clean (pre-push 実走済)
- [x] (skipped — honest scope narrow) Manual end-to-end with 2+ concurrent interventions. Requires a server-side skill that calls multiple `ask_user` in quick succession. The augmentation is unit-pinned by the new Tier 2 cases; the TUI fallback path mirrors the local registry path so the badge semantic is identical.

## Why no OS-side change

Considered: extend `_iv_meta` in `intervention_handler.py` to inline `queued_count`. Rejected — that's OS-side and benefits *all* outbox transports (CLI Panel / WS / future SSE), but each transport already has its own queued-count visibility path (CLI uses local registry; WS now uses meta). Keeping the augmentation in the WS forwarder isolates blast radius and avoids touching shared OS surface for a transport-specific UX gap.

## Stacked PR

Base = `feat/tui-276-phase-b-answer-intervention` (= #334). Merge chain: #333 → #334 → this → next 2 PRs.

## Scope guard

**NOT in scope** (= rest of Phase B, separate PRs):
- list_agents (`/agents` slash — agent enumeration)
- attach_agent (`/attach <name>` slash — remote-side agent switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)