### PR TITLE
fix(router): wire read_tool_result dispatch — completes #385 PoC PR #424

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2220,6 +2220,14 @@ class RouterLoop:
         # that the read-only handlers don't consult (= behavior preserved).
         "reyn_src_list", "reyn_src_read",
         "web_search", "web_fetch",
+        # B49 Step 2 verify (2026-05-22, post-PR #424): `read_tool_result`
+        # was surfaced to the router LLM via `router_tools.build_tools()`
+        # E3, but execution dispatch was missing here. The LLM saw the
+        # tool, called it (= 2/3 shots in N=3 verify), then hit
+        # `{"error": "unhandled tool: read_tool_result"}` → router empty
+        # response → empty reply. Dispatch wiring belongs in the same
+        # registry-path family as web_fetch / read_file / recall.
+        "read_tool_result",
         # Phase 3.5-A+C — file cluster.  Handlers consume
         # RouterCallerState.op_context_factory (= host.make_router_op_context)
         # so op_runtime sees the operator-declared PermissionDecl /


### PR DESCRIPTION
**[dogfood-coder]** — PR #424 surfaced `read_tool_result` to the chat-router LLM via `router_tools.build_tools()` E3, but `router_loop.py:_REGISTRY_DISPATCH_TOOLS` (= the execution dispatch path) was missed. The LLM saw the tool and called it (= 2/3 shots in N=3), but the dispatch returned `{"error": "unhandled tool: read_tool_result"}` → `router_empty_response_detected` → empty A2A reply.

## Discovery via B50 readiness verification

User directive: `confidence 改善しない限り次 B50 はないよ。 patch切り分けで改善確認必須`. Per-patch trace-patch-replay verification was the path:

- Track 1 (deterministic, PR #411 effect): +3V at conf 0.95 — verdict logic confirms 3 scenarios now V
- Track 2 (sonnet sub-agent, PR #412 + #424 effect): re-ran B49 web_fetch scenarios × N=3 → uncovered that read_tool_result invocations returned `unhandled tool` errors

Without the user's "patch切り分け" discipline, this incomplete fix would have shipped to B50 batch unverified and produced flat ΔV.

## Fix

One-line: append `"read_tool_result"` to `_REGISTRY_DISPATCH_TOOLS` right after the web cluster (= shares the same `RouterCallerState.op_context_factory` lifecycle).

## Live verification (Step 2 smoke v9, N=3)

| Signal | v7/v8 (pre-fix) | v9 (post-fix) |
|--------|-----------------|---------------|
| `unhandled tool` errors | 2-3 per Scenario C run | **0** |
| Scenario C expand_rate | 0.78 (call attempted, dispatch failed) | **1.0** (all 3 expanded, dispatch succeeded) |
| Scenario C shot 1 reply length | empty / spawn-ack only | **1944 chars** substantive content from expanded body |
| Scenario C shot 2 reply | empty | 406 chars honest "info not present" after expand |
| B/D/E selective skip=1.0 | preserved | preserved |

## Test plan

- [x] `pytest -k "router_loop or read_tool"` — 117 pass.
- [x] Live smoke v9 N=3: 0 dispatch errors, expand path delivers full content.
- [ ] post-merge: B50 dogfood smoke confirms expand path stable across broader scenario mix.

## Meta

This is the second instance of dogfood-driven OS bug discovery in this session (paired with PR #412 MediaStore session factory gap). Memory `feedback_dogfood_uncovers_production_gap` documents the pattern: when a measurement metric pins at an extreme value across N sub-cases, suspect physical unreachability (= deployment / dispatch gap) before behavioral failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)