### PR TITLE
fix(session): pass multimodal_config in web + mcp ChatSession factories

### DIFF
--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -383,6 +383,7 @@ def run_serve(args: argparse.Namespace) -> None:
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,
+            multimodal_config=session_cfg.config.multimodal,
             action_retrieval_config=session_cfg.config.action_retrieval,
             embedding_config=session_cfg.config.embedding,
         )

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -197,6 +197,7 @@ def _get_registry():
                 events_config=config.events,
                 state_log=state_log,
                 budget_tracker=budget_tracker,
+                multimodal_config=config.multimodal,
                 action_retrieval_config=config.action_retrieval,
                 embedding_config=config.embedding,
             )

--- a/tests/test_session_factory_multimodal_config_uniform.py
+++ b/tests/test_session_factory_multimodal_config_uniform.py
@@ -1,0 +1,128 @@
+"""Tier 2: every ``ChatSession(...)`` call site passes ``multimodal_config``.
+
+Background: ``MediaStore`` is built from ``multimodal_config`` inside
+``ChatSession.__init__``.  When ``multimodal_config`` is missing, the
+session ends up with ``media_store=None``, which silently disables the
+preview-driven tool result path (= path_ref mode in ``web_fetch`` /
+``file_read``).  The failure mode is invisible — the session still runs,
+``web_fetch`` returns inline content instead of a path_ref + preview,
+and ``read_tool_result`` errors with "MediaStore is not configured".
+
+Asymmetry observed 2026-05-22 during #385 Step 2 measurement prep:
+
+* ``src/reyn/cli/commands/chat.py``    — passes ``multimodal_config`` ✓
+* ``src/reyn/cli/commands/dogfood.py`` — passes ``multimodal_config`` ✓
+* ``src/reyn/cli/commands/mcp.py``     — MISSING (this PR fixes)
+* ``src/reyn/web/deps.py``             — MISSING (this PR fixes)
+
+The fix is straightforward, but the asymmetry will reappear whenever a
+new ``ChatSession()`` call site is added (= different surface: A2A
+server, HTTP gateway, scheduled job, etc.).  This test parses each
+file's AST, finds every ``ChatSession(...)`` call, and asserts the
+``multimodal_config`` keyword is present.  Drift is caught at PR-review
+time instead of post-deploy during measurement.
+
+Tier 2 because the cross-callsite invariant is an OS-level wiring rule
+the chat session contract depends on; a regression directly breaks the
+preview-driven path that #385 / PR #396 ship.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    """Return the Reyn repo root by walking up from this test file."""
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("unable to locate repo root from " + str(here))
+
+
+def _chat_session_calls_in(path: Path) -> list[ast.Call]:
+    """Return every ``ChatSession(...)`` call node in the parsed source.
+
+    Matches both ``ChatSession(...)`` (= direct name) and ``X.ChatSession(...)``
+    (= attribute access).  Only the rightmost name segment is compared so
+    aliased / re-exported forms still trigger.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "ChatSession":
+            calls.append(node)
+        elif isinstance(func, ast.Attribute) and func.attr == "ChatSession":
+            calls.append(node)
+    return calls
+
+
+# The 4 call sites this invariant covers.  Adding a new one is a deliberate
+# act — append it here in the same PR that introduces the call site.
+_CALL_SITE_FILES = [
+    "src/reyn/cli/commands/chat.py",
+    "src/reyn/cli/commands/dogfood.py",
+    "src/reyn/cli/commands/mcp.py",
+    "src/reyn/web/deps.py",
+]
+
+
+@pytest.mark.parametrize("rel_path", _CALL_SITE_FILES)
+def test_chat_session_call_site_passes_multimodal_config(rel_path: str) -> None:
+    """Tier 2: each known ``ChatSession()`` factory call passes
+    ``multimodal_config``.  A missing kwarg here disables preview-driven
+    tool result path silently (= ``media_store=None`` fallback).
+    """
+    path = _repo_root() / rel_path
+    assert path.is_file(), f"call-site file moved? {rel_path}"
+    calls = _chat_session_calls_in(path)
+    assert calls, f"no ChatSession(...) call found in {rel_path}"
+    for call in calls:
+        keywords = {kw.arg for kw in call.keywords if kw.arg is not None}
+        assert "multimodal_config" in keywords, (
+            f"{rel_path}:{call.lineno} ChatSession(...) is missing "
+            "`multimodal_config=` kwarg. Add `multimodal_config=<source>` "
+            "so MediaStore can build and preview-driven tool results work."
+        )
+
+
+def test_no_unknown_chat_session_call_sites() -> None:
+    """Tier 2: every ``ChatSession(...)`` call inside ``src/`` is covered
+    by this test's ``_CALL_SITE_FILES`` list.
+
+    If you added a new call site (= different surface like a new HTTP
+    gateway / scheduled job), append it to ``_CALL_SITE_FILES`` IN THE
+    SAME PR so the multimodal_config invariant remains enforced.
+    Forgetting to add it here means the new surface silently ships
+    without preview-driven support.
+
+    Test sites under ``tests/`` are intentionally excluded — they
+    construct minimal ``ChatSession`` instances for unit testing where
+    ``multimodal_config`` doesn't need to be wired.
+    """
+    root = _repo_root()
+    src = root / "src"
+    expected = {(root / p).resolve() for p in _CALL_SITE_FILES}
+    actual = set()
+    for py in src.rglob("*.py"):
+        if not _chat_session_calls_in(py):
+            continue
+        # Filter out the ChatSession class definition itself (= reyn/chat/session.py).
+        # The class file references ``ChatSession`` only through self / its own
+        # definition; constructor call sites are the ones in factory functions.
+        text = py.read_text(encoding="utf-8")
+        if "class ChatSession" in text:
+            continue
+        actual.add(py.resolve())
+    extras = actual - expected
+    assert not extras, (
+        "Unlisted ChatSession() call sites found — add them to "
+        "_CALL_SITE_FILES in this test in the same PR. Found: "
+        + ", ".join(sorted(str(p.relative_to(root)) for p in extras))
+    )


### PR DESCRIPTION
**[e2e-coder]** — unblock #385 Step 2 measurement + structural prep for cross-host β core impl. Sandbox_2 surface during PR #408 plan execution today.

## Summary

- ``ChatSession.__init__`` builds ``MediaStore`` from ``multimodal_config``. When the kwarg is omitted, the session ends up with ``media_store=None``, which silently disables the preview-driven tool result path (= ``path_ref`` mode in ``web_fetch`` / ``file_read``).
- The failure is invisible: session still runs, ``web_fetch`` returns inline content instead of a ``path_ref`` + preview, and ``read_tool_result`` errors with "MediaStore is not configured".
- 2 of 4 ChatSession call sites were dropping the kwarg silently:

| Call site | Surface | ``multimodal_config`` |
|---|---|---|
| ``src/reyn/cli/commands/chat.py`` | ``reyn chat`` (CLI) | ✓ |
| ``src/reyn/cli/commands/dogfood.py`` | ``reyn dogfood`` | ✓ |
| **``src/reyn/cli/commands/mcp.py``** | ``reyn mcp`` (MCP CLI) | ❌ — **this PR fixes** |
| **``src/reyn/web/deps.py``** | web / A2A path | ❌ — **this PR fixes** |

## Impact

- **#385 Step 2 measurement**: web/A2A path silently dropped PR #396 preview-driven mode → false-negative risk on cross-host scenarios. Sandbox_2 surfaced the gap during execution prep today; web/deps.py was the original finding, mcp.py was the additional asymmetry found here.
- **Cross-host β core impl (= e2e-coder upcoming work)**: cross-host RPC routing depends on MediaStore being live in the consumer session. Without this fix, β impl would observe ``media_store=None`` on web/A2A consumers.

## Why also catch ``mcp.py``

The original report was web/deps.py only. Auditing all ``ChatSession()`` call sites surfaced ``mcp.py`` carrying the same asymmetry — same root cause, same silent fail-mode. Per ``feedback_schema_exposure_surface_audit`` (= "fix every discovery channel in the same PR"), fixing both in one PR avoids a follow-up sweep.

## Change shape

- ``src/reyn/web/deps.py`` L183-202 — add ``multimodal_config=config.multimodal,``
- ``src/reyn/cli/commands/mcp.py`` L368-388 — add ``multimodal_config=session_cfg.config.multimodal,``
- ``tests/test_session_factory_multimodal_config_uniform.py`` (new, 5 tests) — pins the cross-callsite invariant via AST walk. A new ``ChatSession()`` call site (= new HTTP gateway / scheduled job / etc.) must be appended to ``_CALL_SITE_FILES`` IN THE SAME PR that introduces it, or the unknown-site sentinel test fails.

## Test plan

- [x] ``pytest tests/test_session_factory_multimodal_config_uniform.py`` — 5/5 pass (4 parametrised per call site + 1 unknown-site sentinel)
- [x] ``pytest tests/`` (full suite) — 4589 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected (= ``test_legacy_no_media_store_path_returns_inline_content`` in ``test_web_fetch_preview_path_ref.py``, confirmed against main earlier today)
- [x] ``ruff check`` on all modified files — clean
- [ ] (manual) ``reyn mcp ...`` interactive invocation with multimodal content — should now build MediaStore. Not run; the test covers the wiring contract, runtime behaviour is exercised by existing ``test_web_fetch_preview_path_ref`` / ``test_file_read_binary_media`` against the chat surface.

## Relation to in-flight work

- **#385 Step 2 measurement** (= sandbox_2): unblocks the path-ref scenarios on web/A2A surface
- **#385 β core impl** (= e2e-coder upcoming, post Step 2 success path): consumer-side MediaStore now reliably present on web/A2A consumers
- **#383 E-full** (= MediaStore origin, PR-C merged earlier): completes the asymmetry that PR-C's docstring flagged as out of scope ("PR-C lands the writer; PR-D wires the consumer")

🤖 Generated with [Claude Code](https://claude.com/claude-code)