### PR TITLE
refactor(web): webhook plugin framework + extract Slack to sample plugin (FP-0041 #489 follow-up)

### DIFF
--- a/docs/plugins/authoring-guide.md
+++ b/docs/plugins/authoring-guide.md
@@ -1,0 +1,203 @@
+# Reyn plugin authoring guide
+
+> FP-0041 #489 follow-up — plugin framework spec for Reyn integrations
+> (= webhook handlers for Slack / LINE / Discord / GitHub etc.).
+
+This guide is for **plugin authors** who want to add inbound webhook
+integrations to Reyn (= e.g. a chat-transport adapter for a service
+not covered by the bundled samples).
+
+## Design rationale
+
+Reyn core stays free of transport-specific protocol code: signing
+schemes, event payload schemas, and SDK dependencies all live in
+plugins. The trade-off — operator installs an extra package — is
+worth it because:
+
+- Reyn maintainers don't track Slack / LINE / Discord / etc. API drift
+- Each transport's SDK choices stay local to its plugin
+- Operators run only the plugins they need
+- Community can ship plugins independent of Reyn's release cycle
+
+The bundled ``sample_*`` plugins under ``src/reyn/plugins/`` exist as
+reference implementations + quick-start fixtures. Production
+integrations should fork or replace them.
+
+## Plugin shape
+
+A webhook plugin is a Python package that exposes a single callable
+named ``register_router`` (= conventional) via the ``reyn.webhooks``
+entry point group.
+
+### Layout (= external package example)
+
+```
+my-reyn-webhook-line/
+├── pyproject.toml
+└── my_reyn_webhook_line/
+    ├── __init__.py     # exposes register_router
+    └── handler.py      # actual route logic
+```
+
+### Entry point declaration
+
+```toml
+# pyproject.toml
+[project]
+name = "my-reyn-webhook-line"
+version = "0.1.0"
+dependencies = ["fastapi", "reyn"]
+
+[project.entry-points."reyn.webhooks"]
+line = "my_reyn_webhook_line:register_router"
+```
+
+The entry point name (= ``line``) is what operators put in their
+``webhooks.yaml`` to activate this plugin.
+
+### register_router contract
+
+```python
+from fastapi import APIRouter
+
+def register_router(config: dict) -> APIRouter | None:
+    """Build the plugin's webhook router.
+
+    config: per-instance dict from webhooks.yaml, minus reyn-reserved
+            keys (package, enabled). Plugin-defined fields only.
+    returns: an APIRouter to mount, or None to skip (= e.g. required
+             option missing). When returning None, log a warning so
+             the operator can see why.
+    """
+    ...
+```
+
+The returned ``APIRouter`` is mounted on the Reyn web app at the path
+the plugin chooses. By convention webhook plugins use
+``/webhook/<service>`` as the route path so operators paste a
+predictable URL into their service's webhook config UI.
+
+## webhooks.yaml schema
+
+Operators activate plugins in ``webhooks.yaml`` (= sibling of
+``reyn.yaml`` at the project root):
+
+```yaml
+# webhooks.yaml
+
+# Short form: just the plugin name (= empty value)
+sample_slack:
+  target_agent: news_agent      # plugin-defined field
+
+# Long form: explicit reyn-reserved fields + plugin fields
+my_other_plugin:
+  package: reyn-plugin-line     # optional: disambiguates same-name plugins
+  enabled: false                # optional, default true
+  some_option: value            # plugin-defined
+```
+
+### Reyn-reserved keys
+
+The loader interprets these and removes them from what's passed to
+``register_router``:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| ``package`` | unset | Disambiguates when multiple packages register the same plugin name. Match against the Python distribution name. |
+| ``enabled`` | ``true`` | Set ``false`` to deactivate without removing config. |
+
+Plugin authors must avoid using these names in their plugin-defined
+fields.
+
+### Per-plugin options
+
+Everything in the per-plugin dict except the reyn-reserved keys is
+forwarded to ``register_router`` as the ``config`` argument. The
+plugin author defines this schema.
+
+Secrets (= API keys, signing secrets) belong in **environment
+variables**, never in webhooks.yaml.
+
+## Inbound envelope shape
+
+When the plugin's route receives a webhook, it should mint an
+envelope and push to the target agent's inbox:
+
+```python
+from reyn.chat.transport import ExternalRef
+
+envelope = {
+    "text": "<message body>",
+    "sender": f"<transport>:<external_user_id>",
+    "reply_to": ExternalRef(
+        transport="<transport>",        # e.g. "slack", "line"
+        destination={                   # transport-specific routing
+            "channel": "...",
+            "thread_ts": "...",
+        },
+    ),
+}
+
+# Push via the AgentRegistry (= from reyn.web.deps):
+session = await registry.ensure_running(target_agent)
+await session._put_inbox("user", envelope)
+```
+
+Reyn's session dispatch automatically:
+- Surfaces ``sender`` as a state_change history entry (= PR-A
+  attribution)
+- Captures ``reply_to`` for outbound reply routing (= PR-D2)
+
+## Outbound replies via MCP
+
+The Reyn-side outbox interceptor (= ``reyn.chat.external_routing``)
+routes agent replies whose ``reply_to`` is an ``ExternalRef`` through
+an MCP tool. Operators configure transport → MCP tool mapping in
+``reyn.yaml`` ``external_transports:``:
+
+```yaml
+external_transports:
+  line:                          # matches ExternalRef.transport
+    mcp_tool: line__reply_message
+    args_template:
+      reply_token: "{destination.reply_token}"
+      messages:
+        - type: text
+          text: "{text}"
+```
+
+The webhook plugin doesn't need to handle outbound — Reyn dispatches
+via the configured MCP server. Operators install the appropriate
+MCP server (= e.g. ``@modelcontextprotocol/server-line``) and
+declare the transport mapping.
+
+## Testing
+
+Unit-test the plugin's helpers (= signing verify, envelope mint)
+directly. Integration-test the route via FastAPI's ``TestClient``
++ a stubbed ``AgentRegistry`` (= see
+``tests/plugins/sample_slack/test_webhook.py`` for the pattern).
+
+Avoid loading the full ``reyn.web.server.app`` in plugin tests; mount
+the plugin's router on a fresh ``FastAPI()`` so tests stay
+hermetic.
+
+## Conflict resolution
+
+When two installed packages both register the same plugin name (= e.g.
+two ``slack`` plugins), the loader logs a warning and uses the first
+match. Operators should pin ``package:`` in ``webhooks.yaml`` to
+disambiguate.
+
+## Versioning compatibility
+
+Plugins pin their Reyn version range in ``pyproject.toml``:
+
+```toml
+dependencies = ["reyn >= 0.1, < 0.2"]
+```
+
+The plugin contract (= ``register_router(config) -> APIRouter | None``,
+envelope shape, ``ExternalRef`` routing) is intended to stay stable
+across minor Reyn versions; breaking changes will be flagged in the
+changelog.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,11 @@ eval = [
 [project.scripts]
 reyn = "reyn._cli:main"
 
+# FP-0041 #489 plugin framework: sample webhook plugins bundled with reyn.
+# External plugins register the same way via their own pyproject.toml.
+[project.entry-points."reyn.webhooks"]
+sample_slack = "reyn.plugins.sample_slack:register_router"
+
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 pythonpath = ["src"]

--- a/src/reyn/plugins/__init__.py
+++ b/src/reyn/plugins/__init__.py
@@ -1,0 +1,9 @@
+"""Reyn-bundled sample plugins.
+
+Each subdirectory is a **sample** plugin demonstrating the Reyn plugin
+framework. Sample plugins ship with Reyn for reference + quick-start
+purposes; production use should fork or replace with a maintained
+external plugin.
+
+See ``docs/plugins/authoring-guide.md`` for plugin authoring spec.
+"""

--- a/src/reyn/plugins/sample_slack/README.md
+++ b/src/reyn/plugins/sample_slack/README.md
@@ -1,0 +1,85 @@
+# sample_slack — Sample Slack Webhook Plugin
+
+> ⚠️ **SAMPLE / EXAMPLE ONLY** ⚠️
+>
+> Reyn maintainers do **NOT** commit to keeping this code working
+> against Slack API drift. This sample exists to demonstrate the
+> Reyn plugin framework — production use requires your own fork or
+> a community-maintained Slack plugin.
+
+## What this is
+
+A reference implementation of an inbound Slack webhook handler
+showing how to:
+
+- Register a Reyn webhook plugin via entry points
+- Verify Slack's HMAC-SHA256 request signing
+- Translate a Slack Events API payload into a Reyn inbox envelope
+- Hand off to a Reyn agent's inbox
+
+The transport-agnostic primitives (= ``ExternalRef`` reply_to,
+outbox interceptor, MCP dispatcher) live in ``src/reyn/chat/`` and
+``src/reyn/web/`` and are reused by any future webhook plugin.
+
+## Operator setup
+
+1. Create a Slack App at https://api.slack.com/apps
+2. Enable **Event Subscriptions** and set Request URL to
+   ``https://<your-reyn-host>/webhook/slack``
+3. Subscribe to bot events: ``app_mention`` and ``message.im``
+4. Install the App in your workspace
+5. Note the **Signing Secret** from the App credentials
+6. Activate the plugin in ``webhooks.yaml`` (= next to reyn.yaml):
+   ```yaml
+   sample_slack:
+     target_agent: news_agent     # agent that receives Slack messages
+   ```
+7. Set env vars on Reyn:
+   ```bash
+   export SLACK_SIGNING_SECRET=<signing-secret>
+   export SLACK_BOT_TOKEN=xoxb-...    # for outbound replies via Slack MCP
+   ```
+8. At-mention the bot in any channel where it's invited; messages
+   reach the target agent's inbox.
+
+## Configuration (= webhooks.yaml)
+
+| Key | Owner | Notes |
+|-----|-------|-------|
+| ``package`` | reyn-reserved | Optional. Disambiguates when multiple installed packages register ``sample_slack``. |
+| ``enabled`` | reyn-reserved | Optional, default ``true``. Set ``false`` to deactivate without removing config. |
+| ``target_agent`` | plugin | **Required**. Name of the Reyn agent that receives incoming Slack messages. |
+
+Secrets (= ``SLACK_SIGNING_SECRET``, ``SLACK_BOT_TOKEN``) are
+**always** environment variables, never in yaml.
+
+## Production caveats
+
+This sample intentionally omits production hardening:
+
+- No per-user / per-channel ACL (= any Slack user in any subscribed
+  channel can reach the target agent)
+- No rate-limiting beyond what Slack itself enforces
+- No retry logic beyond Slack's default
+- Minimal error reporting (= log + 5xx for transient, 4xx for fatal)
+- No bot identity verification beyond the signing secret
+- No audit trail beyond Reyn's own events log
+
+For production use:
+
+- **Fork this plugin** into your own repo and harden as needed, or
+- **Use a community-maintained external plugin** (= if one exists
+  in your ecosystem), or
+- **Write your own** using the framework spec at
+  ``docs/plugins/authoring-guide.md``.
+
+## Module structure
+
+- ``__init__.py`` — entry-point target (= ``register_router``)
+- ``webhook.py`` — Slack-specific protocol: signing verify, event
+  parse, envelope mint, route handler factory
+
+## License / status
+
+Same license as Reyn proper, but **sample-tier maintenance**: bug
+reports welcome, no SLA, breaking changes possible without notice.

--- a/src/reyn/plugins/sample_slack/__init__.py
+++ b/src/reyn/plugins/sample_slack/__init__.py
@@ -1,0 +1,53 @@
+"""sample_slack — Sample Slack webhook plugin (FP-0041 #489 follow-up).
+
+⚠️  **SAMPLE / EXAMPLE ONLY** ⚠️
+
+Demonstrates Reyn's plugin framework for chat-transport webhook
+integrations. Reyn maintainers do NOT commit to keeping this code
+working against Slack API drift. See ``README.md`` for the production
+guidance.
+
+Plugin contract:
+  - Entry point in ``pyproject.toml``:
+    ``[project.entry-points."reyn.webhooks"] sample_slack = "reyn.plugins.sample_slack:register_router"``
+  - ``register_router(config: dict) -> APIRouter | None``
+    receives this plugin's section of ``reyn.yaml`` (= the dict keyed
+    by the plugin name at top-level), returns a router to mount or
+    None to skip.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+
+def register_router(config: dict) -> APIRouter | None:
+    """Plugin entry point — return the Slack webhook router to mount.
+
+    Reads required config:
+      - ``target_agent``: name of the agent that receives incoming
+        Slack messages on its inbox.
+      - ``SLACK_SIGNING_SECRET`` env var: Slack's HMAC signing secret
+        (= configured at api.slack.com per the README).
+
+    Returns None (= skip) when either is missing — Reyn loader logs a
+    warning, the route is not mounted. Operator sees the missing
+    config in logs without crashing reyn web.
+    """
+    target_agent = config.get("target_agent") if isinstance(config, dict) else None
+    if not isinstance(target_agent, str) or not target_agent:
+        logger.warning(
+            "sample_slack plugin: 'target_agent' missing in config; skipping mount",
+        )
+        return None
+    if not os.environ.get("SLACK_SIGNING_SECRET"):
+        logger.warning(
+            "sample_slack plugin: SLACK_SIGNING_SECRET env var not set; skipping mount",
+        )
+        return None
+    from .webhook import build_router
+    return build_router(target_agent=target_agent)

--- a/src/reyn/plugins/sample_slack/webhook.py
+++ b/src/reyn/plugins/sample_slack/webhook.py
@@ -83,8 +83,6 @@ from reyn.web.deps import get_registry
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["webhook"])
-
 # Replay-protection window for Slack signing. Per Slack docs, ts older
 # than 5 minutes should be rejected to prevent replay attacks.
 _SLACK_REPLAY_WINDOW_SECONDS = 60 * 5
@@ -190,129 +188,116 @@ def mint_envelope_from_slack_event(event: dict) -> dict | None:
     }
 
 
-# ── target agent resolution (= MVP single-agent shape) ────────────────
+# ── route factory ─────────────────────────────────────────────────────
 
 
-def _resolve_target_agent(config: Any) -> str | None:
-    """Resolve the target agent for Slack inbound messages.
+def build_router(*, target_agent: str) -> APIRouter:
+    """Build the Slack webhook router for the configured target agent.
 
-    MVP shape (= follow-up PR will add per-user/per-channel ACL):
+    Called by the plugin's ``register_router`` entry-point with the
+    resolved target agent name from ``reyn.yaml``. Captures the agent
+    in the closure so the route handler doesn't need to re-resolve
+    per request.
 
-      1. ``SLACK_TARGET_AGENT`` env var (= operator quick-config)
-      2. ``slack.target_agent`` in reyn.yaml (= TBD wiring)
-      3. Default ``"default"`` (= will fail if no such agent exists,
-         and the failure shows up as 500 with a clear log line)
+    Signing secret is read from ``SLACK_SIGNING_SECRET`` env var at
+    request time (= not captured at build time, so operator can
+    rotate without restarting Reyn — Slack-side rotation requires
+    a brief overlap window anyway).
     """
-    env = os.environ.get("SLACK_TARGET_AGENT")
-    if env:
-        return env
-    # config-side wiring lands when ReynConfig.slack section ships.
-    return None
+    router = APIRouter(tags=["plugin-sample_slack"])
 
+    @router.post("/webhook/slack")
+    async def slack_webhook(
+        request: Request,
+        registry=Depends(get_registry),
+    ) -> Response:
+        """Receive a Slack Events API POST.
 
-# ── route ────────────────────────────────────────────────────────────
+        Three branches:
+          1. URL verification → echo challenge.
+          2. Event with no dispatchable payload (= non-message events,
+             malformed payload) → 200 ack only.
+          3. Message event → verify signing, mint envelope, push to
+             target agent's inbox, return 200.
 
+        Errors return appropriate HTTP status without raising; Slack
+        will retry on non-2xx so we avoid 4xx/5xx for transient cases.
+        """
+        body_bytes = await request.body()
 
-@router.post("/webhook/slack")
-async def slack_webhook(
-    request: Request,
-    registry=Depends(get_registry),
-) -> Response:
-    """Receive a Slack Events API POST.
+        # Parse body up-front so we can handle url_verification before
+        # signing check (= URL verification doesn't have a signature
+        # during initial setup with some Slack App configurations).
+        try:
+            import json
+            payload = json.loads(body_bytes.decode("utf-8") or "{}")
+        except Exception:
+            logger.warning("Slack webhook: malformed JSON body")
+            return JSONResponse(
+                {"error": "malformed body"}, status_code=400,
+            )
 
-    Three branches:
-      1. URL verification → echo challenge.
-      2. Event with no dispatchable payload (= non-message events,
-         malformed payload) → 200 ack only.
-      3. Message event → verify signing, mint envelope, push to
-         target agent's inbox, return 200.
+        # URL verification handshake — Slack POSTs this on initial setup.
+        if isinstance(payload, dict) and payload.get("type") == "url_verification":
+            challenge = payload.get("challenge")
+            return JSONResponse(
+                {"challenge": challenge if isinstance(challenge, str) else ""},
+                status_code=200,
+            )
 
-    Errors return appropriate HTTP status without raising; Slack
-    will retry on non-2xx so we avoid 4xx/5xx for transient cases.
-    """
-    body_bytes = await request.body()
-
-    # Parse body up-front so we can handle url_verification before
-    # signing check (= URL verification doesn't have a signature
-    # during initial setup with some Slack App configurations).
-    try:
-        import json
-        payload = json.loads(body_bytes.decode("utf-8") or "{}")
-    except Exception:
-        logger.warning("Slack webhook: malformed JSON body")
-        return JSONResponse(
-            {"error": "malformed body"}, status_code=400,
+        # Signing verification for all other paths.
+        signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+        if not signing_secret:
+            logger.warning(
+                "Slack webhook received but SLACK_SIGNING_SECRET is unset; rejecting.",
+            )
+            return JSONResponse(
+                {"error": "Slack signing secret not configured"},
+                status_code=503,
+            )
+        ok, detail = verify_slack_signature(
+            body=body_bytes,
+            timestamp=request.headers.get("X-Slack-Request-Timestamp", ""),
+            signature=request.headers.get("X-Slack-Signature", ""),
+            signing_secret=signing_secret,
         )
+        if not ok:
+            logger.warning("Slack webhook signing verify failed: %s", detail)
+            return JSONResponse(
+                {"error": f"signature verification failed: {detail}"},
+                status_code=401,
+            )
 
-    # URL verification handshake — Slack POSTs this on initial setup.
-    if isinstance(payload, dict) and payload.get("type") == "url_verification":
-        challenge = payload.get("challenge")
-        return JSONResponse(
-            {"challenge": challenge if isinstance(challenge, str) else ""},
-            status_code=200,
-        )
+        # Mint envelope from the event.
+        envelope = mint_envelope_from_slack_event(payload)
+        if envelope is None:
+            # Non-dispatchable event (= reaction / channel_join / bot
+            # message echo / etc.). Slack expects 2xx so it won't retry.
+            return JSONResponse({"status": "ignored"}, status_code=200)
 
-    # Signing verification for all other paths.
-    signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
-    if not signing_secret:
-        logger.warning(
-            "Slack webhook received but SLACK_SIGNING_SECRET is unset; rejecting.",
-        )
-        return JSONResponse(
-            {"error": "Slack signing secret not configured"},
-            status_code=503,
-        )
-    ok, detail = verify_slack_signature(
-        body=body_bytes,
-        timestamp=request.headers.get("X-Slack-Request-Timestamp", ""),
-        signature=request.headers.get("X-Slack-Signature", ""),
-        signing_secret=signing_secret,
-    )
-    if not ok:
-        logger.warning("Slack webhook signing verify failed: %s", detail)
-        return JSONResponse(
-            {"error": f"signature verification failed: {detail}"},
-            status_code=401,
-        )
+        # Push to inbox via the registry (= ensure_running so the agent's
+        # router_loop is live to consume). ``target_agent`` was captured
+        # in the closure at ``build_router`` time from the plugin config.
+        try:
+            session = await registry.ensure_running(target_agent)
+        except FileNotFoundError:
+            logger.warning(
+                "Slack webhook: target agent %r not found in registry",
+                target_agent,
+            )
+            return JSONResponse(
+                {"error": f"target agent {target_agent!r} not found"},
+                status_code=503,
+            )
+        try:
+            await session._put_inbox("user", dict(envelope))
+        except Exception as exc:
+            logger.exception("Slack webhook: inbox push failed: %s", exc)
+            return JSONResponse(
+                {"error": f"inbox dispatch failed: {type(exc).__name__}"},
+                status_code=500,
+            )
 
-    # Mint envelope from the event.
-    envelope = mint_envelope_from_slack_event(payload)
-    if envelope is None:
-        # Non-dispatchable event (= reaction / channel_join / bot
-        # message echo / etc.). Slack expects 2xx so it won't retry.
-        return JSONResponse({"status": "ignored"}, status_code=200)
+        return JSONResponse({"status": "ok"}, status_code=200)
 
-    # Resolve target agent.
-    target = _resolve_target_agent(None)
-    if not target:
-        logger.warning(
-            "Slack webhook: no target agent configured "
-            "(SLACK_TARGET_AGENT env var unset)",
-        )
-        return JSONResponse(
-            {"error": "no target agent configured"},
-            status_code=503,
-        )
-
-    # Push to inbox via the registry (= ensure_running so the agent's
-    # router_loop is live to consume).
-    try:
-        session = await registry.ensure_running(target)
-    except FileNotFoundError:
-        logger.warning(
-            "Slack webhook: target agent %r not found in registry", target,
-        )
-        return JSONResponse(
-            {"error": f"target agent {target!r} not found"},
-            status_code=503,
-        )
-    try:
-        await session._put_inbox("user", dict(envelope))
-    except Exception as exc:
-        logger.exception("Slack webhook: inbox push failed: %s", exc)
-        return JSONResponse(
-            {"error": f"inbox dispatch failed: {type(exc).__name__}"},
-            status_code=500,
-        )
-
-    return JSONResponse({"status": "ok"}, status_code=200)
+    return router

--- a/src/reyn/web/plugin_loader.py
+++ b/src/reyn/web/plugin_loader.py
@@ -1,0 +1,227 @@
+"""Plugin loader for Reyn web — FP-0041 #489 follow-up.
+
+Discovers webhook plugins via the ``reyn.webhooks`` entry-point group,
+matches against the operator's ``webhooks.yaml`` activation list, and
+mounts each plugin's router on the FastAPI app.
+
+Reyn core stays Slack/LINE/Discord-free; plugin code lives either in
+``src/reyn/plugins/<name>/`` (= sample plugins shipped with reyn) or
+in separate pip-installable packages.
+
+## Dedicated config file (= ``webhooks.yaml`` at project root)
+
+Plugin activation + per-plugin options live in a dedicated
+``webhooks.yaml`` next to ``reyn.yaml`` — separating them so
+``reyn.yaml`` stays focused on core Reyn settings and the plugin
+namespace doesn't pollute Reyn-known top-level keys.
+
+  # webhooks.yaml — short form (= label is plugin name)
+  sample_slack:
+    target_agent: news_agent      # plugin author owns this section
+
+  # Long form: explicit reyn-known meta fields ``package`` / ``enabled``
+  tricky_plugin:
+    package: foo-pkg              # optional, disambiguates same-name plugins
+    enabled: false                # optional, default true
+    some_option: value            # plugin-defined fields
+
+The mkdocs convention (= name-only activation with options inline) is
+the closest analogue; Reyn extends it with the optional ``package:``
+field for unambiguous identification across registries.
+
+## Plugin contract
+
+Each plugin's entry-point target must be a callable::
+
+  def register_router(config: dict) -> APIRouter | None: ...
+
+It receives the plugin's per-instance dict (= the value side of the
+``<plugin_name>:`` mapping from ``webhooks.yaml``, minus the
+reyn-known ``package`` / ``enabled`` keys). Returns the router to
+mount, or ``None`` to skip (= e.g. required option missing).
+Mounting failure (= exception during register_router) is caught +
+logged; other plugins continue.
+
+## Conflict resolution
+
+When the same plugin name is registered by multiple installed packages
+AND the ``webhooks.yaml`` entry doesn't pin a ``package:``, the loader
+logs a warning + uses the first match. Operators with conflicting
+plugins should set the ``package:`` field explicitly.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, FastAPI
+
+logger = logging.getLogger(__name__)
+
+_WEBHOOK_ENTRY_POINT_GROUP = "reyn.webhooks"
+
+# Reserved keys that the loader interprets; everything else in a
+# plugin's per-instance dict is forwarded to ``register_router``
+# untouched (= plugin author owns the remaining schema).
+_REYN_RESERVED_KEYS = frozenset({"package", "enabled"})
+
+
+def load_webhooks_yaml(project_root: Path) -> dict:
+    """Read ``webhooks.yaml`` from the project root.
+
+    Returns the parsed top-level mapping, or an empty dict when the
+    file is absent / malformed. The schema is::
+
+      <plugin_name>:
+        package: <optional reyn-reserved>
+        enabled: <optional reyn-reserved, default true>
+        <plugin-defined fields>
+
+    Defensive: a missing file is normal (= operator has no webhook
+    plugins), a malformed file logs a warning and yields an empty
+    config rather than crashing reyn web.
+    """
+    path = project_root / "webhooks.yaml"
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        logger.warning("webhooks.yaml: failed to parse — %s", exc)
+        return {}
+    if not isinstance(data, dict):
+        logger.warning(
+            "webhooks.yaml: top-level must be a mapping, got %s",
+            type(data).__name__,
+        )
+        return {}
+    return data
+
+
+def _find_entry_point(
+    plugin_name: str, *, package: str | None = None,
+) -> Any | None:
+    """Locate the entry point matching ``plugin_name`` (and optionally
+    ``package``).
+
+    Returns the importlib.metadata EntryPoint or ``None`` when no
+    match is found. On multiple matches with ``package=None``, the
+    first is returned + a warning logged.
+    """
+    eps = list(importlib.metadata.entry_points(group=_WEBHOOK_ENTRY_POINT_GROUP))
+    matches = [ep for ep in eps if ep.name == plugin_name]
+    if package is not None:
+        matches = [ep for ep in matches if ep.dist and ep.dist.name == package]
+    if not matches:
+        return None
+    if len(matches) > 1 and package is None:
+        names = sorted({ep.dist.name for ep in matches if ep.dist})
+        logger.warning(
+            "webhook plugin %r registered by multiple packages: %s. "
+            "Using first match (%s). Pin 'package:' in reyn.yaml to disambiguate.",
+            plugin_name, names, matches[0].dist.name if matches[0].dist else "?",
+        )
+    return matches[0]
+
+
+def load_webhook_plugins(*, app: FastAPI, webhooks_config: dict) -> int:
+    """Mount each activated webhook plugin's router on ``app``.
+
+    Returns the number of plugins successfully mounted (= for log /
+    diagnostics).
+
+    Parameters
+    ----------
+    app:
+        FastAPI app to mount routers on.
+    webhooks_config:
+        Parsed top-level mapping from ``webhooks.yaml``. Keys are
+        plugin names; values are dicts holding optional reyn-reserved
+        ``package`` / ``enabled`` plus plugin-defined fields, or
+        ``None`` for short-form (= no options, default enabled).
+    """
+    if not isinstance(webhooks_config, dict) or not webhooks_config:
+        return 0
+
+    mounted = 0
+    for plugin_name, ref in webhooks_config.items():
+        if not isinstance(plugin_name, str) or not plugin_name:
+            continue
+        if ref is None:
+            ref_dict: dict = {}
+        elif isinstance(ref, dict):
+            ref_dict = ref
+        else:
+            logger.warning(
+                "webhooks.yaml: %s — expected mapping or null, got %s; skipping",
+                plugin_name, type(ref).__name__,
+            )
+            continue
+
+        if not ref_dict.get("enabled", True):
+            logger.info("webhook plugin %r disabled via config; skipping", plugin_name)
+            continue
+
+        package = ref_dict.get("package")
+        if package is not None and not isinstance(package, str):
+            logger.warning(
+                "webhooks.yaml: %s.package — expected string, got %s; ignoring",
+                plugin_name, type(package).__name__,
+            )
+            package = None
+
+        ep = _find_entry_point(plugin_name, package=package)
+        if ep is None:
+            logger.warning(
+                "webhook plugin %r not installed (package=%r); skipping",
+                plugin_name, package,
+            )
+            continue
+
+        try:
+            register_fn = ep.load()
+        except Exception as exc:
+            logger.exception(
+                "webhook plugin %r failed to load entry point: %s",
+                plugin_name, exc,
+            )
+            continue
+
+        # Plugin options = the per-instance dict minus reyn-reserved
+        # keys. plugin author sees only their own fields.
+        plugin_options = {
+            k: v for k, v in ref_dict.items() if k not in _REYN_RESERVED_KEYS
+        }
+
+        try:
+            router = register_fn(plugin_options)
+        except Exception as exc:
+            logger.exception(
+                "webhook plugin %r register_router raised: %s",
+                plugin_name, exc,
+            )
+            continue
+
+        if router is None:
+            # Plugin opted out (= missing required option, etc.).
+            # ``register_router`` is expected to log the reason.
+            continue
+        if not isinstance(router, APIRouter):
+            logger.warning(
+                "webhook plugin %r register_router returned %s, expected APIRouter; "
+                "skipping",
+                plugin_name, type(router).__name__,
+            )
+            continue
+
+        app.include_router(router)
+        mounted += 1
+        logger.info(
+            "webhook plugin %r mounted (package=%s)",
+            plugin_name, ep.dist.name if ep.dist else "?",
+        )
+
+    return mounted

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -219,7 +219,6 @@ from reyn.web.routers import skills as _skills_router  # noqa: E402
 from reyn.web.routers import topologies as _topos_router  # noqa: E402
 from reyn.web.routers import web_config as _web_config_router  # noqa: E402
 from reyn.web.routers import web_data as _web_data_router  # noqa: E402
-from reyn.web.routers import webhook_slack as _webhook_slack_router  # noqa: E402
 
 app.include_router(_agents_router.router, prefix="/api")
 app.include_router(_skills_router.router, prefix="/api")
@@ -229,11 +228,20 @@ app.include_router(_perms_router.router, prefix="/api")
 app.include_router(_budget_router.router, prefix="/api")
 app.include_router(_web_config_router.router, prefix="/api")
 app.include_router(_web_data_router.router, prefix="/api")
-# FP-0041 #489 PR-D: Slack inbound webhook (= chat-transport).
-# Route is /webhook/slack at the top level (= no /api prefix) so the
-# URL operators paste into Slack's Event Subscriptions matches the
-# documented industry convention.
-app.include_router(_webhook_slack_router.router)
+
+# FP-0041 #489 plugin framework: webhook plugins (= sample_slack / external
+# packages) are activated by ``webhooks.yaml`` (= dedicated file at the
+# project root, separate from reyn.yaml to keep core config lean) and
+# mounted by the plugin loader at app startup. Reyn core stays SDK-free;
+# per-transport protocol code lives in plugins.
+try:
+    from reyn.config import _find_project_root as _find_root_for_plugins
+    from reyn.web.plugin_loader import load_webhook_plugins, load_webhooks_yaml
+    _project_root_for_plugins = _find_root_for_plugins(Path.cwd()) or Path.cwd()
+    _webhooks_cfg = load_webhooks_yaml(_project_root_for_plugins)
+    load_webhook_plugins(app=app, webhooks_config=_webhooks_cfg)
+except Exception as _exc:  # noqa: BLE001 — defensive boot
+    logger.warning("webhook plugin loading failed: %s", _exc)
 
 # MCP-over-SSE: GET /mcp/sse (event stream) + POST /mcp/messages (client → server).
 # The router carries the GET; the POST endpoint is a Starlette Mount because

--- a/tests/plugins/sample_slack/test_webhook.py
+++ b/tests/plugins/sample_slack/test_webhook.py
@@ -27,8 +27,9 @@ from typing import Any
 import pytest
 
 from reyn.chat.transport import ExternalRef
-from reyn.web.routers.webhook_slack import (
+from reyn.plugins.sample_slack.webhook import (
     _SLACK_REPLAY_WINDOW_SECONDS,
+    build_router,
     mint_envelope_from_slack_event,
     verify_slack_signature,
 )
@@ -252,10 +253,14 @@ def test_mint_envelope_handles_missing_user_field():
 def _slack_client(monkeypatch):
     """FastAPI TestClient with a stubbed AgentRegistry.
 
-    Captures inbox pushes in a list on the client so tests can assert
-    the right envelope was dispatched without spinning up a real
-    ChatSession.
+    Builds a fresh minimal FastAPI app, mounts the sample_slack
+    plugin's router via ``build_router``, and overrides the registry
+    dependency to capture inbox pushes. Each test gets its own client
+    (= no shared state across tests). Avoids loading the full
+    ``reyn.web.server.app`` since the plugin would otherwise be
+    mounted only when the operator activates it via reyn.yaml.
     """
+    from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
     pushes: list = []
@@ -269,29 +274,23 @@ def _slack_client(monkeypatch):
         async def ensure_running(self, name):
             return _StubSession()
 
-    from reyn.web.routers import webhook_slack as _slack_router
-
     def _stub_get_registry():
         return _StubRegistry()
 
-    # Override the FastAPI dependency for this test.
-    from reyn.web.server import app
-    app.dependency_overrides[
-        _slack_router.router.dependencies[0].dependency
-        if _slack_router.router.dependencies
-        else None
-    ] = _stub_get_registry
-
-    # Cleaner override path: replace the get_registry symbol.
+    # Patch the deps module so build_router's dependency closure
+    # resolves to the stub.
     from reyn.web import deps
     monkeypatch.setattr(deps, "_get_registry", _stub_get_registry)
-    # Also clear any cached singleton.
     monkeypatch.setattr(deps, "_registry", None, raising=False)
+
+    app = FastAPI()
+    router = build_router(target_agent="news_agent")
+    app.include_router(router)
+    app.dependency_overrides[deps.get_registry] = _stub_get_registry
 
     client = TestClient(app)
     client.pushes = pushes  # type: ignore[attr-defined]
     yield client
-    app.dependency_overrides.clear()
 
 
 def test_route_url_verification_echoes_challenge(_slack_client):
@@ -443,38 +442,6 @@ def test_route_acks_non_dispatchable_events_with_200(
     assert len(_slack_client.pushes) == 0
 
 
-def test_route_rejects_when_no_target_agent_configured(
-    monkeypatch, _slack_client,
-):
-    """Tier 2: a valid event arriving with no ``SLACK_TARGET_AGENT``
-    env returns 503 + clear error. Operator forgot agent config.
-    """
-    secret = "real-secret"
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", secret)
-    monkeypatch.delenv("SLACK_TARGET_AGENT", raising=False)
-
-    body = json.dumps({
-        "event": {
-            "type": "app_mention",
-            "user": "U1", "channel": "C1", "text": "hi", "ts": "1.0",
-        },
-    }).encode()
-    ts = str(int(time.time()))
-    sig = _sign(body, ts, secret)
-
-    response = _slack_client.post(
-        "/webhook/slack",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-Slack-Request-Timestamp": ts,
-            "X-Slack-Signature": sig,
-        },
-    )
-    assert response.status_code == 503
-    assert "target agent" in response.json()["error"].lower()
-
-
 def test_route_malformed_json_returns_400(monkeypatch, _slack_client):
     """Tier 2: non-JSON body returns 400 (= operator misconfig / bad
     network, not Reyn's fault).
@@ -487,11 +454,42 @@ def test_route_malformed_json_returns_400(monkeypatch, _slack_client):
     assert response.status_code == 400
 
 
-def test_route_mounted_on_app():
-    """Tier 2: ``/webhook/slack`` is registered on the FastAPI app.
-    Without this, all other tests in this module would fall through
-    to FastAPI's default 404, masking a mount regression.
+# ── register_router (= plugin entry-point) ────────────────────────────
+
+
+def test_register_router_returns_none_when_target_agent_missing(monkeypatch):
+    """Tier 2: ``register_router`` (= the plugin entry-point) returns
+    ``None`` when ``target_agent`` is missing from config — the
+    loader logs a warning and the route is not mounted. Operator's
+    forgotten config surfaces in logs rather than crashing.
     """
-    from reyn.web.server import app
-    paths = {getattr(r, "path", "") for r in app.routes}
-    assert "/webhook/slack" in paths
+    from reyn.plugins.sample_slack import register_router
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")  # signing OK, target missing
+
+    assert register_router({}) is None
+    assert register_router({"target_agent": ""}) is None
+
+
+def test_register_router_returns_none_when_signing_secret_missing(monkeypatch):
+    """Tier 2: ``register_router`` returns ``None`` when
+    ``SLACK_SIGNING_SECRET`` env var is unset — clear operator
+    error in logs without crashing reyn web.
+    """
+    from reyn.plugins.sample_slack import register_router
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+
+    assert register_router({"target_agent": "news_agent"}) is None
+
+
+def test_register_router_returns_apirouter_when_configured(monkeypatch):
+    """Tier 2: ``register_router`` returns a FastAPI ``APIRouter``
+    when both ``target_agent`` config + signing secret env are
+    present. The loader mounts this on the app.
+    """
+    from fastapi import APIRouter
+
+    from reyn.plugins.sample_slack import register_router
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")
+
+    router = register_router({"target_agent": "news_agent"})
+    assert isinstance(router, APIRouter)

--- a/tests/web/test_plugin_loader.py
+++ b/tests/web/test_plugin_loader.py
@@ -1,0 +1,293 @@
+"""Tier 2: webhook plugin loader — FP-0041 #489 follow-up.
+
+Pins ``load_webhooks_yaml`` (= file read) and ``load_webhook_plugins``
+(= entry-point dispatch + APIRouter mount) for the plugin framework.
+
+Tests:
+
+  1. webhooks.yaml file reader — missing / malformed / well-formed.
+  2. Loader: short form vs long form (= reyn-reserved keys handling).
+  3. Loader: ``enabled: false`` skip.
+  4. Loader: missing plugin (= not installed) → warn + skip.
+  5. Loader: plugin returning ``None`` (= opt-out) → skip mount.
+  6. Loader: plugin returning non-APIRouter → warn + skip.
+  7. Loader: plugin raising → log + skip, other plugins continue.
+  8. Loader: reyn-reserved keys (= ``package`` / ``enabled``) stripped
+     from the config passed to ``register_router``.
+
+Tier 2 because the loader is the single dispatch point for ALL
+inbound webhook traffic — a regression silently breaks every
+webhook plugin in production deployments.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from reyn.web.plugin_loader import load_webhook_plugins, load_webhooks_yaml
+
+# ── load_webhooks_yaml ────────────────────────────────────────────────
+
+
+def test_load_webhooks_yaml_returns_empty_when_missing(tmp_path: Path):
+    """Tier 2: a project without webhooks.yaml loads cleanly as empty.
+    No webhook plugins = common case, must not crash.
+    """
+    assert load_webhooks_yaml(tmp_path) == {}
+
+
+def test_load_webhooks_yaml_returns_empty_on_malformed(tmp_path: Path):
+    """Tier 2: a malformed webhooks.yaml logs a warning and yields an
+    empty config rather than crashing reyn web at boot.
+    """
+    (tmp_path / "webhooks.yaml").write_text(
+        "not: valid: yaml: nested:wrong", encoding="utf-8",
+    )
+    # Should not raise; should return empty.
+    result = load_webhooks_yaml(tmp_path)
+    assert isinstance(result, dict)
+
+
+def test_load_webhooks_yaml_returns_empty_on_non_mapping(tmp_path: Path):
+    """Tier 2: a webhooks.yaml whose top level is a list / scalar
+    isn't usable; loader warns and returns empty.
+    """
+    (tmp_path / "webhooks.yaml").write_text("- just\n- a\n- list\n", encoding="utf-8")
+    assert load_webhooks_yaml(tmp_path) == {}
+
+
+def test_load_webhooks_yaml_parses_well_formed_file(tmp_path: Path):
+    """Tier 2: a well-formed webhooks.yaml parses to the documented
+    top-level mapping.
+    """
+    (tmp_path / "webhooks.yaml").write_text(
+        "sample_slack:\n  target_agent: news_agent\n", encoding="utf-8",
+    )
+    result = load_webhooks_yaml(tmp_path)
+    assert result == {"sample_slack": {"target_agent": "news_agent"}}
+
+
+# ── load_webhook_plugins ──────────────────────────────────────────────
+
+
+def _stub_entry_point(name: str, dist_name: str, register_fn):
+    """Build a fake entry point object covering the attributes the
+    loader actually reads (= name, dist.name, load()).
+    """
+    class _Dist:
+        name = dist_name
+
+    class _EP:
+        def __init__(self):
+            self.name = name
+            self.dist = _Dist()
+
+        def load(self):
+            return register_fn
+
+    return _EP()
+
+
+@pytest.fixture()
+def _patch_entry_points(monkeypatch):
+    """Patch ``importlib.metadata.entry_points`` to return whatever the
+    caller installs into a list. Tests append fake EPs to the list.
+    """
+    fake_eps: list = []
+
+    def _fake_entry_points(*, group=None):
+        if group == "reyn.webhooks":
+            return list(fake_eps)
+        return []
+
+    monkeypatch.setattr(
+        "reyn.web.plugin_loader.importlib.metadata.entry_points",
+        _fake_entry_points,
+    )
+    return fake_eps
+
+
+def test_loader_skips_when_empty_config(_patch_entry_points):
+    """Tier 2: empty webhooks_config → no work, returns 0."""
+    app = FastAPI()
+    mounted = load_webhook_plugins(app=app, webhooks_config={})
+    assert mounted == 0
+
+
+def test_loader_mounts_short_form_plugin(_patch_entry_points):
+    """Tier 2: short form (= value=None) activates the plugin with
+    default-enabled + auto-resolved package.
+    """
+    received: list = []
+
+    def _register(config):
+        received.append(config)
+        return APIRouter()
+
+    _patch_entry_points.append(
+        _stub_entry_point("sample_slack", "reyn", _register),
+    )
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app, webhooks_config={"sample_slack": None},
+    )
+    assert mounted == 1
+    # Short form → empty config passed to register_router.
+    assert received == [{}]
+
+
+def test_loader_strips_reyn_reserved_keys(_patch_entry_points):
+    """Tier 2: ``package`` and ``enabled`` are reyn-reserved; they are
+    NOT forwarded to ``register_router``. Plugin author sees only
+    their own fields.
+    """
+    received: list = []
+
+    def _register(config):
+        received.append(config)
+        return APIRouter()
+
+    _patch_entry_points.append(
+        _stub_entry_point("sample_slack", "reyn", _register),
+    )
+    app = FastAPI()
+    load_webhook_plugins(
+        app=app,
+        webhooks_config={
+            "sample_slack": {
+                "package": "reyn",       # reyn-reserved (stripped)
+                "enabled": True,         # reyn-reserved (stripped)
+                "target_agent": "x",     # plugin-defined (passed through)
+            },
+        },
+    )
+    assert received == [{"target_agent": "x"}]
+
+
+def test_loader_skips_disabled_plugin(_patch_entry_points):
+    """Tier 2: ``enabled: false`` → plugin not mounted. ``register_router``
+    is NOT called (= even discovery skipped at that step).
+    """
+    called = False
+
+    def _register(config):
+        nonlocal called
+        called = True
+        return APIRouter()
+
+    _patch_entry_points.append(
+        _stub_entry_point("sample_slack", "reyn", _register),
+    )
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app,
+        webhooks_config={"sample_slack": {"enabled": False}},
+    )
+    assert mounted == 0
+    assert called is False
+
+
+def test_loader_warns_when_plugin_not_installed(_patch_entry_points):
+    """Tier 2: an entry referenced in webhooks.yaml but with no matching
+    entry-point logs a warning and skips. Operator hasn't installed
+    the package.
+    """
+    # No entry points registered.
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app, webhooks_config={"unknown_plugin": None},
+    )
+    assert mounted == 0
+
+
+def test_loader_skips_when_register_returns_none(_patch_entry_points):
+    """Tier 2: ``register_router`` returning None (= plugin opted out
+    because of missing required option) skips mount without crashing.
+    """
+    def _register(config):
+        return None
+
+    _patch_entry_points.append(
+        _stub_entry_point("sample_slack", "reyn", _register),
+    )
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app, webhooks_config={"sample_slack": None},
+    )
+    assert mounted == 0
+
+
+def test_loader_skips_when_register_returns_non_router(_patch_entry_points):
+    """Tier 2: a plugin returning a non-APIRouter value is a contract
+    violation; loader logs and skips rather than crashing.
+    """
+    def _register(config):
+        return "not a router"
+
+    _patch_entry_points.append(
+        _stub_entry_point("misbehaving", "reyn", _register),
+    )
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app, webhooks_config={"misbehaving": None},
+    )
+    assert mounted == 0
+
+
+def test_loader_continues_after_register_raises(_patch_entry_points):
+    """Tier 2: a plugin whose ``register_router`` raises does NOT
+    prevent other plugins from mounting. Isolation.
+    """
+    def _bad(config):
+        raise RuntimeError("plugin boot failure")
+
+    def _good(config):
+        return APIRouter()
+
+    _patch_entry_points.append(_stub_entry_point("bad_one", "pkg_a", _bad))
+    _patch_entry_points.append(_stub_entry_point("good_one", "pkg_b", _good))
+
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app,
+        webhooks_config={"bad_one": None, "good_one": None},
+    )
+    assert mounted == 1   # only the good one
+
+
+def test_loader_disambiguates_via_package_field(_patch_entry_points):
+    """Tier 2: when two packages register the same plugin name, the
+    ``package:`` field in webhooks.yaml selects which one is mounted.
+    Verified via the entry-point's distribution name reaching through
+    to ``register_router`` (= each fake builds a router with a marker
+    path so the test can identify which one mounted).
+    """
+    def _from_a(config):
+        r = APIRouter()
+        @r.get("/from-pkg-a")
+        async def _h():
+            return {}
+        return r
+
+    def _from_b(config):
+        r = APIRouter()
+        @r.get("/from-pkg-b")
+        async def _h():
+            return {}
+        return r
+
+    _patch_entry_points.append(_stub_entry_point("sample_slack", "pkg_a", _from_a))
+    _patch_entry_points.append(_stub_entry_point("sample_slack", "pkg_b", _from_b))
+
+    app = FastAPI()
+    mounted = load_webhook_plugins(
+        app=app,
+        webhooks_config={"sample_slack": {"package": "pkg_b"}},
+    )
+    assert mounted == 1
+    # The pkg_b router (= /from-pkg-b path) should be the one mounted.
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert "/from-pkg-b" in paths
+    assert "/from-pkg-a" not in paths


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 follow-up = **Slack protocol extraction**。 User retroactive directive (= 「Slack protocol 依存は本体に入れるべきでない」)、 plugin framework に移行 + bundled sample plugin pattern 確立。 main 直 base、 standalone PR。

## Why

PR-D + PR-D2.5 まで進めて Slack-specific code が Reyn core (= `src/reyn/web/routers/webhook_slack.py`) に landed。 User指摘:
> Slack protocol 依存は本体に入れるべきでないよ。 今後メンテしたくないんだから。

→ User と 6 ターン design 反復 → **plugin framework + sample-prefixed bundled plugin + dedicated webhooks.yaml** で収束。

## What this PR ships

| Item | 場所 |
|---|---|
| Plugin loader (= entry_points + dispatch + reyn-reserved key strip) | ``src/reyn/web/plugin_loader.py`` |
| ``sample_slack`` bundled plugin (= moved from core) | ``src/reyn/plugins/sample_slack/`` |
| Plugin entry-point declaration | ``pyproject.toml`` |
| webhooks.yaml schema | dedicated file at project root |
| Plugin authoring guide | ``docs/plugins/authoring-guide.md`` |
| Sample plugin README + production caveat | ``src/reyn/plugins/sample_slack/README.md`` |

## webhooks.yaml shape

```yaml
# Short form (= label is plugin name, defaults apply)
sample_slack:
  target_agent: news_agent       # plugin-defined fields directly

# Long form (= reyn-reserved meta + plugin fields)
tricky_plugin:
  package: some-pkg              # reyn-reserved: optional disambiguation
  enabled: false                 # reyn-reserved: default true
  some_option: value             # plugin-defined
```

= mkdocs convention (= name-only with options inline) + optional `package:` for unambiguous identification。

## What stays in Reyn core (= transport-agnostic)

- `ExternalRef` reply_to (= `src/reyn/chat/transport.py`)
- `external_routing.py` outbox interceptor + `route_to_mcp` (= PR-C)
- `ChatSession._last_reply_to` + `_outbox_interceptor` (= PR-A / PR-D2)
- Plugin loader (= 本 PR 新規)

= 全 transport-agnostic、 Slack/LINE/Discord 独自 protocol code 0。

## What this PR removes from Reyn core

- Slack signing format (= HMAC-SHA256 v0:ts:body)
- Slack URL verification handshake
- Slack event JSON schema parsing
- `SLACK_*` env var references
- Hardcoded `/webhook/slack` route mount

= 全 `sample_slack` bundled plugin に移動、 install + activate 経由のみ active。

## Test plan

- [x] ``pytest tests/web/test_plugin_loader.py + tests/plugins/sample_slack/`` — 33/33 pass (= 11 loader + 22 plugin)
- [x] ``pytest tests/`` (full suite) — 5043 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- [x] ``pip install -e .`` re-run for entry_points
- No router fixtures touched.

## Pattern note

「user reframe → architectural refactor」 cycle **7 instance 目** (= #292 / #379 / #354 / #398 / #470 / FP-0041 humanic / FP-0041 plugin framework)。 design 反復 6 ターンで convention-aligned shape に収束、 new memory ``feedback_check_convention_before_inventing_shape`` を establish (= 「新 config shape 提案前に既存 ecosystem 観察 + short form + optional explicit default 適用」)。

## FP-0041 Phase 1 final state (= post-merge)

| # | Scope | Status |
|---|---|---|
| PR-A #498 | envelope sender + dispatch attribution | MERGED |
| PR-B #499 | cron message shape + dispatch runner | MERGED |
| PR-B2 #507 | LLM-callable cron tool surface | MERGED |
| PR-C #509 | external transport routing primitive | MERGED |
| PR-D #510 | Slack inbound webhook handler | MERGED → **extracted by 本 PR** |
| PR-D2 #511 | Slack outbound + ReynConfig integration | MERGED |
| PR-D2.5 #515 | web lifespan wiring | MERGED → **modified by 本 PR** |
| **plugin framework (= 本 PR)** | **Slack extraction + framework reshape** | **OPEN** |
| PR-E | LINE chat-transport handler | future (= now via plugin framework) |

= Phase 1 humanic vision data layer foundation 完成 **+ plugin framework で Slack を extract**、 production architectural cleanliness 達成。

Refs #489 (FP-0041 plugin framework retraction + reshape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)