### PR TITLE
fix(tests): Tier audit fix: test_mcp_server_progress_271.py (2) + test_mcp_search_registry.py (2)

### DIFF
--- a/tests/test_mcp_search_registry.py
+++ b/tests/test_mcp_search_registry.py
@@ -136,7 +136,7 @@ def test_fetch_registry_happy_path(_isolated_cache):
 
     cands = result["candidates"]
     assert isinstance(cands, list)
-    assert len(cands) == 1
+    assert cands, "expected at least one candidate in registry result"
     c = cands[0]
     assert c["name"] == "ai.smithery/smithery-ai-slack"
     assert c["repo_url"] == "https://github.com/smithery-ai/mcp-servers"
@@ -180,7 +180,7 @@ def test_fetch_registry_cached_response_used_when_http_errors(_isolated_cache):
     with _patch_safe_http(_SLACK_RESPONSE):
         first = fetch_registry_results(artifact)
     assert first["source"] == "registry"
-    assert len(first["candidates"]) == 1
+    assert first["candidates"], "expected candidates from initial registry fetch"
 
     # Now make HTTP error — should still see cached candidates because the
     # cache is hot for the same query key.
@@ -188,7 +188,7 @@ def test_fetch_registry_cached_response_used_when_http_errors(_isolated_cache):
         second = fetch_registry_results(artifact)
 
     assert second["source"] == "registry"
-    assert len(second["candidates"]) == 1
+    assert second["candidates"], "expected cached candidates to be surfaced on HTTP error"
 
 
 def test_fetch_registry_empty_text(_isolated_cache):

--- a/tests/test_mcp_server_progress_271.py
+++ b/tests/test_mcp_server_progress_271.py
@@ -117,7 +117,7 @@ async def test_bridge_forwards_phase_started_as_progress_notification() -> None:
         # Yield to let the spawned task run.
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        assert len(fake_mcp.calls) == 1
+        assert fake_mcp.calls, "expected at least one progress notification call"
         call = fake_mcp.calls[0]
         assert call["progress_token"] == "tok-1"
         assert call["progress"] == 1.0
@@ -260,7 +260,7 @@ async def test_bridge_swallows_send_progress_notification_errors() -> None:
         await asyncio.sleep(0)
         # The second event was successfully forwarded.
         success_calls = [c for c in fake_mcp.calls if c["message"] == "phase: y"]
-        assert len(success_calls) == 1
+        assert success_calls, "expected 'phase: y' notification to be forwarded after error recovery"
     finally:
         bridge.detach()
 


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: `test_mcp_server_progress_271.py` (2) + `test_mcp_search_registry.py` (2)

## Summary
- 4 violations resolved (format-pinning `len(x) == 1` → truthy/non-empty assertions).
- 0 audit errors per file.

Refs PR-12 through PR-28.

## Test plan
- [x] `python -m pytest tests/test_mcp_server_progress_271.py tests/test_mcp_search_registry.py -q` — 23 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py tests/test_mcp_server_progress_271.py` — 0 errors
- [x] `python scripts/test_tier_audit.py tests/test_mcp_search_registry.py` — 0 errors