### PR TITLE
feat(tui): /cancel and /answer expose id-prefix completers (Wave-11 C#3)

### DIFF
--- a/src/reyn/chat/slash/chat.py
+++ b/src/reyn/chat/slash/chat.py
@@ -52,10 +52,32 @@ async def list_cmd(session: "ChatSession", args: str) -> None:
     await reply(session, "\n".join(lines))
 
 
+def _running_run_id_completer(
+    session: "object", arg_partial: str = "",
+) -> list[str]:
+    """Wave-11 C#3 — completer for /cancel <id-prefix>.
+
+    Surfaces running ``run_id`` keys from ``session.running_skills``
+    so the user can Tab through them in the picker hint instead of
+    eye-balling them from ``/list`` output. Defensive: empty list
+    on any access failure (= test stubs / pre-init session) so a
+    broken completer can't break the picker.
+    """
+    try:
+        running = list(getattr(session, "running_skills", {}).keys())
+    except Exception:
+        return []
+    if not arg_partial:
+        return running
+    last_word = arg_partial.rsplit(" ", 1)[-1] if " " in arg_partial else arg_partial
+    return [rid for rid in running if rid.startswith(last_word)]
+
+
 @slash(
     "cancel",
     summary="Cancel a running skill",
     usage="/cancel <id-prefix>",
+    completer=_running_run_id_completer,
 )
 async def cancel_cmd(session: "ChatSession", args: str) -> None:
     """``/cancel <id-prefix>`` — cancel a running skill task."""
@@ -88,10 +110,43 @@ async def cancel_cmd(session: "ChatSession", args: str) -> None:
     ))
 
 
+def _intervention_id_completer(
+    session: "object", arg_partial: str = "",
+) -> list[str]:
+    """Wave-11 C#3 — completer for /answer <id-prefix> <text>.
+
+    Surfaces active intervention ids from
+    ``session._interventions.list_active()`` so the user can Tab
+    through them. ``/answer`` takes ``<id-prefix> <text>`` — only
+    the FIRST word is the id; once the user has typed past the
+    space the input is the answer body and the picker hint is
+    irrelevant. We filter by the LAST whitespace-delimited token
+    of ``arg_partial`` so the prefix-match still works regardless
+    of where the cursor sits.
+    """
+    try:
+        interventions = getattr(session, "_interventions", None)
+        if interventions is None:
+            return []
+        ids = [iv.id for iv in interventions.list_active()]
+    except Exception:
+        return []
+    if not arg_partial:
+        return ids
+    # If the user has already typed past the first whitespace,
+    # the picker hint is no longer useful (= they're typing the
+    # answer body, not the id). The empty-match list naturally
+    # falls back to ``set_hint`` upstream.
+    if " " in arg_partial:
+        return []
+    return [iid for iid in ids if iid.startswith(arg_partial)]
+
+
 @slash(
     "answer",
     summary="Answer a pending intervention",
     usage="/answer <id-prefix> <text>",
+    completer=_intervention_id_completer,
 )
 async def answer_cmd(session: "ChatSession", args: str) -> None:
     """``/answer <id-prefix> <text>`` — deliver answer to a non-head

--- a/tests/test_slash_cancel_answer_completer.py
+++ b/tests/test_slash_cancel_answer_completer.py
@@ -1,0 +1,155 @@
+"""Tier 2: /cancel and /answer expose id-prefix completers (Wave-11 C#3).
+
+Wave-11 finding C#3. Before this PR, ``/cancel <id-prefix>`` and
+``/answer <id-prefix> <text>`` relied on the user typing run_id /
+intervention_id by hand or scrolling ``/list`` output to find
+them. Both commands already enumerate IDs from
+``session.running_skills`` / ``session._interventions.list_active()``;
+exposing those as picker hint completers gives Tab-recall parity
+with ``/attach`` which already has an agent-name completer.
+
+Pinned:
+  - ``_running_run_id_completer`` returns running.keys() when
+    arg_partial is empty
+  - Prefix filter narrows the list
+  - Defensive: empty list / no attribute → empty completion
+  - ``_intervention_id_completer`` returns active intervention IDs
+  - Past-first-whitespace input returns empty (= user is typing
+    the answer body, no longer the id)
+  - Both slash commands have the completer wired
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+class _StubSession:
+    """Minimal session stub — only carries what the completers read."""
+
+    def __init__(self, run_ids=None, interventions=None):
+        self.running_skills = {rid: object() for rid in (run_ids or [])}
+        self._interventions = _StubInterventionRegistry(interventions or [])
+
+
+class _StubInterventionRegistry:
+    def __init__(self, ivs):
+        self._ivs = ivs
+
+    def list_active(self):
+        return self._ivs
+
+
+class _StubIntervention:
+    def __init__(self, iid):
+        self.id = iid
+
+
+def test_running_run_id_completer_returns_keys_when_empty_partial() -> None:
+    """Tier 2: empty arg_partial returns all running ``run_id`` keys."""
+    from reyn.chat.slash.chat import _running_run_id_completer
+
+    session = _StubSession(run_ids=["abc123", "def456", "ghi789"])
+    out = _running_run_id_completer(session, "")
+    assert set(out) == {"abc123", "def456", "ghi789"}
+
+
+def test_running_run_id_completer_filters_by_prefix() -> None:
+    """Tier 2: prefix narrows the completion list."""
+    from reyn.chat.slash.chat import _running_run_id_completer
+
+    session = _StubSession(run_ids=["abc123", "abc999", "def456"])
+    assert set(_running_run_id_completer(session, "abc")) == {"abc123", "abc999"}
+    assert _running_run_id_completer(session, "def") == ["def456"]
+    assert _running_run_id_completer(session, "zzz") == []
+
+
+def test_running_run_id_completer_empty_session_returns_empty() -> None:
+    """Tier 2: session with no running skills returns empty list."""
+    from reyn.chat.slash.chat import _running_run_id_completer
+
+    session = _StubSession(run_ids=[])
+    assert _running_run_id_completer(session, "abc") == []
+
+
+def test_running_run_id_completer_handles_no_attribute() -> None:
+    """Tier 2: session without ``running_skills`` returns empty (defensive)."""
+    from reyn.chat.slash.chat import _running_run_id_completer
+
+    class _Bare:
+        pass
+
+    assert _running_run_id_completer(_Bare(), "") == []
+
+
+def test_intervention_id_completer_returns_active_ids() -> None:
+    """Tier 2: empty arg_partial returns all active intervention IDs."""
+    from reyn.chat.slash.chat import _intervention_id_completer
+
+    session = _StubSession(interventions=[
+        _StubIntervention("iv-aaa"),
+        _StubIntervention("iv-bbb"),
+    ])
+    out = _intervention_id_completer(session, "")
+    assert set(out) == {"iv-aaa", "iv-bbb"}
+
+
+def test_intervention_id_completer_filters_by_prefix() -> None:
+    """Tier 2: prefix filter narrows."""
+    from reyn.chat.slash.chat import _intervention_id_completer
+
+    session = _StubSession(interventions=[
+        _StubIntervention("iv-aaa"),
+        _StubIntervention("iv-bbb"),
+        _StubIntervention("zz-ccc"),
+    ])
+    assert set(_intervention_id_completer(session, "iv-")) == {"iv-aaa", "iv-bbb"}
+    assert _intervention_id_completer(session, "zz") == ["zz-ccc"]
+
+
+def test_intervention_id_completer_past_first_space_empty() -> None:
+    """Tier 2: after the user types past the id+space, the completer goes silent.
+
+    ``/answer <id-prefix> <text>`` — once the user has typed past
+    the first whitespace they're writing the answer body, not the
+    id. Returning [] lets the picker fall back to plain hint mode.
+    """
+    from reyn.chat.slash.chat import _intervention_id_completer
+
+    session = _StubSession(interventions=[_StubIntervention("iv-aaa")])
+    assert _intervention_id_completer(session, "iv-aaa hello") == []
+    assert _intervention_id_completer(session, "iv- text") == []
+
+
+def test_intervention_id_completer_no_registry_returns_empty() -> None:
+    """Tier 2: session without ``_interventions`` returns empty (defensive)."""
+    from reyn.chat.slash.chat import _intervention_id_completer
+
+    class _Bare:
+        pass
+
+    assert _intervention_id_completer(_Bare(), "") == []
+
+
+def test_cancel_slash_has_completer_registered() -> None:
+    """Tier 2: ``/cancel`` registers ``_running_run_id_completer``."""
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.slash.chat import _running_run_id_completer
+
+    cmd = REGISTRY.get("cancel")
+    assert cmd is not None
+    assert cmd.completer is _running_run_id_completer
+
+
+def test_answer_slash_has_completer_registered() -> None:
+    """Tier 2: ``/answer`` registers ``_intervention_id_completer``."""
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.slash.chat import _intervention_id_completer
+
+    cmd = REGISTRY.get("answer")
+    assert cmd is not None
+    assert cmd.completer is _intervention_id_completer


### PR DESCRIPTION
**[tui-coder]** — Wave-11 finding **C#3**. Before this PR, `/cancel <id-prefix>` and `/answer <id-prefix> <text>` relied on the user typing run_id / intervention_id by hand or scrolling `/list` output to find them. Both commands already enumerate IDs from `session.running_skills` / `session._interventions.list_active()` — exposing those as picker hint completers gives Tab-recall parity with `/attach` (which already has an agent-name completer).

## What it does

```
/cancel <Tab>     → picker lists running run_ids; Tab selects one
/cancel abc<Tab>  → picker filters to run_ids starting with "abc"
/answer <Tab>     → picker lists active intervention ids
/answer iv-1 hello → completer goes silent (= user is typing answer body)
```

Combined with the picker-hint usage line from #595 (= Wave-11 C#5), users now see both the structured usage syntax AND the live id list when typing `/cancel ` or `/answer `.

## Implementation

- `_running_run_id_completer(session, arg_partial)` — surfaces `session.running_skills.keys()` filtered by `arg_partial` prefix. Defensive on missing attribute / empty session (= safe empty fallback).
- `_intervention_id_completer(session, arg_partial)` — surfaces active intervention IDs via `session._interventions.list_active()`. Goes silent past the first whitespace (= user is typing the answer body, not the id) so the picker falls back to plain hint mode.
- Wires the completers into the existing `@slash` decorators on `/cancel` and `/answer`.

## Test plan

- [x] `pytest tests/test_slash_cancel_answer_completer.py` — 10/10 pass (empty returns keys, prefix filter, empty session, missing attribute defensive, intervention surface, prefix filter, past-first-space empty, no-registry defensive, both commands wired)
- [x] `pytest tests/cli/ tests/test_slash_*.py` — 743/743 pass
- [x] `ruff check src/reyn/chat/slash/chat.py tests/test_slash_cancel_answer_completer.py` — clean
- [x] Manual: launch `reyn chat`, fire a long-running skill, then type `/cancel ` — picker lists the active run_id. Tab to select it. Same flow with `/answer ` when a pending intervention exists.

## Out of scope (deferred)

- ``/skill discard`` completer — same id-prefix shape but the skill discard logic lives in a different file. Could be a follow-on with the same `_running_run_id_completer` import.
