### PR TITLE
fix(tests): Tier audit fixes — test_tool_recall.py (2) + test_tool_arg_synonym_normalization.py (2)

### DIFF
--- a/tests/test_tool_arg_synonym_normalization.py
+++ b/tests/test_tool_arg_synonym_normalization.py
@@ -67,7 +67,6 @@ async def test_write_file_accepts_text_synonym(monkeypatch):
     args = {"path": "output.txt", "text": "hello world"}
     result = await WRITE_FILE.handler(args, ctx)
 
-    assert len(captured_ops) == 1
     op = captured_ops[0]
     assert isinstance(op, FileIROp)
     assert op.op == "write"
@@ -153,7 +152,6 @@ async def test_drop_source_accepts_source_id_synonym(monkeypatch):
     args = {"source_id": "my_corpus"}
     result = await DROP_SOURCE.handler(args, ctx)
 
-    assert len(captured_ops) == 1
     op = captured_ops[0]
     assert isinstance(op, IndexDropIROp)
     assert op.kind == "index_drop"

--- a/tests/test_tool_recall.py
+++ b/tests/test_tool_recall.py
@@ -163,7 +163,6 @@ async def test_recall_handler_builds_recall_ir_op(monkeypatch):
     }
     result = await RECALL.handler(args, ctx)
 
-    assert len(captured_ops) == 1
     op = captured_ops[0]
     assert isinstance(op, RecallIROp)
     assert op.kind == "recall"
@@ -195,7 +194,6 @@ async def test_recall_handler_defaults(monkeypatch):
     args = {"query": "test query", "sources": ["my_source"]}
     await RECALL.handler(args, ctx)
 
-    assert len(captured_ops) == 1
     op = captured_ops[0]
     assert isinstance(op, RecallIROp)
     assert op.top_k == 5


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: \`test_tool_recall.py\` (2) + \`test_tool_arg_synonym_normalization.py\` (2)

## Summary
- 4 violations resolved: \`len(captured_ops) == 1\` format-pinning assertions removed from 4 tests across both files.
- 0 audit errors per file (was 2 each).
- All 21 tests pass, ruff clean.

Refs PR-12 through PR-27.

## Test plan
- [x] \`python -m pytest tests/test_tool_recall.py tests/test_tool_arg_synonym_normalization.py -q\` → 21 passed
- [x] \`ruff check .\` → All checks passed
- [x] \`python scripts/test_tier_audit.py tests/test_tool_recall.py\` → 0 errors
- [x] \`python scripts/test_tier_audit.py tests/test_tool_arg_synonym_normalization.py\` → 0 errors