### PR TITLE
fix(tui): StickyStatus kind="error" renders ✗ in bold red (I-F1)

### DIFF
--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -27,6 +27,18 @@ _TICK_INTERVAL_S = 0.1  # elapsed timer refresh rate
 _GLYPHS: dict[str, str] = {
     "thinking": "⟳",
     "general": "●",
+    # Wave-10 I-F1: ``"error"`` was passed by 7+ call sites
+    # (``app_outbox._show_transient_status`` for ``/copy`` failures,
+    # ``ws_client`` reconnection notices, right_panel preview-error
+    # surface) but had no entry here, so ``show()`` silently
+    # fell back to ``"thinking"`` (= the ⟳ amber glyph). An error
+    # message rendered with the same shape and color as the
+    # ``⟳ thinking…`` live indicator was easy to read as "the agent
+    # is still working" rather than "an action failed". ``✗`` is
+    # the same glyph used by ToolCallRow / SkillActivityRow for
+    # failure terminals, so the cross-surface vocabulary stays
+    # uniform.
+    "error": "✗",
 }
 
 # Wave-10 G-F8 + I-F8: overwrite-priority hierarchy.
@@ -52,6 +64,14 @@ _GLYPHS: dict[str, str] = {
 _KIND_PRIORITY: dict[str, int] = {
     # Live load-bearing state — must not be displaced by transients.
     "thinking": 100,
+    # Wave-10 I-F1: critical transient signal — an action failed and
+    # the user needs to notice. Higher than ``general`` (= routine
+    # breadcrumbs / turn-position flashes shouldn't overwrite an
+    # error the user hasn't read yet) but lower than ``thinking`` —
+    # if the LLM is mid-call, the live indicator stays visible and
+    # the error log line in the conv pane remains the load-bearing
+    # record.
+    "error": 80,
     # Transient flashes / breadcrumbs / one-shot notices.
     "general": 50,
 }
@@ -158,10 +178,16 @@ class StickyStatus(Static):
         # red — confusable with error indicators. The thinking sticky shows
         # while the agent is working, so route its glyph through _AMBER
         # (which degrades to ANSI yellow / bright yellow) — neutrally
-        # signalling "in progress" rather than "alert". The other kind
-        # (general) keeps _CORAL since it's a transient flash, not the
-        # load-bearing "is the agent working?" indicator.
-        glyph_color = _AMBER if self._kind == "thinking" else _CORAL
+        # signalling "in progress" rather than "alert". The error kind
+        # WANTS to read as alert, so bold red (#aa6666). General keeps
+        # _CORAL since it's a transient flash, not the load-bearing "is
+        # the agent working?" indicator.
+        if self._kind == "thinking":
+            glyph_color = _AMBER
+        elif self._kind == "error":
+            glyph_color = "bold #aa6666"
+        else:
+            glyph_color = _CORAL
         # Total cells in the fixed-width suffix segments so we can truncate
         # the body when narrow terminals would otherwise clip the
         # ``Ctrl+C cancel`` hint behind the right edge.

--- a/tests/cli/test_sticky_status_error_kind.py
+++ b/tests/cli/test_sticky_status_error_kind.py
@@ -1,0 +1,128 @@
+"""Tier 2: StickyStatus ``kind="error"`` renders ✗ in bold red (I-F1).
+
+Wave-10 Topic I finding F1 (P2): seven+ call sites passed
+``kind="error"`` to ``show_status`` (``/copy`` failures in
+app_outbox, ws_client reconnection notices, right_panel
+preview-error surface). The kind was not in ``_GLYPHS`` so
+``show()`` silently fell back to ``kind="thinking"`` — the error
+message rendered with the same ⟳ amber glyph as the live
+``⟳ thinking…`` indicator, easy to read as "the agent is still
+working" rather than "an action failed".
+
+After the fix:
+  - ``_GLYPHS["error"]`` = ``"✗"`` (= same glyph as ToolCallRow /
+    SkillActivityRow failure terminals — cross-surface vocabulary
+    uniform)
+  - ``_KIND_PRIORITY["error"]`` = 80 (above ``general``, below
+    ``thinking``) so an error can displace a turn-flash but not
+    yank a live ``⟳ thinking…`` while the LLM is still working
+  - ``_repaint`` paints the error glyph in bold red so the alert
+    semantic reads even on monochrome terminals (= shape + color
+    as redundant cues)
+
+Public surfaces tested:
+  - ``show("err", kind="error")`` → snapshot kind == "error"
+    (no longer silent thinking fallback)
+  - error overwrites general (= priority > 50)
+  - error does NOT overwrite active thinking (= priority < 100)
+  - error glyph + body appear in the rendered output (= the
+    ``Static.update`` Text carries ``✗`` not ``⟳``)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+async def _sticky(pilot):
+    """Get the StickyStatus mounted under the ConversationView."""
+    from reyn.chat.tui.widgets import ConversationView
+    conv = pilot.app.query_one("#conversation", ConversationView)
+    return conv._sticky()
+
+
+@pytest.mark.asyncio
+async def test_error_kind_is_registered_not_silent_fallback() -> None:
+    """Tier 2: ``show(kind="error")`` records "error" not "thinking"."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("copy failed", kind="error")
+        snap = s.snapshot()
+        assert snap["active"] is True
+        assert snap["kind"] == "error", (
+            f"error kind must be registered, got kind={snap['kind']!r}"
+        )
+        assert snap["body"] == "copy failed"
+
+
+@pytest.mark.asyncio
+async def test_error_overwrites_active_general() -> None:
+    """Tier 2: ``error`` (priority 80) displaces ``general`` (priority 50)."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("↑ turn 2 / 5", kind="general")
+        s.show("validation failed", kind="error")
+        snap = s.snapshot()
+        assert snap["kind"] == "error"
+        assert snap["body"] == "validation failed"
+
+
+@pytest.mark.asyncio
+async def test_error_does_not_overwrite_active_thinking() -> None:
+    """Tier 2: ``error`` priority 80 < ``thinking`` priority 100.
+
+    During an active LLM call, an error sticky must NOT yank the
+    ``⟳ thinking…`` indicator (= the user needs both signals — the
+    error is recorded as a conv-log line elsewhere, the thinking
+    must keep ticking). Lower-priority suppression catches this.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("thinking…", kind="thinking")
+        s.show("backround validation failed", kind="error")
+        snap = s.snapshot()
+        # Thinking stays.
+        assert snap["kind"] == "thinking"
+        assert snap["body"] == "thinking…"
+
+
+@pytest.mark.asyncio
+async def test_error_glyph_resolves_to_check_cross() -> None:
+    """Tier 2: ``_glyph`` resolves to ``✗`` (not the ⟳ thinking fallback).
+
+    ``_glyph`` is the load-bearing internal — it's the string written
+    into the Text the Static renders. Pre-fix this was ⟳ for the
+    error kind too because the kind fell through to ``"thinking"``.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        s = await _sticky(pilot)
+        s.show("copy failed", kind="error")
+        await pilot.pause()
+        # ``_glyph`` is the resolved glyph string used by ``_repaint``.
+        assert s._glyph == "✗", (
+            f"error kind glyph should be ✗, got {s._glyph!r}"
+        )
+        # And the thinking glyph must NOT have been selected.
+        assert s._glyph != "⟳"


### PR DESCRIPTION
**[tui-coder]** — wave-10 PR #10 / **final** (I-F1, P2 S). Single-scope: ``_GLYPHS`` + ``_KIND_PRIORITY`` + ``_repaint`` color branch.

## Sister PR articulation (row 7)

Touches ``sticky_status.py`` (= same file as #490 G+I-F8 already merged). The G+I-F8 PR added ``_KIND_PRIORITY`` infrastructure; this PR extends both ``_GLYPHS`` and ``_KIND_PRIORITY`` with a new ``"error"`` entry. No other open wave-10 PR touches this file.

## Problem

7+ callers passed ``kind="error"`` but ``"error"`` wasn't in ``_GLYPHS`` → silent fallback to ``"thinking"`` → error rendered as ⟳ amber (= same as live "agent is working" indicator). User couldn't tell error from progress.

## Fix

Add ``_GLYPHS["error"] = "✗"`` + ``_KIND_PRIORITY["error"] = 80`` + ``_repaint`` paints error glyph in ``bold #aa6666``. Errors overwrite ``general`` but not ``thinking``.

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests: kind registered (no fallback), error displaces general, error suppressed by thinking, ``_glyph`` resolves to ✗
- [x] Existing 5 sticky priority tests + 40 smoke tests still green

## Wave-10 closure

```
✅ G-F1 / G-F2 / G-F3 / G+I-F8 (merged)
🔄 G-F4 / G-F5 / G-F10 / H-F2 / H-F1 (in review)
🆕 I-F1 (P2 S, this PR — final of top 10)
```

10/10 PR opened. D / E / F / G / H / I 全 wave 完結 (wave-9 + wave-10 combined: 20 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)