### PR TITLE
TUI: PageUp/PageDown keyboard scroll for conv log (AR5)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -102,6 +102,16 @@ class ReynTUIApp(App):
         # dismissing errors. Wave-2 K3.
         Binding("escape", "voice_cancel", "Dismiss / cancel", priority=True, show=False),
         Binding("ctrl+backslash", "screenshot", "Screenshot", priority=True, show=False),
+        # Wave-4 AR5: keyboard scroll for the conv log. RichLog has
+        # ``can_focus=False`` (intentional — prevents inadvertent
+        # focus capture from input), so Textual's default Page
+        # Up/Down don't reach it. Bind at app level + dispatch
+        # through ``conv.scroll_page_up`` / ``scroll_page_down``
+        # without transferring focus, so the user can scroll
+        # back through history with the keyboard alone (= no mouse
+        # required, complement to the existing anchor-based Ctrl+P/N).
+        Binding("pageup", "conv_scroll_page_up", "Scroll up", priority=True, show=False),
+        Binding("pagedown", "conv_scroll_page_down", "Scroll down", priority=True, show=False),
     ]
 
     _REYN_THEME = Theme(
@@ -973,6 +983,28 @@ class ReynTUIApp(App):
         """ctrl+p — scroll the conversation log to the previous agent turn."""
         try:
             self.query_one("#conversation", ConversationView).jump_prev_turn()
+        except Exception:
+            pass
+
+    def action_conv_scroll_page_up(self) -> None:
+        """PageUp — scroll the conv log up one page without changing focus.
+
+        Wave-4 AR5: complements the anchor-based Ctrl+P/N navigation
+        with free-form keyboard scrolling. RichLog has ``can_focus=
+        False`` so Textual's default Page Up doesn't reach it; we
+        dispatch through the conv pane explicitly.
+        """
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.scroll_page_up()
+        except Exception:
+            pass
+
+    def action_conv_scroll_page_down(self) -> None:
+        """PageDown — scroll the conv log down one page without changing focus."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.scroll_page_down()
         except Exception:
             pass
 

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1096,6 +1096,44 @@ class ConversationView(Widget):
             except Exception:
                 pass
 
+    def scroll_page_up(self) -> None:
+        """Scroll the conv log up one page without changing focus.
+
+        Wave-4 AR5: the RichLog has ``can_focus=False`` (intentional —
+        prevents inadvertent focus capture from input), so Textual's
+        default PageUp doesn't reach it. The App's PageUp binding
+        dispatches here to drive ``log.scroll_page_up`` directly.
+        Sets the user-scrolled flag so the scroll watcher doesn't
+        immediately auto-scroll back to the bottom on the next
+        message.
+        """
+        log = self._log()
+        try:
+            log.scroll_page_up(animate=False)
+        except Exception:
+            try:
+                log.scroll_relative(y=-log.size.height, animate=False)
+            except Exception:
+                pass
+        self._user_scrolled = True
+
+    def scroll_page_down(self) -> None:
+        """Scroll the conv log down one page without changing focus."""
+        log = self._log()
+        try:
+            log.scroll_page_down(animate=False)
+        except Exception:
+            try:
+                log.scroll_relative(y=log.size.height, animate=False)
+            except Exception:
+                pass
+        # When we scroll back to the tail, re-arm auto-scroll.
+        try:
+            if log.scroll_y >= log.max_scroll_y - 1:
+                self._user_scrolled = False
+        except Exception:
+            pass
+
     def _jump_to_relative_anchor(self, delta: int) -> None:
         if not self._turn_anchors:
             return


### PR DESCRIPTION
**[tui-coder]** — Wave-4 finding AR5 (P2/M/score=1.0). 6 of 7 effective wave-4 PRs.

## Observation

`ConversationView`'s RichLog has `can_focus=False` (intentional — prevents inadvertent focus capture from input). Textual's default PageUp/PageDown gestures don't reach it. The only keyboard nav into history was Ctrl+P/N (anchor-based, jumps between turn headers, can't stop mid-reply).

## Fix

Add app-level PageUp / PageDown bindings that dispatch through `ConversationView.scroll_page_up` / `scroll_page_down` (new methods) — drives `RichLog.scroll_page_up/_down` (with `scroll_relative` fallback for older Textual) WITHOUT shifting focus to the log.

`scroll_page_up` sets `_user_scrolled = True` so the existing scroll watcher's auto-snap doesn't yank the view back; `scroll_page_down` re-arms `_user_scrolled = False` when the scroll lands at the tail.

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/app.py` | new PageUp/PageDown bindings + action handlers `action_conv_scroll_page_up`/`_down` |
| `src/reyn/chat/tui/widgets/conversation.py` | new `scroll_page_up`/`scroll_page_down` methods |

## Test plan

- [x] `ruff check` — clean (pre-push 実走済).
- [x] (skipped — Textual API smoke) `log.scroll_page_up`/`_down` exist in the Textual version in requirements; try/except + `scroll_relative` fallback handles older Textual gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)