### PR TITLE
fix(tests): tier-audit 4 errors — 3 small files combined

### DIFF
--- a/tests/test_chain_peer_discarded_notify.py
+++ b/tests/test_chain_peer_discarded_notify.py
@@ -120,7 +120,8 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
         e for e in events
         if e["kind"] == "chain_resolve" and e.get("chain_id") == "X-001"
     ]
-    assert len(resolve_events) == 1
+    (only_resolve,) = resolve_events
+    assert only_resolve["chain_id"] == "X-001"
 
 
 def test_handler_is_idempotent_when_chain_already_resolved(tmp_path: Path):
@@ -268,14 +269,16 @@ def test_slash_discard_notifies_upstream_chain_waiter(tmp_path: Path, monkeypatc
         e for e in events
         if e["kind"] == "chain_resolve" and e.get("chain_id") == "X-D14"
     ]
-    assert len(resolves) == 1
+    (only_resolve,) = resolves
+    assert only_resolve["chain_id"] == "X-D14"
     # 3. WAL also has skill_discarded for B's run
     discarded = [
         e for e in events
         if e["kind"] == "skill_discarded"
         and e.get("run_id") == "run_b_d14"
     ]
-    assert len(discarded) == 1
+    (only_discarded,) = discarded
+    assert only_discarded["run_id"] == "run_b_d14"
     # 4. B's running_skills_chain is cleaned up
     assert "run_b_d14" not in sess_b.running_skills_chain
 

--- a/tests/test_tool_description_role_separation.py
+++ b/tests/test_tool_description_role_separation.py
@@ -55,7 +55,7 @@ def test_invoke_action_description_signals_os_owned_spawn_ack() -> None:
 
 
 def test_invoke_action_description_no_dead_priority_block() -> None:
-    """Tier 2 regression guard: the description must NOT carry the obsolete
+    """Tier 2: regression guard: the description must NOT carry the obsolete
     'Priority 1/2/3/4' spawn-ack block. That block was dead code (the router
     exits before the LLM sees it) and reintroducing it would re-confuse the
     LLM about whether it's responsible for the spawn-ack reply.

--- a/tests/test_tool_drop_source.py
+++ b/tests/test_tool_drop_source.py
@@ -138,8 +138,7 @@ async def test_drop_source_handler_builds_index_drop_ir_op(monkeypatch):
     args = {"source": "my_source"}
     result = await DROP_SOURCE.handler(args, ctx)
 
-    assert len(captured_ops) == 1
-    op = captured_ops[0]
+    (op,) = captured_ops
     assert isinstance(op, IndexDropIROp)
     assert op.kind == "index_drop"
     assert op.source == "my_source"


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: 3 small files combined (4 errors total)

## Summary
- 4 violations resolved (strict patterns).
- 0 audit errors per file.

### Per-file detail
| File | Before | After | Fix |
|------|--------|-------|-----|
| `tests/test_chain_peer_discarded_notify.py` | 2 errors | 0 | `len(resolve_events)==1` → `(only_resolve,)=resolve_events`; `len(resolves)==1` → `(only_resolve,)=resolves`; `len(discarded)==1` → `(only_discarded,)=discarded` |
| `tests/test_tool_drop_source.py` | 1 error | 0 | `len(captured_ops)==1; op=captured_ops[0]` → `(op,)=captured_ops` |
| `tests/test_tool_description_role_separation.py` | 1 error | 0 | Docstring `"Tier 2 regression guard:"` → `"Tier 2:"` |

Refs PR-12 through PR-30.

## Test plan
- [x] `python -m pytest tests/test_chain_peer_discarded_notify.py tests/test_tool_drop_source.py tests/test_tool_description_role_separation.py -q` → 35 passed
- [x] `ruff check .` → All checks passed
- [x] `python scripts/test_tier_audit.py` on all 3 files → 0 errors each