### PR TITLE
feat(tui): AsyncStackPanel keyboard navigation — F4 focus + j/k + c + Esc

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -158,6 +158,12 @@ class ReynTUIApp(App):
         # skills are concurrent the user can expand them all at once
         # with one keypress. Status hint when nothing is running.
         Binding("f3", "skill_expand_toggle", "Toggle skill row drill-down", priority=True, show=False),
+        # Focus the bottom AsyncStackPanel for keyboard navigation
+        # (= F4 → panel focus → j/k navigate → c prefills /cancel <id>
+        # → Esc returns to InputBar). Status hint when the panel
+        # has no entries (= nothing to focus). F-key chosen over
+        # Ctrl+letter to avoid clobbering TextArea editing defaults.
+        Binding("f4", "focus_async_stack", "Focus async strip", priority=True, show=False),
         # W13 T2-1: F7 keyboard drill for the most-recent failed ToolCallRow.
         # F4 is reserved for async-stack panel focus (Wave-9 / keys_tab
         # description); F5/F6 reserved for conv-pane error-jump (#586).
@@ -1487,6 +1493,32 @@ class ReynTUIApp(App):
         if tip_shown:
             # Auto-hide the tip after ~4 s once expand has been applied.
             self.set_timer(4.0, conv.hide_status)
+
+    def action_focus_async_stack(self) -> None:
+        """F4 — focus the bottom AsyncStackPanel for keyboard navigation.
+
+        When the panel has entries, give it focus so j/k navigate
+        through the rows. With no entries: surface a status hint
+        rather than silently steal focus to an empty panel (which
+        would trap the user — they'd press Esc to escape only to
+        wonder what they accidentally focused).
+        """
+        try:
+            from .widgets.async_stack_panel import AsyncStackPanel
+            panel = self.query_one("#async-stack", AsyncStackPanel)
+        except Exception:
+            return
+        if not panel.snapshot():
+            try:
+                conv = self.query_one("#conversation", ConversationView)
+                conv.show_status(
+                    "no active tasks in async strip", kind="general",
+                )
+                self.set_timer(2.0, conv.hide_status)
+            except Exception:
+                pass
+            return
+        panel.focus()
 
     def action_drill_failed_tool(self) -> None:
         """F7 — toggle expand on the most-recent failed ToolCallRow.

--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -75,6 +75,7 @@ from typing import Literal
 
 from rich.cells import cell_len
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
@@ -186,9 +187,16 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         padding: 0 1;
         background: transparent;
     }
+    AsyncStackPanel:focus {
+        background: #1a1a1a;
+    }
     """
 
-    can_focus = False
+    # Focusable so the F4 binding can route focus here and j/k
+    # navigation works. Focus visibility is the ``:focus`` CSS
+    # background change above; the per-row selection caret is in
+    # ``_build_lines`` (= ``▌`` glyph on the cursor row when focused).
+    can_focus = True
 
     def __init__(self, *, id: str | None = None) -> None:
         super().__init__(id=id)
@@ -206,6 +214,14 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         # timer fires, the pending timer is cancelled and the entry is
         # unmounted immediately.
         self._flash_timers: dict[str, object] = {}
+        # Cursor index for keyboard navigation when the panel is
+        # focused (= F4 + j/k path). Indexes into the
+        # ``_sorted_visible`` result, NOT the underlying
+        # ``_entries`` dict, so visual ordering and cursor ordering
+        # stay aligned (= pending entries float to top in both).
+        # Clamped on every navigation step + on render so deletes
+        # / completions can't leave a dangling out-of-range cursor.
+        self._cursor: int = 0
 
     # ── Textual lifecycle ────────────────────────────────────────────────────
 
@@ -215,6 +231,19 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
 
     def on_mount(self) -> None:
         self.set_interval(_TICK_INTERVAL_S, self._tick)
+        self._refresh()
+
+    def on_focus(self, event: events.Focus) -> None:
+        """Repaint to show the cursor caret on the selected entry."""
+        # Reset cursor to top on every fresh focus — predictable
+        # entry point regardless of where the user navigated last
+        # time. Without this, returning to the panel after entries
+        # changed could land on a stale offset.
+        self._cursor = 0
+        self._refresh()
+
+    def on_blur(self, event: events.Blur) -> None:
+        """Repaint to drop the cursor caret when focus leaves."""
         self._refresh()
 
     # ── Public API ───────────────────────────────────────────────────────────
@@ -347,6 +376,96 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
             self._entries.clear()
             self._refresh()
 
+    # ── keyboard navigation (F4-driven focus path) ──────────────────────────
+
+    def move_cursor(self, delta: int) -> None:
+        """Move the keyboard cursor by ``delta`` rows (clamped to visible range).
+
+        Visible range = ``_sorted_visible`` count (= up to ``_CAP``,
+        sorted with pending entries first). Wraps modulo the count
+        so j/k can cycle indefinitely without hitting an edge — same
+        idiom as SlashPicker's row navigation. Empty panel: no-op.
+        """
+        visible = self._sorted_visible()
+        if not visible:
+            self._cursor = 0
+            return
+        self._cursor = (self._cursor + delta) % len(visible)
+        self._refresh()
+
+    def selected_agent_id(self) -> str:
+        """Return the agent_id under the keyboard cursor, or "" when empty.
+
+        Used by the F4-mode ``c`` key handler to populate the
+        InputBar with ``/cancel <id>``. Returns the visible-order
+        entry at ``_cursor``; clamps to the first entry if the
+        cursor drifted out of range (= entries removed since
+        last navigation step).
+        """
+        visible = self._sorted_visible()
+        if not visible:
+            return ""
+        idx = max(0, min(self._cursor, len(visible) - 1))
+        return visible[idx][0]
+
+    def on_key(self, event: events.Key) -> None:
+        """Keyboard handler — j/k navigate, c prefills /cancel, Esc unfocus.
+
+        Active only when the panel itself has focus (= F4-driven).
+        The keys bubble up from the focused panel; consumed ones
+        call ``event.stop()`` so they don't fall through to App-level
+        bindings (e.g. ``j`` would scroll the right panel otherwise).
+        """
+        key = event.key
+        if key in ("down", "j"):
+            self.move_cursor(+1)
+            event.stop()
+            return
+        if key in ("up", "k"):
+            self.move_cursor(-1)
+            event.stop()
+            return
+        if key == "c":
+            self._prefill_cancel_and_unfocus()
+            event.stop()
+            return
+        if key == "escape":
+            self._return_focus_to_input()
+            event.stop()
+            return
+
+    def _prefill_cancel_and_unfocus(self) -> None:
+        """``c`` — pre-populate ``/cancel <id>`` in the InputBar and refocus it.
+
+        The user is on the panel via F4 with a task highlighted;
+        ``c`` is the discoverable "cancel this" key. We don't
+        actually cancel here — slash-side ``/cancel <id>`` already
+        owns the cancel contract — we just stage the command so the
+        user reviews + Enters. Empty selection (= no entries) is a
+        silent no-op; focus stays on the panel.
+        """
+        agent_id = self.selected_agent_id()
+        if not agent_id:
+            return
+        try:
+            from .input_bar import InputBar
+            ib = self.app.query_one("#inputbar", InputBar)
+            ta = ib.query_one("#input")
+            ta.load_text(f"/cancel {agent_id}")
+            # Move cursor to end so Enter sends immediately.
+            ta.move_cursor((0, len(f"/cancel {agent_id}")))
+            ib.focus_input()
+        except Exception:
+            pass
+
+    def _return_focus_to_input(self) -> None:
+        """Esc — return focus to the InputBar without staging anything."""
+        try:
+            from .input_bar import InputBar
+            self.app.query_one("#inputbar", InputBar).focus_input()
+        except Exception:
+            pass
+
     def snapshot(self) -> list[dict]:
         """Public read of the current entry list for tests / introspection.
 
@@ -420,9 +539,17 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         return ordered[:_CAP]
 
     def _build_lines(self) -> Text:
-        """Multi-line Text — one row per visible entry + overflow indicator."""
+        """Multi-line Text — one row per visible entry + overflow indicator.
+
+        When the panel itself has focus (= F4 path), the row under
+        the keyboard cursor gets a leading ``▌`` caret (= same idiom
+        as SlashPicker's selection marker) so the user sees which
+        entry the next ``c`` / Enter will target. Unfocused: no
+        caret — the panel stays in its ambient single-line mode.
+        """
         t = Text()
         if not self._entries:
+            self._cursor = 0
             return t
         try:
             total_width = int(getattr(self.size, "width", 0))
@@ -432,9 +559,20 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
             total_width = 80
         body_budget = max(20, total_width - _RIGHT_MARGIN_CELLS)
         visible = self._sorted_visible()
+        # Clamp cursor to current visible range — entries can
+        # disappear between navigation steps (task completed /
+        # cancelled), so the cursor might drift out of bounds.
+        if visible:
+            self._cursor = max(0, min(self._cursor, len(visible) - 1))
+        focused = self.has_focus
         for i, (agent_id, entry, glyph) in enumerate(visible):
             if i > 0:
                 t.append("\n")
+            if focused:
+                if i == self._cursor:
+                    t.append("▌ ", style=_CORAL)
+                else:
+                    t.append("  ", style="#1a1a1a")
             self._append_row(t, agent_id, entry, glyph, body_budget)
         overflow = len(self._entries) - len(visible)
         if overflow > 0:

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -138,6 +138,11 @@ _CONVERSATION_KEYS = {
     # inline expand on widgets that live in the conv pane (=
     # mouse-click + F3 are the two trigger paths to the same UX).
     "f3",
+    # F4 focuses the bottom AsyncStackPanel for keyboard nav.
+    # Panel renders ambient conv-pane work (= attached agent
+    # tasks), so CONVERSATION is the right home for discovery
+    # alongside Ctrl+P / Ctrl+N turn jump.
+    "f4",
     # W13 T2-1: ToolCallRow failure drill-down. Same rationale as F3 --
     # toggles inline expand on a widget that lives in the conv pane.
     "f7",

--- a/tests/cli/test_async_stack_keyboard.py
+++ b/tests/cli/test_async_stack_keyboard.py
@@ -1,0 +1,211 @@
+"""Tier 2: AsyncStackPanel keyboard navigation (F4 focus + j/k + c + Esc).
+
+Categorical UX gap on the execution-control axis. Before this PR,
+the bottom strip (= AsyncStackPanel showing the attached agent's
+running tasks) was mouse-only — no way to focus, navigate, or
+interact via keyboard.
+
+This adds:
+
+  - ``F4`` → focuses the panel when entries are present (status
+    hint when empty so the user doesn't trap focus on nothing)
+  - ``j`` / ``↓`` / ``k`` / ``↑`` → cycle the selection cursor
+    through visible entries (wraps at edges)
+  - ``c`` → prefill the InputBar with ``/cancel <id>`` for the
+    selected entry and refocus the input (= discoverable cancel
+    path that delegates to the existing /cancel slash contract)
+  - ``Esc`` → return focus to the InputBar without staging
+    anything
+
+Public surfaces tested:
+  - ``AsyncStackPanel.can_focus`` is True
+  - ``move_cursor`` advances / wraps cursor index
+  - ``selected_agent_id`` returns the visible-order entry at cursor
+  - ``action_focus_async_stack`` focuses the panel when non-empty
+  - F4 binding registered on the app
+  - Keys tab routes F4 to CONVERSATION group
+  - Empty panel → status hint, focus NOT moved
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_panel_is_focusable() -> None:
+    """Tier 2: ``can_focus`` is True so F4 routing can land here."""
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    assert AsyncStackPanel.can_focus is True
+
+
+@pytest.mark.asyncio
+async def test_move_cursor_advances_and_wraps() -> None:
+    """Tier 2: ``move_cursor(+1)`` advances + wraps at the end."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("task-a", "skill_a")
+        conv.add_async_task("task-b", "skill_b")
+        conv.add_async_task("task-c", "skill_c")
+        await pilot.pause()
+        panel = app.query_one("#async-stack", AsyncStackPanel)
+        # Visible order is "shortest elapsed first" so the most
+        # recently added task floats to the top — task-c, task-b,
+        # task-a. Cursor starts at 0 (= top of the visible list).
+        first = panel.selected_agent_id()
+        panel.move_cursor(+1)
+        second = panel.selected_agent_id()
+        panel.move_cursor(+1)
+        third = panel.selected_agent_id()
+        # All three IDs visited in sorted order (no duplicates / skips).
+        assert {first, second, third} == {"task-a", "task-b", "task-c"}
+        # Wrap forward returns to top.
+        panel.move_cursor(+1)
+        assert panel.selected_agent_id() == first
+        # Backward wraps to bottom (third entry).
+        panel.move_cursor(-1)
+        assert panel.selected_agent_id() == third
+
+
+@pytest.mark.asyncio
+async def test_empty_panel_move_cursor_safe_noop() -> None:
+    """Tier 2: navigation on an empty panel doesn't raise + clamps cursor to 0."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#async-stack", AsyncStackPanel)
+        panel.move_cursor(+1)
+        assert panel.selected_agent_id() == ""
+
+
+@pytest.mark.asyncio
+async def test_f4_focuses_panel_when_entries_present() -> None:
+    """Tier 2: ``action_focus_async_stack`` focuses the panel when non-empty."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("task-x", "skill_x")
+        await pilot.pause()
+        app.action_focus_async_stack()
+        await pilot.pause()
+        panel = app.query_one("#async-stack", AsyncStackPanel)
+        assert panel.has_focus is True
+
+
+@pytest.mark.asyncio
+async def test_f4_with_empty_panel_shows_hint_and_doesnt_focus() -> None:
+    """Tier 2: F4 on an empty strip surfaces a status hint, leaves focus."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#async-stack", AsyncStackPanel)
+        conv = app.query_one("#conversation", ConversationView)
+        assert panel.snapshot() == []
+        app.action_focus_async_stack()
+        await pilot.pause()
+        # Panel NOT focused.
+        assert panel.has_focus is False
+        # Status hint surfaced.
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "no active tasks" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_c_key_prefills_inputbar_with_cancel() -> None:
+    """Tier 2: pressing ``c`` while panel focused stages ``/cancel <id>``."""
+    from textual import events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView, InputBar
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("the-task-id", "skill_y")
+        await pilot.pause()
+        panel = app.query_one("#async-stack", AsyncStackPanel)
+        panel.focus()
+        await pilot.pause()
+        # Simulate 'c' keypress.
+        panel.on_key(events.Key(key="c", character="c"))
+        await pilot.pause()
+        ib = app.query_one("#inputbar", InputBar)
+        ta = ib.query_one("#input")
+        assert ta.text == "/cancel the-task-id"
+
+
+@pytest.mark.asyncio
+async def test_escape_returns_focus_to_input() -> None:
+    """Tier 2: pressing ``Esc`` returns focus to the InputBar.
+
+    Drives panel.on_key directly with an Escape event (= panel-
+    scoped path), then verifies the InputBar's TextArea has
+    focus via app.focused.
+    """
+    from textual import events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.async_stack_panel import AsyncStackPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("task-esc", "skill_esc")
+        await pilot.pause()
+        panel = app.query_one("#async-stack", AsyncStackPanel)
+        panel.focus()
+        await pilot.pause()
+        assert panel.has_focus is True
+        panel.on_key(events.Key(key="escape", character=None))
+        await pilot.pause()
+        # Panel relinquishes focus once the InputBar takes it.
+        assert panel.has_focus is False
+
+
+def test_f4_binding_registered() -> None:
+    """Tier 2: F4 is bound to ``focus_async_stack`` action."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    binds = {(b.key, b.action) for b in ReynTUIApp.BINDINGS}
+    assert ("f4", "focus_async_stack") in binds
+
+
+def test_keys_tab_routes_f4_to_conversation() -> None:
+    """Tier 2: F4 lands in the CONVERSATION group + pretty-prints as "F4"."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import (
+        _key_group_for,
+        _pretty_key,
+    )
+
+    assert _key_group_for("f4") == "CONVERSATION"
+    assert _pretty_key("f4") == "F4"


### PR DESCRIPTION
**[tui-coder]** — Execution-control categorical gap. Before this PR, the bottom strip (= AsyncStackPanel showing the attached agent's running tasks) was mouse-only — no way to focus, navigate, or interact via keyboard. Users running 3 plans + a skill had no keyboard shortcut to identify and cancel a specific one without re-typing the `/cancel` slash with the right id-prefix.

## Summary

`F4` opens a keyboard mode on the panel:

```
  F4         → focus the panel (status hint when empty)
  j / ↓      → cursor down
  k / ↑      → cursor up
  c          → prefill InputBar with /cancel <selected-id> + refocus input
  Esc        → return focus to InputBar (no staging)
```

The selected row gets a leading `▌` caret (= same idiom as the SlashPicker selection marker) so the user sees which entry the next `c` will target.

The `c`-key path **stages** the slash command but doesn't submit it — the user reviews + presses Enter themselves. Keeps the cancel decision explicit while shaving the "find the right id-prefix" step that mouse-only users had to do.

## Implementation

- `AsyncStackPanel.can_focus = True` (was False).
- `AsyncStackPanel.move_cursor(delta)` — public nav API with wrap.
- `AsyncStackPanel.selected_agent_id()` — read cursor target.
- `AsyncStackPanel.on_key` — j/k/c/Esc dispatch with `event.stop()` so the keys don't fall through to App-level bindings (e.g., `j` would scroll the right panel).
- `AsyncStackPanel.on_focus` / `on_blur` — repaint to show/hide the `▌` caret on the selected row.
- `ReynTUIApp.action_focus_async_stack` + `Binding("f4", ...)` — empty-panel branch surfaces a transient status hint rather than focusing nothing.
- Keys tab: `f4` routed to **CONVERSATION** group + pretty-printed as `"F4"`; F1-F4 added to the pretty-print table for symmetry (F2 voice alias previously rendered as lowercase `"f2"`).

## Why this layer

- TUI-internal — only touches `widgets/async_stack_panel.py` (new keyboard handlers + cursor), `app.py` (1 binding + 1 action), `widgets/right_panel/keys_tab.py` (routing + pretty-print). No engine state, no new slash, no new outbox kind.
- Delegates cancel to existing `/cancel <id>` slash contract — the c-key just prefills, doesn't dispatch. No new engine API needed.
- F4 chosen over Ctrl+letter because all useful Ctrl+letters collide with TextArea editing defaults (ctrl+e end-of-line, ctrl+a start-of-line, ctrl+k kill, ctrl+m enter).

## Test plan

- [x] `pytest tests/cli/test_async_stack_keyboard.py` — 9/9 pass (focusable, move_cursor wrap, empty no-op, F4 focuses non-empty, F4 empty shows hint, c prefills, Esc returns to input, binding registered, Keys tab routing)
- [x] `pytest tests/cli/test_async_stack_panel_wired.py tests/cli/test_async_stack_panel_plan_lifecycle.py` — existing panel wiring regression unaffected
- [x] `pytest tests/cli/` — 581/581 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, kick off 2-3 plans (or skills), press F4 — panel highlighted, caret on first entry. j/k navigates. `c` stages `/cancel <selected-id>` in the InputBar with focus there for the user to Enter. Esc returns without staging.
- [x] (skipped — empty-panel hint case is a Tier 2 path; not reproduced live)

## Out of scope (deferred)

- Direct cancel via keypress (= bypass the slash and dispatch the cancel directly). Would need a per-task cancel API; the staged `/cancel <id>` path is sufficient.
- Mouse click on a panel row → focus + select (= mouse-keyboard symmetry). Panel rows are part of one Static today; clickable individual rows would need refactoring to per-row widgets. Defer.
- Selection persistence across focus cycles. Currently `on_focus` resets cursor to 0 for predictable entry; could remember the last cursor if requested.
