### PR TITLE
docs(intervention_registry): drop stale "Not WAL-persisted" docstring

### DIFF
--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -1,11 +1,19 @@
 """InterventionRegistry — owns active-intervention queue (extracted from ChatSession wave 1C).
 
-Not WAL-persisted: active interventions are volatile. PR21 crash-recovery for
-in-flight interventions is tracked in residuals as future work.
+Crash-recovery persistence (PR-intervention-link L2/L5/L6 + R-D12):
+in-flight interventions ARE durably tracked. ``SnapshotJournal`` records
+``intervention_dispatched`` / ``intervention_resolved`` /
+``intervention_answer_buffered`` / ``intervention_answer_consumed`` events
+to the WAL and maintains ``outstanding_interventions`` +
+``buffered_intervention_answers`` in the per-agent snapshot. After a
+restart, ``ChatSession.restore_state`` calls :meth:`restore` to re-enqueue
+the saved interventions with a watcher coroutine that fires
+``intervention_resolved`` once the user answers — see
+``test_intervention_restore`` + ``test_session_intervention_persistence``
+for the e2e pins.
 
 Announce callback is injected at construction so the registry has no direct
-dependency on ChatSession. Wave 2 will wire:
-    registry = InterventionRegistry(on_announce=self._announce_intervention)
+dependency on ChatSession.
 """
 from __future__ import annotations
 
@@ -23,7 +31,11 @@ from reyn.user_intervention import (
 class InterventionRegistry:
     """Owns active_interventions dict + announce/deliver/dispatch flows.
 
-    Not WAL-persisted (PR21 out of scope; future work in residuals).
+    Crash-recovery persistence is handled outside this class — the
+    ``SnapshotJournal`` records dispatch/resolve/buffer events to the WAL
+    and ``ChatSession.restore_state`` calls :meth:`restore` to re-enqueue
+    saved interventions after a restart. See module docstring for the full
+    flow.
 
     Parameters
     ----------


### PR DESCRIPTION
**[dogfood-coder]** — stale docstring cleanup surfaced during residuals audit.

## Summary

Module + class docstrings of `intervention_registry.py` claimed active interventions were volatile and PR21 crash-recovery was out of scope. Both are stale — PR-intervention-link L2/L5/L6 + R-D12 already wired the persistence:

- `SnapshotJournal.record_intervention_dispatched/resolved/answer_buffered/answer_consumed` log each event to the WAL
- Per-agent snapshot tracks `outstanding_interventions` + `buffered_intervention_answers`
- `InterventionRegistry.restore()` re-enqueues with answer watcher
- `ChatSession.restore_state` calls restore() after a crash
- 10 tests pin the e2e flow (`test_intervention_restore.py` + `test_session_intervention_persistence.py`)

## Source of stale claim

Plan file's high-priority residual entry "active_interventions の永続化 — PR21 では out of scope" also stale (= updated in tandem in the local plan file, not part of this PR's diff since plan file is outside repo).

## Test plan
- [x] `pytest tests/test_intervention_restore.py tests/test_session_intervention_persistence.py` — 10 passed
- [x] no other references to "Not WAL-persisted" / "PR21 out of scope" in src/tests/docs (grep clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)