### PR TITLE
fix(tests): delete format-pinning assertion in test_skill_postprocessor_model

### DIFF
--- a/tests/test_skill_postprocessor_model.py
+++ b/tests/test_skill_postprocessor_model.py
@@ -168,7 +168,6 @@ def test_skill_postprocessor_steps_typecheck_preprocessor_steps() -> None:
         ],
     })
     assert isinstance(skill.postprocessor, Postprocessor)
-    assert len(skill.postprocessor.steps) == 1
     assert skill.postprocessor.steps[0].type == "validate"
 
 


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (delete-preferred, single-line): `tests/test_skill_postprocessor_model.py`

## Summary
- Single-line removal of the format-pinning violation.
- 0 audit errors (was 1).

Refs PR-12 through PR-40.