### PR TITLE
feat(mcp): include inputSchema in mcp__list_tools entries (#879 follow-up)

### DIFF
--- a/docs/concepts/mcp.ja.md
+++ b/docs/concepts/mcp.ja.md
@@ -56,13 +56,16 @@ reyn mcp install --source https://github.com/modelcontextprotocol/servers/tree/m
 
 ## クイックスタート: `reyn chat` から MCP を試す（手動設定パス）
 
-手動でサーバーを設定したい場合や、公開レジストリにないサーバーを追加する場合は、`reyn.yaml` に直接追加します。サーバーを設定すると、`reyn chat` は自動的に 3 つの router tool を使えます：
+手動でサーバーを設定したい場合や、公開レジストリにないサーバーを追加する場合は、`reyn.yaml` に直接追加します。 サーバーを設定すると、 `reyn chat` は自動的に 6 個の MCP verb actions を使えます (issue #879 で旧 `mcp.server` / `mcp.tool` / `mcp.operation` の 3 sub-category を collapse):
 
-| Tool | 何をするか |
+| Action | 何をするか |
 |------|-----------|
-| `list_mcp_servers` | `reyn.yaml` に設定された全サーバー名を返す |
-| `list_mcp_tools(server)` | 1 つのサーバーが露出する tool 一覧を返す |
-| `call_mcp_tool(server, tool, args)` | サーバー上の tool を呼び出して結果を返す |
+| `mcp__search_server({text})`        | 公開 registry で新規サーバーを検索 |
+| `mcp__install_server({server_id})`  | サーバーを現 scope の config に install |
+| `mcp__list_servers()`               | `reyn.yaml` に設定された全サーバー名を返す |
+| `mcp__list_tools({server})`         | 1 サーバーが露出する tool 一覧を `{name: "<server>__<tool>", description, inputSchema}` 形式で返す |
+| `mcp__call_tool({tool, args})`      | `<server>__<tool>` ID + tool の declared args で tool を call |
+| `mcp__drop_server({server})`        | install 済サーバーを config から削除 |
 
 LLM router がチャット turn 内で直接これらを呼べます。 初回利用の典型 flow:
 
@@ -85,7 +88,7 @@ reyn chat
 > このディレクトリにある README.md を要約して
 ```
 
-router が自動的に `list_mcp_tools` → `call_mcp_tool` を呼び出します。 どの skill にも `permissions.mcp:` 宣言を書く必要はありません。 **Skill 作成は、 繰り返し使うワークフローを形式化したい時** (= phase graph / validation / retry policy が必要になった時) に検討するものであって、 MCP を使う前提条件ではありません。 以下の deep-dive はその場合の話で、 ad-hoc 利用だけならここで読み終えて問題ありません。
+router が自動的に `mcp__list_tools` → `mcp__call_tool` を呼び出します。 どの skill にも `permissions.mcp:` 宣言を書く必要はありません。 **Skill 作成は、 繰り返し使うワークフローを形式化したい時** (= phase graph / validation / retry policy が必要になった時) に検討するものであって、 MCP を使う前提条件ではありません。 以下の deep-dive はその場合の話で、 ad-hoc 利用だけならここで読み終えて問題ありません。
 
 ## ロール 1：MCP クライアント — Reyn が外部サーバーを呼ぶ
 

--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -56,13 +56,16 @@ For the full `reyn mcp` CLI reference, see [Reference: `reyn mcp`](../reference/
 
 ## Quick start: try MCP from `reyn chat` (manual config path)
 
-If you prefer to configure a server manually (or are adding a server not in the public registry), add it directly to `reyn.yaml`. `reyn chat` exposes three router tools that work automatically once the server is configured:
+If you prefer to configure a server manually (or are adding a server not in the public registry), add it directly to `reyn.yaml`. `reyn chat` exposes six MCP verb actions (issue #879 collapsed the previous `mcp.server` / `mcp.tool` / `mcp.operation` sub-categories) that work automatically once the server is configured:
 
-| Tool | What it does |
+| Action | What it does |
 |------|--------------|
-| `list_mcp_servers` | Returns the names of all servers configured in `reyn.yaml` |
-| `list_mcp_tools(server)` | Returns the tools exposed by one server |
-| `call_mcp_tool(server, tool, args)` | Invokes a tool on a server, returning its result |
+| `mcp__search_server({text})`        | Search the public registry for new servers |
+| `mcp__install_server({server_id})`  | Install a server into the current scope's config |
+| `mcp__list_servers()`               | Returns the names of all servers configured in `reyn.yaml` |
+| `mcp__list_tools({server})`         | Returns the tools exposed by one server (each entry has `name="<server>__<tool>"`, `description`, `inputSchema`) |
+| `mcp__call_tool({tool, args})`      | Call a tool by `<server>__<tool>` identifier (from `mcp__list_tools`) with its declared args |
+| `mcp__drop_server({server})`        | Remove an installed server from the config |
 
 The LLM router can call these directly during a chat turn. Typical first-time flow:
 
@@ -85,7 +88,7 @@ reyn chat
 > このディレクトリにある README.md を要約して
 ```
 
-The router invokes `list_mcp_tools` → `call_mcp_tool` automatically; no `permissions.mcp:` declaration in any skill is required. **Skill authoring is for when you want to formalize a recurring workflow** (= phase graph, validation, retry policy) — not a prerequisite to using MCP. The deep-dive below is for that case; if you only need ad-hoc invocation, you can stop reading here.
+The router invokes `mcp__list_tools` → `mcp__call_tool` automatically; no `permissions.mcp:` declaration in any skill is required. **Skill authoring is for when you want to formalize a recurring workflow** (= phase graph, validation, retry policy) — not a prerequisite to using MCP. The deep-dive below is for that case; if you only need ad-hoc invocation, you can stop reading here.
 
 ## Role 1: MCP client — Reyn calls external servers
 

--- a/docs/concepts/universal-catalog.ja.md
+++ b/docs/concepts/universal-catalog.ja.md
@@ -44,15 +44,13 @@ hallucination 0/35)。
 て O(1) になる** こと。 14 番目の category を足しても 14 番目の tool は
 増えない — `CATEGORIES` tuple に 1 行 + routing rule 1 件で済む。
 
-## 13 category (§D18 master taxonomy)
+## Category 一覧 (§D18 master taxonomy)
 
 | Category | 保持するもの | Canonical invoke 意味論 |
 |---|---|---|
 | `skill` | project / stdlib skill | `input` artifact を持って skill を実行 |
 | `agent.peer` | topology 内の peer agent | その peer にメッセージを delegate |
-| `mcp.server` | 設定済み MCP server (resource) | この server の tools を列挙 |
-| `mcp.tool` | 各 server の個別 tool | `args` を持って tool を call |
-| `mcp.operation` | MCP server 管理 op | op を実行 (例: `drop_server`) |
+| `mcp` | MCP server 管理 + tool dispatch (issue #879) | 6 個の verb_object actions — 下表参照 |
 | `file` | workspace の file op | read / write / delete / list |
 | `web` | web search + fetch | search または fetch |
 | `memory.entry` | 永続 memory record | entry の body を read |
@@ -66,6 +64,19 @@ hallucination 0/35)。
 (= `"noop"` 以外) が configure されている場合のみ surface に出る。 残り
 は常に visible。
 
+Issue #879 で旧 `mcp.server` / `mcp.tool` / `mcp.operation` の 3
+sub-category を `mcp` 1 category に collapse、 LLM に見える surface は
+6 個の verb_object actions:
+
+| Action | 用途 |
+|---|---|
+| `mcp__search_server`  | MCP registry で新規 server を検索 |
+| `mcp__install_server` | server を現 scope の config に install |
+| `mcp__list_servers`   | install 済 server を列挙 |
+| `mcp__list_tools`     | 1 server の tool を `<server>__<tool>` ID で列挙 |
+| `mcp__call_tool`      | `<server>__<tool>` ID + `args` で tool を call |
+| `mcp__drop_server`    | install 済 server を削除 |
+
 ## Qualified-name format
 
 ```
@@ -73,10 +84,10 @@ hallucination 0/35)。
 ```
 
 separator は **double underscore** (`__`)。 category は `.` を含んでよく
-(`mcp.tool`)、 entry name は boundary の `__` sequence 以外なら任意。
-split rule は 「category 名直後の最初の `__`」 なので
-`mcp.tool__brave.search` は (`mcp.tool`, `brave.search`) と正しくパース
-される。
+(`agent.peer`, `rag.corpus`, `reyn.source` 等)、 entry name は boundary
+の `__` sequence 以外なら任意。 split rule は 「category 名直後の最初の
+`__`」 なので `agent.peer__alice` は (`agent.peer`, `alice`) と正しく
+パースされる。
 
 例:
 
@@ -84,8 +95,8 @@ split rule は 「category 名直後の最初の `__`」 なので
 |---|---|
 | `skill__index_docs` | (`skill`, `index_docs`) |
 | `agent.peer__alice` | (`agent.peer`, `alice`) |
-| `mcp.tool__brave.search` | (`mcp.tool`, `brave.search`) |
-| `mcp.operation__drop_server` | (`mcp.operation`, `drop_server`) |
+| `mcp__call_tool` | (`mcp`, `call_tool`) |
+| `mcp__install_server` | (`mcp`, `install_server`) |
 | `rag.corpus__meetings` | (`rag.corpus`, `meetings`) |
 | `file__read` | (`file`, `read`) |
 
@@ -93,7 +104,7 @@ split rule は 「category 名直後の最初の `__`」 なので
 
 OpenAI native function-call API は tool 名を `^[a-zA-Z0-9_-]{1,64}$` に
 制限している (= `.` は不可)。 Reyn の qualified name はカテゴリに `.` を
-含む形 (`mcp.tool`, `agent.peer`, `reyn.source` 等) があり、 **LiteLLM
+含む形 (`agent.peer`, `rag.corpus`, `reyn.source` 等) があり、 **LiteLLM
 proxy 経由なら OK** だが OpenAI native を直接叩く場合 reject される
 可能性がある。
 
@@ -151,10 +162,13 @@ invoke すると、 その種別の *canonical default operation* が走る:
 |---|---|
 | `skill` | skill を実行 |
 | `agent.peer` | message を delegate |
-| `mcp.server` | この server の tools を列挙 |
-| `mcp.tool` | tool を call |
 | `memory.entry` | body を read |
 | `rag.corpus` | single-source recall |
+
+Issue #879 で旧 `mcp.server` / `mcp.tool` の resource entry は削除。
+per-MCP-server / per-MCP-tool dispatch は `mcp` category 内の verb
+actions 経由 (= `mcp__list_tools` →
+`mcp__call_tool({tool: "<server>__<tool>", args})`) で flow する。
 
 これにより LLM は `invoke_action("rag.corpus__meetings", {"query": "Q3
 roadmap"})` と書くだけで wrapper が `recall(sources=["meetings"],
@@ -171,18 +185,17 @@ qualified name → target tool 名のマッピングは
 
 - **`_OPERATION_RULES`** — qualified name → `(target_tool_name,
   arg_transformer)`、 static operation category 向け (file / web /
-  memory.operation / reyn.source / rag.operation / mcp.operation)。
+  memory.operation / reyn.source / rag.operation / mcp)。
 - **`_RESOURCE_RULES`** — category → `(target_tool_name,
   arg_transformer)`、 entry が `RouterCallerState` 由来の resource
-  category 向け (skills / agents / mcp servers / mcp tools / memory
-  entries / rag corpora)。
+  category 向け (skills / agents / memory entries / rag corpora)。
 
 Routing は常に:
 
 1. qualified name を (`category`, `entry_name`) に split。
 2. その category / qualified name の rule を lookup。
-3. arg transformer を実行 (例: `_call_mcp_tool_args` は `entry_name`
-   を `(server, tool)` に分け、 `args` を pack)。
+3. arg transformer を実行 (例: `_invoke_skill_args` は caller の args を
+   skill の input artifact に wrap)。
 4. `ResolvedAction(target_tool_name, target_args)` を返し、 wrapper が
    それを unified `ToolRegistry` に渡す。
 

--- a/docs/concepts/universal-catalog.md
+++ b/docs/concepts/universal-catalog.md
@@ -45,15 +45,13 @@ The architectural win is that **the LLM's tool list is now O(1) in
 resource categories**. A 14th category does not add a 14th tool — it
 adds an entry to the `CATEGORIES` tuple and one routing rule.
 
-## The 13 categories (§D18 master taxonomy)
+## The categories (§D18 master taxonomy)
 
 | Category | Holds | Canonical invoke semantic |
 |---|---|---|
 | `skill` | Project / stdlib skills | run the skill with `input` artifact |
 | `agent.peer` | Peer agents in the topology | delegate a message to that peer |
-| `mcp.server` | Configured MCP servers (resource) | list this server's tools |
-| `mcp.tool` | Individual tools on each server | call the tool with `args` |
-| `mcp.operation` | MCP server management ops | run the op (e.g. `drop_server`) |
+| `mcp` | MCP server management + tool dispatch (issue #879) | six verb_object actions — see below |
 | `file` | Workspace file ops | read / write / delete / list |
 | `web` | Web search + fetch | search or fetch |
 | `memory.entry` | Persistent memory records | read the entry's body |
@@ -62,6 +60,19 @@ adds an entry to the `CATEGORIES` tuple and one routing rule.
 | `rag.corpus` | Indexed corpora (resource) | recall against this single source |
 | `rag.operation` | RAG management ops | multi-source recall / drop source |
 | `exec` | Sandboxed argv execution | run argv under the sandbox backend |
+
+Issue #879 collapsed the previous `mcp.server` / `mcp.tool` /
+`mcp.operation` sub-categories into a single `mcp` category whose six
+verb_object actions cover the LLM-visible surface:
+
+| Action | Purpose |
+|---|---|
+| `mcp__search_server`  | Search the MCP registry for new servers |
+| `mcp__install_server` | Install a server into the current scope's config |
+| `mcp__list_servers`   | Enumerate installed servers |
+| `mcp__list_tools`     | Enumerate one server's tools as `<server>__<tool>` ids |
+| `mcp__call_tool`      | Call a tool by `<server>__<tool>` id with `args` |
+| `mcp__drop_server`    | Remove an installed server |
 
 `exec` is gated by `is_exec_available()` — it only appears when a real
 sandbox backend (= not `"noop"`) is configured. The rest are always
@@ -74,10 +85,10 @@ visible.
 ```
 
 The separator is **double underscore** (`__`). Categories may contain
-dots (`mcp.tool`); entry names may contain anything except the `__`
-sequence at the boundary. The split rule is "first `__` after the
-category name" so `mcp.tool__brave.search` correctly parses as
-(`mcp.tool`, `brave.search`).
+dots (`agent.peer`, `rag.corpus`, `reyn.source`, …); entry names may
+contain anything except the `__` sequence at the boundary. The split
+rule is "first `__` after the category name" so `agent.peer__alice`
+correctly parses as (`agent.peer`, `alice`).
 
 Examples:
 
@@ -85,8 +96,8 @@ Examples:
 |---|---|
 | `skill__index_docs` | (`skill`, `index_docs`) |
 | `agent.peer__alice` | (`agent.peer`, `alice`) |
-| `mcp.tool__brave.search` | (`mcp.tool`, `brave.search`) |
-| `mcp.operation__drop_server` | (`mcp.operation`, `drop_server`) |
+| `mcp__call_tool` | (`mcp`, `call_tool`) |
+| `mcp__install_server` | (`mcp`, `install_server`) |
 | `rag.corpus__meetings` | (`rag.corpus`, `meetings`) |
 | `file__read` | (`file`, `read`) |
 
@@ -94,7 +105,7 @@ Examples:
 
 OpenAI's native function-call API restricts tool names to
 `^[a-zA-Z0-9_-]{1,64}$` (= no `.`). Reyn's qualified names with
-dotted categories (`mcp.tool`, `agent.peer`, `reyn.source`, etc.)
+dotted categories (`agent.peer`, `rag.corpus`, `reyn.source`, etc.)
 therefore **work via a LiteLLM proxy** but may be rejected by direct
 OpenAI native callers.
 
@@ -157,10 +168,13 @@ resource runs the *canonical default operation* for that kind:
 |---|---|
 | `skill` | run the skill |
 | `agent.peer` | delegate a message |
-| `mcp.server` | list this server's tools |
-| `mcp.tool` | call the tool |
 | `memory.entry` | read the body |
 | `rag.corpus` | single-source recall |
+
+Issue #879 removed the previous `mcp.server` / `mcp.tool` resource
+entries; per-MCP-server / per-MCP-tool dispatch now flows through the
+verb actions in the `mcp` category (= `mcp__list_tools` →
+`mcp__call_tool({tool: "<server>__<tool>", args})`).
 
 This means an LLM can say `invoke_action("rag.corpus__meetings",
 {"query": "Q3 roadmap"})` and the wrapper expands it to
@@ -177,18 +191,17 @@ the routing:
 
 - **`_OPERATION_RULES`** — qualified name → `(target_tool_name,
   arg_transformer)` for static operation categories (file / web /
-  memory.operation / reyn.source / rag.operation / mcp.operation).
+  memory.operation / reyn.source / rag.operation / mcp).
 - **`_RESOURCE_RULES`** — category → `(target_tool_name,
   arg_transformer)` for resource categories whose entries come from
-  `RouterCallerState` (skills / agents / mcp servers / mcp tools /
-  memory entries / rag corpora).
+  `RouterCallerState` (skills / agents / memory entries / rag corpora).
 
 Routing always:
 
 1. Splits the qualified name into (`category`, `entry_name`).
 2. Looks up the rule for that category / qualified name.
-3. Runs the arg transformer (e.g. `_call_mcp_tool_args` splits the
-   `entry_name` into `(server, tool)` and packs `args`).
+3. Runs the arg transformer (e.g. `_invoke_skill_args` wraps the
+   caller args under the skill's input artifact).
 4. Returns a `ResolvedAction(target_tool_name, target_args)` that
    the wrapper hands to the unified `ToolRegistry`.
 
@@ -232,8 +245,8 @@ sandbox backend. Hidden categories appear neither in the
 ## System prompt placement (§D9)
 
 When `action_retrieval.universal_wrappers_enabled` is true, the router
-system prompt gains a **`## Action categories`** section listing all
-13 categories with their canonical-default semantic. The section sits
+system prompt gains a **`## Action categories`** section listing every
+category with its canonical-default semantic. The section sits
 between `## Capabilities` and `## Behaviour` so it stays inside the
 static prompt-cache prefix (= every request after the first hits the
 warm cache).

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -169,32 +169,44 @@ async def _handle_list_mcp_tools(
     Phase path: registered with gates.phase=allow (Type C metadata closure)
     but unreachable today — see module docstring for full status.
 
-    FP-0032: returns ``mcp_tools`` key (not ``tools``) to avoid structural
-    collision with OpenAI tool-definition shape. Each entry is trimmed to
-    ``{name, description}`` only — ``inputSchema`` is omitted so the LLM
-    cannot mistake an mcp_tool for a top-level callable. Full schema is
-    available via ``describe_mcp_tool``.
+    Response shape: ``{"mcp_tools": [{"name": "<server>__<tool>",
+    "description": "...", "inputSchema": {...}}, ...]}``.
+
+    Background:
+      - FP-0032 returned ``mcp_tools`` key (not ``tools``) to avoid
+        structural collision with OpenAI tool-definition shape, and
+        also stripped ``inputSchema`` so the entries could not be
+        mistaken for top-level callable functions.
+      - Issue #879 collapsed MCP dispatch into a single
+        ``mcp__call_tool`` verb whose ``tool`` arg takes a
+        ``<server>__<tool>`` self-contained identifier. In that
+        world the entry name is **not** a callable function name in
+        the router's ``tools=`` array, so the FP-0032 shape-collision
+        concern no longer applies — and the LLM needs the schema
+        directly to construct ``mcp__call_tool``'s ``args`` field
+        without an extra ``describe_mcp_tool`` round-trip. Include
+        ``inputSchema`` in each entry verbatim from the MCP server's
+        declared shape.
     """
     if ctx.caller_kind == "router":
         host = _require_host(ctx)
         server = str(args["server"])
         result = await host.mcp_list_tools(server)
-        # Strip inputSchema from each entry so the shape does not resemble
-        # an OpenAI tool definition (FP-0032 root-cause fix). Issue #879:
-        # each entry's ``name`` is rewritten to the self-contained
-        # ``<server>__<tool>`` identifier the LLM passes verbatim to
-        # mcp__call_tool's ``tool`` arg.
-        trimmed: list[dict] = []
+        # Issue #879: rewrite each entry's ``name`` to the
+        # ``<server>__<tool>`` identifier; preserve description + the
+        # tool's declared ``inputSchema`` so the LLM can construct
+        # mcp__call_tool args in a single follow-up turn.
+        rebuilt: list[dict] = []
         for t in (result or []):
             if not isinstance(t, Mapping):
                 continue
             inner_name = t.get("name", "")
             if not inner_name:
                 continue
-            entry = {k: v for k, v in t.items() if k != "inputSchema"}
+            entry = dict(t)
             entry["name"] = f"{server}__{inner_name}"
-            trimmed.append(entry)
-        return {"mcp_tools": trimmed}
+            rebuilt.append(entry)
+        return {"mcp_tools": rebuilt}
 
     return {
         "error": (

--- a/tests/test_router_call_mcp_tool_enum.py
+++ b/tests/test_router_call_mcp_tool_enum.py
@@ -325,19 +325,35 @@ def test_list_mcp_tools_returns_mcp_tools_key():
 # ---------------------------------------------------------------------------
 
 
-def test_list_mcp_tools_omits_input_schema():
-    """Tier 2: each entry in mcp_tools result has no 'inputSchema' key.
+def test_list_mcp_tools_includes_input_schema():
+    """Tier 2: each entry in mcp_tools result carries the tool's
+    declared ``inputSchema`` verbatim.
 
-    FP-0032 structural fix: inputSchema presence makes the entry structurally
-    identical to an OpenAI function tool definition, causing the LLM to treat
-    mcp_tools as directly callable. Removing inputSchema breaks the false affordance.
-    Full schema is available via describe_mcp_tool.
+    Issue #879 collapsed MCP dispatch into a single ``mcp__call_tool``
+    verb whose ``tool`` arg takes a ``<server>__<tool>`` self-contained
+    identifier. The entry name is no longer a top-level callable
+    function name (= the FP-0032 shape-collision concern no longer
+    applies), and the LLM needs the schema directly to construct
+    mcp__call_tool's ``args`` field without an extra describe_mcp_tool
+    round-trip.
     """
     class _FakeHost:
         async def mcp_list_tools(self, server: str) -> list[dict]:
             return [
-                {"name": "search", "description": "Search", "inputSchema": {"type": "object"}},
-                {"name": "news", "description": "News", "inputSchema": {"type": "object"}},
+                {
+                    "name": "search",
+                    "description": "Search",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                        "required": ["q"],
+                    },
+                },
+                {
+                    "name": "news",
+                    "description": "News",
+                    "inputSchema": {"type": "object"},
+                },
             ]
         async def mcp_list_servers(self) -> list[dict]:
             return []
@@ -357,11 +373,16 @@ def test_list_mcp_tools_omits_input_schema():
     result = asyncio.run(
         _handle_list_mcp_tools({"server": "brave"}, ctx)
     )
-    for entry in result["mcp_tools"]:
-        assert "inputSchema" not in entry, (
-            f"list_mcp_tools entry must not contain 'inputSchema' (FP-0032); got: {entry}"
-        )
-        assert "name" in entry, "Each mcp_tools entry must have 'name'"
+    by_name = {e["name"]: e for e in result["mcp_tools"]}
+    # Issue #879: names are <server>__<tool> identifiers.
+    assert set(by_name) == {"brave__search", "brave__news"}
+    # Schema preserved verbatim from MCP server's declaration.
+    assert by_name["brave__search"]["inputSchema"] == {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+    assert by_name["brave__news"]["inputSchema"] == {"type": "object"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — #879 follow-up: re-include MCP tool ``inputSchema`` in ``mcp__list_tools`` response so the LLM can fill ``mcp__call_tool({tool, args})`` in a single turn.

## Why now

Post-#879 (= PR #882) the LLM dispatches MCP tool calls via the single ``mcp__call_tool({tool: "<server>__<tool>", args: {...}})`` verb. To construct ``args`` it needs the tool's declared schema. The previous ``list_mcp_tools`` handler stripped ``inputSchema`` per FP-0032 (= shape-collision avoidance with OpenAI tool defs from the pre-collapse era), forcing an extra ``describe_mcp_tool`` round-trip per tool.

In the post-collapse world the FP-0032 concern no longer applies:
- Entry name is ``<server>__<tool>`` (= self-contained identifier the LLM passes to ``mcp__call_tool``'s ``tool`` arg)
- The entry is **not** a top-level callable function in the router's ``tools=`` array
- → No false-affordance risk; restoring ``inputSchema`` is safe

## Diff

- `src/reyn/tools/mcp.py::_handle_list_mcp_tools` — preserve ``inputSchema`` field on each entry (= rebuild dict verbatim instead of stripping)
- `tests/test_router_call_mcp_tool_enum.py::test_list_mcp_tools_includes_input_schema` — Tier-2 invariant inverts: now pins that schema IS present + matches the MCP-server declaration verbatim
- Docstring updated to record the FP-0032 → #879 transition rationale

## Test plan

- [x] `ruff check .` → green
- [x] `python3 scripts/test_tier_audit.py tests/test_router_call_mcp_tool_enum.py` → 16 tests / 0 errors
- [x] `pytest -q tests/test_router_call_mcp_tool_enum.py tests/test_universal_handlers.py tests/test_universal_dispatch.py` → 155 passed
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし (= polarity flip + richer schema check) ✓ / audit 0 errors ✓

## Notes

- Pre-flip test (`test_list_mcp_tools_omits_input_schema`) was pinning the OLD FP-0032 invariant; this PR replaces it (= same Tier-2 slot, flipped contract). Per `[[feedback_contract_reversal_rewrites_tests]]` the inversion is rewritten as a fresh assertion rather than flipping the `assert not` to `assert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)