### PR TITLE
feat(tui): extend SlashCommand.usage opt-in to remaining key commands

### DIFF
--- a/src/reyn/chat/slash/agent.py
+++ b/src/reyn/chat/slash/agent.py
@@ -29,7 +29,11 @@ _NO_REGISTRY = (
 )
 
 
-@slash("agent", summary="Create new agent (subcommands: new <name>)")
+@slash(
+    "agent",
+    summary="Create new agent",
+    usage="/agent new <name>",
+)
 async def agent_cmd(session: "ChatSession", args: str) -> None:
     """Dispatch ``/agent <sub>`` subcommands."""
     parts = args.strip().split(maxsplit=1)

--- a/src/reyn/chat/slash/budget.py
+++ b/src/reyn/chat/slash/budget.py
@@ -29,7 +29,11 @@ async def cost_cmd(session: "ChatSession", args: str) -> None:
     await reply(session, line)
 
 
-@slash("budget", summary="Full budget breakdown; /budget reset to clear counters")
+@slash(
+    "budget",
+    summary="Full budget breakdown",
+    usage="/budget [reset]",
+)
 async def budget_cmd(session: "ChatSession", args: str) -> None:
     """``/budget`` (full breakdown) or ``/budget reset`` (clear counters).
 

--- a/src/reyn/chat/slash/chat.py
+++ b/src/reyn/chat/slash/chat.py
@@ -52,7 +52,11 @@ async def list_cmd(session: "ChatSession", args: str) -> None:
     await reply(session, "\n".join(lines))
 
 
-@slash("cancel", summary="Cancel a running skill: /cancel <id-prefix>")
+@slash(
+    "cancel",
+    summary="Cancel a running skill",
+    usage="/cancel <id-prefix>",
+)
 async def cancel_cmd(session: "ChatSession", args: str) -> None:
     """``/cancel <id-prefix>`` — cancel a running skill task."""
     prefix = args.strip()
@@ -86,7 +90,8 @@ async def cancel_cmd(session: "ChatSession", args: str) -> None:
 
 @slash(
     "answer",
-    summary="Answer a pending intervention: /answer <id-prefix> <text>",
+    summary="Answer a pending intervention",
+    usage="/answer <id-prefix> <text>",
 )
 async def answer_cmd(session: "ChatSession", args: str) -> None:
     """``/answer <id-prefix> <text>`` — deliver answer to a non-head

--- a/src/reyn/chat/slash/docs_filter.py
+++ b/src/reyn/chat/slash/docs_filter.py
@@ -14,7 +14,11 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.chat.slash import slash
 
 
-@slash("docs-filter", summary="Filter the docs tab by substring (empty = clear)")
+@slash(
+    "docs-filter",
+    summary="Filter the docs tab by substring (empty = clear)",
+    usage="/docs-filter [<substring>]",
+)
 async def docs_filter_cmd(session: "object", args: str) -> None:
     await session._put_outbox(OutboxMessage(
         kind="__docs_filter__",

--- a/src/reyn/chat/slash/image.py
+++ b/src/reyn/chat/slash/image.py
@@ -51,6 +51,7 @@ def _file_size_human(n: int) -> str:
 @slash(
     "image",
     summary="Attach an image to the next user message (multimodal input).",
+    usage="/image <path>",
     aliases=("img",),
 )
 async def image_cmd(session: object, args: str) -> None:

--- a/src/reyn/chat/slash/memory.py
+++ b/src/reyn/chat/slash/memory.py
@@ -50,7 +50,8 @@ def _memory_completer(
 
 @slash(
     "memory",
-    summary="Inspect project memory entries (list / view <name>)",
+    summary="Inspect project memory entries",
+    usage="/memory [list|view <name>]",
     completer=_memory_completer,
 )
 async def memory_cmd(session: "ChatSession", args: str) -> None:

--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -89,7 +89,8 @@ def _step_ids_for_plan(
 
 @slash(
     "plan",
-    summary="Manage active plan-mode runs (list / discard / resume)",
+    summary="Manage active plan-mode runs",
+    usage="/plan [list|discard <id>|resume <id>]",
     completer=_plan_completer,
 )
 async def plan_cmd(session: "ChatSession", args: str) -> None:

--- a/src/reyn/chat/slash/reset.py
+++ b/src/reyn/chat/slash/reset.py
@@ -26,6 +26,7 @@ from reyn.chat.slash import reply, reply_error, slash
 @slash(
     "reset",
     summary="Reset in-flight skill state (snapshots + WAL; audit logs preserved)",
+    usage="/reset confirm",
 )
 async def reset_cmd(session: "object", args: str) -> None:
     token = args.strip().lower()

--- a/src/reyn/chat/slash/skill.py
+++ b/src/reyn/chat/slash/skill.py
@@ -33,7 +33,11 @@ _USAGE = (
 )
 
 
-@slash("skill", summary="Manage active skill runs (list / discard)")
+@slash(
+    "skill",
+    summary="Manage active skill runs",
+    usage="/skill [list|discard <id>]",
+)
 async def skill_cmd(session: "ChatSession", args: str) -> None:
     """Dispatch to sub-command based on the first argument."""
     parts = args.strip().split(maxsplit=1)

--- a/tests/test_slash_memory.py
+++ b/tests/test_slash_memory.py
@@ -25,8 +25,10 @@ async def test_memory_slash_is_registered():
     """Tier 2: ``/memory`` is in the slash registry, summary matches contract."""
     cmd = REGISTRY.get("memory")
     assert cmd is not None
-    assert "list" in cmd.summary.lower()
-    assert "view" in cmd.summary.lower()
+    # Subcommand names landed in ``cmd.usage`` after PR #552 +
+    # follow-on usage extension; summary is prose only now.
+    assert "list" in cmd.usage.lower()
+    assert "view" in cmd.usage.lower()
     assert cmd.completer is not None
 
 

--- a/tests/test_slash_usage_extension.py
+++ b/tests/test_slash_usage_extension.py
@@ -1,0 +1,147 @@
+"""Tier 2: structured ``usage`` opt-in extended to remaining key commands.
+
+Follow-on to PR #552 (= added ``usage`` field + opt-in for /find,
+/save, /copy, /attach) and PR #554 (= /help <cmd> focus mode
+displaying the usage field). This PR completes the opt-in for
+the rest of the high-traffic commands so the picker hint mode
+and the /help <cmd> focus panel both surface structured usage
+rows for them.
+
+Pinned:
+  - /cancel, /answer, /plan, /memory, /docs-filter, /skill,
+    /agent, /image, /reset, /budget all have non-empty
+    ``usage`` set
+  - usage strings follow the convention <arg> required,
+    [arg] optional, [a|b] choice
+  - colon-form usage in old summaries (= "Cancel a running
+    skill: /cancel <id-prefix>") was stripped — usage now
+    lives in its own field, summary is prose only. Regression
+    guard against revert.
+
+Hidden commands (matrix / donut / zen) and no-arg commands
+(/list / /tasks / /skills / /cost / /pending / /expand /
+/quit / /exit / /cost-inline) intentionally do NOT get a
+usage line — they have no args to document. Pinned by spot
+checks to make sure no accidental opt-in slipped through.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# Commands that should have ``usage`` set after this PR.
+_EXPECTED_USAGE: dict[str, str] = {
+    "cancel":      "/cancel <id-prefix>",
+    "answer":      "/answer <id-prefix> <text>",
+    "plan":        "/plan [list|discard <id>|resume <id>]",
+    "memory":      "/memory [list|view <name>]",
+    "docs-filter": "/docs-filter [<substring>]",
+    "skill":       "/skill [list|discard <id>]",
+    "agent":       "/agent new <name>",
+    "image":       "/image <path>",
+    "reset":       "/reset confirm",
+    "budget":      "/budget [reset]",
+}
+
+
+def test_all_key_commands_have_usage_set() -> None:
+    """Tier 2: every targeted key command has its expected usage string."""
+    from reyn.chat.slash import REGISTRY
+
+    for name, expected_usage in _EXPECTED_USAGE.items():
+        cmd = REGISTRY.get(name)
+        assert cmd is not None, f"/{name} not in registry"
+        assert cmd.usage == expected_usage, (
+            f"/{name} usage mismatch: expected {expected_usage!r}, "
+            f"got {cmd.usage!r}"
+        )
+
+
+def test_summary_does_not_re_embed_usage_in_parens() -> None:
+    """Tier 2: cleaned-up summaries no longer carry the embedded usage paren.
+
+    Pre-#552 summaries crammed usage into ``... (/find <query>)``
+    or ``... : /find <query>``. The cleanup moves usage to its
+    own field; this pins that the summary doesn't re-introduce
+    a parenthetical or colon-form copy of the usage string for
+    the cleaned commands (= regression guard against revert).
+    """
+    from reyn.chat.slash import REGISTRY
+
+    # Each entry: (cmd_name, must_not_appear_in_summary).
+    # We only check commands whose old summary explicitly carried
+    # the usage in parens or after a colon.
+    cleaned: list[tuple[str, list[str]]] = [
+        ("cancel",  ["/cancel <id-prefix>", ": /cancel"]),
+        ("answer",  ["/answer <id-prefix>", ": /answer"]),
+        ("plan",    ["(list / discard / resume)"]),
+        ("memory",  ["(list / view <name>)"]),
+        ("skill",   ["(list / discard)"]),
+        ("agent",   ["(subcommands: new <name>)"]),
+        ("budget",  ["/budget reset to clear"]),
+    ]
+    for name, forbidden in cleaned:
+        cmd = REGISTRY.get(name)
+        assert cmd is not None, f"/{name} not in registry"
+        for needle in forbidden:
+            assert needle not in cmd.summary, (
+                f"/{name} summary still contains stripped usage fragment "
+                f"{needle!r}: {cmd.summary!r}"
+            )
+
+
+def test_no_arg_commands_have_no_usage() -> None:
+    """Tier 2: commands with no meaningful args don't get a fake usage row.
+
+    Surfacing ``↳ usage: /list`` for a zero-arg command would be
+    pure noise. Pin that these stay 1-line in the picker hint.
+    """
+    from reyn.chat.slash import REGISTRY
+
+    no_arg_commands = [
+        "list", "tasks", "skills", "cost", "pending", "expand",
+        "quit", "exit", "cost-inline",
+    ]
+    for name in no_arg_commands:
+        cmd = REGISTRY.get(name)
+        assert cmd is not None, f"/{name} not in registry"
+        assert cmd.usage == "", (
+            f"/{name} should not have usage; got {cmd.usage!r}"
+        )
+
+
+def test_hidden_commands_have_no_usage() -> None:
+    """Tier 2: hidden easter-egg commands don't surface usage either."""
+    from reyn.chat.slash import REGISTRY
+
+    for name in ("matrix", "donut", "zen"):
+        cmd = REGISTRY.get(name)
+        assert cmd is not None
+        assert cmd.hidden is True
+        assert cmd.usage == ""
+
+
+def test_help_focus_panel_renders_usage_for_extended_commands() -> None:
+    """Tier 2: /help <cmd> focus panel surfaces the new usage rows.
+
+    Reuses the focus-mode helper introduced in PR #554; this test
+    pins the integration with the freshly-extended commands.
+    """
+    from reyn.chat.slash.help import _render_command_focus
+
+    # /plan is a representative subcommand-style command — pin it
+    # to keep the test from rusting if the exact usage syntax
+    # gets tweaked. We only assert the usage *substring* appears,
+    # not the full string, so trivial wording shifts don't break.
+    panel = _render_command_focus("plan")
+    assert "/plan" in panel
+    assert "usage:" in panel
+    assert "discard" in panel or "resume" in panel or "list" in panel
+
+    panel = _render_command_focus("cancel")
+    assert "/cancel <id-prefix>" in panel


### PR DESCRIPTION
**[tui-coder]** — Mechanical follow-on to #552 (added `usage` field + 4 opt-ins) and #554 (`/help <cmd>` focus mode). Completes the structured `usage` opt-in for the rest of the high-traffic commands so both the picker hint mode and `/help <cmd>` focus panel surface usage rows uniformly.

## Opt-in coverage

| cmd | new usage |
|------|------|
| `/cancel`      | `/cancel <id-prefix>` |
| `/answer`      | `/answer <id-prefix> <text>` |
| `/plan`        | `/plan [list\|discard <id>\|resume <id>]` |
| `/memory`      | `/memory [list\|view <name>]` |
| `/docs-filter` | `/docs-filter [<substring>]` |
| `/skill`       | `/skill [list\|discard <id>]` |
| `/agent`       | `/agent new <name>` |
| `/image`       | `/image <path>` |
| `/reset`       | `/reset confirm` |
| `/budget`      | `/budget [reset]` |

## Summary cleanups

Colon-form / paren-form usage in old summaries was stripped (e.g. `"Cancel a running skill: /cancel <id-prefix>"` → `"Cancel a running skill"` + `usage="/cancel <id-prefix>"`). The focus-panel + picker-hint now show both lines structured instead of one long crammed summary.

## Intentionally NOT opted in

- **No-arg commands**: `/list`, `/tasks`, `/skills`, `/cost`, `/pending`, `/expand`, `/quit`, `/exit`, `/cost-inline` — surfacing `↳ usage: /list` with no args is pure noise.
- **Hidden easter-eggs**: `/matrix`, `/donut`, `/zen` — stay 1-line, no discovery surface needed.

Both groups pinned by Tier 2 tests so a future drive-by edit can't accidentally add usage to them.

## Why this layer

- Pure registry-level metadata extension. No behavioral change — only what the picker hint / `/help <cmd>` rendering pulls.
- Adapts one existing test (`tests/test_slash_memory.py`) to read `list`/`view` from `cmd.usage` instead of `cmd.summary` — the contract for those subcommands moved fields.

## Test plan

- [x] `pytest tests/test_slash_usage_extension.py` — 5/5 pass (every targeted command, summary cleanups regression guard, no-arg commands empty, hidden empty, /help focus integration)
- [x] `pytest tests/cli/ tests/test_slash_*.py` — 617/617 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, type `/plan ` — picker hint should show 2 lines (summary + `↳ usage: /plan [list|discard <id>|resume <id>]`). Type `/help cancel` — focus panel surfaces the structured usage row.
- [x] (skipped — visual rendering for every opt-in command not reproduced live; the 10 commands are pinned by their usage strings in Tier 2)

## Out of scope (deferred)

- Examples (= 3rd row per command in the picker / `/help` focus). Would need a new `examples` field. Defer until requested.
- Auto-derivation of usage from docstrings. Mechanical opt-in via `@slash(... usage=...)` is one-line per command — cheaper than a parser.
