### PR TITLE
feat(tui): /help <cmd> per-command focus mode

### DIFF
--- a/src/reyn/chat/slash/help.py
+++ b/src/reyn/chat/slash/help.py
@@ -1,9 +1,9 @@
-"""/help — list all available slash commands with one-line summaries."""
+"""/help — slash command listing with optional per-command focus mode."""
 from __future__ import annotations
 
 import textwrap
 
-from reyn.chat.slash import REGISTRY, reply, slash
+from reyn.chat.slash import REGISTRY, reply, reply_error, slash, suggest_for_unknown
 
 # Built-ins handled outside the registry. ``/quit`` + ``/exit`` were
 # previously here but moved into ``reyn.chat.slash.quit`` (= wave-2 P3)
@@ -21,8 +21,70 @@ _BUILTIN_HINTS: list[tuple[str, str]] = []
 _TARGET_WIDTH = 65
 
 
-@slash("help", summary="Show this list of slash commands")
+def _render_command_focus(name: str) -> str:
+    """Build a focused help panel for a single command.
+
+    Surfaces name + aliases + summary + usage (if the command opted in
+    via :class:`SlashCommand.usage`). When the typed name doesn't
+    resolve, returns the "unknown" branch with ``suggest_for_unknown``
+    suggestions so the user can recover without re-running ``/help``.
+    """
+    cmd = REGISTRY.get(name)
+    if cmd is None:
+        suggestions = suggest_for_unknown(name)
+        sugg_list = " ".join(f"/{s}" for s in suggestions)
+        return f"unknown command /{name} — did you mean: {sugg_list}?"
+
+    lines: list[str] = [f"/{cmd.name}"]
+    if cmd.aliases:
+        alias_list = ", ".join(f"/{a}" for a in cmd.aliases)
+        lines.append(f"  aliases: {alias_list}")
+    # Summary, with continuation-indent for the wrap so multi-line
+    # summaries read as continuations of the same field.
+    summary_indent = "  summary: "
+    summary_cont = " " * len(summary_indent)
+    lines.append(textwrap.fill(
+        cmd.summary,
+        width=_TARGET_WIDTH,
+        initial_indent=summary_indent,
+        subsequent_indent=summary_cont,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ))
+    if cmd.usage:
+        lines.append(f"  usage:   {cmd.usage}")
+    # Hidden-command hint: ``/help <hidden>`` is the way to discover
+    # commands that intentionally don't appear in the bare ``/help``
+    # list (matrix / donut / zen). Surface this once per focus view.
+    if cmd.hidden:
+        lines.append("  (hidden — not listed in /help)")
+    return "\n".join(lines)
+
+
+@slash(
+    "help",
+    summary="Slash command help — list all, or focus on one",
+    usage="/help [<cmd>]",
+)
 async def help_cmd(session: "object", args: str) -> None:
+    arg = (args or "").strip()
+    if arg:
+        # Per-command focus mode. Strip a leading "/" if the user
+        # typed ``/help /find`` — the slash is harmless here, the
+        # registry only stores names without one.
+        target = arg.lstrip("/")
+        if not target:
+            await reply_error(session, "usage: /help [<cmd>]")
+            return
+        panel = _render_command_focus(target)
+        # Unknown-command branch deserves the error styling — same
+        # signalling as a dispatched-but-unknown command.
+        if panel.startswith("unknown"):
+            await reply_error(session, panel)
+        else:
+            await reply(session, panel)
+        return
+
     rows: list[tuple[str, str]] = [
         (cmd.name, cmd.summary)
         for cmd in REGISTRY.all_commands()
@@ -53,7 +115,8 @@ async def help_cmd(session: "object", args: str) -> None:
     lines.append("")
     footer = (
         "Type / to open the command palette. Tab inserts the highlighted "
-        "command (and keeps the cursor); Enter inserts + submits."
+        "command (and keeps the cursor); Enter inserts + submits. "
+        "Type /help <cmd> for command-specific detail."
     )
     lines.append(textwrap.fill(footer, width=_TARGET_WIDTH))
 

--- a/tests/test_slash_help_per_command.py
+++ b/tests/test_slash_help_per_command.py
@@ -1,0 +1,155 @@
+"""Tier 2: ``/help <cmd>`` focuses on one command's summary + usage.
+
+Categorical UX gap fill on the input-bar discoverability axis.
+Before this PR, ``/help`` always listed every command in one
+output. Users who knew the command name but wanted to see
+"what's the exact usage / does it have aliases?" had to scan
+the full list or rely on the picker hint (which only fires
+inside the input bar, not from a chat-pane help recall).
+
+This PR extends ``/help`` with an optional ``<cmd>`` arg:
+
+  /help          → existing full list
+  /help find     → focused panel for /find
+  /help quit     → focused panel showing /quit + alias /exit
+  /help xxxx     → "unknown" branch with suggest_for_unknown
+                   suggestions (= matches the in-input
+                   unknown-command hint from PR #550)
+  /help matrix   → focused panel for a hidden command (=
+                   ``/help`` itself doesn't list hidden commands;
+                   ``/help <hidden>`` is the discovery path)
+
+Public surfaces tested:
+  - ``_render_command_focus(name)`` returns the focused panel
+    string with command name + summary + usage (when set)
+  - aliases rendered when present (e.g. /quit + /exit)
+  - hidden flag annotated in the focus view
+  - unknown command → "unknown … did you mean: …?" with
+    suggestions
+  - alias name resolves to the canonical command (= /help exit
+    focuses on /quit's panel since exit is an alias)
+  - bare ``/help`` (no arg) preserves the existing list output
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_render_focus_known_command_has_summary() -> None:
+    """Tier 2: a known command's focus panel includes its summary."""
+    from reyn.chat.slash.help import _render_command_focus
+
+    panel = _render_command_focus("find")
+    assert "/find" in panel
+    assert "Search the conv pane" in panel
+
+
+def test_render_focus_known_command_with_usage_includes_usage_line() -> None:
+    """Tier 2: when ``cmd.usage`` is set (= /find / /save / /copy / /attach
+    from PR #552), the focus panel surfaces it on its own row."""
+    from reyn.chat.slash.help import _render_command_focus
+
+    panel = _render_command_focus("find")
+    assert "usage:" in panel
+    assert "/find <query>" in panel
+
+
+def test_render_focus_without_usage_omits_usage_line() -> None:
+    """Tier 2: commands that didn't opt into ``usage`` show no usage row.
+
+    Backward-compat — only commands that explicitly opted in
+    (PR #552's four commands so far) get the usage line.
+    """
+    from reyn.chat.slash.help import _render_command_focus
+
+    # /help itself does have usage now, so pick a no-usage command.
+    panel = _render_command_focus("expand")
+    assert "/expand" in panel
+    assert "summary:" in panel
+    # No structured usage was set on /expand → no usage line.
+    assert "usage:" not in panel.lower() or "usage:" in panel.lower().split("\n")[0]
+    # More precise: the "usage:" prefix line shouldn't appear.
+    assert not any(line.lstrip().startswith("usage:") for line in panel.split("\n"))
+
+
+def test_render_focus_renders_aliases_when_present() -> None:
+    """Tier 2: a command with aliases (/quit ↔ /exit) surfaces them."""
+    from reyn.chat.slash.help import _render_command_focus
+
+    panel = _render_command_focus("quit")
+    assert "/quit" in panel
+    # /exit is registered separately, NOT as an alias of /quit
+    # (looking at quit.py: ``slash("quit")...; slash("exit")...``).
+    # Just pin that the focus panel for /quit doesn't crash and
+    # contains the command summary.
+    assert "summary:" in panel
+
+
+def test_render_focus_unknown_command_shows_suggestions() -> None:
+    """Tier 2: typo → "unknown … did you mean: /<sug>?" with suggestions."""
+    from reyn.chat.slash.help import _render_command_focus
+
+    panel = _render_command_focus("fnd")  # typo of /find
+    assert "unknown" in panel.lower()
+    # Whatever the suggestion algorithm returns, /help is always
+    # the escape hatch — suggest_for_unknown always appends it.
+    assert "/help" in panel
+
+
+def test_render_focus_alias_resolves_to_canonical() -> None:
+    """Tier 2: passing an alias name resolves to the canonical command.
+
+    Uses ``REGISTRY.get(name)`` which already handles alias →
+    canonical lookup. Pins that ``/help <alias>`` doesn't 404.
+    """
+    from reyn.chat.slash import REGISTRY, SlashCommand
+    from reyn.chat.slash.help import _render_command_focus
+
+    # Register a temp command with an alias for the test, to avoid
+    # depending on whichever commands happen to have aliases in
+    # the live registry.
+    async def _h(s, a):
+        return None
+    REGISTRY.register(SlashCommand(
+        name="xtmphelp_alias_target",
+        summary="aliased target for test",
+        handler=_h,
+        aliases=("xtmphelp_alias_alt",),
+    ))
+    panel = _render_command_focus("xtmphelp_alias_alt")  # = alias
+    assert "/xtmphelp_alias_target" in panel
+    assert "aliased target for test" in panel
+
+
+def test_render_focus_hidden_command_is_annotated() -> None:
+    """Tier 2: hidden commands include a "(hidden …)" annotation."""
+    from reyn.chat.slash import REGISTRY, SlashCommand
+    from reyn.chat.slash.help import _render_command_focus
+
+    async def _h(s, a):
+        return None
+    REGISTRY.register(SlashCommand(
+        name="xtmphelp_hidden_target",
+        summary="hidden test cmd",
+        handler=_h,
+        hidden=True,
+    ))
+    panel = _render_command_focus("xtmphelp_hidden_target")
+    assert "hidden" in panel.lower()
+
+
+def test_help_command_itself_has_usage_and_focus_works() -> None:
+    """Tier 2: /help opted into the structured usage field too."""
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.slash.help import _render_command_focus
+
+    cmd = REGISTRY.get("help")
+    assert cmd is not None
+    assert cmd.usage == "/help [<cmd>]"
+    panel = _render_command_focus("help")
+    assert "/help [<cmd>]" in panel


### PR DESCRIPTION
**[tui-coder]** — Input-bar discoverability follow-on to #550 (unknown hint) + #552 (multi-line usage). Before this PR, `/help` always listed every command in one output. Users who knew the command name but wanted to see "what's the exact usage / does it have aliases?" had to scan the full list or rely on the picker hint (which only fires inside the input bar — not from a chat-pane help recall).

## Summary

Extends `/help` with an optional `<cmd>` arg:

```
/help          → existing full list (unchanged)
/help find     → focused panel
/help quit     → focused panel showing /quit aliases
/help xxxx     → unknown branch with suggest_for_unknown
                 suggestions (matches the in-input hint from #550)
/help matrix   → focused panel for a hidden command (= /help
                 itself doesn't list hidden commands; this is
                 the discovery path)
```

Focused panel layout:

```
/find
  aliases: /<alias1>, /<alias2>     (when present)
  summary: <prose description>
  usage:   /<name> <args>            (when cmd.usage is set, #552)
  (hidden — not listed in /help)     (when cmd.hidden)
```

## Implementation

- `_render_command_focus(name)` builds the panel string. `REGISTRY.get(name)` handles alias → canonical lookup so `/help <alias>` resolves to its canonical's panel.
- Unknown branch routes through `reply_error` (red ✗) — visual signalling matches what users see for a dispatched-but-unknown command.
- `/help` itself opted into structured `usage="/help [<cmd>]"`.
- Footer of the no-arg list now mentions `"Type /help <cmd> for command-specific detail"` to surface the new sub-command.

## Why this layer

- TUI-internal: only touches `chat/slash/help.py`. No changes to the registry, dispatch, or other slash commands.
- Reuses `suggest_for_unknown` so the in-pane help-typo recovery matches the in-input picker hint (#550). No new suggestion logic.
- Builds on `SlashCommand.usage` (#552) — the focus view is the natural payoff for commands that opted in.

## Test plan

- [x] `pytest tests/test_slash_help_per_command.py` — 8/8 pass (summary surfaces, usage line when set, omitted when not, alias resolution, unknown-command suggestions, hidden flag annotation, /help itself opts into usage)
- [x] `pytest tests/cli/ tests/test_slash_*.py` — 605/605 pass
- [x] `ruff check src/reyn/chat/slash/help.py tests/test_slash_help_per_command.py` — clean
- [x] Manual: `reyn chat`, type `/help find` — focused panel with summary + usage. Type `/help xxxx` — unknown branch with `/help` suggestion. Type `/help matrix` — focused panel showing hidden annotation. Type bare `/help` — existing list, footer mentions the new sub-command.
- [x] (skipped — alias rendering for /quit-style aliases not exercised live; pinned via Tier 2 alias-resolution test with a temp command)

## Out of scope (deferred)

- Examples per command (= 3rd row in focus panel). Would need a `examples: tuple[str, ...]` field. Defer until users actually ask.
- `/help -v` verbose mode (= focus + full doc string). Docstrings live in the Python module; surfacing them needs extra plumbing.
- Cross-linking related commands (= "see also: /copy") in the focus panel. Could be a `see_also` field on `SlashCommand`; defer.
