### PR TITLE
feat(tui): /find slash for conv pane history search (MVP)

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -169,6 +169,7 @@ from reyn.chat.slash import cost_inline as _cost_inline_mod  # noqa: E402, F401
 from reyn.chat.slash import docs_filter as _docs_filter_mod  # noqa: E402, F401
 from reyn.chat.slash import donut as _donut_mod  # noqa: E402, F401
 from reyn.chat.slash import expand as _expand_mod  # noqa: E402, F401
+from reyn.chat.slash import find as _find_mod  # noqa: E402, F401
 from reyn.chat.slash import help as _help_mod  # noqa: E402, F401
 from reyn.chat.slash import image as _image_mod  # noqa: E402, F401
 from reyn.chat.slash import matrix as _matrix_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/find.py
+++ b/src/reyn/chat/slash/find.py
@@ -1,0 +1,41 @@
+"""/find — search the conv pane buffer for a substring.
+
+Categorical UX gap fill (= "I said something about X earlier, where
+is it?"). Searches the current RichLog buffer for case-insensitive
+substring matches and jumps to the first one near the current
+scroll position. The "search what's visible in scrollback" scope
+is the natural TUI-internal boundary — agent-reply history past
+the ring-buffer trim lives in ``.reyn/events/agents/<name>/`` and
+is reachable via the right-panel Events tab + ``/list`` slash;
+this command surfaces just the in-pane content.
+
+Pattern: same shape as ``/copy`` — the slash command emits a
+sentinel ``__find__`` OutboxMessage with the raw query in
+``text``; the TUI app intercepts via ``_on_find`` in app_outbox,
+runs ``ConversationView.find_in_buffer`` against the live
+RichLog, scrolls to the nearest match, and writes a status line
+with the match count.
+
+Usage::
+
+    /find tokens     # find lines containing "tokens" (case-insensitive)
+    /find foo bar    # multi-word query (literal substring, not regex)
+    /find            # empty query → status reports usage
+"""
+from __future__ import annotations
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import slash
+
+
+@slash(
+    "find",
+    summary="Search the conv pane for a substring (/find <query>)",
+)
+async def find_cmd(session: "object", args: str) -> None:
+    # Forward the raw arg; the TUI handler validates and surfaces
+    # errors so we don't duplicate the parsing logic across the
+    # slash + outbox layers. Matches the ``/copy`` pattern.
+    await session._put_outbox(OutboxMessage(
+        kind="__find__", text=(args or "").strip(),
+    ))

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -168,6 +168,7 @@ class OutboxRouter:
             "__cost_inline_toggle__":   self._on_cost_inline_toggle,
             "__expand_last_reply__":    self._on_expand_last_reply,
             "__copy_last_reply__":      self._on_copy_last_reply,
+            "__find__":                 self._on_find,
             "__docs_filter__":          self._on_docs_filter,
             "__stream_start__":         self._on_stream_start,
             "__stream_chunk__":         self._on_stream_chunk,
@@ -519,6 +520,71 @@ class OutboxRouter:
                 "(install pbcopy / xclip / wl-copy / xsel)",
                 kind="error",
             )
+
+    def _on_find(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """`__find__` — /find slash; substring search across the RichLog buffer.
+
+        ``msg.text`` carries the raw query. Behaviour:
+          - empty query → status with usage hint
+          - 0 matches  → status ``"no matches for '<q>'"`` (= clear "I
+            searched but found nothing")
+          - ≥ 1 match  → scroll the log to the match nearest BELOW
+            the current scroll position (= "go down to where the
+            result is"; wraps to the first match when no downward
+            match exists) AND write a status line with the total
+            count + up to 5 line numbers
+
+        Search target: the live RichLog buffer (= what's currently
+        scrollable). History past the ``_RICHLOG_MAX_LINES`` trim is
+        outside scope — the right-panel Events tab + ``/list``
+        slash cover that. ``ConversationView.find_in_buffer``
+        encapsulates the substring scan + case-insensitive match.
+        """
+        query = (msg.text or "").strip()
+        if not query:
+            self._show_transient_status(
+                conv,
+                "usage: /find <query>",
+                kind="error",
+            )
+            return
+        matches = conv.find_in_buffer(query)
+        if not matches:
+            self._show_transient_status(
+                conv,
+                f"no matches for '{query}'",
+                kind="error",
+            )
+            return
+        # Pick the match nearest BELOW the current scroll position
+        # — feels like "scroll down to the result" rather than
+        # jumping anywhere arbitrarily. Wrap to the first match
+        # when nothing below.
+        target_idx = matches[0][0]
+        try:
+            log = conv._log()
+            current_y = int(getattr(log, "scroll_y", 0))
+            below = [m for m in matches if m[0] >= current_y]
+            target_idx = (below[0][0] if below else matches[0][0])
+            log.scroll_to(y=target_idx, animate=False)
+            # Suppress auto-scroll so the next outbox tick doesn't
+            # immediately yank the view back to the tail.
+            conv._user_scrolled = True
+        except Exception:
+            pass
+        # Compose the status line. Showing the first 5 line numbers
+        # gives the user a sense of distribution without overwhelming
+        # the 1-line sticky budget.
+        line_nums = [str(m[0] + 1) for m in matches[:5]]
+        if len(matches) > 5:
+            line_nums.append(f"+{len(matches) - 5} more")
+        self._show_transient_status(
+            conv,
+            f"{len(matches)} match{'es' if len(matches) != 1 else ''} for "
+            f"'{query}' · lines {', '.join(line_nums)}",
+        )
 
     def _on_docs_filter(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -871,6 +871,36 @@ class ConversationView(Widget):
         """Number of agent replies currently held in the /copy ring buffer."""
         return len(self._recent_replies)
 
+    def find_in_buffer(self, query: str) -> list[tuple[int, str]]:
+        """Return ``(line_idx, line_text)`` for every RichLog line matching ``query``.
+
+        Case-insensitive substring search across the live RichLog
+        buffer (= what's currently scrollable). Lines past the
+        ``_RICHLOG_MAX_LINES`` ring-buffer trim are NOT searched —
+        for older history the user has the right-panel Events tab +
+        the agent-side ``.reyn/events/agents/<name>/`` skill-run
+        directories. Returning the line index lets the caller scroll
+        the log to the match with ``log.scroll_to(y=...)``.
+
+        Empty ``query`` returns an empty list (= the caller treats
+        this as "nothing to search for", typically with a usage hint).
+
+        Each tuple's ``line_text`` carries the line's rendered plain
+        text (= via the Strip's ``.text`` property) so the caller can
+        surface a short preview alongside the line number without
+        re-walking the buffer.
+        """
+        q = (query or "").strip().lower()
+        if not q:
+            return []
+        out: list[tuple[int, str]] = []
+        log = self._log()
+        for idx, strip in enumerate(getattr(log, "lines", []) or []):
+            text = getattr(strip, "text", "") or ""
+            if q in text.lower():
+                out.append((idx, text))
+        return out
+
     def _write_log(self, text: Text) -> None:
         log = self._log()
         log.write(text)

--- a/tests/cli/test_conv_find_history_search.py
+++ b/tests/cli/test_conv_find_history_search.py
@@ -1,0 +1,184 @@
+"""Tier 2: /find slash command searches RichLog buffer (history search MVP).
+
+Categorical UX gap fill: searches the live RichLog buffer for
+case-insensitive substring matches, scrolls to the nearest match
+below the current scroll position, and writes a status line with
+the match count + line numbers.
+
+Public surfaces tested:
+  - ``ConversationView.find_in_buffer`` returns matching lines
+    (case-insensitive substring)
+  - empty query → empty result list
+  - end-to-end via ``OutboxRouter._on_find`` synthesised dispatch:
+    no matches → error status, matches present → status with
+    count, scroll position advances to match line
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_find_in_buffer_returns_substring_matches() -> None:
+    """Tier 2: substring match against the RichLog buffer is case-insensitive."""
+    from rich.text import Text
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv._log()
+        log.write(Text("first line about Apples"))
+        log.write(Text("second line — nothing here"))
+        log.write(Text("third line: apple pie"))
+        await pilot.pause()
+
+        matches = conv.find_in_buffer("apple")
+        # Two lines contain "apple" (case-insensitive: "Apples" + "apple pie").
+        assert len(matches) == 2, (
+            f"expected 2 matches for 'apple', got {len(matches)}: "
+            f"{[m[1] for m in matches]}"
+        )
+        # Tuple shape: (line_idx, line_text).
+        for line_idx, line_text in matches:
+            assert isinstance(line_idx, int)
+            assert "apple" in line_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_find_in_buffer_empty_query_returns_empty_list() -> None:
+    """Tier 2: empty / whitespace-only query → empty result (= safe no-op)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        from rich.text import Text
+        conv._log().write(Text("some content"))
+        await pilot.pause()
+        assert conv.find_in_buffer("") == []
+        assert conv.find_in_buffer("   ") == []
+
+
+@pytest.mark.asyncio
+async def test_on_find_no_matches_writes_error_status() -> None:
+    """Tier 2: query with zero matches → error-kind sticky status."""
+    from rich.text import Text
+
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        conv._log().write(Text("here are some words"))
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="nonexistent"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "no matches for 'nonexistent'" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_on_find_matches_writes_count_and_lines_in_status() -> None:
+    """Tier 2: match list status reports total + first ≤5 line numbers."""
+    from rich.text import Text
+
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        # 3 lines with "needle" + 2 without.
+        log = conv._log()
+        log.write(Text("first needle here"))
+        log.write(Text("unrelated"))
+        log.write(Text("second needle row"))
+        log.write(Text("another unrelated"))
+        log.write(Text("third needle entry"))
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="needle"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        body = snap["body"]
+        # 3 matches reported.
+        assert "3 matches for 'needle'" in body
+        # Line numbers surfaced (1-indexed for human reading).
+        assert "lines 1" in body and "3" in body and "5" in body
+
+
+@pytest.mark.asyncio
+async def test_on_find_empty_query_writes_usage_status() -> None:
+    """Tier 2: empty query → usage hint via error-kind status."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text=""),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "usage: /find" in snap["body"]
+
+
+def test_find_slash_command_is_registered() -> None:
+    """Tier 2: ``/find`` command appears in the slash registry.
+
+    Registration in ``slash/__init__.py`` is the pipe between
+    typing ``/find`` and triggering the TUI handler. Pin that the
+    decorator-registered command is reachable from the registry
+    (= the same surface the slash picker walks).
+    """
+    from reyn.chat.slash import REGISTRY
+
+    names = {c.name for c in REGISTRY.all_commands()}
+    assert "find" in names, (
+        f"/find should be registered; got commands: {sorted(names)}"
+    )


### PR DESCRIPTION
**[tui-coder]** — categorical gap fill: conv pane history search.

## Why

After 76 PR of polish, the largest remaining user-facing categorical gap (= "I said something about X earlier, where is it?") has no surfaced solution. Users can scroll back manually but there's no search affordance. This PR lands an MVP using the established ``/copy`` slash pattern.

## What

- ``/find <query>`` searches the live RichLog buffer (case-insensitive substring)
- Scrolls to the nearest match below current scroll position (wraps to first when nothing below)
- Status line surfaces the total count + first 5 line numbers (``+N more`` suffix when over)
- Empty query / no matches → error-kind sticky status with usage hint / "no matches for '<q>'"

## Scope

- Slash file is registration glue + sentinel emit only (= same shape as ``slash/copy.py``, no engine state touch). Stays in tui-coder scope under that precedent.
- Search target is the current RichLog buffer; pre-trim session history (= ``.reyn/events/agents/<name>/``) is out of scope — already reachable via the Events tab + ``/list``.
- Match cycle (Ctrl+G next / Ctrl+Shift+G prev) deferred to follow-on.

## Test plan

- [x] ruff check passes
- [x] 6 new Tier 2 tests
- [x] Existing 40 smoke tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)