### PR TITLE
fix(tui): wrap RichLog._start_line in protected helper with one-shot warning (G-F15)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -36,6 +36,7 @@ Cost suffix (A4):
 """
 from __future__ import annotations
 
+import logging
 import time
 
 from rich.cells import cell_len
@@ -46,6 +47,10 @@ from rich.text import Text
 from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import RichLog, Static
+
+# Wave-10 follow-up G-F15: module logger for the one-shot
+# Textual-API-change warning in ``_richlog_start_line``.
+logger = logging.getLogger(__name__)
 
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.tui._palette import _AMBER, _CORAL
@@ -309,6 +314,11 @@ class ConversationView(Widget):
         # One-shot flag so the "earlier history trimmed" warning fires at most
         # once per session (= the first time Ctrl+P/N is used after trim).
         self._trim_warned = False
+        # Wave-10 follow-up G-F15: one-shot flag for the "RichLog
+        # private API broke" warning in ``_richlog_start_line``. Prevents
+        # log spam when a Textual upgrade removes the ``_start_line``
+        # attribute we depend on for turn-navigation anchors.
+        self._start_line_warned = False
         # B3 — full text of the last truncated agent reply (or None when the
         # most recent reply fit within _FOLD_THRESHOLD_LINES).
         self._last_long_reply: str | None = None
@@ -801,7 +811,7 @@ class ConversationView(Widget):
         # ``_RICHLOG_MAX_LINES`` boundary never saw the "earlier history
         # trimmed" signal until they happened to hit Ctrl+P. The
         # ``_trim_warned`` flag keeps it strictly one-shot per session.
-        if not self._trim_warned and getattr(log, "_start_line", 0) > 0:
+        if not self._trim_warned and self._richlog_start_line(log) > 0:
             self._maybe_warn_about_trimmed_history(log)
 
     def _write_body(self, renderable: RenderableType) -> None:
@@ -1469,8 +1479,42 @@ class ConversationView(Widget):
         """Scroll the log to the next agent turn anchor."""
         self._jump_to_relative_anchor(+1)
 
-    @staticmethod
-    def _absolute_line_position(log: RichLog) -> int:
+    def _richlog_start_line(self, log: RichLog) -> int:
+        """Return ``log._start_line`` defensively (G-F15, wave-10 follow-up).
+
+        ``_start_line`` is a private RichLog attribute carrying the
+        cumulative dropped-lines counter — load-bearing for the
+        absolute-anchor system that powers Ctrl+P/N turn navigation.
+        Textual hasn't renamed or restructured this attribute in any
+        version we've tested, but relying on a private name means a
+        future upgrade could silently swap it for a new public
+        property. The bare ``getattr(log, "_start_line", 0)`` form
+        would quietly return 0, making all anchor positions degrade
+        to "treated as never-trimmed" — on a long session past the
+        ``_RICHLOG_MAX_LINES`` boundary, every Ctrl+P/N would then
+        land on the wrong line, and the trim-warning would never
+        fire either.
+
+        The helper logs a one-shot warning when the attribute is
+        missing so operators get a detectable signal that the
+        integration is broken. Behavioural fallback stays 0 (= same
+        as the bare ``getattr`` default) so a no-history session
+        keeps working.
+        """
+        value = getattr(log, "_start_line", None)
+        if value is None:
+            if not self._start_line_warned:
+                self._start_line_warned = True
+                logger.warning(
+                    "RichLog._start_line is missing — Textual API may "
+                    "have changed; turn-navigation anchors will degrade "
+                    "to treating all history as never-trimmed. Update "
+                    "the helper at conversation._richlog_start_line.",
+                )
+            return 0
+        return value
+
+    def _absolute_line_position(self, log: RichLog) -> int:
         """Return the absolute write-position (drop-aware) for the next line.
 
         ``log._start_line`` is RichLog's cumulative dropped-lines counter
@@ -1478,8 +1522,11 @@ class ConversationView(Widget):
         a monotonic absolute index that survives the ring-buffer trim —
         unlike the bare ``len(log.lines)`` value, which silently rebases
         the moment ``max_lines`` is exceeded.
+
+        Reads through ``_richlog_start_line`` for the one-shot
+        Textual-API-change warning (G-F15).
         """
-        return getattr(log, "_start_line", 0) + len(log.lines)
+        return self._richlog_start_line(log) + len(log.lines)
 
     def _resolve_anchors_to_current_view(self, log: RichLog) -> list[int]:
         """Project stored absolute anchors back into current ``log.lines`` indexes.
@@ -1489,7 +1536,7 @@ class ConversationView(Widget):
         log would scroll to whatever line happens to occupy that slot now,
         which is exactly the bug the bare-index version exhibited.
         """
-        start = getattr(log, "_start_line", 0)
+        start = self._richlog_start_line(log)
         return [a - start for a in self._turn_anchors if a - start >= 0]
 
     def _maybe_warn_about_trimmed_history(self, log: RichLog) -> None:
@@ -1511,7 +1558,7 @@ class ConversationView(Widget):
         """
         if self._trim_warned:
             return
-        start = getattr(log, "_start_line", 0)
+        start = self._richlog_start_line(log)
         if start <= 0:
             return
         self._trim_warned = True

--- a/tests/cli/test_richlog_start_line_helper.py
+++ b/tests/cli/test_richlog_start_line_helper.py
@@ -1,0 +1,141 @@
+"""Tier 2: _richlog_start_line wraps the private Textual attribute (G-F15).
+
+Wave-10 follow-up Topic G finding F15 (P2): the turn-navigation
+anchor system depended on ``getattr(log, "_start_line", 0)`` at
+four callsites. ``_start_line`` is a private RichLog attribute
+that Textual could rename / restructure on any upgrade. The bare
+``getattr`` form would silently return 0 — making all anchor
+positions degrade to "treated as never-trimmed", with every
+Ctrl+P/N landing on the wrong line in long sessions and the
+trim-warning never firing.
+
+The fix wraps the access in ``_richlog_start_line(log)`` which
+logs a one-shot warning when the attribute is missing. The
+behavioural fallback stays 0 (= same as the bare getattr default)
+so a no-history session keeps working, but operators get a
+detectable signal that the Textual integration is broken.
+
+Public surfaces tested:
+  - normal call (attribute present) returns the value (regression
+    guard)
+  - missing attribute returns 0 (fallback preserved)
+  - missing attribute logs a one-shot warning
+  - subsequent missing-attribute calls do NOT re-log
+    (dedup via ``_start_line_warned``)
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+class _StubLog:
+    """RichLog stand-in carrying or missing the ``_start_line`` attribute."""
+
+    def __init__(self, *, start_line=None) -> None:
+        if start_line is not None:
+            self._start_line = start_line
+        self.lines: list = []
+
+
+@pytest.mark.asyncio
+async def test_normal_call_returns_attribute_value() -> None:
+    """Tier 2 (regression): present ``_start_line`` value is returned."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = _StubLog(start_line=137)
+        assert conv._richlog_start_line(log) == 137
+
+
+@pytest.mark.asyncio
+async def test_missing_attribute_returns_zero_fallback() -> None:
+    """Tier 2: missing ``_start_line`` → 0 fallback (same as legacy getattr)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Reset warning state in case the previous test fired it.
+        conv._start_line_warned = False
+        log = _StubLog()  # no _start_line attribute
+        assert conv._richlog_start_line(log) == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_attribute_logs_one_shot_warning(caplog) -> None:
+    """Tier 2: first missing call logs warning, subsequent calls don't.
+
+    The dedup gives operators a detectable signal without spamming
+    the log on every turn navigation when Textual changes its
+    private API.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv._start_line_warned = False
+        log = _StubLog()
+
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            conv._richlog_start_line(log)
+            first_count = sum(
+                1 for r in caplog.records
+                if "RichLog._start_line is missing" in r.getMessage()
+            )
+            # Three more calls — should NOT log again.
+            conv._richlog_start_line(log)
+            conv._richlog_start_line(log)
+            conv._richlog_start_line(log)
+            total_count = sum(
+                1 for r in caplog.records
+                if "RichLog._start_line is missing" in r.getMessage()
+            )
+
+        assert first_count == 1, (
+            f"first missing-attr call should log exactly once; "
+            f"got {first_count}"
+        )
+        assert total_count == 1, (
+            f"subsequent missing-attr calls should not re-log; "
+            f"total log lines: {total_count}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_absolute_line_position_uses_helper() -> None:
+    """Tier 2: ``_absolute_line_position`` reads through ``_richlog_start_line``.
+
+    Regression guard for the refactor — the static helper became an
+    instance method using ``self._richlog_start_line(log)`` so the
+    one-shot warning path covers ``_absolute_line_position`` too.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = _StubLog(start_line=42)
+        # absolute = start_line + len(log.lines); lines is empty, so 42.
+        assert conv._absolute_line_position(log) == 42
+        log.lines = [1, 2, 3]  # 3 entries
+        assert conv._absolute_line_position(log) == 45


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up PR (G-F15, P2 M). Single-scope: ``_richlog_start_line`` helper + 4 callsite migrations + instance-method conversion of ``_absolute_line_position``.

## Problem

4 callsites used bare ``getattr(log, "_start_line", 0)`` for a private Textual attribute. Future Textual upgrade renaming this attribute would silently degrade turn-navigation anchors to "never-trimmed", with every Ctrl+P/N in long sessions landing on the wrong line and no operator signal.

## Fix

Helper ``_richlog_start_line(log)`` reads through ``getattr(..., None)`` + logs a one-shot warning (via stdlib ``logging``) when the attribute is missing. Fallback stays 0 (same as legacy). All callsites route through the helper. ``_absolute_line_position`` converted from ``@staticmethod`` to instance method.

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests: value-return regression, fallback, one-shot log, dedup
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)