### PR TITLE
feat(chainlit): create new agent from the settings panel + clarify new-chat semantics

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -37,9 +37,11 @@ from reyn.chainlit_app.settings import (
     LANGUAGE_ITEMS,
     LANGUAGE_SETTING_ID,
     MODEL_SETTING_ID,
+    NEW_AGENT_NAME_SETTING_ID,
     language_label_for,
     language_to_value,
     list_model_names,
+    normalise_new_agent_name,
     normalise_role,
     value_to_language,
     value_to_model,
@@ -637,6 +639,26 @@ async def _on_chat_start() -> None:
                 ),
             )
         )
+        # Create-new-agent TextInput — mirrors ``/agent new <name>``
+        # slash so the operator can spin up a new agent from the
+        # panel. Name rule: 1-32 chars of ``[a-z0-9_-]`` starting
+        # with ``[a-z0-9]`` (enforced by ``registry.create``).
+        widgets.append(
+            cl.input_widget.TextInput(
+                id=NEW_AGENT_NAME_SETTING_ID,
+                label="Create new agent",
+                initial="",
+                placeholder=(
+                    "Type a name to create a new agent (e.g. "
+                    "\"research\"). Blank to skip."
+                ),
+                tooltip=(
+                    "Creates a new agent profile under "
+                    "``.reyn/agents/<name>/`` and attaches to it. "
+                    "1-32 chars of [a-z0-9_-] starting with [a-z0-9]."
+                ),
+            )
+        )
         await cl.ChatSettings(widgets).send()
     except Exception:
         pass
@@ -695,6 +717,65 @@ async def _on_settings_update(settings: dict) -> None:
         # operator toggles a different widget without touching role).
         if new_role is not None and new_role != current:
             await _persist_agent_role(registry, session, new_role)
+    if NEW_AGENT_NAME_SETTING_ID in settings:
+        new_name = normalise_new_agent_name(
+            settings.get(NEW_AGENT_NAME_SETTING_ID),
+        )
+        if new_name is not None:
+            await _create_new_agent(registry, new_name)
+
+
+async def _create_new_agent(registry, name: str) -> None:
+    """Mirror ``/agent new <name>`` from chainlit's settings panel.
+
+    Creates the agent on disk via the registry (= same path as the
+    slash command + ``reyn agent new`` CLI), then emits an
+    ``__attach_request__`` outbox sentinel so the drain forwarder
+    flips the attached session to the new agent — chainlit drain
+    will see the next ``agent_attached`` notification flow through.
+
+    The registry's ``_validate_agent_name`` enforces the 1-32
+    ``[a-z0-9_-]`` regex; we surface its ``ValueError`` verbatim so
+    the operator sees exactly why an invalid name was rejected.
+    ``FileExistsError`` (= duplicate) renders a hint to use the
+    chat-profile picker for an attach instead.
+    """
+    from reyn.chat.outbox import OutboxMessage
+
+    try:
+        registry.create(name)
+    except FileExistsError:
+        await cl.ErrorMessage(
+            content=(
+                f"agent {name!r} already exists. Use the chat-profile "
+                f"picker (top of the welcome screen) to attach instead."
+            ),
+        ).send()
+        return
+    except ValueError as exc:
+        await cl.ErrorMessage(content=str(exc)).send()
+        return
+
+    # Notify the operator + trigger the same attach path the
+    # ``/agent new`` slash uses.
+    await cl.Message(
+        content=(
+            f"Created agent **{name}**; attaching…\n"
+            "Use the chat-profile picker (top of the welcome screen) "
+            "to switch agents on subsequent chats."
+        ),
+        author="system",
+    ).send()
+    try:
+        session = registry.attached_session()
+        if session is not None:
+            await session._put_outbox(OutboxMessage(
+                kind="__attach_request__", text=name,
+            ))
+    except Exception:
+        # Attach signal best-effort — the agent profile is already on
+        # disk and the picker will pick it up on next reload.
+        pass
 
 
 async def _persist_agent_role(registry, session, new_role: str) -> None:

--- a/src/reyn/chainlit_app/assets/chainlit.md
+++ b/src/reyn/chainlit_app/assets/chainlit.md
@@ -2,21 +2,31 @@
 
 [reyn](https://github.com/tya5/reyn) は LLM 駆動の **Phase × Skill × OS** エージェントランタイム。 この画面は `reyn chainlit` で立ち上がる Web チャット surface (= TUI `reyn chat` / FastAPI `reyn web` と並列)。
 
-## できること (PoC scope)
+## できること
 
 - メッセージを送るとアタッチ済の agent (= 既定 `default`) が応答
-- skill の実行結果 / status / error は author 別 (= `agent` / `skill` / `status` / `error`) で表示
-- 同 agent state (history / skills / events) を TUI / web と共有
+- 歯車 ⚙ で **output_language / model / agent role / 新規 agent 作成** を panel 経由
+- chat-profile 切替で agent 切替 (= 履歴 replay 自動、 上限は `REYN_CHAINLIT_HISTORY_CAP` 環境変数)
+- tool 実行は `🔧 tool` collapsible step (= click で args / result / error 展開)
+- permission gate は `[y]es / [A]lways / [n]o / [N]ever` button で round-trip
+- slash: `/agents` `/skills` `/list` `/cost` quick action / `/clear-history confirm` / `/agent edit role <text>`
+- 添付ボタンで png/jpg upload → 次 prompt で agent が認識
+
+## エージェント管理
+
+- **既存に切替**: welcome 画面上部の chat-profile picker (`default` / `test219` / ... など)
+- **新規作成**: 歯車 ⚙ → 「Create new agent」 TextInput に名前入力 → save、 もしくは `/agent new <name>` slash
+- **persona 編集**: 歯車 ⚙ → 「Agent role」 TextInput、 もしくは `/agent edit role <text>` slash
+
+> ⚠ 左上「新規チャット」 ボタンは chainlit 標準のセッションリセット (= 同 agent の thread 再描画) で、 **新規 agent 作成ではない**。 新規 agent は上記の panel か slash から。
 
 ## まだできないこと (= follow-on)
 
 - streaming (= token-by-token 表示)
-- intervention の双方向応答 (= `cl.AskUserMessage` round-trip)
-- right panel 相当 (= cost / events / agents / docs)
-- multi-user 真の isolation (= 同時 2 user で attach 上書き)
+- multi-user 真の isolation (= 同 process で 2 user 同時 attach 上書き)
+- agent rename / delete from UI (= `reyn agent rm` CLI 経由)
+- allowed_skills / allowed_mcp 編集 UI
 
 ## 操作
 
-ブラウザ画面下の入力欄から普通にメッセージを送るだけ。 slash command (`/help` 等) は未配線 (= follow-on)。
-
-設定変更したい場合: cwd の `chainlit.md` (このファイル) と `.chainlit/config.toml` を編集 → Chainlit が hot-reload。
+ブラウザ画面下の入力欄から普通にメッセージを送るだけ。 設定変更は cwd の `chainlit.md` (このファイル) と `.chainlit/config.toml` を編集 → Chainlit が hot-reload。

--- a/src/reyn/chainlit_app/settings.py
+++ b/src/reyn/chainlit_app/settings.py
@@ -77,6 +77,26 @@ def language_label_for(value: str) -> str:
 
 
 AGENT_ROLE_SETTING_ID = "agent_role"
+NEW_AGENT_NAME_SETTING_ID = "new_agent_name"
+
+
+def normalise_new_agent_name(value: object) -> str | None:
+    """Strip a candidate "create new agent" name into ``registry.create``
+    input shape.
+
+    Returns ``None`` for non-string / blank inputs so the caller can
+    skip the create roundtrip when the operator left the TextInput
+    empty. Whitespace trimmed; further validation (= name regex /
+    duplicate check) is the registry's job — it raises ``ValueError``
+    or ``FileExistsError`` for invalid / clashing names which the
+    chainlit handler surfaces verbatim via ``cl.ErrorMessage``.
+    """
+    if not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    return v
 
 
 def normalise_role(value: object) -> str | None:
@@ -141,9 +161,11 @@ __all__ = [
     "LANGUAGE_ITEMS",
     "LANGUAGE_SETTING_ID",
     "MODEL_SETTING_ID",
+    "NEW_AGENT_NAME_SETTING_ID",
     "language_label_for",
     "language_to_value",
     "list_model_names",
+    "normalise_new_agent_name",
     "normalise_role",
     "value_to_language",
     "value_to_model",

--- a/tests/cli/test_chainlit_settings.py
+++ b/tests/cli/test_chainlit_settings.py
@@ -23,9 +23,11 @@ from reyn.chainlit_app.settings import (
     LANGUAGE_ITEMS,
     LANGUAGE_SETTING_ID,
     MODEL_SETTING_ID,
+    NEW_AGENT_NAME_SETTING_ID,
     language_label_for,
     language_to_value,
     list_model_names,
+    normalise_new_agent_name,
     normalise_role,
     value_to_language,
     value_to_model,
@@ -203,3 +205,44 @@ def test_normalise_role_pass_through_multiline():
     outer whitespace, not internal newlines / formatting)."""
     multiline = "line one\nline two\n  indented line"
     assert normalise_role("\n" + multiline + "\n") == multiline
+
+
+# ── new agent name normaliser ─────────────────────────────────────────────
+
+
+def test_new_agent_name_setting_id_is_stable():
+    """Tier 1: the widget id + on_settings_update dispatch key agree."""
+    assert NEW_AGENT_NAME_SETTING_ID == "new_agent_name"
+
+
+def test_normalise_new_agent_name_trims_whitespace():
+    """Tier 1: leading / trailing whitespace stripped before the
+    registry's name regex enforcement."""
+    assert normalise_new_agent_name("  research  ") == "research"
+
+
+def test_normalise_new_agent_name_blank_returns_none():
+    """Tier 1: empty / whitespace-only → None (= operator left the
+    TextInput unchanged; skip the create round-trip)."""
+    assert normalise_new_agent_name("") is None
+    assert normalise_new_agent_name("   ") is None
+
+
+def test_normalise_new_agent_name_non_string_returns_none():
+    """Tier 1: defensive — None / non-string → None."""
+    assert normalise_new_agent_name(None) is None
+    assert normalise_new_agent_name(42) is None  # type: ignore[arg-type]
+
+
+def test_normalise_new_agent_name_pass_through_valid_format():
+    """Tier 1: valid name shapes pass through verbatim — the registry's
+    ``_validate_agent_name`` is the authoritative regex check, so this
+    helper deliberately doesn't pre-filter (= invalid names hit
+    ``ValueError`` at create time + the chainlit handler surfaces the
+    reyn error verbatim)."""
+    assert normalise_new_agent_name("agent_with_underscore") == "agent_with_underscore"
+    assert normalise_new_agent_name("agent-with-dash") == "agent-with-dash"
+    assert normalise_new_agent_name("a") == "a"
+    # Invalid names also pass through this helper (= registry rejects):
+    assert normalise_new_agent_name("UPPER") == "UPPER"
+    assert normalise_new_agent_name("-leading-dash") == "-leading-dash"


### PR DESCRIPTION
**[tui-coder]** — user direct 2026-05-25 sequence:
1.「左上に新規チャットボタンあるんだけど、 機能してないよ」
2.「新規エージェント追加できると良いね」
3.「新規チャットボタンが新規エージェント追加ボタンだったら良いのに」

## 状況整理

chainlit 標準「New chat」 button は cl session reset (= 同 agent の thread 再描画 → #892 history replay で見た目変わらず体感「機能してない」)。 chainlit が button event hook を expose してないので直接の **「new chat → new agent」 マップ実装は困難**。 代わりに:

1. **canonical 作成 path 整備**: 歯車 panel に「Create new agent」 TextInput 追加 (= 本 PR)
2. **welcome 文言で semantic 明示**: chainlit.md に「新規チャットボタンは新規 agent 作成ではない」 明文化

## 実装

- `settings.py`:
  - `NEW_AGENT_NAME_SETTING_ID = "new_agent_name"`
  - `normalise_new_agent_name(value)` — strip + None for empty/non-string、 regex validation は registry 任せ
- `_on_chat_start` panel 末尾に TextInput append
- `_on_settings_update` で new key dispatch → `_create_new_agent`
- `_create_new_agent` helper:
  - `registry.create(name)` (= 既存 public API、 `_validate_agent_name` regex check)
  - `FileExistsError` → 「use chat-profile picker」 hint
  - `ValueError` → reyn error verbatim
  - 成功時 system message + `__attach_request__` outbox emit (= /agent new slash と同 path)
- `chainlit.md` — agent 管理セクション追加、 「⚠ 左上『新規チャット』 は ... 新規 agent 作成ではない」 明示

## scope-out (= 同 #906 / #917 と consistent)

- agent rename / delete UI — `reyn agent rm` CLI で対応
- allowed_skills / allowed_mcp 編集 UI
- chainlit「new chat」 button 自体の repurpose (= chainlit 側 hook 拡張待ち、 別 issue)

## Test plan

- [x] **Tier 1 settings** — `pytest tests/cli/test_chainlit_settings.py` (35 tests 緑、 = 既存 30 + 新 5: id 安定性 / trim / blank None / non-string / valid pass-through)
- [x] **Full chainlit-side suite** — 162 tests 緑
- [x] **ruff clean** — 全 touched files
- [x] **app.py import smoke**
- [ ] (skipped — needs browser interaction) **Manual: 歯車 → Create new agent に 「research」 入力 save → 「Created agent research; attaching…」 + ブラウザリロードで picker に research 出現**
- [ ] (skipped — same) **Manual: 重複名 (= default) 入力 save → "agent 'default' already exists; use the chat-profile picker" error**
- [ ] (skipped — same) **Manual: 不正名 (= UPPER / -leading-dash) 入力 → registry の ValueError verbatim**

local server 9001 で 1, 2, 3 番 verify 予定。

## Tier self-check

- ✅ Tier 1 only (= pure normalise + setting id 安定性)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 1 行目 Tier 宣言

🤖 Generated with [Claude Code](https://claude.com/claude-code)