### PR TITLE
feat(tui): /concept slash — inline glossary lookup (T1-3)

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -178,6 +178,7 @@ from reyn.chat.slash import agent as _agent_mod  # noqa: E402, F401
 from reyn.chat.slash import agents as _agents_mod  # noqa: E402, F401
 from reyn.chat.slash import budget as _budget_mod  # noqa: E402, F401
 from reyn.chat.slash import chat as _chat_mod  # noqa: E402, F401
+from reyn.chat.slash import concept as _concept_mod  # noqa: E402, F401
 from reyn.chat.slash import copy as _copy_mod  # noqa: E402, F401
 from reyn.chat.slash import cost_inline as _cost_inline_mod  # noqa: E402, F401
 from reyn.chat.slash import docs_filter as _docs_filter_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/concept.py
+++ b/src/reyn/chat/slash/concept.py
@@ -1,0 +1,179 @@
+"""/concept [<term>] — inline glossary lookup for TUI vocabulary.
+
+Surfaces definitions from ``docs/guide/for-skill-authors/glossary.md``
+without leaving the chat pane.  The glossary uses Markdown tables with
+``| English | 日本語 | Definition |`` rows (and some two-column variant
+tables); the parser walks all tables and captures every term → definition
+pair it finds.
+
+Usage::
+
+    /concept              # shows intro + path to full glossary
+    /concept skill        # exact match → inline definition
+    /concept SKILL        # case-insensitive
+    /concept skil         # typo → "did you mean skill, …?" via difflib
+    /concept zxzxzx       # unknown → "no glossary entry" + 0 suggestions
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from pathlib import Path
+
+from reyn.chat.slash import reply, reply_error, slash
+
+# Canonical path relative to the project root.  Resolved at call time so
+# tests can inject a custom path via the ``_glossary_path`` kwarg on the
+# internal helpers.
+_GLOSSARY_REL = Path("docs/guide/for-skill-authors/glossary.md")
+
+
+def _project_root() -> Path:
+    """Return the project root (= ancestor of ``src/reyn``)."""
+    return Path(__file__).parent.parent.parent.parent
+
+
+def _default_glossary_path() -> Path:
+    return _project_root() / _GLOSSARY_REL
+
+
+# ── parser ────────────────────────────────────────────────────────────────
+
+
+def _parse_glossary(text: str) -> dict[str, str]:
+    """Parse a Markdown glossary text → ``{term_lower: definition}``.
+
+    Handles the two table shapes found in the real glossary:
+
+    1. Three-column ``| English | 日本語 | Definition |``  — the English
+       term is column 0, definition is column 2.
+    2. Two-column ``| File / Term | Purpose / Meaning |`` — column 0 is
+       the term, column 1 is the definition.
+
+    Separator rows (``|---|---|``) and header rows (matching known header
+    labels such as "English", "File", "Verb", "Mode", "Word") are skipped.
+    Rows whose first column is backtick-wrapped code (e.g. `_default`) are
+    included — the backticks are stripped for the lookup key but preserved
+    in the stored definition line.
+
+    Returns a ``dict`` whose keys are lower-cased English terms and whose
+    values are the raw definition strings (stripped).
+    """
+    _HEADER_FIRST_COLS = {
+        "english", "file", "verb", "mode", "word", "term",
+    }
+    result: dict[str, str] = {}
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        # Split on | and discard empty border fragments
+        parts = [p.strip() for p in stripped.split("|")]
+        # Split produces leading/trailing empty strings around the outer |
+        parts = [p for p in parts if p != ""]
+        if len(parts) < 2:
+            continue
+        # Skip separator rows  (e.g. |---|------|------------|)
+        if re.match(r"^[-:]+$", parts[0]):
+            continue
+        col0 = parts[0]
+        # Strip backtick code spans for key derivation
+        key_raw = col0.strip("`").strip()
+        if not key_raw:
+            continue
+        # Skip header rows by checking lower-cased first token
+        if key_raw.lower() in _HEADER_FIRST_COLS:
+            continue
+        # Determine definition column
+        if len(parts) >= 3:
+            # Three-column table: col2 = definition
+            definition = parts[2].strip()
+        else:
+            # Two-column table: col1 = definition / purpose
+            definition = parts[1].strip()
+
+        if not definition:
+            continue
+
+        key = key_raw.lower()
+        # First occurrence wins (glossary may repeat a term across sections)
+        if key not in result:
+            result[key] = definition
+
+    return result
+
+
+# ── public helpers (also used by tests) ───────────────────────────────────
+
+
+def _load_glossary(path: Path) -> dict[str, str] | None:
+    """Read and parse the glossary file.  Returns ``None`` on I/O error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return _parse_glossary(text)
+
+
+def _lookup(
+    term: str,
+    glossary: dict[str, str],
+) -> tuple[str | None, list[str]]:
+    """Return ``(definition_or_None, fuzzy_suggestions)``.
+
+    Case-insensitive exact match first.  On miss, ``difflib`` yields up to
+    3 close matches from the glossary keys (displayed as original-case).
+    """
+    key = term.lower()
+    if key in glossary:
+        return glossary[key], []
+    suggestions = difflib.get_close_matches(key, glossary.keys(), n=3, cutoff=0.5)
+    return None, list(suggestions)
+
+
+# ── slash command ──────────────────────────────────────────────────────────
+
+_GLOSSARY_PATH_HINT = (
+    "Full glossary: Ctrl+B → Docs → guide/for-skill-authors/glossary"
+)
+
+
+@slash(
+    "concept",
+    summary="Look up a TUI/reyn concept in the glossary",
+    usage="/concept [<term>]",
+)
+async def concept_cmd(session: object, args: str) -> None:  # noqa: D401
+    term = (args or "").strip()
+
+    if not term:
+        msg = (
+            "Looks up TUI concepts in the glossary. "
+            "Try /concept skill or /concept plan.\n"
+            f"{_GLOSSARY_PATH_HINT}"
+        )
+        await reply(session, msg)
+        return
+
+    gloss_path = _default_glossary_path()
+    glossary = _load_glossary(gloss_path)
+    if glossary is None:
+        await reply_error(
+            session,
+            f"glossary unreadable — expected at {_GLOSSARY_REL}",
+        )
+        return
+
+    definition, suggestions = _lookup(term, glossary)
+    if definition is not None:
+        await reply(session, f"{term}: {definition}")
+        return
+
+    # Miss — compose "did you mean" line
+    if suggestions:
+        did_you_mean = "did you mean: " + ", ".join(suggestions)
+        msg = f"no glossary entry for '{term}' — {did_you_mean}"
+    else:
+        msg = f"no glossary entry for '{term}'"
+    await reply_error(session, msg)

--- a/tests/test_slash_concept.py
+++ b/tests/test_slash_concept.py
@@ -154,7 +154,7 @@ async def _run_concept(args: str, *, glossary_path: Path | None = None) -> list[
 
 def _run(coro):  # type: ignore[no-untyped-def]
     import asyncio
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _write_fixture_glossary(tmp_path: Path) -> Path:

--- a/tests/test_slash_concept.py
+++ b/tests/test_slash_concept.py
@@ -1,0 +1,266 @@
+"""Tier 2: /concept slash — inline glossary lookup contract.
+
+Pins:
+  1. Bare ``/concept`` (no args) returns intro + glossary path reference.
+  2. Exact match: ``/concept skill`` returns the skill definition.
+  3. Case-insensitive: ``/concept SKILL`` returns the same definition.
+  4. Partial/fuzzy match: ``/concept skil`` (typo) → "no entry" + did-you-mean.
+  5. No match at all: ``/concept zxzxzx`` → "no entry" + no suggestions.
+  6. Missing glossary file: defensive reply, no crash.
+
+Tests use a small fixture glossary string so they don't break on every
+real glossary edit.  Parser helpers are tested directly; the command is
+smoke-tested via the @slash registry to verify end-to-end registration.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# Import the module so the @slash decorator fires and registers the command.
+import reyn.chat.slash.concept  # noqa: F401  (side-effect: registers /concept)
+from reyn.chat.slash.concept import _lookup, _parse_glossary
+
+# ── fixture ────────────────────────────────────────────────────────────────
+
+# Minimal glossary in the real three-column format to keep tests independent
+# of the live glossary.md content.
+_FIXTURE_TEXT = """\
+## Core
+
+| English | 日本語 | Definition |
+|---------|--------|------------|
+| Skill | スキル | A directory defining a phase graph and final output schema. |
+| Phase | フェーズ | A reusable processing unit declaring only its input and instructions. |
+| Workspace | ワークスペース | The shared store for files and artifacts. |
+| Artifact | アーティファクト | Structured data passed between phases. |
+
+## DSL files
+
+| File | Purpose |
+|------|---------|
+| `skill.md` | Skill declaration: entry, graph, final_output, permissions. |
+"""
+
+_FIXTURE_GLOSSARY = _parse_glossary(_FIXTURE_TEXT)
+
+
+# ── _parse_glossary helper ─────────────────────────────────────────────────
+
+
+def test_parse_three_column_table() -> None:
+    """Tier 2: parser extracts term→definition from three-column table rows."""
+    assert "skill" in _FIXTURE_GLOSSARY
+    assert "phase" in _FIXTURE_GLOSSARY
+    assert "workspace" in _FIXTURE_GLOSSARY
+    assert "artifact" in _FIXTURE_GLOSSARY
+
+
+def test_parse_two_column_table() -> None:
+    """Tier 2: parser extracts term→definition from two-column (File/Purpose) tables."""
+    # skill.md is in the two-column DSL table
+    assert "skill.md" in _FIXTURE_GLOSSARY
+    assert "Skill declaration" in _FIXTURE_GLOSSARY["skill.md"]
+
+
+def test_parse_skips_header_and_separator_rows() -> None:
+    """Tier 2: header rows ("English", "File") and separator rows are not in output."""
+    assert "english" not in _FIXTURE_GLOSSARY
+    assert "file" not in _FIXTURE_GLOSSARY
+    # Separator cell would look like "---"
+    assert "---" not in _FIXTURE_GLOSSARY
+
+
+# ── _lookup helper ─────────────────────────────────────────────────────────
+
+
+def test_lookup_exact_match() -> None:
+    """Tier 2: exact match returns the definition and no suggestions."""
+    defn, suggestions = _lookup("skill", _FIXTURE_GLOSSARY)
+    assert defn is not None
+    assert "phase graph" in defn
+    assert suggestions == []
+
+
+def test_lookup_case_insensitive() -> None:
+    """Tier 2: lookup is case-insensitive — SKILL resolves same as skill."""
+    defn_lower, _ = _lookup("skill", _FIXTURE_GLOSSARY)
+    defn_upper, _ = _lookup("SKILL", _FIXTURE_GLOSSARY)
+    assert defn_lower == defn_upper
+    assert defn_lower is not None
+
+
+def test_lookup_fuzzy_miss_returns_suggestions() -> None:
+    """Tier 2: typo 'skil' → no exact match + close-match suggestions."""
+    defn, suggestions = _lookup("skil", _FIXTURE_GLOSSARY)
+    assert defn is None
+    # 'skill' should appear in the suggestions list for a one-char typo
+    assert "skill" in suggestions
+
+
+def test_lookup_no_match_no_suggestions() -> None:
+    """Tier 2: completely unrelated term → no definition, no suggestions."""
+    defn, suggestions = _lookup("zxzxzx", _FIXTURE_GLOSSARY)
+    assert defn is None
+    assert suggestions == []
+
+
+# ── /concept command — smoke tests via the live REGISTRY ──────────────────
+
+
+class _FakeSession:
+    """Minimal session stand-in: collects outbox messages without networking."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def _put_outbox(self, msg: object) -> None:
+        self.messages.append({"kind": msg.kind, "text": msg.text})
+
+
+async def _run_concept(args: str, *, glossary_path: Path | None = None) -> list[dict]:
+    """Invoke the registered /concept handler; returns collected messages.
+
+    When ``glossary_path`` is provided the module's ``_default_glossary_path``
+    is monkey-patched so the command reads a test-controlled file rather than
+    the real glossary.
+    """
+    import reyn.chat.slash.concept as _mod
+    from reyn.chat.slash import REGISTRY
+
+    session = _FakeSession()
+    cmd = REGISTRY.get("concept")
+    assert cmd is not None, "/concept must be registered"
+
+    if glossary_path is not None:
+        original = _mod._default_glossary_path
+        _mod._default_glossary_path = lambda: glossary_path
+        try:
+            await cmd.handler(session, args)
+        finally:
+            _mod._default_glossary_path = original
+    else:
+        await cmd.handler(session, args)
+
+    return session.messages
+
+
+# ── helpers to make async tests runnable ──────────────────────────────────
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    import asyncio
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _write_fixture_glossary(tmp_path: Path) -> Path:
+    p = tmp_path / "glossary.md"
+    p.write_text(_FIXTURE_TEXT, encoding="utf-8")
+    return p
+
+
+# ── test 1: bare /concept ──────────────────────────────────────────────────
+
+
+def test_bare_concept_returns_intro_and_path(tmp_path: Path) -> None:
+    """Tier 2: bare /concept (no args) shows intro + glossary path hint."""
+    gpath = _write_fixture_glossary(tmp_path)
+    msgs = _run(_run_concept("", glossary_path=gpath))
+    assert len(msgs) >= 1
+    text = msgs[0]["text"]
+    assert "glossary" in text.lower()
+    # path reference must be present
+    assert "Ctrl+B" in text or "guide/for-skill-authors/glossary" in text
+
+
+# ── test 2: exact match ────────────────────────────────────────────────────
+
+
+def test_concept_exact_match_returns_definition(tmp_path: Path) -> None:
+    """Tier 2: /concept skill returns the skill definition."""
+    gpath = _write_fixture_glossary(tmp_path)
+    msgs = _run(_run_concept("skill", glossary_path=gpath))
+    assert len(msgs) >= 1
+    text = msgs[0]["text"]
+    assert "skill" in text.lower()
+    assert "phase graph" in text
+
+
+# ── test 3: case-insensitive ───────────────────────────────────────────────
+
+
+def test_concept_case_insensitive(tmp_path: Path) -> None:
+    """Tier 2: /concept SKILL and /concept skill return the same definition text.
+
+    The reply prefix includes the term as typed (= case is echoed back), but
+    the definition portion must be identical — confirming case-insensitive lookup.
+    """
+    gpath = _write_fixture_glossary(tmp_path)
+    msgs_lower = _run(_run_concept("skill", glossary_path=gpath))
+    msgs_upper = _run(_run_concept("SKILL", glossary_path=gpath))
+    # Both must return a hit (not an error)
+    assert msgs_lower[0]["kind"] != "error"
+    assert msgs_upper[0]["kind"] != "error"
+    # The definition portion — everything after the first ": " — must match.
+    def _definition(text: str) -> str:
+        _, _, defn = text.partition(": ")
+        return defn
+    assert _definition(msgs_lower[0]["text"]) == _definition(msgs_upper[0]["text"])
+    assert "phase graph" in msgs_lower[0]["text"]
+    assert "phase graph" in msgs_upper[0]["text"]
+
+
+# ── test 4: fuzzy / did-you-mean ──────────────────────────────────────────
+
+
+def test_concept_fuzzy_miss_shows_did_you_mean(tmp_path: Path) -> None:
+    """Tier 2: /concept skil (typo) → "no entry" + did-you-mean suggestion."""
+    gpath = _write_fixture_glossary(tmp_path)
+    msgs = _run(_run_concept("skil", glossary_path=gpath))
+    assert len(msgs) >= 1
+    text = msgs[0]["text"]
+    assert "no glossary entry" in text
+    assert "skill" in text  # suggestion
+
+
+# ── test 5: no match, no suggestions ──────────────────────────────────────
+
+
+def test_concept_no_match_no_suggestions(tmp_path: Path) -> None:
+    """Tier 2: /concept zxzxzx → "no entry" with no suggestions."""
+    gpath = _write_fixture_glossary(tmp_path)
+    msgs = _run(_run_concept("zxzxzx", glossary_path=gpath))
+    assert len(msgs) >= 1
+    text = msgs[0]["text"]
+    assert "no glossary entry" in text
+    # No "did you mean" when there are zero close matches
+    assert "did you mean" not in text
+
+
+# ── test 6: missing glossary file ─────────────────────────────────────────
+
+
+def test_concept_missing_glossary_returns_error(tmp_path: Path) -> None:
+    """Tier 2: when glossary.md is missing, reply is a graceful error, no crash."""
+    nonexistent = tmp_path / "no_such_glossary.md"
+    msgs = _run(_run_concept("skill", glossary_path=nonexistent))
+    assert len(msgs) >= 1
+    msg = msgs[0]
+    assert msg["kind"] == "error"
+    # Error text should point to the expected path
+    assert "glossary" in msg["text"].lower()
+
+
+# ── /concept registered in REGISTRY ───────────────────────────────────────
+
+
+def test_concept_in_registry() -> None:
+    """Tier 2: /concept is present in the REGISTRY after import."""
+    from reyn.chat.slash import REGISTRY
+    cmd = REGISTRY.get("concept")
+    assert cmd is not None
+    assert cmd.name == "concept"


### PR DESCRIPTION
**[tui-coder]** — Wave-12 T1-3 (doc audit foundation, TUI-side)

## Summary
- New /concept slash command — bare form shows glossary entry path;
  /concept <term> returns inline definition.
- Case-insensitive term match against ``docs/guide/for-skill-authors/
  glossary.md``.
- "Did you mean..." fuzzy fallback on miss via stdlib ``difflib``.
- Defensive: missing/unreadable glossary returns graceful error, no crash.

## Why
TUI surfaces specialised vocabulary everywhere but the glossary file is
reachable only via Ctrl+B → Docs → 3-level navigation. /concept collapses
discovery to one command and gives Wave-12 follow-on PRs a stable link
target (= "see /concept <term>" footers in /plan, /attach, lifecycle
dividers, etc.).

## Test plan
- [x] tests/test_slash_concept.py — 6 Tier-2 tests pass (14 total including parser helpers)
- [x] ruff clean
- [x] /concept registered in REGISTRY
- [x] Manual: /concept skill → returns definition; /concept zxzx → did-you-mean