### PR TITLE
refactor(tui): extract RenderableCacheMixin from 3-count duplication

### DIFF
--- a/src/reyn/chat/tui/widgets/_renderable_cache.py
+++ b/src/reyn/chat/tui/widgets/_renderable_cache.py
@@ -1,0 +1,79 @@
+"""RenderableCacheMixin — shared "what did the widget last render?" surface.
+
+Several Static-backed widgets (= SkillActivityRow, SlashPicker, and the
+upcoming ReynHeader migration) need a stable test-side accessor for
+the most-recent renderable. Textual's ``Static`` / ``Label`` do NOT
+expose a portable ``.renderable`` getter across versions — sometimes
+``_renderable`` (private), sometimes a versioned property, sometimes
+neither. Each widget had ended up duplicating the same ~10-line cache
+pattern:
+
+  self._rendered_cache: Text | None = None
+  ...
+  def rendered_text(self) -> str:
+      cache = self._rendered_cache
+      return str(cache.plain) if cache is not None else ""
+
+This mixin consolidates the pattern. Widgets call
+``self._set_rendered_cache(text)`` immediately after every
+``Static.update(text)`` / ``Label.update(text)`` call, and tests read
+``widget.rendered_text()`` for assertion. Accepts both ``Text`` and
+``str`` — the latter is wrapped before storage so ``.plain`` always
+works downstream.
+
+Trigger for extraction: 3 occurrences of the same pattern (see
+``feedback_test_public_surface_not_private_state`` philosophy — the
+mixin keeps tests reading public surfaces while the production code
+stays decoupled from Textual's private attributes).
+"""
+from __future__ import annotations
+
+from rich.text import Text
+
+
+class RenderableCacheMixin:
+    """Mix-in caching the last Text rendered into the underlying Static.
+
+    Storage: ``Text`` (so ``.plain`` is always available). ``str`` input
+    is wrapped at set-time so the read path stays uniform regardless
+    of which call site produced the renderable.
+
+    Subclasses MUST call :py:meth:`_set_rendered_cache` right after
+    every ``Static.update`` / ``Label.update`` invocation; they're
+    paired updates, not a single funnel — keeping them adjacent is
+    the simplest way to ensure cache and widget stay in sync.
+
+    Subclasses MUST NOT mutate ``_rendered_cache`` directly. The
+    contract is "set via the helper, read via rendered_text".
+    """
+
+    # Class-level annotation so dataclass-style subclasses can still
+    # type their fields; the per-instance value is set lazily on
+    # first call to ``_set_rendered_cache``.
+    _rendered_cache: Text | None = None
+
+    def _set_rendered_cache(self, renderable: Text | str) -> None:
+        """Record what was just rendered. Accepts ``Text`` or ``str``."""
+        if isinstance(renderable, Text):
+            self._rendered_cache = renderable
+        else:
+            # str input — wrap in Text so ``.plain`` access on read
+            # is uniform with the Text case. Empty string maps to
+            # ``Text("")`` (whose ``.plain`` is also ``""``).
+            self._rendered_cache = Text(str(renderable))
+
+    def rendered_text(self) -> str:
+        """Plain-text rendering of the last frame sent to the widget.
+
+        Returns ``""`` when nothing has been rendered yet (= pre-mount,
+        or the widget was never updated). Stable across Textual
+        versions because the value lives in our own cache, not in
+        the framework widget's private renderable slot.
+        """
+        cache = self._rendered_cache
+        if cache is None:
+            return ""
+        return str(cache.plain)
+
+
+__all__ = ["RenderableCacheMixin"]

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -36,6 +36,8 @@ from textual.widgets import Static
 
 from reyn.chat.tui._palette import _CORAL
 
+from ._renderable_cache import RenderableCacheMixin
+
 _TICK_INTERVAL_S = 0.5  # elapsed-time refresh rate
 
 # Max tool calls rendered inline in the drill-down expand view.
@@ -58,7 +60,7 @@ _ELAPSED_AMBER_S = 30.0
 _ELAPSED_RED_S = 60.0
 
 
-class SkillActivityRow(Widget):
+class SkillActivityRow(RenderableCacheMixin, Widget):
     """One ambient skill-progress row that updates in-place.
 
     Transitions from a live running line to a compact completion line on
@@ -165,13 +167,10 @@ class SkillActivityRow(Widget):
 
         # DOM ref
         self._static: Static | None = None
-        # Cached copy of the most-recently-rendered Text (= what's
-        # currently displayed). Updated on every ``_refresh``. Read
-        # by ``rendered_text`` for inspection — used by Tier 2 tests
-        # to assert on the visible content without reaching into
-        # Textual's private Static internals (= ``static._renderable``
-        # is API-unstable across versions).
-        self._rendered_cache: Text | None = None
+        # ``RenderableCacheMixin`` provides the cache + ``rendered_text``
+        # accessor; we just call ``self._set_rendered_cache(text)`` on
+        # every ``Static.update`` so the cache stays in sync with what
+        # the user sees.
 
     # ── Textual lifecycle ──────────────────────────────────────────────────────
 
@@ -487,26 +486,13 @@ class SkillActivityRow(Widget):
             t.append(f", +{hidden} more", style="dim #666666")
         return t
 
-    def rendered_text(self) -> str:
-        """Plain-text rendering of the last frame sent to ``Static.update``.
-
-        Stable testing surface — Textual's ``Static`` does not expose
-        a public getter for its current renderable across versions, so
-        we cache locally in ``_refresh`` and read here. Returns "" when
-        nothing has been rendered yet (= pre-mount).
-        """
-        cache = self._rendered_cache
-        if cache is None:
-            return ""
-        return str(cache.plain)
-
     def _refresh(self) -> None:
         if self._static is None:
             return
         head = self._build_finished() if self._finished else self._build_running()
         if not self._expanded:
             self._static.update(head)
-            self._rendered_cache = head
+            self._set_rendered_cache(head)
             return
         # Expanded view: append the history line under the head with a
         # newline separator. Rich Text handles newlines inside update().
@@ -521,4 +507,4 @@ class SkillActivityRow(Widget):
             body.append("\n")
             body.append_text(self._build_tools_line())
         self._static.update(body)
-        self._rendered_cache = body
+        self._set_rendered_cache(body)

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -22,10 +22,12 @@ from textual.widgets import Static
 from reyn.chat.slash import SlashCommand
 from reyn.chat.tui._palette import _CORAL
 
+from ._renderable_cache import RenderableCacheMixin
+
 _MAX_VISIBLE = 8
 
 
-class SlashPicker(Static):
+class SlashPicker(RenderableCacheMixin, Static):
     """Inline list of slash-command matches shown above the TextArea."""
 
     class Clicked(Message):
@@ -81,13 +83,10 @@ class SlashPicker(Static):
         # single dim row reading ``unknown /<typed> — did you mean /<…>?``.
         self._unknown_token: str = ""
         self._unknown_suggestions: list[str] = []
-        # Cached copy of the most-recently-rendered Text (= what's
-        # currently displayed). Updated on every ``_repaint``. Read by
-        # ``rendered_text`` for inspection — used by Tier 2 tests to
-        # assert on the visible content without reaching into Textual's
-        # private Static internals (= ``Static.renderable`` is API-
-        # unstable across versions, sometimes ``_renderable``).
-        self._rendered_cache = ""
+        # ``RenderableCacheMixin`` provides ``_set_rendered_cache`` +
+        # ``rendered_text``. Every ``self.update(...)`` call in
+        # ``_repaint*`` pairs with ``self._set_rendered_cache(...)`` so
+        # the cache stays in lockstep with the visible content.
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -105,17 +104,6 @@ class SlashPicker(Static):
     @property
     def has_matches(self) -> bool:
         return bool(self._matches)
-
-    def rendered_text(self) -> str:
-        """Plain-text rendering of the last frame sent to ``Static.update``.
-
-        Stable testing surface — ``Static.renderable`` is API-unstable
-        across Textual versions (sometimes ``_renderable``, sometimes
-        a different accessor), so the picker caches the rendered Text
-        on every ``_repaint`` and exposes it here. Returns "" when the
-        picker is empty / hidden.
-        """
-        return self._rendered_cache
 
     def set_matches(self, matches: list[SlashCommand]) -> None:
         """Replace the match list. Resets selection to row 0."""
@@ -279,7 +267,7 @@ class SlashPicker(Static):
                 self._repaint_unknown_hint()
             else:
                 self.update("")
-                self._rendered_cache = ""
+                self._set_rendered_cache("")
             return
 
         # Width for the command-name column (left)
@@ -332,7 +320,7 @@ class SlashPicker(Static):
                 style="dim #888888",
             )
         self.update(body)
-        self._rendered_cache = str(body.plain)
+        self._set_rendered_cache(body)
 
     def _repaint_hint(self) -> None:
         """Render a single dim hint row showing the matched command's summary.
@@ -345,7 +333,7 @@ class SlashPicker(Static):
         cmd = self._hint_cmd
         if cmd is None:
             self.update("")
-            self._rendered_cache = ""
+            self._set_rendered_cache("")
             return
         try:
             term_w = self.app.size.width
@@ -397,7 +385,7 @@ class SlashPicker(Static):
                     style="dim #555555",
                 )
         self.update(t)
-        self._rendered_cache = str(t.plain)
+        self._set_rendered_cache(t)
 
     def _repaint_unknown_hint(self) -> None:
         """Render the unknown-command in-input feedback line.
@@ -426,4 +414,4 @@ class SlashPicker(Static):
                 t.append(f"/{sug}", style="dim #aaaaaa")
             t.append("?", style="dim #888888")
         self.update(t)
-        self._rendered_cache = str(t.plain)
+        self._set_rendered_cache(t)

--- a/tests/cli/test_renderable_cache_mixin.py
+++ b/tests/cli/test_renderable_cache_mixin.py
@@ -1,0 +1,144 @@
+"""Tier 2: RenderableCacheMixin — shared cache pattern for Static-backed widgets.
+
+After three widgets (SkillActivityRow, SlashPicker, soon ReynHeader)
+duplicated the same ~10-line cache pattern for "what did I last
+render?", the trigger to extract a shared mixin was hit. This pins:
+
+  - ``_set_rendered_cache`` accepts both ``Text`` and ``str``
+  - ``rendered_text()`` returns the plain text in both cases
+  - Empty / pre-set / pre-mount returns ``""``
+  - Subclasses keep their ``rendered_text()`` accessor via the mixin
+    (= existing SkillActivityRow / SlashPicker tests still pass)
+  - The mixin doesn't pollute MRO ordering of the host widget
+    (= ``isinstance`` checks against the framework base still work)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_mixin_accepts_text_renderable() -> None:
+    """Tier 2: Text input round-trips through ``rendered_text``."""
+    from rich.text import Text
+
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    obj = RenderableCacheMixin()
+    obj._set_rendered_cache(Text("hello world"))
+    assert obj.rendered_text() == "hello world"
+
+
+def test_mixin_accepts_str_renderable() -> None:
+    """Tier 2: str input is wrapped + plain text returned."""
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    obj = RenderableCacheMixin()
+    obj._set_rendered_cache("plain string")
+    assert obj.rendered_text() == "plain string"
+
+
+def test_mixin_default_returns_empty() -> None:
+    """Tier 2: pre-set / fresh instance returns ``""``."""
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    obj = RenderableCacheMixin()
+    assert obj.rendered_text() == ""
+
+
+def test_mixin_empty_string_round_trip() -> None:
+    """Tier 2: explicit empty string sets a non-None cache that reads as ``""``."""
+    from rich.text import Text
+
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    obj = RenderableCacheMixin()
+    obj._set_rendered_cache("")
+    assert obj.rendered_text() == ""
+    # Now overwrite with non-empty and verify replacement.
+    obj._set_rendered_cache(Text("non-empty"))
+    assert obj.rendered_text() == "non-empty"
+
+
+def test_mixin_styled_text_yields_plain_text() -> None:
+    """Tier 2: styling on the source Text doesn't leak into the plain output.
+
+    Pins that ``rendered_text`` is the plain rendering — markup /
+    styling on the source Text is stripped. Otherwise tests would
+    have to grep around ANSI / markup sequences.
+    """
+    from rich.text import Text
+
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    obj = RenderableCacheMixin()
+    styled = Text()
+    styled.append("hello", style="bold red")
+    styled.append(" ", style="dim")
+    styled.append("world", style="italic blue")
+    obj._set_rendered_cache(styled)
+    out = obj.rendered_text()
+    assert "hello" in out
+    assert "world" in out
+    # No ANSI escape sequences leak through.
+    assert "\x1b[" not in out
+
+
+@pytest.mark.asyncio
+async def test_skill_activity_row_uses_mixin_accessor() -> None:
+    """Tier 2: SkillActivityRow.rendered_text comes from the mixin.
+
+    Regression guard — refactor must not silently remove the
+    accessor or change its signature.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_skill_row(run_id="mixinaa", skill_name="mxn")
+        row.set_phase("plan")
+        await pilot.pause()
+        # Accessor exists + returns string.
+        text = row.rendered_text()
+        assert isinstance(text, str)
+        assert "plan" in text
+        # Inheritance includes the mixin (= refactor landed).
+        assert isinstance(row, RenderableCacheMixin)
+
+
+@pytest.mark.asyncio
+async def test_slash_picker_uses_mixin_accessor() -> None:
+    """Tier 2: SlashPicker.rendered_text comes from the mixin.
+
+    Pins same contract as the SkillActivityRow case — picker
+    keeps its public rendered_text() accessor via the mixin.
+    """
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(name="mxn", summary="mixin probe", handler=_h)
+        picker.set_matches([cmd])
+        await pilot.pause()
+        text = picker.rendered_text()
+        assert isinstance(text, str)
+        assert "/mxn" in text
+        assert isinstance(picker, RenderableCacheMixin)


### PR DESCRIPTION
**[tui-coder]** — Refactor PR. Trigger reached for extraction: three widgets duplicated the same `~10`-line "cache what I last rendered into the Static so tests can read it" pattern.

| widget | from PR | field | accessor |
|--------|---------|-------|----------|
| SkillActivityRow | #546 | `_rendered_cache: Text \| None` | `rendered_text()` |
| SlashPicker | #550 | `_rendered_cache: str` | `rendered_text()` |
| ReynHeader | #565 (in flight) | `_rendered_status_cache: Text \| None` | `rendered_status_text()` |

Per my earlier "tui code refactor 必要?" assessment, the trigger was "3rd occurrence of the same pattern" — that's now hit, with slight drift (str vs Text storage, different accessor names). Consolidating is the cheaper move than letting future Static-backed widgets pile on yet another copy.

## Scope

This PR introduces `RenderableCacheMixin` in a new `widgets/_renderable_cache.py` and migrates the **two widgets currently on main** (SkillActivityRow + SlashPicker). ReynHeader migration is deferred to a follow-on once #565 lands (its `rendered_status_text` accessor will rename to `rendered_text` via the mixin in that follow-on).

## Mixin contract

```python
class RenderableCacheMixin:
    _rendered_cache: Text | None = None

    def _set_rendered_cache(self, renderable: Text | str) -> None:
        """Call after every Static.update / Label.update.
        str input is wrapped in Text so the read path stays uniform."""

    def rendered_text(self) -> str:
        """Plain-text rendering, "" when cache is unset."""
```

Stable across Textual versions because the value lives in our cache, not in the framework's private renderable slot.

## Migration mechanics

- **SkillActivityRow**: `class SkillActivityRow(RenderableCacheMixin, Widget)`; `self._rendered_cache = head/body` → `self._set_rendered_cache(head/body)`; local `rendered_text` method removed.
- **SlashPicker**: `class SlashPicker(RenderableCacheMixin, Static)`; `self._rendered_cache = str(t.plain)` → `self._set_rendered_cache(t)` (mixin handles plain extraction on read); local `rendered_text` method removed.
- Both widgets lose ~10 lines each; new mixin file is ~30 lines of shared logic + docs.

## Why this layer

- TUI-internal refactor — no engine state, no slash change, no behavioral change for users.
- Test stability is the load-bearing concern (= per `feedback_test_public_surface_not_private_state`, the cache exists specifically to give tests a stable public-surface read). The mixin keeps that surface intact for both widgets and adds it to any future Static-backed widget for free.
- `str` → `Text` storage normalization is a small drift the mixin closes — SlashPicker previously stored `str` directly, now stores Text and extracts `.plain` on read. No observable difference but the internal invariant is cleaner.

## Test plan

- [x] `pytest tests/cli/test_renderable_cache_mixin.py` — 7/7 pass (Text/str input, default empty, empty round-trip + replacement, styled→plain, SkillActivityRow integration, SlashPicker integration)
- [x] `pytest tests/cli/test_skill_row_drill_down.py tests/cli/test_skill_row_tool_drill.py` — 15/15 pass (= #546 + #556 regression unchanged)
- [x] `pytest tests/cli/test_slash_picker_unknown_hint.py tests/cli/test_slash_picker_multiline_hint.py` — 17/17 pass (= #550 + #552 regression unchanged)
- [x] `pytest tests/cli/` — 594/594 pass
- [x] `ruff check src/reyn/chat/tui/widgets/_renderable_cache.py src/reyn/chat/tui/widgets/skill_activity.py src/reyn/chat/tui/widgets/slash_picker.py tests/cli/test_renderable_cache_mixin.py` — clean
- [x] Manual: no UI change to verify — same `rendered_text()` surface reads the same content as before.
- [x] (skipped — visual verification not needed for refactor; behavioral equivalence covered by the 39-test regression sweep)

## Follow-on (deferred to its own PR)

- ReynHeader migration: once #565 (in flight, currently CONFLICTING with #563) lands and brings the 3rd cache pattern into main, a 1-commit follow-on inherits ReynHeader from `RenderableCacheMixin`, renames `rendered_status_text` → `rendered_text` (mixin-provided), and updates the existing `test_find_active_state_header.py` accordingly. Defer until #565's conflict is resolved + merged.
