### PR TITLE
feat(permissions): wire require_secret_write at save_secret + wildcard semantics (#571 Phase 6)

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -1010,6 +1010,9 @@ class RouterHostAdapter:
             mcp=mcp_names,
             allowed_mcp=self._allowed_mcp,
             http_get=[{"host": "registry.modelcontextprotocol.io"}],
+            # #571 Phase 6: wildcard secret.write — see ChatSession's
+            # matching pattern for rationale.
+            secret_write=["*"],
         )
         if self._perm is not None:
             for canonical in (".reyn/mcp.yaml", ".reyn/cron.yaml", ".reyn/index/sources.yaml"):

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3957,6 +3957,11 @@ class ChatSession:
             mcp=mcp_names,
             allowed_mcp=self._allowed_mcp,
             http_get=[{"host": "registry.modelcontextprotocol.io"}],
+            # #571 Phase 6: wildcard secret.write authorises LLM-emitted
+            # mcp_install ops to save runtime-determined ``isSecret`` env
+            # vars from the registry — the actual security gate is the
+            # operator's per-value prompt at op-execution time.
+            secret_write=["*"],
         )
         # Session-approve the canonical OS mutation paths so the runtime
         # require_file_write check passes silently for LLM-emitted ops

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -723,6 +723,9 @@ def _run_install_from_source(
     decl = PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],
         http_get=[{"host": "registry.modelcontextprotocol.io"}],
+        # #571 Phase 6: wildcard authorises save_secret for the
+        # registry's ``isSecret`` env vars (= determined at runtime).
+        secret_write=["*"],
     )
 
     ctx = OpContext(

--- a/src/reyn/op_runtime/mcp_install.py
+++ b/src/reyn/op_runtime/mcp_install.py
@@ -256,8 +256,23 @@ async def handle(
             )
 
     # ── 4. Credentials: prompt for isSecret env vars + persist ───────────────
+    # #571 Phase 6: every save_secret call routes through
+    # require_secret_write against the calling skill's decl. The
+    # env-var key set is server-specific (= determined by the registry
+    # response, not statically known by the skill author) so skills
+    # that invoke mcp_install must declare the wildcard form
+    # ``secret.write: ['*']`` — the actual security gate is the
+    # operator's per-value prompt below.
     env_overrides = dict(op.env_overrides or {})
     secret_keys_set: list[str] = []
+
+    def _save_with_gate(key: str, value: str) -> None:
+        if ctx.permission_resolver is not None:
+            ctx.permission_resolver.require_secret_write(
+                ctx.permission_decl, key, ctx.skill_name,
+            )
+        from reyn.secrets.store import save_secret
+        save_secret(key, value)
 
     # Collect environmentVariables from packages[] that have isSecret=True
     for pkg_raw in packages_raw:
@@ -273,8 +288,7 @@ async def handle(
                 continue
             # Already supplied via env_overrides — skip prompt
             if key in env_overrides:
-                from reyn.secrets.store import save_secret
-                save_secret(key, env_overrides[key])
+                _save_with_gate(key, env_overrides[key])
                 secret_keys_set.append(key)
                 continue
             # Prompt via intervention_bus
@@ -290,8 +304,7 @@ async def handle(
                 answer = await ctx.intervention_bus.request(iv)
                 value = getattr(answer, "text", None) or getattr(answer, "choice_id", "")
                 if value:
-                    from reyn.secrets.store import save_secret
-                    save_secret(key, value)
+                    _save_with_gate(key, value)
                     secret_keys_set.append(key)
 
     # ── 5. Write mcp.servers.<name> to scope config file ─────────────────────

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -879,15 +879,25 @@ class PermissionResolver:
     ) -> None:
         """Raise PermissionError if secret-store write of ``key`` is not declared.
 
-        #571 collapse arc Phase 3: axis declaration + resolver method.
-        Callers (= ``reyn.secrets.store.save_secret`` from op handlers)
-        are wired in Phase 5 when bool axes are removed and op handlers
-        route through this gate instead of their dedicated bool-axis
-        ``require_*`` methods. For Phase 3 / 4 this method exists so
-        the schema, parsing, and downstream config wiring can land
-        ahead of the op-handler migration.
+        Two declaration shapes are accepted:
+
+        - **Specific key** — ``secret.write: ["GITHUB_TOKEN"]`` authorises
+          only that exact key. Use when the skill knows at write-time
+          which env-var names it will save.
+        - **Wildcard** ``"*"`` — ``secret.write: ["*"]`` authorises any
+          key. Use when the key set is determined at runtime from
+          external metadata (= ``mcp_install``'s ``isSecret``
+          environment variables from the registry response). The
+          security gate in this case is the operator's per-value prompt
+          at op-execution time; the wildcard declaration is the
+          author's acknowledgement that the skill will route through
+          that prompt-then-save flow.
+
+        Specific entries take precedence — a skill that lists both
+        ``"GITHUB_TOKEN"`` and ``"*"`` is functionally equivalent to
+        just ``"*"`` but conveys intent more clearly.
         """
-        if key in decl.secret_write:
+        if key in decl.secret_write or "*" in decl.secret_write:
             return
         raise PermissionError(
             f"Secret-store write of key {key!r} not declared in skill permissions. "
@@ -895,6 +905,10 @@ class PermissionResolver:
             f"  permissions:\n"
             f"    secret.write:\n"
             f"      - {key}\n"
+            f"or use the wildcard form for runtime-determined keys:\n"
+            f"  permissions:\n"
+            f"    secret.write:\n"
+            f"      - '*'\n"
         )
 
     def is_read_allowed(self, path: str, skill_name: str = "") -> bool:

--- a/src/reyn/stdlib/skills/mcp_install/skill.md
+++ b/src/reyn/stdlib/skills/mcp_install/skill.md
@@ -26,6 +26,15 @@ permissions:
       scope: just_path
   http.get:
     - host: registry.modelcontextprotocol.io
+  # #571 Phase 6 (2026-05-23): wildcard secret.write reflects that the
+  # env-var keys to save are determined at runtime from the registry's
+  # ``isSecret`` environmentVariables block — the skill author cannot
+  # enumerate them statically. The actual security gate is the
+  # operator's per-value prompt at op-execution time; this declaration
+  # is the author's acknowledgement that the op routes through that
+  # prompt-then-save flow.
+  secret.write:
+    - "*"
   python:
     # FP-0042 Phase 2.4 (2026-05-23): migrated from mode: unsafe to mode: safe.
     # Registry HTTP + cache + JSON parse + dedup all hidden inside

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -111,6 +111,10 @@ async def _handle_mcp_install_op(
         synth_decl = PermissionDecl(
             file_write=[{"path": canonical_config, "scope": "just_path"}],
             http_get=[{"host": registry_host}],
+            # #571 Phase 6: wildcard authorises the op handler to save
+            # the user-prompted secret values for whichever env vars
+            # the registry declares as ``isSecret`` at runtime.
+            secret_write=["*"],
         )
         if ctx.permission_resolver is not None:
             ctx.permission_resolver.session_approve_path(

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -140,20 +140,21 @@ def _make_resolver(tmp_path: Path, *, config: dict | None = None) -> PermissionR
 
 
 def _phase5_install_decl(resolver: PermissionResolver) -> PermissionDecl:
-    """Phase 5 successor to ``PermissionDecl(mcp_install=True)``.
+    """Phase 5 + Phase 6 successor to ``PermissionDecl(mcp_install=True)``.
 
     Builds the explicit list-axis decl the op handler now consumes:
     ``file.write`` on the canonical config path + ``http.get`` for the
-    registry host. Session-approves the file path so the
+    registry host + wildcard ``secret.write`` (= #571 Phase 6,
+    authorises save_secret for runtime-determined env-var keys from
+    the registry response). Session-approves the file path so the
     ``require_file_write`` check passes without an interactive prompt.
-    The path is anchored against the resolver's project_root so the
-    session-key matches the op handler's resolved path at check time.
     """
     canonical_config = str(resolver._project_root / ".reyn" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_test", "file.write")
     return PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],
         http_get=[{"host": "registry.modelcontextprotocol.io"}],
+        secret_write=["*"],
     )
 
 
@@ -324,6 +325,42 @@ def test_env_overrides_skip_prompt_and_persist_secret(tmp_path):
     assert env_section.get("EXAMPLE_API_KEY") == "${EXAMPLE_API_KEY}"
     # Raw value must not appear in config
     assert "my-secret-value" not in config_path.read_text(encoding="utf-8")
+
+
+def test_save_secret_blocked_when_secret_write_not_declared(tmp_path):
+    """Tier 2: mcp_install raises PermissionError when secret.write is missing.
+
+    #571 Phase 6: every save_secret call routes through
+    require_secret_write. A skill that declares file.write + http.get
+    but forgets secret.write fails the gate when the registry server
+    has ``isSecret`` env vars.
+    """
+    resolver = _make_resolver(tmp_path)
+    canonical_config = str(resolver._project_root / ".reyn" / "mcp.yaml")
+    resolver.session_approve_path(canonical_config, "mcp_install_test", "file.write")
+    decl = PermissionDecl(
+        file_write=[{"path": canonical_config, "scope": "just_path"}],
+        http_get=[{"host": "registry.modelcontextprotocol.io"}],
+        # secret_write omitted — gate fires when first secret save is attempted
+    )
+    bus = _AutoApproveInterventionBus()
+    ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
+    secrets_path = tmp_path / ".reyn" / "secrets.env"
+
+    op = MCPInstallIROp(
+        kind="mcp_install",
+        server_id="io.github.example/secret-server",
+        scope="local",
+        env_overrides={"EXAMPLE_API_KEY": "my-secret-value"},
+    )
+
+    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
+        with mock.patch(
+            "reyn.secrets.store._secrets_path", return_value=secrets_path
+        ):
+            with _patch_registry_get(_SECRET_SERVER_RESPONSE):
+                with pytest.raises(PermissionError, match="EXAMPLE_API_KEY"):
+                    _run(mcp_install_handle(op, ctx, "control_ir"))
 
 
 def test_secret_value_not_in_event(tmp_path):

--- a/tests/test_mcp_source_install.py
+++ b/tests/test_mcp_source_install.py
@@ -212,17 +212,18 @@ def _make_resolver(tmp_path: Path, *, config: dict | None = None) -> PermissionR
 
 
 def _phase5_source_install_decl(resolver: PermissionResolver) -> PermissionDecl:
-    """Phase 5 successor to ``PermissionDecl(mcp_install=True)`` for source installs.
+    """Phase 5 + Phase 6 successor to ``PermissionDecl(mcp_install=True)``.
 
     Source installs skip the registry fetch but still write to
-    ``.reyn/mcp.yaml`` — declare only the file.write entry (no
-    http.get is needed since no registry HTTP is issued on the
-    source-resolver path).
+    ``.reyn/mcp.yaml`` — declare the file.write entry. Wildcard
+    secret.write (= #571 Phase 6) covers any isSecret env vars the
+    source resolver surfaces.
     """
     canonical_config = str(resolver._project_root / ".reyn" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_source_test", "file.write")
     return PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],
+        secret_write=["*"],
     )
 
 

--- a/tests/test_permission_collapse_phase3.py
+++ b/tests/test_permission_collapse_phase3.py
@@ -136,6 +136,29 @@ def test_require_secret_write_passes_for_declared_key(tmp_path):
     resolver.require_secret_write(decl, "GITHUB_TOKEN")
 
 
+def test_require_secret_write_wildcard_passes_any_key(tmp_path):
+    """Tier 2: secret.write: ['*'] wildcard authorises any key.
+
+    #571 Phase 6: covers the mcp_install case where the env-var key
+    set is determined at runtime from the registry response. The
+    actual security gate is the operator's per-value prompt at
+    op-execution time; the wildcard is the author's acknowledgement.
+    """
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(secret_write=["*"])
+    resolver.require_secret_write(decl, "UNFORESEEN_KEY")
+    resolver.require_secret_write(decl, "ANOTHER_KEY")
+    resolver.require_secret_write(decl, "PG_PASSWORD")
+
+
+def test_require_secret_write_wildcard_alongside_specific_key(tmp_path):
+    """Tier 2: wildcard alongside specific keys still authorises any key."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(secret_write=["GITHUB_TOKEN", "*"])
+    resolver.require_secret_write(decl, "GITHUB_TOKEN")
+    resolver.require_secret_write(decl, "OTHER_KEY")
+
+
 # ── reyn.safe.http enforcement ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — #571 collapse arc Phase 6 follow-up = `secret.write` caller wiring (the Phase 5-deferred loose end).

## Summary

`require_secret_write` was added in Phase 3 (#618) as a declaration-only resolver method and left unwired in Phase 5 (#631) because the bool-axis removal didn't surface a natural caller for it yet. This PR makes it a real gate at `reyn.secrets.store.save_secret` calls from the `mcp_install` op handler — the only path in the OS that programmatically saves a secret on behalf of an LLM-emitted op.

Also adds `secret.write: ["*"]` wildcard semantics to address mcp_install's pattern where env-var keys come from the registry's `isSecret` block at runtime (= skill author cannot enumerate statically). The wildcard is the author's acknowledgement that the op routes through the OS's per-value prompt-then-save flow; the operator's per-value prompt is the actual security gate.

## Changes

- **`PermissionResolver.require_secret_write`**: accepts `"*"` wildcard alongside specific key entries. Specific entries still take precedence; wildcard broadens. Error message suggests both shapes.
- **`op_runtime/mcp_install.py`**: new `_save_with_gate(key, value)` helper; replaces direct `save_secret` calls in both the `env_overrides` path and the `intervention_bus` prompt path.
- **Declaration migrations** (= `secret.write: ["*"]` added):
  - `stdlib/skills/mcp_install/skill.md`
  - `tools/mcp_install.py` synthesised decl
  - `cli/commands/mcp.py` source-install decl
  - `chat/session.py` + `chat/services/router_host_adapter.py` chat router decl
- **Tests**:
  - `test_permission_collapse_phase3.py`: 2 new wildcard tests
  - `test_mcp_install_op.py`: `test_save_secret_blocked_when_secret_write_not_declared`
  - `_phase5_*_decl` fixtures updated with `secret_write=["*"]`

## Architectural impact

Completes the #571 collapse arc's "permission is an OS I/O primitive" principle on the secret-write axis. Every `save_secret` call from an LLM-emitted op now routes through the resolver against the calling skill's declared list axis. The #571 collapse arc closure (#631) is unchanged — this PR finalizes the Phase 5-deferred wiring.

## Test plan

- [x] `pytest -q` from rootdir → 5454 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref.py`, baseline)
- [x] `ruff check .` → All checks passed
- [x] New test (`test_save_secret_blocked_when_secret_write_not_declared`) confirms gate fires when secret.write omitted
- [x] Existing mcp_install / mcp_source_install / mcp_install_skill tests pass with wildcard-declared fixtures

Refs #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)