### PR TITLE
feat(chainlit): ship reyn config.toml — disable confirm_new_chat popup

### DIFF
--- a/src/reyn/chainlit_app/assets/.chainlit/config.toml
+++ b/src/reyn/chainlit_app/assets/.chainlit/config.toml
@@ -1,0 +1,22 @@
+# reyn-shipped Chainlit defaults — copied into cwd/.chainlit/config.toml on
+# first ``reyn chainlit`` launch when the file is absent. Operator edits
+# made after first launch are preserved (= idempotent copy mirroring
+# Chainlit's own ``init_config`` posture).
+#
+# Partial TOML is fine: ``chainlit/config.py::load_settings`` extracts
+# ``[project]`` / ``[features]`` / ``[UI]`` sections and feeds them
+# through the pydantic ``ProjectSettings`` / ``FeaturesSettings`` /
+# ``UISettings`` constructors, which fill in defaults for any missing
+# fields. ``[meta].generated_by`` is the only required field (= the loader
+# raises if absent or <= "0.3.0").
+
+[UI]
+# Skip the "Start a new chat?" confirmation popup when the operator
+# clicks the agent-switch / new-chat button. Operators dogfooding the
+# reyn picker (#888) want to flip between agents quickly; the extra
+# confirm step adds friction without preventing real mistakes
+# (= reyn keeps history per agent regardless).
+confirm_new_chat = false
+
+[meta]
+generated_by = "reyn-chainlit-app"

--- a/src/reyn/chainlit_app/first_run.py
+++ b/src/reyn/chainlit_app/first_run.py
@@ -2,12 +2,13 @@
 
 When the operator launches ``reyn chainlit`` in a directory that has
 never hosted a Chainlit app, Chainlit auto-creates a generic
-``chainlit.md`` welcome page. This module ships a reyn-branded version
-in ``assets/chainlit.md`` and copies it into ``cwd`` first — same
-idempotent pattern as Chainlit's own ``init_config()`` (= copy only if
-the destination doesn't exist).
+``chainlit.md`` welcome page and a default ``.chainlit/config.toml``.
+This module ships reyn-branded / reyn-tweaked versions in ``assets/``
+and copies them into ``cwd`` first — same idempotent pattern as
+Chainlit's own ``init_config()`` (= copy only if the destination
+doesn't exist).
 
-Operator customization is preserved: once they edit ``chainlit.md``,
+Operator customization is preserved: once they edit either file,
 subsequent launches see it exists and skip the copy.
 """
 from __future__ import annotations
@@ -21,21 +22,60 @@ def assets_dir() -> Path:
     return Path(__file__).resolve().parent / "assets"
 
 
-def ensure_chainlit_md(target_dir: Path) -> Path | None:
-    """Copy ``chainlit.md`` from assets to ``target_dir`` if absent.
-
-    Returns the destination path when a copy actually happened, ``None``
-    when the file already existed (= operator customization preserved).
-    """
-    src = assets_dir() / "chainlit.md"
+def _copy_if_absent(src: Path, dst: Path) -> Path | None:
+    """Internal: copy ``src`` to ``dst`` only when ``dst`` doesn't exist."""
     if not src.is_file():
         return None
-    dst = target_dir / "chainlit.md"
     if dst.exists():
         return None
-    target_dir.mkdir(parents=True, exist_ok=True)
+    dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(src, dst)
     return dst
 
 
-__all__ = ["assets_dir", "ensure_chainlit_md"]
+def ensure_chainlit_md(target_dir: Path) -> Path | None:
+    """Copy ``chainlit.md`` from assets to ``target_dir`` if absent."""
+    return _copy_if_absent(
+        assets_dir() / "chainlit.md",
+        target_dir / "chainlit.md",
+    )
+
+
+def ensure_chainlit_config(target_dir: Path) -> Path | None:
+    """Copy ``.chainlit/config.toml`` from assets if absent.
+
+    Ships a partial config that flips ``[UI].confirm_new_chat = false``
+    so agent switches via the chat-profile picker don't pop the
+    "Start a new chat?" confirm dialog. Other ``[UI]`` / ``[features]``
+    fields fall back to chainlit's pydantic class defaults because
+    ``chainlit/config.py::load_settings`` merges partial TOML with the
+    UISettings / FeaturesSettings constructors' defaults.
+
+    Operator customization is preserved across launches — once the
+    file exists at ``target_dir/.chainlit/config.toml`` this function
+    is a no-op. Returns the destination path on copy, ``None`` on skip.
+    """
+    return _copy_if_absent(
+        assets_dir() / ".chainlit" / "config.toml",
+        target_dir / ".chainlit" / "config.toml",
+    )
+
+
+def ensure_all_assets(target_dir: Path) -> list[Path]:
+    """Run every ``ensure_*`` helper, returning the list of paths that
+    were actually written (= empty list when all destinations already
+    existed and the call was a pure no-op)."""
+    written: list[Path] = []
+    for helper in (ensure_chainlit_md, ensure_chainlit_config):
+        result = helper(target_dir)
+        if result is not None:
+            written.append(result)
+    return written
+
+
+__all__ = [
+    "assets_dir",
+    "ensure_all_assets",
+    "ensure_chainlit_config",
+    "ensure_chainlit_md",
+]

--- a/src/reyn/cli/commands/chainlit.py
+++ b/src/reyn/cli/commands/chainlit.py
@@ -85,8 +85,8 @@ def run(args: argparse.Namespace) -> None:
     # operator sees reyn context (not chainlit's generic boilerplate)
     # the first time they hit the URL. Idempotent — operator edits
     # are preserved on subsequent launches.
-    from reyn.chainlit_app.first_run import ensure_chainlit_md
-    ensure_chainlit_md(Path.cwd())
+    from reyn.chainlit_app.first_run import ensure_all_assets
+    ensure_all_assets(Path.cwd())
 
     cmd: list[str] = [
         sys.executable,

--- a/tests/cli/test_chainlit_first_run.py
+++ b/tests/cli/test_chainlit_first_run.py
@@ -1,19 +1,23 @@
-"""Tier 1: ``reyn.chainlit_app.first_run.ensure_chainlit_md`` contract.
+"""Tier 1: ``reyn.chainlit_app.first_run`` asset-copy contracts.
 
-The CLI calls this before launching chainlit so the operator's first
-visit sees a reyn-branded welcome rather than chainlit's generic
-boilerplate. Two invariants pinned:
+The CLI calls these helpers before launching chainlit so the operator
+sees reyn defaults (welcome page + UI tweaks) instead of chainlit's
+generic boilerplate. Two invariants per helper:
 
-1. **Initial drop**: in an empty cwd, the shipped asset is copied in
-   and the destination path is returned.
-2. **Idempotent**: a second call on the same cwd is a no-op and
-   returns ``None`` — operator edits between launches are preserved.
+1. **Initial drop**: empty cwd → asset copied in, destination returned.
+2. **Idempotent**: second call → no-op, returns ``None`` (= operator
+   edits between launches preserved).
 """
 from __future__ import annotations
 
 from pathlib import Path
 
-from reyn.chainlit_app.first_run import assets_dir, ensure_chainlit_md
+from reyn.chainlit_app.first_run import (
+    assets_dir,
+    ensure_all_assets,
+    ensure_chainlit_config,
+    ensure_chainlit_md,
+)
 
 
 def test_assets_dir_contains_chainlit_md():
@@ -52,3 +56,80 @@ def test_ensure_chainlit_md_creates_target_dir(tmp_path: Path):
     assert result is not None
     assert nested.is_dir()
     assert (nested / "chainlit.md").is_file()
+
+
+# ── ensure_chainlit_config ────────────────────────────────────────────────
+
+
+def test_assets_dir_contains_chainlit_config():
+    """Tier 1: shipped ``.chainlit/config.toml`` template exists."""
+    src = assets_dir() / ".chainlit" / "config.toml"
+    assert src.is_file(), f"shipped config.toml missing at {src}"
+
+
+def test_config_template_has_required_meta_for_chainlit_loader():
+    """Tier 1: chainlit's ``load_settings`` raises if ``[meta].generated_by``
+    is absent / <= ``0.3.0``. Pin the shipped template's marker so a
+    future edit doesn't accidentally break the loader."""
+    src = (assets_dir() / ".chainlit" / "config.toml").read_text()
+    assert "[meta]" in src
+    assert "generated_by" in src
+
+
+def test_config_template_disables_confirm_new_chat():
+    """Tier 1: pin the actual override that motivates the template —
+    a stray formatting change shouldn't silently re-enable the popup."""
+    src = (assets_dir() / ".chainlit" / "config.toml").read_text()
+    assert "confirm_new_chat = false" in src
+
+
+def test_ensure_chainlit_config_creates_when_absent(tmp_path: Path):
+    """Tier 1: empty cwd → copy + parent ``.chainlit/`` mkdir + return path."""
+    result = ensure_chainlit_config(tmp_path)
+    assert result == tmp_path / ".chainlit" / "config.toml"
+    assert result.is_file()
+    assert (tmp_path / ".chainlit").is_dir()
+
+
+def test_ensure_chainlit_config_skips_when_present(tmp_path: Path):
+    """Tier 1: existing file → no overwrite, returns None (= operator
+    customization preserved across launches)."""
+    cdir = tmp_path / ".chainlit"
+    cdir.mkdir()
+    custom = cdir / "config.toml"
+    custom.write_text("# operator's config\n")
+    result = ensure_chainlit_config(tmp_path)
+    assert result is None
+    assert custom.read_text() == "# operator's config\n"
+
+
+# ── ensure_all_assets (= CLI entry path) ──────────────────────────────────
+
+
+def test_ensure_all_assets_copies_both_on_first_run(tmp_path: Path):
+    """Tier 1: clean cwd → both chainlit.md and .chainlit/config.toml land."""
+    written = ensure_all_assets(tmp_path)
+    assert len(written) == 2
+    assert (tmp_path / "chainlit.md").is_file()
+    assert (tmp_path / ".chainlit" / "config.toml").is_file()
+
+
+def test_ensure_all_assets_noop_when_both_present(tmp_path: Path):
+    """Tier 1: both files pre-existing → returns empty list, no overwrites."""
+    (tmp_path / "chainlit.md").write_text("custom welcome")
+    (tmp_path / ".chainlit").mkdir()
+    (tmp_path / ".chainlit" / "config.toml").write_text("custom config")
+    written = ensure_all_assets(tmp_path)
+    assert written == []
+    assert (tmp_path / "chainlit.md").read_text() == "custom welcome"
+    assert (tmp_path / ".chainlit" / "config.toml").read_text() == "custom config"
+
+
+def test_ensure_all_assets_partial_one_existing_one_missing(tmp_path: Path):
+    """Tier 1: one asset pre-existing, the other not → copy only the missing
+    one (= per-asset idempotence, not all-or-nothing)."""
+    (tmp_path / "chainlit.md").write_text("custom welcome")
+    written = ensure_all_assets(tmp_path)
+    assert len(written) == 1
+    assert written[0] == tmp_path / ".chainlit" / "config.toml"
+    assert (tmp_path / "chainlit.md").read_text() == "custom welcome"


### PR DESCRIPTION
**[tui-coder]** — user dogfood 観察 2026-05-24「agent 切り替えボタン押すと「新規作成」というポップアップが出てくる。 確認ボタン押すとagent 切り替えできる」 → chainlit の `confirm_new_chat = true` default が agent picker (#888) 経由の切替時に必ず確認ダイアログを出していた。 reyn は agent 切替で history を失わない (= 確認の保護価値なし、 friction のみ) → ship template で `false` 上書き。

## 仕組み

Chainlit の `load_settings` は partial TOML を OK にしてる — `[UI]` / `[features]` / `[project]` の各 section 値を抽出後 `UISettings(**kwargs)` 経由で pydantic class defaults と merge。 missing field は class default に fall back。 `[meta].generated_by` だけは required (= absent または `<= "0.3.0"` なら loader 即 raise)。

= reyn-tweaked **partial** config.toml で `confirm_new_chat = false` 上書きだけ可能。 chainlit minor version 更新で field 追加されても影響受けない (= 我々が触らない field は upstream default に乗る)。

## 実装

- `src/reyn/chainlit_app/assets/.chainlit/config.toml` (新規 25 行) — `[UI].confirm_new_chat = false` + 必須 `[meta].generated_by`
- `first_run.ensure_chainlit_config(target)` — `ensure_chainlit_md` と同じ idempotent copy pattern
- `first_run.ensure_all_assets(target)` — 全 helper を loop で呼ぶ entry point、 future 3rd / 4th asset 追加は first_run 内 tuple 1 行追加
- `cli/commands/chainlit.py::run` で `ensure_all_assets(Path.cwd())` 呼び出し

## Why scope-limited

memory `chainlit-focus-no-internals` 準拠 — `src/reyn/chainlit_app/` + CLI + tests のみ touch、 reyn engine 不変。

## Test plan

- [x] **Tier 1 first_run extended** — `pytest tests/cli/test_chainlit_first_run.py` (12 tests 緑、 = 既存 4 + 新 8、 shipped asset 存在 / required meta / actual override pin / per-helper idempotence / ensure_all_assets 3 cases)
- [x] **Full chainlit-side suite** — 69 tests 緑
- [x] **ruff clean** — 全 new files
- [ ] (skipped — needs browser interaction) **Manual: agent picker 切替時 「新規作成」 popup が出ない (= 即切替)**
- [ ] (skipped — same) **Manual: 既 customized `.chainlit/config.toml` がある cwd で起動 → 上書きされない**

local server 9001 で 1 番 verify 予定 (= 既に local cwd を即時 fix 済、 user 即時反映可能)。

## Tier self-check

- ✅ Tier 1 only (= pure helper + shipped asset content pin)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし (= asset content は文字列 substring assert で format change 許容)
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)