### PR TITLE
feat(chat): E-full PR-E2 — chat_compactor is tool-aware (refs #383)

### DIFF
--- a/docs/concepts/chat-compaction.md
+++ b/docs/concepts/chat-compaction.md
@@ -57,11 +57,23 @@ chat:
 ## Trade-offs
 
 **Preserved:** topic arc, decisions, pending items, user facts, referenced
-artifacts, and the raw first/last N turns.
+artifacts (= including tool activity per issue #383 PR-E2 — files read /
+URLs fetched / MCP tools called surface as `artifacts_referenced`
+entries when the result is conversation-relevant), and the raw first/last
+N turns.
 
 **Lost:** verbatim phrasing of compacted turns; exact ordering of minor
 exchanges. Section caps are soft — slight overruns self-correct on the
 next compaction pass.
+
+### Tool-aware compaction (post-#383 PR-E2)
+
+`new_turns` includes `role="assistant"` entries with `tool_calls` and
+`role="tool"` response entries (= what the router_loop emitted during
+the user turn, persisted via `RouterLoopHost.append_history_entry`).
+The compactor sees these as structured input and decides whether to
+record the call under `artifacts_referenced`. Tool turns count toward
+the head/tail/body slice the same as plain conversational turns.
 
 Compaction runs in a background asyncio task and never blocks the current
 turn. Events `compaction_started` / `compaction_completed` /

--- a/src/reyn/chat/services/compaction_controller.py
+++ b/src/reyn/chat/services/compaction_controller.py
@@ -28,6 +28,44 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text or "") // 4)
 
 
+def _turn_to_compactor_input(t: "ChatMessage") -> dict:
+    """Serialise a ChatMessage into the compactor's ``new_turns`` shape.
+
+    Post-PR-E1 (issue #383) the history may contain ``assistant`` entries
+    with ``tool_calls``, ``tool`` entries with ``tool_call_id`` + ``name``,
+    and ``user``/``assistant`` entries with multimodal ``content`` lists.
+    The compactor skill needs enough structure to reason about tool
+    activity in ``artifacts_referenced`` while staying within token caps.
+
+    Shape we emit per turn:
+      {role, text, seq, [tool_calls], [tool_call_id], [tool_name]}
+
+    ``text`` is the derived text view (= str content or first text part
+    from a list content). Tool fields are only included on the entries
+    where they're set.
+    """
+    out: dict = {"role": t.role, "text": t.text, "seq": t.seq}
+    if getattr(t, "tool_calls", None):
+        # Compact representation: function names + arg-string lengths.
+        # Avoid sending raw arg JSON since it can be large and the
+        # compactor only needs the structural shape ("LLM called fn X
+        # with N chars of args"). The skill's ``artifacts_referenced``
+        # rule decides whether to surface the call.
+        out["tool_calls"] = [
+            {
+                "name": (tc.get("function") or {}).get("name", ""),
+                "args_chars": len((tc.get("function") or {}).get("arguments", "") or ""),
+            }
+            for tc in t.tool_calls
+            if isinstance(tc, dict)
+        ]
+    if getattr(t, "tool_call_id", None):
+        out["tool_call_id"] = t.tool_call_id
+    if getattr(t, "name", None):
+        out["tool_name"] = t.name
+    return out
+
+
 class CompactionController:
     """Background head/body/tail compaction service.
 
@@ -132,7 +170,15 @@ class CompactionController:
             return
         cfg = self._config
         history = self._history_access()
-        turns = [m for m in history if m.role in ("user", "agent")]
+        # E-full PR-E2 (#383): tool turns (= role="assistant" with
+        # tool_calls + role="tool" responses) are now first-class history
+        # entries and should be compactable. "agent" is the pre-#383
+        # spelling of "assistant" — kept here for backward-compat with
+        # any legacy entries that escaped read-time migration.
+        turns = [
+            m for m in history
+            if m.role in ("user", "assistant", "tool", "agent")
+        ]
         if len(turns) <= cfg.head_size + cfg.tail_size:
             self._events.emit(
                 "compaction_check", outcome="too_few_turns",
@@ -203,7 +249,7 @@ class CompactionController:
             "data": {
                 "previous_summary": prev_structured,
                 "new_turns": [
-                    {"role": t.role, "text": t.text, "seq": t.seq}
+                    _turn_to_compactor_input(t)
                     for t in candidates
                 ],
                 "section_token_caps": {

--- a/src/reyn/stdlib/skills/chat_compactor/phases/compact.md
+++ b/src/reyn/stdlib/skills/chat_compactor/phases/compact.md
@@ -15,7 +15,15 @@ information and dropping low-importance items per the retention rules.
 ## Inputs
 
 - `previous_summary` — the current rolling summary (may be null).
-- `new_turns` — recent raw turns to absorb (oldest first).
+- `new_turns` — recent raw turns to absorb (oldest first). Each turn is
+  `{role, text, seq, ...}` where `role` is one of:
+    - `user` / `assistant` — regular conversational turns.
+    - `assistant` (with `tool_calls`) — the LLM decided to invoke one or
+      more tools; the entry carries
+      `tool_calls: [{name, args_chars}, ...]` so you can reason about
+      what was called (= source for `artifacts_referenced`).
+    - `tool` (with `tool_call_id` + `tool_name`) — the tool's response
+      to a specific `tool_call`; `text` is the JSON-serialised result.
 - `section_token_caps` — soft per-section token budgets.
 
 ## Sections (and retention rules)
@@ -32,6 +40,17 @@ information and dropping low-importance items per the retention rules.
   budget — durable attributes belong in MEMORY.md anyway.
 - **artifacts_referenced**: bullets of files / PRs / commits / issues
   referenced this session. Drop ones no longer in scope.
+
+  Include items derived from **tool activity** in `new_turns` when
+  they are conversation-relevant:
+    - `file_read` / `file_write` / `file_edit` ops → "edited
+      <path>" / "read <path>" entries.
+    - `web_fetch` ops → "fetched <url>" entries.
+    - `mcp.tool__<server>.<tool>` ops → "called <server>.<tool>"
+      entries when the call result informed the user-visible reply.
+  Do NOT enumerate every tool call mechanically — only those whose
+  outputs the conversation depends on going forward (= same
+  retention rule as other artifacts).
 
 ## Output
 

--- a/tests/test_compaction_controller_tool_aware.py
+++ b/tests/test_compaction_controller_tool_aware.py
@@ -1,0 +1,129 @@
+"""Tier 2: chat compaction is tool-aware (issue #383 PR-E2).
+
+Post-PR-E1, history.jsonl contains assistant entries with ``tool_calls``
+and ``role="tool"`` response entries. PR-E2 makes the compaction
+controller:
+
+  - Include tool turns in its candidate selection (= the filter no
+    longer drops ``role="tool"`` / ``role="assistant"``).
+  - Serialise each turn into a compactor-skill-input dict that
+    surfaces structured tool detail (``tool_calls`` summary +
+    ``tool_call_id`` + ``tool_name``).
+
+The compactor skill's phase prompt is also updated to mention tool
+turns + add an ``artifacts_referenced`` rule for tool-derived items;
+that's documented in ``src/reyn/stdlib/skills/chat_compactor/phases/compact.md``
+(not directly testable without an LLM call).
+"""
+from __future__ import annotations
+
+from reyn.chat.services.compaction_controller import (
+    _turn_to_compactor_input,
+)
+from reyn.chat.session import ChatMessage
+
+# ── _turn_to_compactor_input ──────────────────────────────────────────
+
+
+def test_user_turn_minimal_shape() -> None:
+    """Tier 2: plain user turn → {role, text, seq} (= no tool fields)."""
+    m = ChatMessage(role="user", content="hi", ts="t1", seq=1)
+    out = _turn_to_compactor_input(m)
+    assert out == {"role": "user", "text": "hi", "seq": 1}
+
+
+def test_assistant_text_only_no_tool_fields() -> None:
+    """Tier 2: assistant final-text turn (= no tool_calls) → no tool fields."""
+    m = ChatMessage(role="assistant", content="here's the answer", ts="t1", seq=2)
+    out = _turn_to_compactor_input(m)
+    assert out == {"role": "assistant", "text": "here's the answer", "seq": 2}
+
+
+def test_assistant_with_tool_calls_emits_compact_summary() -> None:
+    """Tier 2: assistant turn that emitted tool_calls → output carries
+    a ``tool_calls`` list with ``{name, args_chars}`` per call (= compact
+    form, not full arg JSON, so the compactor input stays small).
+    """
+    m = ChatMessage(
+        role="assistant", content="checking", ts="t1", seq=3,
+        tool_calls=[
+            {"id": "c1", "type": "function",
+             "function": {"name": "file_read",
+                          "arguments": '{"path": "src/a.py"}'}},
+            {"id": "c2", "type": "function",
+             "function": {"name": "web_fetch",
+                          "arguments": '{"url": "https://example.com"}'}},
+        ],
+    )
+    out = _turn_to_compactor_input(m)
+    assert out["role"] == "assistant"
+    assert out["text"] == "checking"
+    assert out["tool_calls"] == [
+        {"name": "file_read", "args_chars": len('{"path": "src/a.py"}')},
+        {"name": "web_fetch", "args_chars": len('{"url": "https://example.com"}')},
+    ]
+
+
+def test_tool_response_carries_id_and_name() -> None:
+    """Tier 2: tool response turn → output includes ``tool_call_id`` + ``tool_name``."""
+    m = ChatMessage(
+        role="tool", content='{"contents": "..."}', ts="t1", seq=4,
+        tool_call_id="c1", name="file_read",
+    )
+    out = _turn_to_compactor_input(m)
+    assert out["role"] == "tool"
+    assert out["tool_call_id"] == "c1"
+    assert out["tool_name"] == "file_read"
+
+
+def test_helper_ignores_malformed_tool_call_entries() -> None:
+    """Tier 2: a non-dict entry in tool_calls is skipped (= defensive)."""
+    m = ChatMessage(
+        role="assistant", content="", ts="t1", seq=5,
+        tool_calls=[
+            "not-a-dict",  # type: ignore[list-item]
+            {"id": "c1", "function": {"name": "f", "arguments": "{}"}},
+        ],
+    )
+    out = _turn_to_compactor_input(m)
+    assert out["tool_calls"] == [{"name": "f", "args_chars": 2}]
+
+
+# ── compaction filter (= candidate selection includes tool turns) ─────
+
+
+def test_compaction_filter_includes_tool_role() -> None:
+    """Tier 2: the new role filter in ``_maybe_compact`` admits tool turns.
+
+    Pin via source-text invariant since the filter is a literal tuple
+    inside the method body. The string check guards against accidental
+    revert to the pre-PR-E2 ``("user", "agent")``-only filter.
+    """
+    import inspect
+
+    from reyn.chat.services import compaction_controller
+    src = inspect.getsource(compaction_controller)
+    assert '"user", "assistant", "tool", "agent"' in src, (
+        "compaction candidate filter must include tool + assistant roles "
+        "post-#383 PR-E2"
+    )
+
+
+def test_compaction_phase_prompt_mentions_tool_calls() -> None:
+    """Tier 2: the compactor phase prompt explicitly mentions tool turns +
+    the artifacts_referenced rule for tool-derived items.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    phase = (
+        repo_root
+        / "src/reyn/stdlib/skills/chat_compactor/phases/compact.md"
+    ).read_text(encoding="utf-8")
+
+    # Phase prompt acknowledges tool_calls + tool role in inputs.
+    assert "tool_calls" in phase
+    assert "`tool`" in phase or "role.*tool" in phase
+    # artifacts_referenced rule explicitly covers tool-derived items.
+    assert "tool activity" in phase or "Tool activity" in phase
+    assert "web_fetch" in phase  # at least one canonical example


### PR DESCRIPTION
**[e2e-coder]** — Consumer side of PR-E1's producer changes. PR-E1 made the router_loop persist tool turns; **PR-E2 makes the compactor see them as structured input** so multi-turn compaction preserves meaningful tool activity in the rolling summary.

## What changes

- **\`compaction_controller.py\`**: role filter widened to include \`assistant\` + \`tool\` (post-#383 schema); new \`_turn_to_compactor_input\` helper emits structured tool detail per turn.
- **\`chat_compactor/phases/compact.md\`**: prompt now describes the new turn shapes + adds an \`artifacts_referenced\` rule for tool activity (file_read / web_fetch / mcp.tool__*).
- **\`docs/concepts/chat-compaction.md\`**: trade-off table + new subsection.

## What does NOT change

- Compactor schema (5 sections + covers_through_seq) untouched.
- Postprocessor (\`compute_covers_through_seq\`) unchanged.
- Trigger thresholds + token caps defaults unchanged.

## Test plan

- [x] \`pytest tests/test_compaction_controller_tool_aware.py\` — 7/7 pass
- [x] \`pytest -k compact\` — 34/34 (no regression on existing postprocessor + e2e tests)
- [x] Full suite — **4490 passed / 5 skipped / 3 xfailed**
- [x] \`ruff check\` — clean
- [ ] **Manual**: trigger compaction in a session with mixed tool / text turns; confirm \`artifacts_referenced\` mentions the tool activity.

## Cluster status

| PR | Status |
|---|---|
| PR-A #384 | ✓ merged |
| PR-B #387 | ✓ merged |
| PR-C #388 | open |
| PR-E1 #391 | open |
| **PR-E2 (this)** | open |
| PR-D (tui-coder #385) | parallel, depends on PR-C |
| PR-F (LLMReplay sweep + TUI render) | depends on PR-E1+E2 |

Refs #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)