### PR TITLE
dogfood: --model override + cross-model FizzBuzz curve baseline

### DIFF
--- a/dogfood/baselines/fizzbuzz_curve_cross_model.md
+++ b/dogfood/baselines/fizzbuzz_curve_cross_model.md
@@ -1,0 +1,106 @@
+# FizzBuzz iterate-test-fix loop — cross-model baseline (2026-05-23)
+
+Empirical baseline for the 3-scenario FizzBuzz difficulty curve under
+``dogfood/fixtures/`` , run via ``dogfood/scripts/run_dogfood_iterate.py``.
+
+Driver: ``reyn chat --cui`` per-run on an isolated tmp workspace,
+sandbox ``auto`` → Seatbelt on macOS 25 (Darwin 25.3.0). All runs
+done on commit ``27ee4abe`` (= PR #541 merged) plus the 5-bug
+variant from PR #544.
+
+## Pass rate (= driver pytest verdict)
+
+| Scenario | gemini-2.5-flash-lite | gemini-2.5-flash | Δ |
+|----------|----------------------:|-----------------:|---|
+| ``fizzbuzz_tdd`` (empty stub + failing tests) | 4/5 = 80% (N=5) | **5/5 = 100%** (N=5) | strong ↑ |
+| ``fizzbuzz_bug_planted`` (3 independent bugs) | 5/5 = 100% (N=5) | 5/5 = 100% (N=5) | — |
+| ``fizzbuzz_5bugs_interleaved`` (5 masking bugs) | 4/10 = 40% (N=10) | **0/5 = 0%** (N=5) | **strong ↓** |
+
+## Iteration depth
+
+| Scenario | flash-lite mean_iter | flash mean_iter |
+|----------|---------------------:|----------------:|
+| ``fizzbuzz_tdd``               | 1.6 | 2.0 |
+| ``fizzbuzz_bug_planted``       | 2.2 | 2.2 |
+| ``fizzbuzz_5bugs_interleaved`` | 1.7 | 1.8 |
+
+The stronger model does **not** iterate materially more. On the 5-bug
+case it iterates the same ~1.8 times but converges on a different
+local optimum.
+
+## Attractor (= failure-mode) distribution
+
+| Attractor | flash-lite (5bugs, N=10) | flash (5bugs, N=5) |
+|-----------|--------------------------:|--------------------:|
+| Early-bail (= ``writes=0``, intent-without-action) | 4/10 = 40% | 4/5 = 80% |
+| Zero-special-case preservation (= ``if n == 0: return "0"`` survives) | 2/10 = 20% | 0/5 = 0% |
+| **Positive-only-guard + int-return preservation** | 0/10 = 0% | **1/5 = 20%** (= run-1 inspect) |
+
+## What flash got wrong on the 5-bug case (= the surprise)
+
+Inspecting the run-1 ``--keep-workspace`` artefact: the strong model
+**fixed bugs 1 / 4 / 5** (= zero special-case, ``"FizzBzz"`` typo,
+order-of-check) in a single confident rewrite — and **left bugs 2 / 3
+in place** (= ``if n > 0:`` guard wrapping the divisibility logic,
+``return n`` instead of ``return str(n)``).
+
+```python
+def fizzbuzz(n):
+    if n == 0:
+        return "FizzBuzz"       # bug 1 fixed
+    if n > 0:                   # bug 2 STILL PRESENT
+        if n % 15 == 0:         # bug 5 fixed (15 before 3)
+            return "FizzBuzz"   # bug 4 fixed ("FizzBuzz" not "FizzBzz")
+        elif n % 3 == 0:
+            return "Fizz"
+        elif n % 5 == 0:
+            return "Buzz"
+    return n                    # bug 3 STILL PRESENT (int, not str(n))
+```
+
+The remaining bugs cluster in **structural** properties (guard scope +
+type conversion). The fixed bugs cluster in **surface** properties
+(constant literal + branch order). Strong-model attractor shape, in
+one line: *fix surface bugs in one confident pass, miss structural
+bugs that need iterative re-discovery via failed assertions*.
+
+## Hypothesis
+
+Stronger models may be **more confident** in their first-attempt
+rewrite, leading them to commit earlier in the iterate-test-fix loop.
+flash-lite's slower convergence forces it to consult pytest output
+again, occasionally surfacing the structural bug. Strong's
+high-confidence one-shot rewrite skips that step.
+
+If this hypothesis holds, the "harder" scenarios are not just *more*
+bugs — they're bugs distributed across the **surface vs structural
+axis**, which orthogonal-to-model-capability stresses the
+iterate-vs-confident-rewrite trade-off.
+
+## Caveats (= why not a conclusion)
+
+- **N=5 is small**. flash-lite at 40% pass means 5 consecutive
+  fails have probability ~0.6⁵ ≈ 8% — possible by chance.
+- One model version, one provider proxy (= localhost:4000 LiteLLM).
+- Single fixture set; "FizzBuzz" may not generalise to other
+  coding tasks. CSV parser / LRU cache variants would be needed to
+  test the surface-vs-structural hypothesis across domains.
+
+## Re-test recipe
+
+```bash
+# Default fixture model (= flash-lite per the project's reyn.yaml):
+python dogfood/scripts/run_dogfood_iterate.py \
+    --scenario fizzbuzz_5bugs_interleaved --n 10
+
+# Override the workspace model for cross-model comparison:
+python dogfood/scripts/run_dogfood_iterate.py \
+    --scenario fizzbuzz_5bugs_interleaved --n 5 \
+    --model openai/gemini-2.5-flash
+```
+
+The ``--model`` flag rewrites every tier in the copied workspace
+``reyn.yaml`` to the given LiteLLM-style model string. Strong-model
+runs require explicit per-investigation permission — see
+``feedback_strong_model_cost_gated.md`` in the e2e-coder session
+memory.

--- a/dogfood/scripts/run_dogfood_iterate.py
+++ b/dogfood/scripts/run_dogfood_iterate.py
@@ -64,6 +64,30 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURES_ROOT = REPO_ROOT / "dogfood" / "fixtures"
 
 
+def _override_workspace_model(workspace: Path, model_string: str) -> None:
+    """Rewrite the workspace's reyn.yaml so every tier points at
+    ``model_string`` (= LiteLLM-style string like
+    ``openai/gemini-2.5-flash``).
+
+    Cheap line-rewrite (= no yaml parser dep) because reyn.yaml is
+    fixture-shaped and the ``models:`` block has one entry per tier.
+    """
+    yaml_path = workspace / "reyn.yaml"
+    if not yaml_path.exists():
+        return
+    out_lines: list[str] = []
+    for raw in yaml_path.read_text().splitlines():
+        stripped = raw.lstrip()
+        # Match "  light:    openai/gemini-2.5-flash-lite" etc.
+        for tier in ("light", "standard", "strong"):
+            if stripped.startswith(f"{tier}:"):
+                indent = raw[: len(raw) - len(stripped)]
+                raw = f"{indent}{tier}: {model_string}"
+                break
+        out_lines.append(raw)
+    yaml_path.write_text("\n".join(out_lines) + "\n")
+
+
 def setup_workspace(scenario: str, target: Path) -> str:
     """Copy the scenario's fixture files into ``target`` and return the
     scenario-specific directive prompt.
@@ -227,7 +251,11 @@ def _scenario_files(scenario: str) -> tuple[str, str]:
 
 
 def run_one(
-    scenario: str, idx: int, timeout: int, keep_workspace: bool,
+    scenario: str,
+    idx: int,
+    timeout: int,
+    keep_workspace: bool,
+    model_override: str | None = None,
 ) -> dict:
     """One full trial: workspace setup → chat → pytest verdict."""
     test_file, impl_file = _scenario_files(scenario)
@@ -236,6 +264,8 @@ def run_one(
     )
     try:
         prompt = setup_workspace(scenario, workspace)
+        if model_override:
+            _override_workspace_model(workspace, model_override)
         trace_file = workspace / "llm_trace.jsonl"
         chat = run_chat(prompt, workspace, trace_file, timeout)
         trace = parse_trace(trace_file, impl_file)
@@ -263,13 +293,20 @@ def main() -> None:
     ap.add_argument("--timeout", type=int, default=240, help="per-run timeout (s)")
     ap.add_argument("--keep-workspace", action="store_true",
                     help="don't delete tmp workspaces (debug)")
+    ap.add_argument("--model", default=None,
+                    help="Override the workspace reyn.yaml model string "
+                         "(= sets all tiers to this value, e.g. "
+                         "'openai/gemini-2.5-flash'). Default: use the "
+                         "fixture's reyn.yaml unchanged.")
     args = ap.parse_args()
 
-    print(f"[scenario] {args.scenario}", flush=True)
+    print(f"[scenario] {args.scenario}"
+          + (f"  [model] {args.model}" if args.model else ""), flush=True)
     results = []
     for i in range(1, args.n + 1):
         print(f"[run {i}/{args.n}] starting ...", flush=True)
-        r = run_one(args.scenario, i, args.timeout, args.keep_workspace)
+        r = run_one(args.scenario, i, args.timeout, args.keep_workspace,
+                    model_override=args.model)
         results.append(r)
         print(
             f"[run {i}/{args.n}] verdict={r['verdict']} "
@@ -288,6 +325,7 @@ def main() -> None:
 
     summary = {
         "scenario": args.scenario,
+        "model": args.model or "(fixture default)",
         "n": n,
         "pass_rate": round(n_pass / max(n, 1), 2),
         "n_pass": n_pass,


### PR DESCRIPTION
**[e2e-coder]** — Adds a ``--model`` override to ``run_dogfood_iterate.py`` and pins a cross-model baseline observation document covering the 3-scenario FizzBuzz curve at the gemini-2.5-flash tier vs the flash-lite tier from PR #541 + PR #544.

## What's here

1. **``--model <model_string>`` flag** on ``dogfood/scripts/run_dogfood_iterate.py``
   - Rewrites every tier (`light` / `standard` / `strong`) in the copied workspace `reyn.yaml` to the given LiteLLM-style string before `reyn chat --cui` runs.
   - Default behaviour (= use fixture yaml unchanged) preserved.
   - Cheap line-rewrite, no yaml parser dep.

2. **``dogfood/baselines/fizzbuzz_curve_cross_model.md``** — empirical baseline document.

## Headline result (= the surprise)

| Scenario                       | flash-lite        | gemini-2.5-flash    |
|--------------------------------|-------------------|---------------------|
| ``fizzbuzz_tdd``               | 4/5 = 80%         | **5/5 = 100%**      |
| ``fizzbuzz_bug_planted``       | 5/5 = 100%        | 5/5 = 100%          |
| ``fizzbuzz_5bugs_interleaved`` | 4/10 = 40%        | **0/5 = 0%**        |

The 5-bug case is the surprise: the stronger model performed *worse* in the N=5 sample. Inspecting one run shows a clean attractor shape:

- ✅ **Surface bugs fixed in one confident rewrite**: literal typo (`FizzBzz`), branch order (`%3` before `%15`), zero special-case.
- ❌ **Structural bugs preserved**: `if n > 0:` guard scope + `return n` (int) on default branch.

Hypothesis: stronger models commit to first-attempt rewrites with higher confidence, skipping the iterate step that exposes structural defects. flash-lite's slower convergence forces a second pytest consult that occasionally catches the structural bug.

## Caveats (= why this stays a hypothesis)

- N=5 is small (5 consecutive fails ≈ 8% by chance at 40% base rate)
- Single model version + single fixture domain (FizzBuzz)
- A CSV-parser / LRU-cache variant would be needed to test the surface-vs-structural attractor hypothesis across domains

## Strong-model use authorisation

Per ``feedback_strong_model_cost_gated.md`` (session memory), strong-model runs are forbidden by default + require explicit per-investigation permission. The 15 runs covered by this baseline (3 scenarios × N=5) were authorised by the user with **「試しに strong でも３シナリオ検証して N=5」** on 2026-05-23.

## Test plan

- [x] Rootdir verify: `python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` → 5128 passed, 5 skipped, 1 deselected, 3 xfailed (deselected test = same pre-existing flake noted in PR #544, unrelated)
- [x] `pytest --collect-only -q | grep dogfood/fixtures` → 0 hits (= norecursedirs from PR #541 preserved)
- [x] `python dogfood/scripts/run_dogfood_iterate.py --scenario fizzbuzz_tdd --n 1` (no `--model`) → fixture-default model path still works
- [x] `python dogfood/scripts/run_dogfood_iterate.py --scenario fizzbuzz_tdd --n 1 --model openai/gemini-2.5-flash` → override path verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)