### PR TITLE
fix(tui): cancelled partial stream appended to _recent_replies (G-F10)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -858,6 +858,20 @@ class ConversationView(Widget):
         row.seal()
         self.hide_status()
         if full:
+            # Wave-10 G-F10: stash the partial in the recent-replies ring
+            # buffer so ``/copy`` after a cancel returns the fragment the
+            # user just saw streaming. Pre-fix only the normal
+            # ``end_stream`` path routed through
+            # ``_write_agent_markdown_with_fold`` (= the only writer to
+            # ``_recent_replies``), so a cancel left the buffer carrying
+            # whatever reply ran two turns earlier — ``/copy`` returned
+            # the wrong content with no signal that the cancelled
+            # fragment was unrecoverable. Capping mirrors the
+            # ``_write_agent_markdown_with_fold`` cap (= one source of
+            # truth for the buffer's bounded size).
+            self._recent_replies.append(full)
+            if len(self._recent_replies) > _RECENT_REPLIES_MAX:
+                self._recent_replies = self._recent_replies[-_RECENT_REPLIES_MAX:]
             try:
                 self._log().write(
                     Text("✗ cancelled (partial reply):", style="bold #aa6666"),

--- a/tests/cli/test_end_stream_cancelled_recent_replies.py
+++ b/tests/cli/test_end_stream_cancelled_recent_replies.py
@@ -1,0 +1,119 @@
+"""Tier 2: end_stream_cancelled appends partial to _recent_replies (G-F10).
+
+Wave-10 Topic G finding F10 (P2): the normal ``end_stream`` path
+routed through ``_write_agent_markdown_with_fold`` which appends
+the reply text to ``_recent_replies``. ``end_stream_cancelled``
+(= the Ctrl+C cancel path introduced by wave-9 F-F7) wrote the
+partial body directly to the log, BYPASSING ``_recent_replies``.
+
+Consequence: ``/copy`` after a cancel returned the agent reply
+from TWO turns ago (= whatever was last appended via the normal
+path), not the partial fragment the user just saw streaming. The
+partial text was unrecoverable.
+
+After the fix the cancelled partial is stashed in
+``_recent_replies`` (capped at ``_RECENT_REPLIES_MAX``) so
+``last_reply_text()`` / ``reply_at(1)`` / ``/copy`` all return the
+fragment.
+
+Public surfaces tested:
+  - cancelled stream's partial text is reachable via
+    ``last_reply_text()``
+  - normal ``end_stream`` path still appends (regression guard)
+  - empty partial is NOT appended (= ``end_stream_cancelled`` with
+    no streamed body doesn't pollute the buffer)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_cancelled_partial_is_appended_to_recent_replies() -> None:
+    """Tier 2: ``last_reply_text()`` returns the partial after cancel."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.begin_stream("cancel-recent-id", "test-agent")
+        row.append("partial body the user saw streaming when they cancelled")
+        await pilot.pause()
+
+        # Pre-cancel: buffer empty (no completed reply yet).
+        assert conv.recent_reply_count() == 0
+        assert conv.last_reply_text() is None
+
+        conv.end_stream_cancelled("cancel-recent-id")
+        await pilot.pause()
+
+        # Post-cancel: partial in the buffer + reachable via /copy API.
+        assert conv.recent_reply_count() == 1
+        assert conv.last_reply_text() == (
+            "partial body the user saw streaming when they cancelled"
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_cancel_does_not_pollute_recent_replies() -> None:
+    """Tier 2: empty partial → buffer unchanged (no zero-length entry).
+
+    Regression guard: the ``if full:`` gate at the top of the new
+    append branch must prevent inserting empty strings into the
+    ring buffer.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.begin_stream("empty-cancel-id", "test-agent")
+        await pilot.pause()
+        # Cancel without any appended content.
+        conv.end_stream_cancelled("empty-cancel-id")
+        await pilot.pause()
+        assert conv.recent_reply_count() == 0
+        assert conv.last_reply_text() is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_then_normal_reply_both_in_buffer_order() -> None:
+    """Tier 2: partial + subsequent normal reply both appear, in order.
+
+    ``last_reply_text()`` returns the most recent (= the normal reply
+    after the cancel). ``reply_at(2)`` returns the partial. Pins the
+    interleaving contract.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        # Cancelled partial → buffer index 1.
+        row = conv.begin_stream("first-cancel-id", "test-agent")
+        row.append("partial fragment")
+        await pilot.pause()
+        conv.end_stream_cancelled("first-cancel-id")
+        await pilot.pause()
+
+        # Normal completed reply → buffer index 2.
+        conv._write_agent_markdown_with_fold("complete reply after cancel")
+        await pilot.pause()
+
+        assert conv.recent_reply_count() == 2
+        assert conv.last_reply_text() == "complete reply after cancel"
+        assert conv.reply_at(2) == "partial fragment"


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #7 (G-F10, P2 S). Single-scope: ``end_stream_cancelled`` ring-buffer append.

## Sister PR articulation (row 7)

Touches ``conversation.py:end_stream_cancelled`` only — a different method from any other open PR. No conflict expected.

## Problem

``end_stream_cancelled`` (wave-9 F-F7) wrote the partial body to the log without also appending to ``_recent_replies``. ``/copy`` after a cancel returned content from two turns ago, not the partial the user just saw streaming.

## Fix

Mirror the cap-and-append idiom from ``_write_agent_markdown_with_fold`` inside ``end_stream_cancelled``'s ``if full:`` block.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: partial reachable via ``last_reply_text()``, empty cancel no-op, cancel-then-normal interleaving
- [x] Existing 3 end_stream_cancelled tests (F-F7) + 40 smoke tests still green

## Wave-10 context

```
✅ G-F1 / G-F2 / G-F8+I-F8 / G-F3 (merged)
🔄 G-F4 / G-F5 (in review)
🆕 G-F10 (P2 S, this PR)
🔄 H-F2 / H-F1 / I-F1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)