### PR TITLE
feat(tui): agents tab a key prefills /attach for cursor agent (H-F11)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -505,6 +505,20 @@ class RightPanel(Widget):
                 self._pending_move(-1)
             else:
                 self._scroll_panel(-1)
+        elif event.key == "a" and self._panel_type == "agents":
+            # Wave-10 follow-up H-F11: Agents tab `a` = switch to the
+            # cursor's agent. Mirrors the per-tab action idiom landed
+            # by the pending tab's ``d`` / ``c`` keys: a single letter
+            # owned by the tab whose semantics make sense only there.
+            # MVP: prefill ``/attach <name>`` into the InputBar (same
+            # handoff pattern as Docs tab ``/`` → ``/docs-filter``);
+            # the user confirms with Enter, the existing slash command
+            # dispatches. Direct ``session.attach`` calls bypass the
+            # OS-level event log + permission checks the slash route
+            # already gates through, so the prefill path is the
+            # correct architectural seam.
+            event.prevent_default()
+            self._prefill_attach_for_cursor()
         elif event.key == "d" and self._panel_type == "pending":
             # Issue #277 — Pending tab `d` = discard the cursor's iv.
             event.prevent_default()
@@ -1593,6 +1607,51 @@ class RightPanel(Widget):
         except Exception as exc:
             logger.warning("right_panel copy status failed: %s", exc)
 
+    def _prefill_attach_for_cursor(self) -> None:
+        """`a` on the Agents tab — pre-fill ``/attach <cursor name>``.
+
+        Wave-10 follow-up H-F11. Reads the cursor's flat_item; when
+        the row is an ``"agent"`` kind, prefills the InputBar with
+        ``/attach <agent-name>``. On any other cursor (= running /
+        recent skill / plan rows), the prefill is silently skipped
+        — the action is only meaningful on the agent-label row.
+
+        Switching to the currently-attached agent is harmless (= the
+        slash command treats it as a no-op), so the test for "this
+        is the attached agent already" lives in the slash command,
+        not here.
+        """
+        if not self._agents_items:
+            return
+        idx = max(0, min(len(self._agents_items) - 1, self._agents_cursor))
+        item = self._agents_items[idx]
+        if item.get("kind") != "agent":
+            # The agents tab's cursor walks ALL rows (= agents +
+            # running/recent skills/plans). ``a`` only makes sense
+            # on the agent-label row; for other rows, silently no-op
+            # rather than dispatching a meaningless ``/attach`` for
+            # a skill name.
+            return
+        name = str(item.get("name", "")).strip()
+        if not name:
+            return
+        from .. import InputBar  # late import → avoid cycle
+        try:
+            inputbar = self.app.query_one("#inputbar", InputBar)
+        except Exception as exc:
+            logger.warning("right_panel prefill attach failed: %s", exc)
+            return
+        prefill = f"/attach {name}"
+        try:
+            ta = inputbar.query_one("#input")
+            ta.load_text(prefill)
+            # Move cursor to end so the user can Enter immediately or
+            # edit (= rename agent, etc.) without skipping whitespace.
+            ta.move_cursor((0, len(prefill)))
+            inputbar.focus_input()
+        except Exception as exc:
+            logger.warning("right_panel prefill attach focus failed: %s", exc)
+
     def _prefill_docs_filter(self) -> None:
         """`/` on the Docs tab — focus InputBar and pre-fill `/docs-filter `.
 
@@ -1906,14 +1965,14 @@ class RightPanel(Widget):
             return f"[bold {_CORAL}]Key Bindings[/]  [#555555]j↓ k↑[/]"
         if self._panel_type == "agents":
             # Wave-10 H-F2: surface ``space=open c=copy`` so the cursor's
-            # most useful actions are discoverable from the header. Pre-fix
-            # the agents tab advertised only ``j↓ k↑``, leaving first-time
-            # users to discover Space / c by reading the Keys tab — even
-            # though both bindings work here exactly as in the Memory tab
-            # (which DOES surface them). Matches Memory's hint shape.
+            # most useful actions are discoverable from the header.
+            # Wave-10 follow-up H-F11: also surface ``a=attach`` — the
+            # agents tab's per-tab action that prefills ``/attach
+            # <name>`` for switching the attached agent. Matches the
+            # Pending tab's ``d=discard c=claim`` per-tab hint shape.
             return (
                 f"[bold {_CORAL}]Agents[/]"
-                f"  [#555555]j↓ k↑ space=open c=copy[/]"
+                f"  [#555555]j↓ k↑ space=open c=copy a=attach[/]"
             )
         if self._panel_type == "memory":
             return (

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -135,6 +135,11 @@ def render_keys(app: "App") -> str:
         # no way to discover it from the Keys tab. Surface it here
         # alongside ``c=claim`` for symmetry.
         ("d", "Discard cursor (pending tab)"),
+        # H-F11 (wave-10 follow-up): ``a`` on the Agents tab prefills
+        # ``/attach <name>`` into the InputBar for the cursor's agent.
+        # Same "per-tab action" idiom as the pending-tab ``d`` / ``c``
+        # discard / claim shortcuts.
+        ("a", "Attach to cursor agent (agents tab)"),
     ]
     for key, desc in _PANEL_EXPLICIT:
         if key not in seen:

--- a/tests/cli/test_agents_tab_attach_shortcut.py
+++ b/tests/cli/test_agents_tab_attach_shortcut.py
@@ -1,0 +1,147 @@
+"""Tier 2: agents tab `a` key prefills /attach for the cursor's agent (H-F11).
+
+Wave-10 follow-up Topic H finding F11 (P2): the agents tab had
+no keyboard shortcut to switch the attached agent. Users had to
+type ``/agent switch <name>`` (or ``/attach <name>``) by hand
+from the input bar, even though the cursor was already on the
+target agent's row.
+
+After the fix ``a`` on the agents tab prefills ``/attach <name>``
+into the InputBar (= same handoff pattern as the docs tab ``/``
+→ ``/docs-filter`` prefill). MVP — confirmation still requires
+Enter so the user can edit / abort; the slash command performs
+the actual switch.
+
+Public surfaces tested:
+  - ``a`` on agent-label cursor → InputBar contains
+    ``/attach <name>``
+  - ``a`` on non-agent cursor (= running skill / recent plan
+    row) is silently ignored (= action only meaningful on agent-
+    label rows)
+  - Keys tab surfaces the new key in PANEL group
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_a_key_on_agent_row_prefills_attach() -> None:
+    """Tier 2: ``a`` on agent-label cursor → ``/attach <name>`` in InputBar."""
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        panel._agents_items = [
+            {
+                "kind": "agent",
+                "name": "target-agent",
+                "attached": False,
+                "loaded": True,
+            },
+        ]
+        panel._agents_cursor = 0
+
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+
+        ta = app.query_one("#input", TextArea)
+        assert ta.text == "/attach target-agent", (
+            f"InputBar should prefill /attach target-agent, got {ta.text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_key_on_non_agent_row_is_silent_noop() -> None:
+    """Tier 2: ``a`` on running_skill / recent_plan cursor does nothing.
+
+    The action is meaningful only on the agent-label row; lower
+    rows in the tree (= running skills, recent plans) should not
+    dispatch a meaningless ``/attach <skill_name>``.
+    """
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        panel._agents_items = [
+            {"kind": "running_skill", "skill_name": "test_skill", "run_id": "rid"},
+        ]
+        panel._agents_cursor = 0
+
+        ta = app.query_one("#input", TextArea)
+        pre_text = ta.text
+
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+
+        assert ta.text == pre_text, (
+            f"non-agent cursor should leave InputBar unchanged; "
+            f"pre={pre_text!r} post={ta.text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_key_on_empty_agents_tab_is_safe() -> None:
+    """Tier 2 (regression): empty flat_items → safe no-op (no IndexError)."""
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        panel._panel_type = "agents"
+        panel._agents_items = []
+        panel._agents_cursor = 0
+        # Must not raise.
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+        ta = app.query_one("#input", TextArea)
+        assert ta.text == ""
+
+
+def test_keys_tab_surfaces_a_attach_in_panel_group() -> None:
+    """Tier 2: Keys tab markup lists the new ``a`` action.
+
+    Discoverability: a user reading the Keys tab should be able to
+    learn about the ``a`` action without source-diving.
+    """
+    import asyncio
+
+    from reyn.chat.tui.app import ReynTUIApp
+
+    async def _grab_markup() -> str:
+        from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+        app = ReynTUIApp(
+            registry=None, agent_name="t", model="m", budget_tracker=None,
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            return render_keys(app)
+
+    markup = asyncio.run(_grab_markup())
+    assert "a" in markup
+    assert "Attach to cursor agent" in markup, (
+        f"Keys tab should describe the new attach action; got:\n{markup!r}"
+    )

--- a/tests/cli/test_agents_tab_header_hint.py
+++ b/tests/cli/test_agents_tab_header_hint.py
@@ -53,8 +53,14 @@ async def test_agents_header_surfaces_space_and_c_hints() -> None:
 async def test_agents_header_hint_matches_memory_idiom() -> None:
     """Tier 2: agents + memory headers carry the same set of action hints.
 
-    Same keybindings → same advertised affordances. Pins the
+    Shared keybindings → same advertised affordances. Pins the
     cross-tab consistency contract that H-F2 closes.
+
+    Wave-10 follow-up H-F11 added the agents-specific ``a=attach``
+    shortcut, so agents now ADVERTISES the memory hint set plus the
+    agents-specific extras. The cross-tab contract is "the shared
+    actions all appear in both" (= superset relation), not strict
+    equality.
     """
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import RightPanel
@@ -64,15 +70,23 @@ async def test_agents_header_hint_matches_memory_idiom() -> None:
         await pilot.pause()
         panel = app.query_one(RightPanel)
         panel._panel_type = "memory"
-        memory_hint_segment = panel._panel_header_markup().split("[#555555]")[-1]
+        memory_markup = panel._panel_header_markup()
         panel._panel_type = "agents"
-        agents_hint_segment = panel._panel_header_markup().split("[#555555]")[-1]
-        # Same actions advertised (= the trailing ``[/]`` markup chunk
-        # is identical between the two headers).
-        assert memory_hint_segment == agents_hint_segment, (
-            f"agents and memory headers should advertise identical hints; "
-            f"memory={memory_hint_segment!r}, agents={agents_hint_segment!r}"
-        )
+        agents_markup = panel._panel_header_markup()
+        # Shared affordances ("space=open", "c=copy", "j↓ k↑") appear
+        # in BOTH headers (= cross-tab consistency for the bindings
+        # that work the same way).
+        for shared in ("j↓ k↑", "space=open", "c=copy"):
+            assert shared in memory_markup, (
+                f"memory hint should include {shared!r}; got {memory_markup!r}"
+            )
+            assert shared in agents_markup, (
+                f"agents hint should include {shared!r}; got {agents_markup!r}"
+            )
+        # Agents has an additional tab-specific action that memory
+        # does not (= ``a=attach``, the H-F11 follow-up).
+        assert "a=attach" in agents_markup
+        assert "a=attach" not in memory_markup
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up PR (H-F11, P2 M). Single-scope feature: new keyboard shortcut on agents tab + supporting hint/Keys tab updates + 1 cross-tab parity test re-articulated.

## Sister PR articulation (row 7)

Touches ``right_panel/__init__.py`` (= on_key handler + new ``_prefill_attach_for_cursor`` helper + header hint) and ``keys_tab.py`` (= one entry in ``_PANEL_EXPLICIT``). Also updates ``tests/cli/test_agents_tab_header_hint.py`` (= the H-F2 cross-tab parity test) from strict equality to superset relation because H-F11 intentionally adds an agents-specific action that memory doesn't share. The H-F2 cross-tab consistency contract still holds (= shared actions appear in both), just relaxed from exact equality.

## Problem

Agents tab is "the daily contact point" but had no keyboard shortcut for its most-common follow-on action (= switch attached agent). User had to type ``/attach <name>`` by hand into the InputBar even though the cursor was already on the target row.

## Fix

``a`` key + cursor on agent-label row → prefills ``/attach <name>`` into the InputBar. Matches the docs tab ``/`` → ``/docs-filter`` prefill convention (= preserves OS-level permission/log gating; user can edit/abort before Enter).

Non-agent cursors (running skills, recent plans) silently no-op so the key doesn't dispatch nonsensical ``/attach <skill_name>``.

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests: prefill works, non-agent silent no-op, empty safe, Keys tab surfaces new key
- [x] H-F2 parity test re-articulated to superset relation (= cross-tab consistency contract preserved)
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)