### PR TITLE
fix(tests): Tier audit fix for test_describe_action_resource_description

### DIFF
--- a/tests/test_describe_action_resource_description.py
+++ b/tests/test_describe_action_resource_description.py
@@ -74,8 +74,8 @@ def _describe(qualified_name: str, ctx: ToolContext) -> dict:
 
 
 def test_skill_describe_returns_skill_description():
-    """Tier 2 (B42-NF-W7-1): describe_action(skill__X) returns the SKILL's
-    description (= skill.md frontmatter), NOT invoke_skill's dispatcher
+    """Tier 2: describe_action(skill__X) returns the SKILL's description
+    (= skill.md frontmatter, B42-NF-W7-1), NOT invoke_skill's dispatcher
     instructions.
     """
     actual_desc = (
@@ -126,8 +126,8 @@ def test_skill_describe_unknown_skill_falls_back_to_dispatcher():
 
 
 def test_agent_peer_describe_returns_agent_description():
-    """Tier 2 (B42-NF-W7-1): describe_action(agent.peer__X) returns the
-    AGENT's description / role, not delegate_to_agent's dispatcher text.
+    """Tier 2: describe_action(agent.peer__X) returns the AGENT's
+    description / role (B42-NF-W7-1), not delegate_to_agent's dispatcher text.
     """
     actual_desc = "Researches topics by querying multiple sources."
     ctx = _make_ctx(agents=[
@@ -164,8 +164,8 @@ def test_agent_peer_describe_missing_both_falls_back_to_dispatcher():
 
 
 def test_mcp_tool_describe_returns_tool_description():
-    """Tier 2 (B42-NF-W7-1): describe_action(mcp.tool__server.tool) returns
-    the MCP tool's declared description, not call_mcp_tool's dispatcher text.
+    """Tier 2: describe_action(mcp.tool__server.tool) returns the MCP tool's
+    declared description (B42-NF-W7-1), not call_mcp_tool's dispatcher text.
     """
     actual_desc = "Search GitHub pull requests matching a query."
     ctx = _make_ctx(mcp_servers=[
@@ -199,8 +199,8 @@ def test_mcp_tool_describe_missing_description_falls_back():
 
 
 def test_mcp_server_describe_returns_server_description():
-    """Tier 2 (B42-NF-W7-1): describe_action(mcp.server__X) returns the
-    server's description, not list_mcp_tools' dispatcher text.
+    """Tier 2: describe_action(mcp.server__X) returns the server's
+    description (B42-NF-W7-1), not list_mcp_tools' dispatcher text.
     """
     actual_desc = "GitHub MCP server — search/comment/PR ops."
     ctx = _make_ctx(mcp_servers=[
@@ -214,8 +214,8 @@ def test_mcp_server_describe_returns_server_description():
 
 
 def test_operation_describe_unchanged_by_resource_description_fix():
-    """Tier 2 (regression guard): operation-category actions (file__read,
-    web__fetch, etc.) continue to use ``target.description`` — the fix
+    """Tier 2: operation-category actions (file__read, web__fetch, etc.)
+    continue to use ``target.description`` (regression guard) — the fix
     must not change their resolution path.
     """
     ctx = _make_ctx()


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `tests/test_describe_action_resource_description.py`

## Summary
- 5 mechanical violations resolved: docstrings using `Tier 2 (...)` format reformatted to `Tier 2: ...` (required pattern).
- No source changes.
- 0 audit errors (was 5).

Refs PR-12 through PR-15.

## Test plan
- [x] `python -m pytest tests/test_describe_action_resource_description.py -q` — 10 passed
- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_describe_action_resource_description.py` — 0 errors (was 5)