### PR TITLE
feat(tui): F5 / F6 jump to prev / next ErrorBox in the conv pane

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -150,6 +150,13 @@ class ReynTUIApp(App):
         # win against any widget-level binding.
         Binding("ctrl+g", "find_next", "Find next match", priority=True, show=False),
         Binding("ctrl+shift+g", "find_prev", "Find prev match", priority=True, show=False),
+        # F5 / F6 — jump to the prev / next mounted ErrorBox. Useful in
+        # debugging-heavy sessions where multiple errors stack up and
+        # the user wants to scroll through them quickly without
+        # manual page-up / page-down. Cycles with wrap; first press
+        # always targets the newest error.
+        Binding("f5", "jump_prev_error", "Prev error", priority=True, show=False),
+        Binding("f6", "jump_next_error", "Next error", priority=True, show=False),
         # Keyboard companion to the mouse-click skill-row drill-down
         # (= toggle phase-history expand). F3 avoids the Ctrl+letter
         # collision with TextArea's default editing shortcuts (ctrl+e
@@ -1445,6 +1452,32 @@ class ReynTUIApp(App):
         except Exception:
             pass
         return True
+
+    def _jump_error(self, direction: int) -> None:
+        """Shared helper for F5 / F6 error-jump dispatch."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+        except Exception:
+            return
+        if not conv.jump_to_error(direction):
+            try:
+                conv.show_status("no errors to jump to", kind="general")
+                self.set_timer(2.0, conv.hide_status)
+            except Exception:
+                pass
+
+    def action_jump_prev_error(self) -> None:
+        """F5 — jump to the previous (older) mounted ErrorBox.
+
+        First press from a fresh state targets the newest error;
+        subsequent presses walk backwards through the list with
+        wrap. No-op-with-hint when no errors are mounted.
+        """
+        self._jump_error(-1)
+
+    def action_jump_next_error(self) -> None:
+        """F6 — jump to the next (newer) mounted ErrorBox (wraps)."""
+        self._jump_error(+1)
 
     def action_skill_expand_toggle(self) -> None:
         """F3 — toggle drill-down on every in-flight SkillActivityRow.

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -362,6 +362,12 @@ class ConversationView(Widget):
         self._user_scrolled = False
         # Issue 5 — track mounted ErrorBoxes for Escape-to-dismiss
         self._error_boxes: list[ErrorBox] = []
+        # Cursor into ``_error_boxes`` for the F5 / F6 jump-to-error
+        # navigation. ``-1`` means "no cursor yet" (= first jump
+        # targets the newest error). Invalidated whenever a dismiss
+        # or auto-eviction mutates ``_error_boxes`` so the next jump
+        # re-seeds from the (now-different) newest error.
+        self._error_jump_cursor: int = -1
         # F9 timestamp toggle — default on. Loaded from tui_prefs.json in
         # on_mount; callers use toggle_timestamps() / show_timestamps property.
         # New messages rendered after a toggle use the new indent; past
@@ -1501,6 +1507,11 @@ class ConversationView(Widget):
         # auto-evicted by stack pressure.
         from rich.text import Text as _RichText
         while len(self._error_boxes) >= _MAX_VISIBLE_ERROR_BOXES:
+            # Auto-eviction shifts every remaining error's index down
+            # by 1; the jump cursor would silently point at the wrong
+            # box. Reset to -1 so the next F5 / F6 re-seeds from the
+            # post-eviction newest error.
+            self._error_jump_cursor = -1
             oldest = self._error_boxes.pop(0)
             old_first, _sep, _rest = (
                 getattr(oldest, "_message", "") or ""
@@ -1588,6 +1599,50 @@ class ConversationView(Widget):
         """Return True if any undismissed ErrorBox remains."""
         return bool(self._error_boxes)
 
+    def jump_to_error(self, direction: int) -> bool:
+        """Scroll the conv pane to the next / previous mounted ErrorBox.
+
+        ``direction``: ``+1`` for newer (forward through the list),
+        ``-1`` for older (backward). The list ordering is chronological
+        (= newest at end), so "forward" walks toward the most recent
+        error.
+
+        First call (= cursor unset) targets the NEWEST error (=
+        ``_error_boxes[-1]``) regardless of direction — that's almost
+        always the one the user wants to investigate first. Subsequent
+        calls cycle with wrap.
+
+        Returns True when a jump happened, False when no errors are
+        mounted. The caller surfaces a status hint in the False case;
+        the cursor advance + scroll happen inside this method.
+        """
+        if not self._error_boxes:
+            return False
+        if self._error_jump_cursor < 0 or self._error_jump_cursor >= len(self._error_boxes):
+            self._error_jump_cursor = len(self._error_boxes) - 1
+        else:
+            self._error_jump_cursor = (
+                self._error_jump_cursor + direction
+            ) % len(self._error_boxes)
+        target = self._error_boxes[self._error_jump_cursor]
+        try:
+            target.scroll_visible()
+        except Exception:
+            pass
+        # Suppress auto-scroll so the next outbox tick doesn't yank
+        # the view back to the tail.
+        self._user_scrolled = True
+        return True
+
+    def error_jump_cursor(self) -> int:
+        """Public read of the current error-jump cursor index (= test hook).
+
+        Returns -1 when the cursor is unset (= no jump fired yet) or
+        when the last dismissal invalidated it. Otherwise the
+        0-based index into ``_error_boxes`` of the last jump target.
+        """
+        return self._error_jump_cursor
+
     def dismiss_last_error(self) -> None:
         """Remove the most recently mounted ErrorBox + leave a breadcrumb.
 
@@ -1616,6 +1671,10 @@ class ConversationView(Widget):
         """
         if not self._error_boxes:
             return
+        # Reset the jump cursor — the list just changed shape; the next
+        # F5 / F6 should re-seed from the (now newest-remaining) error
+        # rather than land on a stale index.
+        self._error_jump_cursor = -1
         box = self._error_boxes.pop()
         first_line, _sep, _rest = (getattr(box, "_message", "") or "").partition("\n")
         if len(first_line) > 72:

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -123,7 +123,9 @@ _KEY_PRETTY: dict[str, str] = {
     "ctrl+shift+g": "⌃⇧G",
     "enter": "Enter", "tab": "Tab", "escape": "Esc", "space": "Space",
     "up": "↑", "down": "↓", "left": "←", "right": "→",
-    "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4", "f7": "F7", "f8": "F8", "f9": "F9",
+    "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4",
+    "f5": "F5", "f6": "F6", "f7": "F7", "f8": "F8",
+    "f9": "F9", "f10": "F10", "f11": "F11", "f12": "F12",
     # Quick-jump number keys for the right-panel tabs (Ctrl+1 .. Ctrl+7).
     "ctrl+1": "⌃1", "ctrl+2": "⌃2", "ctrl+3": "⌃3", "ctrl+4": "⌃4",
     "ctrl+5": "⌃5", "ctrl+6": "⌃6", "ctrl+7": "⌃7", "ctrl+8": "⌃8",
@@ -148,6 +150,9 @@ _CONVERSATION_KEYS = {
     # tasks), so CONVERSATION is the right home for discovery
     # alongside Ctrl+P / Ctrl+N turn jump.
     "f4",
+    # F5 / F6 — error block jump (= prev / next mounted ErrorBox).
+    # Conv-pane scoped: targets widgets inside the conv pane.
+    "f5", "f6",
     # W13 T2-1: ToolCallRow failure drill-down. Same rationale as F3 --
     # toggles inline expand on a widget that lives in the conv pane.
     "f7",

--- a/tests/cli/test_conv_error_jump.py
+++ b/tests/cli/test_conv_error_jump.py
@@ -1,0 +1,217 @@
+"""Tier 2: F5 / F6 jump to prev / next mounted ErrorBox in the conv pane.
+
+Categorical UX gap on the debugging axis. In sessions with
+multiple mounted ErrorBox widgets (= 2+ errors stacked under the
+conv pane), the user had no quick way to scroll between them —
+manual PageUp / PageDown or fine-grained cursor scroll was the
+only path. This adds:
+
+  - F5 → jump to previous (older) error
+  - F6 → jump to next (newer) error
+  - First press from fresh state targets the NEWEST error (=
+    almost always the one the user wants first)
+  - Cycle with wrap; cursor invalidated on dismiss / auto-eviction
+  - Status hint when no errors are mounted ("no errors to jump to")
+
+Pinned:
+  - ``jump_to_error(direction)`` returns False with no errors,
+    True after a scroll
+  - First call targets the newest error (= ``len-1`` index)
+  - Subsequent calls cycle with wrap (+1 wraps from last → first,
+    -1 wraps from first → last)
+  - ``dismiss_last_error()`` resets the cursor to -1
+  - Auto-eviction in ``mount_error`` resets the cursor
+  - F5 / F6 bindings registered with correct action names
+  - Keys tab routes F5 / F6 to CONVERSATION + pretty-prints
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_jump_to_error_no_errors_returns_false() -> None:
+    """Tier 2: ``jump_to_error`` with empty list returns False."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        assert conv.jump_to_error(+1) is False
+        assert conv.jump_to_error(-1) is False
+
+
+@pytest.mark.asyncio
+async def test_first_jump_targets_newest_error() -> None:
+    """Tier 2: first F5/F6 press lands on the newest (last-in-list) error."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="first error")
+        conv.mount_error(message="second error")
+        conv.mount_error(message="third error")
+        await pilot.pause()
+        # Cursor unset → both directions land on the newest.
+        assert conv.error_jump_cursor() == -1
+        assert conv.jump_to_error(+1) is True
+        # Cursor advanced to last index (= len-1 = 2 for 3 errors).
+        assert conv.error_jump_cursor() == 2
+
+
+@pytest.mark.asyncio
+async def test_cycle_forward_wraps_to_first() -> None:
+    """Tier 2: F6 past the last error wraps back to the first."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="a")
+        conv.mount_error(message="b")
+        conv.mount_error(message="c")
+        await pilot.pause()
+        # Seed at newest (index 2), advance forward → 0 (wrap).
+        conv.jump_to_error(+1)
+        assert conv.error_jump_cursor() == 2
+        conv.jump_to_error(+1)
+        assert conv.error_jump_cursor() == 0
+
+
+@pytest.mark.asyncio
+async def test_cycle_backward_steps_correctly() -> None:
+    """Tier 2: F5 walks backwards through the list with wrap."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="a")
+        conv.mount_error(message="b")
+        conv.mount_error(message="c")
+        await pilot.pause()
+        # Seed at newest, walk backward → 1, then 0.
+        conv.jump_to_error(-1)
+        assert conv.error_jump_cursor() == 2
+        conv.jump_to_error(-1)
+        assert conv.error_jump_cursor() == 1
+        conv.jump_to_error(-1)
+        assert conv.error_jump_cursor() == 0
+        # One more → wraps to last.
+        conv.jump_to_error(-1)
+        assert conv.error_jump_cursor() == 2
+
+
+@pytest.mark.asyncio
+async def test_dismiss_last_error_resets_cursor() -> None:
+    """Tier 2: dismissing an error invalidates the jump cursor."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="a")
+        conv.mount_error(message="b")
+        await pilot.pause()
+        conv.jump_to_error(+1)
+        assert conv.error_jump_cursor() == 1
+        conv.dismiss_last_error()
+        await pilot.pause()
+        # Cursor reset.
+        assert conv.error_jump_cursor() == -1
+
+
+@pytest.mark.asyncio
+async def test_action_jump_with_no_errors_shows_hint() -> None:
+    """Tier 2: F5/F6 with no errors → status hint."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No errors mounted.
+        app.action_jump_next_error()
+        await pilot.pause()
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "no errors" in snap["body"]
+
+
+@pytest.mark.asyncio
+async def test_action_jump_advances_cursor() -> None:
+    """Tier 2: ``action_jump_next_error`` advances the cursor + scrolls."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="a")
+        conv.mount_error(message="b")
+        await pilot.pause()
+        app.action_jump_next_error()
+        await pilot.pause()
+        # First press → newest (index 1).
+        assert conv.error_jump_cursor() == 1
+        app.action_jump_next_error()
+        await pilot.pause()
+        # Wrap to index 0.
+        assert conv.error_jump_cursor() == 0
+
+
+def test_f5_f6_bindings_registered() -> None:
+    """Tier 2: ``f5`` and ``f6`` are bound to error-jump actions."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    binds = {(b.key, b.action) for b in ReynTUIApp.BINDINGS}
+    assert ("f5", "jump_prev_error") in binds
+    assert ("f6", "jump_next_error") in binds
+
+
+def test_keys_tab_routes_f5_f6_to_conversation() -> None:
+    """Tier 2: F5 / F6 land in the CONVERSATION group + pretty-print."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import (
+        _key_group_for,
+        _pretty_key,
+    )
+
+    assert _key_group_for("f5") == "CONVERSATION"
+    assert _key_group_for("f6") == "CONVERSATION"
+    assert _pretty_key("f5") == "F5"
+    assert _pretty_key("f6") == "F6"
+
+
+@pytest.mark.asyncio
+async def test_keys_tab_render_includes_f5_f6_descriptions() -> None:
+    """Tier 2: rendered Keys tab markup surfaces F5 / F6 descriptions."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        markup, _keys = render_keys(app)
+        assert "F5" in markup
+        assert "F6" in markup
+        assert "error" in markup.lower()


### PR DESCRIPTION
**[tui-coder]** — Debugging-axis categorical gap. In sessions with multiple mounted ErrorBox widgets (= 2+ errors stacked under the conv pane), users had no quick way to scroll between them — manual PageUp / PageDown or fine-grained cursor scroll was the only path. This adds keyboard jump-to-error navigation.

## Keys

| key | action |
|------|------|
| `F5` | jump to previous (older) error |
| `F6` | jump to next (newer) error |

First press from a fresh state targets the **NEWEST** error (= almost always the one the user wants to investigate first). Subsequent presses cycle with wrap. Status hint surfaces when no errors are mounted (`"no errors to jump to"`).

## Implementation

- `ConversationView._error_jump_cursor: int = -1` — cursor into `_error_boxes`; `-1` means "no cursor yet" (= next jump re-seeds from newest).
- `ConversationView.jump_to_error(direction)` → bool — scrolls via `target.scroll_visible()`. Returns False when no errors mounted so the caller can surface a status hint.
- `ConversationView.error_jump_cursor()` — public read for tests + future right-panel inspection.
- Cursor reset to `-1` on:
  - `dismiss_last_error` (= Esc) — list mutated, stale index would land on the wrong box.
  - Auto-eviction inside `mount_error` (= list shift) — same reason.
- App bindings: `Binding("f5", "jump_prev_error", ...)` + `Binding("f6", "jump_next_error", ...)`.
- App actions: `action_jump_prev_error` / `action_jump_next_error` delegate to `conv.jump_to_error` via the `_jump_error` helper.
- Keys tab: `f5` / `f6` routed to **CONVERSATION** group + pretty-printed as `F5` / `F6`. F5–F12 entries added to the pretty-print table for future expansion.

## Why this layer

- TUI-internal: only touches `widgets/conversation.py` (state + method), `app.py` (bindings + actions), `widgets/right_panel/keys_tab.py` (routing + pretty-print). No engine state.
- Cursor invalidation on dismiss / eviction keeps the jump target list-aware; the user never lands on a stale or wrong box.
- F5 / F6 are mnemonically the next free F-keys after F3 (skill drill) + F4 (async stack focus), forming a coherent F3..F6 keyboard cluster for "inline navigation within the conv pane".

## Test plan

- [x] `pytest tests/cli/test_conv_error_jump.py` — 10/10 pass (no-errors False, first jump newest, forward wrap, backward wrap, dismiss resets cursor, action hint when empty, action advances, bindings registered, Keys tab routing + pretty-print, render_keys descriptions)
- [x] `pytest tests/cli/test_skill_expand_keyboard.py` — F3 regression
- [x] `pytest tests/cli/` — 654/654 pass
- [x] `ruff check src/reyn/chat/tui/widgets/conversation.py src/reyn/chat/tui/app.py src/reyn/chat/tui/widgets/right_panel/keys_tab.py tests/cli/test_conv_error_jump.py` — clean
- [x] Manual: run `reyn chat`, trigger 2-3 errors (e.g., invalid skill names or `/cancel nonexistent`). Press F5 — viewport jumps to newest error. F5 again — older. F6 — newer. Esc to dismiss → next F5 re-seeds correctly.
- [x] (skipped — auto-eviction case is hard to trigger live without flooding errors; pinned via the cursor-reset test path)

## Out of scope (deferred)

- Highlight the targeted error visually (= flash / pulse on the ErrorBox border). Currently `scroll_visible()` brings it into view; the user identifies it by position. Defer until requested.
- Mouse-click on `[N pending]` to also seed the error cursor (= "click here for an error inspection"). Out of scope; the badge currently means stalled ops, not errors.
- Persistent error-jump state across `/clear`. Cleared along with the conv pane is acceptable; the jump cursor reset on dismiss/eviction handles the dynamic case.
