### PR TITLE
fix(test): tier docstring — tests/cli/test_header_grouping_wall_clock.py (Tier audit mechanical)

### DIFF
--- a/tests/cli/test_header_grouping_wall_clock.py
+++ b/tests/cli/test_header_grouping_wall_clock.py
@@ -70,7 +70,7 @@ async def test_last_speaker_at_is_wall_clock_after_header_write() -> None:
 
 @pytest.mark.asyncio
 async def test_same_speaker_within_window_groups_under_one_header() -> None:
-    """Tier 2 (regression): same-speaker burst within 60s shares header."""
+    """Tier 2b: same-speaker burst within 60s shares header (regression guard)."""
     from reyn.chat.outbox import OutboxMessage
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import ConversationView
@@ -95,7 +95,7 @@ async def test_same_speaker_within_window_groups_under_one_header() -> None:
 
 @pytest.mark.asyncio
 async def test_same_speaker_past_window_emits_new_header() -> None:
-    """Tier 2 (regression): same-speaker past 60s emits a new header.
+    """Tier 2b: same-speaker past 60s emits a new header (regression guard).
 
     Simulated by back-dating ``_last_speaker_at``.
     """


### PR DESCRIPTION
**[tui-coder]** — Tier docstring mechanical fix.

## Summary

- Two test docstrings in `tests/cli/test_header_grouping_wall_clock.py` had `Tier 2 (regression): ...` as their first line, which does not match the required `Tier N:` prefix pattern checked by `test_tier_audit.py`.
- Changed both to `Tier 2b: ...` (conv pane header speaker grouping wall-clock subsystem = Tier 2b).
- No logic changes; audit-only fix.

## Verification

```
python scripts/test_tier_audit.py tests/cli/test_header_grouping_wall_clock.py
→ 3/3 OK, 0 errors

ruff check tests/cli/test_header_grouping_wall_clock.py
→ All checks passed!
```

## Test plan

- [x] `python scripts/test_tier_audit.py tests/cli/test_header_grouping_wall_clock.py` — 0 errors
- [x] `ruff check tests/cli/test_header_grouping_wall_clock.py` — clean
- [x] (skipped — pytest requires live TUI runtime not available in CI dispatch context) `pytest tests/cli/test_header_grouping_wall_clock.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)