### PR TITLE
fix(tests): delete 3 format-pinning Tier 4 violations in fp0036 e2e test

### DIFF
--- a/tests/test_fp0036_e2e_full_pipeline.py
+++ b/tests/test_fp0036_e2e_full_pipeline.py
@@ -194,7 +194,6 @@ async def test_full_pipeline_scenario_load_run_summary(tmp_path: Path):
     # 2. Load via F1
     scenario_set = load_scenario_set(yaml_path)
     assert scenario_set.name == "fp0036_e2e_test_set"
-    assert len(scenario_set.scenarios) == 2
     ids = {s.id for s in scenario_set.scenarios}
     assert ids == {"verified_scenario", "refuted_scenario"}
 
@@ -369,9 +368,6 @@ async def test_coverage_finds_covers_tags(tmp_path: Path):
     # Both scenarios declare covers: [os-core] — coverage_map["os-core"] must
     # have entries for them
     os_core_refs = matrix.coverage_map.get("os-core", [])
-    assert len(os_core_refs) == 2, (
-        f"Expected 2 scenario refs for 'os-core', got {os_core_refs}"
-    )
 
     scenario_ids = {sid for _, sid in os_core_refs}
     assert "verified_scenario" in scenario_ids
@@ -460,7 +456,6 @@ async def test_replay_run_via_runner_seam(tmp_path: Path):
     )
 
     assert run_result.run_id == "replay-run-001"
-    assert len(run_result.scenario_results) == 2
 
     summary_path = storage_dir / "summary.json"
     assert summary_path.exists()


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (delete-preferred): `tests/test_fp0036_e2e_full_pipeline.py`

## Summary
- 3 format-pinning Tier 4 violations resolved (= user directive 「Tier 4 = delete preferred」 applied).
- Per-line judgment: pure implementation pinning → DELETE; genuine invariant → tuple-unpack.

## Per-line classification

| Line (before) | Assertion | Classification | Action |
|---|---|---|---|
| 197 | `len(scenario_set.scenarios) == 2` | Pure size pin — exact ID membership already pinned by `ids == {...}` on next line | DELETE |
| 372 | `len(os_core_refs) == 2` | Pure count pin — both specific IDs already asserted by lines 376–378 | DELETE |
| 463 | `len(run_result.scenario_results) == 2` | Pure size pin — `summary["total"] == 2` below covers the behavioral invariant | DELETE |

## Test plan
- [x] pytest + ruff + audit all green
- [x] 0 audit errors (was 3)

Refs PR-12 through PR-37, user directive 2026-05-24 「Tier 4 = 積極的 delete」.