### PR TITLE
docs(media-store): document Phase 1 lifecycle + pin no-auto-GC invariant (#385 β sub-task 5)

### DIFF
--- a/src/reyn/workspace/media_store.py
+++ b/src/reyn/workspace/media_store.py
@@ -26,11 +26,34 @@ synthetic follow-up builder) reads the path, encodes, and embeds the
 binary as a data URL ONLY when sending to the model. Storage stays
 light; the LLM sees the materialised form.
 
-Out of scope for PR-C (F1-B):
-  - Preview generator (= deferred to PR-D / #385 PoC).
-  - ``read_tool_result(path)`` action (= deferred to PR-D).
-  - Cleanup policy (TTL / max-N / session boundary) — files accumulate
-    until the user deletes them. Deferred to PR-D.
+Lifecycle policy (#385 β core impl sub-task 5, 2026-05-22 frozen
+contract Phase 1 = "(a) Persistent until user delete"):
+
+  - **No auto-GC.** Files written by ``save_*`` remain on disk until a
+    user / operator deletes them out-of-band (= ``rm``, file explorer,
+    cleanup script). The MediaStore class does NOT enforce TTL,
+    max-N, session-end cleanup, or any other automatic eviction.
+  - **Cross-turn / cross-session re-access supported.** A path-ref
+    minted in user turn 1 remains valid in user turn 2 / next chat
+    session / a forwarded A2A peer's expand — the file is still there.
+    (See Q1 of the frozen contract: ``agent_id = agent name`` durable
+    identity, not per-turn ``chain_id``.)
+  - **Disk usage grows unboundedly.** Documented operational caveat —
+    operators are expected to ``ls -la .reyn/tool-results/`` and clean
+    up periodically. The browsable filename convention makes manual
+    audit straightforward.
+  - **Phase 2 reservation.** When measurement surfaces a real disk
+    pressure or stale-handle problem (= not just hypothetical), Phase 2
+    adds a config-driven policy: TTL / LRU / session-end / mixed. The
+    reyn.yaml ``multimodal:`` block is the natural insertion point;
+    no schema reservation made today (= YAGNI). The ``MediaStoreConfig``
+    dataclass is the future extension surface.
+
+Out of scope (= future work):
+  - Phase 2 cleanup policy (= TTL / max-N / session boundary). Trigger
+    is measurement evidence, not hypothesis.
+  - Cross-host RPC dispatcher for ``resource_uri`` (= #385 β core
+    impl sub-task 3, pending scheme arbitration).
 """
 from __future__ import annotations
 
@@ -99,6 +122,15 @@ class MediaStoreConfig:
     convention chosen in issue #383 / #385:
         ``.reyn/media``        for image binary
         ``.reyn/tool-results`` for text-y tool result dumps
+
+    Phase 1 (= "(a) Persistent until user delete", #385 β sub-task 5):
+    no cleanup-policy fields here today — the storage is intentionally
+    unbounded, audit is via on-disk inspection. Phase 2 (= TTL / max-N /
+    session-end / mixed) extends this dataclass when measurement
+    surfaces a real disk-pressure or stale-handle problem. The
+    extension surface is documented to keep the future addition out of
+    the public-API surprise zone, but no fields are reserved today
+    (= YAGNI; field shape is a Phase 2 design decision).
     """
     media_dir: str = ".reyn/media"
     tool_results_dir: str = ".reyn/tool-results"

--- a/tests/test_media_store.py
+++ b/tests/test_media_store.py
@@ -408,3 +408,91 @@ def test_agent_name_property_returns_set_identity(tmp_path):
     )
     assert no_id.agent_name is None
     assert with_id.agent_name == "alpha"
+
+
+# ── Lifecycle Phase 1 = "(a) Persistent until user delete" (sub-task 5) ──
+#
+# These tests pin the contract that MediaStore DOES NOT auto-GC. Future
+# Phase 2 will add TTL / LRU / session-end policies as opt-in config; until
+# then the storage is intentionally unbounded so cross-turn / cross-session
+# re-access of a path-ref keeps working. Regressing this invariant would
+# silently break the Q1 (= durable agent identity) contract too — a
+# path-ref whose source_agent / agent_name is stable but whose file got
+# auto-deleted would surface as ``not_found`` to consumers that expect
+# Phase 1 semantics.
+
+
+def test_saved_tool_result_persists_across_independent_store_instances(tmp_path):
+    """Tier 2: Phase 1 invariant — a file written by one MediaStore
+    instance is still readable by a separately-constructed instance on
+    the same project root. No constructor-time / process-start cleanup.
+
+    Simulates the cross-session re-access scenario: producer agent's
+    session ends, file stays, a new session (or a different agent in
+    the same project) constructs a fresh MediaStore and re-reads.
+    """
+    producer = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="producer",
+    )
+    block = producer.save_tool_result("persisted body\n", mime_type="text/plain")
+
+    # Drop the producer reference; construct a fresh store on the same root.
+    del producer
+    consumer = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="consumer",
+    )
+    body, found = consumer.read_tool_result(block["path"])
+    assert found is True
+    assert body == "persisted body\n"
+
+
+def test_multiple_saved_tool_results_all_retained(tmp_path):
+    """Tier 2: Phase 1 invariant — MediaStore retains every file written,
+    no implicit eviction. Saving N entries leaves N files on disk and
+    each remains readable. Pins the "no LRU / max-N" Phase 1 commitment.
+
+    Phase 2 (= bounded LRU / TTL) would change this; the test will
+    need an explicit policy=Phase1 marker then. Today the unbounded
+    behaviour is the contract.
+    """
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="me",
+    )
+    blocks = [
+        store.save_tool_result(f"entry {i}\n", mime_type="text/plain", seq=i)
+        for i in range(1, 11)
+    ]
+    # Every file present on disk + readable.
+    for i, block in enumerate(blocks, start=1):
+        body, found = store.read_tool_result(block["path"])
+        assert found is True, f"entry {i} was evicted"
+        assert body == f"entry {i}\n"
+    # Directory listing has all 10 files (= no auto-cleanup).
+    files = list(store.tool_results_dir.iterdir())
+    assert len(files) == 10
+
+
+def test_saved_file_survives_when_no_one_reads_for_a_while(tmp_path):
+    """Tier 2: Phase 1 invariant — passive time does NOT cause eviction.
+
+    Synthesises an "old" file by backdating its mtime to a year ago,
+    then confirms the file is still found by read_tool_result. Pins
+    the "no TTL" Phase 1 commitment so any future change that adds a
+    time-based check (= Phase 2 trigger) is a deliberate contract
+    change, not an accidental regression.
+    """
+    import os
+    import time
+
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="me",
+    )
+    block = store.save_tool_result("old body\n", mime_type="text/plain")
+    full_path = tmp_path / block["path"]
+    # Backdate mtime + atime to ~1 year ago.
+    one_year_ago = time.time() - (365 * 24 * 60 * 60)
+    os.utime(full_path, (one_year_ago, one_year_ago))
+
+    body, found = store.read_tool_result(block["path"])
+    assert found is True
+    assert body == "old body\n"


### PR DESCRIPTION
**[e2e-coder]** — #385 β core impl **sub-task 5 of 6** (= lifecycle Phase 1 (a) "Persistent until user delete"). Doc-only + invariant tests. The current MediaStore already IS Phase 1 (= no TTL, no LRU, no session-end GC), so this sub-task **formalises the contract** and **pins the invariant against future regressions** rather than adding new behaviour.

## Why "no auto-GC" needs a pinning test

Phase 2 is genuine future work — when added (= TTL / LRU / session-end / mixed policy), it WILL be a deliberate contract change. But until then, a well-meaning refactor could accidentally introduce an "obvious" cleanup pass (= "this dir is unbounded, let me prune entries older than 1 day") and silently break the cross-turn / cross-session re-access guarantee that Q1 (= durable agent identity) implicitly relies on.

The three tests pin:
- **Cross-instance persistence** — simulates session restart (= new MediaStore on same root reads old file)
- **No implicit LRU / max-N** — 10 entries all retained simultaneously
- **No implicit TTL** — file backdated 1 year still readable

Any future Phase 2 PR that adds policy must explicitly mark these tests as Phase-2 trigger rather than silently breaking them — making the change visible at review.

## Change shape

- ``src/reyn/workspace/media_store.py``:
  - Module docstring: new "Lifecycle policy" section documenting Phase 1 contract + Phase 2 reservation
  - ``MediaStoreConfig`` docstring: Phase 2 extension surface note
  - "Out of scope" section: replace stale "deferred to PR-D" with current forward-pointer (= sub-task 3 pending scheme arbitration)
- ``tests/test_media_store.py``: +3 Phase-1 invariant tests

## Test plan

- [x] ``pytest tests/test_media_store.py`` — 37/37 pass (34 existing + 3 new)
- [x] ``pytest tests/`` (full suite) — 4658 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No schema / wire-shape change; no fixtures touched.

## Why doc-only + pinning is enough for sub-task 5

Per the design contract Phase 1 = "(a) Persistent until user delete":
- No auto-GC ← already the implementation
- Cross-turn / cross-session re-access ← already works (= ties into Q1 durable identity)
- Disk usage grows unboundedly ← documented operational caveat
- Phase 2 reservation ← documented extension surface, no fields reserved (YAGNI)

There is no NEW behaviour to add at Phase 1; the work is making the contract visible + un-regressable.

## Out of scope (= still pending)

- Sub-task 3: cross-host RPC dispatch (= pending scheme refinement arbitration on #385, comment 4516036105)
- Phase 2 policy implementation (= trigger is measurement evidence, not hypothesis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)