### PR TITLE
fix(tests): Tier docstring prefix in test_router_loop_spawn_ack_message

### DIFF
--- a/tests/test_router_loop_spawn_ack_message.py
+++ b/tests/test_router_loop_spawn_ack_message.py
@@ -66,7 +66,7 @@ def test_spawn_ack_each_locale_signals_background_run():
 
 
 def test_spawn_ack_p7_clean_no_skill_names():
-    """Tier 2 / P7: the template must NOT contain skill-specific
+    """Tier 2: P7 invariant — the template must NOT contain skill-specific
     qualified names (`skill__X`, `file__Y`, `web__Z`, etc.) or
     skill-name-shaped strings. OS-level message stays category-agnostic."""
     tmpl = _load_spawn_ack_template()


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (docstring): `tests/test_router_loop_spawn_ack_message.py`

## Summary
- Add Tier 2 docstring prefix to flagged test (`test_spawn_ack_p7_clean_no_skill_names`).
- Root cause: `"""Tier 2 / P7:` does not match the required `"""Tier N:` pattern; changed to `"""Tier 2: P7 invariant —`.
- 0 audit errors (was 1).

## Test plan
- [x] `python -m pytest tests/test_router_loop_spawn_ack_message.py -q` — 4 passed
- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_router_loop_spawn_ack_message.py` — 0 errors

Refs PR-12 through PR-42.