### PR TITLE
fix(tui): remove dead _user_scrolled assignment in scroll_to_bottom (G-F14)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1548,9 +1548,15 @@ class ConversationView(Widget):
         via PageUp / Ctrl+P without having to either press PageDown
         repeatedly or type a new message (which is what currently
         triggers ``_snap_to_bottom``).
+
+        Wave-10 follow-up G-F14: the previous ``self._user_scrolled =
+        False`` here was dead code — ``_snap_to_bottom`` already
+        unconditionally resets the flag. Removing it eliminates the
+        misleading hint that ``_snap_to_bottom`` might NOT reset the
+        flag (= which a future reader would have to verify before
+        editing either method).
         """
         self._snap_to_bottom()
-        self._user_scrolled = False
 
     def _jump_to_relative_anchor(self, delta: int) -> None:
         if not self._turn_anchors:

--- a/tests/cli/test_scroll_to_bottom_no_dead_assign.py
+++ b/tests/cli/test_scroll_to_bottom_no_dead_assign.py
@@ -1,0 +1,69 @@
+"""Tier 2: scroll_to_bottom drops the dead _user_scrolled assignment (G-F14).
+
+Wave-10 follow-up Topic G finding F14 (P3): ``scroll_to_bottom``
+called ``self._snap_to_bottom()`` and then set
+``self._user_scrolled = False`` — a dead instruction since
+``_snap_to_bottom`` already unconditionally resets the flag. The
+duplicate misled future readers ("does ``_snap_to_bottom`` not
+reset it? else why the second set?"), so removing it is pure
+code hygiene with zero behaviour change.
+
+Public surfaces tested:
+  - ``scroll_to_bottom`` still leaves ``_user_scrolled = False``
+    (= behaviour unchanged, the flag set is now delegated to
+    ``_snap_to_bottom``)
+  - source-level check confirms the dead assignment is gone
+"""
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_scroll_to_bottom_still_resets_user_scrolled_flag() -> None:
+    """Tier 2: behaviour unchanged — ``_user_scrolled = False`` after call."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Simulate the user having scrolled up at some point.
+        conv._user_scrolled = True
+        conv.scroll_to_bottom()
+        await pilot.pause()
+        assert conv._user_scrolled is False, (
+            "scroll_to_bottom must still leave _user_scrolled False; "
+            "the flag set was delegated to _snap_to_bottom, not removed"
+        )
+
+
+def test_scroll_to_bottom_source_has_no_duplicate_flag_set() -> None:
+    """Tier 2 (source-level): the body has exactly one path to flag-reset.
+
+    Pins the cleanup so a future refactor can't silently re-add the
+    duplicate. The ``_user_scrolled = False`` line should appear at
+    most ONCE in ``_snap_to_bottom``'s body, never in
+    ``scroll_to_bottom``'s.
+    """
+    from reyn.chat.tui.widgets.conversation import ConversationView
+
+    snap_src = inspect.getsource(ConversationView._snap_to_bottom)
+    scroll_src = inspect.getsource(ConversationView.scroll_to_bottom)
+    assert "self._user_scrolled = False" in snap_src, (
+        "_snap_to_bottom should still own the flag-reset (regression "
+        "guard for the delegated behaviour)"
+    )
+    assert "self._user_scrolled = False" not in scroll_src, (
+        "scroll_to_bottom should not duplicate the flag-reset that "
+        "_snap_to_bottom already performs"
+    )


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up PR (G-F14, P3 S). Single-scope: 1-line removal.

## Problem

``scroll_to_bottom`` set ``self._user_scrolled = False`` AFTER calling ``_snap_to_bottom()`` — which already does the same thing. Pure code hygiene, no behaviour change.

## Fix

Delete the duplicate line. Comment explains why the delegation is the single source of truth so a future reader doesn't re-add it.

## Test plan

- [x] ruff check passes
- [x] 2 new Tier 2 tests: ``_user_scrolled`` still False after call (regression), source-level check
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)