### PR TITLE
fix(tests): Tier audit fix — test_universal_catalog.py (3 format-pin errors)

### DIFF
--- a/tests/test_universal_catalog.py
+++ b/tests/test_universal_catalog.py
@@ -44,11 +44,6 @@ from reyn.tools.universal_catalog import (
 # ── 1. CATEGORIES taxonomy ────────────────────────────────────────────────
 
 
-def test_categories_has_fourteen_entries() -> None:
-    """Tier 2: FP-0034 §D18 master taxonomy has 14 categories (validation added)."""
-    assert len(CATEGORIES) == 14
-
-
 def test_categories_master_table_order() -> None:
     """Tier 2: CATEGORIES order matches the §D18 master table.
 
@@ -338,14 +333,12 @@ def test_visible_categories_drops_exec_when_sandbox_noop() -> None:
     """Tier 2: visible_categories excludes 'exec' when sandbox=noop."""
     vis = visible_categories(sandbox_backend="noop")
     assert "exec" not in vis
-    assert len(vis) == 13  # 14 - exec
 
 
 def test_visible_categories_includes_exec_when_sandbox_real() -> None:
     """Tier 2: visible_categories includes 'exec' when real backend present."""
     vis = visible_categories(sandbox_backend="seatbelt")
     assert "exec" in vis
-    assert len(vis) == 14
 
 
 def test_visible_categories_drops_exec_when_sandbox_none() -> None:


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `tests/test_universal_catalog.py`

## Summary
- 3 format-pinning violations resolved (`len(x) == N` count assertions removed).
- 0 audit errors (was 3).

Changes:
- Deleted `test_categories_has_fourteen_entries` — fully redundant with `test_categories_master_table_order` which already pins the full tuple (implicitly pinning count).
- Removed `assert len(vis) == 13` from `test_visible_categories_drops_exec_when_sandbox_noop`.
- Removed `assert len(vis) == 14` from `test_visible_categories_includes_exec_when_sandbox_real`.

Refs PR-12 through PR-23.

## Test plan
- [x] `python -m pytest tests/test_universal_catalog.py -q` — 60 passed
- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_universal_catalog.py` — 0 errors (was 3)