### PR TITLE
docs(tui): drift micro-sweep — 5 fixes + /reset doc link (T2-5b)

### DIFF
--- a/docs/concepts/async-skill-execution.md
+++ b/docs/concepts/async-skill-execution.md
@@ -32,20 +32,20 @@ Chat-mode `invoke_skill` is now non-blocking. Plan-mode keeps blocking
 semantics on purpose (= sequential step execution needs the nested
 skill's result inline to feed the next step's LLM).
 
-## How chat-mode invoke_skill works now
+## How chat-mode action dispatch works
 
-> **FP-0034 Phase 6 (2026-05-16) routing note**: since the
-> wrapper-only path is the default, the LLM addresses skills via
-> `invoke_action(action_name="skill__<name>", args={"input": ...})`
-> instead of the legacy `invoke_skill(name, input)` directly.
-> `universal_dispatch.py` routes the wrapper call to the same
-> `invoke_skill` handler shown below — the spawn-ack mechanism is
-> unchanged. The diagram below uses the legacy tool name for
-> readability; the production LLM-visible surface is `invoke_action`.
+Since FP-0034 Phase 6 (2026-05-16), the LLM-visible surface is
+`invoke_action(action_name="skill__<name>", args={"input": ...})`.
+`universal_dispatch.py` routes the wrapper call to the same internal
+`invoke_skill` handler — the spawn-ack mechanism is unchanged.
+The legacy `invoke_skill(name, input)` direct form is no longer
+the production surface (kept internally for plan-mode; see below).
 
 ```
 User: "skill_builder で string_length を作って"
-  └─ RouterLoop: invoke_skill(name="skill_builder", input={...})
+  └─ RouterLoop: invoke_action(action_name="skill__skill_builder",
+                               args={"input": {...}})
+       └─ universal_dispatch → invoke_skill handler
        └─ _handle: spawn_skill_fn → ChatSession._spawn_skill_for_router
             └─ asyncio.create_task(_run_one_skill(...))
             └─ returns IMMEDIATELY:

--- a/docs/concepts/voice.md
+++ b/docs/concepts/voice.md
@@ -11,8 +11,10 @@ Speech-to-text for the `reyn chat` TUI, powered by `faster-whisper`.
 ## What it does
 
 Press **Ctrl+R** to start recording; press **Ctrl+R** again to stop.
-The transcribed text is inserted into the input bar. The voice layer lives
-entirely in `chat/tui/` — the OS and skill layers have no awareness of it (P7).
+The transcribed text is inserted into the input bar. While recording,
+pressing **Enter** stops, transcribes, and submits in one keystroke
+(= dictate-and-send). The voice layer lives entirely in `chat/tui/` —
+the OS and skill layers have no awareness of it (P7).
 
 ## Backend
 

--- a/docs/guide/for-skill-authors/enable-voice-input.md
+++ b/docs/guide/for-skill-authors/enable-voice-input.md
@@ -128,4 +128,7 @@ to OpenAI — opt-in only, never the default.
 ## See also
 
 - [`reyn chat` reference](../../reference/cli/chat.md)
-- Customize TUI key bindings *(doc planned — adjust `Ctrl+R` directly in `src/reyn/chat/tui/app.py` for now)*
+- **Customizing key bindings**: `Ctrl+R` and its `Enter`-while-recording
+  companion are declared in `BINDINGS` at the top of
+  `src/reyn/chat/tui/app.py`. To remap them, edit that file directly —
+  there is no config-file key-binding layer at this time.

--- a/docs/guide/for-users/chat-and-web-ui.md
+++ b/docs/guide/for-users/chat-and-web-ui.md
@@ -101,7 +101,7 @@ The shortcuts you reach for daily:
 | `Ctrl+W` | Cycle to the next tab (Keys → Events → Agents → Memory → Cost → Docs → Pending) |
 | `h` / `l` | Widen / narrow the panel |
 | `j` / `k` | Scroll the current tab |
-| `space` | Toggle the preview pane for the cursor row (works on most tabs) |
+| `space` | Toggle the preview pane for the cursor row (events / agents / memory / docs / pending only) |
 | `c` | Copy the current view; on the Pending tab, claim the cursor's intervention |
 
 ### Quit

--- a/src/reyn/chat/slash/reset.py
+++ b/src/reyn/chat/slash/reset.py
@@ -36,7 +36,9 @@ async def reset_cmd(session: "object", args: str) -> None:
             session,
             "⚠ This will delete all in-flight skill state "
             "(snapshots + WAL). Audit logs are preserved.\n"
-            "Type `/reset confirm` to proceed, or anything else to abort.",
+            "Type `/reset confirm` to proceed, or anything else to abort.\n"
+            "See docs/guide/for-skill-authors/crash-recovery-and-resume.md "
+            "for what snapshots+WAL hold.",
         )
         return
 

--- a/tests/test_slash_reset_docs_link.py
+++ b/tests/test_slash_reset_docs_link.py
@@ -1,0 +1,46 @@
+"""Tier 2: /reset confirm-prompt includes docs link.
+
+Covers the surface added in Wave-12 T2-5b (A#6):
+- /reset confirm-prompt body includes a reference to
+  crash-recovery-and-resume.md so users know where to learn about
+  what snapshots+WAL hold before confirming a destructive reset.
+
+Policy compliance:
+- No MagicMock / AsyncMock / patch — real instances throughout.
+- Docstring first line declares the Tier.
+- Uses only public surfaces: reset_cmd handler + captured reply text.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+class _FakeSession:
+    """Minimal session double that captures reply text via _put_outbox."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def _put_outbox(self, msg: object) -> None:
+        self.messages.append(getattr(msg, "text", str(msg)))
+
+
+def test_reset_confirm_includes_docs_path() -> None:
+    """Tier 2: /reset (without args) confirm-prompt includes crash-recovery-and-resume.md."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401 — triggers registration
+    from reyn.chat.slash.reset import reset_cmd
+
+    session = _FakeSession()
+    asyncio.run(reset_cmd(session, ""))
+
+    assert session.messages, "expected at least one reply from /reset"
+    combined = "\n".join(session.messages)
+    assert "crash-recovery-and-resume.md" in combined, (
+        f"Expected docs link in /reset prompt, got: {combined!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — Wave-12 T2-5b (doc audit follow-on, mostly DOCS)

## Summary
5 doc accuracy fixes + 1 TUI-side /reset link:
- /reset confirm-prompt → cross-ref crash-recovery-and-resume.md
- async-skill-execution.md → invoke_action diagram (post-FP-0034)
- chat-and-web-ui.md → tighten "most tabs" → "events/agents/memory/docs/pending only"
- voice.md → Enter-while-recording dictate-and-send sentence
- enable-voice-input.md → resolve "doc planned" placeholder

## Why
Wave-12 audit (Topic A #6 + Topic D #4/#6/#8 + Topic B cross-cut)
flagged these as one-line drift / accuracy fixes scattered across
TUI-touching docs. Bundling avoids 5 trivial PRs.

Note: chat-and-web-ui.md clarification includes `docs` tab (verified in
`_has_previewable_content` — docs, events, memory, agents, pending all
have preview; keys and cost do not).

## Test plan
- [x] tests/test_slash_reset_docs_link.py — 1 Tier-2 test pass
- [x] ruff clean
- [x] All cross-reference paths verified to exist
- [x] async-skill-execution.md diagram verified against current `RouterLoop` action flow
- [x] voice.md Enter-while-recording sentence verified against `action_voice_stop_and_submit` in app.py
- [x] enable-voice-input.md placeholder resolved with accurate content (BINDINGS in app.py)