### PR TITLE
feat(chat): Slack outbound via outbox interceptor — reply_to propagation + ExternalTransportRouting wiring (FP-0041 #489 PR-D2)

### DIFF
--- a/src/reyn/chat/external_routing.py
+++ b/src/reyn/chat/external_routing.py
@@ -271,11 +271,93 @@ async def route_to_mcp(
     )
 
 
+# ── Outbox interceptor factory (= FP-0041 #489 PR-D2 wiring) ───────────
+
+
+# OutboxMessage type is imported lazily inside the factory to avoid a
+# circular import (= chat.outbox imports transport; this module
+# imports nothing from chat to keep it pure for unit tests).
+
+
+def make_outbox_interceptor(
+    *,
+    routing: ExternalTransportRouting,
+    mcp_dispatcher: Callable[[str, dict], Awaitable[Any]],
+    dispatchable_kinds: tuple[str, ...] = ("agent",),
+) -> Callable[[Any], Awaitable[bool]]:
+    """Build an outbox interceptor for FP-0041 PR-D2 wiring.
+
+    Returns an async ``(OutboxMessage) -> bool`` callable to register
+    on ``ChatSession._outbox_interceptor``. When invoked:
+
+      1. If ``msg.reply_to`` is not an ``ExternalRef`` → return False
+         (= caller falls through to normal outbox queue).
+      2. If ``msg.kind`` is not in ``dispatchable_kinds`` → return False
+         (= status/trace/__end__/intervention are display-only, not
+         relayed to the external transport).
+      3. Otherwise dispatch via ``route_to_mcp``. On ``status="ok"``
+         or ``status="error"`` (= operator-visible via logs) the
+         message is consumed (= return True).
+         On ``status="unconfigured"`` the message falls through (=
+         return False) so the TUI gets a visible signal that the
+         operator config is incomplete.
+
+    The interceptor swallows ``route_to_mcp`` exceptions internally
+    (= ``route_to_mcp`` already converts dispatcher exceptions to
+    ``RouteResult(status="error", ...)``), so it never raises out to
+    the session.
+
+    Parameters
+    ----------
+    routing:
+        Parsed ``ExternalTransportRouting`` config (= mapping from
+        transport name to MCP tool + args template).
+    mcp_dispatcher:
+        Async callable ``(mcp_tool_name, args) -> result`` that
+        invokes the actual MCP tool. Supplied by the caller (= web
+        lifespan / session factory) and closes over the session's
+        MCP client.
+    dispatchable_kinds:
+        Outbox message kinds that should be relayed to external
+        transport. Default ``("agent",)`` — only the LLM-produced
+        reply is sent to Slack/LINE/etc., NOT the various status /
+        trace / intervention / __end__ display markers that don't
+        belong in an external chat surface.
+    """
+    from reyn.chat.transport import ExternalRef
+
+    async def _interceptor(msg: Any) -> bool:
+        reply_to = getattr(msg, "reply_to", None)
+        if not isinstance(reply_to, ExternalRef):
+            return False
+        if getattr(msg, "kind", None) not in dispatchable_kinds:
+            return False
+        text = getattr(msg, "text", "") or ""
+        result = await route_to_mcp(
+            reply_to.transport,
+            dict(reply_to.destination),
+            text,
+            routing=routing,
+            mcp_dispatcher=mcp_dispatcher,
+        )
+        if result.status == "unconfigured":
+            # Let it fall through to the normal queue path so the
+            # operator sees something in TUI / log instead of silent
+            # drop. ``route_to_mcp`` already logged the detail.
+            return False
+        # ok / error → consumed. error means we tried; surfacing on
+        # TUI on every Slack post failure would be noisy.
+        return True
+
+    return _interceptor
+
+
 __all__ = [
     "ExternalTransportEntry",
     "ExternalTransportRouting",
     "RouteResult",
     "build_mcp_args",
+    "make_outbox_interceptor",
     "parse_external_transports",
     "route_to_mcp",
 ]

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1186,6 +1186,21 @@ class ChatSession:
         # agent now) can emit a state_change history entry. None until
         # the first attributed turn is dispatched.
         self._last_sender: str | None = None
+        # FP-0041 (#489) PR-D2: humanic reply attribution.
+        # When an inbox payload carries a ``reply_to`` (= ExternalRef
+        # / A2aRef / etc. encoded by the inbound handler), the dispatch
+        # attribution captures it here so subsequent agent replies via
+        # ``_put_outbox`` default to that reply_to. Cleared / replaced
+        # at each sender transition.
+        self._last_reply_to: Any = None
+        # FP-0041 (#489) PR-D2: outbox interceptor for external transport.
+        # An async callable ``(OutboxMessage) -> bool`` invoked from
+        # ``_put_outbox`` before queueing. When it returns True, the
+        # message is consumed by the interceptor (= dispatched to e.g.
+        # Slack via MCP) and NOT queued for TUI display. Set by web
+        # lifespan / session factory when external transports are
+        # configured; ``None`` skips interception (= default).
+        self._outbox_interceptor: Any = None
         # FP-0034 Phase 2 step 1: build the ActionEmbeddingIndex +
         # EmbeddingProvider once per session when the operator has
         # configured ``action_retrieval.embedding_class``.  Both stay
@@ -1728,6 +1743,15 @@ class ChatSession:
         """
         if not isinstance(payload, dict):
             return
+        # FP-0041 #489 PR-D2: capture reply_to from payload regardless
+        # of sender transition (= even a same-sender follow-up may have
+        # a new reply_to, e.g. different Slack thread). When the payload
+        # doesn't carry reply_to, the previous value is preserved (=
+        # downstream interceptor handles the "no reply_to" case by
+        # falling through to the default surface).
+        reply_to = payload.get("reply_to")
+        if reply_to is not None:
+            self._last_reply_to = reply_to
         new_sender = payload.get("sender")
         if not new_sender or not isinstance(new_sender, str):
             return
@@ -2464,7 +2488,40 @@ class ChatSession:
         `intervention`/`error`/`__end__` are kept so they reach the user
         when re-attached or remain in history (history append happens
         independently in callers).
+
+        FP-0041 #489 PR-D2: outbox reply_to + external transport interceptor.
+          - When ``msg.reply_to`` is unset and the session has a recent
+            inbox-captured ``_last_reply_to``, the outbox message
+            inherits it (= so the agent's reply automatically routes
+            back to the producer's transport without each emit site
+            needing to know).
+          - When ``msg.reply_to`` is an external transport (=
+            ``ExternalRef``) and an outbox interceptor is registered,
+            the interceptor is invoked. If it returns ``True``, the
+            message is treated as fully handled (= dispatched to e.g.
+            Slack via MCP) and NOT queued for TUI display. If it
+            returns ``False`` or raises, the message falls through to
+            the normal queue path (= defensive: a failed external
+            dispatch surfaces to TUI rather than silently disappearing).
         """
+        # PR-D2: default reply_to from last captured inbox reply_to.
+        if msg.reply_to is None and self._last_reply_to is not None:
+            from dataclasses import replace
+            msg = replace(msg, reply_to=self._last_reply_to)
+        # PR-D2: external transport interceptor.
+        if self._outbox_interceptor is not None:
+            from reyn.chat.transport import ExternalRef
+            if isinstance(msg.reply_to, ExternalRef):
+                try:
+                    handled = await self._outbox_interceptor(msg)
+                except Exception:
+                    logger.exception(
+                        "outbox interceptor raised for reply_to=%r; "
+                        "falling through to queue", msg.reply_to,
+                    )
+                    handled = False
+                if handled:
+                    return
         if not self.is_attached and msg.kind in {"status", "trace"}:
             return
         await self.outbox.put(msg)

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1491,6 +1491,24 @@ class ReynConfig:
     # FP-0009 Component B — cron-driven scheduled skill execution.
     # Empty by default; operator declares jobs in reyn.yaml ``cron.jobs``.
     cron: CronConfig = field(default_factory=CronConfig)
+    # FP-0041 #489 PR-D2 — external chat transport routing (= Slack /
+    # LINE / Discord etc.). Empty by default; operator declares
+    # transport → MCP tool mapping in reyn.yaml ``external_transports``.
+    # See ``reyn.chat.external_routing.ExternalTransportRouting``.
+    external_transports: "ExternalTransportRouting" = field(
+        default_factory=lambda: _empty_external_transports(),
+    )
+
+
+def _empty_external_transports():
+    """Lazy import shim for the default ``ExternalTransportRouting``.
+
+    Avoids importing ``reyn.chat.external_routing`` at module-load time
+    (= ``reyn.config`` is imported very early; the chat-side import
+    would create a cycle).
+    """
+    from reyn.chat.external_routing import ExternalTransportRouting
+    return ExternalTransportRouting()
 
 
 def _load_yaml(path: Path) -> dict:
@@ -1799,7 +1817,22 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         self_improvement=_build_self_improvement_config(merged.get("self_improvement")),
         action_retrieval=_build_action_retrieval_config(merged.get("action_retrieval")),
         cron=_build_cron_config(merged.get("cron")),
+        external_transports=_build_external_transports_config(
+            merged.get("external_transports"),
+        ),
     )
+
+
+def _build_external_transports_config(raw: object):
+    """Parse the ``external_transports:`` section (FP-0041 #489 PR-D2).
+
+    Defers to ``reyn.chat.external_routing.parse_external_transports``
+    which handles defensive parsing (= malformed entries silently
+    skipped). Lazy import to avoid the same circular dependency
+    addressed by ``_empty_external_transports``.
+    """
+    from reyn.chat.external_routing import parse_external_transports
+    return parse_external_transports(raw)
 
 
 def _build_voice_config(raw: object) -> VoiceConfig:

--- a/tests/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/test_fp0041_prd2_outbox_interceptor.py
@@ -1,0 +1,383 @@
+"""Tier 2: FP-0041 #489 PR-D2 — Slack outbound via outbox interceptor.
+
+End-to-end reply path completion for the Slack chat-transport. PR-D
+landed inbound (= Slack → Reyn inbox). PR-D2 completes outbound:
+
+  inbox payload reply_to (= ExternalRef from PR-D handler)
+    → ChatSession captures into self._last_reply_to
+    → agent reply via _put_outbox
+    → reply_to defaults from _last_reply_to (when not explicit)
+    → _outbox_interceptor invoked (= PR-D2 wiring)
+    → make_outbox_interceptor dispatches via route_to_mcp (PR-C)
+    → Slack MCP server chat.postMessage (= operator-installed)
+
+Tests:
+
+  1. Sender attribution also captures reply_to into _last_reply_to
+  2. _put_outbox defaults missing reply_to from _last_reply_to
+  3. _put_outbox invokes interceptor when reply_to is ExternalRef
+  4. Interceptor return True → message NOT queued (= consumed by
+     external transport, no TUI duplicate)
+  5. Interceptor return False → message falls through to queue
+  6. Interceptor exception → falls through to queue (= defensive)
+  7. Non-ExternalRef reply_to (= TuiRef etc.) → interceptor skipped
+  8. make_outbox_interceptor dispatch matrix (= ok/error/unconfigured/
+     non-dispatchable kind / non-ExternalRef)
+  9. ReynConfig.external_transports loads from yaml + lazy import OK
+
+Tier 2 because this is the load-bearing wiring that makes Slack
+chat-transport actually work end-to-end. Without it, PR-D inbound
+delivers messages but no reply ever reaches Slack.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.external_routing import (
+    ExternalTransportEntry,
+    ExternalTransportRouting,
+    make_outbox_interceptor,
+)
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.session import ChatSession
+from reyn.chat.transport import ExternalRef, TuiRef
+from reyn.events.state_log import StateLog
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+# ── Section 1: reply_to capture from inbox attribution ────────────────
+
+
+def test_attribution_captures_reply_to_from_payload(tmp_path):
+    """Tier 2: when inbox payload carries ``reply_to``, the dispatch
+    attribution helper saves it into ``self._last_reply_to`` for
+    later outbox emission.
+    """
+    session = _make_session(tmp_path)
+    rt = ExternalRef(transport="slack", destination={"channel": "C1"})
+    session._handle_sender_attribution({
+        "sender": "slack:U1",
+        "reply_to": rt,
+    })
+    assert session._last_reply_to is rt
+
+
+def test_attribution_does_not_clear_reply_to_when_payload_lacks_it(tmp_path):
+    """Tier 2: a follow-up payload without reply_to preserves the
+    previously captured value (= same-thread follow-ups inherit the
+    original reply_to without each producer needing to re-attach).
+    """
+    session = _make_session(tmp_path)
+    rt = ExternalRef(transport="slack", destination={"channel": "C1"})
+    session._handle_sender_attribution({"sender": "slack:U1", "reply_to": rt})
+    # Second payload, no reply_to.
+    session._handle_sender_attribution({"sender": "slack:U1"})
+    assert session._last_reply_to is rt
+
+
+def test_attribution_updates_reply_to_when_payload_carries_new_one(tmp_path):
+    """Tier 2: a new reply_to in the payload replaces the prior value
+    (= different Slack thread / different transport).
+    """
+    session = _make_session(tmp_path)
+    session._last_reply_to = ExternalRef(transport="slack", destination={"channel": "C1"})
+    new_rt = ExternalRef(transport="slack", destination={"channel": "C2"})
+    session._handle_sender_attribution({
+        "sender": "slack:U1", "reply_to": new_rt,
+    })
+    assert session._last_reply_to is new_rt
+
+
+# ── Section 2: _put_outbox reply_to defaulting + interceptor ──────────
+
+
+@pytest.mark.asyncio
+async def test_put_outbox_inherits_reply_to_from_last(tmp_path):
+    """Tier 2: an OutboxMessage without explicit reply_to picks up
+    the session's ``_last_reply_to`` so the agent's reply
+    automatically routes back.
+    """
+    session = _make_session(tmp_path)
+    rt = ExternalRef(transport="slack", destination={"channel": "C1"})
+    session._last_reply_to = rt
+
+    msg = OutboxMessage(kind="agent", text="hello back")
+    await session._put_outbox(msg)
+    queued = await session.outbox.get()
+    assert queued.reply_to is rt
+
+
+@pytest.mark.asyncio
+async def test_put_outbox_keeps_explicit_reply_to(tmp_path):
+    """Tier 2: an explicit reply_to on the OutboxMessage is NOT
+    overwritten by ``_last_reply_to`` defaulting (= producer code
+    that explicitly sets reply_to wins).
+    """
+    session = _make_session(tmp_path)
+    session._last_reply_to = ExternalRef(transport="slack", destination={"channel": "C1"})
+
+    explicit = TuiRef()
+    msg = OutboxMessage(kind="agent", text="x", reply_to=explicit)
+    await session._put_outbox(msg)
+    queued = await session.outbox.get()
+    assert queued.reply_to is explicit
+
+
+@pytest.mark.asyncio
+async def test_put_outbox_invokes_interceptor_for_external_ref(tmp_path):
+    """Tier 2: interceptor is called when reply_to is ExternalRef and
+    one is registered. Return True → message NOT queued.
+    """
+    session = _make_session(tmp_path)
+    intercepted: list = []
+
+    async def _interceptor(msg):
+        intercepted.append(msg)
+        return True
+
+    session._outbox_interceptor = _interceptor
+    rt = ExternalRef(transport="slack", destination={"channel": "C1"})
+    msg = OutboxMessage(kind="agent", text="hi", reply_to=rt)
+    await session._put_outbox(msg)
+
+    assert len(intercepted) == 1
+    assert intercepted[0].reply_to is rt
+    # Not queued.
+    assert session.outbox.empty()
+
+
+@pytest.mark.asyncio
+async def test_put_outbox_interceptor_returns_false_falls_through(tmp_path):
+    """Tier 2: when the interceptor returns False (= "I can't handle
+    this, send it to TUI"), the message proceeds to the normal
+    outbox queue. Used for unconfigured transports so the operator
+    sees the message somewhere.
+    """
+    session = _make_session(tmp_path)
+
+    async def _passthrough(msg):
+        return False
+
+    session._outbox_interceptor = _passthrough
+    rt = ExternalRef(transport="unknown", destination={})
+    msg = OutboxMessage(kind="agent", text="x", reply_to=rt)
+    await session._put_outbox(msg)
+
+    queued = await session.outbox.get()
+    assert queued.reply_to is rt
+
+
+@pytest.mark.asyncio
+async def test_put_outbox_interceptor_exception_falls_through(tmp_path):
+    """Tier 2: a buggy interceptor (= raises) does NOT crash
+    ``_put_outbox``; the message proceeds to the queue so the user
+    sees something. Defensive isolation.
+    """
+    session = _make_session(tmp_path)
+
+    async def _boom(msg):
+        raise RuntimeError("interceptor bug")
+
+    session._outbox_interceptor = _boom
+    rt = ExternalRef(transport="slack", destination={"channel": "C1"})
+    msg = OutboxMessage(kind="agent", text="x", reply_to=rt)
+    await session._put_outbox(msg)
+
+    queued = await session.outbox.get()
+    assert queued.reply_to is rt
+
+
+@pytest.mark.asyncio
+async def test_put_outbox_interceptor_skipped_for_non_external_ref(tmp_path):
+    """Tier 2: a TuiRef (= local terminal reply) does NOT trigger the
+    interceptor. Only ExternalRef paths.
+    """
+    session = _make_session(tmp_path)
+    called: list = []
+
+    async def _interceptor(msg):
+        called.append(msg)
+        return True
+
+    session._outbox_interceptor = _interceptor
+    msg = OutboxMessage(kind="agent", text="x", reply_to=TuiRef())
+    await session._put_outbox(msg)
+
+    assert called == []
+    queued = await session.outbox.get()
+    assert queued is msg
+
+
+# ── Section 3: make_outbox_interceptor dispatch matrix ────────────────
+
+
+@pytest.mark.asyncio
+async def test_make_interceptor_dispatches_external_ref():
+    """Tier 2: the factory-produced interceptor routes ExternalRef
+    messages through ``route_to_mcp`` and the supplied
+    ``mcp_dispatcher``.
+    """
+    dispatched: list = []
+
+    async def _mcp(tool, args):
+        dispatched.append((tool, args))
+        return None
+
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"channel": "{destination.channel}", "text": "{text}"},
+        ),
+    })
+    interceptor = make_outbox_interceptor(
+        routing=routing, mcp_dispatcher=_mcp,
+    )
+    msg = OutboxMessage(
+        kind="agent", text="hello",
+        reply_to=ExternalRef(transport="slack", destination={"channel": "C1"}),
+    )
+    handled = await interceptor(msg)
+    assert handled is True
+    assert dispatched == [(
+        "slack__chat_postMessage",
+        {"channel": "C1", "text": "hello"},
+    )]
+
+
+@pytest.mark.asyncio
+async def test_make_interceptor_returns_false_for_unconfigured():
+    """Tier 2: when the transport isn't configured (= operator hasn't
+    declared an entry), the interceptor returns False so the message
+    falls through to TUI display — operator sees the missing config.
+    """
+    async def _mcp(tool, args):
+        pytest.fail("dispatcher should not be called for unconfigured")
+
+    routing = ExternalTransportRouting()  # empty
+    interceptor = make_outbox_interceptor(
+        routing=routing, mcp_dispatcher=_mcp,
+    )
+    msg = OutboxMessage(
+        kind="agent", text="x",
+        reply_to=ExternalRef(transport="slack", destination={}),
+    )
+    assert (await interceptor(msg)) is False
+
+
+@pytest.mark.asyncio
+async def test_make_interceptor_returns_true_on_dispatcher_error():
+    """Tier 2: a dispatcher exception → ``route_to_mcp`` returns
+    ``status="error"`` → interceptor consumes the message (= True)
+    so a flaky Slack server doesn't flood TUI with retries.
+    """
+    async def _failing(tool, args):
+        raise RuntimeError("Slack unreachable")
+
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"text": "{text}"},
+        ),
+    })
+    interceptor = make_outbox_interceptor(
+        routing=routing, mcp_dispatcher=_failing,
+    )
+    msg = OutboxMessage(
+        kind="agent", text="x",
+        reply_to=ExternalRef(transport="slack", destination={}),
+    )
+    assert (await interceptor(msg)) is True
+
+
+@pytest.mark.asyncio
+async def test_make_interceptor_skips_non_dispatchable_kinds():
+    """Tier 2: status / trace / __end__ / intervention messages are
+    NOT relayed to external transport even if they happen to carry
+    ExternalRef. Only ``agent`` (= LLM reply) by default.
+    """
+    async def _mcp(tool, args):
+        pytest.fail("dispatcher should not be called for non-agent kind")
+
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__post", args_template={"text": "{text}"},
+        ),
+    })
+    interceptor = make_outbox_interceptor(
+        routing=routing, mcp_dispatcher=_mcp,
+    )
+    rt = ExternalRef(transport="slack", destination={})
+    for kind in ("status", "trace", "__end__", "intervention", "error"):
+        msg = OutboxMessage(kind=kind, text="x", reply_to=rt)
+        assert (await interceptor(msg)) is False, f"kind={kind} unexpectedly handled"
+
+
+@pytest.mark.asyncio
+async def test_make_interceptor_skips_non_external_ref():
+    """Tier 2: a TuiRef reply_to is not the interceptor's concern;
+    return False to let the normal flow take over.
+    """
+    async def _mcp(tool, args):
+        pytest.fail("dispatcher should not be called for TuiRef")
+
+    routing = ExternalTransportRouting()
+    interceptor = make_outbox_interceptor(
+        routing=routing, mcp_dispatcher=_mcp,
+    )
+    msg = OutboxMessage(kind="agent", text="x", reply_to=TuiRef())
+    assert (await interceptor(msg)) is False
+
+
+# ── Section 4: ReynConfig.external_transports wiring ──────────────────
+
+
+def test_reyn_config_external_transports_defaults_to_empty(tmp_path, monkeypatch):
+    """Tier 2: a project without ``external_transports:`` loads cleanly
+    with an empty routing config (= no Slack/LINE configured).
+    """
+    from reyn.config import load_config
+
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config(cwd=tmp_path)
+
+    assert isinstance(cfg.external_transports, ExternalTransportRouting)
+    assert cfg.external_transports.transports == {}
+
+
+def test_reyn_config_external_transports_parses_well_formed_yaml(
+    tmp_path, monkeypatch,
+):
+    """Tier 2 (FP-0041 #489 PR-D2 end-to-end config wire): a
+    well-formed ``external_transports:`` section parses into
+    ``ReynConfig.external_transports`` with the documented dataclass
+    shape. Operator can declare Slack + LINE routing in reyn.yaml.
+    """
+    from reyn.config import load_config
+
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\n"
+        "external_transports:\n"
+        "  slack:\n"
+        "    mcp_tool: slack__chat_postMessage\n"
+        "    args_template:\n"
+        "      channel: \"{destination.channel}\"\n"
+        "      text: \"{text}\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config(cwd=tmp_path)
+
+    entry = cfg.external_transports.get("slack")
+    assert entry is not None
+    assert entry.mcp_tool == "slack__chat_postMessage"
+    assert entry.args_template["channel"] == "{destination.channel}"


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 Phase 1 **PR-D2** = Slack outbound (= complete the round-trip)。 ⚠️ **Stacked on PR-D** (#510) — rebase cascade after PR-C → PR-D merge.

## Summary

PR-D landed Slack **inbound** (= webhook → inbox)。 PR-D2 lands **outbound** = ChatSession captures inbox reply_to → agent reply via _put_outbox → outbox interceptor → route_to_mcp (PR-C) → Slack MCP server → chat.postMessage in original thread.

## End-to-end flow (= integration of PR-A + PR-C + PR-D + this PR)

```
Slack user posts → /webhook/slack (PR-D)
  → envelope {text, sender="slack:U...", reply_to=ExternalRef}
  → session.inbox.put
  → run_one_iteration → _handle_sender_attribution
  → [PR-D2 NEW] self._last_reply_to captured
  → [PR-A] state_change attribution entry
  → LLM processes → produces reply
  → _put_outbox(OutboxMessage(kind="agent", text=<reply>))
  → [PR-D2 NEW] reply_to defaults to _last_reply_to
  → [PR-D2 NEW] _outbox_interceptor invoked
  → make_outbox_interceptor → route_to_mcp (PR-C)
  → mcp_dispatcher invokes Slack MCP tool
  → Slack chat.postMessage in original thread
```

## What this PR ships

### ChatSession state

```python
self._last_reply_to: TransportRef | None
self._outbox_interceptor: async (OutboxMessage) -> bool | None
```

- ``_handle_sender_attribution`` 拡張: payload.reply_to を capture (= 不在時は preserve、 新値で update)
- ``_put_outbox`` 拡張: ``reply_to`` 不在時 ``_last_reply_to`` から default、 ExternalRef + interceptor 設定時に invoke、 True で queue.put skip

### Interceptor factory (= external_routing.py)

```python
make_outbox_interceptor(*, routing, mcp_dispatcher,
                        dispatchable_kinds=("agent",))
```

Dispatch matrix:
| Condition | Return | Effect |
|---|---|---|
| reply_to ≠ ExternalRef | False | normal queue path |
| msg.kind not in dispatchable_kinds | False | normal queue path |
| route_to_mcp status=ok | True | consumed (dispatched) |
| route_to_mcp status=error | True | consumed (= avoid TUI noise on flaky MCP) |
| route_to_mcp status=unconfigured | False | fall through (operator sees missing-config) |

### Config wiring

```yaml
# reyn.yaml or reyn.local.yaml
external_transports:
  slack:
    mcp_tool: slack__chat_postMessage
    args_template:
      channel: "{destination.channel}"
      thread_ts: "{destination.thread_ts}"
      text: "{text}"
```

``ReynConfig.external_transports: ExternalTransportRouting`` 新 field (= lazy import で chat ↔ config circular 回避)。

## What's NOT in this PR (= 意図的 split)

- **Web lifespan wiring** (= PR-D2.5 next): セッション factory に interceptor inject する側、 MCP dispatcher closure を session の MCP client で構築する glue。 primitive verify 後の薄い follow-up。
- **Per-user/per-channel ACL**: SLACK_TARGET_AGENT env で固定、 multi-agent dispatch は future
- **LINE outbound**: PR-E mirror

## Change shape

- ``src/reyn/chat/session.py``: ``_last_reply_to`` + ``_outbox_interceptor`` fields + attribution capture + ``_put_outbox`` defaulting/intercept
- ``src/reyn/chat/external_routing.py``: ``make_outbox_interceptor`` factory + dispatch matrix
- ``src/reyn/config.py``: ``ReynConfig.external_transports`` field + lazy-import shim + parser dispatch
- ``tests/test_fp0041_prd2_outbox_interceptor.py`` (new, 16 tests):
  - reply_to capture (3)
  - _put_outbox defaulting + interceptor (6)
  - make_outbox_interceptor dispatch matrix (5)
  - ReynConfig.external_transports yaml loading (2)

## Test plan

- [x] ``pytest tests/test_fp0041_prd2_outbox_interceptor.py`` — 16/16 pass
- [x] ``pytest tests/`` (full suite) — 4947 pass, 5 skip, 3 xfailed, 2 pre-existing unrelated failures deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## FP-0041 Phase 1 progression

| # | Scope | Status |
|---|---|---|
| PR-A | envelope sender + dispatch attribution | MERGED (#498) |
| PR-B | cron message shape + dispatch runner | OPEN (#499) |
| PR-B2 | LLM-callable cron tool surface | OPEN stacked PR-B (#507) |
| PR-C | external transport routing primitive | OPEN (#509) |
| PR-D | Slack inbound webhook handler | OPEN stacked PR-C (#510) |
| **PR-D2** | **Slack outbound interceptor + ReynConfig (= 本)** | **OPEN stacked PR-D** |
| PR-D2.5 | web lifespan dispatcher closure + register | next |
| PR-E | LINE chat-transport handler | parallel-able |

Refs #489 (FP-0041 PR-D2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)