### PR TITLE
feat(chainlit): cap history replay to keep agent switches snappy

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 import chainlit as cl
 
 from reyn.chainlit_app.adapter import outbox_to_chainlit
-from reyn.chainlit_app.history import history_to_chainlit
+from reyn.chainlit_app.history import DEFAULT_REPLAY_CAP, history_to_chainlit
 from reyn.chainlit_app.profiles import list_agent_profiles
 from reyn.chainlit_app.slash_route import (
     QUICK_ACTIONS,
@@ -49,6 +49,29 @@ _REGISTRY: "AgentRegistry | None" = None
 
 def _agent_name_from_env() -> str:
     return os.environ.get("REYN_CHAINLIT_AGENT", "default")
+
+
+def _history_cap_from_env() -> int | None:
+    """Read the replay cap from ``REYN_CHAINLIT_HISTORY_CAP``.
+
+    Returns:
+      - ``DEFAULT_REPLAY_CAP`` when the env var is unset or unparseable
+        (= keep the chat snappy on agents with long history.jsonl).
+      - The parsed int when the env var holds a number. ``0`` or
+        negative becomes "unlimited" by passing ``None`` to the
+        helper, so the operator can opt back into the previous
+        full-replay behavior with ``REYN_CHAINLIT_HISTORY_CAP=0``.
+    """
+    raw = os.environ.get("REYN_CHAINLIT_HISTORY_CAP")
+    if raw is None:
+        return DEFAULT_REPLAY_CAP
+    try:
+        value = int(raw.strip())
+    except (ValueError, AttributeError):
+        return DEFAULT_REPLAY_CAP
+    if value <= 0:
+        return None
+    return value
 
 
 async def _get_or_build_registry() -> "AgentRegistry":
@@ -266,7 +289,7 @@ async def _on_chat_start() -> None:
     # sees the conversation they had previously with this agent
     # instead of an empty thread on every re-attach / browser open.
     history = getattr(session, "history", None) or []
-    for entry in history_to_chainlit(history):
+    for entry in history_to_chainlit(history, cap=_history_cap_from_env()):
         await cl.Message(
             content=entry.content, author=entry.author,
         ).send()

--- a/src/reyn/chainlit_app/history.py
+++ b/src/reyn/chainlit_app/history.py
@@ -100,14 +100,45 @@ def _flatten_content(content: "str | list[dict]") -> str:
     return "\n".join(chunks)
 
 
-def history_to_chainlit(history: Iterable[_MessageLike]) -> list[HistoryEntry]:
+DEFAULT_REPLAY_CAP = 50
+
+
+def _truncation_marker(omitted: int) -> HistoryEntry:
+    """One-line system entry rendered at the top of a capped replay."""
+    return HistoryEntry(
+        author="system",
+        content=(
+            f"_({omitted} earlier turns omitted to keep the chat snappy. "
+            "Set `REYN_CHAINLIT_HISTORY_CAP=0` to show all.)_"
+        ),
+    )
+
+
+def history_to_chainlit(
+    history: Iterable[_MessageLike], *, cap: int | None = None,
+) -> list[HistoryEntry]:
     """Convert ``ChatSession.history`` into a list of replay-ready entries.
 
     Order preserved (= chronological), drops applied per
     ``_DROPPED_ROLES``. Empty-text turns (= ``content`` flattens to ``""``)
     are also dropped so the replay doesn't emit blank cells.
+
+    ``cap``:
+        - ``None`` (default): no cap, full history rendered.
+        - positive int: keep at most this many *visible* entries; if the
+          full history would exceed the cap, slice to the last ``cap``
+          entries and prepend a single ``author="system"`` marker that
+          tells the operator how many entries were skipped + how to
+          opt back into full replay.
+        - ``0`` or negative: treated the same as ``None`` (= unlimited)
+          so the env-var path can use ``REYN_CHAINLIT_HISTORY_CAP=0``
+          as the "show all" sentinel without a separate flag.
+
+    Capping happens after filtering so that ``cap=50`` always shows the
+    last 50 *visible* turns regardless of how many internal entries
+    (tool / system / summary) sit between them on disk.
     """
-    out: list[HistoryEntry] = []
+    visible: list[HistoryEntry] = []
     for msg in history:
         role = getattr(msg, "role", "")
         if role in _DROPPED_ROLES:
@@ -118,11 +149,19 @@ def history_to_chainlit(history: Iterable[_MessageLike]) -> list[HistoryEntry]:
         text = _flatten_content(getattr(msg, "content", ""))
         if not text:
             continue
-        out.append(HistoryEntry(author=author, content=text))
-    return out
+        visible.append(HistoryEntry(author=author, content=text))
+
+    if cap is None or cap <= 0:
+        return visible
+    if len(visible) <= cap:
+        return visible
+
+    omitted = len(visible) - cap
+    return [_truncation_marker(omitted)] + visible[-cap:]
 
 
 __all__ = [
+    "DEFAULT_REPLAY_CAP",
     "HistoryEntry",
     "history_to_chainlit",
 ]

--- a/tests/cli/test_chainlit_history.py
+++ b/tests/cli/test_chainlit_history.py
@@ -143,3 +143,83 @@ def test_mixed_visible_and_internal_roles_filters_correctly():
         _FakeMsg(role="assistant", content="a2"),
     ])
     assert [e.content for e in out] == ["q1", "a1", "a1b", "q2", "a2"]
+
+
+# ── cap behavior ──────────────────────────────────────────────────────────
+
+
+def _seq_history(n: int) -> list:
+    """Build ``n`` alternating user/assistant turns numbered 0..n-1."""
+    out = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append(_FakeMsg(role=role, content=f"turn{i}"))
+    return out
+
+
+def test_cap_none_returns_full_history():
+    """Tier 1: cap=None (default) → no truncation, no marker, all entries."""
+    out = history_to_chainlit(_seq_history(10))
+    assert len(out) == 10
+    assert all(e.author != "system" for e in out)
+
+
+def test_cap_zero_treated_as_unlimited():
+    """Tier 1: cap=0 → unlimited (= the env-var "show all" sentinel)."""
+    out = history_to_chainlit(_seq_history(10), cap=0)
+    assert len(out) == 10
+    assert all(e.author != "system" for e in out)
+
+
+def test_cap_negative_treated_as_unlimited():
+    """Tier 1: cap=-1 → unlimited (= defensive, same as cap=0)."""
+    out = history_to_chainlit(_seq_history(10), cap=-1)
+    assert len(out) == 10
+
+
+def test_cap_larger_than_history_no_marker():
+    """Tier 1: cap=100 on 10-entry history → no truncation, no marker."""
+    out = history_to_chainlit(_seq_history(10), cap=100)
+    assert len(out) == 10
+    assert all(e.author != "system" for e in out)
+
+
+def test_cap_equal_to_history_no_marker():
+    """Tier 1: cap=10 on 10-entry history → exact fit, no marker."""
+    out = history_to_chainlit(_seq_history(10), cap=10)
+    assert len(out) == 10
+    assert all(e.author != "system" for e in out)
+
+
+def test_cap_slices_to_last_n_with_marker():
+    """Tier 1: cap=3 on 10-entry history → 1 system marker + last 3 entries."""
+    out = history_to_chainlit(_seq_history(10), cap=3)
+    assert len(out) == 4  # 1 marker + 3 kept
+    assert out[0].author == "system"
+    assert "7" in out[0].content  # 10 - 3 = 7 omitted
+    assert [e.content for e in out[1:]] == ["turn7", "turn8", "turn9"]
+
+
+def test_cap_marker_mentions_env_var_for_unbounded():
+    """Tier 1: marker text tells the operator how to opt back into full
+    replay (= avoids "where did my history go?" without a hint)."""
+    out = history_to_chainlit(_seq_history(100), cap=10)
+    assert out[0].author == "system"
+    assert "REYN_CHAINLIT_HISTORY_CAP" in out[0].content
+
+
+def test_cap_applied_after_filtering():
+    """Tier 1: cap counts *visible* entries, not raw history length.
+    A history of 100 internal entries + 5 visible should never trigger
+    the marker for cap=10 (= visible < cap)."""
+    msgs = []
+    for i in range(100):
+        msgs.append(_FakeMsg(role="tool", content=f"tool{i}"))
+    msgs.extend([
+        _FakeMsg(role="user", content="visible1"),
+        _FakeMsg(role="assistant", content="visible2"),
+    ])
+    out = history_to_chainlit(msgs, cap=10)
+    assert len(out) == 2
+    assert [e.content for e in out] == ["visible1", "visible2"]
+    assert all(e.author != "system" for e in out)


### PR DESCRIPTION
**[tui-coder]** — user dogfood 観察 2026-05-24「履歴が多すぎて重くなるね」 → 長期間 active な agent (= history.jsonl が肥大) で `_on_chat_start` の全 turn replay が DOM 肥大化 → switch がもたつく → 直近 N turn cap で snappy 化。

## 実装

- `history_to_chainlit(history, *, cap=None)` に cap parameter 追加
  - cap=None / 0 / 負値 → 無制限 (= 既存 behavior、 env var「show all」 sentinel と semantic 一致)
  - cap=N (positive) → filtering 後に **直近 N** に slice + 「(M earlier turns omitted)」 という 1 行 italic system marker を先頭に挿入
- `DEFAULT_REPLAY_CAP = 50`
- `_history_cap_from_env()` が `REYN_CHAINLIT_HISTORY_CAP` env を読む、 未設定 / parse 失敗 → default 50、 `<= 0` → 無制限
- `_on_chat_start` が `history_to_chainlit(history, cap=_history_cap_from_env())` 呼び出し

## Why filter-then-cap

cap を **filter 後** に適用 — raw history (= tool/system/summary 含む) に対してではなく、 visible turn (= user/assistant のみ) に対して N=50。 これで「1000 件の tool entries が cap window から最後の user turn を押し出す」 のような驚きを防ぐ。

## Why scope-limited

memory `chainlit-focus-no-internals` (2026-05-24) 準拠 — `src/reyn/chainlit_app/{history,app}.py` + tests のみ touch、 reyn engine 不変、 `session.history` は read-only access。

## Test plan

- [x] **Tier 1 cap behavior** — `pytest tests/cli/test_chainlit_history.py` (18 tests 緑、 = 既存 10 + 新 8、 cap None/0/負/exact/larger/smaller、 marker shape、 env-var hint、 filter-then-cap)
- [x] **Full chainlit-side suite** — 69 tests 緑
- [x] **ruff clean** — 全 touched files
- [x] **app.py import smoke** — `DEFAULT_REPLAY_CAP` import 追加でも crash 無し
- [ ] (skipped — needs browser interaction with long-history agent) **Manual: 50 turn 超の agent に attach → 直近 50 turn のみ表示 + 上に「(M earlier turns omitted)」 marker**
- [ ] (skipped — same) **Manual: `REYN_CHAINLIT_HISTORY_CAP=0 reyn chainlit` → 全 turn 表示 (= 元 behavior に opt-back)**

local server 9001 で 1 番 verify 予定 (user に refresh 依頼)。

## Tier self-check

- ✅ Tier 1 only (= pure helper contract、 env-var fallback も pure)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)