### PR TITLE
fix(tui): list d=discard pending-tab action in Keys tab (A-F2)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -129,6 +129,12 @@ def render_keys(app: "App") -> str:
         ("k", "Scroll up (current tab)"),
         ("space", "Toggle preview pane"),
         ("c", "Copy current view (pending tab: claim cursor)"),
+        # A-F2 (wave-8): ``d`` is the primary pending-tab action (=
+        # discard the cursor's intervention) but was missing from
+        # _PANEL_EXPLICIT entirely, so a user on the pending tab had
+        # no way to discover it from the Keys tab. Surface it here
+        # alongside ``c=claim`` for symmetry.
+        ("d", "Discard cursor (pending tab)"),
     ]
     for key, desc in _PANEL_EXPLICIT:
         if key not in seen:

--- a/tests/cli/test_keys_tab_panel_bindings.py
+++ b/tests/cli/test_keys_tab_panel_bindings.py
@@ -173,6 +173,30 @@ async def test_keys_tab_renders_h_l_resize_keys() -> None:
 
 
 @pytest.mark.asyncio
+async def test_keys_tab_lists_pending_d_discard_action() -> None:
+    """Tier 2 A-F2 (wave-8): the pending-tab ``d=discard`` action is
+    listed in the PANEL section so users can discover it from the Keys
+    tab without reading the pending tab's own header.
+
+    Before A-F2, ``_PANEL_EXPLICIT`` listed ``c`` (= claim) but not ``d``
+    (= discard). The pending tab's primary destructive action was
+    invisible in the Keys tab — only the gentler ``c=claim`` showed.
+    """
+    app = ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        rendered = render_keys(app)
+        assert "Discard cursor (pending tab)" in rendered, (
+            f"Keys tab must render the pending-tab d=discard hint; got:\n{rendered}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_h_l_resize_keys_group_under_panel_section() -> None:
     """Tier 2: ``h`` and ``l`` resize keys land in the PANEL group.
 


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #4 (A-F2, P2).

## Problem

Keys tab listed ``c=claim cursor`` under PANEL section but ``d=discard cursor`` (= the destructive primary pending-tab action) was completely missing. Users couldn't discover it from the Keys tab.

## Fix

Add ``("d", "Discard cursor (pending tab)")`` to ``_PANEL_EXPLICIT`` in ``keys_tab.py``.

## Test plan

- [x] ruff check passes
- [x] 1 new Tier 2 test asserts description appears in rendered output
- [x] Existing 9 keys_tab tests green

## Wave-8 context

```
✓ C-F1 (P1, PR #457): Ctrl+C seal ToolCallRow
✓ C-F2 (P1, PR #458): ✗ reason text
✓ A-F1 (P2, PR #459): Pending preview pane
🆕 A-F2 (P2, this PR): Keys d=discard
🔄 A-F4 / B-F1 / C-F4 / C-F5 / C-F7 / A-F3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)