### PR TITLE
fix(tui): error count wiring + terminal sticky race — Tier 2 invariant restore (HIGH)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1364,17 +1364,30 @@ class OutboxRouter:
         from .widgets.conversation import _classify_error_severity
         severity = _classify_error_severity(msg.text or "", msg.meta or {})
         if severity == "high":
-            # Don't unconditionally hide first — instead show with terminal
-            # priority so it beats any active thinking indicator. The
-            # render_message call below will mount the ErrorBox which
-            # triggers its own scroll-based hide_status logic.
+            # C[2] fix: render_message FIRST so mount_error's hide_status
+            # fires before we set the terminal sticky.  If we set the
+            # sticky first and then call render_message, mount_error's own
+            # ``hide_status()`` (unconditional when not scrolled) would
+            # immediately clear the terminal-priority sticky we just set —
+            # effective display time ZERO.  By rendering first the sticky
+            # is set AFTER the hide_status inside mount_error has already
+            # run, so it persists for the user to read.
+            conv.render_message(msg)
             try:
                 conv.show_status("✗ terminal error", kind="error", terminal=True)
             except Exception:
-                conv.hide_status()
+                pass
         else:
             conv.hide_status()
-        conv.render_message(msg)
+            conv.render_message(msg)
+        # C[1] fix: increment session._error_box_count to keep slash-
+        # command surfaces (/pending list, /reset preview) in sync with
+        # the actual number of mounted ErrorBoxes.  Defensive: only write
+        # if the session exposes the attribute (= stripped / mock sessions
+        # in tests don't crash).
+        _session = self._app._get_session()
+        if getattr(_session, "_error_box_count", None) is not None:
+            _session._error_box_count += 1  # type: ignore[union-attr]
         self._app._last_focal_tab = "events"
         # Out-of-band: flag the terminal title and ring the bell so a
         # user with reyn in a background tab notices something failed.

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1299,6 +1299,20 @@ class ConversationView(Widget):
             if not row._finished
         ]
 
+    def in_flight_tool_call_rows(self) -> list[ToolCallRow]:
+        """Return ToolCallRow widgets whose tool call is still running.
+
+        Sibling to ``in_flight_skill_rows`` — the F3 keyboard expand
+        action targets both. Finished tool call rows (= success /
+        failure / abort terminal state) are excluded for the same
+        reason: F3 should only touch what's currently executing,
+        not old completed rows that may have scrolled far up.
+        """
+        return [
+            row for row in self._tool_call_rows.values()
+            if not row._finished
+        ]
+
     # ── Tool-call rows (issue #427 step 4) ───────────────────────────────────
 
     def start_tool_call_row(
@@ -1790,6 +1804,17 @@ class ConversationView(Widget):
         # accurate after a dismiss. ``[2/3]`` after removing the
         # newest becomes ``[2/2]`` for the remaining tail entry.
         self._renumber_error_boxes()
+        # C[1] fix: keep session._error_box_count in sync.  Defensive:
+        # only decrement when the session exposes the attribute and the
+        # count is already > 0 (guard against going negative on
+        # double-dismiss or a session that initialises late).
+        try:
+            _session = self.app._get_session()  # type: ignore[attr-defined]
+            if getattr(_session, "_error_box_count", None) is not None:
+                if _session._error_box_count > 0:
+                    _session._error_box_count -= 1
+        except Exception:
+            pass
         # C-F4 (wave-8): after dismiss the live count drops by 1.
         # If still ≥ 2, refresh the count sticky to the new value;
         # otherwise the count form is stale and we clear the
@@ -1826,6 +1851,13 @@ class ConversationView(Widget):
             f"  ✗ {n} {noun} dismissed (see events)",
             style="dim #555555",
         ))
+        # C[1] fix: zero out session._error_box_count.  Defensive guard.
+        try:
+            _session = self.app._get_session()  # type: ignore[attr-defined]
+            if getattr(_session, "_error_box_count", None) is not None:
+                _session._error_box_count = 0
+        except Exception:
+            pass
         # Sticky count is now stale — clear it.
         self.hide_status()
 
@@ -2338,6 +2370,14 @@ class ConversationView(Widget):
             except Exception:
                 pass
         self._error_boxes.clear()
+        # C[1] fix: zero out session._error_box_count after all boxes
+        # are gone.  Defensive guard — _get_session() may return None.
+        try:
+            _session = self.app._get_session()  # type: ignore[attr-defined]
+            if getattr(_session, "_error_box_count", None) is not None:
+                _session._error_box_count = 0
+        except Exception:
+            pass
         # Wave-13 C#1: post-clear audit breadcrumb. Written AFTER _log().clear()
         # so it survives in the fresh log (writing before clear() would wipe it
         # along with the rest of the history). The message is intentionally

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -118,6 +118,10 @@ class StickyStatus(Static):
         self._kind: str = "general"
         self._glyph: str = _GLYPHS["general"]
         self._body: str = ""
+        # W13 A#7: track the *effective* priority (= the value used for
+        # suppression decisions) separately from the kind-lookup so
+        # terminal=True calls (priority=110) are reflected in snapshot().
+        self._current_priority: int = 0
 
     def on_mount(self) -> None:
         """Start the 0.1 s elapsed timer tick."""
@@ -153,12 +157,12 @@ class StickyStatus(Static):
         else:
             new_priority = _KIND_PRIORITY.get(new_kind, 0)
         if self._active:
-            current_priority = _KIND_PRIORITY.get(self._kind, 0)
-            if new_priority < current_priority:
+            if new_priority < self._current_priority:
                 return
         self._kind = new_kind
         self._glyph = _GLYPHS[self._kind]
         self._active = True
+        self._current_priority = new_priority
         self.add_class("active")
         self.update_text(text)
 
@@ -170,6 +174,7 @@ class StickyStatus(Static):
     def hide(self) -> None:
         """Deactivate and hide the status bar."""
         self._active = False
+        self._current_priority = 0
         self.remove_class("active")
 
     def snapshot(self) -> dict:
@@ -189,7 +194,11 @@ class StickyStatus(Static):
             "active": self._active,
             "body": self._body,
             "kind": self._kind,
-            "priority": _KIND_PRIORITY.get(self._kind, 0),
+            # W13 A#7: return the *effective* priority (= the value set at
+            # show()-time, which may be _TERMINAL_ERROR_PRIORITY=110 for
+            # terminal errors) rather than the kind-table lookup so tests
+            # can assert ``snapshot()["priority"] == 110`` for terminal errors.
+            "priority": self._current_priority,
         }
 
     # ── internal ──────────────────────────────────────────────────────────────

--- a/tests/cli/test_error_count_wiring.py
+++ b/tests/cli/test_error_count_wiring.py
@@ -1,0 +1,249 @@
+"""Tier 2: session._error_box_count is wired to mount/dismiss/clear lifecycle.
+
+Wave-13 cascade audit finding C[1]: session._error_box_count was declared
+on ChatSession (line 1627) with the comment "TUI outbox handler increments
+on mount_error and decrements on dismiss", but NO caller ever wrote to it.
+/pending list and /reset preview always showed "0 errors" regardless of how
+many ErrorBoxes were actually mounted.
+
+Fixed by:
+  - app_outbox._on_error: increment after conv.render_message() — defensive
+    getattr guard so a None/_stub session doesn't crash.
+  - ConversationView.dismiss_last_error: decrement via self.app._get_session().
+  - ConversationView.dismiss_all_errors: zero out via self.app._get_session().
+  - ConversationView.clear: zero out via self.app._get_session().
+
+Pinned invariants:
+  1. 3 × render_message (each with kind="error") → count == 3.
+  2. dismiss_last_error → count decrements to 2.
+  3. dismiss_all_errors → count == 0.
+  4. clear() with mounted boxes → count == 0.
+  5. session without _error_box_count attr → defensive no-op, no crash.
+
+No MagicMock / AsyncMock / patch.  Real ReynTUIApp + ConversationView
+instances.  Stub session attached via app._get_session override (same
+pattern as test_out_of_band_signals.py).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── shared helpers ─────────────────────────────────────────────────────────────
+
+
+class _StubSession:
+    """Minimal session stub exposing _error_box_count."""
+
+    def __init__(self) -> None:
+        self._error_box_count: int = 0
+
+
+class _StubSessionNoAttr:
+    """Session-like stub that intentionally LACKS _error_box_count.
+
+    Used to verify the defensive guard: wiring code must not raise
+    AttributeError when working with a stripped / mock session.
+    """
+
+
+def _make_app():
+    from reyn.chat.tui.app import ReynTUIApp
+    return ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+
+
+def _make_error_msg(text: str = "oops"):
+    from reyn.chat.outbox import OutboxMessage
+    return OutboxMessage(kind="error", text=text, meta={"skill": "foo"})
+
+
+# ── test 1: 3 render_message calls → count == 3 ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_three_render_messages_count_three() -> None:
+    """Tier 2: 3 × render_message via _on_error → session._error_box_count == 3."""
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+    session = _StubSession()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        # Wire the stub session so app_outbox._on_error can reach it.
+        app._get_session = lambda: session  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        for i in range(3):
+            router._on_error(_make_error_msg(f"error {i}"), conv, header)
+        await pilot.pause()
+
+        assert session._error_box_count == 3, (
+            f"expected 3 after 3 × _on_error, got {session._error_box_count}"
+        )
+
+
+# ── test 2: dismiss_last_error → count decrements ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dismiss_last_error_decrements_count() -> None:
+    """Tier 2: dismiss_last_error after 3 mounts → count decrements to 2."""
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+    session = _StubSession()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        app._get_session = lambda: session  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        for i in range(3):
+            router._on_error(_make_error_msg(f"error {i}"), conv, header)
+        await pilot.pause()
+
+        assert session._error_box_count == 3, "pre-condition: 3 mounts"
+
+        conv.dismiss_last_error()
+        await pilot.pause()
+
+        assert session._error_box_count == 2, (
+            f"expected 2 after one dismiss, got {session._error_box_count}"
+        )
+
+
+# ── test 3: dismiss_all_errors → count == 0 ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dismiss_all_errors_zeros_count() -> None:
+    """Tier 2: dismiss_all_errors after 3 mounts → count == 0."""
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+    session = _StubSession()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        app._get_session = lambda: session  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        for i in range(3):
+            router._on_error(_make_error_msg(f"error {i}"), conv, header)
+        await pilot.pause()
+
+        assert session._error_box_count == 3, "pre-condition: 3 mounts"
+
+        conv.dismiss_all_errors()
+        await pilot.pause()
+
+        assert session._error_box_count == 0, (
+            f"expected 0 after dismiss_all_errors, got {session._error_box_count}"
+        )
+
+
+# ── test 4: clear() zeros count ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clear_zeros_count() -> None:
+    """Tier 2: clear() with 3 mounted boxes → session._error_box_count == 0."""
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+    session = _StubSession()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        app._get_session = lambda: session  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        for i in range(3):
+            router._on_error(_make_error_msg(f"error {i}"), conv, header)
+        await pilot.pause()
+
+        assert session._error_box_count == 3, "pre-condition: 3 mounts"
+
+        conv.clear()
+        await pilot.pause()
+
+        assert session._error_box_count == 0, (
+            f"expected 0 after clear(), got {session._error_box_count}"
+        )
+
+
+# ── test 5: session without _error_box_count → no crash ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_without_attr_defensive_no_crash() -> None:
+    """Tier 2: session lacking _error_box_count → all operations complete without AttributeError.
+
+    Defensive guard: a stripped/mock session must not cause the wiring
+    code to raise.  mount_error, dismiss_last_error, dismiss_all_errors,
+    and clear() must all complete without exception.
+    """
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+    no_attr_session = _StubSessionNoAttr()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        # Wire a session that has NO _error_box_count attribute.
+        app._get_session = lambda: no_attr_session  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        # All of these must not raise AttributeError.
+        router._on_error(_make_error_msg("err1"), conv, header)
+        router._on_error(_make_error_msg("err2"), conv, header)
+        await pilot.pause()
+
+        conv.dismiss_last_error()
+        await pilot.pause()
+
+        router._on_error(_make_error_msg("err3"), conv, header)
+        conv.dismiss_all_errors()
+        await pilot.pause()
+
+        router._on_error(_make_error_msg("err4"), conv, header)
+        conv.clear()
+        await pilot.pause()
+
+        # If we reach here without exception the defensive guard works.
+        assert not hasattr(no_attr_session, "_error_box_count"), (
+            "stub should not have gained _error_box_count; invariant check"
+        )

--- a/tests/cli/test_terminal_error_sticky_persists.py
+++ b/tests/cli/test_terminal_error_sticky_persists.py
@@ -1,0 +1,194 @@
+"""Tier 2: terminal-error sticky persists after ErrorBox mount (C[2] race fix).
+
+Wave-13 cascade audit finding C[2]: in app_outbox._on_error, the original
+code for severity=="high" called conv.show_status("✗ terminal error",
+terminal=True) BEFORE conv.render_message(msg).  But render_message calls
+mount_error, which internally calls self.hide_status() (unconditional when
+not scrolled).  Result: the sticky was shown then immediately hidden in the
+same call stack — effective display time ZERO.
+
+Fixed by reordering:
+  1. conv.render_message(msg) first (= mount ErrorBox + mount_error's
+     hide_status fires here).
+  2. conv.show_status("✗ terminal error", terminal=True) after (= now
+     persists because mount_error's hide_status has already run).
+
+Pinned invariants:
+  1. _on_error with a "high"-severity message → after dispatch the sticky
+     is active, body contains "terminal error", priority == 110.
+  2. An ErrorBox is also mounted (= both side effects achieved, not just
+     the sticky).
+  3. A "med"-severity message (normal error path) → sticky is NOT
+     showing the terminal-error message (scope guard: only high-severity
+     triggers the terminal sticky).
+
+No MagicMock / AsyncMock / patch.  Real ReynTUIApp + ConversationView.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_app():
+    from reyn.chat.tui.app import ReynTUIApp
+    return ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+
+
+def _make_high_severity_msg():
+    """Build an error OutboxMessage that _classify_error_severity rates 'high'.
+
+    Uses the ``[budget exceeded]`` text marker (one of the _HIGH_TEXT_MARKERS).
+    meta["skill"] is present so the render_message path mounts an ErrorBox
+    (= the error-kind branch in render_message).
+    """
+    from reyn.chat.outbox import OutboxMessage
+    return OutboxMessage(
+        kind="error",
+        text="[budget exceeded] daily token cap reached",
+        meta={"skill": "coder"},
+    )
+
+
+def _make_med_severity_msg():
+    """Build a plain error OutboxMessage that rates 'med' severity."""
+    from reyn.chat.outbox import OutboxMessage
+    return OutboxMessage(
+        kind="error",
+        text="something went wrong (transient)",
+        meta={"skill": "coder"},
+    )
+
+
+# ── test 1: high-severity → sticky active, priority==110, "terminal error" ────
+
+
+@pytest.mark.asyncio
+async def test_high_severity_error_sticky_persists_after_mount() -> None:
+    """Tier 2: high-severity _on_error → sticky active with priority 110, body 'terminal error'.
+
+    Verifies the C[2] race fix: the sticky must survive the hide_status()
+    call inside mount_error because render_message is now called first.
+    """
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        # Wire a None session so _get_session doesn't crash.
+        app._get_session = lambda: None  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        router._on_error(_make_high_severity_msg(), conv, header)
+        await pilot.pause()
+
+        sticky = conv._sticky()
+        assert sticky is not None, "StickyStatus must be mounted under ConversationView"
+
+        snap = sticky.snapshot()
+        assert snap["active"] is True, (
+            f"sticky must be active after high-severity error, got active={snap['active']!r}"
+        )
+        assert "terminal error" in snap["body"], (
+            f"sticky body must contain 'terminal error', got {snap['body']!r}"
+        )
+        assert snap["priority"] == 110, (
+            f"terminal sticky must report priority==110, got {snap['priority']!r}"
+        )
+
+
+# ── test 2: ErrorBox also mounted (both side effects) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_high_severity_error_also_mounts_error_box() -> None:
+    """Tier 2: high-severity _on_error mounts an ErrorBox alongside the sticky.
+
+    Both effects must occur: the sticky (test 1) and the ErrorBox in the
+    conv pane.  Verifies via ConversationView._error_boxes list length.
+    """
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        app._get_session = lambda: None  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        # Pre-condition: no ErrorBox children under ConversationView yet.
+        from reyn.chat.tui.widgets.error_box import ErrorBox
+        pre_boxes = conv.query(ErrorBox)
+        assert not pre_boxes, "pre-condition: no ErrorBoxes mounted yet"
+
+        router._on_error(_make_high_severity_msg(), conv, header)
+        await pilot.pause()
+
+        # At least one ErrorBox must now exist as a child of conv.
+        post_boxes = conv.query(ErrorBox)
+        assert post_boxes, (
+            "at least one ErrorBox must be mounted after high-severity _on_error"
+        )
+
+
+# ── test 3: med-severity does NOT show terminal sticky ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_med_severity_error_does_not_show_terminal_sticky() -> None:
+    """Tier 2: med-severity _on_error does NOT produce a 'terminal error' sticky.
+
+    Scope guard: only high-severity errors trigger the terminal sticky.
+    A med-severity error (the common case) must not carry priority==110
+    or the 'terminal error' body — that would escalate every transient
+    error to terminal prominence.
+    """
+    from reyn.chat.tui.app_outbox import OutboxRouter
+    from reyn.chat.tui.widgets import ConversationView, ReynHeader
+
+    app = _make_app()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        app._get_session = lambda: None  # type: ignore[method-assign]
+
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+
+        router._on_error(_make_med_severity_msg(), conv, header)
+        await pilot.pause()
+
+        sticky = conv._sticky()
+        if sticky is not None:
+            snap = sticky.snapshot()
+            if snap["active"]:
+                assert "terminal error" not in snap["body"], (
+                    f"med-severity must not show 'terminal error' sticky, "
+                    f"got body={snap['body']!r}"
+                )
+                assert snap["priority"] != 110, (
+                    f"med-severity sticky must not have priority 110, "
+                    f"got priority={snap['priority']!r}"
+                )


### PR DESCRIPTION
**[tui-coder]** — Wave-13 cascade audit: fixes 2 HIGH regressions.

## Summary

**C[1]: `session._error_box_count` wiring (never written → always 0)**

`ChatSession._error_box_count` was declared on line 1627 with a docstring promising it would be incremented/decremented by the TUI outbox handler — but no caller ever wrote to it. `/pending list needs-attention` and `/reset` confirm preview always showed "0 errors" regardless of actual screen state.

Fixed by wiring 4 mutation sites:
- `app_outbox._on_error`: increment after `conv.render_message(msg)` — defensive `getattr` guard so None/mock sessions don't crash.
- `ConversationView.dismiss_last_error`: decrement via `self.app._get_session()`.
- `ConversationView.dismiss_all_errors`: zero out.
- `ConversationView.clear()`: zero out.

**C[2]: terminal-error sticky race (effective display time ZERO)**

In `app_outbox._on_error` for `severity == "high"`, the original order was:
1. `conv.show_status("✗ terminal error", terminal=True)` — sets sticky at priority 110
2. `conv.render_message(msg)` → `mount_error()` → `hide_status()` (unconditional when not scrolled)

= sticky shown then immediately cleared. Fixed by swapping order: `render_message` first (ErrorBox mounts + `mount_error`'s `hide_status()` fires), then `show_status` so the sticky persists.

**StickyStatus `snapshot()` priority bug (latent)**

`snapshot()["priority"]` always returned `_KIND_PRIORITY.get(self._kind, 0)` = 80 for `kind="error"`, even when the effective priority was 110 (terminal). Added `_current_priority` tracking in `show()` / reset in `hide()`, returned from `snapshot()`.

## New tests (8 Tier-2, no MagicMock)

`tests/cli/test_error_count_wiring.py` (5 tests):
- 3 × `_on_error` → `session._error_box_count == 3`
- `dismiss_last_error` → count decrements to 2
- `dismiss_all_errors` → count == 0
- `clear()` with boxes → count == 0
- Session without `_error_box_count` attr → defensive no-op, no crash

`tests/cli/test_terminal_error_sticky_persists.py` (3 tests):
- High-severity `_on_error` → sticky active, body "terminal error", priority == 110
- ErrorBox also mounted (both side effects)
- Med-severity → NOT showing terminal sticky (scope guard)

## Test plan

- [x] `pytest tests/cli/test_error_count_wiring.py tests/cli/test_terminal_error_sticky_persists.py` — 8 passed
- [x] `pytest tests/cli/test_*error*.py tests/cli/test_sticky_status*.py tests/test_slash_pending_extended_and_reset_preview.py tests/cli/test_tui_smoke.py` — 130 passed
- [x] `ruff check` on all changed files — clean
- [x] `scripts/test_tier_audit.py` — 8/8 OK, 0 Tier-4 violations
- [x] (skipped — TUI not launchable in this env) Visual: mount 3 errors, check `/pending list` shows "3 errors"
- [x] (skipped — TUI not launchable) Visual: budget-exceeded mid-stream — sticky "✗ terminal error" persists after ErrorBox mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)