### PR TITLE
fix(tui): docs_tab footer — escape [g] unescaped markup (MissingStyle CRITICAL)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
@@ -127,7 +127,7 @@ def render_docs(
     other_lang = "en" if lang == "ja" else "ja"
     lines.append(
         f"[#aaaaaa]  lang: [/][{_CORAL}]{lang}[/]"
-        f"[#555555]  ({other_lang} fallback)  [g] to toggle[/]"
+        f"[#555555]  ({other_lang} fallback)  \\[g] to toggle[/]"
     )
     lines.append("")
 

--- a/tests/cli/test_docs_lang_filter.py
+++ b/tests/cli/test_docs_lang_filter.py
@@ -137,8 +137,9 @@ def test_render_docs_ja_lang_header(tmp_path: Path) -> None:
     assert "(en fallback)" in rendered, (
         f"render_docs(lang='ja') must contain '(en fallback)'; got:\n{rendered}"
     )
-    assert "[g] to toggle" in rendered, (
-        f"render_docs must contain '[g] to toggle' hint; got:\n{rendered}"
+    # After the MissingStyle fix, [g] is escaped as \[g] in the markup string.
+    assert "\\[g] to toggle" in rendered, (
+        f"render_docs must contain escaped '\\[g] to toggle' hint; got:\n{rendered}"
     )
 
 
@@ -303,3 +304,41 @@ def test_build_docs_index_filter_applied_after_lang_collapse(tmp_path: Path) -> 
     assert only_en.stem == "glossary", (
         f"The single result must be glossary.md; got {only_en.stem!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 9: render_docs lang footer markup is parseable by Rich (no MissingStyle)
+# ---------------------------------------------------------------------------
+
+
+def test_docs_lang_toggle_hint_no_missing_style(tmp_path: Path) -> None:
+    """Tier 2b: docs tab fallback hint markup is escaped (no MissingStyle on [g]).
+
+    Regression guard for dogfood report 2026-05-24:
+    `MissingStyle: Failed to get style 'g'` raised when opening Docs tab
+    because `[g] to toggle` in the lang fallback footer was interpreted as
+    a Rich style tag. Fixed by escaping to `\\[g]`.
+    """
+    from rich.text import Text
+
+    from reyn.chat.tui.widgets.right_panel.docs_tab import (
+        build_docs_index,
+        render_docs,
+    )
+
+    root = _make_docs_tree(tmp_path)
+    groups, _ = build_docs_index(root, lang="en")
+
+    # Both lang variants must render without raising MissingStyle.
+    for lang in ("en", "ja"):
+        groups_l, _ = build_docs_index(root, lang=lang)
+        markup = render_docs(root, 0, groups_l, lang=lang)
+        # Rich.Text.from_markup raises MissingStyle if any tag is an invalid
+        # style (e.g. [g]).  This must not raise.
+        try:
+            Text.from_markup(markup)
+        except Exception as exc:  # noqa: BLE001
+            raise AssertionError(
+                f"render_docs(lang={lang!r}) produced markup that Rich cannot parse "
+                f"(MissingStyle regression): {exc}\n\nmarkup:\n{markup}"
+            ) from exc


### PR DESCRIPTION
**[tui-coder]** — Dogfood regression fix (2026-05-24).

## Summary

- **Root cause**: `docs_tab.py` L130 had `[g] to toggle` in an f-string passed to Rich. Rich interprets `[g]` as a style tag → `MissingStyle: Failed to get style 'g'` on every Docs tab open.
- **Fix**: Escaped to `\[g]` matching the convention established in PR #874 (events_tab `[d]` / `[v]` fix).
- **Audit**: Ran `grep -n " \[[a-z]\] "` on docs_tab.py — only one occurrence; no other unescaped single-letter tags found.
- **Tests**: Updated existing Test 3 assertion (`"[g] to toggle" → "\\[g] to toggle"`) + added Tier 2b regression test `test_docs_lang_toggle_hint_no_missing_style` that calls `Rich.Text.from_markup` on the rendered output for both lang variants; raises `AssertionError` wrapping the original `MissingStyle` if any unescaped single-letter tag is present.

## Files changed

- `src/reyn/chat/tui/widgets/right_panel/docs_tab.py` — L130: `[g]` → `\[g]`
- `tests/cli/test_docs_lang_filter.py` — Test 3 assertion update + new Test 9

## Test plan

- [x] `pytest tests/cli/test_docs_lang_filter.py tests/cli/test_docs_filter_esc_clear.py -x` — 12 passed
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/docs_tab.py` — clean
- [x] `python scripts/test_tier_audit.py tests/cli/test_docs_lang_filter.py` — 9 tests OK, 0 Tier 4 violations
- [x] (skipped — TUI smoke test requires running app; fix is a 1-line markup escape with full Rich-parse regression guard)

## Tier rule self-check

- No MagicMock / AsyncMock / patch used — real `tmp_path` fixture + real Rich import
- No private state asserted — public `render_docs` return value only
- Docstring Tier declared: `"""Tier 2b: ...`
- Not Tier 4 (fits Tier 2b: OS invariant — markup must be Rich-parseable)