### PR TITLE
feat(cron): message-based shape (to + message) + dispatch runner (FP-0041 #489 PR-B)

### DIFF
--- a/src/reyn/cli/commands/cron.py
+++ b/src/reyn/cli/commands/cron.py
@@ -89,13 +89,20 @@ def _load_jobs() -> list:
 
 
 def _jobs_to_cron_jobs(job_configs) -> list:
-    """Convert CronJobConfig entries to CronJob instances."""
+    """Convert CronJobConfig entries to CronJob instances.
+
+    Both message-based (= ``to`` + ``message``) and legacy skill-based
+    (= ``skill``) shapes pass through; CronJob carries all three fields
+    and the runner dispatches based on ``is_message_based()``.
+    """
     from reyn.cron import CronJob
     return [
         CronJob(
             name=jc.name,
-            skill=jc.skill,
             schedule=jc.schedule,
+            to=jc.to,
+            message=jc.message,
+            skill=jc.skill,
             input=dict(jc.input),
             enabled=jc.enabled,
         )
@@ -117,13 +124,19 @@ def _print_list_table(jobs: list, *, show_last_run: bool = False) -> None:
         print("(no jobs configured)")
         return
 
-    # Pre-compute next_run_at for each job
+    # Pre-compute next_run_at for each job. FP-0041 #489 PR-B: target
+    # column shows the agent (= message-based) or the skill (= legacy)
+    # so operators can tell at a glance what each job dispatches.
     rows = []
     for job in jobs:
         next_str = _compute_next_run(job)
+        if job.is_message_based():
+            target = f"→{job.to}"
+        else:
+            target = job.skill or "-"
         row = {
             "name": job.name,
-            "skill": job.skill,
+            "skill": target,
             "schedule": job.schedule,
             "enabled": "true" if job.enabled else "false",
             "next_run": next_str,
@@ -138,7 +151,7 @@ def _print_list_table(jobs: list, *, show_last_run: bool = False) -> None:
     w_name = max(len(r["name"]) for r in rows)
     w_name = max(w_name, 4)  # "NAME"
     w_skill = max(len(r["skill"]) for r in rows)
-    w_skill = max(w_skill, 5)  # "SKILL"
+    w_skill = max(w_skill, 6)  # "TARGET"
     w_sched = max(len(r["schedule"]) for r in rows)
     w_sched = max(w_sched, 8)  # "SCHEDULE"
     w_enabled = 7  # "ENABLED"
@@ -153,7 +166,7 @@ def _print_list_table(jobs: list, *, show_last_run: bool = False) -> None:
         w_lre = max(len(r["last_run_error"]) for r in rows)
         w_lre = max(w_lre, 10)  # "LAST ERROR"
         header = (
-            f"{'NAME':<{w_name}}  {'SKILL':<{w_skill}}  "
+            f"{'NAME':<{w_name}}  {'TARGET':<{w_skill}}  "
             f"{'SCHEDULE':<{w_sched}}  {'ENABLED':<{w_enabled}}  "
             f"{'NEXT RUN':<{w_next}}  {'LAST RUN AT':<{w_lra}}  "
             f"{'LAST STATUS':<{w_lrs}}  {'LAST ERROR':<{w_lre}}"
@@ -169,7 +182,7 @@ def _print_list_table(jobs: list, *, show_last_run: bool = False) -> None:
             )
     else:
         header = (
-            f"{'NAME':<{w_name}}  {'SKILL':<{w_skill}}  "
+            f"{'NAME':<{w_name}}  {'TARGET':<{w_skill}}  "
             f"{'SCHEDULE':<{w_sched}}  {'ENABLED':<{w_enabled}}  "
             f"{'NEXT RUN':<{w_next}}"
         )
@@ -249,17 +262,22 @@ async def _run_scheduler() -> None:
 
 
 def _build_runner():
-    """Return the async runner function that executes a CronJob via Agent.run."""
+    """Return the async runner function that executes a CronJob.
 
-    async def _runner(job) -> None:
-        """Execute one CronJob using the headless Agent.run path."""
+    FP-0009 + FP-0041 #489 PR-B: standalone CLI mode supports the
+    legacy skill-based shape only (= ``inbox_pusher=None`` since there
+    is no AgentRegistry context in ``reyn cron run`` foreground). Use
+    ``reyn web`` for message-based jobs.
+    """
+    from reyn.cron.runners import build_default_runner
+
+    async def _legacy_skill_runner(job) -> str:
         from reyn.agent import Agent
         from reyn.cli.commands.run import _build_permission_resolver
         from reyn.cli.logger_factory import make_logger
         from reyn.cli.skill_loader import resolve_skill_path
         from reyn.compiler import load_dsl_skill
         from reyn.config import _find_project_root, load_config, load_project_context
-        from reyn.llm.llm import run_async
         from reyn.llm.model_resolver import ModelResolver
         from reyn.user_intervention import StdinInterventionBus
 
@@ -294,10 +312,16 @@ def _build_runner():
         skill = load_dsl_skill(str(skill_md), skill_root=str(skill_root))
         initial_input = job.input if job.input else {}
 
-        result = run_async(agent.run(skill, initial_input))
+        result = await agent.run(skill, initial_input)
         if not result.ok:
             raise RuntimeError(
                 f"Skill {job.skill!r} ended with status {result.status!r}"
             )
+        return "ok"
 
-    return _runner
+    # Standalone CLI has no AgentRegistry → message-based jobs warn
+    # and skip (= operator should use ``reyn web`` for them).
+    return build_default_runner(
+        legacy_skill_runner=_legacy_skill_runner,
+        inbox_pusher=None,
+    )

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1151,16 +1151,28 @@ class ActionRetrievalConfig:
 
 @dataclass
 class CronJobConfig:
-    """One ``cron.jobs[]`` entry (FP-0009 Component B).
+    """One ``cron.jobs[]`` entry (FP-0009 Component B + FP-0041 #489 PR-B).
 
     Maps directly onto ``CronJob`` consumed by ``CronScheduler``; this
-    config-side dataclass exists to keep the reyn.yaml parsing layer
+    config-side dataclass exists to keep the YAML parsing layer
     independent of the runtime layer.
+
+    Two execution shapes co-exist (= FP-0041 #489 PR-B):
+
+      - **Message-based** (recommended): ``to`` + ``message``. Cron
+        dispatches the message to the target agent's inbox with
+        ``sender="cron:<name>"`` envelope.
+      - **Skill-based** (legacy): ``skill``. Cron runs the skill
+        directly via ``Agent.run`` (= FP-0009 original shape).
+
+    Exactly one shape per job. Validation rejects both / neither.
     """
 
     name: str
-    skill: str
     schedule: str   # 5-field cron expression
+    to: str | None = None        # message-based: target agent name
+    message: str | None = None   # message-based: free-form text
+    skill: str | None = None     # skill-based legacy: skill name
     input: dict = field(default_factory=dict)
     enabled: bool = True
 
@@ -1179,12 +1191,20 @@ class CronConfig:
 
 
 def _build_cron_config(raw: object) -> CronConfig:
-    """Parse the ``cron:`` section from reyn.yaml.
+    """Parse the ``cron:`` section from reyn.yaml / ``.reyn/cron.yaml``.
 
-    Shape::
+    Shape (FP-0009 + FP-0041 #489 PR-B)::
 
         cron:
           jobs:
+            # Message-based (FP-0041 recommended):
+            - name: morning_news
+              to: news_agent
+              message: "今日の主要ニュースをまとめて"
+              schedule: "0 9 * * *"
+              enabled: true
+
+            # Skill-based (FP-0009 legacy, backward compat):
             - name: index_events_hourly
               skill: index_events
               schedule: "0 */6 * * *"
@@ -1192,9 +1212,10 @@ def _build_cron_config(raw: object) -> CronConfig:
               enabled: true
 
     ``None`` / missing block / empty dict → ``CronConfig(jobs=[])``.
-    Validates ``name``, ``skill``, and ``schedule`` are non-empty strings;
-    raises ``ValueError`` naming the offending entry on validation failure.
-    Unknown extra fields are ignored (= forward-compatible).
+    Validates ``name`` + ``schedule`` are non-empty strings + exactly
+    one of (``skill``) OR (``to`` + ``message``) is set per entry.
+    Raises ``ValueError`` naming the offending entry on validation
+    failure. Unknown extra fields are ignored (= forward-compatible).
     """
     if raw is None:
         return CronConfig()
@@ -1215,17 +1236,30 @@ def _build_cron_config(raw: object) -> CronConfig:
                 f"cron.jobs[{i}]: 'name' must be a non-empty string "
                 f"(got {name!r})"
             )
-        skill = entry.get("skill")
-        if not skill or not isinstance(skill, str):
-            raise ValueError(
-                f"cron.jobs[{i}] (name={name!r}): 'skill' must be a non-empty string "
-                f"(got {skill!r})"
-            )
         schedule = entry.get("schedule")
         if not schedule or not isinstance(schedule, str):
             raise ValueError(
                 f"cron.jobs[{i}] (name={name!r}): 'schedule' must be a non-empty string "
                 f"(got {schedule!r})"
+            )
+        # FP-0041 #489 PR-B: shape selection — message-based vs skill-based.
+        skill = entry.get("skill")
+        to = entry.get("to")
+        message = entry.get("message")
+        has_skill = bool(skill) and isinstance(skill, str)
+        has_message_shape = (
+            bool(to) and isinstance(to, str)
+            and bool(message) and isinstance(message, str)
+        )
+        if has_skill and has_message_shape:
+            raise ValueError(
+                f"cron.jobs[{i}] (name={name!r}): cannot set both "
+                f"'skill' and 'to'/'message' (= choose one shape)."
+            )
+        if not has_skill and not has_message_shape:
+            raise ValueError(
+                f"cron.jobs[{i}] (name={name!r}): must set either "
+                f"'skill' (legacy) OR 'to' + 'message' (= recommended)."
             )
         raw_input = entry.get("input") or {}
         if not isinstance(raw_input, dict):
@@ -1233,8 +1267,10 @@ def _build_cron_config(raw: object) -> CronConfig:
         enabled = bool(entry.get("enabled", True))
         jobs.append(CronJobConfig(
             name=name,
-            skill=skill,
             schedule=schedule,
+            to=to if has_message_shape else None,
+            message=message if has_message_shape else None,
+            skill=skill if has_skill else None,
             input=dict(raw_input),
             enabled=enabled,
         ))
@@ -1502,6 +1538,25 @@ def _merge(base: dict, override: dict) -> dict:
             existing_servers = existing.get("servers", {}) if isinstance(existing, dict) else {}
             new_servers = val.get("servers", {}) if isinstance(val, dict) else {}
             result["mcp"] = {**existing, "servers": {**existing_servers, **new_servers}}
+        elif key == "cron" and isinstance(val, dict):
+            # FP-0041 #489 PR-B: cron jobs merge by name — dynamic
+            # entries (= .reyn/cron.yaml) win on collision with legacy
+            # entries (= reyn.yaml cron.jobs[]). Preserves operator
+            # hand-edited entries + runtime-registered entries side
+            # by side without dropping either.
+            existing = result.get("cron", {})
+            existing_jobs = existing.get("jobs", []) if isinstance(existing, dict) else []
+            new_jobs = val.get("jobs", []) if isinstance(val, dict) else []
+            # Build name-keyed dict for union: existing first, then
+            # new overrides (= last write wins).
+            by_name: dict = {}
+            for j in existing_jobs:
+                if isinstance(j, dict) and j.get("name"):
+                    by_name[j["name"]] = j
+            for j in new_jobs:
+                if isinstance(j, dict) and j.get("name"):
+                    by_name[j["name"]] = j
+            result["cron"] = {**existing, "jobs": list(by_name.values())}
         elif key == "chat" and isinstance(val, dict):
             existing = result.get("chat", {})
             if not isinstance(existing, dict):
@@ -1672,6 +1727,18 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # without special-casing.
         dynamic_mcp = _load_yaml(project_root / ".reyn" / "mcp.yaml")
         merged = _merge(merged, dynamic_mcp)
+
+        # FP-0041 #489 PR-B: dynamic cron registry separated from static
+        # config (= same #470 invariant: ``reyn.yaml`` = edit + restart,
+        # ``.reyn/`` = runtime mutable). ``.reyn/cron.yaml`` carries
+        # cron jobs registered at runtime via the future LLM-callable
+        # cron tool (PR-B2 follow-up). Merged LAST so newer dynamic
+        # entries win on name collision with operator-edited
+        # ``reyn.yaml`` cron jobs.
+        # Shape: ``{"cron": {"jobs": [...]}}`` — same as reyn.yaml
+        # cron section. Job-list union via _merge's cron handling.
+        dynamic_cron = _load_yaml(project_root / ".reyn" / "cron.yaml")
+        merged = _merge(merged, dynamic_cron)
 
         # ADR-0031: <project>/.reyn/config.yaml is DEPRECATED (removed from
         # the 3-layer cascade).  Emit a one-time warning if the file exists so

--- a/src/reyn/cron/runners.py
+++ b/src/reyn/cron/runners.py
@@ -1,0 +1,87 @@
+"""Shared cron runner factory (FP-0009 + FP-0041 #489 PR-B).
+
+Builds the ``runner_fn`` passed to ``CronScheduler``. Dispatches each
+fired ``CronJob`` based on its shape:
+
+  - **Message-based** (= FP-0041 PR-B, ``to + message``): pushes an
+    envelope into the target agent's inbox with ``sender="cron:<name>"``
+    attribution. The agent's router_loop consumes it as a normal
+    attributed turn from a scheduled trigger.
+  - **Skill-based** (= FP-0009 legacy, ``skill``): delegates to the
+    legacy skill-running callable. Existing reyn.yaml configurations
+    continue to work unchanged.
+
+Two collaborators are injected (= keeps this factory transport-agnostic):
+
+  - ``legacy_skill_runner(job) -> str``: the FP-0009 skill execution
+    closure. Build with whatever Agent / config wiring the host
+    process needs.
+  - ``inbox_pusher(to, envelope) -> str``: deliver ``envelope`` to the
+    target agent's inbox. In web mode this routes via the
+    AgentRegistry. In CLI standalone mode no registry exists; pass
+    ``None`` and message-based jobs will warn + return "error" instead
+    of dispatching.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.cron.scheduler import CronJob
+
+logger = logging.getLogger(__name__)
+
+
+def build_default_runner(
+    *,
+    legacy_skill_runner: Callable[["CronJob"], Awaitable[str]] | None = None,
+    inbox_pusher: Callable[[str, dict], Awaitable[str]] | None = None,
+) -> Callable[["CronJob"], Awaitable[str]]:
+    """Construct a CronScheduler-compatible runner.
+
+    Parameters
+    ----------
+    legacy_skill_runner:
+        ``async (job: CronJob) -> str`` that executes a skill-based job.
+        When None, skill-based jobs return "error" with a warning.
+    inbox_pusher:
+        ``async (to: str, envelope: dict) -> str`` that delivers an
+        envelope to the target agent's inbox. When None, message-based
+        jobs return "error" with a warning (= e.g. CLI standalone mode
+        with no AgentRegistry context).
+
+    Returns
+    -------
+    Callable returning "ok" / "error" per fire. Exceptions propagate
+    to the scheduler which records ``last_run_error``.
+    """
+    async def _runner(job: "CronJob") -> str:
+        if job.is_message_based():
+            if inbox_pusher is None:
+                logger.warning(
+                    "Cron job %r is message-based (to=%r) but no "
+                    "inbox_pusher is configured — message-based "
+                    "dispatch is not supported in this process "
+                    "(= standalone `reyn cron run` lacks a session "
+                    "registry; use `reyn web` with cron section).",
+                    job.name, job.to,
+                )
+                return "error"
+            envelope = {
+                "text": job.message,
+                "sender": f"cron:{job.name}",
+            }
+            return await inbox_pusher(job.to, envelope)
+        # Skill-based legacy path.
+        if legacy_skill_runner is None:
+            logger.warning(
+                "Cron job %r is skill-based (skill=%r) but no "
+                "legacy_skill_runner is configured — skipping.",
+                job.name, job.skill,
+            )
+            return "error"
+        return await legacy_skill_runner(job)
+
+    return _runner

--- a/src/reyn/cron/scheduler.py
+++ b/src/reyn/cron/scheduler.py
@@ -15,16 +15,38 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class CronJob:
-    """One scheduled skill execution (FP-0009 Component B).
+    """One scheduled execution (FP-0009 Component B + FP-0041 #489 PR-B).
 
-    Mutable on the scheduler side: ``last_run_at`` / ``last_run_status`` /
-    ``last_run_error`` / ``next_run_at`` are updated after each fire.
+    Two execution shapes co-exist:
+
+      - **Message-based** (= FP-0041 PR-B, recommended): set ``to`` (=
+        target agent name) and ``message`` (= free-form text). The
+        scheduler dispatches the message to the agent's inbox with
+        ``sender="cron:<name>"`` so the LLM reads it as a normal
+        attributed turn from a scheduled trigger.
+
+      - **Skill-based** (= legacy FP-0009): set ``skill`` (= skill name).
+        The scheduler runs the skill directly via ``Agent.run``. Kept
+        for backward compatibility with existing ``reyn.yaml``
+        configurations.
+
+    Exactly one shape should be set per job. If both ``skill`` AND
+    ``to`` are set, the message-based path wins (= ``skill`` is
+    ignored with a warning). If neither is set, the job is invalid.
+
+    Mutable on the scheduler side: ``last_run_at`` / ``last_run_status``
+    / ``last_run_error`` / ``next_run_at`` are updated after each fire.
     """
 
     name: str               # job identifier, unique within scheduler
-    skill: str              # skill name to run via Agent.run
     schedule: str           # cron expression, 5-field (e.g. "0 */6 * * *")
+    # ── message-based (FP-0041 PR-B, recommended) ─────────────────
+    to: str | None = None       # target agent name
+    message: str | None = None  # free-form text dispatched to agent.inbox
+    # ── skill-based (FP-0009 legacy, backward compat) ──────────────
+    skill: str | None = None    # skill name to run via Agent.run
     input: dict = field(default_factory=dict)
+    # ── shared ─────────────────────────────────────────────────────
     enabled: bool = True
     last_run_at: datetime | None = None
     last_run_status: str | None = None   # "ok" | "error" | "cancelled" | None
@@ -32,10 +54,16 @@ class CronJob:
     next_run_at: datetime | None = None
     last_run_duration_seconds: float | None = None
 
+    def is_message_based(self) -> bool:
+        """True if this job uses the message-based shape (= ``to + message``)."""
+        return bool(self.to and self.message)
+
     def to_dict(self) -> dict:
         """JSON-safe shape for `reyn cron list` and `reyn cron status`."""
         return {
             "name": self.name,
+            "to": self.to,
+            "message": self.message,
             "skill": self.skill,
             "schedule": self.schedule,
             "input": self.input,

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -29,14 +29,19 @@ logger = logging.getLogger(__name__)
 def _make_cron_runner():
     """Return an async callable that executes a CronJob headlessly.
 
-    Resolves the skill by name (project → local → stdlib lookup) and runs
-    it through Agent.run with sane defaults drawn from load_config().
+    FP-0009 Component B + FP-0041 #489 PR-B: dispatches based on job
+    shape via ``build_default_runner``.
 
-    TODO: wire full headless-run options (shell_allowed, output_language,
-    permission_resolver, mcp_servers, etc.) mirroring cli/commands/run.py
-    once cron-specific config surface is defined (FP-0009 follow-up).
+      - Skill-based legacy: resolves the skill by name and runs through
+        ``Agent.run`` with sane defaults from ``load_config()``.
+      - Message-based (FP-0041): pushes message into target agent's
+        inbox via ``AgentRegistry.ensure_running``, with
+        ``sender="cron:<name>"`` envelope so the agent reads it as a
+        normal attributed turn from a scheduled trigger.
     """
-    async def _runner(job) -> str:
+    from reyn.cron.runners import build_default_runner
+
+    async def _legacy_skill_runner(job) -> str:
         from pathlib import Path as _Path
 
         from reyn.agent import Agent
@@ -74,7 +79,29 @@ def _make_cron_runner():
         result = await agent.run(skill, dict(job.input))
         return "ok" if result.ok else "error"
 
-    return _runner
+    async def _inbox_pusher(to: str, envelope: dict) -> str:
+        """Deliver ``envelope`` to agent ``to`` via the registry.
+
+        Uses ``ensure_running`` so the agent's router loop is live to
+        consume the inbox put — same pattern A2A uses. The envelope
+        is dispatched as ``kind="user"`` so the LLM processes the
+        text as a turn; PR-A sender attribution emits the
+        ``[context shift]`` state_change entry from the
+        ``sender="cron:<name>"`` field.
+        """
+        from reyn.web.deps import _get_registry
+        registry = _get_registry()
+        try:
+            session = await registry.ensure_running(to)
+        except FileNotFoundError:
+            return "error"
+        await session._put_inbox("user", dict(envelope))
+        return "ok"
+
+    return build_default_runner(
+        legacy_skill_runner=_legacy_skill_runner,
+        inbox_pusher=_inbox_pusher,
+    )
 
 
 @asynccontextmanager
@@ -106,8 +133,10 @@ async def _lifespan(app: FastAPI):
         cron_jobs = [
             CronJob(
                 name=j.name,
-                skill=j.skill,
                 schedule=j.schedule,
+                to=j.to,
+                message=j.message,
+                skill=j.skill,
                 input=dict(j.input),
                 enabled=j.enabled,
             )

--- a/tests/test_fp0009_b_cron_cli.py
+++ b/tests/test_fp0009_b_cron_cli.py
@@ -189,7 +189,15 @@ def test_cron_list_shows_header_columns(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture,
 ) -> None:
-    """Tier 2: run_list output contains NAME, SKILL, SCHEDULE, ENABLED, NEXT RUN headers."""
+    """Tier 2: run_list output contains NAME, TARGET, SCHEDULE, ENABLED,
+    NEXT RUN headers.
+
+    FP-0041 #489 PR-B contract reversal (= 2026-05-23): the column
+    previously labelled ``SKILL`` is now ``TARGET`` because each row
+    can show either the legacy skill name OR the message-based target
+    agent (= ``→<agent_name>``). Renamed per
+    ``feedback_contract_reversal_rewrites_tests``.
+    """
     import reyn.config as _cfg_mod
     from reyn.cli.commands.cron import run_list
 
@@ -199,7 +207,7 @@ def test_cron_list_shows_header_columns(
     run_list(argparse.Namespace())
 
     captured = capsys.readouterr()
-    for col in ("NAME", "SKILL", "SCHEDULE", "ENABLED", "NEXT RUN"):
+    for col in ("NAME", "TARGET", "SCHEDULE", "ENABLED", "NEXT RUN"):
         assert col in captured.out
 
 

--- a/tests/test_fp0041_prb_cron_message_shape.py
+++ b/tests/test_fp0041_prb_cron_message_shape.py
@@ -1,0 +1,430 @@
+"""Tier 2: FP-0041 #489 PR-B — cron message-based shape + dispatch.
+
+PR-A foundation landed the inbox envelope ``sender`` convention +
+dispatch attribution. This PR reshapes ``CronJob`` so a scheduled
+fire can deliver a free-form message to a target agent's inbox
+(= sender=cron:<name>) instead of running a skill directly. Legacy
+skill-based jobs continue to work for backward compat.
+
+Pins:
+
+  1. CronJob model gains ``to`` + ``message`` fields, retains
+     ``skill`` for legacy. ``is_message_based()`` returns True iff
+     both message fields are populated.
+  2. CronJobConfig parses both shapes; rejects entries with neither
+     OR both shapes set.
+  3. ``_build_cron_config`` ValueError on invalid shape (= naming
+     the offending entry in the message).
+  4. Loader merges ``.reyn/cron.yaml`` into the cron section (=
+     #470 invariant align, dynamic registry separate from static
+     reyn.yaml).
+  5. ``_merge`` cron path unions ``jobs`` by name; dynamic entries
+     win on collision with legacy reyn.yaml entries.
+  6. ``build_default_runner`` dispatch shapes:
+     - message-based job + inbox_pusher → pusher called with
+       sender=cron:<name> envelope
+     - skill-based job + legacy_skill_runner → legacy called
+     - message-based job + no inbox_pusher → "error" + warn
+     - skill-based job + no legacy_skill_runner → "error" + warn
+
+Tier 2 because the message shape is foundational for FP-0041 Phase
+1 — Slack/LINE chat-transport handlers and the future LLM-callable
+``cron_register`` tool all rely on this CronJob shape.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ── CronJob model shape ───────────────────────────────────────────────
+
+
+def test_cronjob_message_based_detected():
+    """Tier 2: ``CronJob.is_message_based()`` returns True only when
+    BOTH ``to`` and ``message`` are populated.
+    """
+    from reyn.cron import CronJob
+
+    msg = CronJob(name="x", schedule="0 9 * * *", to="agent_x", message="hi")
+    assert msg.is_message_based() is True
+
+    legacy = CronJob(name="y", schedule="0 9 * * *", skill="some_skill")
+    assert legacy.is_message_based() is False
+
+    partial1 = CronJob(name="z", schedule="0 9 * * *", to="agent_x")
+    assert partial1.is_message_based() is False
+
+    partial2 = CronJob(name="w", schedule="0 9 * * *", message="hi")
+    assert partial2.is_message_based() is False
+
+
+def test_cronjob_to_dict_carries_all_shape_fields():
+    """Tier 2: ``to_dict`` includes ``to``, ``message``, ``skill``
+    fields regardless of which shape is set. Operators inspecting
+    ``reyn cron status`` JSON see the complete row.
+    """
+    from reyn.cron import CronJob
+
+    msg = CronJob(name="x", schedule="0 9 * * *", to="agent_x", message="hi")
+    d = msg.to_dict()
+    assert d["to"] == "agent_x"
+    assert d["message"] == "hi"
+    assert d["skill"] is None
+
+    legacy = CronJob(name="y", schedule="0 9 * * *", skill="some_skill")
+    d = legacy.to_dict()
+    assert d["to"] is None
+    assert d["message"] is None
+    assert d["skill"] == "some_skill"
+
+
+# ── CronJobConfig parsing ─────────────────────────────────────────────
+
+
+def test_build_cron_config_parses_message_based_shape():
+    """Tier 2: ``_build_cron_config`` accepts the new ``to + message``
+    shape (= FP-0041 PR-B). Skill field stays None on the resulting
+    config entry.
+    """
+    from reyn.config import _build_cron_config
+
+    raw = {
+        "jobs": [
+            {
+                "name": "morning_news",
+                "to": "news_agent",
+                "message": "今日のニュース",
+                "schedule": "0 9 * * *",
+                "enabled": True,
+            },
+        ],
+    }
+    cfg = _build_cron_config(raw)
+    assert len(cfg.jobs) == 1
+    j = cfg.jobs[0]
+    assert j.name == "morning_news"
+    assert j.to == "news_agent"
+    assert j.message == "今日のニュース"
+    assert j.skill is None
+
+
+def test_build_cron_config_parses_legacy_skill_shape():
+    """Tier 2: legacy skill-based jobs continue to parse — backward
+    compat for existing reyn.yaml configurations.
+    """
+    from reyn.config import _build_cron_config
+
+    raw = {
+        "jobs": [
+            {
+                "name": "index_hourly",
+                "skill": "index_events",
+                "schedule": "0 * * * *",
+            },
+        ],
+    }
+    cfg = _build_cron_config(raw)
+    assert len(cfg.jobs) == 1
+    j = cfg.jobs[0]
+    assert j.skill == "index_events"
+    assert j.to is None
+    assert j.message is None
+
+
+def test_build_cron_config_rejects_both_shapes():
+    """Tier 2: a job that sets both ``skill`` AND ``to``/``message``
+    is rejected with ValueError naming the offending entry. Each
+    shape is mutually exclusive.
+    """
+    from reyn.config import _build_cron_config
+
+    raw = {
+        "jobs": [
+            {
+                "name": "ambiguous",
+                "skill": "x",
+                "to": "y",
+                "message": "z",
+                "schedule": "0 9 * * *",
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match="ambiguous"):
+        _build_cron_config(raw)
+
+
+def test_build_cron_config_rejects_neither_shape():
+    """Tier 2: a job that sets neither ``skill`` NOR ``to``/``message``
+    is rejected. Without a dispatch target the scheduler has nothing
+    to fire.
+    """
+    from reyn.config import _build_cron_config
+
+    raw = {
+        "jobs": [
+            {"name": "empty", "schedule": "0 9 * * *"},
+        ],
+    }
+    with pytest.raises(ValueError, match="empty"):
+        _build_cron_config(raw)
+
+
+def test_build_cron_config_rejects_partial_message_shape():
+    """Tier 2: ``to`` without ``message`` (or vice versa) is treated
+    as 'no shape set' — rejected. Both fields required for the
+    message-based shape.
+    """
+    from reyn.config import _build_cron_config
+
+    # to set, message missing
+    with pytest.raises(ValueError):
+        _build_cron_config({
+            "jobs": [{
+                "name": "partial1",
+                "to": "agent_x",
+                "schedule": "0 9 * * *",
+            }],
+        })
+    # message set, to missing
+    with pytest.raises(ValueError):
+        _build_cron_config({
+            "jobs": [{
+                "name": "partial2",
+                "message": "hi",
+                "schedule": "0 9 * * *",
+            }],
+        })
+
+
+# ── .reyn/cron.yaml loader ────────────────────────────────────────────
+
+
+def test_load_config_reads_dynamic_cron_yaml(tmp_path, monkeypatch):
+    """Tier 2 (#470 invariant align): ``load_config`` reads
+    ``.reyn/cron.yaml`` and merges its ``cron.jobs`` into the merged
+    config. Sister to ``.reyn/mcp.yaml`` from #470.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(tmp_path / "reyn.yaml", "model: standard\n")
+    _write_yaml(
+        tmp_path / ".reyn" / "cron.yaml",
+        "cron:\n  jobs:\n"
+        "    - name: dynamic_job\n      to: my_agent\n      message: hi\n"
+        "      schedule: '0 9 * * *'\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    names = [j.name for j in config.cron.jobs]
+    assert "dynamic_job" in names
+
+
+def test_load_config_unions_legacy_and_dynamic_cron_jobs(tmp_path, monkeypatch):
+    """Tier 2: a legacy job in reyn.yaml and a dynamic job in
+    .reyn/cron.yaml both surface in the merged config (= union by
+    name). Operator can hand-edit AND tool-register without losing
+    either side.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "model: standard\n"
+        "cron:\n  jobs:\n"
+        "    - name: legacy_job\n      skill: some_skill\n"
+        "      schedule: '0 * * * *'\n",
+    )
+    _write_yaml(
+        tmp_path / ".reyn" / "cron.yaml",
+        "cron:\n  jobs:\n"
+        "    - name: dynamic_job\n      to: my_agent\n      message: hi\n"
+        "      schedule: '0 9 * * *'\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    names = sorted(j.name for j in config.cron.jobs)
+    assert names == ["dynamic_job", "legacy_job"]
+
+
+def test_load_config_dynamic_cron_yaml_overrides_legacy_on_name_collision(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: when both files have a job with the same name, the
+    dynamic ``.reyn/cron.yaml`` entry wins (= last write semantics).
+    Protects against double-edit losing the runtime-registered job.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "model: standard\n"
+        "cron:\n  jobs:\n"
+        "    - name: shared\n      skill: legacy_skill\n"
+        "      schedule: '0 * * * *'\n",
+    )
+    _write_yaml(
+        tmp_path / ".reyn" / "cron.yaml",
+        "cron:\n  jobs:\n"
+        "    - name: shared\n      to: new_agent\n      message: replaced\n"
+        "      schedule: '0 9 * * *'\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    assert len(config.cron.jobs) == 1
+    j = config.cron.jobs[0]
+    assert j.name == "shared"
+    # Dynamic shape wins.
+    assert j.to == "new_agent"
+    assert j.skill is None
+
+
+def test_load_config_works_without_dynamic_cron_yaml(tmp_path, monkeypatch):
+    """Tier 2: a project without ``.reyn/cron.yaml`` (= the common
+    case during the migration window) still loads cleanly. Legacy
+    reyn.yaml cron jobs surface unchanged.
+    """
+    from reyn.config import load_config
+
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        "model: standard\n"
+        "cron:\n  jobs:\n"
+        "    - name: legacy\n      skill: x\n"
+        "      schedule: '0 * * * *'\n",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    config = load_config(cwd=tmp_path)
+
+    assert len(config.cron.jobs) == 1
+    assert config.cron.jobs[0].name == "legacy"
+
+
+# ── build_default_runner dispatch ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runner_dispatches_message_based_to_inbox_pusher():
+    """Tier 2: a message-based ``CronJob`` is dispatched via the
+    ``inbox_pusher`` callable, NOT the legacy skill runner. Envelope
+    carries ``sender="cron:<name>"`` for PR-A attribution.
+    """
+    from reyn.cron import CronJob
+    from reyn.cron.runners import build_default_runner
+
+    pushed: list = []
+
+    async def _pusher(to, envelope):
+        pushed.append((to, envelope))
+        return "ok"
+
+    async def _legacy(job):
+        # Should not be called for message-based jobs.
+        raise AssertionError("legacy runner called for message-based job")
+
+    runner = build_default_runner(
+        legacy_skill_runner=_legacy,
+        inbox_pusher=_pusher,
+    )
+    job = CronJob(
+        name="morning_news", schedule="0 9 * * *",
+        to="news_agent", message="今日のニュース",
+    )
+    result = await runner(job)
+
+    assert result == "ok"
+    assert len(pushed) == 1
+    target, envelope = pushed[0]
+    assert target == "news_agent"
+    assert envelope["text"] == "今日のニュース"
+    assert envelope["sender"] == "cron:morning_news"
+
+
+@pytest.mark.asyncio
+async def test_runner_dispatches_skill_based_to_legacy_runner():
+    """Tier 2: a skill-based ``CronJob`` is dispatched via the legacy
+    skill runner, NOT the inbox pusher. Backward compat for FP-0009
+    skill-based jobs.
+    """
+    from reyn.cron import CronJob
+    from reyn.cron.runners import build_default_runner
+
+    called_with: list = []
+
+    async def _pusher(to, envelope):
+        raise AssertionError("inbox_pusher called for skill-based job")
+
+    async def _legacy(job):
+        called_with.append(job)
+        return "ok"
+
+    runner = build_default_runner(
+        legacy_skill_runner=_legacy,
+        inbox_pusher=_pusher,
+    )
+    job = CronJob(name="index_hourly", schedule="0 * * * *", skill="index_events")
+    result = await runner(job)
+
+    assert result == "ok"
+    assert len(called_with) == 1
+    assert called_with[0].skill == "index_events"
+
+
+@pytest.mark.asyncio
+async def test_runner_message_based_without_pusher_returns_error():
+    """Tier 2: a message-based job in a context lacking ``inbox_pusher``
+    (= CLI standalone mode, no AgentRegistry) returns "error" and
+    logs a warning. Operator should use ``reyn web`` for
+    message-based jobs.
+    """
+    from reyn.cron import CronJob
+    from reyn.cron.runners import build_default_runner
+
+    async def _legacy(job):
+        return "ok"
+
+    runner = build_default_runner(
+        legacy_skill_runner=_legacy,
+        inbox_pusher=None,
+    )
+    job = CronJob(
+        name="x", schedule="0 9 * * *",
+        to="agent_x", message="hi",
+    )
+    result = await runner(job)
+    assert result == "error"
+
+
+@pytest.mark.asyncio
+async def test_runner_skill_based_without_legacy_runner_returns_error():
+    """Tier 2: a skill-based job in a context lacking
+    ``legacy_skill_runner`` returns "error" and logs a warning.
+    Defensive — host process should always provide one for
+    legacy support.
+    """
+    from reyn.cron import CronJob
+    from reyn.cron.runners import build_default_runner
+
+    async def _pusher(to, envelope):
+        return "ok"
+
+    runner = build_default_runner(
+        legacy_skill_runner=None,
+        inbox_pusher=_pusher,
+    )
+    job = CronJob(name="x", schedule="0 9 * * *", skill="some_skill")
+    result = await runner(job)
+    assert result == "error"


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 Phase 1 **PR-B foundation** = cron tool **infrastructure** (storage + dispatch reshape)。 LLM-callable tool surface は **PR-B2 follow-up**。

## Summary

``CronJob`` を reshape: scheduled fire が **target agent への message として inbox に push** できる (= sender=cron:<name>) shape を追加、 legacy skill-based は backward compat。 operator は既に ``reyn.yaml`` / ``.reyn/cron.yaml`` 編集で利用可能。

```yaml
cron:
  jobs:
    # 新 message-based shape (FP-0041 PR-B、 recommended):
    - name: morning_news
      to: news_agent
      message: "今日の主要ニュースをまとめて"
      schedule: "0 9 * * *"

    # 既 skill-based (FP-0009 legacy、 unchanged):
    - name: index_hourly
      skill: index_events
      schedule: "0 * * * *"
```

## Dispatch flow (= message-based、 web mode)

```
cron fires (= scheduled time)
  → _make_cron_runner sees job.is_message_based()
  → AgentRegistry.ensure_running(to)
  → session._put_inbox("user", {"text": message, "sender": "cron:<name>"})
  → PR-A _handle_sender_attribution が state_change inject
     "[context shift] Now responding to scheduled cron job 'morning_news'."
  → LLM が attributed turn として処理
```

## Key changes

| File | Change |
|---|---|
| ``src/reyn/cron/scheduler.py`` | CronJob に ``to`` + ``message`` 追加、 ``skill`` Optional 化、 ``is_message_based()`` |
| ``src/reyn/cron/runners.py`` (new) | ``build_default_runner`` factory (= shape dispatch) |
| ``src/reyn/config.py`` | CronJobConfig fields + validation (= exclusive shape rejection) + ``.reyn/cron.yaml`` 読み + name union merge |
| ``src/reyn/web/server.py`` | runner via build_default_runner with AgentRegistry pusher |
| ``src/reyn/cli/commands/cron.py`` | CLI runner via build_default_runner (message-based skip in standalone)、 list 表示 ``SKILL`` → ``TARGET`` 列 |

## Backward compat

- 既 reyn.yaml ``cron.jobs[].skill`` shape: そのまま parse + run
- ``CronJob.skill`` field position 不変 (= Optional 化のみ)、 既存 code 動作
- 列名 ``SKILL`` → ``TARGET`` は contract reversal、 既 test を ``feedback_contract_reversal_rewrites_tests`` で rewrite

## What's NOT in this PR (= PR-B2 follow-up)

- LLM-callable ``cron_register / unregister / list / enable / disable`` tool surface
- Hot-reload integration (= live ``.reyn/cron.yaml`` re-read after LLM tool registration)
- ``cron_register`` permission gating

= PR-B 本 PR で 「storage + dispatch」 foundation 完成、 PR-B2 は tool surface exposure のみ。

## Test plan

- [x] ``pytest tests/test_fp0041_prb_cron_message_shape.py + existing cron tests`` — 61/61 pass (= 14 new + 47 existing)
- [x] ``pytest tests/`` (full suite) — 4878 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## FP-0041 Phase 1 progression

| # | Scope | Status |
|---|---|---|
| PR-A | envelope sender + dispatch attribution | MERGED (PR #498) |
| **PR-B** | **cron message shape + dispatch runner (= 本 PR)** | **OPEN** |
| PR-B2 | LLM-callable cron tool surface + hot reload + permission | follow-up after PR-B merge |
| PR-C | outbox → MCP routing | parallel-able after PR-A |
| PR-D | Slack chat-transport handler | parallel-able |
| PR-E | LINE chat-transport handler | parallel-able |

Refs #489 (FP-0041 PR-B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)