### PR TITLE
feat(chat): external transport routing primitive — ExternalRef + route_to_mcp (FP-0041 #489 PR-C)

### DIFF
--- a/src/reyn/chat/external_routing.py
+++ b/src/reyn/chat/external_routing.py
@@ -1,0 +1,281 @@
+"""External transport routing via MCP — FP-0041 #489 PR-C.
+
+Pure routing helpers for dispatching outbox replies to external chat
+transports (= Slack / LINE / Discord / etc.) by way of installed MCP
+servers. Reyn core stays SDK-free (= FP-0041 #1 decision: "outbound
+external API = MCP delegate"); the actual transport-specific API
+calls happen on the MCP server side.
+
+Components:
+
+  ``ExternalTransportRouting`` — config dataclass mapping transport
+    name → MCP tool name + args template. Parsed from
+    ``reyn.yaml`` / ``.reyn/integrations.yaml`` ``external_transports``
+    section.
+
+  ``route_to_mcp(transport, destination, text, ...)`` — async
+    routing function. Looks up the MCP tool from config, builds
+    args from the destination dict + text via template substitution,
+    invokes the supplied ``mcp_dispatcher`` callable. Returns a
+    ``RouteResult`` for the caller to log / event-emit.
+
+Args template substitution:
+
+  Template values may contain ``{text}`` (= reply text) and
+  ``{destination.<key>}`` (= destination dict lookup). All other
+  literal values pass through verbatim. Templates are simple string
+  format calls; no eval / no recursion.
+
+Wiring is intentionally NOT included in this PR. PR-D (Slack
+handler) brings the outbox subscriber that calls ``route_to_mcp``;
+PR-C ships the primitive so the wiring is purely "subscribe outbox
+→ filter ExternalRef → call route_to_mcp".
+"""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+# ── Config dataclasses ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExternalTransportEntry:
+    """Single transport entry in ``external_transports`` config.
+
+    Fields:
+      mcp_tool: full MCP tool name (= ``<server>__<tool>``) to invoke
+        on dispatch. The server portion identifies which installed
+        MCP server provides the call; the tool portion is the bare
+        tool name on that server.
+      args_template: dict shaped like the MCP tool's expected args.
+        Values may contain ``{text}`` and ``{destination.<key>}``
+        placeholders for substitution at dispatch time.
+    """
+    mcp_tool: str
+    args_template: dict
+
+
+@dataclass(frozen=True)
+class ExternalTransportRouting:
+    """``external_transports:`` config section.
+
+    Maps short transport names to MCP tool dispatch recipes::
+
+        external_transports:
+          slack:
+            mcp_tool: slack__chat_postMessage
+            args_template:
+              channel: "{destination.channel}"
+              thread_ts: "{destination.thread_ts}"
+              text: "{text}"
+          line:
+            mcp_tool: line__reply_message
+            args_template:
+              reply_token: "{destination.reply_token}"
+              messages:
+                - type: text
+                  text: "{text}"
+    """
+    transports: dict[str, ExternalTransportEntry] = field(default_factory=dict)
+
+    def get(self, transport: str) -> ExternalTransportEntry | None:
+        """Return the entry for ``transport`` or None if unconfigured."""
+        return self.transports.get(transport)
+
+
+def parse_external_transports(raw: object) -> ExternalTransportRouting:
+    """Parse the ``external_transports`` section.
+
+    Shape:
+      raw = {<transport_name>: {"mcp_tool": str, "args_template": dict}}
+
+    Defensive: malformed entries are skipped with no exception (=
+    operator config errors shouldn't crash boot; missing transports
+    fall through to "transport unconfigured" at dispatch time).
+    Empty / None / non-dict input returns empty config.
+    """
+    if not isinstance(raw, dict):
+        return ExternalTransportRouting()
+    entries: dict[str, ExternalTransportEntry] = {}
+    for name, raw_entry in raw.items():
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(raw_entry, dict):
+            continue
+        mcp_tool = raw_entry.get("mcp_tool")
+        args_template = raw_entry.get("args_template")
+        if not isinstance(mcp_tool, str) or not mcp_tool:
+            continue
+        if not isinstance(args_template, dict):
+            args_template = {}
+        entries[name] = ExternalTransportEntry(
+            mcp_tool=mcp_tool,
+            args_template=dict(args_template),
+        )
+    return ExternalTransportRouting(transports=entries)
+
+
+# ── Template substitution ─────────────────────────────────────────────
+
+
+def _substitute(value: Any, *, text: str, destination: dict) -> Any:
+    """Recursively substitute ``{text}`` and ``{destination.<key>}``.
+
+    String values: ``str.format``-style placeholders. Lists / dicts
+    are walked recursively. Other types pass through. Missing keys
+    are replaced with empty string (= no KeyError, defensive).
+    """
+    if isinstance(value, str):
+        return _substitute_str(value, text=text, destination=destination)
+    if isinstance(value, list):
+        return [_substitute(v, text=text, destination=destination) for v in value]
+    if isinstance(value, dict):
+        return {
+            k: _substitute(v, text=text, destination=destination)
+            for k, v in value.items()
+        }
+    return value
+
+
+def _substitute_str(template: str, *, text: str, destination: dict) -> str:
+    """``{text}`` / ``{destination.<key>}`` substitution for one string.
+
+    Uses a minimal placeholder scanner instead of ``str.format`` so
+    placeholders inside JSON-like strings (= curly braces in JSON
+    examples) don't false-positive. Only the two documented
+    placeholder shapes resolve.
+    """
+    out: list[str] = []
+    i = 0
+    while i < len(template):
+        if template[i] != "{":
+            out.append(template[i])
+            i += 1
+            continue
+        # find matching close
+        close = template.find("}", i + 1)
+        if close == -1:
+            out.append(template[i])
+            i += 1
+            continue
+        placeholder = template[i + 1:close]
+        if placeholder == "text":
+            out.append(text)
+        elif placeholder.startswith("destination."):
+            key = placeholder[len("destination."):]
+            val = destination.get(key, "")
+            out.append(str(val) if val is not None else "")
+        else:
+            # unknown placeholder — leave literal (= operator config
+            # bug, but don't crash dispatch).
+            out.append(template[i:close + 1])
+        i = close + 1
+    return "".join(out)
+
+
+def build_mcp_args(
+    template: dict, *, text: str, destination: dict,
+) -> dict:
+    """Build the MCP tool's args dict by substituting placeholders.
+
+    Public helper so PR-D's outbox subscriber can compose args before
+    invoking the dispatcher, and so tests can verify substitution
+    directly.
+    """
+    return _substitute(template, text=text, destination=destination)
+
+
+# ── Dispatch ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RouteResult:
+    """Outcome of one ``route_to_mcp`` call.
+
+    Fields:
+      status: "ok" | "unconfigured" | "error"
+      transport: the transport name the caller asked for
+      mcp_tool: the resolved tool name (= empty when status=unconfigured)
+      detail: human-readable detail for log / event emission
+    """
+    status: str
+    transport: str
+    mcp_tool: str
+    detail: str
+
+
+async def route_to_mcp(
+    transport: str,
+    destination: dict,
+    text: str,
+    *,
+    routing: ExternalTransportRouting,
+    mcp_dispatcher: Callable[[str, dict], Awaitable[Any]],
+) -> RouteResult:
+    """Dispatch ``text`` to ``transport`` via the configured MCP tool.
+
+    Parameters
+    ----------
+    transport:
+        Short transport name (= "slack" / "line" / ...). Looked up
+        in ``routing.transports``.
+    destination:
+        Opaque per-transport routing dict (= e.g.
+        ``{"channel": "C123", "thread_ts": "..."}``).
+    text:
+        Reply text to deliver.
+    routing:
+        Parsed ``ExternalTransportRouting`` config.
+    mcp_dispatcher:
+        ``async (mcp_tool_name, args) -> result``. Supplied by the
+        caller (= PR-D outbox subscriber) so this routing primitive
+        stays free of session / MCPClient knowledge.
+
+    Returns
+    -------
+    ``RouteResult`` summarising the outcome. ``status="unconfigured"``
+    when ``transport`` is not in ``routing.transports``;
+    ``status="error"`` on dispatcher exception; ``status="ok"`` on
+    successful invocation.
+    """
+    entry = routing.get(transport)
+    if entry is None:
+        return RouteResult(
+            status="unconfigured",
+            transport=transport,
+            mcp_tool="",
+            detail=(
+                f"No external_transports entry for {transport!r}; "
+                f"add it under reyn.yaml or .reyn/integrations.yaml."
+            ),
+        )
+    args = build_mcp_args(
+        entry.args_template, text=text, destination=dict(destination),
+    )
+    try:
+        await mcp_dispatcher(entry.mcp_tool, args)
+    except Exception as exc:
+        return RouteResult(
+            status="error",
+            transport=transport,
+            mcp_tool=entry.mcp_tool,
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+    return RouteResult(
+        status="ok",
+        transport=transport,
+        mcp_tool=entry.mcp_tool,
+        detail=f"Dispatched via {entry.mcp_tool}",
+    )
+
+
+__all__ = [
+    "ExternalTransportEntry",
+    "ExternalTransportRouting",
+    "RouteResult",
+    "build_mcp_args",
+    "parse_external_transports",
+    "route_to_mcp",
+]

--- a/src/reyn/chat/transport.py
+++ b/src/reyn/chat/transport.py
@@ -73,11 +73,34 @@ class SystemRef:
     """
 
 
+@dataclass(frozen=True)
+class ExternalRef:
+    """External chat transport routed via an MCP tool call (FP-0041 #489 PR-C).
+
+    Used when an inbound webhook handler (= Slack/LINE/Discord/etc.,
+    landing in PR-D / PR-E) encodes the reply destination on the
+    inbox envelope. The outbox routing layer (= future PR-D wiring)
+    matches ``transport`` to a configured MCP tool (= e.g.
+    ``slack__chat_postMessage``) and dispatches the reply text +
+    destination metadata to that tool.
+
+    Fields:
+      transport: short transport name (= "slack" / "line" / "discord").
+        Maps to an MCP tool via ``ExternalTransportRouting`` config.
+      destination: opaque transport-specific routing dict (= e.g.
+        {"channel": "C123", "thread_ts": "1234.5678"} for Slack,
+        {"user_id": "U456"} for LINE). Forwarded to the MCP tool as
+        args via the configured args template.
+    """
+    transport: str
+    destination: dict
+
+
 # ---------------------------------------------------------------------------
 # Union alias
 # ---------------------------------------------------------------------------
 
-TransportRef = TuiRef | McpRef | A2aRef | AgentRef | SystemRef
+TransportRef = TuiRef | McpRef | A2aRef | AgentRef | SystemRef | ExternalRef
 
 __all__ = [
     "TransportRef",
@@ -86,4 +109,5 @@ __all__ = [
     "A2aRef",
     "AgentRef",
     "SystemRef",
+    "ExternalRef",
 ]

--- a/tests/test_fp0041_prc_external_routing.py
+++ b/tests/test_fp0041_prc_external_routing.py
@@ -1,0 +1,316 @@
+"""Tier 2: FP-0041 #489 PR-C — external transport routing via MCP.
+
+Pure routing primitive shipped without outbox wiring (= wiring lands
+in PR-D Slack handler). Tests cover:
+
+  1. ``ExternalRef`` variant added to TransportRef union with
+     transport + destination fields.
+  2. ``parse_external_transports`` accepts well-formed YAML config;
+     rejects malformed entries silently.
+  3. ``build_mcp_args`` template substitution: ``{text}`` and
+     ``{destination.<key>}`` placeholders, nested dicts / lists,
+     missing keys = empty string.
+  4. ``route_to_mcp`` flow: unconfigured transport / dispatcher
+     exception / successful dispatch each return the expected
+     ``RouteResult`` status.
+  5. ``route_to_mcp`` passes correctly-substituted args to the
+     dispatcher (= integration of the substitution + lookup).
+
+Tier 2 because the routing primitive is the foundation for any
+Slack/LINE/Discord chat-transport reply path; a regression in
+substitution semantics or status reporting silently degrades the
+PR-D end-to-end Slack handler.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chat.external_routing import (
+    ExternalTransportEntry,
+    ExternalTransportRouting,
+    RouteResult,
+    build_mcp_args,
+    parse_external_transports,
+    route_to_mcp,
+)
+from reyn.chat.transport import ExternalRef
+
+# ── ExternalRef variant ────────────────────────────────────────────────
+
+
+def test_external_ref_carries_transport_and_destination():
+    """Tier 2: ``ExternalRef`` is a frozen dataclass with the two
+    documented fields. Pinning the shape so PR-D / future transports
+    can rely on a stable envelope contract.
+    """
+    ref = ExternalRef(
+        transport="slack",
+        destination={"channel": "C123", "thread_ts": "1234.5678"},
+    )
+    assert ref.transport == "slack"
+    assert ref.destination["channel"] == "C123"
+
+
+def test_external_ref_is_transport_ref_union_member():
+    """Tier 2: ``ExternalRef`` is part of the ``TransportRef`` union
+    so existing reply_to typing accepts it.
+    """
+    from reyn.chat.transport import TransportRef
+
+    # The union check is structural at runtime; we verify that an
+    # ExternalRef instance is recognised as one of the union variants
+    # by checking the __args__ tuple.
+    variants = getattr(TransportRef, "__args__", ())
+    assert ExternalRef in variants
+
+
+# ── parse_external_transports ─────────────────────────────────────────
+
+
+def test_parse_returns_empty_routing_for_none():
+    assert parse_external_transports(None) == ExternalTransportRouting()
+
+
+def test_parse_returns_empty_routing_for_non_dict():
+    assert parse_external_transports([1, 2, 3]) == ExternalTransportRouting()
+    assert parse_external_transports("not a dict") == ExternalTransportRouting()
+
+
+def test_parse_accepts_well_formed_entry():
+    """Tier 2: a complete entry produces the documented dataclass shape."""
+    raw = {
+        "slack": {
+            "mcp_tool": "slack__chat_postMessage",
+            "args_template": {
+                "channel": "{destination.channel}",
+                "text": "{text}",
+            },
+        },
+    }
+    routing = parse_external_transports(raw)
+    entry = routing.get("slack")
+    assert entry is not None
+    assert entry.mcp_tool == "slack__chat_postMessage"
+    assert entry.args_template["channel"] == "{destination.channel}"
+    assert entry.args_template["text"] == "{text}"
+
+
+def test_parse_skips_entries_with_missing_mcp_tool():
+    """Tier 2: an entry without ``mcp_tool`` is silently skipped so
+    one bad operator config doesn't take down all transports.
+    """
+    raw = {
+        "good": {
+            "mcp_tool": "good__send",
+            "args_template": {"x": "y"},
+        },
+        "bad_no_tool": {
+            "args_template": {"x": "y"},
+        },
+        "bad_empty_tool": {
+            "mcp_tool": "",
+            "args_template": {"x": "y"},
+        },
+    }
+    routing = parse_external_transports(raw)
+    assert routing.get("good") is not None
+    assert routing.get("bad_no_tool") is None
+    assert routing.get("bad_empty_tool") is None
+
+
+def test_parse_normalises_missing_args_template_to_empty_dict():
+    """Tier 2: an entry without ``args_template`` is accepted with an
+    empty template (= caller may dispatch with no substitution).
+    """
+    raw = {
+        "ping": {
+            "mcp_tool": "monitor__ping",
+        },
+    }
+    routing = parse_external_transports(raw)
+    entry = routing.get("ping")
+    assert entry is not None
+    assert entry.args_template == {}
+
+
+# ── build_mcp_args (= placeholder substitution) ────────────────────────
+
+
+def test_build_mcp_args_substitutes_text_placeholder():
+    """Tier 2: ``{text}`` is replaced with the reply text."""
+    template = {"body": "Hello: {text}"}
+    out = build_mcp_args(template, text="world", destination={})
+    assert out == {"body": "Hello: world"}
+
+
+def test_build_mcp_args_substitutes_destination_key_placeholder():
+    """Tier 2: ``{destination.<key>}`` is replaced with the dict value."""
+    template = {"channel": "{destination.channel}"}
+    out = build_mcp_args(
+        template, text="t", destination={"channel": "C123"},
+    )
+    assert out == {"channel": "C123"}
+
+
+def test_build_mcp_args_missing_destination_key_becomes_empty_string():
+    """Tier 2: a placeholder referencing a key not in destination
+    resolves to an empty string (= no KeyError, defensive).
+    """
+    template = {"thread_ts": "{destination.thread_ts}"}
+    out = build_mcp_args(template, text="t", destination={"channel": "C123"})
+    assert out == {"thread_ts": ""}
+
+
+def test_build_mcp_args_substitutes_in_nested_dict_and_list():
+    """Tier 2: substitution walks into nested dicts and lists so
+    structured templates (= LINE's ``messages: [{type, text}]``)
+    work end-to-end.
+    """
+    template = {
+        "messages": [
+            {"type": "text", "text": "{text}"},
+        ],
+        "metadata": {"to": "{destination.user_id}"},
+    }
+    out = build_mcp_args(
+        template, text="hello",
+        destination={"user_id": "U999"},
+    )
+    assert out == {
+        "messages": [{"type": "text", "text": "hello"}],
+        "metadata": {"to": "U999"},
+    }
+
+
+def test_build_mcp_args_unknown_placeholder_left_literal():
+    """Tier 2: an unknown placeholder (= operator typo) passes through
+    as a literal string instead of crashing. Mistakes show up in the
+    MCP tool's args at dispatch time rather than at template build.
+    """
+    template = {"x": "{unknown_placeholder}"}
+    out = build_mcp_args(template, text="t", destination={})
+    assert out == {"x": "{unknown_placeholder}"}
+
+
+def test_build_mcp_args_non_str_values_passthrough():
+    """Tier 2: integers / booleans / None pass through unchanged."""
+    template = {"limit": 10, "verify": True, "extra": None}
+    out = build_mcp_args(template, text="t", destination={})
+    assert out == {"limit": 10, "verify": True, "extra": None}
+
+
+# ── route_to_mcp dispatch flow ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_route_returns_unconfigured_when_transport_missing():
+    """Tier 2: an unknown transport returns ``status="unconfigured"``
+    without calling the dispatcher. Lets the caller log a clear
+    operator-actionable error.
+    """
+    calls = []
+
+    async def _dispatcher(tool, args):
+        calls.append((tool, args))
+
+    routing = ExternalTransportRouting()  # empty
+    result = await route_to_mcp(
+        "slack", {}, "hi",
+        routing=routing, mcp_dispatcher=_dispatcher,
+    )
+    assert result.status == "unconfigured"
+    assert result.transport == "slack"
+    assert result.mcp_tool == ""
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_route_dispatches_and_substitutes_for_configured_transport():
+    """Tier 2: a configured transport substitutes the template and
+    passes the resolved args to the dispatcher; returns ``status="ok"``.
+    """
+    dispatched = []
+
+    async def _dispatcher(tool, args):
+        dispatched.append((tool, args))
+
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={
+                "channel": "{destination.channel}",
+                "thread_ts": "{destination.thread_ts}",
+                "text": "{text}",
+            },
+        ),
+    })
+    result = await route_to_mcp(
+        "slack",
+        {"channel": "C123", "thread_ts": "1.5"},
+        "Hello",
+        routing=routing,
+        mcp_dispatcher=_dispatcher,
+    )
+    assert result.status == "ok"
+    assert result.mcp_tool == "slack__chat_postMessage"
+    assert dispatched == [(
+        "slack__chat_postMessage",
+        {"channel": "C123", "thread_ts": "1.5", "text": "Hello"},
+    )]
+
+
+@pytest.mark.asyncio
+async def test_route_returns_error_on_dispatcher_exception():
+    """Tier 2: dispatcher exception is caught + recorded in
+    ``RouteResult`` instead of propagating. Lets the outbox
+    subscriber log and continue with the next message instead of
+    crashing the routing layer.
+    """
+    async def _failing(tool, args):
+        raise RuntimeError("MCP server unreachable")
+
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"text": "{text}"},
+        ),
+    })
+    result = await route_to_mcp(
+        "slack", {}, "hi", routing=routing, mcp_dispatcher=_failing,
+    )
+    assert result.status == "error"
+    assert result.mcp_tool == "slack__chat_postMessage"
+    assert "MCP server unreachable" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_route_result_carries_detail_text_for_each_status():
+    """Tier 2: ``RouteResult.detail`` is non-empty for each status so
+    operators get a clear log line regardless of outcome.
+    """
+    # ok
+    async def _ok(tool, args):
+        return None
+
+    routing = ExternalTransportRouting(transports={
+        "x": ExternalTransportEntry(mcp_tool="x__send", args_template={}),
+    })
+    r = await route_to_mcp("x", {}, "t", routing=routing, mcp_dispatcher=_ok)
+    assert r.status == "ok"
+    assert r.detail  # non-empty
+
+    # unconfigured
+    r = await route_to_mcp(
+        "missing", {}, "t",
+        routing=ExternalTransportRouting(), mcp_dispatcher=_ok,
+    )
+    assert r.status == "unconfigured"
+    assert r.detail
+
+    # error
+    async def _err(tool, args):
+        raise ValueError("nope")
+
+    r = await route_to_mcp("x", {}, "t", routing=routing, mcp_dispatcher=_err)
+    assert r.status == "error"
+    assert r.detail


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 Phase 1 **PR-C** = external transport routing primitive。 PR-A foundation 上 **独立 standalone** (= PR-B/B2 / PR-D/E と並走可)。

## Summary

PR-D (Slack handler) / PR-E (LINE handler) / future Discord etc. が outbox reply を installed MCP server 経由で dispatch するための **共通 routing primitive**。 Reyn core は SDK-free (= FP-0041 #1 decision: outbound external API は MCP delegate)、 transport-specific の API call は MCP server 側で起きる。

## Components

| Element | Role |
|---|---|
| ``ExternalRef(transport, destination)`` | TransportRef union 新変種、 outbox reply_to で使用 |
| ``ExternalTransportEntry`` / ``ExternalTransportRouting`` | config 用 dataclass (= transport → mcp_tool + args_template) |
| ``parse_external_transports(raw)`` | YAML 解析 (= defensive、 malformed silently skip) |
| ``build_mcp_args(template, text, destination)`` | placeholder substitution helper |
| ``route_to_mcp(transport, dest, text, ..., mcp_dispatcher)`` | async dispatch primitive |
| ``RouteResult`` | ok / unconfigured / error outcome |

## Template substitution

- ``{text}`` → reply text
- ``{destination.<key>}`` → destination dict lookup
- Unknown placeholders pass through literally (= operator typo visibility)
- Nested dicts + lists walked (= LINE-style structured messages work)

## Config shape (= 想定)

```yaml
external_transports:
  slack:
    mcp_tool: slack__chat_postMessage
    args_template:
      channel: "{destination.channel}"
      thread_ts: "{destination.thread_ts}"
      text: "{text}"
  line:
    mcp_tool: line__reply_message
    args_template:
      reply_token: "{destination.reply_token}"
      messages:
        - type: text
          text: "{text}"
```

## What's NOT in this PR (= 意図的 split)

- Outbox subscriber wiring (= PR-D で attach + ``ExternalRef`` filter)
- inbox → outbox reply_to propagation (= PR-D Slack webhook handler が envelope mint)
- ``ReynConfig.external_transports`` field + load_config wiring (= PR-D で必要時)
- MCP dispatcher closure (= PR-D が session の MCP client 経由 supply)

PR-C は **routing primitive のみ**、 PR-D の wiring が ~50 LoC で繋ぐ前提。

## Change shape

- ``src/reyn/chat/transport.py``: ``ExternalRef`` variant + union 追加
- ``src/reyn/chat/external_routing.py`` (new, ~280 lines): routing primitive 全体
- ``tests/test_fp0041_prc_external_routing.py`` (new, 17 tests):
  - ExternalRef shape (2 tests)
  - parse_external_transports (5 tests: None / non-dict / well-formed / skip malformed / empty template default)
  - build_mcp_args substitution (6 tests: text / destination key / missing key / nested / unknown / non-str)
  - route_to_mcp flow (4 tests: unconfigured / dispatch+substitute / error catch / detail-text non-empty)

## Test plan

- [x] ``pytest tests/test_fp0041_prc_external_routing.py`` — 17/17 pass
- [x] ``pytest tests/`` (full suite) — 4912 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## FP-0041 Phase 1 progression

| # | Scope | Status |
|---|---|---|
| PR-A | envelope sender + dispatch attribution | MERGED (#498) |
| PR-B | cron message shape + dispatch runner | OPEN (#499) |
| PR-B2 | LLM-callable cron tool surface | OPEN stacked on PR-B (#507) |
| **PR-C** | **external transport routing primitive (= 本 PR)** | **OPEN** |
| PR-D | Slack chat-transport handler (= uses PR-C) | next |
| PR-E | LINE chat-transport handler (= uses PR-C) | next |

Refs #489 (FP-0041 PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)