### PR TITLE
feat(chat): mcp_server_removed + index_dropped state_change emitters (#398 v4 emitters #3+#4)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -694,6 +694,23 @@ _STATE_CHANGE_EVENT_MAPPINGS: dict[str, tuple[str, str]] = {
         "mcp_install",
         "MCP server '{server_name}' was installed.",
     ),
+    # MCP server removal success (= ``reyn.op_runtime.mcp_drop_server``
+    # emits this after removing the config entry). Symmetric to
+    # mcp_server_installed — surfaces the "no longer available"
+    # state-change to the LLM so it doesn't keep trying.
+    "mcp_server_removed": (
+        "mcp_drop_server",
+        "MCP server '{server}' was removed.",
+    ),
+    # Indexed corpus removal (= ``reyn.op_runtime.index_drop`` emits
+    # this after dropping chunks from the backend). Recall against
+    # the dropped source will now miss; surfacing the change lets
+    # the LLM understand "the source it was citing yesterday doesn't
+    # exist today".
+    "index_dropped": (
+        "index_drop",
+        "Indexed source '{source}' was removed.",
+    ),
     # Future emitter slots (= add when wired):
     # "config_reloaded":  ("config_watcher", "Reyn configuration was updated."),
     # "sp_version_changed": ("sp_loader",   "Agent system prompt was updated to version {version}."),

--- a/tests/test_mcp_install_state_change_emitter.py
+++ b/tests/test_mcp_install_state_change_emitter.py
@@ -184,3 +184,100 @@ def test_multiple_installs_each_mint_separate_state_change(tmp_path):
         "MCP server 'git' was installed.",
         "MCP server 'fetch' was installed.",
     ]
+
+
+# ── mcp_server_removed emission (= #398 v4 emitter #3) ─────────────────
+
+
+def test_mcp_server_removed_event_mints_state_change(tmp_path):
+    """Tier 2 (#398 v4 emitter #3): emitting ``mcp_server_removed`` on
+    the session's chat_events log triggers a state_change history
+    entry. Symmetric to ``mcp_server_installed`` — surfaces the
+    "no longer available" state-change to the LLM so it doesn't keep
+    trying to call a server that was just removed.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    session._chat_events.emit(
+        "mcp_server_removed",
+        server="sqlite",
+        scope="project",
+        removed_path=".reyn/config.yaml",
+    )
+
+    entries = _state_changes(session)
+    assert len(entries) == pre_count + 1
+    assert entries[-1].content == "MCP server 'sqlite' was removed."
+    assert entries[-1].meta.get("source") == "mcp_drop_server"
+
+
+def test_mcp_server_removed_uses_server_field(tmp_path):
+    """Tier 2: the template substitutes the ``server`` field (= the
+    matching ``mcp_drop_server`` op uses ``server``, not ``server_name``).
+    Verifies the dispatch table mapping matches the producer event's
+    actual payload shape — a regression that renamed the field
+    upstream would silently fall through the defensive skip.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    session._chat_events.emit("mcp_server_removed", server="git")
+
+    entries = _state_changes(session)
+    assert len(entries) == pre_count + 1
+    assert entries[-1].content == "MCP server 'git' was removed."
+
+
+# ── index_dropped emission (= #398 v4 emitter #4) ──────────────────────
+
+
+def test_index_dropped_event_mints_state_change(tmp_path):
+    """Tier 2 (#398 v4 emitter #4): emitting ``index_dropped`` on the
+    session's chat_events log triggers a state_change history entry.
+    Recall against the dropped source will now miss; the LLM seeing
+    this entry understands "the source I was citing yesterday doesn't
+    exist today".
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    session._chat_events.emit(
+        "index_dropped",
+        source="some-docs-collection",
+        chunks_dropped=42,
+        manifest_removed=True,
+    )
+
+    entries = _state_changes(session)
+    assert len(entries) == pre_count + 1
+    assert entries[-1].content == "Indexed source 'some-docs-collection' was removed."
+    assert entries[-1].meta.get("source") == "index_drop"
+
+
+# ── 3-way emitter family co-occurrence ─────────────────────────────────
+
+
+def test_install_remove_dropindex_all_minted_separately(tmp_path):
+    """Tier 2: the three op-emitted state changes co-occur without
+    interfering. Each mints its own entry; sources are distinct;
+    contents are distinct. Confirms the dispatch table extension
+    doesn't conflate handlers across event types.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_state_changes(session))
+
+    session._chat_events.emit("mcp_server_installed", server_name="x")
+    session._chat_events.emit("mcp_server_removed", server="y")
+    session._chat_events.emit("index_dropped", source="z")
+
+    entries = _state_changes(session)[pre_count:]
+    assert len(entries) == 3
+    sources = [e.meta.get("source") for e in entries]
+    assert sources == ["mcp_install", "mcp_drop_server", "index_drop"]
+    contents = [e.content for e in entries]
+    assert contents == [
+        "MCP server 'x' was installed.",
+        "MCP server 'y' was removed.",
+        "Indexed source 'z' was removed.",
+    ]


### PR DESCRIPTION
**[e2e-coder]** — two more emitters via the dispatch table established in PR #461. Each is one dict entry; events already exist on the log.

## What's new

| Event | Source | Summary template |
|---|---|---|
| ``mcp_server_removed`` | ``mcp_drop_server`` | "MCP server '{server}' was removed." |
| ``index_dropped`` | ``index_drop`` | "Indexed source '{source}' was removed." |

Both are existing op-emitted events (= already on the chat_events log for P6 audit). Hooking them through the dispatch table is purely additive — no new infrastructure.

## Why batch

- Both are dispatch-table entries (= single-line additions)
- Both fix symmetric LLM trap patterns:
  - mcp_server_removed: stop trying to call a server that just got removed
  - index_dropped: stop citing a corpus that just got purged
- Single focused PR rather than two trivial ones

``config_watcher`` / ``sp_loader`` are NOT in this PR — those need new file-watcher / version-detection infrastructure and warrant their own focused PRs.

## Dispatch table after this PR

```python
_STATE_CHANGE_EVENT_MAPPINGS = {
    "mcp_server_installed": ("mcp_install",     "MCP server '{server_name}' was installed."),
    "mcp_server_removed":   ("mcp_drop_server", "MCP server '{server}' was removed."),       # NEW
    "index_dropped":        ("index_drop",      "Indexed source '{source}' was removed."),    # NEW
    # Future slots:
    # "config_reloaded":    ("config_watcher",  "Reyn configuration was updated."),
    # "sp_version_changed": ("sp_loader",       "Agent system prompt was updated to version {version}."),
}
```

Field-name parity reflects producer event shapes: ``server`` for drop ops vs ``server_name`` for install ops, ``source`` for index ops.

## Change shape

- ``src/reyn/chat/session.py``: 2 new dict entries (= 14 lines incl. comments)
- ``tests/test_mcp_install_state_change_emitter.py``: +4 tests
  - mcp_server_removed mints state_change with right summary + source
  - mcp_server_removed uses ``server`` field (= not server_name)
  - index_dropped mints state_change with right summary + source
  - 3-way emitter co-occurrence (= no handler conflation)

## Test plan

- [x] ``pytest tests/test_mcp_install_state_change_emitter.py`` — 10/10 pass (6 existing + 4 new)
- [x] ``pytest tests/`` (full suite) — 4763 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## #398 v4 emitter family progression

| # | Emitter | Status |
|---|---|---|
| API | ChatSession.notify_state_change | MERGED (PR #455) |
| 1 | permission_manager | MERGED (PR #456, closed #352) |
| 2 | mcp_install | MERGED (PR #461) |
| **3** | **mcp_drop_server** | **OPEN (this PR)** |
| **4** | **index_drop** | **OPEN (this PR)** |
| 5 | config_watcher | follow-up (= new infra needed) |
| 6 | sp_loader | follow-up (= new infra needed) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)