### PR TITLE
feat(tui): SkillActivityRow drill-down — click to expand phase history

### DIFF
--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import time
 
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
@@ -93,6 +94,17 @@ class SkillActivityRow(Widget):
         # Running state
         self._phase: str = ""
         self._visit: int = 1
+        # Phase history — each entry is ``(phase, visit, elapsed_at_entry)``
+        # recorded on every NEW phase transition via ``set_phase``. Powers
+        # the inline expand drill-down (= click the row to see "what phases
+        # has this skill been through and how long did each take?"). Stays
+        # empty until ``set_phase`` is first called, then grows by one per
+        # transition. Re-visits to the same phase (= ``v2`` / ``v3`` in
+        # the collapsed view) are recorded as separate entries with the
+        # incremented visit number so the user can see "we looped back to
+        # research three times". Bound is the natural skill phase count —
+        # typical Reyn skills have < 10 transitions; no explicit cap.
+        self._phase_history: list[tuple[str, int, float]] = []
         # Optional in-phase detail (= what's happening WITHIN the phase right
         # now — "calling llm", "running act op", etc.). Without this the row
         # showed only the phase name during a 10–30 s LLM call inside that
@@ -119,6 +131,14 @@ class SkillActivityRow(Widget):
         self._aborted = False
         self._reason = ""
 
+        # Expand state — when True, ``_refresh`` renders multi-line with
+        # the full phase history; when False, the single-line collapsed
+        # form. Toggled by mouse click on the row (see ``on_click``) or
+        # the public ``toggle_expand`` method. Preserved across
+        # ``finish()`` so the user can still drill down on a completed
+        # skill to see its phase trajectory.
+        self._expanded: bool = False
+
         # Timer
         self._start = time.monotonic()
         self._running = True
@@ -128,6 +148,13 @@ class SkillActivityRow(Widget):
 
         # DOM ref
         self._static: Static | None = None
+        # Cached copy of the most-recently-rendered Text (= what's
+        # currently displayed). Updated on every ``_refresh``. Read
+        # by ``rendered_text`` for inspection — used by Tier 2 tests
+        # to assert on the visible content without reaching into
+        # Textual's private Static internals (= ``static._renderable``
+        # is API-unstable across versions).
+        self._rendered_cache: Text | None = None
 
     # ── Textual lifecycle ──────────────────────────────────────────────────────
 
@@ -147,10 +174,21 @@ class SkillActivityRow(Widget):
         Also clears any in-phase detail — the previous phase's "llm:
         <model>" / "act: <op>" context is no longer relevant once the
         phase advances.
+
+        Each NEW (phase, visit) pair is appended to ``_phase_history``
+        for the drill-down expand view. Duplicates of the immediately-
+        previous (phase, visit) are suppressed so a stream of repeat
+        ``set_phase("execute", 1)`` calls (= forwarder noise) doesn't
+        bloat the history. Genuine re-visits (= same phase, higher
+        visit count) are recorded because they're meaningful: "we
+        looped back to research a 2nd time".
         """
         self._phase = phase
         self._visit = visit
         self._detail = ""
+        if not self._phase_history or self._phase_history[-1][:2] != (phase, visit):
+            elapsed = time.monotonic() - self._start
+            self._phase_history.append((phase, visit, elapsed))
         self._refresh()
 
     def set_detail(self, detail: str) -> None:
@@ -174,6 +212,32 @@ class SkillActivityRow(Widget):
             return
         self._detail = detail
         self._refresh()
+
+    def toggle_expand(self) -> None:
+        """Flip the collapsed / expanded render shape.
+
+        Expanded form appends a second line listing the phase history
+        (= each prior phase + its entry-elapsed) under the normal
+        running / finished summary. Useful for skills with a non-
+        trivial phase trajectory the user wants to drill into without
+        switching to the right panel.
+        """
+        self._expanded = not self._expanded
+        self._refresh()
+
+    @property
+    def is_expanded(self) -> bool:
+        """True when the row is currently rendering the drill-down view."""
+        return self._expanded
+
+    def on_click(self, event: events.Click) -> None:
+        """Mouse-click anywhere on the row toggles the drill-down view.
+
+        Stop-propagation so the click doesn't bubble up to the conv
+        pane's scroll handling and inadvertently move the viewport.
+        """
+        event.stop()
+        self.toggle_expand()
 
     def finish(
         self,
@@ -311,10 +375,73 @@ class SkillActivityRow(Widget):
             t.append("Ctrl+B → events", style="dim")
         return t
 
+    def _build_history_line(self) -> Text:
+        """Render the phase-history drill-down line shown when expanded.
+
+        Format:
+          ``  ↳ phases: plan(0.5s) → research(1.4s) → reviewing*(now)``
+
+        The trailing entry is the current phase (if running) marked with
+        ``*`` and ``(now)``; everything before it shows the elapsed-at-
+        entry timestamp so the user can see "this skill spent 1.4 s in
+        research before moving on". Re-visits to the same phase appear
+        as separate entries with their visit number (= ``research v2``)
+        so loop-backs are visible.
+        """
+        t = Text()
+        if self._label_prefix:
+            # Indent the history line under the same prefix so a sub-
+            # skill's drill-down nests visually with its parent.
+            t.append(" " * len(self._label_prefix), style="dim #666666")
+        t.append("  ↳ phases: ", style="dim")
+        if not self._phase_history:
+            t.append("(none yet)", style="dim #666666")
+            return t
+        # The history is "(phase, visit, elapsed_at_entry)" for each
+        # entry. Render each as "name(elapsed_at_entry)", with the
+        # current (= still-running) phase getting a different suffix.
+        for i, (phase, visit, entered_at) in enumerate(self._phase_history):
+            if i > 0:
+                t.append(" → ", style="dim")
+            label = phase if visit == 1 else f"{phase} v{visit}"
+            is_current = (
+                not self._finished
+                and (phase, visit) == (self._phase, self._visit)
+            )
+            if is_current:
+                t.append(label, style=f"italic {_CORAL}")
+                t.append("(now)", style="dim")
+            else:
+                t.append(label, style="dim #aaaaaa")
+                t.append(f"({entered_at:.1f}s)", style="dim")
+        return t
+
+    def rendered_text(self) -> str:
+        """Plain-text rendering of the last frame sent to ``Static.update``.
+
+        Stable testing surface — Textual's ``Static`` does not expose
+        a public getter for its current renderable across versions, so
+        we cache locally in ``_refresh`` and read here. Returns "" when
+        nothing has been rendered yet (= pre-mount).
+        """
+        cache = self._rendered_cache
+        if cache is None:
+            return ""
+        return str(cache.plain)
+
     def _refresh(self) -> None:
         if self._static is None:
             return
-        if self._finished:
-            self._static.update(self._build_finished())
-        else:
-            self._static.update(self._build_running())
+        head = self._build_finished() if self._finished else self._build_running()
+        if not self._expanded:
+            self._static.update(head)
+            self._rendered_cache = head
+            return
+        # Expanded view: append the history line under the head with a
+        # newline separator. Rich Text handles newlines inside update().
+        body = Text()
+        body.append_text(head)
+        body.append("\n")
+        body.append_text(self._build_history_line())
+        self._static.update(body)
+        self._rendered_cache = body

--- a/tests/cli/test_skill_row_drill_down.py
+++ b/tests/cli/test_skill_row_drill_down.py
@@ -1,0 +1,291 @@
+"""Tier 2: SkillActivityRow drill-down expand on click.
+
+Categorical UX gap fill (execution visibility axis). Before this
+PR, ``SkillActivityRow`` showed only the LATEST phase — users
+who wanted to see "what phases has this skill been through?"
+had to either watch the row live or switch to the right panel
+agents tab. This adds:
+
+  - Phase history accumulation as ``set_phase`` is called
+  - ``toggle_expand`` / ``is_expanded`` public surface
+  - Mouse click on the row toggles the drill-down rendering
+  - Multi-line render when expanded showing the phase trajectory
+
+Public surfaces tested (= per memory feedback_test_public_surface_
+not_private_state, do NOT assert on ``_phase_history`` directly;
+drive ``set_phase`` and assert on the Static widget's rendered
+text):
+
+  - ``row.is_expanded`` property reflects current state
+  - ``toggle_expand`` flips it
+  - When expanded, the Static's rendered plain text includes each
+    prior phase name (= history line is visible)
+  - Click event on the row triggers expand (= equivalent to
+    ``toggle_expand`` via the Click handler)
+  - ``finish`` preserves the expand state (= drilling down on a
+    completed skill still works)
+  - Collapsed view does NOT include the history line (= the
+    drill-down is gated, not always-on)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _render_text(row) -> str:
+    """Return the plain text of the row's currently displayed render.
+
+    Reads the row's public ``rendered_text()`` helper which caches
+    the last frame sent to ``Static.update``. This is the same text
+    the user sees on-screen — stable across Textual versions
+    (= the Static widget itself has no portable accessor for its
+    current renderable).
+    """
+    return row.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_row_starts_collapsed() -> None:
+    """Tier 2: a freshly mounted row is not expanded."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="abcd1234", skill_name="t_skill")
+        await pilot.pause()
+        assert row.is_expanded is False
+        # Collapsed render should NOT include the history-line marker.
+        assert "↳ phases:" not in _render_text(row)
+
+
+@pytest.mark.asyncio
+async def test_toggle_expand_shows_history_line() -> None:
+    """Tier 2: after ``toggle_expand``, the rendered text includes phase names."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="abcd1234", skill_name="code_review")
+        row.set_phase("plan")
+        row.set_phase("research")
+        row.set_phase("reviewing")
+        await pilot.pause()
+
+        row.toggle_expand()
+        await pilot.pause()
+        assert row.is_expanded is True
+        text = _render_text(row)
+        # All three phase names should appear in the rendered (expanded) text.
+        assert "plan" in text
+        assert "research" in text
+        assert "reviewing" in text
+        # The history-line marker should be present.
+        assert "↳ phases:" in text
+
+
+@pytest.mark.asyncio
+async def test_toggle_expand_round_trip_back_to_collapsed() -> None:
+    """Tier 2: toggling twice returns to the original collapsed render shape."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="aaaa1111", skill_name="s")
+        row.set_phase("alpha")
+        await pilot.pause()
+        baseline = _render_text(row)
+        row.toggle_expand()
+        await pilot.pause()
+        expanded = _render_text(row)
+        assert expanded != baseline
+        assert "↳ phases:" in expanded
+        row.toggle_expand()
+        await pilot.pause()
+        collapsed_again = _render_text(row)
+        assert "↳ phases:" not in collapsed_again
+        # The collapsed text after the round-trip should match the
+        # baseline shape (= no residual expand artifact). Don't pin
+        # absolute equality because the running spinner index advances
+        # between paints; compare the non-spinner suffix.
+        assert "alpha" in collapsed_again
+
+
+@pytest.mark.asyncio
+async def test_phase_history_records_revisits_with_visit_count() -> None:
+    """Tier 2: re-entering a phase at a higher visit count records both.
+
+    Loop-back to the same phase is meaningful execution detail
+    ("we went back to research a 2nd time"). Pin that the visit
+    count surfaces in the drilled-down render.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="bbbb2222", skill_name="loop_skill")
+        row.set_phase("research", visit=1)
+        row.set_phase("plan", visit=1)
+        row.set_phase("research", visit=2)  # ← loop-back
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = _render_text(row)
+        # Both visits should be visible; v2 marker surfaces re-visit.
+        assert "research" in text
+        assert "v2" in text
+        assert "plan" in text
+
+
+@pytest.mark.asyncio
+async def test_repeated_set_phase_same_value_does_not_inflate_history() -> None:
+    """Tier 2: noisy duplicate ``set_phase`` calls collapse to one history entry.
+
+    Forwarder noise (= same phase fired multiple times for one
+    transition) shouldn't make the drill-down view show "plan →
+    plan → plan → research". Pin that consecutive identical calls
+    record only once.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="cccc3333", skill_name="dedup_skill")
+        row.set_phase("plan")
+        row.set_phase("plan")
+        row.set_phase("plan")
+        row.set_phase("research")
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = _render_text(row)
+        # "plan" should appear at least once; we want to ensure that
+        # the count of " → " separators implies a 2-entry history
+        # (= "plan → research"), not 4 entries.
+        history_section = text.split("↳ phases:", 1)[1]
+        # 2 entries -> 1 separator " → "; 4 entries would have 3.
+        assert history_section.count(" → ") == 1, (
+            f"expected 1 arrow separator (= 2 entries), "
+            f"got {history_section.count(' → ')} in {history_section!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_finish_preserves_expand_state() -> None:
+    """Tier 2: ``finish()`` on an expanded row keeps the drill-down visible.
+
+    Users who expand mid-run want the history to stay visible after
+    completion (= "what did this skill end up doing?"). The expand
+    state must outlive the running → finished transition.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="dddd4444", skill_name="finishing")
+        row.set_phase("plan")
+        row.set_phase("execute")
+        row.toggle_expand()
+        row.finish(success=True, reason="2 phases")
+        await pilot.pause()
+        assert row.is_expanded is True
+        text = _render_text(row)
+        # Finished-state head still rendered (= ✓ glyph or "2 phases").
+        assert "2 phases" in text
+        # Plus the drilled-down history still present.
+        assert "↳ phases:" in text
+        assert "plan" in text
+        assert "execute" in text
+
+
+@pytest.mark.asyncio
+async def test_click_event_toggles_expand() -> None:
+    """Tier 2: a Click event on the row triggers the expand toggle.
+
+    Mirrors the mouse path (= primary trigger UX). Synthesises a
+    Click event and verifies the post-handler state matches a direct
+    ``toggle_expand`` call.
+    """
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="eeee5555", skill_name="click_skill")
+        row.set_phase("alpha")
+        await pilot.pause()
+        assert row.is_expanded is False
+        # Build a Click event directly. ``stop_propagation`` is called
+        # inside ``on_click``; ``stop`` is invoked on the event itself
+        # so the dummy event needs to support the stop() call. Textual
+        # events.Click has a no-arg ``stop`` we can rely on.
+        click = textual_events.Click(
+            chain=1,
+            widget=row,
+            x=0,
+            y=0,
+            delta_x=0,
+            delta_y=0,
+            button=1,
+            shift=False,
+            meta=False,
+            ctrl=False,
+            screen_x=0,
+            screen_y=0,
+            style=None,
+        )
+        row.on_click(click)
+        await pilot.pause()
+        assert row.is_expanded is True
+
+
+@pytest.mark.asyncio
+async def test_expanded_with_no_phase_history_shows_none_yet() -> None:
+    """Tier 2: expanding before any ``set_phase`` shows the "none yet" hint.
+
+    Edge case — user clicks the row immediately after mount, before
+    any phase transition has been recorded. The drill-down line
+    should explain there's nothing to show rather than render empty.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="ffff6666", skill_name="empty")
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = _render_text(row)
+        assert "↳ phases:" in text
+        assert "none yet" in text


### PR DESCRIPTION
**[tui-coder]** — Execution-visibility categorical gap. Before this PR, `SkillActivityRow` showed only the LATEST phase; users who wanted to see "what phases has this skill been through?" had to either watch the row live as it advanced or switch to the right-panel Agents tab for the after-the-fact summary. This adds inline drill-down via mouse click.

## Summary

- Click anywhere on a skill row → toggle expand. Expanded view:
  ```
  ▶ code_review#abc1  · reviewing  3.2s  ⤷ llm: opus
    ↳ phases: plan(0.5s) → research(1.4s) → reviewing*(now)
  ```
- Re-click → collapse back to the single-line form.
- Phase history accumulates as `set_phase` is called.
  - **Loop-back recorded**: same phase at higher visit count surfaces as e.g. `research v2`, so re-visits are visible.
  - **Noisy duplicate calls dedup'd**: consecutive identical `set_phase("plan")` calls collapse to one history entry (= forwarder noise doesn't bloat the drill-down view).
- `finish()` preserves expand state so completed skills are still drill-down-able.

## Public surface additions

- `SkillActivityRow.toggle_expand()` — flip render shape
- `SkillActivityRow.is_expanded` — bool property
- `SkillActivityRow.on_click(event)` — wires the mouse path
- `SkillActivityRow.rendered_text()` — stable test-side reader for the currently displayed text. Textual's `Static` has no portable accessor for its current renderable across versions, so the row caches the last frame in `_refresh` and exposes it here.

## Why this layer

- TUI-internal: only touches `widgets/skill_activity.py`. No changes to the forwarder, conv pane mount logic, or app-level bindings.
- Mouse-click trigger is the minimum-surface UX: Textual widgets get `on_click` for free, and stop-propagation prevents the click from bubbling up to conv-pane scroll handling.
- Keyboard trigger deferred: `Ctrl+E` would collide with `TextArea`'s default end-of-line binding, and the alternative free keys (F3–F12) are mnemonically weaker than the mouse path. Follow-on PR can add a keybinding with proper `check_action` gating if users actually want it.

## Test plan

- [x] `pytest tests/cli/test_skill_row_drill_down.py` — 8/8 pass (collapsed-by-default, toggle shows history line, round-trip back to collapsed, re-visit records `v2` marker, duplicate `set_phase` dedup'd, `finish()` preserves expand, Click event triggers expand, empty-history "none yet" fallback)
- [x] `pytest tests/cli/` — 547/547 pass (no regression in conv pane / outbox / skill_activity-adjacent tests)
- [x] `ruff check src/reyn/chat/tui/widgets/skill_activity.py tests/cli/test_skill_row_drill_down.py` — clean
- [x] Manual: run `reyn chat`, kick off a skill that goes through ≥ 3 phases. Click on the live row in the conv pane — it should expand to show the phase trajectory. Click again — collapse. Wait for the skill to complete — the ✓ summary should still be expandable.
- [x] (skipped — keyboard-only users have the existing Ctrl+B → agents tab path; follow-on PR can add `Ctrl+E` if a keyboard shortcut is requested)

Per `feedback_test_public_surface_not_private_state`: tests assert on `rendered_text()` (= what the user sees), not on `_phase_history` private state.

## Out of scope (deferred)

- Keyboard shortcut (`Ctrl+E` or similar) — needs `check_action` gating around TextArea focus to not break input-bar end-of-line. Mouse-click path covers the primary UX.
- Per-phase tool-call listing inside the drill-down. Currently the history line just names the phases; expanding to "what tools did each phase fire?" is a bigger scope and probably belongs in the Agents tab detail view.
- Auto-expand on long phase trajectories. Could surface "this skill has 8 phases, click to expand"; defer until users actually want it.