### PR TITLE
feat(slash): /clear-history wipes chat history + action-usage table

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -191,6 +191,7 @@ from reyn.chat.slash import agent as _agent_mod  # noqa: E402, F401
 from reyn.chat.slash import agents as _agents_mod  # noqa: E402, F401
 from reyn.chat.slash import budget as _budget_mod  # noqa: E402, F401
 from reyn.chat.slash import chat as _chat_mod  # noqa: E402, F401
+from reyn.chat.slash import clear_history as _clear_history_mod  # noqa: E402, F401
 from reyn.chat.slash import concept as _concept_mod  # noqa: E402, F401
 from reyn.chat.slash import copy as _copy_mod  # noqa: E402, F401
 from reyn.chat.slash import cost_inline as _cost_inline_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/clear_history.py
+++ b/src/reyn/chat/slash/clear_history.py
@@ -1,0 +1,108 @@
+"""``/clear-history`` — wipe chat history + action-usage table.
+
+Sibling to ``/reset`` (skill state) at a different scope: this command
+clears the conversation thread (``ChatSession.history`` + per-agent
+``history.jsonl``) and the action-usage tracker (= the ranking that
+backs the Memory tab's hot-list augmentation, persisted at
+``.reyn/state/action_usage.jsonl``). Everything else stays intact:
+
+- ``.reyn/events/``                (P6 audit truth — never touched)
+- ``.reyn/state/wal.jsonl``        (skill resume — preserved)
+- ``.reyn/agents/<n>/state/``      (snapshot.json / plans / skills)
+- ``profile.yaml`` / MEMORY.md     (non-runtime config)
+- ``.input_history``               (operator's typed history)
+
+User dogfood 2026-05-25:
+  「ヒストリとagents_usage を初期状態にする、 他はクリアしない」
+
+Two-step confirmation pattern mirrors ``/reset`` because the history
+delete is irreversible (= history.jsonl isn't tracked by git in any
+typical project layout).
+"""
+from __future__ import annotations
+
+from reyn.chat.slash import reply, reply_error, slash
+
+
+def _format_currently_line(session: "object") -> str:
+    """Build a 'Currently: N history turns, M tracked tools' context line."""
+    history = getattr(session, "history", None)
+    tracker = getattr(session, "_action_usage_tracker", None)
+
+    parts: list[str] = []
+    if history is not None:
+        n_turns = len(history)
+        word = "turn" if n_turns == 1 else "turns"
+        parts.append(f"{n_turns} history {word}")
+    if tracker is not None:
+        n_tools = len(getattr(tracker, "_compacted", {}) or {})
+        word = "tool" if n_tools == 1 else "tools"
+        parts.append(f"{n_tools} tracked {word}")
+    if not parts:
+        return ""
+    return "Currently: " + ", ".join(parts) + "."
+
+
+@slash(
+    "clear-history",
+    summary=(
+        "Clear conversation history + action-usage table (= events, "
+        "skill state, profile preserved)"
+    ),
+    usage="/clear-history confirm",
+)
+async def clear_history_cmd(session: "object", args: str) -> None:
+    token = args.strip().lower()
+    if token != "confirm":
+        currently = _format_currently_line(session)
+        preamble = f"{currently}\n" if currently else ""
+        await reply(
+            session,
+            f"{preamble}"
+            "⚠ This will clear the chat history and the action-usage "
+            "ranking. Audit logs (.reyn/events/), in-flight skill state "
+            "(WAL + snapshots), agent profile, and MEMORY.md are all "
+            "preserved.\n"
+            "Type `/clear-history confirm` to proceed, or anything else "
+            "to abort.",
+        )
+        return
+
+    history = getattr(session, "history", None)
+    history_path = getattr(session, "history_path", None)
+    tracker = getattr(session, "_action_usage_tracker", None)
+
+    cleared_parts: list[str] = []
+
+    if isinstance(history, list):
+        n_turns_before = len(history)
+        history.clear()
+        cleared_parts.append(f"{n_turns_before} history turn(s)")
+
+    if history_path is not None:
+        try:
+            history_path.unlink(missing_ok=True)
+        except OSError as exc:
+            await reply_error(
+                session,
+                f"failed to remove history file {history_path}: {exc}",
+            )
+            return
+
+    if tracker is not None and hasattr(tracker, "reset"):
+        n_tools_before = len(getattr(tracker, "_compacted", {}) or {})
+        tracker.reset()
+        cleared_parts.append(f"{n_tools_before} tracked tool(s)")
+
+    if not cleared_parts:
+        await reply(
+            session,
+            "✓ Nothing to clear (= history empty, no action-usage tracker).",
+        )
+        return
+
+    await reply(
+        session,
+        "✓ Cleared: " + ", ".join(cleared_parts) + ". "
+        "Audit logs and skill state preserved.",
+    )

--- a/src/reyn/chat/slash/clear_history.py
+++ b/src/reyn/chat/slash/clear_history.py
@@ -35,7 +35,10 @@ def _format_currently_line(session: "object") -> str:
         word = "turn" if n_turns == 1 else "turns"
         parts.append(f"{n_turns} history {word}")
     if tracker is not None:
-        n_tools = len(getattr(tracker, "_compacted", {}) or {})
+        try:
+            n_tools = len(tracker)
+        except TypeError:
+            n_tools = 0
         word = "tool" if n_tools == 1 else "tools"
         parts.append(f"{n_tools} tracked {word}")
     if not parts:
@@ -90,7 +93,10 @@ async def clear_history_cmd(session: "object", args: str) -> None:
             return
 
     if tracker is not None and hasattr(tracker, "reset"):
-        n_tools_before = len(getattr(tracker, "_compacted", {}) or {})
+        try:
+            n_tools_before = len(tracker)
+        except TypeError:
+            n_tools_before = 0
         tracker.reset()
         cleared_parts.append(f"{n_tools_before} tracked tool(s)")
 

--- a/src/reyn/tools/action_usage_tracker.py
+++ b/src/reyn/tools/action_usage_tracker.py
@@ -218,6 +218,16 @@ class ActionUsageTracker:
 
     # ── Public surface ────────────────────────────────────────────────────
 
+    def __len__(self) -> int:
+        """Number of qualified action names currently tracked.
+
+        Public counter for callers that want to surface "how many tools
+        are in the ranking" without reaching into the internal
+        compacted table (= ``len(tracker)`` reads cleanly in slash
+        previews / confirmation messages).
+        """
+        return len(self._compacted)
+
     def reset(self) -> None:
         """Clear the in-memory compacted table + remove the persist file.
 

--- a/src/reyn/tools/action_usage_tracker.py
+++ b/src/reyn/tools/action_usage_tracker.py
@@ -218,6 +218,27 @@ class ActionUsageTracker:
 
     # ── Public surface ────────────────────────────────────────────────────
 
+    def reset(self) -> None:
+        """Clear the in-memory compacted table + remove the persist file.
+
+        Intended for the ``/clear-history`` slash command and similar
+        explicit "start fresh" affordances. Preserves the tracker's
+        identity (= caller's reference stays valid) so the active
+        ChatSession's wiring keeps working immediately after the
+        reset — only the *data* is wiped.
+
+        Persist-file removal is best-effort (= matches the
+        ``_persist_table`` posture of treating disk failure as
+        non-fatal). The in-memory clear always happens.
+        """
+        self._compacted = {}
+        self._prior_ranking_order = None
+        if self._persist_path is not None:
+            try:
+                self._persist_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
     def merge_compacted(self, records: list[tuple[str, float]]) -> None:
         """Merge a batch of ``(qualified_name, ts)`` records into the
         compacted table.

--- a/tests/test_clear_history_slash_command.py
+++ b/tests/test_clear_history_slash_command.py
@@ -63,10 +63,10 @@ def test_tracker_reset_empties_in_memory_state(tmp_path: Path):
     path = tmp_path / "action_usage.json"
     tracker = ActionUsageTracker(persist_path=path)
     tracker.merge_compacted([("file__read", 100.0), ("file__write", 101.0)])
-    assert len(tracker._compacted) == 2
+    assert len(tracker) == 2
 
     tracker.reset()
-    assert tracker._compacted == {}
+    assert len(tracker) == 0
 
 
 def test_tracker_reset_removes_persist_file(tmp_path: Path):
@@ -88,7 +88,7 @@ def test_tracker_reset_safe_when_file_already_gone(tmp_path: Path):
     tracker.reset()
     # Second reset should not raise even though file is gone.
     tracker.reset()
-    assert tracker._compacted == {}
+    assert len(tracker) == 0
 
 
 def test_tracker_reset_preserves_instance_identity(tmp_path: Path):
@@ -99,8 +99,9 @@ def test_tracker_reset_preserves_instance_identity(tmp_path: Path):
     tracker.merge_compacted([("file__read", 50.0)])
     tracker.reset()
     tracker.merge_compacted([("file__write", 200.0)])
-    assert "file__read" not in tracker._compacted
-    assert "file__write" in tracker._compacted
+    names = {r["qualified_name"] for r in tracker.full_ranking()}
+    assert "file__read" not in names
+    assert "file__write" in names
 
 
 def test_tracker_reset_with_no_persist_path():
@@ -109,7 +110,7 @@ def test_tracker_reset_with_no_persist_path():
     tracker = ActionUsageTracker(persist_path=None)
     tracker.merge_compacted([("file__read", 1.0)])
     tracker.reset()
-    assert tracker._compacted == {}
+    assert len(tracker) == 0
 
 
 # ── /clear-history slash command ──────────────────────────────────────────
@@ -148,7 +149,8 @@ async def test_bare_slash_prints_warning_and_does_not_wipe(tmp_path: Path):
     # Data still intact.
     assert session.history == ["turn1", "turn2"]
     assert history_path.exists()
-    assert "file__read" in tracker._compacted
+    names = {r["qualified_name"] for r in tracker.full_ranking()}
+    assert "file__read" in names
 
 
 @pytest.mark.asyncio
@@ -171,7 +173,7 @@ async def test_confirm_clears_history_and_tracker(tmp_path: Path):
 
     assert session.history == []
     assert not history_path.exists()
-    assert tracker._compacted == {}
+    assert len(tracker) == 0
     msgs = _drain_outbox(session)
     success_lines = [m.text for m in msgs if "Cleared" in m.text]
     assert success_lines, f"expected a confirmation; got {[m.text for m in msgs]}"

--- a/tests/test_clear_history_slash_command.py
+++ b/tests/test_clear_history_slash_command.py
@@ -1,0 +1,237 @@
+"""Tier 2: ``/clear-history`` slash command + ``ActionUsageTracker.reset()``.
+
+User dogfood 2026-05-25 asked for a slash that resets history +
+action_usage to initial state without touching anything else. This
+file pins:
+
+1. Two-step confirmation (= bare ``/clear-history`` warns, requires
+   ``confirm`` to actually wipe).
+2. ``confirm`` form clears ``session.history`` (in-memory) AND removes
+   ``session.history_path`` (on-disk).
+3. ``confirm`` form calls ``tracker.reset()`` when tracker is wired.
+4. ``tracker.reset()`` empties the in-memory table + removes the
+   persist file but leaves the tracker instance reusable.
+5. The slash does NOT touch the ``events/`` directory, the WAL, or the
+   per-agent snapshot.
+
+These are Tier 2 (= OS invariant — wipe surface guarantees) rather
+than Tier 1 because they involve the slash router + filesystem.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import REGISTRY
+from reyn.tools.action_usage_tracker import ActionUsageTracker
+
+
+class _StubSession:
+    """Minimal session-shaped object the slash handler reads from.
+
+    The handler uses ``history``, ``history_path``, ``_action_usage_tracker``,
+    and the same ``_put_outbox`` channel ``reply()`` / ``reply_error()``
+    use. Everything else can be absent.
+    """
+
+    def __init__(self, *, history: list, history_path: Path, tracker):
+        self.history = history
+        self.history_path = history_path
+        self._action_usage_tracker = tracker
+        self.outbox: asyncio.Queue = asyncio.Queue()
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        await self.outbox.put(msg)
+
+
+def _drain_outbox(session: _StubSession) -> list[OutboxMessage]:
+    msgs: list[OutboxMessage] = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+# ── ActionUsageTracker.reset() ────────────────────────────────────────────
+
+
+def test_tracker_reset_empties_in_memory_state(tmp_path: Path):
+    """Tier 2: tracker.reset() clears the compacted table."""
+    path = tmp_path / "action_usage.json"
+    tracker = ActionUsageTracker(persist_path=path)
+    tracker.merge_compacted([("file__read", 100.0), ("file__write", 101.0)])
+    assert len(tracker._compacted) == 2
+
+    tracker.reset()
+    assert tracker._compacted == {}
+
+
+def test_tracker_reset_removes_persist_file(tmp_path: Path):
+    """Tier 2: tracker.reset() deletes the on-disk persist file."""
+    path = tmp_path / "action_usage.json"
+    tracker = ActionUsageTracker(persist_path=path)
+    tracker.merge_compacted([("file__read", 100.0)])
+    assert path.exists()
+
+    tracker.reset()
+    assert not path.exists()
+
+
+def test_tracker_reset_safe_when_file_already_gone(tmp_path: Path):
+    """Tier 2: reset() is idempotent — second call is a no-op, no exception."""
+    path = tmp_path / "action_usage.json"
+    tracker = ActionUsageTracker(persist_path=path)
+    tracker.merge_compacted([("file__read", 100.0)])
+    tracker.reset()
+    # Second reset should not raise even though file is gone.
+    tracker.reset()
+    assert tracker._compacted == {}
+
+
+def test_tracker_reset_preserves_instance_identity(tmp_path: Path):
+    """Tier 2: tracker stays usable after reset — merge_compacted still
+    appends from a clean slate so the caller's wiring keeps working."""
+    path = tmp_path / "action_usage.json"
+    tracker = ActionUsageTracker(persist_path=path)
+    tracker.merge_compacted([("file__read", 50.0)])
+    tracker.reset()
+    tracker.merge_compacted([("file__write", 200.0)])
+    assert "file__read" not in tracker._compacted
+    assert "file__write" in tracker._compacted
+
+
+def test_tracker_reset_with_no_persist_path():
+    """Tier 2: tracker constructed without persist_path → reset() doesn't
+    crash trying to unlink a None path."""
+    tracker = ActionUsageTracker(persist_path=None)
+    tracker.merge_compacted([("file__read", 1.0)])
+    tracker.reset()
+    assert tracker._compacted == {}
+
+
+# ── /clear-history slash command ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slash_registered():
+    """Tier 2: the slash command is discoverable via the registry."""
+    cmd = REGISTRY.get("clear-history")
+    assert cmd is not None
+    assert cmd.name == "clear-history"
+
+
+@pytest.mark.asyncio
+async def test_bare_slash_prints_warning_and_does_not_wipe(tmp_path: Path):
+    """Tier 2: ``/clear-history`` (no confirm) preserves all data and
+    prints a warning that asks for the confirm token."""
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("nonempty\n")
+    tracker = ActionUsageTracker(persist_path=tmp_path / "action_usage.json")
+    tracker.merge_compacted([("file__read", 100.0)])
+
+    session = _StubSession(
+        history=["turn1", "turn2"],
+        history_path=history_path,
+        tracker=tracker,
+    )
+    cmd = REGISTRY.get("clear-history")
+    assert cmd is not None
+    await cmd.handler(session, "")
+
+    msgs = _drain_outbox(session)
+    assert len(msgs) >= 1
+    body = msgs[-1].text
+    assert "confirm" in body.lower()
+    # Data still intact.
+    assert session.history == ["turn1", "turn2"]
+    assert history_path.exists()
+    assert "file__read" in tracker._compacted
+
+
+@pytest.mark.asyncio
+async def test_confirm_clears_history_and_tracker(tmp_path: Path):
+    """Tier 2: ``/clear-history confirm`` wipes both."""
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text(
+        json.dumps({"role": "user", "content": "hi"}) + "\n",
+    )
+    tracker = ActionUsageTracker(persist_path=tmp_path / "action_usage.json")
+    tracker.merge_compacted([("file__read", 100.0), ("file__write", 101.0)])
+
+    session = _StubSession(
+        history=["turn1", "turn2", "turn3"],
+        history_path=history_path,
+        tracker=tracker,
+    )
+    cmd = REGISTRY.get("clear-history")
+    await cmd.handler(session, "confirm")
+
+    assert session.history == []
+    assert not history_path.exists()
+    assert tracker._compacted == {}
+    msgs = _drain_outbox(session)
+    success_lines = [m.text for m in msgs if "Cleared" in m.text]
+    assert success_lines, f"expected a confirmation; got {[m.text for m in msgs]}"
+
+
+@pytest.mark.asyncio
+async def test_confirm_preserves_unrelated_files(tmp_path: Path):
+    """Tier 2: the slash MUST NOT touch events/, the WAL, or snapshots —
+    those live elsewhere on disk. Place a sentinel file in each and
+    verify it survives."""
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("h\n")
+
+    # Sibling sentinels — these stand in for events/ / state/ etc.
+    events_sentinel = tmp_path / "events.jsonl"
+    events_sentinel.write_text("audit-log-entry\n")
+    wal_sentinel = tmp_path / "wal.jsonl"
+    wal_sentinel.write_text("wal-entry\n")
+    snapshot_sentinel = tmp_path / "snapshot.json"
+    snapshot_sentinel.write_text("{}\n")
+
+    tracker = ActionUsageTracker(persist_path=tmp_path / "action_usage.json")
+    tracker.merge_compacted([("file__read", 1.0)])
+
+    session = _StubSession(
+        history=["x"], history_path=history_path, tracker=tracker,
+    )
+    cmd = REGISTRY.get("clear-history")
+    await cmd.handler(session, "confirm")
+
+    assert events_sentinel.read_text() == "audit-log-entry\n"
+    assert wal_sentinel.read_text() == "wal-entry\n"
+    assert snapshot_sentinel.read_text() == "{}\n"
+
+
+@pytest.mark.asyncio
+async def test_confirm_when_tracker_missing(tmp_path: Path):
+    """Tier 2: session without tracker (= test / minimal session) still
+    succeeds — only the history side runs."""
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("h\n")
+    session = _StubSession(
+        history=["x"], history_path=history_path, tracker=None,
+    )
+    cmd = REGISTRY.get("clear-history")
+    await cmd.handler(session, "confirm")
+    assert session.history == []
+    assert not history_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_confirm_when_history_already_empty(tmp_path: Path):
+    """Tier 2: empty history + no tracker → success message stays
+    informative, no crash."""
+    session = _StubSession(
+        history=[],
+        history_path=tmp_path / "nonexistent.jsonl",
+        tracker=None,
+    )
+    cmd = REGISTRY.get("clear-history")
+    await cmd.handler(session, "confirm")
+    msgs = _drain_outbox(session)
+    assert msgs  # something was said


### PR DESCRIPTION
**[tui-coder]** — user direct request 2026-05-25「スラッシュコマンド clear-history がほしい。 ヒストリとagents_usage を初期状態にする、 他はクリアしない」

**Note**: これは **reyn-side slash command** (= 全 surface = TUI / CUI / chainlit 効) で、 「reyn 内部後回し」 制約 ([[chainlit-focus-no-internals]]) を user 直接 ask で今回 lift (= user 判断)。

## Scope (deliberately narrow)

| Action | Path |
|---|---|
| **CLEAR** | `session.history` (in-memory) |
| **CLEAR** | `session.history_path` (= `.reyn/agents/<n>/history.jsonl`) |
| **CLEAR** | `tracker._compacted` (in-memory) |
| **CLEAR** | `tracker._persist_path` (= `.reyn/state/action_usage.jsonl`) |
| **PRESERVE** | `.reyn/events/` (P6 audit truth) |
| **PRESERVE** | `.reyn/state/wal.jsonl` (skill resume) |
| **PRESERVE** | `.reyn/agents/<n>/state/{snapshot,plans,skills}/` |
| **PRESERVE** | `profile.yaml` / `MEMORY.md` / `.input_history` |

## 実装

1. `reyn.tools.action_usage_tracker.ActionUsageTracker.reset()` — `_compacted = {}` + `_persist_path.unlink(missing_ok=True)`、 best-effort posture (`_persist_table` と同 swallow OSError)。 **instance identity 保持** = active session の wiring が切れない (= 既参照が valid のまま、 データだけ wipe)
2. `reyn.chat.slash.clear_history` (新): two-step confirm (= `/reset` 同 pattern、 irreversible delete のため)
   - bare `/clear-history` → 「Currently: N turns, M tools」 + warning + `/clear-history confirm` 案内
   - `/clear-history confirm` → 実行 + 「Cleared: N turn(s), M tool(s)」 success message
3. `slash/__init__.py` — alphabetical 位置 (chat → clear_history → concept) で import

## Why two-step

`/reset` (= skill state wipe) と同レベル severity (= history.jsonl は git tracked でない typical layout、 失うと元に戻せない)。 friction add は意図的、 操作者の typo / 誤クリック保護。

## Test plan

- [x] **Tier 2** — `pytest tests/test_clear_history_slash_command.py` (11 tests 緑、 = tracker reset 5 + slash 6)
- [x] **Regression** — `pytest tests/test_action_usage_tracker.py` (25 tests 緑、 既存 tracker test 影響無し)
- [x] **ruff clean** — 全 touched files
- [ ] (skipped — needs interactive session) **Manual: TUI `/clear-history` → warning → `/clear-history confirm` → success message → 履歴 / hot-list が空に**
- [ ] (skipped — same) **Manual: chainlit でも同 slash 動作 (= #893 で slash routing 既に wired)**
- [ ] (skipped — same) **Manual: `.reyn/events/` の audit log が destination unchanged で残存 (= cat 行数 confirm)**

local server 9001 で 1, 3 番 verify 予定。

## Tier self-check

- ✅ Tier 2 (= OS invariant、 file-side wipe contract)
- ✅ private state assert: `_compacted` / `_persist_path` は test 内で reset 後の state 検証用 (= public surface には `reset()` exposure 、 内部 dict の assert は invariant 確認に必須、 lead-coder review 判断仰ぐ)
- ✅ MagicMock / AsyncMock なし (= _StubSession dataclass + asyncio.Queue)
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)