### PR TITLE
fix(tui): ErrorBox eb-inline-hint defensive display:none default (I-F12)

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -74,15 +74,23 @@ class ErrorBox(Widget):
         width: 1fr;
         padding: 0 2;
     }
-    /* Inline recovery hint extracted from the message — always visible
-       (= no display:none) so users can read "• retry or check provider
-       status" without expanding. Distinct color from `.eb-hint` so it
+    /* Inline recovery hint extracted from the message. Default
+       `display: none` (= matches `.eb-hint` symmetry, wave-10
+       follow-up I-F12) so an accidentally-yielded empty hint
+       doesn't grab a row of layout. The `.-has-content` modifier
+       toggles it visible — applied at yield time so the visibility
+       contract is "the Label was created WITH content, not just
+       attached to the DOM". Distinct color from `.eb-hint` so it
        reads as actionable, not just metadata. */
     ErrorBox Label.eb-inline-hint {
+        display: none;
         color: #8a7a4a;
         height: 1;
         width: 1fr;
         padding: 0 2;
+    }
+    ErrorBox Label.eb-inline-hint.-has-content {
+        display: block;
     }
     /* Expanded state — reveal details */
     ErrorBox.-expanded Static.eb-details {
@@ -190,8 +198,16 @@ class ErrorBox(Widget):
     def compose(self) -> ComposeResult:
         yield Label(self._header_text(), classes="eb-header")
         if self._inline_hint:
+            # Wave-10 follow-up I-F12: tag the Label with
+            # ``-has-content`` so the CSS visibility toggles to
+            # ``display: block``. The ``if`` guard above is still the
+            # primary gate (= we don't mount empty Labels at all);
+            # the class is defense-in-depth so a future refactor that
+            # drops the guard or yields the Label with empty content
+            # doesn't grab a layout row for an empty hint.
             yield Label(
-                f"• {self._inline_hint}", classes="eb-inline-hint",
+                f"• {self._inline_hint}",
+                classes="eb-inline-hint -has-content",
             )
 
         # The trace hint only makes sense when this error came from a

--- a/tests/cli/test_errorbox_inline_hint_defensive.py
+++ b/tests/cli/test_errorbox_inline_hint_defensive.py
@@ -1,0 +1,104 @@
+"""Tier 2: eb-inline-hint defensive CSS (I-F12).
+
+Wave-10 follow-up Topic I finding F12 (P3): the
+``ErrorBox Label.eb-inline-hint`` CSS lacked ``display: none``
+default while its sibling ``.eb-hint`` had it. Today the
+``compose()`` ``if self._inline_hint:`` guard prevents an empty
+Label from ever being mounted, so the asymmetric CSS doesn't
+cause visible breakage. But if a future refactor drops or
+breaks that guard, an empty Label would land in the DOM and
+grab a layout row for nothing.
+
+After the fix the inline-hint Label defaults to ``display: none``
+and only becomes visible via a ``.-has-content`` modifier class
+applied at yield time. The ``if`` guard remains the primary
+gate; the class is defense-in-depth.
+
+Public surfaces tested:
+  - non-empty hint → Label mounted with both classes
+  - empty hint → Label not mounted (regression — current
+    behaviour unchanged)
+  - CSS string contains both the ``display: none`` default and the
+    ``.-has-content`` toggle (= the contract pair)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_inline_hint_label_carries_has_content_class_when_set() -> None:
+    """Tier 2: non-empty inline_hint → Label tagged ``-has-content``."""
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Message with " • hint" trailer → triggers inline_hint extraction.
+        box = conv.mount_error(message="something broke • retry in 30s")
+        await pilot.pause()
+
+        labels = list(box.query(Label))
+        inline_hints = [
+            lbl for lbl in labels if lbl.has_class("eb-inline-hint")
+        ]
+        assert inline_hints, "inline hint Label should be mounted"
+        hint = inline_hints[0]
+        assert hint.has_class("-has-content"), (
+            f"inline hint should carry -has-content modifier; "
+            f"classes: {hint.classes!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_inline_hint_does_not_mount_label() -> None:
+    """Tier 2 (regression): no `• …` trailer → no inline hint Label."""
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        box = conv.mount_error(message="something broke")  # no • hint
+        await pilot.pause()
+
+        labels = list(box.query(Label))
+        inline_hints = [
+            lbl for lbl in labels if lbl.has_class("eb-inline-hint")
+        ]
+        assert inline_hints == [], (
+            f"no hint trailer → no inline hint Label should mount; "
+            f"got {len(inline_hints)} labels"
+        )
+
+
+def test_inline_hint_css_has_display_none_default_and_has_content_toggle() -> None:
+    """Tier 2: CSS pair (default-hidden + visible-modifier) is in place."""
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    css = ErrorBox.DEFAULT_CSS
+    # Default is hidden.
+    assert ".eb-inline-hint {" in css
+    eb_inline_block = css.split(".eb-inline-hint {", 1)[1].split("}", 1)[0]
+    assert "display: none" in eb_inline_block, (
+        f"eb-inline-hint should have display:none default; got "
+        f"block:\n{eb_inline_block!r}"
+    )
+    # And the visibility-toggle modifier exists.
+    assert ".eb-inline-hint.-has-content" in css, (
+        f"missing .-has-content modifier in CSS; got:\n{css!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up final round PR #2 (I-F12, P3 S). Single-scope: CSS defensive pair + compose class augmentation.

## Why now

Together with I-F11 (#527), this closes the wave-10 backlog. Both are P3 defensive cleanups in widgets where the bug is currently latent — fixing them while the file is in mind is cheaper than debugging from a "row of empty space" / "visible state diverged" symptom later.

## Problem

``.eb-inline-hint`` CSS has no ``display: none`` default (asymmetric with ``.eb-hint`` sibling). A future refactor that drops the ``if self._inline_hint:`` guard would mount an empty Label with a visible empty row.

## Fix

Pair:
1. CSS: ``display: none`` default + ``.-has-content`` modifier sets ``display: block``
2. ``compose()``: yields with both ``eb-inline-hint`` and ``-has-content`` classes

Current behaviour unchanged (= if-guard still prevents empty mounts); future-safety added (= the visibility contract now lives at the CSS layer too).

## Test plan

- [x] ruff check passes
- [x] 3 new Tier 2 tests: non-empty carries modifier, empty doesn't mount (regression), CSS has the pair
- [x] Existing ErrorBox tests (header truncate, on_click atomic) + 40 smoke tests still green

## Wave-10 closure

```
✅ G-F1 / G-F2 / G+I-F8 (bundle) / G-F3 / G-F4 / G-F5 / G-F10 (main + r1 + r2)
✅ H-F2 / H-F1 / I-F1 (main)
✅ H-F3 / I-F2 / I-F4 / G-F11 / G-F14 (r1)
✅ G-F6 / G-F9 / H-F4 / I-F3 / I-F9 (r2)
✅ H-F12 / G-F13 / G-F7 (r3) ← H-F8 honest scope drop
✅ H-F6 (r4) ← H-F7 / I-F10 honest scope drops
✅ H-F11 / G-F15 (r5)
🆕 I-F11 (#527 in flight) + I-F12 (this PR, final)
```

73 PR wave-10 周辺 closure (= main 10 + 5 r1 + 5 r2 + 3 r3 + 1 r4 + 2 r5 + 2 final + 2 flaky + 1 docs). All 39 wave-10 findings either landed, intentionally articulated as design choices, or marked out-of-scope with explicit rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)