### PR TITLE
feat(tui): ToolCallRow PoC for #427 (widget only, no wiring yet)

### DIFF
--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -1,0 +1,305 @@
+"""ToolCallRow — per tool_call inline widget for the conv pane (issue #427).
+
+PoC stage: widget shape + state transitions, no production wiring yet.
+A follow-up PR will:
+- emit per-op events from op_runtime (= ``tool_called`` / ``tool_completed``)
+- subscribe ChatLifecycleForwarder to those events
+- mount + drive ToolCallRow from the chat session
+
+Spec (= issue #427 L2):
+- 2 lines fixed, no wrap, terminal-width-adaptive truncation
+- Line 1: ``<state-glyph> <tool>(<args>)  · <elapsed>``
+- Line 2: ``  ⎿ <result snippet>``  (= only shown when result is present)
+- State transitions: running (●) → terminal (✓ / ✗ / ⊘) — frozen after
+- Elapsed updates while running, frozen at terminal time
+
+Caller contract:
+- Instantiate with ``tool_name`` + ``args_repr``.
+- Optionally call ``set_result(snippet)`` as preview data arrives.
+- Call ``finish_success()`` / ``finish_failure(reason)`` / ``finish_aborted(reason)``
+  exactly once on terminal state. After that, the widget is frozen and the
+  timer stops.
+
+Per ``feedback-tui-visibility-axis``: each ToolCallRow is a permanent chat
+event (= history-side), distinct from ephemeral runtime state (= phase /
+plan / current skill) which lives in the bottom strip / right panel.
+"""
+from __future__ import annotations
+
+import time
+
+from rich.cells import cell_len
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+from reyn.chat.tui._palette import _CORAL
+
+_TICK_INTERVAL_S = 0.5  # elapsed-time refresh rate
+
+# Match SkillActivityRow's amber / red thresholds so users build one
+# mental model for "this is taking a while" across both widgets.
+_ELAPSED_AMBER_S = 30.0
+_ELAPSED_RED_S = 60.0
+
+# Indent column for the result line (= ``  ⎿ ``). Two spaces aligns the
+# result under the tool-name column of line 1 in the typical Latin glyph
+# width; CJK / emoji shift this but ⎿ is unambiguous-narrow so the
+# anchor stays readable.
+_RESULT_INDENT = "  ⎿ "
+
+# Reserve cells on the right edge so the elapsed-time segment doesn't
+# clip behind the scrollbar / RichLog right-padding at 80-col widths.
+# Empirically the same 6-cell budget the cost-suffix uses (= conv pane
+# render_cost_suffix). Conservative — overrunning here would silently
+# eat the seconds digit.
+_RIGHT_MARGIN_CELLS = 6
+
+
+class ToolCallRow(Widget):
+    """One inline tool-call row that updates in-place until terminal state.
+
+    State machine:
+        running  → success (finish_success)
+        running  → failure (finish_failure)
+        running  → aborted (finish_aborted)
+
+    After any terminal call the widget freezes — further state changes are
+    ignored. The internal elapsed timer stops on terminal so completed
+    rows don't keep redrawing.
+    """
+
+    DEFAULT_CSS = """
+    ToolCallRow {
+        height: auto;
+        padding: 0 0;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        tool_name: str,
+        args_repr: str = "",
+        id: str | None = None,
+    ) -> None:
+        super().__init__(id=id)
+        self._tool_name = tool_name
+        self._args_repr = args_repr
+        self._result_snippet: str = ""
+
+        # Running state
+        self._start = time.monotonic()
+        self._running = True
+
+        # Terminal state
+        self._finished = False
+        self._success = True
+        self._aborted = False
+        self._reason: str = ""
+        self._frozen_elapsed: float | None = None
+
+        # DOM refs — populated in compose()
+        self._line1: Static | None = None
+        self._line2: Static | None = None
+
+    # ── Textual lifecycle ──────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        self._line1 = Static(id="tool_call_line1")
+        self._line2 = Static(id="tool_call_line2")
+        yield self._line1
+        yield self._line2
+
+    def on_mount(self) -> None:
+        self.set_interval(_TICK_INTERVAL_S, self._tick)
+        self._refresh()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def set_result(self, snippet: str) -> None:
+        """Update the result snippet shown on line 2.
+
+        Called either while running (= incremental preview) or just before
+        finish() (= final result preview). Empty string hides line 2.
+        Ignored after terminal state.
+        """
+        if self._finished:
+            return
+        self._result_snippet = snippet
+        self._refresh()
+
+    def finish_success(self, result_snippet: str | None = None) -> None:
+        """Transition to the success terminal state and stop the timer.
+
+        If ``result_snippet`` is provided, it replaces any pending result.
+        """
+        self._enter_terminal(success=True, reason="", result_snippet=result_snippet)
+
+    def finish_failure(self, reason: str = "", result_snippet: str | None = None) -> None:
+        """Transition to the failure terminal state and stop the timer."""
+        self._enter_terminal(success=False, reason=reason, result_snippet=result_snippet)
+
+    def finish_aborted(self, reason: str = "") -> None:
+        """Transition to the aborted terminal state and stop the timer."""
+        self._enter_terminal(
+            success=False,
+            reason=reason or "aborted",
+            result_snippet=None,
+            aborted=True,
+        )
+
+    # ── Internal rendering ─────────────────────────────────────────────────────
+
+    def _enter_terminal(
+        self,
+        *,
+        success: bool,
+        reason: str,
+        result_snippet: str | None,
+        aborted: bool = False,
+    ) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self._running = False
+        self._success = success
+        self._reason = reason
+        self._aborted = aborted
+        self._frozen_elapsed = time.monotonic() - self._start
+        if result_snippet is not None:
+            self._result_snippet = result_snippet
+        self._refresh()
+
+    def _tick(self) -> None:
+        if not self._running:
+            return
+        self._refresh()
+
+    def _elapsed_s(self) -> float:
+        if self._frozen_elapsed is not None:
+            return self._frozen_elapsed
+        return time.monotonic() - self._start
+
+    def _elapsed_str(self) -> str:
+        return f"{self._elapsed_s():.1f}s"
+
+    def _elapsed_style(self) -> str:
+        secs = self._elapsed_s()
+        if secs >= _ELAPSED_RED_S:
+            return "bold #ff6644"
+        if secs >= _ELAPSED_AMBER_S:
+            return "bold #ffaa44"
+        return "dim"
+
+    def _state_glyph(self) -> tuple[str, str]:
+        """Return ``(glyph, style)`` for the current state."""
+        if not self._finished:
+            return ("●", _CORAL)
+        if self._success:
+            return ("✓", "bold green")
+        if self._aborted:
+            return ("⊘", "dim #888888")
+        return ("✗", "bold red")
+
+    def _truncate_to_cells(self, text: str, max_cells: int) -> str:
+        """Truncate ``text`` to fit within ``max_cells`` display cells.
+
+        Cell-aware so CJK / emoji count as 2 cells per glyph. Appends an
+        ellipsis when truncation happened. Reserves the ellipsis cell so
+        the result fits within the budget.
+        """
+        if max_cells <= 0:
+            return ""
+        if cell_len(text) <= max_cells:
+            return text
+        ellipsis = "…"
+        budget = max_cells - cell_len(ellipsis)
+        if budget <= 0:
+            return ellipsis
+        out: list[str] = []
+        used = 0
+        for ch in text:
+            w = cell_len(ch)
+            if used + w > budget:
+                break
+            out.append(ch)
+            used += w
+        return "".join(out) + ellipsis
+
+    def _build_line1(self) -> Text:
+        """``<glyph> <tool>(<args>)  · <elapsed>`` — terminal-width-adaptive."""
+        t = Text()
+        glyph, glyph_style = self._state_glyph()
+        elapsed = self._elapsed_str()
+
+        # Compute right-edge reservation: elapsed segment + `  · ` prefix
+        # + right margin. The body (= glyph + tool + args) fills whatever
+        # remains.
+        try:
+            total_width = int(getattr(self.size, "width", 0))
+        except Exception:
+            total_width = 0
+        if total_width <= 0:
+            # Pre-mount (= self.size.width is 0) or measurement failure
+            # — fall back to a typical 80-cell terminal so the truncation
+            # arithmetic produces sensible budgets instead of zeroing the
+            # args field.
+            total_width = 80
+        elapsed_segment = f"  · {elapsed}"
+        elapsed_cells = cell_len(elapsed_segment)
+        body_budget = max(8, total_width - elapsed_cells - _RIGHT_MARGIN_CELLS)
+
+        # Body = glyph + " " + tool + "(" + args + ")"
+        # Truncation order: shrink args first (= most disposable).
+        glyph_with_space = f"{glyph} "
+        glyph_cells = cell_len(glyph_with_space)
+        tool_open = f"{self._tool_name}("
+        tool_close = ")"
+        tool_open_cells = cell_len(tool_open)
+        tool_close_cells = cell_len(tool_close)
+        args_budget = max(
+            0,
+            body_budget - glyph_cells - tool_open_cells - tool_close_cells,
+        )
+        args_display = self._truncate_to_cells(self._args_repr, args_budget)
+
+        t.append(glyph_with_space, style=glyph_style)
+        t.append(tool_open, style="bold" if not self._finished else "dim")
+        t.append(args_display, style="dim")
+        t.append(tool_close, style="bold" if not self._finished else "dim")
+        t.append(elapsed_segment, style=self._elapsed_style())
+        return t
+
+    def _build_line2(self) -> Text:
+        """``  ⎿ <result snippet>`` — empty Text when result not yet set."""
+        if not self._result_snippet:
+            return Text("")
+        try:
+            total_width = int(getattr(self.size, "width", 0))
+        except Exception:
+            total_width = 0
+        if total_width <= 0:
+            # Pre-mount (= self.size.width is 0) or measurement failure
+            # — fall back to a typical 80-cell terminal so the truncation
+            # arithmetic produces sensible budgets instead of zeroing the
+            # args field.
+            total_width = 80
+        body_budget = max(
+            8, total_width - cell_len(_RESULT_INDENT) - _RIGHT_MARGIN_CELLS,
+        )
+        snippet = self._truncate_to_cells(self._result_snippet, body_budget)
+        t = Text()
+        t.append(_RESULT_INDENT, style="dim #666666")
+        t.append(snippet, style="dim")
+        return t
+
+    def _refresh(self) -> None:
+        if self._line1 is not None:
+            self._line1.update(self._build_line1())
+        if self._line2 is not None:
+            self._line2.update(self._build_line2())
+
+
+__all__ = ["ToolCallRow"]

--- a/tests/cli/test_tool_call_row_poc.py
+++ b/tests/cli/test_tool_call_row_poc.py
@@ -1,0 +1,133 @@
+"""Tier 2: ToolCallRow widget shape + state transitions (issue #427 PoC).
+
+Pins the user-visible contract:
+
+1. Running: ``● <tool>(<args>)  · <elapsed>`` on line 1, empty line 2 until
+   ``set_result`` is called.
+2. ``set_result(snippet)`` populates line 2 with ``  ⎿ <snippet>``.
+3. Terminal states: ``finish_success`` → ``✓``, ``finish_failure`` → ``✗``,
+   ``finish_aborted`` → ``⊘``.
+4. Post-terminal: ``set_result`` and further ``finish_*`` calls are
+   ignored (= frozen).
+5. Long args are truncated with ``…`` to fit within terminal width.
+
+All assertions go through public render surfaces (= ``_build_line1().plain``
++ ``_build_line2().plain``) per CLAUDE.md testing policy ("NEVER assert
+on private state. Use the public surface or a snapshot()-style read").
+
+The widget is constructed without mounting it inside a Textual app —
+``_refresh`` returns early when its Static children are None, so the
+internal state can be driven directly against the public API and
+verified via the render helpers, the same way ``test_skill_activity_plan_step_persist``
+exercises ``SkillActivityRow``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _row(tool_name: str = "web_fetch", args_repr: str = "url=https://example.com"):
+    """Construct an unmounted ToolCallRow for direct API exercise."""
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+    return ToolCallRow(tool_name=tool_name, args_repr=args_repr)
+
+
+def test_running_line1_contains_glyph_tool_args_and_elapsed() -> None:
+    """Tier 2: initial running render carries all four primary segments."""
+    row = _row(tool_name="web_fetch", args_repr="url=https://example.com")
+    line1 = row._build_line1().plain
+    assert "●" in line1, "running state-glyph"
+    assert "web_fetch" in line1, "tool name"
+    assert "url=https://example.com" in line1, "args"
+    assert "s" in line1, "elapsed segment (e.g. '0.0s')"
+
+
+def test_line2_empty_until_set_result_called() -> None:
+    """Tier 2: line 2 is empty when no result snippet has arrived yet."""
+    row = _row()
+    assert row._build_line2().plain == ""
+    row.set_result("body length 1.2 KB")
+    line2 = row._build_line2().plain
+    assert "⎿" in line2, "result indent marker"
+    assert "body length 1.2 KB" in line2, "snippet present"
+
+
+def test_finish_success_transitions_to_check_glyph() -> None:
+    """Tier 2: success terminal renders ``✓`` instead of ``●``."""
+    row = _row()
+    row.finish_success(result_snippet="200 OK")
+    line1 = row._build_line1().plain
+    assert "✓" in line1
+    assert "●" not in line1
+    line2 = row._build_line2().plain
+    assert "200 OK" in line2
+
+
+def test_finish_failure_transitions_to_cross_glyph() -> None:
+    """Tier 2: failure terminal renders ``✗``."""
+    row = _row()
+    row.finish_failure(reason="timeout")
+    line1 = row._build_line1().plain
+    assert "✗" in line1
+    assert "●" not in line1
+
+
+def test_finish_aborted_transitions_to_circle_slash_glyph() -> None:
+    """Tier 2: aborted terminal renders ``⊘`` (= distinct from ✗)."""
+    row = _row()
+    row.finish_aborted()
+    line1 = row._build_line1().plain
+    assert "⊘" in line1
+    assert "✗" not in line1
+    assert "●" not in line1
+
+
+def test_post_terminal_set_result_and_finish_are_ignored() -> None:
+    """Tier 2: once terminal, further state mutations don't change render."""
+    row = _row()
+    row.finish_success(result_snippet="first")
+    line1_after_first = row._build_line1().plain
+    line2_after_first = row._build_line2().plain
+    row.set_result("second-result-should-be-ignored")
+    row.finish_failure(reason="this-should-also-be-ignored")
+    assert row._build_line1().plain == line1_after_first, (
+        "line 1 (= state glyph + elapsed) must be frozen"
+    )
+    assert row._build_line2().plain == line2_after_first, (
+        "line 2 (= result snippet) must be frozen"
+    )
+    assert "second-result-should-be-ignored" not in row._build_line2().plain
+    assert "✗" not in row._build_line1().plain
+
+
+def test_long_args_truncated_with_ellipsis_within_terminal_width() -> None:
+    """Tier 2: args that overflow the line collapse to an ``…`` suffix.
+
+    The widget's ``self.size.width`` is 0 (= not mounted), which the
+    truncation helper handles by falling back to an 80-cell target.
+    A 200-character args string at 80-cell width is guaranteed to
+    require truncation regardless of margin / glyph / elapsed sizing.
+    """
+    long_args = "url=" + ("a" * 200)
+    row = _row(tool_name="web_fetch", args_repr=long_args)
+    line1 = row._build_line1().plain
+    assert "…" in line1, "ellipsis appears when args overflow line width"
+    # The tool name + elapsed still survive truncation (= args is the
+    # disposable segment, never the framing).
+    assert "web_fetch" in line1
+    assert "s" in line1  # elapsed survives
+
+
+def test_result_snippet_truncated_when_long() -> None:
+    """Tier 2: long result snippets get the same ``…`` treatment on line 2."""
+    row = _row()
+    long_result = "x" * 200
+    row.set_result(long_result)
+    line2 = row._build_line2().plain
+    assert "…" in line2
+    assert "⎿" in line2  # indent marker preserved


### PR DESCRIPTION
**[tui-coder]** — PoC for issue #427 (TUI execution visibility).

Closes design phase L4 step (a): widget single-PR PoC. Production wiring is **deferred** to follow-up PRs in the wave (= issue #427 implementation plan steps 1-5).

## Summary

Lands ``ToolCallRow`` widget per issue #427 L2 spec:

```
● <tool>(<args>)               · 1.2s     ← line 1: glyph + tool + args + elapsed
  ⎿ <result snippet>                       ← line 2: ⎿ indent + result (when set)
```

- 2 lines fixed, no wrap
- Terminal-width-adaptive truncation (= cell-aware ellipsis)
- State transitions: ``running (●)`` → terminal ``✓ / ✗ / ⊘`` — frozen on terminal
- Pre-mount fallback to 80-cell target (= so args/result don't zero-out before layout)

Public API mirrors ``SkillActivityRow`` conventions:

| API | Behavior |
|---|---|
| ``ToolCallRow(tool_name=..., args_repr=...)`` | Construct + start elapsed timer |
| ``set_result(snippet)`` | Update line 2; ignored post-terminal |
| ``finish_success(result_snippet=None)`` | → ``✓``, frozen |
| ``finish_failure(reason="", ...)`` | → ``✗``, frozen |
| ``finish_aborted(reason="")`` | → ``⊘``, frozen |

## Scope (= PoC only)

| In | Out (= follow-up) |
|---|---|
| ✓ widget shape + state transitions | ✗ per-op event emission in op_runtime |
| ✓ Tier 2 tests via public render surface | ✗ ChatLifecycleForwarder per-op subscription |
| ✓ truncation + cell-aware sizing | ✗ conv pane mounting on tool_call lifecycle |
| ✓ 80-cell pre-mount fallback | ✗ AsyncStackPanel (= bottom strip) |
| | ✗ agents tab refactor (= phase / plan / nest depth) |

## Test plan

- [x] ruff check passes (widget + tests)
- [x] 8 Tier 2 tests in ``tests/cli/test_tool_call_row_poc.py`` 8/8 green
- [x] Public-surface assertions only (= per ``feedback_test_public_surface_not_private_state``): all checks read ``_build_line1().plain`` / ``_build_line2().plain``, no ``_field`` private state assertions
- [ ] (skipped — manual TUI verify not applicable; widget is not yet mounted anywhere in production. Real TUI verification arrives with follow-up PR step 3: ``mount + drive from conv pane``)

## Test coverage

1. Running render has glyph + tool + args + elapsed
2. Line 2 empty until ``set_result``
3. ``finish_success`` → ``✓``
4. ``finish_failure`` → ``✗``
5. ``finish_aborted`` → ``⊘``
6. Post-terminal ``set_result`` / ``finish_*`` ignored (frozen state)
7. Long args truncated with ``…``, framing preserved
8. Long result snippet truncated with ``…``, ``⎿`` indent preserved

## Wave context

issue #427 implementation plan:
1. **ToolCallRow widget** (= this PR)
2. Emit per-op ``tool_called`` / ``tool_completed`` events in op_runtime
3. Subscribe ChatLifecycleForwarder to those events
4. Mount + drive ToolCallRow from conv pane
5. AsyncStackPanel for bottom strip async stack
6. agents tab refactor for phase / plan / nest depth

Step 1 is intentionally minimal — design lock from issue #427 is the contract; this widget proves the shape works before the wave commits to event-source + integration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)