### PR TITLE
feat(tui): AsyncStackPanel interrupted/aborted flash before unmount (W13 T2-2)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -719,7 +719,11 @@ class ReynTUIApp(App):
             # for the attached agent's task — drop the row from the
             # bottom-docked overview. Mirrors the ``add_async_task``
             # call in ``_update_skill_exec``'s first-trace branch.
-            conv.remove_async_task(run_id)
+            # Wave-13 T2-2: pass terminal="aborted" when the skill did
+            # not finish cleanly so the bottom strip briefly flashes
+            # the red ✗ shape before unmounting (= audit finding A#6).
+            _async_terminal = "ok" if status == "finished" else "aborted"
+            conv.remove_async_task(run_id, terminal=_async_terminal)
             # Wave-9 D-F11: release the input-bar lock when the last
             # tracked skill finishes. Sub-skills popping during a
             # nested run keep the lock held — only the empty state
@@ -1082,8 +1086,10 @@ class ReynTUIApp(App):
                     # entry needs explicit removal here (= same
                     # rationale as the ``_skill_exec.pop`` directly
                     # below).
+                    # Wave-13 T2-2: terminal="aborted" so the strip
+                    # briefly flashes red before unmounting.
                     try:
-                        conv.remove_async_task(run_id)
+                        conv.remove_async_task(run_id, terminal="aborted")
                     except Exception:
                         pass
                     self._skill_exec.pop(run_id, None)
@@ -1113,7 +1119,10 @@ class ReynTUIApp(App):
                 cancelled_plans += 1
                 if conv is not None:
                     try:
-                        conv.remove_async_task(str(plan_id))
+                        # Wave-13 T2-2: terminal="interrupted" so the
+                        # strip briefly flashes red before unmounting,
+                        # distinguishing plan cancel from clean completion.
+                        conv.remove_async_task(str(plan_id), terminal="interrupted")
                     except Exception:
                         pass
 
@@ -1142,8 +1151,10 @@ class ReynTUIApp(App):
                 # path; needs explicit handling here because
                 # ``task.cancel()`` doesn't produce a
                 # workflow_aborted trace.
+                # Wave-13 T2-2: terminal="aborted" → red flash before
+                # unmount so user can tell user-cancelled from clean done.
                 try:
-                    conv.remove_async_task(run_id)
+                    conv.remove_async_task(run_id, terminal="aborted")
                 except Exception:
                     pass
                 self._skill_exec.pop(run_id, None)

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1133,15 +1133,20 @@ class OutboxRouter:
     ) -> None:
         """`system` — bridge plan lifecycle to AsyncStackPanel + default render.
 
-        ``plan_runner`` emits two ``kind="system"`` messages with a
-        ``source`` discriminator in meta:
+        ``plan_runner`` / ``/plan discard`` emit ``kind="system"`` messages
+        with a ``source`` discriminator in meta:
 
           - ``source="plan_summary"`` (= ``[task_spawned] kind=plan``
             equivalent for the TUI) — fires when a plan starts. Carries
             ``plan_id`` so the AsyncStackPanel can mount a row keyed
             on the plan identity.
           - ``source="plan_complete"`` (= ``[task_completed] kind=plan``
-            equivalent) — fires when the plan finishes. We drop the row.
+            equivalent) — fires when the plan finishes cleanly. Row
+            unmounts immediately (= ``terminal="ok"``).
+          - ``source="plan_aborted"`` (= ``/plan discard`` or other abort
+            path) — fires when the plan is discarded. Wave-13 T2-2:
+            row briefly flashes red before unmounting
+            (= ``terminal="aborted"``).
 
         Other ``kind="system"`` messages (lifecycle markers, slash-command
         output, attach/detach notices) flow through the default
@@ -1164,6 +1169,14 @@ class OutboxRouter:
             elif source == "plan_complete":
                 try:
                     conv.remove_async_task(str(plan_id))
+                except Exception:
+                    pass
+            elif source == "plan_aborted":
+                # Wave-13 T2-2: /plan discard → flash red before unmount
+                # so the user sees the row terminated abnormally rather
+                # than silently disappearing (= audit finding A#6).
+                try:
+                    conv.remove_async_task(str(plan_id), terminal="aborted")
                 except Exception:
                     pass
         # Default render path — preserves the dim marker line / slash

--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -1,5 +1,22 @@
 """AsyncStackPanel — sticky list of the attached agent's running tasks.
 
+Wave-13 T2-2: ``remove(plan_id, terminal=...)`` flash extension.
+
+When ``terminal`` is ``"aborted"`` or ``"interrupted"``, the row briefly
+transitions to a red ``"✗ async: <id> (interrupted)"`` state for ~1.5 s
+before unmounting, so the user can distinguish abnormal terminations from
+clean completions. The same ``terminal="ok"`` default preserves the
+existing immediate-unmount behaviour.
+
+Flash lifecycle per entry:
+  add(summary)                     → running (⟳)
+  set_pending(count)               → pending (⚑)
+  set_running(summary)             → back to running (⟳)
+  remove(ok)                       → immediate unmount
+  remove(aborted|interrupted)      → transition to _FLASH state → 1.5s timer
+                                     → unmount (earlier remove cancels timer)
+
+
 Scope (= user direction 2026-05-23): only the **attached** agent's
 tasks are surfaced. A "task" is the SP-level abstraction covering
 both **skill spawns** and **plan spawns** — the same lifecycle the
@@ -53,7 +70,8 @@ plan spawns). The widget treats it as an opaque key.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
 
 from rich.cells import cell_len
 from rich.text import Text
@@ -75,6 +93,11 @@ _TICK_INTERVAL_S = 1.0
 
 _GLYPH_RUNNING = "⟳"
 _GLYPH_PENDING = "⚑"
+_GLYPH_INTERRUPTED = "✗"
+
+# How long (in seconds) an interrupted/aborted row stays visible before
+# unmounting. Long enough to be noticed; short enough to clear itself.
+_FLASH_DURATION_S = 1.5
 
 _RIGHT_MARGIN_CELLS = 4
 
@@ -117,6 +140,11 @@ class _Entry:
     summary: str
     started_at: float
     pending_count: int = 0  # 0 = running, >0 = intervention pending
+    # Wave-13 T2-2: flash state for terminal non-ok removal.
+    # ``True`` while the 1.5 s interrupted-flash window is active;
+    # the render path reads this to show the red ✗ shape instead of
+    # the normal ⟳ / ⚑ row.
+    flashing: bool = False
 
 
 def _fmt_elapsed(seconds: float) -> str:
@@ -166,6 +194,14 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         # bucket" intent + makes test ordering deterministic).
         self._entries: dict[str, _Entry] = {}
         self._static: Static | None = None
+        # Wave-13 T2-2: per-entry deferred-unmount timer handles.
+        # Keyed by agent_id; value is a Textual timer object (or any
+        # object with a ``stop()`` method — tests may inject a stub).
+        # When ``remove(terminal!="ok")`` fires, a timer is placed here.
+        # If ``remove()`` is called again for the same id before the
+        # timer fires, the pending timer is cancelled and the entry is
+        # unmounted immediately.
+        self._flash_timers: dict[str, object] = {}
 
     # ── Textual lifecycle ────────────────────────────────────────────────────
 
@@ -222,14 +258,86 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
             entry.summary = summary
         self._refresh()
 
-    def remove(self, agent_id: str) -> None:
-        """Remove ``agent_id``'s entry (= complete / fail / disappear)."""
+    def remove(
+        self,
+        agent_id: str,
+        *,
+        terminal: Literal["ok", "aborted", "interrupted"] = "ok",
+    ) -> None:
+        """Remove ``agent_id``'s entry (= complete / fail / disappear).
+
+        ``terminal="ok"`` (default): immediate unmount — same as the
+        historical signature, fully backwards-compatible.
+
+        ``terminal="aborted"`` / ``"interrupted"``: the row briefly
+        transitions to a red ``✗ async: <id> (interrupted)`` state for
+        ~1.5 s before unmounting. If ``remove()`` is called again for
+        the same ``agent_id`` during the flash window (e.g. a forced
+        cancel-all sweep), any pending timer is cancelled and the entry
+        is unmounted immediately instead.
+
+        Any pending flash timer for ``agent_id`` is always cancelled
+        on entry, regardless of ``terminal``, so double-remove calls
+        never leak orphan timers.
+        """
+        # Cancel any pending flash timer before doing anything else.
+        self._cancel_flash_timer(agent_id)
+
+        if agent_id not in self._entries:
+            return
+
+        if terminal == "ok":
+            del self._entries[agent_id]
+            self._refresh()
+            return
+
+        # Non-ok terminal: transition to flash state and schedule unmount.
+        entry = self._entries[agent_id]
+        entry.flashing = True
+        self._refresh()
+        try:
+            timer = self.app.set_timer(
+                _FLASH_DURATION_S,
+                lambda: self._flush_now(agent_id),
+            )
+            self._flash_timers[agent_id] = timer
+        except Exception:
+            # If timer scheduling fails (widget torn down, no app),
+            # fall through to immediate unmount so we don't leak the row.
+            self._flush_now(agent_id)
+
+    def _cancel_flash_timer(self, agent_id: str) -> None:
+        """Cancel any pending flash-timer for ``agent_id`` (no-op if none)."""
+        timer = self._flash_timers.pop(agent_id, None)
+        if timer is None:
+            return
+        try:
+            timer.stop()
+        except Exception:
+            pass
+
+    def _flush_now(self, agent_id: str) -> None:
+        """Immediately unmount ``agent_id``'s entry.
+
+        Called by the deferred flash timer and directly by tests via
+        the public surface. Cancels any pending timer first so this
+        is idempotent (double-flush is a safe no-op).
+        """
+        self._cancel_flash_timer(agent_id)
         if agent_id in self._entries:
             del self._entries[agent_id]
             self._refresh()
 
     def clear(self) -> None:
-        """Reset to empty (= no entries)."""
+        """Reset to empty (= no entries).
+
+        Cancels any pending flash timers so deferred unmounts from a
+        prior interrupted state don't fire after the panel is cleared
+        (e.g. Ctrl+L conversation clear).
+        """
+        # Cancel all pending flash timers first.
+        for aid in list(self._flash_timers.keys()):
+            self._cancel_flash_timer(aid)
         if self._entries:
             self._entries.clear()
             self._refresh()
@@ -239,9 +347,12 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
 
         Returns the visible (= sorted, capped, overflow-substituted) view
         as a list of ``{"agent_id", "glyph", "summary", "pending_count",
-        "elapsed_s", "is_overflow"}`` dicts. Lets callers verify ordering
-        + overflow without reaching into private state (= per testing
-        policy public-surface convention).
+        "elapsed_s", "is_overflow", "flashing"}`` dicts. Lets callers
+        verify ordering + overflow + flash state without reaching into
+        private state (= per testing policy public-surface convention).
+
+        Wave-13 T2-2: ``flashing`` is ``True`` while a non-ok terminal
+        flash window is active (= row is red, pending unmount).
         """
         out: list[dict] = []
         for agent_id, entry, glyph in self._sorted_visible():
@@ -252,6 +363,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
                 "pending_count": entry.pending_count,
                 "elapsed_s": time.monotonic() - entry.started_at,
                 "is_overflow": False,
+                "flashing": entry.flashing,
             })
         overflow = len(self._entries) - len(out)
         if overflow > 0:
@@ -262,6 +374,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
                 "pending_count": 0,
                 "elapsed_s": 0.0,
                 "is_overflow": True,
+                "flashing": False,
             })
         return out
 
@@ -275,18 +388,26 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         """Return up to ``_CAP`` (agent_id, entry, glyph) tuples in display order.
 
         Sort: pending entries (= ⚑) first, then running entries (= ⟳)
-        ordered by elapsed shortest-first. Within each bucket, ties
-        broken by insertion order (= dict iteration stability).
+        ordered by elapsed shortest-first, then flashing entries (= ✗)
+        last. Flashing rows are transitioning out; pushing them to the
+        tail keeps the most actionable rows (pending / running) at the
+        top of the narrow strip where the user's eye lands first.
+
+        Within each bucket, ties broken by insertion order (= dict
+        iteration stability).
         """
         pending: list[tuple[str, _Entry, str]] = []
         running: list[tuple[str, _Entry, str]] = []
+        flashing: list[tuple[str, _Entry, str]] = []
         for agent_id, entry in self._entries.items():
-            if entry.pending_count > 0:
+            if entry.flashing:
+                flashing.append((agent_id, entry, _GLYPH_INTERRUPTED))
+            elif entry.pending_count > 0:
                 pending.append((agent_id, entry, _GLYPH_PENDING))
             else:
                 running.append((agent_id, entry, _GLYPH_RUNNING))
         running.sort(key=lambda triple: time.monotonic() - triple[1].started_at)
-        ordered = pending + running
+        ordered = pending + running + flashing
         return ordered[:_CAP]
 
     def _build_lines(self) -> Text:
@@ -325,7 +446,20 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
 
         Truncation order on overflow: shrink ``summary`` first (= most
         disposable), keep agent_id + glyph + elapsed always visible.
+
+        Wave-13 T2-2: when ``entry.flashing`` is True, bypasses normal
+        rendering and emits a fixed red ``✗ async: <id_short> (interrupted)``
+        row so the user can see the termination reason before unmount.
         """
+        # Flash mode: render a fixed red "interrupted" line and return.
+        # The agent_id is middle-elided to a short form (first 8 chars)
+        # so the row fits comfortably even on narrow terminals.
+        if entry.flashing:
+            id_short = _middle_elide_id(agent_id, min(16, body_budget - 24))
+            flash_text = f"✗ async: {id_short} (interrupted)"
+            t.append(self._truncate_to_cells(flash_text, body_budget), style="bold #ff6644")
+            return
+
         elapsed_str = _fmt_elapsed(time.monotonic() - entry.started_at)
         if entry.pending_count > 0:
             elapsed_segment = f"  ({entry.pending_count} pending)"

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -429,17 +429,33 @@ class ConversationView(Widget):
             return
         panel.add(task_id, summary)
 
-    def remove_async_task(self, task_id: str) -> None:
+    def remove_async_task(
+        self,
+        task_id: str,
+        *,
+        terminal: str = "ok",
+    ) -> None:
         """Drop ``task_id``'s entry from the bottom stack panel.
 
         Called on ``"skill done:"`` from the trace flow + the
         corresponding plan-completion path. Idempotent (= silent
         no-op if the panel isn't mounted or the task is unknown).
+
+        Wave-13 T2-2: ``terminal`` is threaded through to
+        ``AsyncStackPanel.remove`` so aborted / interrupted lifecycle
+        events can trigger the red flash-before-unmount behaviour.
+        Valid values: ``"ok"`` (default, immediate unmount),
+        ``"aborted"``, ``"interrupted"``.
         """
         panel = self._async_stack()
         if panel is None or not task_id:
             return
-        panel.remove(task_id)
+        # Coerce to the Literal values AsyncStackPanel.remove accepts.
+        # Anything unrecognised falls back to "ok" (= existing safe default).
+        if terminal in ("aborted", "interrupted"):
+            panel.remove(task_id, terminal=terminal)  # type: ignore[arg-type]
+        else:
+            panel.remove(task_id)
 
     def clear_async_tasks(self) -> None:
         """Reset the bottom stack panel to empty.

--- a/tests/cli/test_async_stack_interrupted_flash.py
+++ b/tests/cli/test_async_stack_interrupted_flash.py
@@ -1,0 +1,196 @@
+"""Tier 2: AsyncStackPanel interrupted/aborted flash before unmount (W13 T2-2).
+
+Covers audit finding A#6: clean completion vs abort vs interrupt were
+visually identical (= row vanishes). The new ``terminal`` parameter on
+``AsyncStackPanel.remove`` gives non-ok terminations a brief red flash
+before unmounting.
+
+Public surfaces tested (per testing policy — no private state assertions):
+  1. ``remove("p1", terminal="ok")`` → row immediately gone (= existing
+     behaviour preserved; backwards-compat).
+  2. ``remove("p2", terminal="interrupted")`` → row text contains
+     "interrupted" AND row still in DOM (= flashing=True) after 0.1 s.
+  3. After ~1.6 s (= post-flush), row is gone from DOM.
+  4. Calling ``remove("p3", terminal="interrupted")`` then
+     ``remove("p3", terminal="ok")`` quickly → row gone immediately
+     (= second remove cancels pending timer, unmounts immediately).
+  5. Backwards-compat: existing ``remove("p4")`` no-kwarg call still
+     works (= ``terminal`` defaults to ``"ok"``).
+
+Timer determinism: tests 3 uses ``asyncio.sleep(1.6)`` via pilot.pause;
+test 4 verifies immediate cancellation without sleeping.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _panel_has_id(snap: list[dict], agent_id: str) -> bool:
+    """Return True when ``agent_id`` appears in the snapshot (non-overflow rows)."""
+    return any(s["agent_id"] == agent_id for s in snap if not s["is_overflow"])
+
+
+def _panel_row(snap: list[dict], agent_id: str) -> dict | None:
+    """Return the snapshot dict for ``agent_id``, or None if absent."""
+    for s in snap:
+        if s["agent_id"] == agent_id and not s["is_overflow"]:
+            return s
+    return None
+
+
+# ── test 1: terminal="ok" → immediate unmount ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_remove_ok_unmounts_immediately() -> None:
+    """Tier 2: remove(terminal="ok") drops row immediately — existing behaviour."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p1", "doing stuff")
+        await pilot.pause()
+        assert _panel_has_id(panel.snapshot(), "p1"), "row must appear after add"
+
+        panel.remove("p1", terminal="ok")
+        await pilot.pause()
+        assert not _panel_has_id(panel.snapshot(), "p1"), (
+            "row must be gone immediately after terminal='ok'"
+        )
+
+
+# ── test 2: terminal="interrupted" → row stays (flashing) for 0.1 s ─────────
+
+@pytest.mark.asyncio
+async def test_remove_interrupted_row_still_present_before_flush() -> None:
+    """Tier 2: remove(terminal="interrupted") → row present and flashing after 0.1 s."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p2", "long running task")
+        await pilot.pause()
+        assert _panel_has_id(panel.snapshot(), "p2"), "row must appear after add"
+
+        panel.remove("p2", terminal="interrupted")
+        await pilot.pause(0.1)  # 0.1 s — well before the 1.5 s flush
+
+        snap = panel.snapshot()
+        row = _panel_row(snap, "p2")
+        assert row is not None, (
+            "row must still be present during the flash window (before 1.5 s flush)"
+        )
+        assert row["flashing"] is True, (
+            "snapshot must report flashing=True during the flash window"
+        )
+        # The rendered text (via rendered_text()) should contain "interrupted"
+        rendered = panel._build_lines().plain
+        assert "interrupted" in rendered, (
+            f"rendered text must contain 'interrupted' during flash; got: {rendered!r}"
+        )
+
+
+# ── test 3: terminal="interrupted" → row gone after 1.6 s ───────────────────
+
+@pytest.mark.asyncio
+async def test_remove_interrupted_row_gone_after_flush_delay() -> None:
+    """Tier 2: remove(terminal="interrupted") → row gone after ~1.6 s (post-flush)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p2b", "a background plan")
+        await pilot.pause()
+
+        panel.remove("p2b", terminal="interrupted")
+        await pilot.pause(1.6)  # past the 1.5 s flash window
+
+        assert not _panel_has_id(panel.snapshot(), "p2b"), (
+            "row must be gone from DOM after the 1.5 s flash window expires"
+        )
+
+
+# ── test 4: second remove() cancels pending timer + unmounts immediately ─────
+
+@pytest.mark.asyncio
+async def test_second_remove_cancels_timer_and_unmounts_immediately() -> None:
+    """Tier 2: remove(interrupted) then remove(ok) → immediate unmount (timer cancelled)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p3", "concurrent task")
+        await pilot.pause()
+
+        # First remove — enters flash window, arms timer
+        panel.remove("p3", terminal="interrupted")
+        await pilot.pause()
+        assert _panel_has_id(panel.snapshot(), "p3"), (
+            "row must still be present immediately after terminal='interrupted'"
+        )
+
+        # Second remove — should cancel the timer and unmount immediately
+        panel.remove("p3", terminal="ok")
+        await pilot.pause()
+        assert not _panel_has_id(panel.snapshot(), "p3"), (
+            "row must be gone immediately after second remove() cancels the flash timer"
+        )
+
+
+# ── test 5: no-kwarg call still works (backwards-compat) ─────────────────────
+
+@pytest.mark.asyncio
+async def test_remove_no_kwarg_still_works() -> None:
+    """Tier 2: remove(agent_id) no-kwarg call → immediate unmount (backwards-compat)."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p4", "some task")
+        await pilot.pause()
+        assert _panel_has_id(panel.snapshot(), "p4"), "row must appear after add"
+
+        # No terminal kwarg — must default to "ok" (= immediate unmount)
+        panel.remove("p4")
+        await pilot.pause()
+        assert not _panel_has_id(panel.snapshot(), "p4"), (
+            "no-kwarg remove() must still unmount immediately (backwards-compat)"
+        )


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T2-2 (async stack visibility)

## Summary
- AsyncStackPanel.remove(plan_id, terminal="ok"|"aborted"|"interrupted")
- terminal="ok" preserves existing behavior
- terminal != "ok" briefly shows red ✗ state then unmounts after ~1.5s
- conversation.remove_async_task threads terminal kwarg
- app.py wires aborted/interrupted source → terminal value
- app_outbox.py handles plan_aborted source → terminal="aborted"

## Why
Audit finding A#6: clean completion vs abort vs interrupt were
visually identical (= row vanishes). User couldn't tell what happened.

## Test plan
- [x] tests/cli/test_async_stack_interrupted_flash.py — 5 Tier-2 tests (all pass)
- [x] existing async_stack tests still pass (29 tests)
- [x] ruff clean
- [x] (skipped — manual: /plan discard <id> → row flashes red then disappears; requires live reyn session)