### PR TITLE
feat(web_fetch): optional trafilatura extractor backend (closes #355)

### DIFF
--- a/docs/guide/for-users/popular-mcp-servers.md
+++ b/docs/guide/for-users/popular-mcp-servers.md
@@ -32,10 +32,15 @@ Servers covered:
 > With both available, the chat router consistently picks the
 > Reyn-internal op on natural prompts (10/10 in measurement,
 > 2026-05-21). The MCP servers don't get exercised through the
-> agent path. Use them via direct calls (`scripts/mcp_smoke.py`)
-> or, for filesystem, the `read_local_files` stdlib skill, if you
-> have a specific need (e.g. trafilatura extraction quality for
-> fetch, or a sandboxed filesystem root).
+> agent path.
+>
+> **Extraction parity (post-#355)**: install `pip install reyn[fetch]`
+> to add trafilatura as the `web__fetch` HTML extractor — at that
+> point, the Reyn op matches `mcp-server-fetch`'s extraction quality
+> for content-dense pages. The MCP server's remaining advantages are
+> `start_index` pagination (= tracked in #357) and robots.txt
+> awareness. Use direct calls (`scripts/mcp_smoke.py`) or the MCP
+> server itself only if you specifically need those.
 
 > **Chat-history pollution caveat (= issue #352).** If your agent
 > has previously refused a capability (= the LLM said "I cannot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ dev = [
     "mypy",
     "pytest-asyncio>=0.23",
 ]
+fetch = [
+    "trafilatura>=1.8",       # higher-quality HTML extraction for web__fetch (issue #355)
+]
 docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.5",

--- a/src/reyn/op_runtime/web.py
+++ b/src/reyn/op_runtime/web.py
@@ -37,6 +37,31 @@ class _TextExtractor(html.parser.HTMLParser):
         return "\n".join(self._parts)
 
 
+def _extract_html_text(html_content: str) -> tuple[str, str]:
+    """Extract readable text from HTML.
+
+    Tries `trafilatura` (= production-grade extractor, optional `reyn[fetch]`
+    extra) first; falls back to the stdlib `_TextExtractor` when trafilatura
+    is unavailable OR returns no main content. Issue #355.
+
+    Returns ``(text, extractor_name)`` where extractor_name is
+    ``"trafilatura"`` or ``"stdlib"``.
+    """
+    try:
+        import trafilatura
+    except ImportError:
+        trafilatura = None  # type: ignore[assignment]
+
+    if trafilatura is not None:
+        extracted = trafilatura.extract(html_content)
+        if extracted:
+            return extracted, "trafilatura"
+
+    parser = _TextExtractor()
+    parser.feed(html_content)
+    return parser.text(), "stdlib"
+
+
 def _resolve_ssl_verify(ctx: OpContext) -> bool | str:
     """Resolve the SSL verify value for httpx from config + env fallback.
 
@@ -93,11 +118,10 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
     raw = response.text
 
     if "text/html" in content_type:
-        extractor = _TextExtractor()
-        extractor.feed(raw)
-        content = extractor.text()
+        content, extractor_name = _extract_html_text(raw)
     else:
         content = raw
+        extractor_name = "none"
 
     truncated = len(content) > op.max_length
     if truncated:
@@ -109,6 +133,7 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
         status_code=response.status_code,
         content_length=len(content),
         truncated=truncated,
+        extractor=extractor_name,
     )
     return {
         "kind": "web_fetch",
@@ -118,6 +143,7 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
         "content_type": content_type,
         "content": content,
         "truncated": truncated,
+        "extractor": extractor_name,
     }
 
 

--- a/tests/test_web_fetch_extractor_selection.py
+++ b/tests/test_web_fetch_extractor_selection.py
@@ -1,0 +1,219 @@
+"""Tier 2: web_fetch HTML extractor selection (issue #355).
+
+The web_fetch handler picks an HTML extractor at runtime:
+  - `trafilatura` (= optional `reyn[fetch]` extra) when importable AND it
+    returns a non-empty result.
+  - stdlib `_TextExtractor` (= html.parser-based) otherwise.
+
+These tests pin the selection logic + the result envelope shape. They use
+real `_extract_html_text` invocations + a CapturingClient for the
+end-to-end handler tests — no mocks of collaborators.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from reyn.op_runtime.web import _extract_html_text, handle_web_fetch
+from reyn.schemas.models import WebFetchIROp
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _make_ctx() -> Any:
+    """Minimal OpContext for handler tests (no permission gate, no workspace ops)."""
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+
+    class _FakeEventLog:
+        subscribers: list = []
+        def emit(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    class _FakeWorkspace:
+        pass
+
+    return OpContext(
+        workspace=_FakeWorkspace(),  # type: ignore[arg-type]
+        events=_FakeEventLog(),      # type: ignore[arg-type]
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        web_config=None,
+    )
+
+
+class _CapturingHTMLClient:
+    """httpx.AsyncClient drop-in that returns a fixed HTML body."""
+
+    html_body: str = ""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._response = httpx.Response(
+            200,
+            headers={"content-type": "text/html; charset=utf-8"},
+            content=type(self).html_body.encode(),
+            request=httpx.Request("GET", "https://example.com"),
+        )
+
+    async def __aenter__(self) -> "_CapturingHTMLClient":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    async def get(self, url: str) -> httpx.Response:
+        return self._response
+
+
+class _CapturingTextClient:
+    """httpx.AsyncClient drop-in that returns text/plain (= no extractor)."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._response = httpx.Response(
+            200,
+            headers={"content-type": "text/plain"},
+            content=b"hello world",
+            request=httpx.Request("GET", "https://example.com"),
+        )
+
+    async def __aenter__(self) -> "_CapturingTextClient":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    async def get(self, url: str) -> httpx.Response:
+        return self._response
+
+
+# ── _extract_html_text unit tests ──────────────────────────────────────
+
+
+def test_extract_returns_trafilatura_when_available() -> None:
+    """Tier 2: when trafilatura is importable and extracts content, the
+    extractor name reported is "trafilatura".
+
+    Skip the test if trafilatura is not installed in this environment —
+    that path is covered by the fallback test below.
+    """
+    pytest.importorskip("trafilatura")
+    html_body = (
+        "<html><head><title>T</title></head>"
+        "<body><nav>nav</nav>"
+        "<article><p>This is the main article body. " * 10
+        + "It is long enough that trafilatura considers it content.</p></article>"
+        "<footer>footer</footer></body></html>"
+    )
+    text, extractor = _extract_html_text(html_body)
+    assert extractor == "trafilatura"
+    assert "main article body" in text
+    # trafilatura should strip nav/footer boilerplate (= the quality win
+    # over stdlib parser). Pin only the strongest invariant here.
+    assert "nav" not in text or "footer" not in text
+
+
+def test_extract_falls_back_to_stdlib_when_trafilatura_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: when `import trafilatura` raises ImportError, the extractor
+    falls back to the stdlib `_TextExtractor` and reports name "stdlib".
+
+    Simulated by inserting None into sys.modules and clearing any cached
+    real module so the `import trafilatura` line inside `_extract_html_text`
+    raises ImportError on the next call.
+    """
+    monkeypatch.setitem(sys.modules, "trafilatura", None)
+
+    html_body = "<html><body><p>hello</p></body></html>"
+    text, extractor = _extract_html_text(html_body)
+    assert extractor == "stdlib"
+    assert "hello" in text
+
+
+def test_extract_falls_back_to_stdlib_when_trafilatura_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: when trafilatura imports but returns None (= no main content
+    detected, common on tiny / malformed pages), fallback to stdlib.
+
+    Reason: trafilatura is conservative and can refuse to extract from
+    pages it considers "boilerplate-only". The stdlib parser is naive
+    but always returns something — better than empty content.
+    """
+    class _FakeTrafilatura:
+        @staticmethod
+        def extract(html_content: str) -> str | None:
+            return None
+
+    monkeypatch.setitem(sys.modules, "trafilatura", _FakeTrafilatura)
+
+    html_body = "<html><body><p>tiny page</p></body></html>"
+    text, extractor = _extract_html_text(html_body)
+    assert extractor == "stdlib"
+    assert "tiny page" in text
+
+
+# ── handle_web_fetch result envelope tests ─────────────────────────────
+
+
+def test_result_envelope_contains_extractor_field_for_html(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: HTML response → result dict carries `extractor` field with
+    either "trafilatura" or "stdlib" (= one of the two known extractors).
+    """
+    _CapturingHTMLClient.html_body = (
+        "<html><body><p>" + "lorem ipsum dolor sit amet. " * 20 + "</p></body></html>"
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingHTMLClient)
+
+    ctx = _make_ctx()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "ok"
+    assert "extractor" in result
+    assert result["extractor"] in {"trafilatura", "stdlib"}
+
+
+def test_result_envelope_extractor_none_for_non_html(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: non-HTML response (text/plain, application/json, etc.) →
+    `extractor` field is the literal "none" (= no extraction was performed,
+    raw body returned).
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingTextClient)
+
+    ctx = _make_ctx()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["extractor"] == "none"
+    assert result["content"] == "hello world"
+
+
+def test_result_envelope_uses_stdlib_when_trafilatura_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: end-to-end fallback — when trafilatura is unavailable at
+    handler-call time, the result envelope reports `extractor="stdlib"`.
+    """
+    monkeypatch.setitem(sys.modules, "trafilatura", None)
+
+    _CapturingHTMLClient.html_body = "<html><body><p>hello world</p></body></html>"
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingHTMLClient)
+
+    ctx = _make_ctx()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["extractor"] == "stdlib"
+    assert "hello world" in result["content"]


### PR DESCRIPTION
**[e2e-coder]** — closes #355.

## Summary

- \`web__fetch\` op now tries **trafilatura** (= production-grade HTML extractor, the one \`mcp-server-fetch\` ships with) first; falls back to the existing stdlib \`_TextExtractor\` when the optional dep is unavailable OR returns no main content.
- New optional dep: \`pip install reyn[fetch]\` adds \`trafilatura>=1.8\` (= small dep tree, ~3MB).
- Result envelope gains an \`extractor\` field: \`"trafilatura" | "stdlib" | "none"\` so callers / docs can introspect which path ran.

## Why

PR #354 honest-update review (= 2026-05-21 comparative analysis of Reyn ops vs the 3 excluded MCP servers) identified extraction quality as the biggest visible gap. trafilatura strips boilerplate (nav / sidebar / footer) and isolates main content; html.parser-based \`_TextExtractor\` leaves them interleaved. For "fetch a news article and summarise it" workflows the difference is large.

Keeping it optional (= \`[fetch]\` extra) means default \`pip install reyn\` stays light, and users who don't fetch HTML pay nothing for the dep.

## Result envelope change

\`\`\`json
{
  "kind": "web_fetch",
  "url": "...",
  "status": "ok",
  "status_code": 200,
  "content_type": "text/html; charset=utf-8",
  "content": "...",
  "truncated": false,
  "extractor": "trafilatura"  // ← new
}
\`\`\`

- \`"trafilatura"\` — \`reyn[fetch]\` installed AND trafilatura returned content
- \`"stdlib"\` — trafilatura unavailable OR returned None on this page
- \`"none"\` — non-HTML response (raw body returned)

Existing fields are unchanged (= no breaking change).

## Test plan

- [x] \`pytest tests/test_web_fetch_extractor_selection.py\` — 6/6 pass (trafilatura installed in test env)
- [x] \`pytest tests/test_web_fetch_ssl_config.py\` — 10/10 pass (no regression)
- [x] \`pytest -k 'web_fetch or web_search'\` — 60/60 pass
- [x] \`ruff check src/reyn/op_runtime/web.py tests/test_web_fetch_extractor_selection.py\` — clean
- [ ] **Manual**: \`pip install -e .\` (= without \`[fetch]\` extra), \`reyn chat\` "fetch https://example.com" → confirm result["extractor"] == "stdlib"
- [ ] **Manual**: \`pip install -e .[fetch]\`, repeat → confirm result["extractor"] == "trafilatura"

## Docs updated

- \`docs/guide/for-users/popular-mcp-servers.md\` — the "Why no fetch section" callout now says installing \`reyn[fetch]\` brings parity for extraction quality, with remaining gaps (\`start_index\` pagination → #357) flagged.

## Follow-ups (out of scope)

- #356 — \`file__*\` mkdir / mv / stat ops
- #357 — \`web__fetch\` start_index pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)