### PR TITLE
fix(chainlit): listener id must match DEFAULT_CHAT_CHANNEL_ID="tui"

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -415,16 +415,23 @@ async def _on_chat_start() -> None:
     await registry.restore_all()
     session = await registry.attach(name)
 
-    # Register chainlit as an intervention listener so the session's
-    # ``InterventionRegistry`` (= built with
-    # ``enforce_listener_presence=True`` at session.py:1529) actually
-    # dispatches IVs through the bus → outbox. Without this, every
-    # ``bus.request(iv)`` short-circuits at registry.py:230 with an
-    # empty ``InterventionAnswer(text="")``, which the permission
-    # gate treats as a refusal → user sees silent "permission
-    # denied" instead of the AskActionMessage wired in PR #907.
+    # Register the chainlit surface as the canonical chat-channel
+    # intervention listener. The id MUST match ``DEFAULT_CHAT_CHANNEL_ID``
+    # (= "tui") because ``ChatInterventionBus`` stamps every iv with
+    # that channel id (session.py:1661 / 1891 / 4388), and the agent
+    # layer's origin-pin routing then expects a listener registered
+    # under the SAME id. Registering as "chainlit" instead leaves the
+    # iv as ``route="user_channel_stalled"`` — surfaced in the event
+    # log but never dispatched → silent "permission denied" for
+    # web_fetch et al. (Discovered after #908 by inspecting
+    # ``events/agents/*/chat/*.jsonl`` ``intervention_routed`` rows.)
+    #
+    # This is the same id the TUI surface registers under
+    # (``chat/tui/app.py``); only one of TUI / chainlit is attached
+    # to a given process so there's no collision.
+    from reyn.chat.session import DEFAULT_CHAT_CHANNEL_ID
     try:
-        session.register_intervention_listener("chainlit")
+        session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
     except AttributeError:
         # Stripped / mocked session in tests — degrade gracefully.
         pass
@@ -657,6 +664,7 @@ async def _on_chat_end() -> None:
         registry = await _get_or_build_registry()
         session = registry.attached_session()
         if session is not None:
-            session.unregister_intervention_listener("chainlit")
+            from reyn.chat.session import DEFAULT_CHAT_CHANNEL_ID
+            session.unregister_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
     except Exception:
         pass


### PR DESCRIPTION
**[tui-coder]** — user dogfood「まだ反応しない」 後 event log 直接 inspect で **root cause #4** 判明、 #908 の 3 段 fix を補う 4 段目。

## Primary evidence (= events/agents/*.jsonl)

```
intervention_routed: route="user_channel_stalled", origin_channel_id="tui"
```

= IV は emit されてるが、 routing 視点で **"stalled"** 扱い (= origin channel に listener 無し) → dispatch 拒否 → silent deny。

## Root cause

`ChatInterventionBus` は **`DEFAULT_CHAT_CHANNEL_ID = "tui"`** を hardcoded で全 IV に stamp する (= session.py:204、 適用は :1661 / :1891 / :4388 の 3 箇所)。 routing 側は同じ id の listener を expect。

#908 で chainlit listener を `"chainlit"` で register したが、 bus stamping は `"tui"` のまま → id mismatch → `user_channel_stalled` → 無 dispatch。

## Fix

`DEFAULT_CHAT_CHANNEL_ID` constant を直接 import + listener id に使用:

```python
from reyn.chat.session import DEFAULT_CHAT_CHANNEL_ID
session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
```

`unregister` 側も symmetric。 TUI と chainlit が同 process で attach されないので id collision 無し (= 1 process 1 surface)。

## Why #908 3 段 fix で発見できなかった

#908 は `interactive` flag + listener 存在 + future resolve の **dispatch path** を 3 段 fix したが、 stamped channel_id と listener id の整合性は **routing path 側**、 別 axis。 「listener が存在する」 と「routing が正しい listener へ届く」 は別問題。

Tier 1 test で IV emit 自体は cover してるが、 channel_id routing は test 範囲外 (= reyn engine 内部、 chainlit-side からは event log primary evidence で発見)。

## Test plan

- [x] **Full chainlit-side suite** — 129 tests 緑 (= 既存 IV / settings / 全 helper 影響無し)
- [x] **ruff clean**
- [x] **app.py import smoke**
- [ ] (skipped — needs IV-firing prompt via browser) **Manual: `web__fetch <url>` → AskActionMessage `[Yes/Always/No/Never]` 表示 → クリック → fetch 実行 OR 拒否**
- [ ] (skipped — same) **Manual: 同 prompt で event log inspect → `intervention_routed: route="user_channel"` (= NOT stalled) に変わってる**

local server 9001 で 1, 2 番 verify 予定。

## Tier self-check

- ✅ Config 1 行修正 (= 文字列リテラル → constant)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし

## Lesson 候補

memory `multi-axis-safe-default-audit` の section に追記検討: **「同 intent group の wire を全 audit」 は dispatch path だけでなく routing path 側 (= id matching / stamping conventions) も対象**。 4 段目で routing axis surface した分、 axis 列挙時の盲点を memory 化したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)