### PR TITLE
feat(skill_builder): iterate_with_evals — optional post-build eval loop (4-PR closure)

### DIFF
--- a/src/reyn/stdlib/skills/skill_builder/artifacts/build_result.yaml
+++ b/src/reyn/stdlib/skills/skill_builder/artifacts/build_result.yaml
@@ -17,4 +17,20 @@ schema:
     file_count:
       type: integer
       description: Total number of files written.
+    max_iterations:
+      type: integer
+      description: |
+        Iteration cap copied through from the input skill_request (=
+        plumbed for the post-lint ``iterate_with_evals`` phase). 0 = no
+        iteration requested.
+      default: 0
+      minimum: 0
+    score_threshold:
+      type: number
+      description: |
+        Score threshold copied through from input. Only used when
+        ``max_iterations`` > 0.
+      default: 0.85
+      minimum: 0.0
+      maximum: 1.0
   required: [skill_name, skill_path, files_written, file_count]

--- a/src/reyn/stdlib/skills/skill_builder/artifacts/skill_builder_result.yaml
+++ b/src/reyn/stdlib/skills/skill_builder/artifacts/skill_builder_result.yaml
@@ -29,4 +29,56 @@ schema:
     summary:
       type: string
       description: One sentence describing what the generated skill does for its users.
+    max_iterations:
+      type: integer
+      description: |
+        Iteration cap copied through from the input skill_request (= 0
+        when iteration was not requested). When > 0, the
+        ``iterate_with_evals`` phase chained into ``skill_improver``;
+        when 0, the phase short-circuited and this artifact is the
+        build+lint result unchanged.
+      default: 0
+      minimum: 0
+    score_threshold:
+      type: number
+      description: |
+        Score threshold copied through from input (or default 0.85).
+        Only meaningful when ``max_iterations`` > 0.
+      default: 0.85
+      minimum: 0.0
+      maximum: 1.0
+    improvement_summary:
+      type: object
+      description: |
+        Optional — populated by ``iterate_with_evals`` when iteration
+        actually ran (= ``max_iterations`` > 0 AND ``skill_improver``
+        completed). Captures the score progression + termination
+        reason so the caller knows what changed.
+      properties:
+        iterations_run:
+          type: integer
+          description: Actual number of skill_improver iterations performed.
+          minimum: 0
+        initial_score:
+          type: number
+          description: Eval score from the first run_and_eval pass.
+          minimum: 0.0
+          maximum: 1.0
+        final_score:
+          type: number
+          description: Eval score from the last run_and_eval pass.
+          minimum: 0.0
+          maximum: 1.0
+        termination_reason:
+          type: string
+          description: |
+            Why the loop stopped. One of: score_threshold_met,
+            max_iterations_reached, regression_detected,
+            stagnation_detected, no_more_changes_planned, error.
+        files_modified:
+          type: array
+          items:
+            type: string
+          description: Union of files modified across all improver iterations.
+      required: [iterations_run, termination_reason]
   required: [skill_name, skill_path, files_written, file_count, lint_passed, lint_issues, summary]

--- a/src/reyn/stdlib/skills/skill_builder/artifacts/skill_plan.yaml
+++ b/src/reyn/stdlib/skills/skill_builder/artifacts/skill_plan.yaml
@@ -158,6 +158,23 @@ schema:
           type: object
           description: JSON Schema object for the final output's data fields.
       required: [name, description, schema]
+    max_iterations:
+      type: integer
+      description: |
+        Iteration cap copied through from the input skill_request (=
+        plumbed for the post-lint ``iterate_with_evals`` phase). 0 = no
+        iteration requested. Default 0 keeps the legacy
+        build → lint → finish behaviour.
+      default: 0
+      minimum: 0
+    score_threshold:
+      type: number
+      description: |
+        Score threshold copied through from input. Only meaningful when
+        ``max_iterations`` > 0.
+      default: 0.85
+      minimum: 0.0
+      maximum: 1.0
     routing:
       type: object
       description: |

--- a/src/reyn/stdlib/skills/skill_builder/artifacts/skill_request.yaml
+++ b/src/reyn/stdlib/skills/skill_builder/artifacts/skill_request.yaml
@@ -13,4 +13,26 @@ schema:
     goal:
       type: string
       description: Detailed description of the skill's purpose, input, and expected output quality.
+    max_iterations:
+      type: integer
+      description: |
+        Optional — when set to N ≥ 1, after the build + lint completes,
+        ``skill_builder`` chains into ``skill_improver`` via the
+        ``iterate_with_evals`` phase. ``skill_improver`` will
+        auto-generate an ``eval.md`` (via ``eval_builder``) if absent,
+        then loop up to N iterations or until ``score_threshold`` is met.
+        Default 0 = no iteration (= build → lint → finish, the legacy
+        behaviour). Typical opt-in values: 1 (= one improvement pass) or
+        2-3 (= meaningful iteration). Higher values mostly waste tokens.
+      default: 0
+      minimum: 0
+    score_threshold:
+      type: number
+      description: |
+        Optional — paired with ``max_iterations``. When iteration runs,
+        ``skill_improver`` stops early if eval score reaches this value.
+        Ignored when ``max_iterations`` is 0. Default 0.85.
+      default: 0.85
+      minimum: 0.0
+      maximum: 1.0
   required: [skill_name, description, goal]

--- a/src/reyn/stdlib/skills/skill_builder/eval.md
+++ b/src/reyn/stdlib/skills/skill_builder/eval.md
@@ -51,8 +51,14 @@ quality:
 quality:
 - The lint op is executed with the correct `skill_path`.
 - If lint fails, `control.type='rollback'` is emitted with lint issues included in the reason.
-- If lint passes, the phase finishes with a correctly structured `skill_builder_result` artifact.
+- If lint passes, the phase **transitions to `iterate_with_evals`** (= not `finish`) with a correctly structured `skill_builder_result` artifact carrying `max_iterations` + `score_threshold` copied through from `build_result`.
 - The `summary` field in `skill_builder_result` describes what the generated skill does for its users, not the build process itself.
+
+### phase: iterate_with_evals
+quality:
+- When `data.max_iterations == 0`: the phase emits a `finish` decide turn with zero ops and the input artifact passed through verbatim (= legacy fast path).
+- When `data.max_iterations > 0`: the phase emits exactly one `run_skill` op invoking `skill_improver` with `target_skill_path`, `max_iterations`, and `score_threshold` taken from input. After the op returns, the phase finishes with a `skill_builder_result` that adds `improvement_summary` (= `iterations_run`, `initial_score`, `final_score`, `termination_reason`, `files_modified`) and a brief tail appended to `summary`.
+- If `run_skill` returns `status: error`, the phase still finishes successfully (= build itself was OK) with `improvement_summary.termination_reason = "error"` and a diagnostic note. The workflow is NOT aborted.
 
 ## case: complex_review_and_revision_app
 input: "Create a skill that generates a legal disclaimer and allows a reviewer to approve or reject it with specific feedback, looping back for revisions."
@@ -101,5 +107,11 @@ quality:
 quality:
 - The lint op is executed with the correct `skill_path`.
 - If lint fails, `control.type='rollback'` is emitted with lint issues included in the reason.
-- If lint passes, the phase finishes with a correctly structured `skill_builder_result` artifact.
+- If lint passes, the phase **transitions to `iterate_with_evals`** (= not `finish`) with a correctly structured `skill_builder_result` artifact carrying `max_iterations` + `score_threshold` copied through from `build_result`.
 - The `summary` field in `skill_builder_result` describes what the generated skill does for its users, not the build process itself.
+
+### phase: iterate_with_evals
+quality:
+- When `data.max_iterations == 0`: the phase emits a `finish` decide turn with zero ops and the input artifact passed through verbatim (= legacy fast path).
+- When `data.max_iterations > 0`: the phase emits exactly one `run_skill` op invoking `skill_improver` with `target_skill_path`, `max_iterations`, and `score_threshold` taken from input. After the op returns, the phase finishes with a `skill_builder_result` that adds `improvement_summary` (= `iterations_run`, `initial_score`, `final_score`, `termination_reason`, `files_modified`) and a brief tail appended to `summary`.
+- If `run_skill` returns `status: error`, the phase still finishes successfully (= build itself was OK) with `improvement_summary.termination_reason = "error"` and a diagnostic note. The workflow is NOT aborted.

--- a/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
@@ -202,8 +202,10 @@ Checklist before finishing:
 - one python file per entry in data.python_modules (when non-empty)
 - every phase's `input:` field resolves to either a written artifact file, `user_message` (stdlib), or data.final_output.name — if any phase's input is missing, STOP and write the missing artifact file before proceeding
 
-Write all files using one op per file. Once all files are written, finish with a `build_result` artifact:
+Write all files using one op per file. Once all files are written, transition to `verify_skill` with a `build_result` artifact:
 - `skill_name`: the generated skill name
 - `skill_path`: workspace-relative path (e.g. "reyn/local/my_app")
 - `files_written`: list of all file paths written
 - `file_count`: total number of files
+- `max_iterations`: from `data.max_iterations` (= copy through; 0 if absent)
+- `score_threshold`: from `data.score_threshold` (= copy through; 0.85 if absent)

--- a/src/reyn/stdlib/skills/skill_builder/phases/iterate_with_evals.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/iterate_with_evals.md
@@ -1,0 +1,118 @@
+---
+type: phase
+name: iterate_with_evals
+input: skill_builder_result
+role: post_build_optimizer
+can_finish: true
+max_act_turns: 2
+allowed_ops: [run_skill]
+---
+
+## Purpose
+
+Optional post-build improvement loop. When the user requested iteration
+(= ``data.max_iterations`` > 0), chain into ``skill_improver`` to run an
+eval-driven loop on the just-built skill. When iteration was not
+requested (= ``data.max_iterations == 0``, the default), pass the
+build+lint result through unchanged.
+
+This phase is the terminal of the ``skill_builder`` workflow. Output
+is always a ``skill_builder_result`` — augmented with
+``improvement_summary`` when iteration ran, untouched when it didn't.
+
+## Decision tree
+
+### Case 1 — No iteration requested (= ``data.max_iterations == 0``)
+
+Emit a decide turn that finishes with the input artifact verbatim. No
+ops, no run_skill, nothing. The skill_builder workflow ends with the
+build+lint result as before.
+
+```
+control.type = "finish"
+control.decision = "finish"
+control.next_phase = null
+artifact = data (passthrough)
+```
+
+This is the legacy behaviour for callers that don't opt into iteration.
+
+### Case 2 — Iteration requested (= ``data.max_iterations >= 1``)
+
+Run one ``run_skill`` op invoking ``skill_improver`` on the
+just-built skill. ``skill_improver`` will:
+
+  1. Look for an existing ``eval.md`` under the skill directory.
+  2. If absent, auto-generate one via ``eval_builder``.
+  3. Loop: ``run_and_eval`` → ``plan_improvements`` → ``apply_improvements``
+     until score threshold is met, max iterations reached, regression /
+     stagnation detected, or no productive changes remain.
+
+Op shape:
+
+```
+{
+  "kind": "run_skill",
+  "skill": "skill_improver",
+  "input": {
+    "type": "improvement_session",
+    "data": {
+      "target_skill_path": "<data.skill_path>/skill.md",
+      "max_iterations": <data.max_iterations>,
+      "score_threshold": <data.score_threshold>,
+      "improvement_focus": ""
+    }
+  }
+}
+```
+
+The op returns ``final_output`` matching ``improvement_result``:
+``score_history``, ``files_modified``, ``termination_reason``, etc.
+
+### Case 2 decide turn
+
+After the run_skill op returns, emit a decide turn finishing with a
+``skill_builder_result`` artifact built by:
+
+  - Passing through all build+lint fields from the input
+    (``skill_name``, ``skill_path``, ``files_written``, ``file_count``,
+    ``lint_passed``, ``lint_issues``, ``summary``).
+  - Setting ``max_iterations`` and ``score_threshold`` from input.
+  - Setting ``improvement_summary`` from the run_skill result:
+    ```yaml
+    improvement_summary:
+      iterations_run: <improvement_result.iterations_run or len(score_history)>
+      initial_score: <score_history[0] if non-empty else 0.0>
+      final_score: <score_history[-1] if non-empty else 0.0>
+      termination_reason: <improvement_result.termination_reason>
+      files_modified: <improvement_result.files_modified>
+    ```
+  - Augmenting ``summary`` with a brief tail like
+    " (improved across <iterations_run> iteration(s), final score
+    <final_score>, ended <termination_reason>)" so the user-facing
+    summary reflects what happened.
+
+### Case 3 — run_skill error
+
+If the ``run_skill`` op returns ``status: error``, finish with a
+``skill_builder_result`` carrying the original build+lint data and
+``improvement_summary.termination_reason = "error"`` plus the error
+text in ``improvement_summary.files_modified[0]`` as a diagnostic
+note. Do NOT abort the whole workflow — the build itself succeeded
+and the user should still see those files exist.
+
+## Constraints
+
+- Exactly 0 or 1 act turns. Never more than one ``run_skill`` op.
+- Do NOT modify any file. ``skill_improver`` owns that responsibility.
+- Do NOT call lint here. ``verify_skill`` already linted; if iteration
+  modifies the skill, ``skill_improver`` re-validates internally.
+
+## Why this lives in skill_builder
+
+Putting the iteration here (rather than asking the user to type
+``reyn run skill_improver <name>`` afterward) makes ``skill_builder``
+a complete "build a high-quality skill from one command" tool. The
+opt-in default (= ``max_iterations: 0``) preserves backward compat:
+existing callers that didn't ask for iteration still get the fast
+build→lint→finish path.

--- a/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
@@ -167,6 +167,25 @@ final_output:
   - name: snake_case name for the final output artifact
   - description: one sentence describing it
 
+max_iterations:
+  Integer ≥ 0 (default 0). Plumbed through to the post-build
+  ``iterate_with_evals`` phase that optionally chains into
+  ``skill_improver``. Sources:
+  - Structured input (= ``skill_request`` artifact): use
+    ``input_artifact.data.max_iterations`` verbatim if present.
+  - Free-text input (= ``user_message`` artifact): scan for explicit
+    phrasing like "iterate 2 times", "max_iterations=3", "improve and
+    iterate up to N times". Otherwise default to 0 (= no iteration,
+    legacy fast path).
+  Do NOT inflate this — over-iterating wastes tokens. Typical values:
+  0 (default), 1 (one improvement pass), 2-3 (meaningful loop).
+
+score_threshold:
+  Float in [0, 1], default 0.85. Same plumbing. Only used when
+  ``max_iterations`` > 0. Sources:
+  - Structured input: ``input_artifact.data.score_threshold`` verbatim.
+  - Free-text: scan for "threshold 0.9" / "until score 0.95"; else 0.85.
+
 routing:
   Structured routing hints. The chat router uses these **alongside the
   bare `description`** to decide WHEN to dispatch this skill. Every stdlib

--- a/src/reyn/stdlib/skills/skill_builder/phases/verify_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/verify_skill.md
@@ -3,7 +3,7 @@ type: phase
 name: verify_skill
 input: build_result
 role: dsl_verifier
-can_finish: true
+can_finish: false
 max_act_turns: 1
 allowed_ops: [file, lint]
 ---
@@ -25,7 +25,7 @@ If lint returned errors (`passed: false`):
 - The OS re-runs build_skill with your feedback; build_skill has the skill_plan context to fix the files
 - You MUST NOT write or delete files — you lack the skill_plan context
 
-If lint passed (`passed: true`), finish with an `skill_builder_result` artifact:
+If lint passed (`passed: true`), transition to `iterate_with_evals` with a `skill_builder_result` artifact:
 - `skill_name`: from data.skill_name
 - `skill_path`: from data.skill_path
 - `files_written`: from data.files_written
@@ -33,7 +33,15 @@ If lint passed (`passed: true`), finish with an `skill_builder_result` artifact:
 - `lint_passed`: true
 - `lint_issues`: []
 - `summary`: one sentence describing what the skill does for its users
+- `max_iterations`: from data.max_iterations (= copy through; 0 if absent)
+- `score_threshold`: from data.score_threshold (= copy through; 0.85 if absent)
+- (do NOT populate `improvement_summary` — the next phase owns it)
 
 summary MUST describe what the skill does for its users — not what you (the builder) did.
 Good: "A skill that lets users submit documents for reviewer approval or rejection with reasons."
 Bad: "Generated DSL files for the review skill and saved them to the workspace."
+
+The terminal phase is now `iterate_with_evals`. When `max_iterations` is 0
+(= the default), that phase short-circuits and finishes with the artifact you
+produced here unchanged. When `max_iterations` is > 0, it chains into
+`skill_improver` for the eval-driven loop.

--- a/src/reyn/stdlib/skills/skill_builder/skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/skill.md
@@ -9,11 +9,14 @@ final_output_description: |
 finish_criteria:
   - All DSL files for the skill have been written to the workspace
   - The generated DSL has been linted with no errors
+  - When ``max_iterations`` > 0, the post-build improvement loop has completed and the result includes ``improvement_summary``
 graph:
   plan_skill: [design_artifacts]
   design_artifacts: [review_plan]
   review_plan: [build_skill]
   build_skill: [verify_skill]
+  verify_skill: [iterate_with_evals]
+  iterate_with_evals: []
 routing:
   intents: [task]
   when_to_use:


### PR DESCRIPTION
**[e2e-coder]** — Adds the iterative eval loop pattern from Anthropic's ``skill-creator`` (= ``run_loop.py``) as a new opt-in terminal phase. When ``max_iterations >= 1`` in the input, ``skill_builder`` chains into ``skill_improver`` via ``run_skill`` after lint passes. ``skill_improver`` auto-generates an ``eval.md`` if absent, then loops until score threshold / max iterations / regression / stagnation.

When iteration is NOT requested (= default ``max_iterations: 0``), the new phase short-circuits and finishes with the build+lint result unchanged. Backward compat preserved.

## Why

Before this PR, the natural flow was 2 commands:

```bash
reyn run skill_builder "..."           # build + lint
reyn run skill_improver <skill_name>   # iterate (= 2nd command)
```

After:

```bash
reyn run skill_builder '{
  "type": "skill_request",
  "data": {... "max_iterations": 2, "score_threshold": 0.9}
}'
```

## Cumulative skill_builder UX cascade (= 4 PRs)

| PR | When | What |
|---|---|---|
| #564 | build-time | pushy + trigger-aware description |
| #567 | post-build | skill_improver Step 4c pushy rewrites |
| #569 | build-time | structured routing block generation |
| **this** | build-time | opt-in post-build eval loop |

Together: a single ``skill_builder`` invocation can take a NL request all the way through pushy description + structured routing + lint + eval-driven improvement loop.

## Changes (= 10 files)

### Artifact schemas (= 4 files, iteration plumbing)
- ``skill_request`` / ``skill_plan`` / ``build_result`` / ``skill_builder_result`` all gain ``max_iterations`` + ``score_threshold``. ``skill_builder_result`` also gains optional ``improvement_summary`` (= iterations_run, initial_score, final_score, termination_reason, files_modified).

### Phase instructions (= 3 files)
- ``plan_skill.md``: extract ``max_iterations`` / ``score_threshold`` from structured input or scan free text. Default 0 / 0.85.
- ``build_skill.md``: copy through.
- ``verify_skill.md``: ``can_finish`` → ``false``; transition to ``iterate_with_evals`` instead of finishing.

### New phase (= 1 file)
- ``iterate_with_evals.md``: ``input: skill_builder_result``, ``can_finish: true``, ``allowed_ops: [run_skill]``.
  - **Case 1** (``max_iterations == 0``): emit ``finish`` with 0 ops, pass through. Legacy fast path.
  - **Case 2** (``>= 1``): one ``run_skill`` op invoking ``skill_improver``; augment result with ``improvement_summary``.
  - **Case 3** (``run_skill`` error): still finish, with ``termination_reason = "error"``. Don't abort the workflow.

### Top-level + eval (= 2 files)
- ``skill.md`` graph extended.
- ``eval.md`` updates ``verify_skill`` criterion + adds ``iterate_with_evals`` block covering Cases 1/2/3.

## Test plan

- [x] ``reyn skills validate skill_builder`` → OK
- [x] **Rootdir** verify: ``python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`` → 5208 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed (= the 1 deselected = same pre-existing flake noted in PR #544 / #548 / #551 / #555 / #560 / #564 / #567 / #569)

## Out of scope (= deferred follow-ups)

- Test prompt generation phase (= Anthropic's ``skill-creator/scripts/run_loop.py`` also generates synthetic test prompts). Deferred until eval_builder's auto-generated eval.md is empirically insufficient.
- Eval visualization (= Anthropic's ``eval-viewer/generate_review.py``). Reyn's existing event log + replay tooling cover this functionally; a dedicated visualizer is a separate UX surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)