### PR TITLE
feat(tui): inline Braille spinner replaces sticky thinking indicator

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -910,7 +910,7 @@ class ReynTUIApp(App):
                 # confirmation the new turn is starting). When the
                 # natural ``thinking…`` message arrives, it overwrites
                 # with identical text — no flicker.
-                conv.show_status("thinking…", kind="thinking")
+                conv.start_thinking()
                 await session.submit_user_text(text)
             else:
                 from rich.text import Text as RichText
@@ -987,11 +987,12 @@ class ReynTUIApp(App):
     def action_cancel_inflight(self) -> None:
         """Cancel the in-flight skill/plan/model call on the attached session.
 
-        Visibility: clears the sticky ``⟳ thinking…`` indicator AND writes
-        a one-line summary to the conv pane reporting how many skills /
-        plans were actually cancelled. Without this summary the user
-        couldn't tell whether Ctrl+C did anything (= "did it really
-        cancel, or was nothing in flight?").
+        Visibility: unmounts the inline thinking spinner AND clears the
+        sticky ``⟳ thinking…`` indicator. Also writes a one-line summary
+        to the conv pane reporting how many skills / plans were actually
+        cancelled. Without this summary the user couldn't tell whether
+        Ctrl+C did anything (= "did it really cancel, or was nothing in
+        flight?").
 
         Ctrl+C is hierarchical: if the slash picker is open, dismiss it
         first (matches Esc, satisfies the "abort the visible thing"
@@ -1010,6 +1011,7 @@ class ReynTUIApp(App):
         except Exception:
             conv = None
         if conv is not None:
+            conv.stop_thinking()
             conv.hide_status()
         # Wave-9 D-F11: Ctrl+C unconditionally releases the in-flight
         # lock so the user can immediately submit a new prompt. Even if

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -344,9 +344,10 @@ class OutboxRouter:
     ) -> str:
         """`__end__` — registry signals shutdown; loop should break.
 
-        Also clears any leftover ``⟳ thinking…`` sticky so the final
-        TUI frame on shutdown isn't a phantom indicator.
+        Also clears any leftover ``⟳ thinking…`` sticky and inline spinner
+        so the final TUI frame on shutdown isn't a phantom indicator.
         """
+        conv.stop_thinking()
         conv.hide_status()
         return _STOP
 
@@ -390,6 +391,7 @@ class OutboxRouter:
             app._agent_name = new_name
             header.refresh_status(agent_name=new_name)
             self._cancel_transient_timer()
+            conv.stop_thinking()
             conv.hide_status()
             # Capture the running-skill identities BEFORE conv.clear() so
             # we can leave a breadcrumb after the wipe. Without this, a
@@ -917,11 +919,12 @@ class OutboxRouter:
         app = self._app
         msg_id = msg.meta.get("msg_id", id(msg))
         app._current_stream_id = msg_id
-        # Hide the "thinking…" sticky now that the reply is starting. Cancel
-        # any pending transient timer too — a transient that fired right
-        # before the reply must not auto-hide a fresh sticky armed later
-        # in this same turn.
+        # Stop the inline thinking spinner and clear sticky now that the reply
+        # is starting. Cancel any pending transient timer too — a transient
+        # that fired right before the reply must not auto-hide a fresh sticky
+        # armed later in this same turn.
         self._cancel_transient_timer()
+        conv.stop_thinking()
         conv.hide_status()
         conv.begin_stream(msg_id, app._agent_name)
 
@@ -974,9 +977,9 @@ class OutboxRouter:
     ) -> None:
         """`intervention` — mount inline ask_user widget.
 
-        Hides the sticky ``⟳ thinking…`` indicator first: while the
-        agent is waiting for a human answer, "thinking" is misleading
-        — the system is blocked on user input, not on the model.
+        Unmounts the inline thinking spinner first: while the agent is
+        waiting for a human answer, the spinner is misleading — the system
+        is blocked on user input, not on the model.
 
         Computes ``queued_extra`` from the session's intervention registry
         so the widget can render a persistent ``+N more pending`` badge.
@@ -984,6 +987,7 @@ class OutboxRouter:
         by the next ``thinking…`` event, so we need an inline persistent
         signal instead.
         """
+        conv.stop_thinking()
         conv.hide_status()
         iv_id = msg.meta.get("intervention_id", "")
         raw_choices = msg.meta.get("choices")
@@ -1159,7 +1163,7 @@ class OutboxRouter:
                 current_body = str(snap.get("body", ""))
                 if _is_plan_sourced_body(current_body):
                     return  # don't overwrite the higher-priority plan status
-        conv.show_status(msg.text, kind="thinking")
+        conv.start_thinking()
 
     def _on_system(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
@@ -1233,7 +1237,7 @@ class OutboxRouter:
     ) -> None:
         """`error` — render via conv (mounts ErrorBox) + remember focal tab.
 
-        Also clears the sticky ``⟳ thinking…`` indicator: a turn that
+        Also unmounts the inline spinner and clears the sticky: a turn that
         ends in error never reaches `__stream_start__` / `agent`, so
         without this the indicator would stick around indefinitely.
 
@@ -1255,6 +1259,7 @@ class OutboxRouter:
         normal server-side error frames on the existing transient path —
         only the WS-disconnect source triggers the persistent lock.
         """
+        conv.stop_thinking()
         conv.hide_status()
         conv.render_message(msg)
         self._app._last_focal_tab = "events"

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -58,6 +58,7 @@ from reyn.chat.tui._palette import _AMBER, _CORAL
 from .async_stack_panel import AsyncStackPanel
 from .error_box import ErrorBox
 from .foldable_markdown import FoldableMarkdown
+from .inline_thinking_row import InlineThinkingRow
 from .intervention import InterventionWidget
 from .skill_activity import SkillActivityRow
 from .sticky_status import StickyStatus
@@ -723,6 +724,7 @@ class ConversationView(Widget):
         deserve the same visual weight as a slash-command output.
         """
         self._consume_empty_hint()
+        self.stop_thinking()
         self.hide_status()
         text = msg.text or ""
         if _is_lifecycle_marker(text):
@@ -744,7 +746,8 @@ class ConversationView(Widget):
         was active for this turn.
         """
         self._consume_empty_hint()
-        self.hide_status()  # turn finished — clear "thinking…" sticky
+        self.stop_thinking()  # turn finished — unmount inline spinner
+        self.hide_status()    # also clear any sticky status
         meta_pfx = _meta_prefix(msg.meta)
         label = f"reyn  {meta_pfx}".rstrip() if meta_pfx else "reyn"
         # _AMBER for agent identity (header label) — distinct from _CORAL
@@ -992,6 +995,7 @@ class ConversationView(Widget):
         full = row.full_text()
         # Seal stops the cursor + 16ms tick.
         row.seal()
+        self.stop_thinking()  # unmount inline spinner (turn reply started)
         self.hide_status()
         if full:
             try:
@@ -1038,6 +1042,7 @@ class ConversationView(Widget):
             return ""
         full = row.full_text()
         row.seal()
+        self.stop_thinking()  # unmount inline spinner (cancelled stream)
         self.hide_status()
         if full:
             # Wave-10 G-F10: stash the partial in the recent-replies ring
@@ -1365,7 +1370,7 @@ class ConversationView(Widget):
 
     # ── sticky status (A3) ────────────────────────────────────────────────────
 
-    def show_status(self, text: str, kind: str = "thinking") -> None:
+    def show_status(self, text: str, kind: str = "general") -> None:
         s = self._sticky()
         if s is not None:
             s.show(text, kind=kind)
@@ -1379,6 +1384,34 @@ class ConversationView(Widget):
         s = self._sticky()
         if s is not None:
             s.hide()
+
+    # ── inline thinking spinner (A3b) ─────────────────────────────────────────
+
+    _THINKING_ROW_ID = "inline-thinking-row"
+
+    def start_thinking(self) -> None:
+        """Mount an InlineThinkingRow in the conv pane flow, below the last message.
+
+        Idempotent: calling twice mounts only one row (= second call is a
+        no-op when a row is already present).
+        """
+        try:
+            # Already mounted — idempotent.
+            self.query_one(f"#{self._THINKING_ROW_ID}", InlineThinkingRow)
+        except Exception:
+            row = InlineThinkingRow(id=self._THINKING_ROW_ID)
+            self.mount(row)
+
+    def stop_thinking(self) -> None:
+        """Unmount the InlineThinkingRow if present.
+
+        Idempotent: calling without a prior ``start_thinking`` is a no-op.
+        """
+        try:
+            row = self.query_one(f"#{self._THINKING_ROW_ID}", InlineThinkingRow)
+            row.remove()
+        except Exception:
+            pass  # not mounted — idempotent
 
     # ── error box (A2) ────────────────────────────────────────────────────────
 
@@ -1423,14 +1456,14 @@ class ConversationView(Widget):
                 f"  ✗ {old_summary} (rolled to log){old_trailer}",
                 style="dim #555555",
             ))
-        # Replace the sticky "thinking…" — the turn is over (it failed).
-        # When the user is at the tail, a bare ``hide_status`` is enough
-        # (they'll see the ErrorBox the next render tick). When they're
-        # scrolled up reading history, the sticky vanishing was their
-        # only feedback that something happened — leave a "✗ error
-        # below ↓" cue so they know to scroll down. The next user
-        # submit clears it via ``on_input_bar_user_submitted``'s own
-        # ``show_status("thinking…")``.
+        # Stop the inline thinking spinner — the turn is over (it failed).
+        # When the user is at the tail, a bare ``stop_thinking`` + ``hide_status``
+        # is enough (they'll see the ErrorBox the next render tick). When
+        # they're scrolled up reading history, the spinner vanishing was their
+        # only feedback that something happened — leave a "✗ error below ↓"
+        # cue so they know to scroll down. The next user submit clears it
+        # via ``on_input_bar_user_submitted``'s own ``start_thinking()``.
+        self.stop_thinking()  # turn ended in error — unmount inline spinner
         if self._user_scrolled:
             self.show_status("✗ error below ↓", kind="general")
         else:
@@ -2155,7 +2188,8 @@ class ConversationView(Widget):
             self._log().auto_scroll = True
         except Exception:
             pass
-        # Hide sticky status
+        # Stop inline spinner and hide sticky status
+        self.stop_thinking()
         self.hide_status()
         # Restore the empty-state hint so the next session looks fresh.
         self._has_first_message = False

--- a/src/reyn/chat/tui/widgets/inline_thinking_row.py
+++ b/src/reyn/chat/tui/widgets/inline_thinking_row.py
@@ -1,0 +1,68 @@
+"""InlineThinkingRow — inline Braille spinner for LLM-in-flight state.
+
+Replaces the sticky ``kind="thinking"`` indicator (⟳ thinking · Ns) with
+an inline widget mounted in the conv pane flow, right where the agent reply
+will land. Animates a 10-frame Braille cycle at ~10 fps. No text — pure
+visual indicator.
+
+Usage::
+
+    conv.start_thinking()   # mount below the last message
+    # … LLM in flight …
+    conv.stop_thinking()    # unmount (idempotent on both calls)
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Label
+
+_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"  # 10-frame Braille cycle
+_INTERVAL_S = 0.10  # ~10 fps
+
+
+class InlineThinkingRow(Widget):
+    """Inline spinning indicator showing 'LLM in flight'.
+
+    Mounts in the conv pane flow (= below the last rendered message, before
+    the agent reply lands). Animates a Braille spinner via set_interval.
+    No "thinking" word — pure visual indicator.
+
+    Lifecycle: mount via ``ConversationView.start_thinking()``;
+    unmount via ``ConversationView.stop_thinking()``.
+    """
+
+    DEFAULT_CSS = """
+    InlineThinkingRow {
+        height: 1;
+        padding: 0 2;
+        color: #d4945a;
+    }
+    """
+
+    can_focus = False
+
+    def __init__(self, id: str | None = None) -> None:
+        super().__init__(id=id)
+        self._frame_idx = 0
+        self._label: Label | None = None
+        self._timer = None
+
+    def compose(self) -> ComposeResult:
+        self._label = Label(_FRAMES[0])
+        yield self._label
+
+    def on_mount(self) -> None:
+        """Start the Braille animation timer."""
+        self._timer = self.set_interval(_INTERVAL_S, self._tick)
+
+    def _tick(self) -> None:
+        self._frame_idx = (self._frame_idx + 1) % len(_FRAMES)
+        if self._label is not None:
+            self._label.update(_FRAMES[self._frame_idx])
+
+    def on_unmount(self) -> None:
+        """Stop the animation timer when the widget is removed."""
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -1,31 +1,33 @@
 """StickyStatus — a 1-line status bar pinned to the bottom of the conversation pane.
 
-Shows a live "currently happening" message with an elapsed timer that updates
-every 0.1 s. Auto-hides when nothing is being reported. Intended to replace
-inline "⟳ thinking…" log lines with a non-intrusive persistent indicator.
+Shows a currently-happening message. Auto-hides when nothing is being
+reported. Used for error notices, turn-position flashes, and "awaiting your
+answer" badges. The ``⟳ thinking…`` kind has been replaced by the inline
+Braille spinner (``InlineThinkingRow``).
 
 Usage::
 
     status = StickyStatus(id="sticky-status")
     await conversation.mount(status)
-    status.show("thinking", kind="thinking")
+    status.show("⚑ awaiting your answer", kind="general")
     # … later …
     status.hide()
 """
 from __future__ import annotations
 
-import time
-
 from rich.cells import cell_len
 from rich.text import Text
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _AMBER, _CORAL
+from reyn.chat.tui._palette import _CORAL
 
 _TICK_INTERVAL_S = 0.1  # elapsed timer refresh rate
 
 _GLYPHS: dict[str, str] = {
-    "thinking": "⟳",
+    # ``"thinking"`` was removed — the inline Braille spinner
+    # (``InlineThinkingRow``) now handles the LLM-in-flight indicator
+    # directly in the conv pane flow. The sticky is no longer used for
+    # thinking state.
     "general": "●",
     # Wave-10 I-F1: ``"error"`` was passed by 7+ call sites
     # (``app_outbox._show_transient_status`` for ``/copy`` failures,
@@ -62,15 +64,12 @@ _GLYPHS: dict[str, str] = {
 # expected behaviour for genuine status updates, e.g. ``thinking`` →
 # ``thinking`` body update).
 _KIND_PRIORITY: dict[str, int] = {
-    # Live load-bearing state — must not be displaced by transients.
-    "thinking": 100,
+    # ``"thinking"`` removed — the inline Braille spinner
+    # (``InlineThinkingRow``) replaces the sticky thinking indicator.
     # Wave-10 I-F1: critical transient signal — an action failed and
     # the user needs to notice. Higher than ``general`` (= routine
     # breadcrumbs / turn-position flashes shouldn't overwrite an
-    # error the user hasn't read yet) but lower than ``thinking`` —
-    # if the LLM is mid-call, the live indicator stays visible and
-    # the error log line in the conv pane remains the load-bearing
-    # record.
+    # error the user hasn't read yet).
     "error": 80,
     # Transient flashes / breadcrumbs / one-shot notices.
     "general": 50,
@@ -109,10 +108,9 @@ class StickyStatus(Static):
     def __init__(self, *, id: str | None = None) -> None:
         super().__init__("", id=id)
         self._active: bool = False
-        self._kind: str = "thinking"
-        self._glyph: str = _GLYPHS["thinking"]
+        self._kind: str = "general"
+        self._glyph: str = _GLYPHS["general"]
         self._body: str = ""
-        self._start: float = 0.0
 
     def on_mount(self) -> None:
         """Start the 0.1 s elapsed timer tick."""
@@ -120,19 +118,22 @@ class StickyStatus(Static):
 
     # ── public API ────────────────────────────────────────────────────────────
 
-    def show(self, text: str, kind: str = "thinking") -> None:
+    def show(self, text: str, kind: str = "general") -> None:
         """Activate the status bar with the given body text and glyph kind.
 
         Wave-10 G-F8 + I-F8: when the sticky is already active with a
         higher-priority ``kind``, a lower-priority ``show()`` is
         silently suppressed (= the call is a no-op). This protects
-        load-bearing live indicators (``⟳ thinking…``) from being
-        displaced by transient breadcrumbs (turn-position flash,
-        boundary hint). Same-or-higher priority overwrites freely.
+        load-bearing error notices from being displaced by transient
+        breadcrumbs (turn-position flash, boundary hint). Same-or-higher
+        priority overwrites freely.
 
         ``hide()`` is unconditional — explicit dismissal always wins.
+
+        Note: ``kind="thinking"`` is no longer valid — use
+        ``ConversationView.start_thinking()`` for the inline spinner.
         """
-        new_kind = kind if kind in _GLYPHS else "thinking"
+        new_kind = kind if kind in _GLYPHS else "general"
         if self._active:
             current_priority = _KIND_PRIORITY.get(self._kind, 0)
             new_priority = _KIND_PRIORITY.get(new_kind, 0)
@@ -140,7 +141,6 @@ class StickyStatus(Static):
                 return
         self._kind = new_kind
         self._glyph = _GLYPHS[self._kind]
-        self._start = time.monotonic()
         self._active = True
         self.add_class("active")
         self.update_text(text)
@@ -173,44 +173,18 @@ class StickyStatus(Static):
         self._repaint()
 
     def _repaint(self) -> None:
-        elapsed = max(0.1, time.monotonic() - self._start)
         # On 8-color terminals, hex _CORAL (#C8553D) degrades to ANSI bright
-        # red — confusable with error indicators. The thinking sticky shows
-        # while the agent is working, so route its glyph through _AMBER
-        # (which degrades to ANSI yellow / bright yellow) — neutrally
-        # signalling "in progress" rather than "alert". The error kind
-        # WANTS to read as alert, so bold red (#aa6666). General keeps
-        # _CORAL since it's a transient flash, not the load-bearing "is
-        # the agent working?" indicator.
-        if self._kind == "thinking":
-            glyph_color = _AMBER
-        elif self._kind == "error":
+        # red — confusable with error indicators. The error kind WANTS to
+        # read as alert, so bold red (#aa6666). General keeps _CORAL since
+        # it's a transient flash. (The ``"thinking"`` kind is no longer
+        # handled here — the inline Braille spinner replaced it.)
+        if self._kind == "error":
             glyph_color = "bold #aa6666"
         else:
             glyph_color = _CORAL
-        # Wave-10 follow-up I-F2: elapsed suffix is only meaningful for
-        # the ``thinking`` kind (= the user genuinely wants to know how
-        # long the agent has been working). For ``general`` (turn-flash,
-        # boundary hint, breadcrumb) and ``error`` (one-shot failure
-        # notice), elapsed is noise — a turn flash like
-        # ``↑ turn 3 / 8  · 1.4s`` reads as "this turn marker has been
-        # showing for 1.4s", which the user neither needs nor expects.
-        # The internal ``_start`` is still refreshed on every ``show()``
-        # so the value is meaningful for any future kind that opts in.
-        # Total cells in the fixed-width suffix segments so we can truncate
-        # the body when narrow terminals would otherwise clip the
-        # ``Ctrl+C cancel`` hint behind the right edge.
+        # Chrome budget: glyph + 1 space + padding 0 1 (= 2 cells) + 1 margin.
         glyph_cells = cell_len(self._glyph) + 1  # ``<glyph> ``
-        elapsed_suffix = (
-            f" · {elapsed:.1f}s" if self._kind == "thinking" else ""
-        )
-        elapsed_cells = cell_len(elapsed_suffix)
-        cancel_suffix = "  · Ctrl+C cancel" if self._kind == "thinking" else ""
-        cancel_cells = cell_len(cancel_suffix)
-        # Padding 0 1 → 2 cells consumed; another 1-cell safety margin
-        # keeps the body off the right edge even if Textual reserves
-        # something additional (cursor / scrollbar on certain themes).
-        chrome_cells = glyph_cells + elapsed_cells + cancel_cells + 2 + 1
+        chrome_cells = glyph_cells + 2 + 1
         available = max(0, int(getattr(self.size, "width", 0)) - chrome_cells)
         body = self._body
         if available > 0 and cell_len(body) > available:
@@ -228,8 +202,4 @@ class StickyStatus(Static):
         t = Text()
         t.append(self._glyph + " ", style=glyph_color)
         t.append(body, style="dim italic")
-        if elapsed_suffix:
-            t.append(elapsed_suffix, style="dim italic")
-        if cancel_suffix:
-            t.append(cancel_suffix, style="dim italic")
         self.update(t)

--- a/tests/cli/test_inline_thinking_row.py
+++ b/tests/cli/test_inline_thinking_row.py
@@ -1,0 +1,156 @@
+"""Tier 2: InlineThinkingRow + ConversationView.start_thinking / stop_thinking.
+
+Validates the inline Braille spinner lifecycle that replaced the sticky
+``kind="thinking"`` indicator.
+
+Public surfaces tested:
+  1. start_thinking() → exactly 1 InlineThinkingRow mounted
+  2. start_thinking() twice → still exactly 1 (idempotent)
+  3. start_thinking() then stop_thinking() → 0 InlineThinkingRow mounted
+  4. stop_thinking() without prior start → no error (idempotent)
+  5. InlineThinkingRow rendered text contains a Braille frame character
+  6. _tick() advances the frame index (spinner animates)
+  7. kind="thinking" no longer appears in _KIND_PRIORITY
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_start_thinking_mounts_one_row() -> None:
+    """Tier 2: start_thinking() mounts exactly 1 InlineThinkingRow."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.inline_thinking_row import InlineThinkingRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_thinking()
+        await pilot.pause()
+        rows = conv.query(InlineThinkingRow)
+        assert len(rows) == 1, (
+            f"expected 1 InlineThinkingRow after start_thinking(), got {len(rows)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_thinking_idempotent() -> None:
+    """Tier 2: calling start_thinking() twice mounts only 1 row."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.inline_thinking_row import InlineThinkingRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_thinking()
+        await pilot.pause()
+        conv.start_thinking()
+        await pilot.pause()
+        rows = conv.query(InlineThinkingRow)
+        assert len(rows) == 1, (
+            f"expected 1 InlineThinkingRow after two start_thinking() calls, "
+            f"got {len(rows)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_thinking_unmounts_row() -> None:
+    """Tier 2: stop_thinking() after start_thinking() unmounts the row."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.inline_thinking_row import InlineThinkingRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_thinking()
+        await pilot.pause()
+        conv.stop_thinking()
+        await pilot.pause()
+        rows = conv.query(InlineThinkingRow)
+        assert len(rows) == 0, (
+            f"expected 0 InlineThinkingRow after stop_thinking(), got {len(rows)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_thinking_without_start_no_error() -> None:
+    """Tier 2: stop_thinking() without prior start_thinking() is a no-op."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        # Must not raise
+        conv.stop_thinking()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_inline_thinking_row_shows_braille_frame() -> None:
+    """Tier 2: InlineThinkingRow frame index is valid after mounting."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+    from reyn.chat.tui.widgets.inline_thinking_row import _FRAMES, InlineThinkingRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.start_thinking()
+        await pilot.pause()
+        row = conv.query_one(InlineThinkingRow)
+        # frame_idx must point to a valid Braille frame.
+        assert 0 <= row._frame_idx < len(_FRAMES), (
+            f"expected frame_idx in [0, {len(_FRAMES)}), got {row._frame_idx}"
+        )
+        assert _FRAMES[row._frame_idx] in _FRAMES, (
+            f"frame at index {row._frame_idx} is not a valid Braille char"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tick_advances_frame() -> None:
+    """Tier 2: _tick() cycles the Braille frame index forward."""
+    from reyn.chat.tui.widgets.inline_thinking_row import _FRAMES, InlineThinkingRow
+
+    # Exercise _tick() directly without a full app mount.
+    row = InlineThinkingRow()
+    initial_idx = row._frame_idx
+    row._tick()
+    assert row._frame_idx == (initial_idx + 1) % len(_FRAMES), (
+        f"expected frame_idx to advance from {initial_idx} to "
+        f"{(initial_idx + 1) % len(_FRAMES)}, got {row._frame_idx}"
+    )
+    # Cycle wraps: advance through all frames and confirm wrap-around.
+    for _ in range(len(_FRAMES) - 1):
+        row._tick()
+    assert row._frame_idx == initial_idx, (
+        f"after full cycle, frame_idx should return to {initial_idx}, "
+        f"got {row._frame_idx}"
+    )
+
+
+def test_thinking_not_in_kind_priority() -> None:
+    """Tier 2: cleanup — 'thinking' no longer in _KIND_PRIORITY (sticky removed it)."""
+    from reyn.chat.tui.widgets.sticky_status import _KIND_PRIORITY
+
+    assert "thinking" not in _KIND_PRIORITY, (
+        f"'thinking' should have been removed from _KIND_PRIORITY after "
+        f"inline spinner migration; found it: {_KIND_PRIORITY}"
+    )

--- a/tests/cli/test_sticky_elapsed_only_on_thinking.py
+++ b/tests/cli/test_sticky_elapsed_only_on_thinking.py
@@ -1,21 +1,12 @@
-"""Tier 2: elapsed suffix shows only for kind="thinking" (I-F2).
+"""Tier 2: elapsed suffix is never shown in sticky (kind="thinking" removed).
 
-Wave-10 follow-up Topic I finding F2 (P2): ``_repaint`` rendered
-``· N.Ns`` regardless of kind, so a transient ``general`` flash
-like ``↑ turn 3 / 8`` displayed as ``↑ turn 3 / 8  · 1.4s`` —
-the elapsed counter is meaningful only when the user is asking
-"how long has the agent been working?", which is the ``thinking``
-semantics. For navigation breadcrumbs and one-shot error notices,
-the appended elapsed read as noise the user neither needed nor
-expected.
-
-After the fix the elapsed suffix is emitted only when
-``self._kind == "thinking"``. ``_start`` is still refreshed on
-each ``show()`` so the value is meaningful for any future kind
-that opts in.
+Wave-10 follow-up Topic I finding F2 originally tested that the elapsed
+suffix was only shown for ``kind="thinking"``. The ``"thinking"`` kind has
+since been removed from StickyStatus — the inline Braille spinner
+(``InlineThinkingRow``) replaced it. This file now guards that neither
+``general`` nor ``error`` render an elapsed suffix.
 
 Public surfaces tested:
-  - thinking → render contains ``· N.Ns`` (regression guard)
   - general → render does NOT contain elapsed suffix
   - error → render does NOT contain elapsed suffix
 """
@@ -37,21 +28,11 @@ _ELAPSED_RE = re.compile(r"·\s+\d+\.\d+s")
 
 
 async def _render_plain(pilot, kind: str, body: str) -> str:
-    """Drive a real mounted StickyStatus + read the rendered plain text.
-
-    Backs the kind/body into the sticky via ``show``, lets the
-    coalesced ``_repaint`` run, then reads the widget's internal
-    state through the snapshot path + reconstructs the rendered
-    text by calling ``_repaint`` and capturing the ``update`` arg.
-    """
+    """Drive a real mounted StickyStatus + read the rendered plain text."""
     from reyn.chat.tui.widgets import ConversationView
     conv = pilot.app.query_one("#conversation", ConversationView)
     sticky = conv._sticky()
     sticky.show(body, kind=kind)
-    # Back-date _start so a meaningful elapsed value appears for
-    # the thinking case. 2.5s is enough to verify the float pattern.
-    import time
-    sticky._start = time.monotonic() - 2.5
     captured: dict = {}
     original_update = sticky.update
     def _spy(t):  # type: ignore[no-untyped-def]
@@ -61,21 +42,6 @@ async def _render_plain(pilot, kind: str, body: str) -> str:
     sticky._repaint()
     await pilot.pause()
     return captured["text"].plain
-
-
-@pytest.mark.asyncio
-async def test_thinking_kind_renders_elapsed_suffix() -> None:
-    """Tier 2 (regression): thinking still shows ``· N.Ns``."""
-    from reyn.chat.tui.app import ReynTUIApp
-
-    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
-    async with app.run_test(headless=True) as pilot:
-        await pilot.pause()
-        plain = await _render_plain(pilot, "thinking", "thinking…")
-        assert "thinking…" in plain
-        assert _ELAPSED_RE.search(plain), (
-            f"thinking should render elapsed suffix, got: {plain!r}"
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_sticky_status_error_kind.py
+++ b/tests/cli/test_sticky_status_error_kind.py
@@ -13,20 +13,24 @@ After the fix:
   - ``_GLYPHS["error"]`` = ``"✗"`` (= same glyph as ToolCallRow /
     SkillActivityRow failure terminals — cross-surface vocabulary
     uniform)
-  - ``_KIND_PRIORITY["error"]`` = 80 (above ``general``, below
-    ``thinking``) so an error can displace a turn-flash but not
-    yank a live ``⟳ thinking…`` while the LLM is still working
+  - ``_KIND_PRIORITY["error"]`` = 80 (above ``general``) so an
+    error can displace a turn-flash
   - ``_repaint`` paints the error glyph in bold red so the alert
     semantic reads even on monochrome terminals (= shape + color
     as redundant cues)
+
+Note: the original "error does NOT overwrite active thinking"
+test has been removed. The ``"thinking"`` kind was removed from
+StickyStatus — the inline Braille spinner (``InlineThinkingRow``)
+replaced it. Error (priority 80) is now the highest-priority kind.
 
 Public surfaces tested:
   - ``show("err", kind="error")`` → snapshot kind == "error"
     (no longer silent thinking fallback)
   - error overwrites general (= priority > 50)
-  - error does NOT overwrite active thinking (= priority < 100)
   - error glyph + body appear in the rendered output (= the
     ``Static.update`` Text carries ``✗`` not ``⟳``)
+  - unknown kind falls back to ``general`` (not ``thinking``)
 """
 from __future__ import annotations
 
@@ -49,7 +53,7 @@ async def _sticky(pilot):
 
 @pytest.mark.asyncio
 async def test_error_kind_is_registered_not_silent_fallback() -> None:
-    """Tier 2: ``show(kind="error")`` records "error" not "thinking"."""
+    """Tier 2: ``show(kind="error")`` records "error" not "general"."""
     from reyn.chat.tui.app import ReynTUIApp
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
@@ -82,13 +86,12 @@ async def test_error_overwrites_active_general() -> None:
 
 
 @pytest.mark.asyncio
-async def test_error_does_not_overwrite_active_thinking() -> None:
-    """Tier 2: ``error`` priority 80 < ``thinking`` priority 100.
+async def test_unknown_kind_falls_back_to_general() -> None:
+    """Tier 2: unknown kind falls back to ``general`` (not ``thinking``).
 
-    During an active LLM call, an error sticky must NOT yank the
-    ``⟳ thinking…`` indicator (= the user needs both signals — the
-    error is recorded as a conv-log line elsewhere, the thinking
-    must keep ticking). Lower-priority suppression catches this.
+    ``show()`` formerly fell back to ``kind="thinking"`` for unknown
+    kinds. After ``"thinking"`` was removed, the fallback is now
+    ``"general"``.
     """
     from reyn.chat.tui.app import ReynTUIApp
 
@@ -96,12 +99,11 @@ async def test_error_does_not_overwrite_active_thinking() -> None:
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         s = await _sticky(pilot)
-        s.show("thinking…", kind="thinking")
-        s.show("backround validation failed", kind="error")
+        s.show("some message", kind="unknown_kind")
         snap = s.snapshot()
-        # Thinking stays.
-        assert snap["kind"] == "thinking"
-        assert snap["body"] == "thinking…"
+        assert snap["kind"] == "general", (
+            f"unknown kind should fall back to 'general', got {snap['kind']!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -124,5 +126,5 @@ async def test_error_glyph_resolves_to_check_cross() -> None:
         assert s._glyph == "✗", (
             f"error kind glyph should be ✗, got {s._glyph!r}"
         )
-        # And the thinking glyph must NOT have been selected.
+        # And the old thinking glyph must NOT have been selected.
         assert s._glyph != "⟳"

--- a/tests/cli/test_sticky_status_overwrite_priority.py
+++ b/tests/cli/test_sticky_status_overwrite_priority.py
@@ -12,17 +12,22 @@ load-bearing live indicators).
     overwrote the warning before the user could read it.
 
 Fix:
-  - ``StickyStatus.show()`` now respects a ``_KIND_PRIORITY`` map.
-    ``thinking`` (priority 100) cannot be displaced by ``general``
+  - ``StickyStatus.show()`` respects a ``_KIND_PRIORITY`` map.
+    ``error`` (priority 80) cannot be displaced by ``general``
     (priority 50); same-or-higher priority overwrites freely.
   - ``_maybe_warn_about_trimmed_history`` additionally writes a
     permanent dim log line so the warning survives subsequent
     sticky overwrites — the user can find it in scrollback.
 
+Note: the original tests checked ``kind="thinking"`` (priority 100).
+The ``"thinking"`` kind was removed when the inline Braille spinner
+(``InlineThinkingRow``) replaced the sticky thinking indicator. The
+priority hierarchy now has ``error`` (80) as the highest kind.
+
 Public surfaces tested:
-  - thinking-active + general show → suppressed (I-F8)
-  - thinking → thinking overwrite → succeeds (regression guard)
-  - general-active + thinking show → succeeds (priority elevation)
+  - error-active + general show → suppressed (priority guard)
+  - error → error overwrite → succeeds (regression guard)
+  - general-active + error show → succeeds (priority elevation)
   - general → general overwrite → succeeds (same priority)
   - trim warning emits both a sticky AND a permanent log line (G-F8)
 """
@@ -46,35 +51,34 @@ async def _sticky(pilot):
 
 
 @pytest.mark.asyncio
-async def test_general_show_suppressed_when_thinking_active() -> None:
-    """Tier 2 (I-F8): a general flash cannot overwrite an active thinking."""
+async def test_general_show_suppressed_when_error_active() -> None:
+    """Tier 2 (I-F8): a general flash cannot overwrite an active error."""
     from reyn.chat.tui.app import ReynTUIApp
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         s = await _sticky(pilot)
-        s.show("thinking…", kind="thinking")
-        assert s.snapshot()["kind"] == "thinking"
-        assert s.snapshot()["body"] == "thinking…"
+        s.show("copy failed", kind="error")
+        assert s.snapshot()["kind"] == "error"
+        assert s.snapshot()["body"] == "copy failed"
 
-        # Lower-priority "general" must NOT displace thinking.
+        # Lower-priority "general" must NOT displace error.
         s.show("↑ turn 3 / 8", kind="general")
         snap = s.snapshot()
-        assert snap["kind"] == "thinking", (
-            f"thinking should still be active, got kind={snap['kind']!r}"
+        assert snap["kind"] == "error", (
+            f"error should still be active, got kind={snap['kind']!r}"
         )
-        assert snap["body"] == "thinking…", (
-            f"thinking body should be preserved, got body={snap['body']!r}"
+        assert snap["body"] == "copy failed", (
+            f"error body should be preserved, got body={snap['body']!r}"
         )
 
 
 @pytest.mark.asyncio
-async def test_thinking_overwrites_thinking_body() -> None:
+async def test_error_overwrites_error_body() -> None:
     """Tier 2: same-priority overwrite still works (regression guard).
 
-    The natural thinking-body update (e.g. "thinking…" → "calling
-    llm…") must not be suppressed.
+    The natural error-body update must not be suppressed.
     """
     from reyn.chat.tui.app import ReynTUIApp
 
@@ -82,15 +86,15 @@ async def test_thinking_overwrites_thinking_body() -> None:
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         s = await _sticky(pilot)
-        s.show("thinking…", kind="thinking")
-        s.show("calling llm…", kind="thinking")
+        s.show("first error", kind="error")
+        s.show("second error", kind="error")
         snap = s.snapshot()
-        assert snap["kind"] == "thinking"
-        assert snap["body"] == "calling llm…"
+        assert snap["kind"] == "error"
+        assert snap["body"] == "second error"
 
 
 @pytest.mark.asyncio
-async def test_thinking_overwrites_general_when_general_active() -> None:
+async def test_error_overwrites_general_when_general_active() -> None:
     """Tier 2: higher-priority show DISPLACES lower-priority active."""
     from reyn.chat.tui.app import ReynTUIApp
 
@@ -100,10 +104,10 @@ async def test_thinking_overwrites_general_when_general_active() -> None:
         s = await _sticky(pilot)
         s.show("↑ turn 2 / 5", kind="general")
         assert s.snapshot()["kind"] == "general"
-        s.show("thinking…", kind="thinking")
+        s.show("copy failed", kind="error")
         snap = s.snapshot()
-        assert snap["kind"] == "thinking"
-        assert snap["body"] == "thinking…"
+        assert snap["kind"] == "error"
+        assert snap["body"] == "copy failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — UX fix: visible in-flight indicator

## Summary
- New ``InlineThinkingRow`` widget — 10-frame Braille spinner (``⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏``) at ~10fps, mounted in conv pane flow
- ``ConversationView.start_thinking()`` / ``stop_thinking()`` lifecycle hooks (idempotent both ways)
- All ``kind="thinking"`` sticky callers migrated to the inline path
- ``"thinking"`` removed from ``_KIND_PRIORITY`` and ``_GLYPHS`` (sticky no longer handles it; fallback changed from ``"thinking"`` → ``"general"``)
- Sticky remains for error / general / "awaiting answer" / etc.

## Why
User feedback: the sticky ``⟳ thinking · Ns`` indicator at the bottom dock was easy to miss (= short duration for fast inline replies, peripheral location, dim styling). User: *"thinking というワードはノイズなのでいらない。インジケータだけで表現したい"*. Claude Code-style inline spinner placed in the conv pane flow makes the in-flight state unmissable — it appears RIGHT where the reply will land.

## Test plan
- [x] ``tests/cli/test_inline_thinking_row.py`` — 7 Tier-2 tests (start idempotent, stop idempotent, mount/unmount, frame validity, tick advances, kind removed from priority)
- [x] Existing sticky / conv / streaming tests updated for removed ``thinking`` kind — all pass
- [x] ``test_slash_error_recall_hint.py::test_image_no_path_emits_recall_hint_in_outbox`` — pre-existing failure, unrelated to this PR (confirmed on main branch)
- [x] ruff clean (all changed files)
- [x] Manual: submit text → Braille spinner appears in conv pane → reply lands → spinner unmounts