### PR TITLE
feat(chainlit): edit agent role from the settings panel

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -33,12 +33,14 @@ from reyn.chainlit_app.history import DEFAULT_REPLAY_CAP, history_to_chainlit
 from reyn.chainlit_app.intervention import build_intervention_prompt
 from reyn.chainlit_app.profiles import list_agent_profiles
 from reyn.chainlit_app.settings import (
+    AGENT_ROLE_SETTING_ID,
     LANGUAGE_ITEMS,
     LANGUAGE_SETTING_ID,
     MODEL_SETTING_ID,
     language_label_for,
     language_to_value,
     list_model_names,
+    normalise_role,
     value_to_language,
     value_to_model,
 )
@@ -612,6 +614,29 @@ async def _on_chat_start() -> None:
                     ),
                 )
             )
+        # Agent role TextInput — surface the attached agent's persona
+        # so the operator can edit it without typing
+        # ``/agent edit role <text>`` slash. Same 2-side update as the
+        # slash command (= profile.yaml on disk + ``session._agent_role``
+        # in-memory for next turn).
+        current_role = getattr(session, "agent_role", "") or ""
+        widgets.append(
+            cl.input_widget.TextInput(
+                id=AGENT_ROLE_SETTING_ID,
+                label="Agent role",
+                initial=current_role,
+                multiline=True,
+                placeholder=(
+                    "Persona text injected into the LLM system prompt. "
+                    "Blank to leave as-is."
+                ),
+                tooltip=(
+                    "Edits both ``profile.yaml`` on disk and "
+                    "``session._agent_role`` in memory; the next user "
+                    "turn picks up the new role."
+                ),
+            )
+        )
         await cl.ChatSettings(widgets).send()
     except Exception:
         pass
@@ -662,6 +687,60 @@ async def _on_settings_update(settings: dict) -> None:
                 content=f"Model → **{new_model}**.",
                 author="system",
             ).send()
+    if AGENT_ROLE_SETTING_ID in settings:
+        new_role = normalise_role(settings.get(AGENT_ROLE_SETTING_ID))
+        current = getattr(session, "agent_role", "") or ""
+        # Skip when blank (= operator left field empty; preserve current)
+        # OR unchanged (= avoid spurious confirm message when the
+        # operator toggles a different widget without touching role).
+        if new_role is not None and new_role != current:
+            await _persist_agent_role(registry, session, new_role)
+
+
+async def _persist_agent_role(registry, session, new_role: str) -> None:
+    """Mirror ``/agent edit role <text>`` from chainlit's settings panel.
+
+    Two-side update: rewrite ``profile.yaml`` via
+    ``AgentProfile.save`` so the change survives restart, and assign
+    ``session._agent_role`` so the next router turn picks up the new
+    role without restart. Both sides wrapped in try/except so a disk
+    glitch surfaces in the chat as an error message rather than
+    crashing the settings handler.
+    """
+    from dataclasses import replace
+
+    from reyn.chat.profile import AgentProfile
+
+    agent_name = getattr(session, "agent_name", None)
+    if not agent_name:
+        return
+    project_dir = getattr(registry, "_dir", None)
+    if project_dir is None:
+        return
+    agent_dir = project_dir / agent_name
+    try:
+        profile = AgentProfile.load(agent_dir)
+    except FileNotFoundError:
+        await cl.ErrorMessage(
+            content=f"agent profile not found at {agent_dir}/profile.yaml",
+        ).send()
+        return
+    updated = replace(profile, role=new_role)
+    try:
+        updated.save(agent_dir)
+    except OSError as exc:
+        await cl.ErrorMessage(
+            content=f"failed to save agent role: {exc}",
+        ).send()
+        return
+    session._agent_role = new_role
+    await cl.Message(
+        content=(
+            f"Agent **{agent_name}** role updated.\n"
+            "Next user turn will use the new role."
+        ),
+        author="system",
+    ).send()
 
 
 @cl.on_message

--- a/src/reyn/chainlit_app/settings.py
+++ b/src/reyn/chainlit_app/settings.py
@@ -73,6 +73,29 @@ def language_label_for(value: str) -> str:
     return value
 
 
+# ── agent role text ───────────────────────────────────────────────────────
+
+
+AGENT_ROLE_SETTING_ID = "agent_role"
+
+
+def normalise_role(value: object) -> str | None:
+    """Strip a candidate role value into the form ``AgentProfile.save``
+    expects.
+
+    Returns ``None`` for empty / whitespace-only / non-string inputs so
+    the caller can skip the round-trip without writing a stale blank
+    over the agent's current persona. Pass-through for everything else,
+    trailing whitespace trimmed.
+    """
+    if not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    return v
+
+
 # ── model select ──────────────────────────────────────────────────────────
 
 
@@ -114,12 +137,14 @@ def value_to_model(value: str | None, *, default: str) -> str:
 
 
 __all__ = [
+    "AGENT_ROLE_SETTING_ID",
     "LANGUAGE_ITEMS",
     "LANGUAGE_SETTING_ID",
     "MODEL_SETTING_ID",
     "language_label_for",
     "language_to_value",
     "list_model_names",
+    "normalise_role",
     "value_to_language",
     "value_to_model",
 ]

--- a/tests/cli/test_chainlit_settings.py
+++ b/tests/cli/test_chainlit_settings.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 import pytest
 
 from reyn.chainlit_app.settings import (
+    AGENT_ROLE_SETTING_ID,
     LANGUAGE_ITEMS,
     LANGUAGE_SETTING_ID,
     MODEL_SETTING_ID,
     language_label_for,
     language_to_value,
     list_model_names,
+    normalise_role,
     value_to_language,
     value_to_model,
 )
@@ -166,3 +168,38 @@ def test_value_to_model_empty_falls_back_to_default():
     assert value_to_model("", default="standard") == "standard"
     assert value_to_model("   ", default="standard") == "standard"
     assert value_to_model(None, default="standard") == "standard"
+
+
+# ── agent role normaliser ─────────────────────────────────────────────────
+
+
+def test_agent_role_setting_id_is_stable():
+    """Tier 1: the widget id + on_settings_update dispatch key agree."""
+    assert AGENT_ROLE_SETTING_ID == "agent_role"
+
+
+def test_normalise_role_trims_whitespace():
+    """Tier 1: leading / trailing whitespace stripped before save —
+    matches the ``/agent edit role`` slash path's ``.strip()``."""
+    assert normalise_role("  you are a pirate  ") == "you are a pirate"
+
+
+def test_normalise_role_empty_returns_none():
+    """Tier 1: blank input → None (= caller skips persistence, preserves
+    current role) instead of writing a stale blank over the agent's
+    persona."""
+    assert normalise_role("") is None
+    assert normalise_role("   ") is None
+
+
+def test_normalise_role_none_input_returns_none():
+    """Tier 1: defensive — None or non-string → None."""
+    assert normalise_role(None) is None
+    assert normalise_role(12345) is None  # type: ignore[arg-type]
+
+
+def test_normalise_role_pass_through_multiline():
+    """Tier 1: multi-line role text preserved verbatim (= just trim
+    outer whitespace, not internal newlines / formatting)."""
+    multiline = "line one\nline two\n  indented line"
+    assert normalise_role("\n" + multiline + "\n") == multiline


### PR DESCRIPTION
**[tui-coder]** — user direct 2026-05-25「setting panel 使って agent 編集可能？」 → role 編集を gear icon panel に追加 (= #906 の `/agent edit role` slash の panel 対応版)。

## UX

歯車 panel に `cl.input_widget.TextInput(id="agent_role", multiline=True)` 追加、 initial value は現 `session.agent_role`。 編集して save → on_settings_update 経由で 2-side update:

```
profile = AgentProfile.load(agent_dir)
replace(profile, role=new_role).save(agent_dir)   # disk
session._agent_role = new_role                     # in-memory
```

= `/agent edit role <text>` slash と完全同等の path。 panel から / slash から / TUI から 全て同 effect。

## scope-out (= #906 と同じ deferred)

- rename — dir 移動 + history 継承 cascade safety
- delete — `reyn agent rm` CLI
- allowed_skills / allowed_mcp — list-edit UX 別設計

## 実装

- `settings.py`:
  - `AGENT_ROLE_SETTING_ID = "agent_role"`
  - `normalise_role(value)` — strip + None for empty/non-string (= 操作者が空欄のまま save した時 blank で上書きしない)
- `_on_chat_start` panel に widget 1 つ append
- `_on_settings_update` で `agent_role` key dispatch、 blank / unchanged は skip (= 他 widget toggle 時 spurious 確認 message 防止)
- `_persist_agent_role` (new helper) で 2-side update + FileNotFoundError / OSError → `cl.ErrorMessage` graceful

## Test plan

- [x] **Tier 1 settings** — `pytest tests/cli/test_chainlit_settings.py` (30 tests 緑、 = 既存 25 + 新 5: id 安定性 / trim / empty None / non-string defensive / multiline pass-through)
- [x] **Full chainlit-side suite** — 157 tests 緑
- [x] **ruff clean** — 全 touched files
- [x] **app.py import smoke**
- [ ] (skipped — needs browser interaction) **Manual: 歯車 → Agent role TextInput に「you are a pirate」 入力 save → 「Agent default role updated」 + 次 prompt で海賊口調**
- [ ] (skipped — same) **Manual: `cat .reyn/agents/default/profile.yaml` で role 更新 + name / created_at / allowed_* preserved**
- [ ] (skipped — same) **Manual: 空欄 save → spurious confirm 出ない (= 既 role preserved)**

local server 9001 で 1, 3 番 verify 予定。

## Tier self-check

- ✅ Tier 1 only (= pure normalise + setting id 安定性)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)