### PR TITLE
refactor(hot-list): swap mcp 'use installed server' verbs into seed

### DIFF
--- a/src/reyn/tools/action_usage_tracker.py
+++ b/src/reyn/tools/action_usage_tracker.py
@@ -92,6 +92,17 @@ from typing import Callable
 #         as a sibling (= verb-collapse of the previous skill-space hidden
 #         install action, so installation requests don't require list_actions
 #         discovery first).
+#   2026-05-25 (post-#898): mcp__list_tools + mcp__call_tool added (= the
+#         "USE installed server" cold-start path observed missing in the
+#         5-server walkthrough). skill__skill_importer + rag.operation__
+#         drop_source dropped to keep seed size constant — skill_importer
+#         is the niche of the three flagship skill__skill_* verbs (=
+#         external import flow vs builder/improver), and drop_source's
+#         B37 schema-hallucination protection is now covered by the ARS
+#         scope expansion (= ``KNOWN_STATIC_QUALIFIED_NAMES`` is always in
+#         ARS regardless of hot-list per the B38 contract; see
+#         ``_collect_all_session_ars_entries``), so seed presence is no
+#         longer load-bearing for that invariant.
 DEFAULT_HOT_LIST_SEED: tuple[str, ...] = (
     "file__read",
     "file__list",
@@ -102,13 +113,13 @@ DEFAULT_HOT_LIST_SEED: tuple[str, ...] = (
     "reyn.source__list",
     "web__search",
     "web__fetch",
-    "rag.operation__drop_source",
     "memory.operation__remember_shared",
     "skill__skill_builder",
     "skill__skill_improver",
-    "skill__skill_importer",
     "mcp__search_server",
     "mcp__install_server",
+    "mcp__list_tools",
+    "mcp__call_tool",
     "skill__index_docs",
     "skill__eval",
 )

--- a/tests/test_hot_list_seed_default.py
+++ b/tests/test_hot_list_seed_default.py
@@ -23,16 +23,25 @@ from reyn.tools.universal_dispatch import UnknownActionError, resolve_invoke_act
 # file__write — W4 S1: LLM used args key "text" instead of "content" because
 # the action was absent from the hot list and the D2-wrapper ARS block had no
 # entry for it.
-# rag.operation__drop_source — W2 S1 / W4 S6: LLM used "source_id" then
-# "source_name" across batches; synonym normalization is bankrupt. Seeding
-# exposes the canonical {source} schema upfront.
+# 2026-05-25 (post-#898 hot-list seed swap): rag.operation__drop_source
+# removed from the required-entries pin. Its B37 schema-hallucination
+# protection is now covered by the ARS scope-expansion contract (=
+# KNOWN_STATIC_QUALIFIED_NAMES is always in ARS regardless of hot-list,
+# per B38; see test_invoke_action_scope_expansion.py::
+# test_static_ops_always_present_no_session_state). Seed presence is no
+# longer the load-bearing mechanism for that invariant.
+# mcp__list_tools + mcp__call_tool — 2026-05-25 walkthrough: cold-start
+# "use an installed MCP server" path required discovery via list_actions
+# before chaining mcp__list_tools / mcp__call_tool; seeding skips the
+# discovery turn.
 # web__fetch — W3 S4: present in seed since B34; this test asserts it remains.
 
 _B37_REQUIRED_ENTRIES: tuple[str, ...] = (
     "mcp__search_server",         # #879: mcp routing — search verb in hot list
     "mcp__install_server",        # #879: mcp routing — install verb in hot list
+    "mcp__list_tools",            # post-#898: cold-start "use server" verb
+    "mcp__call_tool",             # post-#898: cold-start "use server" verb
     "file__write",                # W4 S1: arg-key hallucination (text vs content)
-    "rag.operation__drop_source", # W2 S1 / W4 S6: hallucination drift source_id→source_name
     "web__fetch",                 # W3 S4: web fetch intent cold-start coverage
 )
 


### PR DESCRIPTION
**[e2e-coder]** — DEFAULT_HOT_LIST_SEED の 2-for-2 swap で 「installed MCP server を USE する」 verbs (mcp__list_tools / mcp__call_tool) を cold-start で直接見えるようにする。 seed size 不変 (17 → 17)、 `hot_list_n` 不変 (20)。

## Why now

5-server walkthrough (2026-05-24、 post-#891) で **5/5 fresh agent doc-example prompt が `list_actions(category=["mcp"])` discovery turn を必要** とし、 2/5 で G12 signal empty-stop trigger、 1/5 で tool 名 guess hallucination。 「installed server を USE する」 verbs が seed なしで cold-start で discoverable でないことが root cause の 1 つ。

seed-growth log pattern (= dogfood で observed cold-start gap を trigger に seed 追加) と整合。

## Swap

| Out | In |
|---|---|
| `skill__skill_importer` (= 3 flagship skill__skill_* の niche、 builder/improver より頻度低) | `mcp__list_tools` (= USE server の discovery verb) |
| `rag.operation__drop_source` (= B37 schema-hallucination 防止用に seed されていたが、 B38 ARS scope-expansion contract で seed-as-mechanism は obsolete) | `mcp__call_tool` (= USE server の dispatch verb) |

## なぜ rag.operation__drop_source を抜けるか

B37 (= LLM が `source_id` / `source_name` を hallucinate) は B38 ARS scope-expansion で fix:
- `KNOWN_STATIC_QUALIFIED_NAMES` の全 entry は **hot-list seed と無関係に常に ARS に存在** (= `test_invoke_action_scope_expansion.py::test_static_ops_always_present_no_session_state` で pin)
- LLM は `invoke_action(rag.operation__drop_source, {source: "X"})` で canonical `{source}` schema へ access 可能、 seed 経由でなくても

→ B38 contract が effective な現状、 seed presence は load-bearing でない。 hot-list slot を MCP USE verbs に明け渡せる。

## Diff

- `src/reyn/tools/action_usage_tracker.py`: DEFAULT_HOT_LIST_SEED 2 entries swap、 growth log に rationale 追記
- `tests/test_hot_list_seed_default.py`: `_B37_REQUIRED_ENTRIES` parametrize 更新 (= drop_source 削除、 mcp 2 verbs 追加)

## Test plan

- [x] `ruff check .` → green
- [x] `pytest -q --ignore=.claude` → 5736 passed, 1 environment-specific pre-existing failure (= `test_legacy_no_media_store_path_returns_inline_content`、 trafilatura、 main で既存)
- [x] `pytest -q tests/test_hot_list_seed_default.py tests/test_invoke_action_scope_expansion.py tests/test_invoke_action_schema_propagation.py tests/test_action_usage_tracker.py` → 57 passed (= B37 invariant / ARS scope contract / tracker behavior 全部維持)
- [x] No replay fixtures affected (= seed changes tools[] shape only, replay hash 不変)
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし (= B37 schema invariant は ARS contract に shift、 seed pin は higher-level cold-start UX 改善 pin に置換) ✓ / audit 0 errors ✓

## Methodology note

User 直接 directive (= 2026-05-25): 「テストに合わせた設計をしないで。 テストが hotlist 依存するのが悪いんだから」 + 「invoke_action 経由で動くようにすれば良いだけでしょ」 = test の seed-pin に対する design freedom 確認。 swap の load-bearing 判断は B38 ARS contract の test invariant (= `test_static_ops_always_present_no_session_state`) で primary evidence backed、 seed-only に依存していなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)