### PR TITLE
fix(eval): postprocessor provides string fallbacks for output_schema required fields (closes NF-W2-S5)

### DIFF
--- a/src/reyn/stdlib/skills/eval/postprocessor.py
+++ b/src/reyn/stdlib/skills/eval/postprocessor.py
@@ -33,6 +33,24 @@ Edge cases:
 """
 
 
+def _ensure_required_strings(data: dict) -> None:
+    """Fill in fallback strings for output_schema-required string fields.
+
+    The python step's ``output_schema`` requires ``weakest_phase`` and
+    ``summary`` as strings. The LLM may set them to ``None`` (or omit
+    them when ``run_status != "finished"``); without a fallback the
+    schema validation fails with ``"None is not of type 'string'"``
+    and the entire eval run is marked failed.
+
+    Discovered B54 NF-W2-S5 (2026-05-24) — eval skill 5 runs all
+    failed at postprocessor validation because the LLM set
+    ``weakest_phase: None`` on failed-target runs.
+    """
+    for field, fallback in (("weakest_phase", "(none)"), ("summary", "(no summary)")):
+        if not isinstance(data.get(field), str):
+            data[field] = fallback
+
+
 def compute_eval_score(artifact: dict) -> dict:
     """Return a new ``data`` dict with deterministic scoring fields merged in.
 
@@ -50,6 +68,7 @@ def compute_eval_score(artifact: dict) -> dict:
         data["overall_score"] = 0.0
         data["passed_criteria"] = 0
         data["total_criteria"] = 0
+        _ensure_required_strings(data)
         return data
 
     # Required iff `required` is True or absent.
@@ -68,6 +87,7 @@ def compute_eval_score(artifact: dict) -> dict:
         data["overall_score"] = 1.0
         data["passed_criteria"] = 0
         data["total_criteria"] = 0
+        _ensure_required_strings(data)
         return data
 
     overall = round(passed_count / total, 2)
@@ -81,4 +101,5 @@ def compute_eval_score(artifact: dict) -> dict:
     # subsumed here (all_required_met implies overall_score == 1.0), but we
     # keep both clauses to make the intent explicit.
     data["passed"] = all_required_met and overall >= 0.6
+    _ensure_required_strings(data)
     return data

--- a/tests/test_eval_postprocessor.py
+++ b/tests/test_eval_postprocessor.py
@@ -192,3 +192,51 @@ def test_preserves_llm_authored_fields() -> None:
     # remain visible (no whitelist filtering in the function).
     assert out["run_status"] == "finished"
     assert "criteria_results" in out
+
+
+# ── Required-string fallbacks (B54 NF-W2-S5 regression) ──────────────────────
+
+
+def test_failed_target_provides_required_string_fallbacks() -> None:
+    """Tier 2: when run_status != "finished" AND LLM omitted the required
+    string fields, the function fills in fallbacks so output_schema
+    validation (= weakest_phase / summary required as type=string) does
+    not fail downstream with "None is not of type 'string'".
+
+    B54 NF-W2-S5 regression — dogfood observed 5/5 eval runs failing at
+    postprocessor schema validation because the LLM set weakest_phase=None
+    on failed-target runs.
+    """
+    art = {"data": {"run_status": "failed"}}  # no weakest_phase / summary
+    out = compute_eval_score(art)
+    assert isinstance(out["weakest_phase"], str) and out["weakest_phase"]
+    assert isinstance(out["summary"], str) and out["summary"]
+
+
+def test_explicit_none_strings_replaced_with_fallback() -> None:
+    """Tier 2: LLM explicitly sets weakest_phase=None / summary=None →
+    fallback string applied. Otherwise the python step's output_schema
+    (required: [..., weakest_phase, summary], both type=string) rejects
+    the dict and the eval run is marked failed at the postprocessor
+    boundary.
+    """
+    art = _wrap(
+        [_crit(met=True, required=True)],
+        weakest_phase=None,
+        summary=None,
+    )
+    out = compute_eval_score(art)
+    assert isinstance(out["weakest_phase"], str) and out["weakest_phase"]
+    assert isinstance(out["summary"], str) and out["summary"]
+
+
+def test_vacuous_pass_provides_required_string_fallbacks() -> None:
+    """Tier 2: vacuous-pass branch (no required criteria) also provides
+    string fallbacks — without the fix, LLMs that omitted these fields
+    when the spec had no required criteria would also hit the schema
+    failure.
+    """
+    art = {"data": {"run_status": "finished", "criteria_results": []}}
+    out = compute_eval_score(art)
+    assert isinstance(out["weakest_phase"], str) and out["weakest_phase"]
+    assert isinstance(out["summary"], str) and out["summary"]


### PR DESCRIPTION
**[dogfood-coder]** — B54 NF-W2-S5 [HIGH] fix.

## Background
B54 dogfood observed **5/5 eval runs failing** at postprocessor schema validation with `"None is not of type 'string'"`. Worker error excerpt:
> Postprocessor step[0] (python): Phase '__post__' preprocessor step[0] python ./postprocessor.py:compute_eval_score return value did not match output_schema: None is not of type 'string'

## Root cause
`compute_eval_score()` modifies the 4 deterministic scoring fields (`passed_criteria` / `total_criteria` / `overall_score` / `passed`) but relied on the LLM to set the required string fields (`weakest_phase` / `summary`). The python step's `output_schema` requires both as `type: string`. When the LLM:
- Set them to `None` explicitly, OR
- Omitted them on `run_status != "finished"` branches (= target skill failed paths)

→ schema validation failed → entire eval run marked failed.

## Fix
Add `_ensure_required_strings()` helper called on all 3 return paths (failed-target / vacuous-pass / normal). Preserves LLM-set valid strings; falls back to `"(none)"` / `"(no summary)"` otherwise.

## Tests (3 new Tier 2 regression)
- `test_failed_target_provides_required_string_fallbacks`
- `test_explicit_none_strings_replaced_with_fallback`
- `test_vacuous_pass_provides_required_string_fallbacks`

## Verify
- 13/13 tests pass (10 existing + 3 new)
- Tier audit: 0 errors
- F541 (no f-string without placeholder): clean

## Test plan
- [x] pytest tests/test_eval_postprocessor.py (13/13 pass)
- [x] inline unit-style verify across 4 cases (all paths return valid string-typed weakest_phase + summary)
- [x] Tier rule self-check: docstring ✓ (Tier 2: first-line format) / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)