### PR TITLE
fix(router): emit [task_spawned] kind=plan structured header on plan spawn-ack (closes #441/#445 plan-side follow-up)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -72,6 +72,24 @@ _SPAWN_ACK_MSG: dict[str, str] = {
 }
 
 
+# B49 plan-side spawn alignment (= #441 / #445 follow-up): the user-
+# friendly trailer that pairs with the `[task_spawned] kind=plan`
+# structured header. Plan dispatch is async (= ADR-0023 §2.1.1) so
+# behaviour mirrors skill spawn-ack: router exits after dispatch,
+# the LLM regains control on the next [task_completed] kind=plan
+# injection from session._handle_plan_completed.
+_PLAN_SPAWN_ACK_MSG: dict[str, str] = {
+    "ja": (
+        "プランをバックグラウンドで実行しています。"
+        " `/tasks` で進行状況を確認できます。"
+    ),
+    "en": (
+        "Plan is running in the background."
+        " Use `/tasks` to monitor progress."
+    ),
+}
+
+
 # NF-W7-B43-2: positive directive injected into the spawn-ack tool_result
 # content. Replaces the previous OS-synthetic spawn-ack outbox push +
 # early-exit pattern with the standard tool_call → tool_result → LLM
@@ -1662,6 +1680,81 @@ class RouterLoop:
                     if get_dispatch_kind(tc["function"]["name"]) == "async"
                 )
                 if async_count:
+                    # B49 plan-side spawn alignment (= #441 / #445
+                    # follow-up): when a plan tool dispatch is in the
+                    # async batch, push a ``[task_spawned] kind=plan``
+                    # structured header instead of the generic
+                    # "dispatched N async request" status. This makes
+                    # plan spawn-ack symmetric with skill spawn-ack
+                    # (= router_loop.py:1881 path), so the LLM history
+                    # carries a correlatable spawn record that pairs
+                    # with the later ``[task_completed] kind=plan
+                    # plan_id=<X>`` injection from
+                    # session._handle_plan_completed.
+                    # B49 plan-side retest discipline (= retest-before-PR
+                    # surfaced this bug): dispatch_tool() wraps all
+                    # invoker results as ``{"status": "ok", "data":
+                    # <raw_result>}`` (see dispatch/dispatcher.py), so
+                    # the spawned status is nested under ``data``. The
+                    # skill spawn-ack indices block (above) already
+                    # handles both forms; mirror that pattern here so
+                    # plan dispatch detection is symmetric.
+                    plan_idx = next(
+                        (
+                            i
+                            for i, (tc, r) in enumerate(zip(tool_calls, tool_results))
+                            if tc["function"]["name"] == "plan"
+                            and isinstance(r, dict)
+                            and (
+                                r.get("status") == "spawned"
+                                or (
+                                    isinstance(r.get("data"), dict)
+                                    and r["data"].get("status") == "spawned"
+                                )
+                            )
+                        ),
+                        None,
+                    )
+                    if plan_idx is not None:
+                        tc_plan = tool_calls[plan_idx]
+                        r_plan = tool_results[plan_idx]
+                        plan_spawn = (
+                            r_plan["data"]
+                            if isinstance(r_plan.get("data"), dict)
+                            else r_plan
+                        )
+                        plan_id = plan_spawn.get("plan_id", "")
+                        plan_chain_id = plan_spawn.get("chain_id", self.chain_id)
+                        n_steps = plan_spawn.get("n_steps", 0)
+                        try:
+                            plan_args = json.loads(
+                                tc_plan["function"].get("arguments") or "{}",
+                            )
+                        except (json.JSONDecodeError, TypeError):
+                            plan_args = {}
+                        plan_goal = plan_args.get("goal", "")
+                        header = (
+                            f"[task_spawned] kind=plan "
+                            f"plan_id={plan_id} chain_id={plan_chain_id}\n"
+                            f"goal: {plan_goal}  n_steps: {n_steps}"
+                        )
+                        lang = getattr(host, "output_language", None)
+                        trailer = _PLAN_SPAWN_ACK_MSG.get(
+                            lang, _PLAN_SPAWN_ACK_MSG["en"],
+                        )
+                        ack_text = f"{header}\n\n{trailer}"
+                        await self.host.put_outbox(
+                            kind="agent",
+                            text=ack_text,
+                            meta={
+                                "chain_id": self.chain_id,
+                                "source": "plan_spawn_ack",
+                            },
+                        )
+                        return self._total_usage
+                    # Non-plan async dispatch (= delegate_to_agent or
+                    # other async tools) falls back to the generic
+                    # status message.
                     plural = "s" if async_count > 1 else ""
                     await self.host.put_outbox(
                         kind="status",


### PR DESCRIPTION
**[dogfood-coder]** — PR #441 + #445 unified the `[task_completed]` injection across skill + plan and added a `[task_spawned] kind=skill` header to skill spawn-ack, but left the plan-side spawn path emitting the generic "dispatched N async request" status message. This breaks the LLM's ability to correlate a plan spawn with its later `[task_completed] kind=plan` injection — the spawn record carries no `plan_id` it can pair with.

**User direction (2026-05-22)**: 「土台から固める意識を持って」 — plan e2e foundation must be solid before per-scenario fixes are meaningful.

## Change

In `router_loop.py` async-tool exit branch, detect when a `plan` tool dispatch returned `status=spawned` (= same dual-form check as the skill spawn-ack indices block: top-level `status` OR nested under `data` because `dispatch_tool()` wraps invoker results). On detection, emit a structured header paired with a user-friendly trailer (`_PLAN_SPAWN_ACK_MSG`, ja/en), mirroring the skill spawn-ack format.

```
[task_spawned] kind=plan plan_id=<X> chain_id=<Y>
goal: <goal>  n_steps: <N>

<user-friendly trailer = "Plan is running in the background..." >
```

Non-plan async dispatches (= `delegate_to_agent` etc.) fall through to the existing generic status message.

## Live retest evidence (= pre-PR per `feedback_retest_before_pr_open`)

N=2 per W6 plan scenario × 3 scenarios = 6 shots against branch HEAD:

| scenario | header observed | evidence |
|----------|-----------------|----------|
| plan_compare_two_concepts (S1) | **2/2** | `[task_spawned] kind=plan plan_id=4ad5ad34`; `plan_id=075dedb4` |
| plan_explain_with_code_references (S2) | 0/2 | S2-s1: LLM did not invoke plan; S2-s2: router crash "list index out of range" |
| plan_summary_across_n_files (S3) | **1/2** | s1: `plan_id=c616b425`; s2: plan_invalid (malformed steps_json from LLM) |

**Scope-bound success: 3/3** in cases where the plan tool actually returned `status=spawned` (= exactly what this fix targets). The 3 R cases are independent issues (= LLM plan-trigger-miss attractor known from B49 baseline, a NEW router "list index out of range" crash, and an LLM malformed steps_json), not caused by the fix.

## Wrapper-dict bug caught by retest

The retest-before-PR discipline caught a subtle bug in the first draft: `dispatch_tool()` wraps all invoker results as `{"status": "ok", "data": <raw>}`, so the inner spawned status is under `data`. The first draft checked `r.get("status") == "spawned"` and always evaluated False. Fixed to mirror the skill spawn-ack indices block's dual-form check. This is exactly the kind of issue unit tests would have missed — the live retest is what surfaced it.

## Residual bugs surfaced (= out of scope, tracked as follow-ups)

1. **Router crash "list index out of range"** on plan invocation (1/6 shots) — caller-side index assumption fails on some plan args path. Independent bug.
2. **LLM `plan_invalid` on malformed `steps_json`** (1/6 shots) — LLM emitted bad JSON for the plan steps. Behaviour-side issue.
3. **LLM not invoking plan for code-reference scenarios** (S2 plan trigger miss) — B49 baseline carry-over, not introduced or addressed by this PR.

## Test plan

- [x] `pytest -k "plan or spawn_ack or router_loop or async_tool"` — 382 pass.
- [x] Live retest N=2 × 3 W6 scenarios (= 6 shots): structured header observed in 3/3 cases where plan spawn returned `status=spawned`; 3 R cases are independent (= not caused by fix).
- [ ] post-merge: B50 retest confirms plan-side spawn-ack header lands consistently when plan dispatch succeeds, paired with the [task_completed] kind=plan injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)