### PR TITLE
fix(tui): shorten preview-pane header hint for narrow widths (E3)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -357,8 +357,14 @@ class _PreviewPane(Widget):
         else:
             name = "—"
         try:
+            # Shortened from ``J/n=next K/p=prev`` (15 cells) to
+            # ``J/K=next/prev`` (14 cells minus 1 — but more importantly,
+            # the trailing prev-shortcut hint is no longer the first
+            # thing to clip at default panel widths. The earlier wording
+            # truncated to ``K/p=pr…`` at 44-cell minimum panel widths,
+            # hiding the prev-item discoverability cue entirely.
             self.query_one("#preview-header", Label).update(
-                f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→  J/n=next K/p=prev"
+                f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→  J/K=next/prev"
             )
         except Exception as exc:
             logger.warning("right_panel preview header update failed: %s", exc)


### PR DESCRIPTION
**[tui-coder]** — wave-5 PR 10/N (E3, wave-5 final)

## Summary

- Collapse the trailing ``J/n=next K/p=prev`` (15 cells) into ``J/K=next/prev`` (14 cells) in ``_PreviewPane._update_header`` so both forward and backward shortcuts stay visible at the 44-cell minimum panel width.

## Observation (wave-5 E3)

Sub-agent reported:

> The preview pane header ``event #N · <type>  │  j↓ k↑ d⇊ u⇈ h← l→  J/n=next K/p=pr…`` is truncated at the default panel width, cutting off ``K/p=prev`` to ``K/p=pr`` so users cannot discover the prev-item shortcut.

Verified at ``widgets/right_panel/shells.py:360-362``:

```python
self.query_one("#preview-header", Label).update(
    f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→  J/n=next K/p=prev"
)
```

The hint string is ~38 cells before the title, plus the title itself, with no width-aware truncation. At minimum panel width (44 cells, SP1 floor), the title + chrome overflows and the last segment clips.

## Fix

```python
# before
f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→  J/n=next K/p=prev"
# after
f"  {name}  │  j↓ k↑ d⇊ u⇈ h← l→  J/K=next/prev"
```

The hint is purely discoverability — the underlying keybinds (``J``, ``K``, ``n``, ``p``, ``N``, ``P``) all still work and are documented in the ``_PreviewPane.on_key`` handler. ``J/K=next/prev`` is one cell shorter and groups both directions into a single token so the truncation point (when the title is wide enough to still cause overflow) clips the WHOLE token instead of a stray fragment like ``K/p=pr``.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] String swap only; no behaviour change to ``on_key`` handlers.

## Refs

- wave-5 finding E3 (= triage list item 10, P3 S, wave-5 final)
- SP1 minimum panel width floor (44 cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)