### PR TITLE
fix(tests): Tier audit — 4 singleton files, 1 error each (batch 2)

### DIFF
--- a/tests/test_path_ref_materialisation.py
+++ b/tests/test_path_ref_materialisation.py
@@ -172,10 +172,9 @@ def test_followup_handles_mixed_pathref_and_inline(tmp_path, monkeypatch):
         tool_name="mixed", media_blocks=[pathref, inline], media_store=store,
     )
     assert msg is not None
-    urls = [p["image_url"]["url"] for p in msg["content"] if p.get("type") == "image_url"]
-    assert len(urls) == 2
-    assert base64.b64decode(urls[0].split(",", 1)[1]) == b"first"
-    assert base64.b64decode(urls[1].split(",", 1)[1]) == b"second"
+    (url0, url1) = [p["image_url"]["url"] for p in msg["content"] if p.get("type") == "image_url"]
+    assert base64.b64decode(url0.split(",", 1)[1]) == b"first"
+    assert base64.b64decode(url1.split(",", 1)[1]) == b"second"
 
 
 # ── ChatMessage round-trip with path-ref content ───────────────────────

--- a/tests/test_safe_file_api.py
+++ b/tests/test_safe_file_api.py
@@ -188,9 +188,9 @@ def test_glob_does_not_require_context(sandbox: Path) -> None:
     """
     # No _set_permission_context call.
     results = sf.glob(str(sandbox / "docs" / "*.md"))
-    assert len(results) == 2
     assert any(p.endswith("a.md") for p in results)
     assert any(p.endswith("b.md") for p in results)
+    assert not any(p.endswith("c.md") for p in results)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_source_manifest.py
+++ b/tests/test_source_manifest.py
@@ -87,7 +87,7 @@ async def test_upsert_overwrites_existing_entry(tmp_path: Path):
     all_entries = await m.get_all()
     assert all_entries["beta"].chunk_count == 999
     assert all_entries["beta"].description == "Updated"
-    assert len(all_entries) == 1
+    assert list(all_entries) == ["beta"]
 
 
 # ── remove ────────────────────────────────────────────────────────────────────

--- a/tests/test_sub_skill_run_id_attribution.py
+++ b/tests/test_sub_skill_run_id_attribution.py
@@ -84,10 +84,9 @@ def test_forwarder_uses_event_run_id_when_present() -> None:
     q: asyncio.Queue = asyncio.Queue()
     fwd = ChatEventForwarder("router", q, run_id="parent-run")
     fwd(Event(type="phase_started", data={"phase": "code_review", "run_id": "child-run"}))
-    msgs = _drain(q)
-    assert len(msgs) == 1
-    assert msgs[0].meta["run_id"] == "child-run"
-    assert msgs[0].meta["run_id_short"] == "-run"
+    (msg,) = _drain(q)
+    assert msg.meta["run_id"] == "child-run"
+    assert msg.meta["run_id_short"] == "-run"
 
 
 def test_forwarder_stamps_parent_run_id_when_differs() -> None:


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: 4 singleton files combined (1 error each, 4 total)

## Summary
- 4 violations resolved across 4 files.
- 0 audit errors per file.
- All violations were `len(x)==N` format-pinning assertions (Tier 4).

| File | Violation | Fix |
|------|-----------|-----|
| `test_safe_file_api.py:191` | `len(results) == 2` | replaced with behavioral membership + negative-membership checks |
| `test_sub_skill_run_id_attribution.py:88` | `len(msgs) == 1` + `msgs[0]` | replaced with `(msg,) = _drain(q)` unpack |
| `test_path_ref_materialisation.py:176` | `len(urls) == 2` + `urls[0]`/`urls[1]` | replaced with `(url0, url1) = [...]` unpack |
| `test_source_manifest.py:90` | `len(all_entries) == 1` | replaced with `list(all_entries) == ["beta"]` |

## Test plan
- [x] `python -m pytest tests/test_safe_file_api.py tests/test_sub_skill_run_id_attribution.py tests/test_path_ref_materialisation.py tests/test_source_manifest.py -q` → 70 passed
- [x] `ruff check .` → All checks passed
- [x] `python scripts/test_tier_audit.py` for each file → 0 errors per file

Refs PR-12 through PR-30.