### PR TITLE
feat(skill_runner): pre-spawn input_schema validation with sync structured error

### DIFF
--- a/src/reyn/chat/services/skill_runner.py
+++ b/src/reyn/chat/services/skill_runner.py
@@ -205,12 +205,20 @@ class SkillRunner:
         if self.running_skills:
             await asyncio.gather(*self.running_skills.values(), return_exceptions=True)
 
-    async def spawn(self, spec: dict, *, chain_id: str | None = None) -> None:
+    async def spawn(self, spec: dict, *, chain_id: str | None = None) -> "dict | None":
         """Launch a skill task and register it in the running dicts.
 
         Extracted from ``ChatSession._spawn_skill``.  Enforces the
-        allowlist, budget cap, and FP-0003 budget extension before
-        creating the asyncio Task.
+        allowlist, budget cap, FP-0003 budget extension, and pre-spawn
+        input_schema validation before creating the asyncio Task.
+
+        Returns ``None`` on successful spawn (= caller relies on
+        ``self.running_skills`` for the run_id). Returns a structured
+        error dict when pre-spawn checks reject the spawn before any
+        asyncio task is created — currently only the input_schema
+        validation path uses this return channel; other refusals (=
+        allowlist, budget) keep the legacy None-return + outbox-error
+        path for backward compat with non-router callers.
         """
         skill_name = spec.get("skill")
         input_artifact = spec.get("input")
@@ -218,7 +226,7 @@ class SkillRunner:
             await self._put_outbox(OutboxMessage(
                 kind="error", text=f"invalid skill spec: {spec}",
             ))
-            return
+            return None
 
         # PR15: defense-in-depth allowlist check.
         if (
@@ -236,7 +244,7 @@ class SkillRunner:
                 "skill_spawn_refused",
                 reason="allowlist", skill=skill_name, agent=self._agent_name,
             )
-            return
+            return None
 
         # PR22: per-chain per-skill cap check.
         if chain_id is not None:
@@ -286,7 +294,7 @@ class SkillRunner:
                     text=format_refusal_message(check),
                     meta={"chain_id": chain_id, "skill": skill_name},
                 ))
-                return
+                return None
             for dim in check.warn_dimensions:
                 from reyn.budget.budget import format_warn_message
                 self._events.emit(
@@ -300,6 +308,112 @@ class SkillRunner:
                     meta={"chain_id": chain_id, "skill": skill_name},
                 ))
             self._budget.record_spawn(chain_id=chain_id, skill=skill_name)
+
+        # Pre-spawn input_schema validation. Loads the skill the same way
+        # ``_run_one_skill`` does, validates ``input_artifact`` against the
+        # entry phase's input_schema, and rejects synchronously with a
+        # structured error before any asyncio task is created.
+        #
+        # Why pre-spawn: post-spawn validation arrives at the router LLM
+        # as an async ``[task_completed] kind=skill status=error`` message
+        # that's temporally separated from the originating invoke_action
+        # call. Weak-tier LLMs struggle to correlate the failure back to
+        # the original args + retry — they default to summarizing the
+        # error to the user. Validating sync at spawn time keeps the
+        # error in the same tool_result round-trip as the wrong args, so
+        # the LLM can react with full local context. Also avoids burning
+        # async-task setup cost on inputs that can never run.
+        try:
+            skill_dir, skill_root = resolve_skill_path(skill_name)
+            _skill_for_validation = load_dsl_skill(
+                str(skill_dir / "skill.md"), skill_root=str(skill_root),
+            )
+        except SkillNotFoundError as exc:
+            self._events.emit(
+                "skill_spawn_refused",
+                reason="skill_not_found",
+                skill=skill_name,
+                detail=str(exc),
+            )
+            await self._put_outbox(OutboxMessage(
+                kind="error",
+                text=f"skill not found: {skill_name}",
+                meta={"chain_id": chain_id, "skill": skill_name},
+            ))
+            return {
+                "status": "error",
+                "data": {
+                    "kind": "spawn_refused",
+                    "reason": "skill_not_found",
+                    "skill": skill_name,
+                    "error": str(exc),
+                },
+            }
+        except Exception as exc:
+            # Skill md parse / compile error — surface as spawn refusal
+            # so the LLM sees a structured failure instead of an async
+            # crash inside _run_one_skill.
+            self._events.emit(
+                "skill_spawn_refused",
+                reason="skill_load_error",
+                skill=skill_name,
+                detail=str(exc),
+            )
+            await self._put_outbox(OutboxMessage(
+                kind="error",
+                text=f"failed to load {skill_name}: {exc}",
+                meta={"chain_id": chain_id, "skill": skill_name},
+            ))
+            return {
+                "status": "error",
+                "data": {
+                    "kind": "spawn_refused",
+                    "reason": "skill_load_error",
+                    "skill": skill_name,
+                    "error": str(exc),
+                },
+            }
+
+        entry_schema = getattr(_skill_for_validation, "entry_input_schema", None)
+        if entry_schema:
+            import jsonschema
+            try:
+                jsonschema.validate(input_artifact, entry_schema)
+            except jsonschema.ValidationError as exc:
+                # Build the structured error response with a schema_hint
+                # the LLM can use directly on its next turn.
+                schema_hint = {
+                    "skill": skill_name,
+                    "input_schema": entry_schema,
+                    "retry_hint": (
+                        "Re-emit invoke_action with input matching "
+                        "input_schema above."
+                    ),
+                }
+                self._events.emit(
+                    "skill_spawn_refused",
+                    reason="input_schema_violation",
+                    skill=skill_name,
+                    detail=exc.message,
+                )
+                await self._put_outbox(OutboxMessage(
+                    kind="error",
+                    text=(
+                        f"input validation failed for skill "
+                        f"{skill_name!r}: {exc.message}"
+                    ),
+                    meta={"chain_id": chain_id, "skill": skill_name},
+                ))
+                return {
+                    "status": "error",
+                    "data": {
+                        "kind": "spawn_refused",
+                        "reason": "input_schema_violation",
+                        "skill": skill_name,
+                        "validation_error": exc.message,
+                        "schema_hint": schema_hint,
+                    },
+                }
 
         run_id = (
             f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
@@ -332,9 +446,17 @@ class SkillRunner:
         Extracted from ``ChatSession._spawn_skill_for_router``.  Wraps
         :meth:`spawn` and returns the spawn-ack dict the router LLM
         consumes via ``invoke_skill``'s tool_result.
+
+        When :meth:`spawn` rejects pre-spawn (= input_schema violation
+        / skill not found / load error), the structured error dict it
+        returns is forwarded verbatim so the router LLM sees a sync
+        tool_result with schema_hint in the same turn as its wrong
+        invoke_action call.
         """
         before = set(self.running_skills.keys())
-        await self.spawn(spec, chain_id=chain_id)
+        spawn_result = await self.spawn(spec, chain_id=chain_id)
+        if isinstance(spawn_result, dict):
+            return spawn_result
         after = set(self.running_skills.keys())
         new_run_ids = after - before
         if not new_run_ids:

--- a/tests/test_skill_runner_pre_spawn_validation.py
+++ b/tests/test_skill_runner_pre_spawn_validation.py
@@ -1,0 +1,233 @@
+"""Tier 2: OS invariant tests for SkillRunner pre-spawn input_schema
+validation.
+
+Asserts that SkillRunner.spawn() validates ``input`` against the loaded
+skill's entry_input_schema BEFORE creating the asyncio task, and that the
+structured error returned propagates through spawn_for_router to the
+router LLM's tool_result.
+
+Why this matters: post-spawn validation arrives at the router LLM as an
+async [task_completed] kind=skill status=error message that's temporally
+separated from the originating invoke_action call. Weak-tier LLMs
+struggle to correlate the failure back to the original args + retry.
+Pre-spawn validation keeps the error in the same tool_result round-trip
+as the wrong args, so the LLM can react with full local context.
+
+No mocks — uses the existing _make_runner fixture pattern that
+monkeypatches resolve_skill_path + load_dsl_skill with real-ish stubs.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+# Re-use the helpers from the sibling invariants test module so
+# fixtures stay coherent.
+from test_skill_runner_invariants import _make_runner
+
+
+def _make_stub_skill(input_schema=None):
+    """Stub skill object exposing only the attributes spawn() touches.
+
+    Pre-spawn validation reads ``skill.entry_input_schema``; nothing
+    else is needed for the validation branch tests.
+    """
+    return SimpleNamespace(entry_input_schema=input_schema)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: invariant 1 — no schema → spawn proceeds (legacy behavior preserved)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_no_schema_proceeds(tmp_path, monkeypatch):
+    """Tier 2: when the loaded skill has no entry_input_schema, spawn()
+    skips validation and proceeds to create the asyncio task (= legacy
+    behavior preserved for skills without declared schemas)."""
+    import reyn.chat.services.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "skill_no_schema"
+    dummy_dir.mkdir()
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", lambda name: (dummy_dir, tmp_path))
+    monkeypatch.setattr(
+        sr_mod, "load_dsl_skill",
+        lambda path, *, skill_root: _make_stub_skill(input_schema=None),
+    )
+
+    block = asyncio.Event()
+    runner, _events, _outbox, _completed = _make_runner(block_on=block)
+
+    async def _run():
+        result = await runner.spawn({"skill": "noschema", "input": {"any": "shape"}})
+        assert result is None, f"expected None on success, got {result!r}"
+        assert len(runner.running_names()) == 1, "task should be running"
+        block.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: invariant 2 — schema + valid input → spawn proceeds
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_valid_input_proceeds(tmp_path, monkeypatch):
+    """Tier 2: input that matches the entry_input_schema passes through
+    pre-spawn validation; the asyncio task is created."""
+    import reyn.chat.services.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "skill_with_schema"
+    dummy_dir.mkdir()
+    schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {"text": {"type": "string"}},
+    }
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", lambda name: (dummy_dir, tmp_path))
+    monkeypatch.setattr(
+        sr_mod, "load_dsl_skill",
+        lambda path, *, skill_root: _make_stub_skill(input_schema=schema),
+    )
+
+    block = asyncio.Event()
+    runner, _events, _outbox, _completed = _make_runner(block_on=block)
+
+    async def _run():
+        result = await runner.spawn({"skill": "ok", "input": {"text": "hello"}})
+        assert result is None, f"expected None on success, got {result!r}"
+        assert len(runner.running_names()) == 1
+        block.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: invariant 3 — schema + invalid input → structured error, no task
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_invalid_input_returns_structured_error(tmp_path, monkeypatch):
+    """Tier 2: input that violates entry_input_schema is rejected
+    pre-spawn. spawn() returns a structured error dict carrying
+    schema_hint, NO asyncio task is created, and the
+    skill_spawn_refused event fires with reason=input_schema_violation."""
+    import reyn.chat.services.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "skill_strict"
+    dummy_dir.mkdir()
+    schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {"text": {"type": "string"}},
+    }
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", lambda name: (dummy_dir, tmp_path))
+    monkeypatch.setattr(
+        sr_mod, "load_dsl_skill",
+        lambda path, *, skill_root: _make_stub_skill(input_schema=schema),
+    )
+
+    runner, events, _outbox, _completed = _make_runner()
+
+    async def _run():
+        # Wrong shape: missing required 'text'
+        result = await runner.spawn({"skill": "strict", "input": {"wrong_key": "x"}})
+        # Structured error dict returned
+        assert isinstance(result, dict), f"expected dict, got {result!r}"
+        assert result["status"] == "error"
+        data = result["data"]
+        assert data["kind"] == "spawn_refused"
+        assert data["reason"] == "input_schema_violation"
+        assert data["skill"] == "strict"
+        assert "validation_error" in data
+        hint = data["schema_hint"]
+        assert hint["skill"] == "strict"
+        assert hint["input_schema"] == schema
+        assert "retry_hint" in hint
+        # No task created
+        assert runner.running_names() == []
+        # Event emitted
+        kinds = [e.type for e in events.all()]
+        assert "skill_spawn_refused" in kinds, f"missing event: {kinds}"
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: invariant 4 — skill not found → structured error
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_skill_not_found_returns_structured_error(tmp_path, monkeypatch):
+    """Tier 2: SkillNotFoundError during pre-spawn skill load is
+    converted to a structured error dict, NO task is created, and the
+    skill_spawn_refused event fires with reason=skill_not_found."""
+    import reyn.chat.services.skill_runner as sr_mod
+
+    def _raise_not_found(name):
+        raise sr_mod.SkillNotFoundError(name, [str(tmp_path)])
+
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", _raise_not_found)
+
+    runner, events, _outbox, _completed = _make_runner()
+
+    async def _run():
+        result = await runner.spawn({"skill": "missing", "input": {}})
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert result["data"]["reason"] == "skill_not_found"
+        assert result["data"]["skill"] == "missing"
+        assert runner.running_names() == []
+        kinds = [e.type for e in events.all()]
+        assert "skill_spawn_refused" in kinds
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: invariant 5 — spawn_for_router propagates the structured error
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_for_router_propagates_pre_spawn_error(tmp_path, monkeypatch):
+    """Tier 2: when spawn() rejects pre-spawn (returns dict),
+    spawn_for_router forwards that dict verbatim so the router LLM
+    sees the schema_hint in the same tool_result round-trip as its
+    originating invoke_action call (= sync error path, no async
+    [task_completed] correlation needed)."""
+    import reyn.chat.services.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "skill_strict"
+    dummy_dir.mkdir()
+    schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {"text": {"type": "string"}},
+    }
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", lambda name: (dummy_dir, tmp_path))
+    monkeypatch.setattr(
+        sr_mod, "load_dsl_skill",
+        lambda path, *, skill_root: _make_stub_skill(input_schema=schema),
+    )
+
+    runner, _events, _outbox, _completed = _make_runner()
+
+    async def _run():
+        out = await runner.spawn_for_router(
+            {"skill": "strict", "input": {"bad": "args"}},
+            chain_id="c1",
+        )
+        # The structured error dict from spawn() must flow through
+        # spawn_for_router unchanged.
+        assert out["status"] == "error"
+        assert out["data"]["kind"] == "spawn_refused"
+        assert out["data"]["reason"] == "input_schema_violation"
+        assert out["data"]["schema_hint"]["input_schema"] == schema
+        # Crucially, the legacy "could not be spawned" fallback message
+        # must NOT be the surface — that wording loses schema_hint.
+        assert "could not be spawned" not in str(out)
+
+    asyncio.run(_run())


### PR DESCRIPTION
**[dogfood-coder]** — F3 design path follow-on (skill__* error sync collapse).

## Summary

- \`SkillRunner.spawn()\` validates skill input against the loaded skill's \`entry_input_schema\` **before** \`asyncio.create_task\`. Validation failure returns a structured error dict (= \`schema_hint\` carrying the canonical input_schema) **synchronously**; \`spawn_for_router\` forwards it verbatim so the router LLM sees schema in the same tool_result round-trip as its originating invoke_action call.
- 5 new Tier 2 invariant tests + 1044 passed / 0 failed in broader sweep (\`-k "skill or spawn or chat or session or router_loop"\`).
- Follow-up optimization (duplicate skill load on success path) filed as #644, **not** bundled here per \`feedback_minimize_speculation\`.

## Motivation — async error correlation problem

Post-spawn validation arrives at the router LLM as an async \`[task_completed] kind=skill status=error\` message that's temporally separated from the originating \`invoke_action\` call. Even with the \`[task_spawned]\` / \`[task_completed]\` \`run_id\` correlation key:

- the **original args** themselves aren't in the envelope (= only \`skill: <name>\`)
- the LLM has to scroll back several turns through history to find the assistant tool_call that produced the \`run_id\`
- weak-tier LLM under temporal separation defaults to summarizing the user-facing failure rather than retrying

Pre-spawn validation collapses the error path to **sync** — args + error visible in the same tool_result round-trip, no async correlation puzzle.

## Honest framing — what's verified, what isn't

**Verified (architectural)**:
- ✅ Error path becomes sync for input_schema_violation / skill_not_found / skill_load_error
- ✅ \`schema_hint\` structure aligned with describe_action.input_schema surface
- ✅ \`skill_spawn_refused reason=input_schema_violation\` event taxonomy clean
- ✅ Backward compat preserved for legacy allowlist / budget refusals (= None+outbox path)
- ✅ P7 clean (no hardcoded action names in OS code)
- ✅ 5 invariant tests + no regressions in 1044-test sweep

**NOT empirically verified (LLM-behavior)**:
- ❌ Retry trigger rate at weak-tier
- F3 / B53 W3-S6 trace deep-dive tested 7 distinct reaction-time hint variants (post-error \`tool_result\` with schema info, DIRECTIVE prefix, MUST-call directives, verbatim args comparison, structured \`schema_hint\`, prose front-prefix). Max weak-tier retry rate observed: **1/10**. The summarize-attractor consistently wins at post-error reaction-time.
- Decision-time signal (= schema in tool definition before LLM decides) drives 10/10 correct calls (F3 patch (a) replay).
- This fix is a **higher-quality reaction-time** (= sync timing + temporal locality vs async cross-turn) but reaction-time nonetheless. Retry rate **may or may not** improve at weak-tier — separate dogfood evidence needed.

The architectural correctness stands independent of retry-rate verification.

## What changed

| File | Change |
|---|---|
| \`src/reyn/chat/services/skill_runner.py\` | \`spawn()\` return type → \`dict \\| None\`; pre-spawn validation block (load skill → jsonschema.validate → structured error dict on failure); \`spawn_for_router\` forwards dict verbatim |
| \`tests/test_skill_runner_pre_spawn_validation.py\` | 5 new Tier 2 invariant tests |

## Return type duality (documented architectural debt)

\`spawn()\` now has asymmetric failure modes:
- **validation / load failures** → return dict (= structured error)
- **allowlist / budget failures** → return None + outbox-error (= legacy path)

Documented in spawn() docstring; future cleanup could unify all refusal paths to return dict. Not bundled here — non-router callers (\`spawn_resumed_skill\`, \`_spawn_skill\` thin wrapper) rely on the None-return shape.

## Test plan

- [x] 5 new Tier 2 invariant tests all pass (\`tests/test_skill_runner_pre_spawn_validation.py\`)
  - no schema → spawn proceeds (legacy preserved)
  - valid input → spawn proceeds
  - invalid input → structured error dict with schema_hint + no asyncio task + \`skill_spawn_refused\` event
  - skill not found → structured error dict with reason=skill_not_found
  - spawn_for_router forwards dict verbatim
- [x] Regression sweep: 1044 passed / 0 failed (\`venv/bin/pytest tests/ -k "skill or spawn or chat or session or router_loop"\`)
- [x] No OS-level skill-specific strings introduced (P7 manually verified)
- [x] No behavior change on success path (= existing spawn callers see None as before)
- [x] Follow-up issue filed (#644) for duplicate-load optimization

## Implications

- **B54+ dogfood**: skill__* wrong-args scenarios now fail-fast with schema_hint in same turn. Whether weak-tier acts on the hint to retry is **separate evidence** required (= cross-batch trigger rate observation in B54-B55).
- **Audit / events trace**: removes async correlation puzzle from skill_run_failed-from-bad-input scenarios.
- **Decision-time fix** (= ARG SCHEMAS sparse description, F3 patch (a) path) remains a **complementary** lane — pre-spawn validation handles the post-call recovery substrate; decision-time enrichment reduces the wrong-call rate at source. Both can land independently.

Closes part of F3 design discussion (= async path collapse to sync); decision-time / ARG SCHEMAS work tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)