### PR TITLE
fix(tui): sticky status priority guard for plan vs router-loop collision

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -35,6 +35,24 @@ if TYPE_CHECKING:
 _STOP = "stop"
 
 
+# Body prefixes emitted by ``planner.py`` for plan-progress status updates.
+# Used by ``_on_status`` to recognise a plan-sourced sticky body that
+# should not be overwritten by an unrelated router-loop status update.
+# Kept here (not in planner.py) because the priority policy is a TUI
+# UX choice, not a planner contract.
+_PLAN_SOURCED_BODY_PREFIXES: tuple[str, ...] = (
+    "plan step ",
+    "plan started ",
+    "リトライ ",
+)
+
+
+def _is_plan_sourced_body(body: str) -> bool:
+    """Return True when ``body`` looks like a plan-sourced status emission."""
+    stripped = body.lstrip()
+    return any(stripped.startswith(p) for p in _PLAN_SOURCED_BODY_PREFIXES)
+
+
 # Re-export for backward compatibility — moved to a shared module so the
 # right_panel widgets can use it without creating an import cycle through
 # app_outbox.
@@ -604,8 +622,35 @@ class OutboxRouter:
         A live ``⟳ thinking…`` must outlive any pending transient timer
         from a slash command that fired just before this turn started —
         otherwise the auto-hide kills the agent's spinner mid-thought.
+
+        Priority guard: ``planner.py`` and ``router_loop.py`` both emit
+        ``kind="status"`` messages that flow through the same sticky bar.
+        Without a guard, a router-loop "dispatched N async requests"
+        update arrives mid-plan and overwrites the more-informative
+        "plan step N/M: <desc>" counter — the user briefly loses the
+        per-step location they just saw and the elapsed timer resets
+        each swap.
+
+        ``planner.py`` already tags its emissions with
+        ``meta={"source": "plan", ...}``; the router-loop "dispatched"
+        path does not. When the incoming message lacks that source tag
+        AND the currently-displayed sticky body matches a plan-shaped
+        prefix (``plan step``, ``plan started``, or the retry banner
+        ``リトライ``), the lower-priority dispatch update is dropped.
+        Plan-sourced updates always go through, so step counters
+        continue to advance normally.
         """
         self._cancel_transient_timer()
+        incoming_source = (msg.meta or {}).get("source")
+        if incoming_source != "plan":
+            try:
+                snap = conv._sticky().snapshot() if conv._sticky() else None
+            except Exception:
+                snap = None
+            if snap and snap.get("active"):
+                current_body = str(snap.get("body", ""))
+                if _is_plan_sourced_body(current_body):
+                    return  # don't overwrite the higher-priority plan status
         conv.show_status(msg.text, kind="thinking")
 
     def _on_trace(


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 8/N (S4)

## Summary

- ``app_outbox._on_status`` now inspects ``msg.meta["source"]`` and the current sticky body; a non-``plan``-sourced status update is dropped when the displayed body looks plan-sourced (``plan step …`` / ``plan started …`` / ``リトライ …``).
- Plan-sourced updates always go through, so step counters advance normally; router-loop "dispatched N async requests" no longer flashes over the live ``plan step N/M`` counter.

## Observation (wave-5 S4)

Sub-agent reported:

> Both ``router_loop.py`` ("dispatched N async requests; awaiting peer reply") and ``planner.py`` ("plan step N/M: …") emit ``kind="status"`` → both route through ``StickyStatus.show()``, which resets the elapsed timer; the dispatch message arrives first … briefly replacing the plan-step counter with a semantically different message before the next step update overwrites it back.

Verified at the two emission sites:

- ``planner.py:1020`` tags with ``meta={"plan_id": ..., "chain_id": ..., "source": "plan"}``
- ``router_loop.py:1561`` tags only with ``meta={"chain_id": ...}`` — no source

So a discriminator already exists in the envelope; the TUI just wasn't using it. The fix is one-sided (TUI-internal) and doesn't touch ``planner.py`` / ``router_loop.py`` (= explicit decision; the priority policy is a UX choice, not a planner contract).

## Fix

```python
incoming_source = (msg.meta or {}).get("source")
if incoming_source != "plan":
    snap = conv._sticky().snapshot() if conv._sticky() else None
    if snap and snap.get("active"):
        current_body = str(snap.get("body", ""))
        if _is_plan_sourced_body(current_body):
            return  # don't overwrite the higher-priority plan status
conv.show_status(msg.text, kind="thinking")
```

The plan-body prefix list (``"plan step "``, ``"plan started "``, ``"リトライ "``) lives in ``app_outbox.py`` rather than ``planner.py`` because the priority policy is a TUI UX choice, not a planner contract. Cross-layer changes (= adding a priority field to OutboxMessage envelope) are avoided.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Code review of emission sites: planner.py emissions all carry ``meta["source"]="plan"``; router-loop emissions don't — discriminator is reliable.
- [ ] (skipped — manual reproduction of the timing collision requires triggering a multi-step plan and observing per-frame whether the step counter survives, which is hard to confirm visually at 0.1 s elapsed-tick resolution. The unit logic + defensive fallback (= guard fails open: status shows = current behaviour) carry the validation.)

## Refs

- wave-5 finding S4 (= triage list item 8, P2 S)
- ``planner.py`` already-existing ``meta["source"]="plan"`` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)