### PR TITLE
feat(media-store): mint url field from multimodal.base_url (#385 β sub-task 3b)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1014,9 +1014,15 @@ class ChatSession:
                 # #385 β core impl sub-task 1: path-refs minted by this
                 # session carry resource_uri / source_agent so cross-host
                 # consumers (= other agents via A2A / MCP / Browser) can
-                # dispatch back here. Sub-task 3 wires the actual cross-
-                # host RPC; here we just stamp the identity.
+                # dispatch back here.
                 agent_name=agent_name,
+                # #385 β core impl sub-task 3b: when this Reyn instance
+                # is reachable over HTTP (= operator sets
+                # ``multimodal.base_url`` in reyn.yaml), path-refs also
+                # carry a ``url`` field pointing at the resources
+                # router so cross-host consumers can HTTP GET the body.
+                # When unset, only same-host ``path`` is available.
+                base_url=multimodal_config.base_url,
             )
         else:
             self._media_store = None

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -760,6 +760,17 @@ class MultimodalConfig:
             Project-relative directory for text-y tool result dumps
             (= #385 PoC foundation). PR-C lands the writer alongside
             ``media_dir``; PR-D wires the consumer + preview.
+        base_url:
+            Optional canonical URL prefix for cross-host path_ref
+            consumption (#385 β core impl sub-task 3b). When set
+            (= e.g. ``"https://reyn.example.com"`` from a deployed
+            ``reyn web`` instance), ``MediaStore.save_*`` augments the
+            path_ref with a ``url`` field pointing at
+            ``<base_url>/agents/<agent>/tool-results/<artifact>`` so
+            cross-host consumers (= A2A peers, MCP clients, browsers)
+            can fetch the body via the resources router. Unset → no
+            ``url`` field minted, same-host fast-path only (= backward
+            compat for legacy / CLI-only deployments).
 
     Issue #364 lands this config + the shared ``require_media_load`` gate;
     paths #365 (file__read binary) and #366 (user chat input image) reuse
@@ -769,6 +780,7 @@ class MultimodalConfig:
     on_oversize: Literal["ask", "allow", "deny"] = "ask"
     media_dir: str = ".reyn/media"
     tool_results_dir: str = ".reyn/tool-results"
+    base_url: str | None = None
 
 
 def _build_multimodal_config(raw: object) -> MultimodalConfig:
@@ -804,9 +816,16 @@ def _build_multimodal_config(raw: object) -> MultimodalConfig:
         if isinstance(tool_results_dir_raw, str) and tool_results_dir_raw
         else ".reyn/tool-results"
     )
+    base_url_raw = raw.get("base_url")
+    base_url: str | None = (
+        str(base_url_raw).rstrip("/")
+        if isinstance(base_url_raw, str) and base_url_raw
+        else None
+    )
     return MultimodalConfig(
         max_bytes=max_bytes, on_oversize=on_oversize,
         media_dir=media_dir, tool_results_dir=tool_results_dir,
+        base_url=base_url,
     )
 
 

--- a/src/reyn/workspace/media_store.py
+++ b/src/reyn/workspace/media_store.py
@@ -173,7 +173,7 @@ class MediaStore:
     shape mirror; see issue #383). The corresponding ``read_*`` methods
     do the inverse lookup with workspace-boundary validation.
 
-    Path-ref shape (#385 β core impl sub-task 1, 2026-05-22 frozen
+    Path-ref shape (#385 β core impl sub-task 1+3b, 2026-05-22 frozen
     contract): when ``agent_name`` is supplied at construction, save_*
     returns the extended shape that carries cross-host routing fields::
 
@@ -183,15 +183,21 @@ class MediaStore:
           "resource_uri": "reyn-tool-result://<agent_name>/<filename>",
           "source_agent": "<agent_name>",     # durable identity for dispatch
           "source_chain_id": "<chain_id>",    # audit annotation only (optional)
+          # When ``base_url`` is ALSO set (= sub-task 3b cross-host
+          # transport surface):
+          "url": "<base_url>/agents/<agent_name>/tool-results/<filename>",
           "mime_type": "...",
           "content_hash": "sha256:...",
         }
 
     When ``agent_name`` is omitted (= legacy call sites, test stubs),
     save_* returns the pre-β shape (= no resource_uri / source_agent /
-    source_chain_id, just ``path``). Consumers must treat the cross-host
-    fields as optional: when present, the dispatcher CAN route across
-    hosts; when absent, only the same-host ``path`` is available.
+    source_chain_id / url, just ``path``). Consumers must treat the
+    cross-host fields as optional: when ``url`` is present a consumer
+    can HTTP GET it cross-host; when only ``resource_uri`` is present
+    the consumer knows the identity but has no transport (= producer
+    deployed without ``reyn web`` or without ``multimodal.base_url``
+    set); when neither is present, only the same-host ``path`` works.
 
     Cross-host RPC routing (sub-task 3 of the β core impl) is NOT
     implemented in this sub-task — ``read_tool_result_by_uri`` raises
@@ -206,6 +212,7 @@ class MediaStore:
         *,
         project_root: Path,
         agent_name: str | None = None,
+        base_url: str | None = None,
     ) -> None:
         self._config = config or MediaStoreConfig()
         self._project_root = project_root.resolve()
@@ -216,6 +223,12 @@ class MediaStore:
             self._project_root / self._config.tool_results_dir
         ).resolve()
         self._agent_name = agent_name or None
+        # #385 β sub-task 3b: when set, save_* augments path-refs with a
+        # ``url`` field pointing at this Reyn instance's resources router
+        # (= ``<base_url>/agents/<agent>/tool-results/<artifact>``) so
+        # cross-host consumers can fetch via standard HTTP GET. Unset →
+        # no ``url`` minted, same-host fast-path only.
+        self._base_url = (base_url or "").rstrip("/") or None
 
     # ── Image storage (= .reyn/media/) ────────────────────────────────
 
@@ -342,6 +355,11 @@ class MediaStore:
         with their original expectations. The added fields are purely
         additive; the ``path`` fast-path stays usable for same-host
         consumers regardless.
+
+        When ``base_url`` is also set (= #385 β sub-task 3b), augments
+        further with a ``url`` field — the HTTP fetch URL for cross-
+        host consumers. Without ``base_url`` only ``resource_uri`` is
+        emitted (= vendor-scheme identifier, no fetch location).
         """
         if not self._agent_name:
             return
@@ -349,6 +367,11 @@ class MediaStore:
         block["source_agent"] = self._agent_name
         if chain_id:
             block["source_chain_id"] = chain_id
+        if self._base_url:
+            block["url"] = (
+                f"{self._base_url}/agents/{self._agent_name}"
+                f"/tool-results/{filename}"
+            )
 
     def read_tool_result_by_uri(self, uri: str) -> tuple[str, bool]:
         """Resolve a ``reyn-tool-result://...`` URI and read the body.

--- a/tests/test_media_store.py
+++ b/tests/test_media_store.py
@@ -472,6 +472,126 @@ def test_multiple_saved_tool_results_all_retained(tmp_path):
     assert len(files) == 10
 
 
+# ── url field (#385 β core impl sub-task 3b) ──────────────────────────
+
+
+def test_save_without_base_url_omits_url_field(tmp_path):
+    """Tier 2: when no ``base_url`` is configured, save_tool_result
+    omits the ``url`` field — cross-host fetch is impossible (= no
+    transport address known), so we don't lie about it. Same-host
+    consumers still get ``path`` and same-host ``resource_uri``.
+    """
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="researcher",
+    )
+    block = store.save_tool_result("body", mime_type="text/plain")
+    assert "url" not in block
+    # Other cross-host fields still present (= identity exists, just no transport).
+    assert "resource_uri" in block
+    assert block["source_agent"] == "researcher"
+
+
+def test_save_with_base_url_emits_url_field(tmp_path):
+    """Tier 2: when ``base_url`` is set, save_tool_result mints a
+    ``url`` field pointing at the resources router on the producing
+    Reyn instance. This is the HTTP fetch URL cross-host consumers
+    (= A2A peers, MCP clients, browsers) use to GET the body.
+    """
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_path,
+        agent_name="researcher",
+        base_url="https://reyn.example.com",
+    )
+    block = store.save_tool_result(
+        "body", mime_type="text/plain", chain_id="c1", tool="web_fetch", seq=1,
+    )
+
+    assert "url" in block
+    filename = Path(block["path"]).name
+    expected = f"https://reyn.example.com/agents/researcher/tool-results/{filename}"
+    assert block["url"] == expected
+
+
+def test_save_with_base_url_but_no_agent_name_still_omits_url(tmp_path):
+    """Tier 2: ``url`` requires BOTH ``base_url`` AND ``agent_name`` —
+    the URL path needs the agent segment. Without an identity, the URL
+    can't be addressed; we don't fabricate a path with placeholder.
+    """
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_path,
+        agent_name=None,
+        base_url="https://reyn.example.com",
+    )
+    block = store.save_tool_result("body", mime_type="text/plain")
+    assert "url" not in block
+
+
+def test_base_url_trailing_slash_is_trimmed(tmp_path):
+    """Tier 2: ``base_url`` is normalised by stripping trailing slashes
+    so the assembled URL never has ``//`` between the host and the
+    path segment. Defensive against operator yaml inputs like
+    ``"https://reyn.example.com/"``.
+    """
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_path,
+        agent_name="me",
+        base_url="https://reyn.example.com/",
+    )
+    block = store.save_tool_result("body", mime_type="text/plain")
+    # No "//" in the path portion (= host stays separated by single /).
+    assert "//agents/" not in block["url"]
+    assert block["url"].startswith("https://reyn.example.com/agents/me/tool-results/")
+
+
+def test_save_image_also_carries_url_when_base_url_set(tmp_path):
+    """Tier 2: the ``url`` augmentation applies uniformly to both
+    save_image and save_tool_result — the path-ref contract is the
+    same shape regardless of media type. (Same intent as the
+    ``resource_uri`` / ``source_agent`` parity test.)
+    """
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_path,
+        agent_name="vision",
+        base_url="https://reyn.example.com",
+    )
+    block = store.save_image(
+        b"\x89PNG\r\n", mime_type="image/png", chain_id="c2",
+    )
+
+    assert "url" in block
+    assert block["url"].startswith(
+        "https://reyn.example.com/agents/vision/tool-results/",
+    )
+
+
+def test_multimodal_config_parses_base_url_from_yaml():
+    """Tier 2: ``multimodal:`` yaml section accepts a ``base_url`` key,
+    parsed as an optional string (= None when absent). This is the
+    operator-facing surface for enabling cross-host path_ref URLs.
+    """
+    from reyn.config import _build_multimodal_config
+
+    with_url = _build_multimodal_config(
+        {"base_url": "https://reyn.example.com"},
+    )
+    assert with_url.base_url == "https://reyn.example.com"
+
+    without_url = _build_multimodal_config({})
+    assert without_url.base_url is None
+
+    # Trailing slash stripped at the config layer too (= same posture as
+    # MediaStore constructor) so downstream consumers don't need to
+    # re-normalise.
+    trailing = _build_multimodal_config(
+        {"base_url": "https://reyn.example.com/"},
+    )
+    assert trailing.base_url == "https://reyn.example.com"
+
+
 def test_saved_file_survives_when_no_one_reads_for_a_while(tmp_path):
     """Tier 2: Phase 1 invariant — passive time does NOT cause eviction.
 


### PR DESCRIPTION
**[e2e-coder]** — #385 β core impl **sub-task 3 part 2** (= producer-side URL minting). Builds on PR #434 (sub-task 3a HTTP route).

## Summary

When ``multimodal.base_url`` is configured, path-refs minted by ``MediaStore.save_*`` now carry a ``url`` field pointing at the resources router (= sub-task 3a) on this Reyn instance. Cross-host consumers can HTTP GET the body without Reyn knowledge.

## Path-ref shape (= 3b extension)

```jsonc
{
  "type": "tool_result_ref" | "image",
  "path": "<project-relative>",                                    // same-host fast-path
  "resource_uri": "reyn-tool-result://<agent>/<artifact>",         // sub-task 1
  "source_agent": "<agent>",                                       // sub-task 1
  "source_chain_id": "<chain>",                                    // sub-task 1
  "url": "<base_url>/agents/<agent>/tool-results/<artifact>",      // ← sub-task 3b (NEW)
  "mime_type": "...",
  "content_hash": "sha256:..."
}
```

``url`` requires BOTH ``base_url`` AND ``agent_name``. Either missing → ``url`` omitted, consumer falls back to ``path`` (same-host) or ``resource_uri`` (same-host identifier). Honest about cross-host transport availability — no fake URLs.

## Why config-based for now

Per lead-coder Q2 leaning (= hybrid runtime + config fallback): this PR lands the **config side** (= static deployment URL via ``reyn.yaml multimodal.base_url``) as the simpler entry point. Per-request ``request.base_url`` extraction (= dynamic, runtime context) can come later when wiring the cross-host dispatcher (= sub-task 3c) needs it. The two paths are additive — runtime extraction would override or complement the config value.

CLI-only Reyn deployments (= no ``reyn web``) keep ``base_url`` unset and get the pre-3b shape — backward compat preserved.

## Change shape

- ``src/reyn/config.py``:
  - ``MultimodalConfig.base_url: str | None = None`` field
  - ``_build_multimodal_config``: parse from yaml, strip trailing slash for uniformity
- ``src/reyn/workspace/media_store.py``:
  - ``MediaStore.__init__`` accepts ``base_url`` kwarg
  - ``_attach_cross_host_fields`` emits ``url`` when both ``agent_name`` + ``base_url`` are set
  - Path-ref shape docstring updated
- ``src/reyn/chat/session.py``: 1 line — passes ``base_url=multimodal_config.base_url`` to MediaStore
- ``tests/test_media_store.py``: +6 tests
  - url omitted when base_url unset / when agent_name unset
  - url emitted with both
  - trailing slash trimmed
  - save_image carries url too (= shape parity)
  - MultimodalConfig parses base_url from yaml

## Test plan

- [x] ``pytest tests/test_media_store.py`` — 43/43 pass (37 existing + 6 new)
- [x] ``pytest tests/`` (full suite) — 4677 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched (= no LLM-visible tool schema change).

## What's NEXT (= sub-task 3c)

The ``url`` field is now **minted** but not yet **consumed** for cross-host fetch. ``MediaStore.read_tool_result_by_uri`` still raises the "cross-host not yet supported" ValueError when the URI's source_agent differs from local. Sub-task 3c adds the dispatcher:

- ``read_tool_result`` handler accepts ``url`` arg
- URL host matches local → same-host fs read short-circuit
- URL host differs → HTTP GET (httpx) + content_hash verify

Sub-task 3d follows with MCP server ``resources/list`` + ``resources/read`` adapters dispatching through the same HTTP route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)