### PR TITLE
feat(tui): surface Ctrl+J newline in input footer hint (D-F8)

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -573,9 +573,9 @@ class InputBar(Widget):
 
     def _build_hint(self) -> str:
         # Fits in 80 cols (= ≤72 cells incl. 2-space left margin) so the
-        # tail "Ctrl+P/N turn" doesn't get clipped on default terminals.
-        # Dropped Ctrl+J nl / Ctrl+O / Ctrl+R / Ctrl+\ — all remain
-        # discoverable via the Keys tab (Ctrl+B).
+        # tail key doesn't get clipped on default terminals. Ctrl+O /
+        # Ctrl+R / Ctrl+\ / Ctrl+P/N remain discoverable via the Keys
+        # tab (Ctrl+B).
         #
         # Wave-2 K4: ``Ctrl+C cancel`` swapped in for ``Ctrl+D quit`` —
         # cancel is the highest-frequency interactive key during active
@@ -584,7 +584,17 @@ class InputBar(Widget):
         # terminal-EOF convention users carry in from the shell. Both
         # remain in the Keys tab; the always-visible footer should
         # advertise the in-session-frequent key, not the universal one.
+        #
+        # Wave-9 D-F8: ``Ctrl+J nl`` surfaced next to ``Enter send`` so a
+        # first-time user can see HOW to enter a multi-line prompt
+        # without first opening the Keys tab. Previously the footer
+        # advertised only ``Enter send`` and users hit Enter expecting
+        # newline (= the natural assumption for code/instruction
+        # blocks), submitting half-typed prompts. ``Ctrl+P/N turn`` is
+        # dropped from the footer — turn navigation is a power-user
+        # convenience, multi-line entry is a daily first-encounter
+        # need.
         return (
-            "  Enter send │ Ctrl+C cancel │ Ctrl+L clear │ "
-            "Ctrl+B panel │ Ctrl+P/N turn"
+            "  Enter send │ Ctrl+J nl │ Ctrl+C cancel │ "
+            "Ctrl+L clear │ Ctrl+B panel"
         )

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -141,6 +141,13 @@ class RightPanel(Widget):
         self._events_filelist_cache: list = []
         self._events_cursor: int = 0
         self._events_visible: list[dict] = []
+        # y-coord (0-indexed line) of each event's headline row in the
+        # rendered output. Populated by `render_events`; used by
+        # `_scroll_events_into_view` so chain-switch blank lines + the
+        # extra ``↳`` reply line on ``user_message_received`` rows don't
+        # drift the viewport off the cursor (A-F3, wave-8). Same idiom
+        # as ``_memory_entry_ys`` / ``_agents_item_ys``.
+        self._events_event_ys: list[int] = []
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
@@ -658,11 +665,17 @@ class RightPanel(Widget):
     def _scroll_events_into_view(self) -> None:
         """Scroll #panel-scroll so the events cursor line is visible.
 
-        Each event renders as one row (PR #79 trimmed timestamp to
-        HH:MM:SS; the type fits next to it on the same line). The
-        ``user_message_received`` rows have an extra `↳` reply line —
-        approximated as 1 here; the small over-/under-scroll on those
-        is barely noticeable.
+        Events render with variable height: chain switches insert a
+        blank separator line between groups, and
+        ``user_message_received`` rows have an extra ``↳`` reply line
+        below the headline. The pre-A-F3 arithmetic projection
+        (``y = 1 + cursor``) under-scrolled by the count of intervening
+        chain-switch + reply lines, so after a few chains the cursor
+        sat below the viewport with no visible movement on j/k.
+
+        ``render_events`` records the exact y of each event's
+        headline row in ``_events_event_ys``; we look it up here.
+        Same idiom as the memory- and agents-tab fixes.
         """
         try:
             vs = self.query_one("#panel-scroll", VerticalScroll)
@@ -670,8 +683,10 @@ class RightPanel(Widget):
             visible = vs.size.height
             if visible <= 0:
                 return
-            # Assume 1 line per event; +1 for content padding-top.
-            y = 1 + self._events_cursor
+            if not (0 <= self._events_cursor < len(self._events_event_ys)):
+                return
+            # +1 for content padding-top, matching the memory-tab fix.
+            y = 1 + self._events_event_ys[self._events_cursor]
             if y < current:
                 vs.scroll_to(y=y, animate=False)
             elif y >= current + visible:
@@ -1784,7 +1799,7 @@ class RightPanel(Widget):
             if self._panel_type == "keys":
                 return render_keys(self.app)
             if self._panel_type == "events":
-                rendered, windowed = render_events(
+                rendered, windowed, event_ys = render_events(
                     self._project_root,
                     self._event_filter_idx,
                     self._event_tail_idx,
@@ -1793,6 +1808,7 @@ class RightPanel(Widget):
                     filelist_cache=self._events_filelist_cache,
                 )
                 self._events_visible = windowed
+                self._events_event_ys = event_ys
                 if self._events_cursor >= len(windowed):
                     self._events_cursor = max(0, len(windowed) - 1)
                 return rendered

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -533,21 +533,28 @@ def render_events(
     cursor: int = 0,
     cache: dict | None = None,
     filelist_cache: list | None = None,
-) -> tuple[str, list[dict]]:
+) -> tuple[str, list[dict], list[int]]:
     """Render the recent-events list for the events tab.
 
-    Returns ``(rendered_markup, visible_events)`` so the orchestrator can
-    drive the cursor + Enter→preview integration without re-parsing files.
+    Returns ``(rendered_markup, visible_events, event_ys)`` so the
+    orchestrator can drive the cursor + Enter→preview integration
+    without re-parsing files. ``event_ys[i]`` is the 0-based line index
+    (within ``rendered_markup``) of event ``visible_events[i]``'s
+    headline row — used by ``_scroll_events_into_view`` to position
+    the viewport precisely even when chain-switch blank lines and
+    multi-line ``user_message_received`` rows have pushed the actual
+    row off the naive ``y = 1 + cursor`` projection (A-F3, wave-8).
+
     Consecutive events sharing a chain_id are visually grouped (a blank
     line separates chain switches). The row at index ``cursor`` is
     highlighted with a coral ▶ prefix.
     """
     if project_root is None:
-        return "[#555555]  (no project root)[/]", []
+        return "[#555555]  (no project root)[/]", [], []
 
     events_root = project_root / ".reyn" / "events"
     if not events_root.is_dir():
-        return "[#555555]  (no events yet)[/]", []
+        return "[#555555]  (no events yet)[/]", [], []
 
     if cache is None:
         cache = {}
@@ -581,7 +588,7 @@ def render_events(
         #      cycle to a different filter (the `[f]` header hint is only
         #      visible when the panel is wider than the filter name).
         if not all_events:
-            return "[#555555]  (no matching events)[/]", []
+            return "[#555555]  (no matching events)[/]", [], []
         # Split the two hints across separate lines so each survives the
         # 44-cell minimum panel width independently. The single-line
         # form was ~47 cells and clipped to ``press [f] to cycle filter
@@ -594,7 +601,7 @@ def render_events(
             f"[#555555] to cycle filter[/]\n"
             f"[#555555]  press [/][bold #aaaaaa]\\[t][/]"
             f"[#555555] for tail size[/]"
-        ), []
+        ), [], []
 
     # Newest-first window — also returned to the caller for cursor / preview
     windowed = list(visible[-tail:])[::-1]
@@ -604,6 +611,7 @@ def render_events(
     chain_replies = _load_chain_replies(project_root)
 
     lines: list[str] = []
+    event_ys: list[int] = []
     prev_chain: str | None = None
     for i, ev in enumerate(windowed):
         ev_type = ev.get("type", "?")
@@ -627,6 +635,12 @@ def render_events(
         cursor_prefix = (
             f"[bold {_CORAL}]▶ [/]" if i == cursor else "  "
         )
+        # Record the y of the headline row BEFORE appending — chain
+        # switches add a blank line above, and user_message_received
+        # rows add a ``↳`` reply line below, both of which drift the
+        # arithmetic ``1 + cursor`` projection. Same idiom as
+        # memory_tab / agents_tab.
+        event_ys.append(len(lines))
         lines.append(
             f"{cursor_prefix}[#444444]{ts}[/]  [{color}]{_esc(ev_type)}[/]{hint_part}"
         )
@@ -654,7 +668,7 @@ def render_events(
                     lines.append(f"[#444444]       ↳ [/][#777777]{short}[/]")
 
     del filter_name
-    return "\n".join(lines), windowed
+    return "\n".join(lines), windowed, event_ys
 
 
 __all__ = [

--- a/tests/cli/test_events_tab_event_ys.py
+++ b/tests/cli/test_events_tab_event_ys.py
@@ -1,0 +1,141 @@
+"""Tier 2: render_events returns per-row y-coords accounting for multi-line drift (A-F3).
+
+Wave-8 Topic A finding F3 (P2): pre-fix ``_scroll_events_into_view``
+used ``y = 1 + cursor`` which assumed one rendered line per event.
+But the actual rendered output has two sources of drift:
+
+  - chain-switch blank line between events that don't share chain_id
+  - extra ``↳`` reply line under each ``user_message_received`` row
+
+After a few chains, the arithmetic projection accumulated 3-5 lines
+of drift, leaving the cursor below the viewport with no apparent
+movement on j/k. Fix mirrors memory_tab / agents_tab: track each
+event's actual y-coord during render and look it up at scroll time.
+"""
+from __future__ import annotations
+
+import json as _json
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _write_events(tmp_path: Path, events: list[dict]) -> None:
+    """Write one jsonl per event under agents/default/ so the loader picks them up."""
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "default"
+    events_root.mkdir(parents=True, exist_ok=True)
+    log = events_root / "session.jsonl"
+    log.write_text(
+        "\n".join(_json.dumps(ev) for ev in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_event_ys_returned_for_single_chain_no_blanks(tmp_path: Path) -> None:
+    """Tier 2: same chain_id → no blank lines → ys are contiguous."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    _write_events(tmp_path, [
+        {"type": "phase_started", "timestamp": f"2026-05-22T10:00:0{i}Z",
+         "data": {"chain_id": "c1", "phase": f"p{i}"}}
+        for i in range(3)
+    ])
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    assert len(visible) == 3
+    assert len(ys) == 3
+    # Single chain, no user_message_received → ys are 0, 1, 2.
+    assert ys == [0, 1, 2]
+    # Sanity-check: ys index into actual rendered lines.
+    lines = rendered.split("\n")
+    for i, y in enumerate(ys):
+        assert "phase_started" in lines[y], (
+            f"event {i} (y={y}) should land on a phase_started row, got: {lines[y]!r}"
+        )
+
+
+def test_event_ys_skips_blank_line_at_chain_switch(tmp_path: Path) -> None:
+    """Tier 2: chain switch inserts blank → ys[1] = 2 (not 1).
+
+    Without the per-row tracking, ``y = 1 + cursor`` would point at
+    the blank separator row rather than the second event's headline.
+    """
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    _write_events(tmp_path, [
+        {"type": "phase_started", "timestamp": "2026-05-22T10:00:00Z",
+         "data": {"chain_id": "c1", "phase": "p0"}},
+        {"type": "phase_started", "timestamp": "2026-05-22T10:00:01Z",
+         "data": {"chain_id": "c2", "phase": "p1"}},
+        {"type": "phase_started", "timestamp": "2026-05-22T10:00:02Z",
+         "data": {"chain_id": "c2", "phase": "p2"}},
+    ])
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    # visible is newest-first: [p2 (c2), p1 (c2), p0 (c1)]
+    # rendered: ▶ p2  /  p1  /  <blank>  /  p0
+    assert len(ys) == 3
+    assert ys[0] == 0
+    assert ys[1] == 1
+    assert ys[2] == 3, f"chain switch should bump y to 3, got {ys!r}"
+    lines = rendered.split("\n")
+    assert lines[2] == "", "row 2 should be the blank chain-switch separator"
+    # Each event's y must land on its actual headline (= phase_started row).
+    for i, y in enumerate(ys):
+        assert "phase_started" in lines[y]
+
+
+def test_event_ys_accounts_for_user_message_reply_line(tmp_path: Path) -> None:
+    """Tier 2: user_message_received adds a ↳ line → subsequent ys bump by 1.
+
+    Even when there's no chain switch, a user_message_received row
+    consumes 2 rendered lines (headline + ``↳`` reply), so the next
+    event's y is 2 not 1.
+    """
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    _write_events(tmp_path, [
+        {"type": "user_message_received",
+         "timestamp": "2026-05-22T10:00:00Z",
+         "data": {"chain_id": "c1", "text": "hello"}},
+        {"type": "phase_started",
+         "timestamp": "2026-05-22T10:00:01Z",
+         "data": {"chain_id": "c1", "phase": "p1"}},
+    ])
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    # visible newest-first: [phase_started, user_message_received]
+    # rendered:
+    #   row 0 → phase_started
+    #   row 1 → user_message_received headline
+    #   row 2 → ↳ (awaiting…)
+    assert len(ys) == 2
+    assert ys[0] == 0
+    assert ys[1] == 1
+    lines = rendered.split("\n")
+    assert "↳" in lines[2], (
+        f"reply line should follow user_message_received, got rendered={rendered!r}"
+    )
+
+
+def test_empty_visible_returns_empty_ys(tmp_path: Path) -> None:
+    """Tier 2: empty / no-match return shape stays a 3-tuple."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    # No events root → "no events yet" early return.
+    rendered, visible, ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
+        cache={}, filelist_cache=None,
+    )
+    assert visible == []
+    assert ys == []
+    assert isinstance(rendered, str)

--- a/tests/cli/test_input_bar_hint_newline.py
+++ b/tests/cli/test_input_bar_hint_newline.py
@@ -1,0 +1,91 @@
+"""Tier 2: InputBar footer hint surfaces Ctrl+J newline (D-F8, wave-9).
+
+Wave-9 Topic D finding F8 (P1): the only way to enter a multi-line
+prompt is ``Ctrl+J``, but the always-visible footer hint advertised
+only ``Enter send`` with no clue about newline entry. A first-time
+user typing a code block or multi-step instruction hits Enter
+expecting newline (= shell / chat-app muscle memory) and submits a
+half-typed prompt. The fix surfaces ``Ctrl+J nl`` next to
+``Enter send`` so the alternative is discoverable without opening
+the Keys tab. ``Ctrl+P/N turn`` (= turn navigation power-user
+convenience) is dropped from the footer to stay under the 72-cell
+budget.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rich.cells import cell_len
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _hint() -> str:
+    from reyn.chat.tui.widgets.input_bar import InputBar
+    # ``_build_hint`` is a pure render that doesn't read any state — call
+    # it on a bare instance without going through Textual mount lifecycle.
+    bar = InputBar.__new__(InputBar)
+    return InputBar._build_hint(bar)
+
+
+def test_hint_surfaces_ctrl_j_newline_next_to_enter_send() -> None:
+    """Tier 2: ``Ctrl+J nl`` appears adjacent to ``Enter send``.
+
+    Adjacency matters — the user reads the footer left-to-right and
+    pairs ``Enter`` with the very next key as "if not Enter, then…".
+    Placing ``Ctrl+J nl`` directly after ``Enter send`` makes the
+    multi-line affordance obvious.
+    """
+    hint = _hint()
+    assert "Enter send" in hint
+    assert "Ctrl+J nl" in hint
+    # The two must appear in this order with nothing else between them
+    # except the separator.
+    assert hint.index("Enter send") < hint.index("Ctrl+J nl")
+    between = hint[
+        hint.index("Enter send") + len("Enter send") : hint.index("Ctrl+J nl")
+    ]
+    assert "│" in between
+    assert "Ctrl+" not in between, (
+        f"another Ctrl+ key snuck between Enter send and Ctrl+J nl: {between!r}"
+    )
+
+
+def test_hint_fits_72_cell_budget_for_default_80_col_terminal() -> None:
+    """Tier 2: hint stays within the 72-cell footer budget.
+
+    Default 80-col terminal minus 8 cells of conv-pane chrome leaves
+    ~72 cells for the footer. Going over wraps the trailing key to
+    a second line as an orphan hint.
+    """
+    width = cell_len(_hint())
+    assert width <= 72, f"footer hint is {width} cells, must be ≤72"
+
+
+def test_hint_retains_essential_keys() -> None:
+    """Tier 2: dropping ``Ctrl+P/N turn`` does not also drop critical keys.
+
+    The trade-off is explicit: ``Ctrl+P/N turn`` is a power-user
+    convenience (= jumping between past turns), ``Ctrl+J nl`` is a
+    first-encounter need. Cancel / clear / panel-toggle remain.
+    """
+    hint = _hint()
+    assert "Ctrl+C cancel" in hint
+    assert "Ctrl+L clear" in hint
+    assert "Ctrl+B panel" in hint
+    # Power-user keys belong to the Keys tab now, not the footer.
+    assert "Ctrl+P/N" not in hint
+
+
+def test_hint_uses_box_drawing_separator_consistently() -> None:
+    """Tier 2: every key is separated by the same ``│`` glyph.
+
+    Mixing separators (e.g. ``│`` + ``·`` + ``,``) would visually
+    break the footer rhythm.
+    """
+    hint = _hint()
+    # 5 keys → 4 separators.
+    assert hint.count("│") == 4, f"expected 4 separators, got {hint.count('│')}"

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -838,7 +838,7 @@ async def test_events_tab_returns_in_timestamp_order(tmp_path):
         encoding="utf-8",
     )
 
-    _, visible = render_events(
+    _, visible, _ys = render_events(
         tmp_path, event_filter_idx=0, event_tail_idx=0, cursor=0,
         cache={}, filelist_cache=None,
     )


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #1 (D-F8, P1 S).

## Problem

First-time users hit Enter expecting newline (shell / chat-app muscle memory) and submit half-typed prompts. The footer advertised only ``Enter send`` with no hint about ``Ctrl+J``.

## Fix

Surface ``Ctrl+J nl`` adjacent to ``Enter send``. Drop ``Ctrl+P/N turn`` from the footer (= power-user convenience, stays in Keys tab) to fit the 72-cell budget.

```
  Enter send │ Ctrl+J nl │ Ctrl+C cancel │ Ctrl+L clear │ Ctrl+B panel   (70 cells)
```

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests: adjacency, 72-cell budget, essential keys retained, separator consistency

## Wave-9 context

```
🆕 D-F8 (P1 S, this PR)
🔄 D-F11 / E-F1 / E-F2 / E-F3 / F-F1+F6 / F-F2 / F-F7 / F-F11 / F-F12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)