### PR TITLE
feat(plugins): reyn.plugins.api public helper + sample refactor (FP-0041 plugins-api PR-1)

### DIFF
--- a/docs/plugins/authoring-guide.md
+++ b/docs/plugins/authoring-guide.md
@@ -118,35 +118,41 @@ plugin author defines this schema.
 Secrets (= API keys, signing secrets) belong in **environment
 variables**, never in webhooks.yaml.
 
-## Inbound envelope shape
+## Inbound envelope shape + stable plugin API
 
-When the plugin's route receives a webhook, it should mint an
-envelope and push to the target agent's inbox:
+When the plugin's route receives a webhook, push to the target
+agent's inbox via the **stable plugin API** in ``reyn.plugins.api``::
 
 ```python
 from reyn.chat.transport import ExternalRef
+from reyn.plugins.api import push_to_agent
 
-envelope = {
-    "text": "<message body>",
-    "sender": f"<transport>:<external_user_id>",
-    "reply_to": ExternalRef(
-        transport="<transport>",        # e.g. "slack", "line"
+await push_to_agent(
+    target_agent=target_agent,
+    text="<message body>",
+    sender=f"<transport>:<external_user_id>",
+    reply_to=ExternalRef(
+        transport="<transport>",       # e.g. "slack", "line"
         destination={                   # transport-specific routing
             "channel": "...",
             "thread_ts": "...",
         },
     ),
-}
-
-# Push via the AgentRegistry (= from reyn.web.deps):
-session = await registry.ensure_running(target_agent)
-await session._put_inbox("user", envelope)
+)
 ```
+
+**Do NOT call internal session methods directly.** ``ChatSession.
+_put_inbox`` etc. are private API and may change between Reyn
+versions; ``reyn.plugins.api`` is the contract that stays stable.
 
 Reyn's session dispatch automatically:
 - Surfaces ``sender`` as a state_change history entry (= PR-A
   attribution)
 - Captures ``reply_to`` for outbound reply routing (= PR-D2)
+
+The plugin API receives an optional ``registry`` kwarg for tests
+(= inject an ``AgentRegistry`` stub). Production code omits it
+and uses the process-shared registry.
 
 ## Outbound replies via MCP
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2061,7 +2061,16 @@ class ChatSession:
     async def _put_inbox(self, kind: str, payload: dict) -> str:
         """Append `inbox_put` to WAL via journal, then queue on the async
         inbox. Returns the assigned message id (also stamped into payload
-        as `_msg_id` so the consumer can look it up)."""
+        as `_msg_id` so the consumer can look it up).
+
+        **Internal API — plugin authors should NOT call directly**
+        (FP-0041 plugins-api). Use ``reyn.plugins.api.push_to_agent``
+        instead; this signature may change between Reyn versions.
+        Other internal Reyn modules (= A2AHandler, MCP handler,
+        InterventionHandler, ChatLifecycleForwarder) keep calling
+        this directly because they manage their own additional state
+        machines (= chain_id / request_id / etc.) on top.
+        """
         msg_id = await self._journal.append_inbox(kind=kind, payload=payload)
         full_payload = {**payload, "_msg_id": msg_id}
         await self.inbox.put((kind, full_payload))

--- a/src/reyn/plugins/api.py
+++ b/src/reyn/plugins/api.py
@@ -1,0 +1,111 @@
+"""Reyn plugin public API — stable surface for plugin authors.
+
+Plugins (= webhook handlers under ``reyn.plugins.*`` or external pip
+packages registered via the ``reyn.webhooks`` entry-point group)
+SHOULD use the helpers in this module to interact with Reyn agents,
+NOT call internal ``ChatSession`` methods (= ``_put_inbox``,
+``_handle_user_message``) directly.
+
+The contract here is intended to stay stable across Reyn minor
+versions; internal session APIs may change without notice.
+
+## Status
+
+  ``push_to_agent`` — Tier-1 stable, FP-0041 PR plugins-api ✅
+  Other helpers — TBD as plugin needs surface.
+
+## Design notes
+
+- The signature is **kwarg-only** so future additions don't shift
+  positional arguments.
+- ``kind`` defaults to ``"user"`` (= the typical webhook plugin case
+  where an external message becomes a user-shaped turn). Future
+  unification with A2A / MCP message paths may use other kind
+  values; the parameter is exposed today so the contract can extend
+  without API break.
+- ``extra_meta`` is a passthrough hook for future per-path metadata
+  (= e.g. A2A's ``chain_id``, MCP's ``request_id``). Webhook plugins
+  typically omit it; A2A/MCP convergence work is tracked separately.
+- ``registry`` defaults to the process-shared singleton from
+  ``reyn.web.deps``; tests pass a stub for isolation.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from reyn.chat.transport import TransportRef
+
+
+async def push_to_agent(
+    *,
+    target_agent: str,
+    text: str,
+    sender: str,
+    reply_to: TransportRef | None = None,
+    kind: str = "user",
+    extra_meta: dict | None = None,
+    registry: Any | None = None,
+) -> None:
+    """Deliver a message to a Reyn agent's inbox.
+
+    This is the **stable public API** for webhook / chat-transport
+    plugins. Use it instead of touching ``ChatSession._put_inbox``
+    directly. Internal session APIs may change between Reyn versions;
+    this function won't.
+
+    Parameters
+    ----------
+    target_agent:
+        Name of the agent in the project's ``.reyn/agents/`` registry
+        that should receive the message. Raises ``FileNotFoundError``
+        when no such agent exists.
+    text:
+        Message body the LLM will see as its turn input.
+    sender:
+        Attribution string with format ``<transport>:<external_id>``
+        (= e.g. ``"slack:U456"``, ``"line:user:U999"``,
+        ``"webhook:github:42"``). PR-A dispatch attribution emits a
+        ``[context shift]`` state_change entry on transitions between
+        senders.
+    reply_to:
+        Optional ``TransportRef`` describing where agent replies
+        should route (= e.g. ``ExternalRef`` for outbound dispatch
+        via MCP). When set, Reyn's outbox interceptor (= PR-D2)
+        forwards replies through ``route_to_mcp``. When ``None``,
+        replies follow the default surface (= TUI / detached).
+    kind:
+        Inbox dispatch kind. ``"user"`` for normal external user
+        messages (= webhook plugin default). Other values are
+        Reyn-internal (= ``"agent_request"`` / ``"agent_response"``
+        for A2A; reserved for future unification work). Plugin
+        authors should not need to override this in current Reyn.
+    extra_meta:
+        Per-path metadata for future unification (= A2A chain_id,
+        MCP request_id, etc.). Webhook plugins typically omit it;
+        passing arbitrary keys here is reserved — see future
+        unification design before relying on it.
+    registry:
+        Optional ``AgentRegistry`` override for tests. Production
+        callers omit it; the process-shared registry is used.
+
+    Raises
+    ------
+    FileNotFoundError:
+        When ``target_agent`` doesn't exist in the project registry.
+    """
+    if registry is None:
+        from reyn.web.deps import _get_registry
+        registry = _get_registry()
+    session = await registry.ensure_running(target_agent)
+    envelope: dict[str, Any] = {
+        "text": text,
+        "sender": sender,
+    }
+    if reply_to is not None:
+        envelope["reply_to"] = reply_to
+    if extra_meta:
+        envelope["meta"] = dict(extra_meta)
+    await session._put_inbox(kind, envelope)
+
+
+__all__ = ["push_to_agent"]

--- a/src/reyn/plugins/sample_line/webhook.py
+++ b/src/reyn/plugins/sample_line/webhook.py
@@ -230,13 +230,24 @@ def build_router(*, target_agent: str) -> APIRouter:
             # No events array → ack (= e.g. LINE verify ping).
             return JSONResponse({"status": "ignored"}, status_code=200)
 
+        # Push each dispatchable event via the stable plugin API
+        # (= reyn.plugins.api, FP-0041 plugins-api).
+        from reyn.plugins.api import push_to_agent
+
         dispatched = 0
         for event in events:
             envelope = mint_envelope_from_line_event(event)
             if envelope is None:
                 continue
             try:
-                session = await registry.ensure_running(target_agent)
+                await push_to_agent(
+                    target_agent=target_agent,
+                    text=envelope["text"],
+                    sender=envelope["sender"],
+                    reply_to=envelope["reply_to"],
+                    registry=registry,
+                )
+                dispatched += 1
             except FileNotFoundError:
                 logger.warning(
                     "LINE webhook: target agent %r not found in registry",
@@ -246,9 +257,6 @@ def build_router(*, target_agent: str) -> APIRouter:
                     {"error": f"target agent {target_agent!r} not found"},
                     status_code=503,
                 )
-            try:
-                await session._put_inbox("user", dict(envelope))
-                dispatched += 1
             except Exception as exc:
                 logger.exception("LINE webhook: inbox push failed: %s", exc)
                 return JSONResponse(

--- a/src/reyn/plugins/sample_slack/webhook.py
+++ b/src/reyn/plugins/sample_slack/webhook.py
@@ -275,11 +275,19 @@ def build_router(*, target_agent: str) -> APIRouter:
             # message echo / etc.). Slack expects 2xx so it won't retry.
             return JSONResponse({"status": "ignored"}, status_code=200)
 
-        # Push to inbox via the registry (= ensure_running so the agent's
-        # router_loop is live to consume). ``target_agent`` was captured
-        # in the closure at ``build_router`` time from the plugin config.
+        # Push to inbox via the stable plugin API (= reyn.plugins.api,
+        # FP-0041 plugins-api). The helper handles registry lookup +
+        # session.ensure_running internally; plugin code should NOT
+        # touch ChatSession internals (= _put_inbox) directly.
+        from reyn.plugins.api import push_to_agent
         try:
-            session = await registry.ensure_running(target_agent)
+            await push_to_agent(
+                target_agent=target_agent,
+                text=envelope["text"],
+                sender=envelope["sender"],
+                reply_to=envelope["reply_to"],
+                registry=registry,
+            )
         except FileNotFoundError:
             logger.warning(
                 "Slack webhook: target agent %r not found in registry",
@@ -289,8 +297,6 @@ def build_router(*, target_agent: str) -> APIRouter:
                 {"error": f"target agent {target_agent!r} not found"},
                 status_code=503,
             )
-        try:
-            await session._put_inbox("user", dict(envelope))
         except Exception as exc:
             logger.exception("Slack webhook: inbox push failed: %s", exc)
             return JSONResponse(

--- a/tests/plugins/test_api.py
+++ b/tests/plugins/test_api.py
@@ -1,0 +1,210 @@
+"""Tier 2: reyn.plugins.api — public plugin helper API (FP-0041 follow-up).
+
+Pins the stable contract that webhook plugins consume:
+
+  push_to_agent(target_agent, text, sender, reply_to=None,
+                kind="user", extra_meta=None, registry=None)
+
+Internal ``ChatSession._put_inbox`` is deliberately private; the
+helper is the documented path. Tests cover:
+
+  1. Happy path: helper resolves registry, calls ensure_running,
+     and pushes the right envelope shape.
+  2. Optional ``reply_to`` propagates when set, absent when None.
+  3. Optional ``extra_meta`` becomes the envelope's ``meta``.
+  4. Non-default ``kind`` is forwarded to ``_put_inbox`` (= future
+     A2A/MCP unify path).
+  5. Custom ``registry`` override is honored (= tests stub out the
+     process singleton).
+  6. ``FileNotFoundError`` from registry propagates (= caller
+     handles, e.g. webhook returns 503).
+
+Tier 2 because the API is the stable contract for all webhook
+plugins; a regression in envelope shape breaks every plugin's
+integration with Reyn.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chat.transport import ExternalRef
+from reyn.plugins.api import push_to_agent
+
+# ── stub registry / session ───────────────────────────────────────────
+
+
+class _StubSession:
+    def __init__(self):
+        self.pushed: list = []
+
+    async def _put_inbox(self, kind, payload):
+        self.pushed.append((kind, payload))
+        return f"msg-{len(self.pushed)}"
+
+
+class _StubRegistry:
+    def __init__(self, *, missing: list[str] | None = None):
+        self._sessions: dict[str, _StubSession] = {}
+        self._missing = set(missing or [])
+
+    async def ensure_running(self, name):
+        if name in self._missing:
+            raise FileNotFoundError(name)
+        if name not in self._sessions:
+            self._sessions[name] = _StubSession()
+        return self._sessions[name]
+
+
+# ── tests ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_minimal_call():
+    """Tier 2: a minimal call (= target_agent + text + sender) lands
+    a ``kind="user"`` envelope with no reply_to / meta.
+    """
+    reg = _StubRegistry()
+    await push_to_agent(
+        target_agent="news",
+        text="hello",
+        sender="slack:U1",
+        registry=reg,
+    )
+    sess = await reg.ensure_running("news")
+    assert sess.pushed == [("user", {"text": "hello", "sender": "slack:U1"})]
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_with_reply_to():
+    """Tier 2: ``reply_to`` propagates into the envelope so the
+    outbox interceptor (= PR-D2) can route replies externally.
+    """
+    reg = _StubRegistry()
+    ref = ExternalRef(transport="slack", destination={"channel": "C1"})
+    await push_to_agent(
+        target_agent="news",
+        text="hello",
+        sender="slack:U1",
+        reply_to=ref,
+        registry=reg,
+    )
+    sess = await reg.ensure_running("news")
+    kind, payload = sess.pushed[0]
+    assert kind == "user"
+    assert payload["reply_to"] is ref
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_omits_reply_to_when_none():
+    """Tier 2: when ``reply_to=None`` the envelope does NOT carry
+    a ``reply_to`` key (= keeps the dispatch attribution code from
+    re-checking a None value).
+    """
+    reg = _StubRegistry()
+    await push_to_agent(
+        target_agent="news",
+        text="hello",
+        sender="slack:U1",
+        registry=reg,
+    )
+    sess = await reg.ensure_running("news")
+    _, payload = sess.pushed[0]
+    assert "reply_to" not in payload
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_extra_meta_propagates():
+    """Tier 2: ``extra_meta`` is stored in the envelope as ``meta``.
+    Used by future unification paths (= A2A chain_id, MCP request_id).
+    """
+    reg = _StubRegistry()
+    await push_to_agent(
+        target_agent="news",
+        text="hello",
+        sender="a2a:peer",
+        extra_meta={"chain_id": "abc-123"},
+        registry=reg,
+    )
+    sess = await reg.ensure_running("news")
+    _, payload = sess.pushed[0]
+    assert payload["meta"] == {"chain_id": "abc-123"}
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_kind_override():
+    """Tier 2: non-default ``kind`` is forwarded to ``_put_inbox``.
+    Reserved for future A2A / MCP unification; webhook plugins use
+    the default ``"user"``.
+    """
+    reg = _StubRegistry()
+    await push_to_agent(
+        target_agent="news",
+        text="please respond",
+        sender="a2a:peer",
+        kind="agent_request",
+        registry=reg,
+    )
+    sess = await reg.ensure_running("news")
+    kind, _ = sess.pushed[0]
+    assert kind == "agent_request"
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_registry_override_for_tests():
+    """Tier 2: the ``registry`` kwarg lets tests pass a stub instead
+    of using the process-shared singleton. Production callers omit
+    it; the singleton is fetched lazily inside the helper.
+    """
+    reg = _StubRegistry()
+    await push_to_agent(
+        target_agent="agent_a",
+        text="x",
+        sender="user:tui",
+        registry=reg,
+    )
+    # Pushed to the supplied stub, not the global registry.
+    session = await reg.ensure_running("agent_a")
+    assert len(session.pushed) == 1
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_propagates_file_not_found():
+    """Tier 2: when the registry can't resolve the agent (=
+    operator typo in ``target_agent`` or agent not yet created),
+    ``FileNotFoundError`` surfaces to the caller. Webhook plugins
+    catch this to return 503 with a clear message.
+    """
+    reg = _StubRegistry(missing=["nonexistent"])
+    with pytest.raises(FileNotFoundError):
+        await push_to_agent(
+            target_agent="nonexistent",
+            text="x",
+            sender="user:tui",
+            registry=reg,
+        )
+
+
+@pytest.mark.asyncio
+async def test_push_to_agent_full_envelope_shape():
+    """Tier 2: a full-args call produces the documented envelope
+    shape (= text + sender + reply_to + meta).
+    """
+    reg = _StubRegistry()
+    ref = ExternalRef(transport="line", destination={"reply_token": "T1"})
+    await push_to_agent(
+        target_agent="news",
+        text="hi",
+        sender="line:user:U1",
+        reply_to=ref,
+        extra_meta={"trace_id": "abc"},
+        registry=reg,
+    )
+    sess = await reg.ensure_running("news")
+    kind, payload = sess.pushed[0]
+    assert kind == "user"
+    assert payload == {
+        "text": "hi",
+        "sender": "line:user:U1",
+        "reply_to": ref,
+        "meta": {"trace_id": "abc"},
+    }


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 follow-up **PR-1 (= plugins-api)** = ``reyn.plugins.api`` public helper module。 main 直 base、 standalone。

## Why

User指摘: 「bolt と reyn を繋ぐレイヤはどうなるの？ そこは標準化されてないでしょ？」 → 確認、 これまで plugin 経由 inbox push は ``session._put_inbox`` 私室 API を直接叩いていた。 この PR で stable 公開 API を確立。

## What this PR ships

### ``reyn.plugins.api.push_to_agent``

```python
async def push_to_agent(
    *,
    target_agent: str,
    text: str,
    sender: str,
    reply_to: TransportRef | None = None,
    kind: str = "user",
    extra_meta: dict | None = None,
    registry: Any | None = None,
) -> None
```

- ``kind`` / ``extra_meta`` は **future-proofing** (= A2A chain_id / MCP request_id 等 unification 用の足場)、 webhook plugin は default のみ使用
- ``registry`` は test 用 stub injection 用、 production は process-shared singleton

### sample plugin refactor

- ``sample_slack`` / ``sample_line`` を ``push_to_agent`` 経由に書き換え (= ``session._put_inbox`` 直接 call 廃止)
- canonical pattern を external plugin author に示す reference

### ``ChatSession._put_inbox`` private-marker

docstring に 「plugin authors は使うな、 ``reyn.plugins.api`` 使え」 と明記。 internal Reyn 他 modules (= A2AHandler / MCP handler 等) は state machine 持つので継続利用。

### authoring guide 更新

``docs/plugins/authoring-guide.md`` の canonical example を ``push_to_agent`` に更新、 internal API 直接叩き warning を明記。

## What's NOT in this PR (= PR-2 で)

- ``sample_slack`` を ``slack-bolt`` に置き換え (= production 品質 protocol layer)
- ``sample_line`` を ``line-bot-sdk`` に置き換え
- A2A / MCP の inbox push path 統合 (= 別 architectural design 必要、 state machine 分離)

= **PR-1 = Reyn-side stable API**、 **PR-2 = OSS SDK 採用で sample を API-to-API glue ~50 行 reference に縮減**、 **future PR = A2A/MCP unify** 段階。

## Change shape

- ``src/reyn/plugins/api.py`` (= new, ~100 lines)
- ``src/reyn/plugins/sample_slack/webhook.py`` ・ ``sample_line/webhook.py``: refactor to use ``push_to_agent``
- ``src/reyn/chat/session.py``: ``_put_inbox`` docstring に private-marker
- ``docs/plugins/authoring-guide.md``: canonical pattern 更新
- ``tests/plugins/test_api.py`` (= new, 8 tests): minimal call / reply_to propagation / reply_to absence on None / extra_meta / kind override / registry override / FileNotFoundError / full-envelope shape

## Test plan

- [x] ``pytest tests/plugins/test_api.py`` — 8/8 pass
- [x] ``pytest tests/plugins/`` (= API + samples + loader) — 46/46
- [x] ``pytest tests/`` (full suite) — 5080 pass, 5 skip, 3 xfailed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## Future architectural unify (= NOT in scope)

A2A / MCP / webhook plugin の inbox push path は 「単純 push」 layer は共通化可能 (= ``push_to_agent`` 経由)、 ただし state machine layer (= A2A chain_id timeout watchdog / MCP JSON-RPC future correlation) は path 毎に独自必要。 PR-1 で API shape を将来拡張可能 (= ``kind`` / ``extra_meta`` 足) にしておき、 unification は separate exploration。

Refs #489 (FP-0041 plugins-api PR-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)