### PR TITLE
fix(skill_importer): artifact wiring — convert phase writes inter-phase artifact YAMLs (lint passes E2E)

### DIFF
--- a/src/reyn/stdlib/skills/skill_importer/phases/convert.md
+++ b/src/reyn/stdlib/skills/skill_importer/phases/convert.md
@@ -37,9 +37,29 @@ For each phase, decide:
 
 - `name` — short snake_case (e.g. `analyze`, `draft`, `review`)
 - `instructions` — the prose for that phase, lifted/condensed from the source
-- `input` — usually the previous phase's output artifact, or `user_message`
-  for the entry phase
+- `input` — name of an **artifact** (NOT a phase name). For the entry phase
+  this is normally `user_message` (stdlib). For every later phase this MUST
+  be a custom artifact name you define in Step 3 — typically named after
+  the previous phase's output, e.g. `<prev_phase>_result` or a domain noun
+  like `draft_text`. The lint will fail if `input` names a phase rather
+  than an artifact you've declared.
 - `can_finish` — true only on the last phase
+
+**CRITICAL — artifact coverage rule** (= same shape as ``skill_builder``):
+Every phase's ``input`` MUST be either ``user_message`` (stdlib) OR an
+artifact you write a YAML schema for in Step 4. If you split the source
+into N phases, you need at least N-1 inter-phase artifacts plus the
+final-output artifact. Counting check:
+
+  - 1-phase skill: 0 custom artifacts (the phase's ``input`` is
+    ``user_message``; ``final_output`` can be ``user_message`` too).
+  - 2-phase skill: 1 inter-phase artifact + 1 final-output artifact
+    (the final-output may reuse the inter-phase one if the second
+    phase produces the user-visible result directly).
+  - 3-phase skill: 2 inter-phase artifacts + 1 final-output (often
+    the last inter-phase IS the final output).
+
+Lint catches missing artifacts; write them all in Step 4.
 
 ### Optional: python preprocessor
 
@@ -127,7 +147,8 @@ If the URL contains a git commit SHA (e.g.
 ---
 type: phase
 name: <phase_name>
-input: <input_artifact_name>
+input: <input_artifact_name>     # MUST name an artifact (= user_message or a YAML
+                                 # file you write below). NEVER a phase name.
 role: <optional_role>
 can_finish: <true|false>
 allowed_ops: [<op_kinds>]
@@ -188,11 +209,73 @@ phase frontmatter and add a note in the `## Source` section that the
 user must `reyn run --allow-untrusted-python` for this skill to work.
 (Note: `unsafe` replaces the old `trusted` keyword as of FP-0014.)
 
-### `reyn/local/<slug>/artifacts/<art>.yaml` (only if needed)
+### `reyn/local/<slug>/artifacts/<art>.yaml` (one per non-stdlib artifact)
 
-If you defined a custom artifact in Step 3, write its YAML schema here.
-For passthrough skills using only `user_message`, no artifact files are
-needed (stdlib provides `user_message`).
+Write a YAML schema file for **every artifact** any phase declares as
+``input`` other than ``user_message``, **and** for the ``final_output``
+artifact if it isn't ``user_message``. Skipping this is the single
+biggest source of lint failures on import — the OS validates that
+every phase's input has a corresponding artifact definition.
+
+Per-file shape (= same format as ``skill_builder`` writes):
+
+```yaml
+name: <art>
+description: One sentence describing what this artifact contains.
+schema:
+  type: object
+  properties:
+    <field_name>:
+      type: <string|integer|number|boolean|array|object>
+      description: One sentence on what this field represents.
+    # ... more fields as needed ...
+  required: [<field_name>, ...]
+```
+
+Rules:
+
+- ``type: object`` at the top level — never a bare string / array.
+- Every property has a ``description``.
+- ``required`` lists the fields the consuming phase can rely on (= the
+  ones it dereferences in its instructions).
+- For an artifact that just carries text between phases, a single
+  ``text: { type: string }`` field is fine.
+- Match the field names the phase instructions actually reference
+  (``input_artifact.data.<field>``) — mismatched names cause the
+  consuming phase to see undefined fields at runtime.
+
+Examples for a 3-phase skill `pdf` (= our smoke-test case):
+
+```yaml
+# artifacts/extracted_pdf.yaml — what read_pdf produces
+name: extracted_pdf
+description: Raw text + page count extracted from a PDF source.
+schema:
+  type: object
+  properties:
+    text:        { type: string,  description: "Concatenated page text." }
+    page_count:  { type: integer, description: "Number of pages." }
+    source_path: { type: string,  description: "Original PDF path or URL." }
+  required: [text, page_count, source_path]
+```
+
+```yaml
+# artifacts/processed_pdf.yaml — what process_pdf produces
+name: processed_pdf
+description: Result of the requested PDF operation (text, file path, or both).
+schema:
+  type: object
+  properties:
+    operation: { type: string, description: "Which operation ran (merge/split/extract/etc.)." }
+    output_text: { type: string, description: "Text output if applicable (else empty)." }
+    output_path: { type: string, description: "File output path if applicable (else empty)." }
+  required: [operation]
+```
+
+For passthrough skills using only ``user_message`` end-to-end (= rare,
+truly single-phase imports), no artifact files are needed (stdlib
+provides ``user_message``). Anything with 2+ phases needs at least
+one custom artifact.
 
 ## Step 5 — Lint the result
 


### PR DESCRIPTION
**[e2e-coder]** — Imported skills failed lint because the LLM was told phases' ``input`` field could be "the previous phase's output artifact" but the instructions never required writing the actual artifact YAML files. Result: multi-phase imports landed as ``input: <phase_name>`` with no ``artifacts/*.yaml`` files — lint failed on every non-entry phase.

This PR rewrites the relevant ``convert.md`` steps so the LLM treats the artifact-coverage rule the way ``skill_builder`` already does, and writes a YAML file per inter-phase artifact.

## End-to-end repro

**Before** (the PR #560 smoke test discovered this):

```bash
reyn run skill_importer '{"text": "Import https://.../pdf/SKILL.md"}'
```
→ ``reyn/local/pdf/`` created with 3 phases, NO ``artifacts/`` directory.
→ ``lint_passed: false``, ``notes: "missing input artifacts between phases (process_pdf, read_pdf)"``

**After**:

```bash
reyn run skill_importer '{"text": "Import https://.../pdf/SKILL.md"}'
```
→ ``reyn/local/pdf/`` with 2 phases + 2 artifact YAMLs (``extracted_pdf.yaml``, ``processed_pdf.yaml``).
→ ``lint_passed: true``, 0 warnings.

## Changes

`src/reyn/stdlib/skills/skill_importer/phases/convert.md` (= 1 file, ~90 added)

### Step 2 — Decompose
- Clarifies the ``input`` field: artifact name, NEVER phase name.
- Adds a **"CRITICAL — artifact coverage rule"** mirroring ``skill_builder/plan_skill.md``'s coverage discipline. Every phase's ``input`` MUST be either ``user_message`` (stdlib) OR an artifact you write a YAML schema for in Step 4. Counting check spelled out for 1/2/3-phase skills.

### Step 4 — Write the files
- Per-phase template gains a comment on the ``input`` line.
- Sub-step "``artifacts/<art>.yaml`` (one per non-stdlib artifact)" replaces the prior "(only if needed)": explicit per-file shape, rules (top-level object, every property has a description, ``required`` matches what the consuming phase dereferences, field names match ``input_artifact.data.<field>``), and a worked example for the PDF case.

## Why this matters

PR #560 unblocked ``reyn run skill_importer`` end-to-end (= web_fetch reached phase OpContext's intervention_bus). This PR makes the imports **usable** — previously they wrote files that immediately failed lint, leaving the user with a skeleton needing manual repair before further use.

Combined with the under-trigger 4-PR cascade (#564 / #567 / #569 / #572), ``skill_importer`` now produces lint-passing skills that ship with the same triggering quality as the built-ins, provided the source SKILL.md content is rich enough for faithful decomposition.

## Test plan

- [x] ``reyn skills validate skill_importer`` → OK
- [x] **Rootdir** verify: ``python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`` → 5217 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed
- [x] **End-to-end smoke**: re-imported the Anthropic PDF skill → ``lint_passed: true``, 2 phases + 2 artifact YAMLs written, ``notes: "All necessary artifact schemas were generated."``

## Out of scope (= deferred)

- **Description preservation**: imported ``description`` is still abbreviated to one sentence (e.g. Anthropic's full PDF trigger list compresses to "Use this skill whenever the user wants to do anything with PDF files."). Orthogonal to artifact wiring.
- **Multi-file follow**: SKILL.md → REFERENCE.md / FORMS.md / scripts/ pulled in when referenced. Current import grabs only the root SKILL.md.
- **Decomposition discipline**: avoid over-splitting content-heavy skills; single-phase is fine when the source is one big imperative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)