### PR TITLE
feat(stdlib/ops_report): migrate aggregate.py to safe-mode (FP-0042 Phase 2.6)

### DIFF
--- a/docs/concepts/python-safe-mode.md
+++ b/docs/concepts/python-safe-mode.md
@@ -233,9 +233,6 @@ mirrors it for human reference.
 | Skill | Function | Why it remains unsafe |
 |-------|----------|----------------------|
 | `index_docs` | `apply_strategy` | Deprecated monolithic step kept for project-override compatibility (FP-0042 Phase 2.1 / 2.2 split the active flow into safe-mode `extract_and_split` + `write_chunks_with_lock`). |
-| `ops_report` | `collect_aggregate_fallback` | Globs event log + reads raw events. Outside FP-0042 Phase 2 listed scope. |
-| `ops_report` | `aggregate_from_raw_events` | Same as above — direct events read. |
-| `ops_report` | `collect_aggregate` | Back-compat wrapper that delegates to the fallback. |
 | `skill_improver` | `resolve_paths` | Legacy path resolver kept for direct callers (= same shape as the `eval_builder` migration finished in Phase 2.5). |
 | `skill_improver` | `collect_traces_fallback` | Globs `.reyn/events/**/*.jsonl` for trace dispatch. |
 | `skill_improver` | `collect_traces` | Back-compat wrapper. |

--- a/src/reyn/stdlib/skills/ops_report/aggregate.py
+++ b/src/reyn/stdlib/skills/ops_report/aggregate.py
@@ -1,26 +1,33 @@
-"""aggregate.py — I/O-using aggregations for ops_report (FP-0009 Component D).
+"""aggregate.py — safe-mode aggregations for ops_report (FP-0009 Component D).
 
 Public functions:
-  collect_aggregate(artifact)                              → dict   (back-compat wrapper; prefer dispatch_aggregate + collect_aggregate_fallback)
-  collect_aggregate_fallback(artifact)                     → dict   (mode: unsafe fallback; no-ops if upstream recalled)
+  collect_aggregate_fallback(artifact)                     → dict   (raw-events fallback)
   aggregate_from_raw_events(events_root, period_days, skills) → dict
 
-These functions use filesystem I/O (glob, os, pathlib) and must be declared
-``mode: unsafe`` in skill.md.
+The legacy ``collect_aggregate`` (= a thin back-compat wrapper that
+composed ``dispatch_aggregate`` + ``collect_aggregate_fallback``) was
+removed in FP-0042 Phase 2.6 — the active preprocessor chain in
+``phases/collect.md`` calls the two steps directly via skill.md
+``preprocessor`` entries, and the only remaining caller was the test
+suite. The composition lives there now (= ``_collect_aggregate`` helper
+in ``tests/test_ops_report_skill.py``).
 
-``aggregate_from_recall_chunks`` has been extracted to the sibling module
-``aggregate_pure.py`` (no unsafe imports) so it can be declared ``mode: safe``.
+FP-0042 Phase 2.6 (2026-05-23): migrated from mode: unsafe to mode: safe.
+File reads go through ``reyn.safe.file``; the event-file glob covers
+``.reyn/events/`` (= default-zone read), no skill.md ``file.read``
+declaration needed. Path manipulation uses plain string operations
+because ``pathlib`` is not on the safe-mode import allowlist.
 
-R-PURE-MODE-REDEFINE wave 3a: the preprocessor chain is now 3 steps:
-  1. recall run_op (unchanged)
-  2. ``dispatch_aggregate`` in ``aggregate_pure.py`` (mode: safe) — aggregates
-     recall chunks inline; returns ``{..., "_path": "recall"}`` or
-     ``{"_path": "needs_fallback", ...}`` sentinel.
-  3. ``collect_aggregate_fallback`` (this module, mode: unsafe) — no-ops when
-     upstream already recalled; otherwise walks ``.reyn/events/*.jsonl``.
+``aggregate_from_recall_chunks`` and ``dispatch_aggregate`` live in
+``aggregate_pure.py``; the two-file split is retained to keep that
+module's import graph minimal (= no ``glob`` import), but both modules
+are now ``mode: safe``.
 
-``collect_aggregate`` is kept as a back-compat wrapper (called by existing tests
-and any code that imports it directly); it dispatches to the new two-step path.
+R-PURE-MODE-REDEFINE wave 3a preprocessor chain (unchanged):
+  1. recall run_op
+  2. ``dispatch_aggregate`` in ``aggregate_pure.py`` (mode: safe)
+  3. ``collect_aggregate_fallback`` (this module, mode: safe) — walks
+     ``.reyn/events/*.jsonl`` only when upstream did not recall.
 
 All functions return the same aggregate-stats output shape. No LLM calls,
 no side effects beyond filesystem reads, fully testable at Tier 2.
@@ -33,17 +40,22 @@ from __future__ import annotations
 
 import glob as _glob_mod
 import json
-import os
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any
+
+from reyn.safe import file as _safe_file
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 _EPOCH_ISO = "1970-01-01T00:00:00Z"
 _ERROR_SAMPLE_MAX = 5
 _ERROR_EXCERPT_MAX = 200
+
+# POSIX stat-mode constants (= stat.S_IFMT / S_IFREG). Hard-coded because
+# the ``stat`` module is not on the safe-mode import allowlist.
+_S_IFMT = 0o170000
+_S_IFREG = 0o100000
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -53,7 +65,10 @@ def collect_aggregate_fallback(artifact: dict) -> dict:
     """Fallback raw-events aggregator. Runs unconditionally; no-ops if upstream
     dispatcher already produced stats.
 
-    Mode: unsafe — imports glob/os/pathlib for .reyn/events/*.jsonl walk.
+    FP-0042 Phase 2.6: mode: safe. Uses ``reyn.safe.file`` for event-file
+    reads + stat checks; ``glob.glob`` covers path enumeration (= safe-mode
+    allowlisted as a restricted ambient source per the 2026-05-15
+    R-PURE-MODE stdlib audit).
 
     If ``data.aggregate._path == "recall"``, the upstream ``dispatch_aggregate``
     step already computed real stats. Strip the sentinel and return them.
@@ -83,35 +98,8 @@ def collect_aggregate_fallback(artifact: dict) -> dict:
         period_days=period_days,
         skills=skills,
     )
-    result["_path"] = "raw_events"  # for debuggability; stripped below
     result.pop("_path", None)
     return result
-
-
-def collect_aggregate(artifact: dict) -> dict:
-    """Back-compat wrapper: dispatches to dispatch_aggregate then collect_aggregate_fallback.
-
-    Kept so that existing tests and any direct callers continue to work.
-    New preprocessor chains should use the 3-step split in collect.md instead.
-
-    Decision logic:
-      - if recall produced ≥1 chunk → pure inline aggregation (mode: safe path)
-      - else → ``aggregate_from_raw_events`` (= fallback: walk
-        ``.reyn/events/*.jsonl`` directly; index not built or empty)
-    """
-    from reyn.stdlib.skills.ops_report.aggregate_pure import dispatch_aggregate
-
-    # Step 1: pure dispatch — produces either recall stats or needs_fallback sentinel.
-    dispatched = dispatch_aggregate(artifact)
-
-    # Inject dispatched result as data.aggregate so collect_aggregate_fallback can read it.
-    import copy
-    patched = copy.deepcopy(artifact)
-    data = patched.setdefault("data", {})
-    data["aggregate"] = dispatched
-
-    # Step 2: fallback step (no-ops if dispatched._path == "recall").
-    return collect_aggregate_fallback(patched)
 
 
 def aggregate_from_raw_events(
@@ -121,9 +109,9 @@ def aggregate_from_raw_events(
 ) -> dict:
     """Walk events under events_root, group by run, return aggregated stats.
 
-    Scans all .jsonl files under *events_root* (non-recursively checks
-    events_root itself and one level of sub-dirs, as the P6 layout is
-    typically flat or date-partitioned).
+    Scans all ``.jsonl`` files under ``events_root`` recursively. FP-0042
+    Phase 2.6: file content + stat go through ``reyn.safe.file``; missing
+    directory or permission denial returns an empty aggregate.
 
     Args:
         events_root: Path to the events directory (e.g. ".reyn/events").
@@ -144,12 +132,11 @@ def aggregate_from_raw_events(
             "errors_sample":       list[str],  # last 5 error strings
         }
     """
-    root = Path(events_root)
-    if not root.exists() or not root.is_dir():
+    if not _path_exists_safe(events_root):
         return _empty_aggregate(period_days)
 
     cutoff = _utc_now() - timedelta(days=period_days)
-    event_files = _discover_event_files(root)
+    event_files = _discover_event_files(events_root)
 
     runs = _group_events_by_run(event_files)
     return _aggregate_runs(runs, cutoff=cutoff, skills=skills, period_days=period_days)
@@ -175,32 +162,73 @@ def _utc_now() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
-def _discover_event_files(root: Path) -> list[Path]:
-    """Discover all .jsonl files under root recursively."""
-    pattern = str(root / "**" / "*.jsonl")
+def _path_exists_safe(path: str) -> bool:
+    """Permission-aware existence check that does not raise.
+
+    ``reyn.safe.file.exists`` raises ``PermissionError`` when the path
+    falls outside the declared read zone. For the events-root probe, we
+    want a permission denial to count as "not present" so the step
+    degrades to an empty aggregate.
+    """
+    try:
+        return _safe_file.exists(path)
+    except (OSError, PermissionError):
+        return False
+
+
+def _is_regular_file(path: str) -> bool:
+    """Return True iff ``path`` exists and is a regular file.
+
+    Replacement for ``os.path.isfile`` (= ``os`` is not on the safe-mode
+    allowlist). Uses ``reyn.safe.file.stat`` and checks the POSIX mode
+    bits. Any error (missing, permission denied, broken symlink)
+    returns False — matches ``os.path.isfile``'s suppress-all-errors
+    behaviour.
+    """
+    try:
+        info = _safe_file.stat(path)
+    except (OSError, PermissionError):
+        return False
+    return (int(info.get("mode", 0)) & _S_IFMT) == _S_IFREG
+
+
+def _discover_event_files(events_root: str) -> list[str]:
+    """Discover all .jsonl files under events_root recursively.
+
+    Returns a list of path strings (= no pathlib, which is not on the
+    safe-mode allowlist). Filters to regular files via
+    :func:`_is_regular_file` to preserve the legacy ``os.path.isfile``
+    behaviour (= directory matches from broad globs are dropped).
+    """
+    pattern = f"{events_root}/**/*.jsonl"
     matches = _glob_mod.glob(pattern, recursive=True)
-    return [Path(m) for m in sorted(matches) if os.path.isfile(m)]
+    return sorted(m for m in matches if _is_regular_file(m))
 
 
-def _group_events_by_run(event_files: list[Path]) -> dict[str, list[dict]]:
-    """Group raw events by run_id."""
+def _group_events_by_run(event_files: list[str]) -> dict[str, list[dict]]:
+    """Group raw events by run_id.
+
+    Reads each event file via :mod:`reyn.safe.file` (= permission-gated).
+    Files outside the declared read zone, or that fail to parse, are
+    silently skipped — matches the legacy OSError-swallowing read loop.
+    """
     runs: dict[str, list[dict]] = defaultdict(list)
 
     for file_path in event_files:
         try:
-            with open(file_path, encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    run_id = _extract_run_id(event)
-                    runs[run_id].append(event)
-        except OSError:
+            content = _safe_file.read(file_path)
+        except (OSError, PermissionError):
             continue
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            run_id = _extract_run_id(event)
+            runs[run_id].append(event)
 
     return runs
 

--- a/src/reyn/stdlib/skills/ops_report/skill.md
+++ b/src/reyn/stdlib/skills/ops_report/skill.md
@@ -35,45 +35,32 @@ permissions:
       - ".reyn/events/"
       - ".reyn/index/"
   python:
-    # R-PURE-MODE wave 3a: dispatch_aggregate is pure — aggregates recall chunks
-    # inline via aggregate_from_recall_chunks. No glob/os/pathlib imports.
-    # Declared mode: safe; 99% hot path (recall hit) runs here.
+    # FP-0042 Phase 2.6 (2026-05-23): all 5 python steps run mode: safe.
+    # File reads + stat go through reyn.safe.file; ``glob.glob`` covers
+    # path enumeration (= restricted ambient source per the 2026-05-15
+    # R-PURE-MODE stdlib audit). ``.reyn/events/`` is inside the
+    # default-read zone (CWD), so no skill.md file.read declaration is
+    # required for the event-log walk.
     - module: ./aggregate_pure.py
       function: dispatch_aggregate
       mode: safe
       timeout: 10
 
-    # R-PURE-MODE wave 3a: collect_aggregate_fallback is honestly mode: unsafe
-    # (globs .reyn/events/*.jsonl). Runs unconditionally but no-ops if upstream
-    # dispatch_aggregate already produced recall stats (_path=recall).
+    # Fallback path: walks .reyn/events/*.jsonl via reyn.safe.file when
+    # upstream did not produce recall stats. No-ops on _path=recall.
     - module: ./aggregate.py
       function: collect_aggregate_fallback
-      mode: unsafe
+      mode: safe
       timeout: 30
 
-    # aggregate_pure.py imports only PURE_STDLIB_ALLOWLIST entries (collections,
-    # typing) — no glob/os/pathlib. R-PURE-MODE-REDEFINE wave 2 Class C fix:
-    # the function was already pure; extraction from aggregate.py unblocks the
-    # honest mode: safe declaration.
     - module: ./aggregate_pure.py
       function: aggregate_from_recall_chunks
       mode: safe
       timeout: 10
 
-    # aggregate.py imports `glob` at module level for .reyn/events/*.jsonl
-    # discovery. `glob` is intentionally outside the safe-mode allowlist
-    # (operator filesystem-state ingress per R-PURE-MODE). Stdlib unsafe is
-    # auto-allowed by `reyn run` via run.py:104-106.
     - module: ./aggregate.py
       function: aggregate_from_raw_events
-      mode: unsafe
-      timeout: 30
-
-    # Back-compat wrapper — kept for tests and direct callers. Delegates to
-    # dispatch_aggregate + collect_aggregate_fallback internally.
-    - module: ./aggregate.py
-      function: collect_aggregate
-      mode: unsafe
+      mode: safe
       timeout: 30
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
@@ -91,7 +78,7 @@ required_credentials: []
    - `dispatch_aggregate` (mode: safe) が recall chunks を inline 集計し、
      `{_path: "recall", ...stats}` を返す（hot path、99%）。
      chunks が空の場合は `{_path: "needs_fallback"}` sentinel を返す。
-   - `collect_aggregate_fallback` (mode: unsafe) が _path sentinel を検査し、
+   - `collect_aggregate_fallback` (mode: safe) が _path sentinel を検査し、
      recall 済みなら no-op（sentinel strip のみ）。needs_fallback なら
      `.reyn/events/*.jsonl` を直接スキャン（fallback path、1%）
    - 集計 dict (`aggregate`) を `summarize` フェーズへ渡す
@@ -138,7 +125,7 @@ reyn run ops_report '{"period_days": 30, "skills": ["swe_bench", "eval"]}'
    - chunks ≥ 1 → `aggregate_from_recall_chunks` で inline 集計、
      `{_path: "recall", ...stats}` を返す（hot path）
    - chunks = 0 / recall skip → `{_path: "needs_fallback", period_days, skills}` sentinel
-3. `collect_aggregate_fallback` (mode: unsafe) が sentinel を検査:
+3. `collect_aggregate_fallback` (mode: safe) が sentinel を検査:
    - _path = "recall" → sentinel strip のみ（no-op）
    - _path = "needs_fallback" → `aggregate_from_raw_events(".reyn/events", ...)` 実行
    - raw events も見つからない場合は `total_runs=0` の空集計を返す

--- a/tests/test_fp0042_stdlib_safe_only.py
+++ b/tests/test_fp0042_stdlib_safe_only.py
@@ -42,14 +42,6 @@ GRANDFATHERED_UNSAFE: set[tuple[str, str]] = {
     # back-compat. See docs/concepts/python-safe-mode.md.
     ("index_docs", "apply_strategy"),
 
-    # ops_report — outside FP-0042 Phase 2 listed scope. The fallback +
-    # back-compat steps perform event-log globbing + raw events read.
-    # Future "Phase 2.6" candidate; until then the existing operator
-    # opt-in via --allow-unsafe-python remains the gate.
-    ("ops_report", "collect_aggregate_fallback"),
-    ("ops_report", "aggregate_from_raw_events"),
-    ("ops_report", "collect_aggregate"),
-
     # skill_improver — outside FP-0042 Phase 2 listed scope. The fallback,
     # back-compat, and snapshot steps perform glob + skill.md read + write
     # to .reyn/skill-versions. Future "Phase 2.7" candidate.

--- a/tests/test_ops_report_skill.py
+++ b/tests/test_ops_report_skill.py
@@ -1,11 +1,18 @@
 """Tier 2: ops_report stdlib skill (FP-0009 Component D).
 
-Tests for aggregate.py pure functions:
+Tests for aggregate.py + aggregate_pure.py functions:
   aggregate_from_raw_events — walk .jsonl files and compute stats
   aggregate_from_recall_chunks — aggregate pre-fetched recall chunks
 
 All tests use real filesystem I/O (tmp_path) and real Python functions.
 No mocks, no AsyncMock, no patch decorators — per CLAUDE.md testing policy.
+
+FP-0042 Phase 2.6 (2026-05-23): ``aggregate.py`` migrated from mode:
+unsafe to mode: safe; file I/O now goes through ``reyn.safe.file``.
+The autouse ``_safe_file_context`` fixture below grants reads under
+``tmp_path`` so the safe-mode helpers can run inside the test process
+(= mirrors how the production preprocessor_executor wires the
+safe-mode subprocess).
 """
 from __future__ import annotations
 
@@ -15,16 +22,57 @@ from pathlib import Path
 
 import pytest
 
+from reyn.safe import file as sf
+
 # Module under test
 from reyn.stdlib.skills.ops_report.aggregate import (
     aggregate_from_raw_events,
-    collect_aggregate,
     collect_aggregate_fallback,
 )
 from reyn.stdlib.skills.ops_report.aggregate_pure import (
     aggregate_from_recall_chunks,
     dispatch_aggregate,
 )
+
+
+def collect_aggregate(artifact: dict) -> dict:
+    """Test helper: dispatches to dispatch_aggregate then collect_aggregate_fallback.
+
+    Was the back-compat wrapper in ``aggregate.py`` before FP-0042 Phase 2.6;
+    moved here because the active preprocessor chain calls the two steps
+    directly via skill.md, and the only consumer was this test module.
+
+    Hosting the composition in the test module also avoids the cross-module
+    ``reyn.stdlib.*`` import the safe-mode AST validator rejects.
+    """
+    import copy
+
+    dispatched = dispatch_aggregate(artifact)
+    patched = copy.deepcopy(artifact)
+    data = patched.setdefault("data", {})
+    data["aggregate"] = dispatched
+    return collect_aggregate_fallback(patched)
+
+
+@pytest.fixture(autouse=True)
+def _safe_file_context(tmp_path: Path):
+    """Grant reyn.safe.file read access over tmp_path for each test.
+
+    Mirrors the production wiring (= CWD as default read zone). Tests
+    in this module operate exclusively under tmp_path, so a wide grant
+    there matches the per-test sandbox model.
+    """
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
+    sf._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path)],
+    )
+    yield
+    sf._read_paths = ()
+    sf._write_paths = ()
+    sf._context_initialised = False
 
 # ── Fixtures / helpers ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
**[dogfood-coder]** — FP-0042 Phase 2.6. Stacked on #580 — 8-stack cascade. Do not merge until #553 + #557 + #562 + #566 + #573 + #575 + #580 land.

## Summary

Migrates all 3 previously-unsafe python steps in `ops_report` (`collect_aggregate_fallback`, `aggregate_from_raw_events`, `collect_aggregate`) to `mode: safe`. File reads + stat now route through `reyn.safe.file`; the `.reyn/events/**/*.jsonl` walk uses `glob.glob` (= restricted ambient source per the 2026-05-15 R-PURE-MODE stdlib audit) plus a `_is_regular_file` mode-bit check.

Pattern is the same as Phase 2.3 (`index_events`): in-place rewrite of `aggregate.py`, drop pathlib/os imports, use string-based path manipulation, autouse fixture in tests for permission context.

## `collect_aggregate` wrapper relocation

`collect_aggregate` was a back-compat composition of `dispatch_aggregate` + `collect_aggregate_fallback`. It used `from reyn.stdlib.skills.ops_report.aggregate_pure import dispatch_aggregate` inside the function body — and the safe-mode AST validator rejects `reyn.stdlib.*` cross-module imports (same constraint hit during Phase 2.1's split-helper duplication).

Since:
1. The active preprocessor chain in `phases/collect.md` calls the two underlying steps directly via skill.md (= production didn't use the wrapper).
2. The only caller was the test suite.

…the wrapper moves to `tests/test_ops_report_skill.py` as a local `collect_aggregate` helper. Production code is clean safe-mode.

## Cumulative across FP-0042 Phase 2.1–2.6

| Skill | Before | After |
|---|---|---|
| `index_docs` | 4 | 1 (`apply_strategy` compat) |
| `index_events` | 3 | 0 |
| `mcp_install` / `mcp_search` | 1 each | 0 |
| `eval_builder` | 1 | 0 |
| `ops_report` | 3 | **0** |
| `skill_improver` | 5 | 5 (= future Phase 2.7) |

The Phase 3 enforcement test (`tests/test_fp0042_stdlib_safe_only.py`) is updated in lock-step — 3 `ops_report` rows removed from `GRANDFATHERED_UNSAFE` and from the mirror table in `docs/concepts/python-safe-mode.md`. The stale-exemption guard would have fired otherwise.

## Test plan

- [x] Existing `test_ops_report_skill.py` (19 tests + 3 enforcement tests) — all pass against the migrated module + updated exemption set.
- [x] `_validate_safe_ast` clean on both `aggregate.py` and `aggregate_pure.py`.
- [x] Full sweep — `5194 passed, 8 skipped, 3 xfailed` (unchanged total: the migration drops 1 production wrapper test was internalised to the test file).
- [x] `ruff check` clean on changed files.
- [ ] Manual dogfood E2E — deferred until stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)