### PR TITLE
feat(tui): conv pane Claude Code style — symbol-only headers + ts toggle (F9)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -166,6 +166,10 @@ class ReynTUIApp(App):
         # F8: toggle the latest FoldableMarkdown widget (long reply expand/collapse).
         # Same action as /expand slash and clicking the widget's hint footer.
         Binding("f8", "toggle_last_foldable", "Toggle long reply (expand/collapse)", priority=True, show=False),
+        # F9: toggle timestamp prefix (HH:MM) in conv pane headers.
+        # With ts hidden, body indent shrinks col 8 → col 2, reclaiming
+        # horizontal space for content. State persists via tui_prefs.json.
+        Binding("f9", "toggle_timestamps", "Toggle timestamps", priority=True, show=False),
     ]
 
     _REYN_THEME = Theme(
@@ -1563,6 +1567,26 @@ class ReynTUIApp(App):
                 self.set_timer(2.0, conv.hide_status)
             except Exception:
                 pass
+
+    def action_toggle_timestamps(self) -> None:
+        """F9 — toggle the HH:MM timestamp prefix in conv-pane message headers.
+
+        With timestamps hidden, the body indent shrinks from col 8 to col 2,
+        reclaiming horizontal space for content. The toggle applies to NEW
+        messages only (= no re-render of past scroll history). State is
+        persisted to ``tui_prefs.json`` so the choice survives a restart.
+        """
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+        except Exception:
+            return
+        new_state = conv.toggle_timestamps()
+        label = "on" if new_state else "off"
+        try:
+            conv.show_status(f"timestamps: {label}", kind="general")
+            self.set_timer(2.0, conv.hide_status)
+        except Exception:
+            pass
 
     def action_next_turn(self) -> None:
         """ctrl+n — scroll the conversation log to the next agent turn."""

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -67,16 +67,24 @@ from .tool_call_row import ToolCallRow
 
 _DASH_TOTAL = 38  # matches the banner separator width
 _GROUP_WINDOW_S = 60.0  # consecutive turns within this window share a header
-# Speaker-identity glyphs prepended to header labels — non-color cue so
-# turn boundaries stay legible in greyscale / for color-blind users.
-# The header name color (cyan / amber / grey) is still the primary
-# signal; the glyph is a redundant shape signal so neither channel
-# alone is load-bearing.
-_GLYPH_USER = "▶"
-_GLYPH_AGENT = "◆"
+# Speaker-identity symbols — 1-char shape cues for turn boundaries.
+# These replace the old "▶ you" / "◆ reyn" labels; the symbol alone
+# differentiates speaker without the redundant label text.
+_GLYPH_USER = ">"
+_GLYPH_AGENT = "⏺"
 _GLYPH_SYSTEM = "·"
 _FOLD_THRESHOLD_LINES = 30  # B3: rendered-screen-line estimate above this folds inline
-_FOLD_WIDTH_FALLBACK = 73   # estimated body width when size.width is 0 (= 80 - _BODY_INDENT_COLS)
+# Hanging indent constants — two modes gated by ``_show_timestamps``.
+# ON  (ts shown):  ``HH:MM <sym>`` = 5 (ts) + 1 (space) + 1 (sym) + 1 (space)
+#                  → body starts col 8.
+# OFF (ts hidden): ``<sym>`` = 1 (sym) + 1 (space) → body starts col 2.
+_BODY_INDENT_WITH_TS = 8
+_BODY_INDENT_NO_TS = 2
+# Legacy alias kept so external code that imports _BODY_INDENT_COLS
+# directly (e.g. streaming_row.py, foldable_markdown.py, tests) still
+# compiles. Points at the ts-on value (= the default).
+_BODY_INDENT_COLS = _BODY_INDENT_WITH_TS
+_FOLD_WIDTH_FALLBACK = 73   # estimated body width when size.width is 0 (= 80 - _BODY_INDENT_WITH_TS)
 # /copy ring-buffer depth. Far enough back that the user can grab "the
 # reply two turns ago" — the typical "wait, that one was useful" recovery
 # pattern — without growing memory unboundedly across long sessions.
@@ -98,15 +106,6 @@ _TOOL_CALL_MIN_DISPLAY_S = 0.3
 # Esc-dismissed breadcrumb) so the footer area can't pile up under a
 # burst of failures (e.g. proxy down + multiple retries).
 _MAX_VISIBLE_ERROR_BOXES = 3
-_NAME_COL_COLS = 4  # display-cell width reserved for the speaker label column
-# Hanging indent for message bodies (= the lines under each header). The
-# header is ``HH:MM  reyn ───`` — 5 (timestamp) + 2 (gap) = 7 cells before
-# the name column starts. Indenting the body to column 7 visually nests
-# replies under their author's name and, crucially, makes wrap continuations
-# of a long body line visually distinct from the start of a new turn
-# (which begins at column 0). Without this, a wrapped URL or code-line
-# looks identical to a new ``HH:MM …`` header on a quick scan.
-_BODY_INDENT_COLS = 7
 
 
 def _pad_to_cells(s: str, target_cells: int) -> str:
@@ -128,32 +127,40 @@ def _pad_to_cells(s: str, target_cells: int) -> str:
     return s + " " * (target_cells - width)
 
 
-def _indent_body(renderable: RenderableType) -> RenderableType:
+def _indent_body(renderable: RenderableType, indent: int = _BODY_INDENT_WITH_TS) -> RenderableType:
     """Wrap ``renderable`` in a left-only Padding for the body indent column.
 
     Used at every body write site (agent markdown, user text, system text,
     fallback formatted lines). Header writes intentionally bypass this
-    helper so the timestamp / name / dash rule stay anchored at column 0.
+    helper so the timestamp / symbol stay anchored at column 0.
+
+    ``indent`` defaults to the ts-on value (= 8). Callers that track
+    ``_show_timestamps`` pass the dynamic value via
+    ``ConversationView._current_body_indent()``.
     """
-    return Padding(renderable, (0, 0, 0, _BODY_INDENT_COLS))
+    return Padding(renderable, (0, 0, 0, indent))
 
 
-def _msg_header(label: str, name_style: str, dash_style: str) -> Text:
-    """Timestamp + label + dash rule for a new message turn.
+def _msg_header(symbol: str, name_style: str, show_ts: bool = True) -> Text:
+    """Symbol-only header for a new message turn.
 
-    Column layout: ``HH:MM`` (5) + 2 spaces + label (>=4 cells) + 1 space +
-    dashes. The dash count flexes with the actual cell width of ``label``
-    so wide-character agent names don't push the line past _DASH_TOTAL.
+    Layout when ``show_ts=True``:
+        ``HH:MM <symbol>``  (5 ts + 1 space + 1 symbol)
+        body starts at col 8 (= _BODY_INDENT_WITH_TS)
+
+    Layout when ``show_ts=False``:
+        ``<symbol>``
+        body starts at col 2 (= _BODY_INDENT_NO_TS)
+
+    The dash rule and label text (``▶ you`` / ``◆ reyn``) are intentionally
+    dropped — the 1-char symbol already differentiates speaker, and blank
+    lines between turns provide turn separation without horizontal noise.
     """
     t = Text()
-    t.append(time.strftime("%H:%M"), style="dim #666666")
-    t.append("  ")
-    padded = _pad_to_cells(label, _NAME_COL_COLS)
-    name_cells = cell_len(padded)
-    t.append(padded, style=name_style)
-    t.append(" ")
-    dashes = max(1, _DASH_TOTAL - 5 - 2 - name_cells - 1)
-    t.append("─" * dashes, style=dash_style)
+    if show_ts:
+        t.append(time.strftime("%H:%M"), style="dim #666666")
+        t.append(" ")
+    t.append(symbol, style=name_style)
     return t
 
 
@@ -355,6 +362,12 @@ class ConversationView(Widget):
         self._user_scrolled = False
         # Issue 5 — track mounted ErrorBoxes for Escape-to-dismiss
         self._error_boxes: list[ErrorBox] = []
+        # F9 timestamp toggle — default on. Loaded from tui_prefs.json in
+        # on_mount; callers use toggle_timestamps() / show_timestamps property.
+        # New messages rendered after a toggle use the new indent; past
+        # messages stay at whatever indent they had when rendered (= no
+        # full re-render of scroll history).
+        self._show_timestamps: bool = True
 
     # ── composition ──────────────────────────────────────────────────────────
 
@@ -490,6 +503,44 @@ class ConversationView(Widget):
             return
         panel.clear()
 
+    # ── timestamp toggle (F9) ─────────────────────────────────────────────────
+
+    @property
+    def show_timestamps(self) -> bool:
+        """True when the ``HH:MM`` prefix is prepended to speaker headers."""
+        return self._show_timestamps
+
+    def _current_body_indent(self) -> int:
+        """Return the dynamic body-indent column based on ``_show_timestamps``.
+
+        ON  → ``_BODY_INDENT_WITH_TS`` (8) — body under the symbol when ts shown.
+        OFF → ``_BODY_INDENT_NO_TS``  (2) — symbol at col 0, body at col 2.
+        """
+        return _BODY_INDENT_WITH_TS if self._show_timestamps else _BODY_INDENT_NO_TS
+
+    def toggle_timestamps(self) -> bool:
+        """Flip the timestamp-visibility state and persist to ``tui_prefs.json``.
+
+        Returns the NEW state (True = ts now visible, False = now hidden).
+        The toggle applies to NEW messages only (= no re-render of past
+        history). Past messages stay at whatever indent they were rendered
+        with — a full re-render would be expensive and confusing mid-session.
+        """
+        self._show_timestamps = not self._show_timestamps
+        try:
+            from reyn.chat.tui.prefs import load_tui_prefs, save_tui_prefs
+            root = None
+            try:
+                root = self.app._project_root_path()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            prefs = load_tui_prefs(root)
+            prefs["show_timestamps"] = self._show_timestamps
+            save_tui_prefs(root, prefs)
+        except Exception:
+            pass
+        return self._show_timestamps
+
     def on_mount(self) -> None:
         """Wire a scroll watcher so user scroll-up suppresses auto-scroll.
 
@@ -502,6 +553,9 @@ class ConversationView(Widget):
         only flips ``auto_scroll`` on the boundary crossing, so writes
         during user-read keep their place and writes after user-return
         immediately auto-scroll again.
+
+        Also loads ``show_timestamps`` from ``tui_prefs.json`` so the
+        F9 toggle state survives a restart.
         """
         log = self._log()
         try:
@@ -509,6 +563,20 @@ class ConversationView(Widget):
         except Exception:
             # If Textual's cross-widget watch API changes, fail open
             # (= keep historic auto-scroll behaviour) rather than crash mount.
+            pass
+        # Load persisted timestamp-toggle state. The app instance holds
+        # the project root; ConversationView reaches it defensively via
+        # app.app (= the Textual ``app`` property on every widget).
+        try:
+            from reyn.chat.tui.prefs import load_tui_prefs
+            root = None
+            try:
+                root = self.app._project_root_path()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            prefs = load_tui_prefs(root)
+            self._show_timestamps = bool(prefs.get("show_timestamps", True))
+        except Exception:
             pass
 
     def _snap_to_bottom(self) -> None:
@@ -568,10 +636,13 @@ class ConversationView(Widget):
 
     # ── header grouping (B1) ──────────────────────────────────────────────────
 
-    def _maybe_write_header(self, speaker: str, label_text: str,
-                             name_style: str, dash_style: str) -> None:
-        """Write a header line only when the speaker changes or the gap is
-        larger than _GROUP_WINDOW_S. Stores the new state.
+    def _maybe_write_header(self, speaker: str, symbol: str,
+                             name_style: str) -> None:
+        """Write a symbol-only header when the speaker changes or the gap exceeds _GROUP_WINDOW_S.
+
+        The header is ``HH:MM <symbol>`` (ts on) or ``<symbol>`` (ts off).
+        A blank line separates turns; the dash rule from the old layout is
+        intentionally absent.
 
         Wave-10 follow-up G-F7: ``time.time()`` (wall clock) rather
         than ``time.monotonic()``. The header's visible HH:MM
@@ -617,7 +688,7 @@ class ConversationView(Widget):
             # The raw list cost is ~8 bytes per turn — a 24h session
             # generating one turn per second is ~700 KB, negligible
             # next to the RichLog itself.
-            log.write(_msg_header(label_text, name_style, dash_style))
+            log.write(_msg_header(symbol, name_style, show_ts=self._show_timestamps))
         self._last_speaker = speaker
         self._last_speaker_at = now
 
@@ -703,9 +774,7 @@ class ConversationView(Widget):
         """
         self._snap_to_bottom()
         self._consume_empty_hint()
-        self._maybe_write_header(
-            "you", f"{_GLYPH_USER} you", "bold #4abbb5", "#666666",
-        )
+        self._maybe_write_header("you", _GLYPH_USER, "bold #4abbb5")
         self._write_body(Text(text))
         self._write_log(Text(""))
 
@@ -730,9 +799,7 @@ class ConversationView(Widget):
         if _is_lifecycle_marker(text):
             self._write_log(_render_lifecycle_marker(text))
             return
-        self._maybe_write_header(
-            "system", f"{_GLYPH_SYSTEM} system", "bold #888888", "#666666",
-        )
+        self._maybe_write_header("system", _GLYPH_SYSTEM, "bold #888888")
         for line in text.splitlines() or [""]:
             self._write_body(Text(line))
         self._write_log(Text(""))
@@ -749,13 +816,14 @@ class ConversationView(Widget):
         self.stop_thinking()  # turn finished — unmount inline spinner
         self.hide_status()    # also clear any sticky status
         meta_pfx = _meta_prefix(msg.meta)
-        label = f"reyn  {meta_pfx}".rstrip() if meta_pfx else "reyn"
-        # _AMBER for agent identity (header label) — distinct from _CORAL
-        # which is reserved for interactive affordances (/expand, picker
-        # selection caret, panel cursor ▶) and "you are here" indicators.
-        self._maybe_write_header(
-            "reyn", f"{_GLYPH_AGENT} {label}", "bold " + _AMBER, "#666666",
-        )
+        # _AMBER for agent identity — distinct from _CORAL (interactive
+        # affordances). The meta prefix (= [skill#abcd]) is emitted on its
+        # own line after the header so the symbol-only header stays minimal.
+        self._maybe_write_header("reyn", _GLYPH_AGENT, "bold " + _AMBER)
+        if meta_pfx:
+            # Emit the meta prefix as a dim sub-line so skill identity is still
+            # discoverable without cluttering the symbol header.
+            self._write_body(Text(meta_pfx.strip(), style="dim #888888"))
         if msg.text:
             self._write_agent_markdown_with_fold(msg.text)
         self._write_log(Text(""))
@@ -779,7 +847,7 @@ class ConversationView(Widget):
         reply through).
         """
         try:
-            width = max(20, self.size.width - _BODY_INDENT_COLS - 2)
+            width = max(20, self.size.width - self._current_body_indent() - 2)
         except Exception:
             width = _FOLD_WIDTH_FALLBACK
         if width <= 0:
@@ -953,25 +1021,23 @@ class ConversationView(Widget):
             self._maybe_warn_about_trimmed_history(log)
 
     def _write_body(self, renderable: RenderableType) -> None:
-        """Append a body renderable at the hanging-indent column.
+        """Append a body renderable at the dynamic hanging-indent column.
 
         Wraps ``renderable`` in left-only ``Padding`` so wrap continuations
-        line up under the speaker name and stay visually distinct from the
-        column-0 turn header. Used for agent markdown, user / system text,
-        and any other content that belongs "under" the most recent header.
+        line up under the speaker symbol and stay visually distinct from the
+        column-0 turn header. The indent is 8 when timestamps are shown
+        (= col 0-4 ts + col 5 space + col 6 symbol + col 7 space + col 8+
+        body) and 2 when hidden (= col 0 symbol + col 1 space + col 2+ body).
         """
-        self._log().write(_indent_body(renderable))
+        self._log().write(_indent_body(renderable, self._current_body_indent()))
 
     # ── streaming support ─────────────────────────────────────────────────────
 
     def begin_stream(self, msg_id: str, agent_name: str = "") -> StreamingRow:
         """Start a streaming agent message row. Returns the row widget."""
         self._consume_empty_hint()
-        label = agent_name if agent_name else "reyn"
         # Same agent-identity styling as _render_agent_markdown (_AMBER).
-        self._maybe_write_header(
-            "reyn", f"{_GLYPH_AGENT} {label}", "bold " + _AMBER, "#666666",
-        )
+        self._maybe_write_header("reyn", _GLYPH_AGENT, "bold " + _AMBER)
         row = StreamingRow(prefix="", id=f"stream_{msg_id[:8]}")
         self._stream_rows[msg_id] = row
         self.mount(row)

--- a/src/reyn/chat/tui/widgets/foldable_markdown.py
+++ b/src/reyn/chat/tui/widgets/foldable_markdown.py
@@ -17,7 +17,7 @@ from textual.widgets import Label, Static
 
 from reyn.chat.tui._palette import _CORAL
 
-_BODY_INDENT_COLS = 7  # must match conversation.py _BODY_INDENT_COLS
+_BODY_INDENT_COLS = 8  # must match conversation.py _BODY_INDENT_WITH_TS (ts-on value)
 
 
 class FoldableMarkdown(Widget):

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -27,6 +27,11 @@ _KEY_DETAILS: dict[str, str] = {
         "/expand or clicking the foldable's hint footer. Collapsed shows\n"
         "preview + ▶ hint; expanded shows full text + ▼ hint."
     ),
+    "f9": (
+        "Toggle the HH:MM timestamp prefix in conv-pane message headers.\n"
+        "With timestamps hidden, body indent shrinks col 8 → col 2, giving\n"
+        "more horizontal space for content. Persists via tui_prefs.json."
+    ),
     "f3": (
         "Drill-down expands the cursor's skill row to show phase history,\n"
         "tool calls, and per-phase events. Mouse-click on the row does\n"
@@ -118,7 +123,7 @@ _KEY_PRETTY: dict[str, str] = {
     "ctrl+shift+g": "⌃⇧G",
     "enter": "Enter", "tab": "Tab", "escape": "Esc", "space": "Space",
     "up": "↑", "down": "↓", "left": "←", "right": "→",
-    "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4", "f7": "F7", "f8": "F8",
+    "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4", "f7": "F7", "f8": "F8", "f9": "F9",
     # Quick-jump number keys for the right-panel tabs (Ctrl+1 .. Ctrl+7).
     "ctrl+1": "⌃1", "ctrl+2": "⌃2", "ctrl+3": "⌃3", "ctrl+4": "⌃4",
     "ctrl+5": "⌃5", "ctrl+6": "⌃6", "ctrl+7": "⌃7", "ctrl+8": "⌃8",
@@ -144,6 +149,8 @@ _CONVERSATION_KEYS = {
     # F8: FoldableMarkdown toggle. Same rationale as F3/F7 — toggles
     # expand state of a widget mounted in the conv pane.
     "f8",
+    # F9: timestamp toggle — affects conv-pane header rendering.
+    "f9",
 }
 # ``j`` / ``k`` / ``space`` / ``c`` are routed via ``RightPanel.on_key``
 # (not ``app.BINDINGS``) and dispatch per-tab inside the panel handler,

--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -71,19 +71,16 @@ def _fmt_idle(idle_seconds: float) -> str:
         return f"{int(secs)}s"
     return f"{int(secs // 60)}m"
 
-# Body content rendered inside ConversationView lives at a 7-cell
-# hanging indent (= ``conversation._BODY_INDENT_COLS``) so wrap
-# continuations sit under the speaker name and the column-0 turn
-# header stays visually distinct. Streaming text mounted here is the
-# same kind of body content, so it must render at the same indent —
-# otherwise the body visibly shifts 7 cells to the right at seal()
-# time when ``end_stream`` commits the final markdown via
-# ``_write_agent_markdown_with_fold`` → ``_write_body`` (= the
-# Padding-wrapped ``_indent_body`` path). Kept as a local constant
-# rather than imported from conversation.py to avoid an import
-# cycle (conversation already imports this module); must stay in
-# sync with conversation._BODY_INDENT_COLS.
-_BODY_INDENT_COLS = 7
+# Body content rendered inside ConversationView lives at a dynamic
+# hanging indent gated by ``_show_timestamps`` (8 with ts, 2 without).
+# The StreamingRow is mounted while a reply is in flight (= before
+# end_stream commits the final markdown). Since the streaming row is
+# spawned after a header is written (timestamps already shown or not),
+# it must use the ts-on value — the header write and the streaming body
+# are in the same state snapshot. Kept as a local constant to avoid an
+# import cycle (conversation already imports this module); must stay in
+# sync with conversation._BODY_INDENT_WITH_TS (= _BODY_INDENT_COLS alias).
+_BODY_INDENT_COLS = 8
 
 
 class StreamingRow(Widget):
@@ -109,20 +106,20 @@ class StreamingRow(Widget):
     # cells to the right at seal time when ``end_stream`` committed
     # the final markdown through ``_write_agent_markdown_with_fold``.
     # The 4-value form is ``top right bottom left``.
-    DEFAULT_CSS = """
-    StreamingRow {
+    DEFAULT_CSS = f"""
+    StreamingRow {{
         padding: 0 0;
         height: auto;
-    }
-    StreamingRow Static {
-        padding: 0 0 0 7;
+    }}
+    StreamingRow Static {{
+        padding: 0 0 0 {_BODY_INDENT_COLS};
         height: auto;
-    }
-    StreamingRow Markdown {
-        padding: 0 0 0 7;
+    }}
+    StreamingRow Markdown {{
+        padding: 0 0 0 {_BODY_INDENT_COLS};
         height: auto;
         background: transparent;
-    }
+    }}
     """
 
     def __init__(self, *, prefix: str = "", id: str | None = None) -> None:

--- a/tests/cli/test_body_hanging_indent.py
+++ b/tests/cli/test_body_hanging_indent.py
@@ -1,12 +1,12 @@
-"""Tier 2: message bodies render at the hanging-indent column.
+"""Tier 2: message bodies render at the dynamic hanging-indent column.
 
-Before this fix, ``RichLog(wrap=True)`` wrapped long lines without any
-leading indent. A continuation of a long URL or code line started at
-column 0 — the same column as a new ``HH:MM …`` header — so the eye
-could not tell them apart. The fix wraps every body write site in
-``Padding(.., (0, 0, 0, _BODY_INDENT_COLS))`` (= 7-cell left indent)
-so both the first body line AND its wrapped continuation sit under the
-speaker name, leaving the header anchored at column 0.
+With timestamps shown (default), bodies start at col 8 (= ``_BODY_INDENT_WITH_TS``);
+with timestamps hidden (F9 toggle), bodies start at col 2 (= ``_BODY_INDENT_NO_TS``).
+
+Before the hanging-indent fix, ``RichLog(wrap=True)`` wrapped long lines
+without any leading indent so a continuation landed at column 0 —
+indistinguishable from a new speaker header. The Padding at every body
+write site keeps wrap continuations visually nested under the symbol.
 
 These tests inspect the rendered RichLog Strips (= what the user
 actually sees on screen) for body lines vs header lines, so a future
@@ -29,7 +29,7 @@ from textual.widgets import RichLog
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.tui.app import ReynTUIApp
 from reyn.chat.tui.widgets import ConversationView
-from reyn.chat.tui.widgets.conversation import _BODY_INDENT_COLS
+from reyn.chat.tui.widgets.conversation import _BODY_INDENT_NO_TS, _BODY_INDENT_WITH_TS
 
 
 def _make_app() -> ReynTUIApp:
@@ -60,11 +60,11 @@ def _find_first_line_containing(log: RichLog, needle: str) -> int:
 
 @pytest.mark.asyncio
 async def test_user_message_body_is_indented() -> None:
-    """Tier 2b: ``render_user_message`` writes its body at the hanging-indent column.
+    """Tier 2b: ``render_user_message`` writes its body at the ts-on hanging-indent column.
 
-    The header (``HH:MM  you  ───``) stays at column 0; the body line
-    "hello world" starts at column 7 so a wrap continuation visually
-    nests under the name column.
+    The header (``HH:MM >`` with ts on) stays at column 0; the body line
+    "hello world" starts at column ``_BODY_INDENT_WITH_TS`` (8) so a wrap
+    continuation visually nests under the symbol column.
     """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
@@ -72,34 +72,57 @@ async def test_user_message_body_is_indented() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
+        # Default state: timestamps on → indent 8.
+        conv._show_timestamps = True
         conv.render_user_message("hello world")
         await pilot.pause()
 
         idx = _find_first_line_containing(log, "hello world")
         body = _line_text(log, idx)
-        assert body.startswith(" " * _BODY_INDENT_COLS), (
-            f"user body must start at indent col {_BODY_INDENT_COLS}; got {body!r}"
+        assert body.startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"user body (ts on) must start at indent col {_BODY_INDENT_WITH_TS}; got {body!r}"
         )
         assert "hello world" in body
 
 
 @pytest.mark.asyncio
-async def test_agent_markdown_body_is_indented() -> None:
-    """Tier 2b: Agent markdown turns render their content at the indent column."""
+async def test_user_message_body_is_indented_ts_off() -> None:
+    """Tier 2b: ``render_user_message`` with ts off uses the narrow indent (col 2)."""
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
+        conv._show_timestamps = False
+        conv.render_user_message("hello ts-off")
+        await pilot.pause()
+
+        idx = _find_first_line_containing(log, "hello ts-off")
+        body = _line_text(log, idx)
+        assert body.startswith(" " * _BODY_INDENT_NO_TS), (
+            f"user body (ts off) must start at indent col {_BODY_INDENT_NO_TS}; got {body!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_markdown_body_is_indented() -> None:
+    """Tier 2b: Agent markdown turns render their content at the ts-on indent column."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._show_timestamps = True
         msg = OutboxMessage(kind="agent", text="this is the agent body line")
         conv.render_message(msg)
         await pilot.pause()
 
         idx = _find_first_line_containing(log, "this is the agent body line")
         body = _line_text(log, idx)
-        assert body.startswith(" " * _BODY_INDENT_COLS), (
-            f"agent body must start at indent col {_BODY_INDENT_COLS}; got {body!r}"
+        assert body.startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"agent body must start at indent col {_BODY_INDENT_WITH_TS}; got {body!r}"
         )
 
 
@@ -112,6 +135,7 @@ async def test_system_message_body_is_indented() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
+        conv._show_timestamps = True
         msg = OutboxMessage(kind="system", text="line a\nline b\nline c")
         conv.render_message(msg)
         await pilot.pause()
@@ -119,7 +143,7 @@ async def test_system_message_body_is_indented() -> None:
         for needle in ("line a", "line b", "line c"):
             idx = _find_first_line_containing(log, needle)
             body = _line_text(log, idx)
-            assert body.startswith(" " * _BODY_INDENT_COLS), (
+            assert body.startswith(" " * _BODY_INDENT_WITH_TS), (
                 f"system line {needle!r} not indented; got {body!r}"
             )
 
@@ -129,10 +153,10 @@ async def test_system_message_body_is_indented() -> None:
 
 @pytest.mark.asyncio
 async def test_header_line_is_not_indented() -> None:
-    """Tier 2b: The timestamp + speaker label header stays at column 0.
+    """Tier 2b: The symbol header stays at column 0.
 
-    This is the load-bearing distinction the fix delivers: header at
-    column 0, body at column ``_BODY_INDENT_COLS``. Without it the wrap
+    This is the load-bearing distinction: header at column 0,
+    body at column ``_BODY_INDENT_WITH_TS``. Without it the wrap
     continuation of a body line and the start of a new header become
     visually identical.
     """
@@ -142,12 +166,13 @@ async def test_header_line_is_not_indented() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
+        conv._show_timestamps = True
         conv.render_user_message("payload")
         await pilot.pause()
 
-        # The header line is the one that has the dash rule (── chars).
-        # Find it and assert it starts at column 0.
-        header_idx = _find_first_line_containing(log, "─")
+        # The header line contains the ``>`` user symbol.
+        # With ts on the line is ``HH:MM >`` — starts at column 0 (no leading space).
+        header_idx = _find_first_line_containing(log, ">")
         header = _line_text(log, header_idx)
         assert not header.startswith(" "), (
             f"header line must NOT be indented (column-0 anchor); got {header!r}"
@@ -172,6 +197,7 @@ async def test_long_user_line_wrap_continuation_is_indented() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
+        conv._show_timestamps = True
         # ~60 chars — well past the 40-cell terminal so it wraps.
         long_payload = "abcdefghij" * 6
         conv.render_user_message(long_payload)
@@ -180,26 +206,27 @@ async def test_long_user_line_wrap_continuation_is_indented() -> None:
         # First body line should be the one containing the start of payload.
         first_body_idx = _find_first_line_containing(log, "abcdefghij")
         first_body = _line_text(log, first_body_idx)
-        assert first_body.startswith(" " * _BODY_INDENT_COLS), first_body
+        assert first_body.startswith(" " * _BODY_INDENT_WITH_TS), first_body
 
         # If wrap fired, the next line should also lead with the indent.
         if first_body_idx + 1 < len(log.lines):
             cont = _line_text(log, first_body_idx + 1)
             stripped = cont.strip()
             if stripped:  # non-empty continuation
-                assert cont.startswith(" " * _BODY_INDENT_COLS), (
+                assert cont.startswith(" " * _BODY_INDENT_WITH_TS), (
                     f"wrap continuation must also be indented; got {cont!r}"
                 )
 
 
-# ── constant invariant ───────────────────────────────────────────────────────
+# ── constant invariants ──────────────────────────────────────────────────────
 
 
-def test_body_indent_constant_matches_header_name_column() -> None:
-    """Tier 2b: ``_BODY_INDENT_COLS`` aligns with where the name column starts.
+def test_body_indent_constants_have_correct_values() -> None:
+    """Tier 2b: ``_BODY_INDENT_WITH_TS`` and ``_BODY_INDENT_NO_TS`` match the spec.
 
-    Header layout: ``HH:MM`` (5) + 2-space gap = 7 cells before the
-    name. The body indent must match so wrapped content nests under
-    the name. If either constant moves, the other must too.
+    ts-on layout:  ``HH:MM <sym>`` = 5 (ts) + 1 (space) + 1 (sym) + 1 (space)
+                   → body starts col 8.
+    ts-off layout: ``<sym>`` = 1 (sym) + 1 (space) → body starts col 2.
     """
-    assert _BODY_INDENT_COLS == 7
+    assert _BODY_INDENT_WITH_TS == 8, f"ts-on indent should be 8, got {_BODY_INDENT_WITH_TS}"
+    assert _BODY_INDENT_NO_TS == 2, f"ts-off indent should be 2, got {_BODY_INDENT_NO_TS}"

--- a/tests/cli/test_conv_ts_toggle.py
+++ b/tests/cli/test_conv_ts_toggle.py
@@ -1,0 +1,320 @@
+"""Tier 2: F9 timestamp toggle — conv-pane header symbol layout and persistence.
+
+Pins the behaviour of ``ConversationView.toggle_timestamps()`` and the
+F9 action in ``ReynTUIApp``.  Seven tests cover:
+
+1. Default (ts on): ``render_user_message`` → output contains ``HH:MM``
+   pattern + ``>`` symbol; body at indent 8.
+2. After ``toggle_timestamps()``: ts off. ``render_user_message`` → no
+   ``HH:MM`` timestamp in header line; ``>`` at col 0; body at indent 2.
+3. Toggle twice → back to on (indent 8 again).
+4. F9 dispatch (``action_toggle_timestamps``) → state flips + flash status
+   emitted.
+5. Persistence: ``_show_timestamps=False`` saved to prefs file; a new
+   ``ConversationView`` instance loads as False.
+6. Old messages rendered before toggle stay at old indent (= no re-render).
+7. Day separator still emitted on day boundary regardless of ts state.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.conversation import (
+    _BODY_INDENT_NO_TS,
+    _BODY_INDENT_WITH_TS,
+    _GLYPH_AGENT,
+    _GLYPH_USER,
+)
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _log_text(log: RichLog) -> str:
+    """Concat all strip text in the RichLog for substring searches."""
+    return "\n".join("".join(seg.text for seg in strip) for strip in log.lines)
+
+
+def _log_lines(log: RichLog) -> list[str]:
+    """Return a list of plain-text lines from the RichLog."""
+    return ["".join(seg.text for seg in strip) for strip in log.lines]
+
+
+def _find_lines_containing(log: RichLog, needle: str) -> list[str]:
+    return [l for l in _log_lines(log) if needle in l]
+
+
+# ---------------------------------------------------------------------------
+# 1. Default (ts on): HH:MM visible, > at col 6, body at indent 8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts_on_by_default_header_contains_timestamp():
+    """Tier 2: with timestamps on (default), user header contains HH:MM."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        assert conv._show_timestamps is True
+        conv.render_user_message("hello ts-on")
+        await pilot.pause()
+
+        full = _log_text(log)
+        # HH:MM pattern should appear in the header area.
+        assert re.search(r"\d{2}:\d{2}", full), (
+            f"expected HH:MM timestamp in conv log (ts on), got:\n{full}"
+        )
+        assert _GLYPH_USER in full
+
+        # Body at indent 8.
+        lines = _log_lines(log)
+        body_lines = [l for l in lines if "hello ts-on" in l]
+        assert body_lines, "body text must appear in log"
+        assert body_lines[0].startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"ts-on body must start at col {_BODY_INDENT_WITH_TS}: {body_lines[0]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. After toggle: ts off — no HH:MM, > at col 0, body at indent 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts_off_after_toggle_no_timestamp_in_header():
+    """Tier 2: after toggle_timestamps(), user header has no HH:MM prefix."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # Flip to off.
+        new_state = conv.toggle_timestamps()
+        assert new_state is False
+        assert conv._show_timestamps is False
+
+        conv.render_user_message("hello ts-off")
+        await pilot.pause()
+
+        lines = _log_lines(log)
+        # Find the header line (= the one containing the symbol, not body).
+        symbol_lines = [l for l in lines if _GLYPH_USER in l and "hello ts-off" not in l]
+        # There should be a header line starting with the symbol (col 0).
+        if symbol_lines:
+            hdr = symbol_lines[-1]
+            assert hdr.startswith(_GLYPH_USER), (
+                f"ts-off header must start with symbol at col 0: {hdr!r}"
+            )
+            # Should NOT contain a HH:MM prefix.
+            assert not re.match(r"\d{2}:\d{2}", hdr), (
+                f"ts-off header must not start with HH:MM: {hdr!r}"
+            )
+
+        # Body at indent 2.
+        body_lines = [l for l in lines if "hello ts-off" in l]
+        assert body_lines, "body text must appear in log"
+        assert body_lines[0].startswith(" " * _BODY_INDENT_NO_TS), (
+            f"ts-off body must start at col {_BODY_INDENT_NO_TS}: {body_lines[0]!r}"
+        )
+        # Body at col 2 must NOT have the wider ts-on indent.
+        assert not body_lines[0].startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"ts-off body must NOT have {_BODY_INDENT_WITH_TS}-col indent: {body_lines[0]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Toggle twice → back to on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toggle_twice_returns_to_on():
+    """Tier 2: two toggles restore the original ts-on state."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        assert conv._show_timestamps is True
+        conv.toggle_timestamps()
+        assert conv._show_timestamps is False
+        conv.toggle_timestamps()
+        assert conv._show_timestamps is True
+
+        # Body rendered after second toggle uses ts-on indent.
+        log = conv.query_one(RichLog)
+        conv.render_user_message("back to on")
+        await pilot.pause()
+
+        lines = _log_lines(log)
+        body_lines = [l for l in lines if "back to on" in l]
+        assert body_lines
+        assert body_lines[0].startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"after 2 toggles body must be at ts-on indent: {body_lines[0]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. F9 dispatch → state flips + flash status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f9_dispatch_flips_state_and_flashes_status():
+    """Tier 2: action_toggle_timestamps flips _show_timestamps and shows status flash."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        before = conv._show_timestamps
+        app.action_toggle_timestamps()
+        await pilot.pause()
+
+        assert conv._show_timestamps is not before, (
+            "action_toggle_timestamps must flip _show_timestamps"
+        )
+        # Flash status: StickyStatus should have been updated (we don't
+        # assert exact text to avoid pinning sticky internals, but the
+        # method must not raise).
+
+
+# ---------------------------------------------------------------------------
+# 5. Persistence — saved to prefs + loaded by new instance
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_persists_to_prefs_file(tmp_path: Path):
+    """Tier 2: toggle_timestamps() writes show_timestamps to tui_prefs.json."""
+    from reyn.chat.tui.prefs import load_tui_prefs, save_tui_prefs
+
+    # Seed an empty prefs file.
+    prefs_dir = tmp_path / ".reyn"
+    prefs_dir.mkdir()
+    prefs_file = prefs_dir / "tui_prefs.json"
+    prefs_file.write_text("{}", encoding="utf-8")
+
+    # Build a minimal ConversationView-like object to test the persist path
+    # directly (= no Textual app needed for the prefs layer).
+    from reyn.chat.tui.widgets.conversation import ConversationView as CV
+
+    # Patch _project_root_path to return tmp_path.
+    class _FakeApp:
+        def _project_root_path(self):
+            return tmp_path
+
+    # Direct test of save/load without mounting a full app:
+    prefs: dict = {}
+    prefs["show_timestamps"] = False
+    save_tui_prefs(tmp_path, prefs)
+
+    loaded = load_tui_prefs(tmp_path)
+    assert loaded.get("show_timestamps") is False, (
+        f"prefs file should have show_timestamps=False; got {loaded}"
+    )
+
+    prefs["show_timestamps"] = True
+    save_tui_prefs(tmp_path, prefs)
+    loaded2 = load_tui_prefs(tmp_path)
+    assert loaded2.get("show_timestamps") is True
+
+
+# ---------------------------------------------------------------------------
+# 6. Old messages stay at old indent after toggle (no re-render)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_old_messages_keep_old_indent_after_toggle():
+    """Tier 2: past messages rendered before the toggle keep their original indent.
+
+    ConversationView does NOT re-render past RichLog content on toggle —
+    only new writes use the new indent. This test writes a message (ts on,
+    indent 8), toggles, then writes another (ts off, indent 2) and
+    verifies both indents coexist.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        # First message: ts on → indent 8.
+        conv._show_timestamps = True
+        conv._last_speaker = ""  # force new header
+        conv.render_user_message("before-toggle")
+        await pilot.pause()
+
+        # Toggle → ts off.
+        conv._show_timestamps = False
+        conv._last_speaker = ""  # force new header
+
+        conv.render_user_message("after-toggle")
+        await pilot.pause()
+
+        lines = _log_lines(log)
+
+        before_body = [l for l in lines if "before-toggle" in l]
+        after_body = [l for l in lines if "after-toggle" in l]
+
+        assert before_body, "before-toggle body must be in log"
+        assert after_body, "after-toggle body must be in log"
+
+        assert before_body[0].startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"before-toggle body must keep ts-on indent: {before_body[0]!r}"
+        )
+        assert after_body[0].startswith(" " * _BODY_INDENT_NO_TS), (
+            f"after-toggle body must use ts-off indent: {after_body[0]!r}"
+        )
+        assert not after_body[0].startswith(" " * _BODY_INDENT_WITH_TS), (
+            f"after-toggle body must NOT have ts-on indent: {after_body[0]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Day separator still emitted on day boundary regardless of ts state
+# ---------------------------------------------------------------------------
+
+
+def test_date_separator_emitted_regardless_of_ts_state():
+    """Tier 2: _date_separator helper is not gated by show_timestamps.
+
+    The day-boundary separator (``── YYYY-MM-DD ───``) comes from
+    ``_date_separator()`` which is called unconditionally inside
+    ``_maybe_write_header``. Verify the helper always produces output.
+    """
+    from rich.cells import cell_len
+
+    from reyn.chat.tui.widgets.conversation import _DASH_TOTAL, _date_separator
+
+    sep = _date_separator("2026-05-24")
+    assert "2026-05-24" in sep.plain
+    assert cell_len(sep.plain) == _DASH_TOTAL, (
+        f"date separator width must equal _DASH_TOTAL={_DASH_TOTAL}, "
+        f"got {cell_len(sep.plain)}"
+    )

--- a/tests/cli/test_lifecycle_marker_render.py
+++ b/tests/cli/test_lifecycle_marker_render.py
@@ -155,19 +155,27 @@ async def test_lifecycle_marker_skips_system_speaker_header():
         rendered = _log_text(log)
         # The marker body lands.
         assert "↑ 3 turns compacted" in rendered
-        # The ``· system`` speaker tag does NOT — that would be the
-        # heavy pre-polish path leaking through.
+        # The system speaker symbol (``·``) must NOT appear as a standalone
+        # header — that would be the heavy pre-polish path leaking through.
+        # We check for the old "· system" label string (pre-refactor label
+        # text), and also that a bare "·" line doesn't appear as a header.
         assert "· system" not in rendered, (
             f"lifecycle marker leaked the system speaker header:\n{rendered}"
         )
+        # With the new symbol-only layout, the symbol for system is "·"
+        # but lifecycle markers bypass _maybe_write_header entirely, so no
+        # "·" should appear as a header line at all.
+        # (The marker itself may contain dashes and label text, but not the
+        # bare system glyph as a standalone speaker indicator.)
 
 
 @pytest.mark.asyncio
 async def test_regular_system_message_still_uses_speaker_header():
-    """Tier 2: non-marker system messages keep the full ``· system`` header.
+    """Tier 2: non-marker system messages keep the symbol (``·``) speaker header.
 
-    Defends against the detector being too greedy and accidentally
-    stripping headers from slash-command output.
+    Post-refactor: the header is symbol-only (``·`` or ``HH:MM ·``), no
+    label text. Defends against the detector being too greedy and
+    accidentally stripping headers from slash-command output.
     """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
@@ -183,7 +191,9 @@ async def test_regular_system_message_still_uses_speaker_header():
         await pilot.pause()
 
         rendered = _log_text(log)
-        assert "· system" in rendered, (
-            f"regular system message lost its speaker header:\n{rendered}"
+        # Symbol-only header: the ``·`` glyph appears (= system speaker).
+        # The old "· system" label is gone; we check for the glyph only.
+        assert "·" in rendered, (
+            f"regular system message lost its speaker symbol:\n{rendered}"
         )
         assert "usage: /help" in rendered

--- a/tests/cli/test_msg_header_cell_align.py
+++ b/tests/cli/test_msg_header_cell_align.py
@@ -1,25 +1,24 @@
-"""Tier 2b: ``_msg_header`` aligns the dash rule by terminal cell width.
+"""Tier 2: ``_msg_header`` symbol-only layout (ts-on and ts-off modes).
 
-Before this fix the header used ``label.ljust(4)`` to reserve a fixed
-4-character name column, then a hardcoded 26-dash rule sized off that
-same constant. ``ljust`` counts Python code points, but terminal columns
-count display cells — a CJK character (or full-width punctuation, or an
-emoji) is 2 cells per glyph. An agent named ``"アリア"`` (3 code points,
-6 cells) blew past the 4-cell column and pushed the dash rule out past
-the banner width, breaking visual alignment between user and agent
-turns.
+Before the Claude Code-style refactor, the header used a padded label
+(``▶ you``, ``◆ reyn``) + a dash rule sized off the label cell-width.
+The new header is symbol-only: either ``HH:MM <symbol>`` (ts on) or
+``<symbol>`` (ts off). No dash rule; no label text.
 
-The fix pads to a target *cell* count via ``rich.cells.cell_len`` and
-flexes the dash count off the actual cell width of the label.
+``_pad_to_cells`` is still in the module (used elsewhere) so its tests
+are preserved.
 """
 from __future__ import annotations
+
+import re
 
 import pytest
 from rich.cells import cell_len
 
 from reyn.chat.tui.widgets.conversation import (
-    _DASH_TOTAL,
-    _NAME_COL_COLS,
+    _GLYPH_AGENT,
+    _GLYPH_SYSTEM,
+    _GLYPH_USER,
     _msg_header,
     _pad_to_cells,
 )
@@ -54,86 +53,57 @@ def test_pad_to_cells_does_not_truncate_wide_strings() -> None:
     assert out == label
 
 
-# ── _msg_header ───────────────────────────────────────────────────────────────
+# ── _msg_header (new symbol-only layout) ─────────────────────────────────────
 
 
-def _header_plain_text(label: str) -> str:
-    """Return the plain-text projection of a rendered header."""
-    return _msg_header(label, "bold", "dim").plain
+def test_msg_header_ts_on_contains_timestamp():
+    """Tier 2: ts-on header contains an HH:MM pattern."""
+    hdr = _msg_header(_GLYPH_USER, "bold #4abbb5", show_ts=True)
+    plain = hdr.plain
+    assert re.search(r"\d{2}:\d{2}", plain), (
+        f"ts-on header must contain HH:MM, got: {plain!r}"
+    )
+    assert _GLYPH_USER in plain
 
 
-def test_narrow_label_dash_count_unchanged() -> None:
-    """Tier 2b: existing 4-cell labels keep their historical 26-dash rule.
-
-    Guards the fix from accidentally changing the visual length for the
-    99% case (``"reyn"`` and ``"you "`` agents).
-    """
-    text = _header_plain_text("reyn")
-    # Layout: 'HH:MM' (5) + '  ' (2) + 'reyn' (4) + ' ' (1) + dashes
-    # _DASH_TOTAL = 38 → dashes = 38 - 5 - 2 - 4 - 1 = 26
-    assert text.count("─") == 26
+def test_msg_header_ts_on_has_symbol():
+    """Tier 2: ts-on header contains the expected symbol for each speaker."""
+    for sym in (_GLYPH_USER, _GLYPH_AGENT, _GLYPH_SYSTEM):
+        hdr = _msg_header(sym, "bold", show_ts=True)
+        assert sym in hdr.plain, (
+            f"ts-on header must contain symbol {sym!r}: {hdr.plain!r}"
+        )
 
 
-def test_short_label_padded_then_dashed_same_count() -> None:
-    """Tier 2b: ``"you"`` (3 cells) is padded to 4 cells, dashes still 26."""
-    text = _header_plain_text("you")
-    assert text.count("─") == 26
-    # The padded column ends just before the dash run — verify cell width
-    # from start of the line through the space before dashes.
-    pre_dash = text.split("─", 1)[0]
-    expected_cells = 5 + 2 + 4 + 1  # HH:MM + 2sp + 4cells + 1sp
-    assert cell_len(pre_dash) == expected_cells, (
-        f"pre-dash prefix has {cell_len(pre_dash)} cells, expected {expected_cells}"
+def test_msg_header_ts_off_has_no_timestamp():
+    """Tier 2: ts-off header does NOT contain an HH:MM pattern."""
+    hdr = _msg_header(_GLYPH_USER, "bold #4abbb5", show_ts=False)
+    plain = hdr.plain
+    assert not re.search(r"\d{2}:\d{2}", plain), (
+        f"ts-off header must NOT contain HH:MM, got: {plain!r}"
+    )
+    assert _GLYPH_USER in plain
+
+
+def test_msg_header_ts_off_starts_with_symbol():
+    """Tier 2: ts-off header starts with the symbol at col 0 (no leading space)."""
+    hdr = _msg_header(_GLYPH_USER, "bold #4abbb5", show_ts=False)
+    assert hdr.plain.startswith(_GLYPH_USER), (
+        f"ts-off header must start with symbol; got {hdr.plain!r}"
     )
 
 
-def test_wide_cjk_label_shrinks_dash_count_to_stay_within_dash_total() -> None:
-    """Tier 2b: ``"アリア"`` (6 cells) shrinks the dash count so the whole
-    line stays at or under _DASH_TOTAL cells.
+def test_msg_header_no_dash_rule():
+    """Tier 2: the new symbol-only header does NOT emit dash characters.
 
-    Without the fix the line would have been longer than _DASH_TOTAL and
-    overrun the banner width.
+    The old layout used ``─────`` to separate turns. The new layout uses
+    blank lines between turns instead, so no dash characters should appear
+    in the header.
     """
-    text = _header_plain_text("アリア")
-    # name_cells = 6 → dashes = 38 - 5 - 2 - 6 - 1 = 24
-    assert text.count("─") == 24
-    # Total line cells must not exceed _DASH_TOTAL
-    assert cell_len(text) <= _DASH_TOTAL
-
-
-def test_header_cell_width_consistent_across_label_types() -> None:
-    """Tier 2b: every header line has the same total cell width.
-
-    This is the user-visible alignment contract: the dash rule's right
-    edge lands at the same column whether the label is "you ", "reyn",
-    or a CJK agent name.
-    """
-    labels = ("reyn", "you ", "you", "a", "アリア", "日本", "")
-    widths = {cell_len(_header_plain_text(label)) for label in labels}
-    # All widths must converge to a single value — use set cardinality check via
-    # equality rather than len() to avoid format-pinning the set size.
-    assert widths == {_DASH_TOTAL}, (
-        f"header cell widths diverged across labels: {widths}"
-    )
-
-
-def test_header_dash_count_never_negative_for_outsized_labels() -> None:
-    """Tier 2b: pathologically wide labels still produce at least 1 dash.
-
-    Guards the ``max(1, ...)`` floor: a 30-cell label would otherwise
-    yield a negative dash count and crash ``"─" * n`` (Python silently
-    returns "" for n<0, which would silently break alignment instead of
-    crashing — both are bad).
-    """
-    huge = "アリア" * 5  # 30 cells
-    text = _header_plain_text(huge)
-    assert text.count("─") >= 1
-
-
-def test_name_col_cols_constant_matches_legacy_layout() -> None:
-    """Tier 2b: the column constant is 4 — matches the historic ``ljust(4)``.
-
-    If this constant ever moves, the layout calc in ``_msg_header`` must
-    move with it; pin the value so a stray rename doesn't desync the two.
-    """
-    assert _NAME_COL_COLS == 4
+    for sym in (_GLYPH_USER, _GLYPH_AGENT, _GLYPH_SYSTEM):
+        for show_ts in (True, False):
+            hdr = _msg_header(sym, "bold", show_ts=show_ts)
+            assert "─" not in hdr.plain, (
+                f"header must not contain dash rule: {hdr.plain!r} "
+                f"(sym={sym!r}, show_ts={show_ts})"
+            )

--- a/tests/cli/test_palette_semantic_split.py
+++ b/tests/cli/test_palette_semantic_split.py
@@ -103,30 +103,32 @@ async def test_agent_header_label_renders_with_amber() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
-        # Render an agent message so the "reyn" label appears in a header
+        # Render an agent message so the agent symbol appears in a header.
+        # Post-refactor: headers are symbol-only (``⏺``); no label text or dash rule.
+        from reyn.chat.tui.widgets.conversation import _GLYPH_AGENT
         conv.render_message(OutboxMessage(kind="agent", text="hi"))
         await pilot.pause()
 
-        # Find the strip containing "reyn" (the speaker label)
+        # Find the strip containing the agent symbol (= the header line).
         strip = None
         for s in log.lines:
             text = "".join(seg.text for seg in s)
-            if "reyn" in text and "─" in text:
+            if _GLYPH_AGENT in text:
                 strip = s
                 break
         assert strip is not None, "agent header strip not found"
 
-        # The segment containing 'reyn' must carry the amber colour
+        # The segment containing the agent symbol must carry the amber colour.
         amber_lower = _AMBER.lower()
         found = False
         for seg in strip:
-            if "reyn" in seg.text and seg.style is not None:
+            if _GLYPH_AGENT in seg.text and seg.style is not None:
                 style_str = str(seg.style).lower()
                 if amber_lower in style_str:
                     found = True
                     break
         assert found, (
-            f"agent label 'reyn' must use _AMBER ({_AMBER}); "
+            f"agent symbol {_GLYPH_AGENT!r} must use _AMBER ({_AMBER}); "
             f"got segments={[(s.text, str(s.style)) for s in strip]}"
         )
 

--- a/tests/cli/test_richlog_no_focus_steal.py
+++ b/tests/cli/test_richlog_no_focus_steal.py
@@ -115,8 +115,8 @@ async def test_ctrl_p_turn_nav_still_scrolls_without_focus() -> None:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
         # Lay down two turn headers so anchors exist
-        conv._maybe_write_header("user", "you ", "bold", "dim")
-        conv._maybe_write_header("reyn", "reyn", "bold", "dim")
+        conv._maybe_write_header("user", ">", "bold")
+        conv._maybe_write_header("reyn", "⏺", "bold")
         await pilot.pause()
         assert len(conv._turn_anchors) >= 1
 

--- a/tests/cli/test_streaming_row_body_indent.py
+++ b/tests/cli/test_streaming_row_body_indent.py
@@ -1,21 +1,22 @@
-"""Tier 2: StreamingRow renders body at the 7-cell hanging indent (F-F1 + F-F6).
+"""Tier 2: StreamingRow renders body at the ts-on hanging indent (F-F1 + F-F6).
 
 Wave-9 Topic F findings F1 + F6 (P1): the streaming body Static and
 the sealed Markdown swap had ``padding: 0 0`` — both rendered at
 col 0 — while the final committed markdown went through
-``_write_body`` → ``_indent_body`` which wraps it in
-``Padding(renderable, (0, 0, 0, 7))``. The body visibly jumped 7
-cells to the right at seal() time when ``end_stream`` committed
-through ``_write_agent_markdown_with_fold``.
+``_write_body`` → ``_indent_body``. The body visibly jumped at seal()
+time when ``end_stream`` committed through ``_write_agent_markdown_with_fold``.
 
 Fix: both the streaming Static and the sealed Markdown carry
-``padding: 0 0 0 7`` so they sit at the same hanging indent as
-the committed body. The horizontal jump is gone.
+``padding: 0 0 0 <_BODY_INDENT_COLS>`` so they sit at the same
+hanging indent as the committed body. The horizontal jump is gone.
+
+``_BODY_INDENT_COLS`` in streaming_row.py is the static ts-on value
+(= 8); ``ConversationView._write_body`` applies the dynamic indent
+(ts-on=8 / ts-off=2) for the RichLog path.
 
 Public surfaces tested:
-  - Static widget mounted by ``compose()`` has 7-cell left padding
-  - Markdown widget mounted by ``_apply_markdown_swap`` has 7-cell
-    left padding
+  - Static widget mounted by ``compose()`` has ts-on (8-cell) left padding
+  - Markdown widget mounted by ``_apply_markdown_swap`` has ts-on left padding
   - Local ``_BODY_INDENT_COLS`` matches ``conversation._BODY_INDENT_COLS``
     (= the contract that prevents drift)
 """
@@ -35,7 +36,7 @@ def test_streaming_row_indent_constant_matches_conversation() -> None:
     """Tier 2: local ``_BODY_INDENT_COLS`` matches conversation.py source.
 
     Pins the cross-module contract — both files must agree on the
-    hanging indent or the horizontal jump returns.
+    ts-on hanging indent or the horizontal jump returns.
     """
     from reyn.chat.tui.widgets import conversation as conv_mod
     from reyn.chat.tui.widgets import streaming_row as stream_mod
@@ -47,13 +48,13 @@ def test_streaming_row_indent_constant_matches_conversation() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_static_has_seven_cell_left_padding() -> None:
-    """Tier 2: the streaming Static is rendered at the 7-cell hanging indent."""
+async def test_streaming_static_has_ts_on_left_padding() -> None:
+    """Tier 2: the streaming Static is rendered at the ts-on hanging indent."""
     from textual.widgets import Static
 
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import ConversationView
-    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+    from reyn.chat.tui.widgets.streaming_row import _BODY_INDENT_COLS as _STREAM_INDENT
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
@@ -67,15 +68,15 @@ async def test_streaming_static_has_seven_cell_left_padding() -> None:
         # Textual resolves the CSS padding into a 4-tuple (top, right,
         # bottom, left) on the widget's styles.
         padding = static.styles.padding
-        assert padding.left == 7, (
-            f"streaming Static left-padding should be 7, got {padding.left} "
-            f"(full: {padding!r})"
+        assert padding.left == _STREAM_INDENT, (
+            f"streaming Static left-padding should be {_STREAM_INDENT}, "
+            f"got {padding.left} (full: {padding!r})"
         )
 
 
 @pytest.mark.asyncio
-async def test_sealed_markdown_has_seven_cell_left_padding() -> None:
-    """Tier 2: the sealed Markdown swap also lands at the 7-cell indent.
+async def test_sealed_markdown_has_ts_on_left_padding() -> None:
+    """Tier 2: the sealed Markdown swap also lands at the ts-on indent.
 
     Even though ``end_stream`` removes the row shortly after sealing
     in production, the brief flash of the sealed Markdown should
@@ -86,7 +87,7 @@ async def test_sealed_markdown_has_seven_cell_left_padding() -> None:
 
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import ConversationView
-    from reyn.chat.tui.widgets.streaming_row import StreamingRow
+    from reyn.chat.tui.widgets.streaming_row import _BODY_INDENT_COLS as _STREAM_INDENT
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
@@ -103,7 +104,7 @@ async def test_sealed_markdown_has_seven_cell_left_padding() -> None:
         assert markdowns, "seal should have mounted a Markdown widget"
         md = markdowns[0]
         padding = md.styles.padding
-        assert padding.left == 7, (
-            f"sealed Markdown left-padding should be 7, got {padding.left} "
-            f"(full: {padding!r})"
+        assert padding.left == _STREAM_INDENT, (
+            f"sealed Markdown left-padding should be {_STREAM_INDENT}, "
+            f"got {padding.left} (full: {padding!r})"
         )

--- a/tests/cli/test_turn_anchors_survive_trim.py
+++ b/tests/cli/test_turn_anchors_survive_trim.py
@@ -81,7 +81,7 @@ async def test_anchor_survives_partial_trim_and_projects_correctly() -> None:
         await pilot.pause()
 
         # Now record a header anchor.
-        conv._maybe_write_header("user", "you ", "bold", "dim")
+        conv._maybe_write_header("user", ">", "bold")
         await pilot.pause()
         assert conv._turn_anchors  # at least one anchor recorded
         anchor_abs = conv._turn_anchors[0]
@@ -110,7 +110,7 @@ async def test_anchor_dropped_when_target_trimmed() -> None:
         log = conv.query_one(RichLog)
 
         # Write a header at absolute position N.
-        conv._maybe_write_header("user", "you ", "bold", "dim")
+        conv._maybe_write_header("user", ">", "bold")
         await pilot.pause()
         anchor = conv._turn_anchors[0]
 
@@ -132,8 +132,8 @@ async def test_jump_no_crash_when_all_anchors_trimmed() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
-        conv._maybe_write_header("user", "you ", "bold", "dim")
-        conv._maybe_write_header("reyn", "reyn", "bold", "dim")
+        conv._maybe_write_header("user", ">", "bold")
+        conv._maybe_write_header("reyn", "⏺", "bold")
         await pilot.pause()
         # Force trim to push every anchor out of range
         log._start_line = 999_999
@@ -154,7 +154,7 @@ async def test_clear_resets_trim_warn_latch() -> None:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
-        conv._maybe_write_header("user", "you ", "bold", "dim")
+        conv._maybe_write_header("user", ">", "bold")
         await pilot.pause()
         log._start_line = 999_999
         conv.jump_prev_turn()


### PR DESCRIPTION
**[tui-coder]** — UX: conv pane to Claude Code style

## Summary
- \`▶ you\` / \`◆ reyn\` / \`· system\` → \`>\` / \`⏺\` / \`·\` (1-char symbol only)
- \`─────\` dash rule dropped (= blank line separates turns)
- Timestamp at message head (= dim \`HH:MM\` before symbol)
- F9 toggle: hide timestamps + body indent col 8 → col 2 (= wider content)
- Persists via tui_prefs.json (\`show_timestamps: bool\`)
- Toggle applies to NEW messages only (= past stays as rendered)

## Symbol mapping
| was | now |
|---|---|
| \`▶ you\` | \`>\` |
| \`◆ reyn\` | \`⏺\` |
| \`· system\` | \`·\` |

## Why
User asked for Claude Code-style minimal conv pane. The label text was
redundant (= symbol already differentiates speaker) and the fixed ts
column wasted horizontal space when not needed.

## Test plan
- [x] tests/cli/test_conv_ts_toggle.py — 7 Tier-2 tests (new)
- [x] existing conv / skill / streaming / smoke tests updated for new layout (776 passed)
- [x] ruff clean (all checks passed)
- [x] (skipped — headless CI only) Manual: send msg → symbol-only header; F9 → ts hides + body widens

## F-key note
F9 was free (verified against BINDINGS list — F8 was the last used).