### PR TITLE
feat(chainlit): intervention round-trip via Ask{User,Action}Message

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -30,6 +30,7 @@ import chainlit as cl
 
 from reyn.chainlit_app.adapter import outbox_to_chainlit
 from reyn.chainlit_app.history import DEFAULT_REPLAY_CAP, history_to_chainlit
+from reyn.chainlit_app.intervention import build_intervention_prompt
 from reyn.chainlit_app.profiles import list_agent_profiles
 from reyn.chainlit_app.settings import (
     LANGUAGE_ITEMS,
@@ -194,6 +195,17 @@ async def _drain_loop(registry: "AgentRegistry") -> None:
     """
     while True:
         msg = await registry.repl_outbox.get()
+        if msg.kind == "intervention":
+            # Intercept before the adapter — the adapter only knows how
+            # to render IVs as plain author="intervention" text, but
+            # `kind="intervention"` is the agent **blocking on user
+            # input**. Hand it off to the round-trip helper so the
+            # operator sees a real prompt + buttons (= AskActionMessage)
+            # or input box (= AskUserMessage) and the answer flows back
+            # to the awaiting skill via `answer_pending_intervention`.
+            await _handle_intervention(registry, msg)
+            continue
+
         payload = outbox_to_chainlit(msg)
         if payload is None:
             continue
@@ -206,6 +218,91 @@ async def _drain_loop(registry: "AgentRegistry") -> None:
                 content=payload.content,
                 author=payload.author,
             ).send()
+
+
+async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
+    """Render an IV outbox payload as a chainlit Ask* prompt + reply back.
+
+    Both branches are wrapped in defensive try/except so chainlit
+    version drift or an exception inside the Ask* round-trip leaves
+    the agent's await intact (= reyn-side timeout / fallback still
+    fires) and the drain loop keeps pumping subsequent messages.
+    """
+    from reyn.user_intervention import InterventionAnswer
+
+    prompt = build_intervention_prompt(msg.meta, text=msg.text or "")
+    session = registry.attached_session()
+    if session is None or prompt.run_id is None:
+        # Can't answer (= no attached session or legacy IV without
+        # run_id) — fall back to plain text render so the operator at
+        # least sees what was asked.
+        await cl.Message(
+            content=prompt.content, author="intervention",
+        ).send()
+        return
+
+    if prompt.is_choice:
+        try:
+            actions = [
+                cl.Action(
+                    name=f"iv_{spec.choice_id}",
+                    label=spec.label,
+                    payload={
+                        "intervention_run_id": prompt.run_id,
+                        "choice_id": spec.choice_id,
+                    },
+                )
+                for spec in prompt.choices
+            ]
+            response = await cl.AskActionMessage(
+                content=prompt.content,
+                actions=actions,
+                timeout=600,
+            ).send()
+        except Exception:
+            response = None
+        if response is None:
+            return
+        payload_dict = getattr(response, "payload", None) or response
+        choice_id = (
+            payload_dict.get("choice_id")
+            if isinstance(payload_dict, dict) else None
+        )
+        label = (
+            payload_dict.get("label")
+            if isinstance(payload_dict, dict) else None
+        ) or choice_id or ""
+        if not isinstance(choice_id, str):
+            return
+        await session.answer_pending_intervention(
+            prompt.run_id,
+            InterventionAnswer(text=str(label), choice_id=choice_id),
+        )
+        return
+
+    # Free-text branch.
+    try:
+        reply = await cl.AskUserMessage(
+            content=prompt.content,
+            timeout=600,
+        ).send()
+    except Exception:
+        reply = None
+    if reply is None:
+        return
+    # AskUserMessage returns a StepDict-like with ``output`` (or
+    # ``content`` on older chainlit). Pull whichever is present.
+    text = ""
+    if isinstance(reply, dict):
+        text = str(
+            reply.get("output") or reply.get("content") or ""
+        )
+    else:
+        text = str(getattr(reply, "output", None) or getattr(reply, "content", "") or "")
+    await session.answer_pending_intervention(
+        prompt.run_id,
+        InterventionAnswer(text=text),
+    )
 
 
 @cl.set_chat_profiles

--- a/src/reyn/chainlit_app/intervention.py
+++ b/src/reyn/chainlit_app/intervention.py
@@ -1,0 +1,110 @@
+"""Convert a reyn ``kind="intervention"`` outbox payload into the args
+needed to render a chainlit Ask* prompt.
+
+The reyn-side ``UserIntervention`` carries one of two shapes:
+  - **closed-set choices**: e.g. permission gates with
+    ``[A]llow once / [B]lock``. Chainlit's ``AskActionMessage`` is the
+    right surface (= clickable buttons, no free-text needed).
+  - **free-text**: e.g. ``ask_user`` skill ops with optional
+    suggestions. Chainlit's ``AskUserMessage`` (= input box prompt).
+
+This pure helper builds the structured args (= content string +
+optional action specs); the caller in ``app.py`` wraps them with the
+appropriate ``cl.Ask*Message`` and awaits the user's reply, then
+hands the answer back to reyn via
+``session.answer_pending_intervention(...)``.
+
+No chainlit import here — unit tests run without the ``[chainlit]``
+extra.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _ChoiceSpec:
+    """One button-spec for AskActionMessage construction."""
+    choice_id: str
+    label: str
+
+
+@dataclass(frozen=True)
+class InterventionPrompt:
+    """Pre-assembled view of an IV ready for chainlit rendering.
+
+    - ``run_id`` is what ``session.answer_pending_intervention`` keys
+      on; ``None`` for legacy / orphaned IVs that the caller should
+      skip (= can't be answered).
+    - ``content`` is the rendered text body (prompt + detail +
+      suggestions hint, in that order).
+    - ``choices`` is non-empty for closed-set IVs → AskActionMessage;
+      empty for free-text IVs → AskUserMessage.
+    """
+    run_id: str | None
+    content: str
+    choices: tuple[_ChoiceSpec, ...]
+
+    @property
+    def is_choice(self) -> bool:
+        return bool(self.choices)
+
+
+def build_intervention_prompt(meta: dict | None, text: str = "") -> InterventionPrompt:
+    """Pre-compute the rendering args from an IV outbox message.
+
+    Falls back gracefully on missing meta fields:
+    - missing / empty ``prompt`` → use the OutboxMessage ``text`` body
+      (= the announce-time multiline string is a reasonable backup)
+    - missing ``run_id`` → returned as None (caller skips answer)
+    - missing ``choices`` → empty tuple → free-text prompt
+    - malformed individual choice (no ``id``) → dropped silently
+    """
+    meta = meta or {}
+    run_id = meta.get("run_id") if isinstance(meta.get("run_id"), str) else None
+
+    body_parts: list[str] = []
+    prompt = meta.get("prompt") if isinstance(meta.get("prompt"), str) else ""
+    detail = meta.get("detail") if isinstance(meta.get("detail"), str) else ""
+
+    if prompt:
+        body_parts.append(prompt)
+    elif text:
+        body_parts.append(text)
+
+    if detail:
+        body_parts.append(detail)
+
+    suggestions = meta.get("suggestions") or []
+    if isinstance(suggestions, list) and suggestions:
+        clean_sugg = [str(s) for s in suggestions if s]
+        if clean_sugg:
+            body_parts.append(
+                "Examples: " + " / ".join(clean_sugg),
+            )
+
+    raw_choices = meta.get("choices") or []
+    choice_specs: list[_ChoiceSpec] = []
+    if isinstance(raw_choices, list):
+        for c in raw_choices:
+            if not isinstance(c, dict):
+                continue
+            cid = c.get("id")
+            label = c.get("label") or cid
+            if not isinstance(cid, str) or not cid:
+                continue
+            choice_specs.append(_ChoiceSpec(choice_id=cid, label=str(label)))
+
+    content = "\n".join(body_parts) if body_parts else "(empty prompt)"
+    return InterventionPrompt(
+        run_id=run_id,
+        content=content,
+        choices=tuple(choice_specs),
+    )
+
+
+__all__ = [
+    "InterventionPrompt",
+    "_ChoiceSpec",
+    "build_intervention_prompt",
+]

--- a/tests/cli/test_chainlit_intervention.py
+++ b/tests/cli/test_chainlit_intervention.py
@@ -1,0 +1,159 @@
+"""Tier 1: ``reyn.chainlit_app.intervention.build_intervention_prompt``.
+
+The chainlit drain loop intercepts ``kind="intervention"`` outbox
+messages and feeds the meta payload to this helper before deciding
+which ``cl.Ask*Message`` to send. Pins:
+
+1. closed-set IVs (= ``meta.choices`` present) build
+   ``InterventionPrompt(choices=non-empty)`` so the caller renders
+   an AskActionMessage.
+2. free-text IVs build empty-choices prompts → AskUserMessage.
+3. ``run_id`` round-trips so the caller can call
+   ``session.answer_pending_intervention(run_id, ...)``.
+4. body assembly: ``prompt`` + ``detail`` + ``suggestions`` are
+   concatenated in fixed order; ``text`` (= OutboxMessage body) is
+   the fallback when ``prompt`` meta is missing.
+5. Malformed shapes (= non-string run_id, choices without id,
+   missing meta entirely) degrade gracefully — no exceptions reach
+   the drain loop.
+"""
+from __future__ import annotations
+
+from reyn.chainlit_app.intervention import (
+    InterventionPrompt,
+    _ChoiceSpec,
+    build_intervention_prompt,
+)
+
+
+def test_free_text_meta_builds_empty_choices_prompt():
+    """Tier 1: meta with no choices → InterventionPrompt with empty
+    choices tuple (= caller picks AskUserMessage)."""
+    out = build_intervention_prompt(
+        {"run_id": "r1", "prompt": "Pick a name?"},
+    )
+    assert out.run_id == "r1"
+    assert out.content == "Pick a name?"
+    assert out.choices == ()
+    assert out.is_choice is False
+
+
+def test_choice_meta_builds_non_empty_choices_prompt():
+    """Tier 1: meta with choices → choices tuple populated (= caller
+    picks AskActionMessage)."""
+    out = build_intervention_prompt(
+        {
+            "run_id": "r2",
+            "prompt": "Allow this?",
+            "choices": [
+                {"id": "allow", "label": "[A]llow"},
+                {"id": "block", "label": "[B]lock"},
+            ],
+        },
+    )
+    assert out.run_id == "r2"
+    assert out.is_choice is True
+    assert out.choices == (
+        _ChoiceSpec(choice_id="allow", label="[A]llow"),
+        _ChoiceSpec(choice_id="block", label="[B]lock"),
+    )
+
+
+def test_choice_missing_id_dropped_silently():
+    """Tier 1: malformed choice entries (no id) skip — don't crash."""
+    out = build_intervention_prompt(
+        {
+            "run_id": "r3",
+            "prompt": "x?",
+            "choices": [
+                {"id": "yes", "label": "Yes"},
+                {"label": "Missing id"},  # dropped
+                "not a dict",  # dropped
+                {"id": "", "label": "Empty id"},  # dropped (empty id)
+            ],
+        },
+    )
+    assert [c.choice_id for c in out.choices] == ["yes"]
+
+
+def test_choice_label_falls_back_to_id():
+    """Tier 1: a choice without ``label`` uses the id as the button text
+    (= avoids a blank button)."""
+    out = build_intervention_prompt(
+        {
+            "run_id": "r4",
+            "prompt": "?",
+            "choices": [{"id": "ok"}],
+        },
+    )
+    assert out.choices[0].label == "ok"
+
+
+def test_body_assembly_prompt_then_detail_then_suggestions():
+    """Tier 1: rendered content concatenates prompt + detail +
+    suggestions in stable order."""
+    out = build_intervention_prompt(
+        {
+            "run_id": "r5",
+            "prompt": "Pick a file",
+            "detail": "stored under ./drafts/",
+            "suggestions": ["a.md", "b.md", "c.md"],
+        },
+    )
+    assert out.content == (
+        "Pick a file\n"
+        "stored under ./drafts/\n"
+        "Examples: a.md / b.md / c.md"
+    )
+
+
+def test_text_used_as_body_fallback_when_prompt_meta_missing():
+    """Tier 1: missing ``meta.prompt`` → fall back to OutboxMessage
+    text body (= the announce-side multiline string)."""
+    out = build_intervention_prompt(
+        {"run_id": "r6"},
+        text="Fallback body line",
+    )
+    assert out.content == "Fallback body line"
+
+
+def test_empty_meta_returns_placeholder_content():
+    """Tier 1: completely empty meta + empty text → visible placeholder
+    so the renderer doesn't try to draw an empty bubble."""
+    out = build_intervention_prompt({}, text="")
+    assert out.run_id is None
+    assert out.content == "(empty prompt)"
+    assert out.choices == ()
+
+
+def test_none_meta_handled_safely():
+    """Tier 1: defensive — None meta passes through without exception."""
+    out = build_intervention_prompt(None, text="hello")
+    assert out.run_id is None
+    assert out.content == "hello"
+
+
+def test_run_id_non_string_dropped():
+    """Tier 1: malformed run_id (= not a string) → None, caller skips
+    answer-back."""
+    out = build_intervention_prompt(
+        {"run_id": 12345, "prompt": "p"},
+    )
+    assert out.run_id is None
+
+
+def test_suggestions_non_list_ignored():
+    """Tier 1: ``suggestions`` of unexpected shape doesn't blow up."""
+    out = build_intervention_prompt(
+        {"run_id": "r7", "prompt": "p", "suggestions": "not-a-list"},
+    )
+    # "Examples:" line should NOT appear.
+    assert "Examples:" not in out.content
+    assert out.content == "p"
+
+
+def test_returns_intervention_prompt_dataclass():
+    """Tier 1: return value is the public dataclass (= caller can read
+    .run_id / .content / .choices / .is_choice without dict gymnastics)."""
+    out = build_intervention_prompt({"run_id": "r", "prompt": "x"})
+    assert isinstance(out, InterventionPrompt)


### PR DESCRIPTION
**[tui-coder]** — user direct request 2026-05-25「intervention 対応可能？」 → yes、 純 chainlit-side で round-trip 完結。 reyn engine 改修ゼロ。

## 問題

`kind="intervention"` outbox message が adapter で `author="intervention"` plain text として描画されるが、 agent は IV future を await したまま **永久 block** (= UI 経由で返事できない経路 無し)。 closed-set (permission gate 等) と free-text (ask_user 等) の両方 stuck。

## 解決

`_drain_loop` で `kind == "intervention"` を adapter 前に intercept:

```
drain loop sees kind="intervention"
  → build_intervention_prompt(meta, text)
  → AskActionMessage (= closed-set choices)  OR  AskUserMessage (= free text)
  → session.answer_pending_intervention(run_id, InterventionAnswer(...))
  → reyn-side skill / router resumes
```

## reyn 側 primary evidence

- `OutboxMessage(kind="intervention").meta` shape: `intervention_id` / `intervention_kind` / `prompt` / `detail` / `run_id` / `skill_name` / `choices: [{id, label, hotkey}]` / `suggestions: [str]` (= `services/intervention_handler.py::announce` で構築)
- 回答 API: **`session.answer_pending_intervention(run_id, InterventionAnswer)`** 公開、 `text` / `choice_id` を受け取って future を resolve
- `InterventionAnswer(text="", choice_id=None)` frozen dataclass、 closed-set は両方、 free-text は text のみ

= reyn 側 API 完全 public、 改修ゼロで wire 可。

## 実装

- `reyn.chainlit_app.intervention` (新 pure helper):
  - `InterventionPrompt(run_id, content, choices)` dataclass
  - `build_intervention_prompt(meta, text="")` で meta → cl render args 変換
  - body assembly: `prompt` + `detail` + 「Examples: a / b / c」 suggestion line、 stable order
  - 防御: missing fields / 不正 shape / non-string run_id / non-list suggestions → 全 graceful、 exception 無し
- `_handle_intervention(registry, msg)` in app.py:
  - `is_choice` → `cl.AskActionMessage` (= 1 Action per choice、 payload に `choice_id` + `intervention_run_id`)
  - else → `cl.AskUserMessage` (free text)
  - 両 branch try/except wrap → chainlit-side 失敗時は agent の await 維持、 drain loop 継続
- `run_id` 無い IV (= legacy / orphan) は plain text fallback (= 既存 author="intervention" 描画)

## Why scope-limited

memory `chainlit-focus-no-internals` 準拠 — `src/reyn/chainlit_app/` + tests のみ touch、 reyn engine 不変。 `answer_pending_intervention` / `InterventionAnswer` は既存 public surface。

## Test plan

- [x] **Tier 1 prompt builder** — `pytest tests/cli/test_chainlit_intervention.py` (11 tests 緑、 free-text / choice branch / id-fallback-to-label / body assembly order / text fallback / 全 defensive path)
- [x] **Full chainlit-side suite** — 129 tests 緑
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke** — 拡張 import + `_handle_intervention` 追加 で crash 無し
- [ ] (skipped — needs IV-firing skill via browser) **Manual: chainlit で permission-gate trigger する prompt → AskActionMessage buttons → クリック → skill resume**
- [ ] (skipped — same) **Manual: `ask_user` skill op trigger → AskUserMessage 表示 → 入力 → skill resume**
- [ ] (skipped — same) **Manual: 古い / orphan IV (run_id 無し) → 平文 fallback (= 既 author="intervention" 表示) で agent block しない確認**

local server 9001 で 1, 2 番 verify 予定 (= permission-trigger / ask_user op を user に試して頂く形)。

## Tier self-check

- ✅ Tier 1 only (= pure meta→prompt mapping)
- ✅ private state assert なし (= public dataclass return)
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

## Future scope-out (= 別 wave 候補)

- multi-IV concurrent display (= AskActionMessage が新規 IV 受信中も古い prompt 残す)
- timeout 600s 固定 → 設定可
- skill_name / run_id_short 等の provenance を cl.Message author に出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)