### PR TITLE
chore(session): expose interventions as @property (Tier C1 cleanup wave 7)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1809,6 +1809,19 @@ class ChatSession:
         """
         return self._agent_role
 
+    @property
+    def interventions(self) -> "InterventionRegistry":
+        """Read-only public accessor for the session's InterventionRegistry.
+
+        The registry itself carries rich public API (= ``get`` /
+        ``queued_count`` / ``list_active`` / ``has_active_listener`` /
+        ``is_listener_enforcement_enabled``), so exposing it directly
+        keeps callers off the underscore field without forcing a
+        delegate-method explosion on ChatSession. The registry
+        instance is set once in ``__init__`` and never re-bound.
+        """
+        return self._interventions
+
     # ── SkillRunner forwarding (FP-0019 Wave 1b) ────────────────────────────────
     # slash/skill.py and slash/tasks.py access these dicts directly via session.
     # Forward to SkillRunner so external callers see the same live dict.

--- a/tests/test_a2a_restart_resume_292.py
+++ b/tests/test_a2a_restart_resume_292.py
@@ -136,7 +136,7 @@ def test_a2a_restart_resume_round_trip_ask_user(tmp_path: Path) -> None:
             await asyncio.sleep(0)
 
         # The iv must be back in the active queue.
-        assert session._interventions.get(iv_id) is not None
+        assert session.interventions.get(iv_id) is not None
 
         # ── Phase 3: simulate peer answer via A2A router path ──────
         # This is what _handle_answer_injection calls under α.

--- a/tests/test_intervention_agent_routing.py
+++ b/tests/test_intervention_agent_routing.py
@@ -136,7 +136,7 @@ def test_self_answer_branch_returns_directly_without_dispatch() -> None:
     assert answer.choice_id == "self"
 
     # And the registry queue must be untouched — no prompt was enqueued.
-    assert session._interventions.queued_count() == 0
+    assert session.interventions.queued_count() == 0
 
 
 def test_self_answer_branch_emits_self_answer_event() -> None:

--- a/tests/test_intervention_agent_subscriber.py
+++ b/tests/test_intervention_agent_subscriber.py
@@ -205,7 +205,7 @@ def test_agent_request_bus_request_with_registered_listener_round_trip(
     assert answer.text == "hello"
 
 
-# ── 5. session._interventions attribute path is stable (tui-coder Q2) ──
+# ── 5. session.interventions attribute path is stable (tui-coder Q2) ──
 
 
 def test_session_interventions_attribute_path_is_stable_in_phase3() -> None:
@@ -215,17 +215,17 @@ def test_session_interventions_attribute_path_is_stable_in_phase3() -> None:
 
     Phase 3 introduces the Agent-layer entry point + AgentRequestBus
     adapter but does NOT move ownership of the registry. TUI continues
-    to read ``session._interventions.queued_count()`` etc. without any
+    to read ``session.interventions.queued_count()`` etc. without any
     import / call site change. If a future phase moves the registry into
-    a sub-component, ``session._interventions`` must remain a proxy.
+    a sub-component, ``session.interventions`` must remain a proxy.
     """
     from reyn.chat.services.intervention_registry import InterventionRegistry
 
     session = ChatSession(agent_name="t")
     assert hasattr(session, "_interventions")
-    assert isinstance(session._interventions, InterventionRegistry)
+    assert isinstance(session.interventions, InterventionRegistry)
     # The registry is still enforcing the Phase 1 subscriber guard.
-    assert session._interventions.is_listener_enforcement_enabled() is True
+    assert session.interventions.is_listener_enforcement_enabled() is True
 
 
 # ── 6. handle_intervention preserves the chain-override path ───────────

--- a/tests/test_intervention_restore.py
+++ b/tests/test_intervention_restore.py
@@ -121,7 +121,7 @@ async def test_registry_restore_all_includes_outstanding_interventions(tmp_path,
     # Yield so the restore tasks register the iv into the queue
     for _ in range(3):
         await asyncio.sleep(0)
-    iv_ids = [iv.id for iv in session._interventions.list_active()]
+    iv_ids = [iv.id for iv in session.interventions.list_active()]
     assert "iv_stranded" in iv_ids, (
         f"restored intervention must be in the session's queue; got {iv_ids}"
     )
@@ -146,7 +146,7 @@ async def test_session_restore_state_re_enqueues_intervention(tmp_path, monkeypa
     # Yield so any restore-time asyncio tasks schedule
     await asyncio.sleep(0)
 
-    actives = session._interventions.list_active()
+    actives = session.interventions.list_active()
     assert actives
     assert actives[0].id == "iv_recovered"
     assert actives[0].prompt == "Recovered Q?"
@@ -221,7 +221,7 @@ async def test_multiple_restored_interventions_preserve_order(tmp_path, monkeypa
     for _ in range(3):
         await asyncio.sleep(0)
 
-    actives = session._interventions.list_active()
+    actives = session.interventions.list_active()
     assert [iv.id for iv in actives] == ["iv_0", "iv_1", "iv_2"]
 
 
@@ -238,4 +238,4 @@ async def test_restore_state_with_no_interventions_is_noop(tmp_path, monkeypatch
     for _ in range(3):
         await asyncio.sleep(0)
 
-    assert session._interventions.list_active() == []
+    assert session.interventions.list_active() == []

--- a/tests/test_intervention_subscriber_guard.py
+++ b/tests/test_intervention_subscriber_guard.py
@@ -224,8 +224,8 @@ def test_chat_session_constructs_registry_in_enforced_mode(tmp_path: Path) -> No
     # Internal attribute access is acceptable here because we are pinning
     # the wiring invariant the entry-point relies on. The public surface
     # ``register_intervention_listener`` is what callers use.
-    assert session._interventions.is_listener_enforcement_enabled() is True
-    assert session._interventions.has_active_listener() is False
+    assert session.interventions.is_listener_enforcement_enabled() is True
+    assert session.interventions.has_active_listener() is False
 
 
 def test_chat_session_register_intervention_listener_round_trip() -> None:
@@ -235,10 +235,10 @@ def test_chat_session_register_intervention_listener_round_trip() -> None:
     session = ChatSession(agent_name="test_agent")
 
     session.register_intervention_listener("tui")
-    assert session._interventions.has_active_listener() is True
+    assert session.interventions.has_active_listener() is True
 
     session.unregister_intervention_listener("tui")
-    assert session._interventions.has_active_listener() is False
+    assert session.interventions.has_active_listener() is False
 
 
 # ── 6. End-to-end: limit hit under interactive + timeout=0 + no listener ──


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 seventh slice. ``@property`` mitigation exposing the session's ``InterventionRegistry`` instance via a public name.

## Changes

### Production
- \`src/reyn/chat/session.py\` — add ``ChatSession.interventions`` ``@property`` returning ``self._interventions``. The registry instance is set once in ``__init__`` and never re-bound; the property is a read-only accessor.

### Tests (9 Tier-C1 findings cleared)
- \`tests/test_a2a_restart_resume_292.py\` (1) — \`session._interventions.get(iv_id)\` → \`session.interventions.get(iv_id)\`
- \`tests/test_intervention_agent_routing.py\` (1) — \`...queued_count()\` access
- \`tests/test_intervention_agent_subscriber.py\` (2) — \`isinstance(..., InterventionRegistry)\` + \`is_listener_enforcement_enabled()\`
- \`tests/test_intervention_restore.py\` (1) — \`list_active()\`
- \`tests/test_intervention_subscriber_guard.py\` (4) — \`is_listener_enforcement_enabled()\` + \`has_active_listener()\` calls

## Why
The ``InterventionRegistry`` itself has a stable public API (= ``get`` / ``queued_count`` / ``list_active`` / ``has_active_listener`` / ``is_listener_enforcement_enabled``). The underscore on the *holder* (= the session's reference to the registry) was the only thing keeping callers off the public surface. Exposing the registry directly is cleaner than enumerating delegate methods on ChatSession.

## Out of scope
- \`tests/cli/test_ws_client_phase_a.py\` (1 finding) accesses a TUI proxy's \`_interventions\` — that is a different attribute on a different class. Deferred to a TUI-side cleanup slice.
- Other Tier-C1 findings in the same test files (= \`_buffered_intervention_answers\`, \`_try_self_answer\`, \`_resolve_parent_agent\`) are different attrs needing different mitigations.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit on touched files for the \`_interventions\` attr → 0 errors (the remaining 5 findings on those files belong to different attrs, articulated above)
- [x] Load-bearing invariants preserved (= identical registry-instance identity semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_a2a_restart_resume_292.py tests/test_intervention_agent_routing.py tests/test_intervention_agent_subscriber.py tests/test_intervention_restore.py tests/test_intervention_subscriber_guard.py\` → 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)