### PR TITLE
feat(tui): picker hint usage + completions render together (Wave-11 C#5)

### DIFF
--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -351,16 +351,21 @@ class SlashPicker(RenderableCacheMixin, Static):
         t.append(name, style="dim #888888")
         t.append("  ")
         t.append(summary, style="dim #888888")
-        # Structured usage line — surfaced as a second hint row when the
-        # command opts in via ``SlashCommand.usage``. Indented under the
-        # summary with a ``↳`` connector so the eye groups them as
-        # "one command, two informational rows". Commands without
-        # usage stay 1-line (backward compatible). Skipped when
-        # completions are present — completions already carry
-        # actionable arg info, and stacking usage + completions would
-        # push the picker past ``max-height: 11`` for /attach-like
-        # cases with many agent names.
-        if cmd.usage and not self._completions:
+        # Structured usage line — surfaced as a second hint row when
+        # the command opts in via ``SlashCommand.usage``. Indented
+        # under the summary with a ``↳`` connector so the eye groups
+        # them as "one command, two informational rows". Commands
+        # without usage stay 1-line (backward compatible).
+        #
+        # Wave-11 C#5: previously skipped when ``_completions`` was
+        # non-empty — but the commands with both required args AND a
+        # finite arg list (/attach, /memory view, /plan resume) were
+        # exactly the ones that benefit most from showing usage.
+        # The guard meant usage rarely rendered in practice. Now
+        # always renders when ``cmd.usage`` is set; total row count
+        # (= 1 summary + 1 usage + ≤ 8 completions + optional "+N
+        # more") stays within the CSS ``max-height: 11`` budget.
+        if cmd.usage:
             indent = " " * (2 + len(name) + 2)
             usage_budget = max(10, content_w - len(indent) - 9)  # 9 = "↳ usage: "
             usage_text = cmd.usage

--- a/tests/cli/test_slash_picker_multiline_hint.py
+++ b/tests/cli/test_slash_picker_multiline_hint.py
@@ -134,13 +134,16 @@ async def test_hint_without_usage_renders_one_line() -> None:
 
 
 @pytest.mark.asyncio
-async def test_completions_suppress_usage_line() -> None:
-    """Tier 2: when completions are surfaced, the usage line is suppressed.
+async def test_usage_and_completions_render_together() -> None:
+    """Tier 2: usage line + completions BOTH render in the picker hint.
 
-    The completions are themselves arg-list context — adding the
-    usage line on top would be redundant + push the picker past
-    its height cap on commands with many matching completions
-    (e.g. /attach with 8 agent names).
+    Wave-11 C#5 reversed the original "suppress usage when
+    completions present" guard. The commands with both required
+    args AND a finite arg list (= /attach, /memory view, /plan
+    resume) were exactly the ones that benefit most from showing
+    usage; the prior guard hid usage from them. Total row count
+    (= 1 summary + 1 usage + ≤ 8 completions + optional "+N more")
+    stays within the CSS ``max-height: 11`` budget.
     """
     from reyn.chat.slash import SlashCommand
     from reyn.chat.tui.app import ReynTUIApp
@@ -165,8 +168,9 @@ async def test_completions_suppress_usage_line() -> None:
         # Completions visible.
         assert "alpha" in text
         assert "beta" in text
-        # Usage line suppressed.
-        assert "↳ usage:" not in text
+        # Usage line ALSO visible (= wave-11 C#5 reversal).
+        assert "↳ usage:" in text
+        assert "/testcmd2 <name>" in text
 
 
 def test_find_command_has_usage() -> None:

--- a/tests/cli/test_slash_picker_usage_with_completions.py
+++ b/tests/cli/test_slash_picker_usage_with_completions.py
@@ -1,0 +1,166 @@
+"""Tier 2: picker hint renders ``usage`` line alongside completions.
+
+Wave-11 finding C#5. Before this PR, ``_repaint_hint`` gated
+the structured ``cmd.usage`` row on ``not self._completions``.
+The very commands that benefit most from usage discoverability
+— /attach, /memory view, /plan resume (= those with both
+required args AND a finite arg list) — were exactly the ones
+that suppressed the usage row.
+
+This PR drops the gate:
+  - ``cmd.usage`` always renders when set, regardless of whether
+    completions are surfaced
+  - Total row count (= 1 summary + 1 usage + ≤ 8 completions +
+    optional "+N more" footer) stays within the CSS
+    ``max-height: 11`` budget
+
+Pinned:
+  - usage line shows when completions are non-empty (= the
+    reversed-gate path)
+  - usage line still shows when completions are empty (= the
+    pre-existing path)
+  - usage line absent when ``cmd.usage`` is empty (backward
+    compatible)
+  - The row count fits within the picker's height cap even with
+    max completions (8) + "+N more" footer
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _picker_text(picker) -> str:
+    return picker.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_usage_renders_with_completions_present() -> None:
+    """Tier 2: usage line surfaces when completions are also being shown."""
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="xattach",
+            summary="Switch attached agent",
+            handler=_h,
+            usage="/xattach <name>",
+        )
+        picker.set_completions(cmd, ["alpha-agent", "beta-agent"])
+        await pilot.pause()
+        text = _picker_text(picker)
+        # Usage line present.
+        assert "↳ usage:" in text
+        assert "/xattach <name>" in text
+        # Completions also present.
+        assert "alpha-agent" in text
+        assert "beta-agent" in text
+
+
+@pytest.mark.asyncio
+async def test_usage_renders_without_completions() -> None:
+    """Tier 2: hint mode (no completions) still shows usage — regression check.
+
+    The reversed-gate change must not break the bare hint-mode
+    path. /find with usage="/find <query>" on a bare ``/find ``
+    typing surfaces the same usage line either way.
+    """
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="xfind",
+            summary="Search the conv pane for a substring",
+            handler=_h,
+            usage="/xfind <query>",
+        )
+        picker.set_hint(cmd)
+        await pilot.pause()
+        text = _picker_text(picker)
+        assert "↳ usage:" in text
+        assert "/xfind <query>" in text
+
+
+@pytest.mark.asyncio
+async def test_no_usage_field_omits_line() -> None:
+    """Tier 2: command without ``cmd.usage`` keeps a clean 1-line hint."""
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="xlegacy",
+            summary="legacy command with no structured usage",
+            handler=_h,
+        )
+        picker.set_completions(cmd, ["alpha", "beta"])
+        await pilot.pause()
+        text = _picker_text(picker)
+        assert "↳ usage:" not in text
+
+
+@pytest.mark.asyncio
+async def test_max_completions_plus_usage_fits_height_budget() -> None:
+    """Tier 2: max completions (= 8) + usage + summary + "+N more" ≤ 11 rows.
+
+    The CSS ``max-height: 11`` caps the picker. Pin that the
+    combined render path doesn't blow past it. Counting newlines
+    in the rendered text is the simplest proxy for visual rows.
+    """
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+        cmd = SlashCommand(
+            name="xcap",
+            summary="cap-budget probe",
+            handler=_h,
+            usage="/xcap <arg>",
+        )
+        # Push past the cap so "+N more" footer also renders.
+        comps = [f"completion-{i}" for i in range(20)]
+        picker.set_completions(cmd, comps)
+        await pilot.pause()
+        text = _picker_text(picker)
+        # Row count = newlines + 1 (= the first row has no preceding newline).
+        row_count = text.count("\n") + 1
+        # CSS budget = 11 (= ``SlashPicker max-height: 11``).
+        assert row_count <= 11, (
+            f"hint mode overflowed CSS budget: {row_count} rows in:\n{text}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **C#5**. Before this PR, `_repaint_hint` gated the structured `cmd.usage` row on `not self._completions`. The very commands that benefit most from usage discoverability — `/attach`, `/memory view`, `/plan resume` (= those with both required args AND a finite arg list) — were exactly the ones that suppressed the usage row. Net: usage rarely rendered in practice for the commands where it would matter most.

## The change

Drop the gate. `cmd.usage` always renders when set.

```
Before:                            After:
  /attach  Switch attached agent     /attach  Switch attached agent
            alpha-agent                       ↳ usage: /attach <name>
            beta-agent                        alpha-agent
                                              beta-agent
```

Total row count (= 1 summary + 1 usage + ≤ 8 completions + optional `+N more` footer) stays within the CSS `max-height: 11` budget — worst case is 8 + 1 + 1 + 1 = 11.

## Implementation

- Single 5-character edit (= remove `not self._completions` from the conditional).
- Comment block updated to reflect the new contract + height accounting.

## Why this layer

- TUI-internal: only `widgets/slash_picker.py`.
- The original height-cap concern was overstated — math shows the combined render fits at the exact cap (= 11 rows for max completions + footer + usage + summary).
- Reversing the guard restores the discoverability promise of `SlashCommand.usage` for the commands that actually rely on it.

## Test plan

- [x] `pytest tests/cli/test_slash_picker_usage_with_completions.py` — 4/4 pass (usage+completions together, usage without completions, no-usage clean, max+usage fits CSS budget)
- [x] `pytest tests/cli/test_slash_picker_multiline_hint.py` — 10/10 pass (= adapted the `completions_suppress_usage_line` test to assert the opposite — same fixture, opposite expectation)
- [x] `pytest tests/cli/` — 673/673 pass
- [x] `ruff check` — clean
- [x] Manual: run `reyn chat`, type `/attach ` — picker shows `Switch attached agent` + `↳ usage: /attach <name>` + the agent-name completion list. Previously the usage line was suppressed.
- [x] (skipped — narrow-terminal truncation verified via the existing usage_budget code path)

## Out of scope (deferred)

- Tightening the completions cap to leave more room (= shrink `_MAX_VISIBLE` from 8 to 7). Current 11-row budget already fits at the max.
- Per-completion descriptions (= `alpha-agent — last attached 2h ago`). Different scope; defer.
