### PR TITLE
feat(tui): SlashPicker in-input feedback for unknown commands

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -468,6 +468,23 @@ class InputBar(Widget):
             c for c in self._slash_commands
             if c.name.startswith(token)
         ]
+        # Unknown-command in-input feedback: when the token is
+        # non-empty (= the user is actively typing a command name)
+        # but no command matches the prefix, surface a dim "did you
+        # mean /<sug>?" row instead of silently hiding the picker.
+        # Without this the user only learns the command is invalid
+        # after pressing Enter, when the backend returns "unknown
+        # command". ``suggest_for_unknown`` already gives us up to 3
+        # fuzzy matches + /help as the escape hatch.
+        if token and not matches:
+            from reyn.chat.slash import suggest_for_unknown
+            picker.set_unknown_hint(
+                token,
+                suggest_for_unknown(
+                    token, names=[c.name for c in self._slash_commands],
+                ),
+            )
+            return
         # Alphabetical so muscle memory built from /help (which lists
         # alphabetically) transfers to the picker. The previous
         # ``(len(name), name)`` ordering pushed common-but-longer

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -74,6 +74,20 @@ class SlashPicker(Static):
         # selection caret, no keyboard intercept.
         self._completions: list[str] = []
         self._total_completions: int = 0
+        # Unknown-command hint state. Set by ``set_unknown_hint`` when the
+        # user types a slash token that doesn't prefix any known command
+        # (= picker would otherwise silently hide, leaving the user with
+        # no in-input feedback that they're typing nonsense). Renders a
+        # single dim row reading ``unknown /<typed> — did you mean /<…>?``.
+        self._unknown_token: str = ""
+        self._unknown_suggestions: list[str] = []
+        # Cached copy of the most-recently-rendered Text (= what's
+        # currently displayed). Updated on every ``_repaint``. Read by
+        # ``rendered_text`` for inspection — used by Tier 2 tests to
+        # assert on the visible content without reaching into Textual's
+        # private Static internals (= ``Static.renderable`` is API-
+        # unstable across versions, sometimes ``_renderable``).
+        self._rendered_cache = ""
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -92,6 +106,17 @@ class SlashPicker(Static):
     def has_matches(self) -> bool:
         return bool(self._matches)
 
+    def rendered_text(self) -> str:
+        """Plain-text rendering of the last frame sent to ``Static.update``.
+
+        Stable testing surface — ``Static.renderable`` is API-unstable
+        across Textual versions (sometimes ``_renderable``, sometimes
+        a different accessor), so the picker caches the rendered Text
+        on every ``_repaint`` and exposes it here. Returns "" when the
+        picker is empty / hidden.
+        """
+        return self._rendered_cache
+
     def set_matches(self, matches: list[SlashCommand]) -> None:
         """Replace the match list. Resets selection to row 0."""
         self._total_matches = len(matches)
@@ -100,6 +125,8 @@ class SlashPicker(Static):
         self._hint_cmd = None
         self._completions = []
         self._total_completions = 0
+        self._unknown_token = ""
+        self._unknown_suggestions = []
         self.remove_class("hint-active")
         if self._matches:
             self.add_class("visible")
@@ -127,6 +154,8 @@ class SlashPicker(Static):
         self._hint_cmd = cmd
         self._completions = []
         self._total_completions = 0
+        self._unknown_token = ""
+        self._unknown_suggestions = []
         self.remove_class("visible")
         self.add_class("hint-active")
         self._repaint()
@@ -148,7 +177,39 @@ class SlashPicker(Static):
         self._hint_cmd = cmd
         self._total_completions = len(completions)
         self._completions = list(completions)[:_MAX_VISIBLE]
+        self._unknown_token = ""
+        self._unknown_suggestions = []
         self.remove_class("visible")
+        self.add_class("hint-active")
+        self._repaint()
+
+    def set_unknown_hint(self, typed: str, suggestions: list[str]) -> None:
+        """Show a single dim row reading ``unknown /<typed> — did you mean /<…>?``.
+
+        Used when the user has typed a slash token (= ``/xxxx``) that
+        doesn't prefix any registered command. Without this, the picker
+        silently hides and the user gets no in-input feedback that the
+        command is invalid — they only learn on submit, after the
+        backend returns an "unknown command" error.
+
+        ``typed`` is the typed token WITHOUT the leading ``/``;
+        ``suggestions`` is the prefix-suggestion list (already capped
+        upstream by ``suggest_for_unknown``). Same informational-only
+        contract as hint mode: no caret, no keyboard intercept; the
+        user keeps typing and Enter still submits whatever they have.
+        """
+        self._matches = []
+        self._total_matches = 0
+        self._selected = 0
+        self._hint_cmd = None
+        self._completions = []
+        self._total_completions = 0
+        self._unknown_token = typed
+        self._unknown_suggestions = list(suggestions)
+        self.remove_class("visible")
+        # Re-use the same display gate as hint mode so the existing
+        # ``visible_`` predicate (= matches-only) stays accurate and
+        # downstream keyboard/click paths skip via ``has_matches``.
         self.add_class("hint-active")
         self._repaint()
 
@@ -158,6 +219,8 @@ class SlashPicker(Static):
         self._hint_cmd = None
         self._completions = []
         self._total_completions = 0
+        self._unknown_token = ""
+        self._unknown_suggestions = []
         self.remove_class("visible")
         self.remove_class("hint-active")
         self._repaint()
@@ -212,8 +275,11 @@ class SlashPicker(Static):
         if not self._matches:
             if self._hint_cmd is not None:
                 self._repaint_hint()
+            elif self._unknown_token:
+                self._repaint_unknown_hint()
             else:
                 self.update("")
+                self._rendered_cache = ""
             return
 
         # Width for the command-name column (left)
@@ -266,6 +332,7 @@ class SlashPicker(Static):
                 style="dim #888888",
             )
         self.update(body)
+        self._rendered_cache = str(body.plain)
 
     def _repaint_hint(self) -> None:
         """Render a single dim hint row showing the matched command's summary.
@@ -278,6 +345,7 @@ class SlashPicker(Static):
         cmd = self._hint_cmd
         if cmd is None:
             self.update("")
+            self._rendered_cache = ""
             return
         try:
             term_w = self.app.size.width
@@ -311,3 +379,33 @@ class SlashPicker(Static):
                     style="dim #555555",
                 )
         self.update(t)
+        self._rendered_cache = str(t.plain)
+
+    def _repaint_unknown_hint(self) -> None:
+        """Render the unknown-command in-input feedback line.
+
+        Shape:
+            unknown /xxxx — did you mean /find /save /help?
+
+        The leading "unknown" is dim red so the user notices the
+        feedback at a glance; the suggestion list is dim grey so it
+        reads as helpful context, not as a separate error. Without
+        ``suggest_for_unknown`` upstream we just say "did you mean
+        /help?" because ``suggest_for_unknown`` always falls back
+        to that.
+        """
+        typed = self._unknown_token
+        suggestions = self._unknown_suggestions
+        t = Text()
+        t.append("  ", style="#1a1a1a")
+        t.append("unknown ", style="dim #d4756a")
+        t.append(f"/{typed}", style="dim #d4756a")
+        if suggestions:
+            t.append("  — did you mean ", style="dim #888888")
+            for i, sug in enumerate(suggestions):
+                if i > 0:
+                    t.append(" ", style="dim #888888")
+                t.append(f"/{sug}", style="dim #aaaaaa")
+            t.append("?", style="dim #888888")
+        self.update(t)
+        self._rendered_cache = str(t.plain)

--- a/tests/cli/test_slash_picker_unknown_hint.py
+++ b/tests/cli/test_slash_picker_unknown_hint.py
@@ -1,0 +1,226 @@
+"""Tier 2: in-input feedback when the typed slash token matches no command.
+
+Categorical UX gap fill on the input-bar discoverability axis.
+Before this PR, typing ``/xxxx`` (= a slash token that doesn't
+prefix any registered command) silently hid the picker. The user
+got no in-input signal that the command was invalid — they only
+learned on submit, when the backend returned "unknown command".
+
+This adds an unknown-command hint row to ``SlashPicker``:
+
+    unknown /xxxx — did you mean /find /save /help?
+
+The suggestion list comes from ``suggest_for_unknown`` (= already
+used by the post-submit ErrorBox path) so the in-input feedback
+matches what the user would see if they hit Enter.
+
+Public surfaces tested:
+  - ``SlashPicker.set_unknown_hint`` sets the dim-red unknown row
+  - Visibility gate: ``hint-active`` class is added, ``visible_``
+    stays False (= no keyboard intercept — user keeps typing)
+  - ``set_matches`` / ``set_hint`` / ``hide`` all clear unknown
+    state (= modes are mutually exclusive)
+  - InputBar's ``_update_picker`` flow: typing ``/xxxx`` shows the
+    unknown hint; typing ``/<known-prefix>`` swaps to matches
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _picker_text(picker) -> str:
+    """Plain text rendered by the picker (= what the user sees).
+
+    Reads ``SlashPicker.rendered_text()`` which caches the last frame
+    sent to ``Static.update`` — Textual's ``Static`` has no portable
+    accessor for its current renderable across versions.
+    """
+    return picker.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_set_unknown_hint_renders_unknown_row() -> None:
+    """Tier 2: ``set_unknown_hint`` writes a row reading ``unknown /<typed>``."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_unknown_hint("xxxx", ["find", "help"])
+        await pilot.pause()
+        text = _picker_text(picker)
+        assert "unknown" in text
+        assert "/xxxx" in text
+        assert "/find" in text
+        assert "/help" in text
+
+
+@pytest.mark.asyncio
+async def test_unknown_hint_does_not_set_visible_predicate() -> None:
+    """Tier 2: unknown hint mode keeps ``visible_`` False (= no keyboard intercept).
+
+    Same contract as the existing ``set_hint`` mode — the picker
+    must not steal Enter / Tab / arrow keys, because the user is
+    still typing and might fix the command name. ``visible_``
+    is the matches-only predicate; unknown-hint mode uses the
+    ``hint-active`` CSS class for display gating.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_unknown_hint("xxxx", ["help"])
+        await pilot.pause()
+        assert picker.visible_ is False
+        assert picker.has_matches is False
+        # The hint-active CSS class is the display gate (display: block).
+        assert picker.has_class("hint-active") is True
+
+
+@pytest.mark.asyncio
+async def test_set_matches_clears_unknown_state() -> None:
+    """Tier 2: switching back to matches removes the unknown row.
+
+    Typical flow: user types ``/xxxx`` (unknown hint), then deletes
+    chars to ``/x`` (= multiple matches), the picker should swap to
+    the match list. Pin that the unknown state doesn't leak.
+    """
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_unknown_hint("xxxx", ["help"])
+        await pilot.pause()
+        assert "unknown" in _picker_text(picker)
+
+        async def _h(session, args):  # dummy handler
+            return None
+
+        cmd = SlashCommand(name="real", summary="A real command", handler=_h)
+        picker.set_matches([cmd])
+        await pilot.pause()
+        text = _picker_text(picker)
+        assert "unknown" not in text
+        assert "/real" in text
+
+
+@pytest.mark.asyncio
+async def test_hide_clears_unknown_state() -> None:
+    """Tier 2: ``hide()`` wipes unknown-hint state too."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_unknown_hint("xxxx", ["help"])
+        await pilot.pause()
+        picker.hide()
+        await pilot.pause()
+        assert "unknown" not in _picker_text(picker)
+        assert picker.has_class("hint-active") is False
+
+
+@pytest.mark.asyncio
+async def test_input_bar_typing_unknown_command_shows_hint() -> None:
+    """Tier 2: end-to-end — typing ``/xxxx`` into the InputBar shows the unknown hint.
+
+    Drives the InputBar's ``_update_picker`` flow with a typed
+    unknown command and verifies the resulting picker render
+    contains the suggestion line. This is the gap-fill the PR
+    targets: before this change, ``/xxxx`` typed into the input
+    would silently hide the picker.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        # Slash commands need to be populated so suggest_for_unknown
+        # has something to suggest from. The app wires this up at
+        # mount time via update_slash_commands; pull from the
+        # registry directly to be safe.
+        from reyn.chat.slash import REGISTRY
+        input_bar.update_slash_commands(REGISTRY.all_commands())
+        await pilot.pause()
+
+        input_bar._update_picker("/xxxxnone")
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        text = _picker_text(picker)
+        assert "unknown" in text
+        assert "/xxxxnone" in text
+        # /help is always appended as the escape hatch.
+        assert "/help" in text
+
+
+@pytest.mark.asyncio
+async def test_input_bar_typing_known_prefix_does_not_show_unknown() -> None:
+    """Tier 2: typing a known prefix shows matches, not the unknown hint."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        from reyn.chat.slash import REGISTRY
+        input_bar.update_slash_commands(REGISTRY.all_commands())
+        await pilot.pause()
+        # "/h" matches /help (and possibly others) — should be matches,
+        # not the unknown hint.
+        input_bar._update_picker("/h")
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        text = _picker_text(picker)
+        assert "unknown" not in text
+        assert "/help" in text
+
+
+@pytest.mark.asyncio
+async def test_empty_slash_token_does_not_show_unknown() -> None:
+    """Tier 2: bare ``/`` (token empty) opens the full picker, not unknown hint.
+
+    Empty token = "show me everything" not "I typed an invalid
+    command". Pin that the empty-token path skips the unknown
+    branch entirely.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        from reyn.chat.slash import REGISTRY
+        input_bar.update_slash_commands(REGISTRY.all_commands())
+        await pilot.pause()
+        input_bar._update_picker("/")
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        text = _picker_text(picker)
+        assert "unknown" not in text
+        # Full picker is open → ``visible_`` is True.
+        assert picker.visible_ is True


### PR DESCRIPTION
**[tui-coder]** — Input-bar discoverability categorical gap. Before this PR, typing `/xxxx` (= a slash token that doesn't prefix any registered command) silently hid the picker. Users got no in-input signal that the command was invalid — they only learned on submit, when the backend returned "unknown command".

## Summary

When the typed token has no matches, the picker now switches to an **unknown-hint** mode instead of hiding:

```
  unknown /xxxx — did you mean /find /save /help?
```

The suggestion list comes from `suggest_for_unknown` — the same helper the post-submit ErrorBox path uses, so the in-input feedback now matches what the user would see if they hit Enter on the bad command.

## Implementation

- `SlashPicker.set_unknown_hint(typed, suggestions)` — new informational mode. Same `hint-active` CSS gate as `set_hint` / `set_completions` (NOT `visible_` — picker stays out of the keyboard intercept path so the user can keep typing).
- `_repaint_unknown_hint()` — renders the dim-red `"unknown /<typed>"` prefix + dim-grey suggestion list.
- `InputBar._update_picker` — when token is non-empty and matches list is empty, route to `set_unknown_hint` instead of `set_matches` (which would have hidden the picker).
- Other mode-setters (`set_matches` / `set_hint` / `set_completions` / `hide`) clear unknown state so modes stay mutually exclusive.

## Other infrastructure

- `SlashPicker.rendered_text()` — stable test-side reader for the currently displayed text. Same pattern as `SkillActivityRow.rendered_text()` from #546 — `Static` has no portable accessor for its current renderable across Textual versions, so the picker caches the last frame in `_repaint` and exposes it here.

## Why this layer

- TUI-internal only: touches `widgets/slash_picker.py` (new mode) and `widgets/input_bar.py` (1 routing branch in `_update_picker`). No engine state, no session state.
- Re-uses `suggest_for_unknown` from `chat/slash/__init__.py` so the in-input + post-submit feedback are aligned. No new suggestion logic.
- Empty token (= bare `/`) explicitly skips the unknown branch — "show me everything" not "I typed an invalid command". Pinned in the empty-token test.

## Test plan

- [x] `pytest tests/cli/test_slash_picker_unknown_hint.py` — 7/7 pass (set_unknown_hint renders the row, visible_ stays False, mode-setters clear unknown state, end-to-end via InputBar with unknown token, known prefix shows matches, empty token opens full picker)
- [x] `pytest tests/cli/test_slash_picker_click.py` — existing picker regression unaffected
- [x] `pytest tests/cli/` — 562/562 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, type `/xxxxnonexistent` — picker should show the unknown hint with `/help` suggestion. Type `/fin` — picker swaps to matches showing `/find`. Type `/` alone — full picker opens, no unknown row.
- [x] (skipped — visual styling validation via Tier 2 substring checks on the rendered text)

## Out of scope (deferred)

- Multi-line per-command help inline (= `/find` + `usage: /find <query>` + example below the picker). Bigger scope; the existing one-line hint already covers most users.
- Validation feedback for arg shape (= `/find` with no query — show "argument required" before submit). Each command would need to declare arg shape; defer until pattern is requested.
- Brightness bump on the existing `set_hint` summary (= make `dim #888888` more visible). Cosmetic; separate PR if needed.
