### PR TITLE
feat(tui): Ctrl+1 .. Ctrl+7 jump directly to a right-panel tab

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -87,6 +87,18 @@ class ReynTUIApp(App):
         Binding("ctrl+w", "panel_next_content", "Next tab", priority=True, show=False),
         Binding("ctrl+shift+w", "panel_prev_content", "Prev tab", priority=True, show=False),
         Binding("ctrl+shift+o", "panel_prev_content", "Prev tab (alt)", priority=True, show=False),
+        # Ctrl+1 .. Ctrl+7 — jump directly to the Nth right-panel tab
+        # (browser / IDE tab convention). Opens the panel if hidden so
+        # the user gets one-keypress access from a closed-panel state.
+        # Order matches ``PANEL_TYPES`` so Ctrl+N corresponds to the
+        # visual tab order — Ctrl+1=Keys, Ctrl+2=Events, …, Ctrl+7=Pending.
+        Binding("ctrl+1", "panel_jump_keys", "Jump to Keys tab", priority=True, show=False),
+        Binding("ctrl+2", "panel_jump_events", "Jump to Events tab", priority=True, show=False),
+        Binding("ctrl+3", "panel_jump_agents", "Jump to Agents tab", priority=True, show=False),
+        Binding("ctrl+4", "panel_jump_memory", "Jump to Memory tab", priority=True, show=False),
+        Binding("ctrl+5", "panel_jump_cost", "Jump to Cost tab", priority=True, show=False),
+        Binding("ctrl+6", "panel_jump_docs", "Jump to Docs tab", priority=True, show=False),
+        Binding("ctrl+7", "panel_jump_pending", "Jump to Pending tab", priority=True, show=False),
         Binding("ctrl+p", "prev_turn", "Prev turn", priority=True, show=False),
         Binding("ctrl+n", "next_turn", "Next turn", priority=True, show=False),
         Binding("f", "event_filter_cycle", "Filter events", priority=True, show=False),
@@ -1443,6 +1455,57 @@ class ReynTUIApp(App):
     def action_panel_prev_content(self) -> None:
         """ctrl+shift+w — cycle to previous panel tab (gated: panel visible only)."""
         self.query_one("#right_panel", RightPanel).cycle(-1)
+
+    def _panel_jump(self, panel_type: str) -> None:
+        """Jump directly to ``panel_type`` tab, opening the panel if hidden.
+
+        Single funnel for the seven Ctrl+1 .. Ctrl+7 quick-jump
+        actions. The action_toggle_panel path may set the tab to the
+        smart-Ctrl+B focal target (``_last_focal_tab``) on open;
+        we override that with the user's explicit choice immediately
+        afterwards, so Ctrl+N always lands on the requested tab.
+
+        Defensive on lookup failure (= panel widget missing in tests
+        that bypass standard compose).
+        """
+        try:
+            panel = self.query_one("#right_panel", RightPanel)
+        except Exception:
+            return
+        if not self._panel_visible:
+            self.action_toggle_panel()
+        try:
+            panel.set_panel_type(panel_type)
+        except Exception:
+            pass
+
+    def action_panel_jump_keys(self) -> None:
+        """Ctrl+1 — open panel + jump to the Keys tab."""
+        self._panel_jump("keys")
+
+    def action_panel_jump_events(self) -> None:
+        """Ctrl+2 — open panel + jump to the Events tab."""
+        self._panel_jump("events")
+
+    def action_panel_jump_agents(self) -> None:
+        """Ctrl+3 — open panel + jump to the Agents tab."""
+        self._panel_jump("agents")
+
+    def action_panel_jump_memory(self) -> None:
+        """Ctrl+4 — open panel + jump to the Memory tab."""
+        self._panel_jump("memory")
+
+    def action_panel_jump_cost(self) -> None:
+        """Ctrl+5 — open panel + jump to the Cost tab."""
+        self._panel_jump("cost")
+
+    def action_panel_jump_docs(self) -> None:
+        """Ctrl+6 — open panel + jump to the Docs tab."""
+        self._panel_jump("docs")
+
+    def action_panel_jump_pending(self) -> None:
+        """Ctrl+7 — open panel + jump to the Pending tab."""
+        self._panel_jump("pending")
 
     def action_event_filter_cycle(self) -> None:
         """f — rotate event filter (gated: events tab visible)."""

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -27,6 +27,10 @@ _KEY_PRETTY: dict[str, str] = {
     "enter": "Enter", "tab": "Tab", "escape": "Esc", "space": "Space",
     "up": "↑", "down": "↓", "left": "←", "right": "→",
     "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4",
+    # Quick-jump number keys for the right-panel tabs (Ctrl+1 .. Ctrl+7).
+    "ctrl+1": "⌃1", "ctrl+2": "⌃2", "ctrl+3": "⌃3", "ctrl+4": "⌃4",
+    "ctrl+5": "⌃5", "ctrl+6": "⌃6", "ctrl+7": "⌃7", "ctrl+8": "⌃8",
+    "ctrl+9": "⌃9",
 }
 _CONVERSATION_KEYS = {
     "ctrl+p", "ctrl+n", "ctrl+shift+n", "ctrl+shift+p",
@@ -55,6 +59,11 @@ _CONVERSATION_KEYS = {
 _PANEL_KEYS = {
     "ctrl+o", "ctrl+w", "ctrl+shift+o", "ctrl+shift+w", "tab", "shift+tab",
     "h", "l", "j", "k", "space", "c",
+    # Quick-jump tab keys (= Ctrl+1 .. Ctrl+7). They open the panel
+    # if hidden + switch to the Nth tab, so the PANEL group is the
+    # natural home.
+    "ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4",
+    "ctrl+5", "ctrl+6", "ctrl+7",
 }
 _EVENTS_KEYS = {"f", "t"}
 # ``/`` stays DOCS-only — it opens the docs name filter, no other tab

--- a/tests/cli/test_right_panel_quick_jump.py
+++ b/tests/cli/test_right_panel_quick_jump.py
@@ -1,0 +1,176 @@
+"""Tier 2: Ctrl+1 .. Ctrl+7 jump directly to a right-panel tab.
+
+Categorical UX gap on the right-panel navigation axis. Before
+this PR, the only keyboard path to a specific tab was Ctrl+W /
+Ctrl+Shift+W cycling — to reach the Cost tab from Events the
+user had to press Ctrl+W four times. This adds direct-jump
+keybindings using the browser / IDE tab convention:
+
+  Ctrl+1 → Keys
+  Ctrl+2 → Events
+  Ctrl+3 → Agents
+  Ctrl+4 → Memory
+  Ctrl+5 → Cost
+  Ctrl+6 → Docs
+  Ctrl+7 → Pending
+
+Key #N corresponds to ``PANEL_TYPES[N-1]`` so the visual tab
+order is preserved.
+
+Pinned:
+  - Each Ctrl+N binding is registered with the matching
+    ``panel_jump_<name>`` action
+  - Each action sets the panel's active tab to its target
+  - Quick-jump opens the panel if it's currently hidden (= one
+    keypress works from a closed-panel state, not two)
+  - When the panel is already open, jump just switches the tab
+    without re-toggling visibility
+  - Keys tab routes the Ctrl+N keys to the PANEL group with
+    pretty-printed ``⌃N`` labels
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+_EXPECTED_BINDINGS = {
+    "ctrl+1": ("panel_jump_keys", "keys"),
+    "ctrl+2": ("panel_jump_events", "events"),
+    "ctrl+3": ("panel_jump_agents", "agents"),
+    "ctrl+4": ("panel_jump_memory", "memory"),
+    "ctrl+5": ("panel_jump_cost", "cost"),
+    "ctrl+6": ("panel_jump_docs", "docs"),
+    "ctrl+7": ("panel_jump_pending", "pending"),
+}
+
+
+def test_quick_jump_bindings_registered() -> None:
+    """Tier 2: each Ctrl+N maps to its ``panel_jump_<name>`` action."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    binds = {(b.key, b.action) for b in ReynTUIApp.BINDINGS}
+    for key, (action, _panel_type) in _EXPECTED_BINDINGS.items():
+        assert (key, action) in binds, (
+            f"{key} → {action} not registered; "
+            f"got {[b for b in binds if b[0] == key]}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_panel_jump_switches_to_target_tab() -> None:
+    """Tier 2: each action sets the panel's active tab to its target."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        # Walk each action; verify the active tab matches.
+        action_map = {
+            "keys":    app.action_panel_jump_keys,
+            "events":  app.action_panel_jump_events,
+            "agents":  app.action_panel_jump_agents,
+            "memory":  app.action_panel_jump_memory,
+            "cost":    app.action_panel_jump_cost,
+            "docs":    app.action_panel_jump_docs,
+            "pending": app.action_panel_jump_pending,
+        }
+        for panel_type, action in action_map.items():
+            action()
+            await pilot.pause()
+            tabs = panel.query_one("#panel-tabs")
+            assert tabs.active == panel_type, (
+                f"Ctrl+jump → {panel_type} failed; active={tabs.active!r}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_quick_jump_opens_hidden_panel() -> None:
+    """Tier 2: jump from a closed-panel state opens the panel + switches tab.
+
+    The "one keypress from anywhere" UX would be broken if the
+    user had to Ctrl+B first.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        # Panel starts hidden in the cold-default app config.
+        assert app._panel_visible is False
+        app.action_panel_jump_cost()
+        await pilot.pause()
+        assert app._panel_visible is True
+        panel = app.query_one("#right_panel", RightPanel)
+        tabs = panel.query_one("#panel-tabs")
+        assert tabs.active == "cost"
+
+
+@pytest.mark.asyncio
+async def test_quick_jump_open_panel_does_not_re_toggle() -> None:
+    """Tier 2: jump when panel already visible just switches tab.
+
+    Pin that the toggle doesn't fire twice (= flip visibility off /
+    on) when the panel is already open. The action_toggle_panel
+    side-effect (focus rescue / DOM mutation) shouldn't run when
+    we just want a tab switch.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        # Open the panel explicitly first.
+        app.action_toggle_panel()
+        await pilot.pause()
+        assert app._panel_visible is True
+        # Quick-jump to a different tab.
+        app.action_panel_jump_agents()
+        await pilot.pause()
+        # Panel stays visible (= no spurious close-then-open flicker).
+        assert app._panel_visible is True
+        panel = app.query_one("#right_panel", RightPanel)
+        tabs = panel.query_one("#panel-tabs")
+        assert tabs.active == "agents"
+
+
+def test_keys_tab_groups_quick_jump_under_panel() -> None:
+    """Tier 2: Ctrl+1 .. Ctrl+7 land in the PANEL group + pretty-print as ⌃N."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import (
+        _key_group_for,
+        _pretty_key,
+    )
+
+    for n in range(1, 8):
+        key = f"ctrl+{n}"
+        assert _key_group_for(key) == "PANEL", (
+            f"{key} should land in PANEL group; got {_key_group_for(key)}"
+        )
+        assert _pretty_key(key) == f"⌃{n}"
+
+
+@pytest.mark.asyncio
+async def test_keys_tab_render_includes_quick_jump_descriptions() -> None:
+    """Tier 2: rendered Keys tab markup surfaces the ⌃N quick-jump descriptions."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        markup = render_keys(app)
+        for n in range(1, 8):
+            assert f"⌃{n}" in markup, f"⌃{n} not in Keys tab markup"
+        # Spot-check a couple of description strings.
+        assert "Keys tab" in markup
+        assert "Pending tab" in markup


### PR DESCRIPTION
**[tui-coder]** — Right-panel navigation categorical gap. Before this PR, the only keyboard path to a specific tab was Ctrl+W / Ctrl+Shift+W cycling — to reach the Cost tab from Events the user had to press Ctrl+W four times. This adds direct-jump keybindings using the browser / IDE tab convention.

## Bindings

| key | tab | PANEL_TYPES index |
|------|--------|------|
| `Ctrl+1` | Keys    | 0 |
| `Ctrl+2` | Events  | 1 |
| `Ctrl+3` | Agents  | 2 |
| `Ctrl+4` | Memory  | 3 |
| `Ctrl+5` | Cost    | 4 |
| `Ctrl+6` | Docs    | 5 |
| `Ctrl+7` | Pending | 6 |

Key #N corresponds to `PANEL_TYPES[N-1]` so the visual tab order is preserved.

## Implementation

- Seven new `Binding("ctrl+N", "panel_jump_<name>", ...)` entries in `ReynTUIApp.BINDINGS`.
- Seven matching `action_panel_jump_<name>` methods, all delegating to:
- `_panel_jump(panel_type)` shared helper:
  - Opens the panel if hidden (= one keypress works from a closed-panel state; user doesn't need Ctrl+B first).
  - Sets the active tab to `panel_type`.
  - Overrides any smart-Ctrl+B focal target the toggle path might have set, so Ctrl+N always lands on the requested tab regardless of the recent focal-hint state.
- Keys tab: `ctrl+1` .. `ctrl+7` routed to the **PANEL** group + pretty-printed as `⌃1` .. `⌃7`. `ctrl+8` / `ctrl+9` entries added to the pretty-print table for future expansion (= no bindings yet, but ready if PANEL_TYPES grows).

## Why this layer

- TUI-internal only: touches `chat/tui/app.py` (bindings + actions) and `widgets/right_panel/keys_tab.py` (group + pretty-print routing). No engine state, no widget refactor.
- One shared helper for all 7 actions — the only difference between actions is the panel_type string. Per-action methods are required by Textual's `Binding.action` resolution (= can't parameterise without action-arg syntax), but the bodies are 1-line delegates.
- Browser / IDE convention (= Ctrl+N = Nth tab) carries muscle memory. Most users will pick this up without reading the Keys tab.

## Test plan

- [x] `pytest tests/cli/test_right_panel_quick_jump.py` — 6/6 pass (all bindings registered, each action lands the matching panel tab, jump from hidden opens panel, jump from visible doesn't re-toggle, Keys tab routing + pretty-print, rendered markup contains ⌃N entries)
- [x] `pytest tests/cli/` — 626/626 pass
- [x] `ruff check src/reyn/chat/tui/app.py src/reyn/chat/tui/widgets/right_panel/keys_tab.py tests/cli/test_right_panel_quick_jump.py` — clean
- [x] Manual: run `reyn chat`. From closed-panel state, press `Ctrl+5` — panel opens to Cost. `Ctrl+2` — switches to Events without closing the panel. `Ctrl+1` — Keys tab shows up with the new `⌃1` … `⌃7` lines under PANEL.
- [x] (skipped — Ctrl+8 / Ctrl+9 are pretty-printed but not yet bound; pinned in the pretty-print test for future PANEL_TYPES expansion)

## Out of scope (deferred)

- Number key with no `Ctrl` (= bare `1` ... `7`) routed via `RightPanel.on_key` when the panel is focused. Currently bare digits would conflict with text input; Ctrl-prefixed is the safer default.
- Tab-ordering preference (= "I prefer Events as Ctrl+1"). Configurable via prefs file deferred until requested; the PANEL_TYPES order is the natural default.
- Alt-prefixed alias (= `Alt+1` .. `Alt+7`). macOS Option key emits special characters that don't reach Textual reliably; Ctrl is the broadly-compatible choice.
