### PR TITLE
fix(tui-test): time-dependent flaky year-prefix assertion in header clock test

### DIFF
--- a/tests/cli/test_header_clock_compact.py
+++ b/tests/cli/test_header_clock_compact.py
@@ -51,18 +51,26 @@ def test_now_text_fits_8_cells() -> None:
 
 
 def test_format_status_contains_compact_clock_not_full_date() -> None:
-    """Tier 2: ``_format_status`` surfaces ``HH:MM:SS`` and NOT ``YYYY-``.
+    """Tier 2: ``_format_status`` surfaces ``HH:MM:SS`` and NOT ``YYYY-MM-DD``.
 
     Defends against a refactor that re-introduces a full-date format in
     a different helper (e.g. ``_now_text_long``) and accidentally wires
     it into the header again.
+
+    The prior assertion used ``"20" not in plain`` as a year-prefix
+    guard, but the substring ``"20"`` also appears in the compact
+    ``HH:MM:SS`` clock during the 20:00-20:59 hour band — so the
+    test reliably failed during evening CI runs even though the
+    header was correct. Replace with a regex that matches only the
+    actual ``YYYY-MM-DD`` shape we're defending against
+    (= no false-positive on a 2-digit hour value).
     """
     header = ReynHeader(agent_name="test", model="test")
     status = header._format_status()
     plain = str(status)
-    # No year prefix in the visible status text.
-    assert "20" not in plain or " 20" not in plain, (
-        f"clock must not include a year-shaped prefix; got {plain!r}"
+    # No YYYY-MM-DD date prefix in the visible status text.
+    assert not re.search(r"\d{4}-\d{2}-\d{2}", plain), (
+        f"clock must not include a YYYY-MM-DD date prefix; got {plain!r}"
     )
     # The compact clock pattern should be findable.
     assert re.search(r"\d{2}:\d{2}:\d{2}", plain), (


### PR DESCRIPTION
**[tui-coder]** — pre-existing flaky test fix. Single-scope: ``tests/cli/test_header_clock_compact.py`` assertion swap.

Lead-coder detected (= broker `msg-1779482209390`) that PR #501 and PR #502 both fail on this test during the 20:00-20:59 evening hour band. Author #501 / #502 changes are unrelated to the failure — the assertion is time-dependent. Lead-coder recommended separate fix landing first so #501 / #502 can rebase + retest.

## Primary evidence

- main pre-merge run 19:54 — `"20"` absent in clock — pass
- PR #501 / #502 CI 20:27 / 20:33 — `"20"` present in clock — fail
- the assertion `"20" not in plain` fires false-positive on a 2-digit hour matching ``20:HH:SS``

## Fix

``re.search(r"\d{4}-\d{2}-\d{2}", plain)`` — matches the actual YYYY-MM-DD shape the test was defending against, no false-positive overlap with hour values.

## Test plan

- [x] ruff check passes
- [x] All 3 tests in the file still pass (including the positive HH:MM:SS regex check, unchanged)
- [x] Assertion now correctly identifies a real date prefix (verified mentally: ``"2026-05-23"`` matches; ``"20:27:01"`` does not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)