### PR TITLE
feat(web): Slack inbound webhook handler (FP-0041 #489 PR-D, stacked on PR-C)

### DIFF
--- a/src/reyn/web/routers/webhook_slack.py
+++ b/src/reyn/web/routers/webhook_slack.py
@@ -1,0 +1,318 @@
+"""Slack inbound webhook router — FP-0041 #489 PR-D.
+
+Inbound chat-transport adapter: receives Slack Events API webhook
+POSTs at ``/webhook/slack``, verifies the signing secret, parses
+the event, mints an inbox envelope with ``sender="slack:<user_id>:
+<display>"`` + ``reply_to=ExternalRef(transport="slack",
+destination={...})``, and pushes to the target agent's inbox.
+
+The agent's router_loop then processes the message as an attributed
+turn (= PR-A dispatch attribution emits a ``[context shift]``
+state_change before the LLM sees the text). Replies flow back out
+via PR-D2 (= outbox subscriber + route_to_mcp via Slack MCP server).
+This PR covers inbound only.
+
+## Slack Events API integration
+
+Reyn's Slack App is configured at api.slack.com → Event Subscriptions:
+  Request URL: https://<reyn>/webhook/slack
+  Subscribe to bot events: ``app_mention`` (= bot is @mentioned),
+    ``message.im`` (= DM to bot)
+  Signing Secret: set as ``SLACK_SIGNING_SECRET`` env var on Reyn
+
+## Signing verification
+
+Slack signs every request with HMAC-SHA256 using the signing secret.
+Verification per https://api.slack.com/authentication/verifying-requests-from-slack:
+
+  base_string = f"v0:{timestamp}:{body}"
+  signature = "v0=" + hmac.sha256(secret, base_string).hexdigest()
+
+  Reject when:
+    - Request older than 5 minutes (= replay guard)
+    - X-Slack-Signature mismatch (= constant-time compare)
+
+## URL verification handshake
+
+When Slack first calls the Request URL, it sends:
+  {"type": "url_verification", "challenge": "<random>"}
+
+Reyn echoes back ``{"challenge": "<random>"}`` (= 200 OK).
+
+## Event shapes handled
+
+  app_mention / message:
+    {"event": {"type": "app_mention", "user": "U456",
+               "text": "<@U_BOT> help", "channel": "C123",
+               "ts": "1234.5678", "thread_ts": "..." | absent}}
+
+Other event types (= reactions, channel join, etc.) are accepted
+and acknowledged but produce no inbox envelope.
+
+## Target agent routing
+
+Phase 1 (= this PR): single target agent configured per Slack workspace
+via ``SLACK_TARGET_AGENT`` env var (or ``slack.target_agent`` in
+reyn.yaml). Per-user / per-channel ACL is follow-up.
+
+## Defensive posture
+
+- Signing failure → 401 + log warning
+- URL verification → 200 + challenge echo
+- Unknown event type → 200 (= Slack will keep delivering)
+- Inbox push failure → 500 + log; Slack will retry
+- Reyn target agent not found → 500 + log
+
+The handler never crashes the FastAPI route; all error paths return
+the appropriate HTTP status with no exception propagation.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, Response
+
+from reyn.chat.transport import ExternalRef
+from reyn.web.deps import get_registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["webhook"])
+
+# Replay-protection window for Slack signing. Per Slack docs, ts older
+# than 5 minutes should be rejected to prevent replay attacks.
+_SLACK_REPLAY_WINDOW_SECONDS = 60 * 5
+
+
+# ── signing verification ──────────────────────────────────────────────
+
+
+def verify_slack_signature(
+    *,
+    body: bytes,
+    timestamp: str,
+    signature: str,
+    signing_secret: str,
+    now: float | None = None,
+) -> tuple[bool, str]:
+    """Verify a Slack-signed webhook request.
+
+    Returns ``(ok, detail)``. ``ok=True`` means the signature
+    matches AND the timestamp is within the replay window;
+    ``detail`` is a short reason string for ``ok=False`` cases
+    (= "missing-timestamp" / "missing-signature" / "stale" /
+    "mismatch"). Constant-time comparison via ``hmac.compare_digest``.
+
+    Exported for test injection — callers (= the route handler) use
+    this with ``now=time.time()``.
+    """
+    if not timestamp:
+        return False, "missing-timestamp"
+    if not signature:
+        return False, "missing-signature"
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False, "invalid-timestamp"
+    current = now if now is not None else time.time()
+    if abs(current - ts) > _SLACK_REPLAY_WINDOW_SECONDS:
+        return False, "stale"
+    base_string = f"v0:{timestamp}:".encode() + body
+    digest = hmac.new(
+        signing_secret.encode(), base_string, hashlib.sha256,
+    ).hexdigest()
+    expected = f"v0={digest}"
+    if not hmac.compare_digest(expected, signature):
+        return False, "mismatch"
+    return True, "ok"
+
+
+# ── envelope minting ─────────────────────────────────────────────────
+
+
+def mint_envelope_from_slack_event(event: dict) -> dict | None:
+    """Convert a Slack event payload into a Reyn inbox envelope.
+
+    Returns the envelope dict (= ``{"text", "sender", "reply_to"}``)
+    or ``None`` when the event isn't a kind we should dispatch (=
+    bot's own message, reaction, channel-join, etc.).
+
+    Sender shape: ``slack:<user_id>`` (= per PR-A sender
+    convention). Display name lookup is not implemented in this PR
+    (= optional augmentation in follow-up if Slack MCP exposes a
+    ``users.info`` call).
+
+    Reply-to shape: ``ExternalRef(transport="slack",
+    destination={"channel": <id>, "thread_ts": <id>})`` — the
+    ``thread_ts`` defaults to the message's own ``ts`` so the agent
+    reply lands in a thread; if the user is replying in an existing
+    thread, that ``thread_ts`` is preserved.
+
+    Stored as a plain dict because the existing inbox mechanism uses
+    dict payloads. The ``reply_to`` is the ExternalRef instance; PR-D2
+    outbox subscriber will read it back.
+    """
+    inner = event.get("event") if isinstance(event, dict) else None
+    if not isinstance(inner, dict):
+        return None
+    event_type = inner.get("type")
+    # Only dispatch message-class events. App-home / reaction / etc.
+    # land here but produce no inbox push.
+    if event_type not in ("app_mention", "message"):
+        return None
+    # Ignore bot's own messages (= prevent feedback loops).
+    if inner.get("bot_id") or inner.get("subtype") == "bot_message":
+        return None
+    text = inner.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    user_id = inner.get("user")
+    channel = inner.get("channel")
+    if not isinstance(channel, str):
+        return None
+    ts = inner.get("ts")
+    thread_ts = inner.get("thread_ts") or ts
+    sender = f"slack:{user_id}" if user_id else "slack:unknown"
+    reply_to = ExternalRef(
+        transport="slack",
+        destination={"channel": channel, "thread_ts": thread_ts},
+    )
+    return {
+        "text": text,
+        "sender": sender,
+        "reply_to": reply_to,
+    }
+
+
+# ── target agent resolution (= MVP single-agent shape) ────────────────
+
+
+def _resolve_target_agent(config: Any) -> str | None:
+    """Resolve the target agent for Slack inbound messages.
+
+    MVP shape (= follow-up PR will add per-user/per-channel ACL):
+
+      1. ``SLACK_TARGET_AGENT`` env var (= operator quick-config)
+      2. ``slack.target_agent`` in reyn.yaml (= TBD wiring)
+      3. Default ``"default"`` (= will fail if no such agent exists,
+         and the failure shows up as 500 with a clear log line)
+    """
+    env = os.environ.get("SLACK_TARGET_AGENT")
+    if env:
+        return env
+    # config-side wiring lands when ReynConfig.slack section ships.
+    return None
+
+
+# ── route ────────────────────────────────────────────────────────────
+
+
+@router.post("/webhook/slack")
+async def slack_webhook(
+    request: Request,
+    registry=Depends(get_registry),
+) -> Response:
+    """Receive a Slack Events API POST.
+
+    Three branches:
+      1. URL verification → echo challenge.
+      2. Event with no dispatchable payload (= non-message events,
+         malformed payload) → 200 ack only.
+      3. Message event → verify signing, mint envelope, push to
+         target agent's inbox, return 200.
+
+    Errors return appropriate HTTP status without raising; Slack
+    will retry on non-2xx so we avoid 4xx/5xx for transient cases.
+    """
+    body_bytes = await request.body()
+
+    # Parse body up-front so we can handle url_verification before
+    # signing check (= URL verification doesn't have a signature
+    # during initial setup with some Slack App configurations).
+    try:
+        import json
+        payload = json.loads(body_bytes.decode("utf-8") or "{}")
+    except Exception:
+        logger.warning("Slack webhook: malformed JSON body")
+        return JSONResponse(
+            {"error": "malformed body"}, status_code=400,
+        )
+
+    # URL verification handshake — Slack POSTs this on initial setup.
+    if isinstance(payload, dict) and payload.get("type") == "url_verification":
+        challenge = payload.get("challenge")
+        return JSONResponse(
+            {"challenge": challenge if isinstance(challenge, str) else ""},
+            status_code=200,
+        )
+
+    # Signing verification for all other paths.
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+    if not signing_secret:
+        logger.warning(
+            "Slack webhook received but SLACK_SIGNING_SECRET is unset; rejecting.",
+        )
+        return JSONResponse(
+            {"error": "Slack signing secret not configured"},
+            status_code=503,
+        )
+    ok, detail = verify_slack_signature(
+        body=body_bytes,
+        timestamp=request.headers.get("X-Slack-Request-Timestamp", ""),
+        signature=request.headers.get("X-Slack-Signature", ""),
+        signing_secret=signing_secret,
+    )
+    if not ok:
+        logger.warning("Slack webhook signing verify failed: %s", detail)
+        return JSONResponse(
+            {"error": f"signature verification failed: {detail}"},
+            status_code=401,
+        )
+
+    # Mint envelope from the event.
+    envelope = mint_envelope_from_slack_event(payload)
+    if envelope is None:
+        # Non-dispatchable event (= reaction / channel_join / bot
+        # message echo / etc.). Slack expects 2xx so it won't retry.
+        return JSONResponse({"status": "ignored"}, status_code=200)
+
+    # Resolve target agent.
+    target = _resolve_target_agent(None)
+    if not target:
+        logger.warning(
+            "Slack webhook: no target agent configured "
+            "(SLACK_TARGET_AGENT env var unset)",
+        )
+        return JSONResponse(
+            {"error": "no target agent configured"},
+            status_code=503,
+        )
+
+    # Push to inbox via the registry (= ensure_running so the agent's
+    # router_loop is live to consume).
+    try:
+        session = await registry.ensure_running(target)
+    except FileNotFoundError:
+        logger.warning(
+            "Slack webhook: target agent %r not found in registry", target,
+        )
+        return JSONResponse(
+            {"error": f"target agent {target!r} not found"},
+            status_code=503,
+        )
+    try:
+        await session._put_inbox("user", dict(envelope))
+    except Exception as exc:
+        logger.exception("Slack webhook: inbox push failed: %s", exc)
+        return JSONResponse(
+            {"error": f"inbox dispatch failed: {type(exc).__name__}"},
+            status_code=500,
+        )
+
+    return JSONResponse({"status": "ok"}, status_code=200)

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -210,6 +210,7 @@ from reyn.web.routers import skills as _skills_router  # noqa: E402
 from reyn.web.routers import topologies as _topos_router  # noqa: E402
 from reyn.web.routers import web_config as _web_config_router  # noqa: E402
 from reyn.web.routers import web_data as _web_data_router  # noqa: E402
+from reyn.web.routers import webhook_slack as _webhook_slack_router  # noqa: E402
 
 app.include_router(_agents_router.router, prefix="/api")
 app.include_router(_skills_router.router, prefix="/api")
@@ -219,6 +220,11 @@ app.include_router(_perms_router.router, prefix="/api")
 app.include_router(_budget_router.router, prefix="/api")
 app.include_router(_web_config_router.router, prefix="/api")
 app.include_router(_web_data_router.router, prefix="/api")
+# FP-0041 #489 PR-D: Slack inbound webhook (= chat-transport).
+# Route is /webhook/slack at the top level (= no /api prefix) so the
+# URL operators paste into Slack's Event Subscriptions matches the
+# documented industry convention.
+app.include_router(_webhook_slack_router.router)
 
 # MCP-over-SSE: GET /mcp/sse (event stream) + POST /mcp/messages (client → server).
 # The router carries the GET; the POST endpoint is a Starlette Mount because

--- a/tests/web/test_webhook_slack_router.py
+++ b/tests/web/test_webhook_slack_router.py
@@ -1,0 +1,497 @@
+"""Tier 2: Slack inbound webhook router — FP-0041 #489 PR-D.
+
+Tests the ``/webhook/slack`` route + the helpers it depends on:
+
+  ``verify_slack_signature`` — HMAC-SHA256 + replay window
+  ``mint_envelope_from_slack_event`` — Slack payload → Reyn envelope
+  POST /webhook/slack — full route flow (URL verification / signing /
+    event dispatch / target agent resolution / inbox push)
+
+The actual end-to-end "Slack message reaches LLM via agent inbox" is
+exercised via FastAPI TestClient + a registry mock that captures
+inbox pushes. The signing helper is unit-tested directly so the
+crypto path is verified independent of the route plumbing.
+
+Tier 2 because the webhook is the **only entry point** for Slack
+messages reaching Reyn. A regression in signing / parsing / inbox
+push silently breaks the entire Slack chat-transport.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+import pytest
+
+from reyn.chat.transport import ExternalRef
+from reyn.web.routers.webhook_slack import (
+    _SLACK_REPLAY_WINDOW_SECONDS,
+    mint_envelope_from_slack_event,
+    verify_slack_signature,
+)
+
+# ── verify_slack_signature ────────────────────────────────────────────
+
+
+def _sign(body: bytes, ts: str, secret: str) -> str:
+    """Helper: produce the Slack-format signature for body + timestamp."""
+    base = f"v0:{ts}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"v0={digest}"
+
+
+def test_verify_signature_accepts_well_formed_request():
+    """Tier 2: a request signed with the correct secret + fresh timestamp
+    passes verification.
+    """
+    secret = "test-secret"
+    body = b'{"hello": "world"}'
+    ts = str(int(time.time()))
+    sig = _sign(body, ts, secret)
+
+    ok, detail = verify_slack_signature(
+        body=body, timestamp=ts, signature=sig, signing_secret=secret,
+    )
+    assert ok is True
+    assert detail == "ok"
+
+
+def test_verify_signature_rejects_stale_timestamp():
+    """Tier 2: a request older than the replay window is rejected as
+    ``stale`` — protects against replay attacks.
+    """
+    secret = "test-secret"
+    body = b'{"hello": "world"}'
+    # Stale timestamp = 10 minutes ago.
+    ts = str(int(time.time()) - 600)
+    sig = _sign(body, ts, secret)
+
+    ok, detail = verify_slack_signature(
+        body=body, timestamp=ts, signature=sig, signing_secret=secret,
+    )
+    assert ok is False
+    assert detail == "stale"
+
+
+def test_verify_signature_rejects_signature_mismatch():
+    """Tier 2: signature computed with a different secret fails the
+    constant-time compare with ``mismatch`` detail.
+    """
+    body = b'{"x":1}'
+    ts = str(int(time.time()))
+    # Sign with the wrong secret.
+    bad_sig = _sign(body, ts, "wrong-secret")
+
+    ok, detail = verify_slack_signature(
+        body=body, timestamp=ts, signature=bad_sig,
+        signing_secret="real-secret",
+    )
+    assert ok is False
+    assert detail == "mismatch"
+
+
+def test_verify_signature_rejects_missing_headers():
+    """Tier 2: missing timestamp or signature returns a clear reason."""
+    secret = "s"
+
+    ok, detail = verify_slack_signature(
+        body=b"", timestamp="", signature="sig", signing_secret=secret,
+    )
+    assert ok is False
+    assert detail == "missing-timestamp"
+
+    ok, detail = verify_slack_signature(
+        body=b"", timestamp="1234", signature="", signing_secret=secret,
+    )
+    assert ok is False
+    assert detail == "missing-signature"
+
+
+def test_verify_signature_replay_window_boundary_inclusive():
+    """Tier 2: at exactly the window boundary (= 5 minutes), the
+    request still passes; one second past, it's stale. Pins the
+    boundary semantics.
+    """
+    secret = "s"
+    body = b""
+    now = 1_000_000.0
+    ts_at_boundary = str(int(now) - _SLACK_REPLAY_WINDOW_SECONDS)
+    sig = _sign(body, ts_at_boundary, secret)
+    ok, _ = verify_slack_signature(
+        body=body, timestamp=ts_at_boundary, signature=sig,
+        signing_secret=secret, now=now,
+    )
+    assert ok is True
+
+    ts_past = str(int(now) - _SLACK_REPLAY_WINDOW_SECONDS - 1)
+    sig = _sign(body, ts_past, secret)
+    ok, detail = verify_slack_signature(
+        body=body, timestamp=ts_past, signature=sig,
+        signing_secret=secret, now=now,
+    )
+    assert ok is False
+    assert detail == "stale"
+
+
+# ── mint_envelope_from_slack_event ────────────────────────────────────
+
+
+def test_mint_envelope_for_app_mention():
+    """Tier 2: an ``app_mention`` event mints an envelope with
+    sender=slack:<user_id> and ExternalRef reply_to carrying
+    channel + thread_ts.
+    """
+    event = {
+        "event": {
+            "type": "app_mention",
+            "user": "U456",
+            "text": "<@U_BOT> help me",
+            "channel": "C123",
+            "ts": "1234.5678",
+        },
+    }
+    env = mint_envelope_from_slack_event(event)
+    assert env is not None
+    assert env["text"] == "<@U_BOT> help me"
+    assert env["sender"] == "slack:U456"
+    rt = env["reply_to"]
+    assert isinstance(rt, ExternalRef)
+    assert rt.transport == "slack"
+    assert rt.destination == {"channel": "C123", "thread_ts": "1234.5678"}
+
+
+def test_mint_envelope_preserves_existing_thread_ts():
+    """Tier 2: when the user replies inside an existing thread, the
+    envelope's reply_to.thread_ts is the thread's ts, NOT the
+    message's own ts — so the agent reply joins the right thread.
+    """
+    event = {
+        "event": {
+            "type": "message",
+            "user": "U456",
+            "text": "follow-up",
+            "channel": "C123",
+            "ts": "9999.0001",
+            "thread_ts": "1234.5678",  # original parent
+        },
+    }
+    env = mint_envelope_from_slack_event(event)
+    assert env is not None
+    assert env["reply_to"].destination["thread_ts"] == "1234.5678"
+
+
+def test_mint_envelope_skips_bot_echo():
+    """Tier 2: a ``bot_message`` subtype (= echo of bot's own post) is
+    NOT dispatched to inbox — prevents feedback loops where the bot
+    receives its own messages.
+    """
+    event = {
+        "event": {
+            "type": "message",
+            "subtype": "bot_message",
+            "bot_id": "B999",
+            "text": "I (the bot) just posted",
+            "channel": "C123",
+            "ts": "1.0",
+        },
+    }
+    assert mint_envelope_from_slack_event(event) is None
+
+
+def test_mint_envelope_skips_non_message_events():
+    """Tier 2: reaction / channel_join / app_home events produce no
+    envelope. Operator can subscribe to broad event scopes without
+    risking accidental dispatch.
+    """
+    for event_type in ("reaction_added", "channel_join", "app_home_opened"):
+        event = {"event": {"type": event_type, "user": "U1", "channel": "C1"}}
+        assert mint_envelope_from_slack_event(event) is None
+
+
+def test_mint_envelope_skips_empty_text():
+    """Tier 2: an event with no text (= whitespace or missing) is
+    skipped. Nothing to dispatch to the LLM.
+    """
+    event = {
+        "event": {
+            "type": "app_mention",
+            "user": "U1",
+            "channel": "C1",
+            "ts": "1.0",
+            "text": "   ",
+        },
+    }
+    assert mint_envelope_from_slack_event(event) is None
+
+
+def test_mint_envelope_handles_missing_user_field():
+    """Tier 2: events without a ``user`` (= system messages, channel
+    purpose updates) get sender=slack:unknown but still dispatch
+    if they have text — defensive about Slack edge cases.
+    """
+    event = {
+        "event": {
+            "type": "message",
+            "text": "hi",
+            "channel": "C1",
+            "ts": "1.0",
+        },
+    }
+    env = mint_envelope_from_slack_event(event)
+    assert env is not None
+    assert env["sender"] == "slack:unknown"
+
+
+# ── route end-to-end via TestClient ───────────────────────────────────
+
+
+@pytest.fixture()
+def _slack_client(monkeypatch):
+    """FastAPI TestClient with a stubbed AgentRegistry.
+
+    Captures inbox pushes in a list on the client so tests can assert
+    the right envelope was dispatched without spinning up a real
+    ChatSession.
+    """
+    from fastapi.testclient import TestClient
+
+    pushes: list = []
+
+    class _StubSession:
+        async def _put_inbox(self, kind, payload):
+            pushes.append((kind, payload))
+            return "stub-msg-id"
+
+    class _StubRegistry:
+        async def ensure_running(self, name):
+            return _StubSession()
+
+    from reyn.web.routers import webhook_slack as _slack_router
+
+    def _stub_get_registry():
+        return _StubRegistry()
+
+    # Override the FastAPI dependency for this test.
+    from reyn.web.server import app
+    app.dependency_overrides[
+        _slack_router.router.dependencies[0].dependency
+        if _slack_router.router.dependencies
+        else None
+    ] = _stub_get_registry
+
+    # Cleaner override path: replace the get_registry symbol.
+    from reyn.web import deps
+    monkeypatch.setattr(deps, "_get_registry", _stub_get_registry)
+    # Also clear any cached singleton.
+    monkeypatch.setattr(deps, "_registry", None, raising=False)
+
+    client = TestClient(app)
+    client.pushes = pushes  # type: ignore[attr-defined]
+    yield client
+    app.dependency_overrides.clear()
+
+
+def test_route_url_verification_echoes_challenge(_slack_client):
+    """Tier 2 (#489 PR-D): the Slack URL verification handshake echoes
+    the challenge string back so api.slack.com can verify Reyn is
+    reachable + responding. This MUST work without signing — Slack
+    doesn't always sign the initial verify.
+    """
+    body = json.dumps({
+        "type": "url_verification",
+        "challenge": "abc123-test-challenge",
+    })
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"challenge": "abc123-test-challenge"}
+
+
+def test_route_rejects_missing_signing_secret(monkeypatch, _slack_client):
+    """Tier 2: with no ``SLACK_SIGNING_SECRET`` env var set, the
+    route returns 503 instead of crashing. Operator forgot to
+    configure → clear error in logs.
+    """
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+    body = json.dumps({
+        "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1",
+            "text": "hi", "ts": "1.0",
+        },
+    })
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 503
+    assert "signing secret" in response.json()["error"].lower()
+
+
+def test_route_rejects_bad_signature(monkeypatch, _slack_client):
+    """Tier 2: a request with the wrong signature returns 401. Even
+    if the body looks like a valid event, Reyn won't dispatch.
+    """
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "real-secret")
+    monkeypatch.setenv("SLACK_TARGET_AGENT", "test_agent")
+    body = json.dumps({
+        "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1",
+            "text": "hi", "ts": "1.0",
+        },
+    }).encode()
+    ts = str(int(time.time()))
+    bad_sig = _sign(body, ts, "wrong-secret")
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Slack-Request-Timestamp": ts,
+            "X-Slack-Signature": bad_sig,
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_route_dispatches_signed_app_mention_to_inbox(
+    monkeypatch, _slack_client,
+):
+    """Tier 2 (#489 PR-D end-to-end): a properly-signed ``app_mention``
+    event reaches the target agent's inbox with the right envelope.
+
+    This is the **happy path** for the Slack chat-transport: Slack
+    user @mentions the bot → Reyn webhook verifies signing → mints
+    envelope with sender + ExternalRef reply_to → pushes to inbox.
+    PR-A dispatch attribution + LLM processing kick in from there.
+    """
+    secret = "real-secret"
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", secret)
+    monkeypatch.setenv("SLACK_TARGET_AGENT", "news_agent")
+
+    body = json.dumps({
+        "event": {
+            "type": "app_mention",
+            "user": "U456",
+            "text": "<@U_BOT> today's news?",
+            "channel": "C123",
+            "ts": "1234.5678",
+        },
+    }).encode()
+    ts = str(int(time.time()))
+    sig = _sign(body, ts, secret)
+
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Slack-Request-Timestamp": ts,
+            "X-Slack-Signature": sig,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+    # One inbox push happened with the expected envelope.
+    pushes = _slack_client.pushes
+    assert len(pushes) == 1
+    kind, payload = pushes[0]
+    assert kind == "user"
+    assert payload["text"] == "<@U_BOT> today's news?"
+    assert payload["sender"] == "slack:U456"
+    rt = payload["reply_to"]
+    assert isinstance(rt, ExternalRef)
+    assert rt.transport == "slack"
+    assert rt.destination == {"channel": "C123", "thread_ts": "1234.5678"}
+
+
+def test_route_acks_non_dispatchable_events_with_200(
+    monkeypatch, _slack_client,
+):
+    """Tier 2: an event with no dispatchable payload (= reaction)
+    returns 200 with ``status="ignored"``. Slack won't retry.
+    """
+    secret = "real-secret"
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", secret)
+
+    body = json.dumps({
+        "event": {
+            "type": "reaction_added", "user": "U1", "channel": "C1",
+        },
+    }).encode()
+    ts = str(int(time.time()))
+    sig = _sign(body, ts, secret)
+
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Slack-Request-Timestamp": ts,
+            "X-Slack-Signature": sig,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "ignored"}
+    assert len(_slack_client.pushes) == 0
+
+
+def test_route_rejects_when_no_target_agent_configured(
+    monkeypatch, _slack_client,
+):
+    """Tier 2: a valid event arriving with no ``SLACK_TARGET_AGENT``
+    env returns 503 + clear error. Operator forgot agent config.
+    """
+    secret = "real-secret"
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", secret)
+    monkeypatch.delenv("SLACK_TARGET_AGENT", raising=False)
+
+    body = json.dumps({
+        "event": {
+            "type": "app_mention",
+            "user": "U1", "channel": "C1", "text": "hi", "ts": "1.0",
+        },
+    }).encode()
+    ts = str(int(time.time()))
+    sig = _sign(body, ts, secret)
+
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Slack-Request-Timestamp": ts,
+            "X-Slack-Signature": sig,
+        },
+    )
+    assert response.status_code == 503
+    assert "target agent" in response.json()["error"].lower()
+
+
+def test_route_malformed_json_returns_400(monkeypatch, _slack_client):
+    """Tier 2: non-JSON body returns 400 (= operator misconfig / bad
+    network, not Reyn's fault).
+    """
+    response = _slack_client.post(
+        "/webhook/slack",
+        content=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+def test_route_mounted_on_app():
+    """Tier 2: ``/webhook/slack`` is registered on the FastAPI app.
+    Without this, all other tests in this module would fall through
+    to FastAPI's default 404, masking a mount regression.
+    """
+    from reyn.web.server import app
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert "/webhook/slack" in paths


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 Phase 1 **PR-D** = Slack inbound chat-transport handler。 ⚠️ **Stacked on PR-C** (#509) — base 切替必要 after PR-C merge。

## Summary

Slack Events API webhook を受けて Reyn agent inbox に envelope を push する **inbound** handler。 outbound (= agent reply → outbox subscriber → Slack MCP server) は **PR-D2 follow-up**、 inbound 単独で end-to-end 動作 (= Slack message が LLM に届く、 reply が Slack に返るのは PR-D2 で)。

## End-to-end flow

```
Slack user @mentions bot
  ↓ POST /webhook/slack (Slack Events API)
Reyn webhook handler
  ├─ URL verification handshake (= setup 時の challenge echo)
  ├─ HMAC-SHA256 signing verify + replay-window guard
  ├─ Event parse + envelope mint
  ↓ envelope:
  {
    text: "<@U_BOT> today's news?",
    sender: "slack:U456",                # PR-A attribution
    reply_to: ExternalRef(transport="slack", destination={channel, thread_ts}),
  }
  ↓ registry.ensure_running(SLACK_TARGET_AGENT) + session._put_inbox("user", envelope)
ChatSession router_loop consumes
  ├─ PR-A _handle_sender_attribution → state_change inject
  ├─ LLM processes attributed turn
  └─ reply goes to outbox (= PR-D2 picks up here)
```

## Defensive HTTP posture

| Case | Status | Slack behavior |
|---|---|---|
| URL verification | 200 + challenge echo | done |
| Missing signing secret env | 503 | retry |
| Bad signature | 401 | retry |
| Malformed JSON body | 400 | drop |
| Non-dispatchable event (= reaction/joined) | 200 ``ignored`` | drop |
| No target agent configured | 503 | retry |
| Target agent not found | 503 | retry |
| Inbox push failure | 500 | retry |
| **Happy path** | 200 ``ok`` | done |

## Operator setup

1. Create Slack App at api.slack.com
2. Event Subscriptions → Request URL: ``https://<reyn>/webhook/slack``
3. Subscribe to ``app_mention``, ``message.im``
4. Install app in workspace
5. Set ``SLACK_SIGNING_SECRET`` + ``SLACK_TARGET_AGENT`` env vars on Reyn
6. At-mention bot in any channel → message reaches Reyn agent inbox

## What's NOT in this PR (= PR-D2 follow-up)

- Outbox subscriber filtering ``ExternalRef``
- ``reply_to`` propagation inbox → session state → outbox
- MCP dispatcher closure for ``route_to_mcp``
- ``ReynConfig.external_transports`` + ``slack`` section parsing
- Per-user / per-channel ACL (= currently single ``SLACK_TARGET_AGENT`` env)

## Change shape

- ``src/reyn/web/routers/webhook_slack.py`` (new, ~280 lines): helpers (= signing verify / envelope mint) + route handler + Slack docs
- ``src/reyn/web/server.py``: mount at top-level ``/webhook/slack``
- ``tests/web/test_webhook_slack_router.py`` (new, 19 tests):
  - ``verify_slack_signature`` direct (= 5 tests)
  - ``mint_envelope_from_slack_event`` (= 6 tests)
  - Route end-to-end via TestClient + stubbed registry (= 8 tests)

## Test plan

- [x] ``pytest tests/web/test_webhook_slack_router.py`` — 19/19 pass
- [x] ``pytest tests/`` (full suite) — 4931 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## FP-0041 Phase 1 progression

| # | Scope | Status |
|---|---|---|
| PR-A | envelope sender + dispatch attribution | MERGED (#498) |
| PR-B | cron message shape + dispatch runner | OPEN (#499) |
| PR-B2 | LLM-callable cron tool surface | OPEN stacked on PR-B (#507) |
| PR-C | external transport routing primitive | OPEN main base (#509) |
| **PR-D** | **Slack inbound webhook (= 本 PR)** | **OPEN stacked on PR-C** |
| PR-D2 | Slack outbound (= reply propagation + outbox subscriber) | next |
| PR-E | LINE chat-transport handler | parallel-able |

Refs #489 (FP-0041 PR-D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)