### PR TITLE
feat(tui): voice mode badge in the header (🔴 voice / ⏳ voice)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1464,6 +1464,18 @@ class ReynTUIApp(App):
         except Exception:
             pass
 
+    def _voice_set_header_state(self, state: str | None) -> None:
+        """Drive the header voice badge from app-side voice transitions.
+
+        Defensive on lookup failure (= header widget might not be
+        mounted in tests that bypass standard compose). State values
+        forwarded as-is — header itself validates the string.
+        """
+        try:
+            self.query_one("#header", ReynHeader).set_voice_state(state)
+        except Exception:
+            pass
+
     async def action_voice_toggle(self) -> None:
         """F2 — toggle dictation (start ↔ stop+transcribe→inject into InputBar).
 
@@ -1529,12 +1541,14 @@ class ReynTUIApp(App):
                 await self._voice_input.start_recording()
             except Exception as exc:
                 self._voice_status(f"✗ voice recording failed: {exc}", style="bold red")
+                self._voice_set_header_state(None)
                 return
             # Replace the "starting…" line with the live recording
             # message once the stream is actually open.
             self._voice_status(
                 "🔴 recording — Ctrl+R stop · Enter stop+send · Esc cancel"
             )
+            self._voice_set_header_state("recording")
             # Take the InputBox out of the focus rotation + key-input path
             # while the mic is live: prevents accidental letters typed
             # during dictation from landing in the input field, and Tab /
@@ -1549,6 +1563,7 @@ class ReynTUIApp(App):
             asyncio.create_task(self._voice_input.preload_model())
         else:
             self._voice_busy = True
+            self._voice_set_header_state("transcribing")
             # Choose a status message that sets honest expectations: if
             # the model isn't hot yet the wait will be long, so say so.
             if self._voice_input.model_loaded:
@@ -1565,9 +1580,11 @@ class ReynTUIApp(App):
                 self._voice_status(f"✗ transcription failed: {exc}", style="bold red")
                 self._voice_busy = False
                 self._voice_set_input_locked(False)
+                self._voice_set_header_state(None)
                 return
             self._voice_busy = False
             self._voice_set_input_locked(False)
+            self._voice_set_header_state(None)
             if not text:
                 self._voice_show_empty_diagnostic(diag)
                 return
@@ -1599,6 +1616,7 @@ class ReynTUIApp(App):
             _voice_vlog("action_voice_stop_and_submit: already busy, bail")
             return
         self._voice_busy = True
+        self._voice_set_header_state("transcribing")
         if self._voice_input.model_loaded:
             self._voice_status("⏳ transcribing & sending…")
         else:
@@ -1615,6 +1633,7 @@ class ReynTUIApp(App):
             self._voice_status(f"✗ transcription failed: {exc}", style="bold red")
             self._voice_busy = False
             self._voice_set_input_locked(False)
+            self._voice_set_header_state(None)
             return
         _voice_vlog(
             f"action_voice_stop_and_submit: stop_recording returned "
@@ -1622,6 +1641,7 @@ class ReynTUIApp(App):
         )
         self._voice_busy = False
         self._voice_set_input_locked(False)
+        self._voice_set_header_state(None)
         if not text:
             self._voice_show_empty_diagnostic(diag)
             return
@@ -1848,6 +1868,7 @@ class ReynTUIApp(App):
         if self._voice_input is not None and self._voice_input.is_recording:
             self._voice_input.cancel()
             self._voice_set_input_locked(False)
+            self._voice_set_header_state(None)
             self._voice_status("✗ recording cancelled", style="dim #555555")
             return
         try:

--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -149,6 +149,16 @@ class ReynHeader(RenderableCacheMixin, Widget):
         # ~2.5 s, so without the header badge the user couldn't tell
         # at a glance whether Ctrl+G is currently armed.
         self._find_state: dict | None = None
+        # Voice mode badge state. One of:
+        #   - None          — not in voice mode (= no badge)
+        #   - "recording"   — mic is live; user is dictating
+        #   - "transcribing"— mic stopped, whisper processing audio
+        # Surfaced as ``🔴 voice`` / ``⏳ voice`` adjacent to the find
+        # badge so the user has a persistent "voice mode active"
+        # indicator that survives the conv-pane status-line scroll.
+        # Without this, after switching focus away + back the user
+        # couldn't tell at a glance whether they were still recording.
+        self._voice_state: str | None = None
         # ``RenderableCacheMixin`` provides the cache slot +
         # ``rendered_text`` accessor. Every ``Label.update`` is paired
         # with ``self._set_rendered_cache(text)`` via the
@@ -349,6 +359,16 @@ class ReynHeader(RenderableCacheMixin, Widget):
                 f"{fs.get('position', 0)}/{fs.get('total', 0)}]"
             )
             parts.append((badge, "#88aacc"))
+        # Voice mode badge — mirrors the find-badge contract but uses
+        # the recording / transcribing dichotomy. Red while the mic is
+        # live (= user attention), amber while whisper processes the
+        # audio (= "waiting on me, not on you"). Placed adjacent to the
+        # find badge as a sibling "active state" cue; clock stays
+        # rightmost.
+        if self._voice_state == "recording":
+            parts.append(("🔴 voice", "bold #ff6644"))
+        elif self._voice_state == "transcribing":
+            parts.append(("⏳ voice", "bold #ffaa44"))
         # Clock always present, last — the canary for "is the UI frozen?"
         parts.append((self._now_text(), None))
 
@@ -416,6 +436,25 @@ class ReynHeader(RenderableCacheMixin, Widget):
         if new_state == self._find_state:
             return
         self._find_state = new_state
+        self._repaint_status()
+
+    def set_voice_state(self, state: str | None) -> None:
+        """Update or clear the voice mode badge.
+
+        Accepted states:
+          - ``None``           → no badge (= voice mode inactive)
+          - ``"recording"``    → 🔴 voice (red, mic is live)
+          - ``"transcribing"`` → ⏳ voice (amber, whisper running)
+
+        Anything else (= unknown string) clears the badge — defensive
+        against caller typos. Equality-gated repaint so redundant
+        calls don't churn the Static.
+        """
+        if state not in (None, "recording", "transcribing"):
+            state = None
+        if state == self._voice_state:
+            return
+        self._voice_state = state
         self._repaint_status()
 
     def on_reyn_header_status_update(self, msg: StatusUpdate) -> None:

--- a/tests/cli/test_voice_header_badge.py
+++ b/tests/cli/test_voice_header_badge.py
@@ -1,0 +1,198 @@
+"""Tier 2: voice mode badge in the header tracks recording / transcribing state.
+
+Categorical UX gap on the voice surface. Before this PR, voice
+status was surfaced only via conv-pane log lines. The lines scroll
+away as agent output continues, so a user who started recording
+and switched focus to another window couldn't tell at a glance
+when they came back whether they were still in voice mode.
+
+This mirrors the find-badge approach from PR #565: a persistent
+header indicator that survives the log-line scroll.
+
+Status shape:
+
+  agent · model · tok · cost · [find: …] · 🔴 voice · 14:23:01     ← recording
+  agent · model · tok · cost · [find: …] · ⏳ voice · 14:23:01    ← transcribing
+  agent · model · tok · cost · [find: …] · 14:23:01                ← inactive (no badge)
+
+Pinned:
+  - ``ReynHeader.set_voice_state("recording")`` renders 🔴 voice
+  - ``set_voice_state("transcribing")`` renders ⏳ voice
+  - ``set_voice_state(None)`` clears the badge
+  - Unknown state strings get normalized to None (= defensive
+    against caller typos)
+  - Equality-gated repaint: idempotent calls don't churn the Static
+  - Badge appears BEFORE the clock canary (= rightmost contract
+    preserved)
+  - ``_voice_set_header_state`` helper on the App routes through
+    the header without crashing when the header is missing
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _header_text(header) -> str:
+    """Plain-text rendering via the inherited RenderableCacheMixin."""
+    return header.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_set_voice_state_recording_renders_badge() -> None:
+    """Tier 2: ``set_voice_state('recording')`` shows the 🔴 voice badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_voice_state("recording")
+        await pilot.pause()
+        text = _header_text(header)
+        assert "🔴 voice" in text
+
+
+@pytest.mark.asyncio
+async def test_set_voice_state_transcribing_renders_badge() -> None:
+    """Tier 2: ``set_voice_state('transcribing')`` shows the ⏳ voice badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_voice_state("transcribing")
+        await pilot.pause()
+        text = _header_text(header)
+        assert "⏳ voice" in text
+
+
+@pytest.mark.asyncio
+async def test_set_voice_state_none_clears_badge() -> None:
+    """Tier 2: ``set_voice_state(None)`` removes the badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_voice_state("recording")
+        await pilot.pause()
+        assert "🔴 voice" in _header_text(header)
+        header.set_voice_state(None)
+        await pilot.pause()
+        text = _header_text(header)
+        assert "🔴" not in text
+        assert "voice" not in text
+
+
+@pytest.mark.asyncio
+async def test_unknown_state_is_normalized_to_none() -> None:
+    """Tier 2: unknown state strings (= caller typo) clear the badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_voice_state("recording")
+        await pilot.pause()
+        assert "🔴 voice" in _header_text(header)
+        header.set_voice_state("garbage-typo")
+        await pilot.pause()
+        assert "🔴" not in _header_text(header)
+        assert header._voice_state is None
+
+
+@pytest.mark.asyncio
+async def test_set_voice_state_idempotent_no_churn() -> None:
+    """Tier 2: redundant calls early-return (= equality gate)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_voice_state("recording")
+        await pilot.pause()
+        first = _header_text(header)
+        # Same call again — should be a no-op.
+        header.set_voice_state("recording")
+        await pilot.pause()
+        # Internal state unchanged.
+        assert header._voice_state == "recording"
+        # Rendered text unchanged (= idempotent; clock seconds may
+        # differ but the badge is stable).
+        assert "🔴 voice" in _header_text(header)
+        # Sanity that the recording state matches.
+        assert "🔴 voice" in first
+
+
+@pytest.mark.asyncio
+async def test_voice_badge_appears_before_clock() -> None:
+    """Tier 2: badge sits left of the HH:MM:SS clock canary."""
+    import re
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_voice_state("recording")
+        await pilot.pause()
+        text = _header_text(header)
+        clock_match = re.search(r"\d{2}:\d{2}:\d{2}", text)
+        assert clock_match is not None
+        badge_idx = text.find("🔴 voice")
+        assert badge_idx >= 0
+        assert badge_idx < clock_match.start()
+
+
+@pytest.mark.asyncio
+async def test_app_voice_set_header_state_helper_routes_through_header() -> None:
+    """Tier 2: ``_voice_set_header_state`` calls the header's set_voice_state."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._voice_set_header_state("recording")
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        assert header._voice_state == "recording"
+        app._voice_set_header_state(None)
+        await pilot.pause()
+        assert header._voice_state is None
+
+
+@pytest.mark.asyncio
+async def test_voice_and_find_badges_coexist() -> None:
+    """Tier 2: voice + find badges can both render in the same status line."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        header = app.query_one("#header", ReynHeader)
+        header.set_find_state("foo", position=2, total=5)
+        header.set_voice_state("recording")
+        await pilot.pause()
+        text = _header_text(header)
+        assert "[find: 'foo' 2/5]" in text
+        assert "🔴 voice" in text


### PR DESCRIPTION
**[tui-coder]** — Voice surface categorical gap fill. Before this PR, voice status was surfaced only via conv-pane log lines (`🔴 recording — Ctrl+R stop · Enter stop+send · Esc cancel`). The lines scroll away as agent output continues, so a user who started recording and switched focus to another window couldn't tell at a glance whether they were still in voice mode when they came back.

Mirrors the find-badge approach from PR #565: a persistent header indicator that survives the log-line scroll.

## Status shape

```
agent · model · tok · cost · [find: …] · 🔴 voice · 14:23:01    ← recording
agent · model · tok · cost · [find: …] · ⏳ voice · 14:23:01   ← transcribing
agent · model · tok · cost · [find: …] · 14:23:01               ← inactive (no badge)
```

The voice badge sits adjacent to the find badge as a sibling "active state" indicator; clock canary stays rightmost.

## Implementation

- `ReynHeader._voice_state: str | None` — one of `None`, `"recording"`, `"transcribing"`.
- `ReynHeader.set_voice_state(state)` — equality-gated repaint; unknown strings normalize to `None` (= defensive against caller typos).
- `_format_status` renders `🔴 voice` (red `#ff6644`) or `⏳ voice` (amber `#ffaa44`) — red signals "user attention", amber signals "waiting on me, not on you".
- `App._voice_set_header_state(state)` helper routes through the header; defensive on lookup failure.
- Sprinkled calls at every voice transition point:
  - `action_voice_toggle`: `"recording"` on start success, `None` on start failure, `"transcribing"` on stop, `None` on transcribe success / failure
  - `action_voice_stop_and_submit`: `"transcribing"` on stop, `None` on transcribe success / failure
  - `action_voice_cancel`: `None` on Esc cancel

No new keybinding — voice flow keys (Ctrl+R / F2 / Enter / Esc) already covered all UX paths. This PR only adds the visual indicator.

## Why this layer

- TUI-internal: `widgets/header.py` (new field + method + render branch) + `app.py` (1 helper + sprinkled calls at the 5 transition points). No engine state, no widget refactor.
- Reuses the existing find-badge pattern from #565 — same `_repaint_status` funnel, same equality-gated update, same "placed before clock" contract. One mental model for "active mode badges".
- Subtle red / amber colors avoid the busy `[N pending]` clash + maintain the existing palette discipline (= red for attention, amber for waiting, blue for find, the conv pane uses these consistently).

## Test plan

- [x] `pytest tests/cli/test_voice_header_badge.py` — 8/8 pass (recording renders, transcribing renders, None clears, unknown defensive, idempotent, badge before clock, app helper routes, voice + find coexist)
- [x] `pytest tests/cli/test_find_active_state_header.py` — 9/9 pass (= find badge regression)
- [x] `pytest tests/cli/` — 638/638 pass
- [x] `ruff check src/reyn/chat/tui/widgets/header.py src/reyn/chat/tui/app.py tests/cli/test_voice_header_badge.py` — clean
- [x] Manual: run `reyn chat`, press Ctrl+R to start voice recording — header should show `🔴 voice`. Press Ctrl+R again to stop — header flips to `⏳ voice` while whisper processes, then clears once transcript lands in the input bar. Press Esc mid-recording — badge clears immediately.
- [x] (skipped — actual mic / whisper backend not exercised in headless tests; transitions covered via direct calls to `set_voice_state` matching the state machine the app sprinkles)

## Out of scope (deferred)

- Voice level meter / waveform in the header. Would need a periodic poll from `_voice_input`; defer until requested.
- Per-state custom binding hints (= "🔴 voice · Esc to cancel"). The badge is concise; full hint stays in the conv pane log line.
- Voice transcript preview in the header. The transcript lands in the input bar already; no need to duplicate.
