### PR TITLE
feat(tui): /find Ctrl+G match cycle navigation (#537 follow-on)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -130,6 +130,14 @@ class ReynTUIApp(App):
         Binding("alt+up", "conv_scroll_line_up", "Scroll up 1 line", priority=True, show=False),
         Binding("alt+down", "conv_scroll_line_down", "Scroll down 1 line", priority=True, show=False),
         Binding("alt+end", "conv_scroll_end", "Scroll to bottom", priority=True, show=False),
+        # ``/find`` cycle navigation. After ``/find <query>`` lands the
+        # first match, Ctrl+G cycles forward and Ctrl+Shift+G cycles
+        # backward through the remaining matches (with wrap). When no
+        # prior ``/find`` query is set, the action surfaces a usage hint
+        # rather than silently no-op'ing. ``priority=True`` so the keys
+        # win against any widget-level binding.
+        Binding("ctrl+g", "find_next", "Find next match", priority=True, show=False),
+        Binding("ctrl+shift+g", "find_prev", "Find prev match", priority=True, show=False),
     ]
 
     _REYN_THEME = Theme(
@@ -163,6 +171,10 @@ class ReynTUIApp(App):
         self._banner = banner
         self._no_restore = no_restore
         self._outbox_task: asyncio.Task | None = None
+        # OutboxRouter instance, kept on the app so actions outside the
+        # outbox loop (= Ctrl+G / Ctrl+Shift+G ``/find`` cycle navigation)
+        # can reach the find-cycle state living on the router.
+        self._outbox_router = None  # type: ignore[assignment]
         self._panel_visible = False
         self._cancel_event: asyncio.Event = asyncio.Event()
         # Most-recent "nothing-in-flight cancel" timestamp, used to
@@ -321,7 +333,11 @@ class ReynTUIApp(App):
         if self._agent_registry is None:
             return
         from .app_outbox import OutboxRouter
-        await OutboxRouter(self).run()
+        self._outbox_router = OutboxRouter(self)
+        try:
+            await self._outbox_router.run()
+        finally:
+            self._outbox_router = None
 
     def _mount_intervention(
         self,
@@ -1299,6 +1315,20 @@ class ReynTUIApp(App):
             conv.scroll_to_bottom()
         except Exception:
             pass
+
+    def action_find_next(self) -> None:
+        """Ctrl+G — cycle to the next ``/find`` match (wraps to first)."""
+        router = self._outbox_router
+        if router is None:
+            return
+        router.cycle_find(+1)
+
+    def action_find_prev(self) -> None:
+        """Ctrl+Shift+G — cycle to the previous ``/find`` match (wraps to last)."""
+        router = self._outbox_router
+        if router is None:
+            return
+        router.cycle_find(-1)
 
     def action_next_turn(self) -> None:
         """ctrl+n — scroll the conversation log to the next agent turn."""

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -157,6 +157,15 @@ class OutboxRouter:
         # timer before installing a new one, and cancel it outright when a
         # live thinking-status arrives so it can't kill the agent's spinner.
         self._transient_status_timer = None  # type: ignore[assignment]
+        # ``/find`` cycle navigation state. Set by ``_on_find`` when a
+        # query produces ≥ 1 match; consumed by ``cycle_find`` driven
+        # from the Ctrl+G / Ctrl+Shift+G app actions. Re-searches the
+        # live RichLog buffer on every cycle so buffer mutations (= new
+        # lines streamed in mid-cycle) don't leave stale indices. None
+        # query ⇒ no prior /find ran this session ⇒ Ctrl+G surfaces a
+        # usage hint rather than silently no-op'ing.
+        self._find_query: str | None = None
+        self._find_cursor_idx: int | None = None
         # Dispatch table — each entry maps a `msg.kind` to its handler.
         # Methods on `self` are bound, so we can reference them directly.
         self.HANDLERS: dict[str, Callable[..., str | None]] = {
@@ -534,7 +543,9 @@ class OutboxRouter:
             the current scroll position (= "go down to where the
             result is"; wraps to the first match when no downward
             match exists) AND write a status line with the total
-            count + up to 5 line numbers
+            count + up to 5 line numbers, AND seed the cycle state
+            so Ctrl+G / Ctrl+Shift+G can step forward/backward
+            through the remaining matches.
 
         Search target: the live RichLog buffer (= what's currently
         scrollable). History past the ``_RICHLOG_MAX_LINES`` trim is
@@ -552,6 +563,11 @@ class OutboxRouter:
             return
         matches = conv.find_in_buffer(query)
         if not matches:
+            # Forget any stale cycle state so a follow-up Ctrl+G
+            # reports the no-match condition for THIS query, not a
+            # ghost from a previous one.
+            self._find_query = None
+            self._find_cursor_idx = None
             self._show_transient_status(
                 conv,
                 f"no matches for '{query}'",
@@ -574,9 +590,15 @@ class OutboxRouter:
             conv._user_scrolled = True
         except Exception:
             pass
+        # Seed cycle state so Ctrl+G picks up from here.
+        self._find_query = query
+        self._find_cursor_idx = target_idx
         # Compose the status line. Showing the first 5 line numbers
         # gives the user a sense of distribution without overwhelming
-        # the 1-line sticky budget.
+        # the 1-line sticky budget. Same format the initial ``/find``
+        # PR introduced — match cycle (Ctrl+G) uses a shorter
+        # ``"match N/M · line K"`` shape so the overview stays here
+        # and the cycle just reports position.
         line_nums = [str(m[0] + 1) for m in matches[:5]]
         if len(matches) > 5:
             line_nums.append(f"+{len(matches) - 5} more")
@@ -584,6 +606,93 @@ class OutboxRouter:
             conv,
             f"{len(matches)} match{'es' if len(matches) != 1 else ''} for "
             f"'{query}' · lines {', '.join(line_nums)}",
+        )
+
+    def cycle_find(self, direction: int) -> None:
+        """Step to the next/previous ``/find`` match (Ctrl+G / Ctrl+Shift+G).
+
+        ``direction``: ``+1`` for forward (next), ``-1`` for backward (prev).
+
+        Behaviour:
+          - No prior ``/find`` query in this session → surface a usage
+            hint (= "no active /find query — try /find <text>"). Silent
+            no-op would leave the user thinking the keybinding is broken.
+          - Prior query had matches BUT the buffer has since mutated so
+            none survive → status ``"no matches for '<q>'"`` AND clear
+            the cycle state so a subsequent Ctrl+G after a new /find
+            starts fresh.
+          - Otherwise: re-run ``find_in_buffer`` (= cheap; bounded by
+            the RichLog ring buffer), locate the current cursor in the
+            sorted match list, advance by ``direction`` with wrap, scroll
+            the log to the new target, write status ``"match N/M for
+            '<q>' · line <ln>"`` and update the cursor.
+
+        Re-searching on every cycle keeps indices honest under streaming
+        — between two Ctrl+G presses the agent might have appended new
+        text that shifts line numbers; a cached match list would
+        scroll-to a stale offset and feel "drifty". The cost is one
+        substring scan per keypress (= O(N) over the bounded buffer).
+        """
+        if direction not in (-1, +1):
+            return
+        query = self._find_query
+        if not query:
+            try:
+                conv = self._app.query_one("#conversation", ConversationView)
+            except Exception:
+                return
+            self._show_transient_status(
+                conv,
+                "no active /find query — try /find <text>",
+                kind="error",
+            )
+            return
+        try:
+            conv = self._app.query_one("#conversation", ConversationView)
+        except Exception:
+            return
+        matches = conv.find_in_buffer(query)
+        if not matches:
+            self._find_query = None
+            self._find_cursor_idx = None
+            self._show_transient_status(
+                conv,
+                f"no matches for '{query}'",
+                kind="error",
+            )
+            return
+        # Locate the current cursor in the sorted match list. If the
+        # cursor's exact idx isn't in the list (= the line drifted out
+        # of the buffer, or the cursor was never set), fall back to
+        # "nearest by line index" so wrap-around still behaves
+        # predictably.
+        idxs = [idx for idx, _ in matches]
+        cursor = self._find_cursor_idx
+        if cursor is None or cursor not in idxs:
+            # Pick the closest position by line index so the next step
+            # feels continuous with the user's last viewport.
+            if cursor is None:
+                pos = 0
+            else:
+                pos = min(
+                    range(len(idxs)),
+                    key=lambda i: abs(idxs[i] - cursor),  # type: ignore[arg-type]
+                )
+        else:
+            pos = idxs.index(cursor)
+        new_pos = (pos + direction) % len(matches)
+        target_idx = matches[new_pos][0]
+        try:
+            log = conv._log()
+            log.scroll_to(y=target_idx, animate=False)
+            conv._user_scrolled = True
+        except Exception:
+            pass
+        self._find_cursor_idx = target_idx
+        self._show_transient_status(
+            conv,
+            f"match {new_pos + 1}/{len(matches)} for '{query}' "
+            f"· line {target_idx + 1}",
         )
 
     def _on_docs_filter(

--- a/tests/cli/test_find_cycle_navigation.py
+++ b/tests/cli/test_find_cycle_navigation.py
@@ -1,0 +1,317 @@
+"""Tier 2: Ctrl+G / Ctrl+Shift+G cycle through ``/find`` matches.
+
+Follow-on to PR #537 (= ``/find`` MVP). The MVP scrolled to the
+first below-cursor match and surfaced a summary status line, but
+left subsequent matches reachable only by re-running ``/find``
+(= no inter-match navigation). This wires:
+
+  - ``Ctrl+G``       → forward to the next match (wraps to first
+                       after the last)
+  - ``Ctrl+Shift+G`` → backward to the previous match (wraps to
+                       last before the first)
+
+State lives on the ``OutboxRouter`` instance (= ``_find_query`` +
+``_find_cursor_idx``) and is seeded by ``_on_find`` when a query
+yields ≥ 1 match. Re-runs ``find_in_buffer`` on every cycle so
+indices stay honest when the buffer mutates between presses.
+
+Public surfaces tested:
+  - ``OutboxRouter.cycle_find(+1)`` and ``cycle_find(-1)`` step
+    through matches and update the sticky status with a
+    ``"match N/M for '<q>' · line <ln>"`` body
+  - wrap-around at both ends
+  - usage hint when no prior ``/find`` query is set
+  - no-matches branch when the buffer mutated and the prior
+    query no longer hits anything (= cycle state is cleared so a
+    fresh ``/find`` starts clean)
+  - ``ctrl+g`` / ``ctrl+shift+g`` appear in the App bindings
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _seed_lines(conv, lines: list[str]) -> None:
+    """Helper: write Rich Text lines into the conv RichLog."""
+    from rich.text import Text
+    log = conv._log()
+    for line in lines:
+        log.write(Text(line))
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_forward_steps_through_matches() -> None:
+    """Tier 2: Ctrl+G after /find moves to the next match in order."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, [
+            "alpha needle 1",   # idx 0
+            "filler 1",         # idx 1
+            "beta needle 2",    # idx 2
+            "filler 2",         # idx 3
+            "gamma needle 3",   # idx 4
+        ])
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="needle"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        # Initial /find lands on the first below-cursor match = idx 0
+        assert router._find_cursor_idx == 0
+
+        # Cycle forward → next match (idx 2)
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert router._find_cursor_idx == 2
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "match 2/3" in snap["body"]
+        assert "'needle'" in snap["body"]
+        assert "line 3" in snap["body"]  # 1-indexed
+
+        # Cycle forward again → idx 4
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert router._find_cursor_idx == 4
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "match 3/3" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_forward_wraps_to_first() -> None:
+    """Tier 2: Ctrl+G past the last match wraps back to the first."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, [
+            "first match",    # idx 0
+            "filler",
+            "second match",   # idx 2
+        ])
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="match"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert router._find_cursor_idx == 0
+        # Forward to last, then forward again → wrap to first
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert router._find_cursor_idx == 2
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert router._find_cursor_idx == 0
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "match 1/2" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_backward_steps_and_wraps() -> None:
+    """Tier 2: Ctrl+Shift+G steps backward and wraps from first → last."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, [
+            "alpha hit",   # idx 0
+            "filler",
+            "beta hit",    # idx 2
+            "filler",
+            "gamma hit",   # idx 4
+        ])
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="hit"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert router._find_cursor_idx == 0
+
+        # Backward from first → wraps to last (idx 4)
+        router.cycle_find(-1)
+        await pilot.pause()
+        assert router._find_cursor_idx == 4
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "match 3/3" in snap["body"]
+
+        # Backward again → idx 2 (middle)
+        router.cycle_find(-1)
+        await pilot.pause()
+        assert router._find_cursor_idx == 2
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "match 2/3" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_without_prior_query_shows_usage_hint() -> None:
+    """Tier 2: Ctrl+G with no prior /find surfaces a usage hint."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No /find dispatched — cycle should report usage.
+        router = OutboxRouter(app)
+        assert router._find_query is None
+        router.cycle_find(+1)
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "no active /find query" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_handles_buffer_mutation_to_zero_matches() -> None:
+    """Tier 2: cycle after buffer mutated to drop all matches → no-match status.
+
+    After a successful /find seeds the cycle state, if the user
+    then runs Ctrl+L (= clear) or the buffer mutates so the query
+    no longer matches anything, cycling must surface the no-match
+    branch rather than NoneType-erroring or scrolling to a stale
+    line. State is also cleared so a subsequent /find starts fresh.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["alpha tag", "beta tag"])
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="tag"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert router._find_query == "tag"
+        assert router._find_cursor_idx is not None
+
+        # Wipe the buffer — Ctrl+L equivalent.
+        conv.clear()
+        await pilot.pause()
+
+        router.cycle_find(+1)
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "no matches for 'tag'" in snap["body"]
+        # State cleared so a fresh /find isn't shadowed.
+        assert router._find_query is None
+        assert router._find_cursor_idx is None
+
+
+@pytest.mark.asyncio
+async def test_find_next_prev_bindings_registered() -> None:
+    """Tier 2: ``ctrl+g`` and ``ctrl+shift+g`` are bound to find actions.
+
+    Pin both bindings + their action names so a rename / removal
+    surfaces here. ``action_find_next`` / ``action_find_prev``
+    are the app-side entry points that delegate to the router's
+    cycle state.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+
+    binds = {(b.key, b.action) for b in ReynTUIApp.BINDINGS}
+    assert ("ctrl+g", "find_next") in binds
+    assert ("ctrl+shift+g", "find_prev") in binds
+
+
+@pytest.mark.asyncio
+async def test_action_find_next_safe_when_router_absent() -> None:
+    """Tier 2: ``action_find_next`` is a silent no-op without an active router.
+
+    The router is set by ``_outbox_loop`` (= only when a registry is
+    attached). Without a registry the action must not raise — the
+    binding still fires from the App's BINDINGS even with no
+    backing router instance.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        # Router never started (no registry); attribute is None.
+        assert app._outbox_router is None
+        # Both actions must be safe no-ops.
+        app.action_find_next()
+        app.action_find_prev()
+
+
+@pytest.mark.asyncio
+async def test_initial_find_seeds_cycle_state() -> None:
+    """Tier 2: ``/find <q>`` seeds router state so Ctrl+G can pick up from there.
+
+    Before the cycle feature, ``_on_find`` left no state behind
+    and a subsequent Ctrl+G had no way to know what to step
+    through. This pins that the post-/find router state is
+    ``(query, cursor_idx)`` where cursor_idx is the first match.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["pear", "apple", "banana"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="apple"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert router._find_query == "apple"
+        assert router._find_cursor_idx == 1  # 'apple' is at line idx 1


### PR DESCRIPTION
**[tui-coder]** — `/find` MVP (= #537) follow-on. The MVP scrolled to the first below-cursor match and surfaced a count + line numbers, but left subsequent matches reachable only by re-running `/find` — no inter-match navigation. This adds Ctrl+G / Ctrl+Shift+G to step through them.

## Summary

- `Ctrl+G` → forward to next match (wraps to first after last)
- `Ctrl+Shift+G` → backward to previous match (wraps to last before first)
- Cycle state (`_find_query` + `_find_cursor_idx`) lives on the `OutboxRouter` instance, seeded by `_on_find` on a ≥ 1 match query
- Router is now exposed as `app._outbox_router` so the keybinding actions can reach it from outside the outbox loop
- `find_in_buffer` is re-run on every cycle so indices stay honest under streaming mutation between presses (= a cached match list would scroll to a stale offset and feel "drifty"). Cost is one substring scan per keypress over the bounded RichLog buffer.

## Edge cases

- **No prior `/find` query** → usage hint (`"no active /find query — try /find <text>"`) rather than silent no-op
- **Prior query had matches but buffer mutated to zero hits** → no-match status AND cycle state cleared so a fresh `/find` starts clean
- **Cursor line drifted out of the buffer** → fall back to nearest-by-line-index so wrap-around behaves predictably

## Why this layer

- The `OutboxRouter` already owns `_on_find` and `_show_transient_status` — putting cycle state next to the existing find handler keeps the search subsystem cohesive.
- Exposing `app._outbox_router` is the minimum surface change: 1 attribute on the App, 1 `try`/`finally` around the `run()` call. Keybinding actions just delegate (`router.cycle_find(±1)`); they do not duplicate the buffer access logic.
- Status format on the initial `/find` is unchanged — only the new cycle uses the terser `"match N/M for '<q>' · line <ln>"` shape so the overview stays on the entry path and the cycle just reports position.

## Test plan

- [x] `pytest tests/cli/test_find_cycle_navigation.py` — 8/8 pass (= forward stepping, forward wrap, backward stepping + wrap, usage hint, zero-match-after-mutation, bindings registered, safe no-op without router, initial /find seeds cycle state)
- [x] `pytest tests/cli/test_conv_find_history_search.py` — 6/6 pass (= MVP regression: no behavioral change to first-call status format)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40/40 pass
- [x] `pytest tests/cli/` — 535/535 pass
- [x] `ruff check src/reyn/chat/tui/app.py src/reyn/chat/tui/app_outbox.py tests/cli/test_find_cycle_navigation.py` — clean
- [x] Manual: run `reyn chat`, type `/find <substring>`, then mash Ctrl+G to cycle forward through all matches — status line should advance `"match N/M"` and the viewport should scroll to each match in turn. Ctrl+Shift+G should walk back.
- [x] (skipped — interactive verification deferred to author's local dogfood) wrap-behavior in real terminal across multiple wrap cycles

## Out of scope (deferred)

- Per-match in-line highlight rendering (= invert / colour the matched substring on the match line). The current MVP scrolls to the match line but does not visually mark which substring matched. Future PR if desired.
- Persistence of search history across `/find` invocations.
- Regex / case-sensitive opt-in.