### PR TITLE
docs(chat): add TUI keyboard shortcuts reference to user guide

### DIFF
--- a/docs/guide/for-users/chat-and-web-ui.md
+++ b/docs/guide/for-users/chat-and-web-ui.md
@@ -65,6 +65,57 @@ The two processes are independent. Stopping one does not affect the other.
 
 ---
 
+## TUI keyboard shortcuts
+
+The TUI footer shows a five-key strip — handy at a glance but not exhaustive.
+Press `Ctrl+B` to open the right panel and switch to the **Keys** tab for the
+full live list (the tab reflects the actual bindings the app is loaded with,
+including any voice-mode keys when recording).
+
+The shortcuts you reach for daily:
+
+### Input
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send the current prompt |
+| `Ctrl+J` | Insert a newline (paste a multi-line prompt) |
+| `Ctrl+U` | Clear the input buffer (single- or multi-line) |
+| `↑` / `↓` | Walk through past prompts (when the slash picker is closed) |
+| `Tab` | Confirm-without-send when the slash picker is open |
+| `Esc` | Dismiss the slash picker / docs filter / pending hint |
+
+### Conversation
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+P` / `Ctrl+N` | Jump to the previous / next turn header |
+| `Ctrl+L` | Clear the conversation pane (engine state untouched) |
+| `Ctrl+C` | Cancel the in-flight skill / LLM call / intervention modal |
+
+### Right panel
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+B` | Toggle the right panel |
+| `Ctrl+W` | Cycle to the next tab (Keys → Events → Agents → Memory → Cost → Docs → Pending) |
+| `h` / `l` | Widen / narrow the panel |
+| `j` / `k` | Scroll the current tab |
+| `space` | Toggle the preview pane for the cursor row (works on most tabs) |
+| `c` | Copy the current view; on the Pending tab, claim the cursor's intervention |
+
+### Quit
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+D` | Quit the TUI (also `/quit`) |
+
+> Slash commands like `/copy`, `/expand`, `/cancel`, `/list`, `/skill`, `/plan`,
+> `/agents`, `/attach`, `/tasks` are documented in the
+> [`reyn chat` reference](../../reference/cli/chat.md#slash-commands).
+
+---
+
 ## A2A endpoint (advanced)
 
 The web server also exposes an [A2A](../../concepts/a2a.md) JSON-RPC endpoint for programmatic access and agent-to-agent communication:


### PR DESCRIPTION
**[tui-coder]** — docs follow-up. Single-scope: new "TUI keyboard shortcuts" section in ``docs/guide/for-users/chat-and-web-ui.md``.

## Why

The user guide surfaced only Ctrl+D / Ctrl+C (quit). Every other shortcut required opening the in-app Keys tab or reading the source. Wave-9 D-F8 surfaced the cost — users hit Enter expecting newline and submitted half-typed prompts. The in-app footer was widened (Ctrl+J nl now visible), but the user guide should also mirror that discoverability for readers who haven't started the TUI yet.

## What

New section after "Stopping" and before "A2A endpoint":
- **Input**: Enter / Ctrl+J / Ctrl+U / ↑↓ / Tab / Esc
- **Conversation**: Ctrl+P/N / Ctrl+L / Ctrl+C
- **Right panel**: Ctrl+B / Ctrl+W / h/l / j/k / space / c
- **Quit**: Ctrl+D

Curated subset only — the in-app Keys tab remains the exhaustive, binding-driven source of truth (= reflects voice-mode-gated keys, future bindings, plugin-added keys). Cross-link to the ``reyn chat`` slash-command reference for /copy /expand /cancel /list /skill /plan /agents /attach /tasks.

## Test plan

- [x] Doc-only change; no code paths affected → no tests required
- [x] Markdown lints clean (existing doc style preserved — same h2 / h3 / table idiom)
- [x] Cross-references verified — both internal links resolve (`reference/cli/chat.md#slash-commands` confirmed by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)