### PR TITLE
refactor(tests/fp): replace unittest.mock with monkeypatch + real callable (Tier audit fix)

### DIFF
--- a/tests/test_fp0016_e_agent_id.py
+++ b/tests/test_fp0016_e_agent_id.py
@@ -15,8 +15,6 @@ a Fake module attribute swap).
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from reyn.config import (
@@ -124,7 +122,7 @@ def test_event_log_agent_id_property_readable() -> None:
 # ── 3. MCPClient X-Reyn-Agent-Id header ────────────────────────────────────
 
 
-def test_mcp_client_injects_x_reyn_agent_id_header() -> None:
+def test_mcp_client_injects_x_reyn_agent_id_header(monkeypatch) -> None:
     """Tier 2: MCPClient(agent_id=...) adds X-Reyn-Agent-Id to HTTP headers."""
     from reyn.mcp_client import MCPClient
 
@@ -138,13 +136,13 @@ def test_mcp_client_injects_x_reyn_agent_id_header() -> None:
         {"type": "http", "url": "https://example.com/mcp"},
         agent_id="reyn/test-agent",
     )
-    with patch("mcp.client.streamable_http.streamablehttp_client",
-               new=fake_streamablehttp_client):
-        client._open_http()
+    monkeypatch.setattr("mcp.client.streamable_http.streamablehttp_client",
+                        fake_streamablehttp_client)
+    client._open_http()
     assert captured["headers"].get("X-Reyn-Agent-Id") == "reyn/test-agent"
 
 
-def test_mcp_client_no_agent_id_no_header() -> None:
+def test_mcp_client_no_agent_id_no_header(monkeypatch) -> None:
     """Tier 2: agent_id=None → no X-Reyn-Agent-Id header (= backwards compat)."""
     from reyn.mcp_client import MCPClient
 
@@ -155,13 +153,13 @@ def test_mcp_client_no_agent_id_no_header() -> None:
         return None
 
     client = MCPClient({"type": "http", "url": "https://example.com/mcp"})
-    with patch("mcp.client.streamable_http.streamablehttp_client",
-               new=fake_streamablehttp_client):
-        client._open_http()
+    monkeypatch.setattr("mcp.client.streamable_http.streamablehttp_client",
+                        fake_streamablehttp_client)
+    client._open_http()
     assert "X-Reyn-Agent-Id" not in (captured["headers"] or {})
 
 
-def test_mcp_client_operator_header_wins() -> None:
+def test_mcp_client_operator_header_wins(monkeypatch) -> None:
     """Tier 2: operator-set X-Reyn-Agent-Id in config wins over agent_id arg.
 
     Operators may need to spoof for tests or proxy in production; respect
@@ -183,9 +181,9 @@ def test_mcp_client_operator_header_wins() -> None:
         },
         agent_id="reyn/auto",
     )
-    with patch("mcp.client.streamable_http.streamablehttp_client",
-               new=fake_streamablehttp_client):
-        client._open_http()
+    monkeypatch.setattr("mcp.client.streamable_http.streamablehttp_client",
+                        fake_streamablehttp_client)
+    client._open_http()
     assert captured["headers"]["X-Reyn-Agent-Id"] == "reyn/spoofed"
 
 

--- a/tests/test_fp0036_live_runner.py
+++ b/tests/test_fp0036_live_runner.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import asyncio
 import shutil
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -144,8 +143,8 @@ async def test_single_turn_scenario_returns_reply(tmp_path, monkeypatch):
     runner_fn = _make_live_runner_fn(tmp_path, agent_name="default")
     assert runner_fn is not None, "_build_live_runner must return a callable"
 
-    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=fake_llm):
-        result = await runner_fn(scenario)
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+    result = await runner_fn(scenario)
 
     assert result.scenario_id == "s1"
     assert result.reply_text, "reply_text must be non-empty for a successful turn"
@@ -179,8 +178,8 @@ async def test_multi_turn_scenario_concatenates_replies(tmp_path, monkeypatch):
     runner_fn = _make_live_runner_fn(tmp_path, agent_name="default")
     assert runner_fn is not None
 
-    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=fake_llm):
-        result = await runner_fn(scenario)
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+    result = await runner_fn(scenario)
 
     assert result.scenario_id == "s2"
     # Both replies must be present in the output.
@@ -227,15 +226,14 @@ async def test_event_isolation_between_scenarios(tmp_path, monkeypatch):
     scenario_a = _make_scenario("iso-a", input_text="Turn A")
     scenario_b = _make_scenario("iso-b", input_text="Turn B")
 
-    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=fake_llm):
-        result_a = await runner_fn(scenario_a)
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+    result_a = await runner_fn(scenario_a)
 
     # The chat events dir should exist after scenario A.
     events_chat_dir = tmp_path / ".reyn" / "events" / "agents" / "default" / "chat"
 
     # After scenario B is run, the runner wipes the event dir first.
-    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=fake_llm):
-        result_b = await runner_fn(scenario_b)
+    result_b = await runner_fn(scenario_b)
 
     # Scenario B's events list must NOT contain events from scenario A.
     # Since the wipe removes all prior files, events in result_b are only
@@ -361,8 +359,8 @@ async def test_history_jsonl_wiped_before_scenario(tmp_path, monkeypatch):
 
     scenario = _make_scenario("hist-s1", input_text="What is fresh?")
 
-    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=capturing_llm):
-        result = await runner_fn(scenario)
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", capturing_llm)
+    result = await runner_fn(scenario)
 
     # The LLM must NOT have seen any of the stale entries in any call.
     # (Cannot assert history_path absence after the run because the session


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix dispatch from lead-coder, FP-framework subset (= 2 files / 10 errors).

## Summary

Both files used \`from unittest.mock import patch\` to inject already-real async callables. Mechanical rewrite: drop the import, add \`monkeypatch\` fixture param, swap \`with patch(...)\` for \`monkeypatch.setattr(...)\`.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Mock vs Fake errors | 10 | **0** |
| Tests passing in scope | 23 | **23** |

## Per-file fix shape

**\`tests/test_fp0036_live_runner.py\` (6 violations)**
- 5 \`with patch("reyn.chat.router_loop.call_llm_tools", side_effect=fake_fn)\` sites across 4 test functions → \`monkeypatch.setattr\`
- All 4 test functions already had \`monkeypatch\` in their signatures
- The injected callables (\`fake_llm\`, \`capturing_llm\`) were already real async — no MagicMock was in use

**\`tests/test_fp0016_e_agent_id.py\` (4 violations)**
- 3 \`with patch("mcp.client.streamable_http.streamablehttp_client", new=real_callable)\` sites → \`monkeypatch.setattr\`
- Added \`monkeypatch\` fixture param to 3 MCP test functions
- Note: \`new=real_callable\` was already policy-correct in spirit (real callable, not MagicMock), but the audit flags \`with patch(...)\` mechanically regardless of \`new=\` contents

## Test plan

- [x] \`venv/bin/pytest tests/test_fp0036_live_runner.py tests/test_fp0016_e_agent_id.py\`: 23/23 passed
- [x] \`python scripts/test_tier_audit.py <2 files>\`: 0 errors
- [x] Broader regression \`-k "fp0036 or fp0016"\`: 326 passed / 2 skipped / 0 failed
- [x] No \`unittest.mock\` imports remaining

## Implementation notes

Sonnet sub-agent under user-approved 3-parallel directive. Hard-cap respected (= ≤50 tool uses, ≤15 min). 1 deliverable (= 2 files fixed). All test sweep + tier audit run by sub-agent before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)