### PR TITLE
fix(skill_importer): preserve full description verbatim — stop compressing to one line

### DIFF
--- a/src/reyn/stdlib/skills/skill_importer/phases/convert.md
+++ b/src/reyn/stdlib/skills/skill_importer/phases/convert.md
@@ -68,8 +68,44 @@ From the source's frontmatter (or the registry candidate name) derive:
 
 - **Slug** — lowercase snake_case, e.g. `pdf_summarizer`, `code_reviewer`.
   Used as the directory name and the skill `name:` field.
-- **Description** — one line, in the user's language if the source had it
-  in that language.
+- **Description** — **preserve the source's full description verbatim** if
+  it already lists trigger contexts / synonyms. Do NOT compress to a
+  one-line summary — that loses the trigger fan-out and causes
+  under-triggering (= same defect class ``skill_builder`` PR #564 fights
+  for new skills, ``skill_improver`` Step 4c remediates for existing ones).
+
+  Anthropic skills typically ship a "pushy + trigger-aware" description
+  already, e.g. the PDF skill's source has:
+
+      Use this skill whenever the user wants to do anything with PDF files.
+      This includes reading or extracting text/tables from PDFs, combining
+      or merging multiple PDFs into one, splitting PDFs apart, rotating
+      pages, adding watermarks, creating new PDFs, filling PDF forms,
+      encrypting/decrypting PDFs, extracting images, and OCR on scanned
+      PDFs to make them searchable. If the user mentions a .pdf file or
+      asks to produce one, use this skill.
+
+  Copy that whole block into the imported ``description:`` field. Yes,
+  it's multiple sentences — that's correct. Reyn's chat router reads the
+  full ``description`` for trigger matching; trimming this is the most
+  common reason an imported skill stops getting picked.
+
+  When the source's description IS too narrow (= one short summary
+  sentence with no trigger fan-out), augment it Reyn-style by appending
+  "Use whenever the user asks to <action1>, <action2>, or
+  <related-phrasing> — even if they don't explicitly say
+  ``<skill_name>``." — derived from the body / phase instructions of the
+  source. Keep total ≤ 2-3 sentences, ≤ ~300 chars. Don't fabricate
+  capabilities the source doesn't describe.
+
+  Multi-line ``description`` in YAML uses the block-scalar form:
+
+  ```yaml
+  description: |
+    Use this skill whenever the user wants to do anything with PDF files.
+    This includes reading or extracting text/tables ...
+  ```
+
 - **Final output** — typically a `text` or `result` artifact. If the source
   produces structured data, declare a per-skill artifact for it; otherwise
   reuse `user_message` as a passthrough wrapper.
@@ -84,7 +120,8 @@ In one act turn, emit `file` ops with `op: write` for:
 ---
 type: skill
 name: <slug>
-description: <one-line>
+description: |
+  <source description, preserved verbatim or augmented per Step 3>
 entry: <first_phase_name>
 final_output: <output_artifact_name>
 final_output_description: <one-line>


### PR DESCRIPTION
**[e2e-coder]** — The convert phase used to instruct the LLM to compress the source's ``description`` into "one line". For Anthropic skills — whose canonical description format **already** lists trigger contexts to fight under-triggering — that compression silently dropped the entire trigger fan-out and left the imported skill with a bare one-sentence summary the chat router couldn't reliably match.

## End-to-end repro (= the Anthropic PDF skill)

**Source** ``SKILL.md`` description:
> Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.

**Pre-fix** imported description:
> Use this skill whenever the user wants to do anything with PDF files.
> (= first sentence only, all trigger contexts lost)

**Post-fix** imported description: full verbatim copy of the source, trigger fan-out preserved.

This is the same defect class ``skill_builder`` PR #564 fights for new skills and ``skill_improver`` Step 4c remediates for existing ones. With this PR, ``skill_importer`` no longer introduces the defect on imported skills.

## Changes (= 1 file, ~40 lines)

`src/reyn/stdlib/skills/skill_importer/phases/convert.md`:

- **Step 3** "Description" rule rewritten: preserve verbatim when source has trigger fan-out; augment Reyn-style when source is narrow (per PR #564 pattern); YAML syntax pointer to ``description: |`` block scalar.
- **Step 4** skill.md template updated: ``description: <one-line>`` → ``description: |\n  <multi-line block>``.

## E2E smoke (= verified)

```bash
reyn run skill_importer '{"text": "Import https://raw.githubusercontent.com/anthropics/skills/main/skills/pdf/SKILL.md"}'
```

Imported ``reyn/local/pdf/skill.md`` now carries the full Anthropic description block verbatim.

## Cumulative under-trigger 5-PR cascade

| PR | When | Surface |
|---|---|---|
| #564 | build-time | ``skill_builder`` pushy description |
| #567 | post-build | ``skill_improver`` Step 4c |
| #569 | build-time | ``skill_builder`` routing block |
| #572 | build-time | ``skill_builder`` iterate_with_evals |
| **this** | import-time | ``skill_importer`` preserves source description |

Every entry path into ``reyn/local/<name>/`` now either prevents under-triggering by construction (build / import) or remediates it on demand (improve).

## Test plan

- [x] ``reyn skills validate skill_importer`` → OK
- [x] **Rootdir** verify: ``python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`` → 5225 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed
- [x] **E2E smoke**: re-imported the Anthropic PDF skill → full multi-sentence description preserved in ``reyn/local/pdf/skill.md``

🤖 Generated with [Claude Code](https://claude.com/claude-code)