### PR TITLE
feat(chat): E-full Phase 1 — ChatMessage wire shape refactor (refs #383)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -7,7 +7,7 @@ import logging
 import re
 import time
 import uuid
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Literal
 
 logger = logging.getLogger(__name__)
 from dataclasses import asdict, dataclass, field
@@ -416,21 +416,196 @@ class ChatInterventionBus:
     # method-level call so the bus signature stays stable.
 
 
-@dataclass
+@dataclass(init=False)
 class ChatMessage:
-    role: str  # "user" | "agent" | "skill_event" | "summary"
-    text: str
-    ts: str
+    """Chat-history entry, shaped to mirror the OpenAI/Anthropic message
+    list wire format (issue #383 E-full).
+
+    Each ``ChatMessage`` is one entry in the LLM-facing conversation, so
+    ``self.history`` can be serialised straight to the LLM without
+    synthesis. Tool turns are represented as their own ``role="tool"``
+    entries; assistant turns that emitted tool calls carry the
+    ``tool_calls`` field; multi-modal user / tool turns use the
+    list-of-parts ``content`` shape.
+
+    Role vocabulary:
+      - ``user`` — user input
+      - ``assistant`` — LLM reply (= previously ``agent``)
+      - ``tool`` — tool response (= new)
+      - ``system`` — system prompt (rare; usually built at wire time)
+      - ``summary`` — chat-compactor output (Reyn-internal, filtered at wire boundary)
+      - ``skill_event`` — TUI display marker (Reyn-internal, filtered at wire boundary)
+    """
+    role: Literal[
+        "user", "assistant", "tool", "system", "summary", "skill_event",
+        # Legacy value retained for read-time migration. Code that reaches
+        # for this directly is a bug — _migrate_legacy_chat_message
+        # rewrites it on load.
+        "agent",
+    ]
+    # ``content`` is either:
+    #   - a ``str`` (= text-only turn), or
+    #   - a ``list[dict]`` of litellm-style content parts (= multimodal user
+    #     turn / tool response with an image / etc.). Each part is e.g.
+    #       {"type": "text", "text": "..."}
+    #       {"type": "image_url", "image_url": {"url": "<data url OR file ref>"}}
+    #       {"type": "image",     "path": "<abs or cwd-rel>",
+    #                             "mime_type": "...", "content_hash": "sha256:..."}
+    # The last shape (= ``"image"`` with ``path``) is the **path-ref**
+    # introduced by #383: storage points at a file on disk, the
+    # wire-shape builder reads and embeds the binary at LLM-call time.
+    content: str | list[dict] = ""
+    ts: str = ""
     seq: int = 0  # monotonic per-session sequence id; 0 for non-conversational entries
     meta: dict = field(default_factory=dict)
-    # Issue #366: optional multimodal media blocks attached to this
-    # message (= images user attached via /image / --image). Each block
-    # is a litellm-style content part, e.g.
-    #   {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
-    # Empty list = pure text message (= backward compat with all callers).
-    # Persisted in history.jsonl via the dataclass default — restart-resume
-    # carries images along with text turns.
-    media: list[dict] = field(default_factory=list)
+    # OpenAI/Anthropic tool-turn fields ─────────────────────────────────
+    # ``tool_calls`` is set ONLY on ``role="assistant"`` entries where the
+    # LLM emitted one or more tool calls. Each block follows the OpenAI
+    # function-tool shape:
+    #   {"id": "<tool_call_id>", "type": "function",
+    #    "function": {"name": "<tool>", "arguments": "<json str>"}}
+    tool_calls: list[dict] | None = None
+    # ``tool_call_id`` is set ONLY on ``role="tool"`` entries. Links the
+    # response back to the originating ``tool_call`` block on the
+    # preceding assistant message.
+    tool_call_id: str | None = None
+    # ``name`` is set ONLY on ``role="tool"`` entries (= function name).
+    # Mirrors the OpenAI tool-message ``name`` field; some providers
+    # require it for tool-result attribution.
+    name: str | None = None
+
+    def __init__(
+        self,
+        role: str,
+        content: "str | list[dict] | None" = None,
+        ts: str = "",
+        seq: int = 0,
+        meta: "dict | None" = None,
+        tool_calls: "list[dict] | None" = None,
+        tool_call_id: "str | None" = None,
+        name: "str | None" = None,
+        # ── Pre-#383 compat kwargs (= retired in PR-B) ──────────────────
+        # ``text`` and ``media`` are folded into ``content`` during
+        # construction so callers that haven't migrated yet still produce
+        # Design-B storage. Both PR-A intra-PR sweep and external test
+        # callers benefit; once PR-B's sweep eliminates the last legacy
+        # caller, these kwargs (and the matching read properties below)
+        # get removed.
+        text: "str | None" = None,
+        media: "list[dict] | None" = None,
+    ) -> None:
+        # role: legacy "agent" → "assistant" at construction time so the
+        # rest of the runtime never sees the pre-#383 spelling.
+        if role == "agent":
+            role = "assistant"
+        # Fold legacy text + media into content when caller didn't pass
+        # the new content kwarg. Caller may pass EITHER content OR
+        # text/media — not both.
+        if content is None:
+            if text is not None or media is not None:
+                _text_val = text or ""
+                _media_val = media or []
+                if _media_val:
+                    parts: list[dict] = []
+                    if _text_val:
+                        parts.append({"type": "text", "text": _text_val})
+                    parts.extend(_media_val)
+                    content = parts
+                else:
+                    content = _text_val
+            else:
+                content = ""
+        self.role = role
+        self.content = content
+        self.ts = ts
+        self.seq = seq
+        self.meta = meta if meta is not None else {}
+        self.tool_calls = tool_calls
+        self.tool_call_id = tool_call_id
+        self.name = name
+
+    @property
+    def text(self) -> str:
+        """Backward-compat read for code that hasn't migrated to
+        ``content``. Returns ``content`` when it is a str; otherwise
+        extracts the first ``{"type":"text"}`` part from a content list.
+        Empty string when neither applies. Retired in PR-B.
+        """
+        if isinstance(self.content, str):
+            return self.content
+        if isinstance(self.content, list):
+            for part in self.content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    return part.get("text", "")
+        return ""
+
+    @property
+    def media(self) -> list[dict]:
+        """Backward-compat read for code expecting the pre-#383 ``media``
+        list (= non-text content parts). Returns the non-text parts of
+        ``content`` when it is a list; empty list otherwise. Retired in
+        PR-B.
+        """
+        if isinstance(self.content, list):
+            return [
+                p for p in self.content
+                if isinstance(p, dict) and p.get("type") != "text"
+            ]
+        return []
+
+
+# ── Legacy ChatMessage migration ───────────────────────────────────────
+#
+# history.jsonl files written before issue #383 used the pre-Design-B
+# shape: ``role`` ∈ {"user","agent","skill_event","summary"}; ``text:
+# str``; ``media: list[dict]`` (= inline base64 image_url parts from
+# #366). On load, ``_migrate_legacy_chat_message`` rewrites such
+# entries into the new wire shape so the runtime only ever sees
+# Design-B ChatMessage instances.
+
+
+def _migrate_legacy_chat_message(raw: dict) -> dict:
+    """Read-time migration for pre-#383 history.jsonl entries.
+
+    Detects the legacy shape (= ``text`` key + optional ``media`` list,
+    ``role="agent"`` for assistant replies) and emits the Design-B
+    shape (= ``content`` field, ``role="assistant"``). Mutates a copy;
+    the caller hands the result to ``ChatMessage(**kwargs)``.
+
+    Legacy → new:
+      role: "agent"            → "assistant"
+      text: "hi"               → content: "hi"
+      text + media: [...]      → content: [{"type": "text", "text": "hi"}, ...media]
+      (no text, media: [...])  → content: [...media]
+
+    Inline base64 in media blocks is left alone — those entries
+    pre-date the path-ref design and rewriting them to files would
+    be a one-shot tool, out of scope for read-time migration.
+    """
+    raw = dict(raw)  # don't mutate the caller's dict
+    if "content" in raw:
+        # Already new shape (= written post-#383 or already migrated).
+        # Still normalise role just in case "agent" snuck in.
+        if raw.get("role") == "agent":
+            raw["role"] = "assistant"
+        return raw
+
+    # Legacy shape: text + optional media.
+    text_val = raw.pop("text", "")
+    media_val = raw.pop("media", None) or []
+
+    if media_val:
+        parts: list[dict] = []
+        if text_val:
+            parts.append({"type": "text", "text": text_val})
+        parts.extend(media_val)
+        raw["content"] = parts
+    else:
+        raw["content"] = text_val
+
+    if raw.get("role") == "agent":
+        raw["role"] = "assistant"
+    return raw
 
 
 def _now_iso() -> str:
@@ -1305,7 +1480,10 @@ class ChatSession:
         ``(role, text, ts, meta)`` signature to ChatSession._append_history
         (which takes a ChatMessage).
         """
-        self._append_history(ChatMessage(role=role, text=text, ts=ts, meta=meta))
+        self._append_history(ChatMessage(
+            role="assistant" if role == "agent" else role,
+            content=text, ts=ts, meta=meta,
+        ))
 
     def _append_history_for_a2a_handler(
         self, role: str, text: str, ts: str, meta: dict,
@@ -1316,7 +1494,10 @@ class ChatSession:
         InterventionHandler.  This adapter bridges to ChatSession._append_history
         (which takes a ChatMessage).
         """
-        self._append_history(ChatMessage(role=role, text=text, ts=ts, meta=meta))
+        self._append_history(ChatMessage(
+            role="assistant" if role == "agent" else role,
+            content=text, ts=ts, meta=meta,
+        ))
 
     # ── A2A transport callbacks (FP-0019 Wave 2 part 2) ─────────────────────────
     # Session-side wrappers that perform registry topology checks and the
@@ -1380,7 +1561,11 @@ class ChatSession:
                 if not line:
                     continue
                 try:
-                    self.history.append(ChatMessage(**json.loads(line)))
+                    raw = json.loads(line)
+                    # Read-time migration for pre-#383 entries (legacy
+                    # text + media shape → new content shape).
+                    raw = _migrate_legacy_chat_message(raw)
+                    self.history.append(ChatMessage(**raw))
                 except Exception:
                     continue
         # Initialize the seq counter past any seqs already in the file. Old
@@ -1650,14 +1835,23 @@ class ChatSession:
                 name="wal-size-safety-net",
             )
 
-        # Issue #366: drain any /image-queued media blocks onto this turn.
+        # Issue #366 → #383: drain any /image-queued media blocks onto
+        # this turn. Each block is a content-part dict (= image_url or
+        # image path-ref shape); when present, the user message becomes
+        # list-content shape mirroring the LLM wire format.
         attached_media = self._pending_user_images
         self._pending_user_images = []
 
+        if attached_media:
+            content: str | list[dict] = (
+                ([{"type": "text", "text": text}] if text else []) + attached_media
+            )
+        else:
+            content = text
+
         self._append_history(ChatMessage(
-            role="user", text=text, ts=_now_iso(),
+            role="user", content=content, ts=_now_iso(),
             meta={"chain_id": chain_id},
-            media=attached_media,
         ))
         self._chat_events.emit(
             "user_message_received", text=text, chain_id=chain_id,
@@ -1904,7 +2098,7 @@ class ChatSession:
             kind="agent", text=fallback, meta={"chain_id": chain_id},
         ))
         self._append_history(ChatMessage(
-            role="agent", text=fallback, ts=_now_iso(),
+            role="assistant", content=fallback, ts=_now_iso(),
             meta={
                 "chain_id": chain_id,
                 "source": "router_cap_exhausted",
@@ -2653,7 +2847,7 @@ class ChatSession:
         )
 
         self._append_history(ChatMessage(
-            role="user", text=injected_text, ts=_now_iso(),
+            role="user", content=injected_text, ts=_now_iso(),
             meta={
                 "source": "skill_completion",
                 "skill": skill_name,
@@ -3092,7 +3286,7 @@ class ChatSession:
                 failures_str = repr(step_failures)
             injected_text += f"\n\nstep_failures:\n{failures_str}\n"
         self._append_history(ChatMessage(
-            role="user", text=injected_text, ts=_now_iso(),
+            role="user", content=injected_text, ts=_now_iso(),
             meta={
                 "source": "plan_completion",
                 "plan_id": plan_id,
@@ -3445,7 +3639,14 @@ class ChatSession:
         actually exceeds the window.
         """
         cfg = self._compaction
-        turns = [m for m in self.history if m.role in ("user", "agent")]
+        # E-full (#383): include tool-turn entries (= assistant w/ tool_calls,
+        # tool responses) in the slice. The wire-shape builder below
+        # forwards them as-is to the LLM. ``summary`` / ``skill_event``
+        # remain Reyn-internal and filtered out.
+        turns = [
+            m for m in self.history
+            if m.role in ("user", "assistant", "tool", "agent")
+        ]
 
         if len(turns) <= cfg.head_size + cfg.tail_size:
             # No compaction needed — head+tail would overlap and duplicate.
@@ -3456,31 +3657,38 @@ class ChatSession:
             tail = turns[-cfg.tail_size:] if cfg.tail_size else []
             summary = self._latest_summary()
             if summary:
+                summary_text = (
+                    summary.content if isinstance(summary.content, str)
+                    else json.dumps(summary.content, ensure_ascii=False)
+                )
                 bridge = [ChatMessage(
-                    role="agent",
-                    text=f"[summary of earlier conversation]\n{summary.text}",
+                    role="assistant",
+                    content=f"[summary of earlier conversation]\n{summary_text}",
                     ts=summary.ts,
                 )]
                 selected = head + bridge + tail
             else:
                 selected = head + tail
 
+        # E-full (#383) pass-through: ChatMessage IS the wire shape, so the
+        # builder just serialises each entry into a litellm-compatible
+        # message dict. Tool fields surface only on the roles where they
+        # are non-None. Path-ref content parts (= ``{"type":"image","path":...}``)
+        # are left as-is; the LLM wire boundary (= call_llm_tools or its
+        # delegates) is responsible for resolving them to data URLs.
         messages: list[dict] = []
         for m in selected:
-            role = "user" if m.role == "user" else "assistant"
-            # Issue #366: when a message carries multimodal media blocks
-            # (= /image-attached images), build content as a list of
-            # litellm content parts. Text-only messages keep the legacy
-            # string-content shape so the existing prompt cache + replay
-            # fixtures stay byte-identical.
-            if m.media:
-                parts: list[dict] = []
-                if m.text:
-                    parts.append({"type": "text", "text": m.text})
-                parts.extend(m.media)
-                messages.append({"role": role, "content": parts})
-            else:
-                messages.append({"role": role, "content": m.text})
+            # Legacy "agent" stragglers (= migrated entries that somehow
+            # bypassed _migrate_legacy_chat_message) → normalise on read.
+            role = "assistant" if m.role == "agent" else m.role
+            msg: dict = {"role": role, "content": m.content}
+            if m.tool_calls is not None:
+                msg["tool_calls"] = m.tool_calls
+            if m.tool_call_id is not None:
+                msg["tool_call_id"] = m.tool_call_id
+            if m.name is not None:
+                msg["name"] = m.name
+            messages.append(msg)
         return messages
 
     async def _run_router_loop(

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -422,10 +422,26 @@ def _load_chain_replies(project_root: Path) -> dict[str, str]:
                     continue
                 try:
                     m = json.loads(raw)
-                    if m.get("role") == "agent":
+                    # Issue #383: role rename "agent" → "assistant".
+                    # Tolerate both for pre-#383 history.jsonl entries.
+                    if m.get("role") in ("assistant", "agent"):
                         cid = (m.get("meta") or {}).get("chain_id")
                         if cid:
-                            replies[cid] = m.get("text", "")
+                            # Pre-#383 entries carry "text"; post-#383
+                            # entries carry "content" (str or list-of-parts).
+                            content = m.get("content")
+                            if isinstance(content, str):
+                                reply_text = content
+                            elif isinstance(content, list):
+                                # extract first text part
+                                reply_text = next(
+                                    (p.get("text", "") for p in content
+                                     if isinstance(p, dict) and p.get("type") == "text"),
+                                    "",
+                                )
+                            else:
+                                reply_text = m.get("text", "")
+                            replies[cid] = reply_text
                 except Exception as exc:
                     logger.warning(
                         "right_panel events: malformed history.jsonl line in %s: %s",

--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -103,7 +103,8 @@ def _new_agent_history_entries(
     """
     out: list[str] = []
     for msg in session.history[baseline:]:
-        if msg.role != "agent" or not msg.text:
+        # Issue #383: role rename "agent" → "assistant"; tolerate both.
+        if msg.role not in ("assistant", "agent") or not msg.text:
             continue
         if chain_id is not None and (msg.meta or {}).get("chain_id") != chain_id:
             continue
@@ -130,8 +131,12 @@ async def _await_turn_complete(
     """
     deadline = asyncio.get_event_loop().time() + timeout
     while True:
+        # Issue #383: assistant replies now have role="assistant". "agent"
+        # kept in the predicate for any pre-#383 history entry that
+        # bypassed read-time migration.
         has_reply = any(
-            msg.role == "agent" for msg in session.history[baseline:]
+            msg.role in ("assistant", "agent")
+            for msg in session.history[baseline:]
         )
         is_idle = session.inbox.empty() and not session.running_skills
         if has_reply and is_idle:

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -577,17 +577,19 @@ def _harvest_completion_narration(session, skill_run_id: str) -> str:
         prev = history[i - 1]
         meta = getattr(msg, "meta", None) or {}
         prev_meta = getattr(prev, "meta", None) or {}
+        # Issue #383: role rename "agent" → "assistant"; tolerate both
+        # while pre-#383 entries may still appear via migration edge cases.
         if (
-            getattr(msg, "role", None) == "agent"
+            getattr(msg, "role", None) in ("assistant", "agent")
             and meta.get("source") != "spawn_ack"
             and prev_meta.get("source") == "skill_completion"
             and prev_meta.get("run_id") == skill_run_id
         ):
             return getattr(msg, "text", "") or ""
-    # Fallback: latest non-spawn-ack agent message.
+    # Fallback: latest non-spawn-ack assistant message.
     for msg in reversed(history):
         meta = getattr(msg, "meta", None) or {}
-        if getattr(msg, "role", None) == "agent" and meta.get("source") != "spawn_ack":
+        if getattr(msg, "role", None) in ("assistant", "agent") and meta.get("source") != "spawn_ack":
             return getattr(msg, "text", "") or ""
     return ""
 

--- a/tests/test_chat_message_e_full_schema.py
+++ b/tests/test_chat_message_e_full_schema.py
@@ -1,0 +1,273 @@
+"""Tier 2: ChatMessage Design-B schema + read-time migration (issue #383).
+
+E-full Phase 1 pins:
+  - New constructor: ``role`` ∈ {user, assistant, tool, system, summary,
+    skill_event}; ``content`` is ``str | list[dict]``;
+    ``tool_calls`` / ``tool_call_id`` / ``name`` for tool-turn fields.
+  - Constructor still accepts legacy ``text=`` / ``media=`` kwargs (= folds
+    into ``content``). PR-A compat shim — removed in PR-B sweep.
+  - ``role="agent"`` is renamed to ``"assistant"`` at construction time.
+  - Backward-compat read properties: ``m.text`` returns the str content
+    (or extracts the first text part from a list); ``m.media`` returns
+    non-text content parts from a list.
+  - ``_migrate_legacy_chat_message`` rewrites pre-#383 dicts into the
+    new shape (used by ``load_history`` on disk-read).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from reyn.chat.session import ChatMessage, _migrate_legacy_chat_message
+
+# ── Constructor: new shape ─────────────────────────────────────────────
+
+
+def test_chat_message_minimal_text_construction() -> None:
+    """Tier 2: bare new-shape construction with str content."""
+    m = ChatMessage(role="user", content="hi", ts="t1")
+    assert m.role == "user"
+    assert m.content == "hi"
+    assert m.tool_calls is None
+    assert m.tool_call_id is None
+    assert m.name is None
+
+
+def test_chat_message_assistant_with_tool_calls() -> None:
+    """Tier 2: assistant role + tool_calls list — mirrors OpenAI shape."""
+    tc = [{
+        "id": "call_1", "type": "function",
+        "function": {"name": "file_read", "arguments": '{"path":"a.py"}'},
+    }]
+    m = ChatMessage(role="assistant", content="", ts="t1", tool_calls=tc)
+    assert m.role == "assistant"
+    assert m.tool_calls == tc
+
+
+def test_chat_message_tool_role_with_call_id_and_name() -> None:
+    """Tier 2: tool role carries ``tool_call_id`` + ``name`` linking back
+    to the originating tool_call on the prior assistant turn.
+    """
+    m = ChatMessage(
+        role="tool", content="<file contents>", ts="t1",
+        tool_call_id="call_1", name="file_read",
+    )
+    assert m.role == "tool"
+    assert m.tool_call_id == "call_1"
+    assert m.name == "file_read"
+
+
+def test_chat_message_multimodal_user_content_list() -> None:
+    """Tier 2: user turn with attached image — content is a list of parts
+    (text + image_url) per litellm wire format.
+    """
+    parts = [
+        {"type": "text", "text": "describe"},
+        {"type": "image_url",
+         "image_url": {"url": "data:image/png;base64,AAA"}},
+    ]
+    m = ChatMessage(role="user", content=parts, ts="t1")
+    assert m.role == "user"
+    assert isinstance(m.content, list)
+    assert m.content == parts
+
+
+# ── Constructor: legacy kwargs compat (= PR-A only, removed in PR-B) ───
+
+
+def test_legacy_text_kwarg_folds_into_content() -> None:
+    """Tier 2 (compat): pre-#383 callers pass ``text=...``. Result has
+    ``content`` set to the same string; ``text`` is not stored.
+    """
+    m = ChatMessage(role="user", text="hello", ts="t1")
+    assert m.content == "hello"
+    # Property delegates back to content.
+    assert m.text == "hello"
+
+
+def test_legacy_media_kwarg_folds_into_content_list() -> None:
+    """Tier 2 (compat): pre-#383 callers pass ``text=`` + ``media=``.
+    Result has list-of-parts content with text-part first, media after.
+    """
+    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+    m = ChatMessage(role="user", text="see this", media=[block], ts="t1")
+    assert isinstance(m.content, list)
+    assert m.content == [{"type": "text", "text": "see this"}, block]
+
+
+def test_legacy_media_only_no_text_folds_into_list() -> None:
+    """Tier 2 (compat): media without text → content is list with just
+    the media block(s)."""
+    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+    m = ChatMessage(role="user", media=[block], ts="t1")
+    assert m.content == [block]
+
+
+def test_role_agent_renames_to_assistant_on_construct() -> None:
+    """Tier 2: ``role="agent"`` is the pre-#383 spelling; constructor
+    normalises it to ``"assistant"`` so no live code path sees the
+    legacy value.
+    """
+    m = ChatMessage(role="agent", text="reply", ts="t1")
+    assert m.role == "assistant"
+
+
+# ── Read properties (= text / media) ───────────────────────────────────
+
+
+def test_text_property_from_str_content() -> None:
+    """Tier 2: m.text returns content directly when content is a str."""
+    m = ChatMessage(role="user", content="hi", ts="t1")
+    assert m.text == "hi"
+
+
+def test_text_property_from_list_content_extracts_text_part() -> None:
+    """Tier 2: m.text extracts the first text-typed part when content
+    is a list-of-parts.
+    """
+    m = ChatMessage(
+        role="user",
+        content=[
+            {"type": "text", "text": "see this"},
+            {"type": "image_url", "image_url": {"url": "data:..."}},
+        ],
+        ts="t1",
+    )
+    assert m.text == "see this"
+
+
+def test_text_property_empty_when_no_text_part() -> None:
+    """Tier 2: list content with no text part → m.text returns empty str."""
+    m = ChatMessage(
+        role="user",
+        content=[{"type": "image_url", "image_url": {"url": "data:..."}}],
+        ts="t1",
+    )
+    assert m.text == ""
+
+
+def test_media_property_returns_non_text_parts() -> None:
+    """Tier 2: m.media returns the non-text content parts."""
+    block = {"type": "image_url", "image_url": {"url": "data:..."}}
+    m = ChatMessage(
+        role="user",
+        content=[{"type": "text", "text": "see this"}, block],
+        ts="t1",
+    )
+    assert m.media == [block]
+
+
+def test_media_property_empty_for_str_content() -> None:
+    """Tier 2: when content is a plain str, m.media is empty."""
+    m = ChatMessage(role="user", content="hi", ts="t1")
+    assert m.media == []
+
+
+# ── Migration ──────────────────────────────────────────────────────────
+
+
+def test_migrate_legacy_agent_to_assistant() -> None:
+    """Tier 2: legacy ``role: "agent"`` with ``text`` is rewritten to
+    ``role: "assistant"`` with ``content``.
+    """
+    legacy = {"role": "agent", "text": "hello", "ts": "t1"}
+    new = _migrate_legacy_chat_message(legacy)
+    assert new["role"] == "assistant"
+    assert new["content"] == "hello"
+    assert "text" not in new
+
+
+def test_migrate_legacy_user_text_only() -> None:
+    """Tier 2: legacy user turn with text only → content=str."""
+    legacy = {"role": "user", "text": "hi", "ts": "t1"}
+    new = _migrate_legacy_chat_message(legacy)
+    assert new["role"] == "user"
+    assert new["content"] == "hi"
+    assert "text" not in new
+
+
+def test_migrate_legacy_user_with_media() -> None:
+    """Tier 2: legacy user turn with text + media → content as list."""
+    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+    legacy = {
+        "role": "user", "text": "see", "media": [block], "ts": "t1",
+    }
+    new = _migrate_legacy_chat_message(legacy)
+    assert new["content"] == [{"type": "text", "text": "see"}, block]
+    assert "media" not in new
+    assert "text" not in new
+
+
+def test_migrate_already_new_shape_is_idempotent() -> None:
+    """Tier 2: dicts already in the new shape pass through unchanged
+    (with the one exception of role='agent' → 'assistant' normalisation).
+    """
+    new_input = {"role": "assistant", "content": "hi", "ts": "t1"}
+    out = _migrate_legacy_chat_message(new_input)
+    assert out == new_input
+
+
+def test_migrate_new_shape_normalises_stale_agent_role() -> None:
+    """Tier 2: even a dict already containing ``content`` gets its role
+    normalised if it slipped in as ``agent`` (= belt-and-suspenders).
+    """
+    out = _migrate_legacy_chat_message(
+        {"role": "agent", "content": "reply", "ts": "t1"}
+    )
+    assert out["role"] == "assistant"
+
+
+# ── history.jsonl round-trip ───────────────────────────────────────────
+
+
+def test_chat_message_round_trips_via_asdict_and_constructor() -> None:
+    """Tier 2: asdict(m) → json.dumps → json.loads → ChatMessage(**dict)
+    yields an equivalent message. Pins the persistence cycle so loaded
+    history matches what was written.
+    """
+    tc = [{"id": "call_1", "type": "function",
+           "function": {"name": "f", "arguments": "{}"}}]
+    original = ChatMessage(
+        role="assistant", content="ack", ts="t1",
+        tool_calls=tc, meta={"chain_id": "abc"},
+    )
+    raw = json.loads(json.dumps(asdict(original)))
+    reloaded = ChatMessage(**raw)
+    assert reloaded.role == original.role
+    assert reloaded.content == original.content
+    assert reloaded.tool_calls == original.tool_calls
+    assert reloaded.meta == original.meta
+
+
+def test_load_history_migrates_legacy_lines(tmp_path: Path) -> None:
+    """Tier 2: ChatSession.load_history rewrites pre-#383 entries on read
+    (= the on-disk file stays in the old shape until the next append, but
+    the in-memory ``self.history`` carries the migrated shape).
+    """
+    # Build a minimal Session-like object that exercises load_history's
+    # file-reading code path without booting the full ChatSession.
+    from reyn.chat.session import ChatSession
+
+    session = ChatSession.__new__(ChatSession)  # bypass __init__
+    session.history_path = tmp_path / "history.jsonl"
+    session.history = []
+    session._next_seq = 1  # touched by post-load init; safe default
+
+    legacy_lines = [
+        {"role": "user", "text": "hi", "ts": "t1"},
+        {"role": "agent", "text": "hello", "ts": "t2",
+         "meta": {"chain_id": "abc"}},
+    ]
+    session.history_path.write_text(
+        "\n".join(json.dumps(line) for line in legacy_lines) + "\n",
+        encoding="utf-8",
+    )
+    session.load_history()
+
+    assert len(session.history) == 2
+    assert session.history[0].role == "user"
+    assert session.history[0].content == "hi"
+    assert session.history[1].role == "assistant"  # renamed from "agent"
+    assert session.history[1].content == "hello"
+    assert session.history[1].meta == {"chain_id": "abc"}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -223,9 +223,10 @@ def test_send_to_agent_history_persists_across_calls(tmp_path, monkeypatch):
     assert "You told me 17." in r2["reply"]
     assert "I will remember 17." not in r2["reply"]
 
-    # History accumulated across calls: 2 user turns + 2 agent turns.
+    # History accumulated across calls: 2 user turns + 2 assistant turns.
+    # Issue #383: role rename "agent" → "assistant".
     user_turns = [m for m in history if m.role == "user"]
-    agent_turns = [m for m in history if m.role == "agent"]
+    agent_turns = [m for m in history if m.role == "assistant"]
     assert len(user_turns) == 2
     assert len(agent_turns) == 2
 

--- a/tests/test_router_cap.py
+++ b/tests/test_router_cap.py
@@ -137,9 +137,10 @@ def test_handle_user_message_emits_fallback_when_cap_exhausted(
     assert "router_retry_exhausted" in names
 
     # History contains the fallback agent message tagged with the reason.
+    # Issue #383: role rename "agent" → "assistant".
     fallback_msgs = [
         m for m in session.history
-        if m.role == "agent" and m.meta.get("source") == "router_cap_exhausted"
+        if m.role == "assistant" and m.meta.get("source") == "router_cap_exhausted"
     ]
     assert len(fallback_msgs) == 1
 

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -108,7 +108,8 @@ def test_user_message_chitchat_appended_to_history(tmp_path, monkeypatch):
 
     _run(run())
 
-    agent_turns = [m for m in session.history if m.role == "agent"]
+    # Issue #383: role rename "agent" → "assistant" at construction time.
+    agent_turns = [m for m in session.history if m.role == "assistant"]
     assert len(agent_turns) == 1
     assert agent_turns[0].text == "hello back"
 


### PR DESCRIPTION
**[e2e-coder]** — first PR of the E-full architectural cluster (= refs #383). Lands the **shape** of the new ChatMessage; subsequent PRs (B/C/D/E) sweep callers, capture tool-detail at runtime, move tool media to file storage, and update the compactor + TUI + replay fixtures.

## Why

ChatMessage was frozen at the 2026-04-30 skill-dispatcher era. FP-0034 (= chat router gained direct tool calls) shipped without updating the persistence model. Net effect: tool_call / tool / multimodal tool-result detail is ephemeral inside one \`router_loop.run()\` call — the next user turn sees only user/agent text in history, even when the previous turn issued 5 tool calls returning images / grep results / file content.

Full background in **#383**, including the concrete list of currently-discarded detail and the e2e weakness it causes.

## What this PR does

- Renames \`role\` from \`agent\` → \`assistant\`; adds \`tool\` and \`system\` to the role vocabulary.
- Unifies \`text\` + \`media\` into a single \`content: str | list[dict]\` field that mirrors litellm's content-parts wire shape.
- Adds OpenAI/Anthropic tool-turn fields: \`tool_calls\`, \`tool_call_id\`, \`name\`.
- Read-time migration (\`_migrate_legacy_chat_message\`) rewrites pre-#383 \`history.jsonl\` entries on load.
- \`_build_history_for_router\` becomes a pass-through (= storage IS wire shape, no synthesis).
- Production sites with \`role==\"agent\"\` filter updated to tolerate both (mcp_server, a2a, events_tab — the last flagged by tui-coder during the cross-session broadcast).

## What this PR does NOT do (= deferred)

- **Phase 2** (= producer): \`router_loop.py\` capturing tool-detail per iteration + ChatMessage(role=\"tool\") entries actually persisted. This PR lands the SHAPE; the producer lands next.
- **Phase 3** (= file-backed media): \`.reyn/media/<flat-filename>\` storage + tool handler rework + \`/image\` path-ref. Today tool handlers still emit inline base64 via the pre-#383 \`media_blocks\` shape.
- **Phase 4** (= chat_compactor): tool-aware \`artifacts_referenced\` section.
- **Phase 5** (= replay + TUI): LLMReplay fixture regeneration + TUI tool-turn rendering.

## Backward-compat scaffold (= removed in PR-B)

Constructor accepts pre-#383 \`text=\` / \`media=\` kwargs and folds them into \`content\`. Read-only \`m.text\` / \`m.media\` properties keep existing callers working without a big-bang sweep. **All scaffold is removed in the next PR (PR-B)** — production sites that still read \`m.text\` or construct via \`text=\` get swept then; the compat shim is the one tolerated mismatch with \"影響考えないで\" spirit, used purely to make PR-A reviewable in isolation.

## Test plan

- [x] \`pytest tests/test_chat_message_e_full_schema.py\` — 20/20 pass (new schema tests)
- [x] \`pytest tests/\` — **4460 passed / 5 skipped / 3 xfailed** (no behaviour regression)
- [x] \`ruff check\` on touched files — clean
- [ ] **Manual**: \`reyn chat\` with a pre-#383 \`history.jsonl\` → confirms migration is silent + history visible.
- [ ] **Manual**: fresh \`reyn chat\` session, \`/image foo.png\`, send → confirms /image still works via legacy kwarg compat (= rework in PR-C).

## Cluster sequencing

| PR | Scope | Status |
|---|---|---|
| **PR-A (this)** | ChatMessage schema + migration + production role-filter sweep | open |
| PR-B | Sweep all \`m.text\` reads + \`text=\` constructors + remove compat shim | next |
| PR-C | Tool handlers (web/file/mcp) save binary to \`.reyn/media/\`; \`/image\` rework | depends on B |
| PR-D | \`router_loop\` producer + chat_compactor tool-awareness | depends on B |
| PR-E | LLMReplay fixture sweep + TUI tool-turn rendering | depends on D |

## Cross-session coordination

- Broker broadcast (initial + scope-update): all 4 sessions ack'd.
- tui-coder: 1 overlap (events_tab.py:425) included in this PR's sweep.
- sandbox_2 (dogfood-coder): paused V-measurement until cluster closure.

Refs #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)