### PR TITLE
fix(tui): hide ToolCallRow elapsed for sub-100ms terminal rows (F-D)

### DIFF
--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -43,6 +43,13 @@ _TICK_INTERVAL_S = 0.5  # elapsed-time refresh rate
 _ELAPSED_AMBER_S = 30.0
 _ELAPSED_RED_S = 60.0
 
+# Below this threshold the terminal-state row hides the elapsed segment
+# entirely (= `· 0.0s` was noise on fast file_read / cache hit / 等).
+# Still-running rows always show elapsed so the user has a "this is
+# alive" signal regardless of duration. Threshold is roughly the
+# tick interval — below it, `0.0s` is just rounding artifact.
+_ELAPSED_HIDE_THRESHOLD_S = 0.1
+
 # Indent column for the result line (= ``  ⎿ ``). Two spaces aligns the
 # result under the tool-name column of line 1 in the typical Latin glyph
 # width; CJK / emoji shift this but ⎿ is unambiguous-narrow so the
@@ -229,10 +236,15 @@ class ToolCallRow(Widget):
         return "".join(out) + ellipsis
 
     def _build_line1(self) -> Text:
-        """``<glyph> <tool>(<args>)  · <elapsed>`` — terminal-width-adaptive."""
+        """``<glyph> <tool>(<args>)  · <elapsed>`` — terminal-width-adaptive.
+
+        Elapsed segment is hidden when the row is in a terminal state AND
+        elapsed < ``_ELAPSED_HIDE_THRESHOLD_S`` (= ``0.0s`` is noise on
+        sub-100ms ops). Still-running rows always show elapsed so the
+        user has a "this is alive" signal regardless of duration.
+        """
         t = Text()
         glyph, glyph_style = self._state_glyph()
-        elapsed = self._elapsed_str()
 
         # Compute right-edge reservation: elapsed segment + `  · ` prefix
         # + right margin. The body (= glyph + tool + args) fills whatever
@@ -247,7 +259,10 @@ class ToolCallRow(Widget):
             # arithmetic produces sensible budgets instead of zeroing the
             # args field.
             total_width = 80
-        elapsed_segment = f"  · {elapsed}"
+        if self._finished and self._elapsed_s() < _ELAPSED_HIDE_THRESHOLD_S:
+            elapsed_segment = ""
+        else:
+            elapsed_segment = f"  · {self._elapsed_str()}"
         elapsed_cells = cell_len(elapsed_segment)
         body_budget = max(8, total_width - elapsed_cells - _RIGHT_MARGIN_CELLS)
 

--- a/tests/cli/test_tool_call_row_poc.py
+++ b/tests/cli/test_tool_call_row_poc.py
@@ -123,6 +123,52 @@ def test_long_args_truncated_with_ellipsis_within_terminal_width() -> None:
     assert "s" in line1  # elapsed survives
 
 
+def test_terminal_state_with_sub_100ms_elapsed_hides_segment() -> None:
+    """Tier 2: terminal-state row with elapsed < 0.1s hides ``· 0.0s`` noise.
+
+    F-D (wave-#427 follow-up): fast ops (= file_read cache hit / 等)
+    rendered ``· 0.0s`` which is noise — sub-100ms is below display
+    resolution. Hide the elapsed segment entirely when the row is
+    terminal AND elapsed is below the threshold.
+    """
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+    row = ToolCallRow(tool_name="cached_op", args_repr="key=x")
+    # Force frozen elapsed to a sub-threshold value before finishing
+    # — avoids race against monotonic clock in test environment.
+    row._frozen_elapsed = 0.0
+    row.finish_success(result_snippet="ok")
+    # Re-pin frozen elapsed because finish_success captures current
+    # monotonic (= may have advanced past threshold during test setup).
+    row._frozen_elapsed = 0.0
+    line1 = row._build_line1().plain
+    assert "0.0s" not in line1, "sub-100ms elapsed should be hidden in terminal state"
+    # Tool name + glyph still visible.
+    assert "cached_op" in line1
+    assert "✓" in line1
+
+
+def test_running_state_always_shows_elapsed_even_at_zero() -> None:
+    """Tier 2: running rows ALWAYS show elapsed (= "alive" signal)."""
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+    row = ToolCallRow(tool_name="slow_op", args_repr="key=x")
+    # Force frozen elapsed visible by NOT finishing — still running.
+    # Render and check elapsed appears regardless of value.
+    line1 = row._build_line1().plain
+    assert "s" in line1, "running row carries elapsed (= alive signal)"
+
+
+def test_terminal_state_above_threshold_shows_elapsed() -> None:
+    """Tier 2: terminal-state row with elapsed >= 0.1s still shows the
+    elapsed segment (= meaningful timing preserved)."""
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+    row = ToolCallRow(tool_name="op", args_repr="")
+    row.finish_success(result_snippet="ok")
+    # Frozen elapsed has whatever monotonic captured; force above threshold.
+    row._frozen_elapsed = 0.5
+    line1 = row._build_line1().plain
+    assert "0.5s" in line1
+
+
 def test_result_snippet_truncated_when_long() -> None:
     """Tier 2: long result snippets get the same ``…`` treatment on line 2."""
     row = _row()


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-D (P2).

## Problem

```
✓ cached_op(key=x)  · 0.0s
                    ^^^^^^
                    noise — sub-100ms rounds to 0
```

Fast ops (= file_read cache hit / result memoization) render ``· 0.0s`` — no information below tick resolution. The ✓ glyph already says "finished"; elapsed adds nothing for instant rows.

## Fix

When the row is in a terminal state AND elapsed is below ``_ELAPSED_HIDE_THRESHOLD_S`` (= 0.1s), hide the elapsed segment.

Still-running rows always show elapsed (= "alive" signal must stay visible regardless of duration).

Threshold rationale: 0.1s ≈ 2× the 0.5s tick interval / 5; below that, the displayed value is rounding artifact rather than measured time.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: terminal+sub-threshold / running always shows / terminal+above-threshold preserved
- [x] Existing 8 tests in same file unaffected

## Wave context

```
✓ F-A (P1, PR #446): placeholder atomic truncation
✓ F-B (P1, PR #447): failed tool error reason visibility
✓ F-C (P2, PR #448): redundant kind / op fields
🆕 F-D (P2, this PR): 0.0s elapsed handling
🔄 F-E (P2): qualified name truncation
🔄 F-F (P2): visual nesting
🔄 F-G (P3): ⎿ indent
🔄 F-H (P3): min display time
🔄 F-I (P3): badge emphasis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)