### PR TITLE
feat(permissions): collapse arc Phase 2 — canonical-paths exception + compat shim (#571)

### DIFF
--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -484,6 +484,19 @@ class PreprocessorExecutor:
         # ``invoke_action(file__read)`` route would be granted by default.
         # Keeping the contract symmetric with the existing permission
         # model.
+        #
+        # #571 collapse arc Phase 2: ``reyn.safe.file._check_write``
+        # additionally enforces a canonical-protected-paths denylist
+        # (= ``.reyn/mcp.yaml`` / ``.reyn/cron.yaml`` /
+        # ``.reyn/index/sources.yaml``). Those paths are allowed through
+        # the broad ``.reyn/`` default zone here, but rejected by the
+        # safe.file gate unless the skill ALSO listed the path
+        # explicitly in ``permissions.file_write`` (which the bool-axis
+        # compat shim does automatically when ``mcp_install`` /
+        # ``cron_register`` / ``index_drop`` / ``mcp_drop_server`` is
+        # set). The narrow exception preserves the broad ``.reyn/``
+        # default for chunkers, cursors, and other workspace scratch
+        # state.
         import os as _os
         _cwd = _os.getcwd()
         file_read_paths = [_cwd] + [

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, ClassVar
 
 from reyn.intervention_choices import (
     ALWAYS,
@@ -54,6 +54,27 @@ if TYPE_CHECKING:
 
 _DEFAULT_WRITE_ZONES = (".reyn", "reyn")
 
+# #571 collapse arc Phase 2: canonical paths whose write is gated by a
+# specific op handler (= mcp_install / mcp_drop_server / cron_register /
+# index_drop) AND therefore must not be silently default-zone-allowed.
+# Skills that legitimately need to mutate these must declare them
+# explicitly via ``file.write: [{path: ...}]`` (or via the bool-axis
+# compat shim that auto-expands into the equivalent file.write entry —
+# see ``PermissionDecl._compat_expand_bool_axes``).
+#
+# Why exempt these specific paths only: they back capability that the
+# OS treats as a distinct event-emit + audit-trail surface (server
+# install / cron register / index drop). Letting any safe-mode python
+# step write them via the broad ``.reyn/`` default zone bypasses the
+# corresponding gate. The narrow exception preserves the broad
+# ``.reyn/`` write zone for everything else (= chunkers, cursors,
+# scratch state).
+_CANONICAL_PROTECTED_WRITE_PATHS = (
+    ".reyn/mcp.yaml",
+    ".reyn/cron.yaml",
+    ".reyn/index/sources.yaml",
+)
+
 
 def _normalize_paths(v: object) -> list[str]:
     if not v:
@@ -68,8 +89,28 @@ def _expand(path_str: str) -> Path:
     return Path(path_str).expanduser().resolve()
 
 
+def _is_canonical_protected_write(path_str: str) -> bool:
+    """Return True if ``path_str`` resolves to one of the #571 protected paths."""
+    base = Path.cwd()
+    p = Path(path_str).expanduser()
+    resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
+    for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
+        if resolved == (base / rel).resolve():
+            return True
+    return False
+
+
 def _in_default_write_zone(path_str: str) -> bool:
-    """Return True if path falls within a default-granted write zone (.reyn/ or reyn/)."""
+    """Return True if path falls within a default-granted write zone (.reyn/ or reyn/).
+
+    Exception: canonical paths gated by specific op handlers (#571
+    collapse arc Phase 2 — ``.reyn/mcp.yaml`` / ``.reyn/cron.yaml`` /
+    ``.reyn/index/sources.yaml``) return False here so the corresponding
+    skill / op handler is forced to declare the explicit ``file.write``
+    entry (= or the bool-axis compat shim expands to it).
+    """
+    if _is_canonical_protected_write(path_str):
+        return False
     base = Path.cwd()
     p = Path(path_str).expanduser()
     resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
@@ -194,11 +235,24 @@ class PermissionDecl:
             ))
         return out
 
+    # #571 collapse arc Phase 2: each bool axis maps to the canonical
+    # protected file.write path(s) it gates. The loader compat shim
+    # below expands any bool axis set to ``True`` into the equivalent
+    # ``file_write`` entry, so existing skills written before the
+    # collapse keep working while the bool form is being phased out
+    # (Phase 5 removes the bool axes entirely).
+    _BOOL_AXIS_TO_FILE_WRITE: ClassVar[dict[str, tuple[str, ...]]] = {
+        "mcp_install":     (".reyn/mcp.yaml",),
+        "mcp_drop_server": (".reyn/mcp.yaml",),
+        "cron_register":   (".reyn/cron.yaml",),
+        "index_drop":      (".reyn/index/sources.yaml",),
+    }
+
     @classmethod
     def from_dict(cls, d: dict | None) -> "PermissionDecl":
         if not d:
             return cls()
-        return cls(
+        decl = cls(
             shell=bool(d.get("shell", False)),
             mcp=_normalize_paths(d.get("mcp")),
             tool=_normalize_paths(d.get("tool")),
@@ -210,6 +264,27 @@ class PermissionDecl:
             mcp_drop_server=bool(d.get("mcp_drop_server", False)),
             cron_register=bool(d.get("cron_register", False)),
         )
+        decl._compat_expand_bool_axes()
+        return decl
+
+    def _compat_expand_bool_axes(self) -> None:
+        """Expand each set bool axis into the equivalent ``file_write`` entry.
+
+        Idempotent and additive: paths already present in ``file_write``
+        are not duplicated; explicit entries with a different scope are
+        kept as-is. The expansion runs once at load time; bool axis
+        fields stay set so ``require_mcp_install`` / etc. continue to
+        gate the op route until they are removed in Phase 5.
+        """
+        existing = {entry.get("path") for entry in self.file_write if isinstance(entry, dict)}
+        for axis, paths in self._BOOL_AXIS_TO_FILE_WRITE.items():
+            if not getattr(self, axis, False):
+                continue
+            for p in paths:
+                if p in existing:
+                    continue
+                self.file_write.append({"path": p, "scope": "just_path"})
+                existing.add(p)
 
 
 class PermissionResolver:
@@ -553,10 +628,24 @@ class PermissionResolver:
         read_seen: set[tuple] = set()
 
         decl = skill.permissions  # aggregated upper bound across all phases
+        # #571 collapse arc Phase 2: file.write entries that the compat
+        # shim auto-expanded from a still-set bool axis (mcp_install /
+        # mcp_drop_server / cron_register / index_drop) are skipped from
+        # the startup_guard prompt — the bool axis's per-op prompt
+        # already covers operator consent at op-execution time, so
+        # prompting again at startup is redundant double-confirmation.
+        # Skills that declared the explicit ``file.write`` entry
+        # WITHOUT a corresponding bool axis still get the normal prompt.
+        canonical_skip: set[str] = set()
+        for axis, paths in PermissionDecl._BOOL_AXIS_TO_FILE_WRITE.items():
+            if getattr(decl, axis, False):
+                canonical_skip.update(paths)
         for entry in decl.file_write:
             path = entry.get("path", "")
             scope = entry.get("scope", "just_path")
             if not path:
+                continue
+            if path in canonical_skip:
                 continue
             if _in_default_write_zone(path):
                 continue

--- a/src/reyn/safe/file.py
+++ b/src/reyn/safe/file.py
@@ -70,6 +70,24 @@ _read_paths: tuple[str, ...] = ()
 _write_paths: tuple[str, ...] = ()
 _context_initialised: bool = False
 
+# #571 collapse arc Phase 2: canonical paths whose write must go through
+# a specific op handler (= mcp_install / mcp_drop_server / cron_register
+# / index_drop). Listing one of these in ``_write_paths`` via a parent
+# directory (e.g. ``.reyn/``) is no longer enough; the path must appear
+# in ``_write_paths`` *exactly* (= via an explicit ``file.write: [{path:
+# ...}]`` decl, or via the bool-axis compat shim that auto-expands to
+# the same entry).
+#
+# Mirrors ``reyn.permissions.permissions._CANONICAL_PROTECTED_WRITE_PATHS``
+# — keep the two lists in sync. They live in two modules because this
+# one runs in the python-harness subprocess where importing the parent's
+# permissions module is not always available.
+_CANONICAL_PROTECTED_WRITE_PATHS = (
+    ".reyn/mcp.yaml",
+    ".reyn/cron.yaml",
+    ".reyn/index/sources.yaml",
+)
+
 
 def _set_permission_context(
     *,
@@ -139,12 +157,58 @@ def _check_read(path: str) -> None:
         )
 
 
+def _is_canonical_protected_write(path: str) -> bool:
+    """Return True if ``path`` resolves to one of the #571 protected paths.
+
+    These paths are normally writable via the broad ``.reyn/`` default
+    zone, but the collapse-arc Phase 2 carve-out requires they be listed
+    explicitly in ``_write_paths`` (not via a parent-directory prefix).
+    """
+    abs_path = _os.path.abspath(path)
+    cwd = _os.getcwd()
+    for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
+        if abs_path == _os.path.abspath(_os.path.join(cwd, rel)):
+            return True
+    return False
+
+
+def _is_explicitly_listed(path: str, allowed: tuple[str, ...]) -> bool:
+    """Return True iff ``path`` exactly matches one of ``allowed`` entries.
+
+    Stricter than :func:`_is_under` — does not accept parent-directory
+    prefix matches. Used to enforce the #571 protected-paths exception.
+    """
+    abs_path = _os.path.abspath(path)
+    for entry in allowed:
+        if entry and abs_path == _os.path.abspath(entry):
+            return True
+    return False
+
+
 def _check_write(path: str) -> None:
     if not _context_initialised:
         raise PermissionError(
             "reyn.safe.file: permission context not initialised "
             f"(write attempted: {path!r})."
         )
+    # #571 collapse arc Phase 2: canonical protected paths require an
+    # explicit listing (= not the broad ``.reyn/`` parent-dir match).
+    if _is_canonical_protected_write(path):
+        if not _is_explicitly_listed(path, _write_paths):
+            raise PermissionError(
+                f"reyn.safe.file: write to {path!r} requires an explicit "
+                f"declaration — this is a canonical protected path "
+                f"(#571) and is not covered by the broad ``.reyn/`` "
+                f"default write zone. Declare it directly:\n"
+                f"  permissions:\n"
+                f"    file.write:\n"
+                f"      - path: {path}\n"
+                f"        scope: just_path\n"
+                f"(or use the corresponding bool axis — `mcp_install` / "
+                f"`mcp_drop_server` / `cron_register` / `index_drop` — "
+                f"which auto-expands to the same explicit entry.)"
+            )
+        return
     if not _is_under(path, _write_paths):
         raise PermissionError(
             f"reyn.safe.file: write to {path!r} is not in the declared "

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -24,13 +24,12 @@ from pathlib import Path
 import pytest
 
 from reyn.permissions.permissions import (
+    _CANONICAL_PROTECTED_WRITE_PATHS,
     PermissionDecl,
     PermissionResolver,
-    _CANONICAL_PROTECTED_WRITE_PATHS,
     _in_default_write_zone,
     _is_canonical_protected_write,
 )
-
 
 # ── default-zone exception ─────────────────────────────────────────────────────
 

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -1,0 +1,242 @@
+"""Tier 2: #571 collapse arc Phase 2 — canonical-paths exception + compat shim.
+
+Verifies the OS-invariants introduced by Phase 2:
+
+1. The three canonical protected paths (.reyn/mcp.yaml / .reyn/cron.yaml /
+   .reyn/index/sources.yaml) are excepted from the broad `.reyn/`
+   default write zone — direct `safe.file.write` to them requires an
+   explicit `file.write: [{path: ...}]` declaration.
+2. The bool-axis compat shim in `PermissionDecl.from_dict` expands each
+   set bool axis (mcp_install / mcp_drop_server / cron_register /
+   index_drop) into the equivalent `file.write` entry, so existing
+   skills written before the collapse keep working through `require_file_write`.
+3. Non-canonical paths under `.reyn/` (= chunkers, cursors, scratch
+   state) are unaffected — the broad default zone still covers them.
+
+Tier policy: these are OS-invariant tests pinning the contract between
+the permission resolver and `reyn.safe.file`. They use real
+PermissionResolver instances + the real safe.file module — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.permissions import (
+    PermissionDecl,
+    PermissionResolver,
+    _CANONICAL_PROTECTED_WRITE_PATHS,
+    _in_default_write_zone,
+    _is_canonical_protected_write,
+)
+
+
+# ── default-zone exception ─────────────────────────────────────────────────────
+
+
+def test_canonical_protected_paths_excepted_from_default_zone(tmp_path, monkeypatch):
+    """Tier 2: the 3 canonical paths return False from _in_default_write_zone."""
+    monkeypatch.chdir(tmp_path)
+    for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
+        assert _in_default_write_zone(rel) is False, (
+            f"{rel!r} should be excepted from the default write zone (Gap A)"
+        )
+        assert _is_canonical_protected_write(rel) is True
+
+
+def test_other_reyn_paths_still_in_default_zone(tmp_path, monkeypatch):
+    """Tier 2: chunker / cursor / scratch paths under .reyn/ still default-allowed."""
+    monkeypatch.chdir(tmp_path)
+    for rel in (
+        ".reyn/index/events_cursor",
+        ".reyn/index/chunks.jsonl",
+        ".reyn/approvals.yaml",
+        ".reyn/events.jsonl",
+        ".reyn/scratch/anything.txt",
+        "reyn/local/whatever.py",
+    ):
+        assert _in_default_write_zone(rel) is True, (
+            f"{rel!r} should remain in the default write zone (non-canonical)"
+        )
+        assert _is_canonical_protected_write(rel) is False
+
+
+def test_require_file_write_rejects_canonical_without_decl(tmp_path, monkeypatch):
+    """Tier 2: require_file_write raises for protected path without explicit decl."""
+    monkeypatch.chdir(tmp_path)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl()  # no axes set
+    with pytest.raises(PermissionError, match="was not approved"):
+        resolver.require_file_write(decl, ".reyn/mcp.yaml", "skill_x")
+
+
+def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, monkeypatch):
+    """Tier 2: require_file_write passes when path was approved at startup_guard time.
+
+    Phase 2 does not change require_file_write semantics — declaration alone
+    does NOT pass; operator must approve (via startup_guard or persisted
+    approval). This test simulates the post-startup-guard state.
+    """
+    monkeypatch.chdir(tmp_path)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(file_write=[{"path": ".reyn/mcp.yaml", "scope": "just_path"}])
+    resolver.session_approve_path(".reyn/mcp.yaml", "skill_x", "file.write")
+    # Should not raise — startup_guard's session approval covers the path.
+    resolver.require_file_write(decl, ".reyn/mcp.yaml", "skill_x")
+
+
+# ── compat shim ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "axis,expected_path",
+    [
+        ("mcp_install",     ".reyn/mcp.yaml"),
+        ("mcp_drop_server", ".reyn/mcp.yaml"),
+        ("cron_register",   ".reyn/cron.yaml"),
+        ("index_drop",      ".reyn/index/sources.yaml"),
+    ],
+)
+def test_bool_axis_compat_shim_expands_to_file_write(axis, expected_path):
+    """Tier 2: setting a bool axis via from_dict auto-adds the canonical file.write entry."""
+    decl = PermissionDecl.from_dict({axis: True})
+    assert getattr(decl, axis) is True, f"bool axis {axis} should remain set"
+    paths = {entry.get("path") for entry in decl.file_write if isinstance(entry, dict)}
+    assert expected_path in paths, (
+        f"compat shim should have added {expected_path!r} to file_write for {axis}"
+    )
+
+
+def test_compat_shim_does_not_duplicate_explicit_entry():
+    """Tier 2: explicit file.write of a canonical path is not duplicated by the shim."""
+    decl = PermissionDecl.from_dict({
+        "mcp_install": True,
+        "file.write": [{"path": ".reyn/mcp.yaml", "scope": "just_path"}],
+    })
+    matching = [e for e in decl.file_write if e.get("path") == ".reyn/mcp.yaml"]
+    assert len(matching) == 1, "explicit + implicit should de-duplicate to a single entry"
+
+
+def test_compat_shim_no_bool_axis_no_implicit_entries():
+    """Tier 2: when no bool axis is set, file_write only contains explicit entries."""
+    decl = PermissionDecl.from_dict({
+        "file.write": [{"path": "/tmp/x", "scope": "just_path"}],
+    })
+    paths = {entry.get("path") for entry in decl.file_write if isinstance(entry, dict)}
+    assert paths == {"/tmp/x"}
+    for canonical in _CANONICAL_PROTECTED_WRITE_PATHS:
+        assert canonical not in paths
+
+
+def test_startup_guard_skips_canonical_when_bool_axis_set(tmp_path, monkeypatch):
+    """Tier 2: startup_guard does not prompt for canonical paths when the bool axis is set.
+
+    Avoids double-prompting: operator already approves the operation via
+    the bool axis's per-op prompt at op-execution time, so prompting again
+    at startup for the equivalent ``file.write`` entry would be redundant.
+    """
+    monkeypatch.chdir(tmp_path)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl.from_dict({"mcp_install": True})
+
+    # The compat shim populated decl.file_write with the canonical path.
+    assert any(
+        e.get("path") == ".reyn/mcp.yaml" for e in decl.file_write
+    ), "compat shim should add the canonical file.write entry"
+
+    # Walk the startup_guard prompt-collection logic directly: build the
+    # set of paths that would be prompted, and verify the canonical
+    # entry is skipped.
+    from reyn.permissions.permissions import _in_default_write_zone
+    canonical_skip = set()
+    for axis, paths in PermissionDecl._BOOL_AXIS_TO_FILE_WRITE.items():
+        if getattr(decl, axis, False):
+            canonical_skip.update(paths)
+    prompt_paths = [
+        entry["path"]
+        for entry in decl.file_write
+        if entry.get("path")
+        and entry["path"] not in canonical_skip
+        and not _in_default_write_zone(entry["path"])
+        and not resolver._is_path_approved_for(entry["path"], "skill_x", "file.write")
+    ]
+    assert ".reyn/mcp.yaml" not in prompt_paths, (
+        "canonical-with-bool-axis path should be skipped from startup prompts"
+    )
+
+
+def test_startup_guard_still_prompts_canonical_without_bool_axis(tmp_path, monkeypatch):
+    """Tier 2: startup_guard DOES prompt for canonical paths declared explicitly without bool axis."""
+    monkeypatch.chdir(tmp_path)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    # Explicit file.write without the bool axis.
+    decl = PermissionDecl.from_dict({
+        "file.write": [{"path": ".reyn/mcp.yaml", "scope": "just_path"}],
+    })
+    assert decl.mcp_install is False
+
+    from reyn.permissions.permissions import _in_default_write_zone
+    canonical_skip = set()
+    for axis, paths in PermissionDecl._BOOL_AXIS_TO_FILE_WRITE.items():
+        if getattr(decl, axis, False):
+            canonical_skip.update(paths)
+    prompt_paths = [
+        entry["path"]
+        for entry in decl.file_write
+        if entry.get("path")
+        and entry["path"] not in canonical_skip
+        and not _in_default_write_zone(entry["path"])
+        and not resolver._is_path_approved_for(entry["path"], "skill_x", "file.write")
+    ]
+    assert ".reyn/mcp.yaml" in prompt_paths, (
+        "explicit-only declaration (no bool axis) should still prompt at startup"
+    )
+
+
+# ── reyn.safe.file enforcement ────────────────────────────────────────────────
+
+
+def test_safe_file_check_write_rejects_canonical_via_parent_dir(tmp_path, monkeypatch):
+    """Tier 2: safe.file._check_write rejects a canonical path covered only by parent dir."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.safe import file as safe_file
+
+    # Simulate the preprocessor_executor wiring: .reyn/ in write_paths via prefix.
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
+    )
+    with pytest.raises(PermissionError, match="canonical protected path"):
+        safe_file._check_write(str(tmp_path / ".reyn" / "mcp.yaml"))
+
+
+def test_safe_file_check_write_accepts_canonical_via_explicit_path(tmp_path, monkeypatch):
+    """Tier 2: safe.file._check_write accepts canonical path when listed explicitly."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[
+            str(tmp_path / ".reyn"),
+            str(tmp_path / "reyn"),
+            str(tmp_path / ".reyn" / "mcp.yaml"),  # explicit
+        ],
+    )
+    # Should not raise.
+    safe_file._check_write(str(tmp_path / ".reyn" / "mcp.yaml"))
+
+
+def test_safe_file_check_write_still_allows_non_canonical_under_reyn(tmp_path, monkeypatch):
+    """Tier 2: non-canonical .reyn/ paths still pass via the broad default zone."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
+    )
+    # Cursor file under .reyn/index/ but NOT sources.yaml → still allowed.
+    safe_file._check_write(str(tmp_path / ".reyn" / "index" / "events_cursor"))
+    safe_file._check_write(str(tmp_path / ".reyn" / "approvals.yaml"))


### PR DESCRIPTION
**[e2e-coder]** — #571 collapse arc Phase 2 (= Gap A closure + collapse foundation).

## Summary

Closes Gap A from the #571 collapse arc: safe-mode python steps can no longer bypass the four bool-axis gates (`mcp_install` / `mcp_drop_server` / `cron_register` / `index_drop`) by writing the canonical `.reyn/*.yaml` files directly via the broad `.reyn/` default write zone.

## Changes

1. **`_in_default_write_zone` exception** for 3 canonical protected paths (`.reyn/mcp.yaml`, `.reyn/cron.yaml`, `.reyn/index/sources.yaml`). Writes must come from explicit `file.write` declaration or the compat shim.
2. **`reyn.safe.file._check_write` subprocess enforcement** — canonical paths covered only by the broad `.reyn/` parent-dir prefix are rejected with a clear message pointing to the explicit decl or the corresponding bool axis.
3. **`PermissionDecl.from_dict` compat shim** — each set bool axis auto-populates the equivalent `file.write` entry. Idempotent; existing entries not duplicated. Bool axis fields stay set so `require_mcp_install` / etc. continue to gate the op route through Phases 2-4.
4. **`startup_guard` skip** for canonical paths when the corresponding bool axis is set — avoids double-prompting (= the bool axis's per-op prompt already collects operator consent at op-execution time). Explicit-only declarations still prompt normally.

## Scope

Phase 5 work (= remove bool axes, route op handlers through `require_file_write`) is deferred. The current bool axes still serve as the op-route gate; adding `require_file_write` to op handlers in Phase 2 would re-introduce the same double-prompt issue this PR's startup_guard skip is fixing.

| Phase | Status |
|---|---|
| 1 — Doc rewrite | merged (PR #613) |
| **2 — Default-zone exception + compat shim + startup_guard skip** | **this PR** |
| 3 — `http.get` / `secret.write` axes new | follow-up |
| 4 — stdlib migration to explicit list-axis form | follow-up |
| 5 — Remove bool axes + route op handlers through `require_file_write` | follow-up |

## Test plan

- [x] `pytest -q` from rootdir → 5459 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`, unrelated, reproduces on main)
- [x] New test file `tests/test_permission_collapse_phase2.py` covers:
  - canonical paths excepted from default zone (positive + negative cases)
  - compat shim expansion per bool axis (parametrized 4 cases)
  - compat shim idempotence (explicit + implicit deduplicate)
  - `safe.file._check_write` rejects canonical via parent-dir prefix
  - `safe.file._check_write` accepts canonical via explicit listing
  - non-canonical `.reyn/` paths still default-allowed (chunkers / cursors / scratch state)
  - `startup_guard` skips canonical when bool axis set
  - `startup_guard` still prompts explicit-only canonical declaration
- [x] Existing `mcp_install` / `cron_register` / `index_drop` tests pass without modification (= compat shim backward-compat verified)

Refs #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)