### PR TITLE
fix(tui): differentiate cancelled partial stream from completed reply (F-F7)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1027,13 +1027,16 @@ class ReynTUIApp(App):
         # end_stream() mutates conv._stream_rows.
         cancelled_streams = 0
         if conv is not None:
-            from rich.text import Text as _RichText
+            # Wave-9 F-F7: route through ``end_stream_cancelled`` so the
+            # partial text gets the dim italic + "✗ cancelled (partial
+            # reply):" header treatment instead of being committed with
+            # the same Markdown styling as a finished reply (with only
+            # a small dim suffix that's easy to miss when the partial
+            # fills the viewport). The summary line emitted below still
+            # reports ``cancelled_streams``.
             for msg_id in list(conv._stream_rows.keys()):
                 try:
-                    conv.end_stream(msg_id)
-                    conv._write_log(
-                        _RichText("  ⌁ cancelled", style="dim italic #888888"),
-                    )
+                    conv.end_stream_cancelled(msg_id)
                     cancelled_streams += 1
                 except Exception:
                     pass

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -823,6 +823,55 @@ class ConversationView(Widget):
             pass
         return full
 
+    def end_stream_cancelled(self, msg_id: str) -> str:
+        """Seal a cancelled stream and write a visually-differentiated partial.
+
+        Wave-9 F-F7: the previous cancel path called ``end_stream``
+        which committed the partial text via the same
+        ``_write_agent_markdown_with_fold`` formatting used for
+        complete replies, then appended a separate ``"  ⌁ cancelled"``
+        suffix line. Scrolling back through history the user couldn't
+        tell which was a cancelled fragment vs a real reply — the
+        partial rendered with full Markdown styling (= bold / headers /
+        code blocks / etc.), and the dim suffix was easy to miss
+        because it sat below the visible region for any reply taller
+        than the viewport.
+
+        The cancelled path now:
+          - emits a clear ``✗ cancelled (partial reply):`` header BEFORE
+            the partial text, in bold dim-red so it sits in the
+            user's eyeline at the top of the fragment
+          - renders the partial body as plain dim italic text (no
+            Markdown). Partial text usually has half-closed code
+            fences / unclosed lists / broken bold spans, so Markdown
+            rendering produced wrong styling anyway — the dim plain
+            text reads as "incomplete fragment".
+
+        The normal ``end_stream`` path is unchanged; only the explicit
+        cancel call site in ``action_cancel_inflight`` routes through
+        here.
+        """
+        row = self._stream_rows.pop(msg_id, None)
+        if row is None:
+            return ""
+        full = row.full_text()
+        row.seal()
+        self.hide_status()
+        if full:
+            try:
+                self._log().write(
+                    Text("✗ cancelled (partial reply):", style="bold #aa6666"),
+                )
+                self._write_body(Text(full, style="dim italic #888888"))
+            except Exception:
+                self._log().write(Text(full))
+        self._log().write(Text(""))
+        try:
+            row.remove()
+        except Exception:
+            pass
+        return full
+
     # ── skill activity rows (C1+A1) ──────────────────────────────────────────
 
     def start_skill_row(

--- a/tests/cli/test_end_stream_cancelled.py
+++ b/tests/cli/test_end_stream_cancelled.py
@@ -1,0 +1,148 @@
+"""Tier 2: cancelled stream renders distinctly from a complete reply (F-F7).
+
+Wave-9 Topic F finding F7 (P1): the old cancel path committed the
+partial accumulated text via ``end_stream`` →
+``_write_agent_markdown_with_fold``, applying the SAME Markdown
+styling used for complete replies. Then a separate
+``"  ⌁ cancelled"`` suffix line was appended. The user couldn't
+tell a cancelled fragment from a finished reply at a glance —
+Markdown rendering applied bold / headers / code blocks to the
+partial (often wrong, since the fragment had half-closed fences),
+and the dim suffix sat below the viewport when the partial filled
+the screen.
+
+The new ``end_stream_cancelled`` path:
+  - writes a bold dim-red ``✗ cancelled (partial reply):`` HEADER
+    BEFORE the partial body, where the user's eye lands first
+  - renders the partial body as plain dim italic text (no Markdown)
+    so half-closed fences don't produce misleading styling
+  - normal completion path (``end_stream``) is unchanged
+
+Public surfaces tested:
+  - cancelled stream produces both the header marker and the dim
+    body text in the conversation log
+  - the partial body does NOT get Markdown rendering (= no inline
+    Markdown widget mounted after cancel)
+  - return value still carries the partial text (= callers like
+    ``action_cancel_inflight`` use this to detect "did any stream
+    cancel" for the summary line)
+  - normal ``end_stream`` (= non-cancelled finalization) is
+    untouched (regression guard)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _richlog_plain(conv) -> str:
+    """Collect the plain text of every line in the RichLog."""
+    log = conv._log()
+    # ``log.lines`` is the list of rendered Strip objects; each has a
+    # ``.text`` property carrying the plain text of that row.
+    lines = []
+    for strip in getattr(log, "lines", []):
+        text = getattr(strip, "text", "")
+        if text:
+            lines.append(text)
+    return "\n".join(lines)
+
+
+@pytest.mark.asyncio
+async def test_end_stream_cancelled_emits_header_and_dim_body() -> None:
+    """Tier 2: cancelled stream commits header + partial body to RichLog."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("cancel-test-id", "test-agent")
+        row.append("# Half-written\n\nThis is a partial reply that ")
+        row.append("the user is about to cancel.")
+        await pilot.pause()
+
+        returned = conv.end_stream_cancelled("cancel-test-id")
+        await pilot.pause()
+
+        # Return value carries the partial text for the caller.
+        assert "partial reply" in returned
+        assert "Half-written" in returned
+
+        log_text = _richlog_plain(conv)
+        # Header marker visible at the top of the fragment.
+        assert "✗ cancelled (partial reply):" in log_text, (
+            f"header marker missing from log; got:\n{log_text!r}"
+        )
+        # Partial body text present.
+        assert "Half-written" in log_text
+        assert "This is a partial reply" in log_text
+
+
+@pytest.mark.asyncio
+async def test_end_stream_cancelled_does_not_render_markdown() -> None:
+    """Tier 2: cancelled partial does NOT route through the Markdown renderer.
+
+    Half-closed fences / unclosed bold / broken lists would render
+    incorrectly under Markdown. The dim plain text reads as "fragment"
+    without misleading styling.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("md-cancel-id", "test-agent")
+        # Half-opened code fence — Markdown would render this badly.
+        row.append("Here is some code:\n```python\ndef foo():")
+        await pilot.pause()
+
+        conv.end_stream_cancelled("md-cancel-id")
+        await pilot.pause()
+
+        log_text = _richlog_plain(conv)
+        # Raw fragment text should be present verbatim — fence markers
+        # included — because we skipped Markdown rendering.
+        assert "```python" in log_text or "def foo()" in log_text, (
+            f"partial fence text should appear in raw form, got:\n{log_text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_end_stream_unchanged_for_completed_reply() -> None:
+    """Tier 2: normal completion still commits with Markdown styling.
+
+    Regression guard: only the cancel path was changed. A successful
+    finish must continue to produce a real Markdown render with no
+    "cancelled (partial reply)" header.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("normal-end-id", "test-agent")
+        row.append("This is a complete reply.")
+        await pilot.pause()
+
+        conv.end_stream("normal-end-id")  # NOT end_stream_cancelled
+        await pilot.pause()
+
+        log_text = _richlog_plain(conv)
+        # The cancellation header must NOT appear.
+        assert "cancelled (partial reply)" not in log_text, (
+            f"normal end_stream should not emit cancel header, got:\n{log_text!r}"
+        )
+        # The reply text itself is present.
+        assert "complete reply" in log_text


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #8 (F-F7, P1 S). Single-scope: new ``end_stream_cancelled`` method + cancel-path callsite swap.

## Problem

Cancel path committed partial text via the same ``_write_agent_markdown_with_fold`` path as a complete reply. Markdown styling applied to fragments (often misleading — half-closed fences render wrong). Dim ``"  ⌁ cancelled"`` suffix sat below the viewport when the partial filled the screen.

## Fix

New ``ConversationView.end_stream_cancelled(msg_id)``:
- Bold dim-red ``✗ cancelled (partial reply):`` HEADER before the body
- Plain dim italic body (no Markdown) → fences / unclosed styling don't mislead

``action_cancel_inflight`` routes through the new method. Normal ``end_stream`` path untouched.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: header + dim body emitted, no Markdown rendering on cancel, normal end_stream unaffected
- [x] Existing 6 streaming_row perf tests + 40 smoke tests still green

## Wave-9 context

```
✅ D-F8 / D-F11 (merged) / E-F1 / E-F2 (approved) / E-F3 / F-F1+F6 / F-F2 (in review)
🆕 F-F7 (P1 S, this PR)
🔄 F-F11 / F-F12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)