### PR TITLE
fix(tui): accept both intervention_id and iv_id meta keys on resolve (E-F1)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -713,7 +713,18 @@ class OutboxRouter:
             conv.hide_status()
         except Exception:
             pass
-        iv_id = msg.meta.get("iv_id", "")
+        # Wave-9 E-F1: accept either ``intervention_id`` (= the key used
+        # by ``_on_intervention`` and by the service's mount + cancel
+        # emits) or ``iv_id`` (= the legacy key used by the resolved
+        # emit only). Reading both with ``intervention_id`` preferred
+        # makes the TUI immune to which key any future producer chooses
+        # — without this, a one-line rename on the service side would
+        # silently leak InterventionWidget orphans (= the lookup at
+        # ``query_one(#iv_…)`` would miss, ``except Exception: pass``
+        # would swallow it, and the widget would stay mounted with no
+        # way to remove it). Same id field, two historical names,
+        # picked here in canonical-key order.
+        iv_id = msg.meta.get("intervention_id") or msg.meta.get("iv_id", "")
         widget_id = f"iv_{iv_id[:8]}"
         try:
             widget = self._app.query_one(f"#{widget_id}")

--- a/tests/cli/test_intervention_resolved_meta_keys.py
+++ b/tests/cli/test_intervention_resolved_meta_keys.py
@@ -1,0 +1,138 @@
+"""Tier 2: `_on_intervention_resolved` tolerates both meta-key shapes (E-F1).
+
+Wave-9 Topic E finding F1 (P1): ``_on_intervention`` reads
+``msg.meta["intervention_id"]`` while ``_on_intervention_resolved``
+read ``msg.meta["iv_id"]``. The service emitted the two keys
+consistently by convention, but a one-line rename on the service
+side would silently break the resolve lookup — the
+``query_one("#iv_…")`` would miss, the bare ``except Exception:
+pass`` would swallow it, and the InterventionWidget would stay
+mounted with no removal path.
+
+The TUI now reads BOTH keys (``intervention_id`` preferred,
+``iv_id`` fallback) so widget removal is immune to which key any
+future producer chooses. Same id field, two historical names.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+async def _mount_intervention_widget(pilot, iv_id: str):
+    """Mount an InterventionWidget under the conversation view."""
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+    app = pilot.app
+    conv = app.query_one("#conversation", ConversationView)
+    widget = InterventionWidget(iv_id=iv_id, question="confirm?")
+    await conv.mount(widget)
+    await pilot.pause()
+    return widget
+
+
+def _resolved_msg(meta: dict):
+    """Build a minimal intervention_resolved OutboxMessage."""
+    from reyn.chat.outbox import OutboxMessage
+    return OutboxMessage(kind="intervention_resolved", text="", meta=meta)
+
+
+@pytest.mark.asyncio
+async def test_resolved_handler_finds_widget_with_legacy_iv_id_key() -> None:
+    """Tier 2: meta carrying only ``iv_id`` still removes the widget.
+
+    The service emits ``meta={"iv_id": iv.id, …}`` on resolve today.
+    The handler must continue to honor this legacy shape.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        widget = await _mount_intervention_widget(pilot, iv_id="abc1efgh-xxxx")
+        assert app.query(InterventionWidget)
+
+        msg = _resolved_msg({"iv_id": "abc1efgh-xxxx"})
+        from reyn.chat.tui.app_outbox import OutboxRouter
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation")
+        header = app.query_one("#header")
+        router._on_intervention_resolved(msg, conv, header)
+        await pilot.pause()
+        assert not app.query(InterventionWidget), (
+            "widget should be removed when meta carries iv_id"
+        )
+        del widget  # keep linter quiet
+
+
+@pytest.mark.asyncio
+async def test_resolved_handler_finds_widget_with_intervention_id_key() -> None:
+    """Tier 2: meta carrying ``intervention_id`` also removes the widget.
+
+    If the service is ever refactored so the resolve emit uses the
+    same ``intervention_id`` key as the mount emit, the TUI must not
+    leak orphan widgets.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        widget = await _mount_intervention_widget(pilot, iv_id="def2hijk-yyyy")
+        assert app.query(InterventionWidget)
+
+        msg = _resolved_msg({"intervention_id": "def2hijk-yyyy"})
+        from reyn.chat.tui.app_outbox import OutboxRouter
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation")
+        header = app.query_one("#header")
+        router._on_intervention_resolved(msg, conv, header)
+        await pilot.pause()
+        assert not app.query(InterventionWidget), (
+            "widget should be removed when meta carries intervention_id"
+        )
+        del widget
+
+
+@pytest.mark.asyncio
+async def test_resolved_handler_prefers_intervention_id_when_both_present() -> None:
+    """Tier 2: ``intervention_id`` wins over ``iv_id`` when both meta keys exist.
+
+    If a future emit carries both keys (= during a migration window),
+    the canonical ``intervention_id`` should be the one consulted.
+    Mount widget under ``intervention_id`` value; pass meta with a
+    NONSENSE ``iv_id`` value alongside the correct ``intervention_id``
+    — successful removal proves ``intervention_id`` was the key read.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        widget = await _mount_intervention_widget(pilot, iv_id="ghi3lmno-zzzz")
+        assert app.query(InterventionWidget)
+
+        msg = _resolved_msg({
+            "intervention_id": "ghi3lmno-zzzz",  # correct
+            "iv_id": "WRONG_KEY_zzz",  # nonsense; would miss the widget
+        })
+        from reyn.chat.tui.app_outbox import OutboxRouter
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation")
+        header = app.query_one("#header")
+        router._on_intervention_resolved(msg, conv, header)
+        await pilot.pause()
+        assert not app.query(InterventionWidget), (
+            "intervention_id should be preferred over iv_id"
+        )
+        del widget


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #3 (E-F1, P1 S).

## Problem

``_on_intervention`` reads ``meta["intervention_id"]`` while ``_on_intervention_resolved`` read ``meta["iv_id"]``. Service emits the two keys consistently by convention — a one-line rename would silently leak InterventionWidget orphans (lookup misses, ``except Exception: pass`` swallows, widget stays mounted).

## Fix

Resolve handler reads BOTH keys with ``intervention_id`` preferred. Same id field, two historical names — TUI is now immune to which key any future producer chooses.

```python
iv_id = msg.meta.get("intervention_id") or msg.meta.get("iv_id", "")
```

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: legacy iv_id-only / future intervention_id-only / both-present preferring intervention_id
- [x] Existing 40 smoke tests still green

## Wave-9 context

```
✅ D-F8 (#474 merged) / D-F11 (#476 in review)
🆕 E-F1 (P1 S, this PR)
🔄 E-F2 / E-F3 / F-F1+F6 / F-F2 / F-F7 / F-F11 / F-F12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)