### PR TITLE
feat(tui): F3 drill-down first-use tip (T2-4)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1350,6 +1350,44 @@ class ReynTUIApp(App):
             return
         router.cycle_find(-1)
 
+    def _maybe_emit_f3_tip(
+        self,
+        show_status_fn: "Callable[[str], None]",
+    ) -> bool:
+        """Emit the first-use F3 tip if it hasn't been shown this project.
+
+        Reads ``tip_f3_seen`` from ``.reyn/tui_prefs.json``. When False
+        (= first F3 press for this project), calls ``show_status_fn``
+        with the onboarding message, flips the flag, and persists. On
+        subsequent presses the tip is silently skipped.
+
+        Returns True if the tip was emitted, False if already seen.
+
+        Failure modes:
+        - Prefs save failure → swallowed (= tip may re-fire next session,
+          but that's better than crashing the action).
+        - ``show_status_fn`` raising → swallowed (= conv pane mid-init).
+        """
+        from reyn.chat.tui.prefs import load_tui_prefs, save_tui_prefs
+
+        root = self._project_root_path()
+        prefs = load_tui_prefs(root)
+        if prefs.get("tip_f3_seen", False):
+            return False
+        try:
+            show_status_fn(
+                "F3: drill-down expands phase history + tool calls for"
+                " in-flight skills (mouse-click does the same)"
+            )
+        except Exception:
+            pass
+        prefs["tip_f3_seen"] = True
+        try:
+            save_tui_prefs(root, prefs)
+        except Exception:
+            pass
+        return True
+
     def action_skill_expand_toggle(self) -> None:
         """F3 — toggle drill-down on every in-flight SkillActivityRow.
 
@@ -1362,20 +1400,33 @@ class ReynTUIApp(App):
 
         No-op with a status hint when nothing is in flight (= the
         user pressed F3 expecting drill-down but no skill is running).
+
+        First-use: shows a one-time onboarding tip via the conv-pane
+        status bar (gated by ``tip_f3_seen`` in tui_prefs.json).
         """
         try:
             conv = self.query_one("#conversation", ConversationView)
         except Exception:
             return
+        # First-use tip fires regardless of whether any skill rows are
+        # in flight — teaching what F3 does is useful either way.
+        tip_shown = self._maybe_emit_f3_tip(
+            lambda msg: conv.show_status(msg, kind="general"),
+        )
         rows = conv.in_flight_skill_rows()
         if not rows:
-            try:
-                conv.show_status(
-                    "no active skill row to expand", kind="general",
-                )
-                self.set_timer(2.0, conv.hide_status)
-            except Exception:
-                pass
+            if tip_shown:
+                # Tip replaces the "no rows" hint for this first press only;
+                # auto-hide after ~4 s.
+                self.set_timer(4.0, conv.hide_status)
+            else:
+                try:
+                    conv.show_status(
+                        "no active skill row to expand", kind="general",
+                    )
+                    self.set_timer(2.0, conv.hide_status)
+                except Exception:
+                    pass
             return
         # Pick a single target state for THIS keypress so the set
         # converges. Without this, F3 on a mixed set (one expanded,
@@ -1385,6 +1436,9 @@ class ReynTUIApp(App):
         for row in rows:
             if row.is_expanded != target_expand:
                 row.toggle_expand()
+        if tip_shown:
+            # Auto-hide the tip after ~4 s once expand has been applied.
+            self.set_timer(4.0, conv.hide_status)
 
     def action_next_turn(self) -> None:
         """ctrl+n — scroll the conversation log to the next agent turn."""

--- a/tests/cli/test_f3_first_use_tip.py
+++ b/tests/cli/test_f3_first_use_tip.py
@@ -1,0 +1,174 @@
+"""Tier 2: F3 first-use onboarding tip (T2-4, Wave-12 Topic B #2).
+
+On the first F3 press per project, a one-time conv-pane status message
+is shown explaining drill-down. Gated by ``tip_f3_seen`` in
+``.reyn/tui_prefs.json`` so it never re-fires.
+
+Pinned:
+  - Default tui_prefs.json (absent / empty) treats tip_f3_seen as False.
+  - Round-trip: save tip_f3_seen=True, reload → flag is True.
+  - _maybe_emit_f3_tip with unseen flag → emits message containing
+    "drill-down" and returns True; prefs file updated.
+  - _maybe_emit_f3_tip with seen flag → no emission, returns False.
+  - (App-level) first F3 press with tip unseen → status contains
+    "drill-down"; subsequent press → no drill-down tip.
+  - (App-level) tip fires even when no in-flight skill rows.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — prefs-level tests (no Pilot / app required)
+# ---------------------------------------------------------------------------
+
+
+def test_tip_f3_seen_absent_treated_as_false(tmp_path: Path) -> None:
+    """Tier 2: missing tui_prefs.json → tip_f3_seen defaults to False."""
+    from reyn.chat.tui.prefs import load_tui_prefs
+
+    prefs = load_tui_prefs(tmp_path)
+    assert prefs.get("tip_f3_seen", False) is False
+
+
+def test_tip_f3_seen_round_trip(tmp_path: Path) -> None:
+    """Tier 2: save tip_f3_seen=True, reload → flag is True."""
+    from reyn.chat.tui.prefs import load_tui_prefs, save_tui_prefs
+
+    prefs: dict[str, Any] = {}
+    prefs["tip_f3_seen"] = True
+    save_tui_prefs(tmp_path, prefs)
+
+    restored = load_tui_prefs(tmp_path)
+    assert restored.get("tip_f3_seen") is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — helper-level tests (_maybe_emit_f3_tip extracted function)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_emit_f3_tip_emits_when_unseen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: _maybe_emit_f3_tip with unseen flag emits and returns True."""
+    from reyn.chat.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    monkeypatch.setattr(app, "_project_root_path", lambda: tmp_path)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        emitted: list[str] = []
+        result = app._maybe_emit_f3_tip(emitted.append)
+
+        assert result is True
+        assert len(emitted) == 1
+        assert "drill-down" in emitted[0]
+
+        # Flag persisted to disk.
+        prefs_path = tmp_path / ".reyn" / "tui_prefs.json"
+        assert prefs_path.exists()
+        data = json.loads(prefs_path.read_text())
+        assert data.get("tip_f3_seen") is True
+
+
+@pytest.mark.asyncio
+async def test_maybe_emit_f3_tip_silent_when_already_seen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: _maybe_emit_f3_tip with seen flag does not emit, returns False."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.prefs import save_tui_prefs
+
+    # Pre-seed the flag.
+    save_tui_prefs(tmp_path, {"tip_f3_seen": True})
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    monkeypatch.setattr(app, "_project_root_path", lambda: tmp_path)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        emitted: list[str] = []
+        result = app._maybe_emit_f3_tip(emitted.append)
+
+        assert result is False
+        assert emitted == []
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — app-level F3 integration via Pilot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f3_first_press_shows_drill_down_tip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: first F3 press with unseen tip → status contains "drill-down"."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    monkeypatch.setattr(app, "_project_root_path", lambda: tmp_path)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        # No rows in flight — the tip should still fire on first press.
+        assert conv.in_flight_skill_rows() == []
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        assert "drill-down" in snap["body"]
+
+        # Flag now persisted.
+        prefs_path = tmp_path / ".reyn" / "tui_prefs.json"
+        data = json.loads(prefs_path.read_text())
+        assert data.get("tip_f3_seen") is True
+
+
+@pytest.mark.asyncio
+async def test_f3_second_press_no_drill_down_tip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: F3 with tip already seen → status shows "no active skill", not tip."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.prefs import save_tui_prefs
+    from reyn.chat.tui.widgets import ConversationView
+
+    # Pre-seed the seen flag.
+    save_tui_prefs(tmp_path, {"tip_f3_seen": True})
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    monkeypatch.setattr(app, "_project_root_path", lambda: tmp_path)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        assert conv.in_flight_skill_rows() == []
+        app.action_skill_expand_toggle()
+        await pilot.pause()
+
+        snap = conv._sticky().snapshot()  # type: ignore[union-attr]
+        assert snap["active"] is True
+        # "drill-down" tip must NOT appear; the standard hint should.
+        assert "drill-down" not in snap["body"]
+        assert "no active skill" in snap["body"]

--- a/tests/cli/test_skill_expand_keyboard.py
+++ b/tests/cli/test_skill_expand_keyboard.py
@@ -119,12 +119,24 @@ async def test_f3_converges_mixed_state_to_single_target() -> None:
 
 
 @pytest.mark.asyncio
-async def test_f3_with_no_in_flight_shows_status_hint() -> None:
-    """Tier 2: F3 with no in-flight rows surfaces a status hint."""
+async def test_f3_with_no_in_flight_shows_status_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: F3 with no in-flight rows surfaces a status hint.
+
+    The first-use tip is pre-seeded as seen so the standard "no active
+    skill" hint is what gets shown (= this test exercises the non-tip
+    code path; first-use tip path is covered in test_f3_first_use_tip.py).
+    """
     from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.prefs import save_tui_prefs
     from reyn.chat.tui.widgets import ConversationView
 
+    # Mark tip already seen so the standard "no rows" hint appears.
+    save_tui_prefs(tmp_path, {"tip_f3_seen": True})
+
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    monkeypatch.setattr(app, "_project_root_path", lambda: tmp_path)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)


### PR DESCRIPTION
**[tui-coder]** — Wave-12 T2-4 (doc audit follow-on, TUI-side)

## Summary
- New ``tip_f3_seen: bool`` key in ``.reyn/tui_prefs.json``.
- On first F3 press per project, conv-pane status shows
  "F3: drill-down expands phase history + tool calls for in-flight
  skills (mouse-click does the same)".
- Flag flips → never re-fires.

## Why
F3 has the most opaque description on the Keys tab. Wave-12 audit
(Topic B #2) flagged it as the strongest onboarding-hint candidate.
A first-use tip teaches the affordance without permanent noise.

## Test plan
- [x] tests/cli/test_f3_first_use_tip.py — 6 Tier-2 tests pass
- [x] tests/cli/test_skill_expand_keyboard.py — 8 tests pass (updated test_f3_with_no_in_flight_shows_status_hint to pre-seed tip_f3_seen=True)
- [x] tests/cli/test_tui_smoke.py — 40 smoke tests still pass
- [x] ruff clean
- [x] Manual: fresh project, press F3 → tip appears; press F3 again → no tip