### PR TITLE
fix(tui): header truncates long agent_name on narrow terminals (C-F5)

### DIFF
--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -13,6 +13,7 @@ import re
 import time
 from dataclasses import dataclass
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.message import Message
@@ -135,6 +136,86 @@ class ReynHeader(Widget):
         except Exception:
             pass
 
+    def _maybe_truncate_agent_name(self) -> str:
+        """Truncate ``_agent_name`` so the assembled status fits the cell.
+
+        Computes the cell-width of every other status field (model,
+        tokens, cost, optional pending badge, clock) plus the ``  │  ``
+        separators (5 cells each), subtracts from the widget's status
+        cell width (= total widget width minus the title cell), and
+        clips the agent name to whatever room remains. Appends ``…``
+        when truncated. When ``self.size.width`` is 0 (= pre-mount) the
+        name is returned verbatim — the next ``_tick_clock`` refresh
+        will recompute once layout is known. A minimum of 3 cells is
+        always reserved for the agent name so the field doesn't
+        disappear entirely on extreme widths.
+        """
+        name = self._agent_name
+        if not name:
+            return name
+        try:
+            total_width = self.size.width
+        except Exception:
+            total_width = 0
+        if total_width <= 0:
+            return name
+        # Title cell ≈ 1 (left pad) + cell_len("Reyn") + 1 (right pad)
+        # — matches the Label("Reyn", id="title") composed above. Hard-
+        # coded here rather than re-querying the DOM because _format_status
+        # is called from _tick_clock every second.
+        title_cells = 2 + cell_len("Reyn")
+        # Right-side status pad is 0 1 (= 1 cell on each side, see
+        # DEFAULT_CSS ``#status padding: 0 1``).
+        status_pad = 2
+        available = total_width - title_cells - status_pad
+        if available <= 0:
+            return name
+        # Cell-width of everything else this _format_status emits.
+        other_cells = 0
+        if self._model:
+            other_cells += cell_len(_shorten_model_id(self._model))
+        tok_str = f"{self._tokens_today:,}"
+        if self._tokens_cap is not None:
+            tok_str += f" / {self._tokens_cap:,}"
+        tok_str += " tok"
+        other_cells += cell_len(tok_str)
+        cost_str = f"${self._cost_usd:.4f}"
+        if self._cost_cap is not None:
+            cost_str += f" / ${self._cost_cap:.2f}"
+        other_cells += cell_len(cost_str)
+        if self._stalled_count > 0:
+            other_cells += cell_len(f"[{self._stalled_count} pending]")
+        other_cells += cell_len(self._now_text())
+        # Separator count: number of joins between parts. With
+        # agent_name included, parts = 1 (agent) + (1 if model) + 2
+        # (tokens, cost) + (1 if stalled) + 1 (clock).
+        part_count = 1 + (1 if self._model else 0) + 2 + (
+            1 if self._stalled_count > 0 else 0
+        ) + 1
+        separator_cells = max(0, part_count - 1) * cell_len("  │  ")
+        budget = available - other_cells - separator_cells
+        if budget >= cell_len(name):
+            return name
+        if budget < 3:
+            # Reserve at least 3 cells so the name isn't fully eaten.
+            budget = 3
+        # Walk the name char-by-char in cell space; stop when adding
+        # the next char would exceed budget − 1 (= keep room for the
+        # ellipsis cell).
+        ellipsis = "…"
+        max_body = budget - cell_len(ellipsis)
+        if max_body <= 0:
+            return ellipsis
+        out: list[str] = []
+        used = 0
+        for ch in name:
+            ch_cells = cell_len(ch)
+            if used + ch_cells > max_body:
+                break
+            out.append(ch)
+            used += ch_cells
+        return "".join(out) + ellipsis
+
     def _format_status(self) -> Text:
         """Build the right-side status as a Rich Text with dim │ separators.
 
@@ -146,12 +227,22 @@ class ReynHeader(Widget):
         changes within a session, so de-emphasising it keeps the user's
         eye on the per-turn metrics that DO change — tokens, cost, and
         the clock canary at the right edge.
+
+        Narrow-terminal truncation: when the assembled status's total
+        cell-width would exceed the widget's available width (= title
+        cell already accounted for), ``_agent_name`` is the field
+        truncated first. Rationale: it is (a) the field most likely to
+        be long (full agent names can run 20+ cells), (b) the least
+        time-sensitive (= changes rarely, doesn't carry per-turn
+        information), and (c) the leftmost — keeping the clock canary,
+        cost, and pending badge at the right edge intact for
+        glance-reading.
         """
         # (text, style) tuples — style=None falls back to the widget's
         # default text color (#aaaaaa, see DEFAULT_CSS above).
         parts: list[tuple[str, str | None]] = []
         if self._agent_name:
-            parts.append((self._agent_name, None))
+            parts.append((self._maybe_truncate_agent_name(), None))
         if self._model:
             parts.append((_shorten_model_id(self._model), "dim #888888"))
         tok_str = f"{self._tokens_today:,}"

--- a/tests/cli/test_header_truncation_guard.py
+++ b/tests/cli/test_header_truncation_guard.py
@@ -1,0 +1,120 @@
+"""Tier 2: ReynHeader truncates _agent_name when the status overflows.
+
+The right-side status renders ``agent_name │ model │ tokens │ cost
+│ [N pending] │ clock`` right-aligned at ``width: 1fr`` (= the
+remaining horizontal cell after the Title label takes its share).
+When all fields are populated AND the agent name is long AND the
+terminal is narrow, the assembled status overflows the status cell
+and Textual either wraps the label to a 2nd row (breaking the
+single-line header docking) or silently clips the right-edge
+clock canary.
+
+These tests pin that under a narrow size the agent name truncates
+with ``…`` and the clock canary stays at the right edge.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets import ReynHeader  # noqa: E402
+
+
+class _HeaderOnlyApp(App):
+    """Minimal app — just a ReynHeader, no conv pane / right panel.
+
+    Lets the test mount + size the header in isolation so width
+    assertions don't have to subtract the right panel cells.
+    """
+
+    def __init__(self, *, agent_name: str = "", model: str = "") -> None:
+        super().__init__()
+        self._agent_name = agent_name
+        self._model = model
+
+    def compose(self) -> ComposeResult:
+        yield ReynHeader(
+            agent_name=self._agent_name, model=self._model, id="header",
+        )
+
+
+@pytest.mark.asyncio
+async def test_long_agent_name_truncates_at_narrow_width():
+    """At 60 cells with a long agent name + model + tokens + cost, the
+    rendered agent name surfaces with the ``…`` truncation marker.
+    """
+    app = _HeaderOnlyApp(
+        agent_name="aria-with-a-very-long-name",
+        model="claude-opus-4-7",
+    )
+    async with app.run_test(headless=True, size=(60, 5)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.refresh_status(tokens_today=12345, cost_usd=0.0123)
+        rendered = header._format_status().plain
+        # Either the truncation marker landed in the agent name slot,
+        # or — if the budget happened to be enough — the full name is
+        # there. Pin the actual narrow case where the full name does
+        # NOT fit; the assertion below proves truncation kicked in.
+        assert "…" in rendered
+        # And the clock canary (HH:MM:SS pattern) stays visible at the
+        # right edge — i.e. the rendered status STILL contains the
+        # colon-separated time.
+        assert ":" in rendered.split("│")[-1]
+
+
+@pytest.mark.asyncio
+async def test_short_agent_name_fits_no_truncation():
+    """A 4-cell agent name at standard width does NOT truncate."""
+    app = _HeaderOnlyApp(
+        agent_name="aria",
+        model="claude-opus-4-7",
+    )
+    async with app.run_test(headless=True, size=(120, 5)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.refresh_status(tokens_today=100, cost_usd=0.01)
+        rendered = header._format_status().plain
+        # Short name in a wide terminal — no … and the full name is
+        # present.
+        assert "aria" in rendered
+        # The truncation marker should NOT appear for the agent name
+        # in this case. (Other Unicode might contain U+2026, so we
+        # check that the *agent name* itself isn't ellipsed.)
+        # The simplest assertion: full "aria" is present unmodified.
+        assert "ari…" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_truncated_name_keeps_minimum_3_cells():
+    """Even at an extreme width, the agent name keeps a minimum visible
+    fragment so the user retains some identity signal.
+    """
+    app = _HeaderOnlyApp(
+        agent_name="alice",
+        model="claude-opus-4-7-20251101",
+    )
+    async with app.run_test(headless=True, size=(40, 5)) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.refresh_status(
+            tokens_today=999_999,
+            tokens_cap=1_000_000,
+            cost_usd=0.9876,
+            cost_cap=10.00,
+        )
+        rendered = header._format_status().plain
+        # The name truncated, but didn't become empty — at minimum
+        # one body cell + the ellipsis cell are present.
+        assert "…" in rendered
+        # First field of the right-aligned status: should be at least
+        # something non-empty before the first separator.
+        first_field = rendered.split("│")[0].strip()
+        assert first_field, "first status field must not be empty after truncation"


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #7 (C-F5)

## Summary

The right-side header status field — ``agent_name │ model │ tokens │ cost │ [N pending] │ clock`` — had no cell-width guard. When the stalled badge appears, the agent name is long, or the terminal is narrow, the assembled status overflows the status cell and either wraps (breaks single-line docking) or silently clips the right-edge clock canary.

New ``_maybe_truncate_agent_name`` computes the cell-width of every other field + separator (``  │  `` = 5 cells × N-1) and the title cell, subtracts from ``self.size.width``, and clips the agent name to fit whatever room remains. A 3-cell minimum is reserved so the field never disappears entirely.

## Why agent_name first?

| Field | Likelihood of being long | Time-sensitivity | Position |
|---|---|---|---|
| **agent_name** | high (20+ cells common) | low (changes rarely) | leftmost |
| model | low (already date-stripped) | low | second-left |
| tokens / cost / pending | small | high (per-turn info) | middle |
| clock | fixed 8 cells | medium (UI canary) | rightmost |

Truncating the leftmost + least time-sensitive field preserves the cost / pending / clock at the right edge for glance-reading.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests in ``tests/cli/test_header_truncation_guard.py`` pin truncation behavior at 60/120/40 cell widths
- [x] Existing ``tests/cli/test_tui_smoke.py`` header tests continue to pass
- [ ] (skipped — manual TUI verify deferred to wave-7 smoke; Tier 2 covers the truncation arithmetic + render path)

## Wave-7 context

7/10 wave-7 PRs. Prior: #413 (A-F5), #414 (A-F1+F2+F7), #415 (A-F8), #416 (B-F1+F5), #417 (B-F2), #418 (C-F1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)