### PR TITLE
feat(tools): emit tool_result_read observability events (#385 β sub-task 2)

### DIFF
--- a/src/reyn/tools/read_tool_result.py
+++ b/src/reyn/tools/read_tool_result.py
@@ -84,13 +84,58 @@ _READ_TOOL_RESULT_PARAMETERS: dict[str, Any] = {
 }
 
 
+def _emit_event(ctx: ToolContext, **fields: Any) -> None:
+    """Emit a ``tool_result_read`` observability event, defensively.
+
+    Observability must not crash the handler — wrap in try/except so a
+    misconfigured / null events log can't break tool dispatch. The event
+    payload follows the #385 β sub-task 2 schema:
+
+    Required:
+      ``status``         — "ok" | "not_found" | "error"
+      ``identifier``     — the path or resource_uri the LLM supplied
+                           (empty when validation failed before either)
+      ``identifier_kind``— "path" | "resource_uri" | "missing"
+
+    On status="ok":
+      ``source_agent``   — extracted from resource_uri (= dispatcher target);
+                           "local" when the read went through ``path``
+      ``total_bytes``    — full body byte size before max_bytes cap
+      ``returned_bytes`` — bytes actually included in the response
+      ``sliced``         — True when offset/limit were applied
+      ``truncated``      — True when max_bytes truncation fired
+
+    On status="error":
+      ``error_kind``     — "missing_args" | "both_supplied" |
+                           "media_store_unconfigured" | "invalid_uri" |
+                           "cross_host_stub" | "path_traversal" | "other"
+      ``error``          — the message surfaced to the LLM
+    """
+    try:
+        ctx.events.emit("tool_result_read", **fields)
+    except Exception:
+        pass
+
+
+def _source_agent_from_uri(resource_uri: str) -> str | None:
+    """Extract the source_agent from a resource_uri for event tagging."""
+    from reyn.workspace.media_store import parse_resource_uri
+    parsed = parse_resource_uri(resource_uri)
+    return parsed[0] if parsed else None
+
+
 async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Read a tool-result file by project-relative path.
+    """Read a tool-result file by project-relative path or resource URI.
 
     Builds a legacy ``OpContext`` to access ``media_store`` (= same
     bridging pattern as ``web_fetch._handle``). When ``media_store`` is
     not configured (= legacy / non-multimodal session), surfaces a
     structured error rather than crashing.
+
+    Emits a ``tool_result_read`` event on every dispatch outcome (= ok /
+    not_found / each error kind) so observability + #385 measurement
+    can count expand frequency by identifier kind and source agent
+    without having to scrape the response surface.
     """
     from reyn.op_runtime.context import OpContext
     from reyn.permissions.permissions import PermissionDecl
@@ -98,24 +143,37 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     path = str(args.get("path", "") or "").strip()
     resource_uri = str(args.get("resource_uri", "") or "").strip()
 
+    # Identifier kind derivation (= used by every emit call below).
+    if resource_uri and not path:
+        identifier_kind = "resource_uri"
+    elif path and not resource_uri:
+        identifier_kind = "path"
+    elif path and resource_uri:
+        identifier_kind = "both"  # caller violation, validated below
+    else:
+        identifier_kind = "missing"
+    identifier = resource_uri or path
+
     # Exactly-one-of contract (= the schema description). Both / neither
     # surface as structured errors so the LLM can correct without crash.
     if not path and not resource_uri:
-        return {
-            "status": "error",
-            "error": (
-                "either path (project-relative under .reyn/tool-results/) "
-                "or resource_uri (reyn-tool-result://<agent>/<artifact>) "
-                "is required"
-            ),
-        }
+        err = (
+            "either path (project-relative under .reyn/tool-results/) "
+            "or resource_uri (reyn-tool-result://<agent>/<artifact>) "
+            "is required"
+        )
+        _emit_event(
+            ctx, status="error", error_kind="missing_args",
+            identifier_kind="missing", identifier="", error=err,
+        )
+        return {"status": "error", "error": err}
     if path and resource_uri:
-        return {
-            "status": "error",
-            "error": (
-                "pass exactly one of path or resource_uri, not both"
-            ),
-        }
+        err = "pass exactly one of path or resource_uri, not both"
+        _emit_event(
+            ctx, status="error", error_kind="both_supplied",
+            identifier_kind="both", identifier=identifier, error=err,
+        )
+        return {"status": "error", "error": err}
 
     rs = ctx.router_state
     if rs is not None and rs.op_context_factory is not None:
@@ -131,14 +189,16 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         )
 
     if legacy_ctx.media_store is None:
-        return {
-            "status": "error",
-            "error": (
-                "MediaStore is not configured for this session. "
-                "Tool-result expansion requires the multimodal media "
-                "storage layer (= reyn.local.yaml multimodal section)."
-            ),
-        }
+        err = (
+            "MediaStore is not configured for this session. "
+            "Tool-result expansion requires the multimodal media "
+            "storage layer (= reyn.local.yaml multimodal section)."
+        )
+        _emit_event(
+            ctx, status="error", error_kind="media_store_unconfigured",
+            identifier_kind=identifier_kind, identifier=identifier, error=err,
+        )
+        return {"status": "error", "error": err}
 
     # Same-host fs read for path; resource_uri dispatches through
     # ``read_tool_result_by_uri`` which raises ValueError on cross-host
@@ -151,13 +211,32 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             )
         else:
             content, found = legacy_ctx.media_store.read_tool_result(path)
-    except (PermissionError, ValueError) as exc:
+    except PermissionError as exc:
+        _emit_event(
+            ctx, status="error", error_kind="path_traversal",
+            identifier_kind=identifier_kind, identifier=identifier,
+            error=str(exc),
+        )
         return {"status": "error", "error": str(exc)}
+    except ValueError as exc:
+        # Heuristic kind classification from the message — keeps the
+        # event payload actionable for measurement (= "how many cross-
+        # host attempts vs malformed URIs?") without needing dispatcher-
+        # side error types.
+        msg = str(exc)
+        kind = "cross_host_stub" if "cross-host" in msg else "invalid_uri"
+        _emit_event(
+            ctx, status="error", error_kind=kind,
+            identifier_kind=identifier_kind, identifier=identifier,
+            error=msg,
+        )
+        return {"status": "error", "error": msg}
 
     if not found:
-        # Echo whichever identifier the LLM supplied so it can correlate
-        # the not_found with its prior request without bookkeeping.
-        identifier = resource_uri or path
+        _emit_event(
+            ctx, status="not_found",
+            identifier_kind=identifier_kind, identifier=identifier,
+        )
         return {
             "status": "not_found",
             "path": identifier,
@@ -189,23 +268,47 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
     encoded = content.encode("utf-8")
     total_bytes = len(encoded)
-    # Echo whichever identifier the LLM supplied so it can correlate
-    # the response with its prior request without bookkeeping (= same
-    # pattern as the not_found branch above).
-    identifier = resource_uri or path
+    # Identifier is already populated above (= echoed in not_found and
+    # event emissions); reuse the same value for the success response.
+    sliced = offset is not None or limit is not None
+    # source_agent extraction: cross-host fields exist on the path-ref only
+    # when the producing MediaStore was constructed with agent_name; when
+    # the LLM passed path (not resource_uri), the read went through the
+    # local store, so source = "local".
+    if resource_uri:
+        source_agent = _source_agent_from_uri(resource_uri) or "unknown"
+    else:
+        source_agent = "local"
+
     if max_bytes > 0 and total_bytes > max_bytes:
         # Truncate on a UTF-8 boundary by using ``errors="replace"``. The
         # LLM still gets the head of the body; the tail is reachable by
         # repeating the call with a higher ``max_bytes``.
-        truncated = encoded[:max_bytes].decode("utf-8", errors="replace")
+        truncated_str = encoded[:max_bytes].decode("utf-8", errors="replace")
+        _emit_event(
+            ctx, status="ok",
+            identifier_kind=identifier_kind, identifier=identifier,
+            source_agent=source_agent,
+            total_bytes=total_bytes,
+            returned_bytes=len(truncated_str.encode("utf-8")),
+            sliced=sliced, truncated=True,
+        )
         return {
             "status": "ok",
             "path": identifier,
-            "content": truncated,
+            "content": truncated_str,
             "truncated": True,
             "max_bytes": max_bytes,
             "total_bytes": total_bytes,
         }
+    _emit_event(
+        ctx, status="ok",
+        identifier_kind=identifier_kind, identifier=identifier,
+        source_agent=source_agent,
+        total_bytes=total_bytes,
+        returned_bytes=total_bytes,
+        sliced=sliced, truncated=False,
+    )
     return {
         "status": "ok",
         "path": identifier,

--- a/tests/test_read_tool_result_tool.py
+++ b/tests/test_read_tool_result_tool.py
@@ -33,13 +33,19 @@ from reyn.workspace.media_store import MediaStore, MediaStoreConfig
 
 
 class _StubEvents:
-    """Minimal stand-in for the events log — the read tool emits none,
-    but ToolContext requires the attribute.
-    """
-    def emit(self, *args, **kwargs) -> None:
-        pass
+    """Minimal stand-in for the events log.
 
-    subscribers: list = []
+    Captures emit calls so #385 β sub-task 2 tests can assert on the
+    ``tool_result_read`` observability event payload. Existing tests
+    that don't read the log are unaffected (= same constructor shape,
+    extra capture list is opt-in).
+    """
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+        self.subscribers: list = []
+
+    def emit(self, name: str, **kwargs) -> None:
+        self.emitted.append((name, kwargs))
 
 
 def _populate_tool_result(
@@ -54,17 +60,26 @@ def _populate_tool_result(
     return store, block["path"]
 
 
-def _ctx_with_media_store(media_store: MediaStore | None) -> ToolContext:
+def _ctx_with_media_store(
+    media_store: MediaStore | None, *, events: _StubEvents | None = None,
+) -> ToolContext:
     """Build a minimal router-caller ToolContext whose router_state
     factory hands back an OpContext carrying ``media_store``.
+
+    Optional ``events`` lets callers inject a shared ``_StubEvents``
+    instance — used by #385 β sub-task 2 tests to assert on emitted
+    ``tool_result_read`` payloads. When omitted, a fresh stub is
+    constructed so existing tests stay unaffected.
     """
     from reyn.op_runtime.context import OpContext
     from reyn.permissions.permissions import PermissionDecl
 
+    events_log = events or _StubEvents()
+
     def _factory() -> OpContext:
         return OpContext(
             workspace=None,
-            events=_StubEvents(),
+            events=events_log,
             permission_decl=PermissionDecl(),
             permission_resolver=None,
             skill_name="",
@@ -73,7 +88,7 @@ def _ctx_with_media_store(media_store: MediaStore | None) -> ToolContext:
         )
 
     return ToolContext(
-        events=_StubEvents(),
+        events=events_log,
         permission_resolver=None,
         workspace=None,
         caller_kind="router",
@@ -425,3 +440,187 @@ def test_read_tool_result_resource_uri_supports_offset_limit_slice(tmp_path):
 
     assert result["status"] == "ok"
     assert result["content"] == "L1\nL2\n"
+
+
+# ── tool_result_read event emission (#385 β core impl sub-task 2) ──────
+
+
+def _only_tool_result_read(events: _StubEvents) -> list[dict]:
+    """Filter the events log down to ``tool_result_read`` payloads.
+
+    Returns the kwargs dict from each emit call; the event name is
+    asserted on by checking the list is non-empty (= the handler made
+    at least one tool_result_read emit during this dispatch).
+    """
+    return [kw for name, kw in events.emitted if name == "tool_result_read"]
+
+
+def test_emits_event_on_success_with_path(tmp_path):
+    """Tier 2: a successful path-based read emits ``tool_result_read``
+    with status=ok, identifier_kind=path, source_agent=local, and
+    sliced/truncated False (= the basic-success payload sub-task 6
+    measurement will key off).
+    """
+    store, path_ref = _populate_tool_result(tmp_path, "hello\n")
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({"path": path_ref}, ctx))
+
+    emits = _only_tool_result_read(events)
+    assert len(emits) == 1
+    payload = emits[0]
+    assert payload["status"] == "ok"
+    assert payload["identifier_kind"] == "path"
+    assert payload["identifier"] == path_ref
+    assert payload["source_agent"] == "local"
+    assert payload["sliced"] is False
+    assert payload["truncated"] is False
+    assert payload["total_bytes"] == len("hello\n".encode("utf-8"))
+    assert payload["returned_bytes"] == payload["total_bytes"]
+
+
+def test_emits_event_on_success_with_resource_uri_carries_source_agent(tmp_path):
+    """Tier 2: a successful resource_uri read emits source_agent =
+    the agent extracted from the URI, not "local". Lets measurement
+    distinguish cross-host expand attempts from local ones.
+    """
+    store, block = _populate_with_agent_name(tmp_path, "researcher")
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({"resource_uri": block["resource_uri"]}, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["status"] == "ok"
+    assert payload["identifier_kind"] == "resource_uri"
+    assert payload["source_agent"] == "researcher"
+
+
+def test_emits_event_with_sliced_true_when_offset_or_limit(tmp_path):
+    """Tier 2: when offset / limit are supplied, ``sliced=True`` lets
+    the measurement pipeline count partial-read frequency separately
+    from full-body reads.
+    """
+    store, path_ref = _populate_tool_result(tmp_path, "L0\nL1\nL2\n")
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({"path": path_ref, "limit": 1}, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["sliced"] is True
+
+
+def test_emits_event_with_truncated_true_when_max_bytes_hit(tmp_path):
+    """Tier 2: when max_bytes truncation fires, ``truncated=True`` and
+    ``returned_bytes < total_bytes``. Measurement can flag "LLM may
+    need a follow-up call" from this signal alone.
+    """
+    store, path_ref = _populate_tool_result(tmp_path, "a" * 5000)
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({"path": path_ref, "max_bytes": 1000}, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["truncated"] is True
+    assert payload["total_bytes"] == 5000
+    assert payload["returned_bytes"] == 1000
+
+
+def test_emits_event_with_error_kind_missing_args(tmp_path):
+    """Tier 2: validation error from neither-arg surfaces in the event
+    as ``error_kind=missing_args`` so measurement can distinguish LLM
+    contract-violation errors from upstream failures.
+    """
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({}, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["status"] == "error"
+    assert payload["error_kind"] == "missing_args"
+    assert payload["identifier_kind"] == "missing"
+
+
+def test_emits_event_with_error_kind_both_supplied(tmp_path):
+    """Tier 2: validation error when both path and resource_uri are
+    given surfaces as ``error_kind=both_supplied``.
+    """
+    store, block = _populate_with_agent_name(tmp_path, "me")
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({
+        "path": block["path"],
+        "resource_uri": block["resource_uri"],
+    }, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["status"] == "error"
+    assert payload["error_kind"] == "both_supplied"
+    assert payload["identifier_kind"] == "both"
+
+
+def test_emits_event_with_error_kind_cross_host_stub(tmp_path):
+    """Tier 2: a cross-host resource_uri surfaces ``error_kind=
+    cross_host_stub`` so measurement can count "LLM tried cross-host
+    expand" attempts — exactly the signal sub-task 3 will need to
+    prioritise actual cross-host RPC enablement.
+    """
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="local",
+    )
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({
+        "resource_uri": "reyn-tool-result://remote/some.txt",
+    }, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["status"] == "error"
+    assert payload["error_kind"] == "cross_host_stub"
+    assert payload["identifier_kind"] == "resource_uri"
+
+
+def test_emits_event_with_error_kind_invalid_uri(tmp_path):
+    """Tier 2: a malformed resource_uri surfaces ``error_kind=
+    invalid_uri``, distinct from cross-host. Measurement can isolate
+    "LLM passed garbage" from "LLM tried real cross-host".
+    """
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="me",
+    )
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({"resource_uri": "not-a-uri"}, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["status"] == "error"
+    assert payload["error_kind"] == "invalid_uri"
+
+
+def test_emits_event_with_status_not_found(tmp_path):
+    """Tier 2: when the underlying file is missing (= deleted between
+    minting and read), the event surfaces ``status=not_found``
+    distinct from ``status=error`` — the file existed once, just isn't
+    there now.
+    """
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    store.tool_results_dir.mkdir(parents=True, exist_ok=True)
+    fake_rel = str(
+        (store.tool_results_dir / "deleted-file.txt").relative_to(tmp_path)
+    )
+    events = _StubEvents()
+    ctx = _ctx_with_media_store(store, events=events)
+
+    asyncio.run(_handle({"path": fake_rel}, ctx))
+
+    payload = _only_tool_result_read(events)[0]
+    assert payload["status"] == "not_found"
+    assert payload["identifier"] == fake_rel


### PR DESCRIPTION
**[e2e-coder]** — #385 β core impl **sub-task 2 of 6** (= same-host dispatch refinement, event emission layer). Builds on PR #425 (sub-task 1) which landed the wire shape.

## Summary

Adds a single ``tool_result_read`` observability event per ``read_tool_result`` dispatch so #385 measurement (= sub-task 6, sandbox_2 territory) can answer the questions Step 2 surfaced without scraping the response surface or correlating against ``web_fetch_completed`` traces.

## Event schema

Emitted on every dispatch outcome (= success / not_found / each error class) — one row per LLM call in the events log.

| Field | When | Notes |
|---|---|---|
| ``status`` | always | ``"ok"`` / ``"not_found"`` / ``"error"`` |
| ``identifier`` | always | The path or resource_uri the LLM supplied (empty when validation failed first) |
| ``identifier_kind`` | always | ``"path"`` / ``"resource_uri"`` / ``"missing"`` / ``"both"`` |
| ``source_agent`` | ok | ``"local"`` for path, extracted agent name for resource_uri |
| ``total_bytes`` / ``returned_bytes`` | ok | Pre-cap vs post-cap byte sizes |
| ``sliced`` | ok | True when offset/limit applied |
| ``truncated`` | ok | True when max_bytes truncation fired |
| ``error_kind`` | error | ``"missing_args"`` / ``"both_supplied"`` / ``"media_store_unconfigured"`` / ``"invalid_uri"`` / ``"cross_host_stub"`` / ``"path_traversal"`` |

## Why this shape

Measurement questions Step 2 raised that this enables:

- **"How often does LLM call read_tool_result vs punting?"** — count emissions vs total turns.
- **"Are LLM expands hitting same-host or cross-host?"** — group by ``source_agent``.
- **"Is cross-host stub the dominant error?"** — ``error_kind`` distribution. Drives sub-task 3 prioritization.
- **"Are slice args used?"** — ``sliced=True`` rate.

Single ``jq`` query against events.jsonl, no LLM trace correlation.

## Defensive emission

``_emit_event`` wraps ``ctx.events.emit`` in try/except so a null / misconfigured events log can't break the handler. Observability is best-effort.

## Change shape

- ``src/reyn/tools/read_tool_result.py``:
  - ``_emit_event`` helper (defensive wrap)
  - ``_source_agent_from_uri`` helper (= parse for event tag)
  - ``identifier_kind`` derivation at handler entry
  - Emit at every branch (= 7 emission sites)
- ``tests/test_read_tool_result_tool.py``:
  - Extend ``_StubEvents`` to capture emit calls
  - Refactor ``_ctx_with_media_store`` to accept optional shared events instance (= backward compat for existing tests)
  - +9 tests covering each emit branch + source_agent local vs remote + sliced / truncated flags

## Test plan

- [x] ``pytest tests/test_read_tool_result_tool.py`` — 26 / 26 pass (17 existing + 9 new event tests)
- [x] ``pytest tests/`` (full suite) — 4641 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No replay fixtures touched — schema (LLM-visible tool catalog) unchanged.

## Out of scope (= sub-task 3+)

- Cross-host RPC dispatch implementation (= sub-task 3 lifts ``cross_host_stub`` into real routing)
- content_hash double verify (= sub-task 4)
- Lifecycle / GC race degrade paths (= sub-task 5)
- Measurement script consuming these events (= sub-task 6, sandbox_2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)