### PR TITLE
fix(tests): tier audit delete-preferred — fp0036 interpretation transcripts

### DIFF
--- a/tests/test_fp0036_interpretation_transcripts.py
+++ b/tests/test_fp0036_interpretation_transcripts.py
@@ -137,7 +137,6 @@ def test_build_prompt_contains_input_reply_and_expected() -> None:
 
     messages = build_prompt(scenario, result)
 
-    assert len(messages) == 2
     assert messages[0]["role"] == "system"
     assert messages[1]["role"] == "user"
 
@@ -160,7 +159,6 @@ def test_build_prompt_truncates_long_reply() -> None:
     user_text = messages[1]["content"]
 
     assert "...(truncated)" in user_text
-    assert len(user_text) < 5000 + 2000  # bounded
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +265,6 @@ def test_build_transcripts_truncates_long_reply(tmp_path) -> None:
     section = build_transcripts_section(run_dir)
 
     assert "...(truncated)" in section
-    assert len(section) < 5000  # bounded by truncation
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (delete-preferred): `tests/test_fp0036_interpretation_transcripts.py`

## Summary
- 3 format-pinning Tier 4 violations resolved (= delete-preferred per directive).
- Per-line judgment: pure pinning → DELETE; invariant → tuple-unpack.

| Line | Assertion deleted | Classification |
|------|------------------|----------------|
| 140 | `assert len(messages) == 2` | Pure size/shape pinning → DELETE |
| 163 | `assert len(user_text) < 5000 + 2000  # bounded` | Pure size bound pinning → DELETE |
| 270 | `assert len(section) < 5000  # bounded by truncation` | Pure size bound pinning → DELETE |

No genuine invariants found — all 3 were implementation-detail size checks with no behavioral contract value.

## Test plan
- [x] verify trio green, 0 audit errors: `pytest -q` 11 passed, `ruff check .` clean, `test_tier_audit.py` 0 errors.

Refs user directive 2026-05-24 「Tier 4 = 積極的 delete」.