### PR TITLE
refactor(tests/lifecycle + a2a + hot_list): Wave 9 PR T4 (Tier audit fix)

### DIFF
--- a/tests/test_a2a_sse_producer_267_gap1.py
+++ b/tests/test_a2a_sse_producer_267_gap1.py
@@ -98,7 +98,7 @@ def test_send_appends_payload_to_history_events() -> None:
     asyncio.run(bridge._send(3, "phase_started", "phase: planning"))
 
     refreshed = registry.get(entry.run_id)
-    assert len(refreshed.history_events) == 1
+    assert refreshed.history_events, "expected at least one history event"
     appended = refreshed.history_events[0]
     assert appended == {
         "run_id": entry.run_id,
@@ -177,7 +177,7 @@ def test_send_posts_webhook_when_webhook_url_set(monkeypatch) -> None:
     # SSE sink
     sse = registry.get(entry.run_id).history_events
     # Webhook sink
-    assert len(posted) == 1
+    assert posted, "expected at least one webhook post"
     posted_url, posted_payload = posted[0]
     # Both sinks saw the SAME payload
     assert sse[0] == posted_payload
@@ -219,7 +219,7 @@ def test_sse_sink_failure_does_not_block_webhook(monkeypatch) -> None:
 
     asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
     # webhook still ran despite SSE failure
-    assert len(posted) == 1
+    assert posted, "expected webhook to fire even when SSE buffer raises"
 
 
 def test_webhook_sink_failure_does_not_block_sse(monkeypatch) -> None:
@@ -282,7 +282,7 @@ def test_a2a_intervention_bus_on_dispatch_appends_input_required_to_history() ->
     asyncio.run(_drive())
 
     refreshed = registry.get(entry.run_id)
-    assert len(refreshed.history_events) == 1
+    assert refreshed.history_events, "expected at least one history event"
     appended = refreshed.history_events[0]
     assert appended["status"] == "input-required"
     assert appended["kind"] == "permission.confirm"

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -40,7 +40,7 @@ def test_compaction_completed_emits_system_marker() -> None:
         data={"new_turn_count": 8, "covers_through_seq": 42},
     ))
     msgs = _drain(q)
-    assert len(msgs) == 1
+    assert msgs, "expected at least one outbox message"
     assert msgs[0].kind == "system"
     assert msgs[0].text == "[↑ 8 turns compacted]"
 
@@ -68,7 +68,7 @@ def test_compaction_missing_count_uses_generic_marker() -> None:
     fwd = ChatLifecycleForwarder(q)
     fwd(Event(type="compaction_completed", data={}))
     msgs = _drain(q)
-    assert len(msgs) == 1
+    assert msgs, "expected at least one outbox message"
     assert msgs[0].text == "[↑ history compacted]"
 
 
@@ -138,7 +138,7 @@ def test_budget_warn_emits_lifecycle_marker_with_pct() -> None:
         },
     ))
     msgs = _drain(q)
-    assert len(msgs) == 1
+    assert msgs, "expected at least one outbox message"
     assert msgs[0].kind == "system"
     assert msgs[0].text == "[↑ budget warn: daily_tokens (80%)]"
 
@@ -156,7 +156,7 @@ def test_budget_warn_without_numeric_context_drops_pct() -> None:
         data={"dimension": "rate_limit"},
     ))
     msgs = _drain(q)
-    assert len(msgs) == 1
+    assert msgs, "expected at least one outbox message"
     assert msgs[0].text == "[↑ budget warn: rate_limit]"
 
 

--- a/tests/test_hot_list_updated_emit.py
+++ b/tests/test_hot_list_updated_emit.py
@@ -41,10 +41,10 @@ def test_tracker_fires_callback_on_first_record() -> None:
         on_ranking_changed=lambda r: seen.append(r),
     )
     tracker.record("file__read")
-    (only,) = seen
-    assert only[0]["qualified_name"] == "file__read"
-    assert only[0]["freq"] == 1
-    assert isinstance(only[0]["last_ts"], float)
+    assert seen, "expected callback to fire at least once"
+    assert seen[0][0]["qualified_name"] == "file__read"
+    assert seen[0][0]["freq"] == 1
+    assert isinstance(seen[0][0]["last_ts"], float)
 
 
 def test_tracker_fires_callback_on_reorder() -> None:
@@ -122,8 +122,12 @@ def test_full_ranking_includes_freq_and_last_ts() -> None:
     tracker.record("b")
     tracker.record("a")  # a now has freq=2
     ranking = tracker.full_ranking()
-    assert [r["qualified_name"] for r in ranking] == ["a", "b"]
+    assert ranking, "expected non-empty ranking"
+    names = [r["qualified_name"] for r in ranking]
+    assert "a" in names and "b" in names, "both recorded names must appear in ranking"
+    assert ranking[0]["qualified_name"] == "a"  # freq=2 outranks freq=1
     assert ranking[0]["freq"] == 2
+    assert ranking[1]["qualified_name"] == "b"
     assert ranking[1]["freq"] == 1
     for r in ranking:
         assert isinstance(r["last_ts"], float)
@@ -150,11 +154,17 @@ def test_lifecycle_forwarder_forwards_hot_list_updated() -> None:
             {"qualified_name": "web__search", "freq": 2, "last_ts": time.time()},
         ]},
     ))
-    (msg,) = _drain(q)
-    assert msg.kind == "hot_list_updated"
-    assert msg.text == ""  # data signal, not display
-    ranking = msg.meta["ranking"]
-    assert [r["qualified_name"] for r in ranking] == ["file__read", "web__search"]
+    msgs = _drain(q)
+    assert msgs, "expected at least one outbox message"
+    assert msgs[0].kind == "hot_list_updated"
+    assert msgs[0].text == ""  # data signal, not display
+    ranking = msgs[0].meta["ranking"]
+    assert ranking, "expected non-empty ranking in outbox message"
+    names = [r["qualified_name"] for r in ranking]
+    assert "file__read" in names and "web__search" in names, (
+        "both input entries must appear in ranking"
+    )
+    assert ranking[0]["qualified_name"] == "file__read"
     assert ranking[0]["freq"] == 5
 
 
@@ -163,5 +173,6 @@ def test_lifecycle_forwarder_empty_ranking_ok() -> None:
     q: asyncio.Queue = asyncio.Queue()
     fwd = ChatLifecycleForwarder(q)
     fwd(Event(type="hot_list_updated", data={}))
-    (msg,) = _drain(q)
-    assert msg.meta["ranking"] == []
+    msgs = _drain(q)
+    assert msgs, "expected at least one outbox message"
+    assert msgs[0].meta["ranking"] == []


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 9 PR T4 (= lifecycle/A2A/hot-list subset).

## Summary

3 test files / 12 format-pinning violations → 0.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Format-pinning errors | 12 | **0** |
| Tests passing | 27 | **27** |

## Per-file fix shape

**\`tests/test_chat_lifecycle_forwarder.py\` (4)**
- 4x \`len(msgs) == 1\` → \`assert msgs\` across 4 tests

**\`tests/test_a2a_sse_producer_267_gap1.py\` (4)**
- 2x \`len(refreshed.history_events) == 1\` → truthy
- 2x \`len(posted) == 1\` → truthy

**\`tests/test_hot_list_updated_emit.py\` (5 incl. iteration)**
- \`len(seen) == 1\` → \`assert seen\`
- \`len(ranking) == 2\` → \`assert ranking\` + content membership (\`"a" in names + "b" in names\`)
- \`len(msgs) == 1\` → \`assert msgs\` + ranking membership for tool names
- \`len(msgs) == 1\` → \`assert msgs\` (= 4th case)

## Test plan

- [x] \`venv/bin/pytest <3 files>\`: 27/27 passed
- [x] \`python scripts/test_tier_audit.py <3 files>\`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)