### PR TITLE
docs(test): fix hot_list contract docstring (A-F3)

### DIFF
--- a/tests/cli/test_memory_tab_hot_list.py
+++ b/tests/cli/test_memory_tab_hot_list.py
@@ -9,8 +9,11 @@ above SHARED / AGENT scopes.
 
 Contract pinned here:
 
-1. Empty / missing ``hot_list`` → no "HOT NOW" header in the rendered
-   output (= cold-start layout unchanged).
+1. Empty / missing ``hot_list`` → "HOT NOW" header still renders with
+   a dim ``(no router activity yet)`` placeholder underneath (wave-4
+   PC5: the section was changed from "omitted entirely when empty" to
+   "always-visible header" so the feature is discoverable on cold
+   start).
 2. Non-empty ``hot_list`` → "HOT NOW" header appears + each entry's
    qualified_name + freq lands in the output.
 3. ``flat_entries`` is NOT polluted with hot-list rows (they are


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #8 (A-F3)

## Summary

The module docstring of ``tests/cli/test_memory_tab_hot_list.py`` (line 12-13) claimed:

> 1. Empty / missing hot_list → no "HOT NOW" header in the rendered output (= cold-start layout unchanged).

But the actual ``test_no_hot_list_shows_placeholder`` (lines 53-63) asserts ``"HOT NOW" in rendered`` for both ``hot_list=None`` and ``hot_list=[]``, and the renderer (``memory_tab.py:64``) unconditionally emits the header. The docstring was a stale copy of the pre-wave-4 PC5 behavior where the entire section was hidden when empty.

Replace point 1 with the current contract: header always renders with a dim ``(no router activity yet)`` placeholder.

## Test plan

- [x] Pure docstring edit, no logic change
- [x] pytest ``tests/cli/test_memory_tab_hot_list.py`` 5/5 green (= existing assertions unchanged)
- [x] ruff check passes

## Wave-7 context

8/10 wave-7 PRs. Prior: #413 (A-F5), #414 (A-F1+F2+F7), #415 (A-F8), #416 (B-F1+F5), #417 (B-F2), #418 (C-F1), #419 (C-F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)