### PR TITLE
feat(tui): /attach mid-skill leaves a breadcrumb for interrupted runs

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -224,8 +224,28 @@ class OutboxRouter:
             header.refresh_status(agent_name=new_name)
             self._cancel_transient_timer()
             conv.hide_status()
+            # Capture the running-skill identities BEFORE conv.clear() so
+            # we can leave a breadcrumb after the wipe. Without this, a
+            # hot-swap mid-skill silently discards the running row — the
+            # user types ``/attach <other>`` and sees only ``── attached
+            # to <other> ──``, with no trace of the in-flight skill that
+            # just got cancelled. ``_skill_name`` / ``_short_id`` are
+            # SkillActivityRow's stable display identifiers; reading them
+            # here is intra-package coupling, but the alternative (a new
+            # public accessor) is more surface area for the same purpose.
+            interrupted: list[str] = []
+            for row in list(conv._skill_rows.values()):
+                try:
+                    interrupted.append(
+                        f"✗ {row._skill_name}#{row._short_id}"
+                        " — interrupted by /attach"
+                    )
+                except Exception:
+                    pass
             conv.clear()
             from rich.text import Text as _RichText
+            for line in interrupted:
+                conv._write_log(_RichText(line, style="dim #888888"))
             conv._write_log(_RichText(
                 f"── attached to {new_name} ──",
                 style="dim #555555",


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 9/N (S5)

## Summary

- ``_on_attach_request`` now captures running-skill identities (``skill#<short_id>``) **before** ``conv.clear()`` and writes a dim ``✗ skill#<id> — interrupted by /attach`` line into the freshly-cleared log for each interrupted run.
- The breadcrumbs land above the attach divider so the user sees what was lost first, then the new context.

## Observation (wave-5 S5)

Sub-agent reported:

> When ``/attach <agent>`` fires while a skill is running on the current agent, ``_on_attach_request`` calls ``conv.clear()`` which force-finishes all ``_skill_rows`` with ``reason="cleared"`` and removes all DOM widgets — the running skill's final state (success/abort) is discarded with no inline signal to the user.

Verified at ``conversation.py:1272-1281``:

```python
def clear(self):
    self._log().clear()
    ...
    for row in list(self._skill_rows.values()):
        row.finish(success=True, reason="cleared")
    self._skill_rows.clear()
    ...
```

The ``reason="cleared"`` finish call updates state, but since the entire log is then wiped + the widget removed, the user never sees ``✗`` or ``cleared``. From the user's perspective the running skill vanished without acknowledgement.

## Fix

Capture identities before the wipe, then write breadcrumbs into the cleared log:

```python
interrupted: list[str] = []
for row in list(conv._skill_rows.values()):
    interrupted.append(f"✗ {row._skill_name}#{row._short_id} — interrupted by /attach")

conv.clear()

for line in interrupted:
    conv._write_log(_RichText(line, style="dim #888888"))
conv._write_log(_RichText(f"── attached to {new_name} ──", style="dim #555555"))
```

Order is intentional: the breadcrumbs appear ABOVE the attach divider so the user reads them in the natural top-down order (what was lost → new context). Matches the existing Ctrl+C cancel-message pattern.

``_skill_name`` / ``_short_id`` are SkillActivityRow's stable display identifiers; reading them here is intra-package coupling, but adding a public accessor is more surface area for the same purpose. The try/except keeps a malformed row from breaking the attach flow.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Code review: no tests pin the current "silently discards" behaviour; the breadcrumb line is additive.
- [ ] (skipped — manual reproduction requires triggering a long-running skill, switching agents mid-run, and observing the breadcrumb. Wave-5 manual TUI sessions consistently hit slow planner LLM completion timing that made this verification path unreliable in finite time. The defensive try/except guarantees no worse than current behaviour on edge cases.)

## Refs

- wave-5 finding S5 (= triage list item 9, P2 S)
- ``conv.clear`` in ``widgets/conversation.py`` — the wipe site whose silent discard this PR breadcrumbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)