### PR TITLE
feat(tui): ToolCallRow drill-down — click to surface full args / result

### DIFF
--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -30,11 +30,14 @@ import time
 
 from rich.cells import cell_len
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
 from reyn.chat.tui._palette import _CORAL
+
+from ._renderable_cache import RenderableCacheMixin
 
 _TICK_INTERVAL_S = 0.5  # elapsed-time refresh rate
 
@@ -93,7 +96,7 @@ def _maybe_middle_elide(name: str, max_cells: int) -> str:
     return name
 
 
-class ToolCallRow(Widget):
+class ToolCallRow(RenderableCacheMixin, Widget):
     """One inline tool-call row that updates in-place until terminal state.
 
     State machine:
@@ -145,6 +148,16 @@ class ToolCallRow(Widget):
         self._reason: str = ""
         self._frozen_elapsed: float | None = None
 
+        # Expand state — when True, line 1 + line 2 render the full
+        # args / result content without cell-budget truncation.
+        # Long args / result get word-wrapped across multiple visual
+        # lines by Static (= ``height: auto`` lets the row grow).
+        # Toggled by mouse click on the row (see ``on_click``) or
+        # the public ``toggle_expand`` method. Preserves across the
+        # running → finished transition so the user can still drill
+        # into a completed call's full args / result.
+        self._expanded: bool = False
+
         # DOM refs — populated in compose()
         self._line1: Static | None = None
         self._line2: Static | None = None
@@ -175,6 +188,34 @@ class ToolCallRow(Widget):
         return max(0.0, time.monotonic() - self._mount_time)
 
     # ── Public API ─────────────────────────────────────────────────────────────
+
+    def toggle_expand(self) -> None:
+        """Flip the collapsed / expanded render shape.
+
+        Expanded form drops cell-budget truncation on both lines so
+        long args / result wrap to multiple visual lines (Static
+        handles wrap; ``height: auto`` lets the row grow). Useful
+        for tool calls whose args / result got snipped to ``…`` in
+        the default 80-cell view.
+        """
+        self._expanded = not self._expanded
+        self._refresh()
+
+    @property
+    def is_expanded(self) -> bool:
+        """True when the row is currently rendering the drill-down view."""
+        return self._expanded
+
+    def on_click(self, event: events.Click) -> None:
+        """Mouse-click anywhere on the row toggles the drill-down view.
+
+        ``event.stop()`` so the click doesn't bubble up to conv-pane
+        scroll handling. Mirrors the SkillActivityRow click contract
+        from PR #546 — same trigger UX for two adjacent inline
+        widgets that the user reads together.
+        """
+        event.stop()
+        self.toggle_expand()
 
     def set_result(self, snippet: str) -> None:
         """Update the result snippet shown on line 2.
@@ -343,6 +384,16 @@ class ToolCallRow(Widget):
         )
         args_display = self._truncate_to_cells(self._args_repr, args_budget)
 
+        # Expand mode: drop the cell-budget cap on args so the full
+        # repr surfaces. Static wraps the line to fit; ``height: auto``
+        # grows the row. Tool name stays un-elided too — when
+        # drilling in, the user wants the qualified name in full.
+        if self._expanded:
+            tool_display = self._tool_name
+            tool_open = f"{tool_display}("
+            tool_close = ")"
+            args_display = self._args_repr
+
         if self._label_prefix:
             t.append(self._label_prefix, style="dim #666666")
         t.append(glyph_with_space, style=glyph_style)
@@ -383,7 +434,11 @@ class ToolCallRow(Widget):
         body_budget = max(
             8, total_width - cell_len(_RESULT_INDENT) - _RIGHT_MARGIN_CELLS,
         )
-        snippet = self._truncate_to_cells(body, body_budget)
+        # Expand mode: surface the full body without cell-budget
+        # truncation. Static wraps; row grows via height: auto.
+        snippet = body if self._expanded else self._truncate_to_cells(
+            body, body_budget,
+        )
         t = Text()
         t.append(_RESULT_INDENT, style="dim #666666")
         t.append(snippet, style=body_style)
@@ -406,10 +461,22 @@ class ToolCallRow(Widget):
         return "", "dim"
 
     def _refresh(self) -> None:
+        l1 = self._build_line1()
+        l2 = self._build_line2()
         if self._line1 is not None:
-            self._line1.update(self._build_line1())
+            self._line1.update(l1)
         if self._line2 is not None:
-            self._line2.update(self._build_line2())
+            self._line2.update(l2)
+        # Concatenate for the renderable-cache mixin — tests read
+        # both lines via ``rendered_text()`` as a single string. Line
+        # 2 is often empty (= running with no result yet); join with
+        # a newline only when both have content.
+        combined = Text()
+        combined.append_text(l1)
+        if l2.plain:
+            combined.append("\n")
+            combined.append_text(l2)
+        self._set_rendered_cache(combined)
 
 
 __all__ = ["ToolCallRow"]

--- a/tests/cli/test_tool_call_row_drill_down.py
+++ b/tests/cli/test_tool_call_row_drill_down.py
@@ -1,0 +1,248 @@
+"""Tier 2: ToolCallRow drill-down — click to surface full args / result.
+
+Categorical UX gap on the conv-pane execution-detail axis. Before
+this PR, ToolCallRow truncated args + result to fit on 2 single-line
+visual rows. Long tool calls (= heavy ``content=`` payloads, big
+shell command lines, multi-key result dicts) lost the tail to ``…``.
+Users could see the call happened but couldn't read what was
+actually called or returned without switching to the right-panel
+Events tab.
+
+This adds a mouse-click toggle (mirrors the SkillActivityRow
+drill-down from PR #546): clicking the row drops the cell-budget
+truncation on both lines so the full content surfaces, with
+Static-driven word-wrap letting the row grow vertically.
+
+Public surfaces tested:
+  - ``ToolCallRow.toggle_expand()`` flips ``is_expanded``
+  - ``ToolCallRow.is_expanded`` reflects current state
+  - ``on_click(event)`` triggers expand (mouse path)
+  - Collapsed render truncates long args with ``…``
+  - Expanded render surfaces the full args + result
+  - Tool name un-elided in expanded view (= long
+    qualified names like ``mcp__server__verb`` are shown in full)
+  - Finished rows still expandable (= state preserved across
+    success / failure terminals)
+  - ToolCallRow inherits RenderableCacheMixin (= rendered_text
+    accessor available, same idiom as SkillActivityRow + SlashPicker)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_row_starts_collapsed() -> None:
+    """Tier 2: a freshly mounted row is not expanded."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_tool_call_row(
+            op_id="op-1", tool_name="file:read", args_repr="path=a.py",
+        )
+        await pilot.pause()
+        assert row is not None
+        assert row.is_expanded is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_expand_flips_state() -> None:
+    """Tier 2: ``toggle_expand`` round-trips collapsed↔expanded."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_tool_call_row(
+            op_id="op-2", tool_name="file:read", args_repr="path=a.py",
+        )
+        await pilot.pause()
+        row.toggle_expand()
+        assert row.is_expanded is True
+        row.toggle_expand()
+        assert row.is_expanded is False
+
+
+@pytest.mark.asyncio
+async def test_collapsed_view_truncates_long_args() -> None:
+    """Tier 2: long args repr truncates with ``…`` in collapsed view."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(80, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        long_args = "cmd=" + ("x" * 100)
+        row = conv.start_tool_call_row(
+            op_id="op-3", tool_name="bash:run", args_repr=long_args,
+        )
+        await pilot.pause()
+        text = row.rendered_text()
+        # Full args NOT in collapsed view.
+        assert long_args not in text
+        # Ellipsis present somewhere as the truncation marker.
+        assert "…" in text
+
+
+@pytest.mark.asyncio
+async def test_expanded_view_surfaces_full_args() -> None:
+    """Tier 2: expanded view contains the entire args repr, no ``…`` cut."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(80, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        long_args = "cmd=" + ("x" * 100)
+        row = conv.start_tool_call_row(
+            op_id="op-4", tool_name="bash:run", args_repr=long_args,
+        )
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = row.rendered_text()
+        # Full args present.
+        assert long_args in text
+
+
+@pytest.mark.asyncio
+async def test_expanded_view_un_elides_long_tool_name() -> None:
+    """Tier 2: qualified tool names that get middle-elided collapsed are
+    rendered in full when expanded."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    # Narrow terminal so the collapsed view triggers middle-elide.
+    async with app.run_test(headless=True, size=(50, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        long_tool = "mcp__server-with-long-name__a_specific_verb"
+        row = conv.start_tool_call_row(
+            op_id="op-5",
+            tool_name=long_tool,
+            args_repr="x=1",
+        )
+        await pilot.pause()
+        row.toggle_expand()
+        await pilot.pause()
+        text = row.rendered_text()
+        # Full qualified name surfaces in expanded.
+        assert long_tool in text
+
+
+@pytest.mark.asyncio
+async def test_expanded_view_surfaces_full_result_snippet() -> None:
+    """Tier 2: long result snippets show in full when expanded."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(80, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        long_result = "output=" + ("y" * 100)
+        row = conv.start_tool_call_row(
+            op_id="op-6", tool_name="bash:run", args_repr="cmd=ls",
+        )
+        row.set_result(long_result)
+        await pilot.pause()
+        # Collapsed: truncated.
+        collapsed = row.rendered_text()
+        assert long_result not in collapsed
+        row.toggle_expand()
+        await pilot.pause()
+        expanded = row.rendered_text()
+        # Expanded: full result visible.
+        assert long_result in expanded
+
+
+@pytest.mark.asyncio
+async def test_click_event_toggles_expand() -> None:
+    """Tier 2: Click event invokes the expand toggle."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_tool_call_row(
+            op_id="op-7", tool_name="bash:run", args_repr="cmd=ls",
+        )
+        await pilot.pause()
+        click = textual_events.Click(
+            chain=1, widget=row, x=0, y=0, delta_x=0, delta_y=0,
+            button=1, shift=False, meta=False, ctrl=False,
+            screen_x=0, screen_y=0, style=None,
+        )
+        row.on_click(click)
+        await pilot.pause()
+        assert row.is_expanded is True
+
+
+@pytest.mark.asyncio
+async def test_finished_row_remains_expandable() -> None:
+    """Tier 2: ``finish_success`` doesn't lock out the expand toggle."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(80, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        long_result = "result=" + ("z" * 100)
+        row = conv.start_tool_call_row(
+            op_id="op-8", tool_name="bash:run", args_repr="cmd=ls",
+        )
+        await pilot.pause()
+        row.finish_success(result_snippet=long_result)
+        await pilot.pause()
+        # Pre-expand: truncated.
+        assert long_result not in row.rendered_text()
+        # User can still click + expand a completed row.
+        row.toggle_expand()
+        await pilot.pause()
+        assert long_result in row.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_tool_call_row_inherits_renderable_cache_mixin() -> None:
+    """Tier 2: ToolCallRow uses the shared RenderableCacheMixin from #568.
+
+    Pins the inheritance — completes the 3rd Static-cache migration
+    that the mixin extraction targeted (= SkillActivityRow + SlashPicker
+    already migrated; ToolCallRow newly added here).
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets._renderable_cache import RenderableCacheMixin
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        row = conv.start_tool_call_row(
+            op_id="op-9", tool_name="x", args_repr="",
+        )
+        await pilot.pause()
+        assert isinstance(row, RenderableCacheMixin)
+        # rendered_text accessor available from the mixin.
+        assert isinstance(row.rendered_text(), str)


### PR DESCRIPTION
**[tui-coder]** — Conv-pane execution-detail axis. Before this PR, ToolCallRow truncated args + result to fit on 2 single-line visual rows. Long tool calls (= heavy `content=` payloads, big shell command lines, multi-key result dicts) lost the tail to `…`. Users could see the call happened but couldn't read what was actually called or returned without switching to the right-panel Events tab.

**Stack note**: base = `refactor/tui-renderable-cache-mixin` (= #568). Will auto-update to main once #568 lands.

## Summary

Mirrors the SkillActivityRow drill-down from #546: click anywhere on the row to drop cell-budget truncation on both lines. Static auto-wraps; `height: auto` (already in CSS) lets the row grow vertically.

```
Collapsed (default):
  ● file:read(path=app.py, conten…)  · 0.4s
    ⎿ status=ok, content=<6543 chars>

After click:
  ● file:read(path=app.py, content=<6543 chars>)  · 0.4s
    ⎿ status=ok, content=<6543 chars>, lines_read=124, bytes=6543, encoding=utf8
```

(In practice the difference is more pronounced on heavy multi-key result dicts or bash:run with long command lines.)

## Implementation

- `ToolCallRow.toggle_expand()` flips `_expanded`.
- `ToolCallRow.is_expanded` — bool property.
- `ToolCallRow.on_click(event)` — mouse trigger; `event.stop()` to prevent bubbling into conv-pane scroll. Same idiom as SkillActivityRow.
- `_build_line1` / `_build_line2` skip cell-budget truncation when expanded:
  - line 1: tool name un-elided (`mcp__server__verb` in full instead of `mcp__…__verb`); args repr in full.
  - line 2: result snippet / failure reason in full.
- Finished rows remain expandable — state preserved across the running → terminal transition so users can still drill into completed calls.

## Why this layer

- TUI-internal: only `widgets/tool_call_row.py`. Mirrors the established SkillActivityRow drill-down pattern (#546) so users get one mental model across both inline widgets.
- Inherits from `RenderableCacheMixin` (= 3rd Static-cache migration after SkillActivityRow + SlashPicker in #568). The mixin's `rendered_text()` concatenates line 1 + line 2 with a newline so tests see the complete row content as a single string.
- Stack on #568 because the mixin lives on that branch; rebases to main automatically when #568 merges.

## Test plan

- [x] `pytest tests/cli/test_tool_call_row_drill_down.py` — 9/9 pass (starts collapsed, toggle flips, collapsed truncates, expanded surfaces full args, un-elides long tool name, full result, Click triggers, finished still expandable, RenderableCacheMixin inheritance)
- [x] `pytest tests/cli/` — 603/603 pass
- [x] `pytest tests/cli/test_renderable_cache_mixin.py tests/cli/test_skill_row_drill_down.py tests/cli/test_slash_picker_unknown_hint.py` — #568 + #546 + #550 regression intact
- [x] `ruff check src/reyn/chat/tui/widgets/tool_call_row.py tests/cli/test_tool_call_row_drill_down.py` — clean
- [x] Manual: run `reyn chat`, fire a heavy tool (= long shell command or content payload), click the live tool_call row — args + result expand to multi-line. Click again — collapse. Wait for completion + click on the ✓ finished row — drill-down still works.
- [x] (skipped — full content propagation upstream from op_runtime is out of scope; the existing app_outbox formatters still pre-truncate bulky fields to `<N chars>` placeholders — expanding only un-truncates what's already been sent to the row)

## Out of scope (deferred)

- True full-content drill-down (= bypass `_format_tool_args` / `_format_tool_result` so users can see the raw `content=<6543 chars>` body). Would need to pass full data through from `ChatEventForwarder` / `op_runtime`. Bigger scope; the expanded view here surfaces what's currently available to the widget.
- F3-style keyboard trigger for tool call expand. Mouse-click is the primary discovered trigger; could add a keyboard companion if requested.
- Per-row syntax highlighting of arg dict / JSON result. Would need a parser pass; defer.
