### PR TITLE
fix(tests): Tier docstring prefix in dogfood verdict scoping test

### DIFF
--- a/tests/test_dogfood_dispatch_verdict_scoping_guidance.py
+++ b/tests/test_dogfood_dispatch_verdict_scoping_guidance.py
@@ -66,7 +66,7 @@ def _make_config() -> BatchConfig:
 
 
 def test_prompt_contains_verdict_scoping_guidance():
-    """Tier 2 (B48 W1 fix): the prompt MUST explicitly state that
+    """Tier 2: the prompt MUST explicitly state that (B48 W1 fix)
     ``covers:`` and scenario metadata are NOT verdict criteria."""
     cfg = _make_config()
     prompt = render_worker_prompt(cfg, cfg.workers[0])


### PR DESCRIPTION
**[e2e-coder]** — Tier audit fix (docstring): `tests/test_dogfood_dispatch_verdict_scoping_guidance.py`

## Summary
- Tier 2 docstring prefix: `Tier 2 (B48 W1 fix):` → `Tier 2: ... (B48 W1 fix)` to match audit pattern `Tier N:`.
- 0 audit errors (was 1).

Refs PR-12 through PR-43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)