### PR TITLE
fix(ruff): remove F541 unnecessary f-prefix in 2 tier-audit residuals

### DIFF
--- a/tests/test_auto_resume_handler_invariants.py
+++ b/tests/test_auto_resume_handler_invariants.py
@@ -170,7 +170,7 @@ def test_resume_active_emits_correct_events(tmp_path: Path, monkeypatch):
     assert count == 1, f"Expected 1 resumed, got {count}"
     resumed_events = [e for e in events.all() if e.type == "skill_run_resumed"]
     assert resumed_events, (
-        f"Expected at least one skill_run_resumed event, got none"
+        "Expected at least one skill_run_resumed event, got none"
     )
     ev = resumed_events[0]
     assert not resumed_events[1:], (
@@ -207,7 +207,7 @@ def test_resume_skill_runner_dispatch_correct(tmp_path: Path, monkeypatch):
     count = asyncio.run(handler.resume_active())
 
     assert count == 1, f"Expected 1 resumed, got {count}"
-    assert launched, f"Expected launcher to be called at least once"
+    assert launched, "Expected launcher to be called at least once"
     assert not launched[1:], f"Expected launcher called exactly once, got extras: {launched[1:]}"
     decision = launched[0]
     assert decision.plan.run_id == "run_dispatch_test", (

--- a/tests/test_llm_memoization_e2e.py
+++ b/tests/test_llm_memoization_e2e.py
@@ -223,7 +223,7 @@ def test_e2e_resume_memos_all_completed_llm_calls(tmp_path, monkeypatch):
         s for s in decision.plan.committed_steps if s.op_kind == "llm"
     ]
     assert llm_committed, (
-        f"expected LLM CommittedSteps in plan; got none"
+        "expected LLM CommittedSteps in plan; got none"
     )
     assert all(s.op_kind == "llm" for s in llm_committed)
 


### PR DESCRIPTION
**[dogfood-coder]** — ruff F541 cleanup for f-strings without placeholders introduced by my prior Tier audit waves (PR #775 R5 + PR #782 T6).

3 sites fixed via `ruff check --fix --select F541`:
- `tests/test_auto_resume_handler_invariants.py:173` + `:210`
- `tests/test_llm_memoization_e2e.py:226`

All descriptive assert messages where f-prefix was a habit but no interpolation present.

**Unblocks all in-flight PRs** — ruff lints whole repo not just PR diff, so any open PR's CI was failing on these residuals (incl. PR #818 PR T10 misc which lead-coder notified DIRTY on).

## Test plan

- [x] `venv/bin/pytest <2 files>`: 4/4 passed
- [x] `ruff check --select F541 .`: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)