### PR TITLE
fix(tests): tier audit fixes for input-hint router + stdlib fallback (PR-28c)

### DIFF
--- a/tests/test_router_list_skills_input_hint.py
+++ b/tests/test_router_list_skills_input_hint.py
@@ -103,9 +103,9 @@ def test_list_skills_result_includes_input_artifact():
     loop = _make_loop(skills)
     result = loop._list_skills("general")
 
-    assert len(result) == 1
-    item = result[0]
-    assert item["name"] == "my_skill"
+    by_name = {r["name"]: r for r in result}
+    assert "my_skill" in by_name, "my_skill must appear in list_skills result"
+    item = by_name["my_skill"]
     assert item.get("input_artifact") == "my_request", (
         "input_artifact must be present in list_skills result when catalogue entry has it"
     )
@@ -227,9 +227,9 @@ def test_list_skills_no_input_hint_is_safe():
     loop = _make_loop(skills)
     result = loop._list_skills("general")
 
-    assert len(result) == 1
-    item = result[0]
-    assert item["name"] == "bare_skill"
+    by_name = {r["name"]: r for r in result}
+    assert "bare_skill" in by_name, "bare_skill must appear in list_skills result"
+    item = by_name["bare_skill"]
     # Fields must be absent (not present with None value)
     assert "input_artifact" not in item, (
         "input_artifact must not appear when the catalogue entry lacks it"

--- a/tests/test_skill_input_hint_stdlib_fallback.py
+++ b/tests/test_skill_input_hint_stdlib_fallback.py
@@ -59,10 +59,10 @@ _STDLIB_ARTIFACTS = _REPO_ROOT / "src" / "reyn" / "stdlib" / "artifacts"
 
 
 def test_word_stats_demo_resolves_input_schema_from_stdlib_user_message():
-    """Tier 2 (B46-fix): ``word_stats_demo`` declares
-    ``input: user_message`` in its entry phase and has no local
-    ``artifacts/user_message.yaml``. After the fix, the hint must
-    resolve ``input_schema`` from the stdlib shared artifact at
+    """Tier 2: ``word_stats_demo`` declares ``input: user_message`` in
+    its entry phase and has no local ``artifacts/user_message.yaml``.
+    After the B46-fix, the hint must resolve ``input_schema`` from the
+    stdlib shared artifact at
     ``src/reyn/stdlib/artifacts/user_message.yaml``."""
     hint = _extract_skill_input_hint(
         _STDLIB_SKILLS / "word_stats_demo", "review",
@@ -100,10 +100,10 @@ def test_stdlib_shared_user_message_artifact_exists_and_declares_text():
 
 
 def test_enumerate_surfaces_input_schema_for_word_stats_demo():
-    """Tier 2 (B46-fix end-to-end): ``enumerate_available_skills``
-    must surface ``input_schema`` on the ``word_stats_demo`` entry.
-    This is the data the hot-list alias builder reads to construct
-    ``skill__word_stats_demo`` wrapper parameters — without
+    """Tier 2: ``enumerate_available_skills`` must surface
+    ``input_schema`` on the ``word_stats_demo`` entry (B46-fix
+    end-to-end). This is the data the hot-list alias builder reads to
+    construct ``skill__word_stats_demo`` wrapper parameters — without
     input_schema present here, the wrapper falls back to
     ``properties: {}, additionalProperties: true`` and the LLM
     calls the skill with ``{}`` (= B46 W2 S6 R verdict)."""


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `test_router_list_skills_input_hint.py` (2) + `test_skill_input_hint_stdlib_fallback.py` (2)

## Summary
- 4 violations resolved.
- 0 audit errors per file.

Refs PR-12 through PR-27.

### Changes

**`test_router_list_skills_input_hint.py`** (2 errors → 0):
- Line 106: removed `len(result) == 1` format-pinning assertion; replaced with `by_name` lookup (behavior pin)
- Line 230: same fix in `test_list_skills_no_input_hint_is_safe`

**`test_skill_input_hint_stdlib_fallback.py`** (2 errors → 0):
- Line 61: docstring `Tier 2 (B46-fix):` → `Tier 2:` (tag moved to body)
- Line 102: docstring `Tier 2 (B46-fix end-to-end):` → `Tier 2:` (tag moved to body)

## Test plan
- [x] `python -m pytest tests/test_router_list_skills_input_hint.py tests/test_skill_input_hint_stdlib_fallback.py -q` — 13 passed
- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_router_list_skills_input_hint.py` — 0 errors
- [x] `python scripts/test_tier_audit.py tests/test_skill_input_hint_stdlib_fallback.py` — 0 errors