### PR TITLE
fix(eval): spec_path nullable + python step tolerates None bus (closes B49 W2-S5)

### DIFF
--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -420,12 +420,17 @@ class PreprocessorExecutor:
         # Resolve permission for this (module, function). Without a resolver
         # (e.g. unit tests), default to a permissive pure-mode entry.
         if self._perm is not None:
-            if self._intervention_bus is None:
-                raise PreprocessorError(
-                    f"Phase '{phase_name}' preprocessor step[{index}] python: "
-                    f"intervention_bus not configured (cannot prompt for "
-                    f"python.{step.module}:{step.function})"
-                )
+            # B49 W2-S5 fix (2026-05-22): pass intervention_bus as-is; it
+            # may be None in non-interactive contexts (= preprocessor /
+            # postprocessor python step invoked from a sub-skill run).
+            # ``PermissionResolver._approve`` already returns True early
+            # when the permission is config-approved (= reyn.yaml
+            # ``python.safe: allow``) or session/saved-approved, without
+            # touching the bus. The pre-check that raised unconditionally
+            # blocked the config-approved path too. ``require_python``'s
+            # PermissionError still raises when interactive prompt is
+            # genuinely required but the bus is missing — see
+            # PermissionResolver._approve / _prompt for the routing.
             try:
                 perm = await self._perm.require_python(
                     self._skill.permissions, step.module, step.function,

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -431,11 +431,16 @@ class RunOrchestrator:
         Raises WorkflowAbortedError on unrecoverable LLM abort.
         """
         if self._perm:
-            if self._intervention_bus is None:
-                raise RuntimeError(
-                    "permission_resolver requires intervention_bus on OSRuntime; "
-                    "wire one via Agent(intervention_bus=...)"
-                )
+            # B49 W2-S5 fix (2026-05-22): pass intervention_bus as-is; it
+            # may be None in non-interactive contexts (= preprocessor
+            # sub-skill runs invoked via ``run_skill`` op from inside
+            # ``iterate`` / ``run_op``). ``startup_guard`` handles the
+            # None case: if all permissions are already approved it
+            # returns early without using the bus; if unapproved
+            # permissions are found it raises ``RuntimeError`` with a
+            # clear message. This removes the pre-check that blocked
+            # sub-skills invoked from preprocessors whenever
+            # permission_resolver was set.
             await self._perm.startup_guard(
                 self._skill, self._skill.name, self._intervention_bus,
             )

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -515,7 +515,7 @@ class PermissionResolver:
         return await self._prompt_file_access(path, scope, skill_name, "file.write", bus)
 
     async def startup_guard(
-        self, skill: "Skill", skill_name: str, bus: RequestBus,
+        self, skill: "Skill", skill_name: str, bus: "RequestBus | None",
     ) -> None:
         """
         Pre-flight permission check: scan all phase declarations, collect paths that
@@ -525,6 +525,21 @@ class PermissionResolver:
         Non-interactive runs require approvals to be in place beforehand: either
         pre-approved in reyn.yaml / reyn.local.yaml (layer 3) or persisted to
         .reyn/approvals.yaml from a prior interactive run (layer 2).
+
+        B49 W2-S5 fix (2026-05-22): ``bus`` may be ``None`` when the caller
+        is a non-interactive context (e.g. a preprocessor sub-skill run
+        invoked via ``run_skill`` op from inside ``iterate`` /
+        ``run_op``). If all permissions are already approved or the skill
+        declares none that need approval, the guard returns without using
+        the bus. If unapproved permissions are found and ``bus is None``,
+        a ``RuntimeError`` is raised with a clear message naming the
+        pending permissions so the caller can surface the
+        mis-configuration. Previously, ``run_orchestrator`` had an
+        unconditional pre-check ``if intervention_bus is None: raise``
+        that blocked any preprocessor sub-skill call when the resolver
+        was configured, regardless of whether prompts were actually
+        needed; that pre-check is removed and the None-handling moves
+        here, where it can branch on actual prompt necessity.
         """
         write_requests: list[dict] = []
         read_requests: list[dict] = []
@@ -610,6 +625,25 @@ class PermissionResolver:
 
         if not (write_requests or read_requests or python_requests):
             return
+
+        # B49 W2-S5 fix (2026-05-22): bus may be None in non-interactive
+        # contexts (= preprocessor sub-skill run). If we reach here,
+        # prompts are needed but no bus is available — surface a clear
+        # error rather than silently skipping approvals or crashing
+        # inside _prompt_*.
+        if bus is None:
+            pending = (
+                [f"file.read:{r['path']}" for r in read_requests]
+                + [f"file.write:{r['path']}" for r in write_requests]
+                + [f"python:{r['module']}:{r['function']}" for r in python_requests]
+            )
+            raise RuntimeError(
+                f"Skill '{skill_name}' has unapproved permissions "
+                f"({', '.join(pending)}) but no intervention_bus is "
+                f"available to prompt the user. Pre-approve via "
+                f"reyn.yaml or an interactive run before using this "
+                f"skill non-interactively."
+            )
 
         for req in read_requests:
             await self._prompt_file_access(
@@ -926,7 +960,7 @@ class PermissionResolver:
 
     async def require_python(
         self, decl: PermissionDecl, module: str, function: str,
-        bus: RequestBus,
+        bus: "RequestBus | None",
         skill_name: str = "",
     ) -> PythonPermission:
         """Resolve which python permission entry applies; raise if denied.
@@ -935,6 +969,16 @@ class PermissionResolver:
         startup_guard approval (saved per skill+module:function). Unsafe-mode
         steps additionally require unsafe_python_allowed=True (set by the
         --allow-unsafe-python CLI flag).
+
+        B49 W2-S5 fix (2026-05-22): ``bus`` may be ``None`` in
+        non-interactive contexts (= preprocessor / postprocessor python
+        step invoked from a sub-skill run). ``_approve`` short-circuits
+        before reaching the prompt path when the permission is
+        config-approved or saved/session-approved, so the bus is only
+        consulted when an interactive prompt is genuinely required.
+        With ``self._interactive=False`` and no prior approval,
+        ``_approve`` returns False without touching the bus, and this
+        method raises PermissionError as before.
         """
         matching = [
             p for p in decl.python

--- a/src/reyn/stdlib/skills/eval/artifacts/case_run_result.yaml
+++ b/src/reyn/stdlib/skills/eval/artifacts/case_run_result.yaml
@@ -7,8 +7,12 @@ schema:
       type: string
       description: Name of the test case that was run.
     spec_path:
-      type: string
-      description: Path to the eval.md spec (passed through for final output).
+      # B49 W2-S5 fix (2026-05-22): nullable to mirror eval_result_raw —
+      # the LLM emits null when the input did not carry a spec_path.
+      type: [string, "null"]
+      description: |
+        Path to the eval.md spec (passed through for final output).
+        Null when the input did not carry a spec_path.
     run_status:
       type: string
       description: Status returned by the target skill run ('finished', 'loop_limit_exceeded', 'aborted', etc.).
@@ -25,4 +29,9 @@ schema:
             type: object
             description: phase_eval_request data (phase_name, artifact_type, artifact_path, criteria).
         required: [type, data]
-  required: [case_name, spec_path, run_status, eval_requests]
+  # B49 W2-S5 fix (2026-05-22): spec_path is pass-through only — the
+  # LLM emits null when no spec file was provided (= direct chat eval).
+  # Same pattern already applied to eval_result_raw via PR #403. Removing
+  # from required so validation does not fail on null; field stays in
+  # properties so the LLM can still fill it when known.
+  required: [case_name, run_status, eval_requests]

--- a/src/reyn/stdlib/skills/eval/artifacts/eval_result_raw.yaml
+++ b/src/reyn/stdlib/skills/eval/artifacts/eval_result_raw.yaml
@@ -45,8 +45,16 @@ schema:
         string when no phases were evaluated (e.g. the target skill failed
         before producing artifacts).
     spec_path:
-      type: string
-      description: Path to the eval spec being run (passed through from input).
+      # B49 W2-S5 fix (2026-05-22): allow null because the LLM emits
+      # null when no spec file was provided (= direct chat eval).
+      # Required-list removal in PR #403 alone was insufficient because
+      # this property-level type constraint still rejected null. Same
+      # nullable shape applied to case_run_result.yaml in the same PR.
+      type: [string, "null"]
+      description: |
+        Path to the eval spec being run (passed through from input).
+        Null when the input did not carry a spec_path (= direct chat
+        eval without a spec.md reference).
     summary:
       type: string
       description: |


### PR DESCRIPTION
**[dogfood-coder]** — B49 W2-S5 (\`eval_run_direct_llm\`) had **two structural OS bugs** producing a vacuous "no phases evaluated" pass:

1. **Schema-contract mismatch on \`spec_path\`** — the eval skill's \`evaluate\` phase emits \`spec_path: null\` when no spec file was provided (= direct chat eval), but \`eval_result_raw.yaml\` declared \`spec_path: {type: string}\`. JSON Schema rejects null → validation_error → phase retry consumes act budget → empty \`criteria_results\`. PR #403 removed \`spec_path\` from \`required\` but the type constraint still rejected null.

2. **Postprocessor python step required intervention_bus** — \`preprocessor_executor._apply_python\` had an unconditional pre-check that raised when bus was None. Eval's postprocessor (\`compute_score\`, \`python.safe\` config-approved via \`python.safe: allow\`) runs from a non-interactive sub-skill context (= no bus), but the pre-check aborted before reaching the config-approval short-circuit inside \`PermissionResolver._approve\`.

Both are OS structural bugs (= reproduce in every eval-from-chat invocation + every non-interactive sub-skill python step path).

## Changes

| File | Change |
|------|--------|
| \`src/reyn/stdlib/skills/eval/artifacts/eval_result_raw.yaml\` | \`spec_path.type: string → [string, "null"]\` |
| \`src/reyn/stdlib/skills/eval/artifacts/case_run_result.yaml\` | same nullable + \`required\` already minus \`spec_path\` |
| \`src/reyn/kernel/preprocessor_executor.py\` | drop unconditional \`intervention_bus is None: raise\` pre-check; \`require_python\` short-circuits on config/saved/session approval before touching the bus |
| \`src/reyn/permissions/permissions.py\` | \`require_python\` + \`startup_guard\` accept \`bus: RequestBus \| None\`; explicit RuntimeError when interactive prompt is required but bus is missing |
| \`src/reyn/kernel/run_orchestrator.py\` | drop the symmetric pre-check (= same delegation pattern) |

## Live retest (= pre-PR per \`feedback_retest_before_pr_open\`)

N=3 against branch HEAD \`3a16aab1\`:

| shot | validation_error | control_ir_failed | criteria_results | verdict |
|------|------------------|-------------------|------------------|---------|
| 1 | **false** | **false** | 1 | V (score=1.0, criterion met=true) |
| 2 | false | false | 1 | V (workflow_finished, confidence=1.0) |
| 3 | false | false | 1 | V (criteria_results + passed in final_output) |

- **v_rate: 3/3** ✓
- B49 baseline: R (= validation_error + control_ir_failed + empty criteria_results)
- **delta: +3V**
- Original attractor (= 2 structural bugs) disappeared 3/3.

Note: shots 2/3 had a router_empty_response_detected on the first invocation (= LLM routing noise unrelated to this fix); retried with same canonical prompt and both routed correctly. Structural fix is robust; LLM routing noise is a separate behaviour issue.

## Test plan

- [x] \`pytest -k "eval or permission or preprocessor or run_orchestrator"\` — 256 pass.
- [x] Live retest N=3 — both layers' attractors disappear; eval completes substantively.
- [ ] post-merge: B50 retest confirms W2-S5 V holds across broader scenario mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)