### PR TITLE
fix(tui): dismiss_last_error guarantees breadcrumb for most-recent box (I-F3)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1243,41 +1243,60 @@ class ConversationView(Widget):
         stays visible in scroll history. ``(see events)`` is appended
         only when the error originated from a skill / run (= the same
         ``has_trace`` gate the ErrorBox's own ``.eb-hint`` label uses).
+
+        Wave-10 follow-up I-F3: previously this used a ``while`` loop
+        that would ``continue`` past boxes whose ``remove()`` raised
+        — silently swallowing the breadcrumb for the actual "most
+        recently mounted" box AND falling through to write a
+        breadcrumb for the NEXT-most-recent one instead. The docstring
+        promised "the most recently mounted" singular; the
+        implementation was "the most recently mounted that can be
+        removed without raising", with the breadcrumb pointing at the
+        wrong box on remove failure.
+
+        Restructured to a single iteration: pop the most recent box,
+        write its breadcrumb FIRST (= the load-bearing record per the
+        F2 intent), then best-effort ``remove()``. Removal failure no
+        longer affects the breadcrumb path.
         """
-        while self._error_boxes:
-            box = self._error_boxes.pop()
-            # Capture the summary BEFORE removal — `box` is invalidated
-            # by `remove()` and we still want to write the breadcrumb
-            # even if removal raises (= the widget was already gone).
-            first_line, _sep, _rest = (getattr(box, "_message", "") or "").partition("\n")
-            if len(first_line) > 72:
-                summary = first_line[:71] + "…"
-            else:
-                summary = first_line
-            has_trace = bool(
-                getattr(box, "_skill_name", "") or getattr(box, "_run_id_short", "")
-            )
-            try:
-                box.remove()
-            except Exception:
-                continue  # already removed, try next
-            trailer = " (see events)" if has_trace else ""
-            from rich.text import Text as _RichText
-            self._write_log(_RichText(
-                f"  ✗ {summary} (dismissed){trailer}",
-                style="dim #555555",
-            ))
-            # C-F4 (wave-8): after dismiss the live count drops by 1.
-            # If still ≥ 2, refresh the count sticky to the new value;
-            # otherwise the count form is stale and we clear the
-            # sticky so it doesn't linger as "2 errors" when only 1
-            # (or 0) remains.
-            n = len(self._error_boxes)
-            if n >= 2:
-                self._maybe_show_error_count_status()
-            else:
-                self.hide_status()
+        if not self._error_boxes:
             return
+        box = self._error_boxes.pop()
+        first_line, _sep, _rest = (getattr(box, "_message", "") or "").partition("\n")
+        if len(first_line) > 72:
+            summary = first_line[:71] + "…"
+        else:
+            summary = first_line
+        has_trace = bool(
+            getattr(box, "_skill_name", "") or getattr(box, "_run_id_short", "")
+        )
+        trailer = " (see events)" if has_trace else ""
+        from rich.text import Text as _RichText
+        # Write the breadcrumb FIRST so it lands regardless of whether
+        # the subsequent remove() succeeds. The F2 intent is "scroll
+        # history retains the failure context"; the DOM remove is
+        # secondary cleanup.
+        self._write_log(_RichText(
+            f"  ✗ {summary} (dismissed){trailer}",
+            style="dim #555555",
+        ))
+        try:
+            box.remove()
+        except Exception:
+            # Already removed / DOM teardown in progress / etc. The
+            # breadcrumb is in the log; that's the user-visible
+            # contract.
+            pass
+        # C-F4 (wave-8): after dismiss the live count drops by 1.
+        # If still ≥ 2, refresh the count sticky to the new value;
+        # otherwise the count form is stale and we clear the
+        # sticky so it doesn't linger as "2 errors" when only 1
+        # (or 0) remains.
+        n = len(self._error_boxes)
+        if n >= 2:
+            self._maybe_show_error_count_status()
+        else:
+            self.hide_status()
 
     def _maybe_show_error_count_status(self) -> None:
         """Surface the live ErrorBox count via the sticky when ≥ 2 stacked.

--- a/tests/cli/test_dismiss_last_error_single_iter.py
+++ b/tests/cli/test_dismiss_last_error_single_iter.py
@@ -1,0 +1,118 @@
+"""Tier 2: dismiss_last_error always writes breadcrumb for most-recent box (I-F3).
+
+Wave-10 follow-up Topic I finding F3 (P2): the previous
+``while self._error_boxes: ... continue`` loop swallowed the
+breadcrumb for the actual most-recently-mounted box if its
+``remove()`` raised, then fell through to write a breadcrumb for
+the NEXT-most-recent box. The docstring promised "the most
+recently mounted" singular; the implementation was "the most
+recently mounted that can be removed without raising".
+
+After the fix the method:
+  - pops a single box (= the most recent, ``[-1]``)
+  - writes the breadcrumb FIRST (= load-bearing per F2 intent)
+  - best-effort ``remove()`` — failure does not affect the
+    breadcrumb path
+
+Public surfaces tested:
+  - normal dismiss → breadcrumb for the most recent + remove
+  - dismiss with no boxes → no-op
+  - sequential dismisses pop in last-in-first-out order
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _log_text(conv) -> str:
+    log = conv._log()
+    return "\n".join(getattr(s, "text", "") for s in getattr(log, "lines", []))
+
+
+@pytest.mark.asyncio
+async def test_dismiss_writes_breadcrumb_for_most_recent_error() -> None:
+    """Tier 2: breadcrumb names the most recently mounted box."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="oldest error message")
+        conv.mount_error(message="middle error message")
+        conv.mount_error(message="most recent error message")
+        await pilot.pause()
+        assert len(conv._error_boxes) == 3
+
+        conv.dismiss_last_error()
+        await pilot.pause()
+
+        # Most recent box was dismissed → breadcrumb names IT.
+        log_text = _log_text(conv)
+        assert "most recent error message" in log_text, (
+            f"breadcrumb should reference the most recent box; "
+            f"log:\n{log_text!r}"
+        )
+        # The other two still in the list.
+        assert len(conv._error_boxes) == 2
+
+
+@pytest.mark.asyncio
+async def test_dismiss_with_no_errors_is_noop() -> None:
+    """Tier 2 (regression): empty list → safe no-op."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Must not raise.
+        conv.dismiss_last_error()
+        await pilot.pause()
+        assert conv._error_boxes == []
+
+
+@pytest.mark.asyncio
+async def test_sequential_dismisses_pop_last_in_first_out() -> None:
+    """Tier 2: three sequential dismisses → most-recent removed first."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="A oldest")
+        conv.mount_error(message="B middle")
+        conv.mount_error(message="C newest")
+        await pilot.pause()
+
+        conv.dismiss_last_error()  # → C
+        conv.dismiss_last_error()  # → B
+        conv.dismiss_last_error()  # → A
+        await pilot.pause()
+
+        assert conv._error_boxes == []
+        log_text = _log_text(conv)
+        # All three breadcrumbs written, in last-in-first-out order.
+        idx_C = log_text.find("C newest")
+        idx_B = log_text.find("B middle")
+        idx_A = log_text.find("A oldest")
+        assert idx_C != -1 and idx_B != -1 and idx_A != -1, (
+            f"all three dismissed errors should leave breadcrumbs; "
+            f"log:\n{log_text!r}"
+        )
+        # Order in log: C breadcrumb first (= most recent), then B, then A.
+        assert idx_C < idx_B < idx_A, (
+            f"breadcrumbs should appear in dismissal order (LIFO); "
+            f"idx_C={idx_C} idx_B={idx_B} idx_A={idx_A}"
+        )


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up round 2 PR #4 (I-F3, P2 S). Single-scope: ``dismiss_last_error`` restructure.

## Problem

``while`` loop with ``continue`` on ``remove()`` exception silently swallowed the breadcrumb for the actual most-recent box on remove failure. Doc said singular "most recently mounted"; impl was "most recently mounted that can be removed without raising".

## Fix

Single iteration matching the doc:
- pop most recent (``[-1]``)
- write breadcrumb FIRST (= load-bearing F2 intent)
- best-effort ``remove()``; failure doesn't affect breadcrumb

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: breadcrumb names most-recent, empty no-op, LIFO order
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)