### PR TITLE
feat(chainlit): collapsible cl.Step for tool calls with args/result detail

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -49,6 +49,14 @@ from reyn.chainlit_app.slash_route import (
     is_chainlit_history_wipe,
     is_slash,
 )
+from reyn.chainlit_app.tool_step import build_tool_step_update
+
+_TOOL_CALL_KINDS = frozenset({
+    "tool_call_started",
+    "tool_call_completed",
+    "tool_call_failed",
+})
+_TOOL_STEP_SESSION_PREFIX = "reyn_tool_step_"
 from reyn.chainlit_app.uploads import collect_image_blocks
 
 if TYPE_CHECKING:
@@ -216,6 +224,21 @@ async def _drain_loop(registry: "AgentRegistry") -> None:
             await _handle_intervention(registry, msg)
             continue
 
+        if msg.kind in _TOOL_CALL_KINDS:
+            # Render the tool invocation as a collapsible ``cl.Step``
+            # (= operator can expand to see args / result / error).
+            # The step lifecycle spans three messages
+            # (started / completed / failed), keyed by ``op_id`` so
+            # the right step is updated. Falls through to the adapter
+            # path on any failure so the row at least renders as a
+            # plain "🔧 tool" message.
+            try:
+                handled = await _handle_tool_call(msg)
+            except Exception:
+                handled = False
+            if handled:
+                continue
+
         payload = outbox_to_chainlit(msg)
         if payload is None:
             continue
@@ -229,6 +252,69 @@ async def _drain_loop(registry: "AgentRegistry") -> None:
                 author=payload.author,
                 type=payload.message_type,
             ).send()
+
+
+async def _handle_tool_call(msg) -> bool:
+    """Render a ``tool_call_*`` outbox message as a collapsible
+    ``cl.Step`` so the operator can expand the row to see args /
+    result / error inline with the rest of the chat thread.
+
+    The lifecycle spans three events keyed by ``op_id`` (= the
+    deterministic ``args_hash`` the lifecycle forwarder packs into
+    ``meta``):
+
+      - ``tool_call_started``    → create the step + show args
+      - ``tool_call_completed``  → update the same step with result
+      - ``tool_call_failed``     → update the same step with error
+
+    Returns True when the row was rendered as a step (= adapter
+    bypass), False when meta is malformed / chainlit raises so the
+    caller falls back to the adapter's plain-text branch. Each
+    interaction with chainlit is wrapped in try/except so a transient
+    glitch never breaks the drain loop.
+    """
+    update = build_tool_step_update(msg.meta, msg.kind)
+    if update is None:
+        return False
+
+    session_key = _TOOL_STEP_SESSION_PREFIX + update.op_id
+
+    try:
+        if update.phase == "started":
+            step = cl.Step(
+                name=update.tool_name,
+                type="tool",
+                show_input="json",
+                default_open=False,
+                auto_collapse=True,
+            )
+            if update.input_text:
+                step.input = update.input_text
+            await step.send()
+            cl.user_session.set(session_key, step)
+            return True
+
+        # completed / failed — look up the started step.
+        step = cl.user_session.get(session_key)
+        if step is None:
+            # Step pairing was lost (= drain restart / shadow event) →
+            # fall back to adapter's plain-text branch so the row at
+            # least shows the completion / failure.
+            return False
+        step.output = update.output_text
+        if update.is_error:
+            # Surface the failure visually on the step. ``is_error``
+            # may not be on every chainlit version, so wrap setattr
+            # in try/except.
+            try:
+                step.is_error = True
+            except Exception:
+                pass
+        await step.update()
+        cl.user_session.set(session_key, None)
+        return True
+    except Exception:
+        return False
 
 
 async def _handle_intervention(registry: "AgentRegistry", msg) -> None:

--- a/src/reyn/chainlit_app/tool_step.py
+++ b/src/reyn/chainlit_app/tool_step.py
@@ -1,0 +1,140 @@
+"""Helpers for rendering reyn ``tool_call_*`` outbox messages as
+collapsible chainlit ``cl.Step`` panels.
+
+The reyn lifecycle forwarder packs three fields the operator wants to
+see inside the step body:
+
+- ``tool``        (= human-friendly tool name, used as step title)
+- ``args``        (only on ``tool_call_started``)
+- ``result``      (only on ``tool_call_completed``)
+- ``error_kind``  (only on ``tool_call_failed``)
+- ``error_message``
+
+Plus ``op_id`` (= the deterministic ``args_hash``) we use as the
+per-session key to pair start / completed / failed events into the
+same step row. Without ``op_id`` matching, a tool's "✓ done" line
+would land in its own un-collapsed step instead of being absorbed
+back into the original started step.
+
+Pure helper module — no chainlit import, so unit tests run without
+the ``[chainlit]`` extra installed.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ToolStepUpdate:
+    """Pre-computed args for a ``cl.Step`` create-or-update call.
+
+    The chainlit-side caller decides whether to call ``Step(...).send()``
+    (= new step for a started event) or ``Step.update()`` after
+    populating an existing object (= for completed / failed).
+    """
+    op_id: str
+    tool_name: str
+    # ``"started"`` → caller creates a new Step and sends it.
+    # ``"completed"`` / ``"failed"`` → caller looks up the prior
+    # step by ``op_id`` and updates it. ``"failed"`` also sets a
+    # visible error glyph in the output.
+    phase: str
+    # JSON-stringified args dict for the step's ``input`` panel
+    # (= empty when args were missing or unserialisable).
+    input_text: str
+    # Rendered ``output`` text. Empty for the started phase.
+    output_text: str
+    # True when the failure path is taken — caller can flag the step
+    # accordingly (e.g. metadata error icon).
+    is_error: bool
+
+
+_TOOL_CALL_KINDS = frozenset({
+    "tool_call_started",
+    "tool_call_completed",
+    "tool_call_failed",
+})
+
+
+def is_tool_call(kind: str) -> bool:
+    """Return True when ``kind`` is one of the 3 ``tool_call_*`` shapes
+    this module knows how to render."""
+    return kind in _TOOL_CALL_KINDS
+
+
+def _stringify(value: Any) -> str:
+    """Best-effort JSON for the input / output panels.
+
+    Falls back to ``str(value)`` when the value isn't json-serialisable
+    so the panel still shows something. Truncates absurdly long blobs
+    so the popup doesn't drown the operator.
+    """
+    if value is None:
+        return ""
+    try:
+        text = json.dumps(value, ensure_ascii=False, indent=2)
+    except (TypeError, ValueError):
+        text = str(value)
+    # Soft cap so a huge result blob doesn't make the step unusable.
+    if len(text) > 8000:
+        text = text[:8000] + "\n… (truncated)"
+    return text
+
+
+def build_tool_step_update(meta: dict | None, kind: str) -> ToolStepUpdate | None:
+    """Convert one tool_call_* outbox message's ``meta`` into step args.
+
+    Returns ``None`` when ``meta`` lacks the bare-minimum routing
+    fields (``op_id`` + ``tool``) — caller falls back to the adapter's
+    plain-text branch so the row at least appears.
+    """
+    if not isinstance(meta, dict):
+        return None
+    op_id = meta.get("op_id")
+    tool = meta.get("tool")
+    if not isinstance(op_id, str) or not isinstance(tool, str) or not op_id or not tool:
+        return None
+
+    if kind == "tool_call_started":
+        return ToolStepUpdate(
+            op_id=op_id,
+            tool_name=tool,
+            phase="started",
+            input_text=_stringify(meta.get("args")),
+            output_text="",
+            is_error=False,
+        )
+    if kind == "tool_call_completed":
+        return ToolStepUpdate(
+            op_id=op_id,
+            tool_name=tool,
+            phase="completed",
+            input_text="",
+            output_text=_stringify(meta.get("result")),
+            is_error=False,
+        )
+    if kind == "tool_call_failed":
+        err_kind = meta.get("error_kind") or ""
+        err_msg = meta.get("error_message") or ""
+        if err_kind and err_msg:
+            body = f"{err_kind}: {err_msg}"
+        else:
+            body = str(err_kind or err_msg or "(unknown error)")
+        return ToolStepUpdate(
+            op_id=op_id,
+            tool_name=tool,
+            phase="failed",
+            input_text="",
+            output_text=body,
+            is_error=True,
+        )
+    return None
+
+
+__all__ = [
+    "ToolStepUpdate",
+    "build_tool_step_update",
+    "is_tool_call",
+]

--- a/tests/cli/test_chainlit_tool_step.py
+++ b/tests/cli/test_chainlit_tool_step.py
@@ -1,0 +1,194 @@
+"""Tier 1: ``reyn.chainlit_app.tool_step.build_tool_step_update`` contract.
+
+The drain loop's ``_handle_tool_call`` consumes ``ToolStepUpdate``
+to drive ``cl.Step.send()`` / ``cl.Step.update()`` for the
+collapsible tool panel. Pins:
+
+1. The 3 ``tool_call_*`` kinds each produce a distinct
+   ``phase`` (= ``"started"`` / ``"completed"`` / ``"failed"``).
+2. ``op_id`` round-trips so start / complete / fail share a step.
+3. Failed phase surfaces ``is_error=True``; the body combines
+   ``error_kind`` + ``error_message`` when both are present.
+4. ``args`` / ``result`` get JSON-stringified into the panel; non-
+   serialisable values fall back to ``str(value)`` instead of
+   crashing.
+5. Missing ``op_id`` / ``tool`` returns ``None`` so the caller falls
+   back to the plain-text adapter render.
+6. ``is_tool_call`` covers exactly the 3 kinds.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chainlit_app.tool_step import (
+    ToolStepUpdate,
+    build_tool_step_update,
+    is_tool_call,
+)
+
+
+@pytest.mark.parametrize(
+    "kind,expected",
+    [
+        ("tool_call_started", True),
+        ("tool_call_completed", True),
+        ("tool_call_failed", True),
+        ("tool_called", False),  # legacy event name
+        ("agent", False),
+        ("status", False),
+        ("", False),
+    ],
+)
+def test_is_tool_call_truth_table(kind: str, expected: bool):
+    """Tier 1: helper recognises exactly the 3 lifecycle kinds."""
+    assert is_tool_call(kind) is expected
+
+
+def test_started_phase_carries_args_in_input_text():
+    """Tier 1: ``tool_call_started`` → phase "started" + input_text
+    JSON-encoded from ``meta.args``; output_text empty."""
+    upd = build_tool_step_update(
+        {
+            "op_id": "abc123",
+            "tool": "file__read",
+            "args": {"path": "/etc/hosts"},
+        },
+        "tool_call_started",
+    )
+    assert upd is not None
+    assert upd.phase == "started"
+    assert upd.op_id == "abc123"
+    assert upd.tool_name == "file__read"
+    assert "/etc/hosts" in upd.input_text
+    assert upd.output_text == ""
+    assert upd.is_error is False
+
+
+def test_completed_phase_carries_result_in_output_text():
+    """Tier 1: ``tool_call_completed`` → phase "completed" + output_text
+    JSON-encoded from ``meta.result``; input_text empty (= the step
+    already has args from the started phase)."""
+    upd = build_tool_step_update(
+        {
+            "op_id": "abc123",
+            "tool": "file__read",
+            "result": {"bytes": 1234, "content": "..."},
+        },
+        "tool_call_completed",
+    )
+    assert upd is not None
+    assert upd.phase == "completed"
+    assert upd.op_id == "abc123"
+    assert "1234" in upd.output_text
+    assert upd.input_text == ""
+    assert upd.is_error is False
+
+
+def test_failed_phase_combines_error_kind_and_message():
+    """Tier 1: ``tool_call_failed`` → phase "failed", is_error=True,
+    output combines kind + message when both present."""
+    upd = build_tool_step_update(
+        {
+            "op_id": "abc123",
+            "tool": "net__fetch",
+            "error_kind": "TimeoutError",
+            "error_message": "request timed out after 30s",
+        },
+        "tool_call_failed",
+    )
+    assert upd is not None
+    assert upd.phase == "failed"
+    assert upd.is_error is True
+    assert "TimeoutError" in upd.output_text
+    assert "timed out" in upd.output_text
+
+
+def test_failed_phase_falls_back_to_unknown_label():
+    """Tier 1: failure without kind / message → "(unknown error)" body."""
+    upd = build_tool_step_update(
+        {"op_id": "x", "tool": "t"},
+        "tool_call_failed",
+    )
+    assert upd is not None
+    assert upd.is_error is True
+    assert upd.output_text == "(unknown error)"
+
+
+def test_missing_op_id_returns_none():
+    """Tier 1: missing ``op_id`` → None (caller falls back to adapter
+    plain-text)."""
+    assert build_tool_step_update(
+        {"tool": "t"}, "tool_call_started",
+    ) is None
+    assert build_tool_step_update(
+        {"op_id": "", "tool": "t"}, "tool_call_started",
+    ) is None
+
+
+def test_missing_tool_returns_none():
+    """Tier 1: missing ``tool`` → None (no step title would render)."""
+    assert build_tool_step_update(
+        {"op_id": "x"}, "tool_call_started",
+    ) is None
+    assert build_tool_step_update(
+        {"op_id": "x", "tool": ""}, "tool_call_started",
+    ) is None
+
+
+def test_non_dict_meta_returns_none():
+    """Tier 1: defensive — None / non-dict meta → None."""
+    assert build_tool_step_update(None, "tool_call_started") is None
+    assert build_tool_step_update("not a dict", "tool_call_started") is None  # type: ignore[arg-type]
+
+
+def test_non_serialisable_args_fall_back_to_str():
+    """Tier 1: when ``meta.args`` contains a non-json type (= e.g. an
+    object), the helper uses ``str(value)`` instead of crashing."""
+
+    class _Unserialisable:
+        def __repr__(self) -> str:
+            return "<NotJsonAble>"
+
+    upd = build_tool_step_update(
+        {
+            "op_id": "x",
+            "tool": "t",
+            "args": _Unserialisable(),
+        },
+        "tool_call_started",
+    )
+    assert upd is not None
+    assert "NotJsonAble" in upd.input_text
+
+
+def test_huge_output_is_truncated():
+    """Tier 1: 8000-char cap on output_text so a giant result blob
+    doesn't make the step unusable in the UI."""
+    huge = "x" * 20_000
+    upd = build_tool_step_update(
+        {"op_id": "x", "tool": "t", "result": huge},
+        "tool_call_completed",
+    )
+    assert upd is not None
+    assert len(upd.output_text) <= 8030  # cap + trailing marker
+    assert "truncated" in upd.output_text
+
+
+def test_unknown_kind_returns_none():
+    """Tier 1: a kind outside the lifecycle set → None (= caller's
+    branch never enters the step path for them)."""
+    assert build_tool_step_update(
+        {"op_id": "x", "tool": "t"}, "tool_called",
+    ) is None
+    assert build_tool_step_update(
+        {"op_id": "x", "tool": "t"}, "agent",
+    ) is None
+
+
+def test_return_type_is_tool_step_update():
+    """Tier 1: return is the public dataclass (= caller reads .op_id /
+    .phase / .input_text / etc. without dict gymnastics)."""
+    upd = build_tool_step_update(
+        {"op_id": "x", "tool": "t"}, "tool_call_started",
+    )
+    assert isinstance(upd, ToolStepUpdate)


### PR DESCRIPTION
**[tui-coder]** — user dogfood 2026-05-25「マシになった。 tool inline に対して tool の詳細を collapse 表示すること可能？」 → yes、 `cl.Step` で実装。

## UX

drain loop が `tool_call_*` outbox kind を adapter 前に intercept、 各 invocation を **collapsible `cl.Step`** として描画。 operator は row をクリック展開で args / result / error を chat thread の流れの中で確認可能。 `auto_collapse=True` で completion 後は閉じた状態を維持、 通常 view 邪魔しない。

## 3-phase lifecycle (= op_id keyed)

```
tool_call_started   → Step(name=tool, type="tool").send() + step.input = json(args)
tool_call_completed → look up by op_id → step.output = json(result) + update
tool_call_failed    → look up by op_id → step.output = "<kind>: <msg>" + is_error + update
```

session-side step instance を `cl.user_session` に op_id key で stash、 後続 phase で lookup。

## Fallback

`build_tool_step_update` が `meta` 不正 / 必須 field 不足で None 返した場合、 OR session lookup 失敗 (= drain 再起動跨ぎ)、 OR chainlit 呼出 raise — いずれも **adapter 旧 path (= "🔧 tool" author + system_message bubble) に fall through**。 transient glitch で drain loop が壊れない。

## Why scope-limited

memory `chainlit-focus-no-internals` 準拠 — 新 helper `tool_step.py` + `app.py` の drain 数行 + tests、 reyn engine 不変。 `meta.op_id` / `meta.tool` / `meta.args` / `meta.result` / `meta.error_*` は既存 `lifecycle_forwarder._enqueue_tool_call` shape の read-only access。

## Test plan

- [x] **Tier 1 tool_step helper** — `pytest tests/cli/test_chainlit_tool_step.py` (12 tests 緑、 truth table / per-phase shape / error body 組合 / missing fields / non-dict defensive / non-serialisable args fallback / 8000-char output 切詰 / unknown-kind None / return-type)
- [x] **Full chainlit-side suite** — 152 tests 緑
- [x] **ruff clean** — 全 new files
- [x] **app.py import smoke**
- [ ] (skipped — needs browser interaction with tool-firing prompt) **Manual: `web__fetch` 等で tool 走る → `🔧 tool: <name>` row 表示 → クリック展開で args + result 見える + 終了後 auto_collapse**
- [ ] (skipped — same) **Manual: tool failure (= 拒否 / network error) → `is_error=True` で row 表示 + 展開で error_kind: error_message**
- [ ] (skipped — same) **Manual: 同一 prompt 内 multi-tool 連続 → 各 op_id 別に独立 step row 表示**

local server 9001 で 1, 2, 3 番 verify 予定 (user 試行)。

## Tier self-check

- ✅ Tier 1 only (= pure meta→step args mapping)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

## Future scope-out

- streaming tool output (= `step.stream_token` for progressive display) は別 PR
- step.metadata / tags / icon の細部 polish は別 wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)