### PR TITLE
feat(tui): ErrorBox context fallback + router skill_name normalization (W13 T1-1)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -619,11 +619,36 @@ class ConversationView(Widget):
             return
 
         if msg.kind == "error":
+            # W13 A#2: derive short keys from full meta when missing.
+            # forwarder.py populates meta["skill_name"] + meta["run_id_short"]
+            # for skill-context errors; direct router emissions (classify path,
+            # chain_timeout, chain_peer_discarded) only set meta["skill"]
+            # (full name) and meta["run_id"] (full id). Deriving here at the
+            # TUI seam restores the [skill#abcd] prefix + re-enables the
+            # Ctrl+B trace hint footer for all router-emitted errors.
+            skill_name = str(
+                msg.meta.get("skill_name") or msg.meta.get("skill", "")
+            )
+            run_id_raw = str(msg.meta.get("run_id", ""))
+            run_id_short = str(
+                msg.meta.get("run_id_short") or (run_id_raw[-4:] if run_id_raw else "")
+            )
+            details = str(msg.meta.get("details", ""))
+            # W13 A#1: when details is empty, build context lines from
+            # well-known meta keys so the expand region surfaces structured
+            # provenance rather than just repeating the header message.
+            context_lines: list[str] = []
+            if not details:
+                for key in ("chain_id", "skill", "run_id", "dimension"):
+                    val = msg.meta.get(key)
+                    if val:
+                        context_lines.append(f"{key}={val}")
             self.mount_error(
                 message=msg.text,
-                details=str(msg.meta.get("details", "")),
-                run_id_short=str(msg.meta.get("run_id_short", "")),
-                skill_name=str(msg.meta.get("skill_name", "")),
+                details=details,
+                run_id_short=run_id_short,
+                skill_name=skill_name,
+                context_lines=context_lines,
             )
             return
 
@@ -1348,6 +1373,7 @@ class ConversationView(Widget):
         details: str = "",
         run_id_short: str = "",
         skill_name: str = "",
+        context_lines: list[str] | None = None,
     ) -> ErrorBox:
         self._consume_empty_hint()
         # F5: cap the live stack. When more than _MAX_VISIBLE_ERROR_BOXES
@@ -1398,6 +1424,7 @@ class ConversationView(Widget):
             details=details,
             run_id_short=run_id_short,
             skill_name=skill_name,
+            context_lines=context_lines,
         )
         self.mount(box)
         self._error_boxes.append(box)

--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -108,6 +108,7 @@ class ErrorBox(Widget):
         details: str = "",
         run_id_short: str = "",
         skill_name: str = "",
+        context_lines: list[str] | None = None,
         id: str | None = None,
         index: int = 0,
         total: int = 0,
@@ -117,6 +118,11 @@ class ErrorBox(Widget):
         self._details = details
         self._run_id_short = run_id_short
         self._skill_name = skill_name
+        # W13 A#1: optional context lines shown in expand region when details
+        # is empty. Callers pass meta-derived lines (chain_id=… / skill=… /
+        # run_id=… / dimension=…) so expand reveals structured provenance
+        # instead of just the header message repeated verbatim.
+        self._context_lines: list[str] = list(context_lines) if context_lines else []
         self._expanded = False
         # Wave-11 B#6 — per-box index badge for stacked errors. When
         # ``total > 1`` the header renders ``✗ [2/3] [skill#abcd]: …``
@@ -277,9 +283,20 @@ class ErrorBox(Widget):
                 yield Label(
                     "Ctrl+B → events for full trace", classes="eb-hint",
                 )
+        elif self._context_lines:
+            # W13 A#1: details empty but meta-derived context lines present.
+            # Render them as a structured context block so expand reveals
+            # useful provenance (chain_id / skill / run_id / dimension)
+            # rather than just the header message repeated verbatim.
+            context_text = "\n".join(self._context_lines)
+            yield Static(_markup_escape(context_text), classes="eb-details")
+            if has_trace:
+                yield Label(
+                    "Ctrl+B → events for full trace", classes="eb-hint",
+                )
         else:
-            # No details supplied — fall back to the full (untruncated) message
-            # so long errors are still readable when the box is expanded.
+            # No details or context lines — fall back to the full (untruncated)
+            # message so long errors are still readable when expanded.
             yield Static(_markup_escape(self._message), classes="eb-details")
             if has_trace:
                 yield Label(

--- a/tests/cli/test_error_box_context_fallback.py
+++ b/tests/cli/test_error_box_context_fallback.py
@@ -1,0 +1,201 @@
+"""Tier 2: ErrorBox context_lines fallback + ConversationView short-key derivation.
+
+Wave-13 T1-1 (Topic A #1 + #2).
+
+A#1: When ``details`` is empty but ``context_lines`` are provided, the
+expand region renders the context lines (chain_id / skill / run_id /
+dimension) instead of repeating the header message verbatim. When
+``details`` is non-empty, ``context_lines`` are silently ignored
+(details wins).
+
+A#2: ``ConversationView.render_message`` with kind="error" derives
+``skill_name`` and ``run_id_short`` from ``meta["skill"]`` /
+``meta["run_id"]`` when the short keys are absent. This restores the
+``[skill#abcd]`` header prefix and re-enables the Ctrl+B trace hint for
+direct router-emitted errors.
+
+Public surfaces asserted:
+  - ErrorBox compose: ``Static.eb-details`` rendered text (via ``.plain``)
+  - ErrorBox._skill_name / ._run_id_short  (init-time value, not private
+    runtime state — these are set in ``__init__`` and read by tests that
+    build via the normal ctor, not bypassing super().__init__)
+  - ConversationView.mount_error ← called by render_message
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_app():
+    from reyn.chat.tui.app import ReynTUIApp
+    return ReynTUIApp(
+        registry=None, agent_name="t", model="m", budget_tracker=None
+    )
+
+
+def _rendered_details_text(box) -> str:
+    """Return the plain text of the eb-details Static inside ``box``.
+
+    Uses Static.render() which returns the Rich Content / Text object;
+    that carries a ``.plain`` attribute with the unstyled text content.
+    """
+    from textual.widgets import Static
+    try:
+        static = box.query_one(".eb-details", Static)
+    except Exception:
+        return ""
+    try:
+        rendered = static.render()
+        return str(getattr(rendered, "plain", rendered))
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# A#1 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_lines_rendered_when_details_empty() -> None:
+    """Tier 2: context_lines appear in expand region when details is empty."""
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        box = ErrorBox(
+            message="router error",
+            details="",
+            context_lines=["chain_id=abc123", "skill=foo"],
+        )
+        app.query_one("#conversation").mount(box)
+        await pilot.pause()
+
+        text = _rendered_details_text(box)
+        assert "chain_id=abc123" in text, (
+            f"Expected 'chain_id=abc123' in expand text, got: {text!r}"
+        )
+        assert "skill=foo" in text, (
+            f"Expected 'skill=foo' in expand text, got: {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_details_wins_over_context_lines() -> None:
+    """Tier 2: when details non-empty, context_lines are ignored (details wins)."""
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        box = ErrorBox(
+            message="router error",
+            details="the real detail text",
+            context_lines=["x=should-not-appear"],
+        )
+        app.query_one("#conversation").mount(box)
+        await pilot.pause()
+
+        text = _rendered_details_text(box)
+        assert "the real detail text" in text, (
+            f"Expected details text in expand region, got: {text!r}"
+        )
+        assert "x=should-not-appear" not in text, (
+            f"context_lines should be suppressed when details non-empty, got: {text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# A#2 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_message_derives_skill_and_run_id_short() -> None:
+    """Tier 2: render_message derives skill_name/run_id_short from meta.skill/meta.run_id."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        msg = OutboxMessage(
+            kind="error",
+            text="classify timeout",
+            meta={
+                "skill": "foo",
+                "run_id": "TS_foo_abcd",
+                # no skill_name, no run_id_short — direct router emission
+            },
+        )
+        conv.render_message(msg)
+        await pilot.pause()
+
+        boxes = list(conv.query(ErrorBox))
+        assert boxes, "ErrorBox should have been mounted"
+        box = boxes[-1]
+        # The header prefix [foo#abcd] must appear in the rendered header
+        header = box._header_text()
+        assert "[foo#abcd]" in header, (
+            f"Expected '[foo#abcd]' prefix in header, got: {header!r}"
+        )
+        # Internal derivation values (set in __init__) confirm correctness.
+        assert box._skill_name == "foo", (
+            f"Expected _skill_name='foo', got: {box._skill_name!r}"
+        )
+        assert box._run_id_short == "abcd", (
+            f"Expected _run_id_short='abcd', got: {box._run_id_short!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_render_message_does_not_double_derive_when_short_keys_present() -> None:
+    """Tier 2: render_message uses skill_name/run_id_short as-is when already set."""
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.error_box import ErrorBox
+
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        msg = OutboxMessage(
+            kind="error",
+            text="skill error",
+            meta={
+                # forwarder.py already set both short keys
+                "skill_name": "code_review",
+                "run_id_short": "ef01",
+                # full keys also present (should NOT override already-set shorts)
+                "skill": "wrong_skill",
+                "run_id": "TS_something_wrongwrong",
+            },
+        )
+        conv.render_message(msg)
+        await pilot.pause()
+
+        boxes = list(conv.query(ErrorBox))
+        assert boxes, "ErrorBox should have been mounted"
+        box = boxes[-1]
+        assert box._skill_name == "code_review", (
+            f"skill_name should come from meta.skill_name, got: {box._skill_name!r}"
+        )
+        assert box._run_id_short == "ef01", (
+            f"run_id_short should come from meta.run_id_short, got: {box._run_id_short!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T1-1 (error-UX foundation)

## Summary
- ErrorBox: optional context_lines slot rendered in expand region
  when details is empty (= surfaces meta chain_id/skill/run_id)
- ConversationView render_message: derive skill_name/run_id_short
  from meta.skill/meta.run_id when missing (was empty for router
  errors, suppressing prefix + trace hint)

## Test plan
- [x] tests/cli/test_error_box_context_fallback.py — 4 Tier-2 tests
- [x] existing error_box / smoke tests still pass
- [x] ruff clean
- [x] (skipped — headless TUI only) Manual: trigger router error → ErrorBox shows [skill#abcd] prefix + Ctrl+B hint