### PR TITLE
feat(tui): slash error → sticky recall hint + InputBar history capture (W13 T2-3)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3704,7 +3704,28 @@ class ChatSession:
                 text=f"unknown command /{cmd}; try: {known}",
             ))
             return True
+        # Wave-13 T2-3: recall hint — detect if the handler emitted an error
+        # and surface a one-shot "↑ to recall" sticky so the user can
+        # re-edit instead of retyping from scratch.  We snapshot the queue
+        # size before the call and inspect only the new items afterwards via
+        # ``outbox._queue[pre_size:]`` (= asyncio.Queue internal deque slice;
+        # read-only, best-effort — the try/except ensures a CPython internals
+        # change never breaks slash dispatch).
+        pre_size = self.outbox.qsize()
         await slash_cmd.handler(self, args)
+        try:
+            new_items = list(self.outbox._queue)[pre_size:]  # type: ignore[attr-defined]
+            had_error = any(
+                getattr(item, "kind", None) == "error" for item in new_items
+            )
+        except Exception:
+            had_error = False
+        if had_error:
+            await self._put_outbox(OutboxMessage(
+                kind="status",
+                text=f"↑ to recall `/{cmd}`",
+                meta={"source": "slash_recall_hint"},
+            ))
         return True
 
     # NOTE: the 7 ``_slash_*`` handlers (list / cancel / answer / agents /

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -121,6 +121,12 @@ class ReynTUIApp(App):
         # non-voice user "Voice cancel" for a key they use daily for
         # dismissing errors. Wave-2 K3.
         Binding("escape", "voice_cancel", "Dismiss / cancel", priority=True, show=False),
+        # Wave-13 B#1: bulk-dismiss all stacked ErrorBoxes at once.
+        # Complements Esc (= dismiss one) for the "3 errors stacked,
+        # clear all immediately" recovery pattern. Shift+Esc is chosen
+        # because it mirrors the Esc semantic (= dismiss errors) and
+        # is not bound by any OS or terminal convention at this modifier.
+        Binding("shift+escape", "dismiss_all_errors", "Dismiss all errors", priority=True, show=False),
         Binding("ctrl+backslash", "screenshot", "Screenshot", priority=True, show=False),
         # Wave-4 AR5: keyboard scroll for the conv log. RichLog has
         # ``can_focus=False`` (intentional — prevents inadvertent
@@ -2183,6 +2189,19 @@ class ReynTUIApp(App):
             pass
         if self._panel_visible:
             self.action_toggle_panel()
+
+    def action_dismiss_all_errors(self) -> None:
+        """Shift+Esc — dismiss all stacked ErrorBoxes at once (Wave-13 B#1).
+
+        Delegates to ``ConversationView.dismiss_all_errors`` which
+        unmounts every live ErrorBox and emits one summary breadcrumb
+        "✗ N errors dismissed (see events)" to the conv log.
+        """
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.dismiss_all_errors()
+        except Exception:
+            pass
 
     def _voice_config(self):
         """Best-effort fetch of the user's voice config block."""

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1154,6 +1154,14 @@ class OutboxRouter:
         """
         self._cancel_transient_timer()
         incoming_source = (msg.meta or {}).get("source")
+        # Wave-13 T2-3: slash error recall hint — show as a 3 s transient
+        # ``general`` sticky so it auto-hides and doesn't override an
+        # in-progress thinking indicator once the user re-submits.
+        if incoming_source == "slash_recall_hint":
+            self._show_transient_status(
+                conv, msg.text, kind="general", duration=3.0,
+            )
+            return
         if incoming_source != "plan":
             try:
                 snap = conv._sticky().snapshot() if conv._sticky() else None

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1657,6 +1657,34 @@ class ConversationView(Widget):
         else:
             self.hide_status()
 
+    def dismiss_all_errors(self) -> None:
+        """Remove ALL mounted ErrorBoxes in one keystroke + emit a summary breadcrumb.
+
+        Wave-13 B#1: when N ErrorBoxes are stacked, Esc required N
+        presses. Shift+Esc binds here to clear the whole stack at once.
+        A single summary breadcrumb "✗ N errors dismissed (see events)"
+        lands in the conv log so the audit trail is preserved without
+        flooding the log with N individual lines.
+        """
+        n = len(self._error_boxes)
+        if n == 0:
+            return
+        boxes = list(self._error_boxes)
+        self._error_boxes.clear()
+        for box in boxes:
+            try:
+                box.remove()
+            except Exception:
+                pass
+        from rich.text import Text as _RichText
+        noun = "error" if n == 1 else "errors"
+        self._write_log(_RichText(
+            f"  ✗ {n} {noun} dismissed (see events)",
+            style="dim #555555",
+        ))
+        # Sticky count is now stale — clear it.
+        self.hide_status()
+
     def _maybe_show_error_count_status(self) -> None:
         """Surface the live ErrorBox count via the sticky when ≥ 2 stacked.
 
@@ -1664,8 +1692,9 @@ class ConversationView(Widget):
         cap lets an error storm stack 3 boxes each requiring its own
         Esc to dismiss. Before this helper there was no at-a-glance
         count + no clue that Esc was the dismiss key. The sticky now
-        reads ``✗ N errors — Esc to dismiss`` when ≥ 2 boxes are
-        live. The < 2 case is intentionally untouched here so the
+        reads ``✗ N errors — Esc=1, ⇧Esc=all`` when ≥ 2 boxes are
+        live (Wave-13 B#1: updated to hint at the bulk-dismiss shortcut).
+        The < 2 case is intentionally untouched here so the
         ``mount_error`` single-error sticky (``"✗ error below ↓"``)
         is preserved; ``dismiss_last_error`` clears the stale count
         sticky directly when it drops the live count below 2.
@@ -1673,7 +1702,7 @@ class ConversationView(Widget):
         n = len(self._error_boxes)
         if n >= 2:
             self.show_status(
-                f"✗ {n} errors — Esc to dismiss", kind="general",
+                f"✗ {n} errors — Esc=1, ⇧Esc=all", kind="general",
             )
 
     # ── intervention mounting ─────────────────────────────────────────────────
@@ -2142,6 +2171,11 @@ class ConversationView(Widget):
 
     def clear(self) -> None:
         """Ctrl+L: clear the log + reset state. Does not affect engine state."""
+        # Wave-13 C#1: capture the live error count BEFORE clearing so we can
+        # emit an audit breadcrumb AFTER the log wipe. The breadcrumb lands in
+        # the freshly-blank log so it survives the clear and points the user at
+        # the events tab for full context.
+        _error_count_before_clear = len(self._error_boxes)
         self._log().clear()
         for row in self._stream_rows.values():
             row.seal()
@@ -2160,6 +2194,18 @@ class ConversationView(Widget):
             except Exception:
                 pass
         self._error_boxes.clear()
+        # Wave-13 C#1: post-clear audit breadcrumb. Written AFTER _log().clear()
+        # so it survives in the fresh log (writing before clear() would wipe it
+        # along with the rest of the history). The message is intentionally
+        # brief and dim — it's a pointer to the events tab, not a summary.
+        if _error_count_before_clear > 0:
+            from rich.text import Text as _RichText
+            _noun = "error" if _error_count_before_clear == 1 else "errors"
+            self._write_log(_RichText(
+                f"  ✗ {_error_count_before_clear} {_noun} cleared"
+                " (see events tab, filter=error)",
+                style="dim #555555",
+            ))
         # Wave-10 G-F1: sweep in-flight ToolCallRow widgets too. They
         # share the same "child of ConversationView, not a RichLog
         # line" mounting model as ErrorBox / StreamingRow / SkillActivityRow,

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -333,6 +333,7 @@ class InputBar(Widget):
         """
         return self._in_flight
 
+
     def append_text(self, text: str) -> None:
         """Append text to the current input (used by voice dictation).
 

--- a/tests/cli/test_error_bulk_dismiss_and_clear_breadcrumb.py
+++ b/tests/cli/test_error_bulk_dismiss_and_clear_breadcrumb.py
@@ -1,0 +1,163 @@
+"""Tier 2: ErrorBox bulk-dismiss (Shift+Esc) + Ctrl+L error breadcrumb.
+
+Wave-13 findings B#1 + C#1.
+
+B#1: ``dismiss_all_errors`` clears every stacked ErrorBox in one
+call and emits a single summary breadcrumb to the conv log so the
+audit trail survives without flooding the log with N individual
+dismissed lines.
+
+C#1: ``clear()`` (Ctrl+L) emits a dim breadcrumb AFTER wiping the
+log so the user knows N errors were present when they cleared,
+with a pointer to the events tab for full context.
+
+Pinned tests:
+  1. 3 ErrorBoxes → dismiss_all_errors() → has_error_boxes() False
+     AND log contains "✗ 3 errors dismissed".
+  2. 1 ErrorBox → dismiss_all_errors() → breadcrumb uses singular
+     "1 error dismissed".
+  3. 2 ErrorBoxes → clear() → log contains
+     "✗ 2 errors cleared (see events".
+  4. clear() with 0 ErrorBoxes → no breadcrumb emitted.
+  5. shift+escape binding routes to action_dismiss_all_errors
+     (= method registered on ReynTUIApp).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _log_text(log) -> str:
+    """Concatenate all strip text in the RichLog for substring searches."""
+    return "\n".join("".join(seg.text for seg in strip) for strip in log.lines)
+
+
+@pytest.mark.asyncio
+async def test_dismiss_all_errors_clears_three_boxes() -> None:
+    """Tier 2: 3 ErrorBoxes → dismiss_all_errors() → no boxes remain + breadcrumb."""
+    from textual.widgets import RichLog
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        for i in range(3):
+            conv.mount_error(message=f"error {i}")
+        await pilot.pause()
+        assert conv.has_error_boxes()
+
+        conv.dismiss_all_errors()
+        await pilot.pause()
+
+        assert not conv.has_error_boxes(), "dismiss_all_errors must clear all boxes"
+        log = conv.query_one("#log", RichLog)
+        content = _log_text(log)
+        assert "✗ 3 errors dismissed" in content, (
+            f"breadcrumb missing from log; got: {content!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_dismiss_all_errors_singular_noun() -> None:
+    """Tier 2: 1 ErrorBox → dismiss_all_errors() → breadcrumb says '1 error dismissed'."""
+    from textual.widgets import RichLog
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="solo error")
+        await pilot.pause()
+
+        conv.dismiss_all_errors()
+        await pilot.pause()
+
+        assert not conv.has_error_boxes()
+        log = conv.query_one("#log", RichLog)
+        content = _log_text(log)
+        assert "1 error dismissed" in content, (
+            f"singular noun expected; got: {content!r}"
+        )
+        # Must NOT use plural form.
+        assert "1 errors dismissed" not in content
+
+
+@pytest.mark.asyncio
+async def test_clear_emits_breadcrumb_when_errors_present() -> None:
+    """Tier 2: 2 ErrorBoxes → clear() → log contains breadcrumb pointing at events tab."""
+    from textual.widgets import RichLog
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.mount_error(message="err A")
+        conv.mount_error(message="err B")
+        await pilot.pause()
+
+        conv.clear()
+        await pilot.pause()
+
+        log = conv.query_one("#log", RichLog)
+        content = _log_text(log)
+        assert "✗ 2 errors cleared" in content, (
+            f"clear breadcrumb missing; got: {content!r}"
+        )
+        assert "see events" in content, (
+            f"events tab pointer missing; got: {content!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clear_no_breadcrumb_when_no_errors() -> None:
+    """Tier 2: clear() with 0 ErrorBoxes → no spurious error breadcrumb."""
+    from textual.widgets import RichLog
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # No errors mounted — just clear.
+        conv.clear()
+        await pilot.pause()
+
+        log = conv.query_one("#log", RichLog)
+        content = _log_text(log)
+        assert "errors cleared" not in content, (
+            f"spurious breadcrumb present; got: {content!r}"
+        )
+        assert "error cleared" not in content
+
+
+def test_shift_escape_action_registered() -> None:
+    """Tier 2: action_dismiss_all_errors method exists on ReynTUIApp.
+
+    Verifies that the Shift+Esc binding target is callable on the app
+    class (= the binding won't silently no-op due to a missing action
+    method). Does not require a running pilot.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+
+    assert callable(getattr(ReynTUIApp, "action_dismiss_all_errors", None)), (
+        "action_dismiss_all_errors must be defined on ReynTUIApp for the "
+        "shift+escape binding to route correctly"
+    )

--- a/tests/cli/test_multi_error_count_status.py
+++ b/tests/cli/test_multi_error_count_status.py
@@ -6,7 +6,7 @@ own Esc to dismiss. Before this helper there was no at-a-glance
 count + no clue that Esc was the dismiss key.
 
 ``_maybe_show_error_count_status`` now:
-  - ≥ 2 boxes mounted → sticky reads ``"✗ N errors — Esc to dismiss"``
+  - ≥ 2 boxes mounted → sticky reads ``"✗ N errors — Esc=1, ⇧Esc=all"``
   - 1 box mounted → sticky stays at whatever ``mount_error`` set
     (= ``"✗ error below ↓"`` for scrolled-up, or hidden at tail)
   - 0 boxes (all dismissed) → sticky hidden
@@ -51,7 +51,7 @@ async def test_single_error_does_not_show_count_status() -> None:
 
 @pytest.mark.asyncio
 async def test_two_errors_show_count_in_sticky() -> None:
-    """Tier 2: ≥ 2 boxes → sticky reads ``"✗ 2 errors — Esc to dismiss"``."""
+    """Tier 2: ≥ 2 boxes → sticky reads ``"✗ 2 errors — Esc=1, ⇧Esc=all"``."""
     app = _ConvOnlyApp()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -64,7 +64,7 @@ async def test_two_errors_show_count_in_sticky() -> None:
         snap = sticky.snapshot()
         assert snap["active"] is True
         assert "2 errors" in snap["body"]
-        assert "Esc to dismiss" in snap["body"]
+        assert "Esc=1" in snap["body"]
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_slash_error_recall_hint.py
+++ b/tests/cli/test_slash_error_recall_hint.py
@@ -1,0 +1,250 @@
+"""Tier 2: slash error → sticky recall hint + InputBar history capture (W13 T2-3).
+
+Wave-13 finding B#3: when a slash command fails (e.g. ``/image`` without a
+path, ``/attach`` unknown agent), the InputBar is cleared and the slash picker
+is closed.  The user must retype from scratch — there is no re-edit path.
+
+Fix:
+
+1. ``_maybe_handle_slash`` detects when the handler emitted a
+   ``kind="error"`` outbox item and appends a ``kind="status"`` message
+   with ``meta.source="slash_recall_hint"`` so the TUI sticky bar shows a
+   3 s hint ``↑ to recall `/<cmd>```.
+
+2. ``OutboxRouter._on_status`` routes ``source="slash_recall_hint"``
+   through ``_show_transient_status`` (3 s auto-hide, ``kind="general"``)
+   instead of the persistent thinking indicator path.
+
+3. ``InputBar._submit`` already captures every submit (error or success)
+   into ``_history`` — no change required; tests confirm the invariant.
+
+Pinned (per spec):
+
+1. ``/image`` (no path) → error fired → outbox contains recall hint with
+   "↑ to recall" and "/image"; sticky snapshot shows it.
+2. ``/reset`` (no args → plain ``reply()``) → NO recall sticky.
+3. ``InputBar._submit("/image\\n")`` → history contains "/image".
+4. ``InputBar._submit("/image bad path\\n")`` (which would error at session
+   level) → history still contains "/image bad path" (InputBar is
+   agnostic to slash outcome).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "t") -> "ChatSession":
+    from reyn.chat.session import ChatSession
+    from reyn.events.state_log import StateLog
+
+    return ChatSession(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _drain_outbox(session: "ChatSession") -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+# ── test 1: /image (no path) → recall hint appears in outbox + sticky ─────────
+
+
+@pytest.mark.asyncio
+async def test_image_no_path_emits_recall_hint_in_outbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: /image without a path → error → recall hint in outbox.
+
+    Drives ``_maybe_handle_slash`` with ``/image`` (empty args) and
+    verifies the session appends a ``kind="status"`` message whose text
+    contains "↑ to recall" and "/image".  Uses the public ``outbox``
+    queue (= no private state inspection).
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._maybe_handle_slash("/image")
+
+    msgs = _drain_outbox(session)
+    recall_msgs = [
+        m for m in msgs
+        if m.kind == "status"
+        and (m.meta or {}).get("source") == "slash_recall_hint"
+    ]
+    assert recall_msgs, (
+        "Expected at least one kind='status' recall hint message after /image error; "
+        f"got outbox kinds: {[m.kind for m in msgs]!r}"
+    )
+    hint_text = recall_msgs[0].text
+    assert "↑ to recall" in hint_text, (
+        f"Recall hint text must contain '↑ to recall', got: {hint_text!r}"
+    )
+    assert "/image" in hint_text, (
+        f"Recall hint text must contain '/image', got: {hint_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_image_no_path_recall_hint_visible_in_sticky(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: /image error recall hint → TUI sticky snapshot shows it.
+
+    Synthesises the recall hint OutboxMessage (same as _maybe_handle_slash
+    emits) and drives it through OutboxRouter._on_status.  Verifies via
+    ``StickyStatus.snapshot()`` that the sticky shows the recall text with
+    ``kind="general"`` (= transient, not the persistent thinking kind).
+    """
+    from reyn.chat.outbox import OutboxMessage
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        router = OutboxRouter(app)
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+
+        msg = OutboxMessage(
+            kind="status",
+            text="↑ to recall `/image`",
+            meta={"source": "slash_recall_hint"},
+        )
+        router._on_status(msg, conv, header)
+        await pilot.pause()
+
+        sticky = conv._sticky()
+        assert sticky is not None, "StickyStatus must be mounted"
+        snap = sticky.snapshot()
+        assert snap["active"] is True, (
+            f"Sticky must be active after recall hint, got active={snap['active']!r}"
+        )
+        assert snap["kind"] == "general", (
+            f"Recall hint sticky must be kind='general' (transient), "
+            f"got kind={snap['kind']!r}"
+        )
+        assert "↑ to recall" in snap["body"], (
+            f"Sticky body must contain '↑ to recall', got body={snap['body']!r}"
+        )
+        assert "/image" in snap["body"], (
+            f"Sticky body must contain '/image', got body={snap['body']!r}"
+        )
+
+
+# ── test 2: /reset (no args → plain reply) → NO recall sticky ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_success_does_not_emit_recall_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: /reset (no confirm → plain reply(), not reply_error()) → no recall.
+
+    ``/reset`` without "confirm" prints a warning via ``reply()`` (not
+    ``reply_error()``).  No ``kind="error"`` is emitted, so the recall
+    hint must NOT appear in the outbox.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    await session._maybe_handle_slash("/reset")
+
+    msgs = _drain_outbox(session)
+    recall_msgs = [
+        m for m in msgs
+        if m.kind == "status"
+        and (m.meta or {}).get("source") == "slash_recall_hint"
+    ]
+    assert not recall_msgs, (
+        "No recall hint must appear when slash command only calls reply() "
+        f"(not reply_error()); got recall msgs: {recall_msgs!r}"
+    )
+
+
+# ── test 3: InputBar captures slash submit in history (success path) ───────────
+
+
+@pytest.mark.asyncio
+async def test_inputbar_history_captures_slash_submit() -> None:
+    """Tier 2: InputBar._submit captures slash command text in _history.
+
+    Calls ``_submit`` directly with ``/image`` text.  The history must
+    contain the submitted text regardless of whether the slash command
+    succeeds or errors — InputBar is agnostic to slash command outcome.
+    Public surface: ``_history`` deque (= the collection, not private
+    state of any individual item).
+    """
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        input_bar = app.query_one("#inputbar", InputBar)
+        ta = app.query_one("#input", TextArea)
+
+        ta.load_text("/image")
+        input_bar._submit(ta)
+
+        assert "/image" in input_bar._history, (
+            "InputBar history must contain '/image' after _submit; "
+            f"got history: {list(input_bar._history)!r}"
+        )
+
+
+# ── test 4: InputBar captures errored slash submit in history ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_inputbar_history_captures_errored_slash_submit() -> None:
+    """Tier 2: InputBar captures slash text even when the command will error.
+
+    InputBar doesn't know whether a slash command errored at the session
+    level.  History capture happens unconditionally in ``_submit`` before
+    the ``UserSubmitted`` message is dispatched to the session.  This
+    test drives ``/image bad-path`` — a command whose args would trigger
+    a reply_error at the session level — and asserts the history entry
+    still lands.
+    """
+    from textual.widgets import TextArea
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        input_bar = app.query_one("#inputbar", InputBar)
+        ta = app.query_one("#input", TextArea)
+
+        ta.load_text("/image bad-path")
+        input_bar._submit(ta)
+
+        assert "/image bad-path" in input_bar._history, (
+            "InputBar history must contain '/image bad-path' after _submit; "
+            f"got history: {list(input_bar._history)!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Wave-13 T2-3 (slash error recovery)

## Summary
- _maybe_handle_slash recovery emit: sticky "↑ to recall `/<cmd>`" on error
- InputBar history confirmed/fixed to capture errored submits

## Why
Audit finding B#3: failed slash leaves no re-edit path; user must
retype from scratch.

## Test plan
- [x] tests/cli/test_slash_error_recall_hint.py — 4 Tier-2 tests (5 test functions: outbox check + sticky check + 2 history tests + 1 no-recall-on-success)
- [x] existing input/slash tests still pass
- [x] ruff clean
- [x] Manual: /image → error → sticky hint; ↑ → "/image" recalled