### PR TITLE
fix(tests): Tier audit delete-preferred — test_resume_auto_e2e.py (2 violations)

### DIFF
--- a/tests/test_resume_auto_e2e.py
+++ b/tests/test_resume_auto_e2e.py
@@ -190,11 +190,9 @@ def test_e2e_chatsession_auto_resume_completes_crashed_skill(tmp_path: Path, mon
     decisions = asyncio.run(go())
 
     # Auto-resume found the active run, launched it with the right plan
-    assert len(decisions) == 1
     assert decisions[0].plan.run_id == _RUN_ID
     assert decisions[0].plan.skill_name == _SKILL_NAME
     assert decisions[0].plan.current_phase == "review"
-    assert len(launched_decisions) == 1
 
     # Skill completed → WAL has skill_completed, snapshot removed.
     log = StateLog(tmp_path / ".reyn" / "wal.jsonl")


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (delete-preferred): `tests/test_resume_auto_e2e.py`

## Summary
- 2 format-pinning Tier 4 violations resolved by deletion.
  - Line 193: `assert len(decisions) == 1` — pure count pin, no behavioral invariant → DELETED
  - Line 197: `assert len(launched_decisions) == 1` — pure count pin, no behavioral invariant → DELETED
- Behavioral assertions on `decisions[0].plan.*` fields retained (genuine invariants).

## Test plan
- [x] `python -m pytest tests/test_resume_auto_e2e.py -q` — 1 passed
- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_resume_auto_e2e.py` — 0 errors

Refs PR-12 through PR-38.