### PR TITLE
fix(tui): header token/cost color escalates near budget cap (B-F1)

### DIFF
--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -29,6 +29,39 @@ _MODEL_DATE_SUFFIX = re.compile(r"-(?:\d{8}|\d{4}-\d{1,2}-\d{1,2})$")
 _MODEL_LATEST_SUFFIX = re.compile(r"-latest$")
 
 
+def _cap_proximity_color(used: float | int, cap: float | int | None) -> str | None:
+    """Return amber / red style when ``used`` is close to ``cap``, else None.
+
+    B-F1 (wave-8): the header's token + cost segments use this to surface
+    cap-proximity at a glance. Returns:
+
+      - None  when no cap is set (= style=None → default ``#aaaaaa``)
+      - ``"#ffaa44"`` (amber) when used / cap >= 0.75
+      - ``"#ff4444"`` (red)   when used / cap >= 0.90
+
+    Thresholds mirror ``cost_tab._budget_bar`` so the visual gradient is
+    consistent across the header status line and the right-panel cost
+    tab's progress bar. The hard ``budget_warn`` lifecycle marker still
+    fires at 80 % per ``BudgetTracker.warn_ratio``; this softer header
+    gradient gives the user lead-time.
+    """
+    if cap is None:
+        return None
+    try:
+        cap_f = float(cap)
+        used_f = float(used)
+    except (TypeError, ValueError):
+        return None
+    if cap_f <= 0:
+        return None
+    ratio = used_f / cap_f
+    if ratio >= 0.90:
+        return "#ff4444"
+    if ratio >= 0.75:
+        return "#ffaa44"
+    return None
+
+
 def _shorten_model_id(model: str) -> str:
     """Return ``model`` with trailing date / ``-latest`` suffix stripped.
 
@@ -256,8 +289,16 @@ class ReynHeader(Widget):
         cost_str = f"${self._cost_usd:.4f}"
         if self._cost_cap is not None:
             cost_str += f" / ${self._cost_cap:.2f}"
-        parts.append((tok_str, None))
-        parts.append((cost_str, None))
+        # B-F1 (wave-8): cap-proximity color escalation. When budget caps
+        # are configured, the token / cost segments shift to amber at
+        # ≥ 75 % utilisation and to red at ≥ 90 % so the user has a
+        # live gradient cue without waiting for the hard
+        # ``[↑ budget warn: …]`` lifecycle marker at 80 %. Thresholds
+        # match the cost-tab's ``_budget_bar`` for cross-surface
+        # consistency. When no cap is configured, the field stays at
+        # the default ``#aaaaaa`` (= style=None falls through).
+        parts.append((tok_str, _cap_proximity_color(self._tokens_today, self._tokens_cap)))
+        parts.append((cost_str, _cap_proximity_color(self._cost_usd, self._cost_cap)))
         # Issue #277 — pending-ops badge. Inserted before the clock so
         # the canary stays in its expected (= rightmost) position.
         # Amber-style colour to signal "user attention soft-required".

--- a/tests/cli/test_header_cap_proximity_color.py
+++ b/tests/cli/test_header_cap_proximity_color.py
@@ -1,0 +1,68 @@
+"""Tier 2: header cost / token segments shift color near budget cap (B-F1).
+
+Wave-8 Topic B finding F1 (P2): before this fix, the header's
+``tokens`` and ``cost`` segments rendered in the default ``#aaaaaa``
+regardless of how close the spend was to the configured cap. The
+``[↑ budget warn: …]`` lifecycle marker fires at 80 % but the
+header surface was silent until then.
+
+Now ``_cap_proximity_color`` returns:
+  - ``"#ffaa44"`` (amber) at ratio ≥ 0.75
+  - ``"#ff4444"`` (red)   at ratio ≥ 0.90
+  - ``None``              otherwise (= default style)
+
+Thresholds mirror ``cost_tab._budget_bar`` for cross-surface consistency.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_cap_proximity_color_returns_none_without_cap() -> None:
+    """Tier 2: no cap → no color override (= default ``#aaaaaa`` falls through)."""
+    from reyn.chat.tui.widgets.header import _cap_proximity_color
+    assert _cap_proximity_color(100, None) is None
+    assert _cap_proximity_color(0, None) is None
+
+
+def test_cap_proximity_color_returns_none_below_75_percent() -> None:
+    """Tier 2: ratio < 0.75 → no color escalation."""
+    from reyn.chat.tui.widgets.header import _cap_proximity_color
+    assert _cap_proximity_color(0, 100) is None
+    assert _cap_proximity_color(50, 100) is None
+    assert _cap_proximity_color(74, 100) is None
+
+
+def test_cap_proximity_color_returns_amber_between_75_and_90() -> None:
+    """Tier 2: 75 % ≤ ratio < 90 % → amber."""
+    from reyn.chat.tui.widgets.header import _cap_proximity_color
+    assert _cap_proximity_color(75, 100) == "#ffaa44"
+    assert _cap_proximity_color(80, 100) == "#ffaa44"
+    assert _cap_proximity_color(89, 100) == "#ffaa44"
+
+
+def test_cap_proximity_color_returns_red_at_90_or_above() -> None:
+    """Tier 2: ratio ≥ 90 % → red."""
+    from reyn.chat.tui.widgets.header import _cap_proximity_color
+    assert _cap_proximity_color(90, 100) == "#ff4444"
+    assert _cap_proximity_color(100, 100) == "#ff4444"
+    assert _cap_proximity_color(150, 100) == "#ff4444"  # over cap stays red
+
+
+def test_cap_proximity_color_handles_zero_cap_gracefully() -> None:
+    """Tier 2: ``cap == 0`` would divide by zero → return None defensively."""
+    from reyn.chat.tui.widgets.header import _cap_proximity_color
+    assert _cap_proximity_color(50, 0) is None
+
+
+def test_cap_proximity_color_handles_non_numeric_input() -> None:
+    """Tier 2: non-numeric ``used`` / ``cap`` doesn't crash; returns None."""
+    from reyn.chat.tui.widgets.header import _cap_proximity_color
+    assert _cap_proximity_color("oops", 100) is None
+    assert _cap_proximity_color(50, "oops") is None
+    assert _cap_proximity_color(None, 100) is None


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #6 (B-F1, P2).

## Problem

Header tokens / cost segments stayed at the default ``#aaaaaa`` regardless of cap proximity. ``[↑ budget warn: …]`` only fires at 80 % — the header gave no lead-time signal before that.

## Fix

New ``_cap_proximity_color(used, cap)``:
- amber (``#ffaa44``) at ≥ 75 %
- red (``#ff4444``) at ≥ 90 %
- None / no cap → default unchanged

Thresholds mirror ``cost_tab._budget_bar`` for cross-surface consistency.

## Test plan

- [x] ruff check passes
- [x] 6 new Tier 2 tests (all branches + defensive paths)
- [x] Existing header tests 5/5 green

## Wave-8 context

```
✓ C-F1 / C-F2 (P1)
✓ A-F1 / A-F2 / A-F4 (P2)
🆕 B-F1 (P2, this PR): Header cap-proximity color
🔄 C-F4 / C-F5 / C-F7 / A-F3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)