### PR TITLE
feat(agent-lifecycle): 3-path spawn_ack + task_completed structural symmetry

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -90,6 +90,27 @@ _PLAN_SPAWN_ACK_MSG: dict[str, str] = {
 }
 
 
+# B55 R-7 (2026-05-25): agent-side spawn alignment — symmetric with
+# skill/plan spawn_ack so the LLM sees a structured task lifecycle
+# event for delegate_to_agent / other peer-async tools too. Prior
+# behaviour pushed a generic `dispatched N async requests; awaiting
+# peer reply` status row with no `[task_spawned]` header, leaving
+# the SP TASK_SPAWNED rule un-anchored for the agent path. Now mirrors
+# the skill / plan format: `[task_spawned] kind=agent ...` header +
+# user-facing trailer. Pairs with the `[task_completed] kind=agent
+# ...` injection on peer reply receipt (see a2a_handler).
+_AGENT_SPAWN_ACK_MSG: dict[str, str] = {
+    "ja": (
+        "ピアエージェントにリクエストを送信しました。"
+        " 返答を待っています — `/tasks` で進行状況を確認できます。"
+    ),
+    "en": (
+        "Request dispatched to the peer agent."
+        " Awaiting reply — use `/tasks` to monitor progress."
+    ),
+}
+
+
 # NF-W7-B43-2: positive directive injected into the spawn-ack tool_result
 # content. Replaces the previous OS-synthetic spawn-ack outbox push +
 # early-exit pattern with the standard tool_call → tool_result → LLM
@@ -1799,17 +1820,64 @@ class RouterLoop:
                             },
                         )
                         return self._total_usage
-                    # Non-plan async dispatch (= delegate_to_agent or
-                    # other async tools) falls back to the generic
-                    # status message.
-                    plural = "s" if async_count > 1 else ""
+                    # B55 R-7 (2026-05-25): non-plan async dispatch (=
+                    # delegate_to_agent or other peer-async tools). Mirror
+                    # skill / plan spawn_ack format: `[task_spawned]
+                    # kind=agent ...` header + user-facing trailer so the
+                    # SP TASK_SPAWNED rule covers this path too. Prior
+                    # behaviour pushed a generic `status` row with no
+                    # structured header, leaving the LLM without a task
+                    # lifecycle anchor when the corresponding
+                    # `[task_completed] kind=agent ...` injection arrives.
+                    #
+                    # Extract peer / request hint from the first async
+                    # tool call (= delegate_to_agent's `to` + `request`
+                    # arguments). Fallback to a generic "peer agent"
+                    # header when arguments aren't parseable (= defensive
+                    # for non-delegate async tools or malformed args).
+                    tc_first_async = None
+                    for tc_a, r_a in zip(tool_calls, tool_results):
+                        if (
+                            isinstance(r_a, dict)
+                            and r_a.get("status") == "spawned"
+                        ):
+                            tc_first_async = tc_a
+                            break
+                    peer = ""
+                    request_preview = ""
+                    if tc_first_async is not None:
+                        try:
+                            async_args = json.loads(
+                                tc_first_async["function"].get("arguments")
+                                or "{}",
+                            )
+                        except (json.JSONDecodeError, TypeError):
+                            async_args = {}
+                        peer = str(async_args.get("to", "") or "")
+                        request_preview = str(
+                            async_args.get("request", "") or "",
+                        )[:200]
+                    header_lines = [
+                        f"[task_spawned] kind=agent "
+                        f"chain_id={self.chain_id} count={async_count}",
+                    ]
+                    if peer:
+                        header_lines.append(f"peer: {peer}")
+                    if request_preview:
+                        header_lines.append(f"request: {request_preview}")
+                    header = "\n".join(header_lines)
+                    lang = getattr(host, "output_language", None)
+                    trailer = _AGENT_SPAWN_ACK_MSG.get(
+                        lang, _AGENT_SPAWN_ACK_MSG["en"],
+                    )
+                    ack_text = f"{header}\n\n{trailer}"
                     await self.host.put_outbox(
-                        kind="status",
-                        text=(
-                            f"dispatched {async_count} async request{plural}; "
-                            f"awaiting peer reply"
-                        ),
-                        meta={"chain_id": self.chain_id},
+                        kind="agent",
+                        text=ack_text,
+                        meta={
+                            "chain_id": self.chain_id,
+                            "source": "agent_spawn_ack",
+                        },
                     )
                     return self._total_usage
 

--- a/src/reyn/chat/services/a2a_handler.py
+++ b/src/reyn/chat/services/a2a_handler.py
@@ -447,8 +447,20 @@ class A2AHandler:
         depth = int(payload.get("depth", 1))
         chain_id = payload.get("chain_id") or _new_chain_id()
 
+        # B55 R-7 (2026-05-25): structural symmetry with skill / plan
+        # completion injections. Wrap the peer's reply in a
+        # `[task_completed] kind=agent ...` header (role=user) so the
+        # SP TASK_COMPLETED rule covers agent-delegation lifecycles
+        # too. Prior behaviour appended the raw reply text alone,
+        # which the LLM read as a plain user message — no task
+        # lifecycle anchor + no parity with skill / plan paths.
+        injected_text = (
+            f"[task_completed] kind=agent "
+            f"from={from_agent or '<unknown>'} chain_id={chain_id}\n"
+            f"reply: {response}"
+        )
         self._append_history(
-            "user", response, _now_iso(),
+            "user", injected_text, _now_iso(),
             {
                 "source": "agent_response",
                 "from_agent": from_agent, "depth": depth,
@@ -496,7 +508,11 @@ class A2AHandler:
             return
 
         try:
-            await self._run_router_loop(response, chain_id)
+            # B55 R-7: pass the structured `[task_completed] kind=agent`
+            # injection (= history's last entry, also user-role) so the
+            # router sees the same lifecycle marker the SP rule covers
+            # — parity with skill / plan completion paths.
+            await self._run_router_loop(injected_text, chain_id)
         except RouterCapExceeded as exc:
             await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
             return

--- a/tests/test_a2a_handler_invariants.py
+++ b/tests/test_a2a_handler_invariants.py
@@ -469,3 +469,66 @@ async def test_pending_chain_resolved_on_all_responses(
     assert upstream_final, "final reply must be sent upstream after chain resolves"
     assert upstream_final[0]["response"] != ""
     assert "synthesized answer" in upstream_final[0]["response"]
+
+
+# ---------------------------------------------------------------------------
+# Test 5: agent_response history injection carries `[task_completed] kind=agent`
+# structural header (B55 R-7 — symmetry with skill / plan completion paths)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_response_history_carries_task_completed_kind_agent_header(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: handle_agent_response must wrap the peer's reply in a
+    ``[task_completed] kind=agent from=<peer> chain_id=<Y>\\nreply: ...``
+    structured header before appending to history (= role=user). Pairs
+    with the ``[task_spawned] kind=agent ...`` spawn_ack in router_loop;
+    together they bring the agent-delegation path into structural
+    parity with skill / plan completion injections so the SP
+    TASK_COMPLETED rule covers all three lifecycles uniformly.
+
+    Prior behaviour appended the raw peer text alone, leaving the LLM
+    without a task lifecycle anchor for agent delegations (= W5
+    agent_delegation rubric content failures observed in B54+ retros).
+    """
+    monkeypatch.chdir(tmp_path)
+    responses: list[dict] = []
+    outbox: list[OutboxMessage] = []
+    history: list[dict] = []
+
+    handler, _chain_manager, _trackers = _build_handler(
+        tmp_path,
+        responses_sent=responses,
+        outbox_items=outbox,
+        history_items=history,
+    )
+
+    await handler.handle_agent_response({
+        "from_agent": "researcher",
+        "response": "FP-0001 is the async task lifecycle proposal.",
+        "depth": 2,
+        "chain_id": "chain-task-completed-001",
+    })
+
+    matching = [
+        h for h in history
+        if h["meta"].get("source") == "agent_response"
+        and h["meta"].get("chain_id") == "chain-task-completed-001"
+    ]
+    assert matching, "agent_response history entry must be appended"
+    entry = matching[0]
+    assert entry["role"] == "user", (
+        "task_completed injections are role=user (= matches skill / plan "
+        "completion path; role=tool would violate provider tool_call_id "
+        "constraints since the spawn happened in a prior turn)"
+    )
+    assert "[task_completed] kind=agent" in entry["text"], (
+        f"structured header missing from history; got: {entry['text']!r}"
+    )
+    assert "from=researcher" in entry["text"]
+    assert "chain_id=chain-task-completed-001" in entry["text"]
+    assert "FP-0001 is the async task lifecycle proposal." in entry["text"], (
+        "peer's raw reply must be preserved in the `reply:` body"
+    )

--- a/tests/test_replay_skill_router.py
+++ b/tests/test_replay_skill_router.py
@@ -371,12 +371,16 @@ async def test_delegate_to_agent(monkeypatch):
     assert host.agent_sends[0]["chain_id"] == "chain-test"
     assert isinstance(host.agent_sends[0]["request"], str)
 
-    # After delegate dispatch, RouterLoop exits with an "awaiting peer
-    # reply" status note; the peer's actual response comes back later via
-    # pending_chain (PR14) which re-invokes the router.
+    # B55 R-7: after delegate dispatch, RouterLoop exits with a
+    # `[task_spawned] kind=agent ...` structured spawn_ack (= parity
+    # with skill / plan spawn_ack format); peer's actual response
+    # arrives later via pending_chain (PR14) which re-invokes router
+    # with a `[task_completed] kind=agent ...` history injection.
     (msg,) = host.outbox
-    assert msg["kind"] == "status"
-    assert "awaiting peer reply" in msg["text"]
+    assert msg["kind"] == "agent"
+    assert msg["meta"].get("source") == "agent_spawn_ack"
+    assert "[task_spawned] kind=agent" in msg["text"]
+    assert "Awaiting reply" in msg["text"] or "返答を待っています" in msg["text"]
 
 
 @pytest.mark.replay("fixtures/llm/router/memory_recall.jsonl")

--- a/tests/test_router_loop.py
+++ b/tests/test_router_loop.py
@@ -541,11 +541,15 @@ async def test_delegate_to_agent(monkeypatch):
     assert agent_send["chain_id"] == "chain-test"
     # Only the first LLM call ran; the second round was never consumed.
     assert scripted.call_count == 1
-    # Outbox shows the "awaiting peer reply" status, not a text reply.
+    # B55 R-7: outbox shows a `[task_spawned] kind=agent ...`
+    # structured spawn_ack (= parity with skill / plan spawn_ack),
+    # not a generic "awaiting peer reply" status row.
     assert any(
-        m["kind"] == "status" and "awaiting peer reply" in m["text"]
+        m["kind"] == "agent"
+        and m.get("meta", {}).get("source") == "agent_spawn_ack"
+        and "[task_spawned] kind=agent" in m["text"]
         for m in host.outbox
-    ), f"Expected awaiting-peer-reply status; got: {host.outbox}"
+    ), f"Expected agent_spawn_ack; got: {host.outbox}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[dogfood-coder]** — async task lifecycle parity across the 3 dispatch paths.

## Background
Pre-fix the agent (`delegate_to_agent`) path was structurally inconsistent with skill / plan async dispatches:

| Path | spawn_ack | task_completed |
|---|---|---|
| skill | `[task_spawned] kind=skill ...` ✓ | `[task_completed] kind=skill ...` ✓ (role=user history inject) |
| plan | `[task_spawned] kind=plan ...` ✓ | `[task_completed] kind=plan ...` ✓ (role=user history inject) |
| **agent (before)** | generic `dispatched N async requests; awaiting peer reply` status row ✗ | raw peer reply text alone ✗ |

The SP TASK_SPAWNED / TASK_COMPLETED rule could not anchor on the agent path. Likely dogfood symptom: W5 `agent_delegation_simple` rubric content failures across B54+ retros — LLM treats peer reply as a plain user message, loses delegation context.

## Why role=user, not role=tool
Provider API contract (OpenAI / LiteLLM) requires `role=tool` messages to follow an assistant message with a matching `tool_call_id`. Async completions arrive AFTER the spawn turn ended — the `tool_call_id` linkage is no longer in the live message sequence. `role=user` + structured header is the provider-agnostic safe path; the SP TASK_COMPLETED rule teaches the LLM to recognise the structured header as a task lifecycle event.

## Changes

### Spawn side — `router_loop.py`
- New constant `_AGENT_SPAWN_ACK_MSG` (en/ja) mirroring `_SPAWN_ACK_MSG` / `_PLAN_SPAWN_ACK_MSG`.
- Replaced generic status row with structured `agent_spawn_ack` outbox push (`kind="agent"`, `meta.source="agent_spawn_ack"`):
  ```
  [task_spawned] kind=agent chain_id=<Y> count=<N>
  peer: <to>          (when extractable)
  request: <preview>  (truncated to 200 chars, when extractable)

  <i18n trailer (en/ja agent-spawn-ack message)>
  ```

### Completion side — `a2a_handler.py`
- `handle_agent_response` now wraps the peer's reply in `[task_completed] kind=agent from=<peer> chain_id=<Y>\nreply: ...` structured header BEFORE appending to history (`role="user"`). The same wrapped text is passed to `_run_router_loop(...)` so the router sees the task lifecycle marker.

## Tests
- `test_a2a_handler_invariants.py`: new Tier 2 `test_agent_response_history_carries_task_completed_kind_agent_header`
- `test_router_loop.py`: updated existing delegate-dispatch assertion to match new format
- `test_replay_skill_router.py`: same update

131 passed + 1 xfailed across chat / router / a2a / session tests.

## Test plan
- [x] `pytest tests/test_router_loop.py tests/test_replay_skill_router.py tests/test_a2a_handler_invariants.py tests/test_peer_agent_not_found.py tests/test_delegate_to_agent_unified.py tests/test_a2a_*.py` — 131 passed / 1 xfailed
- [x] tier audit 0 errors
- [x] F541 clean
- [x] (skipped — empirical W5 agent_delegation lift confirmation deferred to B55 carry-over dispatch wave; structural symmetry is testable at unit level which this PR pins)
- [x] Tier rule self-check: docstring `"""Tier 2: ..."""` ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)