### PR TITLE
feat(chainlit): reyn-branded welcome + starter prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,7 @@ spike_results/
 # chainlit.md welcome page + .chainlit/{config.toml,translations/} in
 # cwd). User-editable but not part of reyn's source — per-project
 # customization belongs in operator's workspace, not the repo.
-chainlit.md
-.chainlit/
+# Anchored to repo root so the shipped asset under
+# src/reyn/chainlit_app/assets/chainlit.md is tracked.
+/chainlit.md
+/.chainlit/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ where = ["src"]
 include = ["reyn*"]
 
 [tool.setuptools.package-data]
-"reyn" = ["py.typed", "stdlib/**/*"]
+"reyn" = ["py.typed", "stdlib/**/*", "chainlit_app/assets/**/*"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -165,6 +165,43 @@ async def _drain_loop(registry: "AgentRegistry") -> None:
             ).send()
 
 
+@cl.set_starters
+async def _starters() -> list[cl.Starter]:
+    """Welcome-screen quick prompts (= reyn-flavored examples).
+
+    Visible only on the very first message; replaced by the live chat
+    once the user sends anything. Keep these grounded in capabilities
+    that work today (= no streaming / IV round-trip dependency).
+    """
+    return [
+        cl.Starter(
+            label="自分の reyn agent を一覧する",
+            message="このプロジェクトに設定されている agent を一覧してください。",
+        ),
+        cl.Starter(
+            label="reyn の Skill を 1 つ動かしてみる",
+            message=(
+                "今このプロジェクトで使える stdlib skill を 1 つ選んで、"
+                "短い試走をしてください。 何が起きるか教えてください。"
+            ),
+        ),
+        cl.Starter(
+            label="MEMORY.md を読んで自己紹介",
+            message=(
+                "プロジェクト root の MEMORY.md と CLAUDE.md を読んで、"
+                "あなた (= attach されている agent) の役割を 3 行で説明してください。"
+            ),
+        ),
+        cl.Starter(
+            label="今の cost と events を要約",
+            message=(
+                "直近の events log と今セッションの token / cost を"
+                "簡潔に教えてください。"
+            ),
+        ),
+    ]
+
+
 @cl.on_chat_start
 async def _on_chat_start() -> None:
     registry = await _get_or_build_registry()

--- a/src/reyn/chainlit_app/assets/chainlit.md
+++ b/src/reyn/chainlit_app/assets/chainlit.md
@@ -1,0 +1,22 @@
+# reyn × Chainlit
+
+[reyn](https://github.com/tya5/reyn) は LLM 駆動の **Phase × Skill × OS** エージェントランタイム。 この画面は `reyn chainlit` で立ち上がる Web チャット surface (= TUI `reyn chat` / FastAPI `reyn web` と並列)。
+
+## できること (PoC scope)
+
+- メッセージを送るとアタッチ済の agent (= 既定 `default`) が応答
+- skill の実行結果 / status / error は author 別 (= `agent` / `skill` / `status` / `error`) で表示
+- 同 agent state (history / skills / events) を TUI / web と共有
+
+## まだできないこと (= follow-on)
+
+- streaming (= token-by-token 表示)
+- intervention の双方向応答 (= `cl.AskUserMessage` round-trip)
+- right panel 相当 (= cost / events / agents / docs)
+- multi-user 真の isolation (= 同時 2 user で attach 上書き)
+
+## 操作
+
+ブラウザ画面下の入力欄から普通にメッセージを送るだけ。 slash command (`/help` 等) は未配線 (= follow-on)。
+
+設定変更したい場合: cwd の `chainlit.md` (このファイル) と `.chainlit/config.toml` を編集 → Chainlit が hot-reload。

--- a/src/reyn/chainlit_app/first_run.py
+++ b/src/reyn/chainlit_app/first_run.py
@@ -1,0 +1,41 @@
+"""First-run asset copy for `reyn chainlit`.
+
+When the operator launches ``reyn chainlit`` in a directory that has
+never hosted a Chainlit app, Chainlit auto-creates a generic
+``chainlit.md`` welcome page. This module ships a reyn-branded version
+in ``assets/chainlit.md`` and copies it into ``cwd`` first — same
+idempotent pattern as Chainlit's own ``init_config()`` (= copy only if
+the destination doesn't exist).
+
+Operator customization is preserved: once they edit ``chainlit.md``,
+subsequent launches see it exists and skip the copy.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def assets_dir() -> Path:
+    """Return the directory holding shipped first-run assets."""
+    return Path(__file__).resolve().parent / "assets"
+
+
+def ensure_chainlit_md(target_dir: Path) -> Path | None:
+    """Copy ``chainlit.md`` from assets to ``target_dir`` if absent.
+
+    Returns the destination path when a copy actually happened, ``None``
+    when the file already existed (= operator customization preserved).
+    """
+    src = assets_dir() / "chainlit.md"
+    if not src.is_file():
+        return None
+    dst = target_dir / "chainlit.md"
+    if dst.exists():
+        return None
+    target_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    return dst
+
+
+__all__ = ["assets_dir", "ensure_chainlit_md"]

--- a/src/reyn/cli/commands/chainlit.py
+++ b/src/reyn/cli/commands/chainlit.py
@@ -81,6 +81,13 @@ def run(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    # First-run UX: drop a reyn-branded chainlit.md into cwd so the
+    # operator sees reyn context (not chainlit's generic boilerplate)
+    # the first time they hit the URL. Idempotent — operator edits
+    # are preserved on subsequent launches.
+    from reyn.chainlit_app.first_run import ensure_chainlit_md
+    ensure_chainlit_md(Path.cwd())
+
     cmd: list[str] = [
         sys.executable,
         "-m",

--- a/tests/cli/test_chainlit_first_run.py
+++ b/tests/cli/test_chainlit_first_run.py
@@ -1,0 +1,54 @@
+"""Tier 1: ``reyn.chainlit_app.first_run.ensure_chainlit_md`` contract.
+
+The CLI calls this before launching chainlit so the operator's first
+visit sees a reyn-branded welcome rather than chainlit's generic
+boilerplate. Two invariants pinned:
+
+1. **Initial drop**: in an empty cwd, the shipped asset is copied in
+   and the destination path is returned.
+2. **Idempotent**: a second call on the same cwd is a no-op and
+   returns ``None`` — operator edits between launches are preserved.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.chainlit_app.first_run import assets_dir, ensure_chainlit_md
+
+
+def test_assets_dir_contains_chainlit_md():
+    """Tier 1: the shipped asset exists at the expected path."""
+    src = assets_dir() / "chainlit.md"
+    assert src.is_file(), f"shipped chainlit.md missing at {src}"
+
+
+def test_ensure_chainlit_md_creates_when_absent(tmp_path: Path):
+    """Tier 1: empty cwd → copy happens, destination path returned."""
+    result = ensure_chainlit_md(tmp_path)
+    assert result == tmp_path / "chainlit.md"
+    assert result.is_file()
+    # Content equality — same bytes as the shipped asset.
+    assert (
+        result.read_bytes()
+        == (assets_dir() / "chainlit.md").read_bytes()
+    )
+
+
+def test_ensure_chainlit_md_skips_when_present(tmp_path: Path):
+    """Tier 1: existing file → no overwrite, returns None (= operator
+    customization preserved across launches)."""
+    custom = tmp_path / "chainlit.md"
+    custom.write_text("# operator's custom welcome\n")
+    result = ensure_chainlit_md(tmp_path)
+    assert result is None
+    assert custom.read_text() == "# operator's custom welcome\n"
+
+
+def test_ensure_chainlit_md_creates_target_dir(tmp_path: Path):
+    """Tier 1: missing target dir → mkdir(parents=True) makes it."""
+    nested = tmp_path / "deeply" / "nested" / "cwd"
+    assert not nested.exists()
+    result = ensure_chainlit_md(nested)
+    assert result is not None
+    assert nested.is_dir()
+    assert (nested / "chainlit.md").is_file()


### PR DESCRIPTION
**[tui-coder]** — Chainlit follow-on #1 (stacked on #886 PoC)。 user 判断「chainlit でできることにどんどん対応進めてほしい、 reyn 内部は後回し」 (= 2026-05-24) に応じた純 chainlit-side 改善。

## Summary

- 起動時 chainlit が出す generic "untitled assistant" welcome を **reyn-branded `chainlit.md`** に差し替え (= shipped asset + CLI が first-run で cwd に copy、 idempotent)
- 空 welcome screen に **4 つ starter prompt** を表示 (= `@cl.set_starters`):
  - 自分の reyn agent を一覧
  - reyn の Skill を 1 つ動かしてみる
  - MEMORY.md を読んで自己紹介
  - 今の cost と events を要約
- `reyn.chainlit_app.first_run` モジュール新規 + Tier 1 4 tests
- `pyproject.toml` に `chainlit_app/assets/**/*` を package-data 追加 (= pip install で welcome template 同梱)
- `.gitignore` の chainlit パターンを repo root anchor (`/chainlit.md`, `/.chainlit/`) に修正、 shipped asset 保護

## Why scope-limited

memory `chainlit-focus-no-internals` (2026-05-24) に従い、 `src/reyn/chainlit_app/` 配下 + CLI + tests + pyproject + gitignore のみ touch。 reyn engine (= `src/reyn/chat/`, `src/reyn/events/`, etc) には一切手を入れない。

## Stacked base

base = `feat/tui-chainlit-cli-scaffold` (= #886)。 #886 merge 後に rebase + base を main に変更します。 stack depth = 1、 依存は #886 で導入する `reyn.chainlit_app` モジュール (= 純 add、 #886 と conflict 可能性低)。

## Test plan

- [x] **Tier 1 first_run contract** — `pytest tests/cli/test_chainlit_first_run.py` (4 tests 緑)
- [x] **Full chainlit-side suite** — `pytest tests/cli/test_chainlit_*` (21 tests 緑)
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — `@cl.set_starters` デコレータ追加でも crash 無し
- [ ] (skipped — visual confirmation needed, can do post-merge dogfood) **Manual: starters が welcome screen に表示**
- [ ] (skipped — same) **Manual: 初回起動で cwd に reyn-branded chainlit.md がコピーされる**
- [ ] (skipped — same) **Manual: 2 回目以降の起動で chainlit.md が上書きされない (= operator edit 保護)**

local server 9001 で実機 verify 予定 (= user に refresh してもらう)。

## Tier self-check

- ✅ Tier 1 only (= file copy contract + asset existence)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)