### PR TITLE
refactor(tests/skill): Wave 14 PR R9 (Tier audit fix)

### DIFF
--- a/tests/test_skill_discard_action.py
+++ b/tests/test_skill_discard_action.py
@@ -47,9 +47,7 @@ def test_complete_with_status_discarded_emits_skill_discarded(tmp_path):
     discarded = [e for e in events if e["kind"] == "skill_discarded"]
     completed = [e for e in events if e["kind"] == "skill_completed"]
 
-    assert len(discarded) == 1, (
-        f"expected 1 skill_discarded; got {[e['kind'] for e in events]}"
-    )
+    (first_discarded,) = discarded  # exactly one skill_discarded event
     assert completed == [], (
         "discarded path must NOT emit skill_completed"
     )
@@ -66,7 +64,7 @@ def test_complete_default_status_still_emits_skill_completed(tmp_path):
 
     events = list(sl.iter_from(0))
     completed = [e for e in events if e["kind"] == "skill_completed"]
-    assert len(completed) == 1
+    (_, ) = completed  # exactly one skill_completed event
 
 
 def test_complete_with_status_discarded_deletes_snapshot_file(tmp_path):

--- a/tests/test_skill_runner_invariants.py
+++ b/tests/test_skill_runner_invariants.py
@@ -174,7 +174,7 @@ def test_dispatch_spawns_task_in_running_dict(tmp_path, monkeypatch):
 
         # Task is now registered.
         names = runner.running_names()
-        assert len(names) >= 1, f"Expected at least 1 running, got {names}"
+        (_, ) = names  # exactly one task registered
 
         # Release the block so the task can complete.
         block.set()
@@ -348,7 +348,7 @@ def test_wait_for_completion_emits_skill_run_completed(tmp_path, monkeypatch):
         f"Expected skill_run_completed, got event types: "
         f"{[e.type for e in emitted]}"
     )
-    assert not interrupted_evts, (
+    assert interrupted_evts == [], (
         f"skill_run_interrupted must NOT be emitted when the skill "
         f"completes naturally; got {interrupted_evts}"
     )

--- a/tests/test_skill_search_invariants.py
+++ b/tests/test_skill_search_invariants.py
@@ -183,8 +183,9 @@ def test_above_threshold_uses_bm25_top_k() -> None:
     # Query keyword "task_000" should match skill_000 strongly.
     result = loop._apply_skill_search(skills, query="task_000 operations")
 
-    assert len(result) >= 1, (
-        f"above threshold: expected at least 1 skill returned, got {len(result)}"
+    assert result, "above threshold: BM25 must return at least one skill for a matching query"
+    assert len(result) <= cfg.top_k, (
+        f"above threshold: results must not exceed top_k={cfg.top_k}, got {len(result)}"
     )
     # skill_000 must be among the results (it has the exact keyword "task_000").
     result_names = {s["name"] for s in result}
@@ -236,10 +237,7 @@ def test_skill_search_emits_invoked_event() -> None:
     loop._apply_skill_search(skills, query="task_001 operations")
 
     invoked_events = [e for e in host.events.emitted if e["type"] == "skill_search_invoked"]
-    assert len(invoked_events) >= 1, (
-        f"expected at least 1 skill_search_invoked event, got {len(invoked_events)}"
-    )
-    ev = invoked_events[0]
+    (ev,) = invoked_events  # exactly one skill_search_invoked event
     # Verify mandatory fields (P6: enough info to reconstruct what happened).
     assert "query" in ev, "event must carry query"
     assert "candidates_count" in ev, "event must carry candidates_count"


### PR DESCRIPTION
**[dogfood-coder]** — Wave 14 PR R9, 3 files / 6 errors → 0, 14/14 passed. New verify-by-grep + count-report sub-discipline confirmed (= per-file BEFORE=2 / AFTER=0 / audit=0).

| metric | before | after |
|---|---|---|
| Errors | 6 | **0** |
| Tests | 14 | 14 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)