### PR TITLE
fix(slash): /plan discard emits plan_aborted system outbox (#536)

### DIFF
--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -182,6 +182,24 @@ async def _discard_plan_run(session: "ChatSession", args: str) -> None:
             pass
         session.running_plans.pop(plan_id, None)
 
+    # 1.5. Emit plan_aborted system outbox so TUI subscribers (=
+    # AsyncStackPanel, PR #532) can clear their plan row. Placed
+    # before the journal record / chain notify so later steps
+    # raising doesn't leave the bottom-strip stale (#536).
+    try:
+        from reyn.chat.outbox import OutboxMessage
+        await session._put_outbox(OutboxMessage(
+            kind="system",
+            text=f"plan discarded · {plan_id}",
+            meta={"plan_id": plan_id, "source": "plan_aborted"},
+        ))
+    except Exception as exc:  # noqa: BLE001
+        import logging
+        logging.getLogger(__name__).warning(
+            "plan_aborted outbox emit on /plan discard failed for %s: %r",
+            plan_id, exc,
+        )
+
     # 2. Record plan_aborted (= prunes active_plan_ids, surfaces audit).
     try:
         await session._journal.record_plan_aborted(

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -204,6 +204,39 @@ async def test_plan_discard_deletes_decomposition_artifact(tmp_path, monkeypatch
     assert not artifact.exists()
 
 
+@pytest.mark.asyncio
+async def test_plan_discard_emits_plan_aborted_outbox(tmp_path, monkeypatch):
+    """Tier 2: /plan discard emits a system OutboxMessage with
+    ``meta.source == "plan_aborted"`` so AsyncStackPanel subscribers
+    can clear the plan row (#536).
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._journal.record_plan_started(
+        plan_id="p_aborted_emit", goal="g", n_steps=2,
+    )
+
+    consumed = await session._maybe_handle_slash(
+        "/plan discard p_aborted_emit",
+    )
+    assert consumed is True
+
+    msgs = _drain_outbox(session)
+    aborted = [
+        m for m in msgs
+        if m.kind == "system"
+        and (m.meta or {}).get("source") == "plan_aborted"
+    ]
+    assert len(aborted) == 1, (
+        f"expected one plan_aborted system emit, got {len(aborted)}: "
+        f"{[(m.kind, m.meta, m.text) for m in msgs]}"
+    )
+    assert aborted[0].meta.get("plan_id") == "p_aborted_emit"
+    assert "p_aborted_emit" in aborted[0].text
+
+
 # ── Usage / unknown sub-command ──────────────────────────────────────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — Fixes #536.

`/plan discard <id>` does the journal record / task cancel / artifact cleanup / chain-notify dance, but **never emits a `system` `OutboxMessage` with `meta.source == "plan_aborted"`**. PR #532's `OutboxRouter._on_system` is designed to dispatch plan_id-tagged system msgs to AsyncStackPanel's bottom-strip remove signal — without this emit, the plan row remains visible until session exit (= ghost row).

## Summary

- Add the missing `OutboxMessage(kind="system", source="plan_aborted")` emit in `slash/plan.py:_discard_plan`, placed between the task-cancel block and the journal record so the bottom-strip clears even if a later step raises.
- Uses `session._put_outbox` directly (= `reply` helper doesn't accept `meta`); wrapped in `try/except` + log warning to match the existing defensive pattern.
- New `test_plan_discard_emits_plan_aborted_outbox` (Tier 2) asserting envelope shape (= `meta.source` + `meta.plan_id` + text contains plan_id).

## What this PR does NOT do (= explicit out-of-scope)

- **TUI side**: `OutboxRouter._on_system` source check extension to `("plan_complete", "plan_aborted")` is a 1-line follow-up that tui-coder will pick up after this engine-side change lands.
- **Plan crash path**: `plan_runner._run_plan_task`'s `except BaseException` branch (= `clean_exit=False`) also leaks the row but is out of scope per the issue body. Same emit pattern applies; needs a separate PR.
- **`/plan resume` cancel side**: net-correct already because relaunch's `plan_summary` emit refreshes the row idempotently.

## Test plan

- [x] New test `test_plan_discard_emits_plan_aborted_outbox` passes (= Tier 2, stub session + outbox queue inspection)
- [x] `tests/test_plan_slash_command.py`: 15 passed (= +1 new)
- [x] Full suite: `python -m pytest tests/ -q --tb=line --timeout=60` → 5085 passed, 5 skipped, 1 deselected, 3 xfailed (= no regressions)

## References

- #536 (issue, tui-coder owner request → e2e-coder)
- PR #531 (AsyncStackPanel skill lifecycle wiring, merged)
- PR #532 (AsyncStackPanel plan lifecycle wiring, ghost-row gap deferred to this PR)
- Existing emit pattern: `src/reyn/chat/services/plan_runner.py:91, 154`
- Existing discard test pattern: `tests/test_plan_slash_command.py:test_plan_discard_records_plan_aborted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)