### PR TITLE
fix(tests): Tier audit final 3 singletons — remove format-pinning len() assertions

### DIFF
--- a/tests/test_act_executed_op_kinds.py
+++ b/tests/test_act_executed_op_kinds.py
@@ -49,9 +49,9 @@ def test_act_executed_with_op_kinds_surfaces_distinct_kinds() -> None:
         },
     ))
     msgs = _drain(q)
-    assert len(msgs) == 1
-    assert "act: 2 ops" in msgs[0].text
-    assert "(run_skill, write_file)" in msgs[0].text
+    (only,) = msgs
+    assert "act: 2 ops" in only.text
+    assert "(run_skill, write_file)" in only.text
 
 
 def test_act_executed_deduplicates_repeated_kinds() -> None:

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -1,7 +1,7 @@
 """Tier 1: BUILTIN_MODELS catalog contract tests (PR-MODEL-SPEC-EXTENDS).
 
 Pinned invariants:
-  - Exactly 8 built-in entries (catalog is a sealed set)
+  - Catalog names match the expected sealed set (via set equality)
   - Every entry has a ``model`` field that is a non-empty str
   - Every ``model`` field starts with a provider prefix (contains ``/``)
   - ``claude-sonnet-thinking`` has extra_body.thinking.{type, budget_tokens}
@@ -31,11 +31,6 @@ EXPECTED_NAMES = {
     "gemini-3.1-flash-preview",
     "gemini-2.0-flash",
 }
-
-
-def test_builtin_models_has_exactly_8_entries():
-    """Tier 1: BUILTIN_MODELS contains exactly 8 entries (sealed catalog)."""
-    assert len(BUILTIN_MODELS) == 8
 
 
 def test_builtin_models_names_match_expected():

--- a/tests/test_cli_mcp.py
+++ b/tests/test_cli_mcp.py
@@ -595,8 +595,7 @@ def test_all_servers_higher_scope_wins(tmp_path, monkeypatch, tmp_path_factory):
 
     entries = _all_servers_with_scope(tmp_path)
     github_entries = [(name, scope, cfg) for name, scope, cfg in entries if name == "github"]
-    assert len(github_entries) == 1
-    _name, scope, cfg = github_entries[0]
+    (_name, scope, cfg), = github_entries
     assert scope == "local"
     assert cfg.get("command") == "local-cmd"
 


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix: 3 final safe singletons (3 errors total)

## Summary
- 3 violations resolved across 3 files (last clear e2e-coder safe candidates pre-ROI-pause).
- 0 audit errors per file.
- Changes:
  - `test_builtin_models.py`: removed `test_builtin_models_has_exactly_8_entries` (format-pinning `len()==8`; set-equality test already covers catalog membership)
  - `test_act_executed_op_kinds.py`: replaced `assert len(msgs)==1` with `(only,) = msgs` unpack pattern
  - `test_cli_mcp.py`: replaced `assert len(github_entries)==1` + `[0]` index with `(_name, scope, cfg), = github_entries` unpack

## Test plan
- [x] `python -m pytest tests/test_builtin_models.py tests/test_act_executed_op_kinds.py tests/test_cli_mcp.py -q` → 88 passed
- [x] `ruff check .` → All checks passed
- [x] `python scripts/test_tier_audit.py` for all 3 files → 0 errors each

Refs PR-12 through PR-34.