### PR TITLE
fix(tui): empty-hint panel tabs — add missing pending tab (discoverability)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -474,7 +474,7 @@ class ConversationView(Widget):
             # clean lines per stanza on any terminal we expect.
             "  Type [bold]/[/] for commands  ·  [bold]/help[/] for a guide\n"
             "  [bold]Ctrl+B[/] side panel ·  [bold]Ctrl+L[/] clear  ·  [bold]Ctrl+P/N[/] turn\n"
-            "  [dim]panel tabs: keys · events · agents · memory · cost · docs[/]",
+            "  [dim]panel tabs: keys · events · agents · memory · cost · docs · pending[/]",
             id="empty-hint",
             markup=True,
         )

--- a/tests/cli/test_empty_hint_discoverability.py
+++ b/tests/cli/test_empty_hint_discoverability.py
@@ -1,6 +1,6 @@
 """Tier 2: empty-state hint surfaces the side-panel tabs by name.
 
-The right panel (Keys / Events / Agents / Memory / Cost / Docs) is
+The right panel (Keys / Events / Agents / Memory / Cost / Docs / Pending) is
 ``display: none`` by default. Before this fix, the only on-screen cue
 was the footer's terse ``Ctrl+B panel`` — a new user with no prior
 context could not tell what the panel even contains, so the entire
@@ -57,8 +57,10 @@ async def test_empty_hint_names_side_panel_and_tabs() -> None:
         assert "side panel" in text.lower(), (
             f"hint must say 'side panel' for discoverability; got: {text!r}"
         )
-        # Tabs — assert on at least three to defend against accidental dropouts
-        for tab in ("keys", "events", "docs"):
+        # Tabs — assert on all seven to defend against accidental dropouts.
+        # ``pending`` was added in fix/tui-empty-hint-pending-tab after dogfood
+        # 2026-05-24 revealed it was the only tab not enumerated in the hint.
+        for tab in ("keys", "events", "agents", "memory", "cost", "docs", "pending"):
             assert tab in text.lower(), f"tab {tab!r} missing from hint: {text!r}"
 
 


### PR DESCRIPTION
**[tui-coder]** — fix: empty-hint panel tabs line omitted `pending`

## Summary

- The conv-pane empty-hint enumerated 6 of 7 right-panel tabs, leaving out `pending`
- Users with queued interventions had no discoverable path to the Pending tab from the empty pane
- One-char addition (`· pending`) to the `[dim]panel tabs: …[/]` line in `conversation.py`
- Updated `test_empty_hint_discoverability.py` to assert all 7 tabs (was asserting only 3)

## Tier rule self-check

- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 errors ✓

## Test plan

- [x] `pytest tests/cli/test_empty_hint_discoverability.py -x` — 2 passed ✓
- [x] `ruff check src/reyn/chat/tui/widgets/conversation.py` — All checks passed ✓
- [x] `python scripts/test_tier_audit.py tests/cli/test_empty_hint_discoverability.py` — 2 OK, 0 errors ✓
- [x] Line width check: visible text `  panel tabs: keys · events · agents · memory · cost · docs · pending` = 69 chars (fits 80-col) ✓
- [x] (skipped — headless TUI visual) Live render in tmux: dogfood session 2026-05-24 confirmed 6-tab bug; fix verified by test

🤖 Generated with [Claude Code](https://claude.com/claude-code)