### PR TITLE
fix(tui): skip redundant kind/op fields in ToolCallRow result snippet (F-C)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -60,6 +60,13 @@ _TOOL_ARG_BULKY_FIELDS = frozenset({
     "content", "new_string", "old_string", "body", "preview",
 })
 
+# Keys to skip when formatting tool result for line-2 display: they're
+# already encoded in the tool name on line 1 (= ``file__read(...)``
+# already carries ``kind=file`` + ``op=read``). Surfacing them again
+# in the result snippet is noise that pushes more-informative fields
+# (= ``status`` / ``exit_code`` / specific data) off the truncated line.
+_TOOL_RESULT_REDUNDANT_KEYS = frozenset({"kind", "op"})
+
 
 def _format_tool_args(args: dict | None) -> str:
     """Compact ``key=value, ...`` repr of dispatcher args for ToolCallRow.
@@ -97,6 +104,8 @@ def _format_tool_result(result) -> str:
         return str(result)[:120]
     parts: list[str] = []
     for key, value in result.items():
+        if key in _TOOL_RESULT_REDUNDANT_KEYS:
+            continue
         if key in _TOOL_ARG_BULKY_FIELDS and isinstance(value, str) and len(value) > 24:
             parts.append(f"{key}=<{len(value)} chars>")
             continue

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -179,6 +179,32 @@ def test_format_tool_result_collapses_bulky_body():
     assert "<5000 chars>" in out
 
 
+def test_format_tool_result_skips_redundant_kind_and_op_keys():
+    """Tier 2: ``kind`` and ``op`` fields are already encoded in the tool
+    name on line 1 — surfacing them again in the result snippet is noise.
+
+    F-C (wave-#427 follow-up): smoke output showed
+    ``kind=file, op=read, path=..., status=ok, ...`` consuming half the
+    line width with information the user already has from line 1's
+    ``file__read(...)``. Skipping them lets ``status`` / ``exit_code``
+    / specific result fields land in the visible budget instead.
+    """
+    out = _format_tool_result({
+        "kind": "file",
+        "op": "read",
+        "status": "ok",
+        "exit_code": 0,
+        "path": "/tmp/x.txt",
+    })
+    # Redundant keys are gone.
+    assert "kind=" not in out
+    assert "op=" not in out
+    # Informative fields remain.
+    assert "status=ok" in out
+    assert "exit_code=0" in out
+    assert "path=/tmp/x.txt" in out
+
+
 def test_format_tool_result_truncates_long_string_input():
     """Tier 2: very long plain-string result gets ellipsised."""
     out = _format_tool_result("x" * 500)


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-C (P2).

## Problem

```
✓ file__read(path=pyproject.toml)  · 0.0s
  ⎿ kind=file, op=read, path=pyproject.toml, status=ok, ...
    ^^^^^^^^^^^^^^^^^^^                    ^^^^^^^^^^^^^^^
    already in tool name on line 1         informative
```

``kind=file`` + ``op=read`` are already encoded in the tool name shown on line 1 (= ``file__read(...)``). Repeating them in the result snippet wastes ~20 characters of an 80-char budget that should be carrying informative fields (= ``status`` / ``exit_code`` / op-specific result data).

## Fix

``_format_tool_result`` skips ``kind`` + ``op`` keys via the new ``_TOOL_RESULT_REDUNDANT_KEYS`` frozenset.

After this fix:
```
✓ file__read(path=pyproject.toml)  · 0.0s
  ⎿ path=pyproject.toml, status=ok, exit_code=0
```

(``path`` stays because it can differ from args.path when the op resolves a relative path — conservative for now; a future iteration could compare args.path == result.path, but needs cross-line state we don't currently pass to the formatter.)

## Test plan

- [x] ruff check passes
- [x] 1 new Tier 2 test verifies skip + informative fields survive
- [x] Existing 12 tests in same file remain green

## Wave context

```
✓ F-A (P1, PR #446): placeholder atomic truncation
✓ F-B (P1, PR #447): failed tool error reason visibility
🆕 F-C (P2, this PR): redundant kind / op fields
🔄 F-D (P2): 0.0s elapsed handling
🔄 F-E (P2): qualified name truncation
🔄 F-F (P2): visual nesting
🔄 F-G (P3): ⎿ indent
🔄 F-H (P3): min display time
🔄 F-I (P3): badge emphasis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)