### PR TITLE
fix(tui): boundary hint writes sticky-only, not log (G-F9)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1650,15 +1650,18 @@ class ConversationView(Widget):
         inward (= turn-flash fires), the dedup clears so re-hitting
         the boundary later flashes again.
 
-        Writes BOTH to the conv log (= permanent breadcrumb) AND to
-        StickyStatus (= immediately visible regardless of scroll
-        position). The log line alone wasn't enough because the
-        end-boundary case fires when the user is scrolled to the
-        last anchor — the new line at log-bottom is below the
-        viewport and invisible. This is the same family of issue
-        flagged by FS1 (turn N/M flash visibility); the sticky
-        surface here gives FS2 immediate readability without
-        depending on the FS1 follow-up.
+        Wave-10 follow-up G-F9: was previously dual-write (=
+        ``_write_log`` permanent breadcrumb + ``show_status``
+        sticky). The log line polluted scrollback — alternating
+        Ctrl+P / Ctrl+N at boundaries wrote two new ``↑ beginning``
+        / ``↓ end`` lines on every direction change, accumulating
+        as navigation artifacts indistinguishable from actual
+        conversation content. ``_flash_turn_position`` already
+        switched to sticky-only after FS1 fixed the visibility
+        gap; the sticky is docked at the conv pane's bottom and is
+        ALWAYS visible regardless of scroll position, so the log
+        line was redundant rather than a fallback. Drop the log
+        write; sticky alone is sufficient.
         """
         if direction == "start":
             text = "↑ beginning of history"
@@ -1672,12 +1675,10 @@ class ConversationView(Widget):
         # Clear the turn-flash dedup so a subsequent in-bounds
         # Ctrl+P/N re-flashes the turn number cleanly.
         self._last_turn_flash = None
-        # Permanent breadcrumb in the log (= readable when scrolled
-        # to bottom; matches the existing turn-flash convention).
-        self._write_log(Text(f"  {text}", style="dim italic #666666"))
-        # Immediate sticky cue — visible regardless of scroll
+        # Sticky-only surface — visible regardless of scroll
         # position. ``kind="general"`` reads as advisory (= grey
-        # accent) without preempting an active ``⟳ thinking…``.
+        # accent) without preempting an active ``⟳ thinking…``
+        # (= the wave-10 G-F8 + I-F8 priority guard handles that).
         self.show_status(text, kind="general")
 
     def _flash_turn_position(self, n: int, total: int, delta: int = -1) -> None:

--- a/tests/cli/test_boundary_hint_sticky_only.py
+++ b/tests/cli/test_boundary_hint_sticky_only.py
@@ -1,0 +1,105 @@
+"""Tier 2: boundary hint writes sticky-only, not log (G-F9).
+
+Wave-10 follow-up Topic G finding F9 (P2): ``_flash_boundary_hint``
+wrote to BOTH the sticky status and the conv log. The log line
+polluted scrollback — alternating Ctrl+P / Ctrl+N at boundaries
+wrote two new ``↑ beginning`` / ``↓ end`` lines on every
+direction change, accumulating in scroll history as navigation
+artifacts indistinguishable from conversation content.
+
+After the fix the log write is dropped; sticky-only matches the
+``_flash_turn_position`` convention (which switched to sticky-
+only after FS1). The sticky is docked at the conv pane bottom
+and is ALWAYS visible regardless of scroll position.
+
+Public surfaces tested:
+  - boundary hint sets sticky body (= visible cue path)
+  - boundary hint does NOT write a log line (= the pollution fix)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_start_boundary_hint_writes_sticky_only() -> None:
+    """Tier 2: ``start`` boundary → sticky body set + log unchanged."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv._log()
+        pre_lines = len(getattr(log, "lines", []))
+
+        conv._flash_boundary_hint("start")
+        await pilot.pause()
+
+        snap = conv._sticky().snapshot()
+        assert snap["active"] is True
+        assert "beginning of history" in snap["body"]
+        # Log line count must NOT have grown.
+        post_lines = len(getattr(log, "lines", []))
+        assert post_lines == pre_lines, (
+            f"boundary hint should not write a log line; "
+            f"pre={pre_lines} post={post_lines}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_end_boundary_hint_writes_sticky_only() -> None:
+    """Tier 2: ``end`` boundary → sticky body set + log unchanged."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv._log()
+        pre_lines = len(getattr(log, "lines", []))
+
+        conv._flash_boundary_hint("end")
+        await pilot.pause()
+
+        snap = conv._sticky().snapshot()
+        assert snap["active"] is True
+        assert "end of history" in snap["body"]
+        post_lines = len(getattr(log, "lines", []))
+        assert post_lines == pre_lines
+
+
+@pytest.mark.asyncio
+async def test_repeated_direction_dedup_unchanged() -> None:
+    """Tier 2 (regression): rapid boundary repeats still deduped."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # First start-boundary fires.
+        conv._flash_boundary_hint("start")
+        snap1 = conv._sticky().snapshot()
+        body_after_first = snap1["body"]
+        # Hide the sticky so we can tell whether the second call
+        # re-shows it.
+        conv.hide_status()
+        conv._flash_boundary_hint("start")
+        snap2 = conv._sticky().snapshot()
+        # Dedup → second call is a no-op → sticky stays hidden.
+        assert snap2["active"] is False, (
+            f"repeated start-boundary should dedup; sticky should stay "
+            f"hidden, got body_after_first={body_after_first!r} "
+            f"snap2={snap2!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up round 2 PR #2 (G-F9, P2 S). Single-scope: ``_flash_boundary_hint`` log-write removal.

## Sister PR articulation (row 7)

Touches ``conversation.py:_flash_boundary_hint`` only. PR #512 (G-F6) touches ``_write_agent_markdown_with_fold`` — different method, no conflict.

## Problem

``_flash_boundary_hint`` wrote both sticky AND a permanent log line. Alternating Ctrl+P / Ctrl+N at boundaries accumulated navigation artifacts in scrollback indistinguishable from real conversation content.

## Fix

Drop the ``_write_log`` call. Sticky is docked at conv pane bottom (always visible regardless of scroll), so the log line was redundant. Aligns with ``_flash_turn_position`` post-FS1.

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: start sticky + no log, end sticky + no log, repeated direction dedup (regression guard)
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)