### PR TITLE
fix(test): Phase A rerun decorator on 2 conv_pane_tool_call flaky tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,11 @@ dev = [
     "ruff",
     "mypy",
     "pytest-asyncio>=0.23",
+    # Issue #927 Phase A: ``@pytest.mark.flaky(reruns=N)`` for tests
+    # with a known CI-env race we haven't root-fixed yet. Each
+    # decorator carries a comment + issue link; removal is the
+    # Phase B PR's exit criterion.
+    "pytest-rerunfailures>=14",
 ]
 fetch = [
     "trafilatura>=1.8",       # higher-quality HTML extraction for web__fetch (issue #355)

--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -83,6 +83,7 @@ async def test_start_tool_call_row_is_idempotent_for_same_op_id():
         assert len(list(conv.query(ToolCallRow))) == 1
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.asyncio
 async def test_complete_tool_call_row_unmounts_live_widget():
     """Tier 2: success terminal removes the live row from the DOM.
@@ -361,6 +362,7 @@ def test_format_tool_result_short_result_unchanged():
 # ── abort_tool_call_rows sweep (C-F1 wave-8) ──────────────────────────────────
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.asyncio
 async def test_abort_tool_call_rows_seals_live_rows_with_aborted_terminal():
     """Tier 2b: ``abort_tool_call_rows`` finishes every live row as ⊘. (C-F1 sweep)


### PR DESCRIPTION
**[tui-coder]** — Issue #927 (N=6 CI flake instances on conv_pane_tool_call tests) の Phase A 短期 mitigation。 lead-coder dispatch + user 優先度判断「A → B」 で着手。

## 状況

`tests/cli/test_conv_pane_tool_call_lifecycle.py` の 2 test:
- `test_abort_tool_call_rows_seals_live_rows_with_aborted_terminal`
- `test_complete_tool_call_row_unmounts_live_widget`

N=6 CI 失敗 (= sandbox_2 #839 / 私 #886 / #898 / #910 / e2e-coder #925 / sandbox_2 #926)、 main N=3 reproduce 3/3 pass → env-specific race。 **本日 local pytest run でも 1 rerun 実発生** で Phase A 適用後 21 passed → mitigation 効果 evidence あり。

## Phase A 実装

- `@pytest.mark.flaky(reruns=2, reruns_delay=1)` 2 test に追加 (= 個別宣言、 file-wide 適用避ける = 他 test の regression 通常通り出る)
- `pytest-rerunfailures>=14` を `[dev]` extras 追加、 comment で「Phase B exit criterion」 明記

## Phase B (= 別 PR、 follow-on)

- file-wide async race の trace (= F-H min-display-time pause + shared event-loop fixture 起源 hypothesis)
- root fix 後 `@flaky` decorator + `pytest-rerunfailures` dep 削除

## Test plan

- [x] **Local rerun verification** — `pytest tests/cli/test_conv_pane_tool_call_lifecycle.py` → 21 passed + 1 rerun (= 実際 flake 検出 + retry pass)
- [x] **Target tests isolated** — 2 test 個別 run も pass
- [x] **ruff clean** — 全 touched
- [ ] (skipped — needs CI run) **Manual CI** = PR push 後 GitHub Actions で flake 発生時 retry pass 確認

## Tier self-check

- ✅ Test infrastructure / dev deps only (= ship code 変更無し)
- ✅ private state assert なし
- ✅ MagicMock / AsyncMock なし
- ✅ snapshot test なし
- ✅ docstring 維持 (= 既存 Tier 2 / 2b 宣言保持)
- ⚠ rerun decorator は **Phase B PR で削除する exit criterion 付き** で merge、 permanent な flake 容認ではない

🤖 Generated with [Claude Code](https://claude.com/claude-code)