### PR TITLE
feat(tui): plan lifecycle drives AsyncStackPanel (I-F5 follow-on)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1066,10 +1066,20 @@ class ReynTUIApp(App):
                 task.cancel()
                 cancelled_skills += 1
         cancelled_plans = 0
-        for task in list(getattr(session, "running_plans", {}).values()):
+        # Iterate ``.items()`` so we can drop the AsyncStackPanel row
+        # for each plan_id alongside the asyncio cancel. ``task.cancel()``
+        # doesn't trigger the ``source=plan_complete`` outbox path the
+        # natural lifecycle hits, so the bottom-strip row would
+        # otherwise persist after Ctrl+C.
+        for plan_id, task in list(getattr(session, "running_plans", {}).items()):
             if not task.done():
                 task.cancel()
                 cancelled_plans += 1
+                if conv is not None:
+                    try:
+                        conv.remove_async_task(str(plan_id))
+                    except Exception:
+                        pass
 
         # Stop any SkillActivityRow spinners + clear the right-panel agents
         # tab. ``task.cancel()`` only stops the asyncio producer; no

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -175,6 +175,7 @@ class OutboxRouter:
             "intervention":             self._on_intervention,
             "intervention_resolved":    self._on_intervention_resolved,
             "status":                   self._on_status,
+            "system":                   self._on_system,
             "trace":                    self._on_trace,
             # NOTE: "skill_done" outbox kind was removed in FP-0011.
             # Skill completion is now signalled via "skill done: <status>"
@@ -793,6 +794,49 @@ class OutboxRouter:
                 if _is_plan_sourced_body(current_body):
                     return  # don't overwrite the higher-priority plan status
         conv.show_status(msg.text, kind="thinking")
+
+    def _on_system(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """`system` — bridge plan lifecycle to AsyncStackPanel + default render.
+
+        ``plan_runner`` emits two ``kind="system"`` messages with a
+        ``source`` discriminator in meta:
+
+          - ``source="plan_summary"`` (= ``[task_spawned] kind=plan``
+            equivalent for the TUI) — fires when a plan starts. Carries
+            ``plan_id`` so the AsyncStackPanel can mount a row keyed
+            on the plan identity.
+          - ``source="plan_complete"`` (= ``[task_completed] kind=plan``
+            equivalent) — fires when the plan finishes. We drop the row.
+
+        Other ``kind="system"`` messages (lifecycle markers, slash-command
+        output, attach/detach notices) flow through the default
+        ``conv.render_message`` path unchanged. The plan side-effect is
+        ADDITIVE — we always also render the message so the conv pane's
+        existing system-message UX (= dim marker line) stays intact.
+        """
+        source = (msg.meta or {}).get("source", "")
+        plan_id = (msg.meta or {}).get("plan_id", "")
+        if plan_id:
+            if source == "plan_summary":
+                # Compact summary for the bottom strip — the full
+                # multi-line ``Executing plan: …`` text already lands
+                # in the conv pane via the default render below.
+                summary = f"plan #{str(plan_id)[:8]}"
+                try:
+                    conv.add_async_task(str(plan_id), summary)
+                except Exception:
+                    pass
+            elif source == "plan_complete":
+                try:
+                    conv.remove_async_task(str(plan_id))
+                except Exception:
+                    pass
+        # Default render path — preserves the dim marker line / slash
+        # output / attach notice display the conv pane already gives
+        # to system messages.
+        conv.render_message(msg)
 
     def _on_trace(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/tests/cli/test_async_stack_panel_plan_lifecycle.py
+++ b/tests/cli/test_async_stack_panel_plan_lifecycle.py
@@ -1,0 +1,174 @@
+"""Tier 2: plan lifecycle drives AsyncStackPanel via system outbox messages.
+
+Follow-up to the I-F5 wiring PR. Plan spawns + completions reach the
+TUI as ``OutboxMessage(kind="system", meta={"source": ..., "plan_id":
+...})`` emitted by ``plan_runner``:
+
+  - ``source="plan_summary"`` (= plan started, ``[task_spawned]
+    kind=plan`` equivalent)
+  - ``source="plan_complete"`` (= plan finished, ``[task_completed]``
+    equivalent)
+
+The new ``OutboxRouter._on_system`` handler intercepts those two
+sources and routes them to ``conv.add_async_task`` /
+``conv.remove_async_task`` (= the same helpers the skill lifecycle
+wiring uses). Other ``kind="system"`` messages flow through the
+default ``conv.render_message`` path unchanged.
+
+Public surfaces tested:
+  - plan_summary → row added (= keyed on plan_id)
+  - plan_complete → row removed
+  - non-plan system message → no effect on AsyncStackPanel,
+    default render still fires
+  - missing plan_id → silent no-op (= defensive against ill-shaped
+    outbox messages)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_plan_summary_adds_async_stack_row() -> None:
+    """Tier 2: plan_summary system msg → AsyncStackPanel row mounted."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        msg = OutboxMessage(
+            kind="system",
+            text="Executing plan:\n1. analyse\n2. summarise",
+            meta={"plan_id": "plan-abc12345-def6", "source": "plan_summary"},
+        )
+        router._on_system(msg, conv, header)
+        await pilot.pause()
+
+        snap = conv._async_stack().snapshot()  # type: ignore[union-attr]
+        rows = [s for s in snap if not s["is_overflow"]]
+        assert any(
+            s["agent_id"] == "plan-abc12345-def6" for s in rows
+        ), f"plan row should appear in panel snapshot; got {rows!r}"
+
+
+@pytest.mark.asyncio
+async def test_plan_complete_removes_async_stack_row() -> None:
+    """Tier 2: plan_complete system msg → AsyncStackPanel row dropped."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        # Spawn first.
+        spawn = OutboxMessage(
+            kind="system",
+            text="Executing plan:\n1. step",
+            meta={"plan_id": "plan-zzz999", "source": "plan_summary"},
+        )
+        router._on_system(spawn, conv, header)
+        await pilot.pause()
+        assert any(
+            s["agent_id"] == "plan-zzz999"
+            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            if not s["is_overflow"]
+        )
+
+        # Then complete.
+        complete = OutboxMessage(
+            kind="system",
+            text="plan complete: 1/1 steps succeeded · plan-zzz999",
+            meta={"plan_id": "plan-zzz999", "source": "plan_complete"},
+        )
+        router._on_system(complete, conv, header)
+        await pilot.pause()
+        assert all(
+            s["agent_id"] != "plan-zzz999"
+            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_plan_system_message_does_not_touch_async_stack() -> None:
+    """Tier 2 (regression): generic system message → no panel side-effect.
+
+    Lifecycle markers (= ``[↑ N turns compacted]``), slash-command
+    output, attach/detach notices are all ``kind="system"`` but
+    carry no plan_id. They must NOT add ghost rows to the panel.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        # Compaction marker — no plan_id, no source.
+        msg = OutboxMessage(
+            kind="system",
+            text="[↑ 5 turns compacted]",
+            meta={},
+        )
+        router._on_system(msg, conv, header)
+        await pilot.pause()
+
+        assert conv._async_stack().snapshot() == [], (  # type: ignore[union-attr]
+            "non-plan system message must not touch the AsyncStackPanel"
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_plan_id_is_silent_noop() -> None:
+    """Tier 2 (defensive): plan_summary without plan_id meta → silent.
+
+    Guard against producer-side shape drift — if the outbox emitter
+    drops the plan_id for some reason, the handler should silently
+    skip the panel side-effect rather than mount a row keyed by
+    empty string.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        msg = OutboxMessage(
+            kind="system",
+            text="Executing plan:\n…",
+            meta={"source": "plan_summary"},  # no plan_id
+        )
+        router._on_system(msg, conv, header)
+        await pilot.pause()
+        # Panel stays empty — no row keyed on empty string.
+        assert conv._async_stack().snapshot() == []  # type: ignore[union-attr]


### PR DESCRIPTION
**[tui-coder]** — I-F5 follow-on: plan lifecycle wiring matching the skill pattern from #531.

## Stacked on #531

This PR depends on the ``add_async_task`` / ``remove_async_task`` helpers introduced in #531 (= AsyncStackPanel wiring, skill lifecycle only). Branch is based on ``feat/tui-async-stack-panel-wired`` — once #531 merges to main, this rebases cleanly.

## Why the system-message route

Skill spawns produced trace events the App's ``_update_skill_exec`` already consumed; plan spawns don't have an equivalent trace path. ``plan_runner`` already emits ``OutboxMessage(kind="system", meta={"source": "plan_summary"/"plan_complete", "plan_id": ...})`` for the conv pane's existing "Executing plan: …" / "plan complete: …" markers — these are the natural task lifecycle signals to subscribe to.

## Hook

- ``OutboxRouter._on_system`` (new) intercepts ``kind="system"``, dispatches plan-source variants to AsyncStackPanel, falls through to ``conv.render_message`` so the dim marker line UX stays unchanged
- Local Ctrl+C cancel: iterate ``running_plans.items()`` + ``remove_async_task(plan_id)`` for each cancelled plan
- Remote cancel: relies on server's ``plan_complete`` outbox traveling back through ``_on_system`` (no explicit hook needed)

## Out of scope (deferred)

- ``/plan discard`` slash command: cancels ``running_plans`` directly without emitting plan_complete outbox → bottom-strip row persists. Fix requires a slash-side emit (= separate cross-layer scope).

## Test plan

- [x] ruff check passes
- [x] 4 new Tier 2 tests: plan_summary adds, plan_complete drops, non-plan system msg no-op (regression), missing plan_id silent (defensive)
- [x] Existing #531 wiring tests (5) + AsyncStackPanel PoC (11) + refresh-guard (3) + 40 smoke tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)