### PR TITLE
feat(chainlit): runtime output_language switch via cl.ChatSettings

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -31,6 +31,13 @@ import chainlit as cl
 from reyn.chainlit_app.adapter import outbox_to_chainlit
 from reyn.chainlit_app.history import DEFAULT_REPLAY_CAP, history_to_chainlit
 from reyn.chainlit_app.profiles import list_agent_profiles
+from reyn.chainlit_app.settings import (
+    LANGUAGE_ITEMS,
+    LANGUAGE_SETTING_ID,
+    language_label_for,
+    language_to_value,
+    value_to_language,
+)
 from reyn.chainlit_app.slash_route import (
     QUICK_ACTIONS,
     QuickAction,
@@ -296,6 +303,30 @@ async def _on_chat_start() -> None:
 
     task = asyncio.create_task(_drain_loop(registry))
     cl.user_session.set(_DRAIN_KEY, task)
+
+    # Settings panel: surface ``output_language`` as a per-cl-session
+    # knob so the operator can flip Auto / 日本語 / English / 中文 / 한국어
+    # without restarting `reyn chainlit`. ``cl.ChatSettings(...).send()``
+    # renders the gear icon next to the input box; selecting an item
+    # fires ``@cl.on_settings_update`` below.
+    try:
+        await cl.ChatSettings([
+            cl.input_widget.Select(
+                id=LANGUAGE_SETTING_ID,
+                label="Output language",
+                items=dict(LANGUAGE_ITEMS),
+                initial_value=language_to_value(
+                    getattr(session, "output_language", None),
+                ),
+                tooltip=(
+                    "LLM の応答言語の指定。 Auto で LLM が user 入力に"
+                    "合わせる。 変更は次の turn から有効。"
+                ),
+            ),
+        ]).send()
+    except Exception:
+        pass
+
     actions = [
         cl.Action(
             name=action_name_for(qa),
@@ -309,6 +340,30 @@ async def _on_chat_start() -> None:
         author="system",
         actions=actions,
     ).send()
+
+
+@cl.on_settings_update
+async def _on_settings_update(settings: dict) -> None:
+    """Apply the gear-icon settings panel updates to the attached session.
+
+    Currently only handles ``output_language``. Future per-session knobs
+    (= e.g. ``REYN_CHAINLIT_HISTORY_CAP`` mid-session change, allowed
+    skill filter) plug into this same dispatcher.
+    """
+    registry = await _get_or_build_registry()
+    session = registry.attached_session()
+    if session is None:
+        return
+    if LANGUAGE_SETTING_ID in settings:
+        value = settings.get(LANGUAGE_SETTING_ID)
+        new_lang = value_to_language(value)
+        session.output_language = new_lang
+        await cl.Message(
+            content=(
+                f"Output language → **{language_label_for(value or 'auto')}**."
+            ),
+            author="system",
+        ).send()
 
 
 @cl.on_message

--- a/src/reyn/chainlit_app/settings.py
+++ b/src/reyn/chainlit_app/settings.py
@@ -1,0 +1,82 @@
+"""Per-session chainlit settings panel for runtime knobs.
+
+``cl.ChatSettings`` lets the operator flip per-session knobs from a
+gear icon next to the input box without restarting ``reyn chainlit``.
+Today we expose one: the LLM ``output_language`` directive that
+otherwise lives in ``reyn.yaml`` and is fixed at process startup.
+
+Pure helper, no chainlit import — unit tests run without the
+``[chainlit]`` extra installed.
+"""
+from __future__ import annotations
+
+# Settings widget id used as the dict key in ``cl.on_settings_update``.
+LANGUAGE_SETTING_ID = "output_language"
+
+# ``_AUTO_VALUE`` represents "let the LLM pick based on the user's
+# input" (= ``session.output_language = None`` reyn-side). Stored as a
+# real string because chainlit's Select widget requires non-null values
+# in its ``items`` map — we round-trip it back to ``None`` on apply.
+_AUTO_VALUE = "auto"
+
+# label → value. Chainlit's Select widget shows the label in the
+# dropdown; ``value`` lands in the ``on_settings_update`` payload.
+# Curated short list — adding a 5th option is just a new dict entry.
+LANGUAGE_ITEMS: dict[str, str] = {
+    "Auto (LLM decides)": _AUTO_VALUE,
+    "日本語": "ja",
+    "English": "en",
+    "中文": "zh",
+    "한국어": "ko",
+}
+
+
+def language_to_value(lang: str | None) -> str:
+    """Map ``ChatSession.output_language`` → widget select value.
+
+    None / empty → ``"auto"`` (= the widget always renders a concrete
+    selection, never blank). Known codes pass through; unknown codes
+    also pass through so a user's custom yaml setting survives the
+    round-trip even if not in ``LANGUAGE_ITEMS`` (= chainlit shows the
+    raw code as the active value).
+    """
+    if lang is None or not lang.strip():
+        return _AUTO_VALUE
+    return lang.strip()
+
+
+def value_to_language(value: str | None) -> str | None:
+    """Map widget select value → ``ChatSession.output_language``.
+
+    ``"auto"`` / None / empty → ``None`` (= let the LLM pick). Any
+    other value passes through verbatim so a future widget item
+    addition reaches reyn without an additional dispatch table.
+    """
+    if value is None:
+        return None
+    v = value.strip()
+    if not v or v == _AUTO_VALUE:
+        return None
+    return v
+
+
+def language_label_for(value: str) -> str:
+    """Reverse lookup: value → human label (= for confirmation messages).
+
+    Falls back to the raw value when not in the curated dict (= a
+    custom yaml-set code still gets a readable acknowledgement instead
+    of an empty cell).
+    """
+    for label, v in LANGUAGE_ITEMS.items():
+        if v == value:
+            return label
+    return value
+
+
+__all__ = [
+    "LANGUAGE_ITEMS",
+    "LANGUAGE_SETTING_ID",
+    "language_label_for",
+    "language_to_value",
+    "value_to_language",
+]

--- a/tests/cli/test_chainlit_settings.py
+++ b/tests/cli/test_chainlit_settings.py
@@ -1,0 +1,107 @@
+"""Tier 1: ``reyn.chainlit_app.settings`` round-trip contracts.
+
+The chat-settings panel surfaces ``output_language`` as a Select
+widget. Two round-trips need to stay consistent:
+
+1. ``ChatSession.output_language`` (str | None) → widget select value
+   (always non-empty string, ``"auto"`` for None) so the dropdown is
+   never blank.
+2. widget select value → ``ChatSession.output_language`` (str | None)
+   so ``"auto"`` round-trips back to ``None`` and reaches reyn's
+   "let the LLM decide" branch.
+
+Plus: every value in ``LANGUAGE_ITEMS`` round-trips through
+``value_to_language(language_to_value(...))`` (= catalog
+self-consistency).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chainlit_app.settings import (
+    LANGUAGE_ITEMS,
+    LANGUAGE_SETTING_ID,
+    language_label_for,
+    language_to_value,
+    value_to_language,
+)
+
+
+def test_setting_id_is_stable():
+    """Tier 1: the dict key the widget emits + ``on_settings_update``
+    expects must agree. Pin the literal so a rename surfaces here."""
+    assert LANGUAGE_SETTING_ID == "output_language"
+
+
+def test_language_items_non_empty():
+    """Tier 1: at least Auto + 1 language so the dropdown isn't useless."""
+    assert len(LANGUAGE_ITEMS) >= 2
+    assert "auto" in LANGUAGE_ITEMS.values()
+
+
+def test_language_to_value_none_maps_to_auto():
+    """Tier 1: reyn's `None` (= LLM decides) → widget shows "Auto"."""
+    assert language_to_value(None) == "auto"
+
+
+def test_language_to_value_empty_string_maps_to_auto():
+    """Tier 1: empty / whitespace-only → "auto" (= same as None)."""
+    assert language_to_value("") == "auto"
+    assert language_to_value("   ") == "auto"
+
+
+@pytest.mark.parametrize("lang", ["ja", "en", "zh", "ko"])
+def test_language_to_value_known_codes_pass_through(lang: str):
+    """Tier 1: known BCP-47 codes hit the widget as-is."""
+    assert language_to_value(lang) == lang
+
+
+def test_language_to_value_unknown_code_preserved():
+    """Tier 1: yaml-set custom code (= not in items) still round-trips
+    so the operator's setting isn't silently flattened to Auto."""
+    assert language_to_value("de") == "de"
+
+
+def test_value_to_language_auto_maps_to_none():
+    """Tier 1: widget "auto" → reyn None (= "LLM decides")."""
+    assert value_to_language("auto") is None
+
+
+def test_value_to_language_empty_and_none_map_to_none():
+    """Tier 1: defensive — empty / None input → None."""
+    assert value_to_language(None) is None
+    assert value_to_language("") is None
+    assert value_to_language("   ") is None
+
+
+@pytest.mark.parametrize("v", ["ja", "en", "zh", "ko", "de"])
+def test_value_to_language_known_and_unknown_pass_through(v: str):
+    """Tier 1: any non-"auto" value reaches reyn verbatim — no dispatch
+    table to maintain when adding a new widget item."""
+    assert value_to_language(v) == v
+
+
+def test_round_trip_for_every_catalog_value():
+    """Tier 1: ``value_to_language(language_to_value(v))`` is the
+    identity for every curated value (= catalog self-consistency)."""
+    for v in LANGUAGE_ITEMS.values():
+        # auto round-trips as: "auto" → None → "auto"
+        if v == "auto":
+            assert value_to_language(v) is None
+            assert language_to_value(None) == "auto"
+        else:
+            assert value_to_language(v) == v
+            assert language_to_value(v) == v
+
+
+def test_language_label_for_known_value():
+    """Tier 1: confirmation message uses the human label, not the code."""
+    assert language_label_for("ja") == "日本語"
+    assert language_label_for("en") == "English"
+    assert language_label_for("auto") == "Auto (LLM decides)"
+
+
+def test_language_label_for_unknown_falls_back_to_value():
+    """Tier 1: yaml-set custom code without a curated label still gets
+    a readable acknowledgement (= the raw code itself)."""
+    assert language_label_for("de") == "de"


### PR DESCRIPTION
**[tui-coder]** — user dogfood 2026-05-25「runtime 上で output_language 帰れるようにできるんかな？」 → **yes**、 reyn 側 trivial 改修無し、 chainlit-side で UI 追加。

## reyn 側確認

`ChatSession.output_language` は **plain attribute** (= `self.output_language = output_language` 単純代入、 property 無し)。 各 turn の prompt builder (= router/skill/router_loop で `output_language=self.output_language` で渡される) で読まれるため、 mid-session に値を変えると **次 user message から反映**。 = reyn engine 改修ゼロで可。

## 実装

- `reyn.chainlit_app.settings` (新 pure helper):
  - `LANGUAGE_ITEMS: dict[str,str]` curated catalog (= Auto / 日本語 / English / 中文 / 한국어)
  - `language_to_value()` / `value_to_language()` round-trip (= `None ↔ "auto"`、 known codes pass-through、 unknown yaml-set codes preserved 双方向)
  - `language_label_for()` 確認メッセージ用 human label
- `_on_chat_start` で `cl.ChatSettings([Select(id="output_language", items=...)])` 送出、 `initial_value` を現 session の `output_language` から
- `@cl.on_settings_update` で値受信 → `session.output_language = value_to_language(...)` 代入 + 「Output language → **<label>**.」 system message で確認

try/except wrap で chainlit version drift / context 不在は「panel 無し」 に degrade、 attach 自体は失敗させない。

## Why scope-limited

memory `chainlit-focus-no-internals` 準拠 — `src/reyn/chainlit_app/{settings,app}.py` + tests のみ touch、 reyn engine 不変。 `session.output_language` は既存 public attribute、 read-write access (= mutate しても reyn の他 caller に副作用無し)。

## Test plan

- [x] **Tier 1 settings round-trip** — `pytest tests/cli/test_chainlit_settings.py` (12 tests 緑、 catalog 自己整合性 / None↔auto / known/unknown 双方向 / label 逆引き / 設定 id 安定性)
- [x] **Full chainlit-side suite** — 96 tests 緑 (= 既存 84 + 新 12)
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — settings import + ChatSettings/on_settings_update 追加で crash 無し
- [ ] (skipped — needs browser interaction with gear icon) **Manual: 入力欄横の歯車アイコンで panel 開く → Select dropdown に 5 言語 + 現言語 initial selected**
- [ ] (skipped — same) **Manual: dropdown で「English」 選択 → 確認 system message 「Output language → **English**.」 → 次 user prompt の応答が英語**
- [ ] (skipped — same) **Manual: yaml で `output_language: de` 設定 → panel に raw value "de" が initial、 操作者 confirm 表示も "de" (= label fallback)**

local server 9001 で 1, 2 番 verify 予定 (user に refresh + dropdown 操作依頼)。

## Tier self-check

- ✅ Tier 1 only (= pure round-trip + catalog 自己整合性)
- ✅ private state assert なし (= public attribute `session.output_language` を assign しても assert 対象は helper return value)
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)