### PR TITLE
fix(tui): surface workflow_aborted reason on SkillActivityRow ✗ line (C-F2)

### DIFF
--- a/src/reyn/chat/forwarder.py
+++ b/src/reyn/chat/forwarder.py
@@ -88,7 +88,16 @@ class ChatEventForwarder:
         self._enqueue("skill done: finished", source_run_id=data.get("run_id"))
 
     def on_workflow_aborted(self, data: dict) -> None:
-        self._enqueue("skill done: aborted", source_run_id=data.get("run_id"))
+        # C-F2 (wave-8): encode the abort reason into the trace text so
+        # ``SkillActivityRow``'s ``✗`` finish line can surface *why* the
+        # skill failed without the user having to switch to the events
+        # tab. Forwarded as ``"skill done: aborted: <reason>"``; the
+        # bare ``"skill done: aborted"`` form (= no reason field) stays
+        # supported for backward-compat in case any consumer relies on
+        # the old format.
+        reason = str(data.get("reason") or "").strip()
+        text = f"skill done: aborted: {reason}" if reason else "skill done: aborted"
+        self._enqueue(text, source_run_id=data.get("run_id"))
 
     # ── In-phase detail signals (skill internal progress) ────────────────────
     # Without these, the SkillActivityRow showed only the phase name

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -612,22 +612,36 @@ class ReynTUIApp(App):
             # FP-0011: skill_narrator removed → skill_done outbox kind gone.
             # ChatEventForwarder now forwards workflow_finished / workflow_aborted
             # as "skill done: <status>" so the row can stop spinning here.
-            status = text[len("skill done: "):].strip()
+            payload = text[len("skill done: "):].strip()
+            # C-F2 (wave-8): forwarder may append the abort reason as
+            # ``"aborted: <reason>"`` — split on the first colon so we
+            # extract both the bare status (= "finished" / "aborted")
+            # and the human-readable reason for the ``✗`` finish line.
+            # Bare ``"aborted"`` (= no reason) falls through to the
+            # legacy phase-count fallback below.
+            abort_reason = ""
+            if ": " in payload:
+                status, abort_reason = payload.split(": ", 1)
+                status = status.strip()
+                abort_reason = abort_reason.strip()
+            else:
+                status = payload
             # Wave-3 SK2: pass the phase-visit count as ``reason`` so
             # ``SkillActivityRow._build_finished`` renders the
-            # ``· N phase(s)`` suffix. Previously hard-coded
-            # ``reason=""`` suppressed the suffix entirely; the
-            # widget already supports the conditional render but had
-            # no caller setting the value. Read from
-            # ``_skill_exec`` which the ``phase started:`` branch
-            # populates throughout the run.
-            _visits = int(
-                (self._skill_exec.get(run_id) or {}).get("phase_visits", 0)
-            )
-            _reason = (
-                f"{_visits} phase{'s' if _visits != 1 else ''}"
-                if _visits > 0 else ""
-            )
+            # ``· N phase(s)`` suffix. C-F2 (wave-8): when the forwarder
+            # supplied an explicit abort reason, that wins over the
+            # phase count — the user wants to see "timeout" or
+            # "budget exceeded", not just "2 phases".
+            if abort_reason:
+                _reason = abort_reason
+            else:
+                _visits = int(
+                    (self._skill_exec.get(run_id) or {}).get("phase_visits", 0)
+                )
+                _reason = (
+                    f"{_visits} phase{'s' if _visits != 1 else ''}"
+                    if _visits > 0 else ""
+                )
             conv.finish_skill_row(
                 run_id, success=(status == "finished"), reason=_reason,
             )

--- a/tests/test_forwarder_workflow_aborted_reason.py
+++ b/tests/test_forwarder_workflow_aborted_reason.py
@@ -1,0 +1,96 @@
+"""Tier 2: ChatEventForwarder.on_workflow_aborted forwards reason in text.
+
+C-F2 (wave-8 follow-up): before this fix, ``on_workflow_aborted``
+emitted only ``"skill done: aborted"`` with no reason field. The
+TUI's ``SkillActivityRow`` ``✗`` finish line rendered as
+``"failed: N phase(s)"`` (phase visit count) regardless of the
+actual abort cause — users had to switch to the events tab to see
+the real reason (= ``budget_exceeded`` / ``timeout`` / etc).
+
+Contract pinned here:
+
+1. ``data["reason"]`` present + non-empty → emit
+   ``"skill done: aborted: <reason>"``
+2. ``data["reason"]`` absent / empty → emit bare
+   ``"skill done: aborted"`` (= backward-compat for older event
+   shapes that don't carry a reason field)
+3. ``run_id`` propagation unchanged
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.forwarder import ChatEventForwarder  # noqa: E402
+from reyn.schemas.models import Event  # noqa: E402
+
+
+def _drain(q: asyncio.Queue) -> list:
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+def test_on_workflow_aborted_with_reason_encodes_in_text() -> None:
+    """Tier 2: reason field → ``"skill done: aborted: <reason>"``."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="workflow_aborted",
+        data={"run_id": "child-run", "reason": "budget_exceeded"},
+    ))
+    msgs = _drain(q)
+    assert len(msgs) == 1
+    assert msgs[0].text == "skill done: aborted: budget_exceeded"
+
+
+def test_on_workflow_aborted_without_reason_emits_bare_text() -> None:
+    """Tier 2: no reason field → bare ``"skill done: aborted"`` (back-compat)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(type="workflow_aborted", data={"run_id": "child-run"}))
+    msgs = _drain(q)
+    assert msgs[0].text == "skill done: aborted"
+
+
+def test_on_workflow_aborted_with_empty_reason_emits_bare_text() -> None:
+    """Tier 2: empty-string reason → bare form (= treat as absent)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="workflow_aborted",
+        data={"run_id": "child-run", "reason": ""},
+    ))
+    msgs = _drain(q)
+    assert msgs[0].text == "skill done: aborted"
+
+
+def test_on_workflow_aborted_with_whitespace_only_reason_emits_bare_text() -> None:
+    """Tier 2: whitespace-only reason → bare form (= treat as absent)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="workflow_aborted",
+        data={"run_id": "child-run", "reason": "   "},
+    ))
+    msgs = _drain(q)
+    assert msgs[0].text == "skill done: aborted"
+
+
+def test_on_workflow_aborted_run_id_provenance_preserved() -> None:
+    """Tier 2: run_id propagation unchanged by the reason-encoding change."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatEventForwarder("test_skill", q, run_id="parent-run")
+    fwd(Event(
+        type="workflow_aborted",
+        data={"run_id": "child-run", "reason": "timeout"},
+    ))
+    msg = _drain(q)[0]
+    assert msg.meta["run_id"] == "child-run"
+    assert msg.meta["parent_run_id"] == "parent-run"


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #2 (C-F2, P1).

## Problem

When a skill failed, the SkillActivityRow ``✗`` finish line rendered as ``"failed: 2 phase(s)"`` (= phase-visit count) regardless of the actual abort cause. The real reason (``budget_exceeded`` / ``timeout`` / ``permission_denied``) sat in the ``workflow_aborted`` event's ``reason`` field but never reached the conv pane.

## Fix

Two-layer:

1. ``ChatEventForwarder.on_workflow_aborted`` encodes reason as ``"skill done: aborted: <reason>"`` when present; bare ``"skill done: aborted"`` when absent (= back-compat).
2. ``_handle_trace_for_skill_row`` parses the colon-suffix; explicit reason wins over the phase-count fallback.

Before:
```
✗ skill_router#abcd  · failed: 2 phases  · Ctrl+B → events
```

After:
```
✗ skill_router#abcd  · failed: budget_exceeded  · Ctrl+B → events
```

## Test plan

- [x] ruff check passes
- [x] 5 new Tier 2 tests in ``tests/test_forwarder_workflow_aborted_reason.py`` (present / absent / empty / whitespace / provenance)
- [x] Existing forwarder + phase_no_progress + plan_step_context tests 18/18 green

## Wave-8 context

```
✓ C-F1 (P1, PR #457): Ctrl+C seal ToolCallRow
🆕 C-F2 (P1, this PR): ✗ reason text
🔄 A-F1 (P2): Pending preview pane
🔄 A-F2 (P2): Keys d=discard
🔄 A-F4 (P2): Docs Esc clear
🔄 B-F1 (P2): Header color escalation
🔄 C-F4 (P2): Multi-error count
🔄 C-F5 (P2): ⊘ for cancel
🔄 C-F7 (P2): Error filter
🔄 A-F3 (P2): Events scroll-into-view
```

P1 closure after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)