### PR TITLE
fix(tui): StickyStatus overwrite priority + trim-warning log line (G-F8+I-F8)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1359,11 +1359,21 @@ class ConversationView(Widget):
         return [a - start for a in self._turn_anchors if a - start >= 0]
 
     def _maybe_warn_about_trimmed_history(self, log: RichLog) -> None:
-        """Surface a one-shot dim status when older history has been trimmed.
+        """Surface a one-shot warning when older history has been trimmed.
 
         We only fire once per session — repeated Ctrl+P presses past the
-        top would otherwise spam the sticky status with the same message.
-        ``/clear`` resets the flag so a fresh session can warn again.
+        top would otherwise spam the message. ``/clear`` resets the
+        flag so a fresh session can warn again.
+
+        Wave-10 G-F8: the warning previously wrote ONLY to the sticky
+        status. The same call stack then invoked ``_flash_turn_position``
+        which overwrote the sticky with ``↑ turn 1 / N`` before the user
+        could read the warning — effectively making it invisible. The
+        sticky path is kept as a glance-cue, but the load-bearing
+        record now lives in the log as a permanent dim line so the user
+        can find it in scrollback even after the sticky has been
+        replaced. Same idiom as ``_render_system_message`` for one-shot
+        notices that must survive subsequent sticky updates.
         """
         if self._trim_warned:
             return
@@ -1371,13 +1381,19 @@ class ConversationView(Widget):
         if start <= 0:
             return
         self._trim_warned = True
+        warning_text = f"↑ earlier history trimmed ({start:,} lines)"
+        # Permanent log line — survives the turn-flash sticky overwrite.
+        try:
+            self._write_log(Text(f"  {warning_text}", style="dim italic #888888"))
+        except Exception:
+            pass
+        # Sticky glance-cue — may be overwritten by the next status
+        # update, but useful at the moment the user actually hit the
+        # boundary.
         sticky = self._sticky()
         if sticky is not None:
             try:
-                sticky.show(
-                    f"↑ earlier history trimmed ({start:,} lines)",
-                    kind="general",
-                )
+                sticky.show(warning_text, kind="general")
             except Exception:
                 pass
 

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -29,6 +29,33 @@ _GLYPHS: dict[str, str] = {
     "general": "●",
 }
 
+# Wave-10 G-F8 + I-F8: overwrite-priority hierarchy.
+#
+# ``show()`` was previously unconditional — a low-priority transient
+# (turn-position breadcrumb, boundary hint) would silently overwrite
+# a load-bearing live indicator (``⟳ thinking…``). Two visible
+# failures resulted:
+#
+#   - I-F8: Ctrl+P / Ctrl+N during an LLM call replaced the ⟳ thinking
+#     indicator with ``↑ turn 3 / 8``, making the agent appear frozen
+#     until the next outbox event arrived.
+#   - G-F8: ``_maybe_warn_about_trimmed_history`` wrote to the sticky,
+#     then ``_flash_turn_position`` fired in the same call frame and
+#     overwrote the warning before the user could read it — the
+#     trim-warning was effectively invisible.
+#
+# This map gives each ``kind`` a numeric priority. ``show()`` suppresses
+# its own call when the requested ``kind`` is LOWER than the currently
+# active ``kind``. Same-or-higher priority overwrites freely (= the
+# expected behaviour for genuine status updates, e.g. ``thinking`` →
+# ``thinking`` body update).
+_KIND_PRIORITY: dict[str, int] = {
+    # Live load-bearing state — must not be displaced by transients.
+    "thinking": 100,
+    # Transient flashes / breadcrumbs / one-shot notices.
+    "general": 50,
+}
+
 
 class StickyStatus(Static):
     """A 1-line sticky status bar with a live elapsed timer.
@@ -74,8 +101,24 @@ class StickyStatus(Static):
     # ── public API ────────────────────────────────────────────────────────────
 
     def show(self, text: str, kind: str = "thinking") -> None:
-        """Activate the status bar with the given body text and glyph kind."""
-        self._kind = kind if kind in _GLYPHS else "thinking"
+        """Activate the status bar with the given body text and glyph kind.
+
+        Wave-10 G-F8 + I-F8: when the sticky is already active with a
+        higher-priority ``kind``, a lower-priority ``show()`` is
+        silently suppressed (= the call is a no-op). This protects
+        load-bearing live indicators (``⟳ thinking…``) from being
+        displaced by transient breadcrumbs (turn-position flash,
+        boundary hint). Same-or-higher priority overwrites freely.
+
+        ``hide()`` is unconditional — explicit dismissal always wins.
+        """
+        new_kind = kind if kind in _GLYPHS else "thinking"
+        if self._active:
+            current_priority = _KIND_PRIORITY.get(self._kind, 0)
+            new_priority = _KIND_PRIORITY.get(new_kind, 0)
+            if new_priority < current_priority:
+                return
+        self._kind = new_kind
         self._glyph = _GLYPHS[self._kind]
         self._start = time.monotonic()
         self._active = True

--- a/tests/cli/test_sticky_status_overwrite_priority.py
+++ b/tests/cli/test_sticky_status_overwrite_priority.py
@@ -1,0 +1,185 @@
+"""Tier 2: StickyStatus overwrite-priority + trim-warning log line (G-F8 + I-F8).
+
+Wave-10 G-F8 + I-F8 (P1, bundled — single root cause: ``show()`` had
+no priority guard, so transient breadcrumbs silently overwrote
+load-bearing live indicators).
+
+  - **I-F8**: Ctrl+P / Ctrl+N during an LLM call replaced the
+    ``⟳ thinking…`` indicator with ``↑ turn 3 / 8``, making the agent
+    appear frozen until the next outbox event arrived.
+  - **G-F8**: ``_maybe_warn_about_trimmed_history`` wrote to the sticky,
+    then ``_flash_turn_position`` fired in the same call frame and
+    overwrote the warning before the user could read it.
+
+Fix:
+  - ``StickyStatus.show()`` now respects a ``_KIND_PRIORITY`` map.
+    ``thinking`` (priority 100) cannot be displaced by ``general``
+    (priority 50); same-or-higher priority overwrites freely.
+  - ``_maybe_warn_about_trimmed_history`` additionally writes a
+    permanent dim log line so the warning survives subsequent
+    sticky overwrites — the user can find it in scrollback.
+
+Public surfaces tested:
+  - thinking-active + general show → suppressed (I-F8)
+  - thinking → thinking overwrite → succeeds (regression guard)
+  - general-active + thinking show → succeeds (priority elevation)
+  - general → general overwrite → succeeds (same priority)
+  - trim warning emits both a sticky AND a permanent log line (G-F8)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+async def _sticky(pilot):
+    """Get the StickyStatus mounted under the ConversationView."""
+    from reyn.chat.tui.widgets import ConversationView
+    conv = pilot.app.query_one("#conversation", ConversationView)
+    return conv._sticky()
+
+
+@pytest.mark.asyncio
+async def test_general_show_suppressed_when_thinking_active() -> None:
+    """Tier 2 (I-F8): a general flash cannot overwrite an active thinking."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("thinking…", kind="thinking")
+        assert s.snapshot()["kind"] == "thinking"
+        assert s.snapshot()["body"] == "thinking…"
+
+        # Lower-priority "general" must NOT displace thinking.
+        s.show("↑ turn 3 / 8", kind="general")
+        snap = s.snapshot()
+        assert snap["kind"] == "thinking", (
+            f"thinking should still be active, got kind={snap['kind']!r}"
+        )
+        assert snap["body"] == "thinking…", (
+            f"thinking body should be preserved, got body={snap['body']!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_thinking_overwrites_thinking_body() -> None:
+    """Tier 2: same-priority overwrite still works (regression guard).
+
+    The natural thinking-body update (e.g. "thinking…" → "calling
+    llm…") must not be suppressed.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("thinking…", kind="thinking")
+        s.show("calling llm…", kind="thinking")
+        snap = s.snapshot()
+        assert snap["kind"] == "thinking"
+        assert snap["body"] == "calling llm…"
+
+
+@pytest.mark.asyncio
+async def test_thinking_overwrites_general_when_general_active() -> None:
+    """Tier 2: higher-priority show DISPLACES lower-priority active."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("↑ turn 2 / 5", kind="general")
+        assert s.snapshot()["kind"] == "general"
+        s.show("thinking…", kind="thinking")
+        snap = s.snapshot()
+        assert snap["kind"] == "thinking"
+        assert snap["body"] == "thinking…"
+
+
+@pytest.mark.asyncio
+async def test_general_overwrites_general() -> None:
+    """Tier 2: same-priority general → general overwrites (turn-flash chain)."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("↑ turn 1 / 5", kind="general")
+        s.show("↑ turn 2 / 5", kind="general")
+        snap = s.snapshot()
+        assert snap["kind"] == "general"
+        assert snap["body"] == "↑ turn 2 / 5"
+
+
+@pytest.mark.asyncio
+async def test_trim_warning_writes_permanent_log_line() -> None:
+    """Tier 2 (G-F8): trim warning survives subsequent sticky overwrite.
+
+    Pre-fix the warning was sticky-only and ``_flash_turn_position`` in
+    the same call frame replaced it. Post-fix the warning is also
+    written as a permanent dim log line that survives any sticky
+    update.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv._log()
+
+        # Simulate ring-buffer trim: ``_start_line`` would be > 0 after
+        # the RichLog has dropped earlier history. Patch it directly
+        # for the test — the public ``_maybe_warn_about_trimmed_history``
+        # reads via ``getattr(log, "_start_line", 0)``.
+        log._start_line = 137  # type: ignore[attr-defined]
+        assert not conv._trim_warned
+
+        conv._maybe_warn_about_trimmed_history(log)
+        await pilot.pause()
+
+        # One-shot — the flag flips so subsequent calls are no-ops.
+        assert conv._trim_warned
+
+        # The permanent log line was written.
+        log_lines = [
+            getattr(strip, "text", "")
+            for strip in getattr(log, "lines", [])
+        ]
+        joined = "\n".join(log_lines)
+        assert "earlier history trimmed" in joined, (
+            f"trim warning should appear as a permanent log line; "
+            f"got:\n{joined!r}"
+        )
+        assert "137" in joined, "trim count should be formatted in the warning"
+
+        # Sticky glance-cue is also active right now.
+        snap = conv._sticky().snapshot()
+        assert snap["active"] is True
+        assert "earlier history trimmed" in snap["body"]
+
+        # Now simulate the same-frame overwrite that previously hid the
+        # warning: a general-kind flash with a different body.
+        conv.show_status("↑ turn 1 / 5", kind="general")
+        snap_after = conv._sticky().snapshot()
+        assert "turn 1 / 5" in snap_after["body"]  # sticky was overwritten
+        # But the log line is still there.
+        log_lines_after = [
+            getattr(strip, "text", "")
+            for strip in getattr(log, "lines", [])
+        ]
+        assert any(
+            "earlier history trimmed" in line for line in log_lines_after
+        ), "trim warning log line must persist after sticky overwrite"


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #3 (G-F8 + I-F8, P1 S, **bundled**).

**Bundle articulation**: G-F8 (trim warning overwritten) and I-F8 (thinking overwritten by turn flash) share a single root cause: ``StickyStatus.show()`` had no priority guard. Fixed with one ``_KIND_PRIORITY`` map + one ``show()`` guard. G-F8 also needs a permanent log line so the trim warning survives same-priority overwrites; included here because it's the same finding pair landing.

## Problem

- I-F8: Ctrl+P / Ctrl+N during LLM call replaced ``⟳ thinking…`` with ``↑ turn N / M`` → looked frozen.
- G-F8: trim warning written to sticky, then ``_flash_turn_position`` in the same call frame overwrote it → invisible.

## Fix

1. ``_KIND_PRIORITY`` map (``thinking=100``, ``general=50``). ``show()`` suppresses lower-priority overwrites.
2. Trim warning also writes a permanent ``_write_log`` dim line — survives any sticky update; reachable in scrollback.

## Test plan

- [x] ruff check passes
- [x] 5 new Tier 2 tests: general-suppressed-by-thinking, thinking→thinking overwrite, thinking elevation, general→general overwrite, trim-warning persists post-overwrite
- [x] Existing 40 smoke tests still green

## Wave-10 context

```
✅ G-F1 (#487) / G-F2 (#488 in review)
🆕 G-F8 + I-F8 bundle (P1 S, this PR)
🔄 G-F3 / G-F4 / G-F5 / G-F10 / H-F2 / H-F1 / I-F1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)