### PR TITLE
fix(tui): seal in-flight ToolCallRow on Ctrl+C cancel (C-F1, wave-8 P1)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -958,6 +958,12 @@ class ReynTUIApp(App):
                         pass
                     self._skill_exec.pop(run_id, None)
                 self._push_exec_state()
+            # C-F1: seal in-flight ToolCallRow widgets too. Without this
+            # sweep, any tool_call that was mid-run when Ctrl+C fires
+            # leaves an orphan ``●`` spinner in scroll history with no
+            # terminal glyph — the user sees a frozen running indicator.
+            if conv is not None:
+                conv.abort_tool_call_rows(reason="cancelled (remote)")
             return
 
         cancelled_skills = 0
@@ -1005,11 +1011,23 @@ class ReynTUIApp(App):
                 except Exception:
                     pass
 
+        # C-F1: seal any live ToolCallRow widgets so mid-run tool_calls
+        # don't leave orphan ``●`` spinners in scroll history. The skill
+        # task cancellation above doesn't emit a ``tool_failed`` event
+        # for the in-flight call, so without this sweep the row never
+        # reaches a terminal state. The row's frozen elapsed + ⊘ glyph
+        # land in RichLog history (= matches the streaming-row pattern
+        # just above).
+        cancelled_tool_calls = 0
+        if conv is not None:
+            cancelled_tool_calls = conv.abort_tool_call_rows(reason="cancelled")
+
         if (
             cancelled_skills == 0
             and cancelled_plans == 0
             and cancelled_streams == 0
             and cancelled_interventions == 0
+            and cancelled_tool_calls == 0
         ):
             # Suppress repeat lines: when the user mashes Ctrl+C on an idle
             # session, log a single "nothing-in-flight cancel" then
@@ -1049,6 +1067,11 @@ class ReynTUIApp(App):
             parts.append(
                 f"{cancelled_interventions} intervention"
                 f"{'s' if cancelled_interventions != 1 else ''}"
+            )
+        if cancelled_tool_calls:
+            parts.append(
+                f"{cancelled_tool_calls} tool_call"
+                f"{'s' if cancelled_tool_calls != 1 else ''}"
             )
         self._voice_status(
             f"✗ cancelled {' + '.join(parts)}", style="bold #aa6666",

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -950,6 +950,30 @@ class ConversationView(Widget):
         row.finish_failure(reason=error)
         self._flush_tool_call_row(row)
 
+    def abort_tool_call_rows(self, reason: str = "cancelled") -> int:
+        """Transition every live tool-call row to the aborted terminal.
+
+        Called from ``ReynTUIApp.action_cancel_inflight`` so Ctrl+C
+        doesn't leave orphan ``●`` spinners frozen in scroll history
+        when the underlying skill task is cancelled mid-tool_call.
+        Returns the count of rows that were live + sealed (= 0 when
+        no tool_calls were in flight). Mirrors the streaming-row +
+        skill-row seal sweeps that precede it in ``action_cancel_inflight``.
+        """
+        cancelled = 0
+        for op_id in list(self._tool_call_rows.keys()):
+            row = self._tool_call_rows.pop(op_id, None)
+            if row is None:
+                continue
+            try:
+                row.finish_aborted(reason=reason)
+                self._flush_tool_call_row(row)
+                cancelled += 1
+            except Exception:
+                # Defensive: don't let one bad row stop the sweep.
+                pass
+        return cancelled
+
     def _flush_tool_call_row(self, row: ToolCallRow) -> None:
         """Render the row's two-line shape into the RichLog and unmount.
 

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -335,3 +335,62 @@ def test_format_tool_result_short_result_unchanged():
     """Tier 2: a result that fits the budget passes through verbatim."""
     out = _format_tool_result({"status": "ok", "exit_code": 0, "bytes": 1234})
     assert out == "status=ok, exit_code=0, bytes=1234"
+
+
+# ── abort_tool_call_rows sweep (C-F1 wave-8) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_abort_tool_call_rows_seals_live_rows_with_aborted_terminal():
+    """Tier 2 C-F1: ``abort_tool_call_rows`` finishes every live row as ⊘.
+
+    The intended call site is ``ReynTUIApp.action_cancel_inflight``;
+    without this sweep, in-flight tool_call widgets stayed mounted as
+    ``●`` spinners and eventually got flushed to RichLog still in the
+    running state (= frozen spinner in scroll history).
+    """
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row("op-1", "read_file", args_repr="path=/a")
+        conv.start_tool_call_row("op-2", "web_fetch", args_repr="url=...")
+        await pilot.pause()
+        assert len(list(conv.query(ToolCallRow))) == 2
+        cancelled = conv.abort_tool_call_rows(reason="cancelled")
+        assert cancelled == 2
+        # Allow F-H min-display-time deferral to elapse before checking
+        # the unmount — same wait pattern the other lifecycle tests use.
+        await pilot.pause(0.4)
+        assert len(list(conv.query(ToolCallRow))) == 0
+
+
+@pytest.mark.asyncio
+async def test_abort_tool_call_rows_returns_zero_when_no_live_rows():
+    """Tier 2: idempotent — no live rows → returns 0, no exception."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No start_tool_call_row called — registry empty.
+        assert conv.abort_tool_call_rows(reason="cancelled") == 0
+
+
+@pytest.mark.asyncio
+async def test_abort_tool_call_rows_after_complete_is_noop():
+    """Tier 2: rows already in a terminal state are not double-counted.
+
+    ``complete_tool_call_row`` pops the row out of ``_tool_call_rows``
+    before the deferred flush, so ``abort_tool_call_rows`` should
+    find an empty registry and return 0.
+    """
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row("op-c", "read_file")
+        await pilot.pause()
+        conv.complete_tool_call_row("op-c", result_snippet="ok")
+        # Even before the F-H deferred flush elapses, the row is already
+        # popped from the registry so abort sees nothing.
+        assert conv.abort_tool_call_rows(reason="cancelled") == 0


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #1 (C-F1, P1).

## Problem

``action_cancel_inflight`` swept ``conv._stream_rows`` and ``self._skill_exec`` but had no sweep for ``conv._tool_call_rows``. Any tool_call mid-run when Ctrl+C fired stayed mounted as ``●`` indefinitely and got flushed into RichLog history still in the running state — frozen spinner in scroll.

## Fix

``ConversationView.abort_tool_call_rows(reason)`` iterates live rows and calls ``finish_aborted`` + flush. Wired into ``action_cancel_inflight`` both local + remote (``--connect``) paths.

Summary line includes ``N tool_call(s)`` count.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests (sweep / no-op / post-complete) + existing 21+13 tests green
- [ ] (manual TUI verify deferred to wave-end smoke)

## Wave-8 context (= top 10 plan)

```
🆕 C-F1 (P1, this PR): Ctrl+C seal ToolCallRow
🔄 C-F2 (P1): ✗ reason text
🔄 A-F1 (P2): Pending preview pane
🔄 A-F2 (P2): Keys d=discard
🔄 A-F4 (P2): Docs Esc clear
🔄 B-F1 (P2): Header color escalation
🔄 C-F4 (P2): Multi-error count
🔄 C-F5 (P2): ⊘ for cancel
🔄 C-F7 (P2): Error filter
🔄 A-F3 (P2): Events scroll-into-view
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)