### PR TITLE
fix(tui): agent-label row Space renders meaningful preview (H-F1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -979,8 +979,80 @@ class RightPanel(Widget):
             self._preview_recent_skill(pane, item)
         elif kind == "recent_plan":
             self._preview_recent_plan(pane, item)
+        elif kind == "agent":
+            # Wave-10 H-F1: agent-label row preview. Pre-fix this branch
+            # fell through to ``pane.clear()``, leaving the preview pane
+            # blank — the user saw Space "work" (pane layout shifted)
+            # but got no content, a silent no-op confusing for a tab
+            # whose other rows render rich previews. Now we show a
+            # compact summary (name + status + attached/loaded flags +
+            # in-flight counts) so opening an agent row tells the user
+            # what that agent is doing right now.
+            self._preview_agent(pane, item)
         else:
             pane.clear()
+
+    def _preview_agent(self, pane: _PreviewPane, item: dict) -> None:
+        """Compact summary for an agent-label row (H-F1, wave-10).
+
+        Renders:
+          - name (bold coral if attached, else white)
+          - status (running / ready / idle) derived from the live
+            ``_exec_state`` (= running skills) and the
+            ``loaded`` flag on the flat-item
+          - count of in-flight skills / plans
+          - "attached" / "loaded" boolean status
+
+        Sources are the same ones ``render_agents`` uses to build the
+        agent-label row, so the preview never disagrees with the
+        tree line above it.
+        """
+        from rich.console import Group as RichGroup
+        from rich.text import Text as RichText
+        name = str(item.get("name", "?"))
+        is_attached = bool(item.get("attached", False))
+        is_loaded = bool(item.get("loaded", False))
+        # Count in-flight skills for this agent from the live state.
+        running_skills = [
+            rid for rid, info in self._exec_state.items()
+            if info.get("agent_name") == name
+        ]
+        has_work = bool(running_skills)
+        if has_work:
+            status_glyph, status_text, status_style = (
+                "● ", "running", "#44cc88",
+            )
+        elif is_loaded:
+            status_glyph, status_text, status_style = (
+                "◐ ", "ready", "#aaaa55",
+            )
+        else:
+            status_glyph, status_text, status_style = (
+                "○ ", "idle", "#555555",
+            )
+        head = RichText()
+        head.append(name, style=("bold " + _CORAL) if is_attached else "#dddddd")
+        head.append("  ")
+        head.append(status_glyph + status_text, style=status_style)
+        head.append("\n")
+        head.append("attached: ", style="dim")
+        head.append("yes" if is_attached else "no", style="#dddddd")
+        head.append("\n")
+        head.append("loaded: ", style="dim")
+        head.append("yes" if is_loaded else "no", style="#dddddd")
+        head.append("\n")
+        head.append("running skills: ", style="dim")
+        head.append(str(len(running_skills)), style="#dddddd")
+        if running_skills:
+            head.append("\n")
+            head.append("  ", style="dim")
+            head.append(
+                ", ".join(rid[:8] for rid in running_skills[:4]),
+                style="dim #aaaaaa",
+            )
+            if len(running_skills) > 4:
+                head.append(f", +{len(running_skills) - 4} more", style="dim")
+        pane.show_text(name, RichGroup(head))
 
     def _preview_running_skill(self, pane: _PreviewPane, item: dict) -> None:
         """Live snapshot for an in-flight skill run."""

--- a/tests/cli/test_agents_tab_agent_label_preview.py
+++ b/tests/cli/test_agents_tab_agent_label_preview.py
@@ -1,0 +1,169 @@
+"""Tier 2: agent-label row Space renders a meaningful preview (H-F1).
+
+Wave-10 Topic H finding F1 (P2): cursoring to an agent-label row
+(the "myagent ○ idle" root line) and pressing Space opened the
+preview pane but ``_show_agent_in_preview`` fell through to
+``pane.clear()``, leaving the user staring at an empty preview
+with no feedback. Space appeared to "work" (pane layout shifted)
+but produced no content — confusing for a tab whose other rows
+(running_skill / running_plan / recent_skill / recent_plan)
+render rich previews.
+
+After the fix, ``_preview_agent`` renders a compact summary
+(name + status badge + attached/loaded flags + running-skill
+count + head of run_id list) sourced from the same data the
+``render_agents`` tree uses, so the preview can never disagree
+with the row visible above it.
+
+Public surfaces tested:
+  - cursoring to an agent-label item + ``_show_agent_in_preview``
+    populates ``pane.title`` with the agent name (= no longer
+    empty)
+  - the rendered body carries status / attached / loaded text
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+class _StubPane:
+    """Minimal _PreviewPane stand-in capturing show_text / clear calls."""
+
+    def __init__(self) -> None:
+        self.last_title: str | None = None
+        self.last_renderable = None
+        self.clear_count = 0
+
+    def show_text(self, title: str, renderable) -> None:  # type: ignore[no-untyped-def]
+        self.last_title = title
+        self.last_renderable = renderable
+
+    def clear(self) -> None:
+        self.clear_count += 1
+
+
+@pytest.mark.asyncio
+async def test_agent_label_preview_renders_name_and_status() -> None:
+    """Tier 2: agent-label preview surfaces name + status + flags.
+
+    Pre-fix the kind="agent" branch fell to ``pane.clear()`` (= empty
+    preview). After the fix the pane.show_text path is exercised with
+    a non-empty title + rendered body.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        # Stub the flat-items list with a single agent-label row at
+        # cursor 0. The agent kind item shape is what
+        # ``render_agents`` emits at agents_tab.py:528-533.
+        panel._agents_items = [
+            {
+                "kind": "agent",
+                "name": "test-agent",
+                "attached": True,
+                "loaded": True,
+            },
+        ]
+        panel._agents_cursor = 0
+        # No running skills in exec_state → "ready" badge.
+        panel._exec_state = {}
+
+        stub = _StubPane()
+        panel._show_agent_in_preview(stub)
+
+        # Body was populated (= not the legacy silent clear path).
+        assert stub.clear_count == 0, "agent kind must not fall through to clear()"
+        assert stub.last_title == "test-agent"
+        # Render the captured renderable to plain text + verify content.
+        from rich.console import Console
+        out = Console(file=None, record=True, force_terminal=False)
+        out.print(stub.last_renderable)
+        plain = out.export_text()
+        assert "test-agent" in plain
+        # Loaded + not running → "ready" badge.
+        assert "ready" in plain
+        # Flag rows.
+        assert "attached:" in plain and "yes" in plain
+        assert "loaded:" in plain
+        assert "running skills:" in plain
+
+
+@pytest.mark.asyncio
+async def test_agent_label_preview_running_badge_when_skills_in_flight() -> None:
+    """Tier 2: running skill in exec_state → ``running`` badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        panel._agents_items = [
+            {
+                "kind": "agent",
+                "name": "busy-agent",
+                "attached": False,
+                "loaded": True,
+            },
+        ]
+        panel._agents_cursor = 0
+        panel._exec_state = {
+            "run_abcdef12": {"agent_name": "busy-agent", "phase": "p1"},
+            "run_xyz98765": {"agent_name": "busy-agent", "phase": "p2"},
+            "run_other001": {"agent_name": "other-agent"},
+        }
+        stub = _StubPane()
+        panel._show_agent_in_preview(stub)
+        assert stub.last_title == "busy-agent"
+        from rich.console import Console
+        out = Console(file=None, record=True, force_terminal=False)
+        out.print(stub.last_renderable)
+        plain = out.export_text()
+        # 2 skills running for this agent (the third belongs to another).
+        assert "running skills: 2" in plain
+        # The third item must NOT be counted.
+        assert "running skills: 3" not in plain
+        # Both run_ids should appear in the head (truncated to 8 chars).
+        assert "run_abcd" in plain or "run_xyz9" in plain
+
+
+@pytest.mark.asyncio
+async def test_non_agent_kind_still_routes_to_dedicated_handler() -> None:
+    """Tier 2 (regression): non-agent kinds keep their existing handlers.
+
+    The new "agent" branch must not interfere with running_skill /
+    recent_skill / running_plan / recent_plan routing — those still
+    call their dedicated ``_preview_*`` methods.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        # Empty items list → still falls through to clear().
+        panel._agents_items = []
+        panel._agents_cursor = 0
+        stub = _StubPane()
+        panel._show_agent_in_preview(stub)
+        assert stub.clear_count == 1, "empty items must clear()"
+        # Unknown kind → still clears.
+        panel._agents_items = [{"kind": "unknown_future_kind", "name": "x"}]
+        stub2 = _StubPane()
+        panel._show_agent_in_preview(stub2)
+        assert stub2.clear_count == 1


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #9 (H-F1, P2 S). Single-scope: new ``_preview_agent`` + kind dispatch branch.

## Sister PR articulation (row 7)

Touches ``right_panel/__init__.py:_show_agent_in_preview`` + new ``_preview_agent`` method. PR #495 (H-F2) touched ``_panel_header_markup`` — different method, no conflict.

## Problem

Agent-label row + Space → ``pane.clear()`` fall-through → silent empty preview.

## Fix

New ``_preview_agent`` summary: name + status (running/ready/idle from ``_exec_state``) + attached/loaded flags + running-skill count + head of run_id list. Data sources shared with ``render_agents`` so the two surfaces can't disagree.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: agent preview surfaces name/status/flags, running-skills count filters by agent (= other agents don't leak), empty/unknown kind falls back to clear (regression guard)
- [x] Existing 40 smoke tests still green

## Wave-10 context

```
✅ G-F1 / G-F2 / G-F3 / G+I-F8 (merged) / G-F4 / G-F5 / G-F10 / H-F2 (in review)
🆕 H-F1 (P2 S, this PR)
🔄 I-F1 (last)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)