### PR TITLE
feat(chat): mcp_install → state_change emitter via dispatch table (#398 v4 emitter #2)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -667,6 +667,39 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+# #398 v4 emitter family — events-log subscriber dispatch table.
+#
+# Maps known emitter event types to (source, template) tuples used by
+# ``ChatSession._on_chat_event_for_state_change`` to convert events
+# into ``notify_state_change`` calls. Adding a new emitter is one
+# entry here + the emitter emitting its event on the session's
+# events log (= OpContext.events, bound to ``_chat_events`` for
+# chat router-initiated ops).
+#
+# ``template`` is a ``str.format``-compatible string; the event's
+# ``data`` dict is passed as kwargs. Missing keys (= malformed event
+# payload) are silently skipped — observability must not crash the
+# events bus.
+#
+# Sister mechanism: PermissionResolver._on_persist_callbacks (= the
+# permission_manager emitter wiring landed in PR #456). The two
+# mechanisms coexist because their natural integration points differ:
+# permission_manager is a singleton service across sessions and
+# benefits from a direct subscriber list; op_runtime ops already emit
+# session-scoped events so the events log is the natural seam.
+_STATE_CHANGE_EVENT_MAPPINGS: dict[str, tuple[str, str]] = {
+    # MCP server install success (= ``reyn.op_runtime.mcp_install``
+    # emits this on the events log after writing the config).
+    "mcp_server_installed": (
+        "mcp_install",
+        "MCP server '{server_name}' was installed.",
+    ),
+    # Future emitter slots (= add when wired):
+    # "config_reloaded":  ("config_watcher", "Reyn configuration was updated."),
+    # "sp_version_changed": ("sp_loader",   "Agent system prompt was updated to version {version}."),
+}
+
+
 def _run_short(run_id: str) -> str:
     """Last 4 chars of a chat-side run_id, used as a display tag."""
     return run_id[-4:] if run_id else ""
@@ -1245,6 +1278,15 @@ class ChatSession:
         # at different scopes.
         from reyn.chat.lifecycle_forwarder import ChatLifecycleForwarder
         self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))
+        # #398 v4 emitter family — generic events-log subscriber that
+        # converts known op-emitted events (= mcp_server_installed,
+        # future: config_reloaded / sp_version_changed) to
+        # ``state_change`` history entries via the
+        # ``_STATE_CHANGE_EVENT_MAPPINGS`` dispatch table. Sister to
+        # the permission_manager direct-callback wiring (= PR #456).
+        self._chat_events.add_subscriber(
+            self._on_chat_event_for_state_change,
+        )
 
         # PR-refactor-session-1 wave 3 PR1: per-session budget adapter.
         # Absorbs total_usage / total_cost_usd / router-cap state that
@@ -1568,6 +1610,39 @@ class ChatSession:
         self.history.append(msg)
         with self.history_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(msg), ensure_ascii=False) + "\n")
+
+    def _on_chat_event_for_state_change(self, event) -> None:
+        """Generic events-log subscriber that converts known emitter events
+        to ``state_change`` history entries (= #398 v4 emitter family).
+
+        The chat router's ``OpContext.events`` is bound to this session's
+        ``_chat_events`` (= session.py make_router_op_context). When the
+        LLM invokes an op like ``mcp_install`` and the op emits its
+        success event, this subscriber sees it and mints the
+        corresponding state_change so the LLM's next turn sees the
+        world-state change without a separate plumbing path per
+        emitter.
+
+        Extension shape (= one dict entry per new emitter):
+          ``_STATE_CHANGE_EVENT_MAPPINGS[event_type] = (source, template)``
+        where ``template`` is a ``str.format``-compatible string and
+        receives the event's ``data`` dict as kwargs. New emitters
+        only need to (a) emit a known event type on the chat events
+        log and (b) register their (source, template) in the mapping.
+
+        Defensive: malformed event payloads (= missing template keys,
+        wrong types) are silently skipped — observability must not
+        crash the events bus or downstream subscribers.
+        """
+        mapping = _STATE_CHANGE_EVENT_MAPPINGS.get(getattr(event, "type", ""))
+        if mapping is None:
+            return
+        source, template = mapping
+        try:
+            summary = template.format(**(event.data or {}))
+        except (KeyError, ValueError, AttributeError):
+            return
+        self.notify_state_change(summary, source=source)
 
     def _on_permission_persisted(self, key: str, approved: bool) -> None:
         """PermissionResolver subscriber — convert grant/revoke to a

--- a/tests/test_mcp_install_state_change_emitter.py
+++ b/tests/test_mcp_install_state_change_emitter.py
@@ -1,0 +1,186 @@
+"""Tier 2: mcp_install → state_change emitter wiring (#398 v4 emitter #2).
+
+Second concrete emitter for the ``notify_state_change`` API. When the
+LLM (or any chat-router-initiated path) successfully installs an MCP
+server, the op_runtime ``mcp_install`` handler emits an
+``mcp_server_installed`` event on the session's chat_events log. The
+``_on_chat_event_for_state_change`` subscriber sees it and mints a
+``state_change`` history entry so the LLM's next turn sees "MCP
+server 'X' was installed." — breaks the symmetric trap to #352
+where the LLM kept saying "I can't access X" after X was newly
+installed.
+
+Pins:
+
+  1. ``mcp_server_installed`` event on the session's chat_events log
+     triggers a state_change history entry.
+  2. The summary text uses the ``server_name`` field from the event.
+  3. The state_change carries ``source="mcp_install"`` for audit.
+  4. Unknown event types don't trigger anything (= dispatch table
+     filters cleanly).
+  5. Malformed event data (= missing template keys) is silently
+     skipped — observability must not crash the events bus.
+  6. The dispatch table is extensible (= adding a new emitter is one
+     entry).
+
+Tier 2 because the contract is the foundation for the rest of the
+#398 v4 emitter family — config_watcher / sp_loader / etc. follow the
+same dispatch table pattern.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import (
+    _STATE_CHANGE_EVENT_MAPPINGS,
+    ChatMessage,
+    ChatSession,
+)
+from reyn.events.state_log import StateLog
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _state_changes(session: ChatSession) -> list[ChatMessage]:
+    return [
+        m for m in session.history
+        if m.role == "system" and (m.meta or {}).get("kind") == "state_change"
+    ]
+
+
+# ── dispatch table contract ───────────────────────────────────────────
+
+
+def test_mcp_server_installed_is_in_dispatch_table():
+    """Tier 2: the dispatch table contains an entry for the
+    ``mcp_server_installed`` event with source ``"mcp_install"`` and a
+    template that consumes ``server_name``.
+
+    Pins the table-driven emitter shape so future PRs that add
+    additional events can follow the same pattern (= one entry per
+    new emitter).
+    """
+    assert "mcp_server_installed" in _STATE_CHANGE_EVENT_MAPPINGS
+    source, template = _STATE_CHANGE_EVENT_MAPPINGS["mcp_server_installed"]
+    assert source == "mcp_install"
+    assert "{server_name}" in template
+
+
+# ── mcp_server_installed emission ─────────────────────────────────────
+
+
+def test_mcp_server_installed_event_mints_state_change(tmp_path):
+    """Tier 2 (#398 v4 emitter #2): emitting
+    ``mcp_server_installed`` on the session's chat_events log triggers
+    a state_change history entry. The LLM's next turn reads "MCP server
+    'X' was installed." and breaks out of the "I can't access X" trap.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    session._chat_events.emit(
+        "mcp_server_installed",
+        server_id="io.github.modelcontextprotocol/server-sqlite",
+        server_name="sqlite",
+        scope="project",
+        runtime="npx",
+    )
+
+    entries = _state_changes(session)
+    assert len(entries) == pre_count + 1
+    assert entries[-1].content == "MCP server 'sqlite' was installed."
+    assert entries[-1].meta.get("source") == "mcp_install"
+
+
+def test_mcp_server_installed_uses_server_name_field(tmp_path):
+    """Tier 2: the template substitutes ``server_name`` from event data,
+    not ``server_id`` (= some registries use IDs that differ from the
+    config key the user actually references). The user-readable name
+    is what the LLM should see.
+    """
+    session = _make_session(tmp_path)
+
+    session._chat_events.emit(
+        "mcp_server_installed",
+        server_id="long.registry.id/server-fs",
+        server_name="filesystem",
+    )
+
+    entries = _state_changes(session)
+    assert entries[-1].content == "MCP server 'filesystem' was installed."
+
+
+# ── dispatch hygiene (= non-mapped events ignored) ─────────────────────
+
+
+def test_non_mapped_event_does_not_trigger_state_change(tmp_path):
+    """Tier 2: events not in the dispatch table are silently ignored —
+    the subscriber doesn't accidentally mint state_change entries for
+    every event on the chat_events log.
+
+    Without this filter the subscriber would create a flood of
+    state_change entries for events like ``router_loop_started`` or
+    ``llm_called`` that have nothing to do with world-state changes.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    # Several non-mapped events that ARE legitimate chat_events traffic.
+    session._chat_events.emit("router_iteration_started")
+    session._chat_events.emit("llm_called", model="x")
+    session._chat_events.emit("act_executed", tool="some_tool")
+
+    # No new state_change entries.
+    assert len(_state_changes(session)) == pre_count
+
+
+def test_malformed_event_data_skipped_defensively(tmp_path):
+    """Tier 2: a mapped event with missing required template keys
+    (= e.g. ``mcp_server_installed`` without ``server_name``) is
+    skipped silently — does not crash the events bus or propagate
+    a KeyError to the producer.
+
+    Defensive isolation: observability must not break the core
+    operation that emitted the event.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    # Emit without the ``server_name`` field the template needs.
+    session._chat_events.emit("mcp_server_installed", server_id="x")
+
+    # No state_change entry minted (= silently skipped).
+    assert len(_state_changes(session)) == pre_count
+
+
+# ── notify_state_change emitter wiring as a system property ────────────
+
+
+def test_multiple_installs_each_mint_separate_state_change(tmp_path):
+    """Tier 2: multiple installs in sequence each mint their own
+    state_change entry — no implicit deduplication or batching.
+    Matches the per-event preservation policy from #398 v4 Q3.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    session._chat_events.emit("mcp_server_installed", server_name="sqlite")
+    session._chat_events.emit("mcp_server_installed", server_name="git")
+    session._chat_events.emit("mcp_server_installed", server_name="fetch")
+
+    entries = _state_changes(session)
+    assert len(entries) == pre_count + 3
+    contents = [e.content for e in entries[-3:]]
+    assert contents == [
+        "MCP server 'sqlite' was installed.",
+        "MCP server 'git' was installed.",
+        "MCP server 'fetch' was installed.",
+    ]


### PR DESCRIPTION
**[e2e-coder]** — #398 v4 emitter #2 (= mcp_install). Second concrete emitter for ``notify_state_change``; follows PR #456 (permission_manager) which closed #352.

## What it does

When the LLM successfully installs an MCP server via the chat-router-initiated ``mcp_install`` op, the existing ``mcp_server_installed`` event on the session's ``chat_events`` log triggers a ``state_change`` history entry. The LLM's next turn reads "MCP server 'X' was installed." — breaks the symmetric trap to #352 where the LLM kept saying "I can't access X" after X was newly installed.

## Two wirings, two mechanisms (= justified divergence)

| Emitter | Mechanism | Why |
|---|---|---|
| permission_manager (PR #456) | Direct subscriber on ``PermissionResolver._on_persist_callbacks`` | Singleton service across sessions; callback list is its natural extension |
| **mcp_install (this PR)** | Events-log subscriber on ``_chat_events`` | ``mcp_server_installed`` event ALREADY exists on the log (P6 audit); subscribe to what's there |

Both reach the same ``notify_state_change`` endpoint. Dual-mode is consistent with #398 v4: "any Reyn module can emit; how it reaches the API is implementation choice".

## Dispatch table

```python
_STATE_CHANGE_EVENT_MAPPINGS: dict[str, tuple[str, str]] = {
    "mcp_server_installed": (
        "mcp_install",
        "MCP server '{server_name}' was installed.",
    ),
    # Future slots commented in source for forward visibility:
    # "config_reloaded":  ("config_watcher", "Reyn configuration was updated."),
    # "sp_version_changed": ("sp_loader", "Agent system prompt was updated to version {version}."),
}
```

Adding a new emitter = one dict entry + the emitter emits its event. The subscriber method is dispatch-table-driven with defensive skip on malformed payloads.

## Change shape

- ``src/reyn/chat/session.py``:
  - ``_STATE_CHANGE_EVENT_MAPPINGS`` module-level table
  - ``_on_chat_event_for_state_change`` subscriber method
  - ``__init__`` adds subscriber to ``_chat_events``
- ``tests/test_mcp_install_state_change_emitter.py`` (new, 6 tests):
  - Dispatch table contains expected entry
  - Emission mints state_change with right summary + source
  - ``server_name`` field used (= not ``server_id``)
  - Non-mapped events ignored (= no flood from other event traffic)
  - Malformed event data skipped defensively
  - Multiple installs → multiple state_change entries (= per-event preservation, no dedup)

## Test plan

- [x] ``pytest tests/test_mcp_install_state_change_emitter.py + sibling`` — 24/24 pass
- [x] ``pytest tests/`` (full suite) — 4759 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## #398 v4 emitter family progression

| # | Emitter | Status |
|---|---|---|
| 1 | permission_manager | MERGED (PR #456, closed #352) |
| **2** | **mcp_install** | **OPEN (this PR)** |
| 3 | config_watcher | follow-up |
| 4 | sp_loader | follow-up |
| 5 | hot_list_tracker (= optional) | follow-up if needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)