### PR TITLE
fix(tests): remove format-pinning Tier 4 assertion in plan_step_result_spill_e2e

### DIFF
--- a/tests/test_plan_step_result_spill_e2e.py
+++ b/tests/test_plan_step_result_spill_e2e.py
@@ -227,7 +227,6 @@ async def test_coordinator_forwards_agent_state_dir_to_analyzer(tmp_path: Path) 
         decomposition_loader=loader,
         agent_state_dir=tmp_path,
     )
-    assert len(decisions) == 1
     s1_state = next(
         s for s in decisions[0].plan.step_states if s.step_id == "s1"
     )


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (delete-preferred, single-line): `tests/test_plan_step_result_spill_e2e.py`

## Summary
- Single-line removal of the format-pinning Tier 4 violation.
- Deleted: `assert len(decisions) == 1` (was line 230 in `test_coordinator_forwards_agent_state_dir_to_analyzer`)
- 0 audit errors after this PR (was 1).

## Test plan
- [x] `pytest tests/test_plan_step_result_spill_e2e.py -q` — 6 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py tests/test_plan_step_result_spill_e2e.py` — 0 errors

Refs PR-12 through PR-40, user directive 2026-05-24.