### PR TITLE
feat(multimodal): web_fetch binary path + shared media-size gate (closes #364)

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -9,7 +9,7 @@ from reyn.budget.budget import BudgetTracker
 from reyn.config import OnLimitConfig, SafetyConfig
 
 if TYPE_CHECKING:
-    from reyn.config import SandboxConfig
+    from reyn.config import MultimodalConfig, SandboxConfig
     from reyn.secrets.store import ScopedSecretStore
 from reyn.events.event_store import EventStore
 from reyn.kernel.runtime import OSRuntime, RunResult
@@ -54,6 +54,7 @@ class Agent:
         caller: str = "direct",
         budget_tracker: BudgetTracker | None = None,
         sandbox_config: "SandboxConfig | None" = None,
+        multimodal_config: "MultimodalConfig | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
     ) -> None:
         self.model = model
@@ -75,6 +76,9 @@ class Agent:
         # FP-0017 follow-up: declarative sandbox config (reyn.yaml `sandbox:`).
         # None → platform auto-detect; otherwise honors backend/on_unsupported.
         self._sandbox_config = sandbox_config
+        # Issue #364 multi-modal cluster: media-size gate config (reyn.yaml
+        # ``multimodal:``). ``None`` → no cap (= permissive default).
+        self._multimodal_config = multimodal_config
         self._secret_store = secret_store
         self._runtime: OSRuntime | None = None
         self.run_id: str | None = None
@@ -145,6 +149,7 @@ class Agent:
             resume_plan=resume_plan,
             parent_run_id=parent_run_id,
             sandbox_config=self._sandbox_config,
+            multimodal_config=self._multimodal_config,
             secret_store=self._secret_store,
             plan_step=plan_step,
         )

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -181,6 +181,12 @@ class RouterHostAdapter:
         # config-deny path still raises, interactive prompt path raises
         # the documented RuntimeError telling the caller a bus is needed).
         intervention_bus_factory: Callable[[], Any] | None = None,
+        # Issue #364 multi-modal cluster: media-size gate config (reyn.yaml
+        # ``multimodal:`` section). Threaded into the OpContext built by
+        # ``make_router_op_context`` so router-initiated web_fetch /
+        # file__read / mcp ops consult the cap + on_oversize policy.
+        # ``None`` = no cap.
+        multimodal_config: Any = None,
     ) -> None:
         self._agent_name = agent_name
         self._agent_role = agent_role
@@ -241,6 +247,9 @@ class RouterHostAdapter:
         # interactive (Layer 4) approval flow without crashing on
         # ``intervention_bus is None`` defensive guards.
         self._intervention_bus_factory = intervention_bus_factory
+        # Issue #364: store the gate config so make_router_op_context can
+        # thread it into the OpContext for router-initiated binary ops.
+        self._multimodal_config = multimodal_config
 
     # --- RouterLoopHost identity attributes ---
 
@@ -972,4 +981,6 @@ class RouterHostAdapter:
             skill_name="chat_router",
             mcp_servers=self._mcp_servers_flat(),
             intervention_bus=bus,
+            # Issue #364: gate config for router-initiated binary ops.
+            multimodal_config=self._multimodal_config,
         )

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -45,6 +45,7 @@ from reyn.config import (  # noqa: F401
     ActionRetrievalConfig,
     EmbeddingConfig,
     EventsConfig,
+    MultimodalConfig,
     OnLimitConfig,
     SafetyConfig,
     SandboxConfig,
@@ -730,6 +731,7 @@ class ChatSession:
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
         sandbox_config: "SandboxConfig | None" = None,
+        multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
@@ -752,6 +754,10 @@ class ChatSession:
         # Plumbed through to spawned Agents so sandboxed_exec backend selection
         # honors the operator's declared policy.
         self._sandbox_config = sandbox_config
+        # Issue #364 — multi-modal cluster: media-size gate config plumbed
+        # through to spawned Agents AND to the router host adapter (=
+        # chat-router web__fetch / file__read / mcp paths).
+        self._multimodal_config = multimodal_config
         # FP-0034 PR-3b-iii: action_retrieval config — drives whether the
         # universal catalog wrappers appear in the router tools=. Default
         # constructs an off-flag ActionRetrievalConfig so existing chat
@@ -1118,6 +1124,8 @@ class ChatSession:
                 self._sandbox_config.backend if self._sandbox_config is not None
                 else None
             ),
+            # Issue #364 multi-modal cluster: media-size gate config.
+            multimodal_config=self._multimodal_config,
             # B25-S5-1: thread eager-build flag so RouterLoop awaits build
             # before computing _search_visible on the first turn.
             eager_embedding_build=self._eager_embedding_build,
@@ -1793,6 +1801,7 @@ class ChatSession:
             caller=f"agents/{self.agent_name}",
             budget_tracker=self._budget_tracker,
             sandbox_config=self._sandbox_config,
+            multimodal_config=self._multimodal_config,
         )
 
     async def _put_outbox(self, msg: OutboxMessage) -> None:

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -299,6 +299,7 @@ def run(args: argparse.Namespace) -> None:
             state_log=state_log,
             budget_tracker=budget_tracker,
             sandbox_config=session_cfg.config.sandbox,
+            multimodal_config=session_cfg.config.multimodal,
             action_retrieval_config=session_cfg.config.action_retrieval,
             embedding_config=session_cfg.config.embedding,
             eager_embedding_build=getattr(args, "eager_embedding_build", False),

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -441,6 +441,7 @@ def _build_live_runner(agent_name: str):
                 state_log=None,  # no WAL for dogfood dispatch
                 budget_tracker=budget_tracker,
                 sandbox_config=config.sandbox,
+                multimodal_config=config.multimodal,
                 action_retrieval_config=config.action_retrieval,
             )
             s.load_history()

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -723,6 +723,67 @@ def _build_web_config(raw: object) -> WebConfig:
     return WebConfig(fetch=_build_web_fetch_config(fetch_raw))
 
 
+# ── multimodal: media-size gate for image/audio/etc. (#364 cluster) ─────────
+
+
+_MULTIMODAL_ON_OVERSIZE = ("ask", "allow", "deny")
+
+
+@dataclass
+class MultimodalConfig:
+    """``multimodal:`` — controls how Reyn handles large binary content
+    (currently images from web__fetch / file__read / MCP servers).
+
+    Fields:
+        max_bytes:
+            Decoded-payload byte cap before the gate fires. Default 5MB
+            matches Anthropic's per-image API limit. Counts the BINARY size
+            (= ``len(response.content)`` / ``len(file_bytes)``), not the
+            base64-encoded shape.
+        on_oversize:
+            What to do when a piece of media exceeds ``max_bytes``:
+
+            - ``ask`` (default): prompt the user via the intervention bus
+              with size + source info; yes loads the media, no drops it.
+            - ``allow``: silently accept; no prompt. Use when running
+              non-interactively in a trusted pipeline.
+            - ``deny``: silently reject; the op returns ``status="denied"``
+              with no media data. Use in cost-sensitive contexts where
+              over-limit content should never reach the LLM.
+
+    Issue #364 lands this config + the shared ``require_media_load`` gate;
+    paths #365 (file__read binary) and #366 (user chat input image) reuse
+    them.
+    """
+    max_bytes: int = 5_000_000
+    on_oversize: Literal["ask", "allow", "deny"] = "ask"
+
+
+def _build_multimodal_config(raw: object) -> MultimodalConfig:
+    """Parse the ``multimodal:`` section. Unknown keys ignored, bad types
+    fall back to defaults.
+    """
+    if not isinstance(raw, dict):
+        return MultimodalConfig()
+    max_bytes_raw = raw.get("max_bytes")
+    try:
+        max_bytes = int(max_bytes_raw) if max_bytes_raw is not None else 5_000_000
+    except (TypeError, ValueError):
+        max_bytes = 5_000_000
+    if max_bytes < 0:
+        max_bytes = 5_000_000
+    on_oversize_raw = raw.get("on_oversize")
+    on_oversize: Literal["ask", "allow", "deny"]
+    if (
+        isinstance(on_oversize_raw, str)
+        and on_oversize_raw in _MULTIMODAL_ON_OVERSIZE
+    ):
+        on_oversize = on_oversize_raw  # type: ignore[assignment]
+    else:
+        on_oversize = "ask"
+    return MultimodalConfig(max_bytes=max_bytes, on_oversize=on_oversize)
+
+
 SKILL_RESUME_POLICIES = ("prompt", "retry", "skip", "discard_skill")
 
 
@@ -1326,6 +1387,9 @@ class ReynConfig:
     # Priority: web.fetch.ca_bundle → web.fetch.verify_ssl → SSL_VERIFY env →
     # litellm.ssl_verify → SSL_CERT_FILE → True (default).
     web: WebConfig = field(default_factory=WebConfig)
+    # Issue #364 — multi-modal cluster: cap binary media size (= images from
+    # web__fetch / file__read / MCP) + iv-gated user permission when exceeded.
+    multimodal: MultimodalConfig = field(default_factory=MultimodalConfig)
     # FP-0029: plan-mode execution tuning (step iteration budget, etc.)
     plan: PlanConfig = field(default_factory=PlanConfig)
     # FP-0007 Component A: trace export adapter config.
@@ -1604,6 +1668,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         embedding=_build_embedding_config(merged.get("embedding")),
         safety=safety,
         web=_build_web_config(merged.get("web")),
+        multimodal=_build_multimodal_config(merged.get("multimodal")),
         skill_search=_build_skill_search_config(merged.get("skill_search")),
         plan=_build_plan_config(merged.get("plan")),
         eval=_build_eval_config(merged.get("eval")),

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from reyn.config import SandboxConfig
+    from reyn.config import MultimodalConfig, SandboxConfig
     from reyn.secrets.store import ScopedSecretStore
 
 from reyn.dispatch import DispatchContext, dispatch_tool
@@ -90,6 +90,7 @@ class ControlIRExecutor:
         resume_plan: Any = None,
         run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
+        multimodal_config: "MultimodalConfig | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
     ) -> None:
         self.workspace = workspace
@@ -127,6 +128,13 @@ class ControlIRExecutor:
         # policy. ``None`` means the factory falls through to platform
         # auto-detection (= unchanged behavior pre-wiring).
         self._sandbox_config = sandbox_config
+        # Issue #364 — multi-modal media-size gate config (= reyn.yaml
+        # ``multimodal:`` section). Threaded into OpContext so binary paths
+        # (web__fetch / file__read / MCP / user input) can consult the cap
+        # + on_oversize policy before loading large payloads into the LLM.
+        # ``None`` = no cap (= permissive default for callers that don't
+        # supply a ReynConfig).
+        self._multimodal_config = multimodal_config
         # FP-0016 D: per-skill credential scoping. None = unrestricted
         # (= preserves backward compat for callers that don't supply a store).
         self._secret_store = secret_store
@@ -286,6 +294,8 @@ class ControlIRExecutor:
             agent_id=getattr(self.events, "agent_id", None),
             # FP-0017 follow-up: declarative sandbox config (reyn.yaml).
             sandbox_config=self._sandbox_config,
+            # Issue #364 — multi-modal cluster media-size gate.
+            multimodal_config=self._multimodal_config,
             # FP-0016 D: per-skill credential scoping.
             secret_store=self._secret_store,
         )

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -10,7 +10,7 @@ from reyn.schemas.models import CandidateOutput, ContextFrame, Skill
 
 if TYPE_CHECKING:
     from reyn.budget.budget import BudgetTracker
-    from reyn.config import SandboxConfig
+    from reyn.config import MultimodalConfig, SandboxConfig
     from reyn.events.state_log import StateLog
     from reyn.secrets.store import ScopedSecretStore
     from reyn.skill.skill_registry import SkillRegistry
@@ -73,6 +73,7 @@ class OSRuntime:
         resume_plan: Any = None,
         parent_run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
+        multimodal_config: "MultimodalConfig | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
         plan_step: dict | None = None,
     ) -> None:
@@ -129,6 +130,8 @@ class OSRuntime:
         # executor so sandboxed_exec backend selection honors the operator's
         # declared backend / on_unsupported policy. None → platform default.
         self._sandbox_config = sandbox_config
+        # Issue #364 multi-modal cluster: media-size gate config.
+        self._multimodal_config = multimodal_config
         # FP-0016 D: per-skill credential scoping. None = unrestricted
         # (= preserves backward compat for callers that don't supply a store).
         self._secret_store = secret_store
@@ -148,6 +151,7 @@ class OSRuntime:
             resume_plan=resume_plan,
             run_id=run_id,
             sandbox_config=sandbox_config,
+            multimodal_config=multimodal_config,
             secret_store=secret_store,
         )
         self._preprocessor = PreprocessorExecutor(

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from reyn.config import SandboxConfig, WebConfig
+    from reyn.config import MultimodalConfig, SandboxConfig, WebConfig
     from reyn.events.events import EventLog
     from reyn.llm.model_resolver import ModelResolver
     from reyn.permissions.permissions import PermissionDecl, PermissionResolver
@@ -98,6 +98,13 @@ class OpContext:
     # When None, sandboxed_exec falls back to platform auto-detection
     # (= same as no-config-loaded behavior).
     sandbox_config: "SandboxConfig | None" = None
+
+    # Issue #364: declarative cap on binary media size (= images from
+    # web__fetch / file__read / MCP / user input). When None, the gate
+    # is skipped — direct-OpContext constructions in tests stay
+    # backward-compatible. Callers with a ReynConfig should pass
+    # config.multimodal here.
+    multimodal_config: "MultimodalConfig | None" = None
 
     # FP-0016 D: per-skill credential scoping. None = unrestricted (= today's
     # behaviour; preserves backward compat for top-level / chat-router /

--- a/src/reyn/op_runtime/web.py
+++ b/src/reyn/op_runtime/web.py
@@ -115,6 +115,62 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
         return {"kind": "web_fetch", "url": op.url, "status": "error", "error": str(exc)}
 
     content_type = response.headers.get("content-type", "")
+
+    # Issue #364: when the response is a binary image, switch to
+    # bytes + base64 + media_blocks instead of decoding as text. Apply the
+    # shared media-size gate (config: multimodal.max_bytes / on_oversize)
+    # before allocating any large payloads into the LLM context. Other
+    # binary types (audio/video) are deferred — fall through to the text
+    # path's errors="replace" behaviour, which preserves the pre-#364
+    # output for non-image binary.
+    if content_type.startswith("image/"):
+        image_bytes = response.content
+        if ctx.permission_resolver is not None and ctx.multimodal_config is not None:
+            if ctx.intervention_bus is None:
+                raise RuntimeError(
+                    "web_fetch op requires intervention_bus when loading "
+                    "binary media (multimodal gate)"
+                )
+            try:
+                await ctx.permission_resolver.require_media_load(
+                    size_bytes=len(image_bytes),
+                    source=f"web fetch {op.url}",
+                    mime_type=content_type,
+                    max_bytes=ctx.multimodal_config.max_bytes,
+                    on_oversize=ctx.multimodal_config.on_oversize,
+                    bus=ctx.intervention_bus,
+                )
+            except PermissionError as exc:
+                ctx.events.emit(
+                    "web_fetch_media_denied",
+                    url=op.url, size_bytes=len(image_bytes),
+                    mime_type=content_type,
+                )
+                return {
+                    "kind": "web_fetch", "url": op.url, "status": "denied",
+                    "content_type": content_type, "size_bytes": len(image_bytes),
+                    "error": str(exc),
+                }
+        import base64
+        data_b64 = base64.b64encode(image_bytes).decode("ascii")
+        ctx.events.emit(
+            "web_fetch_completed",
+            url=op.url, status_code=response.status_code,
+            content_type=content_type, content_length=len(image_bytes),
+            extractor="binary", media_block_count=1,
+        )
+        return {
+            "kind": "web_fetch", "url": op.url, "status": "ok",
+            "status_code": response.status_code, "content_type": content_type,
+            "content": "", "truncated": False,
+            "extractor": "binary",
+            "start_index": 0, "next_start": None,
+            "total_length": len(image_bytes),
+            "media_blocks": [
+                {"type": "image", "data": data_b64, "mimeType": content_type},
+            ],
+        }
+
     raw = response.text
 
     if "text/html" in content_type:
@@ -156,6 +212,7 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
         "content": content,
         "truncated": truncated,
         "extractor": extractor_name,
+        "media_blocks": [],
         "start_index": op.start_index,
         "next_start": next_start,
         "total_length": total_length,

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -951,6 +951,64 @@ class PermissionResolver:
         ):
             raise PermissionError(f"tool {tool!r} access denied")
 
+    async def require_media_load(
+        self,
+        *,
+        size_bytes: int,
+        source: str,
+        mime_type: str,
+        max_bytes: int,
+        on_oversize: str,
+        bus: RequestBus,
+    ) -> None:
+        """Multi-modal cluster gate (issue #364) — applies to binary media
+        (images today; audio/video deferred) about to be loaded into LLM
+        context from web__fetch / file__read / MCP / user input.
+
+        Under-limit: returns immediately (= zero overhead for the common
+        case). At-or-over limit: behaves per ``on_oversize`` (see
+        ``MultimodalConfig``):
+
+          - ``allow`` → pass.
+          - ``deny`` → ``PermissionError`` (caller emits status="denied").
+          - ``ask`` → interactive prompt via 4-layer ``_approve`` flow:
+
+            Layer 1 (config):    ``media.oversize: allow`` → pre-approve.
+                                 ``media.oversize: deny`` → deny.
+            Layer 2 (approvals): ``media.oversize`` persistent decision.
+            Layer 3 (session):   prior in-memory decision (= ALWAYS/NEVER).
+            Layer 4 (interactive): prompt with concrete size + source.
+
+        The shared infrastructure is reused by #365 (file__read binary) and
+        #366 (user chat input image) — only the ``source`` string differs.
+        """
+        if size_bytes <= max_bytes:
+            return
+        if on_oversize == "allow":
+            return
+        if on_oversize == "deny":
+            raise PermissionError(
+                f"media load denied: {source} returned {size_bytes} bytes "
+                f"(limit {max_bytes}, multimodal.on_oversize=deny)"
+            )
+        # on_oversize == "ask" → 4-layer approval path.
+        size_mb = size_bytes / 1_000_000
+        limit_mb = max_bytes / 1_000_000
+        description = (
+            f"{source} returned media ({mime_type}, {size_mb:.1f}MB). "
+            f"Limit is {limit_mb:.1f}MB."
+        )
+        if not await self._approve(
+            "media.oversize",
+            description,
+            bus,
+            user_prompt="Load this oversize media into context?",
+        ):
+            raise PermissionError(
+                f"media load denied by user: {source} ({size_bytes} bytes "
+                f"> {max_bytes})"
+            )
+
     async def require_web_fetch(self, url: str, bus: RequestBus) -> None:
         """Tier 1 gate for web_fetch — no declaration required, full 4-layer approval.
 

--- a/tests/test_web_fetch_binary_media_gate.py
+++ b/tests/test_web_fetch_binary_media_gate.py
@@ -1,0 +1,371 @@
+"""Tier 2: web__fetch binary image content + shared media-size gate (issue #364).
+
+This is the first multi-modal cluster PR, so it also lands the shared
+infrastructure (= `MultimodalConfig` + `PermissionResolver.require_media_load`)
+that #365 (file__read) and #366 (user input) will reuse.
+
+What we pin:
+  - Config parsing: defaults + explicit values + bad-type fallback.
+  - PermissionResolver.require_media_load: allow / deny / ask branches.
+  - handle_web_fetch image path: under-limit returns media_blocks; over-limit
+    on_oversize=deny returns status=denied; on_oversize=allow loads the image;
+    text-only HTML response is unchanged (= backward compat).
+
+Real PermissionResolver, real OpContext, no collaborator mocks. The
+intervention bus uses a fake that pre-answers the prompt without spinning
+up the chat-session intervention machinery.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from reyn.config import MultimodalConfig, _build_multimodal_config
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import (
+    InterventionAnswer,
+    UserIntervention,
+)
+
+# ── config parsing ─────────────────────────────────────────────────────
+
+
+def test_multimodal_config_defaults_when_empty() -> None:
+    """Tier 2: missing / empty multimodal: section → 5MB cap, ask policy."""
+    cfg = _build_multimodal_config(None)
+    assert cfg.max_bytes == 5_000_000
+    assert cfg.on_oversize == "ask"
+
+
+def test_multimodal_config_parses_explicit_values() -> None:
+    """Tier 2: explicit YAML dict → values flow through."""
+    cfg = _build_multimodal_config({"max_bytes": 10_000_000, "on_oversize": "deny"})
+    assert cfg.max_bytes == 10_000_000
+    assert cfg.on_oversize == "deny"
+
+
+def test_multimodal_config_rejects_unknown_on_oversize() -> None:
+    """Tier 2: invalid on_oversize value falls back to ask (= safest)."""
+    cfg = _build_multimodal_config({"on_oversize": "explode"})
+    assert cfg.on_oversize == "ask"
+
+
+def test_multimodal_config_rejects_negative_max_bytes() -> None:
+    """Tier 2: negative max_bytes falls back to default (= prevents accidental
+    'every image is over the limit' configurations).
+    """
+    cfg = _build_multimodal_config({"max_bytes": -1})
+    assert cfg.max_bytes == 5_000_000
+
+
+# ── PermissionResolver.require_media_load ──────────────────────────────
+
+
+class _FakeBus:
+    """Drop-in for RequestBus that pre-answers the prompt with `answer`."""
+
+    def __init__(self, answer: str) -> None:
+        self._answer = answer
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        return InterventionAnswer(text="", choice_id=self._answer)
+
+
+def _resolver(tmp_path: Path, *, config: dict | None = None, interactive: bool = True) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=config or {},
+        project_root=tmp_path,
+        interactive=interactive,
+    )
+
+
+def test_gate_passes_when_under_limit(tmp_path) -> None:
+    """Tier 2: size <= max_bytes returns without consulting the bus."""
+    resolver = _resolver(tmp_path)
+    asyncio.run(
+        resolver.require_media_load(
+            size_bytes=1_000_000,  # well under 5MB
+            source="web fetch https://example.com/x.png",
+            mime_type="image/png",
+            max_bytes=5_000_000,
+            on_oversize="ask",
+            bus=_FakeBus("never_called"),
+        )
+    )
+
+
+def test_gate_allow_skips_prompt_when_over_limit(tmp_path) -> None:
+    """Tier 2: on_oversize="allow" lets oversized media through without a
+    prompt (= unattended pipeline use case).
+    """
+    resolver = _resolver(tmp_path)
+    asyncio.run(
+        resolver.require_media_load(
+            size_bytes=10_000_000,
+            source="web fetch https://big.example/x.png",
+            mime_type="image/png",
+            max_bytes=5_000_000,
+            on_oversize="allow",
+            bus=_FakeBus("never_called"),
+        )
+    )
+
+
+def test_gate_deny_raises_when_over_limit(tmp_path) -> None:
+    """Tier 2: on_oversize="deny" raises PermissionError without prompting
+    (= silent reject for cost-sensitive contexts).
+    """
+    resolver = _resolver(tmp_path)
+    with pytest.raises(PermissionError, match="multimodal.on_oversize=deny"):
+        asyncio.run(
+            resolver.require_media_load(
+                size_bytes=10_000_000,
+                source="web fetch https://big.example/x.png",
+                mime_type="image/png",
+                max_bytes=5_000_000,
+                on_oversize="deny",
+                bus=_FakeBus("never_called"),
+            )
+        )
+
+
+def test_gate_ask_yes_passes(tmp_path) -> None:
+    """Tier 2: on_oversize="ask" + user says yes → no exception (= image loads)."""
+    resolver = _resolver(tmp_path)
+    asyncio.run(
+        resolver.require_media_load(
+            size_bytes=10_000_000,
+            source="web fetch https://big.example/x.png",
+            mime_type="image/png",
+            max_bytes=5_000_000,
+            on_oversize="ask",
+            bus=_FakeBus("yes"),
+        )
+    )
+
+
+def test_gate_ask_no_raises(tmp_path) -> None:
+    """Tier 2: on_oversize="ask" + user says no → PermissionError (=
+    image dropped, caller emits status=denied).
+    """
+    resolver = _resolver(tmp_path)
+    with pytest.raises(PermissionError, match="denied by user"):
+        asyncio.run(
+            resolver.require_media_load(
+                size_bytes=10_000_000,
+                source="web fetch https://big.example/x.png",
+                mime_type="image/png",
+                max_bytes=5_000_000,
+                on_oversize="ask",
+                bus=_FakeBus("no"),
+            )
+        )
+
+
+def test_gate_config_layer_preapproves_oversize(tmp_path) -> None:
+    """Tier 2: reyn.yaml `media.oversize: allow` pre-approves session-wide;
+    Layer 4 prompt never fires.
+    """
+    resolver = _resolver(
+        tmp_path, config={"media.oversize": "allow"}, interactive=False,
+    )
+    asyncio.run(
+        resolver.require_media_load(
+            size_bytes=10_000_000,
+            source="web fetch https://big.example/x.png",
+            mime_type="image/png",
+            max_bytes=5_000_000,
+            on_oversize="ask",
+            bus=_FakeBus("never_called"),
+        )
+    )
+
+
+# ── handle_web_fetch image path ────────────────────────────────────────
+
+
+class _CapturingImageClient:
+    """Returns a fixed image/png body for handle_web_fetch end-to-end tests."""
+
+    body_bytes: bytes = b""
+    content_type: str = "image/png"
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._response = httpx.Response(
+            200,
+            headers={"content-type": type(self).content_type},
+            content=type(self).body_bytes,
+            request=httpx.Request("GET", "https://example.com/foo.png"),
+        )
+
+    async def __aenter__(self) -> "_CapturingImageClient":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    async def get(self, url: str) -> httpx.Response:
+        return self._response
+
+
+def _make_ctx(tmp_path: Path, *, multimodal: MultimodalConfig, bus_answer: str = "yes") -> Any:
+    from reyn.events.events import EventLog
+    from reyn.op_runtime.context import OpContext
+    from reyn.workspace.workspace import Workspace
+
+    events = EventLog()
+    # Pre-approve the URL-level web.fetch gate via config so these tests
+    # exercise ONLY the media-size gate. The URL gate's behaviour is
+    # covered by test_web_fetch_unified.py — out of scope here.
+    resolver = _resolver(tmp_path, config={"web.fetch": "allow"})
+    workspace = Workspace(events=events, permission_resolver=resolver)
+    return OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        intervention_bus=_FakeBus(bus_answer),  # type: ignore[arg-type]
+        multimodal_config=multimodal,
+    )
+
+
+def test_image_under_limit_returns_media_blocks(tmp_path, monkeypatch) -> None:
+    """Tier 2: image/png response under cap → media_blocks carries base64
+    payload, content empty, status=ok.
+    """
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.web import handle_web_fetch
+    from reyn.schemas.models import WebFetchIROp
+
+    _CapturingImageClient.body_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 200  # ~200 bytes
+    _CapturingImageClient.content_type = "image/png"
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingImageClient)
+
+    # Pre-approve web_fetch URL gate so we exercise only the media gate.
+    ctx = _make_ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"),
+        bus_answer="yes",  # if web.fetch prompt fires, accept
+    )
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com/foo.png")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["content"] == ""
+    assert result["extractor"] == "binary"
+    assert len(result["media_blocks"]) == 1
+    block = result["media_blocks"][0]
+    assert block["type"] == "image"
+    assert block["mimeType"] == "image/png"
+    # base64 decodes back to the raw image bytes.
+    assert base64.b64decode(block["data"]) == _CapturingImageClient.body_bytes
+
+
+def test_image_over_limit_with_deny_returns_status_denied(tmp_path, monkeypatch) -> None:
+    """Tier 2: image > cap + on_oversize=deny → result status=denied, no
+    media_blocks, no model-context bloat.
+    """
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.web import handle_web_fetch
+    from reyn.schemas.models import WebFetchIROp
+
+    _CapturingImageClient.body_bytes = b"x" * 10_000_000  # 10MB
+    _CapturingImageClient.content_type = "image/png"
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingImageClient)
+
+    ctx = _make_ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+        bus_answer="yes",
+    )
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com/big.png")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "denied"
+    assert "media_blocks" not in result or not result.get("media_blocks")
+    assert result["size_bytes"] == 10_000_000
+
+
+def test_image_over_limit_with_ask_no_returns_status_denied(tmp_path, monkeypatch) -> None:
+    """Tier 2: image > cap + on_oversize=ask + user says no → status=denied."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.web import handle_web_fetch
+    from reyn.schemas.models import WebFetchIROp
+
+    _CapturingImageClient.body_bytes = b"x" * 10_000_000
+    _CapturingImageClient.content_type = "image/jpeg"
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingImageClient)
+
+    ctx = _make_ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"),
+        bus_answer="no",
+    )
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com/big.jpg")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "denied"
+
+
+def test_image_over_limit_with_allow_returns_media_blocks(tmp_path, monkeypatch) -> None:
+    """Tier 2: image > cap + on_oversize=allow → loads anyway, no prompt."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.web import handle_web_fetch
+    from reyn.schemas.models import WebFetchIROp
+
+    _CapturingImageClient.body_bytes = b"x" * 10_000_000
+    _CapturingImageClient.content_type = "image/png"
+    monkeypatch.setattr(httpx, "AsyncClient", _CapturingImageClient)
+
+    ctx = _make_ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="allow"),
+        bus_answer="never_called",
+    )
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com/big.png")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "ok"
+    assert len(result["media_blocks"]) == 1
+
+
+def test_html_response_unchanged_when_image_gate_present(tmp_path, monkeypatch) -> None:
+    """Tier 2: text/html response → media_blocks is empty list, content is
+    extracted text. Backward compat with #355 / #357 paths preserved.
+    """
+    monkeypatch.chdir(tmp_path)
+    from reyn.op_runtime.web import handle_web_fetch
+    from reyn.schemas.models import WebFetchIROp
+
+    class _HTMLClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self._response = httpx.Response(
+                200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                content=b"<html><body><p>hello world</p></body></html>",
+                request=httpx.Request("GET", "https://example.com"),
+            )
+        async def __aenter__(self) -> "_HTMLClient":
+            return self
+        async def __aexit__(self, *args: object) -> None: pass
+        async def get(self, url: str) -> httpx.Response: return self._response
+
+    monkeypatch.setattr(httpx, "AsyncClient", _HTMLClient)
+
+    ctx = _make_ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"),
+        bus_answer="yes",
+    )
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["media_blocks"] == []
+    assert "hello world" in result["content"]
+    assert result["extractor"] in {"trafilatura", "stdlib"}


### PR DESCRIPTION
**[e2e-coder]** — closes #364. First PR of the multi-modal cluster (= follow-up to PR #354 honest-update review). Lands shared infrastructure that #365 / #366 will reuse.

## Summary

- New \`multimodal:\` config section (\`max_bytes\` default 5MB / \`on_oversize\` default \`ask\`).
- New \`PermissionResolver.require_media_load\` — 4-layer approval mirroring \`require_web_fetch\` / \`require_mcp\`.
- \`handle_web_fetch\` now detects \`image/*\` content-types and returns \`media_blocks\` instead of decoding bytes as text. Over-limit triggers iv prompt (or silent allow/deny per config).
- Full wiring: \`ChatSession → Agent → OSRuntime → ControlIRExecutor → OpContext\` + \`RouterHostAdapter\`. CLI (chat + dogfood) reads \`config.multimodal\`.

## How the gate behaves

\`\`\`
size ≤ max_bytes  → pass (zero overhead)
size > max_bytes  →
  on_oversize=allow → silently load
  on_oversize=deny  → silently raise PermissionError → status="denied"
  on_oversize=ask   → 4-layer approval:
    Layer 1 config:    media.oversize: allow | deny
    Layer 2 approvals: media.oversize entry
    Layer 3 session:   prior in-memory ALWAYS / NEVER
    Layer 4 interactive: prompt user with size + source + mime
\`\`\`

## Test plan

- [x] \`pytest tests/test_web_fetch_binary_media_gate.py\` — 15/15 pass
- [x] \`pytest -k 'web_fetch or web_search or permission or multimodal or mcp'\` — 520/520 (no regression)
- [x] \`ruff check\` on touched files — clean
- [ ] **Manual**: \`reyn chat\` "fetch https://example.com/diagram.png and describe it" with default 5MB cap → expect either inline render OR iv prompt for oversized image.
- [ ] **Manual**: add \`multimodal: {max_bytes: 100, on_oversize: deny}\` to reyn.yaml → repeat → expect status=denied without prompt.

## Out of scope

- \`audio/*\`, \`video/*\` (deferred — limited Reyn use case today).
- Byte-indexed pagination for binary content (separate issue if needed).

## Follow-ups

- **#365** file__read binary — imports the gate.
- **#366** user chat input image — imports the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)