### PR TITLE
fix(index_docs): strategy preprocessor module path (FP-0042 Phase 2.1/2.8 residual)

### DIFF
--- a/src/reyn/stdlib/skills/index_docs/phases/strategy.md
+++ b/src/reyn/stdlib/skills/index_docs/phases/strategy.md
@@ -7,7 +7,7 @@ can_finish: true
 allowed_ops: []
 preprocessor:
   - type: python
-    module: ./chunkers.py
+    module: ./chunkers_preproc_safe.py
     function: gather_samples
     into: data.samples_result
     output_schema:
@@ -38,7 +38,7 @@ preprocessor:
           minimum: 0
           description: Total number of files matched by the path glob.
   - type: python
-    module: ./chunkers.py
+    module: ./chunkers_preproc_safe.py
     function: cost_preflight
     into: data.cost
     output_schema:


### PR DESCRIPTION
**[dogfood-coder]** — FP-0042 cascade residual surfaced by B53 W2-S1 + W2-S7.

## Summary

- `src/reyn/stdlib/skills/index_docs/phases/strategy.md` preprocessor 2 steps still referenced `./chunkers.py` — renamed to `./chunkers_preproc_safe.py` in FP-0042 Phase 2.1 (#553) and deleted in Phase 2.8 (#590). skill.md `permissions:` was updated in the cascade; phases/strategy.md was missed.
- 2-line fix in phases/strategy.md (= both preprocessor steps point at `chunkers_preproc_safe.py`). No OS code touched, no test churn, no schema change.
- B53 W2-S1 (`index_docs_basic`) + W2-S7 (`chained_find_then_index`) both R in the latest batch with verbatim error `python step ./chunkers.py:gather_samples is not declared in skill permissions`. Same root cause on both scenarios.

## Verify-first (= reproduce on main + apply fix + re-run via A2A)

Reproduce confirmed on main HEAD (= B53 W2 events show the failure verbatim).

Post-fix, fresh A2A round-trip against the same scenario shape (= `docs/concepts/` mini subset indexed as `concepts_index`):

| Event | Pre-fix | Post-fix |
|---|---|---|
| `preprocessor_step_completed` | 0 (= permission gate reject) | **2** ✓ |
| `permission_granted` (preproc) | 0 | **2** ✓ |
| `phase_completed` (strategy) | 0 | **1** ✓ |
| `postprocessor_step_completed` | 0 | **4** ✓ |
| `skill_run_failed` | ≥1 | **0** ✓ |
| `workflow_finished` | 0 | **1** ✓ |

Artifacts written: `artifacts/chunks.jsonl` + `artifacts/chunks_with_vectors.jsonl` + `.reyn/index/concepts_index/sources.yaml`.
Reply text: 「登録しました」 (pre-fix: 「エラーが発生しました」).

## Test plan

- [x] Reproduce-first: B53 W2-S1 events on main HEAD show the verbatim permission-gate error string
- [x] 2-line edit to `phases/strategy.md` applied
- [x] Verify-first: fresh A2A request post-fix shows all expected events + artifacts + non-error reply
- [x] Test sweep: 109 passed / 0 failed (`-k "index_docs or chunkers or preproc"`)
- [x] No OS code changes — pure skill metadata bug; runtime preprocessor + permission gate behaviour unchanged

## Implications for B54

- W2-S1 + W2-S7 R → V expected in B54 (= +2V cumulative across W2)
- B53 V projected post-fix: 31/48 = 64.6% (= +3V vs B52 post-retest baseline 28/48)
- Stdlib invariant test gap (= no test pinning `phases/*/preprocessor[].module` ↔ `skill.md.permissions.python[].module` ↔ on-disk file existence) is the meta-finding; filing as B54 candidate, not bundled here per `feedback_minimize_speculation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)