### PR TITLE
test: Tier audit fixes for dispatcher_llm_args_hash + copy_to_work_validation (2+2)

### DIFF
--- a/tests/test_copy_to_work_validation_judgment.py
+++ b/tests/test_copy_to_work_validation_judgment.py
@@ -147,7 +147,7 @@ def _make_frame(skill, validation_ok: bool) -> ContextFrame:
 
 @pytest.mark.replay("fixtures/llm/copy_to_work_validation/validation_ok.jsonl")
 def test_copy_to_work_transitions_when_validation_ok():
-    """Tier 3a (LLM replay): copy_to_work phase transitions to run_and_eval when validation.ok=True.
+    """Tier 3a: copy_to_work phase transitions to run_and_eval when validation.ok=True.
 
     Pins the LLM judgment behavior for the positive case: the preprocessor
     reports a successful copy (validation.ok=True, files_written=files_expected),
@@ -215,7 +215,7 @@ def test_copy_to_work_transitions_when_validation_ok():
 )
 @pytest.mark.replay("fixtures/llm/copy_to_work_validation/validation_fail.jsonl")
 def test_copy_to_work_aborts_when_validation_fails():
-    """Tier 3a (LLM replay): copy_to_work phase aborts when validation.ok=False.
+    """Tier 3a: copy_to_work phase aborts when validation.ok=False.
 
     Pins the LLM judgment behavior for the failure case: the preprocessor
     reports a failed copy (validation.ok=False, files_written=0,

--- a/tests/test_dispatcher_llm_args_hash.py
+++ b/tests/test_dispatcher_llm_args_hash.py
@@ -106,7 +106,6 @@ def test_hash_format_matches_op_args_hash():
     """
     frame = {"phase": "draft"}
     h = _compute_llm_args_hash(model="m", frame=frame)
-    assert len(h) == 16
     assert all(c in "0123456789abcdef" for c in h)
 
 
@@ -116,4 +115,3 @@ def test_unhashable_frame_falls_back_safely():
     frame = {"phase": "draft", "callback": lambda x: x}
     h = _compute_llm_args_hash(model="m", frame=frame)
     assert isinstance(h, str)
-    assert len(h) == 16


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: \`test_dispatcher_llm_args_hash.py\` (2) + \`test_copy_to_work_validation_judgment.py\` (2)

## Summary
- 4 violations resolved (strict tuple-unpack / list-equality).
- 0 audit errors per file.

### test_dispatcher_llm_args_hash.py (2 errors → 0)
- Removed `len(h) == 16` from `test_hash_format_matches_op_args_hash` (line 109): format-pinning Tier 4 violation.
- Removed `len(h) == 16` from `test_unhashable_frame_falls_back_safely` (line 119): format-pinning Tier 4 violation.
- Remaining assertions (`all(c in "0123456789abcdef" ...)` and `isinstance(h, str)`) pin behavior, not size/shape.

### test_copy_to_work_validation_judgment.py (2 errors → 0)
- Fixed docstring format: `"Tier 3a (LLM replay): ..."` → `"Tier 3a: ..."` for both test functions.

## Test plan
- [x] `python -m pytest tests/test_dispatcher_llm_args_hash.py tests/test_copy_to_work_validation_judgment.py -q` — 10 passed, 1 xfailed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py tests/test_dispatcher_llm_args_hash.py` — 0 errors
- [x] `python scripts/test_tier_audit.py tests/test_copy_to_work_validation_judgment.py` — 0 errors

Refs PR-12 through PR-30.