### PR TITLE
docs(permission-model): axis taxonomy + trust boundary + industry comparison + known gaps (#571)

### DIFF
--- a/docs/concepts/permission-model.ja.md
+++ b/docs/concepts/permission-model.ja.md
@@ -207,6 +207,156 @@ web:
 - **自己署名証明書の開発環境**: `verify_ssl: false` を設定
 - **env var に関係なく SSL 検証を強制**: `verify_ssl: true` を設定
 
+## 宣言軸の taxonomy（= bool flag と resource list の使い分け）
+
+`skill.md` frontmatter の `permissions:` ブロックは **3 種類の軸 shape** を混在させている。 本セクションは各軸を明示的に列挙し、 新軸追加時の shape 選定 criterion を確立する。
+
+### 現状の軸
+
+| 軸 | 型 | 粒度 | gate site | 補足 |
+|---|---|---|---|---|
+| `file.read` | `list[{path, scope}]` | resource（per-path）| `require_file_read()` | scope ∈ {`just_path`, `recursive`} |
+| `file.write` | `list[{path, scope}]` | resource（per-path）| `require_file_write()` | write / edit / delete を包含 |
+| `python` | `list[{module, function, mode, timeout}]` | resource（per-step）| `require_python_step()` | mode ∈ {`safe`, `unsafe`} |
+| `mcp` | `list[str]` | resource（per-server）| MCP 呼び出し時 implicit | サーバー名の allowlist |
+| `tool` | `list[str]` | resource（per-tool）| `require_tool()` | 名前指定 tool allowlist |
+| `shell` | `bool` | abstract | `require_shell()` | binary（= shell 全般へのアクセス）|
+| `mcp_install` | `bool`（宣言）+ per-server approval key | hybrid | `require_mcp_install()` | 宣言は bool / approval は `<server_id>` キーで永続 |
+| `mcp_drop_server` | `bool`（同 shape）| hybrid | `require_mcp_drop_server()` | `mcp_install` の counter-op |
+| `index_drop` | `bool`（同 shape）| hybrid | `require_index_drop()` | RAG corpus / source の drop |
+| `cron_register` | `bool`（同 shape、 per-job approval）| hybrid | `require_cron_register()` | register / unregister / enable / disable をまとめて |
+| `allowed_mcp` | `list[str]` または `None` | ACL filter | MCP 呼び出し時 implicit | per-agent restriction、 `mcp` 軸とは cross-cut |
+
+### Criterion — `bool` 軸 vs `list` 軸
+
+ある capability が **bool 軸** に属するのは、 **以下を全て満たす** とき:
+
+1. その capability が起こす **side-effect 集合** が単一 resource scope で表現できない（= config write + chain notify + state_change emit のような複合効果、 `mcp_install` triad が典型）。
+2. Skill 作者が write-time に対象 instance を列挙できない（= 「どの server を install するか」 は runtime に user / LLM が決める、 skill 作者には不可知）。
+3. user が runtime に **per-instance** 承認面を見たい — 宣言は intent shape（= bool）でも、 approval は resource-keyed という hybrid shape。
+
+ある capability が **list 軸** に属するのは、 **以下を全て満たす** とき:
+
+1. 単一の I/O scope に reducible（= 1 path / 1 host / 1 server）。
+2. Skill 作者が write-time に inventory を知っている（= 「これらの path を読む」）。
+3. runtime per-instance prompt は不要（= list 自体が scope、 config tier が ask しない限り追加 prompt なし）。
+
+**`allowed_mcp` ACL 軸** は 3 つめの shape — capability を grant せず、 既に grant 済の resource list の **subset を agent ごとに restrict** する。 ACL filter は bool / list 両軸を cross-cut する別系統。
+
+例示:
+
+| Capability | shape | 理由 |
+|---|---|---|
+| `file.write` | list（resource）| 単一 I/O scope（= 1 path）、 作者が inventory を知る、 chain effect なし |
+| `mcp_install` | bool（hybrid）| side-effect 集合（= config write + emit + notify）、 server name は runtime 決定、 user が per-server prompt 希望 |
+| `shell` | bool | side-effect 集合 unbounded（= 任意プロセス実行）、 作者は 「これらの command」 と列挙不可 |
+| `cron_register` | bool（hybrid）| side-effect 集合（= cron.yaml write + emit）、 job name は runtime 決定、 per-job approval key |
+
+### 隠れた軸 — 「intent ↔ raw I/O」 correlation
+
+bool 軸は **intent** を宣言するが、 実際の side-effect（= file write / HTTP / process spawn）は **underlying primitive** を通る。 同じ raw I/O が直接到達可能（= `file.write` の default-zone path 経由）な場合、 bool 軸の intent は **bypass 可能**。
+
+具体例: `mcp_install: true` は 「この skill は MCP server を install する」 と宣言するが、 副作用（= `.reyn/mcp.yaml` への write）は `reyn.safe.file.write(".reyn/mcp.yaml", ...)` でも到達可能 — `.reyn/` が default-zone write path に含まれるため。 2 経路の reconcile が無い — 後述 [Known gaps](#known-gaps-2026-05-23-監査-追跡は個別-pr) 参照。
+
+提案する canonical correlation rule（= 未実装）:
+
+> bool 軸 B が記述する side-effect 集合に raw I/O R が含まれる場合、 R をどの経路（宣言済 list / default zone / OS 内部 code 経由）で実行しても B の gate を通過する必要がある。
+
+現実装は 4 つの bool 軸（`mcp_install` / `mcp_drop_server` / `index_drop` / `cron_register`）いずれもこの rule を強制していない。
+
+## Trust boundary レイヤー（= 強制が実際どこで掛かるか）
+
+side-effect を実行する 4 つの surface を強制力の強い順に:
+
+```
+┌──────────────────────────────────────────────────────────────┐  ← 最強
+│  sandboxed_exec op (FP-0017)                                 │
+│    OS-kernel 強制（Seatbelt / Landlock / Seccomp）            │
+│    per-call で argv-scoped / network-scoped / fs-scoped       │
+├──────────────────────────────────────────────────────────────┤
+│  safe-mode python step (FP-0042)                             │
+│    AST validation（= compile-time に `import os` 等を reject） │
+│    + reyn.safe.* honor-system による per-call path check       │
+│    kernel sandbox なし、 subprocess は user UID で動作         │
+├──────────────────────────────────────────────────────────────┤
+│  unsafe-mode python step                                     │
+│    `--allow-unsafe-python` opt-in 後は gate なし              │
+│    宣言による trust（= 作者が step の安全性を保証）            │
+├──────────────────────────────────────────────────────────────┤
+│  reyn パッケージ内部（OS handler / registry client）          │  ← 最弱
+│    permission_resolver は call path に居ない                  │
+│    Trust boundary: このコードは OS 自身、 caller を gate するが │
+│    自分自身は gate されない                                   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+最上層・最下層は意図的な非対称、 中 2 層は現状制限:
+
+- **最上層 (sandboxed_exec)** は OS-kernel 強制を持つ唯一のレイヤー。 argv / network / fs scope を per-call で declarative 宣言、 platform sandbox が強制。
+- **最下層 (reyn パッケージ内部)** は構造的に trust 内側 — OS が caller を gate、 自分自身は gate しない。 ここに gate を足すには (a) OS 内部の permission model 別建て（= 循環）、 もしくは (b) I/O を `op_runtime` 層に移す（= 既に gate がある層）必要があり、 どちらも architectural commitment が大きい。
+- **safe-mode python** は honor system: AST validation が `import os` を弾き、 `reyn.safe.file` が宣言済 path を check。 motivated な user が `mode: unsafe` で bypass 可、 通常の `mode: safe` author が accidentally bypass はしにくい。
+- **unsafe-mode python** は宣言 trust: operator が runtime に `--allow-unsafe-python` を承認、 step が host へのフルアクセスを持つことを accept。
+
+## 業界比較（= 設計選択の参照）
+
+| Platform | 宣言 shape | runtime ask | 粒度 | 強制レイヤー |
+|---|---|---|---|---|
+| iOS (TCC + Entitlements) | `Info.plist` capability + purpose string | First-use prompt | Capability axis | OS kernel + signed entitlements |
+| Android (≥ M) | `AndroidManifest.xml` `uses-permission` | dangerous tier に first-use prompt | Permission class + scoped storage | OS kernel + per-app UID |
+| Web Permissions API | feature ごとに query | per-permission prompt | **Origin-scoped**（= per-domain capability）| Browser sandbox |
+| Anthropic Claude Code | Tool list（Bash / Edit / Read / Write）| デフォルトでは無、 sandbox-mode で opt-in | Tool 名（path scope なし）| Seatbelt（sandbox-mode）または trust |
+| MCP servers | server side で tool list 公開 | server がオーナーシップ | per-tool、 server 定義 | プロセス境界 |
+| **Reyn** | `permissions:` ブロック（本 doc）| startup_guard + first-use interactive | **Hybrid**（= per-path list + abstract bool）| safe-mode は AST + honor system / `sandboxed_exec` のみ kernel |
+
+業界の主流は **abstract capability 宣言 + runtime per-instance prompt + OS-kernel 強制**。 Reyn は 2 軸で乖離:
+
+1. **粒度は業界標準より細かい** — path-list `file.read` / `file.write` は iOS / Android の capability axis より Web の origin-scope に近い。 正当化: Reyn skill は workflow code（= 作者が file inventory を知る）、 iOS / Android app は general-purpose（= 作者が write-time に列挙不可）。
+2. **safe-mode python の強制は honor system** — iOS / Android は kernel boundary、 Reyn は AST + path-list check。 Trade-off: 実装簡素（= per-step seatbelt セットアップ不要） vs 強制の弱さ。
+
+これらの乖離は明示的な design choice だが、 safe-mode-python honor-system contract に制約を課す: `reyn.safe.*` を bypass する経路（= AST hole / 直接 I/O path で AST が捕捉しないもの）は宣言 path check を silently escape する。 上の criterion section で挙げた bool 軸 cross-cutting correlation rule は、 この honor-system 破綻が最も visible に現れる surface である。
+
+## Known gaps (2026-05-23 監査、 追跡は個別 PR)
+
+2026-05-23 軸 taxonomy 監査で identify した 3 つの architectural inconsistency。 個別 PR で remediation する前提で、 gap を明示する目的でここに記録。
+
+### Gap A — bool intent vs raw I/O default-zone bypass
+
+4 つの bool 軸（`mcp_install` / `mcp_drop_server` / `index_drop` / `cron_register`）は **intent** を宣言するが、 その side-effect 集合（= `.reyn/` 配下への config write）は `reyn.safe.file.write()` 経由でも到達可能 — `.reyn/` が default-zone write path のため（= `src/reyn/kernel/preprocessor_executor.py:493-499`）。
+
+具体的 bypass: safe-mode python step は `.reyn/mcp.yaml` を直接 write して MCP server registry を変更できる、 `mcp_install: true` 宣言なし + `require_mcp_install()` 承認 prompt なしで。
+
+Remediation 候補（= 後続 PR）:
+
+- Cross-axis correlation gate: `_check_write(path)` で 「raw I/O → bool 軸」 registry（= `.reyn/mcp.yaml` → `mcp_install` / `.reyn/cron.yaml` → `cron_register` 等）を consult、 path match 時に bool 軸も追加強制。
+- もしくは canonical な MCP registry mutation を `safe.file` 経由から外す（= `op_runtime/mcp_install.py` 内のみに keep、 safe.file 層で直接 write を refuse）。
+
+cross-cutting rule は上の [宣言軸の taxonomy](#宣言軸の-taxonomy-bool-flag-と-resource-list-の使い分け) section に articulate 済、 現実装はこれを強制していない。
+
+### Gap B — reyn パッケージ内部コードが permission resolver を経由しない
+
+OS 内部 code（= `src/reyn/registry/client.py` の MCP registry HTTP、 `src/reyn/op_runtime/mcp_install.py` の config write）は `PermissionResolver` を consult せず I/O を実行する。 これは意図的な trust boundary（= OS が caller を gate、 自分自身は gate しない）だが、 境界が undocumented。
+
+この gap は **必ずしも bug ではない**: OS 内部 code への厳密な gate は (a) OS 内部の permission model 別建て（= 循環）か (b) I/O を `op_runtime` 層に押し出す（= 既に gate がある）かのいずれかが必要で、 どちらも architectural commitment が大きい。
+
+Disposition: known trust-boundary choice として記録。 具体的な OS 内部 I/O path が user-visible になり operator が gate を要求する場合（= 例: MCP registry call の `web.fetch` event ログ化）に re-open。
+
+### Gap C — `safe.http` は存在するが gate されていない
+
+`src/reyn/safe/http.py`（= FP-0042 Phase 3 drift-fix で landed）は `get` / `post` / `put` / `delete` を ship — urllib-backed、 AST allowlist 経由で safe-mode step から呼び出し可。 しかし **per-call permission gate を持たない**: module の docstring 自体が 「ここでの "safe" は namespace 役割（= AST-allowlisted）であって、 `reyn.safe.file` が enforce する per-call permission-resolver pattern ではない」 と明示し、 設計解決先として本 issue を参照している。
+
+現状の stdlib 使用:
+
+- `mcp_search` / `mcp_install` は domain-specific `reyn.safe.mcp.registry`（= hardcoded registry URL、 host は skill から見えない）を使用。
+- `skill_search` / `skill_importer` は bare `reyn.safe.http.get`（= 任意 URL、 host check なし）を使用。
+
+宣言 shape の design question（= gate を追加するときの形）は依然として:
+
+- **per-host allowlist**（= `http.get: [{host: "registry.modelcontextprotocol.io"}]`）— resource-list criterion 合致（= 単一 I/O scope、 作者が inventory を知る）。
+- **bool flag**（= `http: true`）— bool criterion 合致は HTTP が fetch 自体を超える side-effect を持つ場合のみ（= 定義上 HTTP GET は read-only でそれを持たない）。
+- **method + origin-scope**（= Web Permissions API style）— 業界 pattern に最も近く、 Reyn の workflow-code use case に granular 十分。
+
+上の criterion section の規則によれば: HTTP read は単一 I/O scope、 作者が host を write-time に知る、 fetch 以外の side-effect なし → **resource list、 bool ではない**。 現在の un-gated state が gap、 `safe.http` に per-host allowlist を追加するのが整合した remediation。
+
 ## `python` パーミッションと `mode: safe` allowlist
 
 `python` パーミッションには 2 段階あります:

--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -228,6 +228,158 @@ is configured — there is no regression for environments that already use env v
 - **Internal dev environment with self-signed certs**: set `verify_ssl: false`
 - **Enforce verification regardless of env vars**: set `verify_ssl: true`
 
+## Declaration axis taxonomy (= when to use a bool flag vs a resource list)
+
+The `permissions:` block in `skill.md` frontmatter mixes axes of three
+shapes. This section names each axis explicitly and gives the criterion
+for picking a shape when a new axis is added.
+
+### Current axes
+
+| Axis | Type | Granularity | Gate site | Notes |
+|---|---|---|---|---|
+| `file.read` | `list[{path, scope}]` | resource (per-path) | `require_file_read()` | scope ∈ {`just_path`, `recursive`} |
+| `file.write` | `list[{path, scope}]` | resource (per-path) | `require_file_write()` | covers write / edit / delete |
+| `python` | `list[{module, function, mode, timeout}]` | resource (per-step) | `require_python_step()` | mode ∈ {`safe`, `unsafe`} |
+| `mcp` | `list[str]` | resource (per-server) | implicit at MCP call | per-server-name allowlist |
+| `tool` | `list[str]` | resource (per-tool) | `require_tool()` | named-tool allowlist |
+| `shell` | `bool` | abstract | `require_shell()` | binary: any shell access at all |
+| `mcp_install` | `bool` (declaration) + per-server approval key | hybrid | `require_mcp_install()` | declaration is bool; approval persists per `<server_id>` |
+| `mcp_drop_server` | `bool` (= same shape as `mcp_install`) | hybrid | `require_mcp_drop_server()` | counter-op to `mcp_install` |
+| `index_drop` | `bool` (= same shape) | hybrid | `require_index_drop()` | RAG corpus / source drop |
+| `cron_register` | `bool` (= same shape; per-job approval key) | hybrid | `require_cron_register()` | covers register / unregister / enable / disable |
+| `allowed_mcp` | `list[str]` or `None` | ACL filter | implicit at MCP call | per-agent restriction, cross-cuts `mcp` |
+
+### Criterion — `bool` axis vs `list` axis
+
+A capability lives on a **bool axis** when **all** of the following hold:
+
+1. The capability fires a **side-effect set** that no single resource scope can describe — e.g. config write + chain-notify peers + state-change emit (the `mcp_install` triad).
+2. The skill author has no natural way to enumerate which instances will be touched at write-time (= "which server I'll install" is determined by the user / LLM at runtime, not by the skill author).
+3. The user wants to see a **per-instance** approval surface at runtime even though the **declaration** is intent-shaped (= the hybrid shape: declaration bool, approval key resource-keyed).
+
+A capability lives on a **list axis** when **all** of the following hold:
+
+1. The capability is reducible to a **single I/O scope** (= one path / one host / one server).
+2. The skill author knows the inventory at write-time (= "I'll read these specific paths").
+3. Per-instance runtime approval is not needed beyond the declared list (= the list **is** the scope; no further per-call prompt unless config tier asks).
+
+The **`allowed_mcp` ACL axis** is a third shape — it doesn't grant capability; it **restricts** which subset of an already-granted resource list a specific agent may use. ACL filters cross-cut both bool and list axes.
+
+Worked examples:
+
+| Capability | Shape | Why |
+|---|---|---|
+| `file.write` | list (resource) | single I/O scope (= one path); author knows the inventory; no chain effects |
+| `mcp_install` | bool (hybrid) | side-effect set (= config write + emit + notify); author doesn't know server name at write time; user wants per-server prompt |
+| `shell` | bool | side-effect set is unbounded (= shell is arbitrary process execution); author can't list "these specific commands" |
+| `cron_register` | bool (hybrid) | side-effect set (= cron.yaml write + emit); job name determined at runtime; per-job approval key |
+
+### Hidden axis — the cross-cutting "intent ↔ raw I/O" correlation
+
+A bool axis declares **intent**; the actual side effects (= file writes / HTTP calls / process spawns) still happen through underlying primitives. When the **same raw I/O** is reachable directly (= via `file.write` in a default-zone path), the bool axis's intent is **bypassable**.
+
+Concretely: `mcp_install: true` declares "this skill installs MCP servers", but the side effect ("write `.reyn/mcp.yaml`") is also reachable via `reyn.safe.file.write(".reyn/mcp.yaml", ...)` because `.reyn/` is in the default-zone write paths. The two paths don't reconcile — see [Known gaps](#known-gaps) below.
+
+The correlation rule (= proposed canonical, not enforced today) is:
+
+> When a bool axis B describes a side-effect set that includes raw I/O R, then performing R by any path (declared list OR default zone OR internal-OS code) MUST also pass B's gate.
+
+Today's implementation does not enforce this rule for any of the four bool axes (`mcp_install`, `mcp_drop_server`, `index_drop`, `cron_register`).
+
+## Trust boundary layers (= where enforcement actually happens)
+
+The four execution surfaces that perform side-effects, ordered by enforcement strength:
+
+```
+┌──────────────────────────────────────────────────────────────┐  ← STRONGEST
+│  sandboxed_exec op (FP-0017)                                 │
+│    OS-kernel enforcement (Seatbelt / Landlock / Seccomp)     │
+│    argv-scoped, network-scoped, fs-scoped per-call           │
+├──────────────────────────────────────────────────────────────┤
+│  safe-mode python step (FP-0042)                             │
+│    AST validation (= rejects `import os` at compile-time)    │
+│    + reyn.safe.* honor-system path checks at function call   │
+│    NOT kernel-sandboxed; subprocess runs with full user UID  │
+├──────────────────────────────────────────────────────────────┤
+│  unsafe-mode python step                                     │
+│    No gate after the `--allow-unsafe-python` opt-in          │
+│    Trusted-by-declaration: author asserts the step is safe   │
+├──────────────────────────────────────────────────────────────┤
+│  reyn package internal code (OS handlers, registry client)   │  ← WEAKEST
+│    permission_resolver not in the call path                  │
+│    Trust boundary: this code IS the OS, gates its callers    │
+│    not itself                                                │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The asymmetry is intentional for the top and bottom layers and a current limitation for the middle two:
+
+- **Top (sandboxed_exec)** is the only layer with OS-kernel enforcement. argv / network / fs scope is declarative per call and enforced by the platform sandbox.
+- **Bottom (reyn package internal)** is trusted by construction — the OS gates its callers, not itself. Adding gates here would require either a separate inside-OS permission model (= cyclic) or moving the I/O out to the `op_runtime` layer (= where gates already exist).
+- **Safe-mode python** is honor-system: AST validation prevents `import os`, and `reyn.safe.file` checks declared paths. A motivated user with `mode: unsafe` access can bypass; a non-motivated `mode: safe` author cannot accidentally bypass via normal coding patterns.
+- **Unsafe-mode python** is trust-by-declaration: the operator approves `--allow-unsafe-python` at runtime and accepts that the step has full host access.
+
+## Industry comparison (= reference for design choices)
+
+| Platform | Declaration shape | Runtime ask | Granularity | Enforcement |
+|---|---|---|---|---|
+| iOS (TCC + Entitlements) | `Info.plist` capability + purpose string | First-use prompt | Capability axis | OS kernel + signed entitlements |
+| Android (≥ M) | `AndroidManifest.xml` `uses-permission` | First-use prompt for "dangerous" tier | Permission class + scoped storage | OS kernel + per-app UID |
+| Web Permissions API | Per-feature query | Per-permission prompt | **Origin-scoped** (= per-domain capability) | Browser sandbox |
+| Anthropic Claude Code | Tool list (Bash / Edit / Read / Write) | None at default; sandbox-mode optional | Tool name (no path scope) | Seatbelt (sandbox-mode) or trust |
+| MCP servers | Server-side tool list exposed to client | Server owns its boundary | Per-tool, server-defined | Process boundary |
+| **Reyn** | `permissions:` block (this doc) | startup_guard + interactive on first use | **Hybrid** (= per-path list + abstract bool) | AST + honor-system for safe-mode; kernel for `sandboxed_exec` only |
+
+The industry pattern is **abstract capability declaration + runtime per-instance prompt + OS-kernel enforcement**. Reyn deviates on two axes:
+
+1. **Granularity is finer than industry default** — path-list `file.read` / `file.write` is closer to Web's origin-scope than to iOS / Android's capability axis. The justification is that Reyn skills are workflow code (= author knows the file inventory), whereas iOS / Android apps are general-purpose (= author cannot enumerate at write-time).
+2. **Enforcement is honor-system for safe-mode python** — iOS / Android rely on kernel boundaries; Reyn relies on AST validation + path-list checks. The trade-off is implementation simplicity (= no per-step seatbelt setup) for weaker enforcement.
+
+These deviations are explicit design choices, but they constrain the safe-mode-python honor-system contract: anything that bypasses `reyn.safe.*` (= via an AST hole, or via a direct I/O path the AST doesn't catch) silently escapes the declared-path check. The bool-axis cross-cutting correlation rule from the criterion section above is the surface that this honor-system breakdown is most visible on.
+
+## Known gaps (= 2026-05-23 audit, follow-up tracked)
+
+Three architectural inconsistencies identified during the 2026-05-23 axis-taxonomy audit, captured here so the gap is explicit while individual remediation PRs are scoped separately.
+
+### Gap A — bool intent vs raw I/O default-zone bypass
+
+The four bool axes (`mcp_install`, `mcp_drop_server`, `index_drop`, `cron_register`) declare **intent** but their side-effect set (= config writes under `.reyn/`) is also reachable through `reyn.safe.file.write()` because `.reyn/` is a default-zone write path (= `src/reyn/kernel/preprocessor_executor.py:493-499`).
+
+Concrete bypass: a safe-mode python step can write `.reyn/mcp.yaml` directly, mutating the MCP server registry, without declaring `mcp_install: true` and without going through `require_mcp_install()`'s approval prompt.
+
+Remediation candidates (= future PR):
+
+- Cross-axis correlation gate: `_check_write(path)` consults a "raw I/O → bool axis" registry (= `.reyn/mcp.yaml` → `mcp_install`, `.reyn/cron.yaml` → `cron_register`, etc.) and additionally enforces the bool axis when the path matches.
+- OR move the canonical MCP-registry mutation out of `safe.file` reach (= keep it inside `op_runtime/mcp_install.py` only, refuse direct write at the safe.file layer).
+
+The cross-cutting rule is articulated in the [Declaration axis taxonomy](#declaration-axis-taxonomy--when-to-use-a-bool-flag-vs-a-resource-list) section above; no implementation enforces it today.
+
+### Gap B — reyn package internal code bypasses the permission resolver
+
+OS-internal code (= `src/reyn/registry/client.py` MCP registry HTTP, `src/reyn/op_runtime/mcp_install.py` config writes) performs I/O without consulting `PermissionResolver`. This is a deliberate trust boundary — the OS gates its callers, not itself — but the boundary is undocumented.
+
+This gap is **not necessarily a bug**: any tight gate around internal OS code would either need a separate inside-OS permission model (= cyclic) or push the I/O into the `op_runtime` layer (= where gates already exist). Either is a significant architectural commitment.
+
+Disposition: documented as a known trust-boundary choice. Re-open if a specific OS-internal I/O path becomes user-visible and operators want to gate it (= e.g. logging a `web.fetch` event for the MCP registry call).
+
+### Gap C — `safe.http` exists but is un-gated
+
+`src/reyn/safe/http.py` (= landed during FP-0042 Phase 3 drift-fix) ships `get` / `post` / `put` / `delete` — urllib-backed, callable from safe-mode steps via the AST allowlist. However it has **no per-call permission gate**: the module's docstring is explicit that the "safe" label here matches the namespace (= AST-allowlisted) rather than the stronger per-call permission-resolver pattern that `reyn.safe.file` enforces, and the docstring references this issue as the design question to resolve.
+
+Stdlib usage today:
+
+- `mcp_search` / `mcp_install` use the domain-specific `reyn.safe.mcp.registry` (= hardcoded registry URL, no host parameter exposed to the skill).
+- `skill_search` / `skill_importer` use bare `reyn.safe.http.get` (= arbitrary URL, no host check).
+
+The shape question (= what gate to add when one is added) remains:
+
+- **Per-host allowlist** (= `http.get: [{host: "registry.modelcontextprotocol.io"}]`) — matches the resource-list criterion (single I/O scope, author knows the inventory).
+- **Bool flag** (= `http: true`) — matches the bool criterion only if HTTP carries side effects beyond the fetch itself (= it doesn't, by definition; HTTP GET is read-only).
+- **Origin-scope with method** (= Web Permissions API style) — most aligned with industry pattern, granular enough for Reyn's workflow-code use case.
+
+Per the criterion section above: HTTP read is a single I/O scope, author knows the hosts at write-time, no side effects beyond the fetch → resource list, **not** bool. The current un-gated state is the gap; adding a per-host allowlist on `safe.http` is the consistent remediation.
+
 ## `python` permission and `mode: safe` allowlist
 
 The `python` permission has two levels:


### PR DESCRIPTION
**[e2e-coder]** — Documents the architectural design questions captured at #571 (= post-FP-0042 Phase 2.4 spawn) directly inside the canonical concept doc.

## Motivation

The existing ``docs/concepts/permission-model.md`` covers the 3-layer model + FP-0022 op-tier classification, but didn't articulate:

- the **declaration-axis taxonomy** (= why some axes are bool flags, others are resource lists, others are ACL filters)
- the **criterion** for picking a shape when a new axis is added
- the **trust boundary layers** (= sandboxed_exec / safe-mode python / unsafe-mode python / reyn package internal) and what enforces each
- **industry comparison** (= iOS / Android / Web Permissions API / Claude Code / MCP servers) as a design reference
- **known gaps** with explicit follow-up disposition

The new section sits between the existing "Permission Tier Model (FP-0022)" group and the "``python`` permission + ``mode: safe`` allowlist" group — it documents the meta-layer (= shape of declarations) that the FP-0022 op-tier table operates on.

## Three known gaps captured (= remediation deferred to separate PRs per user direction)

| Gap | What | Disposition |
|---|---|---|
| **A** | `mcp_install` / `mcp_drop_server` / `index_drop` / `cron_register` declare bool intent; their side-effect set (= `.reyn/` config writes) is reachable via `reyn.safe.file.write()` because `.reyn/` is a default-zone write path | Documented + remediation candidate (= cross-axis correlation gate) noted for future PR |
| **B** | `src/reyn/registry/client.py` MCP registry HTTP and `src/reyn/op_runtime/mcp_install.py` config writes bypass `PermissionResolver` | Deliberate trust-boundary choice; documented with re-open trigger |
| **C** | `src/reyn/safe/http.py` (= landed via FP-0042 Phase 3 drift-fix) has no per-call permission gate; "safe" here is AST-allowlist sense, not permission-resolver sense | Documented; the module's own docstring already references #571 as the design question to resolve |

## FP-0042 state snapshot

Verified at write-time that the FP-0042 cascade is **substantially complete** as of 2026-05-23:

- ✅ Phase 1: `reyn.safe` public namespace + permission-gated `safe.file`
- ✅ Phase 2.1 / 2.2 / 2.3 / 2.4 / 2.5 / 2.6 / 2.7 / 2.8: 8 stdlib skill migrations + ``index_docs apply_strategy`` retire (stdlib unsafe surface = 0)
- ✅ Phase 3: CI guard + docs doctrine + drift-fix migration (= ``reyn.safe.http`` / ``reyn.safe.mcp.registry`` / ``reyn.safe.cache`` landed)

This means stdlib's HTTP path has migrated to ``reyn.safe.http`` / ``reyn.safe.mcp.registry`` without a permission gate. The doc reflects this state in Gap C.

## Test plan

- [x] **Rootdir** verify: ``python -m pytest -q --tb=line --timeout=60 --deselect tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`` → 5400 passed (= no regressions; docs-only change), 5 skipped, 1 deselected, 3 xfailed
- [x] Markdown render manually inspected on both ``.md`` + ``.ja.md`` — new section flows cleanly between FP-0022 group and python-permission section
- [x] Cross-referenced facts against codebase at write time (= `permissions.py:120 PermissionDecl`, `preprocessor_executor.py:493-499` default-zone, `registry/client.py:135` httpx, `safe/http.py` docstring referencing #571, FP-0042 phase landing log)

## Closes (= documentation-side action item)

This PR is the **doc-only** half of #571 per user direction. The implementation-side remediation PRs (= Gap A correlation gate, Gap B disposition affirmation, Gap C per-host allowlist on ``safe.http``) are tracked as references in the doc, not bundled here.

Issue stays open for the implementation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)