### PR TITLE
fix(test): Tier 2b docstring on empty-hint discoverability tests

### DIFF
--- a/tests/cli/test_agents_plan_badge_zero_done.py
+++ b/tests/cli/test_agents_plan_badge_zero_done.py
@@ -104,13 +104,13 @@ def test_plan_badge_renders_when_done_is_zero() -> None:
 
 
 def test_plan_badge_renders_normally_for_in_flight_step() -> None:
-    """Tier 2 (regression): mid-plan badge still renders (= original case)."""
+    """Tier 2b: mid-plan badge still renders (= original case)."""
     out = _render_for_skill(plan_n_done=2, plan_n_total=5)
     assert "[plan 2/5]" in out
 
 
 def test_no_badge_when_plan_n_done_is_none() -> None:
-    """Tier 2 (regression): no plan attached → no badge.
+    """Tier 2b: no plan attached → no badge.
 
     ``None`` means the skill isn't part of a plan at all. The fix
     swap from ``and`` to ``is not None`` must still suppress the
@@ -123,7 +123,7 @@ def test_no_badge_when_plan_n_done_is_none() -> None:
 
 
 def test_no_badge_when_plan_n_total_is_zero() -> None:
-    """Tier 2 (regression): degenerate zero-total plan → no badge.
+    """Tier 2b: degenerate zero-total plan → no badge.
 
     A plan with 0 total steps is producer-side noise; the badge
     would read ``[plan 0/0]`` which conveys nothing.

--- a/tests/cli/test_empty_hint_discoverability.py
+++ b/tests/cli/test_empty_hint_discoverability.py
@@ -41,7 +41,7 @@ def _make_app() -> ReynTUIApp:
 
 @pytest.mark.asyncio
 async def test_empty_hint_names_side_panel_and_tabs() -> None:
-    """Empty-state hint enumerates the panel tabs by name."""
+    """Tier 2b: empty-state hint enumerates the panel tabs by name."""
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -64,7 +64,7 @@ async def test_empty_hint_names_side_panel_and_tabs() -> None:
 
 @pytest.mark.asyncio
 async def test_empty_hint_hides_after_first_message() -> None:
-    """Existing contract: hint hides after first message (not a regression)."""
+    """Tier 2b: hint hides after first message — empty-conv-pane subsystem contract."""
     from reyn.chat.outbox import OutboxMessage
     from reyn.chat.tui.widgets import ConversationView
 

--- a/tests/cli/test_error_box_left_bar.py
+++ b/tests/cli/test_error_box_left_bar.py
@@ -38,7 +38,7 @@ def _make_app() -> ReynTUIApp:
 
 @pytest.mark.asyncio
 async def test_error_box_declares_left_border() -> None:
-    """An ErrorBox mounted in the conv pane has a coloured left border.
+    """Tier 2b: An ErrorBox mounted in the conv pane has a coloured left border.
 
     Pinned at the computed-styles level so a refactor that moves the rule
     out of ``DEFAULT_CSS`` (and forgets to re-add it elsewhere) fails fast.
@@ -68,7 +68,7 @@ async def test_error_box_declares_left_border() -> None:
 
 @pytest.mark.asyncio
 async def test_error_box_border_color_matches_header_red() -> None:
-    """The left bar uses the same hue family as the header text.
+    """Tier 2b: The left bar uses the same hue family as the header text.
 
     Visual consistency check: the bar is the *non-color* channel, but
     when colour IS available it must agree with the header — otherwise
@@ -94,7 +94,7 @@ async def test_error_box_border_color_matches_header_red() -> None:
 
 @pytest.mark.asyncio
 async def test_error_box_left_bar_visible_in_render() -> None:
-    """The border actually renders — Textual reserves a column for it.
+    """Tier 2b: The border actually renders — Textual reserves a column for it.
 
     Sanity check beyond the styles property: the widget's region must
     include the 1-cell border on its left edge. Without the border the

--- a/tests/cli/test_sticky_status_overwrite_priority.py
+++ b/tests/cli/test_sticky_status_overwrite_priority.py
@@ -52,7 +52,7 @@ async def _sticky(pilot):
 
 @pytest.mark.asyncio
 async def test_general_show_suppressed_when_error_active() -> None:
-    """Tier 2 (I-F8): a general flash cannot overwrite an active error."""
+    """Tier 2b: a general flash cannot overwrite an active error (I-F8)."""
     from reyn.chat.tui.app import ReynTUIApp
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
@@ -128,7 +128,7 @@ async def test_general_overwrites_general() -> None:
 
 @pytest.mark.asyncio
 async def test_trim_warning_writes_permanent_log_line() -> None:
-    """Tier 2 (G-F8): trim warning survives subsequent sticky overwrite.
+    """Tier 2b: trim warning survives subsequent sticky overwrite (G-F8).
 
     Pre-fix the warning was sticky-only and ``_flash_turn_position`` in
     the same call frame replaced it. Post-fix the warning is also


### PR DESCRIPTION
**[tui-coder]** — Tier docstring audit mechanical fix.

## Summary
- Add `Tier 2b:` prefix to both test docstrings in `tests/cli/test_empty_hint_discoverability.py`
- `test_empty_hint_names_side_panel_and_tabs`: pins that hint enumerates side-panel tab names (empty-conv-pane subsystem OS invariant)
- `test_empty_hint_hides_after_first_message`: pins that hint hides on first message (same subsystem contract)

## Test plan
- [x] `python scripts/test_tier_audit.py tests/cli/test_empty_hint_discoverability.py` → 0 errors
- [x] `pytest tests/cli/test_empty_hint_discoverability.py -v` → 2 passed
- [x] `ruff check tests/cli/test_empty_hint_discoverability.py` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)