### PR TITLE
fix(tui): clear docs filter on Esc (A-F4)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -427,8 +427,20 @@ class RightPanel(Widget):
             # the App's escape binding is gated by ``check_action`` which
             # returns False when nothing else (recording, error box) is
             # interceptable. Tab cycling stays; this is purely the exit.
+            # A-F4 (wave-8): when the docs tab has an active filter,
+            # Esc clears the filter in place instead of dropping focus
+            # back to the input bar. Without this, the only clear path
+            # was running ``/docs-filter`` (with no argument) — a
+            # mechanical 4-step (=  press `/`, delete pre-fill,
+            # submit empty). Esc-to-clear matches the standard
+            # "back out one level" affordance and keeps focus where
+            # the user just was.
             event.prevent_default()
             event.stop()
+            if self._panel_type == "docs" and self._docs_filter:
+                self._docs_filter = ""
+                self._invalidate()
+                return
             from .. import InputBar  # late import → avoid cycle
             try:
                 self.app.query_one("#inputbar", InputBar).focus_input()

--- a/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
@@ -66,9 +66,14 @@ def render_docs(
 
     lines: list[str] = []
     if docs_filter:
+        # A-F4 (wave-8): hint advertises Esc as the direct clear path.
+        # Pre-A-F4, the only clear flow was ``/docs-filter`` (no arg) — a
+        # 4-step (press `/`, delete prefill, submit empty) that no other
+        # filter UI requires. ``RightPanel.on_key`` now clears in place
+        # on Esc when ``_docs_filter`` is non-empty.
         lines.append(
             f"[#aaaaaa]  filter: [/][{_CORAL}]{_esc(docs_filter)}[/]"
-            f"[#555555]  (clear via /docs-filter)[/]"
+            f"[#555555]  (Esc to clear)[/]"
         )
         lines.append("")
     if not groups:

--- a/tests/cli/test_docs_filter_esc_clear.py
+++ b/tests/cli/test_docs_filter_esc_clear.py
@@ -1,0 +1,92 @@
+"""Tier 2: Docs filter clears on Esc (A-F4).
+
+Before this fix, the only path to clear an active docs filter was
+running ``/docs-filter`` with no argument — a 4-step ritual (press
+``/``, see pre-filled ``/docs-filter ...``, delete the pre-fill,
+submit empty). Esc was a silent no-op when the docs tab had a
+filter active.
+
+Now Esc on the docs tab with an active filter clears in place. The
+hint text in the rendered docs output also updates from "(clear via
+/docs-filter)" to "(Esc to clear)" so the affordance is discoverable.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_render_docs_filter_hint_advertises_esc_to_clear(tmp_path) -> None:
+    """Tier 2: rendered docs output advertises Esc clear path."""
+    from reyn.chat.tui.widgets.right_panel.docs_tab import render_docs
+
+    # Build a docs/ tree so the renderer has something to enumerate.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "alpha.md").write_text("# alpha\n", encoding="utf-8")
+    (docs / "beta.md").write_text("# beta\n", encoding="utf-8")
+
+    from reyn.chat.tui.widgets.right_panel.docs_tab import build_docs_index
+    groups, _flat = build_docs_index(tmp_path, docs_filter="alpha")
+    rendered = render_docs(tmp_path, 0, groups, docs_filter="alpha")
+    # New hint is present.
+    assert "Esc to clear" in rendered
+    # Old wording must not linger.
+    assert "/docs-filter" not in rendered
+
+
+def test_render_docs_no_filter_omits_clear_hint(tmp_path) -> None:
+    """Tier 2: no filter active → no clear hint rendered."""
+    from reyn.chat.tui.widgets.right_panel.docs_tab import render_docs
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "alpha.md").write_text("# alpha\n", encoding="utf-8")
+
+    from reyn.chat.tui.widgets.right_panel.docs_tab import build_docs_index
+    groups, _flat = build_docs_index(tmp_path, docs_filter="")
+    rendered = render_docs(tmp_path, 0, groups, docs_filter="")
+    assert "Esc to clear" not in rendered
+    assert "filter:" not in rendered
+
+
+def test_right_panel_on_key_esc_clears_docs_filter() -> None:
+    """Tier 2: Esc on docs tab with active filter clears in place.
+
+    Constructs a minimal RightPanel via ``__new__`` since
+    ``_docs_filter`` mutation + ``_invalidate`` are all that the Esc
+    branch touches; full Textual app context isn't needed to verify
+    the state mutation.
+    """
+    from reyn.chat.tui.widgets.right_panel import RightPanel
+
+    panel = RightPanel.__new__(RightPanel)
+    panel._panel_type = "docs"
+    panel._docs_filter = "alpha"
+    invalidated = []
+    # Stub _invalidate so the call doesn't need a mounted widget.
+    panel._invalidate = lambda: invalidated.append(True)
+
+    # Stub event object matching the .key API the handler reads.
+    class _Event:
+        key = "escape"
+        prevented = False
+        stopped = False
+
+        def prevent_default(self):
+            self.prevented = True
+
+        def stop(self):
+            self.stopped = True
+
+    event = _Event()
+    panel.on_key(event)
+
+    assert panel._docs_filter == ""
+    assert invalidated == [True]
+    assert event.prevented is True
+    assert event.stopped is True


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #5 (A-F4, P2).

## Problem

Clearing an active docs filter required running ``/docs-filter`` with no arg — a 4-step (press ``/``, see prefilled, delete prefill, submit empty). Esc on the docs tab silently did nothing when a filter was active.

## Fix

- ``RightPanel.on_key`` Esc with active docs filter → clear in place
- Render hint updated from ``"(clear via /docs-filter)"`` → ``"(Esc to clear)"``

Behavior preserved on other tabs: Esc still returns focus to input bar.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests (hint / no-hint / state mutation)

## Wave-8 context

```
✓ C-F1 / C-F2 (P1, #457 / #458)
✓ A-F1 / A-F2 (P2, #459 / #460)
🆕 A-F4 (P2, this PR): Docs Esc clear
🔄 B-F1 / C-F4 / C-F5 / C-F7 / A-F3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)