### PR TITLE
TUI/web: #276 Phase B (4/4) — slash_command forwarder + attach sync

### DIFF
--- a/src/reyn/chat/tui/ws_client.py
+++ b/src/reyn/chat/tui/ws_client.py
@@ -41,6 +41,16 @@ logger = logging.getLogger(__name__)
 # The TUI's OutboxRouter already dispatches on these.
 _KNOWN_KINDS = frozenset({
     "agent", "status", "error", "intervention", "trace", "skill_done",
+    # Issue #276 Phase B (4/5): ``__attach_request__`` is now
+    # forwarded so the TUI's ``_on_attach_request`` handler can
+    # update the header label + clear the conv pane when a remote
+    # ``/attach`` triggers the server-side swap.
+    "__attach_request__",
+    # ``intervention_resolved`` was always forwarded by the server
+    # via the existing ``status`` / ``intervention`` pipeline — listed
+    # here for explicitness so the parse-time `unknown kind`
+    # diagnostic doesn't fire on it.
+    "intervention_resolved",
 })
 
 
@@ -100,6 +110,30 @@ class _WSSessionProxy:
         registration if needed.
         """
         self._intervention_listener_id = listener_id
+
+    async def _maybe_handle_slash(self, text: str) -> bool:
+        """Issue #276 Phase B (4/5): forward all slash commands to the server.
+
+        The local ``ChatSession._maybe_handle_slash`` dispatches to a
+        registered handler (e.g. ``agents_cmd``, ``attach_cmd``) that
+        reads ``session._registry`` — server-side state the proxy
+        cannot reach locally. Forward the raw command text instead;
+        the server runs the slash handler in its own session context
+        and the resulting ``system`` / ``error`` / ``__attach_request__``
+        outbox frames flow back via the existing forwarding pipeline.
+
+        Without this method ``ReynTUIApp.on_input_bar_user_submitted``
+        crashed with ``AttributeError`` on any slash command in
+        ``--connect`` mode (= Phase A regression caught during
+        Phase B testing).
+
+        Returns ``True`` to match the local API shape (= "slash
+        handled, don't fall through to user_message"). Actual
+        execution is async server-side; the visible result arrives
+        as the next inbound frame.
+        """
+        await self._send_fn({"type": "slash_command", "text": text})
+        return True
 
     async def _maybe_answer_oldest_intervention(self, text: str) -> None:
         """Issue #276 Phase B (2/5): send an ``answer_intervention`` WS frame.

--- a/src/reyn/web/ws/chat.py
+++ b/src/reyn/web/ws/chat.py
@@ -46,9 +46,16 @@ router = APIRouter(tags=["websocket"])
 logger = logging.getLogger(__name__)
 
 # Outbox message kinds we forward verbatim to the WebSocket client.
-# __end__ and __attach_request__ are control signals consumed by the registry.
+# __end__ is a control signal consumed by the registry (= shutdown).
+# __attach_request__ used to be dropped here (= the REPL's registry
+# forwarder consumed it), but the TUI in ``--connect`` mode owns the
+# attached-agent label / conv-clear-on-switch UX (= F13 PR #303's
+# ``_on_attach_request`` handler) and needs the sentinel so the
+# header label + conv pane stay in sync when a remote ``/attach``
+# triggers the server-side swap. Issue #276 Phase B (4/5).
 _FORWARDED_KINDS = frozenset({
     "agent", "status", "error", "intervention", "trace", "skill_done",
+    "__attach_request__",
 })
 
 
@@ -229,6 +236,35 @@ async def ws_chat(websocket: WebSocket, agent_name: str) -> None:
                         "cancelled_plans": cancelled_plans,
                     },
                 }))
+            elif msg_type == "slash_command":
+                # Issue #276 Phase B (4/5): forward all slash commands
+                # (= ``/agents``, ``/attach``, ``/cost``, ``/budget``,
+                # ``/cancel``, etc.) to the server's session. Single
+                # routing — the proxy can't reach
+                # ``session._registry`` directly in remote mode, so
+                # the slash handlers (which read ``_registry`` and
+                # other server-side state) run server-side instead.
+                # Their replies surface naturally via the existing
+                # outbox forwarding (= ``reply`` writes
+                # ``kind="system"`` frames, ``reply_error`` writes
+                # ``kind="error"``, both already forwarded).
+                text = str(payload.get("text", "")).strip()
+                if not text or not text.startswith("/"):
+                    await websocket.send_text(json.dumps({
+                        "kind": "error",
+                        "text": "slash_command requires non-empty 'text' starting with '/'.",
+                        "meta": {},
+                    }))
+                    continue
+                try:
+                    await session._maybe_handle_slash(text)
+                except Exception as exc:
+                    logger.exception("slash_command failed")
+                    await websocket.send_text(json.dumps({
+                        "kind": "error",
+                        "text": f"slash_command failed: {exc}",
+                        "meta": {},
+                    }))
             elif msg_type == "answer_intervention":
                 # Issue #276 Phase B (2/5): remote intervention answer.
                 # The TUI in ``--connect`` mode routes intervention-
@@ -276,7 +312,7 @@ async def ws_chat(websocket: WebSocket, agent_name: str) -> None:
                     "kind": "error",
                     "text": f"Unknown message type {msg_type!r}. "
                     "Expected 'user_message', 'cancel_inflight', "
-                    "or 'answer_intervention'.",
+                    "'answer_intervention', or 'slash_command'.",
                     "meta": {},
                 }))
 

--- a/tests/cli/test_ws_client_phase_b_slash.py
+++ b/tests/cli/test_ws_client_phase_b_slash.py
@@ -1,0 +1,103 @@
+"""Tier 2: ``_WSSessionProxy._maybe_handle_slash`` — issue #276 Phase B (4/5).
+
+Pins the wire-protocol shape for slash-command forwarding. All TUI
+slash commands (``/agents``, ``/attach``, ``/cost``, ``/budget``,
+``/cancel``, ``/list``, ``/memory``, ``/pending``, etc.) run server-
+side in ``--connect`` mode because they read ``session._registry``
+and other server-side state the proxy cannot reach locally.
+
+Spies via a recording async lambda — no ``unittest.mock`` per
+``docs/deep-dives/contributing/testing.ja.md``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.ws_client import _parse_frame, _WSSessionProxy
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_slash_sends_wire_frame() -> None:
+    """Tier 2: ``_maybe_handle_slash`` sends
+    ``{"type": "slash_command", "text": "/<full text>"}``.
+
+    The server-side handler routes on ``payload["type"]`` and runs
+    its session's ``_maybe_handle_slash(text)``, so the raw text
+    (including leading ``/``) is the contract.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    result = await proxy._maybe_handle_slash("/attach research")
+
+    assert sent == [{"type": "slash_command", "text": "/attach research"}]
+    # Local ChatSession returns True when a slash was handled — match
+    # the shape so the TUI dispatch doesn't fall through to
+    # user_message.
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_slash_preserves_args() -> None:
+    """Tier 2: multi-argument slashes pass through verbatim.
+
+    Verifies ``/attach <name with spaces?>`` / ``/budget reset
+    --confirm`` / ``/answer iv-abcd1 yes`` all forward intact so
+    server-side parsing matches local-mode semantics.
+    """
+    sent: list[dict] = []
+
+    async def _recorder(payload: dict) -> None:
+        sent.append(payload)
+
+    proxy = _WSSessionProxy(agent_name="planner", send_fn=_recorder)
+    for cmd in [
+        "/agents",
+        "/attach test-agent_2",
+        "/budget reset",
+        "/answer iv-abcd1 yes please",
+        "/memory list",
+    ]:
+        await proxy._maybe_handle_slash(cmd)
+
+    assert [s["text"] for s in sent] == [
+        "/agents",
+        "/attach test-agent_2",
+        "/budget reset",
+        "/answer iv-abcd1 yes please",
+        "/memory list",
+    ]
+    assert all(s["type"] == "slash_command" for s in sent)
+
+
+def test_parse_frame_passes_through_attach_request() -> None:
+    """Tier 2: ``kind="__attach_request__"`` is a recognised kind —
+    no diagnostic log fires + ``OutboxMessage`` carries ``meta``
+    + ``text`` intact for the TUI's ``_on_attach_request`` handler
+    to consume.
+
+    The server forwards this sentinel kind in remote mode so the
+    TUI header label + conv pane stay in sync when a remote
+    ``/attach`` triggers the server-side swap. Issue #276 Phase B
+    (4/5).
+    """
+    import json as _json
+    frame = _json.dumps({
+        "kind": "__attach_request__",
+        "text": "research",
+        "meta": {},
+    })
+    msg = _parse_frame(frame)
+    assert msg is not None
+    assert msg.kind == "__attach_request__"
+    assert msg.text == "research"


### PR DESCRIPTION
**[tui-coder]** — Closes #276 Phase B step 4 of 4 (= consolidated from planned 5; see "Replaces planned PR 5/5" below). Stacked on #335 (= Phase B 3).

## Why one PR instead of two

The agent's Phase B plan listed `list_agents` + `attach_agent` as separate message types. Empirically those would each require a per-slash forwarder + per-slash response shape. But **all** TUI slash commands that read `session._registry` share the same blocker in remote mode: the proxy doesn't expose `_maybe_handle_slash` → all crash with `AttributeError`.

Single `slash_command` forwarder unlocks all of them — `/agents`, `/attach`, `/budget`, `/cancel`, `/list`, `/memory`, `/pending`, `/skill`, `/plan`, `/cost`, `/skills`, `/tasks`, `/answer`, `/agent`, `/expand`, `/copy`, `/help`, etc. — because the server-side `session._maybe_handle_slash(text)` is the same dispatch local TUI calls. Highest-leverage Phase B change.

## Wire-protocol contract

Client → Server:
```json
{"type": "slash_command", "text": "/attach research"}
```

Server runs `session._maybe_handle_slash(text)`; the slash handlers' replies flow back via existing `system` / `error` outbox forwarding. `__attach_request__` outbox kind is now forwarded so the TUI's F13 `_on_attach_request` handler can update the header label + clear the conv pane on agent switch.

## Files

| layer | change |
|---|---|
| Server (`src/reyn/web/ws/chat.py`) | new `slash_command` branch + `__attach_request__` added to `_FORWARDED_KINDS` |
| Client (`src/reyn/chat/tui/ws_client.py`) | `_WSSessionProxy._maybe_handle_slash(text)` forwards + returns True; `_KNOWN_KINDS` adds `__attach_request__` + `intervention_resolved` for explicit pass-through |
| Tests (`tests/cli/test_ws_client_phase_b_slash.py`) | 3 Tier 2 cases |

## Test plan

- [x] `python -m pytest tests/cli/test_ws_client_phase_a.py tests/cli/test_ws_client_phase_b_*.py tests/web/test_ws_chat_serialize_queued_count.py` — 25 passed
- [x] `ruff check` — clean (pre-push 実走済)
- [x] (skipped — honest scope narrow) Manual end-to-end of every slash in `--connect` mode (`/agents`, `/attach`, `/budget`, …). The wire shape is pinned; server uses the same `_maybe_handle_slash` dispatch as local. F13's existing TUI handler exercises the new `__attach_request__` forwarding (already verified in local-mode use).

## Replaces planned PR 5/5

This PR consolidates `list_agents` + `attach_agent` into a single `slash_command` forwarder. PR 5/5 of the original Phase B plan is no longer needed — slash routing covers both. **Phase B closes at 4 PRs** (cancel + answer + list_interventions + this).

## Phase B chain

```
main
  ← #333 (cancel_inflight) ← #334 (answer_intervention) ← #335 (list_interventions) ← this (slash_command + attach)
```

Merge sequentially top-to-bottom.

## Scope guard

**NOT in scope** (= Phase C, separate landing):
- Right panel data sources — scoped disable v1 per owner decision, already in place via `remote_mode` Pending tab + similar paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)