### PR TITLE
feat(tui): picker hint sweep — /pending /agent /image /docs-filter (T2-1)

### DIFF
--- a/src/reyn/chat/slash/agent.py
+++ b/src/reyn/chat/slash/agent.py
@@ -31,7 +31,7 @@ _NO_REGISTRY = (
 
 @slash(
     "agent",
-    summary="Create new agent",
+    summary="Create new agent (new <name> only; rm via `reyn agent rm`)",
     usage="/agent new <name>",
 )
 async def agent_cmd(session: "ChatSession", args: str) -> None:

--- a/src/reyn/chat/slash/docs_filter.py
+++ b/src/reyn/chat/slash/docs_filter.py
@@ -16,7 +16,7 @@ from reyn.chat.slash import slash
 
 @slash(
     "docs-filter",
-    summary="Filter the docs tab by substring (empty = clear)",
+    summary="Filter the right-panel Docs tab (Ctrl+B → Docs) by substring (empty = clear)",
     usage="/docs-filter [<substring>]",
 )
 async def docs_filter_cmd(session: "object", args: str) -> None:

--- a/src/reyn/chat/slash/image.py
+++ b/src/reyn/chat/slash/image.py
@@ -50,7 +50,7 @@ def _file_size_human(n: int) -> str:
 
 @slash(
     "image",
-    summary="Attach an image to the next user message (multimodal input).",
+    summary="Send an image (png/jpg/gif/webp/svg/jpeg)",
     usage="/image <path>",
     aliases=("img",),
 )

--- a/src/reyn/chat/slash/pending.py
+++ b/src/reyn/chat/slash/pending.py
@@ -103,6 +103,7 @@ def _resolve_iv_id(
         "List / discard / claim stalled cross-channel ops "
         "(subcommands: list | discard <id> | claim <id>)"
     ),
+    usage="/pending [list|discard <id>|claim <id>]",
 )
 async def pending_cmd(session: "ChatSession", args: str) -> None:
     """Dispatch ``/pending [list|discard|claim]`` subcommands."""

--- a/tests/test_slash_picker_hint_sweep.py
+++ b/tests/test_slash_picker_hint_sweep.py
@@ -1,0 +1,69 @@
+"""Tier 2: picker hint sweep — Wave-12 T2-1 (Topic A #3/#4/#7/#8).
+
+4 slash commands whose picker hints underspecified behavior:
+  /pending (A#3) — added usage; sub-command vocab now visible in hint
+  /agent   (A#4) — summary now mentions rm escape hatch
+  /image   (A#7) — summary now lists supported extensions
+  /docs-filter (A#8) — summary now names the target tab + Ctrl+B route
+
+All assertions use the REGISTRY public surface (cmd.usage / cmd.summary).
+No MagicMock / patch per testing policy.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def test_pending_usage_surfaces_subcommand_vocab() -> None:
+    """Tier 2: /pending usage exposes list/discard/claim in the picker hint."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("pending")
+    assert cmd is not None, "/pending not in registry"
+    assert cmd.usage == "/pending [list|discard <id>|claim <id>]", (
+        f"/pending usage mismatch: got {cmd.usage!r}"
+    )
+
+
+def test_agent_summary_mentions_rm_escape_hatch() -> None:
+    """Tier 2: /agent summary tells the user where rm lives."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("agent")
+    assert cmd is not None, "/agent not in registry"
+    assert "rm via `reyn agent rm`" in cmd.summary, (
+        f"/agent summary missing rm escape hatch: {cmd.summary!r}"
+    )
+
+
+def test_image_summary_lists_supported_extensions() -> None:
+    """Tier 2: /image summary surfaces png and webp without pinning exact wording."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("image")
+    assert cmd is not None, "/image not in registry"
+    assert "png" in cmd.summary, (
+        f"/image summary missing 'png': {cmd.summary!r}"
+    )
+    assert "webp" in cmd.summary, (
+        f"/image summary missing 'webp': {cmd.summary!r}"
+    )
+
+
+def test_docs_filter_summary_names_tab_and_keybinding() -> None:
+    """Tier 2: /docs-filter summary surfaces Ctrl+B route and Docs tab name."""
+    from reyn.chat.slash import REGISTRY
+
+    cmd = REGISTRY.get("docs-filter")
+    assert cmd is not None, "/docs-filter not in registry"
+    assert "Ctrl+B" in cmd.summary, (
+        f"/docs-filter summary missing 'Ctrl+B': {cmd.summary!r}"
+    )
+    assert "Docs" in cmd.summary, (
+        f"/docs-filter summary missing 'Docs': {cmd.summary!r}"
+    )

--- a/tests/test_slash_usage_extension.py
+++ b/tests/test_slash_usage_extension.py
@@ -46,6 +46,7 @@ _EXPECTED_USAGE: dict[str, str] = {
     "image":       "/image <path>",
     "reset":       "/reset confirm",
     "budget":      "/budget [reset]",
+    "pending":     "/pending [list|discard <id>|claim <id>]",
 }
 
 
@@ -104,7 +105,7 @@ def test_no_arg_commands_have_no_usage() -> None:
     from reyn.chat.slash import REGISTRY
 
     no_arg_commands = [
-        "list", "tasks", "skills", "cost", "pending", "expand",
+        "list", "tasks", "skills", "cost", "expand",
         "quit", "exit", "cost-inline",
     ]
     for name in no_arg_commands:


### PR DESCRIPTION
**[tui-coder]** — Wave-12 T2-1 (doc audit follow-on, TUI-side)

## Summary
- /pending: added usage="/pending [list|discard <id>|claim <id>]"
- /agent: summary now mentions "rm via `reyn agent rm`" so the
  missing-by-design rm subcommand has an escape hatch in the hint
- /image: summary now lists supported extensions
- /docs-filter: summary now says which tab + Ctrl+B route

## Why
4 slash commands had picker hints that underspecified behavior — the
sub-command vocabulary, supported extensions, or target tab were only
discoverable via errors or hidden source docstrings. Wave-12 audit
(Topic A #3/#4/#7/#8) flagged this as low-cost, high-coverage fix.

Side-effect: `test_slash_usage_extension.py` also updated — /pending
was incorrectly listed as a no-arg command in that test's pin list;
moved to the has-usage table.

## Test plan
- [x] tests/test_slash_picker_hint_sweep.py — 4 Tier-2 tests pass
- [x] tests/test_slash_usage_extension.py — 5 existing tests still pass (pending removed from no-arg list, added to expected-usage table)
- [x] ruff clean
- [x] Manual: typed each in the picker → hint surfaces the new info