### PR TITLE
fix(tests): Tier audit fix (format-pin + patch lift): test_router_loop_routing_decided.py (PR-18a)

### DIFF
--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import patch
 
 from reyn.chat.router_loop import RouterLoop
 from reyn.llm.llm import LLMToolCallResult
@@ -180,6 +179,7 @@ class _FakeRouterHost:
 def _run_with_llm_sequence(
     host: _FakeRouterHost,
     llm_turns: list[LLMToolCallResult],
+    monkeypatch,
 ) -> None:
     """Drive RouterLoop.run() using a real coroutine sequence as call_llm_tools.
 
@@ -192,9 +192,9 @@ def _run_with_llm_sequence(
     async def _fake_call_llm_tools(**kwargs: object) -> LLMToolCallResult:
         return turns.pop(0)
 
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _fake_call_llm_tools)
     loop = RouterLoop(host=host, chain_id="chain-test", max_iterations=5)
-    with patch("reyn.chat.router_loop.call_llm_tools", side_effect=_fake_call_llm_tools):
-        asyncio.run(loop.run("hello", []))
+    asyncio.run(loop.run("hello", []))
 
 
 def _routing_decided_events(host: _FakeRouterHost) -> list[dict]:
@@ -206,7 +206,7 @@ def _routing_decided_events(host: _FakeRouterHost) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def test_routing_decided_emitted_for_invoke_action():
+def test_routing_decided_emitted_for_invoke_action(monkeypatch):
     """Tier 2: invoke_action call emits routing_decided with source='invoke_action' and outcome='success'."""
     host = _FakeRouterHost(universal_wrappers_enabled=True)
     # Turn 1: LLM calls invoke_action(action_name="skill__foo")
@@ -217,11 +217,11 @@ def test_routing_decided_emitted_for_invoke_action():
             _tool_result([{"name": "invoke_action", "args": {"action_name": "skill__foo", "args": {}}}]),
             _text_result("ok"),
         ],
+        monkeypatch,
     )
 
     events = _routing_decided_events(host)
-    assert len(events) == 1, f"Expected 1 routing_decided event, got {events}"
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "skill__foo"
     assert ev["source"] == "invoke_action"
     assert ev["outcome"] == "success"
@@ -233,7 +233,7 @@ def test_routing_decided_emitted_for_invoke_action():
 # ---------------------------------------------------------------------------
 
 
-def test_routing_decided_emitted_for_hot_list_alias():
+def test_routing_decided_emitted_for_hot_list_alias(monkeypatch):
     """Tier 2: hot list alias call emits routing_decided with source='hot_list_alias' and outcome='success'.
 
     A real ActionUsageTracker pre-loaded with 'skill__bar' is passed so
@@ -262,11 +262,11 @@ def test_routing_decided_emitted_for_hot_list_alias():
             _tool_result([{"name": "skill__bar", "args": {}}]),
             _text_result("done"),
         ],
+        monkeypatch,
     )
 
     events = _routing_decided_events(host)
-    assert len(events) == 1, f"Expected 1 routing_decided event, got {events}"
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "skill__bar"
     assert ev["source"] == "hot_list_alias"
     assert ev["outcome"] == "success"
@@ -278,7 +278,7 @@ def test_routing_decided_emitted_for_hot_list_alias():
 # ---------------------------------------------------------------------------
 
 
-def test_routing_decided_outcome_error_on_tool_error():
+def test_routing_decided_outcome_error_on_tool_error(monkeypatch):
     """Tier 2: routing_decided outcome='error' when the tool result is an error.
 
     Issue #229 changed the resolvable-direct-call path (= ``skill__bad``)
@@ -301,11 +301,11 @@ def test_routing_decided_outcome_error_on_tool_error():
             _tool_result([{"name": "bogus_category__action", "args": {}}]),
             _text_result("done"),
         ],
+        monkeypatch,
     )
 
     events = _routing_decided_events(host)
-    assert len(events) == 1, f"Expected 1 routing_decided event, got {events}"
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "bogus_category__action"
     assert ev["outcome"] == "error", (
         f"Expected outcome='error' for unknown action, got {ev['outcome']!r}"
@@ -317,7 +317,7 @@ def test_routing_decided_outcome_error_on_tool_error():
 # ---------------------------------------------------------------------------
 
 
-def test_routing_decided_not_emitted_for_non_catalog_tool():
+def test_routing_decided_not_emitted_for_non_catalog_tool(monkeypatch):
     """Tier 2: plain tool without '__' and not invoke_action emits no routing_decided."""
     host = _FakeRouterHost(universal_wrappers_enabled=True)
     # Turn 1: LLM calls list_skills (plain OS tool, no '__')
@@ -329,6 +329,7 @@ def test_routing_decided_not_emitted_for_non_catalog_tool():
             _tool_result([{"name": "list_skills", "args": {}}]),
             _text_result("ok"),
         ],
+        monkeypatch,
     )
 
     events = _routing_decided_events(host)
@@ -343,7 +344,7 @@ def test_routing_decided_not_emitted_for_non_catalog_tool():
 # ---------------------------------------------------------------------------
 
 
-def test_routing_decided_skipped_when_action_name_empty():
+def test_routing_decided_skipped_when_action_name_empty(monkeypatch):
     """Tier 2: invoke_action call with missing action_name does not emit routing_decided."""
     host = _FakeRouterHost(universal_wrappers_enabled=True)
     # invoke_action with empty args (no action_name key)
@@ -353,6 +354,7 @@ def test_routing_decided_skipped_when_action_name_empty():
             _tool_result([{"name": "invoke_action", "args": {}}]),
             _text_result("ok"),
         ],
+        monkeypatch,
     )
 
     events = _routing_decided_events(host)
@@ -367,7 +369,7 @@ def test_routing_decided_skipped_when_action_name_empty():
 # ---------------------------------------------------------------------------
 
 
-def test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name():
+def test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name(monkeypatch):
     """Tier 2: a qualified name not in catalog tags ``source="ars_direct"``.
 
     Issue #241: distinguish "the alias was a real hot-list entry the LLM
@@ -389,10 +391,10 @@ def test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name():
             _tool_result([{"name": "bogus_category__action", "args": {}}]),
             _text_result("done"),
         ],
+        monkeypatch,
     )
     events = _routing_decided_events(host)
-    assert len(events) == 1
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "bogus_category__action"
     assert ev["source"] == "ars_direct", (
         f"Expected source='ars_direct' for qualified name not in catalog, "
@@ -400,7 +402,7 @@ def test_routing_decided_source_ars_direct_for_unsalvageable_qualified_name():
     )
 
 
-def test_routing_decided_source_hot_list_alias_only_when_in_catalog():
+def test_routing_decided_source_hot_list_alias_only_when_in_catalog(monkeypatch):
     """Tier 2: ``source="hot_list_alias"`` requires name to be in tools[].
 
     Pin the discriminator: with a tracker pre-loaded for ``skill__bar``,
@@ -421,10 +423,10 @@ def test_routing_decided_source_hot_list_alias_only_when_in_catalog():
             _tool_result([{"name": "skill__bar", "args": {}}]),
             _text_result("done"),
         ],
+        monkeypatch,
     )
     events = _routing_decided_events(host)
-    assert len(events) == 1
-    ev = events[0]
+    (ev,) = events
     assert ev["action_name"] == "skill__bar"
     assert ev["source"] == "ars_direct", (
         f"Without hot-list landing, source must be 'ars_direct' not "


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (format-pin): `tests/test_router_loop_routing_decided.py`

## Summary
- 6 format-pinning / mock violations resolved (cleanup of pre-existing violations not in PR-15k/PR-16c scope).
- `from unittest.mock import patch` removed; `_run_with_llm_sequence` now accepts `monkeypatch` and uses `monkeypatch.setattr` instead of `with patch(...)`.
- 5x `len(events) == 1` + `ev = events[0]` format-pinning replaced with `(ev,) = events` destructuring.
- No source changes.
- 0 audit errors (was 6).

Refs PR-15k #698 (format-pin partial), PR-16c #715 (call_llm_tools lift).

## Test plan
- [x] `python -m pytest tests/test_router_loop_routing_decided.py -q` → 7 passed
- [x] `ruff check .` → All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_router_loop_routing_decided.py` → 0 errors (was 6)