### PR TITLE
refactor(tests/dogfood + mcp + image): Tier audit fix Wave 3 PR I

### DIFF
--- a/tests/test_dogfood_batch_tools.py
+++ b/tests/test_dogfood_batch_tools.py
@@ -108,6 +108,7 @@ def test_load_batch_config_round_trips_required_fields(tmp_path):
 
 
 def test_load_batch_config_rejects_missing_required_key(tmp_path):
+    """Tier 2: missing batch.name → ValueError with the field name in message."""
     cfg_path = _write_config(tmp_path, """
 batch:
   date: 2026-06-01
@@ -123,6 +124,7 @@ journal_dir: /tmp/j
 
 
 def test_load_batch_config_rejects_empty_workers(tmp_path):
+    """Tier 2: empty workers list → ValueError with "workers" in message."""
     cfg_path = _write_config(tmp_path, """
 batch: {name: B, date: d, head: h}
 workers: []
@@ -139,11 +141,13 @@ journal_dir: /tmp/j
 
 
 def test_normalise_verdicts_handles_short_form_v_i_r_b():
+    """Tier 2: short-form keys V/I/R/B pass through unchanged."""
     out = _normalise_verdicts({"V": 5, "I": 2, "R": 3, "B": 1})
     assert out == {"V": 5, "I": 2, "R": 3, "B": 1}
 
 
 def test_normalise_verdicts_handles_long_form_verified_etc():
+    """Tier 2: long-form keys (verified/inconclusive/refuted/blocked) normalise to short form."""
     out = _normalise_verdicts(
         {"verified": 7, "inconclusive": 1, "refuted": 2, "blocked": 0},
     )
@@ -151,6 +155,7 @@ def test_normalise_verdicts_handles_long_form_verified_etc():
 
 
 def test_normalise_verdicts_treats_missing_as_zero():
+    """Tier 2: empty dict and None both produce all-zero verdict counts."""
     assert _normalise_verdicts({}) == {"V": 0, "I": 0, "R": 0, "B": 0}
     assert _normalise_verdicts(None) == {"V": 0, "I": 0, "R": 0, "B": 0}
 
@@ -161,7 +166,7 @@ def test_normalise_verdicts_treats_missing_as_zero():
 
 
 def test_load_worker_results_reads_existing_b43_journal():
-    """Tier 2 (regression guard against committed data): the real B43
+    """Tier 2: regression guard against committed data — the real B43
     journal in this repo loads to 7 workers (= W1..W7).
     """
     results = load_worker_results(B43_JOURNAL)
@@ -193,8 +198,8 @@ def test_load_worker_results_raises_on_missing_dir(tmp_path):
 
 
 def test_build_aggregate_against_b43_real_journal(tmp_path):
-    """Tier 2 end-to-end: feed the real B43 journal into the new tool
-    + verify the output aggregate.json has the same headline numbers
+    """Tier 2: end-to-end — feed the real B43 journal into the new tool
+    and verify the output aggregate.json has the same headline numbers
     as the published one (V=22, rate≈0.407, B=0). Detects any future
     semantic drift in the aggregate shape.
     """

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -226,8 +226,9 @@ def test_permission_gate_undeclared_raises(tmp_path):
             _run(mcp_install_handle(op, ctx, "control_ir"))
 
 
-def test_permission_gate_passes_with_explicit_decl(tmp_path):
+def test_permission_gate_passes_with_explicit_decl(tmp_path, monkeypatch):
     """Tier 2: mcp_install op proceeds when explicit file.write + http.get are declared."""
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     resolver = _make_resolver(tmp_path)
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
@@ -239,9 +240,8 @@ def test_permission_gate_passes_with_explicit_decl(tmp_path):
         scope="local",
     )
 
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-            result = _run(mcp_install_handle(op, ctx, "control_ir"))
+    with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
+        result = _run(mcp_install_handle(op, ctx, "control_ir"))
 
     assert result["status"] == "ok"
     assert result["server_id"] == "io.github.modelcontextprotocol/server-filesystem"
@@ -252,11 +252,12 @@ def test_permission_gate_passes_with_explicit_decl(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_missing_runtime_returns_error(tmp_path):
+def test_missing_runtime_returns_error(tmp_path, monkeypatch):
     """Tier 2: Handler returns error result when runtime command is not found.
 
     npx missing → status="error" with install hint, no exception raised.
     """
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
     resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
@@ -268,9 +269,8 @@ def test_missing_runtime_returns_error(tmp_path):
         scope="local",
     )
 
-    with mock.patch("shutil.which", return_value=None):
-        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-            result = _run(mcp_install_handle(op, ctx, "control_ir"))
+    with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
+        result = _run(mcp_install_handle(op, ctx, "control_ir"))
 
     assert result["status"] == "error"
     assert "npx" in result["error"].lower() or "node" in result["error"].lower()
@@ -281,18 +281,17 @@ def test_missing_runtime_returns_error(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_env_overrides_skip_prompt_and_persist_secret(tmp_path):
+def test_env_overrides_skip_prompt_and_persist_secret(tmp_path, monkeypatch):
     """Tier 2: env_overrides pre-supply secret values, skipping interactive prompt.
 
     The secret is persisted via secrets.store and the ${KEY} reference is
     written to the config file — not the raw value.
     """
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
     ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-
-    secrets_path = tmp_path / ".reyn" / "secrets.env"
 
     op = MCPInstallIROp(
         kind="mcp_install",
@@ -301,17 +300,15 @@ def test_env_overrides_skip_prompt_and_persist_secret(tmp_path):
         env_overrides={"EXAMPLE_API_KEY": "my-secret-value"},
     )
 
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with mock.patch(
-            "reyn.secrets.store._secrets_path", return_value=secrets_path
-        ):
-            with _patch_registry_get(_SECRET_SERVER_RESPONSE):
-                result = _run(mcp_install_handle(op, ctx, "control_ir"))
+    with _patch_registry_get(_SECRET_SERVER_RESPONSE):
+        result = _run(mcp_install_handle(op, ctx, "control_ir"))
 
     assert result["status"] == "ok"
     assert "EXAMPLE_API_KEY" in result["env_keys_set"]
 
-    # Secret was persisted
+    # Secret was persisted (conftest autouse fixture redirects to tmp_path/secrets.env)
+    import os
+    secrets_path = Path(os.environ["REYN_SECRETS_PATH"])
     assert secrets_path.exists()
     secrets_text = secrets_path.read_text(encoding="utf-8")
     assert "EXAMPLE_API_KEY" in secrets_text
@@ -333,7 +330,7 @@ def test_env_overrides_skip_prompt_and_persist_secret(tmp_path):
     assert "my-secret-value" not in config_path.read_text(encoding="utf-8")
 
 
-def test_save_secret_blocked_when_secret_write_not_declared(tmp_path):
+def test_save_secret_blocked_when_secret_write_not_declared(tmp_path, monkeypatch):
     """Tier 2: mcp_install raises PermissionError when secret.write is missing.
 
     #571 Phase 6: every save_secret call routes through
@@ -341,6 +338,7 @@ def test_save_secret_blocked_when_secret_write_not_declared(tmp_path):
     but forgets secret.write fails the gate when the registry server
     has ``isSecret`` env vars.
     """
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     resolver = _make_resolver(tmp_path)
     canonical_config = str(resolver._project_root / ".reyn" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_test", "file.write")
@@ -351,7 +349,6 @@ def test_save_secret_blocked_when_secret_write_not_declared(tmp_path):
     )
     bus = _AutoApproveInterventionBus()
     ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-    secrets_path = tmp_path / ".reyn" / "secrets.env"
 
     op = MCPInstallIROp(
         kind="mcp_install",
@@ -360,25 +357,21 @@ def test_save_secret_blocked_when_secret_write_not_declared(tmp_path):
         env_overrides={"EXAMPLE_API_KEY": "my-secret-value"},
     )
 
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with mock.patch(
-            "reyn.secrets.store._secrets_path", return_value=secrets_path
-        ):
-            with _patch_registry_get(_SECRET_SERVER_RESPONSE):
-                with pytest.raises(PermissionError, match="EXAMPLE_API_KEY"):
-                    _run(mcp_install_handle(op, ctx, "control_ir"))
+    with _patch_registry_get(_SECRET_SERVER_RESPONSE):
+        with pytest.raises(PermissionError, match="EXAMPLE_API_KEY"):
+            _run(mcp_install_handle(op, ctx, "control_ir"))
 
 
-def test_secret_value_not_in_event(tmp_path):
+def test_secret_value_not_in_event(tmp_path, monkeypatch):
     """Tier 2: mcp_server_installed event contains env_keys_set names but not values.
 
     P6 audit trail must never leak credential values into the event log.
     """
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
     ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-    secrets_path = tmp_path / ".reyn" / "secrets.env"
 
     op = MCPInstallIROp(
         kind="mcp_install",
@@ -387,12 +380,8 @@ def test_secret_value_not_in_event(tmp_path):
         env_overrides={"EXAMPLE_API_KEY": "super-secret-123"},
     )
 
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with mock.patch(
-            "reyn.secrets.store._secrets_path", return_value=secrets_path
-        ):
-            with _patch_registry_get(_SECRET_SERVER_RESPONSE):
-                _run(mcp_install_handle(op, ctx, "control_ir"))
+    with _patch_registry_get(_SECRET_SERVER_RESPONSE):
+        _run(mcp_install_handle(op, ctx, "control_ir"))
 
     events = ctx.events.all()
     install_events = [e for e in events if e.type == "mcp_server_installed"]
@@ -411,9 +400,9 @@ def test_secret_value_not_in_event(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_install_writes_to_dynamic_mcp_yaml_regardless_of_scope(tmp_path):
-    """Tier 2 (#470 2026-05-22 contract reversal): scope arg is now a
-    no-op — every install writes to ``.reyn/mcp.yaml`` regardless of
+def test_install_writes_to_dynamic_mcp_yaml_regardless_of_scope(tmp_path, monkeypatch):
+    """Tier 2: #470 2026-05-22 contract reversal — scope arg is now a
+    no-op; every install writes to ``.reyn/mcp.yaml`` regardless of
     whether the LLM passes ``scope="local"`` / ``"project"`` / ``"user"``
     / nothing. The architectural decision is "one canonical dynamic
     registry location" (= separates op-mutated MCP servers from
@@ -427,6 +416,7 @@ def test_install_writes_to_dynamic_mcp_yaml_regardless_of_scope(tmp_path):
     the rewrite (not patch) makes the contract change visible at
     review.
     """
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     for scope in ("local", "project", "user"):
         resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
         decl = _phase5_install_decl(resolver)
@@ -439,9 +429,8 @@ def test_install_writes_to_dynamic_mcp_yaml_regardless_of_scope(tmp_path):
             scope=scope,
         )
 
-        with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-            with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-                result = _run(mcp_install_handle(op, ctx, "control_ir"))
+        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
+            result = _run(mcp_install_handle(op, ctx, "control_ir"))
 
         expected_path = tmp_path / ".reyn" / "mcp.yaml"
         assert result["status"] == "ok"
@@ -466,11 +455,12 @@ def test_install_writes_to_dynamic_mcp_yaml_regardless_of_scope(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_event_emitted_on_success(tmp_path):
+def test_event_emitted_on_success(tmp_path, monkeypatch):
     """Tier 2: mcp_server_installed event is emitted on successful install.
 
     Event must carry server_id, scope, runtime, env_keys_set.
     """
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     resolver = _make_resolver(tmp_path, config={"mcp_install": "allow"})
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
@@ -482,15 +472,14 @@ def test_event_emitted_on_success(tmp_path):
         scope="local",
     )
 
-    with mock.patch("shutil.which", return_value="/usr/bin/npx"):
-        with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-            result = _run(mcp_install_handle(op, ctx, "control_ir"))
+    with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
+        result = _run(mcp_install_handle(op, ctx, "control_ir"))
 
     assert result["status"] == "ok"
 
     events = ctx.events.all()
     install_events = [e for e in events if e.type == "mcp_server_installed"]
-    assert len(install_events) == 1
+    assert install_events, "expected mcp_server_installed event"
 
     evt = install_events[0]
     assert evt.data["server_id"] == "io.github.modelcontextprotocol/server-filesystem"

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -106,7 +106,7 @@ def test_image_cmd_queues_png(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "shot.png"))
 
-    assert len(session._pending_user_images) == 1
+    assert session._pending_user_images, "expected image queued"
     block = session._pending_user_images[0]
     # Issue #383 PR-C: /image now stores a path-ref to the user's file
     # instead of inlining base64. Storage stays out of history.jsonl.
@@ -128,7 +128,7 @@ def test_image_cmd_supports_jpeg_and_alias(tmp_path, monkeypatch):
     session = _FakeSession()
     _run(cmd.handler(session, "pic.jpg"))
 
-    assert len(session._pending_user_images) == 1
+    assert session._pending_user_images, "expected image queued"
     block = session._pending_user_images[0]
     assert block["mime_type"] == "image/jpeg"
     assert "pic.jpg" in block["path"]
@@ -147,13 +147,16 @@ def test_multiple_image_calls_stack(tmp_path, monkeypatch):
     _run(handler(session, "a.png"))
     _run(handler(session, "b.png"))
 
-    assert len(session._pending_user_images) == 2
+    paths = [b["path"] for b in session._pending_user_images]
+    assert any("a.png" in p for p in paths)
+    assert any("b.png" in p for p in paths)
 
 
 # ── error paths ────────────────────────────────────────────────────────
 
 
 def test_image_cmd_empty_path_errors(tmp_path):
+    """Tier 2: /image with empty path → queue stays empty; outbox shows usage error."""
     session = _FakeSession()
     handler = _get_image_handler()
     _run(handler(session, ""))
@@ -163,6 +166,7 @@ def test_image_cmd_empty_path_errors(tmp_path):
 
 
 def test_image_cmd_missing_file_errors(tmp_path, monkeypatch):
+    """Tier 2: /image with non-existent file → queue stays empty; outbox shows not-found error."""
     monkeypatch.chdir(tmp_path)
     session = _FakeSession()
     handler = _get_image_handler()
@@ -173,6 +177,7 @@ def test_image_cmd_missing_file_errors(tmp_path, monkeypatch):
 
 
 def test_image_cmd_unsupported_extension_errors(tmp_path, monkeypatch):
+    """Tier 2: /image with .txt extension → queue stays empty; outbox shows unsupported error."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "notes.txt").write_bytes(b"text")
     session = _FakeSession()
@@ -232,7 +237,7 @@ def test_image_cmd_no_multimodal_config_skips_gate(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "any.png"))
 
-    assert len(session._pending_user_images) == 1
+    assert session._pending_user_images, "expected image queued (gate skipped)"
 
 
 # ── ChatMessage content shape (issue #383 update) ──────────────────────


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 3 PR I (= dogfood/MCP/image subset).

## Summary

3 test files with 21 mixed Tier 4 violations: docstring + Mock vs Fake + format pinning. Pre-audit-verify per file confirmed all 3 had real work.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Total errors | 21 | **0** |
| Tests passing | 43 | **43** |

## Per-file fix shape

**\`tests/test_dogfood_batch_tools.py\` (7 / docstring only)**
- 5 missing docstrings → \`"""Tier 2: ..."""\`
- 2 wrong format \`"""Tier 2 (...)"""\` → \`"""Tier 2: ..."""\`

**\`tests/test_mcp_install_op.py\` (7 / mock + docstring + format)**
- 6 \`mock.patch("shutil.which", return_value=...)\` → \`monkeypatch.setattr("shutil.which", lambda _cmd: ...)\`
- 3 \`mock.patch("reyn.secrets.store._secrets_path", ...)\` removed entirely — conftest autouse fixture already redirects to \`tmp_path\` per \`testing.ja.md\` filesystem isolation section (= one test updated to read path from \`REYN_SECRETS_PATH\` env var)
- 1 docstring format fix
- 1 \`len(install_events) == 1\` → \`assert install_events\`

**\`tests/test_user_image_input.py\` (7 / format + docstring)**
- 4 \`len(session._pending_user_images) == N\` → truthy / behavioral checks (stacking test checks both filenames)
- 3 missing docstrings added

## Test plan

- [x] \`venv/bin/pytest <3 files>\`: 43/43 passed
- [x] \`python scripts/test_tier_audit.py <3 files>\`: 0 errors
- [x] Pre-audit-verify confirmed work needed (= no skips)

## Implementation notes

Sonnet sub-agent surfaced an idiomatic cleanup: \`_secrets_path\` mock patches were redundant given the conftest autouse fixture pattern documented in testing policy. Removed those patches entirely instead of just converting them — net behavior unchanged, code cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)