### PR TITLE
feat(safe): reyn.safe public namespace + permission-gated reyn.safe.file (FP-0042 Phase 1)

### DIFF
--- a/src/reyn/api/safe/__init__.py
+++ b/src/reyn/api/safe/__init__.py
@@ -1,10 +1,17 @@
-"""Reyn-provided helpers callable from `safe`-mode python steps.
+"""Re-export shim — the public path is now :mod:`reyn.safe`.
 
-Every function here is provably ambient: output is determined only
-by inputs + clock + entropy + bundled static data. The AST
-validator allows ``import reyn.api.safe.*`` from safe mode.
+FP-0042 moved the safe-mode helpers from ``reyn.api.safe.*`` to
+``reyn.safe.*`` so the existing ``_python_allowlist`` rule for
+``reyn.safe.*`` actually matches the import path. This module survives
+for one release as a backward-compat shim: imports from
+``reyn.api.safe.X`` continue to resolve to the canonical
+``reyn.safe.X`` module.
+
+The submodules under this package re-export from ``reyn.safe.*``; see
+each module file. The shim is scheduled for removal in the next
+release — please migrate to ``reyn.safe.*`` imports.
 """
 
-from . import hash, json, random, schema, text, time
+from reyn.safe import hash, json, random, schema, text, time
 
 __all__ = ["hash", "schema", "text", "json", "time", "random"]

--- a/src/reyn/api/safe/hash.py
+++ b/src/reyn/api/safe/hash.py
@@ -1,28 +1,7 @@
-"""Cryptographic and non-cryptographic hash helpers.
+"""Shim re-export — canonical module is :mod:`reyn.safe.hash`.
 
-All functions accept ``bytes`` and return a lowercase hex digest
-string. Wrap stdlib ``hashlib`` — output is a pure function of input.
+FP-0042 backward-compat: import from reyn.api.safe.hash is
+forwarded to the canonical reyn.safe.hash. Scheduled for removal
+in the next release — please migrate to from reyn.safe import hash.
 """
-
-from __future__ import annotations
-
-import hashlib as _hashlib
-
-
-def sha256(b: bytes) -> str:
-    """Return the lowercase hex SHA-256 digest of ``b``."""
-    return _hashlib.sha256(b).hexdigest()
-
-
-def md5(b: bytes) -> str:
-    """Return the lowercase hex MD5 digest of ``b``.
-
-    MD5 is not cryptographically secure; use for non-security
-    fingerprints only.
-    """
-    return _hashlib.md5(b).hexdigest()
-
-
-def blake2b(b: bytes) -> str:
-    """Return the lowercase hex BLAKE2b digest of ``b``."""
-    return _hashlib.blake2b(b).hexdigest()
+from reyn.safe.hash import *  # noqa: F401,F403 — re-export

--- a/src/reyn/api/safe/json.py
+++ b/src/reyn/api/safe/json.py
@@ -1,35 +1,7 @@
-"""Strict / canonical JSON helpers."""
+"""Shim re-export — canonical module is :mod:`reyn.safe.json`.
 
-from __future__ import annotations
-
-import json as _json
-from typing import Any
-
-
-def _no_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    seen: set[str] = set()
-    out: dict[str, Any] = {}
-    for k, v in pairs:
-        if k in seen:
-            raise ValueError(f"duplicate key in JSON object: {k!r}")
-        seen.add(k)
-        out[k] = v
-    return out
-
-
-def loads_strict(s: str) -> Any:
-    """Parse ``s`` as JSON, rejecting objects with duplicate keys.
-
-    Standard ``json.loads`` silently overwrites duplicate keys; this
-    wrapper raises ``ValueError`` instead.
-    """
-    return _json.loads(s, object_pairs_hook=_no_duplicate_keys)
-
-
-def dumps_canonical(d: Any) -> str:
-    """Dump ``d`` in canonical form (= ``sort_keys=True``, non-ASCII kept).
-
-    Suitable for content addressing — two equal objects produce the
-    same byte sequence.
-    """
-    return _json.dumps(d, sort_keys=True, ensure_ascii=False)
+FP-0042 backward-compat: import from reyn.api.safe.json is
+forwarded to the canonical reyn.safe.json. Scheduled for removal
+in the next release — please migrate to from reyn.safe import json.
+"""
+from reyn.safe.json import *  # noqa: F401,F403 — re-export

--- a/src/reyn/api/safe/random.py
+++ b/src/reyn/api/safe/random.py
@@ -1,15 +1,7 @@
-"""Random helpers — explicit seeding only (no ambient global RNG)."""
+"""Shim re-export — canonical module is :mod:`reyn.safe.random`.
 
-from __future__ import annotations
-
-import random as _random
-
-
-def seeded(seed: int) -> _random.Random:
-    """Return a fresh ``random.Random`` seeded with ``seed``.
-
-    The returned RNG is independent of the global ``random`` module
-    state; reusing the same seed across calls reproduces the same
-    sequence (= deterministic under replay).
-    """
-    return _random.Random(seed)
+FP-0042 backward-compat: import from reyn.api.safe.random is
+forwarded to the canonical reyn.safe.random. Scheduled for removal
+in the next release — please migrate to from reyn.safe import random.
+"""
+from reyn.safe.random import *  # noqa: F401,F403 — re-export

--- a/src/reyn/api/safe/schema.py
+++ b/src/reyn/api/safe/schema.py
@@ -1,74 +1,7 @@
-"""JSON Schema validation helper.
+"""Shim re-export — canonical module is :mod:`reyn.safe.schema`.
 
-Prefers the optional ``jsonschema`` dependency; falls back to a
-minimal in-house implementation supporting ``type``, ``required``,
-and ``properties`` only (= sufficient for simple schemas, signals
-to the author when they need richer features).
+FP-0042 backward-compat: import from reyn.api.safe.schema is
+forwarded to the canonical reyn.safe.schema. Scheduled for removal
+in the next release — please migrate to from reyn.safe import schema.
 """
-
-from __future__ import annotations
-
-from typing import Any
-
-try:  # pragma: no cover - import branch determined at install time
-    import jsonschema as _jsonschema  # type: ignore
-    _HAS_JSONSCHEMA = True
-except ImportError:  # pragma: no cover
-    _HAS_JSONSCHEMA = False
-
-
-_TYPE_MAP: dict[str, tuple[type, ...]] = {
-    "object": (dict,),
-    "array": (list,),
-    "string": (str,),
-    "integer": (int,),
-    "number": (int, float),
-    "boolean": (bool,),
-    "null": (type(None),),
-}
-
-
-class SchemaError(ValueError):
-    """Raised when ``data`` does not conform to ``schema``."""
-
-
-def _minimal_validate(data: Any, schema: dict, path: str = "$") -> None:
-    expected = schema.get("type")
-    if expected is not None:
-        # ``integer`` is a subset of ``number`` but bool subclasses int —
-        # exclude bool from int/number checks.
-        types = _TYPE_MAP.get(expected)
-        if types is None:
-            raise SchemaError(f"{path}: unknown schema type {expected!r}")
-        if expected in ("integer", "number") and isinstance(data, bool):
-            raise SchemaError(f"{path}: expected {expected}, got bool")
-        if not isinstance(data, types):
-            raise SchemaError(
-                f"{path}: expected {expected}, got {type(data).__name__}"
-            )
-    if expected == "object" or (expected is None and isinstance(data, dict)):
-        required = schema.get("required", [])
-        for key in required:
-            if key not in data:
-                raise SchemaError(f"{path}: missing required property {key!r}")
-        properties = schema.get("properties", {})
-        for key, subschema in properties.items():
-            if key in data:
-                _minimal_validate(data[key], subschema, f"{path}.{key}")
-
-
-def validate(data: Any, schema: dict) -> None:
-    """Validate ``data`` against the JSON Schema ``schema``.
-
-    Raises ``SchemaError`` (a ``ValueError`` subclass) if invalid.
-    Uses the ``jsonschema`` package if available, otherwise a
-    minimal fallback that understands ``type`` / ``required`` /
-    ``properties``.
-    """
-    if _HAS_JSONSCHEMA:
-        try:
-            _jsonschema.validate(instance=data, schema=schema)  # type: ignore[attr-defined]
-        except _jsonschema.ValidationError as exc:  # type: ignore[attr-defined]
-            raise SchemaError(str(exc)) from exc
-    else:
-        _minimal_validate(data, schema)
+from reyn.safe.schema import *  # noqa: F401,F403 — re-export

--- a/src/reyn/api/safe/text.py
+++ b/src/reyn/api/safe/text.py
@@ -1,37 +1,7 @@
-"""Text helpers: named-group regex extraction and safe templating."""
+"""Shim re-export — canonical module is :mod:`reyn.safe.text`.
 
-from __future__ import annotations
-
-import re as _re
-
-
-def regex_findall_named(pattern: str, text: str) -> list[dict[str, str]]:
-    """Return a list of named-group dicts for every match of ``pattern``.
-
-    Each entry is the ``match.groupdict()`` of one match. Groups that
-    did not participate in the match map to an empty string. Matches
-    without any named groups produce empty dicts.
-    """
-    regex = _re.compile(pattern)
-    out: list[dict[str, str]] = []
-    for m in regex.finditer(text):
-        gd = m.groupdict()
-        out.append({k: (v if v is not None else "") for k, v in gd.items()})
-    return out
-
-
-class _SafeDict(dict):
-    """Dict that returns ``{key}`` literally for missing keys."""
-
-    def __missing__(self, key: str) -> str:  # type: ignore[override]
-        return "{" + key + "}"
-
-
-def template_render_safe(template: str, ctx: dict) -> str:
-    """Render ``template`` with ``str.format_map`` over a safe dict.
-
-    Missing keys render literally as ``{key}`` rather than raising
-    ``KeyError``. No attribute access or method calls are evaluated
-    via this helper since callers only provide a plain ``dict``.
-    """
-    return template.format_map(_SafeDict(ctx))
+FP-0042 backward-compat: import from reyn.api.safe.text is
+forwarded to the canonical reyn.safe.text. Scheduled for removal
+in the next release — please migrate to from reyn.safe import text.
+"""
+from reyn.safe.text import *  # noqa: F401,F403 — re-export

--- a/src/reyn/api/safe/time.py
+++ b/src/reyn/api/safe/time.py
@@ -1,16 +1,7 @@
-"""Time helpers (ambient sources — outputs are non-deterministic)."""
+"""Shim re-export — canonical module is :mod:`reyn.safe.time`.
 
-from __future__ import annotations
-
-import time as _time
-
-
-def monotonic_seq() -> float:
-    """Return a monotonic clock value in seconds.
-
-    Non-deterministic: two calls within the same process produce
-    different values. Wraps ``time.monotonic``. Use only when the
-    step's contract permits ambient clock reads (= replay records
-    the value).
-    """
-    return _time.monotonic()
+FP-0042 backward-compat: import from reyn.api.safe.time is
+forwarded to the canonical reyn.safe.time. Scheduled for removal
+in the next release — please migrate to from reyn.safe import time.
+"""
+from reyn.safe.time import *  # noqa: F401,F403 — re-export

--- a/src/reyn/kernel/_python_harness.py
+++ b/src/reyn/kernel/_python_harness.py
@@ -186,6 +186,12 @@ def main() -> int:
         mode = str(req.get("mode", "safe"))
         artifact = req.get("artifact", {})
         allowed_modules = frozenset(req.get("allowed_modules") or [])
+        # FP-0042: file-permission paths declared by the skill, forwarded
+        # by the parent's PreprocessorExecutor / PythonRunner. Either may
+        # be empty (= no read / write granted). The values gate every
+        # ``reyn.safe.file.*`` call from the user step.
+        file_read_paths = list(req.get("file_read_paths") or [])
+        file_write_paths = list(req.get("file_write_paths") or [])
 
         if mode not in ("safe", "unsafe"):
             raise ValueError(f"unknown mode: {mode!r}")
@@ -200,6 +206,23 @@ def main() -> int:
             raise AttributeError(
                 f"function {function_name!r} not found in {module_path}"
             )
+
+        # FP-0042: initialise reyn.safe.file's permission context before
+        # the user step runs. The user code already executed (= module
+        # exec at _exec_user_module) but the file-call paths only fire
+        # when the function below is invoked. Safe either way: the
+        # context is established before any guarded call.
+        try:
+            from reyn.safe import file as _safe_file
+            _safe_file._set_permission_context(
+                read_paths=file_read_paths,
+                write_paths=file_write_paths,
+            )
+        except ImportError:
+            # reyn.safe.file may not be available in older parent
+            # installations (= shouldn't happen post-FP-0042 land but
+            # defence-in-depth for parent / harness version skew).
+            pass
 
         # Defensive copy so user mutations don't affect the parent's data.
         result = fn(copy.deepcopy(artifact))

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -469,6 +469,22 @@ class PreprocessorExecutor:
             module=step.module, function=step.function, mode=perm.mode,
         )
 
+        # FP-0042: forward the skill's declared file-read / file-write
+        # paths into the subprocess so ``reyn.safe.file.*`` calls inside
+        # the user step can gate against them. Paths are passed verbatim
+        # — the subprocess-side check is decl-membership, not the full
+        # 4-layer ask flow (= those layers already fired at startup_guard
+        # time before this step ran). Empty lists mean "no file access
+        # granted" and any reyn.safe.file.* call raises PermissionError.
+        file_read_paths = [
+            entry["path"] for entry in self._skill.permissions.file_read
+            if isinstance(entry, dict) and entry.get("path")
+        ]
+        file_write_paths = [
+            entry["path"] for entry in self._skill.permissions.file_write
+            if isinstance(entry, dict) and entry.get("path")
+        ]
+
         try:
             result = await asyncio.to_thread(
                 self._python_runner.run,
@@ -479,6 +495,8 @@ class PreprocessorExecutor:
                 artifact=artifact,
                 timeout=perm.timeout,
                 allowed_modules=self._python_allowed_modules,
+                file_read_paths=file_read_paths,
+                file_write_paths=file_write_paths,
             )
         except PythonStepError as exc:
             self._events.emit(

--- a/src/reyn/python_runner.py
+++ b/src/reyn/python_runner.py
@@ -84,6 +84,8 @@ class PythonRunner:
         artifact: dict,
         timeout: int,
         allowed_modules: list[str] | None = None,
+        file_read_paths: list[str] | None = None,
+        file_write_paths: list[str] | None = None,
     ) -> Any:
         """Execute `function` in `module` against `artifact`.
 
@@ -91,6 +93,12 @@ class PythonRunner:
         PythonStepError if anything goes wrong: module-not-found, sandbox
         violation, the function raising, JSON serialization failure,
         timeout, or child crash.
+
+        FP-0042: ``file_read_paths`` / ``file_write_paths`` forward the
+        skill-declared file permission paths into the subprocess so
+        ``reyn.safe.file.*`` calls inside the step can gate against
+        them. Both default to empty (= no file access granted) — pass
+        the absolute paths the parent has approved for this step.
         """
         module_abs = _resolve_module_path(skill_dir, module)
 
@@ -100,6 +108,9 @@ class PythonRunner:
             "mode": mode,
             "artifact": artifact,
             "allowed_modules": list(allowed_modules or []),
+            # FP-0042: file-permission paths for reyn.safe.file gating.
+            "file_read_paths": list(file_read_paths or []),
+            "file_write_paths": list(file_write_paths or []),
         }
 
         try:

--- a/src/reyn/safe/__init__.py
+++ b/src/reyn/safe/__init__.py
@@ -1,0 +1,31 @@
+"""Public surface for Reyn helpers callable from safe-mode python steps.
+
+FP-0042 — `reyn.safe.*` is the documented public path for the helpers the
+allowlist (`src/reyn/kernel/_python_allowlist.py`) already grants safe-mode
+steps. Pre-FP-0042 the implementations lived under `reyn.api.safe.*`,
+which the allowlist does not match — closing that gap is the reason
+this package exists.
+
+Available modules:
+
+- :mod:`reyn.safe.file` — permission-gated file I/O (`read`, `write`,
+  `glob`, `exists`, `stat`, `open`). New in FP-0042. Operates only on
+  paths declared in the calling skill's ``permissions.file.read_paths`` /
+  ``permissions.file.write_paths``; reads outside the declared set raise
+  :class:`PermissionError`.
+
+- :mod:`reyn.safe.hash` — `sha256` / `sha256_hex`.
+- :mod:`reyn.safe.json` — strict / canonical JSON helpers.
+- :mod:`reyn.safe.random` — explicit-seeded RNG.
+- :mod:`reyn.safe.schema` — JSON Schema validation.
+- :mod:`reyn.safe.text` — named-group regex + safe templating.
+- :mod:`reyn.safe.time` — monotonic / wall clock helpers (ambient).
+
+Migration note: until FP-0042 Phase 3 lands, ``reyn.api.safe.*`` continues
+to work via shim re-exports from this package. New code should import from
+``reyn.safe.*``; existing code may migrate at its own pace.
+"""
+
+from . import file, hash, json, random, schema, text, time
+
+__all__ = ["file", "hash", "json", "random", "schema", "text", "time"]

--- a/src/reyn/safe/file.py
+++ b/src/reyn/safe/file.py
@@ -1,0 +1,247 @@
+"""Permission-gated file I/O for safe-mode python preprocessor / postprocessor steps.
+
+FP-0042 — replaces ``reyn.api.unsafe.file`` for stdlib (and any user skill
+that wants to opt into the Reyn permission model). Every file operation
+goes through the path-declaration check that the calling skill's
+``skill.md`` opted into; reads / writes outside the declared paths raise
+:class:`PermissionError` and the step fails with a structured error.
+
+Public surface
+--------------
+
+High-level (drop-in replacement for ``reyn.api.unsafe.file``):
+
+- :func:`read(path, *, encoding="utf-8")` → str
+- :func:`write(path, content, *, encoding="utf-8")` → None
+- :func:`glob(pattern)` → list[str]
+- :func:`exists(path)` → bool
+- :func:`stat(path)` → {size, mtime, mode}
+
+Low-level (Python-IO-compatible):
+
+- :func:`open(path, mode="r", *, encoding="utf-8", **kwargs)` → real
+  ``io.TextIOBase`` / ``io.BufferedIOBase``. Use when streaming or
+  partial reads matter, or when handing a file-like to a stdlib parser
+  (``csv.reader``, ``json.load``, ``for line in f``).
+
+Permission model
+----------------
+
+The check happens at call boundary (read) or at open time (``open``).
+After permission grants, ``read`` performs a single full read and
+``open`` returns the real file object — meaning subsequent ``seek`` /
+``read(n)`` calls on the returned object are NOT individually
+permission-checked. The permission contract is "may read this path",
+not "may read these bytes".
+
+Permission context is injected by the python harness
+(``src/reyn/kernel/_python_harness.py``) before the user step runs.
+Calling these functions outside that context (= bare unit test, ad-hoc
+script) raises a clear ``PermissionError`` explaining how to set up the
+context — see :func:`_set_permission_context` below.
+
+Glob semantics
+--------------
+
+``glob`` does not gate the pattern itself — path enumeration without
+content read is a metadata-level operation endorsed by the
+2026-05-15 R-PURE-MODE stdlib audit. Subsequent content reads of any
+returned path still go through :func:`read` / :func:`open` and are
+permission-gated there.
+"""
+from __future__ import annotations
+
+import builtins as _builtins
+import glob as _glob_mod
+import os as _os
+from typing import IO, Any
+
+# ── Internal state ─────────────────────────────────────────────────────────
+#
+# These three module-globals are set once at python harness start-up via
+# :func:`_set_permission_context`. The values then govern every read /
+# write / open call made by the user's python step against this module.
+
+_read_paths: tuple[str, ...] = ()
+_write_paths: tuple[str, ...] = ()
+_context_initialised: bool = False
+
+
+def _set_permission_context(
+    *,
+    read_paths: list[str] | tuple[str, ...] | None = None,
+    write_paths: list[str] | tuple[str, ...] | None = None,
+) -> None:
+    """Wire permission paths into this module.
+
+    Called by :mod:`reyn.kernel._python_harness` before the user step
+    runs. Tests that exercise the file API directly may call this to
+    establish a controlled context; production code should not.
+
+    Idempotent: calling this overwrites the previous context. Passing
+    ``None`` for either argument leaves that paths list empty (= every
+    read / write is denied).
+    """
+    global _read_paths, _write_paths, _context_initialised
+    _read_paths = tuple(read_paths or ())
+    _write_paths = tuple(write_paths or ())
+    _context_initialised = True
+
+
+def _is_under(path: str, allowed: tuple[str, ...]) -> bool:
+    """Return True if ``path`` resolves under any of ``allowed`` paths.
+
+    Each ``allowed`` entry is normalised via ``os.path.abspath`` and
+    treated as a directory-or-file prefix. ``path`` is normalised the
+    same way, so ``../foo`` style escapes are caught by abspath
+    expansion.
+
+    Behaviour notes:
+      - ``""`` (= empty string) in ``allowed`` matches nothing.
+      - An exact-match prefix at a directory boundary counts (= the
+        ``+ os.sep`` guard prevents ``/foo/bar`` matching ``/foo/barbaz``).
+    """
+    abs_path = _os.path.abspath(path)
+    for entry in allowed:
+        if not entry:
+            continue
+        abs_entry = _os.path.abspath(entry)
+        if abs_path == abs_entry:
+            return True
+        # Treat allowed entries as prefixes only at directory boundaries.
+        if abs_path.startswith(abs_entry + _os.sep):
+            return True
+    return False
+
+
+def _check_read(path: str) -> None:
+    if not _context_initialised:
+        raise PermissionError(
+            "reyn.safe.file: permission context not initialised. This "
+            "module must be invoked from a PythonRunner-managed safe-mode "
+            "step; bare-process use requires calling "
+            "_set_permission_context(read_paths=..., write_paths=...) "
+            f"first (read attempted: {path!r})."
+        )
+    if not _is_under(path, _read_paths):
+        raise PermissionError(
+            f"reyn.safe.file: read from {path!r} is not in the declared "
+            f"read_paths {list(_read_paths)}. Declare it in skill.md "
+            f"frontmatter:\n"
+            f"  permissions:\n"
+            f"    file.read:\n"
+            f"      - path: {path}\n"
+            f"        scope: just_path\n"
+        )
+
+
+def _check_write(path: str) -> None:
+    if not _context_initialised:
+        raise PermissionError(
+            "reyn.safe.file: permission context not initialised "
+            f"(write attempted: {path!r})."
+        )
+    if not _is_under(path, _write_paths):
+        raise PermissionError(
+            f"reyn.safe.file: write to {path!r} is not in the declared "
+            f"write_paths {list(_write_paths)}. Declare it in skill.md "
+            f"frontmatter:\n"
+            f"  permissions:\n"
+            f"    file.write:\n"
+            f"      - path: {path}\n"
+            f"        scope: just_path\n"
+        )
+
+
+# ── High-level API (drop-in for reyn.api.unsafe.file) ───────────────────────
+
+
+def read(path: str, *, encoding: str = "utf-8") -> str:
+    """Read and return the text contents of ``path``.
+
+    Permission-checked: ``path`` must resolve under one of the
+    declared ``read_paths``. Raises :class:`PermissionError` otherwise.
+    """
+    _check_read(path)
+    with _builtins.open(path, encoding=encoding) as f:
+        return f.read()
+
+
+def write(path: str, content: str, *, encoding: str = "utf-8") -> None:
+    """Write ``content`` to ``path``, replacing any existing content.
+
+    Permission-checked: ``path`` must resolve under one of the
+    declared ``write_paths``. Raises :class:`PermissionError` otherwise.
+    """
+    _check_write(path)
+    with _builtins.open(path, "w", encoding=encoding) as f:
+        f.write(content)
+
+
+def glob(pattern: str) -> list[str]:
+    """Return paths matching ``pattern`` (recursive ``**`` supported).
+
+    Glob is metadata-level enumeration, not content read; the
+    2026-05-15 R-PURE-MODE stdlib audit endorsed unrestricted glob
+    for safe-mode python steps. Subsequent reads of any returned path
+    still go through :func:`read` / :func:`open` and are
+    permission-gated there.
+
+    Result is sorted for stable iteration.
+    """
+    return sorted(_glob_mod.glob(pattern, recursive=True))
+
+
+def exists(path: str) -> bool:
+    """Return whether ``path`` exists.
+
+    Permission-checked as a read (= existence is a metadata observation
+    that requires the same authority as reading the file).
+    """
+    _check_read(path)
+    return _os.path.exists(path)
+
+
+def stat(path: str) -> dict[str, Any]:
+    """Return a simplified ``{size, mtime, mode}`` dict for ``path``.
+
+    Permission-checked as a read.
+    """
+    _check_read(path)
+    st = _os.stat(path)
+    return {"size": st.st_size, "mtime": st.st_mtime, "mode": st.st_mode}
+
+
+# ── Low-level API (Python-IO-compatible) ────────────────────────────────────
+
+
+def open(  # noqa: A001 — intentional shadowing of builtin in this module's surface
+    path: str,
+    mode: str = "r",
+    *,
+    encoding: str = "utf-8",
+    **kwargs: Any,
+) -> IO[Any]:
+    """Permission-gated equivalent of ``builtins.open``.
+
+    Returns a real ``io.TextIOBase`` / ``io.BufferedIOBase``. Mode
+    determines which permission applies: any mode containing ``w``,
+    ``a``, ``x``, or ``+`` requires write; otherwise read.
+
+    Once permission grants, the returned object behaves identically to
+    the result of ``builtins.open(path, mode, encoding=encoding,
+    **kwargs)``. Subsequent ``seek`` / ``read(n)`` / iteration on the
+    returned object are NOT per-call permission-checked — the contract
+    is "may read this path".
+
+    ``builtins.open`` itself is banned in safe-mode python by the AST
+    validator; this function is the permission-gated gateway that
+    replaces it.
+    """
+    needs_write = any(c in mode for c in ("w", "a", "x", "+"))
+    if needs_write:
+        _check_write(path)
+    else:
+        # Default to read for empty / read-only modes ("r", "rb", "rt", ...).
+        _check_read(path)
+    return _builtins.open(path, mode, encoding=encoding, **kwargs)

--- a/src/reyn/safe/hash.py
+++ b/src/reyn/safe/hash.py
@@ -1,0 +1,28 @@
+"""Cryptographic and non-cryptographic hash helpers.
+
+All functions accept ``bytes`` and return a lowercase hex digest
+string. Wrap stdlib ``hashlib`` — output is a pure function of input.
+"""
+
+from __future__ import annotations
+
+import hashlib as _hashlib
+
+
+def sha256(b: bytes) -> str:
+    """Return the lowercase hex SHA-256 digest of ``b``."""
+    return _hashlib.sha256(b).hexdigest()
+
+
+def md5(b: bytes) -> str:
+    """Return the lowercase hex MD5 digest of ``b``.
+
+    MD5 is not cryptographically secure; use for non-security
+    fingerprints only.
+    """
+    return _hashlib.md5(b).hexdigest()
+
+
+def blake2b(b: bytes) -> str:
+    """Return the lowercase hex BLAKE2b digest of ``b``."""
+    return _hashlib.blake2b(b).hexdigest()

--- a/src/reyn/safe/json.py
+++ b/src/reyn/safe/json.py
@@ -1,0 +1,35 @@
+"""Strict / canonical JSON helpers."""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+
+def _no_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    out: dict[str, Any] = {}
+    for k, v in pairs:
+        if k in seen:
+            raise ValueError(f"duplicate key in JSON object: {k!r}")
+        seen.add(k)
+        out[k] = v
+    return out
+
+
+def loads_strict(s: str) -> Any:
+    """Parse ``s`` as JSON, rejecting objects with duplicate keys.
+
+    Standard ``json.loads`` silently overwrites duplicate keys; this
+    wrapper raises ``ValueError`` instead.
+    """
+    return _json.loads(s, object_pairs_hook=_no_duplicate_keys)
+
+
+def dumps_canonical(d: Any) -> str:
+    """Dump ``d`` in canonical form (= ``sort_keys=True``, non-ASCII kept).
+
+    Suitable for content addressing — two equal objects produce the
+    same byte sequence.
+    """
+    return _json.dumps(d, sort_keys=True, ensure_ascii=False)

--- a/src/reyn/safe/random.py
+++ b/src/reyn/safe/random.py
@@ -1,0 +1,15 @@
+"""Random helpers — explicit seeding only (no ambient global RNG)."""
+
+from __future__ import annotations
+
+import random as _random
+
+
+def seeded(seed: int) -> _random.Random:
+    """Return a fresh ``random.Random`` seeded with ``seed``.
+
+    The returned RNG is independent of the global ``random`` module
+    state; reusing the same seed across calls reproduces the same
+    sequence (= deterministic under replay).
+    """
+    return _random.Random(seed)

--- a/src/reyn/safe/schema.py
+++ b/src/reyn/safe/schema.py
@@ -1,0 +1,74 @@
+"""JSON Schema validation helper.
+
+Prefers the optional ``jsonschema`` dependency; falls back to a
+minimal in-house implementation supporting ``type``, ``required``,
+and ``properties`` only (= sufficient for simple schemas, signals
+to the author when they need richer features).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - import branch determined at install time
+    import jsonschema as _jsonschema  # type: ignore
+    _HAS_JSONSCHEMA = True
+except ImportError:  # pragma: no cover
+    _HAS_JSONSCHEMA = False
+
+
+_TYPE_MAP: dict[str, tuple[type, ...]] = {
+    "object": (dict,),
+    "array": (list,),
+    "string": (str,),
+    "integer": (int,),
+    "number": (int, float),
+    "boolean": (bool,),
+    "null": (type(None),),
+}
+
+
+class SchemaError(ValueError):
+    """Raised when ``data`` does not conform to ``schema``."""
+
+
+def _minimal_validate(data: Any, schema: dict, path: str = "$") -> None:
+    expected = schema.get("type")
+    if expected is not None:
+        # ``integer`` is a subset of ``number`` but bool subclasses int —
+        # exclude bool from int/number checks.
+        types = _TYPE_MAP.get(expected)
+        if types is None:
+            raise SchemaError(f"{path}: unknown schema type {expected!r}")
+        if expected in ("integer", "number") and isinstance(data, bool):
+            raise SchemaError(f"{path}: expected {expected}, got bool")
+        if not isinstance(data, types):
+            raise SchemaError(
+                f"{path}: expected {expected}, got {type(data).__name__}"
+            )
+    if expected == "object" or (expected is None and isinstance(data, dict)):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in data:
+                raise SchemaError(f"{path}: missing required property {key!r}")
+        properties = schema.get("properties", {})
+        for key, subschema in properties.items():
+            if key in data:
+                _minimal_validate(data[key], subschema, f"{path}.{key}")
+
+
+def validate(data: Any, schema: dict) -> None:
+    """Validate ``data`` against the JSON Schema ``schema``.
+
+    Raises ``SchemaError`` (a ``ValueError`` subclass) if invalid.
+    Uses the ``jsonschema`` package if available, otherwise a
+    minimal fallback that understands ``type`` / ``required`` /
+    ``properties``.
+    """
+    if _HAS_JSONSCHEMA:
+        try:
+            _jsonschema.validate(instance=data, schema=schema)  # type: ignore[attr-defined]
+        except _jsonschema.ValidationError as exc:  # type: ignore[attr-defined]
+            raise SchemaError(str(exc)) from exc
+    else:
+        _minimal_validate(data, schema)

--- a/src/reyn/safe/text.py
+++ b/src/reyn/safe/text.py
@@ -1,0 +1,37 @@
+"""Text helpers: named-group regex extraction and safe templating."""
+
+from __future__ import annotations
+
+import re as _re
+
+
+def regex_findall_named(pattern: str, text: str) -> list[dict[str, str]]:
+    """Return a list of named-group dicts for every match of ``pattern``.
+
+    Each entry is the ``match.groupdict()`` of one match. Groups that
+    did not participate in the match map to an empty string. Matches
+    without any named groups produce empty dicts.
+    """
+    regex = _re.compile(pattern)
+    out: list[dict[str, str]] = []
+    for m in regex.finditer(text):
+        gd = m.groupdict()
+        out.append({k: (v if v is not None else "") for k, v in gd.items()})
+    return out
+
+
+class _SafeDict(dict):
+    """Dict that returns ``{key}`` literally for missing keys."""
+
+    def __missing__(self, key: str) -> str:  # type: ignore[override]
+        return "{" + key + "}"
+
+
+def template_render_safe(template: str, ctx: dict) -> str:
+    """Render ``template`` with ``str.format_map`` over a safe dict.
+
+    Missing keys render literally as ``{key}`` rather than raising
+    ``KeyError``. No attribute access or method calls are evaluated
+    via this helper since callers only provide a plain ``dict``.
+    """
+    return template.format_map(_SafeDict(ctx))

--- a/src/reyn/safe/time.py
+++ b/src/reyn/safe/time.py
@@ -1,0 +1,16 @@
+"""Time helpers (ambient sources — outputs are non-deterministic)."""
+
+from __future__ import annotations
+
+import time as _time
+
+
+def monotonic_seq() -> float:
+    """Return a monotonic clock value in seconds.
+
+    Non-deterministic: two calls within the same process produce
+    different values. Wraps ``time.monotonic``. Use only when the
+    step's contract permits ambient clock reads (= replay records
+    the value).
+    """
+    return _time.monotonic()

--- a/tests/test_safe_file_api.py
+++ b/tests/test_safe_file_api.py
@@ -1,0 +1,292 @@
+"""Tier 2 — reyn.safe.file permission-gated file API contract tests (FP-0042).
+
+The :mod:`reyn.safe.file` module exposes read / write / glob / exists / stat
+/ open to safe-mode python steps with a path-list permission check. These
+tests pin the gate behaviour: declared-path-in → grant, declared-path-out
+→ deny with :class:`PermissionError`, context-not-set → deny, ``open`` mode
+selects read-vs-write gate correctly, and the returned file object is a
+real ``io.TextIOBase`` so stdlib libraries work against it.
+
+The permission-context globals on the module are reset before every test
+via the :func:`_reset_context` fixture so test order does not leak state.
+"""
+from __future__ import annotations
+
+import io
+import json as _stdlib_json
+from pathlib import Path
+
+import pytest
+
+from reyn.safe import file as sf
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    """Reset reyn.safe.file's module-global permission context.
+
+    Tests that need a permission context call ``sf._set_permission_context``
+    explicitly. The reset ensures order-independent runs and matches the
+    "fresh subprocess per step" production behaviour.
+    """
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+    yield
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    """Create a sandbox tmpdir with one readable + one writable subdir."""
+    read_dir = tmp_path / "docs"
+    read_dir.mkdir()
+    (read_dir / "a.md").write_text("hello A\n", encoding="utf-8")
+    (read_dir / "b.md").write_text("hello B\n", encoding="utf-8")
+    write_dir = tmp_path / "out"
+    write_dir.mkdir()
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Context-not-initialised path
+# ---------------------------------------------------------------------------
+
+
+def test_read_without_context_raises() -> None:
+    """Tier 2: bare-process read fails when no permission context is set.
+
+    The harness initialises the context before user code runs; if a
+    caller invokes the API outside that flow, the helpful error
+    message must point at ``_set_permission_context``.
+    """
+    with pytest.raises(PermissionError) as exc:
+        sf.read("README.md")
+    assert "permission context not initialised" in str(exc.value)
+    assert "_set_permission_context" in str(exc.value)
+
+
+def test_write_without_context_raises() -> None:
+    """Tier 2: same as read but for write."""
+    with pytest.raises(PermissionError):
+        sf.write("/tmp/x", "content")
+
+
+# ---------------------------------------------------------------------------
+# Path inclusion / exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_read_within_read_paths_returns_content(sandbox: Path) -> None:
+    """Tier 2: declared read path grants access; content matches."""
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    content = sf.read(str(sandbox / "docs" / "a.md"))
+    assert content == "hello A\n"
+
+
+def test_read_outside_read_paths_raises(sandbox: Path) -> None:
+    """Tier 2: read of a sibling-dir file is denied with an actionable error."""
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    target = sandbox / "out" / "stray.md"
+    target.write_text("private\n", encoding="utf-8")
+    with pytest.raises(PermissionError) as exc:
+        sf.read(str(target))
+    msg = str(exc.value)
+    assert "not in the declared read_paths" in msg
+    assert "file.read:" in msg  # mentions the skill.md fix
+
+
+def test_write_within_write_paths_writes(sandbox: Path) -> None:
+    """Tier 2: declared write path grants write; file content lands."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "result.txt"
+    sf.write(str(target), "payload\n")
+    assert target.read_text() == "payload\n"
+
+
+def test_write_outside_write_paths_raises(sandbox: Path) -> None:
+    """Tier 2: write outside declared paths denies even when target exists."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    with pytest.raises(PermissionError):
+        sf.write(str(sandbox / "docs" / "a.md"), "overwrite attempt")
+    # Original content untouched.
+    assert (sandbox / "docs" / "a.md").read_text() == "hello A\n"
+
+
+# ---------------------------------------------------------------------------
+# Boundary cases — prefix matching
+# ---------------------------------------------------------------------------
+
+
+def test_path_prefix_does_not_match_partial_segment(sandbox: Path) -> None:
+    """Tier 2: ``/foo/bar`` access does NOT grant ``/foo/barbaz``.
+
+    The allowed prefix is a directory-boundary prefix, not a string
+    prefix. Without the ``os.sep`` guard, ``/foo/bar`` would falsely
+    match ``/foo/barbaz/x.md``. This catches accidental authority
+    leak across sibling directory names.
+    """
+    bar = sandbox / "bar"
+    barbaz = sandbox / "barbaz"
+    bar.mkdir()
+    barbaz.mkdir()
+    (barbaz / "x.md").write_text("not yours\n", encoding="utf-8")
+    sf._set_permission_context(read_paths=[str(bar)])
+    with pytest.raises(PermissionError):
+        sf.read(str(barbaz / "x.md"))
+
+
+def test_exact_path_match_grants_access(sandbox: Path) -> None:
+    """Tier 2: a single-file ``read_paths`` entry grants exactly that file."""
+    target = sandbox / "docs" / "a.md"
+    sf._set_permission_context(read_paths=[str(target)])
+    assert sf.read(str(target)) == "hello A\n"
+    # But not its sibling.
+    with pytest.raises(PermissionError):
+        sf.read(str(sandbox / "docs" / "b.md"))
+
+
+# ---------------------------------------------------------------------------
+# Metadata helpers
+# ---------------------------------------------------------------------------
+
+
+def test_exists_gated_as_read(sandbox: Path) -> None:
+    """Tier 2: ``exists`` is permission-checked as a read.
+
+    Existence probing is an observation that requires the same
+    authority as reading the file (= protects against directory
+    enumeration outside declared paths).
+    """
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    assert sf.exists(str(sandbox / "docs" / "a.md")) is True
+    assert sf.exists(str(sandbox / "docs" / "missing.md")) is False
+    with pytest.raises(PermissionError):
+        sf.exists(str(sandbox / "out" / "anything"))
+
+
+def test_stat_gated_as_read(sandbox: Path) -> None:
+    """Tier 2: ``stat`` is permission-checked as a read; returns the
+    documented shape ``{size, mtime, mode}``."""
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    info = sf.stat(str(sandbox / "docs" / "a.md"))
+    assert set(info.keys()) == {"size", "mtime", "mode"}
+    assert info["size"] == len("hello A\n")
+    with pytest.raises(PermissionError):
+        sf.stat(str(sandbox / "out"))
+
+
+def test_glob_does_not_require_context(sandbox: Path) -> None:
+    """Tier 2: ``glob`` is metadata-only enumeration, no permission gate.
+
+    The 2026-05-15 R-PURE-MODE stdlib audit endorsed bare ``glob.glob``
+    as a safe ambient source — path enumeration without content read.
+    Subsequent reads of any returned path still go through :func:`read`
+    and are gated there.
+    """
+    # No _set_permission_context call.
+    results = sf.glob(str(sandbox / "docs" / "*.md"))
+    assert len(results) == 2
+    assert any(p.endswith("a.md") for p in results)
+    assert any(p.endswith("b.md") for p in results)
+
+
+# ---------------------------------------------------------------------------
+# Low-level open() — IO compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_open_read_returns_real_textiobase(sandbox: Path) -> None:
+    """Tier 2: ``sf.open(path, "r")`` returns a real ``io.TextIOBase``.
+
+    The contract is that stdlib libraries (``json.load``, ``csv.reader``,
+    ``for line in f``) accept the returned object without adapter. Without
+    this, callers couldn't use the low-level API to integrate with stdlib.
+    """
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    with sf.open(str(sandbox / "docs" / "a.md"), "r") as f:
+        assert isinstance(f, io.TextIOBase)
+        first = f.read()
+    assert first == "hello A\n"
+
+
+def test_open_supports_iteration_and_seek(sandbox: Path) -> None:
+    """Tier 2: returned file object supports ``for line in f`` + ``seek``.
+
+    These are the streaming primitives stdlib libraries expect. The
+    permission contract is "may read this path", so byte-level
+    re-checks on seek/iter are deliberately absent.
+    """
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    target = sandbox / "docs" / "a.md"
+    target.write_text("line1\nline2\nline3\n", encoding="utf-8")
+    with sf.open(str(target), "r") as f:
+        lines = list(f)
+        assert lines == ["line1\n", "line2\n", "line3\n"]
+        f.seek(0)
+        assert f.read(5) == "line1"
+
+
+def test_open_compatible_with_stdlib_json_load(sandbox: Path, tmp_path: Path) -> None:
+    """Tier 2: ``json.load(sf.open(...))`` works — the canonical demo
+    of why the low-level API exists in addition to high-level ``read``.
+    """
+    target = tmp_path / "data.json"
+    target.write_text('{"x": 1, "y": 2}\n', encoding="utf-8")
+    sf._set_permission_context(read_paths=[str(tmp_path)])
+    with sf.open(str(target), "r") as f:
+        loaded = _stdlib_json.load(f)
+    assert loaded == {"x": 1, "y": 2}
+
+
+def test_open_write_mode_uses_write_gate(sandbox: Path) -> None:
+    """Tier 2: ``sf.open(path, "w")`` checks against ``write_paths``,
+    not ``read_paths``. Cross-axis denial: read-granted-but-write-denied
+    path should fail at open time."""
+    sf._set_permission_context(
+        read_paths=[str(sandbox / "docs")],
+        write_paths=[],
+    )
+    with pytest.raises(PermissionError):
+        sf.open(str(sandbox / "docs" / "a.md"), "w")
+
+
+def test_open_append_mode_uses_write_gate(sandbox: Path) -> None:
+    """Tier 2: ``a`` (append) is a write — must be in write_paths."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "log.txt"
+    with sf.open(str(target), "a") as f:
+        f.write("entry\n")
+    assert target.read_text() == "entry\n"
+
+
+def test_open_read_plus_mode_requires_write(sandbox: Path) -> None:
+    """Tier 2: ``r+`` opens for read+write — the '+' flag elevates to
+    the write gate. A path in read_paths but NOT write_paths fails."""
+    target = sandbox / "docs" / "a.md"
+    sf._set_permission_context(
+        read_paths=[str(sandbox / "docs")],
+        write_paths=[],
+    )
+    with pytest.raises(PermissionError):
+        sf.open(str(target), "r+")
+
+
+# ---------------------------------------------------------------------------
+# Context override / re-initialisation
+# ---------------------------------------------------------------------------
+
+
+def test_context_can_be_reinitialised(sandbox: Path) -> None:
+    """Tier 2: calling ``_set_permission_context`` again overrides the
+    previous context. Production use-case: a tester sets up paths,
+    runs a step, then resets to a different set for the next step.
+    """
+    sf._set_permission_context(read_paths=[str(sandbox / "docs")])
+    assert sf.read(str(sandbox / "docs" / "a.md")) == "hello A\n"
+
+    sf._set_permission_context(read_paths=[])
+    with pytest.raises(PermissionError):
+        sf.read(str(sandbox / "docs" / "a.md"))


### PR DESCRIPTION
**[dogfood-coder]** — Phase 1 of FP-0042 (issue #549). Establishes the public ``reyn.safe.*`` namespace the safe-mode python allowlist already grants, migrates the existing helpers under ``reyn.api.safe.*`` with one-release shims, and adds the new permission-gated ``reyn.safe.file`` API + harness wiring. No stdlib skill changes here — Phase 2 lands those per-skill in subsequent PRs.

## Summary

- ``src/reyn/safe/`` new package with ``file.py`` + ``hash`` / ``json`` / ``random`` / ``schema`` / ``text`` / ``time`` migrated from ``reyn.api.safe.*``.
- ``src/reyn/api/safe/*`` becomes shim re-exports for one release (``reyn.api.safe.X`` ≡ ``reyn.safe.X``). Removal scheduled for the release after Phase 2 lands.
- ``src/reyn/safe/file.py`` — new permission-gated file API:
  - **High-level**: ``read`` / ``write`` / ``glob`` / ``exists`` / ``stat`` (drop-in replacement for ``reyn.api.unsafe.file`` so Phase 2 diffs stay small).
  - **Low-level**: ``open(path, mode, encoding=...)`` returns a real ``io.TextIOBase`` / ``io.BufferedIOBase`` after the permission check. Stdlib libraries (``json.load``, ``csv.reader``, ``for line in f``) work unchanged against the returned object.
- ``_python_harness.py`` / ``python_runner.py`` / ``preprocessor_executor.py`` — wire ``file_read_paths`` / ``file_write_paths`` from skill declaration → JSON harness request → ``reyn.safe.file._set_permission_context`` before the user step's function runs.

## Permission flow (= per the FP-0042 design)

```
skill.md permissions.file.read_paths / write_paths
        │
        ▼
PreprocessorExecutor extracts the lists from skill.permissions
        │
        ▼
PythonRunner.run(file_read_paths=..., file_write_paths=...)
        │
        ▼
JSON harness request, fields ``file_read_paths`` / ``file_write_paths``
        │
        ▼
_python_harness.main reads request → reyn.safe.file._set_permission_context
        │
        ▼
User step calls reyn.safe.file.read(path):
        ├─ path in declared read_paths → builtin open() → return content
        └─ path NOT in read_paths      → raise PermissionError
                                          (subprocess returncode → skill_run_failed)
```

The subprocess-side check is decl-membership (= ``_is_under(path, read_paths)``), not the full 4-layer ask flow — those layers already fired at startup_guard time in the parent before this step runs.

## Why ``glob`` is not gated

``glob`` performs path enumeration without content read — endorsed by the 2026-05-15 R-PURE-MODE stdlib audit as a safe ambient source. Subsequent content reads of any returned path still go through ``read`` / ``open`` and are gated there.

## ``open()`` mode → gate selection

- Modes containing ``w`` / ``a`` / ``x`` / ``+`` → ``write_paths`` gate
- Otherwise (``r``, ``rb``, ``rt``) → ``read_paths`` gate
- ``r+`` correctly elevates to the write gate (= ``+`` flag triggers write check)

After the check grants, the returned object behaves identically to ``builtins.open``. Subsequent ``seek`` / ``read(n)`` / iteration are NOT per-call permission-checked — the contract is "may read this path", not "may read these bytes". Documented trade-off; out-of-scope to address here.

## Retest evidence

- ``tests/test_safe_file_api.py`` — **18 new Tier-2 contract tests** covering deny-without-context, declared-path grants, denials with actionable error messages, directory-boundary prefix matching (no false ``/foo/bar`` → ``/foo/barbaz`` match), exact-path single-file grants, ``exists`` / ``stat`` gated-as-read, ``glob`` ungated, ``open`` returns real ``io.TextIOBase``, ``open`` supports iter + seek, stdlib ``json.load`` compatibility, mode → gate selection (``w`` / ``a`` / ``r+``), context re-initialisation.
- ``pytest tests/ -q`` → **5128 passed**, 8 skipped, 3 xfailed (= 5090 baseline + 18 new + 20 existing ``reyn.api.safe`` tests flowing through the shim, all green).
- ``ruff check`` on all edited modules → clean.

## Test plan

- [x] 18 Tier-2 tests on the file API
- [x] Full pytest sweep (5128 passed)
- [x] ruff lint clean
- [x] Smoke: ``from reyn.api.safe import hash, json, ...`` continues to resolve via shim (existing tests + manual check pass)
- [x] Smoke: ``from reyn.safe import file as sf; sf.read(...)`` works end-to-end (5/5 manual cases via REPL)
- [ ] Manual: run a stdlib skill that uses python preprocessor + ``permissions.file.read_paths`` declared — verify the harness propagates paths and ``reyn.safe.file.read`` grants. (Phase 2 PRs will exercise this on real skills; this PR adds the surface only.)

## Out of scope (= deliberate, per the FP-0042 proposal)

- Stdlib skill migrations (= ``index_docs``, ``index_events``, ``mcp_install``, ``mcp_search``, ``eval_builder`` off ``reyn.api.unsafe.file``). Each lands as its own Phase 2 PR so the permission decl is reviewed against the skill's actual file access pattern.
- Removing ``reyn.api.unsafe.file`` — user skills still need the unsafe option behind ``--allow-unsafe-python``.
- Per-call audit events for ``reyn.safe.file.*`` reads (= FP-0015 follow-up, Phase 4).
- Removing the ``reyn.api.safe.*`` shim — scheduled for one release after Phase 2 completes.
- TOCTOU hardening (= fd-based handoff, reopening between check and read).

## Refs

- Issue #549 — FP-0042 design (= ``docs/deep-dives/proposals/0042-stdlib-safe-only-and-permission-gated-file-api.md``).
- ``src/reyn/kernel/_python_allowlist.py:163-172`` — the ``reyn.safe.*`` allow / ``reyn.unsafe.*`` reject rules this PR finally makes reachable.
- ``docs/deep-dives/audits/2026-05-15-pure-mode-stdlib-audit.md`` — the audit that previously split ``extract_and_split`` into ``chunkers_safe.py``; this PR generalises that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)