### PR TITLE
feat(tui): /find active-state header badge + RenderableCacheMixin migration

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -589,6 +589,10 @@ class OutboxRouter:
             # ghost from a previous one.
             self._find_query = None
             self._find_cursor_idx = None
+            try:
+                header.set_find_state(None)
+            except Exception:
+                pass
             self._show_transient_status(
                 conv,
                 f"no matches for '{query}'",
@@ -614,6 +618,17 @@ class OutboxRouter:
         # Seed cycle state so Ctrl+G picks up from here.
         self._find_query = query
         self._find_cursor_idx = target_idx
+        # Set the header find-state badge so the user has a persistent
+        # cue that /find mode is active. Position = 1-based index of
+        # the cursor's match in the sorted match list.
+        position = next(
+            (i + 1 for i, m in enumerate(matches) if m[0] == target_idx),
+            1,
+        )
+        try:
+            header.set_find_state(query, position, len(matches))
+        except Exception:
+            pass
         # Compose the status line. Showing the first 5 line numbers
         # gives the user a sense of distribution without overwhelming
         # the 1-line sticky budget. Same format the initial ``/find``
@@ -695,6 +710,10 @@ class OutboxRouter:
         if not matches:
             self._find_query = None
             self._find_cursor_idx = None
+            try:
+                self._app.query_one("#header", ReynHeader).set_find_state(None)
+            except Exception:
+                pass
             self._show_transient_status(
                 conv,
                 f"no matches for '{query}'",
@@ -729,10 +748,21 @@ class OutboxRouter:
         except Exception:
             pass
         self._find_cursor_idx = target_idx
-        # Same matched-line preview idea as ``_on_find`` — surface
-        # WHAT the cursor landed on so the user doesn't have to
-        # eyeball the viewport to confirm. ``matches[new_pos][1]``
-        # is the line content stored at search time.
+        # Refresh header badge with the new position so the user sees
+        # ``[find: 'q' 2/3]`` advance as they cycle. Total stays
+        # constant for the same buffer, but a buffer mutation between
+        # presses could shift it — recomputed every step.
+        try:
+            self._app.query_one("#header", ReynHeader).set_find_state(
+                query, new_pos + 1, len(matches),
+            )
+        except Exception:
+            pass
+        # Matched-line preview (= #563) — surface WHAT the cursor
+        # landed on so the user doesn't have to eyeball the viewport.
+        # ``matches[new_pos][1]`` is the line content stored at search
+        # time. Gated on non-empty snippet so whitespace-only lines
+        # don't dangle ``""`` quotes.
         snippet = _find_preview_snippet(matches[new_pos][1])
         body = (
             f"match {new_pos + 1}/{len(matches)} for '{query}' "

--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -20,6 +20,8 @@ from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Label
 
+from ._renderable_cache import RenderableCacheMixin
+
 # Trailing date suffix on a model id: ``-YYYYMMDD`` (8 digits) or the
 # ``-YYYY-MM-DD`` form. Both rotate per release and add 9-11 cells to
 # the header without changing within a session. Stripping them recovers
@@ -84,7 +86,7 @@ def _shorten_model_id(model: str) -> str:
     return stripped or model  # paranoia: never return empty
 
 
-class ReynHeader(Widget):
+class ReynHeader(RenderableCacheMixin, Widget):
     """Single-line status bar docked at the top of the screen."""
 
     DEFAULT_CSS = """
@@ -139,10 +141,25 @@ class ReynHeader(Widget):
         # mutation). Omitted from the status entirely when 0 so the
         # cold-default UX is unchanged.
         self._stalled_count: int = 0
+        # ``/find`` cycle-state badge — {"query", "position", "total"} dict
+        # when a /find query is active (= router has seeded cycle state),
+        # None otherwise. Surfaced as ``[find: 'q' 2/3]`` next to the
+        # ``[N pending]`` badge so the user has a persistent "you're in
+        # find mode" cue. The sticky status itself auto-hides after
+        # ~2.5 s, so without the header badge the user couldn't tell
+        # at a glance whether Ctrl+G is currently armed.
+        self._find_state: dict | None = None
+        # ``RenderableCacheMixin`` provides the cache slot +
+        # ``rendered_text`` accessor. Every ``Label.update`` is paired
+        # with ``self._set_rendered_cache(text)`` via the
+        # ``_repaint_status`` funnel so the cache stays in lockstep
+        # with the visible content.
 
     def compose(self) -> ComposeResult:
         yield Label("Reyn", id="title")
-        yield Label(self._format_status(), id="status")
+        initial = self._format_status()
+        self._set_rendered_cache(initial)
+        yield Label(initial, id="status")
 
     def on_mount(self) -> None:
         # Re-render once per second so the embedded clock stays current.
@@ -164,8 +181,20 @@ class ReynHeader(Widget):
         return time.strftime("%H:%M:%S")
 
     def _tick_clock(self) -> None:
+        self._repaint_status()
+
+    def _repaint_status(self) -> None:
+        """Render + cache the status Text, push to the Label widget.
+
+        Single funnel for "status changed → repaint" so the mixin's
+        cache stays in sync with what the user sees. Three sites
+        previously did ``Label.update(_format_status())`` directly;
+        they all delegate here now.
+        """
+        new_text = self._format_status()
+        self._set_rendered_cache(new_text)
         try:
-            self.query_one("#status", Label).update(self._format_status())
+            self.query_one("#status", Label).update(new_text)
         except Exception:
             pass
 
@@ -308,6 +337,18 @@ class ReynHeader(Widget):
             parts.append(
                 (f"[{self._stalled_count} pending]", "#ffaa44"),
             )
+        # ``/find`` active-state badge — placed alongside [N pending]
+        # as a sibling "active state" indicator. Subtle blue
+        # (= ``#88aacc``) so it doesn't compete with the amber pending
+        # marker or red error styling; complementary palette signals
+        # "informational state, no action required".
+        if self._find_state is not None:
+            fs = self._find_state
+            badge = (
+                f"[find: '{fs.get('query', '')}' "
+                f"{fs.get('position', 0)}/{fs.get('total', 0)}]"
+            )
+            parts.append((badge, "#88aacc"))
         # Clock always present, last — the canary for "is the UI frozen?"
         parts.append((self._now_text(), None))
 
@@ -347,11 +388,35 @@ class ReynHeader(Widget):
             self._cost_cap = cost_cap
         if stalled_count is not None:
             self._stalled_count = max(0, int(stalled_count))
-        try:
-            label = self.query_one("#status", Label)
-            label.update(self._format_status())
-        except Exception:
-            pass
+        self._repaint_status()
+
+    def set_find_state(
+        self,
+        query: str | None,
+        position: int = 0,
+        total: int = 0,
+    ) -> None:
+        """Update or clear the ``/find`` active-state badge.
+
+        ``query=None`` clears the badge (= no /find currently active).
+        Any non-empty query installs the badge as
+        ``[find: 'q' position/total]``. The header re-renders only
+        when the new state differs from the previous, so a stream
+        of redundant updates from the router doesn't generate paint
+        churn.
+        """
+        if query is None:
+            new_state: dict | None = None
+        else:
+            new_state = {
+                "query": query,
+                "position": int(position),
+                "total": int(total),
+            }
+        if new_state == self._find_state:
+            return
+        self._find_state = new_state
+        self._repaint_status()
 
     def on_reyn_header_status_update(self, msg: StatusUpdate) -> None:
         """Handle StatusUpdate message."""

--- a/tests/cli/test_find_active_state_header.py
+++ b/tests/cli/test_find_active_state_header.py
@@ -1,0 +1,292 @@
+"""Tier 2: ReynHeader surfaces a ``[find: 'q' N/M]`` badge while cycle is active.
+
+Categorical UX gap on the /find surface. The sticky status auto-
+hides after ~2.5 s; without a persistent indicator, the user
+can't tell at a glance whether ``Ctrl+G`` is currently armed (=
+whether a /find query is still active in the router's cycle
+state). This adds a small subtle-blue badge to the header that
+stays visible while the cycle state is non-empty.
+
+Status shape:
+
+  agent · model · 1,234 tok · $0.01 · [3 pending] · [find: 'foo' 2/5] · 14:23:01
+
+Public surfaces tested:
+  - ``ReynHeader.set_find_state(query, position, total)`` installs
+    the badge
+  - ``set_find_state(None)`` clears the badge
+  - Equality-gated repaint: idempotent calls don't churn the
+    Static (defensive against router-side noise)
+  - ``_format_status`` includes the badge in the rendered Text
+    when state is set, omits it when None
+  - Initial ``_on_find`` seeds the badge with the cursor match
+    position
+  - Ctrl+G cycle updates the badge to the new position
+  - No-match clear branches drop the badge
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from rich.text import Text
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _seed(conv, lines: list[str]) -> None:
+    log = conv._log()
+    for line in lines:
+        log.write(Text(line))
+
+
+def _header_text(header) -> str:
+    """Plain-text rendering of the header's status label.
+
+    Reads ``ReynHeader.rendered_text()`` (= the inherited
+    ``RenderableCacheMixin`` accessor) which caches the most
+    recent Text sent to ``Label.update``. Textual's Label has no
+    portable ``.renderable`` accessor across versions.
+    """
+    return header.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_header_inherits_renderable_cache_mixin() -> None:
+    """Tier 2: ReynHeader migrated to RenderableCacheMixin (= #568 follow-on).
+
+    Pins the inheritance so the rendered_text() accessor flows
+    through the shared mixin, not a per-widget duplicate. Same
+    pattern as SkillActivityRow + SlashPicker + ToolCallRow.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        assert isinstance(header, RenderableCacheMixin)
+        # Accessor exists and returns a string (= initial render set
+        # by ``compose``).
+        assert isinstance(header.rendered_text(), str)
+
+
+@pytest.mark.asyncio
+async def test_set_find_state_renders_badge() -> None:
+    """Tier 2: set_find_state(...) makes the badge visible in the header."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_find_state("foo", position=2, total=5)
+        await pilot.pause()
+        text = _header_text(header)
+        assert "[find: 'foo' 2/5]" in text
+
+
+@pytest.mark.asyncio
+async def test_set_find_state_none_clears_badge() -> None:
+    """Tier 2: passing ``None`` clears the badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_find_state("foo", position=1, total=1)
+        await pilot.pause()
+        assert "[find:" in _header_text(header)
+        header.set_find_state(None)
+        await pilot.pause()
+        assert "[find:" not in _header_text(header)
+
+
+@pytest.mark.asyncio
+async def test_set_find_state_idempotent_no_repaint_churn() -> None:
+    """Tier 2: redundant calls don't trigger unnecessary repaints.
+
+    Equality-gate: when the new state == the previous state, the
+    function early-returns without touching the Static. Pin this
+    so router-side noise (= per-frame re-seeds) doesn't generate
+    paint churn.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_find_state("foo", 1, 3)
+        await pilot.pause()
+        first_state = dict(header._find_state)  # snapshot
+        # Same call again — should be a no-op.
+        header.set_find_state("foo", 1, 3)
+        await pilot.pause()
+        # Internal state unchanged (= still the same dict shape).
+        assert header._find_state == first_state
+
+
+@pytest.mark.asyncio
+async def test_on_find_sets_header_badge() -> None:
+    """Tier 2: initial /find sets the header badge with the cursor's position."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        _seed(conv, ["needle one", "filler", "needle two"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="needle"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        text = _header_text(header)
+        # Badge should report 2 matches total.
+        assert "[find: 'needle' 1/2]" in text
+
+
+@pytest.mark.asyncio
+async def test_cycle_find_updates_header_position() -> None:
+    """Tier 2: Ctrl+G advances the badge position alongside the cursor."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        _seed(conv, ["needle one", "filler", "needle two", "filler", "needle three"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="needle"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert "[find: 'needle' 1/3]" in _header_text(header)
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert "[find: 'needle' 2/3]" in _header_text(header)
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert "[find: 'needle' 3/3]" in _header_text(header)
+
+
+@pytest.mark.asyncio
+async def test_no_match_branch_clears_header_badge() -> None:
+    """Tier 2: /find with zero matches clears any prior badge.
+
+    After a successful /find foo (badge set), running /find
+    nonexistent should clear the badge — the prior find mode is
+    no longer relevant.
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        _seed(conv, ["needle"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="needle"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert "[find:" in _header_text(header)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="zzz-no-match"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert "[find:" not in _header_text(header)
+
+
+@pytest.mark.asyncio
+async def test_buffer_mutation_clears_badge_via_cycle() -> None:
+    """Tier 2: when buffer empties, Ctrl+G clears the badge alongside state."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        _seed(conv, ["alpha", "beta"])
+        await pilot.pause()
+        router = OutboxRouter(app)
+        router._on_find(
+            OutboxMessage(kind="__find__", text="alpha"),
+            conv,
+            header,
+        )
+        await pilot.pause()
+        assert "[find:" in _header_text(header)
+        # Wipe the buffer (= Ctrl+L equivalent).
+        conv.clear()
+        await pilot.pause()
+        router.cycle_find(+1)
+        await pilot.pause()
+        assert "[find:" not in _header_text(header)
+
+
+@pytest.mark.asyncio
+async def test_badge_appears_before_clock() -> None:
+    """Tier 2: badge sits before the clock canary, not after.
+
+    The clock is always rightmost (= canary for "is the UI
+    frozen?"). The find badge should land left of it so the
+    canary contract isn't disturbed.
+    """
+    import re
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_find_state("xxx", 1, 1)
+        await pilot.pause()
+        text = _header_text(header)
+        clock_match = re.search(r"\d{2}:\d{2}:\d{2}", text)
+        assert clock_match is not None
+        badge_idx = text.find("[find:")
+        assert badge_idx >= 0
+        assert badge_idx < clock_match.start(), (
+            f"badge at {badge_idx} should be left of clock at "
+            f"{clock_match.start()}: {text!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Rebased + extended. Original scope (#565): add a persistent `[find: 'q' N/M]` badge to the header so the user has a "find mode active" cue that survives the sticky-status auto-hide. Extended scope (= today's user-chosen follow-on): **migrate ReynHeader to RenderableCacheMixin** (#568 follow-on) so the local cache pattern collapses into the shared mixin.

## Status shape

```
agent · model · 1,234 tok · $0.01 · [find: 'foo' 2/5] · 14:23:01
```

Subtle blue badge alongside the existing `[N pending]` indicator, placed before the clock canary so the rightmost-position contract stays intact.

## Two folded changes

### 1. Active-state badge (= original #565 scope, rebased)

- `ReynHeader.set_find_state(query, position, total)` installs the badge; `query=None` clears.
- **Equality-gated repaint**: idempotent calls early-return so router-side noise doesn't churn the Static.
- `_format_status` renders `[find: 'q' N/M]` as a peer of `[N pending]`. Subtle blue (`#88aacc`) avoids competing with amber pending / red error styling.
- `app_outbox._on_find` seeds the badge with the cursor's 1-based position; `cycle_find` refreshes on every Ctrl+G step; no-match branches clear via `set_find_state(None)`.

### 2. RenderableCacheMixin migration (= #568 follow-on, deferred to here)

- `class ReynHeader(RenderableCacheMixin, Widget)`.
- Local `_rendered_status_cache` field removed — mixin provides storage.
- Local `rendered_status_text()` accessor removed — mixin provides `rendered_text()` instead.
- All `Label.update(...)` sites paired with `self._set_rendered_cache(...)` via the `_repaint_status` funnel.
- Test helper updated to `header.rendered_text()` (= the inherited mixin accessor).

## Cycle_find conflict resolution

Main now has `_find_preview_snippet` integration in `cycle_find` (= #563's matched-line preview). The rebase merged the two features so cycle_find both:

1. Refreshes the header badge with the new position
2. Surfaces the matched-line content preview in the status sticky

Both behaviors land on every Ctrl+G step. Tier 2 coverage in #563 and this PR confirm neither path regresses.

## Why fold the migration into this PR

- The rebase had to merge `_repaint_status` (= the find-badge cache funnel) with the new mixin pattern anyway. Doing both in one commit avoids a follow-on PR that just renames `rendered_status_text` → `rendered_text` after this one lands.
- ReynHeader is the 3rd Static-cache widget; the mixin extraction in #568 explicitly deferred this migration. Closing the loop here makes the refactor complete.

## Test plan

- [x] `pytest tests/cli/test_find_active_state_header.py` — 9/9 pass (set/clear, idempotence, _on_find seeds, cycle updates, no-match clears, buffer mutation clears, badge before clock, **new**: mixin inheritance regression guard)
- [x] `pytest tests/cli/test_find_match_line_preview.py` — 8/8 pass (= #563 regression: cycle_find still surfaces line preview)
- [x] `pytest tests/cli/test_find_cycle_navigation.py` — 8/8 pass (= #539 regression)
- [x] `pytest tests/cli/test_renderable_cache_mixin.py` — 7/7 pass (= #568 mixin itself unaffected)
- [x] `pytest tests/cli/` — 612/612 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, type `/find <word>` — header shows `[find: 'word' 1/N]` + status sticky shows match preview. Ctrl+G advances both. `/find nonexistent` — badge clears. Header clock keeps ticking (= no `Label.update` regression from the migration).
- [x] (skipped — visual styling validation via Tier 2 substring checks on the rendered status text)

## Out of scope (deferred)

- Explicit "clear find mode" keybinding. Currently the badge clears on no-match cycles, new /find, or Ctrl+L (buffer wipe). Defer until requested.
- Per-flag indicator (= `[find: 'foo' 2/5 r]` for regex / `c` for case-sensitive). Could add but adds visual width; defer.
