### PR TITLE
feat(chainlit): agent picker via cl.set_chat_profiles

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 import chainlit as cl
 
 from reyn.chainlit_app.adapter import outbox_to_chainlit
+from reyn.chainlit_app.profiles import list_agent_profiles
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry
@@ -165,6 +166,25 @@ async def _drain_loop(registry: "AgentRegistry") -> None:
             ).send()
 
 
+@cl.set_chat_profiles
+async def _chat_profiles() -> list[cl.ChatProfile]:
+    """Expose every agent on disk as a chainlit chat profile picker entry.
+
+    The browser's chat-profile dropdown lets the operator choose which
+    reyn agent to attach for the current chat session. With multiple
+    agents declared on disk, the picker appears at the top of the
+    welcome screen; with only one (= `default`) chainlit hides it.
+
+    Selection is stored on ``cl.user_session["chat_profile"]`` and read
+    in ``_on_chat_start`` to drive ``registry.attach(<picked>)``.
+    """
+    registry = await _get_or_build_registry()
+    return [
+        cl.ChatProfile(**dct.as_kwargs())
+        for dct in list_agent_profiles(registry)
+    ]
+
+
 @cl.set_starters
 async def _starters() -> list[cl.Starter]:
     """Welcome-screen quick prompts (= reyn-flavored examples).
@@ -202,10 +222,25 @@ async def _starters() -> list[cl.Starter]:
     ]
 
 
+def _picked_agent_name(default: str) -> str:
+    """Resolve which agent to attach for this cl session.
+
+    Priority: chat-profile picker selection > REYN_CHAINLIT_AGENT env > ``default``.
+    Picker selection lands on ``cl.user_session["chat_profile"]`` when
+    the operator picks one — chainlit only shows the picker when
+    ``set_chat_profiles`` returns >= 2 entries, so the env fallback
+    covers the single-agent case where no picker is rendered.
+    """
+    picked = cl.user_session.get("chat_profile")
+    if isinstance(picked, str) and picked.strip():
+        return picked.strip()
+    return default
+
+
 @cl.on_chat_start
 async def _on_chat_start() -> None:
     registry = await _get_or_build_registry()
-    name = _agent_name_from_env()
+    name = _picked_agent_name(_agent_name_from_env())
     if not registry.exists(name):
         await cl.ErrorMessage(
             content=(

--- a/src/reyn/chainlit_app/profiles.py
+++ b/src/reyn/chainlit_app/profiles.py
@@ -1,0 +1,70 @@
+"""Agent profile listing for Chainlit's chat-profile picker.
+
+Pure helper (= no chainlit import) so unit tests run without the
+``[chainlit]`` extra. The decorator-side caller in ``app`` consumes the
+returned dicts and wraps each with ``cl.ChatProfile(**d)``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _RegistryLike(Protocol):
+    """Minimal surface this module needs from ``AgentRegistry``.
+
+    Defined as a Protocol so the unit tests can pass a tiny fake
+    without dragging in the real registry's constructor dependencies
+    (StateLog / config / etc.).
+    """
+
+    def list_names(self) -> list[str]: ...
+
+    def load_profile(self, name: str) -> "_ProfileLike": ...
+
+
+class _ProfileLike(Protocol):
+    name: str
+    role: str
+
+
+@dataclass(frozen=True)
+class ChatProfileDict:
+    """Plain-data shape consumed by ``cl.ChatProfile(**fields)``.
+
+    Mirrors ``chainlit.ChatProfile``'s public fields. Keeping the dict
+    here (instead of importing cl.ChatProfile) lets tests run without
+    the [chainlit] extra.
+    """
+    name: str
+    markdown_description: str
+    icon: str | None = None
+
+    def as_kwargs(self) -> dict:
+        out = {"name": self.name, "markdown_description": self.markdown_description}
+        if self.icon is not None:
+            out["icon"] = self.icon
+        return out
+
+
+_NO_ROLE_MARKER = "_(no role description)_"
+
+
+def list_agent_profiles(registry: _RegistryLike) -> list[ChatProfileDict]:
+    """Return one ChatProfileDict per agent on disk.
+
+    Picks each agent's ``role`` as the markdown description; falls back
+    to a dim italic marker when role is empty. Agents are sorted by
+    name (= same order as ``registry.list_names()``), so the picker is
+    stable across reloads.
+    """
+    out: list[ChatProfileDict] = []
+    for name in registry.list_names():
+        profile = registry.load_profile(name)
+        role = (getattr(profile, "role", "") or "").strip()
+        description = role if role else _NO_ROLE_MARKER
+        out.append(ChatProfileDict(name=name, markdown_description=description))
+    return out
+
+
+__all__ = ["ChatProfileDict", "list_agent_profiles"]

--- a/tests/cli/test_chainlit_profiles.py
+++ b/tests/cli/test_chainlit_profiles.py
@@ -1,0 +1,101 @@
+"""Tier 1: ``reyn.chainlit_app.profiles.list_agent_profiles`` contract.
+
+The chainlit-side ``@cl.set_chat_profiles`` decorator consumes the
+list this helper returns and wraps each entry with
+``cl.ChatProfile(**dict.as_kwargs())``. Three invariants pinned:
+
+1. Each on-disk agent surfaces as exactly one ChatProfileDict.
+2. Empty-role agents land a fallback markdown marker (= the picker
+   should never show a blank description cell).
+3. Order is whatever ``registry.list_names()`` returns (= the
+   registry's stable sort), so the picker order is reproducible.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from reyn.chainlit_app.profiles import (
+    _NO_ROLE_MARKER,
+    ChatProfileDict,
+    list_agent_profiles,
+)
+
+
+@dataclass
+class _FakeProfile:
+    name: str
+    role: str
+
+
+class _FakeRegistry:
+    """Smallest possible thing that satisfies ``list_agent_profiles``."""
+
+    def __init__(self, profiles: list[_FakeProfile]) -> None:
+        self._profiles = {p.name: p for p in profiles}
+        # ``registry.list_names()`` returns names sorted on disk; mirror that.
+        self._order = sorted(self._profiles)
+
+    def list_names(self) -> list[str]:
+        return list(self._order)
+
+    def load_profile(self, name: str) -> _FakeProfile:
+        return self._profiles[name]
+
+
+def test_returns_one_dict_per_agent():
+    """Tier 1: 3 on-disk agents → 3 ChatProfileDict entries, in registry order."""
+    reg = _FakeRegistry([
+        _FakeProfile(name="default", role="general assistant"),
+        _FakeProfile(name="alpha", role="research"),
+        _FakeProfile(name="beta", role="code review"),
+    ])
+    out = list_agent_profiles(reg)
+    assert [d.name for d in out] == ["alpha", "beta", "default"]
+    assert [d.markdown_description for d in out] == [
+        "research", "code review", "general assistant",
+    ]
+
+
+def test_empty_role_uses_fallback_marker():
+    """Tier 1: empty / whitespace-only role → italic placeholder so the
+    picker cell is never blank."""
+    reg = _FakeRegistry([
+        _FakeProfile(name="bare", role=""),
+        _FakeProfile(name="space", role="   "),
+        _FakeProfile(name="real", role="has a role"),
+    ])
+    out = {d.name: d.markdown_description for d in list_agent_profiles(reg)}
+    assert out["bare"] == _NO_ROLE_MARKER
+    assert out["space"] == _NO_ROLE_MARKER
+    assert out["real"] == "has a role"
+
+
+def test_as_kwargs_omits_icon_when_none():
+    """Tier 1: ``ChatProfileDict.as_kwargs`` matches ``cl.ChatProfile``'s
+    accepted kwargs; ``icon`` omitted unless set so chainlit picks its
+    default avatar."""
+    d = ChatProfileDict(name="x", markdown_description="y")
+    assert d.as_kwargs() == {"name": "x", "markdown_description": "y"}
+    d2 = ChatProfileDict(name="x", markdown_description="y", icon="/foo.png")
+    assert d2.as_kwargs() == {
+        "name": "x", "markdown_description": "y", "icon": "/foo.png",
+    }
+
+
+def test_role_attr_missing_treated_as_empty():
+    """Tier 1: a profile-like object without ``role`` attribute (= future
+    AgentProfile shape change) still works — fallback to marker, no crash."""
+
+    @dataclass
+    class _RolelessProfile:
+        name: str
+
+    class _Reg:
+        def list_names(self) -> list[str]:
+            return ["x"]
+        def load_profile(self, name: str) -> _RolelessProfile:
+            return _RolelessProfile(name=name)
+
+    out = list_agent_profiles(_Reg())
+    assert len(out) == 1
+    assert out[0].markdown_description == _NO_ROLE_MARKER


### PR DESCRIPTION
**[tui-coder]** — Chainlit follow-on #2 (stacked on #887 → #886)。 user 判断「chainlit でできることにどんどん対応進めて、 reyn 内部は後回し」 (2026-05-24) に沿って純 chainlit-side で agent picker を追加。

## Summary

- 現状: chainlit 起動時 hardcoded `default` agent に attach、 multi-agent project だと他 agent に届かない
- 改善: `@cl.set_chat_profiles` で `.reyn/agents/<name>/profile.yaml` 全 agent を picker entry として表示、 操作者が選択 → 選んだ agent に attach
- 単一 agent (= default のみ) project は元と同じ UX (= chainlit が <2 profile で picker 隠す + env / default fallback で attach)

## 実装

- `reyn.chainlit_app.profiles` (新) — pure helper `list_agent_profiles(registry)` → `list[ChatProfileDict]`。 chainlit import 無し、 tests は [chainlit] extra 不要で走る
- `@cl.set_chat_profiles` in `app.py` が helper の dict を `cl.ChatProfile(**kwargs)` でラップ
- `_picked_agent_name(default)` resolver: `cl.user_session["chat_profile"]` > `REYN_CHAINLIT_AGENT` env > `default` の優先順位
- 空 role agent は `_(no role description)_` 斜体プレースホルダ → picker セル空白回避

## Stacked base

base = `feat/tui-chainlit-welcome-starters` (= #887、 さらに #886 の上)。 stack depth = 2。 #886 → #887 → 本 PR の順で merge 想定。 各 PR 独立 review 可、 dep 関係は純 add (= 互いの touch point 無し)。

## Why scope-limited

memory `chainlit-focus-no-internals` (2026-05-24) 準拠:
- touch 範囲: `src/reyn/chainlit_app/` + tests のみ
- reyn engine 不変 (= `registry.list_names()` / `registry.load_profile()` は既存 public API、 signature 変更無し)

## Test plan

- [x] **Tier 1 picker helper** — `pytest tests/cli/test_chainlit_profiles.py` (4 tests 緑)
- [x] **Full chainlit-side suite** — `pytest tests/cli/test_chainlit_*` (25 tests 緑)
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — `@cl.set_chat_profiles` デコレータ追加でも crash 無し
- [ ] (skipped — visual confirmation needed, post-merge dogfood) **Manual: 複数 agent (= `reyn agent new alpha` 後) でブラウザに picker 表示**
- [ ] (skipped — same) **Manual: picker で alpha 選択 → attach 後の `Connected to agent **alpha**` system message**
- [ ] (skipped — same) **Manual: 単一 agent project で picker 非表示 + 従来挙動維持**

local server 9001 で 1, 3 番 verify 予定 (user に refresh 依頼)。 2 番は `reyn agent new alpha` 必要。

## Tier self-check

- ✅ Tier 1 only (= pure helper contract)
- ✅ private state assert 無し (= ChatProfileDict は public dataclass)
- ✅ MagicMock / AsyncMock 無し (= _FakeRegistry + Protocol で型のみ)
- ✅ snapshot test 無し
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)