### PR TITLE
refactor(plugins): sample_slack/sample_line use slack-bolt + line-bot-sdk (FP-0041 plugins-api PR-2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,19 @@ voice = [
 eval = [
     "opentelemetry-exporter-otlp-proto-http>=1.20",
 ]
+# FP-0041 #489 plugins-api PR-2: sample webhook plugins use OSS SDKs.
+# Reyn core stays SDK-free for operators who don't activate the
+# samples; SDK deps are opt-in via these extras:
+#
+#   pip install reyn[sample_slack]      # = reyn + slack-bolt
+#   pip install reyn[sample_line]       # = reyn + line-bot-sdk
+#   pip install reyn[all-samples]       # = reyn + both
+#
+# When the SDK isn't installed, ``register_router`` returns ``None``
+# with a clear log message; reyn boots without crashing.
+sample_slack = ["slack-bolt>=1.18"]
+sample_line = ["line-bot-sdk>=3.0"]
+all-samples = ["slack-bolt>=1.18", "line-bot-sdk>=3.0"]
 
 [project.scripts]
 reyn = "reyn._cli:main"
@@ -103,6 +116,18 @@ reyn = "reyn._cli:main"
 [project.entry-points."reyn.webhooks"]
 sample_slack = "reyn.plugins.sample_slack:register_router"
 sample_line = "reyn.plugins.sample_line:register_router"
+
+# FP-0041 #489 plugins-api PR-2: sample plugins now use OSS SDKs for
+# transport-specific protocol (= slack-bolt / line-bot-sdk). Installed
+# via optional pip extras so reyn core stays SDK-free for operators
+# who don't activate the samples:
+#
+#   pip install reyn[sample_slack]      # = reyn + slack-bolt
+#   pip install reyn[sample_line]       # = reyn + line-bot-sdk
+#   pip install reyn[all-samples]       # = reyn + both
+#
+# When the SDK isn't installed, ``register_router`` returns ``None``
+# with a clear log message so reyn boots without crashing.
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"

--- a/src/reyn/plugins/sample_line/README.md
+++ b/src/reyn/plugins/sample_line/README.md
@@ -21,23 +21,27 @@ handler, mirror of ``sample_slack`` for LINE. Demonstrates:
 
 ## Operator setup
 
-1. Create a LINE Messaging API channel at
+1. Install Reyn with the ``sample_line`` extra:
+   ```bash
+   pip install 'reyn[sample_line]'   # = reyn + line-bot-sdk
+   ```
+2. Create a LINE Messaging API channel at
    https://developers.line.biz/console/
-2. Note the **Channel Secret** + **Channel Access Token** from the
+3. Note the **Channel Secret** + **Channel Access Token** from the
    channel's "Basic settings" + "Messaging API" tabs
-3. Set the **Webhook URL** to ``https://<your-reyn-host>/webhook/line``
-4. Enable **Use webhook** in the Messaging API settings
-5. Activate the plugin in ``webhooks.yaml``:
+4. Set the **Webhook URL** to ``https://<your-reyn-host>/webhook/line``
+5. Enable **Use webhook** in the Messaging API settings
+6. Activate the plugin in ``webhooks.yaml``:
    ```yaml
    sample_line:
      target_agent: line_agent     # agent that receives LINE messages
    ```
-6. Set env vars on Reyn:
+7. Set env vars on Reyn:
    ```bash
    export LINE_CHANNEL_SECRET=<channel-secret>
    export LINE_CHANNEL_ACCESS_TOKEN=<channel-access-token>   # for outbound replies
    ```
-7. Send a message to your LINE bot; it reaches the target agent's inbox.
+8. Send a message to your LINE bot; it reaches the target agent's inbox.
 
 ## Configuration (= webhooks.yaml)
 

--- a/src/reyn/plugins/sample_line/__init__.py
+++ b/src/reyn/plugins/sample_line/__init__.py
@@ -1,17 +1,17 @@
-"""sample_line — Sample LINE Messaging API webhook plugin (FP-0041 #489 PR-E).
+"""sample_line — Sample LINE Messaging API webhook plugin (FP-0041 #489).
 
 ⚠️  **SAMPLE / EXAMPLE ONLY** ⚠️
 
-Mirror of ``sample_slack`` for LINE Messaging API. Reyn maintainers
-do NOT commit to keeping this code working against LINE API drift.
-See ``README.md`` for the production guidance.
+Mirror of ``sample_slack`` for LINE Messaging API, wired through
+``line-bot-sdk`` v3 + ``reyn.plugins.api``. Reyn maintainers do NOT
+commit to keeping this code working against LINE API drift. See
+``README.md`` for the production guidance.
 
 Plugin contract:
   - Entry point in ``pyproject.toml``:
-    ``[project.entry-points."reyn.webhooks"] sample_line = "reyn.plugins.sample_line:register_router"``
+    ``[project.entry-points."reyn.webhooks"]
+       sample_line = "reyn.plugins.sample_line:register_router"``
   - ``register_router(config: dict) -> APIRouter | None``
-    receives the plugin's section of ``webhooks.yaml``, returns the
-    router to mount or None to skip.
 """
 from __future__ import annotations
 
@@ -26,19 +26,15 @@ logger = logging.getLogger(__name__)
 def register_router(config: dict) -> APIRouter | None:
     """Plugin entry point — return the LINE webhook router to mount.
 
-    Reads required config:
-      - ``target_agent``: name of the agent that receives incoming
-        LINE messages on its inbox.
-      - ``LINE_CHANNEL_SECRET`` env var: LINE's channel secret
-        (= from the LINE Developers Console).
-
-    Returns ``None`` (= skip) when either is missing. Reyn loader
-    logs a warning, route is not mounted.
+    Skips (= returns None) when any of these are missing:
+      - ``target_agent`` in config
+      - ``LINE_CHANNEL_SECRET`` env var
+      - ``line-bot-sdk`` package (= install ``reyn[sample_line]``)
     """
     target_agent = config.get("target_agent") if isinstance(config, dict) else None
     if not isinstance(target_agent, str) or not target_agent:
         logger.warning(
-            "sample_line plugin: 'target_agent' missing in config; skipping mount",
+            "sample_line plugin: 'target_agent' missing in webhooks.yaml; skipping mount",
         )
         return None
     if not os.environ.get("LINE_CHANNEL_SECRET"):
@@ -46,5 +42,14 @@ def register_router(config: dict) -> APIRouter | None:
             "sample_line plugin: LINE_CHANNEL_SECRET env var not set; skipping mount",
         )
         return None
-    from .webhook import build_router
+    try:
+        from .webhook import build_router
+    except ImportError as exc:
+        logger.warning(
+            "sample_line plugin: required SDK not installed "
+            "(install with ``pip install reyn[sample_line]``); skipping mount. "
+            "Detail: %s",
+            exc,
+        )
+        return None
     return build_router(target_agent=target_agent)

--- a/src/reyn/plugins/sample_line/webhook.py
+++ b/src/reyn/plugins/sample_line/webhook.py
@@ -1,276 +1,153 @@
-"""LINE Messaging API webhook — sample_line plugin (FP-0041 #489 PR-E).
+"""LINE Messaging API webhook — sample_line plugin (FP-0041 #489 plugins-api PR-2).
 
 ⚠️  **SAMPLE / EXAMPLE ONLY** ⚠️ — see ``README.md``.
 
-Inbound chat-transport for the LINE Messaging API. Receives webhook
-POSTs from LINE's platform, verifies the ``X-Line-Signature`` HMAC,
-parses the events array, mints a Reyn inbox envelope per dispatchable
-message event, and pushes to the configured target agent.
+Inbound chat-transport for the LINE Messaging API, wired through
+``line-bot-sdk`` v3 (= LINE's official SDK). Mirror of the
+``sample_slack`` refactor: OSS SDK handles transport-specific
+protocol; ``reyn.plugins.api`` handles Reyn-side dispatch. The
+plugin's own glue is intentionally minimal (= ~50 lines).
 
-## LINE specifics that differ from Slack
+## LINE Messaging API integration
 
-- **Signing**: HMAC-SHA256 of the raw body, **base64-encoded**
-  (= Slack uses hex). Header is ``X-Line-Signature``.
-- **No replay window**: LINE doesn't include a timestamp in the
-  signing input, so there's nothing to compare against the clock.
-  Replay attacks are mitigated by the ``replyToken``'s single-use
-  semantics on the LINE side (= only useful within ~30 seconds of
-  the original event).
-- **Events array**: payload is ``{"events": [...]}`` with a list
-  of events, not a single event under ``event:``. The handler
-  iterates and dispatches each ``message`` event.
-- **Source variants**: an event's source is one of
-  ``user`` / ``group`` / ``room``; sender attribution + reply
-  destination differ per source type.
-- **replyToken**: each event carries a single-use, time-limited
-  token for the LINE Reply API. The outbound side (= via Reyn's
-  external_transports + LINE MCP server) uses it; this inbound
-  handler simply forwards it in the ``ExternalRef.destination``.
+LINE Developers Console (= https://developers.line.biz/console/):
+
+  Webhook URL:           https://<reyn>/webhook/line
+  Use webhook:           enabled
+  Channel Secret:        set as ``LINE_CHANNEL_SECRET`` env var
+  Channel Access Token:  set as ``LINE_CHANNEL_ACCESS_TOKEN`` env
+                         var (= for outbound replies via LINE MCP)
+
+## What line-bot-sdk handles (= we don't)
+
+- HMAC-SHA256 + base64 signature verification (= ``WebhookParser``)
+- Webhook envelope parsing into typed event objects
+- Event-type discrimination (= MessageEvent / FollowEvent / etc.)
+- Message-content discrimination (= TextMessageContent / etc.)
+- Source-type variants (= UserSource / GroupSource / RoomSource)
+
+## What we glue
+
+- Map ``MessageEvent`` + ``TextMessageContent`` → Reyn envelope
+- Use ``make_sender`` for the LINE attribution format
+- Use ``push_to_agent`` for inbox dispatch
+- Forward ``reply_token`` + source identifiers in ``ExternalRef``
 
 ## Reference
 
-- LINE Messaging API webhook spec:
-  https://developers.line.biz/en/reference/messaging-api/#webhooks
-- Signature verification:
-  https://developers.line.biz/en/reference/messaging-api/#signature-validation
+- line-bot-sdk:        https://github.com/line/line-bot-sdk-python
+- Webhook spec:        https://developers.line.biz/en/reference/messaging-api/#webhooks
 """
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
 import logging
 import os
-from typing import Any
 
-from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse, Response
-
-from reyn.chat.transport import ExternalRef
-from reyn.web.deps import get_registry
+from fastapi import APIRouter, HTTPException, Request
 
 logger = logging.getLogger(__name__)
-
-
-# ── signing verification ──────────────────────────────────────────────
-
-
-def verify_line_signature(
-    *, body: bytes, signature: str, channel_secret: str,
-) -> tuple[bool, str]:
-    """Verify a LINE-signed webhook request.
-
-    Returns ``(ok, detail)``. ``ok=True`` means the signature
-    matches; ``detail`` is a short reason for ``ok=False`` cases
-    (= ``missing-signature`` / ``mismatch``). Constant-time
-    comparison via ``hmac.compare_digest``.
-
-    LINE's spec: ``signature = base64(HMAC-SHA256(channel_secret, body))``.
-    No timestamp involved — replay is mitigated by ``replyToken``
-    single-use semantics on the LINE side.
-    """
-    if not signature:
-        return False, "missing-signature"
-    digest = hmac.new(
-        channel_secret.encode(), body, hashlib.sha256,
-    ).digest()
-    expected = base64.b64encode(digest).decode()
-    if not hmac.compare_digest(expected, signature):
-        return False, "mismatch"
-    return True, "ok"
-
-
-# ── envelope minting ─────────────────────────────────────────────────
-
-
-def mint_envelope_from_line_event(event: dict) -> dict | None:
-    """Convert a single LINE webhook event into a Reyn inbox envelope.
-
-    Returns ``None`` when the event isn't a dispatchable message
-    (= follow / unfollow / postback / sticker without text / etc.).
-
-    Sender shape:
-      ``line:user:<userId>``   — 1:1 chat
-      ``line:group:<groupId>:<userId>``   — group chat
-      ``line:room:<roomId>:<userId>``     — room chat
-
-    Reply-to shape:
-      ExternalRef(transport="line", destination={
-          "reply_token": <replyToken>,   # single-use, 30-sec window
-          "source_type": "user" | "group" | "room",
-          "source_id": <userId | groupId | roomId>,
-      })
-
-    The dispatcher (= LINE MCP server side) chooses between the
-    Reply API (= using reply_token) and the Push API (= using
-    source_id) based on timing.
-    """
-    if not isinstance(event, dict):
-        return None
-    if event.get("type") != "message":
-        return None
-    message = event.get("message")
-    if not isinstance(message, dict):
-        return None
-    if message.get("type") != "text":
-        # Sticker / image / location etc. — not directly dispatchable
-        # as a plain text turn. Future plugin enhancements could
-        # surface these to the LLM via multimodal envelope shape.
-        return None
-    text = message.get("text")
-    if not isinstance(text, str) or not text.strip():
-        return None
-
-    source = event.get("source")
-    if not isinstance(source, dict):
-        return None
-    source_type = source.get("type")
-    from reyn.plugins.api import make_sender
-    if source_type == "user":
-        user_id = source.get("userId") or "unknown"
-        sender = make_sender("line", user_id, source_scope="user")
-        source_id = user_id
-    elif source_type == "group":
-        group_id = source.get("groupId") or "unknown"
-        user_id = source.get("userId") or ""
-        sender = make_sender(
-            "line", group_id, source_scope="group", display=user_id,
-        )
-        source_id = group_id
-    elif source_type == "room":
-        room_id = source.get("roomId") or "unknown"
-        user_id = source.get("userId") or ""
-        sender = make_sender(
-            "line", room_id, source_scope="room", display=user_id,
-        )
-        source_id = room_id
-    else:
-        return None
-
-    reply_token = event.get("replyToken")
-    if not isinstance(reply_token, str):
-        reply_token = ""
-
-    reply_to = ExternalRef(
-        transport="line",
-        destination={
-            "reply_token": reply_token,
-            "source_type": source_type,
-            "source_id": source_id,
-        },
-    )
-    return {"text": text, "sender": sender, "reply_to": reply_to}
-
-
-# ── route factory ────────────────────────────────────────────────────
 
 
 def build_router(*, target_agent: str) -> APIRouter:
     """Build the LINE webhook router for the configured target agent.
 
-    Called by the plugin's ``register_router`` entry point with the
-    resolved ``target_agent`` from ``webhooks.yaml``. Captures the
-    agent in the closure so the route handler doesn't re-resolve
-    per request.
+    Wires ``line-bot-sdk``'s ``WebhookParser`` for signature
+    verification + typed event parsing; routes message events to
+    Reyn's agent inbox via ``reyn.plugins.api.push_to_agent``.
 
-    The channel secret is read from ``LINE_CHANNEL_SECRET`` env var
-    at request time (= not at build time, so operator can rotate
-    without restart — LINE-side rotation requires a brief overlap
-    window anyway).
+    Raises ``ImportError`` if ``line-bot-sdk`` isn't installed;
+    ``register_router`` handles this by returning ``None``.
     """
+    from linebot.v3 import WebhookParser
+    from linebot.v3.exceptions import InvalidSignatureError
+    from linebot.v3.webhooks import (
+        GroupSource,
+        MessageEvent,
+        RoomSource,
+        TextMessageContent,
+        UserSource,
+    )
+
+    from reyn.chat.transport import ExternalRef
+    from reyn.plugins.api import make_sender, push_to_agent
+
+    channel_secret = os.environ.get("LINE_CHANNEL_SECRET", "")
+    parser = WebhookParser(channel_secret)
+
     router = APIRouter(tags=["plugin-sample_line"])
 
     @router.post("/webhook/line")
-    async def line_webhook(
-        request: Request,
-        registry=Depends(get_registry),
-    ) -> Response:
-        """Receive a LINE Messaging API POST.
-
-        Behaviour:
-          1. Verify ``X-Line-Signature``. Bad → 401.
-          2. Parse body as JSON; iterate events array.
-          3. For each dispatchable message event, mint envelope +
-             push to target agent's inbox.
-          4. Return 200 (= LINE retries 4xx/5xx within the same
-             webhook delivery attempt budget; 2xx ends the
-             attempt).
-        """
-        body_bytes = await request.body()
-
-        channel_secret = os.environ.get("LINE_CHANNEL_SECRET")
-        if not channel_secret:
-            logger.warning(
-                "LINE webhook received but LINE_CHANNEL_SECRET is unset; rejecting.",
-            )
-            return JSONResponse(
-                {"error": "LINE channel secret not configured"},
-                status_code=503,
-            )
-
-        ok, detail = verify_line_signature(
-            body=body_bytes,
-            signature=request.headers.get("X-Line-Signature", ""),
-            channel_secret=channel_secret,
-        )
-        if not ok:
-            logger.warning("LINE webhook signing verify failed: %s", detail)
-            return JSONResponse(
-                {"error": f"signature verification failed: {detail}"},
-                status_code=401,
-            )
-
-        # Parse body.
+    async def line_webhook(req: Request):
+        body = await req.body()
+        signature = req.headers.get("X-Line-Signature", "")
         try:
-            import json
-            payload = json.loads(body_bytes.decode("utf-8") or "{}")
-        except Exception:
-            logger.warning("LINE webhook: malformed JSON body")
-            return JSONResponse(
-                {"error": "malformed body"}, status_code=400,
-            )
-
-        events: Any = payload.get("events") if isinstance(payload, dict) else None
-        if not isinstance(events, list):
-            # No events array → ack (= e.g. LINE verify ping).
-            return JSONResponse({"status": "ignored"}, status_code=200)
-
-        # Push each dispatchable event via the stable plugin API
-        # (= reyn.plugins.api, FP-0041 plugins-api).
-        from reyn.plugins.api import push_to_agent
+            events = parser.parse(body.decode("utf-8"), signature)
+        except InvalidSignatureError as exc:
+            logger.warning("LINE webhook signature verification failed: %s", exc)
+            raise HTTPException(status_code=401, detail="invalid signature") from exc
 
         dispatched = 0
         for event in events:
-            envelope = mint_envelope_from_line_event(event)
-            if envelope is None:
+            if not isinstance(event, MessageEvent):
                 continue
+            message = event.message
+            if not isinstance(message, TextMessageContent):
+                # Sticker / image / location etc. — not dispatched as
+                # plain text turns in this sample.
+                continue
+            text = message.text or ""
+            if not text.strip():
+                continue
+
+            source = event.source
+            if isinstance(source, UserSource):
+                user_id = source.user_id or "unknown"
+                sender = make_sender("line", user_id, source_scope="user")
+                source_id = user_id
+                source_type = "user"
+            elif isinstance(source, GroupSource):
+                group_id = source.group_id or "unknown"
+                user_id = source.user_id or ""
+                sender = make_sender(
+                    "line", group_id, source_scope="group", display=user_id,
+                )
+                source_id = group_id
+                source_type = "group"
+            elif isinstance(source, RoomSource):
+                room_id = source.room_id or "unknown"
+                user_id = source.user_id or ""
+                sender = make_sender(
+                    "line", room_id, source_scope="room", display=user_id,
+                )
+                source_id = room_id
+                source_type = "room"
+            else:
+                continue
+
+            reply_to = ExternalRef(
+                transport="line",
+                destination={
+                    "reply_token": event.reply_token or "",
+                    "source_type": source_type,
+                    "source_id": source_id,
+                },
+            )
             try:
                 await push_to_agent(
                     target_agent=target_agent,
-                    text=envelope["text"],
-                    sender=envelope["sender"],
-                    reply_to=envelope["reply_to"],
-                    registry=registry,
+                    text=text,
+                    sender=sender,
+                    reply_to=reply_to,
                 )
                 dispatched += 1
             except FileNotFoundError:
                 logger.warning(
-                    "LINE webhook: target agent %r not found in registry",
+                    "sample_line: target agent %r not in registry; skipping",
                     target_agent,
                 )
-                return JSONResponse(
-                    {"error": f"target agent {target_agent!r} not found"},
-                    status_code=503,
-                )
             except Exception as exc:
-                logger.exception("LINE webhook: inbox push failed: %s", exc)
-                return JSONResponse(
-                    {"error": f"inbox dispatch failed: {type(exc).__name__}"},
-                    status_code=500,
-                )
+                logger.exception("sample_line: inbox push failed: %s", exc)
 
-        return JSONResponse(
-            {"status": "ok", "dispatched": dispatched}, status_code=200,
-        )
+        return {"status": "ok", "dispatched": dispatched}
 
     return router

--- a/src/reyn/plugins/sample_slack/README.md
+++ b/src/reyn/plugins/sample_slack/README.md
@@ -23,23 +23,27 @@ outbox interceptor, MCP dispatcher) live in ``src/reyn/chat/`` and
 
 ## Operator setup
 
-1. Create a Slack App at https://api.slack.com/apps
-2. Enable **Event Subscriptions** and set Request URL to
+1. Install Reyn with the ``sample_slack`` extra:
+   ```bash
+   pip install 'reyn[sample_slack]'   # = reyn + slack-bolt
+   ```
+2. Create a Slack App at https://api.slack.com/apps
+3. Enable **Event Subscriptions** and set Request URL to
    ``https://<your-reyn-host>/webhook/slack``
-3. Subscribe to bot events: ``app_mention`` and ``message.im``
-4. Install the App in your workspace
-5. Note the **Signing Secret** from the App credentials
-6. Activate the plugin in ``webhooks.yaml`` (= next to reyn.yaml):
+4. Subscribe to bot events: ``app_mention`` and ``message.im``
+5. Install the App in your workspace
+6. Note the **Signing Secret** from the App credentials
+7. Activate the plugin in ``webhooks.yaml`` (= next to reyn.yaml):
    ```yaml
    sample_slack:
      target_agent: news_agent     # agent that receives Slack messages
    ```
-7. Set env vars on Reyn:
+8. Set env vars on Reyn:
    ```bash
    export SLACK_SIGNING_SECRET=<signing-secret>
    export SLACK_BOT_TOKEN=xoxb-...    # for outbound replies via Slack MCP
    ```
-8. At-mention the bot in any channel where it's invited; messages
+9. At-mention the bot in any channel where it's invited; messages
    reach the target agent's inbox.
 
 ## Configuration (= webhooks.yaml)

--- a/src/reyn/plugins/sample_slack/__init__.py
+++ b/src/reyn/plugins/sample_slack/__init__.py
@@ -1,19 +1,20 @@
-"""sample_slack — Sample Slack webhook plugin (FP-0041 #489 follow-up).
+"""sample_slack — Sample Slack webhook plugin (FP-0041 #489).
 
 ⚠️  **SAMPLE / EXAMPLE ONLY** ⚠️
 
 Demonstrates Reyn's plugin framework for chat-transport webhook
-integrations. Reyn maintainers do NOT commit to keeping this code
-working against Slack API drift. See ``README.md`` for the production
-guidance.
+integrations via ``slack-bolt`` (= Slack's official SDK) + the
+``reyn.plugins.api`` stable contract. Reyn maintainers do NOT
+commit to keeping this code working against Slack API drift. See
+``README.md`` for the production guidance.
 
 Plugin contract:
   - Entry point in ``pyproject.toml``:
-    ``[project.entry-points."reyn.webhooks"] sample_slack = "reyn.plugins.sample_slack:register_router"``
+    ``[project.entry-points."reyn.webhooks"]
+       sample_slack = "reyn.plugins.sample_slack:register_router"``
   - ``register_router(config: dict) -> APIRouter | None``
-    receives this plugin's section of ``reyn.yaml`` (= the dict keyed
-    by the plugin name at top-level), returns a router to mount or
-    None to skip.
+    receives the per-instance dict from ``webhooks.yaml``, returns
+    the router to mount or None to skip (= missing dep / config).
 """
 from __future__ import annotations
 
@@ -28,20 +29,16 @@ logger = logging.getLogger(__name__)
 def register_router(config: dict) -> APIRouter | None:
     """Plugin entry point — return the Slack webhook router to mount.
 
-    Reads required config:
-      - ``target_agent``: name of the agent that receives incoming
-        Slack messages on its inbox.
-      - ``SLACK_SIGNING_SECRET`` env var: Slack's HMAC signing secret
-        (= configured at api.slack.com per the README).
-
-    Returns None (= skip) when either is missing — Reyn loader logs a
-    warning, the route is not mounted. Operator sees the missing
-    config in logs without crashing reyn web.
+    Skips (= returns None) when any of these are missing:
+      - ``target_agent`` in config (= operator forgot to declare)
+      - ``SLACK_SIGNING_SECRET`` env var (= operator forgot to set)
+      - ``slack-bolt`` package (= operator didn't install
+        ``reyn[sample_slack]``)
     """
     target_agent = config.get("target_agent") if isinstance(config, dict) else None
     if not isinstance(target_agent, str) or not target_agent:
         logger.warning(
-            "sample_slack plugin: 'target_agent' missing in config; skipping mount",
+            "sample_slack plugin: 'target_agent' missing in webhooks.yaml; skipping mount",
         )
         return None
     if not os.environ.get("SLACK_SIGNING_SECRET"):
@@ -49,5 +46,14 @@ def register_router(config: dict) -> APIRouter | None:
             "sample_slack plugin: SLACK_SIGNING_SECRET env var not set; skipping mount",
         )
         return None
-    from .webhook import build_router
+    try:
+        from .webhook import build_router
+    except ImportError as exc:
+        logger.warning(
+            "sample_slack plugin: required SDK not installed "
+            "(install with ``pip install reyn[sample_slack]``); skipping mount. "
+            "Detail: %s",
+            exc,
+        )
+        return None
     return build_router(target_agent=target_agent)

--- a/src/reyn/plugins/sample_slack/webhook.py
+++ b/src/reyn/plugins/sample_slack/webhook.py
@@ -1,310 +1,158 @@
-"""Slack inbound webhook router — FP-0041 #489 PR-D.
+"""Slack Events API webhook — sample_slack plugin (FP-0041 #489 plugins-api PR-2).
 
-Inbound chat-transport adapter: receives Slack Events API webhook
-POSTs at ``/webhook/slack``, verifies the signing secret, parses
-the event, mints an inbox envelope with ``sender="slack:<user_id>:
-<display>"`` + ``reply_to=ExternalRef(transport="slack",
-destination={...})``, and pushes to the target agent's inbox.
+⚠️  **SAMPLE / EXAMPLE ONLY** ⚠️ — see ``README.md``.
 
-The agent's router_loop then processes the message as an attributed
-turn (= PR-A dispatch attribution emits a ``[context shift]``
-state_change before the LLM sees the text). Replies flow back out
-via PR-D2 (= outbox subscriber + route_to_mcp via Slack MCP server).
-This PR covers inbound only.
+Inbound chat-transport for the Slack Events API, wired through
+``slack-bolt`` (= Slack's official SDK). This refactor demonstrates
+the canonical pattern for a Reyn webhook plugin:
+
+  OSS SDK (= slack-bolt)  for transport-specific protocol
+  reyn.plugins.api        for Reyn-side envelope dispatch
+
+The plugin's own glue is intentionally minimal (= ~50 lines) so
+plugin authors see exactly what "API-to-API" looks like.
 
 ## Slack Events API integration
 
-Reyn's Slack App is configured at api.slack.com → Event Subscriptions:
-  Request URL: https://<reyn>/webhook/slack
-  Subscribe to bot events: ``app_mention`` (= bot is @mentioned),
-    ``message.im`` (= DM to bot)
+Reyn's Slack App is configured at api.slack.com:
+
+  Request URL:    https://<reyn>/webhook/slack
+  Bot Events:     ``app_mention`` (= bot is @mentioned),
+                  ``message.im`` (= DM to bot)
   Signing Secret: set as ``SLACK_SIGNING_SECRET`` env var on Reyn
 
-## Signing verification
+## What slack-bolt handles (= we don't)
 
-Slack signs every request with HMAC-SHA256 using the signing secret.
-Verification per https://api.slack.com/authentication/verifying-requests-from-slack:
+- HMAC-SHA256 v0 signature verification + replay window
+- URL verification handshake challenge / response
+- Event subscription dispatch (= ``@app.event(...)`` decorators)
+- Retry deduplication via ``X-Slack-Retry-Num``
+- OAuth flows (= if Reyn adds multi-workspace later)
+- Socket Mode (= future option for hosted Reyn)
 
-  base_string = f"v0:{timestamp}:{body}"
-  signature = "v0=" + hmac.sha256(secret, base_string).hexdigest()
+## What we glue (= the ~30 lines)
 
-  Reject when:
-    - Request older than 5 minutes (= replay guard)
-    - X-Slack-Signature mismatch (= constant-time compare)
+- Map ``app_mention`` / ``message`` event → Reyn envelope
+- Use ``reyn.plugins.api.make_sender`` for the attribution string
+- Use ``reyn.plugins.api.push_to_agent`` for inbox dispatch
 
-## URL verification handshake
+## Reference
 
-When Slack first calls the Request URL, it sends:
-  {"type": "url_verification", "challenge": "<random>"}
-
-Reyn echoes back ``{"challenge": "<random>"}`` (= 200 OK).
-
-## Event shapes handled
-
-  app_mention / message:
-    {"event": {"type": "app_mention", "user": "U456",
-               "text": "<@U_BOT> help", "channel": "C123",
-               "ts": "1234.5678", "thread_ts": "..." | absent}}
-
-Other event types (= reactions, channel join, etc.) are accepted
-and acknowledged but produce no inbox envelope.
-
-## Target agent routing
-
-Phase 1 (= this PR): single target agent configured per Slack workspace
-via ``SLACK_TARGET_AGENT`` env var (or ``slack.target_agent`` in
-reyn.yaml). Per-user / per-channel ACL is follow-up.
-
-## Defensive posture
-
-- Signing failure → 401 + log warning
-- URL verification → 200 + challenge echo
-- Unknown event type → 200 (= Slack will keep delivering)
-- Inbox push failure → 500 + log; Slack will retry
-- Reyn target agent not found → 500 + log
-
-The handler never crashes the FastAPI route; all error paths return
-the appropriate HTTP status with no exception propagation.
+- slack-bolt-python:    https://slack.dev/bolt-python/
+- FastAPI adapter:      ``slack_bolt.adapter.fastapi.async_handler``
 """
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
 import os
-import time
-from typing import Any
 
-from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse, Response
-
-from reyn.chat.transport import ExternalRef
-from reyn.web.deps import get_registry
+from fastapi import APIRouter, Request
 
 logger = logging.getLogger(__name__)
-
-# Replay-protection window for Slack signing. Per Slack docs, ts older
-# than 5 minutes should be rejected to prevent replay attacks.
-_SLACK_REPLAY_WINDOW_SECONDS = 60 * 5
-
-
-# ── signing verification ──────────────────────────────────────────────
-
-
-def verify_slack_signature(
-    *,
-    body: bytes,
-    timestamp: str,
-    signature: str,
-    signing_secret: str,
-    now: float | None = None,
-) -> tuple[bool, str]:
-    """Verify a Slack-signed webhook request.
-
-    Returns ``(ok, detail)``. ``ok=True`` means the signature
-    matches AND the timestamp is within the replay window;
-    ``detail`` is a short reason string for ``ok=False`` cases
-    (= "missing-timestamp" / "missing-signature" / "stale" /
-    "mismatch"). Constant-time comparison via ``hmac.compare_digest``.
-
-    Exported for test injection — callers (= the route handler) use
-    this with ``now=time.time()``.
-    """
-    if not timestamp:
-        return False, "missing-timestamp"
-    if not signature:
-        return False, "missing-signature"
-    try:
-        ts = int(timestamp)
-    except (TypeError, ValueError):
-        return False, "invalid-timestamp"
-    current = now if now is not None else time.time()
-    if abs(current - ts) > _SLACK_REPLAY_WINDOW_SECONDS:
-        return False, "stale"
-    base_string = f"v0:{timestamp}:".encode() + body
-    digest = hmac.new(
-        signing_secret.encode(), base_string, hashlib.sha256,
-    ).hexdigest()
-    expected = f"v0={digest}"
-    if not hmac.compare_digest(expected, signature):
-        return False, "mismatch"
-    return True, "ok"
-
-
-# ── envelope minting ─────────────────────────────────────────────────
-
-
-def mint_envelope_from_slack_event(event: dict) -> dict | None:
-    """Convert a Slack event payload into a Reyn inbox envelope.
-
-    Returns the envelope dict (= ``{"text", "sender", "reply_to"}``)
-    or ``None`` when the event isn't a kind we should dispatch (=
-    bot's own message, reaction, channel-join, etc.).
-
-    Sender shape: ``slack:<user_id>`` (= per PR-A sender
-    convention). Display name lookup is not implemented in this PR
-    (= optional augmentation in follow-up if Slack MCP exposes a
-    ``users.info`` call).
-
-    Reply-to shape: ``ExternalRef(transport="slack",
-    destination={"channel": <id>, "thread_ts": <id>})`` — the
-    ``thread_ts`` defaults to the message's own ``ts`` so the agent
-    reply lands in a thread; if the user is replying in an existing
-    thread, that ``thread_ts`` is preserved.
-
-    Stored as a plain dict because the existing inbox mechanism uses
-    dict payloads. The ``reply_to`` is the ExternalRef instance; PR-D2
-    outbox subscriber will read it back.
-    """
-    inner = event.get("event") if isinstance(event, dict) else None
-    if not isinstance(inner, dict):
-        return None
-    event_type = inner.get("type")
-    # Only dispatch message-class events. App-home / reaction / etc.
-    # land here but produce no inbox push.
-    if event_type not in ("app_mention", "message"):
-        return None
-    # Ignore bot's own messages (= prevent feedback loops).
-    if inner.get("bot_id") or inner.get("subtype") == "bot_message":
-        return None
-    text = inner.get("text")
-    if not isinstance(text, str) or not text.strip():
-        return None
-    user_id = inner.get("user")
-    channel = inner.get("channel")
-    if not isinstance(channel, str):
-        return None
-    ts = inner.get("ts")
-    thread_ts = inner.get("thread_ts") or ts
-    from reyn.plugins.api import make_sender
-    sender = make_sender("slack", user_id or "unknown")
-    reply_to = ExternalRef(
-        transport="slack",
-        destination={"channel": channel, "thread_ts": thread_ts},
-    )
-    return {
-        "text": text,
-        "sender": sender,
-        "reply_to": reply_to,
-    }
-
-
-# ── route factory ─────────────────────────────────────────────────────
 
 
 def build_router(*, target_agent: str) -> APIRouter:
     """Build the Slack webhook router for the configured target agent.
 
-    Called by the plugin's ``register_router`` entry-point with the
-    resolved target agent name from ``reyn.yaml``. Captures the agent
-    in the closure so the route handler doesn't need to re-resolve
-    per request.
+    Wires ``slack-bolt``'s ``AsyncApp`` to a FastAPI router via the
+    ``AsyncSlackRequestHandler``. The bot's incoming events (=
+    ``app_mention`` + ``message``) are dispatched to Reyn's agent
+    inbox via ``reyn.plugins.api.push_to_agent``.
 
-    Signing secret is read from ``SLACK_SIGNING_SECRET`` env var at
-    request time (= not captured at build time, so operator can
-    rotate without restarting Reyn — Slack-side rotation requires
-    a brief overlap window anyway).
+    Raises ``RuntimeError`` if ``slack-bolt`` isn't installed; the
+    ``register_router`` entry point handles this by returning ``None``
+    so the loader logs + skips.
     """
-    router = APIRouter(tags=["plugin-sample_slack"])
+    # SDK imports kept inside ``build_router`` so the module is
+    # importable without the SDK (= ``register_router`` decides the
+    # opt-out behaviour).
+    from slack_bolt.adapter.fastapi.async_handler import (
+        AsyncSlackRequestHandler,
+    )
+    from slack_bolt.async_app import AsyncApp
+    from slack_bolt.authorization import AuthorizeResult
 
-    @router.post("/webhook/slack")
-    async def slack_webhook(
-        request: Request,
-        registry=Depends(get_registry),
-    ) -> Response:
-        """Receive a Slack Events API POST.
+    from reyn.chat.transport import ExternalRef
+    from reyn.plugins.api import make_sender, push_to_agent
 
-        Three branches:
-          1. URL verification → echo challenge.
-          2. Event with no dispatchable payload (= non-message events,
-             malformed payload) → 200 ack only.
-          3. Message event → verify signing, mint envelope, push to
-             target agent's inbox, return 200.
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
+    # Reyn dispatches outbound replies via the Slack MCP server, NOT
+    # through bolt. Bolt's default ``single_team_authorization`` calls
+    # ``auth.test`` against Slack to verify the bot token at request
+    # time — we skip that probe with a custom ``authorize`` that
+    # returns a stub AuthorizeResult so inbound dispatch works without
+    # a real bot token configured.
+    bot_token = os.environ.get("SLACK_BOT_TOKEN") or "xoxb-placeholder"
 
-        Errors return appropriate HTTP status without raising; Slack
-        will retry on non-2xx so we avoid 4xx/5xx for transient cases.
-        """
-        body_bytes = await request.body()
-
-        # Parse body up-front so we can handle url_verification before
-        # signing check (= URL verification doesn't have a signature
-        # during initial setup with some Slack App configurations).
-        try:
-            import json
-            payload = json.loads(body_bytes.decode("utf-8") or "{}")
-        except Exception:
-            logger.warning("Slack webhook: malformed JSON body")
-            return JSONResponse(
-                {"error": "malformed body"}, status_code=400,
-            )
-
-        # URL verification handshake — Slack POSTs this on initial setup.
-        if isinstance(payload, dict) and payload.get("type") == "url_verification":
-            challenge = payload.get("challenge")
-            return JSONResponse(
-                {"challenge": challenge if isinstance(challenge, str) else ""},
-                status_code=200,
-            )
-
-        # Signing verification for all other paths.
-        signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
-        if not signing_secret:
-            logger.warning(
-                "Slack webhook received but SLACK_SIGNING_SECRET is unset; rejecting.",
-            )
-            return JSONResponse(
-                {"error": "Slack signing secret not configured"},
-                status_code=503,
-            )
-        ok, detail = verify_slack_signature(
-            body=body_bytes,
-            timestamp=request.headers.get("X-Slack-Request-Timestamp", ""),
-            signature=request.headers.get("X-Slack-Signature", ""),
-            signing_secret=signing_secret,
+    async def _authorize(*args, **kwargs):
+        return AuthorizeResult(
+            enterprise_id=None,
+            team_id=None,
+            user_id=None,
+            bot_user_id=None,
+            bot_id=None,
+            bot_token=bot_token,
         )
-        if not ok:
-            logger.warning("Slack webhook signing verify failed: %s", detail)
-            return JSONResponse(
-                {"error": f"signature verification failed: {detail}"},
-                status_code=401,
-            )
 
-        # Mint envelope from the event.
-        envelope = mint_envelope_from_slack_event(payload)
-        if envelope is None:
-            # Non-dispatchable event (= reaction / channel_join / bot
-            # message echo / etc.). Slack expects 2xx so it won't retry.
-            return JSONResponse({"status": "ignored"}, status_code=200)
+    bolt_app = AsyncApp(
+        signing_secret=signing_secret,
+        authorize=_authorize,
+    )
 
-        # Push to inbox via the stable plugin API (= reyn.plugins.api,
-        # FP-0041 plugins-api). The helper handles registry lookup +
-        # session.ensure_running internally; plugin code should NOT
-        # touch ChatSession internals (= _put_inbox) directly.
-        from reyn.plugins.api import push_to_agent
+    async def _dispatch(event: dict) -> None:
+        """Translate a Slack message-class event → Reyn envelope +
+        push via the stable plugin API.
+        """
+        text = event.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return
+        if event.get("bot_id") or event.get("subtype") == "bot_message":
+            return  # bot echo, drop
+        user_id = event.get("user") or "unknown"
+        channel = event.get("channel")
+        if not isinstance(channel, str):
+            return
+        ts = event.get("ts")
+        thread_ts = event.get("thread_ts") or ts
+
         try:
             await push_to_agent(
                 target_agent=target_agent,
-                text=envelope["text"],
-                sender=envelope["sender"],
-                reply_to=envelope["reply_to"],
-                registry=registry,
+                text=text,
+                sender=make_sender("slack", user_id),
+                reply_to=ExternalRef(
+                    transport="slack",
+                    destination={"channel": channel, "thread_ts": thread_ts},
+                ),
             )
         except FileNotFoundError:
             logger.warning(
-                "Slack webhook: target agent %r not found in registry",
+                "sample_slack: target agent %r not in registry; skipping",
                 target_agent,
             )
-            return JSONResponse(
-                {"error": f"target agent {target_agent!r} not found"},
-                status_code=503,
-            )
         except Exception as exc:
-            logger.exception("Slack webhook: inbox push failed: %s", exc)
-            return JSONResponse(
-                {"error": f"inbox dispatch failed: {type(exc).__name__}"},
-                status_code=500,
-            )
+            logger.exception("sample_slack: inbox push failed: %s", exc)
 
-        return JSONResponse({"status": "ok"}, status_code=200)
+    @bolt_app.event("app_mention")
+    async def on_app_mention(event):  # noqa: D401
+        await _dispatch(event)
+
+    @bolt_app.event("message")
+    async def on_message(event):  # noqa: D401
+        await _dispatch(event)
+
+    handler = AsyncSlackRequestHandler(bolt_app)
+    router = APIRouter(tags=["plugin-sample_slack"])
+
+    @router.post("/webhook/slack")
+    async def slack_webhook(req: Request):
+        """Forward incoming Slack POSTs to bolt's handler.
+
+        Bolt internally verifies signing, parses events, and routes
+        to the registered handlers (= ``on_app_mention`` /
+        ``on_message`` above). URL verification handshake +
+        retry dedup are bolt's responsibility too.
+        """
+        return await handler.handle(req)
 
     return router

--- a/tests/plugins/sample_line/test_webhook.py
+++ b/tests/plugins/sample_line/test_webhook.py
@@ -1,25 +1,20 @@
-"""Tier 2: sample_line plugin (FP-0041 #489 PR-E).
+"""Tier 2: sample_line plugin (FP-0041 plugins-api PR-2).
 
-LINE Messaging API webhook handler — mirror of ``sample_slack``
-with LINE-specific protocol (= base64 HMAC, events array, source
-type variants, replyToken).
+The hand-rolled webhook handler that landed in PR #524 has been
+replaced with ``line-bot-sdk`` v3. The SDK handles signature
+verification + event parsing; the plugin glues SDK events → Reyn
+``push_to_agent``.
 
-Tests:
+Tests focus on:
 
-  1. ``verify_line_signature`` — base64 HMAC matches, mismatch,
-     missing header, channel secret rotation
-  2. ``mint_envelope_from_line_event``: text message / user / group /
-     room source / non-text events skipped / non-message skipped /
-     replyToken forwarded
-  3. ``register_router`` entry point — missing target_agent /
-     missing channel secret → None; happy path → APIRouter
-  4. Route via TestClient + stubbed registry: signed valid event →
-     inbox push; bad signature → 401; LINE verify ping (= events
-     [] or absent) → 200 ignored
-
-Tier 2 because the plugin is the only inbound path for LINE chat-
-transport; a regression in signing / parsing / dispatch silently
-breaks the integration.
+  1. ``register_router`` entry-point opt-out paths.
+  2. ``build_router`` mounts ``/webhook/line``.
+  3. End-to-end via TestClient + signed body + stubbed registry:
+     - User-source text message → envelope with user-scoped sender
+     - Group-source → group-scoped sender + group ``source_id``
+     - Room-source → room-scoped sender + room ``source_id``
+     - Non-text / non-message events skip dispatch
+     - Bad signature → 401
 """
 from __future__ import annotations
 
@@ -29,175 +24,22 @@ import hmac
 import json
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
-from reyn.chat.transport import ExternalRef
-from reyn.plugins.sample_line.webhook import (
-    build_router,
-    mint_envelope_from_line_event,
-    verify_line_signature,
-)
+linebot = pytest.importorskip("linebot.v3")
 
 
 def _sign(body: bytes, secret: str) -> str:
+    """Build LINE's X-Line-Signature header value."""
     return base64.b64encode(
         hmac.new(secret.encode(), body, hashlib.sha256).digest(),
     ).decode()
 
 
-# ── verify_line_signature ─────────────────────────────────────────────
-
-
-def test_verify_signature_accepts_well_formed():
-    """Tier 2: a base64-encoded HMAC-SHA256 of the body matches."""
-    secret = "channel-secret"
-    body = b'{"events": []}'
-    sig = _sign(body, secret)
-    ok, detail = verify_line_signature(
-        body=body, signature=sig, channel_secret=secret,
-    )
-    assert ok is True
-    assert detail == "ok"
-
-
-def test_verify_signature_rejects_mismatch():
-    """Tier 2: a signature computed with a different secret fails the
-    constant-time compare with ``mismatch`` detail.
-    """
-    body = b'{"x":1}'
-    bad_sig = _sign(body, "wrong-secret")
-    ok, detail = verify_line_signature(
-        body=body, signature=bad_sig, channel_secret="real-secret",
-    )
-    assert ok is False
-    assert detail == "mismatch"
-
-
-def test_verify_signature_rejects_missing_header():
-    """Tier 2: no ``X-Line-Signature`` header → ``missing-signature``."""
-    ok, detail = verify_line_signature(
-        body=b"", signature="", channel_secret="s",
-    )
-    assert ok is False
-    assert detail == "missing-signature"
-
-
-# ── mint_envelope_from_line_event ─────────────────────────────────────
-
-
-def test_mint_envelope_user_message():
-    """Tier 2: a ``message`` event from a 1:1 user chat mints an
-    envelope with ``sender="line:user:<userId>"`` and ExternalRef
-    reply_to carrying the replyToken + source_id.
-    """
-    event = {
-        "type": "message",
-        "replyToken": "TOK_123",
-        "source": {"type": "user", "userId": "U456"},
-        "message": {"type": "text", "text": "hello bot"},
-    }
-    env = mint_envelope_from_line_event(event)
-    assert env is not None
-    assert env["text"] == "hello bot"
-    assert env["sender"] == "line:user:U456"
-    rt = env["reply_to"]
-    assert isinstance(rt, ExternalRef)
-    assert rt.transport == "line"
-    assert rt.destination["reply_token"] == "TOK_123"
-    assert rt.destination["source_type"] == "user"
-    assert rt.destination["source_id"] == "U456"
-
-
-def test_mint_envelope_group_message():
-    """Tier 2: group source has both groupId + userId. Sender
-    encodes both so the agent knows who said what in which group.
-    """
-    event = {
-        "type": "message",
-        "replyToken": "TOK",
-        "source": {"type": "group", "groupId": "G999", "userId": "U456"},
-        "message": {"type": "text", "text": "hi everyone"},
-    }
-    env = mint_envelope_from_line_event(event)
-    assert env is not None
-    assert env["sender"] == "line:group:G999:U456"
-    assert env["reply_to"].destination["source_id"] == "G999"
-
-
-def test_mint_envelope_room_message():
-    """Tier 2: room source variant (= LINE multi-user chat without
-    a group)."""
-    event = {
-        "type": "message",
-        "replyToken": "TOK",
-        "source": {"type": "room", "roomId": "R777", "userId": "U456"},
-        "message": {"type": "text", "text": "hello room"},
-    }
-    env = mint_envelope_from_line_event(event)
-    assert env is not None
-    assert env["sender"] == "line:room:R777:U456"
-
-
-def test_mint_envelope_skips_non_text_message():
-    """Tier 2: sticker / image / location messages don't dispatch
-    as plain text turns. Future multimodal envelope shape could
-    surface them; this sample doesn't.
-    """
-    for msg_type in ("sticker", "image", "location", "video", "audio"):
-        event = {
-            "type": "message",
-            "replyToken": "TOK",
-            "source": {"type": "user", "userId": "U1"},
-            "message": {"type": msg_type},
-        }
-        assert mint_envelope_from_line_event(event) is None
-
-
-def test_mint_envelope_skips_non_message_events():
-    """Tier 2: follow / unfollow / postback / etc. don't dispatch."""
-    for event_type in ("follow", "unfollow", "postback", "join", "leave"):
-        event = {
-            "type": event_type,
-            "source": {"type": "user", "userId": "U1"},
-        }
-        assert mint_envelope_from_line_event(event) is None
-
-
-def test_mint_envelope_skips_empty_text():
-    """Tier 2: a message with whitespace-only text doesn't dispatch."""
-    event = {
-        "type": "message",
-        "replyToken": "TOK",
-        "source": {"type": "user", "userId": "U1"},
-        "message": {"type": "text", "text": "   "},
-    }
-    assert mint_envelope_from_line_event(event) is None
-
-
-def test_mint_envelope_handles_missing_reply_token():
-    """Tier 2: an event without ``replyToken`` (= unusual but
-    possible for some event types) still mints an envelope with an
-    empty reply_token string. Outbound dispatcher fall back to push
-    API based on source_id.
-    """
-    event = {
-        "type": "message",
-        "source": {"type": "user", "userId": "U1"},
-        "message": {"type": "text", "text": "hi"},
-    }
-    env = mint_envelope_from_line_event(event)
-    assert env is not None
-    assert env["reply_to"].destination["reply_token"] == ""
-
-
-# ── register_router entry point ────────────────────────────────────────
+# ── register_router entry-point ────────────────────────────────────────
 
 
 def test_register_router_returns_none_when_target_agent_missing(monkeypatch):
-    """Tier 2: register_router returns None if config has no
-    ``target_agent`` — loader warns + skips mount.
-    """
+    """Tier 2: register_router skips when target_agent absent."""
     from reyn.plugins.sample_line import register_router
     monkeypatch.setenv("LINE_CHANNEL_SECRET", "x")
     assert register_router({}) is None
@@ -205,18 +47,14 @@ def test_register_router_returns_none_when_target_agent_missing(monkeypatch):
 
 
 def test_register_router_returns_none_when_channel_secret_missing(monkeypatch):
-    """Tier 2: register_router returns None if
-    ``LINE_CHANNEL_SECRET`` env var is unset.
-    """
+    """Tier 2: register_router skips when channel secret env unset."""
     from reyn.plugins.sample_line import register_router
     monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
     assert register_router({"target_agent": "x"}) is None
 
 
 def test_register_router_returns_apirouter_when_configured(monkeypatch):
-    """Tier 2: with both target_agent + channel secret, returns
-    an APIRouter (= loader mounts it).
-    """
+    """Tier 2: with both present, returns an APIRouter."""
     from fastapi import APIRouter
 
     from reyn.plugins.sample_line import register_router
@@ -225,63 +63,65 @@ def test_register_router_returns_apirouter_when_configured(monkeypatch):
     assert isinstance(router, APIRouter)
 
 
-# ── route end-to-end via TestClient ───────────────────────────────────
+# ── route mount ───────────────────────────────────────────────────────
+
+
+def test_build_router_mounts_webhook_line_path(monkeypatch):
+    """Tier 2: the router exposes POST ``/webhook/line``."""
+    from fastapi import FastAPI
+
+    from reyn.plugins.sample_line.webhook import build_router
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "x")
+    app = FastAPI()
+    app.include_router(build_router(target_agent="line_agent"))
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert "/webhook/line" in paths
+
+
+# ── end-to-end via TestClient + stubbed registry ──────────────────────
 
 
 @pytest.fixture()
 def _line_client(monkeypatch):
-    """FastAPI TestClient with a stubbed registry.
+    """FastAPI TestClient with stubbed registry; captures pushes."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
 
-    Mounts the LINE plugin's router on a fresh app so tests stay
-    hermetic (= no dependency on reyn.web.server module state).
-    """
-    pushes: list = []
+    pushed: list = []
 
     class _StubSession:
         async def _put_inbox(self, kind, payload):
-            pushes.append((kind, payload))
+            pushed.append((kind, payload))
             return "stub-msg-id"
 
     class _StubRegistry:
         async def ensure_running(self, name):
             return _StubSession()
 
-    def _stub_get_registry():
-        return _StubRegistry()
+        def list_names(self):
+            return ["line_agent"]
+
+        def exists(self, name):
+            return name == "line_agent"
 
     from reyn.web import deps
-    monkeypatch.setattr(deps, "_get_registry", _stub_get_registry)
+    monkeypatch.setattr(deps, "_get_registry", lambda: _StubRegistry())
     monkeypatch.setattr(deps, "_registry", None, raising=False)
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "channel-secret")
 
+    from reyn.plugins.sample_line.webhook import build_router
     app = FastAPI()
-    router = build_router(target_agent="line_agent")
-    app.include_router(router)
-    app.dependency_overrides[deps.get_registry] = _stub_get_registry
+    app.include_router(build_router(target_agent="line_agent"))
 
     client = TestClient(app)
-    client.pushes = pushes  # type: ignore[attr-defined]
+    client.pushed = pushed  # type: ignore[attr-defined]
     yield client
 
 
-def test_route_dispatches_signed_event_to_inbox(monkeypatch, _line_client):
-    """Tier 2 end-to-end: a properly-signed LINE message event reaches
-    the target agent's inbox with the right envelope.
-    """
-    secret = "channel-secret"
-    monkeypatch.setenv("LINE_CHANNEL_SECRET", secret)
-
-    body = json.dumps({
-        "destination": "U-bot",
-        "events": [{
-            "type": "message",
-            "replyToken": "TOK_xyz",
-            "source": {"type": "user", "userId": "U456"},
-            "message": {"type": "text", "text": "hello LINE bot"},
-        }],
-    }).encode()
+def _post_signed(client, secret: str, payload: dict):
+    body = json.dumps(payload).encode()
     sig = _sign(body, secret)
-
-    response = _line_client.post(
+    return client.post(
         "/webhook/line",
         content=body,
         headers={
@@ -289,28 +129,127 @@ def test_route_dispatches_signed_event_to_inbox(monkeypatch, _line_client):
             "X-Line-Signature": sig,
         },
     )
-    assert response.status_code == 200
-    assert response.json()["status"] == "ok"
-    assert response.json()["dispatched"] == 1
 
-    pushes = _line_client.pushes
-    assert len(pushes) == 1
-    kind, payload = pushes[0]
+
+def _user_text_event(text: str, user_id: str = "U456",
+                      reply_token: str = "TOK1") -> dict:
+    return {
+        "type": "message",
+        "replyToken": reply_token,
+        "source": {"type": "user", "userId": user_id},
+        "message": {
+            "type": "text",
+            "id": "M1",
+            "text": text,
+            "quoteToken": "Q1",
+        },
+        "timestamp": 1234,
+        "mode": "active",
+        "webhookEventId": "EV1",
+        "deliveryContext": {"isRedelivery": False},
+    }
+
+
+def test_user_text_message_dispatches_to_agent(_line_client):
+    """Tier 2 end-to-end: a 1:1 user text message reaches the agent
+    with sender=line:user:<id>.
+    """
+    response = _post_signed(_line_client, "channel-secret", {
+        "destination": "U-bot",
+        "events": [_user_text_event("hello LINE bot")],
+    })
+    assert response.status_code == 200
+    pushed = _line_client.pushed
+    assert len(pushed) == 1
+    kind, payload = pushed[0]
     assert kind == "user"
     assert payload["text"] == "hello LINE bot"
     assert payload["sender"] == "line:user:U456"
-    rt = payload["reply_to"]
-    assert isinstance(rt, ExternalRef)
-    assert rt.transport == "line"
-    assert rt.destination["reply_token"] == "TOK_xyz"
+
+    from reyn.chat.transport import ExternalRef
+    assert isinstance(payload["reply_to"], ExternalRef)
+    assert payload["reply_to"].transport == "line"
+    assert payload["reply_to"].destination["reply_token"] == "TOK1"
+    assert payload["reply_to"].destination["source_type"] == "user"
+    assert payload["reply_to"].destination["source_id"] == "U456"
 
 
-def test_route_rejects_bad_signature(monkeypatch, _line_client):
-    """Tier 2: wrong signature returns 401, no inbox push."""
-    monkeypatch.setenv("LINE_CHANNEL_SECRET", "real-secret")
-    body = json.dumps({"events": []}).encode()
+def test_group_source_text_message(_line_client):
+    """Tier 2: group source produces line:group:<groupId>:<userId>."""
+    event = {
+        "type": "message",
+        "replyToken": "TOK2",
+        "source": {"type": "group", "groupId": "G999", "userId": "U456"},
+        "message": {
+            "type": "text", "id": "M2", "text": "hi", "quoteToken": "Q2",
+        },
+        "timestamp": 1234, "mode": "active", "webhookEventId": "EV2",
+        "deliveryContext": {"isRedelivery": False},
+    }
+    response = _post_signed(_line_client, "channel-secret", {
+        "destination": "U-bot",
+        "events": [event],
+    })
+    assert response.status_code == 200
+    _, payload = _line_client.pushed[0]
+    assert payload["sender"] == "line:group:G999:U456"
+    assert payload["reply_to"].destination["source_id"] == "G999"
+
+
+def test_room_source_text_message(_line_client):
+    """Tier 2: room source produces line:room:<roomId>:<userId>."""
+    event = {
+        "type": "message",
+        "replyToken": "TOK3",
+        "source": {"type": "room", "roomId": "R777", "userId": "U456"},
+        "message": {
+            "type": "text", "id": "M3", "text": "hi room", "quoteToken": "Q3",
+        },
+        "timestamp": 1234, "mode": "active", "webhookEventId": "EV3",
+        "deliveryContext": {"isRedelivery": False},
+    }
+    response = _post_signed(_line_client, "channel-secret", {
+        "destination": "U-bot",
+        "events": [event],
+    })
+    assert response.status_code == 200
+    _, payload = _line_client.pushed[0]
+    assert payload["sender"] == "line:room:R777:U456"
+    assert payload["reply_to"].destination["source_id"] == "R777"
+
+
+def test_non_text_message_skipped(_line_client):
+    """Tier 2: sticker / image / etc. messages aren't dispatched
+    as text turns. line-bot-sdk parses them as separate Content
+    types; our handler only dispatches TextMessageContent.
+    """
+    event = {
+        "type": "message",
+        "replyToken": "TOK4",
+        "source": {"type": "user", "userId": "U1"},
+        "message": {
+            "type": "sticker",
+            "id": "M4",
+            "packageId": "1",
+            "stickerId": "1",
+            "stickerResourceType": "STATIC",
+            "quoteToken": "Q4",
+        },
+        "timestamp": 1234, "mode": "active", "webhookEventId": "EV4",
+        "deliveryContext": {"isRedelivery": False},
+    }
+    response = _post_signed(_line_client, "channel-secret", {
+        "destination": "U-bot",
+        "events": [event],
+    })
+    assert response.status_code == 200
+    assert _line_client.pushed == []
+
+
+def test_bad_signature_returns_401(_line_client):
+    """Tier 2: an incorrectly-signed body → 401, no inbox push."""
+    body = json.dumps({"destination": "U-bot", "events": []}).encode()
     bad_sig = _sign(body, "wrong-secret")
-
     response = _line_client.post(
         "/webhook/line",
         content=body,
@@ -320,84 +259,17 @@ def test_route_rejects_bad_signature(monkeypatch, _line_client):
         },
     )
     assert response.status_code == 401
-    assert len(_line_client.pushes) == 0
+    assert _line_client.pushed == []
 
 
-def test_route_rejects_missing_channel_secret(monkeypatch, _line_client):
-    """Tier 2: ``LINE_CHANNEL_SECRET`` env var unset → 503."""
-    monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
-    response = _line_client.post(
-        "/webhook/line",
-        content=b'{"events": []}',
-        headers={"Content-Type": "application/json"},
-    )
-    assert response.status_code == 503
-
-
-def test_route_acks_empty_events_array(monkeypatch, _line_client):
-    """Tier 2: a verify ping with empty events array returns 200
-    ``ignored`` without pushing to inbox.
+def test_empty_events_array_returns_ok(_line_client):
+    """Tier 2: an empty events array (= LINE verify ping) returns
+    200 ``dispatched=0`` without crashing.
     """
-    secret = "channel-secret"
-    monkeypatch.setenv("LINE_CHANNEL_SECRET", secret)
-    body = json.dumps({"events": []}).encode()
-    sig = _sign(body, secret)
-
-    response = _line_client.post(
-        "/webhook/line",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-Line-Signature": sig,
-        },
-    )
-    # Empty events array → 200 with dispatched=0.
+    response = _post_signed(_line_client, "channel-secret", {
+        "destination": "U-bot",
+        "events": [],
+    })
     assert response.status_code == 200
     assert response.json()["dispatched"] == 0
-    assert len(_line_client.pushes) == 0
-
-
-def test_route_dispatches_multiple_events_in_one_post(monkeypatch, _line_client):
-    """Tier 2: LINE bundles multiple events in a single webhook POST
-    when they fire close together; the handler iterates and pushes
-    each dispatchable one.
-    """
-    secret = "channel-secret"
-    monkeypatch.setenv("LINE_CHANNEL_SECRET", secret)
-
-    body = json.dumps({
-        "events": [
-            {
-                "type": "message",
-                "replyToken": "T1",
-                "source": {"type": "user", "userId": "U1"},
-                "message": {"type": "text", "text": "first"},
-            },
-            {
-                "type": "follow",   # skipped (= non-message)
-                "source": {"type": "user", "userId": "U1"},
-            },
-            {
-                "type": "message",
-                "replyToken": "T2",
-                "source": {"type": "user", "userId": "U1"},
-                "message": {"type": "text", "text": "second"},
-            },
-        ],
-    }).encode()
-    sig = _sign(body, secret)
-
-    response = _line_client.post(
-        "/webhook/line",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-Line-Signature": sig,
-        },
-    )
-    assert response.status_code == 200
-    assert response.json()["dispatched"] == 2
-    pushes = _line_client.pushes
-    assert len(pushes) == 2
-    assert pushes[0][1]["text"] == "first"
-    assert pushes[1][1]["text"] == "second"
+    assert _line_client.pushed == []

--- a/tests/plugins/sample_slack/test_webhook.py
+++ b/tests/plugins/sample_slack/test_webhook.py
@@ -1,20 +1,29 @@
-"""Tier 2: Slack inbound webhook router — FP-0041 #489 PR-D.
+"""Tier 2: sample_slack plugin (FP-0041 plugins-api PR-2).
 
-Tests the ``/webhook/slack`` route + the helpers it depends on:
+The hand-rolled webhook handler that landed in PR #522 has been
+replaced with ``slack-bolt`` (= Slack's official SDK). Bolt handles
+signing / event parsing / URL verification; the plugin just glues
+bolt events → Reyn ``push_to_agent``.
 
-  ``verify_slack_signature`` — HMAC-SHA256 + replay window
-  ``mint_envelope_from_slack_event`` — Slack payload → Reyn envelope
-  POST /webhook/slack — full route flow (URL verification / signing /
-    event dispatch / target agent resolution / inbox push)
+These tests are deliberately thin compared to the pre-refactor
+suite (= old tests pinned hand-rolled signing + envelope mint
+which are now bolt's responsibility). What we test now:
 
-The actual end-to-end "Slack message reaches LLM via agent inbox" is
-exercised via FastAPI TestClient + a registry mock that captures
-inbox pushes. The signing helper is unit-tested directly so the
-crypto path is verified independent of the route plumbing.
+  1. ``register_router`` entry-point contract (= missing config /
+     env / SDK → None opt-out).
+  2. ``build_router`` actually mounts a ``/webhook/slack`` route.
+  3. Round-trip integration via TestClient + a signed bolt-shaped
+     payload + stubbed registry: agent receives the right envelope
+     (= sender via ``make_sender``, ``ExternalRef`` reply_to with
+     channel + thread_ts).
+  4. Non-text / bot-echo events skip dispatch (= filter logic in
+     our ``_dispatch`` closure).
 
-Tier 2 because the webhook is the **only entry point** for Slack
-messages reaching Reyn. A regression in signing / parsing / inbox
-push silently breaks the entire Slack chat-transport.
+Tier 2 because the sample is the operator-facing reference for
+Slack chat-transport — a regression silently breaks the integration.
+
+When ``slack-bolt`` isn't installed, the SDK-using tests skip via
+``pytest.importorskip``.
 """
 from __future__ import annotations
 
@@ -22,371 +31,123 @@ import hashlib
 import hmac
 import json
 import time
-from typing import Any
 
 import pytest
 
-from reyn.chat.transport import ExternalRef
-from reyn.plugins.sample_slack.webhook import (
-    _SLACK_REPLAY_WINDOW_SECONDS,
-    build_router,
-    mint_envelope_from_slack_event,
-    verify_slack_signature,
-)
-
-# ── verify_slack_signature ────────────────────────────────────────────
+# Skip the SDK-dependent tests when slack-bolt isn't installed (= when
+# reyn is installed without the ``sample_slack`` extra).
+slack_bolt = pytest.importorskip("slack_bolt")
 
 
-def _sign(body: bytes, ts: str, secret: str) -> str:
-    """Helper: produce the Slack-format signature for body + timestamp."""
+def _sign(body: bytes, secret: str, ts: str) -> str:
+    """Build the Slack signature header value for body + timestamp."""
     base = f"v0:{ts}:".encode() + body
     digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
     return f"v0={digest}"
 
 
-def test_verify_signature_accepts_well_formed_request():
-    """Tier 2: a request signed with the correct secret + fresh timestamp
-    passes verification.
+# ── register_router entry point ────────────────────────────────────────
+
+
+def test_register_router_returns_none_when_target_agent_missing(monkeypatch):
+    """Tier 2: register_router returns None if config has no
+    ``target_agent`` — loader warns + skips mount.
     """
-    secret = "test-secret"
-    body = b'{"hello": "world"}'
-    ts = str(int(time.time()))
-    sig = _sign(body, ts, secret)
-
-    ok, detail = verify_slack_signature(
-        body=body, timestamp=ts, signature=sig, signing_secret=secret,
-    )
-    assert ok is True
-    assert detail == "ok"
+    from reyn.plugins.sample_slack import register_router
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")
+    assert register_router({}) is None
+    assert register_router({"target_agent": ""}) is None
 
 
-def test_verify_signature_rejects_stale_timestamp():
-    """Tier 2: a request older than the replay window is rejected as
-    ``stale`` — protects against replay attacks.
+def test_register_router_returns_none_when_signing_secret_missing(monkeypatch):
+    """Tier 2: register_router returns None if SLACK_SIGNING_SECRET
+    env var is unset.
     """
-    secret = "test-secret"
-    body = b'{"hello": "world"}'
-    # Stale timestamp = 10 minutes ago.
-    ts = str(int(time.time()) - 600)
-    sig = _sign(body, ts, secret)
-
-    ok, detail = verify_slack_signature(
-        body=body, timestamp=ts, signature=sig, signing_secret=secret,
-    )
-    assert ok is False
-    assert detail == "stale"
+    from reyn.plugins.sample_slack import register_router
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+    assert register_router({"target_agent": "x"}) is None
 
 
-def test_verify_signature_rejects_signature_mismatch():
-    """Tier 2: signature computed with a different secret fails the
-    constant-time compare with ``mismatch`` detail.
+def test_register_router_returns_apirouter_when_configured(monkeypatch):
+    """Tier 2: with both target_agent + signing secret, returns an
+    APIRouter (= loader mounts it).
     """
-    body = b'{"x":1}'
-    ts = str(int(time.time()))
-    # Sign with the wrong secret.
-    bad_sig = _sign(body, ts, "wrong-secret")
+    from fastapi import APIRouter
 
-    ok, detail = verify_slack_signature(
-        body=body, timestamp=ts, signature=bad_sig,
-        signing_secret="real-secret",
-    )
-    assert ok is False
-    assert detail == "mismatch"
+    from reyn.plugins.sample_slack import register_router
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")
+    router = register_router({"target_agent": "news_agent"})
+    assert isinstance(router, APIRouter)
 
 
-def test_verify_signature_rejects_missing_headers():
-    """Tier 2: missing timestamp or signature returns a clear reason."""
-    secret = "s"
-
-    ok, detail = verify_slack_signature(
-        body=b"", timestamp="", signature="sig", signing_secret=secret,
-    )
-    assert ok is False
-    assert detail == "missing-timestamp"
-
-    ok, detail = verify_slack_signature(
-        body=b"", timestamp="1234", signature="", signing_secret=secret,
-    )
-    assert ok is False
-    assert detail == "missing-signature"
+# ── route mounted on a FastAPI app ────────────────────────────────────
 
 
-def test_verify_signature_replay_window_boundary_inclusive():
-    """Tier 2: at exactly the window boundary (= 5 minutes), the
-    request still passes; one second past, it's stale. Pins the
-    boundary semantics.
+def test_build_router_mounts_webhook_slack_path(monkeypatch):
+    """Tier 2: ``build_router`` produces a router with ``/webhook/slack``
+    registered as POST. Without this, the operator's Slack App
+    Request URL hits 404.
     """
-    secret = "s"
-    body = b""
-    now = 1_000_000.0
-    ts_at_boundary = str(int(now) - _SLACK_REPLAY_WINDOW_SECONDS)
-    sig = _sign(body, ts_at_boundary, secret)
-    ok, _ = verify_slack_signature(
-        body=body, timestamp=ts_at_boundary, signature=sig,
-        signing_secret=secret, now=now,
-    )
-    assert ok is True
+    from fastapi import FastAPI
 
-    ts_past = str(int(now) - _SLACK_REPLAY_WINDOW_SECONDS - 1)
-    sig = _sign(body, ts_past, secret)
-    ok, detail = verify_slack_signature(
-        body=body, timestamp=ts_past, signature=sig,
-        signing_secret=secret, now=now,
-    )
-    assert ok is False
-    assert detail == "stale"
+    from reyn.plugins.sample_slack.webhook import build_router
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")
+
+    app = FastAPI()
+    app.include_router(build_router(target_agent="news_agent"))
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert "/webhook/slack" in paths
 
 
-# ── mint_envelope_from_slack_event ────────────────────────────────────
-
-
-def test_mint_envelope_for_app_mention():
-    """Tier 2: an ``app_mention`` event mints an envelope with
-    sender=slack:<user_id> and ExternalRef reply_to carrying
-    channel + thread_ts.
-    """
-    event = {
-        "event": {
-            "type": "app_mention",
-            "user": "U456",
-            "text": "<@U_BOT> help me",
-            "channel": "C123",
-            "ts": "1234.5678",
-        },
-    }
-    env = mint_envelope_from_slack_event(event)
-    assert env is not None
-    assert env["text"] == "<@U_BOT> help me"
-    assert env["sender"] == "slack:U456"
-    rt = env["reply_to"]
-    assert isinstance(rt, ExternalRef)
-    assert rt.transport == "slack"
-    assert rt.destination == {"channel": "C123", "thread_ts": "1234.5678"}
-
-
-def test_mint_envelope_preserves_existing_thread_ts():
-    """Tier 2: when the user replies inside an existing thread, the
-    envelope's reply_to.thread_ts is the thread's ts, NOT the
-    message's own ts — so the agent reply joins the right thread.
-    """
-    event = {
-        "event": {
-            "type": "message",
-            "user": "U456",
-            "text": "follow-up",
-            "channel": "C123",
-            "ts": "9999.0001",
-            "thread_ts": "1234.5678",  # original parent
-        },
-    }
-    env = mint_envelope_from_slack_event(event)
-    assert env is not None
-    assert env["reply_to"].destination["thread_ts"] == "1234.5678"
-
-
-def test_mint_envelope_skips_bot_echo():
-    """Tier 2: a ``bot_message`` subtype (= echo of bot's own post) is
-    NOT dispatched to inbox — prevents feedback loops where the bot
-    receives its own messages.
-    """
-    event = {
-        "event": {
-            "type": "message",
-            "subtype": "bot_message",
-            "bot_id": "B999",
-            "text": "I (the bot) just posted",
-            "channel": "C123",
-            "ts": "1.0",
-        },
-    }
-    assert mint_envelope_from_slack_event(event) is None
-
-
-def test_mint_envelope_skips_non_message_events():
-    """Tier 2: reaction / channel_join / app_home events produce no
-    envelope. Operator can subscribe to broad event scopes without
-    risking accidental dispatch.
-    """
-    for event_type in ("reaction_added", "channel_join", "app_home_opened"):
-        event = {"event": {"type": event_type, "user": "U1", "channel": "C1"}}
-        assert mint_envelope_from_slack_event(event) is None
-
-
-def test_mint_envelope_skips_empty_text():
-    """Tier 2: an event with no text (= whitespace or missing) is
-    skipped. Nothing to dispatch to the LLM.
-    """
-    event = {
-        "event": {
-            "type": "app_mention",
-            "user": "U1",
-            "channel": "C1",
-            "ts": "1.0",
-            "text": "   ",
-        },
-    }
-    assert mint_envelope_from_slack_event(event) is None
-
-
-def test_mint_envelope_handles_missing_user_field():
-    """Tier 2: events without a ``user`` (= system messages, channel
-    purpose updates) get sender=slack:unknown but still dispatch
-    if they have text — defensive about Slack edge cases.
-    """
-    event = {
-        "event": {
-            "type": "message",
-            "text": "hi",
-            "channel": "C1",
-            "ts": "1.0",
-        },
-    }
-    env = mint_envelope_from_slack_event(event)
-    assert env is not None
-    assert env["sender"] == "slack:unknown"
-
-
-# ── route end-to-end via TestClient ───────────────────────────────────
+# ── end-to-end: signed Slack event → Reyn agent inbox ─────────────────
 
 
 @pytest.fixture()
 def _slack_client(monkeypatch):
     """FastAPI TestClient with a stubbed AgentRegistry.
 
-    Builds a fresh minimal FastAPI app, mounts the sample_slack
-    plugin's router via ``build_router``, and overrides the registry
-    dependency to capture inbox pushes. Each test gets its own client
-    (= no shared state across tests). Avoids loading the full
-    ``reyn.web.server.app`` since the plugin would otherwise be
-    mounted only when the operator activates it via reyn.yaml.
+    Patches the reyn.plugins.api module so push_to_agent dispatches
+    to the stub registry; captures pushed envelopes for assertions.
     """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
-    pushes: list = []
+    pushed: list = []
 
     class _StubSession:
         async def _put_inbox(self, kind, payload):
-            pushes.append((kind, payload))
+            pushed.append((kind, payload))
             return "stub-msg-id"
 
     class _StubRegistry:
         async def ensure_running(self, name):
             return _StubSession()
 
-    def _stub_get_registry():
-        return _StubRegistry()
+        def list_names(self):
+            return ["news_agent"]
 
-    # Patch the deps module so build_router's dependency closure
-    # resolves to the stub.
+        def exists(self, name):
+            return name == "news_agent"
+
     from reyn.web import deps
-    monkeypatch.setattr(deps, "_get_registry", _stub_get_registry)
+    monkeypatch.setattr(deps, "_get_registry", lambda: _StubRegistry())
     monkeypatch.setattr(deps, "_registry", None, raising=False)
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "test-secret")
 
+    from reyn.plugins.sample_slack.webhook import build_router
     app = FastAPI()
-    router = build_router(target_agent="news_agent")
-    app.include_router(router)
-    app.dependency_overrides[deps.get_registry] = _stub_get_registry
+    app.include_router(build_router(target_agent="news_agent"))
 
     client = TestClient(app)
-    client.pushes = pushes  # type: ignore[attr-defined]
+    client.pushed = pushed  # type: ignore[attr-defined]
     yield client
 
 
-def test_route_url_verification_echoes_challenge(_slack_client):
-    """Tier 2 (#489 PR-D): the Slack URL verification handshake echoes
-    the challenge string back so api.slack.com can verify Reyn is
-    reachable + responding. This MUST work without signing — Slack
-    doesn't always sign the initial verify.
-    """
-    body = json.dumps({
-        "type": "url_verification",
-        "challenge": "abc123-test-challenge",
-    })
-    response = _slack_client.post(
-        "/webhook/slack",
-        content=body,
-        headers={"Content-Type": "application/json"},
-    )
-    assert response.status_code == 200
-    assert response.json() == {"challenge": "abc123-test-challenge"}
-
-
-def test_route_rejects_missing_signing_secret(monkeypatch, _slack_client):
-    """Tier 2: with no ``SLACK_SIGNING_SECRET`` env var set, the
-    route returns 503 instead of crashing. Operator forgot to
-    configure → clear error in logs.
-    """
-    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
-    body = json.dumps({
-        "event": {
-            "type": "app_mention", "user": "U1", "channel": "C1",
-            "text": "hi", "ts": "1.0",
-        },
-    })
-    response = _slack_client.post(
-        "/webhook/slack",
-        content=body,
-        headers={"Content-Type": "application/json"},
-    )
-    assert response.status_code == 503
-    assert "signing secret" in response.json()["error"].lower()
-
-
-def test_route_rejects_bad_signature(monkeypatch, _slack_client):
-    """Tier 2: a request with the wrong signature returns 401. Even
-    if the body looks like a valid event, Reyn won't dispatch.
-    """
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", "real-secret")
-    monkeypatch.setenv("SLACK_TARGET_AGENT", "test_agent")
-    body = json.dumps({
-        "event": {
-            "type": "app_mention", "user": "U1", "channel": "C1",
-            "text": "hi", "ts": "1.0",
-        },
-    }).encode()
+def _post_signed_event(client, secret: str, event_payload: dict):
+    body = json.dumps({"event": event_payload, "type": "event_callback"}).encode()
     ts = str(int(time.time()))
-    bad_sig = _sign(body, ts, "wrong-secret")
-    response = _slack_client.post(
-        "/webhook/slack",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-Slack-Request-Timestamp": ts,
-            "X-Slack-Signature": bad_sig,
-        },
-    )
-    assert response.status_code == 401
-
-
-def test_route_dispatches_signed_app_mention_to_inbox(
-    monkeypatch, _slack_client,
-):
-    """Tier 2 (#489 PR-D end-to-end): a properly-signed ``app_mention``
-    event reaches the target agent's inbox with the right envelope.
-
-    This is the **happy path** for the Slack chat-transport: Slack
-    user @mentions the bot → Reyn webhook verifies signing → mints
-    envelope with sender + ExternalRef reply_to → pushes to inbox.
-    PR-A dispatch attribution + LLM processing kick in from there.
-    """
-    secret = "real-secret"
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", secret)
-    monkeypatch.setenv("SLACK_TARGET_AGENT", "news_agent")
-
-    body = json.dumps({
-        "event": {
-            "type": "app_mention",
-            "user": "U456",
-            "text": "<@U_BOT> today's news?",
-            "channel": "C123",
-            "ts": "1234.5678",
-        },
-    }).encode()
-    ts = str(int(time.time()))
-    sig = _sign(body, ts, secret)
-
-    response = _slack_client.post(
+    sig = _sign(body, secret, ts)
+    return client.post(
         "/webhook/slack",
         content=body,
         headers={
@@ -395,101 +156,78 @@ def test_route_dispatches_signed_app_mention_to_inbox(
             "X-Slack-Signature": sig,
         },
     )
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
 
-    # One inbox push happened with the expected envelope.
-    pushes = _slack_client.pushes
-    assert len(pushes) == 1
-    kind, payload = pushes[0]
+
+def test_app_mention_dispatches_to_agent_inbox(_slack_client):
+    """Tier 2 end-to-end: an ``app_mention`` event signed correctly
+    reaches the target agent's inbox with the right envelope.
+    """
+    response = _post_signed_event(_slack_client, "test-secret", {
+        "type": "app_mention",
+        "user": "U456",
+        "text": "<@U_BOT> hello",
+        "channel": "C123",
+        "ts": "1234.5678",
+    })
+    assert response.status_code == 200
+    pushed = _slack_client.pushed
+    assert len(pushed) == 1
+    kind, payload = pushed[0]
     assert kind == "user"
-    assert payload["text"] == "<@U_BOT> today's news?"
+    assert payload["text"] == "<@U_BOT> hello"
     assert payload["sender"] == "slack:U456"
-    rt = payload["reply_to"]
-    assert isinstance(rt, ExternalRef)
-    assert rt.transport == "slack"
-    assert rt.destination == {"channel": "C123", "thread_ts": "1234.5678"}
+
+    from reyn.chat.transport import ExternalRef
+    assert isinstance(payload["reply_to"], ExternalRef)
+    assert payload["reply_to"].transport == "slack"
+    assert payload["reply_to"].destination == {
+        "channel": "C123",
+        "thread_ts": "1234.5678",
+    }
 
 
-def test_route_acks_non_dispatchable_events_with_200(
-    monkeypatch, _slack_client,
-):
-    """Tier 2: an event with no dispatchable payload (= reaction)
-    returns 200 with ``status="ignored"``. Slack won't retry.
+def test_message_event_with_thread_preserves_thread_ts(_slack_client):
+    """Tier 2: when the user replies in an existing thread,
+    ``reply_to.thread_ts`` is the thread's parent ts (= not the
+    message's own ts) so agent replies join the right thread.
     """
-    secret = "real-secret"
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", secret)
-
-    body = json.dumps({
-        "event": {
-            "type": "reaction_added", "user": "U1", "channel": "C1",
-        },
-    }).encode()
-    ts = str(int(time.time()))
-    sig = _sign(body, ts, secret)
-
-    response = _slack_client.post(
-        "/webhook/slack",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-Slack-Request-Timestamp": ts,
-            "X-Slack-Signature": sig,
-        },
-    )
+    response = _post_signed_event(_slack_client, "test-secret", {
+        "type": "message",
+        "user": "U456",
+        "text": "follow-up",
+        "channel": "C123",
+        "ts": "9999.0001",
+        "thread_ts": "1234.5678",
+    })
     assert response.status_code == 200
-    assert response.json() == {"status": "ignored"}
-    assert len(_slack_client.pushes) == 0
+    _, payload = _slack_client.pushed[0]
+    assert payload["reply_to"].destination["thread_ts"] == "1234.5678"
 
 
-def test_route_malformed_json_returns_400(monkeypatch, _slack_client):
-    """Tier 2: non-JSON body returns 400 (= operator misconfig / bad
-    network, not Reyn's fault).
+def test_bot_echo_message_is_not_dispatched(_slack_client):
+    """Tier 2: a message with ``subtype=bot_message`` (= our own bot
+    posting) is filtered out to prevent feedback loops.
     """
-    response = _slack_client.post(
-        "/webhook/slack",
-        content=b"not json",
-        headers={"Content-Type": "application/json"},
-    )
-    assert response.status_code == 400
+    _post_signed_event(_slack_client, "test-secret", {
+        "type": "message",
+        "subtype": "bot_message",
+        "bot_id": "B999",
+        "text": "I (bot) just posted",
+        "channel": "C123",
+        "ts": "1.0",
+    })
+    assert _slack_client.pushed == []
 
 
-# ── register_router (= plugin entry-point) ────────────────────────────
-
-
-def test_register_router_returns_none_when_target_agent_missing(monkeypatch):
-    """Tier 2: ``register_router`` (= the plugin entry-point) returns
-    ``None`` when ``target_agent`` is missing from config — the
-    loader logs a warning and the route is not mounted. Operator's
-    forgotten config surfaces in logs rather than crashing.
+def test_empty_text_message_is_not_dispatched(_slack_client):
+    """Tier 2: whitespace-only text doesn't dispatch (= no value
+    forwarding to the LLM, no envelope spam).
     """
-    from reyn.plugins.sample_slack import register_router
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")  # signing OK, target missing
-
-    assert register_router({}) is None
-    assert register_router({"target_agent": ""}) is None
-
-
-def test_register_router_returns_none_when_signing_secret_missing(monkeypatch):
-    """Tier 2: ``register_router`` returns ``None`` when
-    ``SLACK_SIGNING_SECRET`` env var is unset — clear operator
-    error in logs without crashing reyn web.
-    """
-    from reyn.plugins.sample_slack import register_router
-    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
-
-    assert register_router({"target_agent": "news_agent"}) is None
-
-
-def test_register_router_returns_apirouter_when_configured(monkeypatch):
-    """Tier 2: ``register_router`` returns a FastAPI ``APIRouter``
-    when both ``target_agent`` config + signing secret env are
-    present. The loader mounts this on the app.
-    """
-    from fastapi import APIRouter
-
-    from reyn.plugins.sample_slack import register_router
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", "x")
-
-    router = register_router({"target_agent": "news_agent"})
-    assert isinstance(router, APIRouter)
+    _post_signed_event(_slack_client, "test-secret", {
+        "type": "message",
+        "user": "U1",
+        "text": "   ",
+        "channel": "C1",
+        "ts": "1.0",
+    })
+    assert _slack_client.pushed == []


### PR DESCRIPTION
**[e2e-coder]** — FP-0041 #489 plugins-api **PR-2**: refactor the two sample webhook plugins to adopt their official OSS SDKs.

Builds on:
- PR-1   #528 (= `reyn.plugins.api` `push_to_agent` helper)
- PR-1b  #530 (= `list_agents` / `agent_exists` / `make_sender` discovery helpers)

## Summary

- **sample_slack**: hand-rolled HMAC verify + event dispatch (PR #522) → `slack-bolt` AsyncApp + `AsyncSlackRequestHandler`
- **sample_line**:  hand-rolled HMAC verify + event parse (PR #524) → `line-bot-sdk` v3 `WebhookParser` + typed events
- New optional-deps in `pyproject.toml`:
  - `reyn[sample_slack]` (= + `slack-bolt>=1.18`)
  - `reyn[sample_line]`  (= + `line-bot-sdk>=3.0`)
  - `reyn[all-samples]`  (= both)
- `register_router()` gracefully returns `None` when the SDK is not installed → loader logs + skips mount.
- Tests use `pytest.importorskip(...)` so framework-level tests still run without the SDKs.

Diff stat: **+637 / −1258** (net **−621 lines**) — most of the deletion is signing/parsing/dispatch now living in the SDKs.

## Why

- **Maintenance**: signing, event parsing, URL verification, retry dedup, OAuth (future) are now the SDK's responsibility, not Reyn's. Reyn maintainers don't track Slack/LINE API drift.
- **Operator confidence**: production fork-path is now "harden this sample" instead of "rewrite against the SDK first, then harden" — removes a step.
- **Plugin author guidance**: PR-1's `docs/plugins/authoring-guide.md` can now point at a real SDK-based example as the canonical shape.

## slack-bolt authorize note (= non-obvious)

Bolt's default `single_team_authorization` middleware probes Slack's `auth.test` at request time. Because Reyn dispatches outbound replies via the Slack MCP server (= not through bolt), we wire a custom no-op `authorize` callable that returns a stub `AuthorizeResult`, skipping the `auth.test` probe. Inbound dispatch works without a real bot token configured.

```python
async def _authorize(*args, **kwargs):
    return AuthorizeResult(
        enterprise_id=None, team_id=None, user_id=None,
        bot_user_id=None, bot_id=None, bot_token=bot_token,
    )

bolt_app = AsyncApp(signing_secret=signing_secret, authorize=_authorize)
```

## Test plan

- [x] `python -m pytest tests/plugins/ -q --tb=short --timeout=30` → **35 passed, 0 failed**
- [x] Full suite: `python -m pytest tests/ -q --tb=line --timeout=60` → **5075 passed, 5 skipped, 1 deselected, 2 xfailed, 1 xpassed** (199s) — no regressions
- [x] `register_router` opt-outs verified (= missing target_agent / missing env / missing SDK → None gracefully)
- [x] Slack: `app_mention` + `message` + bot-echo filter + empty-text filter + thread_ts preservation — all via signed payload + `AsyncSlackRequestHandler`
- [x] LINE: user / group / room source variants + sticker skip + bad-signature 401 + empty-events ping — all via signed payload + `WebhookParser`
- [x] READMEs updated to mention `pip install 'reyn[sample_slack]'` / `pip install 'reyn[sample_line]'`

## Out of scope (= deferred)

- Tier 2 (= `list_transports` discovery)
- Tier 3 (= subscription / lifecycle hooks)
- Lifecycle 5 gaps (= mount timing / teardown / hot reload / test impact / path conflict warning)

User has explicitly deferred these; will pick up in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)