### PR TITLE
feat(skill_builder): generate a routing block on user-built skills (under-trigger 3-PR closure)

### DIFF
--- a/src/reyn/stdlib/skills/skill_builder/artifacts/skill_plan.yaml
+++ b/src/reyn/stdlib/skills/skill_builder/artifacts/skill_plan.yaml
@@ -158,6 +158,72 @@ schema:
           type: object
           description: JSON Schema object for the final output's data fields.
       required: [name, description, schema]
+    routing:
+      type: object
+      description: |
+        Structured routing hints the chat router uses alongside the bare
+        `description` to decide WHEN to dispatch this skill. Mirrors the
+        structure used by every stdlib skill — populating it puts new
+        user-built skills on the same triggering footing as the built-ins.
+        All sub-fields are required even if some are empty lists. Missing
+        routing leaves the router with only `description` to match against,
+        which is the under-triggering trap PR #564 / #567 already partially
+        address at the description layer.
+      properties:
+        intents:
+          type: array
+          description: |
+            Intent kinds the router associates with this skill. Almost
+            always [task] for action-oriented skills. Use
+            [stable_knowledge] only for Q&A skills that answer factual
+            questions about a fixed domain (rare for user-built skills).
+          items:
+            type: string
+            enum: [task, stable_knowledge]
+        when_to_use:
+          type: array
+          description: |
+            Concrete trigger scenarios — third-person phrases the router
+            matches against the user's turn semantics. 2-5 entries.
+            Examples: "User wants to build a dashboard", "User mentions
+            data visualization". Should overlap with the synonyms in
+            `skill_description` but written as scenario descriptions
+            rather than imperative trigger phrases.
+          items:
+            type: string
+        when_not_to_use:
+          type: array
+          description: |
+            Anti-trigger scenarios — when the router should pick a
+            different skill or answer inline instead. 1-3 entries.
+            Examples: "User wants the conceptual explanation (= stable
+            knowledge)", "User wants to test the skill (= use eval)".
+            Include cross-references to sibling skills the request might
+            be confused with.
+          items:
+            type: string
+        examples:
+          type: object
+          description: Verbatim example user phrasings, positive + negative.
+          properties:
+            positive:
+              type: array
+              description: |
+                User phrasings that SHOULD trigger this skill. 2-3 examples,
+                in the user's actual language (ja / en mixed is fine).
+                Quote-shaped strings, not paraphrased descriptions.
+              items:
+                type: string
+            negative:
+              type: array
+              description: |
+                User phrasings that should NOT trigger this skill (= might
+                look similar but belong to a sibling skill). 1-2 examples.
+                Comment in parentheses naming the actual target skill.
+              items:
+                type: string
+          required: [positive, negative]
+      required: [intents, when_to_use, when_not_to_use, examples]
     mcp_servers:
       type: array
       description: MCP servers recommended for this skill (empty if none needed).
@@ -195,4 +261,4 @@ schema:
               in matching preprocessor steps. Sandboxing constraints (pure
               vs trusted) apply per-step, not per-module.
         required: [path, source]
-  required: [skill_name, skill_description, skill_path, entry_phase, finish_criteria, phases, transitions, artifacts, final_output, mcp_servers, python_modules]
+  required: [skill_name, skill_description, skill_path, entry_phase, finish_criteria, phases, transitions, artifacts, final_output, routing, mcp_servers, python_modules]

--- a/src/reyn/stdlib/skills/skill_builder/eval.md
+++ b/src/reyn/stdlib/skills/skill_builder/eval.md
@@ -19,6 +19,7 @@ quality:
 - Transitions correctly define the graph flow, with `to` values being only phase names.
 - Artifacts list includes all artifacts used as input by phases, with clear descriptions.
 - Final output artifact is well-defined with a name and description.
+- The `routing` block is populated with intents (= [task] for action skills, [stable_knowledge] for Q&A), 2-5 when_to_use scenario phrases, 1-3 when_not_to_use anti-trigger phrases (cross-referencing sibling skills), and examples.positive (2-3 verbatim phrasings) + examples.negative (1-2 quoting sibling-skill confusion). A missing or empty routing block is a fail — it leaves the chat router with only `description` to match against (= under-triggers in practice, same defect class as a bare description).
 
 ### phase: design_artifacts
 quality:
@@ -37,7 +38,8 @@ quality:
 
 ### phase: build_skill
 quality:
-- skill.md is correctly generated with all required fields (name, description, entry, final_output, finish_criteria).
+- skill.md is correctly generated with all required fields (name, description, entry, final_output, finish_criteria, routing).
+- The `routing:` block in skill.md is present and copied verbatim from `data.routing` (= intents / when_to_use / when_not_to_use / examples sub-fields all written, even when some lists are short). A skill.md without a routing block is a fail.
 - The graph in skill.md correctly reflects the transitions defined in the plan.
 - Phase files correctly include `type: phase`, `name`, `input`, `role`, `model_class` (if applicable), and `can_finish` (if applicable).
 - Phase instructions are copied verbatim from the plan.
@@ -67,6 +69,7 @@ quality:
 - Transitions correctly define the graph flow, with `to` values being only phase names.
 - Artifacts list includes all artifacts used as input by phases, with clear descriptions.
 - Final output artifact is well-defined with a name and description.
+- The `routing` block is populated with intents (= [task] for action skills, [stable_knowledge] for Q&A), 2-5 when_to_use scenario phrases, 1-3 when_not_to_use anti-trigger phrases (cross-referencing sibling skills), and examples.positive (2-3 verbatim phrasings) + examples.negative (1-2 quoting sibling-skill confusion). A missing or empty routing block is a fail — it leaves the chat router with only `description` to match against (= under-triggers in practice, same defect class as a bare description).
 
 ### phase: design_artifacts
 quality:
@@ -85,7 +88,8 @@ quality:
 
 ### phase: build_skill
 quality:
-- skill.md is correctly generated with all required fields (name, description, entry, final_output, finish_criteria).
+- skill.md is correctly generated with all required fields (name, description, entry, final_output, finish_criteria, routing).
+- The `routing:` block in skill.md is present and copied verbatim from `data.routing` (= intents / when_to_use / when_not_to_use / examples sub-fields all written, even when some lists are short). A skill.md without a routing block is a fail.
 - The graph in skill.md correctly reflects the transitions defined in the plan.
 - Phase files correctly include `type: phase`, `name`, `input`, `role`, `model_class` (if applicable), and `can_finish` (if applicable).
 - Phase instructions are copied verbatim from the plan.

--- a/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
@@ -47,6 +47,19 @@ finish_criteria:
 graph:
   {phase_a}: [{phase_b}]
   {phase_b}: [{phase_c}, {phase_d}]
+routing:
+  intents: {routing.intents}
+  when_to_use:
+    - {when_to_use_1}
+    - {when_to_use_2}
+  when_not_to_use:
+    - {when_not_to_use_1}
+  examples:
+    positive:
+      - "{positive_example_1}"
+      - "{positive_example_2}"
+    negative:
+      - "{negative_example_1}"
 ---
 
 ## 概要
@@ -55,6 +68,11 @@ graph:
 ## 入力
 {入力に期待する内容と例}
 ```
+
+The `routing:` block is **required** in the generated skill.md — copy each
+sub-field verbatim from `data.routing`. Do NOT omit it even if some lists
+are short. Missing routing leaves the chat router with only `description`
+to match against, which causes under-triggering (see PR #564 / #567).
 
 If `data.mcp_servers` is non-empty, append a `## MCP` section after `## 入力`:
 ```

--- a/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
@@ -167,6 +167,59 @@ final_output:
   - name: snake_case name for the final output artifact
   - description: one sentence describing it
 
+routing:
+  Structured routing hints. The chat router uses these **alongside the
+  bare `description`** to decide WHEN to dispatch this skill. Every stdlib
+  skill has one; populating it puts new user-built skills on the same
+  triggering footing.
+
+  All four sub-fields are REQUIRED — even empty lists are valid for
+  fields that don't apply (rare). Missing the whole block leaves the
+  router with only `description` to match against, which is the
+  under-trigger trap.
+
+  Sub-fields:
+
+  - intents: almost always [task]. Use [stable_knowledge] only for
+    Q&A skills that answer factual questions about a fixed domain
+    (rare for user-built skills).
+  - when_to_use: 2-5 third-person scenario phrases describing when
+    the router should pick this skill. Example: "User wants to
+    build a dashboard / data visualization / chart panel."
+  - when_not_to_use: 1-3 anti-trigger scenarios that cross-reference
+    sibling skills. Example: "User wants to invoke the dashboard
+    (= use the built skill directly)". Helps the router NOT
+    over-trigger.
+  - examples: { positive: [...], negative: [...] }
+    - positive: 2-3 verbatim user phrasings (ja/en mixed OK) that
+      SHOULD trigger. Quote-shaped strings, not paraphrases.
+    - negative: 1-2 verbatim phrasings that look similar but belong
+      to a sibling skill, with `(= use <skill_name>)` annotation.
+
+  Style: keep the lists tight. Long routing blocks crowd out other
+  skills in the router's context budget. The bullets are SIGNAL, not
+  documentation — every line should help the router make a clearer
+  decision.
+
+  Example for a hypothetical `dashboard_builder`:
+
+  ```yaml
+  routing:
+    intents: [task]
+    when_to_use:
+      - User wants to build / generate / scaffold a dashboard
+      - User mentions data visualization, charts, panels, metrics views
+    when_not_to_use:
+      - User wants to edit an existing dashboard's data (= use the built skill directly)
+      - User asks "what's a dashboard?" (= stable_knowledge / direct_llm)
+    examples:
+      positive:
+        - "ダッシュボード作って"
+        - "Build me a dashboard for our internal metrics"
+      negative:
+        - "dashboard って何？"   # this is direct_llm, not dashboard_builder
+  ```
+
 ---
 
 ## Design principles


### PR DESCRIPTION
**[e2e-coder]** — Closes the deferred follow-up from PR #564 + #567. Every stdlib skill ships with a structured ``routing:`` block; user-built skills got nothing. This PR teaches ``skill_builder`` to plan + emit one as a normal part of every generated skill.

## Why this matters

PR #564 (= pushy description, build-time) + PR #567 (= post-build remediation in skill_improver) closed the bare-description side of the under-trigger problem. The chat router *also* consumes a structured ``routing:`` block when present — `when_to_use` / `when_not_to_use` / `examples` — but user-built skills had no way to get one. This PR closes that gap.

## Cumulative under-trigger mitigation

| PR | When | What |
|---|---|---|
| #564 | build-time | pushy + trigger-aware `description` for new skills |
| #567 | post-build | `skill_improver` Step 4c proposes pushy rewrites for existing skills |
| **this** | build-time | structured `routing:` block (= `when_to_use` / `when_not_to_use` / `examples`) for new skills |

Together: user-built skills now ship on the same triggering footing as stdlib.

## Changes

### `artifacts/skill_plan.yaml`
Adds the `routing` property with required sub-fields:
- `intents` — enum `[task, stable_knowledge]`
- `when_to_use` — 2-5 third-person scenario phrases
- `when_not_to_use` — 1-3 anti-trigger phrases that cross-reference sibling skills
- `examples.positive` — 2-3 verbatim user phrasings (ja/en OK) that SHOULD trigger
- `examples.negative` — 1-2 verbatim phrasings that should NOT trigger, with `(= use <sibling>)` annotation

`routing` is added to the top-level `required` list — missing it is a planning bug.

### `phases/plan_skill.md`
Adds a `routing:` section to the structure-definition block of Step 3. Style guidance (= keep tight, signal not docs), field-by-field explanation, and a worked example for a hypothetical `dashboard_builder`:

```yaml
routing:
  intents: [task]
  when_to_use:
    - User wants to build / generate / scaffold a dashboard
    - User mentions data visualization, charts, panels, metrics
  when_not_to_use:
    - User wants to edit an existing dashboard's data (= use the built skill directly)
    - User asks "what's a dashboard?" (= stable_knowledge / direct_llm)
  examples:
    positive:
      - "ダッシュボード作って"
      - "Build me a dashboard for our internal metrics"
    negative:
      - "dashboard って何？"   # this is direct_llm
```

### `phases/build_skill.md`
Adds the `routing:` block to the skill.md frontmatter template, with a "MUST be present" note + pointer to the under-trigger pattern (PR #564 / #567).

### `eval.md`
Two new quality criteria, applied in both eval cases:
- `plan_skill` phase — routing block populated with required sub-fields (empty/missing = fail).
- `build_skill` phase — routing block present in skill.md and copied verbatim from `data.routing`.

## Test plan

- [x] `reyn skills validate skill_builder` → OK
- [x] **Rootdir** verify: `python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` → 5199 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed (= the 1 deselected = same pre-existing flake noted in PR #544 / #548 / #551 / #555 / #560 / #564 / #567)

## Migration for existing user skills

Existing skills without a routing block can be brought up to the same footing via `skill_improver` with `improvement_focus: "add routing block"` — the PR #567 Step 4c instructions apply the same pattern shape to `when_to_use` etc. since the LLM has the structure in `plan_improvements.md` context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)