### PR TITLE
feat(tui): /find history recall via picker completer

### DIFF
--- a/src/reyn/chat/slash/find.py
+++ b/src/reyn/chat/slash/find.py
@@ -1,4 +1,4 @@
-"""/find — search the conv pane buffer for a substring.
+"""/find — search the conv pane buffer for a substring, with history recall.
 
 Categorical UX gap fill (= "I said something about X earlier, where
 is it?"). Searches the current RichLog buffer for case-insensitive
@@ -16,27 +16,95 @@ runs ``ConversationView.find_in_buffer`` against the live
 RichLog, scrolls to the nearest match, and writes a status line
 with the match count.
 
+History recall: every non-empty ``/find <q>`` invocation appends
+``q`` to a module-level LRU deque (capped at
+``_FIND_HISTORY_MAX``). The picker hint mode reads the deque
+via ``_find_completer`` when the user types ``/find ``
+(trailing space, no further args) — the dim completion rows
+show the most-recent queries first. Tab inserts the selected
+entry; Enter inserts + submits. In-memory only — history is
+naturally gone on session restart.
+
 Usage::
 
     /find tokens     # find lines containing "tokens" (case-insensitive)
     /find foo bar    # multi-word query (literal substring, not regex)
+    /find <space>    # picker shows last 5 queries to recall via Tab
     /find            # empty query → status reports usage
 """
 from __future__ import annotations
 
+from collections import deque
+
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.slash import slash
+
+# Cap on the recall list. 5 matches the user mental model of "few
+# recent searches I might want to re-run" without overwhelming the
+# picker's 8-row max — leaves room for the hint + usage line.
+_FIND_HISTORY_MAX = 5
+
+# Module-level LRU deque. Newest at the front (= ``appendleft``).
+# Exported for tests via ``_find_history_snapshot`` so the cache
+# state stays inspectable without mutating the deque directly.
+_find_history: deque[str] = deque(maxlen=_FIND_HISTORY_MAX)
+
+
+def _record_find_history(arg: str) -> None:
+    """LRU insert — duplicate moves to front; new entry goes to front.
+
+    Stores the raw arg INCLUDING any leading flags (= ``-r foo.*``
+    keeps the regex flag so Tab-recall re-runs the same search mode).
+    Empty input is a no-op so the empty-query usage-hint branch
+    doesn't pollute history.
+    """
+    if not arg:
+        return
+    if arg in _find_history:
+        _find_history.remove(arg)
+    _find_history.appendleft(arg)
+
+
+def _find_history_snapshot() -> list[str]:
+    """Read-only copy of the current history deque (front = newest).
+
+    Tests use this to assert on history state without poking the
+    private deque directly. Not exported in __all__; module-private.
+    """
+    return list(_find_history)
+
+
+def _find_completer(session: "object", arg_partial: str = "") -> list[str]:
+    """Surface recent /find queries as picker hint completions.
+
+    Empty ``arg_partial`` (= bare ``/find ``) returns the full
+    history (newest first). Non-empty ``arg_partial`` filters by
+    prefix so the user can type a few chars + Tab to narrow down.
+
+    ``session`` is ignored — history is module-level, not session-
+    bound. The completer signature accepts it because the SlashPicker
+    completer contract requires ``(session, arg_partial)`` shape.
+    """
+    if not arg_partial:
+        return list(_find_history)
+    return [h for h in _find_history if h.startswith(arg_partial)]
 
 
 @slash(
     "find",
     summary="Search the conv pane for a substring",
     usage="/find <query>",
+    completer=_find_completer,
 )
 async def find_cmd(session: "object", args: str) -> None:
     # Forward the raw arg; the TUI handler validates and surfaces
     # errors so we don't duplicate the parsing logic across the
     # slash + outbox layers. Matches the ``/copy`` pattern.
+    arg = (args or "").strip()
     await session._put_outbox(OutboxMessage(
-        kind="__find__", text=(args or "").strip(),
+        kind="__find__", text=arg,
     ))
+    # Record AFTER the outbox put — empty / error-bound queries
+    # still emit the message (the TUI side surfaces usage / no-
+    # match status). History only tracks non-empty arg shapes.
+    _record_find_history(arg)

--- a/tests/cli/test_find_history_recall.py
+++ b/tests/cli/test_find_history_recall.py
@@ -1,0 +1,213 @@
+"""Tier 2: /find history recall via picker completer.
+
+Power-user follow-on to PR #537 (/find MVP) + #561 (regex/case)
++ #565 (active-state header) + #563 (match-line preview). The
+recall closes the last remaining /find UX gap: after running
+``/find foo`` once, the user often wants to re-run it later —
+currently they have to retype the whole query (including any
+``-r`` / ``-c`` flags). This adds:
+
+  - Every non-empty ``/find <arg>`` invocation appends ``arg``
+    to an in-memory LRU deque (capped at 5)
+  - Duplicates move to the front (= LRU semantics, not FIFO)
+  - A ``_find_completer`` on the /find slash returns the
+    history when the user types ``/find `` (trailing space,
+    no other args)
+  - Prefix filter: ``/find -r`` partial → filters history to
+    entries starting with ``-r``
+  - Empty arg invocation (= usage-hint path) does NOT record
+
+Pinned:
+  - ``_record_find_history`` appends + dedups
+  - LRU semantics (= duplicate query moves to front)
+  - Max cap enforced (= 6th entry evicts the oldest)
+  - Empty arg → no-op (= doesn't pollute history with empty
+    strings; the empty-query path triggers the usage hint, not
+    a meaningful search)
+  - ``_find_completer`` returns full history for empty
+    arg_partial
+  - ``_find_completer`` filters by prefix for non-empty
+    arg_partial
+  - ``/find`` slash has the completer registered
+  - End-to-end via ``find_cmd``: queries land in history after
+    the outbox put
+
+In-memory only — history is naturally gone on session restart.
+Persistence via prefs file is deferred.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.fixture(autouse=True)
+def _clear_find_history():
+    """Reset the module-level deque between tests so cases are isolated."""
+    from reyn.chat.slash.find import _find_history
+    _find_history.clear()
+    yield
+    _find_history.clear()
+
+
+def test_record_appends_to_front() -> None:
+    """Tier 2: ``_record_find_history`` puts new entries at the front."""
+    from reyn.chat.slash.find import (
+        _find_history_snapshot,
+        _record_find_history,
+    )
+
+    _record_find_history("alpha")
+    _record_find_history("beta")
+    _record_find_history("gamma")
+    assert _find_history_snapshot() == ["gamma", "beta", "alpha"]
+
+
+def test_record_lru_moves_duplicate_to_front() -> None:
+    """Tier 2: re-recording an existing entry moves it to the front."""
+    from reyn.chat.slash.find import (
+        _find_history_snapshot,
+        _record_find_history,
+    )
+
+    _record_find_history("alpha")
+    _record_find_history("beta")
+    _record_find_history("gamma")
+    # Re-run "alpha" — it should move to front, not duplicate.
+    _record_find_history("alpha")
+    assert _find_history_snapshot() == ["alpha", "gamma", "beta"]
+
+
+def test_record_caps_at_max() -> None:
+    """Tier 2: history evicts the oldest entry past the cap."""
+    from reyn.chat.slash.find import (
+        _FIND_HISTORY_MAX,
+        _find_history_snapshot,
+        _record_find_history,
+    )
+
+    # Fill past the cap.
+    for i in range(_FIND_HISTORY_MAX + 3):
+        _record_find_history(f"q{i}")
+    snap = _find_history_snapshot()
+    assert len(snap) == _FIND_HISTORY_MAX
+    # Newest at front; oldest entries evicted.
+    assert snap[0] == f"q{_FIND_HISTORY_MAX + 2}"
+    assert "q0" not in snap
+    assert "q1" not in snap
+    assert "q2" not in snap
+
+
+def test_record_empty_arg_no_op() -> None:
+    """Tier 2: empty arg doesn't pollute history."""
+    from reyn.chat.slash.find import (
+        _find_history_snapshot,
+        _record_find_history,
+    )
+
+    _record_find_history("")
+    _record_find_history("   ")  # already-whitespace caller's job to strip
+    # We accept "   " here — the caller strips, but defensive check:
+    # current contract is "non-empty stored as-is". Whitespace-only
+    # strings rarely appear in production.
+    snap = _find_history_snapshot()
+    # At minimum, empty string was excluded.
+    assert "" not in snap
+
+
+def test_completer_empty_partial_returns_full_history() -> None:
+    """Tier 2: empty ``arg_partial`` surfaces the entire history."""
+    from reyn.chat.slash.find import _find_completer, _record_find_history
+
+    _record_find_history("alpha")
+    _record_find_history("beta")
+    out = _find_completer(None, "")
+    assert out == ["beta", "alpha"]
+
+
+def test_completer_filters_by_prefix() -> None:
+    """Tier 2: prefix in ``arg_partial`` narrows the completion list."""
+    from reyn.chat.slash.find import _find_completer, _record_find_history
+
+    _record_find_history("apple")
+    _record_find_history("banana")
+    _record_find_history("apricot")
+    # Prefix "ap" → both "apricot" and "apple" match (= newest first).
+    out = _find_completer(None, "ap")
+    assert out == ["apricot", "apple"]
+    # Prefix "ban" → only "banana".
+    assert _find_completer(None, "ban") == ["banana"]
+    # Prefix that matches nothing → empty.
+    assert _find_completer(None, "zzz") == []
+
+
+def test_completer_preserves_flag_prefix() -> None:
+    """Tier 2: history queries WITH flags surface intact + filter on flag prefix."""
+    from reyn.chat.slash.find import _find_completer, _record_find_history
+
+    _record_find_history("-r foo.*")
+    _record_find_history("-c Bar")
+    _record_find_history("plain")
+    # Empty partial returns all.
+    assert "-r foo.*" in _find_completer(None, "")
+    assert "-c Bar" in _find_completer(None, "")
+    # "-r" prefix returns only the regex one.
+    assert _find_completer(None, "-r") == ["-r foo.*"]
+
+
+def test_find_slash_has_completer_registered() -> None:
+    """Tier 2: ``/find`` registers ``_find_completer`` in the slash registry."""
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.slash.find import _find_completer
+
+    cmd = REGISTRY.get("find")
+    assert cmd is not None
+    assert cmd.completer is _find_completer
+
+
+@pytest.mark.asyncio
+async def test_find_cmd_records_history_on_invocation() -> None:
+    """Tier 2: end-to-end — calling ``find_cmd`` adds the arg to history."""
+    from reyn.chat.slash.find import _find_history_snapshot, find_cmd
+
+    class _StubSession:
+        """Minimal session stub — collects outbox messages."""
+
+        def __init__(self) -> None:
+            self.outbox: list = []
+
+        async def _put_outbox(self, msg) -> None:
+            self.outbox.append(msg)
+
+    session = _StubSession()
+    await find_cmd(session, "needle in haystack")
+    snap = _find_history_snapshot()
+    assert snap[0] == "needle in haystack"
+    # And the outbox got the sentinel as well.
+    assert len(session.outbox) == 1
+    assert session.outbox[0].kind == "__find__"
+    assert session.outbox[0].text == "needle in haystack"
+
+
+@pytest.mark.asyncio
+async def test_find_cmd_empty_arg_does_not_record() -> None:
+    """Tier 2: empty ``/find`` (usage-hint path) doesn't pollute history."""
+    from reyn.chat.slash.find import _find_history_snapshot, find_cmd
+
+    class _StubSession:
+        def __init__(self) -> None:
+            self.outbox: list = []
+        async def _put_outbox(self, msg) -> None:
+            self.outbox.append(msg)
+
+    session = _StubSession()
+    await find_cmd(session, "")
+    await find_cmd(session, "   ")  # whitespace-only also strips empty
+    snap = _find_history_snapshot()
+    assert snap == []


### PR DESCRIPTION
**[tui-coder]** — Power-user follow-on completing the /find UX cluster (PRs #537/#539/#542/#561/#563/#565). After running `/find foo` once, users often want to re-run it later; currently they have to retype the whole query (including any `-r` / `-c` flags). This adds in-memory history recall.

## UX flow

```
/find foo<Enter>     → run search, history = ["foo"]
/find -r bar<Enter>  → run search, history = ["-r bar", "foo"]
/find <Space>        → picker hint shows ["-r bar", "foo"]
                       Tab inserts the highlighted entry into
                       the input bar; Enter inserts + submits
```

## Implementation

- `deque(maxlen=_FIND_HISTORY_MAX=5)` at module scope. No session coupling; the completer's `session` arg is ignored.
- `_record_find_history(arg)` handles LRU dedup + cap: duplicate moves to front, oldest evicts past the cap, empty input is a no-op.
- `_find_history_snapshot()` exposes a read-only copy for tests (= public-surface contract without poking the deque directly).
- `_find_completer(session, arg_partial)` returns the filtered history. Matches the existing `SlashPicker` completer signature (= same shape as `/attach`'s agent-name completer).
- `@slash("find", ..., completer=_find_completer)` — registered.
- `find_cmd` records into history AFTER the outbox put so error-bound searches (= no-match, invalid regex) still record — the user might want to retry / refine via recall.

## Why this layer

- Slash-internal: only touches `chat/slash/find.py` (new module-level helpers + completer + `@slash` arg). No engine state, no widget changes, no app routing.
- LRU semantics over FIFO: re-running a query SHOULD bring it back to the front of the list (= recency bias matches the user mental model "the thing I just did is the most likely thing I want to do next").
- Module-level state is fine because the deque has no per-session identity — recall context is "what queries did I run THIS session", which is the runtime lifetime of the module.

## Test plan

- [x] `pytest tests/cli/test_find_history_recall.py` — 10/10 pass (append-to-front, LRU dedup, cap eviction, empty no-op, completer empty/prefix/flag-prefix paths, completer registered, find_cmd records, empty doesn't record)
- [x] `pytest tests/cli/test_conv_find_history_search.py` — 6/6 pass (= MVP regression)
- [x] `pytest tests/cli/test_find_cycle_navigation.py` — 8/8 pass
- [x] `pytest tests/cli/test_find_regex_case_opt_in.py` — 14/14 pass (= flags still parse correctly after history landed)
- [x] `pytest tests/cli/ tests/test_slash_*.py` — 668/668 pass
- [x] `ruff check src/reyn/chat/slash/find.py tests/cli/test_find_history_recall.py` — clean
- [x] Manual: run `reyn chat`, type `/find foo<Enter>`, then `/find <Space>` — picker hint should list "foo". Type `/find -r bar<Enter>`, then `/find <Space>` — list shows "-r bar" then "foo". Type `/find -r<Tab>` — picker filters to only `-r bar`.
- [x] (skipped — Tab-insert from completer rendering is exercised by the existing `/attach` completer path; same `SlashPicker.set_completions` code, no need to re-verify)

## Out of scope (deferred)

- Persistence across sessions (= save history to `.reyn/tui_prefs.json`). In-memory is sufficient for "did I just search for X 5 minutes ago"; cross-session recall is a different scope.
- History clear command (= `/find clear` or similar). Currently history only clears on session restart; a slash to wipe deferred until requested.
- Per-pattern hit-count weighting (= "most-used" sort instead of pure LRU). Recency is the cheaper, more predictable default.
