### PR TITLE
feat(tui): destructive slash confirm parity — /cancel /plan discard /pending discard (W13 T1-5)

### DIFF
--- a/src/reyn/chat/slash/chat.py
+++ b/src/reyn/chat/slash/chat.py
@@ -76,12 +76,27 @@ def _running_run_id_completer(
 @slash(
     "cancel",
     summary="Cancel a running skill",
-    usage="/cancel <id-prefix>",
+    usage="/cancel <id-prefix> [confirm]",
     completer=_running_run_id_completer,
 )
 async def cancel_cmd(session: "ChatSession", args: str) -> None:
-    """``/cancel <id-prefix>`` — cancel a running skill task."""
-    prefix = args.strip()
+    """``/cancel <id-prefix>`` — cancel a running skill task (2-step confirm).
+
+    First invocation prints a warning and asks the user to re-type with
+    ``confirm`` appended.  Second invocation (``/cancel <id-prefix> confirm``)
+    executes the cancellation.  Mirrors ``/reset``'s 2-step pattern so a
+    Tab-completed prefix can't accidentally abort the wrong skill on first
+    press (Wave-13 B#2).
+    """
+    stripped = args.strip()
+    # Detect "confirm" suffix (case-insensitive, space-separated).
+    if stripped.lower().endswith(" confirm"):
+        prefix = stripped[: -len(" confirm")].strip()
+        _do_confirm = True
+    else:
+        prefix = stripped
+        _do_confirm = False
+
     if not prefix:
         await reply_error(session, "usage: /cancel <id-prefix>")
         return
@@ -100,6 +115,21 @@ async def cancel_cmd(session: "ChatSession", args: str) -> None:
     if task is None or task.done():
         await reply(session, f"skill {_run_short(rid)} already finished")
         return
+
+    if not _do_confirm:
+        # First invocation — show warning, require explicit confirm.
+        short = _run_short(rid)
+        # Recover skill_name from run_id for the warning context line.
+        trimmed = rid[: -len(short) - 1] if short else rid
+        _, _, skill_part = trimmed.partition("_")
+        await reply(
+            session,
+            f"⚠ About to cancel: {skill_part} #{short}\n"
+            f"Type `/cancel {prefix} confirm` to abort the skill, "
+            "or anything else to leave it running.",
+        )
+        return
+
     task.cancel()
     # Preserve the per-run meta on the cancel-requested system message so
     # the TUI's skill-activity row can match against it.

--- a/src/reyn/chat/slash/pending.py
+++ b/src/reyn/chat/slash/pending.py
@@ -134,14 +134,62 @@ async def _list(session: "ChatSession") -> None:
 
 
 async def _discard(session: "ChatSession", supplied_id: str) -> None:
+    """Two-step confirm: first invocation shows a warning; second executes.
+
+    Mirrors ``/reset``'s pattern (Wave-13 B#2).  The user must re-type
+    ``/pending discard <id> confirm`` to proceed.  The ``confirm`` suffix
+    is stripped before resolving the intervention id so the existing
+    prefix-resolution logic is unchanged.
+    """
     if not hasattr(session, "discard_pending_intervention"):
         await reply_error(session, _NO_SESSION)
         return
-    iv_id, err = _resolve_iv_id(session, supplied_id)
+
+    # Detect "confirm" suffix (case-insensitive, space-separated).
+    stripped = supplied_id.strip()
+    if stripped.lower().endswith(" confirm"):
+        id_part = stripped[: -len(" confirm")].strip()
+        _do_confirm = True
+    else:
+        id_part = stripped
+        _do_confirm = False
+
+    iv_id, err = _resolve_iv_id(session, id_part)
     if err is not None:
         await reply_error(session, err)
         return
     assert iv_id is not None  # mypy guard
+
+    if not _do_confirm:
+        # First invocation — show warning with iv context, require confirm.
+        # Retrieve iv details from the stalled list for the warning line.
+        kind_hint = ""
+        skill_hint = ""
+        try:
+            ops = session.list_stalled_interventions()
+            match = next(
+                (v for v in ops if str(getattr(v, "id", "")).startswith(id_part)),
+                None,
+            )
+            if match is not None:
+                kind_hint = getattr(match, "kind", "") or ""
+                skill_hint = getattr(match, "summary", "") or ""
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
+        context = ""
+        if kind_hint:
+            context = f" ({kind_hint}"
+            if skill_hint:
+                context += f": {skill_hint[:40]}"
+            context += ")"
+        await reply(
+            session,
+            f"⚠ About to discard pending intervention: {iv_id[:8]}{context}\n"
+            f"Type `/pending discard {id_part} confirm` to proceed, "
+            "or anything else to leave it queued.",
+        )
+        return
+
     try:
         ok = await session.discard_pending_intervention(iv_id)
     except Exception as exc:

--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -151,6 +151,10 @@ async def _list_plan_runs(session: "ChatSession") -> None:
 async def _discard_plan_run(session: "ChatSession", args: str) -> None:
     """Abort a plan: cancel task, surface outbox notice, clean up state.
 
+    Two-step confirm pattern (mirrors ``/reset``): first invocation prints
+    a warning showing the plan summary and asks for ``/plan discard <id>
+    confirm``; second invocation (args ending with " confirm") proceeds.
+
     Steps (mirror /skill discard):
       1. Cancel asyncio.Task (= triggers PlanRuntime's finally clause →
          no plan_completed → active_plan_ids preserved for cleanup).
@@ -161,7 +165,15 @@ async def _discard_plan_run(session: "ChatSession", args: str) -> None:
          per-plan chain_id (= f"plan_{plan_id}") gets resolved
          immediately rather than waiting for chain_timeout.
     """
-    plan_id = args.strip()
+    stripped = args.strip()
+    # Detect "confirm" suffix (case-insensitive, space-separated).
+    if stripped.lower().endswith(" confirm"):
+        plan_id = stripped[: -len(" confirm")].strip()
+        _do_confirm = True
+    else:
+        plan_id = stripped
+        _do_confirm = False
+
     if not plan_id:
         await reply_error(session, "Usage: /plan discard <plan_id>")
         return
@@ -172,6 +184,31 @@ async def _discard_plan_run(session: "ChatSession", args: str) -> None:
     is_active = plan_id in snap.active_plan_ids
     if not is_running and not is_active:
         await reply_error(session, f"unknown plan run: {plan_id}")
+        return
+
+    if not _do_confirm:
+        # First invocation — show warning with plan context, require confirm.
+        status = "running" if is_running else "active (no task)"
+        # Try to surface step count from the decomposition artifact.
+        step_hint = ""
+        try:
+            from pathlib import Path
+
+            from reyn.plan import read_decomposition
+            agent_state_dir = (
+                Path(".reyn") / "agents" / session.agent_name / "state"
+            )
+            decomp = read_decomposition(agent_state_dir, plan_id)
+            n = len(decomp.steps)
+            step_hint = f", {n} step{'s' if n != 1 else ''}"
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
+        await reply(
+            session,
+            f"⚠ About to discard plan: {plan_id} ({status}{step_hint})\n"
+            f"Type `/plan discard {plan_id} confirm` to proceed, "
+            "or anything else to leave it running.",
+        )
         return
 
     # 1. Cancel the asyncio.Task if mid-flight.

--- a/tests/cli/test_pending_slash_command.py
+++ b/tests/cli/test_pending_slash_command.py
@@ -124,8 +124,9 @@ async def test_pending_list_empty_returns_friendly_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pending_discard_invokes_session_api() -> None:
-    """Tier 2: ``/pending discard <id>`` calls ``discard_pending_intervention``."""
+async def test_pending_discard_first_invocation_shows_warning() -> None:
+    """Tier 2: ``/pending discard <id>`` (no confirm) emits a warning and
+    does NOT call discard_pending_intervention (Wave-13 B#2 confirm parity)."""
     sess = _StubSession(pending_ops=[
         _PendingOpStub(
             id="iv-abcd1234", kind="intervention",
@@ -134,6 +135,26 @@ async def test_pending_discard_invokes_session_api() -> None:
     ])
     cmd = _get_pending_cmd()
     await cmd.handler(sess, "discard iv-abcd1234")
+    # Must NOT have called the API.
+    assert sess.discard_calls == []
+    # Must emit a warning with "confirm" hint.
+    reply_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
+    assert len(reply_msgs) == 1
+    assert "confirm" in reply_msgs[0].text
+
+
+@pytest.mark.asyncio
+async def test_pending_discard_invokes_session_api_with_confirm() -> None:
+    """Tier 2: ``/pending discard <id> confirm`` calls
+    ``discard_pending_intervention`` (2-step confirm suffix)."""
+    sess = _StubSession(pending_ops=[
+        _PendingOpStub(
+            id="iv-abcd1234", kind="intervention",
+            origin_channel_id="tui:x", summary="ok?",
+        ),
+    ])
+    cmd = _get_pending_cmd()
+    await cmd.handler(sess, "discard iv-abcd1234 confirm")
     assert sess.discard_calls == ["iv-abcd1234"]
     reply_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
     assert any("discarded" in m.text for m in reply_msgs)
@@ -141,10 +162,12 @@ async def test_pending_discard_invokes_session_api() -> None:
 
 @pytest.mark.asyncio
 async def test_pending_discard_resolves_short_prefix_id() -> None:
-    """Tier 2: ``discard`` accepts a short prefix that uniquely matches one iv.
+    """Tier 2: ``discard confirm`` accepts a short prefix that uniquely
+    matches one iv.
 
     Mirrors the Pending tab's UX (= ``id[:8]`` short form is what the
-    user sees in the list output).
+    user sees in the list output).  The confirm suffix must be stripped
+    before prefix resolution.
     """
     sess = _StubSession(pending_ops=[
         _PendingOpStub(
@@ -153,7 +176,7 @@ async def test_pending_discard_resolves_short_prefix_id() -> None:
         ),
     ])
     cmd = _get_pending_cmd()
-    await cmd.handler(sess, "discard iv-abcd1")
+    await cmd.handler(sess, "discard iv-abcd1 confirm")
     assert sess.discard_calls == ["iv-abcd1234"]
 
 

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -116,8 +116,8 @@ async def test_plan_discard_unknown_id_reports_error(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_plan_discard_records_plan_aborted(tmp_path, monkeypatch):
-    """Tier 2: /plan discard emits plan_aborted to WAL + clears
-    active_plan_ids."""
+    """Tier 2: /plan discard confirm emits plan_aborted to WAL + clears
+    active_plan_ids.  Uses the 2-step confirm suffix (Wave-13 B#2)."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     session.is_attached = True
@@ -127,7 +127,9 @@ async def test_plan_discard_records_plan_aborted(tmp_path, monkeypatch):
     )
     assert "p_to_discard" in session._journal.snapshot.active_plan_ids
 
-    consumed = await session._maybe_handle_slash("/plan discard p_to_discard")
+    consumed = await session._maybe_handle_slash(
+        "/plan discard p_to_discard confirm",
+    )
     assert consumed is True
 
     # active_plan_ids cleared via plan_aborted apply.
@@ -165,7 +167,9 @@ async def test_plan_discard_cancels_running_task(tmp_path, monkeypatch):
         plan_id="p_running", goal="g", n_steps=1,
     )
 
-    consumed = await session._maybe_handle_slash("/plan discard p_running")
+    consumed = await session._maybe_handle_slash(
+        "/plan discard p_running confirm",
+    )
     assert consumed is True
     assert task.cancelled() or cancelled.is_set()
     assert "p_running" not in session.running_plans
@@ -200,7 +204,7 @@ async def test_plan_discard_deletes_decomposition_artifact(tmp_path, monkeypatch
         plan_id="p_artifact", goal="g", n_steps=2,
     )
 
-    await session._maybe_handle_slash("/plan discard p_artifact")
+    await session._maybe_handle_slash("/plan discard p_artifact confirm")
     assert not artifact.exists()
 
 
@@ -219,7 +223,7 @@ async def test_plan_discard_emits_plan_aborted_outbox(tmp_path, monkeypatch):
     )
 
     consumed = await session._maybe_handle_slash(
-        "/plan discard p_aborted_emit",
+        "/plan discard p_aborted_emit confirm",
     )
     assert consumed is True
 

--- a/tests/test_slash_destructive_confirm_parity.py
+++ b/tests/test_slash_destructive_confirm_parity.py
@@ -1,0 +1,277 @@
+"""Tier 2: destructive slash commands require 2-step confirm (Wave-13 B#2).
+
+/cancel, /plan discard, and /pending discard now mirror /reset's pattern:
+  - First invocation (no "confirm" suffix) → warning + hint; action NOT taken.
+  - Second invocation (same args + " confirm") → action proceeds.
+
+This prevents a misclick on a Tab-completed prefix from immediately
+aborting a skill, plan, or intervention.
+
+Pinned per task spec:
+  1. /cancel <id> (no confirm) → outbox carries warning + "confirm" hint;
+     task.cancel() NOT called.
+  2. /cancel <id> confirm → task.cancel() called.
+  3. /plan discard <id> (no confirm) → warning; plan NOT discarded.
+  4. /plan discard <id> confirm → plan IS discarded.
+  5. /pending discard <id> (no confirm) → warning; API NOT called.
+  6. /pending discard <id> confirm → API called.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import REGISTRY
+
+# ── /cancel stubs ─────────────────────────────────────────────────────────
+
+
+class _CancelTask:
+    """Minimal asyncio.Task stand-in that records cancel() calls."""
+
+    def __init__(self):
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def done(self):
+        return False
+
+
+class _CancelSession:
+    """Stub session for /cancel tests."""
+
+    def __init__(self, rid: str):
+        self._rid = rid
+        self._task = _CancelTask()
+        self.running_skills = {rid: self._task}
+        self.running_skills_started_at = {}
+        self.outbox_messages: list[OutboxMessage] = []
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self.outbox_messages.append(msg)
+
+    def _resolve_run_id(self, prefix: str):
+        """Return (rid, []) when prefix matches, else (None, [])."""
+        matches = [r for r in self.running_skills if r.startswith(prefix)]
+        if len(matches) == 1:
+            return matches[0], []
+        if len(matches) > 1:
+            return None, matches
+        return None, []
+
+
+def _get_cmd(name: str):
+    cmd = REGISTRY.get(name)
+    assert cmd is not None, f"/{name} must be registered"
+    return cmd
+
+
+# ── Test 1: /cancel <id> (no confirm) → warning; task NOT cancelled ───────
+
+
+@pytest.mark.asyncio
+async def test_cancel_no_confirm_shows_warning_not_cancelled() -> None:
+    """Tier 2: /cancel <id> without confirm emits warning; task.cancel() NOT called."""
+    rid = "20250101_my_skill_abcd"
+    sess = _CancelSession(rid)
+    cmd = _get_cmd("cancel")
+    await cmd.handler(sess, rid)
+
+    # task must NOT be cancelled
+    assert not sess._task._cancelled
+
+    # outbox must contain a system warning with "confirm" hint
+    warn_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
+    assert len(warn_msgs) == 1, (
+        f"expected 1 warning system message, got {len(warn_msgs)}: "
+        f"{[m.text for m in sess.outbox_messages]}"
+    )
+    assert "confirm" in warn_msgs[0].text
+    assert rid in warn_msgs[0].text or "abcd" in warn_msgs[0].text
+
+
+# ── Test 2: /cancel <id> confirm → task.cancel() called ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_with_confirm_cancels_task() -> None:
+    """Tier 2: /cancel <id> confirm calls task.cancel()."""
+    rid = "20250101_my_skill_abcd"
+    sess = _CancelSession(rid)
+    cmd = _get_cmd("cancel")
+    await cmd.handler(sess, f"{rid} confirm")
+
+    assert sess._task._cancelled
+
+    # outbox must carry the cancel-requested system message
+    system_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
+    assert any("cancel" in m.text.lower() for m in system_msgs), (
+        f"expected 'cancel' in system outbox, got: {[m.text for m in system_msgs]}"
+    )
+
+
+# ── /plan discard stubs and tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plan_discard_no_confirm_shows_warning(tmp_path, monkeypatch):
+    """Tier 2: /plan discard <id> (no confirm) → warning msg; plan not discarded."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.chat.session import ChatSession
+    from reyn.events.state_log import StateLog
+
+    session = ChatSession(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+    session.is_attached = True
+
+    await session._journal.record_plan_started(
+        plan_id="p_warn", goal="g", n_steps=2,
+    )
+    assert "p_warn" in session._journal.snapshot.active_plan_ids
+
+    await session._maybe_handle_slash("/plan discard p_warn")
+
+    # Plan must still be active.
+    assert "p_warn" in session._journal.snapshot.active_plan_ids
+
+    # Outbox must carry a warning with "confirm" hint.
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    warn_msgs = [m for m in msgs if m.kind == "system"]
+    assert warn_msgs, f"expected system warning, got: {[(m.kind, m.text) for m in msgs]}"
+    assert "confirm" in warn_msgs[0].text
+    assert "p_warn" in warn_msgs[0].text
+
+
+@pytest.mark.asyncio
+async def test_plan_discard_with_confirm_discards_plan(tmp_path, monkeypatch):
+    """Tier 2: /plan discard <id> confirm discards the plan (clears active_plan_ids)."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.chat.session import ChatSession
+    from reyn.events.state_log import StateLog
+
+    session = ChatSession(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+    session.is_attached = True
+
+    await session._journal.record_plan_started(
+        plan_id="p_confirm", goal="g", n_steps=2,
+    )
+
+    consumed = await session._maybe_handle_slash(
+        "/plan discard p_confirm confirm",
+    )
+    assert consumed is True
+
+    # Plan must be cleared.
+    assert "p_confirm" not in session._journal.snapshot.active_plan_ids
+
+    # Outbox must carry the "discarded plan run" confirmation.
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    status_texts = [m.text for m in msgs if m.kind == "system"]
+    assert any("discarded plan run" in t for t in status_texts), (
+        f"expected 'discarded plan run' in system msgs, got: {status_texts}"
+    )
+
+
+# ── /pending discard stubs and tests ─────────────────────────────────────
+
+
+@dataclass
+class _PendingOpStub:
+    id: str
+    kind: str
+    origin_channel_id: str
+    created_at: str = ""
+    summary: str = ""
+    detail: str = ""
+
+
+class _PendingStubSession:
+    """Minimal session stub for /pending dispatch tests."""
+
+    def __init__(
+        self,
+        *,
+        pending_ops: list | None = None,
+        agent_name: str = "default",
+        discard_result: bool = True,
+    ) -> None:
+        self._pending = pending_ops or []
+        self.agent_name = agent_name
+        self._discard_result = discard_result
+        self.outbox_messages: list[OutboxMessage] = []
+        self.discard_calls: list[str] = []
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self.outbox_messages.append(msg)
+
+    def list_stalled_interventions(self) -> list:
+        return list(self._pending)
+
+    async def discard_pending_intervention(
+        self, iv_id: str, *, reason: str = "user_discarded",
+    ) -> bool:
+        self.discard_calls.append(iv_id)
+        return self._discard_result
+
+
+@pytest.mark.asyncio
+async def test_pending_discard_no_confirm_shows_warning_not_discarded() -> None:
+    """Tier 2: /pending discard <id> (no confirm) → warning; API NOT called."""
+    sess = _PendingStubSession(pending_ops=[
+        _PendingOpStub(
+            id="iv-abcd1234", kind="ask_user",
+            origin_channel_id="tui:x", summary="Allow exec?",
+        ),
+    ])
+    cmd = _get_cmd("pending")
+    await cmd.handler(sess, "discard iv-abcd1234")
+
+    # API must NOT be called.
+    assert sess.discard_calls == []
+
+    # Warning with "confirm" hint must be in the outbox.
+    warn_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
+    assert len(warn_msgs) == 1, (
+        f"expected 1 system warning, got {len(warn_msgs)}: "
+        f"{[m.text for m in sess.outbox_messages]}"
+    )
+    assert "confirm" in warn_msgs[0].text
+
+
+@pytest.mark.asyncio
+async def test_pending_discard_with_confirm_calls_api() -> None:
+    """Tier 2: /pending discard <id> confirm calls discard_pending_intervention."""
+    sess = _PendingStubSession(pending_ops=[
+        _PendingOpStub(
+            id="iv-abcd1234", kind="ask_user",
+            origin_channel_id="tui:x", summary="Allow exec?",
+        ),
+    ])
+    cmd = _get_cmd("pending")
+    await cmd.handler(sess, "discard iv-abcd1234 confirm")
+
+    assert sess.discard_calls == ["iv-abcd1234"]
+    reply_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
+    assert any("discarded" in m.text for m in reply_msgs)

--- a/tests/test_slash_usage_extension.py
+++ b/tests/test_slash_usage_extension.py
@@ -36,7 +36,7 @@ if str(_SRC) not in sys.path:
 
 # Commands that should have ``usage`` set after this PR.
 _EXPECTED_USAGE: dict[str, str] = {
-    "cancel":      "/cancel <id-prefix>",
+    "cancel":      "/cancel <id-prefix> [confirm]",
     "answer":      "/answer <id-prefix> <text>",
     "plan":        "/plan [list|discard <id>|resume <id>]",
     "memory":      "/memory [list|view <name>]",


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T1-5 (destructive guard parity)

## Summary
- /cancel <id> → warning + "type `/cancel <id> confirm` to abort"
- /plan discard <id> → warning shows plan summary + requires confirm
- /pending discard <id> → warning shows iv kind/skill + requires confirm

## Why
/reset has been 2-step since inception; other destructive slashes
fired on first invocation. With the recent Tab-completer for /cancel
+ /answer (#601), a misclick on Tab-completed prefix could discard
the wrong thing irreversibly. Audit finding B#2.

## Test plan
- [x] tests/test_slash_destructive_confirm_parity.py — Tier-2 tests
- [x] existing slash tests updated for new contract
- [x] ruff clean
- [x] Manual: /cancel <id> → warning; /cancel <id> confirm → cancel proceeds