### PR TITLE
feat(permissions): collapse arc Phase 3 — http.get axis + safe.http per-host gate (#571)

### DIFF
--- a/src/reyn/kernel/_python_harness.py
+++ b/src/reyn/kernel/_python_harness.py
@@ -192,6 +192,9 @@ def main() -> int:
         # ``reyn.safe.file.*`` call from the user step.
         file_read_paths = list(req.get("file_read_paths") or [])
         file_write_paths = list(req.get("file_write_paths") or [])
+        # #571 collapse arc Phase 3: host allowlist for reyn.safe.http
+        # gating. Empty = no HTTP via safe.http.
+        http_hosts = list(req.get("http_hosts") or [])
 
         if mode not in ("safe", "unsafe"):
             raise ValueError(f"unknown mode: {mode!r}")
@@ -222,6 +225,15 @@ def main() -> int:
             # reyn.safe.file may not be available in older parent
             # installations (= shouldn't happen post-FP-0042 land but
             # defence-in-depth for parent / harness version skew).
+            pass
+
+        # #571 collapse arc Phase 3: initialise reyn.safe.http's host
+        # allowlist before the user step runs. Mirrors the file-context
+        # wiring above.
+        try:
+            from reyn.safe import http as _safe_http
+            _safe_http._set_permission_context(http_hosts=http_hosts)
+        except ImportError:
             pass
 
         # Defensive copy so user mutations don't affect the parent's data.

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -510,6 +510,14 @@ class PreprocessorExecutor:
             entry["path"] for entry in self._skill.permissions.file_write
             if isinstance(entry, dict) and entry.get("path")
         ]
+        # #571 collapse arc Phase 3: forward the skill's declared http.get
+        # host allowlist into the subprocess so ``reyn.safe.http.*`` calls
+        # gate against it. Empty list = no HTTP allowed via safe.http
+        # (web_fetch's Tier-1 path is unaffected — separate surface).
+        http_hosts = [
+            entry["host"] for entry in self._skill.permissions.http_get
+            if isinstance(entry, dict) and entry.get("host")
+        ]
 
         try:
             result = await asyncio.to_thread(
@@ -523,6 +531,7 @@ class PreprocessorExecutor:
                 allowed_modules=self._python_allowed_modules,
                 file_read_paths=file_read_paths,
                 file_write_paths=file_write_paths,
+                http_hosts=http_hosts,
             )
         except PythonStepError as exc:
             self._events.emit(

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -192,6 +192,20 @@ class PermissionDecl:
     # rejects immediately. Covers register / unregister / enable /
     # disable on the LLM-callable ``cron`` action category.
     cron_register: bool = False
+    # #571 collapse arc Phase 3: per-host HTTP allowlist for
+    # ``reyn.safe.http.*`` calls from safe-mode python steps. Each
+    # entry: {"host": str}. Empty list = no HTTP allowed via safe.http
+    # (the ``web_fetch`` Tier-1 op route is unaffected — that's a
+    # separate, LLM-callable surface with its own approval flow).
+    http_get: list[dict] = field(default_factory=list)
+    # #571 collapse arc Phase 3: per-key secret-store write allowlist
+    # for ``~/.reyn/secrets.env`` writes. Each entry is a key name
+    # (env var name). Declared here so the axis exists in the schema
+    # and the compat shim can wire mcp_install secret prompts to it;
+    # actual enforcement at the ``reyn.secrets.store.save_secret``
+    # boundary is a Phase 5 task (= op handlers route through
+    # ``require_secret_write`` when bool axes are removed).
+    secret_write: list[str] = field(default_factory=list)
 
     @staticmethod
     def _parse_path_list(raw: object) -> list[dict]:
@@ -209,6 +223,41 @@ class PermissionDecl:
                     "scope": str(item.get("scope", "just_path")),
                 })
         return out
+
+    @staticmethod
+    def _parse_host_list(raw: object) -> list[dict]:
+        """Parse a ``http.get`` list. Accepts ``[{host: str}]`` or ``[str]``.
+
+        A bare string is normalised to ``{"host": <str>}``. Empty / non-list
+        / non-dict / non-string entries are dropped silently — same lenient
+        shape as ``_parse_path_list``.
+        """
+        if not raw:
+            return []
+        if not isinstance(raw, list):
+            raw = [raw]
+        out: list[dict] = []
+        for item in raw:
+            if isinstance(item, str):
+                out.append({"host": item})
+            elif isinstance(item, dict):
+                host = str(item.get("host", ""))
+                if host:
+                    out.append({"host": host})
+        return out
+
+    @staticmethod
+    def _parse_secret_key_list(raw: object) -> list[str]:
+        """Parse a ``secret.write`` list of key names.
+
+        Accepts ``list[str]`` or a bare ``str`` (normalised to a single-item
+        list). Non-string entries are dropped silently.
+        """
+        if not raw:
+            return []
+        if not isinstance(raw, list):
+            raw = [raw]
+        return [str(item) for item in raw if isinstance(item, (str, int))]
 
     @staticmethod
     def _parse_python_list(raw: object) -> list[PythonPermission]:
@@ -248,6 +297,16 @@ class PermissionDecl:
         "index_drop":      (".reyn/index/sources.yaml",),
     }
 
+    # #571 collapse arc Phase 3: each bool axis also gates a set of
+    # HTTP hosts (= the registry the bool-axis op talks to). The compat
+    # shim expands these into the equivalent ``http_get`` entries so
+    # bool-axis decls continue to authorise the op handler's HTTP
+    # traffic without needing an explicit ``http.get`` declaration. The
+    # actual ``reyn.safe.http`` gate is wired against ``http_get``.
+    _BOOL_AXIS_TO_HTTP_GET: ClassVar[dict[str, tuple[str, ...]]] = {
+        "mcp_install": ("registry.modelcontextprotocol.io",),
+    }
+
     @classmethod
     def from_dict(cls, d: dict | None) -> "PermissionDecl":
         if not d:
@@ -263,28 +322,57 @@ class PermissionDecl:
             index_drop=bool(d.get("index_drop", False)),
             mcp_drop_server=bool(d.get("mcp_drop_server", False)),
             cron_register=bool(d.get("cron_register", False)),
+            http_get=cls._parse_host_list(d.get("http.get")),
+            secret_write=cls._parse_secret_key_list(d.get("secret.write")),
         )
         decl._compat_expand_bool_axes()
         return decl
 
     def _compat_expand_bool_axes(self) -> None:
-        """Expand each set bool axis into the equivalent ``file_write`` entry.
+        """Expand each set bool axis into the equivalent list-axis entries.
 
-        Idempotent and additive: paths already present in ``file_write``
-        are not duplicated; explicit entries with a different scope are
-        kept as-is. The expansion runs once at load time; bool axis
-        fields stay set so ``require_mcp_install`` / etc. continue to
-        gate the op route until they are removed in Phase 5.
+        Idempotent and additive: entries already present are not
+        duplicated; explicit entries with different metadata are kept
+        as-is. The expansion runs once at load time; bool axis fields
+        stay set so ``require_mcp_install`` / etc. continue to gate the
+        op route until they are removed in Phase 5.
+
+        Two cross-cutting expansions:
+          - ``_BOOL_AXIS_TO_FILE_WRITE``: bool → ``file_write`` entries
+            (Phase 2, canonical ``.reyn/*.yaml`` config writes).
+          - ``_BOOL_AXIS_TO_HTTP_GET``: bool → ``http_get`` entries
+            (Phase 3, the registry host the op talks to).
+
+        ``secret_write`` is NOT auto-expanded — the env-var keys the op
+        will save are determined at runtime from the registry response,
+        not statically by the skill author, so there is no useful
+        compat-shim mapping. Skills that need explicit secret-write
+        authorisation declare it manually.
         """
-        existing = {entry.get("path") for entry in self.file_write if isinstance(entry, dict)}
+        # file.write expansion (Phase 2).
+        existing_writes = {
+            entry.get("path") for entry in self.file_write if isinstance(entry, dict)
+        }
         for axis, paths in self._BOOL_AXIS_TO_FILE_WRITE.items():
             if not getattr(self, axis, False):
                 continue
             for p in paths:
-                if p in existing:
+                if p in existing_writes:
                     continue
                 self.file_write.append({"path": p, "scope": "just_path"})
-                existing.add(p)
+                existing_writes.add(p)
+        # http.get expansion (Phase 3).
+        existing_hosts = {
+            entry.get("host") for entry in self.http_get if isinstance(entry, dict)
+        }
+        for axis, hosts in self._BOOL_AXIS_TO_HTTP_GET.items():
+            if not getattr(self, axis, False):
+                continue
+            for h in hosts:
+                if h in existing_hosts:
+                    continue
+                self.http_get.append({"host": h})
+                existing_hosts.add(h)
 
 
 class PermissionResolver:
@@ -838,6 +926,56 @@ class PermissionResolver:
             f"      - path: {path}\n"
             f"        scope: just_path\n"
             f"Then re-run — the startup guard will ask for approval before execution starts."
+        )
+
+    def require_http_get(
+        self, decl: PermissionDecl, host: str, skill_name: str = "",
+    ) -> None:
+        """Raise PermissionError if HTTP access to ``host`` is not declared.
+
+        #571 collapse arc Phase 3: gates ``reyn.safe.http.*`` calls from
+        safe-mode python steps. Skills declare hosts in their
+        ``permissions.http.get: [{host: "..."}]`` block (or via the bool
+        axis compat shim, which auto-expands ``mcp_install: true`` to
+        include the registry host).
+
+        Sync, no prompt — the declaration IS the authorisation at this
+        layer. Operator-level pre-approval / startup_guard prompts for
+        HTTP are not in scope for Phase 3 (the bool-axis op route still
+        carries the operator confirmation in transitional phases).
+        """
+        for entry in decl.http_get:
+            if isinstance(entry, dict) and entry.get("host") == host:
+                return
+        raise PermissionError(
+            f"HTTP access to host {host!r} not declared in skill permissions. "
+            f"Add to skill.md frontmatter:\n"
+            f"  permissions:\n"
+            f"    http.get:\n"
+            f"      - host: {host}\n"
+        )
+
+    def require_secret_write(
+        self, decl: PermissionDecl, key: str, skill_name: str = "",
+    ) -> None:
+        """Raise PermissionError if secret-store write of ``key`` is not declared.
+
+        #571 collapse arc Phase 3: axis declaration + resolver method.
+        Callers (= ``reyn.secrets.store.save_secret`` from op handlers)
+        are wired in Phase 5 when bool axes are removed and op handlers
+        route through this gate instead of their dedicated bool-axis
+        ``require_*`` methods. For Phase 3 / 4 this method exists so
+        the schema, parsing, and downstream config wiring can land
+        ahead of the op-handler migration.
+        """
+        if key in decl.secret_write:
+            return
+        raise PermissionError(
+            f"Secret-store write of key {key!r} not declared in skill permissions. "
+            f"Add to skill.md frontmatter:\n"
+            f"  permissions:\n"
+            f"    secret.write:\n"
+            f"      - {key}\n"
         )
 
     def is_read_allowed(self, path: str, skill_name: str = "") -> bool:

--- a/src/reyn/python_runner.py
+++ b/src/reyn/python_runner.py
@@ -86,6 +86,7 @@ class PythonRunner:
         allowed_modules: list[str] | None = None,
         file_read_paths: list[str] | None = None,
         file_write_paths: list[str] | None = None,
+        http_hosts: list[str] | None = None,
     ) -> Any:
         """Execute `function` in `module` against `artifact`.
 
@@ -99,6 +100,10 @@ class PythonRunner:
         ``reyn.safe.file.*`` calls inside the step can gate against
         them. Both default to empty (= no file access granted) — pass
         the absolute paths the parent has approved for this step.
+
+        #571 collapse arc Phase 3: ``http_hosts`` mirrors the same wiring
+        for ``reyn.safe.http.*`` per-host gating. Empty = no HTTP via
+        safe.http.
         """
         module_abs = _resolve_module_path(skill_dir, module)
 
@@ -111,6 +116,8 @@ class PythonRunner:
             # FP-0042: file-permission paths for reyn.safe.file gating.
             "file_read_paths": list(file_read_paths or []),
             "file_write_paths": list(file_write_paths or []),
+            # #571 Phase 3: host allowlist for reyn.safe.http gating.
+            "http_hosts": list(http_hosts or []),
         }
 
         try:

--- a/src/reyn/safe/http.py
+++ b/src/reyn/safe/http.py
@@ -1,34 +1,25 @@
-"""Safe-mode HTTP for stdlib skills (FP-0042 Phase 3 drift-fix).
+"""Safe-mode HTTP for stdlib skills.
 
 Exposes the same ``get`` / ``post`` / ``put`` / ``delete`` surface as
 ``reyn.api.unsafe.http`` (= ``urllib.request``-backed, no extra deps),
 but in the ``reyn.safe.*`` namespace so safe-mode python steps can
 import it through the AST allowlist.
 
-Threat model + permission rationale
------------------------------------
+Permission model (#571 Phase 3)
+-------------------------------
 
-This module has **no per-call permission gate**. The "safe" label here
-matches the namespace's role (= AST-allowlisted, callable from safe-mode
-code) rather than the stronger per-call permission-resolver pattern
-that :mod:`reyn.safe.file` enforces.
+Each call is gated against the calling skill's declared host allowlist
+(``permissions.http.get: [{host: "..."}]``). The host is parsed from
+the URL and checked at every method entry; an unauthorised host raises
+``PermissionError`` and the safe-mode step fails with a structured
+error. Bool axes that cover an HTTP host (= ``mcp_install: true`` for
+the MCP registry) auto-expand to the equivalent ``http.get`` entry via
+the ``PermissionDecl.from_dict`` compat shim, so existing bool-decl
+skills keep working without an explicit ``http.get`` declaration.
 
-This is the pragmatic landing point for the cascade of FP-0042 Phase
-3-class skills that fetch from public registries (= ``mcp_install`` /
-``mcp_search`` already use the domain-specific
-:mod:`reyn.safe.mcp.registry`; this module covers the broader
-``skill_search`` + ``skill_importer`` family that fetches from GitHub
-raw / Contents endpoints).
-
-The architectural decision on **whether** HTTP needs a permission gate
-(and what shape it should take — bool flag, host allowlist, capability
-axis) is captured at `Issue #571
-<https://github.com/tya5/reyn/issues/571>`_ ("Permission model:
-granularity decomposition vs abstraction granularity"). When that
-discussion lands, this module's surface should be revisited; until
-then, ``reyn.safe.http`` is operationally equivalent to
-``reyn.api.unsafe.http`` (same urllib wiring, same envelope shape) and
-exists only to keep stdlib skills inside the safe-mode AST allowlist.
+Mirrors :mod:`reyn.safe.file`'s permission-context contract: the
+parent process configures the allowlist via :func:`_set_permission_context`
+before the user step runs; the python harness wires that.
 
 Internal layering
 -----------------
@@ -50,8 +41,61 @@ from __future__ import annotations
 import json as _json
 from typing import Any
 from urllib.error import HTTPError as _HTTPError
+from urllib.parse import urlparse as _urlparse
 from urllib.request import Request as _Request
 from urllib.request import urlopen as _urlopen
+
+# ── Internal state ─────────────────────────────────────────────────────────
+#
+# Set once at python harness start-up via :func:`_set_permission_context`.
+# Used by :func:`_check_host` to gate every outbound call. Mirrors
+# ``reyn.safe.file``'s module-globals contract.
+
+_allowed_hosts: tuple[str, ...] = ()
+_context_initialised: bool = False
+
+
+def _set_permission_context(
+    *,
+    http_hosts: list[str] | tuple[str, ...] | None = None,
+) -> None:
+    """Wire the host allowlist into this module.
+
+    Called by :mod:`reyn.kernel._python_harness` before the user step
+    runs. Tests that exercise the http API directly may call this to
+    establish a controlled context; production code should not.
+
+    Idempotent — calling this overwrites the previous context. Passing
+    ``None`` or an empty list leaves the allowlist empty, meaning every
+    HTTP call is rejected.
+    """
+    global _allowed_hosts, _context_initialised
+    _allowed_hosts = tuple(http_hosts or ())
+    _context_initialised = True
+
+
+def _check_host(url: str) -> None:
+    """Raise PermissionError if ``url``'s host is not in the allowlist."""
+    if not _context_initialised:
+        raise PermissionError(
+            "reyn.safe.http: permission context not initialised. This "
+            "module must be invoked from a PythonRunner-managed safe-mode "
+            "step; bare-process use requires calling "
+            "_set_permission_context(http_hosts=[...]) first "
+            f"(request attempted: {url!r})."
+        )
+    parsed = _urlparse(url)
+    host = parsed.hostname or ""
+    if host in _allowed_hosts:
+        return
+    raise PermissionError(
+        f"reyn.safe.http: request to host {host!r} (url={url!r}) is not "
+        f"in the declared http_hosts {list(_allowed_hosts)}. Declare it "
+        f"in skill.md frontmatter:\n"
+        f"  permissions:\n"
+        f"    http.get:\n"
+        f"      - host: {host}\n"
+    )
 
 
 def _response_dict(resp: Any) -> dict:
@@ -74,6 +118,7 @@ def _request(
     headers: dict[str, str] | None = None,
     timeout: float = 30,
 ) -> dict:
+    _check_host(url)
     data: bytes | None = None
     hdrs: dict[str, str] = dict(headers or {})
     if body is not None:

--- a/src/reyn/stdlib/skills/skill_importer/skill.md
+++ b/src/reyn/stdlib/skills/skill_importer/skill.md
@@ -25,11 +25,11 @@ permissions:
       scope: recursive
   python:
     # FP-0042 Phase 3 drift-fix (2026-05-23): migrated from mode: unsafe
-    # to mode: safe via reyn.safe.http (= urllib-backed; no per-call
-    # permission gate, see Issue #571 for the deferred gate-design
-    # discussion). The GitHub raw + Contents API fetches stay
-    # structurally identical, only the import path moved into the
-    # safe-mode-callable namespace.
+    # to mode: safe via reyn.safe.http (= urllib-backed). #571 collapse
+    # arc Phase 3 (2026-05-23) added per-host gating on reyn.safe.http;
+    # this skill explicitly declares the two GitHub hosts it fetches
+    # from (raw.githubusercontent.com for skill source, api.github.com
+    # for the Contents API sibling listing).
     - module: ./detect_reference_format.py
       function: detect
       mode: safe
@@ -38,6 +38,9 @@ permissions:
       function: fetch
       mode: safe
       timeout: 60
+  http.get:
+    - host: api.github.com
+    - host: raw.githubusercontent.com
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 routing:

--- a/src/reyn/stdlib/skills/skill_search/skill.md
+++ b/src/reyn/stdlib/skills/skill_search/skill.md
@@ -17,15 +17,16 @@ graph:
 permissions:
   python:
     # FP-0042 Phase 3 drift-fix (2026-05-23): migrated from mode: unsafe
-    # to mode: safe via reyn.safe.http (= urllib-backed; no per-call
-    # permission gate, see Issue #571 for the deferred gate-design
-    # discussion). The skill_search → GitHub Contents API + raw URL
-    # fetches stay structurally identical, only the import path moved
-    # into the safe-mode-callable namespace.
+    # to mode: safe via reyn.safe.http (= urllib-backed). #571 collapse
+    # arc Phase 3 (2026-05-23) added per-host gating on reyn.safe.http;
+    # this skill explicitly declares the two GitHub hosts it talks to.
     - module: ./registry_fetch.py
       function: fetch_registry_results
       mode: safe
       timeout: 30
+  http.get:
+    - host: api.github.com
+    - host: raw.githubusercontent.com
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 routing:

--- a/tests/test_permission_collapse_phase3.py
+++ b/tests/test_permission_collapse_phase3.py
@@ -1,0 +1,192 @@
+"""Tier 2: #571 collapse arc Phase 3 — http.get axis + safe.http per-host gate.
+
+Verifies the OS-invariants introduced by Phase 3:
+
+1. `PermissionDecl` accepts `http_get` and `secret_write` axes from
+   `from_dict`, with appropriate normalisation (string entries lifted
+   to `{host: ...}` for http.get, secret.write accepts list[str]).
+2. The compat shim expands `mcp_install: true` to include
+   `http.get: [{host: registry.modelcontextprotocol.io}]` in addition
+   to the Phase 2 `file.write` expansion. Idempotent; no duplicates
+   when the explicit form is also declared.
+3. `PermissionResolver.require_http_get` raises for undeclared hosts
+   and passes for declared ones (per-host exact match, no implicit
+   wildcards).
+4. `PermissionResolver.require_secret_write` raises for undeclared
+   keys and passes for declared ones. (No callers in Phase 3 — wired
+   in Phase 5 — but the resolver method exists and is invariant-pinned.)
+5. `reyn.safe.http._check_host` rejects an unauthorised host with a
+   structured PermissionError that names the host and points to the
+   skill.md declaration form.
+6. Unset permission context (= bare-process use without harness setup)
+   raises with the documented guidance.
+
+Tier policy: real PermissionResolver instances + the real safe.http
+module — no mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.permissions.permissions import (
+    PermissionDecl,
+    PermissionResolver,
+)
+
+# ── PermissionDecl parsing ─────────────────────────────────────────────────────
+
+
+def test_http_get_parses_dict_form():
+    """Tier 2: from_dict accepts [{host: str}] verbatim."""
+    decl = PermissionDecl.from_dict({
+        "http.get": [{"host": "api.github.com"}, {"host": "registry.modelcontextprotocol.io"}],
+    })
+    hosts = [e["host"] for e in decl.http_get]
+    assert hosts == ["api.github.com", "registry.modelcontextprotocol.io"]
+
+
+def test_http_get_parses_bare_string_form():
+    """Tier 2: from_dict normalises bare strings to {host: str}."""
+    decl = PermissionDecl.from_dict({
+        "http.get": ["api.github.com", "example.com"],
+    })
+    hosts = [e["host"] for e in decl.http_get]
+    assert hosts == ["api.github.com", "example.com"]
+
+
+def test_secret_write_parses_list_of_strings():
+    """Tier 2: from_dict accepts list[str] for secret.write."""
+    decl = PermissionDecl.from_dict({
+        "secret.write": ["GITHUB_TOKEN", "STRIPE_KEY"],
+    })
+    assert decl.secret_write == ["GITHUB_TOKEN", "STRIPE_KEY"]
+
+
+def test_secret_write_drops_non_string_entries():
+    """Tier 2: from_dict drops non-string/non-int entries silently."""
+    decl = PermissionDecl.from_dict({
+        "secret.write": ["OK", None, {"nope": 1}, "ALSO_OK"],
+    })
+    assert decl.secret_write == ["OK", "ALSO_OK"]
+
+
+# ── compat shim ────────────────────────────────────────────────────────────────
+
+
+def test_mcp_install_compat_shim_expands_http_get():
+    """Tier 2: mcp_install: true adds the registry host to http_get."""
+    decl = PermissionDecl.from_dict({"mcp_install": True})
+    hosts = [e["host"] for e in decl.http_get]
+    assert "registry.modelcontextprotocol.io" in hosts
+
+
+def test_mcp_install_compat_shim_idempotent_with_explicit_http_get():
+    """Tier 2: explicit + implicit http_get entries deduplicate."""
+    decl = PermissionDecl.from_dict({
+        "mcp_install": True,
+        "http.get": [{"host": "registry.modelcontextprotocol.io"}],
+    })
+    matching = [e for e in decl.http_get if e["host"] == "registry.modelcontextprotocol.io"]
+    assert len(matching) == 1
+
+
+def test_non_mcp_install_bool_axes_do_not_expand_http_get():
+    """Tier 2: only mcp_install carries an HTTP expansion today."""
+    for axis in ("mcp_drop_server", "cron_register", "index_drop"):
+        decl = PermissionDecl.from_dict({axis: True})
+        assert decl.http_get == [], f"{axis} should not expand to http_get"
+
+
+def test_compat_shim_does_not_expand_secret_write():
+    """Tier 2: no bool axis auto-expands to secret_write entries.
+
+    Rationale: the env-var keys mcp_install will save are determined at
+    runtime from the registry response, not statically by the skill
+    author, so there is no useful compat-shim mapping. Skills declare
+    secret.write explicitly (or it stays empty).
+    """
+    decl = PermissionDecl.from_dict({"mcp_install": True})
+    assert decl.secret_write == []
+
+
+# ── PermissionResolver gates ──────────────────────────────────────────────────
+
+
+def test_require_http_get_raises_for_undeclared_host(tmp_path):
+    """Tier 2: require_http_get raises with a structured error."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "api.github.com"}])
+    with pytest.raises(PermissionError, match="example.com"):
+        resolver.require_http_get(decl, "example.com")
+
+
+def test_require_http_get_passes_for_declared_host(tmp_path):
+    """Tier 2: require_http_get passes for an exact host match."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "api.github.com"}])
+    resolver.require_http_get(decl, "api.github.com")
+
+
+def test_require_http_get_passes_via_compat_shim(tmp_path):
+    """Tier 2: end-to-end — mcp_install bool decl passes the registry host check."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl.from_dict({"mcp_install": True})
+    resolver.require_http_get(decl, "registry.modelcontextprotocol.io")
+
+
+def test_require_secret_write_raises_for_undeclared_key(tmp_path):
+    """Tier 2: require_secret_write raises with a structured error."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(secret_write=["GITHUB_TOKEN"])
+    with pytest.raises(PermissionError, match="STRIPE_KEY"):
+        resolver.require_secret_write(decl, "STRIPE_KEY")
+
+
+def test_require_secret_write_passes_for_declared_key(tmp_path):
+    """Tier 2: require_secret_write passes for an exact key match."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(secret_write=["GITHUB_TOKEN"])
+    resolver.require_secret_write(decl, "GITHUB_TOKEN")
+
+
+# ── reyn.safe.http enforcement ────────────────────────────────────────────────
+
+
+def test_safe_http_check_host_rejects_unauthorised():
+    """Tier 2: safe.http rejects a request to an unauthorised host."""
+    from reyn.safe import http as safe_http
+    safe_http._set_permission_context(http_hosts=["api.github.com"])
+    with pytest.raises(PermissionError, match="example.com"):
+        safe_http._check_host("https://example.com/path")
+
+
+def test_safe_http_check_host_accepts_authorised():
+    """Tier 2: safe.http allows a request to an explicitly allowed host."""
+    from reyn.safe import http as safe_http
+    safe_http._set_permission_context(http_hosts=["api.github.com"])
+    safe_http._check_host("https://api.github.com/repos/foo/bar")
+
+
+def test_safe_http_unset_context_raises():
+    """Tier 2: bare-process use without harness setup raises with guidance."""
+    from reyn.safe import http as safe_http
+    # Reset to uninitialised by direct assignment (= mirrors safe.file pattern).
+    safe_http._context_initialised = False
+    safe_http._allowed_hosts = ()
+    with pytest.raises(PermissionError, match="permission context not initialised"):
+        safe_http._check_host("https://example.com/")
+
+
+def test_safe_http_all_verbs_gate_via_check_host(monkeypatch):
+    """Tier 2: get/post/put/delete all go through _check_host."""
+    from reyn.safe import http as safe_http
+
+    safe_http._set_permission_context(http_hosts=["only.allowed.example"])
+    for verb, args in (
+        ("get", ("https://blocked.example/x",)),
+        ("post", ("https://blocked.example/x", {"a": 1})),
+        ("put", ("https://blocked.example/x", {"a": 1})),
+        ("delete", ("https://blocked.example/x",)),
+    ):
+        with pytest.raises(PermissionError, match="blocked.example"):
+            getattr(safe_http, verb)(*args)


### PR DESCRIPTION
**[e2e-coder]** — #571 collapse arc Phase 3 (= per-host HTTP gate + secret.write axis declaration).

**Stacked on PR #616** (= Phase 2). Base will switch to `main` once #616 merges; this PR's diff stays equivalent to its incremental delta over Phase 2.

## Summary

- `PermissionDecl` gains `http_get: list[dict]` and `secret_write: list[str]` axes. `from_dict` parses both; the compat shim now expands `mcp_install: true` to include `http.get: [{host: registry.modelcontextprotocol.io}]` in addition to the Phase 2 `file.write` expansion.
- `reyn.safe.http` gains a per-host gate: `_set_permission_context(http_hosts=...)` + `_check_host(url)` reject unauthorised hosts with a structured error pointing at the skill.md declaration form. All four verbs (get / post / put / delete) call `_check_host` before httpx.
- End-to-end wiring: `decl.http_get` → `PreprocessorExecutor` → `PythonRunner` → `_python_harness` → `safe.http._set_permission_context`. Mirrors the FP-0042 file wiring path.
- `PermissionResolver` gains `require_http_get(decl, host)` (wired) and `require_secret_write(decl, key)` (declaration-only — callers wired in Phase 5 when bool axes retire).
- Stdlib migration: `skill_search` and `skill_importer` declare `http.get: [api.github.com, raw.githubusercontent.com]` in their `skill.md` so they keep working under the new gate.

## Scope

`secret_write` enforcement at the `reyn.secrets.store.save_secret` boundary is deferred to Phase 5 (= when op handlers route through `require_secret_write` instead of their dedicated bool-axis `require_*` methods). Phase 3 lands the axis declaration, parsing, and resolver method so the schema + downstream config wiring can land ahead of the op-handler migration.

| Phase | Status |
|---|---|
| 1 — Doc rewrite | merged (PR #613) |
| 2 — Default-zone exception + compat shim + startup_guard skip | PR #616 (CI re-trigger in progress) |
| **3 — `http.get` per-host gate + `secret.write` axis declaration** | **this PR** |
| 4 — stdlib migration (= covered for skill_search / skill_importer in this PR; remaining `mcp_install` op handler routing through safe.http is Phase 5) | partial here |
| 5 — Remove bool axes + route op handlers through `require_file_write` / `require_http_get` / `require_secret_write` | follow-up |

## Test plan

- [x] `pytest -q` from rootdir → 5476 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref.py`, same as PR #613 / #616 baseline, verified reproducing on main)
- [x] `ruff check .` → All checks passed
- [x] New file `tests/test_permission_collapse_phase3.py` (17 tests):
  - `http.get` dict / bare-string parsing
  - `secret.write` list parsing + non-string drop
  - `mcp_install` compat shim → http.get registry entry
  - idempotence with explicit `http.get`
  - other bool axes do NOT expand to http.get
  - `secret_write` not auto-expanded
  - `require_http_get` / `require_secret_write` raise + pass
  - `safe.http._check_host` rejects unauthorised + accepts authorised
  - `safe.http` unset context raises with guidance
  - All four verbs gate via `_check_host`
- [x] Existing tests in `tests/test_permission_collapse_phase2.py` still pass (= compat with Phase 2 verified)

Refs #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)