### PR TITLE
fix(tests): Tier audit fix for test_session_router_history_slicing

### DIFF
--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -89,16 +89,15 @@ def test_history_fits_in_window_returns_unique_turns(tmp_path):
 
     msgs = session._build_history_for_router()
     # Must equal exactly 7 entries — pre-fix would have produced 14.
-    assert len(msgs) == 7, (
-        f"expected 7 messages (= 1-for-1 with history), got {len(msgs)}; "
-        "head+tail overlap duplication regression"
-    )
-    # No duplicates by content.
-    user_texts = [m["content"] for m in msgs if m["role"] == "user"]
-    assert user_texts == ["hello", "what can you do?", "tell me about yourself", "list available skills"]
-    assert len(set(user_texts)) == len(user_texts), (
-        "user texts should be unique; duplication detected"
-    )
+    assert msgs == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "what can you do?"},
+        {"role": "assistant", "content": "I can help with..."},
+        {"role": "user", "content": "tell me about yourself"},
+        {"role": "assistant", "content": "I am a Reyn agent."},
+        {"role": "user", "content": "list available skills"},
+    ], "head+tail overlap duplication regression: expected 7 unique messages"
 
 
 def test_empty_history_returns_empty_messages(tmp_path):
@@ -113,8 +112,8 @@ def test_single_turn_returns_single_message(tmp_path):
     session = _make_session(tmp_path)
     _push_turn(session, "user", "hello")
     msgs = session._build_history_for_router()
-    assert len(msgs) == 1
-    assert msgs[0] == {"role": "user", "content": "hello"}
+    (only,) = msgs
+    assert only == {"role": "user", "content": "hello"}
 
 
 # ── Boundary: exactly at head + tail ────────────────────────────────────────
@@ -132,7 +131,6 @@ def test_exactly_head_plus_tail_no_duplication(tmp_path):
     for i in range(4):
         _push_turn(session, "user" if i % 2 == 0 else "agent", f"msg-{i}")
     msgs = session._build_history_for_router()
-    assert len(msgs) == 4, f"expected 4, got {len(msgs)}"
     assert [m["content"] for m in msgs] == ["msg-0", "msg-1", "msg-2", "msg-3"]
 
 
@@ -149,7 +147,6 @@ def test_history_exceeds_window_applies_head_tail_slice(tmp_path):
         _push_turn(session, "user" if i % 2 == 0 else "agent", f"msg-{i}")
     # 8 turns > 2+2=4 → head=msg-0..1, tail=msg-6..7
     msgs = session._build_history_for_router()
-    assert len(msgs) == 4
     assert [m["content"] for m in msgs] == ["msg-0", "msg-1", "msg-6", "msg-7"]
 
 
@@ -161,5 +158,4 @@ def test_zero_tail_size_no_overlap_in_unfit_branch(tmp_path):
     for i in range(5):
         _push_turn(session, "user", f"msg-{i}")
     msgs = session._build_history_for_router()
-    assert len(msgs) == 2
     assert [m["content"] for m in msgs] == ["msg-0", "msg-1"]


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `tests/test_session_router_history_slicing.py`

## Summary
- 5 mechanical violations resolved (all `len(x) == N` format-pinning).
- Transforms: `len==7` → list-equality, `len==1`+index → `(only,)=`, `len==4`/`len==2` redundant checks removed (list-equality already pins count).
- No source changes.
- 0 audit errors (was 5).

## Test plan
- [x] verify trio green: `pytest tests/test_session_router_history_slicing.py -q` → 6 passed; `ruff check .` → clean; `test_tier_audit.py` → 0 errors

Refs PR-12 through PR-15.