### PR TITLE
feat(chainlit): wire attachment-button uploads into multimodal queue

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -30,6 +30,7 @@ import chainlit as cl
 
 from reyn.chainlit_app.adapter import outbox_to_chainlit
 from reyn.chainlit_app.profiles import list_agent_profiles
+from reyn.chainlit_app.uploads import collect_image_blocks
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry
@@ -269,6 +270,18 @@ async def _on_message(message: cl.Message) -> None:
             content="No agent attached. Reload the page to reconnect.",
         ).send()
         return
+
+    # Multimodal upload bridge: any image element dropped via the
+    # chainlit attachment button rides the same ``_pending_user_images``
+    # queue that ``/image PATH`` uses. The queue is drained on the
+    # next user turn by ``ChatSession._handle_user_message``.
+    elements = getattr(message, "elements", None) or []
+    if elements:
+        blocks = collect_image_blocks(elements)
+        queue = getattr(session, "_pending_user_images", None)
+        if queue is not None and blocks:
+            queue.extend(blocks)
+
     await session.submit_user_text(message.content)
 
 

--- a/src/reyn/chainlit_app/uploads.py
+++ b/src/reyn/chainlit_app/uploads.py
@@ -1,0 +1,107 @@
+"""Convert chainlit ``Element`` uploads into reyn's image-attach queue.
+
+Reyn's ``/image`` slash and ``ChatSession._handle_user_message`` already
+share a per-session queue (``session._pending_user_images: list[dict]``)
+drained on the next user turn. This module mirrors that queue's
+contract from the chainlit side so a file dropped via chainlit's
+attachment button rides the same code path as a typed ``/image PATH``.
+
+The block shape is the path-ref form introduced by issue #383 PR-C
+(= storage points at the file on disk; LLM-call time reads + embeds
+binary). Mirrored here so we don't fork the wire shape.
+
+Supported extensions mirror ``reyn.chat.slash.image._IMAGE_EXTENSIONS``
+(= same set ``file__read`` accepts via #365). Non-image elements
+(.pdf / audio / video / etc.) are dropped — multimodal pipelines for
+those are V2.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+# Mirror reyn.chat.slash.image._IMAGE_EXTENSIONS. Duplicated rather
+# than imported because the slash module pulls in ChatSession
+# internals; the chainlit adapter intentionally stays decoupled from
+# that import graph so unit tests run fast.
+_IMAGE_EXTENSIONS: dict[str, str] = {
+    ".png":  "image/png",
+    ".jpg":  "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif":  "image/gif",
+    ".webp": "image/webp",
+    ".svg":  "image/svg+xml",
+}
+
+
+@dataclass(frozen=True)
+class _ElementLike:
+    """Minimal subset of ``chainlit.Element`` the helper needs.
+
+    The real chainlit Element has many fields; we only touch path /
+    mime / name so tests can pass a small fake.
+    """
+    path: str | None = None
+    mime: str | None = None
+    name: str | None = None
+
+
+def _mime_for_path(path: Path) -> str | None:
+    return _IMAGE_EXTENSIONS.get(path.suffix.lower())
+
+
+def build_image_block(element_path: str, *, element_mime: str | None = None) -> dict | None:
+    """Build a path-ref image block for ``_pending_user_images``.
+
+    Returns ``None`` when the file is missing, has an unsupported
+    extension, or can't be read (= permission / IO failure). The
+    chainlit side drops silently and continues with text + remaining
+    elements; explicit error messaging is the caller's responsibility.
+    """
+    p = Path(element_path)
+    if not p.is_file():
+        return None
+    mime = _mime_for_path(p) or (
+        element_mime if (element_mime or "").startswith("image/") else None
+    )
+    if mime is None:
+        return None
+    try:
+        data = p.read_bytes()
+    except OSError:
+        return None
+    content_hash = "sha256:" + hashlib.sha256(data).hexdigest()
+    return {
+        "type": "image",
+        "path": str(p.resolve()),
+        "mime_type": mime,
+        "content_hash": content_hash,
+    }
+
+
+def collect_image_blocks(elements: list) -> list[dict]:
+    """Walk a chainlit ``Message.elements`` list, returning supported image blocks.
+
+    Non-image elements + unreadable paths are dropped. The returned
+    order preserves the input order so the caller's enqueue keeps the
+    upload sequence intact.
+    """
+    out: list[dict] = []
+    for el in elements or []:
+        path = getattr(el, "path", None)
+        if not path:
+            continue
+        mime = getattr(el, "mime", None)
+        block = build_image_block(str(path), element_mime=mime)
+        if block is not None:
+            out.append(block)
+    return out
+
+
+__all__ = [
+    "_IMAGE_EXTENSIONS",
+    "_ElementLike",
+    "build_image_block",
+    "collect_image_blocks",
+]

--- a/tests/cli/test_chainlit_uploads.py
+++ b/tests/cli/test_chainlit_uploads.py
@@ -1,0 +1,136 @@
+"""Tier 1: ``reyn.chainlit_app.uploads`` contract.
+
+Chainlit's attachment button drops files onto disk + hands a
+``Message.elements`` list to ``@cl.on_message``. The uploads module
+converts each supported image element into the same path-ref block
+shape ``reyn.chat.slash.image`` writes to
+``session._pending_user_images``. This test pins:
+
+1. Supported extensions are accepted (= same set as the slash
+   command + ``file__read`` via #365).
+2. Unsupported extensions are dropped (= silent skip, not crash).
+3. Missing / unreadable paths are dropped.
+4. ``content_hash`` uses sha256 prefix shape (= path-ref boundary
+   for drift detection in materialisation).
+5. Order preserved across ``collect_image_blocks`` (= upload sequence
+   intact when caller enqueues).
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from reyn.chainlit_app.uploads import (
+    _IMAGE_EXTENSIONS,
+    build_image_block,
+    collect_image_blocks,
+)
+
+
+@dataclass
+class _FakeElement:
+    """Mimics chainlit Element's path / mime / name surface."""
+    path: str | None = None
+    mime: str | None = None
+    name: str | None = None
+
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64  # minimal not-a-real-PNG
+
+
+def _write_png(tmp_path: Path, name: str = "shot.png") -> Path:
+    p = tmp_path / name
+    p.write_bytes(_PNG_BYTES)
+    return p
+
+
+@pytest.mark.parametrize("ext,expected_mime", sorted(_IMAGE_EXTENSIONS.items()))
+def test_supported_extensions_build_blocks(
+    tmp_path: Path, ext: str, expected_mime: str
+):
+    """Tier 1: each whitelisted extension → block with correct mime."""
+    p = _write_png(tmp_path, f"x{ext}")
+    block = build_image_block(str(p))
+    assert block is not None
+    assert block["type"] == "image"
+    assert block["mime_type"] == expected_mime
+    assert block["path"] == str(p.resolve())
+
+
+def test_unsupported_extension_is_dropped(tmp_path: Path):
+    """Tier 1: .txt / .pdf / unknown → returns None (silent skip)."""
+    p = tmp_path / "doc.txt"
+    p.write_bytes(b"hello")
+    assert build_image_block(str(p)) is None
+
+
+def test_missing_file_is_dropped(tmp_path: Path):
+    """Tier 1: nonexistent path → returns None, no exception."""
+    assert build_image_block(str(tmp_path / "ghost.png")) is None
+
+
+def test_content_hash_uses_sha256_prefix(tmp_path: Path):
+    """Tier 1: content_hash is ``sha256:<hex>`` (= matches reyn slash shape
+    so the materialisation path's drift detector works uniformly)."""
+    p = _write_png(tmp_path)
+    block = build_image_block(str(p))
+    assert block is not None
+    assert block["content_hash"].startswith("sha256:")
+    expected = "sha256:" + hashlib.sha256(_PNG_BYTES).hexdigest()
+    assert block["content_hash"] == expected
+
+
+def test_mime_override_from_element_used_when_extension_unknown(tmp_path: Path):
+    """Tier 1: element-side mime ``image/png`` is accepted even when the
+    file extension wouldn't normally match (= chainlit's stored upload
+    keeps a UUID name with no useful suffix)."""
+    p = tmp_path / "uuid_no_extension"
+    p.write_bytes(_PNG_BYTES)
+    block = build_image_block(str(p), element_mime="image/png")
+    assert block is not None
+    assert block["mime_type"] == "image/png"
+
+
+def test_mime_override_non_image_still_dropped(tmp_path: Path):
+    """Tier 1: element-side mime ``application/pdf`` → dropped (= image-only
+    PoC, V2 expands to other multimodal kinds)."""
+    p = tmp_path / "doc"
+    p.write_bytes(b"%PDF")
+    assert build_image_block(str(p), element_mime="application/pdf") is None
+
+
+def test_collect_preserves_order(tmp_path: Path):
+    """Tier 1: 3 elements in order → 3 blocks in same order (= upload sequence)."""
+    a = _write_png(tmp_path, "a.png")
+    b = _write_png(tmp_path, "b.png")
+    c = _write_png(tmp_path, "c.png")
+    elements = [_FakeElement(path=str(p)) for p in (a, b, c)]
+    out = collect_image_blocks(elements)
+    assert [block["path"] for block in out] == [
+        str(a.resolve()), str(b.resolve()), str(c.resolve()),
+    ]
+
+
+def test_collect_skips_non_image_silently(tmp_path: Path):
+    """Tier 1: mixed list → image kept, non-image dropped, no exception."""
+    img = _write_png(tmp_path, "good.png")
+    txt = tmp_path / "bad.txt"
+    txt.write_bytes(b"hi")
+    elements = [
+        _FakeElement(path=str(img)),
+        _FakeElement(path=str(txt)),
+        _FakeElement(path=None),
+        _FakeElement(path=str(tmp_path / "ghost.png")),
+    ]
+    out = collect_image_blocks(elements)
+    assert len(out) == 1
+    assert out[0]["path"] == str(img.resolve())
+
+
+def test_collect_handles_empty_or_none(tmp_path: Path):
+    """Tier 1: empty list / None → empty list (= safe to call unconditionally)."""
+    assert collect_image_blocks([]) == []
+    assert collect_image_blocks(None) == []  # type: ignore[arg-type]


### PR DESCRIPTION
**[tui-coder]** — Chainlit follow-on (= #888 と並列、 base=main 独立)。 user dogfood 観察 2026-05-24「添付ファイルボタンあるけど、 これもマルチモーダルと繋がってるの？」 → **繋がっていなかった** → 繋ぐ。

## 問題

`_on_message` ハンドラが `message.content` (text) しか読まず、 `message.elements` (uploaded files) を **silent drop**。 chainlit のデフォルト UI でアップロードボタンが表示されるが、 ファイルが reyn 側に届かない 「ボタン押せるけど何も起きない」 状態。

## 解決

1. `reyn.chainlit_app.uploads` モジュール新規 (pure):
   - `build_image_block(path, *, element_mime=None) -> dict | None` — path-ref block shape (#383 PR-C) を構築
   - `collect_image_blocks(elements: list) -> list[dict]` — supported subset を取り出して順序保持
2. `_on_message` で `message.elements` を `collect_image_blocks` に通して `session._pending_user_images` queue に extend (= `/image` slash と同じ queue)
3. 次 user turn で既存 `ChatSession._handle_user_message` が queue を drain (= 既存パス、 reyn 側変更無し)

サポート対象: png / jpg / jpeg / gif / webp / svg (= `reyn.chat.slash.image._IMAGE_EXTENSIONS` と同 set)。 PDF / audio / video / 不明 mime は **silent drop** (= V2)。

## Why scope-limited

memory `chainlit-focus-no-internals` (2026-05-24) 準拠 — `src/reyn/chainlit_app/` + tests のみ touch、 reyn engine 不変。 `_pending_user_images` は既存 reyn convention (= `/image` slash + ChatSession で確立)、 同じ getattr pattern で参照。

## Test plan

- [x] **Tier 1 uploads** — `pytest tests/cli/test_chainlit_uploads.py` (13 tests 緑、 extension table / hash shape / order / mime override / empty handling)
- [x] **Full chainlit-side suite** — 35 tests 緑
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — `from reyn.chainlit_app.uploads import` 追加でも crash 無し
- [ ] (skipped — needs browser interaction with file picker) **Manual: ブラウザでクリップ アイコンから png upload → 「これ何の画像?」 と聞いて画像認識する**

post-merge dogfood で user 実機確認お願いします。

## Tier self-check

- ✅ Tier 1 only (= pure helper contract)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)