### PR TITLE
feat(tui): events tab i key isolates cursor's chain_id

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -148,6 +148,14 @@ class RightPanel(Widget):
         # drift the viewport off the cursor (A-F3, wave-8). Same idiom
         # as ``_memory_entry_ys`` / ``_agents_item_ys``.
         self._events_event_ys: list[int] = []
+        # Chain isolation — when set to a chain_id string, ``render_events``
+        # restricts the visible list to events sharing that chain_id (=
+        # "show me only this one conversation thread"). Toggled by the
+        # ``i`` key on the events tab: first press captures the cursor's
+        # chain_id; second press clears. Wave-11 A#2 — interleaved-chain
+        # tail at tail=200 is unreadable; isolate makes one chain
+        # legible at a time.
+        self._events_chain_isolate: str | None = None
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
@@ -430,6 +438,42 @@ class RightPanel(Widget):
         self._event_tail_idx = (self._event_tail_idx + 1) % len(_TAIL_CYCLE)
         self._invalidate()
 
+    def toggle_chain_isolate(self) -> bool:
+        """Toggle events-tab chain isolation centered on the cursor.
+
+        When isolation is OFF, captures the chain_id of the event under
+        the cursor and switches the visible list to that chain only.
+        When isolation is ON, clears it (= back to the full filtered
+        tail). Returns True if isolation became active, False if cleared
+        or no-op (= cursor outside list, or cursor event has no
+        chain_id).
+        """
+        if self._events_chain_isolate is not None:
+            # Clear isolation.
+            self._events_chain_isolate = None
+            self._invalidate()
+            self._scroll_events_into_view()
+            return False
+        # Capture cursor's chain_id.
+        if not self._events_visible:
+            return False
+        idx = max(0, min(len(self._events_visible) - 1, self._events_cursor))
+        ev = self._events_visible[idx]
+        chain_id = (ev.get("data") or {}).get("chain_id") or ""
+        if not chain_id:
+            # Cursor event has no chain_id (= bare system event). Don't
+            # silently set an empty-string isolate; let caller surface a
+            # hint instead.
+            return False
+        self._events_chain_isolate = chain_id
+        # Reset cursor to top of the filtered list (= the newest event
+        # in this chain). The filtered list ordering is preserved by
+        # render_events.
+        self._events_cursor = 0
+        self._invalidate()
+        self._scroll_events_into_view()
+        return True
+
     # ── tab activation ───────────────────────────────────────────────────────
 
     def on_key(self, event) -> None:
@@ -505,6 +549,21 @@ class RightPanel(Widget):
                 self._pending_move(-1)
             else:
                 self._scroll_panel(-1)
+        elif event.key == "i" and self._panel_type == "events":
+            # Wave-11 A#2 — Events tab ``i`` = isolate cursor's chain_id.
+            # First press: filter list to that chain only. Re-press:
+            # clear isolation. Status hint when cursor's event has no
+            # chain_id (= bare system event, can't isolate to nothing).
+            event.prevent_default()
+            became_active = self.toggle_chain_isolate()
+            if (
+                self._events_chain_isolate is None
+                and not became_active
+                and self._events_visible
+            ):
+                # Wasn't already-isolated AND toggle returned False →
+                # cursor event has no chain_id. Surface a hint.
+                self._flash_status("chain_id missing; cannot isolate")
         elif event.key == "a" and self._panel_type == "agents":
             # Wave-10 follow-up H-F11: Agents tab `a` = switch to the
             # cursor's agent. Mirrors the per-tab action idiom landed
@@ -2043,6 +2102,7 @@ class RightPanel(Widget):
                     cursor=self._events_cursor,
                     cache=self._events_cache,
                     filelist_cache=self._events_filelist_cache,
+                    chain_isolate=self._events_chain_isolate,
                 )
                 self._events_visible = windowed
                 self._events_event_ys = event_ys

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -533,6 +533,7 @@ def render_events(
     cursor: int = 0,
     cache: dict | None = None,
     filelist_cache: list | None = None,
+    chain_isolate: str | None = None,
 ) -> tuple[str, list[dict], list[int]]:
     """Render the recent-events list for the events tab.
 
@@ -567,6 +568,17 @@ def render_events(
         visible = [ev for ev in all_events if ev.get("type") in filter_set]
     else:
         visible = list(all_events)
+
+    # Chain isolation (wave-11 A#2): when a chain_id is pinned, restrict
+    # the visible list to just that chain. Empty result is rare — the
+    # cursor's own chain seeds the isolate, so at least one matching
+    # event is guaranteed — but the post-isolation list might shrink
+    # below 1 if cache has rotated. Treated like any empty result.
+    if chain_isolate:
+        visible = [
+            ev for ev in visible
+            if ((ev.get("data") or {}).get("chain_id") or "") == chain_isolate
+        ]
 
     # File-path iteration order doesn't match wall-clock: the events root
     # holds agents/<id>/events/*.jsonl alongside direct/<id>/skill_runs/*
@@ -612,6 +624,21 @@ def render_events(
 
     lines: list[str] = []
     event_ys: list[int] = []
+    # Wave-11 A#2 — chain isolation header. When active, surface the
+    # isolated chain_id (truncated to 8-char prefix for readability)
+    # + the unset key cue. This adds 2 visual rows above the event
+    # list so ``event_ys`` indices still align to ``lines`` because
+    # ``event_ys.append(len(lines))`` is computed AFTER the header
+    # rows are appended (= each event row gets the post-header y).
+    if chain_isolate:
+        short = chain_isolate[:8] + ("…" if len(chain_isolate) > 8 else "")
+        lines.append(
+            f"  [#88aacc]⛓ chain isolated:[/] [bold {_CORAL}]{_esc(short)}[/]"
+        )
+        lines.append(
+            "  [#555555]  press [/][bold #aaaaaa]\\[i][/]"
+            "[#555555] to clear isolation[/]"
+        )
     prev_chain: str | None = None
     for i, ev in enumerate(windowed):
         ev_type = ev.get("type", "?")

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -65,7 +65,7 @@ _PANEL_KEYS = {
     "ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4",
     "ctrl+5", "ctrl+6", "ctrl+7",
 }
-_EVENTS_KEYS = {"f", "t"}
+_EVENTS_KEYS = {"f", "t", "i"}
 # ``/`` stays DOCS-only — it opens the docs name filter, no other tab
 # consumes it.
 _DOCS_KEYS = {"/"}
@@ -165,6 +165,10 @@ def render_keys(app: "App") -> str:
         # Same "per-tab action" idiom as the pending-tab ``d`` / ``c``
         # discard / claim shortcuts.
         ("a", "Attach to cursor agent (agents tab)"),
+        # Wave-11 A#2: ``i`` on the Events tab isolates the cursor's
+        # chain_id so the user can read one chain's lifecycle without
+        # interleaving noise from other concurrent chains.
+        ("i", "Isolate cursor's chain (events tab)"),
     ]
     for key, desc in _PANEL_EXPLICIT:
         if key not in seen:

--- a/tests/cli/test_events_tab_chain_isolate.py
+++ b/tests/cli/test_events_tab_chain_isolate.py
@@ -1,0 +1,212 @@
+"""Tier 2: events tab ``i`` key isolates cursor's chain_id.
+
+Wave-11 finding A#2. With tail=200 and multi-chain interleaving,
+the events tab is unreadable when the user wants to follow one
+chain's lifecycle. The blank-line chain separator helps but only
+within consecutive runs of the same chain — interleaved chains
+need a filter.
+
+This adds chain isolation:
+  - ``RightPanel.toggle_chain_isolate()`` captures the cursor's
+    chain_id and restricts the visible list. Re-press clears.
+  - ``render_events`` accepts ``chain_isolate=<chain_id>`` kwarg
+    that filters ``visible`` by chain_id after the type-filter.
+  - Header row "⛓ chain isolated: <prefix>" + "[i] to clear"
+    surfaces the active state above the event list.
+  - ``i`` key on events tab triggers the toggle via the
+    ``RightPanel.on_key`` dispatch.
+
+Public surfaces tested:
+  - toggle_chain_isolate when off captures cursor's chain
+  - toggle_chain_isolate when on clears
+  - toggle_chain_isolate on empty list returns False
+  - toggle_chain_isolate when cursor event has no chain_id
+    returns False without setting isolate
+  - render_events with chain_isolate filters visible list
+  - Keys tab routes ``i`` correctly + lists it in the explicit
+    panel keys
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_toggle_chain_isolate_captures_cursor_chain() -> None:
+    """Tier 2: first ``i`` press sets isolate to cursor's chain_id."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        # Seed cursor + visible list (= what render_events would have
+        # filled). Module-private but matches the cursor-driven contract
+        # render_events writes per-tick.
+        panel._events_visible = [
+            {"type": "phase_started", "data": {"chain_id": "chain-A"}},
+            {"type": "phase_started", "data": {"chain_id": "chain-B"}},
+        ]
+        panel._events_cursor = 0
+        assert panel._events_chain_isolate is None
+        became_active = panel.toggle_chain_isolate()
+        assert became_active is True
+        assert panel._events_chain_isolate == "chain-A"
+
+
+@pytest.mark.asyncio
+async def test_toggle_chain_isolate_second_press_clears() -> None:
+    """Tier 2: re-press of ``i`` clears the active isolate."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._events_visible = [
+            {"type": "phase_started", "data": {"chain_id": "chain-X"}},
+        ]
+        panel._events_cursor = 0
+        panel.toggle_chain_isolate()
+        assert panel._events_chain_isolate == "chain-X"
+        # Second press clears.
+        cleared = panel.toggle_chain_isolate()
+        assert cleared is False
+        assert panel._events_chain_isolate is None
+
+
+@pytest.mark.asyncio
+async def test_toggle_chain_isolate_empty_list_returns_false() -> None:
+    """Tier 2: toggling with no events visible is a no-op."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._events_visible = []
+        result = panel.toggle_chain_isolate()
+        assert result is False
+        assert panel._events_chain_isolate is None
+
+
+@pytest.mark.asyncio
+async def test_toggle_chain_isolate_cursor_event_no_chain_id() -> None:
+    """Tier 2: cursor event with no chain_id → no-op + False return.
+
+    Bare system events (= no chain_id in data) can't anchor an
+    isolation; toggling should leave state unchanged and return
+    False so the caller surfaces a hint.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._events_visible = [
+            {"type": "system_event", "data": {}},  # no chain_id
+        ]
+        panel._events_cursor = 0
+        result = panel.toggle_chain_isolate()
+        assert result is False
+        assert panel._events_chain_isolate is None
+
+
+def test_render_events_filters_by_chain_isolate(tmp_path: Path) -> None:
+    """Tier 2: ``render_events(..., chain_isolate=X)`` keeps only chain X."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    # Seed a fake events dir with 2 chains interleaved.
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "test" / "events"
+    events_root.mkdir(parents=True)
+    log = events_root / "log.jsonl"
+    import json
+    lines = [
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:00",
+         "data": {"chain_id": "A", "phase": "p1"}},
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:01",
+         "data": {"chain_id": "B", "phase": "p1"}},
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:02",
+         "data": {"chain_id": "A", "phase": "p2"}},
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:03",
+         "data": {"chain_id": "B", "phase": "p2"}},
+    ]
+    log.write_text("\n".join(json.dumps(item) for item in lines))
+
+    rendered, visible, _ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=2,  # tail=200
+        cursor=0,
+    )
+    # All 4 events visible without isolation.
+    assert len(visible) == 4
+
+    # With chain_isolate="A" → only chain A's 2 events visible.
+    rendered_iso, visible_iso, _ys2 = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=2,
+        cursor=0, chain_isolate="A",
+    )
+    assert len(visible_iso) == 2
+    assert all(
+        (ev.get("data") or {}).get("chain_id") == "A" for ev in visible_iso
+    )
+    # Rendered output surfaces the isolation banner.
+    assert "chain isolated" in rendered_iso
+    assert "[i]" in rendered_iso
+
+
+@pytest.mark.asyncio
+async def test_i_key_on_events_tab_invokes_toggle() -> None:
+    """Tier 2: pressing ``i`` while events tab focused triggers the toggle."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel.set_panel_type("events")
+        await pilot.pause()
+        # Seed cursor + visible.
+        panel._events_visible = [
+            {"type": "phase_started", "data": {"chain_id": "C"}},
+        ]
+        panel._events_cursor = 0
+        # Synthesise the key press.
+        key_event = textual_events.Key(key="i", character="i")
+        panel.on_key(key_event)
+        await pilot.pause()
+        assert panel._events_chain_isolate == "C"
+
+
+def test_keys_tab_lists_i_under_panel_explicit() -> None:
+    """Tier 2: ``i`` appears in the Keys tab's panel-key listing."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import _EVENTS_KEYS
+
+    assert "i" in _EVENTS_KEYS
+
+
+@pytest.mark.asyncio
+async def test_keys_tab_render_includes_i_isolate_description() -> None:
+    """Tier 2: rendered Keys tab markup surfaces the ``i`` isolate hint."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        markup = render_keys(app)
+        assert "Isolate cursor's chain" in markup or "isolate" in markup.lower()


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **A#2**. With `tail=200` and multi-chain interleaving, the events tab is unreadable when the user wants to follow ONE chain's lifecycle. The blank-line chain separator helps only within consecutive runs — interleaved chains need a filter.

## Summary

```
i (events tab) → capture cursor's chain_id, filter list to it
i (again)       → clear isolation, return to full filtered tail
```

When active, the events tab prepends a 2-line header:

```
  ⛓ chain isolated: abc12345…
    press [i] to clear isolation
```

## Implementation

- `RightPanel._events_chain_isolate: str | None` — None when off, chain_id string when active.
- `RightPanel.toggle_chain_isolate()`:
  - When OFF: captures cursor's chain_id, resets cursor to top of filtered list, returns `True`.
  - When ON: clears isolation, returns `False`.
  - Empty list or cursor event with no chain_id → no-op, returns `False`. Caller surfaces a `_flash_status` hint in that case.
- `RightPanel.on_key`: `i` on events tab calls toggle, with flash-status fallback for the no-chain-id branch.
- `render_events` accepts `chain_isolate=<chain_id>` kwarg; filters `visible` by chain_id AFTER the type-filter so isolation composes with the existing `[f]` filter cycle.
- Header banner prepended to `lines` before the per-event loop. `event_ys` offsets stay correct because they're computed via `len(lines)` at append time (= post-header).
- Keys tab: `i` added to `_EVENTS_KEYS` routing + explicit `PANEL_EXPLICIT` entry `"Isolate cursor's chain (events tab)"` so the binding surfaces in the rendered Keys tab.

## Why this layer

- TUI-internal: only touches `widgets/right_panel/__init__.py` (state + toggle + key dispatch), `widgets/right_panel/events_tab.py` (kwarg + filter + banner), `widgets/right_panel/keys_tab.py` (registration). No engine state, no event-emission changes.
- Composes with existing filters: type-filter cycle (`[f]`) + tail-size cycle (`[t]`) + new chain-isolate (`[i]`) layer on top of each other in render_events.
- Re-uses the cursor that's already tracked for `_scroll_events_into_view` — no new cursor state needed.

## Test plan

- [x] `pytest tests/cli/test_events_tab_chain_isolate.py` — 8/8 pass (toggle captures, second press clears, empty list no-op, no-chain-id no-op, render_events filters + banner, `i` key invokes toggle, _EVENTS_KEYS contains `i`, Keys tab renders description)
- [x] `pytest tests/cli/test_right_panel*.py` — existing right-panel tests pass (regression unchanged)
- [x] `pytest tests/cli/` — 652/652 pass
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/__init__.py src/reyn/chat/tui/widgets/right_panel/events_tab.py src/reyn/chat/tui/widgets/right_panel/keys_tab.py tests/cli/test_events_tab_chain_isolate.py` — clean
- [x] Manual: run `reyn chat` with multi-chain history. Open Events tab. Navigate to an event in chain A with j/k. Press `i` — list filters to chain A's events only; banner appears. Press `i` again — full tail returns.
- [x] (skipped — narrow-terminal banner truncation; the banner is 2 short lines and renders within any reasonable panel width)

## Out of scope (deferred)

- Multi-chain isolation (= "show chains A AND B but hide C"). Single-chain is the common use case; multi-chain would need set-based state.
- Persisting the isolated chain across `/clear`. Conv pane reset clears the visible list anyway; defer.
- Visual chain-color coding when isolation is OFF (= same chain → same accent color in the timestamp column). Bigger render-side change; defer.
