### PR TITLE
fix(skill_builder): teach plan_skill to write pushy, trigger-aware descriptions

### DIFF
--- a/src/reyn/stdlib/skills/skill_builder/eval.md
+++ b/src/reyn/stdlib/skills/skill_builder/eval.md
@@ -10,7 +10,7 @@ input: "Build a skill that writes a short article about a given topic."
 ### phase: plan_skill
 quality:
 - The generated skill_name is in snake_case.
-- The skill_description accurately summarizes the skill's purpose in one sentence.
+- The skill_description (a) accurately summarizes the skill's purpose AND (b) lists at least one trigger context / synonym set the chat router can match against (e.g. "Use whenever the user asks to <action>, <synonym>, or <related-phrasing> — even if they don't explicitly say <skill_name>"). A bare one-line summary without trigger guidance is a fail (= under-triggers in practice).
 - The skill_path is correctly formatted as 'reyn/local/{skill_name}'.
 - The entry_phase is correctly identified and matches a phase name.
 - finish_criteria are relevant and clearly stated.
@@ -58,7 +58,7 @@ input: "Create a skill that generates a legal disclaimer and allows a reviewer t
 ### phase: plan_skill
 quality:
 - The generated skill_name is in snake_case.
-- The skill_description accurately summarizes the skill's purpose in one sentence.
+- The skill_description (a) accurately summarizes the skill's purpose AND (b) lists at least one trigger context / synonym set the chat router can match against (e.g. "Use whenever the user asks to <action>, <synonym>, or <related-phrasing> — even if they don't explicitly say <skill_name>"). A bare one-line summary without trigger guidance is a fail (= under-triggers in practice).
 - The skill_path is correctly formatted as 'reyn/local/{skill_name}'.
 - The entry_phase is correctly identified and matches a phase name.
 - finish_criteria are relevant and clearly stated.

--- a/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
@@ -79,7 +79,40 @@ Do NOT add review phases unless the output is subjective or hard to verify.
 ## Step 3 — Define structure
 
 skill_name: snake_case name of the target skill
-skill_description: one sentence describing what the skill does (used in `reyn skills` listing)
+skill_description: 1–2 sentences that the chat router uses to decide WHEN to dispatch this skill.
+  The router compares the user's turn against this string in addition to the skill name, so the
+  description is the **primary triggering signal** — not just human-facing documentation.
+
+  Reyn's chat router (like Claude generally) **under-triggers** skills by default — it tends to
+  hand-wave a request instead of dispatching the right skill when the description is too narrow
+  or too literal. Combat under-triggering by writing descriptions that are deliberately
+  **slightly pushy**: include the trigger contexts in the description itself, not just the
+  one-line summary.
+
+  Concretely, the description should answer **both** "what does this do?" and "when should it
+  fire?" — the latter listing the words/phrases/scenarios that should route here even when the
+  user does not name the skill explicitly.
+
+  Length guidance: ≤ 2 sentences total. ≤ 250 characters is comfortable; 300 is the soft cap.
+  Past that, the description starts to crowd out other skills' descriptions in the router's
+  context budget.
+
+  ❌ Too narrow (under-triggers):
+
+      description: Generate a short article on a topic.
+
+  ✅ Pushy + scoped (catches the natural phrasings):
+
+      description: Generate a short article on a topic. Use whenever the user asks to write,
+        draft, or compose a blog post, article, short essay, write-up, or any short-form prose
+        on a given subject — even if they don't explicitly say "article".
+
+  Do NOT pad descriptions with non-trigger fluff (= marketing-sounding phrases like "robust"
+  / "production-quality" / "powerful"). Every word should either say what the skill does or
+  signal a trigger context. If a `routing:` block exists on the target skill (= `when_to_use`
+  / `when_not_to_use` / `examples`), the bare `description` field still carries the under-trigger
+  weight, so keep it pushy independently of the routing block.
+
 skill_path: "reyn/local/{skill_name}"
 entry_phase: name of the first phase
 finish_criteria: 2–4 bullet strings describing when the TARGET workflow is done


### PR DESCRIPTION
**[e2e-coder]** — Adopts a pattern from Anthropic's `skill-creator` (= the canonical meta-skill in `github.com/anthropics/skills`): combat skill **under-triggering** by making the `description` field do double duty as both summary AND trigger guidance, not just summary.

## Background

Anthropic's skill-creator explicitly warns:

> Currently Claude has a tendency to "undertrigger" skills — to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "[that] … Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard'."

Reyn's `skill_builder` produced descriptions matching the "too narrow" pattern. The chat router compares the user turn against the bare `description` field — a one-line summary under-triggers in practice because the router doesn't see the synonym set or the natural phrasings the user is likely to use.

## Changes

### `src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md`

Expands the `skill_description` definition with:
- Framing as **primary triggering signal**, not just human-facing docs.
- "Pushy + scoped" pattern: cover BOTH what the skill does AND when it should fire, listing trigger contexts / synonyms in the description body.
- ❌ / ✅ example pair showing a too-narrow description vs a pushy + scoped one:
  ```
  ❌ Too narrow (under-triggers):
      description: Generate a short article on a topic.
  ✅ Pushy + scoped (catches the natural phrasings):
      description: Generate a short article on a topic. Use whenever the user asks to write,
        draft, or compose a blog post, article, short essay, write-up, or any short-form
        prose on a given subject — even if they don't explicitly say "article".
  ```
- Length guidance: ≤ 2 sentences, ≤ 250 chars comfortable, 300 soft cap.
- Anti-fluff: no marketing-sounding adjectives.
- Notes that the bare `description` carries under-trigger weight independently of any `routing:` block.

### `src/reyn/stdlib/skills/skill_builder/eval.md`

Updates the plan_skill quality criterion in both eval cases. A bare one-line summary without trigger guidance is now a fail.

## Test plan

- [x] `reyn skills validate skill_builder` → OK
- [x] **Rootdir** verify: `python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` → 5184 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed (= the 1 deselected = same pre-existing flake noted in PR #544 / #548 / #551 / #555 / #560)

## Out of scope (= deferred)

This is the smallest, highest-leverage change from the skill-creator comparison. Larger items for follow-ups:
- Generate a `routing:` block (= `when_to_use` / `when_not_to_use` / `examples`) on user-built skills. All stdlib skills have one; user-built skills don't.
- Iterative eval loop (= run generated skill on test prompts, surface failures, regenerate). Anthropic's `run_loop.py` pattern.
- Standalone `description_improver` skill (= Anthropic's `improve_description.py` analogue) that optimizes the description of an existing skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)