### PR TITLE
feat(tui): events tab — hide compaction_check by default + v toggle

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -162,6 +162,13 @@ class RightPanel(Widget):
         # tail at tail=200 is unreadable; isolate makes one chain
         # legible at a time.
         self._events_chain_isolate: str | None = None
+        # Verbose mode — when False (default), ``render_events`` hides
+        # ``compaction_check`` events which fire on every chat turn but
+        # mostly carry "didn't compact" outcomes (too_few_turns /
+        # below_min_batch / below_threshold / already_running). The actual
+        # compaction lifecycle (compaction_started / completed / failed)
+        # is always shown. Toggled by ``v`` on the events tab.
+        self._events_verbose: bool = False
         # Memory tab state — flat cursor over all entries
         self._memory_cursor: int = 0
         self._memory_entries: list[Any] = []
@@ -652,6 +659,22 @@ class RightPanel(Widget):
             # a flash for the wrong-tab case.
             event.prevent_default()
             self._flash_status("'i' only active on the Events tab")
+        elif event.key == "v" and self._panel_type == "events":
+            # Events tab ``v`` = toggle verbose mode. When off (default),
+            # compaction_check events are hidden (= "didn't compact" noise).
+            # When on, the full unfiltered list is shown including
+            # compaction_check. Scoped to events tab only — other tabs
+            # don't consume ``v``.
+            event.prevent_default()
+            self._events_verbose = not self._events_verbose
+            self._invalidate()
+            state = "on" if self._events_verbose else "off"
+            self._flash_status(f"events: verbose={state}")
+        elif event.key == "v" and self._panel_type != "events":
+            # ``v`` is only meaningful on the Events tab. Surface a flash
+            # hint so a wrong-tab press isn't a silent no-op.
+            event.prevent_default()
+            self._flash_status("'v' only active on the Events tab")
         elif event.key == "a" and self._panel_type == "agents":
             # Wave-10 follow-up H-F11: Agents tab `a` = switch to the
             # cursor's agent. Mirrors the per-tab action idiom landed
@@ -2282,6 +2305,7 @@ class RightPanel(Widget):
                     cache=self._events_cache,
                     filelist_cache=self._events_filelist_cache,
                     chain_isolate=self._events_chain_isolate,
+                    verbose=self._events_verbose,
                 )
                 self._events_visible = windowed
                 self._events_event_ys = event_ys

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -534,6 +534,7 @@ def render_events(
     cache: dict | None = None,
     filelist_cache: list | None = None,
     chain_isolate: str | None = None,
+    verbose: bool = False,
 ) -> tuple[str, list[dict], list[int]]:
     """Render the recent-events list for the events tab.
 
@@ -549,6 +550,16 @@ def render_events(
     Consecutive events sharing a chain_id are visually grouped (a blank
     line separates chain switches). The row at index ``cursor`` is
     highlighted with a coral ▶ prefix.
+
+    When ``verbose=False`` (the default), events with
+    ``type == "compaction_check"`` are filtered out of the visible list
+    — these fire on every chat turn with outcomes like
+    ``too_few_turns`` / ``below_min_batch`` / ``below_threshold`` /
+    ``already_running`` (= "didn't compact, just checking") and clutter
+    the tab without conveying actionable information. The actual
+    compaction lifecycle (``compaction_started`` / ``compaction_completed``
+    / ``compaction_failed``) is always shown. Pass ``verbose=True`` to
+    restore the full unfiltered view.
     """
     if project_root is None:
         return "[#555555]  (no project root)[/]", [], []
@@ -579,6 +590,22 @@ def render_events(
             ev for ev in visible
             if ((ev.get("data") or {}).get("chain_id") or "") == chain_isolate
         ]
+
+    # Compaction-check noise suppression: when verbose=False (the
+    # default), hide compaction_check events from the visible list.
+    # They fire on every chat turn but the vast majority carry
+    # "not triggered" outcomes — the actual lifecycle is covered by
+    # compaction_started / compaction_completed / compaction_failed.
+    # Track the suppressed count so the footer can surface the toggle.
+    n_compaction_check_hidden = 0
+    if not verbose:
+        filtered_visible: list[dict] = []
+        for ev in visible:
+            if ev.get("type") == "compaction_check":
+                n_compaction_check_hidden += 1
+            else:
+                filtered_visible.append(ev)
+        visible = filtered_visible
 
     # File-path iteration order doesn't match wall-clock: the events root
     # holds agents/<id>/events/*.jsonl alongside direct/<id>/skill_runs/*
@@ -698,6 +725,13 @@ def render_events(
     # Dim footer hint — always appended after the event rows so the user
     # can discover the [d] docs shortcut from the events tab itself.
     lines.append("[#555555]  ? press [d] for events.md reference[/]")
+    # Compaction-check suppression footer: when at least 1 event was
+    # hidden, surface a dim hint so the user can discover the [v] toggle.
+    if n_compaction_check_hidden > 0:
+        lines.append(
+            f"[#444444]  ↩ {n_compaction_check_hidden} compaction_check hidden"
+            " ([v] to show)[/]"
+        )
     return "\n".join(lines), windowed, event_ys
 
 

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -83,6 +83,13 @@ _KEY_DETAILS: dict[str, str] = {
         "Isolate the cursor's chain in the Events tab — hides events\n"
         "not in the same chain_id. Only active on the Events tab."
     ),
+    "v": (
+        "Toggle verbose mode on the Events tab. When off (default),\n"
+        "hides compaction_check events (= 'not compacted' noise — fires\n"
+        "on every chat turn with outcomes too_few_turns /\n"
+        "below_min_batch / below_threshold / already_running).\n"
+        "When on, shows everything. Only active on the Events tab."
+    ),
 }
 
 
@@ -143,7 +150,7 @@ _PANEL_KEYS = {
     "ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4",
     "ctrl+5", "ctrl+6", "ctrl+7",
 }
-_EVENTS_KEYS = {"f", "t", "i"}
+_EVENTS_KEYS = {"f", "t", "i", "v"}
 # ``/`` stays DOCS-only — it opens the docs name filter, no other tab
 # consumes it.
 _DOCS_KEYS = {"/"}
@@ -286,6 +293,9 @@ def render_keys(
         # interleaving noise from other concurrent chains. T2-3: added
         # "(events tab)" suffix so the gating is visible without Space-expand.
         ("i", "Isolate cursor's chain (events tab only)"),
+        # Events tab ``v`` = toggle verbose mode. Default-off hides
+        # compaction_check noise; verbose-on shows everything.
+        ("v", "Toggle verbose (events tab)"),
     ]
     # Note: memory tab's ``t`` (= cycle_memory_type_filter, wave-11
     # A#1) is intentionally NOT in this list because ``t`` is already

--- a/tests/cli/test_events_verbose_toggle.py
+++ b/tests/cli/test_events_verbose_toggle.py
@@ -1,0 +1,279 @@
+"""Tier 2: events tab verbose toggle — hide compaction_check by default + v key.
+
+compaction_check events fire on every chat turn but the vast majority carry
+"didn't compact" outcomes (too_few_turns / below_min_batch / below_threshold /
+already_running). The actual lifecycle is covered by compaction_started /
+compaction_completed / compaction_failed. Default-hide the noise; bind v on
+the events tab to toggle verbose mode.
+
+Public surfaces tested:
+  1. render_events(verbose=False) with mixed events → compaction_check absent,
+     others present.
+  2. render_events(verbose=True) → compaction_check present.
+  3. render_events(3 compaction_check + 1 other, verbose=False) → footer
+     "3 compaction_check hidden".
+  4. render_events(0 compaction_check, verbose=False) → no footer.
+  5. on_key ``v`` on events tab → _events_verbose toggles + render reflects.
+  6. on_key ``v`` on memory tab → _events_verbose unchanged (scope guard).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_events(events_root: Path, events: list[dict]) -> None:
+    """Write events as a JSONL file under events_root."""
+    events_root.mkdir(parents=True, exist_ok=True)
+    log = events_root / "log.jsonl"
+    log.write_text("\n".join(json.dumps(ev) for ev in events), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — verbose=False hides compaction_check, shows other events
+# ---------------------------------------------------------------------------
+
+def test_render_events_verbose_false_hides_compaction_check(tmp_path: Path) -> None:
+    """Tier 2: verbose=False suppresses compaction_check, keeps other types."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "test" / "events"
+    _write_events(events_root, [
+        {"type": "compaction_check", "timestamp": "2026-05-23T10:00:00",
+         "data": {"outcome": "too_few_turns"}},
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:01",
+         "data": {"phase": "analyse"}},
+        {"type": "compaction_check", "timestamp": "2026-05-23T10:00:02",
+         "data": {"outcome": "below_threshold"}},
+        {"type": "llm_called", "timestamp": "2026-05-23T10:00:03",
+         "data": {"phase": "analyse"}},
+    ])
+
+    rendered, visible, _ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=2,
+        cursor=0, verbose=False,
+    )
+
+    # compaction_check must not appear in visible list
+    types = [ev.get("type") for ev in visible]
+    assert "compaction_check" not in types, (
+        f"compaction_check should be hidden when verbose=False; got types={types}"
+    )
+
+    # Other events must be present
+    assert "phase_started" in types
+    assert "llm_called" in types
+
+    # Rendered markup must not contain compaction_check event rows
+    # (the type string appears in the color dict + footer; check the
+    # rendered output for the event-row pattern which pairs timestamp + type)
+    assert "compaction_check" not in rendered or "hidden" in rendered, (
+        "compaction_check should not appear as a visible event row when verbose=False"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — verbose=True includes compaction_check
+# ---------------------------------------------------------------------------
+
+def test_render_events_verbose_true_shows_compaction_check(tmp_path: Path) -> None:
+    """Tier 2: verbose=True includes compaction_check events in visible list."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "test" / "events"
+    _write_events(events_root, [
+        {"type": "compaction_check", "timestamp": "2026-05-23T10:00:00",
+         "data": {"outcome": "too_few_turns"}},
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:01",
+         "data": {"phase": "analyse"}},
+    ])
+
+    rendered, visible, _ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=2,
+        cursor=0, verbose=True,
+    )
+
+    types = [ev.get("type") for ev in visible]
+    assert "compaction_check" in types, (
+        f"compaction_check should appear when verbose=True; got types={types}"
+    )
+    assert "phase_started" in types
+
+    # Rendered markup should show compaction_check event row
+    assert "compaction_check" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — footer shows hidden count when N > 0
+# ---------------------------------------------------------------------------
+
+def test_render_events_verbose_false_footer_shows_hidden_count(tmp_path: Path) -> None:
+    """Tier 2: footer surfaces count of suppressed compaction_check events."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "test" / "events"
+    _write_events(events_root, [
+        {"type": "compaction_check", "timestamp": "2026-05-23T10:00:00",
+         "data": {"outcome": "too_few_turns"}},
+        {"type": "compaction_check", "timestamp": "2026-05-23T10:00:01",
+         "data": {"outcome": "below_min_batch"}},
+        {"type": "compaction_check", "timestamp": "2026-05-23T10:00:02",
+         "data": {"outcome": "already_running"}},
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:03",
+         "data": {"phase": "analyse"}},
+    ])
+
+    rendered, visible, _ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=2,
+        cursor=0, verbose=False,
+    )
+
+    # Footer must mention 3 hidden + the [v] toggle cue
+    assert "3 compaction_check hidden" in rendered, (
+        f"Expected '3 compaction_check hidden' in footer; rendered=\n{rendered}"
+    )
+    assert "[v]" in rendered, (
+        f"Expected '[v] to show' cue in footer; rendered=\n{rendered}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — no footer when 0 compaction_check events
+# ---------------------------------------------------------------------------
+
+def test_render_events_verbose_false_no_footer_when_zero_hidden(tmp_path: Path) -> None:
+    """Tier 2: footer not added when no compaction_check events were suppressed."""
+    from reyn.chat.tui.widgets.right_panel.events_tab import render_events
+
+    events_root = tmp_path / ".reyn" / "events" / "agents" / "test" / "events"
+    _write_events(events_root, [
+        {"type": "phase_started", "timestamp": "2026-05-23T10:00:00",
+         "data": {"phase": "analyse"}},
+        {"type": "llm_called", "timestamp": "2026-05-23T10:00:01",
+         "data": {"phase": "analyse"}},
+    ])
+
+    rendered, visible, _ys = render_events(
+        tmp_path, event_filter_idx=0, event_tail_idx=2,
+        cursor=0, verbose=False,
+    )
+
+    assert "compaction_check hidden" not in rendered, (
+        "No compaction_check hidden footer should appear when none were suppressed"
+    )
+    assert "[v] to show" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — v key on events tab toggles _events_verbose
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_v_key_on_events_tab_toggles_verbose() -> None:
+    """Tier 2: pressing v on the events tab flips _events_verbose."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel.set_panel_type("events")
+        await pilot.pause()
+
+        # Default state is False (= hide compaction_check)
+        assert panel._events_verbose is False
+
+        # First v press → True
+        key_event = textual_events.Key(key="v", character="v")
+        panel.on_key(key_event)
+        await pilot.pause()
+        assert panel._events_verbose is True, (
+            "Expected _events_verbose=True after first v press on events tab"
+        )
+
+        # Second v press → False again
+        key_event2 = textual_events.Key(key="v", character="v")
+        panel.on_key(key_event2)
+        await pilot.pause()
+        assert panel._events_verbose is False, (
+            "Expected _events_verbose=False after second v press on events tab"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — v key on memory tab leaves _events_verbose unchanged
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_v_key_on_memory_tab_does_not_toggle_verbose() -> None:
+    """Tier 2: pressing v on the memory tab must not change _events_verbose."""
+    from textual import events as textual_events
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        panel.set_panel_type("memory")
+        await pilot.pause()
+
+        assert panel._events_verbose is False
+
+        key_event = textual_events.Key(key="v", character="v")
+        panel.on_key(key_event)
+        await pilot.pause()
+
+        # Must still be False — the v handler is events-tab-only
+        assert panel._events_verbose is False, (
+            "_events_verbose must not change when v is pressed on a non-events tab"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Keys tab registrations
+# ---------------------------------------------------------------------------
+
+def test_v_in_events_keys_set() -> None:
+    """Tier 2: v is registered in _EVENTS_KEYS (= EVENTS (gated) group)."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import _EVENTS_KEYS
+
+    assert "v" in _EVENTS_KEYS
+
+
+def test_v_in_key_details() -> None:
+    """Tier 2: v has a detail entry in _KEY_DETAILS."""
+    from reyn.chat.tui.widgets.right_panel.keys_tab import _KEY_DETAILS
+
+    assert "v" in _KEY_DETAILS
+    assert "verbose" in _KEY_DETAILS["v"].lower()
+
+
+@pytest.mark.asyncio
+async def test_keys_tab_render_includes_v_description() -> None:
+    """Tier 2: rendered Keys tab markup surfaces the v verbose hint."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        markup, _ = render_keys(app)
+        assert "verbose" in markup.lower() or "Toggle verbose" in markup, (
+            "Keys tab markup should surface the v=Toggle verbose entry"
+        )


### PR DESCRIPTION
**[tui-coder]** — UX fix: events tab noise reduction

## Summary
- Default-hide `compaction_check` events on the Events tab
- New `v` keybinding (events tab only) toggles verbose mode
- Footer "↩ N compaction_check hidden ([v] to show)" surfaces toggle when filter is active

## Why
User report: "compaction check はノイズだよね。 compaction 発動はあって欲しいけど。 events の話ね" — every turn fires compaction_check with outcome=too_few_turns / below_min_batch / below_threshold / already_running (= "not compacted, just checking"). The actual lifecycle events (compaction_started / completed / failed) remain always visible.

## Pre-flight
- `v` confirmed free in app.py / input_bar.py / right_panel/__init__.py before binding.

## Test plan
- [x] `tests/cli/test_events_verbose_toggle.py` — 9 Tier-2 tests (6 specified + 3 keys-tab registrations)
- [x] existing events/keys/smoke tests pass (94 tests)
- [x] ruff clean
- [x] Manual: open events tab → compaction_check rows absent; press v → rows appear; press v again → hidden + footer surfaces