### PR TITLE
fix(plan): plan_invalid self-correction loop (B51 NF-W6-3)

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sys
 import uuid
 from dataclasses import dataclass, field
@@ -103,6 +104,43 @@ _PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE = (
     "paths, header names, function names, line numbers, exact values). "
     "Do not call another tool. Write the report text now."
 )
+
+
+# B51 NF-W6-3 fix: directive template for the plan_invalid self-correction
+# loop. The router LLM gets the parser error message back inside a
+# user-role directive and is asked to re-emit a corrected plan call.
+#
+# Observed failure: weak-tier LLM (= flash-lite) generates a plan tool
+# call whose ``steps_json`` includes the user's quoted phrase verbatim
+# inside a step description, forgetting that the JSON-encoded outer
+# string requires inner ``"`` to be backslash-escaped. The JSON parser
+# fails (e.g. "Expecting ',' delimiter at char 445") and the plan
+# never spawns.
+#
+# Mitigation: the router loop intercepts the plan_invalid tool result,
+# formats this directive with the (sanitised) parser error, appends it
+# as a user-role message, and re-enters the LLM loop bounded by
+# ``safety.loop.plan_invalid_retries`` (= dedicated counter). The
+# closing line guards against a meta-loop where the LLM copies the
+# error text into the new steps_json and re-fails.
+_PLAN_INVALID_RETRY_DIRECTIVE_TEMPLATE = (
+    "Your previous plan() call failed validation: {error_message}\n"
+    "Common cause: unescaped \" inside step description / id / tools "
+    "strings. Re-emit the plan with all inner \" escaped as \\\". "
+    "Do not copy the original error text into the new steps_json."
+)
+
+
+def _build_plan_invalid_retry_directive(error_message: str) -> str:
+    """Render the plan_invalid retry directive with a sanitised error message.
+
+    Strips control characters (= LLM-injection safety: an attacker
+    crafting a steps_json that triggers a parser error embedding control
+    bytes should not be able to smuggle them into the retry prompt) and
+    caps the length so the directive stays bounded.
+    """
+    safe = re.sub(r"[\x00-\x1f\x7f]", "", error_message or "")[:500]
+    return _PLAN_INVALID_RETRY_DIRECTIVE_TEMPLATE.format(error_message=safe)
 
 # Exception types that must NOT be retried and must be re-raised to their
 # own safety-layer ask/abort path. Retrying them would cause double-ask or

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1209,6 +1209,7 @@ class RouterLoop:
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
+        plan_invalid_retries: int = 1,  # B51 NF-W6-3 — safety.loop.plan_invalid_retries
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
     ):
         self.host = host
@@ -1257,6 +1258,17 @@ class RouterLoop:
         # process — the directive plumbing lands in the codebase but no
         # default runtime behaviour change.
         self._empty_stop_retry_directive = empty_stop_retry_directive
+        # B51 NF-W6-3: plan_invalid self-correction retry cap. When the
+        # ``plan`` tool returns ``{status:error, error:{kind:
+        # plan_invalid}}`` (= the LLM's ``steps_json`` failed JSON
+        # validation, typically from unescaped ``"`` inside step
+        # description strings), the router loop appends a sanitised
+        # directive carrying the parser error and re-enters the LLM
+        # loop. This counter caps the per-turn directive injections so
+        # a persistently-failing LLM is bounded; the outer caps
+        # (``max_router_calls_per_turn`` + ``max_iterations``) still
+        # apply on top. ``0`` disables the retry (= pre-fix behaviour).
+        self._plan_invalid_max_retries = max(0, int(plan_invalid_retries))
         # Tier 2 test seam: when set, ``run()`` calls this callable instead of
         # the module-level ``call_llm_tools``. Allows real-fake injection
         # (= scripted async callable) without ``unittest.mock.patch`` — per
@@ -1587,6 +1599,12 @@ class RouterLoop:
         # prompt; the second empty stop falls through to the standard
         # "observe + surface" path).
         _empty_stop_retries: int = 0
+        # B51 NF-W6-3: plan_invalid retry counter. Incremented every time
+        # the plan tool returns ``{status:error, kind:plan_invalid}`` and
+        # the router injects a self-correction directive back into the
+        # message list. Bounded by ``self._plan_invalid_max_retries``
+        # (default 1 = one correction attempt per chat turn).
+        _plan_invalid_retries: int = 0
 
         for _iteration in range(self.max_iterations):
             resolved_model = host.resolve_model(self.router_model)
@@ -2108,6 +2126,46 @@ class RouterLoop:
                         )
                         if followup is not None:
                             messages.append(followup)
+
+                # B51 NF-W6-3: plan_invalid self-correction loop. When the
+                # plan tool returned ``{status:error, error:{kind:plan_invalid}}``
+                # the most common cause is the LLM forgetting to escape
+                # ``"`` inside step description strings (= weak-tier JSON
+                # generation failure mode, observed B50/B51 W6-S3 at ~60%
+                # rate on user queries containing quoted phrases). Append a
+                # sanitised directive carrying the parser error so the LLM
+                # gets one corrected attempt before falling through to the
+                # generic tool-error path. Bounded by
+                # ``self._plan_invalid_max_retries`` (= safety.loop config).
+                # Imported lazily so the existing top-level import surface
+                # of router_loop stays stable.
+                from reyn.chat.planner import _build_plan_invalid_retry_directive
+                plan_invalid_idx = next(
+                    (
+                        i
+                        for i, (tc, r) in enumerate(zip(tool_calls, tool_results))
+                        if tc["function"]["name"] == "plan"
+                        and isinstance(r, dict)
+                        and isinstance(r.get("error"), dict)
+                        and r["error"].get("kind") == "plan_invalid"
+                    ),
+                    None,
+                )
+                if (
+                    plan_invalid_idx is not None
+                    and _plan_invalid_retries < self._plan_invalid_max_retries
+                ):
+                    err_payload = tool_results[plan_invalid_idx]["error"]
+                    err_msg = str(err_payload.get("message") or "")
+                    directive = _build_plan_invalid_retry_directive(err_msg)
+                    messages.append({"role": "user", "content": directive})
+                    _plan_invalid_retries += 1
+                    self.host.events.emit(
+                        "router_plan_invalid_retry_injected",
+                        directive_length=len(directive),
+                        chain_id=self.chain_id,
+                        retry_count=_plan_invalid_retries,
+                    )
                 continue
 
             # Option F (ADR-0021): detect empty-stop before treating as text reply.

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -4233,6 +4233,14 @@ class ChatSession:
         # FP-0005: now async (consults safety.on_limit on hit).
         await self._check_and_increment_router_cap(user_text)
         from reyn.chat.router_loop import RouterLoop
+        # B51 NF-W6-3: plan_invalid self-correction cap, sourced from
+        # safety.loop.plan_invalid_retries (default 1). When set to 0
+        # the retry is disabled and the LLM sees the plain tool error.
+        _plan_invalid_retries_cap = getattr(
+            getattr(self._safety, "loop", None),
+            "plan_invalid_retries",
+            1,
+        )
         loop = RouterLoop(
             host=self._router_host, chain_id=chain_id, max_iterations=5,
             budget=self._budget_tracker,
@@ -4240,6 +4248,7 @@ class ChatSession:
             # mechanic as PR #265's plan-step wiring — directive plumbed
             # unconditionally, runtime gated by ``REYN_EMPTY_STOP_RETRY=1``.
             empty_stop_retry_directive=_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE,
+            plan_invalid_retries=_plan_invalid_retries_cap,
         )
         history = self._build_history_for_router()
         router_usage = await loop.run(user_text=user_text, history=history)

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -224,6 +224,25 @@ class LoopConfig:
     skill_calls_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
     skill_tokens_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
 
+    # B51 NF-W6-3 fix: plan() tool call parse-error self-correction loop.
+    #
+    # When the router LLM emits ``plan(args={steps_json: <malformed>})``
+    # and the plan tool returns ``{status: error, error: {kind:
+    # plan_invalid, ...}}``, the router loop appends a user-role
+    # directive carrying the error message + an "escape inner quotes"
+    # hint and re-enters the LLM loop so the LLM gets a chance to
+    # re-emit with valid JSON. ``0`` disables the retry (= the LLM
+    # receives the plain error tool result and decides next step
+    # itself, the pre-fix behaviour). ``1`` (= default) allows one
+    # directive-driven correction per chat turn.
+    #
+    # Dedicated counter rather than reusing ``max_router_calls_per_turn``
+    # so the operator can tune plan-revision attempts independently
+    # from the broader router-call cap. The natural outer bounds
+    # (``max_router_calls_per_turn`` + ``RouterLoop.max_iterations``)
+    # still apply on top.
+    plan_invalid_retries: int = 1
+
 
 @dataclass
 class TimeoutConfig:
@@ -2027,6 +2046,9 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         skill_tokens_per_chain=_build_cost_limit(
             loop_raw.get("skill_tokens_per_chain")
         ),
+        plan_invalid_retries=int(loop_raw.get(
+            "plan_invalid_retries", loop_defaults.plan_invalid_retries,
+        )),
     )
     timeout = TimeoutConfig(
         llm_call_seconds=float(timeout_raw.get(

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -983,3 +983,72 @@ def test_plan_step_host_make_router_op_context_none_when_parent_lacks_factory():
     )
     host = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
     assert host.make_router_op_context() is None
+
+
+# ---------------------------------------------------------------------------
+# B51 NF-W6-3: plan_invalid retry directive builder
+# ---------------------------------------------------------------------------
+
+
+def test_plan_invalid_retry_directive_includes_error_message():
+    """Tier 2: directive renders the parser error message verbatim
+    (sanitised) so the LLM has the failure context for self-correction.
+    """
+    from reyn.chat.planner import _build_plan_invalid_retry_directive
+
+    out = _build_plan_invalid_retry_directive(
+        "Expecting ',' delimiter at char 445"
+    )
+    assert "Expecting ',' delimiter at char 445" in out
+    # Mentions the actionable cue (= escape inner quotes).
+    assert "escape" in out.lower() or "\\\"" in out
+    # Includes the meta-loop guard.
+    assert "Do not copy the original error text" in out
+
+
+def test_plan_invalid_retry_directive_strips_control_chars():
+    """Tier 2: control bytes in the parser error must not survive into the
+    LLM prompt — they would either break the wire encoding or hide a
+    smuggled directive. The builder strips ``\\x00-\\x1f\\x7f`` before
+    embedding.
+    """
+    from reyn.chat.planner import _build_plan_invalid_retry_directive
+
+    out = _build_plan_invalid_retry_directive("foo\x00bar\x01baz\x7fend")
+    assert "foobarbazend" in out
+    # No raw control char survived in the embedded error segment. The
+    # template's own ``\n`` line break is legitimate structure, so the
+    # assertion excludes 0x09/0x0a/0x0d (= TAB/LF/CR) which are the only
+    # whitespace control chars the template may legitimately contain.
+    import re as _re
+    assert not _re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", out)
+
+
+def test_plan_invalid_retry_directive_caps_length():
+    """Tier 2: error message segment is capped at 500 chars so a verbose
+    parser trace can't blow the LLM directive budget.
+    """
+    from reyn.chat.planner import _build_plan_invalid_retry_directive
+
+    long_err = "x" * 5000
+    out = _build_plan_invalid_retry_directive(long_err)
+    # The error segment must be truncated; the directive boilerplate
+    # adds its own text but the embedded payload is bounded.
+    # Count consecutive 'x' run — must not exceed 500.
+    longest_x_run = max(
+        (len(m) for m in __import__("re").findall(r"x+", out)),
+        default=0,
+    )
+    assert longest_x_run <= 500
+
+
+def test_plan_invalid_retry_directive_handles_empty_input():
+    """Tier 2: defensive — empty / None error message still renders a
+    well-formed directive, just with an empty error segment.
+    """
+    from reyn.chat.planner import _build_plan_invalid_retry_directive
+
+    out_empty = _build_plan_invalid_retry_directive("")
+    out_none = _build_plan_invalid_retry_directive(None)  # type: ignore[arg-type]
+    assert "failed validation:" in out_empty
+    assert "failed validation:" in out_none

--- a/tests/test_safety_config.py
+++ b/tests/test_safety_config.py
@@ -70,12 +70,29 @@ safety:
     max_agent_hops: 5
     skill_calls_per_chain:
       hard_limit: 12
+    plan_invalid_retries: 2
 """.lstrip())
     cfg = load_config(cwd=isolated_project)
     assert cfg.safety.loop.max_phase_visits == 50
     assert cfg.safety.loop.max_router_calls_per_turn == 7
     assert cfg.safety.loop.max_agent_hops == 5
     assert cfg.safety.loop.skill_calls_per_chain.hard_limit == 12.0
+    assert cfg.safety.loop.plan_invalid_retries == 2
+
+
+def test_safety_loop_plan_invalid_retries_default_is_one(
+    isolated_project: Path,
+) -> None:
+    """Tier 2: ``safety.loop.plan_invalid_retries`` default is 1.
+
+    Out-of-the-box behaviour: one directive-driven correction attempt
+    after a plan_invalid tool result, before falling through to the
+    plain tool-error path. Operators dial up / down via
+    ``safety.loop.plan_invalid_retries`` in reyn.yaml.
+    """
+    _write_yaml(isolated_project / "reyn.yaml", "")
+    cfg = load_config(cwd=isolated_project)
+    assert cfg.safety.loop.plan_invalid_retries == 1
 
 
 def test_safety_timeout_keys_populate(


### PR DESCRIPTION
**[dogfood-coder]** — adds a self-correction loop at the router-loop layer so a plan() tool call that fails JSON validation gets one directive-driven retry before falling through to the plain tool-error path. New dedicated counter ``safety.loop.plan_invalid_retries`` (default 1) gates the retry; the surrounding caps (``max_router_calls_per_turn`` + ``RouterLoop.max_iterations``) remain authoritative.

## Summary

- ``src/reyn/config.py`` — new ``LoopConfig.plan_invalid_retries: int = 1`` field + safety-loop YAML loader wiring.
- ``src/reyn/chat/planner.py`` — ``_PLAN_INVALID_RETRY_DIRECTIVE_TEMPLATE`` + ``_build_plan_invalid_retry_directive(error_message)`` helper. The helper sanitises the LLM-supplied parser error (= strips control chars, caps at 500 chars) before the directive reaches the model wire.
- ``src/reyn/chat/router_loop.py`` — RouterLoop accepts ``plan_invalid_retries`` at construction; after each tool dispatch round, detects ``{status:error, error:{kind:plan_invalid}}`` results, emits ``router_plan_invalid_retry_injected``, appends the directive as a user-role message, increments a per-turn counter, and continues the loop.
- ``src/reyn/chat/session.py`` — source the cap from ``self._safety.loop.plan_invalid_retries`` and pass it to RouterLoop alongside the existing empty_stop directive.

## Why (= concrete malfunction evidence)

B51 W6-S3 (``plan_summary_across_n_files``) chain replay measured a **60% plan_invalid rate (3/5 baseline)** on a user query containing the quoted phrase 「OS is constant, skills are variable」. The weak-tier LLM (gemini-2.5-flash-lite) embeds the phrase verbatim inside the JSON-encoded step description, forgetting the outer string requires inner ``"`` to be ``\``-escaped. The plan tool returns ``{status:error, kind:plan_invalid}`` and the LLM typically gives up rather than self-correcting.

B50 → B51 trajectory traced this:
- B50 W6-S3: ``control_ir_failed kind=index_query`` × 3 (= upstream workspace bug, PR #535 fix).
- B51 W6-S3 (post-#535): ``control_ir_failed`` 0 hits (verified ✓) → new residual failure mode = LLM steps_json malformed JSON at char ~445.

The original NF-W6-2 was workspace propagation (closed by #535). The new NF-W6-3 is LLM JSON-generation stability — fixable by a self-correction directive at the router layer, since the parser error already carries the exact position information.

## Why the retry pattern (= not a description tweak)

A purely descriptive fix (= adding ``"escape inner \\"" 注意書き"`` to the plan tool's steps_json description) was chain-replay-measured at only **+10-15pt** improvement (= 53% → 60% OK), because flash-lite consistently forgets the escape on first emission no matter how the description is phrased. The retry-with-directive path lets the LLM see the *actual* parser error inline and re-emit — empirically the right shape for "LLM had the information needed but made a syntactic mistake".

## Safety stack (= multi-layer per user discipline)

| Layer | Mechanism | Default |
|---|---|---|
| 1. Dedicated counter | ``safety.loop.plan_invalid_retries`` | 1 |
| 2. Wider router cap | ``safety.loop.max_router_calls_per_turn`` | 3 |
| 3. Hard iteration bound | ``RouterLoop.max_iterations`` | 5 |
| 4. Error sanitisation | control-char strip + 500-char cap | hardcoded |
| 5. Meta-loop guard | directive includes "do not copy original error text" | hardcoded |
| 6. Audit | ``router_plan_invalid_retry_injected`` event w/ chain_id + retry_count | always |

The dedicated counter lets operators tune plan-revision attempts independently from the broader router-call cap — small enough to surface a misconfigured plan tool, large enough to handle a one-shot LLM JSON typo. Note: per user direction, this PR does NOT add an env-var gate — the previous ``REYN_EMPTY_STOP_RETRY`` env-gate was a model-bug workaround, whereas plan_invalid retry is a normal correction loop and belongs in the always-on config surface.

## Retest evidence (= chain replay, BEFORE PR open)

- ``_build_plan_invalid_retry_directive`` rendering on the actual B51 W6-S3 error: directive cleanly carries the parser position + escape hint + meta-loop guard.
- Chain-replay quote-escape patch (= description-only, prior measurement): 53% → 60% OK. Insufficient.
- This retry mechanism: empirical W6-S3 V flip rate will be measured in B52 dogfood batch — included here as the structural fix for the **mechanism**, not yet the V-rate measurement.
- ``pytest tests/ -q`` → **5082 passed**, 8 skipped, 3 xfailed.
- ``ruff check`` on the four edited modules → clean.

## Test plan

- [x] 4 Tier-2 tests on the directive builder (= ``test_plan_invalid_retry_directive_*``): error-message embedding, control-char sanitisation, length cap, empty/None input.
- [x] 2 Tier-2 tests on config loading (= ``test_safety_loop_keys_populate`` extended + ``test_safety_loop_plan_invalid_retries_default_is_one``).
- [x] Full pytest sweep (= 5082 passed).
- [x] ruff lint clean.
- [ ] Manual: real Reyn run of "Summarise principles.md focusing on 'OS is constant' perspective" — confirm second-attempt plan succeeds; the first plan_invalid + directive + retry sequence is visible in events log.
- [ ] B52 dogfood batch (= when dispatched) measures W6-S3 V-rate impact.

## Relation to recent SP work

- PR #526 (V18 SP baseline): 4-intent multi-step routing — landed.
- PR #533 (V19 SP task-path slice): single-target vs multi-target — landed.
- PR #535 (NF-W6-2 plan workspace): _PlanStepHost passthrough — landed.
- **This PR (NF-W6-3 plan_invalid retry): self-correction loop** — closes the residual W6-S3 failure mode exposed by the #535 fix.

These four together form the B50/B51 carry-over closure set on the plan-side surface.

## Out of scope / future

- W6-S3 V-rate impact measurement (= B52 dispatch).
- Generalising the retry-with-directive pattern to other tool validation errors (e.g. invoke_action shape mismatches). Deliberately scoped to plan_invalid here per the "concrete malfunction evidence drives the fix" discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)