### PR TITLE
fix(catalog): list_actions/search_actions surface explicit error on stale category

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -622,6 +622,93 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
     return []
 
 
+# ── Category validation (#934 stale-enum explicit error) ────────────────────
+#
+# LLM providers vary in how strictly they enforce a JSON-Schema ``enum`` on a
+# tool argument. In practice an LLM whose training-data catalog snapshot
+# pre-dates one of Reyn's category collapses (#882 mcp / #909 multi_agent /
+# etc.) passes a stale name like ``"mcp.server"`` through to the handler.
+# Pre-#934 the handlers silently dropped unknown entries from ``category=[…]``
+# and returned an empty result; the LLM had no recovery cue.
+#
+# Post-#934 the handlers surface an explicit error envelope that lists the
+# current valid categories AND maps the legacy names to their replacement,
+# so the LLM can self-correct in a single retry without further inference.
+
+_LEGACY_CATEGORY_REDIRECTS: Final[dict[str, str]] = {
+    # PR #882 — mcp.server / mcp.tool / mcp.operation collapsed into a single
+    # ``mcp`` verb category.
+    "mcp.server": "mcp",
+    "mcp.tool": "mcp",
+    "mcp.operation": "mcp",
+    # PR #909 — agent.peer resource category collapsed into ``multi_agent``
+    # operation category (= multi_agent__list_peers / __describe_peer /
+    # __delegate).
+    "agent.peer": "multi_agent",
+}
+
+
+def _unknown_categories_error(unknowns: list[str]) -> dict[str, Any]:
+    """Build the error envelope returned when ``category=[…]`` carries an
+    unknown name.
+
+    The message inlines (a) the full current ``CATEGORIES`` list and (b) any
+    legacy→current mapping that matches an unknown entry. The mapping is the
+    load-bearing part: a bare valid-list forces the LLM to do a "which is
+    the new name" inference round-trip; the inline mapping enables
+    single-turn self-correction. See #934 design rationale (= sandbox_2
+    B57 W6-S3-style observation).
+    """
+    valid_list = ", ".join(repr(c) for c in CATEGORIES)
+    redirects = [
+        f"{legacy!r} → {current!r}"
+        for legacy in unknowns
+        if (current := _LEGACY_CATEGORY_REDIRECTS.get(legacy)) is not None
+    ]
+    redirect_block = ""
+    if redirects:
+        redirect_block = (
+            "\n\nLegacy categories from prior collapse refactors:\n  "
+            + "\n  ".join(redirects)
+        )
+    return {
+        "error": (
+            f"unknown category {unknowns[0]!r}"
+            if len(unknowns) == 1
+            else f"unknown categories {unknowns!r}"
+        ),
+        "reason": (
+            f"category names must be one of: {valid_list}.{redirect_block}"
+        ),
+        "hint": (
+            "Re-call with `category=[<valid name>]`. Use list_actions() with "
+            "no category argument to enumerate everything visible."
+        ),
+        "unknown": list(unknowns),
+        "valid": list(CATEGORIES),
+    }
+
+
+def _validate_category_filter(
+    raw: "list[str] | str | None",
+) -> "tuple[list[str], dict[str, Any] | None]":
+    """Normalise + validate the ``category=[…]`` argument.
+
+    Returns ``(normalised_list, error_envelope_or_None)``. When the
+    returned envelope is non-None, the handler must surface it verbatim
+    instead of proceeding with enumeration / search — every entry the
+    LLM supplied must be a current category for the call to succeed.
+    """
+    if not raw:
+        return [], None
+    if isinstance(raw, str):
+        raw = [raw]
+    unknowns = [c for c in raw if c not in CATEGORIES]
+    if unknowns:
+        return [], _unknown_categories_error(unknowns)
+    return list(raw), None
+
+
 # ── Real handlers (PR-3a) ─────────────────────────────────────────────────
 
 
@@ -636,15 +723,17 @@ async def _handle_list_actions(
 
     Sort is alphabetical by qualified_name (= pagination stability).
     Pagination uses offset+limit REST conventions.
+
+    #934: when ``category=[…]`` carries a name not in the current
+    ``CATEGORIES`` tuple (= LLM-training-time stale enum), the handler
+    returns an explicit error envelope instead of silently filtering.
     """
-    # Resolve category filter — empty / unset = all visible categories
-    category_filter = args.get("category") or []
-    if isinstance(category_filter, str):
-        category_filter = [category_filter]
-    if category_filter:
-        categories = [c for c in category_filter if c in CATEGORIES]
-    else:
-        categories = list(CATEGORIES)
+    # Validate category filter — surface stale-enum errors explicitly.
+    raw_filter = args.get("category") or []
+    valid_filter, err = _validate_category_filter(raw_filter)
+    if err is not None:
+        return err
+    categories = valid_filter if valid_filter else list(CATEGORIES)
 
     offset = max(0, int(args.get("offset", 0) or 0))
     limit = max(1, int(args.get("limit", 20) or 20))
@@ -713,14 +802,13 @@ async def _handle_search_actions(
         return {"items": [], "total": 0}
 
     # Optional category restriction (§D14 schema), default = all.
-    category_filter = args.get("category") or []
-    if isinstance(category_filter, str):
-        category_filter = [category_filter]
-    category_set = (
-        {c for c in category_filter if c in CATEGORIES}
-        if category_filter
-        else None
-    )
+    # #934: validate up-front; stale-enum entries surface as an explicit
+    # error envelope rather than silently dropping.
+    raw_filter = args.get("category") or []
+    valid_filter, err = _validate_category_filter(raw_filter)
+    if err is not None:
+        return err
+    category_set = set(valid_filter) if valid_filter else None
 
     limit = args.get("limit", 10)
     try:

--- a/tests/data/embedding_bench/manifest.yaml
+++ b/tests/data/embedding_bench/manifest.yaml
@@ -220,3 +220,33 @@ fixtures:
     expected_reach_path:
       - 'search_actions({query: "PDF"})'
     axis: [call_rate]
+
+  # ── stale-enum self-correction (#934, sandbox_2 B57 finding) ─────────────
+  #
+  # B57 observed: LLM passes a category that no longer exists (= 'mcp.server'
+  # post-#882) into list_actions / search_actions; the pre-#934 silent
+  # filter returns an empty list and the LLM has no recovery cue. This
+  # fixture captures the "fires + downstream args invalid → retry with the
+  # current name → success" failure-and-recover loop so the #934
+  # explicit-error-with-redirect fix is regression-gated in the bench.
+  #
+  # Regression detector scope: a single-round self-correction is only
+  # possible because #934's error envelope carries the legacy→current
+  # mapping inline (= the LLM doesn't need a separate inference round to
+  # figure out "which is the new name"). If a future PR simplifies the
+  # envelope by dropping the mapping block, the prefix-match here would
+  # silently lengthen (= more rounds before reach), so this fixture
+  # doubles as a content regression detector for the envelope itself,
+  # not just for the silent-vs-explicit dichotomy.
+
+  - id: stale_mcp_category_self_correction
+    source: synthesized
+    prompt: "MCP の category にあるアクションを一覧して。"
+    expected_action: mcp__list_servers
+    expected_reach_path:
+      # First attempt may carry the stale category name; the explicit
+      # error envelope (#934) carries the legacy→current mapping inline
+      # so the LLM self-corrects in a single round to the current name.
+      - 'list_actions({category: ["mcp.server"]})'
+      - 'list_actions({category: ["mcp"]})'
+    axis: [call_rate]

--- a/tests/test_universal_handlers.py
+++ b/tests/test_universal_handlers.py
@@ -351,9 +351,16 @@ def test_search_actions_filters_by_category() -> None:
 
 
 def test_list_actions_dynamic_category_empty_when_state_absent() -> None:
-    """Tier 2: dynamic categories return empty without router_state."""
+    """Tier 2: dynamic categories return empty without router_state.
+
+    Restricted to truly dynamic categories (= those whose enumeration
+    requires session state). Pre-#882 / pre-#909 names ``agent.peer``
+    / ``mcp.server`` / ``mcp.tool`` were dropped from CATEGORIES and
+    now surface as explicit errors per #934 — their handling is
+    verified by the dedicated stale-enum tests below.
+    """
     result = _run(LIST_ACTIONS.handler(
-        {"category": ["skill", "agent.peer", "mcp.server", "mcp.tool"]},
+        {"category": ["skill", "rag.corpus", "memory.entry"]},
         _make_ctx(),
     ))
     assert result["items"] == []
@@ -373,13 +380,85 @@ def test_list_actions_pagination_offset_limit() -> None:
     assert page["items"][0]["qualified_name"] == full["items"][1]["qualified_name"]
 
 
-def test_list_actions_unknown_category_silently_ignored() -> None:
-    """Tier 2: unknown category in filter list is dropped (not error)."""
+def test_list_actions_unknown_category_returns_explicit_error() -> None:
+    """Tier 2: #934 — unknown category in filter surfaces an explicit error.
+
+    Pre-#934 the handler silently dropped unknown entries and returned
+    the partial result. Post-#934 it returns the error envelope listing
+    valid categories so the LLM can self-correct rather than seeing
+    misleading partial output.
+    """
     result = _run(LIST_ACTIONS.handler(
         {"category": ["file", "not_a_category"]}, _make_ctx(),
     ))
-    # File items still returned (7 after FP-0040 +edit); bad category contributed 0
-    assert result["total"] == 7
+    assert "error" in result
+    assert "not_a_category" in result["error"]
+    assert "valid" in result and "file" in result["valid"]
+    # Items/total are absent in the error shape — the LLM sees a clear
+    # failure rather than a half-filled result.
+    assert "items" not in result
+
+
+def test_list_actions_legacy_mcp_server_carries_redirect_hint() -> None:
+    """Tier 2: #934 — stale ``mcp.server`` triggers error with mapping hint.
+
+    The error payload's ``reason`` field inlines the legacy→current
+    mapping (= ``'mcp.server' → 'mcp'``) so the LLM self-corrects in
+    a single retry without further inference. Pinned because the
+    redirect hint is the load-bearing part of the design per
+    sandbox_2's B57 W6-S3-style observation.
+    """
+    result = _run(LIST_ACTIONS.handler(
+        {"category": ["mcp.server"]}, _make_ctx(),
+    ))
+    assert "error" in result
+    assert "mcp.server" in result["error"]
+    # Mapping hint MUST identify both the legacy name and its replacement.
+    assert "'mcp.server' → 'mcp'" in result["reason"], (
+        f"redirect hint missing; reason={result['reason']!r}"
+    )
+
+
+def test_list_actions_legacy_agent_peer_carries_redirect_hint() -> None:
+    """Tier 2: #934 — stale ``agent.peer`` → ``multi_agent`` redirect surfaced."""
+    result = _run(LIST_ACTIONS.handler(
+        {"category": ["agent.peer"]}, _make_ctx(),
+    ))
+    assert "error" in result
+    assert "'agent.peer' → 'multi_agent'" in result["reason"]
+
+
+def test_list_actions_mixed_valid_and_stale_returns_error() -> None:
+    """Tier 2: #934 — even a single stale entry in a mixed list errors.
+
+    Partial success would hide the LLM's mistake (= return file items
+    while ``mcp.server`` was silently dropped). The handler treats the
+    whole call as a no-go so the LLM sees the issue.
+    """
+    result = _run(LIST_ACTIONS.handler(
+        {"category": ["file", "mcp.server"]}, _make_ctx(),
+    ))
+    assert "error" in result
+    assert "items" not in result
+    assert "mcp.server" in result["error"]
+
+
+def test_list_actions_empty_category_list_remains_unfiltered() -> None:
+    """Tier 2: #934 regression guard — empty ``category=[]`` is NOT an error.
+
+    The handler must keep treating ``category=[]`` (and the omitted
+    case) as "no filter applied"; only entries that ARE present and
+    unknown trigger the error.
+    """
+    result = _run(LIST_ACTIONS.handler(
+        {"category": []}, _make_ctx(),
+    ))
+    assert "items" in result
+    assert "error" not in result
+    # And the no-arg case also stays valid.
+    result2 = _run(LIST_ACTIONS.handler({}, _make_ctx()))
+    assert "items" in result2
+    assert "error" not in result2
 
 
 # ── 4. describe_action returns target schema ──────────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — Closes #934. Co-author: sandbox_2 (B57 primary evidence + legacy-redirect design enhancement).

## Summary

`list_actions` / `search_actions` accept a `category=[...]` argument with `enum: list(CATEGORIES)` on the schema, but LLM providers vary in how strictly they enforce enums. An LLM whose training catalog snapshot pre-dates a Reyn collapse (#882 mcp, #909 multi_agent) passes a stale name like `"mcp.server"`; pre-fix the handlers silently filtered it and returned `{items: [], total: 0}` — the LLM had no recovery cue.

sandbox_2's B57 batch confirmed this is real: post-#925 `search_actions` fires correctly on W5 scenarios, but the follow-on `list_actions(category=["mcp.server"])` returned empty and the chain stalled. Independent axis from the description-tone fix.

## Fix design — explicit error + inline redirect hint

Replace silent filter with an explicit error envelope. The error carries the current `CATEGORIES` list AND an inline legacy→current mapping for any matched collapse. The redirect-mapping is the load-bearing part: a bare valid-list forces the LLM into a "which is the new name" inference round-trip, whereas an inline legacy→current pair enables self-correction in a single retry (= sandbox_2's W6-S3-style design enhancement).

```text
unknown category 'mcp.server'

category names must be one of: 'skill', 'multi_agent', 'mcp', 'file',
  'web', 'memory.entry', 'memory.operation', 'reyn.source', 'rag.corpus',
  'rag.operation', 'validation', 'exec'.

Legacy categories from prior collapse refactors:
  'mcp.server' → 'mcp'

Hint: Re-call with `category=[<valid name>]`. Use list_actions() with
no category argument to enumerate everything visible.
```

4 legacy names covered: `mcp.server` / `mcp.tool` / `mcp.operation` → `mcp` (PR #882) and `agent.peer` → `multi_agent` (PR #909).

Partial-success is rejected (= mixed valid + stale → error envelope, not half-filled items) so the LLM cannot mistake the stale entry for a no-op.

## Files changed (3 / +210 / -22)

| File | Notes |
|---|---|
| `src/reyn/tools/universal_catalog.py` | `_LEGACY_CATEGORY_REDIRECTS` table; `_unknown_categories_error()` + `_validate_category_filter()` helpers; both handlers validate up-front |
| `tests/test_universal_handlers.py` | 2 existing tests updated (= old silent-filter contract removed); 4 new Tier-2 tests pinning redirect hint, mixed-list rejection, empty/omitted regression guard |
| `tests/data/embedding_bench/manifest.yaml` | New `stale_mcp_category_self_correction` Axis 3 fixture capturing the fire-but-args-invalid failure mode (regression gate for any future drift back to silent filtering) |

## Test plan

- [x] `pytest tests/test_universal_handlers.py tests/test_universal_catalog.py tests/test_embedding_bench_manifest.py`: 113 passed
- [x] `pytest -q --ignore=.claude` from rootdir: 5868 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` — HTML extraction, unrelated)
- [x] `ruff check` on changed files passes
- [x] Private-attr grep self-check: `grep -nE 'assert .*\._[a-z_]+' tests/test_universal_handlers.py` returns 0 hits (per [[feedback_tier4_private_state_repeat_6_round]] mitigation)
- [ ] B57-equivalent dogfood scenario re-run: expected to show stale-mcp scenarios transitioning from "tool_failed → user-facing apology" to "error → single self-correction retry → invoke_action success". sandbox_2 will verify this in next dogfood sweep once #931 + this PR are both on main.

## Tier rule self-check

- All test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 tests (= no `Mock` / `MagicMock` / `AsyncMock`; no private state assertion; no format-pinning; no snapshot/golden files)
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced
- (= 6-round Tier-4-private-state pattern + grep self-check applied per [[feedback_tier4_private_state_repeat_6_round]])

## Relationship to other work

- **#925** (description symmetry fix, merged): unlocked search_actions firing. This PR fixes the next-layer issue where firing is correct but args reference removed categories.
- **#928** (Phase 1 bench scaffold, merged): manifest gets the Axis 3 fixture here; future runner extensions (= sandbox_2's manifest (a)+(b) combined work) will exercise the self-correction loop end-to-end.
- **FP-0043 (#922)**: this PR is Axis 2 / Axis 3 territory (= LLM call behaviour) — out of scope for the local-embed backend itself but enables better measurement of its effect.
- **B57 retro PR #933** (sandbox_2): documents the dogfood-batch evidence that motivated this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)