### PR TITLE
fix(run_skill): form-4 hallucination recovery — closes B47-NF-eval-1 FileNotFoundError 3/3 repro

### DIFF
--- a/src/reyn/op_runtime/run_skill.py
+++ b/src/reyn/op_runtime/run_skill.py
@@ -17,7 +17,7 @@ _log = logging.getLogger(__name__)
 def _resolve_skill_ref(skill_ref: str) -> tuple[str, Path, str | None]:
     """Resolve a sub-skill reference to ``(skill_md_path, path_for_hash, skill_root)``.
 
-    Accepts three reference shapes on the ``op.skill`` field:
+    Accepts four reference shapes on the ``op.skill`` field:
 
     1. **Bare name** — e.g. ``"direct_llm"``. Resolved via
        ``resolve_skill_path`` search order (reyn/local → reyn/project →
@@ -34,29 +34,74 @@ def _resolve_skill_ref(skill_ref: str) -> tuple[str, Path, str | None]:
     3. **Multi-segment literal path** — e.g.
        ``"reyn/local/my_app/skill.md"``. Passed through to
        ``load_dsl_skill`` as written.
+    4. **LLM-hallucination forms** (B47-NF-eval-1): router LLMs at flash-lite
+       hallucinate paths like ``"skills/direct_llm.yaml"``,
+       ``"skills/direct_llm.py"``, or ``"skills/skill__direct_llm.py"`` when
+       constructing ``target_skill_path`` for the eval skill. N=3
+       reproduction (2026-05-21) showed 3/3 failures with varying wrong paths.
+       Each hallucination has a recoverable bare-skill-name candidate buried
+       in the last path segment after stripping ``skill__`` prefix and any
+       ``.yaml`` / ``.py`` / ``.md`` extension. We try that candidate against
+       ``resolve_skill_path`` as a defensive last resort *before* falling
+       through to form 3 (= literal-path interpretation that would fail
+       relative to CWD). The form-3 fall-through is preserved for genuinely
+       literal callers.
     """
-    from reyn.skill.skill_paths import resolve_skill_path
+    from reyn.skill.skill_paths import SkillNotFoundError, resolve_skill_path
 
-    parts = skill_ref.split("/")
-    if "/" not in skill_ref and not skill_ref.endswith(".md"):
-        # form 1
-        skill_dir, inferred_root = resolve_skill_path(skill_ref)
+    def _pack(skill_dir: Path, inferred_root: Path) -> tuple[str, Path, str | None]:
         skill_md_path = str(skill_dir / "skill.md")
         path_for_hash = skill_dir / "skill.md"
-        skill_root = str(inferred_root) if inferred_root else None
-        return skill_md_path, path_for_hash, skill_root
+        skill_root_str = str(inferred_root) if inferred_root else None
+        return skill_md_path, path_for_hash, skill_root_str
+
+    parts = skill_ref.split("/")
+    form1_tried = False
+    if "/" not in skill_ref and not skill_ref.endswith(".md"):
+        # form 1: bare name
+        try:
+            return _pack(*resolve_skill_path(skill_ref))
+        except (SkillNotFoundError, FileNotFoundError):
+            form1_tried = True  # fall through to form 4
     if len(parts) == 2 and parts[1] == "skill.md" and parts[0]:
         # form 2: ``<name>/skill.md`` — try stdlib resolution by the
         # leading segment first.
         try:
-            skill_dir, inferred_root = resolve_skill_path(parts[0])
-            skill_md_path = str(skill_dir / "skill.md")
-            path_for_hash = skill_dir / "skill.md"
-            skill_root = str(inferred_root) if inferred_root else None
-            return skill_md_path, path_for_hash, skill_root
-        except FileNotFoundError:
+            return _pack(*resolve_skill_path(parts[0]))
+        except (SkillNotFoundError, FileNotFoundError):
+            pass  # fall through to form 4 then form 3
+    # form 4: LLM-hallucination recovery. Try extracting a bare skill name
+    # from the last path segment after stripping common extensions and the
+    # ``skill__`` action-alias prefix. Fires after forms 1/2 fail (= the
+    # caller's literal ref doesn't resolve as bare name nor as
+    # ``<name>/skill.md``). The form-3 literal fall-through stays in place
+    # for callers who actually mean a literal relative path.
+    last_segment = parts[-1] if parts else skill_ref
+    candidate = last_segment
+    for ext in (".yaml", ".py", ".md"):
+        if candidate.endswith(ext):
+            candidate = candidate[: -len(ext)]
+            break
+    if candidate.startswith("skill__"):
+        candidate = candidate[len("skill__"):]
+    if candidate and candidate != skill_ref:
+        try:
+            skill_dir, inferred_root = resolve_skill_path(candidate)
+            _log.warning(
+                "run_skill: recovered skill ref %r → %r via "
+                "form-4 LLM-hallucination normalization. Callers should "
+                "pass the bare skill name to avoid this fallback.",
+                skill_ref, candidate,
+            )
+            return _pack(skill_dir, inferred_root)
+        except (SkillNotFoundError, FileNotFoundError):
             pass  # fall through to form 3 literal-path interpretation
-    # form 3
+    # form 3: literal-path passthrough. If form 1 was tried and failed (= a
+    # bare-looking name that doesn't resolve), preserve the original
+    # SkillNotFoundError semantics by re-raising it; otherwise return the
+    # literal path for callers who mean a relative path.
+    if form1_tried:
+        raise SkillNotFoundError(skill_ref, [])
     return skill_ref, Path(skill_ref), None
 
 

--- a/tests/test_run_skill_form4_hallucination_recovery.py
+++ b/tests/test_run_skill_form4_hallucination_recovery.py
@@ -1,0 +1,141 @@
+"""Tier 2: ``_resolve_skill_ref`` recovers LLM-hallucinated path forms.
+
+Pinned invariants:
+
+- Form 1 (bare name): unchanged contract, still resolves via
+  ``resolve_skill_path``.
+- Form 2 (``<name>/skill.md``): unchanged contract, still resolves
+  via leading-segment lookup.
+- **Form 4 (B47-NF-eval-1)**: router LLMs at flash-lite hallucinate
+  paths like ``"skills/direct_llm.yaml"``, ``"skills/direct_llm.py"``,
+  ``"skills/skill__direct_llm.py"`` when constructing
+  ``target_skill_path`` for the eval skill. The resolver now extracts
+  a bare-skill-name candidate from the last path segment after
+  stripping ``skill__`` prefix and the ``.yaml`` / ``.py`` / ``.md``
+  extension, tries it against ``resolve_skill_path``, and on success
+  returns the resolved skill.
+- Form 3 fall-through preserved: when the hallucination-recovery
+  candidate also fails, the literal-path interpretation kicks in for
+  pre-form-4 callers who genuinely pass a relative path.
+- Reproducibility evidence (2026-05-21 N=3 reproduction of B47-W2-S5
+  eval scenario): every run hit FileNotFoundError with a different
+  hallucinated path. After form 4, all 3 resolve to ``direct_llm``.
+
+testing.ja.md compliance:
+- No mocks. Real ``_resolve_skill_ref`` called against the real
+  stdlib skill tree.
+- Tier 2 contract pin: the resolver's documented input → output map.
+- No private-state assertions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.op_runtime.run_skill import _resolve_skill_ref
+from reyn.skill.skill_paths import SkillNotFoundError
+
+# ---------------------------------------------------------------------------
+# Form 4: LLM-hallucination recovery — the headline B47-NF-eval-1 fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hallucinated_ref", [
+    "skills/direct_llm.yaml",            # n3 of B47 reproduction
+    "skills/direct_llm.py",              # n2
+    "skills/skill__direct_llm.py",       # n1
+])
+def test_form4_recovers_known_hallucinations_to_direct_llm(hallucinated_ref):
+    """Tier 2 (B47-fix): each of the 3 N=3-reproduced hallucination
+    forms resolves to direct_llm via form-4 normalization."""
+    md_path, _path_for_hash, _root = _resolve_skill_ref(hallucinated_ref)
+    assert md_path.endswith("/stdlib/skills/direct_llm/skill.md"), (
+        f"hallucinated ref {hallucinated_ref!r} should resolve to "
+        f"direct_llm via form-4 recovery. Got: {md_path!r}"
+    )
+
+
+@pytest.mark.parametrize("ref,expected_skill", [
+    # Strip .yaml extension + nested path
+    ("skills/word_stats_demo.yaml", "word_stats_demo"),
+    # Strip .py extension + skill__ prefix + nested path
+    ("skills/skill__word_stats_demo.py", "word_stats_demo"),
+    # Strip just .md extension + skill__ prefix
+    ("skill__direct_llm.md", "direct_llm"),
+    # Single-segment with extension
+    ("direct_llm.yaml", "direct_llm"),
+])
+def test_form4_strips_extension_and_skill_prefix(ref, expected_skill):
+    """Tier 2: form-4 covers the normalization combinations — extension
+    stripping, ``skill__`` prefix stripping, and nested path tail
+    extraction, in either order or combination."""
+    md_path, _, _ = _resolve_skill_ref(ref)
+    assert md_path.endswith(f"/stdlib/skills/{expected_skill}/skill.md"), (
+        f"ref {ref!r} should normalize to {expected_skill!r}. Got: {md_path!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Form 1-3: regression guards
+# ---------------------------------------------------------------------------
+
+
+def test_form1_bare_name_unchanged():
+    """Tier 2: regression — bare skill name still resolves identically
+    to pre-form-4 behavior."""
+    md_path, _, _ = _resolve_skill_ref("direct_llm")
+    assert md_path.endswith("/stdlib/skills/direct_llm/skill.md")
+
+
+def test_form2_short_name_slash_skill_md_unchanged():
+    """Tier 2: regression — ``<name>/skill.md`` form still resolves
+    via leading-segment lookup."""
+    md_path, _, _ = _resolve_skill_ref("direct_llm/skill.md")
+    assert md_path.endswith("/stdlib/skills/direct_llm/skill.md")
+
+
+def test_form3_genuine_literal_path_passes_through():
+    """Tier 2: regression — a multi-segment literal path that doesn't
+    match any stdlib skill (= form 4 candidate also fails) falls
+    through to literal-path interpretation. The returned md_path is
+    the input verbatim — caller's open() will fail with FileNotFound
+    as before, NOT silently resolve to something else."""
+    ref = "reyn/local/my_imaginary_app/skill.md"
+    md_path, _path_for_hash, root = _resolve_skill_ref(ref)
+    assert md_path == ref, (
+        f"genuine literal path must pass through verbatim. Got: {md_path!r}"
+    )
+    assert root is None
+
+
+def test_form4_does_not_shadow_form1_for_valid_bare_name():
+    """Tier 2: form-4 only fires after forms 1-3 fail. A genuine bare
+    name with a real skill on disk must not trigger form-4
+    normalization. We verify by checking that the input was treated
+    as form 1 — the result path matches form 1's output."""
+    md_path, _, _ = _resolve_skill_ref("word_stats_demo")
+    assert md_path.endswith("/stdlib/skills/word_stats_demo/skill.md")
+
+
+# ---------------------------------------------------------------------------
+# Form 4: failure modes — when normalization can't help
+# ---------------------------------------------------------------------------
+
+
+def test_form4_unknown_skill_falls_through_to_form3():
+    """Tier 2: when the form-4 candidate can't be resolved either (=
+    truly unknown skill name), the function falls through to form 3
+    literal-path interpretation rather than raising."""
+    ref = "skills/totally_made_up_skill_x9z7.yaml"
+    md_path, _, root = _resolve_skill_ref(ref)
+    # Form 3: returned as-is, no resolution. Caller's open() will
+    # FileNotFoundError later — that surfaces the issue to the user.
+    assert md_path == ref
+    assert root is None
+
+
+def test_form1_strictness_preserved_for_truly_bare_unknown_name():
+    """Tier 2: a bare name with no matching skill still raises
+    SkillNotFoundError — form 4 does not silently allow unknown bare
+    names through (= bare names go to form 1, which raises)."""
+    with pytest.raises(SkillNotFoundError):
+        _resolve_skill_ref("totally_made_up_skill_x9z7_bare")


### PR DESCRIPTION
**[dogfood-coder]** — Router LLMs at flash-lite consistently hallucinate the \`target_skill_path\` field when invoking the eval skill with a stdlib target. N=3 reproduction (2026-05-21 B47 W2-S5 \`eval_run_direct_llm\` via A2A POST, identical prompts) hit FileNotFoundError **3/3** with varying wrong paths:

- n1: \`"skills/skill__direct_llm.py"\`
- n2: \`"skills/direct_llm.py"\`
- n3: \`"skills/direct_llm.yaml"\`

Each path is a deterministic combination of LLM confusion signals:
- \`skills/\` directory prefix (= LLM thinks skills live there)
- \`skill__\` action-alias prefix (= router sees this in hot-list)
- \`.py\` / \`.yaml\` extension (= LLM thinks skills are .py or .yaml files)

The eval skill's run_target phase faithfully passed these to \`run_skill\` op → \`_resolve_skill_ref\` → \`FileNotFoundError\`. The bug is **NOT in eval skill** (= \`run_target.md\` correctly says "use verbatim from the artifact"); the **router LLM at the \`invoke_action(skill__eval)\` call site is the source**. Prompt-layer fix is brittle for flash-lite, so defensive normalization at the resolver layer is the practical fix per the \`feedback_envelope_layer_fix\` ladder (envelope > schema > SP content).

## Fix

Add form 4 to \`_resolve_skill_ref\`. When forms 1-2 fail, extract a bare-skill-name candidate from the last path segment after stripping:
- \`.yaml\` / \`.py\` / \`.md\` extension
- \`skill__\` action-alias prefix
- Everything before the final \`/\`

Try the candidate against \`resolve_skill_path\`. On success, emit a warning log (= visibility for callers passing non-canonical refs) and return the resolved skill. On failure, fall through to form 3 literal-path interpretation as before.

## Edge cases handled

- form 1 (bare name) failing now ALSO falls through to form 4, then re-raises SkillNotFoundError if form 4 can't recover (= preserves legacy strictness for truly unknown bare names)
- form 3 literal-path semantics unchanged for genuine relative refs
- \`"X/skill.md"\` form 2 contract preserved

## Test plan

- [x] **13 Tier 2 tests**:
  - 7 form-4 recovery cases (= 3 N=3-repro hallucinations + 4 more extension/prefix/path combinations)
  - 4 regression guards (= forms 1-3 unchanged behavior)
  - 2 failure-mode guards (= unknown bare name re-raises SkillNotFoundError, form 3 fall-through preserved)
- [x] **55 existing run_skill / resolve_skill / skill_runner tests pass**
- [x] **ruff clean**
- [ ] B48 dogfood verifies B47-W2-S5 \`eval_run_direct_llm\` scenario no longer fails with FileNotFoundError (= primary end-to-end check)

## Methodology note

This fix follows the \`feedback_code_inspection_not_enough_for_fix\` discipline: N=3 reproduction confirmed deterministic trigger rate (3/3) before proposing structural fix.

The B47 N=1 observation alone was classified as "not yet confirmed" by user pushback (= correct challenge per \`feedback_pre_conclusion_observation_checklist\`); N=3 reproducibility moved it from hypothesis to confirmed bug. Separately verified that the other 2 candidates (#337 wrapper "stats=0" / #358 build_skill "invalid JSON") were N=0/3 and N=1/3 respectively — those were noise, NOT real bugs, and have been retracted from the bug list.

## References

- B47 retrospective W2-S5 \`eval_run_direct_llm\` R verdict (= primary observation)
- N=3 reproducibility check (2026-05-21) — see commit message for n1/n2/n3 paths
- \`feedback_code_inspection_not_enough_for_fix\` — trigger-rate observation required for structural attribution
- \`feedback_pre_conclusion_observation_checklist\` — operationalised by user pushback during retrospective interpretation

🤖 Generated with [Claude Code](https://claude.com/claude-code)