### PR TITLE
fix(tests): Tier 2 docstring prefix in test_dogfood_dispatch_absolute_deliverable

### DIFF
--- a/tests/test_dogfood_dispatch_absolute_deliverable.py
+++ b/tests/test_dogfood_dispatch_absolute_deliverable.py
@@ -76,9 +76,9 @@ def _make_config(journal_dir: str) -> BatchConfig:
 
 
 def test_deliverable_path_is_absolute_against_repo_root(tmp_path):
-    """Tier 2 (B45-carry-over fix): rendered prompt emits the
-    deliverable path as an absolute filesystem path joined from the
-    supplied repo_root + journal_dir + worker filename."""
+    """Tier 2: rendered prompt emits the deliverable path as an absolute
+    filesystem path joined from the supplied repo_root + journal_dir +
+    worker filename (B45-carry-over fix)."""
     config = _make_config("docs/journal/test-batch")
     repo_root = tmp_path / "fake-repo"
     repo_root.mkdir()


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (docstring): `tests/test_dogfood_dispatch_absolute_deliverable.py`

## Summary
- Add Tier 2 docstring prefix to `test_deliverable_path_is_absolute_against_repo_root`.
- 0 audit errors (was 1).

## Details
The docstring began with `"""Tier 2 (B45-carry-over fix):` which the tier audit regex rejects because the tier number is not immediately followed by `:`. Rewritten to `"""Tier 2: ... (B45-carry-over fix)` so the pattern matches.

## Test plan
- [x] `python -m pytest tests/test_dogfood_dispatch_absolute_deliverable.py -q` — 5 passed
- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/test_dogfood_dispatch_absolute_deliverable.py` — 0 errors

Refs PR-12 through PR-42.