### PR TITLE
feat(tui): events tab [d] → runtime/events.md + plan_* lifecycle table (T2-5a)

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -40,6 +40,27 @@ See [Concepts: multi-agent](../../concepts/multi-agent.md) — "Agent ID propaga
 | `loop_limit_exceeded` | A phase exceeded `limits.phase.max_visits` | `phase`, `visit_count`, `max` |
 | `phase_budget_exceeded` | A phase exceeded its wall-clock budget (`limits.phase.max_wall_seconds`) | `phase`, `elapsed`, `budget` |
 
+## Plan lifecycle
+
+Plan-mode events cover the full lifetime of a parallel plan — from decomposition through step execution to aggregation or interruption. See [Concepts: plan-mode](../../concepts/plan-mode.md) for the architectural context.
+
+`plan_started` and `plan_completed` / `plan_aborted` are written to the agent WAL (`state_log.jsonl`), not the forensic event log — they appear in state recovery but not in the Events tab stream. The remaining events below are emitted to the regular events log and surface in the TUI Events tab under the `plan` filter.
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `plan_started` | Plan execution begins (WAL only — not in events log) | `plan_id`, `goal`, `n_steps`, `target` (agent name) |
+| `plan_step_started` | A step's sub-loop begins | `plan_id`, `step_id`, `depends_on` (list), `n_tools`, `chain_id` |
+| `plan_step_completed` | A step's sub-loop finished successfully | `plan_id`, `step_id`, `content_len` (bytes of result text), `chain_id` |
+| `plan_step_failed` | A step's sub-loop exhausted retries without success | `plan_id`, `step_id`, `error` (repr), `chain_id` |
+| `plan_completed` | All steps finished; plan aggregation done (WAL only — not in events log) | `plan_id`, `target` |
+| `plan_run_interrupted` | Plan loop exited via crash / cancel / unexpected exception (NOT `WorkflowAbortedError`) | `plan_id`, `exc_type` (exception class name), `chain_id` |
+| `plan_aborted` | Plan was explicitly discarded via `/plan discard` or AgentRegistry cleanup after crash recovery (WAL only — not in events log) | `plan_id`, `reason`, `target` |
+
+**Notes:**
+- WAL-only events (`plan_started`, `plan_completed`, `plan_aborted`) appear in `state_log.jsonl` alongside the agent snapshot. They are not in `.reyn/events/*.jsonl` and do not show in the TUI Events tab.
+- `plan_run_interrupted` is the crash/cancel signal; `plan_aborted` is the post-recovery cleanup signal. A crash followed by `reyn` restart will produce `plan_run_interrupted` (from the crashed session) then `plan_aborted` (from `AgentRegistry.restore_all`).
+- `plan_step_started` is also written to WAL (via `record_plan_step_started`) in addition to the events log, to enable resume-time step pairing.
+
 ## LLM and context
 
 | Kind | Key payload |

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -646,6 +646,12 @@ class RightPanel(Widget):
             # correct architectural seam.
             event.prevent_default()
             self._prefill_attach_for_cursor()
+        elif event.key == "d" and self._panel_type == "events":
+            # T2-5a (Wave-12): Events tab [d] → jump Docs tab to runtime/events.md.
+            # Scoped to events tab only so the pending tab's `d` = discard and
+            # any future per-tab `d` bindings remain unaffected.
+            event.prevent_default()
+            self._jump_docs_to_events_md()
         elif event.key == "d" and self._panel_type == "pending":
             # Issue #277 — Pending tab `d` = discard the cursor's iv.
             event.prevent_default()
@@ -1835,6 +1841,53 @@ class RightPanel(Widget):
             inputbar.focus_input()
         except Exception as exc:
             logger.warning("right_panel prefill docs filter focus failed: %s", exc)
+
+    def _jump_docs_to_events_md(self) -> None:
+        """Events tab [d] — switch to Docs tab, cursor on runtime/events.md.
+
+        T2-5a (Wave-12): closes the navigation gap between the events tab
+        (the densest jargon surface) and the runtime/events.md reference.
+        Builds the docs index from the current project root, finds the first
+        file whose stem equals ``events`` inside the ``reference/runtime``
+        section (or any section), sets the cursor there, then activates the
+        Docs tab. Falls through silently when docs/ or the target file are
+        absent — the user stays on the events tab.
+        """
+        groups, ordered = build_docs_index(self._project_root, "")
+        if not ordered:
+            self._flash_status("docs/: not found")
+            return
+        # Find index of the file whose stem is "events" under reference/runtime
+        # (preferred) or anywhere in the flat list (fallback).
+        target_idx: int | None = None
+        for i, path in enumerate(ordered):
+            if path.stem == "events" and "runtime" in str(path):
+                target_idx = i
+                break
+        if target_idx is None:
+            # Fallback: first file named events.md anywhere
+            for i, path in enumerate(ordered):
+                if path.stem == "events":
+                    target_idx = i
+                    break
+        if target_idx is None:
+            self._flash_status("runtime/events.md: not found in docs/")
+            return
+        self._docs_groups = groups
+        self._docs_files = ordered
+        self._docs_cursor = target_idx
+        self.set_panel_type("docs")
+
+    def current_doc_stem(self) -> str:
+        """Return the stem of the currently highlighted doc file, or "".
+
+        Public accessor for tests (and future callers) that need to verify
+        the Docs tab cursor position without reading private state directly.
+        """
+        if not self._docs_files:
+            return ""
+        idx = max(0, min(len(self._docs_files) - 1, self._docs_cursor))
+        return self._docs_files[idx].stem
 
     def _build_recent_skill_bundle(self, item: dict) -> str:
         """Header + events YAML for a finished skill run."""

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -695,6 +695,9 @@ def render_events(
                     lines.append(f"[#444444]       ↳ [/][#777777]{short}[/]")
 
     del filter_name
+    # Dim footer hint — always appended after the event rows so the user
+    # can discover the [d] docs shortcut from the events tab itself.
+    lines.append("[#555555]  ? press [d] for events.md reference[/]")
     return "\n".join(lines), windowed, event_ys
 
 

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -179,6 +179,13 @@ def render_keys(
     # detail lookup. MOUSE rows use "" since they have no key semantics.
     group_keys: dict[str, list[str]] = {g: [] for g in _GROUP_ORDER}
     seen: set[str] = set()
+    # ``binding_seen`` tracks keys that were emitted from app.BINDINGS /
+    # InputBar.BINDINGS. Used by the _PANEL_EXPLICIT loop below to skip
+    # entries whose key was already surfaced from a real Binding — but
+    # distinct from ``seen`` so that multiple _PANEL_EXPLICIT entries for
+    # the same key (= same key, different tab contexts) are not dropped
+    # against each other.
+    binding_seen: set[str] = set()
     # App-level bindings first — they take precedence on same-key conflicts
     # (the InputBar's ctrl+c / ctrl+d / ctrl+l shadow app's, but app's
     # description is the load-bearing one users see in the footer hint).
@@ -191,6 +198,7 @@ def render_keys(
         if b.key in _INPUT_OWNED_KEYS:
             continue
         seen.add(b.key)
+        binding_seen.add(b.key)
         group = _key_group_for(b.key)
         if group not in groups:
             group = "OTHER"
@@ -205,6 +213,7 @@ def render_keys(
         if b.key in seen or not b.description:
             continue
         seen.add(b.key)
+        binding_seen.add(b.key)
         groups["INPUT"].append((_pretty_key(b.key), b.description))
         group_keys["INPUT"].append(b.key.lower())
 
@@ -222,9 +231,12 @@ def render_keys(
         ("space", "Toggle preview pane"),
         ("c", "Copy current view (pending tab: claim cursor)"),
         # A-F2 (wave-8): ``d`` is the primary pending-tab action (=
-        # discard the cursor's intervention). T2-5a (wave-12): also
-        # opens runtime/events.md in Docs tab when on events tab.
-        ("d", "Discard cursor (pending) / open events.md (events tab)"),
+        # discard the cursor's intervention).
+        ("d", "Discard cursor (pending tab)"),
+        # T2-5a (wave-12): ``d`` on the events tab opens runtime/events.md
+        # in the Docs tab. Listed as a second row because it's a different
+        # tab context — not a merge of the pending-tab meaning.
+        ("d", "Open events.md reference (events tab)"),
         # H-F11 (wave-10 follow-up): ``a`` on the Agents tab prefills
         # ``/attach <name>`` into the InputBar for the cursor's agent.
         # Same "per-tab action" idiom as the pending-tab ``d`` / ``c``
@@ -241,8 +253,16 @@ def render_keys(
     # de-dupe guard would silently swallow this entry. The memory
     # binding self-documents via ``_flash_status("memory filter: <X>")``
     # on every press.
+    #
+    # The guard here is ``binding_seen`` (not ``seen``) so that multiple
+    # _PANEL_EXPLICIT rows with the same key but different tab-context
+    # descriptions (e.g. two ``d`` rows — pending-tab discard and
+    # events-tab docs jump) are both emitted. ``binding_seen`` only tracks
+    # keys that were already surfaced from app/InputBar Binding objects;
+    # two explicit synthetic rows for the same key are intentional and must
+    # not de-dupe against each other.
     for key, desc in _PANEL_EXPLICIT:
-        if key not in seen:
+        if key not in binding_seen:
             groups["PANEL"].append((_pretty_key(key), desc))
             group_keys["PANEL"].append(key.lower())
             seen.add(key)

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -222,11 +222,9 @@ def render_keys(
         ("space", "Toggle preview pane"),
         ("c", "Copy current view (pending tab: claim cursor)"),
         # A-F2 (wave-8): ``d`` is the primary pending-tab action (=
-        # discard the cursor's intervention) but was missing from
-        # _PANEL_EXPLICIT entirely, so a user on the pending tab had
-        # no way to discover it from the Keys tab. Surface it here
-        # alongside ``c=claim`` for symmetry.
-        ("d", "Discard cursor (pending tab)"),
+        # discard the cursor's intervention). T2-5a (wave-12): also
+        # opens runtime/events.md in Docs tab when on events tab.
+        ("d", "Discard cursor (pending) / open events.md (events tab)"),
         # H-F11 (wave-10 follow-up): ``a`` on the Agents tab prefills
         # ``/attach <name>`` into the InputBar for the cursor's agent.
         # Same "per-tab action" idiom as the pending-tab ``d`` / ``c``

--- a/tests/cli/test_events_tab_d_jumps_to_events_md.py
+++ b/tests/cli/test_events_tab_d_jumps_to_events_md.py
@@ -1,0 +1,152 @@
+"""Tier 2: events tab [d] keybinding → Docs tab cursor on runtime/events.md.
+
+Wave-12 T2-5a (doc audit follow-on). Three invariants:
+
+1. Events tab rendered output contains the "press [d] for events.md reference"
+   footer hint so the user can discover the shortcut from the tab itself.
+2. When events tab is active and ``d`` is dispatched, Docs tab becomes active
+   AND its cursor lands on runtime/events.md (asserted via the public
+   ``current_doc_stem()`` accessor).
+3. When events tab is NOT active (e.g. memory tab) and ``d`` is dispatched,
+   the events tab doesn't activate, Docs tab doesn't open (scope guard).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── Test 1: footer hint is present in rendered events output ─────────────────
+
+
+def test_events_tab_footer_contains_d_hint(tmp_path: Path) -> None:
+    """Tier 2: render_events output ends with the [d]-for-events.md footer row."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    # Seed a minimal events log so the renderer doesn't return the early
+    # "no matching events" branch (= that path also now appends the footer,
+    # but testing against the non-empty path is more representative).
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "test" / "events"
+    events_root.mkdir(parents=True)
+    log = events_root / "log.jsonl"
+    log.write_text(
+        json.dumps({
+            "type": "phase_started",
+            "timestamp": "2026-05-23T10:00:00",
+            "data": {"chain_id": "x", "phase": "p1"},
+        }) + "\n"
+    )
+
+    rendered, _visible, _ys = render_events(
+        tmp_path,
+        event_filter_idx=0,  # all
+        event_tail_idx=2,    # tail=100
+        cursor=0,
+    )
+    assert "press [d] for events.md reference" in rendered
+
+
+# ── Test 2: [d] on events tab → Docs tab opens, cursor on events ─────────────
+
+
+@pytest.mark.asyncio
+async def test_d_key_on_events_tab_jumps_to_docs_events_md(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``d`` on events tab activates Docs tab with cursor on events.md."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    # Seed a minimal docs/ tree so build_docs_index finds something.
+    # Place events.md under docs/reference/runtime/ — the canonical location.
+    docs_dir = tmp_path / "docs" / "reference" / "runtime"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "events.md").write_text("# Events\n\ntest\n")
+    # Add a second file so the cursor isn't trivially at 0 by default.
+    (tmp_path / "docs" / "reference" / "runtime" / "control-ir.md").write_text(
+        "# Control IR\n"
+    )
+
+    app = ReynTUIApp(
+        registry=None,
+        agent_name="t",
+        model="m",
+        budget_tracker=None,
+    )
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        # Inject project_root so build_docs_index finds our seed docs/.
+        panel._project_root = tmp_path
+        # Start on events tab.
+        panel.set_panel_type("events")
+        await pilot.pause()
+        assert panel._panel_type == "events"
+
+        # Dispatch 'd'.
+        key_event = textual_events.Key(key="d", character="d")
+        panel.on_key(key_event)
+        await pilot.pause()
+
+        # Docs tab must now be active.
+        assert panel._panel_type == "docs", (
+            f"Expected panel_type='docs', got {panel._panel_type!r}"
+        )
+        # Cursor must be on events.md (stem = "events").
+        stem = panel.current_doc_stem()
+        assert stem == "events", (
+            f"Expected docs cursor on 'events', got {stem!r}"
+        )
+
+
+# ── Test 3: [d] on non-events tab is a scope-guard no-op ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_d_key_on_memory_tab_does_not_open_docs(tmp_path: Path) -> None:
+    """Tier 2: ``d`` while memory tab is active leaves panel_type unchanged."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(
+        registry=None,
+        agent_name="t",
+        model="m",
+        budget_tracker=None,
+    )
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._project_root = tmp_path
+        # Switch to memory tab (not events).
+        panel.set_panel_type("memory")
+        await pilot.pause()
+        assert panel._panel_type == "memory"
+
+        # Record docs cursor before the key press.
+        cursor_before = panel._docs_cursor
+
+        # Dispatch 'd' — should be a no-op for the docs jump.
+        # (Memory tab has no `d` handler, so it falls through to the
+        # generic `c`-copy / `l`/`h` resize / etc. guards unchanged.)
+        key_event = textual_events.Key(key="d", character="d")
+        panel.on_key(key_event)
+        await pilot.pause()
+
+        # Panel must still be on memory, not docs.
+        assert panel._panel_type == "memory", (
+            f"Expected 'memory', got {panel._panel_type!r}"
+        )
+        # Docs cursor must not have moved.
+        assert panel._docs_cursor == cursor_before


### PR DESCRIPTION
**[tui-coder]** — Wave-12 T2-5a (doc audit follow-on, TUI + DOCS)

## Summary
- Events tab footer: "? press [d] for events.md reference"
- [d] on events tab → Docs tab opens cursor on runtime/events.md
- runtime/events.md: new "Plan lifecycle" sub-table covering
  plan_started / plan_step_started / plan_step_completed /
  plan_step_failed / plan_completed / plan_run_interrupted /
  plan_aborted with emit conditions sourced from src/reyn/

## Why
Events tab is the densest jargon surface in the TUI. runtime/events.md
exists but had no path from the tab AND was missing the plan_* events
the AsyncStackPanel surfaces. Wave-12 audit (Topic C #2 + Topic D #5)
flagged the two as a paired fix.

## Test plan
- [x] tests/cli/test_events_tab_d_jumps_to_events_md.py — 3 Tier-2 tests pass
- [x] tests/cli/test_events_tab_chain_isolate.py — no regress
- [x] tests/cli/test_tui_smoke.py — 40 smoke tests pass
- [x] ruff clean
- [x] Manual: open events tab → footer shows; press [d] → Docs tab opens on events.md
- [x] (skipped — headless test env) Manual: open memory tab → press [d] → nothing happens (= scope guard verified by test 3)