### PR TITLE
feat(chainlit): slash typing palette via emitter.set_commands

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -35,6 +35,7 @@ from reyn.chainlit_app.slash_route import (
     QUICK_ACTIONS,
     QuickAction,
     action_name_for,
+    build_command_dicts,
     is_slash,
 )
 from reyn.chainlit_app.uploads import collect_image_blocks
@@ -273,6 +274,25 @@ async def _on_chat_start() -> None:
 
     task = asyncio.create_task(_drain_loop(registry))
     cl.user_session.set(_DRAIN_KEY, task)
+
+    # Slash typing palette: when the operator types ``/`` in the
+    # input box, chainlit pops up a hint list of registered
+    # commands. We populate it from reyn's ``REGISTRY`` so adding a
+    # new slash command anywhere in the codebase appears here
+    # automatically — no manual sync needed.
+    try:
+        from chainlit.context import context as cl_context
+
+        from reyn.chat.slash import REGISTRY as _slash_registry
+        commands = build_command_dicts(_slash_registry.all_commands())
+        if commands:
+            await cl_context.emitter.set_commands(commands)
+    except Exception:
+        # Chainlit version drift or context unavailability is not
+        # fatal for the chat itself — degrade to "no typing palette"
+        # rather than crashing the attach.
+        pass
+
     actions = [
         cl.Action(
             name=action_name_for(qa),

--- a/src/reyn/chainlit_app/slash_route.py
+++ b/src/reyn/chainlit_app/slash_route.py
@@ -9,7 +9,10 @@ route to the session's slash dispatcher; otherwise hand it to
 
 This module also catalogs a small set of "quick action" slash
 commands surfaced as ``cl.Action`` buttons on the welcome message so
-operators don't have to memorize the slash vocabulary.
+operators don't have to memorize the slash vocabulary, and builds the
+typing-time slash completion list consumed by chainlit's
+``emitter.set_commands`` API (= the ``/`` palette that pops up while
+the operator types).
 
 No chainlit import here — kept pure so tests run without the
 ``[chainlit]`` extra.
@@ -17,6 +20,7 @@ No chainlit import here — kept pure so tests run without the
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 
 def is_slash(text: str) -> bool:
@@ -67,9 +71,91 @@ def action_name_for(action: QuickAction) -> str:
     return f"slash_{action.name}"
 
 
+# ── slash typing palette (chainlit emitter.set_commands) ─────────────────
+
+
+class _SlashCommandLike(Protocol):
+    """Minimal surface ``build_command_dicts`` reads on each entry.
+
+    Defined as a Protocol so tests can pass a tiny fake without
+    constructing the real ``reyn.chat.slash.SlashCommand`` dataclass.
+    """
+    name: str
+    summary: str
+    hidden: bool
+
+
+# Per-command lucide icon picks. Lucide icon names — see
+# https://lucide.dev — chainlit forwards the string verbatim to the
+# frontend, which renders the matching SVG. Anything not in this
+# map falls back to ``_FALLBACK_ICON``.
+_ICON_BY_NAME: dict[str, str] = {
+    "agents":      "users",
+    "skills":      "wrench",
+    "list":        "list",
+    "cost":        "dollar-sign",
+    "tasks":       "list-checks",
+    "expand":      "maximize-2",
+    "help":        "help-circle",
+    "cost-inline": "badge-dollar-sign",
+    "image":       "image",
+    "img":         "image",
+    "find":        "search",
+    "plan":        "map",
+    "attach":      "link",
+    "save":        "save",
+    "copy":        "copy",
+    "reset":       "rotate-ccw",
+    "quit":        "log-out",
+    "exit":        "log-out",
+}
+
+_FALLBACK_ICON = "slash"
+
+
+def icon_for_slash_name(name: str) -> str:
+    """Return the lucide icon name for ``name`` (with sensible fallback)."""
+    return _ICON_BY_NAME.get(name, _FALLBACK_ICON)
+
+
+def build_command_dicts(commands: list[_SlashCommandLike]) -> list[dict]:
+    """Convert a list of reyn ``SlashCommand`` entries → chainlit CommandDicts.
+
+    The chainlit ``emitter.set_commands`` API consumes a
+    ``List[CommandDict]`` (= ``TypedDict`` with ``id`` / ``description``
+    / ``icon`` required). This helper:
+
+    - Drops ``hidden=True`` entries (= ``matrix`` / ``donut`` / ``zen``
+      etc., which already don't appear in /help or the TUI palette)
+    - Builds ``id = "/<name>"`` (= chainlit displays this verbatim in
+      the popup palette; matches what gets dispatched on submit)
+    - Carries the canonical ``summary`` through as ``description``
+    - Picks a lucide icon via ``icon_for_slash_name`` so each row has
+      a visual hint
+    - Sorts by name for stable ordering across reloads
+    """
+    out: list[dict] = []
+    for cmd in commands:
+        if getattr(cmd, "hidden", False):
+            continue
+        name = getattr(cmd, "name", "")
+        summary = getattr(cmd, "summary", "") or ""
+        if not name:
+            continue
+        out.append({
+            "id": f"/{name}",
+            "description": summary,
+            "icon": icon_for_slash_name(name),
+        })
+    out.sort(key=lambda d: d["id"])
+    return out
+
+
 __all__ = [
     "QUICK_ACTIONS",
     "QuickAction",
     "action_name_for",
+    "build_command_dicts",
+    "icon_for_slash_name",
     "is_slash",
 ]

--- a/tests/cli/test_chainlit_slash_route.py
+++ b/tests/cli/test_chainlit_slash_route.py
@@ -14,14 +14,28 @@ Pinned invariants:
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import pytest
 
 from reyn.chainlit_app.slash_route import (
+    _FALLBACK_ICON,
     QUICK_ACTIONS,
     QuickAction,
     action_name_for,
+    build_command_dicts,
+    icon_for_slash_name,
     is_slash,
 )
+
+
+@dataclass
+class _FakeCommand:
+    """Minimal stand-in for ``reyn.chat.slash.SlashCommand`` — just the
+    fields ``build_command_dicts`` reads."""
+    name: str
+    summary: str
+    hidden: bool = False
 
 
 @pytest.mark.parametrize(
@@ -81,3 +95,72 @@ def test_action_name_for_uses_slash_prefix():
     the welcome button builder)."""
     qa = QuickAction(name="example", label="/example", slash_text="/example")
     assert action_name_for(qa) == "slash_example"
+
+
+# ── build_command_dicts (slash typing palette) ──────────────────────────
+
+
+def test_build_command_dicts_basic_shape():
+    """Tier 1: each visible SlashCommand → CommandDict with required
+    chainlit fields (id, description, icon)."""
+    out = build_command_dicts([
+        _FakeCommand(name="agents", summary="List all agents"),
+    ])
+    assert out == [{
+        "id": "/agents",
+        "description": "List all agents",
+        "icon": "users",  # known mapping
+    }]
+
+
+def test_build_command_dicts_drops_hidden():
+    """Tier 1: hidden commands (= matrix / donut / zen etc.) never
+    surface in the typing palette."""
+    out = build_command_dicts([
+        _FakeCommand(name="agents", summary="visible"),
+        _FakeCommand(name="matrix", summary="easter egg", hidden=True),
+        _FakeCommand(name="zen", summary="hidden", hidden=True),
+        _FakeCommand(name="skills", summary="visible too"),
+    ])
+    ids = [d["id"] for d in out]
+    assert ids == ["/agents", "/skills"]
+
+
+def test_build_command_dicts_sorts_by_id():
+    """Tier 1: output sorted by id so the popup palette is stable
+    across reloads (= input order doesn't matter)."""
+    out = build_command_dicts([
+        _FakeCommand(name="zebra", summary="z"),
+        _FakeCommand(name="apple", summary="a"),
+        _FakeCommand(name="mango", summary="m"),
+    ])
+    assert [d["id"] for d in out] == ["/apple", "/mango", "/zebra"]
+
+
+def test_build_command_dicts_empty_name_skipped():
+    """Tier 1: defensive — entries without a name don't crash, just drop."""
+    out = build_command_dicts([
+        _FakeCommand(name="", summary="no name"),
+        _FakeCommand(name="ok", summary="fine"),
+    ])
+    assert [d["id"] for d in out] == ["/ok"]
+
+
+def test_build_command_dicts_empty_input_returns_empty_list():
+    """Tier 1: no commands → no palette entries (= safe to call unconditionally
+    at chat-start time)."""
+    assert build_command_dicts([]) == []
+
+
+def test_icon_for_slash_name_known_mappings():
+    """Tier 1: the curated lucide-icon map applies for the commands
+    we picked it for."""
+    assert icon_for_slash_name("agents") == "users"
+    assert icon_for_slash_name("cost") == "dollar-sign"
+    assert icon_for_slash_name("help") == "help-circle"
+
+
+def test_icon_for_slash_name_falls_back_on_unknown():
+    """Tier 1: unknown command name → fallback icon (= no crash,
+    typing palette still gets an icon for every entry)."""
+    assert icon_for_slash_name("not_in_table_at_all") == _FALLBACK_ICON


### PR DESCRIPTION
**[tui-coder]** — Chainlit follow-on (stacked on #893)。 user dogfood 観察 2026-05-24「補完は流石にないか」 → **chainlit 2.x には `emitter.set_commands` API があった** → registry から流す。

## 仕組み

Chainlit が JSON API でセッションごとに「コマンド一覧」 を受け取り、 入力欄で `/` を打つとポップアップでヒント表示する仕組み (= `CommandDict` = id / description / icon required)。 reyn 側はもう slash REGISTRY 持ってるので、 そこから dict 列を組み立てて `await context.emitter.set_commands(...)` で送るだけ。

新しい `@slash(...)` を reyn 内に追加すると **自動で** palette に出る (= 手動 sync 不要)。

## 実装

- `slash_route.py` 拡張 (= pure helper):
  - `build_command_dicts(commands)` — `hidden=True` を drop、 `id=/<name>` + `description=summary` を組み、 lucide icon を `_ICON_BY_NAME` table から map (= agents → users / cost → dollar-sign / help → help-circle 等)、 不明 name は `slash` fallback、 id sort
  - `icon_for_slash_name(name)` — testable / 観察用に公開
- `_on_chat_start` で attach 直後に `await cl_context.emitter.set_commands(...)` 呼び出し。 try/except で chainlit version drift / context 不在は「palette 無し」 に degrade、 attach 自体は失敗させない

## Stacked base

base = `feat/tui-chainlit-slash-routing-actions` (= #893)。 stack depth = 1。 #893 review settle 後に rebase + base 切替予定。 lead-coder「depth 2 まで OK」 範囲内。

## Why scope-limited

memory `chainlit-focus-no-internals` 準拠 — `slash_route.py` 拡張 + `_on_chat_start` の 1 行追加のみ、 reyn engine 不変。 `REGISTRY.all_commands()` は既存 public surface。

## Test plan

- [x] **Tier 1 build_command_dicts + icon** — `pytest tests/cli/test_chainlit_slash_route.py` (19 tests 緑、 = 既存 12 + 新 7、 shape / hidden filter / sort / empty-name skip / empty-input / icon known mapping / fallback)
- [x] **Full chainlit-side suite** — 68 tests 緑
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — `build_command_dicts` import 追加でも crash 無し
- [ ] (skipped — needs browser interaction) **Manual: 入力欄で `/` を押した時 popup に reyn の全 slash command 一覧 (= 非 hidden) がアイコン付きで表示**
- [ ] (skipped — same) **Manual: popup から `/skills` を選択 → enter → 実行**

local server 9001 で実機 verify 予定。

## Tier self-check

- ✅ Tier 1 only (= pure helper contract)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)