### PR TITLE
feat(chat): dispatch attribution — sender transition → state_change inject (FP-0041 #489 PR-A)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -667,6 +667,74 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+# FP-0041 (#489) PR-A: humanic dispatch attribution helper.
+#
+# Sender envelope strings follow ``<transport>:<id>[:<display>]``. This
+# helper produces a human-readable label for inclusion in state_change
+# summaries so the LLM sees "bob (Slack)" instead of "slack:U456:bob".
+# Unknown / malformed senders fall through to the raw string.
+_SENDER_TRANSPORT_DISPLAY = {
+    "user":     "user",
+    "slack":    "Slack",
+    "line":     "LINE",
+    "cron":     "scheduled cron job",
+    "a2a":      "peer agent",
+    "webhook":  "external webhook",
+}
+
+
+def _format_sender_label(sender: str | None) -> str:
+    """Format a sender envelope string for LLM-visible state_change text.
+
+    Examples
+    --------
+    ``"slack:U456:bob"`` → ``"bob (Slack)"``
+    ``"slack:U456"`` → ``"slack user U456"``
+    ``"cron:morning_news"`` → ``"scheduled cron job 'morning_news'"``
+    ``"user:tui"`` → ``"user (TUI)"``
+    ``"a2a:news_agent"`` → ``"peer agent 'news_agent'"``
+    ``None`` → ``"an unknown sender"`` (= used in first-turn pre-state)
+
+    Falls through to the raw string when the transport is not in the
+    known list — keeps the dispatch resilient to new sources added by
+    future PRs without label updates here.
+    """
+    if sender is None:
+        return "an unknown sender"
+    parts = sender.split(":", 2)
+    if not parts or not parts[0]:
+        return sender
+    transport = parts[0]
+    rest = parts[1:] if len(parts) > 1 else []
+    transport_label = _SENDER_TRANSPORT_DISPLAY.get(transport)
+    if transport_label is None:
+        return sender
+    if transport == "user":
+        # ``user:tui`` / ``user:web`` / ``user:cli`` → "user (TUI)" etc.
+        surface = rest[0].upper() if rest else ""
+        return f"user ({surface})" if surface else "user"
+    if transport == "slack" or transport == "line":
+        # Prefer display name when present, fall back to id.
+        if len(rest) >= 2 and rest[1]:
+            return f"{rest[1]} ({transport_label})"
+        if len(rest) >= 1 and rest[0]:
+            return f"{transport_label.lower()} user {rest[0]}"
+        return transport_label
+    if transport == "cron":
+        if rest and rest[0]:
+            return f"{transport_label} '{rest[0]}'"
+        return transport_label
+    if transport == "a2a":
+        if rest and rest[0]:
+            return f"{transport_label} '{rest[0]}'"
+        return transport_label
+    if transport == "webhook":
+        if rest and rest[0]:
+            return f"{transport_label} ({rest[0]})"
+        return transport_label
+    return sender
+
+
 # #398 v4 emitter family — events-log subscriber dispatch table.
 #
 # Maps known emitter event types to (source, template) tuples used by
@@ -1112,6 +1180,12 @@ class ChatSession:
             from reyn.config import _default_agent_id
             agent_id = _default_agent_id()
         self._agent_id: str = agent_id
+        # FP-0041 (#489) PR-A: humanic dispatch attribution.
+        # Tracks the sender of the most-recently-dispatched inbox item
+        # so a sender transition (= different consumer addresses the
+        # agent now) can emit a state_change history entry. None until
+        # the first attributed turn is dispatched.
+        self._last_sender: str | None = None
         # FP-0034 Phase 2 step 1: build the ActionEmbeddingIndex +
         # EmbeddingProvider once per session when the operator has
         # configured ``action_retrieval.embedding_class``.  Both stay
@@ -1628,6 +1702,56 @@ class ChatSession:
         with self.history_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(msg), ensure_ascii=False) + "\n")
 
+    def _handle_sender_attribution(self, payload: object) -> None:
+        """Surface a sender transition to the LLM as a state_change entry
+        (= FP-0041 (#489) PR-A humanic dispatch attribution).
+
+        When the sender of an inbox item differs from the prior turn's
+        sender, emit a state_change history entry so the LLM reads
+        "[context shift] Now responding to <X> via <transport>.
+        Previous turn was from <Y>." before processing the new turn.
+        Without this, merged-inbox multi-consumer dispatch produces a
+        confused linear feed where the LLM can't tell who's talking.
+
+        ``sender`` convention (= envelope shape):
+          - ``user:tui`` / ``user:web`` / ``user:cli`` — local human user
+          - ``slack:<user_id>[:<display_name>]`` — Slack consumer
+          - ``line:<user_id>[:<display_name>]`` — LINE consumer
+          - ``cron:<job_name>`` — scheduled fire
+          - ``a2a:<peer_agent>`` — peer-agent message
+          - ``webhook:<source>`` — external event source (= Phase 2)
+
+        Payloads without a ``sender`` field are dispatched unchanged
+        (= backward compat for existing inbox producers that haven't
+        adopted the convention yet). No state_change is emitted in
+        that case; ``self._last_sender`` is unchanged.
+        """
+        if not isinstance(payload, dict):
+            return
+        new_sender = payload.get("sender")
+        if not new_sender or not isinstance(new_sender, str):
+            return
+        if new_sender == self._last_sender:
+            return
+        prev_label = _format_sender_label(self._last_sender)
+        new_label = _format_sender_label(new_sender)
+        if self._last_sender is None:
+            summary = (
+                f"[context shift] Now responding to {new_label}. "
+                f"This is the first attributed turn this session."
+            )
+        else:
+            summary = (
+                f"[context shift] Now responding to {new_label}. "
+                f"Previous turn was from {prev_label}."
+            )
+        try:
+            self.notify_state_change(summary, source="dispatch_attribution")
+        except Exception:
+            # Defensive: attribution emission must not crash dispatch.
+            pass
+        self._last_sender = new_sender
+
     def _on_chat_event_for_state_change(self, event) -> None:
         """Generic events-log subscriber that converts known emitter events
         to ``state_change`` history entries (= #398 v4 emitter family).
@@ -2023,6 +2147,17 @@ class ChatSession:
         kind, payload = await self._consume_inbox()
         if kind == "shutdown":
             return False
+        # FP-0041 (#489) PR-A: humanic dispatch attribution.
+        # If this inbox item carries a ``sender`` (= new envelope
+        # convention: who/what produced this message — e.g.
+        # ``user:tui`` / ``slack:U456:bob`` / ``cron:morning_news`` /
+        # ``a2a:peer_agent``) and it differs from the prior turn's
+        # sender, surface the transition to the LLM as a state_change
+        # history entry. Makes the multi-consumer (humanic) model
+        # explicit: the agent knows "I was just talking to Alice via
+        # cron, now Bob from Slack just said something" instead of
+        # seeing a confused linear feed.
+        self._handle_sender_attribution(payload)
         if kind == "user":
             await self._handle_user_message(
                 payload.get("text", ""),

--- a/tests/test_session_dispatch_attribution.py
+++ b/tests/test_session_dispatch_attribution.py
@@ -1,0 +1,269 @@
+"""Tier 2: ChatSession dispatch attribution — FP-0041 (#489) PR-A.
+
+Humanic multi-consumer model foundation: when a different consumer
+addresses the agent on the same session inbox (= sender transition),
+a ``state_change`` history entry is injected before the new turn so
+the LLM reads ``[context shift] Now responding to <X>. Previous turn
+was from <Y>.`` instead of seeing a confused linear feed.
+
+Pins:
+
+  1. Payload with ``sender`` triggers transition detection on the
+     first attributed turn (= no prior sender, "first attributed
+     turn this session" wording).
+  2. Sender transition (= different sender than prior turn) emits a
+     state_change history entry with both labels.
+  3. Same sender consecutive turns do NOT emit state_change (= no
+     transition, normal within-conversation flow).
+  4. Payload without ``sender`` field is dispatched unchanged (=
+     backward compat for existing producers).
+  5. Non-dict payload doesn't crash (= defensive).
+  6. ``_last_sender`` tracks the last attributed sender across turns.
+
+Plus ``_format_sender_label`` helper coverage for the documented
+sender shapes (= ``user:tui`` / ``slack:U456:bob`` / ``cron:job`` /
+``a2a:peer`` / unknown transport fall-through).
+
+Tier 2 because the attribution is load-bearing for the humanic model
+— a regression that dropped sender transitions silently regresses
+multi-consumer agent UX to the "confused linear feed" failure mode.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import (
+    ChatMessage,
+    ChatSession,
+    _format_sender_label,
+)
+from reyn.events.state_log import StateLog
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _state_changes(session: ChatSession) -> list[ChatMessage]:
+    return [
+        m for m in session.history
+        if m.role == "system" and (m.meta or {}).get("kind") == "state_change"
+    ]
+
+
+def _attribution_entries(session: ChatSession) -> list[ChatMessage]:
+    """state_change entries minted specifically by dispatch attribution."""
+    return [
+        m for m in _state_changes(session)
+        if (m.meta or {}).get("source") == "dispatch_attribution"
+    ]
+
+
+# ── first attributed turn ──────────────────────────────────────────────
+
+
+def test_first_sender_triggers_first_attributed_turn_entry(tmp_path):
+    """Tier 2: the first inbox payload that carries a ``sender``
+    triggers a state_change entry with "first attributed turn this
+    session" wording (= prior sender is None, so the "previous turn
+    was from ..." framing doesn't apply).
+    """
+    session = _make_session(tmp_path)
+    assert session._last_sender is None
+
+    session._handle_sender_attribution({"sender": "slack:U456:bob"})
+
+    entries = _attribution_entries(session)
+    assert len(entries) == 1
+    assert "bob (Slack)" in entries[0].content
+    assert "first attributed turn" in entries[0].content
+    assert session._last_sender == "slack:U456:bob"
+
+
+# ── sender transition ────────────────────────────────────────────────
+
+
+def test_sender_transition_emits_state_change(tmp_path):
+    """Tier 2: when the new sender differs from ``_last_sender``, a
+    state_change history entry is minted with both old and new labels,
+    so the LLM reads "[context shift] Now responding to X. Previous
+    turn was from Y."
+    """
+    session = _make_session(tmp_path)
+    session._handle_sender_attribution({"sender": "cron:morning_news"})
+    pre_count = len(_attribution_entries(session))
+
+    session._handle_sender_attribution({"sender": "slack:U456:bob"})
+
+    entries = _attribution_entries(session)
+    assert len(entries) == pre_count + 1
+    last = entries[-1].content
+    assert "bob (Slack)" in last
+    assert "morning_news" in last  # previous = cron job
+    assert "Previous turn was from" in last
+    assert session._last_sender == "slack:U456:bob"
+
+
+# ── same sender = no transition ────────────────────────────────────────
+
+
+def test_same_sender_consecutive_does_not_emit(tmp_path):
+    """Tier 2: consecutive turns from the same sender (= normal
+    within-conversation flow) do NOT emit state_change. Attribution
+    only fires on the boundary between consumers.
+    """
+    session = _make_session(tmp_path)
+    session._handle_sender_attribution({"sender": "user:tui"})
+    pre_count = len(_attribution_entries(session))
+
+    # Same sender again — no new transition.
+    session._handle_sender_attribution({"sender": "user:tui"})
+    session._handle_sender_attribution({"sender": "user:tui"})
+
+    assert len(_attribution_entries(session)) == pre_count
+    assert session._last_sender == "user:tui"
+
+
+# ── backward compat: no sender ─────────────────────────────────────────
+
+
+def test_payload_without_sender_skips_attribution(tmp_path):
+    """Tier 2: existing inbox producers that haven't adopted the
+    ``sender`` envelope convention still work. ``_handle_sender_attribution``
+    doesn't crash, doesn't mint a state_change, doesn't change
+    ``_last_sender``.
+    """
+    session = _make_session(tmp_path)
+    pre_count = len(_attribution_entries(session))
+    pre_last = session._last_sender
+
+    session._handle_sender_attribution({"text": "hello", "chain_id": "c1"})
+
+    assert len(_attribution_entries(session)) == pre_count
+    assert session._last_sender == pre_last  # unchanged
+
+
+def test_empty_sender_string_skips_attribution(tmp_path):
+    """Tier 2: ``sender=""`` is treated as absent (= no transition
+    fired). Prevents accidental empty-string emissions from
+    producers that haven't fully populated the field.
+    """
+    session = _make_session(tmp_path)
+    session._handle_sender_attribution({"sender": ""})
+
+    assert len(_attribution_entries(session)) == 0
+    assert session._last_sender is None
+
+
+# ── defensive: non-dict payload ────────────────────────────────────────
+
+
+def test_non_dict_payload_does_not_crash(tmp_path):
+    """Tier 2: ``_handle_sender_attribution`` is called with raw
+    payloads from the inbox; if a non-dict slips in (= producer bug),
+    the attribution helper silently returns without crashing
+    dispatch. Defensive isolation.
+    """
+    session = _make_session(tmp_path)
+    session._handle_sender_attribution(None)
+    session._handle_sender_attribution("string-not-dict")
+    session._handle_sender_attribution(["list-not-dict"])
+    session._handle_sender_attribution(42)
+
+    assert len(_attribution_entries(session)) == 0
+    assert session._last_sender is None
+
+
+# ── 3-way transition ──────────────────────────────────────────────────
+
+
+def test_three_way_transition_each_fires(tmp_path):
+    """Tier 2: three distinct senders in sequence fire 3 separate
+    state_change entries — one per boundary.
+    """
+    session = _make_session(tmp_path)
+    session._handle_sender_attribution({"sender": "user:tui"})
+    session._handle_sender_attribution({"sender": "cron:nightly"})
+    session._handle_sender_attribution({"sender": "a2a:peer_one"})
+
+    entries = _attribution_entries(session)
+    assert len(entries) == 3
+    # Final state reflects the latest sender.
+    assert session._last_sender == "a2a:peer_one"
+    # Each entry mentions the current sender's label.
+    assert "user (TUI)" in entries[0].content
+    assert "nightly" in entries[1].content
+    assert "peer_one" in entries[2].content
+
+
+# ── _format_sender_label coverage ──────────────────────────────────────
+
+
+@pytest.mark.parametrize("sender, expected_fragment", [
+    ("slack:U456:bob", "bob (Slack)"),
+    ("slack:U456", "slack user U456"),
+    ("line:U789:alice", "alice (LINE)"),
+    ("line:U789", "line user U789"),
+    ("cron:morning_news", "scheduled cron job 'morning_news'"),
+    ("a2a:news_agent", "peer agent 'news_agent'"),
+    ("user:tui", "user (TUI)"),
+    ("user:web", "user (WEB)"),
+    ("user:cli", "user (CLI)"),
+    ("user", "user"),
+    ("webhook:github", "external webhook (github)"),
+    # Fall-through: unknown transport returns raw.
+    ("unknown_transport:foo:bar", "unknown_transport:foo:bar"),
+    # Edge: None → "an unknown sender".
+    (None, "an unknown sender"),
+])
+def test_format_sender_label_known_shapes(sender, expected_fragment):
+    """Tier 2: parametrised coverage of the documented sender shapes.
+    Pins the human-readable labels that appear in attribution
+    state_change entries.
+    """
+    result = _format_sender_label(sender)
+    assert expected_fragment in result, (
+        f"sender={sender!r} expected to contain {expected_fragment!r}, "
+        f"got {result!r}"
+    )
+
+
+def test_format_sender_label_empty_string_falls_through():
+    """Tier 2: empty string falls through to itself (= no crash, no
+    spurious label).
+    """
+    assert _format_sender_label("") == ""
+
+
+# ── attribution survives notify_state_change failure ──────────────────
+
+
+def test_attribution_resilient_to_notify_state_change_failure(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: if ``notify_state_change`` raises (= subscriber bug /
+    events log misconfig), the dispatch attribution helper swallows
+    the exception so the inbox dispatch path doesn't crash. Defensive
+    — observability must not break core dispatch.
+
+    ``_last_sender`` IS still updated (= we recorded the transition
+    even though the audit emission failed).
+    """
+    session = _make_session(tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated subscriber failure")
+
+    monkeypatch.setattr(session, "notify_state_change", _boom)
+
+    # Must not raise.
+    session._handle_sender_attribution({"sender": "slack:U456:bob"})
+
+    # _last_sender did update despite the failure.
+    assert session._last_sender == "slack:U456:bob"


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 Phase 1 **PR-A foundation**。 humanic vision の data layer 実装、 SP instruction は意図的に追加せず (= user directive 「SP は機能不全対策以外で修正禁止」)。

## Summary

inbox payload に ``sender`` field (= ``user:tui`` / ``slack:U456:bob`` / ``cron:morning_news`` / ``a2a:peer_agent``) があり、 前 turn と異なる時、 ``state_change`` history entry を inject:

> [context shift] Now responding to bob (Slack). Previous turn was from scheduled cron job 'morning_news'.

LLM はこれを **事実** として読む (= data layer)、 instruction なし。 多 consumer merged inbox の 「誰が話してるかわからない」 trap を解消。

## Why dispatch attribution (= data) not SP instruction

設計途中で SP に humanic baseline (= 「be consistent」 / 「respect privacy」 / 「use cross-conversation knowledge」) 追加しようとして user reject:

> SP は機能不全対策以外で修正禁止

= preemptive SP instruction は YAGNI、 LLM-malfunction evidence なしに追加しない。 humanic vision は **envelope + dispatch + state_change の data layer** で完結表現、 LLM 自然反応を信頼。 SP 追加は measurement で concrete malfunction emerge してから検討。

新 memory `feedback_sp_modification_forbidden_without_malfunction` 作成済、 future sessions に伝達。

## Backward compat

``sender`` 不在の payload は素通し (= no state_change、 ``_last_sender`` 不変)。 既存 inbox producer は無変更で動く。 新 producer (= PR-B cron / PR-D Slack / PR-E LINE) が opt-in。

## Change shape

- ``src/reyn/chat/session.py``:
  - ``self._last_sender: str | None``
  - ``_handle_sender_attribution(payload)`` — transition detection + notify_state_change emit
  - ``_format_sender_label`` module helper — ``"slack:U456:bob"`` → ``"bob (Slack)"``
  - ``run_one_iteration`` で consume_inbox 直後に attribution helper 呼出
- ``tests/test_session_dispatch_attribution.py`` (new, 22 tests):
  - first-turn / transition / same-sender / no-sender backward compat / empty / non-dict / 3-way
  - ``_format_sender_label`` parametrised (= slack / line / cron / a2a / user variants / webhook / unknown / None)
  - resilience: notify_state_change 失敗時 dispatch crash しない

## Test plan

- [x] ``pytest tests/test_session_dispatch_attribution.py`` — 22/22 pass
- [x] ``pytest tests/`` (full suite) — 4810 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## FP-0041 Phase 1 progression

| # | Scope | Status |
|---|---|---|
| **PR-A** | **envelope sender + dispatch attribution (= 本 PR)** | **OPEN** |
| PR-B | cron tool (= LLM-callable schedule) | pending |
| PR-C | outbox → MCP routing | pending |
| PR-D | Slack webhook handler | pending |
| PR-E | LINE webhook handler | pending |

Refs #489 (FP-0041 PR-A foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)