### PR TITLE
fix(tui): harden Events tab Rich markup parsing (defense-in-depth)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -30,6 +30,22 @@ def _truncate_to_cells(s: str, max_cells: int) -> tuple[str, bool]:
         used += w
     return "".join(out_chars), True
 
+
+def _oneline(s: str) -> str:
+    """Collapse any whitespace run (incl. newlines) to a single space.
+
+    Event hints and reply previews land inside a single Rich markup line
+    like ``[#777777]<text>[/]``. An embedded ``\\n`` in ``<text>`` splits
+    that markup across two rendered lines, leaving the closing ``[/]``
+    on its own with no matching open tag — ``Text.from_markup`` raises
+    ``MarkupError`` on the orphan close, the Static fallback returns an
+    empty string, and the entire Events tab goes blank. Collapsing
+    whitespace upstream keeps the rendered output single-line per row.
+    """
+    if not s:
+        return ""
+    return " ".join(s.split())
+
 _EVENT_COLORS: dict[str, str] = {
     "phase_started":               "#44cc88",
     "phase_completed":             "#44cc88",
@@ -584,7 +600,7 @@ def render_events(
         # "2026-05-17T09:54:42…" — the time block lives in chars 11-19
         ts = _esc(raw_ts[11:19] if len(raw_ts) >= 19 else raw_ts)
         color = _EVENT_COLORS.get(ev_type, _DEFAULT_EVENT_COLOR)
-        hint = _esc(_event_hint(ev))
+        hint = _esc(_oneline(_event_hint(ev)))
         hint_part = f"  [#555555]{hint}[/]" if hint else ""
         cursor_prefix = (
             f"[bold {_CORAL}]▶ [/]" if i == cursor else "  "
@@ -605,8 +621,13 @@ def render_events(
                     # ``↳`` line across 2-3 panel rows. 40 cells matches
                     # the ``_event_hint`` cap used elsewhere in this
                     # file and fits the 36-col panel min with the 7-cell
-                    # ``↳`` indent.
-                    truncated, was_truncated = _truncate_to_cells(reply, 40)
+                    # ``↳`` indent. Reply collapses to one line first
+                    # so an embedded newline doesn't orphan the `[/]`
+                    # and crash ``Text.from_markup`` (= the whole tab
+                    # would render blank — see ``_oneline`` docstring).
+                    truncated, was_truncated = _truncate_to_cells(
+                        _oneline(reply), 40,
+                    )
                     short = _esc(truncated) + ("…" if was_truncated else "")
                     lines.append(f"[#444444]       ↳ [/][#777777]{short}[/]")
 

--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -79,10 +79,18 @@ class _PanelContent(Static):
                 return Text.from_markup(markup)
             # Truncate each line independently so long values
             # (event types, file names, …) don't wrap into multiple
-            # rows and split words mid-line.
+            # rows and split words mid-line. A single line whose
+            # markup fails to parse (orphaned ``[/]`` from a leaked
+            # newline upstream, for example) falls back to plain text
+            # rather than killing the whole tab render via the outer
+            # ``except`` — losing one row's color is OK, the entire
+            # panel going blank is not.
             parts: list[Text] = []
             for line_markup in markup.split("\n"):
-                line_t = Text.from_markup(line_markup)
+                try:
+                    line_t = Text.from_markup(line_markup)
+                except Exception:
+                    line_t = Text(line_markup)
                 line_t.truncate(width, overflow="ellipsis")
                 parts.append(line_t)
             return Text("\n").join(parts)


### PR DESCRIPTION
**[tui-coder]** — wave-5 partial (E1 honest scope narrow)

## Summary

- Sanitize multi-line strings in event-hint and chain-reply preview before substituting into Rich markup, so a stray ``\n`` never orphans a closing ``[/]`` tag.
- Per-line catch + plain-text fallback inside ``_PanelContent.render`` so a single broken markup row degrades to monochrome instead of blanking the entire tab.

## Observation (wave-5 E1)

Sub-agent reported "Events tab \`all\` filter renders blank list despite events existing" and pinned it to scroll arithmetic. Drove the TUI directly and reproduced the blank panel at the default tail=200 (= ``_event_tail_idx=3``).

Investigation found a real but **partial** root cause: chain-reply previews for ``user_message_received`` events can carry multi-line bodies (e.g. ``"The available tools are:\n\n*   \`agent.peer__default\`…"``). The renderer substitutes that text into the line template ``[#444444]       ↳ [/][#777777]{short}[/]``, so the trailing ``\n`` splits the markup across two output lines and the next ``[/]`` lands without an opener. ``Text.from_markup`` raises ``MarkupError`` on that orphan, the existing outer ``except`` in ``_PanelContent.render`` returns ``""``, and the whole Events tab goes blank.

Python repro confirmed the markup crash (line 65: ``'*   \`agent.peer_…[/]'`` → ``closing tag '[/]' at position 17 has nothing to close``). This PR's ``_oneline`` helper collapses any whitespace run (incl. newlines) to a single space before the markup substitution, and ``_event_hint`` is wrapped identically as a precaution since hints can also embed arbitrary content (tool error messages, validation errors, etc.).

## Honest scope (= row 5 reproduction axis)

After landing the upstream sanitization + per-line render fallback locally and verifying ``MarkupError`` is gone from ``Text.from_markup`` for every line in the rendered string (full text and per-line both parse cleanly), the user-visible blank-panel symptom **still reproduces** at tail=200 on a fresh ``reyn chat`` boot. Cycling tail (``t`` key) to 30 / 50 / 100 still renders correctly, then cycling back to 200 stays blank. The Textual log shows ``_PanelContent`` resizing to ``height=1`` for the Events tab even after the markup fix, indicating a separate render / scroll cause that is **not** the markup parse.

This PR therefore lands the markup hardening as defense-in-depth — the corruption path is real and would re-emerge whenever any future event hint leaks a newline — but it does **not** claim to fix the wave-5 E1 visible symptom. That symptom is deferred to a focused follow-up investigation; this PR is the independently-correct upstream piece.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Python repro on the real ``.reyn/events/`` directory: before fix, line 65 raises ``MarkupError``; after fix, all 286 lines parse cleanly (both per-line and full-string ``Text.from_markup``).
- [x] Manual: open ``reyn chat``, ``Ctrl+B`` → Events tab — markup hardening verified at code path; **blank-panel symptom at tail=200 still present** (= honest scope narrow, separate root cause).
- [x] Manual: cycle ``t`` to tail=30, events render with cursor highlight, ``j``/``k`` navigation works — no regression.

## Refs

- wave-5 finding E1 (= triage list item 1, P1)
- defensive pattern matches ``MemoryError`` handling elsewhere in the renderer (= one row degrades, panel stays usable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)