### PR TITLE
fix(tui): track per-row y-coords for events scroll-into-view (A-F3)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -141,6 +141,13 @@ class RightPanel(Widget):
         self._events_filelist_cache: list = []
         self._events_cursor: int = 0
         self._events_visible: list[dict] = []
+        # y-coord (0-indexed line) of each event's headline row in the
+        # rendered output. Populated by `render_events`; used by
+        # `_scroll_events_into_view` so chain-switch blank lines + the
+        # extra ``↳`` reply line on ``user_message_received`` rows don't
+        # drift the viewport off the cursor (A-F3, wave-8). Same idiom
+        # as ``_memory_entry_ys`` / ``_agents_item_ys``.
+        self._events_event_ys: list[int] = []
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
@@ -658,11 +665,17 @@ class RightPanel(Widget):
     def _scroll_events_into_view(self) -> None:
         """Scroll #panel-scroll so the events cursor line is visible.
 
-        Each event renders as one row (PR #79 trimmed timestamp to
-        HH:MM:SS; the type fits next to it on the same line). The
-        ``user_message_received`` rows have an extra `↳` reply line —
-        approximated as 1 here; the small over-/under-scroll on those
-        is barely noticeable.
+        Events render with variable height: chain switches insert a
+        blank separator line between groups, and
+        ``user_message_received`` rows have an extra ``↳`` reply line
+        below the headline. The pre-A-F3 arithmetic projection
+        (``y = 1 + cursor``) under-scrolled by the count of intervening
+        chain-switch + reply lines, so after a few chains the cursor
+        sat below the viewport with no visible movement on j/k.
+
+        ``render_events`` records the exact y of each event's
+        headline row in ``_events_event_ys``; we look it up here.
+        Same idiom as the memory- and agents-tab fixes.
         """
         try:
             vs = self.query_one("#panel-scroll", VerticalScroll)
@@ -670,8 +683,10 @@ class RightPanel(Widget):
             visible = vs.size.height
             if visible <= 0:
                 return
-            # Assume 1 line per event; +1 for content padding-top.
-            y = 1 + self._events_cursor
+            if not (0 <= self._events_cursor < len(self._events_event_ys)):
+                return
+            # +1 for content padding-top, matching the memory-tab fix.
+            y = 1 + self._events_event_ys[self._events_cursor]
             if y < current:
                 vs.scroll_to(y=y, animate=False)
             elif y >= current + visible:
@@ -1784,7 +1799,7 @@ class RightPanel(Widget):
             if self._panel_type == "keys":
                 return render_keys(self.app)
             if self._panel_type == "events":
-                rendered, windowed = render_events(
+                rendered, windowed, event_ys = render_events(
                     self._project_root,
                     self._event_filter_idx,
                     self._event_tail_idx,
@@ -1793,6 +1808,7 @@ class RightPanel(Widget):
                     filelist_cache=self._events_filelist_cache,
                 )
                 self._events_visible = windowed
+                self._events_event_ys = event_ys
                 if self._events_cursor >= len(windowed):
                     self._events_cursor = max(0, len(windowed) - 1)
                 return rendered

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -533,21 +533,28 @@ def render_events(
     cursor: int = 0,
     cache: dict | None = None,
     filelist_cache: list | None = None,
-) -> tuple[str, list[dict]]:
+) -> tuple[str, list[dict], list[int]]:
     """Render the recent-events list for the events tab.
 
-    Returns ``(rendered_markup, visible_events)`` so the orchestrator can
-    drive the cursor + Enter→preview integration without re-parsing files.
+    Returns ``(rendered_markup, visible_events, event_ys)`` so the
+    orchestrator can drive the cursor + Enter→preview integration
+    without re-parsing files. ``event_ys[i]`` is the 0-based line index
+    (within ``rendered_markup``) of event ``visible_events[i]``'s
+    headline row — used by ``_scroll_events_into_view`` to position
+    the viewport precisely even when chain-switch blank lines and
+    multi-line ``user_message_received`` rows have pushed the actual
+    row off the naive ``y = 1 + cursor`` projection (A-F3, wave-8).
+
     Consecutive events sharing a chain_id are visually grouped (a blank
     line separates chain switches). The row at index ``cursor`` is
     highlighted with a coral ▶ prefix.
     """
     if project_root is None:
-        return "[#555555]  (no project root)[/]", []
+        return "[#555555]  (no project root)[/]", [], []
 
     events_root = project_root / ".reyn" / "events"
     if not events_root.is_dir():
-        return "[#555555]  (no events yet)[/]", []
+        return "[#555555]  (no events yet)[/]", [], []
 
     if cache is None:
         cache = {}
@@ -581,7 +588,7 @@ def render_events(
         #      cycle to a different filter (the `[f]` header hint is only
         #      visible when the panel is wider than the filter name).
         if not all_events:
-            return "[#555555]  (no matching events)[/]", []
+            return "[#555555]  (no matching events)[/]", [], []
         # Split the two hints across separate lines so each survives the
         # 44-cell minimum panel width independently. The single-line
         # form was ~47 cells and clipped to ``press [f] to cycle filter
@@ -594,7 +601,7 @@ def render_events(
             f"[#555555] to cycle filter[/]\n"
             f"[#555555]  press [/][bold #aaaaaa]\\[t][/]"
             f"[#555555] for tail size[/]"
-        ), []
+        ), [], []
 
     # Newest-first window — also returned to the caller for cursor / preview
     windowed = list(visible[-tail:])[::-1]
@@ -604,6 +611,7 @@ def render_events(
     chain_replies = _load_chain_replies(project_root)
 
     lines: list[str] = []
+    event_ys: list[int] = []
     prev_chain: str | None = None
     for i, ev in enumerate(windowed):
         ev_type = ev.get("type", "?")
@@ -627,6 +635,12 @@ def render_events(
         cursor_prefix = (
             f"[bold {_CORAL}]▶ [/]" if i == cursor else "  "
         )
+        # Record the y of the headline row BEFORE appending — chain
+        # switches add a blank line above, and user_message_received
+        # rows add a ``↳`` reply line below, both of which drift the
+        # arithmetic ``1 + cursor`` projection. Same idiom as
+        # memory_tab / agents_tab.
+        event_ys.append(len(lines))
         lines.append(
             f"{cursor_prefix}[#444444]{ts}[/]  [{color}]{_esc(ev_type)}[/]{hint_part}"
         )
@@ -654,7 +668,7 @@ def render_events(
                     lines.append(f"[#444444]       ↳ [/][#777777]{short}[/]")
 
     del filter_name
-    return "\n".join(lines), windowed
+    return "\n".join(lines), windowed, event_ys
 
 
 __all__ = [

--- a/tests/cli/test_events_tab_event_ys.py
+++ b/tests/cli/test_events_tab_event_ys.py
@@ -1,0 +1,141 @@
+"""Tier 2: render_events returns per-row y-coords accounting for multi-line drift (A-F3).
+
+Wave-8 Topic A finding F3 (P2): pre-fix ``_scroll_events_into_view``
+used ``y = 1 + cursor`` which assumed one rendered line per event.
+But the actual rendered output has two sources of drift:
+
+  - chain-switch blank line between events that don't share chain_id
+  - extra ``↳`` reply line under each ``user_message_received`` row
+
+After a few chains, the arithmetic projection accumulated 3-5 lines
+of drift, leaving the cursor below the viewport with no apparent
+movement on j/k. Fix mirrors memory_tab / agents_tab: track each
+event's actual y-coord during render and look it up at scroll time.
+"""
+from __future__ import annotations
+
+import json as _json
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _write_events(tmp_path: Path, events: list[dict]) -> None:
+    """Write one jsonl per event under agents/default/ so the loader picks them up."""
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "default"
+    events_root.mkdir(parents=True, exist_ok=True)
+    log = events_root / "session.jsonl"
+    log.write_text(
+        "\n".join(_json.dumps(ev) for ev in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_event_ys_returned_for_single_chain_no_blanks(tmp_path: Path) -> None:
+    """Tier 2: same chain_id → no blank lines → ys are contiguous."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    _write_events(tmp_path, [
+        {"type": "phase_started", "timestamp": f"2026-05-22T10:00:0{i}Z",
+         "data": {"chain_id": "c1", "phase": f"p{i}"}}
+        for i in range(3)
+    ])
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    assert len(visible) == 3
+    assert len(ys) == 3
+    # Single chain, no user_message_received → ys are 0, 1, 2.
+    assert ys == [0, 1, 2]
+    # Sanity-check: ys index into actual rendered lines.
+    lines = rendered.split("\n")
+    for i, y in enumerate(ys):
+        assert "phase_started" in lines[y], (
+            f"event {i} (y={y}) should land on a phase_started row, got: {lines[y]!r}"
+        )
+
+
+def test_event_ys_skips_blank_line_at_chain_switch(tmp_path: Path) -> None:
+    """Tier 2: chain switch inserts blank → ys[1] = 2 (not 1).
+
+    Without the per-row tracking, ``y = 1 + cursor`` would point at
+    the blank separator row rather than the second event's headline.
+    """
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    _write_events(tmp_path, [
+        {"type": "phase_started", "timestamp": "2026-05-22T10:00:00Z",
+         "data": {"chain_id": "c1", "phase": "p0"}},
+        {"type": "phase_started", "timestamp": "2026-05-22T10:00:01Z",
+         "data": {"chain_id": "c2", "phase": "p1"}},
+        {"type": "phase_started", "timestamp": "2026-05-22T10:00:02Z",
+         "data": {"chain_id": "c2", "phase": "p2"}},
+    ])
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    # visible is newest-first: [p2 (c2), p1 (c2), p0 (c1)]
+    # rendered: ▶ p2  /  p1  /  <blank>  /  p0
+    assert len(ys) == 3
+    assert ys[0] == 0
+    assert ys[1] == 1
+    assert ys[2] == 3, f"chain switch should bump y to 3, got {ys!r}"
+    lines = rendered.split("\n")
+    assert lines[2] == "", "row 2 should be the blank chain-switch separator"
+    # Each event's y must land on its actual headline (= phase_started row).
+    for i, y in enumerate(ys):
+        assert "phase_started" in lines[y]
+
+
+def test_event_ys_accounts_for_user_message_reply_line(tmp_path: Path) -> None:
+    """Tier 2: user_message_received adds a ↳ line → subsequent ys bump by 1.
+
+    Even when there's no chain switch, a user_message_received row
+    consumes 2 rendered lines (headline + ``↳`` reply), so the next
+    event's y is 2 not 1.
+    """
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    _write_events(tmp_path, [
+        {"type": "user_message_received",
+         "timestamp": "2026-05-22T10:00:00Z",
+         "data": {"chain_id": "c1", "text": "hello"}},
+        {"type": "phase_started",
+         "timestamp": "2026-05-22T10:00:01Z",
+         "data": {"chain_id": "c1", "phase": "p1"}},
+    ])
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    # visible newest-first: [phase_started, user_message_received]
+    # rendered:
+    #   row 0 → phase_started
+    #   row 1 → user_message_received headline
+    #   row 2 → ↳ (awaiting…)
+    assert len(ys) == 2
+    assert ys[0] == 0
+    assert ys[1] == 1
+    lines = rendered.split("\n")
+    assert "↳" in lines[2], (
+        f"reply line should follow user_message_received, got rendered={rendered!r}"
+    )
+
+
+def test_empty_visible_returns_empty_ys(tmp_path: Path) -> None:
+    """Tier 2: empty / no-match return shape stays a 3-tuple."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    # No events root → "no events yet" early return.
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    assert visible == []
+    assert ys == []
+    assert isinstance(rendered, str)

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -838,7 +838,7 @@ async def test_events_tab_returns_in_timestamp_order(tmp_path):
         encoding="utf-8",
     )
 
-    _, visible = render_events(
+    _, visible, _ys = render_events(
         tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
         cache={}, filelist_cache=None,
     )


### PR DESCRIPTION
**[tui-coder]** — wave-8 PR #9 (A-F3, P2). Final of the top-10.

## Problem

``_scroll_events_into_view`` used ``y = 1 + cursor`` which assumed one rendered line per event. But chain-switch blanks + ``user_message_received`` ``↳`` reply lines drift the actual y, so after a few chains the cursor sat below the viewport with no visible movement on j/k.

## Fix

``render_events`` returns ``event_ys: list[int]`` (per-event actual y); ``_scroll_events_into_view`` looks it up. Same idiom as ``_memory_entry_ys`` (PR #97).

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests pin contiguous / chain-switch-drift / user-message-drift / empty cases
- [x] Existing ``test_events_tab_returns_in_timestamp_order`` updated for new 3-tuple shape (+ smoke / intervention / reply-truncate tests still green)

## Wave-8 final status

```
✓ C-F1 / C-F2 (P1, #457 / #458)
✓ A-F1 / A-F2 / A-F4 / B-F1 / C-F4 / C-F5 (P2, #459 / #460 / #462 / #463 / #465 / #466)
✗ C-F7 — dropped honestly: skill_run_failed was already in error filter
🆕 A-F3 (this PR)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)