### PR TITLE
dogfood(scenarios): F2 — drop skill_run_spawned from mcp_install scenarios post-#918

### DIFF
--- a/dogfood/scenarios/multi_agent_and_mcp.yaml
+++ b/dogfood/scenarios/multi_agent_and_mcp.yaml
@@ -157,14 +157,20 @@ scenarios:
 
   # ── 6. MCP install permission gate ───────────────────────────────────────
   # B54 R-5a redesign (2026-05-25): "mentions permission approval step"
-  # content rubric removed — permission gate fires INSIDE the skill, not in
-  # the LLM reply. The structural test (= mcp_install skill spawned) is
-  # what catches permission-gate regression. LLM mention of permission was
-  # over-strict content requirement, not a real Reyn behavior test.
+  # content rubric removed — permission gate fires INSIDE the install
+  # flow, not in the LLM reply. LLM mention of permission was over-strict
+  # content requirement, not a real Reyn behavior test.
+  #
+  # F2 (2026-05-27): post-PR-#918 mcp install 3-verb split removed the
+  # ``mcp_install`` stdlib skill in favour of the
+  # ``mcp__install_registry`` / ``mcp__install_package`` /
+  # ``mcp__install_local`` verb handlers (= op_runtime direct, no skill
+  # spawn). ``skill_run_spawned`` no longer fires for install; structural
+  # signal narrows to ``routing_decided`` + the behavioural rubric. The
+  # ``stdlib-skills/mcp-install`` cover tag is dropped accordingly.
   - id: mcp_install_permission_gate
     covers:
       - mcp/mcp-install
-      - stdlib-skills/mcp-install
       - permissions/layer-4-interactive-prompt
       - control-ir-ops/mcp-install
     input: "postgres MCP サーバーをインストールして。"
@@ -177,7 +183,6 @@ scenarios:
       events:
         must_emit:
           - { type: routing_decided, count: ">=1" }
-          - { type: skill_run_spawned, count: ">=1" }
       outcome_prediction:
         verified: 0.5
         inconclusive: 0.3

--- a/dogfood/scenarios/permissions_and_safety.yaml
+++ b/dogfood/scenarios/permissions_and_safety.yaml
@@ -50,6 +50,14 @@ scenarios:
       blocked: 0.0
 
   # ── S2: MCP install gate triggers interactive prompt ─────────────────────
+  # F2 (2026-05-27): post-PR-#918 mcp install 3-verb split, the install
+  # action no longer routes through a stdlib skill (= the previous
+  # ``skill_run_spawned`` signal is gone); the new verb handlers call
+  # op_runtime/mcp_install directly. The structural signal we can still
+  # rely on is ``routing_decided`` from the router; the install-success
+  # ``mcp_server_installed`` event is post-prompt and unreliable in batch
+  # mode (= no real user to approve the gate). The judge rubric carries
+  # the behavioural test.
   - id: mcp_install_gate_prompt
     covers:
       - permissions/layer-4-interactive-prompt
@@ -68,10 +76,7 @@ scenarios:
       events:
         must_emit:
           - { type: routing_decided, count: ">=1" }
-          - { type: skill_run_spawned, count: ">=1" }
         must_not_emit: []
-        # intervention_dispatched and mcp_server_installed order depends on
-        # operator config; we assert only the spawned event as reliable.
         sequence: []
       artifacts:
         - { present: true }


### PR DESCRIPTION
**[e2e-coder]** — F2 dispatch from sandbox_2 (via lead-coder relay). Co-author: sandbox_2 (= dispatch + post-#918 framing).

## Problem

PR #918 mcp install 3-verb split + #882 stdlib `mcp_install` skill removal both landed. The `mcp__install_registry` / `mcp__install_package` / `mcp__install_local` handlers now call `op_runtime/mcp_install` directly — no skill is spawned. The previous `skill_run_spawned` event will never fire for install.

Two dogfood scenarios still pinned the pre-collapse structural test:

| Scenario | File |
|---|---|
| `mcp_install_gate_prompt` (W4-S2) | `dogfood/scenarios/permissions_and_safety.yaml` |
| `mcp_install_permission_gate` | `dogfood/scenarios/multi_agent_and_mcp.yaml` |

Both expect `must_emit: [routing_decided, skill_run_spawned]`. Post-#918 the second clause is structurally unreachable → false-positive failures on every dogfood run that hits these scenarios.

## Fix

- Drop `skill_run_spawned` from each scenario's `must_emit`; `routing_decided` stays as the reliable structural signal.
- Drop `stdlib-skills/mcp-install` from `mcp_install_permission_gate.covers` (= the skill no longer exists, so claiming coverage was structurally wrong).
- Update the inline rationale comment in each scenario noting F2 / post-#918 framing so a future reader sees the narrowing reason.

The behavioural rubric (judge-based reply check) is preserved verbatim. The install-success `mcp_server_installed` event would be a candidate must_emit, but it's post-prompt and unreliable in batch mode (= no user to approve the gate), so it's intentionally not added either.

## Files changed (2 / +19 / -9)

| File | Notes |
|---|---|
| `dogfood/scenarios/permissions_and_safety.yaml` | `mcp_install_gate_prompt`: drop `skill_run_spawned`; add F2 / #918 framing comment |
| `dogfood/scenarios/multi_agent_and_mcp.yaml` | `mcp_install_permission_gate`: drop `skill_run_spawned` + `stdlib-skills/mcp-install` cover; add F2 / #918 framing comment |

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open(...))"` on both files: clean parse
- [x] `grep -rn "mcp__install_server\|stdlib-skills/mcp-install" dogfood/scenarios/` after edit: 0 remaining stale refs (`mcp/mcp-install` and `control-ir-ops/mcp-install` remain because the op kind is still `mcp_install`)
- [ ] sandbox_2 pre-fix verify N=5 ($0.10 within the $0.60 budget already approved) once this PR lands — measures the scenario pass rate before vs after the rubric narrowing. Expected: false-positive failure rate drops to 0 (= `skill_run_spawned` no longer asserted), `routing_decided` still fires.

## Attribution

- Dispatch + post-#918 framing — sandbox_2 (dogfood-coder)
- #918 author context (= verb name mapping) + edits + PR — e2e-coder

## Relationship to other work

- **#918** (mcp install 3-verb split, merged): the structural change this rubric is catching up to.
- **#882** (stdlib mcp surface collapse): removed the `mcp_install` skill — the cover-tag drop reflects that.
- **#933** (sandbox_2 B57 retro): the dogfood batch context where the false-positive surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)