### PR TITLE
feat(tui): line-granularity + jump-to-tail conv scroll keys (B-F1+F5)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -120,6 +120,16 @@ class ReynTUIApp(App):
         # required, complement to the existing anchor-based Ctrl+P/N).
         Binding("pageup", "conv_scroll_page_up", "Scroll up", priority=True, show=False),
         Binding("pagedown", "conv_scroll_page_down", "Scroll down", priority=True, show=False),
+        # Line-granularity + jump-to-tail scroll keys. Alt-prefixed so
+        # they don't collide with the input bar's Up/Down history bindings
+        # or with TextArea's End=end-of-line. Complements the existing
+        # page-step keys when a PageUp overshoots and the user wants to
+        # nudge the viewport by a single line. Alt+End re-arms auto-scroll
+        # so the next streaming message follows along again without
+        # waiting for a manual PageDown chain.
+        Binding("alt+up", "conv_scroll_line_up", "Scroll up 1 line", priority=True, show=False),
+        Binding("alt+down", "conv_scroll_line_down", "Scroll down 1 line", priority=True, show=False),
+        Binding("alt+end", "conv_scroll_end", "Scroll to bottom", priority=True, show=False),
     ]
 
     _REYN_THEME = Theme(
@@ -1093,6 +1103,30 @@ class ReynTUIApp(App):
         try:
             conv = self.query_one("#conversation", ConversationView)
             conv.scroll_page_down()
+        except Exception:
+            pass
+
+    def action_conv_scroll_line_up(self) -> None:
+        """Alt+Up — scroll the conv log up one line without changing focus."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.scroll_line_up()
+        except Exception:
+            pass
+
+    def action_conv_scroll_line_down(self) -> None:
+        """Alt+Down — scroll the conv log down one line without changing focus."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.scroll_line_down()
+        except Exception:
+            pass
+
+    def action_conv_scroll_end(self) -> None:
+        """Alt+End — jump to the conv log tail and re-arm auto-scroll."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.scroll_to_bottom()
         except Exception:
             pass
 

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1178,6 +1178,45 @@ class ConversationView(Widget):
         except Exception:
             pass
 
+    def scroll_line_up(self) -> None:
+        """Scroll the conv log up one line without changing focus.
+
+        Complements ``scroll_page_up`` for fine-grained navigation when
+        a single PageUp overshoots. Sets ``_user_scrolled`` so the
+        scroll watcher doesn't auto-scroll back to bottom on the next
+        message.
+        """
+        log = self._log()
+        try:
+            log.scroll_relative(y=-1, animate=False)
+        except Exception:
+            pass
+        self._user_scrolled = True
+
+    def scroll_line_down(self) -> None:
+        """Scroll the conv log down one line without changing focus."""
+        log = self._log()
+        try:
+            log.scroll_relative(y=1, animate=False)
+        except Exception:
+            pass
+        try:
+            if log.scroll_y >= log.max_scroll_y - 1:
+                self._user_scrolled = False
+        except Exception:
+            pass
+
+    def scroll_to_bottom(self) -> None:
+        """Jump to the tail of the conv log and re-arm auto-scroll.
+
+        Lets the user return to the live tail after reading history
+        via PageUp / Ctrl+P without having to either press PageDown
+        repeatedly or type a new message (which is what currently
+        triggers ``_snap_to_bottom``).
+        """
+        self._snap_to_bottom()
+        self._user_scrolled = False
+
     def _jump_to_relative_anchor(self, delta: int) -> None:
         if not self._turn_anchors:
             return


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #4 (bundle: B-F1 + B-F5)

## Summary

Two complementary scroll keys on the conv log, sharing the same dispatch shape as the existing PageUp/PageDown handlers (wave-4 AR5).

### B-F1: Alt+Up / Alt+Down — line-granularity scroll
PageUp/PageDown exist but a single PageUp often overshoots when the user wants to nudge back by one paragraph. Alt-prefix avoids collision with the input bar's Up/Down history bindings.

### B-F5: Alt+End — jump to tail
After reading history via PageUp / Ctrl+P, the only way back to the live tail is chaining PageDown or sending a message (which triggers ``_snap_to_bottom``). Alt+End provides a direct path and re-arms auto-scroll so the next streaming message follows along again.

## Why Alt-prefix?

| Key | Existing meaning |
|---|---|
| Up / Down | input bar history navigation (``input_bar.py:46-47``, priority=True) |
| End | TextArea end-of-line |
| Alt+Up / Alt+Down / Alt+End | Not bound anywhere — collision-free |

App-level binding with ``priority=True`` would steal Up/Down from the input bar. Alt-prefix keeps the existing input bindings intact and surfaces a discoverable alternative for scroll. Same precedent as Ctrl+P/N (anchor navigation) vs Up/Down (history).

## Bundle rationale

Both findings live in:
- ``app.py`` BINDINGS + action methods (= 3 new bindings + 3 new actions)
- ``ConversationView`` (= 3 new helper methods mirroring ``scroll_page_*`` shape)

Same dispatch contract, same flag handling, same focus model — reviewer reads one cohesive change rather than two PRs that diff the same files in sequence.

## Test plan

- [x] ruff check passes
- [x] Mirrors the established ``scroll_page_up`` / ``scroll_page_down`` pattern — same ``_log()`` dispatch, same ``_user_scrolled`` arm/disarm logic, same try/except defense
- [ ] (skipped — manual TUI verify deferred to wave-7 smoke; bindings + dispatch follow the same architecture as existing PageUp/PageDown which are already exercised in production)

## Wave-7 context

4/10 wave-7 PRs. Prior: #413 (A-F5), #414 (A-F1+F2+F7 bundle), #415 (A-F8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)