### PR TITLE
chore(embedding): @property accessors for LiteLLMEmbeddingProvider config (Tier C1 cleanup wave 5)

### DIFF
--- a/src/reyn/embedding/litellm_provider.py
+++ b/src/reyn/embedding/litellm_provider.py
@@ -169,6 +169,28 @@ class LiteLLMEmbeddingProvider:
             self._retry_backoff: float = float(config.get("retry_backoff", 2.0))
             self.tokenizer: str = config.get("tokenizer", "cl100k_base")
 
+    # ── Config read-only accessors ────────────────────────────────────────
+    # Tier-C1 cleanup: expose the init-time-frozen config fields via
+    # ``@property`` so callers (= tests, future tooling) can read them
+    # without reaching for ``_batch_size`` etc. Pure read-only — the
+    # provider does not mutate these after ``__init__``.
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    @property
+    def max_concurrent(self) -> int:
+        return self._max_concurrent
+
+    @property
+    def max_retries(self) -> int:
+        return self._max_retries
+
+    @property
+    def retry_backoff(self) -> float:
+        return self._retry_backoff
+
     # ── Model resolution ───────────────────────────────────────────────────
 
     def _resolve_model(self, model: str) -> str:

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -466,17 +466,17 @@ class TestConfigDefaults:
     def test_default_batch_size(self):
         """Tier 2: batch_size defaults to 100 when not in config."""
         provider = _make_provider()
-        assert provider._batch_size == 100
+        assert provider.batch_size == 100
 
     def test_default_max_concurrent(self):
         """Tier 2: max_concurrent_batches defaults to 1 (sequential)."""
         provider = _make_provider()
-        assert provider._max_concurrent == 1
+        assert provider.max_concurrent == 1
 
     def test_default_max_retries(self):
         """Tier 2: max_retries defaults to 3."""
         provider = _make_provider()
-        assert provider._max_retries == 3
+        assert provider.max_retries == 3
 
     def test_default_tokenizer(self):
         """Tier 2: tokenizer defaults to cl100k_base."""
@@ -493,8 +493,8 @@ class TestConfigDefaults:
             "tokenizer": "p50k_base",
         }
         provider = _make_provider(config)
-        assert provider._batch_size == 25
-        assert provider._max_concurrent == 4
-        assert provider._max_retries == 5
-        assert provider._retry_backoff == 3.0
+        assert provider.batch_size == 25
+        assert provider.max_concurrent == 4
+        assert provider.max_retries == 5
+        assert provider.retry_backoff == 3.0
         assert provider.tokenizer == "p50k_base"


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 fifth slice. ``@property`` mitigation pattern for the four init-time-frozen config scalars on ``LiteLLMEmbeddingProvider``.

## Changes

### Production (4 @property accessors)
- \`src/reyn/embedding/litellm_provider.py\` — add \`batch_size\` / \`max_concurrent\` / \`max_retries\` / \`retry_backoff\` properties. The provider does not mutate these after \`__init__\`, so read-only is the right surface.

### Tests (7 Tier-C1 findings cleared)
- \`tests/test_embedding_provider.py::TestConfigDefaults\` — 7 \`provider._<field>\` reads → \`provider.<field>\` (= \`_batch_size\` ×2, \`_max_concurrent\` ×2, \`_max_retries\` ×2, \`_retry_backoff\` ×1)

## Why
Mitigation pattern matches PR #906 (= \`@property\` for read-only scalar). The fields are unambiguously read-only (no setter on production side); exposing them via property is a clean public-API addition without changing storage layout.

## Companion to PR #948
Both slices touch \`src/reyn/embedding/litellm_provider.py\` but their diffs do NOT overlap:
- #948 = method rename (\`_resolve_model\` → \`resolve_model\`)
- #945 (this one) = new \`@property\` blocks

Either can land first; the other will merge cleanly without rebase.

## Out of scope
The 6 \`_resolve_model\` findings in this same test file are in PR #948 (= different mitigation). Once both PRs land, \`tests/test_embedding_provider.py\` will be private-state-clean.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit on touched file: 7 config-field findings → 0 (the 6 remaining are \`_resolve_model\` covered by PR #948)
- [x] Load-bearing invariants preserved (= identical equality semantics, only the symbol moved)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_embedding_provider.py\` → 46 passed
- [x] \`grep -E "provider\._batch_size|\._max_concurrent|\._max_retries|\._retry_backoff" tests/test_embedding_provider.py\` → 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)