### PR TITLE
fix(audit): exclude file-copy invariant from snapshot detection

### DIFF
--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -53,6 +53,17 @@ SNAPSHOT_RE = re.compile(
     re.DOTALL,
 )
 
+# Exclusion: both sides are dynamic file reads (= file-copy faithfulness
+# invariant, NOT a snapshot pin). Common in tests that verify a preprocessor
+# copies source → target without mutation. Example:
+#   assert copied.read_text() == source.read_text()
+# This is a Tier 2b sub-system invariant (copy correctness), not a snapshot test
+# (which would compare a runtime output against a frozen golden file).
+INVARIANT_FILE_COPY_RE = re.compile(
+    r"assert\b.*\.(read|read_text)\s*\([^)]*\)\s*==.*\.(read|read_text)\s*\(",
+    re.DOTALL,
+)
+
 RULE_NAMES = {
     "tier-docstring",
     "format-pinning",
@@ -261,6 +272,9 @@ class TestAuditor:
         if self._rule_active("snapshot") and not in_scaffold:
             for rel_lineno, line in enumerate(node_lines):
                 if SNAPSHOT_RE.search(line):
+                    # Exclude file-copy invariant pattern (both sides .read_text())
+                    if INVARIANT_FILE_COPY_RE.search(line):
+                        continue
                     abs_lineno = node.lineno + rel_lineno
                     result.findings.append(
                         Finding(


### PR DESCRIPTION
**[lead-coder]** — Tier audit fix coordination の一環、 `scripts/test_tier_audit.py` の false positive 削減。

## Summary
- Rule 6 (snapshot/golden test detection) が file-copy faithfulness invariant pattern を false positive 検出していた問題を修正
- 新 `INVARIANT_FILE_COPY_RE` pattern 追加、 両 side が `.read_text()` / `.read()` の場合は exclude
- 真の snapshot test (= LHS variable result vs RHS golden file read) は引き続き catch

## Root cause
\`tests/test_copy_to_work_preprocessor.py:158\`:
\`\`\`python
assert copied.read_text() == source.read_text()
\`\`\`

= \`copy_to_work\` preprocessor が source → target を faithfully copy するかの **Tier 2b sub-system invariant verify**、 snapshot test (= runtime output vs frozen golden file) ではない。

## Verify (= trio commitment alignment)
- audit re-run: 全 audit errors 879 → 877 (= **-2、 false positive 削減 confirm**)
- \`tests/test_copy_to_work_preprocessor.py\` 全 4 tests ✓ PASS
- \`ruff check .\` → All checks passed

## Context
本 PR は user directive 「fix して欲しい。 みんなで分担しよう」 経由 Tier audit fix multi-author parallel wave の coordination 一環。 lead-coder side 直接 execute scope (= dispatch 後 残 「Snapshot 1 false positive 確認 + audit tool refine」)。

並行 dispatch state:
- ✅ e2e-coder = OS/router/mcp surface 71 errors / 5 PR sequence (#652 + #653 + #656 open / merged)
- ✅ tui-coder = TUI/chat Private 14 errors / 2 files (#651 merged)、 additional dispatch propose (= Missing Tier docstring 104 errors)
- ✅ sandbox_2 = 68 errors / 5 PR + 1 DEFER (#654 + #655 open、 PR C/D/E sequence)

## Test plan
- [x] audit re-run で Snapshot rule false positive 削減 confirm
- [x] tests/test_copy_to_work_preprocessor.py 全 PASS
- [x] ruff check . All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)