### PR TITLE
feat(forwarder): relay tool-call lifecycle events to outbox (#427 L4 step 3)

### DIFF
--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -247,6 +247,108 @@ class ChatEventForwarder:
             source_run_id=data.get("run_id"),
         )
 
+    # ── Tool-call lifecycle events (issue #427 L4 step 3) ─────────────────
+    # Forward the existing ``dispatch/dispatcher.py`` emissions to outbox
+    # messages so the conv pane can mount per-tool_call ToolCallRow widgets
+    # (= step 4 wires the consumer). These three handlers complement the
+    # phase / skill_run / workflow handlers above and intentionally share
+    # the same fire-and-forget + ``parent_run_id`` provenance discipline.
+
+    def on_tool_called(self, data: dict) -> None:
+        """Bridge ``dispatch_tool``'s pre-event into a ``tool_call_started``
+        outbox message.
+
+        Source schema (= ``dispatch/dispatcher.py:200``):
+            {caller_kind, caller_id, tool, chain_id, args, args_hash}
+
+        ``args_hash`` is the deterministic correlation id we hand to the
+        TUI widget so it can match the eventual ``tool_call_completed`` /
+        ``tool_call_failed`` to this mount call. Args themselves go in
+        meta so the renderer can build a short args_repr.
+        """
+        self._enqueue_tool_call(
+            kind="tool_call_started",
+            text=str(data.get("tool", "")),
+            data=data,
+            extra_meta={"args": data.get("args")},
+        )
+
+    def on_tool_returned(self, data: dict) -> None:
+        """Bridge ``dispatch_tool``'s post-event into a ``tool_call_completed``
+        outbox message.
+
+        Source schema (= ``dispatch/dispatcher.py:262``):
+            {caller_kind, caller_id, tool, chain_id, args_hash, result}
+
+        The full result dict is forwarded in meta so the renderer can
+        synthesise a short result preview (= the TUI's truncation logic
+        already handles cell-aware ellipsis).
+        """
+        self._enqueue_tool_call(
+            kind="tool_call_completed",
+            text=str(data.get("tool", "")),
+            data=data,
+            extra_meta={"result": data.get("result")},
+        )
+
+    def on_tool_failed(self, data: dict) -> None:
+        """Bridge ``dispatch_tool``'s failure event into a ``tool_call_failed``
+        outbox message.
+
+        Source schema (= ``dispatch/dispatcher.py:222``):
+            {caller_kind, caller_id, tool, chain_id, args_hash, error_kind, message}
+        """
+        self._enqueue_tool_call(
+            kind="tool_call_failed",
+            text=str(data.get("tool", "")),
+            data=data,
+            extra_meta={
+                "error_kind": data.get("error_kind"),
+                "error_message": data.get("message"),
+            },
+        )
+
+    def _enqueue_tool_call(
+        self,
+        *,
+        kind: str,
+        text: str,
+        data: dict,
+        extra_meta: dict,
+    ) -> None:
+        """Shared enqueue path for the three tool-call lifecycle outbox kinds.
+
+        Carries the same ``run_id`` / ``parent_run_id`` provenance the
+        ``_enqueue`` helper builds for trace messages so consumers can
+        attribute each tool-call row to its owning skill thread. Adds
+        ``tool`` + ``args_hash`` to every message — together they form
+        the (tool, op_id) correlation key the TUI widget keys off of.
+        """
+        source_run_id = data.get("run_id")
+        effective_run_id = source_run_id or self.run_id
+        meta: dict = {"skill_name": self.skill_name}
+        if effective_run_id:
+            meta["run_id"] = effective_run_id
+            meta["run_id_short"] = effective_run_id[-4:]
+        if (
+            source_run_id is not None
+            and self.run_id is not None
+            and source_run_id != self.run_id
+        ):
+            meta["parent_run_id"] = self.run_id
+        # Stable across the three lifecycle phases so the consumer can
+        # pair start/end/fail without ambiguity. Falls back to None when
+        # the source event didn't include a hash (= shouldn't happen but
+        # is non-fatal — consumer treats missing op_id as "no pairing").
+        meta["tool"] = data.get("tool")
+        meta["op_id"] = data.get("args_hash")
+        meta["chain_id"] = data.get("chain_id")
+        meta.update(extra_meta)
+        try:
+            self.outbox.put_nowait(OutboxMessage(kind=kind, text=text, meta=meta))
+        except asyncio.QueueFull:
+            pass
+
     def _enqueue(self, text: str, *, source_run_id: str | None = None) -> None:
         # Fire-and-forget: trace messages are advisory, never block the skill.
         #

--- a/tests/test_forwarder_tool_call_events.py
+++ b/tests/test_forwarder_tool_call_events.py
@@ -1,0 +1,194 @@
+"""Tier 2: ChatEventForwarder relays tool-call lifecycle events to outbox.
+
+issue #427 L4 step 3 — forwarder subscribes to the existing
+``dispatch/dispatcher.py`` ``tool_called`` / ``tool_returned`` /
+``tool_failed`` events and emits ``OutboxMessage`` (kind=
+``tool_call_started`` / ``tool_call_completed`` / ``tool_call_failed``)
+so the conv pane (= step 4) can mount + drive ToolCallRow widgets.
+
+Contract pinned here:
+
+1. ``on_tool_called`` enqueues ``OutboxMessage(kind="tool_call_started")``
+   with the tool name as text + ``op_id`` (= source ``args_hash``) in meta.
+2. ``on_tool_returned`` enqueues ``tool_call_completed`` with result in meta.
+3. ``on_tool_failed`` enqueues ``tool_call_failed`` with error_kind / message
+   in meta.
+4. The same ``op_id`` flows across the three lifecycle phases for a
+   given tool call so the consumer can correlate them.
+5. Standard provenance fields (``run_id``, ``parent_run_id``,
+   ``skill_name``) appear in meta — same shape as ``_enqueue`` for
+   trace messages.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.forwarder import ChatEventForwarder  # noqa: E402
+from reyn.schemas.models import Event  # noqa: E402
+
+
+def _drain(q: asyncio.Queue) -> list:
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+def test_on_tool_called_enqueues_tool_call_started_outbox_message() -> None:
+    """Tier 2: ``on_tool_called`` emits ``OutboxMessage(kind='tool_call_started')``."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="tool_called",
+        data={
+            "caller_kind": "skill_phase",
+            "caller_id": "child-run-1",
+            "tool": "read_file",
+            "chain_id": "chain-abc",
+            "args": {"path": "/tmp/example.txt"},
+            "args_hash": "hash-xyz",
+            "run_id": "child-run-1",
+        },
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert msg.kind == "tool_call_started"
+    assert msg.text == "read_file"
+    assert msg.meta["op_id"] == "hash-xyz"
+    assert msg.meta["tool"] == "read_file"
+    assert msg.meta["args"] == {"path": "/tmp/example.txt"}
+
+
+def test_on_tool_returned_enqueues_tool_call_completed_with_result_in_meta() -> None:
+    """Tier 2: ``on_tool_returned`` emits ``tool_call_completed`` with result."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="tool_returned",
+        data={
+            "caller_kind": "skill_phase",
+            "caller_id": "child-run-2",
+            "tool": "web_fetch",
+            "chain_id": "chain-abc",
+            "args_hash": "hash-fetch",
+            "result": {"status": "ok", "preview": "200 OK 1.2KB"},
+            "run_id": "child-run-2",
+        },
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert msg.kind == "tool_call_completed"
+    assert msg.text == "web_fetch"
+    assert msg.meta["op_id"] == "hash-fetch"
+    assert msg.meta["result"] == {"status": "ok", "preview": "200 OK 1.2KB"}
+
+
+def test_on_tool_failed_enqueues_tool_call_failed_with_error_in_meta() -> None:
+    """Tier 2: ``on_tool_failed`` emits ``tool_call_failed`` with error fields."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="tool_failed",
+        data={
+            "caller_kind": "skill_phase",
+            "caller_id": "child-run-3",
+            "tool": "shell",
+            "chain_id": "chain-abc",
+            "args_hash": "hash-shell",
+            "error_kind": "permission_denied",
+            "message": "shell outside cwd: /etc/passwd",
+            "run_id": "child-run-3",
+        },
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert msg.kind == "tool_call_failed"
+    assert msg.text == "shell"
+    assert msg.meta["op_id"] == "hash-shell"
+    assert msg.meta["error_kind"] == "permission_denied"
+    assert msg.meta["error_message"] == "shell outside cwd: /etc/passwd"
+
+
+def test_op_id_correlates_across_three_lifecycle_events() -> None:
+    """Tier 2: same ``args_hash`` source → same ``op_id`` across phases.
+
+    Lets the TUI consumer match start → end without ambiguity even when
+    multiple tool calls are in flight concurrently.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+
+    fwd(Event(type="tool_called", data={
+        "tool": "read_file", "args_hash": "matched-id",
+        "args": {"path": "/x"}, "run_id": "r1",
+    }))
+    fwd(Event(type="tool_returned", data={
+        "tool": "read_file", "args_hash": "matched-id",
+        "result": {"status": "ok"}, "run_id": "r1",
+    }))
+    fwd(Event(type="tool_failed", data={
+        "tool": "read_file", "args_hash": "matched-id",
+        "error_kind": "exception", "message": "ignored",
+        "run_id": "r1",
+    }))
+
+    msgs = _drain(q)
+    assert len(msgs) == 3
+    assert all(m.meta["op_id"] == "matched-id" for m in msgs)
+
+
+def test_sub_skill_attribution_stamps_parent_run_id_on_tool_call_messages() -> None:
+    """Tier 2: when source run_id differs from forwarder's own, stamp parent_run_id.
+
+    Same provenance discipline as ``_enqueue`` for trace messages so TUI
+    consumers can render nested tool-call rows under their parent skill
+    when a sub-skill spawned via ``run_skill`` issues its own tool calls.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("parent_skill", q, run_id="parent-run")
+    fwd(Event(type="tool_called", data={
+        "tool": "read_file", "args_hash": "h1",
+        "args": {"path": "/x"}, "run_id": "child-run",
+    }))
+    msg = _drain(q)[0]
+    assert msg.meta["run_id"] == "child-run"
+    assert msg.meta["parent_run_id"] == "parent-run"
+
+
+def test_run_id_short_appears_for_compact_display() -> None:
+    """Tier 2: ``run_id_short`` (last 4 chars) lands in meta for compact prefix."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(type="tool_called", data={
+        "tool": "read_file", "args_hash": "h",
+        "args": {}, "run_id": "20260522T123456_skill_abcdEFGH",
+    }))
+    msg = _drain(q)[0]
+    assert msg.meta["run_id_short"] == "EFGH"
+
+
+def test_missing_args_hash_does_not_crash_and_uses_none_op_id() -> None:
+    """Tier 2: degrade-safe when source event lacks ``args_hash``.
+
+    Should never happen with dispatcher.py's well-formed emissions, but
+    the forwarder must not crash on a stripped / partial event.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(type="tool_called", data={
+        "tool": "read_file", "args": {"path": "/x"},
+        "run_id": "r1",
+    }))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].meta["op_id"] is None
+    assert msgs[0].meta["tool"] == "read_file"


### PR DESCRIPTION
**[tui-coder]** — issue #427 L4 step 3 of 6.

Bridges existing ``dispatch/dispatcher.py`` tool-call lifecycle events into outbox messages so the conv pane can mount + drive ToolCallRow widgets (= step 4).

## Re-plan context (= step 2 dropped)

Original wave plan added new per-op events at the op_runtime layer (PR #431, retracted). Grep-verified that ``dispatch/dispatcher.py:200-274`` already emits the same lifecycle at the correct **tool-name granularity** (= ``read_file`` / ``web_fetch`` / ``mcp__server__tool``), matching the TUI consumer spec per memory ``feedback_tui_visibility_axis``. This PR subscribes to those existing events rather than adding new ones — single emission source preserved, schema clash avoided.

Memory ``feedback_verify_existing_event_emission_before_adding`` documents the trap + the grep-first discipline that surfaced this.

## Summary

Three new ``ChatEventForwarder`` handlers:

| event | handler | outbox kind |
|---|---|---|
| ``tool_called`` | ``on_tool_called`` | ``tool_call_started`` |
| ``tool_returned`` | ``on_tool_returned`` | ``tool_call_completed`` |
| ``tool_failed`` | ``on_tool_failed`` | ``tool_call_failed`` |

Each message carries:
- ``meta["tool"]`` = tool name
- ``meta["op_id"]`` = source ``args_hash`` (= correlates start → terminal across concurrent calls)
- ``meta["chain_id"]`` + standard provenance (``run_id`` / ``parent_run_id`` / ``skill_name`` / ``run_id_short``)
- Per-kind extras (``args`` on started, ``result`` on completed, ``error_kind`` + ``error_message`` on failed)

## Test plan

- [x] ruff check passes
- [x] 7 new Tier 2 tests in ``tests/test_forwarder_tool_call_events.py`` 7/7 green
- [x] Existing ``tests/test_plan_step_context.py`` 10/10 (= no regression on phase / plan_step / workflow handlers)
- [ ] (skipped — manual TUI verify not applicable; consumer side arrives with step 4)

## Wave context (= updated after step 2 drop)

```
✓ step 1: ToolCallRow widget                (PR #429, merged)
✗ step 2: per-op event emission             (PR #431, retracted — wrong layer)
🆕 step 3: forwarder subscribe + outbox      (this PR)
🔄 step 4: conv pane mount + drive ToolCallRow
🔄 step 5: AsyncStackPanel (bottom strip)
🔄 step 6: agents tab refactor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)