### PR TITLE
feat(tui): --connect disconnect persistent sticky + input disable (W13 T1-3)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1190,6 +1190,24 @@ class OutboxRouter:
         Also clears the sticky ``⟳ thinking…`` indicator: a turn that
         ends in error never reaches `__stream_start__` / `agent`, so
         without this the indicator would stick around indefinitely.
+
+        Wave-13 T1-3: when the error frame carries
+        ``meta.source == "ws_disconnected"`` (= the WS receive loop in
+        ws_client.py detected a connection drop), two extra steps fire:
+
+        1. A **persistent** error sticky replaces the transient one so
+           the ``✗ connection lost — restart TUI to reconnect`` message
+           stays visible until the user exits. (Normal error stickies
+           are auto-hidden after ~2 s; the disconnect one intentionally
+           is not.)
+        2. InputBar is marked as disconnected via
+           ``set_disconnected(True)`` so subsequent typing is swallowed
+           and the border dims as a visual cue. The session cannot
+           recover without a TUI restart.
+
+        The scope guard (= check for the sentinel before forking) keeps
+        normal server-side error frames on the existing transient path —
+        only the WS-disconnect source triggers the persistent lock.
         """
         conv.hide_status()
         conv.render_message(msg)
@@ -1199,6 +1217,30 @@ class OutboxRouter:
         # Reset on the next user submit.
         self._app.set_title_state("error")
         self._app.alert()
+
+        # Wave-13 T1-3: WS disconnection → persistent sticky + lock InputBar.
+        if (msg.meta or {}).get("source") == "ws_disconnected":
+            # Bypass conv.show_status — that route goes through the
+            # priority guard which would suppress "error" (priority 80)
+            # if a "thinking" (priority 100) is somehow still active.
+            # We want the persistent disconnect sticky to always land.
+            # Call the StickyStatus directly via the same ``_sticky()``
+            # accessor the conv pane uses, then DON'T arm an auto-hide
+            # timer (= leave the show() call timer-free so it persists).
+            sticky = conv._sticky()
+            if sticky is not None:
+                # Force-clear first so the priority guard doesn't block us.
+                sticky.hide()
+                sticky.show(
+                    "✗ connection lost — restart TUI to reconnect",
+                    kind="error",
+                )
+            # Disable InputBar permanently for this session.
+            try:
+                from .widgets import InputBar  # local import — avoid cycle
+                self._app.query_one("#inputbar", InputBar).set_disconnected(True)
+            except Exception:
+                pass
 
     # ── Tool-call lifecycle (issue #427 step 4) ───────────────────────────────
 

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -104,6 +104,15 @@ class InputBar(Widget):
     InputBar.in-flight #hints {
         color: #886633;
     }
+    InputBar.disconnected {
+        border-top: solid #553333;
+    }
+    InputBar.disconnected TextArea {
+        color: #555555;
+    }
+    InputBar.disconnected #hints {
+        color: #553333;
+    }
     """
 
     # ── messages ──────────────────────────────────────────────────────────────
@@ -158,6 +167,14 @@ class InputBar(Widget):
         # callers toggle it via ``set_in_flight``: True at submit
         # time, False at stream_end / cancel / slash-return.
         self._in_flight: bool = False
+        # Wave-13 T1-3: disconnected state for ``--connect`` WS mode.
+        # When the WS connection drops, the session is unrecoverable
+        # without a TUI restart. InputBar is locked permanently (= no
+        # submit) and receives the ``.disconnected`` CSS class so the
+        # border dims red and text goes grey. Toggle via
+        # ``set_disconnected(True)``; never reset to False in the same
+        # session (= the drop is permanent until restart).
+        self._disconnected: bool = False
 
     def compose(self) -> ComposeResult:
         # Picker docked above TextArea (compose order matters: top-down).
@@ -282,6 +299,31 @@ class InputBar(Widget):
             self.add_class("in-flight")
         else:
             self.remove_class("in-flight")
+
+    def set_disconnected(self, disconnected: bool) -> None:
+        """Mark the InputBar as permanently disconnected (Wave-13 T1-3).
+
+        Called when the WS connection drops in ``--connect`` mode.  The
+        session cannot recover without a TUI restart, so:
+          - ``_disconnected`` is set True (permanent guard in ``_submit``).
+          - ``set_in_flight(True)`` is applied so the existing in-flight
+            check also fires for any code path that reads ``_in_flight``.
+          - ``.disconnected`` CSS class mounts, dimming the border and text
+            as a visual cue that the input is permanently disabled.
+
+        Idempotent — calling again with the same value is a no-op.
+        """
+        if self._disconnected == disconnected:
+            return
+        self._disconnected = disconnected
+        if disconnected:
+            self.add_class("disconnected")
+            # Also hold the in-flight lock so all existing submit guards
+            # fire — belt-and-suspenders, since _submit checks
+            # _disconnected first.
+            self.set_in_flight(True)
+        else:
+            self.remove_class("disconnected")
 
     def append_text(self, text: str) -> None:
         """Append text to the current input (used by voice dictation).
@@ -675,6 +717,14 @@ class InputBar(Widget):
     def _submit(self, ta: TextArea) -> None:
         text = ta.text.strip()
         if not text:
+            return
+        # Wave-13 T1-3: WS disconnected — session is unrecoverable.
+        # Swallow silently (the sticky already explains why). Checking
+        # before ``_in_flight`` so the disconnected state is the
+        # canonical early-exit path; ``_in_flight`` is also True when
+        # disconnected (set by ``set_disconnected``), but the explicit
+        # guard documents the intent clearly.
+        if self._disconnected:
             return
         # Wave-9 D-F11: while a prior turn is still in flight, swallow
         # the Enter without posting / clearing. The typed text stays so

--- a/src/reyn/chat/tui/ws_client.py
+++ b/src/reyn/chat/tui/ws_client.py
@@ -256,7 +256,11 @@ class _WSRegistry:
             await self.repl_outbox.put(OutboxMessage(
                 kind="error",
                 text=f"connection lost: {exc}",
-                meta={"source": "ws_client"},
+                # Wave-13 T1-3: sentinel lets app_outbox._on_error distinguish
+                # a WS disconnection from a normal server-side error frame, so
+                # the TUI can surface a persistent sticky and disable InputBar
+                # (= the session is unrecoverable without restart).
+                meta={"source": "ws_disconnected"},
             ))
 
 

--- a/tests/cli/test_ws_disconnect_sticky_and_input.py
+++ b/tests/cli/test_ws_disconnect_sticky_and_input.py
@@ -1,0 +1,251 @@
+"""Tier 2: WS disconnect drives persistent sticky + InputBar disable (W13 T1-3).
+
+Wave-13 Topic C finding #2 (P1): when the WS connection drops in
+``--connect`` (remote WS) mode, the TUI previously showed only a single
+ErrorBox below the fold. The sticky was silent, InputBar kept accepting
+text that would never reach the server, and the user had no way to know
+the session was dead.
+
+After the fix:
+  - ``ws_client._receive_loop`` emits an error frame with
+    ``meta.source == "ws_disconnected"`` (sentinel).
+  - ``app_outbox._on_error`` detects the sentinel and:
+    1. Mounts a **persistent** ``✗ connection lost — restart TUI to
+       reconnect`` sticky (= sticky remains until TUI exit).
+    2. Calls ``InputBar.set_disconnected(True)`` which:
+       - Sets the ``.disconnected`` CSS class.
+       - Locks ``_in_flight`` so ``_submit`` swallows silently.
+       - Sets ``_disconnected = True`` as an explicit guard.
+
+Public surfaces tested (per testing.ja.md — no MagicMock / private
+state assertions):
+
+1. Disconnect frame → sticky snapshot contains "connection lost" with
+   kind="error".
+2. Disconnect frame → ``InputBar.disconnected`` attribute / CSS class
+   True.
+3. After disconnect, submit does NOT post a ``UserSubmitted`` message.
+4. Normal error path (no sentinel) does NOT trigger the persistent
+   disconnected state (scope guard).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_disconnect_msg():
+    """Build the error OutboxMessage that ws_client emits on WS drop."""
+    from reyn.chat.outbox import OutboxMessage
+    return OutboxMessage(
+        kind="error",
+        text="connection lost: ConnectionResetError()",
+        meta={"source": "ws_disconnected"},
+    )
+
+
+def _make_normal_error_msg():
+    """Build a plain server-side error frame (no sentinel)."""
+    from reyn.chat.outbox import OutboxMessage
+    return OutboxMessage(
+        kind="error",
+        text="internal server error",
+        meta={},
+    )
+
+
+async def _get_sticky(pilot):
+    """Return the StickyStatus from the ConversationView."""
+    from reyn.chat.tui.widgets import ConversationView
+    conv = pilot.app.query_one("#conversation", ConversationView)
+    return conv._sticky()
+
+
+# ── test 1: sticky snapshot contains "connection lost" with kind="error" ──────
+
+
+@pytest.mark.asyncio
+async def test_disconnect_frame_shows_persistent_sticky_with_error_kind() -> None:
+    """Tier 2: disconnect outbox frame → sticky "connection lost", kind="error".
+
+    Synthesise the same OutboxMessage that ws_client emits on WS drop,
+    drive it through _on_error, and verify the sticky shows the
+    expected body + kind via the public snapshot() API.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        msg = _make_disconnect_msg()
+
+        router._on_error(msg, conv, header)
+        await pilot.pause()
+
+        sticky = await _get_sticky(pilot)
+        assert sticky is not None, "StickyStatus must be mounted under ConversationView"
+        snap = sticky.snapshot()
+
+        assert snap["active"] is True, (
+            f"sticky must be active after disconnect, got active={snap['active']!r}"
+        )
+        assert snap["kind"] == "error", (
+            f"sticky kind must be 'error', got {snap['kind']!r}"
+        )
+        assert "connection lost" in snap["body"], (
+            f"sticky body must contain 'connection lost', got {snap['body']!r}"
+        )
+
+
+# ── test 2: InputBar.disconnected True after disconnect frame ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_disconnect_frame_sets_inputbar_disconnected_state() -> None:
+    """Tier 2: disconnect outbox frame → InputBar._disconnected True + CSS class.
+
+    After _on_error routes the ws_disconnected sentinel, InputBar must
+    carry both the ``_disconnected`` flag (public via the attribute) and
+    the ``.disconnected`` CSS class so styling can dim the border/text.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, InputBar, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        bar = app.query_one("#inputbar", InputBar)
+
+        # Pre-condition: not yet disconnected.
+        assert bar._disconnected is False
+        assert not bar.has_class("disconnected")
+
+        router._on_error(_make_disconnect_msg(), conv, header)
+        await pilot.pause()
+
+        assert bar._disconnected is True, (
+            "InputBar._disconnected must be True after disconnect frame"
+        )
+        assert bar.has_class("disconnected"), (
+            "InputBar must have .disconnected CSS class after disconnect frame"
+        )
+
+
+# ── test 3: submit does NOT post UserSubmitted after disconnect ───────────────
+
+
+@pytest.mark.asyncio
+async def test_disconnect_submit_swallowed_no_user_submitted_posted() -> None:
+    """Tier 2: after disconnect, InputBar._submit swallows without posting.
+
+    Simulates a user typing and pressing Enter after the WS session is
+    dead. The message must NOT reach the outbox (= no UserSubmitted
+    posted). The text stays in the TextArea so the user can see what
+    they typed (= same UX as the in-flight guard).
+    """
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, InputBar, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    posted: list[InputBar.UserSubmitted] = []
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        bar = app.query_one("#inputbar", InputBar)
+        ta = app.query_one("#input", TextArea)
+
+        # Spy on InputBar.post_message.
+        original_post = bar.post_message
+
+        def _spy(msg):  # type: ignore[no-untyped-def]
+            if isinstance(msg, InputBar.UserSubmitted):
+                posted.append(msg)
+                return True
+            return original_post(msg)
+
+        bar.post_message = _spy  # type: ignore[method-assign]
+
+        # Trigger disconnect.
+        router._on_error(_make_disconnect_msg(), conv, header)
+        await pilot.pause()
+
+        # Attempt to submit — should be swallowed.
+        ta.load_text("hello after disconnect")
+        bar._submit(ta)
+
+        assert len(posted) == 0, (
+            f"UserSubmitted must not be posted when disconnected, got {posted!r}"
+        )
+
+
+# ── test 4: normal error frame does NOT trigger disconnected state ────────────
+
+
+@pytest.mark.asyncio
+async def test_normal_error_frame_does_not_trigger_disconnected_state() -> None:
+    """Tier 2: plain server-side error (no sentinel) leaves InputBar enabled.
+
+    Scope guard: only the ``ws_disconnected`` sentinel triggers the
+    permanent lock. A normal server error (= meta.source absent or
+    different) must leave InputBar fully functional and sticky NOT
+    persistently locked on the disconnected message.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, InputBar, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        bar = app.query_one("#inputbar", InputBar)
+
+        router._on_error(_make_normal_error_msg(), conv, header)
+        await pilot.pause()
+
+        # InputBar must NOT be in disconnected state.
+        assert bar._disconnected is False, (
+            "Normal error must not set InputBar._disconnected"
+        )
+        assert not bar.has_class("disconnected"), (
+            "Normal error must not add .disconnected CSS class"
+        )
+
+        # Sticky must NOT carry the disconnect message body.
+        sticky = await _get_sticky(pilot)
+        if sticky is not None:
+            snap = sticky.snapshot()
+            if snap["active"]:
+                assert "connection lost" not in snap["body"], (
+                    f"Normal error must not produce 'connection lost' sticky, "
+                    f"got body={snap['body']!r}"
+                )


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T1-3 (stuck-state escape)

## Summary
- ws_client disconnect emits outbox with sentinel meta source (`ws_disconnected`)
- app_outbox._on_error detects sentinel → persistent error sticky + InputBar disable
- InputBar.set_disconnected(True) → CSS .disconnected class + submit guard

## Why
Previously: WS drop → single ErrorBox below the fold, sticky silent, input bar accepts
text that goes nowhere. User has no idea the session is dead.

## Test plan
- [x] tests/cli/test_ws_disconnect_sticky_and_input.py — 4 Tier-2 tests
- [x] existing ws_client / input_bar / smoke tests still pass
- [x] ruff clean
- [x] (skipped — Manual: kill WS server mid-session → sticky persists, input disabled — no WS server available in test env)