### PR TITLE
fix(tui): tighten intervention chip sizing for panel-open 80-col fit (IV4)

### DIFF
--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -58,13 +58,27 @@ class InterventionWidget(Widget):
         margin-top: 0;
     }
     InterventionWidget Button {
+        /* Wave-6 IV4: tight chip sizing so all 5 buttons fit on a single
+           row even when ``Ctrl+B`` opens the right panel and cuts the
+           conv pane width roughly in half. ``min-width: 6`` is the
+           shortest hotkey-format label (``"[y]es"``) + 1-cell breathing
+           room; ``padding: 0`` removes the previous 2-cell side padding.
+           Width is ``auto`` so longer labels (``"[A]lways"``,
+           ``"free response…"``) expand to fit their text without
+           forcing the shorter chips wider. Inter-chip gap drops from
+           ``margin: 0 1 0 0`` to a single space between labels
+           (= preserved by the existing 1-cell padding-x). Net width
+           budget at default labels: ~42 cells (= ``5 + 8 + 4 + 7 +
+           14 + 4-cell gap``), fits comfortably in a 50-cell narrow
+           pane. */
         margin: 0 1 0 0;
         background: $primary;
         color: #ffffff;
         border: none;
-        padding: 0 2;
+        padding: 0;
         height: 1;
-        min-width: 10;
+        width: auto;
+        min-width: 6;
     }
     InterventionWidget Button:hover {
         background: #e0664e;


### PR DESCRIPTION
**[tui-coder]** — wave-6 PR 5/5 (IV4)

## Summary

When ``Ctrl+B`` opens the right panel while an intervention modal is up at 80-col, the conv pane width drops to ~50 cells and the chip row (= ``[y]es`` / ``[A]lways`` / ``[n]o`` / ``[N]ever`` / ``free response…``) clipped its right half off-screen. Tighten the chip CSS so the natural label widths fit even at the narrow pane.

## Observation

Sub-agent (wave-6 intervention widget exploration):

> When the Ctrl+B side panel is opened while an intervention is active (at default 80-col width), the intervention widget is split — its right portion is pushed out of view. The chip row renders as "[y]es [A]lways" with "[n]o [N]ever free response…" clipped entirely.

The intervention widget's row was ``layout: horizontal`` with each Button at ``min-width: 10`` + ``padding: 0 2``. Total: ~58 cells. Conv pane at panel-open: ~50 cells. Overflow.

## Fix

```diff
 InterventionWidget Button {
-    margin: 0 1 0 0;
+    margin: 0 1 0 0;
     background: $primary;
     color: #ffffff;
     border: none;
-    padding: 0 2;
+    padding: 0;
     height: 1;
-    min-width: 10;
+    width: auto;
+    min-width: 6;
 }
```

- ``padding: 0 2`` → ``padding: 0`` — internal padding removed; the hotkey-bracket prefix (``[y]``) already provides visual separation.
- ``min-width: 10`` → ``min-width: 6`` — shortest label ``"[y]es"`` is 5 cells; ``6`` leaves 1 cell breathing room.
- Add ``width: auto`` so longer labels (``[A]lways``, ``free response…``) expand to fit their text instead of being capped at the (now-smaller) min-width.

Budget at default labels:

  ``5 + 8 + 4 + 7 + 14 + 4-cell margin = ~42 cells``

Fits comfortably in a 50-cell pane. Inter-chip 1-cell gap preserved via the existing ``margin: 0 1 0 0``.

## Tradeoffs

- **+** Chip row fits 80-col panel-open without clipping.
- **+** Chip rendering still visually clear — hotkey prefix is the load-bearing identifier; the empty padding around it doesn't add information.
- **−** Tap target slightly smaller (= ~5-6 cells vs ~10-14 cells). Acceptable for keyboard-first UX post the IV1 auto-focus + Tab fix in PR #401; click users still hit the button bounds.

## Test plan

- [x] ``pytest tests/cli/`` → 307 pass.
- [x] ``ruff check`` → clean.
- [ ] (skipped — TUI manual test was blocked by chat-session state instability in the test pane during this batch; the CSS-only change is small enough that code review + the cell-count math + the existing intervention widget tests cover the regression risk.)

## Refs

- wave-6 finding IV4 (= prio list item 7, P2 S)
- Pairs with PR #401 (= IV1+IV2+IV3 keyboard accessibility): together the intervention widget is now both keyboard-reachable + visible at narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)