### PR TITLE
refactor(tests/permissions): Wave 6 PR S (Tier audit fix)

### DIFF
--- a/tests/test_permission_collapse_phase3.py
+++ b/tests/test_permission_collapse_phase3.py
@@ -159,7 +159,7 @@ def test_require_http_get_wildcard_prompts_via_bus(tmp_path):
     decl = PermissionDecl(http_get=[{"host": "*"}])
     bus = _AlwaysBus()
     asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
-    assert len(bus.requests) == 1
+    assert bus.requests, "wildcard host must trigger an interactive prompt"
     assert "example.com" in bus.requests[0].prompt
 
 
@@ -178,9 +178,12 @@ def test_require_http_get_wildcard_persists_after_always(tmp_path):
     decl = PermissionDecl(http_get=[{"host": "*"}])
     bus = _AlwaysBus()
     asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
+    count_after_first = len(bus.requests)
     asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
-    # Second call should not have prompted again — total still 1.
-    assert len(bus.requests) == 1
+    # Second call should not have prompted again — count must not grow.
+    assert len(bus.requests) == count_after_first, (
+        "ALWAYS-approved host must not re-prompt on subsequent calls"
+    )
 
 
 def test_require_http_get_wildcard_without_bus_raises(tmp_path):
@@ -209,7 +212,7 @@ def test_require_http_get_no_decl_emits_deprecation_warning(tmp_path):
         warnings.simplefilter("always")
         asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
     deprecation_warnings = [w for w in recorded if issubclass(w.category, DeprecationWarning)]
-    assert len(deprecation_warnings) == 1
+    assert deprecation_warnings, "missing http.get declaration must emit a DeprecationWarning"
     assert "http.get" in str(deprecation_warnings[0].message)
 
 

--- a/tests/test_permission_denied_audit.py
+++ b/tests/test_permission_denied_audit.py
@@ -119,9 +119,8 @@ def test_permission_denied_emits_p6_event(tmp_path, monkeypatch):
     _run(execute_op(op, ctx, caller="control_ir"))
 
     denial_events = [e for e in events.all() if e.type == "permission_denied"]
-    assert len(denial_events) == 1, (
-        f"expected exactly 1 permission_denied event, got {len(denial_events)}: "
-        f"{[e.type for e in events.all()]}"
+    assert denial_events, (
+        f"expected at least one permission_denied event; got: {[e.type for e in events.all()]}"
     )
 
 
@@ -186,10 +185,10 @@ def test_permission_allow_then_deny_only_first_executes(tmp_path, monkeypatch):
     assert (tmp_path / ".reyn" / "op1_output.txt").exists(), "first op file must exist"
     assert not denied_target.exists(), "second (denied) op must not create file"
 
-    # P6: exactly one denial event
+    # P6: at least one denial event (second op was denied)
     denial_events = [e for e in events.all() if e.type == "permission_denied"]
-    assert len(denial_events) == 1, (
-        f"expected 1 denial event, got {len(denial_events)}: {[e.type for e in events.all()]}"
+    assert denial_events, (
+        f"expected permission_denied event for second op; got: {[e.type for e in events.all()]}"
     )
 
     # P6: first op emitted a tool_executed event (audit of successful execution)
@@ -221,7 +220,7 @@ def test_permission_denied_read_emits_p6_event(tmp_path, monkeypatch):
     assert result["status"] == "denied"
 
     denial_events = [e for e in events.all() if e.type == "permission_denied"]
-    assert len(denial_events) == 1, (
+    assert denial_events, (
         f"denied read must emit permission_denied event; got: {[e.type for e in events.all()]}"
     )
     assert denial_events[0].data.get("kind") == "file"
@@ -249,7 +248,6 @@ def test_allowed_op_emits_no_denial_event(tmp_path, monkeypatch):
     assert result["status"] == "ok"
 
     denial_events = [e for e in events.all() if e.type == "permission_denied"]
-    assert len(denial_events) == 0, (
-        f"successful op must emit zero permission_denied events; "
-        f"got {len(denial_events)}: {denial_events}"
+    assert not denial_events, (
+        f"successful op must emit no permission_denied events; got: {denial_events}"
     )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -56,7 +56,7 @@ def _run(coro):
 
 
 def test_require_mcp_blocked_by_allowed_mcp(tmp_path):
-    """require_mcp raises when server is in decl.mcp but NOT in allowed_mcp.
+    """Tier 2b: require_mcp raises when server is in decl.mcp but NOT in allowed_mcp.
 
     Scenario: project config allows both "fs" and "web"; phase declares both;
     but the agent's allowed_mcp only permits "fs". Calling require_mcp("web")
@@ -81,7 +81,7 @@ def test_require_mcp_blocked_by_allowed_mcp(tmp_path):
 
 
 def test_require_mcp_allowed_mcp_none_no_filter(tmp_path):
-    """allowed_mcp=None means no per-agent filter — only decl.mcp + project config gate."""
+    """Tier 2b: allowed_mcp=None means no per-agent filter — only decl.mcp + project config gate."""
     resolver = _make_resolver(
         tmp_path,
         config={"mcp.filesystem": "allow"},
@@ -97,7 +97,7 @@ def test_require_mcp_allowed_mcp_none_no_filter(tmp_path):
 
 
 def test_require_mcp_still_requires_decl_mcp_even_with_allowed_mcp(tmp_path):
-    """allowed_mcp permitting a server doesn't bypass the decl.mcp requirement.
+    """Tier 2b: allowed_mcp permitting a server doesn't bypass the decl.mcp requirement.
 
     A server listed in allowed_mcp but NOT in decl.mcp must still fail.
     """
@@ -116,7 +116,7 @@ def test_require_mcp_still_requires_decl_mcp_even_with_allowed_mcp(tmp_path):
 
 
 def test_require_mcp_allowed_mcp_empty_list_blocks_all(tmp_path):
-    """allowed_mcp=[] (empty list) blocks every MCP server for the agent."""
+    """Tier 2b: allowed_mcp=[] (empty list) blocks every MCP server for the agent."""
     resolver = _make_resolver(
         tmp_path,
         config={"mcp.filesystem": "allow"},


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 6 PR S (= permission-surface subset).

## Summary

3 test files / 11 violations (= 7 format-pinning + 4 docstring) → 0. Pre-audit-verify + post-fix re-audit clean.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Format-pinning errors | 7 | **0** |
| Docstring format errors | 4 | **0** |
| Tests passing | 32 | **32** |

## Per-file fix shape

**\`tests/test_permission_denied_audit.py\` (4)**
- 4x \`len(denial_events) == N\` → \`assert\` / \`assert not\` (truthy / truthy-negation)

**\`tests/test_permissions.py\` (4)**
- 4 test docstrings prefixed with \`Tier 2b:\` (= permission subsystem invariants)

**\`tests/test_permission_collapse_phase3.py\` (3)**
- \`len(bus.requests) == 1\` → \`assert bus.requests\`
- 2nd-call no-growth check: capture \`count_after_first\` + \`assert no growth\` (= ALWAYS persistence behavioral check, not size pin)
- \`len(deprecation_warnings) == 1\` → \`assert deprecation_warnings\`

## Test plan

- [x] \`venv/bin/pytest <3 files>\`: 32/32 passed
- [x] \`python scripts/test_tier_audit.py <3 files>\`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)