### PR TITLE
feat(tools): read_tool_result accepts offset/limit (Q7, 4-surface symmetry)

### DIFF
--- a/src/reyn/tools/read_tool_result.py
+++ b/src/reyn/tools/read_tool_result.py
@@ -14,13 +14,20 @@ Path validation lives in :meth:`MediaStore.read_tool_result` — the
 resolved path must be inside ``tool_results_dir`` (= workspace
 boundary), otherwise the call raises ``PermissionError``.
 
-Out of scope for PoC PR-D (= follow-up work):
+Slice arguments (= ``offset`` / ``limit``) follow PR #409's line-based
+contract shared with ``read_file`` / ``reyn_src_read`` / ``read_memory_body``
+so the four "read one entry" surfaces stay parameter-symmetric. ``offset``
+counts 0-indexed lines from the start of the body; ``limit`` caps the
+line count taken. Slice happens before ``max_bytes`` truncation so the
+byte cap applies to the resulting sliced content (= two orthogonal axes
+for partial-read shape control).
 
-  - offset / limit pagination (= file_read-style partial read for very
-    long results). Current implementation caps at ``max_bytes`` and
-    surfaces truncation.
+Out of scope (= follow-up work):
+
   - search-within-result (= ``grep_tool_result(path, pattern)``).
   - cleanup policy enforcement (= LLM cannot delete; user-managed).
+  - cross-host RPC routing via ``resource_uri`` (= #385 β core impl,
+    gated on Step 2 measurement success path confirmation).
 """
 from __future__ import annotations
 
@@ -33,13 +40,29 @@ _READ_TOOL_RESULT_DESCRIPTION = (
     "path-ref preview (= web_fetch and similar). path: project-relative "
     "path under .reyn/tool-results/. Returns the content body or an "
     "error if the path is invalid or the file no longer exists. "
-    "max_bytes caps the returned size (default 16384)."
+    "offset / limit slice by line (0-indexed) — the same shape as "
+    "read_file / reyn_src_read / read_memory_body. max_bytes caps the "
+    "returned size after slicing (default 16384)."
 )
 
 _READ_TOOL_RESULT_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "path": {"type": "string"},
+        "offset": {
+            "type": "integer",
+            "description": (
+                "Line number to start reading from (0-indexed). "
+                "Omit to start at the beginning of the body."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                "Number of lines to read from `offset`. "
+                "Omit to read through end of body."
+            ),
+        },
         "max_bytes": {"type": "integer"},
     },
     "required": ["path"],
@@ -98,6 +121,23 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             "path": path,
             "error": "tool result file does not exist or was deleted",
         }
+
+    offset_raw = args.get("offset")
+    limit_raw = args.get("limit")
+    try:
+        offset = int(offset_raw) if offset_raw is not None else None
+    except (TypeError, ValueError):
+        offset = None
+    try:
+        limit = int(limit_raw) if limit_raw is not None else None
+    except (TypeError, ValueError):
+        limit = None
+
+    if offset is not None or limit is not None:
+        lines = content.splitlines(keepends=True)
+        start = max(0, offset or 0)
+        sliced = lines[start:start + limit] if limit is not None else lines[start:]
+        content = "".join(sliced)
 
     max_bytes_raw = args.get("max_bytes")
     try:

--- a/tests/test_read_offset_limit_symmetry.py
+++ b/tests/test_read_offset_limit_symmetry.py
@@ -185,23 +185,29 @@ def test_memory_slice_body_lines_past_eof_is_empty() -> None:
 # ── cross-surface symmetry (= the contract this PR enforces) ────────────────
 
 
-def test_all_three_read_schemas_share_offset_limit_shape() -> None:
-    """Tier 2: ``read_file``, ``reyn_src_read``, ``read_memory_body`` all
-    expose the same ``offset`` / ``limit`` line-slice arguments in their
-    LLM-visible parameter schemas, with identical types (integer) and
-    optional status (not in ``required``).
+def test_all_four_read_schemas_share_offset_limit_shape() -> None:
+    """Tier 2: all four "read one entry" LLM-callable surfaces —
+    ``read_file``, ``reyn_src_read``, ``read_memory_body``, and
+    ``read_tool_result`` — expose the same ``offset`` / ``limit``
+    line-slice arguments in their LLM-visible parameter schemas, with
+    identical types (integer) and optional status (not in ``required``).
 
     This is the symmetry contract — adding a slice arg to one surface and
-    not the others would silently regress to the pre-PR asymmetry.
+    not the others would silently regress to the pre-PR asymmetry. The
+    four surfaces were established by PR #409 (= read_file /
+    reyn_src_read / read_memory_body) and completed by #385 Q7
+    adoption (= read_tool_result).
     """
     from reyn.tools.file import _READ_FILE_PARAMETERS
     from reyn.tools.memory import _READ_MEMORY_BODY_PARAMETERS
+    from reyn.tools.read_tool_result import _READ_TOOL_RESULT_PARAMETERS
     from reyn.tools.reyn_src import _REYN_SRC_READ_PARAMETERS
 
     for label, schema in [
         ("read_file", _READ_FILE_PARAMETERS),
         ("reyn_src_read", _REYN_SRC_READ_PARAMETERS),
         ("read_memory_body", _READ_MEMORY_BODY_PARAMETERS),
+        ("read_tool_result", _READ_TOOL_RESULT_PARAMETERS),
     ]:
         props = schema["properties"]
         required = schema.get("required", [])

--- a/tests/test_read_tool_result_tool.py
+++ b/tests/test_read_tool_result_tool.py
@@ -189,3 +189,113 @@ def test_read_tool_result_without_media_store_degrades_with_error(tmp_path):
 
     assert result["status"] == "error"
     assert "MediaStore" in result["error"]
+
+
+# ── offset / limit line-slice (= PR #409 4-surface symmetry adoption, Q7) ──
+
+
+def test_read_tool_result_offset_only_skips_leading_lines(tmp_path):
+    """Tier 2: ``offset=N`` starts at line N (0-indexed), reads through
+    end-of-body. Mirrors ``read_file`` / ``reyn_src_read`` /
+    ``read_memory_body`` semantics introduced in PR #409.
+    """
+    store, path_ref = _populate_tool_result(
+        tmp_path, "L0\nL1\nL2\nL3\nL4\n",
+    )
+    ctx = _ctx_with_media_store(store)
+
+    result = asyncio.run(_handle({"path": path_ref, "offset": 2}, ctx))
+
+    assert result["status"] == "ok"
+    assert result["content"] == "L2\nL3\nL4\n"
+
+
+def test_read_tool_result_limit_only_takes_first_n(tmp_path):
+    """Tier 2: ``limit=N`` without ``offset`` takes the first N lines."""
+    store, path_ref = _populate_tool_result(
+        tmp_path, "L0\nL1\nL2\nL3\nL4\n",
+    )
+    ctx = _ctx_with_media_store(store)
+
+    result = asyncio.run(_handle({"path": path_ref, "limit": 2}, ctx))
+
+    assert result["status"] == "ok"
+    assert result["content"] == "L0\nL1\n"
+
+
+def test_read_tool_result_offset_and_limit_window(tmp_path):
+    """Tier 2: combining ``offset`` + ``limit`` returns the
+    ``[offset, offset+limit)`` line window.
+    """
+    store, path_ref = _populate_tool_result(
+        tmp_path, "L0\nL1\nL2\nL3\nL4\n",
+    )
+    ctx = _ctx_with_media_store(store)
+
+    result = asyncio.run(
+        _handle({"path": path_ref, "offset": 1, "limit": 2}, ctx),
+    )
+
+    assert result["status"] == "ok"
+    assert result["content"] == "L1\nL2\n"
+
+
+def test_read_tool_result_offset_past_eof_returns_empty(tmp_path):
+    """Tier 2: ``offset`` past the body's last line returns empty
+    content — never an error. Matches the past-EOF semantic of the
+    three sister read tools so the LLM detects out-of-range without a
+    structured failure path.
+    """
+    store, path_ref = _populate_tool_result(tmp_path, "L0\nL1\nL2\n")
+    ctx = _ctx_with_media_store(store)
+
+    result = asyncio.run(_handle({"path": path_ref, "offset": 99}, ctx))
+
+    assert result["status"] == "ok"
+    assert result["content"] == ""
+
+
+def test_read_tool_result_slice_then_max_bytes_compose(tmp_path):
+    """Tier 2: ``offset`` / ``limit`` (= line slice) are applied BEFORE
+    ``max_bytes`` (= byte cap) — the two axes compose. Verifies the
+    slice happens against the full body, then the resulting sliced
+    text is byte-capped if it still exceeds ``max_bytes``.
+
+    Scenario: 100 lines of 20-char content (= ~2000 bytes). offset=10,
+    limit=50 → sliced ~1000 bytes. max_bytes=300 → final 300 bytes of
+    the sliced window, ``truncated=True`` on the sliced size.
+    """
+    lines = [f"line {i:>3} content" for i in range(100)]  # 16-char each
+    body = "\n".join(lines) + "\n"
+    store, path_ref = _populate_tool_result(tmp_path, body)
+    ctx = _ctx_with_media_store(store)
+
+    result = asyncio.run(
+        _handle(
+            {"path": path_ref, "offset": 10, "limit": 50, "max_bytes": 300},
+            ctx,
+        ),
+    )
+
+    assert result["status"] == "ok"
+    # max_bytes hit, surfaces truncated=True.
+    assert result["truncated"] is True
+    assert result["max_bytes"] == 300
+    # content starts at offset=10 (= "line  10 content"), not the file head.
+    assert result["content"].startswith("line  10 content")
+    # content is exactly 300 bytes (= max_bytes cap on the sliced window).
+    assert len(result["content"].encode("utf-8")) == 300
+
+
+def test_read_tool_result_no_slice_args_is_unchanged_behaviour(tmp_path):
+    """Tier 2: omitting ``offset`` / ``limit`` preserves the prior
+    full-body / max_bytes-only behaviour — backwards-compatible.
+    """
+    store, path_ref = _populate_tool_result(tmp_path, "alpha\nbeta\ngamma\n")
+    ctx = _ctx_with_media_store(store)
+
+    result = asyncio.run(_handle({"path": path_ref}, ctx))
+
+    assert result["status"] == "ok"
+    assert result["content"] == "alpha\nbeta\ngamma\n"
+    assert result["truncated"] is False


### PR DESCRIPTION
**[e2e-coder]** — #385 Q7 adoption per frozen design contract (= comment 4514611036). Pre-implementation parallel work while sandbox_2 runs Step 2 measurement.

## Summary

- PR #409 established ``offset`` / ``limit`` line-slice on three "read one entry" surfaces: ``read_file``, ``reyn_src_read``, ``read_memory_body``.
- The fourth surface ``read_tool_result`` (= #385 PoC PR-D lazy-expand for path_ref previews) had only ``max_bytes``, creating an LLM-visible asymmetry ("this one tool reads differently").
- This PR adopts **Q7** from the #385 design contract: add optional ``offset`` / ``limit`` line-slice args with semantics identical to the other three surfaces.

## Composition rule

``slice → byte-cap``. The line-slice operates against the full body first; the resulting sliced content is then byte-capped by ``max_bytes`` if it still exceeds the cap. The two axes are orthogonal and can be combined (= window of lines, then byte cap on that window).

## Change shape

- ``src/reyn/tools/read_tool_result.py``:
  - ``_READ_TOOL_RESULT_PARAMETERS``: add ``offset`` + ``limit`` (integer, optional)
  - ``_READ_TOOL_RESULT_DESCRIPTION``: extend with slice contract
  - ``_handle``: line-slice between content read and ``max_bytes`` truncation
- ``tests/test_read_tool_result_tool.py``: +6 tests (offset-only / limit-only / window / past-EOF / slice+cap compose / unchanged-when-no-slice-args)
- ``tests/test_read_offset_limit_symmetry.py``: rename cross-surface test 3→4 surfaces, add read_tool_result to the invariant set

## Why this PR now (= pre-Step-2-results)

- Q7 is independent of cross-host RPC routing — it's a local-only schema + handler addition
- Completes the 4-surface symmetry contract established in PR #409
- Safe to land regardless of Step 2 outcome (= if Step 2 success → β core impl builds on this; if Step 2 reveals preview-driven hypothesis needs revision → this is still a useful symmetry fix in isolation)

## What's NOT in this PR (= β core impl scope, after Step 2 results)

- ``resource_uri`` / ``source_agent`` / ``source_chain_id`` path_ref fields (= sub-task 1 of β core impl, gated on Step 2)
- Cross-host RPC routing for ``read_tool_result`` (= sub-task 3, gated on Step 2)
- content_hash double verify (= sub-task 4, gated on Step 2)

## Test plan

- [x] ``pytest tests/test_read_tool_result_tool.py`` — 12/12 pass (6 new + 6 existing)
- [x] ``pytest tests/test_read_offset_limit_symmetry.py`` — 14/14 pass (1 cross-surface test now covers 4 surfaces)
- [x] ``pytest tests/`` (full suite) — 4595 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected (= ``test_legacy_no_media_store_path_returns_inline_content``, confirmed on main earlier today)
- [x] ``ruff check`` on all modified files — clean
- [ ] (manual) ``read_tool_result(path=..., offset=10, limit=5)`` against a large web_fetch result — verify LLM-visible slice behaviour. Not run; the test covers the contract.

## Design contract reference

Frozen state at #385 comment [4514611036](https://github.com/tya5/reyn/issues/385#issuecomment-4514611036). Q7 adoption + 4-surface symmetry was the explicit rationale, double-acked by lead-coder + me, then user 最終 OK 2026-05-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)