### PR TITLE
feat(cli): FP-0043 Component C.2 — reyn embeddings status / rebuild / clear

### DIFF
--- a/src/reyn/cli/commands/__init__.py
+++ b/src/reyn/cli/commands/__init__.py
@@ -13,6 +13,7 @@ from . import chat as chat
 from . import config as config
 from . import cron as cron
 from . import dogfood as dogfood
+from . import embeddings as embeddings
 from . import eval as eval
 from . import events as events
 from . import init as init
@@ -29,4 +30,4 @@ from . import topology as topology
 from . import web as web
 
 # Order is the order shown in `reyn --help`.
-ALL = [init, config, skills, skill, run, chat, agent, topology, eval, lint, memory, permissions, auth, events, web, chainlit, mcp, secret, source, cron, dogfood]
+ALL = [init, config, skills, skill, run, chat, agent, topology, eval, lint, memory, permissions, auth, events, web, chainlit, mcp, secret, source, cron, dogfood, embeddings]

--- a/src/reyn/cli/commands/embeddings.py
+++ b/src/reyn/cli/commands/embeddings.py
@@ -1,0 +1,435 @@
+"""``reyn embeddings`` — inspect and manage the action embedding index.
+
+FP-0043 Component C.2. Provides an operator surface for the embedding
+machinery that backs ``search_actions``:
+
+  status   table or JSON dump of configured embedding classes + the
+           on-disk action index state
+  rebuild  force a rebuild of the action index on next chat session
+           start (= removes the SQLite cache so the next ``build()``
+           call re-embeds)
+  clear    wipe the cache directory entirely (= SQLite index, build
+           lock, downloaded sentence-transformers model cache)
+
+The shape mirrors ``reyn mcp list`` (= header + aligned rows) per the
+tui-coder + lead-coder consolidated O4 decision in FP-0043. ``--json``
+is supported on every subcommand for scripting / N=20-bench data
+aggregation pipelines.
+
+Network-touching ops (= would-be probes against the embedding API)
+are NOT performed by this command — like ``mcp list`` without
+``--probe``, it reads on-disk state only. Network behaviour is
+verified by the bench runner (``scripts/embedding_bench.py``).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from reyn.config import load_config
+
+# ── data shape ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ClassRow:
+    """One row in the ``status`` output."""
+
+    name: str
+    backend: str          # "litellm" / "sentence-transformers"
+    model: str            # resolved model string (= class.model)
+    cache_path: str       # filesystem path or "(memory only)"
+    size_mb: float        # cached SQLite + model bytes, 0.0 when absent
+    indexed_actions: int  # vectors row count, 0 when absent / unreadable
+    last_built: str       # ISO timestamp or "(never)"
+
+
+# ── path resolution ───────────────────────────────────────────────────────────
+
+
+def _resolve_action_index_dir(project_root: Path) -> Path:
+    """Return the directory the action index SQLite lives in.
+
+    Mirrors the convention RouterLoop uses: ``<project>/.reyn/action_index/``.
+    The presence of the directory is the source of truth for "has been
+    built at least once"; the absence is a clean state.
+    """
+    return project_root / ".reyn" / "action_index"
+
+
+def _resolve_st_cache_dir() -> Path:
+    """Return the sentence-transformers model cache dir.
+
+    Honours the same precedence the runtime backend uses:
+      REYN_CACHE_DIR > XDG_CACHE_HOME > ~/.cache/reyn/
+    See ``src/reyn/embedding/sentence_transformers_provider.py``
+    for the canonical implementation; we duplicate the resolution
+    here (rather than importing it) to avoid a transitive
+    ``sentence_transformers`` import the CLI doesn't need.
+    """
+    if v := os.environ.get("REYN_CACHE_DIR"):
+        root = Path(v).expanduser()
+    elif v := os.environ.get("XDG_CACHE_HOME"):
+        root = Path(v).expanduser() / "reyn"
+    else:
+        root = Path.home() / ".cache" / "reyn"
+    return root / "sentence-transformers"
+
+
+def _get_project_root() -> Path:
+    """Return cwd as the project root (consistent with other reyn commands)."""
+    return Path.cwd()
+
+
+# ── status data collection ────────────────────────────────────────────────────
+
+
+def _dir_size_mb(path: Path) -> float:
+    """Return the total bytes under ``path`` as MB. 0.0 if absent."""
+    if not path.exists():
+        return 0.0
+    total = 0
+    for p in path.rglob("*"):
+        try:
+            if p.is_file():
+                total += p.stat().st_size
+        except OSError:
+            continue
+    return round(total / (1024 * 1024), 2)
+
+
+def _read_index_state(index_dir: Path) -> tuple[int, str]:
+    """Return ``(indexed_actions, last_built_iso)`` from the SQLite cache.
+
+    ``indexed_actions`` is the row count of the ``vectors`` table;
+    ``last_built_iso`` is the file mtime of ``index.db`` formatted as
+    an ISO 8601 string. Both default to (0, "(never)") when the file
+    is absent or unreadable.
+    """
+    db_path = index_dir / "index.db"
+    if not db_path.exists():
+        return 0, "(never)"
+    try:
+        con = sqlite3.connect(str(db_path))
+        try:
+            row = con.execute(
+                "SELECT COUNT(*) FROM vectors"
+            ).fetchone()
+            n = int(row[0]) if row else 0
+        finally:
+            con.close()
+    except (sqlite3.DatabaseError, OSError):
+        n = 0
+    try:
+        import datetime as _dt
+        ts = _dt.datetime.fromtimestamp(
+            db_path.stat().st_mtime,
+            tz=_dt.timezone.utc,
+        )
+        last_built = ts.replace(microsecond=0).isoformat()
+    except OSError:
+        last_built = "(never)"
+    return n, last_built
+
+
+def _backend_for_model(model: str) -> str:
+    """Return ``litellm`` or ``sentence-transformers`` based on prefix."""
+    if model.startswith("sentence-transformers/"):
+        return "sentence-transformers"
+    return "litellm"
+
+
+def _collect_status_rows(project_root: Path) -> list[ClassRow]:
+    """Build one ``ClassRow`` per configured embedding class.
+
+    The on-disk index state (= ``indexed_actions`` / ``last_built``)
+    is shared across classes — the SQLite cache stores one ``model_class``
+    at a time per FP-0043 Component E. We attribute the state to the
+    class currently recorded in ``meta.model_class``; other classes
+    get the zero/never defaults so the operator can see "this class
+    has not been built yet" without an external probe.
+    """
+    cfg = load_config()
+    classes = cfg.embedding.classes
+    index_dir = _resolve_action_index_dir(project_root)
+
+    # Resolve the on-disk index's current class binding, if any.
+    on_disk_class: str | None = None
+    on_disk_count = 0
+    on_disk_last_built = "(never)"
+    db_path = index_dir / "index.db"
+    if db_path.exists():
+        try:
+            con = sqlite3.connect(str(db_path))
+            try:
+                meta_rows = con.execute(
+                    "SELECT key, value FROM meta"
+                ).fetchall()
+                meta = {k: v for k, v in meta_rows}
+                on_disk_class = meta.get("model_class")
+            finally:
+                con.close()
+            if on_disk_class:
+                on_disk_count, on_disk_last_built = _read_index_state(index_dir)
+        except (sqlite3.DatabaseError, OSError):
+            pass
+
+    st_cache_dir = _resolve_st_cache_dir()
+    st_cache_size = _dir_size_mb(st_cache_dir)
+    index_size = _dir_size_mb(index_dir)
+
+    rows: list[ClassRow] = []
+    for class_name, spec in sorted(classes.items()):
+        backend = _backend_for_model(spec.model)
+        # The cache_path column shows where each backend's persistent
+        # state lives: the action index SQLite for all classes, plus
+        # the HF model cache for sentence-transformers entries.
+        if backend == "sentence-transformers":
+            cache_path = str(st_cache_dir)
+            size_mb = st_cache_size + index_size
+        else:
+            cache_path = str(index_dir)
+            size_mb = index_size
+
+        # Only the class that the on-disk meta currently records gets
+        # the indexed_actions / last_built numbers; others get the
+        # zero/never defaults so the operator sees "not built yet"
+        # without ambiguity about who's the current owner.
+        if class_name == on_disk_class:
+            indexed_actions = on_disk_count
+            last_built = on_disk_last_built
+        else:
+            indexed_actions = 0
+            last_built = "(never)"
+
+        rows.append(ClassRow(
+            name=class_name,
+            backend=backend,
+            model=spec.model,
+            cache_path=cache_path,
+            size_mb=size_mb,
+            indexed_actions=indexed_actions,
+            last_built=last_built,
+        ))
+    return rows
+
+
+# ── output rendering ──────────────────────────────────────────────────────────
+
+
+def _print_table(rows: list[ClassRow]) -> None:
+    """Render ``rows`` as an aligned plain-text table."""
+    if not rows:
+        print("No embedding classes configured.")
+        return
+    name_w = max(max(len(r.name) for r in rows), 4)
+    backend_w = max(max(len(r.backend) for r in rows), 7)
+    model_w = max(max(len(r.model) for r in rows), 5)
+    cache_w = max(max(len(r.cache_path) for r in rows), 5)
+    header = (
+        f"{'NAME':<{name_w}}  {'BACKEND':<{backend_w}}  "
+        f"{'MODEL':<{model_w}}  {'CACHE_PATH':<{cache_w}}  "
+        f"{'SIZE_MB':>8}  {'ACTIONS':>7}  LAST_BUILT"
+    )
+    print(header)
+    print("─" * len(header))
+    for r in rows:
+        print(
+            f"{r.name:<{name_w}}  {r.backend:<{backend_w}}  "
+            f"{r.model:<{model_w}}  {r.cache_path:<{cache_w}}  "
+            f"{r.size_mb:>8.2f}  {r.indexed_actions:>7}  {r.last_built}"
+        )
+
+
+def _emit_json(rows: list[ClassRow]) -> None:
+    """Emit ``rows`` as a JSON list of dicts (= same field names)."""
+    print(json.dumps(
+        [
+            {
+                "name": r.name,
+                "backend": r.backend,
+                "model": r.model,
+                "cache_path": r.cache_path,
+                "size_mb": r.size_mb,
+                "indexed_actions": r.indexed_actions,
+                "last_built": r.last_built,
+            }
+            for r in rows
+        ],
+        indent=2,
+        ensure_ascii=False,
+    ))
+
+
+# ── subcommand runners ───────────────────────────────────────────────────────
+
+
+def run_status(args: argparse.Namespace) -> None:
+    """``reyn embeddings status`` — show configured classes + index state."""
+    project_root = _get_project_root()
+    rows = _collect_status_rows(project_root)
+    if getattr(args, "json", False):
+        _emit_json(rows)
+    else:
+        _print_table(rows)
+
+
+def run_rebuild(args: argparse.Namespace) -> None:
+    """``reyn embeddings rebuild [<name>]`` — drop the SQLite cache.
+
+    The next chat session ``build()`` call will re-embed the catalog.
+    Does NOT itself trigger the embedding API; it only removes the
+    cached state. ``<name>`` is accepted for forward compatibility
+    with a future per-class cache (the SQLite layout today is shared
+    across classes); when supplied, we verify the class exists in
+    config and emit a note so the operator knows the broader cache
+    was wiped.
+    """
+    project_root = _get_project_root()
+    cfg = load_config()
+
+    target = getattr(args, "name", None)
+    if target is not None and target not in cfg.embedding.classes:
+        print(
+            f"error: embedding class {target!r} not in reyn.yaml's "
+            f"embedding.classes. Configured: "
+            f"{sorted(cfg.embedding.classes)}"
+        )
+        raise SystemExit(2)
+
+    index_dir = _resolve_action_index_dir(project_root)
+    db_path = index_dir / "index.db"
+    if not db_path.exists():
+        print(f"no action index found at {db_path}; nothing to rebuild.")
+        return
+
+    # Drop the DB and the WAL/SHM sidecars; leave the directory itself
+    # so the build lock helper can re-create files on next run.
+    removed: list[str] = []
+    for sidecar in ("index.db", "index.db-wal", "index.db-shm",
+                    ".build.lock"):
+        p = index_dir / sidecar
+        if p.exists():
+            try:
+                p.unlink()
+                removed.append(sidecar)
+            except OSError as exc:
+                print(f"warning: could not remove {p}: {exc}")
+
+    if target is not None:
+        print(
+            f"removed action index cache (shared across classes today): "
+            f"{', '.join(removed) or '(nothing)'}. "
+            f"The next chat session will re-embed for class {target!r}."
+        )
+    else:
+        print(
+            f"removed action index cache: "
+            f"{', '.join(removed) or '(nothing)'}. "
+            f"The next chat session will re-embed."
+        )
+
+
+def run_clear(args: argparse.Namespace) -> None:
+    """``reyn embeddings clear`` — wipe action index + sentence-transformers cache.
+
+    Aggressive: removes the entire ``.reyn/action_index/`` directory
+    AND the sentence-transformers HF model cache resolved per the
+    REYN_CACHE_DIR / XDG_CACHE_HOME precedence. Useful for "the cache
+    is corrupted" or "I want to switch backends and reclaim disk".
+    """
+    project_root = _get_project_root()
+    index_dir = _resolve_action_index_dir(project_root)
+    st_cache_dir = _resolve_st_cache_dir()
+
+    removed_bytes_mb = 0.0
+    for target in (index_dir, st_cache_dir):
+        if target.exists():
+            removed_bytes_mb += _dir_size_mb(target)
+            try:
+                shutil.rmtree(target)
+                print(f"removed {target}")
+            except OSError as exc:
+                print(f"warning: could not remove {target}: {exc}")
+        else:
+            print(f"skip {target} (= absent)")
+
+    if removed_bytes_mb > 0:
+        print(f"freed ~{removed_bytes_mb:.2f} MB")
+
+
+# ── argparse registration ─────────────────────────────────────────────────────
+
+
+def register(sub: Any) -> None:
+    """Register the ``reyn embeddings`` subcommand."""
+    p = sub.add_parser(
+        "embeddings",
+        help="Inspect and manage the action embedding index",
+        description=(
+            "Inspect and manage Reyn's action embedding index "
+            "(= the SQLite cache backing search_actions). See "
+            "`reyn embeddings status` for current state."
+        ),
+    )
+    inner = p.add_subparsers(
+        dest="embeddings_command",
+        metavar="<subcommand>",
+    )
+    inner.required = True
+
+    # status
+    status = inner.add_parser(
+        "status",
+        help="Show configured embedding classes + index state",
+        description=(
+            "Show one row per configured embedding class with "
+            "backend / model / cache_path / size_mb / indexed_actions "
+            "/ last_built. Reads on-disk state only — no network."
+        ),
+    )
+    status.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON instead of an aligned table.",
+    )
+    status.set_defaults(func=run_status)
+
+    # rebuild
+    rebuild = inner.add_parser(
+        "rebuild",
+        help="Drop the action index cache so the next session re-embeds",
+        description=(
+            "Remove the cached action index SQLite and build-lock "
+            "marker. Does NOT itself trigger embedding; the next "
+            "ChatSession that uses search_actions will re-embed."
+        ),
+    )
+    rebuild.add_argument(
+        "name", nargs="?", default=None,
+        help=(
+            "Optional class name to target. Today the SQLite cache "
+            "is shared across classes; passing a name verifies it "
+            "exists in reyn.yaml and notes the broader cache wipe."
+        ),
+    )
+    rebuild.set_defaults(func=run_rebuild)
+
+    # clear
+    clear = inner.add_parser(
+        "clear",
+        help="Wipe the action index and the local model cache directory",
+        description=(
+            "Remove .reyn/action_index/ AND the sentence-transformers "
+            "model cache directory. Aggressive: useful for cache "
+            "corruption or backend swap reclamation."
+        ),
+    )
+    clear.set_defaults(func=run_clear)
+
+    p.set_defaults(func=lambda _a: p.print_help())

--- a/tests/test_reyn_embeddings_cli.py
+++ b/tests/test_reyn_embeddings_cli.py
@@ -1,0 +1,288 @@
+"""Tier 2: FP-0043 Component C.2 — ``reyn embeddings`` CLI contract.
+
+Pins the operator-facing CLI surface:
+
+  1. ``reyn embeddings status`` renders one row per configured embedding
+     class with the agreed columns (name / backend / model / cache_path /
+     size_mb / indexed_actions / last_built).
+  2. ``--json`` emits a JSON list matching the table column names so
+     downstream scripts can aggregate without parsing the table.
+  3. Backend column is derived from the ``model`` prefix (= "litellm"
+     for non-prefixed / "sentence-transformers" for the ``sentence-
+     transformers/`` prefix).
+  4. ``reyn embeddings rebuild`` drops the on-disk action index SQLite
+     + the build-lock marker; a missing index reports "nothing to
+     rebuild" without erroring.
+  5. ``reyn embeddings rebuild <name>`` rejects unknown class names.
+  6. ``reyn embeddings clear`` removes the action index directory AND
+     the sentence-transformers cache directory; absent paths are
+     reported as skipped.
+
+No mocks. Tests work against real on-disk state in ``tmp_path`` with
+``monkeypatch.chdir(tmp_path)`` so the CLI's cwd-based project-root
+resolution is exercised end-to-end.
+"""
+from __future__ import annotations
+
+import json
+import struct
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from reyn.cli.commands.embeddings import (
+    _backend_for_model,
+    _collect_status_rows,
+    run_clear,
+    run_rebuild,
+    run_status,
+)
+
+
+def _write_index_db(
+    index_dir: Path, class_name: str, vectors: dict[str, list[float]],
+) -> None:
+    """Stand up a real SQLite ``index.db`` matching ActionEmbeddingIndex shape."""
+    import sqlite3
+    index_dir.mkdir(parents=True, exist_ok=True)
+    db_path = index_dir / "index.db"
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS meta "
+            "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS vectors "
+            "(qualified_name TEXT PRIMARY KEY, item_json TEXT NOT NULL, "
+            "vector_blob BLOB NOT NULL)"
+        )
+        con.execute(
+            "INSERT OR REPLACE INTO meta VALUES ('model_class', ?)",
+            (class_name,),
+        )
+        con.execute(
+            "INSERT OR REPLACE INTO meta VALUES ('catalog_hash', 'h')",
+        )
+        for qn, vec in vectors.items():
+            con.executemany(
+                "INSERT OR REPLACE INTO vectors VALUES (?, ?, ?)",
+                [(qn, '{}', struct.pack(f"{len(vec)}d", *vec))],
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
+# ── 1. backend resolution ─────────────────────────────────────────────────────
+
+
+def test_backend_for_litellm_prefix() -> None:
+    """Tier 2: non-prefixed model string → litellm backend."""
+    assert _backend_for_model("openai/text-embedding-3-small") == "litellm"
+
+
+def test_backend_for_sentence_transformers_prefix() -> None:
+    """Tier 2: ``sentence-transformers/`` prefix → sentence-transformers backend."""
+    assert (
+        _backend_for_model("sentence-transformers/all-MiniLM-L6-v2")
+        == "sentence-transformers"
+    )
+
+
+# ── 2. status row collection ────────────────────────────────────────────────
+
+
+def test_status_rows_include_every_configured_class(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: every class in ``embedding.classes`` produces a row."""
+    monkeypatch.chdir(tmp_path)
+    rows = _collect_status_rows(tmp_path)
+    names = {r.name for r in rows}
+    # Defaults from FP-0043 Phase 2 (= local-mini + local-e5 added).
+    for expected in ("light", "standard", "strong", "local-mini", "local-e5"):
+        assert expected in names, (
+            f"class {expected!r} missing from status rows; got {names}"
+        )
+
+
+def test_status_rows_attribute_count_to_on_disk_class_only(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: indexed_actions is attributed to the class recorded in meta only.
+
+    Component E pins one model_class per SQLite cache. The CLI reflects
+    this by showing the count + last_built ONLY on the row whose name
+    matches the recorded meta.model_class. Other rows show 0 / "(never)".
+    """
+    monkeypatch.chdir(tmp_path)
+    index_dir = tmp_path / ".reyn" / "action_index"
+    _write_index_db(
+        index_dir,
+        class_name="local-mini",
+        vectors={"file__read": [0.1, 0.2], "web__search": [0.3, 0.4]},
+    )
+    rows = _collect_status_rows(tmp_path)
+    by_name = {r.name: r for r in rows}
+    assert by_name["local-mini"].indexed_actions == 2
+    assert by_name["local-mini"].last_built != "(never)"
+    # Other classes get zeros — not the foreign class's count.
+    assert by_name["standard"].indexed_actions == 0
+    assert by_name["standard"].last_built == "(never)"
+
+
+# ── 3. status / --json output ───────────────────────────────────────────────
+
+
+def test_status_default_emits_aligned_table(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: ``reyn embeddings status`` prints aligned table with header row.
+
+    Mirrors the ``reyn mcp list`` shape (= O4 resolution per FP-0043
+    tui-coder + lead-coder consolidated decision).
+    """
+    monkeypatch.chdir(tmp_path)
+    run_status(Namespace(json=False))
+    out = capsys.readouterr().out
+    # Header column names present, in order.
+    header_idx = out.find("NAME")
+    assert header_idx >= 0
+    for col in ("BACKEND", "MODEL", "CACHE_PATH", "SIZE_MB",
+                "ACTIONS", "LAST_BUILT"):
+        assert out.find(col, header_idx) > header_idx, (
+            f"column {col!r} missing or out of order"
+        )
+    # At least one configured class shows up.
+    assert "standard" in out or "light" in out
+
+
+def test_status_json_emits_machine_readable_array(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: ``--json`` emits a list of dicts with the agreed keys."""
+    monkeypatch.chdir(tmp_path)
+    run_status(Namespace(json=True))
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert isinstance(data, list) and data
+    required_keys = {
+        "name", "backend", "model", "cache_path",
+        "size_mb", "indexed_actions", "last_built",
+    }
+    for row in data:
+        assert isinstance(row, dict)
+        assert required_keys.issubset(row.keys()), (
+            f"row missing keys {required_keys - set(row.keys())}: {row}"
+        )
+
+
+# ── 4. rebuild ──────────────────────────────────────────────────────────────
+
+
+def test_rebuild_removes_index_files_when_present(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: rebuild drops index.db + WAL sidecars + .build.lock."""
+    monkeypatch.chdir(tmp_path)
+    index_dir = tmp_path / ".reyn" / "action_index"
+    _write_index_db(index_dir, "standard", {"file__read": [0.1, 0.2]})
+    (index_dir / ".build.lock").write_text("{}", encoding="utf-8")
+    run_rebuild(Namespace(name=None))
+    out = capsys.readouterr().out
+    assert not (index_dir / "index.db").exists()
+    assert not (index_dir / ".build.lock").exists()
+    assert "removed action index cache" in out
+
+
+def test_rebuild_no_index_reports_nothing_to_do(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: rebuild on a clean project reports "nothing to rebuild" cleanly.
+
+    Must not raise — operator running rebuild after a `clear` should
+    see a friendly message, not a crash.
+    """
+    monkeypatch.chdir(tmp_path)
+    run_rebuild(Namespace(name=None))
+    out = capsys.readouterr().out
+    assert "nothing to rebuild" in out
+
+
+def test_rebuild_unknown_class_name_rejects(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: rebuild with a name not in reyn.yaml classes exits non-zero.
+
+    Catches typos and prevents silent no-op confusion (= "I rebuilt
+    'lcal-mini' (= typo of local-mini) and nothing changed").
+    """
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as excinfo:
+        run_rebuild(Namespace(name="nonexistent_class"))
+    assert excinfo.value.code == 2
+    out = capsys.readouterr().out
+    assert "nonexistent_class" in out
+    assert "Configured:" in out
+
+
+def test_rebuild_known_class_name_notes_shared_cache(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: rebuild with a valid class name notes the cache-shared semantics.
+
+    Pinned because the per-class cache split is a possible future
+    direction; passing the name today verifies the class exists and
+    emits a clear note about the shared cache being wiped.
+    """
+    monkeypatch.chdir(tmp_path)
+    index_dir = tmp_path / ".reyn" / "action_index"
+    _write_index_db(index_dir, "local-mini", {"file__read": [0.1, 0.2]})
+    run_rebuild(Namespace(name="local-mini"))
+    out = capsys.readouterr().out
+    assert "local-mini" in out
+    assert "shared across classes" in out
+
+
+# ── 5. clear ────────────────────────────────────────────────────────────────
+
+
+def test_clear_removes_index_dir_and_st_cache_dir(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: clear removes BOTH the action index dir AND the ST model cache.
+
+    Both directories are explicitly cleared; absent paths are reported
+    as skipped (= no crash on a clean install).
+    """
+    # Override the ST cache so it's under tmp_path and we can verify removal
+    # without touching the developer's real ~/.cache.
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path / "reyn-cache"))
+    monkeypatch.chdir(tmp_path)
+    index_dir = tmp_path / ".reyn" / "action_index"
+    _write_index_db(index_dir, "standard", {"file__read": [0.1, 0.2]})
+    st_cache = tmp_path / "reyn-cache" / "sentence-transformers"
+    st_cache.mkdir(parents=True)
+    (st_cache / "model.bin").write_bytes(b"\x00" * 1024)
+
+    run_clear(Namespace())
+    out = capsys.readouterr().out
+
+    assert not index_dir.exists(), "index dir should have been removed"
+    assert not st_cache.exists(), "ST cache dir should have been removed"
+    assert "removed" in out
+    assert "freed" in out
+
+
+def test_clear_on_absent_paths_reports_skip(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: clear on a clean project skips gracefully without error."""
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path / "reyn-cache-empty"))
+    monkeypatch.chdir(tmp_path)
+    run_clear(Namespace())
+    out = capsys.readouterr().out
+    # Both targets absent → two skip lines, no failure.
+    assert out.count("skip") >= 2


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 §Component C.2 implementation. Refs #922.

## Summary

Adds the operator-facing CLI for the action embedding index that backs `search_actions`. Reads on-disk state only (= no network probes), matching the `reyn mcp list` family shape (O4 resolution per FP-0043 tui-coder + lead-coder consolidated decision).

## Subcommands

| Subcommand | What |
|---|---|
| `reyn embeddings status [--json]` | Table or JSON of every configured embedding class with `name / backend / model / cache_path / size_mb / indexed_actions / last_built` |
| `reyn embeddings rebuild [<name>]` | Drops `.reyn/action_index/index.db` + WAL sidecars + `.build.lock` so the next ChatSession re-embeds. Empty-project state reports "nothing to rebuild" without erroring. `<name>` verifies the class exists in `reyn.yaml`. |
| `reyn embeddings clear` | Removes BOTH `.reyn/action_index/` AND the sentence-transformers HF model cache (resolved via `REYN_CACHE_DIR > XDG_CACHE_HOME > ~/.cache/reyn` matching the runtime backend). Useful for cache corruption / backend swap. |

### Example output

```
NAME        BACKEND                MODEL                                                 CACHE_PATH                                          SIZE_MB  ACTIONS  LAST_BUILT
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
light       litellm                openai/text-embedding-3-small                         .reyn/action_index                                     0.00        0  (never)
local-e5    sentence-transformers  sentence-transformers/intfloat/multilingual-e5-small  ~/.cache/reyn/sentence-transformers                    0.00        0  (never)
local-mini  sentence-transformers  sentence-transformers/all-MiniLM-L6-v2                ~/.cache/reyn/sentence-transformers                    0.00        0  (never)
standard    litellm                openai/text-embedding-3-small                         .reyn/action_index                                     0.00        0  (never)
strong      litellm                openai/text-embedding-3-large                         .reyn/action_index                                     0.00        0  (never)
```

## Cross-class attribution (Component E continuity)

The SQLite cache stores ONE `model_class` at a time per FP-0043 Component E. `status` attributes `indexed_actions` / `last_built` ONLY to the row whose class name matches the recorded `meta.model_class`; other classes show `0 / "(never)"`. This surfaces "this class has not been built yet" without an external probe and prevents ambiguity about ownership when an operator swaps between `local-mini` and `standard`.

## Files changed (3 / +725 / -1)

| File | Notes |
|---|---|
| `src/reyn/cli/commands/embeddings.py` | NEW — 3 subcommands + supporting helpers |
| `src/reyn/cli/commands/__init__.py` | Register the embeddings module |
| `tests/test_reyn_embeddings_cli.py` | NEW — 12 Tier-2 tests |

## Test plan

- [x] `pytest tests/test_reyn_embeddings_cli.py`: 12 passed
- [x] `pytest -q --ignore=.claude` from rootdir: **5902 passed**, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` — HTML extraction, unrelated)
- [x] `ruff check` on changed files passes
- [x] `grep -nE 'assert .*\._[a-z_]+' tests/test_reyn_embeddings_cli.py`: 0 hits ([[feedback_tier4_private_state_repeat_6_round]] mitigation applied at write time)
- [x] Smoke test: `reyn embeddings status` / `reyn embeddings status --json` both render expected shape against a fresh project
- [ ] Manual: `reyn embeddings rebuild` on a real `.reyn/action_index/` from a prior chat session removes the SQLite + restarts the build on next `reyn chat`. Will verify when local-embed extras are installed end-to-end (sandbox_2 dogfood env or follow-up smoke).

## Tier rule self-check

- All test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 violations (= no `Mock` / `MagicMock` / `AsyncMock`; no private state assertion; no format-pinning; no snapshot)
- Tests use real on-disk SQLite via `monkeypatch.chdir(tmp_path)` + a small `_write_index_db` helper that stands up the actual schema ActionEmbeddingIndex uses (= round-trip-safe)
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced

## Relationship to other work

- **FP-0043 (#922)** §Component C.2 — this PR is the implementation.
- **#936** (C.1 list_actions hidden-state hint, merged): LLM-visible counterpart. The hint tells the LLM "search is unavailable, here's how to enable"; this CLI is the operator-side surface that confirms the state ("yes, embedding_class is unset" / "yes, index.db is missing") and lets them fix it.
- **#931** (Component E, merged): the SQLite `meta.model_class` field this CLI reads was added there.
- **C.3** (first-time DL UX) / **C.4** (TUI Memory tab integration) — follow-up PRs, separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)