### PR TITLE
fix(tests): Tier 2b docstring prefix — async-stack-panel plan lifecycle

### DIFF
--- a/tests/cli/test_async_stack_panel_plan_lifecycle.py
+++ b/tests/cli/test_async_stack_panel_plan_lifecycle.py
@@ -110,7 +110,7 @@ async def test_plan_complete_removes_async_stack_row() -> None:
 
 @pytest.mark.asyncio
 async def test_non_plan_system_message_does_not_touch_async_stack() -> None:
-    """Tier 2 (regression): generic system message → no panel side-effect.
+    """Tier 2b: generic system message → no AsyncStackPanel side-effect.
 
     Lifecycle markers (= ``[↑ N turns compacted]``), slash-command
     output, attach/detach notices are all ``kind="system"`` but
@@ -144,7 +144,7 @@ async def test_non_plan_system_message_does_not_touch_async_stack() -> None:
 
 @pytest.mark.asyncio
 async def test_missing_plan_id_is_silent_noop() -> None:
-    """Tier 2 (defensive): plan_summary without plan_id meta → silent.
+    """Tier 2b: plan_summary without plan_id meta → silent no-op.
 
     Guard against producer-side shape drift — if the outbox emitter
     drops the plan_id for some reason, the handler should silently


### PR DESCRIPTION
**[tui-coder]** — Tier docstring mechanical fix for `tests/cli/test_async_stack_panel_plan_lifecycle.py`.

## Summary

- `test_non_plan_system_message_does_not_touch_async_stack`: `Tier 2 (regression):` → `Tier 2b:`
- `test_missing_plan_id_is_silent_noop`: `Tier 2 (defensive):` → `Tier 2b:`
- No logic changes; intent text lightly updated for clarity

## Verification

```
python scripts/test_tier_audit.py tests/cli/test_async_stack_panel_plan_lifecycle.py
# Summary: 4 tests inspected — ✓ OK: 4, ✗ errors: 0

pytest tests/cli/test_async_stack_panel_plan_lifecycle.py -v
# 4 passed in 2.88s

ruff check tests/cli/test_async_stack_panel_plan_lifecycle.py
# All checks passed!
```

## Test plan

- [x] `test_tier_audit.py` exits 0 — 4/4 OK
- [x] `pytest` 4/4 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)