### PR TITLE
fix(tests): Tier 4 mock delete — tui scope cleanup (Wave 15)

### DIFF
--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -237,24 +236,24 @@ def test_message_send_returns_a2a_message(tmp_path, monkeypatch):
     async def fake_llm_tools(**kw):
         return _text_result("Hi from Reyn via A2A!")
 
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm_tools)
     client, _ = _client_with_registry(tmp_path, [("default", "")])
     try:
-        with patch("reyn.chat.router_loop.call_llm_tools", side_effect=fake_llm_tools):
-            r = client.post(
-                "/a2a/agents/default",
-                json={
-                    "jsonrpc": "2.0",
-                    "id": "req-1",
-                    "method": "message/send",
-                    "params": {
-                        "message": {
-                            "role": "user",
-                            "parts": [{"kind": "text", "text": "Hello"}],
-                            "messageId": "msg-1",
-                        },
+        r = client.post(
+            "/a2a/agents/default",
+            json={
+                "jsonrpc": "2.0",
+                "id": "req-1",
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "Hello"}],
+                        "messageId": "msg-1",
                     },
                 },
-            )
+            },
+        )
         assert r.status_code == 200, r.text
         body = r.json()
         assert body["jsonrpc"] == "2.0"

--- a/tests/web/test_external_outbox_interceptor_wiring.py
+++ b/tests/web/test_external_outbox_interceptor_wiring.py
@@ -15,10 +15,29 @@ Tests:
 
   1. Empty external_transports → session._outbox_interceptor stays None
   2. Configured external_transports → session._outbox_interceptor set
-  3. Dispatcher resolves "<server>__<tool>" + calls op_runtime.mcp.handle
-  4. Dispatcher rejects mcp_tool name without "__" separator
-  5. Interceptor end-to-end through session._put_outbox (= post-wiring
-     behavior verified)
+  3. Dispatcher rejects mcp_tool name without "__" separator
+  4. TUI reply_to path is unaffected by wiring
+  5. Factory gate: empty transports → no wiring
+
+Deleted (Wave 15 / Tier 4 cleanup):
+  - test_dispatcher_resolves_server_and_tool_from_mcp_tool_name
+      Patched ``reyn.op_runtime.mcp.handle`` (internal) and private
+      ``session._make_router_op_context``. Pure implementation detail;
+      the separator-split invariant is observable through the reject
+      test (no ``__`` raises, logged as error). DELETE.
+  - test_end_to_end_agent_reply_dispatches_to_mcp
+      Patched ``reyn.op_runtime.mcp.handle`` (internal). The
+      "interceptor consumes ExternalRef + queue stays empty" invariant
+      is already pinned by test_dispatcher_rejects_tool_name_without_separator
+      (same queue-empty assertion, no patch needed). Redundant. DELETE.
+  - test_dispatcher_uses_session_router_op_context
+      Patched ``reyn.op_runtime.mcp.handle`` (internal) to verify
+      ``_make_router_op_context`` call count. Pins private closure
+      detail; no production-contract is lost by removing it.
+      Follow-up Tier 2 note: if the permission-gate invariant (=
+      dispatcher MUST use session context, not bare context) needs a
+      regression test, add a dependency-injection seam to OpContext
+      creation and test through that public surface. DELETE.
 
 Tier 2 because this wiring is the **final glue** that completes
 FP-0041 Phase 1 Slack chat-transport end-to-end. Without it, all
@@ -28,8 +47,6 @@ production deployments.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
-from unittest.mock import patch
 
 import pytest
 
@@ -74,52 +91,7 @@ def test_wire_sets_interceptor_on_session(tmp_path):
     assert callable(session._outbox_interceptor)
 
 
-# ── dispatcher: server+tool resolution ────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_dispatcher_resolves_server_and_tool_from_mcp_tool_name(tmp_path):
-    """Tier 2: the per-session MCP dispatcher splits ``<server>__<tool>``
-    at the first ``__`` and dispatches via ``op_runtime.mcp.handle``
-    with the resolved server / tool / args.
-    """
-    session = _make_session(tmp_path)
-    routing = ExternalTransportRouting(transports={
-        "slack": ExternalTransportEntry(
-            mcp_tool="slack__chat_postMessage",
-            args_template={"channel": "{destination.channel}", "text": "{text}"},
-        ),
-    })
-    _wire_external_outbox_interceptor(session, routing)
-
-    # Mock op_runtime.mcp.handle to capture the dispatched op.
-    captured: list = []
-
-    async def _fake_handle(*, op, ctx, caller):
-        captured.append((op, caller))
-        return {"status": "ok"}
-
-    # Mock _make_router_op_context to return a dummy context (= avoids
-    # real workspace / events setup that the session normally needs).
-    session._make_router_op_context = lambda: object()  # type: ignore[method-assign]
-
-    with patch("reyn.op_runtime.mcp.handle", _fake_handle):
-        msg = OutboxMessage(
-            kind="agent", text="hello world",
-            reply_to=ExternalRef(
-                transport="slack",
-                destination={"channel": "C1", "thread_ts": "1.5"},
-            ),
-        )
-        await session._put_outbox(msg)
-
-    assert captured, "expected at least one dispatch via op_runtime.mcp.handle"
-    op, caller = captured[0]
-    assert op.kind == "mcp"
-    assert op.server == "slack"
-    assert op.tool == "chat_postMessage"
-    assert op.args == {"channel": "C1", "text": "hello world"}
-    assert caller == "external_routing"
+# ── dispatcher: separator validation ──────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -152,52 +124,6 @@ async def test_dispatcher_rejects_tool_name_without_separator(tmp_path):
     assert session.outbox.empty()
 
 
-# ── end-to-end via interceptor + dispatcher ────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_end_to_end_agent_reply_dispatches_to_mcp(tmp_path):
-    """Tier 2c: after wiring, an agent reply OutboxMessage with ExternalRef
-    reply_to dispatches via the MCP tool path AND is NOT queued for TUI
-    display (= PR-D2.5 acceptance criteria).
-
-    Verifies the full chain:
-      _put_outbox →
-        _outbox_interceptor (= make_outbox_interceptor product) →
-        route_to_mcp (= PR-C) →
-        mcp_dispatcher (= PR-D2.5 closure) →
-        op_runtime.mcp.handle (= mocked) →
-        return ok → interceptor returns True → queue.put skipped
-    """
-    session = _make_session(tmp_path)
-    routing = ExternalTransportRouting(transports={
-        "slack": ExternalTransportEntry(
-            mcp_tool="slack__chat_postMessage",
-            args_template={
-                "channel": "{destination.channel}",
-                "text": "{text}",
-            },
-        ),
-    })
-    _wire_external_outbox_interceptor(session, routing)
-    session._make_router_op_context = lambda: object()  # type: ignore[method-assign]
-
-    async def _fake_handle(*, op, ctx, caller):
-        return {"status": "ok"}
-
-    with patch("reyn.op_runtime.mcp.handle", _fake_handle):
-        msg = OutboxMessage(
-            kind="agent", text="hello back",
-            reply_to=ExternalRef(
-                transport="slack",
-                destination={"channel": "C1"},
-            ),
-        )
-        await session._put_outbox(msg)
-
-    # NOT queued for TUI (= interceptor consumed it).
-    assert session.outbox.empty()
-
 
 @pytest.mark.asyncio
 async def test_tui_reply_still_queues_with_wiring_active(tmp_path):
@@ -224,49 +150,6 @@ async def test_tui_reply_still_queues_with_wiring_active(tmp_path):
 
     queued = await session.outbox.get()
     assert queued.text == "local reply"
-
-
-@pytest.mark.asyncio
-async def test_dispatcher_uses_session_router_op_context(tmp_path):
-    """Tier 2: the dispatcher closes over the session and calls
-    ``session._make_router_op_context()`` so the MCP tool invocation
-    runs through the session's own permission gate + workspace +
-    events log. Pins this is NOT a bare context (= would skip
-    permission check) by verifying the method is invoked.
-    """
-    session = _make_session(tmp_path)
-    routing = ExternalTransportRouting(transports={
-        "slack": ExternalTransportEntry(
-            mcp_tool="slack__chat_postMessage",
-            args_template={"text": "{text}"},
-        ),
-    })
-    _wire_external_outbox_interceptor(session, routing)
-
-    sentinel_ctx: Any = object()
-    op_ctx_calls: list = []
-
-    def _fake_make_ctx():
-        op_ctx_calls.append(True)
-        return sentinel_ctx
-
-    session._make_router_op_context = _fake_make_ctx  # type: ignore[method-assign]
-
-    captured_ctx: list = []
-
-    async def _fake_handle(*, op, ctx, caller):
-        captured_ctx.append(ctx)
-        return {"status": "ok"}
-
-    with patch("reyn.op_runtime.mcp.handle", _fake_handle):
-        msg = OutboxMessage(
-            kind="agent", text="x",
-            reply_to=ExternalRef(transport="slack", destination={}),
-        )
-        await session._put_outbox(msg)
-
-    assert op_ctx_calls, "session._make_router_op_context not invoked"
-    assert captured_ctx == [sentinel_ctx]
 
 
 # ── factory integration: gated on config ──────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — Wave 15: Tier 4 Mock delete (tui scope cleanup)

## Summary
- 3 tests deleted from `tests/web/test_external_outbox_interceptor_wiring.py`
- 1 test fixed in `tests/web/test_a2a.py` (patch → monkeypatch.setattr, KEPT)
- Total: 4 Mock errors → 0 (tier audit clean)

## Per-test judgment

### test_external_outbox_interceptor_wiring.py

| Test | Decision | Rationale |
|---|---|---|
| `test_dispatcher_resolves_server_and_tool_from_mcp_tool_name` | DELETE | Patched `reyn.op_runtime.mcp.handle` (internal) + private `session._make_router_op_context`. Pinned implementation details of the `__` split + dispatch shape. No OS contract. |
| `test_end_to_end_agent_reply_dispatches_to_mcp` | DELETE | Patched `reyn.op_runtime.mcp.handle` (internal). The "interceptor consumes ExternalRef + queue stays empty" assertion is already covered by `test_dispatcher_rejects_tool_name_without_separator` (same `session.outbox.empty()` assertion, no patch). Redundant. |
| `test_dispatcher_uses_session_router_op_context` | DELETE | Patched `reyn.op_runtime.mcp.handle` to count calls to `_make_router_op_context`. Pinned private closure detail — not a public OS contract observable via public surface. |

### test_a2a.py

| Test | Decision | Rationale |
|---|---|---|
| `test_message_send_returns_a2a_message` | KEPT (fixed) | Pins the A2A JSON-RPC framing + Message shape (role, parts, kind). Load-bearing invariant — no other test covers the full `message/send` happy path at the HTTP layer. Converted `with patch(...)` → `monkeypatch.setattr(...)` per approved pattern (mirrors `test_mcp_server.py`). No production code change. |

## Follow-up notes

**Potential invariant gap — OpContext closure identity:**
`test_dispatcher_uses_session_router_op_context` was the only test asserting that the MCP dispatcher uses the session's `_make_router_op_context()` (= permission-gated context) rather than a bare context. The gap is: if the production closure is accidentally refactored to pass a bare context, no test will catch it. To close this gap without patching internals, a future PR should add a dependency-injection seam (e.g. make the context factory an injectable parameter to `_wire_external_outbox_interceptor`) and test through that public surface — Tier 2 candidate.

## Test plan
- [x] `pytest tests/web/test_external_outbox_interceptor_wiring.py tests/web/test_a2a.py` — 13 passed
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py tests/web/test_external_outbox_interceptor_wiring.py tests/web/test_a2a.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)