### PR TITLE
TUI: remove dual completion marker on skill done (SK1)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -575,19 +575,16 @@ class ReynTUIApp(App):
             if status != "finished":
                 self.set_title_state("error")
                 self.alert()
-            # Issue 2 — dim completion line in conversation log
-            _existing = self._skill_exec.get(run_id) or {}
-            _elapsed = _now_monotonic() - _existing.get("start_time", _now_monotonic())
-            _sname = _existing.get("skill_name") or skill_name or run_id
-            from rich.text import Text as _RichText
-            _note = _RichText()
-            _icon = "✓" if status == "finished" else "✗"
-            _color = "#447744" if status == "finished" else "#884444"
-            _note.append(
-                f"{_icon} {_sname}: {status} ({_elapsed:.0f}s)",
-                style=f"dim {_color}",
-            )
-            conv._write_log(_note)
+            # Wave-3 SK1: previously a second ``conv._write_log`` line
+            # ``✓ skill_name: finished (Xs)`` was emitted here, but
+            # ``SkillActivityRow._build_finished`` (= the row the
+            # ``finish_skill_row`` call above transitions) already
+            # renders ``✓ skill#abcd  · Ns  · Ctrl+B → agents`` /
+            # ``✗ skill#abcd  · failed: …`` in-pane. The dual marker
+            # cluttered the conv log with redundant lines. Drop the
+            # ``_write_log`` block; book-keeping (= ``_skill_exec``
+            # pop + ``_push_exec_state`` + ``_last_focal_tab``)
+            # stays.
             self._skill_exec.pop(run_id, None)
             self._push_exec_state()
             self._last_focal_tab = "agents"


### PR DESCRIPTION
**[tui-coder]** — Wave-3 finding SK1 (P2/S/score=2.0). 2 of 6 planned wave-3 PRs.

## Observation

`skill done: <status>` outbox trace triggered BOTH:
1. `conv.finish_skill_row(run_id, success=..., reason="")` — transitions the SkillActivityRow widget to its `✓ skill#abcd · Ns · Ctrl+B → agents` / `✗ skill#abcd · failed: …` final state.
2. `conv._write_log(_note)` — emits a SEPARATE dim `✓ skill_name: finished (Xs)` line directly into the conv log.

Two overlapping completion signals for the same event in the same pane = visual clutter.

## Fix

Drop the redundant `_write_log` block (`app.py:578-590` of the `"skill done: "` branch). The SkillActivityRow already renders the ✓ / ✗ icon + elapsed.

Keep: book-keeping (`_skill_exec.pop`, `_push_exec_state`, `_last_focal_tab = "agents"`) and the attention-grabbing pieces (`set_title_state("error")` + `alert()` on non-finished status).

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | `_handle_trace_for_skill_row` `"skill done:"` branch — drop the dim `_note` block; keep book-keeping + non-finished alert |

## Test plan

- [x] Manual: tmux MCP — `OPENAI_API_KEY=dummy reyn chat` → plan-mode prompt (`tell me about clouds in 2 sentences`) → plan completes → conv log shows only `plan complete: 2/2 steps succeeded · ...` + agent reply; the previous dim `✓ direct_llm: finished (Xs)` line is gone.
- [x] `ruff check src/reyn/chat/tui/app.py` — clean (pre-push 実走済).
- [x] (skipped — Tier 4 risk) Automated test pinning the absence of the dim line — UX formatting that should stay free to tweak.

## Scope guard

**NOT in scope**:
- SK2 (`reason=""` always passed — phase count hint suppressed) — separate finding in wave-3, planned as next PR. This PR keeps the `reason=""` call intact; SK2 will pass `f"{visits} phase{'s' if visits != 1 else ''}"` instead.
- SK5 (stale-spinner detection) — separate, M cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)