### PR TITLE
feat(bench): FP-0043 Phase 1 — N=20 retrieval bench scaffold (manifest + runner)

### DIFF
--- a/scripts/embedding_bench.py
+++ b/scripts/embedding_bench.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""embedding_bench.py — FP-0043 Phase 1 N=20 retrieval benchmark runner.
+
+Measures **Axis 1 (precision)** — does the embedding ranking surface
+the expected qualified_name in the top-K? — across one or more embedding
+classes for the bench fixtures declared in
+``tests/data/embedding_bench/manifest.yaml``.
+
+Axis 2 (= LLM call-rate) is NOT measured here; it requires a live router
+loop with an LLM and is captured by the dogfood scenario sweep
+(see #925 / B57 in FP-0043 §Phases).
+
+Usage:
+    # Single class (default: light, = "openai/text-embedding-3-small")
+    python scripts/embedding_bench.py
+
+    # Multiple classes — comma-separated
+    python scripts/embedding_bench.py --classes light,standard
+
+    # JSON output for downstream aggregation
+    python scripts/embedding_bench.py --json
+
+    # Custom manifest path
+    python scripts/embedding_bench.py --manifest tests/data/embedding_bench/manifest.yaml
+
+Output (table mode):
+
+    bench: tests/data/embedding_bench/manifest.yaml (20 fixtures)
+
+    class       model                              hit@1  hit@3  hit@5  N
+    light       openai/text-embedding-3-small        12     18     19   20
+
+    misses (hit@5 fail):
+      - file_glob_grep_search                expected=file__grep            top=[...]
+
+The catalog is enumerated via the production list_actions handler with
+no router state attached (= static-categories only). Dynamic categories
+(skill / mcp.tool / memory.entry / etc.) without router state surface
+as their static-category placeholders only; this is intentional — bench
+queries target the universal-catalog surface a fresh-context LLM would
+see, not the per-session catalog superset.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """One row of the bench manifest."""
+
+    id: str
+    prompt: str
+    expected_action: str
+    axis: tuple[str, ...]
+    source: str
+
+
+@dataclass(frozen=True)
+class HitResult:
+    """Per-fixture result: where did `expected_action` land in the top-K?"""
+
+    fixture_id: str
+    expected: str
+    rank: int  # 0-indexed rank in the top-K, or -1 if not present
+    top_k: tuple[str, ...]
+
+
+def _load_manifest(path: Path) -> tuple[str, list[Fixture]]:
+    """Load manifest.yaml into (commit_sha, fixtures). Strict; no defaults."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    sha = data.get("last_synced_commit_sha", "")
+    raw_fixtures = data.get("fixtures") or []
+    fixtures: list[Fixture] = []
+    for raw in raw_fixtures:
+        if "precision" not in (raw.get("axis") or []):
+            continue  # this runner measures precision only
+        fixtures.append(Fixture(
+            id=raw["id"],
+            prompt=raw["prompt"],
+            expected_action=raw["expected_action"],
+            axis=tuple(raw["axis"]),
+            source=raw.get("source", ""),
+        ))
+    return sha, fixtures
+
+
+async def _enumerate_catalog() -> list[dict[str, Any]]:
+    """Return the catalog items the bench will index, as list_actions does.
+
+    Pulls every category through the production handler with a None
+    router_state so only static-category items surface. The result shape
+    matches what ActionEmbeddingIndex.build expects.
+    """
+    from reyn.tools.types import ToolContext
+    from reyn.tools.universal_catalog import CATEGORIES, LIST_ACTIONS
+
+    class _Events:
+        def emit(self, *a: Any, **kw: Any) -> None:
+            pass
+
+    ctx = ToolContext(
+        events=_Events(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=None,
+    )
+
+    items: list[dict[str, Any]] = []
+    for cat in CATEGORIES:
+        page = await LIST_ACTIONS.handler({"category": [cat]}, ctx)
+        for item in page.get("items", []):
+            items.append({
+                "qualified_name": item["qualified_name"],
+                "short_description": item.get("short_description", ""),
+            })
+    return items
+
+
+async def _run_class(
+    class_name: str,
+    fixtures: list[Fixture],
+    catalog: list[dict[str, Any]],
+    top_k: int,
+) -> tuple[str, list[HitResult]]:
+    """Build a fresh index for `class_name` and score each fixture."""
+    from reyn.config import load_config
+    from reyn.embedding.litellm_provider import LiteLLMEmbeddingProvider
+    from reyn.tools.action_index import ActionEmbeddingIndex
+
+    cfg = load_config()
+    provider = LiteLLMEmbeddingProvider(config=cfg.embedding)
+    resolved = provider._resolve_model(class_name)
+
+    index = ActionEmbeddingIndex(persist_dir=None)
+    await index.build(catalog, provider, class_name)
+
+    results: list[HitResult] = []
+    for f in fixtures:
+        hits = await index.query(f.prompt, provider, class_name, top_k=top_k)
+        names = tuple(h["qualified_name"] for h in hits)
+        try:
+            rank = names.index(f.expected_action)
+        except ValueError:
+            rank = -1
+        results.append(HitResult(
+            fixture_id=f.id,
+            expected=f.expected_action,
+            rank=rank,
+            top_k=names,
+        ))
+    return resolved, results
+
+
+def _summarize(class_name: str, model: str, results: list[HitResult]) -> dict[str, Any]:
+    """Compute hit@1 / hit@3 / hit@5 counts for a class."""
+    n = len(results)
+    hit1 = sum(1 for r in results if 0 <= r.rank < 1)
+    hit3 = sum(1 for r in results if 0 <= r.rank < 3)
+    hit5 = sum(1 for r in results if 0 <= r.rank < 5)
+    return {
+        "class": class_name,
+        "model": model,
+        "hit@1": hit1,
+        "hit@3": hit3,
+        "hit@5": hit5,
+        "N": n,
+    }
+
+
+def _print_table(summaries: list[dict[str, Any]]) -> None:
+    """Print results as an aligned table."""
+    header = f"  {'class':12} {'model':40} {'hit@1':>6} {'hit@3':>6} {'hit@5':>6} {'N':>4}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for s in summaries:
+        print(
+            f"  {s['class']:12} {s['model'][:40]:40} "
+            f"{s['hit@1']:>6} {s['hit@3']:>6} {s['hit@5']:>6} {s['N']:>4}"
+        )
+
+
+def _print_misses(class_name: str, results: list[HitResult]) -> None:
+    """Print fixtures that missed hit@5 for debugging."""
+    misses = [r for r in results if r.rank == -1 or r.rank >= 5]
+    if not misses:
+        return
+    print(f"\n  misses for class={class_name!r} (hit@5 fail):")
+    for r in misses:
+        top3 = ", ".join(r.top_k[:3])
+        rank_str = "miss" if r.rank == -1 else f"rank={r.rank}"
+        print(f"    - {r.fixture_id:36} expected={r.expected:35} {rank_str:8} top3=[{top3}]")
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    sha, fixtures = _load_manifest(manifest_path)
+    if not fixtures:
+        print(f"no precision-axis fixtures in {manifest_path}", file=sys.stderr)
+        return 1
+
+    catalog = await _enumerate_catalog()
+
+    if args.dry_run:
+        # Env-independent validation: manifest loads, catalog enumerates,
+        # every fixture's expected_action appears in the catalog. Skips
+        # the embedding provider call entirely (= safe to run in CI / on
+        # machines without embedding credentials).
+        catalog_qns = {item["qualified_name"] for item in catalog}
+        unknown = [f for f in fixtures if f.expected_action not in catalog_qns]
+        print(f"dry-run: manifest={manifest_path} sha={sha[:12]}")
+        print(f"  fixtures (precision-axis): {len(fixtures)}")
+        print(f"  catalog size: {len(catalog)}")
+        if unknown:
+            print(f"  unknown expected_action entries ({len(unknown)}):")
+            for f in unknown:
+                print(f"    - {f.id}: {f.expected_action}")
+            return 3
+        print("  all expected_action entries present in catalog ✓")
+        return 0
+
+    class_names = [c.strip() for c in args.classes.split(",") if c.strip()]
+    summaries: list[dict[str, Any]] = []
+    all_results: dict[str, list[HitResult]] = {}
+    for class_name in class_names:
+        try:
+            model, results = await _run_class(class_name, fixtures, catalog, top_k=args.top_k)
+        except Exception as exc:
+            print(f"class={class_name!r} build/query failed: {exc}", file=sys.stderr)
+            return 2
+        summaries.append(_summarize(class_name, model, results))
+        all_results[class_name] = results
+
+    if args.json:
+        out = {
+            "manifest": str(manifest_path),
+            "manifest_sha": sha,
+            "catalog_size": len(catalog),
+            "summaries": summaries,
+            "results": {
+                cn: [
+                    {
+                        "fixture_id": r.fixture_id,
+                        "expected": r.expected,
+                        "rank": r.rank,
+                        "top_k": list(r.top_k),
+                    }
+                    for r in rs
+                ]
+                for cn, rs in all_results.items()
+            },
+        }
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"bench: {manifest_path} ({len(fixtures)} precision-axis fixtures, "
+          f"catalog={len(catalog)} actions)\n")
+    _print_table(summaries)
+    for class_name in class_names:
+        _print_misses(class_name, all_results[class_name])
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--manifest",
+        default="tests/data/embedding_bench/manifest.yaml",
+        help="Path to manifest.yaml (default: tests/data/embedding_bench/manifest.yaml)",
+    )
+    p.add_argument(
+        "--classes",
+        default="light",
+        help="Comma-separated embedding class names to compare (default: light).",
+    )
+    p.add_argument(
+        "--top-k", type=int, default=5,
+        help="Top-K cutoff for hit measurement (default 5).",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of table.")
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help=(
+            "Validate manifest + catalog coverage without calling the "
+            "embedding provider. Useful for CI / no-credential env."
+        ),
+    )
+    args = p.parse_args()
+    return asyncio.run(_main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/embedding_bench/manifest.yaml
+++ b/tests/data/embedding_bench/manifest.yaml
@@ -1,0 +1,222 @@
+# FP-0043 N=20 retrieval benchmark — manifest v1.
+#
+# Bootstrap source: dogfood/scenarios/*.yaml (= reality-grounded query set).
+# Persisted here as the bench's source-of-truth (= tui-coder + lead-coder
+# stance: isolated bench fixture) while declaratively referencing the
+# scenario it was derived from (= sandbox_2 stance: co-evolution check via
+# last_synced_commit_sha drift detection).
+#
+# Each fixture entry is consumed by scripts/embedding_bench.py for two
+# orthogonal axes (see FP-0043 §Measurement axes):
+#
+#   - Axis 1 (precision): does the LLM's resulting invoke_action carry
+#     `expected_action` as its action_name? Measured as recall@1/3/5
+#     against the embedding index ranking AND as hit rate when invoke
+#     is reached via search_actions.
+#
+#   - Axis 2 (call-rate): does the LLM's tool_call sequence prefix-match
+#     any entry of `expected_reach_path`? Measured independent of which
+#     embedding backend is in use; pre-#925 trace showed 0/N on this axis.
+#
+# `axis: [precision, call_rate]` per-entry enum disambiguates which axes
+# a fixture is ground truth for (= some entries are precision-only when
+# the query is unambiguous category enumeration; some are call-rate-only
+# when invoke matters less than the discovery path taken).
+#
+# Drift handling: `last_synced_commit_sha` is the dogfood/scenarios/
+# state at bootstrap. When the underlying scenario yaml drifts, this
+# manifest's expected_* fields may need re-curation; the field surfaces
+# the drift so a periodic check can flag stale entries.
+
+last_synced_commit_sha: 6b58abca23fd29b76e9f6a4d2c3c82a549290bfc
+schema_version: 1
+
+fixtures:
+
+  # ── file ops (4 entries) ──────────────────────────────────────────────────
+
+  - id: file_read_via_chat
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "Show me the contents of `docs/concepts/principles.md`."
+    expected_action: file__read
+    expected_reach_path:
+      - 'file__read({path: "docs/concepts/principles.md"})'
+      - 'invoke_action({action_name: "file__read", args: {path: "docs/concepts/principles.md"}})'
+    axis: [precision, call_rate]
+
+  - id: file_glob_grep_search
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "Find all skill.md files under src/ that mention 'preprocessor'."
+    expected_action: file__grep
+    expected_reach_path:
+      - 'file__glob({pattern: "src/**/skill.md"})'
+      - 'file__grep({pattern: "preprocessor", path: "src/"})'
+      - 'search_actions({query: "find files matching pattern"})'
+    axis: [precision, call_rate]
+
+  - id: file_list_directory
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "src/reyn/tools/ ディレクトリの中身を教えて。"
+    expected_action: file__list
+    expected_reach_path:
+      - 'file__list({path: "src/reyn/tools/"})'
+    axis: [precision]
+
+  - id: file_write_capability
+    source: dogfood/scenarios/permissions_and_safety.yaml
+    prompt: "Write the text 'hello' to /tmp/test.txt."
+    expected_action: file__write
+    expected_reach_path:
+      - 'file__write({path: "/tmp/test.txt", content: "hello"})'
+    axis: [precision]
+
+  # ── web (2 entries) ───────────────────────────────────────────────────────
+
+  - id: web_search_query
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "Search the web for 'OpenAI Python SDK changelog 2026'."
+    expected_action: web__search
+    expected_reach_path:
+      - 'web__search({query: "OpenAI Python SDK changelog 2026"})'
+    axis: [precision]
+
+  - id: web_fetch_url
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "Fetch and summarise https://docs.python.org/3/whatsnew/3.12.html — what are the highlights?"
+    expected_action: web__fetch
+    expected_reach_path:
+      - 'web__fetch({url: "https://docs.python.org/3/whatsnew/3.12.html"})'
+    axis: [precision]
+
+  # ── mcp (3 entries) ───────────────────────────────────────────────────────
+
+  - id: mcp_search_registry_jp
+    source: dogfood/scenarios/multi_agent_and_mcp.yaml
+    prompt: "MCP レジストリで github 関連のサーバーを探して。"
+    expected_action: mcp__search_registry
+    expected_reach_path:
+      - 'search_actions({query: "mcp github"})'
+      - 'mcp__search_registry({text: "github"})'
+    axis: [precision, call_rate]
+
+  - id: mcp_call_tool_jp
+    source: dogfood/scenarios/multi_agent_and_mcp.yaml
+    prompt: "github MCP サーバーを使って最近の PR を一覧して。"
+    expected_action: mcp__call_tool
+    expected_reach_path:
+      - 'mcp__list_tools({server: "github"})'
+      - 'mcp__call_tool({tool: "github__list_pulls"})'
+    axis: [precision, call_rate]
+
+  - id: mcp_search_pdf_capability
+    source: synthesized
+    prompt: "PDF を扱える MCP server があるか調べて。"
+    expected_action: mcp__search_registry
+    expected_reach_path:
+      - 'search_actions({query: "PDF"})'
+      - 'mcp__search_registry({text: "PDF"})'
+    axis: [precision, call_rate]
+
+  # ── multi_agent (1 entry) ─────────────────────────────────────────────────
+
+  - id: agent_delegation_simple
+    source: dogfood/scenarios/multi_agent_and_mcp.yaml
+    prompt: "researcher エージェントに FP-0001 の概要を要約してもらって。"
+    expected_action: multi_agent__delegate
+    expected_reach_path:
+      - 'multi_agent__delegate({to: "researcher", request: "FP-0001 の概要を要約"})'
+    axis: [precision]
+
+  # ── multi_agent (additional 2 entries) ────────────────────────────────────
+
+  - id: multi_agent_list_peers
+    source: synthesized
+    prompt: "他にどんなエージェントが居るか教えて。"
+    expected_action: multi_agent__list_peers
+    expected_reach_path:
+      - 'multi_agent__list_peers({})'
+    axis: [precision]
+
+  - id: multi_agent_describe_peer
+    source: synthesized
+    prompt: "researcher エージェントは何をする人なのか説明して。"
+    expected_action: multi_agent__describe_peer
+    expected_reach_path:
+      - 'multi_agent__describe_peer({name: "researcher"})'
+    axis: [precision]
+
+  # ── mcp install variants (additional 2 entries) ───────────────────────────
+
+  - id: mcp_install_package_pypi
+    source: synthesized
+    prompt: "pypi:mcp-server-time をインストールして。"
+    expected_action: mcp__install_package
+    expected_reach_path:
+      - 'mcp__install_package({kind: "pypi", identifier: "mcp-server-time"})'
+    axis: [precision]
+
+  - id: mcp_install_local_script
+    source: synthesized
+    prompt: "/tmp/weather_mcp.py を MCP server として登録して。"
+    expected_action: mcp__install_local
+    expected_reach_path:
+      - 'mcp__install_local({name: "weather", command: "python", args: ["/tmp/weather_mcp.py"]})'
+    axis: [precision]
+
+  # ── rag (2 entries) ───────────────────────────────────────────────────────
+
+  - id: rag_recall_semantic
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "Use the rag.operation__recall action to find documentation about 'phase rollback'."
+    expected_action: rag.operation__recall
+    expected_reach_path:
+      - 'rag.operation__recall({query: "phase rollback"})'
+    axis: [precision]
+
+  - id: rag_drop_source_destructive
+    source: dogfood/scenarios/permissions_and_safety.yaml
+    prompt: "Drop the events index to free up disk space."
+    expected_action: rag.operation__drop_source
+    expected_reach_path:
+      - 'rag.operation__drop_source({source_name: "events"})'
+    axis: [precision]
+
+  # ── memory (1 entry) ──────────────────────────────────────────────────────
+
+  - id: memory_remember_shared
+    source: synthesized
+    prompt: "「私の好きな色は青」 という事実を覚えておいて。"
+    expected_action: memory.operation__remember_shared
+    expected_reach_path:
+      - 'memory.operation__remember_shared({content: "私の好きな色は青"})'
+    axis: [precision]
+
+  # ── validation (1 entry) ──────────────────────────────────────────────────
+
+  - id: validation_lint_skill
+    source: dogfood/scenarios/control_ir_ops.yaml
+    prompt: "Use the validation__lint action to lint the index_events skill."
+    expected_action: validation__lint
+    expected_reach_path:
+      - 'validation__lint({skill_path: "index_events"})'
+    axis: [precision]
+
+  # ── reyn.source (1 entry) ─────────────────────────────────────────────────
+
+  - id: reyn_source_grep
+    source: synthesized
+    prompt: "reyn のソースで 'class Skill' を検索して。"
+    expected_action: reyn.source__grep
+    expected_reach_path:
+      - 'reyn.source__grep({pattern: "class Skill"})'
+    axis: [precision]
+
+  # ── discovery (call_rate-focused, 1 entry) ────────────────────────────────
+
+  - id: capability_discovery_semantic
+    source: synthesized
+    prompt: "PDF を扱えるツールを教えて。"
+    expected_action: mcp__search_registry
+    expected_reach_path:
+      - 'search_actions({query: "PDF"})'
+    axis: [call_rate]

--- a/tests/test_embedding_bench_manifest.py
+++ b/tests/test_embedding_bench_manifest.py
@@ -1,0 +1,138 @@
+"""Tier 2: FP-0043 Phase 1 — embedding bench manifest + runner contract.
+
+Pins the bench infrastructure shape so future edits to the manifest or
+the runner don't silently break the measurement contract:
+
+  1. Manifest loads as YAML with schema_version 1 + last_synced_commit_sha
+     + a non-empty fixtures list.
+  2. Each fixture carries id / source / prompt / expected_action /
+     expected_reach_path / axis fields with the right types.
+  3. The set of qualified_names referenced by precision-axis fixtures is
+     a subset of the static-only catalog (= what a fresh-context router
+     state without dynamic skills / exec backends surfaces). This pins
+     the "fresh-user" framing of the bench — fixtures that would require
+     post-discovery dynamic enumeration are explicitly out of scope here,
+     and a future bench section can add them with router-state wiring.
+  4. Fixture id is unique across the manifest.
+  5. ``axis`` is restricted to the enum {"precision", "call_rate"}.
+
+No mocks. Real manifest load + real LIST_ACTIONS handler enumeration.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from reyn.tools.types import ToolContext
+from reyn.tools.universal_catalog import CATEGORIES, LIST_ACTIONS
+
+_MANIFEST_PATH = (
+    Path(__file__).parent.parent
+    / "tests" / "data" / "embedding_bench" / "manifest.yaml"
+)
+_ALLOWED_AXES = {"precision", "call_rate"}
+
+
+def _load_manifest() -> dict[str, Any]:
+    return yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+class _Events:
+    def emit(self, *a: Any, **kw: Any) -> None:
+        pass
+
+
+async def _static_catalog() -> set[str]:
+    ctx = ToolContext(
+        events=_Events(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=None,
+    )
+    out: set[str] = set()
+    for cat in CATEGORIES:
+        page = await LIST_ACTIONS.handler({"category": [cat]}, ctx)
+        for item in page.get("items", []):
+            out.add(item["qualified_name"])
+    return out
+
+
+# ── 1. Manifest structural shape ──────────────────────────────────────────────
+
+
+def test_manifest_loads_and_carries_schema_version_and_sha() -> None:
+    """Tier 2: manifest.yaml parses and declares schema + drift-detection sha."""
+    data = _load_manifest()
+    assert data["schema_version"] == 1
+    assert isinstance(data["last_synced_commit_sha"], str)
+    assert len(data["last_synced_commit_sha"]) >= 40  # full git SHA
+    assert isinstance(data["fixtures"], list)
+    assert len(data["fixtures"]) >= 10  # the bench must not shrink silently
+
+
+# ── 2. Per-fixture field contract ─────────────────────────────────────────────
+
+
+def test_each_fixture_carries_required_fields() -> None:
+    """Tier 2: every fixture entry has id / source / prompt / expected_action /
+    expected_reach_path / axis with the right primitive types.
+    """
+    data = _load_manifest()
+    for fx in data["fixtures"]:
+        assert isinstance(fx["id"], str) and fx["id"]
+        assert isinstance(fx["source"], str)
+        assert isinstance(fx["prompt"], str) and fx["prompt"].strip()
+        assert isinstance(fx["expected_action"], str) and "__" in fx["expected_action"]
+        assert isinstance(fx["expected_reach_path"], list)
+        assert all(isinstance(p, str) for p in fx["expected_reach_path"])
+        assert isinstance(fx["axis"], list)
+        assert set(fx["axis"]).issubset(_ALLOWED_AXES), (
+            f"fixture {fx['id']!r}: axis={fx['axis']} contains values outside "
+            f"{sorted(_ALLOWED_AXES)}"
+        )
+
+
+# ── 3. precision-axis fixtures all resolve in the static catalog ──────────────
+
+
+def test_precision_axis_fixtures_resolve_in_static_catalog() -> None:
+    """Tier 2: every precision-axis fixture's expected_action exists in the
+    fresh-context (= router_state=None) catalog enumeration.
+
+    This pins the "fresh-user precision" framing: bench measurement is over
+    the catalog a brand-new ChatSession sees before any dynamic skill /
+    sandbox-backed exec is wired. Fixtures that would require dynamic
+    enumeration go into a future section with explicit router-state setup.
+    """
+    data = _load_manifest()
+    precision_fixtures = [fx for fx in data["fixtures"] if "precision" in fx["axis"]]
+    catalog = asyncio.run(_static_catalog())
+    unknown = [
+        (fx["id"], fx["expected_action"])
+        for fx in precision_fixtures
+        if fx["expected_action"] not in catalog
+    ]
+    assert not unknown, (
+        f"{len(unknown)} precision-axis fixture(s) reference qualified names "
+        f"absent from the static catalog (= dynamic-enumeration only). "
+        f"Move them to a non-precision axis or wire up router-state for "
+        f"dynamic enumeration in the bench runner:\n"
+        + "\n".join(f"  - {fid}: {qn}" for fid, qn in unknown)
+    )
+
+
+# ── 4. Uniqueness ─────────────────────────────────────────────────────────────
+
+
+def test_fixture_ids_are_unique() -> None:
+    """Tier 2: fixture id collisions silently overwrite measurements; reject."""
+    data = _load_manifest()
+    ids = [fx["id"] for fx in data["fixtures"]]
+    assert len(ids) == len(set(ids)), (
+        f"duplicate fixture ids: "
+        f"{[i for i in set(ids) if ids.count(i) > 1]}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 Phase 1 implementation. Refs #922. Co-author: sandbox_2 (bench shape design).

## Summary

Bench infrastructure for FP-0043 Axis 1 (= embedding precision). Lands the **measurement scaffold** ahead of Phase 2 (= sentence-transformers backend) so Axis 1 numbers can be captured the moment Phase 2 lands, without an additional infra spin-up.

User authorised parallel Phase 1+2 execution, unblocking Phase 1 from the B57 dispatch result wait.

## What lands

| File | What |
|---|---|
| `tests/data/embedding_bench/manifest.yaml` | 20 fixtures bootstrapped from dogfood scenarios; 2-axis shape (`expected_action` for precision, `expected_reach_path` for call-rate); schema_version + last_synced_commit_sha for drift detection |
| `scripts/embedding_bench.py` | Runner that enumerates the static-only catalog, builds an `ActionEmbeddingIndex` per class via `LiteLLMEmbeddingProvider`, reports hit@1/3/5; `--json` / `--dry-run` |
| `tests/test_embedding_bench_manifest.py` | Tier-2 contract tests pinning schema, fixture fields, axis enum, fresh-user invariant (= precision fixtures resolve in static catalog), id uniqueness |

## Bench fixture shape (= 4-session consolidated O3 resolution)

```yaml
last_synced_commit_sha: 6b58abca23fd29b76e9f6a4d2c3c82a549290bfc
schema_version: 1
fixtures:
  - id: mcp_search_pdf_capability
    source: synthesized
    prompt: "PDF を扱える MCP server があるか調べて。"
    expected_action: mcp__search_registry              # Axis 1 (precision)
    expected_reach_path:                                # Axis 2 (call-rate)
      - 'search_actions({query: "PDF"})'
      - 'mcp__search_registry({text: "PDF"})'
    axis: [precision, call_rate]
```

- **Axis 1** (this PR measures): top-K recall of `expected_action` against the embedding ranking
- **Axis 2** (measured by dogfood scenario sweep + #925 description fix): LLM call-rate for `expected_reach_path` prefixes

Combining both metrics in one fixture lets the same N=20 set drive both bench dimensions; the per-fixture `axis` enum disambiguates which metric a given entry is ground truth for.

## Catalog coverage (= fresh-user framing)

`scripts/embedding_bench.py` enumerates the catalog via the production `LIST_ACTIONS` handler with `router_state=None`. This deliberately limits coverage to the **static catalog** (= 30 actions across file / web / mcp / multi_agent / memory.operation / reyn.source / rag.operation / validation), excluding dynamic categories (`skill__*` / `exec__sandboxed_exec` / `memory.entry__*` / `rag.corpus__*` / `mcp.tool__*`) that only enumerate with router state.

This matches the **fresh-user precision** framing in FP-0043: the bench measures how an embedding model surfaces actions a brand-new session sees. A future bench section with router-state wiring can extend coverage to post-discovery dynamic actions.

The 19 precision-axis fixtures all resolve in the static catalog — pinned by `test_precision_axis_fixtures_resolve_in_static_catalog`.

## Baseline numbers: TBD (env constraint, follow-up)

This env can't capture baseline `light` (= `openai/text-embedding-3-small`) numbers right now:
- local LiteLLM proxy at `:4000` routes to `gemini-embedding-001`, which rejects the `encoding_format: float` parameter
- direct OpenAI returns 429 (insufficient quota)

Numbers will be captured in:
1. A follow-up commit on this branch (= when an OpenAI key with quota is available), OR
2. The sandbox_2 dogfood env which has the appropriate credentials — sandbox_2 has acked the bench shape and will re-review after running

The `--dry-run` mode + Tier-2 manifest test pin the manifest+catalog invariant in the meantime, so the scaffold is verified end-to-end (= manifest loads, fixtures parse, every precision-axis qualified_name exists in the catalog).

## Test plan

- [x] `pytest tests/test_embedding_bench_manifest.py`: 4 tests pass (schema, fields, fresh-user invariant, uniqueness)
- [x] `python scripts/embedding_bench.py --dry-run`: 19 precision-axis fixtures + 30 catalog entries, all resolvable ✓
- [x] `ruff check` on the 2 new Python files passes
- [ ] Baseline `light` hit@K numbers — follow-up commit (see "Baseline numbers" above)
- [ ] Phase 2 multi-class comparison — lands with Phase 2 PR
- [ ] sandbox_2 re-review on fixture content after B57 dispatch results inform ground-truth alignment

## Tier rule self-check

- Tier-2 test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 tests added (= no Mock/MagicMock/AsyncMock; tests use real manifest load + real LIST_ACTIONS handler with real ToolContext)
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced

## Relationship to other work

- **FP-0043 (#922)** §Phase 1: this PR is the implementation. Body update v2 referenced this scaffold as the substrate for D2 default-model selection.
- **#925 (Axis 2 description fix)**: merged; B57 will measure post-fix call-rate effect size. This PR's `expected_reach_path` fixture entries are the call-rate ground truth that sweep consumes.
- **FP-0043 Phase 2 (sentence-transformers backend)**: separate PR. Once landed, runs against this bench by passing `--classes light,local-mini,local-e5` for the 3-model recall@K comparison that drives D2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)