### PR TITLE
fix(tui): nest ToolCallRow under parent SkillActivityRow visually (F-F)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -792,9 +792,18 @@ class OutboxRouter:
         op_id = str(meta.get("op_id") or "")
         tool_name = str(meta.get("tool") or msg.text or "tool")
         args = meta.get("args") or {}
+        # F-F: pass through the source run_id so the conv pane can nest
+        # the tool_call row under its owning SkillActivityRow when one
+        # is currently mounted (= sub-skill spawned the call). The conv
+        # pane checks whether the run_id matches a mounted skill row;
+        # unmatched → root-level rendering (no prefix).
+        parent_run_id = str(meta.get("run_id") or "")
         try:
             conv.start_tool_call_row(
-                op_id, tool_name, args_repr=_format_tool_args(args),
+                op_id,
+                tool_name,
+                args_repr=_format_tool_args(args),
+                parent_run_id=parent_run_id,
             )
         except Exception:
             pass

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -880,6 +880,7 @@ class ConversationView(Widget):
         tool_name: str,
         *,
         args_repr: str = "",
+        parent_run_id: str = "",
     ) -> ToolCallRow | None:
         """Mount a ToolCallRow for ``op_id`` if one isn't already present.
 
@@ -890,6 +891,13 @@ class ConversationView(Widget):
         None (= consumer with no correlation id falls back to silent
         suppression rather than mounting an unkeyed row that can never
         be finalised).
+
+        ``parent_run_id`` (F-F): when non-empty AND a SkillActivityRow
+        for that run_id is currently mounted, the new row renders with
+        a ``  └─ `` prefix so tool_calls visibly nest under their owning
+        skill — same idiom as ``start_skill_row``'s ``parent_run_id``
+        handling for sub-skill rows (issue #210). Root-level tool_calls
+        (= no matching parent skill row) render with empty prefix.
         """
         if not op_id:
             return None
@@ -897,9 +905,13 @@ class ConversationView(Widget):
         if existing is not None:
             return existing
         self._consume_empty_hint()
+        label_prefix = ""
+        if parent_run_id and parent_run_id in self._skill_rows:
+            label_prefix = "  └─ "
         row = ToolCallRow(
             tool_name=tool_name,
             args_repr=args_repr,
+            label_prefix=label_prefix,
             id=f"toolcall_{op_id[:8]}",
         )
         self._tool_call_rows[op_id] = row

--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -82,12 +82,20 @@ class ToolCallRow(Widget):
         *,
         tool_name: str,
         args_repr: str = "",
+        label_prefix: str = "",
         id: str | None = None,
     ) -> None:
         super().__init__(id=id)
         self._tool_name = tool_name
         self._args_repr = args_repr
         self._result_snippet: str = ""
+        # F-F: when this tool_call originated from a sub-skill whose
+        # SkillActivityRow is currently mounted, the conv pane passes
+        # ``label_prefix="  └─ "`` so the inline rows visibly nest
+        # under the parent skill row — same idiom as SkillActivityRow's
+        # own ``label_prefix`` (issue #210 sub-skill nesting). Empty
+        # for root-level tool_calls.
+        self._label_prefix = label_prefix
 
         # Running state
         self._start = time.monotonic()
@@ -265,6 +273,8 @@ class ToolCallRow(Widget):
         )
         args_display = self._truncate_to_cells(self._args_repr, args_budget)
 
+        if self._label_prefix:
+            t.append(self._label_prefix, style="dim #666666")
         t.append(glyph_with_space, style=glyph_style)
         t.append(tool_open, style="bold" if not self._finished else "dim")
         t.append(args_display, style="dim")

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -141,6 +141,54 @@ async def test_unknown_op_id_terminals_are_no_op():
         assert len(list(conv.query(ToolCallRow))) == 0
 
 
+@pytest.mark.asyncio
+async def test_tool_call_with_parent_run_id_matching_skill_row_nests():
+    """Tier 2 F-F: tool_call whose run_id matches a mounted SkillActivityRow
+    renders with a ``└─`` prefix so the nesting is visible.
+    """
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Mount a SkillActivityRow first (= "parent" of the eventual
+        # tool_call) so the run_id lookup hits.
+        conv.start_skill_row(run_id="parent-skill-run", skill_name="planner")
+        await pilot.pause()
+        row = conv.start_tool_call_row(
+            "op-nested",
+            "read_file",
+            args_repr="path=/x",
+            parent_run_id="parent-skill-run",
+        )
+        await pilot.pause()
+        assert row is not None
+        line1 = row._build_line1().plain
+        assert "└─" in line1, "nested tool_call carries └─ prefix"
+        assert "read_file" in line1
+
+
+@pytest.mark.asyncio
+async def test_tool_call_with_unmatched_parent_run_id_renders_root_level():
+    """Tier 2 F-F: tool_call whose run_id doesn't match any mounted skill
+    row falls back to root-level rendering (= no └─ prefix).
+    """
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No skill rows mounted — parent_run_id has nothing to match.
+        row = conv.start_tool_call_row(
+            "op-root",
+            "read_file",
+            args_repr="path=/x",
+            parent_run_id="non-existent-run",
+        )
+        await pilot.pause()
+        assert row is not None
+        line1 = row._build_line1().plain
+        assert "└─" not in line1, "root-level tool_call has no prefix"
+
+
 # ── app_outbox formatter helper tests ─────────────────────────────────────────
 
 


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-F (P2).

## Problem

Sub-skill tool_calls rendered flat with no visual tie to their owning skill row. With multiple concurrent skills (= planner + sub-skills), the user couldn't tell which tool_call belonged to which thread without checking the agents tab.

## Fix

Mirror ``SkillActivityRow``'s ``label_prefix`` idiom (= issue #210). When the conv pane's ``start_tool_call_row`` detects that the tool_call's source ``run_id`` matches a currently-mounted SkillActivityRow, render with ``  └─ `` prefix on line 1.

Result:
```
✓ planner#abcd · execute · 12.1s · [plan 2/5]  · ⤷ act 3/5 spawn sub_skill_x
  └─ ✓ read_file(path=/tmp/x.toml)  · 0.2s
       ⎿ status=ok, exit_code=0
```

Behavior:
- run_id matches a mounted skill row → ``└─`` prefix
- No matching skill row → root-level rendering (= no orphan ``└─``)

## Wiring

- ``ToolCallRow.__init__`` accepts ``label_prefix`` (= empty default)
- ``_build_line1`` prepends in dim grey
- ``ConversationView.start_tool_call_row`` gains ``parent_run_id`` arg
- ``OutboxRouter._on_tool_call_started`` forwards ``meta["run_id"]``

## Test plan

- [x] ruff check passes
- [x] 2 new Tier 2 tests (matched nests / unmatched falls back to root)
- [x] Existing 12 + 9 conv-pane + ToolCallRow tests unaffected

## Wave context

```
✓ F-A (P1, PR #446): placeholder atomic truncation
✓ F-B (P1, PR #447): failed tool error reason visibility
✓ F-C (P2, PR #448): redundant kind / op fields
✓ F-D (P2, PR #449): 0.0s elapsed handling
✓ F-E (P2, PR #450): qualified name middle-elide
🆕 F-F (P2, this PR): visual nesting under parent skill
🔄 F-G (P3): ⎿ indent
🔄 F-H (P3): min display time
🔄 F-I (P3): badge emphasis
```

P2 closure after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)