### PR TITLE
fix(skill/eval): postprocessor output_schema → envelope shape (closes B48-NF-W2-S5)

### DIFF
--- a/src/reyn/stdlib/skills/eval/artifacts/eval_result.yaml
+++ b/src/reyn/stdlib/skills/eval/artifacts/eval_result.yaml
@@ -1,0 +1,77 @@
+name: eval_result
+description: |
+  Caller-facing eval result. The `evaluate` phase produces the
+  `eval_result_raw` artifact (LLM-contract: criteria_results + prose
+  fields); the python postprocessor (`compute_eval_score`) adds the
+  deterministic scoring fields (passed, overall_score, passed_criteria,
+  total_criteria) by counting required-criteria results. This
+  envelope-shaped schema is referenced by `postprocessor.output_schema`
+  so the OS wraps it into `{type, data}` and the final validation
+  passes when the postprocessor return value lands in `data`.
+schema:
+  type: object
+  properties:
+    passed:
+      type: boolean
+      description: |
+        Whether the eval passed overall. True when every required
+        criterion is met; false when at least one required criterion
+        failed or the target run did not finish.
+    overall_score:
+      type: number
+      minimum: 0.0
+      maximum: 1.0
+      description: |
+        Fraction of required criteria that were met. 0.0 when the
+        target run failed; 1.0 when there are no required criteria
+        (vacuous pass).
+    passed_criteria:
+      type: integer
+      minimum: 0
+      description: Count of required criteria with met=true.
+    total_criteria:
+      type: integer
+      minimum: 0
+      description: Count of required criteria considered.
+    weakest_phase:
+      type: string
+      description: |
+        Name of the phase with the lowest score (passed through from
+        eval_result_raw). Empty string when no phases were judged.
+    spec_path:
+      type: string
+      description: Path to the eval spec being run.
+    summary:
+      type: string
+      description: |
+        2–3 sentence prose summary of what passed, what failed, and any
+        optional-criterion shortfalls.
+    criteria_results:
+      type: array
+      description: |
+        Per-criterion results passed through from eval_result_raw, so
+        callers can inspect individual judgments alongside the
+        aggregate scoring fields.
+      items:
+        type: object
+        properties:
+          phase_name: {type: string}
+          description: {type: string}
+          required:   {type: boolean}
+          met:        {type: boolean}
+          reason:     {type: string}
+        required: [phase_name, description, met, reason]
+    run_status:
+      type: string
+      description: |
+        Target skill run status, passed through from
+        case_run_result. "finished" on normal completion; any other
+        value signals the target run did not finish and the score is
+        short-circuited to passed=false, overall_score=0.0.
+  required:
+    - passed
+    - overall_score
+    - passed_criteria
+    - total_criteria
+    - weakest_phase
+    - summary

--- a/src/reyn/stdlib/skills/eval/skill.md
+++ b/src/reyn/stdlib/skills/eval/skill.md
@@ -26,17 +26,13 @@ postprocessor:
     Caller-facing eval result: deterministic scoring fields are added by the
     python postprocessor step; the LLM-authored prose fields (summary,
     weakest_phase, spec_path) pass through unchanged.
-  output_schema:
-    type: object
-    properties:
-      passed:           {type: boolean}
-      overall_score:    {type: number, minimum: 0.0, maximum: 1.0}
-      passed_criteria:  {type: integer, minimum: 0}
-      total_criteria:   {type: integer, minimum: 0}
-      weakest_phase:    {type: string}
-      spec_path:        {type: string}
-      summary:          {type: string}
-    required: [passed, overall_score, passed_criteria, total_criteria, weakest_phase, summary]
+  # B48-NF-W2-S5 fix (2026-05-22): reference the artifact by name so the
+  # compiler wraps it into the full `{type, data}` envelope schema via
+  # `artifact_to_json_schema()`. Inline dict literals bypass the wrapping
+  # step, so PostprocessorExecutor.run()'s final validation fails with
+  # "required property missing" for every data field (= same trap as
+  # judge_phase B38-fix; this skill predates that convention).
+  output_schema: eval_result
   steps:
     - type: python
       module: ./postprocessor.py

--- a/tests/test_eval_skill_spec_path_optional.py
+++ b/tests/test_eval_skill_spec_path_optional.py
@@ -90,20 +90,33 @@ def test_eval_result_raw_keeps_other_required_fields():
 
 
 def test_skill_md_final_output_does_not_require_spec_path():
-    """Tier 2: caller-facing eval_result final_output_schema in
-    skill.md must NOT require spec_path. Matches the
-    eval_result_raw relaxation — spec_path is pass-through, not
-    load-bearing for scoring."""
+    """Tier 2: caller-facing eval_result schema must NOT require
+    spec_path. Matches the eval_result_raw relaxation — spec_path is
+    pass-through, not load-bearing for scoring.
+
+    B48-NF-W2-S5 fix (2026-05-22): skill.md's
+    ``postprocessor.output_schema`` is now a string reference to the
+    ``eval_result`` artifact (so the compiler wraps it into a
+    ``{type, data}`` envelope). The schema itself lives in
+    ``artifacts/eval_result.yaml`` — read it through that indirection.
+    """
     fm = _parse_skill_md_frontmatter(_EVAL_SKILL_DIR / "skill.md")
-    output_schema = fm["postprocessor"]["output_schema"]
-    required = output_schema.get("required", [])
+    ref = fm["postprocessor"]["output_schema"]
+    assert isinstance(ref, str) and ref == "eval_result", (
+        f"postprocessor.output_schema must reference the eval_result "
+        f"artifact by name (= envelope-wrapped via compiler). "
+        f"Currently: {ref!r}"
+    )
+    art = _load_yaml(_EVAL_SKILL_DIR / "artifacts" / "eval_result.yaml")
+    schema = art["schema"]
+    required = schema.get("required", [])
     assert "spec_path" not in required, (
-        f"final_output_schema.required must NOT include spec_path. "
+        f"eval_result.schema.required must NOT include spec_path. "
         f"Currently: {required}"
     )
     # The field stays declared (= callers that pass it through still
     # see it in the schema).
-    assert "spec_path" in output_schema["properties"]
+    assert "spec_path" in schema["properties"]
 
 
 def test_skill_md_postprocessor_step_does_not_require_spec_path():
@@ -121,18 +134,60 @@ def test_skill_md_postprocessor_step_does_not_require_spec_path():
     )
 
 
+def test_compiled_postprocessor_output_schema_is_envelope_shaped():
+    """Tier 2 (B48-NF-W2-S5 fix, 2026-05-22): the compiled
+    ``postprocessor.output_schema`` must be the full
+    ``{type, data}`` envelope so PostprocessorExecutor.run()'s final
+    validation (which inspects the envelope-shaped result) succeeds.
+
+    Before the fix, skill.md declared the schema inline as a flat dict
+    with ``required: [passed, overall_score, ...]`` at top level. The
+    compiler used the literal as-is, so the executor's envelope-vs-flat
+    mismatch caused every postprocessor run to fail with
+    ``'overall_score' is a required property`` (Mode F W2-S5 in B48,
+    3/3 deterministic reproduction).
+
+    Pinned invariant: compiled top-level required must be
+    ``[type, data]`` (= envelope-wrapped), AND ``properties.type.const``
+    must be ``eval_result``.
+    """
+    from reyn.compiler import load_dsl_skill
+    skill = load_dsl_skill(
+        str(_EVAL_SKILL_DIR / "skill.md"),
+        skill_root=str(_EVAL_SKILL_DIR),
+    )
+    schema = skill.postprocessor.output_schema
+    required = schema.get("required", [])
+    assert set(required) == {"type", "data"}, (
+        f"compiled postprocessor.output_schema must be envelope-shaped "
+        f"(= top-level required == [type, data]); got {required!r}. "
+        f"Likely cause: skill.md declared output_schema as an inline "
+        f"dict instead of an artifact-name string reference, bypassing "
+        f"the compiler's artifact_to_json_schema() envelope wrapper."
+    )
+    type_const = schema.get("properties", {}).get("type", {}).get("const")
+    assert type_const == "eval_result", (
+        f"compiled envelope schema must pin type.const == 'eval_result'; "
+        f"got {type_const!r}."
+    )
+
+
 def test_skill_md_final_output_keeps_other_required_fields():
     """Tier 2: regression guard for the caller-facing schema.
     Scoring fields (``passed`` / ``overall_score`` / ``passed_criteria``
     / ``total_criteria``) and prose contract fields (``weakest_phase``
-    / ``summary``) remain required."""
-    fm = _parse_skill_md_frontmatter(_EVAL_SKILL_DIR / "skill.md")
-    required = set(fm["postprocessor"]["output_schema"].get("required", []))
+    / ``summary``) remain required.
+
+    Reads through the ``eval_result.yaml`` artifact (= source of truth
+    after B48-NF-W2-S5 fix; skill.md only references it by name).
+    """
+    art = _load_yaml(_EVAL_SKILL_DIR / "artifacts" / "eval_result.yaml")
+    required = set(art["schema"].get("required", []))
     for field in (
         "passed", "overall_score", "passed_criteria", "total_criteria",
         "weakest_phase", "summary",
     ):
         assert field in required, (
-            f"{field} must remain required in final_output_schema. "
+            f"{field} must remain required in eval_result.schema. "
             f"Currently: {required}"
         )


### PR DESCRIPTION
**[dogfood-coder]** — B48 Mode F W2-S5 (`eval_run_direct_llm`) was failing 3/3 deterministic with `skill_run_failed: postprocessor output schema validation error — required fields (overall_score, passed, passed_criteria, ...)`. Root cause: the `eval` skill declared `postprocessor.output_schema` as an **inline flat dict**, which bypasses the compiler's `artifact_to_json_schema()` envelope wrapper. `PostprocessorExecutor.run()` validates the full `{type, data}` envelope, so validation always failed with "required property missing" for every data field — identical trap that `judge_phase` fixed in B38.

## Summary
- Switch `postprocessor.output_schema` from inline dict → artifact-name string ref (`eval_result`) so the compiler wraps it in the `{type, data}` envelope.
- New `artifacts/eval_result.yaml` becomes the caller-facing schema source-of-truth (mirrors `chat_compactor`'s `chat_summary.yaml` pattern).
- New Tier 2 test pins the **compiled** envelope shape (`required == [type, data]`, `properties.type.const == "eval_result"`) so the inline-dict regression cannot recur.

## Verification
- Smoke replay of B48 W2-S5 failing payload (`criteria_results=[]`, `run_status="finished"`) through `compute_eval_score` + new envelope schema → **0 jsonschema errors**.
- B48 worker-2 results JSON: `eval_run_direct_llm` reason verbatim matches the schema-validation error this fix closes.
- 6/6 eval-schema tests pass (incl. updated `test_skill_md_final_output_does_not_require_spec_path` reading through the new artifact yaml, and new `test_compiled_postprocessor_output_schema_is_envelope_shaped`).
- 183-test sweep (`postprocessor or eval or compiler`) green.

ΔV: **+1V** Mode F partial closure (= W2-S5 deterministic), confidence **0.95** (= structural schema mismatch, validator path inspected, smoke test passes).

## Test plan
- [x] `pytest tests/test_eval_skill_spec_path_optional.py` — 6 pass.
- [x] `pytest -k "postprocessor or eval or compiler"` — 183 pass.
- [x] Smoke replay: postprocessor return + envelope validation = 0 errors.
- [ ] B49 dogfood re-run of W2-S5 — verify `eval_run_direct_llm` lands V (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)