### PR TITLE
feat(tui): defer ToolCallRow flush by 0.3s min-display-time (F-H)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -79,6 +79,12 @@ _RECENT_REPLIES_MAX = 10
 # turn anchors below are drop-aware so even pathological sessions that DO
 # cross the boundary don't break Ctrl+P/N navigation.
 _RICHLOG_MAX_LINES = 20_000
+# F-H: minimum visible duration for an inline ToolCallRow before the conv
+# pane flushes it into the RichLog scroll history + unmounts the live
+# widget. Cache hits / instant returns would otherwise mount + flush
+# within a single event-loop tick, leaving no perceptual cue. 0.3s
+# matches typical perceptual threshold (= "I saw something happen").
+_TOOL_CALL_MIN_DISPLAY_S = 0.3
 # Cap on simultaneously-mounted ErrorBox widgets. Past this, the oldest
 # rolls into a dim ``_write_log`` breadcrumb (= same shape as the F2
 # Esc-dismissed breadcrumb) so the footer area can't pile up under a
@@ -939,7 +945,31 @@ class ConversationView(Widget):
         to scroll history, live widget removed). The row's render
         helpers are pure over its state, so reading them after the
         finish_* call captures the terminal shape.
+
+        F-H min-display-time: very fast tool_calls (= cache hits, instant
+        returns) would mount + flush within a single event-loop tick,
+        leaving no perceptual cue that the tool ran. When the row has
+        been mounted for less than ``_TOOL_CALL_MIN_DISPLAY_S``, defer
+        the flush via ``set_timer`` so each row stays visible briefly
+        before transitioning into RichLog history.
         """
+        elapsed = row.mounted_for_seconds()
+        if elapsed < _TOOL_CALL_MIN_DISPLAY_S:
+            delay = _TOOL_CALL_MIN_DISPLAY_S - elapsed
+            try:
+                self.app.set_timer(
+                    delay, lambda: self._do_flush_tool_call_row(row),
+                )
+                return
+            except Exception:
+                # If timer scheduling fails (e.g. widget already torn
+                # down), fall through to immediate flush — better
+                # to land the row in history than lose it.
+                pass
+        self._do_flush_tool_call_row(row)
+
+    def _do_flush_tool_call_row(self, row: ToolCallRow) -> None:
+        """Actual write-to-RichLog + unmount; safe to call from a timer."""
         try:
             line1 = row._build_line1()
             line2 = row._build_line2()

--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -91,6 +91,7 @@ class ToolCallRow(Widget):
 
         # Running state
         self._start = time.monotonic()
+        self._mount_time = self._start  # updated in on_mount when widget composes
         self._running = True
 
         # Terminal state
@@ -113,8 +114,21 @@ class ToolCallRow(Widget):
         yield self._line2
 
     def on_mount(self) -> None:
+        self._mount_time = time.monotonic()
         self.set_interval(_TICK_INTERVAL_S, self._tick)
         self._refresh()
+
+    def mounted_for_seconds(self) -> float:
+        """Wall-time elapsed since the widget actually mounted (= on_mount).
+
+        Used by ``ConversationView._flush_tool_call_row`` to enforce a
+        minimum visible duration: very fast ops (= cache hit, instant
+        return) would otherwise mount + flush within the same event-loop
+        tick, leaving the user with no perceptual cue that the tool was
+        called. The caller defers the flush until this exceeds the
+        configured minimum so each row is briefly perceivable.
+        """
+        return max(0.0, time.monotonic() - self._mount_time)
 
     # ── Public API ─────────────────────────────────────────────────────────────
 

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -85,7 +85,11 @@ async def test_start_tool_call_row_is_idempotent_for_same_op_id():
 
 @pytest.mark.asyncio
 async def test_complete_tool_call_row_unmounts_live_widget():
-    """Tier 2: success terminal removes the live row from the DOM."""
+    """Tier 2: success terminal removes the live row from the DOM.
+
+    F-H min-display-time defers flush by up to 0.3s for very fast ops;
+    the test waits past the threshold so the deferred unmount completes.
+    """
     app = _ConvOnlyApp()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -94,7 +98,8 @@ async def test_complete_tool_call_row_unmounts_live_widget():
         await pilot.pause()
         assert len(list(conv.query(ToolCallRow))) == 1
         conv.complete_tool_call_row("op-b", result_snippet="200 OK 1.2KB")
-        await pilot.pause()
+        # Wait for F-H min-display-time deferral to elapse.
+        await pilot.pause(0.4)
         # Row is unmounted after flush.
         assert len(list(conv.query(ToolCallRow))) == 0
 
@@ -109,7 +114,33 @@ async def test_fail_tool_call_row_unmounts_live_widget_and_records_error():
         conv.start_tool_call_row("op-c", "shell")
         await pilot.pause()
         conv.fail_tool_call_row("op-c", error="timeout")
+        # Wait for F-H min-display-time deferral.
+        await pilot.pause(0.4)
+        assert len(list(conv.query(ToolCallRow))) == 0
+
+
+@pytest.mark.asyncio
+async def test_fast_tool_call_defers_flush_so_row_stays_visible_briefly():
+    """Tier 2 F-H: very fast ops (= mount + complete in same tick) defer
+    the flush so the user can perceive the row before it transitions
+    to RichLog history.
+    """
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row("op-fast", "cached_op", args_repr="key=x")
+        await pilot.pause()
+        # Complete immediately — F-H should defer the flush.
+        conv.complete_tool_call_row("op-fast", result_snippet="ok")
+        # Brief pause — less than the min-display threshold; row should
+        # still be visible because the flush is deferred.
+        await pilot.pause(0.05)
+        assert len(list(conv.query(ToolCallRow))) == 1, (
+            "fast row stays mounted briefly so it's perceivable"
+        )
+        # Wait past the threshold — row should be flushed by now.
+        await pilot.pause(0.4)
         assert len(list(conv.query(ToolCallRow))) == 0
 
 


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-H (P3).

## Problem

Very fast tool_calls (= cache hit, instant return, memoized result) mounted + flushed within a single event-loop tick. The terminal-state line landed in RichLog history but the user couldn't perceive the row transition (● → ✓) — no visual cue that the tool actually ran.

## Fix

Add minimum visible duration (= ``_TOOL_CALL_MIN_DISPLAY_S`` = 0.3s, matching typical perceptual threshold). When ``_flush_tool_call_row`` fires within this window of mount, defer the flush via ``set_timer`` so the row stays briefly visible.

## Implementation

- ToolCallRow tracks ``_mount_time`` in ``on_mount``
- New ``mounted_for_seconds()`` public read for ConversationView decision
- ``_flush_tool_call_row`` checks elapsed; defers via ``self.app.set_timer``
- New ``_do_flush_tool_call_row`` (= write+remove) is the safe timer entry point
- Timer scheduling failure → immediate flush (defensive)

## Test plan

- [x] ruff check passes
- [x] Existing tests updated with ``pilot.pause(0.4)`` for deferred flush
- [x] 1 new Tier 2 test pins F-H contract: brief pause → row mounted, long pause → flushed

## Wave context

```
✓ F-A (P1, PR #446): placeholder atomic truncation
✓ F-B (P1, PR #447): failed tool error reason visibility
✓ F-C (P2, PR #448): redundant kind / op fields
✓ F-D (P2, PR #449): 0.0s elapsed handling
✓ F-E (P2, PR #450): qualified name middle-elide
✓ F-F (P2, PR #451): visual nesting under parent skill
✗ F-G (P3, skipped): indent shorten was misanalysis (= alignment-meaningful)
🆕 F-H (P3, this PR): min-display-time deferral
🔄 F-I (P3): badge emphasis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)