### PR TITLE
fix(dogfood): Mode A completion — W1-S1/S6/S7 artifact requirement removal (B48 follow-up to PR #397)

### DIFF
--- a/dogfood/scenarios/chat_router_smoke.yaml
+++ b/dogfood/scenarios/chat_router_smoke.yaml
@@ -35,8 +35,10 @@ scenarios:
           - { type: user_message_received, count: ">=1" }
         must_not_emit:
           - { type: permission_denied }
-      artifacts:
-        - { skill: direct_llm, present: true }
+      # B48 W1-S1 fix (2026-05-22): artifact requirement removed (was:
+      # skill direct_llm present: true). Router-inline reply is also a
+      # valid path for a meta capability question — forcing direct_llm
+      # dispatch incentivises unnecessary skill invocation.
       # outcome_prediction refitted from B27/B28/B30/B32 actuals (H5 ablation, 2026-05-17)
       outcome_prediction:
         verified: 0.25
@@ -176,8 +178,9 @@ scenarios:
         must_emit: []
         must_not_emit:
           - { type: permission_denied }
-      artifacts:
-        - { skill: direct_llm, present: true }
+      # B48 W1-S6 fix (2026-05-22): artifact requirement removed (was:
+      # skill direct_llm present: true). Inline router reply for a code
+      # example is valid — forcing direct_llm dispatch is over-strict.
       # outcome_prediction refitted from B27/B28/B30/B32 actuals (H5 ablation, 2026-05-17)
       outcome_prediction:
         verified: 0.25
@@ -202,8 +205,9 @@ scenarios:
         must_emit: []
         must_not_emit:
           - { type: permission_denied }
-      artifacts:
-        - { skill: direct_llm, present: true }
+      # B48 W1-S7 fix (2026-05-22): artifact requirement removed (was:
+      # skill direct_llm present: true). Out-of-scope decline is correctly
+      # answered inline — direct_llm dispatch isn't necessary.
       # outcome_prediction refitted from B27/B28/B30/B32 actuals (H5 ablation, 2026-05-17)
       outcome_prediction:
         verified: 0.0


### PR DESCRIPTION
**[dogfood-coder]** — Honest self-correction. PR #397 added worker prompt verdict-scoping guidance + 1 yaml edit (W1-S3) but **missed** that W1-S1, W1-S6, W1-S7 scenarios ALSO have \`artifacts: skill: direct_llm, present: true\` in their yaml — not just metadata in the \`covers:\` field.

Sub-agent at B48 was NOT imposing unwritten requirements; it was correctly enforcing the yaml's \`artifacts:\` block. My Mode A verification missed the artifacts block by reading only the \`events:\` section. A system-reminder surfaced the full yaml content, triggering this correction.

## What PR #397 fixed (retained on main, still correct)

- Worker prompt template "verdict scoping" guidance: prevents future sub-agents from inferring artifact requirements from \`covers:\`
- W1-S3 yaml: \`must_emit_any\` for inline path + artifact requirement removed
- W4-S7 yaml: "explains substitution" made optional

## What this PR fixes (= Mode A completion)

W1-S1 \`simple_capability_question\`, W1-S6 \`multi_turn_pronoun_reference\`, W1-S7 \`out_of_scope_graceful_decline\`: remove \`artifacts: skill direct_llm present: true\` from each. Router-inline reply is a valid solution for each scenario per the rubric semantics; forcing direct_llm dispatch incentivises unnecessary skill invocation.

## Expected ΔV impact

3 W1 scenarios that were I in B48 should be V in B49 (= rubric was met inline; only the artifact requirement blocked V). **+3V expected at confidence ~0.85** (= deterministic yaml change).

Combined with PR #397's Mode A + I (+5V), Mode A total is now **+7V at conf ~0.80** for the same B48 35-scenario analysis baseline.

## Methodology lift

This PR documents an honest miss in the per-mode verification step:
- ✗ Read only \`events:\` section of yaml, missed \`artifacts:\` block
- ✓ Identified mode + cost + ΔV potential
- ✓ Self-corrected when system-reminder surfaced full yaml content

\`feedback_pre_conclusion_observation_checklist\` reminder for future per-mode verification: ALL of \`rubric\` / \`events.must_emit\` / \`events.must_not_emit\` / \`artifacts\` must be inspected — not just the section the worker note happens to reference.

## Test plan

- [x] YAML parse smoke on edited file
- [x] All 28 batch_dispatch / batch_tools / batch_config / dispatch_absolute / verdict_scoping tests pass (= no regression)
- [x] ruff check N/A (yaml only)
- [ ] B49 dispatch will verify +3V observed on W1 worker

## References

- PR #397 (= initial Mode A + I closure) — corrected by this PR
- B48 retrospective (forthcoming) per-scenario context analysis (35 scenarios into 9 emergent modes)
- \`feedback_pre_conclusion_observation_checklist\` — yaml inspection completeness reinforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)