### PR TITLE
feat(tui): AsyncStackPanel middle-elides long agent_id on narrow widths (Wave-11 B#5)

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -63,6 +63,8 @@ from textual.widgets import Static
 
 from reyn.chat.tui._palette import _AMBER, _CORAL
 
+from ._renderable_cache import RenderableCacheMixin
+
 # Visible cap. Past this, overflow collapses to a single "… +N more" row
 # so the panel never crowds the input bar even under unusual fan-out.
 _CAP = 5
@@ -75,6 +77,36 @@ _GLYPH_RUNNING = "⟳"
 _GLYPH_PENDING = "⚑"
 
 _RIGHT_MARGIN_CELLS = 4
+
+# Wave-11 B#5: when the row is narrow enough that summary would be
+# wiped to 0 cells, the agent_id (often a 36-char UUID) gets
+# middle-elided to free cells for the more-informative summary.
+# Below this many cells of summary budget, prefer to elide id over
+# blanking summary entirely. 8 cells fits a typical short word.
+_MIN_SUMMARY_BUDGET_CELLS = 8
+
+# Minimum cells preserved for the elided agent_id: 4 head + 1 "…"
+# + 4 tail = 9. Typical UUID head ``abcd`` + tail ``7890`` is
+# enough to disambiguate among ≤ _CAP simultaneous tasks.
+_MIN_ELIDED_ID_CELLS = 9
+
+
+def _middle_elide_id(agent_id: str, max_cells: int) -> str:
+    """Middle-elide an identifier to fit ``max_cells`` cells.
+
+    Returns ``head + '…' + tail``. Below 3 cells degrades to plain
+    head truncation (= can't fit head+ellipsis+tail meaningfully).
+    Input shorter than the budget round-trips unchanged so calling
+    this on already-fitting IDs is a safe no-op.
+    """
+    if cell_len(agent_id) <= max_cells:
+        return agent_id
+    if max_cells < 3:
+        return agent_id[:max_cells]
+    keep = max_cells - 1  # 1 cell for "…"
+    head_n = keep // 2
+    tail_n = keep - head_n
+    return agent_id[:head_n] + "…" + agent_id[-tail_n:]
 
 
 @dataclass
@@ -100,7 +132,7 @@ def _fmt_elapsed(seconds: float) -> str:
     return f"{h}h{m:02d}m"
 
 
-class AsyncStackPanel(Widget):
+class AsyncStackPanel(RenderableCacheMixin, Widget):
     """Bottom-docked sticky list of non-attach agent activity.
 
     State machine per entry:
@@ -313,6 +345,25 @@ class AsyncStackPanel(Widget):
         summary_budget = max(
             0, body_budget - prefix_cells - sep_cells - elapsed_cells,
         )
+        # Wave-11 B#5: when summary would be wiped to ≤ a few cells
+        # by a long agent_id (typical UUID = 36 cells), middle-elide
+        # the id to free room for the more-informative summary.
+        # Identity preserved via head+tail preview; full id is rarely
+        # needed at-a-glance, but the summary tells the user what's
+        # actually running.
+        if entry.summary and summary_budget < _MIN_SUMMARY_BUDGET_CELLS:
+            fixed_cells = cell_len(f"{glyph} async: ") + sep_cells + elapsed_cells
+            target_id_cells = max(
+                _MIN_ELIDED_ID_CELLS,
+                body_budget - fixed_cells - _MIN_SUMMARY_BUDGET_CELLS,
+            )
+            if target_id_cells < cell_len(agent_id):
+                agent_id = _middle_elide_id(agent_id, target_id_cells)
+                prefix = f"{glyph} async: {agent_id}"
+                prefix_cells = cell_len(prefix)
+                summary_budget = max(
+                    0, body_budget - prefix_cells - sep_cells - elapsed_cells,
+                )
         summary_display = self._truncate_to_cells(entry.summary, summary_budget)
 
         t.append(f"{glyph} ", style=glyph_style)
@@ -373,7 +424,14 @@ class AsyncStackPanel(Widget):
         # incompatible runtimes.
         if not getattr(self, "is_mounted", True):
             return
-        self._static.update(self._build_lines())
+        text = self._build_lines()
+        self._static.update(text)
+        # Wave-11 (mixin migration): cache the rendered Text so the
+        # RenderableCacheMixin's ``rendered_text()`` accessor stays
+        # in sync with what's on screen. Matches the funnel pattern
+        # used by SkillActivityRow / SlashPicker / ReynHeader /
+        # ToolCallRow — 5th widget on the shared mixin.
+        self._set_rendered_cache(text)
 
 
 __all__ = ["AsyncStackPanel"]

--- a/tests/cli/test_async_stack_narrow_elide.py
+++ b/tests/cli/test_async_stack_narrow_elide.py
@@ -1,0 +1,135 @@
+"""Tier 2: AsyncStackPanel middle-elides long agent_id on narrow widths.
+
+Wave-11 finding B#5. Before this PR, the truncation order
+shrunk ``summary`` first, keeping the full ``agent_id`` always
+visible. For typical UUID-shaped task ids (~36 chars) the
+prefix consumed ~50 cells; on a 50-cell narrow pane (panel
+open + small terminal) summary went to 0 cells and the entry
+became unreadable identity-only.
+
+This PR adds a middle-elide fallback: when summary would be
+wiped below ``_MIN_SUMMARY_BUDGET_CELLS``, the agent_id is
+middle-elided (= ``abcd…7890``) to free cells for the summary.
+Identity is preserved via head+tail preview, which is enough
+to disambiguate among ≤ _CAP simultaneous tasks.
+
+Pinned:
+  - ``_middle_elide_id`` head+tail+ellipsis output shape
+  - Short input round-trips unchanged
+  - Sub-3-cell budget degrades to plain head truncation
+  - Wide-panel renders preserve the full agent_id
+    (= no regression on the common case)
+  - Narrow-panel renders elide the id + render the summary
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_middle_elide_id_short_input_unchanged() -> None:
+    """Tier 2: ID shorter than budget round-trips unchanged."""
+    from reyn.chat.tui.widgets.async_stack_panel import _middle_elide_id
+
+    assert _middle_elide_id("alice", 9) == "alice"
+    assert _middle_elide_id("ab", 5) == "ab"
+
+
+def test_middle_elide_id_long_input_keeps_head_and_tail() -> None:
+    """Tier 2: long input collapses to ``<head>…<tail>``."""
+    from reyn.chat.tui.widgets.async_stack_panel import _middle_elide_id
+
+    uuid_36 = "abcdef12-3456-7890-abcd-ef1234567890"
+    out = _middle_elide_id(uuid_36, 9)
+    assert len(out) == 9
+    assert out.startswith("abcd")
+    assert out.endswith("7890")
+    assert "…" in out
+
+
+def test_middle_elide_id_subtle_budget_degrades_to_trunc() -> None:
+    """Tier 2: < 3 cell budget degrades to plain head trim."""
+    from reyn.chat.tui.widgets.async_stack_panel import _middle_elide_id
+
+    assert _middle_elide_id("abcdefgh", 2) == "ab"
+    assert _middle_elide_id("abcdefgh", 1) == "a"
+
+
+@pytest.mark.asyncio
+async def test_wide_panel_keeps_full_agent_id() -> None:
+    """Tier 2: wide panel (= plenty of summary budget) preserves the
+    full agent_id (= regression check)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(140, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        uuid_36 = "abcdef12-3456-7890-abcd-ef1234567890"
+        conv.add_async_task(uuid_36, "code_review")
+        await pilot.pause()
+        panel = conv._async_stack()
+        snap = panel.snapshot()
+        # Snapshot returns the raw agent_id (not the rendered form).
+        ids = {entry["agent_id"] for entry in snap if not entry["is_overflow"]}
+        assert uuid_36 in ids
+        # Rendered text (via cache) preserves the full id at wide width.
+        text = panel.rendered_text()
+        assert uuid_36 in text
+
+
+@pytest.mark.asyncio
+async def test_narrow_panel_elides_agent_id_to_preserve_summary() -> None:
+    """Tier 2: narrow panel middle-elides the id + still renders summary."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    # Narrow terminal — async stack panel is full-width on the bottom
+    # strip, so total width matters here.
+    async with app.run_test(headless=True, size=(60, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        uuid_36 = "abcdef12-3456-7890-abcd-ef1234567890"
+        conv.add_async_task(uuid_36, "this-is-a-distinctive-summary")
+        await pilot.pause()
+        panel = conv._async_stack()
+        text = panel.rendered_text()
+        # Full UUID NOT in render — it was elided.
+        assert uuid_36 not in text
+        # Head + ellipsis + tail signature present.
+        assert "abcd" in text
+        assert "7890" in text
+        assert "…" in text
+        # Summary surfaced (at least partially — the distinctive
+        # head should land).
+        assert "this-is" in text or "distinctive" in text
+
+
+@pytest.mark.asyncio
+async def test_narrow_panel_no_summary_skips_elide() -> None:
+    """Tier 2: when entry has no summary, no elide pressure — id stays full.
+
+    Without a summary to make room for, there's nothing to gain by
+    eliding the id; the row just renders ``<glyph> async: <id> · <elapsed>``.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(60, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Short id (already fits) — no elide needed.
+        conv.add_async_task("short-id", "")  # empty summary
+        await pilot.pause()
+        panel = conv._async_stack()
+        text = panel.rendered_text()
+        assert "short-id" in text


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **B#5**. Before this PR, the truncation order shrunk `summary` first, keeping the full `agent_id` always visible. For typical UUID-shaped task ids (~36 chars), the prefix consumed ~50 cells; on a 50-cell narrow pane (= panel open + small terminal) summary went to 0 cells and the entry became unreadable identity-only.

## Fix

When summary would be wiped below `_MIN_SUMMARY_BUDGET_CELLS` (= 8) by a long `agent_id`, the id is middle-elided (= `abcd…7890`) to free room for the more-informative summary. Identity preserved via head+tail preview — enough to disambiguate among ≤ `_CAP` simultaneous tasks.

```
Before (narrow): ⟳ async: abcdef12-3456-7890-abcd-ef1234567890           · 1.2s
After  (narrow): ⟳ async: abcd…7890  · this-is-a-distinct-summary       · 1.2s
```

## Implementation

- New `_middle_elide_id(agent_id, max_cells)` module helper.
- `_append_row` computes the would-be `summary_budget`; falls through to elide when it's too tight + entry has summary.
- Wide-panel renders unchanged (= no regression on the common case).
- Empty-summary entries skip the elide path (= no point).

## Mixin migration (= side-benefit)

This PR also migrates `AsyncStackPanel` to `RenderableCacheMixin` (= 5th widget on the shared mixin after SkillActivityRow, SlashPicker, ReynHeader, ToolCallRow). Tests can now use `rendered_text()` without reaching into the version-unstable `Static.renderable`.

## Test plan

- [x] `pytest tests/cli/test_async_stack_narrow_elide.py` — 6/6 pass (helper round-trip, head+tail signature, sub-3-cell degradation, wide-panel full id preserved, narrow elides + summary preserved, empty-summary skips)
- [x] `pytest tests/cli/` — 687/687 pass
- [x] `ruff check src/reyn/chat/tui/widgets/async_stack_panel.py tests/cli/test_async_stack_narrow_elide.py` — clean
- [x] Manual: open `reyn chat` with the panel open + narrow terminal (~60 cols). Spawn a plan task (= UUID-shaped id) — bottom strip should show `⟳ async: abcd…7890 · <summary> · <elapsed>` rather than the id-only render.
