### PR TITLE
chore(embedding): rename _resolve_model → resolve_model (Tier C1 cleanup wave 4)

### DIFF
--- a/scripts/embedding_bench.py
+++ b/scripts/embedding_bench.py
@@ -139,7 +139,7 @@ async def _run_class(
 
     cfg = load_config()
     provider = LiteLLMEmbeddingProvider(config=cfg.embedding)
-    resolved = provider._resolve_model(class_name)
+    resolved = provider.resolve_model(class_name)
 
     index = ActionEmbeddingIndex(persist_dir=None)
     await index.build(catalog, provider, class_name)

--- a/src/reyn/embedding/litellm_provider.py
+++ b/src/reyn/embedding/litellm_provider.py
@@ -171,7 +171,7 @@ class LiteLLMEmbeddingProvider:
 
     # ── Model resolution ───────────────────────────────────────────────────
 
-    def _resolve_model(self, model: str) -> str:
+    def resolve_model(self, model: str) -> str:
         """Resolve a model class name or literal string to a LiteLLM model.
 
         If model contains "/" it's already a literal string — use directly.
@@ -204,7 +204,7 @@ class LiteLLMEmbeddingProvider:
 
     def get_dimension(self, model: str) -> int:
         """Return vector dimension for a model. Uses static table; defaults 1536."""
-        resolved = self._resolve_model(model)
+        resolved = self.resolve_model(model)
         return _MODEL_DIMENSIONS.get(resolved, _DEFAULT_DIMENSION)
 
     # ── Core embed ─────────────────────────────────────────────────────────
@@ -223,10 +223,10 @@ class LiteLLMEmbeddingProvider:
             EmbedBatchResult with vectors, canonical model name, total_tokens.
         """
         if not texts:
-            resolved = self._resolve_model(model)
+            resolved = self.resolve_model(model)
             return EmbedBatchResult(vectors=[], model=resolved, total_tokens=0)
 
-        resolved_model = self._resolve_model(model)
+        resolved_model = self.resolve_model(model)
 
         # Split into batches
         batches: list[list[str]] = []

--- a/src/reyn/embedding/sentence_transformers_provider.py
+++ b/src/reyn/embedding/sentence_transformers_provider.py
@@ -184,7 +184,7 @@ class SentenceTransformersEmbeddingProvider:
 
     # ── Model resolution ───────────────────────────────────────────────────
 
-    def _resolve_model(self, model: str) -> str:
+    def resolve_model(self, model: str) -> str:
         """Resolve a class name to the underlying ``sentence-transformers/<id>``.
 
         If ``model`` already carries the prefix or a ``/``, return as-is.
@@ -304,7 +304,7 @@ class SentenceTransformersEmbeddingProvider:
         table for local models; sentence-transformers exposes this on
         the loaded instance).
         """
-        resolved = self._resolve_model(model)
+        resolved = self.resolve_model(model)
         m = self._load(resolved)
         return int(m.get_sentence_embedding_dimension())
 
@@ -320,7 +320,7 @@ class SentenceTransformersEmbeddingProvider:
             EmbedBatchResult with vectors in input order. ``total_tokens``
             is the estimate (no API per-token billing for local models).
         """
-        resolved = self._resolve_model(model)
+        resolved = self.resolve_model(model)
         if not texts:
             return EmbedBatchResult(vectors=[], model=resolved, total_tokens=0)
 

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -198,14 +198,14 @@ class TestResolveModel:
     def test_literal_model_passthrough(self):
         """Tier 2: model with '/' is used directly without class lookup."""
         provider = _make_provider({"classes": {}})
-        assert provider._resolve_model("openai/text-embedding-3-small") == \
+        assert provider.resolve_model("openai/text-embedding-3-small") == \
             "openai/text-embedding-3-small"
 
     def test_class_lookup_string_value(self):
         """Tier 2: class name without '/' is resolved via classes dict."""
         config = {"classes": {"standard": "openai/text-embedding-3-small"}}
         provider = _make_provider(config)
-        assert provider._resolve_model("standard") == "openai/text-embedding-3-small"
+        assert provider.resolve_model("standard") == "openai/text-embedding-3-small"
 
     def test_class_lookup_dict_value(self):
         """Tier 2: dict-form class is resolved via 'model' key."""
@@ -215,7 +215,7 @@ class TestResolveModel:
             }
         }
         provider = _make_provider(config)
-        assert provider._resolve_model("custom") == "openai/text-embedding-3-large"
+        assert provider.resolve_model("custom") == "openai/text-embedding-3-large"
 
     def test_class_extends_chain(self):
         """Tier 2: 'extends' chain resolves transitively."""
@@ -226,7 +226,7 @@ class TestResolveModel:
             }
         }
         provider = _make_provider(config)
-        assert provider._resolve_model("derived") == "openai/text-embedding-3-small"
+        assert provider.resolve_model("derived") == "openai/text-embedding-3-small"
 
     def test_class_extends_with_model_override(self):
         """Tier 2: 'extends' + explicit 'model' key overrides the base model."""
@@ -240,13 +240,13 @@ class TestResolveModel:
             }
         }
         provider = _make_provider(config)
-        assert provider._resolve_model("custom") == "openai/text-embedding-3-large"
+        assert provider.resolve_model("custom") == "openai/text-embedding-3-large"
 
     def test_unknown_class_passthrough(self):
         """Tier 2: unknown class name (no '/') passes through unchanged."""
         provider = _make_provider({"classes": {}})
         # No slash, not in classes → passthrough (backward compat)
-        assert provider._resolve_model("mystery") == "mystery"
+        assert provider.resolve_model("mystery") == "mystery"
 
     def test_cycle_raises_value_error(self):
         """Tier 2: circular extends raises ValueError."""

--- a/tests/test_embedding_sentence_transformers_provider.py
+++ b/tests/test_embedding_sentence_transformers_provider.py
@@ -112,7 +112,7 @@ def test_class_name_resolves_to_model_string() -> None:
     """Tier 2: 'local-mini' → 'sentence-transformers/all-MiniLM-L6-v2' via classes map."""
     cfg = _config_with_local_class()
     p = SentenceTransformersEmbeddingProvider(config=cfg)
-    assert p._resolve_model("local-mini") == "sentence-transformers/all-MiniLM-L6-v2"
+    assert p.resolve_model("local-mini") == "sentence-transformers/all-MiniLM-L6-v2"
 
 
 def test_model_string_with_slash_passes_through() -> None:
@@ -120,7 +120,7 @@ def test_model_string_with_slash_passes_through() -> None:
     cfg = _config_with_local_class()
     p = SentenceTransformersEmbeddingProvider(config=cfg)
     assert (
-        p._resolve_model("sentence-transformers/all-MiniLM-L6-v2")
+        p.resolve_model("sentence-transformers/all-MiniLM-L6-v2")
         == "sentence-transformers/all-MiniLM-L6-v2"
     )
 


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 fourth slice. Same **rename** mitigation pattern as PR #947 — drop the underscore on a pure-function method with a stable contract.

## Changes

### Production (rename + 5 internal callers updated)
- \`src/reyn/embedding/litellm_provider.py\`: \`LiteLLMEmbeddingProvider._resolve_model\` → \`resolve_model\` + 3 internal \`self.\` callers
- \`src/reyn/embedding/sentence_transformers_provider.py\`: \`SentenceTransformersEmbeddingProvider._resolve_model\` → \`resolve_model\` + 2 internal \`self.\` callers

### Script (1 caller updated)
- \`scripts/embedding_bench.py\`: \`provider._resolve_model(class_name)\` → \`provider.resolve_model(class_name)\`

### Tests (8 Tier-C1 findings cleared)
- \`tests/test_embedding_provider.py\` — 6 findings on \`provider._resolve_model(...)\` (LiteLLM variant)
- \`tests/test_embedding_sentence_transformers_provider.py\` — 2 findings on \`p._resolve_model(...)\` (sentence-transformers variant)

## Why
The resolver is a pure class-name-to-model-string lookup with stable contract (= literal passthrough for \`/\`-prefixed names, dict lookup otherwise). The leading underscore was convention; no API stability marker, no external promise. Rename ships cleanly.

The module-level helper \`_resolve_model_from_config\` keeps its underscore — it is the actual private implementation detail consumed only inside the class.

## Out of scope
Remaining ~7 findings in \`tests/test_embedding_provider.py\` for \`_batch_size\` / \`_max_concurrent\` / \`_max_retries\` / \`_retry_backoff\` are config-field reads — different mitigation (= \`@property\` accessor or constructor-arg surface). Will be in a separate slice to keep this PR focused on the rename pattern.

## Tier rule self-check
- [x] Tier docstrings preserved
- [x] Audit: \`_resolve_model\` findings cleared (= 0 left); the config-field findings remain (= out of scope, articulated above)
- [x] Load-bearing invariants preserved (= identical return-value semantics, only the symbol moved)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_embedding_provider.py tests/test_embedding_sentence_transformers_provider.py tests/test_action_embedding_index.py\` → 79 passed (= no regression in adjacent embedding tests)
- [x] \`grep -rn "\._resolve_model(" --include="*.py"\` → 0 matches
- [x] \`ruff check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)