### PR TITLE
fix(tests): tier audit mechanical fixes — test_router_loop_routing_decided

### DIFF
--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -220,8 +220,7 @@ def test_routing_decided_emitted_for_invoke_action():
     )
 
     events = _routing_decided_events(host)
-    assert len(events) == 1, f"Expected 1 routing_decided event, got {events}"
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "skill__foo"
     assert ev["source"] == "invoke_action"
     assert ev["outcome"] == "success"
@@ -265,8 +264,7 @@ def test_routing_decided_emitted_for_hot_list_alias():
     )
 
     events = _routing_decided_events(host)
-    assert len(events) == 1, f"Expected 1 routing_decided event, got {events}"
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "skill__bar"
     assert ev["source"] == "hot_list_alias"
     assert ev["outcome"] == "success"
@@ -304,8 +302,7 @@ def test_routing_decided_outcome_error_on_tool_error():
     )
 
     events = _routing_decided_events(host)
-    assert len(events) == 1, f"Expected 1 routing_decided event, got {events}"
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "bogus_category__action"
     assert ev["outcome"] == "error", (
         f"Expected outcome='error' for unknown action, got {ev['outcome']!r}"
@@ -391,8 +388,7 @@ def test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name():
         ],
     )
     events = _routing_decided_events(host)
-    assert len(events) == 1
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "bogus_category__action"
     assert ev["source"] == "ars_direct", (
         f"Expected source='ars_direct' for qualified name not in catalog, "
@@ -423,8 +419,7 @@ def test_routing_decided_source_hot_list_alias_only_when_in_catalog():
         ],
     )
     events = _routing_decided_events(host)
-    assert len(events) == 1
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "skill__bar"
     assert ev["source"] == "ars_direct", (
         f"Without hot-list landing, source must be 'ars_direct' not "


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `tests/test_router_loop_routing_decided.py`

## Summary
- 5 mechanical format-pinning violations resolved: `len(events) == 1` + `events[0]` → `(ev,) = events` tuple-unpack.
- 1 remaining error (module-level `from unittest.mock import patch` for `call_llm_tools` patching) is **out-of-scope** — requires LLMReplay Fake lift, not a mechanical fix. The `patch` usage wraps a real coroutine function, not a MagicMock, but the import still triggers the audit rule.
- No source changes.
- Errors: 6 → 1 (1 remaining is out-of-scope).

## Test plan
- [x] `pytest tests/test_router_loop_routing_decided.py -q` green (7 passed)
- [x] `ruff check .` green
- [x] `python scripts/test_tier_audit.py tests/test_router_loop_routing_decided.py` → 1 error remaining, all out-of-scope (Mock vs Fake / LLMReplay lift)

Refs PR-12 through PR-15 Tier audit sequence.