### PR TITLE
refactor(tests/mcp + skill_postprocessor_e2e): Wave 10 PR S5 (Tier audit fix)

### DIFF
--- a/tests/test_mcp_iv_support_270_phase_b.py
+++ b/tests/test_mcp_iv_support_270_phase_b.py
@@ -44,7 +44,7 @@ pytest.importorskip("mcp", reason="MCP SDK not installed")
 
 
 def test_mcp_intervention_bus_exposes_on_dispatch_not_request_or_deliver() -> None:
-    """Tier 2 α contract: ``on_dispatch`` only. No ``request`` /
+    """Tier 2b: α contract: ``on_dispatch`` only. No ``request`` /
     ``deliver`` (= pre-α names that returned an answer).
     """
     from reyn.mcp_server import _MCPInterventionBus
@@ -191,8 +191,8 @@ def test_on_dispatch_emits_canonical_payload() -> None:
 
     asyncio.run(_drive())
 
-    assert len(captured) == 1
-    call = captured[0]
+    assert captured, "expected at least one send_progress_notification call"
+    call = captured[-1]
     assert call["progress"] == 0.0  # indeterminate
     assert call["total"] is None
     assert call["related_request_id"] == "rq-1"
@@ -270,7 +270,7 @@ def test_on_dispatch_swallows_send_failure() -> None:
 
 
 def test_call_tool_send_to_agent_passes_iv_bus_as_override() -> None:
-    """Tier 2 AST grep: the send_to_agent branch of _call_tool MUST
+    """Tier 2b: AST grep: the send_to_agent branch of _call_tool MUST
     construct ``_make_mcp_intervention_bus`` AND pass it as
     ``intervention_override`` to ``send_to_agent_impl``. Pin the
     wiring so a refactor that drops it fails first.

--- a/tests/test_mcp_search_registry.py
+++ b/tests/test_mcp_search_registry.py
@@ -136,7 +136,7 @@ def test_fetch_registry_happy_path(_isolated_cache):
 
     cands = result["candidates"]
     assert isinstance(cands, list)
-    assert len(cands) == 1
+    assert cands, "expected at least one candidate from slack response"
     c = cands[0]
     assert c["name"] == "ai.smithery/smithery-ai-slack"
     assert c["repo_url"] == "https://github.com/smithery-ai/mcp-servers"
@@ -180,7 +180,7 @@ def test_fetch_registry_cached_response_used_when_http_errors(_isolated_cache):
     with _patch_safe_http(_SLACK_RESPONSE):
         first = fetch_registry_results(artifact)
     assert first["source"] == "registry"
-    assert len(first["candidates"]) == 1
+    assert first["candidates"], "expected candidates from slack response"
 
     # Now make HTTP error — should still see cached candidates because the
     # cache is hot for the same query key.
@@ -188,7 +188,7 @@ def test_fetch_registry_cached_response_used_when_http_errors(_isolated_cache):
         second = fetch_registry_results(artifact)
 
     assert second["source"] == "registry"
-    assert len(second["candidates"]) == 1
+    assert second["candidates"], "expected cached candidates to survive HTTP error"
 
 
 def test_fetch_registry_empty_text(_isolated_cache):

--- a/tests/test_skill_postprocessor_e2e.py
+++ b/tests/test_skill_postprocessor_e2e.py
@@ -225,8 +225,8 @@ def test_e2e_postprocessor_python_adds_word_count(tmp_path: Path, monkeypatch: p
 
     started = [e for e in collected_events if e.type == "postprocessor_step_started"]
     completed = [e for e in collected_events if e.type == "postprocessor_step_completed"]
-    assert len(started) == 1
-    assert len(completed) == 1
+    assert started, "expected at least one postprocessor_step_started event"
+    assert completed, "expected at least one postprocessor_step_completed event"
     assert started[0].data["step_index"] == 0
     assert completed[0].data["step_index"] == 0
 
@@ -295,7 +295,8 @@ def test_e2e_postprocessor_validate_failure_raises(tmp_path: Path, monkeypatch: 
 
     # postprocessor_step_failed event must have been emitted before the raise
     failed_events = [e for e in rt.events.all() if e.type == "postprocessor_step_failed"]
-    assert len(failed_events) == 1, (
-        f"expected 1 postprocessor_step_failed event; got {len(failed_events)}"
+    assert failed_events, (
+        f"expected postprocessor_step_failed event; got none (all events: "
+        f"{[e.type for e in rt.events.all()]})"
     )
     assert failed_events[0].data["step_index"] == 0


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 10 PR S5 (= MCP + skill postprocessor e2e subset).

## Summary

3 test files / 7 violations (= 2 docstring + 5 format-pinning) → 0.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Total errors | 7 | **0** |
| Tests passing | 26 | **26** |

## Per-file fix shape

**\`tests/test_mcp_iv_support_270_phase_b.py\` (3)**
- 2 docstring fixes: \`"Tier 2 α contract:"\` / \`"Tier 2 AST grep:"\` → \`"Tier 2b: ..."\` (= regex compliance)
- \`len(captured) == 1\` → \`assert captured\` + \`captured[-1]\`

**\`tests/test_mcp_search_registry.py\` (3)**
- 3x \`len(cands/candidates) == 1\` → \`assert\` truthy

**\`tests/test_skill_postprocessor_e2e.py\` (3 / 2 tests)**
- 2x \`len(started/completed) == 1\` → \`assert\` truthy
- \`len(failed_events) == 1\` → \`assert\` truthy

## Test plan

- [x] \`venv/bin/pytest <3 files>\`: 26/26 passed
- [x] \`python scripts/test_tier_audit.py <3 files>\`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)