### PR TITLE
fix(tui): wrap Cost tab disclaimer for narrow panel widths

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -255,16 +255,18 @@ def render_cost(
                 "right_panel cost: read of %s failed: %s", jsonl, exc,
             )
 
-    # Disclaimer line — costs displayed are client-side estimates derived
+    # Disclaimer — costs displayed are client-side estimates derived
     # from litellm's pricing DB at LLM-call time. They may diverge from
     # the actual amount billed by the upstream provider (= rate changes
     # between call time and the bill cycle, special pricing tiers,
     # unmetered features, etc.) and from any proxy-side accounting.
-    # Surfacing this once at the top of the Cost tab prevents the user
-    # from treating the displayed cents as a billing-authoritative source.
-    lines.append(
-        "[#555555]  (litellm estimate — may differ from actual provider billing)[/]"
-    )
+    # Split across two short lines so the disclaimer survives narrow
+    # panel widths (= 44 cells minimum, see SP1) — a single 62-cell
+    # line clipped to ``(litellm estimate — may differ from …)`` and
+    # the actionable half ("from actual provider billing") never
+    # reached the user.
+    lines.append("[#555555]  (litellm estimate —[/]")
+    lines.append("[#555555]   may differ from actual billing)[/]")
     lines.append("")
 
     # ── TODAY ────────────────────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 3/N (C2)

## Summary

- Split the Cost tab disclaimer line ``(litellm estimate — may differ from actual provider billing)`` (62 cells) at the em-dash into two short lines that both fit the 44-cell minimum panel width (= SP1 floor).
- Drop "provider" from the second half (= "from actual billing") so the wrap survives even when the panel is minimum-width.

## Observation (wave-5 C2)

Sub-agent driving the cost surface found the disclaimer silently truncates at default panel width:

> ``(litellm estimate — may differ from actual provider billing)`` (62 chars) is truncated to ``(litellm estimate — may differ from …)`` at default panel width (~40 chars), making it appear the sentence ends at "from …" with no actionable context.

Drove the TUI directly to verify — disclaimer renders on one line and ``…`` ellipsis clips the actionable half. Same render pipeline as every other tab; the Static widget's per-line ``truncate(width, overflow="ellipsis")`` does what it's told.

## Fix

```python
# before
lines.append(
    "[#555555]  (litellm estimate — may differ from actual provider billing)[/]"
)

# after
lines.append("[#555555]  (litellm estimate —[/]")
lines.append("[#555555]   may differ from actual billing)[/]")
```

Cell counts:
- L1: 2 indent + 20 = 22 cells ✓
- L2: 3 indent + 30 = 33 cells ✓ (fits 44-cell minimum)

Same idiom as the Memory tab's "(empty) / try: remember <fact>" wrap landed in an earlier wave for the same narrow-width constraint.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Manual: launch ``OPENAI_API_KEY=dummy .venv/bin/reyn chat``, ``Ctrl+B`` → cycle to Cost tab — disclaimer now wraps to 2 lines, both fully visible (confirmed in tmux capture).
- [x] Both halves of the disclaimer convey the substantive point ("litellm estimate" + "may differ from actual billing"); meaning preserved.

## Refs

- wave-5 finding C2 (= triage list item 3, P2 S)
- SP1 minimum panel width floor (44 cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)