### PR TITLE
fix(tui): align streaming + sealed Markdown to 7-cell body indent (F-F1+F6)

### DIFF
--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -39,6 +39,20 @@ from reyn.chat.tui._palette import _AMBER
 _RENDER_INTERVAL_MS = 16  # ~60 fps max
 _RENDER_INTERVAL_S = _RENDER_INTERVAL_MS / 1000
 
+# Body content rendered inside ConversationView lives at a 7-cell
+# hanging indent (= ``conversation._BODY_INDENT_COLS``) so wrap
+# continuations sit under the speaker name and the column-0 turn
+# header stays visually distinct. Streaming text mounted here is the
+# same kind of body content, so it must render at the same indent —
+# otherwise the body visibly shifts 7 cells to the right at seal()
+# time when ``end_stream`` commits the final markdown via
+# ``_write_agent_markdown_with_fold`` → ``_write_body`` (= the
+# Padding-wrapped ``_indent_body`` path). Kept as a local constant
+# rather than imported from conversation.py to avoid an import
+# cycle (conversation already imports this module); must stay in
+# sync with conversation._BODY_INDENT_COLS.
+_BODY_INDENT_COLS = 7
+
 
 class StreamingRow(Widget):
     """One in-progress agent message that accumulates token chunks.
@@ -56,17 +70,24 @@ class StreamingRow(Widget):
         row.seal()   # swaps raw text for Markdown widget
     """
 
+    # Wave-9 F-F1 + F-F6: Static (streaming) and Markdown (sealed swap)
+    # both get a 7-cell left padding so the body sits at the same
+    # hanging indent as ``_write_body`` / ``_indent_body``. Without
+    # this, the streaming text rendered at col 0 and visibly jumped 7
+    # cells to the right at seal time when ``end_stream`` committed
+    # the final markdown through ``_write_agent_markdown_with_fold``.
+    # The 4-value form is ``top right bottom left``.
     DEFAULT_CSS = """
     StreamingRow {
         padding: 0 0;
         height: auto;
     }
     StreamingRow Static {
-        padding: 0 0;
+        padding: 0 0 0 7;
         height: auto;
     }
     StreamingRow Markdown {
-        padding: 0 0;
+        padding: 0 0 0 7;
         height: auto;
         background: transparent;
     }

--- a/tests/cli/test_streaming_row_body_indent.py
+++ b/tests/cli/test_streaming_row_body_indent.py
@@ -1,0 +1,109 @@
+"""Tier 2: StreamingRow renders body at the 7-cell hanging indent (F-F1 + F-F6).
+
+Wave-9 Topic F findings F1 + F6 (P1): the streaming body Static and
+the sealed Markdown swap had ``padding: 0 0`` — both rendered at
+col 0 — while the final committed markdown went through
+``_write_body`` → ``_indent_body`` which wraps it in
+``Padding(renderable, (0, 0, 0, 7))``. The body visibly jumped 7
+cells to the right at seal() time when ``end_stream`` committed
+through ``_write_agent_markdown_with_fold``.
+
+Fix: both the streaming Static and the sealed Markdown carry
+``padding: 0 0 0 7`` so they sit at the same hanging indent as
+the committed body. The horizontal jump is gone.
+
+Public surfaces tested:
+  - Static widget mounted by ``compose()`` has 7-cell left padding
+  - Markdown widget mounted by ``_apply_markdown_swap`` has 7-cell
+    left padding
+  - Local ``_BODY_INDENT_COLS`` matches ``conversation._BODY_INDENT_COLS``
+    (= the contract that prevents drift)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_streaming_row_indent_constant_matches_conversation() -> None:
+    """Tier 2: local ``_BODY_INDENT_COLS`` matches conversation.py source.
+
+    Pins the cross-module contract — both files must agree on the
+    hanging indent or the horizontal jump returns.
+    """
+    from reyn.chat.tui.widgets import conversation as conv_mod
+    from reyn.chat.tui.widgets import streaming_row as stream_mod
+
+    assert stream_mod._BODY_INDENT_COLS == conv_mod._BODY_INDENT_COLS, (
+        f"streaming_row._BODY_INDENT_COLS={stream_mod._BODY_INDENT_COLS} "
+        f"must match conversation._BODY_INDENT_COLS={conv_mod._BODY_INDENT_COLS}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_static_has_seven_cell_left_padding() -> None:
+    """Tier 2: the streaming Static is rendered at the 7-cell hanging indent."""
+    from textual.widgets import Static
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("test-msg-id", "test-agent")
+        row.append("hello world streaming body")
+        await pilot.pause()
+
+        static = row.query_one(Static)
+        # Textual resolves the CSS padding into a 4-tuple (top, right,
+        # bottom, left) on the widget's styles.
+        padding = static.styles.padding
+        assert padding.left == 7, (
+            f"streaming Static left-padding should be 7, got {padding.left} "
+            f"(full: {padding!r})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_sealed_markdown_has_seven_cell_left_padding() -> None:
+    """Tier 2: the sealed Markdown swap also lands at the 7-cell indent.
+
+    Even though ``end_stream`` removes the row shortly after sealing
+    in production, the brief flash of the sealed Markdown should
+    not introduce a different indent — otherwise fast streams show
+    a flicker at the wrong x-position.
+    """
+    from textual.widgets import Markdown
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("seal-test-id", "test-agent")
+        row.append("# header\n\nbody paragraph")
+        await pilot.pause()
+        row.seal()
+        await pilot.pause()
+
+        # After seal, _apply_markdown_swap mounted a Markdown child.
+        markdowns = list(row.query(Markdown))
+        assert markdowns, "seal should have mounted a Markdown widget"
+        md = markdowns[0]
+        padding = md.styles.padding
+        assert padding.left == 7, (
+            f"sealed Markdown left-padding should be 7, got {padding.left} "
+            f"(full: {padding!r})"
+        )


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #6 (F-F1 + F-F6 bundled, P1 S).

**Bundled scope**: F-F1 (streaming body indent jump) + F-F6 (sealed Markdown swap indent inconsistency) share a single root cause (= ``StreamingRow`` rendered at col 0 vs ``_indent_body`` at col 7). Fixed together with one CSS change so the contract stays consistent across the streaming → seal → commit lifecycle.

## Problem

Streaming Static rendered at col 0; ``end_stream`` committed via ``_write_body`` which wraps the body in ``Padding(_, (0,0,0,7))``. Body visibly jumped 7 cells right at seal time. ``_apply_markdown_swap`` mounted Markdown at col 0 too — same indent mismatch during the brief flash before row removal.

## Fix

DEFAULT_CSS:
```
StreamingRow Static    { padding: 0 0 0 7; ... }
StreamingRow Markdown  { padding: 0 0 0 7; ... }
```

Local ``_BODY_INDENT_COLS = 7`` with comment documenting the cross-module contract with ``conversation._BODY_INDENT_COLS`` (kept local to avoid a back-import cycle).

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: cross-module constant agreement, streaming Static padding=7, sealed Markdown padding=7
- [x] Existing 6 streaming_row perf tests + 40 smoke tests still green

## Wave-9 context

```
✅ D-F8 (#474 merged) / D-F11 (#476 merged) / E-F1 (#477 approved) / E-F2 (#478 approved) / E-F3 (#479)
🆕 F-F1+F6 (P1 S, this PR — bundled, single root cause)
🔄 F-F2 / F-F7 / F-F11 / F-F12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)