### PR TITLE
fix(tests): Tier audit - 4 mixed singleton violations (PR-33c)

### DIFF
--- a/tests/test_llm_result_ref_integration.py
+++ b/tests/test_llm_result_ref_integration.py
@@ -85,11 +85,10 @@ def test_runtime_offloads_large_llm_result_and_writes_ref_in_wal(tmp_path: Path)
     asyncio.run(go())
 
     # WAL: result is a {"_ref": ...} placeholder
-    completed = [
+    (only,) = [
         e for e in log.iter_from(0) if e["kind"] == "step_completed"
     ]
-    assert len(completed) == 1
-    wal_result = completed[0]["result"]
+    wal_result = only["result"]
     assert isinstance(wal_result, dict)
     assert list(wal_result.keys()) == ["_ref"]
     assert wal_result["_ref"] == "hash_int.json"

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -205,18 +205,15 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
 
     # Two mcp_progress events should have been emitted with the
     # structured fields the forwarder consumes.
-    progress_events = [
+    first, last = [
         e.model_dump(mode="json") for e in events.all()
         if e.type == "mcp_progress"
     ]
-    assert len(progress_events) == 2
-    first = progress_events[0]
     assert first["data"]["server"] == "demo"
     assert first["data"]["tool"] == "thing"
     assert first["data"]["progress"] == 0.25
     assert first["data"]["total"] == 1.0
     assert first["data"]["message"] == "starting"
-    last = progress_events[-1]
     assert last["data"]["progress"] == 1.0
     assert last["data"]["message"] == "done"
 

--- a/tests/test_media_store.py
+++ b/tests/test_media_store.py
@@ -469,7 +469,7 @@ def test_multiple_saved_tool_results_all_retained(tmp_path):
         assert body == f"entry {i}\n"
     # Directory listing has all 10 files (= no auto-cleanup).
     files = list(store.tool_results_dir.iterdir())
-    assert len(files) == 10
+    assert len(files) == len(blocks)
 
 
 # ── url field (#385 β core impl sub-task 3b) ──────────────────────────

--- a/tests/test_run_skill_form4_hallucination_recovery.py
+++ b/tests/test_run_skill_form4_hallucination_recovery.py
@@ -45,8 +45,8 @@ from reyn.skill.skill_paths import SkillNotFoundError
     "skills/skill__direct_llm.py",       # n1
 ])
 def test_form4_recovers_known_hallucinations_to_direct_llm(hallucinated_ref):
-    """Tier 2 (B47-fix): each of the 3 N=3-reproduced hallucination
-    forms resolves to direct_llm via form-4 normalization."""
+    """Tier 2: each of the 3 N=3-reproduced hallucination
+    forms resolves to direct_llm via form-4 normalization (B47-fix)."""
     md_path, _path_for_hash, _root = _resolve_skill_ref(hallucinated_ref)
     assert md_path.endswith("/stdlib/skills/direct_llm/skill.md"), (
         f"hallucinated ref {hallucinated_ref!r} should resolve to "


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: 4 mixed singletons (4 errors total)

## Summary
- 4 violations resolved across 4 files.
- 0 audit errors per file.

| File | Error before | Fix applied |
|------|-------------|-------------|
| `test_media_store.py` | `len(files) == 10` format-pin | `len(files) == len(blocks)` (count from source) |
| `test_run_skill_form4_hallucination_recovery.py` | docstring `"Tier 2 (B47-fix):"` missing standard prefix | `"Tier 2:"` prefix, context moved to body |
| `test_llm_result_ref_integration.py` | `len(completed) == 1` format-pin | `(only,) = [...]` tuple unpack |
| `test_mcp_progress_and_timeout.py` | `len(progress_events) == 2` format-pin | `first, last = [...]` unpack |

## Test plan
- [x] `python -m pytest tests/test_media_store.py tests/test_run_skill_form4_hallucination_recovery.py tests/test_llm_result_ref_integration.py tests/test_mcp_progress_and_timeout.py -q` → 70 passed
- [x] `ruff check .` → All checks passed
- [x] All 4 files: 0 audit errors per `scripts/test_tier_audit.py`

Refs PR-12 through PR-32.