### PR TITLE
fix(dogfood): auto-derive worker n_scenarios from scenario yaml — closes B45-B47 W6 carry-over

### DIFF
--- a/scripts/dogfood_batch_config.py
+++ b/scripts/dogfood_batch_config.py
@@ -39,11 +39,37 @@ Config shape (YAML)::
 """
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+
+def _count_scenarios(scenario_yaml_path: str) -> int | None:
+    """Count ``- id:`` entries in a scenario yaml file.
+
+    Returns ``None`` when the file is unreadable / malformed / not a
+    mapping with a ``scenarios`` list — the caller falls back to the
+    declared ``n_scenarios`` rather than crashing the batch load.
+    """
+    try:
+        path = Path(scenario_yaml_path)
+        if not path.is_file():
+            return None
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        scenarios = data.get("scenarios")
+        if not isinstance(scenarios, list):
+            return None
+        return sum(
+            1 for s in scenarios
+            if isinstance(s, dict) and "id" in s
+        )
+    except Exception:  # noqa: BLE001 — best-effort; never break batch load
+        return None
 
 
 @dataclass(frozen=True)
@@ -62,7 +88,7 @@ class WorkerSpec:
     scenario_set: str
     scenario_set_path: str
     port: int
-    n_scenarios: int
+    n_scenarios: int  # caller-declared, validated/overridden against actual scenario yaml at load time
     worktree: str
     agent_prefix: str
 
@@ -113,15 +139,34 @@ def load_batch_config(path: Path) -> BatchConfig:
     workers: list[WorkerSpec] = []
     for i, w in enumerate(workers_raw):
         for key in ("name", "scenario_set", "scenario_set_path", "port",
-                    "n_scenarios", "worktree", "agent_prefix"):
+                    "worktree", "agent_prefix"):
             if key not in w:
                 raise ValueError(f"workers[{i}].{key} is required")
+        # B47 carry-over fix (2026-05-21): n_scenarios is now derived from
+        # the actual scenario yaml. Caller-declared value is honoured only
+        # when it matches the on-disk scenario count; mismatch emits a
+        # warning and uses the on-disk count. This prevents the recurring
+        # W6 drift where ``n_scenarios: 7`` was hardcoded against a
+        # ``plan_mode.yaml`` that had 3 scenarios → sub-agent dispatched
+        # 7 agents, 4 of them ended up Blocked.
+        actual_n = _count_scenarios(w["scenario_set_path"])
+        declared_n = int(w.get("n_scenarios", actual_n))
+        if actual_n is not None and declared_n != actual_n:
+            warnings.warn(
+                f"workers[{i}].n_scenarios={declared_n} does not match "
+                f"the actual scenario count in {w['scenario_set_path']!r} "
+                f"(= {actual_n}). Using {actual_n}. Drop the n_scenarios "
+                f"field from the batch yaml to silence this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+        n_scenarios = actual_n if actual_n is not None else declared_n
         workers.append(WorkerSpec(
             name=w["name"],
             scenario_set=w["scenario_set"],
             scenario_set_path=w["scenario_set_path"],
             port=int(w["port"]),
-            n_scenarios=int(w["n_scenarios"]),
+            n_scenarios=n_scenarios,
             worktree=w["worktree"],
             agent_prefix=w["agent_prefix"],
         ))

--- a/tests/test_dogfood_batch_config_scenario_count_autoderive.py
+++ b/tests/test_dogfood_batch_config_scenario_count_autoderive.py
@@ -1,0 +1,230 @@
+"""Tier 2: ``load_batch_config`` derives ``n_scenarios`` from the actual
+scenario yaml, with caller-declared overrides validated.
+
+Pinned invariants:
+
+- When the batch yaml omits ``n_scenarios``, the loader fills it from
+  the on-disk scenario yaml's actual count.
+- When the batch yaml declares a ``n_scenarios`` that matches the
+  on-disk count, the loader silently accepts it (= backwards compat
+  with existing batch_b4*.yaml configs).
+- When the batch yaml declares a ``n_scenarios`` that **mismatches**
+  the on-disk count, the loader:
+  - emits a ``UserWarning`` explaining the drift
+  - **uses the on-disk count** as the authoritative value
+- When the scenario yaml is missing / unreadable / malformed, the
+  loader falls back to the caller-declared value (= best-effort, no
+  hard crash on partial filesystem state).
+
+Motivation: B45/B46/B47 W6 entries had ``n_scenarios: 7`` hardcoded
+against ``plan_mode.yaml`` which has 3 scenarios. The mismatch caused
+sub-agents to dispatch 7 agents but only 3 scenarios existed → 4
+``Blocked`` verdicts per batch. The B47 retrospective documented this
+as a carry-over; this fix closes it at the loader layer so future
+batch yamls cannot drift without a visible warning.
+
+testing.ja.md compliance:
+- No mocks. Real ``load_batch_config`` against tmp_path yamls.
+- No private-state assertions; pins the public ``WorkerSpec.n_scenarios``.
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from dogfood_batch_config import load_batch_config  # noqa: E402
+
+
+def _write_scenario_yaml(path: Path, n: int) -> None:
+    """Write a minimal scenario yaml with ``n`` scenario entries."""
+    scenarios = "\n".join(
+        f"  - id: scen_{i}\n    input: hello\n    expected: world"
+        for i in range(n)
+    )
+    path.write_text(
+        "metadata:\n  name: test\nscenarios:\n" + scenarios,
+        encoding="utf-8",
+    )
+
+
+def _write_batch_yaml(
+    path: Path,
+    scenario_yaml_path: str,
+    *,
+    n_scenarios_declared: int | None = None,
+) -> None:
+    """Write a minimal batch yaml referencing the given scenario yaml.
+
+    When ``n_scenarios_declared`` is None, the worker block omits the
+    field entirely (= exercising the auto-derive path)."""
+    n_field = (
+        f"    n_scenarios: {n_scenarios_declared}\n"
+        if n_scenarios_declared is not None
+        else ""
+    )
+    path.write_text(
+        f"""batch:
+  name: TEST
+  date: "2026-05-21"
+  head: deadbeef
+workers:
+  - name: W1
+    scenario_set: test_set
+    scenario_set_path: {scenario_yaml_path}
+    port: 8001
+{n_field}    worktree: /tmp/test-wt
+    agent_prefix: test-w1-s
+past_batches: []
+journal_dir: /tmp/test-journal
+""",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auto-derive: omitted n_scenarios is filled from the scenario yaml
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_n_scenarios_derived_from_scenario_yaml(tmp_path):
+    """Tier 2 (B47-fix): batch yaml may omit ``n_scenarios`` entirely;
+    the loader fills it from the on-disk scenario yaml count."""
+    scen_path = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen_path, n=5)
+    batch_path = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch_path, str(scen_path), n_scenarios_declared=None)
+
+    cfg = load_batch_config(batch_path)
+    assert cfg.workers[0].n_scenarios == 5, (
+        f"omitted n_scenarios should be derived as 5; got "
+        f"{cfg.workers[0].n_scenarios}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation: declared n_scenarios is overridden when it mismatches
+# ---------------------------------------------------------------------------
+
+
+def test_declared_n_scenarios_matching_actual_silent(tmp_path):
+    """Tier 2: backwards-compat — declaring ``n_scenarios`` that matches
+    the actual count loads silently (= no warning)."""
+    scen_path = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen_path, n=3)
+    batch_path = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch_path, str(scen_path), n_scenarios_declared=3)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cfg = load_batch_config(batch_path)
+        mismatch_warnings = [
+            w for w in caught
+            if "n_scenarios" in str(w.message) and "does not match" in str(w.message)
+        ]
+        assert not mismatch_warnings, (
+            f"matching declared n_scenarios should be silent; got "
+            f"{[str(w.message) for w in mismatch_warnings]}"
+        )
+    assert cfg.workers[0].n_scenarios == 3
+
+
+def test_declared_n_scenarios_mismatched_warns_and_overrides(tmp_path):
+    """Tier 2 (B47-fix headline): the W6 drift case — declared
+    ``n_scenarios: 7`` against a 3-scenario yaml emits warning and
+    uses the actual count (3) as authoritative."""
+    scen_path = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen_path, n=3)
+    batch_path = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch_path, str(scen_path), n_scenarios_declared=7)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cfg = load_batch_config(batch_path)
+        mismatch_warnings = [
+            w for w in caught
+            if "n_scenarios" in str(w.message) and "does not match" in str(w.message)
+        ]
+        assert len(mismatch_warnings) == 1, (
+            f"mismatched declared n_scenarios should emit exactly one "
+            f"warning; got {len(mismatch_warnings)}: "
+            f"{[str(w.message) for w in caught]}"
+        )
+        assert "7" in str(mismatch_warnings[0].message)
+        assert "3" in str(mismatch_warnings[0].message)
+
+    # Authoritative value is the on-disk actual count, not the declared one.
+    assert cfg.workers[0].n_scenarios == 3, (
+        f"mismatched n_scenarios should be overridden to 3 (actual); "
+        f"got {cfg.workers[0].n_scenarios}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallback: scenario yaml unreadable → use declared
+# ---------------------------------------------------------------------------
+
+
+def test_missing_scenario_yaml_falls_back_to_declared(tmp_path):
+    """Tier 2: if the scenario yaml file doesn't exist, the loader
+    falls back to the caller-declared value rather than crashing.
+    This keeps best-effort behavior for batch yamls that point at
+    not-yet-created scenario files (= dispatch-time prep)."""
+    batch_path = tmp_path / "batch.yaml"
+    _write_batch_yaml(
+        batch_path, "/nonexistent/scenarios.yaml", n_scenarios_declared=4,
+    )
+    cfg = load_batch_config(batch_path)
+    assert cfg.workers[0].n_scenarios == 4
+
+
+def test_malformed_scenario_yaml_falls_back_to_declared(tmp_path):
+    """Tier 2: a malformed scenario yaml (= not a mapping, or no
+    ``scenarios`` list) also falls back. Catches partial-filesystem
+    state without hard-crashing the batch load."""
+    scen_path = tmp_path / "scenarios.yaml"
+    scen_path.write_text("just a string, not a dict\n", encoding="utf-8")
+    batch_path = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch_path, str(scen_path), n_scenarios_declared=2)
+
+    cfg = load_batch_config(batch_path)
+    assert cfg.workers[0].n_scenarios == 2
+
+
+# ---------------------------------------------------------------------------
+# Required-field regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_required_fields_still_enforced(tmp_path):
+    """Tier 2: dropping ``n_scenarios`` is now allowed (= auto-derived),
+    but the other required worker fields (``name``, ``port``,
+    ``worktree``, etc.) still raise ValueError on omission."""
+    scen_path = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen_path, n=2)
+    batch_path = tmp_path / "batch.yaml"
+    # Omit `port` — should raise
+    batch_path.write_text(
+        f"""batch:
+  name: TEST
+  date: "2026-05-21"
+  head: deadbeef
+workers:
+  - name: W1
+    scenario_set: test_set
+    scenario_set_path: {scen_path}
+    worktree: /tmp/test-wt
+    agent_prefix: test-w1-s
+past_batches: []
+journal_dir: /tmp/test-journal
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="port"):
+        load_batch_config(batch_path)


### PR DESCRIPTION
**[dogfood-coder]** — batch config yamls hardcoded \`n_scenarios\` per worker, which drifted silently when the underlying scenario yaml changed. The recurring W6 case: \`batch_b4{4,5,6,7}.yaml\` set \`n_scenarios: 7\` against \`dogfood/scenarios/plan_mode.yaml\` which has only 3 scenarios. Result: sub-agents dispatched 7 agents, only 3 scenarios existed → **4 Blocked verdicts per batch** (= measurement noise, not real test failure). Carry-over documented in B45 + B47 retrospectives.

## Fix at the loader layer (\`load_batch_config\`)

- \`n_scenarios\` is now **optional** in worker entries
- When omitted: derived from the scenario yaml's actual \`- id:\` count
- When declared AND matches actual: silent backwards-compat
- When declared AND mismatches actual: emits \`UserWarning\` and uses **on-disk actual count** as authoritative
- When scenario yaml is missing/malformed: best-effort fallback to the declared value (= partial-filesystem state doesn't crash batch load)

## Backwards compatibility

Existing batch yamls (B43-B47 journals) keep working without modification — the auto-correction surfaces the drift via warning during dispatch but doesn't break historical configs. Future batch yamls can simply omit the field entirely.

## Smoke evidence

\`load_batch_config('dogfood/batch_b47.yaml')\` emits exactly one warning:

\`\`\`
UserWarning: workers[5].n_scenarios=7 does not match the actual scenario count
in 'dogfood/scenarios/plan_mode.yaml' (= 3). Using 3. Drop the n_scenarios
field from the batch yaml to silence this warning.
\`\`\`

\`WorkerSpec.n_scenarios\` ends up as 3 (= on-disk actual), W6 worker prompt now correctly says "run 3 scenarios".

## Test plan

- [x] 6 new Tier 2 tests:
  - omitted-derives (= field absent → loader fills from yaml)
  - declared-matches-silent (= backwards compat)
  - declared-mismatches-warns-and-overrides (= the W6 headline case)
  - missing-yaml-falls-back (= robust against not-yet-created scenario files)
  - malformed-yaml-falls-back (= robust against partial state)
  - other-required-fields-still-enforced (= regression guard for ValueError surfaces)
- [x] 20 existing batch_config + batch_tools + batch_dispatch tests pass
- [x] ruff check clean

## References

- B45 retrospective carry-over: dogfood dispatch script hygiene
- B47 retrospective (PR #386) "Pipeline / tooling note": "W6 prompts say 7, plan_mode.yaml has 3 — fix during E-full pause window if time allows"
- \`feedback_no_batch_with_known_bugs\` — close known carry-overs before next batch dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)