### PR TITLE
fix(tui): clear() preserves today's date so same-day Ctrl+L doesn't dup separator (G-F13)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1825,7 +1825,19 @@ class ConversationView(Widget):
         # Reset header-grouping + turn anchors + fold stash
         self._last_speaker = ""
         self._last_speaker_at = 0.0
-        self._last_header_date = ""
+        # Wave-10 follow-up G-F13: preserve today's date as the
+        # "last separator date" so a same-day Ctrl+L doesn't emit
+        # another ``── YYYY-MM-DD ──`` separator on the next message.
+        # The separator is a *day-boundary* marker, not a session-start
+        # marker — emitting it every clear made it appear multiple
+        # times per day purely because the user cleared the pane.
+        # ``""`` is the cold-start value (= "no date written yet"), and
+        # the first message's ``_maybe_write_header`` would emit the
+        # separator unconditionally. Setting to today's date makes that
+        # branch a no-op for same-day clears while leaving day-crossing
+        # clears (= rare but possible if the user clears around midnight)
+        # correct.
+        self._last_header_date = time.strftime("%Y-%m-%d")
         self._last_turn_flash = None
         self._last_boundary_flash = None
         self._turn_anchors.clear()

--- a/tests/cli/test_clear_preserves_date_header.py
+++ b/tests/cli/test_clear_preserves_date_header.py
@@ -1,0 +1,109 @@
+"""Tier 2: clear() preserves today's date so same-day Ctrl+L doesn't dup separator (G-F13).
+
+Wave-10 follow-up Topic G finding F13 (P3): ``clear()`` reset
+``_last_header_date = ""`` which is the cold-start sentinel
+meaning "no date written yet". On the next message after a
+same-day Ctrl+L, ``_maybe_write_header`` saw the date sentinel,
+treated the day as un-marked, and emitted another
+``── YYYY-MM-DD ──`` separator. The separator is supposed to
+mark *day boundaries* — emitting it after every Ctrl+L on the
+same day made it appear multiple times per day purely from
+session-clear actions.
+
+After the fix ``clear()`` sets ``_last_header_date`` to today's
+date so a same-day clear suppresses the redundant separator;
+day-crossing clears (= rare midnight case) still emit correctly
+because the next message's ``today`` differs.
+
+Public surfaces tested:
+  - clear() sets ``_last_header_date`` to today's YYYY-MM-DD
+    string (= same format ``_maybe_write_header`` compares
+    against, so the next-message branch is a no-op for same-day)
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_clear_sets_last_header_date_to_today() -> None:
+    """Tier 2: post-clear ``_last_header_date`` equals today's YYYY-MM-DD.
+
+    Same-format invariant means the ``_maybe_write_header`` guard
+    ``if today != self._last_header_date`` evaluates False on the
+    next same-day message, suppressing the redundant separator.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv.clear()
+        await pilot.pause()
+
+        today = time.strftime("%Y-%m-%d")
+        assert conv._last_header_date == today, (
+            f"clear() should set _last_header_date to today's date "
+            f"({today!r}); got {conv._last_header_date!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_same_day_clear_does_not_emit_duplicate_date_separator() -> None:
+    """Tier 2: same-day Ctrl+L → next message has no extra separator.
+
+    End-to-end check: render a user message → date separator emits.
+    clear(). Render another user message → no new date separator
+    (= the same day was already marked).
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        today = time.strftime("%Y-%m-%d")
+
+        # First message → separator should appear.
+        conv.render_user_message("first message")
+        conv._render_agent_markdown(OutboxMessage(kind="agent", text="reply"))
+        await pilot.pause()
+        log_text = "\n".join(
+            getattr(s, "text", "") for s in getattr(conv._log(), "lines", [])
+        )
+        assert today in log_text, (
+            f"first message should emit today's date separator; got:\n{log_text!r}"
+        )
+        first_sep_count = log_text.count(today)
+
+        conv.clear()
+        await pilot.pause()
+
+        # Second message after clear → no NEW separator (= the same
+        # date was already marked).
+        conv.render_user_message("post-clear message")
+        await pilot.pause()
+        log_text_after = "\n".join(
+            getattr(s, "text", "") for s in getattr(conv._log(), "lines", [])
+        )
+        # Pre-fix: today appears ONCE more after clear (= dup separator).
+        # Post-fix: today appears 0 times (= log was cleared, no new
+        # separator emitted on the post-clear message).
+        assert today not in log_text_after, (
+            f"post-clear same-day message should not emit a new date "
+            f"separator; got:\n{log_text_after!r}"
+        )
+        del first_sep_count  # quiet linter


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up round 3 PR #2 (G-F13, P3 S). Single-scope: 1-line ``clear()`` assignment change.

## Problem

``_last_header_date = ""`` after clear → next same-day message emits another ``── YYYY-MM-DD ──`` separator. Heavy Ctrl+L users see multiple separators per day; the separator is supposed to mark day-boundaries, not session-clear events.

## Fix

``self._last_header_date = time.strftime("%Y-%m-%d")`` — pre-marks today as already-written so same-day suppresses; day-crossing clears still emit correctly because the next ``today`` differs.

## Test plan

- [x] ruff check passes
- [x] 2 new Tier 2 tests: post-clear sentinel == today, end-to-end same-day no-dup
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)