### PR TITLE
feat(tui): surface multi-error count in sticky status (C-F4)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1112,6 +1112,12 @@ class ConversationView(Widget):
         )
         self.mount(box)
         self._error_boxes.append(box)
+        # C-F4 (wave-8): once ≥ 2 error boxes are stacked, surface the
+        # count via the sticky so the user can see at a glance that
+        # one Esc per box is the dismiss path. Single-error case keeps
+        # the existing ``"✗ error below ↓"`` cue (= no count noise for
+        # the common path).
+        self._maybe_show_error_count_status()
         # Same scroll-respect rule as ``mount_intervention``: when the
         # user has scrolled up to read prior context, an async error
         # arriving must not yank the view to the bottom; the error box
@@ -1162,7 +1168,36 @@ class ConversationView(Widget):
                 f"  ✗ {summary} (dismissed){trailer}",
                 style="dim #555555",
             ))
+            # C-F4 (wave-8): after dismiss the live count drops by 1.
+            # If still ≥ 2, refresh the count sticky to the new value;
+            # otherwise the count form is stale and we clear the
+            # sticky so it doesn't linger as "2 errors" when only 1
+            # (or 0) remains.
+            n = len(self._error_boxes)
+            if n >= 2:
+                self._maybe_show_error_count_status()
+            else:
+                self.hide_status()
             return
+
+    def _maybe_show_error_count_status(self) -> None:
+        """Surface the live ErrorBox count via the sticky when ≥ 2 stacked.
+
+        C-F4 (wave-8): the existing ``_MAX_VISIBLE_ERROR_BOXES = 3``
+        cap lets an error storm stack 3 boxes each requiring its own
+        Esc to dismiss. Before this helper there was no at-a-glance
+        count + no clue that Esc was the dismiss key. The sticky now
+        reads ``✗ N errors — Esc to dismiss`` when ≥ 2 boxes are
+        live. The < 2 case is intentionally untouched here so the
+        ``mount_error`` single-error sticky (``"✗ error below ↓"``)
+        is preserved; ``dismiss_last_error`` clears the stale count
+        sticky directly when it drops the live count below 2.
+        """
+        n = len(self._error_boxes)
+        if n >= 2:
+            self.show_status(
+                f"✗ {n} errors — Esc to dismiss", kind="general",
+            )
 
     # ── intervention mounting ─────────────────────────────────────────────────
 

--- a/tests/cli/test_multi_error_count_status.py
+++ b/tests/cli/test_multi_error_count_status.py
@@ -1,0 +1,134 @@
+"""Tier 2: sticky status surfaces ErrorBox count when ≥ 2 stacked (C-F4).
+
+Wave-8 Topic C finding F4 (P2): ``_MAX_VISIBLE_ERROR_BOXES = 3`` lets
+up to 3 ErrorBoxes stack under the conv pane, each requiring its
+own Esc to dismiss. Before this helper there was no at-a-glance
+count + no clue that Esc was the dismiss key.
+
+``_maybe_show_error_count_status`` now:
+  - ≥ 2 boxes mounted → sticky reads ``"✗ N errors — Esc to dismiss"``
+  - 1 box mounted → sticky stays at whatever ``mount_error`` set
+    (= ``"✗ error below ↓"`` for scrolled-up, or hidden at tail)
+  - 0 boxes (all dismissed) → sticky hidden
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets import ConversationView  # noqa: E402
+
+
+class _ConvOnlyApp(App):
+    def compose(self) -> ComposeResult:
+        yield ConversationView(id="conversation")
+
+
+@pytest.mark.asyncio
+async def test_single_error_does_not_show_count_status() -> None:
+    """Tier 2: 1 box → sticky uses single-error cue, not count."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="first error")
+        await pilot.pause()
+        # Single-error sticky is either ``"✗ error below ↓"`` or hidden;
+        # the count-form ``"N errors"`` must NOT appear.
+        sticky = conv._sticky()
+        if sticky is not None:
+            snap = sticky.snapshot()
+            assert "errors —" not in snap.get("body", "")
+            assert "errors  —" not in snap.get("body", "")
+
+
+@pytest.mark.asyncio
+async def test_two_errors_show_count_in_sticky() -> None:
+    """Tier 2: ≥ 2 boxes → sticky reads ``"✗ 2 errors — Esc to dismiss"``."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="first error")
+        conv.mount_error(message="second error")
+        await pilot.pause()
+        sticky = conv._sticky()
+        assert sticky is not None
+        snap = sticky.snapshot()
+        assert snap["active"] is True
+        assert "2 errors" in snap["body"]
+        assert "Esc to dismiss" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_three_errors_show_count_three() -> None:
+    """Tier 2: count updates with stack depth (3 stacked boxes)."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="first")
+        conv.mount_error(message="second")
+        conv.mount_error(message="third")
+        await pilot.pause()
+        sticky = conv._sticky()
+        assert sticky is not None
+        snap = sticky.snapshot()
+        assert "3 errors" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_refreshes_count_below_threshold() -> None:
+    """Tier 2: dismissing one of two boxes drops back below count threshold.
+
+    After dismiss, ``_maybe_show_error_count_status`` should NOT keep
+    the count sticky active (= n == 1 → falls through to existing
+    single-error behaviour).
+    """
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="first")
+        conv.mount_error(message="second")
+        await pilot.pause()
+        # Count visible.
+        sticky = conv._sticky()
+        assert sticky is not None
+        assert "2 errors" in sticky.snapshot()["body"]
+        conv.dismiss_last_error()
+        await pilot.pause()
+        # One box remaining → count form should NOT linger as ACTIVE.
+        # The sticky's body retains the prior text after ``hide``
+        # (the widget doesn't blank it), but ``active=False`` is the
+        # load-bearing visibility signal users actually see.
+        snap = sticky.snapshot()
+        assert snap.get("active") is False, (
+            "sticky must be inactive after dismiss drops below threshold"
+        )
+
+
+@pytest.mark.asyncio
+async def test_dismiss_all_hides_sticky() -> None:
+    """Tier 2: dismissing every box → sticky cleared (= no orphan count)."""
+    app = _ConvOnlyApp()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="first")
+        conv.mount_error(message="second")
+        await pilot.pause()
+        conv.dismiss_last_error()
+        conv.dismiss_last_error()
+        await pilot.pause()
+        sticky = conv._sticky()
+        assert sticky is not None
+        snap = sticky.snapshot()
+        assert snap.get("active") is False


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #7 (C-F4, P2).

## Problem

``_MAX_VISIBLE_ERROR_BOXES = 3`` lets up to 3 ErrorBoxes stack each requiring its own Esc to dismiss. Before this helper there was no at-a-glance count + no clue that Esc was the dismiss key.

## Fix

New ``_maybe_show_error_count_status``:
- ≥ 2 boxes → sticky reads ``"✗ N errors — Esc to dismiss"``
- < 2 boxes → no-op (= preserves single-error sticky from mount_error)

``dismiss_last_error`` clears stale count sticky when drop below 2.

## Test plan

- [x] ruff check passes
- [x] 5 new Tier 2 tests (1 box / 2 / 3 / dismiss to 1 / dismiss all)
- [x] Existing ErrorBox left-bar tests green

## Wave-8 context

```
✓ C-F1 / C-F2 (P1)
✓ A-F1 / A-F2 / A-F4 / B-F1 (P2)
🆕 C-F4 (P2, this PR): Multi-error count
🔄 C-F5 / C-F7 / A-F3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)