### PR TITLE
feat(slash): /agent edit role <text> rewrites attached agent's persona

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1339,6 +1339,12 @@ class ChatSession:
         self._prompt_cache_enabled = prompt_cache_enabled
         self._project_context = project_context
         self._agent_role = agent_role
+        # ``agent_role`` (public read-only via @property below) gives callers a
+        # stable accessor without exposing the private backing field; mutation
+        # still goes through ``self._agent_role = ...`` (= same convention as
+        # other per-session knobs flipped at runtime, e.g. ``output_language``
+        # / ``model``). The property exists so tests and external read-only
+        # consumers don't reach into the underscore attribute directly.
         # Optional back-reference for slash commands like /agents / /attach
         # and for agent-to-agent message routing (PR11). The factory in
         # cli/commands/chat.py wires this; tests can leave it None.
@@ -1753,6 +1759,18 @@ class ChatSession:
     @property
     def total_cost_usd(self) -> float:
         return self._budget.total_cost_usd
+
+    @property
+    def agent_role(self) -> str:
+        """Read-only public accessor for the attached agent's role text.
+
+        Mutation still goes through ``self._agent_role = ...`` so the
+        intent of "this is a runtime knob, not a constructor-time
+        immutable" stays visible at the call site. Reads via the
+        property are the encapsulation-respecting surface for slash
+        commands and tests that need to verify the role.
+        """
+        return self._agent_role
 
     # ── SkillRunner forwarding (FP-0019 Wave 1b) ────────────────────────────────
     # slash/skill.py and slash/tasks.py access these dicts directly via session.

--- a/src/reyn/chat/slash/agent.py
+++ b/src/reyn/chat/slash/agent.py
@@ -1,18 +1,23 @@
-"""/agent slash command — agent lifecycle from chat (currently: create).
+"""/agent slash command — agent lifecycle from chat.
 
-Sub-commands (initial scope):
+Sub-commands:
   /agent new <name>          — create a new agent and attach to it
+  /agent edit role <text>    — replace the attached agent's role text;
+                                next turn picks up the new role.
 
-Removal / rename / role-edit are intentionally NOT here yet — the
-registry's ``remove()`` exists but cascade safety (= topology
-references, in-flight tasks) deserves explicit confirmation UX that
-isn't a one-liner. Filing as follow-ups if surfaced.
+Removal / rename are intentionally NOT here yet — the registry's
+``remove()`` exists but cascade safety (= topology references,
+in-flight tasks, history continuity on rename) deserves explicit
+confirmation UX that isn't a one-liner. Filing as follow-ups if
+surfaced.
 """
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from reyn.chat.outbox import OutboxMessage
+from reyn.chat.profile import AgentProfile
 from reyn.chat.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
@@ -20,9 +25,11 @@ if TYPE_CHECKING:
 
 
 _USAGE = (
-    "Usage: /agent new <name>\n"
-    "  new <name>   — create a new agent and attach to it\n"
-    "                 (name: 1-32 chars of [a-z0-9_-], starting with [a-z0-9])"
+    "Usage:\n"
+    "  /agent new <name>          — create a new agent and attach to it\n"
+    "                                (name: 1-32 chars of [a-z0-9_-], "
+    "starting with [a-z0-9])\n"
+    "  /agent edit role <text>    — replace the attached agent's role text"
 )
 _NO_REGISTRY = (
     "agent registry not wired; /agent only works in `reyn chat`"
@@ -31,8 +38,11 @@ _NO_REGISTRY = (
 
 @slash(
     "agent",
-    summary="Create new agent (new <name> only; rm via `reyn agent rm`)",
-    usage="/agent new <name>",
+    summary=(
+        "Agent lifecycle: new <name> / edit role <text> "
+        "(rm via `reyn agent rm`)"
+    ),
+    usage="/agent new <name> | /agent edit role <text>",
 )
 async def agent_cmd(session: "ChatSession", args: str) -> None:
     """Dispatch ``/agent <sub>`` subcommands."""
@@ -44,6 +54,8 @@ async def agent_cmd(session: "ChatSession", args: str) -> None:
     sub_args = parts[1] if len(parts) > 1 else ""
     if sub == "new":
         await _create_agent(session, sub_args)
+    elif sub == "edit":
+        await _edit_agent(session, sub_args)
     else:
         await reply_error(session, _USAGE)
 
@@ -79,3 +91,79 @@ async def _create_agent(session: "ChatSession", name: str) -> None:
     await session._put_outbox(OutboxMessage(
         kind="__attach_request__", text=name,
     ))
+
+
+async def _edit_agent(session: "ChatSession", args: str) -> None:
+    """Dispatch ``/agent edit <field> <value>`` — currently ``role`` only.
+
+    Edits operate on the **attached agent** (= ``session.agent_name``).
+    Cross-agent edit (= "edit role on some-other-agent") would need a
+    name argument and clearer mental model; deferred.
+    """
+    parts = args.strip().split(maxsplit=1)
+    if not parts:
+        await reply_error(session, "Usage: /agent edit role <text>")
+        return
+    field = parts[0]
+    rest = parts[1] if len(parts) > 1 else ""
+    if field == "role":
+        await _edit_role(session, rest)
+    else:
+        await reply_error(
+            session,
+            f"unknown edit field {field!r}; only `role` is supported.",
+        )
+
+
+async def _edit_role(session: "ChatSession", new_role: str) -> None:
+    """Replace the attached agent's role text on disk + in-memory.
+
+    Two-side update:
+      1. ``profile.yaml`` rewritten via ``AgentProfile.save`` so the
+         change survives restart.
+      2. ``session._agent_role`` mutated so the next router turn picks
+         up the new role without restart (= consumed at Agent
+         construction time per line ~2655 in session.py).
+    """
+    new_role = new_role.strip()
+    if not new_role:
+        await reply_error(
+            session,
+            "Usage: /agent edit role <text>  (text must be non-empty; "
+            "clearing the role intentionally is not yet supported)",
+        )
+        return
+
+    registry = session._registry
+    if registry is None:
+        await reply_error(session, _NO_REGISTRY)
+        return
+
+    name = session.agent_name
+    agent_dir = registry._dir / name
+    try:
+        profile = AgentProfile.load(agent_dir)
+    except FileNotFoundError:
+        await reply_error(
+            session,
+            f"profile for agent {name!r} not found at {agent_dir}/profile.yaml",
+        )
+        return
+
+    updated = replace(profile, role=new_role)
+    try:
+        updated.save(agent_dir)
+    except OSError as exc:
+        await reply_error(session, f"failed to save profile: {exc}")
+        return
+
+    # Mutate in-memory so the next turn's Agent construction picks up
+    # the new role (= session._agent_role is read at
+    # ``_construct_agent`` time, not cached on a prompt object).
+    session._agent_role = new_role
+
+    await reply(
+        session,
+        f"✓ Updated agent {name!r} role.\n  new role: {new_role}\n"
+        "Next user turn will use the new role.",
+    )

--- a/tests/test_slash_agent.py
+++ b/tests/test_slash_agent.py
@@ -25,12 +25,15 @@ class _FakeSession:
     """Minimal session stub for the /agent flow.
 
     Exposes only what the slash handler reads (``_registry``,
-    ``_put_outbox``). Captures emitted outbox messages so the test can
-    assert on the ``__attach_request__`` sentinel.
+    ``_put_outbox``, ``agent_name``, ``_agent_role``). Captures
+    emitted outbox messages so the test can assert on the
+    ``__attach_request__`` sentinel.
     """
 
-    def __init__(self, registry) -> None:
+    def __init__(self, registry, *, agent_name: str = "default", agent_role: str = "") -> None:
         self._registry = registry
+        self.agent_name = agent_name
+        self._agent_role = agent_role
         self.outbox_calls: list[OutboxMessage] = []
 
     async def _put_outbox(self, msg: OutboxMessage) -> None:
@@ -126,3 +129,134 @@ async def test_agent_new_rejects_invalid_name(tmp_path):
     )
     error_msgs = [m for m in session.outbox_calls if m.kind == "error"]
     assert error_msgs
+
+
+# ── /agent edit role ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_edit_role_persists_to_profile_and_session(tmp_path):
+    """Tier 2: ``/agent edit role <text>`` writes the new role to disk
+    and updates ``session._agent_role`` so the next turn sees it."""
+    from reyn.chat.profile import AgentProfile
+    from reyn.chat.slash.agent import _edit_role
+
+    registry = _build_real_registry(tmp_path)
+    registry.create("gamma", role="old role")
+    session = _FakeSession(registry, agent_name="gamma", agent_role="old role")
+
+    await _edit_role(session, "  new persona text  ")
+
+    # Disk side: profile.yaml carries the new role (stripped).
+    reloaded = AgentProfile.load(tmp_path / ".reyn" / "agents" / "gamma")
+    assert reloaded.role == "new persona text"
+    # In-memory: session attribute mutated for next-turn pickup.
+    assert session._agent_role == "new persona text"
+    # Confirmation message landed on outbox (system kind, not error).
+    successes = [m for m in session.outbox_calls if m.kind == "system"]
+    assert successes, f"expected system reply; got {session.outbox_calls}"
+
+
+@pytest.mark.asyncio
+async def test_agent_edit_role_preserves_other_profile_fields(tmp_path):
+    """Tier 2: role edit MUST NOT clobber name / created_at / allowed_skills /
+    allowed_mcp."""
+    from reyn.chat.profile import PROFILE_FILENAME, AgentProfile
+    from reyn.chat.slash.agent import _edit_role
+
+    registry = _build_real_registry(tmp_path)
+    registry.create("delta", role="initial")
+    # Hand-write an allowed_skills + allowed_mcp config the create() flow
+    # doesn't set, to verify the edit doesn't drop them.
+    agent_dir = tmp_path / ".reyn" / "agents" / "delta"
+    profile = AgentProfile.load(agent_dir)
+    from dataclasses import replace
+    enriched = replace(
+        profile,
+        allowed_skills=["skill_a", "skill_b"],
+        allowed_mcp=["mcp_x"],
+    )
+    enriched.save(agent_dir)
+    original_created_at = enriched.created_at
+
+    session = _FakeSession(registry, agent_name="delta", agent_role="initial")
+    await _edit_role(session, "edited persona")
+
+    reloaded = AgentProfile.load(agent_dir)
+    assert reloaded.role == "edited persona"
+    assert reloaded.name == "delta"
+    assert reloaded.created_at == original_created_at
+    assert reloaded.allowed_skills == ["skill_a", "skill_b"]
+    assert reloaded.allowed_mcp == ["mcp_x"]
+
+
+@pytest.mark.asyncio
+async def test_agent_edit_role_empty_value_errors(tmp_path):
+    """Tier 2: empty / whitespace role → error message, no disk change."""
+    from reyn.chat.profile import AgentProfile
+    from reyn.chat.slash.agent import _edit_role
+
+    registry = _build_real_registry(tmp_path)
+    registry.create("eps", role="keep me")
+    session = _FakeSession(registry, agent_name="eps", agent_role="keep me")
+
+    await _edit_role(session, "   ")
+
+    errors = [m for m in session.outbox_calls if m.kind == "error"]
+    assert errors
+    # On-disk role unchanged.
+    assert AgentProfile.load(tmp_path / ".reyn" / "agents" / "eps").role == "keep me"
+    # In-memory role unchanged.
+    assert session._agent_role == "keep me"
+
+
+@pytest.mark.asyncio
+async def test_agent_edit_unknown_field_errors(tmp_path):
+    """Tier 2: ``/agent edit <field> ...`` with field ≠ ``role`` errors.
+
+    Drives the dispatcher (= ``_edit_agent``) so the sub-routing
+    layer is covered, not only the leaf handler."""
+    from reyn.chat.slash.agent import _edit_agent
+
+    registry = _build_real_registry(tmp_path)
+    session = _FakeSession(registry, agent_name="default", agent_role="r")
+
+    await _edit_agent(session, "name newname")
+
+    errors = [m for m in session.outbox_calls if m.kind == "error"]
+    assert errors
+    assert any("role" in m.text for m in errors)
+
+
+@pytest.mark.asyncio
+async def test_agent_edit_no_args_errors(tmp_path):
+    """Tier 2: bare ``/agent edit`` (= no sub-field) errors."""
+    from reyn.chat.slash.agent import _edit_agent
+
+    registry = _build_real_registry(tmp_path)
+    session = _FakeSession(registry, agent_name="default", agent_role="r")
+
+    await _edit_agent(session, "")
+
+    errors = [m for m in session.outbox_calls if m.kind == "error"]
+    assert errors
+
+
+@pytest.mark.asyncio
+async def test_agent_dispatcher_routes_edit_to_handler(tmp_path):
+    """Tier 2: the top-level ``agent_cmd`` dispatches ``edit role <text>``
+    through to the leaf handler (= ``_edit_role``)."""
+    from reyn.chat.profile import AgentProfile
+    from reyn.chat.slash.agent import agent_cmd
+
+    registry = _build_real_registry(tmp_path)
+    registry.create("zeta", role="before")
+    session = _FakeSession(registry, agent_name="zeta", agent_role="before")
+
+    await agent_cmd(session, "edit role after")
+
+    assert (
+        AgentProfile.load(tmp_path / ".reyn" / "agents" / "zeta").role
+        == "after"
+    )
+    assert session._agent_role == "after"

--- a/tests/test_slash_agent.py
+++ b/tests/test_slash_agent.py
@@ -33,8 +33,18 @@ class _FakeSession:
     def __init__(self, registry, *, agent_name: str = "default", agent_role: str = "") -> None:
         self._registry = registry
         self.agent_name = agent_name
+        # Mirror the real ChatSession's surface: ``_agent_role`` is the
+        # mutable backing field (production code writes here), and
+        # ``agent_role`` is the public read-only accessor (tests assert
+        # through this). Keep the two-attribute shape so the slash
+        # handler's ``session._agent_role = ...`` works against the fake
+        # exactly as it does against ChatSession.
         self._agent_role = agent_role
         self.outbox_calls: list[OutboxMessage] = []
+
+    @property
+    def agent_role(self) -> str:
+        return self._agent_role
 
     async def _put_outbox(self, msg: OutboxMessage) -> None:
         self.outbox_calls.append(msg)
@@ -137,7 +147,7 @@ async def test_agent_new_rejects_invalid_name(tmp_path):
 @pytest.mark.asyncio
 async def test_agent_edit_role_persists_to_profile_and_session(tmp_path):
     """Tier 2: ``/agent edit role <text>`` writes the new role to disk
-    and updates ``session._agent_role`` so the next turn sees it."""
+    and updates ``session.agent_role`` so the next turn sees it."""
     from reyn.chat.profile import AgentProfile
     from reyn.chat.slash.agent import _edit_role
 
@@ -151,7 +161,7 @@ async def test_agent_edit_role_persists_to_profile_and_session(tmp_path):
     reloaded = AgentProfile.load(tmp_path / ".reyn" / "agents" / "gamma")
     assert reloaded.role == "new persona text"
     # In-memory: session attribute mutated for next-turn pickup.
-    assert session._agent_role == "new persona text"
+    assert session.agent_role == "new persona text"
     # Confirmation message landed on outbox (system kind, not error).
     successes = [m for m in session.outbox_calls if m.kind == "system"]
     assert successes, f"expected system reply; got {session.outbox_calls}"
@@ -207,7 +217,7 @@ async def test_agent_edit_role_empty_value_errors(tmp_path):
     # On-disk role unchanged.
     assert AgentProfile.load(tmp_path / ".reyn" / "agents" / "eps").role == "keep me"
     # In-memory role unchanged.
-    assert session._agent_role == "keep me"
+    assert session.agent_role == "keep me"
 
 
 @pytest.mark.asyncio
@@ -259,4 +269,4 @@ async def test_agent_dispatcher_routes_edit_to_handler(tmp_path):
         AgentProfile.load(tmp_path / ".reyn" / "agents" / "zeta").role
         == "after"
     )
-    assert session._agent_role == "after"
+    assert session.agent_role == "after"

--- a/tests/test_slash_usage_extension.py
+++ b/tests/test_slash_usage_extension.py
@@ -42,7 +42,7 @@ _EXPECTED_USAGE: dict[str, str] = {
     "memory":      "/memory [list|view <name>]",
     "docs-filter": "/docs-filter [<substring>]",
     "skill":       "/skill [list|discard <id>]",
-    "agent":       "/agent new <name>",
+    "agent":       "/agent new <name> | /agent edit role <text>",
     "image":       "/image <path>",
     "reset":       "/reset confirm",
     "budget":      "/budget [reset]",


### PR DESCRIPTION
**[tui-coder]** — user direct request 2026-05-25「agent の新規作成と編集できると良いね」 → `/agent new <name>` は既存、 「編集」 ぶん不足を補う。

**Scope shift**: reyn-side slash 拡張 (= `chainlit-focus-no-internals` 制約 lift、 user 直接 ask)。 既存 `/agent` ファイル 1 つに sub-command 追加で全 surface 効。

## Sub-command 層

| Form | Status | Notes |
|---|---|---|
| `/agent new <name>` | 既存 | create + attach |
| `/agent edit role <text>` | **新 (本 PR)** | attached agent の persona 書換 |
| `/agent rename` | scope 外 | dir move + history 継承の cascade safety |
| `/agent delete` | scope 外 | `reyn agent rm` CLI で実施 |
| edit allowed_skills / allowed_mcp | scope 外 | list-edit UX は別設計 |

## 実装

`AgentProfile` は frozen dataclass のため `dataclasses.replace(profile, role=new_role)` で immutable 更新:

```python
profile = AgentProfile.load(agent_dir)
updated = replace(profile, role=new_role)
updated.save(agent_dir)
session._agent_role = new_role  # 次 turn 即反映
```

- name / created_at / allowed_skills / allowed_mcp は ALL preserved (= `replace` の default behaviour)
- session 側 `_agent_role` も同時更新で **次 turn から新 role 反映** (= `chainlit.ChatSettings` の output_language / model 同 pattern)
- エラーは `reply_error` 経由で Python stack trace を chat thread に流さない (unknown field / empty role / profile 未存在 / OSError 全て)

## Why scope-limited (= 部分的 lift)

- `chainlit-focus-no-internals` (2026-05-24) を user 直接 ask で部分 lift
- ただし scope は **既存 `/agent` slash の 1 sub-command 追加** に限定 (= 既存 dispatcher pattern 踏襲、 新 file 無し)
- registry / profile API は既存 public surface (= `registry._dir` access のみ、 既 `_create_agent` も同 pattern)
- cascade-impact あるもの (rename / delete / allowed_*) は今 PR 範囲外

## Test plan

- [x] **Tier 2** — `pytest tests/test_slash_agent.py` (10 tests 緑、 = 既存 4 + 新 6)
  - 新 6: 永続化+session 更新 / 他 field 保存 / empty 拒否 / unknown field 拒否 / bare edit 拒否 / dispatcher 経由
- [x] **ruff clean** — 全 touched files
- [ ] (skipped — needs interactive session) **Manual: TUI / chainlit で `/agent edit role "you are now a pirate"` → success message → 次 user prompt の応答が role 反映**
- [ ] (skipped — same) **Manual: `cat .reyn/agents/<n>/profile.yaml` で role 更新 + name/created_at/allowed_* 保存 確認**

local server 9001 で 1 番 verify 予定 (= chainlit 経由で動作確認)。

## Tier self-check

- ✅ Tier 2 (= OS invariant、 slash dispatch + persist contract)
- ✅ private state assert なし (= public `AgentProfile.load/save` + 既 `_agent_role` attribute mutate は src と同 access pattern)
- ✅ MagicMock / AsyncMock なし (= `_FakeSession` dataclass + real `AgentRegistry` on tmp_path)
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)