### PR TITLE
feat(op_runtime): per-op tool_called / tool_completed events (#427 L4 step 2)

### DIFF
--- a/src/reyn/op_runtime/__init__.py
+++ b/src/reyn/op_runtime/__init__.py
@@ -13,11 +13,14 @@ is call-site agnostic.
 """
 from __future__ import annotations
 
+import time
+import uuid
 from typing import Literal
 
 from reyn.schemas.models import ControlIROp
 
 from .context import OpContext
+from .registry import OpPurity, get_op_purity
 from .result import OpDenied, OpResult, OpSkipped
 
 
@@ -26,6 +29,72 @@ class OpDispatchError(RuntimeError):
 
 
 _PREPROCESSOR_FORBIDDEN_KINDS = frozenset({"ask_user"})
+
+# Max cell-width for ``args_summary`` / ``result_summary`` event payloads.
+# Bounded so the event log doesn't blow up on a 50 MB file content arg or
+# similar pathological payload; consumers (= TUI ToolCallRow) further
+# truncate to terminal width.
+_OP_SUMMARY_MAX_CHARS = 120
+
+# Fields that are typically multi-KB and not useful in a one-line summary.
+# Replaced with a ``<N chars>`` placeholder when present so the summary
+# stays readable and the event log stays small.
+_OP_ARG_BULKY_FIELDS = frozenset({
+    "content", "new_string", "old_string", "body", "preview",
+})
+
+
+def _summarize_op_args(op: ControlIROp) -> str:
+    """One-line repr of the op's user-visible args for event display.
+
+    Pydantic ``model_dump`` then formats key=value pairs, excluding bulky
+    free-form fields (= ``content`` etc) which are summarised as
+    ``<N chars>``. Bounded to ``_OP_SUMMARY_MAX_CHARS`` cells with ellipsis.
+    Best-effort: returns empty string on any error so the event still
+    fires.
+    """
+    try:
+        data = op.model_dump(exclude_none=True)
+    except Exception:
+        return ""
+    data.pop("kind", None)
+    parts: list[str] = []
+    for key, value in data.items():
+        if key in _OP_ARG_BULKY_FIELDS and isinstance(value, str) and len(value) > 24:
+            parts.append(f"{key}=<{len(value)} chars>")
+            continue
+        s = str(value)
+        if len(s) > 60:
+            s = s[:57] + "..."
+        parts.append(f"{key}={s}")
+    summary = ", ".join(parts)
+    if len(summary) > _OP_SUMMARY_MAX_CHARS:
+        summary = summary[: _OP_SUMMARY_MAX_CHARS - 1] + "…"
+    return summary
+
+
+def _summarize_op_result(result: dict) -> str:
+    """One-line repr of the op result dict for the ``tool_completed`` event.
+
+    Excludes bulky body fields (= same set as args). Bounded to
+    ``_OP_SUMMARY_MAX_CHARS``. Returns empty string when result has
+    nothing presentable.
+    """
+    if not isinstance(result, dict):
+        return ""
+    parts: list[str] = []
+    for key, value in result.items():
+        if key in _OP_ARG_BULKY_FIELDS and isinstance(value, str) and len(value) > 24:
+            parts.append(f"{key}=<{len(value)} chars>")
+            continue
+        s = str(value)
+        if len(s) > 60:
+            s = s[:57] + "..."
+        parts.append(f"{key}={s}")
+    summary = ", ".join(parts)
+    if len(summary) > _OP_SUMMARY_MAX_CHARS:
+        summary = summary[: _OP_SUMMARY_MAX_CHARS - 1] + "…"
+    return summary
 
 
 async def execute_op(
@@ -64,6 +133,47 @@ async def execute_op(
             "reason": "handler_not_implemented",
         }
 
+    # Per-op lifecycle events (issue #427 L4 step 2). ``tool_called`` fires
+    # before the handler runs; ``tool_completed`` fires on every terminal
+    # state (success / denied / skipped / failed). A per-call ``op_id``
+    # ties the two events together so consumers (= TUI ToolCallRow,
+    # post-hoc audit) can match start/end without ambiguity. Pure ops
+    # skip emission per the registry intent (= ``OP_PURITY.pure`` =
+    # no externally-observable side effect to disambiguate).
+    emit_lifecycle = get_op_purity(op.kind) is not OpPurity.pure
+    op_id = ""
+    started_at = 0.0
+    if emit_lifecycle:
+        op_id = uuid.uuid4().hex[:8]
+        started_at = time.monotonic()
+        ctx.events.emit(
+            "tool_called",
+            run_id=ctx.run_id,
+            skill=ctx.skill_name,
+            phase=ctx.current_phase,
+            kind=op.kind,
+            op_id=op_id,
+            args_summary=_summarize_op_args(op),
+        )
+
+    def _emit_completed(
+        *, status: str, result: dict | None, error: str = "",
+    ) -> None:
+        if not emit_lifecycle:
+            return
+        ctx.events.emit(
+            "tool_completed",
+            run_id=ctx.run_id,
+            skill=ctx.skill_name,
+            phase=ctx.current_phase,
+            kind=op.kind,
+            op_id=op_id,
+            status=status,
+            duration_s=max(0.0, time.monotonic() - started_at),
+            result_summary=_summarize_op_result(result) if result else "",
+            error=error,
+        )
+
     try:
         result = await handler(op, ctx, caller)
         path = getattr(op, "path", None)
@@ -75,6 +185,7 @@ async def execute_op(
             kind=op.kind,
             path=path,
         )
+        _emit_completed(status="success", result=result)
         return result
     except PermissionError as exc:
         path = getattr(op, "path", None)
@@ -87,12 +198,15 @@ async def execute_op(
             path=path,
             reason=str(exc),
         )
+        _emit_completed(status="denied", result=None, error=str(exc))
         return {"kind": op.kind, "status": "denied", "error": str(exc)}
     except OpSkipped as exc:
         ctx.events.emit("control_ir_skipped", kind=op.kind, reason=exc.reason)
+        _emit_completed(status="skipped", result=None, error=exc.reason)
         return {"kind": op.kind, "status": "skipped", "reason": exc.reason}
     except Exception as exc:
         ctx.events.emit("control_ir_failed", kind=op.kind, error=str(exc))
+        _emit_completed(status="failed", result=None, error=str(exc))
         return {"kind": op.kind, "status": "error", "error": str(exc)}
 
 

--- a/tests/test_op_runtime_tool_called_events.py
+++ b/tests/test_op_runtime_tool_called_events.py
@@ -1,0 +1,264 @@
+"""Tier 2: ``execute_op`` emits per-op ``tool_called`` / ``tool_completed``
+events (issue #427 L4 step 2).
+
+The TUI ToolCallRow widget (= PR #429 PoC) needs per-op lifecycle
+events to drive mount + state transitions. This module pins the
+event-emission contract so the forwarder + conv pane wiring (= L4
+steps 3-4) can reliably subscribe.
+
+Contract pinned here:
+
+1. Successful dispatch emits ``tool_called`` (before handler) and
+   ``tool_completed`` with ``status="success"`` (after handler).
+2. The ``op_id`` field matches between the start and end events so
+   consumers can pair start/end without ambiguity.
+3. ``args_summary`` is present on ``tool_called`` and captures
+   user-visible op fields (= excludes bulky body fields).
+4. ``result_summary`` is present on ``tool_completed`` success and
+   captures non-bulky result fields.
+5. ``duration_s`` is present + non-negative on ``tool_completed``.
+6. Pure ops (= ``OpPurity.pure``, e.g. ``lint``) skip lifecycle
+   emission entirely — keeps event log volume bounded on cheap ops.
+7. Failure paths (= ``OpSkipped`` / ``Exception``) still emit
+   ``tool_completed`` with ``status`` set to the failure mode.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.events.events import EventLog  # noqa: E402
+from reyn.op_runtime import execute_op  # noqa: E402
+from reyn.op_runtime.context import OpContext  # noqa: E402
+from reyn.op_runtime.result import OpSkipped  # noqa: E402
+from reyn.permissions.permissions import PermissionDecl  # noqa: E402
+from reyn.schemas.models import LintIROp, ShellIROp  # noqa: E402
+
+
+def _make_ctx(events: EventLog) -> OpContext:
+    """Minimal OpContext sufficient for execute_op's dispatch surface."""
+    return OpContext(
+        workspace=None,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        skill_name="test_skill",
+        run_id="test-run-1",
+        current_phase="resolve",
+    )
+
+
+def _events_of_type(events: EventLog, type_: str) -> list[dict]:
+    return [e.data for e in events.all() if e.type == type_]
+
+
+@pytest.fixture
+def temp_handler():
+    """Register a temporary handler for shell ops + clean up after.
+
+    The real handlers live in op_runtime submodules; for these tests
+    we want a deterministic handler that returns a known result dict
+    so the event payload assertions don't depend on subprocess output.
+    """
+    from reyn.op_runtime import _HANDLERS
+
+    saved_shell = _HANDLERS.get("shell")
+    yield
+    if saved_shell is not None:
+        _HANDLERS["shell"] = saved_shell
+    else:
+        _HANDLERS.pop("shell", None)
+
+
+def test_success_emits_tool_called_and_tool_completed_with_matching_op_id(
+    temp_handler,
+) -> None:
+    """Tier 2: success path emits both events; ``op_id`` ties them."""
+    from reyn.op_runtime import _HANDLERS
+
+    async def _stub_shell(op, ctx, caller):
+        return {"kind": "shell", "status": "ok", "exit_code": 0}
+
+    _HANDLERS["shell"] = _stub_shell
+
+    events = EventLog()
+    ctx = _make_ctx(events)
+    op = ShellIROp(kind="shell", cmd="echo hi")
+
+    asyncio.run(execute_op(op, ctx, caller="control_ir"))
+
+    called = _events_of_type(events, "tool_called")
+    completed = _events_of_type(events, "tool_completed")
+    assert len(called) == 1, "tool_called fires exactly once on success"
+    assert len(completed) == 1, "tool_completed fires exactly once on success"
+
+    start = called[0]
+    end = completed[0]
+    assert start["op_id"], "tool_called carries op_id"
+    assert start["op_id"] == end["op_id"], "op_id matches start/end"
+    assert start["kind"] == "shell"
+    assert end["kind"] == "shell"
+    assert end["status"] == "success"
+
+
+def test_tool_called_args_summary_includes_user_visible_fields(
+    temp_handler,
+) -> None:
+    """Tier 2: ``args_summary`` carries non-bulky op fields for display."""
+    from reyn.op_runtime import _HANDLERS
+
+    async def _stub_shell(op, ctx, caller):
+        return {"status": "ok"}
+
+    _HANDLERS["shell"] = _stub_shell
+
+    events = EventLog()
+    ctx = _make_ctx(events)
+    op = ShellIROp(kind="shell", cmd="ls -la")
+
+    asyncio.run(execute_op(op, ctx, caller="control_ir"))
+
+    called = _events_of_type(events, "tool_called")
+    summary = called[0]["args_summary"]
+    # The exact format isn't pinned; only that the cmd field shows up.
+    assert "cmd=" in summary
+    assert "ls -la" in summary
+
+
+def test_tool_completed_carries_duration_and_result_summary(
+    temp_handler,
+) -> None:
+    """Tier 2: ``tool_completed`` has duration + result summary on success."""
+    from reyn.op_runtime import _HANDLERS
+
+    async def _stub_shell(op, ctx, caller):
+        return {"kind": "shell", "status": "ok", "exit_code": 0, "stderr": ""}
+
+    _HANDLERS["shell"] = _stub_shell
+
+    events = EventLog()
+    ctx = _make_ctx(events)
+    op = ShellIROp(kind="shell", cmd="true")
+
+    asyncio.run(execute_op(op, ctx, caller="control_ir"))
+
+    end = _events_of_type(events, "tool_completed")[0]
+    assert "duration_s" in end
+    assert end["duration_s"] >= 0.0
+    # Result summary includes the status field; exact format not pinned.
+    assert "status=ok" in end["result_summary"] or "status" in end["result_summary"]
+
+
+def test_pure_op_kind_skips_lifecycle_emission(temp_handler) -> None:
+    """Tier 2: ``pure`` ops (e.g. ``lint``) do NOT emit tool_called/completed.
+
+    ``OP_PURITY.pure`` documents that no externally-observable side
+    effect distinguishes start/end, so the event log doesn't carry
+    these for cheap pure ops.
+    """
+    from reyn.op_runtime import _HANDLERS
+
+    async def _stub_lint(op, ctx, caller):
+        return {"status": "ok"}
+
+    saved = _HANDLERS.get("lint")
+    _HANDLERS["lint"] = _stub_lint
+    try:
+        events = EventLog()
+        ctx = _make_ctx(events)
+        op = LintIROp(kind="lint", skill_path="reyn/local/test_skill")
+        asyncio.run(execute_op(op, ctx, caller="control_ir"))
+        assert _events_of_type(events, "tool_called") == []
+        assert _events_of_type(events, "tool_completed") == []
+    finally:
+        if saved is not None:
+            _HANDLERS["lint"] = saved
+        else:
+            _HANDLERS.pop("lint", None)
+
+
+def test_op_skipped_emits_tool_completed_with_skipped_status(temp_handler) -> None:
+    """Tier 2: ``OpSkipped`` failure path still fires ``tool_completed``."""
+    from reyn.op_runtime import _HANDLERS
+
+    async def _stub_shell(op, ctx, caller):
+        raise OpSkipped("test reason")
+
+    _HANDLERS["shell"] = _stub_shell
+
+    events = EventLog()
+    ctx = _make_ctx(events)
+    op = ShellIROp(kind="shell", cmd="echo")
+
+    asyncio.run(execute_op(op, ctx, caller="control_ir"))
+
+    completed = _events_of_type(events, "tool_completed")
+    assert len(completed) == 1
+    assert completed[0]["status"] == "skipped"
+    assert completed[0]["error"] == "test reason"
+
+
+def test_generic_exception_emits_tool_completed_with_failed_status(
+    temp_handler,
+) -> None:
+    """Tier 2: unhandled exception path still fires ``tool_completed``."""
+    from reyn.op_runtime import _HANDLERS
+
+    async def _stub_shell(op, ctx, caller):
+        raise RuntimeError("boom")
+
+    _HANDLERS["shell"] = _stub_shell
+
+    events = EventLog()
+    ctx = _make_ctx(events)
+    op = ShellIROp(kind="shell", cmd="echo")
+
+    asyncio.run(execute_op(op, ctx, caller="control_ir"))
+
+    completed = _events_of_type(events, "tool_completed")
+    assert len(completed) == 1
+    assert completed[0]["status"] == "failed"
+    assert "boom" in completed[0]["error"]
+
+
+def test_bulky_args_field_replaced_with_size_placeholder(temp_handler) -> None:
+    """Tier 2: long ``content``-class fields collapse to ``<N chars>``.
+
+    Keeps the event log lean — a 50KB write payload should not balloon
+    every ``tool_called`` event with the full body.
+    """
+    from reyn.op_runtime import _HANDLERS
+    from reyn.schemas.models import FileIROp
+
+    async def _stub_file(op, ctx, caller):
+        return {"status": "ok"}
+
+    saved = _HANDLERS.get("file")
+    _HANDLERS["file"] = _stub_file
+    try:
+        events = EventLog()
+        ctx = _make_ctx(events)
+        op = FileIROp(
+            kind="file",
+            op="write",
+            path="/tmp/example.txt",
+            content="x" * 5000,
+        )
+        asyncio.run(execute_op(op, ctx, caller="control_ir"))
+        summary = _events_of_type(events, "tool_called")[0]["args_summary"]
+        assert "<5000 chars>" in summary, (
+            "bulky content field is summarised, not inlined"
+        )
+        assert "xxxx" not in summary, "raw body must not leak into summary"
+    finally:
+        if saved is not None:
+            _HANDLERS["file"] = saved
+        else:
+            _HANDLERS.pop("file", None)


### PR DESCRIPTION
**[tui-coder]** — issue #427 L4 step 2 of 6.

Lands per-op lifecycle event emission for the TUI ToolCallRow widget (= PR #429 PoC) to consume. No TUI changes yet — those come in subsequent wave PRs (steps 3-6).

## Summary

``execute_op`` (= ``op_runtime.__init__``) now emits ``tool_called`` before the handler and ``tool_completed`` after every terminal state:

```python
# tool_called
{run_id, skill, phase, kind, op_id, args_summary}

# tool_completed
{run_id, skill, phase, kind, op_id, status, duration_s,
 result_summary, error}
```

- **``op_id``** (= ``uuid4().hex[:8]``) ties start/end together
- **``status``** = ``success`` / ``denied`` / ``skipped`` / ``failed`` (= 4 terminal modes the dispatcher already handles)
- **Existing events unchanged** — ``permission_granted`` / ``permission_denied`` / ``control_ir_skipped`` / ``control_ir_failed`` remain for backward compat
- **Pure ops skip emission** per ``OpPurity.pure`` registry intent (= no externally-observable distinction, bounds event log volume)
- **Bulky fields collapsed** to ``<N chars>`` placeholder in ``args_summary`` / ``result_summary`` (= 50KB write payload doesn't bloat the event log)

## Test plan

- [x] ruff check passes (source + tests)
- [x] 7 new Tier 2 tests in ``tests/test_op_runtime_tool_called_events.py`` 7/7 green
- [x] Existing op_runtime tests (file/mkdir/move/stat + mcp progress + fp0016 agent_id + act_executed) 41+5 = 46/46 green (= no regression on existing event flows)
- [ ] (skipped — manual TUI verify not applicable; widget consumption arrives with follow-up steps 3-4)

## Test coverage

1. Success path emits both events with matching ``op_id``
2. ``args_summary`` captures user-visible op fields (e.g. ``cmd=ls -la``)
3. ``tool_completed`` carries ``duration_s`` + ``result_summary``
4. Pure op kinds (``lint``) skip lifecycle emission entirely
5. ``OpSkipped`` failure path emits ``tool_completed`` with ``status=skipped``
6. Unhandled ``Exception`` emits ``tool_completed`` with ``status=failed``
7. Bulky args fields (e.g. 5000-char file content) collapse to ``<5000 chars>``

## Wave context

issue #427 L4 plan:
1. ✓ ToolCallRow widget (= PR #429, merged)
2. ✓ Emit per-op events in op_runtime (= **this PR**)
3. Subscribe ChatLifecycleForwarder to those events
4. Mount + drive ToolCallRow from conv pane
5. AsyncStackPanel for bottom strip async stack
6. agents tab refactor for phase / plan / nest depth

Step 2 lands the backend half; steps 3-4 wire the existing ToolCallRow widget to consume these events. No TUI integration in this PR keeps the diff small + reviewable independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)