### PR TITLE
chore(agent): add Agent.secret_store @property (Tier C1 cleanup wave 6)

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -92,6 +92,16 @@ class Agent:
     def caller(self) -> str:
         return self._caller
 
+    @property
+    def secret_store(self):
+        """Read-only accessor for the injected ScopedSecretStore (or None).
+
+        Mirrors ``OSRuntime.secret_store`` / ``ControlIRExecutor.secret_store``
+        so callers (= tests verifying DI identity) can probe the wiring via
+        the public surface instead of reaching into ``_secret_store``.
+        """
+        return self._secret_store
+
     async def run(
         self,
         skill: Skill,

--- a/tests/test_fp0016_d_secret_store_threading.py
+++ b/tests/test_fp0016_d_secret_store_threading.py
@@ -106,7 +106,7 @@ def test_agent_default_secret_store_is_none() -> None:
     from reyn.agent import Agent
 
     agent = Agent(model="standard")
-    assert agent._secret_store is None
+    assert agent.secret_store is None
 
 
 def test_agent_explicit_secret_store_is_stored() -> None:
@@ -115,7 +115,7 @@ def test_agent_explicit_secret_store_is_stored() -> None:
 
     store = _make_store(["API_KEY"])
     agent = Agent(model="standard", secret_store=store)
-    assert agent._secret_store is store
+    assert agent.secret_store is store
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ def test_osruntime_stores_secret_store(tmp_path: Path) -> None:
     skill = _make_minimal_skill()
     store = _make_store(["DB_PASSWORD"])
     runtime = OSRuntime(skill, "standard", secret_store=store)
-    assert runtime._secret_store is store
+    assert runtime.secret_store is store
 
 
 def test_osruntime_propagates_store_to_control_ir_executor(tmp_path: Path) -> None:
@@ -172,14 +172,14 @@ def test_osruntime_none_store_propagates_as_none(tmp_path: Path) -> None:
 def test_control_ir_executor_default_secret_store_is_none(tmp_path: Path) -> None:
     """Tier 2: ControlIRExecutor() without secret_store defaults _secret_store to None."""
     executor = _make_executor(tmp_path)
-    assert executor._secret_store is None
+    assert executor.secret_store is None
 
 
 def test_control_ir_executor_stores_secret_store(tmp_path: Path) -> None:
     """Tier 2: ControlIRExecutor(secret_store=<store>) stores on _secret_store."""
     store = _make_store(["API_TOKEN"])
     executor = _make_executor(tmp_path, secret_store=store)
-    assert executor._secret_store is store
+    assert executor.secret_store is store
 
 
 def test_control_ir_executor_build_ctx_propagates_store(tmp_path: Path) -> None:
@@ -207,14 +207,14 @@ def test_control_ir_executor_build_ctx_none_store_propagates_none(tmp_path: Path
 def test_preprocessor_executor_default_secret_store_is_none() -> None:
     """Tier 2: PreprocessorExecutor() without secret_store defaults _secret_store to None."""
     executor = _make_preprocessor_executor()
-    assert executor._secret_store is None
+    assert executor.secret_store is None
 
 
 def test_preprocessor_executor_stores_secret_store() -> None:
     """Tier 2: PreprocessorExecutor(secret_store=<store>) stores on _secret_store."""
     store = _make_store(["WEBHOOK_SECRET"])
     executor = _make_preprocessor_executor(secret_store=store)
-    assert executor._secret_store is store
+    assert executor.secret_store is store
 
 
 def test_preprocessor_executor_build_op_ctx_propagates_store() -> None:


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 sixth slice. ``@property`` mitigation that brings ``Agent``'s secret-store surface into symmetry with the three sibling DI carriers (\`OSRuntime\` / \`ControlIRExecutor\` / \`PreprocessorExecutor\`).

## Changes

### Production
- \`src/reyn/agent.py\` — add \`Agent.secret_store\` ``@property`` returning the same instance threaded in via \`__init__\`. Read-only; the existing siblings (\`OSRuntime.secret_store\`, \`ControlIRExecutor.secret_store\`, \`PreprocessorExecutor.secret_store\`) already expose the equivalent property; Agent now matches.

### Tests (7 Tier-C1 findings cleared)
- \`tests/test_fp0016_d_secret_store_threading.py\`:
  - \`agent._secret_store is None\` → \`agent.secret_store is None\` (×2)
  - \`runtime._secret_store is store\` → \`runtime.secret_store is store\` (×1)
  - \`executor._secret_store is None / is store\` → \`executor.secret_store is …\` (×4)

## Why
The four DI carriers are interchangeable in test prose — "the store handed in is the same object threaded down". Three of them expose the public surface already; \`Agent\` only had the private field. The asymmetry caused the test file to mix \`agent.secret_store\` (NB: doesn't exist) with \`runtime._secret_store\` (NB: also accepted by sibling property) — the cleanup makes both lookups uniform.

Storage layout unchanged — only the public read accessor is new.

## Tier rule self-check
- [x] Tier 2 docstrings preserved (= per-test \`Tier 2:\` prefix kept)
- [x] Audit: \`python3 scripts/test_tier_audit.py --check private-state tests/test_fp0016_d_secret_store_threading.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical \`is\`-identity semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_fp0016_d_secret_store_threading.py\` → 15 passed
- [x] \`ruff check\` → clean
- [x] Remaining \`_secret_store\` strings in the file are docstring / comment text only (= not assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)