### PR TITLE
feat(stdlib/mcp): migrate mcp_install + mcp_search to safe-mode + reyn.safe.mcp.registry (FP-0042 Phase 2.4)

### DIFF
--- a/src/reyn/safe/__init__.py
+++ b/src/reyn/safe/__init__.py
@@ -16,6 +16,8 @@ Available modules:
 
 - :mod:`reyn.safe.hash` — `sha256` / `sha256_hex`.
 - :mod:`reyn.safe.json` — strict / canonical JSON helpers.
+- :mod:`reyn.safe.mcp` — MCP helpers (`mcp.registry.search` / `lookup`).
+  New in FP-0042 Phase 2.4 — ambient (URL hardcoded, no permission gate).
 - :mod:`reyn.safe.process` — process identity (`getpid`, `pid_alive`).
   Ambient (no permission gate). New in FP-0042 Phase 2.2.
 - :mod:`reyn.safe.random` — explicit-seeded RNG.
@@ -28,6 +30,8 @@ to work via shim re-exports from this package. New code should import from
 ``reyn.safe.*``; existing code may migrate at its own pace.
 """
 
-from . import file, hash, json, process, random, schema, text, time
+from . import file, hash, json, mcp, process, random, schema, text, time
 
-__all__ = ["file", "hash", "json", "process", "random", "schema", "text", "time"]
+__all__ = [
+    "file", "hash", "json", "mcp", "process", "random", "schema", "text", "time",
+]

--- a/src/reyn/safe/mcp/__init__.py
+++ b/src/reyn/safe/mcp/__init__.py
@@ -1,0 +1,16 @@
+"""MCP-related helpers callable from safe-mode python steps.
+
+Currently exposes:
+
+- :mod:`reyn.safe.mcp.registry` — MCP server registry lookup
+  (= ``search`` / ``lookup``). Hardcoded URL, no permission gate.
+
+The naming ``reyn.safe.mcp.*`` mirrors the wider ``reyn.safe.*`` doctrine
+(= per-call gated where state mutation is involved; ambient where the call
+is observation-only). Registry lookup is ambient — see the module docstring
+for the threat model.
+"""
+
+from . import registry
+
+__all__ = ["registry"]

--- a/src/reyn/safe/mcp/registry.py
+++ b/src/reyn/safe/mcp/registry.py
@@ -1,0 +1,190 @@
+"""Safe-mode MCP server registry lookup (FP-0042 Phase 2.4).
+
+Exposes ``search(query, limit)`` and ``lookup(server_id)`` to safe-mode
+python steps. Internally batches HTTP GET against
+``registry.modelcontextprotocol.io``, caches responses on disk (~/.reyn/
+registry-cache/), parses + dedups the registry envelope, and returns
+plain JSON-serialisable dicts.
+
+Threat model + permission rationale
+-----------------------------------
+
+The registry URL is **hardcoded** to the official MCP server registry.
+There is no env var override, no config-driven base_url, and no
+per-skill host allowlist. As a result, registry lookup is treated as an
+*ambient* operation in the same sense as ``time`` and ``random`` —
+operator-controlled state is not in the loop, so the operation has no
+permission gate.
+
+If a future requirement needs operator-configurable registry URLs (=
+private mirror / corporate registry), the design question moves into
+Issue #571 ("Permission model: granularity decomposition vs abstraction
+granularity"); at that point the URL becomes config-controlled and the
+permission shape needs to be co-designed with the rest of the MCP
+permission family.
+
+Internal layering
+-----------------
+
+This module is reyn-package internal code (= not subject to the
+safe-mode AST validator). It is free to import urllib / reyn.registry
+helpers; the validator only rejects user-code imports outside the
+allowlist, and ``reyn.safe.*`` is admitted.
+
+Public API (returned dict shape)
+--------------------------------
+
+Both ``search`` and ``lookup`` return plain dicts (= JSON-friendly, no
+dataclasses) so safe-mode skills can pass results through artifact
+boundaries without translation:
+
+::
+
+    {
+        "name":         "io.github.foo/bar-mcp",
+        "description":  "One-line description from server.json",
+        "repo_url":     "https://github.com/foo/bar-mcp" | None,
+        "runtime_hint": "npx" | "uvx" | "docker" | "dnx" | "",
+    }
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+# Internal reuse of the non-safe-namespaced helpers. These are pure
+# (= dedup is a list transform; server_info_from_raw is a dict reshape)
+# or scoped to reyn-internal disk cache. None of them are reachable from
+# user code through this safe namespace surface.
+from reyn.registry import cache as _cache
+from reyn.registry.client import _dedup_by_latest
+from reyn.registry.models import server_info_from_raw
+
+# Hardcoded URL — see module docstring for the rationale.
+_BASE_URL = "https://registry.modelcontextprotocol.io"
+
+# urlopen timeout in seconds. 10s covers the canonical registry's p99
+# without leaving steps hanging if the network is wedged.
+_HTTP_TIMEOUT = 10.0
+
+_USER_AGENT = "reyn/1.0 (safe.mcp.registry)"
+
+
+class RegistryError(RuntimeError):
+    """Raised when the registry response is non-2xx or cannot be parsed."""
+
+
+def _http_get_json(url: str) -> dict:
+    """GET ``url`` and JSON-parse the body. Raises :class:`RegistryError` on
+    any failure (HTTP non-2xx, transport error, JSON parse error)."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            raw = resp.read()
+            status = getattr(resp, "status", None) or resp.getcode()
+    except urllib.error.HTTPError as exc:
+        raise RegistryError(
+            f"Registry returned HTTP {exc.code} for {url}"
+        ) from exc
+    except Exception as exc:  # noqa: BLE001 — surface everything as RegistryError
+        raise RegistryError(f"Registry transport error for {url}: {exc}") from exc
+
+    if status >= 400:
+        raise RegistryError(f"Registry returned HTTP {status} for {url}")
+
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise RegistryError(f"Registry JSON parse error for {url}: {exc}") from exc
+
+
+def _info_to_dict(info: Any) -> dict:
+    """Convert a :class:`reyn.registry.models.ServerInfo` to the public dict shape."""
+    return {
+        "name": info.name,
+        "description": info.description,
+        "repo_url": info.repository_url,
+        "runtime_hint": info.runtime_hint,
+    }
+
+
+def _candidates_from_payload(payload: dict) -> list[dict]:
+    """Convert a registry search payload into the public list[dict] shape.
+
+    Applies :func:`_dedup_by_latest` to collapse multiple versions of the
+    same server down to the newest, then reshapes each entry via
+    :func:`server_info_from_raw`.
+    """
+    raw_entries = payload.get("servers", []) or []
+    deduped = _dedup_by_latest(raw_entries)
+    out: list[dict] = []
+    for entry in deduped:
+        info = server_info_from_raw(entry)
+        if info.name:
+            out.append(_info_to_dict(info))
+    return out
+
+
+def search(query: str, *, limit: int = 20) -> list[dict]:
+    """Search the MCP registry for servers matching ``query``.
+
+    Returns a list of result dicts (= newest version per server name,
+    other dups removed). Empty list when the query yields no results.
+    Raises :class:`RegistryError` on registry / network failure with a
+    descriptive message; callers that want fail-soft behaviour should
+    catch it and degrade to stale cache / empty result on their side.
+
+    Caching: search results are cached on disk for 24 hours under
+    ``~/.reyn/registry-cache/``. Subsequent identical queries within
+    the TTL return the cached payload without hitting the network.
+    """
+    if not query:
+        return []
+    cache_key = f"search:{query}:{limit}"
+
+    cached = _cache.get(cache_key)
+    if cached is not None:
+        return _candidates_from_payload(cached)
+
+    qs = urllib.parse.urlencode({"search": query, "limit": str(limit)})
+    url = f"{_BASE_URL}/v0.1/servers?{qs}"
+    data = _http_get_json(url)
+    _cache.set(cache_key, data)
+    return _candidates_from_payload(data)
+
+
+def lookup(server_id: str) -> dict | None:
+    """Return the registry entry for the exact ``server_id``, or None.
+
+    ``server_id`` is the registry-canonical name (= ``namespace/server-name``,
+    e.g. ``io.github.modelcontextprotocol/server-filesystem``).
+
+    The lookup hits ``/v0.1/servers/{id}/versions/latest`` and reshapes
+    the response into the same dict shape as :func:`search`. Returns
+    None when the registry replies 404. Raises :class:`RegistryError`
+    on other failures (= transport error, parse error, 5xx).
+
+    Caching: 24-hour disk cache keyed by ``server_id``.
+    """
+    if not server_id:
+        return None
+    cache_key = f"server:{server_id}"
+
+    cached = _cache.get(cache_key)
+    if cached is not None:
+        return _info_to_dict(server_info_from_raw(cached))
+
+    url = f"{_BASE_URL}/v0.1/servers/{urllib.parse.quote(server_id, safe='')}/versions/latest"
+    try:
+        data = _http_get_json(url)
+    except RegistryError as exc:
+        # 404 = not found → return None instead of raising.
+        if "HTTP 404" in str(exc):
+            return None
+        raise
+
+    _cache.set(cache_key, data)
+    return _info_to_dict(server_info_from_raw(data))

--- a/src/reyn/stdlib/skills/mcp_install/registry_fetch.py
+++ b/src/reyn/stdlib/skills/mcp_install/registry_fetch.py
@@ -1,6 +1,6 @@
 """Deterministic preprocessor for mcp_install — resolves user request to server_id.
 
-Called as a ``type: python`` preprocessor step. Signature contract:
+Called as a ``type: python`` preprocessor step (mode: safe). Signature:
   ``fetch_server_for_install(artifact: dict) -> dict``
 
 Input (from ``artifact["data"]``):
@@ -8,36 +8,29 @@ Input (from ``artifact["data"]``):
 
 Output (placed at ``data.registry``):
   ``server_id``  — exact registry identifier if resolved; "" if ambiguous or not found.
-  ``candidates`` — list of {name, description, repo_url} when search returns results.
+  ``candidates`` — list of {name, description, repo_url, runtime_hint} when search returns results.
   ``source``     — "direct" | "search" | "not_found" | "error"
   ``query``      — the search query used (or the original text if direct lookup).
 
 Resolution strategy:
-  1. If text contains "/" — treat as explicit server_id; skip search.
+  1. If text contains "/" — treat as explicit server_id; direct lookup.
   2. Otherwise — search the registry with the text as query.
      If exactly one result: use it as server_id (source="direct").
      If multiple results: return candidates (source="search").
      If zero results: source="not_found".
 
-I/O route: ``reyn.api.unsafe.http.get`` (= urllib, no extra deps).
-JSON parse: ``reyn.api.safe.json.loads_strict``.
-Caching: ``reyn.registry.cache`` (file-based TTL cache, 24 h).
+FP-0042 Phase 2.4 (2026-05-23): migrated from mode: unsafe to mode: safe.
+HTTP + cache + JSON parse + dedup are all hidden inside
+``reyn.safe.mcp.registry``; this module only deals with the resolution
+strategy. The legacy ``REYN_MCP_REGISTRY_URL`` env var override is no
+longer honoured here (= safe.mcp.registry hardcodes the URL); see Issue
+#571 for the design discussion that decided this scope.
 """
 from __future__ import annotations
 
-import os
 import re
-import urllib.parse
 
-from reyn.api.safe.json import loads_strict
-from reyn.api.unsafe.http import get as http_get
-
-
-def _base_url() -> str:
-    return os.environ.get(
-        "REYN_MCP_REGISTRY_URL",
-        "https://registry.modelcontextprotocol.io",
-    ).rstrip("/")
+from reyn.safe.mcp.registry import RegistryError, lookup, search
 
 
 def _looks_like_server_id(text: str) -> bool:
@@ -59,93 +52,43 @@ def _extract_keyword(text: str) -> str:
     return token.lower()
 
 
-def _http_get_json(url: str) -> dict:
-    """GET *url*, parse body as JSON. Raises RuntimeError on non-2xx or parse error."""
-    resp = http_get(url, headers={"User-Agent": "reyn/1.0"})
-    if resp["status"] >= 400:
-        raise RuntimeError(f"Registry returned HTTP {resp['status']} for {url}")
-    return loads_strict(resp["body"])
-
-
 def _direct_lookup(server_id: str) -> dict:
     """Attempt to look up a specific server_id; return registry result dict."""
-    import reyn.registry.cache as cache
-
-    cache_key = f"server:{server_id}"
-    cached = cache.get(cache_key)
-    if cached is not None:
-        return {
-            "server_id": server_id,
-            "candidates": [],
-            "source": "direct",
-            "query": server_id,
-        }
-
-    url = f"{_base_url()}/v0.1/servers/{urllib.parse.quote(server_id, safe='')}/versions/latest"
     try:
-        data = _http_get_json(url)
-        cache.set(cache_key, data)
-        return {
-            "server_id": server_id,
-            "candidates": [],
-            "source": "direct",
-            "query": server_id,
-        }
-    except RuntimeError:
-        return {
-            "server_id": "",
-            "candidates": [],
-            "source": "not_found",
-            "query": server_id,
-        }
-    except Exception:
+        info = lookup(server_id)
+    except RegistryError:
         return {
             "server_id": "",
             "candidates": [],
             "source": "error",
             "query": server_id,
         }
+    if info is None:
+        return {
+            "server_id": "",
+            "candidates": [],
+            "source": "not_found",
+            "query": server_id,
+        }
+    return {
+        "server_id": server_id,
+        "candidates": [],
+        "source": "direct",
+        "query": server_id,
+    }
 
 
 def _search_lookup(query: str) -> dict:
     """Search the registry and return candidates."""
-    import reyn.registry.cache as cache
-    from reyn.registry.client import _dedup_by_latest
-    from reyn.registry.models import server_info_from_raw
-
-    limit = 10
-    cache_key = f"search:{query}:{limit}"
-    cached = cache.get(cache_key)
-
-    if cached is not None:
-        data = cached
-    else:
-        qs = urllib.parse.urlencode({"search": query, "limit": str(limit)})
-        url = f"{_base_url()}/v0.1/servers?{qs}"
-        try:
-            data = _http_get_json(url)
-            cache.set(cache_key, data)
-        except Exception:
-            return {
-                "server_id": "",
-                "candidates": [],
-                "source": "error",
-                "query": query,
-            }
-
-    raw_entries = data.get("servers", [])
-    deduped = _dedup_by_latest(raw_entries)
-    candidates = []
-    for entry in deduped:
-        info = server_info_from_raw(entry)
-        if info.name:
-            candidates.append(
-                {
-                    "name": info.name,
-                    "description": info.description,
-                    "repo_url": info.repository_url,
-                }
-            )
+    try:
+        candidates = search(query, limit=10)
+    except RegistryError:
+        return {
+            "server_id": "",
+            "candidates": [],
+            "source": "error",
+            "query": query,
+        }
 
     if not candidates:
         return {

--- a/src/reyn/stdlib/skills/mcp_install/skill.md
+++ b/src/reyn/stdlib/skills/mcp_install/skill.md
@@ -17,9 +17,13 @@ graph:
 permissions:
   mcp_install: true
   python:
+    # FP-0042 Phase 2.4 (2026-05-23): migrated from mode: unsafe to mode: safe.
+    # Registry HTTP + cache + JSON parse + dedup all hidden inside
+    # reyn.safe.mcp.registry (= URL hardcoded, no permission gate per the
+    # ambient-read treatment captured in Issue #571).
     - module: ./registry_fetch.py
       function: fetch_server_for_install
-      mode: unsafe
+      mode: safe
       timeout: 20
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []

--- a/src/reyn/stdlib/skills/mcp_search/registry_fetch.py
+++ b/src/reyn/stdlib/skills/mcp_search/registry_fetch.py
@@ -1,14 +1,14 @@
 """Deterministic preprocessor for mcp_search — fetches MCP registry results.
 
-Called as a ``type: python`` preprocessor step.  Signature contract:
+Called as a ``type: python`` preprocessor step (mode: safe). Signature:
   ``fetch_registry_results(artifact: dict) -> dict``
 
 Input (from ``artifact["data"]``):
   ``text``  — the user's natural language capability request (e.g. "Slack 連携").
 
 Output (placed at ``data.registry``):
-  ``candidates`` — list of {name, repo_url, description} dicts from the registry.
-  ``source``     — ``"registry"`` | ``"registry_stale"`` | ``"error"``
+  ``candidates`` — list of {name, repo_url, description, runtime_hint} dicts.
+  ``source``     — ``"registry"`` | ``"error"``
   ``query``      — keyword extracted and used for the registry search.
 
 The keyword extraction is intentionally minimal and deterministic:
@@ -16,28 +16,23 @@ The keyword extraction is intentionally minimal and deterministic:
   first whitespace-separated token of the input text.
 
 Registry unreachable:
-  On HTTP error or any exception the preprocessor returns an empty candidates
-  list with ``source="error"`` so the LLM phase can still finish with an empty
-  result rather than crashing the phase.
+  On HTTP error or any other registry failure the preprocessor returns an
+  empty candidates list with ``source="error"`` so the LLM phase can still
+  finish gracefully. The 24-hour disk cache hidden inside
+  ``reyn.safe.mcp.registry`` covers the "stale-but-available" case
+  transparently — when the network is down but a recent search payload
+  exists on disk, the safe-mode lookup returns the cached value and we
+  surface it as ``source="registry"`` (= the legacy ``"registry_stale"``
+  status is folded into the same path; the LLM contract no longer
+  distinguishes fresh-vs-stale because the cache TTL is short).
 
-I/O route: ``reyn.api.unsafe.http.get`` (= urllib, no extra deps).
-JSON parse: ``reyn.api.safe.json.loads_strict``.
-Caching: ``reyn.registry.cache`` (file-based TTL cache, 24 h).
+FP-0042 Phase 2.4 (2026-05-23): migrated from mode: unsafe to mode: safe.
 """
 from __future__ import annotations
 
-import os
 import re
 
-from reyn.api.safe.json import loads_strict
-from reyn.api.unsafe.http import get as http_get
-
-
-def _base_url() -> str:
-    return os.environ.get(
-        "REYN_MCP_REGISTRY_URL",
-        "https://registry.modelcontextprotocol.io",
-    ).rstrip("/")
+from reyn.safe.mcp.registry import RegistryError, search
 
 
 def _extract_keyword(text: str) -> str:
@@ -45,97 +40,34 @@ def _extract_keyword(text: str) -> str:
 
     Strategy: find the first run of ASCII letters (≥ 3 chars) — these are
     almost always English product/service names embedded in Japanese or
-    mixed-language text.  If nothing qualifies, fall back to the first
+    mixed-language text. If nothing qualifies, fall back to the first
     whitespace token lowercased (for purely English input).
     """
-    # Try to find an English word (≥ 3 ASCII letters) — handles mixed ja/en text.
     match = re.search(r"[A-Za-z]{3,}", text)
     if match:
         return match.group(0).lower()
-    # Fallback: first whitespace-separated token.
     token = text.split()[0] if text.split() else text
     return token.lower()
-
-
-def _search_registry(query: str, limit: int = 20) -> dict:
-    """Fetch search results from the registry HTTP API.
-
-    Returns the parsed JSON response dict.
-    Raises ``RuntimeError`` on non-2xx status or JSON parse failure.
-    """
-    url = f"{_base_url()}/v0.1/servers"
-    # Build query string manually — urllib does not support params kwarg.
-    import urllib.parse
-    qs = urllib.parse.urlencode({"search": query, "limit": str(limit)})
-    resp = http_get(f"{url}?{qs}", headers={"User-Agent": "reyn/1.0"})
-    if resp["status"] >= 400:
-        raise RuntimeError(f"Registry returned HTTP {resp['status']}")
-    return loads_strict(resp["body"])
-
-
-def _dedup_and_extract(raw_entries: list[dict]) -> list[dict]:
-    """Deduplicate and convert raw registry entries to candidate dicts."""
-    from reyn.registry.client import _dedup_by_latest
-    from reyn.registry.models import server_info_from_raw
-
-    deduped = _dedup_by_latest(raw_entries)
-    candidates = []
-    for entry in deduped:
-        info = server_info_from_raw(entry)
-        if info.name:
-            candidates.append(
-                {
-                    "name": info.name,
-                    "repo_url": info.repository_url,
-                    "description": info.description,
-                }
-            )
-    return candidates
 
 
 def fetch_registry_results(artifact: dict) -> dict:
     """Python preprocessor entry point.
 
-    Receives the phase input artifact dict.  Returns a dict placed at
+    Receives the phase input artifact dict. Returns a dict placed at
     ``data.registry`` in the enriched artifact.
     """
-    import reyn.registry.cache as cache
-
     text: str = (artifact.get("data") or {}).get("text") or ""
     query = _extract_keyword(text) if text.strip() else ""
     if not query:
         return {"candidates": [], "source": "error", "query": ""}
 
-    limit = 20
-    cache_key = f"search:{query}:{limit}"
-
-    # Cache hit — serve without network.
-    cached = cache.get(cache_key)
-    if cached is not None:
-        raw_entries = cached.get("servers", [])
-        return {
-            "candidates": _dedup_and_extract(raw_entries),
-            "source": "registry",
-            "query": query,
-        }
-
     try:
-        data = _search_registry(query, limit=limit)
-        cache.set(cache_key, data)
-        raw_entries = data.get("servers", [])
-        return {
-            "candidates": _dedup_and_extract(raw_entries),
-            "source": "registry",
-            "query": query,
-        }
-    except Exception:
-        # Registry unreachable — try stale cache before giving up.
-        stale = cache.get(cache_key)
-        if stale:
-            raw_entries = stale.get("servers", [])
-            return {
-                "candidates": _dedup_and_extract(raw_entries),
-                "source": "registry_stale",
-                "query": query,
-            }
+        candidates = search(query, limit=20)
+    except RegistryError:
         return {"candidates": [], "source": "error", "query": query}
+
+    return {
+        "candidates": candidates,
+        "source": "registry",
+        "query": query,
+    }

--- a/src/reyn/stdlib/skills/mcp_search/skill.md
+++ b/src/reyn/stdlib/skills/mcp_search/skill.md
@@ -15,9 +15,13 @@ graph:
   search: []
 permissions:
   python:
+    # FP-0042 Phase 2.4 (2026-05-23): migrated from mode: unsafe to mode: safe.
+    # Registry HTTP + cache + JSON parse + dedup all hidden inside
+    # reyn.safe.mcp.registry (= URL hardcoded, no permission gate per the
+    # ambient-read treatment captured in Issue #571).
     - module: ./registry_fetch.py
       function: fetch_registry_results
-      mode: unsafe
+      mode: safe
       timeout: 20
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []

--- a/tests/test_mcp_install_skill.py
+++ b/tests/test_mcp_install_skill.py
@@ -61,42 +61,36 @@ _EMPTY_SEARCH_RESPONSE = {
 
 
 def _patch_registry_get_versions(server_response: dict, status: int = 200):
-    """Patch ``http_get`` in mcp_install.registry_fetch for versions/latest endpoint."""
-    import json as _json
+    """Patch the safe-mode registry HTTP helper for the versions/latest endpoint.
 
-    def _fake_get(url, *, headers=None, timeout=30):
+    FP-0042 Phase 2.4: ``mcp_install.registry_fetch`` no longer imports
+    ``http_get``; HTTP is encapsulated in ``reyn.safe.mcp.registry``. We
+    patch the internal ``_http_get_json`` there — it's the lowest stable
+    seam and matches the existing test pattern (= patch HTTP boundary, run
+    the real cache + dedup + dict-shape code path).
+    """
+    import reyn.safe.mcp.registry as _safe_registry
+
+    def _fake(url: str) -> dict:
         if status >= 400:
-            return {"status": status, "body": f"HTTP {status}", "headers": {}}
+            raise _safe_registry.RegistryError(f"HTTP {status} for {url}")
         if "/versions/latest" in url:
-            return {
-                "status": 200,
-                "body": _json.dumps({"server": server_response}),
-                "headers": {},
-            }
-        # search endpoint
-        return {
-            "status": 200,
-            "body": _json.dumps(_FILESYSTEM_SEARCH_RESPONSE),
-            "headers": {},
-        }
+            return {"server": server_response}
+        return _FILESYSTEM_SEARCH_RESPONSE
 
-    return mock.patch(
-        "reyn.stdlib.skills.mcp_install.registry_fetch.http_get", _fake_get
-    )
+    return mock.patch.object(_safe_registry, "_http_get_json", _fake)
 
 
 def _patch_registry_search(response_data: dict, status: int = 200):
-    """Patch ``http_get`` in mcp_install.registry_fetch for search endpoint."""
-    import json as _json
+    """Patch the safe-mode registry HTTP helper for the search endpoint."""
+    import reyn.safe.mcp.registry as _safe_registry
 
-    def _fake_get(url, *, headers=None, timeout=30):
+    def _fake(url: str) -> dict:
         if status >= 400:
-            return {"status": status, "body": f"HTTP {status}", "headers": {}}
-        return {"status": 200, "body": _json.dumps(response_data), "headers": {}}
+            raise _safe_registry.RegistryError(f"HTTP {status} for {url}")
+        return response_data
 
-    return mock.patch(
-        "reyn.stdlib.skills.mcp_install.registry_fetch.http_get", _fake_get
-    )
+    return mock.patch.object(_safe_registry, "_http_get_json", _fake)
 
 
 def _run(coro):
@@ -273,20 +267,19 @@ def test_fetch_server_registry_error_source_error(tmp_path):
 
 def test_fetch_server_empty_text_source_error():
     """Tier 2: Empty input text → source='error', no HTTP call made."""
+    import reyn.safe.mcp.registry as _safe_registry
     from reyn.stdlib.skills.mcp_install.registry_fetch import fetch_server_for_install
 
     call_count = 0
 
-    def _fake_get(url, *, headers=None, timeout=30):
+    def _spy(url: str) -> dict:
         nonlocal call_count
         call_count += 1
-        return {"status": 200, "body": "{}", "headers": {}}
+        return {}
 
     artifact = {"data": {"text": ""}}
 
-    with mock.patch(
-        "reyn.stdlib.skills.mcp_install.registry_fetch.http_get", _fake_get
-    ):
+    with mock.patch.object(_safe_registry, "_http_get_json", _spy):
         result = fetch_server_for_install(artifact)
 
     assert result["source"] == "error"

--- a/tests/test_mcp_search_registry.py
+++ b/tests/test_mcp_search_registry.py
@@ -2,25 +2,31 @@
 
 Tests the deterministic preprocessor function ``fetch_registry_results``.
 
-No LLM calls. Uses unittest.mock to patch ``reyn.api.unsafe.http.get``
-(the I/O route used by the refactored preprocessor) and exercises the real
-cache + dedup code path.
+No LLM calls. Uses ``unittest.mock`` to patch the lowest-stable seam in
+``reyn.safe.mcp.registry`` (= the internal ``_http_get_json`` helper) so
+tests exercise the real keyword-extraction / cache / dedup / dict-shape
+code path. The HTTP boundary is the only mocked thing; the rest is real.
 
 Invariants:
   - Keyword extraction from mixed-language text is deterministic.
   - fetch_registry_results returns the expected dict shape.
   - On registry error, returns empty candidates with source="error".
-  - On stale cache fallback, returns candidates with source="registry_stale".
+  - Empty input text yields source="error" without HTTP calls.
+
+FP-0042 Phase 2.4 (2026-05-23): tests updated to match the safe-mode
+rewrite of ``mcp_search/registry_fetch.py``. The legacy
+``"registry_stale"`` source was folded into ``"registry"`` because the
+safe.mcp.registry layer handles cache transparency internally (= callers
+don't distinguish fresh-vs-stale; both surface as ``"registry"``).
 """
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from unittest import mock
 
 import pytest
 
 import reyn.registry.cache as cache_mod
+import reyn.safe.mcp.registry as safe_registry
 from reyn.stdlib.skills.mcp_search.registry_fetch import (
     _extract_keyword,
     fetch_registry_results,
@@ -99,27 +105,32 @@ def test_extract_keyword_purely_japanese():
 # ---------------------------------------------------------------------------
 
 
-def _make_http_patcher(response_body: dict, status: int = 200):
-    """Patch ``reyn.api.unsafe.http.get`` to return a fixed response envelope."""
-    body_str = json.dumps(response_body)
+def _patch_safe_http(response_body: dict | None = None, raise_error: Exception | None = None):
+    """Patch ``reyn.safe.mcp.registry._http_get_json`` to return a fixed payload
+    or raise the given exception."""
 
-    def _fake_get(url, *, headers=None, timeout=30):
-        return {"status": status, "body": body_str, "headers": {}}
+    def _fake(url: str) -> dict:
+        if raise_error is not None:
+            raise raise_error
+        return response_body or {}
 
-    return mock.patch("reyn.stdlib.skills.mcp_search.registry_fetch.http_get", _fake_get)
+    return mock.patch.object(safe_registry, "_http_get_json", _fake)
 
 
-def test_fetch_registry_happy_path(tmp_path):
+@pytest.fixture
+def _isolated_cache(tmp_path, monkeypatch):
+    """Redirect the disk cache to a per-test tmp dir so cache state doesn't leak."""
+    monkeypatch.setattr(cache_mod, "_cache_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def test_fetch_registry_happy_path(_isolated_cache):
     """Tier 2: fetch_registry_results returns expected dict shape on success."""
     artifact = {"data": {"text": "Slack 連携できる MCP サーバーを探して"}}
 
-    with mock.patch.object(cache_mod, "_cache_dir", return_value=tmp_path):
-        with _make_http_patcher(_SLACK_RESPONSE):
-            result = fetch_registry_results(artifact)
+    with _patch_safe_http(_SLACK_RESPONSE):
+        result = fetch_registry_results(artifact)
 
-    assert "candidates" in result
-    assert "source" in result
-    assert "query" in result
     assert result["source"] == "registry"
     assert result["query"] == "slack"
 
@@ -132,14 +143,13 @@ def test_fetch_registry_happy_path(tmp_path):
     assert "Slack" in c["description"]
 
 
-def test_fetch_registry_empty_candidates(tmp_path):
+def test_fetch_registry_empty_candidates(_isolated_cache):
     """Tier 2: fetch_registry_results returns empty list when registry returns no servers."""
     artifact = {"data": {"text": "some very obscure thing"}}
     empty_response = {"servers": [], "metadata": {"count": 0}}
 
-    with mock.patch.object(cache_mod, "_cache_dir", return_value=tmp_path):
-        with _make_http_patcher(empty_response):
-            result = fetch_registry_results(artifact)
+    with _patch_safe_http(empty_response):
+        result = fetch_registry_results(artifact)
 
     assert result["candidates"] == []
     assert result["source"] == "registry"
@@ -150,68 +160,61 @@ def test_fetch_registry_empty_candidates(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_fetch_registry_error_returns_empty(tmp_path):
-    """Tier 2: On RegistryError with no cache, returns source='error' with empty candidates."""
+def test_fetch_registry_error_returns_empty(_isolated_cache):
+    """Tier 2: registry error with no cache returns source='error' + empty list."""
     artifact = {"data": {"text": "PostgreSQL database"}}
 
-    with mock.patch.object(cache_mod, "_cache_dir", return_value=tmp_path):
-        with _make_http_patcher({}, status=503):
-            result = fetch_registry_results(artifact)
+    with _patch_safe_http(raise_error=safe_registry.RegistryError("HTTP 503")):
+        result = fetch_registry_results(artifact)
 
     assert result["candidates"] == []
     assert result["source"] == "error"
 
 
-def test_fetch_registry_error_with_stale_cache(tmp_path):
-    """Tier 2: On RegistryError with stale cache present, returns source='registry_stale'."""
-    import time
-
+def test_fetch_registry_cached_response_used_when_http_errors(_isolated_cache):
+    """Tier 2: when a previous successful response is cached, a subsequent
+    HTTP error still surfaces the cached candidates (= cache hit short-circuits
+    the HTTP path entirely, no error visible to caller)."""
+    # Prime the cache with a real response.
     artifact = {"data": {"text": "Slack integration"}}
-    query = "slack"
-    limit = 20
-    cache_key = f"search:{query}:{limit}"
+    with _patch_safe_http(_SLACK_RESPONSE):
+        first = fetch_registry_results(artifact)
+    assert first["source"] == "registry"
+    assert len(first["candidates"]) == 1
 
-    # Pre-populate cache with stale data.
-    with mock.patch.object(cache_mod, "_cache_dir", return_value=tmp_path):
-        cache_mod.set(cache_key, _SLACK_RESPONSE)
-        # Push mtime to 25h ago so it's "stale" for TTL, but we still want
-        # the fallback path — the client raises RegistryError before cache TTL matters.
-        # (cache.get would still return it if mtime is recent, but RegistryError
-        #  triggers the fallback branch directly.)
-        with _make_http_patcher({}, status=503):
-            result = fetch_registry_results(artifact)
+    # Now make HTTP error — should still see cached candidates because the
+    # cache is hot for the same query key.
+    with _patch_safe_http(raise_error=safe_registry.RegistryError("HTTP 503")):
+        second = fetch_registry_results(artifact)
 
-    # With stale cache present and registry error, should fall back.
-    assert result["source"] in ("registry_stale", "registry")
-    assert isinstance(result["candidates"], list)
+    assert second["source"] == "registry"
+    assert len(second["candidates"]) == 1
 
 
-def test_fetch_registry_empty_text(tmp_path):
-    """Tier 2: Empty input text returns empty candidates without making HTTP calls."""
+def test_fetch_registry_empty_text(_isolated_cache):
+    """Tier 2: empty input returns source='error' without invoking HTTP."""
     artifact = {"data": {"text": ""}}
     call_count = 0
 
-    def _fake_get(url, *, headers=None, timeout=30):
+    def _spy(url: str) -> dict:
         nonlocal call_count
         call_count += 1
-        return {"status": 200, "body": '{"servers": []}', "headers": {}}
+        return {"servers": []}
 
-    with mock.patch.object(cache_mod, "_cache_dir", return_value=tmp_path):
-        with mock.patch("reyn.stdlib.skills.mcp_search.registry_fetch.http_get", _fake_get):
-            result = fetch_registry_results(artifact)
+    with mock.patch.object(safe_registry, "_http_get_json", _spy):
+        result = fetch_registry_results(artifact)
 
     assert result["candidates"] == []
     assert result["source"] == "error"
-    assert call_count == 0  # no HTTP call when query is empty
+    assert call_count == 0
 
 
-def test_fetch_registry_missing_data_key(tmp_path):
-    """Tier 2: Artifact without 'data' key is handled gracefully."""
+def test_fetch_registry_missing_data_key(_isolated_cache):
+    """Tier 2: artifact without 'data' key is handled gracefully."""
     artifact = {}
 
-    with mock.patch.object(cache_mod, "_cache_dir", return_value=tmp_path):
-        with _make_http_patcher({}, status=503):
-            result = fetch_registry_results(artifact)
+    with _patch_safe_http(raise_error=safe_registry.RegistryError("HTTP 503")):
+        result = fetch_registry_results(artifact)
 
     assert result["candidates"] == []
     assert result["source"] == "error"

--- a/tests/test_safe_mcp_registry.py
+++ b/tests/test_safe_mcp_registry.py
@@ -1,0 +1,228 @@
+"""Tier 2 — reyn.safe.mcp.registry contract tests (FP-0042 Phase 2.4).
+
+Tests the ``search`` and ``lookup`` public surface that safe-mode skills
+import. The HTTP boundary (``_http_get_json``) is the only mocked seam;
+everything else (= cache, dedup, dict reshape, 404 → None handling) runs
+real against a per-test tmp cache dir.
+
+Threat-model rationale (= URL hardcoded, no permission gate, ambient
+treatment) is documented in the module docstring and Issue #571.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import reyn.registry.cache as cache_mod
+import reyn.safe.mcp.registry as sr
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def _isolated_cache(tmp_path, monkeypatch):
+    """Redirect the disk cache to per-test tmp dir."""
+    monkeypatch.setattr(cache_mod, "_cache_dir", lambda: tmp_path)
+    return tmp_path
+
+
+_SEARCH_RESPONSE = {
+    "servers": [
+        {
+            "server": {
+                "name": "io.github.foo/bar-mcp",
+                "description": "Bar MCP server",
+                "repository": {"url": "https://github.com/foo/bar-mcp"},
+                "version": "1.0.0",
+                "packages": [{"registryType": "npm", "identifier": "@foo/bar"}],
+            },
+            "_meta": {
+                "io.modelcontextprotocol.registry/official": {"isLatest": True},
+            },
+        }
+    ],
+    "metadata": {"count": 1},
+}
+
+_VERSIONS_LATEST_RESPONSE = {
+    "server": {
+        "name": "io.github.modelcontextprotocol/server-filesystem",
+        "description": "Filesystem MCP server",
+        "version": "0.6.2",
+        "repository": {"url": "https://github.com/modelcontextprotocol/servers"},
+        "$schema": "https://static.modelcontextprotocol.io/schemas/server.schema.json",
+        "packages": [{"registryType": "npm", "identifier": "@modelcontextprotocol/server-filesystem"}],
+        "remotes": [],
+    }
+}
+
+
+def _patch_http(payload=None, raise_error=None):
+    """Patch ``_http_get_json`` to return a payload or raise an error."""
+
+    def _fake(url: str) -> dict:
+        if raise_error is not None:
+            raise raise_error
+        return payload or {}
+
+    return mock.patch.object(sr, "_http_get_json", _fake)
+
+
+# ── search ─────────────────────────────────────────────────────────────────
+
+
+def test_search_returns_dict_list_with_expected_shape(_isolated_cache):
+    """Tier 2: search returns list of dicts shaped {name, description, repo_url, runtime_hint}."""
+    with _patch_http(_SEARCH_RESPONSE):
+        result = sr.search("bar")
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    entry = result[0]
+    assert set(entry.keys()) == {"name", "description", "repo_url", "runtime_hint"}
+    assert entry["name"] == "io.github.foo/bar-mcp"
+    assert entry["repo_url"] == "https://github.com/foo/bar-mcp"
+    assert entry["runtime_hint"] == "npx"
+
+
+def test_search_empty_query_returns_empty_list_no_http(_isolated_cache):
+    """Tier 2: empty query short-circuits, no HTTP call."""
+    call_count = 0
+
+    def _spy(url: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {}
+
+    with mock.patch.object(sr, "_http_get_json", _spy):
+        assert sr.search("") == []
+
+    assert call_count == 0
+
+
+def test_search_caches_response_disk(_isolated_cache):
+    """Tier 2: second call with same query reads from cache, no HTTP call."""
+    call_count = 0
+
+    def _counting_http(url: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return _SEARCH_RESPONSE
+
+    with mock.patch.object(sr, "_http_get_json", _counting_http):
+        first = sr.search("bar", limit=10)
+        second = sr.search("bar", limit=10)
+
+    assert first == second
+    assert call_count == 1, f"Expected 1 HTTP call (cache hit on 2nd), got {call_count}"
+
+
+def test_search_propagates_registry_error(_isolated_cache):
+    """Tier 2: RegistryError from the HTTP layer propagates to the caller."""
+    with _patch_http(raise_error=sr.RegistryError("HTTP 503")):
+        with pytest.raises(sr.RegistryError, match="HTTP 503"):
+            sr.search("anything")
+
+
+def test_search_dedups_multiple_versions(_isolated_cache):
+    """Tier 2: when registry returns multiple versions of one server, only
+    the latest survives (= reuses reyn.registry.client._dedup_by_latest)."""
+    payload = {
+        "servers": [
+            {
+                "server": {
+                    "name": "io.github.foo/dup",
+                    "description": "v1",
+                    "version": "1.0.0",
+                    "repository": {"url": "https://example.com/dup"},
+                    "packages": [{"registryType": "npm", "identifier": "@foo/dup"}],
+                },
+            },
+            {
+                "server": {
+                    "name": "io.github.foo/dup",
+                    "description": "v2",
+                    "version": "2.0.0",
+                    "repository": {"url": "https://example.com/dup"},
+                    "packages": [{"registryType": "npm", "identifier": "@foo/dup"}],
+                },
+                "_meta": {"io.modelcontextprotocol.registry/official": {"isLatest": True}},
+            },
+        ]
+    }
+    with _patch_http(payload):
+        result = sr.search("dup")
+
+    assert len(result) == 1
+    assert result[0]["description"] == "v2"  # latest wins
+
+
+# ── lookup ─────────────────────────────────────────────────────────────────
+
+
+def test_lookup_returns_dict_on_hit(_isolated_cache):
+    """Tier 2: lookup of a known server_id returns the dict shape."""
+    with _patch_http(_VERSIONS_LATEST_RESPONSE):
+        result = sr.lookup("io.github.modelcontextprotocol/server-filesystem")
+
+    assert result is not None
+    assert result["name"] == "io.github.modelcontextprotocol/server-filesystem"
+    assert result["repo_url"] == "https://github.com/modelcontextprotocol/servers"
+
+
+def test_lookup_returns_none_on_404(_isolated_cache):
+    """Tier 2: a 404 from the registry surfaces as None (not raise)."""
+    with _patch_http(raise_error=sr.RegistryError("HTTP 404 for ...")):
+        result = sr.lookup("does/not-exist")
+
+    assert result is None
+
+
+def test_lookup_propagates_non_404_errors(_isolated_cache):
+    """Tier 2: registry errors other than 404 propagate."""
+    with _patch_http(raise_error=sr.RegistryError("HTTP 503 transient")):
+        with pytest.raises(sr.RegistryError, match="503"):
+            sr.lookup("any/thing")
+
+
+def test_lookup_empty_id_returns_none(_isolated_cache):
+    """Tier 2: empty server_id short-circuits to None, no HTTP call."""
+    call_count = 0
+
+    def _spy(url: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {}
+
+    with mock.patch.object(sr, "_http_get_json", _spy):
+        assert sr.lookup("") is None
+
+    assert call_count == 0
+
+
+def test_lookup_caches_response(_isolated_cache):
+    """Tier 2: second lookup of same server_id reads from cache."""
+    call_count = 0
+
+    def _counting_http(url: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return _VERSIONS_LATEST_RESPONSE
+
+    with mock.patch.object(sr, "_http_get_json", _counting_http):
+        first = sr.lookup("io.github.modelcontextprotocol/server-filesystem")
+        second = sr.lookup("io.github.modelcontextprotocol/server-filesystem")
+
+    assert first == second
+    assert call_count == 1
+
+
+# ── URL hardcoding regression ─────────────────────────────────────────────
+
+
+def test_base_url_is_hardcoded():
+    """Tier 2: regression guard — the registry URL must stay hardcoded to the
+    official MCP registry. If a future change adds env-var or config-driven
+    override, Issue #571 needs revisiting first (= permission shape decision)."""
+    assert sr._BASE_URL == "https://registry.modelcontextprotocol.io"


### PR DESCRIPTION
**[dogfood-coder]** — FP-0042 Phase 2.4. Stacked on #566. Do not merge until #553 + #557 + #562 + #566 land.

## Summary

- Both `mcp_install/registry_fetch.py` + `mcp_search/registry_fetch.py` migrate from mode: unsafe → mode: safe.
- New `reyn.safe.mcp.registry` module exposes `search(query, limit)` + `lookup(server_id)`. HTTP / disk cache / JSON parse / dedup all hidden behind these two semantic calls.
- URL hardcoded to `https://registry.modelcontextprotocol.io`. Env-var override (`REYN_MCP_REGISTRY_URL`) no longer honoured in safe-mode; unsafe-mode `reyn.registry.client` still respects it.
- Stdlib unsafe surface drops: `mcp_install` 1→0, `mcp_search` 1→0.

**Cumulative stdlib unsafe surface drop across FP-0042 Phase 2.1+2.2+2.3+2.4**:
- `index_docs`: 4 → 1 (`apply_strategy` deprecated compat)
- `index_events`: 3 → 0
- `mcp_install`: 1 → 0
- `mcp_search`: 1 → 0

## Architectural deferral — Issue #571

The migration surfaced 3 permission-design tensions that exceed Phase 2.4 scope:
- A. `safe.file` default-zone bypass of op-level gates (= safe-mode python can write `.reyn/mcp.yaml` without `mcp_install` op)
- B. reyn package internal I/O (= op handlers, registry client) is not permission-gated
- C. generic `safe.http` permission shape (host gating? bool flag? capability axis?)

These are tracked in [Issue #571](https://github.com/tya5/reyn/issues/571) and don't block Phase 2.4. The phase took the URL-hardcode + ambient-treatment path that doesn't prejudge any of the deferred decisions.

## API shape

```python
from reyn.safe.mcp.registry import search, lookup, RegistryError

# Search returns list of plain dicts (JSON-friendly, no dataclasses)
candidates = search("slack", limit=20)
# [{ "name": ..., "description": ..., "repo_url": ..., "runtime_hint": ... }, ...]

# Lookup returns one dict or None (404 → None, other errors raise)
info = lookup("io.github.modelcontextprotocol/server-filesystem")
# None | { "name": ..., ... }
```

## Internal layering

`reyn.safe.mcp.registry` is reyn-package internal code (= not subject to the safe-mode AST validator). It freely imports `urllib.request` for HTTP, reuses `reyn.registry.cache` for disk cache, and reuses `reyn.registry.client._dedup_by_latest` + `reyn.registry.models.server_info_from_raw` for parse/dedup. The validator only rejects user-code imports outside the allowlist; `reyn.safe.*` is admitted, so user code only needs `from reyn.safe.mcp.registry import search`.

## Wiring + permission

- skill.md `permissions.python.{fn}.mode: safe` (= 2 perm entries flipped)
- No new permission flags. Existing `mcp_install: true` (= for the `mcp_install` op) stays as-is.
- No new file.write declarations needed (= mcp skills don't write outside default zones).

## Test plan

- [x] New Tier 2 contract suite for `reyn.safe.mcp.registry` — 11 tests covering search/lookup dict shape, empty-query short-circuit, disk cache hit, error propagation, dedup-by-latest, 404 → None, URL hardcode regression.
- [x] Existing `test_mcp_search_registry.py` updated to patch the new HTTP seam (`_http_get_json`) instead of the removed `http_get`. Stale-cache test merged into a "cache hit short-circuits HTTP" test (= legacy "registry_stale" source distinction was folded into the new uniform "registry" source).
- [x] Existing `test_mcp_install_skill.py` patch helpers swapped to target `reyn.safe.mcp.registry._http_get_json`.
- [x] `_validate_safe_ast` clean on both migrated `registry_fetch.py` modules.
- [x] Full sweep — `5190 passed, 8 skipped, 3 xfailed` (= +11 from Phase 2.3 baseline).
- [x] `ruff check` clean on changed files.
- [ ] Manual dogfood E2E — deferred until full stack (#553→#557→#562→#566→#571's resolution) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)