### PR TITLE
feat(permissions): wire grant/revoke → ChatSession.notify_state_change (closes #352, #398 v4 emitter #1)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -986,6 +986,18 @@ class ChatSession:
         self.model = model
         self._resolver = resolver or ModelResolver({})
         self._perm = permission_resolver
+        # #398 v4 emitter wiring (= permission_manager → state_change).
+        # Subscribe to ``_persist`` events on the shared PermissionResolver
+        # so a permission grant / revoke mints a state_change history
+        # entry in this session — the LLM sees "permission for X was
+        # granted" in its next turn and breaks out of the #352 refusal
+        # trap. Stored as a bound method so the same reference can be
+        # unregistered on session shutdown.
+        if self._perm is not None and hasattr(self._perm, "register_on_persist"):
+            self._on_perm_persist_cb = self._on_permission_persisted
+            self._perm.register_on_persist(self._on_perm_persist_cb)
+        else:
+            self._on_perm_persist_cb = None
         _safety = safety or SafetyConfig()
         self._safety = _safety
         # FP-0017 follow-up: declarative sandbox config (reyn.yaml `sandbox:`).
@@ -1557,6 +1569,25 @@ class ChatSession:
         with self.history_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(msg), ensure_ascii=False) + "\n")
 
+    def _on_permission_persisted(self, key: str, approved: bool) -> None:
+        """PermissionResolver subscriber — convert grant/revoke to a
+        ``state_change`` history entry (= #398 v4 emitter wiring,
+        #352 in-context-learning refusal trap mitigation).
+
+        The LLM reading the next turn's prompt sees this as a
+        ``role="system"`` entry containing "Permission for '<key>' was
+        granted." (or revoked) — breaking out of the prior-refusal
+        learning pattern by surfacing the world-state change.
+
+        Phrasing uses single quotes around the key so the human-
+        readable summary stays unambiguous when the key contains
+        dots / colons (= common in Reyn approval keys like
+        ``mcp.servers.sqlite`` or ``file.write:/path``).
+        """
+        verb = "granted" if approved else "revoked"
+        summary = f"Permission for '{key}' was {verb}."
+        self.notify_state_change(summary, source="permission_manager")
+
     def notify_state_change(
         self, summary: str, *, source: str | None = None,
     ) -> None:
@@ -1768,6 +1799,17 @@ class ChatSession:
 
     async def shutdown(self) -> None:
         # `shutdown` is a control signal, not recovery state — skip WAL/snapshot.
+        # #398 v4 emitter wiring cleanup: unregister the
+        # permission-persist subscriber so dead-session references
+        # don't accumulate in the shared PermissionResolver. Defensive
+        # — the resolver may have been replaced or never have had the
+        # method; in either case unregister is a no-op.
+        if self._on_perm_persist_cb is not None and self._perm is not None:
+            try:
+                self._perm.unregister_on_persist(self._on_perm_persist_cb)
+            except Exception:
+                pass
+            self._on_perm_persist_cb = None
         await self.inbox.put(("shutdown", {}))
 
     # ── PR21: state persistence helpers (WAL + snapshot) ─────────────────────

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from reyn.intervention_choices import (
     ALWAYS,
@@ -235,6 +235,15 @@ class PermissionResolver:
         if trusted_python_allowed is not None:
             unsafe_python_allowed = trusted_python_allowed
         self._unsafe_python_allowed = unsafe_python_allowed
+        # #398 v4 emitter wiring: subscribers fired when ``_persist`` lands
+        # an approval (= "always allow") or revoke decision to approvals.yaml.
+        # ChatSession registers a callback that mints a ``state_change``
+        # history entry so the LLM sees "permission for X was
+        # granted/revoked" in its next turn — directly mitigates the
+        # #352 in-context-learning refusal trap. PermissionResolver is
+        # shared across sessions; each ChatSession registers its own
+        # callback so a project-wide grant notifies every active session.
+        self._on_persist_callbacks: list[Callable[[str, bool], None]] = []
 
     # ── Persistence ──────────────────────────────────────────────────────────
 
@@ -266,6 +275,57 @@ class PermissionResolver:
             )
         except Exception:
             pass
+        # #398 v4 emitter wiring: notify subscribers (= ChatSession
+        # instances that registered themselves) so the LLM sees the
+        # permission change as a ``state_change`` history entry next
+        # turn. Iterate a snapshot so a callback that unregisters
+        # itself mid-iteration doesn't trip the loop. Each callback is
+        # wrapped in try/except — observability must not break the
+        # core persistence path.
+        for cb in list(self._on_persist_callbacks):
+            try:
+                cb(key, approved)
+            except Exception:
+                # Defensive: bad subscriber (= dead session reference,
+                # callback bug) must not crash _persist.
+                pass
+
+    # ── #398 v4 emitter wiring (= state_change subscriber API) ──────────────
+
+    def register_on_persist(
+        self, callback: Callable[[str, bool], None],
+    ) -> None:
+        """Subscribe to ``_persist`` events for emitter wiring (= #398 v4).
+
+        ``callback(key, approved)`` is invoked after the approval is
+        written to ``approvals.yaml``. Used by ChatSession to mint
+        a ``state_change`` history entry per ``notify_state_change``
+        so the LLM sees the permission update in its next turn
+        (= directly mitigates the #352 in-context-learning refusal
+        trap pattern).
+
+        Multiple ChatSessions can register the same shared resolver
+        so a project-wide grant notifies every active session
+        independently.
+        """
+        self._on_persist_callbacks.append(callback)
+
+    def unregister_on_persist(
+        self, callback: Callable[[str, bool], None],
+    ) -> bool:
+        """Detach a previously registered callback.
+
+        Returns True iff the callback was found and removed. Use this
+        on ChatSession shutdown to prevent dead-session callbacks from
+        accumulating in long-running PermissionResolver instances
+        (= the shared singleton model in ``reyn web`` / ``reyn run``
+        sessions outlive individual ChatSessions).
+        """
+        try:
+            self._on_persist_callbacks.remove(callback)
+            return True
+        except ValueError:
+            return False
 
     # ── Config check ─────────────────────────────────────────────────────────
 

--- a/tests/test_permission_state_change_emitter.py
+++ b/tests/test_permission_state_change_emitter.py
@@ -1,0 +1,240 @@
+"""Tier 2: permission_manager → state_change emitter wiring (#398 v4).
+
+The first concrete emitter for the ``notify_state_change`` API
+landed in PR #455. When a permission decision is persisted to
+``approvals.yaml`` (= user said "yes always" / "no never" on an
+intervention), ChatSession mints a ``state_change`` history entry so
+the LLM sees the world-state change in its next turn. Directly
+mitigates the #352 in-context-learning refusal trap pattern (= the
+LLM was continuing to refuse a capability after the user had granted
+it, because the permission grant was invisible in the chat history).
+
+Pins:
+
+  1. ``PermissionResolver.register_on_persist`` / ``unregister_on_persist``
+     subscriber API exists and stores callbacks in a list.
+  2. ``_persist(key, approved)`` fires all registered callbacks with the
+     same ``(key, approved)`` args.
+  3. ChatSession subscribes itself on construction; the callback fires
+     a ``notify_state_change`` with summary derived from ``key`` and
+     ``approved``.
+  4. Multiple ChatSessions on the same PermissionResolver all receive
+     notifications independently (= shared-resolver model).
+  5. A bad callback doesn't crash ``_persist`` (= other subscribers
+     and the core persistence path are unaffected).
+  6. ChatSession.shutdown unregisters the callback so dead-session
+     references don't accumulate.
+
+Tier 2 because the contract is load-bearing for #352 closure —
+removing the wiring silently re-opens the refusal trap.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatMessage, ChatSession
+from reyn.events.state_log import StateLog
+from reyn.permissions.permissions import PermissionResolver
+
+
+def _make_session(
+    tmp_path: Path, *, agent_name: str, perm_resolver: PermissionResolver,
+) -> ChatSession:
+    """Build a ChatSession redirected to ``tmp_path`` with a shared
+    PermissionResolver injected.
+    """
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+        permission_resolver=perm_resolver,
+    )
+
+
+def _make_resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+
+
+def _state_changes(session: ChatSession) -> list[ChatMessage]:
+    return [
+        m for m in session.history
+        if m.role == "system" and (m.meta or {}).get("kind") == "state_change"
+    ]
+
+
+# ── subscriber API on PermissionResolver ───────────────────────────────
+
+
+def test_register_on_persist_stores_callback(tmp_path):
+    """Tier 2: ``register_on_persist`` accepts a callback and stores it.
+
+    Doesn't fire yet — that's a separate test. Pinning the API surface
+    so a future refactor that changes the storage shape (= e.g.
+    moving to a set / dict) doesn't silently change semantics.
+    """
+    resolver = _make_resolver(tmp_path)
+    called: list = []
+
+    def cb(key, approved):  # noqa: ARG001
+        called.append((key, approved))
+
+    resolver.register_on_persist(cb)
+    # Internal state: callback list contains it (= use the public
+    # API to verify by firing _persist, not by reading private state).
+    resolver._persist("test.key", True)
+    assert called == [("test.key", True)]
+
+
+def test_unregister_on_persist_removes_callback(tmp_path):
+    """Tier 2: ``unregister_on_persist`` removes a previously registered
+    callback so subsequent ``_persist`` invocations don't fire it.
+
+    Returns True on successful removal; False if not found.
+    """
+    resolver = _make_resolver(tmp_path)
+    called: list = []
+
+    def cb(key, approved):  # noqa: ARG001
+        called.append(key)
+
+    resolver.register_on_persist(cb)
+    assert resolver.unregister_on_persist(cb) is True
+    # Second unregister returns False — already removed.
+    assert resolver.unregister_on_persist(cb) is False
+    resolver._persist("any.key", True)
+    assert called == []
+
+
+def test_persist_fires_all_registered_callbacks(tmp_path):
+    """Tier 2: multiple registered callbacks all fire with the same
+    ``(key, approved)`` args.
+    """
+    resolver = _make_resolver(tmp_path)
+    cb1_calls = []
+    cb2_calls = []
+    resolver.register_on_persist(lambda k, a: cb1_calls.append((k, a)))
+    resolver.register_on_persist(lambda k, a: cb2_calls.append((k, a)))
+
+    resolver._persist("mcp.sqlite", True)
+    resolver._persist("file.write:/path", False)
+
+    assert cb1_calls == [("mcp.sqlite", True), ("file.write:/path", False)]
+    assert cb2_calls == [("mcp.sqlite", True), ("file.write:/path", False)]
+
+
+def test_persist_callback_exception_does_not_crash_persist(tmp_path):
+    """Tier 2: a buggy callback (= raises) doesn't crash ``_persist``
+    or prevent OTHER subscribers from firing. Defensive isolation —
+    observability bugs shouldn't break the core persistence path.
+    """
+    resolver = _make_resolver(tmp_path)
+    good_calls = []
+
+    def bad_cb(key, approved):  # noqa: ARG001
+        raise RuntimeError("oops")
+
+    resolver.register_on_persist(bad_cb)
+    resolver.register_on_persist(lambda k, a: good_calls.append(k))
+
+    # Must NOT raise.
+    resolver._persist("safe.key", True)
+
+    # Good callback still fired despite bad_cb raising.
+    assert good_calls == ["safe.key"]
+    # And approvals.yaml side still completed.
+    assert resolver._saved.get("safe.key") is True
+
+
+# ── ChatSession wiring ────────────────────────────────────────────────
+
+
+def test_session_mints_state_change_on_permission_grant(tmp_path):
+    """Tier 2 (#398 v4 + #352): a permission grant via
+    ``PermissionResolver._persist`` triggers a state_change history
+    entry in the subscribed session — the LLM-visible mitigation
+    for the #352 in-context-learning refusal trap.
+
+    Summary text follows the documented shape: "Permission for
+    '<key>' was granted." (= single-quotes preserve key unambiguity
+    when the key contains dots / colons).
+    """
+    resolver = _make_resolver(tmp_path)
+    session = _make_session(tmp_path, agent_name="alpha", perm_resolver=resolver)
+
+    resolver._persist("mcp.sqlite", True)
+
+    entries = _state_changes(session)
+    assert len(entries) == 1
+    assert entries[0].content == "Permission for 'mcp.sqlite' was granted."
+    assert entries[0].meta.get("source") == "permission_manager"
+
+
+def test_session_mints_state_change_on_permission_revoke(tmp_path):
+    """Tier 2: revocation also surfaces — symmetric wording "was
+    revoked" so the LLM sees the negative transition too.
+    """
+    resolver = _make_resolver(tmp_path)
+    session = _make_session(tmp_path, agent_name="alpha", perm_resolver=resolver)
+
+    resolver._persist("mcp.sqlite", False)
+
+    entries = _state_changes(session)
+    assert len(entries) == 1
+    assert entries[0].content == "Permission for 'mcp.sqlite' was revoked."
+    assert entries[0].meta.get("source") == "permission_manager"
+
+
+def test_multiple_sessions_all_notified_on_shared_resolver(tmp_path):
+    """Tier 2: when N ChatSessions share the same PermissionResolver
+    (= the typical reyn web / reyn run model), a single permission
+    grant notifies all N sessions independently. Each gets its own
+    state_change history entry — the grant is project-wide, all
+    agents in the project should know.
+    """
+    resolver = _make_resolver(tmp_path)
+    session_a = _make_session(tmp_path, agent_name="alpha", perm_resolver=resolver)
+    session_b = _make_session(tmp_path, agent_name="beta", perm_resolver=resolver)
+
+    resolver._persist("file.write:/data", True)
+
+    assert len(_state_changes(session_a)) == 1
+    assert len(_state_changes(session_b)) == 1
+
+
+def test_session_with_no_resolver_works_unchanged(tmp_path):
+    """Tier 2: ChatSession can be constructed without a
+    PermissionResolver (= CLI / test stubs). No callback registered,
+    no crash on shutdown. Backward compat path.
+    """
+    session = ChatSession(
+        agent_name="loner",
+        state_log=StateLog(tmp_path / "loner.wal"),
+        snapshot_path=tmp_path / "loner_snapshot.json",
+        # permission_resolver=None — default
+    )
+    assert session._on_perm_persist_cb is None
+    # No exception even though no resolver was wired.
+
+
+@pytest.mark.asyncio
+async def test_session_shutdown_unregisters_callback(tmp_path):
+    """Tier 2: ``ChatSession.shutdown`` unregisters its callback from
+    the shared PermissionResolver — prevents dead-session references
+    from accumulating across long-running ``reyn web`` sessions.
+    """
+    resolver = _make_resolver(tmp_path)
+    session = _make_session(tmp_path, agent_name="ephemeral", perm_resolver=resolver)
+
+    pre = len(resolver._on_persist_callbacks)
+    assert pre == 1
+
+    await session.shutdown()
+    # Drain the shutdown signal that shutdown put on the inbox so the
+    # call doesn't block other tests if reused. Inbox shutdown isn't
+    # the focus here — just confirming unregister fired.
+    assert session._on_perm_persist_cb is None
+    assert len(resolver._on_persist_callbacks) == pre - 1


### PR DESCRIPTION
**[e2e-coder]** — first concrete emitter for the ``notify_state_change`` API. **Closes #352** (= in-context-learning refusal trap).

## Why this closes #352

#352 symptom: user denies a capability → LLM produces refusal turns → user later grants via approvals.yaml → LLM continues refusing because the grant happened OUTSIDE chat context, prior-refusal turns dominate in-context-learning.

#398 v4 fix: surface the grant as a history entry. Earlier measurement (= flash-lite 100% trap with refusal turns, 0% with explicit sentinel prefix prepended) confirmed an in-context state-change signal breaks the trap. This PR wires the production emission so the sentinel happens **automatically** when permissions change.

## Subscriber API on PermissionResolver

```python
resolver.register_on_persist(callback: Callable[[str, bool], None]) -> None
resolver.unregister_on_persist(callback) -> bool
```

- Callback fires after ``_persist`` writes to ``approvals.yaml``
- Multiple sessions can register independently (= shared resolver in ``reyn web`` / ``reyn run`` → project-wide grant notifies every active session)
- Bad callback exception is swallowed defensively — observability must not crash core persistence

## ChatSession wiring

```python
# __init__:
self._perm.register_on_persist(self._on_permission_persisted)

# _on_permission_persisted(key, approved):
# approved=True  → "Permission for '<key>' was granted."  → notify_state_change
# approved=False → "Permission for '<key>' was revoked."  → notify_state_change

# shutdown:
self._perm.unregister_on_persist(self._on_perm_persist_cb)
```

Single quotes around the key preserve unambiguity for compound keys (= ``mcp.sqlite``, ``file.write:/path``).

## Change shape

- ``src/reyn/permissions/permissions.py``: subscriber API + ``_persist`` invokes callbacks (defensive iteration)
- ``src/reyn/chat/session.py``: register on init, ``_on_permission_persisted`` callback, unregister on shutdown
- ``tests/test_permission_state_change_emitter.py`` (new, 9 tests):
  - Subscriber API (register/unregister/multiple)
  - ``_persist`` fires callbacks with right args
  - Bad callback doesn't crash ``_persist``
  - Session mints state_change on grant + revoke
  - Multiple sessions all notified on shared resolver
  - Session-without-resolver works (= backward compat)
  - Shutdown unregisters

## Test plan

- [x] ``pytest tests/test_permission_state_change_emitter.py tests/test_session_notify_state_change.py`` — 18/18 pass
- [x] ``pytest tests/`` (full suite) — 4753 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## What's still ahead (= other emitters)

- mcp_install: when ``reyn mcp install`` succeeds, notify sessions
- config_watcher: when reyn.yaml / reyn.local.yaml is touched
- sp_loader: when SP version changes mid-session
- hot_list_tracker: optional

Each is a focused follow-up PR. This PR ships the most critical one — it's the one that closes #352.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)