### PR TITLE
feat(chainlit): slash routing + quick-action buttons in welcome

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -31,6 +31,12 @@ import chainlit as cl
 from reyn.chainlit_app.adapter import outbox_to_chainlit
 from reyn.chainlit_app.history import history_to_chainlit
 from reyn.chainlit_app.profiles import list_agent_profiles
+from reyn.chainlit_app.slash_route import (
+    QUICK_ACTIONS,
+    QuickAction,
+    action_name_for,
+    is_slash,
+)
 from reyn.chainlit_app.uploads import collect_image_blocks
 
 if TYPE_CHECKING:
@@ -267,9 +273,18 @@ async def _on_chat_start() -> None:
 
     task = asyncio.create_task(_drain_loop(registry))
     cl.user_session.set(_DRAIN_KEY, task)
+    actions = [
+        cl.Action(
+            name=action_name_for(qa),
+            label=qa.label,
+            payload={"slash": qa.slash_text},
+        )
+        for qa in QUICK_ACTIONS
+    ]
     await cl.Message(
         content=f"Connected to agent **{name}**.",
         author="system",
+        actions=actions,
     ).send()
 
 
@@ -294,7 +309,58 @@ async def _on_message(message: cl.Message) -> None:
         if queue is not None and blocks:
             queue.extend(blocks)
 
-    await session.submit_user_text(message.content)
+    # Slash routing parity with the CUI / TUI surfaces. ``submit_user_text``
+    # bypasses slash dispatch — slash handling lives on the wrapper layer
+    # via ``session._maybe_handle_slash``. Without this, typing ``/help``
+    # would be sent to the agent as plain text instead of running the
+    # slash command. Returning True from the dispatcher consumes the line
+    # (including unknown slashes, which get a hint on the outbox).
+    text = message.content or ""
+    if is_slash(text):
+        await session._maybe_handle_slash(text)
+        return
+
+    await session.submit_user_text(text)
+
+
+async def _run_quick_action(action_payload: dict) -> None:
+    """Shared handler body for every ``slash_<name>`` action callback.
+
+    Lives outside the decorator so the per-action wrappers stay tiny
+    and the dispatch logic is testable on its own.
+    """
+    registry = await _get_or_build_registry()
+    session = registry.attached_session()
+    if session is None:
+        await cl.ErrorMessage(
+            content="No agent attached. Reload the page to reconnect.",
+        ).send()
+        return
+    slash_text = action_payload.get("slash") if action_payload else None
+    if not isinstance(slash_text, str) or not is_slash(slash_text):
+        return
+    await session._maybe_handle_slash(slash_text)
+
+
+def _register_action_callbacks() -> None:
+    """Bind one ``@cl.action_callback("slash_<name>")`` per QuickAction.
+
+    Done at module load via a loop so adding a new entry to
+    ``QUICK_ACTIONS`` is the only edit needed — no duplicated handler
+    boilerplate per command.
+    """
+
+    def _make_handler(qa: QuickAction):
+        async def _handler(action: cl.Action) -> None:
+            await _run_quick_action(getattr(action, "payload", None) or {})
+        _handler.__name__ = f"_on_action_{qa.name}"
+        return _handler
+
+    for qa in QUICK_ACTIONS:
+        cl.action_callback(action_name_for(qa))(_make_handler(qa))
+
+
+_register_action_callbacks()
 
 
 @cl.on_chat_end

--- a/src/reyn/chainlit_app/slash_route.py
+++ b/src/reyn/chainlit_app/slash_route.py
@@ -1,0 +1,75 @@
+"""Pure helpers for routing slash commands from the chainlit surface.
+
+``ChatSession.submit_user_text`` bypasses slash dispatch (= slash
+handling lives on the TUI / CUI wrappers via
+``session._maybe_handle_slash``). The chainlit ``@cl.on_message`` glue
+mirrors the same pattern: if the typed content starts with ``/``,
+route to the session's slash dispatcher; otherwise hand it to
+``submit_user_text`` as a normal user turn.
+
+This module also catalogs a small set of "quick action" slash
+commands surfaced as ``cl.Action`` buttons on the welcome message so
+operators don't have to memorize the slash vocabulary.
+
+No chainlit import here — kept pure so tests run without the
+``[chainlit]`` extra.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def is_slash(text: str) -> bool:
+    """Return True when ``text`` looks like a slash command.
+
+    Empty / None / leading-whitespace strings are NOT considered slash
+    (= chainlit's input box trims most whitespace already; this keeps
+    behavior predictable for the rare leading-space paste).
+    """
+    if not text:
+        return False
+    return text.startswith("/")
+
+
+@dataclass(frozen=True)
+class QuickAction:
+    """A welcome-message button entry.
+
+    - ``name``: stable id used by ``@cl.action_callback("slash_<name>")``.
+      Prefixed at the call site to namespace away from other actions.
+    - ``label``: button label the operator clicks (e.g. ``"/agents"``).
+    - ``slash_text``: full slash command sent to
+      ``session._maybe_handle_slash`` when clicked.
+    """
+    name: str
+    label: str
+    slash_text: str
+
+
+# Quick-action buttons rendered on the welcome message. Curated to
+# read-only / quick-info commands so a stray click never has
+# side-effects. Adding entries here is the single edit point for the
+# chainlit welcome button row.
+QUICK_ACTIONS: tuple[QuickAction, ...] = (
+    QuickAction(name="agents", label="/agents", slash_text="/agents"),
+    QuickAction(name="skills", label="/skills", slash_text="/skills"),
+    QuickAction(name="list", label="/list", slash_text="/list"),
+    QuickAction(name="cost", label="/cost", slash_text="/cost"),
+)
+
+
+def action_name_for(action: QuickAction) -> str:
+    """Return the ``cl.Action.name`` (= callback key) for a QuickAction.
+
+    Centralised so the welcome message builder and the
+    ``@cl.action_callback`` decorator agree on the same namespaced key.
+    """
+    return f"slash_{action.name}"
+
+
+__all__ = [
+    "QUICK_ACTIONS",
+    "QuickAction",
+    "action_name_for",
+    "is_slash",
+]

--- a/tests/cli/test_chainlit_slash_route.py
+++ b/tests/cli/test_chainlit_slash_route.py
@@ -1,0 +1,83 @@
+"""Tier 1: ``reyn.chainlit_app.slash_route`` contract.
+
+Pinned invariants:
+
+1. ``is_slash`` truth table: ``/`` prefix → True, anything else → False.
+   Empty / None / leading-space inputs → False (= predictable for paste
+   edge cases).
+2. ``QUICK_ACTIONS`` exposes a non-empty curated set; each entry's
+   ``slash_text`` itself satisfies ``is_slash`` (= self-consistency,
+   no malformed catalog entries).
+3. ``action_name_for`` namespaces with ``slash_`` prefix and is stable
+   per QuickAction (= callback registry key must match what the
+   decorator + welcome button builder use).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chainlit_app.slash_route import (
+    QUICK_ACTIONS,
+    QuickAction,
+    action_name_for,
+    is_slash,
+)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("/help", True),
+        ("/agents", True),
+        ("/", True),  # bare slash — odd but matches CUI/TUI handling
+        ("hello", False),
+        ("hello /world", False),  # only leading / counts
+        (" /help", False),  # leading whitespace → not slash (paste edge case)
+        ("", False),
+    ],
+)
+def test_is_slash_truth_table(text: str, expected: bool):
+    """Tier 1: exact behavior on representative inputs."""
+    assert is_slash(text) is expected
+
+
+def test_is_slash_handles_none_safely():
+    """Tier 1: None / empty → False (no exception, predictable for
+    callers using ``message.content or ''`` shorthand)."""
+    assert is_slash("") is False
+    assert is_slash(None) is False  # type: ignore[arg-type]
+
+
+def test_quick_actions_non_empty():
+    """Tier 1: catalog ships at least one entry (= the welcome button
+    row would otherwise render empty)."""
+    assert len(QUICK_ACTIONS) >= 1
+
+
+def test_quick_actions_self_consistent():
+    """Tier 1: every catalog entry's ``slash_text`` is itself a valid
+    slash command (= the dispatcher's first guard always passes when
+    invoked from a button click)."""
+    for qa in QUICK_ACTIONS:
+        assert isinstance(qa, QuickAction)
+        assert qa.name, "QuickAction.name must be non-empty"
+        assert qa.label.startswith("/"), (
+            f"QuickAction.label must look like a slash command: {qa.label!r}"
+        )
+        assert is_slash(qa.slash_text), (
+            f"QuickAction.slash_text must satisfy is_slash: {qa.slash_text!r}"
+        )
+
+
+def test_quick_action_names_unique():
+    """Tier 1: ``action_name_for`` returns a unique key per entry; a
+    duplicate would silently shadow the prior ``@cl.action_callback``."""
+    keys = [action_name_for(qa) for qa in QUICK_ACTIONS]
+    assert len(keys) == len(set(keys))
+
+
+def test_action_name_for_uses_slash_prefix():
+    """Tier 1: callback key namespace is ``slash_<name>`` (= shared with
+    the welcome button builder)."""
+    qa = QuickAction(name="example", label="/example", slash_text="/example")
+    assert action_name_for(qa) == "slash_example"


### PR DESCRIPTION
**[tui-coder]** — Chainlit follow-on (= 全 chainlit cascade landing 後の next、 lead-coder autonomy 「user direction 「どんどん進めて」 有効、 author judgment」 で着手)。 **scope: 純 chainlit-side、 reyn engine 不変** (memory `chainlit-focus-no-internals` 準拠)。

## Two related additions

1. **Typed slash routing**: 入力欄で `/help` と打つと、 これまでは agent に plain text として送信されていた。 これを `session._maybe_handle_slash(text)` 経由でディスパッチするように修正 (= TUI / CUI と同じ slash router)。
2. **Quick-action buttons**: welcome `cl.Message` に `cl.Action` ボタン行を追加 — `/agents` `/skills` `/list` `/cost` 4 件 (= 全て read-only / quick-info の安全な command)。 操作者は slash vocab を覚えなくてもクリックで実行可能。

## 実装

- `reyn.chainlit_app.slash_route` (新規 pure helper、 chainlit import 無し):
  - `is_slash(text)` — 真偽値、 None / empty / 先頭 whitespace の edge を pin
  - `QUICK_ACTIONS: tuple[QuickAction, ...]` — curated catalog (= 追加は 1 行)
  - `action_name_for(qa)` — namespaced callback key (`slash_<name>`) builder
- `_on_message` で slash 判定 → `_maybe_handle_slash` ディスパッチ、 そうでなければ `submit_user_text` (= 既存 fallthrough)
- `_register_action_callbacks()` を module load 時 1 回呼び、 `QUICK_ACTIONS` をループして per-action `@cl.action_callback` を bind。 shared `_run_quick_action` ハンドラ本体で per-action wrapper を軽量化。 新 button 追加は **`QUICK_ACTIONS` への 1 行 append のみ** で済む
- welcome `cl.Message(content=..., actions=[...])` で同 catalog から button 行を組み立て (= label 同期)

## API touch

- `session._maybe_handle_slash(text) -> bool` (= 既存 `_` prefix private but conventional、 TUI app.py も同 pattern で使用)
- `_pending_user_images` (= multimodal queue) と同じ「reyn-internal だが gateway から OK」 surface 扱い

reyn 側 API signature 変更無し、 chainlit_app/ + tests のみ touch。

## Test plan

- [x] **Tier 1 slash_route helper** — `pytest tests/cli/test_chainlit_slash_route.py` (7 tests 緑、 truth table / catalog self-consistency / unique callback keys / namespace prefix)
- [x] **Full chainlit-side suite** — `pytest tests/cli/test_chainlit_*` (61 tests 緑)
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — `_register_action_callbacks()` の module-load 時 loop bind でも crash 無し
- [ ] (skipped — needs browser interaction) **Manual: 入力欄に `/agents` と打って enter → agent 一覧が表示**
- [ ] (skipped — same) **Manual: welcome の `/skills` ボタンクリック → skill 一覧 が表示**
- [ ] (skipped — same) **Manual: `/halp` 等 unknown slash → 「unknown command」 hint が outbox に流れる (= `_maybe_handle_slash` の責務)**

local server 9001 で実機 verify 予定 (user に refresh 依頼)。

## Tier self-check

- ✅ Tier 1 only (= pure helper contract)
- ✅ private state assert なし (= QuickAction は public dataclass、 catalog は frozen tuple)
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)