### PR TITLE
fix(tui): pending tab scroll-into-view +1 padding offset (A-F5)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -1704,7 +1704,7 @@ class RightPanel(Widget):
                 return
             if not (0 <= self._pending_cursor < len(self._pending_item_ys)):
                 return
-            y = self._pending_item_ys[self._pending_cursor]
+            y = 1 + self._pending_item_ys[self._pending_cursor]
             if y < current:
                 vs.scroll_to(y=y, animate=False)
             elif y >= current + visible:


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #1 (A-F5)

## Summary

- `_scroll_pending_into_view` was the only cursor-scroll helper in `right_panel` missing the `+1` padding-top offset
- 1-character fix: `y = self._pending_item_ys[cursor]` → `y = 1 + ...`
- Matches the documented pattern used by `_scroll_events_into_view`, `_scroll_memory_into_view`, `_scroll_agents_into_view`, `_scroll_docs_into_view`

## Root cause

`#panel-content` has `padding-top: 1`. All sibling scroll helpers add `+1` to map widget Y coords into `#panel-scroll` Y coords. Pending tab was the outlier, so j/k navigation anchored the cursor row one line above the viewport target.

## Test plan

- [x] ruff check passes (all)
- [x] No tests cover scroll-into-view arithmetic directly; existing `tests/cli/test_pending_tab_render.py` exercises `render_pending` + `_flat` / `item_ys` shape, unaffected
- [ ] (skipped — manual TUI verify deferred to follow-up smoke; 1-char arithmetic change, identical pattern to 4 sibling helpers, defensive coverage = code-review + sibling-pattern symmetry)

## Wave-7 context

First PR of wave-7 (= TUI/UX exploration, Topic A: Memory tab + cross-tab discovery). Discovered via memory-tab pattern audit, ships as standalone 1-line PR per `1 commit = 1 branch = 1 PR` invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)