### PR TITLE
fix(tui): cost suffix elapsed_s no longer clips at 80-col

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1021,24 +1021,39 @@ class ConversationView(Widget):
     def render_cost_suffix(self, tokens: int, cost_usd: float, elapsed_s: float) -> None:
         """Append a dim per-turn cost suffix, right-aligned. Caller decides when (opt-in).
 
-        Both pieces are load-bearing: ``Text(..., justify="right")`` only
-        right-aligns when the renderer is told a width to fill, and
-        ``RichLog.write`` defaults to ``expand=False`` — without
-        ``expand=True`` the suffix silently renders at column 0.
+        Three pieces are load-bearing:
 
-        Separator is ``│`` (U+2502, narrow, unambiguous width) rather than
-        ``·`` (U+00B7, East Asian Width "Ambiguous") so Rich's cell-width
-        accounting matches what the terminal actually paints — the previous
-        ``·`` rendered as 2 cells on some terminals, pushing the elapsed
-        tail past the right edge and clipping ``14.3s`` to ``·`` alone.
-        Matches the header's existing ``│`` separator for visual consistency.
+        - ``Text(..., justify="right")`` only right-aligns when the
+          renderer is told a width to fill, and ``RichLog.write`` defaults
+          to ``expand=False`` — without ``expand=True`` the suffix
+          silently renders at column 0.
+        - Wrapping the Text in ``Padding(text, (0, RIGHT_PAD, 0, 0))``
+          reserves explicit right-margin cells. Without that margin the
+          right-justified end of the suffix landed under the vertical
+          scrollbar + the small right-padding RichLog reserves and the
+          trailing ``N.Ns`` segment was clipped at 80-col terminal widths
+          (the ``expand=True`` fill width didn't subtract the scrollbar
+          column from the right edge of the right-justified text).
+        - Separator is ``│`` (U+2502, narrow, unambiguous width) rather
+          than ``·`` (U+00B7, East Asian Width "Ambiguous") so Rich's
+          cell-width accounting matches what the terminal actually paints.
         """
+        from rich.padding import Padding
         t = Text(
             f"⌁ {tokens}t │ ${cost_usd:.4f} │ {elapsed_s:.1f}s",
             style="dim #666666",
             justify="right",
         )
-        self._log().write(t, expand=True)
+        # ``(top=0, right=6, bottom=0, left=0)`` — reserve 6 cells on
+        # the right so the right-justified text stays inside the
+        # scrollbar + widget right-padding. Empirical calibration at
+        # 80-col widths: 2 cells still clipped (``17.``), 3 still clipped
+        # (``17.1.``), 6 leaves the full ``N.Ns`` segment + a visible gap
+        # from the scrollbar. The ``expand=True`` fill width doesn't
+        # subtract the scrollbar column or RichLog's own right-padding
+        # from the right edge of the right-justified text, so we have to
+        # reserve it manually.
+        self._log().write(Padding(t, (0, 6, 0, 0)), expand=True)
 
     # ── turn navigation (B4) ──────────────────────────────────────────────────
 


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 5/N (C4)

## Summary

- Wrap the right-justified cost-suffix ``Text`` in ``Padding(t, (0, 6, 0, 0))`` so the trailing ``N.Ns`` segment stays inside the visible right edge at 80-col terminal widths.
- Pre-fix at 80-col: ``⌁ 8851t │ $0.0009 │`` (elapsed clipped behind the scrollbar).
- Post-fix at 80-col: ``⌁ 7888t │ $0.0008 │ 3.1s`` (full suffix visible).

## Observation (wave-5 C4)

Sub-agent reported the per-turn cost suffix clips the elapsed-time field at 80-col widths:

> The right-aligned cost suffix ``⌁ 17564t │ $0.0018 │ 17.3s`` appears in the conversation as ``⌁ 17564t │ $0.0018 │`` — the ``elapsed_s`` field is clipped or absent at the right margin.

Reproduced directly via ``OPENAI_API_KEY=dummy .venv/bin/reyn chat`` at tmux pane size 80×24: ``/cost-inline on`` + send a short prompt → suffix shows ``⌁ 8851t │ $0.0009 │`` with no trailing ``N.Ns``.

Root cause: ``Text(..., justify="right") + RichLog.write(expand=True)`` fills to the widget's full width but the actual visible content region is narrower — RichLog's own ``padding: 0 1`` (= 1 cell each side) plus the vertical scrollbar (1 cell on the right) consume ~3 cells. The right-justified end of the text landed in that consumed region and got clipped.

## Fix

```python
from rich.padding import Padding
t = Text(suffix, style="dim #666666", justify="right")
self._log().write(Padding(t, (0, 6, 0, 0)), expand=True)
```

Explicit right-margin reservation via ``Padding(t, (0, RIGHT, 0, 0))``.

Empirical calibration of ``RIGHT`` at 80-col:
- 2 cells: still clipped (``17.``)
- 3 cells: still clipped (``17.1.``)
- 6 cells: full ``N.Ns`` + visible gap from scrollbar

The existing right-align contract (Tier 2 test ``test_render_cost_suffix_is_right_aligned``) is preserved because ``Padding + expand=True`` still right-justifies at render time. The suffix survives early-write before layout settles.

## Test plan

- [x] ``pytest tests/cli/test_cost_suffix_right_align.py`` → 2/2 pass (Tier 2 right-align contract).
- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Manual at 80×24 (tmux pane size): launch ``.venv/bin/reyn chat``, ``/cost-inline on``, send a prompt — observe full ``⌁ Nt │ $N │ N.Ns`` suffix line including the elapsed seconds (confirmed in tmux capture).

## Refs

- wave-5 finding C4 (= triage list item 5, P2 S)
- ``render_cost_suffix`` in ``widgets/conversation.py`` — the same path the existing Tier 2 right-align test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)