### PR TITLE
fix(test): tier docstring — tests/cli/test_error_box_left_bar.py (Tier audit mechanical)

### DIFF
--- a/tests/cli/test_error_box_left_bar.py
+++ b/tests/cli/test_error_box_left_bar.py
@@ -38,7 +38,7 @@ def _make_app() -> ReynTUIApp:
 
 @pytest.mark.asyncio
 async def test_error_box_declares_left_border() -> None:
-    """An ErrorBox mounted in the conv pane has a coloured left border.
+    """Tier 2b: An ErrorBox mounted in the conv pane has a coloured left border.
 
     Pinned at the computed-styles level so a refactor that moves the rule
     out of ``DEFAULT_CSS`` (and forgets to re-add it elsewhere) fails fast.
@@ -68,7 +68,7 @@ async def test_error_box_declares_left_border() -> None:
 
 @pytest.mark.asyncio
 async def test_error_box_border_color_matches_header_red() -> None:
-    """The left bar uses the same hue family as the header text.
+    """Tier 2b: The left bar uses the same hue family as the header text.
 
     Visual consistency check: the bar is the *non-color* channel, but
     when colour IS available it must agree with the header — otherwise
@@ -94,7 +94,7 @@ async def test_error_box_border_color_matches_header_red() -> None:
 
 @pytest.mark.asyncio
 async def test_error_box_left_bar_visible_in_render() -> None:
-    """The border actually renders — Textual reserves a column for it.
+    """Tier 2b: The border actually renders — Textual reserves a column for it.
 
     Sanity check beyond the styles property: the widget's region must
     include the 1-cell border on its left edge. Without the border the


### PR DESCRIPTION
**[tui-coder]** — Tier docstring mechanical fix.

## Summary

- Added `Tier 2b:` prefix to the docstring first line of all 3 tests in `tests/cli/test_error_box_left_bar.py`
- ErrorBox left-bar visual subsystem invariant tests classify as Tier 2b (OS invariant — visual subsystem)
- No logic, no production code, no other test files touched

## Verification

- `python scripts/test_tier_audit.py tests/cli/test_error_box_left_bar.py` → 3/3 OK, 0 errors
- `ruff check tests/cli/test_error_box_left_bar.py` → All checks passed

## Test plan

- [x] `python scripts/test_tier_audit.py tests/cli/test_error_box_left_bar.py` — 0 errors
- [x] `ruff check tests/cli/test_error_box_left_bar.py` — clean
- [x] (skipped — pytest run requires Textual async headless env not available in this worktree; tier audit + ruff are sufficient for a docstring-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)