### PR TITLE
refactor(tests/budget + resume): Wave 12 PR R7 (Tier audit fix)

### DIFF
--- a/tests/test_budget_persistence.py
+++ b/tests/test_budget_persistence.py
@@ -70,22 +70,22 @@ def test_save_state_includes_per_chain_skill_counters(tmp_path):
     chain_skill_calls = data.get("chain_skill_calls", [])
     matched = [
         e for e in chain_skill_calls
-        if (isinstance(e, list) and len(e) >= 3
-            and e[0] == "c1" and e[1] == "my_skill")
+        if (isinstance(e, list) and e[:2] == ["c1", "my_skill"])
     ]
     assert matched, (
         f"chain_skill_calls must include c1/my_skill; got {chain_skill_calls}"
     )
-    assert matched[0][2] == 1
+    chain_id, skill_name, calls = matched[0]
+    assert calls == 1
     # tokens are also persisted
     chain_skill_tokens = data.get("chain_skill_tokens", [])
     matched_tokens = [
         e for e in chain_skill_tokens
-        if (isinstance(e, list) and len(e) >= 3
-            and e[0] == "c1" and e[1] == "my_skill")
+        if (isinstance(e, list) and e[:2] == ["c1", "my_skill"])
     ]
     assert matched_tokens
-    assert matched_tokens[0][2] == 150
+    _, _, tokens = matched_tokens[0]
+    assert tokens == 150
 
 
 def test_load_state_restores_per_agent_counters(tmp_path):

--- a/tests/test_resume_auto_e2e.py
+++ b/tests/test_resume_auto_e2e.py
@@ -190,11 +190,11 @@ def test_e2e_chatsession_auto_resume_completes_crashed_skill(tmp_path: Path, mon
     decisions = asyncio.run(go())
 
     # Auto-resume found the active run, launched it with the right plan
-    assert len(decisions) == 1
-    assert decisions[0].plan.run_id == _RUN_ID
-    assert decisions[0].plan.skill_name == _SKILL_NAME
-    assert decisions[0].plan.current_phase == "review"
-    assert len(launched_decisions) == 1
+    (decision,) = decisions
+    assert decision.plan.run_id == _RUN_ID
+    assert decision.plan.skill_name == _SKILL_NAME
+    assert decision.plan.current_phase == "review"
+    (launched,) = launched_decisions
 
     # Skill completed → WAL has skill_completed, snapshot removed.
     log = StateLog(tmp_path / ".reyn" / "wal.jsonl")

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -254,8 +254,8 @@ def test_e2e_crash_during_phase2_then_resume_to_completion(tmp_path, monkeypatch
         state_log=state_log2,
         policy=SkillResumeConfig(),
     )
-    assert len(decisions) == 1, f"expected 1 active run, got {decisions}"
-    decision = decisions[0]
+    assert decisions, f"expected 1 active run, got {decisions}"
+    (decision,) = decisions
     # Clean run (no ambiguous step events were written): action='resume'
     assert decision.action == "resume"
     assert decision.plan.current_phase == "review"
@@ -321,8 +321,8 @@ def test_e2e_resume_emits_skill_resumed_audit_event(tmp_path, monkeypatch):
     # Inspect EventLog directly (post-run); skill_resumed must have been
     # emitted exactly once with run_id, resume_phase, and visit_counts.
     resumed = [e for e in rt.events.all() if e.type == "skill_resumed"]
-    assert len(resumed) == 1
-    ev = resumed[0]
+    assert resumed, "expected skill_resumed event to be emitted"
+    (ev,) = resumed
     assert ev.data["run_id"] == "run_e2e_001"
     assert ev.data["resume_phase"] == "review"
     assert ev.data["visit_counts"] == {"draft": 1}


### PR DESCRIPTION
**[dogfood-coder]** — Wave 12 PR R7, 3 files / 6 errors → 0, 12/12 passed.

| metric | before | after |
|---|---|---|
| Errors | 6 | **0** |
| Tests | 12 | 12 |

Per-file:
- `test_budget_persistence.py` (2): `len(e) >= 3` → slice equality + tuple-unpack
- `test_resume_auto_e2e.py` (2): `len == 1` → `(x,) = ...` tuple-unpack (= unpack asserts exactly 1)
- `test_resume_e2e.py` (2): same tuple-unpack pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)