### PR TITLE
TUI: bump panel min-width 36 → 44 for 7-tab bar (SP1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -74,6 +74,7 @@ class RightPanel(Widget):
     RightPanel {
         display: none;
         width: 33%;
+        min-width: 44;
         background: #111111;
         layout: vertical;
         height: 100%;
@@ -335,15 +336,21 @@ class RightPanel(Widget):
         if self._panel_width == 0:
             self._panel_width = self.size.width or 40
         max_width = self._max_panel_width()
-        # Min width is sized so the full 6-tab bar
-        # (Keys/Events/Agents/Memory/Cost/Docs ≈ 36 cells incl. margins)
-        # always fits. Below this the Textual Tabs widget silently scrolls
-        # the right-most tabs out of view with no overflow marker, leaving
-        # the user no way to tell which tabs exist by glancing at the
-        # bar — Ctrl+W still cycles them but the visible set was a
-        # misleading subset. Bumped from 24 → 36 to guarantee the bar
-        # acts as a complete navigation surface at every width.
-        _MIN_WIDTH = 36
+        # Min width is sized so the full 7-tab bar
+        # (Keys/Events/Agents/Memory/Cost/Docs/Pending ≈ 44 cells incl.
+        # margins) always fits. Below this the Textual Tabs widget
+        # silently scrolls the right-most tabs out of view with no
+        # overflow marker, leaving the user no way to tell which tabs
+        # exist by glancing at the bar — Ctrl+W still cycles them but
+        # the visible set is a misleading subset.
+        #
+        # Bump history:
+        # - 24 → 36 (6 tabs era: Keys/Events/Agents/Memory/Cost/Docs)
+        # - 36 → 44 (= wave-3 SP1, 7-tab era: + Pending from issue #277)
+        #   At 36 cells, "Pending" truncated to "Pend…" or scrolled
+        #   out entirely at the default 33%-width panel; bumping to 44
+        #   guarantees the full label fits with the new tab.
+        _MIN_WIDTH = 44
         new_width = max(_MIN_WIDTH, min(max_width, self._panel_width + delta))
         # Flash the new width in the conv sticky bar so the user sees
         # something changed (and learns the bounds via the at-min /


### PR DESCRIPTION
**[tui-coder]** — Wave-3 finding SP1 (P2/S/score=2.0). 3 of 6 planned wave-3 PRs.

## Observation

The right panel had `_MIN_WIDTH = 36` sized for the 6-tab era (Keys/Events/Agents/Memory/Cost/Docs). Issue #277 added Pending as the 7th tab — total required width ≈ 44 cells. At 36 the "Pending" tab truncated to "Pendi…" / "Pend" / scrolled out silently with no overflow marker, leaving the user no way to tell the tab existed.

## Fix

Two changes:
- `_MIN_WIDTH = 36` → `44` in `_panel_resize` (= h/l manual resize lower bound)
- CSS `RightPanel { min-width: 44 }` so CSS default `width: 33%` is also clamped on narrow terminals (otherwise 33 % of a 100-col terminal = 33 cells, below the 7-tab floor before any user resize)

## Visual

Before (100-col term, default 33% panel = ~33 cells):
```
│Keys Events Agents Memory Cost D
```

After (`min-width: 44` clamps default):
```
│Keys Events Agents Memory Cost Docs Pending
```

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/right_panel/__init__.py` | `_MIN_WIDTH` 36 → 44 + CSS `min-width: 44` |

## Test plan

- [x] Manual: tmux MCP — narrow term (100x30) → `reyn chat` → Ctrl+B → all 7 tabs `Keys Events Agents Memory Cost Docs Pending` visible without truncation. Previously bar was clipped at "Cost D" at the column boundary.
- [x] `ruff check` — clean (pre-push 実走済).
- [x] `grep -rn "_MIN_WIDTH" tests/` — 0 hits, no test pins prior 36.

## Scope guard

**NOT in scope**:
- SP2 (overflow marker for when panel is below min-width via some other constraint) — separate finding, P2/M.
- SP3 (tab header hint truncate `space=ope` / `d=discar`) — separate, P3/S.

🤖 Generated with [Claude Code](https://claude.com/claude-code)