### PR TITLE
feat(config): reyn config migrate-mcp + template update (#470 follow-up)

### DIFF
--- a/src/reyn/cli/commands/config.py
+++ b/src/reyn/cli/commands/config.py
@@ -26,6 +26,18 @@ def register(sub) -> None:
                    help="Config key (e.g. api_base, models.standard). Run 'reyn config fields' for the full list.")
     s.add_argument("value", metavar="VALUE", help="Value to set (YAML syntax accepted)")
 
+    m = csub.add_parser(
+        "migrate-mcp",
+        help=(
+            "Move legacy mcp.servers entries from reyn.yaml / reyn.local.yaml "
+            "to .reyn/mcp.yaml (issue #470 config separation)"
+        ),
+    )
+    m.add_argument(
+        "--dry-run", action="store_true",
+        help="Show what would move without writing any files.",
+    )
+
 
 def run(args: argparse.Namespace) -> None:
     sub = getattr(args, "config_cmd", None)
@@ -37,6 +49,8 @@ def run(args: argparse.Namespace) -> None:
         _get(args.key)
     elif sub == "set":
         _set(args.key, args.value)
+    elif sub == "migrate-mcp":
+        _migrate_mcp(dry_run=bool(getattr(args, "dry_run", False)))
     else:
         _show()
 
@@ -83,6 +97,154 @@ def _get(key: str) -> None:
         print(yaml.dump(value, allow_unicode=True, default_flow_style=False), end="")
     else:
         print(value)
+
+
+def _migrate_mcp(*, dry_run: bool = False) -> None:
+    """Move legacy ``mcp.servers`` entries from ``reyn.yaml`` /
+    ``reyn.local.yaml`` (and ``~/.reyn/config.yaml``) into the canonical
+    ``.reyn/mcp.yaml`` location (= issue #470 config separation).
+
+    Why: post-#470, the dynamic MCP server registry lives at
+    ``.reyn/mcp.yaml`` so ``reyn.yaml`` carries only static deployment
+    config. Existing projects continue to load legacy entries (=
+    backward compat), but operators who want the clean separation
+    today can run this command to migrate explicitly.
+
+    Behaviour:
+      - Reads ``mcp.servers`` from reyn.yaml + reyn.local.yaml +
+        ~/.reyn/config.yaml (= the legacy locations).
+      - Merges into ``.reyn/mcp.yaml`` (= entries already present
+        there win on conflict so a partial migration doesn't get
+        clobbered).
+      - Removes the ``mcp.servers`` section from each legacy file
+        (= leaves other config sections intact).
+      - On ``--dry-run``: prints the plan without writing.
+
+    Non-goals:
+      - Auto-migration on every load (= explicit by design; operator
+        decides when to clean up the diff).
+      - Removing the ``mcp:`` key entirely from legacy files (=
+        leaves ``mcp:`` with sibling keys like ``mcp_servers_extra``
+        intact if any exist; only the ``servers`` sub-key is moved).
+    """
+    import yaml
+
+    from reyn.config import _find_project_root
+
+    project_root = _find_project_root(Path.cwd())
+    if project_root is None:
+        print(
+            "Error: no Reyn project root found. Run from a directory with "
+            "reyn.yaml or .reyn/.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Legacy paths to scan: project + local + user-global.
+    legacy_paths = [
+        project_root / "reyn.yaml",
+        project_root / "reyn.local.yaml",
+        Path.home() / ".reyn" / "config.yaml",
+    ]
+    dynamic_path = project_root / ".reyn" / "mcp.yaml"
+
+    def _read(p: Path) -> dict:
+        if not p.exists():
+            return {}
+        try:
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    # Collect legacy servers per file (for the move-out step).
+    legacy_by_file: dict[Path, dict] = {}
+    for p in legacy_paths:
+        cfg = _read(p)
+        servers = (
+            cfg.get("mcp", {}).get("servers", {})
+            if isinstance(cfg.get("mcp"), dict)
+            else {}
+        )
+        if isinstance(servers, dict) and servers:
+            legacy_by_file[p] = dict(servers)
+
+    if not legacy_by_file:
+        print("No legacy mcp.servers entries found — nothing to migrate.")
+        return
+
+    # Compose target: existing dynamic file's entries (= take precedence
+    # so a partial prior migration isn't clobbered) plus the legacy
+    # entries that aren't already there.
+    dynamic_cfg = _read(dynamic_path)
+    dynamic_servers = (
+        dynamic_cfg.get("mcp", {}).get("servers", {})
+        if isinstance(dynamic_cfg.get("mcp"), dict)
+        else {}
+    )
+    if not isinstance(dynamic_servers, dict):
+        dynamic_servers = {}
+
+    merged_dynamic = dict(dynamic_servers)
+    for _src, src_servers in legacy_by_file.items():
+        for name, entry in src_servers.items():
+            if name not in merged_dynamic:
+                merged_dynamic[name] = entry
+
+    # Print plan.
+    print(f"# Migration plan ({'DRY RUN' if dry_run else 'WRITING'})")
+    for src, src_servers in legacy_by_file.items():
+        try:
+            rel = src.relative_to(project_root)
+            src_label = str(rel)
+        except ValueError:
+            src_label = str(src)
+        moved = sorted(src_servers.keys())
+        print(f"  from {src_label}: {len(moved)} server(s) → {', '.join(moved)}")
+    print("  → into .reyn/mcp.yaml (existing entries preserved)")
+    print(
+        f"  total servers in .reyn/mcp.yaml after migration: "
+        f"{len(merged_dynamic)}"
+    )
+
+    if dry_run:
+        print("\nDry run only — no files written. Re-run without --dry-run to apply.")
+        return
+
+    # Write the merged dynamic file.
+    dynamic_path.parent.mkdir(parents=True, exist_ok=True)
+    new_dynamic = dict(dynamic_cfg)
+    new_dynamic_mcp = dict(new_dynamic.get("mcp", {})) if isinstance(new_dynamic.get("mcp"), dict) else {}
+    new_dynamic_mcp["servers"] = merged_dynamic
+    new_dynamic["mcp"] = new_dynamic_mcp
+    dynamic_path.write_text(
+        yaml.dump(new_dynamic, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    print(f"\nWrote {dynamic_path}")
+
+    # Remove ``mcp.servers`` from each legacy file (= leave other keys intact).
+    for src in legacy_by_file:
+        cfg = _read(src)
+        mcp_section = cfg.get("mcp")
+        if isinstance(mcp_section, dict) and "servers" in mcp_section:
+            del mcp_section["servers"]
+            # If the mcp section is now empty, drop it entirely so the
+            # legacy file doesn't keep a dangling ``mcp: {}`` key.
+            if not mcp_section:
+                del cfg["mcp"]
+            else:
+                cfg["mcp"] = mcp_section
+        src.write_text(
+            yaml.dump(cfg, allow_unicode=True, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+        try:
+            rel = src.relative_to(project_root)
+            src_label = str(rel)
+        except ValueError:
+            src_label = str(src)
+        print(f"Removed mcp.servers from {src_label}")
 
 
 def _set(key: str, value: str) -> None:

--- a/src/reyn/cli/templates.py
+++ b/src/reyn/cli/templates.py
@@ -73,22 +73,24 @@ permissions:
   # shell: allow
 
 # ───────────────────────────────────────────────────────────────────────────
-# MCP servers (optional). Stdlib skills that depend on MCP need a
-# `filesystem` server. Uncomment below to enable, or see the full example at
-# cookbook/configs/with-mcp.yaml.  Run the server manually first to verify:
-#   npx -y @modelcontextprotocol/server-filesystem .
+# MCP servers (= op-managed, not edited here).
+#
+# Issue #470 (2026-05-22): MCP server registry lives in `.reyn/mcp.yaml`, not
+# in this file. The split matches the principle that `reyn.yaml` should carry
+# only **static deployment config** (= edit + restart to apply), while
+# runtime-mutable state lives under `.reyn/`. Sister convention to
+# `.reyn/approvals.yaml` (= dynamic permission state, ops-managed).
+#
+# Install / remove MCP servers via the CLI; the ops write to `.reyn/mcp.yaml`:
+#   reyn mcp install io.github.modelcontextprotocol/server-filesystem
+#   reyn mcp drop filesystem
+#
+# Migration: if you have legacy `mcp.servers` entries here from before #470,
+# they continue to load. Run `reyn config migrate-mcp` (or `--dry-run` first)
+# to move them to `.reyn/mcp.yaml` and remove from this file.
+#
 # Full setup guide: docs/guide/for-skill-authors/use-an-mcp-server.md
 # ───────────────────────────────────────────────────────────────────────────
-# mcp:
-#   servers:
-#     filesystem:
-#       type: stdio
-#       command: npx
-#       args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
-#     # git:
-#     #   type: stdio
-#     #   command: npx
-#     #   args: ["-y", "@modelcontextprotocol/server-git", "--repository", "."]
 """
 
 

--- a/tests/test_config_migrate_mcp_command.py
+++ b/tests/test_config_migrate_mcp_command.py
@@ -1,0 +1,235 @@
+"""Tier 2: ``reyn config migrate-mcp`` CLI command (#470 follow-up).
+
+Tests the explicit operator migration of legacy ``mcp.servers`` entries
+from ``reyn.yaml`` / ``reyn.local.yaml`` into the canonical
+``.reyn/mcp.yaml`` location landed in PR #473.
+
+Pins:
+
+  1. No-op when no legacy entries exist (= clean state).
+  2. Migration moves entries from reyn.yaml + reyn.local.yaml + user
+     global into .reyn/mcp.yaml.
+  3. Legacy files have ``mcp.servers`` removed; other config keys
+     stay intact.
+  4. Dry-run prints the plan without writing.
+  5. Existing .reyn/mcp.yaml entries take precedence on conflict
+     (= partial prior migration isn't clobbered).
+  6. Empty ``mcp:`` section dropped entirely after removal (= no
+     dangling ``mcp: {}`` left in legacy yaml).
+
+Tier 2 because the command is the operator-facing migration path; a
+regression that silently dropped servers or clobbered configs would
+be a real data-loss hazard.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _run_migrate(*, dry_run: bool = False):
+    from reyn.cli.commands.config import _migrate_mcp
+    _migrate_mcp(dry_run=dry_run)
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Standard project root with a reyn.yaml seed.
+
+    Monkeypatch ``Path.home`` to a tmp subdir so the user-global
+    ``~/.reyn/config.yaml`` lookup doesn't touch the real home.
+    Monkeypatch ``_find_project_root`` so the command finds the
+    tmp project regardless of pytest cwd.
+    """
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr(
+        "reyn.config._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ── no-op cases ────────────────────────────────────────────────────────
+
+
+def test_migrate_no_legacy_entries_is_noop(project, capsys):
+    """Tier 2: no ``mcp.servers`` anywhere → command prints "nothing to
+    migrate" and doesn't write any files.
+    """
+    _write_yaml(project / "reyn.yaml", "model: standard\n")
+
+    _run_migrate()
+
+    out = capsys.readouterr().out
+    assert "nothing to migrate" in out.lower()
+    # No .reyn/mcp.yaml created.
+    assert not (project / ".reyn" / "mcp.yaml").exists()
+
+
+# ── full migration ────────────────────────────────────────────────────
+
+
+def test_migrate_moves_reyn_yaml_servers_to_dynamic(project, capsys):
+    """Tier 2: ``mcp.servers`` from reyn.yaml moves to .reyn/mcp.yaml;
+    the source file has the section stripped.
+    """
+    _write_yaml(
+        project / "reyn.yaml",
+        "model: standard\n"
+        "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
+    )
+
+    _run_migrate()
+
+    # Target file written with the entry.
+    import yaml
+    dyn = yaml.safe_load((project / ".reyn" / "mcp.yaml").read_text())
+    assert "sqlite" in dyn["mcp"]["servers"]
+    assert dyn["mcp"]["servers"]["sqlite"]["command"] == "npx"
+
+    # Source file no longer has mcp.servers — model stays.
+    src = yaml.safe_load((project / "reyn.yaml").read_text())
+    assert src.get("model") == "standard"
+    # Empty mcp section dropped entirely.
+    assert "mcp" not in src
+
+    # Summary printed.
+    out = capsys.readouterr().out
+    assert "sqlite" in out
+    assert "reyn.yaml" in out
+
+
+def test_migrate_moves_from_both_reyn_yaml_and_local(project, capsys):
+    """Tier 2: entries from BOTH reyn.yaml and reyn.local.yaml are
+    moved; the target file has the union of all sources.
+    """
+    _write_yaml(
+        project / "reyn.yaml",
+        "model: standard\n"
+        "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
+    )
+    _write_yaml(
+        project / "reyn.local.yaml",
+        "api_base: http://local\n"
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: uvx\n",
+    )
+
+    _run_migrate()
+
+    import yaml
+    dyn = yaml.safe_load((project / ".reyn" / "mcp.yaml").read_text())
+    servers = dyn["mcp"]["servers"]
+    assert "sqlite" in servers
+    assert "git" in servers
+    assert servers["sqlite"]["command"] == "npx"
+    assert servers["git"]["command"] == "uvx"
+
+    # Local file's api_base preserved; mcp section stripped.
+    local = yaml.safe_load((project / "reyn.local.yaml").read_text())
+    assert local.get("api_base") == "http://local"
+    assert "mcp" not in local
+
+
+def test_migrate_preserves_existing_dynamic_entries(project, capsys):
+    """Tier 2: ``.reyn/mcp.yaml`` entries that already exist win on
+    conflict — protects against double-migration corrupting a
+    server entry that the operator may have edited post-install.
+    """
+    _write_yaml(
+        project / "reyn.yaml",
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: old-cmd\n",
+    )
+    _write_yaml(
+        project / ".reyn" / "mcp.yaml",
+        "mcp:\n  servers:\n    git:\n      type: stdio\n      command: new-cmd\n",
+    )
+
+    _run_migrate()
+
+    import yaml
+    dyn = yaml.safe_load((project / ".reyn" / "mcp.yaml").read_text())
+    # Existing dynamic entry wins.
+    assert dyn["mcp"]["servers"]["git"]["command"] == "new-cmd"
+    # Legacy source stripped regardless.
+    src = yaml.safe_load((project / "reyn.yaml").read_text())
+    assert "mcp" not in src
+
+
+# ── dry-run ────────────────────────────────────────────────────────────
+
+
+def test_migrate_dry_run_does_not_write_files(project, capsys):
+    """Tier 2: ``--dry-run`` prints the plan but doesn't mutate any
+    file — operators can preview before committing.
+    """
+    _write_yaml(
+        project / "reyn.yaml",
+        "model: standard\n"
+        "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
+    )
+
+    _run_migrate(dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "sqlite" in out
+
+    # Files unchanged.
+    import yaml
+    src = yaml.safe_load((project / "reyn.yaml").read_text())
+    assert "mcp" in src
+    assert "sqlite" in src["mcp"]["servers"]
+    assert not (project / ".reyn" / "mcp.yaml").exists()
+
+
+# ── side-key preservation ──────────────────────────────────────────────
+
+
+def test_migrate_preserves_other_mcp_subkeys_if_any(project):
+    """Tier 2: only the ``servers`` sub-key is removed from the legacy
+    ``mcp:`` section. If sibling keys exist (= hypothetical future
+    schema extension), they stay intact.
+    """
+    _write_yaml(
+        project / "reyn.yaml",
+        "mcp:\n"
+        "  servers:\n    sqlite:\n      type: stdio\n      command: npx\n"
+        "  hypothetical_future_key: keep-me\n",
+    )
+
+    _run_migrate()
+
+    import yaml
+    src = yaml.safe_load((project / "reyn.yaml").read_text())
+    # Server moved out, but the sibling key stays.
+    assert src.get("mcp") == {"hypothetical_future_key": "keep-me"}
+
+
+# ── command surface ───────────────────────────────────────────────────
+
+
+def test_migrate_subcommand_is_registered():
+    """Tier 2: ``reyn config migrate-mcp`` is registered as a
+    subcommand. Without this, the CLI surface doesn't expose the
+    migration path even though the function works.
+    """
+    import argparse
+
+    from reyn.cli.commands.config import register
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    register(sub)
+
+    # Parse just enough to verify the subcommand exists.
+    args = parser.parse_args(["config", "migrate-mcp", "--dry-run"])
+    assert args.config_cmd == "migrate-mcp"
+    assert args.dry_run is True


### PR DESCRIPTION
**[e2e-coder]** — follow-up to PR #473 (= #470 core refactor). Lands operator-facing migration command + REYN_YAML_TEMPLATE update that point at the new ``.reyn/mcp.yaml`` location.

## Summary

After PR #473 landed the runtime split (= ``.reyn/mcp.yaml`` is now the canonical write target for mcp_install / mcp_drop ops), operators with legacy ``reyn.yaml`` ``mcp.servers`` blocks need an explicit migration path + the template needs to stop suggesting they edit MCP config in reyn.yaml.

## ``reyn config migrate-mcp``

```
reyn config migrate-mcp [--dry-run]
```

- Reads legacy ``mcp.servers`` from ``reyn.yaml`` / ``reyn.local.yaml`` / ``~/.reyn/config.yaml``
- Merges into ``.reyn/mcp.yaml`` — existing entries there WIN on conflict (= protects partial-migration state)
- Strips ``mcp.servers`` from each legacy file
- Drops empty ``mcp:`` sections; preserves other sibling keys
- ``--dry-run`` prints the plan without writing

## REYN_YAML_TEMPLATE update

The commented ``mcp:`` block is replaced with an explanatory note:
- MCP registry lives in ``.reyn/mcp.yaml`` (= op-managed)
- Install / remove via ``reyn mcp install`` / ``reyn mcp drop``
- Run ``reyn config migrate-mcp`` for legacy entries
- Sister convention to ``.reyn/approvals.yaml``

## Change shape

- ``src/reyn/cli/commands/config.py``: ``migrate-mcp`` subparser + ``_migrate_mcp`` implementation
- ``src/reyn/cli/templates.py``: REYN_YAML_TEMPLATE comment block updated
- ``tests/test_config_migrate_mcp_command.py`` (new, 7 tests): no-op clean state / move from reyn.yaml / move from both yaml files / existing-dynamic precedence / dry-run no-write / sibling mcp.* keys preserved / subparser registered

## Test plan

- [x] ``pytest tests/test_config_migrate_mcp_command.py`` — 7/7 pass
- [x] ``pytest tests/`` (full suite) — 4777 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## #470 status after this PR

| Item | Status |
|---|---|
| Core refactor (loader + write target) | MERGED PR #473 |
| Migration command + template | **this PR** |
| ``docs/concepts/config.md`` section | optional follow-up (= not blocking #470 closure since principle is documented in code) |

After this merge, the #470 architectural invariant ("``reyn.yaml`` = edit + restart, ``.reyn/`` = runtime mutable") is fully landed end-to-end. Operators have a clean migration path; the template no longer suggests editing MCP config in reyn.yaml.

Refs #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)