### PR TITLE
feat(tui): agents a walks up to owning agent on non-agent row (Wave-11 A#6)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -1721,12 +1721,27 @@ class RightPanel(Widget):
         idx = max(0, min(len(self._agents_items) - 1, self._agents_cursor))
         item = self._agents_items[idx]
         if item.get("kind") != "agent":
-            # The agents tab's cursor walks ALL rows (= agents +
-            # running/recent skills/plans). ``a`` only makes sense
-            # on the agent-label row; for other rows, silently no-op
-            # rather than dispatching a meaningless ``/attach`` for
-            # a skill name.
-            return
+            # Wave-11 A#6: walk UP through the flat list to the nearest
+            # agent-label row. The agents tab orders items per-agent
+            # (header row + that agent's running / recent items), so
+            # the first ``kind == "agent"`` above the cursor is the
+            # owning agent. Previously this was a silent no-op which
+            # gave the user no feedback (= "is the key broken?"); now
+            # we prefill the owning agent's /attach so the user gets
+            # a meaningful result regardless of which sub-row they
+            # landed on.
+            owning: dict | None = None
+            for upstream in reversed(self._agents_items[:idx]):
+                if upstream.get("kind") == "agent":
+                    owning = upstream
+                    break
+            if owning is None:
+                # No agent header found above cursor — surface a hint
+                # so the user knows the key did something (= they're
+                # likely on a malformed / empty agents tab; rare).
+                self._flash_status("a: no owning agent for this row")
+                return
+            item = owning
         name = str(item.get("name", "")).strip()
         if not name:
             return

--- a/tests/cli/test_agents_a_non_agent_feedback.py
+++ b/tests/cli/test_agents_a_non_agent_feedback.py
@@ -1,0 +1,148 @@
+"""Tier 2: Agents tab ``a`` on a non-agent row walks up to owning agent.
+
+Wave-11 finding A#6. Before this PR, pressing ``a`` while the
+cursor sat on a running_skill / running_plan / recent_skill /
+recent_plan row silently no-op'd. User got no feedback —
+indistinguishable from "the key is broken". First-time-user
+discoverability bug.
+
+This PR: walk UP through ``_agents_items`` to the nearest
+``kind == "agent"`` row and prefill /attach for THAT agent. The
+agents tab orders items per-agent (header + that agent's sub-
+rows), so the first agent above the cursor is the owning
+agent. Net: ``a`` always does something meaningful regardless
+of which sub-row the user landed on.
+
+Edge case (= rare): no agent above the cursor → surface a
+``_flash_status`` hint.
+
+Pinned:
+  - cursor on running_skill row → walks up to parent agent
+  - cursor on recent_plan row → walks up to parent agent
+  - cursor on agent row → unchanged from prior behaviour
+  - empty agent list above cursor → flash hint, no prefill
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_cursor_on_running_skill_walks_to_owning_agent() -> None:
+    """Tier 2: ``a`` on a running_skill row prefills the parent agent's /attach."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar, RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        # Seed flat_items: alice agent + alice's running skill, then
+        # bob agent + bob's running skill. Cursor lands on alice's
+        # skill row.
+        panel._agents_items = [
+            {"kind": "agent", "name": "alice"},
+            {"kind": "running_skill", "skill_name": "code_review"},
+            {"kind": "agent", "name": "bob"},
+            {"kind": "running_skill", "skill_name": "shell"},
+        ]
+        panel._agents_cursor = 1  # alice's running skill
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+        ib = app.query_one("#inputbar", InputBar)
+        ta = ib.query_one("#input")
+        assert ta.text == "/attach alice"
+
+
+@pytest.mark.asyncio
+async def test_cursor_on_bobs_sub_row_walks_to_bob_not_alice() -> None:
+    """Tier 2: walk-up stops at the NEAREST agent header above cursor."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar, RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._agents_items = [
+            {"kind": "agent", "name": "alice"},
+            {"kind": "running_skill", "skill_name": "code_review"},
+            {"kind": "agent", "name": "bob"},
+            {"kind": "recent_plan", "plan_id": "p1"},
+        ]
+        panel._agents_cursor = 3  # bob's recent plan
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+        ib = app.query_one("#inputbar", InputBar)
+        ta = ib.query_one("#input")
+        assert ta.text == "/attach bob"
+
+
+@pytest.mark.asyncio
+async def test_cursor_on_agent_row_unchanged_behaviour() -> None:
+    """Tier 2: cursor directly on agent header → original prefill path."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar, RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._agents_items = [
+            {"kind": "agent", "name": "charlie"},
+        ]
+        panel._agents_cursor = 0
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+        ib = app.query_one("#inputbar", InputBar)
+        ta = ib.query_one("#input")
+        assert ta.text == "/attach charlie"
+
+
+@pytest.mark.asyncio
+async def test_no_agent_above_cursor_flashes_hint() -> None:
+    """Tier 2: when no agent header exists above a non-agent cursor → flash."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar, RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        # Pathological state: a sub-row without any preceding agent
+        # header. In practice render_agents shouldn't emit this, but
+        # the helper guards against it.
+        panel._agents_items = [
+            {"kind": "running_skill", "skill_name": "orphan"},
+        ]
+        panel._agents_cursor = 0
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()
+        # InputBar text should NOT have been prefilled.
+        ib = app.query_one("#inputbar", InputBar)
+        ta = ib.query_one("#input")
+        assert "/attach" not in ta.text
+
+
+@pytest.mark.asyncio
+async def test_empty_agents_items_silent_no_op() -> None:
+    """Tier 2: empty list → silent no-op (existing behaviour preserved)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._agents_items = []
+        panel._agents_cursor = 0
+        # Should not raise.
+        panel._prefill_attach_for_cursor()
+        await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **A#6**. Before this PR, pressing `a` while the cursor sat on a `running_skill` / `running_plan` / `recent_skill` / `recent_plan` row silently no-op'd. User got no feedback — indistinguishable from "the key is broken". First-time-user discoverability bug.

## Fix

Walk UP through `_agents_items` to the nearest `kind == "agent"` row and prefill `/attach` for THAT agent. The agents tab orders items per-agent (= header + running/recent sub-rows for that agent), so the first agent header above the cursor is the owning agent.

```
Before:           cursor on alice's running_skill row → `a` → silent no-op
After:            cursor on alice's running_skill row → `a` → "/attach alice" prefilled
```

Edge case: no agent header above cursor (= rare, render_agents shouldn't produce it) → `_flash_status` hint so even malformed states get user feedback.

## Test plan

- [x] `pytest tests/cli/test_agents_a_non_agent_feedback.py` — 5/5 pass (cursor on running_skill walks to parent, walks to NEAREST agent header, cursor on agent row unchanged, no-agent-above flashes, empty list silent)
- [x] `pytest tests/cli/` — 682/682 pass
- [x] `ruff check` — clean
- [x] Manual: navigate Agents tab so cursor lands on a sub-row, press `a` → input bar prefills `/attach <owning-agent>`. Press `a` on the agent header row directly → same result (= existing behaviour).
