### PR TITLE
feat(tui): ErrorBox [N/M] index badge for stacked errors (Wave-11 B#6)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1401,6 +1401,11 @@ class ConversationView(Widget):
         )
         self.mount(box)
         self._error_boxes.append(box)
+        # Wave-11 B#6 — renumber the stack so every mounted box shows
+        # ``[N/M]`` for its current position. Cheap (≤ ``_MAX_VISIBLE
+        # _ERROR_BOXES`` rows = small loop), idempotent via
+        # ``set_index_total``'s equality gate.
+        self._renumber_error_boxes()
         # C-F4 (wave-8): once ≥ 2 error boxes are stacked, surface the
         # count via the sticky so the user can see at a glance that
         # one Esc per box is the dismiss path. Single-error case keeps
@@ -1418,6 +1423,24 @@ class ConversationView(Widget):
             except Exception:
                 pass
         return box
+
+    def _renumber_error_boxes(self) -> None:
+        """Push current ``[i, total]`` to every mounted ErrorBox.
+
+        Wave-11 B#6 — called after every mutation to ``_error_boxes``
+        (= new mount, dismiss, auto-eviction) so the per-box
+        ``[N/M]`` header badge stays accurate. ``ErrorBox.set_index_total``
+        is equality-gated (no DOM round-trip when values are
+        unchanged), so re-numbering an unchanged stack is cheap.
+        Index is 1-based for human readability.
+        """
+        total = len(self._error_boxes)
+        for i, box in enumerate(self._error_boxes):
+            try:
+                box.set_index_total(i + 1, total)
+            except Exception:
+                # Box mid-teardown / DOM teardown — best-effort.
+                pass
 
     def has_error_boxes(self) -> bool:
         """Return True if any undismissed ErrorBox remains."""
@@ -1477,6 +1500,10 @@ class ConversationView(Widget):
             # breadcrumb is in the log; that's the user-visible
             # contract.
             pass
+        # Wave-11 B#6 — renumber surviving boxes so the badge stays
+        # accurate after a dismiss. ``[2/3]`` after removing the
+        # newest becomes ``[2/2]`` for the remaining tail entry.
+        self._renumber_error_boxes()
         # C-F4 (wave-8): after dismiss the live count drops by 1.
         # If still ≥ 2, refresh the count sticky to the new value;
         # otherwise the count form is stale and we clear the

--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -109,6 +109,8 @@ class ErrorBox(Widget):
         run_id_short: str = "",
         skill_name: str = "",
         id: str | None = None,
+        index: int = 0,
+        total: int = 0,
     ) -> None:
         super().__init__(id=id)
         self._message = message
@@ -116,6 +118,17 @@ class ErrorBox(Widget):
         self._run_id_short = run_id_short
         self._skill_name = skill_name
         self._expanded = False
+        # Wave-11 B#6 — per-box index badge for stacked errors. When
+        # ``total > 1`` the header renders ``✗ [2/3] [skill#abcd]: …``
+        # so a user landing on a focused box (= via F5/F6 jump) sees
+        # which one of the stack they're reading. ``mount_error`` /
+        # ``dismiss_last_error`` keep these values fresh via
+        # ``set_index_total`` after every stack mutation. Defaults
+        # (= 0/0) omit the badge so single-error rendering is
+        # unchanged (cold-default + backward compat for any caller
+        # that doesn't pass the new kwargs).
+        self._index: int = index
+        self._total: int = total
         # Extract trailing ``• <hint>`` from the first line so the header
         # can truncate the detail portion without silently dropping the
         # recovery hint — ``classify_router_error`` formats messages as
@@ -189,9 +202,44 @@ class ErrorBox(Widget):
         else:
             msg = first_line
         msg = _markup_escape(msg)
+        # Wave-11 B#6 — render a ``[N/M]`` index badge between ✗ and
+        # the prefix when this row is part of a stack (total > 1).
+        # Single-error renders omit the badge entirely so the
+        # cold-default layout is unchanged. Badge sits BEFORE the
+        # skill prefix so the eye reads "this is error 2 of 3 in
+        # the [code_review#abc1] skill". Defensive ``getattr`` keeps
+        # the ``__new__``-bypass-init test path working without
+        # forcing every test to seed the fields.
+        idx = getattr(self, "_index", 0)
+        tot = getattr(self, "_total", 0)
+        index_badge = (
+            f"[{idx}/{tot}] "
+            if tot > 1 and idx > 0
+            else ""
+        )
         if prefix:
-            return f"✗ {prefix}: {msg}  {arrow}"
-        return f"✗ {msg}  {arrow}"
+            return f"✗ {index_badge}{prefix}: {msg}  {arrow}"
+        return f"✗ {index_badge}{msg}  {arrow}"
+
+    def set_index_total(self, index: int, total: int) -> None:
+        """Update the stack-position badge and re-render the header.
+
+        Called by ``ConversationView`` after every mutation to the
+        ``_error_boxes`` list (= new mount, dismiss, auto-eviction)
+        so the badge stays accurate. Single-error states (= total
+        ≤ 1) hide the badge automatically.
+
+        Idempotent — repeated calls with the same values skip the
+        DOM round-trip so churn on a per-render tick stays cheap.
+        """
+        if self._index == index and self._total == total:
+            return
+        self._index = index
+        self._total = total
+        try:
+            self.query_one(".eb-header", Label).update(self._header_text())
+        except Exception:
+            pass
 
     # ── compose ───────────────────────────────────────────────────────────────
 

--- a/tests/cli/test_error_box_count_badge.py
+++ b/tests/cli/test_error_box_count_badge.py
@@ -1,0 +1,181 @@
+"""Tier 2: ErrorBox renders ``[N/M]`` index badge for stacked errors.
+
+Wave-11 finding B#6. Before this PR, every stacked ErrorBox
+header read identically ``✗ [skill#abcd]: msg ▶`` — no per-box
+index. The sticky surfaced the total count, but on F5/F6 jump
+landing the user had no signal "this is error 2 of 3" inside
+the focused box. With identical-looking failures (= timeout × 3)
+the user couldn't tell which they were reading.
+
+This PR: each ErrorBox carries ``_index`` + ``_total`` that the
+header renders as ``[N/M]`` when total > 1. ``ConversationView``
+calls ``set_index_total`` after every mutation to ``_error_boxes``
+(mount, dismiss, auto-eviction) so the badges stay accurate.
+
+Pinned:
+  - Single error → no badge (= cold-default unchanged)
+  - 2+ errors → each shows correct ``[N/M]``
+  - Dismiss → surviving boxes renumber (e.g. ``[1/2]`` → ``[1/1]``
+    → no badge)
+  - Auto-eviction → renumbers
+  - ``set_index_total`` is equality-gated (= idempotent calls
+    skip the DOM round-trip)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _header_text_of(box) -> str:
+    """Read the rendered header text via the .eb-header Label."""
+    from textual.widgets import Label
+    try:
+        label = box.query_one(".eb-header", Label)
+    except Exception:
+        return ""
+    renderable = getattr(label, "_renderable", None) or getattr(label, "renderable", None)
+    if renderable is None:
+        # Fallback to building the header directly from the widget's helper.
+        return box._header_text()
+    return str(getattr(renderable, "plain", renderable))
+
+
+@pytest.mark.asyncio
+async def test_single_error_no_badge() -> None:
+    """Tier 2: 1 mounted error → no ``[N/M]`` prefix (= cold-default)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        box = conv.mount_error(message="solo error")
+        await pilot.pause()
+        header = box._header_text()
+        # No badge present.
+        assert "[1/1]" not in header
+        # ``✗ solo error  ▶`` shape preserved.
+        assert "solo error" in header
+
+
+@pytest.mark.asyncio
+async def test_two_errors_renumber_correctly() -> None:
+    """Tier 2: 2 mounted errors → each shows ``[1/2]`` / ``[2/2]``."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        first = conv.mount_error(message="first error")
+        second = conv.mount_error(message="second error")
+        await pilot.pause()
+        assert "[1/2]" in first._header_text()
+        assert "[2/2]" in second._header_text()
+
+
+@pytest.mark.asyncio
+async def test_three_errors_renumber_correctly() -> None:
+    """Tier 2: 3 mounted errors → each shows the right position."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        boxes = [
+            conv.mount_error(message=f"err {i}") for i in range(3)
+        ]
+        await pilot.pause()
+        assert "[1/3]" in boxes[0]._header_text()
+        assert "[2/3]" in boxes[1]._header_text()
+        assert "[3/3]" in boxes[2]._header_text()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_renumbers_survivors() -> None:
+    """Tier 2: dismissing the newest box renumbers the rest down."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        first = conv.mount_error(message="first")
+        second = conv.mount_error(message="second")
+        third = conv.mount_error(message="third")
+        await pilot.pause()
+        assert "[3/3]" in third._header_text()
+        conv.dismiss_last_error()  # removes third
+        await pilot.pause()
+        # Now 2 remain; renumber to [1/2] [2/2].
+        assert "[1/2]" in first._header_text()
+        assert "[2/2]" in second._header_text()
+        conv.dismiss_last_error()  # removes second
+        await pilot.pause()
+        # Single error remaining → no badge.
+        assert "[1/" not in first._header_text()
+        assert "[2/" not in first._header_text()
+
+
+def test_header_text_omits_badge_for_total_one() -> None:
+    """Tier 2: a directly-constructed box with total=1 omits the badge.
+
+    Cold-default ctor params (= index=0, total=0) skip the badge
+    too — ``total > 1 and index > 0`` is the gate.
+    """
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    # total=1, single error case.
+    box = ErrorBox(message="x", index=1, total=1)
+    assert "[1/1]" not in box._header_text()
+    # Defaults: index=0, total=0 — no badge.
+    box2 = ErrorBox(message="x")
+    assert "/" not in box2._header_text().split("✗", 1)[1].split("▶")[0]
+
+
+def test_set_index_total_idempotent_skip() -> None:
+    """Tier 2: redundant set_index_total calls early-return (= no DOM churn).
+
+    Internal counter check: after the first set, the second
+    call with identical values doesn't change ``_index`` /
+    ``_total``.
+    """
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    box = ErrorBox(message="x")
+    box.set_index_total(2, 3)
+    assert box._index == 2
+    assert box._total == 3
+    # Same values — equality gate short-circuits.
+    box.set_index_total(2, 3)
+    assert box._index == 2
+    assert box._total == 3
+
+
+@pytest.mark.asyncio
+async def test_set_index_total_updates_header() -> None:
+    """Tier 2: ``set_index_total`` re-renders the header with the new badge."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        box = conv.mount_error(message="x")
+        await pilot.pause()
+        box.set_index_total(2, 5)
+        await pilot.pause()
+        assert "[2/5]" in box._header_text()


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **B#6**. Before this PR, every stacked ErrorBox header read identically `✗ [skill#abcd]: msg ▶` — no per-box index. The sticky status surfaced the total count, but on F5/F6 jump landing the user had no signal "this is error 2 of 3" inside the focused box. With identical-looking failures (= timeout × 3) the user couldn't tell which they were reading.

## Fix

```
Before (3 stacked):                    After (3 stacked):
  ✗ [skill#abc1]: timeout  ▶            ✗ [1/3] [skill#abc1]: timeout  ▶
  ✗ [skill#abc1]: timeout  ▶            ✗ [2/3] [skill#abc1]: timeout  ▶
  ✗ [skill#abc1]: timeout  ▶            ✗ [3/3] [skill#abc1]: timeout  ▶
```

Single-error renders omit the badge entirely (= cold-default unchanged).

## Implementation

- `ErrorBox.__init__` accepts `index: int = 0` + `total: int = 0`.
- `_header_text` prefixes `[N/M]` when `total > 1 and index > 0`.
- `ErrorBox.set_index_total(index, total)` updates fields + re-renders the `.eb-header` Label; equality-gated so redundant calls skip the DOM round-trip.
- `ConversationView._renumber_error_boxes()` walks the list and `set_index_total`s each row with its 1-based position.
- `mount_error` + `dismiss_last_error` call `_renumber_error_boxes` after mutating the list (auto-eviction's net new state is covered by the same post-append call in `mount_error`).
- Defensive `getattr` on `_index` / `_total` keeps the existing `ErrorBox.__new__`-bypass-init test pattern working without forcing every test to seed the fields.

## Test plan

- [x] `pytest tests/cli/test_error_box_count_badge.py` — 7/7 pass (single no badge, 2-error renumber, 3-error renumber, dismiss renumbers, total=1 omits, set_index_total idempotent, set_index_total updates header)
- [x] `pytest tests/cli/test_errorbox_*.py` — existing ErrorBox regression tests pass (= defensive getattr keeps __new__ tests working)
- [x] `pytest tests/cli/` — 696/696 pass
- [x] `ruff check src/reyn/chat/tui/widgets/error_box.py src/reyn/chat/tui/widgets/conversation.py tests/cli/test_error_box_count_badge.py` — clean
- [x] Manual: trigger 3 errors in `reyn chat` — each header shows `[1/3]` / `[2/3]` / `[3/3]`. Press Esc on the newest — surviving 2 renumber to `[1/2]` / `[2/2]`. Press Esc again — single error left, badge disappears.
