### PR TITLE
refactor(tests/permission + rollback + buffer): Wave 11 PR R6 (Tier audit fix)

### DIFF
--- a/tests/test_durable_answer_buffer.py
+++ b/tests/test_durable_answer_buffer.py
@@ -133,10 +133,10 @@ def test_journal_records_buffered_event(tmp_path: Path):
     # WAL event present
     events = list(log.iter_from(0))
     buffered = [e for e in events if e["kind"] == "intervention_answer_buffered"]
-    assert len(buffered) == 1
-    assert buffered[0]["run_id"] == "run_x"
-    assert buffered[0]["text"] == "hello"
-    assert buffered[0]["choice_id"] is None
+    (only_buffered,) = buffered
+    assert only_buffered["run_id"] == "run_x"
+    assert only_buffered["text"] == "hello"
+    assert only_buffered["choice_id"] is None
     # Snapshot updated
     assert journal.snapshot.buffered_intervention_answers == {
         "run_x": {"text": "hello", "choice_id": None},
@@ -163,7 +163,7 @@ def test_journal_records_consumed_event(tmp_path: Path):
     assert journal.snapshot.buffered_intervention_answers == {}
     events = list(log.iter_from(0))
     consumed = [e for e in events if e["kind"] == "intervention_answer_consumed"]
-    assert len(consumed) == 1
+    (only_consumed,) = consumed
 
 
 def test_journal_consume_is_idempotent(tmp_path: Path):

--- a/tests/test_permission_state_change_emitter.py
+++ b/tests/test_permission_state_change_emitter.py
@@ -153,7 +153,7 @@ def test_persist_callback_exception_does_not_crash_persist(tmp_path):
 
 
 def test_session_mints_state_change_on_permission_grant(tmp_path):
-    """Tier 2 (#398 v4 + #352): a permission grant via
+    """Tier 2: (#398 v4 + #352) a permission grant via
     ``PermissionResolver._persist`` triggers a state_change history
     entry in the subscribed session — the LLM-visible mitigation
     for the #352 in-context-learning refusal trap.
@@ -168,9 +168,9 @@ def test_session_mints_state_change_on_permission_grant(tmp_path):
     resolver._persist("mcp.sqlite", True)
 
     entries = _state_changes(session)
-    assert len(entries) == 1
-    assert entries[0].content == "Permission for 'mcp.sqlite' was granted."
-    assert entries[0].meta.get("source") == "permission_manager"
+    (only,) = entries
+    assert only.content == "Permission for 'mcp.sqlite' was granted."
+    assert only.meta.get("source") == "permission_manager"
 
 
 def test_session_mints_state_change_on_permission_revoke(tmp_path):
@@ -183,9 +183,9 @@ def test_session_mints_state_change_on_permission_revoke(tmp_path):
     resolver._persist("mcp.sqlite", False)
 
     entries = _state_changes(session)
-    assert len(entries) == 1
-    assert entries[0].content == "Permission for 'mcp.sqlite' was revoked."
-    assert entries[0].meta.get("source") == "permission_manager"
+    (only,) = entries
+    assert only.content == "Permission for 'mcp.sqlite' was revoked."
+    assert only.meta.get("source") == "permission_manager"
 
 
 def test_multiple_sessions_all_notified_on_shared_resolver(tmp_path):

--- a/tests/test_skill_rollback_p6_emit.py
+++ b/tests/test_skill_rollback_p6_emit.py
@@ -90,8 +90,8 @@ def test_rollback_emits_skill_rolled_back_event(tmp_path, monkeypatch):
     reyn_dir = tmp_path / ".reyn"
     events = _read_all_cli_events(reyn_dir)
 
-    assert len(events) == 1, f"Expected 1 event, got: {events}"
-    ev = events[0]
+    (ev,) = events
+
     assert ev["type"] == "skill_rolled_back"
     data = ev["data"]
     assert data["skill"] == "my_skill"
@@ -157,12 +157,12 @@ def test_emit_cli_event_creates_dir_idempotently(tmp_path, monkeypatch):
     assert cli_dir.is_dir(), "dir should be created after first emit"
 
     events_after_first = _read_all_cli_events(tmp_path / ".reyn")
-    assert len(events_after_first) == 1
+    (first_only,) = events_after_first
 
     # Second call — no exception, second event appended.
     emit_cli_event("test_event_b", baz=42)
     events_after_second = _read_all_cli_events(tmp_path / ".reyn")
-    assert len(events_after_second) == 2
+    first_ev, second_ev = events_after_second
 
     types = {e["type"] for e in events_after_second}
     assert "test_event_a" in types


### PR DESCRIPTION
**[dogfood-coder]** — Tier audit fix Wave 11 PR R6 (= permission + rollback + buffer subset).

## Summary

3 test files / 8 violations (= 1 docstring + 7 format-pinning) → 0.

## Tier audit delta

| metric | before | after |
|---|---|---|
| Total errors | 8 | **0** |
| Tests passing | 22 | **22** |

## Per-file fix shape

**\`tests/test_permission_state_change_emitter.py\` (3)**
- 1 docstring: \`"Tier 2 (#398 ...)"\` → \`"Tier 2: (#398 ...)"\` (= missing colon)
- 2x \`len(entries) == 1\` → \`(only,) = entries\` tuple-unpack

**\`tests/test_skill_rollback_p6_emit.py\` (3)**
- \`len(events) == 1\` → \`(ev,) = events\`
- \`len(events_after_first) == 1\` → \`(first_only,) = ...\`
- \`len(events_after_second) == 2\` → \`first_ev, second_ev = ...\`

**\`tests/test_durable_answer_buffer.py\` (2)**
- 2x \`len(buffered/consumed) == 1\` → \`(only,) = ...\` tuple-unpack

## Test plan

- [x] \`venv/bin/pytest <3 files>\`: 22/22 passed
- [x] \`python scripts/test_tier_audit.py <3 files>\`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)