### PR TITLE
chore(auth): rename _classify_token_status → classify_token_status (Tier C1 cleanup wave 3)

### DIFF
--- a/src/reyn/cli/commands/auth.py
+++ b/src/reyn/cli/commands/auth.py
@@ -295,7 +295,7 @@ def run_login(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
-def _classify_token_status(delta_seconds: float) -> str:
+def classify_token_status(delta_seconds: float) -> str:
     """Map an ``expires_at - now`` delta (seconds) to a 3-state label.
 
     Issue #291 Priority 3 #9: previously the 2-state label ``valid`` /
@@ -331,7 +331,7 @@ def run_list(args: argparse.Namespace) -> None:
             print(f"  {key}: <malformed>")
             continue
         delta = token.expires_at - now
-        status = _classify_token_status(delta.total_seconds())
+        status = classify_token_status(delta.total_seconds())
         print(f"  {key}: {status}, expires {token.expires_at.isoformat()}")
 
 

--- a/tests/cli/test_auth_login_ux_p3.py
+++ b/tests/cli/test_auth_login_ux_p3.py
@@ -5,7 +5,7 @@ Pins:
   1. ``_print_scope_advertisement`` prints the configured scopes before
      the device_authorization POST (= user sees what permissions reyn
      is about to ask for, can abort before any network round-trip).
-  2. ``_classify_token_status`` returns ``expired`` / ``near-expiry``
+  2. ``classify_token_status`` returns ``expired`` / ``near-expiry``
      / ``valid`` matching the OAuth refresh buffer threshold (60 s).
   3. ``run_list`` surfaces the 3-state classification end-to-end with
      fixture tokens written to a tmp_path OAuth store.
@@ -78,13 +78,13 @@ def test_scope_advertisement_handles_missing_scopes_attr(
     assert capsys.readouterr().err == ""
 
 
-# ── _classify_token_status ──────────────────────────────────────────────────
+# ── classify_token_status ──────────────────────────────────────────────────
 
 
 def test_classify_token_status_expired() -> None:
     """Tier 2: negative delta → ``expired`` (= past expires_at)."""
-    assert auth_mod._classify_token_status(-1.0) == "expired"
-    assert auth_mod._classify_token_status(-3600.0) == "expired"
+    assert auth_mod.classify_token_status(-1.0) == "expired"
+    assert auth_mod.classify_token_status(-3600.0) == "expired"
 
 
 def test_classify_token_status_near_expiry() -> None:
@@ -94,16 +94,16 @@ def test_classify_token_status_near_expiry() -> None:
     token within 60 s of expiry will refresh on next ``get_valid_token``
     call, so flagging it explicitly helps users predict behavior.
     """
-    assert auth_mod._classify_token_status(0.0) == "near-expiry"
-    assert auth_mod._classify_token_status(30.0) == "near-expiry"
-    assert auth_mod._classify_token_status(59.999) == "near-expiry"
+    assert auth_mod.classify_token_status(0.0) == "near-expiry"
+    assert auth_mod.classify_token_status(30.0) == "near-expiry"
+    assert auth_mod.classify_token_status(59.999) == "near-expiry"
 
 
 def test_classify_token_status_valid() -> None:
     """Tier 2: delta >= 60 → ``valid`` (= no refresh needed)."""
-    assert auth_mod._classify_token_status(60.0) == "valid"
-    assert auth_mod._classify_token_status(3600.0) == "valid"
-    assert auth_mod._classify_token_status(86400.0) == "valid"
+    assert auth_mod.classify_token_status(60.0) == "valid"
+    assert auth_mod.classify_token_status(3600.0) == "valid"
+    assert auth_mod.classify_token_status(86400.0) == "valid"
 
 
 # ── run_list end-to-end with 3-state fixtures ───────────────────────────────


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 third slice. **Rename** mitigation: the leading underscore on a stable, pure-function module-level helper was just a convention signal, not an API stability marker. Dropping it lets tests reference the public name; the only production caller is in the same module.

## Changes

\`src/reyn/cli/commands/auth.py\`:
- \`def _classify_token_status(...)\` → \`def classify_token_status(...)\`
- caller in \`run_list\` (1 site) updated

\`tests/cli/test_auth_login_ux_p3.py\`:
- 8 Tier-C1 findings cleared
- \`auth_mod._classify_token_status(...)\` → \`auth_mod.classify_token_status(...)\` (8 sites)
- Docstring / section-header text references updated for consistency
- Test function names (= \`test_classify_token_status_*\`) preserved

## Why

The helper is a pure 3-state OAuth-expiry classifier (issue #291 Priority 3 #9) with stable contract. The \`_\` prefix had no API-stability promise — no external callers (verified via repo-wide grep). Same rationale as PRs #944 / #945; this slice's mitigation is **rename** (vs the previous slices' **add public accessor**) because module-level helpers are cleaner with a public name than a wrapper.

## Tier rule self-check
- [x] Tier docstrings carry \`Tier 2:\` prefix (= pre-existing)
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/cli/test_auth_login_ux_p3.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical equality / return-value semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/cli/test_auth_login_ux_p3.py\` → 8 passed
- [x] \`grep -rn "_classify_token_status" --include="*.py"\` → only \`test_classify_token_status_*\` function names remain (= not the underscore-prefixed module function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)