### PR TITLE
TUI: pass phase-visit count as finish_skill_row reason (SK2)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -566,7 +566,24 @@ class ReynTUIApp(App):
             # ChatEventForwarder now forwards workflow_finished / workflow_aborted
             # as "skill done: <status>" so the row can stop spinning here.
             status = text[len("skill done: "):].strip()
-            conv.finish_skill_row(run_id, success=(status == "finished"), reason="")
+            # Wave-3 SK2: pass the phase-visit count as ``reason`` so
+            # ``SkillActivityRow._build_finished`` renders the
+            # ``· N phase(s)`` suffix. Previously hard-coded
+            # ``reason=""`` suppressed the suffix entirely; the
+            # widget already supports the conditional render but had
+            # no caller setting the value. Read from
+            # ``_skill_exec`` which the ``phase started:`` branch
+            # populates throughout the run.
+            _visits = int(
+                (self._skill_exec.get(run_id) or {}).get("phase_visits", 0)
+            )
+            _reason = (
+                f"{_visits} phase{'s' if _visits != 1 else ''}"
+                if _visits > 0 else ""
+            )
+            conv.finish_skill_row(
+                run_id, success=(status == "finished"), reason=_reason,
+            )
             # Out-of-band: an aborted skill is an attention case — flash the
             # title to "error" and ring the bell so a user with reyn in a
             # background tab sees something happened. Successful finishes


### PR DESCRIPTION
**[tui-coder]** — Wave-3 finding SK2 (P3/S/score=1.0). 5 of 6 planned wave-3 PRs.

## Observation

`SkillActivityRow._build_finished` already renders `· {reason}` when reason is non-empty (design = `· N phases`), but every `skill done:` handler in `app._handle_trace_for_skill_row` called `finish_skill_row(run_id, success=..., reason="")` — unconditionally empty. The phase-count suffix was never shown.

## Fix

Read `phase_visits` from `_skill_exec[run_id]` (populated by the `phase started:` branch as the skill progresses) and pass it as the reason:

```
✓ skill#abcd  · 4.2s  · 3 phases   Ctrl+B → agents
```

Edge: `phase_visits = 0` → empty reason, original behaviour preserved (defensive against synthesised `workflow_finished` traces with no phase events).

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | `_handle_trace_for_skill_row` "skill done:" branch — compute `_reason` from `_skill_exec[run_id].phase_visits`, pass to `finish_skill_row` |

## Test plan

- [x] `ruff check` — clean (pre-push 実走済).
- [x] (skipped — manual visual ineffective on single-phase) The suffix only shows for multi-phase runs (`chat_compactor`, plan_step skills); single-phase gives `"1 phase"`, visits=0 gives empty. The conditional render is in the widget (= already exercised by existing tests); this PR flips the caller to pass a non-empty value when available.

## Scope guard

**NOT in scope**:
- SK1 (dual completion marker) — separate PR #340 in wave-3, removes the redundant `_write_log` block after this `finish_skill_row` call. Both are independent edits to the same `"skill done:"` branch; either can merge first.
- SK3 (elapsed seconds format mismatch) — separate, P3/S.

🤖 Generated with [Claude Code](https://claude.com/claude-code)