### PR TITLE
docs: FP-0043 Phase 5 — local embedding backend docs + reyn embeddings reference

### DIFF
--- a/docs/concepts/rag.md
+++ b/docs/concepts/rag.md
@@ -183,21 +183,39 @@ Embedded 5K / 100K chunks (5%), ETA 25 min
 
 ## Embedding configuration
 
-The embedding model and batching behaviour are configured under `embedding:` in `reyn.yaml`:
+The embedding model and batching behaviour are configured under `embedding:` in `reyn.yaml`. Five built-in classes ship by default — three OpenAI-backed and two sentence-transformers-backed (= local; activated by the `local-embed` extras, see [§Local embedding backend](#local-embedding-backend-fp-0043) below):
 
 ```yaml
 embedding:
   default_class: standard
   classes:
-    light:    openai/text-embedding-3-small
-    standard: openai/text-embedding-3-small
-    strong:   openai/text-embedding-3-large
+    light:      openai/text-embedding-3-small
+    standard:   openai/text-embedding-3-small
+    strong:     openai/text-embedding-3-large
+    local-mini: sentence-transformers/all-MiniLM-L6-v2
+    local-e5:   sentence-transformers/intfloat/multilingual-e5-small
   batch_size: 100
   max_retries: 3
   cost_warn_threshold: 10000
 ```
 
-The API key is read from `~/.reyn/secrets.env` via `${OPENAI_API_KEY}` — no literal value in `reyn.yaml`. After setting the key with `reyn secret set OPENAI_API_KEY`, indexing works out of the box with no further configuration.
+Dispatch is **provider-prefix-based**: classes whose `model` string starts with `sentence-transformers/` route to the local backend; everything else (`openai/`, future LiteLLM-routable providers) routes through LiteLLM. Existing OpenAI-backed callers are byte-identical to pre-FP-0043; the routing wrapper passes them through transparently.
+
+The OpenAI API key is read from `~/.reyn/secrets.env` via `${OPENAI_API_KEY}` — no literal value in `reyn.yaml`. After setting the key with `reyn secret set OPENAI_API_KEY`, indexing with `standard` / `light` / `strong` works out of the box with no further configuration.
+
+### Local embedding backend (FP-0043)
+
+`local-mini` and `local-e5` use [sentence-transformers](https://www.sbert.net/) to embed locally (= no API, no credentials, no per-query cost). They are gated behind an `extras` install so the base `reyn` package stays small:
+
+```bash
+pip install 'reyn[local-embed]'
+```
+
+This pulls `sentence-transformers >= 2.7` and `torch >= 2.0`. The model itself downloads on first use (~22 MB for `local-mini`, ~118 MB for `local-e5`) and caches under `~/.cache/reyn/sentence-transformers/` (overridable via `REYN_CACHE_DIR` / `XDG_CACHE_HOME`).
+
+Device selection is `cpu` by default; opt into GPU acceleration via the `REYN_EMBED_DEVICE` env var (`mps` for Apple Silicon, `cuda` for NVIDIA). Invalid values warn and fall back to `cpu`.
+
+For chat-side action retrieval specifically (= `search_actions`), see [Guide: enable semantic search](../guide/for-users/enable-semantic-search.md) and the [`reyn embeddings`](../reference/cli/embeddings.md) CLI for cache management.
 
 ## Phase 1 scope
 
@@ -216,12 +234,16 @@ The API key is read from `~/.reyn/secrets.env` via `${OPENAI_API_KEY}` — no li
 
 - Memory layer migration from inline expansion to `recall(sources=["memory"])`. Memory continues to work as-is in 1.0.
 
+**Landed post-1.0:**
+
+- Local embedding models via sentence-transformers (FP-0043, 2026-05) — see [§Local embedding backend](#local-embedding-backend-fp-0043). The chat-side `search_actions` surface is the first consumer; the same `local-mini` / `local-e5` classes are reachable from `embedding.default_class` for document indexing too.
+
 **Deferred to Phase 2 (post-1.1):**
 
 - Alternative vector store backends (Qdrant, FAISS, Pinecone)
 - Incremental re-indexing on file change
 - Advanced retrieval (rerank, HyDE, contextual retrieval)
-- Local embedding models (sentence-transformers, ollama)
+- Additional local backends (ollama, ONNX, GGUF)
 - RAG evaluation framework
 
 ## Limitations
@@ -231,7 +253,7 @@ The API key is read from `~/.reyn/secrets.env` via `${OPENAI_API_KEY}` — no li
 - **Memory layer is unchanged in Phase 1.** Session memory still uses inline system-prompt expansion. The `recall` tool and memory are independent systems in this release.
 - **No advanced retrieval.** Phase 1 uses cosine similarity only — no reranking, HyDE, or contextual retrieval.
 - **Sensitive data.** reyn does not redact sensitive content before indexing. Do not index secrets, credentials, or PII unless you understand the implications. A redaction policy is planned for Phase 2.
-- **Embedding API required.** Phase 1 has no local embedding path. An OpenAI-compatible API key is required.
+- **Embedding requires either an API key OR local-embed extras.** OpenAI-backed classes (`light` / `standard` / `strong`) need `OPENAI_API_KEY`; local classes (`local-mini` / `local-e5`) need `pip install 'reyn[local-embed]'` and a one-time model download. See [§Embedding configuration](#embedding-configuration). A fully credential-free, zero-extras `recall` path is not yet available.
 
 ## Operational Intelligence — `recall` on events
 

--- a/docs/concepts/universal-catalog.md
+++ b/docs/concepts/universal-catalog.md
@@ -277,11 +277,37 @@ action_retrieval:
 
 ## What stays out of Phase 1
 
-The structural surface is complete; behavioral / discovery features
-deferred to Phase 2:
+The structural surface is complete. Discovery features landed and
+deferred:
 
-- **`search_actions`** — semantic, embedding-backed search. The
-  handler is a stub; visibility waits for `ActionEmbeddingIndex`.
+**Landed post-1.0:**
+
+- **`search_actions`** — semantic, embedding-backed search **shipped
+  in FP-0043 (2026-05)**. `ActionEmbeddingIndex` (= SQLite-WAL
+  persistence + class-swap detection + cross-process build lock)
+  backs the handler; visibility is gated by §D14 (= tool appears only
+  once the index has built ≥1 vector). When the gate fails, the
+  `list_actions` response carries a structured **hidden-state hint**
+  pointing operators at `pip install 'reyn[local-embed]'` /
+  `reyn embeddings status` so the install path is self-discoverable
+  mid-chat. The local backend is the default; the OpenAI-backed
+  classes (`light` / `standard` / `strong`) are equally usable. See
+  [Guide: enable semantic search](../guide/for-users/enable-semantic-search.md)
+  and the [`reyn embeddings`](../reference/cli/embeddings.md) CLI for
+  the operator surface.
+
+**Category validation + legacy redirect**
+
+`list_actions(category=[...])` and `search_actions(category=[...])`
+validate every supplied name against the live category enum.
+Unknown names return an explicit error carrying a `legacy → current`
+mapping (`mcp.server` → `mcp`, `agent.peer` → `multi_agent`, …) so
+LLMs whose training data references a pre-collapse name self-correct
+in a single retry. See `_LEGACY_CATEGORY_REDIRECTS` in
+`src/reyn/tools/universal_catalog.py`.
+
+**Deferred to Phase 2:**
+
 - **`rag.corpus` enumeration** — needs a `RouterCallerState` field
   carrying indexed-source metadata, then plumbing through
   `RouterHostAdapter`. The `invoke` and `describe` paths already work

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -286,6 +286,7 @@ All ops are documented in the single reference page: **[Control IR](reference/ru
 | `reyn mcp` | Serve, search, install, and manage MCP servers | [Reference](reference/cli/mcp.md) |
 | `reyn secret` | Set / list / clear secrets in `~/.reyn/secrets.env` | [Reference](reference/cli/secret.md) |
 | `reyn source` | List, describe, and remove indexed RAG sources | [Reference](reference/cli/source.md) |
+| `reyn embeddings` | `status` / `rebuild` / `clear` for the action embedding index (`search_actions`) | [Reference](reference/cli/embeddings.md) |
 | `reyn config` | Show, query, and set effective configuration | [Reference](reference/cli/config.md) |
 | `reyn web` | Start FastAPI + WebSocket gateway server | [Reference](reference/cli/web.md) |
 | `reyn init` | Scaffold `reyn.yaml` and `.reyn/` in current directory | [Reference](reference/cli/init.md) |
@@ -352,11 +353,14 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
 | LiteLLM embedding backend | Any provider via named model class config | [RAG concepts](concepts/rag.md) |
+| Local embedding backend | sentence-transformers via `pip install 'reyn[local-embed]'` — `local-mini` / `local-e5` classes, credential-free, GPU-optional via `REYN_EMBED_DEVICE` (FP-0043) | [RAG concepts § Local embedding backend](concepts/rag.md#local-embedding-backend-fp-0043) · [Guide](guide/for-users/enable-semantic-search.md) |
+| Provider-prefix routing | `sentence-transformers/` → local backend; anything else → LiteLLM (FP-0043) | [RAG concepts § Embedding configuration](concepts/rag.md#embedding-configuration) |
 | Batch embed | Configurable `batch_size` with concurrency semaphore | [RAG concepts](concepts/rag.md) |
 | Dimension table | Static lookup for OpenAI / Voyage / Cohere | [RAG concepts](concepts/rag.md) |
 | SQLite index per source | `.reyn/index/<source>/index.db` with WAL mode | [RAG concepts](concepts/rag.md) |
 | Chunk dedup | `content_hash` upsert prevents re-indexing | [RAG concepts](concepts/rag.md) |
 | `recall` op | embed → `index_query` per source → merge top-K globally | [Control IR](reference/runtime/control-ir.md) |
+| Action embedding index | `ActionEmbeddingIndex` (SQLite-WAL, class-swap detection, cross-process build lock) — backs the `search_actions` tool the chat LLM uses (FP-0043) | [Universal catalog § search_actions](concepts/universal-catalog.md#what-stays-out-of-phase-1) · [`reyn embeddings`](reference/cli/embeddings.md) |
 | Memory CRUD | `list` / `read` / `remember_shared` / `remember_agent` / `forget` | [Memory concepts](concepts/memory.md) · [reyn memory CLI](reference/cli/memory.md) |
 | Chat compaction | head+tail preservation + rolling LLM summary within token budget | [Chat Compaction](concepts/chat-compaction.md) · [`chat_compactor`](reference/stdlib/chat_compactor.md) |
 

--- a/docs/guide/for-users/enable-semantic-search.md
+++ b/docs/guide/for-users/enable-semantic-search.md
@@ -1,0 +1,98 @@
+# Enable semantic action search
+
+`reyn chat` ships with two ways for the LLM to discover what it can do: a fast **`list_actions`** browser (= category-prefix enumeration, always available) and a **`search_actions`** semantic search (= natural-language queries against an embedding index of every action). This guide walks through enabling the semantic path.
+
+> **TL;DR**: run `pip install 'reyn[local-embed]'` once and `search_actions` becomes usable with no credentials. If you'd rather use OpenAI's embedding API (slightly higher quality), set `action_retrieval.embedding_class: standard` in `reyn.yaml` after `reyn secret set OPENAI_API_KEY`.
+
+## When you'd want it
+
+`search_actions` is the difference between:
+
+- **Without it**: the LLM has to guess which category your intent belongs to (`file` / `mcp` / `memory.entry` / …) and run `list_actions(category=[...])` to enumerate. For natural-language asks like _"find an action that converts PDF to text"_ the LLM may also try and refuse if it doesn't immediately spot a match.
+- **With it**: the LLM runs `search_actions(query="PDF to text")` and gets a top-K relevance-ranked list across every category. It can then `describe_action` or `invoke_action` directly.
+
+For a fresh `reyn` install with no embedding class configured, `search_actions` is gated **out** of the LLM's tool list (= the [§D14 visibility gate](../../concepts/universal-catalog.md#what-stays-out-of-phase-1)). The LLM never sees it; chat-driven discovery falls back to `list_actions` only.
+
+## Path A — local sentence-transformers (recommended for first-time users)
+
+```bash
+pip install 'reyn[local-embed]'
+```
+
+That's it. The `local-embed` extras install `sentence-transformers` + `torch`, and Reyn's default `action_retrieval.embedding_class` switches to `local-mini` (= `all-MiniLM-L6-v2`, 22 MB, 384-dim, English).
+
+The first time `reyn chat` reaches `search_actions`, the model downloads (~5–10 s on a typical connection) and the embedding index builds. The TUI Memory tab shows a `⟳ loading…` row during the download and a `✓ loaded · all-MiniLM-L6-v2 · 384d` row when done; subsequent sessions warm-start from the local cache in <1 s.
+
+### What you get
+
+- **Zero credentials** — no API key required. Everything runs locally.
+- **Zero per-query cost** — the `local-mini` model embeds queries in ~30–80 ms on a typical laptop CPU.
+- **Offline-capable** — once the model is cached, semantic search works without network access.
+- **`reyn embeddings status`** to inspect the cache state at any time:
+
+```bash
+$ reyn embeddings status
+NAME        BACKEND                MODEL                                  ACTIONS  LAST_BUILT
+local-mini  sentence-transformers  sentence-transformers/all-MiniLM-L6-v2     87  2026-05-27T19:02:00+00:00
+```
+
+### Multilingual content
+
+If your prompts include Japanese / Chinese / European languages, swap to `local-e5` (= `multilingual-e5-small`, 118 MB, 50 languages, better cross-lingual recall):
+
+```yaml
+# reyn.yaml
+action_retrieval:
+  embedding_class: local-e5
+```
+
+After the swap, `reyn embeddings rebuild` drops the old cache so the next session re-embeds with the new model.
+
+## Path B — OpenAI embeddings (slightly higher quality)
+
+If you'd rather pay per query for marginally better recall (= the OpenAI text-embedding-3-small model scores ~5 pp higher on MTEB than `multilingual-e5-small`):
+
+```bash
+reyn secret set OPENAI_API_KEY
+# enter your sk-... key when prompted
+```
+
+Then in `reyn.yaml`:
+
+```yaml
+action_retrieval:
+  embedding_class: standard   # = openai/text-embedding-3-small
+```
+
+No `pip` install needed; the LiteLLM client is already a base dependency. The HTTP round-trip adds ~150–300 ms per query versus the local path; embedding cost is ~$0.00002 per chat session (= negligible).
+
+## GPU acceleration (optional)
+
+If you have a CUDA / Apple-Silicon GPU and want sentence-transformers to use it:
+
+```bash
+export REYN_EMBED_DEVICE=mps    # macOS Apple Silicon
+export REYN_EMBED_DEVICE=cuda   # NVIDIA GPU
+```
+
+Default is `cpu`. The encode latency drops to ~5–15 ms per query on `mps`, which is enough of a step-change to be perceptible in long chat sessions. Invalid values warn and fall back to `cpu` rather than failing.
+
+## How Reyn tells you when it's not configured
+
+If you skip both Path A and Path B and still ask the LLM to "find an action for …", the response from `list_actions` carries a structured **hint** field listing the install / config paths above. The LLM relays the hint to you so the install is self-discoverable mid-chat — no need to memorise this guide. The hint disappears the moment `search_actions` becomes available.
+
+## Troubleshooting
+
+**`search_actions` doesn't appear in the LLM's tool list** — the embedding index hasn't finished building yet (= cold start, ~5–10 s) OR the configured class points at a backend whose extras aren't installed. Check `reyn embeddings status` — a configured class with `ACTIONS = 0` and `LAST_BUILT = (never)` means the build hasn't completed.
+
+**"failed to load \<model>" in TUI / events** — partial cache state. Run `reyn embeddings clear` to wipe and start fresh; the next chat session re-downloads cleanly.
+
+**Swapping classes returns stale results** — Reyn's cache stores one `model_class` at a time. Class swaps trigger automatic re-embedding on the next session, but you can force it eagerly with `reyn embeddings rebuild`.
+
+**Old `mcp.server` / `agent.peer` category mentioned by the LLM** — the LLM's training data may pre-date a Reyn collapse refactor. `list_actions(category=["mcp.server"])` post-Reyn-0.4 returns an [explicit error with a legacy → current mapping](../../concepts/universal-catalog.md#category-validation--legacy-redirect) so the LLM self-corrects in a single retry.
+
+## Related
+
+- [`reyn embeddings` CLI reference](../../reference/cli/embeddings.md) — status / rebuild / clear
+- [Concepts: universal catalog](../../concepts/universal-catalog.md) — how `list_actions` / `search_actions` fit together
+- [Concepts: RAG](../../concepts/rag.md#embedding-configuration) — the underlying `embedding.classes` config map (shared with document recall)

--- a/docs/reference/cli/embeddings.md
+++ b/docs/reference/cli/embeddings.md
@@ -1,0 +1,104 @@
+---
+type: reference
+topic: cli
+audience: [human, agent]
+applies_to: [reyn embeddings]
+---
+
+# `reyn embeddings`
+
+Inspect and manage the action embedding index that backs `search_actions`. Reads on-disk state only — no network probes; matches the cheap-by-default posture of `reyn mcp list`.
+
+See [Concepts: enable semantic search](../../guide/for-users/enable-semantic-search.md) for the onboarding walkthrough, and [Concepts: RAG — Embedding configuration](../../concepts/rag.md#embedding-configuration) for the underlying `embedding.classes` map.
+
+## Synopsis
+
+```
+reyn embeddings status [--json]
+reyn embeddings rebuild [<class_name>]
+reyn embeddings clear
+```
+
+## Subcommands
+
+### `status [--json]`
+
+Show one row per configured embedding class with `name / backend / model / cache_path / size_mb / indexed_actions / last_built`. Reads `reyn.yaml` for the class list and `.reyn/action_index/index.db` for the current on-disk binding.
+
+```bash
+$ reyn embeddings status
+
+NAME        BACKEND                MODEL                                                 CACHE_PATH                                            SIZE_MB  ACTIONS  LAST_BUILT
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+light       litellm                openai/text-embedding-3-small                         .reyn/action_index                                       0.00        0  (never)
+local-e5    sentence-transformers  sentence-transformers/intfloat/multilingual-e5-small  ~/.cache/reyn/sentence-transformers                      0.00        0  (never)
+local-mini  sentence-transformers  sentence-transformers/all-MiniLM-L6-v2                ~/.cache/reyn/sentence-transformers                     22.43      87  2026-05-27T19:02:00+00:00
+standard    litellm                openai/text-embedding-3-small                         .reyn/action_index                                       0.00        0  (never)
+strong      litellm                openai/text-embedding-3-large                         .reyn/action_index                                       0.00        0  (never)
+```
+
+The SQLite cache stores one `model_class` at a time (= one row carries the current `indexed_actions` / `last_built`; the rest report `0 / "(never)"`). This avoids ambiguity about which class owns the on-disk index after a class swap.
+
+`--json` emits the same data as a list of dicts for scripting:
+
+```bash
+reyn embeddings status --json | jq '.[] | select(.indexed_actions > 0)'
+```
+
+### `rebuild [<class_name>]`
+
+Drop the on-disk action index SQLite + WAL sidecars + `.build.lock` marker so the next `reyn chat` session re-embeds. Does NOT itself trigger embedding; the next ChatSession that uses `search_actions` re-runs `ActionEmbeddingIndex.build()`.
+
+```bash
+reyn embeddings rebuild
+# removed action index cache: index.db, index.db-wal.
+# The next chat session will re-embed.
+```
+
+A clean project state (= no `.reyn/action_index/index.db`) reports "nothing to rebuild" without erroring:
+
+```bash
+reyn embeddings rebuild
+# no action index found at .reyn/action_index/index.db; nothing to rebuild.
+```
+
+`<class_name>` is accepted for forward compatibility with a future per-class cache. Today the SQLite layout stores one `model_class` at a time, so passing a name verifies the class exists in `reyn.yaml` and notes the cache-shared semantics:
+
+```bash
+reyn embeddings rebuild local-mini
+# removed action index cache (shared across classes today): index.db, index.db-wal.
+# The next chat session will re-embed for class 'local-mini'.
+```
+
+Unknown class names exit non-zero with the configured list inline:
+
+```bash
+reyn embeddings rebuild lcal-mini   # typo
+# error: embedding class 'lcal-mini' not in reyn.yaml's embedding.classes.
+# Configured: ['light', 'local-e5', 'local-mini', 'standard', 'strong']
+```
+
+### `clear`
+
+Aggressive cleanup. Removes BOTH `.reyn/action_index/` (= SQLite + build lock) AND the sentence-transformers HF model cache directory (resolved via `REYN_CACHE_DIR > XDG_CACHE_HOME > ~/.cache/reyn` precedence, matching the runtime backend).
+
+```bash
+reyn embeddings clear
+# removed /path/to/.reyn/action_index
+# removed /Users/.../.cache/reyn/sentence-transformers
+# freed ~22.43 MB
+```
+
+Useful for:
+
+- **Cache corruption** — a partial download / interrupted load leaves the cache in a state that the next `embed()` call can't recover from on its own.
+- **Backend swap reclamation** — operator switched `action_retrieval.embedding_class` from `local-mini` to `standard` (= OpenAI) and wants to reclaim the 22 MB local model. `rebuild` keeps the model cache; `clear` removes it.
+
+Absent paths are reported as skipped — calling `clear` on a clean install is a no-op.
+
+## Related
+
+- [Concepts: enable semantic search](../../guide/for-users/enable-semantic-search.md) — fresh-user setup
+- [Concepts: universal catalog — `search_actions`](../../concepts/universal-catalog.md#what-stays-out-of-phase-1) — the surface this index backs
+- [Concepts: RAG — Embedding configuration](../../concepts/rag.md#embedding-configuration) — `embedding.classes` map
+- [`reyn secret`](secret.md) — set `OPENAI_API_KEY` for the LiteLLM-backed embedding classes


### PR DESCRIPTION
**[e2e-coder]** — Phase 5 of FP-0043 (= FP-0043 §922) closes the docs gap left by Components A–E. **Phase 5 is the last remaining FP-0043 phase per lead-coder's 全 Phase 3 完結 broker on 2026-05-26**; Phase 4 (= `action_retrieval.embedding_class` default switch to `local-mini` with graceful degrade) is the only implementation work still pending.

## Summary

Four surfaces touched, two new pages.

### New pages

- **`docs/reference/cli/embeddings.md`** — full reference for `reyn embeddings status / rebuild / clear` (= shipped via PR #937). Mirrors the `reyn mcp list` reference shape: synopsis, per-subcommand examples, `--json` mode, cross-class attribution explanation.
- **`docs/guide/for-users/enable-semantic-search.md`** — fresh-user onboarding for the `search_actions` LLM tool: Path A (`pip install 'reyn[local-embed]'`, recommended) vs Path B (OpenAI), §D14 visibility gate + hidden-state hint mechanism, `REYN_EMBED_DEVICE` GPU opt-in, multilingual swap, troubleshooting.

### Updated pages

- **`docs/concepts/rag.md`**:
  - Extended "Embedding configuration" example with `local-mini` / `local-e5` classes; documented provider-prefix dispatch.
  - New "Local embedding backend (FP-0043)" subsection (extras / cache dir precedence / `REYN_EMBED_DEVICE`).
  - "Deferred to Phase 2" list: moved sentence-transformers to a new "Landed post-1.0" bullet referencing FP-0043; kept ollama / ONNX / GGUF as deferred.
  - "Limitations" → "Embedding API required" entry: rewritten to reflect that EITHER a key OR `local-embed` extras suffice.
- **`docs/concepts/universal-catalog.md`**:
  - "What stays out of Phase 1" → split into "Landed post-1.0" + "Deferred to Phase 2". `search_actions` moves to landed with the §D14 gate + hidden-state hint description.
  - New "Category validation + legacy redirect" subsection documenting `_LEGACY_CATEGORY_REDIRECTS` (= PRs #935 + #936).
- **`docs/feature-map.md`**:
  - CLI table: added `reyn embeddings` row.
  - Memory & RAG table: added Local embedding backend / Provider-prefix routing / Action embedding index rows.

## Test plan

- [x] Manual: spot-checked anchor targets — `enable-semantic-search.md` ↔ `embeddings.md` ↔ `rag.md#local-embedding-backend-fp-0043` ↔ `universal-catalog.md#what-stays-out-of-phase-1` all valid.
- [x] Visual: new table rows match sibling-row conventions (= `reyn voice` extras row precedent for the `local-embed` mention).
- [x] No Python touched; pytest collection / ruff irrelevant. `ruff check docs/` passes (= empty rule set, no .py files).
- [x] **Tier rule self-check**: docs-only PR, no test changes; Tier policy N/A.

Branch rebased onto fresh `origin/main` (= post-#942 baseline) per [[feedback_post_merge_baseline_freshness]].

Refs #922 (FP-0043 consolidated issue — Phase 5 closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)