### PR TITLE
fix(tui): use ⊘ glyph for user-cancelled SkillActivityRow (C-F5)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -951,8 +951,14 @@ class ReynTUIApp(App):
             if conv is not None and self._skill_exec:
                 for run_id in list(self._skill_exec.keys()):
                     try:
+                        # C-F5 (wave-8): aborted=True → ⊘ glyph (not ✗)
+                        # so user-initiated cancel reads visually distinct
+                        # from a system failure.
                         conv.finish_skill_row(
-                            run_id, success=False, reason="cancelled (remote)",
+                            run_id,
+                            success=False,
+                            reason="cancelled (remote)",
+                            aborted=True,
                         )
                     except Exception:
                         pass
@@ -980,8 +986,13 @@ class ReynTUIApp(App):
         if conv is not None and self._skill_exec:
             for run_id in list(self._skill_exec.keys()):
                 try:
+                    # C-F5 (wave-8): aborted=True → ⊘ glyph (not ✗) for
+                    # user-initiated cancel.
                     conv.finish_skill_row(
-                        run_id, success=False, reason="cancelled",
+                        run_id,
+                        success=False,
+                        reason="cancelled",
+                        aborted=True,
                     )
                 except Exception:
                     pass

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -998,7 +998,12 @@ class ConversationView(Widget):
     # ── SkillActivityRow (issue #210 / wave-7 #418) ───────────────────────────
 
     def finish_skill_row(
-        self, run_id: str, *, success: bool = True, reason: str = "",
+        self,
+        run_id: str,
+        *,
+        success: bool = True,
+        reason: str = "",
+        aborted: bool = False,
     ) -> None:
         """Transition the row to ``✓ / ✗`` and roll it into the scroll log.
 
@@ -1022,7 +1027,7 @@ class ConversationView(Widget):
         row = self._skill_rows.pop(run_id, None)
         if row is None:
             return
-        row.finish(success=success, reason=reason)
+        row.finish(success=success, reason=reason, aborted=aborted)
         try:
             finished_text = row._build_finished()
             self._write_body(finished_text)

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -112,6 +112,11 @@ class SkillActivityRow(Widget):
         # Finish state
         self._finished = False
         self._success = True
+        # C-F5 (wave-8): distinguishes user-initiated cancellation from
+        # system failure. When ``True``, ``_build_finished`` renders the
+        # ⊘ glyph in dim grey instead of the ✗ glyph in red. Set by
+        # ``finish(..., aborted=True)`` from ``action_cancel_inflight``.
+        self._aborted = False
         self._reason = ""
 
         # Timer
@@ -170,13 +175,28 @@ class SkillActivityRow(Widget):
         self._detail = detail
         self._refresh()
 
-    def finish(self, success: bool = True, reason: str = "") -> None:
-        """Transition to the completed line and stop the timer."""
+    def finish(
+        self,
+        success: bool = True,
+        reason: str = "",
+        *,
+        aborted: bool = False,
+    ) -> None:
+        """Transition to the completed line and stop the timer.
+
+        ``aborted=True`` (C-F5, wave-8) marks the finish as user-initiated
+        cancellation rather than a system failure — renders as ``⊘`` in
+        dim grey instead of ``✗`` in red. Use ``aborted=True`` from
+        ``action_cancel_inflight``; leave it False for failures coming
+        from workflow_aborted / exception paths so the user can tell
+        "I cancelled" from "the system failed".
+        """
         if self._finished:
             return
         self._finished = True
         self._running = False
         self._success = success
+        self._aborted = aborted
         self._reason = reason
         self._refresh()
 
@@ -263,6 +283,21 @@ class SkillActivityRow(Widget):
             # focal tab so it lands on agents/events automatically.
             t.append("  · ", style="dim")
             t.append("Ctrl+B → agents", style="dim")
+        elif self._aborted:
+            # C-F5 (wave-8): user-initiated cancellation gets the ⊘
+            # glyph in dim grey, distinguishing intent from a system
+            # failure. Same shape design as ToolCallRow's aborted
+            # state — color + glyph as a redundant cue.
+            t.append("⊘ ", style="dim #888888")
+            t.append(
+                f"{self._skill_name}#{self._short_id}",
+                style="dim",
+            )
+            t.append("  · ", style="dim")
+            cancel_msg = (
+                f"cancelled: {self._reason}" if self._reason else "cancelled"
+            )
+            t.append(cancel_msg, style="dim")
         else:
             t.append("✗ ", style="bold red")
             t.append(

--- a/tests/cli/test_skill_row_aborted_glyph.py
+++ b/tests/cli/test_skill_row_aborted_glyph.py
@@ -1,0 +1,82 @@
+"""Tier 2: SkillActivityRow uses ⊘ glyph for user-cancelled state (C-F5).
+
+Wave-8 Topic C finding F5 (P2): before this fix, a Ctrl+C-cancelled
+skill rendered as ``✗ skill#abcd · failed: cancelled · Ctrl+B → events``
+— visually identical to a system failure (= the same ``✗`` glyph in
+bold red). Scrolling back through history, the user couldn't tell
+"I cancelled this" from "the system failed this".
+
+Now ``finish(aborted=True)`` renders ``⊘`` in dim grey + "cancelled"
+text (without the events tab pointer). Same shape design as
+ToolCallRow's aborted state (= color + glyph as redundant cue).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _row():
+    """Construct an unmounted SkillActivityRow for direct exercise."""
+    from reyn.chat.tui.widgets.skill_activity import SkillActivityRow
+    return SkillActivityRow(run_id="abc1efgh", skill_name="test_skill")
+
+
+def test_finish_aborted_renders_circle_slash_glyph_not_x() -> None:
+    """Tier 2: aborted state renders ``⊘`` (= dim grey), NOT ``✗`` (= red).
+
+    Color is the redundant cue alongside the glyph; tests assert
+    on the rendered plain text via the existing ``_build_finished``
+    public render surface.
+    """
+    row = _row()
+    row.finish(success=False, reason="cancelled", aborted=True)
+    finished = row._build_finished().plain
+    assert "⊘" in finished, "aborted state must render ⊘"
+    assert "✗" not in finished, "aborted state must NOT render ✗"
+    # Reason text uses "cancelled:" not "failed:" for the aborted path.
+    assert "cancelled" in finished
+
+
+def test_finish_aborted_with_no_reason_falls_back_to_bare_cancelled() -> None:
+    """Tier 2: empty reason → bare ``"cancelled"`` (no orphan colon)."""
+    row = _row()
+    row.finish(success=False, reason="", aborted=True)
+    finished = row._build_finished().plain
+    assert "⊘" in finished
+    # Should NOT show ``cancelled:`` (= empty after the colon) — bare
+    # ``cancelled`` is the only legible form.
+    assert "cancelled:" not in finished
+    assert "cancelled" in finished
+
+
+def test_finish_failure_keeps_x_glyph_without_aborted_flag() -> None:
+    """Tier 2: existing system-failure path unaffected — still ✗ + red.
+
+    Ensures the aborted flag is opt-in; legacy callers that pass only
+    ``success=False`` continue to get the ✗ rendering.
+    """
+    row = _row()
+    row.finish(success=False, reason="timeout")
+    finished = row._build_finished().plain
+    assert "✗" in finished
+    assert "⊘" not in finished
+    assert "failed: timeout" in finished
+    assert "Ctrl+B → events" in finished
+
+
+def test_finish_success_unchanged_when_aborted_flag_ignored() -> None:
+    """Tier 2: ``success=True`` ignores ``aborted`` — still ✓ rendering.
+
+    The aborted branch only fires when ``success=False AND aborted=True``;
+    a successful finish should never reach the aborted code path.
+    """
+    row = _row()
+    row.finish(success=True, reason="2 phases", aborted=True)
+    finished = row._build_finished().plain
+    assert "✓" in finished
+    assert "⊘" not in finished


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #8 (C-F5, P2).

## Problem

Ctrl+C-cancelled skills rendered identical to system failures (``✗`` in bold red). The user couldn't distinguish intent from history.

## Fix

``finish(aborted=True)`` → ``⊘`` dim grey + ``cancelled[: <reason>]`` text. Wiring through ``finish_skill_row`` (opt-in arg) and ``action_cancel_inflight`` (both local + remote paths).

Legacy failure paths unchanged (= ``success=False`` only → ``✗`` red).

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests pin aborted / no-reason / legacy-failure / success-unaffected
- [x] Existing skill_activity_plan_step_persist tests green

## Wave-8 context

```
✓ C-F1 / C-F2 (P1)
✓ A-F1 / A-F2 / A-F4 / B-F1 / C-F4 (P2)
🆕 C-F5 (P2, this PR): ⊘ for cancel
🔄 C-F7 / A-F3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)