### PR TITLE
refactor(tests/skill_resume + intervention_persistence): Wave 5 PR P (Tier audit fix)

### DIFF
--- a/tests/test_session_intervention_persistence.py
+++ b/tests/test_session_intervention_persistence.py
@@ -91,8 +91,8 @@ async def test_dispatch_intervention_appends_wal_before_await(tmp_path, monkeypa
 
     events = _wal_events(tmp_path)
     dispatched = [e for e in events if e["kind"] == "intervention_dispatched"]
-    assert len(dispatched) == 1, (
-        f"expected 1 intervention_dispatched in WAL while awaiting; "
+    assert dispatched, (
+        f"expected intervention_dispatched in WAL while awaiting; "
         f"got {[e['kind'] for e in events]}"
     )
     ev = dispatched[0]
@@ -129,7 +129,7 @@ async def test_deliver_answer_appends_intervention_resolved(tmp_path, monkeypatc
 
     events = _wal_events(tmp_path)
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
-    assert len(resolved) == 1
+    assert resolved, "intervention_resolved must be emitted after successful answer"
     assert resolved[0]["intervention_id"] == iv.id
     assert resolved[0]["target"] == "alpha"
 
@@ -156,7 +156,7 @@ async def test_unknown_choice_does_not_emit_resolved(tmp_path, monkeypatch):
     events = _wal_events(tmp_path)
     dispatched = [e for e in events if e["kind"] == "intervention_dispatched"]
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
-    assert len(dispatched) == 1
+    assert dispatched, "intervention_dispatched must be present in WAL"
     assert resolved == [], (
         f"unknown-choice answer must NOT emit resolve; got {resolved}"
     )

--- a/tests/test_skill_resume_applier.py
+++ b/tests/test_skill_resume_applier.py
@@ -180,7 +180,7 @@ def test_resume_action_passed_through(tmp_path: Path):
         return await coord.apply_decisions([d], skill_registry=registry)
 
     remaining = asyncio.run(go())
-    assert remaining, "resume decision must remain in launchable list"
+    assert len(remaining) == 1
     assert remaining[0].action == "resume"
 
 
@@ -197,7 +197,7 @@ def test_retry_action_passed_through(tmp_path: Path):
         return await coord.apply_decisions([d], skill_registry=registry)
 
     remaining = asyncio.run(go())
-    assert remaining, "retry decision must remain in launchable list"
+    assert len(remaining) == 1
     assert remaining[0].action == "retry"
 
 
@@ -227,7 +227,7 @@ def test_skip_action_passed_through(tmp_path: Path):
         return await coord.apply_decisions([d], skill_registry=registry)
 
     remaining = asyncio.run(go())
-    assert remaining, "skip decision must remain in launchable list"
+    assert len(remaining) == 1
     assert remaining[0].action == "skip"
     assert remaining[0].plan.committed_steps[0].result == {"status": "skipped"}
 
@@ -254,7 +254,7 @@ def test_prompt_required_treated_as_retry_for_auto_resume(tmp_path: Path):
     remaining = asyncio.run(go())
     # Remains in launchable list — the caller will launch it; ambiguous
     # steps are absent from committed_steps so they retry naturally.
-    assert remaining, "prompt_required decision must remain in launchable list"
+    assert len(remaining) == 1
     assert remaining[0].action in ("prompt_required", "retry")
 
 
@@ -300,5 +300,5 @@ def test_apply_decisions_mixed_batch(tmp_path: Path):
         e for e in log.iter_from(0)
         if e["kind"] == "skill_discarded"
     ]
-    assert discarded, "WAL must contain skill_discarded for run_b"
+    assert len(discarded) == 1
     assert discarded[0]["run_id"] == "run_b"

--- a/tests/test_skill_resume_applier.py
+++ b/tests/test_skill_resume_applier.py
@@ -180,7 +180,7 @@ def test_resume_action_passed_through(tmp_path: Path):
         return await coord.apply_decisions([d], skill_registry=registry)
 
     remaining = asyncio.run(go())
-    assert len(remaining) == 1
+    assert remaining, "resume decision must remain in launchable list"
     assert remaining[0].action == "resume"
 
 
@@ -197,7 +197,7 @@ def test_retry_action_passed_through(tmp_path: Path):
         return await coord.apply_decisions([d], skill_registry=registry)
 
     remaining = asyncio.run(go())
-    assert len(remaining) == 1
+    assert remaining, "retry decision must remain in launchable list"
     assert remaining[0].action == "retry"
 
 
@@ -227,7 +227,7 @@ def test_skip_action_passed_through(tmp_path: Path):
         return await coord.apply_decisions([d], skill_registry=registry)
 
     remaining = asyncio.run(go())
-    assert len(remaining) == 1
+    assert remaining, "skip decision must remain in launchable list"
     assert remaining[0].action == "skip"
     assert remaining[0].plan.committed_steps[0].result == {"status": "skipped"}
 
@@ -254,7 +254,7 @@ def test_prompt_required_treated_as_retry_for_auto_resume(tmp_path: Path):
     remaining = asyncio.run(go())
     # Remains in launchable list — the caller will launch it; ambiguous
     # steps are absent from committed_steps so they retry naturally.
-    assert len(remaining) == 1
+    assert remaining, "prompt_required decision must remain in launchable list"
     assert remaining[0].action in ("prompt_required", "retry")
 
 
@@ -300,5 +300,5 @@ def test_apply_decisions_mixed_batch(tmp_path: Path):
         e for e in log.iter_from(0)
         if e["kind"] == "skill_discarded"
     ]
-    assert len(discarded) == 1
+    assert discarded, "WAL must contain skill_discarded for run_b"
     assert discarded[0]["run_id"] == "run_b"

--- a/tests/test_skill_resume_coordinator.py
+++ b/tests/test_skill_resume_coordinator.py
@@ -69,7 +69,7 @@ def test_prompt_policy_with_ambiguity_yields_prompt_required():
     cfg = SkillResumeConfig(default="prompt")
     d = coord.decide_for_plan(_plan(has_amb=True), cfg)
     assert d.action == "prompt_required"
-    assert len(d.ambiguous_steps) == 1
+    assert d.ambiguous_steps, "ambiguous_steps must be populated for prompt_required"
 
 
 def test_retry_policy_with_ambiguity_yields_retry():
@@ -170,13 +170,13 @@ def test_discover_and_decide_clean_run_yields_resume(tmp_path):
     decisions = coord.discover_and_decide(
         skill_registry=reg2, state_log=log2, policy=SkillResumeConfig(),
     )
-    assert len(decisions) == 1
+    assert decisions, "clean run must yield a resume decision"
     d = decisions[0]
     assert d.plan.run_id == "r1"
     assert d.action == "resume"
     assert d.ambiguous_steps == []
     # Committed step was paired
-    assert len(d.plan.committed_steps) == 1
+    assert d.plan.committed_steps, "committed_steps must be populated for clean run"
 
 
 def test_discover_and_decide_ambiguous_step_applies_policy(tmp_path):
@@ -207,10 +207,10 @@ def test_discover_and_decide_ambiguous_step_applies_policy(tmp_path):
     decisions = coord.discover_and_decide(
         skill_registry=reg2, state_log=log2, policy=cfg,
     )
-    assert len(decisions) == 1
+    assert decisions, "ambiguous run must yield a decision"
     d = decisions[0]
     assert d.action == "retry"
-    assert len(d.ambiguous_steps) == 1
+    assert d.ambiguous_steps, "ambiguous_steps must be populated for retry decision"
     assert d.ambiguous_steps[0].op_kind == "mcp"
 
 
@@ -261,7 +261,7 @@ def test_discover_does_not_cross_pair_runs(tmp_path):
     # PR-resume-auto; auto-resume never blocks on prompt). Ambiguous
     # steps are surfaced for inspection regardless.
     assert by_run["run_B"].action == "retry"
-    assert len(by_run["run_B"].ambiguous_steps) == 1
+    assert by_run["run_B"].ambiguous_steps, "run_B must have ambiguous steps from orphaned start"
     assert by_run["run_B"].ambiguous_steps[0].op_kind == "mcp"
 
 


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 5 PR P (= skill-resume + intervention-persistence subset).

**Cross-author yield (= post-broker-update)**: \`test_skill_resume_applier.py\` originally included in this PR was **yielded to e2e-coder PR #730 (PR-19a)** (= flagged by lead-coder cross-coordination broker as overlap). Revert commit on this branch.

Final scope: **2 files / 8 errors** (= test_skill_resume_coordinator + test_session_intervention_persistence).

## Summary

8 format-pinning violations across 2 test files → 0. Pre-audit-verify confirmed both files had real work.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Format-pinning errors | 8 | **0** |
| Tests passing in scope | subset of 24 | **all pass** |

## Per-file fix shape

**\`tests/test_skill_resume_coordinator.py\` (5)**: \`ambiguous_steps\`/\`decisions\`/\`committed_steps\` size pins → truthy across 4 tests

**\`tests/test_session_intervention_persistence.py\` (3)**: \`dispatched\`/\`resolved\` WAL event list size pins → truthy across 3 tests

## Cross-author coordination

Original Wave 5 PR P scope was 3 files (= 13 errors). After collision detected with e2e-coder PR-19a #730 (= via lead-coder broker), this PR yielded \`test_skill_resume_applier.py\` to whichever merges first. Per cross-author etiquette: first-open wins, second-author reverts to avoid race-loss.

Net contribution from this PR: 8 errors resolved.

## Test plan

- [x] \`venv/bin/pytest tests/test_skill_resume_coordinator.py tests/test_session_intervention_persistence.py\`: passes
- [x] \`python scripts/test_tier_audit.py <2 files>\`: 0 errors
- [x] Yielded \`test_skill_resume_applier.py\` to e2e-coder PR #730 (revert commit on this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)