### PR TITLE
feat(tui): agents tab plan-step badge (#427 L4 step 6)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -519,6 +519,25 @@ class ReynTUIApp(App):
             phase = text[len("phase started: "):].strip()
             existing["phase"] = phase
             existing["phase_visits"] = existing.get("phase_visits", 0) + 1
+        # Text pattern: "detail: plan N/M" (= ChatEventForwarder one-shot
+        # plan-step badge emit, see forwarder.on_phase_started). Capture
+        # the N/M values into _skill_exec so the right-panel agents tab
+        # can render a [plan N/M] badge alongside the running skill row
+        # — same data wave-7 PR #418 routed into SkillActivityRow's
+        # persistent slot for the conv pane. C-F2 from the wave-7
+        # Topic C exploration.
+        if text.startswith("detail: plan ") and "/" in text:
+            badge = text[len("detail: "):].strip()
+            tail = badge[len("plan "):]
+            if "/" in tail:
+                head, _, rest = tail.partition("/")
+                # rest may have trailing words; take the leading int run.
+                n_total_str = rest.split()[0] if rest else ""
+                try:
+                    existing["plan_n_done"] = int(head)
+                    existing["plan_n_total"] = int(n_total_str)
+                except (ValueError, IndexError):
+                    pass
 
     def _push_exec_state(self) -> None:
         """Forward current _skill_exec snapshot to RightPanel for live display."""

--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -580,6 +580,20 @@ def render_agents(
                     info.get("skill_name", "?"),
                     style=name_style or "#dddddd",
                 )
+                # Wave-7 Topic C-F2: surface plan-step attribution as a
+                # dim ``[plan N/M]`` badge after the skill name so the
+                # agents tab matches the conv pane SkillActivityRow's
+                # persistent plan badge (wave-7 PR #418). Source is the
+                # ``_skill_exec`` snapshot, populated when
+                # ``_update_skill_exec`` parses ``detail: plan N/M``
+                # traces from ChatEventForwarder.
+                plan_n_done = info.get("plan_n_done")
+                plan_n_total = info.get("plan_n_total")
+                if plan_n_done and plan_n_total:
+                    skill_label.append(
+                        f"  [plan {plan_n_done}/{plan_n_total}]",
+                        style=f"dim {_CORAL}",
+                    )
                 skill_node = parent_node.add(skill_label)
                 nodes_by_run_id[run_id] = skill_node
                 item_ys.append(y_counter)
@@ -612,6 +626,11 @@ def render_agents(
                     # Issue #210: surface parent linkage in flat_items so
                     # the preview pane / future actions can route by it.
                     "parent_run_id": info.get("parent_run_id", ""),
+                    # Wave-7 Topic C-F2: plan-step attribution carried
+                    # so preview / future cursor actions can show "this
+                    # skill is plan step N/M".
+                    "plan_n_done": info.get("plan_n_done"),
+                    "plan_n_total": info.get("plan_n_total"),
                 })
 
             # Pass 1: root skills (no parent OR parent not on this agent

--- a/tests/cli/test_agents_tab_plan_step_badge.py
+++ b/tests/cli/test_agents_tab_plan_step_badge.py
@@ -1,0 +1,169 @@
+"""Tier 2: agents tab renders ``[plan N/M]`` badge for plan-step skill rows.
+
+issue #427 L4 step 6 — agents tab refactor for phase / plan / nest
+depth. This PR addresses the wave-7 Topic C-F2 finding (= "agents-tab
+running-skill tree lacks plan step attribution") by surfacing the
+plan-step badge alongside the running skill row, matching the conv
+pane SkillActivityRow's persistent plan badge (wave-7 PR #418).
+
+Contract pinned here:
+
+1. ``running_skill`` flat_items carry ``plan_n_done`` / ``plan_n_total``
+   so cursor / preview / future actions can route by plan attribution.
+2. When both fields are present + > 0, the rendered tree label
+   includes a ``[plan N/M]`` badge after the skill name.
+3. When the fields are absent / 0, no badge appears (= cold-default
+   layout unchanged for non-planner skills).
+4. Badge survives nested sub-skill rendering (= ``parent_run_id``
+   nesting from issue #210 + the plan badge are independent axes).
+
+The plan_n_done / plan_n_total values are populated in ``_skill_exec``
+by ``ReynTUIApp._update_skill_exec`` when it parses
+``ChatEventForwarder``'s ``"detail: plan N/M"`` trace text. This test
+exercises the consumer side (= render_agents) by passing a fake
+exec_state — the parser side is a small string-pattern op covered by
+inspection.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _render_to_plain(renderable) -> str:
+    """Capture a Rich renderable's plain-text output via an isolated console.
+
+    ``render_agents`` returns a ``rich.console.Group`` (header + tree);
+    asserting on substring presence requires rendering through a real
+    console rather than relying on a ``.plain`` attribute that only
+    exists on ``Text``.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=200)
+    console.print(renderable)
+    return buf.getvalue()
+
+
+def _make_registry(tmp_path):
+    from reyn.chat.registry import AgentRegistry
+
+    def _factory(profile):
+        return object()
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=None,
+    )
+
+
+def _exec_entry(
+    skill_name: str,
+    *,
+    plan_n_done: int | None = None,
+    plan_n_total: int | None = None,
+    parent_run_id: str = "",
+):
+    entry = {
+        "skill_name": skill_name,
+        "agent_name": "default",
+        "start_time": time.monotonic(),
+        "phase": "resolve",
+        "phase_visits": 1,
+        "triggered_by": "test",
+        "parent_run_id": parent_run_id,
+    }
+    if plan_n_done is not None:
+        entry["plan_n_done"] = plan_n_done
+    if plan_n_total is not None:
+        entry["plan_n_total"] = plan_n_total
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_running_skill_with_plan_step_carries_fields_in_flat_items(tmp_path):
+    """Tier 2: plan_n_done / plan_n_total surface in flat_items."""
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {
+        "r-1": _exec_entry("planner_sub", plan_n_done=2, plan_n_total=5),
+    }
+    _, flat_items, _ = render_agents(registry, exec_state, cursor=0)
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    assert len(skill_items) == 1
+    assert skill_items[0]["plan_n_done"] == 2
+    assert skill_items[0]["plan_n_total"] == 5
+
+
+@pytest.mark.asyncio
+async def test_running_skill_without_plan_step_omits_badge_in_render(tmp_path):
+    """Tier 2: skills without plan_n_done/plan_n_total render no badge."""
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {"r-1": _exec_entry("non_planner_skill")}
+    rendered, flat_items, _ = render_agents(
+        registry, exec_state, cursor=0,
+    )
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    assert len(skill_items) == 1
+    # The badge text "[plan " must NOT appear in the rendered tree output.
+    plain = _render_to_plain(rendered)
+    assert "[plan " not in plain
+    # flat_items still carries the keys (= None) for schema consistency.
+    assert skill_items[0].get("plan_n_done") is None
+    assert skill_items[0].get("plan_n_total") is None
+
+
+@pytest.mark.asyncio
+async def test_running_skill_with_plan_step_renders_badge_text(tmp_path):
+    """Tier 2: ``[plan N/M]`` substring appears in the rendered output."""
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {
+        "r-1": _exec_entry("planner_sub", plan_n_done=3, plan_n_total=7),
+    }
+    rendered, _, _ = render_agents(registry, exec_state, cursor=0)
+    plain = _render_to_plain(rendered)
+    assert "[plan 3/7]" in plain
+
+
+@pytest.mark.asyncio
+async def test_plan_badge_survives_subskill_nesting(tmp_path):
+    """Tier 2: nested sub-skill with plan_step still renders the badge.
+
+    Verifies the badge axis is orthogonal to the parent_run_id nesting
+    axis — both can coexist on the same row.
+    """
+    from reyn.chat.tui.widgets.right_panel.agents_tab import render_agents
+
+    registry = _make_registry(tmp_path)
+    exec_state = {
+        "r-root": _exec_entry("planner"),
+        "r-child": _exec_entry(
+            "planner_sub", plan_n_done=2, plan_n_total=4,
+            parent_run_id="r-root",
+        ),
+    }
+    rendered, flat_items, _ = render_agents(
+        registry, exec_state, cursor=0,
+    )
+    plain = _render_to_plain(rendered)
+    # Both rows present, child carries badge.
+    assert "planner" in plain
+    assert "planner_sub" in plain
+    assert "[plan 2/4]" in plain
+    # Topology preserved: parent emits before child.
+    skill_items = [i for i in flat_items if i.get("kind") == "running_skill"]
+    run_ids = [i["run_id"] for i in skill_items]
+    assert run_ids.index("r-root") < run_ids.index("r-child")


### PR DESCRIPTION
**[tui-coder]** — issue #427 L4 step 6 of 6 — wave-#427 closure candidate.

Brings the agents-tab running-skill row to parity with the conv-pane SkillActivityRow's persistent plan badge (wave-7 PR #418). Addresses the wave-7 Topic C-F2 deferred finding (= "agents-tab running-skill tree lacks plan step attribution").

## Summary

```
Before:
  ⟳ skill_name#abcd  · execute  · 8.1s

After (when in plan context):
  ⟳ skill_name#abcd  · execute  · 8.1s  [plan 2/5]
```

Plan attribution is now visible across both surfaces (= conv pane via SkillActivityRow / agents tab via this PR).

## Scope (= focused subset of step 6)

| In | Out (= deferred) |
|---|---|
| ✓ ``[plan N/M]`` badge on agents-tab running-skill rows (C-F2) | ✗ tool_call nesting under skill rows (= needs backend per-skill tool_call tracking) |
| ✓ ``plan_n_done`` / ``plan_n_total`` in ``flat_items`` for cursor routing | ✗ plan row "currently-executing step description" (C-F8; needs backend event extension to carry step description in ``plan_step_started`` data) |

The deferred items are bigger architectural pieces that need backend event changes; this PR keeps the wave's closure scope tight while landing the user-facing value (= plan attribution at-a-glance from the right panel).

## Implementation

1. ``ReynTUIApp._update_skill_exec`` learns the ``"detail: plan N/M"`` text pattern emitted by ``ChatEventForwarder.on_phase_started``. Parses N/M values into ``_skill_exec[run_id]`` as ``plan_n_done`` / ``plan_n_total``.
2. ``agents_tab._emit_skill_row`` appends a ``[plan N/M]`` dim-coral badge after the skill name when both fields are present + > 0. Cold-default unchanged.
3. ``flat_items`` carries ``plan_n_done`` / ``plan_n_total`` for cursor / preview / future actions.

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests in ``tests/cli/test_agents_tab_plan_step_badge.py`` 4/4 green:
  - flat_items carries plan fields
  - no plan_step → no badge in render
  - plan_step → ``[plan N/M]`` substring in rendered output (via Rich console capture)
  - badge axis orthogonal to parent_run_id nesting axis
- [x] Existing agents_tab tests (cursor + subskill nesting + compact_ts) 10/10 green (= no regression)
- [x] All assertions via public render surface (= per ``feedback_test_public_surface_not_private_state``); no ``_field`` private state checks
- [ ] (skipped — manual TUI verify deferred to wave-end smoke once AsyncStackPanel production wiring lands; render contract covered by Tier 2)

## Wave-#427 closure

```
✓ step 1 #429: ToolCallRow widget PoC                       (merged)
✗ step 2 #431: op_runtime emission                           (retracted — wrong layer)
✓ step 3 #433: forwarder relay                              (merged)
✓ step 4 #435: conv pane mount end-to-end functional        (merged)
✓ step 5 #437: AsyncStackPanel PoC                          (merged)
🆕 step 6: agents tab plan badge (this PR)                  ← wave closure
```

After this lands, wave-#427 reaches **6/6 progression**. Deferred follow-ups for full feature completeness (= AsyncStackPanel production wiring, tool_call nesting in agents tab, plan-step description) become separate wave candidates per user direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)