### PR TITLE
fix(skill_runner): reuse pre-spawn loaded Skill in _run_one_skill (closes #644)

### DIFF
--- a/src/reyn/chat/services/skill_runner.py
+++ b/src/reyn/chat/services/skill_runner.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from reyn.agent import Agent
     from reyn.budget.budget import BudgetGateway
     from reyn.events.state_log import StateLog
+    from reyn.schemas.models import Skill
     from reyn.skill.skill_registry import SkillRegistry
 
 logger = logging.getLogger(__name__)
@@ -428,7 +429,11 @@ class SkillRunner:
         ))
 
         task = asyncio.create_task(
-            self._run_one_skill(run_id, skill_name, input_artifact, chain_id=chain_id)
+            self._run_one_skill(
+                run_id, skill_name, input_artifact,
+                chain_id=chain_id,
+                pre_loaded_skill=_skill_for_validation,
+            )
         )
         self.running_skills[run_id] = task
 
@@ -761,44 +766,55 @@ class SkillRunner:
         input_artifact: dict,
         *,
         chain_id: str | None = None,
+        pre_loaded_skill: "Skill | None" = None,
     ) -> None:
         """Core skill execution coroutine.
 
         Extracted from ``ChatSession._run_one_skill``.  Loads the skill,
         builds the agent with a ChatEventForwarder subscriber, runs it,
         and emits lifecycle events (P6).
+
+        ``pre_loaded_skill`` lets ``spawn()`` hand off the Skill it
+        already parsed for pre-spawn input_schema validation, eliminating
+        the duplicate resolve_skill_path + load_dsl_skill on the success
+        path (= 2x disk read + 2x YAML parse per spawn pre-fix). When
+        absent (= callers other than spawn(), or future code paths) the
+        load fallback below preserves original behaviour.
         """
         meta = _run_meta(run_id, skill_name)
-        try:
-            skill_dir, skill_root = resolve_skill_path(skill_name)
-        except SkillNotFoundError:
-            self._events.emit(
-                "skill_run_failed", run_id=run_id, skill=skill_name,
-                error=f"skill not found: {skill_name}",
-            )
-            await self._put_outbox(OutboxMessage(
-                kind="error", text=f"skill not found: {skill_name}", meta=meta,
-            ))
-            await self._enqueue_skill_completed(
-                run_id=run_id, skill=skill_name, chain_id=chain_id,
-                status="error", data={"error": f"skill not found: {skill_name}"},
-            )
-            return
-        try:
-            skill = load_dsl_skill(str(skill_dir / "skill.md"), skill_root=str(skill_root))
-        except Exception as exc:
-            self._events.emit(
-                "skill_run_failed", run_id=run_id, skill=skill_name,
-                error=f"failed to load: {exc}",
-            )
-            await self._put_outbox(OutboxMessage(
-                kind="error", text=f"failed to load {skill_name}: {exc}", meta=meta,
-            ))
-            await self._enqueue_skill_completed(
-                run_id=run_id, skill=skill_name, chain_id=chain_id,
-                status="error", data={"error": f"failed to load {skill_name}: {exc}"},
-            )
-            return
+        if pre_loaded_skill is not None:
+            skill = pre_loaded_skill
+        else:
+            try:
+                skill_dir, skill_root = resolve_skill_path(skill_name)
+            except SkillNotFoundError:
+                self._events.emit(
+                    "skill_run_failed", run_id=run_id, skill=skill_name,
+                    error=f"skill not found: {skill_name}",
+                )
+                await self._put_outbox(OutboxMessage(
+                    kind="error", text=f"skill not found: {skill_name}", meta=meta,
+                ))
+                await self._enqueue_skill_completed(
+                    run_id=run_id, skill=skill_name, chain_id=chain_id,
+                    status="error", data={"error": f"skill not found: {skill_name}"},
+                )
+                return
+            try:
+                skill = load_dsl_skill(str(skill_dir / "skill.md"), skill_root=str(skill_root))
+            except Exception as exc:
+                self._events.emit(
+                    "skill_run_failed", run_id=run_id, skill=skill_name,
+                    error=f"failed to load: {exc}",
+                )
+                await self._put_outbox(OutboxMessage(
+                    kind="error", text=f"failed to load {skill_name}: {exc}", meta=meta,
+                ))
+                await self._enqueue_skill_completed(
+                    run_id=run_id, skill=skill_name, chain_id=chain_id,
+                    status="error", data={"error": f"failed to load {skill_name}: {exc}"},
+                )
+                return
 
         from reyn.chat.forwarder import ChatEventForwarder
         agent = self._build_agent_fn(

--- a/tests/test_skill_runner_pre_spawn_validation.py
+++ b/tests/test_skill_runner_pre_spawn_validation.py
@@ -231,3 +231,95 @@ def test_spawn_for_router_propagates_pre_spawn_error(tmp_path, monkeypatch):
         assert "could not be spawned" not in str(out)
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Issue #644: pre-spawn skill load is reused by _run_one_skill (no 2x I/O)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_passes_pre_loaded_skill_no_second_load(tmp_path, monkeypatch):
+    """Tier 2: spawn() hands its validated Skill to _run_one_skill via
+    ``pre_loaded_skill``, so the async task body skips the duplicate
+    resolve_skill_path + load_dsl_skill that happened pre-issue-#644.
+    """
+    import reyn.chat.services.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "skill_reuse"
+    dummy_dir.mkdir()
+
+    resolve_calls = {"n": 0}
+    load_calls = {"n": 0}
+
+    def _counting_resolve(name):
+        resolve_calls["n"] += 1
+        return dummy_dir, tmp_path
+
+    def _counting_load(path, *, skill_root):
+        load_calls["n"] += 1
+        return _make_stub_skill(input_schema=None)
+
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", _counting_resolve)
+    monkeypatch.setattr(sr_mod, "load_dsl_skill", _counting_load)
+
+    runner, _events, _outbox, _completed = _make_runner()
+
+    async def _run():
+        result = await runner.spawn({"skill": "reuse", "input": {}})
+        assert result is None, f"expected None on success, got {result!r}"
+        # Allow the asyncio task to step through _run_one_skill's load gate.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # Pre-issue-#644 both calls fired twice. Post-fix, _run_one_skill
+        # receives the already-loaded Skill so the second load is skipped.
+        assert load_calls["n"] == 1, (
+            f"expected 1 load_dsl_skill call (pre-spawn only), got {load_calls['n']}"
+        )
+        assert resolve_calls["n"] == 1, (
+            f"expected 1 resolve_skill_path call (pre-spawn only), got {resolve_calls['n']}"
+        )
+
+    asyncio.run(_run())
+
+
+def test_run_one_skill_falls_back_to_load_when_pre_loaded_skill_absent(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: when ``_run_one_skill`` is invoked directly without a
+    ``pre_loaded_skill`` (= future callers, defensive default),
+    it still performs the resolve + load itself. Preserves backward
+    compatibility for any non-spawn() entry path.
+    """
+    import reyn.chat.services.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "skill_fallback"
+    dummy_dir.mkdir()
+
+    resolve_calls = {"n": 0}
+    load_calls = {"n": 0}
+
+    def _counting_resolve(name):
+        resolve_calls["n"] += 1
+        return dummy_dir, tmp_path
+
+    def _counting_load(path, *, skill_root):
+        load_calls["n"] += 1
+        return _make_stub_skill(input_schema=None)
+
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", _counting_resolve)
+    monkeypatch.setattr(sr_mod, "load_dsl_skill", _counting_load)
+
+    runner, _events, _outbox, _completed = _make_runner()
+
+    async def _run():
+        # Call _run_one_skill directly with pre_loaded_skill=None.
+        await runner._run_one_skill(
+            run_id="run-x", skill_name="fallback", input_artifact={},
+            chain_id=None, pre_loaded_skill=None,
+        )
+        assert load_calls["n"] == 1, (
+            f"expected 1 load_dsl_skill call (direct invocation fallback), got {load_calls['n']}"
+        )
+        assert resolve_calls["n"] == 1
+
+    asyncio.run(_run())


### PR DESCRIPTION
**[e2e-coder]** — Optimization: eliminate duplicate skill load on the successful-spawn path (closes #644).

## Problem

Pre-issue-#644 each successful `SkillRunner.spawn()` paid for the skill md file twice:

```
spawn() body:
  resolve_skill_path(skill_name)        ← 1st
  load_dsl_skill(...)                    ← 1st parse
  jsonschema.validate(...)
  (loaded skill discarded)
  asyncio.create_task(_run_one_skill(...))

_run_one_skill() body:
  resolve_skill_path(skill_name)        ← 2nd (same result)
  load_dsl_skill(...)                    ← 2nd parse (same result)
  agent.run(skill, ...)
```

Per-call cost is small but cumulative impact noticeable in frequent-spawn environments (multi-agent flows, dogfood batches).

## Fix

Thread the validated `Skill` through `_run_one_skill` via a new `pre_loaded_skill` kwarg (default `None`). On the spawn() success path, `_run_one_skill` skips `resolve_skill_path` + `load_dsl_skill` entirely. On the absent path (= future callers, direct invocation), it falls back to the original load behaviour so existing entry points stay compatible.

Skill load is idempotent + side-effect-free, so reusing the validated instance is functionally equivalent to reloading — purely a cost-reduction with no behavior change risk.

## Test plan
- [x] `test_spawn_passes_pre_loaded_skill_no_second_load` — counts resolve + load invocations after spawn() success; asserts each fires exactly once.
- [x] `test_run_one_skill_falls_back_to_load_when_pre_loaded_skill_absent` — direct invocation with `pre_loaded_skill=None`; asserts load fallback runs (backward-compat).
- [x] All existing skill_runner tests pass (37/37).
- [x] `ruff check .` clean.
- [x] `python scripts/test_tier_audit.py tests/test_skill_runner_pre_spawn_validation.py` → 0 errors.

Closes #644.