### PR TITLE
fix(test): tier docstring — tests/cli/test_focus_restore.py (Tier audit mechanical)

### DIFF
--- a/tests/cli/test_focus_restore.py
+++ b/tests/cli/test_focus_restore.py
@@ -49,7 +49,7 @@ def _make_app() -> ReynTUIApp:
 
 @pytest.mark.asyncio
 async def test_escape_from_right_panel_focuses_input() -> None:
-    """Esc inside the right panel returns focus to the input TextArea.
+    """Tier 2b: Esc inside the right panel returns focus to the input TextArea.
 
     Reproduces the previous trap: the user opens the panel, focus moves
     into it, and the standard "back out" key (Esc) used to do nothing.
@@ -83,7 +83,7 @@ async def test_escape_from_right_panel_focuses_input() -> None:
 
 @pytest.mark.asyncio
 async def test_intervention_widget_submit_restores_input_focus() -> None:
-    """After ``InterventionWidget._submit`` removes itself, focus is on input.
+    """Tier 2b: After ``InterventionWidget._submit`` removes itself, focus is on input.
 
     The chip-button submit path explicitly calls ``focus_input()`` after
     ``self.remove()``. Without that, Textual's auto-focus walker can
@@ -126,7 +126,7 @@ async def test_intervention_widget_submit_restores_input_focus() -> None:
 
 @pytest.mark.asyncio
 async def test_intervention_resolved_handler_restores_input_focus() -> None:
-    """The text-input route ``_on_intervention_resolved`` also restores focus.
+    """Tier 2b: The text-input route ``_on_intervention_resolved`` also restores focus.
 
     Mirrors the chip-button path: when the user answers an intervention
     by typing into the InputBar (Enter routes through the session, not


### PR DESCRIPTION
**[tui-coder]** — Mechanical Tier docstring fix; no logic changes.

## Summary

- `tests/cli/test_focus_restore.py`: add `Tier 2b:` prefix to the first docstring line of all 3 tests (`test_escape_from_right_panel_focuses_input`, `test_intervention_widget_submit_restores_input_focus`, `test_intervention_resolved_handler_restores_input_focus`).
- Focus restore tests exercise the TUI focus management subsystem (OS-level widget invariant) → **Tier 2b**.
- `python scripts/test_tier_audit.py tests/cli/test_focus_restore.py` → 3/3 OK, exit 0.

## Test plan

- [x] `python scripts/test_tier_audit.py tests/cli/test_focus_restore.py` → 0 errors
- [x] `pytest tests/cli/test_focus_restore.py -v` → 3 passed
- [x] `ruff check tests/cli/test_focus_restore.py` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)