### PR TITLE
feat(stdlib/index_docs): migrate write_chunks_with_lock to safe-mode (FP-0042 Phase 2.2)

### DIFF
--- a/src/reyn/safe/__init__.py
+++ b/src/reyn/safe/__init__.py
@@ -16,6 +16,8 @@ Available modules:
 
 - :mod:`reyn.safe.hash` — `sha256` / `sha256_hex`.
 - :mod:`reyn.safe.json` — strict / canonical JSON helpers.
+- :mod:`reyn.safe.process` — process identity (`getpid`, `pid_alive`).
+  Ambient (no permission gate). New in FP-0042 Phase 2.2.
 - :mod:`reyn.safe.random` — explicit-seeded RNG.
 - :mod:`reyn.safe.schema` — JSON Schema validation.
 - :mod:`reyn.safe.text` — named-group regex + safe templating.
@@ -26,6 +28,6 @@ to work via shim re-exports from this package. New code should import from
 ``reyn.safe.*``; existing code may migrate at its own pace.
 """
 
-from . import file, hash, json, random, schema, text, time
+from . import file, hash, json, process, random, schema, text, time
 
-__all__ = ["file", "hash", "json", "random", "schema", "text", "time"]
+__all__ = ["file", "hash", "json", "process", "random", "schema", "text", "time"]

--- a/src/reyn/safe/file.py
+++ b/src/reyn/safe/file.py
@@ -16,6 +16,8 @@ High-level (drop-in replacement for ``reyn.api.unsafe.file``):
 - :func:`glob(pattern)` → list[str]
 - :func:`exists(path)` → bool
 - :func:`stat(path)` → {size, mtime, mode}
+- :func:`mkdir(path, *, parents=False, exist_ok=False)` → None
+- :func:`delete(path, *, missing_ok=False)` → None
 
 Low-level (Python-IO-compatible):
 
@@ -210,6 +212,53 @@ def stat(path: str) -> dict[str, Any]:
     _check_read(path)
     st = _os.stat(path)
     return {"size": st.st_size, "mtime": st.st_mtime, "mode": st.st_mode}
+
+
+def mkdir(
+    path: str,
+    *,
+    parents: bool = False,
+    exist_ok: bool = False,
+) -> None:
+    """Create directory ``path``.
+
+    Permission-checked as a write — ``path`` must resolve under one of
+    the declared ``write_paths``. Mirrors :meth:`pathlib.Path.mkdir`:
+
+    - ``parents=True`` creates missing intermediate directories;
+    - ``exist_ok=True`` does not raise when the directory already exists.
+
+    Raises :class:`PermissionError` when ``path`` is outside the declared
+    write zone, :class:`FileExistsError` when the directory exists and
+    ``exist_ok=False``, and :class:`FileNotFoundError` when a parent
+    directory is missing and ``parents=False``.
+    """
+    _check_write(path)
+    if parents:
+        _os.makedirs(path, exist_ok=exist_ok)
+        return
+    try:
+        _os.mkdir(path)
+    except FileExistsError:
+        if not exist_ok:
+            raise
+
+
+def delete(path: str, *, missing_ok: bool = False) -> None:
+    """Remove file ``path``.
+
+    Permission-checked as a write — the path must resolve under one of
+    the declared ``write_paths``. Mirrors :meth:`pathlib.Path.unlink`:
+    ``missing_ok=True`` swallows :class:`FileNotFoundError`. Directory
+    removal isn't part of the safe surface — explicit unsafe-mode is the
+    right gate when needed.
+    """
+    _check_write(path)
+    try:
+        _os.unlink(path)
+    except FileNotFoundError:
+        if not missing_ok:
+            raise
 
 
 # ── Low-level API (Python-IO-compatible) ────────────────────────────────────

--- a/src/reyn/safe/process.py
+++ b/src/reyn/safe/process.py
@@ -1,0 +1,68 @@
+"""Process-identity helpers for safe-mode python steps (FP-0042 Phase 2.2).
+
+Safe-mode python bans ``import os``, but a small subset of os surface is
+needed by stdlib skills — specifically PID identity for advisory locks
+(``index_docs.write_chunks_with_lock`` records its own PID in
+``.reyn/index/<source>/.lock`` and checks holder liveness on next
+acquire).
+
+The two functions here are *ambient* in the same sense as ``time`` and
+``random``: they observe process state without performing file I/O,
+network access, or operator-controlled state mutation. They do not need
+a permission gate.
+
+Surface:
+
+- :func:`getpid` — current process id (= the subprocess running the
+  safe-mode step). Returns ``os.getpid()`` verbatim.
+- :func:`pid_alive` — whether a given PID is currently running. Mirrors
+  the standard ``os.kill(pid, 0)`` liveness probe with the same
+  semantics (= signal 0 does nothing but raises ``ProcessLookupError`` /
+  ``PermissionError`` when the PID is unreachable).
+
+Out of scope: anything beyond identity + liveness. Process spawning,
+signal sending, environment / argv reads, and file-descriptor mucking
+are correctly gated to unsafe-mode.
+"""
+from __future__ import annotations
+
+import os as _os
+
+
+def getpid() -> int:
+    """Return the current process id.
+
+    In safe-mode this is the python subprocess running the step. Lock
+    files that record this PID become reapable as stale once the
+    subprocess exits, which is the correct semantics for advisory locks
+    scoped to the step's lifetime.
+    """
+    return _os.getpid()
+
+
+def pid_alive(pid: int) -> bool:
+    """Return whether ``pid`` is currently a running process.
+
+    Uses the standard ``os.kill(pid, 0)`` probe: signal 0 performs error
+    checking without delivering a signal. Returns False on
+    :class:`ProcessLookupError` (PID doesn't exist) and on
+    :class:`OSError` more broadly (= covers Windows / restricted-cap
+    edge cases where the call itself fails). Returns True when the
+    probe succeeds, and also when the call raises
+    :class:`PermissionError` — that means the PID exists but is owned
+    by a different user, which still counts as "alive" for stale-lock
+    purposes.
+    """
+    if pid <= 0:
+        return False
+    try:
+        _os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user. From the
+        # stale-lock-detection perspective, that's "alive".
+        return True
+    except OSError:
+        return False

--- a/src/reyn/stdlib/skills/index_docs/chunkers.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers.py
@@ -1,29 +1,25 @@
-"""Default chunker implementations for index_docs stdlib skill.
+"""Deprecated unsafe-mode chunker step for index_docs stdlib skill.
 
-Each public function is a python preprocessor / postprocessor step that
-receives the full artifact dict from the OS harness and returns a
-JSON-serializable value that is placed at ``into`` in the artifact.
+Post-FP-0042 (2026-05-23) this module hosts only the deprecated
+``apply_strategy`` step, kept for project-override compatibility. All
+active stdlib code paths run mode: safe via the companion modules:
 
-Override pattern (ADR-0033 §2.1): project-specific chunkers (Python AST,
-custom Markdown) replace this module via skill.md ``module:`` override.
-
-Module split (= reduces unsafe surface in stdlib per FP-0042):
-  ``gather_samples`` / ``cost_preflight`` (mode: safe) — live in
-    ``chunkers_preproc_safe.py``; file I/O goes through
-    ``reyn.safe.file`` with permission-gated reads. Migrated 2026-05-22
-    from this module's prior mode: unsafe implementation.
-  ``extract_and_split`` (mode: safe) — lives in ``chunkers_safe.py``
-    (the original R-PURE-MODE-REDEFINE Class A split).
-  ``write_chunks_with_lock`` (mode: unsafe, minimal) — kept here:
-    source file content read, advisory lock acquire/release, .jsonl write.
-    Migration to safe-mode is FP-0042 Phase 2.2 pending ``reyn.safe.file``
-    growing ``delete`` / ``mkdir`` and a lock primitive.
-  ``apply_strategy`` (mode: unsafe, deprecated) — kept for project
-    override compatibility.
+  - ``chunkers_preproc_safe.py`` — Phase-1 preprocessor (gather_samples,
+    cost_preflight). Migrated in Phase 2.1.
+  - ``chunkers_safe.py`` — postprocessor safe-mode steps
+    (extract_and_split, write_chunks_with_lock). The latter migrated in
+    Phase 2.2.
 
 This module's ``import os`` / ``from pathlib import Path`` would be
 inherited by the safe-mode AST walk if the safe-mode steps lived here,
-which is why they live in companion modules.
+which is why they live in companion modules. ``apply_strategy``
+remains mode: unsafe so its imports are admitted.
+
+Override pattern (ADR-0033 §2.1): project-specific chunkers replace this
+module via skill.md ``module:`` override. Existing overrides that
+patch ``apply_strategy`` continue to work; new overrides should target
+the two-step chain (``extract_and_split`` → ``write_chunks_with_lock``)
+in ``chunkers_safe.py``.
 """
 from __future__ import annotations
 
@@ -36,90 +32,10 @@ from pathlib import Path
 from typing import Iterator
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Postprocessor python steps
+# Deprecated postprocessor python step (kept for project-override compat)
 # ─────────────────────────────────────────────────────────────────────────────
 
 _CHUNKS_JSONL_PATH = "artifacts/chunks.jsonl"
-
-
-def write_chunks_with_lock(artifact: dict) -> dict:
-    """Postprocessor python step (mode: unsafe, minimal): lock + content read + jsonl write.
-
-    Receives the artifact after ``extract_and_split`` has placed the ordered
-    file list at ``data.chunk_list``. Acquires the source-level advisory lock,
-    reads each source file's content, splits into chunks per LLM strategy,
-    writes ``artifacts/chunks.jsonl``, then releases the lock.
-
-    This is the irreducible minimum unsafe step:
-      - ``Path.read_text`` (file content read — cannot be done in safe mode)
-      - ``.lock`` JSON write + PID alive check (advisory lock, concurrent safety)
-      - ``.jsonl`` write (workspace artifact output)
-
-    Returns a summary dict placed at ``data.chunk_stats``:
-        {
-            "chunk_count":          int,
-            "source_lock_acquired": bool,
-            "chunks_path":          str,
-        }
-    """
-    import time as _time
-
-    data = artifact.get("data") or {}
-    strategy = {
-        "boundary": data.get("boundary", "blank_line"),
-        "max_chunk_size_tokens": int(data.get("max_chunk_size_tokens") or 600),
-        "min_chunk_size_tokens": int(data.get("min_chunk_size_tokens") or 50),
-        "overlap_ratio": float(data.get("overlap_ratio") or 0.0),
-        "preserve_parent_context": bool(data.get("preserve_parent_context", True)),
-    }
-    source = str(data.get("source") or "unknown")
-    # chunk_list from extract_and_split: [{"source_path": str}, ...]
-    chunk_list = data.get("chunk_list") or []
-    file_paths: list[str] = []
-    seen: set[str] = set()
-    for entry in chunk_list:
-        fp = str(entry.get("source_path", ""))
-        if fp and fp not in seen:
-            file_paths.append(fp)
-            seen.add(fp)
-
-    # ── Concurrent lock (UX gap fix D) ───────────────────────────────────────
-    lock_path = Path(".reyn") / "index" / source / ".lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_acquired = False
-
-    if lock_path.exists():
-        try:
-            lock_data = json.loads(lock_path.read_text(encoding="utf-8"))
-            holder_pid = int(lock_data.get("pid", 0))
-            if holder_pid and _pid_alive(holder_pid):
-                raise RuntimeError(
-                    f"Source '{source}' is currently being indexed by PID"
-                    f" {holder_pid}. Wait for completion or kill the holder."
-                )
-        except (json.JSONDecodeError, ValueError):
-            pass  # Corrupted lock — take over
-
-    lock_path.write_text(
-        json.dumps({"pid": os.getpid(), "ts": _time.time()}),
-        encoding="utf-8",
-    )
-    lock_acquired = True
-
-    try:
-        chunk_count = _write_chunks_jsonl_from_paths(file_paths, strategy)
-    finally:
-        # Release lock on completion or error
-        try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass
-
-    return {
-        "chunk_count": chunk_count,
-        "source_lock_acquired": lock_acquired,
-        "chunks_path": _CHUNKS_JSONL_PATH,
-    }
 
 
 def apply_strategy(artifact: dict) -> dict:
@@ -204,15 +120,15 @@ def apply_strategy(artifact: dict) -> dict:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# JSONL writers (called by postprocessor steps)
+# JSONL writers (called by deprecated apply_strategy)
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int:
     """Chunk an ordered list of file paths and write to artifacts/chunks.jsonl.
 
-    Called by ``write_chunks_with_lock`` (mode: unsafe). Reads file content,
-    splits per strategy, writes JSONL. Returns chunk count.
+    Called only by ``apply_strategy`` (the deprecated monolithic step).
+    The active two-step chain has its own writer in ``chunkers_safe.py``.
     """
     boundary = strategy["boundary"]
     max_size = strategy["max_chunk_size_tokens"]

--- a/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
@@ -1,26 +1,35 @@
-"""Safe-mode postprocessor step for index_docs (= the `extract_and_split`
-path enumeration phase).
+"""Safe-mode postprocessor steps for index_docs.
 
-Split out from ``chunkers.py`` so that ``extract_and_split`` can actually
-run under ``mode: safe``. The companion ``chunkers.py`` module
-legitimately imports ``os`` / ``pathlib`` for its remaining unsafe-mode
-steps (``write_chunks_with_lock``, ``apply_strategy``), and the safe-mode
-AST validator walks all imports in the module via ``ast.walk(tree)`` — so
-a single-file layout forces every safe-mode step to inherit those
-unsafe imports. Following the audit's own Wave 2 pattern (= ``aggregate``
-→ ``aggregate_pure``), this module hosts only the safe-mode step and the
-exact set of imports the safe-mode allowlist admits.
+Hosts the two postprocessor python steps that run mode: safe —
+``extract_and_split`` (glob enumeration) and ``write_chunks_with_lock``
+(advisory lock + chunked JSONL write). Split out from ``chunkers.py``
+so that the safe-mode AST validator does not inherit chunkers.py's
+``os`` / ``pathlib`` imports through ``ast.walk(tree)`` (= same pattern
+as ``chunkers_preproc_safe.py`` from FP-0042 Phase 2.1).
 
-R-PURE-MODE-REDEFINE audit (2026-05-15) signed off on ``glob.glob`` as a
-restricted ambient source for path-list-only enumeration. See
-``docs/deep-dives/audits/2026-05-15-pure-mode-stdlib-audit.md`` and
-``_python_allowlist.py`` for the contract. FP-0042 Phase 2.1 (2026-05-22)
-migrated the two preprocessor steps to their own
-``chunkers_preproc_safe.py`` for the same reason.
+FP-0042 Phase 2.2 (2026-05-23): migrated ``write_chunks_with_lock``
+from chunkers.py mode: unsafe to here. File reads / writes / mkdir /
+delete go through :mod:`reyn.safe.file`; PID identity + liveness go
+through :mod:`reyn.safe.process`. Path manipulation uses plain string
+operations because ``pathlib`` is not on the safe-mode import
+allowlist.
+
+R-PURE-MODE-REDEFINE audit (2026-05-15) signed off on ``glob.glob`` as
+a restricted ambient source for path-list-only enumeration; that
+carveout still governs the ``extract_and_split`` glob call.
 """
 from __future__ import annotations
 
 import glob as _glob_mod
+import hashlib
+import json
+import re
+import time as _time
+
+from reyn.safe import file as _safe_file
+from reyn.safe import process as _safe_process
+
+# ─── extract_and_split ──────────────────────────────────────────────────────
 
 
 def extract_and_split(artifact: dict) -> list:
@@ -28,7 +37,7 @@ def extract_and_split(artifact: dict) -> list:
 
     Receives the LLM's finish artifact (= chunk_strategy). Enumerates files
     matching the path glob and returns an ordered list of source file paths.
-    Does NOT read file content — content read is deferred to the unsafe step
+    Does NOT read file content — content read is deferred to
     ``write_chunks_with_lock``.
 
     Glob ownership rationale (R-PURE-MODE audit, 2026-05-15): ``glob.glob``
@@ -37,13 +46,13 @@ def extract_and_split(artifact: dict) -> list:
     ambient source — see ``docs/deep-dives/audits/2026-05-15-pure-mode-
     stdlib-audit.md`` for the full reasoning.
 
-    No ``os.path.isfile`` filter: keeping the safe-mode allowlist narrow
-    means this module imports only ``glob``. ``glob.glob`` does not
-    distinguish files from directories, but for typed-extension patterns
-    (``**/*.md``, ``**/*.py``, …) directory matches are exotic. If one
-    does sneak through, the downstream ``write_chunks_with_lock`` (=
-    mode: unsafe) fails explicitly at content read time, which is
-    preferable to a silent drop.
+    No file-type filter: keeping the safe-mode allowlist narrow means
+    ``glob.glob`` does not distinguish files from directories, but for
+    typed-extension patterns (``**/*.md``, ``**/*.py``, …) directory
+    matches are exotic. If one does sneak through, ``write_chunks_with_lock``
+    surfaces it via the file read raising ``IsADirectoryError`` /
+    ``PermissionError`` (skipped silently in the read loop) — preferable
+    to a silent drop here.
 
     Returns a list of source-file path dicts placed at ``data.chunk_list``:
         [{"source_path": str}, ...]
@@ -55,3 +64,251 @@ def extract_and_split(artifact: dict) -> list:
 
     matches = _glob_mod.glob(path, recursive=True)
     return [{"source_path": fp} for fp in sorted(matches)]
+
+
+# ─── write_chunks_with_lock ─────────────────────────────────────────────────
+
+
+_CHUNKS_JSONL_PATH = "artifacts/chunks.jsonl"
+
+
+def write_chunks_with_lock(artifact: dict) -> dict:
+    """Postprocessor python step (mode: safe): source-level advisory lock +
+    chunked JSONL write.
+
+    Receives the artifact after ``extract_and_split`` has placed the ordered
+    file list at ``data.chunk_list``. Acquires the source-level lock under
+    ``.reyn/index/<source>/.lock`` (= default-zone write), reads each source
+    file's content (= default-zone read, granted by ``preprocessor_executor``
+    via CWD), splits into chunks per strategy, writes ``artifacts/chunks.jsonl``
+    (= requires ``permissions.file.write: artifacts``), releases the lock.
+
+    The lock is recovered as stale when the holder PID is no longer alive
+    (= ``reyn.safe.process.pid_alive`` returns False), matching the
+    legacy unsafe-mode behaviour. The PID written is the safe-mode
+    subprocess's own — when the subprocess exits without releasing
+    (= SIGKILL, OOM, parent crash), the lock is reapable on the next run.
+
+    Returns:
+        {
+            "chunk_count":          int,
+            "source_lock_acquired": bool,
+            "chunks_path":          str,
+        }
+    """
+    data = artifact.get("data") or {}
+    strategy = {
+        "boundary": data.get("boundary", "blank_line"),
+        "max_chunk_size_tokens": int(data.get("max_chunk_size_tokens") or 600),
+        "min_chunk_size_tokens": int(data.get("min_chunk_size_tokens") or 50),
+        "overlap_ratio": float(data.get("overlap_ratio") or 0.0),
+        "preserve_parent_context": bool(data.get("preserve_parent_context", True)),
+    }
+    source = str(data.get("source") or "unknown")
+    chunk_list = data.get("chunk_list") or []
+    file_paths: list[str] = []
+    seen: set[str] = set()
+    for entry in chunk_list:
+        fp = str(entry.get("source_path", ""))
+        if fp and fp not in seen:
+            file_paths.append(fp)
+            seen.add(fp)
+
+    # Lock path: ".reyn/index/<source>/.lock" via plain string join (pathlib
+    # is not on the safe-mode import allowlist). The .reyn/ tree is the
+    # default write zone, so no extra skill.md declaration is needed for
+    # the lock itself.
+    lock_dir = f".reyn/index/{source}"
+    lock_path = f"{lock_dir}/.lock"
+
+    _safe_file.mkdir(lock_dir, parents=True, exist_ok=True)
+    lock_acquired = False
+
+    if _safe_file.exists(lock_path):
+        try:
+            lock_data = json.loads(_safe_file.read(lock_path))
+            holder_pid = int(lock_data.get("pid", 0))
+            if holder_pid and _safe_process.pid_alive(holder_pid):
+                raise RuntimeError(
+                    f"Source '{source}' is currently being indexed by PID"
+                    f" {holder_pid}. Wait for completion or kill the holder."
+                )
+        except (json.JSONDecodeError, ValueError):
+            pass  # Corrupted lock — take over.
+
+    _safe_file.write(
+        lock_path,
+        json.dumps({"pid": _safe_process.getpid(), "ts": _time.time()}),
+    )
+    lock_acquired = True
+
+    try:
+        chunk_count = _write_chunks_jsonl_from_paths(file_paths, strategy)
+    finally:
+        _safe_file.delete(lock_path, missing_ok=True)
+
+    return {
+        "chunk_count": chunk_count,
+        "source_lock_acquired": lock_acquired,
+        "chunks_path": _CHUNKS_JSONL_PATH,
+    }
+
+
+# ─── JSONL writer + split helpers ───────────────────────────────────────────
+#
+# Duplicated from chunkers.py's deprecated ``apply_strategy`` codepath. The
+# safe-mode AST validator walks every import in this module — chunkers.py
+# legitimately imports ``os`` / ``pathlib`` for its remaining unsafe-mode
+# steps, so we cannot re-use those helpers from here. The split is pure
+# regex + string ops, so divergence risk is low.
+
+
+def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int:
+    """Chunk an ordered list of file paths and write artifacts/chunks.jsonl.
+
+    Reads source files via :mod:`reyn.safe.file`; writes the JSONL output
+    via the same. The output path ``artifacts/chunks.jsonl`` is outside
+    the default ``.reyn/`` write zone and is granted explicitly in
+    skill.md via ``permissions.file.write: artifacts``.
+
+    Returns the number of chunks written (= one JSONL row per chunk).
+    """
+    boundary = strategy["boundary"]
+    max_size = strategy["max_chunk_size_tokens"]
+    min_size = strategy.get("min_chunk_size_tokens", 50)
+    overlap = strategy.get("overlap_ratio", 0.0)
+    preserve = strategy.get("preserve_parent_context", True)
+
+    _safe_file.mkdir("artifacts", parents=True, exist_ok=True)
+
+    chunk_idx = 0
+    chunk_records: list[str] = []
+    for file_path in file_paths:
+        try:
+            text = _safe_file.read(file_path)
+        except (OSError, PermissionError):
+            continue
+        for chunk_text, parent_ctx in _split(
+            text, boundary, max_size, min_size, overlap
+        ):
+            content_hash = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+            metadata = {
+                "source_path": file_path,
+                "source_type": _suffix_no_dot(file_path) or "unknown",
+                "content_hash": content_hash,
+                "embedding_model": "",   # filled in by embed op
+                "chunk_index": chunk_idx,
+                "size_tokens": _approx_tokens(chunk_text),
+                "parent_context": parent_ctx if preserve else None,
+                "extra": {},
+            }
+            record = {"text": chunk_text, "metadata": metadata}
+            chunk_records.append(json.dumps(record, ensure_ascii=False))
+            chunk_idx += 1
+
+    # Single write to keep the file atomic-ish (= no partial JSONL on
+    # mid-write crash; the prior unsafe-mode version streamed line-by-line).
+    _safe_file.write(_CHUNKS_JSONL_PATH, "\n".join(chunk_records) + ("\n" if chunk_records else ""))
+    return chunk_idx
+
+
+def _suffix_no_dot(path: str) -> str:
+    """Return the file extension without the leading dot (e.g. ``foo.md`` → ``md``).
+
+    Replaces ``pathlib.PurePath(path).suffix.lstrip(".")`` which the
+    legacy unsafe code used. Pathlib is not in the safe-mode allowlist.
+    """
+    name = path.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    idx = name.rfind(".")
+    if idx <= 0:
+        return ""
+    return name[idx + 1:]
+
+
+def _approx_tokens(text: str) -> int:
+    """Rough token count: ~4 chars per token (GPT-style BPE approximation)."""
+    return max(1, len(text) // 4)
+
+
+def _split(
+    text: str,
+    boundary: str,
+    max_size: int,
+    min_size: int,
+    overlap: float,
+):
+    """Yield (chunk_text, parent_context) tuples per strategy."""
+    if boundary == "heading":
+        yield from _split_heading(text, max_size, min_size, overlap)
+    elif boundary == "blank_line":
+        yield from _split_blank_line(text, max_size, min_size, overlap)
+    elif boundary == "sentence":
+        yield from _split_sentence(text, max_size, min_size, overlap)
+    else:
+        yield from _split_blank_line(text, max_size, min_size, overlap)
+
+
+def _split_heading(text, max_size, min_size, overlap):
+    """Split at Markdown headings (#, ##); pack each section until max_size."""
+    headings = list(re.finditer(r"^(#+)\s+(.+)$", text, re.MULTILINE))
+    if not headings:
+        yield from _split_blank_line(text, max_size, min_size, overlap)
+        return
+    for i, h in enumerate(headings):
+        section_start = h.start()
+        section_end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+        section_text = text[section_start:section_end]
+        heading_label = h.group(2).strip()
+        if _approx_tokens(section_text) <= max_size:
+            if _approx_tokens(section_text) >= min_size:
+                yield section_text, heading_label
+        else:
+            for sub, _ in _split_blank_line(section_text, max_size, min_size, overlap):
+                yield sub, heading_label
+
+
+def _split_blank_line(text, max_size, min_size, overlap):
+    """Split at blank lines; pack paragraphs into chunks <= max_size."""
+    paragraphs = re.split(r"\n\s*\n", text)
+    current: list[str] = []
+    current_size = 0
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+        para_size = _approx_tokens(para)
+        if current_size + para_size > max_size and current:
+            chunk = "\n\n".join(current)
+            if _approx_tokens(chunk) >= min_size:
+                yield chunk, None
+            current = [para]
+            current_size = para_size
+        else:
+            current.append(para)
+            current_size += para_size
+    if current:
+        chunk = "\n\n".join(current)
+        if _approx_tokens(chunk) >= min_size:
+            yield chunk, None
+
+
+def _split_sentence(text, max_size, min_size, overlap):
+    """Split at sentence boundaries; pack into chunks <= max_size."""
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    current: list[str] = []
+    current_size = 0
+    for sent in sentences:
+        s_size = _approx_tokens(sent)
+        if current_size + s_size > max_size and current:
+            chunk = " ".join(current)
+            if _approx_tokens(chunk) >= min_size:
+                yield chunk, None
+            current = [sent]
+            current_size = s_size
+        else:
+            current.append(sent)
+            current_size += s_size
+    if current:
+        chunk = " ".join(current)
+        if _approx_tokens(chunk) >= min_size:
+            yield chunk, None

--- a/src/reyn/stdlib/skills/index_docs/skill.md
+++ b/src/reyn/stdlib/skills/index_docs/skill.md
@@ -33,7 +33,7 @@ permissions:
   python:
     # FP-0042 Phase 2.1 (2026-05-22): preprocessor steps migrated from
     # chunkers.py (mode: unsafe) → chunkers_preproc_safe.py (mode: safe).
-    # File reads / stat calls now go through reyn.safe.file, which gates
+    # File reads / stat calls go through reyn.safe.file, which gates
     # against the workspace default-read-zone (CWD) and any explicit
     # file.read entries below.
     - module: ./chunkers_preproc_safe.py
@@ -48,16 +48,28 @@ permissions:
       function: extract_and_split
       mode: safe
       timeout: 30
-    - module: ./chunkers.py
+    # FP-0042 Phase 2.2 (2026-05-23): write_chunks_with_lock migrated to
+    # chunkers_safe.py (mode: safe). Source file reads + lock + jsonl
+    # write all go through reyn.safe.file; PID identity + liveness go
+    # through reyn.safe.process. The artifacts/ write zone below grants
+    # the chunks.jsonl output (= outside the default .reyn/ zone).
+    - module: ./chunkers_safe.py
       function: write_chunks_with_lock
-      mode: unsafe
-      unsafe_reason: "minimal filesystem I/O + advisory lock for concurrent indexing (FP-0042 Phase 2.2 will migrate this once reyn.safe.file grows delete/mkdir + lock support)"
+      mode: safe
       timeout: 300
     - module: ./chunkers.py
       function: apply_strategy
       mode: unsafe
       unsafe_reason: "deprecated monolithic step kept for project override compatibility"
       timeout: 300
+  # FP-0042 Phase 2.2: write_chunks_with_lock writes the chunked JSONL
+  # output to ``<cwd>/artifacts/chunks.jsonl`` — outside the default
+  # ``.reyn/`` write zone, so it needs an explicit grant. The lock file
+  # at ``.reyn/index/<source>/.lock`` does not need a declaration (=
+  # default-zone write).
+  file.write:
+    - path: artifacts
+      scope: recursive
 postprocessor:
   output_schema: index_summary
   steps:

--- a/tests/test_chunkers_safe_write_chunks.py
+++ b/tests/test_chunkers_safe_write_chunks.py
@@ -1,0 +1,283 @@
+"""Tier 2 — chunkers_safe.write_chunks_with_lock contract tests (FP-0042 Phase 2.2).
+
+Tests the safe-mode postprocessor step that replaced chunkers.py's
+unsafe-mode ``write_chunks_with_lock`` (= advisory lock + chunked
+JSONL write). Coverage mirrors the lock-discipline tests previously
+exercised against the deprecated ``apply_strategy`` so the contract
+stays observably stable across the migration.
+
+The function reads source files + writes ``artifacts/chunks.jsonl`` +
+acquires ``.reyn/index/<source>/.lock`` — all through reyn.safe.file.
+The autouse fixture sets a permission context that grants reads
+under tmp_path and writes under tmp_path/.reyn/ + tmp_path/artifacts/.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from reyn.safe import file as sf
+
+
+def _load_chunkers_safe():
+    """Import chunkers_safe.py from the skill directory."""
+    skill_dir = (
+        Path(__file__).parent.parent
+        / "src" / "reyn" / "stdlib" / "skills" / "index_docs"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "chunkers_safe", skill_dir / "chunkers_safe.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_C = _load_chunkers_safe()
+
+
+@pytest.fixture(autouse=True)
+def _reset_safe_file_context():
+    """Reset reyn.safe.file's module-global permission context per test."""
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+    yield
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Wire a sandbox tmpdir: cwd here, safe.file context grants reads
+    under tmp_path and writes under tmp_path/.reyn + tmp_path/artifacts.
+
+    Mirrors how the production preprocessor_executor wires the
+    subprocess's permission context (= CWD as default read zone;
+    .reyn/ as default write zone; plus explicit artifacts/ from
+    skill.md).
+    """
+    monkeypatch.chdir(tmp_path)
+    sf._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[
+            str(tmp_path / ".reyn"),
+            str(tmp_path / "artifacts"),
+        ],
+    )
+    return tmp_path
+
+
+def _make_artifact(data: dict) -> dict:
+    return {"type": "chunk_strategy", "data": data}
+
+
+def _strategy_payload(*, source: str, file_paths: list[str]) -> dict:
+    return {
+        "boundary": "blank_line",
+        "max_chunk_size_tokens": 500,
+        "min_chunk_size_tokens": 1,
+        "overlap_ratio": 0.0,
+        "preserve_parent_context": True,
+        "source": source,
+        "chunk_list": [{"source_path": p} for p in file_paths],
+        "mode": "append",
+        "description": "test docs",
+        "path": "irrelevant — chunk_list drives the work",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_write_chunks_writes_jsonl_under_artifacts(sandbox: Path):
+    """Tier 2: write_chunks_with_lock writes artifacts/chunks.jsonl with one
+    JSON object per line, summary dict reflects the count."""
+    md = sandbox / "doc.md"
+    md.write_text("Hello world.\n\nSecond paragraph.\n", encoding="utf-8")
+
+    artifact = _make_artifact(
+        _strategy_payload(source="s1", file_paths=[str(md)])
+    )
+    result = _C.write_chunks_with_lock(artifact)
+
+    assert result["chunk_count"] > 0
+    assert result["source_lock_acquired"] is True
+    assert result["chunks_path"] == "artifacts/chunks.jsonl"
+
+    chunks_path = sandbox / "artifacts" / "chunks.jsonl"
+    assert chunks_path.exists()
+    lines = [json.loads(l) for l in chunks_path.read_text().splitlines() if l.strip()]
+    assert len(lines) == result["chunk_count"]
+    for ln in lines:
+        assert "text" in ln
+        assert "metadata" in ln
+        assert "content_hash" in ln["metadata"]
+        assert "source_path" in ln["metadata"]
+
+
+def test_write_chunks_lock_released_on_success(sandbox: Path):
+    """Tier 2: the .lock file is deleted after a successful run."""
+    md = sandbox / "doc.md"
+    md.write_text("body", encoding="utf-8")
+
+    artifact = _make_artifact(
+        _strategy_payload(source="release_test", file_paths=[str(md)])
+    )
+    _C.write_chunks_with_lock(artifact)
+
+    lock_path = sandbox / ".reyn" / "index" / "release_test" / ".lock"
+    assert not lock_path.exists()
+
+
+def test_write_chunks_lock_released_on_error(sandbox: Path):
+    """Tier 2: the .lock file is deleted even if the chunking raises.
+
+    Simulate an inner failure by passing a non-list ``chunk_list`` (=
+    the iteration over ``data.chunk_list`` raises). The lock acquire
+    happens before that, so the ``finally`` block must reap it.
+    """
+    artifact = _make_artifact(_strategy_payload(source="err_test", file_paths=[]))
+    artifact["data"]["chunk_list"] = 42  # not iterable as a list of dicts
+
+    with pytest.raises(Exception):
+        _C.write_chunks_with_lock(artifact)
+
+    lock_path = sandbox / ".reyn" / "index" / "err_test" / ".lock"
+    assert not lock_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Lock semantics — concurrent + stale
+# ---------------------------------------------------------------------------
+
+
+def test_write_chunks_blocks_when_holder_alive(sandbox: Path):
+    """Tier 2: a pre-existing lock with the current PID (= alive) blocks
+    the new run with a RuntimeError mentioning the holder."""
+    source = "concurrent_test"
+    lock_dir = sandbox / ".reyn" / "index" / source
+    lock_dir.mkdir(parents=True)
+    lock_path = lock_dir / ".lock"
+    lock_path.write_text(
+        json.dumps({"pid": os.getpid(), "ts": 0.0}), encoding="utf-8"
+    )
+
+    md = sandbox / "doc.md"
+    md.write_text("body", encoding="utf-8")
+    artifact = _make_artifact(
+        _strategy_payload(source=source, file_paths=[str(md)])
+    )
+
+    with pytest.raises(RuntimeError, match="currently being indexed"):
+        _C.write_chunks_with_lock(artifact)
+
+
+def test_write_chunks_reaps_stale_lock(sandbox: Path):
+    """Tier 2: a lock with a dead PID is reaped; the run completes."""
+    source = "stale_test"
+    lock_dir = sandbox / ".reyn" / "index" / source
+    lock_dir.mkdir(parents=True)
+    lock_path = lock_dir / ".lock"
+    # PID 2_000_000_000 is past any plausible kernel.pid_max.
+    lock_path.write_text(
+        json.dumps({"pid": 2_000_000_000, "ts": 0.0}), encoding="utf-8"
+    )
+
+    md = sandbox / "doc.md"
+    md.write_text("body", encoding="utf-8")
+    artifact = _make_artifact(
+        _strategy_payload(source=source, file_paths=[str(md)])
+    )
+
+    result = _C.write_chunks_with_lock(artifact)
+    assert result["chunk_count"] > 0
+    assert result["source_lock_acquired"] is True
+
+
+def test_write_chunks_takes_over_corrupted_lock(sandbox: Path):
+    """Tier 2: a corrupted lock (= invalid JSON) is taken over silently."""
+    source = "corrupt_test"
+    lock_dir = sandbox / ".reyn" / "index" / source
+    lock_dir.mkdir(parents=True)
+    lock_path = lock_dir / ".lock"
+    lock_path.write_text("not valid json {{", encoding="utf-8")
+
+    md = sandbox / "doc.md"
+    md.write_text("body", encoding="utf-8")
+    artifact = _make_artifact(
+        _strategy_payload(source=source, file_paths=[str(md)])
+    )
+
+    result = _C.write_chunks_with_lock(artifact)
+    assert result["chunk_count"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Permission denial surface
+# ---------------------------------------------------------------------------
+
+
+def test_write_chunks_skips_unreadable_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Tier 2: a source path outside the declared read zone is silently
+    skipped (matches the legacy OSError-swallowing read loop). When all
+    inputs are denied, the JSONL is empty and chunk_count is 0.
+    """
+    monkeypatch.chdir(tmp_path)
+    grant = tmp_path / "ok"
+    grant.mkdir()
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    md = denied / "secret.md"
+    md.write_text("secret content", encoding="utf-8")
+
+    sf._set_permission_context(
+        # Grant reads where there are no source files, plus the lock dir
+        # so write_chunks_with_lock can probe / read its own lock. Source
+        # files in tmp_path/denied/ stay unreadable, which is the path under
+        # test.
+        read_paths=[str(grant), str(tmp_path / ".reyn")],
+        write_paths=[
+            str(tmp_path / ".reyn"),
+            str(tmp_path / "artifacts"),
+        ],
+    )
+
+    artifact = _make_artifact(
+        _strategy_payload(source="denied_test", file_paths=[str(md)])
+    )
+    result = _C.write_chunks_with_lock(artifact)
+
+    assert result["chunk_count"] == 0
+    chunks_path = tmp_path / "artifacts" / "chunks.jsonl"
+    # Output file is written (possibly empty) — the writer always produces it.
+    assert chunks_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Helper pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("foo.md", "md"),
+        ("/a/b/c.py", "py"),
+        ("noext", ""),
+        (".hidden", ""),
+        (".hidden.md", "md"),
+        ("nested.dir/file.txt", "txt"),
+    ],
+)
+def test_suffix_no_dot(path: str, expected: str):
+    """Tier 2: _suffix_no_dot strips the leading dot; mirrors
+    pathlib.PurePath.suffix.lstrip(".") for the production paths."""
+    assert _C._suffix_no_dot(path) == expected

--- a/tests/test_index_docs_pure_split_invariants.py
+++ b/tests/test_index_docs_pure_split_invariants.py
@@ -107,24 +107,21 @@ def test_extract_and_split_returns_path_list_without_content_read(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_index_docs_skill_permissions_python_has_safe_extract_and_unsafe_write():
-    """Tier 2: skill.md permissions.python has extract_and_split as safe and
-    write_chunks_with_lock as unsafe with unsafe_reason annotation.
+def test_index_docs_skill_permissions_python_active_steps_are_safe():
+    """Tier 2: skill.md permissions.python has the active postprocessor steps
+    (= extract_and_split + write_chunks_with_lock) both as mode=safe.
 
-    Verifies the R-PURE-MODE-REDEFINE Class A permission declaration:
-    - extract_and_split: mode=safe (glob enum only, no I/O)
-    - write_chunks_with_lock: mode=unsafe (irreducible: lock + content + jsonl)
+    Post-FP-0042 Phase 2.2 (2026-05-23) the active two-step chain runs
+    entirely safe-mode. Only the deprecated ``apply_strategy`` step
+    remains mode=unsafe for project-override compatibility.
 
-    The unsafe_reason annotation is checked by parsing the raw YAML frontmatter
-    directly (the compiled PythonPermission dataclass does not carry unsafe_reason,
-    so we read the skill.md source and parse the permissions block to verify the
-    annotation exists in the YAML text).
+    The ``unsafe_reason`` annotation must still be present on
+    ``apply_strategy`` (= FP-0014 Component F documentation contract).
     """
     import re
 
     skill_md_text = _SKILL_MD_PATH.read_text(encoding="utf-8")
 
-    # ── Compiled model check: modes ───────────────────────────────────────────
     skill = _load_skill()
     fn_modes = {p.function: p.mode for p in skill.permissions.python}
 
@@ -132,19 +129,21 @@ def test_index_docs_skill_permissions_python_has_safe_extract_and_unsafe_write()
         f"extract_and_split must be mode=safe, got {fn_modes.get('extract_and_split')!r}. "
         "glob enum is pure (path list only, no file content read)."
     )
-    assert fn_modes.get("write_chunks_with_lock") == "unsafe", (
-        f"write_chunks_with_lock must be mode=unsafe, got {fn_modes.get('write_chunks_with_lock')!r}. "
-        "It performs lock acquire, Path.read_text, and .jsonl write."
+    assert fn_modes.get("write_chunks_with_lock") == "safe", (
+        f"write_chunks_with_lock must be mode=safe post-FP-0042 Phase 2.2, "
+        f"got {fn_modes.get('write_chunks_with_lock')!r}. It now uses "
+        "reyn.safe.file + reyn.safe.process."
+    )
+    assert fn_modes.get("apply_strategy") == "unsafe", (
+        f"apply_strategy stays mode=unsafe (= deprecated compat path), "
+        f"got {fn_modes.get('apply_strategy')!r}."
     )
 
-    # ── Raw YAML check: unsafe_reason annotation is present ──────────────────
-    # Extract the frontmatter block (between first --- and second ---)
     fm_match = re.match(r"^---\n(.*?)\n---", skill_md_text, re.DOTALL)
     assert fm_match, "Could not parse skill.md frontmatter"
     fm_text = fm_match.group(1)
 
     assert "unsafe_reason" in fm_text, (
-        "write_chunks_with_lock permissions entry must include an unsafe_reason "
-        "annotation in skill.md (FP-0014 Component F documentation contract). "
-        "Add `unsafe_reason: \"...\"` to the write_chunks_with_lock entry."
+        "apply_strategy must keep its unsafe_reason annotation "
+        "(FP-0014 Component F documentation contract)."
     )

--- a/tests/test_index_docs_skill.py
+++ b/tests/test_index_docs_skill.py
@@ -172,8 +172,8 @@ def test_index_docs_postprocessor_output_name():
 def test_index_docs_postprocessor_four_steps():
     """Tier 2: postprocessor has exactly 4 steps: python → python → run_op → run_op.
 
-    R-PURE-MODE-REDEFINE Class A split: apply_strategy was split into
-    extract_and_split (safe, step 0) + write_chunks_with_lock (unsafe, step 1).
+    Post-FP-0042 Phase 2.2: both python steps now run mode: safe via
+    chunkers_safe.py (= extract_and_split + write_chunks_with_lock).
     Steps 2 and 3 are the existing embed and index_write run_ops.
     """
     skill = _load()
@@ -195,7 +195,7 @@ def test_index_docs_postprocessor_step0_is_extract_and_split():
 
 
 def test_index_docs_postprocessor_step1_is_write_chunks_with_lock():
-    """Tier 2: postprocessor step[1] calls write_chunks_with_lock (unsafe, minimal I/O)."""
+    """Tier 2: postprocessor step[1] calls write_chunks_with_lock (safe, reyn.safe.file + reyn.safe.process)."""
     skill = _load()
     step = skill.postprocessor.steps[1]
     assert isinstance(step, PythonStep)
@@ -241,11 +241,9 @@ def test_index_docs_postprocessor_step3_args_from():
 def test_index_docs_permissions_python_modes_declared():
     """Tier 2: skill declares the expected mode per chunker function.
 
-    Post-FP-0042 Phase 2.1:
+    Post-FP-0042 Phase 2.2:
       - gather_samples / cost_preflight: safe (chunkers_preproc_safe.py)
-      - extract_and_split: safe (chunkers_safe.py)
-      - write_chunks_with_lock: unsafe minimal — lock + content read +
-        jsonl write (will migrate in Phase 2.2)
+      - extract_and_split / write_chunks_with_lock: safe (chunkers_safe.py)
       - apply_strategy: unsafe deprecated, kept for override compat
     """
     skill = _load()
@@ -256,7 +254,7 @@ def test_index_docs_permissions_python_modes_declared():
     assert fn_modes.get("gather_samples") == "safe"
     assert fn_modes.get("cost_preflight") == "safe"
     assert fn_modes.get("extract_and_split") == "safe"
-    assert fn_modes.get("write_chunks_with_lock") == "unsafe"
+    assert fn_modes.get("write_chunks_with_lock") == "safe"
     assert fn_modes.get("apply_strategy") == "unsafe"
 
 

--- a/tests/test_safe_file_api.py
+++ b/tests/test_safe_file_api.py
@@ -290,3 +290,106 @@ def test_context_can_be_reinitialised(sandbox: Path) -> None:
     sf._set_permission_context(read_paths=[])
     with pytest.raises(PermissionError):
         sf.read(str(sandbox / "docs" / "a.md"))
+
+
+# ---------------------------------------------------------------------------
+# mkdir — FP-0042 Phase 2.2
+# ---------------------------------------------------------------------------
+
+
+def test_mkdir_within_write_path_creates_directory(sandbox: Path) -> None:
+    """Tier 2: mkdir in declared write zone creates the directory."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "new"
+    sf.mkdir(str(target))
+    assert target.is_dir()
+
+
+def test_mkdir_outside_write_path_raises(sandbox: Path) -> None:
+    """Tier 2: mkdir outside the declared write zone raises PermissionError."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    with pytest.raises(PermissionError):
+        sf.mkdir(str(sandbox / "docs" / "should_not_exist"))
+
+
+def test_mkdir_without_context_raises() -> None:
+    """Tier 2: mkdir without permission context raises clearly."""
+    with pytest.raises(PermissionError):
+        sf.mkdir("/tmp/no-context-mkdir")
+
+
+def test_mkdir_existing_dir_default_raises(sandbox: Path) -> None:
+    """Tier 2: mkdir raises FileExistsError on existing dir by default."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "already"
+    target.mkdir()
+    with pytest.raises(FileExistsError):
+        sf.mkdir(str(target))
+
+
+def test_mkdir_exist_ok_true_swallows_existing(sandbox: Path) -> None:
+    """Tier 2: mkdir(exist_ok=True) is a no-op on existing dir."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "already"
+    target.mkdir()
+    sf.mkdir(str(target), exist_ok=True)
+    assert target.is_dir()
+
+
+def test_mkdir_parents_true_creates_intermediates(sandbox: Path) -> None:
+    """Tier 2: mkdir(parents=True) creates intermediate directories."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "a" / "b" / "c"
+    sf.mkdir(str(target), parents=True)
+    assert target.is_dir()
+
+
+def test_mkdir_parents_false_missing_intermediate_raises(sandbox: Path) -> None:
+    """Tier 2: mkdir without parents=True fails when intermediates missing."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "missing" / "leaf"
+    with pytest.raises(FileNotFoundError):
+        sf.mkdir(str(target))
+
+
+# ---------------------------------------------------------------------------
+# delete — FP-0042 Phase 2.2
+# ---------------------------------------------------------------------------
+
+
+def test_delete_within_write_path_removes_file(sandbox: Path) -> None:
+    """Tier 2: delete in declared write zone removes the file."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "out" / "trash.txt"
+    target.write_text("bye\n", encoding="utf-8")
+    sf.delete(str(target))
+    assert not target.exists()
+
+
+def test_delete_outside_write_path_raises(sandbox: Path) -> None:
+    """Tier 2: delete outside the declared write zone raises PermissionError;
+    the file stays put."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    target = sandbox / "docs" / "a.md"
+    with pytest.raises(PermissionError):
+        sf.delete(str(target))
+    assert target.exists()
+
+
+def test_delete_missing_default_raises(sandbox: Path) -> None:
+    """Tier 2: delete of a missing file raises FileNotFoundError by default."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    with pytest.raises(FileNotFoundError):
+        sf.delete(str(sandbox / "out" / "ghost.txt"))
+
+
+def test_delete_missing_ok_true_swallows(sandbox: Path) -> None:
+    """Tier 2: delete(missing_ok=True) is a no-op when the file doesn't exist."""
+    sf._set_permission_context(write_paths=[str(sandbox / "out")])
+    sf.delete(str(sandbox / "out" / "ghost.txt"), missing_ok=True)
+
+
+def test_delete_without_context_raises() -> None:
+    """Tier 2: delete without permission context raises clearly."""
+    with pytest.raises(PermissionError):
+        sf.delete("/tmp/no-context-delete")

--- a/tests/test_safe_process.py
+++ b/tests/test_safe_process.py
@@ -1,0 +1,50 @@
+"""Tier 2 — reyn.safe.process contract tests (FP-0042 Phase 2.2).
+
+The :mod:`reyn.safe.process` module exposes ``getpid`` + ``pid_alive``
+to safe-mode python steps without a permission gate (process identity
+is ambient in the same sense as ``time`` / ``random``). These tests
+pin: getpid returns the same value as ``os.getpid``, pid_alive is
+True for the current process, False for an obviously-dead PID, and
+False for non-positive PIDs (= input guard).
+"""
+from __future__ import annotations
+
+import os
+
+from reyn.safe import process as sp
+
+
+def test_getpid_matches_os_getpid() -> None:
+    """Tier 2: reyn.safe.process.getpid() returns os.getpid() verbatim."""
+    assert sp.getpid() == os.getpid()
+
+
+def test_pid_alive_true_for_self() -> None:
+    """Tier 2: pid_alive returns True for the current process."""
+    assert sp.pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_false_for_obviously_dead_pid() -> None:
+    """Tier 2: pid_alive returns False for a PID very unlikely to exist.
+
+    Linux/macOS PIDs are bounded by ``kernel.pid_max`` (= ~32k on macOS,
+    ~4M on modern Linux). 2_000_000_000 is comfortably past both, so
+    ``os.kill(pid, 0)`` raises ``ProcessLookupError`` and pid_alive
+    returns False.
+    """
+    assert sp.pid_alive(2_000_000_000) is False
+
+
+def test_pid_alive_false_for_zero() -> None:
+    """Tier 2: pid_alive(0) returns False (= guarded against the kill(0,0)
+    "signal all processes in current group" semantics, which would
+    incorrectly return True).
+    """
+    assert sp.pid_alive(0) is False
+
+
+def test_pid_alive_false_for_negative() -> None:
+    """Tier 2: pid_alive on a negative PID returns False (= guarded against
+    kill(-1, 0) "broadcast" semantics)."""
+    assert sp.pid_alive(-1) is False
+    assert sp.pid_alive(-12345) is False


### PR DESCRIPTION
**[dogfood-coder]** — FP-0042 Phase 2.2. Stacked on #557. Do not merge until #553 + #557 land.

## Summary

- `write_chunks_with_lock` migrates from `chunkers.py` (mode: unsafe) → `chunkers_safe.py` (mode: safe, alongside `extract_and_split`).
- New `reyn.safe.file.mkdir` / `delete` (write-gated).
- New `reyn.safe.process` module with `getpid` + `pid_alive` (ambient, no gate).
- Stdlib unsafe surface for `index_docs` drops to 1 step (`apply_strategy`, deprecated compat). 4 → 1 across Phase 2.1+2.2.

## Wiring

- `.reyn/index/<source>/.lock` (advisory lock) lives in the default write zone — no extra skill.md grant.
- `artifacts/chunks.jsonl` (chunk output) is *outside* the default `.reyn/` write zone, so the skill now declares `permissions.file.write: [{path: artifacts, scope: recursive}]`. This is the first stdlib skill exercising the per-skill `file.write` declaration through the FP-0042 path.

## Module-split rationale

`chunkers_safe.py` duplicates the `_split*` / `_approx_tokens` helpers (rather than importing from `chunkers.py`) because the safe-mode AST validator walks every module-level import via `ast.walk(tree)`. `chunkers.py` still legitimately imports `os` / `pathlib` for the remaining `apply_strategy` step, so re-importing back would force the safe walk to reject the module. Same pattern as `chunkers_preproc_safe.py` from Phase 2.1.

## Lock semantics preserved

- `os.getpid()` → `reyn.safe.process.getpid()` — writes the subprocess PID, exactly as before.
- `os.kill(pid, 0)` → `reyn.safe.process.pid_alive(pid)` — same liveness probe; guards PID ≤ 0 to avoid `kill(0, 0)` / `kill(-1, 0)` broadcast semantics.
- Concurrent-blocking, stale-reaping, corrupted-lock-takeover paths all retested under the new module.

## Out of scope

- `apply_strategy` (mode: unsafe) — kept for project-override compat; will retire when no overrides reference it.
- `reyn.safe.file.rmtree` / directory delete — not added; no stdlib use case yet. Skills that need it must declare mode: unsafe.

## Test plan

- [x] Tier 2 contract suite for `reyn.safe.file.mkdir` / `delete` — 12 tests covering grant / deny / `parents` / `exist_ok` / `missing_ok` / context-not-initialised.
- [x] Tier 2 contract suite for `reyn.safe.process` — 5 tests covering `getpid` vs `os.getpid`, `pid_alive` for self / dead PID / 0 / negative.
- [x] Tier 2 contract suite for `chunkers_safe.write_chunks_with_lock` — 13 tests: happy path, lock release on success, lock release on error, concurrent-block, stale-PID reap, corrupted-lock takeover, denied-read silent-skip, `_suffix_no_dot` parametrics.
- [x] `_validate_safe_ast` clean on both `chunkers_safe.py` and `chunkers_preproc_safe.py` (= the AST validator admits the new import set).
- [x] Full sweep — `5174 passed, 8 skipped, 3 xfailed` (= +30 from Phase 2.1 baseline).
- [x] `ruff check` clean on changed files.
- [ ] Manual dogfood E2E (= live `reyn run index_docs '{...}'`) — deferred until #553 + #557 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)