### PR TITLE
fix(tui): plain coral on agents-tab plan badge for legibility (F-I)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -581,18 +581,21 @@ def render_agents(
                     style=name_style or "#dddddd",
                 )
                 # Wave-7 Topic C-F2: surface plan-step attribution as a
-                # dim ``[plan N/M]`` badge after the skill name so the
+                # ``[plan N/M]`` badge after the skill name so the
                 # agents tab matches the conv pane SkillActivityRow's
                 # persistent plan badge (wave-7 PR #418). Source is the
                 # ``_skill_exec`` snapshot, populated when
                 # ``_update_skill_exec`` parses ``detail: plan N/M``
                 # traces from ChatEventForwarder.
+                # F-I (#427 follow-up): plain coral instead of dim, so the
+                # badge is readable at a glance — the prior ``dim {coral}``
+                # blended into surrounding text and was easy to miss.
                 plan_n_done = info.get("plan_n_done")
                 plan_n_total = info.get("plan_n_total")
                 if plan_n_done and plan_n_total:
                     skill_label.append(
                         f"  [plan {plan_n_done}/{plan_n_total}]",
-                        style=f"dim {_CORAL}",
+                        style=_CORAL,
                     )
                 skill_node = parent_node.add(skill_label)
                 nodes_by_run_id[run_id] = skill_node


### PR DESCRIPTION
**[tui-coder]** — wave-#427 UX follow-up F-I (P3) — **wave closure**.

## Problem

The ``[plan N/M]`` badge on the agents-tab running-skill row used ``dim {_CORAL}`` styling so it blended into surrounding text — easy to miss when scanning the tree.

## Fix

Switch to plain ``_CORAL`` (= bold by default). Badge stands out at a glance without being noisy.

## Test plan

- [x] ruff check passes
- [x] Existing 10 tests (badge presence + cursor + subskill nesting) green — contracts pin badge text + orthogonality, not specific styling

## Wave closure

```
✓ F-A (P1, PR #446): placeholder atomic truncation
✓ F-B (P1, PR #447): failed tool error reason visibility
✓ F-C (P2, PR #448): redundant kind / op fields
✓ F-D (P2, PR #449): 0.0s elapsed handling
✓ F-E (P2, PR #450): qualified name middle-elide
✓ F-F (P2, PR #451): visual nesting under parent skill
✗ F-G (P3, skipped): indent shorten was misanalysis (= alignment-meaningful)
✓ F-H (P3, PR #453): min-display-time deferral
🆕 F-I (P3, this PR): plan badge legibility
```

= **8/9 PRs landed + 1 honest scope drop** (F-G).

🤖 Generated with [Claude Code](https://claude.com/claude-code)