### PR TITLE
fix(tui): guard InputBar against double-submit during in-flight turn (D-F11)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -652,6 +652,19 @@ class ReynTUIApp(App):
             self._skill_exec.pop(run_id, None)
             self._push_exec_state()
             self._last_focal_tab = "agents"
+            # Wave-9 D-F11: release the input-bar lock when the last
+            # tracked skill finishes. Sub-skills popping during a
+            # nested run keep the lock held — only the empty state
+            # signals "turn is fully done, safe to accept a new
+            # submit". ``_on_stream_end`` is the other unlock path
+            # (covers streaming turns that don't necessarily route
+            # through ``_skill_exec``); both are idempotent so calling
+            # twice in a turn is harmless.
+            if not self._skill_exec:
+                try:
+                    self.query_one("#inputbar", InputBar).set_in_flight(False)
+                except Exception:
+                    pass
 
     def _maybe_render_cost_suffix(
         self, conv: ConversationView, *, attempt: int = 0,
@@ -761,11 +774,24 @@ class ReynTUIApp(App):
             # the intercept keeps a single source of truth for the slash
             # dispatch path.
             # Dispatch to session._maybe_handle_slash (which uses registry)
-            if session is not None:
-                await session._maybe_handle_slash(text)
-            else:
-                # No session — still try the registry
-                await self._dispatch_slash_no_session(text, conv)
+            try:
+                if session is not None:
+                    await session._maybe_handle_slash(text)
+                else:
+                    # No session — still try the registry
+                    await self._dispatch_slash_no_session(text, conv)
+            finally:
+                # Wave-9 D-F11: slash commands are synchronous from the
+                # user's POV — once ``_maybe_handle_slash`` returns the
+                # turn is over, so release the in-flight lock the
+                # ``InputBar._submit`` set. Without this, a slash submit
+                # would leave the input bar locked until the next
+                # stream_end (which may never come for a pure slash
+                # turn).
+                try:
+                    self.query_one("#inputbar", InputBar).set_in_flight(False)
+                except Exception:
+                    pass
         else:
             if session is not None:
                 # Optimistic sticky: the skill_runner emits its first
@@ -878,6 +904,13 @@ class ReynTUIApp(App):
             conv = None
         if conv is not None:
             conv.hide_status()
+        # Wave-9 D-F11: Ctrl+C unconditionally releases the in-flight
+        # lock so the user can immediately submit a new prompt. Even if
+        # no skills were actually cancelled (= the lock was set
+        # spuriously, or a stream_end was missed), Ctrl+C is the
+        # documented escape hatch from a stuck state.
+        if input_bar is not None:
+            input_bar.set_in_flight(False)
 
         session = self._get_session()
         # Wave-6 IV2: pending user interventions are "in-flight" from

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -589,6 +589,18 @@ class OutboxRouter:
         app._maybe_refresh_status(header)
         # A4: render per-turn cost suffix when opt-in is enabled
         app._maybe_render_cost_suffix(conv)
+        # Wave-9 D-F11: release the input-bar lock at the end of the
+        # last live stream. Concurrent streams keep the lock held —
+        # only when ``_current_stream_id`` is cleared (= no live
+        # stream remaining) is the user safe to submit again. The
+        # "skill done" branch in ``_handle_trace_for_skill_row`` is
+        # the other unlock path; both are idempotent.
+        if app._current_stream_id is None:
+            try:
+                from .widgets import InputBar  # local import — avoid cycle
+                app.query_one("#inputbar", InputBar).set_in_flight(False)
+            except Exception:
+                pass
 
     def _on_intervention(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -74,6 +74,12 @@ class InputBar(Widget):
         color: #555555;
         padding: 0 2;
     }
+    InputBar.in-flight TextArea {
+        color: #666666;
+    }
+    InputBar.in-flight #hints {
+        color: #886633;
+    }
     """
 
     # ── messages ──────────────────────────────────────────────────────────────
@@ -111,6 +117,13 @@ class InputBar(Widget):
         # ``row_count`` Up presses to advance one history step.
         # Cleared on ``TextArea.Changed`` (= user edit).
         self._restore_pristine: bool = False
+        # Wave-9 D-F11: lock state for the in-flight turn. While True,
+        # ``_submit`` returns early without posting ``UserSubmitted`` or
+        # clearing the TextArea — so a fast Enter / Enter sequence
+        # doesn't dispatch two LLM calls for the same prompt. App-side
+        # callers toggle it via ``set_in_flight``: True at submit
+        # time, False at stream_end / cancel / slash-return.
+        self._in_flight: bool = False
 
     def compose(self) -> ComposeResult:
         # Picker docked above TextArea (compose order matters: top-down).
@@ -147,6 +160,28 @@ class InputBar(Widget):
             self.query_one("#input", TextArea).focus()
         except Exception:
             pass
+
+    def set_in_flight(self, in_flight: bool) -> None:
+        """Toggle the in-flight lock (D-F11, wave-9).
+
+        While in-flight, ``_submit`` returns early so a second Enter
+        keypress during an LLM response in flight doesn't dispatch a
+        duplicate ``UserSubmitted`` message (= double LLM call, doubled
+        cost, conv-pane noise). The ``.in-flight`` CSS class dims the
+        TextArea text and the hint footer so the lock is visible.
+
+        Idempotent — calling with the same value is a no-op. The lock
+        is set by ``_submit`` immediately after a successful post, and
+        cleared by the App at lifecycle points (stream_end, skill done
+        with empty queue, action_cancel_inflight, slash-command return).
+        """
+        if self._in_flight == in_flight:
+            return
+        self._in_flight = in_flight
+        if in_flight:
+            self.add_class("in-flight")
+        else:
+            self.remove_class("in-flight")
 
     def append_text(self, text: str) -> None:
         """Append text to the current input (used by voice dictation).
@@ -524,6 +559,15 @@ class InputBar(Widget):
         text = ta.text.strip()
         if not text:
             return
+        # Wave-9 D-F11: while a prior turn is still in flight, swallow
+        # the Enter without posting / clearing. The typed text stays so
+        # the user can edit and re-submit once the lock releases (e.g.
+        # via stream_end). Without this guard, hitting Enter twice
+        # quickly while an LLM call is in progress dispatches the same
+        # prompt twice → doubled spend + duplicated reply in the conv
+        # pane.
+        if self._in_flight:
+            return
         if not self._history or self._history[-1] != text:
             self._history.append(text)
         self._history_idx = -1
@@ -534,6 +578,13 @@ class InputBar(Widget):
         except Exception:
             pass
         self.post_message(self.UserSubmitted(text))
+        # Lock immediately — the App handler will unlock at the next
+        # lifecycle boundary (stream end / cancel / slash return).
+        # Setting after ``post_message`` is fine because Textual
+        # processes message queues serially: a second Enter pressed
+        # before this line lands would have already been routed to the
+        # same handler and exited at ``if self._in_flight`` above.
+        self.set_in_flight(True)
 
     def _history_up(self, ta: TextArea) -> None:
         if not self._history:

--- a/tests/cli/test_input_bar_double_submit_guard.py
+++ b/tests/cli/test_input_bar_double_submit_guard.py
@@ -1,0 +1,150 @@
+"""Tier 2: InputBar swallows duplicate Enter while turn is in flight (D-F11).
+
+Wave-9 Topic D finding F11 (P1): the TextArea stayed enabled while a
+prior turn was still in flight (= LLM streaming), so a fast Enter /
+Enter sequence dispatched the same prompt twice. Doubled spend and
+duplicated reply in the conv pane.
+
+Now ``InputBar`` carries an ``_in_flight`` flag. ``_submit`` sets it
+immediately after posting ``UserSubmitted`` and returns early on
+subsequent calls. The App releases the lock at lifecycle boundaries
+(stream end, skill done with empty queue, Ctrl+C cancel, slash-command
+return) via the public ``set_in_flight`` method.
+
+Public surfaces tested:
+  - ``set_in_flight`` toggles the ``in-flight`` CSS class idempotently
+  - second ``_submit`` during in-flight does NOT post a second
+    ``UserSubmitted`` and does NOT clear the TextArea (= typed text
+    preserved for re-submit after unlock)
+  - ``action_cancel_inflight`` (Ctrl+C) releases the lock
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_set_in_flight_toggles_css_class_idempotently() -> None:
+    """Tier 2: ``set_in_flight`` is idempotent + toggles ``in-flight`` class."""
+    from reyn.chat.tui.widgets import InputBar
+
+    bar = InputBar()
+    # Default state.
+    assert bar._in_flight is False
+    assert not bar.has_class("in-flight")
+
+    bar.set_in_flight(True)
+    assert bar._in_flight is True
+    assert bar.has_class("in-flight")
+
+    # Idempotent re-set is a no-op.
+    bar.set_in_flight(True)
+    assert bar._in_flight is True
+    assert bar.has_class("in-flight")
+
+    bar.set_in_flight(False)
+    assert bar._in_flight is False
+    assert not bar.has_class("in-flight")
+
+    # Idempotent un-set.
+    bar.set_in_flight(False)
+    assert bar._in_flight is False
+    assert not bar.has_class("in-flight")
+
+
+@pytest.mark.asyncio
+async def test_submit_during_in_flight_swallows_text_unchanged() -> None:
+    """Tier 2: ``_submit`` during in-flight preserves text + posts no message.
+
+    Uses the full Textual harness to drive a real TextArea + post_message
+    queue. Spy on ``UserSubmitted`` via a list mutated from a wrapper
+    around ``post_message``.
+    """
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    posted: list[InputBar.UserSubmitted] = []
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        ta = app.query_one("#input", TextArea)
+
+        # Spy on InputBar.post_message — capture every ``UserSubmitted``
+        # the widget produces and intercept it (do NOT forward to the
+        # real queue). We're testing the InputBar's emission contract,
+        # not the downstream App routing — forwarding the messages
+        # would trigger ``on_input_bar_user_submitted`` which expects
+        # a fully-wired session and a #conversation widget. Other
+        # message types (e.g. UserSubmitted siblings) bypass the
+        # capture and forward normally.
+        original_post = bar.post_message
+
+        def _spy(msg):  # type: ignore[no-untyped-def]
+            if isinstance(msg, InputBar.UserSubmitted):
+                posted.append(msg)
+                return True  # match Textual's post_message return shape
+            return original_post(msg)
+
+        bar.post_message = _spy  # type: ignore[method-assign]
+
+        # First submit: text populated, _submit called → posts + locks.
+        ta.load_text("hi")
+        bar._submit(ta)
+        assert len(posted) == 1
+        assert posted[0].text == "hi"
+        assert bar._in_flight is True
+        assert bar.has_class("in-flight")
+        assert ta.text == "", "first submit should clear the TextArea"
+
+        # Second submit while locked: text NOT cleared, NO new message.
+        ta.load_text("yo")
+        bar._submit(ta)
+        assert len(posted) == 1, (
+            f"second submit slipped through while in-flight: {posted!r}"
+        )
+        assert ta.text == "yo", (
+            f"text cleared on swallowed submit (lost user input): {ta.text!r}"
+        )
+
+        # Release the lock + submit again: posts normally.
+        bar.set_in_flight(False)
+        bar._submit(ta)
+        assert len(posted) == 2
+        assert posted[1].text == "yo"
+        assert ta.text == ""
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_releases_in_flight_lock() -> None:
+    """Tier 2: ``action_cancel_inflight`` unconditionally clears the lock.
+
+    Even with no skills actually running, Ctrl+C is the documented
+    escape hatch from a stuck state. The lock must release so the
+    user can submit again.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+
+        bar.set_in_flight(True)
+        assert bar.has_class("in-flight")
+
+        app.action_cancel_inflight()
+        await pilot.pause()
+        assert bar._in_flight is False
+        assert not bar.has_class("in-flight")


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #2 (D-F11, P1 M).

## Problem

TextArea stayed enabled while a prior turn was still in flight. Fast Enter / Enter sequence dispatched the same prompt twice → doubled spend + duplicated reply.

## Fix

``InputBar._in_flight`` flag with public ``set_in_flight``. ``_submit`` early-returns when locked (preserves typed text). ``.in-flight`` CSS class dims TextArea + hint footer.

Unlock at 4 idempotent points:
- ``_on_stream_end`` when no live stream remains
- ``_handle_trace_for_skill_row`` "skill done:" with empty ``_skill_exec``
- ``action_cancel_inflight`` (= Ctrl+C escape hatch)
- end of slash-command dispatch

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: CSS class idempotency, double-submit swallowed + text preserved, Ctrl+C unlock
- [x] Existing 40 smoke tests still green (no regression on slash picker / typing / Ctrl+L)

## Wave-9 context

```
✅ D-F8 (#474 merged)
🆕 D-F11 (P1 M, this PR)
🔄 E-F1 / E-F2 / E-F3 / F-F1+F6 / F-F2 / F-F7 / F-F11 / F-F12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)