### PR TITLE
feat(file_op): add mkdir / move / stat sub-operations (closes #356)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -12,7 +12,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 
 | Kind | Purpose | Permission required |
 |------|---------|---------------------|
-| `file` | Read, write, glob, grep, edit, or delete files | `file.<op>` |
+| `file` | Read, write, glob, grep, edit, delete, mkdir, move, or stat files | `file.<op>` |
 | `ask_user` | Pause the phase and ask the user a question | none (always allowed) |
 | `run_skill` | Run another skill as a sub-workflow | none (skill-level decision) |
 | `lint` | Run the DSL linter on a skill directory | none |
@@ -46,7 +46,7 @@ The OS validates the op against its kind's schema, executes it, and returns a re
 
 ## `file`
 
-Sub-operations: `read`, `write`, `edit`, `delete`, `glob`, `grep`, `regenerate_index`.
+Sub-operations: `read`, `write`, `edit`, `delete`, `glob`, `grep`, `regenerate_index`, `mkdir`, `move`, `stat`.
 
 ```json
 {"kind": "file", "op": "read", "path": "src/foo.py"}
@@ -68,7 +68,19 @@ Sub-operations: `read`, `write`, `edit`, `delete`, `glob`, `grep`, `regenerate_i
  "output_path": ".reyn/memory/MEMORY.md",
  "entry_template": "- [{name}]({slug}.md) — {description}",
  "header": "# Memory Index\n\n"}
+
+{"kind": "file", "op": "mkdir", "path": "subdir/nested"}
+
+{"kind": "file", "op": "move", "path": "old.txt", "dest_path": "new.txt"}
+
+{"kind": "file", "op": "stat", "path": "src/foo.py"}
 ```
+
+**`mkdir`** creates a directory under the project. `mkdir -p` semantics — parents are created and the call is idempotent (returns `created: false` when the directory already exists). Raises an error if a non-directory exists at the path. Permission: `file.write`.
+
+**`move`** renames / moves a file or directory. Requires write permission on **both** source (= delete-like) and destination (= write-like). Destination parent directories are created as needed. Returns `status: not_found` if the source does not exist.
+
+**`stat`** returns filesystem metadata for a path: `{size, mtime, ctime, is_dir, is_file, mode}`. Returns `status: not_found` cleanly if the path does not exist. Permission: `file.read`.
 
 **`regenerate_index`** rebuilds a Markdown index from the YAML frontmatter of every `*.md` file under `path`. Fields:
 

--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -1,4 +1,4 @@
-"""file kind handler — read/write/glob/grep/delete/edit/regenerate_index."""
+"""file kind handler — read/write/glob/grep/delete/edit/regenerate_index/mkdir/move/stat."""
 from __future__ import annotations
 
 import re
@@ -11,8 +11,8 @@ from reyn.schemas.models import FileIROp
 from . import register
 from .context import OpContext
 
-_WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index"})
-_READ_OPS = frozenset({"read", "glob", "grep"})
+_WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index", "mkdir", "move"})
+_READ_OPS = frozenset({"read", "glob", "grep", "stat"})
 
 # Max nearby-file suggestions returned on a not_found error. Mirrors the
 # ~8-suggestion shape that invoke_action's UnknownActionError emits so the
@@ -45,8 +45,14 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
             ctx.permission_resolver.require_file_write(
                 ctx.permission_decl, write_target, ctx.skill_name,
             )
+            # move also writes to dest_path — gate both source (= the file
+            # being effectively deleted) and dest (= the file being created).
+            if op.op == "move" and op.dest_path:
+                ctx.permission_resolver.require_file_write(
+                    ctx.permission_decl, op.dest_path, ctx.skill_name,
+                )
         elif op.op in _READ_OPS:
-            # read / glob / grep — gate against read scope
+            # read / glob / grep / stat — gate against read scope
             ctx.permission_resolver.require_file_read(
                 ctx.permission_decl, op.path, ctx.skill_name,
             )
@@ -109,6 +115,56 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
 
     if op.op == "regenerate_index":
         return _execute_regenerate_index(op, ctx)
+
+    if op.op == "mkdir":
+        try:
+            created = ctx.workspace.make_directory(op.path)
+        except FileExistsError as exc:
+            ctx.events.emit("tool_executed", op="mkdir", path=op.path, status="error")
+            return {
+                "kind": "file", "op": "mkdir", "path": op.path,
+                "status": "error", "error": str(exc),
+            }
+        ctx.events.emit("tool_executed", op="mkdir", path=op.path, created=created)
+        return {
+            "kind": "file", "op": "mkdir", "path": op.path,
+            "status": "ok", "created": created,
+        }
+
+    if op.op == "move":
+        if not op.dest_path:
+            return {
+                "kind": "file", "op": "move", "path": op.path,
+                "status": "error", "error": "dest_path is required for move",
+            }
+        moved = ctx.workspace.move_path(op.path, op.dest_path)
+        if not moved:
+            ctx.events.emit("tool_executed", op="move", path=op.path, found=False)
+            return {
+                "kind": "file", "op": "move", "path": op.path,
+                "dest_path": op.dest_path, "status": "not_found",
+                "error": f"source file not found: {op.path}",
+            }
+        ctx.events.emit("tool_executed", op="move", path=op.path, dest_path=op.dest_path)
+        return {
+            "kind": "file", "op": "move", "path": op.path,
+            "dest_path": op.dest_path, "status": "ok", "moved": True,
+        }
+
+    if op.op == "stat":
+        info = ctx.workspace.stat_path(op.path)
+        if info is None:
+            ctx.events.emit("tool_executed", op="stat", path=op.path, found=False)
+            return {
+                "kind": "file", "op": "stat", "path": op.path,
+                "status": "not_found",
+                "error": f"path not found: {op.path}",
+            }
+        ctx.events.emit("tool_executed", op="stat", path=op.path)
+        return {
+            "kind": "file", "op": "stat", "path": op.path,
+            "status": "ok", "info": info,
+        }
 
     raise ValueError(f"unsupported file op: {op.op!r}")
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -214,9 +214,13 @@ class Skill(BaseModel):
 
 class FileIROp(BaseModel):
     kind: Literal["file"]
-    op: Literal["read", "write", "glob", "delete", "grep", "edit", "regenerate_index"]
-    path: str                        # file path for read/write/edit/delete; glob pattern for glob; dir or file for grep; source dir for regenerate_index
+    op: Literal[
+        "read", "write", "glob", "delete", "grep", "edit",
+        "regenerate_index", "mkdir", "move", "stat",
+    ]
+    path: str                        # file path for read/write/edit/delete/stat; glob pattern for glob; dir or file for grep; source dir for regenerate_index; directory path for mkdir; source path for move
     content: str | None = None       # write only
+    dest_path: str | None = None     # move only: destination path
     max_results: int = 50            # glob only: cap on number of matching paths returned
     # read-specific
     offset: int | None = None        # line number to start reading from (0-indexed); None = beginning

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -87,6 +87,63 @@ class Workspace:
             return True
         return False
 
+    def make_directory(self, path_str: str, *, parents: bool = True) -> bool:
+        """Create a directory under the project (issue #356).
+
+        Idempotent: returns True if newly created, False if the directory
+        already existed. Raises FileExistsError if a non-directory
+        (= a regular file) sits at the path. Raises PermissionError via
+        ``_resolve_write`` if the path is outside the project and not
+        explicitly approved.
+        """
+        path = self._resolve_write(path_str)
+        if path.exists():
+            if path.is_dir():
+                return False
+            raise FileExistsError(
+                f"path exists but is not a directory: {path_str!r}"
+            )
+        path.mkdir(parents=parents, exist_ok=False)
+        self._events.emit("workspace_updated", path=str(path))
+        return True
+
+    def move_path(self, src_str: str, dst_str: str) -> bool:
+        """Move / rename a file or directory (issue #356).
+
+        Requires write permission on BOTH source (= effectively a delete)
+        and destination (= effectively a write). Returns True on success,
+        False if the source does not exist.
+        """
+        src = self._resolve_write(src_str)
+        dst = self._resolve_write(dst_str)
+        if not src.exists():
+            return False
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        src.rename(dst)
+        self._events.emit("workspace_updated", path=str(dst))
+        return True
+
+    def stat_path(self, path_str: str) -> dict | None:
+        """Filesystem metadata for a file / directory (issue #356).
+
+        Returns ``None`` if the path does not exist. Otherwise returns a
+        dict with ``size`` (bytes), ``mtime`` / ``ctime`` (epoch seconds,
+        float), ``is_dir``, ``is_file``, and ``mode`` (= octal permissions
+        string, e.g. ``"0o644"``). Gated by ``_resolve_read``.
+        """
+        path = self._resolve_read(path_str)
+        if not path.exists():
+            return None
+        st = path.stat()
+        return {
+            "size": st.st_size,
+            "mtime": st.st_mtime,
+            "ctime": st.st_ctime,
+            "is_dir": path.is_dir(),
+            "is_file": path.is_file(),
+            "mode": oct(st.st_mode & 0o777),
+        }
+
     def glob_files(self, pattern: str, max_results: int = 50) -> list[str]:
         """
         Expand a glob pattern. Relative patterns resolve under base_dir (CWD).

--- a/tests/test_op_runtime_file_mkdir_move_stat.py
+++ b/tests/test_op_runtime_file_mkdir_move_stat.py
@@ -1,0 +1,244 @@
+"""Tier 2: file__ mkdir / move / stat ops (issue #356).
+
+Three new sub-operations on FileIROp:
+
+  - mkdir: idempotent directory creation under write permission.
+  - move:  rename / move; requires write permission on BOTH paths.
+  - stat:  metadata read; requires read permission.
+
+These tests pin both happy-path behaviour AND the permission-gate
+shape (= outside-CWD paths get denied without an explicit grant).
+Uses real Workspace + PermissionResolver — no collaborator mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.op_runtime.context import OpContext
+from reyn.op_runtime.file import handle
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.schemas.models import FileIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    permission_resolver: PermissionResolver | None,
+    permission_decl: PermissionDecl | None = None,
+) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=permission_resolver)
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=permission_decl or PermissionDecl(),
+        permission_resolver=permission_resolver,
+        skill_name="test_skill",
+    )
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── mkdir ──────────────────────────────────────────────────────────────
+
+
+def test_mkdir_creates_new_directory(tmp_path, monkeypatch):
+    """Tier 2: mkdir creates a directory under the default write zone (.reyn/)
+    + reports created=True.
+    """
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="mkdir", path=".reyn/newdir/nested")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["created"] is True
+    assert (tmp_path / ".reyn" / "newdir" / "nested").is_dir()
+
+
+def test_mkdir_is_idempotent_when_dir_already_exists(tmp_path, monkeypatch):
+    """Tier 2: second mkdir on the same path returns created=False (idempotent)."""
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="mkdir", path=".reyn/d")
+    first = _run(handle(op, ctx, "control_ir"))
+    second = _run(handle(op, ctx, "control_ir"))
+
+    assert first["created"] is True
+    assert second["status"] == "ok"
+    assert second["created"] is False
+
+
+def test_mkdir_fails_when_path_is_existing_file(tmp_path, monkeypatch):
+    """Tier 2: mkdir on a path occupied by a regular file returns status=error."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "blocker.txt").write_text("hi")
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="mkdir", path=".reyn/blocker.txt")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "error"
+    assert "not a directory" in result["error"]
+
+
+def test_mkdir_outside_cwd_denied(tmp_path, monkeypatch):
+    """Tier 2: mkdir on an absolute path outside CWD raises PermissionError
+    (= the same write-zone gate as write/edit/delete).
+    """
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="mkdir", path="/tmp/reyn_test_should_be_denied_356")
+    with pytest.raises(PermissionError):
+        _run(handle(op, ctx, "control_ir"))
+
+
+# ── move ───────────────────────────────────────────────────────────────
+
+
+def test_move_renames_existing_file(tmp_path, monkeypatch):
+    """Tier 2: move with both paths under the default write zone (.reyn/)
+    succeeds.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "src.txt").write_text("payload")
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(
+        kind="file", op="move",
+        path=".reyn/src.txt", dest_path=".reyn/dst.txt",
+    )
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["moved"] is True
+    assert not (tmp_path / ".reyn" / "src.txt").exists()
+    assert (tmp_path / ".reyn" / "dst.txt").read_text() == "payload"
+
+
+def test_move_returns_not_found_when_source_missing(tmp_path, monkeypatch):
+    """Tier 2: move on a non-existent source returns status=not_found cleanly."""
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(
+        kind="file", op="move",
+        path=".reyn/missing.txt", dest_path=".reyn/elsewhere.txt",
+    )
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert "not found" in result["error"]
+
+
+def test_move_without_dest_path_errors(tmp_path, monkeypatch):
+    """Tier 2: move requires dest_path; calling without one returns status=error.
+
+    Permission gate runs first and only checks `op.path`, so the missing
+    dest_path bubbles up as an op-level error from the handler (not a
+    permission failure).
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "src.txt").write_text("payload")
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="move", path=".reyn/src.txt")  # no dest_path
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "error"
+    assert "dest_path" in result["error"]
+
+
+def test_move_dest_outside_zone_denied(tmp_path, monkeypatch):
+    """Tier 2: move where dest_path is outside the write zone raises
+    PermissionError — the second write-gate (dest) blocks even when source
+    is allowed.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "src.txt").write_text("payload")
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(
+        kind="file", op="move", path=".reyn/src.txt",
+        dest_path="/tmp/reyn_test_should_be_denied_356.txt",
+    )
+    with pytest.raises(PermissionError):
+        _run(handle(op, ctx, "control_ir"))
+
+
+# ── stat ───────────────────────────────────────────────────────────────
+
+
+def test_stat_returns_metadata_for_existing_file(tmp_path, monkeypatch):
+    """Tier 2: stat on an existing file returns size + timestamps + mode."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("hello")
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="stat", path="f.txt")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    info = result["info"]
+    assert info["size"] == 5
+    assert info["is_file"] is True
+    assert info["is_dir"] is False
+    assert "mtime" in info and "ctime" in info
+    assert info["mode"].startswith("0o")
+
+
+def test_stat_returns_not_found_when_path_missing(tmp_path, monkeypatch):
+    """Tier 2: stat on a missing path returns status=not_found (no exception)."""
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="stat", path="missing.txt")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+
+
+def test_stat_outside_cwd_denied(tmp_path, monkeypatch):
+    """Tier 2: stat on a path outside CWD raises PermissionError (read-gate)."""
+    monkeypatch.chdir(tmp_path)
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="stat", path="/etc/passwd")
+    with pytest.raises(PermissionError):
+        _run(handle(op, ctx, "control_ir"))
+
+
+def test_stat_distinguishes_directory_from_file(tmp_path, monkeypatch):
+    """Tier 2: stat on a directory returns is_dir=True / is_file=False."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "subdir").mkdir()
+    ctx = _make_ctx(tmp_path, permission_resolver=_resolver(tmp_path))
+
+    op = FileIROp(kind="file", op="stat", path="subdir")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["info"]["is_dir"] is True
+    assert result["info"]["is_file"] is False


### PR DESCRIPTION
**[e2e-coder]** — closes #356. Final follow-up from PR #354 honest-update review. With this + #359 (trafilatura) + #360 (start_index), the Reyn op surface reaches parity with the three excluded MCP servers on every gap identified in the 2026-05-21 comparative analysis.

## Summary

Three new \`FileIROp\` sub-operations:

- \`mkdir\` — \`mkdir -p\` semantics, idempotent. Returns \`created: bool\`.
- \`move\` — rename / move. Requires write permission on **both** source and destination.
- \`stat\` — filesystem metadata: size + mtime + ctime + is_dir + is_file + mode.

Previously these were only reachable via the \`shell\` op, which drops out of the file-scope permission system. Now they go through the same \`require_file_write\` / \`require_file_read\` gate as the other file ops.

## Permission gate

\`\`\`text
_WRITE_OPS = {write, edit, delete, regenerate_index, mkdir, move}
_READ_OPS  = {read, glob, grep, stat}
\`\`\`

Move's two-path gate runs before any filesystem mutation:

\`\`\`python
ctx.permission_resolver.require_file_write(decl, op.path, skill)
if op.op == "move" and op.dest_path:
    ctx.permission_resolver.require_file_write(decl, op.dest_path, skill)
\`\`\`

Default write zone (= \`.reyn/\` + \`reyn/\`) unchanged. Paths outside the zone still require explicit declaration in \`permissions.file.write\` — same shape as existing write/edit/delete.

## Test plan

- [x] \`pytest tests/test_op_runtime_file_mkdir_move_stat.py\` — 12/12 pass
- [x] \`pytest tests/test_op_runtime_file_permissions.py tests/test_file_*\` — 90/90 (no regression on existing ops)
- [x] \`ruff check src/reyn/op_runtime/file.py src/reyn/workspace/workspace.py src/reyn/schemas/models.py tests/test_op_runtime_file_mkdir_move_stat.py\` — clean
- [ ] **Manual**: \`reyn chat\` "create a directory called .reyn/foo and stat it" → confirm both ops invoked through dispatch + permission gate logs both events.

## Reference doc

\`docs/reference/runtime/control-ir.md\` § \`file\` updated per CLAUDE.md sync rule. New sub-operations enumerated with example IR blocks.

## Deferred (= out of scope, captured in #356 body)

- \`directory_tree\` — buildable from \`glob\` post-processing today.
- \`list_directory_with_sizes\` — buildable from \`glob\` + per-file \`stat\`.

## Cluster status (post-merge)

| Issue | PR | Status |
|---|---|---|
| #355 trafilatura | #359 | ✓ merged (e6d31b6) |
| #357 start_index | #360 | open (rebase needed post-#359) |
| #356 mkdir/move/stat | this PR | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)