### PR TITLE
fix(tui): agents tab header surfaces space=open + c=copy hints (H-F2)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -1744,7 +1744,16 @@ class RightPanel(Widget):
         if self._panel_type == "keys":
             return f"[bold {_CORAL}]Key Bindings[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "agents":
-            return f"[bold {_CORAL}]Agents[/]  [#555555]j↓ k↑[/]"
+            # Wave-10 H-F2: surface ``space=open c=copy`` so the cursor's
+            # most useful actions are discoverable from the header. Pre-fix
+            # the agents tab advertised only ``j↓ k↑``, leaving first-time
+            # users to discover Space / c by reading the Keys tab — even
+            # though both bindings work here exactly as in the Memory tab
+            # (which DOES surface them). Matches Memory's hint shape.
+            return (
+                f"[bold {_CORAL}]Agents[/]"
+                f"  [#555555]j↓ k↑ space=open c=copy[/]"
+            )
         if self._panel_type == "memory":
             return (
                 f"[bold {_CORAL}]Memory[/]"

--- a/tests/cli/test_agents_tab_header_hint.py
+++ b/tests/cli/test_agents_tab_header_hint.py
@@ -1,0 +1,104 @@
+"""Tier 2: agents tab header surfaces space=open + c=copy (H-F2).
+
+Wave-10 Topic H finding F2 (P2): the agents tab header advertised
+only ``j↓ k↑`` while the Memory tab next door advertised
+``j↓ k↑ space=open c=copy``. Both tabs honor identical Space (open
+preview) and ``c`` (copy bundle) keybindings — the agents tab
+simply omitted the hint. First-time users on the agents tab had
+to read the Keys tab to learn about Space / c.
+
+After the fix the agents tab header mirrors Memory's hint shape.
+
+Public surfaces tested:
+  - the ``_panel_header_markup`` for ``"agents"`` includes
+    ``space=open`` and ``c=copy``
+  - the hint shape matches Memory's idiom (= readability uniform)
+  - other tab headers are unchanged (regression guard)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_agents_header_surfaces_space_and_c_hints() -> None:
+    """Tier 2: ``Agents`` header includes ``space=open`` and ``c=copy``."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        markup = panel._panel_header_markup()
+        assert "Agents" in markup
+        assert "j↓ k↑" in markup
+        assert "space=open" in markup, (
+            f"agents header should surface space=open, got: {markup!r}"
+        )
+        assert "c=copy" in markup, (
+            f"agents header should surface c=copy, got: {markup!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_agents_header_hint_matches_memory_idiom() -> None:
+    """Tier 2: agents + memory headers carry the same set of action hints.
+
+    Same keybindings → same advertised affordances. Pins the
+    cross-tab consistency contract that H-F2 closes.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "memory"
+        memory_hint_segment = panel._panel_header_markup().split("[#555555]")[-1]
+        panel._panel_type = "agents"
+        agents_hint_segment = panel._panel_header_markup().split("[#555555]")[-1]
+        # Same actions advertised (= the trailing ``[/]`` markup chunk
+        # is identical between the two headers).
+        assert memory_hint_segment == agents_hint_segment, (
+            f"agents and memory headers should advertise identical hints; "
+            f"memory={memory_hint_segment!r}, agents={agents_hint_segment!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_other_tab_headers_unchanged() -> None:
+    """Tier 2: keys / cost / docs / pending headers are not affected.
+
+    Regression guard — H-F2 was scoped to the agents header only.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        # Keys: minimal navigation hint
+        panel._panel_type = "keys"
+        assert "j↓ k↑" in panel._panel_header_markup()
+        # Cost: minimal navigation hint
+        panel._panel_type = "cost"
+        assert "j↓ k↑" in panel._panel_header_markup()
+        # Pending: discard + claim
+        panel._panel_type = "pending"
+        ph = panel._panel_header_markup()
+        assert "d=discard" in ph and "c=claim" in ph
+        # Docs: filter + open
+        panel._panel_type = "docs"
+        dh = panel._panel_header_markup()
+        assert "space=open" in dh and "/=filter" in dh


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #8 (H-F2, P2 S). Single-scope: ``_panel_header_markup`` agents branch.

## Sister PR articulation (row 7)

Touches ``right_panel/__init__.py:_panel_header_markup`` agents branch only. No other open wave-10 PR touches this method.

## Problem

Agents tab header advertised ``j↓ k↑`` but missed ``space=open c=copy`` — both keybindings work here exactly as in the Memory tab.

## Fix

Mirror Memory's hint shape: ``j↓ k↑ space=open c=copy``. Pure visibility fix.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: agents surfaces both hints, agents hint segment == memory's, other tab headers untouched
- [x] Existing 40 smoke tests still green

## Wave-10 context

```
✅ G-F1 / G-F2 / G-F3 / G+I-F8 (merged)
🔄 G-F4 / G-F5 / G-F10 (in review)
🆕 H-F2 (P2 S, this PR)
🔄 H-F1 / I-F1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)