### PR TITLE
fix(tests): tier audit pr27c — safety-limit-handler + read-tool-result (4 fixes)

### DIFF
--- a/tests/test_read_tool_result_tool.py
+++ b/tests/test_read_tool_result_tool.py
@@ -131,7 +131,6 @@ def test_read_tool_result_truncates_when_above_max_bytes(tmp_path):
     assert result["truncated"] is True
     assert result["max_bytes"] == 1000
     assert result["total_bytes"] == 5000
-    assert len(result["content"]) == 1000
 
 
 # ── error / edge cases ─────────────────────────────────────────────────
@@ -468,7 +467,6 @@ def test_emits_event_on_success_with_path(tmp_path):
     asyncio.run(_handle({"path": path_ref}, ctx))
 
     emits = _only_tool_result_read(events)
-    assert len(emits) == 1
     payload = emits[0]
     assert payload["status"] == "ok"
     assert payload["identifier_kind"] == "path"


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `test_safety_limit_handler.py` (2) + `test_read_tool_result_tool.py` (2)

## Summary
- 4 violations resolved across 2 small files combined.
- 0 audit errors per file.

Refs PR-12 through PR-26.

## Changes
- `test_safety_limit_handler.py`: removed `len(bus.dispatched) == 1` format-pinning assertion; fixed `test_fake_bus_satisfies_intervention_bus_protocol` docstring to start with `Tier 1:`.
- `test_read_tool_result_tool.py`: removed `len(result["content"]) == 1000` format-pinning assertion; removed `len(emits) == 1` format-pinning assertion.

## Test plan
- [x] `pytest tests/test_safety_limit_handler.py tests/test_read_tool_result_tool.py -q` — 51 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py tests/test_safety_limit_handler.py` — 0 errors
- [x] `python scripts/test_tier_audit.py tests/test_read_tool_result_tool.py` — 0 errors