### PR TITLE
feat(mcp): forward image content as multimodal LLM message (closes #362)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -139,6 +139,47 @@ def _strip_frontmatter(content: str) -> str:
     return "\n".join(body_lines).rstrip("\n") + ("\n" if body_lines else "")
 
 
+def _build_media_followup_message(
+    *, tool_name: str, media_blocks: list[dict],
+) -> dict | None:
+    """Build a multimodal follow-up user message for MCP tool results that
+    include image / non-text content blocks (issue #362).
+
+    Strategy (= Option A): after each tool result that carries non-text
+    media, append a synthetic user message containing those media blocks
+    in litellm-normalised shape. Provider-agnostic because user messages
+    with content lists are universally supported (Anthropic, Gemini,
+    OpenAI vision models); a tool message with content list would break
+    OpenAI's tool-message contract.
+
+    Returns None when no image-typed block can be rendered (= other media
+    types like resources are deferred until a real use case appears).
+    """
+    parts: list[dict] = [
+        {"type": "text", "text": f"Tool `{tool_name}` returned the following image(s):"},
+    ]
+    rendered = 0
+    for block in media_blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "image":
+            continue
+        data = block.get("data")
+        mime = block.get("mimeType") or block.get("mime_type") or "image/png"
+        if not isinstance(data, str) or not data:
+            continue
+        # data is base64 per MCP spec. Build a data URL (= litellm /
+        # OpenAI-vision standard wire format).
+        parts.append({
+            "type": "image_url",
+            "image_url": {"url": f"data:{mime};base64,{data}"},
+        })
+        rendered += 1
+    if rendered == 0:
+        return None
+    return {"role": "user", "content": parts}
+
+
 def _is_empty_router_response(response: Any) -> bool:
     """OS-side detection: model emitted no text and no tool calls.
 
@@ -1802,6 +1843,19 @@ class RouterLoop:
                     if isinstance(r, dict) and isinstance(r.get("_post_text"), str):
                         post_text = r["_post_text"]
                         r = {k: v for k, v in r.items() if k != "_post_text"}
+
+                    # Issue #362: extract MCP media blocks (= image, etc.)
+                    # BEFORE JSON-serialising the tool result. The blocks
+                    # would JSON-stringify into the tool message as opaque
+                    # base64 (= wasted tokens) — instead, surface them as a
+                    # multimodal follow-up user message so vision-capable
+                    # models actually see the image. Strip from `r` so the
+                    # tool result text stays compact.
+                    media_blocks: list[dict] = []
+                    if isinstance(r, dict) and isinstance(r.get("media_blocks"), list):
+                        media_blocks = list(r["media_blocks"])
+                        r = {k: v for k, v in r.items() if k != "media_blocks"}
+
                     content_str = json.dumps(r, default=str)
                     if post_text:
                         content_str = f"{content_str}\n\n---\n{post_text}"
@@ -1810,6 +1864,13 @@ class RouterLoop:
                         "tool_call_id": tc["id"],
                         "content": content_str,
                     })
+                    if media_blocks:
+                        followup = _build_media_followup_message(
+                            tool_name=tc.get("function", {}).get("name", "tool"),
+                            media_blocks=media_blocks,
+                        )
+                        if followup is not None:
+                            messages.append(followup)
                 continue
 
             # Option F (ADR-0021): detect empty-stop before treating as text reply.

--- a/src/reyn/op_runtime/mcp.py
+++ b/src/reyn/op_runtime/mcp.py
@@ -99,17 +99,31 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
             item.get("text", "") for item in content_items
             if isinstance(item, dict) and item.get("type") == "text"
         )
+        # Issue #362: preserve non-text content blocks (images, etc.) so the
+        # chat router can forward them to vision-capable models. content_blocks
+        # carries only NON-text items (= image, resource, ...); the text field
+        # above already covers type=="text". Empty list when the result is
+        # text-only — backward-compatible with callers that only read `content`.
+        media_blocks = [
+            item for item in content_items
+            if isinstance(item, dict) and item.get("type") != "text"
+        ]
     else:
         text = str(content_items)
+        media_blocks = []
 
     is_error = bool(result.get("isError"))
-    ctx.events.emit("mcp_completed", server=op.server, tool=op.tool, is_error=is_error)
+    ctx.events.emit(
+        "mcp_completed", server=op.server, tool=op.tool, is_error=is_error,
+        media_block_count=len(media_blocks),
+    )
     return {
         "kind": "mcp",
         "status": "error" if is_error else "ok",
         "server": op.server,
         "tool": op.tool,
         "content": text,
+        "media_blocks": media_blocks,
         "raw": result,
     }
 

--- a/tests/test_mcp_multimodal_forwarding.py
+++ b/tests/test_mcp_multimodal_forwarding.py
@@ -1,0 +1,209 @@
+"""Tier 2: MCP image content → multimodal LLM message (issue #362).
+
+The chat router needs to forward MCP-returned images to vision-capable
+LLMs. The flow has two layers we pin here:
+
+  1. op_runtime/mcp.py — preserves image content blocks in the op result
+     under `media_blocks`, alongside the text-only `content` summary.
+  2. chat/router_loop._build_media_followup_message — converts a list of
+     MCP image blocks into a litellm-normalised user message with
+     data-URL image_url parts.
+
+Real instances, no collaborator mocks. The MCP server is stubbed via a
+minimal client; the LLM layer is not invoked.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.chat.router_loop import _build_media_followup_message
+
+# ── op_runtime/mcp.py: media_blocks preservation ───────────────────────
+
+
+class _FakeMCPClient:
+    """Stand-in for ``reyn.mcp_client.MCPClient`` — returns a canned
+    ``call_tool`` result without spawning a subprocess.
+    """
+
+    def __init__(self, content: list[dict], *, is_error: bool = False) -> None:
+        self._content = content
+        self._is_error = is_error
+
+    async def call_tool(
+        self, name: str, args: dict, *,
+        progress_callback: Any = None, timeout_seconds: Any = None,
+    ) -> dict:
+        return {
+            "content": self._content,
+            "isError": self._is_error,
+            "structuredContent": None,
+        }
+
+
+def _make_ctx(tmp_path, mcp_client: _FakeMCPClient) -> Any:
+    """Build a minimal OpContext that uses the fake client for the test server."""
+    from reyn.events.events import EventLog
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+    from reyn.workspace.workspace import Workspace
+
+    events = EventLog()
+    return OpContext(
+        workspace=Workspace(events=events),
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,  # bypass permission gate
+        mcp_servers={"testsrv": {"type": "stdio", "command": "fake"}},
+        mcp_clients={"testsrv": mcp_client},  # type: ignore[dict-item]
+    )
+
+
+def test_op_result_preserves_image_blocks(tmp_path, monkeypatch):
+    """Tier 2: MCP result with image content → op result's media_blocks
+    carries the image block; text content remains the text-only join.
+    """
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    image_block = {
+        "type": "image",
+        "data": "iVBORw0KGgoAAAANSU=",  # truncated base64 sample
+        "mimeType": "image/png",
+    }
+    text_block = {"type": "text", "text": "screenshot taken"}
+    client = _FakeMCPClient(content=[text_block, image_block])
+    ctx = _make_ctx(tmp_path, client)
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshot", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["status"] == "ok"
+    assert result["content"] == "screenshot taken"
+    assert result["media_blocks"] == [image_block]
+
+
+def test_op_result_text_only_keeps_empty_media_blocks(tmp_path, monkeypatch):
+    """Tier 2: text-only MCP result → media_blocks is an empty list (=
+    backward compat for callers that only read `content`).
+    """
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    client = _FakeMCPClient(content=[{"type": "text", "text": "hello"}])
+    ctx = _make_ctx(tmp_path, client)
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="echo", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["content"] == "hello"
+    assert result["media_blocks"] == []
+
+
+def test_op_result_multiple_images_all_preserved(tmp_path, monkeypatch):
+    """Tier 2: MCP result with multiple image blocks → all preserved in order."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    img1 = {"type": "image", "data": "AAAA", "mimeType": "image/png"}
+    img2 = {"type": "image", "data": "BBBB", "mimeType": "image/jpeg"}
+    client = _FakeMCPClient(content=[img1, img2])
+    ctx = _make_ctx(tmp_path, client)
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshots", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["media_blocks"] == [img1, img2]
+    assert result["content"] == ""  # no text blocks
+
+
+# ── _build_media_followup_message: shape ───────────────────────────────
+
+
+def test_followup_builds_litellm_image_url_format() -> None:
+    """Tier 2: image blocks → user message with image_url parts in
+    data-URL form (= litellm / OpenAI-vision standard wire format).
+    """
+    blocks = [
+        {"type": "image", "data": "AAAA", "mimeType": "image/png"},
+    ]
+    msg = _build_media_followup_message(tool_name="screenshot", media_blocks=blocks)
+
+    assert msg is not None
+    assert msg["role"] == "user"
+    assert isinstance(msg["content"], list)
+    assert msg["content"][0]["type"] == "text"
+    assert "screenshot" in msg["content"][0]["text"]
+    image_part = msg["content"][1]
+    assert image_part["type"] == "image_url"
+    assert image_part["image_url"]["url"] == "data:image/png;base64,AAAA"
+
+
+def test_followup_defaults_mime_type_to_png() -> None:
+    """Tier 2: when an image block omits mimeType, default to image/png."""
+    blocks = [{"type": "image", "data": "XYZ"}]
+    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+
+    assert msg is not None
+    assert msg["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_followup_handles_snake_case_mime_type() -> None:
+    """Tier 2: MCP servers may serialise mimeType as snake_case mime_type
+    (= depending on SDK version); both keys should resolve.
+    """
+    blocks = [{"type": "image", "data": "XYZ", "mime_type": "image/webp"}]
+    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+
+    assert msg is not None
+    assert "data:image/webp;base64,XYZ" in msg["content"][1]["image_url"]["url"]
+
+
+def test_followup_skips_non_image_blocks() -> None:
+    """Tier 2: non-image media blocks (= resources, etc.) are filtered
+    out for now (deferred until a real use case appears). When ALL blocks
+    are skippable, the function returns None so caller doesn't append
+    an empty follow-up.
+    """
+    blocks = [
+        {"type": "resource", "resource": {"uri": "file:///x"}},
+        {"type": "unknown_kind", "data": "..."},
+    ]
+    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+
+    assert msg is None
+
+
+def test_followup_drops_image_block_with_empty_data() -> None:
+    """Tier 2: image block with empty / missing data string is dropped
+    (= protect against malformed server responses).
+    """
+    blocks = [
+        {"type": "image", "data": "", "mimeType": "image/png"},
+        {"type": "image", "mimeType": "image/png"},  # no data key at all
+    ]
+    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+
+    assert msg is None  # both dropped → no usable blocks → no follow-up
+
+
+def test_followup_preserves_block_order() -> None:
+    """Tier 2: multiple image blocks → image_url parts appear in the
+    same order as the input list.
+    """
+    blocks = [
+        {"type": "image", "data": "FIRST", "mimeType": "image/png"},
+        {"type": "image", "data": "SECOND", "mimeType": "image/jpeg"},
+    ]
+    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+
+    assert msg is not None
+    urls = [p["image_url"]["url"] for p in msg["content"] if p["type"] == "image_url"]
+    assert urls == [
+        "data:image/png;base64,FIRST",
+        "data:image/jpeg;base64,SECOND",
+    ]


### PR DESCRIPTION
**[e2e-coder]** — closes #362. Prerequisite for the playwright MCP scenario (= screenshots / \`browser_take_screenshot\` blocked by current text-only flattening at \`op_runtime/mcp.py:96-103\`).

## Summary

- \`op_runtime/mcp.py\`: op result preserves non-text content blocks in a new \`media_blocks: list[dict]\` field. Text path unchanged.
- \`chat/router_loop.py\`: after each tool result that contains image media, append a synthetic \`role: \"user\"\` follow-up message containing the image(s) as litellm-normalised \`image_url\` data-URL parts.
- New module helper \`_build_media_followup_message\` does the shape conversion + filtering.

## Why a synthetic user message (= Option A) over content list in the tool message (= Option B)

Option A:
\`\`\`
assistant → [tool_calls]
tool      → [text-only results, all tool_call_ids]
user      → [synthetic: \"Tool X returned the following image(s):\" + image blocks]
assistant → [next response]
\`\`\`

Option B would put the image inside the tool message as a content list — Anthropic supports this in their tool_result block, but OpenAI's tool-message contract is strictly string-content and would reject it. Option A works across **all** vision-capable providers (Anthropic / Gemini / OpenAI) because user messages with multimodal content are universally supported.

For text-only tools, no follow-up message is appended → message flow is byte-identical to today.

## Test plan

- [x] \`pytest tests/test_mcp_multimodal_forwarding.py\` — 9/9 pass
- [x] \`pytest -k mcp\` — 373/373 (no regression on existing MCP tests)
- [x] \`ruff check\` on touched files — clean
- [ ] **Manual**: \`reyn mcp install --source npm:@playwright/mcp\` + \`reyn chat\` \"take a screenshot of https://example.com and describe what you see\" → expect the assistant to actually describe the page (= vision loop closed).

## Out of scope

- \`resource\` content blocks (= deferred until real use case)
- Audio blocks (= not in current MCP spec)
- Option-B tool-message content list (= provider-specific serialisation, deferred)

## Follow-up

- **playwright MCP scenario** (= the user-facing target this PR enables). Once this lands, document playwright in \`popular-mcp-servers.md\` with the screenshot-driven usage example actually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)