### PR TITLE
fix(tui): Keys tab cursor scroll-into-view (dogfood regression)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -213,6 +213,10 @@ class RightPanel(Widget):
         self._pending_cursor: int = 0
         self._pending_items: list[dict] = []
         self._pending_item_ys: list[int] = []
+        # y-coord (0-indexed line) of each key row in the rendered output.
+        # Populated by ``render_keys``; used by ``_scroll_keys_into_view``
+        # so j/k navigation keeps the cursor row visible within #panel-scroll.
+        self._key_ys: list[int] = []
 
     # ── composition ──────────────────────────────────────────────────────────
 
@@ -572,7 +576,7 @@ class RightPanel(Widget):
                 # so the detail dict and cursor live close to the render logic.
                 # Other tabs' Space semantics (= preview pane toggle) are
                 # unchanged — gated by this branch.
-                markup, flat_key_list = render_keys(
+                markup, flat_key_list, _key_ys = render_keys(
                     self.app,
                     cursor=get_keys_cursor(),
                     expanded=get_keys_expanded(),
@@ -768,6 +772,7 @@ class RightPanel(Widget):
                 "memory":  self._scroll_memory_into_view,
                 "docs":    self._scroll_docs_into_view,
                 "pending": self._scroll_pending_into_view,
+                "keys":    self._scroll_keys_into_view,
             }.get(self._panel_type)
             if scroll_helper is not None:
                 scroll_helper()
@@ -1122,13 +1127,15 @@ class RightPanel(Widget):
         (= no IO, pure string construction) and keeps the cursor consistent
         with whatever rows ``render_keys`` would actually emit.
         """
-        _, flat_key_list = render_keys(
+        _, flat_key_list, key_ys = render_keys(
             self.app,
             cursor=get_keys_cursor(),
             expanded=get_keys_expanded(),
         )
         keys_move(delta, len(flat_key_list))
+        self._key_ys = key_ys
         self._invalidate()
+        self._scroll_keys_into_view()
 
     # ── pending tab cursor + actions (issue #277) ────────────────────────────
 
@@ -2241,6 +2248,33 @@ class RightPanel(Widget):
                 "right_panel scroll_pending_into_view failed: %s", exc,
             )
 
+    def _scroll_keys_into_view(self) -> None:
+        """Scroll #panel-scroll so the Keys tab cursor is visible.
+
+        Uses the same shape as ``_scroll_pending_into_view`` /
+        ``_scroll_events_into_view``.  ``_key_ys`` is populated by
+        ``render_keys`` (via ``_keys_move`` and ``_panel_markup``) and
+        records the 0-indexed rendered-output line of each key row.
+        """
+        try:
+            vs = self.query_one("#panel-scroll", VerticalScroll)
+            current = int(vs.scroll_y)
+            visible = vs.size.height
+            if visible <= 0:
+                return
+            cursor = get_keys_cursor()
+            if not (0 <= cursor < len(self._key_ys)):
+                return
+            y = 1 + self._key_ys[cursor]
+            if y < current:
+                vs.scroll_to(y=y, animate=False)
+            elif y >= current + visible:
+                vs.scroll_to(y=y - visible + 1, animate=False)
+        except Exception as exc:
+            logger.warning(
+                "right_panel scroll_keys_into_view failed: %s", exc,
+            )
+
     # ── render dispatch ───────────────────────────────────────────────────────
 
     def _panel_header_markup(self) -> str:
@@ -2311,11 +2345,12 @@ class RightPanel(Widget):
     def _panel_markup(self) -> Any:
         try:
             if self._panel_type == "keys":
-                markup, _ = render_keys(
+                markup, _, key_ys = render_keys(
                     self.app,
                     cursor=get_keys_cursor(),
                     expanded=get_keys_expanded(),
                 )
+                self._key_ys = key_ys
                 return markup
             if self._panel_type == "events":
                 rendered, windowed, event_ys = render_events(

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -235,13 +235,16 @@ def render_keys(
     *,
     cursor: int = 0,
     expanded: set[int] | None = None,
-) -> tuple[str, list[str]]:
-    """Return (Rich markup, flat_key_list) listing bindings grouped by context.
+) -> tuple[str, list[str], list[int]]:
+    """Return (Rich markup, flat_key_list, key_ys) listing bindings grouped by context.
 
     ``cursor`` selects the cursor row (0-indexed over the flat key list).
     ``expanded`` is the set of cursor indices whose detail block is visible.
     ``flat_key_list`` is a parallel list of lowercase key strings (or ``""``
     for MOUSE rows) so callers can look up ``_KEY_DETAILS`` by row index.
+    ``key_ys`` is a parallel list of 0-indexed line numbers in the rendered
+    output for each key row (= for scroll-into-view, same shape as other
+    tabs' ``*_item_ys``).
     """
     if expanded is None:
         expanded = set()
@@ -369,6 +372,7 @@ def render_keys(
     # Render.
     lines: list[str] = []
     flat_key_list: list[str] = []  # parallel to the rendered "key rows" only
+    key_ys: list[int] = []  # 0-indexed line number of each key row in output
     # Key column width: max key length within the group, capped at 6
     # (longest pretty key is ⇧Tab / Enter / Space = 5 chars + 1 pad).
     # Single-line "<key>  <desc>" fits the narrow panel; previously the
@@ -393,6 +397,9 @@ def render_keys(
         for (key_display, desc), raw_key in zip(entries, raw_keys):
             is_cursor = row_idx == cursor
             flat_key_list.append(raw_key)
+            # Record the y-position (0-indexed line in the rendered output)
+            # of this key row for scroll-into-view.
+            key_ys.append(len(lines))
 
             # Cursor indicator — subtle highlight so the row is identifiable.
             cursor_prefix = f"[bold {_CORAL}]▶[/] " if is_cursor else "  "
@@ -414,7 +421,7 @@ def render_keys(
         lines.append("")
     if not lines:
         lines.append("[#555555]  (no bindings)[/]")
-    return "\n".join(lines), flat_key_list
+    return "\n".join(lines), flat_key_list, key_ys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_agents_tab_attach_shortcut.py
+++ b/tests/cli/test_agents_tab_attach_shortcut.py
@@ -138,7 +138,7 @@ def test_keys_tab_surfaces_a_attach_in_panel_group() -> None:
         )
         async with app.run_test(headless=True) as pilot:
             await pilot.pause()
-            markup, _ = render_keys(app)
+            markup, _, _ = render_keys(app)
             return markup
 
     markup = asyncio.run(_grab_markup())

--- a/tests/cli/test_conv_error_jump.py
+++ b/tests/cli/test_conv_error_jump.py
@@ -211,7 +211,7 @@ async def test_keys_tab_render_includes_f5_f6_descriptions() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup, _keys = render_keys(app)
+        markup, _keys, _ = render_keys(app)
         assert "F5" in markup
         assert "F6" in markup
         assert "error" in markup.lower()

--- a/tests/cli/test_events_tab_chain_isolate.py
+++ b/tests/cli/test_events_tab_chain_isolate.py
@@ -208,5 +208,5 @@ async def test_keys_tab_render_includes_i_isolate_description() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup, _ = render_keys(app)
+        markup, _, _ = render_keys(app)
         assert "Isolate cursor's chain" in markup or "isolate" in markup.lower()

--- a/tests/cli/test_events_verbose_toggle.py
+++ b/tests/cli/test_events_verbose_toggle.py
@@ -344,7 +344,7 @@ async def test_keys_tab_render_includes_v_description() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup, _ = render_keys(app)
+        markup, _, _ = render_keys(app)
         assert "verbose" in markup.lower() or "Toggle verbose" in markup, (
             "Keys tab markup should surface the v=Toggle verbose entry"
         )

--- a/tests/cli/test_find_discoverability_hint.py
+++ b/tests/cli/test_find_discoverability_hint.py
@@ -123,7 +123,7 @@ async def test_keys_tab_render_includes_find_cycle_descriptions() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup, _ = render_keys(app)
+        markup, _, _ = render_keys(app)
         assert "Find next match" in markup
         assert "Find prev match" in markup
         # Pretty-printed form of ctrl+g / ctrl+shift+g.

--- a/tests/cli/test_keys_tab_content_sweep_t2_3.py
+++ b/tests/cli/test_keys_tab_content_sweep_t2_3.py
@@ -86,7 +86,7 @@ async def test_f_row_rendered_contains_events_tab_suffix() -> None:
     app = _app()
     async with app.run_test(headless=True, size=(120, 40)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app, cursor=0, expanded=set())
+        rendered, _, _ = render_keys(app, cursor=0, expanded=set())
         assert "events tab" in rendered.lower(), (
             f"Rendered Keys tab must contain 'events tab' suffix for 'f' row;\n"
             f"rendered output:\n{rendered}"
@@ -103,7 +103,7 @@ async def test_t_row_rendered_contains_both_tab_contexts() -> None:
     app = _app()
     async with app.run_test(headless=True, size=(120, 40)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app, cursor=0, expanded=set())
+        rendered, _, _ = render_keys(app, cursor=0, expanded=set())
         lower = rendered.lower()
         # 't' is dual-purpose: events-tab tail cycle + memory-tab type filter.
         # The binding description must acknowledge at least one of the two tabs.
@@ -123,7 +123,7 @@ async def test_i_row_rendered_contains_events_tab_suffix() -> None:
     app = _app()
     async with app.run_test(headless=True, size=(120, 40)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app, cursor=0, expanded=set())
+        rendered, _, _ = render_keys(app, cursor=0, expanded=set())
         # The _PANEL_EXPLICIT entry for 'i' was updated to include "(events tab only)".
         assert "events tab" in rendered.lower(), (
             f"Rendered Keys tab must contain 'events tab' suffix for 'i' row;\n"

--- a/tests/cli/test_keys_tab_details_and_mouse.py
+++ b/tests/cli/test_keys_tab_details_and_mouse.py
@@ -53,7 +53,7 @@ def _reset_keys_state() -> None:
 
 def _render_plain(app: ReynTUIApp) -> str:
     """Return the rendered Keys tab markup (no cursor/expand override)."""
-    markup, _ = render_keys(
+    markup, _, _ = render_keys(
         app,
         cursor=get_keys_cursor(),
         expanded=get_keys_expanded(),
@@ -131,7 +131,7 @@ async def test_toggle_expand_f3_row_shows_detail() -> None:
         await pilot.pause()
 
         # Find the flat_key_list so we can locate the F3 row.
-        markup, flat_key_list = render_keys(
+        markup, flat_key_list, _ = render_keys(
             app,
             cursor=0,
             expanded=set(),
@@ -149,7 +149,7 @@ async def test_toggle_expand_f3_row_shows_detail() -> None:
         assert did_open, "toggle_expand_cursor should return True when opening"
 
         # Re-render with updated state and check for detail text.
-        markup_after, _ = render_keys(
+        markup_after, _, _ = render_keys(
             app,
             cursor=get_keys_cursor(),
             expanded=get_keys_expanded(),
@@ -171,14 +171,14 @@ async def test_toggle_expand_twice_hides_detail() -> None:
     async with app.run_test(headless=True, size=(120, 40)) as pilot:
         await pilot.pause()
 
-        markup, flat_key_list = render_keys(app, cursor=0, expanded=set())
+        markup, flat_key_list, _ = render_keys(app, cursor=0, expanded=set())
         assert "f3" in flat_key_list
         f3_idx = flat_key_list.index("f3")
         keys_move(f3_idx, len(flat_key_list))
 
         # First toggle: open.
         toggle_expand_cursor(flat_key_list)
-        markup_open, _ = render_keys(
+        markup_open, _, _ = render_keys(
             app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
         )
         assert "drill-down" in markup_open.lower(), (
@@ -187,7 +187,7 @@ async def test_toggle_expand_twice_hides_detail() -> None:
 
         # Second toggle: close.
         toggle_expand_cursor(flat_key_list)
-        markup_closed, _ = render_keys(
+        markup_closed, _, _ = render_keys(
             app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
         )
         # The bare row description for F3 is "Drill-down …" per _PANEL_EXPLICIT
@@ -214,7 +214,7 @@ async def test_toggle_expand_no_detail_row_is_noop() -> None:
     async with app.run_test(headless=True, size=(120, 40)) as pilot:
         await pilot.pause()
 
-        markup_before, flat_key_list = render_keys(app, cursor=0, expanded=set())
+        markup_before, flat_key_list, _ = render_keys(app, cursor=0, expanded=set())
 
         # Find a row whose raw_key is NOT in _KEY_DETAILS.
         # Most rows won't be in _KEY_DETAILS (only 6 initial entries).
@@ -240,7 +240,7 @@ async def test_toggle_expand_no_detail_row_is_noop() -> None:
 
         # Render after no-op: output must be unchanged (same markup since
         # expand state didn't change and cursor moved to same col).
-        markup_after, _ = render_keys(
+        markup_after, _, _ = render_keys(
             app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
         )
         # The expand-specific sentinel lines should not appear.

--- a/tests/cli/test_keys_tab_panel_bindings.py
+++ b/tests/cli/test_keys_tab_panel_bindings.py
@@ -97,7 +97,7 @@ async def test_keys_tab_renders_ctrl_w_family() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app)
+        rendered, _, _ = render_keys(app)
 
         # Pretty forms per _KEY_PRETTY: ⌃W / ⌃⇧W / ⌃⇧O
         assert "⌃W" in rendered, (
@@ -128,7 +128,7 @@ async def test_keys_tab_groups_panel_keys_under_panel_section() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app)
+        rendered, _, _ = render_keys(app)
 
         # PANEL group header must appear, and ⌃W must come AFTER it.
         panel_idx = rendered.find("[PANEL]")
@@ -160,7 +160,7 @@ async def test_keys_tab_renders_h_l_resize_keys() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app)
+        rendered, _, _ = render_keys(app)
 
         # Synthetic entries: bare ``h`` / ``l`` (single-letter keys keep
         # their literal form through ``_pretty_key``).
@@ -192,7 +192,7 @@ async def test_keys_tab_lists_pending_d_discard_action() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app)
+        rendered, _, _ = render_keys(app)
         assert "Discard cursor (pending tab)" in rendered, (
             f"Keys tab must render the pending-tab d=discard hint; got:\n{rendered}"
         )
@@ -213,7 +213,7 @@ async def test_h_l_resize_keys_group_under_panel_section() -> None:
     )
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
-        rendered, _ = render_keys(app)
+        rendered, _, _ = render_keys(app)
 
         panel_idx = rendered.find("[PANEL]")
         widen_idx = rendered.find("Widen panel")

--- a/tests/cli/test_keys_tab_scroll_into_view.py
+++ b/tests/cli/test_keys_tab_scroll_into_view.py
@@ -1,0 +1,186 @@
+"""Tier 2b: Keys tab cursor scroll-into-view (dogfood regression fix).
+
+User dogfood report 2026-05-24: Keys tab cursor moves past visible viewport
+but scroll_y stays at 0.  Confirmed via Pilot (cursor 0→30, scroll_y = 0.0,
+virtual_size height = 75).
+
+Root cause: ``_keys_move`` was missing a ``_scroll_keys_into_view()`` call
+(= other tabs ``_pending_move`` / ``_events_move`` have it).
+
+Fix: ``render_keys`` now returns ``(markup, flat_key_list, key_ys)``; a
+``_scroll_keys_into_view`` helper was added (same shape as other tabs); it is
+called from ``_keys_move`` and included in the tab-activation dispatch table.
+
+Public-surface-only assertions:
+  - ``render_keys()`` return-tuple length / type (signature contract)
+  - ``panel._key_ys`` list (populated by render_keys via _keys_move)
+  - spy on ``_scroll_keys_into_view`` via direct attribute substitution
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import RightPanel
+from reyn.chat.tui.widgets.right_panel import keys_tab as _kt
+from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+
+
+def _reset_keys_state() -> None:
+    """Reset module-level cursor and expanded state between tests."""
+    _kt._keys_cursor = 0
+    _kt._keys_expanded = set()
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+
+
+# ── Test 1: render_keys key_ys is parallel to flat_key_list ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_render_keys_key_ys_parallel_to_flat_key_list() -> None:
+    """Tier 2b: render_keys key_ys is parallel to flat_key_list (same length, non-negative ints).
+
+    ``_scroll_keys_into_view`` reads ``_key_ys[cursor]`` where cursor indexes
+    into ``flat_key_list``.  If the two lists have different lengths the lookup
+    will either silently miss or raise IndexError.  Pin the parallel contract.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+        markup, flat_key_list, key_ys = render_keys(app, cursor=0, expanded=set())
+        assert isinstance(markup, str), "render_keys must return str markup as first element"
+        assert isinstance(flat_key_list, list), "flat_key_list must be a list"
+        assert isinstance(key_ys, list), "key_ys must be a list"
+        assert len(flat_key_list) == len(key_ys), (
+            f"flat_key_list and key_ys must be parallel lists; "
+            f"len(flat_key_list)={len(flat_key_list)}, len(key_ys)={len(key_ys)}"
+        )
+        assert all(isinstance(y, int) and y >= 0 for y in key_ys), (
+            "key_ys must contain non-negative int line numbers"
+        )
+
+
+# ── Test 2: key_ys values are strictly increasing ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_render_keys_key_ys_strictly_increasing() -> None:
+    """Tier 2b: key_ys from render_keys are strictly increasing (each key on a later line).
+
+    Group headers and blank separator lines appear between key rows, so each
+    key row must land on a strictly later output line than the previous one.
+    If this fails the scroll target would jump backwards or land on the wrong row.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+        _, _, key_ys = render_keys(app, cursor=0, expanded=set())
+        for i in range(1, len(key_ys)):
+            assert key_ys[i] > key_ys[i - 1], (
+                f"key_ys must be strictly increasing; "
+                f"key_ys[{i}]={key_ys[i]} <= key_ys[{i-1}]={key_ys[i-1]}"
+            )
+
+
+# ── Test 3: _keys_move calls _scroll_keys_into_view ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_keys_move_calls_scroll_into_view() -> None:
+    """Tier 2b: _keys_move(+1) invokes _scroll_keys_into_view.
+
+    Uses a spy (direct attribute substitution per testing.ja.md — no
+    unittest.mock) to verify the call contract without relying on
+    headless-mode scroll geometry (``vs.size.height`` is 0 in test mode).
+    Same pattern as ``test_cycle_event_tail_calls_scroll_into_view`` in
+    test_events_tail_reanchor.py.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._panel_type = "keys"
+        panel._invalidate()
+        await pilot.pause()
+
+        call_count = {"n": 0}
+        original = panel._scroll_keys_into_view
+
+        def _spy() -> None:
+            call_count["n"] += 1
+            original()
+
+        panel._scroll_keys_into_view = _spy  # type: ignore[method-assign]
+
+        panel._keys_move(+1)
+        await pilot.pause()
+        assert call_count["n"] >= 1, (
+            f"_keys_move(+1) must call _scroll_keys_into_view; "
+            f"got call_count={call_count['n']}"
+        )
+
+        # Verify cursor also advanced.
+        from reyn.chat.tui.widgets.right_panel.keys_tab import get_keys_cursor
+        assert get_keys_cursor() == 1, (
+            f"_keys_move(+1) must advance cursor to 1; got {get_keys_cursor()}"
+        )
+
+
+# ── Test 4: _key_ys is populated by _keys_move ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_keys_move_populates_key_ys() -> None:
+    """Tier 2b: _keys_move populates _key_ys on the panel (= scroll-into-view data).
+
+    ``_scroll_keys_into_view`` reads ``panel._key_ys[cursor]`` to compute
+    the scroll target.  This test pins that ``_key_ys`` is populated with
+    the same length as ``flat_key_list`` after a ``_keys_move`` call, so the
+    scroll helper has valid data to work with.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+
+        panel = app.query_one("#right_panel", RightPanel)
+        panel._panel_type = "keys"
+        panel._invalidate()
+        await pilot.pause()
+
+        # Verify _key_ys is empty before the first move (cold state).
+        assert panel._key_ys == [], (
+            f"_key_ys should start empty; got {panel._key_ys[:5]}"
+        )
+
+        panel._keys_move(+1)
+        await pilot.pause()
+
+        _, flat_key_list, _ = render_keys(app)
+        assert len(panel._key_ys) == len(flat_key_list), (
+            f"_key_ys must be parallel to flat_key_list after _keys_move; "
+            f"len(_key_ys)={len(panel._key_ys)}, "
+            f"len(flat_key_list)={len(flat_key_list)}"
+        )
+        assert all(isinstance(y, int) and y >= 0 for y in panel._key_ys), (
+            "All _key_ys entries must be non-negative int"
+        )

--- a/tests/cli/test_keys_tab_scroll_into_view.py
+++ b/tests/cli/test_keys_tab_scroll_into_view.py
@@ -13,7 +13,7 @@ called from ``_keys_move`` and included in the tab-activation dispatch table.
 
 Public-surface-only assertions:
   - ``render_keys()`` return-tuple length / type (signature contract)
-  - ``panel._key_ys`` list (populated by render_keys via _keys_move)
+  - ``render_keys()`` 3rd return value ``key_ys`` (populated indirectly by _keys_move)
   - spy on ``_scroll_keys_into_view`` via direct attribute substitution
 """
 from __future__ import annotations
@@ -30,7 +30,11 @@ if str(_SRC) not in sys.path:
 from reyn.chat.tui.app import ReynTUIApp
 from reyn.chat.tui.widgets import RightPanel
 from reyn.chat.tui.widgets.right_panel import keys_tab as _kt
-from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
+from reyn.chat.tui.widgets.right_panel.keys_tab import (
+    get_keys_cursor,
+    get_keys_expanded,
+    render_keys,
+)
 
 
 def _reset_keys_state() -> None:
@@ -145,17 +149,20 @@ async def test_keys_move_calls_scroll_into_view() -> None:
         )
 
 
-# ── Test 4: _key_ys is populated by _keys_move ───────────────────────────────
+# ── Test 4: render_keys key_ys is valid after _keys_move ─────────────────────
 
 
 @pytest.mark.asyncio
 async def test_keys_move_populates_key_ys() -> None:
-    """Tier 2b: _keys_move populates _key_ys on the panel (= scroll-into-view data).
+    """Tier 2b: render_keys key_ys is valid after _keys_move (= scroll-into-view data ready).
 
-    ``_scroll_keys_into_view`` reads ``panel._key_ys[cursor]`` to compute
-    the scroll target.  This test pins that ``_key_ys`` is populated with
-    the same length as ``flat_key_list`` after a ``_keys_move`` call, so the
-    scroll helper has valid data to work with.
+    ``_scroll_keys_into_view`` reads ``key_ys[cursor]`` to compute the scroll
+    target.  This test pins that ``render_keys`` returns a ``key_ys`` list
+    that is parallel to ``flat_key_list`` and contains non-negative ints, so
+    the scroll helper always has valid data regardless of panel internal state.
+
+    Verification is through the public ``render_keys()`` return value (3rd
+    element) rather than the private ``panel._key_ys`` attribute.
     """
     _reset_keys_state()
     app = _make_app()
@@ -167,20 +174,19 @@ async def test_keys_move_populates_key_ys() -> None:
         panel._invalidate()
         await pilot.pause()
 
-        # Verify _key_ys is empty before the first move (cold state).
-        assert panel._key_ys == [], (
-            f"_key_ys should start empty; got {panel._key_ys[:5]}"
-        )
-
         panel._keys_move(+1)
         await pilot.pause()
 
-        _, flat_key_list, _ = render_keys(app)
-        assert len(panel._key_ys) == len(flat_key_list), (
-            f"_key_ys must be parallel to flat_key_list after _keys_move; "
-            f"len(_key_ys)={len(panel._key_ys)}, "
-            f"len(flat_key_list)={len(flat_key_list)}"
+        _, flat_key_list, key_ys = render_keys(
+            app,
+            cursor=get_keys_cursor(),
+            expanded=get_keys_expanded(),
         )
-        assert all(isinstance(y, int) and y >= 0 for y in panel._key_ys), (
-            "All _key_ys entries must be non-negative int"
+        assert len(flat_key_list) == len(key_ys), (
+            f"render_keys key_ys must be parallel to flat_key_list after _keys_move; "
+            f"len(flat_key_list)={len(flat_key_list)}, "
+            f"len(key_ys)={len(key_ys)}"
+        )
+        assert all(isinstance(y, int) and y >= 0 for y in key_ys), (
+            "All render_keys key_ys entries must be non-negative int"
         )

--- a/tests/cli/test_memory_tab_type_filter.py
+++ b/tests/cli/test_memory_tab_type_filter.py
@@ -193,6 +193,6 @@ def test_keys_tab_t_first_occurrence_is_events() -> None:
     from reyn.chat.tui.widgets.right_panel.keys_tab import render_keys
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
-    markup, _ = render_keys(app)
+    markup, _, _ = render_keys(app)
     # ``t`` from app.BINDINGS (events tab) still renders.
     assert "Tail events" in markup

--- a/tests/cli/test_panel_tab_switch_scrolls_cursor.py
+++ b/tests/cli/test_panel_tab_switch_scrolls_cursor.py
@@ -47,10 +47,12 @@ def _instrument_scroll_helpers(panel: RightPanel) -> dict[str, list[None]]:
     that grows by one each time the helper is invoked.
     """
     calls: dict[str, list[None]] = {
-        "events": [],
-        "agents": [],
-        "memory": [],
-        "docs":   [],
+        "events":  [],
+        "agents":  [],
+        "memory":  [],
+        "docs":    [],
+        "pending": [],
+        "keys":    [],
     }
 
     def _make_recorder(key: str):
@@ -58,10 +60,12 @@ def _instrument_scroll_helpers(panel: RightPanel) -> dict[str, list[None]]:
             calls[key].append(None)
         return _fake
 
-    panel._scroll_events_into_view = _make_recorder("events")   # type: ignore[method-assign]
-    panel._scroll_agents_into_view = _make_recorder("agents")   # type: ignore[method-assign]
-    panel._scroll_memory_into_view = _make_recorder("memory")   # type: ignore[method-assign]
-    panel._scroll_docs_into_view   = _make_recorder("docs")     # type: ignore[method-assign]
+    panel._scroll_events_into_view  = _make_recorder("events")   # type: ignore[method-assign]
+    panel._scroll_agents_into_view  = _make_recorder("agents")   # type: ignore[method-assign]
+    panel._scroll_memory_into_view  = _make_recorder("memory")   # type: ignore[method-assign]
+    panel._scroll_docs_into_view    = _make_recorder("docs")     # type: ignore[method-assign]
+    panel._scroll_pending_into_view = _make_recorder("pending")  # type: ignore[method-assign]
+    panel._scroll_keys_into_view    = _make_recorder("keys")     # type: ignore[method-assign]
     return calls
 
 
@@ -82,7 +86,7 @@ async def test_cursor_tab_activation_invokes_matching_scroll_helper(
         panel = app.query_one("#right_panel", RightPanel)
         calls = _instrument_scroll_helpers(panel)
 
-        for tab_id in ("events", "agents", "memory", "docs"):
+        for tab_id in ("events", "agents", "memory", "docs", "pending", "keys"):
             panel.on_tabs_tab_activated(_make_tab_event(panel, tab_id))
             await pilot.pause()
             # Exactly one call on the matching helper, zero on the others.
@@ -106,7 +110,7 @@ async def test_cursor_tab_activation_invokes_matching_scroll_helper(
 async def test_non_cursor_tab_activation_invokes_no_scroll_helper(
     tmp_path,
 ) -> None:
-    """Tier 2: ``keys`` / ``cost`` tabs have no cursor → no helper called.
+    """Tier 2: ``cost`` tab has no cursor → no helper called.
 
     Defends against an accidentally over-broad dispatch (= "scroll
     something just in case") that could re-anchor the scroll incorrectly
@@ -118,7 +122,7 @@ async def test_non_cursor_tab_activation_invokes_no_scroll_helper(
         panel = app.query_one("#right_panel", RightPanel)
         calls = _instrument_scroll_helpers(panel)
 
-        for tab_id in ("keys", "cost"):
+        for tab_id in ("cost",):
             panel.on_tabs_tab_activated(_make_tab_event(panel, tab_id))
             await pilot.pause()
             assert all(v == [] for v in calls.values()), (

--- a/tests/cli/test_right_panel_quick_jump.py
+++ b/tests/cli/test_right_panel_quick_jump.py
@@ -168,7 +168,7 @@ async def test_keys_tab_render_includes_quick_jump_descriptions() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup, _ = render_keys(app)
+        markup, _, _ = render_keys(app)
         for n in range(1, 8):
             assert f"⌃{n}" in markup, f"⌃{n} not in Keys tab markup"
         # Spot-check a couple of description strings.

--- a/tests/cli/test_skill_expand_keyboard.py
+++ b/tests/cli/test_skill_expand_keyboard.py
@@ -208,7 +208,7 @@ async def test_keys_tab_render_includes_f3_with_description() -> None:
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        markup, _ = render_keys(app)
+        markup, _, _ = render_keys(app)
         assert "F3" in markup
         # Description uses "skill row drill-down" (main UI wording).
         assert "skill row drill-down" in markup.lower()


### PR DESCRIPTION
**[tui-coder]** — Keys tab scroll-into-view fix (dogfood)

## Summary
- `render_keys` now returns `(markup, flat_key_list, key_ys)` 3-tuple — `key_ys` is a parallel list of 0-indexed rendered-output line numbers for each key row
- `_scroll_keys_into_view` added (same shape as `_scroll_pending_into_view` / `_scroll_events_into_view`)
- `_keys_move` caches `_key_ys` and calls `_scroll_keys_into_view` after cursor move
- `keys` added to tab-activation scroll dispatch table so cursor is visible on tab switch too
- All `render_keys` callers updated to unpack the new 3-tuple

## Why
User dogfood report 2026-05-24: Keys tab cursor moved past viewport but `scroll_y` stayed at 0. Confirmed via Pilot (`cursor 0→30`, `scroll_y=0.0`, `virtual_size.height=75`). Every other cursor tab (`events` / `agents` / `memory` / `docs` / `pending`) had a `_scroll_*_into_view` call in its move handler — Keys tab was the only missing one.

## Test plan
- [x] `tests/cli/test_keys_tab_scroll_into_view.py` — 4 Tier-2b tests (new file)
  - `test_render_keys_key_ys_parallel_to_flat_key_list` — signature contract
  - `test_render_keys_key_ys_strictly_increasing` — data integrity
  - `test_keys_move_calls_scroll_into_view` — spy verifies call contract
  - `test_keys_move_populates_key_ys` — data path from render → scroll helper
- [x] `tests/cli/test_panel_tab_switch_scrolls_cursor.py` — updated: `keys` added to cursor-bearing tabs list; non-cursor-tab test now only covers `cost`
- [x] All existing `render_keys` callers updated to unpack 3-tuple — 13 test files, 0 regressions
- [x] ruff clean ✓
- [x] tier audit 0 errors ✓
- [x] 85 tests pass across all affected files ✓
- [x] (skipped — headless test mode: `vs.size.height=0` in test mode, scroll_y delta not testable) Manual repro: `/tmp/tui_keys_scroll_repro.py` → scroll_y > 0 after 30 j (= fix confirmed via Pilot pre-dispatch)