### PR TITLE
fix(tui): keep ToolCallRow result placeholders atomic (#427 follow-up F-A)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -82,12 +82,24 @@ def _format_tool_args(args: dict | None) -> str:
     return ", ".join(parts)
 
 
+# Output budget for the assembled result snippet. ToolCallRow re-truncates
+# at terminal width for very narrow terminals, but the formatter itself
+# caps total length to keep ``<N chars>`` placeholder fields atomic — if
+# the cell-aware truncation downstream had to cut into a placeholder
+# (= ``content=<3 cha…``), the placeholder would lose its meaning.
+# Drop trailing fields whole instead of truncating mid-placeholder.
+_TOOL_RESULT_BUDGET_CHARS = 80
+
+
 def _format_tool_result(result) -> str:
     """Compact one-line repr of dispatcher result for the ToolCallRow row-2.
 
     Accepts dict / str / None; degrades to "" when result has nothing
-    presentable. The widget further truncates to terminal width, so
-    this just removes the bulky body fields and joins the rest.
+    presentable. Caps total length at ``_TOOL_RESULT_BUDGET_CHARS`` by
+    dropping trailing fields whole rather than truncating mid-string, so
+    ``<N chars>`` placeholders never get cut into incomprehensible
+    fragments (= ``content=<3 cha…`` instead of ``content=<3 chars>``
+    or the field dropped entirely).
     """
     if result is None:
         return ""
@@ -104,6 +116,13 @@ def _format_tool_result(result) -> str:
         if len(s) > 60:
             s = s[:57] + "..."
         parts.append(f"{key}={s}")
+    # Drop trailing fields whole until the joined string fits the budget.
+    # Preserves atomic shape of ``<N chars>`` placeholders + ``key=value``
+    # pairs — partial fields would be noise. Keeps ``status`` / earlier
+    # context fields first because dict iteration is insertion-order, and
+    # op handlers tend to emit ``status`` / primary signals first.
+    while parts and len(", ".join(parts)) > _TOOL_RESULT_BUDGET_CHARS:
+        parts.pop()
     return ", ".join(parts)
 
 

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -184,3 +184,45 @@ def test_format_tool_result_truncates_long_string_input():
     out = _format_tool_result("x" * 500)
     assert out.endswith("...")
     assert len(out) <= 120
+
+
+def test_format_tool_result_drops_trailing_fields_to_keep_placeholders_atomic():
+    """Tier 2: ``<N chars>`` placeholder must survive whole — drop trailing
+    fields rather than truncating into the placeholder string.
+
+    Wave-#427 smoke detected ``content=<3 cha…`` (= placeholder broken
+    mid-string) when the joined result exceeded the body budget. The
+    fixed formatter drops trailing fields atomically; the placeholder
+    is either present in full or dropped entirely — never truncated
+    into a meaningless fragment.
+    """
+    # Many small fields plus a placeholder-eligible bulky one at the end
+    # — the assembled string blows past the budget, so trailing fields
+    # should be dropped while earlier ones survive intact.
+    result = {
+        "kind": "file",
+        "op": "read",
+        "path": "some/really/long/path/that/eats/up/many/cells.toml",
+        "status": "ok",
+        "exit_code": 0,
+        "extra_field_1": "value_one",
+        "extra_field_2": "value_two",
+        "content": "x" * 5000,
+    }
+    out = _format_tool_result(result)
+    # Budget cap honored.
+    assert len(out) <= 80
+    # No partial placeholder fragments — if `content=` appears, the full
+    # `<5000 chars>` must follow; otherwise it shouldn't appear at all.
+    if "content=" in out:
+        assert "<5000 chars>" in out, (
+            f"placeholder broken mid-string: {out!r}"
+        )
+    # Earlier, more-important fields preserved (= dict insertion order).
+    assert "kind=file" in out
+
+
+def test_format_tool_result_short_result_unchanged():
+    """Tier 2: a result that fits the budget passes through verbatim."""
+    out = _format_tool_result({"status": "ok", "exit_code": 0, "bytes": 1234})
+    assert out == "status=ok, exit_code=0, bytes=1234"


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-A (P1).

## Problem (= observed in tmux smoke)

```
✓ file__read(path=pyproject.toml)  · 0.0s
  ⎿ kind=file, op=read, path=pyproject.toml, status=ok, content=<3 cha…
                                                              ^^^^^^^^
                                        placeholder cut mid-string
```

The bulky-field collapse correctly produced ``content=<3 chars>`` (= "field exists, body collapsed" signal), but the assembled snippet exceeded the body budget so ``ToolCallRow._build_line2``'s cell-aware truncation cut into the placeholder text. The fragment ``<3 cha…`` carries no information.

## Fix

``_format_tool_result`` now caps total length at ``_TOOL_RESULT_BUDGET_CHARS`` (= 80) by dropping trailing fields whole rather than truncating mid-string. Earlier fields (= ``status`` / primary signals — op handlers emit those first per dict insertion order) survive intact; trailing placeholders are either preserved in full or dropped entirely — never truncated into incomprehensible fragments.

ToolCallRow's terminal-width truncation stays as defense-in-depth for narrow terminals but doesn't get to see strings that would force it to cut placeholders.

## Test plan

- [x] ruff check passes
- [x] 2 new Tier 2 tests in ``test_conv_pane_tool_call_lifecycle.py``:
  - Long result with placeholder → placeholder atomic or dropped
  - Short result → unchanged passthrough
- [x] Existing 12 tests in same file remain green (= no regression on short / typical inputs)
- [ ] (skipped — manual TUI smoke verify deferred to wave end; behavior covered by Tier 2 against the formatter helper directly)

## Wave context

wave-#427 UX follow-up sequence (9 findings):
- **🆕 F-A (this PR, P1)**: placeholder truncation
- F-B (P1): failed tool error reason visibility
- F-C (P2): redundant kind / op fields
- F-D (P2): 0.0s elapsed handling
- F-E (P2): qualified name truncation
- F-F (P2): visual nesting
- F-G (P3): ⎿ indent
- F-H (P3): min display time
- F-I (P3): badge emphasis

🤖 Generated with [Claude Code](https://claude.com/claude-code)