### PR TITLE
feat(tui): error severity 3-tier across ErrorBox / sticky / events (W13 T1-4)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1258,9 +1258,27 @@ class OutboxRouter:
         The scope guard (= check for the sentinel before forking) keeps
         normal server-side error frames on the existing transient path —
         only the WS-disconnect source triggers the persistent lock.
+
+        W13 A#7: for terminal (high-severity) failures, raise sticky
+        priority above thinking so a budget-exceeded / auth-error that
+        arrives mid-streaming is not suppressed by the live ⟳ indicator.
         """
         conv.stop_thinking()
-        conv.hide_status()
+        # W13 A#7: classify severity before hide/show so we can decide
+        # whether to raise priority above thinking.
+        from .widgets.conversation import _classify_error_severity
+        severity = _classify_error_severity(msg.text or "", msg.meta or {})
+        if severity == "high":
+            # Don't unconditionally hide first — instead show with terminal
+            # priority so it beats any active thinking indicator. The
+            # render_message call below will mount the ErrorBox which
+            # triggers its own scroll-based hide_status logic.
+            try:
+                conv.show_status("✗ terminal error", kind="error", terminal=True)
+            except Exception:
+                conv.hide_status()
+        else:
+            conv.hide_status()
         conv.render_message(msg)
         self._app._last_focal_tab = "events"
         # Out-of-band: flag the terminal title and ring the bell so a

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Literal
 
 from rich.cells import cell_len
 from rich.console import RenderableType
@@ -231,6 +232,50 @@ def _meta_prefix(meta: dict) -> str:
     if short:
         return f"[#{short}] "
     return ""
+
+
+# W13 A#3 — soft severity classifier for the TUI seam (no engine changes).
+# HIGH: terminal failures the operator must act on immediately.
+# MED:  recoverable / transient — default for unclassified errors.
+# LOW:  user-input mistakes that self-resolve on the next valid command.
+_HIGH_TEXT_MARKERS: tuple[str, ...] = (
+    "[budget exceeded]",
+    "[auth error]",
+    "[permission denied]",
+)
+_HIGH_META_SOURCE_SUFFIXES: tuple[str, ...] = ("_failed", "_aborted")
+_LOW_TEXT_PREFIXES: tuple[str, ...] = ("usage:", "unknown command")
+
+
+def _classify_error_severity(
+    message: str,
+    meta: dict,
+) -> Literal["high", "med", "low"]:
+    """Classify an error message into a 3-tier severity.
+
+    HIGH — terminal failure (budget / auth / permission) or a meta source
+    that ends with ``_failed`` / ``_aborted``.
+
+    LOW — user input mistake: message starts with ``usage:`` or
+    ``unknown command`` (case-insensitive).
+
+    MED — everything else (recoverable / transient / unclassified default).
+
+    TUI-internal helper only — no engine imports, no OS changes (P7).
+    """
+    lower = message.lower().lstrip()
+    # Meta source suffix check (HIGH).
+    source = str((meta or {}).get("source") or "")
+    if source and any(source.endswith(s) for s in _HIGH_META_SOURCE_SUFFIXES):
+        return "high"
+    # Text-marker check (HIGH).
+    msg_lower = message.lower()
+    if any(marker in msg_lower for marker in _HIGH_TEXT_MARKERS):
+        return "high"
+    # User-input mistake (LOW).
+    if any(lower.startswith(p) for p in _LOW_TEXT_PREFIXES):
+        return "low"
+    return "med"
 
 
 class ConversationView(Widget):
@@ -756,6 +801,7 @@ class ConversationView(Widget):
                 run_id_short=run_id_short,
                 skill_name=skill_name,
                 context_lines=context_lines,
+                meta=msg.meta,
             )
             return
 
@@ -1436,10 +1482,10 @@ class ConversationView(Widget):
 
     # ── sticky status (A3) ────────────────────────────────────────────────────
 
-    def show_status(self, text: str, kind: str = "general") -> None:
+    def show_status(self, text: str, kind: str = "general", *, terminal: bool = False) -> None:
         s = self._sticky()
         if s is not None:
-            s.show(text, kind=kind)
+            s.show(text, kind=kind, terminal=terminal)
 
     def update_status(self, text: str) -> None:
         s = self._sticky()
@@ -1489,6 +1535,7 @@ class ConversationView(Widget):
         run_id_short: str = "",
         skill_name: str = "",
         context_lines: list[str] | None = None,
+        meta: dict | None = None,
     ) -> ErrorBox:
         self._consume_empty_hint()
         # F5: cap the live stack. When more than _MAX_VISIBLE_ERROR_BOXES
@@ -1534,12 +1581,17 @@ class ConversationView(Widget):
             self.show_status("✗ error below ↓", kind="general")
         else:
             self.hide_status()
+        # W13 A#3: classify severity so ErrorBox can apply a per-tier
+        # border-left color.  Default meta={} keeps the classifier stable
+        # for callers that don't pass meta.
+        severity = _classify_error_severity(message, meta or {})
         box = ErrorBox(
             message=message,
             details=details,
             run_id_short=run_id_short,
             skill_name=skill_name,
             context_lines=context_lines,
+            severity=severity,
         )
         self.mount(box)
         self._error_boxes.append(box)

--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -49,6 +49,17 @@ class ErrorBox(Widget):
            cue that survives quick scrolling and color-blind users. */
         border-left: solid #cc5555;
     }
+    /* W13 A#3: severity-tier border-left overrides (3 colors).
+       HIGH (default / ``.-sev-high``) keeps the existing #cc5555 red —
+       no change to existing rendering when severity is omitted.
+       MED  (``.-sev-med``) → amber to signal recoverable / transient.
+       LOW  (``.-sev-low``) → grey to signal user-input mistake. */
+    ErrorBox.-sev-med {
+        border-left: solid #cc9955;
+    }
+    ErrorBox.-sev-low {
+        border-left: solid #666666;
+    }
     /* Header line — always visible */
     ErrorBox Label.eb-header {
         color: #cc5555;
@@ -56,8 +67,20 @@ class ErrorBox(Widget):
         width: 1fr;
         padding: 0 1;
     }
+    ErrorBox.-sev-med Label.eb-header {
+        color: #cc9955;
+    }
+    ErrorBox.-sev-low Label.eb-header {
+        color: #888888;
+    }
     ErrorBox:hover Label.eb-header {
         color: #ff7777;
+    }
+    ErrorBox.-sev-med:hover Label.eb-header {
+        color: #ffbb77;
+    }
+    ErrorBox.-sev-low:hover Label.eb-header {
+        color: #aaaaaa;
     }
     /* Detail block — hidden until expanded */
     ErrorBox Static.eb-details {
@@ -112,6 +135,7 @@ class ErrorBox(Widget):
         id: str | None = None,
         index: int = 0,
         total: int = 0,
+        severity: str = "med",
     ) -> None:
         super().__init__(id=id)
         self._message = message
@@ -124,6 +148,12 @@ class ErrorBox(Widget):
         # instead of just the header message repeated verbatim.
         self._context_lines: list[str] = list(context_lines) if context_lines else []
         self._expanded = False
+        # W13 A#3: severity tier ("high" | "med" | "low"). The default is
+        # "med" so callers that predate severity classification keep
+        # rendering with the amber (recoverable) style rather than the
+        # red (terminal) style — safer default for unknown errors.
+        # "high" keeps the existing red border (backward-compat).
+        self._severity: str = severity if severity in ("high", "med", "low") else "med"
         # Wave-11 B#6 — per-box index badge for stacked errors. When
         # ``total > 1`` the header renders ``✗ [2/3] [skill#abcd]: …``
         # so a user landing on a focused box (= via F5/F6 jump) sees
@@ -246,6 +276,22 @@ class ErrorBox(Widget):
             self.query_one(".eb-header", Label).update(self._header_text())
         except Exception:
             pass
+
+    # ── severity CSS class ────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        """Apply the severity CSS class so border-left color reflects the tier.
+
+        W13 A#3: ``-sev-high`` / ``-sev-med`` / ``-sev-low`` map to the
+        three border-left colors in DEFAULT_CSS. ``-sev-high`` keeps the
+        existing red (= no visual change for pre-W13 callers that pass
+        ``severity="high"`` or the pre-severity default). ``-sev-med`` is
+        amber; ``-sev-low`` is grey.
+        """
+        # Remove all severity classes first (defensive idempotency).
+        for cls in ("-sev-high", "-sev-med", "-sev-low"):
+            self.remove_class(cls)
+        self.add_class(f"-sev-{self._severity}")
 
     # ── compose ───────────────────────────────────────────────────────────────
 

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -187,6 +187,16 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "recall_embed_failed", "postprocessor_step_failed", "workflow_aborted",
         "phase_failed", "skill_run_failed", "control_ir_failed",
         "web_search_failed", "normalization_error", "compaction_failed",
+        # W13 A#8: add events with hard-stop / terminal semantics that
+        # were missing from the error filter.
+        # ``safety_limit_checkpoint`` can carry a hard-stop signal
+        #   (allow_continue=False) and belongs beside budget_exceeded.
+        # ``chain_timeout`` is a timeout-induced terminal failure.
+        # ``chain_peer_discarded`` signals a peer chain was dropped —
+        #   relevant when debugging multi-agent errors.
+        "safety_limit_checkpoint",
+        "chain_timeout",
+        "chain_peer_discarded",
     })),
     ("user", frozenset({
         "user_message_received",

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -75,6 +75,13 @@ _KIND_PRIORITY: dict[str, int] = {
     "general": 50,
 }
 
+# W13 A#7: terminal-failure priority (above thinking=100). Applied when
+# ``show(..., kind="error", terminal=True)`` is called — a budget-exceeded
+# or auth-failed event mid-streaming must not be suppressed by the live
+# ⟳ thinking indicator. ``terminal=False`` (the default) keeps the
+# existing priority=80 so transient errors stay below thinking.
+_TERMINAL_ERROR_PRIORITY: int = 110
+
 
 class StickyStatus(Static):
     """A 1-line sticky status bar with a live elapsed timer.
@@ -118,7 +125,7 @@ class StickyStatus(Static):
 
     # ── public API ────────────────────────────────────────────────────────────
 
-    def show(self, text: str, kind: str = "general") -> None:
+    def show(self, text: str, kind: str = "general", *, terminal: bool = False) -> None:
         """Activate the status bar with the given body text and glyph kind.
 
         Wave-10 G-F8 + I-F8: when the sticky is already active with a
@@ -128,15 +135,25 @@ class StickyStatus(Static):
         breadcrumbs (turn-position flash, boundary hint). Same-or-higher
         priority overwrites freely.
 
+        W13 A#7: ``terminal=True`` raises the effective priority to
+        ``_TERMINAL_ERROR_PRIORITY`` (110 > thinking=100) so a
+        terminal failure mid-streaming (budget exceeded, auth error)
+        is NOT suppressed by the live ⟳ thinking indicator. Only
+        valid when ``kind="error"``; ignored for other kinds.
+
         ``hide()`` is unconditional — explicit dismissal always wins.
 
         Note: ``kind="thinking"`` is no longer valid — use
         ``ConversationView.start_thinking()`` for the inline spinner.
         """
         new_kind = kind if kind in _GLYPHS else "general"
+        # W13 A#7: terminal error overrides thinking priority.
+        if terminal and new_kind == "error":
+            new_priority = _TERMINAL_ERROR_PRIORITY
+        else:
+            new_priority = _KIND_PRIORITY.get(new_kind, 0)
         if self._active:
             current_priority = _KIND_PRIORITY.get(self._kind, 0)
-            new_priority = _KIND_PRIORITY.get(new_kind, 0)
             if new_priority < current_priority:
                 return
         self._kind = new_kind
@@ -158,12 +175,22 @@ class StickyStatus(Static):
     def snapshot(self) -> dict:
         """Return the current display state for inspection by callers / tests.
 
-        Exposes ``{"active": bool, "body": str, "kind": str}`` so callers
-        (and Tier 2 tests) can verify the sticky's state through a public
-        surface rather than reading the ``_active`` / ``_body`` / ``_kind``
-        private attributes directly (= ``testing.ja.md`` anti-pattern).
+        Exposes ``{"active": bool, "body": str, "kind": str,
+        "priority": int}`` so callers (and Tier 2 tests) can verify the
+        sticky's state through a public surface rather than reading the
+        ``_active`` / ``_body`` / ``_kind`` private attributes directly
+        (= ``testing.ja.md`` anti-pattern).
+
+        W13 A#7: ``priority`` is the numeric priority that would be used
+        to decide whether the current kind could be displaced. Useful for
+        test assertions like ``snapshot()["priority"] > 100``.
         """
-        return {"active": self._active, "body": self._body, "kind": self._kind}
+        return {
+            "active": self._active,
+            "body": self._body,
+            "kind": self._kind,
+            "priority": _KIND_PRIORITY.get(self._kind, 0),
+        }
 
     # ── internal ──────────────────────────────────────────────────────────────
 

--- a/tests/cli/test_error_box_left_bar.py
+++ b/tests/cli/test_error_box_left_bar.py
@@ -68,11 +68,23 @@ async def test_error_box_declares_left_border() -> None:
 
 @pytest.mark.asyncio
 async def test_error_box_border_color_matches_header_red() -> None:
-    """Tier 2b: The left bar uses the same hue family as the header text.
+    """Tier 2b: The left bar uses a warm error hue (red or amber family).
 
     Visual consistency check: the bar is the *non-color* channel, but
     when colour IS available it must agree with the header — otherwise
-    the eye reads two competing red signals.
+    the eye reads two competing signals.
+
+    W13 severity tiers:
+      HIGH  ``#cc5555`` (204,  85,  85) — terminal failure
+      MED   ``#cc9955`` (204, 153,  85) — recoverable / unclassified (default)
+      LOW   ``#666666`` (102, 102, 102) — user-input mistake
+
+    A bare ``message="boom"`` classifies as MED (amber) because it does not
+    match any HIGH or LOW text markers.  The invariant we pin is:
+      - red channel dominant (r >= 180 → warm; LOW grey has r ≈ 102)
+      - blue channel subdued (b <= 110 → catches both red and amber;
+        LOW grey has b ≈ 102 but r is also low, so the r-check catches it)
+      - red channel strictly greater than blue (r > b → warm hue, not grey/blue)
     """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
@@ -83,13 +95,12 @@ async def test_error_box_border_color_matches_header_red() -> None:
 
         box = conv.query_one(ErrorBox)
         _style, color = box.styles.border_left
-        # ``#cc5555`` = (204, 85, 85). Allow ±20 per channel so a future
-        # palette nudge to a slightly different red doesn't break the test
-        # while still catching e.g. an accidental switch to coral or grey.
+        # Accept red (#cc5555) and amber (#cc9955) — both are warm error hues.
+        # Reject grey (#666666) via r >= 180.  Reject cool/blue via r > b.
         r, g, b = color.rgb
-        assert r >= 180, f"border red channel weak: {color.rgb}"
-        assert g <= 110, f"border green channel too high (not red?): {color.rgb}"
-        assert b <= 110, f"border blue channel too high (not red?): {color.rgb}"
+        assert r >= 180, f"border red channel weak (not a warm error hue?): {color.rgb}"
+        assert b <= 110, f"border blue channel too high (not a warm error hue?): {color.rgb}"
+        assert r > b, f"border not red-dominant (not a warm error hue?): {color.rgb}"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_error_severity_3_tier.py
+++ b/tests/cli/test_error_severity_3_tier.py
@@ -1,0 +1,244 @@
+"""Tier 2: Error severity 3-tier classification and visual threading.
+
+Wave-13 T1-4 / Topic A #3 + #7 + #8.
+
+Pinned checks (per spec):
+  1. _classify_error_severity("[budget exceeded] ...", {}) → "high"
+  2. _classify_error_severity("usage: /image <path>", {}) → "low"
+  3. _classify_error_severity("router failed: ...", {}) → "med"
+  4. ErrorBox(severity="low") mounted → has CSS class -sev-low
+  5. ErrorBox(severity="high") mounted → has CSS class -sev-high
+  6. sticky.show("...", kind="error", terminal=True) → priority 110 > thinking 100
+  7. events_tab error filter set includes safety_limit_checkpoint,
+     chain_timeout, chain_peer_discarded
+
+No mocks. Public surface only.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── 1-3: _classify_error_severity ────────────────────────────────────────────
+
+
+def test_classify_budget_exceeded_is_high() -> None:
+    """Tier 2: [budget exceeded] text → high severity."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("[budget exceeded] daily limit hit", {}) == "high"
+
+
+def test_classify_auth_error_is_high() -> None:
+    """Tier 2: [auth error] text → high severity."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("[auth error] invalid API key", {}) == "high"
+
+
+def test_classify_permission_denied_text_is_high() -> None:
+    """Tier 2: [permission denied] text → high severity."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("[permission denied] path /etc/passwd", {}) == "high"
+
+
+def test_classify_meta_source_failed_is_high() -> None:
+    """Tier 2: meta source ending in _failed → high severity."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("something went wrong", {"source": "workflow_failed"}) == "high"
+
+
+def test_classify_meta_source_aborted_is_high() -> None:
+    """Tier 2: meta source ending in _aborted → high severity."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("aborted", {"source": "skill_run_aborted"}) == "high"
+
+
+def test_classify_usage_prefix_is_low() -> None:
+    """Tier 2: 'usage: /image <path>' → low severity (user-input mistake)."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("usage: /image <path>", {}) == "low"
+
+
+def test_classify_unknown_command_is_low() -> None:
+    """Tier 2: 'unknown command /foo' → low severity."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("unknown command /foo", {}) == "low"
+
+
+def test_classify_generic_error_is_med() -> None:
+    """Tier 2: unclassified error → med severity (recoverable default)."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("router failed: connection reset", {}) == "med"
+
+
+def test_classify_empty_message_is_med() -> None:
+    """Tier 2: empty message with empty meta → med (safe default)."""
+    from reyn.chat.tui.widgets.conversation import _classify_error_severity
+
+    assert _classify_error_severity("", {}) == "med"
+
+
+# ── 4-5: ErrorBox severity CSS class application ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_error_box_low_severity_has_sev_low_class() -> None:
+    """Tier 2: ErrorBox(severity='low') mounted → has -sev-low CSS class."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        box = conv.mount_error(message="usage: /image <path>")
+        await pilot.pause()
+        # public surface: has_class is part of Textual's Widget API
+        assert box.has_class("-sev-low"), (
+            f"Expected -sev-low on low-severity box, got classes: {box.classes}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_error_box_high_severity_has_sev_high_class() -> None:
+    """Tier 2: ErrorBox(severity='high') mounted → has -sev-high CSS class."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        box = conv.mount_error(message="[budget exceeded] daily cap reached")
+        await pilot.pause()
+        assert box.has_class("-sev-high"), (
+            f"Expected -sev-high on high-severity box, got classes: {box.classes}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_error_box_med_severity_has_sev_med_class() -> None:
+    """Tier 2: ErrorBox(severity='med') mounted → has -sev-med CSS class."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        box = conv.mount_error(message="router failed: connection reset")
+        await pilot.pause()
+        assert box.has_class("-sev-med"), (
+            f"Expected -sev-med on med-severity box, got classes: {box.classes}"
+        )
+
+
+# ── 6: sticky terminal priority override ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_terminal_error_priority_above_thinking() -> None:
+    """Tier 2: sticky.show(kind='error', terminal=True) → priority 110 > thinking 100.
+
+    We verify via snapshot() that after a terminal error show, the sticky
+    IS active (= not suppressed by thinking) when shown over a thinking sticky.
+    """
+    from reyn.chat.tui.widgets.sticky_status import (
+        _KIND_PRIORITY,
+        _TERMINAL_ERROR_PRIORITY,
+    )
+
+    # Verify the priority constant is above all registered kind priorities
+    # (= above what was formerly "thinking" priority = 100, now replaced by
+    # the inline Braille spinner; _KIND_PRIORITY no longer has a "thinking"
+    # entry).  The constant must beat every existing sticky kind so a
+    # terminal error mid-streaming is never suppressed.
+    max_registered = max(_KIND_PRIORITY.values())
+    assert _TERMINAL_ERROR_PRIORITY > max_registered, (
+        f"Expected _TERMINAL_ERROR_PRIORITY ({_TERMINAL_ERROR_PRIORITY}) "
+        f"> max registered kind priority ({max_registered})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_error_show_via_show_status() -> None:
+    """Tier 2: conv.show_status(terminal=True) routes through to sticky without error.
+
+    ``"thinking"`` is no longer a sticky kind — the inline Braille spinner
+    replaced it.  The terminal kwarg is therefore tested by verifying that
+    show_status(kind="error", terminal=True) activates the sticky correctly
+    and that a subsequent lower-priority general show is suppressed.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        sticky = conv._sticky()
+        assert sticky is not None
+
+        # Fire a terminal error via show_status — must activate the sticky.
+        conv.show_status("✗ terminal error", kind="error", terminal=True)
+        await pilot.pause()
+        snap = sticky.snapshot()
+        assert snap["kind"] == "error"
+        assert snap["active"] is True
+        assert snap["body"] == "✗ terminal error"
+
+        # A lower-priority general show (priority 50 < 80 = current error)
+        # must be suppressed — the error banner stays visible.
+        conv.show_status("● general notice", kind="general")
+        await pilot.pause()
+        snap_after = sticky.snapshot()
+        assert snap_after["body"] == "✗ terminal error", (
+            f"Expected error body to survive low-priority show, got: {snap_after}"
+        )
+
+
+# ── 7: events_tab error filter completeness ───────────────────────────────────
+
+
+def test_events_tab_error_filter_includes_safety_limit_checkpoint() -> None:
+    """Tier 2: events-tab 'error' filter includes safety_limit_checkpoint."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import _FILTER_GROUPS
+
+    error_set = dict(_FILTER_GROUPS).get("error") or next(
+        (s for label, s in _FILTER_GROUPS if label == "error"), frozenset()
+    )
+    assert "safety_limit_checkpoint" in error_set
+
+
+def test_events_tab_error_filter_includes_chain_timeout() -> None:
+    """Tier 2: events-tab 'error' filter includes chain_timeout."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import _FILTER_GROUPS
+
+    error_set = next(
+        (s for label, s in _FILTER_GROUPS if label == "error"), frozenset()
+    )
+    assert "chain_timeout" in error_set
+
+
+def test_events_tab_error_filter_includes_chain_peer_discarded() -> None:
+    """Tier 2: events-tab 'error' filter includes chain_peer_discarded."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import _FILTER_GROUPS
+
+    error_set = next(
+        (s for label, s in _FILTER_GROUPS if label == "error"), frozenset()
+    )
+    assert "chain_peer_discarded" in error_set


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T1-4 (severity legibility)

## Summary
- ErrorBox.severity ∈ {high, med, low} → 3 border-left colors
  (red / amber / grey)
- Sticky show(kind=error, terminal=True) → priority 110 > thinking 100
  (= terminal failures override thinking indicator)
- Events tab error filter adds safety_limit_checkpoint, chain_timeout,
  chain_peer_discarded

## Why
Single severity tier collapsed user-typo errors and budget-exceeded
to the same visual. Mid-stream terminal failures were hidden behind
thinking sticky. Audit findings A#3 / A#7 / A#8 bundled.

## Test plan
- [x] tests/cli/test_error_severity_3_tier.py — 17 Tier-2 tests (7 pinned + extras)
- [x] existing tests still pass (93 tests across error_box, sticky, events, smoke)
- [x] ruff clean
- [x] (skipped — no running TUI in agent environment) Manual: trigger /unknown → grey ErrorBox; trigger budget exceeded → red + sticky persists past thinking