### PR TITLE
fix(tui): freeze elapsed counter during 1.5s abort/interrupt flash window

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -145,6 +145,10 @@ class _Entry:
     # the render path reads this to show the red ✗ shape instead of
     # the normal ⟳ / ⚑ row.
     flashing: bool = False
+    # Captured at the moment flashing starts; None = compute live elapsed.
+    # Freeze elapsed so the row reads "stopped, fading out" rather than
+    # "still running" during the 1.5 s flash window.
+    frozen_elapsed_s: float | None = None
 
 
 def _fmt_elapsed(seconds: float) -> str:
@@ -293,6 +297,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
 
         # Non-ok terminal: transition to flash state and schedule unmount.
         entry = self._entries[agent_id]
+        entry.frozen_elapsed_s = time.monotonic() - entry.started_at
         entry.flashing = True
         self._refresh()
         try:
@@ -356,12 +361,16 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         """
         out: list[dict] = []
         for agent_id, entry, glyph in self._sorted_visible():
+            if entry.frozen_elapsed_s is not None:
+                elapsed_s = entry.frozen_elapsed_s
+            else:
+                elapsed_s = time.monotonic() - entry.started_at
             out.append({
                 "agent_id": agent_id,
                 "glyph": glyph,
                 "summary": entry.summary,
                 "pending_count": entry.pending_count,
-                "elapsed_s": time.monotonic() - entry.started_at,
+                "elapsed_s": elapsed_s,
                 "is_overflow": False,
                 "flashing": entry.flashing,
             })
@@ -460,7 +469,11 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
             t.append(self._truncate_to_cells(flash_text, body_budget), style="bold #ff6644")
             return
 
-        elapsed_str = _fmt_elapsed(time.monotonic() - entry.started_at)
+        if entry.frozen_elapsed_s is not None:
+            elapsed_s = entry.frozen_elapsed_s
+        else:
+            elapsed_s = time.monotonic() - entry.started_at
+        elapsed_str = _fmt_elapsed(elapsed_s)
         if entry.pending_count > 0:
             elapsed_segment = f"  ({entry.pending_count} pending)"
             elapsed_style = "bold #ffaa44"

--- a/tests/cli/test_async_stack_interrupted_flash.py
+++ b/tests/cli/test_async_stack_interrupted_flash.py
@@ -194,3 +194,100 @@ async def test_remove_no_kwarg_still_works() -> None:
         assert not _panel_has_id(panel.snapshot(), "p4"), (
             "no-kwarg remove() must still unmount immediately (backwards-compat)"
         )
+
+
+# ── test 6: elapsed freezes at flash start (not live) ────────────────────────
+
+@pytest.mark.asyncio
+async def test_elapsed_frozen_at_flash_start() -> None:
+    """Tier 2: elapsed_s in snapshot is frozen the moment remove(terminal!='ok') fires.
+
+    After calling remove(terminal='aborted'), the snapshot's elapsed_s for
+    the flashing row must not increase when time passes — it must stay at
+    (approximately) the value captured at the moment of remove().
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p5", "background job")
+        await pilot.pause()
+
+        # Let 0.2 s accumulate so elapsed_s is non-trivial at remove time.
+        await pilot.pause(0.2)
+
+        panel.remove("p5", terminal="aborted")
+        await pilot.pause()
+
+        # Snapshot immediately after remove — capture the frozen elapsed.
+        snap1 = panel.snapshot()
+        row1 = _panel_row(snap1, "p5")
+        assert row1 is not None, "row must still be present during flash window"
+        assert row1["flashing"] is True
+        elapsed_at_flash = row1["elapsed_s"]
+
+        # Wait ~1 s — well inside the 1.5 s flash window.
+        await pilot.pause(1.0)
+
+        snap2 = panel.snapshot()
+        row2 = _panel_row(snap2, "p5")
+        assert row2 is not None, "row must still be present within the flash window"
+        assert row2["flashing"] is True
+
+        # Elapsed must be frozen: same value as at flash start (within float noise).
+        assert row2["elapsed_s"] == elapsed_at_flash, (
+            f"elapsed_s must be frozen during flash; "
+            f"at flash start: {elapsed_at_flash}, after 1 s: {row2['elapsed_s']}"
+        )
+
+
+# ── test 7: non-flashing entry continues to update elapsed ───────────────────
+
+@pytest.mark.asyncio
+async def test_live_elapsed_for_running_entry() -> None:
+    """Tier 2: elapsed_s in snapshot increases for a non-flashing (running) entry.
+
+    Freeze logic must only apply to flashing entries; a still-running entry
+    must continue to report live elapsed so the user sees the task progressing.
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        panel.add("p6", "still running task")
+        await pilot.pause()
+
+        snap1 = panel.snapshot()
+        row1 = _panel_row(snap1, "p6")
+        assert row1 is not None
+        assert row1["flashing"] is False
+        elapsed1 = row1["elapsed_s"]
+
+        # Wait 1 s — elapsed must grow for a running entry.
+        await pilot.pause(1.0)
+
+        snap2 = panel.snapshot()
+        row2 = _panel_row(snap2, "p6")
+        assert row2 is not None
+        assert row2["flashing"] is False
+
+        assert row2["elapsed_s"] > elapsed1, (
+            f"live elapsed must increase for running entry; "
+            f"before: {elapsed1}, after 1 s: {row2['elapsed_s']}"
+        )
+
+        # Cleanup: remove cleanly so no timers dangle.
+        panel.remove("p6", terminal="ok")
+        await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — Fix: freeze elapsed during flash window

## Summary
- `_Entry.frozen_elapsed_s` new field (default `None`)
- `remove(id, terminal!="ok")` captures `time.monotonic() - entry.started_at` before entering flash state
- `_build_lines` / `snapshot()` use frozen elapsed for flashing entries; live `time.monotonic()` for others

## Why
1.5s flash mechanism (= visual cue distinguishing aborted/interrupted
from clean completion) stays, but the elapsed counter kept ticking
during the flash window — gave the impression task was still running
during fade-out. Freeze the displayed elapsed to match the terminal
visual.

## Test plan
- [x] tests/cli/test_async_stack_interrupted_flash.py — extended with
  2 new freeze tests (test 6: elapsed frozen at flash start; test 7: live elapsed for running entry)
- [x] existing flash + smoke tests still pass (30 panel tests + 40 smoke = 70 total, all green)
- [x] ruff clean