### PR TITLE
TUI: Memory tab HOT NOW always-visible with cold-start placeholder (PC5)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -52,13 +52,17 @@ def render_memory(
     flat_entries: list[Any] = []
     entry_ys: list[int] = []
 
-    # Hot now section (issue #192). Renders only when the list is
-    # populated — keeps the cold-start layout (= no router activity
-    # yet) untouched. Capped at _HOT_LIST_MAX_VISIBLE so a long
-    # ranking doesn't push the SHARED / AGENT entries off the top
-    # of a narrow panel.
+    # Hot now section (issue #192). Always renders the header so the
+    # feature is discoverable on cold-start (= before any router
+    # activity). Wave-4 PC5: previously the entire section was
+    # conditionally hidden when ``hot_list`` was empty, so first-launch
+    # users never learned the section existed. Now the header is
+    # always there + a dim placeholder line when no data, populated
+    # rows once the ARS forwarder emits ``hot_list_updated``.
+    # Capped at _HOT_LIST_MAX_VISIBLE so a long ranking doesn't push
+    # the SHARED / AGENT entries off the top of a narrow panel.
+    lines.append("[bold #ffaa44]  HOT NOW[/]")
     if hot_list:
-        lines.append("[bold #ffaa44]  HOT NOW[/]")
         for entry in hot_list[:_HOT_LIST_MAX_VISIBLE]:
             try:
                 name = str(entry.get("qualified_name", ""))
@@ -76,7 +80,9 @@ def render_memory(
             lines.append(
                 f"[#555555]    … {overflow} more[/]"
             )
-        lines.append("")
+    else:
+        lines.append("[#555555]    (no router activity yet)[/]")
+    lines.append("")
 
     def _render_scope(entries: list, label: str, label_color: str) -> None:
         lines.append(f"[bold {label_color}]  {_esc(label)}[/]")

--- a/tests/cli/test_memory_tab_hot_list.py
+++ b/tests/cli/test_memory_tab_hot_list.py
@@ -37,19 +37,30 @@ def _project_with_empty_memory(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_no_hot_list_omits_hot_now_section(tmp_path):
-    """Tier 2: empty hot_list keeps the existing layout untouched."""
+def test_no_hot_list_shows_placeholder(tmp_path):
+    """Tier 2: empty hot_list still renders the HOT NOW header
+    with a ``(no router activity yet)`` placeholder.
+
+    Wave-4 PC5: the cold-start behavior was changed from "section
+    omitted entirely" to "always-visible section with placeholder"
+    so the feature is discoverable on first launch / before any
+    router activity. Previously the section only appeared after
+    ARS emitted ``hot_list_updated`` for the first time, leaving
+    new users with no idea the feature existed.
+    """
     from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
 
     rendered, _flat, _ys = render_memory(
         _project_with_empty_memory(tmp_path), cursor=0, hot_list=None,
     )
-    assert "HOT NOW" not in rendered
+    assert "HOT NOW" in rendered
+    assert "no router activity yet" in rendered
 
     rendered, _flat, _ys = render_memory(
         _project_with_empty_memory(tmp_path), cursor=0, hot_list=[],
     )
-    assert "HOT NOW" not in rendered
+    assert "HOT NOW" in rendered
+    assert "no router activity yet" in rendered
 
 
 def test_hot_list_renders_qualified_name_and_freq(tmp_path):


### PR DESCRIPTION
**[tui-coder]** — Wave-4 finding PC5 (P3/S/score=1.0). 5 of 7 effective wave-4 PRs (= PC4 dropped per row 5).

## Observation

The HOT NOW section in Memory tab was gated behind `if hot_list:` — empty/never-populated ranking meant the entire section (header + entries) was omitted. First-launch users had no way to learn the feature existed; only appeared after ARS emitted `hot_list_updated` for the first time.

## Fix

Render the header unconditionally + dim placeholder `(no router activity yet)` when empty. Populated rows replace the placeholder once data arrives.

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/right_panel/memory_tab.py` | unconditional `HOT NOW` header + empty-case placeholder branch |
| `tests/cli/test_memory_tab_hot_list.py` | renamed `test_no_hot_list_omits_hot_now_section` → `test_no_hot_list_shows_placeholder`; asserts new contract |

## Test plan

- [x] `python -m pytest tests/cli/test_memory_tab_hot_list.py` — 5 passed.
- [x] `ruff check` — clean (pre-push 実走済).

🤖 Generated with [Claude Code](https://claude.com/claude-code)