### PR TITLE
feat(chainlit): render tool_call_* with distinct author + status prefix

### DIFF
--- a/src/reyn/chainlit_app/adapter.py
+++ b/src/reyn/chainlit_app/adapter.py
@@ -3,19 +3,23 @@
 Pure conversion layer with no chainlit dependency. Unit tests can
 exercise this without installing the ``[chainlit]`` extra.
 
-PoC kind coverage:
-- ``agent``        → main reply, author "agent"
-- ``skill_done``   → green-bordered system note, author "skill"
-- ``status``       → dim hint, author "status"
-- ``error``        → red note, author "error"
-- ``intervention`` → author "intervention" (full handler is V2 — for
-                     PoC just render as text)
-- ``trace``        → dropped (debug noise)
-- ``system``       → author "system" (plan_summary / plan_complete /
-                     plan_aborted bridge messages)
-- ``__stream_*__`` → dropped (TUI-only incremental render kinds)
-- ``__end__``      → sentinel, signals drain to stop (returns None)
-- anything else    → author "system", text passed through
+Kind coverage:
+- ``agent``                → main reply, author "agent"
+- ``skill_done``           → green-bordered system note, author "skill"
+- ``status``               → dim hint, author "status"
+- ``error``                → red note, author "error"
+- ``intervention``         → author "intervention" (full handler is V2 — for
+                             PoC just render as text)
+- ``tool_call_started``    → author "tool", text "→ <name>" (= visual
+                             start marker, distinct from agent / system)
+- ``tool_call_completed``  → author "tool", text "✓ <name>"
+- ``tool_call_failed``     → author "tool", text "✗ <name>: <err>"
+- ``trace``                → dropped (debug noise)
+- ``system``               → author "system" (plan_summary / plan_complete /
+                             plan_aborted bridge messages)
+- ``__stream_*__``         → dropped (TUI-only incremental render kinds)
+- ``__end__``              → sentinel, signals drain to stop (returns None)
+- anything else            → author "system", text passed through
 """
 from __future__ import annotations
 
@@ -41,6 +45,35 @@ class ChainlitPayload:
     content: str
 
 
+_TOOL_KINDS = frozenset({
+    "tool_call_started", "tool_call_completed", "tool_call_failed",
+})
+
+
+def _format_tool_call(msg: OutboxMessage) -> str:
+    """Build the tool-call body text with a status-prefix marker.
+
+    The lifecycle forwarder packs the tool name into both ``text`` and
+    ``meta["tool"]`` so either works; we prefer meta when present so a
+    future emitter that uses a richer text field (e.g. with args
+    inline) won't collide with the prefix.
+    """
+    name = msg.meta.get("tool") if isinstance(msg.meta, dict) else None
+    if not isinstance(name, str) or not name:
+        name = msg.text or "(unnamed)"
+    if msg.kind == "tool_call_started":
+        return f"→ {name}"
+    if msg.kind == "tool_call_completed":
+        return f"✓ {name}"
+    # tool_call_failed
+    err = ""
+    if isinstance(msg.meta, dict):
+        em = msg.meta.get("error_message")
+        if isinstance(em, str) and em:
+            err = f": {em}"
+    return f"✗ {name}{err}"
+
+
 def outbox_to_chainlit(msg: OutboxMessage) -> ChainlitPayload | None:
     """Map one OutboxMessage to a Chainlit payload, or None to drop.
 
@@ -50,7 +83,9 @@ def outbox_to_chainlit(msg: OutboxMessage) -> ChainlitPayload | None:
           (``trace``, ``__stream_*__`` incremental render frames).
         - ``ChainlitPayload(role="error", ...)`` for ``kind="error"``.
         - ``ChainlitPayload(role="message", author=<label>, content=<text>)``
-          for everything else.
+          for everything else (including the 3 ``tool_call_*`` kinds,
+          which use author ``"tool"`` so the chat thread visually
+          separates tool activity from the agent's prose reply).
     """
     kind = msg.kind
     text = msg.text or ""
@@ -63,6 +98,13 @@ def outbox_to_chainlit(msg: OutboxMessage) -> ChainlitPayload | None:
 
     if kind == "error":
         return ChainlitPayload(role="error", author="error", content=text)
+
+    if kind in _TOOL_KINDS:
+        return ChainlitPayload(
+            role="message",
+            author="tool",
+            content=_format_tool_call(msg),
+        )
 
     author = {
         "agent": "agent",

--- a/tests/cli/test_chainlit_adapter.py
+++ b/tests/cli/test_chainlit_adapter.py
@@ -75,3 +75,96 @@ def test_empty_text_is_preserved_as_empty_string():
     payload = outbox_to_chainlit(msg)
     assert payload is not None
     assert payload.content == ""
+
+
+# ── tool_call_* kinds ─────────────────────────────────────────────────────
+
+
+def test_tool_call_started_renders_arrow_prefix():
+    """Tier 1: ``tool_call_started`` → author "tool", text "→ <name>"
+    (= visual marker distinct from agent / system)."""
+    msg = OutboxMessage(
+        kind="tool_call_started",
+        text="file__read",
+        meta={"tool": "file__read", "op_id": "h1"},
+    )
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.role == "message"
+    assert payload.author == "tool"
+    assert payload.content == "→ file__read"
+
+
+def test_tool_call_completed_renders_check_prefix():
+    """Tier 1: ``tool_call_completed`` → ``✓ <name>``."""
+    msg = OutboxMessage(
+        kind="tool_call_completed",
+        text="shell__run",
+        meta={"tool": "shell__run", "op_id": "h2", "result": "..."},
+    )
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.author == "tool"
+    assert payload.content == "✓ shell__run"
+
+
+def test_tool_call_failed_renders_x_with_error_message():
+    """Tier 1: ``tool_call_failed`` → ``✗ <name>: <err>`` when error_message
+    present; falls back to plain ``✗ <name>`` when absent."""
+    failed_with_err = OutboxMessage(
+        kind="tool_call_failed",
+        text="net__fetch",
+        meta={
+            "tool": "net__fetch",
+            "op_id": "h3",
+            "error_kind": "TimeoutError",
+            "error_message": "request timed out",
+        },
+    )
+    payload = outbox_to_chainlit(failed_with_err)
+    assert payload is not None
+    assert payload.author == "tool"
+    assert payload.content == "✗ net__fetch: request timed out"
+
+    failed_no_err = OutboxMessage(
+        kind="tool_call_failed", text="t", meta={"tool": "t"},
+    )
+    payload = outbox_to_chainlit(failed_no_err)
+    assert payload is not None
+    assert payload.content == "✗ t"
+
+
+def test_tool_call_prefers_meta_tool_over_text_field():
+    """Tier 1: when meta.tool and text differ (= a future emitter packs
+    richer info into text), the meta-side name wins so the prefix marker
+    stays clean."""
+    msg = OutboxMessage(
+        kind="tool_call_started",
+        text="file__read(path=foo)",  # richer text
+        meta={"tool": "file__read"},
+    )
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.content == "→ file__read"
+
+
+def test_tool_call_falls_back_to_text_when_meta_missing():
+    """Tier 1: defensively, when meta.tool is absent the text field is
+    used so the row still shows something meaningful instead of
+    ``→ (unnamed)``."""
+    msg = OutboxMessage(
+        kind="tool_call_started", text="my_tool", meta={},
+    )
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.content == "→ my_tool"
+
+
+def test_tool_call_uses_unnamed_placeholder_when_both_absent():
+    """Tier 1: edge case — neither meta nor text carries a name → use a
+    visible placeholder rather than rendering ``→ `` (= operator sees
+    something went wrong-ish but the row doesn't disappear)."""
+    msg = OutboxMessage(kind="tool_call_started", text="", meta={})
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.content == "→ (unnamed)"


### PR DESCRIPTION
**[tui-coder]** — user dogfood 観察 2026-05-25「会話が tool 起動と assistant 区別つかないね」 → adapter で 3 つの `tool_call_*` kind (= `started` / `completed` / `failed`) が fall-through で `author="system"` 扱い → 会話 thread で agent reply / system note と視覚的に区別不能 → fix。

## 解決

adapter で 3 kind を author `"tool"` (= chainlit が unique author に独自 avatar / 色を付与) にルーティング + status prefix marker で flow が一目で分かる:

```
→ file__read              (start)
✓ file__read              (success)
✗ net__fetch: timed out   (failure with error_message)
```

## 実装

- `_TOOL_KINDS = {tool_call_started, tool_call_completed, tool_call_failed}` 定数
- `_format_tool_call(msg)` で kind ごとに prefix を変える pure helper
- tool 名は `meta["tool"]` (= `lifecycle_forwarder._enqueue_tool_call` がそこに pack) を優先、 text 欠落時 fallback、 両方無い場合 `(unnamed)` placeholder
- `tool_call_failed` のみ `meta["error_message"]` を追記 (= `: <msg>` suffix、 absent 時は plain `✗ <name>`)

## Why scope-limited

memory `chainlit-focus-no-internals` 準拠 — `adapter.py` + tests のみ touch、 reyn engine 不変。 `meta` shape は既 lifecycle_forwarder が確定 (`tool` / `op_id` / `chain_id` / `error_kind` / `error_message`)、 read-only access。

## Test plan

- [x] **Tier 1 tool_call_* render** — `pytest tests/cli/test_chainlit_adapter.py` (19 tests 緑、 = 既存 13 + 新 6)
- [x] **Full chainlit-side suite** — 83 tests 緑
- [x] **ruff clean** — 全 touched files
- [x] **app.py import smoke** — adapter 拡張で crash 無し
- [ ] (skipped — needs browser interaction triggering a tool call) **Manual: 「ls してみて」 等で tool 発火 → `→ file__list` → `✓ file__list` 等が author=tool で連続表示**
- [ ] (skipped — same) **Manual: error 発火する tool 実行 → `✗ <name>: <error>` 表示**

local server 9001 で 1, 2 番 verify 予定 (user に refresh + tool 発火依頼)。

## Tier self-check

- ✅ Tier 1 only (= adapter contract、 既存 pattern と同じ)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし (= prefix string substring assert)
- ✅ docstring 1 行目 Tier 宣言

## Future follow-on (= scope 外)

`cl.Step` で tool call を入れ子表示 (= started/completed/failed を 1 つの折りたたみ可能 step 内に集約) は別 PR で検討。 今回は **「区別がつく」 最小修正** に絞ってます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)