### PR TITLE
fix(tui): middle-elide long qualified tool names (F-E)

### DIFF
--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -64,6 +64,35 @@ _RESULT_INDENT = "  ⎿ "
 _RIGHT_MARGIN_CELLS = 6
 
 
+def _maybe_middle_elide(name: str, max_cells: int) -> str:
+    """Middle-elide a qualified tool name so head + tail stay visible.
+
+    For ``mcp__server__tool_name`` with budget 18, returns
+    ``mcp__…__tool_name``. The first and last segments carry the most
+    identity signal (= provider prefix + verb); middle segments
+    (= server / namespace) are the disposable part.
+
+    Falls back to plain tail-truncate when:
+    - name doesn't contain ``__`` (= no qualified shape)
+    - name has fewer than 3 segments (= no middle to elide)
+    - even the elided form exceeds the budget (= rare; budget very tight)
+    """
+    if cell_len(name) <= max_cells:
+        return name
+    sep = "__"
+    if sep not in name:
+        return name  # caller falls through to its own truncation
+    parts = name.split(sep)
+    if len(parts) < 3:
+        return name
+    elided = f"{parts[0]}{sep}…{sep}{parts[-1]}"
+    if cell_len(elided) <= max_cells:
+        return elided
+    # Even compressed form too long — give up, let caller's tail-truncate
+    # (= cell-aware ellipsis on the full name) take over.
+    return name
+
+
 class ToolCallRow(Widget):
     """One inline tool-call row that updates in-place until terminal state.
 
@@ -292,7 +321,19 @@ class ToolCallRow(Widget):
         # Truncation order: shrink args first (= most disposable).
         glyph_with_space = f"{glyph} "
         glyph_cells = cell_len(glyph_with_space)
-        tool_open = f"{self._tool_name}("
+        # F-E: when the tool name itself is so long that args have no
+        # room to render, middle-elide qualified names
+        # (``mcp__server__tool_name`` → ``mcp__…__tool_name``) so args
+        # still get a usable budget. Plain names without ``__`` fall
+        # through to the existing args-first truncation.
+        framing_cells = glyph_cells + 2  # 2 = "(" + ")"
+        # Reserve at least 8 cells for args so very long tool names
+        # trigger middle-elide before args get fully ejected.
+        max_tool_budget = max(0, body_budget - framing_cells - 8)
+        tool_display = self._tool_name
+        if max_tool_budget > 0 and cell_len(tool_display) > max_tool_budget:
+            tool_display = _maybe_middle_elide(tool_display, max_tool_budget)
+        tool_open = f"{tool_display}("
         tool_close = ")"
         tool_open_cells = cell_len(tool_open)
         tool_close_cells = cell_len(tool_close)

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -304,6 +304,9 @@ def test_format_tool_result_drops_trailing_fields_to_keep_placeholders_atomic():
     # Many small fields plus a placeholder-eligible bulky one at the end
     # — the assembled string blows past the budget, so trailing fields
     # should be dropped while earlier ones survive intact.
+    # Note: ``kind`` + ``op`` are skipped by ``_format_tool_result`` per
+    # F-C (PR #448), so the surviving earlier field is ``path`` (= first
+    # non-redundant key in dict order).
     result = {
         "kind": "file",
         "op": "read",
@@ -323,8 +326,9 @@ def test_format_tool_result_drops_trailing_fields_to_keep_placeholders_atomic():
         assert "<5000 chars>" in out, (
             f"placeholder broken mid-string: {out!r}"
         )
-    # Earlier, more-important fields preserved (= dict insertion order).
-    assert "kind=file" in out
+    # Earlier, more-important fields preserved (= ``path`` is the first
+    # non-redundant field after F-C's kind/op skip).
+    assert "path=" in out
 
 
 def test_format_tool_result_short_result_unchanged():

--- a/tests/cli/test_tool_call_row_poc.py
+++ b/tests/cli/test_tool_call_row_poc.py
@@ -169,6 +169,49 @@ def test_terminal_state_above_threshold_shows_elapsed() -> None:
     assert "0.5s" in line1
 
 
+def test_long_qualified_tool_name_middle_elides_for_args_budget() -> None:
+    """Tier 2: ``mcp__server__tool_name(args)`` middle-elides when over budget.
+
+    F-E (wave-#427 follow-up): before this fix, very long qualified
+    tool names ate all of the body budget, leaving args with 0
+    cells (= args fully truncated to "…"). Middle-elide keeps the
+    head + tail of the qualified name so args still get a usable
+    budget.
+    """
+    from reyn.chat.tui.widgets.tool_call_row import (
+        ToolCallRow,
+        _maybe_middle_elide,
+    )
+
+    # Unit test the helper directly — easier to verify shape than
+    # integration through _build_line1's budget arithmetic.
+    name = "mcp__some_long_server_namespace__do_the_thing_now"
+    # Budget large enough for ``mcp__…__do_the_thing_now`` (= 24 cells).
+    elided = _maybe_middle_elide(name, max_cells=30)
+    # Head + tail preserved, middle replaced with ``…``.
+    assert elided.startswith("mcp__")
+    assert elided.endswith("__do_the_thing_now")
+    assert "…" in elided
+    # Plain (non-qualified) names fall through unchanged.
+    assert _maybe_middle_elide("short_name", max_cells=20) == "short_name"
+    # Short names under budget are returned verbatim.
+    assert _maybe_middle_elide("a__b__c", max_cells=100) == "a__b__c"
+    # Two-segment names (= no middle to elide) also fall through.
+    assert _maybe_middle_elide("only__two", max_cells=5) == "only__two"
+    # When even the elided form exceeds the budget, helper bails to the
+    # original name (caller's tail-truncate then takes over).
+    assert _maybe_middle_elide(name, max_cells=10) == name
+
+    # Integration: ToolCallRow with a very long qualified name still
+    # surfaces both prefix and suffix of the name in line 1.
+    row = ToolCallRow(
+        tool_name=name, args_repr="param1=value1",
+    )
+    line1 = row._build_line1().plain
+    assert "mcp" in line1, "prefix segment of qualified name survives"
+    assert "do_the_thing_now" in line1, "tail segment of qualified name survives"
+
+
 def test_result_snippet_truncated_when_long() -> None:
     """Tier 2: long result snippets get the same ``…`` treatment on line 2."""
     row = _row()


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-E (P2).

## Problem

Before this fix, very long qualified tool names ate all body budget on line 1, leaving args fully ejected:

```
✓ mcp__some_long_server_namespace__do_the_thing_now(…)  · 0.5s
                                                     ^
                                              args fully truncated
```

Identity signal preserved but args context lost.

## Fix

``_maybe_middle_elide`` compresses qualified names by replacing middle segments with ``…``:

```
mcp__some_long_server_namespace__do_the_thing_now
                  ↓ (when over budget)
mcp__…__do_the_thing_now
```

First segment (= provider / prefix) + last segment (= verb) carry identity signal; middle segments (= server / namespace) are the disposable part.

Trigger: line 1 reserves ≥ 8 cells for args. When the tool name would force args below that, the elider activates. Plain (= non-qualified) names fall through to existing tail-truncate.

## Test plan

- [x] ruff check passes
- [x] 1 new Tier 2 test covers helper (= unit shape + edge cases) + integration through ``_build_line1``
- [x] Existing 8 tests in same file unaffected

## Wave context

```
✓ F-A (P1, PR #446): placeholder atomic truncation
✓ F-B (P1, PR #447): failed tool error reason visibility
✓ F-C (P2, PR #448): redundant kind / op fields
✓ F-D (P2, PR #449): 0.0s elapsed handling
🆕 F-E (P2, this PR): qualified name middle-elide
🔄 F-F (P2): visual nesting
🔄 F-G (P3): ⎿ indent
🔄 F-H (P3): min display time
🔄 F-I (P3): badge emphasis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)