### PR TITLE
feat(plugins): plugin API discovery helpers — list_agents / agent_exists / make_sender (FP-0041 plugins-api PR-1b)

### DIFF
--- a/docs/plugins/authoring-guide.md
+++ b/docs/plugins/authoring-guide.md
@@ -118,6 +118,34 @@ plugin author defines this schema.
 Secrets (= API keys, signing secrets) belong in **environment
 variables**, never in webhooks.yaml.
 
+## Stable plugin API — ``reyn.plugins.api``
+
+The module exposes the **stable contract** plugin authors consume.
+Internal session methods (= ``_put_inbox`` etc.) may change between
+Reyn versions; this API stays stable.
+
+### Helpers
+
+  push_to_agent(*, target_agent, text, sender, reply_to=None,
+                kind="user", extra_meta=None, registry=None)
+    Deliver a message to a Reyn agent's inbox. Default for webhook
+    plugins.
+
+  list_agents(*, registry=None) -> list[str]
+    All agent names known to the project (= sorted disk view).
+    Use at register_router time to validate config or discover
+    targets dynamically.
+
+  agent_exists(name, *, registry=None) -> bool
+    Pre-flight check for a single agent name. Defensive: registry
+    error → False.
+
+  make_sender(transport, external_id, *, display=None,
+              source_scope=None) -> str
+    Assemble the documented sender attribution string. Prefer over
+    raw f-strings so dispatch attribution label rendering follows
+    the standard format. See examples in the docstring.
+
 ## Inbound envelope shape + stable plugin API
 
 When the plugin's route receives a webhook, push to the target

--- a/src/reyn/plugins/api.py
+++ b/src/reyn/plugins/api.py
@@ -108,4 +108,106 @@ async def push_to_agent(
     await session._put_inbox(kind, envelope)
 
 
-__all__ = ["push_to_agent"]
+# ── agent discovery ────────────────────────────────────────────────────
+
+
+def list_agents(*, registry: Any | None = None) -> list[str]:
+    """Return all agent names known to the project (= file-system view).
+
+    Plugin authors use this at ``register_router`` time to validate the
+    ``target_agent`` in their config OR to discover available agents
+    dynamically. Returns a sorted list of agent names (= subdirs of
+    ``.reyn/agents/`` carrying a profile file).
+
+    Includes agents that are NOT currently running (= ``ensure_running``
+    will start them on first push). Lazy / on-disk view, not the live
+    set of router_loop tasks.
+
+    ``registry`` is optional for tests; production callers omit it and
+    the process-shared singleton from ``reyn.web.deps`` is used.
+    """
+    if registry is None:
+        from reyn.web.deps import _get_registry
+        registry = _get_registry()
+    return registry.list_names()
+
+
+def agent_exists(name: str, *, registry: Any | None = None) -> bool:
+    """True iff ``name`` is registered in the project's agents dir.
+
+    Useful for pre-flight validation in ``register_router`` so a
+    plugin can return ``None`` (= skip mount) when the configured
+    ``target_agent`` is mistyped, instead of failing on every webhook
+    POST with a 503.
+
+    Falls back to ``False`` on any registry error (= defensive: a
+    boot-time registry hiccup shouldn't crash plugin discovery).
+    """
+    try:
+        if registry is None:
+            from reyn.web.deps import _get_registry
+            registry = _get_registry()
+        return registry.exists(name)
+    except Exception:
+        return False
+
+
+# ── sender formatting ──────────────────────────────────────────────────
+
+
+def make_sender(
+    transport: str,
+    external_id: str,
+    *,
+    display: str | None = None,
+    source_scope: str | None = None,
+) -> str:
+    """Build a Reyn ``sender`` attribution string.
+
+    Reyn's dispatch attribution (= PR-A) emits a ``[context shift]``
+    state_change history entry when the sender changes between turns.
+    The format is ``<transport>[:<source_scope>]:<external_id>[:<display>]``
+    so ``_format_sender_label`` (= reyn.chat.session) renders a
+    readable label for the LLM.
+
+    Examples
+    --------
+    Slack 1:1 chat::
+
+        make_sender("slack", "U456")
+        # → "slack:U456"
+
+        make_sender("slack", "U456", display="bob")
+        # → "slack:U456:bob"
+
+    LINE 1:1 chat with explicit source scope::
+
+        make_sender("line", "U456", source_scope="user")
+        # → "line:user:U456"
+
+    LINE group chat (= external_id is the group, display is the
+    posting user)::
+
+        make_sender("line", "G999", source_scope="group", display="U456")
+        # → "line:group:G999:U456"
+
+    Plugin authors SHOULD prefer this helper over raw f-string
+    assembly so the dispatch attribution label rendering follows
+    the documented format; future scope changes propagate without
+    each plugin needing to update.
+    """
+    parts: list[str] = [transport]
+    if source_scope:
+        parts.append(source_scope)
+    parts.append(external_id)
+    if display:
+        parts.append(display)
+    return ":".join(parts)
+
+
+__all__ = [
+    "agent_exists",
+    "list_agents",
+    "make_sender",
+    "push_to_agent",
+]

--- a/src/reyn/plugins/sample_line/webhook.py
+++ b/src/reyn/plugins/sample_line/webhook.py
@@ -125,19 +125,24 @@ def mint_envelope_from_line_event(event: dict) -> dict | None:
     if not isinstance(source, dict):
         return None
     source_type = source.get("type")
+    from reyn.plugins.api import make_sender
     if source_type == "user":
-        user_id = source.get("userId", "")
-        sender = f"line:user:{user_id}" if user_id else "line:user:unknown"
+        user_id = source.get("userId") or "unknown"
+        sender = make_sender("line", user_id, source_scope="user")
         source_id = user_id
     elif source_type == "group":
-        group_id = source.get("groupId", "")
-        user_id = source.get("userId", "")
-        sender = f"line:group:{group_id}:{user_id}" if group_id else "line:group:unknown"
+        group_id = source.get("groupId") or "unknown"
+        user_id = source.get("userId") or ""
+        sender = make_sender(
+            "line", group_id, source_scope="group", display=user_id,
+        )
         source_id = group_id
     elif source_type == "room":
-        room_id = source.get("roomId", "")
-        user_id = source.get("userId", "")
-        sender = f"line:room:{room_id}:{user_id}" if room_id else "line:room:unknown"
+        room_id = source.get("roomId") or "unknown"
+        user_id = source.get("userId") or ""
+        sender = make_sender(
+            "line", room_id, source_scope="room", display=user_id,
+        )
         source_id = room_id
     else:
         return None

--- a/src/reyn/plugins/sample_slack/webhook.py
+++ b/src/reyn/plugins/sample_slack/webhook.py
@@ -176,7 +176,8 @@ def mint_envelope_from_slack_event(event: dict) -> dict | None:
         return None
     ts = inner.get("ts")
     thread_ts = inner.get("thread_ts") or ts
-    sender = f"slack:{user_id}" if user_id else "slack:unknown"
+    from reyn.plugins.api import make_sender
+    sender = make_sender("slack", user_id or "unknown")
     reply_to = ExternalRef(
         transport="slack",
         destination={"channel": channel, "thread_ts": thread_ts},

--- a/tests/plugins/test_api.py
+++ b/tests/plugins/test_api.py
@@ -208,3 +208,108 @@ async def test_push_to_agent_full_envelope_shape():
         "reply_to": ref,
         "meta": {"trace_id": "abc"},
     }
+
+
+# ── list_agents / agent_exists ─────────────────────────────────────────
+
+
+class _StubDiscoveryRegistry:
+    """Registry stub exposing list_names + exists for discovery tests."""
+    def __init__(self, names: list[str]):
+        self._names = list(names)
+
+    def list_names(self) -> list[str]:
+        return sorted(self._names)
+
+    def exists(self, name: str) -> bool:
+        return name in self._names
+
+
+def test_list_agents_returns_registry_names():
+    """Tier 2: ``list_agents`` returns the registry's sorted
+    ``list_names()``. Plugin authors use this at register_router
+    time to validate config or discover available agents.
+    """
+    from reyn.plugins.api import list_agents
+    reg = _StubDiscoveryRegistry(["zeta", "alpha", "beta"])
+    assert list_agents(registry=reg) == ["alpha", "beta", "zeta"]
+
+
+def test_list_agents_empty_when_no_agents():
+    """Tier 2: a project with no agents on disk returns empty list."""
+    from reyn.plugins.api import list_agents
+    reg = _StubDiscoveryRegistry([])
+    assert list_agents(registry=reg) == []
+
+
+def test_agent_exists_true_for_known():
+    """Tier 2: ``agent_exists`` matches the registry's ``exists``."""
+    from reyn.plugins.api import agent_exists
+    reg = _StubDiscoveryRegistry(["news_agent"])
+    assert agent_exists("news_agent", registry=reg) is True
+    assert agent_exists("missing", registry=reg) is False
+
+
+def test_agent_exists_returns_false_on_registry_error():
+    """Tier 2: ``agent_exists`` is defensive — registry exception
+    yields False rather than propagating. A boot-time registry
+    hiccup shouldn't crash plugin discovery.
+    """
+    from reyn.plugins.api import agent_exists
+
+    class _BrokenRegistry:
+        def exists(self, name):
+            raise RuntimeError("registry broken")
+
+    assert agent_exists("anything", registry=_BrokenRegistry()) is False
+
+
+# ── make_sender ────────────────────────────────────────────────────────
+
+
+def test_make_sender_basic_transport_id():
+    """Tier 2: minimal call produces ``<transport>:<external_id>``."""
+    from reyn.plugins.api import make_sender
+    assert make_sender("slack", "U456") == "slack:U456"
+
+
+def test_make_sender_with_display():
+    """Tier 2: ``display`` appends as the trailing segment."""
+    from reyn.plugins.api import make_sender
+    assert make_sender("slack", "U456", display="bob") == "slack:U456:bob"
+
+
+def test_make_sender_with_source_scope():
+    """Tier 2: ``source_scope`` inserts between transport and id —
+    LINE 1:1 chat shape per ``_format_sender_label`` expectations.
+    """
+    from reyn.plugins.api import make_sender
+    assert (
+        make_sender("line", "U456", source_scope="user")
+        == "line:user:U456"
+    )
+
+
+def test_make_sender_line_group_full_shape():
+    """Tier 2: a LINE group sender combines transport + source_scope
+    + group_id + posting user. Pins the documented shape that
+    ``_format_sender_label`` recognises.
+    """
+    from reyn.plugins.api import make_sender
+    sender = make_sender(
+        "line", "G999", source_scope="group", display="U456",
+    )
+    assert sender == "line:group:G999:U456"
+
+
+def test_make_sender_omits_falsy_display_and_scope():
+    """Tier 2: empty / None ``display`` and ``source_scope`` are
+    NOT included (= no trailing colons, no doubled separators).
+    """
+    from reyn.plugins.api import make_sender
+    assert make_sender("slack", "U1", display=None) == "slack:U1"
+    assert make_sender("slack", "U1", display="") == "slack:U1"
+    assert (
+        make_sender("slack", "U1", source_scope=None, display=None)
+        == "slack:U1"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 follow-up **PR-1b** = plugin API discovery + format helpers。 PR #528 への amend tier 1 が timing で merge に間に合わず 新 PR で立てる、 main 直 base。

## Why this PR

User pointed out PR #528 didn't address 3 plugin-author gaps:

> target_agent に何を指定すれば良いか利用者はわからない。 他パラメタも利用者がわからない。 動的変化するならそれを取得する api も必要。

This PR adds the "Tier 1" helpers per the design discussion: agent discovery + sender format helper. ``list_transports`` (= Tier 2) + subscription API (= Tier 3) deferred.

## What this PR ships

### 3 new helpers in ``reyn.plugins.api``

```python
def list_agents(*, registry=None) -> list[str]
    # All agent names known to the project (= sorted disk view)

def agent_exists(name, *, registry=None) -> bool
    # Pre-flight check; defensive (= registry error → False)

def make_sender(transport, external_id, *, display=None, source_scope=None) -> str
    # Build sender attribution string, format match _format_sender_label
```

### make_sender examples

```python
make_sender("slack", "U456")                              → "slack:U456"
make_sender("slack", "U456", display="bob")               → "slack:U456:bob"
make_sender("line", "U456", source_scope="user")          → "line:user:U456"
make_sender("line", "G999", source_scope="group",
            display="U456")                                → "line:group:G999:U456"
```

### Sample plugin refactor

``sample_slack`` / ``sample_line`` 全 sender 構築箇所を ``make_sender`` 経由に書き換え (= canonical pattern を sample で示す)。

### Authoring guide

``docs/plugins/authoring-guide.md`` に **Stable plugin API** section 追加、 4 helpers (= push_to_agent + 3 new) の signature + 用途を一覧化。

## Tier 区分 (= 設計討議で確定)

| Tier | API | 本 PR |
|---|---|---|
| **1 (= 本 PR + #528 の push_to_agent)** | push_to_agent / list_agents / agent_exists / make_sender | ✓ |
| 2 (= follow-up) | list_transports + 設定 discovery | defer |
| 3 (= demand-driven) | on_agent_added / on_agent_removed subscription | defer |

= Tier 1 で **「plugin author の最 minimal な discovery / 構築」** カバー、 Tier 2/3 は 必要性 出てから。

## Change shape

- ``src/reyn/plugins/api.py``: 3 new helpers + ``__all__`` 更新
- ``src/reyn/plugins/sample_slack/webhook.py``: ``make_sender`` 採用
- ``src/reyn/plugins/sample_line/webhook.py``: 3 source variants 全 ``make_sender`` 採用
- ``docs/plugins/authoring-guide.md``: Stable plugin API section 追加
- ``tests/plugins/test_api.py``: +9 tests (= list_agents 2 / agent_exists 2 / make_sender 5)

## Test plan

- [x] ``pytest tests/plugins/test_api.py`` — 17/17 pass
- [x] ``pytest tests/plugins/`` — 55/55 pass
- [x] ``pytest tests/`` (full suite) — 5095 pass, 5 skip, 2 xfailed, 1 xpassed, 1 pre-existing unrelated failure deselected
- [x] ``ruff check`` on modified files — clean
- No router fixtures touched.

## Origin note

User reviewed PR #528 + asked for "Option A: amend". The amend changes (= these 3 helpers) didn't make the force-push window before #528 merged, so this PR (= "PR-1b" per design discussion) ships the missing Tier 1 surface as additive follow-up.

Refs #489 (FP-0041 plugins-api PR-1b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)