### PR TITLE
fix(chainlit): answer IV by intervention_id so permission gates render buttons

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -306,15 +306,26 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
         if response is None:
             await _resolve_empty()
             return
-        payload_dict = getattr(response, "payload", None) or response
-        choice_id = (
-            payload_dict.get("choice_id")
-            if isinstance(payload_dict, dict) else None
-        )
+        # ``cl.AskActionMessage`` returns an ``AskActionResponse``
+        # TypedDict with shape ``{name, payload, label, tooltip,
+        # forId, id}``. The dict ``payload`` field is what carries
+        # the per-Action dict we passed at construction time — that's
+        # where ``choice_id`` actually lives. A prior version read
+        # ``getattr(response, "payload", None) or response`` which
+        # falls through to the OUTER dict and ends up reading
+        # ``choice_id`` from the wrong layer → always None → reyn-side
+        # validation classifies as "unknown choice".
+        outer: dict = response if isinstance(response, dict) else {}
+        nested_payload = outer.get("payload")
+        if not isinstance(nested_payload, dict):
+            nested_payload = {}
+        choice_id = nested_payload.get("choice_id")
         label = (
-            payload_dict.get("label")
-            if isinstance(payload_dict, dict) else None
-        ) or choice_id or ""
+            nested_payload.get("label")
+            or outer.get("label")
+            or choice_id
+            or ""
+        )
         if not isinstance(choice_id, str):
             await _resolve_empty()
             return

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -238,14 +238,36 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
     the agent's await intact (= reyn-side timeout / fallback still
     fires) and the drain loop keeps pumping subsequent messages.
     """
-    from reyn.user_intervention import InterventionAnswer
-
     prompt = build_intervention_prompt(msg.meta, text=msg.text or "")
     session = registry.attached_session()
-    if session is None or prompt.run_id is None:
-        # Can't answer (= no attached session or legacy IV without
-        # run_id) — fall back to plain text render so the operator at
-        # least sees what was asked.
+    if session is None or prompt.intervention_id is None:
+        # Can't dispatch the answer (= no attached session or malformed
+        # meta lacking intervention_id) — fall back to plain-text render
+        # so the operator at least sees what was asked.
+        await cl.Message(
+            content=prompt.content, author="intervention",
+        ).send()
+        return
+
+    # Look up the live UserIntervention by id. ``_interventions.list_active``
+    # is the public-shape (= used by slash commands), and the iv carries
+    # its own future + choices, so we route through
+    # ``session._deliver_answer_to(iv, text, choice_id_override=...)``
+    # which works regardless of whether ``iv.run_id`` is set (permission
+    # gate IVs from ``_prompt`` have no run_id; ``ask_user`` IVs do).
+    def _find_iv():
+        try:
+            for iv in session._interventions.list_active():
+                if getattr(iv, "id", None) == prompt.intervention_id:
+                    return iv
+        except AttributeError:
+            return None
+        return None
+
+    iv_obj = _find_iv()
+    if iv_obj is None:
+        # IV already answered or vanished between announce and our
+        # handler picking it up — render plain text, nothing to answer.
         await cl.Message(
             content=prompt.content, author="intervention",
         ).send()
@@ -256,10 +278,10 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
     # ChatSession.run_one_iteration never picks up the next inbox
     # message — the entire chat appears frozen.
     async def _resolve_empty() -> None:
-        await session.answer_pending_intervention(
-            prompt.run_id,
-            InterventionAnswer(text=""),
-        )
+        try:
+            await session._deliver_answer_to(iv_obj, "")
+        except Exception:
+            pass
 
     if prompt.is_choice:
         try:
@@ -268,7 +290,7 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
                     name=f"iv_{spec.choice_id}",
                     label=spec.label,
                     payload={
-                        "intervention_run_id": prompt.run_id,
+                        "intervention_id": prompt.intervention_id,
                         "choice_id": spec.choice_id,
                     },
                 )
@@ -296,10 +318,12 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
         if not isinstance(choice_id, str):
             await _resolve_empty()
             return
-        await session.answer_pending_intervention(
-            prompt.run_id,
-            InterventionAnswer(text=str(label), choice_id=choice_id),
-        )
+        try:
+            await session._deliver_answer_to(
+                iv_obj, str(label), choice_id_override=choice_id,
+            )
+        except Exception:
+            await _resolve_empty()
         return
 
     # Free-text branch.
@@ -322,10 +346,10 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
         )
     else:
         text = str(getattr(reply, "output", None) or getattr(reply, "content", "") or "")
-    await session.answer_pending_intervention(
-        prompt.run_id,
-        InterventionAnswer(text=text),
-    )
+    try:
+        await session._deliver_answer_to(iv_obj, text)
+    except Exception:
+        await _resolve_empty()
 
 
 @cl.set_chat_profiles

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -415,16 +415,23 @@ async def _on_chat_start() -> None:
     await registry.restore_all()
     session = await registry.attach(name)
 
-    # Register chainlit as an intervention listener so the session's
-    # ``InterventionRegistry`` (= built with
-    # ``enforce_listener_presence=True`` at session.py:1529) actually
-    # dispatches IVs through the bus → outbox. Without this, every
-    # ``bus.request(iv)`` short-circuits at registry.py:230 with an
-    # empty ``InterventionAnswer(text="")``, which the permission
-    # gate treats as a refusal → user sees silent "permission
-    # denied" instead of the AskActionMessage wired in PR #907.
+    # Register the chainlit surface as the canonical chat-channel
+    # intervention listener. The id MUST match ``DEFAULT_CHAT_CHANNEL_ID``
+    # (= "tui") because ``ChatInterventionBus`` stamps every iv with
+    # that channel id (session.py:1661 / 1891 / 4388), and the agent
+    # layer's origin-pin routing then expects a listener registered
+    # under the SAME id. Registering as "chainlit" instead leaves the
+    # iv as ``route="user_channel_stalled"`` — surfaced in the event
+    # log but never dispatched → silent "permission denied" for
+    # web_fetch et al. (Discovered after #908 by inspecting
+    # ``events/agents/*/chat/*.jsonl`` ``intervention_routed`` rows.)
+    #
+    # This is the same id the TUI surface registers under
+    # (``chat/tui/app.py``); only one of TUI / chainlit is attached
+    # to a given process so there's no collision.
+    from reyn.chat.session import DEFAULT_CHAT_CHANNEL_ID
     try:
-        session.register_intervention_listener("chainlit")
+        session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
     except AttributeError:
         # Stripped / mocked session in tests — degrade gracefully.
         pass
@@ -657,6 +664,7 @@ async def _on_chat_end() -> None:
         registry = await _get_or_build_registry()
         session = registry.attached_session()
         if session is not None:
-            session.unregister_intervention_listener("chainlit")
+            from reyn.chat.session import DEFAULT_CHAT_CHANNEL_ID
+            session.unregister_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
     except Exception:
         pass

--- a/src/reyn/chainlit_app/intervention.py
+++ b/src/reyn/chainlit_app/intervention.py
@@ -33,14 +33,22 @@ class _ChoiceSpec:
 class InterventionPrompt:
     """Pre-assembled view of an IV ready for chainlit rendering.
 
-    - ``run_id`` is what ``session.answer_pending_intervention`` keys
-      on; ``None`` for legacy / orphaned IVs that the caller should
-      skip (= can't be answered).
+    - ``intervention_id`` is the UUID set on every ``UserIntervention``;
+      the caller looks it up via
+      ``session._interventions.list_active()`` to get the iv instance,
+      then answers via ``session._deliver_answer_to(iv, text,
+      choice_id_override=...)``. ``None`` only for malformed meta —
+      caller falls back to a plain-text render.
+    - ``run_id`` is the skill's run id when the IV originated from a
+      running skill (= ``ask_user``); ``None`` for permission gates
+      (= ``_prompt`` constructs IVs without a skill context). Not
+      used for answer dispatch — keep for diagnostic / future use.
     - ``content`` is the rendered text body (prompt + detail +
       suggestions hint, in that order).
     - ``choices`` is non-empty for closed-set IVs → AskActionMessage;
       empty for free-text IVs → AskUserMessage.
     """
+    intervention_id: str | None
     run_id: str | None
     content: str
     choices: tuple[_ChoiceSpec, ...]
@@ -56,11 +64,18 @@ def build_intervention_prompt(meta: dict | None, text: str = "") -> Intervention
     Falls back gracefully on missing meta fields:
     - missing / empty ``prompt`` → use the OutboxMessage ``text`` body
       (= the announce-time multiline string is a reasonable backup)
-    - missing ``run_id`` → returned as None (caller skips answer)
+    - missing ``intervention_id`` → returned as None (caller falls back
+      to plain-text render; can't dispatch answer back)
+    - missing ``run_id`` → returned as None (informational only;
+      permission gates legitimately have no run_id)
     - missing ``choices`` → empty tuple → free-text prompt
     - malformed individual choice (no ``id``) → dropped silently
     """
     meta = meta or {}
+    intervention_id = (
+        meta.get("intervention_id")
+        if isinstance(meta.get("intervention_id"), str) else None
+    )
     run_id = meta.get("run_id") if isinstance(meta.get("run_id"), str) else None
 
     body_parts: list[str] = []
@@ -97,6 +112,7 @@ def build_intervention_prompt(meta: dict | None, text: str = "") -> Intervention
 
     content = "\n".join(body_parts) if body_parts else "(empty prompt)"
     return InterventionPrompt(
+        intervention_id=intervention_id,
         run_id=run_id,
         content=content,
         choices=tuple(choice_specs),

--- a/tests/cli/test_chainlit_intervention.py
+++ b/tests/cli/test_chainlit_intervention.py
@@ -157,3 +157,47 @@ def test_returns_intervention_prompt_dataclass():
     .run_id / .content / .choices / .is_choice without dict gymnastics)."""
     out = build_intervention_prompt({"run_id": "r", "prompt": "x"})
     assert isinstance(out, InterventionPrompt)
+
+
+def test_intervention_id_round_trips_when_present():
+    """Tier 1: meta carries the UUID set by ``_iv_meta`` on every IV —
+    chainlit uses it to find the live UserIntervention via
+    ``session._interventions.list_active()`` and answer via the
+    intervention-direct path (= works even when run_id is None, which
+    is the permission-gate IV shape)."""
+    out = build_intervention_prompt(
+        {"intervention_id": "abc-uuid-123", "prompt": "x"},
+    )
+    assert out.intervention_id == "abc-uuid-123"
+
+
+def test_intervention_id_independent_of_run_id():
+    """Tier 1: permission-gate IVs (= ``_prompt``) have no run_id but
+    DO have an intervention_id — handler must not short-circuit on a
+    missing run_id."""
+    out = build_intervention_prompt(
+        {
+            "intervention_id": "iv-1",
+            "prompt": "Allow fetching?",
+            "choices": [{"id": "yes", "label": "Yes"}],
+        },
+    )
+    assert out.intervention_id == "iv-1"
+    assert out.run_id is None
+    assert out.is_choice is True
+
+
+def test_intervention_id_non_string_dropped():
+    """Tier 1: defensive — non-string intervention_id → None (caller
+    falls back to plain-text render)."""
+    out = build_intervention_prompt(
+        {"intervention_id": 12345, "prompt": "x"},
+    )
+    assert out.intervention_id is None
+
+
+def test_intervention_id_absent_returns_none():
+    """Tier 1: missing intervention_id → None (= legacy / malformed IV
+    meta; caller can't dispatch answer back)."""
+    out = build_intervention_prompt({"run_id": "r", "prompt": "x"})
+    assert out.intervention_id is None


### PR DESCRIPTION
**[tui-coder]** — user dogfood「Allow fetching from 'glama.ai'? と出てくるけど、 選択肢とか出てこないよ」 → IV emit + 描画も成功してるが、 plain text 落ち + button 無し。 **root cause #5 (= #908 / #910 後の更 1 段)**。

## Primary evidence (= code inspection)

`permissions.py::_prompt`:
```python
iv = UserIntervention(
    kind="permission.generic",
    prompt=user_prompt or ...,
    choices=generic_yn_choices(),
)
# ↑ run_id を渡してない、 = iv.run_id is None
```

`chainlit_app/app.py::_handle_intervention` (= 旧):
```python
if session is None or prompt.run_id is None:
    await cl.Message(content=..., author="intervention").send()  # plain text fallback
    return
```

permission IV は run_id 持たない (= skill 由来でないため) → 私の handler が「run_id 無い = 答えられない → plain text」 で早期 return → AskActionMessage 通らず → button 表示無し。

## Fix

`iv.id` (= 全 IV に存在する UUID、 既 `_iv_meta` で meta に含まれる) を使う。 `session._interventions.list_active()` で iv を id で lookup → `session._deliver_answer_to(iv, text, choice_id_override=cid)` で answer dispatch (= iv-direct path、 run_id 有無に依存しない)。

`InterventionPrompt` に `intervention_id` field 追加、 short-circuit 条件を `intervention_id is None` (= 真の malformed) + iv-not-found (= 既 answered / vanished) に変更。

## Test plan

- [x] **Tier 1 intervention** — `pytest tests/cli/test_chainlit_intervention.py` (15 tests 緑、 = 既存 11 + 新 4: intervention_id round-trip / run_id 独立 / non-string 防御 / missing default)
- [x] **Full chainlit-side suite** — 133 tests 緑
- [x] **ruff clean**
- [x] **app.py import smoke**
- [ ] (skipped — needs browser interaction) **Manual: `web__fetch <url>` → AskActionMessage `[y]es / [A]lways / [n]o / [N]ever` buttons 表示 → クリック → fetch 実行 OR 拒否**
- [ ] (skipped — same) **Manual: 同 prompt event log inspect → `intervention_routed: route="user_channel"` + iv 即解決 (= queue から消える)**

local server 9001 で 1, 2 番 verify 予定。

## Cascade observation

#908 → #910 → 本 PR で 「permission IV → chainlit UI」 経路は 5 段 fix:
1. `interactive=True` (= permission gate `_prompt` short-circuit 解除)
2. listener register (= dispatch empty-answer short-circuit 解除)
3. future resolve on no-response (= chat 反応停止防止)
4. listener id = "tui" (= origin_channel_id matching)
5. iv.id 経由で answer (= run_id 不要 path)

= [[multi-axis-safe-default-audit]] の memory 拡張余地: **「dispatch axis + routing axis + answer-dispatch axis + render axis」 の 4 axis 全 audit**。 単一 PoC 機能でも 5 段 wire 必要だった事案、 サマリ memory に追記予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)