### PR TITLE
feat(multimodal): /image slash command for user chat image input (closes #366)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1488,7 +1488,17 @@ class RouterLoop:
         # an empty / mismatched history alive).
         messages: list[dict] = [{"role": "system", "content": system_prompt}]
         messages.extend(history)
-        if not history or history[-1].get("role") != "user" or history[-1].get("content") != user_text:
+        # When history's last entry is a user message, trust it — it is
+        # either:
+        #   - text identical to ``user_text`` (= the normal chat path,
+        #     ChatSession already appended it via _append_history); or
+        #   - a content-list shape (= issue #366 multimodal turn where
+        #     the user attached images via /image; comparing string
+        #     ``user_text`` against the list would always fail and
+        #     produce a duplicate text-only entry).
+        # Only append the fallback text user message when history is
+        # empty / mismatched (= defensive for direct-RouterLoop tests).
+        if not history or history[-1].get("role") != "user":
             messages.append({"role": "user", "content": user_text})
 
         # B28-Q2 Case A: per-turn counters for chat_turn_completed_inline.

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -423,6 +423,14 @@ class ChatMessage:
     ts: str
     seq: int = 0  # monotonic per-session sequence id; 0 for non-conversational entries
     meta: dict = field(default_factory=dict)
+    # Issue #366: optional multimodal media blocks attached to this
+    # message (= images user attached via /image / --image). Each block
+    # is a litellm-style content part, e.g.
+    #   {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+    # Empty list = pure text message (= backward compat with all callers).
+    # Persisted in history.jsonl via the dataclass default — restart-resume
+    # carries images along with text turns.
+    media: list[dict] = field(default_factory=list)
 
 
 def _now_iso() -> str:
@@ -758,6 +766,12 @@ class ChatSession:
         # through to spawned Agents AND to the router host adapter (=
         # chat-router web__fetch / file__read / mcp paths).
         self._multimodal_config = multimodal_config
+        # Issue #366: queue of image blocks the user attached via
+        # ``/image PATH`` or ``--image PATH``. Drained on the next user
+        # message turn (= attached to that ChatMessage's ``media`` field).
+        # litellm-style content parts:
+        #   {"type": "image_url", "image_url": {"url": "data:...;base64,..."}}
+        self._pending_user_images: list[dict] = []
         # FP-0034 PR-3b-iii: action_retrieval config — drives whether the
         # universal catalog wrappers appear in the router tools=. Default
         # constructs an off-flag ActionRetrievalConfig so existing chat
@@ -1636,11 +1650,19 @@ class ChatSession:
                 name="wal-size-safety-net",
             )
 
+        # Issue #366: drain any /image-queued media blocks onto this turn.
+        attached_media = self._pending_user_images
+        self._pending_user_images = []
+
         self._append_history(ChatMessage(
             role="user", text=text, ts=_now_iso(),
             meta={"chain_id": chain_id},
+            media=attached_media,
         ))
-        self._chat_events.emit("user_message_received", text=text, chain_id=chain_id)
+        self._chat_events.emit(
+            "user_message_received", text=text, chain_id=chain_id,
+            media_block_count=len(attached_media),
+        )
         await self._put_outbox(OutboxMessage(
             kind="status", text="thinking…", meta={"chain_id": chain_id},
         ))
@@ -3446,7 +3468,19 @@ class ChatSession:
         messages: list[dict] = []
         for m in selected:
             role = "user" if m.role == "user" else "assistant"
-            messages.append({"role": role, "content": m.text})
+            # Issue #366: when a message carries multimodal media blocks
+            # (= /image-attached images), build content as a list of
+            # litellm content parts. Text-only messages keep the legacy
+            # string-content shape so the existing prompt cache + replay
+            # fixtures stay byte-identical.
+            if m.media:
+                parts: list[dict] = []
+                if m.text:
+                    parts.append({"type": "text", "text": m.text})
+                parts.extend(m.media)
+                messages.append({"role": role, "content": parts})
+            else:
+                messages.append({"role": role, "content": m.text})
         return messages
 
     async def _run_router_loop(

--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -142,6 +142,7 @@ from reyn.chat.slash import docs_filter as _docs_filter_mod  # noqa: E402, F401
 from reyn.chat.slash import donut as _donut_mod  # noqa: E402, F401
 from reyn.chat.slash import expand as _expand_mod  # noqa: E402, F401
 from reyn.chat.slash import help as _help_mod  # noqa: E402, F401
+from reyn.chat.slash import image as _image_mod  # noqa: E402, F401
 from reyn.chat.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.chat.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.chat.slash import pending as _pending_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/image.py
+++ b/src/reyn/chat/slash/image.py
@@ -1,0 +1,139 @@
+"""``/image PATH`` slash command — attach an image to the next user message.
+
+Issue #366 — multi-modal cluster path 3/3.
+
+The command:
+  1. Resolves PATH relative to CWD (= same scope rule as file__read).
+  2. Reads the bytes + infers the MIME type from the extension.
+  3. Applies the shared media-size gate landed in #364
+     (``PermissionResolver.require_media_load`` — 4-layer approval).
+  4. Base64-encodes the bytes into a litellm-style ``image_url`` content
+     part and queues it on ``session._pending_user_images``.
+  5. The next user message in this session consumes the queue: its
+     ``ChatMessage.media`` carries the queued blocks, and the router
+     loop's history builder switches that turn to content-list shape.
+
+Multiple ``/image`` calls before the next user message stack into a
+multi-image attachment. The queue is drained per user turn — images
+do not leak into subsequent turns.
+"""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from reyn.chat.slash import reply, reply_error, slash
+
+# Mirror op_runtime/file._IMAGE_EXTENSIONS so the slash command accepts
+# the same set #365 accepts via `file__read`.
+_IMAGE_EXTENSIONS: dict[str, str] = {
+    ".png":  "image/png",
+    ".jpg":  "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif":  "image/gif",
+    ".webp": "image/webp",
+    ".svg":  "image/svg+xml",
+}
+
+
+def _mime_for_path(path: Path) -> str | None:
+    return _IMAGE_EXTENSIONS.get(path.suffix.lower())
+
+
+def _file_size_human(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}MB"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}KB"
+    return f"{n} bytes"
+
+
+@slash(
+    "image",
+    summary="Attach an image to the next user message (multimodal input).",
+    aliases=("img",),
+)
+async def image_cmd(session: object, args: str) -> None:
+    path_str = args.strip()
+    if not path_str:
+        await reply_error(
+            session,
+            "usage: /image <path>  (e.g. `/image ./shot.png`). "
+            "Supported extensions: .png / .jpg / .jpeg / .gif / .webp / .svg.",
+        )
+        return
+
+    # Resolve relative to CWD (= the same scope ChatSession uses for
+    # file reads). Absolute paths are honoured as-is.
+    path = Path(path_str).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    path = path.resolve()
+
+    if not path.exists():
+        await reply_error(session, f"image not found: {path_str}")
+        return
+    if not path.is_file():
+        await reply_error(session, f"not a file: {path_str}")
+        return
+
+    mime = _mime_for_path(path)
+    if mime is None:
+        await reply_error(
+            session,
+            f"unsupported image extension {path.suffix!r}. "
+            f"Supported: {', '.join(sorted(_IMAGE_EXTENSIONS))}",
+        )
+        return
+
+    try:
+        image_bytes = path.read_bytes()
+    except OSError as exc:
+        await reply_error(session, f"failed to read {path_str}: {exc}")
+        return
+
+    # Apply the shared media-size gate (= #364 infrastructure). When the
+    # session was built without a ReynConfig (= direct construction in
+    # tests), `_multimodal_config` is None — skip the gate gracefully.
+    mm_cfg = getattr(session, "_multimodal_config", None)
+    perm = getattr(session, "_perm", None)
+    bus = getattr(session, "_intervention_bus", None)
+    if mm_cfg is not None and perm is not None and bus is not None:
+        try:
+            await perm.require_media_load(
+                size_bytes=len(image_bytes),
+                source=f"chat /image {path.name}",
+                mime_type=mime,
+                max_bytes=mm_cfg.max_bytes,
+                on_oversize=mm_cfg.on_oversize,
+                bus=bus,
+            )
+        except PermissionError as exc:
+            await reply_error(
+                session,
+                f"image not attached: {exc}",
+            )
+            return
+
+    data_b64 = base64.b64encode(image_bytes).decode("ascii")
+    block: dict = {
+        "type": "image_url",
+        "image_url": {"url": f"data:{mime};base64,{data_b64}"},
+    }
+    # Queue is drained by ChatSession._handle_user_message on the next
+    # user turn (= attached to that ChatMessage.media).
+    queue: list[dict] = getattr(session, "_pending_user_images", None)
+    if queue is None:
+        # ChatSession variants without #366 wiring shouldn't accept the
+        # command — surface a clear error rather than silently no-op.
+        await reply_error(
+            session,
+            "image queue is unavailable on this session (=#366 wiring missing).",
+        )
+        return
+    queue.append(block)
+    await reply(
+        session,
+        f"image attached: {path.name} ({_file_size_human(len(image_bytes))}, {mime}). "
+        f"queued count: {len(queue)}. Send your next message to include it.",
+    )

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -1,0 +1,312 @@
+"""Tier 2: user image input (issue #366).
+
+The ``/image PATH`` slash command queues an image as a litellm content
+block on the session. The next user message drains the queue onto the
+ChatMessage.media field, and ``_build_history_for_router`` emits
+content as a list of parts for that turn.
+
+We pin:
+  - Slash command happy path: file exists, ext supported → queue grows.
+  - Slash command rejects unsupported / missing / non-image files.
+  - Media gate (= #364) integration: oversize image with on_oversize=deny
+    keeps the queue empty + emits error.
+  - History builder switches to content-list shape only for messages
+    with non-empty media — text-only messages stay string-content
+    (= backward compat with existing replay fixtures).
+  - ChatMessage.media defaults to empty (= existing callers unaffected).
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatMessage
+from reyn.chat.slash import REGISTRY
+from reyn.config import MultimodalConfig
+from reyn.permissions.permissions import PermissionResolver
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _FakeBus:
+    def __init__(self, answer: str) -> None:
+        self._answer = answer
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        return InterventionAnswer(text="", choice_id=self._answer)
+
+
+@dataclass
+class _OutboxRecord:
+    kind: str
+    text: str
+
+
+@dataclass
+class _FakeSession:
+    """Minimal ChatSession-shaped stand-in for /image testing.
+
+    Holds only the attributes ``image_cmd`` touches: the pending-images
+    queue, the multimodal config, the permission resolver, the
+    intervention bus, and a captured outbox.
+    """
+    _multimodal_config: MultimodalConfig | None = None
+    _perm: PermissionResolver | None = None
+    _intervention_bus: _FakeBus | None = None
+    _pending_user_images: list[dict] = field(default_factory=list)
+    captured_outbox: list[_OutboxRecord] = field(default_factory=list)
+
+    async def _put_outbox(self, msg: object) -> None:
+        self.captured_outbox.append(
+            _OutboxRecord(
+                kind=getattr(msg, "kind", "system"),
+                text=getattr(msg, "text", ""),
+            )
+        )
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=True,
+    )
+
+
+def _png_bytes(size: int = 200) -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + b"\x00" * (size - 8)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _get_image_handler():
+    cmd = REGISTRY.get("image")
+    assert cmd is not None, "/image slash command should be registered"
+    return cmd.handler
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+
+def test_image_cmd_queues_png(tmp_path, monkeypatch):
+    """Tier 2: /image foo.png → block appended to queue; outbox message
+    contains the filename + size.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "shot.png").write_bytes(_png_bytes(500))
+
+    session = _FakeSession(
+        _multimodal_config=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"),
+        _perm=_resolver(tmp_path),
+        _intervention_bus=_FakeBus("yes"),
+    )
+
+    handler = _get_image_handler()
+    _run(handler(session, "shot.png"))
+
+    assert len(session._pending_user_images) == 1
+    block = session._pending_user_images[0]
+    assert block["type"] == "image_url"
+    assert block["image_url"]["url"].startswith("data:image/png;base64,")
+    # outbox confirmation
+    assert any("shot.png" in m.text for m in session.captured_outbox)
+
+
+def test_image_cmd_supports_jpeg_and_alias(tmp_path, monkeypatch):
+    """Tier 2: /img alias works; jpeg extension produces image/jpeg mime."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pic.jpg").write_bytes(b"jpeg-payload")
+
+    cmd = REGISTRY.get("img")  # alias
+    assert cmd is not None
+    session = _FakeSession()
+    _run(cmd.handler(session, "pic.jpg"))
+
+    assert len(session._pending_user_images) == 1
+    assert "data:image/jpeg;base64," in session._pending_user_images[0]["image_url"]["url"]
+
+
+def test_multiple_image_calls_stack(tmp_path, monkeypatch):
+    """Tier 2: two /image calls before the next user message → queue
+    holds both, in order.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a.png").write_bytes(_png_bytes())
+    (tmp_path / "b.png").write_bytes(_png_bytes())
+
+    session = _FakeSession()
+    handler = _get_image_handler()
+    _run(handler(session, "a.png"))
+    _run(handler(session, "b.png"))
+
+    assert len(session._pending_user_images) == 2
+
+
+# ── error paths ────────────────────────────────────────────────────────
+
+
+def test_image_cmd_empty_path_errors(tmp_path):
+    session = _FakeSession()
+    handler = _get_image_handler()
+    _run(handler(session, ""))
+
+    assert session._pending_user_images == []
+    assert any(m.kind == "error" and "usage" in m.text for m in session.captured_outbox)
+
+
+def test_image_cmd_missing_file_errors(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    session = _FakeSession()
+    handler = _get_image_handler()
+    _run(handler(session, "no-such.png"))
+
+    assert session._pending_user_images == []
+    assert any(m.kind == "error" and "not found" in m.text for m in session.captured_outbox)
+
+
+def test_image_cmd_unsupported_extension_errors(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "notes.txt").write_bytes(b"text")
+    session = _FakeSession()
+    handler = _get_image_handler()
+    _run(handler(session, "notes.txt"))
+
+    assert session._pending_user_images == []
+    assert any(m.kind == "error" and "unsupported" in m.text for m in session.captured_outbox)
+
+
+# ── media gate integration (= #364 reuse) ──────────────────────────────
+
+
+def test_image_cmd_oversize_with_deny_keeps_queue_empty(tmp_path, monkeypatch):
+    """Tier 2: oversize image + on_oversize=deny → gate denies, queue
+    stays empty, error in outbox.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "huge.png").write_bytes(b"x" * 10_000_000)
+    session = _FakeSession(
+        _multimodal_config=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+        _perm=_resolver(tmp_path),
+        _intervention_bus=_FakeBus("never_called"),
+    )
+
+    handler = _get_image_handler()
+    _run(handler(session, "huge.png"))
+
+    assert session._pending_user_images == []
+    assert any(m.kind == "error" for m in session.captured_outbox)
+
+
+def test_image_cmd_oversize_with_ask_no_keeps_queue_empty(tmp_path, monkeypatch):
+    """Tier 2: oversize image + on_oversize=ask + user-no → gate denies."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "huge.png").write_bytes(b"x" * 10_000_000)
+    session = _FakeSession(
+        _multimodal_config=MultimodalConfig(max_bytes=5_000_000, on_oversize="ask"),
+        _perm=_resolver(tmp_path),
+        _intervention_bus=_FakeBus("no"),
+    )
+
+    handler = _get_image_handler()
+    _run(handler(session, "huge.png"))
+
+    assert session._pending_user_images == []
+
+
+def test_image_cmd_no_multimodal_config_skips_gate(tmp_path, monkeypatch):
+    """Tier 2: when session lacks a multimodal_config (= direct test
+    construction), the gate is skipped — image still queues.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "any.png").write_bytes(b"x" * 10_000_000)  # would normally exceed
+    session = _FakeSession()  # no multimodal_config, no perm
+
+    handler = _get_image_handler()
+    _run(handler(session, "any.png"))
+
+    assert len(session._pending_user_images) == 1
+
+
+# ── ChatMessage.media field + history builder ──────────────────────────
+
+
+def test_chat_message_default_media_is_empty():
+    """Tier 2: ChatMessage.media defaults to empty list — existing callers
+    that build ChatMessage without media argument see no behaviour change.
+    """
+    msg = ChatMessage(role="user", text="hi", ts="2026-05-21T00:00:00+00:00")
+    assert msg.media == []
+
+
+def test_chat_message_media_persisted_when_provided():
+    """Tier 2: explicit media is preserved on construction."""
+    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+    msg = ChatMessage(
+        role="user", text="see this", ts="2026-05-21T00:00:00+00:00",
+        media=[block],
+    )
+    assert msg.media == [block]
+
+
+# ── history-builder content-list shape ─────────────────────────────────
+
+
+def _make_history_builder():
+    """Pluck ``_build_history_for_router`` in a minimal harness — we
+    only need its content-shape decision logic.
+    """
+    from reyn.chat.session import ChatSession
+
+    cs = ChatSession.__new__(ChatSession)  # bypass __init__
+    cs.history = []  # set by tests
+    # Compaction config must be present; the no-compaction branch fires
+    # when len(turns) <= head + tail, so set both to large.
+    from reyn.config import CompactionConfig
+    cs._compaction = CompactionConfig(head_size=100, tail_size=100)
+    cs._latest_summary = lambda: None  # type: ignore[method-assign]
+    return cs
+
+
+def test_history_text_only_emits_string_content():
+    """Tier 2: text-only ChatMessage → string content (= backward compat
+    with all existing replay fixtures + prompt cache).
+    """
+    cs = _make_history_builder()
+    cs.history = [
+        ChatMessage(role="user", text="hi", ts="t1"),
+        ChatMessage(role="agent", text="hello", ts="t2"),
+    ]
+    msgs = cs._build_history_for_router()
+
+    assert msgs[0] == {"role": "user", "content": "hi"}
+    assert msgs[1] == {"role": "assistant", "content": "hello"}
+
+
+def test_history_message_with_media_emits_content_list():
+    """Tier 2: ChatMessage with media → content is a list of litellm parts."""
+    cs = _make_history_builder()
+    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+    cs.history = [
+        ChatMessage(role="user", text="look at this", ts="t1", media=[block]),
+    ]
+    msgs = cs._build_history_for_router()
+
+    assert msgs[0]["role"] == "user"
+    content = msgs[0]["content"]
+    assert isinstance(content, list)
+    assert content == [{"type": "text", "text": "look at this"}, block]
+
+
+def test_history_message_with_media_and_no_text_emits_only_image() -> None:
+    """Tier 2: a message with media but no text (= edge case, /image
+    sent without typing) still produces a valid content list with just
+    the image part — no empty text block leaked.
+    """
+    cs = _make_history_builder()
+    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+    cs.history = [ChatMessage(role="user", text="", ts="t1", media=[block])]
+    msgs = cs._build_history_for_router()
+
+    assert msgs[0]["content"] == [block]


### PR DESCRIPTION
**[e2e-coder]** — closes #366. Third and final PR of the multi-modal cluster (= follow-up to PR #354 honest-update review).

## Summary

- New \`/image PATH\` slash command (alias \`/img\`) attaches a local image to the next user message.
- New \`ChatMessage.media: list[dict]\` field carries litellm-style content parts; defaults to empty list (= backward compat).
- New \`ChatSession._pending_user_images\` queue + drain on \`_handle_user_message\`.
- \`_build_history_for_router\` switches to content-list shape **only** for messages with non-empty media; text-only stays string-content.
- Reuses #364 \`require_media_load\` gate per image (= same 5MB cap + ask/allow/deny policy).

## UX

\`\`\`
> /image ./shot.png
image attached: shot.png (123.4KB, image/png). queued count: 1. Send your next message to include it.

> describe what you see
[LLM sees user message with text + image_url content blocks]
\`\`\`

## Test plan

- [x] \`pytest tests/test_user_image_input.py\` — 14/14 pass
- [x] \`pytest -k 'slash or chat or session or router_loop or multimodal'\` — 442/442 pass (no regression)
- [x] \`ruff check\` — clean
- [ ] **Manual**: \`reyn chat\` → \`/image ./screenshot.png\` → \`describe what you see\` → expect the assistant to describe the image.
- [ ] **Manual**: \`/image ./huge.png\` (>5MB) with default \`on_oversize: ask\` → iv prompt; deny → outbox error, queue stays empty.
- [ ] **Manual**: \`/image foo.png\` then \`/image bar.png\` then send message → both images visible in the user message.

## Out of scope

- \`--image PATH\` CLI flag (= single-shot mode; can be a follow-up).
- TUI paste / drag-and-drop.
- LLM-output image rendering.
- PDF / audio / video attachments.

## Cluster status (post-merge of all 3)

| Path into LLM | Implementation |
|---|---|
| MCP tool result image | #362 / #363 (merged) |
| Web fetch image URL | #374 (merged) |
| Local file read image | #378 (open) |
| User chat attachment | this PR |

→ Multi-modal cluster **closed** once #378 + this PR merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)