### PR TITLE
fix(tui): conv pane inline header + body — #646 design intent restore (UX fix)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -165,6 +165,27 @@ def _msg_header(symbol: str, name_style: str, show_ts: bool = True) -> Text:
     return t
 
 
+def _build_header_prefix(symbol: str, name_style: str, show_ts: bool = True) -> Text:
+    """Build the ``HH:MM <symbol> `` (trailing space) inline prefix Text.
+
+    Same glyph/timestamp logic as ``_msg_header`` but appends a trailing
+    space so the body can be concatenated directly to produce the Claude
+    Code-style ``HH:MM > body text`` inline layout.
+
+    Used by ``_write_inline_header_body`` to combine the header and first
+    body line into a single RichLog write, which puts the speaker symbol
+    and message content on the same visual line with col-8 hanging indent
+    for wrap continuations.
+    """
+    t = Text()
+    if show_ts:
+        t.append(time.strftime("%H:%M"), style="dim #666666")
+        t.append(" ")
+    t.append(symbol, style=name_style)
+    t.append(" ")  # trailing space so body starts immediately after symbol
+    return t
+
+
 def _is_lifecycle_marker(text: str) -> bool:
     """Heuristic: ``ChatLifecycleForwarder`` marker text starts with ``[↑``
     and ends with ``]``, and is single-line.
@@ -687,6 +708,36 @@ class ConversationView(Widget):
 
     # ── header grouping (B1) ──────────────────────────────────────────────────
 
+    def _check_new_turn(self, speaker: str, log: "RichLog") -> bool:
+        """Return True if this is a new turn (different speaker or window expired).
+
+        Side-effects when a new turn starts:
+          - Emits a date-separator when the calendar day has changed.
+          - Records the current absolute line position as a turn anchor.
+        Does NOT write any header line — the caller decides what to write.
+
+        ``_last_speaker`` / ``_last_speaker_at`` are updated by the caller
+        AFTER the header/body write (so anchors are recorded before the write
+        that advances the line counter).
+
+        Wave-10 follow-up G-F7: ``time.time()`` (wall clock) matches the
+        visible ``HH:MM`` timestamp and grouping decision — see
+        ``_maybe_write_header`` docstring for full rationale.
+        """
+        now = time.time()
+        same_speaker = (speaker == self._last_speaker)
+        within_window = (now - self._last_speaker_at) < _GROUP_WINDOW_S
+        if same_speaker and within_window:
+            return False
+        # Day boundary marker.
+        today = time.strftime("%Y-%m-%d")
+        if today != self._last_header_date:
+            log.write(_date_separator(today))
+            self._last_header_date = today
+        # Record a turn anchor.
+        self._turn_anchors.append(self._absolute_line_position(log))
+        return True
+
     def _maybe_write_header(self, speaker: str, symbol: str,
                              name_style: str) -> None:
         """Write a symbol-only header when the speaker changes or the gap exceeds _GROUP_WINDOW_S.
@@ -708,24 +759,8 @@ class ConversationView(Widget):
         user-visible timeline exactly.
         """
         now = time.time()
-        same_speaker = (speaker == self._last_speaker)
-        within_window = (now - self._last_speaker_at) < _GROUP_WINDOW_S
-        if not (same_speaker and within_window):
-            log = self._log()
-            # Day boundary marker: when this header lands on a different
-            # calendar day than the previous one (or the session's first
-            # header), emit a dim "── YYYY-MM-DD ─────" line so users in a
-            # multi-day session can tell which "21:55" they're looking at.
-            today = time.strftime("%Y-%m-%d")
-            if today != self._last_header_date:
-                log.write(_date_separator(today))
-                self._last_header_date = today
-            # Record a turn anchor whenever a new speaker header appears
-            # — agent replies, user inputs, and system / slash-command
-            # results. Ctrl+P / Ctrl+N then walk through every header in
-            # order, which matches the user's mental model of "jump to
-            # the previous turn" better than "jump only to agent replies".
-            self._turn_anchors.append(self._absolute_line_position(log))
+        log = self._log()
+        if self._check_new_turn(speaker, log):
             # No cap. The previous 200-entry cap silently dropped the
             # oldest anchors in long sessions, so Ctrl+P/N's "N / M"
             # readout showed an M smaller than the real turn count and
@@ -742,6 +777,86 @@ class ConversationView(Widget):
             log.write(_msg_header(symbol, name_style, show_ts=self._show_timestamps))
         self._last_speaker = speaker
         self._last_speaker_at = now
+
+    def _maybe_write_inline_header_body(
+        self,
+        speaker: str,
+        symbol: str,
+        name_style: str,
+        body_text: Text,
+    ) -> None:
+        """Write header + body inline (#646 Claude Code style) with col-8 hanging indent.
+
+        When a new turn starts (new speaker or _GROUP_WINDOW_S expired):
+          - Emits ``HH:MM <sym> <body_first_line>`` at column 0.
+          - Emits each body-wrap continuation at ``_current_body_indent()``
+            columns so the wrap visually nests under the body text, not the
+            symbol.
+
+        When within the same speaker's grouping window (= header suppressed):
+          - Emits body only via ``_write_body`` (= hanging-indent Padding),
+            same as the original 2-line path.  The symbol is intentionally
+            absent so successive messages from the same speaker don't pile up
+            repeated headers.
+
+        Body wrap is computed by splitting ``body_text`` at
+        ``pane_width - indent`` cell-width.  The pane width falls back to
+        ``_FOLD_WIDTH_FALLBACK + indent`` when ``self.size.width`` is 0
+        (= widget not yet laid-out or test harness with ``size=(0,0)``).
+
+        This is the load-bearing writer for ``render_user_message`` and
+        ``_render_agent_markdown`` (plain-text first-line path).
+        """
+        now = time.time()
+        log = self._log()
+        is_new_turn = self._check_new_turn(speaker, log)
+        self._last_speaker = speaker
+        self._last_speaker_at = now
+
+        indent = self._current_body_indent()
+
+        if not is_new_turn:
+            # Grouped turn: no header, just body at hanging-indent.
+            self._write_body(body_text)
+            return
+
+        # New turn: build inline header prefix.
+        prefix = _build_header_prefix(symbol, name_style, show_ts=self._show_timestamps)
+        prefix_cells = cell_len(prefix.plain)
+
+        # Compute body wrap width = pane_width minus the indent column.
+        # The first body line starts at col ``prefix_cells`` (= same as
+        # ``indent`` by design: both are 8 with ts-on, 2 with ts-off).
+        try:
+            pane_width = self.size.width
+            if pane_width <= 0:
+                pane_width = _FOLD_WIDTH_FALLBACK + indent
+        except Exception:
+            pane_width = _FOLD_WIDTH_FALLBACK + indent
+        # RichLog has 1-cell padding on each side (see CSS: padding: 0 1).
+        body_width = max(10, pane_width - indent - 2)
+
+        # Split body_text into wrap lines at body_width.
+        try:
+            from rich.console import Console as _Console
+            _buf_console = _Console(width=body_width, highlight=False)
+            wrapped_lines = list(body_text.wrap(_buf_console, body_width))
+        except Exception:
+            wrapped_lines = [body_text]
+
+        if not wrapped_lines:
+            # Empty body: emit just the header prefix as a standalone line.
+            log.write(prefix)
+            return
+
+        # First line: header prefix + first body-wrap line inline.
+        first_line = prefix + wrapped_lines[0]
+        log.write(first_line)
+
+        # Remaining wrap lines: indented to ``indent`` col via Padding.
+        for cont in wrapped_lines[1:]:
+            if cont.plain.strip():  # skip blank-only continuation lines
+                log.write(_indent_body(cont, indent))
 
     # ── non-streaming message rendering ───────────────────────────────────────
 
@@ -823,11 +938,16 @@ class ConversationView(Widget):
         user had previously scrolled up to read history, they now want to
         see the conversation continue. Snap back to the bottom and re-arm
         auto-scroll so subsequent agent reply chunks track the tail.
+
+        #646 Claude Code-style inline layout: ``HH:MM > message text`` on the
+        same logical line, with wrap continuations landing at col 8
+        (``_BODY_INDENT_WITH_TS``) so they nest visually under the body text.
         """
         self._snap_to_bottom()
         self._consume_empty_hint()
-        self._maybe_write_header("you", _GLYPH_USER, "bold #4abbb5")
-        self._write_body(Text(text))
+        self._maybe_write_inline_header_body(
+            "you", _GLYPH_USER, "bold #4abbb5", Text(text),
+        )
         self._write_log(Text(""))
 
     def _render_system_message(self, msg: OutboxMessage) -> None:
@@ -863,21 +983,63 @@ class ConversationView(Widget):
         agent replies appear under their header instead of being pushed to
         the bottom of the pane. Hides any sticky "thinking…" indicator that
         was active for this turn.
+
+        #646 Claude Code-style inline layout: ``HH:MM ⏺ [meta] first_line``
+        appears on the same logical line.  The first plain-text line of the
+        message body (or the meta prefix when present) is extracted and
+        inlined with the header via ``_maybe_write_inline_header_body``.
+        The remaining Markdown body (if any) is written at col-8 indent.
+
+        Implementation note (structural vs simple tradeoff):
+          - Markdown formatting on the first line is rendered as plain text
+            (e.g. ``**bold**`` shows as plain ``bold``). For the typical
+            agent reply, the first line is prose — this is an acceptable
+            trade-off that avoids reimplementing Rich's Markdown renderer.
+          - When no body text is present (= header-only turn signal), only
+            the header prefix is emitted.
         """
         self._consume_empty_hint()
         self.stop_thinking()  # turn finished — unmount inline spinner
         self.hide_status()    # also clear any sticky status
         meta_pfx = _meta_prefix(msg.meta)
-        # _AMBER for agent identity — distinct from _CORAL (interactive
-        # affordances). The meta prefix (= [skill#abcd]) is emitted on its
-        # own line after the header so the symbol-only header stays minimal.
-        self._maybe_write_header("reyn", _GLYPH_AGENT, "bold " + _AMBER)
+        body_text = msg.text or ""
+
+        # Build the inline first-line text: meta prefix (if any) + first body
+        # line stripped of Markdown markup.  For an agent reply that begins
+        # "**Plan**:" this reads "Plan:" in the inline header — acceptable.
         if meta_pfx:
-            # Emit the meta prefix as a dim sub-line so skill identity is still
-            # discoverable without cluttering the symbol header.
-            self._write_body(Text(meta_pfx.strip(), style="dim #888888"))
-        if msg.text:
-            self._write_agent_markdown_with_fold(msg.text)
+            first_line_plain = meta_pfx.rstrip()
+            if body_text:
+                # Append first source line (stripped of leading # / * / `) to
+                # keep the header line short and readable.
+                src_first = body_text.splitlines()[0].strip().lstrip("#* `_")
+                if src_first:
+                    first_line_plain = f"{first_line_plain} {src_first}"
+        elif body_text:
+            first_line_plain = body_text.splitlines()[0].strip().lstrip("#* `_")
+        else:
+            first_line_plain = ""
+
+        inline_body = Text(first_line_plain, style="dim #888888" if meta_pfx else "")
+
+        # _AMBER for agent identity — distinct from _CORAL (interactive
+        # affordances).
+        self._maybe_write_inline_header_body(
+            "reyn", _GLYPH_AGENT, "bold " + _AMBER, inline_body,
+        )
+
+        # Write the full Markdown body (all lines) at hanging-indent.
+        # This causes the first line to appear twice when body_text has one
+        # line, but for Markdown replies the full render at col 8 gives
+        # correct formatting (= bold, code, lists) for lines 2+.
+        # When body has only one line, suppress the duplicate body write.
+        if body_text:
+            body_lines = body_text.splitlines()
+            if len(body_lines) > 1:
+                # Remaining lines as Markdown (preserving formatting).
+                rest = "\n".join(body_lines[1:])
+                self._write_agent_markdown_with_fold(rest)
+            # Single-line body: already rendered inline; no extra write needed.
         self._write_log(Text(""))
 
     # ── B3 fold (long-reply truncation + /expand) ────────────────────────────

--- a/tests/cli/test_body_hanging_indent.py
+++ b/tests/cli/test_body_hanging_indent.py
@@ -1,17 +1,23 @@
-"""Tier 2: message bodies render at the dynamic hanging-indent column.
+"""Tier 2: message bodies render inline with the header — Claude Code style.
 
-With timestamps shown (default), bodies start at col 8 (= ``_BODY_INDENT_WITH_TS``);
-with timestamps hidden (F9 toggle), bodies start at col 2 (= ``_BODY_INDENT_NO_TS``).
+#646 design intent: ``HH:MM > message text`` on the same logical line with
+wrap continuations landing at col 8 (= ``_BODY_INDENT_WITH_TS``) to nest
+visually under the body text, not the symbol.
 
-Before the hanging-indent fix, ``RichLog(wrap=True)`` wrapped long lines
-without any leading indent so a continuation landed at column 0 —
-indistinguishable from a new speaker header. The Padding at every body
-write site keeps wrap continuations visually nested under the symbol.
+With timestamps shown (default):
+  - User  header prefix: ``HH:MM > `` (8 cells → body inline at col 8)
+  - Agent header prefix: ``HH:MM ⏺ `` (8 cells → body inline at col 8)
+  - First body line: inline with the header on the same RichLog line.
+  - Wrap continuations: col 8 via Padding.
+
+With timestamps hidden (F9 toggle):
+  - Header prefix is ``> `` (2 cells).
+  - First body line inline at col 2.
+  - Wrap continuations at col 2.
 
 These tests inspect the rendered RichLog Strips (= what the user
-actually sees on screen) for body lines vs header lines, so a future
-refactor that drops the indent or accidentally applies it to headers
-would surface immediately.
+actually sees on screen) for inline layout, wrap continuation indent,
+and the invariant that the header line is never indented.
 """
 from __future__ import annotations
 
@@ -29,7 +35,11 @@ from textual.widgets import RichLog
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.tui.app import ReynTUIApp
 from reyn.chat.tui.widgets import ConversationView
-from reyn.chat.tui.widgets.conversation import _BODY_INDENT_NO_TS, _BODY_INDENT_WITH_TS
+from reyn.chat.tui.widgets.conversation import (
+    _BODY_INDENT_NO_TS,
+    _BODY_INDENT_WITH_TS,
+    _GLYPH_USER,
+)
 
 
 def _make_app() -> ReynTUIApp:
@@ -55,39 +65,52 @@ def _find_first_line_containing(log: RichLog, needle: str) -> int:
     raise AssertionError(f"text {needle!r} never appeared in RichLog")
 
 
-# ── body indent applied to common write paths ────────────────────────────────
+# ── inline header + body (the new Claude Code-style layout) ──────────────────
 
 
 @pytest.mark.asyncio
-async def test_user_message_body_is_indented() -> None:
-    """Tier 2b: ``render_user_message`` writes its body at the ts-on hanging-indent column.
+async def test_user_message_body_is_inline_with_header() -> None:
+    """Tier 2b: ``render_user_message`` puts body inline with the header (ts on).
 
-    The header (``HH:MM >`` with ts on) stays at column 0; the body line
-    "hello world" starts at column ``_BODY_INDENT_WITH_TS`` (8) so a wrap
-    continuation visually nests under the symbol column.
+    #646 design: the header prefix (``HH:MM > ``) and body appear on the
+    same logical line.  The line found in the RichLog for "hello world"
+    must start with an HH:MM timestamp (col 0, no leading spaces) and
+    contain the body text — not start with col-8 spaces as in the old
+    2-line layout.
     """
+    import re
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
-        # Default state: timestamps on → indent 8.
+        # Default state: timestamps on.
         conv._show_timestamps = True
         conv.render_user_message("hello world")
         await pilot.pause()
 
         idx = _find_first_line_containing(log, "hello world")
-        body = _line_text(log, idx)
-        assert body.startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"user body (ts on) must start at indent col {_BODY_INDENT_WITH_TS}; got {body!r}"
+        line = _line_text(log, idx)
+        # Inline: the body-containing line must start with HH:MM (col 0, no indent).
+        assert re.search(r"^\d{2}:\d{2}", line), (
+            f"ts-on inline line must start with HH:MM at col 0; got {line!r}"
         )
-        assert "hello world" in body
+        assert _GLYPH_USER in line, f"user symbol must be on the same line; got {line!r}"
+        assert "hello world" in line, f"body text must be inline; got {line!r}"
+        # Must NOT start with spaces (= old 2-line indented body).
+        assert not line.startswith(" "), (
+            f"inline line must NOT start with spaces (col 0 anchor); got {line!r}"
+        )
 
 
 @pytest.mark.asyncio
-async def test_user_message_body_is_indented_ts_off() -> None:
-    """Tier 2b: ``render_user_message`` with ts off uses the narrow indent (col 2)."""
+async def test_user_message_body_is_inline_ts_off() -> None:
+    """Tier 2b: ``render_user_message`` with ts off puts body inline at col 0.
+
+    When timestamps are hidden, header prefix is ``> `` (2 cells).
+    The first body line is inline and starts with ``>`` at col 0.
+    """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -99,15 +122,22 @@ async def test_user_message_body_is_indented_ts_off() -> None:
         await pilot.pause()
 
         idx = _find_first_line_containing(log, "hello ts-off")
-        body = _line_text(log, idx)
-        assert body.startswith(" " * _BODY_INDENT_NO_TS), (
-            f"user body (ts off) must start at indent col {_BODY_INDENT_NO_TS}; got {body!r}"
+        line = _line_text(log, idx)
+        # ts-off: line starts with symbol at col 0.
+        assert line.startswith(_GLYPH_USER), (
+            f"ts-off inline line must start with user symbol; got {line!r}"
+        )
+        assert "hello ts-off" in line, f"body text must be inline; got {line!r}"
+        # Must NOT start with 2-space indent (= old 2-line layout).
+        assert not line.startswith("  "), (
+            f"ts-off inline line must NOT start with spaces; got {line!r}"
         )
 
 
 @pytest.mark.asyncio
-async def test_agent_markdown_body_is_indented() -> None:
-    """Tier 2b: Agent markdown turns render their content at the ts-on indent column."""
+async def test_agent_markdown_body_is_inline_with_header() -> None:
+    """Tier 2b: Agent markdown first line is inline with the speaker symbol."""
+    import re
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -120,15 +150,25 @@ async def test_agent_markdown_body_is_indented() -> None:
         await pilot.pause()
 
         idx = _find_first_line_containing(log, "this is the agent body line")
-        body = _line_text(log, idx)
-        assert body.startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"agent body must start at indent col {_BODY_INDENT_WITH_TS}; got {body!r}"
+        line = _line_text(log, idx)
+        # Inline: body line starts with HH:MM at col 0 (not with spaces).
+        assert re.search(r"^\d{2}:\d{2}", line), (
+            f"agent inline line must start with HH:MM; got {line!r}"
+        )
+        assert not line.startswith(" "), (
+            f"agent inline line must NOT start with spaces; got {line!r}"
         )
 
 
 @pytest.mark.asyncio
 async def test_system_message_body_is_indented() -> None:
-    """Tier 2b: ``/slash`` output rendered as system kind also gets indented."""
+    """Tier 2b: ``/slash`` output rendered as system kind still gets indented.
+
+    System messages (= slash-command output) use the legacy 2-line path
+    (``_maybe_write_header`` + ``_write_body``).  They are multi-line text
+    blocks and are not subject to the #646 inline fix.  Body lines must
+    start at col ``_BODY_INDENT_WITH_TS`` (8).
+    """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -148,17 +188,16 @@ async def test_system_message_body_is_indented() -> None:
             )
 
 
-# ── header lines stay at column 0 ────────────────────────────────────────────
+# ── header line is never indented ────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_header_line_is_not_indented() -> None:
-    """Tier 2b: The symbol header stays at column 0.
+    """Tier 2b: The inline header+body line starts at column 0 (no leading spaces).
 
-    This is the load-bearing distinction: header at column 0,
-    body at column ``_BODY_INDENT_WITH_TS``. Without it the wrap
-    continuation of a body line and the start of a new header become
-    visually identical.
+    With the inline layout the line containing the user symbol and body
+    text is also the header line — it must start at col 0 so it is
+    visually distinct from any hanging-indent wrap continuations.
     """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
@@ -170,25 +209,26 @@ async def test_header_line_is_not_indented() -> None:
         conv.render_user_message("payload")
         await pilot.pause()
 
-        # The header line contains the ``>`` user symbol.
-        # With ts on the line is ``HH:MM >`` — starts at column 0 (no leading space).
+        # The inline header+body line contains the ``>`` user symbol.
+        # With ts on the line is ``HH:MM > payload`` — starts at col 0.
         header_idx = _find_first_line_containing(log, ">")
         header = _line_text(log, header_idx)
         assert not header.startswith(" "), (
-            f"header line must NOT be indented (column-0 anchor); got {header!r}"
+            f"header+body inline line must NOT be indented (col-0 anchor); got {header!r}"
         )
 
 
-# ── wrap continuation also indented (the user-visible bug) ───────────────────
+# ── wrap continuation indented (load-bearing invariant) ──────────────────────
 
 
 @pytest.mark.asyncio
 async def test_long_user_line_wrap_continuation_is_indented() -> None:
     """Tier 2b: Wrap continuation of a long body line lands at the indent column.
 
-    This is the user-visible behaviour the agent's UX audit flagged:
-    a long URL or code line that wraps used to put the continuation at
-    column 0, indistinguishable from a new header.
+    The first body line is inline with the header at col 0.  When the
+    body wraps, the continuation must land at ``_BODY_INDENT_WITH_TS``
+    (= col 8) so it nests under the body text, not back at col 0 which
+    would be visually indistinguishable from a new speaker header.
     """
     app = _make_app()
     # Narrow terminal forces a wrap on a moderate-length payload.
@@ -198,23 +238,26 @@ async def test_long_user_line_wrap_continuation_is_indented() -> None:
         log = conv.query_one(RichLog)
 
         conv._show_timestamps = True
-        # ~60 chars — well past the 40-cell terminal so it wraps.
+        # ~60 chars — well past the 40-cell terminal body width so it wraps.
         long_payload = "abcdefghij" * 6
         conv.render_user_message(long_payload)
         await pilot.pause()
 
-        # First body line should be the one containing the start of payload.
+        # The first line containing the payload start is the inline header line.
         first_body_idx = _find_first_line_containing(log, "abcdefghij")
         first_body = _line_text(log, first_body_idx)
-        assert first_body.startswith(" " * _BODY_INDENT_WITH_TS), first_body
+        # First line: inline — starts with HH:MM (no leading space).
+        assert not first_body.startswith(" "), (
+            f"first (inline) line must start at col 0; got {first_body!r}"
+        )
 
-        # If wrap fired, the next line should also lead with the indent.
+        # If wrap fired, the next non-empty line is a continuation at indent.
         if first_body_idx + 1 < len(log.lines):
             cont = _line_text(log, first_body_idx + 1)
             stripped = cont.strip()
-            if stripped:  # non-empty continuation
+            if stripped:  # non-empty continuation line
                 assert cont.startswith(" " * _BODY_INDENT_WITH_TS), (
-                    f"wrap continuation must also be indented; got {cont!r}"
+                    f"wrap continuation must be at col {_BODY_INDENT_WITH_TS}; got {cont!r}"
                 )
 
 
@@ -224,9 +267,9 @@ async def test_long_user_line_wrap_continuation_is_indented() -> None:
 def test_body_indent_constants_have_correct_values() -> None:
     """Tier 2b: ``_BODY_INDENT_WITH_TS`` and ``_BODY_INDENT_NO_TS`` match the spec.
 
-    ts-on layout:  ``HH:MM <sym>`` = 5 (ts) + 1 (space) + 1 (sym) + 1 (space)
-                   → body starts col 8.
-    ts-off layout: ``<sym>`` = 1 (sym) + 1 (space) → body starts col 2.
+    ts-on layout:  ``HH:MM <sym> `` = 5 (ts) + 1 (space) + 1 (sym) + 1 (space)
+                   → body inline starting at col 8; wrap continuation at col 8.
+    ts-off layout: ``<sym> `` = 1 (sym) + 1 (space) → body at col 2.
     """
     assert _BODY_INDENT_WITH_TS == 8, f"ts-on indent should be 8, got {_BODY_INDENT_WITH_TS}"
     assert _BODY_INDENT_NO_TS == 2, f"ts-off indent should be 2, got {_BODY_INDENT_NO_TS}"

--- a/tests/cli/test_conv_inline_header_body.py
+++ b/tests/cli/test_conv_inline_header_body.py
@@ -1,0 +1,295 @@
+"""Tier 2: conv pane inline header + body — #646 Claude Code style.
+
+Before this fix, ``render_user_message`` and ``_render_agent_markdown``
+emitted TWO visible lines per turn:
+  1. ``HH:MM >``          (bare header)
+  2. ``        body text`` (body at col-8 indent)
+
+#646 design intent (Claude Code style) specifies ONE line:
+  ``HH:MM > body text``  — header prefix + body inline
+  ``        wrap cont``  — wrap continuation at col 8 (hanging indent)
+
+These tests verify the new inline layout via the public RichLog surface
+(= ``log.lines`` Strip text) without asserting on private ``_`` state.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.conversation import (
+    _BODY_INDENT_NO_TS,
+    _BODY_INDENT_WITH_TS,
+    _GLYPH_AGENT,
+    _GLYPH_USER,
+    _GROUP_WINDOW_S,
+)
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _log_lines(log: RichLog) -> list[str]:
+    """Return plain-text of every line in the RichLog."""
+    return ["".join(seg.text for seg in strip) for strip in log.lines]
+
+
+def _find_first_line_containing(log: RichLog, needle: str) -> str:
+    """Return the first RichLog line containing ``needle``, or raise."""
+    for strip in log.lines:
+        text = "".join(seg.text for seg in strip)
+        if needle in text:
+            return text
+    raise AssertionError(f"{needle!r} not found in RichLog")
+
+
+# ── Test 1: render_user_message single-line inline layout ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_render_user_message_single_line_inline() -> None:
+    """Tier 2b: render_user_message produces inline header+body on one line.
+
+    #646 fix: instead of a bare ``HH:MM >`` header line followed by a
+    separately indented body line, the output must be ``HH:MM > hello``
+    on a single RichLog line (no leading spaces).
+
+    Verification: find the line containing the body text; assert it
+    also contains the HH:MM timestamp and the user symbol, and does NOT
+    start with spaces.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._show_timestamps = True
+        conv.render_user_message("hello")
+        await pilot.pause()
+
+        line = _find_first_line_containing(log, "hello")
+        # Inline: the body-containing line also carries the header.
+        assert re.search(r"\d{2}:\d{2}", line), (
+            f"inline line must contain HH:MM timestamp; got {line!r}"
+        )
+        assert _GLYPH_USER in line, (
+            f"inline line must contain user symbol {_GLYPH_USER!r}; got {line!r}"
+        )
+        assert not line.startswith(" "), (
+            f"inline line must start at col 0 (no leading spaces); got {line!r}"
+        )
+
+        # Verify the old 2-line layout is gone: no separate header-only line.
+        lines = _log_lines(log)
+        ts_only_lines = [
+            l for l in lines
+            if re.search(r"^\d{2}:\d{2} " + re.escape(_GLYPH_USER) + r"\s*$", l)
+        ]
+        assert not ts_only_lines, (
+            f"old bare header line (HH:MM > alone) must not appear; "
+            f"found: {ts_only_lines}"
+        )
+
+
+# ── Test 2: render_user_message wrap continuation at col 8 ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_render_user_message_wrap_continuation_at_col_8() -> None:
+    """Tier 2b: long user message wraps with continuation at col 8.
+
+    When the body text exceeds the body_width, wrap continuations must
+    land at ``_BODY_INDENT_WITH_TS`` (= col 8) so they nest under the
+    body text, not at col 0 where they would be indistinguishable from
+    a new speaker header.
+
+    We use a narrow terminal (40 cols) to force wrapping on a ~60-char
+    payload and check the line AFTER the inline header+first-body line.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(40, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._show_timestamps = True
+        # Payload long enough to force wrap at 40-col terminal.
+        payload = "abcdefghij" * 6  # 60 chars
+        conv.render_user_message(payload)
+        await pilot.pause()
+
+        lines = _log_lines(log)
+        # Find the inline header+first-body line (col 0, no leading space).
+        first_idx = next(
+            (i for i, l in enumerate(lines) if "abcdefghij" in l and not l.startswith(" ")),
+            None,
+        )
+        assert first_idx is not None, (
+            "inline header+first-body line (no leading space, contains payload) not found"
+        )
+
+        # If wrap fired, the next non-empty line must be the continuation.
+        cont_candidates = [
+            l for l in lines[first_idx + 1:]
+            if l.strip()
+        ]
+        if cont_candidates:
+            cont = cont_candidates[0]
+            # Continuation must start with the indent (spaces), not col 0.
+            assert cont.startswith(" " * _BODY_INDENT_WITH_TS), (
+                f"wrap continuation must start at col {_BODY_INDENT_WITH_TS}; "
+                f"got {cont!r}"
+            )
+
+
+# ── Test 3: _render_agent_markdown inlines first line with symbol ─────────────
+
+
+@pytest.mark.asyncio
+async def test_render_agent_markdown_inlines_first_line() -> None:
+    """Tier 2b: _render_agent_markdown puts first line inline with agent symbol.
+
+    The agent reply ``render_message(kind='agent', text='Hello')`` must
+    produce a line starting with ``HH:MM ⏺`` that also contains ``Hello``
+    — not a bare ``HH:MM ⏺`` header on its own line followed by a
+    separately indented ``Hello``.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._show_timestamps = True
+        msg = OutboxMessage(kind="agent", text="Hello")
+        conv.render_message(msg)
+        await pilot.pause()
+
+        line = _find_first_line_containing(log, "Hello")
+        # The line containing "Hello" must also carry the agent symbol.
+        assert _GLYPH_AGENT in line, (
+            f"agent inline line must contain {_GLYPH_AGENT!r}; got {line!r}"
+        )
+        assert re.search(r"\d{2}:\d{2}", line), (
+            f"agent inline line must contain HH:MM; got {line!r}"
+        )
+        assert not line.startswith(" "), (
+            f"agent inline line must start at col 0; got {line!r}"
+        )
+
+
+# ── Test 4: ts toggle off — header indent col 2, body inline ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_ts_off_inline_header_at_col_0() -> None:
+    """Tier 2b: ts toggle off → header prefix is symbol only, body still inline.
+
+    With ts hidden, header prefix = ``> `` (2 cells at col 0).
+    The inline line must start with the user symbol at col 0 and contain
+    the body text — no separate indented body line at col 2.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._show_timestamps = False
+        conv.render_user_message("body inline ts-off")
+        await pilot.pause()
+
+        line = _find_first_line_containing(log, "body inline ts-off")
+        # ts-off inline: starts with symbol at col 0.
+        assert line.startswith(_GLYPH_USER), (
+            f"ts-off inline line must start with user symbol; got {line!r}"
+        )
+        assert not re.search(r"^\d{2}:\d{2}", line), (
+            f"ts-off inline line must NOT start with HH:MM; got {line!r}"
+        )
+        assert not line.startswith(" "), (
+            f"ts-off inline line must NOT start with spaces; got {line!r}"
+        )
+
+        # Old 2-line layout check: no separate bare-symbol header line.
+        lines = _log_lines(log)
+        bare_header = [
+            l for l in lines
+            if re.match(r"^" + re.escape(_GLYPH_USER) + r"\s*$", l)
+        ]
+        assert not bare_header, (
+            f"old bare symbol header line must not appear; found: {bare_header}"
+        )
+
+
+# ── Test 5: speaker grouping suppresses repeat header, body still inline ──────
+
+
+@pytest.mark.asyncio
+async def test_speaker_grouping_suppresses_header_body_still_inline() -> None:
+    """Tier 2b: grouped consecutive messages suppress the header but body is still written.
+
+    When two user messages arrive within ``_GROUP_WINDOW_S`` seconds, only
+    the first gets a header+body inline line.  The second message must
+    still appear in the log (body written via ``_write_body`` at hanging
+    indent) — it must not be silently dropped.
+
+    This verifies the grouping path in ``_maybe_write_inline_header_body``:
+    ``is_new_turn=False`` → ``_write_body`` branch.
+    """
+    import time as _time
+
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv._show_timestamps = True
+        # Force the same speaker within the grouping window.
+        conv._last_speaker = ""  # ensure first message gets a header.
+        conv.render_user_message("first message")
+        await pilot.pause()
+
+        # Second message from same speaker within window (no time has passed).
+        # _last_speaker is now "you" and _last_speaker_at is current wall time.
+        conv.render_user_message("second message")
+        await pilot.pause()
+
+        lines = _log_lines(log)
+
+        # Both messages must appear in the log.
+        first_lines = [l for l in lines if "first message" in l]
+        second_lines = [l for l in lines if "second message" in l]
+        assert first_lines, "first message must appear in log"
+        assert second_lines, "second message must appear in log"
+
+        # First message: inline with header (no leading space).
+        assert not first_lines[0].startswith(" "), (
+            f"first message (new turn) must be inline at col 0; got {first_lines[0]!r}"
+        )
+
+        # Second message: grouped (header suppressed) → body via _write_body
+        # (leading spaces = hanging indent).
+        assert second_lines[0].startswith(" "), (
+            f"second message (grouped) must be at hanging indent; got {second_lines[0]!r}"
+        )

--- a/tests/cli/test_conv_ts_toggle.py
+++ b/tests/cli/test_conv_ts_toggle.py
@@ -3,16 +3,16 @@
 Pins the behaviour of ``ConversationView.toggle_timestamps()`` and the
 F9 action in ``ReynTUIApp``.  Seven tests cover:
 
-1. Default (ts on): ``render_user_message`` → output contains ``HH:MM``
-   pattern + ``>`` symbol; body at indent 8.
+1. Default (ts on): ``render_user_message`` → inline line contains ``HH:MM``
+   pattern + ``>`` symbol + body text on same line (Claude Code style #646).
 2. After ``toggle_timestamps()``: ts off. ``render_user_message`` → no
-   ``HH:MM`` timestamp in header line; ``>`` at col 0; body at indent 2.
-3. Toggle twice → back to on (indent 8 again).
+   ``HH:MM`` timestamp; ``>`` at col 0 with body inline.
+3. Toggle twice → back to on (same inline layout with ts prefix).
 4. F9 dispatch (``action_toggle_timestamps``) → state flips + flash status
    emitted.
 5. Persistence: ``_show_timestamps=False`` saved to prefs file; a new
    ``ConversationView`` instance loads as False.
-6. Old messages rendered before toggle stay at old indent (= no re-render).
+6. Old messages rendered before toggle stay at old layout (= no re-render).
 7. Day separator still emitted on day boundary regardless of ts state.
 """
 from __future__ import annotations
@@ -66,13 +66,18 @@ def _find_lines_containing(log: RichLog, needle: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# 1. Default (ts on): HH:MM visible, > at col 6, body at indent 8
+# 1. Default (ts on): HH:MM visible, > inline with body on same line (#646)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_ts_on_by_default_header_contains_timestamp():
-    """Tier 2: with timestamps on (default), user header contains HH:MM."""
+    """Tier 2: with timestamps on (default), user header+body inline on same line.
+
+    #646 Claude Code style: ``HH:MM > body_text`` all on one logical line.
+    The line containing the body text must also contain the HH:MM timestamp
+    and the > symbol, and must start at col 0 (no leading spaces).
+    """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -84,29 +89,37 @@ async def test_ts_on_by_default_header_contains_timestamp():
         await pilot.pause()
 
         full = _log_text(log)
-        # HH:MM pattern should appear in the header area.
+        # HH:MM pattern should appear in the log.
         assert re.search(r"\d{2}:\d{2}", full), (
             f"expected HH:MM timestamp in conv log (ts on), got:\n{full}"
         )
         assert _GLYPH_USER in full
 
-        # Body at indent 8.
+        # Inline layout: body text is on the same line as the header (col 0).
         lines = _log_lines(log)
         body_lines = [l for l in lines if "hello ts-on" in l]
         assert body_lines, "body text must appear in log"
-        assert body_lines[0].startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"ts-on body must start at col {_BODY_INDENT_WITH_TS}: {body_lines[0]!r}"
+        # The inline line starts with HH:MM at col 0, not with spaces.
+        assert re.search(r"^\d{2}:\d{2}", body_lines[0]), (
+            f"ts-on inline line must start with HH:MM at col 0: {body_lines[0]!r}"
+        )
+        assert not body_lines[0].startswith(" "), (
+            f"ts-on inline line must NOT start with spaces: {body_lines[0]!r}"
         )
 
 
 # ---------------------------------------------------------------------------
-# 2. After toggle: ts off — no HH:MM, > at col 0, body at indent 2
+# 2. After toggle: ts off — no HH:MM, > inline with body at col 0
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_ts_off_after_toggle_no_timestamp_in_header():
-    """Tier 2: after toggle_timestamps(), user header has no HH:MM prefix."""
+    """Tier 2: after toggle_timestamps(), header+body inline with no HH:MM prefix.
+
+    #646 inline layout with ts off: ``> body text`` on same line at col 0.
+    No HH:MM timestamp prefix, body text not on a separate indented line.
+    """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
@@ -122,28 +135,20 @@ async def test_ts_off_after_toggle_no_timestamp_in_header():
         await pilot.pause()
 
         lines = _log_lines(log)
-        # Find the header line (= the one containing the symbol, not body).
-        symbol_lines = [l for l in lines if _GLYPH_USER in l and "hello ts-off" not in l]
-        # There should be a header line starting with the symbol (col 0).
-        if symbol_lines:
-            hdr = symbol_lines[-1]
-            assert hdr.startswith(_GLYPH_USER), (
-                f"ts-off header must start with symbol at col 0: {hdr!r}"
-            )
-            # Should NOT contain a HH:MM prefix.
-            assert not re.match(r"\d{2}:\d{2}", hdr), (
-                f"ts-off header must not start with HH:MM: {hdr!r}"
-            )
 
-        # Body at indent 2.
+        # Inline layout: the body line also starts with the symbol at col 0.
         body_lines = [l for l in lines if "hello ts-off" in l]
         assert body_lines, "body text must appear in log"
-        assert body_lines[0].startswith(" " * _BODY_INDENT_NO_TS), (
-            f"ts-off body must start at col {_BODY_INDENT_NO_TS}: {body_lines[0]!r}"
+        # ts-off inline: starts with symbol, no HH:MM, no leading spaces.
+        assert body_lines[0].startswith(_GLYPH_USER), (
+            f"ts-off inline line must start with user symbol at col 0: {body_lines[0]!r}"
         )
-        # Body at col 2 must NOT have the wider ts-on indent.
-        assert not body_lines[0].startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"ts-off body must NOT have {_BODY_INDENT_WITH_TS}-col indent: {body_lines[0]!r}"
+        assert not re.match(r"\d{2}:\d{2}", body_lines[0]), (
+            f"ts-off inline line must NOT start with HH:MM: {body_lines[0]!r}"
+        )
+        # Must NOT start with spaces (ts-on indent or ts-off old indent).
+        assert not body_lines[0].startswith(" "), (
+            f"ts-off inline line must NOT start with spaces: {body_lines[0]!r}"
         )
 
 
@@ -166,7 +171,7 @@ async def test_toggle_twice_returns_to_on():
         conv.toggle_timestamps()
         assert conv._show_timestamps is True
 
-        # Body rendered after second toggle uses ts-on indent.
+        # Body rendered after second toggle uses ts-on inline layout.
         log = conv.query_one(RichLog)
         conv.render_user_message("back to on")
         await pilot.pause()
@@ -174,8 +179,12 @@ async def test_toggle_twice_returns_to_on():
         lines = _log_lines(log)
         body_lines = [l for l in lines if "back to on" in l]
         assert body_lines
-        assert body_lines[0].startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"after 2 toggles body must be at ts-on indent: {body_lines[0]!r}"
+        # ts-on inline: starts with HH:MM at col 0 (not with spaces).
+        assert re.search(r"^\d{2}:\d{2}", body_lines[0]), (
+            f"after 2 toggles, ts-on inline line must start with HH:MM: {body_lines[0]!r}"
+        )
+        assert not body_lines[0].startswith(" "), (
+            f"after 2 toggles body must NOT start with spaces: {body_lines[0]!r}"
         )
 
 
@@ -250,13 +259,14 @@ def test_toggle_persists_to_prefs_file(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_old_messages_keep_old_indent_after_toggle():
-    """Tier 2: past messages rendered before the toggle keep their original indent.
+async def test_old_messages_keep_old_layout_after_toggle():
+    """Tier 2: past messages rendered before the toggle keep their original layout.
 
     ConversationView does NOT re-render past RichLog content on toggle —
-    only new writes use the new indent. This test writes a message (ts on,
-    indent 8), toggles, then writes another (ts off, indent 2) and
-    verifies both indents coexist.
+    only new writes use the new layout.  With the #646 inline format:
+      - ts-on message: inline line starts with HH:MM at col 0.
+      - ts-off message: inline line starts with symbol at col 0.
+    Both coexist in the log after a toggle.
     """
     app = _make_app()
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
@@ -264,7 +274,7 @@ async def test_old_messages_keep_old_indent_after_toggle():
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
-        # First message: ts on → indent 8.
+        # First message: ts on → inline with HH:MM prefix.
         conv._show_timestamps = True
         conv._last_speaker = ""  # force new header
         conv.render_user_message("before-toggle")
@@ -285,14 +295,20 @@ async def test_old_messages_keep_old_indent_after_toggle():
         assert before_body, "before-toggle body must be in log"
         assert after_body, "after-toggle body must be in log"
 
-        assert before_body[0].startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"before-toggle body must keep ts-on indent: {before_body[0]!r}"
+        # ts-on inline: starts with HH:MM (no leading space).
+        assert re.search(r"^\d{2}:\d{2}", before_body[0]), (
+            f"before-toggle (ts-on) must start with HH:MM: {before_body[0]!r}"
         )
-        assert after_body[0].startswith(" " * _BODY_INDENT_NO_TS), (
-            f"after-toggle body must use ts-off indent: {after_body[0]!r}"
+        assert not before_body[0].startswith(" "), (
+            f"before-toggle line must NOT start with spaces: {before_body[0]!r}"
         )
-        assert not after_body[0].startswith(" " * _BODY_INDENT_WITH_TS), (
-            f"after-toggle body must NOT have ts-on indent: {after_body[0]!r}"
+
+        # ts-off inline: starts with symbol at col 0 (no HH:MM, no spaces).
+        assert after_body[0].startswith(_GLYPH_USER), (
+            f"after-toggle (ts-off) must start with user symbol: {after_body[0]!r}"
+        )
+        assert not after_body[0].startswith(" "), (
+            f"after-toggle line must NOT start with spaces: {after_body[0]!r}"
         )
 
 


### PR DESCRIPTION
**[tui-coder]** — conv pane inline body fix (Claude Code style)

## Summary
- `render_user_message`: header + body on same line (`HH:MM > message text`), col 8 hanging indent for wrap continuations
- `_render_agent_markdown`: header + first line inline (`HH:MM ⏺ first line`), remaining Markdown body at col 8 indent
- `_check_new_turn` extracted from `_maybe_write_header` to share grouping + anchor logic between standalone-header and inline-header paths
- `_build_header_prefix` module helper + `_maybe_write_inline_header_body` method added

## Why
#646 mockup specified inline body; implementation rendered 2-line (bare `HH:MM >` then body on next line at col 8). Live tmux dogfood (2026-05-24) confirmed the discrepancy.

User: "conv pane の記号とメッセージの行がずれてるところに気づかなかった？"

Before (buggy):
```
17:34 >
        hello, please answer
```

After (correct):
```
17:34 > hello, please answer
        wrap continuation at col 8
```

## Test plan
- [x] `tests/cli/test_conv_inline_header_body.py` — 5 new Tier-2b tests covering: single-line inline, wrap continuation at col 8, agent markdown inline, ts-off inline, speaker grouping body-only path
- [x] `tests/cli/test_body_hanging_indent.py` — updated for inline layout (7 tests pass)
- [x] `tests/cli/test_conv_ts_toggle.py` — updated for inline layout (7 tests pass)
- [x] All 872 `tests/cli/` tests pass (2m29s)
- [x] `ruff check` clean on all changed files
- [x] `python scripts/test_tier_audit.py tests/cli/test_conv_inline_header_body.py` → 0 errors
- [x] Manual: live layout confirmed inline via test assertions (`17:44 > hello world` on one line)
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)