### PR TITLE
fix(tui): auto-scroll StreamingRow into view as content grows (F-F11)

### DIFF
--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -129,6 +129,14 @@ class StreamingRow(Widget):
         # of the session — a 20-turn dogfood produced 20 × 60 = 1200 dead
         # callbacks/s on the event loop.
         self._interval_handle = None  # type: ignore[assignment]
+        # Wave-9 F-F11: set when ``append()`` adds tokens (= the row's
+        # rendered height may grow). Consumed by ``_flush_render`` to
+        # gate the ``scroll_visible`` call so we only scroll on actual
+        # content growth, not on cursor-blink ticks. Without the gate
+        # the row would scroll-into-view 60 times per second during
+        # idle blink — wasted work and a potential fight with the
+        # user's intentional scroll-up.
+        self._height_dirty: bool = False
 
     def compose(self) -> ComposeResult:
         self._static = Static(id="streaming_text")
@@ -160,6 +168,23 @@ class StreamingRow(Widget):
         if self._dirty and self._static is not None:
             self._dirty = False
             self._static.update(self._build_renderable())
+            # Wave-9 F-F11: keep the growing row visible. ``StreamingRow``
+            # is mounted as a sibling of the RichLog (not as a log line),
+            # and ``RichLog.auto_scroll`` doesn't track sibling height
+            # changes. On a short conversation the row's bottom slips
+            # below the viewport as tokens wrap onto new lines, forcing
+            # the user to manually scroll to see new content arrive.
+            # ``scroll_visible`` walks up to the nearest scrollable
+            # ancestor and brings this row into view. Gated by
+            # ``_height_dirty`` so cursor-blink ticks (= rendered output
+            # changed but height did NOT) don't fire 60 redundant
+            # scroll calls per second.
+            if self._height_dirty:
+                self._height_dirty = False
+                try:
+                    self.scroll_visible(animate=False)
+                except Exception:
+                    pass
 
     def _stop_interval(self) -> None:
         """Cancel the 16 ms render-coalescing interval, if running.
@@ -229,6 +254,11 @@ class StreamingRow(Widget):
         # of chunks on every render tick.
         self._accumulated += text
         self._dirty = True
+        # Wave-9 F-F11: mark the row's height as "may have grown" so the
+        # next ``_flush_render`` triggers ``scroll_visible``. Set here
+        # (= where new tokens actually arrive) rather than on every
+        # cursor blink, so idle re-renders don't spam scroll calls.
+        self._height_dirty = True
 
     def seal(self) -> None:
         """Mark the stream as complete and swap to a Markdown widget.

--- a/tests/cli/test_streaming_row_scroll_visible.py
+++ b/tests/cli/test_streaming_row_scroll_visible.py
@@ -1,0 +1,152 @@
+"""Tier 2: StreamingRow scrolls itself into view as content grows (F-F11).
+
+Wave-9 Topic F finding F11 (P1): StreamingRow mounts as a sibling
+of the RichLog (not as a log line), and ``RichLog.auto_scroll``
+only tracks the log's own lines. As tokens wrap and the row grows,
+the bottom of the row slips below the viewport on a short
+conversation — the user must manually scroll to see new tokens
+arrive, defeating the purpose of streaming UX.
+
+``_flush_render`` now calls ``self.scroll_visible(animate=False)``
+when the row's content actually grew (= ``_height_dirty`` set by
+``append``). Cursor-blink ticks that re-render but don't change
+height are gated out so we don't fire 60 redundant scroll calls
+per second during idle.
+
+Public surfaces tested:
+  - ``append()`` sets ``_height_dirty`` (= the next flush will scroll)
+  - ``_flush_render`` calls ``scroll_visible`` once per append cycle
+  - cursor-blink rerenders without a preceding ``append`` do NOT call
+    ``scroll_visible`` (regression guard against the 60 Hz spam path)
+  - ``scroll_visible`` exceptions are swallowed (= the row keeps
+    rendering even when no scrollable ancestor exists)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_append_marks_height_dirty() -> None:
+    """Tier 2: ``append()`` flips ``_height_dirty`` so the next flush scrolls."""
+    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+
+    row = StreamingRow(prefix="")
+    assert row._height_dirty is False
+    row.append("hello")
+    assert row._height_dirty is True
+
+
+@pytest.mark.asyncio
+async def test_flush_render_calls_scroll_visible_once_per_append_cycle() -> None:
+    """Tier 2: scroll_visible is invoked exactly once per append + flush."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("scroll-test-id", "test-agent")
+        await pilot.pause()
+
+        calls: list[None] = []
+        original = row.scroll_visible
+
+        def _spy(**kwargs) -> None:  # type: ignore[no-untyped-def]
+            calls.append(None)
+            return original(**kwargs)
+
+        row.scroll_visible = _spy  # type: ignore[method-assign]
+
+        # Reset (the row may have flushed during begin_stream).
+        calls.clear()
+        row._height_dirty = False
+
+        row.append("hello world")
+        assert row._height_dirty is True
+        row._flush_render()
+        assert len(calls) == 1, (
+            f"flush after append should call scroll_visible once, "
+            f"got {len(calls)}"
+        )
+        # After flush, the flag is consumed.
+        assert row._height_dirty is False
+
+
+@pytest.mark.asyncio
+async def test_cursor_blink_alone_does_not_call_scroll_visible() -> None:
+    """Tier 2: idle cursor-blink rerenders don't spam scroll_visible.
+
+    The blink path sets ``_dirty`` to retrigger the static update but
+    must NOT set ``_height_dirty`` — the row's rendered height doesn't
+    change when only the cursor character toggles.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("blink-test-id", "test-agent")
+        await pilot.pause()
+
+        calls: list[None] = []
+        original = row.scroll_visible
+
+        def _spy(**kwargs) -> None:  # type: ignore[no-untyped-def]
+            calls.append(None)
+            return original(**kwargs)
+
+        row.scroll_visible = _spy  # type: ignore[method-assign]
+        calls.clear()
+        row._height_dirty = False
+
+        # Drive enough flush ticks to cross a cursor-blink boundary
+        # (= every 30 flushes, see ``_flush_render``). The row has not
+        # received any ``append`` calls, so each flush is a pure blink
+        # re-render.
+        for _ in range(35):
+            row._flush_render()
+        assert calls == [], (
+            f"cursor-blink-only flushes should not call scroll_visible, "
+            f"got {len(calls)} calls"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scroll_visible_exception_is_swallowed() -> None:
+    """Tier 2: a ``scroll_visible`` exception does not break the flush.
+
+    If the row has no scrollable ancestor (= rare; pre-mount in some
+    test harnesses), the call may raise. The bare ``try / except``
+    must let the static update path proceed.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("err-test-id", "test-agent")
+        await pilot.pause()
+
+        def _explode(**kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("no scrollable ancestor")
+
+        row.scroll_visible = _explode  # type: ignore[method-assign]
+
+        row.append("payload")
+        # Must not raise.
+        row._flush_render()
+        # And the underlying text was still committed to the Static
+        # (= rendering path completed).
+        assert "payload" in row.full_text()


### PR DESCRIPTION
**[tui-coder]** — wave-9 PR #10 / final (F-F11, P1 M). Single-scope: ``StreamingRow._flush_render`` + new ``_height_dirty`` gate.

## Problem

StreamingRow is a sibling of RichLog, not a log line. ``RichLog.auto_scroll`` doesn't track sibling height. As tokens wrap and the row grows on a short conversation, the bottom slips below the viewport — user must manually scroll.

## Fix

``_flush_render`` calls ``self.scroll_visible(animate=False)`` when the row's height actually grew. New ``_height_dirty`` flag set by ``append()``, consumed once per flush — keeps the steady-state scroll-call rate at one-per-append-cycle (not 60 Hz cursor-blink).

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests: ``append`` sets flag, flush calls ``scroll_visible`` once per append, 35 cursor-blink flushes fire zero scroll calls (regression guard), exception is swallowed
- [x] Existing 6 streaming_row perf tests + 40 smoke tests still green

## Wave-9 final progression

```
✅ D-F8 / D-F11 (merged) / E-F1 / E-F2 (approved) / E-F3 / F-F1+F6 / F-F2 / F-F7 / F-F12 (in review)
🆕 F-F11 (P1 M, this PR — final of top 10)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)