### PR TITLE
fix(tui): split Events tab filter-empty hint so [t] survives narrow widths (E5)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -566,12 +566,18 @@ def render_events(
         #      visible when the panel is wider than the filter name).
         if not all_events:
             return "[#555555]  (no matching events)[/]", []
+        # Split the two hints across separate lines so each survives the
+        # 44-cell minimum panel width independently. The single-line
+        # form was ~47 cells and clipped to ``press [f] to cycle filter
+        # · [t] for ta…`` at narrow widths, hiding the ``[t]`` tail-size
+        # discoverability cue entirely.
         return (
             f"[#555555]  (no events matching filter: [/]"
             f"[bold #aaaaaa]{_esc(filter_name)}[/][#555555])[/]\n"
             f"[#555555]  press [/][bold #aaaaaa]\\[f][/]"
-            f"[#555555] to cycle filter · [/]"
-            f"[bold #aaaaaa]\\[t][/][#555555] for tail size[/]"
+            f"[#555555] to cycle filter[/]\n"
+            f"[#555555]  press [/][bold #aaaaaa]\\[t][/]"
+            f"[#555555] for tail size[/]"
         ), []
 
     # Newest-first window — also returned to the caller for cursor / preview


### PR DESCRIPTION
**[tui-coder]** — wave-5 parking lot drain 1/N (E5)

## Summary

- Split the filter-empty hint ``press [f] to cycle filter · [t] for tail size`` (47 cells) into two short lines so each fits the 44-cell minimum panel width independently.

## Observation (wave-5 E5, parking lot)

Sub-agent reported:

> When a filter has no matching events, the second line of the empty-state message ``press [f] to cycle filter · [t] for tail size`` is truncated to ``press [f] to cycle filter · [t] for ta…`` at default panel width, hiding the ``[t]`` tail-size hint.

Verified via Python repro: at panel width ~44 cells the line clips and the ``[t]`` tail-size cue disappears entirely. The cap indicator ``[t]:200`` in the header already gets clipped to ``[t]:20`` at the same width (= a related but separate symptom), so this hint was the only remaining on-screen reminder that ``t`` was a tail-cycle key.

## Fix

```diff
-    f"[#555555]  press [/][bold #aaaaaa]\\[f][/]"
-    f"[#555555] to cycle filter · [/]"
-    f"[bold #aaaaaa]\\[t][/][#555555] for tail size[/]"
+    f"[#555555]  press [/][bold #aaaaaa]\\[f][/]"
+    f"[#555555] to cycle filter[/]\\n"
+    f"[#555555]  press [/][bold #aaaaaa]\\[t][/]"
+    f"[#555555] for tail size[/]"
```

Cell counts after split:
- ``press [f] to cycle filter`` — 27 cells
- ``press [t] for tail size`` — 25 cells

Both well within the 44-cell minimum panel budget. Parallel ``press`` prefix on each line makes the hints read as a list of bindings rather than two unrelated lines.

## Test plan

- [x] ``pytest tests/cli/`` → 304/304 pass.
- [x] Python repro: ``render_events(filter_idx=4 /* rag */, ...)`` returns the three-line empty-state with cell counts 34 / 27 / 25 — all fit the 44-cell budget.
- [x] No behaviour change to non-empty branches.

## Refs

- wave-5 finding E5 (= parking lot, P3 S)
- SP1 minimum panel width floor (44 cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)