### PR TITLE
feat(tui): /find Ctrl+G hint + Keys tab CONVERSATION grouping (#539 follow-on)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -598,15 +598,22 @@ class OutboxRouter:
         # the 1-line sticky budget. Same format the initial ``/find``
         # PR introduced — match cycle (Ctrl+G) uses a shorter
         # ``"match N/M · line K"`` shape so the overview stays here
-        # and the cycle just reports position.
+        # and the cycle just reports position. The trailing
+        # ``"· Ctrl+G next"`` hint surfaces the keybinding ONCE per
+        # /find so users discover cycle navigation without having to
+        # find it in the Keys tab; the hint is only useful when
+        # there's more than one match to step through, so it's
+        # gated on ``len(matches) > 1``.
         line_nums = [str(m[0] + 1) for m in matches[:5]]
         if len(matches) > 5:
             line_nums.append(f"+{len(matches) - 5} more")
-        self._show_transient_status(
-            conv,
+        body = (
             f"{len(matches)} match{'es' if len(matches) != 1 else ''} for "
-            f"'{query}' · lines {', '.join(line_nums)}",
+            f"'{query}' · lines {', '.join(line_nums)}"
         )
+        if len(matches) > 1:
+            body += " · Ctrl+G next"
+        self._show_transient_status(conv, body)
 
     def cycle_find(self, direction: int) -> None:
         """Step to the next/previous ``/find`` match (Ctrl+G / Ctrl+Shift+G).

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -26,7 +26,15 @@ _KEY_PRETTY: dict[str, str] = {
     "enter": "Enter", "tab": "Tab", "escape": "Esc", "space": "Space",
     "up": "↑", "down": "↓", "left": "←", "right": "→",
 }
-_CONVERSATION_KEYS = {"ctrl+p", "ctrl+n", "ctrl+shift+n", "ctrl+shift+p"}
+_CONVERSATION_KEYS = {
+    "ctrl+p", "ctrl+n", "ctrl+shift+n", "ctrl+shift+p",
+    # ``/find`` cycle navigation — semantically conv-pane scoped
+    # (= step through matches in the conv log), so they belong with
+    # the other conv-navigation keys (turn jump). Without this they
+    # would land in the generic GLOBAL group and be harder to
+    # discover next to their conceptual peers.
+    "ctrl+g", "ctrl+shift+g",
+}
 # ``j`` / ``k`` / ``space`` / ``c`` are routed via ``RightPanel.on_key``
 # (not ``app.BINDINGS``) and dispatch per-tab inside the panel handler,
 # so they are panel-universal — not docs-only. Wave-2 K1: previously

--- a/tests/cli/test_find_discoverability_hint.py
+++ b/tests/cli/test_find_discoverability_hint.py
@@ -1,0 +1,130 @@
+"""Tier 2: /find surfaces the Ctrl+G cycle keybinding for discoverability.
+
+Follow-on to PR #537 (/find MVP) + PR #539 (Ctrl+G match cycle).
+The cycle keybinding is invisible without either reading the
+Keys tab or the source — users who ran ``/find`` would never
+discover that Ctrl+G steps through subsequent matches. This pins:
+
+  1. When the initial /find lands ≥ 2 matches, the status line
+     trailing-appends ``"· Ctrl+G next"`` so the keybinding
+     surfaces on the exact UX moment users care about it.
+  2. The 1-match case suppresses the hint (= nothing to cycle to).
+  3. The Keys tab groups ``ctrl+g`` and ``ctrl+shift+g`` under
+     CONVERSATION (= their semantic home alongside Ctrl+P/N turn
+     jump), not the generic GLOBAL fallback.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_initial_find_status_includes_ctrl_g_hint_when_multi_match() -> None:
+    """Tier 2: status string includes ``Ctrl+G next`` when matches ≥ 2."""
+    from rich.text import Text
+
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        log = conv._log()
+        log.write(Text("alpha mark"))
+        log.write(Text("beta mark"))
+        log.write(Text("gamma mark"))
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="mark"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        body = snap["body"]
+        assert "3 matches for 'mark'" in body
+        assert "Ctrl+G next" in body
+
+
+@pytest.mark.asyncio
+async def test_initial_find_status_omits_hint_when_single_match() -> None:
+    """Tier 2: single-match status does NOT include the cycle hint.
+
+    With only one match, Ctrl+G would just cycle back to itself
+    (= len-1 wrap). Surfacing the hint would imply there's
+    "next" to go to. Suppress when ``len(matches) == 1``.
+    """
+    from rich.text import Text
+
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        log = conv._log()
+        log.write(Text("alpha lone-needle here"))
+        log.write(Text("beta unrelated"))
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="lone-needle"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "1 match for 'lone-needle'" in snap["body"]
+        assert "Ctrl+G" not in snap["body"]
+
+
+def test_keys_tab_groups_find_cycle_under_conversation() -> None:
+    """Tier 2: ctrl+g / ctrl+shift+g land in CONVERSATION group, not GLOBAL.
+
+    Pins the semantic home of the cycle keys. Falling back into
+    GLOBAL would scatter them away from the other conv-pane
+    navigation keys (Ctrl+P / Ctrl+N turn jump) which is exactly
+    where users will look first.
+    """
+    from reyn.chat.tui.widgets.right_panel.keys_tab import _key_group_for
+
+    assert _key_group_for("ctrl+g") == "CONVERSATION"
+    assert _key_group_for("ctrl+shift+g") == "CONVERSATION"
+
+
+@pytest.mark.asyncio
+async def test_keys_tab_render_includes_find_cycle_descriptions() -> None:
+    """Tier 2: rendered Keys tab markup includes the cycle keys with descriptions.
+
+    End-to-end check that the binding descriptions (= "Find next
+    match" / "Find prev match") flow through ``render_keys`` to
+    the visible markup so users actually see them in the panel.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        markup = render_keys(app)
+        assert "Find next match" in markup
+        assert "Find prev match" in markup
+        # Pretty-printed form of ctrl+g / ctrl+shift+g.
+        assert "⌃G" in markup


### PR DESCRIPTION
**[tui-coder]** — `/find` MVP (#537) + Ctrl+G cycle (#539) discoverability follow-on. The cycle keybinding was invisible without reading the Keys tab or source — users who ran `/find` would never discover Ctrl+G steps through subsequent matches.

## Summary

Two small fixes — both polish the discoverability surface of the existing `/find` UX:

1. **Status hint**: when the initial `/find` lands ≥ 2 matches, the status line trailing-appends `"· Ctrl+G next"`. Surfaces the keybinding at the exact UX moment users care about it (= just found 3 matches, what now?). Suppressed when only 1 match — Ctrl+G would wrap to itself, the hint would imply "next" exists when it doesn't.

2. **Keys tab grouping**: move `ctrl+g` / `ctrl+shift+g` from the fallback **GLOBAL** group into **CONVERSATION** (= their semantic home alongside Ctrl+P / Ctrl+N turn jump). Users looking for conv-pane navigation will scan CONVERSATION first; the cycle keys now sit next to their conceptual peers.

## Why this layer

- Hint-on-status is the cheapest discoverability win: it costs one line in `_on_find`, doesn't change the cycle-time status (= cycle uses a separate terser format introduced in #539), and gates correctly on `len(matches) > 1`.
- Keys tab group membership is a 4-line declarative change to `_CONVERSATION_KEYS`. No code path change — `_key_group_for` already routes through the set lookup.
- No new public surface, no behavioral change for users not running `/find`, no impact on the initial-find status text when there's exactly 1 match (= backwards compatible against the existing #537 regression test).

## Test plan

- [x] `pytest tests/cli/test_find_discoverability_hint.py` — 4/4 pass (multi-match hint present, single-match hint absent, group routing, render_keys output)
- [x] `pytest tests/cli/test_find_cycle_navigation.py` — 8/8 pass (= #539 cycle regression unaffected)
- [x] `pytest tests/cli/test_conv_find_history_search.py` — 6/6 pass (= #537 MVP regression: substring assertion `"3 matches for 'needle'" in body` still passes with the new hint suffix)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40/40 pass
- [x] `ruff check src/reyn/chat/tui/app_outbox.py src/reyn/chat/tui/widgets/right_panel/keys_tab.py tests/cli/test_find_discoverability_hint.py` — clean
- [x] Manual: run `reyn chat`, type `/find <substring>` against a buffer with ≥ 2 matches — status line should end with "· Ctrl+G next". Open the right panel Keys tab — Ctrl+G / Ctrl+Shift+G should appear under CONVERSATION, not GLOBAL.
- [x] (skipped — single-match case is hard to set up live; the Tier 2 single-match test pins the behavior)

## Out of scope

- Per-match in-line highlight (= invert / colour the matched substring on the scrolled-to line). Still deferred from #539; would require RichLog line-replacement which is non-trivial.
- Recurring hint on every cycle step. Once per /find is enough; repeating on every Ctrl+G press would feel naggy.