### PR TITLE
fix(tests): add Tier 2b docstring prefix to cost-suffix partial-marker tests

### DIFF
--- a/tests/cli/test_cost_suffix_partial_marker.py
+++ b/tests/cli/test_cost_suffix_partial_marker.py
@@ -44,7 +44,7 @@ def _last_rendered_text(conv: ConversationView) -> str:
 
 @pytest.mark.asyncio
 async def test_cost_suffix_partial_prefixes_numbers_with_tilde():
-    """``partial=True`` → all three numeric segments carry the ``~`` prefix."""
+    """Tier 2b: ``partial=True`` → all three numeric segments carry the ``~`` prefix."""
     app = _ConvOnlyApp()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -62,7 +62,7 @@ async def test_cost_suffix_partial_prefixes_numbers_with_tilde():
 
 @pytest.mark.asyncio
 async def test_cost_suffix_default_has_no_tilde():
-    """Default (``partial=False``) emits the unchanged shape."""
+    """Tier 2b: Default (``partial=False``) emits the unchanged shape."""
     app = _ConvOnlyApp()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — Tier docstring fix for `tests/cli/test_cost_suffix_partial_marker.py`.

## Summary

- Two test functions (`test_cost_suffix_partial_prefixes_numbers_with_tilde`, `test_cost_suffix_default_has_no_tilde`) were missing the mandatory `Tier N:` first-line docstring prefix.
- Added `Tier 2b:` prefix to both docstrings (cost suffix partial marker rendering = OS invariant subsystem).
- No logic, production code, or test behaviour changes.

## Test plan

- [x] `python scripts/test_tier_audit.py tests/cli/test_cost_suffix_partial_marker.py` → 2 OK, 0 errors
- [x] `pytest tests/cli/test_cost_suffix_partial_marker.py -v` → 2 passed
- [x] `ruff check tests/cli/test_cost_suffix_partial_marker.py` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)