### PR TITLE
chore(session): add last_sender() public accessor (Tier C1 cleanup wave 2)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1990,6 +1990,13 @@ class ChatSession:
             pass
         self._last_sender = new_sender
 
+    def last_sender(self) -> str | None:
+        """Return the most-recently-attributed sender label or None if no
+        message has been routed yet. Read-only accessor for
+        ``_last_sender`` — write side stays internal to the dispatch
+        attribution path."""
+        return self._last_sender
+
     def _on_chat_event_for_state_change(self, event) -> None:
         """Generic events-log subscriber that converts known emitter events
         to ``state_change`` history entries (= #398 v4 emitter family).

--- a/tests/test_session_dispatch_attribution.py
+++ b/tests/test_session_dispatch_attribution.py
@@ -75,7 +75,7 @@ def test_first_sender_triggers_first_attributed_turn_entry(tmp_path):
     was from ..." framing doesn't apply).
     """
     session = _make_session(tmp_path)
-    assert session._last_sender is None
+    assert session.last_sender() is None
 
     session._handle_sender_attribution({"sender": "slack:U456:bob"})
 
@@ -84,7 +84,7 @@ def test_first_sender_triggers_first_attributed_turn_entry(tmp_path):
     (entry,) = entries
     assert "bob (Slack)" in entry.content
     assert "first attributed turn" in entry.content
-    assert session._last_sender == "slack:U456:bob"
+    assert session.last_sender() == "slack:U456:bob"
 
 
 # ── sender transition ────────────────────────────────────────────────
@@ -108,7 +108,7 @@ def test_sender_transition_emits_state_change(tmp_path):
     assert "bob (Slack)" in last
     assert "morning_news" in last  # previous = cron job
     assert "Previous turn was from" in last
-    assert session._last_sender == "slack:U456:bob"
+    assert session.last_sender() == "slack:U456:bob"
 
 
 # ── same sender = no transition ────────────────────────────────────────
@@ -128,7 +128,7 @@ def test_same_sender_consecutive_does_not_emit(tmp_path):
     session._handle_sender_attribution({"sender": "user:tui"})
 
     assert len(_attribution_entries(session)) == pre_count
-    assert session._last_sender == "user:tui"
+    assert session.last_sender() == "user:tui"
 
 
 # ── backward compat: no sender ─────────────────────────────────────────
@@ -142,12 +142,12 @@ def test_payload_without_sender_skips_attribution(tmp_path):
     """
     session = _make_session(tmp_path)
     pre_count = len(_attribution_entries(session))
-    pre_last = session._last_sender
+    pre_last = session.last_sender()
 
     session._handle_sender_attribution({"text": "hello", "chain_id": "c1"})
 
     assert len(_attribution_entries(session)) == pre_count
-    assert session._last_sender == pre_last  # unchanged
+    assert session.last_sender() == pre_last  # unchanged
 
 
 def test_empty_sender_string_skips_attribution(tmp_path):
@@ -159,7 +159,7 @@ def test_empty_sender_string_skips_attribution(tmp_path):
     session._handle_sender_attribution({"sender": ""})
 
     assert len(_attribution_entries(session)) == 0
-    assert session._last_sender is None
+    assert session.last_sender() is None
 
 
 # ── defensive: non-dict payload ────────────────────────────────────────
@@ -178,7 +178,7 @@ def test_non_dict_payload_does_not_crash(tmp_path):
     session._handle_sender_attribution(42)
 
     assert len(_attribution_entries(session)) == 0
-    assert session._last_sender is None
+    assert session.last_sender() is None
 
 
 # ── 3-way transition ──────────────────────────────────────────────────
@@ -196,7 +196,7 @@ def test_three_way_transition_each_fires(tmp_path):
     entries = _attribution_entries(session)
     e0, e1, e2 = entries
     # Final state reflects the latest sender.
-    assert session._last_sender == "a2a:peer_one"
+    assert session.last_sender() == "a2a:peer_one"
     # Each entry mentions the current sender's label.
     assert "user (TUI)" in e0.content
     assert "nightly" in e1.content
@@ -267,4 +267,4 @@ def test_attribution_resilient_to_notify_state_change_failure(
     session._handle_sender_attribution({"sender": "slack:U456:bob"})
 
     # _last_sender did update despite the failure.
-    assert session._last_sender == "slack:U456:bob"
+    assert session.last_sender() == "slack:U456:bob"


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 second slice. Same mitigation pattern as PR #944 — public read-side accessor on the owning class so callers (= tests) stop reading the private field.

## Changes

\`src/reyn/chat/session.py\` — add \`last_sender() -> str | None\` next to the existing dispatch-attribution path that maintains \`_last_sender\`. Write side stays internal.

\`tests/test_session_dispatch_attribution.py\` (9 Tier-C1 findings, all in this single file):
- \`session._last_sender\` → \`session.last_sender()\`
- 9 occurrences across 6 test functions (= \`is None\` / \`== "x"\` / \`pre_last = ...\` / \`== pre_last\`)
- Behaviour unchanged (= identical read semantics)

## Why
Same rationale as #944. Scalar read accessor for an internal-state field; the dispatch attribution path is the only writer and stays internal. Tests now check the public surface.

## Tier rule self-check
- [x] All test docstrings carry \`Tier 2:\` prefix (= pre-existing)
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_session_dispatch_attribution.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical \`is None\` / \`==\` semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_session_dispatch_attribution.py\` → 22 passed
- [x] Audit on touched test file → 0 private-state findings
- [x] grep \`tests/ -- '_last_sender'\` → only docstring/comment references remain (= not asserts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)