### PR TITLE
feat(web): wire external transport outbox interceptor into session factory (FP-0041 #489 PR-D2.5)

### DIFF
--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -145,6 +145,55 @@ def get_perm_resolver():
 
 
 # ---------------------------------------------------------------------------
+# FP-0041 #489 PR-D2.5: external transport outbox interceptor wiring
+# ---------------------------------------------------------------------------
+
+
+def _wire_external_outbox_interceptor(session, routing) -> None:
+    """Build and attach the external transport outbox interceptor.
+
+    Composes:
+      - per-session MCP dispatcher (= closes over ``session`` so the
+        tool call uses the session's router OpContext: workspace,
+        events log, permission resolver).
+      - ``make_outbox_interceptor`` factory (= dispatch matrix landed
+        in PR-D2: ExternalRef + dispatchable kind → route_to_mcp).
+
+    Sets ``session._outbox_interceptor`` so ``_put_outbox`` consults
+    it on each agent reply.
+
+    The dispatcher resolves the MCP tool name ``<server>__<tool>``
+    (= the convention ``external_transports`` config uses) into a
+    server + tool pair, builds an ``MCPIROp``, and dispatches via
+    ``op_runtime.mcp.handle`` — the same path the LLM-callable
+    ``call_mcp_tool`` uses. Permission gating runs (= operator must
+    have declared ``mcp: [<server>]`` for the agent OR config-level
+    allow); failures propagate as exceptions and are surfaced through
+    ``RouteResult(status="error", ...)`` by the routing primitive.
+    """
+    from reyn.chat.external_routing import make_outbox_interceptor
+
+    async def _mcp_dispatcher(mcp_tool: str, args: dict):
+        if "__" not in mcp_tool:
+            raise ValueError(
+                f"external_transports mcp_tool must be '<server>__<tool>', "
+                f"got {mcp_tool!r}",
+            )
+        server, tool = mcp_tool.split("__", 1)
+        from reyn.op_runtime.mcp import handle as mcp_handle
+        from reyn.schemas.models import MCPIROp
+        op = MCPIROp(kind="mcp", server=server, tool=tool, args=dict(args))
+        ctx = session._make_router_op_context()
+        return await mcp_handle(op=op, ctx=ctx, caller="external_routing")
+
+    interceptor = make_outbox_interceptor(
+        routing=routing,
+        mcp_dispatcher=_mcp_dispatcher,
+    )
+    session._outbox_interceptor = interceptor
+
+
+# ---------------------------------------------------------------------------
 # AgentRegistry  (process-shared)
 # ---------------------------------------------------------------------------
 
@@ -202,6 +251,18 @@ def _get_registry():
                 embedding_config=config.embedding,
             )
             s.load_history()
+            # FP-0041 #489 PR-D2.5: external transport outbox interceptor.
+            # When the operator has declared ``external_transports`` in
+            # reyn.yaml (= e.g. Slack / LINE / Discord routing), build
+            # the per-session interceptor so agent replies to inbox
+            # messages carrying ``ExternalRef`` reply_to are dispatched
+            # via the configured MCP tools instead of the TUI display
+            # queue. The dispatcher closure captures ``s`` so each
+            # session's MCP-tool invocations route through that
+            # session's own router OpContext (= permission gate,
+            # workspace, events log all from the right session).
+            if config.external_transports.transports:
+                _wire_external_outbox_interceptor(s, config.external_transports)
             return s
 
         registry = AgentRegistry(

--- a/tests/web/test_external_outbox_interceptor_wiring.py
+++ b/tests/web/test_external_outbox_interceptor_wiring.py
@@ -1,0 +1,295 @@
+"""Tier 2: FP-0041 #489 PR-D2.5 — web lifespan wiring for Slack outbound.
+
+Pins ``_wire_external_outbox_interceptor`` (= web/deps.py) which is
+called by the session factory when ``config.external_transports`` has
+entries. Composes:
+
+  - per-session MCP dispatcher (= closes over the session so the tool
+    call uses the session's router OpContext)
+  - ``make_outbox_interceptor`` (= dispatch matrix from PR-D2)
+
+And sets ``session._outbox_interceptor`` so the next agent reply with
+ExternalRef reply_to dispatches via Slack MCP tool.
+
+Tests:
+
+  1. Empty external_transports → session._outbox_interceptor stays None
+  2. Configured external_transports → session._outbox_interceptor set
+  3. Dispatcher resolves "<server>__<tool>" + calls op_runtime.mcp.handle
+  4. Dispatcher rejects mcp_tool name without "__" separator
+  5. Interceptor end-to-end through session._put_outbox (= post-wiring
+     behavior verified)
+
+Tier 2 because this wiring is the **final glue** that completes
+FP-0041 Phase 1 Slack chat-transport end-to-end. Without it, all
+the PR-A..PR-D2 primitives exist but nothing connects them in
+production deployments.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from reyn.chat.external_routing import (
+    ExternalTransportEntry,
+    ExternalTransportRouting,
+)
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.session import ChatSession
+from reyn.chat.transport import ExternalRef
+from reyn.events.state_log import StateLog
+from reyn.web.deps import _wire_external_outbox_interceptor
+
+
+def _make_session(tmp_path: Path) -> ChatSession:
+    return ChatSession(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "alpha.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+
+
+# ── wiring: empty vs configured ───────────────────────────────────────
+
+
+def test_wire_sets_interceptor_on_session(tmp_path):
+    """Tier 2: ``_wire_external_outbox_interceptor`` populates
+    ``session._outbox_interceptor`` so the next ``_put_outbox``
+    invocation consults it.
+    """
+    session = _make_session(tmp_path)
+    assert session._outbox_interceptor is None
+
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"channel": "{destination.channel}", "text": "{text}"},
+        ),
+    })
+    _wire_external_outbox_interceptor(session, routing)
+    assert session._outbox_interceptor is not None
+    assert callable(session._outbox_interceptor)
+
+
+# ── dispatcher: server+tool resolution ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_resolves_server_and_tool_from_mcp_tool_name(tmp_path):
+    """Tier 2: the per-session MCP dispatcher splits ``<server>__<tool>``
+    at the first ``__`` and dispatches via ``op_runtime.mcp.handle``
+    with the resolved server / tool / args.
+    """
+    session = _make_session(tmp_path)
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"channel": "{destination.channel}", "text": "{text}"},
+        ),
+    })
+    _wire_external_outbox_interceptor(session, routing)
+
+    # Mock op_runtime.mcp.handle to capture the dispatched op.
+    captured: list = []
+
+    async def _fake_handle(*, op, ctx, caller):
+        captured.append((op, caller))
+        return {"status": "ok"}
+
+    # Mock _make_router_op_context to return a dummy context (= avoids
+    # real workspace / events setup that the session normally needs).
+    session._make_router_op_context = lambda: object()  # type: ignore[method-assign]
+
+    with patch("reyn.op_runtime.mcp.handle", _fake_handle):
+        msg = OutboxMessage(
+            kind="agent", text="hello world",
+            reply_to=ExternalRef(
+                transport="slack",
+                destination={"channel": "C1", "thread_ts": "1.5"},
+            ),
+        )
+        await session._put_outbox(msg)
+
+    assert len(captured) == 1
+    op, caller = captured[0]
+    assert op.kind == "mcp"
+    assert op.server == "slack"
+    assert op.tool == "chat_postMessage"
+    assert op.args == {"channel": "C1", "text": "hello world"}
+    assert caller == "external_routing"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_rejects_tool_name_without_separator(tmp_path):
+    """Tier 2: an ``external_transports`` config entry with
+    ``mcp_tool`` missing the ``__`` separator (= operator typo) causes
+    the dispatcher to raise. ``route_to_mcp`` catches the exception
+    and converts to ``RouteResult(status="error")`` — interceptor
+    consumes the message but the error is logged for operator
+    debugging.
+    """
+    session = _make_session(tmp_path)
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="bad-no-separator",  # missing __
+            args_template={},
+        ),
+    })
+    _wire_external_outbox_interceptor(session, routing)
+    session._make_router_op_context = lambda: object()  # type: ignore[method-assign]
+
+    msg = OutboxMessage(
+        kind="agent", text="x",
+        reply_to=ExternalRef(transport="slack", destination={}),
+    )
+    # The interceptor returns True even on error (= consumed, not
+    # forwarded to TUI), so the queue stays empty. The dispatcher's
+    # raise becomes RouteResult(status="error") internally.
+    await session._put_outbox(msg)
+    assert session.outbox.empty()
+
+
+# ── end-to-end via interceptor + dispatcher ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_agent_reply_dispatches_to_mcp(tmp_path):
+    """Tier 2 (= **PR-D2.5 acceptance criteria**): after wiring, an
+    agent reply OutboxMessage with ExternalRef reply_to dispatches
+    via the MCP tool path AND is NOT queued for TUI display.
+
+    Verifies the full chain:
+      _put_outbox →
+        _outbox_interceptor (= make_outbox_interceptor product) →
+        route_to_mcp (= PR-C) →
+        mcp_dispatcher (= PR-D2.5 closure) →
+        op_runtime.mcp.handle (= mocked) →
+        return ok → interceptor returns True → queue.put skipped
+    """
+    session = _make_session(tmp_path)
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={
+                "channel": "{destination.channel}",
+                "text": "{text}",
+            },
+        ),
+    })
+    _wire_external_outbox_interceptor(session, routing)
+    session._make_router_op_context = lambda: object()  # type: ignore[method-assign]
+
+    async def _fake_handle(*, op, ctx, caller):
+        return {"status": "ok"}
+
+    with patch("reyn.op_runtime.mcp.handle", _fake_handle):
+        msg = OutboxMessage(
+            kind="agent", text="hello back",
+            reply_to=ExternalRef(
+                transport="slack",
+                destination={"channel": "C1"},
+            ),
+        )
+        await session._put_outbox(msg)
+
+    # NOT queued for TUI (= interceptor consumed it).
+    assert session.outbox.empty()
+
+
+@pytest.mark.asyncio
+async def test_tui_reply_still_queues_with_wiring_active(tmp_path):
+    """Tier 2: a TuiRef reply_to (= local terminal user) does NOT
+    trigger the interceptor even when wiring is active. Only
+    ExternalRef paths dispatch externally — local TUI chat path
+    remains unaffected by the Slack wiring.
+    """
+    from reyn.chat.transport import TuiRef
+
+    session = _make_session(tmp_path)
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"text": "{text}"},
+        ),
+    })
+    _wire_external_outbox_interceptor(session, routing)
+
+    msg = OutboxMessage(
+        kind="agent", text="local reply", reply_to=TuiRef(),
+    )
+    await session._put_outbox(msg)
+
+    queued = await session.outbox.get()
+    assert queued.text == "local reply"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_uses_session_router_op_context(tmp_path):
+    """Tier 2: the dispatcher closes over the session and calls
+    ``session._make_router_op_context()`` so the MCP tool invocation
+    runs through the session's own permission gate + workspace +
+    events log. Pins this is NOT a bare context (= would skip
+    permission check) by verifying the method is invoked.
+    """
+    session = _make_session(tmp_path)
+    routing = ExternalTransportRouting(transports={
+        "slack": ExternalTransportEntry(
+            mcp_tool="slack__chat_postMessage",
+            args_template={"text": "{text}"},
+        ),
+    })
+    _wire_external_outbox_interceptor(session, routing)
+
+    sentinel_ctx: Any = object()
+    op_ctx_calls: list = []
+
+    def _fake_make_ctx():
+        op_ctx_calls.append(True)
+        return sentinel_ctx
+
+    session._make_router_op_context = _fake_make_ctx  # type: ignore[method-assign]
+
+    captured_ctx: list = []
+
+    async def _fake_handle(*, op, ctx, caller):
+        captured_ctx.append(ctx)
+        return {"status": "ok"}
+
+    with patch("reyn.op_runtime.mcp.handle", _fake_handle):
+        msg = OutboxMessage(
+            kind="agent", text="x",
+            reply_to=ExternalRef(transport="slack", destination={}),
+        )
+        await session._put_outbox(msg)
+
+    assert len(op_ctx_calls) == 1, "session._make_router_op_context not invoked"
+    assert captured_ctx == [sentinel_ctx]
+
+
+# ── factory integration: gated on config ──────────────────────────────
+
+
+def test_factory_skips_wiring_when_no_external_transports(tmp_path):
+    """Tier 2: a project without ``external_transports`` config does
+    NOT get an interceptor — sessions stay as before, no risk of
+    misrouting local TUI messages through MCP.
+
+    Verified at the wiring helper level by directly checking that
+    when ``routing.transports`` is empty, the caller (= _session_factory
+    in deps.py) skips ``_wire_external_outbox_interceptor`` entirely.
+    The factory has::
+
+        if config.external_transports.transports:
+            _wire_external_outbox_interceptor(s, config.external_transports)
+
+    which is the only call site of the helper.
+    """
+    session = _make_session(tmp_path)
+    # Simulate the factory's gate: empty transports → no wiring.
+    routing = ExternalTransportRouting()
+    if routing.transports:
+        _wire_external_outbox_interceptor(session, routing)
+    assert session._outbox_interceptor is None


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 Phase 1 **PR-D2.5** = web lifespan wiring。 main 直 base。 **PR-A..PR-D2 を connect する final glue**、 Slack chat-transport end-to-end 完成。

## Summary

PR-D2 までで全 primitive (= envelope / attribution / cron / external_routing / Slack inbound / outbound interceptor primitive / ReynConfig field) が landed。 本 PR は session factory に interceptor を attach し、 operator 設定 + Slack MCP server install で **完全 round-trip 動作** を実現。

## End-to-end flow (= post-merge)

```
Slack user @mention
  → /webhook/slack (PR-D)
  → envelope mint (sender + ExternalRef reply_to)
  → session.inbox.put
  → run_one_iteration → _handle_sender_attribution
  → PR-A state_change + PR-D2 _last_reply_to capture
  → LLM 処理 → reply
  → _put_outbox(OutboxMessage(kind="agent", ...))
  → PR-D2 reply_to defaulting + _outbox_interceptor invocation
  → make_outbox_interceptor → route_to_mcp (PR-C)
  → ★ PR-D2.5 _mcp_dispatcher ★ → MCPIROp → op_runtime.mcp.handle
  → Slack MCP server → chat.postMessage in original thread
```

## What this PR ships

### Wiring helper (= `src/reyn/web/deps.py`)

```python
def _wire_external_outbox_interceptor(session, routing) -> None:
    async def _mcp_dispatcher(mcp_tool: str, args: dict):
        # "slack__chat_postMessage" → server="slack", tool="chat_postMessage"
        server, tool = mcp_tool.split("__", 1)
        op = MCPIROp(kind="mcp", server=server, tool=tool, args=args)
        ctx = session._make_router_op_context()  # ← permission gate / audit
        return await mcp_handle(op=op, ctx=ctx, caller="external_routing")
    
    interceptor = make_outbox_interceptor(
        routing=routing, mcp_dispatcher=_mcp_dispatcher,
    )
    session._outbox_interceptor = interceptor
```

### Session factory integration

```python
def _session_factory(profile):
    s = ChatSession(...)
    s.load_history()
    if config.external_transports.transports:
        _wire_external_outbox_interceptor(s, config.external_transports)
    return s
```

= operator が ``external_transports`` 宣言 → 全 session に interceptor 自動 attach。 宣言なし → 既存 local-only TUI 動作 unchanged。

## End-to-end acceptance (= PR-D2.5 完了基準)

- ✓ Agent reply + ExternalRef → MCP dispatch、 TUI queue **NOT** push
- ✓ Agent reply + TuiRef → 通常 TUI queue (= local 不変)
- ✓ status/trace/__end__/intervention + ExternalRef → TUI queue (= LLM reply ではない、 Slack に出さない)
- ✓ Dispatcher 例外 → route_to_mcp が ``status="error"`` 化、 interceptor consume、 error log のみ
- ✓ Permission gating → ``session._make_router_op_context()`` 経由で agent 宣言通り

## Change shape

- ``src/reyn/web/deps.py``: ``_wire_external_outbox_interceptor`` helper + ``_session_factory`` invocation gate
- ``tests/web/test_external_outbox_interceptor_wiring.py`` (new, 7 tests):
  - Wiring sets interceptor
  - Dispatcher server/tool resolution + op_runtime.mcp.handle invocation
  - Malformed mcp_tool name rejection (= route_to_mcp error swallow)
  - End-to-end through ``session._put_outbox`` (= PR-D2.5 acceptance)
  - TuiRef bypasses interceptor (= local unchanged)
  - Dispatcher uses session's router OpContext
  - Factory gates on config

## Test plan

- [x] ``pytest tests/web/test_external_outbox_interceptor_wiring.py`` — 7/7 pass
- [x] ``pytest tests/`` (full suite) — 5007 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## FP-0041 Phase 1 progression (= post-merge)

| # | Scope | PR | Status |
|---|---|---|---|
| PR-A | envelope sender + dispatch attribution | #498 | MERGED |
| PR-B | cron message shape + dispatch runner | #499 | MERGED |
| PR-B2 | LLM-callable cron tool surface | #507 | MERGED |
| PR-C | external transport routing primitive | #509 | MERGED |
| PR-D | Slack inbound webhook handler | #510 | MERGED |
| PR-D2 | Slack outbound + ReynConfig integration | #511 | MERGED |
| **PR-D2.5** | **web lifespan wiring (= 本 PR)** | TBD | **OPEN main base** |
| PR-E | LINE chat-transport handler | future | mirror of PR-D/D2 |

After this merge: **Phase 1 Slack chat-transport end-to-end complete**。 humanic vision (= 1 agent = 1 mind = 1 memory = N consumer with attribution) data layer foundation 完成。

Refs #489 (FP-0041 PR-D2.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)