### PR TITLE
feat(stdlib/index_docs): migrate preprocessor steps to safe-mode + reyn.safe.file (FP-0042 Phase 2.1)

### DIFF
--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -471,16 +471,29 @@ class PreprocessorExecutor:
 
         # FP-0042: forward the skill's declared file-read / file-write
         # paths into the subprocess so ``reyn.safe.file.*`` calls inside
-        # the user step can gate against them. Paths are passed verbatim
-        # — the subprocess-side check is decl-membership, not the full
-        # 4-layer ask flow (= those layers already fired at startup_guard
-        # time before this step ran). Empty lists mean "no file access
-        # granted" and any reyn.safe.file.* call raises PermissionError.
-        file_read_paths = [
+        # the user step can gate against them. The subprocess-side check
+        # is decl-membership, not the full 4-layer ask flow (= those
+        # layers already fired at startup_guard time before this step
+        # ran).
+        #
+        # Mirror the parent-side ``_in_default_read_zone`` / ``_in_default_write_zone``
+        # behaviour by pre-pending the implicit default zones (CWD for
+        # read; ``.reyn/`` + ``reyn/`` under CWD for write). Without this,
+        # a safe-mode step that reads a workspace-local file would have
+        # to declare every path explicitly, even though the equivalent
+        # ``invoke_action(file__read)`` route would be granted by default.
+        # Keeping the contract symmetric with the existing permission
+        # model.
+        import os as _os
+        _cwd = _os.getcwd()
+        file_read_paths = [_cwd] + [
             entry["path"] for entry in self._skill.permissions.file_read
             if isinstance(entry, dict) and entry.get("path")
         ]
         file_write_paths = [
+            _os.path.join(_cwd, ".reyn"),
+            _os.path.join(_cwd, "reyn"),
+        ] + [
             entry["path"] for entry in self._skill.permissions.file_write
             if isinstance(entry, dict) and entry.get("path")
         ]

--- a/src/reyn/stdlib/skills/index_docs/chunkers.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers.py
@@ -7,16 +7,23 @@ JSON-serializable value that is placed at ``into`` in the artifact.
 Override pattern (ADR-0033 §2.1): project-specific chunkers (Python AST,
 custom Markdown) replace this module via skill.md ``module:`` override.
 
-R-PURE-MODE-REDEFINE Class A split (postprocessor steps):
-  ``extract_and_split`` (mode: safe) — moved to companion module
-    ``chunkers_safe.py``; this module's ``import os`` / ``import
-    reyn.api.unsafe.file`` would otherwise be inherited by the safe-mode
-    AST validator (which walks all module imports), forcing it to fail.
-  ``write_chunks_with_lock`` (mode: unsafe, minimal) — irreducible minimum:
+Module split (= reduces unsafe surface in stdlib per FP-0042):
+  ``gather_samples`` / ``cost_preflight`` (mode: safe) — live in
+    ``chunkers_preproc_safe.py``; file I/O goes through
+    ``reyn.safe.file`` with permission-gated reads. Migrated 2026-05-22
+    from this module's prior mode: unsafe implementation.
+  ``extract_and_split`` (mode: safe) — lives in ``chunkers_safe.py``
+    (the original R-PURE-MODE-REDEFINE Class A split).
+  ``write_chunks_with_lock`` (mode: unsafe, minimal) — kept here:
     source file content read, advisory lock acquire/release, .jsonl write.
+    Migration to safe-mode is FP-0042 Phase 2.2 pending ``reyn.safe.file``
+    growing ``delete`` / ``mkdir`` and a lock primitive.
+  ``apply_strategy`` (mode: unsafe, deprecated) — kept for project
+    override compatibility.
 
-The two preprocessor helpers (``gather_samples``, ``cost_preflight``) remain
-mode: unsafe because they call ``reyn.api.unsafe.file``.
+This module's ``import os`` / ``from pathlib import Path`` would be
+inherited by the safe-mode AST walk if the safe-mode steps lived here,
+which is why they live in companion modules.
 """
 from __future__ import annotations
 
@@ -25,181 +32,14 @@ import hashlib
 import json
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Iterator
 
-import reyn.api.unsafe.file as _unsafe_file
-
 # ─────────────────────────────────────────────────────────────────────────────
-# Phase 1 preprocessor steps
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def gather_samples(artifact: dict) -> dict:
-    """Phase 1 preprocessor: sample files matched by path glob.
-
-    Receives the full index_docs_input artifact. Returns sample excerpts
-    and a file summary for the LLM's strategy decision.
-
-    Returns:
-        {
-            "samples": [
-                {
-                    "path": str,
-                    "excerpt": str,         # first ~1500 chars
-                    "size_tokens": int,     # rough token estimate
-                    "structure_hint": str,  # e.g. "Markdown with headings"
-                }
-            ],
-            "summary": {
-                "file_count": int,
-                "ext_dist":   dict,  # e.g. {".md": 10, ".py": 5}
-                "total_bytes": int,
-                "mean_bytes":  int,
-            },
-            "file_count": int,  # top-level convenience copy
-        }
-    """
-    data = artifact.get("data") or {}
-    path = str(data.get("path") or "")
-    sample_size: int = int(data.get("sample_size") or 5)
-
-    files = _api_glob_files(path)
-    if not files:
-        return {
-            "samples": [],
-            "summary": {
-                "file_count": 0,
-                "ext_dist": {},
-                "total_bytes": 0,
-                "mean_bytes": 0,
-            },
-            "file_count": 0,
-        }
-
-    # ── Build extension index + total size ───────────────────────────────────
-    by_ext: dict[str, list[str]] = {}
-    total_bytes = 0
-    for f in files:
-        ext = Path(f).suffix
-        by_ext.setdefault(ext, []).append(f)
-        try:
-            total_bytes += _unsafe_file.stat(f)["size"]
-        except OSError:
-            pass
-
-    # ── Stratified sampling: 1–2 per extension, up to sample_size total ──────
-    picks: list[str] = []
-    for _ext, file_list in by_ext.items():
-        n = min(2, len(file_list))
-        picks.extend(file_list[:n])
-        if len(picks) >= sample_size:
-            picks = picks[:sample_size]
-            break
-    picks = picks[:sample_size]
-
-    samples = []
-    for f in picks:
-        try:
-            text = _unsafe_file.read(f)
-        except OSError:
-            continue
-        excerpt = text[:1500]
-        samples.append(
-            {
-                "path": f,
-                "excerpt": excerpt,
-                "size_tokens": _approx_tokens(text),
-                "structure_hint": _detect_structure(text, Path(f).suffix),
-            }
-        )
-
-    n = len(files)
-    return {
-        "samples": samples,
-        "summary": {
-            "file_count": n,
-            "ext_dist": {ext: len(fs) for ext, fs in by_ext.items()},
-            "total_bytes": total_bytes,
-            "mean_bytes": total_bytes // n if n else 0,
-        },
-        "file_count": n,
-    }
-
-
-def cost_preflight(artifact: dict) -> dict:
-    """Phase 1 preprocessor: estimate embedding cost (UX gap fix B).
-
-    Receives the artifact after ``gather_samples`` has injected its result
-    at ``data.samples_result``. Returns cost estimate fields so the LLM
-    can decide to abort if cost is too high.
-
-    Returns:
-        {
-            "chunk_count":        int,
-            "estimated_tokens":   int,
-            "estimated_cost_usd": float,
-            "model":              str,
-            "threshold_exceeded": bool,
-        }
-    """
-    from math import ceil
-
-    data = artifact.get("data") or {}
-    path = str(data.get("path") or "")
-    samples_result = data.get("samples_result") or {}
-    samples = samples_result.get("samples") or []
-    threshold = int(data.get("cost_warn_threshold") or 10_000)
-
-    if not samples:
-        return {
-            "chunk_count": 0,
-            "estimated_tokens": 0,
-            "estimated_cost_usd": 0.0,
-            "model": "standard",
-            "threshold_exceeded": False,
-        }
-
-    files = _api_glob_files(path)
-    n_files = len(files)
-
-    # Rough estimate: avg tokens per sample → chunks per file
-    avg_size = sum(s.get("size_tokens", 0) for s in samples) / len(samples)
-    # Assume each file produces ceil(size / 600) chunks (default max_chunk_size)
-    chunks_per_file = max(1, ceil(avg_size / 600))
-    estimated_chunks = max(1, n_files) * chunks_per_file
-
-    # Cost estimation: ~0.02 USD / 1M tokens for text-embedding-3-small
-    # Use sample token counts to extrapolate
-    sample_texts = [s.get("excerpt", "") for s in samples]
-    sample_tokens = sum(_approx_tokens(t) for t in sample_texts)
-    avg_tokens_per_sample = sample_tokens / len(samples) if samples else 0
-    total_tokens = int(avg_tokens_per_sample * estimated_chunks)
-
-    rate = 0.02  # USD / 1M tokens (text-embedding-3-small; phase 1 hardcoded)
-    cost = total_tokens / 1_000_000 * rate
-
-    return {
-        "chunk_count": estimated_chunks,
-        "estimated_tokens": total_tokens,
-        "estimated_cost_usd": round(cost, 4),
-        "model": "standard",
-        "threshold_exceeded": estimated_chunks > threshold,
-    }
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Postprocessor python steps (R-PURE-MODE-REDEFINE Class A split)
+# Postprocessor python steps
 # ─────────────────────────────────────────────────────────────────────────────
 
 _CHUNKS_JSONL_PATH = "artifacts/chunks.jsonl"
-
-
-# ``extract_and_split`` was moved to ``chunkers_safe.py`` so the safe-mode
-# AST validator, which walks all module-level imports via ``ast.walk(tree)``,
-# does not reject it because of this module's legitimate ``os`` /
-# ``reyn.api.unsafe.file`` imports used by the surrounding unsafe-mode steps.
 
 
 def write_chunks_with_lock(artifact: dict) -> dict:
@@ -526,7 +366,8 @@ def _split_sentence(
 def _glob_files(path: str) -> list[str]:
     """Expand a glob pattern; return sorted list of file paths.
 
-    Used by apply_strategy (= postprocessor, mode: unsafe, Class A deferred).
+    Used by ``apply_strategy`` (= deprecated monolithic postprocessor
+    step, mode: unsafe).
     """
     if not path:
         return []
@@ -534,38 +375,9 @@ def _glob_files(path: str) -> list[str]:
     return sorted(m for m in matches if os.path.isfile(m))
 
 
-def _api_glob_files(path: str) -> list[str]:
-    """Expand a glob pattern via reyn.api.unsafe.file; return sorted file paths.
-
-    Used by gather_samples and cost_preflight (= preprocessor steps, Class B
-    refactored). Delegates to reyn.api.unsafe.file.glob then filters to files.
-    """
-    if not path:
-        return []
-    matches = _unsafe_file.glob(path)
-    return [m for m in matches if os.path.isfile(m)]
-
-
 def _approx_tokens(text: str) -> int:
     """Rough token count: ~4 chars per token (GPT-style BPE approximation)."""
     return max(1, len(text) // 4)
-
-
-def _detect_structure(text: str, ext: str) -> str:
-    """Heuristic structure hint for LLM strategy context."""
-    if ext in {".md", ".markdown", ".mdx"}:
-        if re.search(r"^#+\s", text, re.MULTILINE):
-            return "Markdown with headings"
-        return "Markdown without headings"
-    if ext == ".py":
-        if re.search(r"^(class |def )", text, re.MULTILINE):
-            return "Python with class/function definitions"
-        return "Python script"
-    if ext in {".js", ".ts", ".tsx", ".jsx"}:
-        return "JavaScript/TypeScript"
-    if ext in {".json", ".yaml", ".yml", ".toml"}:
-        return "Structured data file"
-    return "Plain text"
 
 
 def _pid_alive(pid: int) -> bool:

--- a/src/reyn/stdlib/skills/index_docs/chunkers_preproc_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_preproc_safe.py
@@ -1,0 +1,262 @@
+"""Safe-mode preprocessor steps for index_docs (FP-0042 Phase 2.1).
+
+This module is the safe-mode home for ``gather_samples`` and
+``cost_preflight`` — the two Phase-1 preprocessor python steps that
+sample input files and estimate embedding cost so the LLM can choose
+a chunk strategy (or abort on cost). Before FP-0042 these lived in
+``chunkers.py`` with ``mode: unsafe`` because they called
+``reyn.api.unsafe.file``. After FP-0042 they read via
+``reyn.safe.file``, which goes through Reyn's permission resolver
+per call.
+
+Module split rationale (matches the existing ``chunkers_safe.py``
+pattern from R-PURE-MODE-REDEFINE Class A): the safe-mode AST
+validator walks every module-level import. ``chunkers.py`` still
+contains ``import os`` / ``import reyn.api.unsafe.file`` for the
+remaining unsafe-mode steps (``write_chunks_with_lock``,
+``apply_strategy``); inheriting those imports would force every
+safe-mode step in the same module to fail validation. Splitting the
+safe steps into their own file with safe-only imports keeps both
+sides clean.
+
+The remaining unsafe step ``write_chunks_with_lock`` will migrate to
+safe-mode in a follow-up PR (FP-0042 Phase 2.2) once the
+``reyn.safe.file`` surface grows ``delete`` / ``mkdir_parents`` and
+the lock mechanism is reworked off ``os.getpid``.
+
+Output-shape contract: the two functions here return the same shape
+as the legacy ``chunkers.py`` implementations so the LLM-facing
+artifact at ``data.samples_result`` / ``data.cost`` is bit-compatible
+across the migration. Field names, key sets, rounding, and the
+``_detect_structure`` heuristic all mirror the unsafe-mode versions.
+"""
+from __future__ import annotations
+
+import glob as _glob_mod
+import re as _re
+from math import ceil
+
+from reyn.safe import file as _safe_file
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+
+# POSIX file-type mask + regular-file bit (= stat.S_IFMT / S_IFREG).
+# We hard-code the values rather than ``import stat`` because the safe-mode
+# allowlist does not include the ``stat`` module. The numbers are stable
+# POSIX constants and are also the values CPython's stat.py exposes.
+_S_IFMT = 0o170000
+_S_IFREG = 0o100000
+
+
+def _is_regular_file(path: str) -> bool:
+    """Return True iff ``path`` exists and is a regular file.
+
+    Replaces the unsafe-mode ``os.path.isfile`` filter — ``os`` is not
+    in the safe-mode import allowlist. Uses ``reyn.safe.file.stat``
+    whose ``mode`` field is the underlying ``os.stat`` mode int. Any
+    error (permission denied, missing file, broken symlink) returns
+    False, matching ``os.path.isfile``'s suppress-all-errors behaviour.
+    """
+    try:
+        info = _safe_file.stat(path)
+    except (OSError, PermissionError):
+        return False
+    return (int(info.get("mode", 0)) & _S_IFMT) == _S_IFREG
+
+
+def _path_suffix(path: str) -> str:
+    """Return the lowercase extension including the leading dot.
+
+    Pathlib is not in the safe-mode allowlist, so use plain string
+    manipulation. Mirrors ``pathlib.PurePath.suffix`` for the cases
+    that matter to ``_detect_structure``:
+
+    - ``foo.md`` → ``.md``
+    - ``.hidden`` → ``""`` (hidden file with no real extension)
+    - ``.hidden.md`` → ``.md``
+    - ``foo`` → ``""``
+    """
+    name = path.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    idx = name.rfind(".")
+    return name[idx:] if idx > 0 else ""
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token count: ~4 chars per token (GPT-style BPE approximation)."""
+    return max(1, len(text) // 4)
+
+
+def _detect_structure(text: str, ext: str) -> str:
+    """Heuristic structure hint for LLM strategy context.
+
+    Mirrors ``chunkers.py``'s unsafe-mode helper exactly so the LLM
+    sees identical ``structure_hint`` strings across the migration.
+    Duplicated rather than imported because importing back into
+    ``chunkers.py`` would re-inherit its unsafe imports under the
+    safe-mode AST walk.
+    """
+    if ext in {".md", ".markdown", ".mdx"}:
+        if _re.search(r"^#+\s", text, _re.MULTILINE):
+            return "Markdown with headings"
+        return "Markdown without headings"
+    if ext == ".py":
+        if _re.search(r"^(class |def )", text, _re.MULTILINE):
+            return "Python with class/function definitions"
+        return "Python script"
+    if ext in {".js", ".ts", ".tsx", ".jsx"}:
+        return "JavaScript/TypeScript"
+    if ext in {".json", ".yaml", ".yml", ".toml"}:
+        return "Structured data file"
+    return "Plain text"
+
+
+def _glob_files(path: str) -> list[str]:
+    """Expand a glob pattern; return sorted regular-file matches.
+
+    Uses stdlib ``glob.glob`` (allowed in safe mode as a restricted
+    ambient source per the 2026-05-15 R-PURE-MODE stdlib audit) then
+    filters to regular files via ``_is_regular_file`` — this preserves
+    the unsafe-mode behaviour where ``os.path.isfile`` filtered
+    directories out before sampling.
+    """
+    if not path:
+        return []
+    matches = _glob_mod.glob(path, recursive=True)
+    return sorted(m for m in matches if _is_regular_file(m))
+
+
+# ─── Preprocessor steps ─────────────────────────────────────────────────────
+
+
+def gather_samples(artifact: dict) -> dict:
+    """Phase 1 preprocessor: sample files matched by path glob.
+
+    Receives the full ``index_docs_input`` artifact. Returns sample
+    excerpts and a file summary for the LLM's strategy decision.
+
+    FP-0042: file content reads + stat calls go through
+    ``reyn.safe.file``, which checks the path is under the skill's
+    declared read paths (or the workspace default zone). Reads
+    outside the declared set raise ``PermissionError`` which the
+    loops below treat the same as ``OSError`` (= silent skip,
+    matching the legacy ``os.path.isfile`` / ``open`` failure path).
+    """
+    data = artifact.get("data") or {}
+    path = str(data.get("path") or "")
+    sample_size: int = int(data.get("sample_size") or 5)
+
+    files = _glob_files(path)
+    if not files:
+        return {
+            "samples": [],
+            "summary": {
+                "file_count": 0,
+                "ext_dist": {},
+                "total_bytes": 0,
+                "mean_bytes": 0,
+            },
+            "file_count": 0,
+        }
+
+    by_ext: dict[str, list[str]] = {}
+    total_bytes = 0
+    for f in files:
+        ext = _path_suffix(f)
+        by_ext.setdefault(ext, []).append(f)
+        try:
+            total_bytes += int(_safe_file.stat(f).get("size", 0))
+        except (OSError, PermissionError):
+            pass
+
+    # Stratified sampling: 1–2 per extension, up to sample_size total.
+    picks: list[str] = []
+    for _ext, file_list in by_ext.items():
+        n = min(2, len(file_list))
+        picks.extend(file_list[:n])
+        if len(picks) >= sample_size:
+            picks = picks[:sample_size]
+            break
+    picks = picks[:sample_size]
+
+    samples = []
+    for f in picks:
+        try:
+            text = _safe_file.read(f)
+        except (OSError, PermissionError):
+            continue
+        excerpt = text[:1500]
+        samples.append(
+            {
+                "path": f,
+                "excerpt": excerpt,
+                "size_tokens": _approx_tokens(text),
+                "structure_hint": _detect_structure(text, _path_suffix(f)),
+            }
+        )
+
+    n = len(files)
+    return {
+        "samples": samples,
+        "summary": {
+            "file_count": n,
+            "ext_dist": {ext: len(fs) for ext, fs in by_ext.items()},
+            "total_bytes": total_bytes,
+            "mean_bytes": total_bytes // n if n else 0,
+        },
+        "file_count": n,
+    }
+
+
+def cost_preflight(artifact: dict) -> dict:
+    """Phase 1 preprocessor: estimate embedding cost (UX gap fix B).
+
+    Receives the artifact after ``gather_samples`` has injected its
+    result at ``data.samples_result``. Returns cost-estimate fields so
+    the LLM can decide to abort if cost is too high.
+
+    FP-0042 note: no file content I/O here — the file_count comes from
+    re-globbing the same path the samples were drawn from. ``glob.glob``
+    is metadata-only (admitted by the safe-mode allowlist as a
+    restricted ambient source); no ``reyn.safe.file`` calls happen, so
+    the migration is purely about dropping the
+    ``import reyn.api.unsafe.file`` dependency.
+    """
+    data = artifact.get("data") or {}
+    path = str(data.get("path") or "")
+    samples_result = data.get("samples_result") or {}
+    samples = samples_result.get("samples") or []
+    threshold = int(data.get("cost_warn_threshold") or 10_000)
+
+    if not samples:
+        return {
+            "chunk_count": 0,
+            "estimated_tokens": 0,
+            "estimated_cost_usd": 0.0,
+            "model": "standard",
+            "threshold_exceeded": False,
+        }
+
+    files = _glob_files(path)
+    n_files = len(files)
+
+    avg_size = sum(s.get("size_tokens", 0) for s in samples) / len(samples)
+    # Each file produces ceil(size / 600) chunks at the default max_chunk_size.
+    chunks_per_file = max(1, ceil(avg_size / 600))
+    estimated_chunks = max(1, n_files) * chunks_per_file
+
+    sample_texts = [s.get("excerpt", "") for s in samples]
+    sample_tokens = sum(_approx_tokens(t) for t in sample_texts)
+    avg_tokens_per_sample = sample_tokens / len(samples) if samples else 0
+    total_tokens = int(avg_tokens_per_sample * estimated_chunks)
+
+    rate = 0.02  # USD / 1M tokens (text-embedding-3-small; phase 1 hardcoded)
+    cost = total_tokens / 1_000_000 * rate
+
+    return {
+        "chunk_count": estimated_chunks,
+        "estimated_tokens": total_tokens,
+        "estimated_cost_usd": round(cost, 4),
+        "model": "standard",
+        "threshold_exceeded": estimated_chunks > threshold,
+    }

--- a/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
@@ -1,12 +1,12 @@
 """Safe-mode postprocessor step for index_docs (= the `extract_and_split`
 path enumeration phase).
 
-Split out from ``chunkers.py`` so that ``extract_and_split`` can actually run
-under ``mode: safe``. The companion ``chunkers.py`` module legitimately
-imports ``os`` / ``reyn.api.unsafe.file`` for its unsafe-mode steps
-(``gather_samples``, ``cost_preflight``, ``write_chunks_with_lock``), and the
-safe-mode AST validator walks all imports in the module via ``ast.walk(tree)``
-— so a single-file layout forces every safe-mode step to inherit those
+Split out from ``chunkers.py`` so that ``extract_and_split`` can actually
+run under ``mode: safe``. The companion ``chunkers.py`` module
+legitimately imports ``os`` / ``pathlib`` for its remaining unsafe-mode
+steps (``write_chunks_with_lock``, ``apply_strategy``), and the safe-mode
+AST validator walks all imports in the module via ``ast.walk(tree)`` — so
+a single-file layout forces every safe-mode step to inherit those
 unsafe imports. Following the audit's own Wave 2 pattern (= ``aggregate``
 → ``aggregate_pure``), this module hosts only the safe-mode step and the
 exact set of imports the safe-mode allowlist admits.
@@ -14,7 +14,9 @@ exact set of imports the safe-mode allowlist admits.
 R-PURE-MODE-REDEFINE audit (2026-05-15) signed off on ``glob.glob`` as a
 restricted ambient source for path-list-only enumeration. See
 ``docs/deep-dives/audits/2026-05-15-pure-mode-stdlib-audit.md`` and
-``_python_allowlist.py`` for the contract.
+``_python_allowlist.py`` for the contract. FP-0042 Phase 2.1 (2026-05-22)
+migrated the two preprocessor steps to their own
+``chunkers_preproc_safe.py`` for the same reason.
 """
 from __future__ import annotations
 

--- a/src/reyn/stdlib/skills/index_docs/skill.md
+++ b/src/reyn/stdlib/skills/index_docs/skill.md
@@ -31,13 +31,18 @@ graph:
   strategy: []
 permissions:
   python:
-    - module: ./chunkers.py
+    # FP-0042 Phase 2.1 (2026-05-22): preprocessor steps migrated from
+    # chunkers.py (mode: unsafe) → chunkers_preproc_safe.py (mode: safe).
+    # File reads / stat calls now go through reyn.safe.file, which gates
+    # against the workspace default-read-zone (CWD) and any explicit
+    # file.read entries below.
+    - module: ./chunkers_preproc_safe.py
       function: gather_samples
-      mode: unsafe
+      mode: safe
       timeout: 30
-    - module: ./chunkers.py
+    - module: ./chunkers_preproc_safe.py
       function: cost_preflight
-      mode: unsafe
+      mode: safe
       timeout: 10
     - module: ./chunkers_safe.py
       function: extract_and_split
@@ -46,7 +51,7 @@ permissions:
     - module: ./chunkers.py
       function: write_chunks_with_lock
       mode: unsafe
-      unsafe_reason: "minimal filesystem I/O + advisory lock for concurrent indexing"
+      unsafe_reason: "minimal filesystem I/O + advisory lock for concurrent indexing (FP-0042 Phase 2.2 will migrate this once reyn.safe.file grows delete/mkdir + lock support)"
       timeout: 300
     - module: ./chunkers.py
       function: apply_strategy

--- a/tests/test_chunkers.py
+++ b/tests/test_chunkers.py
@@ -1,11 +1,16 @@
 """Tier 2: OS invariant tests for index_docs stdlib skill chunkers.
 
-Tests the deterministic chunking logic (gather_samples, cost_preflight,
-apply_strategy, _split_*) used by the index_docs skill (ADR-0033 §2.1).
+Tests the deterministic chunking logic (apply_strategy, _split_*,
+write_chunks_with_lock helpers) used by the index_docs skill
+(ADR-0033 §2.1).
+
+Coverage for the safe-mode preprocessor steps (``gather_samples`` /
+``cost_preflight``) lives in ``test_chunkers_preproc_safe.py`` — they
+moved out of this module to ``chunkers_preproc_safe.py`` as part of
+FP-0042 Phase 2.1.
 
 No mocks; uses real filesystem operations via tmp_path.
-Tests cover UX gap fix B (cost_preflight threshold) and UX gap fix D
-(concurrent lock detection in apply_strategy).
+Tests cover UX gap fix D (concurrent lock detection in apply_strategy).
 """
 from __future__ import annotations
 
@@ -46,177 +51,9 @@ _C = _load_chunkers()
 # ---------------------------------------------------------------------------
 
 
-def _make_artifact(data: dict) -> dict:
-    """Wrap data in the standard artifact envelope."""
-    return {"type": "index_docs_input", "data": data}
-
-
 def _make_chunk_strategy_artifact(data: dict) -> dict:
     """Wrap data in chunk_strategy artifact envelope."""
     return {"type": "chunk_strategy", "data": data}
-
-
-# ---------------------------------------------------------------------------
-# gather_samples
-# ---------------------------------------------------------------------------
-
-
-def test_gather_samples_empty_path_returns_empty():
-    """Tier 2: gather_samples on empty / non-existent path returns empty samples."""
-    artifact = _make_artifact({"path": "/nonexistent/path/**/*.md", "source": "x"})
-    result = _C.gather_samples(artifact)
-
-    assert result["samples"] == []
-    assert result["file_count"] == 0
-    assert result["summary"]["file_count"] == 0
-    assert result["summary"]["total_bytes"] == 0
-
-
-def test_gather_samples_stratified_by_extension(tmp_path):
-    """Tier 2: gather_samples picks samples per extension (stratified)."""
-    # Create 3 .md and 2 .py files
-    for i in range(3):
-        (tmp_path / f"doc{i}.md").write_text(f"# Heading {i}\nContent {i}", encoding="utf-8")
-    for i in range(2):
-        (tmp_path / f"script{i}.py").write_text(f"def fn{i}():\n    pass", encoding="utf-8")
-
-    artifact = _make_artifact({"path": str(tmp_path / "**" / "*"), "source": "x"})
-    result = _C.gather_samples(artifact)
-
-    samples = result["samples"]
-    exts = {Path(s["path"]).suffix for s in samples}
-    # Should have samples from both .md and .py
-    assert ".md" in exts
-    assert ".py" in exts
-    assert result["file_count"] == 5
-    assert result["summary"]["file_count"] == 5
-
-
-def test_gather_samples_respects_sample_size_cap(tmp_path):
-    """Tier 2: gather_samples respects sample_size cap (default 5)."""
-    for i in range(10):
-        (tmp_path / f"doc{i}.md").write_text(f"# Doc {i}\nSome content.", encoding="utf-8")
-
-    artifact = _make_artifact({"path": str(tmp_path / "*.md"), "source": "x"})
-    result = _C.gather_samples(artifact)
-
-    assert len(result["samples"]) <= 5
-    assert result["file_count"] == 10
-
-
-def test_gather_samples_structure_hint_for_markdown(tmp_path):
-    """Tier 2: gather_samples returns 'Markdown with headings' for .md with # headings."""
-    (tmp_path / "readme.md").write_text(
-        "# Title\n\n## Section\n\nBody text.", encoding="utf-8"
-    )
-    artifact = _make_artifact({"path": str(tmp_path / "*.md"), "source": "x"})
-    result = _C.gather_samples(artifact)
-
-    assert len(result["samples"]) == 1
-    assert result["samples"][0]["structure_hint"] == "Markdown with headings"
-
-
-def test_gather_samples_structure_hint_for_python(tmp_path):
-    """Tier 2: gather_samples returns Python hint for .py files with class/def."""
-    (tmp_path / "module.py").write_text(
-        "class MyClass:\n    def method(self):\n        pass", encoding="utf-8"
-    )
-    artifact = _make_artifact({"path": str(tmp_path / "*.py"), "source": "x"})
-    result = _C.gather_samples(artifact)
-
-    assert len(result["samples"]) == 1
-    assert "Python" in result["samples"][0]["structure_hint"]
-
-
-def test_gather_samples_summary_ext_dist(tmp_path):
-    """Tier 2: gather_samples populates ext_dist correctly."""
-    (tmp_path / "a.md").write_text("hello", encoding="utf-8")
-    (tmp_path / "b.md").write_text("world", encoding="utf-8")
-    (tmp_path / "c.py").write_text("x = 1", encoding="utf-8")
-
-    artifact = _make_artifact({"path": str(tmp_path / "*"), "source": "x"})
-    result = _C.gather_samples(artifact)
-
-    ext_dist = result["summary"]["ext_dist"]
-    assert ext_dist.get(".md") == 2
-    assert ext_dist.get(".py") == 1
-
-
-# ---------------------------------------------------------------------------
-# cost_preflight
-# ---------------------------------------------------------------------------
-
-
-def test_cost_preflight_empty_samples_returns_zero():
-    """Tier 2: cost_preflight with empty samples returns zero cost."""
-    artifact = _make_artifact(
-        {
-            "path": "/nonexistent/**",
-            "source": "x",
-            "samples_result": {"samples": [], "summary": {}, "file_count": 0},
-        }
-    )
-    result = _C.cost_preflight(artifact)
-
-    assert result["chunk_count"] == 0
-    assert result["estimated_tokens"] == 0
-    assert result["estimated_cost_usd"] == 0.0
-    assert result["threshold_exceeded"] is False
-
-
-def test_cost_preflight_threshold_exceeded_flag(tmp_path):
-    """Tier 2: cost_preflight sets threshold_exceeded when estimated chunks exceed threshold."""
-    # Create 1000 tiny files so estimated_chunks > threshold=100
-    for i in range(100):
-        (tmp_path / f"doc{i}.md").write_text("x" * 4000, encoding="utf-8")
-
-    samples = [
-        {
-            "path": str(tmp_path / "doc0.md"),
-            "excerpt": "x" * 1000,
-            "size_tokens": 1000,
-            "structure_hint": "Markdown without headings",
-        }
-    ]
-
-    artifact = _make_artifact(
-        {
-            "path": str(tmp_path / "*.md"),
-            "source": "x",
-            "cost_warn_threshold": 10,  # very low threshold
-            "samples_result": {"samples": samples, "file_count": 100},
-        }
-    )
-    result = _C.cost_preflight(artifact)
-
-    assert result["threshold_exceeded"] is True
-
-
-def test_cost_preflight_not_exceeded_for_few_files(tmp_path):
-    """Tier 2: cost_preflight threshold_exceeded=False for small input sets."""
-    (tmp_path / "doc.md").write_text("Short file.", encoding="utf-8")
-
-    samples = [
-        {
-            "path": str(tmp_path / "doc.md"),
-            "excerpt": "Short file.",
-            "size_tokens": 3,
-            "structure_hint": "Markdown without headings",
-        }
-    ]
-
-    artifact = _make_artifact(
-        {
-            "path": str(tmp_path / "*.md"),
-            "source": "x",
-            "cost_warn_threshold": 10_000,
-            "samples_result": {"samples": samples, "file_count": 1},
-        }
-    )
-    result = _C.cost_preflight(artifact)
-
-    assert result["threshold_exceeded"] is False
-    assert result["estimated_cost_usd"] >= 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chunkers_preproc_safe.py
+++ b/tests/test_chunkers_preproc_safe.py
@@ -1,0 +1,337 @@
+"""Tier 2: OS invariant tests for chunkers_preproc_safe (FP-0042 Phase 2.1).
+
+Tests the safe-mode preprocessor steps (``gather_samples`` /
+``cost_preflight``) that replaced the prior unsafe versions in
+``chunkers.py``. Coverage mirrors the equivalent tests in
+``test_chunkers.py`` so the migration is observably bit-compatible
+at the artifact contract.
+
+No mocks; uses real filesystem operations via tmp_path. The
+``_set_permission_context`` autouse fixture establishes a read grant
+over ``tmp_path`` so the safe-mode file API can be exercised
+directly (= same pattern as ``test_safe_file_api.py``).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from reyn.safe import file as sf
+
+
+def _load_chunkers_preproc_safe():
+    """Import chunkers_preproc_safe.py from the skill directory."""
+    skill_dir = (
+        Path(__file__).parent.parent
+        / "src" / "reyn" / "stdlib" / "skills" / "index_docs"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "chunkers_preproc_safe", skill_dir / "chunkers_preproc_safe.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_C = _load_chunkers_preproc_safe()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_safe_file_context():
+    """Reset reyn.safe.file's module-global permission context per test."""
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+    yield
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+
+
+@pytest.fixture
+def grant_tmp_read(tmp_path: Path):
+    """Grant safe.file read permission over ``tmp_path``.
+
+    Mirrors the production wiring where ``preprocessor_executor`` pre-pends
+    the CWD as a default read zone so a safe-mode step can read
+    workspace-local files without explicit declarations.
+    """
+    sf._set_permission_context(read_paths=[str(tmp_path)])
+    return tmp_path
+
+
+def _make_artifact(data: dict) -> dict:
+    """Wrap data in the standard artifact envelope."""
+    return {"type": "index_docs_input", "data": data}
+
+
+# ---------------------------------------------------------------------------
+# gather_samples
+# ---------------------------------------------------------------------------
+
+
+def test_gather_samples_empty_path_returns_empty(grant_tmp_read: Path):
+    """Tier 2: gather_samples on a non-existent path returns empty samples."""
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "nonexistent" / "**" / "*.md"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    assert result["samples"] == []
+    assert result["file_count"] == 0
+    assert result["summary"]["file_count"] == 0
+    assert result["summary"]["total_bytes"] == 0
+
+
+def test_gather_samples_stratified_by_extension(grant_tmp_read: Path):
+    """Tier 2: gather_samples picks samples per extension (stratified)."""
+    for i in range(3):
+        (grant_tmp_read / f"doc{i}.md").write_text(
+            f"# Heading {i}\nContent {i}", encoding="utf-8"
+        )
+    for i in range(2):
+        (grant_tmp_read / f"script{i}.py").write_text(
+            f"def fn{i}():\n    pass", encoding="utf-8"
+        )
+
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "**" / "*"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    samples = result["samples"]
+    exts = {Path(s["path"]).suffix for s in samples}
+    assert ".md" in exts
+    assert ".py" in exts
+    assert result["file_count"] == 5
+    assert result["summary"]["file_count"] == 5
+
+
+def test_gather_samples_respects_sample_size_cap(grant_tmp_read: Path):
+    """Tier 2: gather_samples respects the sample_size cap (default 5)."""
+    for i in range(10):
+        (grant_tmp_read / f"doc{i}.md").write_text(
+            f"# Doc {i}\nSome content.", encoding="utf-8"
+        )
+
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "*.md"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    assert len(result["samples"]) <= 5
+    assert result["file_count"] == 10
+
+
+def test_gather_samples_structure_hint_for_markdown(grant_tmp_read: Path):
+    """Tier 2: structure_hint is 'Markdown with headings' for .md with # headings."""
+    (grant_tmp_read / "readme.md").write_text(
+        "# Title\n\n## Section\n\nBody text.", encoding="utf-8"
+    )
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "*.md"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    assert len(result["samples"]) == 1
+    assert result["samples"][0]["structure_hint"] == "Markdown with headings"
+
+
+def test_gather_samples_structure_hint_for_python(grant_tmp_read: Path):
+    """Tier 2: structure_hint mentions Python for .py with class/def."""
+    (grant_tmp_read / "module.py").write_text(
+        "class MyClass:\n    def method(self):\n        pass",
+        encoding="utf-8",
+    )
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "*.py"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    assert len(result["samples"]) == 1
+    assert "Python" in result["samples"][0]["structure_hint"]
+
+
+def test_gather_samples_summary_ext_dist(grant_tmp_read: Path):
+    """Tier 2: ext_dist counts files per extension."""
+    (grant_tmp_read / "a.md").write_text("hello", encoding="utf-8")
+    (grant_tmp_read / "b.md").write_text("world", encoding="utf-8")
+    (grant_tmp_read / "c.py").write_text("x = 1", encoding="utf-8")
+
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "*"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    ext_dist = result["summary"]["ext_dist"]
+    assert ext_dist.get(".md") == 2
+    assert ext_dist.get(".py") == 1
+
+
+def test_gather_samples_filters_directories(grant_tmp_read: Path):
+    """Tier 2: directories returned by glob are filtered out (= os.path.isfile
+    behaviour preserved via reyn.safe.file.stat mode check)."""
+    (grant_tmp_read / "subdir").mkdir()
+    (grant_tmp_read / "a.md").write_text("content", encoding="utf-8")
+
+    artifact = _make_artifact(
+        {"path": str(grant_tmp_read / "*"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    # Only "a.md" is a regular file; "subdir" should not appear.
+    assert result["file_count"] == 1
+    assert result["summary"]["ext_dist"].get(".md") == 1
+    # No entry for the (extension-less) directory should leak into ext_dist.
+    assert "" not in result["summary"]["ext_dist"]
+
+
+def test_gather_samples_denied_path_returns_empty(tmp_path: Path):
+    """Tier 2: when the path is outside the granted read zone, the safe
+    file API raises PermissionError → samples skip silently (matching
+    legacy ``os.path.isfile`` False / ``open`` OSError behaviour).
+    Net effect: ``file_count`` reflects glob's view but ``samples`` /
+    sizes stay empty because every stat / read fails the permission
+    check.
+    """
+    (tmp_path / "denied.md").write_text("secret", encoding="utf-8")
+    # Grant a *different* directory than the one we'll glob.
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    sf._set_permission_context(read_paths=[str(other)])
+
+    artifact = _make_artifact(
+        {"path": str(tmp_path / "*.md"), "source": "x"}
+    )
+    result = _C.gather_samples(artifact)
+
+    # stat() raised PermissionError → _is_regular_file returned False →
+    # the file was filtered before sampling. file_count is 0 because
+    # _glob_files filters through _is_regular_file.
+    assert result["samples"] == []
+    assert result["file_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# cost_preflight
+# ---------------------------------------------------------------------------
+
+
+def test_cost_preflight_empty_samples_returns_zero(grant_tmp_read: Path):
+    """Tier 2: cost_preflight with empty samples returns zero cost."""
+    artifact = _make_artifact(
+        {
+            "path": str(grant_tmp_read / "missing" / "**"),
+            "source": "x",
+            "samples_result": {"samples": [], "summary": {}, "file_count": 0},
+        }
+    )
+    result = _C.cost_preflight(artifact)
+
+    assert result["chunk_count"] == 0
+    assert result["estimated_tokens"] == 0
+    assert result["estimated_cost_usd"] == 0.0
+    assert result["threshold_exceeded"] is False
+
+
+def test_cost_preflight_threshold_exceeded_flag(grant_tmp_read: Path):
+    """Tier 2: threshold_exceeded flips when estimated chunks > threshold."""
+    for i in range(100):
+        (grant_tmp_read / f"doc{i}.md").write_text("x" * 4000, encoding="utf-8")
+
+    samples = [
+        {
+            "path": str(grant_tmp_read / "doc0.md"),
+            "excerpt": "x" * 1000,
+            "size_tokens": 1000,
+            "structure_hint": "Markdown without headings",
+        }
+    ]
+
+    artifact = _make_artifact(
+        {
+            "path": str(grant_tmp_read / "*.md"),
+            "source": "x",
+            "cost_warn_threshold": 10,
+            "samples_result": {"samples": samples, "file_count": 100},
+        }
+    )
+    result = _C.cost_preflight(artifact)
+
+    assert result["threshold_exceeded"] is True
+
+
+def test_cost_preflight_not_exceeded_for_few_files(grant_tmp_read: Path):
+    """Tier 2: threshold_exceeded stays False for small input sets."""
+    (grant_tmp_read / "doc.md").write_text("Short file.", encoding="utf-8")
+
+    samples = [
+        {
+            "path": str(grant_tmp_read / "doc.md"),
+            "excerpt": "Short file.",
+            "size_tokens": 3,
+            "structure_hint": "Markdown without headings",
+        }
+    ]
+
+    artifact = _make_artifact(
+        {
+            "path": str(grant_tmp_read / "*.md"),
+            "source": "x",
+            "cost_warn_threshold": 10_000,
+            "samples_result": {"samples": samples, "file_count": 1},
+        }
+    )
+    result = _C.cost_preflight(artifact)
+
+    assert result["threshold_exceeded"] is False
+    assert result["estimated_cost_usd"] >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# _path_suffix / _detect_structure (internal helpers — pinned because the
+# LLM-facing structure_hint string must stay stable across the migration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("foo.md", ".md"),
+        ("/a/b/c.py", ".py"),
+        ("noext", ""),
+        (".hidden", ""),
+        (".hidden.md", ".md"),
+        ("a/b/.dotonly", ""),
+        ("nested.dir/file.txt", ".txt"),
+    ],
+)
+def test_path_suffix_mirrors_pathlib(path: str, expected: str):
+    """Tier 2: _path_suffix matches pathlib.PurePath.suffix for our cases."""
+    assert _C._path_suffix(path) == expected
+
+
+@pytest.mark.parametrize(
+    "ext, text, expected",
+    [
+        (".md", "# Heading\nbody", "Markdown with headings"),
+        (".md", "plain text only", "Markdown without headings"),
+        (".py", "class Foo:\n    pass", "Python with class/function definitions"),
+        (".py", "x = 1\nprint(x)", "Python script"),
+        (".ts", "const x = 1;", "JavaScript/TypeScript"),
+        (".json", "{}", "Structured data file"),
+        (".txt", "anything", "Plain text"),
+    ],
+)
+def test_detect_structure_mirrors_unsafe_heuristic(ext: str, text: str, expected: str):
+    """Tier 2: _detect_structure strings match chunkers.py's legacy heuristic
+    exactly — the LLM sees identical structure_hint values across the
+    FP-0042 migration."""
+    assert _C._detect_structure(text, ext) == expected

--- a/tests/test_index_docs_skill.py
+++ b/tests/test_index_docs_skill.py
@@ -238,20 +238,23 @@ def test_index_docs_postprocessor_step3_args_from():
 # ---------------------------------------------------------------------------
 
 
-def test_index_docs_permissions_python_unsafe_declared():
-    """Tier 2: skill declares python permissions for all chunker functions.
+def test_index_docs_permissions_python_modes_declared():
+    """Tier 2: skill declares the expected mode per chunker function.
 
-    R-PURE-MODE-REDEFINE Class A: extract_and_split is safe (glob enum only),
-    write_chunks_with_lock is unsafe (lock + content read + jsonl write).
-    apply_strategy remains unsafe (deprecated monolithic step, compat kept).
+    Post-FP-0042 Phase 2.1:
+      - gather_samples / cost_preflight: safe (chunkers_preproc_safe.py)
+      - extract_and_split: safe (chunkers_safe.py)
+      - write_chunks_with_lock: unsafe minimal — lock + content read +
+        jsonl write (will migrate in Phase 2.2)
+      - apply_strategy: unsafe deprecated, kept for override compat
     """
     skill = _load()
     python_perms = skill.permissions.python
     assert len(python_perms) >= 5, f"Expected at least 5 python perms, got {len(python_perms)}"
 
     fn_modes = {p.function: p.mode for p in python_perms}
-    assert fn_modes.get("gather_samples") == "unsafe"
-    assert fn_modes.get("cost_preflight") == "unsafe"
+    assert fn_modes.get("gather_samples") == "safe"
+    assert fn_modes.get("cost_preflight") == "safe"
     assert fn_modes.get("extract_and_split") == "safe"
     assert fn_modes.get("write_chunks_with_lock") == "unsafe"
     assert fn_modes.get("apply_strategy") == "unsafe"


### PR DESCRIPTION
**[dogfood-coder]** — FP-0042 Phase 2.1. Stacked on #553. Do not merge until #553 lands.

## Summary

- Migrate `gather_samples` + `cost_preflight` from `chunkers.py` (mode: unsafe, `reyn.api.unsafe.file`) → new `chunkers_preproc_safe.py` (mode: safe, `reyn.safe.file`).
- `chunkers.py` loses its `reyn.api.unsafe.file` import and the orphaned `_api_glob_files` / `_detect_structure` / `sys` helpers.
- `preprocessor_executor` pre-pends CWD (read) + `.reyn/` + `reyn/` (write) as default zones into `file_read_paths` / `file_write_paths`, so safe-mode steps mirror the parent permission resolver's default-zone semantics — workspace-local reads don't need explicit `file.read` declarations.

This is the first stdlib skill to migrate under FP-0042's "stdlib should not require unsafe-python" goal. Stdlib `index_docs` unsafe-mode declarations drop from 4 → 2 (= `write_chunks_with_lock` + deprecated `apply_strategy`, both queued for Phase 2.2).

## Bit-compatibility

The new safe-mode functions return the same artifact shape as the legacy unsafe versions:

- `_detect_structure` matches the original heuristic exactly (Markdown w/ vs w/o headings, Python class/def vs script, JS/TS, JSON/YAML/TOML, plain text) — pinned via parametric tests so the LLM sees identical `structure_hint` strings across the migration.
- `_path_suffix` mirrors `pathlib.PurePath.suffix` for the cases that drive `_detect_structure` — pinned via parametric tests.
- `os.path.isfile` filter on glob results is replaced with `reyn.safe.file.stat(path)` + `S_IFREG` mode check (`stat` module isn't on the safe allowlist; we hard-code POSIX constants `_S_IFMT=0o170000` / `_S_IFREG=0o100000`).

## Why `chunkers_preproc_safe.py` (not in chunkers.py)

The safe-mode AST validator walks every module-level import. `chunkers.py` still legitimately imports `os` / `pathlib` for the remaining `write_chunks_with_lock` + `apply_strategy` unsafe-mode steps. A single-file layout would force safe-mode steps to inherit those unsafe imports and fail validation. Same pattern as the existing `chunkers_safe.py` split (R-PURE-MODE-REDEFINE Class A, 2026-05-15).

## Out of scope (Phase 2.2)

- `write_chunks_with_lock` (mode: unsafe, minimal) — pending `reyn.safe.file.delete` / `mkdir` + lock primitive.
- `apply_strategy` (mode: unsafe, deprecated) — kept for project-override compat; will retire when no overrides reference it.

## Test plan

- [x] Tier 2 contract suite for `chunkers_preproc_safe` — 25 tests, including 7 parametric `_path_suffix` cases + 7 parametric `_detect_structure` cases, directory-filter behaviour, and a denied-path silent-skip case (mirrors the legacy `os.path.isfile` False path).
- [x] `test_index_docs_skill.py` mode-assertion updated to expect `safe` for the two preprocessor steps.
- [x] Full test sweep — `5144 passed, 8 skipped, 3 xfailed` in 3:25 on the migration commit.
- [x] `ruff check` clean on changed files.
- [ ] Manual dogfood E2E (= live `reyn run index_docs '{"source": "x", "path": "docs/**/*.md", ...}'`) — deferred to after #553 merges (avoids retesting against a moving base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)