### PR TITLE
fix(tests): Tier audit fixes for test_replay_multi_hop.py

### DIFF
--- a/tests/test_replay_multi_hop.py
+++ b/tests/test_replay_multi_hop.py
@@ -142,7 +142,7 @@ def test_agent_a_produces_delegation_with_chain_id():
 
 @pytest.mark.replay("fixtures/llm/multi_hop/agent_delegation.jsonl")
 def test_chain_id_in_input_affects_fixture_key():
-    """Tier 3a drift detection: changing chain_id changes the prompt hash → MissingFixture.
+    """Tier 3a: drift detection — changing chain_id changes the prompt hash → MissingFixture.
 
     Protects: chain_id must be part of the ContextFrame hash so that a
     different chain_id produces a different fixture key. If the hash did not
@@ -180,7 +180,7 @@ def test_chain_id_in_input_affects_fixture_key():
 )
 @pytest.mark.replay("fixtures/llm/multi_hop/cycle_a_b_a.jsonl")
 def test_agent_a_refuses_self_loop_in_chain():
-    """Tier 3a corner: Agent A sees a chain that already includes itself → must not delegate again.
+    """Tier 3a: corner — Agent A sees a chain that already includes itself → must not delegate again.
 
     Single-LLM-call exercise: the chain history shown to Agent A indicates
     it already participated upstream. A correct multi-hop policy should not
@@ -264,7 +264,7 @@ def test_agent_a_refuses_self_loop_in_chain():
 
 @pytest.mark.replay("fixtures/llm/multi_hop/chain_timeout_mid_relay.jsonl")
 def test_agent_acknowledges_imminent_chain_timeout():
-    """Tier 3a corner: chain metadata flags timeout imminent → agent must not start a new relay.
+    """Tier 3a: corner — chain metadata flags timeout imminent → agent must not start a new relay.
 
     Multi-call timeout firing during a real LLM call belongs to Tier 3b
     (cannot be reproduced in a single call). We pin the simpler invariant:
@@ -327,6 +327,6 @@ def test_agent_acknowledges_imminent_chain_timeout():
     art_data = data["artifact"]["data"]
     # When chain budget is exhausted, the agent must not start a new delegation.
     msgs = art_data.get("messages_to_agents", [])
-    assert len(msgs) == 0, (
+    assert not msgs, (
         f"Agent should not delegate when chain_status=exhausted; got {msgs}"
     )

--- a/tests/test_skill_postprocessor_executor.py
+++ b/tests/test_skill_postprocessor_executor.py
@@ -191,8 +191,8 @@ def test_postprocessor_validate_step_fails_raises_error() -> None:
 
     # step_failed event emitted
     failed_events = [e for e in events._collected if e.type == "postprocessor_step_failed"]
-    assert len(failed_events) == 1
-    assert failed_events[0].data["step_index"] == 0
+    (only,) = failed_events
+    assert only.data["step_index"] == 0
 
 
 # ── Tier 2: output_schema validation at the end ───────────────────────────────
@@ -263,13 +263,9 @@ def test_postprocessor_events_emitted_for_each_step() -> None:
 
     started = [e for e in events._collected if e.type == "postprocessor_step_started"]
     completed = [e for e in events._collected if e.type == "postprocessor_step_completed"]
-    assert len(started) == 2
-    assert len(completed) == 2
     # Steps are indexed correctly
-    assert started[0].data["step_index"] == 0
-    assert started[1].data["step_index"] == 1
-    assert completed[0].data["step_index"] == 0
-    assert completed[1].data["step_index"] == 1
+    assert [e.data["step_index"] for e in started] == [0, 1]
+    assert [e.data["step_index"] for e in completed] == [0, 1]
 
 
 # ── Tier 2: multiple steps applied in order ───────────────────────────────────
@@ -300,7 +296,7 @@ def test_postprocessor_multiple_steps_applied_in_order() -> None:
     # First step completed, second step failed
     completed = [e for e in events._collected if e.type == "postprocessor_step_completed"]
     failed = [e for e in events._collected if e.type == "postprocessor_step_failed"]
-    assert len(completed) == 1
-    assert completed[0].data["step_index"] == 0
-    assert len(failed) == 1
-    assert failed[0].data["step_index"] == 1
+    (completed_only,) = completed
+    (failed_only,) = failed
+    assert completed_only.data["step_index"] == 0
+    assert failed_only.data["step_index"] == 1


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `tests/test_replay_multi_hop.py`

## Summary
- 4 violations resolved.
- 0 audit errors (was 4).

Refs PR-12 through PR-24.