### PR TITLE
feat(tui): /find regex + case-sensitive opt-in flags

### DIFF
--- a/src/reyn/chat/slash/find.py
+++ b/src/reyn/chat/slash/find.py
@@ -1,20 +1,20 @@
-"""/find — search the conv pane buffer for a substring, with history recall.
+"""/find — search the conv pane buffer for a substring or regex, with history recall.
 
 Categorical UX gap fill (= "I said something about X earlier, where
-is it?"). Searches the current RichLog buffer for case-insensitive
-substring matches and jumps to the first one near the current
-scroll position. The "search what's visible in scrollback" scope
-is the natural TUI-internal boundary — agent-reply history past
-the ring-buffer trim lives in ``.reyn/events/agents/<name>/`` and
-is reachable via the right-panel Events tab + ``/list`` slash;
-this command surfaces just the in-pane content.
+is it?"). Searches the current RichLog buffer and jumps to the
+first match near the current scroll position. Default is
+case-insensitive substring; flags opt into regex / case-sensitive
+modes. The "search what's visible in scrollback" scope is the
+natural TUI-internal boundary — agent-reply history past the
+ring-buffer trim lives in ``.reyn/events/agents/<name>/`` and is
+reachable via the right-panel Events tab + ``/list`` slash; this
+command surfaces just the in-pane content.
 
 Pattern: same shape as ``/copy`` — the slash command emits a
-sentinel ``__find__`` OutboxMessage with the raw query in
-``text``; the TUI app intercepts via ``_on_find`` in app_outbox,
-runs ``ConversationView.find_in_buffer`` against the live
-RichLog, scrolls to the nearest match, and writes a status line
-with the match count.
+sentinel ``__find__`` OutboxMessage with the raw arg in ``text``;
+the TUI app intercepts via ``_on_find`` in app_outbox, parses
+leading flags off the front, runs ``find_in_buffer`` with the
+chosen mode, scrolls to the nearest match, and writes a status.
 
 History recall: every non-empty ``/find <q>`` invocation appends
 ``q`` to a module-level LRU deque (capped at
@@ -27,10 +27,16 @@ naturally gone on session restart.
 
 Usage::
 
-    /find tokens     # find lines containing "tokens" (case-insensitive)
-    /find foo bar    # multi-word query (literal substring, not regex)
-    /find <space>    # picker shows last 5 queries to recall via Tab
-    /find            # empty query → status reports usage
+    /find tokens         # case-insensitive substring (default)
+    /find -c Foo         # case-sensitive substring
+    /find -r f.*o        # case-insensitive regex
+    /find -rc Foo.*      # case-sensitive regex (combined flag)
+    /find -cr Foo.*      # same as -rc (flag order doesn't matter)
+    /find -hyphen-term   # leading hyphen + unrecognised letters →
+                          treated as the literal query (= the user
+                          is searching for ``-hyphen-term``)
+    /find <space>        # picker shows last 5 queries to recall via Tab
+    /find                # empty query → usage hint
 """
 from __future__ import annotations
 
@@ -105,8 +111,8 @@ def _find_completer(session: "object", arg_partial: str = "") -> list[str]:
 
 @slash(
     "find",
-    summary="Search the conv pane for a substring",
-    usage="/find <query>",
+    summary="Search the conv pane (substring or regex)",
+    usage="/find [-r|-c|-rc] <query>",
     completer=_find_completer,
 )
 async def find_cmd(session: "object", args: str) -> None:

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -161,6 +161,44 @@ def _find_preview_snippet(text: str) -> str:
     return compact[: max(1, _FIND_PREVIEW_MAX_CHARS - 1)] + "…"
 
 
+def _parse_find_flags(raw: str) -> tuple[bool, bool, str]:
+    """Split ``/find`` arg into ``(regex, case_sensitive, query)``.
+
+    Accepts a single leading short-flag token of the shape ``-X``
+    where X is any combination of ``r`` (regex) and ``c`` (case-
+    sensitive). Order within the token doesn't matter (``-rc`` =
+    ``-cr``). Anything that doesn't look like a flag token is
+    treated as the start of the query (= ``/find -foo`` searches
+    for ``"-foo"`` literally, because ``-foo`` isn't a known flag
+    combo). The query keeps its full text including spaces; the
+    flag token is only consumed when it sits at the head.
+
+    Examples::
+
+        _parse_find_flags("foo")          → (False, False, "foo")
+        _parse_find_flags("-c Foo")       → (False, True,  "Foo")
+        _parse_find_flags("-r f.*o")      → (True,  False, "f.*o")
+        _parse_find_flags("-rc Foo.*")    → (True,  True,  "Foo.*")
+        _parse_find_flags("-cr Foo.*")    → (True,  True,  "Foo.*")
+        _parse_find_flags("-foo bar")     → (False, False, "-foo bar")
+        _parse_find_flags("")             → (False, False, "")
+    """
+    s = (raw or "").strip()
+    if not s.startswith("-"):
+        return False, False, s
+    # Peel the leading flag token off the front. ``split(maxsplit=1)``
+    # gives [flag_token, rest_of_query] or just [flag_token] if no
+    # trailing query.
+    head, _, tail = s.partition(" ")
+    body = head[1:]  # strip the leading "-"
+    if not body or any(c not in ("r", "c") for c in body):
+        # Not a recognised flag combo — treat the whole thing as
+        # the query (= the user is searching for a hyphen-prefixed
+        # term like ``-h`` or ``-flag``).
+        return False, False, s
+    return ("r" in body), ("c" in body), tail.strip()
+
+
 class OutboxRouter:
     """Drain + dispatch loop for the registry's outbox queue."""
 
@@ -186,6 +224,14 @@ class OutboxRouter:
         # usage hint rather than silently no-op'ing.
         self._find_query: str | None = None
         self._find_cursor_idx: int | None = None
+        # Search flags applied to the active cycle (set in ``_on_find``,
+        # read in ``cycle_find``). Default both False = case-insensitive
+        # substring (= the original /find behaviour, unchanged for plain
+        # ``/find <text>`` invocations). The flags survive Ctrl+G /
+        # Ctrl+Shift+G so the same search mode is re-applied as the
+        # buffer mutates between presses.
+        self._find_regex: bool = False
+        self._find_case_sensitive: bool = False
         # Dispatch table — each entry maps a `msg.kind` to its handler.
         # Methods on `self` are bound, so we can reference them directly.
         self.HANDLERS: dict[str, Callable[..., str | None]] = {
@@ -589,35 +635,55 @@ class OutboxRouter:
     def _on_find(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
     ) -> None:
-        """`__find__` — /find slash; substring search across the RichLog buffer.
+        """`__find__` — /find slash; substring / regex search of the conv buffer.
 
-        ``msg.text`` carries the raw query. Behaviour:
-          - empty query → status with usage hint
-          - 0 matches  → status ``"no matches for '<q>'"`` (= clear "I
-            searched but found nothing")
-          - ≥ 1 match  → scroll the log to the match nearest BELOW
-            the current scroll position (= "go down to where the
-            result is"; wraps to the first match when no downward
-            match exists) AND write a status line with the total
-            count + up to 5 line numbers, AND seed the cycle state
-            so Ctrl+G / Ctrl+Shift+G can step forward/backward
-            through the remaining matches.
+        ``msg.text`` carries the raw arg string. Leading short flags
+        are parsed off the front (= ``-r``, ``-c``, or combined
+        ``-rc``); everything after is the query.
 
-        Search target: the live RichLog buffer (= what's currently
-        scrollable). History past the ``_RICHLOG_MAX_LINES`` trim is
-        outside scope — the right-panel Events tab + ``/list``
-        slash cover that. ``ConversationView.find_in_buffer``
-        encapsulates the substring scan + case-insensitive match.
+          /find foo            → case-insensitive substring (default)
+          /find -c Foo         → case-sensitive substring
+          /find -r f.*o        → case-insensitive regex
+          /find -rc Foo.*      → case-sensitive regex (combined flag)
+
+        Behaviour:
+          - empty query → usage hint
+          - invalid regex → error status with the ``re.error`` message
+          - 0 matches  → ``"no matches for '<q>'"``
+          - ≥ 1 match  → scroll to nearest below-cursor + seed cycle
+            state with the same flags so Ctrl+G / Ctrl+Shift+G keep
+            applying them as the buffer mutates between presses.
+
+        Search target: the live RichLog buffer. History past the
+        ``_RICHLOG_MAX_LINES`` trim is outside scope — the right-
+        panel Events tab + ``/list`` slash cover that.
         """
-        query = (msg.text or "").strip()
+        regex, case_sensitive, query = _parse_find_flags(msg.text or "")
         if not query:
             self._show_transient_status(
                 conv,
-                "usage: /find <query>",
+                "usage: /find [-r|-c|-rc] <query>",
                 kind="error",
             )
             return
-        matches = conv.find_in_buffer(query)
+        try:
+            matches = conv.find_in_buffer(
+                query, regex=regex, case_sensitive=case_sensitive,
+            )
+        except Exception as exc:
+            # Invalid regex (= ``re.error``) lands here. Catching all
+            # Exceptions defensively so a future syntax issue in
+            # find_in_buffer can't crash the outbox loop; the message
+            # naming preserves the underlying ``re.error`` text for
+            # actionability.
+            self._find_query = None
+            self._find_cursor_idx = None
+            self._show_transient_status(
+                conv,
+                f"/find: invalid pattern: {exc}",
+                kind="error",
+            )
+            return
         if not matches:
             # Forget any stale cycle state so a follow-up Ctrl+G
             # reports the no-match condition for THIS query, not a
@@ -653,6 +719,8 @@ class OutboxRouter:
         # Seed cycle state so Ctrl+G picks up from here.
         self._find_query = query
         self._find_cursor_idx = target_idx
+        self._find_regex = regex
+        self._find_case_sensitive = case_sensitive
         # Set the header find-state badge so the user has a persistent
         # cue that /find mode is active. Position = 1-based index of
         # the cursor's match in the sorted match list.
@@ -741,7 +809,26 @@ class OutboxRouter:
             conv = self._app.query_one("#conversation", ConversationView)
         except Exception:
             return
-        matches = conv.find_in_buffer(query)
+        try:
+            matches = conv.find_in_buffer(
+                query,
+                regex=self._find_regex,
+                case_sensitive=self._find_case_sensitive,
+            )
+        except Exception as exc:
+            # Defensive: re-search shouldn't normally fail mid-cycle
+            # since the same pattern compiled at /find time, but a
+            # buffer mutation could theoretically expose a corner
+            # case. Surface + clear state so the user can recover
+            # with a fresh /find.
+            self._find_query = None
+            self._find_cursor_idx = None
+            self._show_transient_status(
+                conv,
+                f"/find: pattern failed: {exc}",
+                kind="error",
+            )
+            return
         if not matches:
             self._find_query = None
             self._find_cursor_idx = None

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -960,33 +960,65 @@ class ConversationView(Widget):
         """Number of agent replies currently held in the /copy ring buffer."""
         return len(self._recent_replies)
 
-    def find_in_buffer(self, query: str) -> list[tuple[int, str]]:
+    def find_in_buffer(
+        self,
+        query: str,
+        *,
+        regex: bool = False,
+        case_sensitive: bool = False,
+    ) -> list[tuple[int, str]]:
         """Return ``(line_idx, line_text)`` for every RichLog line matching ``query``.
 
-        Case-insensitive substring search across the live RichLog
-        buffer (= what's currently scrollable). Lines past the
-        ``_RICHLOG_MAX_LINES`` ring-buffer trim are NOT searched —
-        for older history the user has the right-panel Events tab +
-        the agent-side ``.reyn/events/agents/<name>/`` skill-run
-        directories. Returning the line index lets the caller scroll
-        the log to the match with ``log.scroll_to(y=...)``.
+        Search modes (off → on, two independent flags):
+          - ``regex=False`` (default): substring match — fast, no
+            metacharacters interpreted
+          - ``regex=True``: compiled regex search via ``re.search``;
+            invalid patterns raise ``re.error`` so the caller can
+            surface a clear error status
+          - ``case_sensitive=False`` (default): match across cases
+            (= ``"Foo"`` query matches ``"foo bar"``)
+          - ``case_sensitive=True``: exact-case match
 
-        Empty ``query`` returns an empty list (= the caller treats
-        this as "nothing to search for", typically with a usage hint).
+        Scope: the live RichLog buffer (= what's currently
+        scrollable). Lines past the ``_RICHLOG_MAX_LINES`` ring-
+        buffer trim are NOT searched — for older history the user
+        has the right-panel Events tab + the agent-side
+        ``.reyn/events/agents/<name>/`` skill-run directories.
 
-        Each tuple's ``line_text`` carries the line's rendered plain
-        text (= via the Strip's ``.text`` property) so the caller can
-        surface a short preview alongside the line number without
-        re-walking the buffer.
+        Empty ``query`` returns an empty list (= caller treats this
+        as "nothing to search for", usually with a usage hint).
+
+        Each tuple's ``line_text`` carries the line's rendered
+        plain text (via the Strip's ``.text`` property) so callers
+        can surface a short preview alongside the line number.
         """
-        q = (query or "").strip().lower()
+        q = (query or "").strip()
         if not q:
             return []
-        out: list[tuple[int, str]] = []
         log = self._log()
+        out: list[tuple[int, str]] = []
+
+        if regex:
+            import re
+            # ``re.error`` (invalid pattern) bubbles up — callers
+            # catch it and surface a status; silent suppression
+            # would leave the user wondering why ``/find -r foo(``
+            # silently matched nothing.
+            flags = 0 if case_sensitive else re.IGNORECASE
+            pattern = re.compile(q, flags)
+            for idx, strip in enumerate(getattr(log, "lines", []) or []):
+                text = getattr(strip, "text", "") or ""
+                if pattern.search(text):
+                    out.append((idx, text))
+            return out
+
+        # Substring path — same lookup whether case-sensitive or
+        # not; only the comparison case differs.
+        needle = q if case_sensitive else q.lower()
         for idx, strip in enumerate(getattr(log, "lines", []) or []):
             text = getattr(strip, "text", "") or ""
-            if q in text.lower():
+            haystack = text if case_sensitive else text.lower()
+            if needle in haystack:
                 out.append((idx, text))
         return out
 

--- a/tests/cli/test_find_regex_case_opt_in.py
+++ b/tests/cli/test_find_regex_case_opt_in.py
@@ -1,0 +1,314 @@
+"""Tier 2: /find regex + case-sensitive opt-in flags.
+
+Follow-on to PR #537 (/find MVP) + #539 (Ctrl+G cycle) + #542
+(discoverability) + #552 (usage field). The MVP was hard-wired
+to case-insensitive substring; this PR adds opt-in flags for
+power users:
+
+  /find foo            → case-insensitive substring (default; unchanged)
+  /find -c Foo         → case-sensitive substring
+  /find -r f.*o        → case-insensitive regex
+  /find -rc Foo.*      → case-sensitive regex (combined flag)
+
+Pinned:
+  - ``ConversationView.find_in_buffer`` accepts ``regex`` and
+    ``case_sensitive`` kwargs; default = both False (= MVP path)
+  - Invalid regex raises ``re.error`` so the caller can surface
+    a clear status
+  - Flag parser splits ``"-rc Foo.*"`` into (regex=True, case=True,
+    query="Foo.*") with order-independence (``-cr`` = ``-rc``)
+  - Unrecognised flag combos fall through as literal query
+    (= ``/find -hyphen-term`` searches for ``-hyphen-term``)
+  - Cycle state remembers the flags so Ctrl+G keeps applying the
+    same mode as the buffer mutates between presses
+  - Invalid regex in /find → error status, no crash
+  - /find summary + usage updated for the new flag set
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from rich.text import Text
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _seed(conv, lines: list[str]) -> None:
+    log = conv._log()
+    for line in lines:
+        log.write(Text(line))
+
+
+# ── _parse_find_flags ────────────────────────────────────────────────────────
+
+
+def test_parse_no_flag_is_default_path() -> None:
+    """Tier 2: bare query → both flags False, full arg preserved."""
+    from reyn.chat.tui.app_outbox import _parse_find_flags
+
+    assert _parse_find_flags("foo") == (False, False, "foo")
+    assert _parse_find_flags("foo bar baz") == (False, False, "foo bar baz")
+    assert _parse_find_flags("") == (False, False, "")
+
+
+def test_parse_recognises_individual_flags() -> None:
+    """Tier 2: ``-c`` / ``-r`` parsed cleanly."""
+    from reyn.chat.tui.app_outbox import _parse_find_flags
+
+    assert _parse_find_flags("-c Foo") == (False, True, "Foo")
+    assert _parse_find_flags("-r f.*o") == (True, False, "f.*o")
+
+
+def test_parse_combined_flag_order_independent() -> None:
+    """Tier 2: ``-rc`` and ``-cr`` mean the same."""
+    from reyn.chat.tui.app_outbox import _parse_find_flags
+
+    assert _parse_find_flags("-rc Foo.*") == (True, True, "Foo.*")
+    assert _parse_find_flags("-cr Foo.*") == (True, True, "Foo.*")
+
+
+def test_parse_unrecognised_flag_treated_as_query() -> None:
+    """Tier 2: ``-foo`` is not a flag, falls through as a literal query.
+
+    The user might be searching for a hyphen-prefixed term in
+    their conv (e.g., ``-h`` or ``--force``). Without this fall-
+    through they'd have no way to /find it.
+    """
+    from reyn.chat.tui.app_outbox import _parse_find_flags
+
+    assert _parse_find_flags("-foo bar") == (False, False, "-foo bar")
+    assert _parse_find_flags("-x") == (False, False, "-x")
+
+
+def test_parse_flag_only_no_query_returns_empty_query() -> None:
+    """Tier 2: ``-r`` alone (no query) → flag set, empty query.
+
+    The caller surfaces a usage hint when query is empty, so the
+    parser just splits cleanly without inventing content.
+    """
+    from reyn.chat.tui.app_outbox import _parse_find_flags
+
+    assert _parse_find_flags("-r") == (True, False, "")
+    assert _parse_find_flags("-c") == (False, True, "")
+
+
+# ── find_in_buffer flag-aware ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_in_buffer_case_sensitive_excludes_lowercase_variants() -> None:
+    """Tier 2: case-sensitive substring matches case exactly."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        _seed(conv, ["Foo line", "foo line", "FOO line"])
+        await pilot.pause()
+        matches = conv.find_in_buffer("Foo", case_sensitive=True)
+        texts = [m[1] for m in matches]
+        assert "Foo line" in texts
+        assert "foo line" not in texts
+        assert "FOO line" not in texts
+
+
+@pytest.mark.asyncio
+async def test_find_in_buffer_regex_pattern_matches() -> None:
+    """Tier 2: regex search picks up pattern-matching lines."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        _seed(conv, ["foo123", "fox456", "bar789", "fooXXX"])
+        await pilot.pause()
+        # Pattern: 'fo' then any chars then 'X'.
+        matches = conv.find_in_buffer(r"fo.*X", regex=True)
+        texts = [m[1] for m in matches]
+        assert "fooXXX" in texts
+        # Plain substring "fo.*X" doesn't appear literally → only
+        # regex-mode matches return anything.
+        assert "foo123" not in texts
+
+
+@pytest.mark.asyncio
+async def test_find_in_buffer_regex_case_sensitive() -> None:
+    """Tier 2: regex + case-sensitive only matches exact case patterns."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        _seed(conv, ["Foo1", "foo1", "Foo2"])
+        await pilot.pause()
+        matches = conv.find_in_buffer(
+            r"Foo\d", regex=True, case_sensitive=True,
+        )
+        texts = [m[1] for m in matches]
+        assert "Foo1" in texts
+        assert "Foo2" in texts
+        assert "foo1" not in texts
+
+
+@pytest.mark.asyncio
+async def test_find_in_buffer_invalid_regex_raises() -> None:
+    """Tier 2: invalid regex bubbles up so the caller can surface it."""
+    import re
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        with pytest.raises(re.error):
+            conv.find_in_buffer("foo(", regex=True)
+
+
+# ── _on_find dispatch end-to-end ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_find_with_flags_seeds_router_state() -> None:
+    """Tier 2: /find -r preserves the regex flag in router cycle state."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed(conv, ["abc", "abx", "xyz"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="-r ab."),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert router._find_query == "ab."
+        assert router._find_regex is True
+        assert router._find_case_sensitive is False
+        assert router._find_cursor_idx is not None
+
+
+@pytest.mark.asyncio
+async def test_on_find_invalid_regex_emits_error_status() -> None:
+    """Tier 2: malformed regex surfaces an error status, clears cycle state."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        _seed(conv, ["sample"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="-r foo("),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "invalid pattern" in snap["body"]
+        # No stale cycle state.
+        assert router._find_query is None
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_preserves_flags() -> None:
+    """Tier 2: Ctrl+G re-search uses the same flags as the initial /find."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        # Mixed-case content. Case-sensitive search should walk
+        # only the Capitalised entries.
+        _seed(conv, ["Foo1", "foo2", "Foo3", "fox4"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="-c Foo"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        # Cycle forward — should walk only the Foo1/Foo3 case-
+        # sensitive matches (skipping foo2).
+        prev_cursor = router._find_cursor_idx
+        router.cycle_find(+1)
+        await pilot.pause()
+        # The cursor moved AND case_sensitive flag survived.
+        assert router._find_case_sensitive is True
+        new_cursor = router._find_cursor_idx
+        # New target is the OTHER Foo line, not the foo2 lower-case line.
+        assert new_cursor != prev_cursor
+        # Sanity: foo2 is at idx between Foo1 and Foo3; verify cursor
+        # avoided it by inspecting the match list directly.
+        matches = conv.find_in_buffer("Foo", case_sensitive=True)
+        match_idxs = [m[0] for m in matches]
+        assert new_cursor in match_idxs
+
+
+@pytest.mark.asyncio
+async def test_flag_only_no_query_shows_usage_hint() -> None:
+    """Tier 2: ``/find -r`` with no query falls through to the usage hint."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header")
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="-r"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "usage:" in snap["body"]
+
+
+def test_find_slash_summary_and_usage_updated() -> None:
+    """Tier 2: /find's structured usage field reflects the new flag set."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("find")
+    assert cmd is not None
+    assert cmd.usage == "/find [-r|-c|-rc] <query>"
+    # Summary mentions both modes.
+    assert "substring" in cmd.summary.lower()
+    assert "regex" in cmd.summary.lower()

--- a/tests/cli/test_slash_picker_multiline_hint.py
+++ b/tests/cli/test_slash_picker_multiline_hint.py
@@ -174,12 +174,18 @@ async def test_usage_and_completions_render_together() -> None:
 
 
 def test_find_command_has_usage() -> None:
-    """Tier 2: /find opts into the structured usage line."""
+    """Tier 2: /find opts into the structured usage line.
+
+    Usage syntax expanded in the regex/case opt-in PR
+    (``[-r|-c|-rc]`` flag block). The substring ``<query>`` stays
+    so the contract "usage names the query placeholder" survives.
+    """
     from reyn.chat.slash import REGISTRY
 
     cmd = REGISTRY.get("find")
     assert cmd is not None
-    assert cmd.usage == "/find <query>"
+    assert "<query>" in cmd.usage
+    assert "/find" in cmd.usage
 
 
 def test_save_command_has_usage() -> None:
@@ -212,14 +218,17 @@ def test_attach_command_has_usage() -> None:
 def test_find_summary_no_longer_carries_redundant_paren_usage() -> None:
     """Tier 2: /find summary stripped of the embedded ``(/find <query>)``.
 
-    After moving usage to its own field, the summary should be
-    the prose description only — no embedded usage paren. Pin
-    this so a future revert can't accidentally re-introduce the
-    redundancy.
+    After moving usage to its own field, the summary no longer
+    embeds the ``/find`` usage syntax in parens. The regex/case
+    opt-in PR added ``(substring or regex)`` to the summary
+    which is mode disambiguation, NOT a usage hint, so it stays.
+    Pin only that the embedded ``(/find ...)`` form doesn't return.
     """
     from reyn.chat.slash import REGISTRY
 
     cmd = REGISTRY.get("find")
     assert cmd is not None
+    # Embedded ``(/find ...)`` paren-form usage must not return.
     assert "(/find" not in cmd.summary
-    assert cmd.summary == "Search the conv pane for a substring"
+    # Summary still describes the conv pane scope.
+    assert "conv pane" in cmd.summary.lower()

--- a/tests/test_slash_help_per_command.py
+++ b/tests/test_slash_help_per_command.py
@@ -51,12 +51,20 @@ def test_render_focus_known_command_has_summary() -> None:
 
 def test_render_focus_known_command_with_usage_includes_usage_line() -> None:
     """Tier 2: when ``cmd.usage`` is set (= /find / /save / /copy / /attach
-    from PR #552), the focus panel surfaces it on its own row."""
+    from PR #552), the focus panel surfaces it on its own row.
+
+    The /find usage string was expanded in PR #561 (regex + case opt-in
+    flags) from ``/find <query>`` to ``/find [-r|-c|-rc] <query>``.
+    Pin only that the usage row is present and contains the placeholder,
+    not the exact flag syntax (= avoids re-pinning on every /find
+    evolution).
+    """
     from reyn.chat.slash.help import _render_command_focus
 
     panel = _render_command_focus("find")
     assert "usage:" in panel
-    assert "/find <query>" in panel
+    assert "/find" in panel
+    assert "<query>" in panel
 
 
 def test_render_focus_without_usage_omits_usage_line() -> None:


### PR DESCRIPTION
**[tui-coder]** — Power-user flexibility on the /find surface. The MVP (#537) was hard-wired to case-insensitive substring; this PR adds opt-in flags so users can pull regex matching and exact-case matching when needed, while keeping the default behaviour unchanged.

## Summary

```
/find foo            → case-insensitive substring (default)
/find -c Foo         → case-sensitive substring
/find -r f.*o        → case-insensitive regex
/find -rc Foo.*      → case-sensitive regex (combined flag)
/find -cr Foo.*      → same as -rc (flag order doesn't matter)
/find -hyphen-term   → unrecognised letter combo falls through
                       as literal query (= search "-hyphen-term")
```

## Implementation

- `ConversationView.find_in_buffer` gains `regex` + `case_sensitive` kwargs (both default False = MVP path unchanged).
- Regex mode uses `re.search` with `IGNORECASE` gated by the case flag; invalid patterns raise `re.error` so the caller can surface a clear error status rather than silently match nothing.
- `_parse_find_flags(raw)` (module-level in `app_outbox`) peels the leading `-X` flag token off the front; unrecognised letter combos fall through as literal query.
- `_on_find` catches `re.error` → `"/find: invalid pattern: <err>"` error-kind status, cycle state cleared.
- Router persists `_find_regex` + `_find_case_sensitive` flags so Ctrl+G / Ctrl+Shift+G cycle navigation re-applies the same mode as the buffer mutates between presses.

## UI surface updates

- `find.py` summary: `"Search the conv pane (substring or regex)"`
- `find.py` usage: `"/find [-r|-c|-rc] <query>"`
- Empty-query hint: `"usage: /find [-r|-c|-rc] <query>"`

## Why this layer

- TUI-internal: only touches `widgets/conversation.py` (kwargs on existing method), `app_outbox.py` (1 helper + flag wiring), `slash/find.py` (summary + usage). No engine state.
- Backward compatible: `/find foo` behaviour identical to before. Existing tests on the MVP path (= no flags) keep passing without changes.
- Regex compile happens per `_on_find` invocation and per `cycle_find` step. For the bounded RichLog buffer this is O(N) over a small N — negligible cost; no caching needed.

## Test plan

- [x] `pytest tests/cli/test_find_regex_case_opt_in.py` — 14/14 pass (parser unit cases, case-sensitive substring, regex pattern, regex+case combined, invalid regex raises, _on_find seeds flags, invalid regex status, cycle preserves flags, flag-only usage, slash usage updated)
- [x] `pytest tests/cli/test_conv_find_history_search.py` — 6/6 pass (= MVP regression)
- [x] `pytest tests/cli/test_find_cycle_navigation.py` — 8/8 pass (= #539 cycle regression)
- [x] `pytest tests/cli/test_find_discoverability_hint.py` — 4/4 pass (= #542 hint regression)
- [x] `pytest tests/cli/test_slash_picker_multiline_hint.py` — adapted 2 of #552's tests to substring contracts (`<query>` in usage, embedded `(/find` not in summary) instead of exact equality, so the regex-mode UI updates don't regress them
- [x] `pytest tests/cli/` — 593/593 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, accumulate a conv with mixed-case text. `/find Foo` → finds all cases. `/find -c Foo` → only `"Foo"` exact case. `/find -r f.*o` → regex matches. `/find -r foo(` → error status with invalid-pattern message. Ctrl+G after `/find -c` keeps walking case-sensitive only.
- [x] (skipped — combined `-rc` exact ordering tested via Tier 2 unit test, not reproduced live)

## Out of scope (deferred)

- Negative search (`/find -v <pattern>` to invert match). Could be useful for filter-out style searches; defer until requested.
- Whole-word match (`/find -w foo`). Currently regex with `\bfoo\b` covers this.
- Persistent flag preference across sessions. Currently flags are per-invocation; remembering "last user always wanted -c" needs prefs wiring.
