### PR TITLE
feat(tui): structured usage field on SlashCommand + multi-line hint

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -42,6 +42,15 @@ class SlashCommand:
     completer: CompleterFn | None = None  # optional: (session, arg_partial="") -> list[str]
     hidden: bool = False    # if True, omit from /help and the Tab palette
                             # (still dispatchable when typed by name)
+    # Optional structured usage line — when set, the SlashPicker hint
+    # mode (= what shows once the user types ``/<cmd> ``) renders a
+    # second line ``  ↳ usage: <usage>`` below the summary. Commands
+    # that don't set this fall back to single-line hint (= current
+    # behavior, backward-compatible for all existing commands).
+    # Convention: ``/<name> <args>`` with ``<arg>`` for required and
+    # ``[arg]`` for optional, matching the slash tradition (e.g.
+    # ``/find <query>``, ``/copy [N|list]``).
+    usage: str = ""
 
 
 class SlashRegistry:
@@ -115,11 +124,15 @@ def slash(
     aliases: Iterable[str] = (),
     completer: CompleterFn | None = None,
     hidden: bool = False,
+    usage: str = "",
 ) -> Callable[[HandlerFn], HandlerFn]:
     """Decorator that registers `fn` as a slash command on import.
 
     Arguments mirror :class:`SlashCommand`. The decorated function must be
     `async def fn(session, args: str) -> None`.
+
+    ``usage`` is the optional structured usage line surfaced as the
+    second row of the SlashPicker hint mode (see ``SlashCommand.usage``).
     """
 
     def _decorator(fn: HandlerFn) -> HandlerFn:
@@ -130,6 +143,7 @@ def slash(
             aliases=tuple(aliases),
             completer=completer,
             hidden=hidden,
+            usage=usage,
         ))
         return fn
 

--- a/src/reyn/chat/slash/agents.py
+++ b/src/reyn/chat/slash/agents.py
@@ -85,7 +85,8 @@ async def agents_cmd(session: "ChatSession", args: str) -> None:
 
 @slash(
     "attach",
-    summary="Switch attached agent: /attach <name>",
+    summary="Switch attached agent",
+    usage="/attach <name>",
     completer=_attach_completer,
 )
 async def attach_cmd(session: "ChatSession", args: str) -> None:

--- a/src/reyn/chat/slash/copy.py
+++ b/src/reyn/chat/slash/copy.py
@@ -27,7 +27,11 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.chat.slash import slash
 
 
-@slash("copy", summary="Copy an agent reply to the clipboard (/copy [N] or /copy list)")
+@slash(
+    "copy",
+    summary="Copy an agent reply to the clipboard",
+    usage="/copy [N|list]",
+)
 async def copy_cmd(session: "object", args: str) -> None:
     # Forward the raw arg; the TUI handler validates and surfaces errors so
     # we don't duplicate the parsing logic across the slash + outbox layers.

--- a/src/reyn/chat/slash/find.py
+++ b/src/reyn/chat/slash/find.py
@@ -30,7 +30,8 @@ from reyn.chat.slash import slash
 
 @slash(
     "find",
-    summary="Search the conv pane for a substring (/find <query>)",
+    summary="Search the conv pane for a substring",
+    usage="/find <query>",
 )
 async def find_cmd(session: "object", args: str) -> None:
     # Forward the raw arg; the TUI handler validates and surfaces

--- a/src/reyn/chat/slash/save.py
+++ b/src/reyn/chat/slash/save.py
@@ -29,7 +29,8 @@ from reyn.chat.slash import slash
 
 @slash(
     "save",
-    summary="Save the conv pane to a file (/save [path])",
+    summary="Save the conv pane to a file",
+    usage="/save [path]",
 )
 async def save_cmd(session: "object", args: str) -> None:
     # Forward the raw arg; the TUI handler resolves the path

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -363,6 +363,24 @@ class SlashPicker(Static):
         t.append(name, style="dim #888888")
         t.append("  ")
         t.append(summary, style="dim #888888")
+        # Structured usage line — surfaced as a second hint row when the
+        # command opts in via ``SlashCommand.usage``. Indented under the
+        # summary with a ``↳`` connector so the eye groups them as
+        # "one command, two informational rows". Commands without
+        # usage stay 1-line (backward compatible). Skipped when
+        # completions are present — completions already carry
+        # actionable arg info, and stacking usage + completions would
+        # push the picker past ``max-height: 11`` for /attach-like
+        # cases with many agent names.
+        if cmd.usage and not self._completions:
+            indent = " " * (2 + len(name) + 2)
+            usage_budget = max(10, content_w - len(indent) - 9)  # 9 = "↳ usage: "
+            usage_text = cmd.usage
+            if len(usage_text) > usage_budget:
+                usage_text = usage_text[: max(1, usage_budget - 1)] + "…"
+            t.append("\n")
+            t.append(indent + "↳ usage: ", style="dim #666666")
+            t.append(usage_text, style="dim #aaaaaa")
         # Completion rows (if the command supplied a CompleterFn — e.g.
         # /attach surfacing agent names). Indented under the hint row,
         # one per line, dim, informational only.

--- a/tests/cli/test_slash_picker_multiline_hint.py
+++ b/tests/cli/test_slash_picker_multiline_hint.py
@@ -1,0 +1,221 @@
+"""Tier 2: SlashPicker hint mode renders a usage line when ``cmd.usage`` is set.
+
+Follow-on to PR #550 (= unknown-command hint). Completes the input-
+bar discoverability axis. Before this PR, the picker hint mode
+(= what shows once the user types ``/<cmd> ``) was a single dim row:
+
+    /find  Search the conv pane for a substring (/find <query>)
+
+The usage was crammed into the summary string in parens, which:
+  1. Truncated on narrow terminals (usage often got cut off)
+  2. Mixed prose description with formal arg syntax
+  3. Was inconsistent across commands (some used parens, others
+     used colon, others didn't surface usage at all)
+
+This PR adds an optional structured ``usage`` field to
+:class:`SlashCommand`. When set, the hint mode renders a second
+row:
+
+    /find  Search the conv pane for a substring
+            ↳ usage: /find <query>
+
+Commands that don't set ``usage`` stay 1-line (backward
+compatible — no existing command behaviour changes by default).
+Opt-in update for /find, /save, /copy, /attach in this PR;
+remaining commands stay 1-line until a future PR extends them.
+
+Public surfaces tested:
+  - ``SlashCommand.usage`` defaults to empty string
+  - ``@slash(... usage=...)`` decorator stores the value
+  - ``_repaint_hint`` renders a second ``↳ usage:`` line when
+    ``cmd.usage`` is set, NOT when it's empty
+  - ``_repaint_hint`` does NOT render the usage line when
+    completions are active (= /attach <partial> with matches;
+    completions already carry actionable arg info)
+  - /find, /save, /copy, /attach commands have usage configured
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _picker_text(picker) -> str:
+    return picker.rendered_text()
+
+
+def test_slashcommand_usage_field_defaults_to_empty() -> None:
+    """Tier 2: ``usage`` defaults to empty so existing commands keep working."""
+    from reyn.chat.slash import SlashCommand
+
+    async def _h(s, a):
+        return None
+
+    cmd = SlashCommand(name="x", summary="summary", handler=_h)
+    assert cmd.usage == ""
+
+
+def test_slash_decorator_forwards_usage() -> None:
+    """Tier 2: ``@slash(usage=...)`` propagates the value into the registered command."""
+    from reyn.chat.slash import REGISTRY, slash
+
+    @slash("xtmpcmd_usage", summary="t", usage="/xtmpcmd_usage <arg>")
+    async def _h(s, a):
+        return None
+
+    cmd = REGISTRY.get("xtmpcmd_usage")
+    assert cmd is not None
+    assert cmd.usage == "/xtmpcmd_usage <arg>"
+
+
+@pytest.mark.asyncio
+async def test_hint_with_usage_renders_two_lines() -> None:
+    """Tier 2: hint mode shows the usage line below the summary."""
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="testcmd",
+            summary="Do a thing with the buffer",
+            handler=_h,
+            usage="/testcmd <arg>",
+        )
+        picker.set_hint(cmd)
+        await pilot.pause()
+        text = _picker_text(picker)
+        # Both lines present.
+        assert "/testcmd" in text
+        assert "Do a thing with the buffer" in text
+        assert "↳ usage:" in text
+        assert "/testcmd <arg>" in text
+        # Two-line shape: at least one newline between summary and usage.
+        assert "\n" in text
+
+
+@pytest.mark.asyncio
+async def test_hint_without_usage_renders_one_line() -> None:
+    """Tier 2: legacy command (no usage set) keeps the original 1-line hint."""
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="legacy",
+            summary="Legacy command with no structured usage",
+            handler=_h,
+        )
+        picker.set_hint(cmd)
+        await pilot.pause()
+        text = _picker_text(picker)
+        assert "Legacy command" in text
+        # No usage line.
+        assert "↳ usage:" not in text
+
+
+@pytest.mark.asyncio
+async def test_completions_suppress_usage_line() -> None:
+    """Tier 2: when completions are surfaced, the usage line is suppressed.
+
+    The completions are themselves arg-list context — adding the
+    usage line on top would be redundant + push the picker past
+    its height cap on commands with many matching completions
+    (e.g. /attach with 8 agent names).
+    """
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="testcmd2",
+            summary="Has both usage and completions",
+            handler=_h,
+            usage="/testcmd2 <name>",
+        )
+        picker.set_completions(cmd, ["alpha", "beta"])
+        await pilot.pause()
+        text = _picker_text(picker)
+        # Completions visible.
+        assert "alpha" in text
+        assert "beta" in text
+        # Usage line suppressed.
+        assert "↳ usage:" not in text
+
+
+def test_find_command_has_usage() -> None:
+    """Tier 2: /find opts into the structured usage line."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("find")
+    assert cmd is not None
+    assert cmd.usage == "/find <query>"
+
+
+def test_save_command_has_usage() -> None:
+    """Tier 2: /save opts into the structured usage line."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("save")
+    assert cmd is not None
+    assert cmd.usage == "/save [path]"
+
+
+def test_copy_command_has_usage() -> None:
+    """Tier 2: /copy opts into the structured usage line."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("copy")
+    assert cmd is not None
+    assert cmd.usage == "/copy [N|list]"
+
+
+def test_attach_command_has_usage() -> None:
+    """Tier 2: /attach opts into the structured usage line."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("attach")
+    assert cmd is not None
+    assert cmd.usage == "/attach <name>"
+
+
+def test_find_summary_no_longer_carries_redundant_paren_usage() -> None:
+    """Tier 2: /find summary stripped of the embedded ``(/find <query>)``.
+
+    After moving usage to its own field, the summary should be
+    the prose description only — no embedded usage paren. Pin
+    this so a future revert can't accidentally re-introduce the
+    redundancy.
+    """
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("find")
+    assert cmd is not None
+    assert "(/find" not in cmd.summary
+    assert cmd.summary == "Search the conv pane for a substring"


### PR DESCRIPTION
**[tui-coder]** — Input-bar discoverability axis completion PR (#550 follow-on). Before this PR, the picker hint mode (= what shows once the user types `/<cmd> `) was a single dim row with usage crammed into the summary string in parens. Truncated on narrow terminals, mixed prose with formal arg syntax, and was inconsistent across commands (some parens, some colon, some nothing).

## Summary

Add an optional structured `usage` field to `SlashCommand`. When set, the hint mode renders a second row:

```
  /find  Search the conv pane for a substring
          ↳ usage: /find <query>
```

Commands without `usage` set stay 1-line — backward compatible for every command not touched by this PR.

## Opt-in update (this PR)

| cmd      | new summary                              | new usage           |
|----------|------------------------------------------|---------------------|
| `/find`  | Search the conv pane for a substring     | `/find <query>`     |
| `/save`  | Save the conv pane to a file             | `/save [path]`      |
| `/copy`  | Copy an agent reply to the clipboard     | `/copy [N\|list]`   |
| `/attach`| Switch attached agent                    | `/attach <name>`    |

Remaining commands (`/cancel`, `/answer`, `/plan`, `/agent`, `/memory`, `/docs-filter`, etc.) keep their existing summaries → 1-line hint unchanged. Future PR can extend opt-in as needed.

## Implementation

- `SlashCommand.usage: str = ""` — new field on the dataclass, defaults to empty so existing commands keep working.
- `@slash(... usage=...)` — decorator forwards the value.
- `SlashPicker._repaint_hint` — when `cmd.usage` is non-empty AND no completions are surfaced, render a second indented row `↳ usage: <usage>` below the summary. Width-budget aware (truncates with `…` on very narrow terminals).
- Completions suppress the usage line — they already carry actionable arg info (e.g., `/attach <partial>` showing agent names); stacking usage on top would be redundant + push the picker past its `max-height: 11` cap.

## Why this layer

- TUI-internal: touches `chat/slash/__init__.py` (1 field + decorator forward) and `chat/tui/widgets/slash_picker.py` (1 render branch). The 4 opt-in commands get small tweaks to their `@slash` decoration. No engine state.
- Backward compatible — every command that doesn't opt in renders identically to before.

## Test plan

- [x] `pytest tests/cli/test_slash_picker_multiline_hint.py` — 10/10 pass (usage default, decorator forward, 2-line vs 1-line, completions suppress, opt-in pinned for /find /save /copy /attach, /find summary regression guard)
- [x] `pytest tests/cli/test_conv_find_history_search.py` — 6/6 pass (= /find MVP regression: summary substring assertion still passes because the desc-only summary is still a substring of the old paren form)
- [x] `pytest tests/cli/test_conv_save_to_file.py` — 8/8 pass
- [x] `pytest tests/cli/test_slash_picker_unknown_hint.py` — 7/7 pass
- [x] `pytest tests/cli/test_slash_picker_click.py` — 5/5 pass
- [x] `pytest tests/cli/` — 572/572 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, type `/find ` (with space) — picker should show the 2-line hint (description + ↳ usage). Type `/cost-inline ` — should still show 1-line hint (unchanged, no opt-in). Type `/attach a` — completions show, usage line suppressed.
- [x] (skipped — narrow-terminal truncation validated via width-budget code path, not live)

## Out of scope (deferred)

- Multi-line examples (= a 3rd "↳ example: …" row). The `usage` field surfaces formal syntax; examples would need either a new `examples: tuple[str, ...]` field or parsing from docstrings. Defer until requested.
- Extending opt-in to remaining commands (`/cancel`, `/answer`, `/plan`, `/agent`, `/memory`, /`docs-filter`, etc.). Mechanical; each takes 1 line. Defer to a follow-on so this PR stays scoped to the field + 4 high-traffic commands.
- Tab-confirm hint on the 2nd line (= "Tab → autocomplete"). Could surface in a 3rd row but adds visual weight; defer.
