### PR TITLE
fix(plan): _PlanStepHost propagates workspace + make_router_op_context to parent (B50 NF-W6-2)

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -605,6 +605,39 @@ class _PlanStepHost:
     def captured_text(self) -> str:
         return self._captured_text
 
+    # ── Workspace / op_context passthrough (B50 NF-W6-2 fix) ──────────────
+    #
+    # _PlanStepHost previously omitted ``workspace`` and
+    # ``make_router_op_context`` from the parent passthrough surface.
+    # Consequence: when a plan step's LLM called a router-side tool
+    # whose handler builds an OpContext (e.g. ``recall``, which dispatches
+    # ``index_query`` via op_runtime), RouterLoop built the ToolContext
+    # with ``workspace=getattr(self.host, "workspace", None)`` → None,
+    # and the recall handler fell into its minimal-context fallback that
+    # also propagates None, so ``index_query`` raised
+    # ``op_runtime context has no workspace``. Observed B50 W6-S3 plan
+    # step s4 (3x ``control_ir_failed kind=index_query``).
+    #
+    # Pass through both surfaces to the parent so plan-step tool calls
+    # see the same workspace + OpContext factory the chat router uses.
+    # The narrowing this facade provides is at the catalog / tool-set
+    # layer (= what tools the step can see); workspace itself is a
+    # global property of the agent and must not be narrowed.
+
+    @property
+    def workspace(self) -> Any:
+        return getattr(self._parent, "workspace", None)
+
+    @property
+    def permission_resolver(self) -> Any:
+        return getattr(self._parent, "permission_resolver", None)
+
+    def make_router_op_context(self) -> Any:
+        factory = getattr(self._parent, "make_router_op_context", None)
+        if factory is None:
+            return None
+        return factory()
+
 
 # ── Executor ────────────────────────────────────────────────────────────────
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -900,3 +900,86 @@ async def test_plan_step_retry_limit_exhaustion_asks_user_via_limit_handler():
         f"Expected s1 to succeed after user-approved extension; "
         f"step_failures={result2.step_failures}"
     )
+
+
+# ---------------------------------------------------------------------------
+# B50 NF-W6-2 fix: _PlanStepHost workspace + make_router_op_context passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_plan_step_host_propagates_workspace_from_parent():
+    """Tier 2: _PlanStepHost.workspace forwards to the parent host.
+
+    Without this propagation, RouterLoop inside a plan step builds the
+    ToolContext with ``workspace=None``; the recall handler then falls
+    into its minimal-context fallback that also propagates None, and
+    ``index_query`` raises ``op_runtime context has no workspace``.
+    Observed B50 W6-S3 plan step s4 (3x ``control_ir_failed
+    kind=index_query``).
+    """
+    parent = _FakeParentHost()
+    # Inject a fake workspace + permission_resolver onto parent.
+    parent.workspace = object()  # sentinel — any non-None object is fine
+    parent.permission_resolver = object()
+    plan = Plan(
+        goal="g",
+        steps=(PlanStep(id="s1", description="d", tools=()),),
+    )
+    host = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
+    assert host.workspace is parent.workspace
+    assert host.permission_resolver is parent.permission_resolver
+
+
+def test_plan_step_host_workspace_none_when_parent_has_none():
+    """Tier 2: when parent has no workspace attribute, the property
+    returns None rather than raising. This keeps test stubs working.
+    """
+    parent = _FakeParentHost()
+    # No workspace attribute on the bare fake host.
+    assert not hasattr(parent, "workspace")
+    plan = Plan(
+        goal="g",
+        steps=(PlanStep(id="s1", description="d", tools=()),),
+    )
+    host = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
+    assert host.workspace is None
+
+
+def test_plan_step_host_make_router_op_context_delegates_to_parent():
+    """Tier 2: _PlanStepHost.make_router_op_context delegates to the
+    parent's factory.
+
+    The recall handler's OpContext resolution preferentially uses
+    ``ctx.router_state.op_context_factory()`` (which is bound to
+    ``self.host.make_router_op_context`` at router init). Plan-step
+    hosts previously didn't define this method, so the factory bound
+    to ``None`` and recall fell into its workspace-less fallback.
+    """
+    parent = _FakeParentHost()
+    sentinel = object()
+
+    def _make() -> object:
+        return sentinel
+
+    parent.make_router_op_context = _make
+    plan = Plan(
+        goal="g",
+        steps=(PlanStep(id="s1", description="d", tools=()),),
+    )
+    host = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
+    assert host.make_router_op_context() is sentinel
+
+
+def test_plan_step_host_make_router_op_context_none_when_parent_lacks_factory():
+    """Tier 2: if the parent doesn't define make_router_op_context,
+    the plan-step facade returns None rather than raising — test
+    stubs / older hosts continue to work.
+    """
+    parent = _FakeParentHost()
+    assert not hasattr(parent, "make_router_op_context")
+    plan = Plan(
+        goal="g",
+        steps=(PlanStep(id="s1", description="d", tools=()),),
+    )
+    host = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
+    assert host.make_router_op_context() is None


### PR DESCRIPTION
**[dogfood-coder]** — closes the index_query workspace-missing bug observed in B50 W6-S3 (`plan_summary_across_n_files`) plan step s4. Adds `workspace` / `permission_resolver` properties and a `make_router_op_context` method to `_PlanStepHost` that all delegate to the parent host.

## Summary

- `src/reyn/chat/planner.py` — extend `_PlanStepHost` with 3 parent-passthrough members (workspace property, permission_resolver property, make_router_op_context method). Previously the facade silently dropped these, so RouterLoop inside a plan step built ToolContext with `workspace=None` and the recall handler's OpContext-resolution fallback couldn't recover.
- `tests/test_planner.py` — 4 new Tier-2 contract tests covering populated-parent and missing-attribute branches for both `workspace` and `make_router_op_context`.

## Bug trace (= context analysis from B50 W6-S3 events)

```
21:43:30  user_message_received  (W6-S3 prompt)
21:43:40  tool_called plan        → plan_emitted (4 steps)
21:43:40  plan_step_started s1
…
21:44:43  plan_step_completed s3
21:44:43  plan_step_started s4
21:44:46  tool_called recall      (= step s4 LLM calls recall)
21:44:46  permission_granted
21:44:46  control_ir_failed kind=index_query err="op_runtime context has no workspace…"
21:44:46  control_ir_failed kind=index_query err="op_runtime context has no workspace…"
21:44:46  control_ir_failed kind=index_query err="op_runtime context has no workspace…"
21:44:46  tool_returned recall    (failed)
21:44:57  plan_step_completed s4
21:44:57  plan_aggregated n_completed=4 n_failed=0
```

The `recall` tool dispatches to op_runtime; `index_query` raised because `ctx.workspace` was None. The ValueError trace explicitly says "calling tool (e.g. recall, drop_source) was invoked from a router-side path without a workspace" — and the router-side here is the plan-step RouterLoop, not the chat router.

### Why this only broke inside plan steps

The chat router's `RouterHostAdapter.make_router_op_context()` builds a proper `OpContext(workspace=Workspace(...), …)`. `recall`'s OpContext resolution preferentially calls `ctx.router_state.op_context_factory()` (which is bound to `host.make_router_op_context` at router init), so chat-router-side recall works.

`_PlanStepHost`'s parent-passthrough surface (in `planner.py:428+`) listed `events`, model resolution, web/file/mcp passthroughs, memory paths, and so on — but **not** `workspace` and **not** `make_router_op_context`. So inside a plan step:

```python
op_context_factory=getattr(self.host, "make_router_op_context", None)  # → None
workspace=getattr(self.host, "workspace", None)                          # → None
```

`recall` then fell through to its minimal-context fallback (`OpContext(workspace=ctx.workspace, …)`) and `index_query` raised.

## Retest evidence

- 4 new Tier-2 tests in `test_planner.py` covering both populated-parent and missing-attribute branches for `workspace` and `make_router_op_context` — all green.
- `pytest tests/ -q` → **5099 passed**, 6 skipped, 3 xfailed (= 5095 pre-fix + 4 new tests).
- `ruff check src/reyn/chat/planner.py` → clean.

## Out of scope (= separate B50 carry-over)

W6-S3 also failed to fire `chat_turn_completed_inline` after `plan_aggregated` — the synthesis turn that should have narrated the plan result back to the user never ran. The sibling W6-S1 run on the same worktree fired `plan_completion_injected` correctly, so this is not a universal break.

This issue sits downstream of the recall-failure path investigated here. If it persists after this fix lands (= recall stops polluting step s4's tool-call sequence with errors), it's a separate plan-runner / session-inbox-lifecycle bug that needs its own reproduction (likely on real Reyn rather than chain replay, since the chain replay tooling stubs `recall` differently and doesn't model the inbox loop).

## Test plan

- [x] Unit tests for both populated and missing parent attributes
- [x] Full pytest sweep (= 5099 passed)
- [x] ruff lint clean
- [ ] Manual: real Reyn run of a plan-mode query that calls `recall` from within a step (= e.g. "summarise the design docs in docs/concepts/") — confirm no `control_ir_failed kind=index_query` and `chat_turn_completed_inline` fires after aggregation
- [ ] Dogfood B51 batch will provide regression evidence on W6-S3 specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)