### PR TITLE
chore(tui): dead-code + inconsistency cleanup bundle (B-F8+C-F4+C-F7)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -263,9 +263,8 @@ class ConversationView(Widget):
     }
     """
 
-    def __init__(self, *, scroll_end: bool = True, id: str | None = None) -> None:
+    def __init__(self, *, id: str | None = None) -> None:
         super().__init__(id=id)
-        self._scroll_end = scroll_end
         self._stream_rows: dict[str, StreamingRow] = {}
         self._skill_rows: dict[str, SkillActivityRow] = {}
         # Header-grouping state (B1)

--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -575,7 +575,7 @@ def render_agents(
                     elapsed_style = "bold #ffaa44"
                 else:
                     elapsed_style = "#888888"
-                skill_label.append(f"[{elapsed:3d}s] ", style=elapsed_style)
+                skill_label.append(f"{elapsed:3d}s  ", style=elapsed_style)
                 skill_label.append(
                     info.get("skill_name", "?"),
                     style=name_style or "#dddddd",

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -26,7 +26,6 @@ _TICK_INTERVAL_S = 0.1  # elapsed timer refresh rate
 
 _GLYPHS: dict[str, str] = {
     "thinking": "⟳",
-    "tool": "⚙",
     "general": "●",
 }
 
@@ -116,9 +115,9 @@ class StickyStatus(Static):
         # red — confusable with error indicators. The thinking sticky shows
         # while the agent is working, so route its glyph through _AMBER
         # (which degrades to ANSI yellow / bright yellow) — neutrally
-        # signalling "in progress" rather than "alert". Other kinds (tool,
-        # general) keep _CORAL since they're typically transient flashes,
-        # not the load-bearing "is the agent working?" indicator.
+        # signalling "in progress" rather than "alert". The other kind
+        # (general) keeps _CORAL since it's a transient flash, not the
+        # load-bearing "is the agent working?" indicator.
         glyph_color = _AMBER if self._kind == "thinking" else _CORAL
         # Total cells in the fixed-width suffix segments so we can truncate
         # the body when narrow terminals would otherwise clip the


### PR DESCRIPTION
**[tui-coder]** — wave-7 PR #9 (bundle: B-F8 + C-F4 + C-F7)

## Summary

Three tiny cleanups bundled together — each is a <10-line diff with zero behavioral coupling, shipped as one PR so the reviewer reads one cohesive "cleanup" change rather than three open PRs.

### B-F8: drop dead ``scroll_end`` parameter
``ConversationView.__init__`` accepted ``scroll_end: bool = True`` and stored it as ``self._scroll_end`` but the attribute is never read anywhere. ``app.py`` constructs ``ConversationView(id="conversation")`` without passing it.

### C-F4: drop dead ``"tool"`` glyph
``StickyStatus._GLYPHS`` declared ``"tool": "⚙"`` but production only ever emits ``kind="thinking"`` and ``kind="general"``. No ``show_status`` call site passes ``"tool"``. Removed the entry + updated the colour-routing comment to match.

### C-F7: drop bracket framing on agents-tab elapsed counter
``SkillActivityRow._build_running`` (conv pane) renders elapsed as ``42s``. ``agents_tab._emit_skill_row`` rendered it as ``[ 42s]`` — same colour thresholds (30 s amber, 60 s red) but with unnecessary bracket noise. Both surfaces now share the same format.

## Test plan

- [x] ruff check passes
- [x] All sticky_status / agents_tab / scroll-related tests continue to pass (16 + 20 = 36 tests)
- [x] grep verified no caller passes ``scroll_end=`` or ``kind="tool"`` anywhere in the repo
- [ ] (skipped — manual TUI verify deferred to wave-7 smoke; pure dead-code removal + cosmetic format change)

## Wave-7 context

9/10 wave-7 PRs. Prior: #413 (A-F5), #414 (A-F1+F2+F7), #415 (A-F8), #416 (B-F1+F5), #417 (B-F2), #418 (C-F1), #419 (C-F5), #420 (A-F3 docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)