### PR TITLE
feat(web): Browser endpoint hardening — CORS + Content-Disposition + OPTIONS (#442)

### DIFF
--- a/src/reyn/web/routers/resources.py
+++ b/src/reyn/web/routers/resources.py
@@ -33,6 +33,34 @@ this very Reyn instance) is the dispatcher's responsibility on the
 consumer side; this router unconditionally serves the local file if it
 exists. Path-traversal escapes (= ``..`` etc.) are rejected via the
 same boundary check ``MediaStore.read_tool_result`` uses.
+
+Browser hardening (#442, 2026-05-22 follow-up after #385 sub-task 3
+"implicit close" retraction):
+
+* **CORS** — ``Access-Control-Allow-Origin: *`` is set so cross-origin
+  Browser frontends can ``fetch(url)`` against this route. Permissive
+  default — tighten via FastAPI's ``CORSMiddleware`` if an origin
+  allowlist becomes needed. The resource itself is already
+  identity-validated (= agent existence check + path-traversal
+  protection), so opening CORS doesn't widen the attack surface
+  beyond what an authenticated same-origin request can already do.
+* **Content-Disposition** — by default ``inline; filename="<artifact>"``
+  so the browser renders the body in a tab. Pass ``?download=1`` to
+  switch to ``attachment; filename="<artifact>"``, triggering the
+  download dialog instead. Consistent UX with how typical file-host
+  endpoints behave.
+* **/api/ prefix decision** — this route stays at top-level
+  ``/agents/<agent>/tool-results/<artifact>`` rather than moving under
+  ``/api``. Rationale: ``reyn web`` already has the mixed convention
+  (``/api/agents`` for REST CRUD, ``/a2a/agents`` for A2A protocol,
+  ``/mcp/*`` for MCP); a resource fetch surface that maps to the
+  filesystem layout (= mirrors ``.reyn/tool-results/``) is naturally
+  the third kind. The ``/api`` prefix is for the REST control plane
+  (= list / create / update), not for content fetch.
+* **Range request** — not implemented in this iteration. Tool results
+  are typically small text bodies; partial-fetch over Range would be
+  useful for large image artifacts but is a stretch goal tracked in
+  the same issue.
 """
 from __future__ import annotations
 
@@ -81,11 +109,32 @@ def _mime_for(artifact: str) -> str:
 # ── GET /agents/<agent>/tool-results/<artifact> ───────────────────────
 
 
+def _browser_headers(artifact: str, *, download: bool) -> dict[str, str]:
+    """Build the response header set for the Browser hardening (#442).
+
+    ``Access-Control-Allow-Origin: *`` — permissive CORS so cross-origin
+    Browser frontends can fetch. Tighten via FastAPI ``CORSMiddleware``
+    if an origin allowlist becomes needed.
+
+    ``Content-Disposition`` — ``inline; filename="..."`` for in-tab
+    render (default), ``attachment; filename="..."`` when ``?download=1``
+    triggers the download dialog. Filename is the artifact basename,
+    which is already validated to be inside ``tool_results_dir`` (= no
+    path-traversal injection via the disposition header).
+    """
+    disposition_kind = "attachment" if download else "inline"
+    return {
+        "access-control-allow-origin": "*",
+        "content-disposition": f'{disposition_kind}; filename="{artifact}"',
+    }
+
+
 @router.get("/agents/{agent_name}/tool-results/{artifact}")
 async def get_tool_result(
     agent_name: str,
     artifact: str,
     request: Request,  # noqa: ARG001 — kept for symmetry with a2a routes
+    download: int = 0,
     registry=Depends(get_registry),
 ) -> Response:
     """Serve a tool-result file by ``<agent>/<artifact>`` route.
@@ -94,7 +143,12 @@ async def get_tool_result(
     the artifact resolves inside ``.reyn/tool-results/`` (= 400 if a
     path-traversal escape is attempted, 404 if the file is absent /
     deleted by the user). Returns the body bytes with a best-effort
-    Content-Type derived from the artifact extension.
+    Content-Type derived from the artifact extension, plus the Browser
+    hardening headers from ``_browser_headers``.
+
+    Query parameter ``download``: when truthy (= ``?download=1``), the
+    Content-Disposition switches to ``attachment`` so Browsers trigger
+    the download dialog. Default is ``inline`` for in-tab render.
 
     Authentication: relies on whatever transport-layer protection
     ``reyn web`` is fronted by (= same posture as ``/a2a/agents/...``
@@ -139,4 +193,41 @@ async def get_tool_result(
             ),
         )
 
-    return Response(content=body, media_type=_mime_for(artifact))
+    return Response(
+        content=body,
+        media_type=_mime_for(artifact),
+        headers=_browser_headers(artifact, download=bool(download)),
+    )
+
+
+# ── OPTIONS /agents/<agent>/tool-results/<artifact> ─────────────────────
+#
+# CORS preflight: browsers send OPTIONS before non-simple cross-origin
+# requests (= ones with custom headers, credentials, or non-GET/POST
+# methods). For simple GETs the preflight isn't strictly required, but
+# adding the handler future-proofs the route against clients that send
+# preflight unconditionally (= some HTTP libraries do) and against
+# future header additions.
+
+
+@router.options("/agents/{agent_name}/tool-results/{artifact}")
+async def options_tool_result(
+    agent_name: str,  # noqa: ARG001 — preflight doesn't need agent existence check
+    artifact: str,  # noqa: ARG001 — preflight doesn't read the artifact
+) -> Response:
+    """CORS preflight response for ``GET /agents/<agent>/tool-results/<artifact>``.
+
+    Returns 204 + permissive CORS headers. Doesn't validate agent
+    existence so a probing client can't enumerate agents via preflight
+    (= the GET still 404s on unknown agents; preflight is just "is
+    this method+origin allowed").
+    """
+    return Response(
+        status_code=204,
+        headers={
+            "access-control-allow-origin": "*",
+            "access-control-allow-methods": "GET, OPTIONS",
+            "access-control-allow-headers": "*",
+            "access-control-max-age": "3600",
+        },
+    )

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -201,3 +201,97 @@ def test_resources_route_is_mounted_on_app():
         "/agents/" in p and "/tool-results/" in p
         for p in paths
     ), f"resources route not mounted; routes seen: {sorted(paths)}"
+
+
+# ── Browser hardening (#442) ───────────────────────────────────────────
+
+
+def test_cors_allow_origin_header_present_on_get(tmp_project: Path):
+    """Tier 2 (#442): a successful GET carries
+    ``Access-Control-Allow-Origin: *`` so cross-origin Browser
+    frontends can ``fetch(url)`` without preflight failure. This is
+    the core fix for the "implicit close was premature" retraction.
+    """
+    block = _mint_path_ref(tmp_project, content="x\n")
+    artifact = Path(block["path"]).name
+
+    response = _client().get(f"/agents/researcher/tool-results/{artifact}")
+
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "*"
+
+
+def test_content_disposition_inline_by_default(tmp_project: Path):
+    """Tier 2 (#442): default Content-Disposition is ``inline; filename="..."``
+    so Browsers render the body in-tab rather than triggering download.
+    Matches the "preview / read" UX path that the LLM-side dispatcher
+    uses too — opening the URL just shows the content.
+    """
+    block = _mint_path_ref(tmp_project, content="render me\n")
+    artifact = Path(block["path"]).name
+
+    response = _client().get(f"/agents/researcher/tool-results/{artifact}")
+
+    cd = response.headers.get("content-disposition", "")
+    assert cd.startswith("inline"), f"expected inline, got: {cd!r}"
+    assert f'filename="{artifact}"' in cd
+
+
+def test_content_disposition_attachment_when_download_query(tmp_project: Path):
+    """Tier 2 (#442): ``?download=1`` switches Content-Disposition to
+    ``attachment`` so Browsers trigger the download dialog. The
+    filename remains the artifact name (= mirrors the same-host fs
+    convention).
+    """
+    block = _mint_path_ref(tmp_project, content="save me\n")
+    artifact = Path(block["path"]).name
+
+    response = _client().get(
+        f"/agents/researcher/tool-results/{artifact}?download=1",
+    )
+
+    cd = response.headers.get("content-disposition", "")
+    assert cd.startswith("attachment"), f"expected attachment, got: {cd!r}"
+    assert f'filename="{artifact}"' in cd
+
+
+def test_options_preflight_returns_cors_headers(tmp_project: Path):
+    """Tier 2 (#442): OPTIONS preflight returns 204 + the CORS headers
+    a Browser needs to permit a subsequent cross-origin GET. Future-
+    proofing: most simple GETs don't need preflight today, but HTTP
+    libraries vary on when they send it, and a missing preflight
+    handler silently 405s on those clients.
+    """
+    response = _client().options(
+        "/agents/researcher/tool-results/anything.txt",
+    )
+
+    assert response.status_code == 204
+    assert response.headers.get("access-control-allow-origin") == "*"
+    assert "GET" in response.headers.get("access-control-allow-methods", "")
+
+
+def test_options_preflight_does_not_leak_agent_existence(tmp_project: Path):
+    """Tier 2 (#442): OPTIONS preflight returns 204 even for an
+    unregistered agent (= the preflight is "can I do this method+
+    origin combination", not "does this resource exist"). Prevents
+    using preflight as an enumeration channel — GET still 404s
+    properly on unknown agents.
+
+    The risk this defends against: a malicious page probing
+    ``/agents/<guess>/tool-results/x`` via preflight to enumerate
+    valid agent names. With preflight 204 regardless, the only
+    signal a probe gets is the GET response, which is rate-limit /
+    auth target territory.
+    """
+    response = _client().options(
+        "/agents/totally-unknown-agent/tool-results/whatever.txt",
+    )
+
+    # Returns 204 (= preflight successful), not 404
+    assert response.status_code == 204
+    # Compare to GET which DOES 404 on unknown agent (= existing test).
+    get_response = _client().get(
+        "/agents/totally-unknown-agent/tool-results/whatever.txt",
+    )
+    assert get_response.status_code == 404


### PR DESCRIPTION
**[e2e-coder]** — closes #442 (= core of the issue, stretch items below). Follow-up to #385 sub-task 3 ``implicit close`` retraction.

## Summary

The HTTP route landed in PR #434 was functional for same-origin Browser fetch + the LLM-side httpx dispatcher, but cross-origin Browser frontends and file-download UX needed actual hardening. This PR addresses the gaps the retraction surfaced.

## Why this isn't in #385

| Axis | Issue | What |
|---|---|---|
| **LLM-side cross-host dispatcher** | #385 | Producer mints URL, consumer LLM resolves via httpx |
| **Browser-as-consumer frontend UX** | #442 (this) | CORS / Content-Disposition / OPTIONS preflight |

Both share the route but diverge on which HTTP headers / methods matter. Splitting keeps each issue's audit trail clean.

## Hardening details

### CORS
- ``Access-Control-Allow-Origin: *`` on GET — permissive default so cross-origin Browser frontends can ``fetch(url)``
- OPTIONS preflight handler returns 204 + ``Access-Control-Allow-*`` headers

### Content-Disposition
- Default ``inline; filename="<artifact>"`` — render in-tab (= same UX as opening a URL)
- ``?download=1`` switches to ``attachment; filename="..."`` — triggers download dialog
- Filename is the artifact name (= already validated inside ``tool_results_dir``; no header injection)

### ``/api/`` prefix decision (documented in docstring)
Route stays at top-level. Rationale: ``reyn web`` mixed convention:
- ``/api/agents/...`` — REST CRUD
- ``/a2a/agents/...`` — A2A protocol
- ``/mcp/*`` — MCP-over-SSE
- ``/agents/<>/tool-results/<>`` — content fetch (this route)

``/api`` is for the REST control plane, not content fetch. Adding it here would conflate the two.

### OPTIONS preflight: agent enumeration defence
Preflight returns 204 even for unknown agents — intentional. Preflight is "can I do this method+origin combination", NOT "does this resource exist". Validating existence on preflight would create an enumeration channel via preflight reactions. GET-side 404 stays the only signal — easier to rate-limit / monitor.

### Range request (= stretch, not this PR)
Tool results are typically small text; Range would help for large image artifacts but isn't required for LLM or default Browser use cases. Tracked in #442 as a stretch goal; not required for this issue's closure.

## Change shape

- ``src/reyn/web/routers/resources.py``:
  - ``_browser_headers(artifact, download)`` helper
  - GET handler: ``download: int = 0`` query param, pass headers to Response
  - New OPTIONS handler for CORS preflight
  - Module docstring: "Browser hardening" section
- ``tests/web/test_resources_router.py``: +5 tests
  - CORS Allow-Origin on GET
  - Content-Disposition inline default
  - Content-Disposition attachment via ``?download=1``
  - OPTIONS returns 204 + CORS headers
  - OPTIONS doesn't leak agent existence

## Test plan

- [x] ``pytest tests/web/test_resources_router.py`` — 11/11 pass (6 existing + 5 new)
- [x] ``pytest tests/`` (full suite) — 4720 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched (= no LLM-visible tool schema change).

## What's still in #442 as future work

- Range request (= 206 Partial Content) — stretch goal
- Origin allowlist via ``CORSMiddleware`` — if permissive default becomes too lax under concrete production origins
- Auth headers (= per-route token verification beyond transport layer)

Closes the **core** of #442; stretch items can land in follow-up PRs without breaking this PR's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)