### PR TITLE
feat(action-index): FP-0043 Component E — class-swap detection + cross-process build lock

### DIFF
--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -51,15 +51,122 @@ Not yet implemented (= Phase 2 step 3+):
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import math
+import os
 import struct
+import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Iterator, Mapping
 
 if TYPE_CHECKING:
     from reyn.embedding.provider import EmbeddingProvider
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort check whether a PID corresponds to a live process.
+
+    On POSIX, ``os.kill(pid, 0)`` raises ProcessLookupError when the PID
+    is gone and PermissionError when it exists but is not ours; both
+    mean "still alive enough to defer to". Windows is best-effort.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+@contextlib.contextmanager
+def _try_acquire_build_lock(persist_dir: Path) -> Iterator[bool]:
+    """Advisory cross-process build lock — non-blocking, take-or-skip.
+
+    Writes a marker file at ``<persist_dir>/.build.lock`` carrying
+    ``{pid, ts}``. The contract:
+
+      - If the file is absent OR the previous holder's PID is dead,
+        we take the lock and yield ``True``. The caller proceeds with
+        the build and the marker is removed on exit.
+      - If a live holder is detected, we yield ``False`` immediately
+        (= no waiting, no embed-call duplication). The caller is
+        expected to either fall back to whatever's already on disk or
+        skip the build entirely and let the next attempt observe the
+        finished state.
+
+    Atomicity: uses ``O_CREAT | O_EXCL`` for the take so two processes
+    racing the take produce exactly one winner. A subsequent stale-PID
+    reap is also atomic (unlink + re-take).
+
+    Filesystem-write errors fall through with ``False`` (= caller skips
+    the build rather than crashing on a permission / quota issue).
+    """
+    lock_path = persist_dir / ".build.lock"
+    try:
+        persist_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        yield False
+        return
+
+    def _take_atomic() -> bool:
+        try:
+            fd = os.open(
+                str(lock_path),
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o644,
+            )
+        except FileExistsError:
+            return False
+        except OSError:
+            return False
+        try:
+            os.write(
+                fd,
+                json.dumps({"pid": os.getpid(), "ts": time.time()}).encode(),
+            )
+        finally:
+            os.close(fd)
+        return True
+
+    took = _take_atomic()
+    if not took:
+        # Existing lock — see if the holder is alive.
+        try:
+            data = json.loads(lock_path.read_text(encoding="utf-8"))
+            holder_pid = int(data.get("pid", 0))
+        except (OSError, ValueError, json.JSONDecodeError):
+            holder_pid = 0
+        if holder_pid and _pid_alive(holder_pid):
+            yield False
+            return
+        # Stale lock — reap and retry exactly once.
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            yield False
+            return
+        if not _take_atomic():
+            yield False
+            return
+
+    try:
+        yield True
+    finally:
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
@@ -125,6 +232,7 @@ class ActionEmbeddingIndex:
         self._vectors: dict[str, list[float]] = {}
         self._items: dict[str, dict[str, Any]] = {}
         self._catalog_hash: str | None = None
+        self._model_class: str | None = None  # FP-0043 Component E: class-swap detection
         self._build_lock = asyncio.Lock()
         self._building = False
         self._persist_dir = persist_dir
@@ -137,14 +245,23 @@ class ActionEmbeddingIndex:
             return None
         return self._persist_dir / "index.db"
 
-    def _try_load_from_disk(self, expected_hash: str) -> bool:
-        """Load vectors from SQLite if the on-disk catalog hash matches.
+    def _try_load_from_disk(
+        self, expected_hash: str, expected_model_class: str,
+    ) -> bool:
+        """Load vectors from SQLite if BOTH catalog hash AND model class match.
 
         Returns True and populates ``_vectors`` / ``_items`` /
-        ``_catalog_hash`` when the disk state is fresh.  Returns False
-        (without mutating state) when the DB is absent, unreadable, or
-        has a different hash.  Any exception is swallowed — disk load
-        failure is non-fatal; the caller falls through to re-embedding.
+        ``_catalog_hash`` / ``_model_class`` when the disk state is
+        fresh against the supplied expectations. Returns False (without
+        mutating state) when the DB is absent, unreadable, or has a
+        different catalog hash or a different model class.
+
+        FP-0043 Component E: model class is checked alongside catalog
+        hash so a class swap (= operator edits
+        ``action_retrieval.embedding_class`` between sessions, or two
+        sessions configured against different classes share the cache
+        dir) invalidates the cache. Otherwise vectors from a different
+        embedding model would be returned by query() → garbage results.
 
         Caller MUST hold ``_build_lock``.
         """
@@ -156,19 +273,22 @@ class ActionEmbeddingIndex:
             con = sqlite3.connect(str(db_path))
             con.execute("PRAGMA journal_mode=WAL")
             try:
-                row = con.execute(
-                    "SELECT value FROM meta WHERE key='catalog_hash'"
-                ).fetchone()
-                if row is None or row[0] != expected_hash:
-                    return False
                 rows = con.execute(
+                    "SELECT key, value FROM meta"
+                ).fetchall()
+                meta = {k: v for k, v in rows}
+                if meta.get("catalog_hash") != expected_hash:
+                    return False
+                if meta.get("model_class") != expected_model_class:
+                    return False
+                vec_rows = con.execute(
                     "SELECT qualified_name, item_json, vector_blob FROM vectors"
                 ).fetchall()
             finally:
                 con.close()
             vectors: dict[str, list[float]] = {}
             items: dict[str, dict[str, Any]] = {}
-            for qn, item_json, vec_blob in rows:
+            for qn, item_json, vec_blob in vec_rows:
                 n = len(vec_blob) // 8
                 vec = list(struct.unpack(f"{n}d", vec_blob))
                 vectors[qn] = vec
@@ -176,6 +296,7 @@ class ActionEmbeddingIndex:
             self._vectors = vectors
             self._items = items
             self._catalog_hash = expected_hash
+            self._model_class = expected_model_class
             return True
         except Exception:
             return False
@@ -186,6 +307,13 @@ class ActionEmbeddingIndex:
         No-op when ``persist_dir`` is None or no catalog hash is recorded.
         Persistence failures are swallowed — in-memory state is always
         authoritative; a failed write is retried on the next build.
+
+        FP-0043 Component E: ``model_class`` is persisted alongside
+        ``catalog_hash`` so a future load can detect class-swap
+        invalidation. The two keys are co-written in the same
+        transaction; the new vectors are also written in the same
+        transaction so an interrupted save can't leave the meta keys
+        pointing at the previous build's vectors.
 
         Caller MUST hold ``_build_lock``.
         """
@@ -211,6 +339,10 @@ class ActionEmbeddingIndex:
                 con.execute(
                     "INSERT OR REPLACE INTO meta VALUES ('catalog_hash', ?)",
                     (self._catalog_hash,),
+                )
+                con.execute(
+                    "INSERT OR REPLACE INTO meta VALUES ('model_class', ?)",
+                    (self._model_class or "",),
                 )
                 rows_to_insert = []
                 for qn, vec in self._vectors.items():
@@ -241,6 +373,18 @@ class ActionEmbeddingIndex:
         """Return the recorded catalog snapshot hash, or None pre-build."""
         return self._catalog_hash
 
+    @property
+    def model_class(self) -> str | None:
+        """Return the model class associated with the current vectors, or None.
+
+        FP-0043 Component E: paired with ``catalog_hash`` as a two-axis
+        cache key. A change in either axis triggers rebuild on the next
+        ``build()`` call. Exposed as a public read-only property so
+        callers + tests can observe the binding without reaching into
+        the underscored attribute.
+        """
+        return self._model_class
+
     def size(self) -> int:
         """Return the number of indexed items (= vectors stored)."""
         return len(self._vectors)
@@ -259,67 +403,121 @@ class ActionEmbeddingIndex:
         category-prefixed name and the human-readable summary
         contribute to the embedding.
 
-        Idempotent: when the catalog hash matches the current state,
-        returns immediately without re-embedding.  Different hash
-        triggers a full rebuild (Phase 2 step 2 will diff).
+        Unified build trigger (FP-0043 Component E): the call is
+        idempotent in three orthogonal ways —
+
+          1. catalog hash matches AND model class matches  → no-op
+          2. catalog hash matches BUT model class differs  → rebuild
+             (class-swap invalidates vectors from the previous model)
+          3. catalog hash differs                          → rebuild
+             (= the existing "different hash triggers rebuild" semantics
+             from Phase 2 step 2 are preserved as a strict subset)
+
+        Cross-process build coordination: when ``persist_dir`` is set,
+        a non-blocking advisory file lock (= ``.build.lock`` marker
+        carrying ``{pid, ts}``) coordinates concurrent builds across
+        OS processes. If another live process is mid-build, this call
+        falls back to the disk state without invoking the embedding
+        provider — preventing duplicate API-cost / duplicate
+        sentence-transformers model loads. Single-process callers
+        bypass the file lock when ``persist_dir`` is None.
         """
         async with self._build_lock:
             new_hash = compute_catalog_hash(list(items))
-            if new_hash == self._catalog_hash:
-                return  # idempotent (in-memory match)
+            if (
+                new_hash == self._catalog_hash
+                and self._model_class == model_class
+            ):
+                return  # idempotent (in-memory match on BOTH axes)
 
-            # Phase 2 step 2: try loading from disk before embedding.
-            if self._try_load_from_disk(new_hash):
+            # Phase 2 step 2 + Component E: try loading from disk first.
+            # The disk check honours the same (catalog_hash, model_class)
+            # pair, so a class-swap with a fresh catalog hash will load
+            # cleanly when that combination was persisted previously
+            # (= e.g. user toggles between local-mini and standard).
+            if self._try_load_from_disk(new_hash, model_class):
                 return  # cache hit — skip embed call
 
-            # Filter out items missing qualified_name once; embed each
-            # remaining one.  Keep the items list ordered by sorted
-            # qualified_name for determinism in tests.
-            valid_items = sorted(
-                (dict(it) for it in items if it.get("qualified_name")),
-                key=lambda it: str(it["qualified_name"]),
-            )
-            if not valid_items:
-                # Empty catalog — record the empty hash and persist.
-                self._vectors = {}
-                self._items = {}
-                self._catalog_hash = new_hash
-                self._save_to_disk()
-                return
+            # Cross-process advisory lock (= take-or-skip). When another
+            # live process holds the lock, fall back to whatever's on
+            # disk and avoid duplicate embed calls. We accept that the
+            # fallback may be a stale state — the in-flight build will
+            # publish its result, and the next build() call on this
+            # instance observes it via _try_load_from_disk.
+            persist_dir = self._persist_dir
+            if persist_dir is not None:
+                file_lock_cm = _try_acquire_build_lock(persist_dir)
+            else:
+                # No persist_dir → no cross-process coordination needed
+                # (= test / fully-in-memory path). Use a trivial
+                # always-acquired context to keep the control flow flat.
+                file_lock_cm = contextlib.nullcontext(True)
 
-            texts = [
-                f"{it['qualified_name']}: {it.get('short_description', '')}"
-                for it in valid_items
-            ]
+            with file_lock_cm as got_lock:
+                if not got_lock:
+                    # Another process is building. We can't safely block
+                    # the event loop on a sync lock; surface our current
+                    # state (likely empty or stale) and let the next
+                    # call observe the in-progress process's result.
+                    return
 
-            self._building = True
-            _built_ok = False
-            try:
-                result = await provider.embed(texts, model_class)
-                vectors = list(result["vectors"])
-                if len(vectors) != len(valid_items):
-                    # Provider returned a mismatched count — refuse the
-                    # partial result so we don't end up with a corrupt
-                    # half-populated index.  The catalog hash is NOT
-                    # updated so the next build attempt retries.
-                    raise RuntimeError(
-                        f"EmbeddingProvider returned {len(vectors)} vectors "
-                        f"for {len(valid_items)} items; refusing partial build"
-                    )
-                self._vectors = {
-                    str(it["qualified_name"]): list(v)
-                    for it, v in zip(valid_items, vectors)
-                }
-                self._items = {
-                    str(it["qualified_name"]): it
+                # Re-check disk under the lock — another process may
+                # have completed between our pre-lock check and now.
+                if self._try_load_from_disk(new_hash, model_class):
+                    return
+
+                # Filter out items missing qualified_name once; embed
+                # each remaining one. Keep the items list ordered by
+                # sorted qualified_name for determinism in tests.
+                valid_items = sorted(
+                    (dict(it) for it in items if it.get("qualified_name")),
+                    key=lambda it: str(it["qualified_name"]),
+                )
+                if not valid_items:
+                    # Empty catalog — record the empty hash and persist.
+                    self._vectors = {}
+                    self._items = {}
+                    self._catalog_hash = new_hash
+                    self._model_class = model_class
+                    self._save_to_disk()
+                    return
+
+                texts = [
+                    f"{it['qualified_name']}: {it.get('short_description', '')}"
                     for it in valid_items
-                }
-                self._catalog_hash = new_hash
-                _built_ok = True
-            finally:
-                self._building = False
-            if _built_ok:
-                self._save_to_disk()
+                ]
+
+                self._building = True
+                _built_ok = False
+                try:
+                    result = await provider.embed(texts, model_class)
+                    vectors = list(result["vectors"])
+                    if len(vectors) != len(valid_items):
+                        # Provider returned a mismatched count — refuse
+                        # the partial result so we don't end up with a
+                        # corrupt half-populated index. The catalog
+                        # hash is NOT updated so the next build attempt
+                        # retries.
+                        raise RuntimeError(
+                            f"EmbeddingProvider returned {len(vectors)} "
+                            f"vectors for {len(valid_items)} items; "
+                            f"refusing partial build"
+                        )
+                    self._vectors = {
+                        str(it["qualified_name"]): list(v)
+                        for it, v in zip(valid_items, vectors)
+                    }
+                    self._items = {
+                        str(it["qualified_name"]): it
+                        for it in valid_items
+                    }
+                    self._catalog_hash = new_hash
+                    self._model_class = model_class
+                    _built_ok = True
+                finally:
+                    self._building = False
+                if _built_ok:
+                    self._save_to_disk()
 
     async def query(
         self,

--- a/tests/test_action_embedding_index_concurrency.py
+++ b/tests/test_action_embedding_index_concurrency.py
@@ -1,0 +1,286 @@
+"""Tier 2: FP-0043 Component E — concurrency + class-swap detection contract.
+
+Pins ActionEmbeddingIndex behaviour added by the Component E PR:
+
+  1. **Class-swap detection**: rebuilding with a different ``model_class``
+     against an identical catalog re-invokes the provider (= vectors
+     from the previous model are NOT silently reused).
+  2. **Cross-process advisory lock**: when ``persist_dir/.build.lock``
+     carries a live PID, a concurrent ``build()`` skips the embed call
+     (= no duplicate API cost / duplicate sentence-transformers model
+     load). The lock file marks holder PID + timestamp atomically.
+  3. **Stale-lock reaping**: a ``.build.lock`` whose recorded PID is
+     dead is taken over (= no permanent deadlock after a crash).
+  4. **Disk persistence carries model_class**: ``_save_to_disk`` writes
+     ``model_class`` into the meta table; ``_try_load_from_disk`` checks
+     it. Same catalog hash + same model class → load. Same catalog
+     hash + different model class → reject (= rebuild).
+
+No mocks. Real ActionEmbeddingIndex + real ``_FakeProvider`` counting
+embed calls + real filesystem operations.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import struct
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.embedding.provider import EmbedBatchResult
+from reyn.tools.action_index import (
+    ActionEmbeddingIndex,
+    _pid_alive,
+    _try_acquire_build_lock,
+    compute_catalog_hash,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeProvider:
+    """Real-fake EmbeddingProvider; counts embed() invocations + records model."""
+
+    def __init__(self, dim: int = 8):
+        self.dim = dim
+        self.embed_calls: list[str] = []  # model arg per call
+
+    async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
+        self.embed_calls.append(model)
+        return EmbedBatchResult(
+            vectors=[[float((i + 1) * 0.1) for i in range(self.dim)] for _ in texts],
+            model=model,
+            total_tokens=sum(len(t) // 4 for t in texts),
+        )
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return sum(len(t) // 4 for t in texts)
+
+    def get_dimension(self, model: str) -> int:
+        return self.dim
+
+
+def _items() -> list[dict[str, Any]]:
+    return [
+        {"qualified_name": "file__read", "short_description": "Read a file"},
+        {"qualified_name": "web__search", "short_description": "Search the web"},
+    ]
+
+
+# ── 1. Class-swap detection ──────────────────────────────────────────────────
+
+
+def test_same_catalog_different_class_triggers_rebuild(tmp_path: Path) -> None:
+    """Tier 2: identical items + new model_class → provider.embed called again."""
+    provider = _FakeProvider()
+    idx = ActionEmbeddingIndex(persist_dir=tmp_path)
+
+    _run(idx.build(_items(), provider, "openai/text-embedding-3-small"))
+    assert provider.embed_calls == ["openai/text-embedding-3-small"]
+
+    # Same catalog, different class — must re-embed even though hash matches.
+    _run(idx.build(_items(), provider, "sentence-transformers/all-MiniLM-L6-v2"))
+    assert provider.embed_calls == [
+        "openai/text-embedding-3-small",
+        "sentence-transformers/all-MiniLM-L6-v2",
+    ]
+    # Internal class tracker reflects the latest build.
+    assert idx.model_class == "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def test_same_catalog_same_class_remains_idempotent(tmp_path: Path) -> None:
+    """Tier 2: regression guard — class match preserves Phase 2 step 2 idempotency.
+
+    The class-swap check must not break the existing "same hash → no-op"
+    contract; a second build() with the same catalog AND the same model
+    class must skip the embed call.
+    """
+    provider = _FakeProvider()
+    idx = ActionEmbeddingIndex(persist_dir=tmp_path)
+
+    _run(idx.build(_items(), provider, "standard"))
+    _run(idx.build(_items(), provider, "standard"))
+    assert provider.embed_calls == ["standard"]  # second call short-circuited
+
+
+# ── 2. Disk persistence carries model_class ──────────────────────────────────
+
+
+def test_disk_load_rejects_model_class_mismatch(tmp_path: Path) -> None:
+    """Tier 2: cross-process cache reuse blocked when model class differs.
+
+    Mirrors the scenario where two reyn processes share .reyn/action_index/
+    but configured against different embedding classes. The first process
+    persists vectors tagged with its class; the second loads, sees the
+    mismatch, and rebuilds with its own provider rather than serving
+    foreign-model vectors.
+    """
+    provider_a = _FakeProvider()
+    idx_a = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx_a.build(_items(), provider_a, "openai/text-embedding-3-small"))
+    assert provider_a.embed_calls == ["openai/text-embedding-3-small"]
+
+    # Fresh instance pointing at the same persist_dir but with a different
+    # model class — must re-embed because the on-disk meta records the
+    # other class.
+    provider_b = _FakeProvider()
+    idx_b = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx_b.build(_items(), provider_b, "sentence-transformers/all-MiniLM-L6-v2"))
+    assert provider_b.embed_calls == ["sentence-transformers/all-MiniLM-L6-v2"]
+
+
+def test_disk_load_accepts_matching_class_and_catalog(tmp_path: Path) -> None:
+    """Tier 2: process restart with same class + catalog → disk-only path.
+
+    The second instance does NOT invoke its provider; the vectors are
+    loaded from SQLite.
+    """
+    provider_a = _FakeProvider()
+    idx_a = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx_a.build(_items(), provider_a, "standard"))
+
+    provider_b = _FakeProvider()
+    idx_b = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx_b.build(_items(), provider_b, "standard"))
+    assert provider_b.embed_calls == []  # loaded from disk; embed not called
+    assert idx_b.is_ready()
+    assert idx_b.model_class == "standard"
+
+
+# ── 3. Cross-process advisory lock ──────────────────────────────────────────
+
+
+def test_concurrent_build_skips_when_lock_held_by_live_pid(tmp_path: Path) -> None:
+    """Tier 2: another live process holding .build.lock → embed call skipped.
+
+    Simulates the chainlit + reyn-web parallel-session race tui-coder
+    reported: both decide to rebuild simultaneously. Without the file
+    lock both would call provider.embed() and one would lose the disk
+    write race. With the lock, only the holder rebuilds; the other
+    falls back to whatever's currently on disk (= here, nothing → empty
+    state, which is fine; the holder's eventual save will be picked up
+    on the next build() call).
+    """
+    # Stage: write a lock file claiming the current (live) PID is mid-build.
+    lock_path = tmp_path / ".build.lock"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(
+        json.dumps({"pid": os.getpid(), "ts": time.time()}),
+        encoding="utf-8",
+    )
+
+    provider = _FakeProvider()
+    idx = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx.build(_items(), provider, "standard"))
+
+    # The lock was held → embed must NOT have been called.
+    assert provider.embed_calls == []
+    # The index also did not mutate its in-memory state (= consistent
+    # with the "another process owns this build" semantics).
+    assert not idx.is_ready()
+    # Clean up the staged lock so other tests don't inherit it.
+    lock_path.unlink(missing_ok=True)
+
+
+def test_stale_lock_is_reaped(tmp_path: Path) -> None:
+    """Tier 2: a .build.lock whose PID is dead is taken over (no deadlock)."""
+    lock_path = tmp_path / ".build.lock"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    # Pick a PID that's almost certainly dead (= a very large number
+    # well outside the typical PID range). os.kill(pid, 0) will surface
+    # ProcessLookupError for it.
+    dead_pid = 2**31 - 1  # max int32; not allocated by any kernel
+    assert not _pid_alive(dead_pid), (
+        f"precondition: PID {dead_pid} must not be alive for this test"
+    )
+    lock_path.write_text(
+        json.dumps({"pid": dead_pid, "ts": time.time()}),
+        encoding="utf-8",
+    )
+
+    provider = _FakeProvider()
+    idx = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx.build(_items(), provider, "standard"))
+
+    # Stale lock reaped → embed called normally; build completed.
+    assert provider.embed_calls == ["standard"]
+    assert idx.is_ready()
+    # Lock file removed on context exit.
+    assert not lock_path.exists()
+
+
+def test_corrupt_lock_file_is_treated_as_stale(tmp_path: Path) -> None:
+    """Tier 2: malformed .build.lock (= partial write, garbage) is recoverable.
+
+    A crashed previous process may leave a half-written lock; the next
+    builder should treat it as stale rather than wedging forever.
+    """
+    lock_path = tmp_path / ".build.lock"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("not json at all }}}", encoding="utf-8")
+
+    provider = _FakeProvider()
+    idx = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx.build(_items(), provider, "standard"))
+
+    assert provider.embed_calls == ["standard"]
+
+
+# ── 4. Lock helper unit invariants ──────────────────────────────────────────
+
+
+def test_try_acquire_lock_yields_true_then_releases(tmp_path: Path) -> None:
+    """Tier 2: helper acquires the lock and removes the marker on exit."""
+    with _try_acquire_build_lock(tmp_path) as got:
+        assert got is True
+        assert (tmp_path / ".build.lock").exists()
+    assert not (tmp_path / ".build.lock").exists()
+
+
+def test_try_acquire_lock_yields_false_when_holder_alive(tmp_path: Path) -> None:
+    """Tier 2: helper yields False when a live PID holds the lock."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".build.lock").write_text(
+        json.dumps({"pid": os.getpid(), "ts": time.time()}),
+        encoding="utf-8",
+    )
+    with _try_acquire_build_lock(tmp_path) as got:
+        assert got is False
+    # Holder lock is preserved (= we did not unlink someone else's marker).
+    assert (tmp_path / ".build.lock").exists()
+    (tmp_path / ".build.lock").unlink()
+
+
+def test_pid_alive_dead_pid_returns_false() -> None:
+    """Tier 2: _pid_alive sanity — a huge PID returns False (= no false-positive)."""
+    assert _pid_alive(2**31 - 1) is False
+
+
+def test_pid_alive_self_returns_true() -> None:
+    """Tier 2: _pid_alive of os.getpid() returns True."""
+    assert _pid_alive(os.getpid()) is True
+
+
+# ── 5. Empty catalog records model_class too ────────────────────────────────
+
+
+def test_empty_catalog_records_class_for_subsequent_match(tmp_path: Path) -> None:
+    """Tier 2: building over an empty catalog still imprints model_class.
+
+    Otherwise the next call with the same empty catalog + same class
+    would re-enter the build path (= regression against the Phase 2
+    step 2 empty-catalog short-circuit).
+    """
+    provider = _FakeProvider()
+    idx = ActionEmbeddingIndex(persist_dir=tmp_path)
+    _run(idx.build([], provider, "standard"))
+    assert idx.model_class == "standard"
+    # Same args → no-op (no second embed call).
+    _run(idx.build([], provider, "standard"))
+    assert provider.embed_calls == []  # empty catalog never calls embed


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 Component E implementation. Refs #922. Lands the concurrency + rebuild policy contract.

## Summary

Two structural gaps closed in `ActionEmbeddingIndex`:

1. **Class-swap silently served stale vectors** — `model_class` was not part of the cache key, so swapping `action_retrieval.embedding_class` between an OpenAI class and a sentence-transformers class would silently load the previous-model vectors from SQLite and return them through `query()`. Different embedding models live in different vector spaces; the cosine ranking on cross-model vectors is garbage.

2. **Cross-process build coordination missing** — `_build_lock` was an `asyncio.Lock` (in-process only). When `chainlit` + `reyn web` + `reyn chat` boot against the same `.reyn/action_index/` (tui-coder's observed shape), both processes decide to rebuild simultaneously, both call `provider.embed()` (= duplicate API cost / duplicate ST model load), and the disk write race produces a half-deterministic winner.

## What changes

### 1. Class-swap detection (cache key extension)

- `__init__` tracks `_model_class: str | None = None`
- `_save_to_disk` writes `model_class` into the SQLite `meta` table in the same transaction as `catalog_hash` and the vectors (= atomic)
- `_try_load_from_disk` checks BOTH keys; mismatch on either rejects the load
- `build()` early-return condition is now `(catalog_hash matches) AND (model_class matches)`

`compute_catalog_hash` signature **unchanged** (= catalog-only semantics preserved per FP-0043 §Verification "model class is a separate cache key axis"). Existing callers don't need to update.

### 2. Cross-process advisory lock

- New `_try_acquire_build_lock(persist_dir)` context manager
  - Atomic `O_CREAT | O_EXCL` open on `<persist_dir>/.build.lock`
  - Marker file carries `{pid, ts}`
  - **Take-or-skip semantics** (= no waiting, no embed-call duplication): if a live PID holds the lock, yields `False` and the caller falls back without invoking the provider
  - Stale-PID locks are reaped atomically (= dead-PID detection via `os.kill(pid, 0)`)
  - Corrupt JSON locks treated as stale
- `build()` wraps the embed-and-persist section in this lock. `persist_dir=None` (= in-memory tests) bypasses via `contextlib.nullcontext(True)`.

### 3. Behaviour preservation

- All 18 existing `tests/test_action_embedding_index.py` tests pass without modification
- ``persist_dir=None`` path is byte-identical to pre-PR (= test fixtures + in-memory callers unaffected)
- Empty-catalog short-circuit + provider mismatch error path preserved verbatim

## Files changed (2 / +540 / -68)

| File | Notes |
|---|---|
| `src/reyn/tools/action_index.py` | Adds `_pid_alive`, `_try_acquire_build_lock`, `_model_class` tracking, meta-table extension; rewrites `build()` early-return + adds the cross-process lock wrap |
| `tests/test_action_embedding_index_concurrency.py` | NEW — 12 Tier-2 tests (no Mock, no private state assertion except documented `_model_class` set-then-check which is internal-to-test-file and via the public build → load cycle) |

## Test plan

- [x] `pytest tests/test_action_embedding_index.py`: 18 existing tests pass
- [x] `pytest tests/test_action_embedding_index_concurrency.py`: 12 new tests pass
- [x] `pytest -q --ignore=.claude` from rootdir: **5876 passed**, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` — HTML extraction, unrelated)
- [x] `ruff check` on changed files passes
- [ ] Manual cross-process check (= follow-up): boot 2 chat sessions concurrently against the same `.reyn/action_index/`, confirm only one process emits the `action_index_build` event payload. This is a runtime smoke that needs both #929 (= sentence-transformers backend, merged) and a working embedding endpoint; will be covered by sandbox_2's dogfood env when bench numbers are captured.

## Tier rule self-check

- All test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 tests (= no `Mock` / `MagicMock` / `AsyncMock`; real `ActionEmbeddingIndex` + real `_FakeProvider` counting embed calls + real filesystem operations on `tmp_path`)
- `_model_class` references in tests use the in-memory attribute access pattern that the existing `test_action_embedding_index.py` already uses for `_catalog_hash` (= same precedent, same Tier framing); the **invariant** under test is the externally-observable rebuild behaviour, not the attribute value per se
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced

## Relationship to other work

- **FP-0043 (#922)** Component E — this PR is the implementation. Body referenced "file lock + atomic rename + catalog-hash diff detection" as the substrate; class-swap detection emerged here as an adjacent invariant the same cache-key infrastructure naturally absorbs.
- **#929 (sentence-transformers backend, merged)** — the class-swap detection here is what makes the "user toggles between `light` (openai) and `local-mini` (sentence-transformers) in reyn.yaml" workflow safe.
- **Component C (UX + CLI + TUI integration)** — separate PR; `reyn embeddings rebuild` CLI subcommand will surface this lock via the unified trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)