### PR TITLE
fix(dogfood): emit absolute deliverable path + MAIN repo CWD in worker prompts (closes B45 carry-over)

### DIFF
--- a/scripts/dogfood_batch_dispatch.py
+++ b/scripts/dogfood_batch_dispatch.py
@@ -82,7 +82,11 @@ def _past_verdicts_for_worker(
     return out
 
 
-def render_worker_prompt(config: BatchConfig, worker: WorkerSpec) -> str:
+def render_worker_prompt(
+    config: BatchConfig,
+    worker: WorkerSpec,
+    repo_root: Path | None = None,
+) -> str:
     """Compose the markdown worker prompt.
 
     Matches the structure the sandbox_2 session has been hand-rolling
@@ -112,10 +116,19 @@ def render_worker_prompt(config: BatchConfig, worker: WorkerSpec) -> str:
         )
     tool_uses_cap = config.batch.hard_caps.get("tool_uses", 50)
     wall_cap = config.batch.hard_caps.get("wall_clock_min", 15)
-    deliverable_path = (
+    # B45 carry-over fix (2026-05-22): the deliverable path is now emitted
+    # as an absolute filesystem path against the main-repo root, with an
+    # explicit "from MAIN repo CWD" line in the prompt. Pre-fix, the path
+    # was relative (= config.journal_dir/workers/...) and sub-agents
+    # running from the worker's worktree CWD wrote to the worktree-relative
+    # location — the main repo never saw the results JSON without a
+    # post-batch `cp` step. Observed B44/B45/B47 W2/W3/W7.
+    repo_root_abs = repo_root.resolve() if repo_root else Path.cwd().resolve()
+    deliverable_rel = (
         f"{config.journal_dir}/workers/results-worker-"
         f"{worker.name.lstrip('W')}.json"
     )
+    deliverable_path = str(repo_root_abs / deliverable_rel)
 
     return f"""{config.batch.name} worker {worker.name} — run `{worker.scenario_set_path}` ({worker.n_scenarios} scenarios), emit results JSON.
 
@@ -153,6 +166,8 @@ For each of the {worker.n_scenarios} scenarios in `{worker.scenario_set_path}`:
 {json.dumps(config.batch.user_params, indent=2)}
 
 ## Deliverable
+
+Write the results JSON at the **absolute path** below — sub-agents running from a worker worktree CWD must use this exact path so the main repo receives the file (= worktree-relative paths leave the result inside the worktree and the aggregator never sees it). The MAIN repo CWD is `{repo_root_abs}`.
 
 Write `{deliverable_path}` with this shape:
 
@@ -243,14 +258,14 @@ def main() -> int:
     if args.prompts_dir:
         args.prompts_dir.mkdir(parents=True, exist_ok=True)
         for w in config.workers:
-            prompt = render_worker_prompt(config, w)
+            prompt = render_worker_prompt(config, w, repo_root=args.repo_root)
             (args.prompts_dir / f"worker-{w.name}.md").write_text(prompt)
             print(f"[prompt] {w.name} → {args.prompts_dir}/worker-{w.name}.md",
                   file=sys.stderr)
     else:
         for w in config.workers:
             print(f"--- WORKER {w.name} ---")
-            print(render_worker_prompt(config, w))
+            print(render_worker_prompt(config, w, repo_root=args.repo_root))
             print()
     return 0
 

--- a/tests/test_dogfood_dispatch_absolute_deliverable.py
+++ b/tests/test_dogfood_dispatch_absolute_deliverable.py
@@ -1,0 +1,185 @@
+"""Tier 2: ``dogfood_batch_dispatch.render_worker_prompt`` emits an
+absolute deliverable path against the supplied repo root.
+
+Pinned invariants:
+
+- The "Deliverable" section of the generated prompt contains an
+  **absolute filesystem path** (= starts with ``/``) for the
+  ``results-worker-N.json`` write target, not the relative
+  ``config.journal_dir/...`` form.
+- The prompt explicitly states the MAIN repo CWD so the sub-agent
+  knows which root the absolute path corresponds to.
+- The absolute path is constructed by joining ``repo_root`` with
+  ``config.journal_dir`` and ``workers/results-worker-<n>.json``.
+- When ``repo_root`` is omitted, the function falls back to
+  ``Path.cwd()`` — backwards-compat for callers that pre-date this
+  fix.
+
+Motivation: B45 retrospective recorded the "worker output path
+inconsistency" carry-over: W2/W3/W7 wrote to the worktree-relative
+``docs/...`` path inside ``/tmp/reyn-worktrees/b{n}-{w}/...`` rather
+than the main repo's ``docs/...``. The aggregator then couldn't find
+the files and a manual ``cp`` step was required. B47 worked around it
+by hand-coding "from MAIN repo CWD" into each Agent() dispatch prompt;
+this fix lifts that into the script-generated template.
+
+testing.ja.md compliance:
+- No mocks. Real ``render_worker_prompt`` called against a tmp_path
+  config.
+- Tier 2 contract pin: the prompt's deliverable-path shape.
+- No private-state assertions; only the rendered string.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from dogfood_batch_config import (  # noqa: E402
+    BatchConfig,
+    BatchMeta,
+    PastBatch,
+    WorkerSpec,
+)
+from dogfood_batch_dispatch import render_worker_prompt  # noqa: E402
+
+
+def _make_config(journal_dir: str) -> BatchConfig:
+    return BatchConfig(
+        batch=BatchMeta(
+            name="BTEST",
+            date="2026-05-22",
+            head="deadbeef",
+            env_vars={"REYN_EMPTY_STOP_RETRY": "1"},
+            user_params={"hot_list_n": 10},
+            hard_caps={"tool_uses": 50, "wall_clock_min": 15},
+        ),
+        workers=(
+            WorkerSpec(
+                name="W1",
+                scenario_set="test_set.yaml",
+                scenario_set_path="dogfood/scenarios/test_set.yaml",
+                port=8201,
+                n_scenarios=3,
+                worktree="/tmp/test-wt-1",
+                agent_prefix="test-w1-s",
+            ),
+        ),
+        past_batches=(PastBatch(name="BPREV", aggregate_path="prev.json"),),
+        journal_dir=journal_dir,
+    )
+
+
+def test_deliverable_path_is_absolute_against_repo_root(tmp_path):
+    """Tier 2 (B45-carry-over fix): rendered prompt emits the
+    deliverable path as an absolute filesystem path joined from the
+    supplied repo_root + journal_dir + worker filename."""
+    config = _make_config("docs/journal/test-batch")
+    repo_root = tmp_path / "fake-repo"
+    repo_root.mkdir()
+
+    prompt = render_worker_prompt(
+        config, config.workers[0], repo_root=repo_root,
+    )
+    expected_path = str(
+        repo_root.resolve()
+        / "docs/journal/test-batch/workers/results-worker-1.json"
+    )
+    assert expected_path in prompt, (
+        f"prompt should contain absolute deliverable path "
+        f"{expected_path!r}. Got prompt excerpt:\n"
+        f"{prompt[prompt.find('## Deliverable'):prompt.find('## Hard caps')]}"
+    )
+
+
+def test_prompt_states_main_repo_cwd_explicitly(tmp_path):
+    """Tier 2: the prompt must say "MAIN repo CWD is <path>" so the
+    sub-agent knows which root the absolute path corresponds to (=
+    avoids ambiguity for sub-agents running from a worktree)."""
+    config = _make_config("docs/journal/test")
+    repo_root = tmp_path / "fake-repo"
+    repo_root.mkdir()
+
+    prompt = render_worker_prompt(
+        config, config.workers[0], repo_root=repo_root,
+    )
+    assert "MAIN repo CWD" in prompt, (
+        f"prompt should explicitly state the MAIN repo CWD. "
+        f"Got Deliverable section:\n"
+        f"{prompt[prompt.find('## Deliverable'):prompt.find('## Hard caps')]}"
+    )
+    assert str(repo_root.resolve()) in prompt
+
+
+def test_deliverable_path_is_no_longer_relative(tmp_path):
+    """Tier 2: regression guard — the prompt MUST NOT emit the
+    bare relative form `{config.journal_dir}/workers/results-worker-N.json`
+    (= the pre-fix shape that caused workers to write to worktree-
+    relative paths)."""
+    config = _make_config("docs/journal/test")
+    repo_root = tmp_path / "fake-repo"
+    repo_root.mkdir()
+
+    prompt = render_worker_prompt(
+        config, config.workers[0], repo_root=repo_root,
+    )
+    # The exact relative form (= journal_dir/workers/...) should NOT
+    # appear as a backtick-wrapped Write target. We check by looking
+    # for the bare relative path inside a `Write` instruction.
+    bare_rel = "docs/journal/test/workers/results-worker-1.json"
+    # The bare relative path may appear *inside* the absolute path
+    # (because the absolute is the relative joined to repo_root). What
+    # we forbid is the bare relative wrapped as a backticked Write
+    # target by itself (= no preceding path component).
+    bad_form = f"`{bare_rel}`"
+    assert bad_form not in prompt, (
+        f"prompt must not contain the bare relative deliverable form "
+        f"{bad_form!r}. Got prompt:\n{prompt[:500]}"
+    )
+
+
+def test_default_repo_root_is_cwd_when_omitted():
+    """Tier 2: when ``repo_root`` is omitted, the function falls back
+    to ``Path.cwd()`` — backwards-compat for callers pre-fix. We
+    verify the cwd appears in the prompt; the exact absolute path is
+    not pinned because it depends on test invocation cwd."""
+    config = _make_config("docs/journal/test")
+    prompt = render_worker_prompt(config, config.workers[0])
+    cwd = str(Path.cwd().resolve())
+    assert cwd in prompt, (
+        f"prompt should contain the current cwd {cwd!r} when "
+        f"repo_root is omitted (= backwards-compat)"
+    )
+
+
+def test_smoke_against_b47_yaml_does_not_emit_relative_paths():
+    """Tier 2: end-to-end smoke against a real committed batch yaml
+    (= dogfood/batch_b47.yaml) — the resulting prompt for W1 must
+    contain an absolute path, not the bare relative shape. This pins
+    the fix against the actual production yaml shape, not just the
+    synthetic test config."""
+    real_yaml = (
+        Path(__file__).resolve().parent.parent
+        / "dogfood" / "batch_b47.yaml"
+    )
+    if not real_yaml.is_file():
+        pytest.skip("dogfood/batch_b47.yaml not present in checkout")
+    from dogfood_batch_config import load_batch_config
+
+    config = load_batch_config(real_yaml)
+    prompt = render_worker_prompt(
+        config, config.workers[0], repo_root=Path.cwd(),
+    )
+    assert "/Users" in prompt or "/home" in prompt or "/tmp" in prompt, (
+        "prompt should contain an absolute filesystem path"
+    )
+    # Bare relative form must not appear as the Write target.
+    relative_only = (
+        f"`{config.journal_dir}/workers/results-worker-1.json`"
+    )
+    assert relative_only not in prompt


### PR DESCRIPTION
**[dogfood-coder]** — B45 retrospective recorded the worker output path inconsistency carry-over: W2/W3/W7 wrote \`results-worker-N.json\` to the worktree-relative \`journal_dir\`, not the main repo. The aggregator couldn't find the files and a manual \`cp\` step was required after each batch.

B47 worked around this by hand-coding "from MAIN repo CWD \`<abs path>\`" into each Agent() dispatch prompt. This PR lifts the workaround into the script-generated template.

## Fix

- \`render_worker_prompt\` accepts a new \`repo_root\` keyword argument (default: \`Path.cwd()\` for backwards compat)
- The "Deliverable" section now states the MAIN repo CWD explicitly + emits the results target as an ABSOLUTE filesystem path joined from \`repo_root + config.journal_dir + workers/results-worker-N.json\`
- The bare relative form (= \`config.journal_dir/workers/...\`) is no longer present as a Write target in the prompt
- \`main()\` callers pass \`args.repo_root\` (= same value as the worktree-setup path uses) so the absolute path matches the user-invoked repo root

## Effect

Future B-batch sub-agents dispatched from worker worktree CWDs will write directly to the main repo's journal directory. The post-batch \`cp\` step needed for B44/B45/B47 W2/W3/W7 is gone.

## Test plan

- [x] **5 new Tier 2 tests**:
  - deliverable path is absolute joined from \`repo_root + journal_dir\`
  - prompt states "MAIN repo CWD \`<abs>\`" explicitly
  - regression guard: bare relative form NOT present as Write target
  - backwards compat: default \`repo_root = Path.cwd()\` when omitted
  - end-to-end smoke against real \`dogfood/batch_b47.yaml\` confirms shape
- [x] **20 existing batch_dispatch + batch_tools + batch_config tests pass**
- [x] **ruff check clean**

## References

- B45 retrospective "Worker output path inconsistency" carry-over (PR #313)
- B47 retrospective "Pipeline / tooling note" (PR #386) — listed as fix-during-pause-window candidate
- Sibling carry-over closures: PR #389 (W6 n_scenarios drift) + PR #390 (parallel-dispatch known limitations doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)