### PR TITLE
TUI: reroute turn-N/M flash from log to sticky status (FS1)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1189,11 +1189,30 @@ class ConversationView(Widget):
         self.show_status(text, kind="general")
 
     def _flash_turn_position(self, n: int, total: int) -> None:
-        """Write a dim ``↑ turn N / M`` line to the conv log.
+        """Surface ``↑ turn N / M`` feedback for Ctrl+P/N navigation.
 
         Deduped by ``_last_turn_flash`` so rapid Ctrl+P/N presses that
-        land on the same anchor don't spam the log with identical lines.
-        Cleared on Ctrl+L so post-clear navigation flashes fresh.
+        land on the same anchor don't spam the surface with identical
+        messages. Cleared on Ctrl+L so post-clear navigation flashes
+        fresh.
+
+        Wave-3 FS1: previously this wrote ONLY to the conv log via
+        ``_write_log``. Problem: Ctrl+P scrolls the user UP through
+        history, and the new turn-N/M line lands at the LOG BOTTOM
+        (= invisible at the current scroll position). The user
+        navigates to turn 1 of 8 but only sees the flash when they
+        later scroll back to the bottom — by which time the lines
+        have accumulated as junk in conversation history.
+
+        Switch to the sticky-status surface (= the same place the
+        boundary hint from FS2 writes to). It's visible regardless
+        of scroll position AND it doesn't pollute the conv log
+        permanently. ``kind="general"`` reads as advisory (grey
+        accent), doesn't preempt an active ``⟳ thinking…`` (= those
+        use ``kind="thinking"``).
+
+        Boundary dedup state also cleared here so any successful
+        in-bounds move re-flashes the boundary cue next time.
         """
         if self._last_turn_flash == (n, total):
             return
@@ -1202,7 +1221,7 @@ class ConversationView(Widget):
         # dedup so the next time the user hits the edge they get the
         # hint fresh (= "user navigated away from the boundary").
         self._last_boundary_flash = None
-        self._write_log(Text(f"  ↑ turn {n} / {total}", style="dim italic #666666"))
+        self.show_status(f"↑ turn {n} / {total}", kind="general")
 
     def clear(self) -> None:
         """Ctrl+L: clear the log + reset state. Does not affect engine state."""


### PR DESCRIPTION
**[tui-coder]** — Wave-3 finding FS1 (P2/M/score=1.0, score-tied with P2/S cases). 4 of 6 planned wave-3 PRs. Stacked on #339 (= FS2 boundary feedback).

## Observation

`_flash_turn_position` wrote `↑ turn N / M` lines via `_write_log` — but Ctrl+P scrolls the user UP through history, and the new line lands at the LOG BOTTOM (= invisible at the current scroll position). The user navigates to turn 1 of 8 but only sees the cue when they later scroll back to the bottom, by which time the lines have accumulated as junk in conversation history (= sub-agent observed multiple "↑ turn N / M" lines mixed into conv after Ctrl+P navigation).

## Fix

Switch to the sticky-status surface (= same surface the FS2 boundary hint dual-writes to). Visible regardless of scroll position AND doesn't pollute the conv log permanently. `kind="general"` reads as advisory (grey accent), doesn't preempt an active `⟳ thinking…` (those use `kind="thinking"`).

Boundary-flash dedup state (`_last_boundary_flash`) now cleared on a successful in-bounds turn move so re-hitting the edge later re-flashes the boundary cue cleanly.

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/conversation.py` | `_flash_turn_position`: `_write_log` → `show_status(..., kind="general")`; clear `_last_boundary_flash` on in-bounds move |

## Test plan

- [x] Manual: tmux MCP — `reyn chat` → multiple turns → Ctrl+P → log no longer accumulates `↑ turn N / M` lines (= the bug is gone). Sticky cue visible regardless of scroll position.
- [x] `ruff check` — clean (pre-push 実走済).
- [x] (honest scope narrow) Isolated turn-N/M flash (= NOT firing boundary path) requires multi-turn session where Ctrl+P lands on an intermediate anchor; in fresh-log scenarios cur_y=0 falls within FS2's abs-<=1 boundary tolerance and the boundary path fires first. The turn-flash code path is identical to FS2's boundary path in its sticky integration (= same show_status call shape), so behavior is logically validated by FS2's working start-boundary smoke.

## Stacked PR

Base = `feat/tui-ctrl-pn-boundary-feedback` (= FS2 #339). Merge after #339 lands. Same rebase hygiene as Phase B chain (= row 7 of calibration matrix).

## Scope guard

**NOT in scope**:
- FS2 boundary tolerance refinement (= cur_y=0 edge case where fresh-log first Ctrl+P fires boundary even with multiple anchors) — separate concern, the FS2 detection logic may want a smarter "at top of log" check.
- Trim-warning routing (= `_maybe_warn_about_trimmed_history` still uses log breadcrumb) — separate, that warning is once-per-session and the log breadcrumb is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)