### PR TITLE
fix(dogfood): scope chat.compaction config to opt-in workers (closes B55 W1-S4)

### DIFF
--- a/dogfood/batch_b55.yaml
+++ b/dogfood/batch_b55.yaml
@@ -72,6 +72,7 @@ workers:
     n_scenarios: 7
     worktree: /tmp/reyn-worktrees/b55-2
     agent_prefix: dogfood-b55-2-s
+    compaction_grant: true  # B55 retro: opt-in for chat_compactor_auto_trigger
 
   - name: W3
     scenario_set: control_ir_ops.yaml

--- a/dogfood/batch_b56.yaml
+++ b/dogfood/batch_b56.yaml
@@ -73,6 +73,7 @@ workers:
     n_scenarios: 7
     worktree: /tmp/reyn-worktrees/b56-2
     agent_prefix: dogfood-b56-2-s
+    compaction_grant: true  # B55 retro: opt-in for chat_compactor_auto_trigger
 
   - name: W3
     scenario_set: control_ir_ops.yaml

--- a/dogfood/batch_b57.yaml
+++ b/dogfood/batch_b57.yaml
@@ -46,6 +46,7 @@ workers:
     n_scenarios: 7
     worktree: /tmp/reyn-worktrees/b57-2
     agent_prefix: dogfood-b57-2-s
+    compaction_grant: true  # B55 retro: opt-in for chat_compactor_auto_trigger
 
   - name: W3
     scenario_set: control_ir_ops.yaml

--- a/scripts/dogfood_batch_config.py
+++ b/scripts/dogfood_batch_config.py
@@ -91,6 +91,20 @@ class WorkerSpec:
     n_scenarios: int  # caller-declared, validated/overridden against actual scenario yaml at load time
     worktree: str
     agent_prefix: str
+    # B55 retro fix (2026-05-27): the chat.compaction config lowering
+    # introduced for chat_compactor_auto_trigger (PR #880) sets
+    # head_size: 1 / tail_size: 1, which ``_build_history_for_router``
+    # uses on every router LLM call to slice history when len > head+tail.
+    # With 1/1, the slice keeps only the first + last entries — dropping
+    # the assistant tool_call + tool response in the middle. The next
+    # router turn after ``[task_completed]`` then loses the evidence that
+    # the skill was already invoked, and the LLM re-spawns the skill
+    # (= B55 W1-S4 word_stats_demo R verdict; the reply ends as a
+    # spawn-ack instead of the actual stats). Inject the config only on
+    # the worker that actually hosts chat_compactor_auto_trigger; other
+    # workers keep the production-default head/tail (= 12/12) so the
+    # 4-entry skill-spawn turn pattern survives the slicer.
+    compaction_grant: bool = False
 
 
 @dataclass(frozen=True)
@@ -169,6 +183,7 @@ def load_batch_config(path: Path) -> BatchConfig:
             n_scenarios=n_scenarios,
             worktree=w["worktree"],
             agent_prefix=w["agent_prefix"],
+            compaction_grant=bool(w.get("compaction_grant", False)),
         ))
 
     past_batches = tuple(

--- a/scripts/dogfood_batch_dispatch.py
+++ b/scripts/dogfood_batch_dispatch.py
@@ -257,14 +257,28 @@ def setup_worktree(worker: WorkerSpec, head: str, repo_root: Path) -> None:
         "  web.fetch: allow\n"
         "sandbox:\n"
         "  backend: noop\n"
+    )
+    # B55 retro fix (2026-05-27): chat.compaction config lowering is opt-in
+    # per worker via ``compaction_grant: true`` in the batch yaml. Previously
+    # it was injected unconditionally — that cross-impacted unrelated
+    # short-skill scenarios on other workers because the lowered
+    # head_size/tail_size (= 1/1) is consumed by
+    # ``_build_history_for_router`` (session.py:4454), which slices history
+    # to ``head + tail`` whenever ``len(turns) > head + tail``. A normal
+    # skill spawn turn has 4 history entries (user request + assistant
+    # tool_call + tool response + ``[task_completed]``); 1/1 slicing keeps
+    # only the first + last, dropping the assistant turn. The LLM at the
+    # next router call sees only ``[user_request, task_completed]`` and
+    # re-spawns the skill (= B55 W1-S4 R verdict — reply ends as a
+    # spawn-ack instead of the actual stats). Only the worker hosting
+    # chat_compactor_auto_trigger needs the grant.
+    compaction_block = (
         "# B54 R-3 (2026-05-24): chat_compactor needs ~10s of turns to reach\n"
         "# default trigger_total_tokens=30000 via head/tail=12 + min_batch=5.\n"
         "# Lower thresholds so a 5-turn dogfood scenario can trigger the\n"
-        "# CompactionController auto-fire path. Override is additive (= other\n"
-        "# scenarios whose prompts don't grow context don't fire compaction)\n"
-        "# and compaction events are not in any current must_emit /\n"
-        "# must_not_emit rubric outside the chat_compactor_auto_trigger\n"
-        "# scenario, so the change is safe across the rest of the batch.\n"
+        "# CompactionController auto-fire path. Opt-in per worker (B55 retro)\n"
+        "# to avoid cross-impacting short-skill scenarios on workers that do\n"
+        "# not host chat_compactor_auto_trigger.\n"
         "chat:\n"
         "  compaction:\n"
         "    trigger_total_tokens: 2000\n"
@@ -272,6 +286,8 @@ def setup_worktree(worker: WorkerSpec, head: str, repo_root: Path) -> None:
         "    tail_size: 1\n"
         "    min_compact_batch: 2\n"
     )
+    if worker.compaction_grant:
+        runner_grants = runner_grants + compaction_block
     if "Dogfood worker env grants" not in text:
         text = text.rstrip() + "\n" + runner_grants
     dst.write_text(text)

--- a/tests/test_dogfood_batch_compaction_grant_opt_in.py
+++ b/tests/test_dogfood_batch_compaction_grant_opt_in.py
@@ -35,7 +35,6 @@ from pathlib import Path
 
 import pytest
 
-
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))

--- a/tests/test_dogfood_batch_compaction_grant_opt_in.py
+++ b/tests/test_dogfood_batch_compaction_grant_opt_in.py
@@ -1,0 +1,193 @@
+"""Tier 2: ``compaction_grant`` is opt-in per worker (B55 retro fix).
+
+Pinned invariants:
+
+- ``WorkerSpec.compaction_grant`` defaults to ``False`` when the batch
+  yaml entry omits the field (= backwards compat with batch_b4*.yaml
+  and pre-B55 configs).
+- When the batch yaml sets ``compaction_grant: true`` on a worker, the
+  loader returns ``WorkerSpec.compaction_grant == True``.
+- ``setup_worktree`` injects the ``chat.compaction`` block into the
+  worker's ``reyn.local.yaml`` **only** when
+  ``worker.compaction_grant`` is True.
+- The ``permissions`` + ``sandbox`` env grant block (= B52 retro) is
+  unconditional and remains injected regardless of the compaction flag.
+
+Motivation: B55 W1-S4 word_stats_demo R verdict was caused by the
+``chat.compaction`` config lowering (PR #880) being injected into every
+worker's ``reyn.local.yaml``. Compaction_check fired mid-flow on a
+short-skill scenario that didn't need it, partially compacted the
+post-spawn context, and the final reply LLM ended up re-spawning the
+skill instead of synthesising from the artifact. The grant is needed
+only by the worker hosting ``chat_compactor_auto_trigger``, hence
+opt-in.
+
+testing.ja.md compliance:
+- No mocks. Real ``load_batch_config`` against tmp_path yamls and
+  real ``setup_worktree`` writing to a tmp directory.
+- No private-state assertions; pins ``WorkerSpec.compaction_grant``
+  and the on-disk ``reyn.local.yaml`` content.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from dogfood_batch_config import WorkerSpec, load_batch_config  # noqa: E402
+from dogfood_batch_dispatch import setup_worktree  # noqa: E402
+
+
+def _write_scenario_yaml(path: Path) -> None:
+    path.write_text(
+        "metadata:\n  name: test\nscenarios:\n"
+        "  - id: scen_0\n    input: hello\n    expected: world\n",
+        encoding="utf-8",
+    )
+
+
+def _write_batch_yaml(
+    path: Path,
+    scenario_yaml_path: str,
+    *,
+    compaction_grant: bool | None,
+) -> None:
+    """Write a minimal batch yaml; optionally include compaction_grant."""
+    grant_field = (
+        f"    compaction_grant: {'true' if compaction_grant else 'false'}\n"
+        if compaction_grant is not None
+        else ""
+    )
+    path.write_text(
+        f"""batch:
+  name: TEST
+  date: "2026-05-27"
+  head: deadbeef
+workers:
+  - name: W2
+    scenario_set: test_set
+    scenario_set_path: {scenario_yaml_path}
+    port: 8001
+    worktree: /tmp/test-wt
+    agent_prefix: test-w2-s
+{grant_field}past_batches: []
+journal_dir: /tmp/test-journal
+""",
+        encoding="utf-8",
+    )
+
+
+# ── Loader contract ──────────────────────────────────────────────────────
+
+
+def test_omitted_compaction_grant_defaults_to_false(tmp_path):
+    """Tier 2: batch yaml may omit ``compaction_grant`` entirely; the
+    loader defaults to False so legacy batch configs preserve the
+    pre-B55-retro behaviour of *not* injecting the compaction block."""
+    scen = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen)
+    batch = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch, str(scen), compaction_grant=None)
+
+    cfg = load_batch_config(batch)
+    assert cfg.workers[0].compaction_grant is False
+
+
+def test_explicit_compaction_grant_true_is_respected(tmp_path):
+    """Tier 2: ``compaction_grant: true`` propagates to ``WorkerSpec``."""
+    scen = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen)
+    batch = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch, str(scen), compaction_grant=True)
+
+    cfg = load_batch_config(batch)
+    assert cfg.workers[0].compaction_grant is True
+
+
+def test_explicit_compaction_grant_false_is_respected(tmp_path):
+    """Tier 2: ``compaction_grant: false`` is the same as omitting it
+    (= both produce the default off-by-default behaviour)."""
+    scen = tmp_path / "scenarios.yaml"
+    _write_scenario_yaml(scen)
+    batch = tmp_path / "batch.yaml"
+    _write_batch_yaml(batch, str(scen), compaction_grant=False)
+
+    cfg = load_batch_config(batch)
+    assert cfg.workers[0].compaction_grant is False
+
+
+# ── setup_worktree behaviour ────────────────────────────────────────────
+
+
+def _mk_repo_and_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Set up a minimal repo + pre-existing worktree dir.
+
+    ``setup_worktree`` only invokes ``git worktree add`` when the dir
+    doesn't already exist, so pre-creating the dir bypasses the git
+    call in tests (= no real git operations needed)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "reyn.local.yaml").write_text(
+        "models:\n  strong:   openai/gemini-2.5-flash\n",
+        encoding="utf-8",
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    return repo, wt
+
+
+def _mk_worker(wt: Path, *, compaction_grant: bool) -> WorkerSpec:
+    return WorkerSpec(
+        name="W2",
+        scenario_set="x",
+        scenario_set_path="x",
+        port=1,
+        n_scenarios=1,
+        worktree=str(wt),
+        agent_prefix="x",
+        compaction_grant=compaction_grant,
+    )
+
+
+def test_setup_worktree_injects_compaction_when_granted(tmp_path):
+    """Tier 2: when ``compaction_grant=True``, the worker's
+    ``reyn.local.yaml`` contains the ``chat.compaction`` block with
+    ``trigger_total_tokens: 2000``."""
+    repo, wt = _mk_repo_and_worktree(tmp_path)
+    setup_worktree(_mk_worker(wt, compaction_grant=True), "HEAD", repo)
+
+    yaml_text = (wt / "reyn.local.yaml").read_text()
+    assert "chat:" in yaml_text
+    assert "compaction:" in yaml_text
+    assert "trigger_total_tokens: 2000" in yaml_text
+
+
+def test_setup_worktree_omits_compaction_without_grant(tmp_path):
+    """Tier 2: when ``compaction_grant=False`` (= default), the worker's
+    ``reyn.local.yaml`` does NOT contain the ``chat.compaction`` block
+    so unrelated short-skill scenarios on the worker run with the
+    production-default ``trigger_total_tokens: 30000``."""
+    repo, wt = _mk_repo_and_worktree(tmp_path)
+    setup_worktree(_mk_worker(wt, compaction_grant=False), "HEAD", repo)
+
+    yaml_text = (wt / "reyn.local.yaml").read_text()
+    assert "trigger_total_tokens" not in yaml_text
+    assert "chat:\n  compaction:" not in yaml_text
+
+
+def test_setup_worktree_b52_grants_unconditional(tmp_path):
+    """Tier 2: the B52 retro grants (``permissions: web.fetch`` and
+    ``sandbox: backend: noop``) inject regardless of compaction grant
+    because they're per-worker env requirements unrelated to compaction."""
+    repo, wt = _mk_repo_and_worktree(tmp_path)
+    setup_worktree(_mk_worker(wt, compaction_grant=False), "HEAD", repo)
+
+    yaml_text = (wt / "reyn.local.yaml").read_text()
+    assert "web.fetch: allow" in yaml_text
+    assert "backend: noop" in yaml_text


### PR DESCRIPTION
**[dogfood-coder]** — F1 fix for B55 W1-S4 word_stats_demo R verdict. lead-coder dispatched as part of Tier C1 axis 2 (= B55 regressions root cause). User approved $0.60 verify-first budget; actual cost ~$0.10.

## Root cause (= primary evidence)

PR #880 (= chat_compactor_auto_trigger scenario redesign) added a runner_grants block that **unconditionally** injected the lowered ``chat.compaction`` config (= ``trigger_total_tokens: 2000``, ``head_size: 1``, ``tail_size: 1``, ``min_compact_batch: 2``) into every worker's ``reyn.local.yaml``.

The destructive vector is **NOT** the auto-compaction batch trigger (= ``compaction_check`` fired in B55 W1-S4 with ``outcome=below_min_batch``, a no-op). It is ``_build_history_for_router`` at \`src/reyn/chat/session.py:4454\`:

\`\`\`python
if len(turns) <= cfg.head_size + cfg.tail_size:
    selected = turns
else:
    head = turns[:cfg.head_size]   # head_size=1 → [user_request]
    tail = turns[-cfg.tail_size:]  # tail_size=1 → [task_completed]
    selected = head + tail         # ← assistant tool_call + tool response ELIDED
\`\`\`

Skill spawn flow produces 4 history entries (user request + assistant tool_call + tool response + ``[task_completed]``). At 1/1 the slicer drops the assistant turn. The next router call sees only ``[user_request, task_completed]``, has no record of the prior invoke, and the LLM **re-invokes** the same skill → final user-visible reply is a 2nd spawn-ack instead of the actual stats.

### Primary evidence

- B55 W1-S4 history.jsonl: 10 entries preserved (= chat history file is correct)
- B55 W1-S4 llm_trace.jsonl entry 18 (post-task_completed router call): **only 3 messages** (= slicer dropped middle entries)
- Code path direct read confirms head + tail slicing on every router LLM call regardless of token count
- ``compaction_check`` event outcome ``below_min_batch`` rules out the auto-compaction batch trigger as the mechanism

## Fix

Add ``compaction_grant: bool = False`` to ``WorkerSpec``. Only inject the chat.compaction block when the worker explicitly opts in via ``compaction_grant: true`` in the batch yaml. Only the worker that hosts ``chat_compactor_auto_trigger`` (= W2 in current batch shape) needs the grant; other workers keep the production-default head/tail (= 12/12) so skill-spawn turns survive the slicer.

### Files

- ``scripts/dogfood_batch_config.py``: ``WorkerSpec.compaction_grant`` field + loader reads ``compaction_grant: bool`` from worker yaml
- ``scripts/dogfood_batch_dispatch.py``: conditional injection of compaction block based on ``worker.compaction_grant``
- ``dogfood/batch_b55.yaml`` / ``b56.yaml`` / ``b57.yaml``: explicit ``compaction_grant: true`` on W2 to preserve re-run reproducibility
- ``tests/test_dogfood_batch_compaction_grant_opt_in.py``: 6 Tier 2 tests pinning loader contract + setup_worktree behavior

## Verify (= trace-patch-replay, ~\$0.10 actual cost, \$0.50 budget)

B55 W1-S4 request_id \`9ca44585-7b99-4243-bc43-b7e788eb7e34\` (gemini-2.5-flash-lite via LiteLLM proxy):

| Variant | invoke_action | stop (= compose reply) |
|---|---|---|
| Baseline (3-msg sliced history) | **2/3 (67%)** | 1/3 |
| Patched (5-msg full history) | **0/5** | **5/5** |

Patched reply content (sample run): \`"The text you provided has been analyzed. It contains 9 words and 44 characters."\` → matches B55 W1-S4 rubric (= \`"9 words"\`, \`"44 characters"\`) → V verdict.

## Process correction

My initial Axis 2 analysis (broker, 2026-05-27) misattributed the mechanism to "compaction wiped context". On pre-fix verification I directly inspected the events.jsonl and discovered \`compaction_check\` outcome was \`below_min_batch\` (= no-op). Honest correction sent to user, who directed deep-dive over land — that deep-dive surfaced the actual mechanism (= the head/tail slicer in \`_build_history_for_router\`). Per \`[[feedback_pre_conclusion_observation_checklist]]\`: event-type-only extrapolation downgraded to hypothesis until event-data inspection.

## Out of scope

- ``_build_history_for_router`` slicer robustness against the 4-entry skill-spawn pattern (= production-side fix that would make head/tail=1/1 safe). Considered, but config-layer scope-restrict is minimal and reverts to a known-good default for non-compaction workers.
- W2-S2 / W4-S6 / W6-S1 B55 regressions (= F3 / LLM noise) — separate.
- W4-S2 (= F2) already landed via PR #940 (e2e-coder).

## Tier rule self-check

- [x] All test \`Tier 2:\` docstring prefix 済
- [x] Tier 4 violations 0 (= no private-state assertions; pins ``WorkerSpec.compaction_grant`` + on-disk yaml content)
- [x] No mocks (= real ``load_batch_config`` + real ``setup_worktree`` writing to ``tmp_path``)
- [x] No format-pinning on algorithm output

## Test plan

- [x] \`venv/bin/pytest tests/test_dogfood_batch_compaction_grant_opt_in.py\` → 6 passed
- [x] \`venv/bin/pytest tests/test_dogfood_batch_config_scenario_count_autoderive.py tests/test_dogfood_batch_tools.py\` → 20 passed (no regression in adjacent loader tests)
- [x] Trace-patch-replay verify (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)