### PR TITLE
fix(tui): Keys tab scroll cursor off-by-one (dogfood 2026-05-24)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -2229,6 +2229,13 @@ class RightPanel(Widget):
         as the events / agents / memory / docs helpers and integrates
         with the ``on_tabs_tab_activated`` dispatch table established
         in TUI Right Panel exploration wave (PR #231).
+
+        Note: ``render_pending`` starts ``lines`` with a header element,
+        so ``item_ys[0]`` is already 1 (not 0).  Adding +1 here would
+        compute ``scroll_to(y=2)`` for cursor=0, scrolling PAST item 0
+        and hiding it above the viewport — same off-by-one as the keys
+        tab.  Use ``item_ys[cursor]`` directly (same fix as
+        ``_scroll_keys_into_view``).
         """
         try:
             vs = self.query_one("#panel-scroll", VerticalScroll)
@@ -2238,7 +2245,7 @@ class RightPanel(Widget):
                 return
             if not (0 <= self._pending_cursor < len(self._pending_item_ys)):
                 return
-            y = 1 + self._pending_item_ys[self._pending_cursor]
+            y = self._pending_item_ys[self._pending_cursor]
             if y < current:
                 vs.scroll_to(y=y, animate=False)
             elif y >= current + visible:
@@ -2255,6 +2262,14 @@ class RightPanel(Widget):
         ``_scroll_events_into_view``.  ``_key_ys`` is populated by
         ``render_keys`` (via ``_keys_move`` and ``_panel_markup``) and
         records the 0-indexed rendered-output line of each key row.
+
+        Note: unlike ``_scroll_events_into_view`` / ``_scroll_memory_into_view``
+        (where the rendered output starts at line 0 so +1 accounts for
+        panel-content padding-top), ``_key_ys[i]`` already encodes the
+        rendered line index INCLUDING the group-header offset (= group header
+        at line 0, first key row at line 1).  No additional +1 is needed —
+        adding one would scroll past the cursor row, hiding it above the
+        viewport.  Dogfood 2026-05-24: cursor 0 復帰時 cursor が画面外.
         """
         try:
             vs = self.query_one("#panel-scroll", VerticalScroll)
@@ -2265,7 +2280,7 @@ class RightPanel(Widget):
             cursor = get_keys_cursor()
             if not (0 <= cursor < len(self._key_ys)):
                 return
-            y = 1 + self._key_ys[cursor]
+            y = self._key_ys[cursor]
             if y < current:
                 vs.scroll_to(y=y, animate=False)
             elif y >= current + visible:

--- a/tests/cli/test_keys_tab_scroll_into_view.py
+++ b/tests/cli/test_keys_tab_scroll_into_view.py
@@ -190,3 +190,115 @@ async def test_keys_move_populates_key_ys() -> None:
         assert all(isinstance(y, int) and y >= 0 for y in key_ys), (
             "All render_keys key_ys entries must be non-negative int"
         )
+
+
+# ── Test 5: key_ys[0] >= 1 — group header precedes first key row ─────────────
+
+
+@pytest.mark.asyncio
+async def test_key_ys_cursor0_not_at_render_line0() -> None:
+    """Tier 2b: key_ys[0] >= 1 — a group header occupies line 0, so cursor 0
+    is at render line >=1.  The old formula ``y = 1 + key_ys[0]`` would
+    therefore produce a scroll target >= 2, scrolling PAST the cursor row and
+    hiding it above the viewport.  The fix drops the +1.
+
+    This is a pure contract test on ``render_keys``'s 3rd return — no
+    scroll geometry needed.  If this invariant breaks, the off-by-one fix
+    is invalidated.
+
+    Dogfood 2026-05-24: cursor 0 復帰時 cursor が画面外で隠れる.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+        _, flat_key_list, key_ys = render_keys(app, cursor=0, expanded=set())
+        assert len(key_ys) > 0, "render_keys must return at least one key row"
+        assert key_ys[0] >= 1, (
+            f"key_ys[0]={key_ys[0]}: first key row must be at render line >= 1 "
+            f"because a group header occupies line 0.  If key_ys[0] == 0, the "
+            f"old '1 + key_ys[cursor]' formula and the fix formula would differ "
+            f"by a line but the geometry would need re-evaluation."
+        )
+
+
+# ── Test 6: old formula would be strictly greater than key_ys[0] ─────────────
+
+
+@pytest.mark.asyncio
+async def test_old_plus1_formula_exceeds_key_ys0() -> None:
+    """Tier 2b: ``1 + key_ys[0]`` exceeds ``key_ys[0]``, which is
+    the exact off-by-one: scroll_to(1 + key_ys[0]) puts render line
+    (1 + key_ys[0]) at viewport top, so the cursor at render line
+    key_ys[0] is above the viewport.
+
+    Regression pin: if this test fails it means key_ys[0] == 0, which
+    would change the geometry analysis and require a re-audit.
+
+    Pure contract — no scroll geometry needed.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+        _, _, key_ys = render_keys(app, cursor=0, expanded=set())
+        assert len(key_ys) > 0, "render_keys must return at least one key row"
+        # The off-by-one: 1 + key_ys[0] > key_ys[0].  If scroll_to is
+        # called with (1 + key_ys[0]) when current > key_ys[0], the
+        # cursor row is scrolled past.
+        assert 1 + key_ys[0] > key_ys[0], "sanity: 1 + n > n always"
+        # Pin the exact expected value so any future change to group
+        # layout surfaces here first.
+        assert key_ys[0] == 1, (
+            f"key_ys[0]={key_ys[0]}: expected 1 (group header at line 0, "
+            f"first key at line 1).  Old formula gave 1+1=2 (off by one). "
+            f"If this value changed, re-verify _scroll_keys_into_view formula."
+        )
+
+
+# ── Test 7: scroll_to target for mid-list cursor is key_ys[cursor] ───────────
+
+
+@pytest.mark.asyncio
+async def test_scroll_target_for_mid_cursor_equals_key_ys() -> None:
+    """Tier 2b: for cursor N>=1, ``key_ys[N]`` is the correct scroll target
+    (not ``1 + key_ys[N]``).
+
+    Verifies that every key_ys entry equals the rendered line that contains
+    the cursor indicator (▶), so ``scroll_to(y=key_ys[N])`` puts that
+    exact row at viewport top.
+
+    Pure contract: iterate over a handful of cursor positions and verify
+    that the render line at key_ys[N] contains the cursor indicator text.
+    """
+    _reset_keys_state()
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+        for cursor in range(3):
+            markup, flat_key_list, key_ys = render_keys(
+                app, cursor=cursor, expanded=set()
+            )
+            if cursor >= len(key_ys):
+                break
+            lines = markup.split("\n")
+            y = key_ys[cursor]
+            assert 0 <= y < len(lines), (
+                f"cursor={cursor}: key_ys[cursor]={y} is out of range "
+                f"(rendered output has {len(lines)} lines)"
+            )
+            # The cursor row always contains "▶" (the cursor indicator).
+            assert "▶" in lines[y], (
+                f"cursor={cursor}: key_ys[cursor]={y} → render line "
+                f"{lines[y]!r} does not contain cursor indicator '▶'.  "
+                f"The scroll target should land exactly on the cursor row."
+            )
+            # Verify that 1 + key_ys[cursor] does NOT contain the cursor:
+            # this is the off-by-one line that was wrongly used as the target.
+            wrong_y = 1 + y
+            if wrong_y < len(lines):
+                assert "▶" not in lines[wrong_y], (
+                    f"cursor={cursor}: the off-by-one line {wrong_y} "
+                    f"({lines[wrong_y]!r}) unexpectedly contains '▶' — "
+                    f"re-audit the formula."
+                )


### PR DESCRIPTION
**[tui-coder]** — Dogfood 2026-05-24: Keys tab cursor 下→上 wrap / walk 時に cursor が画面外で隠れる。

## Root cause

`_scroll_keys_into_view` computed scroll target as:
```python
y = 1 + self._key_ys[cursor]  # cursor=0: y = 1 + 1 = 2
```

`_key_ys[cursor]` is the 0-indexed render line of the cursor row (populated by `render_keys`). For cursor=0, the first group header occupies line 0, so `key_ys[0] = 1`. Adding +1 gives `y=2`, which scrolls PAST the cursor row — putting render line 2 at viewport top, cursor at line 1 is hidden.

The `+1` was inherited from `_scroll_pending_into_view` copy without verifying the indexing convention. `render_events` / `render_memory` start `lines = []` so their first item is at render line 0 and the `+1` offsets correctly for their layout. `render_keys` starts with a group header, so `key_ys[0]` is already 1 — the `+1` is spurious.

## Pending tab audit

`_scroll_pending_into_view`: `render_pending` also starts `lines` with a header element (`"  Pending operations (N)"`), so `item_ys[0] = 1`. The same `1 + item_ys[cursor]` formula gives `y=2` for cursor=0, scrolling past item 0. Fixed in the same PR.

## Fix

`src/reyn/chat/tui/widgets/right_panel/__init__.py`:
- `_scroll_keys_into_view`: `y = self._key_ys[cursor]` (was `1 + ...`)
- `_scroll_pending_into_view`: `y = self._pending_item_ys[self._pending_cursor]` (was `1 + ...`)

## Tests (Tier 2b, added to `test_keys_tab_scroll_into_view.py`)

- **Test 5** (`test_key_ys_cursor0_not_at_render_line0`): `key_ys[0] >= 1` — group header precedes first key; pure contract.
- **Test 6** (`test_old_plus1_formula_exceeds_key_ys0`): `key_ys[0] == 1` exactly; pins that old formula `1+1=2` was off by one.
- **Test 7** (`test_scroll_target_for_mid_cursor_equals_key_ys`): for cursor in {0,1,2}, render line `key_ys[cursor]` contains `▶`; render line `1 + key_ys[cursor]` does NOT. Direct proof that fix scroll target lands on the correct row.

All 3 tests are pure `render_keys()` contract tests — no private state, no scroll geometry (headless height=0 would cause early-return so spy geometry tests are not appropriate here; public surface suffices).

## Test plan

- [x] `pytest tests/cli/test_keys_tab*.py tests/cli/test_right_panel*.py tests/cli/test_tui_smoke.py -x` — 80 passed
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/__init__.py` — All checks passed
- [x] `python scripts/test_tier_audit.py tests/cli/test_keys_tab_scroll_into_view.py` — 7 OK, 0 errors
- [x] (skipped — live TUI run: headless test environment / no display in agent context) Manual repro: cursor=0 復帰後 cursor visible at top confirmed by Pilot analysis and test 7 proof

## Tier rule self-check

- No `MagicMock` / `patch` used (direct attribute substitution only in existing test 3, new tests are pure)
- No private state asserted (`_key_ys` not touched; all assertions via `render_keys()` public return)
- Each test docstring declares Tier 2b on first line