### PR TITLE
TUI: history Up jumps past restored multi-line entry (ML4)

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -104,6 +104,13 @@ class InputBar(Widget):
         self._slash_commands: list[SlashCommand] = list(slash_commands or [])
         self._history: list[str] = []
         self._history_idx: int = -1
+        # Wave-4 ML4: track whether the current TextArea contents came
+        # from a history restore + haven't been edited yet. When True,
+        # Up/Down navigate history directly (skipping the line-by-line
+        # cursor walk) so multi-line restored entries don't require
+        # ``row_count`` Up presses to advance one history step.
+        # Cleared on ``TextArea.Changed`` (= user edit).
+        self._restore_pristine: bool = False
 
     def compose(self) -> ComposeResult:
         # Picker docked above TextArea (compose order matters: top-down).
@@ -167,6 +174,11 @@ class InputBar(Widget):
     @on(TextArea.Changed, "#input")
     def on_textarea_changed(self, event: TextArea.Changed) -> None:
         self._update_picker(event.text_area.text)
+        # ML4: any text edit clears the restore-pristine flag so the
+        # next Up/Down resumes line-by-line cursor walk (= edit mode).
+        # ``_load_history_entry`` re-sets the flag after this fires,
+        # so restore → flag True flow is preserved.
+        self._restore_pristine = False
 
     # ── action handlers (priority-bound keys) ────────────────────────────────
 
@@ -201,13 +213,26 @@ class InputBar(Widget):
             self._confirm_picker(picker, ta)
 
     def action_key_up(self) -> None:
-        """Up — picker selection if open, else input history at top edge."""
+        """Up — picker selection if open, else input history at top edge.
+
+        Wave-4 ML4: while ``_restore_pristine`` is True (= the current
+        text came from a history restore and hasn't been edited), Up
+        jumps to the previous history entry directly — skipping the
+        line-by-line cursor walk that previously required N Up presses
+        for an N-line restored entry to advance one history step. Any
+        text edit clears the flag (see ``on_textarea_changed``), so
+        once the user starts modifying the restored entry, Up resumes
+        cursor-up navigation within the buffer.
+        """
         picker = self._picker()
         ta = self._textarea()
         if ta is None:
             return
         if picker is not None and picker.visible_ and picker.has_matches:
             picker.move_selection(-1)
+            return
+        if self._restore_pristine:
+            self._history_up(ta)
             return
         row, _ = ta.cursor_location
         if row == 0:
@@ -217,13 +242,21 @@ class InputBar(Widget):
         ta.action_cursor_up()
 
     def action_key_down(self) -> None:
-        """Down — picker selection if open, else input history at bottom edge."""
+        """Down — picker selection if open, else input history at bottom edge.
+
+        Wave-4 ML4 mirror: while ``_restore_pristine`` is True, Down
+        navigates history forward; otherwise it's cursor-down within
+        the buffer.
+        """
         picker = self._picker()
         ta = self._textarea()
         if ta is None:
             return
         if picker is not None and picker.visible_ and picker.has_matches:
             picker.move_selection(+1)
+            return
+        if self._restore_pristine:
+            self._history_down(ta)
             return
         last_row = ta.text.count("\n")
         row, _ = ta.cursor_location
@@ -476,6 +509,15 @@ class InputBar(Widget):
         lines = text.split("\n")
         last_row = len(lines) - 1
         ta.move_cursor((last_row, len(lines[last_row])))
+        # Wave-4 ML4: signal that the buffer now holds a verbatim
+        # history entry. Subsequent Up/Down navigates history while
+        # this flag is set; the first text edit (via
+        # ``on_textarea_changed``) clears it. ``load_text`` above
+        # fires ``TextArea.Changed`` which would normally clear the
+        # flag — but on_textarea_changed runs SYNCHRONOUSLY before
+        # we get here, so setting the flag at this point lands after
+        # the changed-event clear. Tested via tmux smoke.
+        self._restore_pristine = True
 
     # ── hint rendering ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
**[tui-coder]** — Wave-4 finding ML4 (P2/S/score=2.0). 4 of 8 planned wave-4 PRs.

## Observation

After Up restored a 3-line history entry, cursor landed at last row + last col. Subsequent Ups walked cursor row-by-row to row 0, requiring (lines + 1) Up presses to traverse one history step. 5-line entry = 6 Ups to go one step back.

## Fix

Track `_restore_pristine: bool`. Set True in `_load_history_entry`; cleared on `TextArea.Changed` (= user edit). In `action_key_up` / `action_key_down`, when `_restore_pristine` is True, jump directly to history nav (skip cursor-walk).

Edit clears flag → resumes line-by-line cursor nav within the buffer.

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/input_bar.py` | new `_restore_pristine` flag + branch in `action_key_up`/`_down` + set in `_load_history_entry` + clear in `on_textarea_changed` |

## Test plan

- [x] Manual: tmux MCP — submit 3-line entry + 1-line entry → Up × 2 → 2nd Up directly restores 3-line (was 4 Ups pre-fix).
- [x] `python -m pytest tests/cli/test_tui_smoke.py` — 3 passed.
- [x] `ruff check` — clean (pre-push 実走済).

## Scope guard

**NOT in scope**:
- Cursor-position preservation across history nav (= cursor still lands at end of each restored entry per `_load_history_entry` design).
- Pre-edit cursor-arrow detection (= right/left arrow doesn't clear flag yet; only text edits do, which is the simpler semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)