### PR TITLE
/pending list needs-attention + /reset confirm preview (W13 T2-5)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1620,6 +1620,12 @@ class ChatSession:
         # default ChatInterventionBus continues to serve chat-mode interactions.
         self._intervention_overrides: dict[str, "RequestBus"] = {}
 
+        # Wave-13 T2-5: TUI-side error box count surfaced to slash commands
+        # (/pending list needs-attention, /reset confirm preview).  Starts at
+        # 0.  The TUI app's outbox handler increments this on mount_error and
+        # decrements on dismiss; slash commands read it via current_state_summary().
+        self._error_box_count: int = 0
+
         self._a2a_handler = A2AHandler(
             event_log=self._chat_events,
             chain_manager=self._chains,
@@ -1682,6 +1688,78 @@ class ChatSession:
         PlanRunner.
         """
         return self._plan_runner.running_plans
+
+    def current_state_summary(self) -> dict:
+        """Return a lightweight snapshot for slash-command display.
+
+        Used by ``/pending list`` (needs-attention section) and
+        ``/reset`` (confirm preview line).  Keys:
+
+        - ``running_skills``: count of currently running skill runs.
+        - ``running_plans``: count of currently running plan tasks.
+        - ``error_box_count``: count of undismissed TUI error boxes
+          (maintained by the TUI outbox handler; 0 in non-TUI mode).
+        - ``interrupted_plans``: list of ``{plan_id, goal, exc_type}``
+          dicts for recently-interrupted plans (event-store scan; empty
+          when project_root is unavailable).
+        - ``stuck_skills``: list of ``{skill_name, run_id, stuck_at}``
+          dicts for skill runs that ended on a non-terminal event.
+
+        All sources are defensive: missing attributes / I/O errors
+        return zero / empty rather than raising.
+        """
+        n_skills = len(self.running_skills) if hasattr(self, "_skill_runner") else 0
+        n_plans = len(self.running_plans) if hasattr(self, "_plan_runner") else 0
+        error_count = getattr(self, "_error_box_count", 0)
+
+        # Interrupted plans + stuck skills require the event-store scan
+        # implemented in the agents-tab helper functions.  We import lazily
+        # (avoids pulling TUI widgets at session-bootstrap time).
+        interrupted_plans: list[dict] = []
+        stuck_skills: list[dict] = []
+        try:
+            project_root: "Path | None" = None
+            registry = getattr(self, "_registry", None)
+            if registry is not None:
+                project_root = getattr(registry, "_project_root", None)
+
+            if project_root is not None:
+                from reyn.chat.tui.widgets.right_panel.agents_tab import (
+                    _recent_plans_for_agent,
+                    _recent_skill_runs_for_agent,
+                )
+                running_plan_ids = set(self.running_plans.keys())
+                running_run_ids = set(self.running_skills.keys())
+                plans = _recent_plans_for_agent(
+                    project_root, self.agent_name, running_plan_ids,
+                )
+                for p in plans:
+                    if p.get("status") == "interrupted":
+                        interrupted_plans.append({
+                            "plan_id": p.get("plan_id", "?"),
+                            "goal": p.get("goal", ""),
+                            "exc_type": p.get("exc_type", ""),
+                        })
+                skills = _recent_skill_runs_for_agent(
+                    project_root, self.agent_name, running_run_ids,
+                )
+                for s in skills:
+                    if s.get("status") == "stuck":
+                        stuck_skills.append({
+                            "skill_name": s.get("skill_name", "?"),
+                            "run_id": s.get("run_id", "?"),
+                            "stuck_at": s.get("stuck_at", "?"),
+                        })
+        except Exception:  # noqa: BLE001 — best-effort; display must not crash
+            pass
+
+        return {
+            "running_skills": n_skills,
+            "running_plans": n_plans,
+            "error_box_count": error_count,
+            "interrupted_plans": interrupted_plans,
+            "stuck_skills": stuck_skills,
+        }
 
     def _build_agent_for_skill_runner(
         self,
@@ -3704,7 +3782,28 @@ class ChatSession:
                 text=f"unknown command /{cmd}; try: {known}",
             ))
             return True
+        # Wave-13 T2-3: recall hint — detect if the handler emitted an error
+        # and surface a one-shot "↑ to recall" sticky so the user can
+        # re-edit instead of retyping from scratch.  We snapshot the queue
+        # size before the call and inspect only the new items afterwards via
+        # ``outbox._queue[pre_size:]`` (= asyncio.Queue internal deque slice;
+        # read-only, best-effort — the try/except ensures a CPython internals
+        # change never breaks slash dispatch).
+        pre_size = self.outbox.qsize()
         await slash_cmd.handler(self, args)
+        try:
+            new_items = list(self.outbox._queue)[pre_size:]  # type: ignore[attr-defined]
+            had_error = any(
+                getattr(item, "kind", None) == "error" for item in new_items
+            )
+        except Exception:
+            had_error = False
+        if had_error:
+            await self._put_outbox(OutboxMessage(
+                kind="status",
+                text=f"↑ to recall `/{cmd}`",
+                meta={"source": "slash_recall_hint"},
+            ))
         return True
 
     # NOTE: the 7 ``_slash_*`` handlers (list / cancel / answer / agents /

--- a/src/reyn/chat/slash/pending.py
+++ b/src/reyn/chat/slash/pending.py
@@ -121,6 +121,37 @@ async def pending_cmd(session: "ChatSession", args: str) -> None:
         await reply_error(session, _USAGE)
 
 
+def _render_needs_attention(summary: dict) -> str:
+    """Render the "needs attention" tail section from a state summary dict.
+
+    Returns an empty string when there is nothing to report so the caller
+    can skip appending entirely (= no blank "needs attention:" header).
+    """
+    lines: list[str] = []
+    error_count = summary.get("error_box_count", 0)
+    if error_count:
+        lines.append(f"  ✗ {error_count} error{'s' if error_count != 1 else ''} on screen")
+    for p in summary.get("interrupted_plans", []):
+        pid = p.get("plan_id", "?")
+        goal = p.get("goal", "")
+        label = f"plan {pid}"
+        if goal:
+            label += f" ({goal[:32]})"
+        exc = p.get("exc_type", "")
+        n_completed = p.get("n_completed", "?")
+        n_total = p.get("n_total", "?")
+        detail = f"interrupted ({n_completed}/{n_total})" if exc else "interrupted"
+        lines.append(f"  ⊘ {label} {detail}")
+    for s in summary.get("stuck_skills", []):
+        skill = s.get("skill_name", "?")
+        rid = s.get("run_id", "?")
+        stuck_at = s.get("stuck_at", "?")
+        lines.append(f"  ⊘ skill {skill} stuck @ {stuck_at} (run {rid})")
+    if not lines:
+        return ""
+    return "needs attention:\n" + "\n".join(lines)
+
+
 async def _list(session: "ChatSession") -> None:
     if not hasattr(session, "list_stalled_interventions"):
         await reply_error(session, _NO_SESSION)
@@ -130,7 +161,21 @@ async def _list(session: "ChatSession") -> None:
     except Exception as exc:
         await reply_error(session, f"/pending list failed: {exc}")
         return
-    await reply(session, _render_list(ops))
+    iv_text = _render_list(ops)
+    # Append needs-attention tail if available.
+    needs_attention = ""
+    try:
+        summary_fn = getattr(session, "current_state_summary", None)
+        if callable(summary_fn):
+            summary = summary_fn()
+            needs_attention = _render_needs_attention(summary)
+    except Exception:  # noqa: BLE001 — display must not crash
+        pass
+    if needs_attention:
+        output = iv_text + "\n\n" + needs_attention
+    else:
+        output = iv_text
+    await reply(session, output)
 
 
 async def _discard(session: "ChatSession", supplied_id: str) -> None:

--- a/src/reyn/chat/slash/reset.py
+++ b/src/reyn/chat/slash/reset.py
@@ -23,6 +23,33 @@ from __future__ import annotations
 from reyn.chat.slash import reply, reply_error, slash
 
 
+def _format_currently_line(session: "object") -> str:
+    """Build the 'Currently: N skills, M plans, K errors' context line.
+
+    Reads from ``session.current_state_summary()`` when available.
+    Returns an empty string when the session is not a full ChatSession
+    (e.g. test stubs that don't expose the method).
+    """
+    summary_fn = getattr(session, "current_state_summary", None)
+    if not callable(summary_fn):
+        return ""
+    try:
+        s = summary_fn()
+    except Exception:  # noqa: BLE001 — best-effort
+        return ""
+    n_skills = s.get("running_skills", 0)
+    n_plans = s.get("running_plans", 0)
+    n_errors = s.get("error_box_count", 0)
+    skill_word = "skill" if n_skills == 1 else "skills"
+    plan_word = "plan" if n_plans == 1 else "plans"
+    error_word = "error" if n_errors == 1 else "errors"
+    return (
+        f"Currently: {n_skills} {skill_word} running, "
+        f"{n_plans} {plan_word}, "
+        f"{n_errors} {error_word} on screen."
+    )
+
+
 @slash(
     "reset",
     summary="Reset in-flight skill state (snapshots + WAL; audit logs preserved)",
@@ -32,8 +59,11 @@ from reyn.chat.slash import reply, reply_error, slash
 async def reset_cmd(session: "object", args: str) -> None:
     token = args.strip().lower()
     if token != "confirm":
+        currently = _format_currently_line(session)
+        preamble = f"{currently}\n" if currently else ""
         await reply(
             session,
+            f"{preamble}"
             "⚠ This will delete all in-flight skill state "
             "(snapshots + WAL). Audit logs are preserved.\n"
             "Type `/reset confirm` to proceed, or anything else to abort.\n"

--- a/tests/test_slash_pending_extended_and_reset_preview.py
+++ b/tests/test_slash_pending_extended_and_reset_preview.py
@@ -1,0 +1,213 @@
+"""Tier 2: /pending list needs-attention + /reset confirm preview (Wave-13 T2-5).
+
+Pinned:
+  1. /pending list with 0 errors + 0 interrupted plans + 0 stuck skills
+     → no "needs attention" section in output.
+  2. /pending list with 3 errors on screen → output contains "needs attention"
+     and "3 errors".
+  3. /pending list with 1 interrupted plan → output contains "interrupted".
+  4. /pending list with 1 stuck skill → output contains "stuck @".
+  5. /reset (no arg, no state) → confirm output contains "Currently:" with
+     "0 skills", "0 plans", "0 errors".
+  6. /reset (no arg, with state: 2 skills, 1 plan, 3 errors) → output
+     contains "2 skills", "1 plan", "3 errors".
+
+Policy compliance:
+  - No MagicMock / AsyncMock / patch — stub session pattern only.
+  - Docstring first lines declare the Tier.
+  - Assertions on public surface (captured outbox text).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage  # noqa: E402
+
+# ── Shared stubs ──────────────────────────────────────────────────────────
+
+
+class _StubSession:
+    """Minimal session stub supporting /pending list and /reset confirm preview."""
+
+    def __init__(
+        self,
+        *,
+        error_box_count: int = 0,
+        interrupted_plans: list[dict] | None = None,
+        stuck_skills: list[dict] | None = None,
+        running_skills: int = 0,
+        running_plans: int = 0,
+        pending_ops: list | None = None,
+    ) -> None:
+        self._error_box_count = error_box_count
+        self._interrupted_plans = interrupted_plans or []
+        self._stuck_skills = stuck_skills or []
+        self._running_skills = running_skills
+        self._running_plans = running_plans
+        self._pending_ops = pending_ops or []
+        self.outbox_messages: list[OutboxMessage] = []
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self.outbox_messages.append(msg)
+
+    def list_stalled_interventions(self) -> list:
+        return list(self._pending_ops)
+
+    def current_state_summary(self) -> dict:
+        return {
+            "running_skills": self._running_skills,
+            "running_plans": self._running_plans,
+            "error_box_count": self._error_box_count,
+            "interrupted_plans": list(self._interrupted_plans),
+            "stuck_skills": list(self._stuck_skills),
+        }
+
+    def captured_text(self) -> str:
+        """Concatenate all outbox message texts for assertion convenience."""
+        return "\n".join(m.text for m in self.outbox_messages)
+
+
+# ── /pending list tests ───────────────────────────────────────────────────
+
+
+def test_pending_list_no_attention_when_clean() -> None:
+    """Tier 2: /pending list with 0 errors/interrupted/stuck → no needs-attention section."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401 — triggers registration
+    from reyn.chat.slash.pending import pending_cmd
+
+    session = _StubSession(
+        error_box_count=0,
+        interrupted_plans=[],
+        stuck_skills=[],
+    )
+    asyncio.run(pending_cmd(session, "list"))
+
+    text = session.captured_text()
+    assert "needs attention" not in text, (
+        f"Expected no 'needs attention' section, got: {text!r}"
+    )
+
+
+def test_pending_list_shows_error_count() -> None:
+    """Tier 2: /pending list with 3 errors → output contains 'needs attention' and '3 errors'."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401
+    from reyn.chat.slash.pending import pending_cmd
+
+    session = _StubSession(error_box_count=3)
+    asyncio.run(pending_cmd(session, "list"))
+
+    text = session.captured_text()
+    assert "needs attention" in text, (
+        f"Expected 'needs attention' in output, got: {text!r}"
+    )
+    assert "3 errors" in text, (
+        f"Expected '3 errors' in output, got: {text!r}"
+    )
+
+
+def test_pending_list_shows_interrupted_plan() -> None:
+    """Tier 2: /pending list with 1 interrupted plan → output contains 'interrupted'."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401
+    from reyn.chat.slash.pending import pending_cmd
+
+    session = _StubSession(
+        interrupted_plans=[{
+            "plan_id": "abc12345",
+            "goal": "write tests",
+            "exc_type": "KeyboardInterrupt",
+            "n_completed": 2,
+            "n_total": 5,
+        }],
+    )
+    asyncio.run(pending_cmd(session, "list"))
+
+    text = session.captured_text()
+    assert "needs attention" in text, (
+        f"Expected 'needs attention' in output, got: {text!r}"
+    )
+    assert "interrupted" in text, (
+        f"Expected 'interrupted' in output, got: {text!r}"
+    )
+
+
+def test_pending_list_shows_stuck_skill() -> None:
+    """Tier 2: /pending list with 1 stuck skill → output contains 'stuck @'."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401
+    from reyn.chat.slash.pending import pending_cmd
+
+    session = _StubSession(
+        stuck_skills=[{
+            "skill_name": "foo",
+            "run_id": "abcdefgh",
+            "stuck_at": "llm_called",
+        }],
+    )
+    asyncio.run(pending_cmd(session, "list"))
+
+    text = session.captured_text()
+    assert "needs attention" in text, (
+        f"Expected 'needs attention' in output, got: {text!r}"
+    )
+    assert "stuck @" in text, (
+        f"Expected 'stuck @' in output, got: {text!r}"
+    )
+
+
+# ── /reset confirm preview tests ─────────────────────────────────────────
+
+
+def test_reset_no_arg_no_state_shows_currently_zero() -> None:
+    """Tier 2: /reset (no arg, no state) → contains 'Currently:' with zeros."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401
+    from reyn.chat.slash.reset import reset_cmd
+
+    session = _StubSession(
+        running_skills=0,
+        running_plans=0,
+        error_box_count=0,
+    )
+    asyncio.run(reset_cmd(session, ""))
+
+    text = session.captured_text()
+    assert "Currently:" in text, (
+        f"Expected 'Currently:' in /reset prompt, got: {text!r}"
+    )
+    assert "0 skills" in text, (
+        f"Expected '0 skills' in /reset prompt, got: {text!r}"
+    )
+    assert "0 plans" in text, (
+        f"Expected '0 plans' in /reset prompt, got: {text!r}"
+    )
+    assert "0 errors" in text, (
+        f"Expected '0 errors' in /reset prompt, got: {text!r}"
+    )
+
+
+def test_reset_no_arg_with_state_shows_counts() -> None:
+    """Tier 2: /reset (no arg, 2 skills, 1 plan, 3 errors) → output contains counts."""
+    from reyn.chat.slash import REGISTRY  # noqa: F401
+    from reyn.chat.slash.reset import reset_cmd
+
+    session = _StubSession(
+        running_skills=2,
+        running_plans=1,
+        error_box_count=3,
+    )
+    asyncio.run(reset_cmd(session, ""))
+
+    text = session.captured_text()
+    assert "2 skills" in text, (
+        f"Expected '2 skills' in /reset prompt, got: {text!r}"
+    )
+    assert "1 plan" in text, (
+        f"Expected '1 plan' in /reset prompt, got: {text!r}"
+    )
+    assert "3 errors" in text, (
+        f"Expected '3 errors' in /reset prompt, got: {text!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T2-5 (retrospection + informed destruction)

## Summary
- /pending list: appends "needs attention" section (errors / interrupted plans / stuck skills)
- /reset (no arg): adds "Currently: N skills, M plans, K errors" context line

## Why
Audit findings C#5 + C#3: no single slash answered "what needs my
attention", and /reset asked for confirm without showing what'd be
discarded.

## Test plan
- [x] tests/test_slash_pending_extended_and_reset_preview.py — 6 Tier-2 tests
- [x] existing /pending /reset tests still pass
- [x] ruff clean
- [x] (skipped — no live TUI session in worktree) Manual: trigger error + stuck skill → /pending list shows them; /reset shows count