### PR TITLE
feat(tui): F3 keyboard companion to skill row drill-down (#546 follow-on)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -138,6 +138,14 @@ class ReynTUIApp(App):
         # win against any widget-level binding.
         Binding("ctrl+g", "find_next", "Find next match", priority=True, show=False),
         Binding("ctrl+shift+g", "find_prev", "Find prev match", priority=True, show=False),
+        # Keyboard companion to the mouse-click skill-row drill-down
+        # (= toggle phase-history expand). F3 avoids the Ctrl+letter
+        # collision with TextArea's default editing shortcuts (ctrl+e
+        # end-of-line, ctrl+a start-of-line, etc.). Target is every
+        # in-flight skill row — typically one row, but if multiple
+        # skills are concurrent the user can expand them all at once
+        # with one keypress. Status hint when nothing is running.
+        Binding("f3", "skill_expand_toggle", "Toggle skill row drill-down", priority=True, show=False),
     ]
 
     _REYN_THEME = Theme(
@@ -1329,6 +1337,42 @@ class ReynTUIApp(App):
         if router is None:
             return
         router.cycle_find(-1)
+
+    def action_skill_expand_toggle(self) -> None:
+        """F3 — toggle drill-down on every in-flight SkillActivityRow.
+
+        Keyboard companion to the row-click expand: instead of clicking
+        each row individually, F3 flips them all at once. The new
+        target state matches the FIRST in-flight row's current state
+        flipped, then applied uniformly — so a mixed-state set (one
+        expanded, one collapsed) converges to a single state per
+        keypress rather than oscillating in place.
+
+        No-op with a status hint when nothing is in flight (= the
+        user pressed F3 expecting drill-down but no skill is running).
+        """
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+        except Exception:
+            return
+        rows = conv.in_flight_skill_rows()
+        if not rows:
+            try:
+                conv.show_status(
+                    "no active skill row to expand", kind="general",
+                )
+                self.set_timer(2.0, conv.hide_status)
+            except Exception:
+                pass
+            return
+        # Pick a single target state for THIS keypress so the set
+        # converges. Without this, F3 on a mixed set (one expanded,
+        # one collapsed) would flip each individually and the next
+        # F3 press would oscillate — not what the user wants.
+        target_expand = not rows[0].is_expanded
+        for row in rows:
+            if row.is_expanded != target_expand:
+                row.toggle_expand()
 
     def action_next_turn(self) -> None:
         """ctrl+n — scroll the conversation log to the next agent turn."""

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1105,6 +1105,27 @@ class ConversationView(Widget):
         if row is not None:
             row.set_detail(detail)
 
+    def in_flight_skill_rows(self) -> list[SkillActivityRow]:
+        """Return SkillActivityRow widgets whose skill is still running.
+
+        Powers the F3 keyboard expand action (= toggle drill-down on
+        whatever's executing right now). The mouse path can target any
+        specific row by clicking it; the keyboard path needs a default
+        target, and "everything currently running" is the most useful
+        — typically that's a single row, but if multiple skills are
+        concurrent the user can drill into all of them at once.
+
+        Finished rows are excluded — once a skill completes, the user
+        can still click it individually to expand, but F3 should not
+        surprise them by toggling old finished rows that have scrolled
+        far up. Returns an empty list when nothing is in flight; the
+        caller surfaces a status hint in that case.
+        """
+        return [
+            row for row in self._skill_rows.values()
+            if not row._finished
+        ]
+
     # ── Tool-call rows (issue #427 step 4) ───────────────────────────────────
 
     def start_tool_call_row(

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -23,8 +23,10 @@ _KEY_PRETTY: dict[str, str] = {
     "shift+tab": "⇧Tab",
     "ctrl+shift+o": "⌃⇧O",
     "ctrl+shift+w": "⌃⇧W",
+    "ctrl+shift+g": "⌃⇧G",
     "enter": "Enter", "tab": "Tab", "escape": "Esc", "space": "Space",
     "up": "↑", "down": "↓", "left": "←", "right": "→",
+    "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4",
 }
 _CONVERSATION_KEYS = {
     "ctrl+p", "ctrl+n", "ctrl+shift+n", "ctrl+shift+p",
@@ -34,6 +36,12 @@ _CONVERSATION_KEYS = {
     # would land in the generic GLOBAL group and be harder to
     # discover next to their conceptual peers.
     "ctrl+g", "ctrl+shift+g",
+    # SkillActivityRow drill-down toggle. F3 doesn't start with
+    # "ctrl+" so the default routing would land it under OTHER;
+    # CONVERSATION is the right home because the action toggles
+    # inline expand on widgets that live in the conv pane (=
+    # mouse-click + F3 are the two trigger paths to the same UX).
+    "f3",
 }
 # ``j`` / ``k`` / ``space`` / ``c`` are routed via ``RightPanel.on_key``
 # (not ``app.BINDINGS``) and dispatch per-tab inside the panel handler,

--- a/tests/cli/test_skill_expand_keyboard.py
+++ b/tests/cli/test_skill_expand_keyboard.py
@@ -1,0 +1,197 @@
+"""Tier 2: F3 keyboard companion to SkillActivityRow drill-down.
+
+Follow-on to PR #546 (= mouse-click drill-down). The mouse path
+covers the primary UX but keyboard-driven users had no way to
+trigger the expand without reaching for the mouse. This adds:
+
+  - F3 toggles drill-down on every in-flight SkillActivityRow
+  - When multiple rows are concurrent, F3 converges to a single
+    target state (not per-row oscillation)
+  - When no rows are in flight, F3 surfaces a status hint rather
+    than silently no-op'ing
+  - F3 is added to the Keys tab CONVERSATION group with a pretty
+    "F3" label
+
+Public surfaces tested:
+  - ``ConversationView.in_flight_skill_rows()`` returns unfinished rows
+  - ``action_skill_expand_toggle`` flips ``is_expanded`` on every
+    in-flight row
+  - Mixed-state set converges to a single state per keypress
+  - Empty in-flight set → status sticky with usage hint
+  - F3 binding registered with correct action name
+  - Keys tab routes F3 to CONVERSATION group + pretty-prints as F3
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_in_flight_skill_rows_excludes_finished() -> None:
+    """Tier 2: only unfinished rows are returned (= F3 target set)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        live = conv.start_skill_row(run_id="aaaa1111", skill_name="live")
+        done = conv.start_skill_row(run_id="bbbb2222", skill_name="done")
+        done.finish(success=True, reason="ok")
+        await pilot.pause()
+        rows = conv.in_flight_skill_rows()
+        ids = {r._run_id for r in rows}
+        assert "aaaa1111" in ids
+        assert "bbbb2222" not in ids
+        assert live in rows
+        assert done not in rows
+
+
+@pytest.mark.asyncio
+async def test_f3_action_expands_single_in_flight_row() -> None:
+    """Tier 2: F3 toggles is_expanded on the lone in-flight row."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="cccc3333", skill_name="alone")
+        row.set_phase("plan")
+        await pilot.pause()
+        assert row.is_expanded is False
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+        assert row.is_expanded is True
+        # Pressing again collapses back.
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+        assert row.is_expanded is False
+
+
+@pytest.mark.asyncio
+async def test_f3_converges_mixed_state_to_single_target() -> None:
+    """Tier 2: mixed-state set converges per keypress, not oscillates.
+
+    With one row expanded and another collapsed, pressing F3 once
+    should leave BOTH in the same state (= opposite of the first
+    row's prior state). Without this convergence, naive per-row
+    toggle would flip each individually and the next press would
+    return to the original split — F3 would feel "stuck".
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row_a = conv.start_skill_row(run_id="dddd4444", skill_name="a")
+        row_b = conv.start_skill_row(run_id="eeee5555", skill_name="b")
+        row_a.set_phase("plan")
+        row_b.set_phase("plan")
+        # Pre-state: a expanded, b collapsed.
+        row_a.toggle_expand()
+        await pilot.pause()
+        assert row_a.is_expanded is True
+        assert row_b.is_expanded is False
+
+        # F3 → converge. row_a was expanded → target = collapsed.
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+        assert row_a.is_expanded is False
+        assert row_b.is_expanded is False
+
+        # F3 again → both expanded.
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+        assert row_a.is_expanded is True
+        assert row_b.is_expanded is True
+
+
+@pytest.mark.asyncio
+async def test_f3_with_no_in_flight_shows_status_hint() -> None:
+    """Tier 2: F3 with no in-flight rows surfaces a status hint."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No skill rows mounted.
+        assert conv.in_flight_skill_rows() == []
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "no active skill" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_f3_skips_finished_rows() -> None:
+    """Tier 2: F3 only touches in-flight rows, leaves finished ones alone."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        live = conv.start_skill_row(run_id="ffff6666", skill_name="live")
+        done = conv.start_skill_row(run_id="abcd7777", skill_name="done")
+        live.set_phase("plan")
+        done.set_phase("plan")
+        done.finish(success=True, reason="ok")
+        await pilot.pause()
+        # Pre-state: both collapsed.
+        assert live.is_expanded is False
+        assert done.is_expanded is False
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+        # Live row toggled, done row untouched.
+        assert live.is_expanded is True
+        assert done.is_expanded is False
+
+
+def test_f3_binding_registered() -> None:
+    """Tier 2: ``f3`` is bound to ``skill_expand_toggle`` in app BINDINGS."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    binds = {(b.key, b.action) for b in ReynTUIApp.BINDINGS}
+    assert ("f3", "skill_expand_toggle") in binds
+
+
+def test_keys_tab_routes_f3_to_conversation() -> None:
+    """Tier 2: F3 lands in the CONVERSATION group, not OTHER."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import (
+        _key_group_for,
+        _pretty_key,
+    )
+
+    assert _key_group_for("f3") == "CONVERSATION"
+    # Pretty label is the proper capitalised "F3".
+    assert _pretty_key("f3") == "F3"
+
+
+@pytest.mark.asyncio
+async def test_keys_tab_render_includes_f3_with_description() -> None:
+    """Tier 2: rendered Keys tab markup surfaces F3 + its description."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        markup = render_keys(app)
+        assert "F3" in markup
+        assert "skill row drill-down" in markup.lower()


### PR DESCRIPTION
**[tui-coder]** — #546 follow-on. Mouse-click drill-down in #546 covers the primary UX; this adds the keyboard companion.

**Stack note**: base = `feat/tui-skill-row-drill-down` (= #546 branch). Will auto-update to main once #546 lands.

## Summary

- `F3` toggles drill-down on every in-flight `SkillActivityRow`.
- Mixed-state convergence: F3 lands all rows in a single target state per keypress (no oscillation).
- No-in-flight branch surfaces a status hint, not silent no-op.
- Finished rows excluded from F3 target set.
- Keys tab: F3 routed to CONVERSATION group + pretty-printed as "F3"; F1/F2/F4 added to pretty table for symmetry.

## Why F3 not Ctrl+E

Ctrl+letter combos collide with TextArea defaults (ctrl+e end-of-line, ctrl+a start-of-line, ctrl+k kill, ctrl+m enter). F3 is mnemonically weaker but collision-free.

## Test plan

- [x] `pytest tests/cli/test_skill_expand_keyboard.py` — 8/8 pass
- [x] `pytest tests/cli/test_skill_row_drill_down.py` — 8/8 pass (#546 regression unaffected)
- [x] `pytest tests/cli/` — 555/555 pass
- [x] `ruff check` — clean
- [x] Manual: F3 expands live row; F3 again collapses; F3 with nothing running shows status hint
- [x] (skipped — multi-concurrent convergence reproduced via Tier 2 test, not live)

## Out of scope

- Per-row F3 targeting (= row-under-cursor). Conv pane has no row cursor concept.
- Auto-expand on long-running skills.
