### PR TITLE
fix(tui): auto-close preview on tab switch without content (A-F8)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -529,7 +529,16 @@ class RightPanel(Widget):
             if scroll_helper is not None:
                 scroll_helper()
             if self._preview_visible:
-                self._update_preview()
+                # If the new tab has nothing previewable (= keys / cost,
+                # or an empty memory / events list), auto-close the
+                # preview so the user isn't left with a blank half-pane
+                # and a `_toggle_preview` guard that silently no-ops on
+                # the next Space press. Tabs that do have content keep
+                # the preview open and refresh it.
+                if not self._has_previewable_content():
+                    self._toggle_preview()
+                else:
+                    self._update_preview()
 
     @on(_PreviewPane.CloseRequested)
     def _on_preview_close_requested(self, event) -> None:


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #3 (A-F8)

## Summary

When the preview pane is open and the user switches to a tab that has nothing to preview (keys / cost, or an empty memory / events list), the pane stays visible-class with no body. ``_toggle_preview``'s guard refuses to re-open, so the next Space press silently no-ops. Result: blank half-pane stuck on screen with no recovery affordance.

Fix: in ``on_tabs_tab_activated``, if the preview is visible and the new tab has no previewable content, auto-close the pane.

## Test plan

- [x] ruff check passes
- [ ] (skipped — manual TUI verify deferred to wave-7 smoke; behavioral change is gated by the existing ``_has_previewable_content`` helper which is already exercised by ``_toggle_preview`` covers + test sites that exercise content-bearing tabs)
- [x] Code-review verifies the existing branch only adds an else+close path; the previously-tested content-bearing tab path is preserved

## Wave-7 context

3/10 wave-7 PRs. Prior: #413 (A-F5), #414 (A-F1+F2+F7 bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)