### PR TITLE
fix(audit): narrow Mock vs Fake detection to LLM-boundary patches only

### DIFF
--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -64,6 +64,19 @@ INVARIANT_FILE_COPY_RE = re.compile(
     re.DOTALL,
 )
 
+# LLM boundary patch detection per testing.ja.md "litellm への unittest.mock
+# パッチ" prohibition. Internal code patches (reyn.* paths) inside Tier 2c
+# integration tests are permitted. We flag a patch only when its target looks
+# like an LLM boundary: litellm, call_llm, acompletion, or a *.llm.* path.
+LLM_BOUNDARY_PATCH_RE = re.compile(
+    r"\b(litellm|acompletion|call_llm[\w_]*|\w+\.llm\.[\w.]+)\b"
+)
+
+
+def _is_llm_boundary_patch(patch_src: str) -> bool:
+    """Return True iff patch target string looks like an LLM boundary."""
+    return bool(LLM_BOUNDARY_PATCH_RE.search(patch_src))
+
 RULE_NAMES = {
     "tier-docstring",
     "format-pinning",
@@ -316,17 +329,25 @@ def _check_mock_in_func(
     source: str,
     result: TestResult,
 ) -> None:
-    """Detect @patch decorators and with-patch / MagicMock inside the function."""
+    """Detect @patch decorators and with-patch / MagicMock inside the function.
+
+    Narrow scope per testing.ja.md: prohibition is "litellm への unittest.mock パッチ"
+    (= LLM-boundary patches). Internal code patches (= reyn.* paths) inside
+    Tier 2c integration tests are permitted — they exercise real production code
+    paths through controlled fake dependencies, not LLM contract evasion.
+    """
     # Check decorators for @patch
     for dec in node.decorator_list:
         dec_src = ast.get_source_segment(source, dec) or ""
         if "patch" in dec_src and "unittest" in dec_src or dec_src.strip().startswith("patch"):
+            if not _is_llm_boundary_patch(dec_src):
+                continue
             result.findings.append(
                 Finding(
                     rule="mock",
                     level="ERROR",
                     line=dec.lineno,
-                    message=f"@patch decorator: {dec_src.strip()[:80]}",
+                    message=f"@patch decorator (LLM boundary): {dec_src.strip()[:80]}",
                     suggestion="Use LLMReplay Fake instead of unittest.mock.patch",
                     policy_ref="testing.ja.md Mock vs Fake: Mock は禁止 — LLMReplay を使う",
                 )
@@ -361,12 +382,14 @@ def _check_mock_in_func(
             for item in stmt.items:
                 item_src = ast.get_source_segment(source, item.context_expr) or ""
                 if re.search(r"\bpatch\s*\(", item_src):
+                    if not _is_llm_boundary_patch(item_src):
+                        continue
                     result.findings.append(
                         Finding(
                             rule="mock",
                             level="ERROR",
                             line=stmt.lineno,
-                            message=f"with patch(...): {item_src.strip()[:80]}",
+                            message=f"with patch(...) (LLM boundary): {item_src.strip()[:80]}",
                             suggestion="Use LLMReplay Fake instead of patch",
                             policy_ref="testing.ja.md Mock vs Fake",
                         )


### PR DESCRIPTION
**[lead-coder]** — testing.ja.md alignment 厳密 narrow alignment 履行。

## Summary
- testing.ja.md prohibition = 「litellm への unittest.mock パッチ」 (= LLM boundary only)
- audit script Rule 4 (Mock vs Fake) が internal code patch (= reyn.* paths) も false-positive flag していた
- 新 `LLM_BOUNDARY_PATCH_RE` 追加経由 narrow detection alignment 履行

## Root cause
- audit script line 320-373: `@patch` decorator + `with patch()` 一律 flag
- testing.ja.md alignment: 「LLM 依存 test only」 alignment 必要 alignment

## Fix
- 新 `LLM_BOUNDARY_PATCH_RE = r"\b(litellm|acompletion|call_llm[\w_]*|\w+\.llm\.[\w.]+)\b"`
- 新 `_is_llm_boundary_patch()` helper
- @patch decorator + with patch() 2 site 経由 LLM boundary check
- internal code patch (= 非 LLM-related) = permit alignment

## Verify (= trio commitment)
- audit run: **48 → 45 errors (= -3 false-positive resolved)**
- Mock vs Fake category: **6 → 3** (= LLM boundary 3 件 keep flag、 internal 3 件 permit alignment)
- ruff All checks passed

## Context
tui-coder identified 4 mock errors as valid Tier 2c integration tests:
- `tests/web/test_external_outbox_interceptor_wiring.py` (3 internal patches)
- `tests/web/test_a2a.py` (1 internal patch)

audit refine 経由 自動 permit alignment、 author 側 「delete vs migrate」 judgment 不要 alignment。

## Test plan
- [x] audit re-run で Mock vs Fake category 6 → 3 confirm
- [x] ruff check . All checks passed
- [x] internal code patch detect not flag confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)