### PR TITLE
docs(catalog): note OpenAI-native portability caveat for dotted qualified names (closes #54)

### DIFF
--- a/docs/concepts/universal-catalog.ja.md
+++ b/docs/concepts/universal-catalog.ja.md
@@ -89,6 +89,29 @@ split rule は 「category 名直後の最初の `__`」 なので
 | `rag.corpus__meetings` | (`rag.corpus`, `meetings`) |
 | `file__read` | (`file`, `read`) |
 
+### Provider portability — qualified name 中の `.`
+
+OpenAI native function-call API は tool 名を `^[a-zA-Z0-9_-]{1,64}$` に
+制限している (= `.` は不可)。 Reyn の qualified name はカテゴリに `.` を
+含む形 (`mcp.tool`, `agent.peer`, `reyn.source` 等) があり、 **LiteLLM
+proxy 経由なら OK** だが OpenAI native を直接叩く場合 reject される
+可能性がある。
+
+Reyn の標準設定は全 provider を LiteLLM 経由でルーティングする
+(`reyn.yaml: models: standard: openai/...`) ため、 ドット入り名でも
+end-to-end で動作する。 Gemini / Anthropic / OpenAI-compat endpoint は
+すべて LiteLLM 経由なら `.` を許容する。
+
+OpenAI native (= LiteLLM を介さない) 経路を新規に追加する場合は:
+
+  - LiteLLM proxy を前に立てる (= 推奨、 Reyn の default に揃う)、 もしくは
+  - qualified name を全て `_` ベースに移行 (= catalog enumerator /
+    dispatch table / hot-list / fixture / scenario すべて同期 update が
+    必要な breaking change。 FP-0034 §D18 / #54 で tracking)。
+
+直接 OpenAI native callsite が現プロジェクトには存在しないため、
+移行は今は scope 外。 LiteLLM proxy が canonical ingress。
+
 ## 3 つの wrapper
 
 ### `list_actions(category, filter, offset, limit) → {items, total}`

--- a/docs/concepts/universal-catalog.md
+++ b/docs/concepts/universal-catalog.md
@@ -90,6 +90,33 @@ Examples:
 | `rag.corpus__meetings` | (`rag.corpus`, `meetings`) |
 | `file__read` | (`file`, `read`) |
 
+### Provider portability — dots in qualified names
+
+OpenAI's native function-call API restricts tool names to
+`^[a-zA-Z0-9_-]{1,64}$` (= no `.`). Reyn's qualified names with
+dotted categories (`mcp.tool`, `agent.peer`, `reyn.source`, etc.)
+therefore **work via a LiteLLM proxy** but may be rejected by direct
+OpenAI native callers.
+
+Reyn's default setup routes all providers through LiteLLM
+(`reyn.yaml: models: standard: openai/...`), so the dotted form works
+end-to-end out of the box for the bundled scenarios. Gemini /
+Anthropic / OpenAI-compatible endpoints all tolerate the `.` when
+called via LiteLLM.
+
+If you wire up a direct-OpenAI-native caller (= no LiteLLM in the
+middle), you'll need either:
+
+  - keep using a LiteLLM proxy in front (= recommended; matches the
+    Reyn default), OR
+  - migrate qualified names to use `_` everywhere (= breaking change
+    across catalog enumerators / dispatch tables / hot-list / fixtures /
+    scenarios; tracked at FP-0034 §D18 / #54 should it become real).
+
+The migration is out of scope today because no direct-OpenAI-native
+path exists in the Reyn project and the LiteLLM proxy is the canonical
+ingress.
+
 ## The 3 wrappers
 
 ### `list_actions(category, filter, offset, limit) → {items, total}`


### PR DESCRIPTION
**[e2e-coder]** — FP-0034 §D18 follow-up (= #54) raised that Reyn's qualified-name format (``<category>__<entry_name>`` with categories like ``mcp.tool`` / ``agent.peer`` / ``reyn.source`` containing literal ``.``) doesn't match OpenAI's native function-call name spec (``^[a-zA-Z0-9_-]{1,64}$``).

In practice the issue is currently dormant: Reyn's default setup routes all providers through LiteLLM (``reyn.yaml: models: standard: openai/...``), and LiteLLM tolerates the ``.`` for Gemini / Anthropic / OpenAI-compat endpoints. No direct-OpenAI-native callsite exists in the project, and migrating qualified names to ``_``-only would be a breaking change touching catalog enumerators, dispatch tables, hot-list seed, fixtures, scenarios.

## Changes

Adds a "Provider portability — dots in qualified names" subsection to:

- ``docs/concepts/universal-catalog.md``
- ``docs/concepts/universal-catalog.ja.md``

Right after the qualified-name examples table. Documents:

- Why dotted names work today (= LiteLLM proxy tolerates).
- Which providers are affected (= direct OpenAI native only).
- Two migration options (= keep proxy / rename to ``_``).
- Why the rename is out of scope today (= no direct-native path).

## Test plan

- [x] **Rootdir** verify: ``python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`` → 5355 passed (= no regressions), 5 skipped, 1 deselected, 3 xfailed
- [x] Markdown render manually inspected — table + new subsection layout reads cleanly

## Closes

#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)