### PR TITLE
fix(tui): flush finished SkillActivityRow into log + remove widget (S1+S2)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -831,9 +831,38 @@ class ConversationView(Widget):
     def finish_skill_row(
         self, run_id: str, *, success: bool = True, reason: str = "",
     ) -> None:
+        """Transition the row to ``✓ / ✗`` and roll it into the scroll log.
+
+        Previously the row was only popped from ``_skill_rows`` and
+        ``row.finish(...)`` was called, leaving the widget mounted in
+        the ConversationView DOM forever. That had two consequences:
+
+        - DOM accumulation: every completed skill stacked another
+          mounted ``SkillActivityRow`` widget, growing layout cost
+          monotonically across the session.
+        - Unreachable breadcrumb: the ``✓ skill#abcd · Ns · Ctrl+B →
+          agents`` line lived below the RichLog as a sibling, so
+          ``Ctrl+P/N`` / ``Page_Up`` / arrow scrolling never reached
+          it — the finished status was visible only while the user
+          stayed at the bottom.
+
+        Flush the finished row's renderable into the RichLog (where it
+        becomes part of the scrollable history) and then remove the
+        widget.
+        """
         row = self._skill_rows.pop(run_id, None)
-        if row is not None:
-            row.finish(success=success, reason=reason)
+        if row is None:
+            return
+        row.finish(success=success, reason=reason)
+        try:
+            finished_text = row._build_finished()
+            self._write_body(finished_text)
+            row.remove()
+        except Exception:
+            # If anything in the flush path fails, leave the row mounted
+            # — the breadcrumb stays visible (just not scrollable), which
+            # is strictly better than blowing up the outbox loop.
+            pass
 
     # ── sticky status (A3) ────────────────────────────────────────────────────
 


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 6/N (S1 + S2 combined)

## Summary

- ``finish_skill_row`` now captures the finished row's renderable via ``row._build_finished()``, writes it into the RichLog through ``_write_body`` (= scrollable history), then removes the SkillActivityRow widget from the DOM.
- Same fix addresses two distinct sub-agent findings (S1 + S2) — they have the same mechanism.

## Observation (wave-5 S1 + S2)

Sub-agent driving skill-row visibility found:

**S1 — Finished SkillActivityRow widgets accumulate in DOM, never removed**

> ``finish_skill_row`` pops the row from ``_skill_rows`` and calls ``row.finish()`` but never calls ``row.remove()`` — the ``✓``/``✗`` widget stays mounted in the ConversationView DOM indefinitely.

**S2 — Finished ``✓`` line unreachable via any scroll mechanism**

> The ``✓ skill#abcd · Ns · N phases · Ctrl+B → agents`` completion line mounts below the RichLog as a Textual child of ConversationView; the RichLog fills ``1fr``, so completed rows stack below the visible area and no scroll path reaches them.

Both are real and share the same root cause: ``finish_skill_row`` only transitioned the row's state, never moved its content into the scrollable log. Code claim verified directly at ``widgets/conversation.py:831-836``:

```python
def finish_skill_row(self, run_id, *, success=True, reason=""):
    row = self._skill_rows.pop(run_id, None)
    if row is not None:
        row.finish(success=success, reason=reason)
    # ← no row.remove(), no write into RichLog
```

## Fix

```python
def finish_skill_row(self, run_id, *, success=True, reason=""):
    row = self._skill_rows.pop(run_id, None)
    if row is None:
        return
    row.finish(success=success, reason=reason)
    try:
        finished_text = row._build_finished()
        self._write_body(finished_text)
        row.remove()
    except Exception:
        # row stays mounted on failure (= prior behaviour, not a crash)
        pass
```

``_write_body`` is the existing indented-write path used by agent / system rows, so the flushed ``✓ skill#abcd · Ns · Ctrl+B → agents`` line lands at the same hanging-indent column as everything else in the log. The defensive try/except keeps a malformed row from breaking the outbox loop — failure mode degrades to "row stays mounted" (= prior behaviour), strictly better than a crash.

Combines the two findings deliberately: implementing them as separate PRs would require either (a) duplicating the same change in both or (b) sequencing them when the underlying call site is identical. One bundled commit matches the actual code change.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass (incl. ``test_phase_completed_visible.py`` which exercises the SkillActivityRow lifecycle).
- [x] Code review of the call sites: every ``conv.finish_skill_row(run_id, ...)`` site (``app.py:594, 850, 879``) goes through this method, so all routes benefit from the flush.
- [ ] (skipped — manual TUI verification of the ``✓ skill#abcd`` line landing in scrollback was blocked by slow planner LLM response timing during ad-hoc testing; the unit logic + 304 tests carry the validation, and the defensive try/except guarantees no worse than current behaviour on edge cases.)

## Refs

- wave-5 findings S1 + S2 (= triage list items 6 + 11)
- ``_build_finished`` in ``widgets/skill_activity.py`` (the renderable being flushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)