### PR TITLE
feat(tui): SkillActivityRow 2-level drill — surface tool calls

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1141,6 +1141,18 @@ class ConversationView(Widget):
         label_prefix = ""
         if parent_run_id and parent_run_id in self._skill_rows:
             label_prefix = "  └─ "
+            # Record the tool call on the owning SkillActivityRow so
+            # its drill-down expand view can surface the call list
+            # (= 2-level drill: phases × tools). Belt-and-braces over
+            # ``ToolCallRow``'s own rendering — the row gets unmounted
+            # on finalise, but the skill's drill-down should remember
+            # what tools ran beneath it for the rest of the session.
+            try:
+                self._skill_rows[parent_run_id].record_tool_call(
+                    tool_name, args_repr,
+                )
+            except Exception:
+                pass
         row = ToolCallRow(
             tool_name=tool_name,
             args_repr=args_repr,

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -38,6 +38,12 @@ from reyn.chat.tui._palette import _CORAL
 
 _TICK_INTERVAL_S = 0.5  # elapsed-time refresh rate
 
+# Max tool calls rendered inline in the drill-down expand view.
+# Beyond this we collapse to ``+N more``. Skills with > ~8 tool
+# calls would otherwise push the expanded row across many screen
+# lines, defeating the "compact drill-down" idiom.
+_TOOL_DRILL_MAX_RENDER = 6
+
 # Braille-dot spinner frames. Cycles once every (len(_SPINNER_FRAMES) *
 # _TICK_INTERVAL_S) = 5 s, which is slow enough to be calming and fast
 # enough to make "still alive" obvious at a glance.
@@ -105,6 +111,17 @@ class SkillActivityRow(Widget):
         # research three times". Bound is the natural skill phase count —
         # typical Reyn skills have < 10 transitions; no explicit cap.
         self._phase_history: list[tuple[str, int, float]] = []
+        # Tool-call history — each entry is ``(tool_name, args_snippet)``
+        # recorded when a tool_call_started event fires under this
+        # skill's run_id (= parent-aware routing from
+        # ConversationView.start_tool_call_row). Powers the 2nd level
+        # of the drill-down expand view — phases × tools — so a user
+        # exploring a finished skill can see both "which phases ran"
+        # and "what did each phase actually call". Bounded only by
+        # the natural per-skill tool-call count; we cap the rendered
+        # list at _TOOL_DRILL_MAX_RENDER to keep the expand row from
+        # exploding for tool-heavy skills.
+        self._tool_calls: list[tuple[str, str]] = []
         # Optional in-phase detail (= what's happening WITHIN the phase right
         # now — "calling llm", "running act op", etc.). Without this the row
         # showed only the phase name during a 10–30 s LLM call inside that
@@ -212,6 +229,25 @@ class SkillActivityRow(Widget):
             return
         self._detail = detail
         self._refresh()
+
+    def record_tool_call(self, tool_name: str, args_repr: str = "") -> None:
+        """Append a tool call to the drill-down history.
+
+        Called by ``ConversationView.start_tool_call_row`` when a
+        ``tool_call_started`` event arrives with a ``parent_run_id``
+        matching this row's run_id. The pair (tool name + args
+        snippet) is stored verbatim; rendering trims at expand time
+        so the recorded data stays full-fidelity for future replay /
+        export uses. Re-runs of the same tool with different args
+        record as separate entries — re-invocation IS meaningful
+        execution detail.
+        """
+        self._tool_calls.append((tool_name, args_repr))
+        # Refresh only when expanded — collapsed view doesn't show
+        # tool calls, so the rebuild would be wasted paint cycles
+        # during a tool-call-heavy phase.
+        if self._expanded:
+            self._refresh()
 
     def toggle_expand(self) -> None:
         """Flip the collapsed / expanded render shape.
@@ -416,6 +452,41 @@ class SkillActivityRow(Widget):
                 t.append(f"({entered_at:.1f}s)", style="dim")
         return t
 
+    def _build_tools_line(self) -> Text:
+        """Render the tool-call drill-down line shown when expanded.
+
+        Format:
+          ``  ↳ tools (3): file:read, file:grep("foo"), bash:run("npm…")``
+
+        Only rendered when ``_tool_calls`` is non-empty so skills
+        that didn't call any tools don't get a dangling "tools: ()"
+        line. The list is truncated at ``_TOOL_DRILL_MAX_RENDER``
+        with a ``+N more`` suffix beyond that; the full tool list
+        is still in ``_tool_calls`` for inspection / future export.
+        """
+        t = Text()
+        if self._label_prefix:
+            # Indent under the same prefix as the head/history lines
+            # so a sub-skill's tool list nests visually with its parent.
+            t.append(" " * len(self._label_prefix), style="dim #666666")
+        t.append(f"  ↳ tools ({len(self._tool_calls)}): ", style="dim")
+        for i, (tool_name, args) in enumerate(
+            self._tool_calls[:_TOOL_DRILL_MAX_RENDER]
+        ):
+            if i > 0:
+                t.append(", ", style="dim")
+            t.append(tool_name, style="dim #aaaaaa")
+            if args:
+                # Compress args to a short hint so the tools-line
+                # stays readable. Full args live on the
+                # ToolCallRow (= ``_tool_call_rows[op_id]``).
+                snippet = args if len(args) <= 14 else args[:13] + "…"
+                t.append(f"({snippet})", style="dim #888888")
+        hidden = len(self._tool_calls) - _TOOL_DRILL_MAX_RENDER
+        if hidden > 0:
+            t.append(f", +{hidden} more", style="dim #666666")
+        return t
+
     def rendered_text(self) -> str:
         """Plain-text rendering of the last frame sent to ``Static.update``.
 
@@ -443,5 +514,11 @@ class SkillActivityRow(Widget):
         body.append_text(head)
         body.append("\n")
         body.append_text(self._build_history_line())
+        # Tool-call drill-down (= 2nd level): only when at least one
+        # tool ran under this skill. Without the gate, skills with
+        # no tool calls would get a misleading empty "tools (0):" row.
+        if self._tool_calls:
+            body.append("\n")
+            body.append_text(self._build_tools_line())
         self._static.update(body)
         self._rendered_cache = body

--- a/tests/cli/test_skill_row_tool_drill.py
+++ b/tests/cli/test_skill_row_tool_drill.py
@@ -1,0 +1,243 @@
+"""Tier 2: 2-level drill-down — SkillActivityRow surfaces its tool calls.
+
+Follow-on to PR #546 (= phase-history drill-down) + PR #547
+(= F3 keyboard expand). The phase drill-down shows "what
+phases ran"; this PR adds the second axis — "what tools ran
+under each phase" — by recording each tool_call_started event
+that fires with a matching parent_run_id and rendering them
+as a new line below the phase-history row.
+
+Expanded view after this PR:
+
+  ▶ code_review#abc1  · reviewing  3.2s
+    ↳ phases: plan(0.5s) → research(1.4s) → reviewing*(now)
+    ↳ tools (3): file:read(*.py), file:grep("foo"), bash:run
+
+Public surfaces tested:
+  - ``SkillActivityRow.record_tool_call(tool, args)`` appends
+    to the row's tool-call history
+  - Expanded render includes ``↳ tools (N):`` followed by the
+    recorded tool names
+  - Args snippet truncated at ~14 chars (= readable inline)
+  - Beyond _TOOL_DRILL_MAX_RENDER (= 6), a "+N more" suffix
+    appears so the row stays compact
+  - Collapsed view does NOT include the tools line
+  - Skills with no tool calls do NOT show a misleading
+    "tools (0):" row
+  - End-to-end: ``conv.start_tool_call_row`` with
+    ``parent_run_id`` matching a mounted skill row propagates
+    the tool name to that skill's drill-down
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _rendered(row) -> str:
+    return row.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_record_tool_call_appears_in_expanded_render() -> None:
+    """Tier 2: ``record_tool_call`` adds the tool name to the expanded view."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="aaaa1111", skill_name="t_skill")
+        row.set_phase("execute")
+        row.record_tool_call("file:read", "")
+        row.record_tool_call("bash:run", "npm test")
+        row.toggle_expand()
+        await pilot.pause()
+        text = _rendered(row)
+        assert "↳ tools (2):" in text
+        assert "file:read" in text
+        assert "bash:run" in text
+
+
+@pytest.mark.asyncio
+async def test_collapsed_view_omits_tools_line() -> None:
+    """Tier 2: collapsed render does NOT include the tools drill-down."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="bbbb2222", skill_name="collapsed")
+        row.set_phase("execute")
+        row.record_tool_call("file:read", "")
+        await pilot.pause()
+        assert row.is_expanded is False
+        text = _rendered(row)
+        assert "↳ tools" not in text
+
+
+@pytest.mark.asyncio
+async def test_expanded_with_no_tools_omits_tools_line() -> None:
+    """Tier 2: expanded view of a skill with no tool calls hides the row.
+
+    Without the gate, the expanded render would show a
+    misleading "tools (0):" row for skills that didn't fire
+    any tools.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="cccc3333", skill_name="no_tools")
+        row.set_phase("execute")
+        # No record_tool_call calls.
+        row.toggle_expand()
+        await pilot.pause()
+        text = _rendered(row)
+        # Phase history line still present.
+        assert "↳ phases:" in text
+        # Tools line suppressed.
+        assert "↳ tools" not in text
+
+
+@pytest.mark.asyncio
+async def test_tool_args_snippet_truncated_for_long_args() -> None:
+    """Tier 2: long args repr gets shortened with ``…`` so the line stays compact."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="dddd4444", skill_name="truncate")
+        row.set_phase("execute")
+        long_args = "command=very-long-command-with-lots-of-args"
+        row.record_tool_call("bash:run", long_args)
+        row.toggle_expand()
+        await pilot.pause()
+        text = _rendered(row)
+        # The full long args string should NOT appear verbatim in
+        # the rendered line (= truncated).
+        assert long_args not in text
+        assert "bash:run" in text
+        # Truncation marker visible.
+        assert "…" in text
+
+
+@pytest.mark.asyncio
+async def test_tool_drill_renders_plus_n_more_beyond_cap() -> None:
+    """Tier 2: tool call count beyond the cap collapses to "+N more"."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.skill_activity import _TOOL_DRILL_MAX_RENDER
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="eeee5555", skill_name="many_tools")
+        row.set_phase("execute")
+        # Add cap + 3 tools = 3 over the cap.
+        over = _TOOL_DRILL_MAX_RENDER + 3
+        for i in range(over):
+            row.record_tool_call(f"tool_{i}", "")
+        row.toggle_expand()
+        await pilot.pause()
+        text = _rendered(row)
+        # Total count appears in the prefix.
+        assert f"↳ tools ({over}):" in text
+        # "+3 more" suffix indicates 3 hidden beyond the cap.
+        assert "+3 more" in text
+        # The first tool is visible.
+        assert "tool_0" in text
+        # The last tool (= beyond cap) is NOT visible.
+        assert "tool_8" not in text
+
+
+@pytest.mark.asyncio
+async def test_start_tool_call_row_propagates_to_skill_row() -> None:
+    """Tier 2: end-to-end propagation from conv.start_tool_call_row.
+
+    When the conv pane gets a ``tool_call_started`` for a tool
+    whose ``parent_run_id`` matches a mounted skill row, the
+    skill row's drill-down should record it. This is the path
+    ``app_outbox._on_tool_call_started`` drives in production.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        skill_run_id = "ffff6666"
+        row = conv.start_skill_row(run_id=skill_run_id, skill_name="prod")
+        row.set_phase("execute")
+        # Production path: app_outbox calls conv.start_tool_call_row
+        # with parent_run_id set to the running skill.
+        conv.start_tool_call_row(
+            op_id="op-1",
+            tool_name="file:read",
+            args_repr="path=app.py",
+            parent_run_id=skill_run_id,
+        )
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = _rendered(row)
+        assert "↳ tools (1):" in text
+        assert "file:read" in text
+
+
+@pytest.mark.asyncio
+async def test_orphan_tool_call_does_not_record_on_any_skill() -> None:
+    """Tier 2: tool calls without a matching parent_run_id don't accidentally
+    attach to an unrelated skill row.
+
+    Defensive — if the forwarder ever emitted a ``tool_call_started``
+    with an empty or mismatching ``parent_run_id``, the call should
+    NOT contaminate a different skill row's drill-down.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="abcd7777", skill_name="ours")
+        row.set_phase("execute")
+        # Tool call with NO parent_run_id → must not register on any row.
+        conv.start_tool_call_row(
+            op_id="op-orphan",
+            tool_name="orphan:tool",
+            args_repr="",
+            parent_run_id="",
+        )
+        # Tool call with a parent that doesn't match → also no register.
+        conv.start_tool_call_row(
+            op_id="op-mismatch",
+            tool_name="mismatch:tool",
+            args_repr="",
+            parent_run_id="not-our-run-id-xxxxxx",
+        )
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = _rendered(row)
+        assert "↳ tools" not in text
+        assert "orphan:tool" not in text
+        assert "mismatch:tool" not in text


### PR DESCRIPTION
**[tui-coder]** — Follow-on to #546 (phase drill-down) + #547 (F3 expand). The phase drill-down shows "what phases ran"; this PR adds the second axis — "what tools ran under each skill" — by recording every `tool_call_started` event that arrives with a matching `parent_run_id` and rendering the names on a new line in the expanded view.

## Summary

Expanded view after this PR:

```
  ▶ code_review#abc1  · reviewing  3.2s
    ↳ phases: plan(0.5s) → research(1.4s) → reviewing*(now)
    ↳ tools (3): file:read(path=app.py), file:grep("foo"), bash:run
```

## Recording path (production)

1. `ChatEventForwarder` emits `tool_call_started` with `run_id` matching the owning skill's run_id.
2. `app_outbox._on_tool_call_started` already calls `conv.start_tool_call_row(..., parent_run_id=run_id)`.
3. `conv.start_tool_call_row` now ALSO calls `skill_row.record_tool_call(tool_name, args_repr)` when a `SkillActivityRow` with that run_id is mounted.

No new event subscriptions — piggybacks on the existing routing.

## Rendering details

- Tools line **only renders when at least one tool was recorded** — skills with no tool calls don't get a misleading `"tools (0):"` row.
- **Args snippet trimmed at 14 chars** with `…` so the line stays readable; full args still live on the `ToolCallRow`.
- **Beyond `_TOOL_DRILL_MAX_RENDER` (= 6) tool calls**, list collapses to `"+N more"` for compact expansion.
- **Collapsed view unchanged** — tools line only when expanded.
- `record_tool_call` refreshes only when the row is already expanded (= avoids paint cycle during heavy tool-call phases).

## Why this layer

- TUI-internal: only touches `widgets/skill_activity.py` (new field + record method + render line) and `widgets/conversation.py` (1 propagation hook in `start_tool_call_row`). No engine state, no forwarder change.
- Reuses the existing `parent_run_id` routing — same idiom as the `└─ ` nesting prefix for sub-skill / sub-tool rows in the conv pane.
- Defensive: orphan / mismatching `parent_run_id` events don't contaminate other skill rows (pinned by Tier 2 test).

## Test plan

- [x] `pytest tests/cli/test_skill_row_tool_drill.py` — 7/7 pass (record → expanded render, collapsed omits, no-tools expand omits, long-args snippet trunc, "+N more" beyond cap, end-to-end conv propagation, orphan-parent doesn't contaminate)
- [x] `pytest tests/cli/test_skill_row_drill_down.py` — 8/8 pass (= #546 regression unaffected)
- [x] `pytest tests/cli/test_skill_expand_keyboard.py` — 8/8 pass (= #547 regression unaffected)
- [x] `pytest tests/cli/` — 579/579 pass
- [x] `ruff check src/reyn/chat/tui/widgets/skill_activity.py src/reyn/chat/tui/widgets/conversation.py tests/cli/test_skill_row_tool_drill.py` — clean
- [x] Manual: run `reyn chat`, fire a skill that calls 2-3 tools, click the live row — drill-down should show both phase trajectory AND tool list. F3 toggle should also reveal both lines.
- [x] (skipped — `+N more` overflow case with > 6 tool calls is exercised in Tier 2 with a synthetic count; not reproduced live)

## Out of scope (deferred)

- Per-tool status / duration in the drill-down (= `file:read ✓ 0.4s`). Would require recording `tool_call_completed` events too; deferred until users actually want it.
- Tool args full-detail expand on click (= 3rd-level drill, click an entry in the tools line to see full args / result). Conv pane doesn't support nested clickables today.
- Auto-expand on long-running skills with many tools (= heuristic "this is interesting, surface the drill-down for the user"). The F3 / click triggers are explicit; auto-expand adds visual noise.
