### PR TITLE
fix(a2a): preserve early reply text on partial+running escalation (closes B48-NF-W2-S2)

### DIFF
--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -400,14 +400,32 @@ async def _handle_message_send(
     # spawn-ack returns but no subsequent request arrives to drive the
     # skill_completion_injected inbox drain, so the run becomes a silent
     # tombstone (B42 W6-S6 reproduction).
+    #
+    # B48-NF-W2-S2 fix (2026-05-22): only escalate to Task when the
+    # already-harvested reply text is empty. When the LLM produced an
+    # early ack (= ``reply_text`` non-empty, e.g. "skill creation
+    # started — wait for completion") before the timeout fired, prefer
+    # the Message envelope so the caller actually sees that ack — the
+    # prior unconditional escalation discarded it and the caller
+    # observed ``(empty)`` reply (W2-S2 = ``skill_builder_web_summariser``
+    # 3/3 deterministic in B48). The skill's eventual completion
+    # narration still lands on the next ``message/send`` to the same
+    # agent via ``skill_completion_injected`` inbox drain — preserving
+    # B42-NF-W6-2's intent (= no silent tombstone) without dropping the
+    # spawn-ack text on the floor.
     running_ids = result.get("running_skill_run_ids") or []
-    if result.get("partial") and running_ids:
+    reply_text = result.get("reply", "")
+    if (
+        not reply_text.strip()
+        and result.get("partial")
+        and running_ids
+    ):
         return await _escalate_to_task(
             req_id, agent_name, running_ids, registry, run_registry,
         )
 
     reply_msg = _build_message_response(
-        reply_text=result.get("reply", ""),
+        reply_text=reply_text,
         partial=bool(result.get("partial", False)),
     )
     return _jsonrpc_result(req_id, reply_msg)

--- a/tests/test_a2a_sync_async_escalation.py
+++ b/tests/test_a2a_sync_async_escalation.py
@@ -32,6 +32,7 @@ import pytest
 
 from reyn.web.routers.a2a import (
     _await_skill_completion,
+    _handle_message_send,
     _harvest_completion_narration,
 )
 from reyn.web.run_registry import RunRegistry
@@ -247,6 +248,153 @@ def test_run_registry_update_failure_path_sets_error():
 # ---------------------------------------------------------------------------
 # Task envelope shape (= A2A spec v0.2.0 discriminator)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _handle_message_send escalation predicate (B48-NF-W2-S2 fix)
+# ---------------------------------------------------------------------------
+
+
+class _StubSendImpl:
+    """Patches ``send_to_agent_impl`` so escalation-path tests can drive
+    the handler without spinning up a session. Stores the result dict
+    the patched implementation returns.
+    """
+
+    def __init__(self, result: dict):
+        self._result = result
+
+    async def __call__(self, registry, *, agent_name, message, timeout):
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_escalation_skipped_when_reply_text_nonempty(monkeypatch):
+    """Tier 2 (B48-NF-W2-S2 fix): when ``send_to_agent_impl`` returns a
+    non-empty ``reply`` AND ``partial=True`` AND a still-running skill,
+    the handler must return a **Message envelope carrying that reply**
+    — not escalate to a Task envelope that drops the text.
+
+    Before the fix the handler escalated unconditionally on
+    ``partial AND running_ids``, discarding the early ack and surfacing
+    ``(empty)`` to the caller (B48 W2-S2 = ``skill_builder_web_summariser``
+    3/3 deterministic reproduction).
+    """
+    import reyn.web.routers.a2a as a2a_mod
+
+    stub = _StubSendImpl({
+        "reply": "Skill creation started — wait for completion.",
+        "partial": True,
+        "agent": "alice",
+        "running_skill_run_ids": ["run-skill-builder-1"],
+    })
+    monkeypatch.setattr(a2a_mod, "send_to_agent_impl", stub)
+
+    result = await _handle_message_send(
+        req_id=1,
+        params={
+            "message": {
+                "parts": [{"kind": "text", "text": "build a skill"}],
+            },
+        },
+        agent_name="alice",
+        registry=object(),  # unused — stub bypasses session lookup
+        run_registry=RunRegistry(),
+    )
+
+    assert result["jsonrpc"] == "2.0"
+    envelope = result["result"]
+    assert envelope["kind"] == "message", (
+        f"Expected Message envelope (early reply preserved), got "
+        f"{envelope.get('kind')!r}. Escalation must skip when "
+        f"reply_text is non-empty."
+    )
+    # The reply text must be present in parts[0].text — this is the
+    # invariant the B48 W2-S2 bug violated.
+    parts = envelope["parts"]
+    assert parts[0]["text"] == "Skill creation started — wait for completion."
+    # ``partial`` metadata still surfaces so the caller can poll if it
+    # wants more — the skill keeps running in the background.
+    assert envelope["metadata"]["partial"] is True
+
+
+@pytest.mark.asyncio
+async def test_escalation_still_fires_when_reply_text_empty(monkeypatch):
+    """Tier 2: when no early reply landed before the timeout (= empty
+    ``reply``) and a skill is still running, the handler MUST escalate
+    to a Task envelope — preserves B42-NF-W6-2's intent (= no silent
+    tombstone for callers that didn't poll back).
+    """
+    import reyn.web.routers.a2a as a2a_mod
+
+    stub = _StubSendImpl({
+        "reply": "",
+        "partial": True,
+        "agent": "alice",
+        "running_skill_run_ids": ["run-skill-builder-2"],
+    })
+    monkeypatch.setattr(a2a_mod, "send_to_agent_impl", stub)
+
+    # _escalate_to_task tries to fetch the session; patch _get_session_for_monitor
+    # to return a minimal stand-in so the monitor task can be created.
+    monkeypatch.setattr(
+        a2a_mod, "_get_session_for_monitor",
+        lambda registry, agent_name: _Session(),
+    )
+
+    result = await _handle_message_send(
+        req_id=2,
+        params={
+            "message": {
+                "parts": [{"kind": "text", "text": "spawn something async"}],
+            },
+        },
+        agent_name="alice",
+        registry=object(),
+        run_registry=RunRegistry(),
+    )
+
+    envelope = result["result"]
+    assert envelope["kind"] == "task", (
+        f"Expected Task envelope (empty reply + still-running skill), "
+        f"got {envelope.get('kind')!r}. B42-NF-W6-2 path must remain "
+        f"active for the no-reply case."
+    )
+    assert envelope["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_escalation_skipped_when_whitespace_only_reply(monkeypatch):
+    """Tier 2: whitespace-only reply counts as empty (``.strip()`` matters).
+    A trailing-newline-only response is not a real ack, so the escalation
+    branch should still run when a skill is in flight.
+    """
+    import reyn.web.routers.a2a as a2a_mod
+
+    stub = _StubSendImpl({
+        "reply": "   \n  ",
+        "partial": True,
+        "agent": "alice",
+        "running_skill_run_ids": ["run-1"],
+    })
+    monkeypatch.setattr(a2a_mod, "send_to_agent_impl", stub)
+    monkeypatch.setattr(
+        a2a_mod, "_get_session_for_monitor",
+        lambda registry, agent_name: _Session(),
+    )
+
+    result = await _handle_message_send(
+        req_id=3,
+        params={
+            "message": {"parts": [{"kind": "text", "text": "go"}]},
+        },
+        agent_name="alice",
+        registry=object(),
+        run_registry=RunRegistry(),
+    )
+
+    envelope = result["result"]
+    assert envelope["kind"] == "task"
 
 
 def test_task_envelope_carries_kind_field_for_a2a_discrimination():


### PR DESCRIPTION
**[dogfood-coder]** — B48 Mode F/F-W2 W2-S2 (\`skill_builder_web_summariser\`) was failing 3/3 deterministic with \`reply_excerpt="(empty)"\`. Code-path analysis of \`src/reyn/web/routers/a2a.py:_handle_message_send\` + the b48-2 worker trace pinned the bug to **unconditional Task escalation discarding an early ack reply**. No LLM noise — this is a deterministic OS path bug.

## Summary
- A2A \`message/send\` previously escalated to a Task envelope on \`partial AND running_skill_run_ids\` regardless of whether \`result["reply"]\` was non-empty.
- When the LLM produced an early spawn-ack ("skill creation started — wait for completion") inside the 60s timeout window, \`send_to_agent_impl\` harvested it into \`result["reply"]\` but the handler escalated to Task, dropping the text.
- Caller (= dogfood worker harness expecting a Message envelope) observed \`(empty)\`.

## Fix
Gate escalation on **empty** \`reply_text\` in addition to \`partial\` + \`running_ids\`. When the reply text is present, return the Message envelope with \`metadata.partial=true\` so the caller actually sees the ack. B42-NF-W6-2's "no silent tombstone" intent stays intact for the truly-empty case (= LLM never produced text within the window).

\`\`\`python
running_ids = result.get("running_skill_run_ids") or []
reply_text = result.get("reply", "")
if not reply_text.strip() and result.get("partial") and running_ids:
    return await _escalate_to_task(...)
# else: return Message envelope with metadata.partial
\`\`\`

## Trace evidence (b48-2 worker, agent dogfood-b48-2-s2, chain ffcb95c)
- T+0s : user prompt
- T+5s : LLM tool-call invoke_action skill__skill_builder (ack-exit)
- T+14s: \`router_empty_response_retry_injected\` (= empty-stop retry directive)
- **T+20s: assistant entry persisted with 88-char ack "ウェブ記事の URL を受け取り... 作成を開始しました..." (chain_id=ffcb95c, role=assistant, text non-empty)**
- T+60s: \`send_to_agent_impl\` timeout fires → harvests 88-char ack into \`result["reply"]\`, reports \`partial=True\`, \`running_skill_run_ids=[skill_builder_5e03]\` (skill still working)
- T+60s: handler escalates → Task envelope returned (parts dropped) → worker records \`(empty)\`

After fix: handler returns Message envelope with the 88-char ack text + \`metadata.partial=true\` (skill keeps running in background; next \`message/send\` to the agent drains the \`skill_completion_injected\` inbox).

## Test plan
- [x] 3 new Tier 2 tests in \`tests/test_a2a_sync_async_escalation.py\`:
  - non-empty reply + partial + running → Message envelope (= the W2-S2 fix)
  - empty reply + partial + running → Task envelope (= B42-NF-W6-2 path preserved)
  - whitespace-only reply + partial + running → Task envelope (= \`.strip()\` regression guard)
- [x] \`pytest tests/test_a2a_sync_async_escalation.py\` — 13 pass.
- [x] A2A/web sweep — 248 pass, 2 skipped, 0 fail.
- [ ] B49 dogfood re-run of W2-S2 — verify \`skill_builder_web_summariser\` lands V (post-merge).

## ΔV
**+1V** Mode F partial closure (= W2-S2 deterministic), confidence **0.90** (= structural OS code-path bug; code reading + history.jsonl direct observation + 3/3 reproduction). Side effect: any other scenario where a skill exceeds the 60s A2A timeout but the LLM produced an early ack also benefits (= likely W2-S1 \`index_docs_basic\` and similar long-running skill spawns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)