### PR TITLE
fix(tui): promote /help to top of empty slash palette (SL1)

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -441,6 +441,19 @@ class InputBar(Widget):
         # who stopped reading after the first few rows never saw the
         # high-value entries.
         matches.sort(key=lambda c: c.name)
+        # Wave-6 SL1: on the bare "/" open (= no filter token), promote
+        # /help to the top of the visible list. The picker shows only
+        # the first ``_MAX_VISIBLE`` rows (= 8), so alphabetical order
+        # alone pushed /help into the "+15 more — keep typing to
+        # filter" overflow, invisible to users who don't know the
+        # command name. Filtered opens (= token non-empty) keep the
+        # alphabetical order so muscle memory transfers from /help.
+        if not token:
+            help_cmd = next(
+                (c for c in matches if c.name == "help"), None,
+            )
+            if help_cmd is not None:
+                matches = [help_cmd] + [c for c in matches if c is not help_cmd]
         picker.set_matches(matches)
 
     def _run_completer(


### PR DESCRIPTION
**[tui-coder]** — wave-6 PR 3/5 (SL1)

## Summary

Promote ``/help`` to position 1 in the empty-token slash palette so users who don't yet know the command catalog have a clear discoverability path. Filtered opens keep alphabetical order.

## Observation

Sub-agent (wave-6 slash palette exploration):

> Typing ``/`` shows 8 alphabetically-first commands (``/agent`` through ``/cost``); ``/help``, ``/list``, ``/quit``, ``/expand``, ``/cost-inline`` are all in the "+15 more — keep typing to filter" overflow, invisible until the user already knows what to type.

Reproduced in TUI: bare ``/`` open showed ``/agent``, ``/agents``, ``/answer``, ``/attach``, ``/budget``, ``/cancel``, ``/copy``, ``/cost`` — ``/help`` was below the visible 8.

## Fix

```python
# After the alphabetical sort:
if not token:
    help_cmd = next(
        (c for c in matches if c.name == "help"), None,
    )
    if help_cmd is not None:
        matches = [help_cmd] + [c for c in matches if c is not help_cmd]
```

Only fires when ``token`` is empty (= bare ``/``). Filtered prefix opens preserve the alphabetical order — muscle memory built from ``/help`` rendering transfers cleanly.

## Test plan

- [x] ``pytest tests/cli/`` → 307 pass.
- [x] ``ruff check src/reyn/chat/tui/widgets/input_bar.py`` → clean.
- [x] Manual: ``.venv/bin/reyn chat --no-restore`` → type ``/`` → palette top row is now ``▌ /help    Show this list of slash commands``, followed by ``/agent``, ``/agents``, ``/answer``, ``/attach``, ``/budget``, ``/cancel``, ``/copy``, with the ``+15 more`` overflow below (= one row less than before since /help left the overflow).
- No new automated tests — the change is a single sort step. Pinning "/help is first when token empty" with Tier 2 isn't load-bearing enough for the cost; the existing picker tests + manual verify cover the contract.

## Refs

- wave-6 finding SL1 (= prio list item 5, P2 M reclassified S after sub-agent suggested promotion as one-line fix).
- ``_MAX_VISIBLE = 8`` in ``widgets/slash_picker.py`` — the budget that made the overflow invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)