### PR TITLE
feat(web): HTTP route /agents/<agent>/tool-results/<artifact> (#385 β sub-task 3a)

### DIFF
--- a/src/reyn/web/routers/resources.py
+++ b/src/reyn/web/routers/resources.py
@@ -1,0 +1,142 @@
+"""Resources router — HTTP fetch endpoint for path_ref bodies (#385 β
+core impl sub-task 3, cross-host transport surface).
+
+The companion to ``MediaStore`` (= same-host fs storage) on the network
+side. When agent A produces a tool result and includes a path_ref in
+its response, a cross-host consumer (= agent B on a different Reyn
+process, an MCP client, a browser frontend) needs a transport to fetch
+the body. This router exposes that surface as a plain HTTP GET so:
+
+* A2A peers can resolve ``FilePart.uri`` URLs with standard HTTP
+  semantics (= the A2A spec gap for resource fetch is handled the
+  industry-standard way: URI in artifact, HTTP GET to fetch).
+* MCP server ``resources/read`` adapter (= future, separate file) can
+  dispatch via the same route, no duplicate fetch path.
+* Browser / curl / any HTTP client works without Reyn knowledge.
+
+URL convention (= #385 wire shape per lead-coder Q3 leaning toward
+Reyn directory naming uniformity):
+
+  GET /agents/<agent_name>/tool-results/<artifact>
+
+``<agent_name>``  — for routing / audit (= which Reyn instance / agent
+                    minted this artifact). Today's single-process Reyn
+                    has a shared ``.reyn/tool-results/`` dir; the agent
+                    segment is the identity that future multi-process
+                    deployments dispatch on.
+``<artifact>``    — the filename portion of the path_ref, as minted by
+                    MediaStore (= ``YYYYMMDDTHHMMSS-<chain_short>-
+                    <tool>-<seq>.<ext>``).
+
+Same-host short-circuit (= when the resolved URL would point back to
+this very Reyn instance) is the dispatcher's responsibility on the
+consumer side; this router unconditionally serves the local file if it
+exists. Path-traversal escapes (= ``..`` etc.) are rejected via the
+same boundary check ``MediaStore.read_tool_result`` uses.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
+
+from reyn.web.deps import get_registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["resources"])
+
+
+# Conservative MIME inference from file extension. Same intent as
+# MediaStore's _MIME_TO_EXT but the inverse direction; we don't import
+# it to avoid coupling the HTTP layer to the storage internals.
+_EXT_TO_MIME: dict[str, str] = {
+    ".png":  "image/png",
+    ".jpg":  "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif":  "image/gif",
+    ".webp": "image/webp",
+    ".svg":  "image/svg+xml",
+    ".html": "text/html; charset=utf-8",
+    ".txt":  "text/plain; charset=utf-8",
+    ".md":   "text/markdown; charset=utf-8",
+    ".json": "application/json",
+    ".xml":  "application/xml",
+}
+
+
+def _mime_for(artifact: str) -> str:
+    """Return a Content-Type for the given artifact filename.
+
+    Defaults to ``application/octet-stream`` for unknown extensions —
+    the caller can still consume the bytes; only the auto-render in a
+    browser degrades.
+    """
+    suffix = Path(artifact).suffix.lower()
+    return _EXT_TO_MIME.get(suffix, "application/octet-stream")
+
+
+# ── GET /agents/<agent>/tool-results/<artifact> ───────────────────────
+
+
+@router.get("/agents/{agent_name}/tool-results/{artifact}")
+async def get_tool_result(
+    agent_name: str,
+    artifact: str,
+    request: Request,  # noqa: ARG001 — kept for symmetry with a2a routes
+    registry=Depends(get_registry),
+) -> Response:
+    """Serve a tool-result file by ``<agent>/<artifact>`` route.
+
+    Validates the agent exists in the registry (= 404 if not) and that
+    the artifact resolves inside ``.reyn/tool-results/`` (= 400 if a
+    path-traversal escape is attempted, 404 if the file is absent /
+    deleted by the user). Returns the body bytes with a best-effort
+    Content-Type derived from the artifact extension.
+
+    Authentication: relies on whatever transport-layer protection
+    ``reyn web`` is fronted by (= same posture as ``/a2a/agents/...``
+    endpoints, no per-route auth in this MVP). When auth becomes a
+    concern, it'd be added as middleware on the whole router.
+    """
+    # 1) Agent existence: prevents arbitrary path scans for
+    #    ``/agents/<garbage>/tool-results/<probe>`` attempts.
+    if not registry.exists(agent_name):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Reyn agent {agent_name!r} not found on this server.",
+        )
+
+    # 2) Path-traversal protection: the artifact must resolve inside
+    #    the project's ``.reyn/tool-results/`` directory. We re-use
+    #    MediaStore's existing boundary check so the route and the
+    #    same-host fs reader share one rule (= no chance of drift).
+    from reyn.workspace.media_store import MediaStore, MediaStoreConfig
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=Path.cwd(),
+        agent_name=agent_name,
+    )
+    rel_path = str(
+        (store.tool_results_dir / artifact).relative_to(Path.cwd()),
+    )
+    try:
+        body, found = store.read_tool_result(rel_path)
+    except PermissionError as exc:
+        # MediaStore raises PermissionError when the resolved path
+        # escapes ``tool_results_dir`` — this catches a malicious /
+        # malformed ``artifact`` that includes ``..`` or absolute paths.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if not found:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"tool result {artifact!r} not found for agent "
+                f"{agent_name!r} (= deleted by user, or never existed)"
+            ),
+        )
+
+    return Response(content=body, media_type=_mime_for(artifact))

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -175,6 +175,7 @@ from reyn.web.routers import agents as _agents_router  # noqa: E402
 from reyn.web.routers import budget as _budget_router  # noqa: E402
 from reyn.web.routers import mcp as _mcp_router  # noqa: E402
 from reyn.web.routers import permissions as _perms_router  # noqa: E402
+from reyn.web.routers import resources as _resources_router  # noqa: E402
 from reyn.web.routers import runs as _runs_router  # noqa: E402
 from reyn.web.routers import skills as _skills_router  # noqa: E402
 from reyn.web.routers import topologies as _topos_router  # noqa: E402
@@ -210,6 +211,13 @@ except ImportError:  # pragma: no cover — `[mcp]` extra not installed
 # and converse via JSON-RPC 2.0 POST /a2a/agents/<name>. Same backing
 # impl as MCP (send_to_agent_impl), different wire protocol.
 app.include_router(_a2a_router.router)
+
+# #385 β core impl sub-task 3: HTTP fetch surface for path_ref bodies
+# (= GET /agents/<agent>/tool-results/<artifact>). Cross-host consumers
+# (= A2A peers, MCP `resources/read` adapter, browser, curl) resolve a
+# resource_uri / url to a body via plain HTTP GET — fills the A2A
+# spec gap for resource fetch with the industry-standard pattern.
+app.include_router(_resources_router.router)
 
 # ── WebSocket routes ────────────────────────────────────────────────────────
 

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -1,0 +1,203 @@
+"""Tier 2: resources router — HTTP fetch surface for path_ref bodies
+(#385 β core impl sub-task 3).
+
+The route ``GET /agents/<agent>/tool-results/<artifact>`` is the
+cross-host transport for ``read_tool_result`` consumers: A2A peers,
+MCP ``resources/read`` adapters, browsers, curl. These tests pin:
+
+1. A real path_ref minted by MediaStore is fetchable via the route.
+2. Path-traversal escapes are rejected (= 400, not silent leak).
+3. Missing / deleted file → 404 (= ``not_found`` semantics aligned
+   with ``read_tool_result``).
+4. Unknown agent → 404 (= can't probe arbitrary paths via
+   ``/agents/<garbage>/tool-results/<probe>``).
+5. Content-Type derivation from the artifact extension (= text/plain
+   for .txt, image/png for .png, application/octet-stream fallback).
+
+Tier 2 because the route is the cross-host integrity boundary: a path-
+traversal escape would expose arbitrary fs content; an unbounded agent
+existence check would enable enumeration. Pin both invariants here so
+any future refactor surfaces them at review.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Same path-bootstrap pattern as tests/web/test_smoke.py — keep the
+# worktree src ahead of any editable-install collision.
+_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_WORKTREE_SRC) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_SRC))
+
+fastapi = pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
+httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
+
+
+@pytest.fixture()
+def tmp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Minimal Reyn project with one agent registered, deps cleared.
+
+    Mirrors the smoke-test fixture so the FastAPI TestClient runs
+    against a clean filesystem and the cached singletons in
+    ``reyn.web.deps`` resolve to this tmp project.
+    """
+    reyn_dir = tmp_path / ".reyn"
+    agents_dir = reyn_dir / "agents" / "researcher"
+    agents_dir.mkdir(parents=True)
+
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (agents_dir / "profile.yaml").write_text(
+        "name: researcher\nrole: ''\ncreated_at: '2026-01-01T00:00:00+00:00'\n",
+        encoding="utf-8",
+    )
+
+    import reyn.web.deps as deps
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+    monkeypatch.setattr(
+        "reyn.config._find_project_root", lambda _cwd: tmp_path,
+    )
+    # MediaStore reads from cwd; the route mints MediaStore with
+    # ``project_root=Path.cwd()`` so the working dir must match for the
+    # route's fs lookups to resolve in the test fixture.
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+
+def _client():
+    from fastapi.testclient import TestClient
+
+    from reyn.web.server import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _mint_path_ref(tmp_project: Path, content: str = "hello world\n") -> dict:
+    """Use MediaStore to write a real path_ref under the tmp project."""
+    from reyn.workspace.media_store import MediaStore, MediaStoreConfig
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_project,
+        agent_name="researcher",
+    )
+    return store.save_tool_result(
+        content, mime_type="text/plain", chain_id="chainX", tool="web_fetch", seq=1,
+    )
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+
+def test_get_serves_minted_path_ref_body(tmp_project: Path):
+    """Tier 2: a path-ref minted by MediaStore is fetchable through the
+    HTTP route — confirms the cross-host transport contract: minted
+    URL → HTTP GET → original body.
+    """
+    block = _mint_path_ref(tmp_project, content="cross-host body\n")
+    artifact = Path(block["path"]).name
+
+    response = _client().get(f"/agents/researcher/tool-results/{artifact}")
+
+    assert response.status_code == 200, response.text
+    assert response.content == b"cross-host body\n"
+
+
+def test_get_returns_text_plain_for_txt_artifact(tmp_project: Path):
+    """Tier 2: ``Content-Type`` for ``.txt`` artifact is
+    ``text/plain; charset=utf-8`` — lets browsers / HTTP clients render
+    inline without download prompts.
+    """
+    block = _mint_path_ref(tmp_project, content="x")
+    artifact = Path(block["path"]).name
+
+    response = _client().get(f"/agents/researcher/tool-results/{artifact}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+# ── path-traversal protection ──────────────────────────────────────────
+
+
+def test_get_rejects_dot_dot_traversal(tmp_project: Path):
+    """Tier 2: a ``..`` escape in the artifact path is rejected with 400
+    rather than reading outside the ``.reyn/tool-results/`` directory.
+    Defends the cross-host transport against adversarial / malformed
+    URLs minted by hostile peers.
+
+    Even crafted as a single segment (= URL-encoded ``..``), the
+    MediaStore boundary check catches the escape. FastAPI's router may
+    pre-process some traversal patterns at the routing layer; this test
+    pins the deepest layer (= MediaStore.read_tool_result raise) is
+    reachable for any pattern that does get through.
+    """
+    # %2E%2E%2Fpasswd = "../passwd"; relies on FastAPI passing the raw
+    # path segment to the handler so MediaStore sees the malformed input.
+    response = _client().get(
+        "/agents/researcher/tool-results/%2E%2E%2Fpasswd",
+    )
+
+    # Either 400 (= MediaStore boundary check caught it) or 404 (=
+    # FastAPI / starlette refused before reaching the handler). Both
+    # are acceptable "did not leak" outcomes; pin that it's NOT 200.
+    assert response.status_code in (400, 404), (
+        f"path traversal returned {response.status_code} — should be "
+        f"400 or 404 to indicate refusal: {response.text}"
+    )
+
+
+# ── not_found semantics ────────────────────────────────────────────────
+
+
+def test_get_missing_file_returns_404(tmp_project: Path):
+    """Tier 2: a syntactically valid artifact name whose file doesn't
+    exist returns 404 — matches ``MediaStore.read_tool_result``'s
+    ``(b"", False)`` convention surfaced as HTTP semantics.
+    """
+    response = _client().get(
+        "/agents/researcher/tool-results/20990101T000000-none-tool-1.txt",
+    )
+
+    assert response.status_code == 404
+
+
+def test_get_unknown_agent_returns_404(tmp_project: Path):
+    """Tier 2: an unregistered agent name returns 404 — prevents probing
+    for arbitrary paths via ``/agents/<garbage>/tool-results/<probe>``
+    even when the artifact filename is otherwise valid.
+    """
+    response = _client().get(
+        "/agents/nonexistent/tool-results/any.txt",
+    )
+
+    assert response.status_code == 404
+
+
+# ── router registration ────────────────────────────────────────────────
+
+
+def test_resources_route_is_mounted_on_app():
+    """Tier 2: the resources router is registered on the gateway. Without
+    this, every other test in this module would still pass via 404 from
+    FastAPI's default-not-found, masking a route-mount regression.
+    """
+    from reyn.web.server import app
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert any(
+        "/agents/" in p and "/tool-results/" in p
+        for p in paths
+    ), f"resources route not mounted; routes seen: {sorted(paths)}"


### PR DESCRIPTION
**[e2e-coder]** — #385 β core impl **sub-task 3 part 1** = HTTP fetch surface for path_ref bodies. Lead-coder explicit go signal (= broker, fork (a) per user 「実装先終わらせる」 directive) received.

## Summary

New endpoint ``GET /agents/<agent_name>/tool-results/<artifact>`` exposes the cross-host transport for ``read_tool_result`` consumers (= A2A peers, MCP ``resources/read`` adapters, browsers, curl).

## Why HTTP route is the right surface

A2A spec has a known gap: it allows artifact URIs but does NOT define a fetch RPC. The de-facto industry workaround is "URI in FilePart = HTTP URL, consumer = HTTP GET". Reyn aligns with that pattern: producer mints a URL pointing to its own ``reyn web`` gateway; any consumer resolves it with standard HTTP semantics.

This single endpoint unifies what the original design plan fragmented into three transport-specific bindings:
- **A2A peer cross-host fetch** → standard HTTP GET this URL
- **MCP `resources/read` server-side adapter** → dispatch to this same route (= follow-up PR 3d)
- **Browser / curl / external HTTP client** → same endpoint, no Reyn knowledge required

## URL convention

```
GET /agents/<agent_name>/tool-results/<artifact>
```

Path naming per lead-coder Q3 leaning toward Reyn directory naming uniformity (``.reyn/tool-results/`` ↔ ``/tool-results/``). If scheme refinement arbitration lands on ``/resources/`` (= MCP align), it's a 1-line edit in the route decorator.

## Integrity boundary

| Check | Outcome |
|---|---|
| Agent name not in registry | 404 (= prevents arbitrary path scans) |
| Artifact resolves outside ``.reyn/tool-results/`` (= ``..`` escape) | 400 (= reuses MediaStore boundary check, no rule drift) |
| File doesn't exist | 404 (= matches ``read_tool_result`` ``(b"", False)`` convention) |
| All good | 200 + body with MIME-inferred Content-Type |

Auth: relies on transport-layer protection of ``reyn web`` (= same posture as ``/a2a/agents/...``). Middleware-based auth is the natural addition surface when needed.

## Change shape

- ``src/reyn/web/routers/resources.py`` (new): FastAPI router with the GET endpoint
- ``src/reyn/web/server.py``: import + ``app.include_router(...)``
- ``tests/web/test_resources_router.py`` (new, 6 tests): happy-path / Content-Type / traversal / missing file / unknown agent / route-mounted sentinel

## Test plan

- [x] ``pytest tests/web/test_resources_router.py`` — 6/6 pass
- [x] ``pytest tests/`` (full suite) — 4664 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on all modified files — clean
- No schema / wire-shape change; no router fixtures touched.

## What's NEXT in sub-task 3 (= follow-up PRs)

- **3b**: MediaStore mints ``url`` field alongside ``resource_uri`` (= producer-side URL minting per lead-coder Q2 leaning: hybrid runtime ``request.base_url`` + config fallback)
- **3c**: ``read_tool_result`` handler accepts ``url`` arg, HTTP-GETs it when host doesn't match local (= cross-host dispatcher, same-host short-circuit retained)
- **3d**: MCP server-side ``resources/list`` + ``resources/read`` adapters dispatch to this HTTP route

The cross-host stub error in ``MediaStore.read_tool_result_by_uri`` stays in place until 3c lands; this PR adds the **transport surface** without changing dispatch behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)