### PR TITLE
feat(multimodal): file__read binary image content (closes #365)

### DIFF
--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -14,10 +14,95 @@ from .context import OpContext
 _WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index", "mkdir", "move"})
 _READ_OPS = frozenset({"read", "glob", "grep", "stat"})
 
+# Issue #365: image extensions that trigger the binary read path.
+# Extension-based detection (= no magic-byte sniff for the initial scope);
+# unknown binaries still fall through to the text path with errors="replace"
+# (= pre-#365 behaviour preserved).
+_IMAGE_EXTENSIONS: dict[str, str] = {
+    ".png":  "image/png",
+    ".jpg":  "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif":  "image/gif",
+    ".webp": "image/webp",
+    ".svg":  "image/svg+xml",
+}
+
+
+def _image_mime_for_path(path: str) -> str | None:
+    """Return the image MIME type for ``path`` if its extension is in
+    ``_IMAGE_EXTENSIONS``, else None (= treat as text).
+    """
+    dot = path.rfind(".")
+    if dot == -1:
+        return None
+    return _IMAGE_EXTENSIONS.get(path[dot:].lower())
+
 # Max nearby-file suggestions returned on a not_found error. Mirrors the
 # ~8-suggestion shape that invoke_action's UnknownActionError emits so the
 # LLM's "did you mean X" narration looks the same across both surfaces.
 _NOT_FOUND_SUGGESTIONS_LIMIT = 8
+
+
+async def _read_image_file(op: FileIROp, ctx: OpContext, *, mime_type: str) -> dict:
+    """Read an image file as bytes, apply the media-size gate, return as
+    a media_blocks-bearing result (issue #365).
+
+    Permission-gate flow: the outer ``handle`` already called
+    ``require_file_read`` against ``op.path`` (= read-zone check). This
+    helper additionally calls ``require_media_load`` for the multi-modal
+    size cap (= shared with web__fetch / user input). When the gate
+    rejects, returns ``status="denied"`` with no media payload.
+    """
+    image_bytes, found = ctx.workspace.read_file_bytes(op.path)
+    if not found:
+        ctx.events.emit("tool_executed", op="read_file", path=op.path, found=False)
+        return {
+            "kind": "file", "op": "read", "path": op.path,
+            "status": "not_found",
+            "error": f"file not found: {op.path}",
+            "suggestions": _nearby_files(ctx.workspace, op.path),
+            "content": "",
+        }
+
+    if ctx.permission_resolver is not None and ctx.multimodal_config is not None:
+        if ctx.intervention_bus is None:
+            raise RuntimeError(
+                "file read of binary image requires intervention_bus on "
+                "OpContext (multimodal gate)"
+            )
+        try:
+            await ctx.permission_resolver.require_media_load(
+                size_bytes=len(image_bytes),
+                source=f"file read {op.path}",
+                mime_type=mime_type,
+                max_bytes=ctx.multimodal_config.max_bytes,
+                on_oversize=ctx.multimodal_config.on_oversize,
+                bus=ctx.intervention_bus,
+            )
+        except PermissionError as exc:
+            ctx.events.emit(
+                "file_read_media_denied",
+                path=op.path, size_bytes=len(image_bytes), mime_type=mime_type,
+            )
+            return {
+                "kind": "file", "op": "read", "path": op.path,
+                "status": "denied", "content_type": mime_type,
+                "size_bytes": len(image_bytes), "error": str(exc),
+            }
+
+    import base64
+    data_b64 = base64.b64encode(image_bytes).decode("ascii")
+    ctx.events.emit(
+        "tool_executed", op="read_file", path=op.path,
+        mode="binary", mime_type=mime_type, media_block_count=1,
+    )
+    return {
+        "kind": "file", "op": "read", "path": op.path,
+        "status": "ok", "content": "",
+        "media_blocks": [
+            {"type": "image", "data": data_b64, "mimeType": mime_type},
+        ],
+    }
 
 
 def _nearby_files(ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LIMIT) -> list[str]:
@@ -63,6 +148,11 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         return {"kind": "file", "op": "write", "path": op.path, "status": "ok"}
 
     if op.op == "read":
+        # Issue #365: image extensions → binary path with media-size gate.
+        image_mime = _image_mime_for_path(op.path)
+        if image_mime is not None:
+            return await _read_image_file(op, ctx, mime_type=image_mime)
+
         content, found = ctx.workspace.read_file(op.path)
         if not found:
             suggestions = _nearby_files(ctx.workspace, op.path)

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -71,6 +71,19 @@ class Workspace:
             return path.read_text(encoding="utf-8"), True
         return "", False
 
+    def read_file_bytes(self, path_str: str) -> tuple[bytes, bool]:
+        """Read a file as raw bytes (issue #365).
+
+        Mirrors ``read_file`` but skips text decoding — used by the file
+        handler's binary path (image/* extensions). Returns
+        ``(content_bytes, found)``. Raises PermissionError if the read is
+        denied by the workspace policy.
+        """
+        path = self._resolve_read(path_str)
+        if path.exists():
+            return path.read_bytes(), True
+        return b"", False
+
     def write_file(self, path_str: str, content: str) -> None:
         """Write a file into the project. Raises PermissionError if denied."""
         path = self._resolve_write(path_str)

--- a/tests/test_file_read_binary_media.py
+++ b/tests/test_file_read_binary_media.py
@@ -1,0 +1,241 @@
+"""Tier 2: file__read binary image content (issue #365).
+
+Imports the media-size gate landed in #364 and applies it to local
+image files read via ``FileIROp(op="read", path="...png")``.
+
+What we pin:
+  - Image extensions (.png/.jpg/.jpeg/.gif/.webp/.svg) trigger the
+    binary path → result carries media_blocks instead of garbage text.
+  - Non-image extensions take the existing text path unchanged.
+  - Media-size gate behaviour mirrors #364:
+      under-limit → media_blocks loaded
+      over-limit + deny → status=denied, no payload
+      over-limit + ask + user-no → status=denied
+  - File-not-found still surfaces cleanly with suggestions (= pre-#365
+    behaviour preserved for binary paths too).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+
+import pytest
+
+from reyn.config import MultimodalConfig
+from reyn.events.events import EventLog
+from reyn.op_runtime.context import OpContext
+from reyn.op_runtime.file import handle
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.schemas.models import FileIROp
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+from reyn.workspace.workspace import Workspace
+
+
+class _FakeBus:
+    def __init__(self, answer: str) -> None:
+        self._answer = answer
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        return InterventionAnswer(text="", choice_id=self._answer)
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=True,
+    )
+
+
+def _ctx(tmp_path: Path, *, multimodal: MultimodalConfig | None, bus_answer: str = "yes") -> OpContext:
+    events = EventLog()
+    resolver = _resolver(tmp_path)
+    workspace = Workspace(events=events, permission_resolver=resolver)
+    return OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        skill_name="test",
+        intervention_bus=_FakeBus(bus_answer),  # type: ignore[arg-type]
+        multimodal_config=multimodal,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── image extensions → binary path ─────────────────────────────────────
+
+
+def test_read_png_returns_media_block(tmp_path, monkeypatch):
+    """Tier 2: .png file → result carries media_blocks with base64 data
+    and mimeType image/png; content is empty.
+    """
+    monkeypatch.chdir(tmp_path)
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 300
+    (tmp_path / "shot.png").write_bytes(raw)
+
+    ctx = _ctx(tmp_path, multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"))
+    op = FileIROp(kind="file", op="read", path="shot.png")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["content"] == ""
+    assert len(result["media_blocks"]) == 1
+    block = result["media_blocks"][0]
+    assert block["type"] == "image"
+    assert block["mimeType"] == "image/png"
+    assert base64.b64decode(block["data"]) == raw
+
+
+@pytest.mark.parametrize(
+    "filename, expected_mime",
+    [
+        ("img.jpg", "image/jpeg"),
+        ("img.jpeg", "image/jpeg"),
+        ("anim.gif", "image/gif"),
+        ("pic.webp", "image/webp"),
+        ("icon.svg", "image/svg+xml"),
+        ("UPPER.PNG", "image/png"),  # case-insensitive extension match
+    ],
+)
+def test_read_recognised_image_extensions(tmp_path, monkeypatch, filename, expected_mime):
+    """Tier 2: each known image extension routes through the binary path
+    with the correct mimeType. Case-insensitive on the extension.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / filename).write_bytes(b"binary-payload")
+
+    ctx = _ctx(tmp_path, multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"))
+    op = FileIROp(kind="file", op="read", path=filename)
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["media_blocks"][0]["mimeType"] == expected_mime
+
+
+def test_read_text_file_unchanged_when_extension_not_image(tmp_path, monkeypatch):
+    """Tier 2: .md / .txt / .py extension → existing text path; no
+    media_blocks key. Backward compat with all callers that read code /
+    markdown.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "notes.md").write_text("# title\n\nhello world\n")
+
+    ctx = _ctx(tmp_path, multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"))
+    op = FileIROp(kind="file", op="read", path="notes.md")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert "hello world" in result["content"]
+    assert "media_blocks" not in result
+
+
+def test_read_unknown_extension_takes_text_path(tmp_path, monkeypatch):
+    """Tier 2: extension not in _IMAGE_EXTENSIONS (= .pdf / .bin / no
+    extension) takes the text path (= errors='replace' fallback). Pre-
+    #365 behaviour preserved for those file types — separate issue if
+    they need binary handling.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "noext").write_text("plain text")
+
+    ctx = _ctx(tmp_path, multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"))
+    op = FileIROp(kind="file", op="read", path="noext")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert result["content"] == "plain text"
+    assert "media_blocks" not in result
+
+
+# ── media-size gate (reuses #364 infra) ────────────────────────────────
+
+
+def test_oversize_image_with_deny_returns_status_denied(tmp_path, monkeypatch):
+    """Tier 2: image > cap + on_oversize=deny → status=denied, no media
+    payload, file-read permission gate already passed (= shape matches
+    web__fetch denied path from #364).
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "huge.png").write_bytes(b"x" * 10_000_000)
+
+    ctx = _ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+    )
+    op = FileIROp(kind="file", op="read", path="huge.png")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "denied"
+    assert result["size_bytes"] == 10_000_000
+    assert "media_blocks" not in result or not result.get("media_blocks")
+
+
+def test_oversize_image_with_ask_no_returns_status_denied(tmp_path, monkeypatch):
+    """Tier 2: image > cap + on_oversize=ask + user-no → status=denied."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "huge.jpg").write_bytes(b"x" * 10_000_000)
+
+    ctx = _ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"),
+        bus_answer="no",
+    )
+    op = FileIROp(kind="file", op="read", path="huge.jpg")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "denied"
+
+
+def test_oversize_image_with_allow_loads_anyway(tmp_path, monkeypatch):
+    """Tier 2: image > cap + on_oversize=allow → loads without prompt."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "huge.png").write_bytes(b"x" * 10_000_000)
+
+    ctx = _ctx(
+        tmp_path,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="allow"),
+        bus_answer="never_called",
+    )
+    op = FileIROp(kind="file", op="read", path="huge.png")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert len(result["media_blocks"]) == 1
+
+
+def test_no_multimodal_config_skips_gate(tmp_path, monkeypatch):
+    """Tier 2: when multimodal_config is None (= direct-OpContext tests
+    or callers that never built a ReynConfig), the gate is bypassed
+    entirely — backward compat for the legacy code path.
+    """
+    monkeypatch.chdir(tmp_path)
+    raw = b"any-size"
+    (tmp_path / "shot.png").write_bytes(raw)
+
+    ctx = _ctx(tmp_path, multimodal=None)
+    op = FileIROp(kind="file", op="read", path="shot.png")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "ok"
+    assert len(result["media_blocks"]) == 1
+
+
+# ── error paths ────────────────────────────────────────────────────────
+
+
+def test_read_missing_image_returns_not_found(tmp_path, monkeypatch):
+    """Tier 2: image extension + non-existent path → status=not_found
+    with suggestions list (= same shape as text not_found, NOT denied).
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "other.png").write_bytes(b"sibling")
+
+    ctx = _ctx(tmp_path, multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"))
+    op = FileIROp(kind="file", op="read", path="missing.png")
+    result = _run(handle(op, ctx, "control_ir"))
+
+    assert result["status"] == "not_found"
+    assert "suggestions" in result


### PR DESCRIPTION
**[e2e-coder]** — closes #365. Second PR of the multi-modal cluster. **Stacked on #374** (= retargets to main automatically once #374 merges).

## Summary

- New \`Workspace.read_file_bytes(path)\` helper.
- \`op_runtime/file.py\` op=\"read\" detects \`.png/.jpg/.jpeg/.gif/.webp/.svg\` extensions and routes them through a new \`_read_image_file\` async path that applies the shared media-size gate (from #364) and returns \`media_blocks\` instead of garbage text.
- Default text path is unchanged — backward compat for all callers reading code / markdown.

## Permission gate layering

| Layer | Check | Failure mode |
|---|---|---|
| A | workspace read-zone (existing \`require_file_read\`) | PermissionError raised |
| B | media-size gate (#364 \`require_media_load\`) | clean \`status=\"denied\"\` result |

## Test plan

- [x] \`pytest tests/test_file_read_binary_media.py\` — 14/14 pass
- [x] \`pytest -k 'file or multimodal or web_fetch'\` — 301/301 (no regression)
- [x] \`ruff check\` — clean
- [ ] **Manual**: \`reyn chat\` "describe ./screenshot.png" → expect image visible to LLM, assistant produces a description.
- [ ] **Manual**: read a 10MB png with default config (\`on_oversize: ask\`) → expect iv prompt; deny path leaves \`status=denied\` and the assistant explains it.

## Out of scope

- PDF / audio / video — separate issues if needed.
- Magic-byte detection for files without extensions — initial scope is extension-based.

## Cluster status

| Issue | PR | Status |
|---|---|---|
| #364 web__fetch + gate | #374 | open (base) |
| #365 file__read binary | this PR | open (stacked) |
| #366 user chat input image | next | TBD |

🤖 Generated with [Claude Code](https://claude.com/claude-code)