### PR TITLE
fix(test): tier docstring — tests/cli/test_cost_suffix_right_align.py (Tier audit mechanical)

### DIFF
--- a/tests/cli/test_cost_suffix_right_align.py
+++ b/tests/cli/test_cost_suffix_right_align.py
@@ -46,7 +46,7 @@ def _line_text(log: RichLog, index: int) -> str:
 
 @pytest.mark.asyncio
 async def test_render_cost_suffix_is_right_aligned():
-    """Cost suffix renders at the right edge of the RichLog content region.
+    """Tier 2b: cost suffix renders at the right edge of the RichLog content region.
 
     Drives ``conv.render_cost_suffix`` directly with known values, then
     inspects the resulting RichLog Strip: the visible glyphs of the suffix
@@ -95,7 +95,7 @@ async def test_render_cost_suffix_is_right_aligned():
 
 @pytest.mark.asyncio
 async def test_render_cost_suffix_no_crash_on_zero_values():
-    """Cost suffix with zero deltas still renders without raising.
+    """Tier 2b: cost suffix with zero deltas still renders without raising.
 
     The caller (``app._maybe_render_cost_suffix``) skips the call when
     both deltas are zero, but this is a defence-in-depth check that the


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- Add `Tier 2b:` prefix to both test docstring first lines in `tests/cli/test_cost_suffix_right_align.py`
- Satisfies `test_tier_audit.py` policy (testing.ja.md: each test docstring first line must declare its Tier)
- No logic changes, no production edits

## Test plan

- [x] `python scripts/test_tier_audit.py tests/cli/test_cost_suffix_right_align.py` → 0 errors
- [x] `ruff check tests/cli/test_cost_suffix_right_align.py` → All checks passed
- [x] (skipped — pytest run requires full TUI env with litellm proxy; docstring-only change carries no runtime risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)