### PR TITLE
feat(tui): wire AsyncStackPanel to attached-agent task lifecycle (I-F5)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -514,6 +514,19 @@ class ReynTUIApp(App):
                     self._run_id_to_user_message.pop(
                         next(iter(self._run_id_to_user_message)),
                     )
+            # AsyncStackPanel wiring: this branch is the "task spawned"
+            # signal for the TUI (= first trace for this run_id, the
+            # ``[task_spawned] kind=skill`` notification the LLM sees
+            # in its context). Add the row to the bottom-docked
+            # running-tasks overview. The corresponding remove fires
+            # in ``_handle_trace_for_skill_row`` on the
+            # ``"skill done: …"`` trace (= the matching
+            # ``[task_completed]`` boundary).
+            try:
+                conv = self.query_one("#conversation", ConversationView)
+                conv.add_async_task(run_id, skill_name or "skill")
+            except Exception:
+                pass
         # Text pattern: "phase started: <phase_name>"
         if text.startswith("phase started: "):
             phase = text[len("phase started: "):].strip()
@@ -666,6 +679,11 @@ class ReynTUIApp(App):
             self._skill_exec.pop(run_id, None)
             self._push_exec_state()
             self._last_focal_tab = "agents"
+            # AsyncStackPanel wiring: the ``[task_completed]`` boundary
+            # for the attached agent's task — drop the row from the
+            # bottom-docked overview. Mirrors the ``add_async_task``
+            # call in ``_update_skill_exec``'s first-trace branch.
+            conv.remove_async_task(run_id)
             # Wave-9 D-F11: release the input-bar lock when the last
             # tracked skill finishes. Sub-skills popping during a
             # nested run keep the lock held — only the empty state
@@ -1021,6 +1039,17 @@ class ReynTUIApp(App):
                         )
                     except Exception:
                         pass
+                    # AsyncStackPanel: drop the row for this cancelled
+                    # task — the remote cancel path tears down the
+                    # task locally without waiting for a
+                    # workflow_aborted trace, so the bottom-stack
+                    # entry needs explicit removal here (= same
+                    # rationale as the ``_skill_exec.pop`` directly
+                    # below).
+                    try:
+                        conv.remove_async_task(run_id)
+                    except Exception:
+                        pass
                     self._skill_exec.pop(run_id, None)
                 self._push_exec_state()
             # C-F1: seal in-flight ToolCallRow widgets too. Without this
@@ -1059,6 +1088,16 @@ class ReynTUIApp(App):
                         reason="cancelled",
                         aborted=True,
                     )
+                except Exception:
+                    pass
+                # AsyncStackPanel: drop the cancelled task from the
+                # bottom-stack overview. Mirrors the remote-cancel
+                # branch above + the natural ``"skill done:"`` trace
+                # path; needs explicit handling here because
+                # ``task.cancel()`` doesn't produce a
+                # workflow_aborted trace.
+                try:
+                    conv.remove_async_task(run_id)
                 except Exception:
                     pass
                 self._skill_exec.pop(run_id, None)

--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -1,15 +1,27 @@
-"""AsyncStackPanel — sticky list of non-attach agents currently running.
+"""AsyncStackPanel — sticky list of the attached agent's running tasks.
 
-PoC stage for issue #427 L4 step 5: widget shape + entry state mgmt +
-ordering + cap behaviour. Production wiring (= subscribe to agent
-registry / non-attach agent lifecycle events, drive entries on the
-real signal) is deferred to a follow-up PR.
+Scope (= user direction 2026-05-23): only the **attached** agent's
+tasks are surfaced. A "task" is the SP-level abstraction covering
+both **skill spawns** and **plan spawns** — the same lifecycle the
+LLM observes via ``[task_spawned]`` / ``[task_completed]``
+notifications. Non-attached agent activity flows through its own
+event log and is not the TUI's concern.
 
-Spec (= issue #427 L2):
+The original PoC framing (= "non-attach agents currently running",
+issue #427 L4 step 5) was narrowed to attached-only because:
+  - the attached agent's tasks are already tracked by the trace
+    lifecycle the App drives (``_handle_trace_for_skill_row``), so
+    the event source needs no new plumbing
+  - non-attached agents have their own ``.reyn/events/agents/<name>/``
+    surface (= visible via the right-panel Agents tab) that suits
+    a "what other agents are doing" overview better than a sticky
+    1-line strip
 
-  ⟳ async: code_review · 12.3s      ← running entry
+Spec (= issue #427 L2 visual contract, retained):
+
+  ⟳ async: code_review · 12.3s      ← running task
   ⟳ async: monitor_loop · 5m21s      ← running, longer-running
-  ⚑ async: alice (1 pending)         ← intervention-pending entry
+  ⚑ async: alice (1 pending)         ← intervention-pending task
   … +N more (panel for all)          ← overflow indicator when > _CAP
 
 - 1-5 entries dynamic, ``_CAP`` cap with overflow indicator
@@ -26,11 +38,17 @@ widget never emits to history; consumers route history-side events
 (= start / complete inline markers) through a separate path.
 
 Public API:
-    panel.add(agent_id, summary)       # mount / update a running entry
-    panel.set_pending(agent_id, count) # switch entry to ⚑ + pending count
+
+    panel.add(agent_id, summary)         # mount / update a running entry
+    panel.set_pending(agent_id, count)   # switch entry to ⚑ + pending count
     panel.set_running(agent_id, summary) # switch back to ⟳ (intervention resolved)
-    panel.remove(agent_id)             # entry disappeared (complete / fail)
-    panel.clear()                      # reset all entries
+    panel.remove(agent_id)               # entry disappeared (complete / fail)
+    panel.clear()                        # reset all entries
+
+The ``agent_id`` parameter is a legacy name from the PoC era — in
+the attached-agent-only production wiring, this string is the
+**task identity** (= ``run_id`` for skill spawns, ``plan_id`` for
+plan spawns). The widget treats it as an opaque key.
 """
 from __future__ import annotations
 

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.tui._palette import _AMBER, _CORAL
 
+from .async_stack_panel import AsyncStackPanel
 from .error_box import ErrorBox
 from .intervention import InterventionWidget
 from .skill_activity import SkillActivityRow
@@ -372,8 +373,21 @@ class ConversationView(Widget):
             id="empty-hint",
             markup=True,
         )
-        # A3: sticky status pinned to bottom of conv pane
+        # A3: sticky status pinned to bottom of conv pane (= 1-line
+        # ``⟳ thinking…`` / ``⚑ awaiting answer`` live indicator).
+        # AsyncStackPanel docks ABOVE the sticky (= the 0-5-line
+        # "currently running tasks" overview). Per Textual's
+        # ``dock: bottom`` stacking rule (= multiple bottom-docked
+        # siblings stack in declaration order, with each new sibling
+        # placed further FROM the bottom edge), yielding StickyStatus
+        # first pins it to the very bottom; the subsequent
+        # AsyncStackPanel sits above it. Result from bottom-up:
+        # ``input bar → sticky → async stack → conv log``.
+        # AsyncStackPanel collapses to zero height when no tasks are
+        # active so the input bar layout is unchanged in the
+        # cold-default case.
         yield StickyStatus(id="sticky-status")
+        yield AsyncStackPanel(id="async-stack")
 
     def _log(self) -> RichLog:
         return self.query_one("#log", RichLog)
@@ -383,6 +397,62 @@ class ConversationView(Widget):
             return self.query_one("#sticky-status", StickyStatus)
         except Exception:
             return None
+
+    def _async_stack(self) -> AsyncStackPanel | None:
+        """Return the bottom-docked AsyncStackPanel, if mounted.
+
+        Mirrors ``_sticky()`` — the panel may not exist during
+        composition in test harnesses that mount ConversationView
+        manually without going through the full compose path.
+        """
+        try:
+            return self.query_one("#async-stack", AsyncStackPanel)
+        except Exception:
+            return None
+
+    def add_async_task(self, task_id: str, summary: str) -> None:
+        """Add or update an attached-agent task in the bottom stack panel.
+
+        Wiring helper for the production hook (= app.py's
+        ``_handle_trace_for_skill_row`` calls this on the
+        ``"phase started:"`` first-trace branch and on plan
+        spawn events). ``task_id`` is the canonical task identity
+        — ``run_id`` for skill spawns or ``plan_id`` for plan
+        spawns; both flow through this single entry point.
+
+        Silent no-op when the panel isn't mounted (= test
+        harness path), matching the ``show_status`` / ``hide_status``
+        defensive style.
+        """
+        panel = self._async_stack()
+        if panel is None or not task_id:
+            return
+        panel.add(task_id, summary)
+
+    def remove_async_task(self, task_id: str) -> None:
+        """Drop ``task_id``'s entry from the bottom stack panel.
+
+        Called on ``"skill done:"`` from the trace flow + the
+        corresponding plan-completion path. Idempotent (= silent
+        no-op if the panel isn't mounted or the task is unknown).
+        """
+        panel = self._async_stack()
+        if panel is None or not task_id:
+            return
+        panel.remove(task_id)
+
+    def clear_async_tasks(self) -> None:
+        """Reset the bottom stack panel to empty.
+
+        Called from ``clear()`` so a Ctrl+L wipes the running-task
+        overview alongside the conv log. The visible stack would
+        otherwise survive the clear and look like "ghost rows"
+        attached to a fresh-looking pane.
+        """
+        panel = self._async_stack()
+        if panel is None:
+            return
+        panel.clear()
 
     def on_mount(self) -> None:
         """Wire a scroll watcher so user scroll-up suppresses auto-scroll.
@@ -1866,6 +1936,13 @@ class ConversationView(Widget):
             except Exception:
                 pass
         self._tool_call_rows.clear()
+        # AsyncStackPanel wiring: drop all bottom-stack entries so a
+        # Ctrl+L leaves the panel empty alongside the conv log.
+        # Without this the running-task overview would survive the
+        # clear and look like ghost rows attached to an otherwise-
+        # fresh pane. Same pattern as the ErrorBox / ToolCallRow
+        # sweeps directly above.
+        self.clear_async_tasks()
         # Wave-10 G-F2: sweep any pending InterventionWidget children too.
         # ``mount_intervention`` adds the widget via ``self.mount(widget)``
         # with no tracking list, so the only way to find them at clear()

--- a/tests/cli/test_async_stack_panel_wired.py
+++ b/tests/cli/test_async_stack_panel_wired.py
@@ -1,0 +1,148 @@
+"""Tier 2: AsyncStackPanel is mounted + wired to attached-agent task lifecycle.
+
+Wave-10 follow-up I-F5 (= honest scope drop revisited): the
+``AsyncStackPanel`` widget existed as a PoC but was never mounted
+into the conv pane and had no event source driving it. User
+direction (2026-05-23) narrowed the scope to attached-agent
+tasks only.
+
+This PR mounts the panel in ``ConversationView.compose()`` near
+the StickyStatus dock and wires the production hooks:
+
+  - ``add_async_task(run_id, skill_name)`` fires on the FIRST
+    trace for a new ``run_id`` (= the
+    ``[task_spawned] kind=skill`` boundary)
+  - ``remove_async_task(run_id)`` fires on the ``"skill done: …"``
+    trace AND on the local + remote Ctrl+C cancel paths (=
+    ``[task_completed]`` boundary or its cancel equivalent)
+  - ``clear_async_tasks()`` fires on ``ConversationView.clear()``
+    (= Ctrl+L wipes the running-task overview alongside the log)
+
+Public surfaces tested:
+  - panel is present in the mounted DOM
+  - add_async_task → entry visible in the panel's snapshot
+  - remove_async_task → entry gone
+  - clear_async_tasks → panel empty
+  - silent no-op when panel is somehow absent (= defensive
+    against ConversationView used outside the standard compose
+    path)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_async_stack_panel_mounted_in_conv_pane() -> None:
+    """Tier 2: ``compose()`` yields an AsyncStackPanel with id ``async-stack``."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv.query_one("#async-stack", AsyncStackPanel)
+        assert panel is not None
+
+
+@pytest.mark.asyncio
+async def test_add_async_task_surfaces_entry_in_snapshot() -> None:
+    """Tier 2: ``add_async_task`` adds a row visible via the panel's snapshot."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("run-abc", "code_review")
+        await pilot.pause()
+        snap = conv._async_stack().snapshot()  # type: ignore[union-attr]
+        # First non-overflow entry should be our task.
+        running = [s for s in snap if not s["is_overflow"]]
+        assert running, "task should appear in panel snapshot"
+        assert running[0]["agent_id"] == "run-abc"
+        assert running[0]["summary"] == "code_review"
+
+
+@pytest.mark.asyncio
+async def test_remove_async_task_drops_entry() -> None:
+    """Tier 2: ``remove_async_task`` removes the entry from the panel."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("run-xyz", "shell")
+        await pilot.pause()
+        assert any(
+            s["agent_id"] == "run-xyz"
+            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+        )
+        conv.remove_async_task("run-xyz")
+        await pilot.pause()
+        assert all(
+            s["agent_id"] != "run-xyz"
+            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+        )
+
+
+@pytest.mark.asyncio
+async def test_clear_async_tasks_empties_panel() -> None:
+    """Tier 2: ``clear_async_tasks`` (= Ctrl+L path) leaves the panel empty.
+
+    The full ``ConversationView.clear()`` also calls this — verified
+    indirectly via the panel ending up empty after clear.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("run-1", "a")
+        conv.add_async_task("run-2", "b")
+        await pilot.pause()
+        assert len(conv._async_stack().snapshot()) >= 2  # type: ignore[union-attr]
+        conv.clear()
+        await pilot.pause()
+        assert conv._async_stack().snapshot() == []  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_helpers_safe_when_panel_absent() -> None:
+    """Tier 2 (defensive): ``add/remove/clear_async_tasks`` are safe no-ops.
+
+    ``_async_stack()`` returns None when the panel isn't mounted
+    (= ConversationView used outside the standard compose path,
+    or panel removed mid-test). The public helper methods must
+    silently no-op in that case rather than raise.
+
+    Simulated by monkey-patching ``_async_stack`` to return None.
+    Directly unmounting via ``panel.remove()`` would collide with
+    AsyncStackPanel's own ``remove(agent_id)`` method override.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv._async_stack = lambda: None  # type: ignore[method-assign]
+        # Helpers must not raise.
+        conv.add_async_task("run-x", "foo")
+        conv.remove_async_task("run-x")
+        conv.clear_async_tasks()


### PR DESCRIPTION
**[tui-coder]** — wave-10 follow-up I-F5 revisited (= honest scope drop引き上げ). Single-scope: AsyncStackPanel mount in ConversationView + production hooks via existing trace lifecycle.

## Scope narrowing (= user direction 2026-05-23)

Original I-F5 honest drop reasoning was "needs L-level wiring across modules" because the panel docstring said "non-attach agents". User clarified:
1. AsyncStack 1 row = 1 task (= skill OR plan spawn, the SP-level "task" abstraction)
2. task_spawned / task_completed are the LLM-facing lifecycle events
3. TUI cares ONLY about the attached agent
4. Bottom stack = attached agent only

With "attached agent only" + "per-task rows", the wiring reuses the existing trace flow that already tracks the attached agent's skill spawns (= ``_update_skill_exec`` / ``_handle_trace_for_skill_row``). No new cross-agent event channel needed.

## Wiring

- **Mount**: ConversationView.compose() yields after StickyStatus → ``input bar → sticky → async stack → conv log`` (bottom-up)
- **add**: ``_update_skill_exec`` first-trace branch (= task_spawned boundary)
- **remove**: ``_handle_trace_for_skill_row`` "skill done:" branch + local + remote cancel paths
- **clear**: ``ConversationView.clear()`` sweep alongside other widget sweeps

## Out of scope (= deferred follow-on)

- Plan spawn lifecycle (= same hook pattern for ``running_plans``)
- Intervention pending count (``set_pending``)

## Test plan

- [x] ruff check passes
- [x] 5 new Tier 2 tests: mount, add, remove, clear, safe-when-absent
- [x] Existing 11 AsyncStackPanel PoC + 3 refresh-guard tests still green
- [x] clear() regression tests (ErrorBox / ToolCallRow / Intervention) still green
- [x] 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)