### PR TITLE
feat(chainlit): replay chat history on attach so agent switches keep context

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 import chainlit as cl
 
 from reyn.chainlit_app.adapter import outbox_to_chainlit
+from reyn.chainlit_app.history import history_to_chainlit
 from reyn.chainlit_app.profiles import list_agent_profiles
 
 if TYPE_CHECKING:
@@ -251,7 +252,18 @@ async def _on_chat_start() -> None:
         return
 
     await registry.restore_all()
-    await registry.attach(name)
+    session = await registry.attach(name)
+
+    # Replay prior chat turns from ``ChatSession.history`` (= what
+    # ``load_history`` read from ``history.jsonl``) so the operator
+    # sees the conversation they had previously with this agent
+    # instead of an empty thread on every re-attach / browser open.
+    history = getattr(session, "history", None) or []
+    for entry in history_to_chainlit(history):
+        await cl.Message(
+            content=entry.content, author=entry.author,
+        ).send()
+
     task = asyncio.create_task(_drain_loop(registry))
     cl.user_session.set(_DRAIN_KEY, task)
     await cl.Message(

--- a/src/reyn/chainlit_app/history.py
+++ b/src/reyn/chainlit_app/history.py
@@ -1,0 +1,128 @@
+"""Render reyn's ``session.history`` into a list of Chainlit-ready entries.
+
+When the operator switches to a different agent via the chat-profile
+picker (or just opens a new browser tab on the same agent), chainlit
+spins up a fresh per-session UI thread — but the reyn-side
+``ChatSession.history`` already holds every prior turn from disk
+(``load_history`` reads ``history.jsonl``). Without replay, the
+operator sees an empty conversation while the agent still
+"remembers" everything from the LLM side, which is confusing.
+
+This module is the pure conversion layer. ``app._on_chat_start``
+calls ``history_to_chainlit(session.history)`` and pushes each
+returned tuple via ``cl.Message`` before starting the live drain.
+
+Filter policy (= mirrors the CUI / TUI renderer's visible set):
+- ``user`` / ``assistant`` → kept, author label same as live outbox
+- ``tool`` / ``system`` / ``summary`` / ``skill_event`` → dropped
+  (= LLM-wire entries or Reyn-internal markers, not chat-thread turns)
+
+Multimodal content (= list-of-dict parts on user / tool turns) is
+flattened to its text parts only — image / file parts are shown as
+``[image: <name>]`` markers because chainlit can't re-display a
+file that lives only as a path-ref on the operator's disk without
+re-uploading.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+
+class _MessageLike(Protocol):
+    """The minimal surface ``history_to_chainlit`` reads on each entry.
+
+    Defined as a Protocol so tests can pass a tiny fake without
+    instantiating the real ``ChatMessage`` (= avoids dragging in
+    ChatSession's full import graph).
+    """
+    role: str
+    content: "str | list[dict]"
+
+
+@dataclass(frozen=True)
+class HistoryEntry:
+    """One Chainlit-ready replay frame.
+
+    The drain-loop callers convert this to
+    ``cl.Message(author=author, content=content).send()``.
+    """
+    author: str
+    content: str
+
+
+# Authors mirror ``adapter.outbox_to_chainlit`` for the same role so a
+# replayed turn looks identical to a live one in the chat thread.
+_AUTHOR_BY_ROLE = {
+    "user": "user",
+    "assistant": "agent",
+}
+
+# Roles intentionally dropped from the chat thread. Kept as an
+# explicit set so future ChatMessage role additions surface as a
+# silent drop (= caller can grep for this set when adding a new
+# role) instead of accidentally rendering as a fallback.
+_DROPPED_ROLES = frozenset({
+    "tool", "system", "summary", "skill_event",
+})
+
+
+def _flatten_content(content: "str | list[dict]") -> str:
+    """Pull a renderable text string out of ChatMessage's content union.
+
+    String content → returned verbatim. List content (= multimodal)
+    → text parts concatenated by newline, image / file parts replaced
+    by ``[image: <name>]`` markers so the operator sees something was
+    there without breaking the layout.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    chunks: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        kind = part.get("type")
+        if kind == "text":
+            text = part.get("text") or ""
+            if text:
+                chunks.append(text)
+        elif kind == "image":
+            path = part.get("path") or ""
+            name = path.rsplit("/", 1)[-1] if path else "image"
+            chunks.append(f"[image: {name}]")
+        elif kind == "image_url":
+            chunks.append("[image]")
+        # other / unknown part shapes — drop silently; future
+        # ChatMessage extensions land here as no-op until explicitly
+        # wired (= same conservative posture as _DROPPED_ROLES).
+    return "\n".join(chunks)
+
+
+def history_to_chainlit(history: Iterable[_MessageLike]) -> list[HistoryEntry]:
+    """Convert ``ChatSession.history`` into a list of replay-ready entries.
+
+    Order preserved (= chronological), drops applied per
+    ``_DROPPED_ROLES``. Empty-text turns (= ``content`` flattens to ``""``)
+    are also dropped so the replay doesn't emit blank cells.
+    """
+    out: list[HistoryEntry] = []
+    for msg in history:
+        role = getattr(msg, "role", "")
+        if role in _DROPPED_ROLES:
+            continue
+        author = _AUTHOR_BY_ROLE.get(role)
+        if author is None:
+            continue
+        text = _flatten_content(getattr(msg, "content", ""))
+        if not text:
+            continue
+        out.append(HistoryEntry(author=author, content=text))
+    return out
+
+
+__all__ = [
+    "HistoryEntry",
+    "history_to_chainlit",
+]

--- a/tests/cli/test_chainlit_history.py
+++ b/tests/cli/test_chainlit_history.py
@@ -1,0 +1,145 @@
+"""Tier 1: ``reyn.chainlit_app.history`` contract.
+
+Pinned invariants:
+
+1. ``user`` / ``assistant`` roles land in the output; chainlit-side
+   author labels match the live outbox adapter's mapping.
+2. ``tool`` / ``system`` / ``summary`` / ``skill_event`` roles are
+   dropped (= LLM-wire / Reyn-internal markers that don't belong in
+   the chat thread).
+3. Unknown role (= future ChatMessage role addition) is dropped, not
+   rendered with a fallback author — same conservative posture as
+   the ``_DROPPED_ROLES`` set so a new role surfaces as a silent
+   skip until explicitly wired.
+4. Multimodal ``content`` (= ``list[dict]`` of parts) flattens to
+   text parts plus ``[image: <name>]`` markers for image parts.
+5. Empty-content turns are dropped so the replay doesn't emit blank
+   message cells.
+6. Order preserved (= chronological replay).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from reyn.chainlit_app.history import HistoryEntry, history_to_chainlit
+
+
+@dataclass
+class _FakeMsg:
+    role: str
+    content: "str | list[dict]" = ""
+    meta: dict = field(default_factory=dict)
+
+
+def test_user_and_assistant_roles_pass_through():
+    """Tier 1: user → author="user", assistant → author="agent"."""
+    out = history_to_chainlit([
+        _FakeMsg(role="user", content="hi"),
+        _FakeMsg(role="assistant", content="hello"),
+    ])
+    assert out == [
+        HistoryEntry(author="user", content="hi"),
+        HistoryEntry(author="agent", content="hello"),
+    ]
+
+
+def test_internal_roles_dropped():
+    """Tier 1: tool / system / summary / skill_event filtered out."""
+    out = history_to_chainlit([
+        _FakeMsg(role="tool", content="tool result"),
+        _FakeMsg(role="system", content="system prompt"),
+        _FakeMsg(role="summary", content="compaction summary"),
+        _FakeMsg(role="skill_event", content="skill marker"),
+    ])
+    assert out == []
+
+
+def test_unknown_role_dropped_not_fallback():
+    """Tier 1: unrecognised role (= future ChatMessage extension)
+    does NOT render with a fallback author — drops silently so the
+    addition surfaces as a deliberate wiring task."""
+    out = history_to_chainlit([
+        _FakeMsg(role="future_role", content="surprise"),
+    ])
+    assert out == []
+
+
+def test_multimodal_list_content_extracts_text_parts():
+    """Tier 1: list-of-parts content → text concatenated by newline,
+    image parts → ``[image: <name>]`` markers."""
+    out = history_to_chainlit([
+        _FakeMsg(role="user", content=[
+            {"type": "text", "text": "look at this"},
+            {"type": "image", "path": "/tmp/shot.png", "mime_type": "image/png"},
+            {"type": "text", "text": "what is it?"},
+        ]),
+    ])
+    assert len(out) == 1
+    assert out[0].author == "user"
+    assert out[0].content == "look at this\n[image: shot.png]\nwhat is it?"
+
+
+def test_multimodal_image_without_path_uses_generic_marker():
+    """Tier 1: image part with empty path → ``[image]`` (= no name)."""
+    out = history_to_chainlit([
+        _FakeMsg(role="user", content=[
+            {"type": "image", "path": "", "mime_type": "image/png"},
+        ]),
+    ])
+    assert out == [HistoryEntry(author="user", content="[image: image]")]
+
+
+def test_image_url_part_renders_as_image_marker():
+    """Tier 1: ``image_url`` part (= data-URL form) → ``[image]`` marker."""
+    out = history_to_chainlit([
+        _FakeMsg(role="user", content=[
+            {"type": "image_url", "image_url": {"url": "data:..."}},
+        ]),
+    ])
+    assert out == [HistoryEntry(author="user", content="[image]")]
+
+
+def test_empty_content_dropped():
+    """Tier 1: turns whose flattened content is empty are dropped so
+    blank cells don't show up on replay."""
+    out = history_to_chainlit([
+        _FakeMsg(role="user", content=""),
+        _FakeMsg(role="assistant", content=""),
+        _FakeMsg(role="user", content=[]),
+        _FakeMsg(role="assistant", content=[{"type": "unknown_kind"}]),
+    ])
+    assert out == []
+
+
+def test_chronological_order_preserved():
+    """Tier 1: order in input → order in output (= the operator sees
+    the conversation in the same sequence they had it)."""
+    out = history_to_chainlit([
+        _FakeMsg(role="user", content="1"),
+        _FakeMsg(role="assistant", content="2"),
+        _FakeMsg(role="user", content="3"),
+        _FakeMsg(role="assistant", content="4"),
+    ])
+    assert [e.content for e in out] == ["1", "2", "3", "4"]
+    assert [e.author for e in out] == ["user", "agent", "user", "agent"]
+
+
+def test_empty_history_returns_empty_list():
+    """Tier 1: no history (= fresh agent) → ``[]`` (= no replay frames)."""
+    assert history_to_chainlit([]) == []
+
+
+def test_mixed_visible_and_internal_roles_filters_correctly():
+    """Tier 1: realistic mixed history — only user/assistant survive
+    in their original order."""
+    out = history_to_chainlit([
+        _FakeMsg(role="system", content="boot"),
+        _FakeMsg(role="user", content="q1"),
+        _FakeMsg(role="assistant", content="a1"),
+        _FakeMsg(role="tool", content="tool resp"),
+        _FakeMsg(role="assistant", content="a1b"),
+        _FakeMsg(role="user", content="q2"),
+        _FakeMsg(role="summary", content="compaction"),
+        _FakeMsg(role="assistant", content="a2"),
+    ])
+    assert [e.content for e in out] == ["q1", "a1", "a1b", "q2", "a2"]


### PR DESCRIPTION
**[tui-coder]** — Chainlit follow-on (= base=main 独立、 #890 と並列)。 user dogfood 観察 2026-05-24 「agent 切り替えると以前のチャット履歴が消えてる。 やむなし？」 → **やむなし ではなく chainlit 側未実装**。 → 実装。

## 問題

agent picker (#888) で別 agent に切り替える / ブラウザを開き直すと、 chainlit の chat thread はゼロから始まる。 reyn 側 `session.history` (= `load_history` が `history.jsonl` から読み込む list[ChatMessage]) は全 turn 保持済で agent は LLM 側で「覚えている」 が、 UI に映らない → 操作者は混乱、 LLM 側との認識ズレ。

## 解決

`@cl.on_chat_start` で `await registry.attach(name)` が返す session の `.history` を読み、 各 visible turn を `cl.Message.send()` で replay してから live drain を start。

## 実装

1. `reyn.chainlit_app.history` (new、 pure):
   - `history_to_chainlit(history) -> list[HistoryEntry]`、 chainlit import 無し、 [chainlit] extra 不要で test 走る
   - filter: `user` / `assistant` のみ render、 `tool` / `system` / `summary` / `skill_event` は LLM-wire / Reyn-internal なので drop
   - 不明 role (= 将来 ChatMessage 拡張) は silent drop (= `_DROPPED_ROLES` set と同 posture)
2. multimodal content (= `list[dict]`) は text 部分を newline で結合、 image 部分は `[image: <name>]` marker で代替 (= chainlit は path-ref image を再 upload 無しで再表示できないため)
3. 空 content turn は drop (= blank cell 防止)
4. `_on_chat_start` を `session = await registry.attach(name)` で session 受け、 replay → drain start → `Connected to agent **...**` system message の順

## Why scope-limited

memory `chainlit-focus-no-internals` (2026-05-24) 準拠 — `src/reyn/chainlit_app/` + tests のみ touch、 reyn engine 不変。 `session.history` / `ChatMessage` は既存 public surface、 read-only access。

## Test plan

- [x] **Tier 1 history helper** — `pytest tests/cli/test_chainlit_history.py` (10 tests 緑、 role filter / multimodal flatten / image marker / empty drop / order)
- [x] **Full chainlit-side suite** — 35 tests 緑
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — `from reyn.chainlit_app.history import` 追加でも crash 無し
- [ ] (skipped — needs browser interaction with agent switch) **Manual: agent を 2 つ用意 → 1 つ目で何か会話 → 2 つ目に切替 → 1 つ目に戻ると過去 turn 表示**
- [ ] (skipped — same) **Manual: 履歴 0 件の agent (= 初対面) で空 thread (= 何も replay されない、 welcome のみ)**
- [ ] (skipped — same) **Manual: image 含む turn → `[image: shot.png]` marker で表示**

local server 9001 で 1, 2 番 verify 予定 (user に refresh 依頼)。

## Tier self-check

- ✅ Tier 1 only (= pure helper contract)
- ✅ private state assert なし (= HistoryEntry は public dataclass)
- ✅ MagicMock / AsyncMock なし (= _FakeMsg dataclass + Protocol)
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)