### PR TITLE
refactor(config): separate dynamic MCP registry to .reyn/mcp.yaml (#470 core)

### DIFF
--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1662,6 +1662,17 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         project_local = _load_yaml(project_root / "reyn.local.yaml")
         merged = _merge(merged, project_local)
 
+        # Issue #470: dynamic MCP registry separated from static config.
+        # ``.reyn/mcp.yaml`` carries op-managed server entries; merged
+        # LAST so it overrides any operator-edited ``mcp.servers`` in
+        # reyn.yaml / reyn.local.yaml (= newer installs win, but
+        # legacy entries continue to load for backward compat).
+        # Shape: ``{"mcp": {"servers": {<name>: {<entry>}}}}`` — same
+        # as the section in reyn.yaml, so ``_merge`` handles it
+        # without special-casing.
+        dynamic_mcp = _load_yaml(project_root / ".reyn" / "mcp.yaml")
+        merged = _merge(merged, dynamic_mcp)
+
         # ADR-0031: <project>/.reyn/config.yaml is DEPRECATED (removed from
         # the 3-layer cascade).  Emit a one-time warning if the file exists so
         # users know to migrate.  The file is intentionally NOT loaded.

--- a/src/reyn/op_runtime/mcp_drop_server.py
+++ b/src/reyn/op_runtime/mcp_drop_server.py
@@ -43,7 +43,20 @@ from .context import OpContext
 
 
 def _scope_to_path(scope: str, project_root: Path) -> Path:
-    """Resolve the target config file path for the given scope."""
+    """Resolve the target config file path for the given scope.
+
+    Issue #470 (2026-05-22): for the NEW dynamic registry location
+    (``"dynamic"``), this returns ``.reyn/mcp.yaml``. Legacy scopes
+    are retained so ``_detect_scope`` can walk older config files
+    that still carry ``mcp.servers`` from before the separation.
+
+    Migration order in ``_detect_scope`` queries ``"dynamic"`` first
+    so new installs are dropped from the canonical location; older
+    hand-edited entries in reyn.yaml / reyn.local.yaml / user config
+    remain droppable via the legacy paths.
+    """
+    if scope == "dynamic":
+        return project_root / ".reyn" / "mcp.yaml"
     if scope == "local":
         return project_root / "reyn.local.yaml"
     if scope == "project":
@@ -79,8 +92,16 @@ def _detect_scope(server: str, project_root: Path) -> str | None:
     """Walk scope tiers to find the first that contains ``server``.
 
     Returns the scope name or None when the server is absent from all.
+    Issue #470 (2026-05-22): ``"dynamic"`` (= ``.reyn/mcp.yaml``) is
+    queried first because that's the canonical location for new
+    installs. Older hand-edited entries in ``reyn.yaml`` /
+    ``reyn.local.yaml`` / ``~/.reyn/config.yaml`` remain droppable
+    via the legacy walk order — backward compat preserved.
+
+    All scopes share the same ``{"mcp": {"servers": {...}}}`` shape
+    so the lookup logic is uniform; only the file location differs.
     """
-    for scope in ("local", "project", "user"):
+    for scope in ("dynamic", "local", "project", "user"):
         cfg = _read_yaml_config(_scope_to_path(scope, project_root))
         servers = (
             cfg.get("mcp", {}).get("servers", {})

--- a/src/reyn/op_runtime/mcp_install.py
+++ b/src/reyn/op_runtime/mcp_install.py
@@ -62,13 +62,31 @@ def _short_name(server_id: str) -> str:
 
 
 def _scope_to_path(scope: str, project_root: Path) -> Path:
-    """Resolve the target config file path for the given scope."""
-    if scope == "local":
-        return project_root / "reyn.local.yaml"
-    elif scope == "project":
-        return project_root / "reyn.yaml"
-    else:  # "user"
-        return Path.home() / ".reyn" / "config.yaml"
+    """Resolve the target config file path for the given scope.
+
+    Issue #470 (2026-05-22): dynamic MCP server registry is being
+    separated from the static deployment config. New installs write
+    to ``.reyn/mcp.yaml`` regardless of ``scope`` — the scope flag
+    is retained as a no-op for CLI backward compat (= existing
+    ``reyn mcp install --scope X`` invocations don't break) but no
+    longer determines the write target.
+
+    Rationale: ``reyn.yaml`` semantics = "edit + restart" should
+    apply uniformly across all of its content. ``mcp.servers`` was
+    the only field that violated this by being op-mutated at
+    runtime — separating it into ``.reyn/mcp.yaml`` purifies the
+    invariant and matches the existing pattern where dynamic state
+    (= ``.reyn/approvals.yaml``) already lives under ``.reyn/``.
+
+    Backward compat (= preserved by ``_merge`` in config.py): if
+    the operator hand-wrote ``mcp.servers`` into reyn.yaml,
+    those entries continue to load. New installs land in the new
+    location; ``reyn config migrate-mcp`` (= follow-up) provides
+    explicit migration.
+    """
+    # Scope arg ignored — single canonical target for dynamic registry.
+    _ = scope  # noqa: F841 — retained on signature for CLI compat
+    return project_root / ".reyn" / "mcp.yaml"
 
 
 def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:

--- a/tests/test_config_separation_mcp_yaml.py
+++ b/tests/test_config_separation_mcp_yaml.py
@@ -1,0 +1,219 @@
+"""Tier 2: config separation — ``.reyn/mcp.yaml`` is the canonical
+write target for op-managed MCP server registry (#470, 2026-05-22).
+
+Pins the architectural separation between static deployment config
+(= ``reyn.yaml`` / ``reyn.local.yaml`` — operator-owned, edit + restart)
+and dynamic MCP server registry (= ``.reyn/mcp.yaml`` — op-managed,
+runtime-mutable).
+
+Backward compat: existing ``reyn.yaml`` ``mcp.servers`` blocks continue
+to load (= operator-hand-edited entries still work); new installs
+land in the new location.
+
+Tier 2 because the separation is the foundational invariant for the
+config UX axis — a regression that re-introduced mcp.servers writes
+to reyn.yaml would silently re-mix the static / dynamic kinds.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ── Loader: .reyn/mcp.yaml is read and merged ────────────────────────
+
+
+def test_load_config_reads_dynamic_mcp_yaml(tmp_path, monkeypatch):
+    """Tier 2: ``load_config`` reads ``.reyn/mcp.yaml`` and merges its
+    ``mcp.servers`` into the merged config. New canonical location
+    for dynamic registry.
+    """
+    from reyn.config import load_config
+
+    # Plant a reyn.yaml so _find_project_root finds tmp_path.
+    _write_yaml(tmp_path / "reyn.yaml", "model: standard\n")
+    _write_yaml(
+        tmp_path / ".reyn" / "mcp.yaml",
+        "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    assert "sqlite" in config.mcp.get("servers", {})
+    sqlite_entry = config.mcp["servers"]["sqlite"]
+    assert sqlite_entry["type"] == "stdio"
+    assert sqlite_entry["command"] == "npx"
+
+
+def test_load_config_dynamic_mcp_yaml_overrides_reyn_yaml(tmp_path, monkeypatch):
+    """Tier 2: when both ``reyn.yaml`` and ``.reyn/mcp.yaml`` carry
+    entries for the same server, the dynamic file wins (= newer
+    op-managed value beats older operator-edited value). Backward
+    compat is preserved by READING both; conflict resolution favours
+    the runtime-mutable source.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "model: standard\n"
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: old-cmd\n",
+    )
+    _write_yaml(
+        tmp_path / ".reyn" / "mcp.yaml",
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: new-cmd\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    assert config.mcp["servers"]["git"]["command"] == "new-cmd"
+
+
+def test_load_config_dynamic_mcp_yaml_and_reyn_yaml_servers_union(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: a server present only in reyn.yaml (= operator legacy)
+    and one only in ``.reyn/mcp.yaml`` (= new install) both surface
+    in the merged config. The merge is a UNION on the servers dict,
+    not an override of the whole section.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "model: standard\n"
+        "mcp:\n  servers:\n    legacy:\n      type: stdio\n      command: legacy-cmd\n",
+    )
+    _write_yaml(
+        tmp_path / ".reyn" / "mcp.yaml",
+        "mcp:\n  servers:\n    fresh:\n      type: stdio\n      command: fresh-cmd\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    servers = config.mcp["servers"]
+    assert "legacy" in servers
+    assert "fresh" in servers
+    assert servers["legacy"]["command"] == "legacy-cmd"
+    assert servers["fresh"]["command"] == "fresh-cmd"
+
+
+def test_load_config_works_without_dynamic_mcp_yaml(tmp_path, monkeypatch):
+    """Tier 2: an existing project with no ``.reyn/mcp.yaml`` (= the
+    common case during the migration window) still loads cleanly.
+    No spurious empty-section, no warning.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "model: standard\n"
+        "mcp:\n  servers:\n    only-in-reyn:\n      type: stdio\n      command: x\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    assert "only-in-reyn" in config.mcp.get("servers", {})
+
+
+# ── mcp_install: write target redirected ─────────────────────────────
+
+
+def test_mcp_install_scope_to_path_returns_dot_reyn_mcp_yaml(tmp_path):
+    """Tier 2: ``_scope_to_path`` (= mcp_install) now returns
+    ``.reyn/mcp.yaml`` regardless of scope arg. The scope kwarg is a
+    no-op for CLI backward compat; the architectural decision is "one
+    canonical dynamic registry location".
+    """
+    from reyn.op_runtime.mcp_install import _scope_to_path
+
+    for scope in ("local", "project", "user", ""):
+        result = _scope_to_path(scope, tmp_path)
+        assert result == tmp_path / ".reyn" / "mcp.yaml", (
+            f"scope={scope!r} should resolve to .reyn/mcp.yaml, "
+            f"got {result}"
+        )
+
+
+# ── mcp_drop_server: legacy detection + new ──────────────────────────
+
+
+def test_mcp_drop_detects_dynamic_scope_first(tmp_path):
+    """Tier 2: when a server exists in both ``.reyn/mcp.yaml`` AND
+    a legacy location, ``_detect_scope`` returns ``"dynamic"`` first
+    (= canonical drop target is the newer location).
+    """
+    from reyn.op_runtime.mcp_drop_server import _detect_scope
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: old\n",
+    )
+    _write_yaml(
+        tmp_path / ".reyn" / "mcp.yaml",
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: new\n",
+    )
+
+    assert _detect_scope("git", tmp_path) == "dynamic"
+
+
+def test_mcp_drop_detects_legacy_when_dynamic_missing(tmp_path):
+    """Tier 2: a server present only in legacy reyn.yaml (= operator
+    pre-migration) is still droppable — ``_detect_scope`` walks
+    through ``dynamic`` → ``local`` → ``project`` → ``user``.
+    """
+    from reyn.op_runtime.mcp_drop_server import _detect_scope
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "mcp:\n  servers:\n    legacy-only:\n      type: stdio\n      command: x\n",
+    )
+
+    assert _detect_scope("legacy-only", tmp_path) == "project"
+
+
+def test_mcp_drop_returns_none_for_absent_server(tmp_path):
+    """Tier 2: a server absent from all scopes returns None — drop
+    op handles this as "nothing to remove".
+    """
+    from reyn.op_runtime.mcp_drop_server import _detect_scope
+
+    # No reyn.yaml, no .reyn/mcp.yaml.
+    assert _detect_scope("nope", tmp_path) is None
+
+
+def test_mcp_drop_scope_to_path_dynamic_returns_dot_reyn_mcp_yaml(tmp_path):
+    """Tier 2: ``_scope_to_path("dynamic", root)`` (= mcp_drop) returns
+    ``.reyn/mcp.yaml``. The new scope name lets ``_detect_scope``
+    identify which location to mutate after finding the server there.
+    """
+    from reyn.op_runtime.mcp_drop_server import _scope_to_path
+
+    assert _scope_to_path("dynamic", tmp_path) == tmp_path / ".reyn" / "mcp.yaml"
+
+
+def test_mcp_drop_legacy_scopes_unchanged(tmp_path):
+    """Tier 2: legacy scope names (= ``local`` / ``project`` / ``user``)
+    still resolve to the same legacy locations they always did. New
+    ``dynamic`` scope is additive; old behaviour is preserved for
+    backward-compat drop paths.
+    """
+    from reyn.op_runtime.mcp_drop_server import _scope_to_path
+
+    assert _scope_to_path("local", tmp_path) == tmp_path / "reyn.local.yaml"
+    assert _scope_to_path("project", tmp_path) == tmp_path / "reyn.yaml"
+    # "user" goes to home dir; we just verify the suffix to avoid
+    # coupling to the test runner's $HOME.
+    user_path = _scope_to_path("user", tmp_path)
+    assert user_path.name == "config.yaml"
+    assert ".reyn" in user_path.parts

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -301,8 +301,11 @@ def test_env_overrides_skip_prompt_and_persist_secret(tmp_path):
     assert "EXAMPLE_API_KEY" in secrets_text
     assert "my-secret-value" in secrets_text
 
-    # Config file written with ${KEY} reference, not raw value
-    config_path = tmp_path / "reyn.local.yaml"
+    # Config file written with ${KEY} reference, not raw value.
+    # Issue #470 (2026-05-22): write target is now ``.reyn/mcp.yaml``
+    # regardless of the op's ``scope`` arg — separating dynamic MCP
+    # registry from static deployment config.
+    config_path = tmp_path / ".reyn" / "mcp.yaml"
     assert config_path.exists()
     import yaml
     written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
@@ -356,83 +359,54 @@ def test_secret_value_not_in_event(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_scope_local_writes_to_reyn_local_yaml(tmp_path):
-    """Tier 2: scope='local' writes to <project>/reyn.local.yaml."""
-    resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
-    decl = PermissionDecl(mcp_install=True)
-    bus = _AutoApproveInterventionBus()
-    ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
+def test_install_writes_to_dynamic_mcp_yaml_regardless_of_scope(tmp_path):
+    """Tier 2 (#470 2026-05-22 contract reversal): scope arg is now a
+    no-op — every install writes to ``.reyn/mcp.yaml`` regardless of
+    whether the LLM passes ``scope="local"`` / ``"project"`` / ``"user"``
+    / nothing. The architectural decision is "one canonical dynamic
+    registry location" (= separates op-mutated MCP servers from
+    static deployment config in reyn.yaml).
 
-    op = MCPInstallIROp(
-        kind="mcp_install",
-        server_id="io.github.modelcontextprotocol/server-filesystem",
-        scope="local",
-    )
+    Renamed + consolidated from three prior tests
+    (test_scope_local_writes_to_reyn_local_yaml /
+    test_scope_project_writes_to_reyn_yaml /
+    test_scope_user_writes_to_home_reyn_config) that pinned the
+    pre-#470 per-scope routing. Per ``feedback_contract_reversal_rewrites_tests``,
+    the rewrite (not patch) makes the contract change visible at
+    review.
+    """
+    for scope in ("local", "project", "user"):
+        resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
+        decl = PermissionDecl(mcp_install=True)
+        bus = _AutoApproveInterventionBus()
+        ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
 
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-            result = _run(mcp_install_handle(op, ctx, "control_ir"))
+        op = MCPInstallIROp(
+            kind="mcp_install",
+            server_id="io.github.modelcontextprotocol/server-filesystem",
+            scope=scope,
+        )
 
-    assert result["status"] == "ok"
-    expected_path = tmp_path / "reyn.local.yaml"
-    assert result["installed_path"] == str(expected_path)
-    assert expected_path.exists()
+        with mock.patch("shutil.which", return_value="/usr/bin/npx"):
+            with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
+                result = _run(mcp_install_handle(op, ctx, "control_ir"))
 
+        expected_path = tmp_path / ".reyn" / "mcp.yaml"
+        assert result["status"] == "ok"
+        assert result["installed_path"] == str(expected_path), (
+            f"scope={scope!r} should write to .reyn/mcp.yaml; got {result['installed_path']}"
+        )
+        assert expected_path.exists()
 
-def test_scope_project_writes_to_reyn_yaml(tmp_path):
-    """Tier 2: scope='project' writes to <project>/reyn.yaml."""
-    resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
-    decl = PermissionDecl(mcp_install=True)
-    bus = _AutoApproveInterventionBus()
-    ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-
-    op = MCPInstallIROp(
-        kind="mcp_install",
-        server_id="io.github.modelcontextprotocol/server-filesystem",
-        scope="project",
-    )
-
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-            result = _run(mcp_install_handle(op, ctx, "control_ir"))
-
-    assert result["status"] == "ok"
-    expected_path = tmp_path / "reyn.yaml"
-    assert result["installed_path"] == str(expected_path)
-    assert expected_path.exists()
-
-    import yaml
-    written = yaml.safe_load(expected_path.read_text(encoding="utf-8"))
-    assert "mcp" in written
-    assert "servers" in written["mcp"]
-
-
-def test_scope_user_writes_to_home_reyn_config(tmp_path, monkeypatch):
-    """Tier 2: scope='user' writes to ~/.reyn/config.yaml (mocked home)."""
-    # Redirect home to tmp_path to avoid polluting real ~/.reyn/config.yaml
-    fake_home = tmp_path / "fake_home"
-    fake_home.mkdir()
-    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
-
-    resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
-    decl = PermissionDecl(mcp_install=True)
-    bus = _AutoApproveInterventionBus()
-    ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-
-    op = MCPInstallIROp(
-        kind="mcp_install",
-        server_id="io.github.modelcontextprotocol/server-filesystem",
-        scope="user",
-    )
-
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-            result = _run(mcp_install_handle(op, ctx, "control_ir"))
-
-    assert result["status"] == "ok"
-    expected_path = fake_home / ".reyn" / "config.yaml"
-    assert result["installed_path"] == str(expected_path)
-    assert expected_path.exists()
+        # The minted shape carries the ``{mcp: {servers: {...}}}`` wrapper
+        # so the existing config loader's ``_merge`` handles it without
+        # special-casing.
+        import yaml
+        written = yaml.safe_load(expected_path.read_text(encoding="utf-8"))
+        assert "mcp" in written
+        assert "servers" in written["mcp"]
+        # Clean up between iterations so subsequent scope tests start fresh.
+        expected_path.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_source_install.py
+++ b/tests/test_mcp_source_install.py
@@ -259,7 +259,7 @@ def test_source_npm_skips_registry_and_installs(tmp_path):
     # Config file written. issue #319: server key is the prefix-stripped
     # short form. issue #318: ``type: stdio`` is present so the loader
     # accepts the entry without manual edit.
-    config_path = tmp_path / "reyn.local.yaml"
+    config_path = tmp_path / ".reyn" / "mcp.yaml"
     assert config_path.exists()
     import yaml
     written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
@@ -292,7 +292,7 @@ def test_source_pypi_skips_registry_and_installs(tmp_path):
     assert result["runtime"] == "uvx"
 
     import yaml
-    config_path = tmp_path / "reyn.local.yaml"
+    config_path = tmp_path / ".reyn" / "mcp.yaml"
     written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     servers = written["mcp"]["servers"]
     assert "my-mcp-server" in servers
@@ -318,7 +318,7 @@ def test_source_invalid_specifier_returns_error(tmp_path):
     assert result["status"] == "error"
     assert "Source resolution failed" in result["error"]
     # Config file must NOT have been written
-    config_path = tmp_path / "reyn.local.yaml"
+    config_path = tmp_path / ".reyn" / "mcp.yaml"
     assert not config_path.exists()
 
 
@@ -370,7 +370,7 @@ def test_source_github_known_installs_npm(tmp_path):
     assert result["runtime"] == "npx"
 
     import yaml
-    config_path = tmp_path / "reyn.local.yaml"
+    config_path = tmp_path / ".reyn" / "mcp.yaml"
     written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     servers = written["mcp"]["servers"]
     # issue #319: prefix-stripped short key.


### PR DESCRIPTION
**[e2e-coder]** — architectural refactor surfaced during #398 v4 emitter wiring follow-up (user reframe: "動的範囲部分は今の config から分離すべき"). Closes the **runtime split** part of #470; follow-up PR for migration command + template + docs.

## Net invariant after this PR

> ``reyn.yaml`` semantics = **"edit + restart"**.
> Anything that mutates at runtime lives under ``.reyn/``.

## File layout

| File | Kind | Touch convention |
|---|---|---|
| ``reyn.yaml`` | static deployment config (= operator-owned, commit) | operator edits, restart to apply |
| ``reyn.local.yaml`` | local env overrides (= same static semantics, gitignored) | operator edits, restart to apply |
| **``.reyn/mcp.yaml``** | **dynamic MCP registry (= op-managed)** ← **NEW** | only ``mcp_install`` / ``mcp_drop_server`` ops write |
| ``.reyn/approvals.yaml`` | dynamic permission state (= op-managed, existing) | only PermissionResolver writes |

## Backward compat (= preserved)

- Existing ``reyn.yaml`` ``mcp.servers`` blocks **continue to load**
- ``load_config`` reads ``.reyn/mcp.yaml`` LAST so new op-managed entries win, but legacy operator-edited entries still surface
- ``mcp_drop_server._detect_scope`` walks ``dynamic`` → ``local`` → ``project`` → ``user`` so legacy entries remain droppable
- ``scope`` arg on mcp_install ops is a no-op (= retained on signature for CLI command compat; documented as ignored)

## Why split this from follow-up

- **This PR**: runtime split (= loader + write target). Load-bearing for the architectural invariant.
- **Follow-up PR**: ``reyn config migrate-mcp`` command + REYN_YAML_TEMPLATE update + docs.

The runtime split alone delivers the architectural value; the migration / template / docs are operator-facing UX polish that doesn't gate functionality.

## Change shape

- ``src/reyn/config.py``: ``load_config`` adds ``.reyn/mcp.yaml`` to the merge chain
- ``src/reyn/op_runtime/mcp_install.py``: ``_scope_to_path`` always returns ``.reyn/mcp.yaml``
- ``src/reyn/op_runtime/mcp_drop_server.py``: new ``"dynamic"`` scope name + ``_detect_scope`` walks it first
- ``tests/test_config_separation_mcp_yaml.py`` (new, 10 tests): loader behavior + write target + drop detection + backward compat
- ``tests/test_mcp_install_op.py``: 3 prior scope-specific tests consolidated + renamed per ``feedback_contract_reversal_rewrites_tests``; 1 env_overrides test path updated
- ``tests/test_mcp_source_install.py``: 4 install-target assertions updated

## Test plan

- [x] ``pytest tests/test_config_separation_mcp_yaml.py`` — 10/10 pass
- [x] ``pytest tests/test_mcp_install_op.py + drop + source_install`` — 71/71 pass
- [x] ``pytest tests/`` (full suite) — 4770 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected (= clock flaky, web_fetch preview path_ref)
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## What's still in #470 as follow-up

- ``reyn config migrate-mcp`` CLI command (= explicit operator migration)
- ``REYN_YAML_TEMPLATE`` update (= drop commented ``mcp:`` block, point to ``.reyn/mcp.yaml``)
- Documentation (= separation rationale in ``docs/concepts/config.md`` or equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)