### PR TITLE
fix(tui): direction arrow on turn-position flash reflects navigation (G-F5)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1531,7 +1531,7 @@ class ConversationView(Widget):
             idx = anchors.index(target)
         except ValueError:
             return
-        self._flash_turn_position(idx + 1, len(anchors))
+        self._flash_turn_position(idx + 1, len(anchors), delta=delta)
 
     def _flash_boundary_hint(self, direction: str) -> None:
         """Surface a ``↑ beginning of history`` / ``↓ end of history`` cue.
@@ -1574,8 +1574,16 @@ class ConversationView(Widget):
         # accent) without preempting an active ``⟳ thinking…``.
         self.show_status(text, kind="general")
 
-    def _flash_turn_position(self, n: int, total: int) -> None:
-        """Surface ``↑ turn N / M`` feedback for Ctrl+P/N navigation.
+    def _flash_turn_position(self, n: int, total: int, delta: int = -1) -> None:
+        """Surface ``↑/↓ turn N / M`` feedback for Ctrl+P/N navigation.
+
+        ``delta`` selects the direction arrow: negative (Ctrl+P / backward
+        toward earlier history) → ``↑``, positive (Ctrl+N / forward
+        toward newer history) → ``↓``. Pre-fix the arrow was hard-coded
+        to ``↑`` regardless of direction (G-F5, wave-10) — pressing
+        Ctrl+N to advance forward through turns showed
+        ``↑ turn 5 / 8``, which contradicts the actual movement and
+        misleads users who use the arrow as a navigation cue.
 
         Deduped by ``_last_turn_flash`` so rapid Ctrl+P/N presses that
         land on the same anchor don't spam the surface with identical
@@ -1607,7 +1615,8 @@ class ConversationView(Widget):
         # dedup so the next time the user hits the edge they get the
         # hint fresh (= "user navigated away from the boundary").
         self._last_boundary_flash = None
-        self.show_status(f"↑ turn {n} / {total}", kind="general")
+        arrow = "↑" if delta < 0 else "↓"
+        self.show_status(f"{arrow} turn {n} / {total}", kind="general")
 
     def clear(self) -> None:
         """Ctrl+L: clear the log + reset state. Does not affect engine state."""

--- a/tests/cli/test_flash_turn_direction_arrow.py
+++ b/tests/cli/test_flash_turn_direction_arrow.py
@@ -1,0 +1,103 @@
+"""Tier 2: _flash_turn_position arrow reflects navigation direction (G-F5).
+
+Wave-10 Topic G finding F5 (P2): ``_flash_turn_position`` hard-coded
+``↑ turn N / M`` regardless of whether the user pressed Ctrl+P
+(backward → ``↑``) or Ctrl+N (forward → ``↓``). Forward navigation
+showed an upward arrow, contradicting the actual movement and
+misleading users who use the arrow as a navigation cue.
+
+Fix: ``_flash_turn_position`` takes a ``delta`` parameter; negative
+delta → ``↑``, positive delta → ``↓``. ``_jump_to_relative_anchor``
+passes its own ``delta`` through.
+
+Public surfaces tested:
+  - backward jump (delta=-1) → sticky body starts with ``↑``
+  - forward jump (delta=+1) → sticky body starts with ``↓``
+  - the rest of the body shape ``turn N / M`` is unchanged
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_backward_jump_renders_up_arrow() -> None:
+    """Tier 2: Ctrl+P (delta=-1) → ``↑ turn N / M`` in sticky."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv._log()
+        conv._turn_anchors = [5, 50, 100]
+        try:
+            log.scroll_to(y=100, animate=False)
+        except Exception:
+            pass
+        await pilot.pause()
+
+        conv._jump_to_relative_anchor(-1)
+        await pilot.pause()
+        snap = conv._sticky().snapshot()
+        assert snap["active"]
+        assert snap["body"].startswith("↑ turn"), (
+            f"backward jump should render ↑, got body={snap['body']!r}"
+        )
+        # Body shape: ↑ turn N / M
+        assert " turn " in snap["body"]
+        assert " / " in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_forward_jump_renders_down_arrow() -> None:
+    """Tier 2: Ctrl+N (delta=+1) → ``↓ turn N / M`` in sticky.
+
+    Pre-fix this was ``↑ turn N / M`` — wrong direction.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv._log()
+        conv._turn_anchors = [5, 50, 100]
+        try:
+            log.scroll_to(y=10, animate=False)
+        except Exception:
+            pass
+        await pilot.pause()
+
+        conv._jump_to_relative_anchor(+1)
+        await pilot.pause()
+        snap = conv._sticky().snapshot()
+        assert snap["active"]
+        assert snap["body"].startswith("↓ turn"), (
+            f"forward jump should render ↓, got body={snap['body']!r}"
+        )
+
+
+def test_flash_turn_position_signature_accepts_delta_kwarg() -> None:
+    """Tier 2: ``delta`` kwarg defaults to -1 (backward) for backward compat.
+
+    Older callers that pass only ``(n, total)`` should continue to get
+    the legacy ``↑`` arrow.
+    """
+    import inspect
+
+    from reyn.chat.tui.widgets.conversation import ConversationView
+    sig = inspect.signature(ConversationView._flash_turn_position)
+    assert "delta" in sig.parameters
+    # Default is backward (preserves legacy behavior for any caller
+    # that doesn't pass the new arg).
+    assert sig.parameters["delta"].default == -1


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #6 (G-F5, P2 S). Single-scope: ``_flash_turn_position`` + ``_jump_to_relative_anchor`` (one caller).

## Sister PR articulation (row 7 commitment)

This PR touches ``conversation.py:_flash_turn_position`` + ``_jump_to_relative_anchor`` (= adjacent lines). No other open PR currently touches these lines:
- #488 / #491 / #490 / #487 (= already merged) touched ``clear()`` block
- #492 (G-F4) touched ``_jump_to_relative_anchor`` body (different lines — the ``scroll_to`` block); minor rebase if it lands first, no conflict expected

## Problem

Ctrl+N (forward navigation) showed ``↑ turn N / M`` — wrong arrow direction. Contradicted the user's mental model where arrow = direction of movement.

## Fix

Add ``delta`` kwarg to ``_flash_turn_position`` (default ``-1`` for backward compat). Negative → ``↑``, positive → ``↓``. ``_jump_to_relative_anchor`` forwards its own ``delta``.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: backward → ↑, forward → ↓, signature has default delta=-1
- [x] Existing 40 smoke tests still green

## Wave-10 context

```
✅ G-F1 (#487) / G-F2 (#488) / G-F8+I-F8 (#490) / G-F3 (#491) (merged)
🔄 G-F4 (#492 in review)
🆕 G-F5 (P2 S, this PR)
🔄 G-F10 / H-F2 / H-F1 / I-F1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)