### PR TITLE
feat(tui): memory tab t cycles per-type filter (Wave-11 A#1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -159,6 +159,13 @@ class RightPanel(Widget):
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
+        # Wave-11 A#1 — memory tab per-type filter. Cycled by the ``t``
+        # key on memory tab (events tab's ``t`` is gated to events-only
+        # via check_action, so the two share the key without conflict).
+        # Cycle: None → "user" → "feedback" → "project" → "reference"
+        # → None. Pinned at None on cold-default so the full list is
+        # the starting view.
+        self._memory_type_filter: str | None = None
         # Latest ARS hot-list ranking from ChatLifecycleForwarder (issue
         # #192). ``[{"qualified_name": str, "freq": int, "last_ts": str},
         # ...]`` full ranking. Fed by ``update_hot_list`` (= driven from
@@ -438,6 +445,25 @@ class RightPanel(Widget):
         self._event_tail_idx = (self._event_tail_idx + 1) % len(_TAIL_CYCLE)
         self._invalidate()
 
+    def cycle_memory_type_filter(self) -> str | None:
+        """Cycle the memory tab's type-filter through the known kinds.
+
+        Order: ``None`` → ``"user"`` → ``"feedback"`` → ``"project"``
+        → ``"reference"`` → ``None``. Returns the new value. Resets
+        the memory cursor to 0 because the visible-list shape just
+        changed and clamping the old index would land arbitrarily.
+        """
+        _cycle = (None, "user", "feedback", "project", "reference")
+        try:
+            current_idx = _cycle.index(self._memory_type_filter)
+        except ValueError:
+            current_idx = 0  # garbage state → start fresh
+        new_filter = _cycle[(current_idx + 1) % len(_cycle)]
+        self._memory_type_filter = new_filter
+        self._memory_cursor = 0
+        self._invalidate()
+        return new_filter
+
     def toggle_chain_isolate(self) -> bool:
         """Toggle events-tab chain isolation centered on the cursor.
 
@@ -549,6 +575,16 @@ class RightPanel(Widget):
                 self._pending_move(-1)
             else:
                 self._scroll_panel(-1)
+        elif event.key == "t" and self._panel_type == "memory":
+            # Wave-11 A#1 — memory tab ``t`` cycles per-type filter.
+            # Events tab's ``t`` (= cycle_event_tail) is gated to
+            # events-only via App.check_action, so the same key here
+            # is contention-free. Picker for filter values cycles in
+            # the order: None → user → feedback → project → reference.
+            event.prevent_default()
+            new_filter = self.cycle_memory_type_filter()
+            label = new_filter.upper() if new_filter else "ALL"
+            self._flash_status(f"memory filter: {label}")
         elif event.key == "i" and self._panel_type == "events":
             # Wave-11 A#2 — Events tab ``i`` = isolate cursor's chain_id.
             # First press: filter list to that chain only. Re-press:
@@ -2125,6 +2161,7 @@ class RightPanel(Widget):
                     self._project_root,
                     cursor=self._memory_cursor,
                     hot_list=self._hot_list_ranking,
+                    type_filter=self._memory_type_filter,
                 )
                 self._memory_entries = flat_entries
                 self._memory_entry_ys = entry_ys

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -170,6 +170,12 @@ def render_keys(app: "App") -> str:
         # interleaving noise from other concurrent chains.
         ("i", "Isolate cursor's chain (events tab)"),
     ]
+    # Note: memory tab's ``t`` (= cycle_memory_type_filter, wave-11
+    # A#1) is intentionally NOT in this list because ``t`` is already
+    # in ``seen`` via the events-tab tail-cycle binding, and the
+    # de-dupe guard would silently swallow this entry. The memory
+    # binding self-documents via ``_flash_status("memory filter: <X>")``
+    # on every press.
     for key, desc in _PANEL_EXPLICIT:
         if key not in seen:
             groups["PANEL"].append((_pretty_key(key), desc))

--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -48,6 +48,7 @@ def render_memory(
     *,
     cursor: int = 0,
     hot_list: list[dict] | None = None,
+    type_filter: str | None = None,
 ) -> tuple[str, list[Any], list[int]]:
     """Return Rich markup + the flat ordered list of MemoryEntry items
     + the y-coordinate (= 0-indexed line number) of each entry's name row.
@@ -77,6 +78,22 @@ def render_memory(
     lines: list[str] = []
     flat_entries: list[Any] = []
     entry_ys: list[int] = []
+    # Wave-11 A#1 — memory-type filter banner. When type_filter is one
+    # of the four known kinds, prepend a 2-row banner so the user has
+    # a persistent cue that the list is narrowed (rather than the
+    # missing types looking like "this scope has no FEEDBACK entries
+    # actually"). Press [t] to cycle next; banner disappears when
+    # back to None.
+    if type_filter in _TYPE_COLORS:
+        banner_color = _TYPE_COLORS[type_filter]
+        lines.append(
+            f"  [bold {banner_color}]⌕ filter: [/]"
+            f"[bold {_CORAL}]{_esc(type_filter.upper())}[/]"
+        )
+        lines.append(
+            "  [#555555]  press [/][bold #aaaaaa]\\[t][/]"
+            "[#555555] to cycle filter[/]"
+        )
 
     # Hot now section (issue #192). Always renders the header so the
     # feature is discoverable on cold-start (= before any router
@@ -138,6 +155,16 @@ def render_memory(
                 groups[e.type].append(e)
             else:
                 other.append(e)
+        # Wave-11 A#1 — when type_filter is active, drop every type
+        # except the one named. ``other`` is also wiped because the
+        # filter contract is "show ONLY this type". Sub-headers for
+        # skipped types vanish too because the ``if not group``
+        # guard below skips empty buckets.
+        if type_filter in groups:
+            for k in list(groups.keys()):
+                if k != type_filter:
+                    groups[k] = []
+            other = []
         for type_key in ("user", "feedback", "project", "reference"):
             group = groups[type_key]
             if not group:

--- a/tests/cli/test_memory_tab_type_filter.py
+++ b/tests/cli/test_memory_tab_type_filter.py
@@ -1,0 +1,198 @@
+"""Tier 2: Memory tab ``t`` cycles per-type filter (Wave-11 A#1).
+
+Wave-11 A#1. The memory tab can grow to 20+ entries (MEMORY.md
+alone has 20+ feedback rows in active sessions). j/k walks the
+flat list one row at a time; reaching a specific TYPE requires
+many keypresses. This adds a per-type cycle filter on ``t``.
+
+Cycle: ``None`` → ``user`` → ``feedback`` → ``project`` →
+``reference`` → ``None``. Banner surfaces the active filter +
+``[t] to cycle`` hint.
+
+Coexistence with events tab's ``t`` (= tail cycle): events tab
+binding is gated to ``panel_type == "events"`` via
+``App.check_action``, so when the user is on the memory tab the
+``t`` key falls through to ``RightPanel.on_key`` for the type
+cycle.
+
+Pinned:
+  - ``cycle_memory_type_filter`` advances through the cycle in
+    order, wraps to ``None`` after ``reference``
+  - cycling resets the memory cursor to 0 (= list shape changed)
+  - ``render_memory(type_filter="feedback")`` keeps only FEEDBACK
+    entries + adds the banner
+  - ``t`` key on memory tab invokes the cycle
+  - Keys tab routes the description through PANEL_EXPLICIT
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _make_fake_entries():
+    """Build minimal MemoryEntry-shaped objects for the renderer test."""
+    class _FakeEntry:
+        def __init__(self, name: str, kind: str, description: str = ""):
+            self.name = name
+            self.type = kind
+            self.description = description
+            self.body = ""
+
+    return [
+        _FakeEntry("alpha_user", "user", "user pref"),
+        _FakeEntry("beta_feedback", "feedback", "feedback note"),
+        _FakeEntry("gamma_project", "project", "project fact"),
+        _FakeEntry("delta_reference", "reference", "ref"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cycle_memory_type_filter_walks_order() -> None:
+    """Tier 2: cycle advances None → user → feedback → project → reference → None."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        assert panel._memory_type_filter is None
+        assert panel.cycle_memory_type_filter() == "user"
+        assert panel.cycle_memory_type_filter() == "feedback"
+        assert panel.cycle_memory_type_filter() == "project"
+        assert panel.cycle_memory_type_filter() == "reference"
+        assert panel.cycle_memory_type_filter() is None
+
+
+@pytest.mark.asyncio
+async def test_cycle_resets_memory_cursor() -> None:
+    """Tier 2: cycling clamps cursor to 0 (= list shape changed)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._memory_cursor = 7
+        panel.cycle_memory_type_filter()
+        assert panel._memory_cursor == 0
+
+
+def test_render_memory_with_type_filter_keeps_only_target(tmp_path: Path) -> None:
+    """Tier 2: ``render_memory(type_filter='feedback')`` drops other types."""
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    # Build a real memory dir with 4 entries — one per type.
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    for name, kind in [
+        ("alpha_user", "user"),
+        ("beta_feedback", "feedback"),
+        ("gamma_project", "project"),
+        ("delta_reference", "reference"),
+    ]:
+        # memory.py reads ``type`` at the frontmatter root (= flat),
+        # not nested under ``metadata`` despite the prod-format MEMORY.md
+        # nesting convention. The flat form is what the parser actually
+        # honours.
+        (mem_dir / f"{name}.md").write_text(
+            f"---\nname: {name}\ndescription: d\ntype: {kind}\n---\n\n"
+            f"body for {name}\n"
+        )
+
+    # No filter — all 4 entries visible.
+    _rendered, all_entries, _ys = render_memory(tmp_path, cursor=0)
+    names = {e.name for e in all_entries}
+    assert {"alpha_user", "beta_feedback", "gamma_project", "delta_reference"} <= names
+
+    # Filter to "feedback" → only that type appears.
+    rendered_f, entries_f, _ys2 = render_memory(
+        tmp_path, cursor=0, type_filter="feedback",
+    )
+    names_f = {e.name for e in entries_f}
+    assert "beta_feedback" in names_f
+    assert "alpha_user" not in names_f
+    assert "gamma_project" not in names_f
+    assert "delta_reference" not in names_f
+    # Banner surfaces the filter.
+    assert "FEEDBACK" in rendered_f
+    assert "[t]" in rendered_f
+
+
+def test_render_memory_without_filter_omits_banner(tmp_path: Path) -> None:
+    """Tier 2: cold-default (no filter) does NOT prepend the banner."""
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "x.md").write_text(
+        "---\nname: x\ndescription: d\ntype: user\n---\n\nbody\n"
+    )
+    rendered, _entries, _ys = render_memory(tmp_path, cursor=0)
+    # Banner is gated on type_filter being set.
+    assert "⌕ filter:" not in rendered
+
+
+def test_render_memory_unknown_filter_is_ignored(tmp_path: Path) -> None:
+    """Tier 2: an unrecognised ``type_filter`` value falls through to all-types."""
+    from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+
+    mem_dir = tmp_path / ".reyn" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "x.md").write_text(
+        "---\nname: x\ndescription: d\ntype: user\n---\n\nbody\n"
+    )
+    rendered, entries, _ys = render_memory(
+        tmp_path, cursor=0, type_filter="garbage-typo",
+    )
+    # Unknown filter → no banner + full entry list.
+    assert "⌕ filter:" not in rendered
+    assert len(entries) == 1
+
+
+@pytest.mark.asyncio
+async def test_t_key_on_memory_tab_invokes_cycle() -> None:
+    """Tier 2: pressing ``t`` while memory tab focused advances the filter."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel.set_panel_type("memory")
+        await pilot.pause()
+        assert panel._memory_type_filter is None
+        key_event = textual_events.Key(key="t", character="t")
+        panel.on_key(key_event)
+        await pilot.pause()
+        assert panel._memory_type_filter == "user"
+
+
+def test_keys_tab_t_first_occurrence_is_events() -> None:
+    """Tier 2: ``t`` already appears in Keys tab under EVENTS (gated).
+
+    The memory-tab ``t`` (= type-filter cycle) is documented via the
+    flash status (``memory filter: USER`` etc.) since the Keys tab
+    de-duplicates by key. Documenting it in the Keys tab would need
+    a same-key duplicate row — not worth the dedup-logic complexity
+    for a single-tab convenience binding. Pin that the events
+    binding (the prior owner of ``t``) still renders.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    markup = render_keys(app)
+    # ``t`` from app.BINDINGS (events tab) still renders.
+    assert "Tail events" in markup


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **A#1**. The memory tab can grow to 20+ entries (`MEMORY.md` alone has 20+ feedback rows in active sessions). j/k walks the flat list one row at a time; reaching a specific TYPE required many keypresses.

## Summary

`t` on the memory tab cycles a per-type filter:

```
None → user → feedback → project → reference → None
```

Active filter prepends a 2-row banner:

```
  ⌕ filter: FEEDBACK
    press [t] to cycle filter
```

## Coexistence with events tab's ``t``

The events `t` binding in `App.BINDINGS` (= tail cycle) is gated to `panel_type == "events"` via `App.check_action`. When the user is on the memory tab, the `t` key falls through cleanly to `RightPanel.on_key` for the type cycle. Same key, different tab, no collision.

## Implementation

- `RightPanel._memory_type_filter: str | None` — pinned at None cold-default.
- `RightPanel.cycle_memory_type_filter()` — advances + wraps through the 5-state cycle; resets `_memory_cursor` to 0 because the list shape changed.
- `RightPanel.on_key`: `t` on memory tab calls cycle + `_flash_status("memory filter: USER")` so the new state is discoverable on every press.
- `render_memory` accepts `type_filter` kwarg. When set to one of the four known kinds, the per-scope `_render_scope` empties all non-target buckets (and clears `other`) so only the target type's entries land in flat_entries + the rendered output.
- Banner header prepended to `lines` before any scope is rendered; `entry_ys` offsets stay correct because they're computed via `len(lines)` at append time.
- Unknown filter values (= caller typo) silently fall through to the all-types path.

## Why this layer

- TUI-internal: only `widgets/right_panel/__init__.py` (state + cycle + key dispatch), `widgets/right_panel/memory_tab.py` (kwarg + filter + banner). No engine state.
- Composes with existing memory tab features (= Hot Now section unaffected, cursor + Enter→preview still works on filtered entries).
- Reuses the `_flash_status` helper already used by `cycle_event_filter` so cross-tab status-line behaviour stays consistent.

## Keys tab listing

`t` is already in `app.BINDINGS` for the events-tail-cycle, and the Keys tab de-duplicates by key. Adding a memory-tab `t` row would need same-key duplicate logic — not worth the dedup-bypass complexity for a single-tab convenience binding. The memory `t` self-documents via the flash-status hint on every press.

## Test plan

- [x] `pytest tests/cli/test_memory_tab_type_filter.py` — 7/7 pass (cycle order + wrap, cursor reset, filter keeps target + banner, no-banner cold-default, unknown filter falls through, `t` key invokes cycle, Keys tab regression)
- [x] `pytest tests/cli/` — 669/669 pass
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/__init__.py src/reyn/chat/tui/widgets/right_panel/memory_tab.py src/reyn/chat/tui/widgets/right_panel/keys_tab.py tests/cli/test_memory_tab_type_filter.py` — clean
- [x] Manual: run `reyn chat`, open Memory tab (Ctrl+4), press `t` — banner appears showing USER filter + cycle hint; user-type entries only. Press `t` until FEEDBACK / PROJECT / REFERENCE / back to all. j/k navigates within the filtered set.
- [x] (skipped — actual prod-format MEMORY.md frontmatter uses nested `metadata.type` but the parser reads flat `type:`; test fixtures use the flat form the parser actually honours)

## Out of scope (deferred)

- Multi-type filter (= "show USER + FEEDBACK but hide PROJECT/REFERENCE"). Single-type filter is the dominant use case; multi would need set-based state.
- Filter persistence across sessions via prefs. Defer until requested.
- A separate Hot-Now type filter (= drill into hot actions by category). Different surface entirely.
