### PR TITLE
fix(tui): sticky status body truncates so Ctrl+C cancel survives narrow widths

### DIFF
--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import time
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual.widgets import Static
 
@@ -111,7 +112,6 @@ class StickyStatus(Static):
 
     def _repaint(self) -> None:
         elapsed = max(0.1, time.monotonic() - self._start)
-        t = Text()
         # On 8-color terminals, hex _CORAL (#C8553D) degrades to ANSI bright
         # red — confusable with error indicators. The thinking sticky shows
         # while the agent is working, so route its glyph through _AMBER
@@ -120,9 +120,36 @@ class StickyStatus(Static):
         # general) keep _CORAL since they're typically transient flashes,
         # not the load-bearing "is the agent working?" indicator.
         glyph_color = _AMBER if self._kind == "thinking" else _CORAL
+        # Total cells in the fixed-width suffix segments so we can truncate
+        # the body when narrow terminals would otherwise clip the
+        # ``Ctrl+C cancel`` hint behind the right edge.
+        glyph_cells = cell_len(self._glyph) + 1  # ``<glyph> ``
+        elapsed_suffix = f" · {elapsed:.1f}s"
+        elapsed_cells = cell_len(elapsed_suffix)
+        cancel_suffix = "  · Ctrl+C cancel" if self._kind == "thinking" else ""
+        cancel_cells = cell_len(cancel_suffix)
+        # Padding 0 1 → 2 cells consumed; another 1-cell safety margin
+        # keeps the body off the right edge even if Textual reserves
+        # something additional (cursor / scrollbar on certain themes).
+        chrome_cells = glyph_cells + elapsed_cells + cancel_cells + 2 + 1
+        available = max(0, int(getattr(self.size, "width", 0)) - chrome_cells)
+        body = self._body
+        if available > 0 and cell_len(body) > available:
+            # Truncate by cells (CJK / wide-char aware) and append the
+            # ellipsis. ``available - 1`` reserves the ellipsis cell.
+            out_chars: list[str] = []
+            used = 0
+            for ch in body:
+                w = cell_len(ch)
+                if used + w > max(0, available - 1):
+                    break
+                out_chars.append(ch)
+                used += w
+            body = "".join(out_chars) + "…"
+        t = Text()
         t.append(self._glyph + " ", style=glyph_color)
-        t.append(self._body, style="dim italic")
-        t.append(f" · {elapsed:.1f}s", style="dim italic")
-        if self._kind == "thinking":
-            t.append("  · Ctrl+C cancel", style="dim italic")
+        t.append(body, style="dim italic")
+        t.append(elapsed_suffix, style="dim italic")
+        if cancel_suffix:
+            t.append(cancel_suffix, style="dim italic")
         self.update(t)


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 7/N (S3)

## Summary

- ``StickyStatus._repaint`` now computes the visible cell width, subtracts the fixed chrome (glyph + elapsed + ``Ctrl+C cancel`` suffix + padding + safety margin), and cell-truncates ``_body`` with a trailing ``…`` when needed.
- At 60-col terminals the line now renders as e.g. ``⟳ dispatched 1 async reque… · 5.8s  · Ctrl+C cancel`` instead of clipping the cancel hint behind the right edge.

## Observation (wave-5 S3)

Sub-agent reported:

> ``StickyStatus._repaint()`` appends glyph + body + elapsed + ``  · Ctrl+C cancel`` into a single ``height: 1`` ``Static`` widget with no ellipsis or truncation logic; at 60-col width, the ``plan step 1/4: <60-char desc> · 1.4s  · Ctrl+C cancel`` string overflows and the terminal clips it without any indicator.

Verified at ``widgets/sticky_status.py:112-128`` — original ``_repaint`` indeed appends all four segments and calls ``self.update(t)`` with no width logic. Drove the TUI at ``tmux resize-window -x 60`` and reproduced the clip on a long-body status: ``Ctrl+C cancel`` was the casualty.

## Fix

```python
glyph_cells = cell_len(self._glyph) + 1
elapsed_suffix = f" · {elapsed:.1f}s"
elapsed_cells = cell_len(elapsed_suffix)
cancel_suffix = "  · Ctrl+C cancel" if self._kind == "thinking" else ""
cancel_cells = cell_len(cancel_suffix)
# padding 0 1 → 2 cells, +1 safety margin
chrome_cells = glyph_cells + elapsed_cells + cancel_cells + 2 + 1
available = max(0, int(getattr(self.size, "width", 0)) - chrome_cells)
body = self._body
if available > 0 and cell_len(body) > available:
    # cell-truncate with ellipsis (CJK / wide-char aware)
    ...
```

CJK / wide-char aware via ``rich.cells.cell_len`` — the same idiom used by the Events tab's ``_truncate_to_cells`` helper. Fixed-width chrome stays visible; the variable-width body shrinks first, which is the right priority (= a truncated description with ``…`` is informative; a missing ``Ctrl+C cancel`` is unrecoverable for the user).

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass (incl. existing ``test_sticky_*`` Tier 2 tests).
- [x] Manual at 60-col (``tmux resize-window -x 60``): launch ``.venv/bin/reyn chat``, send a plan request to trigger the sticky — observe ``⟳ dispatched 1 async reque… · 5.8s  · Ctrl+C cancel`` rendered with ellipsis + full cancel hint visible (confirmed in tmux capture).
- [x] No body truncation when width is sufficient (= the existing 80-col / 120-col behaviour is unchanged because ``cell_len(body) > available`` is False at typical widths).

## Refs

- wave-5 finding S3 (= triage list item 7, P2 S)
- ``_truncate_to_cells`` (events_tab.py) — same cell-aware truncation idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)