### PR TITLE
feat(chainlit): hide the upstream "New Chat" button via shipped CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,11 @@ spike_results/
 .handoff/
 
 # Chainlit auto-created artifacts (= first `reyn chainlit` run drops
-# chainlit.md welcome page + .chainlit/{config.toml,translations/} in
-# cwd). User-editable but not part of reyn's source — per-project
-# customization belongs in operator's workspace, not the repo.
-# Anchored to repo root so the shipped asset under
-# src/reyn/chainlit_app/assets/chainlit.md is tracked.
+# chainlit.md welcome page + .chainlit/{config.toml,translations/} +
+# public/ in cwd). User-editable but not part of reyn's source —
+# per-project customization belongs in operator's workspace, not the
+# repo. Anchored to repo root so the shipped assets under
+# src/reyn/chainlit_app/assets/ are tracked.
 /chainlit.md
 /.chainlit/
+/public/

--- a/src/reyn/chainlit_app/assets/.chainlit/config.toml
+++ b/src/reyn/chainlit_app/assets/.chainlit/config.toml
@@ -11,12 +11,28 @@
 # raises if absent or <= "0.3.0").
 
 [UI]
+# Required by chainlit's pydantic ``UISettings`` (= no default; the
+# loader raises ``ValidationError`` when missing). Shows in the
+# browser tab title + ``[UI]`` panel header.
+name = "reyn"
+
 # Skip the "Start a new chat?" confirmation popup when the operator
 # clicks the agent-switch / new-chat button. Operators dogfooding the
 # reyn picker (#888) want to flip between agents quickly; the extra
 # confirm step adds friction without preventing real mistakes
 # (= reyn keeps history per agent regardless).
 confirm_new_chat = false
+
+# Hide chainlit's "New Chat" button. In a reyn context it triggers a
+# bare session reset (= clean_session socket event → on_chat_end →
+# on_chat_start cycle); the attached agent, history, and panel state
+# all rebuild identically, so the button is functionally a page
+# reload. Operators dogfooding mistook it for a "create new agent"
+# affordance — see the chat-profile picker / `/agent new <name>`
+# slash / settings panel for the actual agent management entry
+# points. Remove this line and the public/reyn.css ship to put the
+# upstream button back.
+custom_css = "/public/reyn.css"
 
 [meta]
 generated_by = "reyn-chainlit-app"

--- a/src/reyn/chainlit_app/assets/public/reyn.css
+++ b/src/reyn/chainlit_app/assets/public/reyn.css
@@ -1,0 +1,32 @@
+/*
+ * reyn × Chainlit — UI tweaks shipped on first `reyn chainlit` launch.
+ *
+ * To re-enable the upstream Chainlit UI, either edit this file in
+ * `<cwd>/public/reyn.css` or remove the `custom_css` line from
+ * `<cwd>/.chainlit/config.toml`. The file is gitignored at the repo
+ * root via the `/public/` rule alongside `chainlit.md` and
+ * `.chainlit/` so operator edits survive subsequent `reyn chainlit`
+ * launches (= idempotent first-run copy posture, mirroring
+ * `ensure_chainlit_md` / `ensure_chainlit_config`).
+ */
+
+/* Hide the chainlit "New Chat" button. In a reyn context it triggers
+ * a bare session reset (= clean_session socket event → on_chat_end →
+ * on_chat_start cycle): the attached agent, history.jsonl replay,
+ * and settings panel all rebuild identically, making it functionally
+ * a page reload. Operators mistook it for a "create new agent"
+ * affordance during dogfood — the chat-profile picker, the
+ * `/agent new <name>` slash, and the settings-panel TextInput are
+ * the actual agent management entry points.
+ *
+ * Selectors are intentionally broad to survive chainlit version
+ * drift — aria-label / data-tooltip on the button + the localised
+ * variants in en-US / ja-JP. Add more locale strings if you ship
+ * additional `.chainlit/translations/` overrides.
+ */
+button[aria-label="New Chat"],
+button[aria-label="新規チャット"],
+[data-tooltip-id*="newChat" i],
+[data-testid*="new-chat" i] {
+    display: none !important;
+}

--- a/src/reyn/chainlit_app/first_run.py
+++ b/src/reyn/chainlit_app/first_run.py
@@ -61,12 +61,30 @@ def ensure_chainlit_config(target_dir: Path) -> Path | None:
     )
 
 
+def ensure_public_css(target_dir: Path) -> Path | None:
+    """Copy ``public/reyn.css`` from assets if absent.
+
+    Chainlit's ``[UI].custom_css`` flag in the shipped config.toml
+    points at ``/public/reyn.css`` (= APP_ROOT-relative path), so the
+    file MUST sit at ``target_dir/public/reyn.css`` for the rule to
+    apply. The default ships hides the upstream "New Chat" button
+    because in a reyn context it triggers a bare session reset (=
+    confusing as a UX affordance — see header comment in
+    ``assets/public/reyn.css``). Operator can edit the file or drop
+    the ``custom_css`` line to put the button back.
+    """
+    return _copy_if_absent(
+        assets_dir() / "public" / "reyn.css",
+        target_dir / "public" / "reyn.css",
+    )
+
+
 def ensure_all_assets(target_dir: Path) -> list[Path]:
     """Run every ``ensure_*`` helper, returning the list of paths that
     were actually written (= empty list when all destinations already
     existed and the call was a pure no-op)."""
     written: list[Path] = []
-    for helper in (ensure_chainlit_md, ensure_chainlit_config):
+    for helper in (ensure_chainlit_md, ensure_chainlit_config, ensure_public_css):
         result = helper(target_dir)
         if result is not None:
             written.append(result)
@@ -78,4 +96,5 @@ __all__ = [
     "ensure_all_assets",
     "ensure_chainlit_config",
     "ensure_chainlit_md",
+    "ensure_public_css",
 ]

--- a/tests/cli/test_chainlit_first_run.py
+++ b/tests/cli/test_chainlit_first_run.py
@@ -17,6 +17,7 @@ from reyn.chainlit_app.first_run import (
     ensure_all_assets,
     ensure_chainlit_config,
     ensure_chainlit_md,
+    ensure_public_css,
 )
 
 
@@ -107,29 +108,95 @@ def test_ensure_chainlit_config_skips_when_present(tmp_path: Path):
 
 
 def test_ensure_all_assets_copies_both_on_first_run(tmp_path: Path):
-    """Tier 1: clean cwd → both chainlit.md and .chainlit/config.toml land."""
+    """Tier 1: clean cwd → all 3 shipped assets (chainlit.md /
+    .chainlit/config.toml / public/reyn.css) land."""
     written = ensure_all_assets(tmp_path)
-    assert len(written) == 2
+    assert len(written) == 3
     assert (tmp_path / "chainlit.md").is_file()
     assert (tmp_path / ".chainlit" / "config.toml").is_file()
+    assert (tmp_path / "public" / "reyn.css").is_file()
 
 
 def test_ensure_all_assets_noop_when_both_present(tmp_path: Path):
-    """Tier 1: both files pre-existing → returns empty list, no overwrites."""
+    """Tier 1: all 3 files pre-existing → returns empty list, no overwrites."""
     (tmp_path / "chainlit.md").write_text("custom welcome")
     (tmp_path / ".chainlit").mkdir()
     (tmp_path / ".chainlit" / "config.toml").write_text("custom config")
+    (tmp_path / "public").mkdir()
+    (tmp_path / "public" / "reyn.css").write_text("/* custom css */")
     written = ensure_all_assets(tmp_path)
     assert written == []
     assert (tmp_path / "chainlit.md").read_text() == "custom welcome"
     assert (tmp_path / ".chainlit" / "config.toml").read_text() == "custom config"
+    assert (tmp_path / "public" / "reyn.css").read_text() == "/* custom css */"
 
 
 def test_ensure_all_assets_partial_one_existing_one_missing(tmp_path: Path):
-    """Tier 1: one asset pre-existing, the other not → copy only the missing
-    one (= per-asset idempotence, not all-or-nothing)."""
+    """Tier 1: one asset pre-existing, the others not → copy only the
+    missing ones (= per-asset idempotence, not all-or-nothing)."""
     (tmp_path / "chainlit.md").write_text("custom welcome")
     written = ensure_all_assets(tmp_path)
-    assert len(written) == 1
-    assert written[0] == tmp_path / ".chainlit" / "config.toml"
+    # config.toml + public/reyn.css missing → 2 copies.
+    assert len(written) == 2
+    written_names = sorted(p.name for p in written)
+    assert written_names == ["config.toml", "reyn.css"]
     assert (tmp_path / "chainlit.md").read_text() == "custom welcome"
+
+
+# ── ensure_public_css ─────────────────────────────────────────────────────
+
+
+def test_assets_dir_contains_public_reyn_css():
+    """Tier 1: shipped ``public/reyn.css`` template exists."""
+    src = assets_dir() / "public" / "reyn.css"
+    assert src.is_file(), f"shipped reyn.css missing at {src}"
+
+
+def test_public_css_hides_new_chat_button_selectors():
+    """Tier 1: pin the actual visible-hide rule — a stray formatting
+    change shouldn't silently lose the selector that does the work."""
+    src = (assets_dir() / "public" / "reyn.css").read_text()
+    assert "display: none" in src
+    # Multiple aria-label / data-tooltip selectors so chainlit version
+    # drift in localised strings or test-id renames doesn't silently
+    # re-show the button.
+    assert "New Chat" in src
+    assert "newChat" in src
+
+
+def test_config_template_points_at_public_reyn_css():
+    """Tier 1: shipped ``.chainlit/config.toml`` references the same
+    relative path the ``ensure_public_css`` helper writes to. A
+    rename on either side without updating the other would leave the
+    rule loaded but the file missing."""
+    src = (assets_dir() / ".chainlit" / "config.toml").read_text()
+    assert "/public/reyn.css" in src
+    assert "custom_css" in src
+
+
+def test_ensure_public_css_creates_when_absent(tmp_path: Path):
+    """Tier 1: empty cwd → copy + parent ``public/`` mkdir + return path."""
+    result = ensure_public_css(tmp_path)
+    assert result == tmp_path / "public" / "reyn.css"
+    assert result.is_file()
+    assert (tmp_path / "public").is_dir()
+
+
+def test_ensure_public_css_skips_when_present(tmp_path: Path):
+    """Tier 1: existing file → no overwrite, returns None."""
+    pdir = tmp_path / "public"
+    pdir.mkdir()
+    custom = pdir / "reyn.css"
+    custom.write_text("/* operator's css */\n")
+    result = ensure_public_css(tmp_path)
+    assert result is None
+    assert custom.read_text() == "/* operator's css */\n"
+
+
+def test_ensure_all_assets_includes_public_css(tmp_path: Path):
+    """Tier 1: clean cwd → all 3 shipped assets land."""
+    written = ensure_all_assets(tmp_path)
+    assert len(written) == 3
+    assert (tmp_path / "chainlit.md").is_file()
+    assert (tmp_path / ".chainlit" / "config.toml").is_file()
+    assert (tmp_path / "public" / "reyn.css").is_file()


### PR DESCRIPTION
**[tui-coder]** — user dogfood 2026-05-25 follow-on after #919 close (= 「微妙」 撤回後):「難しいなら、 そもそも表示消したいね」。 chainlit「New Chat」 button は **bare session reset** (= 同 agent / 同 history / 同 panel 再構築、 ページリロード相当)、 隣の chat-profile picker と pair で「manage agent」 affordance に見えるが実態は無関係。 chainlit upstream button-event hook 無いので repurpose 困難 → **CSS で hide** が最 minimum。

## 実装

- `assets/public/reyn.css` (新規) — `display: none !important` rule、 multiple selector (aria-label / data-tooltip、 en-US + ja-JP) で chainlit version drift 耐性。 header comment で why + revert 手順
- `assets/.chainlit/config.toml` — `[UI].custom_css = "/public/reyn.css"` + 必須 `[UI].name = "reyn"` (= pydantic UISettings.name no-default、 partial config 拡張時に validation 失敗するので明示)
- `first_run.ensure_public_css` + `ensure_all_assets` 3 asset 対応
- `.gitignore` に `/public/` 追加 (= chainlit-artifacts block)

Operator revert path: `cwd/public/reyn.css` 編集 OR `cwd/.chainlit/config.toml` から `custom_css` 行削除。 idempotent first-run copy なので削除しても先 push しない限り再生成されない。

## Test plan

- [x] **Tier 1 first_run** — `pytest tests/cli/test_chainlit_first_run.py` (18 tests 緑、 = 既存 12 + 新 6: 存在 / hide rule substring / config↔css path 整合 / create-skip idempotence / ensure_all_assets per-asset + all-three counts)
- [x] **Full chainlit-side suite** — 163 tests 緑
- [x] **ruff clean** — 全 touched files
- [x] **app.py import smoke** — 拡張無し (= ship-only change)
- [x] **Manual local verify**: reyn chainlit 起動 → `cwd/.chainlit/config.toml` に shipped 内容着地 + `/public/reyn.css` HTTP 200 配信確認 ✓
- [ ] (skipped — needs browser interaction) **Manual: ブラウザリロード → 左上「New Chat」 button 表示消える + 残る picker / 歯車は表示維持**
- [ ] (skipped — same) **Manual: `cwd/public/reyn.css` 削除 + reyn chainlit 再起動 → button 復活 (= revert path 動作)**

local server 9001 で 1, 2 番 verify 予定。

## Tier self-check

- ✅ Tier 1 only (= asset file existence + content invariant + helper idempotence)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし (= substring assert で selector / display:none / path agreement)
- ✅ docstring 1 行目 Tier 宣言

## scope-out

- chainlit upstream に `@cl.on_new_chat` hook feature request (= 別 issue 切り、 hide だけは即適用)
- 他 chainlit UI element の hide / restyle (= 「微妙」 報告無き限り pursue しない、 minimal posture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)