### PR TITLE
feat(tui): Memory tab render polish (A-F1+F2+F7 bundle)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -1,6 +1,7 @@
 """Memory tab — renders shared and per-agent memory entries with cursor."""
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,31 @@ _TYPE_COLORS: dict[str, str] = {
 
 
 _HOT_LIST_MAX_VISIBLE = 8
+
+
+def _fmt_ago(last_ts: Any) -> str:
+    """Best-effort relative-time string for the hot-list ``last_ts`` field.
+
+    The ARS forwarder emits ``last_ts`` as a Unix-epoch float (see
+    ``ActionUsageTracker.full_ranking``). Returns an empty string when
+    the value is missing, unparseable, or in the future — callers append
+    a dim suffix only when this returns non-empty so the layout stays
+    intact for older payloads that omitted the field.
+    """
+    try:
+        ts = float(last_ts)
+    except (TypeError, ValueError):
+        return ""
+    delta = time.time() - ts
+    if delta < 0 or ts <= 0:
+        return ""
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    return f"{int(delta // 86400)}d ago"
 
 
 def render_memory(
@@ -71,9 +97,13 @@ def render_memory(
                 continue
             if not name:
                 continue
+            if freq <= 0:
+                continue
+            ago = _fmt_ago(entry.get("last_ts") if hasattr(entry, "get") else None)
+            ago_suffix = f"  [#555555]{ago}[/]" if ago else ""
             lines.append(
                 f"[#ffaa44]    🔥 [/][#dddddd]{_esc(name)}[/]  "
-                f"[#666666]×{freq}[/]"
+                f"[#666666]×{freq}[/]{ago_suffix}"
             )
         overflow = len(hot_list) - _HOT_LIST_MAX_VISIBLE
         if overflow > 0:
@@ -132,6 +162,8 @@ def render_memory(
                 indent = f"[bold {_CORAL}]    ▶ [/]" if is_cursor else "      "
                 name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
                 lines.append(f"{indent}[{name_style}]{_esc(e.name)}[/]")
+                if e.description:
+                    lines.append(f"[#555555]        {_esc(e.description)}[/]")
         lines.append("")
 
     # Shared memory

--- a/tests/cli/test_memory_tab_hot_list.py
+++ b/tests/cli/test_memory_tab_hot_list.py
@@ -139,3 +139,82 @@ def test_hot_list_overflow_marker(tmp_path):
     )
     # 12 entries; cap is 8 in the renderer → 4 should be hidden.
     assert "more" in rendered
+
+
+def test_hot_list_renders_relative_time_when_last_ts_valid(tmp_path):
+    """Tier 2: a valid ``last_ts`` float surfaces a relative-time hint.
+
+    The ARS forwarder emits ``last_ts`` as a Unix-epoch float (see
+    ``ActionUsageTracker.full_ranking``). Without this hint the user
+    has no way to tell whether the ranking is fresh or stale — same
+    ``×N`` count can mean "this turn" or "yesterday".
+    """
+    import time as _time
+
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    hot = [
+        {
+            "qualified_name": "skill__direct_llm",
+            "freq": 5,
+            "last_ts": _time.time() - 90,  # 90 seconds ago → "1m ago"
+        }
+    ]
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=hot,
+    )
+    # The exact suffix wording is not pinned — only that *some* relative
+    # marker ("ago" substring) appears. Tolerates 89s / 90s / 91s timing
+    # drift between the test and the renderer.
+    assert "ago" in rendered
+
+
+def test_hot_list_skips_zero_freq_entries(tmp_path):
+    """Tier 2: entries with ``freq <= 0`` are filtered out.
+
+    ``freq=0`` next to a fire emoji ("🔥 skill__foo ×0") is visually
+    contradictory. The ranking semantics are "skill has been used N
+    times in the relevant window"; a zero count means the skill is no
+    longer hot and should not appear under HOT NOW at all.
+    """
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    hot = [
+        {"qualified_name": "skill__alive", "freq": 3, "last_ts": ""},
+        {"qualified_name": "skill__evicted", "freq": 0, "last_ts": ""},
+        {"qualified_name": "skill__negative", "freq": -1, "last_ts": ""},
+    ]
+    rendered, _flat, _ys = render_memory(
+        _project_with_empty_memory(tmp_path), cursor=0, hot_list=hot,
+    )
+    assert "skill__alive" in rendered
+    assert "skill__evicted" not in rendered
+    assert "skill__negative" not in rendered
+
+
+def test_other_bucket_entries_render_description(tmp_path):
+    """Tier 2: ``OTHER``-bucket entries surface their description line.
+
+    The typed buckets (USER / FEEDBACK / PROJECT / REFERENCE) render
+    ``description`` underneath the name when populated. Entries whose
+    ``type`` falls outside the four canonical types land in OTHER and
+    must use the same render shape — otherwise the OTHER section
+    becomes silently lower-fidelity than the typed ones.
+    """
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    # Plant one memory file with type="custom" so it lands in OTHER.
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / "custom_thing.md").write_text(
+        "---\nname: custom-thing\ndescription: a non-standard memory type\n"
+        "metadata:\n  type: custom\n---\n\nbody text\n",
+        encoding="utf-8",
+    )
+
+    rendered, _flat, _ys = render_memory(
+        tmp_path, cursor=0, hot_list=None,
+    )
+    assert "OTHER" in rendered
+    assert "custom-thing" in rendered
+    assert "a non-standard memory type" in rendered


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #2 (bundle: A-F1 + A-F2 + A-F7)

## Summary

Three small render-shape fixes inside the Memory tab's ``render_memory``, all bundled in one PR because they touch the same file and the same render pass (= no inter-finding coupling, just locality).

### A-F1: OTHER bucket loses description line
USER / FEEDBACK / PROJECT / REFERENCE render ``e.description`` under the name. OTHER skipped that line, so non-standard memory types were silently lower-fidelity than typed ones. Added the mirror branch.

### A-F2: ``last_ts`` field never surfaces
``ActionUsageTracker.full_ranking`` emits a Unix-epoch float per entry. Renderer ignored it, leaving the user no temporal context — same ``×N`` count could mean "this turn" or "last week". New ``_fmt_ago`` helper appends a dim ``Ns/m/h/d ago`` suffix when the value parses as a positive float; silently degrades for unparseable / missing / future / string-typed values.

### A-F7: ``freq <= 0`` entries silently rendered
A 🔥 next to ``×0`` is visually contradictory. ``freq=0`` means the skill is no longer hot and shouldn't appear under HOT NOW. Filter at the same guard layer that skips empty names.

## Test plan

- [x] ruff check passes (all)
- [x] Existing 5 contract tests in ``test_memory_tab_hot_list.py`` continue to pass
- [x] 3 new Tier 2 contract tests added:
  - ``test_hot_list_renders_relative_time_when_last_ts_valid``
  - ``test_hot_list_skips_zero_freq_entries``
  - ``test_other_bucket_entries_render_description``
- [x] pytest ``tests/cli/test_memory_tab_hot_list.py`` 8/8 green locally
- [ ] (skipped — manual TUI verify deferred to wave-7 smoke at the end; pure render-shape fixes covered by Tier 2 contract assertions)

## Bundle rationale

All three findings:
- live in ``src/reyn/chat/tui/widgets/right_panel/memory_tab.py``
- are independent in code (= no shared logic between them)
- are coupled in **review locality** (= reviewer reads the same hot-list loop + same OTHER branch)
- ship as 1 commit so the diff is read at once rather than three open PRs hitting the same file in sequence

Same wave-6 IV-bundle (IV1+IV2+IV3) precedent — review locality dominates over per-finding isolation.

## Wave-7 context

2/10 wave-7 PRs (= Topic A: Memory tab UX polish). Prior: #413 (A-F5 pending scroll +1 offset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)