### PR TITLE
feat(tui): mount ToolCallRow on tool_call lifecycle outbox (#427 L4 step 4)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -53,6 +53,60 @@ def _is_plan_sourced_body(body: str) -> bool:
     return any(stripped.startswith(p) for p in _PLAN_SOURCED_BODY_PREFIXES)
 
 
+# Bulky / free-form keys we want to summarise rather than inline in the
+# ToolCallRow's args / result line. Same set the forwarder/op_runtime
+# helpers use — keeps the visual contract consistent across surfaces.
+_TOOL_ARG_BULKY_FIELDS = frozenset({
+    "content", "new_string", "old_string", "body", "preview",
+})
+
+
+def _format_tool_args(args: dict | None) -> str:
+    """Compact ``key=value, ...`` repr of dispatcher args for ToolCallRow.
+
+    Returns "" when ``args`` is empty / non-dict — ToolCallRow renders
+    the tool name with empty parens in that case. Bulky string fields
+    collapse to ``<N chars>`` so the line stays short.
+    """
+    if not isinstance(args, dict) or not args:
+        return ""
+    parts: list[str] = []
+    for key, value in args.items():
+        if key in _TOOL_ARG_BULKY_FIELDS and isinstance(value, str) and len(value) > 24:
+            parts.append(f"{key}=<{len(value)} chars>")
+            continue
+        s = str(value)
+        if len(s) > 60:
+            s = s[:57] + "..."
+        parts.append(f"{key}={s}")
+    return ", ".join(parts)
+
+
+def _format_tool_result(result) -> str:
+    """Compact one-line repr of dispatcher result for the ToolCallRow row-2.
+
+    Accepts dict / str / None; degrades to "" when result has nothing
+    presentable. The widget further truncates to terminal width, so
+    this just removes the bulky body fields and joins the rest.
+    """
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        return result[:117] + "..." if len(result) > 120 else result
+    if not isinstance(result, dict):
+        return str(result)[:120]
+    parts: list[str] = []
+    for key, value in result.items():
+        if key in _TOOL_ARG_BULKY_FIELDS and isinstance(value, str) and len(value) > 24:
+            parts.append(f"{key}=<{len(value)} chars>")
+            continue
+        s = str(value)
+        if len(s) > 60:
+            s = s[:57] + "..."
+        parts.append(f"{key}={s}")
+    return ", ".join(parts)
+
+
 # Re-export for backward compatibility — moved to a shared module so the
 # right_panel widgets can use it without creating an import cycle through
 # app_outbox.
@@ -100,6 +154,12 @@ class OutboxRouter:
             # workflow_aborted events) and handled in app._handle_trace_for_skill_row.
             "error":                    self._on_error,
             "hot_list_updated":         self._on_hot_list_updated,
+            # Issue #427 step 4: tool-call lifecycle from ChatEventForwarder
+            # (= step 3). Mount a ToolCallRow on _started, finalise
+            # on _completed / _failed, keyed by op_id.
+            "tool_call_started":        self._on_tool_call_started,
+            "tool_call_completed":      self._on_tool_call_completed,
+            "tool_call_failed":         self._on_tool_call_failed,
         }
 
     # ── transient sticky helpers ──────────────────────────────────────────────
@@ -711,6 +771,67 @@ class OutboxRouter:
         # Reset on the next user submit.
         self._app.set_title_state("error")
         self._app.alert()
+
+    # ── Tool-call lifecycle (issue #427 step 4) ───────────────────────────────
+
+    def _on_tool_call_started(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """``tool_call_started`` — mount a ToolCallRow for this op_id.
+
+        ``meta`` carries the dispatcher-side payload bridged by
+        ``ChatEventForwarder.on_tool_called``:
+            {tool, op_id, args, chain_id, run_id, ...}
+
+        Render ``args`` as a compact ``key=value`` line (= the same shape
+        ToolCallRow's truncation helper expects). The conv pane keys
+        the row off ``op_id`` so the eventual completed / failed
+        message can find it back.
+        """
+        meta = msg.meta or {}
+        op_id = str(meta.get("op_id") or "")
+        tool_name = str(meta.get("tool") or msg.text or "tool")
+        args = meta.get("args") or {}
+        try:
+            conv.start_tool_call_row(
+                op_id, tool_name, args_repr=_format_tool_args(args),
+            )
+        except Exception:
+            pass
+
+    def _on_tool_call_completed(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """``tool_call_completed`` — finalise the row to its success terminal."""
+        meta = msg.meta or {}
+        op_id = str(meta.get("op_id") or "")
+        result = meta.get("result")
+        try:
+            conv.complete_tool_call_row(
+                op_id, result_snippet=_format_tool_result(result),
+            )
+        except Exception:
+            pass
+
+    def _on_tool_call_failed(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """``tool_call_failed`` — finalise the row to its failure terminal."""
+        meta = msg.meta or {}
+        op_id = str(meta.get("op_id") or "")
+        error_kind = str(meta.get("error_kind") or "")
+        error_msg = str(meta.get("error_message") or "")
+        # Prefer "kind: message" when both present; fall back to whichever
+        # one is non-empty. Keeps the row's error display informative even
+        # when the dispatcher omits one of the two fields.
+        if error_kind and error_msg:
+            reason = f"{error_kind}: {error_msg}"
+        else:
+            reason = error_kind or error_msg or "failed"
+        try:
+            conv.fail_tool_call_row(op_id, error=reason)
+        except Exception:
+            pass
 
     def _on_hot_list_updated(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -55,6 +55,7 @@ from .intervention import InterventionWidget
 from .skill_activity import SkillActivityRow
 from .sticky_status import StickyStatus
 from .streaming_row import StreamingRow
+from .tool_call_row import ToolCallRow
 
 _DASH_TOTAL = 38  # matches the banner separator width
 _GROUP_WINDOW_S = 60.0  # consecutive turns within this window share a header
@@ -268,6 +269,11 @@ class ConversationView(Widget):
         super().__init__(id=id)
         self._stream_rows: dict[str, StreamingRow] = {}
         self._skill_rows: dict[str, SkillActivityRow] = {}
+        # Issue #427 step 4: per-tool_call inline rows keyed by op_id
+        # (= dispatch_tool's args_hash, propagated via forwarder OutboxMessage
+        # meta). Mounted on tool_call_started, finalised on
+        # tool_call_completed / tool_call_failed.
+        self._tool_call_rows: dict[str, ToolCallRow] = {}
         # Header-grouping state (B1)
         self._last_speaker: str = ""
         self._last_speaker_at: float = 0.0
@@ -865,6 +871,89 @@ class ConversationView(Widget):
         row = self._skill_rows.get(run_id)
         if row is not None:
             row.set_detail(detail)
+
+    # ── Tool-call rows (issue #427 step 4) ───────────────────────────────────
+
+    def start_tool_call_row(
+        self,
+        op_id: str,
+        tool_name: str,
+        *,
+        args_repr: str = "",
+    ) -> ToolCallRow | None:
+        """Mount a ToolCallRow for ``op_id`` if one isn't already present.
+
+        Returns the row (existing or newly mounted). ``op_id`` is the
+        ``args_hash`` propagated through the forwarder; it correlates the
+        eventual ``tool_call_completed`` / ``tool_call_failed`` outbox
+        message back to this row. Empty ``op_id`` short-circuits to
+        None (= consumer with no correlation id falls back to silent
+        suppression rather than mounting an unkeyed row that can never
+        be finalised).
+        """
+        if not op_id:
+            return None
+        existing = self._tool_call_rows.get(op_id)
+        if existing is not None:
+            return existing
+        self._consume_empty_hint()
+        row = ToolCallRow(
+            tool_name=tool_name,
+            args_repr=args_repr,
+            id=f"toolcall_{op_id[:8]}",
+        )
+        self._tool_call_rows[op_id] = row
+        self.mount(row)
+        return row
+
+    def complete_tool_call_row(
+        self, op_id: str, *, result_snippet: str = "",
+    ) -> None:
+        """Transition the row keyed by ``op_id`` to the success terminal.
+
+        Mirrors ``finish_skill_row`` semantics: finalise the row, flush
+        its rendered shape into the RichLog so scrollback / Ctrl+P/N
+        can reach it, then unmount the live widget to bound DOM growth
+        across long sessions. No-op when no row is mounted for ``op_id``
+        (e.g. the start message was lost or the row was already
+        finalised by a prior terminal).
+        """
+        row = self._tool_call_rows.pop(op_id, None)
+        if row is None:
+            return
+        row.finish_success(result_snippet=result_snippet or None)
+        self._flush_tool_call_row(row)
+
+    def fail_tool_call_row(self, op_id: str, *, error: str = "") -> None:
+        """Transition the row keyed by ``op_id`` to the failure terminal."""
+        row = self._tool_call_rows.pop(op_id, None)
+        if row is None:
+            return
+        row.finish_failure(reason=error)
+        self._flush_tool_call_row(row)
+
+    def _flush_tool_call_row(self, row: ToolCallRow) -> None:
+        """Render the row's two-line shape into the RichLog and unmount.
+
+        Same flush pattern as ``finish_skill_row`` (= finished line goes
+        to scroll history, live widget removed). The row's render
+        helpers are pure over its state, so reading them after the
+        finish_* call captures the terminal shape.
+        """
+        try:
+            line1 = row._build_line1()
+            line2 = row._build_line2()
+            self._write_body(line1)
+            if line2.plain:
+                self._write_body(line2)
+            row.remove()
+        except Exception:
+            # Same defensive stance as finish_skill_row: a flush
+            # failure leaves the row mounted (= breadcrumb stays
+            # visible) rather than blowing up the outbox loop.
+            pass
+
+    # ── SkillActivityRow (issue #210 / wave-7 #418) ───────────────────────────
 
     def finish_skill_row(
         self, run_id: str, *, success: bool = True, reason: str = "",

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -1,0 +1,186 @@
+"""Tier 2: ConversationView mounts + finalises ToolCallRow on outbox lifecycle.
+
+issue #427 L4 step 4 — the conv pane's ``start_tool_call_row`` /
+``complete_tool_call_row`` / ``fail_tool_call_row`` are the bridge
+between forwarder-relayed outbox messages (= step 3) and the
+ToolCallRow widget (= step 1 PoC).
+
+Contract pinned here:
+
+1. ``start_tool_call_row(op_id, tool, args_repr)`` mounts a ToolCallRow
+   under the conv pane and keys it by ``op_id``.
+2. Calling ``start_tool_call_row`` again with the same ``op_id`` is
+   idempotent — returns the existing row instead of double-mounting.
+3. ``complete_tool_call_row(op_id, result_snippet)`` transitions the
+   row to its success terminal, flushes the rendered shape into the
+   RichLog scrollback, and unmounts the live widget.
+4. ``fail_tool_call_row(op_id, error)`` does the same with ✗ glyph.
+5. Empty ``op_id`` short-circuits start_tool_call_row to None — we
+   refuse to mount unkeyed rows that could never be finalised.
+6. Calling complete / fail with an unknown ``op_id`` is a no-op
+   (= forwarder bug or out-of-order delivery shouldn't blow up).
+
+Plus the two app_outbox formatting helpers:
+- ``_format_tool_args`` collapses bulky body fields to ``<N chars>``
+- ``_format_tool_result`` handles dict / str / None gracefully
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app_outbox import _format_tool_args, _format_tool_result  # noqa: E402
+from reyn.chat.tui.widgets import ConversationView  # noqa: E402
+from reyn.chat.tui.widgets.tool_call_row import ToolCallRow  # noqa: E402
+
+
+class _ConvOnlyApp(App):
+    def compose(self) -> ComposeResult:
+        yield ConversationView(id="conversation")
+
+
+# ── Conv pane lifecycle API tests ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_tool_call_row_mounts_widget_keyed_by_op_id():
+    """Tier 2: mounting a tool-call row makes a ToolCallRow visible in the DOM."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_tool_call_row(
+            "op-xyz", "read_file", args_repr="path=/tmp/x",
+        )
+        await pilot.pause()
+        assert row is not None
+        rows = list(conv.query(ToolCallRow))
+        assert len(rows) == 1
+        # The rendered line 1 carries the tool name + args.
+        line1 = rows[0]._build_line1().plain
+        assert "read_file" in line1
+        assert "path=/tmp/x" in line1
+
+
+@pytest.mark.asyncio
+async def test_start_tool_call_row_is_idempotent_for_same_op_id():
+    """Tier 2: same op_id doesn't double-mount; second call returns existing row."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        first = conv.start_tool_call_row("op-a", "read_file")
+        second = conv.start_tool_call_row("op-a", "read_file")
+        await pilot.pause()
+        assert first is second
+        assert len(list(conv.query(ToolCallRow))) == 1
+
+
+@pytest.mark.asyncio
+async def test_complete_tool_call_row_unmounts_live_widget():
+    """Tier 2: success terminal removes the live row from the DOM."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row("op-b", "web_fetch")
+        await pilot.pause()
+        assert len(list(conv.query(ToolCallRow))) == 1
+        conv.complete_tool_call_row("op-b", result_snippet="200 OK 1.2KB")
+        await pilot.pause()
+        # Row is unmounted after flush.
+        assert len(list(conv.query(ToolCallRow))) == 0
+
+
+@pytest.mark.asyncio
+async def test_fail_tool_call_row_unmounts_live_widget_and_records_error():
+    """Tier 2: failure terminal removes the live row from the DOM."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row("op-c", "shell")
+        await pilot.pause()
+        conv.fail_tool_call_row("op-c", error="timeout")
+        await pilot.pause()
+        assert len(list(conv.query(ToolCallRow))) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_op_id_short_circuits_to_no_mount():
+    """Tier 2: empty op_id refuses to mount — would be un-finalisable."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_tool_call_row("", "read_file")
+        await pilot.pause()
+        assert row is None
+        assert len(list(conv.query(ToolCallRow))) == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_op_id_terminals_are_no_op():
+    """Tier 2: terminal for unknown op_id doesn't crash or mount anything."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No start_tool_call_row called for these op_ids.
+        conv.complete_tool_call_row("never-mounted", result_snippet="x")
+        conv.fail_tool_call_row("also-never-mounted", error="x")
+        await pilot.pause()
+        # No widgets mounted, no exception.
+        assert len(list(conv.query(ToolCallRow))) == 0
+
+
+# ── app_outbox formatter helper tests ─────────────────────────────────────────
+
+
+def test_format_tool_args_empty_and_non_dict():
+    """Tier 2: empty / non-dict inputs produce empty string."""
+    assert _format_tool_args(None) == ""
+    assert _format_tool_args({}) == ""
+
+
+def test_format_tool_args_keys_and_values():
+    """Tier 2: dict args produce ``key=value, ...`` line."""
+    out = _format_tool_args({"path": "/tmp/x", "limit": 50})
+    assert "path=/tmp/x" in out
+    assert "limit=50" in out
+
+
+def test_format_tool_args_collapses_bulky_fields():
+    """Tier 2: long ``content``-class fields become ``<N chars>`` placeholder."""
+    out = _format_tool_args({"path": "/x", "content": "y" * 5000})
+    assert "<5000 chars>" in out
+    assert "yyyy" not in out
+
+
+def test_format_tool_result_dict_string_none():
+    """Tier 2: result formatter handles dict / str / None gracefully."""
+    assert _format_tool_result(None) == ""
+    assert _format_tool_result("simple text") == "simple text"
+    out = _format_tool_result({"status": "ok", "exit_code": 0})
+    assert "status=ok" in out
+    assert "exit_code=0" in out
+
+
+def test_format_tool_result_collapses_bulky_body():
+    """Tier 2: result with bulky body field collapses to ``<N chars>``."""
+    out = _format_tool_result({"status": "ok", "body": "z" * 5000})
+    assert "<5000 chars>" in out
+
+
+def test_format_tool_result_truncates_long_string_input():
+    """Tier 2: very long plain-string result gets ellipsised."""
+    out = _format_tool_result("x" * 500)
+    assert out.endswith("...")
+    assert len(out) <= 120


### PR DESCRIPTION
**[tui-coder]** — issue #427 L4 step 4 of 6.

Wires the outbox messages from step 3 (PR #433, merged) to the ToolCallRow widget from step 1 (PR #429, merged), completing the end-to-end "tool-call inline visibility" path for the attach-agent sync flow.

## Summary

Two pieces:

### ConversationView lifecycle API

```python
conv.start_tool_call_row(op_id, tool_name, args_repr="...")
   → mounts ToolCallRow keyed by op_id
   → idempotent (same op_id returns existing row)
   → empty op_id short-circuits to None (= refuses un-finalisable rows)

conv.complete_tool_call_row(op_id, result_snippet="...")
   → ✓ terminal, flush rendered shape into RichLog, unmount live widget

conv.fail_tool_call_row(op_id, error="...")
   → ✗ terminal, same flush path
```

Flush pattern mirrors ``finish_skill_row`` so completed rows land in the scrollable RichLog history (= Ctrl+P/N reachable) rather than living as ever-mounted DOM children.

### OutboxRouter dispatch

```
"tool_call_started"   → _on_tool_call_started  → conv.start_tool_call_row
"tool_call_completed" → _on_tool_call_completed → conv.complete_tool_call_row
"tool_call_failed"    → _on_tool_call_failed   → conv.fail_tool_call_row
```

Two module-level helpers:
- ``_format_tool_args(dict)`` — ``key=value, ...`` compact line
- ``_format_tool_result(any)`` — handles dict / str / None

Both collapse bulky body fields (``content`` / ``new_string`` / ``old_string`` / ``body`` / ``preview``) over 24 chars to ``<N chars>`` so a 50KB file write payload doesn't blow up the ToolCallRow's args / result lines. Same key set as forwarder helpers — visual contract consistent across surfaces.

## Test plan

- [x] ruff check passes
- [x] 12 new Tier 2 tests in ``tests/cli/test_conv_pane_tool_call_lifecycle.py`` 12/12 green:
  - 6 conv pane API: mount / idempotent / complete unmount / fail unmount / empty op_id refusal / unknown op_id no-op
  - 6 formatter helpers: empty / non-dict / keys / bulky collapse / dict-str-None / long-string truncation
- [x] Existing TUI tests (smoke + ToolCallRow PoC + SkillActivityRow plan-step) 52/52 green
- [ ] (skipped — manual TUI verify deferred to step 5/6 closure smoke when AsyncStackPanel + agents tab refactor land; wiring covered by Tier 2 against real ConversationView + ToolCallRow widgets in Textual ``run_test`` pilots)

## Branch hygiene

Per ``feedback_one_commit_one_branch_one_pr``: step 4 lives on a fresh branch from main (not stacked on the step 3 branch). Step 3 (PR #433) already merged; step 4 is a separate finding with its own review surface.

## Wave context

```
✓ step 1: ToolCallRow widget                (PR #429, merged)
✗ step 2: per-op event emission             (PR #431, retracted — wrong layer)
✓ step 3: forwarder subscribe + outbox      (PR #433, merged)
🆕 step 4: conv pane mount + drive ToolCallRow (this PR)
🔄 step 5: AsyncStackPanel (= bottom strip)
🔄 step 6: agents tab refactor
```

After this lands, tool_call lifecycle ⇒ inline ToolCallRow visibility is **end-to-end functional** for the attach-agent sync flow. Steps 5-6 are independent surface additions (= async stack + nested visualization in agents tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)