### PR TITLE
chore(session): add public read-side methods for intervention overrides (Tier C1 cleanup wave 1)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3041,6 +3041,25 @@ class ChatSession:
         """Remove an override. Idempotent."""
         self._intervention_overrides.pop(chain_id, None)
 
+    def has_intervention_override(self, chain_id: str) -> bool:
+        """Return True iff *chain_id* currently has a registered override
+        ``RequestBus``. Public read-side counterpart to
+        ``register_intervention_override`` / ``unregister_intervention_override``.
+        """
+        return chain_id in self._intervention_overrides
+
+    def get_intervention_override(self, chain_id: str) -> "RequestBus | None":
+        """Return the override bus for *chain_id* or None if absent. Read-only
+        accessor for callers (= primarily tests) that need to confirm the
+        registered bus identity without consuming the override."""
+        return self._intervention_overrides.get(chain_id)
+
+    def intervention_override_count(self) -> int:
+        """Return the number of currently-registered overrides. Public
+        emptiness probe for cleanup-leak tests (= prefer over reading the
+        private mapping directly)."""
+        return len(self._intervention_overrides)
+
     # ── Listener registration (issue #254 Phase 1) ──────────────────────────
 
     def register_intervention_listener(self, listener_id: str) -> None:

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -215,18 +215,12 @@ def test_chat_session_intervention_override_is_used():
         stub_bus = _ScriptedBus()
         session.register_intervention_override(chain_id, stub_bus)
 
-        # Directly probe the override map via the routing logic:
-        # _intervention_overrides is internal but the test uses the
-        # _route_intervention public-equivalent path by calling it through
-        # the session's own method if available.  If the session exposes
-        # a `_route_intervention` method we use it; otherwise we check the
-        # internal dict is non-empty (acceptable — we're testing the
-        # register/unregister contract, not an internal field value).
+        # Probe the override via the session's public accessor.
         iv = UserIntervention(kind="ask_user", prompt="hello?", run_id="r1")
 
         async def _exercise():
             # Simulate what the OS does: look up the override for this chain.
-            override = session._intervention_overrides.get(chain_id)
+            override = session.get_intervention_override(chain_id)
             assert override is stub_bus, (
                 "register_intervention_override must store the bus at the chain_id key"
             )
@@ -243,7 +237,7 @@ def test_chat_session_intervention_override_is_used():
 
         # After unregister, the chain_id should no longer be present.
         session.unregister_intervention_override(chain_id)
-        assert chain_id not in session._intervention_overrides
+        assert not session.has_intervention_override(chain_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fp0001_session_override.py
+++ b/tests/test_fp0001_session_override.py
@@ -155,18 +155,18 @@ async def test_register_and_unregister_intervention_override(tmp_path):
     chain_id = "chain-abc"
 
     # Before registration — not present.
-    assert chain_id not in session._intervention_overrides
+    assert not session.has_intervention_override(chain_id)
 
     session.register_intervention_override(chain_id, bus)
-    assert session._intervention_overrides.get(chain_id) is bus
+    assert session.get_intervention_override(chain_id) is bus
 
     # Unregister removes it.
     session.unregister_intervention_override(chain_id)
-    assert chain_id not in session._intervention_overrides
+    assert not session.has_intervention_override(chain_id)
 
     # Idempotent: second unregister does not raise.
     session.unregister_intervention_override(chain_id)
-    assert chain_id not in session._intervention_overrides
+    assert not session.has_intervention_override(chain_id)
 
 
 # ---------------------------------------------------------------------------
@@ -205,7 +205,7 @@ async def test_dispatch_falls_through_when_no_override(tmp_path):
     answer = await asyncio.wait_for(task, timeout=2.0)
     assert answer.text == "default-answer"
     # Override bus was never called (no override registered).
-    assert "_intervention_overrides" in dir(session)
+    assert session.intervention_override_count() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -434,7 +434,7 @@ def test_send_to_agent_impl_override_registered_and_cleaned_up(tmp_path, monkeyp
     # The same chain_id was registered and unregistered.
     assert registered_chain_ids[0] == unregistered_chain_ids[0]
     # After the call, the session has no lingering overrides.
-    assert session._intervention_overrides == {}
+    assert session.intervention_override_count() == 0
 
 
 def test_send_to_agent_impl_override_cleaned_up_on_exception(tmp_path, monkeypatch):
@@ -469,9 +469,8 @@ def test_send_to_agent_impl_override_cleaned_up_on_exception(tmp_path, monkeypat
         asyncio.run(go())
 
     # After the exception, the session must have no lingering overrides.
-    assert session._intervention_overrides == {}, (
-        f"Override leak detected: {session._intervention_overrides!r}"
-    )
+    leak_count = session.intervention_override_count()
+    assert leak_count == 0, f"Override leak detected: {leak_count} stale entries"
 
 
 # ---------------------------------------------------------------------------
@@ -568,4 +567,4 @@ def test_concurrent_send_to_agent_impl_no_override_leak(tmp_path, monkeypatch):
     )
 
     # No lingering overrides after both calls.
-    assert session._intervention_overrides == {}
+    assert session.intervention_override_count() == 0


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 first instalment (= lead-coder dispatched as Axis 1 follow-up to PR #938 mechanical detection).

## Scope (= deliberately narrow first slice)

Original design draft estimated batch P1 as the \`__len__\` family ~80 findings. The actual \`_intervention_overrides\` cleanup is just **8 findings across 2 files** — landing this slice independently to establish the mitigation pattern + reviewer cadence before scaling. Honest scope correction; the remaining ~70 findings will be in follow-up PRs as they cluster around distinct mitigations.

## Changes

\`src/reyn/chat/session.py\` — add three public read-side methods next to the existing \`register_intervention_override\` / \`unregister_intervention_override\`:
- \`has_intervention_override(chain_id) -> bool\`
- \`get_intervention_override(chain_id) -> RequestBus | None\`
- \`intervention_override_count() -> int\`

\`tests/test_fp0001_session_override.py\` (6 findings) + \`tests/test_fp0001_e2e_ask_user_roundtrip.py\` (2 findings):
- \`chain_id not in session._intervention_overrides\` → \`not session.has_intervention_override(chain_id)\`
- \`session._intervention_overrides.get(chain_id) is bus\` → \`session.get_intervention_override(chain_id) is bus\`
- \`session._intervention_overrides == {}\` → \`session.intervention_override_count() == 0\`
- \`"_intervention_overrides" in dir(session)\` (= weak existence probe) → \`session.intervention_override_count() == 0\` (= the actual contract the surrounding test prose intended)

## Why

Mitigation pattern follows PR #903 (\`__len__\` exposure) and PR #906 (\`@property\`-style read-side accessors) — exposes the public surface tests need without leaking the dict shape. After the migration, \`_intervention_overrides\` is once again pure-internal storage; production code still reads it directly (only the test paths needed lifting).

## Tier rule self-check
- [x] Test docstrings carry \`Tier 2:\` prefix (= pre-existing)
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_fp0001_session_override.py tests/test_fp0001_e2e_ask_user_roundtrip.py\` → 0 errors
- [x] Load-bearing invariants preserved (= count-zero assertion is stronger than dict-equality for the cleanup-leak contract)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_fp0001_session_override.py tests/test_fp0001_e2e_ask_user_roundtrip.py\` → 16 passed
- [x] Audit on touched files → 0 private-state findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)