### PR TITLE
fix(stdlib): skill_importer drops ask_user for registry URL, defaults to anthropics/skills

### DIFF
--- a/src/reyn/stdlib/skills/skill_importer/phases/search.md
+++ b/src/reyn/stdlib/skills/skill_importer/phases/search.md
@@ -5,10 +5,17 @@ input: user_message
 role: skill_searcher
 can_finish: false
 max_act_turns: 4
-allowed_ops: [file, ask_user, web_fetch]
+allowed_ops: [file, web_fetch]
 ---
 
 Find skills in a public registry that match what the user is asking for.
+
+> Most users should call ``skill_search`` first for richer discovery
+> (= keyword + description match, 24h cache, scoped to a known
+> registry). This phase is the fallback path used when the caller
+> hands skill_importer a free-form user message *with no registry
+> URL*. The chat router may prefer chaining
+> ``skill_search → skill_importer`` for the best UX.
 
 ## Step 1 — Parse the user's request
 
@@ -17,11 +24,19 @@ Find skills in a public registry that match what the user is asking for.
 - A capability description ("PDF を要約", "translate", "code review")
 - An optional registry URL ("from https://example.com/skills.md")
 
-If the user did NOT include a registry URL, **emit an `ask_user` op** with
-question "Which registry URL should I search?" and use the answer as the
-registry URL. Do not invent one.
+**If the user included a URL**, extract it and use that as the registry URL.
 
-If the user did include a URL, extract it and use that.
+**If the user did NOT include a URL**, default to the canonical Anthropic
+skills registry as a directory listing:
+
+```
+https://api.github.com/repos/anthropics/skills/contents/skills
+```
+
+Override via the ``REYN_SKILL_REGISTRY_URL`` environment variable if set
+on the host. Do not ask the user for the URL — the default is good enough
+for the common case, and ``skill_search`` is the discovery surface when
+the user wants something other than the default registry.
 
 ## Step 2 — Fetch the registry
 
@@ -30,7 +45,10 @@ is expected to be one of these formats:
 
 - A markdown file with a list of skills, each entry a link to a source `.md`
 - An HTML page with `<a href>` links to skill markdown files
-- A JSON document mapping names to URLs
+- A JSON document mapping names to URLs (= what the GitHub Contents API
+  returns for the default registry above; each entry has ``name`` +
+  ``html_url``; the raw source markdown lives at
+  ``raw.githubusercontent.com/<owner>/<repo>/main/skills/<name>/SKILL.md``)
 
 Be permissive about format — the LLM (you) parses the response in Step 3.
 

--- a/src/reyn/stdlib/skills/skill_importer/skill.md
+++ b/src/reyn/stdlib/skills/skill_importer/skill.md
@@ -58,7 +58,13 @@ want, e.g. "PDF を読んで要約する", "translate documents", "code review".
 
 The user may also include the registry URL in the same message
 ("...from https://example.com/skills.md"). If no URL is present, the
-search phase asks the user via `ask_user`.
+search phase defaults to the canonical Anthropic skills registry at
+``https://api.github.com/repos/anthropics/skills/contents/skills``
+(overridable via the ``REYN_SKILL_REGISTRY_URL`` env var). For
+richer discovery against the same registry — keyword scoring,
+description-based filtering, 24h cache, deterministic preprocessor —
+prefer the ``skill_search`` skill first, then hand the chosen
+``source_url`` to ``skill_importer``.
 
 ## Output
 

--- a/tests/test_multi_agent_p7.py
+++ b/tests/test_multi_agent_p7.py
@@ -220,6 +220,7 @@ _KNOWN_SKILL_NAMES: frozenset[str] = frozenset({
     "eval_builder",
     "judge_phase",
     "mcp_search",
+    "skill_search",
     "read_local_files",
     "recall_docs",
     "direct_llm",


### PR DESCRIPTION
**[e2e-coder]** — Closes the loop on the ``skill_search → skill_importer`` chain by removing the friction point: when no registry URL is in the user's request, ``skill_importer`` previously emitted an ``ask_user`` op asking *"Which registry URL should I search?"* — but users never know that URL. Now bakes in the canonical Anthropic skills registry as the default (= matches PR #551's ``skill_search`` default) and lets the user override only when they need to.

## Why this matters

This is the second half of the ``mcp_search → mcp_install`` mirror UX work started in PR #551:

| | Discover | Install |
|---|---|---|
| MCP | ``mcp_search`` (= ``registry.modelcontextprotocol.io`` baked-in) | ``mcp_install`` (= source spec) |
| Skills (= **now**) | ``skill_search`` (= ``github.com/anthropics/skills`` baked-in, PR #551) | ``skill_importer`` (= URL OR default registry, **this PR**) |

Both surfaces now work without ever needing the user to type a registry URL.

## Changes

- ``src/reyn/stdlib/skills/skill_importer/phases/search.md``
  - Removed ``ask_user`` from ``allowed_ops``.
  - Step 1 instructions: default to ``https://api.github.com/repos/anthropics/skills/contents/skills`` when no URL is in the user's request. Mention the ``REYN_SKILL_REGISTRY_URL`` env override.
  - Step 2 docs: GitHub Contents API shape, so the LLM knows how to parse the default registry response.
  - Header note pointing chat router at the ``skill_search → skill_importer`` chain for richer discovery.
- ``src/reyn/stdlib/skills/skill_importer/skill.md``
  - Input docs: replace *"search phase asks the user via ask_user"* with new default-registry behaviour + skill_search pointer.
- ``tests/test_multi_agent_p7.py``
  - Added ``skill_search`` to ``_KNOWN_SKILL_NAMES`` (= the P7 grep audit list). Missed in PR #551; closing the gap here since I'm in the area.

## Test plan

- [x] ``reyn skills validate skill_importer`` → OK
- [x] ``reyn skills validate skill_search`` → OK
- [x] ``pytest tests/test_multi_agent_p7.py`` → 4/4 pass
- [x] **Rootdir** verify: ``python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`` → 5162 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed (the 1 deselected = same pre-existing flake noted in PR #544 / #548 / #551)

## Out of scope (= future work, not blocking)

- Restructuring ``skill_importer``'s ``search`` + ``select`` phases to delegate to ``skill_search`` via ``run_skill`` op (= bigger refactor, drops duplicate LLM-driven web_fetch+parsing). Worth doing once the discovery vs install split has shipped a release and we know whether direct ``skill_importer`` invocation is a real path users take.
- Dogfood scenario for the full chain — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)