### PR TITLE
fix(tests): lift call_llm_tools mock patches to monkeypatch.setattr (PR-16a)

### DIFF
--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -82,10 +82,13 @@ def test_user_message_chitchat_e2e(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True  # enable status messages
 
+    async def fake_llm(*args, **kwargs):
+        return _text_result("hi")
+
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+
     async def run():
-        with patch("reyn.chat.router_loop.call_llm_tools", new_callable=AsyncMock) as mock_llm:
-            mock_llm.return_value = _text_result("hi")
-            await session._handle_user_message("hello", chain_id="chain-001")
+        await session._handle_user_message("hello", chain_id="chain-001")
 
     _run(run())
 
@@ -101,10 +104,13 @@ def test_user_message_chitchat_appended_to_history(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
+    async def fake_llm(*args, **kwargs):
+        return _text_result("hello back")
+
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+
     async def run():
-        with patch("reyn.chat.router_loop.call_llm_tools", new_callable=AsyncMock) as mock_llm:
-            mock_llm.return_value = _text_result("hello back")
-            await session._handle_user_message("hello", chain_id="chain-002")
+        await session._handle_user_message("hello", chain_id="chain-002")
 
     _run(run())
 
@@ -169,23 +175,30 @@ def test_user_message_invoke_skill_e2e(tmp_path, monkeypatch):
         # No round 2: H3 patch exits the loop on spawn-ack.
     ]
 
-    async def run():
-        async def fake_adapter_spawn_skill(*, skill, input, chain_id):
-            spawn_called["called"] = True
-            return {
-                "status": "spawned",
-                "run_id": "20260510T000000Z_some_skill_aaaa",
-                "chain_id": chain_id,
-                "skill": skill,
-                "note": "Running in the background. I will notify you when it completes. Use /tasks to check progress.",
-            }
+    async def fake_adapter_spawn_skill(*, skill, input, chain_id):
+        spawn_called["called"] = True
+        return {
+            "status": "spawned",
+            "run_id": "20260510T000000Z_some_skill_aaaa",
+            "chain_id": chain_id,
+            "skill": skill,
+            "note": "Running in the background. I will notify you when it completes. Use /tasks to check progress.",
+        }
 
-        with patch("reyn.chat.router_loop.call_llm_tools", new_callable=AsyncMock) as mock_llm, \
-             patch.object(session._router_host, "spawn_skill",
+    call_count = {"n": 0}
+
+    async def fake_llm(*args, **kwargs):
+        result = rounds[call_count["n"]]
+        call_count["n"] += 1
+        return result
+
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+
+    async def run():
+        with patch.object(session._router_host, "spawn_skill",
                           side_effect=fake_adapter_spawn_skill), \
              patch.object(session._router_host, "list_available_skills",
                           return_value=[{"name": "some_skill", "category": "general"}]):
-            mock_llm.side_effect = rounds
             await session._handle_user_message("run skill", chain_id="chain-003")
 
     _run(run())
@@ -255,15 +268,22 @@ def test_delegate_registers_pending_chain(tmp_path, monkeypatch):
         _text_result("Delegated."),
     ]
 
+    call_count = {"n": 0}
+
+    async def fake_llm(*args, **kwargs):
+        result = rounds[call_count["n"]]
+        call_count["n"] += 1
+        return result
+
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
+
     async def run():
-        with patch("reyn.chat.router_loop.call_llm_tools", new_callable=AsyncMock) as mock_llm:
-            mock_llm.side_effect = rounds
-            await session._handle_agent_request({
-                "from_agent": "origin_agent",
-                "request": "can you delegate this?",
-                "depth": 1,
-                "chain_id": "chain-del-001",
-            })
+        await session._handle_agent_request({
+            "from_agent": "origin_agent",
+            "request": "can you delegate this?",
+            "depth": 1,
+            "chain_id": "chain-del-001",
+        })
 
     _run(run())
 


### PR DESCRIPTION
**[e2e-coder]** — Tier audit lift: `tests/test_router_loop_chatsession.py` (4 deferred `call_llm_tools` mocks → 5 audit errors → 2)

## Summary
- Migrated 4 `with patch("reyn.chat.router_loop.call_llm_tools", new_callable=AsyncMock)` blocks to `monkeypatch.setattr` with real `async def fake_llm` functions (= PR #674 pattern uniform).
- These were the deferred violations from PR-12b (#653, merged).
- No source changes.
- Audit errors: 5 → 2. Remaining 2 are `MagicMock`/`AsyncMock` for `AgentRegistry` in `test_delegate_registers_pending_chain` — different boundary, out-of-scope per mission spec (= opus judgment territory, escalated in PR notes below).

## Transformation notes
- Tests 1 and 2 (`chitchat_e2e`, `chitchat_appended_to_history`): straightforward — `return_value` became `async def fake_llm` returning the fixed result; `monkeypatch.setattr` placed before `async def run()`.
- Test 3 (`invoke_skill_e2e`): `mock_llm.side_effect = rounds` (iterator) replaced with `call_count` dict + index increment; `patch.object` for `spawn_skill` and `list_available_skills` retained (= those are `patch.object` on a real instance, not `call_llm_tools`).
- Test 4 (`delegate_registers_pending_chain`): `call_llm_tools` patch migrated; `monkeypatch` added to function signature; `AgentRegistry` mocks (lines 245, 252, 253, 255) left untouched — they fake a registry collaborator, different from `call_llm_tools`, out-of-scope.

## STOP: AgentRegistry mock hits (out-of-scope, escalation)
`test_delegate_registers_pending_chain` uses `MagicMock()` for `registry` and `target_session`, and `AsyncMock` for `registry.ensure_running` and `target_session.submit_agent_request`. These are `AgentRegistry` / peer `ChatSession` collaborators, not `call_llm_tools`. Per mission instructions, these require opus judgment. They account for the 2 remaining audit errors.

## Test plan
- [x] `pytest tests/test_router_loop_chatsession.py -q` green (8 passed)
- [x] `ruff check .` green
- [x] `python scripts/test_tier_audit.py tests/test_router_loop_chatsession.py` → 2 errors (was 5; remaining 2 = AgentRegistry mocks, out-of-scope)

Refs PR #653 (PR-12b original deferral), PR #674 (pattern precedent).