### PR TITLE
feat(embedding): FP-0043 Component C.3 — first-time DL progress events

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1288,7 +1288,31 @@ class ChatSession:
             try:
                 from reyn.embedding import get_provider as _get_provider
                 from reyn.tools.action_index import ActionEmbeddingIndex
-                self._embedding_provider = _get_provider("litellm", embedding_config)
+
+                # FP-0043 Component C.3: surface the sentence-transformers
+                # lazy model-load lifecycle (= downloading / loaded /
+                # error) via the session's events bus so the TUI /
+                # chainlit surfaces can render a sticky status row + a
+                # green "done" frame + a retry-hint error row. The sink
+                # is called from the embed worker thread; events.emit is
+                # GIL-protected + sync so this is safe without a
+                # call_soon_threadsafe bridge.
+                _events = self.events
+
+                def _embedding_event_sink(
+                    kind: str, text: str, meta: dict,
+                ) -> None:
+                    _events.emit(
+                        f"embedding_{kind}",
+                        text=text,
+                        **meta,
+                    )
+
+                self._embedding_provider = _get_provider(
+                    "litellm",
+                    embedding_config,
+                    event_sink=_embedding_event_sink,
+                )
                 self._embedding_model_class = self._action_retrieval.embedding_class
                 self._action_embedding_index = ActionEmbeddingIndex(
                     persist_dir=Path(".reyn") / "action_index",

--- a/src/reyn/embedding/__init__.py
+++ b/src/reyn/embedding/__init__.py
@@ -22,6 +22,8 @@ Layers (ADR-0033 + FP-0043):
 """
 from __future__ import annotations
 
+from typing import Any
+
 from reyn.embedding.cost_estimator import CostEstimate, estimate_indexing_cost
 from reyn.embedding.litellm_provider import LiteLLMEmbeddingProvider
 from reyn.embedding.provider import EmbedBatchResult, EmbeddingProvider
@@ -51,7 +53,10 @@ def register_provider(name: str, impl: type[EmbeddingProvider]) -> None:
 
 
 def get_provider(
-    name: str = "litellm", config: dict | None = None
+    name: str = "litellm",
+    config: dict | None = None,
+    *,
+    event_sink: "Any | None" = None,
 ) -> EmbeddingProvider:
     """Instantiate and return an EmbeddingProvider by name.
 
@@ -62,6 +67,13 @@ def get_provider(
                 carries the ``sentence-transformers/`` prefix).
         config: Provider configuration dict (e.g. reyn.yaml ``embedding:``
                 section). Empty dict used when None.
+        event_sink: Optional ``(kind, text, meta) -> None`` callable
+                forwarded to backends that emit lifecycle events (= the
+                routing wrapper passes it through to the lazily-built
+                sentence-transformers backend for model-load
+                notifications). Passed only to provider classes that
+                accept the kwarg; ignored otherwise.
+                FP-0043 Component C.3 onboarding UX.
 
     Returns:
         An EmbeddingProvider instance.
@@ -70,6 +82,8 @@ def get_provider(
         KeyError: if name is not registered.
     """
     cls = _PROVIDERS[name]
+    if event_sink is not None and cls is RoutingEmbeddingProvider:
+        return cls(config or {}, event_sink=event_sink)  # type: ignore[call-arg]
     return cls(config or {})  # type: ignore[call-arg]
 
 

--- a/src/reyn/embedding/router_provider.py
+++ b/src/reyn/embedding/router_provider.py
@@ -72,6 +72,12 @@ class RoutingEmbeddingProvider:
             instantiated lazily on first prefix-match (= production
             posture: zero overhead when only LiteLLM-routable models
             are used). Tests pass a fake here to verify dispatch.
+        event_sink: Optional ``(kind, text, meta) -> None`` callable
+            forwarded to the lazily-constructed sentence-transformers
+            backend so its model-load lifecycle (= downloading / loaded
+            / error) surfaces back to the caller. Ignored for the
+            LiteLLM backend (= no lazy load to report on).
+            FP-0043 Component C.3 onboarding UX.
     """
 
     def __init__(
@@ -80,6 +86,7 @@ class RoutingEmbeddingProvider:
         *,
         litellm_provider: "Any | None" = None,
         sentence_transformers_provider: "Any | None" = None,
+        event_sink: "Any | None" = None,
     ) -> None:
         self._config = config
         self._litellm = (
@@ -88,6 +95,7 @@ class RoutingEmbeddingProvider:
             else LiteLLMEmbeddingProvider(config=config)
         )
         self._st: Any = sentence_transformers_provider  # lazy when None
+        self._event_sink = event_sink
 
         # Cache the classes map for prefix resolution without re-walking
         # the EmbeddingConfig structure on every embed() call.
@@ -117,6 +125,7 @@ class RoutingEmbeddingProvider:
                 )
                 self._st = SentenceTransformersEmbeddingProvider(
                     config=self._config,
+                    event_sink=self._event_sink,
                 )
             return self._st
         return self._litellm

--- a/src/reyn/embedding/sentence_transformers_provider.py
+++ b/src/reyn/embedding/sentence_transformers_provider.py
@@ -57,9 +57,27 @@ import asyncio
 import os
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.embedding.provider import EmbedBatchResult
+
+# FP-0043 Component C.3 — first-time DL progress UX.
+#
+# An EventSink is an optional ``(kind, text, meta) -> None`` callable
+# the caller passes in to receive lifecycle notifications during the
+# lazy model load. The provider emits:
+#
+#   ("status",     "<msg>", {model, target_dir, device})   on DL start
+#   ("skill_done", "<msg>", {model, dimension})            on load complete
+#   ("error",      "<msg>", {model, retry_hint})           on load failure
+#
+# The sink is called synchronously from inside ``_load`` (= which itself
+# runs under ``asyncio.to_thread`` when invoked via ``embed``). Sink
+# implementations that need to bridge into an async event bus should
+# either be thread-safe or use a thread-safe primitive (= queue,
+# loop.call_soon_threadsafe). Sink exceptions are swallowed so a
+# misbehaving sink can never break the embedding load.
+EventSink = Callable[[str, str, dict], None]
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer  # noqa: F401
@@ -118,9 +136,19 @@ class SentenceTransformersEmbeddingProvider:
             lookup table; this provider does NOT honour batch_size /
             max_concurrent_batches at the moment — sentence-transformers
             encodes in a single call per batch internally.
+        event_sink: Optional ``(kind, text, meta) -> None`` callable
+            that receives lifecycle notifications during the lazy model
+            load (= "downloading...", "loaded", "error"). When ``None``
+            the load runs silently — preserves the pre-#922 behaviour.
+            FP-0043 Component C.3 onboarding UX.
     """
 
-    def __init__(self, config: "dict[str, Any] | Any | None" = None) -> None:
+    def __init__(
+        self,
+        config: "dict[str, Any] | Any | None" = None,
+        *,
+        event_sink: "EventSink | None" = None,
+    ) -> None:
         if config is None:
             config = {}
         if not isinstance(config, dict) and hasattr(config, "classes"):
@@ -134,6 +162,25 @@ class SentenceTransformersEmbeddingProvider:
         self._models: dict[str, Any] = {}
         self._cache_dir = _resolve_cache_dir()
         self._device = _resolve_device()
+        self._event_sink: "EventSink | None" = event_sink
+
+    # ── Event sink helper ─────────────────────────────────────────────────
+
+    def _emit(self, kind: str, text: str, meta: "dict | None" = None) -> None:
+        """Dispatch a lifecycle event through the configured sink, if any.
+
+        Sink exceptions are intentionally swallowed: an event-bus
+        misconfiguration must not prevent the embedding load from
+        completing (= the LLM still needs vectors regardless of
+        whether the operator's TUI got a "downloading..." line).
+        """
+        sink = self._event_sink
+        if sink is None:
+            return
+        try:
+            sink(kind, text, meta or {})
+        except Exception:
+            pass
 
     # ── Model resolution ───────────────────────────────────────────────────
 
@@ -158,6 +205,16 @@ class SentenceTransformersEmbeddingProvider:
         Raises ImportError when the optional dep is missing — the caller
         is expected to surface this with the canonical install hint
         (already embedded in the exception message).
+
+        Lifecycle events (FP-0043 Component C.3):
+          * ``status`` before the load begins, carrying ``model`` /
+            ``target_dir`` / ``device`` so the TUI can render a sticky
+            status row.
+          * ``skill_done`` after the load succeeds, with the resolved
+            dimension for cross-checking.
+          * ``error`` if the load (or the underlying import) fails,
+            with a ``retry_hint`` pointing at the relevant recovery
+            command.
         """
         cached = self._models.get(resolved_model)
         if cached is not None:
@@ -165,14 +222,62 @@ class SentenceTransformersEmbeddingProvider:
         try:
             from sentence_transformers import SentenceTransformer
         except ImportError as exc:
+            self._emit(
+                "error",
+                f"sentence_transformers not installed; cannot load "
+                f"{resolved_model!r}",
+                {
+                    "model": resolved_model,
+                    "retry_hint": (
+                        "Run `pip install 'reyn[local-embed]'` to "
+                        "install the local embedding extras, then retry."
+                    ),
+                },
+            )
             raise ImportError(_INSTALL_HINT) from exc
 
         hf_id = _strip_prefix(resolved_model)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
-        model = SentenceTransformer(
-            hf_id,
-            cache_folder=str(self._cache_dir),
-            device=self._device,
+        self._emit(
+            "status",
+            f"loading embedding model {resolved_model!r} "
+            f"(first run may download ~20-120 MB)",
+            {
+                "model": resolved_model,
+                "target_dir": str(self._cache_dir),
+                "device": self._device,
+            },
+        )
+        try:
+            model = SentenceTransformer(
+                hf_id,
+                cache_folder=str(self._cache_dir),
+                device=self._device,
+            )
+        except Exception as exc:
+            self._emit(
+                "error",
+                f"failed to load {resolved_model!r}: {exc}",
+                {
+                    "model": resolved_model,
+                    "retry_hint": (
+                        "Check network connectivity, then retry. If the "
+                        "cache is partial / corrupt, run "
+                        "`reyn embeddings clear` to wipe and start fresh."
+                    ),
+                },
+            )
+            raise
+        # Resolve dimension without re-loading; sentence-transformers
+        # exposes this on the loaded instance.
+        try:
+            dim = int(model.get_sentence_embedding_dimension())
+        except Exception:
+            dim = 0
+        self._emit(
+            "skill_done",
+            f"loaded embedding model {resolved_model!r} ({dim}d)",
+            {"model": resolved_model, "dimension": dim},
         )
         self._models[resolved_model] = model
         return model
@@ -247,6 +352,7 @@ class SentenceTransformersEmbeddingProvider:
 
 __all__ = [
     "SentenceTransformersEmbeddingProvider",
+    "EventSink",
     "_PREFIX",  # exported for the routing layer
     "_resolve_cache_dir",  # exported for tests
     "_resolve_device",

--- a/tests/test_embedding_dl_progress_events.py
+++ b/tests/test_embedding_dl_progress_events.py
@@ -1,0 +1,381 @@
+"""Tier 2: FP-0043 Component C.3 — first-time DL progress event sink contract.
+
+Pins the lifecycle-event surface that ``SentenceTransformersEmbeddingProvider``
+emits during its lazy model load, plus the routing-wrapper forwarding
+and the ``get_provider`` factory plumbing.
+
+What is pinned:
+
+  1. ``event_sink`` is an opt-in kwarg on
+     ``SentenceTransformersEmbeddingProvider`` / ``RoutingEmbeddingProvider`` /
+     ``get_provider``. When ``None`` is passed, the lazy load path is
+     byte-identical to the pre-C.3 behaviour (= no events emitted).
+  2. The ImportError path (= ``sentence_transformers`` not installed)
+     emits a single ``("error", …, {retry_hint: …})`` event with the
+     canonical install command in the hint before raising.
+  3. A successful load emits exactly
+        ``status`` → ``skill_done`` (in that order).
+     ``status.meta`` carries ``model`` / ``target_dir`` / ``device``;
+     ``skill_done.meta`` carries ``model`` / ``dimension``.
+  4. A load that fails after the import succeeded (= simulated by a
+     SentenceTransformer constructor raising) emits
+        ``status`` → ``error``.
+     ``error.meta.retry_hint`` references the ``reyn embeddings clear``
+     recovery path. The original exception propagates verbatim.
+  5. Sink exceptions are swallowed (= a buggy sink does NOT crash
+     embedding loads).
+  6. ``RoutingEmbeddingProvider`` forwards the sink to its lazily-built
+     sentence-transformers backend (= the sink passed at the routing
+     layer reaches the ST backend's emit path).
+  7. ``get_provider("litellm", config, event_sink=…)`` passes the sink
+     through to the routing wrapper.
+
+No mocks. Tests use ``monkeypatch.setitem(sys.modules, ...)`` to install
+real-shape fake ``sentence_transformers`` modules so the import + load
+path runs end-to-end without requiring the actual heavy dependency.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+import pytest
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _record() -> tuple[list[tuple[str, str, dict]], Any]:
+    """Return (events_list, sink_callable) for capturing emissions."""
+    events: list[tuple[str, str, dict]] = []
+
+    def _sink(kind: str, text: str, meta: dict) -> None:
+        events.append((kind, text, meta))
+
+    return events, _sink
+
+
+# ── Real-shape fake sentence_transformers module ─────────────────────────────
+
+
+class _FakeST:
+    """Real-shape SentenceTransformer stand-in. Constructor params match."""
+
+    instances: list["_FakeST"] = []
+
+    def __init__(
+        self,
+        hf_id: str,
+        cache_folder: str | None = None,
+        device: str | None = None,
+        **_kw: Any,
+    ):
+        self.hf_id = hf_id
+        self.cache_folder = cache_folder
+        self.device = device
+        _FakeST.instances.append(self)
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 384
+
+    def encode(self, texts: list[str], **_kw: Any) -> list[list[float]]:
+        return [[0.1] * 384 for _ in texts]
+
+
+class _ExplodingST:
+    """SentenceTransformer constructor that always raises (= load failure path)."""
+
+    def __init__(self, *_a: Any, **_kw: Any):
+        raise RuntimeError("simulated load failure")
+
+
+def _install_fake_st(monkeypatch, ctor: type) -> None:
+    """Install a real-shape fake ``sentence_transformers`` module."""
+    import types
+    module = types.ModuleType("sentence_transformers")
+    module.SentenceTransformer = ctor  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+
+
+def _uninstall_st(monkeypatch) -> None:
+    """Block the import entirely (= ImportError path)."""
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+
+
+# ── 1. event_sink None → byte-identical pre-C.3 behaviour ────────────────────
+
+
+def test_no_sink_no_emissions_on_successful_load(monkeypatch, tmp_path) -> None:
+    """Tier 2: with ``event_sink=None`` the load path is silent."""
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    from reyn.embedding.sentence_transformers_provider import (
+        SentenceTransformersEmbeddingProvider,
+    )
+    p = SentenceTransformersEmbeddingProvider(config={})
+    result = _run(p.embed(
+        ["hello"],
+        "sentence-transformers/all-MiniLM-L6-v2",
+    ))
+    # No event_sink set → no observable side-effect besides the load.
+    assert len(_FakeST.instances) == 1
+    assert result["vectors"][0]  # actually loaded + ran encode
+
+
+# ── 2. ImportError path emits a single error event before raising ────────────
+
+
+def test_import_error_emits_error_event_with_install_hint(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: missing ``sentence_transformers`` → error event + install hint."""
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _uninstall_st(monkeypatch)
+
+    events, sink = _record()
+    from reyn.embedding.sentence_transformers_provider import (
+        SentenceTransformersEmbeddingProvider,
+    )
+    p = SentenceTransformersEmbeddingProvider(config={}, event_sink=sink)
+    with pytest.raises(ImportError) as excinfo:
+        _run(p.embed(
+            ["x"],
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ))
+    assert "reyn[local-embed]" in str(excinfo.value)
+    # Exactly one event: error with retry_hint pointing at the extras.
+    assert len(events) == 1
+    kind, _text, meta = events[0]
+    assert kind == "error"
+    assert "reyn[local-embed]" in meta["retry_hint"]
+    assert meta["model"] == "sentence-transformers/all-MiniLM-L6-v2"
+
+
+# ── 3. Successful load emits status → skill_done ─────────────────────────────
+
+
+def test_successful_load_emits_status_then_done(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: load lifecycle = status (with model/target_dir/device) then
+    skill_done (with model/dimension), in that order.
+    """
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("REYN_EMBED_DEVICE", "cpu")
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    events, sink = _record()
+    from reyn.embedding.sentence_transformers_provider import (
+        SentenceTransformersEmbeddingProvider,
+    )
+    p = SentenceTransformersEmbeddingProvider(config={}, event_sink=sink)
+    _run(p.embed(
+        ["hi"],
+        "sentence-transformers/all-MiniLM-L6-v2",
+    ))
+    kinds = [k for k, _t, _m in events]
+    assert kinds == ["status", "skill_done"], (
+        f"expected [status, skill_done]; got {kinds}"
+    )
+    status_meta = events[0][2]
+    done_meta = events[1][2]
+    assert status_meta["model"] == "sentence-transformers/all-MiniLM-L6-v2"
+    assert status_meta["target_dir"]  # path string non-empty
+    assert status_meta["device"] == "cpu"
+    assert done_meta["model"] == "sentence-transformers/all-MiniLM-L6-v2"
+    assert done_meta["dimension"] == 384
+
+
+def test_subsequent_load_emits_no_events_when_cached(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: second embed against an already-loaded model is silent.
+
+    Lifecycle events fire ONLY on the cold-start lazy load; the
+    in-process cache makes every subsequent call a no-op for the
+    sink.
+    """
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    events, sink = _record()
+    from reyn.embedding.sentence_transformers_provider import (
+        SentenceTransformersEmbeddingProvider,
+    )
+    p = SentenceTransformersEmbeddingProvider(config={}, event_sink=sink)
+    _run(p.embed(["a"], "sentence-transformers/all-MiniLM-L6-v2"))
+    _run(p.embed(["b"], "sentence-transformers/all-MiniLM-L6-v2"))
+    # Only the first call's two events; second call hits the cache.
+    assert [k for k, _t, _m in events] == ["status", "skill_done"]
+
+
+# ── 4. Load failure after import emits status → error ───────────────────────
+
+
+def test_load_failure_emits_status_then_error_with_clear_hint(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: SentenceTransformer constructor raising → status then error.
+
+    ``error.meta.retry_hint`` must reference ``reyn embeddings clear``
+    so the operator has a concrete recovery command when the cache
+    state is partial.
+    """
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _install_fake_st(monkeypatch, _ExplodingST)
+
+    events, sink = _record()
+    from reyn.embedding.sentence_transformers_provider import (
+        SentenceTransformersEmbeddingProvider,
+    )
+    p = SentenceTransformersEmbeddingProvider(config={}, event_sink=sink)
+    with pytest.raises(RuntimeError, match="simulated load failure"):
+        _run(p.embed(
+            ["x"],
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ))
+    kinds = [k for k, _t, _m in events]
+    assert kinds == ["status", "error"], (
+        f"expected [status, error]; got {kinds}"
+    )
+    assert "reyn embeddings clear" in events[1][2]["retry_hint"]
+
+
+# ── 5. Sink exception is swallowed ───────────────────────────────────────────
+
+
+def test_sink_exception_does_not_crash_load(monkeypatch, tmp_path) -> None:
+    """Tier 2: a buggy sink callable must not break the embedding load."""
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    def _bad_sink(kind: str, text: str, meta: dict) -> None:
+        raise RuntimeError("sink imploded")
+
+    from reyn.embedding.sentence_transformers_provider import (
+        SentenceTransformersEmbeddingProvider,
+    )
+    p = SentenceTransformersEmbeddingProvider(
+        config={}, event_sink=_bad_sink,
+    )
+    # Should NOT raise — the sink's exception is swallowed.
+    result = _run(p.embed(
+        ["x"],
+        "sentence-transformers/all-MiniLM-L6-v2",
+    ))
+    assert result["vectors"]
+
+
+# ── 6. Routing wrapper forwards the sink ─────────────────────────────────────
+
+
+def test_routing_wrapper_forwards_event_sink_to_st_backend(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: a sink passed to RoutingEmbeddingProvider reaches the ST backend.
+
+    The wrapper constructs the ST backend lazily; the sink supplied at
+    the wrapper layer must be forwarded to that lazy construction.
+    """
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    events, sink = _record()
+    from reyn.config import EmbeddingClassSpec, EmbeddingConfig
+    from reyn.embedding.router_provider import RoutingEmbeddingProvider
+
+    cfg = EmbeddingConfig(
+        default_class="local-mini",
+        classes={
+            "local-mini": EmbeddingClassSpec(
+                model="sentence-transformers/all-MiniLM-L6-v2",
+            ),
+        },
+        batch_size=100,
+        max_concurrent_batches=1,
+        max_retries=3,
+        retry_backoff="exponential",
+        tokenizer="cl100k_base",
+    )
+    provider = RoutingEmbeddingProvider(config=cfg, event_sink=sink)
+    _run(provider.embed(["x"], "local-mini"))
+    # Backend was lazily constructed and emitted lifecycle events.
+    assert [k for k, _t, _m in events] == ["status", "skill_done"]
+
+
+# ── 7. get_provider passes the sink through ──────────────────────────────────
+
+
+def test_get_provider_threads_event_sink_through_routing_wrapper(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: ``get_provider("litellm", config, event_sink=…)`` plumbs the sink.
+
+    The factory must hand the sink to the routing wrapper so production
+    callers (= ChatSession) only need to call ``get_provider`` once.
+    """
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    events, sink = _record()
+    from reyn.config import EmbeddingClassSpec, EmbeddingConfig
+    from reyn.embedding import get_provider
+
+    cfg = EmbeddingConfig(
+        default_class="local-mini",
+        classes={
+            "local-mini": EmbeddingClassSpec(
+                model="sentence-transformers/all-MiniLM-L6-v2",
+            ),
+        },
+        batch_size=100,
+        max_concurrent_batches=1,
+        max_retries=3,
+        retry_backoff="exponential",
+        tokenizer="cl100k_base",
+    )
+    provider = get_provider("litellm", cfg, event_sink=sink)
+    _run(provider.embed(["x"], "local-mini"))
+    assert [k for k, _t, _m in events] == ["status", "skill_done"]
+
+
+def test_get_provider_without_event_sink_keeps_backward_compat(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: ``get_provider`` without ``event_sink`` returns a working wrapper.
+
+    Pre-C.3 callers (= those who don't pass the new kwarg) keep working
+    — the wrapper is byte-identical from their POV.
+    """
+    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
+    _FakeST.instances.clear()
+    _install_fake_st(monkeypatch, _FakeST)
+
+    from reyn.config import EmbeddingClassSpec, EmbeddingConfig
+    from reyn.embedding import get_provider
+
+    cfg = EmbeddingConfig(
+        default_class="local-mini",
+        classes={
+            "local-mini": EmbeddingClassSpec(
+                model="sentence-transformers/all-MiniLM-L6-v2",
+            ),
+        },
+        batch_size=100,
+        max_concurrent_batches=1,
+        max_retries=3,
+        retry_backoff="exponential",
+        tokenizer="cl100k_base",
+    )
+    provider = get_provider("litellm", cfg)  # no event_sink kwarg
+    result = _run(provider.embed(["x"], "local-mini"))
+    assert result["vectors"]


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 §Component C.3 implementation. Refs #922.

## Summary

A fresh user installing `pip install 'reyn[local-embed]'` and running `reyn chat` for the first time hits a ~5–10s "silent freeze" while sentence-transformers downloads the ~22 MB MiniLM model. Without progress feedback they may assume the session is hung. This PR plumbs a 3-state lifecycle (status / skill_done / error) through the embedding chain so TUI / chainlit surfaces can render a sticky status row + green-frame done + retry-hint error.

## Lifecycle events

Fired from inside `SentenceTransformersEmbeddingProvider._load()`:

| Kind | When | Meta |
|---|---|---|
| `status` | Before SentenceTransformer ctor (= DL + load about to start) | `model` / `target_dir` / `device` |
| `skill_done` | After successful load | `model` / `dimension` |
| `error` | ImportError (= extras missing) OR ctor exception (= partial cache / network fail) | `model` / `retry_hint` with the exact recovery command |

Retry hints reference the actually-existing recovery surface:
- ImportError → `pip install 'reyn[local-embed]'`
- Ctor failure → `reyn embeddings clear` (= C.2 lands the CLI this PR points at)

## Wiring

```
SentenceTransformersEmbeddingProvider(..., event_sink=callable)  ← new kwarg
RoutingEmbeddingProvider(..., event_sink=callable)               ← forwards
get_provider("litellm", config, event_sink=callable)             ← plumbs through
ChatSession.__init__                                              ← constructs sink
    └── sink emits onto self.events bus as f"embedding_{kind}"
```

`event_sink=None` (= default) is byte-identical to pre-C.3 behaviour. The sink contract is sync + tolerant: exceptions are swallowed inside `_emit` so a buggy sink cannot break embedding loads.

## Thread-safety

`_load` runs under `asyncio.to_thread` when reached via `embed`. The default ChatSession sink calls `events.emit` which is sync + GIL-protected + appends to a list — cross-thread call is safe without `call_soon_threadsafe`. Subscribers that need an event-loop bridge add it themselves (C.4 territory).

## Files changed (5 / +542 / -8)

| File | Notes |
|---|---|
| `src/reyn/embedding/sentence_transformers_provider.py` | `EventSink` type + kwarg + `_emit` helper + 3-event instrumented `_load` |
| `src/reyn/embedding/router_provider.py` | `event_sink` kwarg + forward to ST backend on lazy construction |
| `src/reyn/embedding/__init__.py` | `get_provider` `event_sink` kwarg + conditional pass-through |
| `src/reyn/chat/session.py` | Constructs sink that wraps `events.emit`; passes to `get_provider` |
| `tests/test_embedding_dl_progress_events.py` | NEW — 9 Tier-2 tests |

## Test plan

- [x] `pytest tests/test_embedding_dl_progress_events.py`: 9 passed
- [x] `pytest tests/test_embedding_sentence_transformers_provider.py tests/test_embedding_router_provider.py tests/test_embedding_provider.py`: 69 passed (= backward compat)
- [x] `pytest -q --ignore=.claude` from rootdir: **5899 passed**, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` — HTML extraction, unrelated)
- [x] `ruff check` on changed files: clean
- [x] `grep -nE 'assert .*\._[a-z_]+' tests/test_embedding_dl_progress_events.py`: 0 hits ([[feedback_tier4_private_state_repeat_6_round]] mitigation applied at write time)
- [ ] Manual smoke: install `reyn[local-embed]` extras, run `reyn chat` with `embedding_class: local-mini` set, observe `embedding_status` / `embedding_skill_done` events on the events bus during the first turn. C.4 will surface them in the TUI.

## Tier rule self-check

- All test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 violations (= no `Mock` / `MagicMock` / `AsyncMock`; no private state assertion; no format-pinning; no snapshot)
- Tests install a real-shape `sentence_transformers` module via `monkeypatch.setitem(sys.modules, ...)` so the import + load path runs end-to-end without the heavy real dep. `_FakeST` mirrors the constructor signature + dimension API; `_ExplodingST` exercises the load-failure path.
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced

## Relationship to other work

- **FP-0043 (#922)** §Component C.3 — this PR is the implementation.
- **#929** (sentence-transformers backend, merged): the lazy `_load` this PR instruments was added there.
- **#931** (Component E, merged): the cache + lock infrastructure the error retry-hint references.
- **#936** (C.1 list_actions hidden-state hint, merged): user with NO embedding class → C.1 fires. User WITH a class but extras missing OR mid-download → C.3's error / status events fire.
- **#937** (C.2 reyn embeddings CLI, merged): operator-side surface; the C.3 retry-hint `reyn embeddings clear` references the C.2 subcommand.
- **C.4** (TUI Memory tab integration) — follow-up PR; subscribes to `embedding_{status,skill_done,error}` events on the bus this PR feeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)