### PR TITLE
TUI: annotate .ja docs with (ja) suffix in Docs tab (PC2)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
@@ -81,10 +81,34 @@ def render_docs(
         lines.append(f"[bold #aaaaaa]  \\[{_esc(label)}][/]")
         for md in groups[section]:
             indent = "    "
-            if file_idx == docs_cursor:
-                lines.append(f"[bold {_CORAL}]{indent}▶ {_esc(md.stem)}[/]")
+            # Wave-4 PC2: stems ending in ``.ja`` (= ``foo.ja.md``)
+            # are Japanese translations of the English doc next to
+            # them. Without distinction the alphabetical sort
+            # interleaves them (``a2a.ja / a2a / care-boundary.ja /
+            # care-boundary / …``), confusing for English-default
+            # users. Annotate the JA stems with a dim ``(ja)``
+            # suffix so the list reads at-a-glance: same alphabetical
+            # order, language identified per row. Avoids a deeper
+            # restructure (= subsection split / filter UI) for the
+            # minimum visible-distinction fix.
+            stem = md.stem
+            if stem.endswith(".ja"):
+                base = stem[:-3]
+                if file_idx == docs_cursor:
+                    lines.append(
+                        f"[bold {_CORAL}]{indent}▶ {_esc(base)}[/]"
+                        f"[dim {_CORAL}]  (ja)[/]"
+                    )
+                else:
+                    lines.append(
+                        f"[#666666]{indent}  {_esc(base)}[/]"
+                        f"[dim #666666]  (ja)[/]"
+                    )
             else:
-                lines.append(f"[#666666]{indent}  {_esc(md.stem)}[/]")
+                if file_idx == docs_cursor:
+                    lines.append(f"[bold {_CORAL}]{indent}▶ {_esc(stem)}[/]")
+                else:
+                    lines.append(f"[#666666]{indent}  {_esc(stem)}[/]")
             file_idx += 1
         lines.append("")
 


### PR DESCRIPTION
**[tui-coder]** — Wave-4 finding PC2 (P3/M/score=0.5). 7 of 7 effective wave-4 PRs — closes the wave.

## Observation

`rglob("*.md")` picks up both English (`a2a.md`) and Japanese (`a2a.ja.md`) Markdown files when no `docs/en/` subdir exists. Alphabetical sort interleaves them — `a2a.ja / a2a / care-boundary.ja / care-boundary / …` — making it tedious for English-default users to scan.

## Fix

Annotate `.ja`-suffixed stems with a dim `(ja)` indicator when rendered:

```
[CONCEPTS]
    a2a
    a2a              (ja)
    care-boundary
    care-boundary    (ja)
```

Preserves cursor navigation order (alphabetical) AND identifies language at-a-glance.

## Trade-off rationale

- ❌ Subsection split (`[CONCEPTS / ja]`) — more invasive, reorders cursor index
- ❌ Hide `.ja` paired with English — loses access to translations
- ❌ Lang filter — needs new filter UI
- ✅ **(ja) annotation** — minimum visible-distinction fix

## Files

| file | change |
|---|---|
| `src/reyn/chat/tui/widgets/right_panel/docs_tab.py` | `render_docs`: detect `.ja` stem suffix, render with `(ja)` annotation |

## Test plan

- [x] `ruff check` — clean (pre-push 実走済).
- [x] `grep -rn "docs_tab|render_docs" tests/` — 0 hits, no tests pin prior format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Wave-4 summary (this is the last PR)

| # | Finding | PR | Status |
|---|---|---|---|
| 1 | PC1 Ctrl+B auto-focus panel | #345 | open |
| 2 | AR1 /expand tail-only render | #346 | open |
| 3 | ML1+ML2 paste handler (bracket + \r\n) | #347 | open |
| 4 | ML4 history Up multi-line jump | #348 | open |
| 5 | PC5 Memory HOT NOW cold-start | #349 | open |
| 6 | AR5 PageUp/PageDown conv scroll | #350 | open |
| 7 | PC2 docs (ja) suffix annotation | this | open |

Dropped per row 5 (= sub-agent claim verify): PC4 (= events tab cursor scroll-into-view — `_scroll_events_into_view` already exists + works in smoke).