### PR TITLE
fix(tui): defer cost suffix write until inflight skills finish (ST3)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -47,6 +47,14 @@ if TYPE_CHECKING:
 # Ctrl+C presses within this many seconds are absorbed silently.
 _IDLE_CANCEL_DEDUP_S = 1.5
 
+# Wave-6 ST3: cost-suffix deferral while skills / plans are still
+# spinning. We retry the snapshot every ``INTERVAL_S`` for up to
+# ``MAX_ATTEMPTS`` total seconds before falling back to a write
+# with whatever the budget tracker shows. The cap prevents an
+# infinitely-running skill from suppressing the cost line forever.
+_COST_SUFFIX_DEFER_INTERVAL_S = 1.0
+_COST_SUFFIX_DEFER_MAX_ATTEMPTS = 30
+
 
 class ReynTUIApp(App):
     """Main Textual application for `reyn chat`."""
@@ -616,11 +624,38 @@ class ReynTUIApp(App):
             self._push_exec_state()
             self._last_focal_tab = "agents"
 
-    def _maybe_render_cost_suffix(self, conv: ConversationView) -> None:
-        """A4 — emit a dim per-turn cost suffix line when /cost-inline is on."""
+    def _maybe_render_cost_suffix(
+        self, conv: ConversationView, *, attempt: int = 0,
+    ) -> None:
+        """A4 — emit a dim per-turn cost suffix line when /cost-inline is on.
+
+        Wave-6 ST3: defer the write while any skill / plan from this
+        turn is still running. The agent-reply outbox fires when the
+        LLM text reply lands, but post-reply phases (plan aggregator,
+        chat_router final follow-up, compaction) continue to spend
+        tokens. Writing at agent-reply time pinned a snapshot 5-10 s
+        earlier than the user's perceived "turn finished" moment, so
+        the ``⌁ Nt │ $X.XXXX │ Ys`` line under-reported the real total.
+
+        Strategy: peek at ``self._skill_exec`` (= map of run_id →
+        live skill snapshot maintained by ``_handle_trace_for_skill_row``).
+        Non-empty = at least one skill row is still spinning. Defer
+        by 1 s and re-attempt, up to ``_COST_SUFFIX_DEFER_MAX_ATTEMPTS``
+        times. If the cap is reached (= a skill is genuinely long-
+        running and the cost suffix would otherwise never fire) write
+        with what we have to preserve the previous always-visible UX.
+        """
         if not self._cost_inline_enabled:
             return
         if self._budget_tracker is None:
+            return
+        if attempt < _COST_SUFFIX_DEFER_MAX_ATTEMPTS and self._skill_exec:
+            self.set_timer(
+                _COST_SUFFIX_DEFER_INTERVAL_S,
+                lambda: self._maybe_render_cost_suffix(
+                    conv, attempt=attempt + 1,
+                ),
+            )
             return
         try:
             snap = self._budget_tracker.snapshot()


### PR DESCRIPTION
**[tui-coder]** — wave-6 PR 4/5 (ST3)

## Summary

Defer ``_maybe_render_cost_suffix`` while any skill in ``self._skill_exec`` is still spinning. Retry every 1 s up to 30 attempts (~30 s cap) before falling back to a write with whatever the budget tracker reports.

## Observation

Sub-agent (wave-6 streaming exploration):

> During the 28 s ML-guide stream, the suffix showed ``⌁ 31928t │ $0.0033 │ 20.4s`` even though the skill ran for a further 7 s to ``✓ direct_llm#2026 · 27.5s`` — the token delta from the final phase was not included.

Confirmed by code review: ``_maybe_render_cost_suffix`` is invoked from the ``kind="agent"`` outbox handler in ``app_outbox.py``. The LLM reply lands and outbox fires — but post-reply phases (= plan aggregator, chat_router final follow-up, compaction) continue spending tokens. The snapshot is taken early, so the line under-reports.

## Fix

```python
def _maybe_render_cost_suffix(self, conv, *, attempt: int = 0):
    if not self._cost_inline_enabled:
        return
    if self._budget_tracker is None:
        return
    if attempt < _COST_SUFFIX_DEFER_MAX_ATTEMPTS and self._skill_exec:
        self.set_timer(
            _COST_SUFFIX_DEFER_INTERVAL_S,
            lambda: self._maybe_render_cost_suffix(conv, attempt=attempt + 1),
        )
        return
    # ... existing snapshot + write path
```

- ``self._skill_exec`` (= map of run_id → live skill-row snapshot maintained by ``_handle_trace_for_skill_row``) is non-empty exactly when one or more skill activity rows are still spinning. That's the "still doing work" signal the cost suffix should wait on.
- Defer ``INTERVAL_S = 1.0`` second per attempt, ``MAX_ATTEMPTS = 30`` total = ~30 s ceiling. Genuinely long-running skills eventually get a cost-suffix write at the cap so the line always appears.
- ``_turn_start_cost_usd`` / ``_turn_start_tokens`` (= snapshot at user submit) are unchanged — the delta computation still anchors to the user-submit moment; only the "now" snapshot read is deferred.

## Tradeoffs

- **+** Cost line accurately reflects total turn spend including post-reply phases.
- **+** Single-PR addition — no new state, just early-return + retry.
- **−** Cost line appears 1-30 s after agent reply rather than immediately. For most turns (= no extra skill work) the delay is zero. For multi-phase turns the user sees the reply first, then the cost suffix lands when work truly settles.
- **−** Timer-based retry adds a small accumulating cost — 30 attempts × 1 s + tiny ``self.set_timer`` overhead. Negligible at this scale.

## Test plan

- [x] ``pytest tests/cli/`` → 307 pass (= no regression to existing cost-suffix tests).
- [x] ``ruff check`` → clean.
- [ ] (skipped — manual reproduction requires triggering a multi-phase plan + watching the cost line move past the previously-stuck 20.4 s value; the test fixture infrastructure for timer-based defer + state-based predicate is non-trivial to build clean, and the change is small enough that code review + the existing cost-suffix tests + the constants' explicit caps cover the failure modes.)

## Refs

- wave-6 finding ST3 (= prio list item 6, P2 M)
- ``_handle_trace_for_skill_row`` in ``tui/app.py`` maintains ``_skill_exec`` — same data the agents-tab and `Ctrl+B → agents` view consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)