### PR TITLE
feat(chat): E-full Phase 1 PR-B — retire ChatMessage compat shim (refs #383)

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -569,8 +569,12 @@ class RouterHostAdapter:
         # cascading-attractor mitigation needs to live elsewhere
         # (= context build / classifier-side, tracked as follow-up).
         if kind == "agent" and text:
+            # Issue #383: chat history now uses ``role="assistant"`` +
+            # ``content=`` (= wire shape mirror); the OutboxMessage above
+            # keeps ``kind="agent"`` since that's the TUI-facing
+            # OutboxMessage taxonomy, independent of the LLM-side role.
             self._append_history_cb(ChatMessage(
-                role="agent", text=text, ts=_now_iso(), meta=meta,
+                role="assistant", content=text, ts=_now_iso(), meta=meta,
             ))
             # Capture for agent-to-agent paths that need to forward the
             # reply upstream via _send_agent_response.

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -438,10 +438,6 @@ class ChatMessage:
     """
     role: Literal[
         "user", "assistant", "tool", "system", "summary", "skill_event",
-        # Legacy value retained for read-time migration. Code that reaches
-        # for this directly is a bug — _migrate_legacy_chat_message
-        # rewrites it on load.
-        "agent",
     ]
     # ``content`` is either:
     #   - a ``str`` (= text-only turn), or
@@ -477,44 +473,25 @@ class ChatMessage:
     def __init__(
         self,
         role: str,
-        content: "str | list[dict] | None" = None,
+        content: "str | list[dict]" = "",
         ts: str = "",
         seq: int = 0,
         meta: "dict | None" = None,
         tool_calls: "list[dict] | None" = None,
         tool_call_id: "str | None" = None,
         name: "str | None" = None,
-        # ── Pre-#383 compat kwargs (= retired in PR-B) ──────────────────
-        # ``text`` and ``media`` are folded into ``content`` during
-        # construction so callers that haven't migrated yet still produce
-        # Design-B storage. Both PR-A intra-PR sweep and external test
-        # callers benefit; once PR-B's sweep eliminates the last legacy
-        # caller, these kwargs (and the matching read properties below)
-        # get removed.
-        text: "str | None" = None,
-        media: "list[dict] | None" = None,
     ) -> None:
-        # role: legacy "agent" → "assistant" at construction time so the
-        # rest of the runtime never sees the pre-#383 spelling.
+        # Reject the pre-#383 ``"agent"`` spelling. Migration of on-disk
+        # ``history.jsonl`` entries happens at load time via
+        # ``_migrate_legacy_chat_message``; nothing else should be
+        # constructing with ``role="agent"`` anymore.
         if role == "agent":
-            role = "assistant"
-        # Fold legacy text + media into content when caller didn't pass
-        # the new content kwarg. Caller may pass EITHER content OR
-        # text/media — not both.
-        if content is None:
-            if text is not None or media is not None:
-                _text_val = text or ""
-                _media_val = media or []
-                if _media_val:
-                    parts: list[dict] = []
-                    if _text_val:
-                        parts.append({"type": "text", "text": _text_val})
-                    parts.extend(_media_val)
-                    content = parts
-                else:
-                    content = _text_val
-            else:
-                content = ""
+            raise ValueError(
+                "ChatMessage role='agent' was renamed to 'assistant' in "
+                "issue #383. Pass role='assistant' instead. "
+                "(Legacy on-disk entries are migrated read-time by "
+                "_migrate_legacy_chat_message.)"
+            )
         self.role = role
         self.content = content
         self.ts = ts
@@ -526,10 +503,16 @@ class ChatMessage:
 
     @property
     def text(self) -> str:
-        """Backward-compat read for code that hasn't migrated to
-        ``content``. Returns ``content`` when it is a str; otherwise
-        extracts the first ``{"type":"text"}`` part from a content list.
-        Empty string when neither applies. Retired in PR-B.
+        """Derived view returning a str representation of ``content``.
+
+        - str content → returned as-is.
+        - list-of-parts content → the first ``{"type":"text"}`` part's text.
+        - neither → empty string.
+
+        This is a convenience accessor, NOT a legacy compatibility shim:
+        readers that want a textual rendering of any ChatMessage (text or
+        multimodal) call ``m.text`` instead of branching on isinstance.
+        Writers update ``content`` directly.
         """
         if isinstance(self.content, str):
             return self.content
@@ -538,20 +521,6 @@ class ChatMessage:
                 if isinstance(part, dict) and part.get("type") == "text":
                     return part.get("text", "")
         return ""
-
-    @property
-    def media(self) -> list[dict]:
-        """Backward-compat read for code expecting the pre-#383 ``media``
-        list (= non-text content parts). Returns the non-text parts of
-        ``content`` when it is a list; empty list otherwise. Retired in
-        PR-B.
-        """
-        if isinstance(self.content, list):
-            return [
-                p for p in self.content
-                if isinstance(p, dict) and p.get("type") != "text"
-            ]
-        return []
 
 
 # ── Legacy ChatMessage migration ───────────────────────────────────────
@@ -1342,7 +1311,7 @@ class ChatSession:
             history_appender=self._append_history,
             make_summary_message=lambda rendered, structured, covers: ChatMessage(
                 role="summary",
-                text=rendered,
+                content=rendered,
                 ts=_now_iso(),
                 meta={"structured": structured, "covers_through_seq": covers},
             ),

--- a/tests/test_chat_message_e_full_schema.py
+++ b/tests/test_chat_message_e_full_schema.py
@@ -1,17 +1,17 @@
 """Tier 2: ChatMessage Design-B schema + read-time migration (issue #383).
 
-E-full Phase 1 pins:
-  - New constructor: ``role`` ∈ {user, assistant, tool, system, summary,
+E-full Phase 1 (PR-A + PR-B) final state pins:
+  - Constructor: ``role`` ∈ {user, assistant, tool, system, summary,
     skill_event}; ``content`` is ``str | list[dict]``;
     ``tool_calls`` / ``tool_call_id`` / ``name`` for tool-turn fields.
-  - Constructor still accepts legacy ``text=`` / ``media=`` kwargs (= folds
-    into ``content``). PR-A compat shim — removed in PR-B sweep.
-  - ``role="agent"`` is renamed to ``"assistant"`` at construction time.
-  - Backward-compat read properties: ``m.text`` returns the str content
-    (or extracts the first text part from a list); ``m.media`` returns
-    non-text content parts from a list.
-  - ``_migrate_legacy_chat_message`` rewrites pre-#383 dicts into the
-    new shape (used by ``load_history`` on disk-read).
+  - PR-B removed the PR-A compat shim:
+      * legacy ``text=`` / ``media=`` kwargs → constructor raises TypeError
+      * ``role="agent"`` → constructor raises ValueError (= force update)
+      * ``.media`` property removed (= callers branch on isinstance directly)
+  - Permanent derived view: ``m.text`` returns the str content
+    (or extracts the first text part from a list-of-parts content).
+  - ``_migrate_legacy_chat_message`` STILL exists for on-disk pre-#383
+    history.jsonl entries (= load-time migration, not constructor-time).
 """
 from __future__ import annotations
 
@@ -73,47 +73,41 @@ def test_chat_message_multimodal_user_content_list() -> None:
     assert m.content == parts
 
 
-# ── Constructor: legacy kwargs compat (= PR-A only, removed in PR-B) ───
+# ── Constructor rejects pre-#383 legacy shape ──────────────────────────
 
 
-def test_legacy_text_kwarg_folds_into_content() -> None:
-    """Tier 2 (compat): pre-#383 callers pass ``text=...``. Result has
-    ``content`` set to the same string; ``text`` is not stored.
+def test_constructor_rejects_legacy_agent_role() -> None:
+    """Tier 2 (PR-B): ``role="agent"`` is the pre-#383 spelling.
+    PR-A accepted it for transition; PR-B's constructor rejects it with
+    a structured ValueError so any straggler caller gets a loud signal.
+    Migration of on-disk entries still happens via
+    ``_migrate_legacy_chat_message`` on history load.
     """
-    m = ChatMessage(role="user", text="hello", ts="t1")
-    assert m.content == "hello"
-    # Property delegates back to content.
-    assert m.text == "hello"
+    import pytest
+    with pytest.raises(ValueError, match="role='agent'"):
+        ChatMessage(role="agent", content="x", ts="t1")
 
 
-def test_legacy_media_kwarg_folds_into_content_list() -> None:
-    """Tier 2 (compat): pre-#383 callers pass ``text=`` + ``media=``.
-    Result has list-of-parts content with text-part first, media after.
+def test_constructor_no_longer_accepts_text_kwarg() -> None:
+    """Tier 2 (PR-B): the legacy ``text=`` kwarg was removed alongside
+    the compat shim. Callers must pass ``content=``.
     """
-    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
-    m = ChatMessage(role="user", text="see this", media=[block], ts="t1")
-    assert isinstance(m.content, list)
-    assert m.content == [{"type": "text", "text": "see this"}, block]
+    import pytest
+    with pytest.raises(TypeError):
+        ChatMessage(role="user", text="hi", ts="t1")  # type: ignore[call-arg]
 
 
-def test_legacy_media_only_no_text_folds_into_list() -> None:
-    """Tier 2 (compat): media without text → content is list with just
-    the media block(s)."""
-    block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
-    m = ChatMessage(role="user", media=[block], ts="t1")
-    assert m.content == [block]
-
-
-def test_role_agent_renames_to_assistant_on_construct() -> None:
-    """Tier 2: ``role="agent"`` is the pre-#383 spelling; constructor
-    normalises it to ``"assistant"`` so no live code path sees the
-    legacy value.
+def test_constructor_no_longer_accepts_media_kwarg() -> None:
+    """Tier 2 (PR-B): the legacy ``media=`` kwarg was removed alongside
+    the compat shim. Callers must build a content list directly.
     """
-    m = ChatMessage(role="agent", text="reply", ts="t1")
-    assert m.role == "assistant"
+    import pytest
+    block = {"type": "image_url", "image_url": {"url": "data:..."}}
+    with pytest.raises(TypeError):
+        ChatMessage(role="user", media=[block], ts="t1")  # type: ignore[call-arg]
 
 
-# ── Read properties (= text / media) ───────────────────────────────────
+# ── Derived text view (= permanent API, NOT a compat shim) ─────────────
 
 
 def test_text_property_from_str_content() -> None:
@@ -145,23 +139,6 @@ def test_text_property_empty_when_no_text_part() -> None:
         ts="t1",
     )
     assert m.text == ""
-
-
-def test_media_property_returns_non_text_parts() -> None:
-    """Tier 2: m.media returns the non-text content parts."""
-    block = {"type": "image_url", "image_url": {"url": "data:..."}}
-    m = ChatMessage(
-        role="user",
-        content=[{"type": "text", "text": "see this"}, block],
-        ts="t1",
-    )
-    assert m.media == [block]
-
-
-def test_media_property_empty_for_str_content() -> None:
-    """Tier 2: when content is a plain str, m.media is empty."""
-    m = ChatMessage(role="user", content="hi", ts="t1")
-    assert m.media == []
 
 
 # ── Migration ──────────────────────────────────────────────────────────

--- a/tests/test_fp0001_session_override.py
+++ b/tests/test_fp0001_session_override.py
@@ -404,11 +404,11 @@ def test_send_to_agent_impl_override_registered_and_cleaned_up(tmp_path, monkeyp
 
     async def _fake_handle(self_inner, message, *, chain_id):
         self_inner._append_history(ChatMessage(
-            role="user", text=message, ts="2026-05-16T00:00:00",
+            role="user", content=message, ts="2026-05-16T00:00:00",
             meta={"chain_id": chain_id},
         ))
         self_inner._append_history(ChatMessage(
-            role="agent", text="stub-reply",
+            role="assistant", content="stub-reply",
             ts="2026-05-16T00:00:01",
             meta={"chain_id": chain_id},
         ))
@@ -520,12 +520,12 @@ def test_concurrent_send_to_agent_impl_no_override_leak(tmp_path, monkeypatch):
         nonlocal call_count
         call_count += 1
         self_inner._append_history(ChatMessage(
-            role="user", text=message, ts="2026-05-16T00:00:00",
+            role="user", content=message, ts="2026-05-16T00:00:00",
             meta={"chain_id": chain_id},
         ))
         self_inner._append_history(ChatMessage(
-            role="agent",
-            text=f"reply-to:{message[:20]}",
+            role="assistant",
+            content=f"reply-to:{message[:20]}",
             ts="2026-05-16T00:00:01",
             meta={"chain_id": chain_id},
         ))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -333,7 +333,7 @@ def test_send_to_agent_waits_for_plan_terminal_text(tmp_path, monkeypatch):
         from reyn.chat.session import ChatMessage
         # Append the user message (= mirror real path)
         self._append_history(ChatMessage(
-            role="user", text=message, ts="2026-05-08T00:00:00",
+            role="user", content=message, ts="2026-05-08T00:00:00",
             meta={"chain_id": chain_id},
         ))
         # Schedule a background "plan task" that appends terminal
@@ -341,7 +341,7 @@ def test_send_to_agent_waits_for_plan_terminal_text(tmp_path, monkeypatch):
         async def _plan_task():
             await asyncio.sleep(0.05)
             self._append_history(ChatMessage(
-                role="agent", text=f"PLAN_RESULT_FOR:{message[:20]}",
+                role="assistant", content=f"PLAN_RESULT_FOR:{message[:20]}",
                 ts="2026-05-08T00:00:01",
                 meta={"chain_id": chain_id, "source": "plan"},
             ))
@@ -399,7 +399,7 @@ def test_send_to_agent_drains_skill_completed_inbox(tmp_path, monkeypatch):
     async def _fake_handle_user_message(self, message, *, chain_id):
         from reyn.chat.session import ChatMessage
         self._append_history(ChatMessage(
-            role="user", text=message, ts="2026-05-11T00:00:00",
+            role="user", content=message, ts="2026-05-11T00:00:00",
             meta={"chain_id": chain_id},
         ))
 
@@ -419,8 +419,8 @@ def test_send_to_agent_drains_skill_completed_inbox(tmp_path, monkeypatch):
     async def _fake_handle_skill_completed(self, payload):
         from reyn.chat.session import ChatMessage
         self._append_history(ChatMessage(
-            role="agent",
-            text=f"{sentinel}: {payload.get('skill')} {payload.get('status')}",
+            role="assistant",
+            content=f"{sentinel}: {payload.get('skill')} {payload.get('status')}",
             ts="2026-05-11T00:00:01",
             meta={
                 "chain_id": payload.get("chain_id"),

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -359,12 +359,12 @@ def test_build_history_for_router_shape(tmp_path, monkeypatch):
     from reyn.chat.session import ChatMessage
     session = _make_session(tmp_path)
 
-    # Inject some history
+    # Inject some history (Issue #383: new content kwarg + assistant role)
     session.history = [
-        ChatMessage(role="user", text="hello", ts="t1"),
-        ChatMessage(role="agent", text="hi", ts="t2"),
-        ChatMessage(role="user", text="tell me more", ts="t3"),
-        ChatMessage(role="agent", text="sure!", ts="t4"),
+        ChatMessage(role="user", content="hello", ts="t1"),
+        ChatMessage(role="assistant", content="hi", ts="t2"),
+        ChatMessage(role="user", content="tell me more", ts="t3"),
+        ChatMessage(role="assistant", content="sure!", ts="t4"),
     ]
 
     history = session._build_history_for_router()

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -60,7 +60,11 @@ def _make_session(
 
 
 def _push_turn(session, role: str, text: str) -> None:
-    session.history.append(ChatMessage(role=role, text=text, ts=_now()))
+    # Issue #383: ChatMessage uses ``content`` field; legacy "agent" role
+    # → "assistant" for new construction.
+    if role == "agent":
+        role = "assistant"
+    session.history.append(ChatMessage(role=role, content=text, ts=_now()))
 
 
 # ── No-overlap branch (= len(turns) <= head_size + tail_size) ────────────────

--- a/tests/test_transport_ref.py
+++ b/tests/test_transport_ref.py
@@ -508,11 +508,11 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
     async def _fake_handle_user_message(self, text, *, chain_id):
         from reyn.chat.session import ChatMessage
         self._append_history(ChatMessage(
-            role="user", text=text, ts="2026-05-14T00:00:00",
+            role="user", content=text, ts="2026-05-14T00:00:00",
             meta={"chain_id": chain_id},
         ))
         self._append_history(ChatMessage(
-            role="agent", text=f"bus_reply:{text}",
+            role="assistant", content=f"bus_reply:{text}",
             ts="2026-05-14T00:00:01",
             meta={"chain_id": chain_id},
         ))

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -229,25 +229,31 @@ def test_image_cmd_no_multimodal_config_skips_gate(tmp_path, monkeypatch):
     assert len(session._pending_user_images) == 1
 
 
-# ── ChatMessage.media field + history builder ──────────────────────────
+# ── ChatMessage content shape (issue #383 update) ──────────────────────
 
 
-def test_chat_message_default_media_is_empty():
-    """Tier 2: ChatMessage.media defaults to empty list — existing callers
-    that build ChatMessage without media argument see no behaviour change.
+def test_chat_message_default_content_str_empty():
+    """Tier 2: ChatMessage with str content has no media via the derived
+    ``.text`` property; constructing without media-typed parts leaves
+    the content as a plain string.
     """
-    msg = ChatMessage(role="user", text="hi", ts="2026-05-21T00:00:00+00:00")
-    assert msg.media == []
+    msg = ChatMessage(role="user", content="hi", ts="2026-05-21T00:00:00+00:00")
+    assert msg.content == "hi"
+    assert msg.text == "hi"  # derived text view
 
 
-def test_chat_message_media_persisted_when_provided():
-    """Tier 2: explicit media is preserved on construction."""
+def test_chat_message_content_list_persists_image_block():
+    """Tier 2: image block stored in ``content`` (list-of-parts shape)
+    survives construction; ``.text`` returns the text-part only.
+    """
     block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
     msg = ChatMessage(
-        role="user", text="see this", ts="2026-05-21T00:00:00+00:00",
-        media=[block],
+        role="user",
+        content=[{"type": "text", "text": "see this"}, block],
+        ts="2026-05-21T00:00:00+00:00",
     )
-    assert msg.media == [block]
+    assert msg.content == [{"type": "text", "text": "see this"}, block]
+    assert msg.text == "see this"
 
 
 # ── history-builder content-list shape ─────────────────────────────────
@@ -275,8 +281,8 @@ def test_history_text_only_emits_string_content():
     """
     cs = _make_history_builder()
     cs.history = [
-        ChatMessage(role="user", text="hi", ts="t1"),
-        ChatMessage(role="agent", text="hello", ts="t2"),
+        ChatMessage(role="user", content="hi", ts="t1"),
+        ChatMessage(role="assistant", content="hello", ts="t2"),
     ]
     msgs = cs._build_history_for_router()
 
@@ -285,11 +291,17 @@ def test_history_text_only_emits_string_content():
 
 
 def test_history_message_with_media_emits_content_list():
-    """Tier 2: ChatMessage with media → content is a list of litellm parts."""
+    """Tier 2: ChatMessage with multimodal content → wire shape is a
+    list of litellm parts (pass-through, no synthesis).
+    """
     cs = _make_history_builder()
     block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
     cs.history = [
-        ChatMessage(role="user", text="look at this", ts="t1", media=[block]),
+        ChatMessage(
+            role="user",
+            content=[{"type": "text", "text": "look at this"}, block],
+            ts="t1",
+        ),
     ]
     msgs = cs._build_history_for_router()
 
@@ -306,7 +318,7 @@ def test_history_message_with_media_and_no_text_emits_only_image() -> None:
     """
     cs = _make_history_builder()
     block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
-    cs.history = [ChatMessage(role="user", text="", ts="t1", media=[block])]
+    cs.history = [ChatMessage(role="user", content=[block], ts="t1")]
     msgs = cs._build_history_for_router()
 
     assert msgs[0]["content"] == [block]


### PR DESCRIPTION
**[e2e-coder]** — PR-B of E-full cluster (= refs #383). **Stacked on PR-A (#384)** — once #384 merges, this auto-retargets to main.

## What this PR does

Removes the PR-A backward-compat scaffold so the codebase is on the Design-B shape only:

| PR-A scaffold | PR-B disposition |
|---|---|
| Constructor accepts \`text=\` / \`media=\` kwargs | **Removed** — passing them now raises \`TypeError\` |
| Constructor accepts \`role=\"agent\"\` | **Removed** — passing it now raises \`ValueError\` with migration guidance |
| Type \`Literal\` includes \`\"agent\"\` | **Removed** from the Literal |
| \`.media\` read-only property | **Removed** — readers branch on isinstance(m.content, list) |
| \`.text\` read-only property | **KEPT** — promoted from compat shim to permanent derived view (= convenient text rendering of either str or list content) |
| \`_migrate_legacy_chat_message\` (read-time) | **KEPT** — still required for old on-disk \`history.jsonl\` entries |

## Sweep

- Production: 2 sites in chat/ updated to \`content=\` + \`role=\"assistant\"\`.
- Tests: 7 files updated (= 4 fake handlers in test_mcp_server / test_transport_ref / test_fp0001_session_override, 3 fixture rebuilds in test_user_image_input / test_router_loop_chatsession / test_session_router_history_slicing).
- PR-A schema tests rewritten: \`text=\` / \`media=\` / \`role=\"agent\"\` now have **reject-tests** that pin the new error surface.

## Test plan

- [x] \`pytest tests/test_chat_message_e_full_schema.py\` — schema reject + derived-view tests pass
- [x] Full suite — **4477 passed / 5 skipped / 3 xfailed** (no regression)
- [x] \`ruff check\` — clean
- [ ] **Manual**: \`reyn chat\` with pre-#383 history.jsonl → confirm load-time migration still runs (= PR-A's path, not touched here).

## Why this didn't ship in PR-A

PR-A was 100+ touchpoints if done as a single sweep. The compat shim let PR-A land in isolation (= schema-only review, reviewable in minutes) while PR-B handles the mechanical sweep (= touchpoint-by-touchpoint, no design decisions). Per user direction \"既存コード影響なんか考えないで。理想形を作って\" with \"step by step OK\" — final state matches the ideal, the path was split for review-friendliness.

## Cluster status after this PR

| PR | Scope | Status |
|---|---|---|
| PR-A (#384) | Schema + migration + compat shim | open |
| **PR-B (this)** | Compat shim removal + caller sweep | open (stacked on PR-A) |
| PR-C | \`.reyn/media/\` file storage + tool handler rework + \`/image\` path-ref | next |
| PR-D | router_loop producer + chat_compactor tool-awareness | depends on B |
| PR-E | LLMReplay fixture sweep + TUI tool-turn rendering | depends on D |

Refs #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)