### PR TITLE
feat(tui): Keys tab — _KEY_DETAILS + Space-to-expand + MOUSE group (T1-4)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -23,7 +23,13 @@ from .base import _CORAL, _esc, logger
 from .cost_tab import render_cost
 from .docs_tab import build_docs_index, render_docs
 from .events_tab import _FILTER_GROUPS, _TAIL_CYCLE, render_events
-from .keys_tab import render_keys
+from .keys_tab import (
+    get_keys_cursor,
+    get_keys_expanded,
+    keys_move,
+    render_keys,
+    toggle_expand_cursor,
+)
 from .memory_tab import render_memory
 from .pending_tab import render_pending
 from .shells import (
@@ -547,17 +553,33 @@ class RightPanel(Widget):
             except Exception:
                 pass
         elif event.key == "space":
-            # Space is a uniform preview toggle: works on any tab when
-            # focus is anywhere inside the right panel (tabs included).
-            # _update_preview() dispatches per-tab content (docs/events/
-            # memory); other tabs render a cleared preview pane.
             event.prevent_default()
-            self._toggle_preview()
-            if self._preview_visible:
-                self._update_preview()
+            if self._panel_type == "keys":
+                # Keys tab: Space toggles inline detail block for cursor row
+                # (T1-4, Wave-12). Delegates to keys_tab module-level state
+                # so the detail dict and cursor live close to the render logic.
+                # Other tabs' Space semantics (= preview pane toggle) are
+                # unchanged — gated by this branch.
+                markup, flat_key_list = render_keys(
+                    self.app,
+                    cursor=get_keys_cursor(),
+                    expanded=get_keys_expanded(),
+                )
+                toggle_expand_cursor(flat_key_list)
+                self._invalidate()
+            else:
+                # Space is a uniform preview toggle: works on any tab when
+                # focus is anywhere inside the right panel (tabs included).
+                # _update_preview() dispatches per-tab content (docs/events/
+                # memory); other tabs render a cleared preview pane.
+                self._toggle_preview()
+                if self._preview_visible:
+                    self._update_preview()
         elif event.key == "j":
             event.prevent_default()
-            if self._panel_type == "docs":
+            if self._panel_type == "keys":
+                self._keys_move(+1)
+            elif self._panel_type == "docs":
                 self._docs_move(+1)
             elif self._panel_type == "events":
                 self._events_move(+1)
@@ -571,7 +593,9 @@ class RightPanel(Widget):
                 self._scroll_panel(+1)
         elif event.key == "k":
             event.prevent_default()
-            if self._panel_type == "docs":
+            if self._panel_type == "keys":
+                self._keys_move(-1)
+            elif self._panel_type == "docs":
                 self._docs_move(-1)
             elif self._panel_type == "events":
                 self._events_move(-1)
@@ -1019,6 +1043,24 @@ class RightPanel(Widget):
         body_md = RichMarkdown(getattr(entry, "body", "") or "")
         title = getattr(entry, "slug", "") or getattr(entry, "name", "") or "memory"
         pane.show_text(title, RichGroup(head, body_md))
+
+    # ── keys tab cursor (T1-4, Wave-12) ─────────────────────────────────────
+
+    def _keys_move(self, delta: int) -> None:
+        """Move the keys-tab cursor by ``delta`` and re-render.
+
+        The flat row count is derived from a speculative ``render_keys`` call
+        so ``keys_move`` knows the list length for wrapping. This is cheap
+        (= no IO, pure string construction) and keeps the cursor consistent
+        with whatever rows ``render_keys`` would actually emit.
+        """
+        _, flat_key_list = render_keys(
+            self.app,
+            cursor=get_keys_cursor(),
+            expanded=get_keys_expanded(),
+        )
+        keys_move(delta, len(flat_key_list))
+        self._invalidate()
 
     # ── pending tab cursor + actions (issue #277) ────────────────────────────
 
@@ -2152,7 +2194,12 @@ class RightPanel(Widget):
     def _panel_markup(self) -> Any:
         try:
             if self._panel_type == "keys":
-                return render_keys(self.app)
+                markup, _ = render_keys(
+                    self.app,
+                    cursor=get_keys_cursor(),
+                    expanded=get_keys_expanded(),
+                )
+                return markup
             if self._panel_type == "events":
                 rendered, windowed, event_ys = render_events(
                     self._project_root,

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -11,6 +11,46 @@ if TYPE_CHECKING:
     from textual.app import App
 
 
+# ---------------------------------------------------------------------------
+# Inline detail table (T1-4, Wave-12).
+# Maps the lowercase key string → multi-line "what does this REALLY do" text.
+# Initial 6 entries; content sweep (Tab / Up / Down / F2 / f / t / i / etc.)
+# is deferred to Wave-12 T2-3.
+# ---------------------------------------------------------------------------
+_KEY_DETAILS: dict[str, str] = {
+    "f3": (
+        "Drill-down expands the cursor's skill row to show phase history,\n"
+        "tool calls, and per-phase events. Mouse-click on the row does\n"
+        "the same. No-op when no skill row has cursor focus."
+    ),
+    "esc": (
+        "Context-aware back/cancel:\n"
+        "  • voice mode → cancel recording\n"
+        "  • error box → dismiss\n"
+        "  • right panel → close (= drop focus back to input)\n"
+        "  • docs filter active → clear filter"
+    ),
+    "ctrl+b": (
+        "Open/close right panel. Opens to the most recent context tab\n"
+        "(= last skill activity → Agents; last error jump → Events)."
+    ),
+    "space": (
+        "Toggle preview pane for cursor row. Works on Events / Agents /\n"
+        "Memory / Pending tabs. No-op on Cost / Docs / Keys (= those tabs\n"
+        "have no per-row preview, except Keys uses Space for THIS expand)."
+    ),
+    "f4": (
+        "Focus the async-stack panel at the bottom of the screen so its\n"
+        "rows can be cursored with j/k and inspected."
+    ),
+    "ctrl+r": (
+        "Toggle voice recording. While recording: Enter stops, transcribes,\n"
+        "and submits immediately (= dictate-and-send). Esc cancels.\n"
+        "F2 is an alias (macOS may intercept F2 — prefer Ctrl+R there)."
+    ),
+}
+
+
 _KEY_PRETTY: dict[str, str] = {
     "ctrl+a": "⌃A", "ctrl+b": "⌃B", "ctrl+c": "⌃C", "ctrl+d": "⌃D",
     "ctrl+e": "⌃E", "ctrl+f": "⌃F", "ctrl+g": "⌃G", "ctrl+h": "⌃H",
@@ -71,7 +111,15 @@ _EVENTS_KEYS = {"f", "t", "i"}
 _DOCS_KEYS = {"/"}
 _GROUP_ORDER = [
     "GLOBAL", "INPUT", "CONVERSATION", "PANEL",
-    "EVENTS (gated)", "DOCS (gated)", "OTHER",
+    "EVENTS (gated)", "DOCS (gated)", "OTHER", "MOUSE",
+]
+
+# Explicit mouse-interaction rows (no key-press semantics — cross-cutting
+# affordances that have no Binding entry but are discoverable here).
+_MOUSE_EXPLICIT: list[tuple[str, str]] = [
+    ("click skill row", "Drill-down (= F3 mouse equivalent)"),
+    ("click header [N pending]", "Jump to Pending tab"),
+    ("click header [find: ...]", "Clear find filter"),
 ]
 
 # Keys whose app-level binding is voice-mode-gated (active only during
@@ -105,14 +153,31 @@ def _pretty_key(key: str) -> str:
     return key
 
 
-def render_keys(app: "App") -> str:
-    """Return Rich markup listing bindings grouped by context."""
+def render_keys(
+    app: "App",
+    *,
+    cursor: int = 0,
+    expanded: set[int] | None = None,
+) -> tuple[str, list[str]]:
+    """Return (Rich markup, flat_key_list) listing bindings grouped by context.
+
+    ``cursor`` selects the cursor row (0-indexed over the flat key list).
+    ``expanded`` is the set of cursor indices whose detail block is visible.
+    ``flat_key_list`` is a parallel list of lowercase key strings (or ``""``
+    for MOUSE rows) so callers can look up ``_KEY_DETAILS`` by row index.
+    """
+    if expanded is None:
+        expanded = set()
+
     # Local import keeps right_panel/keys_tab decoupled from widget-init
     # order (InputBar imports from chat.slash, which would otherwise be
     # pulled in at module-load time).
     from ..input_bar import InputBar
 
     groups: dict[str, list[tuple[str, str]]] = {g: [] for g in _GROUP_ORDER}
+    # Parallel dict: group_name → list of raw key strings (lowercase) for
+    # detail lookup. MOUSE rows use "" since they have no key semantics.
+    group_keys: dict[str, list[str]] = {g: [] for g in _GROUP_ORDER}
     seen: set[str] = set()
     # App-level bindings first — they take precedence on same-key conflicts
     # (the InputBar's ctrl+c / ctrl+d / ctrl+l shadow app's, but app's
@@ -130,6 +195,7 @@ def render_keys(app: "App") -> str:
         if group not in groups:
             group = "OTHER"
         groups[group].append((_pretty_key(b.key), b.description))
+        group_keys[group].append(b.key.lower())
     # InputBar-level bindings: chat-input affordances (Enter / Tab / arrows
     # / Esc / Ctrl+J Newline / Ctrl+U Clear input). Without surfacing
     # these the Keys tab silently omitted "how do I insert a newline"
@@ -140,6 +206,7 @@ def render_keys(app: "App") -> str:
             continue
         seen.add(b.key)
         groups["INPUT"].append((_pretty_key(b.key), b.description))
+        group_keys["INPUT"].append(b.key.lower())
 
     # Right-panel keys handled via ``RightPanel.on_key`` (not declared
     # ``Binding`` objects) are invisible to the BINDINGS iterations above.
@@ -179,29 +246,129 @@ def render_keys(app: "App") -> str:
     for key, desc in _PANEL_EXPLICIT:
         if key not in seen:
             groups["PANEL"].append((_pretty_key(key), desc))
+            group_keys["PANEL"].append(key.lower())
             seen.add(key)
 
+    # MOUSE group (T1-4, Wave-12): explicit click-interaction rows.
+    # These have no key semantics so raw_key is "" for all of them.
+    for display, desc in _MOUSE_EXPLICIT:
+        groups["MOUSE"].append((display, desc))
+        group_keys["MOUSE"].append("")
+
+    # Build flat list of (key_display, desc, raw_key) across all groups in
+    # _GROUP_ORDER order for cursor + expand tracking.
+    flat_rows: list[tuple[str, str, str]] = []  # (display, desc, raw_key)
+    for group_name in _GROUP_ORDER:
+        entries = groups.get(group_name, [])
+        raw_keys = group_keys.get(group_name, [])
+        for (kd, desc), rk in zip(entries, raw_keys):
+            flat_rows.append((kd, desc, rk))
+
+    # Render.
     lines: list[str] = []
+    flat_key_list: list[str] = []  # parallel to the rendered "key rows" only
     # Key column width: max key length within the group, capped at 6
     # (longest pretty key is ⇧Tab / Enter / Space = 5 chars + 1 pad).
     # Single-line "<key>  <desc>" fits the narrow panel; previously the
     # column was a fixed 16 chars which forced every binding onto two
     # rows after wrapping.
+
+    # Row index tracking — increments only for key/mouse entries, not headers.
+    row_idx = 0
+
     for group_name in _GROUP_ORDER:
         entries = groups.get(group_name, [])
+        raw_keys = group_keys.get(group_name, [])
         if not entries:
             continue
         lines.append(f"[bold #aaaaaa]  \\[{_esc(group_name)}][/]")
-        key_width = min(6, max((len(k) for k, _ in entries), default=2) + 1)
-        for key_display, desc in entries:
+        # MOUSE rows can be much longer than 6 chars — use a wider cap for
+        # the MOUSE group so the descriptions don't collide with the key col.
+        if group_name == "MOUSE":
+            key_width = max((len(k) for k, _ in entries), default=2) + 2
+        else:
+            key_width = min(6, max((len(k) for k, _ in entries), default=2) + 1)
+        for (key_display, desc), raw_key in zip(entries, raw_keys):
+            is_cursor = row_idx == cursor
+            flat_key_list.append(raw_key)
+
+            # Cursor indicator — subtle highlight so the row is identifiable.
+            cursor_prefix = f"[bold {_CORAL}]▶[/] " if is_cursor else "  "
             key_col = f"{_esc(key_display):<{key_width}}"
             lines.append(
-                f"  [{_CORAL}]{key_col}[/]  [#dddddd]{_esc(desc)}[/]"
+                f"{cursor_prefix}[{_CORAL}]{key_col}[/]  [#dddddd]{_esc(desc)}[/]"
             )
+
+            # Inline detail block when this row is expanded.
+            if row_idx in expanded:
+                detail = _KEY_DETAILS.get(raw_key, "")
+                if detail:
+                    for detail_line in detail.splitlines():
+                        lines.append(
+                            f"  [dim #aaaaaa]    {_esc(detail_line)}[/]"
+                        )
+
+            row_idx += 1
         lines.append("")
     if not lines:
         lines.append("[#555555]  (no bindings)[/]")
-    return "\n".join(lines)
+    return "\n".join(lines), flat_key_list
 
 
-__all__ = ["render_keys"]
+# ---------------------------------------------------------------------------
+# Keys-tab cursor + expand state (owned at module level so RightPanel can
+# delegate to these helpers without carrying keys-specific state itself).
+# ---------------------------------------------------------------------------
+_keys_cursor: int = 0
+_keys_expanded: set[int] = set()
+
+
+def keys_move(delta: int, n_rows: int) -> None:
+    """Move the keys-tab cursor by ``delta``; wraps around ``n_rows``."""
+    global _keys_cursor
+    if n_rows == 0:
+        _keys_cursor = 0
+        return
+    _keys_cursor = (_keys_cursor + delta) % n_rows
+
+
+def toggle_expand_cursor(flat_key_list: list[str]) -> bool:
+    """Toggle the inline detail block for the cursor row.
+
+    Returns True if a detail block is now visible (= toggle-on), False if
+    hidden or no-op. No-op when the cursor row has no ``_KEY_DETAILS`` entry.
+    """
+    global _keys_cursor, _keys_expanded
+    if not flat_key_list:
+        return False
+    idx = max(0, min(len(flat_key_list) - 1, _keys_cursor))
+    raw_key = flat_key_list[idx]
+    if not raw_key or raw_key not in _KEY_DETAILS:
+        # No detail entry → no-op (no crash, no state change).
+        return False
+    if idx in _keys_expanded:
+        _keys_expanded.discard(idx)
+        return False
+    else:
+        _keys_expanded.add(idx)
+        return True
+
+
+def get_keys_cursor() -> int:
+    """Return the current keys-tab cursor index."""
+    return _keys_cursor
+
+
+def get_keys_expanded() -> set[int]:
+    """Return the current set of expanded row indices (read-only copy)."""
+    return set(_keys_expanded)
+
+
+__all__ = [
+    "render_keys",
+    "_KEY_DETAILS",
+    "keys_move",
+    "toggle_expand_cursor",
+    "get_keys_cursor",
+    "get_keys_expanded",
+]

--- a/tests/cli/test_agents_tab_attach_shortcut.py
+++ b/tests/cli/test_agents_tab_attach_shortcut.py
@@ -138,7 +138,8 @@ def test_keys_tab_surfaces_a_attach_in_panel_group() -> None:
         )
         async with app.run_test(headless=True) as pilot:
             await pilot.pause()
-            return render_keys(app)
+            markup, _ = render_keys(app)
+            return markup
 
     markup = asyncio.run(_grab_markup())
     assert "a" in markup

--- a/tests/cli/test_events_tab_chain_isolate.py
+++ b/tests/cli/test_events_tab_chain_isolate.py
@@ -208,5 +208,5 @@ async def test_keys_tab_render_includes_i_isolate_description() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup = render_keys(app)
+        markup, _ = render_keys(app)
         assert "Isolate cursor's chain" in markup or "isolate" in markup.lower()

--- a/tests/cli/test_find_discoverability_hint.py
+++ b/tests/cli/test_find_discoverability_hint.py
@@ -123,7 +123,7 @@ async def test_keys_tab_render_includes_find_cycle_descriptions() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup = render_keys(app)
+        markup, _ = render_keys(app)
         assert "Find next match" in markup
         assert "Find prev match" in markup
         # Pretty-printed form of ctrl+g / ctrl+shift+g.

--- a/tests/cli/test_keys_tab_details_and_mouse.py
+++ b/tests/cli/test_keys_tab_details_and_mouse.py
@@ -1,0 +1,248 @@
+"""Tier 2: _KEY_DETAILS table, MOUSE group, and Space-to-expand on Keys tab.
+
+Wave-12 T1-4 (doc audit foundation):
+  - ``_KEY_DETAILS`` dict exposes "what does this key REALLY do" detail text.
+  - MOUSE group in Keys tab lists click-interaction affordances.
+  - ``toggle_expand_cursor()`` toggles an inline detail block under the cursor
+    row; two presses = hidden again; no-op on rows with no detail entry.
+
+Tests assert against the PUBLIC SURFACE — rendered markup plain text — not
+private state. Module-level cursor / expand state is reset at the start of
+each test using the public reset helpers (keys_move + toggle) so tests are
+independent regardless of run order.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets.right_panel import keys_tab as _kt
+from reyn.chat.tui.widgets.right_panel.keys_tab import (
+    _KEY_DETAILS,
+    get_keys_cursor,
+    get_keys_expanded,
+    keys_move,
+    render_keys,
+    toggle_expand_cursor,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _reset_keys_state() -> None:
+    """Reset module-level cursor and expanded state between tests."""
+    # Move cursor back to 0 by delegating through the public interface.
+    # We do this by setting _keys_cursor + _keys_expanded directly on the
+    # module; the public surface is designed to be used via RightPanel, but
+    # the module-level state is intentionally accessible so tests can reset
+    # it without spinning up the full TUI app. Testing policy: assert on
+    # public surface, but STATE SETUP may touch module attrs when the public
+    # interface for reset doesn't exist. Here _keys_cursor / _keys_expanded
+    # are module globals (= listed in __all__'s sibling helpers), so this
+    # is the correct reset path.
+    _kt._keys_cursor = 0
+    _kt._keys_expanded = set()
+
+
+def _render_plain(app: ReynTUIApp) -> str:
+    """Return the rendered Keys tab markup (no cursor/expand override)."""
+    markup, _ = render_keys(
+        app,
+        cursor=get_keys_cursor(),
+        expanded=get_keys_expanded(),
+    )
+    return markup
+
+
+def _app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+
+
+# ── Test 1: MOUSE group header is present ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mouse_group_header_present() -> None:
+    """Tier 2: Keys tab rendered output includes a MOUSE group header."""
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+        rendered = _render_plain(app)
+        assert "[MOUSE]" in rendered, (
+            f"Keys tab must render a MOUSE group header; got:\n{rendered}"
+        )
+
+
+# ── Test 2: "click skill row" row is present ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mouse_click_skill_row_present() -> None:
+    """Tier 2: Keys tab rendered output includes 'click skill row' entry."""
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+        rendered = _render_plain(app)
+        assert "click skill row" in rendered, (
+            f"Keys tab must render the 'click skill row' MOUSE entry; "
+            f"got:\n{rendered}"
+        )
+
+
+# ── Test 3: _KEY_DETAILS has at least 6 entries ──────────────────────────────
+
+
+def test_key_details_has_at_least_six_entries() -> None:
+    """Tier 2: _KEY_DETAILS has at least 6 entries (content sweep deferred to T2-3)."""
+    assert len(_KEY_DETAILS) >= 6, (
+        f"_KEY_DETAILS must have at least 6 entries; got {len(_KEY_DETAILS)}: "
+        f"{list(_KEY_DETAILS.keys())}"
+    )
+
+
+# ── Test 4: Space-expand on F3 row shows detail text ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_toggle_expand_f3_row_shows_detail() -> None:
+    """Tier 2: toggle_expand_cursor() on the F3 row → detail block contains 'drill-down'."""
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        # Find the flat_key_list so we can locate the F3 row.
+        markup, flat_key_list = render_keys(
+            app,
+            cursor=0,
+            expanded=set(),
+        )
+        assert "f3" in flat_key_list, (
+            f"F3 must appear in the flat key list; got: {flat_key_list}"
+        )
+        f3_idx = flat_key_list.index("f3")
+
+        # Move cursor to F3 row via the public helper.
+        keys_move(f3_idx, len(flat_key_list))
+
+        # Toggle expand.
+        did_open = toggle_expand_cursor(flat_key_list)
+        assert did_open, "toggle_expand_cursor should return True when opening"
+
+        # Re-render with updated state and check for detail text.
+        markup_after, _ = render_keys(
+            app,
+            cursor=get_keys_cursor(),
+            expanded=get_keys_expanded(),
+        )
+        assert "drill-down" in markup_after.lower(), (
+            f"After expand on F3 row, rendered output must contain 'drill-down'; "
+            f"got:\n{markup_after}"
+        )
+
+
+# ── Test 5: Double toggle on F3 row hides detail block ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_toggle_expand_twice_hides_detail() -> None:
+    """Tier 2: toggle_expand_cursor() twice → detail block is gone (toggle semantics)."""
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        markup, flat_key_list = render_keys(app, cursor=0, expanded=set())
+        assert "f3" in flat_key_list
+        f3_idx = flat_key_list.index("f3")
+        keys_move(f3_idx, len(flat_key_list))
+
+        # First toggle: open.
+        toggle_expand_cursor(flat_key_list)
+        markup_open, _ = render_keys(
+            app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
+        )
+        assert "drill-down" in markup_open.lower(), (
+            "Detail must be visible after first toggle"
+        )
+
+        # Second toggle: close.
+        toggle_expand_cursor(flat_key_list)
+        markup_closed, _ = render_keys(
+            app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
+        )
+        # The bare row description for F3 is "Drill-down …" per _PANEL_EXPLICIT
+        # / CONVERSATION group. The *inline detail block* lines are the ones
+        # emitted by the expand logic (prefixed with dim #aaaaaa). After
+        # close, those extra detail lines must be gone. We detect this by
+        # checking that the detail text from _KEY_DETAILS["f3"] is absent —
+        # the per-phase / tool-calls sentences are not in the row description.
+        detail_sentinel = "per-phase events"
+        assert detail_sentinel not in markup_closed, (
+            f"After second toggle detail must be hidden; "
+            f"sentinel {detail_sentinel!r} still present:\n{markup_closed}"
+        )
+
+
+# ── Test 6: toggle_expand_cursor on no-detail row → no-op ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_toggle_expand_no_detail_row_is_noop() -> None:
+    """Tier 2: toggle_expand_cursor() on a row with no _KEY_DETAILS entry → no-op, no crash."""
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        markup_before, flat_key_list = render_keys(app, cursor=0, expanded=set())
+
+        # Find a row whose raw_key is NOT in _KEY_DETAILS.
+        # Most rows won't be in _KEY_DETAILS (only 6 initial entries).
+        no_detail_idx: int | None = None
+        for i, rk in enumerate(flat_key_list):
+            if rk not in _KEY_DETAILS:
+                no_detail_idx = i
+                break
+
+        assert no_detail_idx is not None, (
+            "There should be at least one row without a _KEY_DETAILS entry"
+        )
+
+        # Move cursor to that row.
+        keys_move(no_detail_idx, len(flat_key_list))
+
+        # Toggle — must return False (= no-op).
+        result = toggle_expand_cursor(flat_key_list)
+        assert result is False, (
+            f"toggle_expand_cursor must return False for row with no detail; "
+            f"raw_key={flat_key_list[no_detail_idx]!r}"
+        )
+
+        # Render after no-op: output must be unchanged (same markup since
+        # expand state didn't change and cursor moved to same col).
+        markup_after, _ = render_keys(
+            app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
+        )
+        # The expand-specific sentinel lines should not appear.
+        for rk, detail in _KEY_DETAILS.items():
+            # Check first sentence of each detail is absent.
+            first_line = detail.splitlines()[0][:30]
+            assert first_line not in markup_after, (
+                f"No detail block should be visible after a no-op toggle; "
+                f"found {first_line!r} in output"
+            )

--- a/tests/cli/test_keys_tab_panel_bindings.py
+++ b/tests/cli/test_keys_tab_panel_bindings.py
@@ -97,7 +97,7 @@ async def test_keys_tab_renders_ctrl_w_family() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered = render_keys(app)
+        rendered, _ = render_keys(app)
 
         # Pretty forms per _KEY_PRETTY: ⌃W / ⌃⇧W / ⌃⇧O
         assert "⌃W" in rendered, (
@@ -128,7 +128,7 @@ async def test_keys_tab_groups_panel_keys_under_panel_section() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered = render_keys(app)
+        rendered, _ = render_keys(app)
 
         # PANEL group header must appear, and ⌃W must come AFTER it.
         panel_idx = rendered.find("[PANEL]")
@@ -160,7 +160,7 @@ async def test_keys_tab_renders_h_l_resize_keys() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered = render_keys(app)
+        rendered, _ = render_keys(app)
 
         # Synthetic entries: bare ``h`` / ``l`` (single-letter keys keep
         # their literal form through ``_pretty_key``).
@@ -190,7 +190,7 @@ async def test_keys_tab_lists_pending_d_discard_action() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered = render_keys(app)
+        rendered, _ = render_keys(app)
         assert "Discard cursor (pending tab)" in rendered, (
             f"Keys tab must render the pending-tab d=discard hint; got:\n{rendered}"
         )
@@ -211,7 +211,7 @@ async def test_h_l_resize_keys_group_under_panel_section() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered = render_keys(app)
+        rendered, _ = render_keys(app)
 
         panel_idx = rendered.find("[PANEL]")
         widen_idx = rendered.find("Widen panel")

--- a/tests/cli/test_memory_tab_type_filter.py
+++ b/tests/cli/test_memory_tab_type_filter.py
@@ -193,6 +193,6 @@ def test_keys_tab_t_first_occurrence_is_events() -> None:
     from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
-    markup = render_keys(app)
+    markup, _ = render_keys(app)
     # ``t`` from app.BINDINGS (events tab) still renders.
     assert "Tail events" in markup

--- a/tests/cli/test_right_panel_quick_jump.py
+++ b/tests/cli/test_right_panel_quick_jump.py
@@ -168,7 +168,7 @@ async def test_keys_tab_render_includes_quick_jump_descriptions() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup = render_keys(app)
+        markup, _ = render_keys(app)
         for n in range(1, 8):
             assert f"⌃{n}" in markup, f"⌃{n} not in Keys tab markup"
         # Spot-check a couple of description strings.

--- a/tests/cli/test_skill_expand_keyboard.py
+++ b/tests/cli/test_skill_expand_keyboard.py
@@ -192,6 +192,6 @@ async def test_keys_tab_render_includes_f3_with_description() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup = render_keys(app)
+        markup, _ = render_keys(app)
         assert "F3" in markup
         assert "skill row drill-down" in markup.lower()


### PR DESCRIPTION
**[tui-coder]** — Wave-12 T1-4 (doc audit foundation, TUI-side)

## Summary
- ``_KEY_DETAILS: dict[str, str]`` table (6 initial entries:
  f3 / esc / ctrl+b / space / f4 / ctrl+r) — content sweep deferred
  to T2-3 (Tab / Up / Down / Ctrl+B nuances / f-t-i per-tab / F2 / etc.)
- New MOUSE group in Keys tab listing click-skill-row drill-down and
  header-badge click affordances.
- Space when Keys tab is focused: toggles inline detail block under
  the cursor row. Other tabs' Space semantics unchanged (= gated).

## Why
Keys tab is the sole keybinding-discovery surface and each row is a
1-line description. Wave-12 audit (Topic B #1 + #4) flagged the lack
of "explain deeper" affordance + the invisibility of mouse interactions.
This PR establishes the table + dispatch; content sweep follows in T2-3.

## Test plan
- [x] tests/cli/test_keys_tab_details_and_mouse.py — 6 Tier-2 tests pass
- [x] tests/cli/test_keys_tab_panel_bindings.py existing tests still pass
- [x] tests/cli/test_tui_smoke.py — 40 smoke tests still pass
- [x] ruff clean
- [x] (skipped — headless worktree) Manual: Ctrl+B → Keys tab → press Space on F3 row → detail block expands
- [x] (skipped — headless worktree) Manual: Press Space on Events tab → still toggles preview (= unchanged)