### PR TITLE
feat(skill_improver): Step 4c — propose description pushy rewrite for under-triggering

### DIFF
--- a/src/reyn/stdlib/skills/skill_improver/phases/plan_improvements.md
+++ b/src/reyn/stdlib/skills/skill_improver/phases/plan_improvements.md
@@ -111,6 +111,47 @@ Empty `[]` for pure decision phases. The runtime default `[file, ask_user]`
 is permissive — meta-skills should explicitly tighten it when the eval
 shows drift.
 
+### Step 4c — Consider rewriting `description` for trigger accuracy
+
+The `description` field in the target skill's `skill.md` is the **primary
+triggering signal** the chat router compares the user's turn against.
+A "too narrow" description causes **under-triggering**: the router
+hand-waves the request instead of dispatching the right skill when the
+user's phrasing doesn't literally include the skill's name.
+
+This pattern is invisible to `eval.md`-driven scoring (= eval measures
+correctness when the skill IS invoked, not whether the router picks it).
+Two signals to watch for:
+
+  1. **User's `improvement_focus` mentions** "trigger", "description",
+     "routing", "under-trigger", "doesn't fire", "doesn't get picked", or
+     similar — the user has noticed the under-trigger problem directly.
+  2. **Eval evidence is thin** but the user reports the skill "isn't being
+     used" — the eval criteria pass when invoked, so the gap is at the
+     router-decision layer, not the phase-execution layer.
+
+When either signal is present, propose an `update` to the target skill's
+`skill.md` rewriting the `description` field using the pushy pattern
+established in `skill_builder/phases/plan_skill.md`:
+
+  - Cover BOTH what the skill does AND when it should fire.
+  - List the synonym set / trigger contexts the user is likely to use.
+  - Keep ≤ 2 sentences, ≤ ~250 chars (300 soft cap).
+  - No marketing fluff — every word is either capability or trigger.
+
+Example shape:
+
+```
+description: <one-sentence what>. Use whenever the user asks to <action1>,
+  <action2>, or <related-phrasing> — even if they don't explicitly say
+  "<skill_name>".
+```
+
+Treat this as one candidate `update` change in your plan. If the skill
+already has a pushy + trigger-aware description (= explicit "Use whenever
+…" or equivalent), and the user's reported problem is something else,
+do NOT touch the description.
+
 ## Output
 
 Emit `improvement_plan` with:


### PR DESCRIPTION
**[e2e-coder]** — Extends ``skill_improver``'s ``plan_improvements`` phase with a new diagnosis-then-fix tactic for the under-trigger pattern that PR #564 prevents at build time.

## Background

PR #564 landed pushy + trigger-aware descriptions as a **build-time** default for new skills via ``skill_builder/plan_skill``. That covers prevention for skills written from scratch.

But existing skills suffer the same under-trigger problem:
- User skills written before PR #564.
- Skills brought in via ``skill_importer`` whose descriptions are tuned for Claude's router rather than Reyn's.
- Any skill the user reports "isn't being used" — the chat router hand-waves the request instead of dispatching.

``skill_improver`` is the natural tool to fix them. Rather than build a separate ``description_improver`` skill (= mostly overlaps with skill_improver's existing scope), this PR teaches skill_improver to **recognize the under-trigger pattern** and propose a description rewrite as one tactic in its existing plan→apply loop.

## What's new

`src/reyn/stdlib/skills/skill_improver/phases/plan_improvements.md`

Adds **Step 4c — Consider rewriting `description` for trigger accuracy** alongside the existing Step 4a (Python preprocessor) and Step 4b (allowed_ops tightening).

**Triggering conditions** (= when the LLM should propose this):
1. User's ``improvement_focus`` mentions trigger / description / routing / under-trigger / "doesn't fire" / similar.
2. Eval evidence is thin but the user reports the skill "isn't being used" — the gap is at the router-decision layer, not the phase-execution layer.

**Pattern reused verbatim from PR #564** for consistency: ≤ 2 sentences / ≤ ~250 chars / both "what does it do" AND "when should it fire" / synonym set in description body / no marketing fluff.

**Guardrail**: if the skill already has a pushy + trigger-aware description (= explicit "Use whenever …" or equivalent), and the user's reported problem is something else, do NOT touch the description.

## Why not a separate ``description_improver`` skill?

Considered + rejected for now:
- **Lite version** (= 1-shot rewrite) overlaps 100% with skill_improver's existing plan→apply on a single field. The eval.md requirement is the only practical gap, but for a single-field rewrite the loop terminates after one pass anyway.
- **Full version** (= router simulation, novel) is a genuinely new capability but the demand isn't there yet. Defer until a real under-trigger case in practice can't be solved by Step 4c.

Net: this PR is the smallest path that covers the post-build improvement gap without adding a redundant skill.

## Scope discipline

- One new section, mirrors the structure of Steps 4a/4b.
- The eval-driven loop is unchanged; this is just one more tactic the planner considers.
- No new input fields, no new graph edges, no new artifacts.
- Entry point: existing ``improvement_focus`` free-text field — users who write "improve description" or "skill isn't triggering" get the new behaviour automatically.

## Test plan

- [x] `reyn skills validate skill_improver` → OK
- [x] **Rootdir** verify: `python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` → 5192 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed (= the 1 deselected = same pre-existing flake noted in PR #544 / #548 / #551 / #555 / #560 / #564)

## Related

- PR #564 (build-time prevention): `skill_builder/plan_skill` writes pushy descriptions for new skills.
- This PR (post-build remediation): `skill_improver` proposes pushy rewrites for existing skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)