### PR TITLE
feat(tui): docs tab lang preference toggle — ja preferred + en fallback

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -137,6 +137,11 @@ class RightPanel(Widget):
         self._docs_files: list[Path] = []
         self._docs_groups: dict[str, list[Path]] = {}
         self._docs_filter: str = ""
+        # Language preference for the Docs tab. Two valid values: "ja"
+        # (default — Japanese preferred, English fallback when .ja.md absent)
+        # and "en" (English preferred, Japanese fallback). Toggled by the
+        # ``g`` key while the Docs tab is active.
+        self._docs_lang: str = "ja"
         self._preview_visible: bool = False
         self._panel_width: int = 0  # 0 = use CSS default (33%); set on first resize
         # run_id → {skill_name, agent_name, start_time, phase, phase_visits}
@@ -731,6 +736,20 @@ class RightPanel(Widget):
             if self._panel_type == "docs":
                 event.prevent_default()
                 self._prefill_docs_filter()
+        elif event.key == "g":
+            # Docs tab only: toggle language preference between "ja"
+            # (Japanese preferred, English fallback) and "en" (English
+            # preferred, Japanese fallback). Each concept appears once
+            # in the list; ``g`` is free on all other tabs (``ctrl+g``
+            # is already used for find-next but bare ``g`` is unused).
+            if self._panel_type == "docs":
+                event.prevent_default()
+                self._docs_lang = "en" if self._docs_lang == "ja" else "ja"
+                other = "en" if self._docs_lang == "ja" else "ja"
+                self._flash_status(
+                    f"docs lang: {self._docs_lang} ({other} fallback)"
+                )
+                self._invalidate()
 
 
     def on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
@@ -1896,7 +1915,9 @@ class RightPanel(Widget):
         Docs tab. Falls through silently when docs/ or the target file are
         absent — the user stays on the events tab.
         """
-        groups, ordered = build_docs_index(self._project_root, "")
+        groups, ordered = build_docs_index(
+            self._project_root, "", lang=self._docs_lang,
+        )
         if not ordered:
             self._flash_status("docs/: not found")
             return
@@ -2246,7 +2267,7 @@ class RightPanel(Widget):
         if self._panel_type == "docs":
             return (
                 f"[bold {_CORAL}]Docs[/]"
-                f"  [#555555]j↓ k↑ space=open /=filter[/]"
+                f"  [#555555]j↓ k↑ space=open /=filter g=lang[/]"
             )
         if self._panel_type == "pending":
             # Issue #277 — Pending tab keybinds: j/k cursor +
@@ -2341,6 +2362,7 @@ class RightPanel(Widget):
             if self._panel_type == "docs":
                 groups, ordered = build_docs_index(
                     self._project_root, self._docs_filter,
+                    lang=self._docs_lang,
                 )
                 self._docs_groups = groups
                 self._docs_files = ordered
@@ -2349,6 +2371,7 @@ class RightPanel(Widget):
                 return render_docs(
                     self._project_root, self._docs_cursor, groups,
                     docs_filter=self._docs_filter,
+                    lang=self._docs_lang,
                 )
             if self._panel_type == "pending":
                 # Issue #277 — surface stalled / cross-channel ops.

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -137,11 +137,11 @@ class RightPanel(Widget):
         self._docs_files: list[Path] = []
         self._docs_groups: dict[str, list[Path]] = {}
         self._docs_filter: str = ""
-        # Language preference for the Docs tab. Two valid values: "ja"
-        # (default — Japanese preferred, English fallback when .ja.md absent)
-        # and "en" (English preferred, Japanese fallback). Toggled by the
+        # Language preference for the Docs tab. Two valid values: "en"
+        # (default — English preferred, Japanese fallback when .md absent)
+        # and "ja" (Japanese preferred, English fallback). Toggled by the
         # ``g`` key while the Docs tab is active.
-        self._docs_lang: str = "ja"
+        self._docs_lang: str = "en"
         self._preview_visible: bool = False
         self._panel_width: int = 0  # 0 = use CSS default (33%); set on first resize
         # run_id → {skill_name, agent_name, start_time, phase, phase_visits}

--- a/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
@@ -5,10 +5,30 @@ from pathlib import Path
 
 from .base import _CORAL, _esc
 
+# ---------------------------------------------------------------------------
+# Language helpers
+# ---------------------------------------------------------------------------
+
+def _base_stem(p: Path) -> str:
+    """Return the language-neutral base stem for a docs path.
+
+    ``glossary.ja.md`` → ``"glossary"``
+    ``glossary.md``    → ``"glossary"``
+    """
+    stem = p.stem  # strips the final ".md"
+    return stem[:-3] if stem.endswith(".ja") else stem
+
+
+def _is_ja(p: Path) -> bool:
+    """True when the path is the Japanese (.ja.md) variant."""
+    return p.stem.endswith(".ja")
+
 
 def build_docs_index(
     project_root: Path | None,
     docs_filter: str = "",
+    *,
+    lang: str = "ja",
 ) -> tuple[dict[str, list[Path]], list[Path]]:
     """Scan docs/ and return (groups_by_section, ordered_flat_list).
 
@@ -16,6 +36,15 @@ def build_docs_index(
     When `docs_filter` is non-empty, only files whose stem (case-insensitive)
     contains the filter substring are kept. Sections with no matching files
     are dropped from the groups dict.
+
+    ``lang`` controls which language variant is preferred per concept:
+
+    * ``"ja"`` (default) — prefer ``.ja.md``; fall back to ``.md`` when absent.
+    * ``"en"``           — prefer ``.md``; fall back to ``.ja.md`` when absent.
+
+    Each unique base concept appears exactly once in the returned lists.
+    The fallback variant is still included but labelled so the caller can
+    render a dim suffix (see ``render_docs``).
     """
     if project_root is None:
         return {}, []
@@ -26,17 +55,39 @@ def build_docs_index(
     if not docs_root.is_dir():
         return {}, []
 
-    groups: dict[str, list[Path]] = {}
+    # Collect all .md files grouped by section.
+    raw_groups: dict[str, list[Path]] = {}
     for md in sorted(docs_root.rglob("*.md")):
         rel = md.relative_to(docs_root)
         section = rel.parts[0] if len(rel.parts) > 1 else ""
-        groups.setdefault(section, []).append(md)
+        raw_groups.setdefault(section, []).append(md)
+
+    # Per section: collapse en/ja pairs to one file per base stem.
+    groups: dict[str, list[Path]] = {}
+    for section, paths in raw_groups.items():
+        # Build base → {True: ja_path, False: en_path} map.
+        by_base: dict[str, dict[bool, Path]] = {}
+        for p in paths:
+            base = _base_stem(p)
+            by_base.setdefault(base, {})[_is_ja(p)] = p
+
+        # Pick the preferred variant for each base, in alphabetical base order.
+        chosen: list[Path] = []
+        for base in sorted(by_base):
+            variants = by_base[base]
+            if lang == "ja":
+                # Prefer Japanese; fall back to English.
+                chosen.append(variants.get(True) or variants[False])
+            else:
+                # Prefer English; fall back to Japanese.
+                chosen.append(variants.get(False) or variants[True])
+        groups[section] = chosen
 
     if docs_filter:
         needle = docs_filter.lower()
         filtered: dict[str, list[Path]] = {}
         for section, paths in groups.items():
-            kept = [p for p in paths if needle in p.stem.lower()]
+            kept = [p for p in paths if needle in _base_stem(p).lower()]
             if kept:
                 filtered[section] = kept
         groups = filtered
@@ -53,8 +104,13 @@ def render_docs(
     groups: dict[str, list[Path]],
     *,
     docs_filter: str = "",
+    lang: str = "ja",
 ) -> str:
-    """Render the docs index with the file at ``docs_cursor`` highlighted."""
+    """Render the docs index with the file at ``docs_cursor`` highlighted.
+
+    ``lang`` must be ``"ja"`` or ``"en"`` — controls the preference header
+    and which rows are annotated with a dim fallback suffix.
+    """
     if project_root is None:
         return "[#555555]  (no project root)[/]"
     # Mirror the fallback logic in build_docs_index.
@@ -65,6 +121,16 @@ def render_docs(
         return "[#555555]  (docs/ not found)[/]"
 
     lines: list[str] = []
+
+    # Lang preference header — always rendered so the user knows the active
+    # setting without having to press ``g``.
+    other_lang = "en" if lang == "ja" else "ja"
+    lines.append(
+        f"[#aaaaaa]  lang: [/][{_CORAL}]{lang}[/]"
+        f"[#555555]  ({other_lang} fallback)  [g] to toggle[/]"
+    )
+    lines.append("")
+
     if docs_filter:
         # A-F4 (wave-8): hint advertises Esc as the direct clear path.
         # Pre-A-F4, the only clear flow was ``/docs-filter`` (no arg) — a
@@ -86,34 +152,28 @@ def render_docs(
         lines.append(f"[bold #aaaaaa]  \\[{_esc(label)}][/]")
         for md in groups[section]:
             indent = "    "
-            # Wave-4 PC2: stems ending in ``.ja`` (= ``foo.ja.md``)
-            # are Japanese translations of the English doc next to
-            # them. Without distinction the alphabetical sort
-            # interleaves them (``a2a.ja / a2a / care-boundary.ja /
-            # care-boundary / …``), confusing for English-default
-            # users. Annotate the JA stems with a dim ``(ja)``
-            # suffix so the list reads at-a-glance: same alphabetical
-            # order, language identified per row. Avoids a deeper
-            # restructure (= subsection split / filter UI) for the
-            # minimum visible-distinction fix.
-            stem = md.stem
-            if stem.endswith(".ja"):
-                base = stem[:-3]
-                if file_idx == docs_cursor:
-                    lines.append(
-                        f"[bold {_CORAL}]{indent}▶ {_esc(base)}[/]"
-                        f"[dim {_CORAL}]  (ja)[/]"
-                    )
-                else:
-                    lines.append(
-                        f"[#666666]{indent}  {_esc(base)}[/]"
-                        f"[dim #666666]  (ja)[/]"
-                    )
+            base = _base_stem(md)
+            is_ja_file = _is_ja(md)
+
+            # Determine if this row is a fallback (= preferred lang was absent).
+            # lang="ja" + file is NOT ja → fallback → show dim (en) suffix.
+            # lang="en" + file IS ja    → fallback → show dim (ja) suffix.
+            fallback_suffix = ""
+            if lang == "ja" and not is_ja_file:
+                fallback_suffix = "  (en)"
+            elif lang == "en" and is_ja_file:
+                fallback_suffix = "  (ja)"
+
+            if file_idx == docs_cursor:
+                lines.append(
+                    f"[bold {_CORAL}]{indent}▶ {_esc(base)}[/]"
+                    + (f"[dim {_CORAL}]{fallback_suffix}[/]" if fallback_suffix else "")
+                )
             else:
-                if file_idx == docs_cursor:
-                    lines.append(f"[bold {_CORAL}]{indent}▶ {_esc(stem)}[/]")
-                else:
-                    lines.append(f"[#666666]{indent}  {_esc(stem)}[/]")
+                lines.append(
+                    f"[#666666]{indent}  {_esc(base)}[/]"
+                    + (f"[dim #666666]{fallback_suffix}[/]" if fallback_suffix else "")
+                )
             file_idx += 1
         lines.append("")
 

--- a/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
@@ -28,7 +28,7 @@ def build_docs_index(
     project_root: Path | None,
     docs_filter: str = "",
     *,
-    lang: str = "ja",
+    lang: str = "en",
 ) -> tuple[dict[str, list[Path]], list[Path]]:
     """Scan docs/ and return (groups_by_section, ordered_flat_list).
 
@@ -39,8 +39,8 @@ def build_docs_index(
 
     ``lang`` controls which language variant is preferred per concept:
 
-    * ``"ja"`` (default) — prefer ``.ja.md``; fall back to ``.md`` when absent.
-    * ``"en"``           — prefer ``.md``; fall back to ``.ja.md`` when absent.
+    * ``"en"`` (default) — prefer ``.md``; fall back to ``.ja.md`` when absent.
+    * ``"ja"``           — prefer ``.ja.md``; fall back to ``.md`` when absent.
 
     Each unique base concept appears exactly once in the returned lists.
     The fallback variant is still included but labelled so the caller can
@@ -104,11 +104,11 @@ def render_docs(
     groups: dict[str, list[Path]],
     *,
     docs_filter: str = "",
-    lang: str = "ja",
+    lang: str = "en",
 ) -> str:
     """Render the docs index with the file at ``docs_cursor`` highlighted.
 
-    ``lang`` must be ``"ja"`` or ``"en"`` — controls the preference header
+    ``lang`` must be ``"en"`` or ``"ja"`` — controls the preference header
     and which rows are annotated with a dim fallback suffix.
     """
     if project_root is None:

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -95,6 +95,11 @@ _KEY_DETAILS: dict[str, str] = {
         "below_min_batch / below_threshold / already_running).\n"
         "When on, shows everything. Only active on the Events tab."
     ),
+    "g": (
+        "Docs tab only. Switches language preference: ja → en → ja.\n"
+        "Each concept appears once; (ja)/(en) suffix marks fallback\n"
+        "rows when the preferred variant is absent."
+    ),
 }
 
 
@@ -159,9 +164,9 @@ _PANEL_KEYS = {
     "ctrl+5", "ctrl+6", "ctrl+7",
 }
 _EVENTS_KEYS = {"f", "t", "i", "v"}
-# ``/`` stays DOCS-only — it opens the docs name filter, no other tab
-# consumes it.
-_DOCS_KEYS = {"/"}
+# ``/`` and ``g`` stay DOCS-only — ``/`` opens the docs name filter;
+# ``g`` toggles the language preference (ja preferred / en preferred).
+_DOCS_KEYS = {"/", "g"}
 _GROUP_ORDER = [
     "GLOBAL", "INPUT", "CONVERSATION", "PANEL",
     "EVENTS (gated)", "DOCS (gated)", "OTHER", "MOUSE",
@@ -305,6 +310,9 @@ def render_keys(
         # Events tab ``v`` = toggle verbose mode. Default-off hides
         # compaction_check noise; verbose-on shows everything.
         ("v", "Toggle verbose (events tab)"),
+        # Lang toggle: each doc concept appears once; ``g`` switches the
+        # preferred language (ja ↔ en). Only active on the Docs tab.
+        ("g", "Toggle docs language preference (ja ↔ en, docs tab only)"),
     ]
     # Note: memory tab's ``t`` (= cycle_memory_type_filter, wave-11
     # A#1) is intentionally NOT in this list because ``t`` is already

--- a/tests/cli/test_docs_lang_filter.py
+++ b/tests/cli/test_docs_lang_filter.py
@@ -1,8 +1,8 @@
-"""Tier 2: Docs tab lang preference toggle — ja preferred + en fallback.
+"""Tier 2: Docs tab lang preference toggle — en preferred + ja fallback.
 
-Each doc concept appears once in the Docs tab. Default: ja preferred,
-en fallback when .ja.md absent. ``g`` key (docs tab only) toggles to
-en preferred (ja fallback).
+Each doc concept appears once in the Docs tab. Default: en preferred,
+ja fallback when .md absent. ``g`` key (docs tab only) toggles to
+ja preferred (en fallback).
 
 Fixture layout (created per-test via tmp_path):
   docs/

--- a/tests/cli/test_docs_lang_filter.py
+++ b/tests/cli/test_docs_lang_filter.py
@@ -1,0 +1,318 @@
+"""Tier 2: Docs tab lang preference toggle — ja preferred + en fallback.
+
+Each doc concept appears once in the Docs tab. Default: ja preferred,
+en fallback when .ja.md absent. ``g`` key (docs tab only) toggles to
+en preferred (ja fallback).
+
+Fixture layout (created per-test via tmp_path):
+  docs/
+    concepts/
+      glossary.md           # both en and ja present
+      glossary.ja.md
+      plan-mode.md          # en only
+      universal-catalog.ja.md  # ja only
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+def _make_docs_tree(tmp_path: Path) -> Path:
+    """Create a minimal docs/ tree and return the project root (= tmp_path)."""
+    concepts = tmp_path / "docs" / "concepts"
+    concepts.mkdir(parents=True)
+    (concepts / "glossary.md").write_text("# glossary (en)\n", encoding="utf-8")
+    (concepts / "glossary.ja.md").write_text("# glossary (ja)\n", encoding="utf-8")
+    (concepts / "plan-mode.md").write_text("# plan-mode (en)\n", encoding="utf-8")
+    (concepts / "universal-catalog.ja.md").write_text(
+        "# universal-catalog (ja)\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: build_docs_index lang="ja" — prefer ja, en fallback, no duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_build_docs_index_ja_lang_resolves_correctly(tmp_path: Path) -> None:
+    """Tier 2: lang=ja → glossary→.ja.md, plan-mode→.md (fallback), no duplicates."""
+    root = _make_docs_tree(tmp_path)
+    from reyn.chat.tui.widgets.right_panel.docs_tab import build_docs_index
+
+    groups, ordered = build_docs_index(root, lang="ja")
+
+    # Exactly three files — no duplicates.
+    assert len(ordered) == 3, (
+        f"Expected 3 files (one per concept), got {len(ordered)}: {ordered}"
+    )
+
+    stems = [p.stem for p in ordered]
+    # glossary.ja.md is preferred (ja present).
+    assert "glossary.ja" in stems, f"glossary.ja.md must be chosen; got stems={stems}"
+    # plan-mode has no .ja.md — should fall back to en.
+    assert "plan-mode" in stems, f"plan-mode.md must appear; got stems={stems}"
+    # universal-catalog has no .md — should use .ja.md.
+    assert "universal-catalog.ja" in stems, (
+        f"universal-catalog.ja.md must appear; got stems={stems}"
+    )
+
+    # Strict no-duplicate check: each base stem appears at most once.
+    from reyn.chat.tui.widgets.right_panel.docs_tab import _base_stem
+    base_stems = [_base_stem(p) for p in ordered]
+    assert len(base_stems) == len(set(base_stems)), (
+        f"Duplicate base stems found: {base_stems}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: build_docs_index lang="en" — prefer en, ja fallback, no duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_build_docs_index_en_lang_resolves_correctly(tmp_path: Path) -> None:
+    """Tier 2: lang=en → glossary→.md, plan-mode→.md, universal-catalog→.ja.md (fallback)."""
+    root = _make_docs_tree(tmp_path)
+    from reyn.chat.tui.widgets.right_panel.docs_tab import build_docs_index
+
+    groups, ordered = build_docs_index(root, lang="en")
+
+    assert len(ordered) == 3, (
+        f"Expected 3 files (one per concept), got {len(ordered)}: {ordered}"
+    )
+
+    stems = [p.stem for p in ordered]
+    # glossary.md preferred (en present).
+    assert "glossary" in stems, f"glossary.md must be chosen; got stems={stems}"
+    # glossary.ja must NOT be chosen.
+    assert "glossary.ja" not in stems, (
+        f"glossary.ja.md must NOT be chosen (en preferred); got stems={stems}"
+    )
+    # plan-mode has no .ja.md — still en.
+    assert "plan-mode" in stems, f"plan-mode.md must appear; got stems={stems}"
+    # universal-catalog has no .md — fall back to ja.
+    assert "universal-catalog.ja" in stems, (
+        f"universal-catalog.ja.md must appear (ja fallback); got stems={stems}"
+    )
+
+    # Strict no-duplicate check.
+    from reyn.chat.tui.widgets.right_panel.docs_tab import _base_stem
+    base_stems = [_base_stem(p) for p in ordered]
+    assert len(base_stems) == len(set(base_stems)), (
+        f"Duplicate base stems found: {base_stems}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: render_docs lang="ja" output contains "lang: ja" + "(en fallback)" hint
+# ---------------------------------------------------------------------------
+
+
+def test_render_docs_ja_lang_header(tmp_path: Path) -> None:
+    """Tier 2: render_docs(lang='ja') header shows 'lang: ja' and 'en fallback'."""
+    root = _make_docs_tree(tmp_path)
+    from reyn.chat.tui.widgets.right_panel.docs_tab import (
+        build_docs_index,
+        render_docs,
+    )
+
+    groups, ordered = build_docs_index(root, lang="ja")
+    rendered = render_docs(root, 0, groups, lang="ja")
+
+    # The markup contains Rich color tags interleaved with the text, e.g.:
+    #   "[#aaaaaa]  lang: [/][#C8553D]ja[/][#555555]  (en fallback)..."
+    # We check for the literal substrings that appear in the markup regardless
+    # of tag boundaries.
+    assert "lang: " in rendered, (
+        f"render_docs(lang='ja') must contain 'lang: ' prefix; got:\n{rendered}"
+    )
+    assert "]ja[/" in rendered, (
+        f"render_docs(lang='ja') must contain tagged 'ja' value; got:\n{rendered}"
+    )
+    assert "(en fallback)" in rendered, (
+        f"render_docs(lang='ja') must contain '(en fallback)'; got:\n{rendered}"
+    )
+    assert "[g] to toggle" in rendered, (
+        f"render_docs must contain '[g] to toggle' hint; got:\n{rendered}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: render_docs lang="ja" shows (en) suffix for plan-mode (fallback row)
+# ---------------------------------------------------------------------------
+
+
+def test_render_docs_ja_lang_fallback_en_suffix(tmp_path: Path) -> None:
+    """Tier 2: render_docs(lang='ja') shows (en) suffix for en-only doc."""
+    root = _make_docs_tree(tmp_path)
+    from reyn.chat.tui.widgets.right_panel.docs_tab import (
+        build_docs_index,
+        render_docs,
+    )
+
+    groups, ordered = build_docs_index(root, lang="ja")
+    rendered = render_docs(root, 0, groups, lang="ja")
+
+    # plan-mode has no .ja.md → resolved to .md (en) → must show (en) suffix.
+    assert "(en)" in rendered, (
+        f"render_docs(lang='ja') must show (en) suffix for plan-mode fallback; "
+        f"got:\n{rendered}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: render_docs lang="ja" — preferred match (glossary.ja) has NO (en) suffix
+# ---------------------------------------------------------------------------
+
+
+def test_render_docs_ja_lang_no_en_suffix_for_preferred_match(tmp_path: Path) -> None:
+    """Tier 2: render_docs(lang='ja') glossary row has no (en) suffix (ja matched)."""
+    root = _make_docs_tree(tmp_path)
+    from reyn.chat.tui.widgets.right_panel.docs_tab import (
+        build_docs_index,
+        render_docs,
+    )
+
+    groups, ordered = build_docs_index(root, lang="ja")
+
+    # Find the cursor index for the glossary file.
+    glossary_idx = next(
+        (i for i, p in enumerate(ordered) if p.stem == "glossary.ja"), None
+    )
+    assert glossary_idx is not None, "glossary.ja.md must be in the ordered list"
+
+    rendered = render_docs(root, glossary_idx, groups, lang="ja")
+
+    # The glossary row is the preferred match — it must not carry an (en) suffix.
+    # Strategy: check that the line containing "glossary" does not contain "(en)".
+    # We split on newlines and inspect the glossary line specifically.
+    glossary_lines = [ln for ln in rendered.splitlines() if "glossary" in ln.lower()]
+    assert glossary_lines, "glossary must appear in the rendered output"
+    for ln in glossary_lines:
+        assert "(en)" not in ln, (
+            f"glossary line (preferred ja match) must not contain '(en)'; "
+            f"got line: {ln!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: RightPanel 'g' on docs tab toggles _docs_lang ja → en → ja
+# ---------------------------------------------------------------------------
+
+
+def test_right_panel_g_key_on_docs_tab_toggles_lang() -> None:
+    """Tier 2: pressing 'g' on docs tab cycles _docs_lang ja → en → ja."""
+    from reyn.chat.tui.widgets.right_panel import RightPanel
+
+    panel = RightPanel.__new__(RightPanel)
+    panel._panel_type = "docs"
+    panel._docs_lang = "ja"
+    invalidated: list[bool] = []
+    panel._invalidate = lambda: invalidated.append(True)
+    panel._flash_status = lambda *a, **kw: None  # stub
+
+    class _Event:
+        key = "g"
+        prevented = False
+
+        def prevent_default(self):
+            self.prevented = True
+
+        def stop(self):
+            pass
+
+    ev = _Event()
+    panel.on_key(ev)
+    assert panel._docs_lang == "en", (
+        f"First 'g' press on docs tab must toggle ja → en; got {panel._docs_lang!r}"
+    )
+    assert invalidated == [True]
+    assert ev.prevented is True
+
+    # Second press: en → ja.
+    ev2 = _Event()
+    panel.on_key(ev2)
+    assert panel._docs_lang == "ja", (
+        f"Second 'g' press must toggle en → ja; got {panel._docs_lang!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: RightPanel 'g' on memory tab does NOT change _docs_lang (scope guard)
+# ---------------------------------------------------------------------------
+
+
+def test_right_panel_g_key_on_memory_tab_does_not_toggle_lang() -> None:
+    """Tier 2: pressing 'g' on a non-docs tab must NOT change _docs_lang."""
+    from reyn.chat.tui.widgets.right_panel import RightPanel
+
+    panel = RightPanel.__new__(RightPanel)
+    panel._panel_type = "memory"
+    panel._docs_lang = "ja"
+    invalidated: list[bool] = []
+    panel._invalidate = lambda: invalidated.append(True)
+    panel._flash_status = lambda *a, **kw: None
+
+    class _Event:
+        key = "g"
+        prevented = False
+
+        def prevent_default(self):
+            self.prevented = True
+
+        def stop(self):
+            pass
+
+    ev = _Event()
+    panel.on_key(ev)
+    assert panel._docs_lang == "ja", (
+        f"'g' on memory tab must NOT change _docs_lang; got {panel._docs_lang!r}"
+    )
+    # _invalidate must NOT have been called (no state change occurred).
+    assert invalidated == [], (
+        f"'g' on memory tab must not trigger _invalidate; got {invalidated}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: docs_filter interaction — lang collapse runs before substring filter
+# ---------------------------------------------------------------------------
+
+
+def test_build_docs_index_filter_applied_after_lang_collapse(tmp_path: Path) -> None:
+    """Tier 2: docs_filter substring is applied after lang-collapse (no duplicates leak)."""
+    root = _make_docs_tree(tmp_path)
+    from reyn.chat.tui.widgets.right_panel.docs_tab import build_docs_index
+
+    # Filter to "glossary" only, ja preferred.
+    groups, ordered = build_docs_index(root, docs_filter="glossary", lang="ja")
+
+    assert len(ordered) == 1, (
+        f"Filter 'glossary' with lang=ja must yield exactly 1 file; "
+        f"got {len(ordered)}: {ordered}"
+    )
+    assert ordered[0].stem == "glossary.ja", (
+        f"The single result must be glossary.ja.md; got {ordered[0].stem!r}"
+    )
+
+    # Same with lang=en.
+    groups_en, ordered_en = build_docs_index(root, docs_filter="glossary", lang="en")
+    assert len(ordered_en) == 1, (
+        f"Filter 'glossary' with lang=en must yield exactly 1 file; "
+        f"got {len(ordered_en)}: {ordered_en}"
+    )
+    assert ordered_en[0].stem == "glossary", (
+        f"The single result must be glossary.md; got {ordered_en[0].stem!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — UX fix: Docs tab lang preference

## Summary
- Docs tab default: en preferred, ja fallback when .md absent
- `g` key (docs tab only) toggles: en ↔ ja preferred
- Each concept appears ONCE (= no en/.ja.md interleaving)
- Dim (en) / (ja) suffix marks fallback-resolved rows
- Header shows "lang: en (ja fallback) [g] to toggle"

## Why
User: "Docs tab なんだけどさ、en/ja リスト表示切り替えしたいよね" +
"ja なければ en fallback". Previously en + ja interleaved with (ja)
suffix on Japanese rows — readable but cluttered with duplicates.
Default flipped to en (user clarified preference post-initial dispatch).

## Key choice note
Task spec proposed `l` but `l` is already bound to `_panel_resize(-2)`
(narrow panel) — confirmed via pre-flight grep at line 687 of `__init__.py`.
Chose `g` (free on all tabs, mnemonic for language/group) instead.

## Test plan
- [x] `tests/cli/test_docs_lang_filter.py` — 8 Tier-2 tests (all pass)
- [x] existing docs/keys/smoke tests pass — 81 pass, 0 fail
- [x] ruff clean
- [x] Manual: open Docs tab → en-preferred list shows; press `g` → ja-preferred