### PR TITLE
feat(cli): reyn chainlit PoC — web chat coexistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ spike_results/
 # between Desktop / CLI / different sessions).  Git-ignored so private
 # session context does not leak into repo history.
 .handoff/
+
+# Chainlit auto-created artifacts (= first `reyn chainlit` run drops
+# chainlit.md welcome page + .chainlit/{config.toml,translations/} in
+# cwd). User-editable but not part of reyn's source — per-project
+# customization belongs in operator's workspace, not the repo.
+chainlit.md
+.chainlit/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ web = [
     "uvicorn[standard]>=0.27",
     "websockets>=12",
 ]
+# `reyn chainlit` PoC: Chainlit を別 surface として共存させる薄い CLI 起動口。
+# Web UI (= `reyn web` + openui) と TUI (= `reyn chat`) と並列に動かす。
+chainlit = ["chainlit>=2.0"]
 mcp = ["mcp>=1.0"]
 release = [
     "build>=1.0",

--- a/src/reyn/chainlit_app/__init__.py
+++ b/src/reyn/chainlit_app/__init__.py
@@ -1,0 +1,13 @@
+"""reyn × Chainlit integration (PoC).
+
+Surface: ``reyn chainlit`` launches Chainlit's dev server which loads
+``app.py`` in this package. Coexists with ``reyn chat`` (TUI) and
+``reyn web`` (FastAPI + openui) — all three share the same
+``ChatSession`` / `OutboxMessage` model defined in ``reyn.chat``.
+
+Module layout:
+- ``adapter``: pure function mapping ``OutboxMessage`` → Chainlit payload.
+  No chainlit import, so unit tests run without the ``[chainlit]`` extra.
+- ``app``: Chainlit-side glue (@cl.on_chat_start / @cl.on_message).
+  Imports chainlit at module level — only loaded by ``chainlit run``.
+"""

--- a/src/reyn/chainlit_app/adapter.py
+++ b/src/reyn/chainlit_app/adapter.py
@@ -1,0 +1,78 @@
+"""OutboxMessage → Chainlit payload mapper.
+
+Pure conversion layer with no chainlit dependency. Unit tests can
+exercise this without installing the ``[chainlit]`` extra.
+
+PoC kind coverage:
+- ``agent``        → main reply, author "agent"
+- ``skill_done``   → green-bordered system note, author "skill"
+- ``status``       → dim hint, author "status"
+- ``error``        → red note, author "error"
+- ``intervention`` → author "intervention" (full handler is V2 — for
+                     PoC just render as text)
+- ``trace``        → dropped (debug noise)
+- ``system``       → author "system" (plan_summary / plan_complete /
+                     plan_aborted bridge messages)
+- ``__stream_*__`` → dropped (TUI-only incremental render kinds)
+- ``__end__``      → sentinel, signals drain to stop (returns None)
+- anything else    → author "system", text passed through
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from reyn.chat.outbox import OutboxMessage
+
+
+@dataclass(frozen=True)
+class ChainlitPayload:
+    """What the chainlit drain loop should send to the browser.
+
+    ``role`` selects the cl-side renderer branch:
+    - ``"message"``: ``cl.Message(author=author, content=content).send()``
+    - ``"error"``: ``cl.ErrorMessage(content=content).send()``
+    - ``"end"``: drain loop terminates (no send)
+
+    Drain loop callers should treat ``None`` (= drop) and ``role="end"``
+    as separate signals: ``None`` skip-this-frame, ``end`` exit-loop.
+    """
+    role: str
+    author: str
+    content: str
+
+
+def outbox_to_chainlit(msg: OutboxMessage) -> ChainlitPayload | None:
+    """Map one OutboxMessage to a Chainlit payload, or None to drop.
+
+    Returns:
+        - ``ChainlitPayload(role="end", ...)`` for ``kind="__end__"``.
+        - ``None`` for kinds the PoC intentionally drops
+          (``trace``, ``__stream_*__`` incremental render frames).
+        - ``ChainlitPayload(role="error", ...)`` for ``kind="error"``.
+        - ``ChainlitPayload(role="message", author=<label>, content=<text>)``
+          for everything else.
+    """
+    kind = msg.kind
+    text = msg.text or ""
+
+    if kind == "__end__":
+        return ChainlitPayload(role="end", author="", content="")
+
+    if kind.startswith("__stream_") or kind == "trace":
+        return None
+
+    if kind == "error":
+        return ChainlitPayload(role="error", author="error", content=text)
+
+    author = {
+        "agent": "agent",
+        "status": "status",
+        "skill_done": "skill",
+        "intervention": "intervention",
+        "system": "system",
+    }.get(kind, "system")
+
+    return ChainlitPayload(role="message", author=author, content=text)
+
+
+__all__ = ["ChainlitPayload", "outbox_to_chainlit"]

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -1,0 +1,207 @@
+"""Chainlit entry point for reyn — loaded by ``python -m chainlit run``.
+
+The `reyn chainlit` CLI subcommand shells out to chainlit with this
+file as the target. ``@cl.on_chat_start`` builds (or reuses) an
+``AgentRegistry``, attaches the default agent, and starts a background
+task that drains ``registry.repl_outbox`` → ``cl.Message.send()``.
+``@cl.on_message`` forwards user input via ``submit_user_text`` so the
+existing ``session.run()`` loop picks it up.
+
+PoC scope (= explicitly out of scope for this PR, follow-ons):
+- multi-user isolation: today all browser sessions share one process
+  ``AgentRegistry`` and compete for the single ``attached`` slot; true
+  per-cl-session sandboxing needs a registry-per-session refactor or
+  an N-attached multi-foreground extension.
+- intervention UI: ``kind="intervention"`` is rendered as plain text;
+  no ``cl.AskUserMessage`` round-trip wiring yet.
+- streaming: ``__stream_*__`` incremental frames are dropped; only the
+  final ``agent`` kind reaches the browser.
+- skill selection / per-agent attach / cost panel: none of the right-panel
+  TUI affordances exist; only the central chat thread.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import chainlit as cl
+
+from reyn.chainlit_app.adapter import outbox_to_chainlit
+
+if TYPE_CHECKING:
+    from reyn.chat.registry import AgentRegistry
+
+_DRAIN_KEY = "reyn_drain_task"
+_REGISTRY_LOCK = asyncio.Lock()
+_REGISTRY: "AgentRegistry | None" = None
+
+
+def _agent_name_from_env() -> str:
+    return os.environ.get("REYN_CHAINLIT_AGENT", "default")
+
+
+async def _get_or_build_registry() -> "AgentRegistry":
+    """Process-singleton registry, built lazily on first chat start.
+
+    Mirrors the construction order in ``cli/commands/chat.py``:
+    BudgetTracker → hydrate → PermissionResolver → AgentRegistry.
+
+    The web (``reyn.web.deps``) and chainlit gateways intentionally do
+    not share their bootstrap helper today: web/deps imports fastapi at
+    module level, so chainlit can't reach it without the ``[web]``
+    extra. A follow-on can extract a shared ``reyn.chat.bootstrap``
+    when there is a third surface (= when the duplication actually
+    costs something).
+    """
+    global _REGISTRY
+    async with _REGISTRY_LOCK:
+        if _REGISTRY is not None:
+            return _REGISTRY
+
+        import argparse
+
+        from reyn.budget.budget import BudgetTracker
+        from reyn.chat.profile import AgentProfile
+        from reyn.chat.registry import AgentRegistry
+        from reyn.chat.session import ChatSession
+        from reyn.cli.session import Session
+        from reyn.config import _find_project_root, load_project_context
+        from reyn.events.state_log import StateLog
+        from reyn.permissions.permissions import PermissionResolver
+
+        # Reuse the same yaml-loading path the CLI uses so reyn.yaml /
+        # reyn.local.yaml / env overrides Just Work. The *_for(args)
+        # helpers do ``getattr(args, "...", None)`` everywhere, so an
+        # empty Namespace gives us config defaults across the board.
+        empty_args = argparse.Namespace()
+        session_cfg = Session.from_args(empty_args)
+        model, _resolved = session_cfg.model_for(empty_args)
+        output_language = session_cfg.output_language_for(empty_args)
+        safety = session_cfg.safety_for(empty_args)
+
+        project_root = _find_project_root(Path.cwd()) or Path.cwd()
+        state_log = StateLog(project_root / ".reyn" / "state" / "wal.jsonl")
+        budget_tracker = BudgetTracker(session_cfg.config.cost, safety=safety)
+        budget_tracker.hydrate(
+            project_root / ".reyn" / "state" / "budget_ledger.jsonl"
+        )
+        budget_state_path = (
+            project_root / ".reyn" / "state" / "budget_state.json"
+        )
+        budget_tracker.load_state(budget_state_path)
+        budget_tracker.set_state_path(budget_state_path)
+
+        perm_config = getattr(session_cfg.config, "permissions", {}) or {}
+        perm_resolver = PermissionResolver(
+            config_permissions=perm_config,
+            project_root=project_root,
+            interactive=False,
+            unsafe_python_allowed=False,
+        )
+
+        project_context = load_project_context(session_cfg.config, project_root)
+
+        registry_ref: list = []
+
+        def _session_factory(profile: AgentProfile) -> ChatSession:
+            s = ChatSession(
+                agent_name=profile.name,
+                model=model,
+                resolver=session_cfg.resolver,
+                permission_resolver=perm_resolver,
+                safety=safety,
+                mcp_servers=session_cfg.config.mcp,
+                output_language=output_language,
+                prompt_cache_enabled=session_cfg.config.prompt_cache_enabled,
+                project_context=project_context,
+                agent_role=profile.role,
+                compaction_config=session_cfg.config.chat.compaction,
+                registry=registry_ref[0],
+                allowed_skills=profile.allowed_skills,
+                allowed_mcp=profile.allowed_mcp,
+                events_config=session_cfg.config.events,
+                state_log=state_log,
+                budget_tracker=budget_tracker,
+                sandbox_config=session_cfg.config.sandbox,
+                multimodal_config=session_cfg.config.multimodal,
+                action_retrieval_config=session_cfg.config.action_retrieval,
+                embedding_config=session_cfg.config.embedding,
+                agent_id=session_cfg.config.agent.id,
+            )
+            s.load_history()
+            return s
+
+        registry = AgentRegistry(
+            project_root=project_root,
+            session_factory=_session_factory,
+            state_log=state_log,
+        )
+        registry_ref.append(registry)
+        _REGISTRY = registry
+        return registry
+
+
+async def _drain_loop(registry: "AgentRegistry") -> None:
+    """Pump ``registry.repl_outbox`` to the Chainlit browser session.
+
+    Runs as a per-cl-session background task. Terminates on ``__end__``
+    sentinel (= session shutdown) or task cancellation.
+    """
+    while True:
+        msg = await registry.repl_outbox.get()
+        payload = outbox_to_chainlit(msg)
+        if payload is None:
+            continue
+        if payload.role == "end":
+            return
+        if payload.role == "error":
+            await cl.ErrorMessage(content=payload.content).send()
+        else:
+            await cl.Message(
+                content=payload.content,
+                author=payload.author,
+            ).send()
+
+
+@cl.on_chat_start
+async def _on_chat_start() -> None:
+    registry = await _get_or_build_registry()
+    name = _agent_name_from_env()
+    if not registry.exists(name):
+        await cl.ErrorMessage(
+            content=(
+                f"Agent {name!r} not found. Create it with "
+                f"`reyn agent new {name}` and reload."
+            )
+        ).send()
+        return
+
+    await registry.restore_all()
+    await registry.attach(name)
+    task = asyncio.create_task(_drain_loop(registry))
+    cl.user_session.set(_DRAIN_KEY, task)
+    await cl.Message(
+        content=f"Connected to agent **{name}**.",
+        author="system",
+    ).send()
+
+
+@cl.on_message
+async def _on_message(message: cl.Message) -> None:
+    registry = await _get_or_build_registry()
+    session = registry.attached_session()
+    if session is None:
+        await cl.ErrorMessage(
+            content="No agent attached. Reload the page to reconnect.",
+        ).send()
+        return
+    await session.submit_user_text(message.content)
+
+
+@cl.on_chat_end
+async def _on_chat_end() -> None:
+    task = cl.user_session.get(_DRAIN_KEY)
+    if task is not None:
+        task.cancel()

--- a/src/reyn/cli/commands/__init__.py
+++ b/src/reyn/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from . import agent as agent
 from . import auth as auth
+from . import chainlit as chainlit
 from . import chat as chat
 from . import config as config
 from . import cron as cron
@@ -28,4 +29,4 @@ from . import topology as topology
 from . import web as web
 
 # Order is the order shown in `reyn --help`.
-ALL = [init, config, skills, skill, run, chat, agent, topology, eval, lint, memory, permissions, auth, events, web, mcp, secret, source, cron, dogfood]
+ALL = [init, config, skills, skill, run, chat, agent, topology, eval, lint, memory, permissions, auth, events, web, chainlit, mcp, secret, source, cron, dogfood]

--- a/src/reyn/cli/commands/chainlit.py
+++ b/src/reyn/cli/commands/chainlit.py
@@ -1,0 +1,104 @@
+"""`reyn chainlit` — Chainlit ベースの Web チャット UI を起動する (PoC)。
+
+Chainlit (https://chainlit.io) を `python -m chainlit run` 経由で起動し、
+``src/reyn/chainlit_app/app.py`` に定義した @cl.on_chat_start /
+@cl.on_message ハンドラ越しに `ChatSession` と接続する。
+
+TUI (`reyn chat`) / FastAPI Web UI (`reyn web`) と共存する第三の surface:
+- 既存 `reyn web` (FP-0013 MessageBus + openui) と同じ "サーバ起動" 体験
+- 各 Chainlit ブラウザセッション = 独立の `ChatSession`
+- multi-user は Chainlit 側 WebSocket セッション分離に乗る
+
+このコマンドは reyn の `[chainlit]` オプション依存を必要とする:
+    pip install -e ".[chainlit]"
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "chainlit",
+        help="Chainlit Web チャット UI を起動する (PoC)",
+        description=(
+            "Chainlit を起動して http://<host>:<port>/ から reyn にチャットする。\n"
+            "インストール: pip install -e \".[chainlit]\""
+        ),
+    )
+    p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        metavar="HOST",
+        help="バインドするホスト (デフォルト: 127.0.0.1)",
+    )
+    p.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        metavar="PORT",
+        help="バインドするポート (デフォルト: 8000 = chainlit default)",
+    )
+    p.add_argument(
+        "--watch",
+        action="store_true",
+        help="コード変更時に自動リロードする (= chainlit --watch、 開発用)",
+    )
+    p.add_argument(
+        "--headless",
+        action="store_true",
+        help="起動時にブラウザを開かない (= chainlit --headless)",
+    )
+    p.set_defaults(func=run)
+
+
+def _app_module_path() -> Path:
+    """Resolve ``src/reyn/chainlit_app/app.py`` for the running install."""
+    return Path(__file__).resolve().parents[2] / "chainlit_app" / "app.py"
+
+
+def run(args: argparse.Namespace) -> None:
+    try:
+        import chainlit  # noqa: F401
+    except ImportError:
+        print(
+            "Error: chainlit is not installed. "
+            "Run `pip install -e \".[chainlit]\"` to install Chainlit.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    app_path = _app_module_path()
+    if not app_path.is_file():
+        print(
+            f"Error: reyn chainlit app entry not found at {app_path}. "
+            "Reinstall reyn or report a bug.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cmd: list[str] = [
+        sys.executable,
+        "-m",
+        "chainlit",
+        "run",
+        str(app_path),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+    ]
+    if args.watch:
+        cmd.append("--watch")
+    if args.headless:
+        cmd.append("--headless")
+
+    env = os.environ.copy()
+    try:
+        subprocess.run(cmd, env=env, check=False)
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/cli/test_chainlit_adapter.py
+++ b/tests/cli/test_chainlit_adapter.py
@@ -1,0 +1,77 @@
+"""Tier 1: OutboxMessage → ChainlitPayload mapping contract.
+
+The adapter is the single boundary between reyn's outbox kinds and
+Chainlit's render primitives. This test pins the mapping so a kind
+rename / new kind doesn't silently start being dropped or mis-rendered.
+
+Lives in ``reyn.chainlit_app.adapter`` (= pure module, no chainlit
+import) so this test runs without the ``[chainlit]`` extra installed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chainlit_app.adapter import ChainlitPayload, outbox_to_chainlit
+from reyn.chat.outbox import OutboxMessage
+
+
+@pytest.mark.parametrize(
+    "kind,expected_role,expected_author",
+    [
+        ("agent", "message", "agent"),
+        ("status", "message", "status"),
+        ("skill_done", "message", "skill"),
+        ("intervention", "message", "intervention"),
+        ("system", "message", "system"),
+        ("error", "error", "error"),
+    ],
+)
+def test_known_kinds_map_to_expected_payload(
+    kind: str, expected_role: str, expected_author: str
+):
+    """Tier 1: each PoC-supported kind lands the right (role, author)."""
+    msg = OutboxMessage(kind=kind, text="hello")
+    payload = outbox_to_chainlit(msg)
+    assert isinstance(payload, ChainlitPayload)
+    assert payload.role == expected_role
+    assert payload.author == expected_author
+    assert payload.content == "hello"
+
+
+def test_end_sentinel_returns_end_role():
+    """Tier 1: ``__end__`` produces an end-role payload (drain loop terminator)."""
+    msg = OutboxMessage(kind="__end__", text="")
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.role == "end"
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["__stream_user__", "__stream_agent__", "__stream_partial__", "trace"],
+)
+def test_dropped_kinds_return_none(kind: str):
+    """Tier 1: incremental / trace kinds are dropped (= return None)."""
+    msg = OutboxMessage(kind=kind, text="incremental")
+    assert outbox_to_chainlit(msg) is None
+
+
+def test_unknown_kind_falls_back_to_system_author():
+    """Tier 1: unrecognised kind renders as a system message (not dropped),
+    so a future kind addition surfaces in the browser instead of being silently
+    eaten."""
+    msg = OutboxMessage(kind="some_future_kind", text="future text")
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.role == "message"
+    assert payload.author == "system"
+    assert payload.content == "future text"
+
+
+def test_empty_text_is_preserved_as_empty_string():
+    """Tier 1: missing text field becomes "" not None (chainlit cl.Message
+    rejects None content)."""
+    msg = OutboxMessage(kind="agent", text="")
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.content == ""

--- a/tests/cli/test_chainlit_command_smoke.py
+++ b/tests/cli/test_chainlit_command_smoke.py
@@ -1,0 +1,84 @@
+"""Tier 1: `reyn chainlit` CLI argparse + missing-extra fallback.
+
+Two contracts pinned:
+1. ``register(sub)`` adds the ``chainlit`` subcommand with
+   ``--host`` / ``--port`` / ``--watch`` / ``--headless`` flags.
+2. When ``chainlit`` is not installed, ``run()`` prints a hint to
+   stderr and exits with status 1 (= same UX as ``reyn web``).
+
+The actual chainlit subprocess invocation is exercised manually
+(= Test plan item). These tests cover the argparse + fallback paths
+that ship in every environment.
+"""
+from __future__ import annotations
+
+import argparse
+import builtins
+import sys
+
+import pytest
+
+from reyn.cli.commands.chainlit import register, run
+
+
+def _make_parser_with_chainlit() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    register(sub)
+    return parser
+
+
+def test_chainlit_subcommand_default_flags():
+    """Tier 1: bare ``chainlit`` invocation lands all default values."""
+    parser = _make_parser_with_chainlit()
+    args = parser.parse_args(["chainlit"])
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+    assert args.watch is False
+    assert args.headless is False
+
+
+def test_chainlit_subcommand_overrides_parse():
+    """Tier 1: --host / --port / --watch / --headless all accepted."""
+    parser = _make_parser_with_chainlit()
+    args = parser.parse_args(
+        ["chainlit", "--host", "0.0.0.0", "--port", "9000",
+         "--watch", "--headless"]
+    )
+    assert args.host == "0.0.0.0"
+    assert args.port == 9000
+    assert args.watch is True
+    assert args.headless is True
+
+
+def test_chainlit_missing_dependency_hint(monkeypatch, capsys):
+    """Tier 1: import error path prints install hint and exits non-zero."""
+    real_import = builtins.__import__
+
+    def _fail_chainlit(name, *args, **kwargs):
+        if name == "chainlit":
+            raise ImportError("No module named 'chainlit'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail_chainlit)
+
+    ns = argparse.Namespace(
+        host="127.0.0.1", port=8000, watch=False, headless=False,
+    )
+    with pytest.raises(SystemExit) as ei:
+        run(ns)
+    assert ei.value.code == 1
+    err = capsys.readouterr().err
+    assert "chainlit" in err.lower()
+    assert "pip install" in err
+
+
+def test_chainlit_subcommand_registered_in_build_parser():
+    """Tier 1: ``reyn chainlit`` is discoverable via the top-level parser
+    (= chainlit module is wired into ``commands.__init__.ALL``)."""
+    from reyn.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["chainlit", "--port", "9999"])
+    assert args.command == "chainlit"
+    assert args.port == 9999

--- a/tests/test_session_factory_multimodal_config_uniform.py
+++ b/tests/test_session_factory_multimodal_config_uniform.py
@@ -70,6 +70,7 @@ _CALL_SITE_FILES = [
     "src/reyn/cli/commands/dogfood.py",
     "src/reyn/cli/commands/mcp.py",
     "src/reyn/web/deps.py",
+    "src/reyn/chainlit_app/app.py",
 ]
 
 

--- a/tests/test_session_factory_sandbox_config_uniform.py
+++ b/tests/test_session_factory_sandbox_config_uniform.py
@@ -64,6 +64,7 @@ _CALL_SITE_FILES = [
     "src/reyn/cli/commands/dogfood.py",
     "src/reyn/cli/commands/mcp.py",
     "src/reyn/web/deps.py",
+    "src/reyn/chainlit_app/app.py",
 ]
 
 


### PR DESCRIPTION
**[tui-coder]** — Chainlit を `reyn web` / `reyn chat` (TUI) と並ぶ第三の surface として薄く加える PoC。 user direction (= 既存 webui (openui) 完成度が低い、 Chainlit 化したい / TUI 共存 / multi-user 想定) に応じて Pattern C (= sidecar) で着地。

## Summary

- `reyn chainlit --host --port [--watch --headless]` を追加 (= `reyn web` と同じ ergonomics)
- `python -m chainlit run` に shell-out して `src/reyn/chainlit_app/app.py` を loader として渡す
- `@cl.on_chat_start` で `AgentRegistry` を build (process-singleton)、 default agent attach、 `registry.repl_outbox` → `cl.Message.send()` の drain task を per-cl-session で start
- `@cl.on_message` → `session.submit_user_text(text)` で既存 `session.run()` loop へ流す
- adapter は pure module (= chainlit import 無し) で `OutboxMessage` → `(role, author, content)` を mapping、 unit test は `[chainlit]` extra 無しで走る

## Why Chainlit (= sequencing 判断)

FP に **Event Store Backend (FP-0018)** 案があったが、 これは EventStore の storage 抽象化 (JSONL → SQLite/DuckDB) で **subscribe / push の話ではない** → Chainlit 接続の prerequisite ではない。 関連は **FP-0013 Unified Inbox/Outbox Transport** で、 これは既に **done (2026-05-14、 commits `11d96dc`→`bdd9235`)**。 MessageBus + TransportRef + RoutingLayer + pumping model が landed 済 → Chainlit は registry の repl_outbox を per-cl-session subscriber として乗せるだけで動く。

= FP-0018 を待たずに Chainlit PoC を出せる。

## Scope (= PoC、 explicit follow-ons あり)

含むもの:
- CLI `reyn chainlit` + chainlit subprocess 起動
- 単一 `default` agent attach + outbox drain
- `agent` / `status` / `error` / `skill_done` / `intervention` / `system` kind の cl.Message 化
- `__stream_*__` / `trace` は drop (= noise 抑制)
- `error` は `cl.ErrorMessage` 経由
- `__end__` で drain loop 終了

明示的に follow-on (= この PR 範囲外):
- **multi-user 真の isolation**: 現在 process-singleton registry + 単一 attach slot で全 cl session を共有 → 同時 2 user は最後の attach に上書きされる。 registry-per-cl-session または N-attached multi-foreground extension で対応
- **FP-0016 auth wiring**: identity / per-user agent_id 紐付けは未着手 (= lead-coder 領域)
- **persistence source-of-truth**: 既存 `.reyn/state/*` を共有しているだけ、 マルチユーザ前提の sharding / per-user workspace 未設計
- **intervention UI round-trip**: `cl.AskUserMessage` を使った双方向 IV 未実装、 PoC では text として表示
- **streaming**: `__stream_*__` 全 drop、 incremental display は V2
- **right panel parity**: cost / events / agents / docs などの TUI 右 panel 相当機能は無し

## Test plan

- [x] **Tier 1 contract tests** — `pytest tests/cli/test_chainlit_command_smoke.py tests/cli/test_chainlit_adapter.py` (17 tests, 全 緑)
- [x] **CLI parser regression** — `pytest tests/test_chat_cli_flags.py tests/test_cli_source.py` (40 tests, 全 緑)
- [x] **ruff** — `ruff check` clean on all new files
- [x] **build_parser 統合** — `reyn chainlit` が top-level parser 経由で discoverable (= test_chainlit_subcommand_registered_in_build_parser でカバー)
- [ ] (skipped — chainlit extra not installed in dev env) **Manual: chainlit subprocess 起動** — `pip install -e ".[chainlit]" && reyn chainlit --headless --port 9000` でブラウザに welcome message が出る
- [ ] (skipped — chainlit extra not installed in dev env) **Manual: user message round-trip** — 上記環境で 1 turn 流れる (= user → cl.Message → adapter → cl render)
- [ ] (skipped — chainlit extra not installed in dev env) **Manual: drain loop kind 別 render** — agent / status / error / skill_done が各 author 表示で render される

Manual 3 項目は `[chainlit]` extra を install できる環境 (= reviewer 側 or 後続 dogfood) でチェック必要。 PoC scope なので blocking ではないが merge 前に 1 度は実機確認したい。

## Tier self-check

- ✅ Tier 1: contract tests のみ (= argparse + adapter pure mapping)
- ✅ private state assert 無し (= adapter は public dataclass、 CLI は argparse Namespace)
- ✅ MagicMock / AsyncMock 使用無し (= 実 import + monkeypatch 1 箇所のみ)
- ✅ snapshot test 無し
- ✅ test docstring 1 行目で Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)