### PR TITLE
feat(tui): intervention keyboard accessibility (IV1+IV2 wave-6 bundle)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -810,11 +810,45 @@ class ReynTUIApp(App):
             conv.hide_status()
 
         session = self._get_session()
+        # Wave-6 IV2: pending user interventions are "in-flight" from
+        # the user's POV. Without this branch, Ctrl+C while a permission
+        # prompt was on screen reported ``nothing in-flight to cancel``
+        # and the modal stayed up indefinitely. Handle iv cancellation
+        # BEFORE the session-None check because the visible widget
+        # removal must fire even when the session has detached (= rare
+        # but the conv pane still shows the stale modal otherwise).
+        cancelled_interventions = 0
+        interventions = (
+            getattr(session, "_interventions", None) if session is not None else None
+        )
+        if interventions is not None:
+            for iv in list(interventions.list_active()):
+                if interventions.cancel(iv.id):
+                    cancelled_interventions += 1
+        if conv is not None:
+            from .widgets.intervention import InterventionWidget
+            for widget in list(conv.query(InterventionWidget)):
+                try:
+                    widget.remove()
+                    if interventions is None:
+                        # No registry to cancel against — still count
+                        # the visible dismissal so the summary line
+                        # reflects what the user just saw disappear.
+                        cancelled_interventions += 1
+                except Exception:
+                    pass
         if session is None:
-            self._voice_status(
-                "(nothing to cancel — no session attached)",
-                style="dim #aa6666",
-            )
+            if cancelled_interventions:
+                self._voice_status(
+                    f"✗ cancelled {cancelled_interventions} "
+                    f"intervention{'s' if cancelled_interventions != 1 else ''}",
+                    style="bold #aa6666",
+                )
+            else:
+                self._voice_status(
+                    "(nothing to cancel — no session attached)",
+                    style="dim #aa6666",
+                )
             return
 
         # Issue #276 Phase B: remote (``--connect``) mode delegates the
@@ -905,6 +939,7 @@ class ReynTUIApp(App):
             cancelled_skills == 0
             and cancelled_plans == 0
             and cancelled_streams == 0
+            and cancelled_interventions == 0
         ):
             # Suppress repeat lines: when the user mashes Ctrl+C on an idle
             # session, log a single "nothing-in-flight cancel" then
@@ -939,6 +974,11 @@ class ReynTUIApp(App):
         if cancelled_streams:
             parts.append(
                 f"{cancelled_streams} stream{'s' if cancelled_streams != 1 else ''}"
+            )
+        if cancelled_interventions:
+            parts.append(
+                f"{cancelled_interventions} intervention"
+                f"{'s' if cancelled_interventions != 1 else ''}"
             )
         self._voice_status(
             f"✗ cancelled {' + '.join(parts)}", style="bold #aa6666",

--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -249,13 +249,53 @@ class InterventionWidget(Widget):
                     id="chip__free",
                     variant="default",
                 )
+            # Hint reflects the keyboard-first chip nav landed by the
+            # wave-6 IV bundle: the first chip is auto-focused on mount,
+            # so single-key hotkeys (``y`` / ``A`` / ``n`` / ``N``) fire
+            # directly without the user having to Ctrl+O hunt for chip
+            # focus. ``Tab`` cycles chips, ``Enter`` / ``Space`` activate,
+            # ``Ctrl+C`` abandons the prompt entirely.
             yield Label(
-                "↓ type a free answer in the chat input below, or click a button",
+                "hotkey · Tab cycles · Ctrl+C cancels · free response… for free text",
                 classes="iv-hint",
                 markup=False,
             )
         else:
             yield Input(placeholder="type your answer…", id="iv_input")
+
+    def on_mount(self) -> None:
+        """Auto-focus the first chip so chip hotkeys fire without Ctrl+O.
+
+        Before this, the InputBar's TextArea held focus by default and
+        consumed printable keys (``y`` / ``A`` / ``n`` / ``N``) into the
+        editor buffer before they could bubble up to ``on_key``. Users
+        either had to discover the undocumented ``Ctrl+O`` shortcut to
+        cycle focus to the chip area, or click chips with the mouse.
+
+        Focusing the first chip on mount means the chip area is
+        keyboard-active immediately: single-key hotkeys (= the chip's
+        ``[y]``-style mnemonic) match through the existing ``on_key``
+        handler, ``Tab`` cycles between chips, ``Enter`` / ``Space``
+        activates. The "free response…" chip is reachable by Tab and
+        continues to mount its own ``Input`` field via
+        ``_show_free_input`` when pressed.
+
+        Free-text answer path is unchanged for the no-chip case (=
+        ``Input`` widget at the bottom of ``compose``, still
+        auto-focused there); only the chip case gains keyboard access.
+        """
+        if not self._choices:
+            return
+        try:
+            first = self.query("Button").first()
+        except Exception:
+            return
+        if first is None:
+            return
+        try:
+            first.focus()
+        except Exception:
+            pass
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         event.stop()

--- a/tests/cli/test_intervention_keyboard_accessibility.py
+++ b/tests/cli/test_intervention_keyboard_accessibility.py
@@ -1,0 +1,156 @@
+"""Tier 2: InterventionWidget keyboard accessibility (wave-6 IV1 + IV2).
+
+Pins the contract that mounted interventions are keyboard-reachable
+without the user having to discover ``Ctrl+O`` to cycle focus into the
+chip area, and that ``Ctrl+C`` (= ``action_cancel_inflight``) dismisses
+a pending intervention.
+
+Before this work:
+  - InputBar's TextArea held focus by default and consumed printable
+    keys ('y' / 'A' / etc.) into its editor buffer before the bubble
+    reached the InterventionWidget's ``on_key`` handler, so chip
+    hotkeys were dead and the only keyboard path was ``Ctrl+O`` + Tab.
+  - ``action_cancel_inflight`` only iterated ``session.running_skills``
+    / ``running_plans`` / streams. A pending intervention (= modal
+    waiting for an answer) was invisible to the cancel path, so
+    ``Ctrl+C`` reported ``nothing in-flight to cancel`` and the modal
+    stayed up indefinitely.
+
+Tier 2 contracts pinned here:
+
+1. Mounting an InterventionWidget with chips auto-focuses the first
+   chip Button. Keyboard hotkeys reach ``on_key`` without further
+   focus manipulation.
+2. ``action_cancel_inflight`` removes any mounted InterventionWidget
+   from the conversation view. (Cancelling the iv future via the
+   session's InterventionRegistry is exercised in the integration
+   path; the widget removal is the user-visible half pinned here.)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.widgets import Button
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── IV1: auto-focus first chip on mount ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intervention_auto_focuses_first_chip_on_mount() -> None:
+    """Tier 2: mounting an iv with chips moves focus to the first Button.
+
+    Without this, the InputBar's TextArea retains focus and consumes
+    chip hotkey keystrokes before they reach the iv widget.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        widget = conv.mount_intervention(
+            question="Continue?",
+            choices=[
+                {"label": "[y]es", "id": "yes", "hotkey": "y", "default": True},
+                {"label": "[n]o", "id": "no", "hotkey": "n", "default": False},
+            ],
+            iv_id="iv-focus-test",
+        )
+        # Mount fires before our on_mount; pause to let composition + focus settle.
+        await pilot.pause()
+        await pilot.pause()
+
+        focused = app.focused
+        assert isinstance(focused, Button), (
+            f"expected first chip Button to be focused, got: {focused!r}"
+        )
+        # First chip should be the "yes" chip.
+        assert (focused.id or "").startswith("chip_yes"), (
+            f"expected first chip to be 'chip_yes', got: {focused.id!r}"
+        )
+
+        # Cleanup — remove so we don't dangle.
+        widget.remove()
+
+
+@pytest.mark.asyncio
+async def test_intervention_without_chips_does_not_grab_focus() -> None:
+    """Tier 2: no-chip iv (= free-text only) follows the legacy path —
+    the embedded Input field auto-focuses (existing behaviour), and
+    the on_mount focus-shift is skipped for the chip-less branch.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        widget = conv.mount_intervention(
+            question="Any thoughts?", choices=None, iv_id="iv-no-chip",
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        # The on_mount path early-returns when ``self._choices`` is
+        # empty; whatever Textual's default focus walker chose is fine,
+        # what matters is no Button was force-focused (= no Button
+        # exists on this widget).
+        buttons = list(widget.query(Button))
+        assert buttons == [], "no-chip iv should not mount any Button"
+
+        widget.remove()
+
+
+# ── IV2: action_cancel_inflight removes mounted InterventionWidget ────
+
+
+@pytest.mark.asyncio
+async def test_cancel_inflight_removes_mounted_intervention_widget() -> None:
+    """Tier 2: ``action_cancel_inflight`` clears any mounted iv widget.
+
+    Without a session attached the cancel path's session iteration is a
+    no-op, but the conv-side widget removal must still fire so the user
+    sees the modal disappear when they press Ctrl+C. Pins the visible
+    half of the cancel contract; the iv future cancellation is
+    exercised at the InterventionRegistry layer.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        widget = conv.mount_intervention(
+            question="Allow?",
+            choices=[
+                {"label": "[y]es", "id": "yes", "hotkey": "y", "default": True},
+                {"label": "[n]o", "id": "no", "hotkey": "n", "default": False},
+            ],
+            iv_id="iv-cancel-test",
+        )
+        await pilot.pause()
+        assert widget in list(conv.query(InterventionWidget))
+
+        # Drive the same code path Ctrl+C fires.
+        app.action_cancel_inflight()
+        await pilot.pause()
+        await pilot.pause()
+
+        mounted = list(conv.query(InterventionWidget))
+        assert mounted == [], (
+            f"expected no InterventionWidget mounted after cancel; got: {mounted!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — wave-6 IV bundle (IV1 + IV2 + IV3-subsumed)

## Problem

The InterventionWidget (= permission prompts like "Allow fetching this URL?", ``ask_user``, etc.) had two related keyboard-accessibility gaps:

1. **Chip hotkeys dead by default** — InputBar's TextArea consumed printable keys (``y`` / ``A`` / ``n`` / ``N``) into the editor buffer before they could reach ``InterventionWidget.on_key``. Users either had to discover the undocumented ``Ctrl+O`` shortcut OR click chips with the mouse.
2. **No keyboard escape from intervention** — ``Ctrl+C`` only canceled in-flight skills / plans / streams. A pending modal stayed up indefinitely; ``Ctrl+C`` reported ``nothing in-flight to cancel``.

Row 5 reproduction verified both (= real Ctrl+C signal via ``bash tmux send-keys C-c`` actually fires ``action_cancel_inflight``, but the cancel path doesn't see pending iv as cancellable work).

## Fix

### IV1: auto-focus first chip on mount

``InterventionWidget`` gains ``on_mount`` that focuses the first chip ``Button`` when chips are present:

```python
def on_mount(self) -> None:
    if not self._choices:
        return
    try:
        first = self.query("Button").first()
    except Exception:
        return
    if first is None:
        return
    try:
        first.focus()
    except Exception:
        pass
```

Hotkeys now reach ``on_key`` natively. ``Tab`` cycles between chips. ``Enter`` / ``Space`` activates. ``Tab`` past the last chip returns to InputBar for free text. The no-chip path (= ``Input`` widget auto-focused for free answers) is preserved by the ``self._choices`` early-return.

Hint label updated:

```
- ↓ type a free answer in the chat input below, or click a button
+ hotkey · Tab cycles · Ctrl+C cancels · free response… for free text
```

Reflects the new keyboard-first contract.

### IV2: action_cancel_inflight dismisses pending interventions

Add an iv-cancellation branch that runs BEFORE the session-None check (= so widget removal fires even when the session has detached):

```python
cancelled_interventions = 0
interventions = (
    getattr(session, "_interventions", None) if session is not None else None
)
if interventions is not None:
    for iv in list(interventions.list_active()):
        if interventions.cancel(iv.id):
            cancelled_interventions += 1
if conv is not None:
    from .widgets.intervention import InterventionWidget
    for widget in list(conv.query(InterventionWidget)):
        try:
            widget.remove()
            if interventions is None:
                cancelled_interventions += 1
        except Exception:
            pass
```

Two halves:
- ``session._interventions.cancel(iv.id)`` — pops the iv from the registry and calls ``iv.future.cancel()``, so awaiting skill code receives ``CancelledError`` on its ``await iv.future``.
- ``InterventionWidget`` removal from the conv pane — modal disappears in the same Ctrl+C.

Summary line now reports ``"✗ cancelled N intervention(s)"`` (or includes it in the parts list alongside skills/plans/streams).

### IV3: subsumed

Auto-focusing the first chip on mount eliminates the need for ``Ctrl+O`` to reach chips for the common keyboard path. The shortcut still exists (= focus-toggle binding at App level) for users who Tab elsewhere and want to come back, but it's no longer a discoverability gap.

## Tests

3 new Tier 2 in ``tests/cli/test_intervention_keyboard_accessibility.py``:

- ``test_intervention_auto_focuses_first_chip_on_mount`` — focus lands on first chip Button (= ``chip_yes``) after mount.
- ``test_intervention_without_chips_does_not_grab_focus`` — no-chip iv preserves legacy free-text path (= early-return).
- ``test_cancel_inflight_removes_mounted_intervention_widget`` — ``action_cancel_inflight`` removes the mounted iv widget (visible half of the cancel contract).

## Test plan

- [x] ``pytest tests/cli/test_intervention_keyboard_accessibility.py`` → 3/3 pass.
- [x] ``pytest tests/`` → 4551 passed / 6 skipped / 2 xfailed / 1 xpassed.
- [x] Manual at 80x24: launch ``.venv/bin/reyn chat --no-restore``, trigger ``Use web_fetch on https://example.com``, observe new hint text → press ``y`` → first chip activates + web_fetch proceeds. Re-trigger with different URL → press real ``Ctrl+C`` → "✗ cancelled 1 intervention" appears + modal dismissed.
- [x] (Row 5 reproduction verify completed before fix design — IV2 confirmed real bug, IV1 mechanism slightly different from sub-agent's diagnosis but outcome same; IV3 subsumed by IV1 fix.)

## Out of scope (= followups)

- **IV4** (= chip row clip under Ctrl+B panel at 80-col) — separate wave-6 PR.
- **SL2 / SL1 / ST3** (= other wave-6 findings) — separate PRs.
- Mouse-click tests — sub-agent flagged that mouse path wasn't testable from tmux; the auto-focus fix preserves the mouse path unchanged (= click chip = activate).

## Refs

- wave-6 findings IV1 / IV2 / IV3 (= prio list items 3, 2, 8 from wave-6 triage)
- ST1 (= input-bar stale prepend) was honest-scope-dropped after row 5 verify — sub-agent observation was a tmux ``send-keys`` timing artifact, not a real bug. Saved in ``feedback_verify_test_env_before_failure_conclusion``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)