### PR TITLE
fix(word_stats_demo): fallback to artifact.text when no data wrapper (closes B49 W2-S3)

### DIFF
--- a/src/reyn/stdlib/skills/word_stats_demo/stats.py
+++ b/src/reyn/stdlib/skills/word_stats_demo/stats.py
@@ -11,6 +11,15 @@ def compute_text_stats(artifact: dict) -> dict:
     # `{"type": "user_message", "data": "..."}`) or a dict with a "text" key
     # (the canonical `{"data": {"text": "..."}}` form).  Handle both.
     #
+    # B49 W2-S3 fix (2026-05-22): the router's `invoke_action(args={"text":
+    # ...})` path delivers the artifact as `{"text": "..."}` (= top-level
+    # text, no `data` wrapper) rather than the phase-side canonical
+    # `{"data": {"text": ...}}` form. Both shapes are valid skill
+    # invocation paths, so fall through to `artifact["text"]` when `data`
+    # is absent or empty. Without this, the preprocessor returned
+    # all-zero stats and the review-phase LLM substituted the
+    # instructions' example number ("133") for the actual stat.
+    #
     # Returns the *normalized* data dict `{"text": ..., "stats": {...}}` so
     # the caller can write the result to `into: data`, replacing the whole
     # field in one step and ensuring `data.text` and `data.stats` are always
@@ -22,7 +31,7 @@ def compute_text_stats(artifact: dict) -> dict:
         text = data.get("text", "") or ""
     else:
         text = ""
-    text = text or ""
+    text = text or artifact.get("text", "") or ""
     lines = text.splitlines()
     line_count = len(lines) if lines else (1 if text else 0)
     word_count = len(text.split())


### PR DESCRIPTION
**[dogfood-coder]** — B49 W2-S3 (\`word_stats_demo_sentence\`) reported 133 chars for a 44-char English text. Root cause: \`compute_text_stats\` only handled the canonical phase-side artifact shape \`{\"data\": {\"text\": \"...\"}}\`, not the router-side \`invoke_action\` shape \`{\"text\": \"...\"}\`. With \`data\` absent → \`text=\"\"\` → all stats zero → the review-phase LLM substituted the example "133 chars across 3 lines" from its instruction prompt (= example bleed-through under uncertainty).

## Fix

One-line fallback in \`src/reyn/stdlib/skills/word_stats_demo/stats.py\`:

\`\`\`python
text = text or artifact.get("text", "") or ""
\`\`\`

Both invocation shapes now produce identical stats. Domain-agnostic — no scenario-specific keyword.

## Live retest (= pre-PR per \`feedback_retest_before_pr_open\`)

N=3 against branch HEAD:

| shot | char_count | verdict | evidence (reply excerpt) |
|------|------------|---------|--------------------------|
| 1 | **44** | V | "The text you provided has 44 characters and is on a single line." |
| 2 | **44** | V | "このテキストには44文字が含まれており、1行です。" |
| 3 | **44** | V | "このテキストは 44 文字で、1 行に 44 文字で構成されています。" |

- **v_rate: 3/3**
- B49 baseline: I (= 133 chars fabricated)
- **delta: +3V** vs B49 baseline
- Zero shots reported the fabricated 133 — example bleed-through fully eliminated.

## Test plan

- [x] Live retest N=3 — all shots correct.
- [x] No test changes needed (= additive fallback, existing tests unaffected).
- [ ] post-merge: B50 retest confirms W2-S3 V across broader scenario mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)