### PR TITLE
fix(tui): arm StreamingRow stall indicator from stream open (F-F2)

### DIFF
--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -90,7 +90,17 @@ class StreamingRow(Widget):
         self._mounted = False
         # Cursor blink state
         self._cursor_visible: bool = True
-        self._last_chunk_at: float = 0.0
+        # Wave-9 F-F2: arm the idle timer from stream open (= row
+        # construction). The sticky ``⟳ thinking…`` indicator hides at
+        # ``__stream_start__`` — BEFORE the first token arrives — so a
+        # cold-start LLM that takes 6-20s to deliver its first token
+        # previously left the user with only a blinking cursor and no
+        # "still waiting" cue (= the old ``_last_chunk_at = 0.0``
+        # sentinel disabled the stall calculation until the first chunk
+        # landed). With the timer armed from open, the stall ``  …``
+        # indicator fires at the standard 5s threshold even when the
+        # first chunk is still in flight.
+        self._last_chunk_at: float = monotonic()
         self._cursor_tick_count: int = 0
         # Handle for the 16 ms render-coalescing interval, stored so
         # ``seal()`` can stop it. Without this the timer kept firing at
@@ -151,7 +161,11 @@ class StreamingRow(Widget):
         t.append(self._prefix, style="bold " + _AMBER)
         t.append(self._accumulated)
         if not self._sealed:
-            idle = (monotonic() - self._last_chunk_at) if self._last_chunk_at != 0.0 else 0.0
+            # ``_last_chunk_at`` is armed at construction (F-F2) so this
+            # calculation is always meaningful — no sentinel-zero guard
+            # needed. Idle past 5s shows the stall cue regardless of
+            # whether any token has arrived yet.
+            idle = monotonic() - self._last_chunk_at
             if idle > 5.0:
                 t.append(" …", style="dim")
             else:

--- a/tests/cli/test_streaming_row_stall_arm.py
+++ b/tests/cli/test_streaming_row_stall_arm.py
@@ -1,0 +1,93 @@
+"""Tier 2: StreamingRow arms stall indicator from stream open (F-F2).
+
+Wave-9 Topic F finding F2 (P1): the sticky ``⟳ thinking…``
+indicator hid at ``__stream_start__`` (= before the first token).
+``_last_chunk_at`` was initialised to ``0.0`` as a sentinel, and
+``_build_renderable`` used ``idle = 0.0`` whenever the sentinel
+was unchanged — disabling the stall ``  …`` cue until the first
+token arrived. A cold-start LLM call (6-20s first-token latency
+is realistic for long-context queries) left the user staring at
+only a blinking cursor with no "still waiting" feedback during
+the most expensive part of the call.
+
+After the fix ``_last_chunk_at`` is set to ``monotonic()`` at
+construction so the idle calculation is meaningful from open.
+The standard 5s stall threshold now fires during a slow first
+token too.
+
+Public surfaces tested:
+  - immediately after construction, idle < 5s → cursor (not stall)
+  - back-dating ``_last_chunk_at`` by 6s → stall ``  …`` fires
+  - first ``append()`` then back-dating still triggers stall (= the
+    post-first-token path was already working; this is the regression
+    guard that we didn't break it)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from time import monotonic
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_freshly_constructed_row_renders_cursor_not_stall() -> None:
+    """Tier 2: a new row with no tokens shows the cursor, not the stall cue."""
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+
+    row = StreamingRow(prefix="")
+    rendered = row._build_renderable().plain
+    # Cursor glyph present; stall ellipsis absent.
+    assert "▍" in rendered, (
+        f"new row should render cursor, got plain={rendered!r}"
+    )
+    assert " …" not in rendered, (
+        f"new row should NOT render stall cue (idle < 5s), got: {rendered!r}"
+    )
+
+
+def test_open_with_no_tokens_after_six_seconds_renders_stall_cue() -> None:
+    """Tier 2: 6s of no tokens since open shows the stall ``  …`` cue.
+
+    The fix arms ``_last_chunk_at`` from construction. Back-date it
+    by 6s to simulate "first token still pending after 6s of cold
+    start" without actually sleeping in the test.
+    """
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+
+    row = StreamingRow(prefix="")
+    # Simulate 6s elapsed since open with NO append() ever called.
+    row._last_chunk_at = monotonic() - 6.0
+    rendered = row._build_renderable().plain
+    assert "…" in rendered, (
+        f"6s without first token should fire stall cue, got: {rendered!r}"
+    )
+    assert "▍" not in rendered, (
+        f"stall path should drop the cursor, got: {rendered!r}"
+    )
+
+
+def test_chunk_arrival_resets_idle_timer() -> None:
+    """Tier 2: ``append()`` updates ``_last_chunk_at`` so the cursor returns.
+
+    Pre-fix this branch worked; we keep it as a regression guard so
+    later refactors of the idle path can't silently disable the
+    post-first-token cursor reset.
+    """
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+
+    row = StreamingRow(prefix="")
+    row._last_chunk_at = monotonic() - 6.0  # stall would fire here
+    assert "…" in row._build_renderable().plain
+
+    row.append("hello")  # fresh chunk — _last_chunk_at = monotonic()
+    rendered = row._build_renderable().plain
+    assert "▍" in rendered, (
+        f"after chunk arrival, cursor should return, got: {rendered!r}"
+    )
+    assert " …" not in rendered, (
+        f"stall cue should clear after chunk, got: {rendered!r}"
+    )
+    assert "hello" in rendered


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #7 (F-F2, P1 S). Single-scope: ``_last_chunk_at`` init + idle guard removal.

## Problem

Sticky ``⟳ thinking…`` hides at ``__stream_start__`` — before the first token. ``_last_chunk_at`` was init to ``0.0`` sentinel and ``_build_renderable`` used ``idle = 0.0`` whenever unchanged, disabling stall until the first chunk arrived. Cold-start LLM calls (6-20s first-token latency) showed only a blinking cursor with no "still waiting" cue.

## Fix

Initialize ``_last_chunk_at = monotonic()`` at construction. Drop the sentinel-zero guard in ``_build_renderable``. Stall cue ``  …`` fires at the standard 5s threshold even when the first token is still in flight.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: fresh row → cursor, back-dated 6s → stall, append() resets to cursor
- [x] Existing 6 streaming_row perf tests still green (no behavior change post-first-token)

## Wave-9 context

```
✅ D-F8 / D-F11 (merged) / E-F1 / E-F2 (approved) / E-F3 / F-F1+F6 (in review)
🆕 F-F2 (P1 S, this PR)
🔄 F-F7 / F-F11 / F-F12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)