### PR TITLE
feat(tui): /cost-inline toggle writes a persistent log marker

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -266,6 +266,16 @@ class OutboxRouter:
             app._cost_inline_enabled = not app._cost_inline_enabled
         state = "on" if app._cost_inline_enabled else "off"
         self._show_transient_status(conv, f"cost-inline {state}", duration=2.5)
+        # Persist the state-change in the conv log too — a 2.5 s sticky
+        # is easy to miss if the user just scanned the screen. The
+        # lifecycle-marker shape (= same dim ``── ↑ <body> ────`` divider
+        # used by compaction markers) keeps the visual weight low while
+        # leaving an auditable record of when the toggle fired.
+        from reyn.chat.tui.widgets.conversation import _render_lifecycle_marker
+        try:
+            conv._write_log(_render_lifecycle_marker(f"↑ cost-inline {state}"))
+        except Exception:
+            pass
         # Persist the new state — additive merge, so unknown future
         # pref keys round-trip untouched. Failure is silent (= file
         # write errors don't break the toggle itself).


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 4/N (C3)

## Summary

- ``_on_cost_inline_toggle`` now also writes a lifecycle-marker line ``── ↑ cost-inline on ───…`` / ``── ↑ cost-inline off ───…`` into the conv log, in addition to the existing 2.5 s sticky status.
- The transient sticky stays for the immediate "did it land?" feedback; the dim log marker is the durable, auditable record.

## Observation (wave-5 C3)

Sub-agent driving the cost surface found:

> Toggling ``/cost-inline`` shows a transient 2.5 s status that disappears before most users notice it, and no persistent system message appears in the conversation log to confirm the new on/off state.

Verified directly: tmux ``send-keys "/cost-inline"`` + Enter shows ``cost-inline on`` for ~2 s and then nothing. A user who glanced away (= the common case while waiting for an agent reply) sees no record that the toggle ever happened. State persists in ``tui_prefs.json`` and across restarts, so the silence isn't just an aesthetic issue — there's no way from the conv log alone to tell whether the slash even reached the app.

## Fix

```python
# In _on_cost_inline_toggle, after the existing transient sticky:
from reyn.chat.tui.widgets.conversation import _render_lifecycle_marker
try:
    conv._write_log(_render_lifecycle_marker(f"↑ cost-inline {state}"))
except Exception:
    pass
```

Uses the same dim ``── ↑ <body> ────…`` shape already used by compaction markers (``ChatLifecycleForwarder`` lifecycle text). Failure is swallowed (= the transient sticky stays the load-bearing feedback even if the log write fails for any reason).

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Manual: launch ``.venv/bin/reyn chat``, type ``/cost-inline`` + Enter — observe ``── ↑ cost-inline on ────…`` (or ``off``) line in conv log; toggle again to confirm state-flip both directions emit a corresponding marker (tmux capture verified).
- [x] Transient sticky still fires for 2.5 s as before — both feedback channels coexist.

## Refs

- wave-5 finding C3 (= triage list item 4, P2 S)
- ``_render_lifecycle_marker`` / ``_is_lifecycle_marker`` in ``widgets/conversation.py`` (reused pattern from compaction markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)