### PR TITLE
fix(tui): clear() sweeps in-flight ToolCallRow widgets (G-F1)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1613,6 +1613,31 @@ class ConversationView(Widget):
             except Exception:
                 pass
         self._error_boxes.clear()
+        # Wave-10 G-F1: sweep in-flight ToolCallRow widgets too. They
+        # share the same "child of ConversationView, not a RichLog
+        # line" mounting model as ErrorBox / StreamingRow / SkillActivityRow,
+        # so ``_log().clear()`` doesn't unmount them. Without this loop:
+        #   - the row widgets stay on screen as orphans on the now-blank
+        #     pane (= same visual artefact ErrorBox suffered before its
+        #     sweep was added)
+        #   - ``_tool_call_rows`` still carries the stale op_id keys, so
+        #     when the in-flight tool finally completes,
+        #     ``complete_tool_call_row`` / ``fail_tool_call_row`` pops
+        #     the dict entry and calls ``row.remove()`` against an
+        #     already-orphaned widget → Textual DOM exception swallowed
+        #     by the bare ``except Exception: pass`` in the caller.
+        # We use ``finish_aborted("cleared")`` rather than a bare
+        # ``remove()`` so the row briefly renders its ⊘ terminal state
+        # before the parent ``clear()`` blanks the log — matches the
+        # ``_skill_rows`` ``finish(reason="cleared")`` idiom directly
+        # above.
+        for row in list(self._tool_call_rows.values()):
+            try:
+                row.finish_aborted("cleared")
+                row.remove()
+            except Exception:
+                pass
+        self._tool_call_rows.clear()
         # Reset header-grouping + turn anchors + fold stash
         self._last_speaker = ""
         self._last_speaker_at = 0.0

--- a/tests/cli/test_conv_clear_sweeps_tool_call_rows.py
+++ b/tests/cli/test_conv_clear_sweeps_tool_call_rows.py
@@ -1,0 +1,127 @@
+"""Tier 2: ConversationView.clear() sweeps in-flight ToolCallRow widgets (G-F1).
+
+Wave-10 Topic G finding F1 (P1): ``clear()`` (= Ctrl+L) swept
+``_stream_rows``, ``_skill_rows``, and ``_error_boxes`` but NOT
+``_tool_call_rows``. Tool-call widgets are mounted as direct
+children of ConversationView (not lines in the RichLog), so
+``_log().clear()`` doesn't unmount them. Two visible failures
+followed:
+
+  - the widget stayed on screen as an orphan over the now-blank
+    pane (= same visual artefact ErrorBox had before its sweep was
+    added)
+  - ``_tool_call_rows`` still carried the stale op_id key, so when
+    the in-flight tool completed, ``complete_tool_call_row`` /
+    ``fail_tool_call_row`` popped the dict entry and called
+    ``row.remove()`` against an already-orphaned widget → silent
+    Textual DOM exception
+
+After the fix ``clear()`` removes every ToolCallRow via
+``finish_aborted("cleared") + remove()`` and empties the dict.
+
+Public surfaces tested:
+  - in-flight ToolCallRow is removed from the DOM after clear()
+  - the ``_tool_call_rows`` dict is empty after clear()
+  - subsequent ``complete_tool_call_row`` for the now-orphaned
+    op_id does NOT raise (= dict pop returns None, idempotent)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_in_flight_tool_call_widgets() -> None:
+    """Tier 2: after clear() the DOM has no ToolCallRow children."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row(
+            op_id="op-clear-1",
+            tool_name="file__read",
+            args_repr="path=/tmp/x",
+        )
+        await pilot.pause()
+        # Sanity: the row is mounted + tracked.
+        assert app.query(ToolCallRow), (
+            "test scaffolding broken — ToolCallRow should be mounted"
+        )
+        assert "op-clear-1" in conv._tool_call_rows
+
+        conv.clear()
+        await pilot.pause()
+
+        assert not app.query(ToolCallRow), (
+            "ToolCallRow widget should be removed from DOM after clear()"
+        )
+        assert not conv._tool_call_rows, (
+            f"_tool_call_rows dict should be empty after clear(), "
+            f"got {list(conv._tool_call_rows.keys())!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_completion_after_clear_does_not_raise() -> None:
+    """Tier 2: stale op_id completion is a no-op (idempotent).
+
+    Pre-fix the dict entry survived clear(), so a late
+    ``complete_tool_call_row`` would call ``row.remove()`` against
+    an orphaned widget → exception. The dict-pop-returns-None
+    pattern means a late completion now silently returns.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_tool_call_row(
+            op_id="op-late-completion",
+            tool_name="file__read",
+            args_repr="path=/tmp/x",
+        )
+        await pilot.pause()
+
+        conv.clear()
+        await pilot.pause()
+
+        # Late completion for the cleared op must not raise.
+        conv.complete_tool_call_row(
+            op_id="op-late-completion",
+            result_snippet="status=ok",
+        )
+        await pilot.pause()
+        # Dict stays empty.
+        assert "op-late-completion" not in conv._tool_call_rows
+
+
+@pytest.mark.asyncio
+async def test_clear_with_no_tool_call_rows_is_no_op_safe() -> None:
+    """Tier 2: clear() on a session with zero ToolCallRows still completes.
+
+    Regression guard for ``for row in list({}.values())`` empty-iter.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No tool calls created — just clear.
+        conv.clear()
+        await pilot.pause()
+        assert conv._tool_call_rows == {}


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #1 (G-F1, P1 S). Single-scope: ``ConversationView.clear()`` tool-call sweep loop.

## Problem

``clear()`` swept ``_stream_rows`` / ``_skill_rows`` / ``_error_boxes`` but missed ``_tool_call_rows``. After Ctrl+L on an in-flight tool call:
- the widget stayed on screen as an orphan over the blank pane
- the stale ``op_id`` in the dict caused ``complete_tool_call_row`` to call ``remove()`` on an already-orphaned widget → silent DOM exception

## Fix

Add a sweep loop mirroring ``_skill_rows`` pattern: ``finish_aborted("cleared")`` + ``remove()`` + dict ``.clear()``.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: widget removed from DOM, dict empty after clear, late completion is no-op
- [x] Existing 40 smoke tests still green

## Wave-10 context

```
🆕 G-F1 (P1 S, this PR)
🔄 G-F2 / G+I-F8 (bundle) / G-F3 / G-F4 / G-F5 / G-F10 / H-F2 / H-F1 / I-F1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)