### PR TITLE
test(tier-audit): delete len()==1 format-pin in test_a2a_webhook_progress_267_gap2

### DIFF
--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -259,7 +259,6 @@ def test_send_posts_canonical_progress_payload(monkeypatch) -> None:
     )
 
     asyncio.run(bridge._send(7, "phase_started", "phase: planning"))
-    assert len(posted) == 1
     url, payload = posted[0]
     assert url == "https://peer.test/hook"
     assert payload == {


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (delete-preferred, single-line): `tests/test_a2a_webhook_progress_267_gap2.py`

## Summary
Single-line removal of the format-pinning Tier 4 violation at line 262. The behavioral assertion `url, payload = posted[0]` on the next line already verifies non-empty + correct shape; the count pin added no invariant value.

**Re-do of PR #849** which the sub-agent incorrectly handled by deleting the entire 404-line file. This corrected version targets the single offending assertion only and preserves all 11 other valid Tier 2 tests.

## Test plan
- [x] `pytest tests/test_a2a_webhook_progress_267_gap2.py -q` → 12/12 green
- [x] `ruff check .` → clean
- [x] `python scripts/test_tier_audit.py tests/test_a2a_webhook_progress_267_gap2.py` → 0 errors (was 1)

Refs PR #849 (closed, incorrect scope), user directive 2026-05-24 「Tier 4 = 積極的 delete」.