### PR TITLE
feat(tui): AsyncStackPanel PoC for bottom strip (#427 L4 step 5)

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -1,0 +1,333 @@
+"""AsyncStackPanel — sticky list of non-attach agents currently running.
+
+PoC stage for issue #427 L4 step 5: widget shape + entry state mgmt +
+ordering + cap behaviour. Production wiring (= subscribe to agent
+registry / non-attach agent lifecycle events, drive entries on the
+real signal) is deferred to a follow-up PR.
+
+Spec (= issue #427 L2):
+
+  ⟳ async: code_review · 12.3s      ← running entry
+  ⟳ async: monitor_loop · 5m21s      ← running, longer-running
+  ⚑ async: alice (1 pending)         ← intervention-pending entry
+  … +N more (panel for all)          ← overflow indicator when > _CAP
+
+- 1-5 entries dynamic, ``_CAP`` cap with overflow indicator
+- Sort: intervention-pending (= ⚑) on top, then running by elapsed (= shortest first)
+- Lifetime: entries appear on ``add()`` / ``set_pending()``, disappear on
+  ``remove()``; history persists via inline conv-pane markers (= separate
+  surface, not this widget's concern)
+- Dock: bottom (= above input bar, complements StickyStatus which keeps
+  its 1-line attached-agent thinking role)
+
+Per ``feedback-tui-visibility-axis``: bottom strip is for ephemeral
+runtime state (= "what's running right now"), not chat history. This
+widget never emits to history; consumers route history-side events
+(= start / complete inline markers) through a separate path.
+
+Public API:
+    panel.add(agent_id, summary)       # mount / update a running entry
+    panel.set_pending(agent_id, count) # switch entry to ⚑ + pending count
+    panel.set_running(agent_id, summary) # switch back to ⟳ (intervention resolved)
+    panel.remove(agent_id)             # entry disappeared (complete / fail)
+    panel.clear()                      # reset all entries
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from rich.cells import cell_len
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+from reyn.chat.tui._palette import _AMBER, _CORAL
+
+# Visible cap. Past this, overflow collapses to a single "… +N more" row
+# so the panel never crowds the input bar even under unusual fan-out.
+_CAP = 5
+
+# Tick rate for elapsed-time updates. 1 Hz is plenty for ambient status;
+# slower than SkillActivityRow's 0.5s by design (= ambient, not focus).
+_TICK_INTERVAL_S = 1.0
+
+_GLYPH_RUNNING = "⟳"
+_GLYPH_PENDING = "⚑"
+
+_RIGHT_MARGIN_CELLS = 4
+
+
+@dataclass
+class _Entry:
+    """One row in the stack. Keyed externally by ``agent_id`` in the
+    panel's dict; this struct just carries the renderable state."""
+
+    summary: str
+    started_at: float
+    pending_count: int = 0  # 0 = running, >0 = intervention pending
+
+
+def _fmt_elapsed(seconds: float) -> str:
+    """Compact elapsed time for ambient status (= "12.3s" / "5m21s" / "1h12m")."""
+    if seconds < 60.0:
+        return f"{seconds:.1f}s"
+    if seconds < 3600.0:
+        m = int(seconds // 60)
+        s = int(seconds - m * 60)
+        return f"{m}m{s:02d}s"
+    h = int(seconds // 3600)
+    m = int((seconds - h * 3600) // 60)
+    return f"{h}h{m:02d}m"
+
+
+class AsyncStackPanel(Widget):
+    """Bottom-docked sticky list of non-attach agent activity.
+
+    State machine per entry:
+        add(summary)            → running (⟳)
+        set_pending(count)      → pending (⚑ count)
+        set_running(summary)    → back to running (⟳, e.g. intervention resolved)
+        remove()                → entry gone
+
+    The widget itself stays mounted (= dock:bottom, height:auto) but
+    renders empty when no entries are active. When there's nothing to
+    show, ``_build_lines()`` returns an empty Text and Textual collapses
+    the height — input bar regains full vertical space.
+    """
+
+    DEFAULT_CSS = """
+    AsyncStackPanel {
+        dock: bottom;
+        height: auto;
+        padding: 0 1;
+        background: transparent;
+    }
+    """
+
+    can_focus = False
+
+    def __init__(self, *, id: str | None = None) -> None:
+        super().__init__(id=id)
+        # Insertion-order dict so two entries with identical elapsed
+        # break ties by add-order (= older entries float to the top
+        # of their sort bucket — matches the "shortest first within
+        # bucket" intent + makes test ordering deterministic).
+        self._entries: dict[str, _Entry] = {}
+        self._static: Static | None = None
+
+    # ── Textual lifecycle ────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        self._static = Static(id="async_stack_text")
+        yield self._static
+
+    def on_mount(self) -> None:
+        self.set_interval(_TICK_INTERVAL_S, self._tick)
+        self._refresh()
+
+    # ── Public API ───────────────────────────────────────────────────────────
+
+    def add(self, agent_id: str, summary: str) -> None:
+        """Mount or update a running entry for ``agent_id``."""
+        if not agent_id:
+            return
+        existing = self._entries.get(agent_id)
+        if existing is not None:
+            existing.summary = summary
+            existing.pending_count = 0  # back to running on summary update
+        else:
+            self._entries[agent_id] = _Entry(
+                summary=summary,
+                started_at=time.monotonic(),
+            )
+        self._refresh()
+
+    def set_pending(self, agent_id: str, count: int) -> None:
+        """Switch ``agent_id``'s entry to ⚑ glyph with the given pending count.
+
+        No-op when the entry doesn't exist (= ordering between agent
+        registry signals isn't strictly guaranteed; treat unknown
+        agent_id as "not visible yet" rather than auto-mounting).
+        """
+        entry = self._entries.get(agent_id)
+        if entry is None:
+            return
+        entry.pending_count = max(0, int(count))
+        self._refresh()
+
+    def set_running(self, agent_id: str, summary: str | None = None) -> None:
+        """Switch ``agent_id`` back to running (⟳) state.
+
+        Used when an intervention is resolved and the agent resumes
+        execution. ``summary`` (optional) lets the caller refresh the
+        displayed text at the same time.
+        """
+        entry = self._entries.get(agent_id)
+        if entry is None:
+            return
+        entry.pending_count = 0
+        if summary is not None:
+            entry.summary = summary
+        self._refresh()
+
+    def remove(self, agent_id: str) -> None:
+        """Remove ``agent_id``'s entry (= complete / fail / disappear)."""
+        if agent_id in self._entries:
+            del self._entries[agent_id]
+            self._refresh()
+
+    def clear(self) -> None:
+        """Reset to empty (= no entries)."""
+        if self._entries:
+            self._entries.clear()
+            self._refresh()
+
+    def snapshot(self) -> list[dict]:
+        """Public read of the current entry list for tests / introspection.
+
+        Returns the visible (= sorted, capped, overflow-substituted) view
+        as a list of ``{"agent_id", "glyph", "summary", "pending_count",
+        "elapsed_s", "is_overflow"}`` dicts. Lets callers verify ordering
+        + overflow without reaching into private state (= per testing
+        policy public-surface convention).
+        """
+        out: list[dict] = []
+        for agent_id, entry, glyph in self._sorted_visible():
+            out.append({
+                "agent_id": agent_id,
+                "glyph": glyph,
+                "summary": entry.summary,
+                "pending_count": entry.pending_count,
+                "elapsed_s": time.monotonic() - entry.started_at,
+                "is_overflow": False,
+            })
+        overflow = len(self._entries) - len(out)
+        if overflow > 0:
+            out.append({
+                "agent_id": "",
+                "glyph": "",
+                "summary": f"… +{overflow} more (panel for all)",
+                "pending_count": 0,
+                "elapsed_s": 0.0,
+                "is_overflow": True,
+            })
+        return out
+
+    # ── Internal rendering ───────────────────────────────────────────────────
+
+    def _tick(self) -> None:
+        if self._entries:
+            self._refresh()
+
+    def _sorted_visible(self) -> list[tuple[str, _Entry, str]]:
+        """Return up to ``_CAP`` (agent_id, entry, glyph) tuples in display order.
+
+        Sort: pending entries (= ⚑) first, then running entries (= ⟳)
+        ordered by elapsed shortest-first. Within each bucket, ties
+        broken by insertion order (= dict iteration stability).
+        """
+        pending: list[tuple[str, _Entry, str]] = []
+        running: list[tuple[str, _Entry, str]] = []
+        for agent_id, entry in self._entries.items():
+            if entry.pending_count > 0:
+                pending.append((agent_id, entry, _GLYPH_PENDING))
+            else:
+                running.append((agent_id, entry, _GLYPH_RUNNING))
+        running.sort(key=lambda triple: time.monotonic() - triple[1].started_at)
+        ordered = pending + running
+        return ordered[:_CAP]
+
+    def _build_lines(self) -> Text:
+        """Multi-line Text — one row per visible entry + overflow indicator."""
+        t = Text()
+        if not self._entries:
+            return t
+        try:
+            total_width = int(getattr(self.size, "width", 0))
+        except Exception:
+            total_width = 0
+        if total_width <= 0:
+            total_width = 80
+        body_budget = max(20, total_width - _RIGHT_MARGIN_CELLS)
+        visible = self._sorted_visible()
+        for i, (agent_id, entry, glyph) in enumerate(visible):
+            if i > 0:
+                t.append("\n")
+            self._append_row(t, agent_id, entry, glyph, body_budget)
+        overflow = len(self._entries) - len(visible)
+        if overflow > 0:
+            t.append("\n")
+            tail = f"… +{overflow} more (panel for all)"
+            t.append(self._truncate_to_cells(tail, body_budget), style="dim #888888")
+        return t
+
+    def _append_row(
+        self,
+        t: Text,
+        agent_id: str,
+        entry: _Entry,
+        glyph: str,
+        body_budget: int,
+    ) -> None:
+        """Append one ``<glyph> async: <agent_id> · <body> · <elapsed>`` row.
+
+        Truncation order on overflow: shrink ``summary`` first (= most
+        disposable), keep agent_id + glyph + elapsed always visible.
+        """
+        elapsed_str = _fmt_elapsed(time.monotonic() - entry.started_at)
+        if entry.pending_count > 0:
+            elapsed_segment = f"  ({entry.pending_count} pending)"
+            elapsed_style = "bold #ffaa44"
+            glyph_style = _AMBER
+        else:
+            elapsed_segment = f"  · {elapsed_str}"
+            elapsed_style = "dim"
+            glyph_style = _CORAL
+
+        prefix = f"{glyph} async: {agent_id}"
+        prefix_cells = cell_len(prefix)
+        elapsed_cells = cell_len(elapsed_segment)
+        sep = "  · " if entry.summary else ""
+        sep_cells = cell_len(sep)
+
+        summary_budget = max(
+            0, body_budget - prefix_cells - sep_cells - elapsed_cells,
+        )
+        summary_display = self._truncate_to_cells(entry.summary, summary_budget)
+
+        t.append(f"{glyph} ", style=glyph_style)
+        t.append("async: ", style="dim #888888")
+        t.append(agent_id, style="bold")
+        if summary_display:
+            t.append(sep, style="dim")
+            t.append(summary_display, style="dim")
+        t.append(elapsed_segment, style=elapsed_style)
+
+    def _truncate_to_cells(self, text: str, max_cells: int) -> str:
+        if max_cells <= 0:
+            return ""
+        if cell_len(text) <= max_cells:
+            return text
+        ellipsis = "…"
+        budget = max_cells - cell_len(ellipsis)
+        if budget <= 0:
+            return ellipsis
+        out: list[str] = []
+        used = 0
+        for ch in text:
+            w = cell_len(ch)
+            if used + w > budget:
+                break
+            out.append(ch)
+            used += w
+        return "".join(out) + ellipsis
+
+    def _refresh(self) -> None:
+        if self._static is None:
+            return
+        self._static.update(self._build_lines())
+
+
+__all__ = ["AsyncStackPanel"]

--- a/tests/cli/test_async_stack_panel_poc.py
+++ b/tests/cli/test_async_stack_panel_poc.py
@@ -1,0 +1,201 @@
+"""Tier 2: AsyncStackPanel entry state mgmt + ordering + cap behaviour.
+
+issue #427 L4 step 5 PoC — widget shape only, no production wiring
+(= agent registry subscription is a follow-up). Pins the contract
+that step 6 / production code can rely on.
+
+Contract pinned here:
+
+1. ``add(agent_id, summary)`` mounts a running entry visible in the
+   rendered output and the public ``snapshot()`` view.
+2. ``add`` is idempotent — same ``agent_id`` updates instead of
+   double-mounting.
+3. ``set_pending(agent_id, count)`` switches the entry's glyph + carries
+   the pending count in the row.
+4. ``set_running(agent_id, summary)`` reverses the pending state.
+5. ``remove(agent_id)`` drops the entry (= invisible in render +
+   snapshot).
+6. Ordering: pending entries (= ⚑) come first, then running entries
+   sorted by elapsed (= shortest first). Empty / non-existent
+   ``agent_id`` calls degrade safely.
+7. Cap behaviour: more than ``_CAP`` (= 5) entries collapse the tail to
+   a ``"… +N more (panel for all)"`` overflow row visible at the end
+   of the rendered output and as the final ``snapshot()`` entry with
+   ``is_overflow=True``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.async_stack_panel import (  # noqa: E402
+    AsyncStackPanel,
+)
+
+
+class _PanelOnlyApp(App):
+    """Minimal app that mounts AsyncStackPanel for ``run_test`` pilots."""
+
+    def compose(self) -> ComposeResult:
+        yield AsyncStackPanel(id="async_stack")
+
+
+# ── Unmounted construction tests (= state without Textual context) ─────────
+
+
+def _panel() -> AsyncStackPanel:
+    """Construct an unmounted panel — ``_refresh`` returns early when
+    ``_static`` is None so the public API still drives internal state.
+    """
+    return AsyncStackPanel()
+
+
+def test_empty_panel_renders_empty_text_and_empty_snapshot() -> None:
+    """Tier 2: no entries → empty Text + empty snapshot list."""
+    panel = _panel()
+    assert panel._build_lines().plain == ""
+    assert panel.snapshot() == []
+
+
+def test_add_creates_running_entry_visible_in_snapshot() -> None:
+    """Tier 2: ``add()`` produces a snapshot row + render line."""
+    panel = _panel()
+    panel.add("alice", "code_review")
+    snap = panel.snapshot()
+    assert len(snap) == 1
+    assert snap[0]["agent_id"] == "alice"
+    assert snap[0]["glyph"] == "⟳"
+    assert snap[0]["summary"] == "code_review"
+    assert snap[0]["pending_count"] == 0
+    rendered = panel._build_lines().plain
+    assert "alice" in rendered
+    assert "code_review" in rendered
+    assert "⟳" in rendered
+
+
+def test_add_is_idempotent_for_same_agent_id() -> None:
+    """Tier 2: second ``add()`` with same id updates summary, doesn't duplicate."""
+    panel = _panel()
+    panel.add("alice", "first")
+    panel.add("alice", "second")
+    snap = panel.snapshot()
+    assert len(snap) == 1
+    assert snap[0]["summary"] == "second"
+
+
+def test_set_pending_switches_glyph_and_carries_count() -> None:
+    """Tier 2: ``set_pending()`` flips ⟳ → ⚑ + visible pending count."""
+    panel = _panel()
+    panel.add("alice", "code_review")
+    panel.set_pending("alice", 2)
+    snap = panel.snapshot()
+    assert snap[0]["glyph"] == "⚑"
+    assert snap[0]["pending_count"] == 2
+    rendered = panel._build_lines().plain
+    assert "⚑" in rendered
+    assert "2 pending" in rendered
+
+
+def test_set_running_reverses_pending_state() -> None:
+    """Tier 2: ``set_running()`` flips ⚑ → ⟳ and resets pending count."""
+    panel = _panel()
+    panel.add("alice", "code_review")
+    panel.set_pending("alice", 1)
+    panel.set_running("alice", "code_review (resumed)")
+    snap = panel.snapshot()
+    assert snap[0]["glyph"] == "⟳"
+    assert snap[0]["pending_count"] == 0
+    assert snap[0]["summary"] == "code_review (resumed)"
+
+
+def test_remove_drops_entry() -> None:
+    """Tier 2: ``remove()`` makes the entry vanish from snapshot + render."""
+    panel = _panel()
+    panel.add("alice", "code_review")
+    panel.add("bob", "monitor")
+    panel.remove("alice")
+    snap = panel.snapshot()
+    assert len(snap) == 1
+    assert snap[0]["agent_id"] == "bob"
+    rendered = panel._build_lines().plain
+    assert "alice" not in rendered
+    assert "bob" in rendered
+
+
+def test_pending_entries_sort_before_running_entries() -> None:
+    """Tier 2: ⚑ pending entries surface above ⟳ running entries."""
+    panel = _panel()
+    panel.add("alice", "code_review")
+    panel.add("bob", "monitor")
+    panel.set_pending("bob", 1)
+    snap = panel.snapshot()
+    # bob (pending) on top, alice (running) below.
+    assert snap[0]["agent_id"] == "bob"
+    assert snap[0]["glyph"] == "⚑"
+    assert snap[1]["agent_id"] == "alice"
+    assert snap[1]["glyph"] == "⟳"
+
+
+def test_cap_collapses_tail_to_overflow_indicator() -> None:
+    """Tier 2: > ``_CAP`` entries produce a ``… +N more`` overflow row."""
+    panel = _panel()
+    for i in range(8):  # _CAP=5 + 3 overflow
+        panel.add(f"agent-{i}", f"task-{i}")
+    snap = panel.snapshot()
+    # 5 entries + 1 overflow indicator = 6 rows.
+    assert len(snap) == 6
+    assert snap[-1]["is_overflow"] is True
+    assert "+3 more" in snap[-1]["summary"]
+    rendered = panel._build_lines().plain
+    assert "+3 more" in rendered
+
+
+def test_empty_agent_id_degrades_safely() -> None:
+    """Tier 2: ``add("")`` is a no-op, ``set_pending``/``remove`` on
+    unknown id don't crash.
+    """
+    panel = _panel()
+    panel.add("", "should-not-mount")
+    panel.set_pending("never-mounted", 3)
+    panel.remove("also-never-mounted")
+    assert panel.snapshot() == []
+
+
+def test_clear_resets_all_entries() -> None:
+    """Tier 2: ``clear()`` empties the panel."""
+    panel = _panel()
+    panel.add("alice", "x")
+    panel.add("bob", "y")
+    panel.clear()
+    assert panel.snapshot() == []
+    assert panel._build_lines().plain == ""
+
+
+# ── Mounted integration test ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_panel_renders_under_app_with_multiple_entries():
+    """Tier 2: mounted panel actually renders text content at terminal size."""
+    app = _PanelOnlyApp()
+    async with app.run_test(headless=True, size=(80, 10)) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#async_stack", AsyncStackPanel)
+        panel.add("alice", "code_review")
+        panel.add("bob", "monitor")
+        panel.set_pending("alice", 1)
+        await pilot.pause()
+        rendered = panel._build_lines().plain
+        # Both agents appear; pending sorted first.
+        assert "alice" in rendered
+        assert "bob" in rendered
+        first_line = rendered.split("\n", 1)[0]
+        assert "alice" in first_line
+        assert "⚑" in first_line


### PR DESCRIPTION
**[tui-coder]** — issue #427 L4 step 5 of 6.

PoC widget for the bottom-strip async stack per issue #427 L2 spec. Widget shape + entry state mgmt + ordering + cap behaviour land here; production wiring (= agent registry subscription, lifecycle event hookup) is a follow-up PR — same pattern as step 1's ToolCallRow PoC (PR #429).

## Summary

```
⟳ async: code_review · 12.3s      ← running entry
⟳ async: monitor_loop · 5m21s
⚑ async: alice (1 pending)         ← intervention-pending entry
… +N more (panel for all)          ← overflow when > _CAP
```

- ``dock: bottom`` + ``height: auto`` (= collapses to 0 height when empty)
- 1-5 entries dynamic, ``_CAP=5`` overflow indicator
- Sort: ⚑ pending first → ⟳ running by elapsed (shortest first)
- Lifetime: explicit add / set_pending / set_running / remove / clear
- ``snapshot()`` exposes sorted + capped + overflow view for tests / consumers

## Public API

```python
panel.add(agent_id, summary)       # mount / update running entry
panel.set_pending(agent_id, count) # ⟳ → ⚑ + pending count
panel.set_running(agent_id, ...)   # ⚑ → ⟳ (e.g. intervention resolved)
panel.remove(agent_id)             # entry vanishes
panel.clear()                      # reset all
panel.snapshot()                   # list[dict] visible view
```

## Architecture references

Per memory ``feedback_tui_visibility_axis``: bottom strip = ephemeral runtime state (= "what's running right now"). Inline chat history (= ToolCallRow events) is a distinct surface. This widget never emits to history — async lifecycle markers route through inline conv-pane separately when wired up in a follow-up.

## Test plan

- [x] ruff check passes
- [x] 11 Tier 2 tests in ``tests/cli/test_async_stack_panel_poc.py`` 11/11 green:
  - 10 unmounted state tests via ``snapshot()`` + ``_build_lines().plain`` public surfaces
  - 1 mounted integration test exercising ``run_test`` pilot at 80x10
- [x] All assertions via public-surface (= per ``feedback_test_public_surface_not_private_state``); no ``_field`` private state assertions
- [ ] (skipped — manual TUI verify not applicable; widget not yet wired to any production surface. Wave-end smoke arrives when step 6 + production hookup land)

## Wave context

```
✓ step 1: ToolCallRow widget        (PR #429, merged)
✗ step 2: per-op event emission     (retracted)
✓ step 3: forwarder relay           (PR #433, merged)
🔄 step 4: conv pane mount ToolCallRow (PR #435, open)
🆕 step 5: AsyncStackPanel PoC       (this PR)
🔄 step 6: agents tab refactor (= phase / plan / nest depth)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)