### PR TITLE
fix(tui): clear() removes mounted InterventionWidget children (G-F2)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1654,6 +1654,22 @@ class ConversationView(Widget):
             except Exception:
                 pass
         self._tool_call_rows.clear()
+        # Wave-10 G-F2: sweep any pending InterventionWidget children too.
+        # ``mount_intervention`` adds the widget via ``self.mount(widget)``
+        # with no tracking list, so the only way to find them at clear()
+        # time is ``self.query(InterventionWidget)``. Without this sweep,
+        # a Ctrl+L while an intervention modal is open leaves the chip
+        # buttons floating on a blank pane — the user can still "answer"
+        # the question, firing the answer_callback against a session
+        # context the user just cleared (= acting on stale UI state). The
+        # sticky ``⚑ intervention below ↓`` set by ``mount_intervention``
+        # is already hidden by the ``hide_status`` call below; this loop
+        # removes the visible widget too.
+        for widget in list(self.query(InterventionWidget)):
+            try:
+                widget.remove()
+            except Exception:
+                pass
         # Reset header-grouping + turn anchors + fold stash
         self._last_speaker = ""
         self._last_speaker_at = 0.0

--- a/tests/cli/test_conv_clear_sweeps_intervention_widgets.py
+++ b/tests/cli/test_conv_clear_sweeps_intervention_widgets.py
@@ -1,0 +1,83 @@
+"""Tier 2: ConversationView.clear() removes mounted InterventionWidget (G-F2).
+
+Wave-10 Topic G finding F2 (P1): ``clear()`` swept
+``_stream_rows`` / ``_skill_rows`` / ``_error_boxes`` /
+(post-G-F1) ``_tool_call_rows``, but missed
+``InterventionWidget``. ``mount_intervention`` adds the widget
+via ``self.mount(widget)`` with no tracking list. After Ctrl+L
+the widget stayed on the now-blank pane and the user could still
+click chip buttons → fired the answer_callback against a session
+context they just cleared (= acting on stale UI state).
+
+``clear()`` now queries ``self.query(InterventionWidget)`` and
+removes each, mirroring the ErrorBox sweep directly above. No
+tracking list is added — the per-clear ``query`` cost is
+negligible compared with the ``log.clear()`` call right next to
+it.
+
+Public surfaces tested:
+  - InterventionWidget present before clear() is gone after
+  - clear() with no intervention mounted is a no-op (regression
+    guard for the empty-query path)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_pending_intervention_widget() -> None:
+    """Tier 2: clear() unmounts a pending InterventionWidget."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_intervention(
+            question="proceed?",
+            choices=[{"label": "[y]es", "id": "yes", "hotkey": "y"}],
+            iv_id="iv-clear-test",
+        )
+        await pilot.pause()
+        # Sanity: widget mounted before clear.
+        assert app.query(InterventionWidget), (
+            "test scaffolding broken — InterventionWidget should be mounted"
+        )
+
+        conv.clear()
+        await pilot.pause()
+
+        assert not app.query(InterventionWidget), (
+            "InterventionWidget should be removed from DOM after clear()"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clear_with_no_intervention_is_safe() -> None:
+    """Tier 2: clear() with no intervention mounted completes without error.
+
+    Regression guard: the ``for widget in list(self.query(...))`` empty
+    iteration must not raise.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.intervention import InterventionWidget
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        assert not app.query(InterventionWidget)
+        conv.clear()  # must not raise
+        await pilot.pause()
+        assert not app.query(InterventionWidget)


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #2 (G-F2, P1 S). Single-scope: ``ConversationView.clear()`` InterventionWidget sweep.

## Problem

``mount_intervention`` calls ``self.mount(widget)`` with no tracking list. ``clear()`` had no sweep for it, so Ctrl+L left the widget mounted on the blank pane — user could click chip buttons against an already-cleared session context.

## Fix

``for widget in list(self.query(InterventionWidget)): widget.remove()`` — same idiom as the ErrorBox sweep right above it. No tracking list added (per-clear query is cheap; keeps the mount / resolve paths untouched).

## Test plan

- [x] ruff check passes
- [x] 2 new Tier 2 tests: widget unmounted after clear, no-intervention case is safe (regression guard)
- [x] Existing 40 smoke tests still green

## Wave-10 context

```
✅ G-F1 (#487 in review)
🆕 G-F2 (P1 S, this PR)
🔄 G+I-F8 / G-F3 / G-F4 / G-F5 / G-F10 / H-F2 / H-F1 / I-F1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)