### PR TITLE
feat(tui): FP-0043 Component C.4 — Memory tab Embeddings section + C.3 hotfix

### DIFF
--- a/src/reyn/chat/lifecycle_forwarder.py
+++ b/src/reyn/chat/lifecycle_forwarder.py
@@ -97,6 +97,49 @@ class ChatLifecycleForwarder:
             pct_part = ""
         self._enqueue(f"[↑ budget warn: {dim}{pct_part}]")
 
+    # ── Embedding model load lifecycle (FP-0043 C.3 → C.4) ───────────────
+    #
+    # C.3 added three ``embedding_*`` events on the chat_events bus
+    # (``status`` / ``skill_done`` / ``error``) covering the lazy
+    # sentence-transformers model download + load. C.4 forwards them to
+    # the chat outbox as structured signals so the TUI Memory tab can
+    # render a sticky status row + green "done" frame + retry-hint
+    # error row without polling. The outbox payload preserves the full
+    # meta dict (= model, target_dir, device, dimension, retry_hint
+    # depending on kind); the conv pane suppresses these kinds at
+    # display time — they're data signals for the right-panel
+    # subscriber, not chat-stream lines.
+
+    def on_embedding_status(self, data: dict) -> None:
+        """Forward ``embedding_status`` (= DL/load starting) to outbox."""
+        self._forward_embedding("embedding_status", data)
+
+    def on_embedding_skill_done(self, data: dict) -> None:
+        """Forward ``embedding_skill_done`` (= load completed) to outbox."""
+        self._forward_embedding("embedding_skill_done", data)
+
+    def on_embedding_error(self, data: dict) -> None:
+        """Forward ``embedding_error`` (= load failed; retry_hint inline) to outbox."""
+        self._forward_embedding("embedding_error", data)
+
+    def _forward_embedding(self, kind: str, data: dict) -> None:
+        """Common forwarder for embedding lifecycle events.
+
+        Preserves the full meta dict so the Memory tab subscriber can
+        surface ``model`` / ``device`` / ``dimension`` / ``retry_hint``
+        as appropriate per ``kind``. Falls back to an empty text since
+        these kinds are data signals (= the structured ``meta`` is the
+        load-bearing payload).
+        """
+        text = str(data.get("text", "") or "")
+        meta = {k: v for k, v in data.items() if k != "text"}
+        try:
+            self.outbox.put_nowait(OutboxMessage(
+                kind=kind, text=text, meta=meta,
+            ))
+        except asyncio.QueueFull:
+            pass
+
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
     def on_compaction_completed(self, data: dict) -> None:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1297,16 +1297,29 @@ class ChatSession:
                 # is called from the embed worker thread; events.emit is
                 # GIL-protected + sync so this is safe without a
                 # call_soon_threadsafe bridge.
-                _events = self.events
-
+                #
+                # C.4 hotfix (2026-05-27): the sink closure resolves
+                # ``self._chat_events`` at *call* time, not at
+                # construction time — the EventLog is built later in
+                # __init__ (= line ~1482). The previous C.3 wiring
+                # captured ``self.events`` (= attribute that does NOT
+                # exist on ChatSession), which silently raised
+                # AttributeError at this point and the outer ``except``
+                # swallowed it, disabling search_actions for every
+                # operator who had ``embedding_class`` set. Mirrors the
+                # ``_on_hot_list_changed`` closure pattern in the
+                # ActionUsageTracker setup below.
                 def _embedding_event_sink(
                     kind: str, text: str, meta: dict,
                 ) -> None:
-                    _events.emit(
-                        f"embedding_{kind}",
-                        text=text,
-                        **meta,
-                    )
+                    try:
+                        self._chat_events.emit(
+                            f"embedding_{kind}",
+                            text=text,
+                            **meta,
+                        )
+                    except Exception:
+                        pass
 
                 self._embedding_provider = _get_provider(
                     "litellm",

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -21,7 +21,7 @@ Design:
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.chat.outbox import OutboxMessage
 
@@ -260,6 +260,12 @@ class OutboxRouter:
             # workflow_aborted events) and handled in app._handle_trace_for_skill_row.
             "error":                    self._on_error,
             "hot_list_updated":         self._on_hot_list_updated,
+            # FP-0043 Component C.4 — embedding model-load lifecycle.
+            # The 3 kinds share an update path on the right panel; the
+            # Memory tab renders the cached snapshot via render_memory.
+            "embedding_status":         self._on_embedding_lifecycle,
+            "embedding_skill_done":     self._on_embedding_lifecycle,
+            "embedding_error":          self._on_embedding_lifecycle,
             # Issue #427 step 4: tool-call lifecycle from ChatEventForwarder
             # (= step 3). Mount a ToolCallRow on _started, finalise
             # on _completed / _failed, keyed by op_id.
@@ -1486,6 +1492,33 @@ class OutboxRouter:
             reason = error_kind or error_msg or "failed"
         try:
             conv.fail_tool_call_row(op_id, error=reason)
+        except Exception:
+            pass
+
+    def _on_embedding_lifecycle(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """FP-0043 C.4 — embedding model-load lifecycle → right panel cache.
+
+        Handles the 3 ``embedding_status`` / ``embedding_skill_done`` /
+        ``embedding_error`` outbox kinds (= forwarded by
+        ``ChatLifecycleForwarder``). Pushes a snapshot dict to the
+        ``RightPanel`` whose Memory tab renders an Embeddings end-section
+        with current model + state + retry hint. The conv pane
+        intentionally suppresses these kinds at display time — they are
+        data signals for the right-panel subscriber, not chat lines.
+        """
+        state: dict[str, Any] = {
+            "kind": msg.kind,  # "embedding_status" / "_skill_done" / "_error"
+            "text": msg.text,
+        }
+        if msg.meta:
+            state.update(msg.meta)
+        try:
+            from .widgets import RightPanel
+            self._app.query_one(
+                "#right_panel", RightPanel,
+            ).update_embedding_state(state)
         except Exception:
             pass
 

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -192,6 +192,13 @@ class RightPanel(Widget):
         # list is non-empty; otherwise the section is omitted entirely
         # so the existing layout is unchanged on cold-start.
         self._hot_list_ranking: list[dict] = []
+
+        # FP-0043 C.4 — cached embedding model-load lifecycle snapshot.
+        # Fed by ``update_embedding_state`` (= driven from
+        # ``OutboxRouter._on_embedding_lifecycle``). Memory tab reads it
+        # when next painting; ``None`` = no embedding activity observed
+        # this session (= operator default, search_actions hidden).
+        self._embedding_state: dict | None = None
         # y-coord (0-indexed line) of each memory entry's name row in the
         # rendered output. Populated by `render_memory`; used by
         # `_scroll_memory_into_view` to keep the cursor visible as j/k
@@ -388,6 +395,21 @@ class RightPanel(Widget):
         the next paint of any other tab via the same field.
         """
         self._hot_list_ranking = list(ranking)
+        if self._panel_type == "memory":
+            self._invalidate()
+
+    def update_embedding_state(self, state: dict) -> None:
+        """FP-0043 C.4 — cache the embedding model-load lifecycle snapshot.
+
+        Called from ``OutboxRouter._on_embedding_lifecycle`` whenever
+        the lifecycle forwarder emits ``embedding_status`` /
+        ``embedding_skill_done`` / ``embedding_error``. The cached
+        snapshot is consumed by ``render_memory`` to render the
+        Embeddings end-section (= current model + state + retry hint
+        on failure). Mirrors the ``update_hot_list`` invalidation
+        pattern: refresh only when the Memory tab is currently visible.
+        """
+        self._embedding_state = dict(state)
         if self._panel_type == "memory":
             self._invalidate()
 
@@ -2419,6 +2441,7 @@ class RightPanel(Widget):
                     cursor=self._memory_cursor,
                     hot_list=self._hot_list_ranking,
                     type_filter=self._memory_type_filter,
+                    embedding_state=self._embedding_state,
                 )
                 self._memory_entries = flat_entries
                 self._memory_entry_ys = entry_ys

--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -49,6 +49,7 @@ def render_memory(
     cursor: int = 0,
     hot_list: list[dict] | None = None,
     type_filter: str | None = None,
+    embedding_state: dict | None = None,
 ) -> tuple[str, list[Any], list[int]]:
     """Return Rich markup + the flat ordered list of MemoryEntry items
     + the y-coordinate (= 0-indexed line number) of each entry's name row.
@@ -69,6 +70,14 @@ def render_memory(
     turn. The hot list is **not** part of ``flat_entries`` — entries
     listed there are MemoryEntry items, and the hot list carries
     qualified action names which are a different kind of object.
+
+    ``embedding_state`` (FP-0043 C.4): the latest snapshot from the
+    sentence-transformers lazy-load lifecycle, forwarded by
+    ``ChatLifecycleForwarder.on_embedding_{status,skill_done,error}``.
+    When present, an ``EMBEDDINGS`` end-section renders below SHARED /
+    AGENT showing the current state — "loading…", "loaded · Nd", or
+    "error · <retry hint>". The state is also NOT part of
+    ``flat_entries`` (= metadata, not a navigable memory entry).
     """
     if project_root is None:
         return "[#555555]  (no project root)[/]", [], []
@@ -207,7 +216,73 @@ def render_memory(
             agent_entries = list_entries(mem_dir)
             _render_scope(agent_entries, f"AGENT  {agent_dir.name}", "#7a9fc7")
 
+    # FP-0043 C.4 — Embedding model-load lifecycle section. Renders
+    # only when an event has been observed this session; absent state
+    # means "operator hasn't enabled embedding_class" (= the §C.1
+    # list_actions hint covers that path on the LLM side), so the TUI
+    # stays quiet rather than displaying a permanent "(none)" line.
+    if embedding_state:
+        _render_embedding_section(lines, embedding_state)
+
     return "\n".join(lines), flat_entries, entry_ys
+
+
+def _render_embedding_section(
+    lines: list[str], state: dict,
+) -> None:
+    """Append the EMBEDDINGS section reflecting the latest lifecycle event.
+
+    Three shapes per ``state["kind"]``:
+
+      embedding_status     loading… · <model> · <device>
+      embedding_skill_done loaded · <model> · <dimension>d
+      embedding_error      error · <model> · <retry_hint truncated>
+
+    The model string is shortened (= drop the ``sentence-transformers/``
+    prefix when present) so it fits a narrow right panel.
+    """
+    kind = str(state.get("kind", "") or "")
+    model_raw = str(state.get("model", "") or "")
+    model = model_raw[len("sentence-transformers/"):] if model_raw.startswith(
+        "sentence-transformers/",
+    ) else model_raw
+
+    lines.append("[bold #6aa9c7]  EMBEDDINGS[/]")
+    if kind == "embedding_status":
+        device = str(state.get("device", "") or "")
+        device_part = f" · {_esc(device)}" if device else ""
+        model_part = f" · {_esc(model)}" if model else ""
+        lines.append(
+            f"[#888888]    ⟳ loading…[/][#aaaaaa]{model_part}{device_part}[/]"
+        )
+    elif kind == "embedding_skill_done":
+        try:
+            dim = int(state.get("dimension", 0))
+        except (TypeError, ValueError):
+            dim = 0
+        dim_part = f" · {dim}d" if dim > 0 else ""
+        model_part = f" · {_esc(model)}" if model else ""
+        lines.append(
+            f"[#44cc88]    ✓ loaded[/][#cccccc]{model_part}{dim_part}[/]"
+        )
+    elif kind == "embedding_error":
+        hint_raw = str(state.get("retry_hint", "") or "")
+        # Truncate the retry hint so it survives the ~33%-panel
+        # default width; the full text is in the events tab.
+        max_hint = 60
+        hint = hint_raw if len(hint_raw) <= max_hint else hint_raw[:max_hint - 1].rstrip() + "…"
+        model_part = f" · {_esc(model)}" if model else ""
+        lines.append(
+            f"[#ff6666]    ✗ error[/][#dddddd]{model_part}[/]"
+        )
+        if hint:
+            lines.append(f"[#aaaaaa]      {_esc(hint)}[/]")
+    else:
+        # Unknown kind from a future emitter — show the raw text as a
+        # graceful fallback rather than rendering nothing at all.
+        text = str(state.get("text", "") or "(no detail)")
+        lines.append(f"[#888888]    {_esc(text)}[/]")
+    lines.append("")
 
 
 __all__ = ["render_memory"]

--- a/tests/test_tui_memory_embedding_section.py
+++ b/tests/test_tui_memory_embedding_section.py
@@ -1,0 +1,256 @@
+"""Tier 2: FP-0043 Component C.4 — TUI Memory tab embedding section contract.
+
+Pins the surface invariants from end to end:
+
+  Producer side (ChatLifecycleForwarder):
+    1. ``on_embedding_status`` / ``on_embedding_skill_done`` /
+       ``on_embedding_error`` each emit an ``OutboxMessage`` carrying the
+       full meta dict so the TUI Memory tab subscriber sees ``model`` /
+       ``device`` / ``dimension`` / ``retry_hint`` as appropriate.
+    2. The outbox kind matches the event-type prefix so the TUI handler
+       dispatch table routes correctly.
+
+  Renderer side (render_memory + _render_embedding_section):
+    3. No ``embedding_state`` → no EMBEDDINGS section in the output.
+    4. ``embedding_status`` state → "loading…" row with model + device.
+    5. ``embedding_skill_done`` state → "loaded" row with model + dim.
+    6. ``embedding_error`` state → "error" row plus retry-hint subline
+       (truncated to fit narrow panel).
+    7. The ``sentence-transformers/`` prefix is dropped from model
+       strings so wide HF ids fit a default-width panel.
+
+No mocks. Tests use a real ``ChatLifecycleForwarder`` against a real
+``asyncio.Queue``, and call ``render_memory`` directly with a tmp
+project root.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.chat.lifecycle_forwarder import ChatLifecycleForwarder
+from reyn.chat.tui.widgets.right_panel.memory_tab import render_memory
+from reyn.schemas.models import Event
+
+
+def _make_forwarder() -> tuple[ChatLifecycleForwarder, asyncio.Queue]:
+    """Build a forwarder + the asyncio.Queue it pushes outbox messages into."""
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        outbox: asyncio.Queue = asyncio.Queue()
+    finally:
+        loop.close()
+    return ChatLifecycleForwarder(outbox), outbox
+
+
+def _drain(queue: asyncio.Queue) -> list[Any]:
+    """Pop all items currently in the queue without awaiting."""
+    items: list[Any] = []
+    while True:
+        try:
+            items.append(queue.get_nowait())
+        except asyncio.QueueEmpty:
+            break
+    return items
+
+
+# ── 1. Lifecycle forwarder emits OutboxMessage with full meta ────────────────
+
+
+def test_on_embedding_status_emits_outbox_message_with_meta() -> None:
+    """Tier 2: ``embedding_status`` event → outbox kind preserves meta."""
+    fwd, outbox = _make_forwarder()
+    fwd(Event(type="embedding_status", data={
+        "text": "loading model X",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "target_dir": "/tmp/cache/sentence-transformers",
+        "device": "cpu",
+    }))
+    msgs = _drain(outbox)
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert msg.kind == "embedding_status"
+    assert msg.text == "loading model X"
+    assert msg.meta["model"] == "sentence-transformers/all-MiniLM-L6-v2"
+    assert msg.meta["device"] == "cpu"
+    assert msg.meta["target_dir"] == "/tmp/cache/sentence-transformers"
+
+
+def test_on_embedding_skill_done_emits_outbox_message_with_dimension() -> None:
+    """Tier 2: ``embedding_skill_done`` carries ``dimension`` for UX."""
+    fwd, outbox = _make_forwarder()
+    fwd(Event(type="embedding_skill_done", data={
+        "text": "loaded",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "dimension": 384,
+    }))
+    msgs = _drain(outbox)
+    assert len(msgs) == 1 and msgs[0].kind == "embedding_skill_done"
+    assert msgs[0].meta["dimension"] == 384
+
+
+def test_on_embedding_error_emits_outbox_message_with_retry_hint() -> None:
+    """Tier 2: ``embedding_error`` carries ``retry_hint`` for self-correction."""
+    fwd, outbox = _make_forwarder()
+    fwd(Event(type="embedding_error", data={
+        "text": "failed to load",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "retry_hint": "Run `reyn embeddings clear` to wipe partial state.",
+    }))
+    msgs = _drain(outbox)
+    assert len(msgs) == 1 and msgs[0].kind == "embedding_error"
+    assert "reyn embeddings clear" in msgs[0].meta["retry_hint"]
+
+
+# ── 2. Renderer suppresses section when no state observed ────────────────────
+
+
+def test_render_memory_omits_embedding_section_when_state_none(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``embedding_state=None`` (= default) → no EMBEDDINGS section."""
+    rendered, _entries, _ys = render_memory(
+        tmp_path, embedding_state=None,
+    )
+    assert "EMBEDDINGS" not in rendered
+
+
+def test_render_memory_omits_embedding_section_when_state_missing_kwarg(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: caller may omit the new kwarg entirely (= forward compat)."""
+    rendered, _entries, _ys = render_memory(tmp_path)
+    assert "EMBEDDINGS" not in rendered
+
+
+# ── 3. Renderer surfaces each lifecycle kind correctly ───────────────────────
+
+
+def test_render_memory_status_shows_loading_with_model_and_device(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``embedding_status`` → loading row carrying model + device."""
+    state = {
+        "kind": "embedding_status",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "device": "cpu",
+        "target_dir": "/tmp/cache",
+    }
+    rendered, _, _ = render_memory(tmp_path, embedding_state=state)
+    assert "EMBEDDINGS" in rendered
+    assert "loading" in rendered
+    # ST prefix dropped so the model fits a narrow panel.
+    assert "all-MiniLM-L6-v2" in rendered
+    assert "sentence-transformers/" not in rendered
+    assert "cpu" in rendered
+
+
+def test_render_memory_skill_done_shows_loaded_with_dimension(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``embedding_skill_done`` → loaded row + Nd dimension suffix."""
+    state = {
+        "kind": "embedding_skill_done",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "dimension": 384,
+    }
+    rendered, _, _ = render_memory(tmp_path, embedding_state=state)
+    assert "loaded" in rendered
+    assert "384d" in rendered
+    assert "all-MiniLM-L6-v2" in rendered
+
+
+def test_render_memory_error_shows_retry_hint_subline(tmp_path: Path) -> None:
+    """Tier 2: ``embedding_error`` → error row + truncated retry-hint subline."""
+    state = {
+        "kind": "embedding_error",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "retry_hint": (
+            "Run `reyn embeddings clear` to wipe the cache + check "
+            "network connectivity + retry."
+        ),
+    }
+    rendered, _, _ = render_memory(tmp_path, embedding_state=state)
+    assert "error" in rendered
+    # Hint is included (possibly truncated at the panel-width boundary).
+    assert "reyn embeddings clear" in rendered
+
+
+def test_render_memory_truncates_very_long_retry_hint(tmp_path: Path) -> None:
+    """Tier 2: a 200-char retry hint is truncated with an ellipsis suffix.
+
+    Default panel width is ~33% of the terminal; long hints would wrap
+    awkwardly and obscure other entries. The Events tab carries the
+    full text.
+    """
+    long_hint = (
+        "Run `reyn embeddings clear` to wipe the cache, then "
+        + ("verify network and ensure proxy is reachable. " * 5)
+    )
+    state = {
+        "kind": "embedding_error",
+        "model": "x",
+        "retry_hint": long_hint,
+    }
+    rendered, _, _ = render_memory(tmp_path, embedding_state=state)
+    # Truncation marker present; the full long_hint is NOT verbatim.
+    assert "…" in rendered or long_hint not in rendered
+
+
+def test_render_memory_handles_non_st_prefixed_model(tmp_path: Path) -> None:
+    """Tier 2: a non-``sentence-transformers/`` model passes through verbatim.
+
+    Future backends (= ONNX / GGUF) reaching this surface should display
+    their model id without the prefix-strip path mangling them.
+    """
+    state = {
+        "kind": "embedding_skill_done",
+        "model": "openai/text-embedding-3-small",
+        "dimension": 1536,
+    }
+    rendered, _, _ = render_memory(tmp_path, embedding_state=state)
+    assert "openai/text-embedding-3-small" in rendered
+    assert "1536d" in rendered
+
+
+# ── 4. Existing sections preserved when embedding section renders ────────────
+
+
+def test_render_memory_embedding_section_does_not_break_hot_list(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: HOT NOW + EMBEDDINGS coexist; no section is silently dropped."""
+    state = {"kind": "embedding_skill_done", "model": "x", "dimension": 8}
+    hot_list = [{"qualified_name": "file__read", "freq": 5, "last_ts": 0.0}]
+    rendered, _, _ = render_memory(
+        tmp_path,
+        hot_list=hot_list,
+        embedding_state=state,
+    )
+    assert "HOT NOW" in rendered
+    assert "EMBEDDINGS" in rendered
+    # The embedding section comes AFTER the HOT NOW section
+    # (= structural ordering pinned by render_memory: hot → scopes →
+    # embeddings).
+    assert rendered.index("HOT NOW") < rendered.index("EMBEDDINGS")
+
+
+def test_render_memory_unknown_kind_falls_back_to_text(tmp_path: Path) -> None:
+    """Tier 2: future emitter kind shows the raw text rather than blank.
+
+    Pinned so a new ``embedding_*`` kind landing without a matching
+    render branch still produces SOME row instead of a silent section
+    header.
+    """
+    state = {
+        "kind": "embedding_unknown_future_kind",
+        "text": "novel state",
+        "model": "x",
+    }
+    rendered, _, _ = render_memory(tmp_path, embedding_state=state)
+    assert "EMBEDDINGS" in rendered
+    assert "novel state" in rendered


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 §Component C.4 implementation + C.3 latent-bug hotfix. Refs #922.

## TL;DR

Surfaces the embedding model-load lifecycle (= C.3 events) into the TUI Memory tab as an `EMBEDDINGS` end-section with `loading…` / `loaded · Nd` / `error · <hint>` rows. **Also fixes a latent bug from #939** that silently disabled the C.3 events bus in production — discovered while wiring C.4's subscriber.

## C.3 hotfix (latent bug from #939)

`session.py:1300` captured `self.events` (= attribute that does NOT exist on ChatSession), and the outer `except Exception` swallowed the AttributeError. Every operator with `embedding_class` set hit the silent fall-through to "no embedding provider", which:
- Disabled `search_actions` for that session
- Suppressed the C.3 lifecycle events entirely

**Fix**: deferred closure referencing `self._chat_events` at call time — the EventLog is built later in `__init__` (line ~1482), and the neighbouring `_on_hot_list_changed` sink already uses this pattern.

## C.4 wiring

```
ChatLifecycleForwarder.on_embedding_{status,skill_done,error}
                ↓ emits OutboxMessage(kind=…, text=…, meta=…)
OutboxRouter._on_embedding_lifecycle
                ↓ snapshot dict
RightPanel.update_embedding_state(state)
                ↓ cache + invalidate Memory tab
render_memory(..., embedding_state=state)
                ↓ Rich markup
_render_embedding_section(lines, state)  ← appends:
    ⟳ loading… · <model> · <device>      (status)
    ✓ loaded · <model> · Nd               (skill_done)
    ✗ error · <model>
        <retry_hint truncated>            (error)
```

`sentence-transformers/` prefix is dropped from model strings so HF ids fit a narrow panel; non-prefixed models (= openai/, future ONNX/, etc.) pass through verbatim.

`embedding_state=None` (= operator default, no `embedding_class` set) suppresses the section entirely so the TUI stays quiet rather than displaying a permanent "(none)" line — §C.1 hidden-state hint covers that path on the LLM side already.

## Files changed (6 / +451 / -8)

| File | Notes |
|---|---|
| `src/reyn/chat/session.py` | C.3 hotfix — deferred sink closure for `_chat_events` |
| `src/reyn/chat/lifecycle_forwarder.py` | Three `on_embedding_*` handlers + shared `_forward_embedding` |
| `src/reyn/chat/tui/app_outbox.py` | Three dispatch entries + `_on_embedding_lifecycle` |
| `src/reyn/chat/tui/widgets/right_panel/__init__.py` | `_embedding_state` attribute + `update_embedding_state` + pass-through |
| `src/reyn/chat/tui/widgets/right_panel/memory_tab.py` | `embedding_state` kwarg + `_render_embedding_section` helper |
| `tests/test_tui_memory_embedding_section.py` | NEW — 12 Tier-2 tests |

## Test plan

- [x] `pytest tests/test_tui_memory_embedding_section.py`: 12 passed
- [x] `pytest tests/test_chat_lifecycle_forwarder.py`: 10 passed (= existing handlers unaffected)
- [x] `pytest -q --ignore=.claude` from rootdir: **5934 passed**, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` — HTML extraction, unrelated)
- [x] `ruff check` on changed files: clean
- [x] `grep -nE 'assert .*\._[a-z_]+' tests/test_tui_memory_embedding_section.py`: 0 hits ([[feedback_tier4_private_state_repeat_6_round]] mitigation applied at write time)
- [ ] Manual: `pip install -e '.[local-embed]'`, set `embedding_class: local-mini`, `reyn chat`, switch to Memory tab — observe `EMBEDDINGS` section with `⟳ loading…` then `✓ loaded · all-MiniLM-L6-v2 · 384d`. tui-coder coord req for the visual review on real TUI.

## Tier rule self-check

- All test docstrings declare Tier (= "Tier 2: ...")
- No Tier 4 violations (= no Mock / MagicMock / AsyncMock; no private state assertion; no format-pinning; no snapshot)
- Tests use a real `ChatLifecycleForwarder` against a real `asyncio.Queue`, and call `render_memory` directly with a tmp project root.
- No invariant relies on hot-list seed
- Tier audit: 0 violations introduced

## Relationship to other work

- **FP-0043 (#922)** §Component C.4 — this PR is the implementation. Also hotfixes the latent C.3 events-bus bug from #939.
- **#939** (C.3 first-time DL progress events, merged): the lifecycle events this PR forwards. The hotfix here makes those events actually fire in production.
- **#936** (C.1 list_actions hidden-state hint, merged): covers the "no embedding class set" path on the LLM side; this PR covers "class set + mid-load / loaded / error" on the TUI side.
- **#937** (C.2 reyn embeddings CLI, merged): operator-side mirror of the same state; the retry hint surfaced here points at C.2's `reyn embeddings clear` subcommand.
- **Component C complete**: A → B → C.1 → C.2 → C.3 → C.4 + E all landed across #929 / #931 / #936 / #937 / #939 / this PR. FP-0043 §Phase 3 + 4 closed.

## tui-coder coord ask

The `Memory` tab integration goes through `render_memory` + `RightPanel` which tui-coder owns. Specifically:
- 1-line `EMBEDDINGS` section header pattern matches the existing `HOT NOW` / `SHARED` / `AGENT` headers — uses the same `[bold #color]  LABEL[/]` shape
- No new tab; appends below existing scopes (= tui-coder's "existing統合 over new tab" stance preserved)
- `update_embedding_state` mirrors `update_hot_list` invalidation semantics verbatim

If the surface needs different colour / icon / layout, the small adjustments are isolated to `_render_embedding_section` and easy to iterate. Tagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)