### PR TITLE
feat(catalog): FP-0043 Component C.1 — list_actions hidden-state hint injection

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -709,6 +709,79 @@ def _validate_category_filter(
     return list(raw), None
 
 
+# ── Hidden-state hint (FP-0043 Component C.1) ──────────────────────────────
+#
+# When ``search_actions`` is gated out of ``tools=`` (= operator hasn't
+# configured ``action_retrieval.embedding_class``, or the embedding
+# class points at a backend whose extras aren't installed), the LLM
+# has no way to discover that semantic search exists. ``list_actions``
+# is the discovery wrapper the LLM does see; we attach a ``hint`` field
+# to its response so the LLM can surface the install / config path
+# back to the user. This is the "self-service onboarding" bridge in
+# FP-0043 §Component C.
+
+_HIDDEN_STATE_HINT: Final[str] = (
+    "Semantic action search (`search_actions`) is currently unavailable "
+    "in this session. To enable it, run ONE of:\n"
+    "  - `pip install 'reyn[local-embed]'` — local sentence-transformers "
+    "model, no credentials, ~22MB one-time download (recommended for "
+    "first-time users)\n"
+    "  - add to reyn.yaml: `action_retrieval:\\n  embedding_class: standard`"
+    " — uses OpenAI embeddings, requires `OPENAI_API_KEY`\n"
+    "Until enabled, use `list_actions(category=[...])` to browse the "
+    "catalog by category and `describe_action(action_name=...)` to inspect "
+    "a specific action."
+)
+
+
+def _search_actions_ready(rs: Any) -> bool:
+    """Return True iff ``search_actions`` would currently serve queries.
+
+    The check mirrors the router-side §D14 visibility gate (= idx
+    configured + provider + model class + index is_ready) but stays
+    local to the catalog module so the hint logic doesn't need to
+    re-import router internals.
+
+    A None ``rs`` means we're outside a real session (= unit test /
+    standalone caller); the caller decides whether to suppress the
+    hint in that case via the production-context check below.
+    """
+    if rs is None:
+        return False
+    idx = getattr(rs, "action_embedding_index", None)
+    provider = getattr(rs, "embedding_provider", None)
+    model_class = getattr(rs, "embedding_model_class", None)
+    if idx is None or provider is None or not model_class:
+        return False
+    is_ready = getattr(idx, "is_ready", None)
+    if not callable(is_ready):
+        return False
+    try:
+        return bool(is_ready())
+    except Exception:
+        return False
+
+
+def _should_inject_hidden_state_hint(rs: Any) -> bool:
+    """Return True iff the hint should be added to a list_actions response.
+
+    Fires when (a) a production-context router_state is present (=
+    ChatSession-mediated; rules out pure unit-test contexts that
+    don't construct an rs at all) AND (b) search_actions is not
+    currently usable. Pure-test contexts (``rs is None``) are
+    explicitly excluded so test fixtures + LLMReplay don't drift.
+
+    Brief false-positives during the background index build (= rs is
+    present but idx.is_ready() returns False yet) are acceptable —
+    the hint is informational, not blocking; the LLM may surface
+    "install local-embed" once during boot, then stop on subsequent
+    turns once the index becomes ready.
+    """
+    if rs is None:
+        return False
+    return not _search_actions_ready(rs)
+
+
 # ── Real handlers (PR-3a) ─────────────────────────────────────────────────
 
 
@@ -727,6 +800,12 @@ async def _handle_list_actions(
     #934: when ``category=[…]`` carries a name not in the current
     ``CATEGORIES`` tuple (= LLM-training-time stale enum), the handler
     returns an explicit error envelope instead of silently filtering.
+
+    FP-0043 Component C.1: when ``search_actions`` is gated out of
+    ``tools=`` in the current session, a ``hint`` field is added to
+    the response so the LLM can surface install / config instructions
+    to the user. Pure-test contexts (``router_state=None``) don't
+    receive the hint so fixture replay stays byte-stable.
     """
     # Validate category filter — surface stale-enum errors explicitly.
     raw_filter = args.get("category") or []
@@ -747,7 +826,10 @@ async def _handle_list_actions(
     total = len(items)
     page = items[offset:offset + limit]
 
-    return {"items": page, "total": total}
+    response: dict[str, Any] = {"items": page, "total": total}
+    if _should_inject_hidden_state_hint(ctx.router_state):
+        response["hint"] = _HIDDEN_STATE_HINT
+    return response
 
 
 async def _handle_search_actions(

--- a/tests/test_list_actions_hidden_state_hint.py
+++ b/tests/test_list_actions_hidden_state_hint.py
@@ -1,0 +1,247 @@
+"""Tier 2: FP-0043 Component C.1 — list_actions hidden-state hint contract.
+
+Pins the self-service onboarding bridge that surfaces install / config
+instructions to the LLM when ``search_actions`` is gated out of ``tools=``:
+
+  1. Pure-test context (``router_state=None``) MUST NOT receive the hint.
+     This guarantees existing fixtures + LLMReplay tests stay byte-stable.
+
+  2. Production-context with no embedding class configured (= operator
+     default) gets the hint. This is the fresh-user discovery path.
+
+  3. Production-context with an embedding class set but the index not
+     yet ready (= mid-build, or missing extras) ALSO gets the hint.
+     False-positives during the brief build window are acceptable per
+     FP-0043 §Component C.1 design.
+
+  4. Production-context with a fully-ready index does NOT get the hint
+     (= the LLM already sees search_actions in tools= via the §D14
+     visibility gate).
+
+  5. Hint content references the canonical install + config paths so a
+     future docs / extras-name change surfaces here.
+
+No mocks. Uses real RouterCallerState + a real fake EmbeddingProvider /
+ActionEmbeddingIndex pair injected via constructor DI (= pattern
+established in #929 / #931 reviews).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import LIST_ACTIONS
+
+
+class _NullEvents:
+    subscribers: list[Any] = []
+
+    def emit(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+
+def _ctx(rs: RouterCallerState | None = None) -> ToolContext:
+    return ToolContext(
+        events=_NullEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=rs,
+    )
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+class _ReadyIndex:
+    """Real fake ActionEmbeddingIndex stand-in claiming readiness."""
+
+    def is_ready(self) -> bool:
+        return True
+
+
+class _NotReadyIndex:
+    """Real fake ActionEmbeddingIndex stand-in claiming non-readiness."""
+
+    def is_ready(self) -> bool:
+        return False
+
+
+class _FakeProvider:
+    """Real fake EmbeddingProvider — methods exist but are never invoked."""
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        return {"vectors": [], "model": model, "total_tokens": 0}
+
+    def estimate_tokens(self, _t: list[str]) -> int:
+        return 0
+
+    def get_dimension(self, _m: str) -> int:
+        return 384
+
+
+# ── 1. Pure-test context: no hint ───────────────────────────────────────────
+
+
+def test_pure_test_context_does_not_receive_hint() -> None:
+    """Tier 2: ``router_state=None`` (= unit-test / standalone caller) suppresses
+    the hint so existing fixtures + LLMReplay tests stay byte-stable.
+    """
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(None)))
+    assert "hint" not in result
+
+
+# ── 2. Fresh-user production context: hint fires ────────────────────────────
+
+
+def test_no_embedding_class_configured_fires_hint() -> None:
+    """Tier 2: fresh production session with no embedding class fires the hint.
+
+    This is the canonical onboarding scenario: operator hasn't enabled
+    semantic search, the LLM sees only ``list_actions`` in tools=, the
+    hint tells the LLM how to enable the rest.
+    """
+    rs = RouterCallerState(
+        action_embedding_index=None,
+        embedding_provider=None,
+        embedding_model_class=None,
+    )
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    assert "hint" in result, (
+        "hint must fire when embedding_class is unset in a production session"
+    )
+
+
+def test_class_set_but_index_not_ready_fires_hint() -> None:
+    """Tier 2: class set but index still building (or missing extras) → hint.
+
+    Catches both the brief background-build window AND the
+    "configured-but-extras-not-installed" case. Both are situations
+    where the LLM should surface the install path; the hint is
+    informational, not blocking.
+    """
+    rs = RouterCallerState(
+        action_embedding_index=_NotReadyIndex(),
+        embedding_provider=_FakeProvider(),
+        embedding_model_class="local-mini",
+    )
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    assert "hint" in result
+
+
+def test_class_set_but_index_object_missing_fires_hint() -> None:
+    """Tier 2: embedding_model_class set but action_embedding_index is None.
+
+    Edge case: operator set the config but RouterLoop hasn't constructed
+    the index yet (= very early in session boot). Hint fires; the LLM
+    relays "install local-embed" which is harmless extra info.
+    """
+    rs = RouterCallerState(
+        action_embedding_index=None,
+        embedding_provider=_FakeProvider(),
+        embedding_model_class="local-mini",
+    )
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    assert "hint" in result
+
+
+# ── 3. Ready production context: no hint ────────────────────────────────────
+
+
+def test_ready_index_suppresses_hint() -> None:
+    """Tier 2: when the §D14 gate would expose search_actions, no hint.
+
+    The LLM already sees search_actions in tools=; surfacing the
+    install hint to the user would be confusing noise.
+    """
+    rs = RouterCallerState(
+        action_embedding_index=_ReadyIndex(),
+        embedding_provider=_FakeProvider(),
+        embedding_model_class="local-mini",
+    )
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    assert "hint" not in result
+
+
+# ── 4. Hint content invariants ──────────────────────────────────────────────
+
+
+def test_hint_references_local_embed_extras() -> None:
+    """Tier 2: hint string mentions the canonical extras name.
+
+    Pinned so a future rename of the extras (= ``local-embed`` → ?)
+    surfaces here rather than silently breaking the onboarding path.
+    """
+    rs = RouterCallerState()
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    hint = result["hint"]
+    assert "reyn[local-embed]" in hint
+
+
+def test_hint_references_openai_config_path() -> None:
+    """Tier 2: hint string mentions the OpenAI-via-reyn.yaml alternative.
+
+    Operator with credentials but unwilling to install heavy extras
+    can take the OpenAI path; the hint must document both options.
+    """
+    rs = RouterCallerState()
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    hint = result["hint"]
+    assert "OPENAI_API_KEY" in hint
+    assert "embedding_class" in hint
+
+
+def test_hint_references_search_actions_by_name() -> None:
+    """Tier 2: hint identifies search_actions as the unlocked capability.
+
+    The LLM needs to understand WHAT the install enables, not just HOW.
+    """
+    rs = RouterCallerState()
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    hint = result["hint"]
+    assert "search_actions" in hint
+
+
+# ── 5. Existing shape preserved ─────────────────────────────────────────────
+
+
+def test_items_and_total_shape_unchanged_when_hint_present() -> None:
+    """Tier 2: adding ``hint`` MUST NOT mutate the ``items`` / ``total`` shape.
+
+    Downstream callers depend on the §D11 envelope; the hint is an
+    additive field, not a replacement.
+    """
+    rs = RouterCallerState()
+    result = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs)))
+    assert isinstance(result["items"], list)
+    assert isinstance(result["total"], int)
+    assert result["total"] == len(result["items"])
+    assert "hint" in result  # added on top, not replacing
+
+
+def test_items_count_when_hint_absent_matches_when_present() -> None:
+    """Tier 2: identical category filter yields identical items regardless
+    of whether the hint fired.
+
+    The hint is presentational metadata only; it has zero impact on
+    the underlying catalog enumeration.
+    """
+    rs_ready = RouterCallerState(
+        action_embedding_index=_ReadyIndex(),
+        embedding_provider=_FakeProvider(),
+        embedding_model_class="local-mini",
+    )
+    rs_unready = RouterCallerState()
+    r_ready = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs_ready)))
+    r_unready = _run(LIST_ACTIONS.handler({"category": ["file"]}, _ctx(rs_unready)))
+    assert "hint" not in r_ready
+    assert "hint" in r_unready
+    # Same items in the same order, regardless of hint state.
+    assert (
+        [it["qualified_name"] for it in r_ready["items"]]
+        == [it["qualified_name"] for it in r_unready["items"]]
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 §Component C.1 implementation. Refs #922.

## Summary

Fresh users (= `action_retrieval.embedding_class: None` default) can't discover that `search_actions` exists because the §D14 visibility gate hides it from `tools=`. This PR adds a `hint` field to `list_actions` responses **only when** semantic search is currently unavailable in a production session, so the LLM can surface install / config instructions to the user — closing the self-service onboarding loop FP-0043 §Component C calls out.

## Fire conditions (response field, not SP edit)

The hint fires when ALL of:
- `ctx.router_state is not None` (= excludes pure-test contexts; existing LLMReplay fixtures stay byte-stable)

AND any of:
- `embedding_model_class` unset (= operator default — the fresh-user case)
- `action_embedding_index` is None (= early session boot)
- `embedding_provider` is None (= mis-wired)
- `idx.is_ready()` returns False (= mid-build, or missing extras causing build failure)

Brief false-positives during the background build window are acceptable per FP-0043 §Component C.1 — the hint is informational, not blocking.

## Hint content

```
Semantic action search (`search_actions`) is currently unavailable in this
session. To enable it, run ONE of:
  - `pip install 'reyn[local-embed]'` — local sentence-transformers model,
    no credentials, ~22MB one-time download (recommended for first-time users)
  - add to reyn.yaml: `action_retrieval:\n  embedding_class: standard` — uses
    OpenAI embeddings, requires `OPENAI_API_KEY`
Until enabled, use `list_actions(category=[...])` to browse the catalog by
category and `describe_action(action_name=...)` to inspect a specific action.
```

The text references the canonical install / config paths AND the `search_actions` capability by name, so a future rename surfaces in the pinning tests.

## Why a response field, not a description / SP edit

- **Dynamic per-session**: fires only when actually needed; ready sessions don't see clutter
- **Invisible to SP byte content**: no LLMReplay fixture re-record required
- **Strictly additive** to the §D11 envelope (`items` / `total` unchanged)
- **Test-fixture isolation**: pure-test contexts (`router_state=None`) excluded so unit tests + replay fixtures stay byte-stable

## Files changed (2 / +330 / -1)

| File | Notes |
|---|---|
| `src/reyn/tools/universal_catalog.py` | `_HIDDEN_STATE_HINT` constant + `_search_actions_ready()` + `_should_inject_hidden_state_hint()` helpers; `_handle_list_actions` adds the field when the gate fires |
| `tests/test_list_actions_hidden_state_hint.py` | NEW — 10 Tier-2 tests pinning all fire conditions + suppress paths + response-shape preservation |

## Test plan

- [x] `pytest tests/test_list_actions_hidden_state_hint.py`: 10 passed
- [x] `pytest tests/test_universal_handlers.py`: 44 passed (= existing handlers unaffected; test contexts all use `router_state=None` so hint is absent)
- [x] `pytest -q --ignore=.claude` from rootdir: **5874 passed**, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` — HTML extraction, unrelated)
- [x] `ruff check` on changed files passes
- [x] `grep -nE 'assert .*\._[a-z_]+' tests/test_list_actions_hidden_state_hint.py`: 0 hits ([[feedback_tier4_private_state_repeat_6_round]] mitigation applied at write time)
- [ ] Manual smoke test once merged: fresh `reyn chat` with no embedding config → ask "what can you do" → LLM should surface install/config hint as part of the capability summary (= the user-facing onboarding path this PR enables)

## Tier rule self-check

- All test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 violations (= no Mock / MagicMock / AsyncMock; no private state assertion; no format-pinning; no snapshot/golden)
- Tests use real `RouterCallerState` dataclass + real fake `_ReadyIndex` / `_NotReadyIndex` / `_FakeProvider` classes injected through the dataclass kwargs (= constructor DI pattern established in #929 / #931 reviews)
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced

## Relationship to other work

- **FP-0043 (#922)** §Component C.1 — this PR is the implementation. Splits Component C into 4 sub-PRs (C.1 hint / C.2 `reyn embeddings` CLI / C.3 first-time DL UX / C.4 TUI Memory tab integration); the others are follow-ups.
- **#929** (sentence-transformers backend, merged) — this PR's hint points at the `local-embed` extras that PR registered.
- **#935** (stale category enum explicit error, merged) — both PRs are part of the "make the LLM-facing surface self-correcting" theme: this one for missing capabilities, that one for stale category names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)