### PR TITLE
feat(web): --eager-embedding-build flag for reyn web (parity with reyn chat)

### DIFF
--- a/scripts/dogfood_batch_dispatch.py
+++ b/scripts/dogfood_batch_dispatch.py
@@ -140,7 +140,7 @@ rm -rf .reyn/agents .reyn/state .reyn/events .reyn/action_index .reyn/llm_trace.
 {env_block} \\
   REYN_LLM_TRACE_DUMP=$(pwd)/.reyn/llm_trace.jsonl \\
   nohup /Users/yasudatetsuya/Workspace/junk/claude_sandbox/sandbox_2/venv/bin/reyn web \\
-    --port {worker.port} --log-level warning > /tmp/b{config.batch.name.lstrip('B')}-{worker.name.lstrip('W')}-server.log 2>&1 &
+    --port {worker.port} --log-level warning --eager-embedding-build > /tmp/b{config.batch.name.lstrip('B')}-{worker.name.lstrip('W')}-server.log 2>&1 &
 sleep 4
 curl -s -o /dev/null -w "%{{http_code}}\\n" http://localhost:{worker.port}/health  # must be 200
 ```

--- a/src/reyn/cli/commands/web.py
+++ b/src/reyn/cli/commands/web.py
@@ -54,6 +54,24 @@ def register(sub) -> None:
         dest="default_design",
         help="デフォルトの design slug (env REYN_WEB_DEFAULT_DESIGN に設定)",
     )
+    # Parity with `reyn chat --eager-embedding-build` (= B25-S5-1).
+    # Builds the action-index synchronously on session start so
+    # ``search_actions`` is visible in tools[] from the first router
+    # turn, instead of becoming visible only after the background build
+    # finishes. Paid as a one-time per-session cost; ``is_ready()`` then
+    # short-circuits subsequent turns via the SQLite cache.
+    p.add_argument(
+        "--eager-embedding-build",
+        action="store_true",
+        default=False,
+        dest="eager_embedding_build",
+        help=(
+            "action_embedding_index を session 起動時 sync で build "
+            "(env REYN_WEB_EAGER_EMBEDDING_BUILD=1 と同等)。"
+            " search_actions を 1 turn 目から見せたい dogfood / web "
+            "デプロイで有効化。"
+        ),
+    )
     p.set_defaults(func=run)
 
 
@@ -82,6 +100,12 @@ def run(args: argparse.Namespace) -> None:
     import os
     if getattr(args, "default_design", None):
         os.environ["REYN_WEB_DEFAULT_DESIGN"] = args.default_design
+
+    # --eager-embedding-build flag: propagate via env so the web session
+    # factory (= reyn.web.deps:_session_factory) can read it. Parity with
+    # `reyn chat --eager-embedding-build` (= B25-S5-1).
+    if getattr(args, "eager_embedding_build", False):
+        os.environ["REYN_WEB_EAGER_EMBEDDING_BUILD"] = "1"
 
     uvicorn.run(
         "reyn.web.server:app",

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -227,6 +227,17 @@ def _get_registry():
         # registry is referenced inside the factory closure — defined below.
         registry_ref: list = []
 
+        # `reyn web --eager-embedding-build` flag (parity with `reyn chat`).
+        # When set, ChatSession waits for the action_embedding_index build
+        # synchronously on the first router turn so ``search_actions`` is
+        # visible in tools[] from Turn 1 instead of only after the
+        # background build completes. Default False keeps existing
+        # behaviour (background build, ``search_actions`` initially
+        # hidden until the index is ready).
+        _eager_embedding_build = (
+            os.environ.get("REYN_WEB_EAGER_EMBEDDING_BUILD", "").strip() == "1"
+        )
+
         def _session_factory(profile: AgentProfile) -> ChatSession:
             registry = registry_ref[0]
             s = ChatSession(
@@ -258,6 +269,7 @@ def _get_registry():
                 multimodal_config=config.multimodal,
                 action_retrieval_config=config.action_retrieval,
                 embedding_config=config.embedding,
+                eager_embedding_build=_eager_embedding_build,
             )
             s.load_history()
             # FP-0041 #489 PR-D2.5: external transport outbox interceptor.


### PR DESCRIPTION
**[dogfood-coder]** — close the chat-vs-web CLI parity gap for eager embedding-index build.

## Background
`reyn chat` has had `--eager-embedding-build` (= B25-S5-1) since the universal-catalog landing, but `reyn web` didn't expose it. In web mode the action_embedding_index builds in the **background** on first router turn, so `search_actions` is hidden from tools[] until the build completes.

Dogfood impact (= B55 W5 trace, primary evidence):
- `search_actions` in tools[]: **2 / 23 router calls (8.7%)**
- `search_actions` actually called by LLM: **0 times**

Most dogfood scenarios are 1-3 turns, so Turn-1 invisibility = full session invisibility.

## Changes
1. **`src/reyn/cli/commands/web.py`**: add `--eager-embedding-build` CLI flag mirroring `reyn chat`. Sets `REYN_WEB_EAGER_EMBEDDING_BUILD=1` env for the uvicorn child to read.
2. **`src/reyn/web/deps.py`**: `_session_factory` reads the env var and passes `eager_embedding_build=<bool>` to `ChatSession(...)`.
3. **`scripts/dogfood_batch_dispatch.py`**: dogfood worker prompt template now includes `--eager-embedding-build` in the `reyn web` invocation so future batches consistently see `search_actions` from Turn 1.

## Smoke verify (= live, 2026-05-25)
```
reyn web --port 8590 --eager-embedding-build &
curl -X POST /a2a/agents/eager-test -d '{"message":"hi"}'
```
First router call tools[] inspection:
```
call rid=09bb926d tools_n=16 has_search_actions=True   ✓
```

| Path | search_actions in Turn 1 tools[] |
|---|---|
| Pre-fix (B55 W5 baseline) | 2/23 calls (= 8.7%) |
| **Post-fix smoke** | **1/1 (= 100%)** |

## Cost
Eager build pays a one-time per-session cost (= ~5-10s depending on catalog size). Subsequent turns short-circuit via the SQLite cache `is_ready()` check. For dogfood, every scenario sees `search_actions` from Turn 1, so semantic-search vs hot-list / list_actions comparisons become apples-to-apples.

## Test plan
- [x] CLI flag visible (`reyn web --help | grep eager` ✓)
- [x] syntax validate (web.py / deps.py / dispatch.py all parse)
- [x] live smoke (= Turn 1 tools[] has search_actions ✓)
- [x] existing session-factory uniformity tests pass (12/12)
- [x] (skipped — dedicated env-var-wiring test is brittle; smoke verify above is the contract proof; B56 dispatch will confirm consistent visibility across 50 scenarios)
- [x] Tier rule self-check: no test changes (docstring N/A / Tier 4 violations 0 / invariant 弱化なし / audit N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)