### PR TITLE
fix(tui): header surfaces resolved model id, not tier key

### DIFF
--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -232,7 +232,11 @@ def run(args: argparse.Namespace) -> None:
     session_cfg = Session.from_args(args)
     from reyn.cli.credentials_check import verify_credentials_or_exit
     verify_credentials_or_exit(session_cfg, args)
-    model, _ = session_cfg.model_for(args)
+    # ``model`` (= tier key like "standard" / "strong") drives ChatSession's
+    # ModelResolver. ``resolved_model`` (= the litellm string like
+    # "openai/gemini-2.5-flash-lite") is what the header should surface so
+    # the user can see which model their requests actually go to.
+    model, resolved_model = session_cfg.model_for(args)
     output_language = session_cfg.output_language_for(args)
     safety = session_cfg.safety_for(args)
 
@@ -351,7 +355,7 @@ def run(args: argparse.Namespace) -> None:
             await run_tui(
                 registry,
                 agent_name=name,
-                model=model,
+                model=resolved_model,
                 budget_tracker=budget_tracker,
                 banner=getattr(args, "banner", False),
                 no_restore=skip_restore,


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 2/N (C1)

## Summary

- ``cli/commands/chat.py`` keeps the tier key (``"standard"`` / ``"strong"`` / …) bound to ``ChatSession`` — model routing is unchanged — but now also captures the resolved litellm string from ``Session.model_for(args)`` and hands **that** to ``run_tui(model=...)``.
- The header's model column now reads ``openai/gemini-2.5-flash-lite`` (the real LLM destination) instead of ``standard`` (the config tier key).

## Observation (wave-5 C1)

Sub-agent driving the cost/budget surface found:

> Header displays the string ``standard`` (the config-tier key) in the model position, not the resolved model identifier (e.g., ``gemini-2.5-flash-lite``), so users cannot tell from the header which LLM is actually handling their requests.

Verified directly: with ``models: { standard: openai/gemini-2.5-flash-lite }`` in ``reyn.local.yaml``, the header shows ``standard`` next to the agent name. ``Session.model_for(args)`` returns ``("standard", "openai/gemini-2.5-flash-lite")`` — the second slot is exactly what the header needs and was being thrown away with ``model, _ = session_cfg.model_for(args)``.

## Fix

```python
# before
model, _ = session_cfg.model_for(args)
...
await run_tui(... model=model ...)

# after
model, resolved_model = session_cfg.model_for(args)  # tier key vs litellm string
...
await run_tui(... model=resolved_model ...)
```

``ChatSession(model=model, ...)`` continues to receive the tier key (line 281 — the ModelResolver depends on it for routing).

``--connect <ws>`` mode is untouched: line 199 still passes ``model=""`` so the header shows an empty field, matching the existing comment "Model / budget unknown in remote mode — the server owns them. Show empty fields rather than guessing."

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Manual: launch ``OPENAI_API_KEY=dummy .venv/bin/reyn chat``, verify header reads ``Reyn  default  │  openai/gemini-2.5-flash-lite  │  …`` instead of ``standard`` (confirmed in tmux capture).
- [x] ``_shorten_model_id`` still strips date suffixes for Anthropic / OpenAI / Gemini strings — long provider strings like ``openai/gemini-2.5-flash-lite`` have no date suffix to strip and stay readable on narrow terminals.

## Refs

- wave-5 finding C1 (= triage list item 2, P1 S)
- comment-only change at the inline doc for ``model_for`` callers, no public API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)