### PR TITLE
docs(a2a): refresh "what's supported" — task lifecycle is shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,11 +312,34 @@ curl -X POST http://localhost:8080/a2a/agents/default \
 
 The reply comes back as a standard A2A `Message` (`role: agent`, with text parts). Multi-turn history is preserved across calls — same backing as MCP.
 
-### v1 supported / not yet
+### Async tasks (`async_mode: true`)
 
-Supported: `message/send` (synchronous), Agent Card discovery, multi-turn history persistence.
+For long-running skills — including ones that fire `ask_user` mid-execution — set `params.async_mode: true` (or supply `params.webhook_url`) on `message/send`. The response is an A2A `Task` envelope (`{kind: "task", id: <run_id>, status: "running", ...}`); the agent runs in the background and the peer polls or subscribes to the lifecycle:
 
-Not yet (tracked as A2A v2 follow-ups): `message/stream`, task lifecycle (`tasks/get`, `tasks/cancel`, push notifications), authentication, non-text message parts.
+- `GET /a2a/tasks/{run_id}` — poll status (`running` / `input-required` / `completed` / `failed` / `cancelled`). Carries `question`, `result`, `error` fields as the task progresses.
+- `GET /a2a/tasks/{run_id}/events` — SSE stream of task events; closes on terminal status.
+- `POST /a2a/tasks/{run_id}/cancel` — cancel the underlying `asyncio.Task` (idempotent).
+- Mid-run `ask_user`: when the task transitions to `input-required`, the prompt is exposed as `question`. Reply with another `message/send` carrying `params.task_id` and the user's answer in `params.message`.
+- Push notifications: when `params.webhook_url` is set on the initial call, Reyn POSTs JSON payloads to the URL on each status transition.
+
+Details: [`docs/concepts/a2a.md`](docs/concepts/a2a.md#task-lifecycle-and-async-execution-fp-0001).
+
+### Supported
+
+| Method / capability | Status |
+|---|---|
+| `message/send` (synchronous reply) | ✅ |
+| `message/send` (async via `async_mode: true`) | ✅ |
+| `GET /a2a/tasks/{run_id}` (status polling) | ✅ |
+| `POST /a2a/tasks/{run_id}/cancel` | ✅ |
+| `GET /a2a/tasks/{run_id}/events` (SSE) | ✅ |
+| Mid-run `ask_user` injection | ✅ |
+| Push notifications (`params.webhook_url`) | ✅ |
+| Agent Card discovery (`.well-known/agent-card.json`) | ✅ |
+| Multi-turn history persistence | ✅ |
+| `message/stream` standalone method | ❌ (use the SSE endpoint above) |
+| Authentication (bearer tokens / OAuth) | ❌ |
+| Non-text message parts (`file`, `data`) | ❌ |
 
 Spec reference: <https://google.github.io/A2A/>.
 

--- a/docs/concepts/a2a.ja.md
+++ b/docs/concepts/a2a.ja.md
@@ -41,16 +41,22 @@ Agent Card に含まれる情報：
 
 ## サポート状況
 
-| Method | v1 | v2（予定） |
+| メソッド / 機能 | 状態 | 備考 |
 |---|---|---|
-| `message/send` | ✅ 同期返信 | — |
-| `message/stream` | ❌ | streaming SSE レスポンス |
-| `tasks/get` / `tasks/cancel` | ❌ | 長時間実行のタスクライフサイクル |
-| プッシュ通知 | ❌ | コールバック形式の結果 |
-| 認証 | ❌ | bearer トークン / OAuth |
-| テキスト以外のパーツ（`file`、`data`） | ❌ | Reyn workspace 経由のファイルアップロード |
+| `message/send`（同期返信） | ✅ | デフォルトモード。ピアは最終返信テキストまで待機します。 |
+| `message/send`（`async_mode: true` による非同期） | ✅ | A2A `Task` envelope を返し、ピアはポーリングまたは購読します。下記 [タスクライフサイクル](#タスクライフサイクルと非同期実行-fp-0001) 参照。 |
+| `GET /a2a/tasks/{run_id}`（ステータスポーリング） | ✅ | `running` / `input-required` / `completed` / `failed` / `cancelled` を返します。 |
+| `POST /a2a/tasks/{run_id}/cancel` | ✅ | 内部 `asyncio.Task` をキャンセル（idempotent）。 |
+| `GET /a2a/tasks/{run_id}/events`（SSE ストリーム） | ✅ | Reyn ネイティブのストリーミング窓口。終了状態でクローズ。 |
+| 実行中の `ask_user` 介入 | ✅ | タスクは `input-required` に遷移し、ピアは `task_id` 付き `message/send` で応答します。 |
+| プッシュ通知（`params.webhook_url`） | ✅ | 各ステータス遷移で Reyn が JSON を POST。 |
+| Agent Card discovery（`.well-known/agent-card.json`） | ✅ | agent ごとと multi-agent index の両エンドポイント。 |
+| マルチターン履歴の永続化 | ✅ | MCP と同じ backing。agent ごとに `ChatSession.history`。 |
+| `message/stream`（単独 JSON-RPC メソッド） | ❌ | 代替として上記 `/events` SSE エンドポイントを使用。 |
+| 認証（bearer トークン / OAuth） | ❌ | v1 では対象外。ネットワーク層のアクセス制御に依存。 |
+| テキスト以外のパーツ（`file`、`data`） | ❌ | 現状はファイルを Reyn workspace 経由で交換。 |
 
-`message/send` が MVP の中心機能です。最も一般的な interop パターン（ピア agent が Reyn agent に質問し、最終返信テキストを受け取る）をカバーするためです。マルチターンの履歴は呼び出し間で保持されます。Reyn の `ChatSession.history` は agent ごとに永続化されており — MCP パスと同じ特性です。
+`message/send` が MVP の中心機能です。最も一般的な interop パターン（ピア agent が Reyn agent に質問し、最終返信テキストを受け取る）をカバーするためです。マルチターンの履歴は呼び出し間で保持されます。Reyn の `ChatSession.history` は agent ごとに永続化されており — MCP パスと同じ特性です。上に重ねた非同期タスクライフサイクル（FP-0001、下記詳細）により、ピアは長時間実行 skill を駆動し、実行中の `ask_user` に応答し、キャンセルできます。`message/send` のワイヤー形状は変わりません。
 
 ## MCP と A2A の両方を使う理由
 

--- a/docs/concepts/a2a.md
+++ b/docs/concepts/a2a.md
@@ -55,20 +55,29 @@ The Agent Card surfaces:
 
 ## What's supported
 
-| Method | v1 | v2 (planned) |
+| Method / capability | Status | Notes |
 |---|---|---|
-| `message/send` | ✅ synchronous reply | — |
-| `message/stream` | ❌ | streaming SSE responses |
-| `tasks/get` / `tasks/cancel` | ❌ | task lifecycle for long-running runs |
-| Push notifications | ❌ | callback-style results |
-| Authentication | ❌ | bearer tokens / OAuth |
-| Non-text parts (`file`, `data`) | ❌ | file uploads via Reyn workspace |
+| `message/send` (synchronous reply) | ✅ | Default mode — peer waits for the final reply text. |
+| `message/send` (async via `async_mode: true`) | ✅ | Returns an A2A `Task` envelope; peer polls or subscribes. See [Task lifecycle](#task-lifecycle-and-async-execution-fp-0001). |
+| `GET /a2a/tasks/{run_id}` (status polling) | ✅ | Reports `running` / `input-required` / `completed` / `failed` / `cancelled`. |
+| `POST /a2a/tasks/{run_id}/cancel` | ✅ | Cancels the underlying `asyncio.Task` (idempotent). |
+| `GET /a2a/tasks/{run_id}/events` (SSE stream) | ✅ | Reyn-native streaming surface; closes on terminal status. |
+| Mid-run `ask_user` injection | ✅ | Task transitions to `input-required`; reply with `message/send` + `task_id`. |
+| Push notifications (`params.webhook_url`) | ✅ | Reyn POSTs JSON payloads on each status transition. |
+| Agent Card discovery (`.well-known/agent-card.json`) | ✅ | Per-agent + multi-agent index endpoints. |
+| Multi-turn history persistence | ✅ | Same backing as MCP; per-agent `ChatSession.history`. |
+| `message/stream` (standalone JSON-RPC method) | ❌ | Use the `/events` SSE endpoint above instead. |
+| Authentication (bearer tokens / OAuth) | ❌ | Out of scope for v1; relies on network-level access control. |
+| Non-text message parts (`file`, `data`) | ❌ | Files exchanged via the Reyn workspace today. |
 
 `message/send` is the headline of the MVP because it covers the most
 common interop pattern: peer agent has a question for a Reyn agent,
 gets the final reply text. Multi-turn history is preserved across
 calls because Reyn's `ChatSession.history` is per-agent and
-persistent — exactly the same property the MCP path relies on.
+persistent — exactly the same property the MCP path relies on. The
+async task lifecycle layered on top (FP-0001, detailed below) lets
+peers drive long-running skills, react to mid-run `ask_user`, and
+cancel without changing the wire shape of the `message/send` call.
 
 ## Why both MCP and A2A
 


### PR DESCRIPTION
**[e2e-coder]** — README + `docs/concepts/a2a.md` の A2A サポート状況が古い (= FP-0001 で landed 済の async task lifecycle / push / cancel が 「v2 planned」 のまま) ので refresh。

## Why now

E2E シナリオ 「Reyn の A2A protocol はどう実装されてる?」 を流したところ、 V18 SP は正しく `reyn.source__read(README.md)` を選んで読み出していた — つまり SP layer は正しく機能しているが、 README が返す中身が古いせいで agent が user に間違った答え (= 「`tasks/get` はまだ未実装」) を返す状態だった。

dogfood trace で挙動確認:

- request_id `7dd419f6-a07b-420a-8aae-650a9c20e395` で 「Reyn の A2A protocol はどう実装されてる?」 をルーティング
- 5/5 試行で `reyn.source__read({"path": "README.md"})` を選択 (= 期待動作)
- README は stale な 「Not yet (tracked as A2A v2 follow-ups): `message/stream`, task lifecycle (`tasks/get`, `tasks/cancel`), push notifications, ...」 をそのまま返す
- 結果: agent が user に 「未実装」 と答える

## What's stale

実装は landed (`src/reyn/web/routers/a2a.py`):

- `message/send` (sync + async via `async_mode: true`)
- `GET /a2a/tasks/{run_id}` (status polling)
- `POST /a2a/tasks/{run_id}/cancel`
- `GET /a2a/tasks/{run_id}/events` (SSE)
- Mid-run `ask_user` injection (`input-required` 状態 + `task_id` 付き返信)
- Push notifications via `params.webhook_url`

加えて、 `docs/concepts/a2a.md` 自身も内部矛盾していた:

- 「## What's supported」 table → ❌ 表記
- 「## Task lifecycle and async execution (FP-0001)」 セクション → ✅ 実装詳細

LLM はテーブルを先に読んで 「未実装」 と判断する pattern。

## Changes

- **README.md** A2A セクション
  - 旧 「### v1 supported / not yet」 (5 行段落) を以下に置換:
    - 「### Async tasks (`async_mode: true`)」 (新規 subsection、 polling / SSE / cancel / mid-run ask / webhook を 1 段落 + 5 bullet)
    - 「### Supported」 表 (12 行 capability table)
  - `docs/concepts/a2a.md` への deep-link (anchor 付き) を 1 行追加
- **docs/concepts/a2a.md** 「What's supported」 table を 12 行 capability table に再生成 (anchor `#task-lifecycle-and-async-execution-fp-0001` を併記)
- **docs/concepts/a2a.ja.md** 同じく 12 行 table + anchor 1 行 + 末尾段落の 1 文補足

残る ❌:

- `message/stream` standalone JSON-RPC method (= 代替として `/events` SSE)
- Authentication (bearer / OAuth)
- Non-text parts (`file`, `data`)

## Scope

Docs only. コードは変更なし。 実装の事実関係は `src/reyn/web/routers/a2a.py` + `docs/concepts/a2a.md` の 「Task lifecycle and async execution (FP-0001)」 セクション (line 90-173) を source of truth として参照。

## Test plan

- [x] `ruff check README.md docs/concepts/a2a.md docs/concepts/a2a.ja.md` → All checks passed (no Python files)
- [x] `git diff --stat` 確認: 3 ファイル / +58 / -20
- [x] README A2A section の anchor (`docs/concepts/a2a.md#task-lifecycle-and-async-execution-fp-0001`) が `docs/concepts/a2a.md` の見出し ID と整合 (= GitHub-flavored markdown が小文字 + `-` 連結 + 括弧除去するため `task-lifecycle-and-async-execution-fp-0001`)
- [x] ja.md の anchor (`#タスクライフサイクルと非同期実行-fp-0001`) も同じ規則で生成済
- [x] テストファイル変更なし → Tier rule self-check 対象外 (docs-only PR)

## Notes for reviewer

- e2e-coder の trace-driven validation 経由で発見した stale doc。 シナリオ駆動の UX bug としては典型的 (= LLM 層は正しく動いていて doc 層が古い)。
- 「Question intent + 直接 invoke」 という V18 SP 設計が機能している証拠でもあるので、 docs 修正単独で UX 改善が達成される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)