### PR TITLE
feat(fp-0043): Phase 4 — embedding_class default to local-mini + graceful degrade

### DIFF
--- a/docs/concepts/universal-catalog.md
+++ b/docs/concepts/universal-catalog.md
@@ -275,6 +275,36 @@ action_retrieval:
   universal_wrappers_enabled: false
 ```
 
+## `embedding_class` default + graceful degrade (FP-0043 Phase 4)
+
+Since **FP-0043 Phase 4 (2026-05-27)**,
+`ActionRetrievalConfig.embedding_class` defaults to `"local-mini"`
+(= `sentence-transformers/all-MiniLM-L6-v2`). This makes
+`search_actions` automatically available for any fresh installation
+that runs `pip install 'reyn[local-embed]'` — no `reyn.yaml` edits
+required.
+
+When the `local-embed` extras are NOT installed, `ChatSession.__init__`
+detects the missing import via a cheap `importlib.util.find_spec`
+probe and silently treats the configured class as if it were `None`:
+no `ActionEmbeddingIndex` is built, `search_actions` stays hidden by
+the §D14 gate, and `list_actions` carries the hidden-state hint
+pointing operators at the install command (= self-discoverable
+mid-chat — see [Guide: enable semantic search](../guide/for-users/enable-semantic-search.md)).
+
+The probe lives in `src/reyn/chat/session.py` as
+`_embedding_class_needs_missing_extras(class_name, embedding_config)`
+and only returns `True` when:
+
+1. The class's `model` string starts with `sentence-transformers/`,
+2. `sentence_transformers` is **not** importable, AND
+3. The configured class exists in `embedding.classes`.
+
+Operators who prefer OpenAI-backed embeddings can override with
+`action_retrieval.embedding_class: standard` (= or `light` / `strong`)
+in `reyn.yaml`; setting it to `null` opts out of `search_actions`
+entirely.
+
 ## What stays out of Phase 1
 
 The structural surface is complete. Discovery features landed and

--- a/docs/guide/for-users/enable-semantic-search.md
+++ b/docs/guide/for-users/enable-semantic-search.md
@@ -11,7 +11,7 @@
 - **Without it**: the LLM has to guess which category your intent belongs to (`file` / `mcp` / `memory.entry` / …) and run `list_actions(category=[...])` to enumerate. For natural-language asks like _"find an action that converts PDF to text"_ the LLM may also try and refuse if it doesn't immediately spot a match.
 - **With it**: the LLM runs `search_actions(query="PDF to text")` and gets a top-K relevance-ranked list across every category. It can then `describe_action` or `invoke_action` directly.
 
-For a fresh `reyn` install with no embedding class configured, `search_actions` is gated **out** of the LLM's tool list (= the [§D14 visibility gate](../../concepts/universal-catalog.md#what-stays-out-of-phase-1)). The LLM never sees it; chat-driven discovery falls back to `list_actions` only.
+**Since FP-0043 Phase 4** (2026-05-27), `action_retrieval.embedding_class` defaults to `local-mini`, so installing the `local-embed` extras is the only step required. If the extras are absent, ChatSession silently treats this as "no class configured" — `search_actions` is gated **out** of the LLM's tool list (= the [§D14 visibility gate](../../concepts/universal-catalog.md#what-stays-out-of-phase-1)) and `list_actions` surfaces the hidden-state hint pointing back at this guide.
 
 ## Path A — local sentence-transformers (recommended for first-time users)
 
@@ -19,7 +19,7 @@ For a fresh `reyn` install with no embedding class configured, `search_actions` 
 pip install 'reyn[local-embed]'
 ```
 
-That's it. The `local-embed` extras install `sentence-transformers` + `torch`, and Reyn's default `action_retrieval.embedding_class` switches to `local-mini` (= `all-MiniLM-L6-v2`, 22 MB, 384-dim, English).
+That's it. The `local-embed` extras install `sentence-transformers` + `torch`. The default `action_retrieval.embedding_class` is already `local-mini` (= `all-MiniLM-L6-v2`, 22 MB, 384-dim, English) since FP-0043 Phase 4, so the moment the import succeeds the wiring activates — no `reyn.yaml` edit needed.
 
 The first time `reyn chat` reaches `search_actions`, the model downloads (~5–10 s on a typical connection) and the embedding index builds. The TUI Memory tab shows a `⟳ loading…` row during the download and a `✓ loaded · all-MiniLM-L6-v2 · 384d` row when done; subsequent sessions warm-start from the local cache in <1 s.
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -313,7 +313,7 @@ FP-0034 universal catalog visibility + retrieval settings.  Provides the chat ro
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # default since PR-3b-iv; set false to opt out
-  embedding_class: null               # name in embedding.classes for search_actions
+  embedding_class: local-mini         # default since FP-0043 Phase 4
   hot_list_n: 10                      # Phase 2 — top-N freq+recency projection
   mode: default                       # default | minimal | performance (§D24)
 ```
@@ -331,7 +331,7 @@ action_retrieval:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | When `true` (default since PR-3b-iv), the router's `tools=` exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) plus hot-list direct aliases.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM but remain in the registry as wrapper backing handlers.  `search_actions` is gated separately by `embedding_class` (FP-0034 §D14).  Set `false` to disable the wrapper surface entirely (= no catalog routing; legacy tools become the only addressing path again — primarily for fixture-stability tests). |
-| `embedding_class` | string \| null | `null` | Name of an entry in [`embedding.classes`](../../concepts/rag.md) to use for action-retrieval semantic search (FP-0034 §D13).  When `null` or empty, `search_actions` is excluded from `tools=` even when wrappers are enabled. Setting this also enables [eager embedding build](#reyn-chat---eager-embedding-build) on cold-start sessions to avoid Turn-1 hallucinations. |
+| `embedding_class` | string \| null | `"local-mini"` | Name of an entry in [`embedding.classes`](../../concepts/rag.md) to use for action-retrieval semantic search (FP-0034 §D13).  Default since FP-0043 Phase 4: `local-mini` (= `sentence-transformers/all-MiniLM-L6-v2`).  When `null` or empty, `search_actions` is excluded from `tools=` even when wrappers are enabled.  Setting this also enables [eager embedding build](#reyn-chat---eager-embedding-build) on cold-start sessions to avoid Turn-1 hallucinations.  **Graceful degrade**: if the chosen class points at a `sentence-transformers/` model but the `local-embed` extras aren't installed, ChatSession silently treats this as `null` and the [`list_actions` hidden-state hint](../../concepts/universal-catalog.md#what-stays-out-of-phase-1) surfaces the install command to the LLM. Set explicitly to `standard` (= OpenAI) or `null` (= opt out) to override. |
 | `hot_list_n` | int | `10` | Hot-list projection size for top-N `freq+recency` direct aliases (FP-0034 §D2 / §D24). Must be ≥ 0. `0` opts out entirely (= §D24 minimal mode). |
 | `mode` | string | `"default"` | Operational mode label per §D24: `"minimal"` (max cache stability, no hot list) / `"default"` (balanced) / `"performance"` (large hot list).  Free-form string; callers layer semantics on top. |
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -142,6 +142,43 @@ def _parse_no_reply_marker(text: str) -> tuple[str, str] | None:
     return m.group(1).strip(), m.group(2).strip()
 
 
+def _embedding_class_needs_missing_extras(
+    class_name: str, embedding_config: Any,
+) -> bool:
+    """Whether the configured embedding class needs sentence-transformers
+    extras that haven't been installed (FP-0043 Phase 4 graceful-degrade).
+
+    The Phase 4 default flip makes ``action_retrieval.embedding_class``
+    default to ``"local-mini"``. For fresh installs that don't have
+    ``pip install 'reyn[local-embed]'`` yet, we don't want to instantiate
+    an ActionEmbeddingIndex whose first embed() call will ImportError —
+    we want ``search_actions`` to stay hidden and let list_actions
+    surface the hidden-state hint pointing operators at the install
+    command. Returns True iff:
+
+      1. ``class_name`` resolves to an entry in ``embedding_config.classes``
+      2. that entry's ``model`` starts with ``sentence-transformers/``
+      3. ``sentence_transformers`` is NOT importable in this env
+
+    Any other failure mode (= unknown class, malformed config) returns
+    False — let the normal try/except path handle it.
+    """
+    try:
+        from reyn.embedding.sentence_transformers_provider import (
+            _PREFIX,
+            is_available,
+        )
+        spec = embedding_config.classes.get(class_name)
+        if spec is None:
+            return False
+        model = getattr(spec, "model", None)
+        if not isinstance(model, str) or not model.startswith(_PREFIX):
+            return False
+        return not is_available()
+    except Exception:
+        return False
+
+
 # Localized user-facing message when a peer agent's reply signals failure (B2-H2).
 # "en" is the global-safe default (no regional fallback to "ja" per the Q2
 # i18n principle). Placeholders: {peer} = peer agent name, {reason} = failure reason.
@@ -1284,6 +1321,10 @@ class ChatSession:
             self._action_retrieval.universal_wrappers_enabled
             and self._action_retrieval.embedding_class
             and embedding_config is not None
+            and not _embedding_class_needs_missing_extras(
+                self._action_retrieval.embedding_class,
+                embedding_config,
+            )
         ):
             try:
                 from reyn.embedding import get_provider as _get_provider

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1147,9 +1147,22 @@ class ActionRetrievalConfig:
             empty, ``search_actions`` is excluded from tools= even if
             ``universal_wrappers_enabled`` is True (§D14 gating).
 
-            Phase 1 leaves the embedding index unbuilt; PR-3b+ may
-            add it. Setting this field today is harmless (= no
-            consumers).
+            **Default since FP-0043 Phase 4**: ``"local-mini"`` (=
+            ``sentence-transformers/all-MiniLM-L6-v2``). When the
+            ``local-embed`` extras are not installed (= ``import
+            sentence_transformers`` fails), ChatSession silently
+            degrades to None — ``search_actions`` stays hidden and
+            ``list_actions`` injects a hidden-state hint pointing
+            operators at ``pip install 'reyn[local-embed]'``. So the
+            new default is "active when the import succeeds, no-op
+            otherwise", giving zero-config fresh users semantic
+            search the moment they install the extras.
+
+            Operators who want OpenAI-backed embeddings instead can
+            set ``action_retrieval.embedding_class: standard`` (= or
+            ``light`` / ``strong``) explicitly in reyn.yaml. Setting
+            it to ``null`` or empty disables ``search_actions``
+            entirely.
 
         hot_list_n:
             Hot list size for top-N freq+recency projection (§D2).
@@ -1170,7 +1183,7 @@ class ActionRetrievalConfig:
     """
 
     universal_wrappers_enabled: bool = True
-    embedding_class: str | None = None
+    embedding_class: str | None = "local-mini"
     hot_list_n: int = 20
     mode: str = "default"
     # FP-0034 §D16: seed qualified names for initial hot list (before freq

--- a/src/reyn/embedding/sentence_transformers_provider.py
+++ b/src/reyn/embedding/sentence_transformers_provider.py
@@ -91,6 +91,19 @@ _INSTALL_HINT = (
 )
 
 
+def is_available() -> bool:
+    """Whether the optional sentence-transformers extras are installed.
+
+    Cheap probe using importlib.util.find_spec — does NOT import the
+    heavy module, just checks whether the import would succeed. Used by
+    callers that need to decide between an ST-backed path and a graceful
+    fallback before any actual embed() call (= FP-0043 Phase 4 default-
+    switch graceful-degrade in :class:`ChatSession`).
+    """
+    import importlib.util
+    return importlib.util.find_spec("sentence_transformers") is not None
+
+
 def _resolve_cache_dir() -> Path:
     """Resolve the cache root per O2 reconcile precedence."""
     if v := os.environ.get("REYN_CACHE_DIR"):

--- a/tests/test_action_retrieval_config.py
+++ b/tests/test_action_retrieval_config.py
@@ -37,10 +37,14 @@ def test_default_action_retrieval_config_is_on() -> None:
 
     PR-3b-iv flipped universal_wrappers_enabled from False to True.
     FP-0034 Phase 6 removed hide_legacy_tools (wrapper-only is the sole path).
+    FP-0043 Phase 4 flipped embedding_class default from None to "local-mini"
+    so semantic action search is on the moment ``reyn[local-embed]`` extras
+    are installed — graceful-degrade kicks in at ChatSession construction
+    when the extras are absent.
     """
     cfg = ActionRetrievalConfig()
     assert cfg.universal_wrappers_enabled is True
-    assert cfg.embedding_class is None
+    assert cfg.embedding_class == "local-mini"
     assert cfg.hot_list_n == 20  # B37: covers DEFAULT_HOT_LIST_SEED (17) + headroom
     assert cfg.mode == "default"
 
@@ -230,7 +234,7 @@ def test_load_config_without_action_retrieval_uses_defaults(tmp_path: Path) -> N
 
     cfg = load_config(cwd=tmp_path)
     assert cfg.action_retrieval.universal_wrappers_enabled is True
-    assert cfg.action_retrieval.embedding_class is None
+    assert cfg.action_retrieval.embedding_class == "local-mini"  # FP-0043 Phase 4
     assert cfg.action_retrieval.hot_list_n == 20
     assert cfg.action_retrieval.mode == "default"
 

--- a/tests/test_fp0043_phase4_default_switch.py
+++ b/tests/test_fp0043_phase4_default_switch.py
@@ -1,0 +1,221 @@
+"""Tier 2: FP-0043 Phase 4 — default ``embedding_class`` flip to ``local-mini``
++ ChatSession graceful-degrade probe when the ``local-embed`` extras
+aren't installed.
+
+What lands here:
+  1. ``ActionRetrievalConfig`` default is ``"local-mini"`` (= flipped
+     from None in this PR).
+  2. ``is_available()`` is a cheap importlib.util.find_spec probe and
+     reflects the live env (= True iff sentence_transformers is
+     importable).
+  3. ``_embedding_class_needs_missing_extras`` correctly identifies
+     when the configured class would require the missing extras:
+
+     - ST-backed class + extras absent  → True  (graceful degrade)
+     - ST-backed class + extras present → False (wire normally)
+     - OpenAI / LiteLLM class           → False (no extras dependency)
+     - Unknown class name               → False (let normal path raise)
+     - Malformed embedding_config       → False (defensive)
+
+  4. The end-to-end shape: when the probe returns True the session
+     skips embedding-index wiring (= same outcome as
+     ``embedding_class=None``).
+
+Phase 4 design intent: fresh users who install ``reyn[local-embed]``
+get ``search_actions`` automatically (= no reyn.yaml edits). Fresh
+users WITHOUT extras see the existing hidden-state hint via
+``list_actions`` pointing them at the install command. No scary
+ImportError at first embed() call; graceful from session start.
+"""
+from __future__ import annotations
+
+import importlib.util
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.chat.session import _embedding_class_needs_missing_extras
+from reyn.config import (
+    ActionRetrievalConfig,
+    EmbeddingClassSpec,
+    EmbeddingConfig,
+)
+from reyn.embedding.sentence_transformers_provider import is_available
+
+# ── 1. Default config value ────────────────────────────────────────────────
+
+
+def test_default_embedding_class_is_local_mini() -> None:
+    """Tier 2: out-of-the-box ``ActionRetrievalConfig`` selects local-mini.
+
+    Phase 4 design: zero-config fresh users with ``reyn[local-embed]``
+    installed get semantic search active without touching reyn.yaml.
+    """
+    cfg = ActionRetrievalConfig()
+    assert cfg.embedding_class == "local-mini"
+
+
+# ── 2. is_available() probe ────────────────────────────────────────────────
+
+
+def test_is_available_matches_live_import_spec() -> None:
+    """Tier 2: is_available() agrees with importlib.util.find_spec.
+
+    The probe doesn't import the heavy module — only checks the spec.
+    Whichever way the env is configured (= extras installed or not),
+    both checks must produce the same boolean.
+    """
+    live_check = importlib.util.find_spec("sentence_transformers") is not None
+    assert is_available() is live_check
+
+
+# ── 3. Probe — ST class, extras-dependent matrix ───────────────────────────
+
+
+def _config_with_classes(**extra: EmbeddingClassSpec) -> EmbeddingConfig:
+    base: dict[str, EmbeddingClassSpec] = {
+        "local-mini": EmbeddingClassSpec(
+            model="sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        "local-e5": EmbeddingClassSpec(
+            model="sentence-transformers/intfloat/multilingual-e5-small",
+        ),
+        "standard": EmbeddingClassSpec(
+            model="openai/text-embedding-3-small",
+        ),
+    }
+    base.update(extra)
+    return EmbeddingConfig(default_class="standard", classes=base)
+
+
+def test_probe_st_class_when_extras_missing_returns_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ST class + import unavailable → True (graceful degrade).
+
+    Simulates a fresh user who set ``embedding_class: local-mini`` (or
+    inherited the Phase 4 default) but never ran
+    ``pip install 'reyn[local-embed]'``. The probe must return True so
+    ChatSession skips embedding wiring entirely; the hidden-state hint
+    path on ``list_actions`` takes over the user-discovery surface.
+    """
+    monkeypatch.setattr(
+        "reyn.embedding.sentence_transformers_provider.is_available",
+        lambda: False,
+    )
+    cfg = _config_with_classes()
+    assert _embedding_class_needs_missing_extras("local-mini", cfg) is True
+    assert _embedding_class_needs_missing_extras("local-e5", cfg) is True
+
+
+def test_probe_st_class_when_extras_present_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ST class + import available → False (wire normally).
+
+    User installed ``reyn[local-embed]``. Probe says "no degrade
+    needed"; the normal wiring path builds the EmbeddingProvider +
+    ActionEmbeddingIndex and ``search_actions`` becomes visible after
+    the first index build completes.
+    """
+    monkeypatch.setattr(
+        "reyn.embedding.sentence_transformers_provider.is_available",
+        lambda: True,
+    )
+    cfg = _config_with_classes()
+    assert _embedding_class_needs_missing_extras("local-mini", cfg) is False
+    assert _embedding_class_needs_missing_extras("local-e5", cfg) is False
+
+
+# ── 4. Probe — non-ST classes never trigger graceful degrade ───────────────
+
+
+@pytest.mark.parametrize("st_available", [True, False])
+def test_probe_openai_class_returns_false(
+    monkeypatch: pytest.MonkeyPatch, st_available: bool,
+) -> None:
+    """Tier 2: OpenAI-backed class doesn't depend on ST extras.
+
+    Regardless of whether ``sentence_transformers`` is importable,
+    setting ``embedding_class: standard`` (= openai/...) must NOT
+    trigger graceful-degrade. The LiteLLM backend handles it; the
+    probe is irrelevant to that path.
+    """
+    monkeypatch.setattr(
+        "reyn.embedding.sentence_transformers_provider.is_available",
+        lambda: st_available,
+    )
+    cfg = _config_with_classes()
+    assert _embedding_class_needs_missing_extras("standard", cfg) is False
+
+
+# ── 5. Probe — defensive cases ─────────────────────────────────────────────
+
+
+def test_probe_unknown_class_returns_false() -> None:
+    """Tier 2: unknown class name → False (let downstream raise normally).
+
+    The probe is a fast filter, not a config validator. Unknown
+    classes flow through to the normal try/except wiring path where
+    KeyError surfaces as a Session-init failure via the existing
+    catch-all (= consistent with Pre-Phase-4 behavior).
+    """
+    cfg = _config_with_classes()
+    assert _embedding_class_needs_missing_extras("nope", cfg) is False
+
+
+def test_probe_malformed_config_returns_false() -> None:
+    """Tier 2: malformed embedding_config (= missing .classes) → False.
+
+    Defensive against exotic test fixtures or partial config shapes.
+    Returning False lets the existing try/except handle the surface
+    rather than the probe masking real config errors.
+    """
+    malformed = SimpleNamespace()  # no .classes attribute
+    assert _embedding_class_needs_missing_extras("local-mini", malformed) is False
+
+
+def test_probe_non_string_model_field_returns_false() -> None:
+    """Tier 2: spec with non-string model → False (defensive)."""
+    cfg = EmbeddingConfig(
+        default_class="standard",
+        classes={"weird": SimpleNamespace(model=None)},  # type: ignore[dict-item]
+    )
+    assert _embedding_class_needs_missing_extras("weird", cfg) is False
+
+
+def test_probe_st_prefix_substring_doesnt_trigger() -> None:
+    """Tier 2: model name that merely contains the prefix does NOT trigger.
+
+    Only the leading ``sentence-transformers/`` qualifies. A model
+    string like ``foo/sentence-transformers/...`` is treated as
+    not-ST (= future-compat shield).
+    """
+    cfg = EmbeddingConfig(
+        default_class="standard",
+        classes={
+            "tricky": EmbeddingClassSpec(model="foo/sentence-transformers/bar"),
+        },
+    )
+    assert _embedding_class_needs_missing_extras("tricky", cfg) is False
+
+
+# ── 6. End-to-end shape (= the probe is wired into the gate) ──────────────
+
+
+def test_probe_is_referenced_in_session_init_source() -> None:
+    """Tier 2: the probe call appears in ChatSession.__init__'s gate.
+
+    We don't construct a full ChatSession here (= heavy deps). Instead
+    we sanity-check that ``_embedding_class_needs_missing_extras`` is
+    actually invoked from the gate by inspecting the module source.
+    Catches a future accidental removal that would silently disable
+    the graceful-degrade branch (= the existing default-flip would
+    then start raising ImportError at first embed() for fresh users
+    without extras).
+    """
+    import inspect
+
+    import reyn.chat.session as session_mod
+    src = inspect.getsource(session_mod.ChatSession.__init__)
+    assert "_embedding_class_needs_missing_extras" in src

--- a/tests/test_router_system_prompt_wrapper_visibility.py
+++ b/tests/test_router_system_prompt_wrapper_visibility.py
@@ -92,9 +92,12 @@ def test_search_actions_enabled_true_includes_behaviour_guidance() -> None:
 def test_search_actions_enabled_false_omits_search_actions_from_sp() -> None:
     """Tier 2: search_actions_enabled=False → search_actions absent from SP.
 
-    This is the path when no embedding_class is configured (= default env).
-    The LLM must not see search_actions in the SP because it is not in
-    tools=, which would invite hallucinated calls (N5 finding).
+    This is the path when embedding_class is unset (= explicit ``null`` /
+    empty in ``reyn.yaml``) OR the graceful-degrade probe fired (= FP-0043
+    Phase 4 default `local-mini` but ``reyn[local-embed]`` extras absent).
+    Both routes set ``search_actions_enabled=False`` upstream. The LLM
+    must not see search_actions in the SP because it is not in tools=,
+    which would invite hallucinated calls (N5 finding).
     """
     sp = build_system_prompt(**_BASE, search_actions_enabled=False)
     assert "search_actions" not in sp


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 final phase per [#922](https://github.com/tya5/reyn/issues/922). User authorized via AskUserQuestion: "Switch to local-mini (recommended)". This closes FP-0043 → next FP slot opens.

## Summary

- Flips `ActionRetrievalConfig.embedding_class` default from `None` to `"local-mini"`. Fresh users who run `pip install 'reyn[local-embed]'` get `search_actions` automatically — no `reyn.yaml` edits.
- Adds a graceful-degrade probe (`_embedding_class_needs_missing_extras`) wired into `ChatSession.__init__`'s embedding-wiring gate. When the configured class is `sentence-transformers/`-prefixed but `sentence_transformers` is not importable, the probe returns True and the session silently behaves as if `embedding_class=None` (= `search_actions` hidden by §D14 gate; `list_actions` hidden-state hint surfaces the install command to the LLM).
- New cheap `is_available()` helper in the ST provider using `importlib.util.find_spec` — no heavy import at probe time.

## What this is NOT

- Not a runtime check at every embed call — strictly session-construction-time. The check is O(1) and runs once.
- Not a behavior change for operators with an explicit `embedding_class:` in `reyn.yaml`. Only the default (= field omitted) is affected.
- Not a backwards-compat shim — existing OpenAI users (`embedding_class: standard`) are unchanged.

## Files changed

| Surface | File | Change |
|---|---|---|
| Config default | `src/reyn/config.py` | `embedding_class` default `None` → `"local-mini"`; docstring extended |
| ST probe | `src/reyn/embedding/sentence_transformers_provider.py` | NEW `is_available()` public helper |
| Session gate | `src/reyn/chat/session.py` | NEW `_embedding_class_needs_missing_extras` helper + wired into wiring gate |
| Test (NEW) | `tests/test_fp0043_phase4_default_switch.py` | 9 Tier-2 tests — default, probe matrix, defensive cases, source-inspection guard |
| Test (updated) | `tests/test_action_retrieval_config.py` | 2 default-pin assertions flipped; opt-out parser tests unchanged |
| Test (updated) | `tests/test_router_system_prompt_wrapper_visibility.py` | docstring update reflecting the new graceful-degrade route |
| Docs | `docs/reference/config/reyn-yaml.md` | example + field-table default + graceful-degrade description |
| Docs | `docs/concepts/universal-catalog.md` | new section "`embedding_class` default + graceful degrade (FP-0043 Phase 4)" |
| Docs | `docs/guide/for-users/enable-semantic-search.md` | Path A copy adjusted; fresh-install behavior described |

## Test plan

- [x] **Targeted**: `pytest -q tests/test_fp0043_phase4_default_switch.py tests/test_action_retrieval_config.py tests/test_router_system_prompt_wrapper_visibility.py` — 44 pass.
- [x] **Impacted area**: `pytest -q tests/test_action_embedding_index*.py tests/test_embedding_*.py tests/test_list_actions_hidden_state_hint.py tests/test_universal_handlers.py tests/test_universal_catalog.py tests/test_universal_dispatch.py` — 309 pass.
- [x] **Full suite**: `pytest -q --ignore=.claude` — 5951 pass / 1 pre-existing failure (= `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`, reproduces on `origin/main` HEAD, unrelated to FP-0043) / 5 skipped / 3 xfailed.
- [x] **Lint**: `ruff check .` — passes (one auto-fixable I001 on the new test file was applied before commit).
- [x] **Tier rule self-check** (= [[feedback_pr_tier_rule_self_check]]):
   - docstrings: every new test opens with `"""Tier 2:` ✓
   - Tier 4 ban: no Mock/AsyncMock/patch on collaborators; `monkeypatch.setattr` on a pure module function is policy-permitted ✓
   - private-state ban: `grep -nE 'assert .*\._[a-z_]+' tests/test_fp0043_phase4_default_switch.py` returns empty ✓
   - format-pinning ban: source-inspection test asserts symbol name presence only ✓

## Test plan check

End-of-PR-body line per the [[feedback_pr_tier_rule_self_check]] workflow: **all four self-check items above pass**, audit count = 0.

Closes FP-0043 (= [#922](https://github.com/tya5/reyn/issues/922)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)