### PR TITLE
TUI: Ctrl+B auto-focuses panel tabs (PC1)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -955,6 +955,19 @@ class ReynTUIApp(App):
                     panel.set_panel_type(self._last_focal_tab)
                 except Exception:
                     pass
+            # Wave-4 PC1: auto-focus the panel tabs so ``j`` / ``k`` /
+            # ``space`` etc. immediately drive the panel's cursor +
+            # preview, not the input bar. Previously the user had to
+            # press Ctrl+B then Ctrl+O to start navigating — pressing
+            # ``j`` after Ctrl+B alone inserted a literal "j" into
+            # the input box. The close path's focus-rescue already
+            # restores input focus when Ctrl+B closes the panel, so
+            # the peek-while-typing flow stays intact (= Ctrl+B opens,
+            # Ctrl+B closes, focus returns, text preserved).
+            try:
+                panel.focus_tabs()
+            except Exception:
+                pass
         else:
             # Closing: rescue focus if it lives inside the panel.
             focused = self.focused

--- a/tests/cli/test_focus_restore.py
+++ b/tests/cli/test_focus_restore.py
@@ -58,10 +58,10 @@ async def test_escape_from_right_panel_focuses_input() -> None:
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
 
-        # Open the panel + focus it
-        await pilot.press("ctrl+b")     # toggle visible
-        await pilot.pause()
-        await pilot.press("ctrl+o")     # focus into the panel
+        # Open the panel — PC1 (PR #345): Ctrl+B now auto-focuses
+        # panel tabs on open, so the separate Ctrl+O hop is no longer
+        # part of the setup. See ``action_toggle_panel`` in app.py.
+        await pilot.press("ctrl+b")
         await pilot.pause()
 
         # Sanity: focus is no longer on the input TextArea


### PR DESCRIPTION
**[tui-coder]** — Wave-4 finding PC1 (P2/S/score=2.0). 1 of 8 planned wave-4 PRs.

## Observation

Pressing Ctrl+B opened the panel but kept keyboard focus on the input bar — `j` / `k` / `space` went to the TextArea as literal characters instead of driving the panel cursor. The user had to press Ctrl+B then Ctrl+O before the panel keys worked. Mental-model mismatch: in most chat clients Ctrl+B opens AND focuses a sidebar.

## Fix

Call `panel.focus_tabs()` after `panel.display = True` in `action_toggle_panel`. The close-path focus rescue already restores input focus when Ctrl+B closes the panel, so peek-while-typing stays intact.

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | `action_toggle_panel` open branch calls `panel.focus_tabs()` |

## Test plan

- [x] Manual: tmux MCP — `reyn chat` → Ctrl+B → press `j` → panel scrolls, no literal "j" in input. Previously `j` went to input.
- [x] `ruff check` — clean (pre-push 実走済).

## Scope guard

**NOT in scope**:
- Ctrl+O semantics change — still works for re-focusing the panel after input gets focus back.
- Conditional auto-focus (= only if input is empty) — kept simple; close-path focus rescue handles peek-while-typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)