### PR TITLE
feat(tui): /save slash writes conv pane to a text file

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -178,6 +178,7 @@ from reyn.chat.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.chat.slash import plan as _plan_mod  # noqa: E402, F401
 from reyn.chat.slash import quit as _quit_mod  # noqa: E402, F401
 from reyn.chat.slash import reset as _reset_mod  # noqa: E402, F401
+from reyn.chat.slash import save as _save_mod  # noqa: E402, F401
 from reyn.chat.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.chat.slash import skills as _skills_mod  # noqa: E402, F401
 from reyn.chat.slash import tasks as _tasks_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/save.py
+++ b/src/reyn/chat/slash/save.py
@@ -1,0 +1,42 @@
+"""/save — write the conv pane to a text file.
+
+Categorical UX gap fill (= "I want to share / archive this
+conversation"). Snapshots the live RichLog buffer (= what's
+currently in the scrollback) to a plain-text file. Pre-trim
+history past ``_RICHLOG_MAX_LINES`` is out of scope — for full
+agent history the user has the right-panel Events tab + the
+``.reyn/events/agents/<name>/`` event log directories.
+
+Pattern: same shape as ``/copy`` and ``/find`` — the slash
+command emits a sentinel ``__save__`` OutboxMessage with the
+raw path argument in ``text``; the TUI app intercepts via
+``_on_save`` in app_outbox, walks
+``ConversationView.dump_buffer_text()``, and writes the result
+to disk.
+
+Usage::
+
+    /save                  # auto-generate ./reyn-conv-YYYYMMDD-HHMMSS.txt
+    /save notes.txt        # write to ./notes.txt (overwrites if exists)
+    /save ~/dump.txt       # write to home (~ is expanded)
+    /save /tmp/sess.txt    # absolute path
+"""
+from __future__ import annotations
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import slash
+
+
+@slash(
+    "save",
+    summary="Save the conv pane to a file (/save [path])",
+)
+async def save_cmd(session: "object", args: str) -> None:
+    # Forward the raw arg; the TUI handler resolves the path
+    # (expanduser / auto-name / overwrite) and surfaces errors via
+    # the sticky status so we don't duplicate I/O logic across the
+    # slash + outbox layers. Matches the ``/copy`` and ``/find``
+    # pattern.
+    await session._put_outbox(OutboxMessage(
+        kind="__save__", text=(args or "").strip(),
+    ))

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -178,6 +178,7 @@ class OutboxRouter:
             "__expand_last_reply__":    self._on_expand_last_reply,
             "__copy_last_reply__":      self._on_copy_last_reply,
             "__find__":                 self._on_find,
+            "__save__":                 self._on_save,
             "__docs_filter__":          self._on_docs_filter,
             "__stream_start__":         self._on_stream_start,
             "__stream_chunk__":         self._on_stream_chunk,
@@ -693,6 +694,87 @@ class OutboxRouter:
             conv,
             f"match {new_pos + 1}/{len(matches)} for '{query}' "
             f"· line {target_idx + 1}",
+        )
+
+    def _on_save(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """`__save__` — /save slash; write the conv pane buffer to a file.
+
+        ``msg.text`` carries the raw path argument (may be empty,
+        relative, absolute, or ``~``-prefixed). Behaviour:
+          - empty arg → auto-generate ``./reyn-conv-YYYYMMDD-HHMMSS.txt``
+            in the current working directory
+          - relative path → resolved relative to cwd
+          - ``~/foo.txt`` → expanded against the user's home
+          - existing file → overwritten silently (slash UX has no
+            confirmation channel; the user typed the path)
+
+        On success: status ``"saved N lines to <path>"``. On failure
+        (parent dir missing, permission denied, …): error-kind status
+        with the exception class + message. The file write is
+        synchronous because the buffer is bounded (≤ a few thousand
+        lines), so blocking the outbox loop for ≤ a few ms is fine —
+        no need for the ``/copy`` subprocess-offload pattern.
+        """
+        from datetime import datetime
+        from pathlib import Path
+
+        arg = (msg.text or "").strip()
+        if arg:
+            try:
+                target = Path(arg).expanduser()
+            except Exception as exc:
+                self._show_transient_status(
+                    conv, f"/save: bad path: {exc}", kind="error",
+                )
+                return
+        else:
+            stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            target = Path.cwd() / f"reyn-conv-{stamp}.txt"
+
+        # Resolve to absolute for the status line so the user always
+        # sees where the file landed (= ``./notes.txt`` is ambiguous
+        # depending on cwd; the absolute form is unambiguous).
+        try:
+            abs_target = target.resolve() if target.is_absolute() else (
+                Path.cwd() / target
+            ).resolve()
+        except Exception:
+            abs_target = target
+
+        lines = conv.dump_buffer_text()
+        body = "\n".join(lines)
+        # Trailing newline so POSIX tools (``cat`` / ``less`` / ``wc -l``)
+        # report a sane line count and the final line isn't headless.
+        if body and not body.endswith("\n"):
+            body += "\n"
+
+        try:
+            target.write_text(body, encoding="utf-8")
+        except FileNotFoundError as exc:
+            self._show_transient_status(
+                conv,
+                f"/save: parent dir missing: {exc.filename or target.parent}",
+                kind="error",
+            )
+            return
+        except PermissionError:
+            self._show_transient_status(
+                conv, f"/save: permission denied: {abs_target}", kind="error",
+            )
+            return
+        except OSError as exc:
+            self._show_transient_status(
+                conv, f"/save: {type(exc).__name__}: {exc}", kind="error",
+            )
+            return
+
+        self._show_transient_status(
+            conv,
+            f"saved {len(lines)} line{'s' if len(lines) != 1 else ''} "
+            f"to {abs_target}",
+            duration=3.0,
         )
 
     def _on_docs_filter(

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -901,6 +901,23 @@ class ConversationView(Widget):
                 out.append((idx, text))
         return out
 
+    def dump_buffer_text(self) -> list[str]:
+        """Return the plain-text rendering of every line in the RichLog buffer.
+
+        Sibling to :meth:`find_in_buffer` — same buffer scope (= the
+        live, scrollable RichLog content; not historical events past
+        ``_RICHLOG_MAX_LINES``), but returns the full ordered list
+        without filtering. Used by ``/save`` to materialise the conv
+        pane to a text file. Each entry is a single line (= no
+        embedded newlines), already stripped of ANSI / Rich markup
+        by Strip's ``.text`` property.
+        """
+        log = self._log()
+        return [
+            getattr(strip, "text", "") or ""
+            for strip in (getattr(log, "lines", []) or [])
+        ]
+
     def _write_log(self, text: Text) -> None:
         log = self._log()
         log.write(text)

--- a/tests/cli/test_conv_save_to_file.py
+++ b/tests/cli/test_conv_save_to_file.py
@@ -1,0 +1,283 @@
+"""Tier 2: /save writes the conv pane buffer to a text file.
+
+Categorical UX gap fill — "I want to share / archive this
+conversation". Snapshots the live RichLog buffer to a plain-text
+file. Mirrors the ``/copy`` + ``/find`` slash pattern: the slash
+command emits a sentinel ``__save__`` OutboxMessage with the
+path arg; the TUI handler resolves the path and writes the file.
+
+Public surfaces tested:
+  - ``ConversationView.dump_buffer_text`` returns the live buffer
+    as a list of plain-text lines
+  - ``OutboxRouter._on_save`` writes the buffer to:
+      * explicit path
+      * auto-generated path when arg is empty
+      * ``~``-expanded path
+  - error branches: permission denied / parent-dir-missing →
+    error-kind status, no file written
+  - empty buffer → file created with 0 lines (= status reports 0)
+  - status surfaces line count + absolute path
+  - ``/save`` slash command is registered in the slash registry
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from rich.text import Text
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _seed_lines(conv, lines: list[str]) -> None:
+    """Helper: write Rich Text lines into the conv RichLog."""
+    log = conv._log()
+    for line in lines:
+        log.write(Text(line))
+
+
+@pytest.mark.asyncio
+async def test_dump_buffer_text_returns_lines_in_order() -> None:
+    """Tier 2: ``dump_buffer_text`` returns the buffer in insertion order."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        _seed_lines(conv, ["first", "second", "third"])
+        await pilot.pause()
+        dump = conv.dump_buffer_text()
+        # The conv pane may have prelude lines (banner / today header)
+        # before the seeded content. Pin only that the seeded content
+        # appears in order, not the absolute index.
+        idx_first = next(i for i, t in enumerate(dump) if t == "first")
+        idx_second = next(i for i, t in enumerate(dump) if t == "second")
+        idx_third = next(i for i, t in enumerate(dump) if t == "third")
+        assert idx_first < idx_second < idx_third
+
+
+@pytest.mark.asyncio
+async def test_on_save_writes_to_explicit_path(tmp_path: Path) -> None:
+    """Tier 2: /save with an explicit path writes the buffer to that file."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    target = tmp_path / "dump.txt"
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["alpha", "beta", "gamma"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_save(
+            OutboxMessage(kind="__save__", text=str(target)),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert target.exists(), "file should be created"
+        content = target.read_text(encoding="utf-8")
+        assert "alpha" in content
+        assert "beta" in content
+        assert "gamma" in content
+        # Trailing newline for POSIX-tool friendliness.
+        assert content.endswith("\n")
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "saved" in snap["body"]
+        assert str(target.resolve()) in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_on_save_auto_generates_path_when_arg_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: empty arg → auto-named file in cwd matching reyn-conv-*.txt."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    # Run with cwd = tmp_path so the auto-generated file lands there.
+    monkeypatch.chdir(tmp_path)
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["payload"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_save(
+            OutboxMessage(kind="__save__", text=""),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        created = list(tmp_path.glob("reyn-conv-*.txt"))
+        assert len(created) == 1, (
+            f"expected one auto-named file, got {created}"
+        )
+        content = created[0].read_text(encoding="utf-8")
+        assert "payload" in content
+
+
+@pytest.mark.asyncio
+async def test_on_save_expands_tilde(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ``~/foo.txt`` is expanded against $HOME."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    # Point HOME at tmp_path so the test never touches the real home dir.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["tilde line"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_save(
+            OutboxMessage(kind="__save__", text="~/dump.txt"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        expected = tmp_path / "dump.txt"
+        assert expected.exists(), (
+            f"~/dump.txt should expand to {expected}; "
+            f"cwd contents: {list(tmp_path.iterdir())}"
+        )
+        assert "tilde line" in expected.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_on_save_parent_dir_missing_emits_error(tmp_path: Path) -> None:
+    """Tier 2: missing parent dir → error status, no file written.
+
+    Slash UX should not silently create deep directory chains; the
+    error message names the missing parent so the user can fix it.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    bad = tmp_path / "no-such-dir" / "out.txt"
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["x"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_save(
+            OutboxMessage(kind="__save__", text=str(bad)),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert not bad.exists()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "/save:" in snap["body"]
+        # The missing parent path should be surfaced for actionability.
+        assert "no-such-dir" in snap["body"] or "missing" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_on_save_overwrites_existing_file(tmp_path: Path) -> None:
+    """Tier 2: pre-existing file at target path is overwritten silently.
+
+    The slash UX has no confirmation channel — the user typed the
+    path knowing it. ``write_text`` semantics match: truncate +
+    write. Pin the behavior so a future "refuse to overwrite"
+    safety policy is a deliberate decision.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    target = tmp_path / "existing.txt"
+    target.write_text("stale content\n", encoding="utf-8")
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed_lines(conv, ["fresh content"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_save(
+            OutboxMessage(kind="__save__", text=str(target)),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        content = target.read_text(encoding="utf-8")
+        assert "stale content" not in content
+        assert "fresh content" in content
+
+
+def test_save_slash_command_is_registered() -> None:
+    """Tier 2: ``/save`` command appears in the slash registry.
+
+    Pins the registration glue — without the import line in
+    ``slash/__init__.py``, the decorator never runs and the user's
+    typed ``/save`` falls through to "unknown command".
+    """
+    from reyn.chat.slash import REGISTRY
+
+    names = {c.name for c in REGISTRY.all_commands()}
+    assert "save" in names, (
+        f"/save should be registered; got commands: {sorted(names)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_save_empty_buffer_writes_zero_line_file(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: empty conv pane → file exists (possibly with no content)."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    target = tmp_path / "empty.txt"
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        conv.clear()
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_save(
+            OutboxMessage(kind="__save__", text=str(target)),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        # File should exist even when buffer is empty post-clear.
+        assert target.exists()
+        # Status should report the line count (0 or low) + path.
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert "saved" in snap["body"]
+        assert "line" in snap["body"]


### PR DESCRIPTION
**[tui-coder]** — Categorical UX gap fill. Currently there's no in-TUI way to materialise the conv pane to a file; users either screenshot or copy/paste window contents. Same pattern as /copy and /find: slash → sentinel → TUI handler.

## Summary

```
/save                  → ./reyn-conv-YYYYMMDD-HHMMSS.txt
/save notes.txt        → ./notes.txt
/save ~/dump.txt       → expanded against $HOME
/save /tmp/sess.txt    → absolute path
```

- Snapshots the live RichLog buffer (= what's currently scrollable) — same surface `/find` searches. Pre-trim history past `_RICHLOG_MAX_LINES` stays out of scope; for full agent history the user has the right-panel Events tab + `.reyn/events/agents/<name>/`.
- New `ConversationView.dump_buffer_text()` helper returns the buffer as `list[str]` (mirrors `find_in_buffer` shape).
- Synchronous write — the buffer is bounded (≤ a few thousand lines), so blocking the outbox loop for ≤ a few ms is fine. No `/copy` subprocess-offload pattern needed.
- Existing files are overwritten silently (slash UX has no confirmation channel; the user typed the path).
- Trailing newline appended so POSIX tools (`cat` / `less` / `wc -l`) report a sane line count.

## Error branches → error-kind sticky status, no file written

- parent dir missing → `"parent dir missing: <path>"`
- permission denied  → `"permission denied: <path>"`
- any other OSError  → `"<exception class>: <message>"`

## Why this layer

- TUI-internal — only touches `chat/slash/save.py` (new), `chat/slash/__init__.py` (1-line register), `chat/tui/app_outbox.py` (1-line dispatch + handler), `chat/tui/widgets/conversation.py` (new helper). No engine state, no session state, no event log write — just buffer-to-disk dump.
- Slash + handler layer split matches `/copy` and `/find` exactly. The slash file is registration-only; all real work happens in the handler so I/O logic isn't duplicated across layers.
- `dump_buffer_text()` is a sibling to `find_in_buffer` — same buffer scope, same Strip `.text` access — so the search and save commands operate on identically defined data.

## Test plan

- [x] `pytest tests/cli/test_conv_save_to_file.py` — 8/8 pass (dump_buffer_text order, explicit-path write, auto-named cwd file, ~-expansion, parent-dir-missing error, overwrite, registry registration, empty-buffer file creation)
- [x] `pytest tests/cli/` — 543/543 pass
- [x] `ruff check src/reyn/chat/slash/save.py src/reyn/chat/slash/__init__.py src/reyn/chat/tui/app_outbox.py src/reyn/chat/tui/widgets/conversation.py tests/cli/test_conv_save_to_file.py` — clean
- [x] Manual: run `reyn chat`, accumulate a few turns, type `/save` (no args) — file `reyn-conv-<stamp>.txt` should appear in cwd, status should report line count + absolute path. Then `/save notes.txt` to an existing file — should overwrite, no prompt.
- [x] (skipped — permission-denied case hard to set up live; the Tier 2 error-branch test pins the behavior)

## Out of scope (deferred)

- Refuse to overwrite existing files (= require `--force` style flag). Defer until a user actually loses data; current UX is straightforward and slash-grade.
- JSON / structured export (= one row per OutboxMessage with full meta). Would need different scope and a non-TUI consumer.
- Pre-trim full history export — engine event log scope, not tui-coder.