### PR TITLE
refactor(tests/dogfood + trace): Wave 7 PR T2 (Tier audit fix)

### DIFF
--- a/tests/test_dogfood_batch_config_scenario_count_autoderive.py
+++ b/tests/test_dogfood_batch_config_scenario_count_autoderive.py
@@ -94,7 +94,7 @@ journal_dir: /tmp/test-journal
 
 
 def test_omitted_n_scenarios_derived_from_scenario_yaml(tmp_path):
-    """Tier 2 (B47-fix): batch yaml may omit ``n_scenarios`` entirely;
+    """Tier 2b: batch yaml may omit ``n_scenarios`` entirely;
     the loader fills it from the on-disk scenario yaml count."""
     scen_path = tmp_path / "scenarios.yaml"
     _write_scenario_yaml(scen_path, n=5)
@@ -136,9 +136,9 @@ def test_declared_n_scenarios_matching_actual_silent(tmp_path):
 
 
 def test_declared_n_scenarios_mismatched_warns_and_overrides(tmp_path):
-    """Tier 2 (B47-fix headline): the W6 drift case — declared
-    ``n_scenarios: 7`` against a 3-scenario yaml emits warning and
-    uses the actual count (3) as authoritative."""
+    """Tier 2b: the W6 drift case — declared ``n_scenarios: 7`` against a
+    3-scenario yaml emits a warning and uses the actual count (3) as
+    authoritative."""
     scen_path = tmp_path / "scenarios.yaml"
     _write_scenario_yaml(scen_path, n=3)
     batch_path = tmp_path / "batch.yaml"
@@ -151,9 +151,9 @@ def test_declared_n_scenarios_mismatched_warns_and_overrides(tmp_path):
             w for w in caught
             if "n_scenarios" in str(w.message) and "does not match" in str(w.message)
         ]
-        assert len(mismatch_warnings) == 1, (
-            f"mismatched declared n_scenarios should emit exactly one "
-            f"warning; got {len(mismatch_warnings)}: "
+        assert mismatch_warnings, (
+            f"mismatched declared n_scenarios should emit at least one "
+            f"warning; got none. All warnings: "
             f"{[str(w.message) for w in caught]}"
         )
         assert "7" in str(mismatch_warnings[0].message)

--- a/tests/test_dogfood_trace_llm_modes.py
+++ b/tests/test_dogfood_trace_llm_modes.py
@@ -273,7 +273,7 @@ class TestLlmDetailMode:
         out, rc = _run(["--mode", "llm-detail", REQUEST_ID_A, "--trace", str(trace)])
         assert rc == 0
         # The full 1000-char system prompt should NOT appear without --full
-        assert len(out) < 1000 + 500  # allow some overhead, but not 1000 chars of As
+        assert "A" * 1000 not in out, "full 1000-char system prompt should be truncated without --full"
 
         out_full, rc_full = _run(["--mode", "llm-detail", REQUEST_ID_A, "--trace", str(trace), "--full"])
         assert rc_full == 0
@@ -293,8 +293,10 @@ class TestLlmToolsSchemaMode:
         # Output should be parseable JSON
         parsed = json.loads(out)
         assert isinstance(parsed, list)
-        assert len(parsed) == 1
-        assert parsed[0]["function"]["name"] == "run_skill"
+        assert parsed, "tools JSON should be a non-empty list"
+        assert any(entry["function"]["name"] == "run_skill" for entry in parsed), (
+            "tools list should contain the run_skill tool definition"
+        )
 
     def test_shows_enum_constraints(self, tmp_path: Path) -> None:
         """Tier 2: llm-tools-schema output includes enum constraints in parameter schema."""

--- a/tests/test_dogfood_trace_multi_file.py
+++ b/tests/test_dogfood_trace_multi_file.py
@@ -159,13 +159,13 @@ class TestMultiFlagForm:
     def test_multi_flag_total_record_count(self, tmp_path: Path) -> None:
         """Tier 2: --trace a --trace b produces output for records from all files."""
         file_a, file_b = _make_traces(tmp_path)
-        # File A has 2 requests; File B has 1 request — expect 3 request lines
+        # File A has 2 requests; File B has 1 request — all should appear
         out, rc = _run(
             ["--mode", "llm-payloads", "--trace", str(file_a), "--trace", str(file_b)]
         )
         assert rc == 0
         request_lines = [ln for ln in out.splitlines() if "request_id=" in ln and "response_id" not in ln]
-        assert len(request_lines) == 3
+        assert request_lines, "combined --trace flags should produce request output lines"
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +191,7 @@ class TestCommaSeparatedForm:
         out, rc = _run(["--mode", "llm-payloads", "--trace", combined])
         assert rc == 0
         request_lines = [ln for ln in out.splitlines() if "request_id=" in ln and "response_id" not in ln]
-        assert len(request_lines) == 3
+        assert request_lines, "comma-separated --trace form should produce request output lines"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 7 PR T2 (= dogfood + trace subset).

## Summary

3 test files / 6 violations (= 2 docstring + 4 format-pinning) → 0.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Docstring errors | 2 | **0** |
| Format-pinning errors | 4 | **0** |
| Tests passing | 41 | **41** |

## Per-file fix shape

**\`tests/test_dogfood_batch_config_scenario_count_autoderive.py\` (2)**
- 2 docstrings: \`"Tier 2 (B47-fix):"\` → \`"Tier 2b: ..."\` (= regex compliance)
- \`len(mismatch_warnings) == 1\` → \`assert mismatch_warnings\` (= pin "warning emitted", not exact count)

**\`tests/test_dogfood_trace_llm_modes.py\` (2)**
- \`len(out) < 1500\` → \`"A" * 1000 not in out\` (= behavioral "full content suppressed", not byte length)
- \`len(parsed) == 1\` → \`assert parsed\` + \`any(entry["function"]["name"] == "run_skill" for entry in parsed)\` (= expected tool present, not cardinality)

**\`tests/test_dogfood_trace_multi_file.py\` (2)**
- 2x \`len(request_lines) == 3\` → \`assert request_lines\` (= sibling \`*_shows_all_request_ids\` tests already prove all-IDs coverage)

## Test plan

- [x] \`venv/bin/pytest <3 files>\`: 41/41 passed
- [x] \`python scripts/test_tier_audit.py <3 files>\`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)