### PR TITLE
test(fp-0016): switch private-state asserts to public secret_store/preprocessor accessors

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -150,6 +150,11 @@ class ControlIRExecutor:
         """Return the ResumePlan this executor was constructed with, or None."""
         return self._resume_plan
 
+    @property
+    def secret_store(self):
+        """Read-only accessor for the injected ScopedSecretStore (or None)."""
+        return self._secret_store
+
     def available_ops(self) -> list[ControlIROpSpec]:
         """Return the Control IR op kinds this executor advertises to the LLM.
 

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -129,6 +129,11 @@ class PreprocessorExecutor:
         # (= preserves backward compat for callers that don't supply a store).
         self._secret_store = secret_store
 
+    @property
+    def secret_store(self):
+        """Read-only accessor for the injected ScopedSecretStore (or None)."""
+        return self._secret_store
+
     def _build_op_ctx(self, phase: "Phase", step_index: int):
         """Construct an OpContext for an op_runtime call from this preprocessor."""
         from reyn.op_runtime.context import OpContext

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -262,6 +262,20 @@ class OSRuntime:
     def _history(self, value: list[str]) -> None:
         self._state.history = value
 
+    # ── Public read-only accessors (FP-0016 D wiring verification) ─────────
+    # Tests verify dependency-injection identity ("the store handed in is the
+    # exact object threaded down to executors"). Exposing read-only accessors
+    # lets tests assert that invariant through the public surface instead of
+    # reaching into ``_secret_store`` / ``_preprocessor``.
+
+    @property
+    def secret_store(self):
+        return self._secret_store
+
+    @property
+    def preprocessor(self):
+        return self._preprocessor
+
     # ── Phase setup ────────────────────────────────────────────────────────────
 
     def _build_candidates(self, current_phase: str) -> list[CandidateOutput]:

--- a/tests/test_fp0016_d_secret_store_threading.py
+++ b/tests/test_fp0016_d_secret_store_threading.py
@@ -134,23 +134,23 @@ def test_osruntime_stores_secret_store(tmp_path: Path) -> None:
 
 
 def test_osruntime_propagates_store_to_control_ir_executor(tmp_path: Path) -> None:
-    """Tier 2: OSRuntime threads secret_store into ControlIRExecutor._secret_store."""
+    """Tier 2: OSRuntime threads secret_store into ControlIRExecutor.secret_store."""
     from reyn.kernel.runtime import OSRuntime
 
     skill = _make_minimal_skill()
     store = _make_store(["TOKEN"])
     runtime = OSRuntime(skill, "standard", secret_store=store)
-    assert runtime.control_ir_executor._secret_store is store
+    assert runtime.control_ir_executor.secret_store is store
 
 
 def test_osruntime_propagates_store_to_preprocessor_executor(tmp_path: Path) -> None:
-    """Tier 2: OSRuntime threads secret_store into PreprocessorExecutor._secret_store."""
+    """Tier 2: OSRuntime threads secret_store into PreprocessorExecutor.secret_store."""
     from reyn.kernel.runtime import OSRuntime
 
     skill = _make_minimal_skill()
     store = _make_store(["SECRET_TOKEN"])
     runtime = OSRuntime(skill, "standard", secret_store=store)
-    assert runtime._preprocessor._secret_store is store
+    assert runtime.preprocessor.secret_store is store
 
 
 def test_osruntime_none_store_propagates_as_none(tmp_path: Path) -> None:
@@ -159,9 +159,9 @@ def test_osruntime_none_store_propagates_as_none(tmp_path: Path) -> None:
 
     skill = _make_minimal_skill()
     runtime = OSRuntime(skill, "standard")
-    assert runtime._secret_store is None
-    assert runtime.control_ir_executor._secret_store is None
-    assert runtime._preprocessor._secret_store is None
+    assert runtime.secret_store is None
+    assert runtime.control_ir_executor.secret_store is None
+    assert runtime.preprocessor.secret_store is None
 
 
 # ---------------------------------------------------------------------------
@@ -255,9 +255,9 @@ def test_threading_preserves_identity_not_copy(tmp_path: Path) -> None:
     runtime = OSRuntime(skill, "standard", secret_store=store)
 
     # All three layers must hold the exact same object
-    assert runtime._secret_store is store
-    assert runtime.control_ir_executor._secret_store is store
-    assert runtime._preprocessor._secret_store is store
+    assert runtime.secret_store is store
+    assert runtime.control_ir_executor.secret_store is store
+    assert runtime.preprocessor.secret_store is store
 
     # OpContext built by ControlIRExecutor must also carry same object
     decl = PermissionDecl()
@@ -266,5 +266,5 @@ def test_threading_preserves_identity_not_copy(tmp_path: Path) -> None:
 
     # OpContext built by PreprocessorExecutor must also carry same object
     phase = skill.phases["phase_a"]
-    pre_ctx = runtime._preprocessor._build_op_ctx(phase, step_index=0)
+    pre_ctx = runtime.preprocessor._build_op_ctx(phase, step_index=0)
     assert pre_ctx.secret_store is store


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `tests/test_fp0016_d_secret_store_threading.py`

## Summary
- Resolves 4 Tier-4 private-state violations flagged by `scripts/test_tier_audit.py`:
  - `runtime.control_ir_executor._secret_store is store/None`
  - `runtime._preprocessor._secret_store is store/None`
- Test intent (= dependency-injection identity through Agent → OSRuntime → executors → OpContext) is a real invariant; fix shape per [[feedback_tier_policy_strict_compliance]] = expose public read-only accessors, mirroring the `session_approve_host` precedent from #643.

## OS source changes (read-only accessors only, no behavior change)
- `ControlIRExecutor.secret_store` property → `self._secret_store`
- `PreprocessorExecutor.secret_store` property → `self._secret_store`
- `OSRuntime.secret_store` property → `self._secret_store`
- `OSRuntime.preprocessor` property → `self._preprocessor`

## Test plan
- [x] `pytest tests/test_fp0016_d_secret_store_threading.py -q` → 15/15 pass
- [x] `ruff check .` → clean
- [x] `python scripts/test_tier_audit.py tests/test_fp0016_d_secret_store_threading.py` → 0 errors (was 4)
- [x] Full rootdir `pytest -q -x` → 5386 pass / 1 pre-existing baseline failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` — unrelated to this PR)

Refs PR-12 Tier audit fix sequence: #652 (12a) #653 (12b) #656 (12d) #658 (12e).