### PR TITLE
chore(session): add pending_user_images @property (Tier C1 cleanup wave 8)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1838,6 +1838,18 @@ class ChatSession:
         """
         return self._plan_runner.running_plans
 
+    @property
+    def pending_user_images(self) -> list[dict]:
+        """Read-only accessor for the per-session image upload queue.
+
+        Tests and slash commands inspect this queue to verify that an
+        uploaded image landed (= ``/image`` slash + chainlit attachment
+        button both feed the same list). The write side stays on
+        ``self._pending_user_images`` so the lifecycle (= drain on
+        send, reset to []) is visible in the production call sites.
+        """
+        return self._pending_user_images
+
     def current_state_summary(self) -> dict:
         """Return a lightweight snapshot for slash-command display.
 

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -58,6 +58,11 @@ class _FakeSession:
     _pending_user_images: list[dict] = field(default_factory=list)
     captured_outbox: list[_OutboxRecord] = field(default_factory=list)
 
+    @property
+    def pending_user_images(self) -> list[dict]:
+        """Mirror of ChatSession.pending_user_images for the fake stub."""
+        return self._pending_user_images
+
     async def _put_outbox(self, msg: object) -> None:
         self.captured_outbox.append(
             _OutboxRecord(
@@ -106,8 +111,8 @@ def test_image_cmd_queues_png(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "shot.png"))
 
-    assert session._pending_user_images, "expected image queued"
-    block = session._pending_user_images[0]
+    assert session.pending_user_images, "expected image queued"
+    block = session.pending_user_images[0]
     # Issue #383 PR-C: /image now stores a path-ref to the user's file
     # instead of inlining base64. Storage stays out of history.jsonl.
     assert block["type"] == "image"
@@ -128,8 +133,8 @@ def test_image_cmd_supports_jpeg_and_alias(tmp_path, monkeypatch):
     session = _FakeSession()
     _run(cmd.handler(session, "pic.jpg"))
 
-    assert session._pending_user_images, "expected image queued"
-    block = session._pending_user_images[0]
+    assert session.pending_user_images, "expected image queued"
+    block = session.pending_user_images[0]
     assert block["mime_type"] == "image/jpeg"
     assert "pic.jpg" in block["path"]
 
@@ -147,7 +152,7 @@ def test_multiple_image_calls_stack(tmp_path, monkeypatch):
     _run(handler(session, "a.png"))
     _run(handler(session, "b.png"))
 
-    paths = [b["path"] for b in session._pending_user_images]
+    paths = [b["path"] for b in session.pending_user_images]
     assert any("a.png" in p for p in paths)
     assert any("b.png" in p for p in paths)
 
@@ -161,7 +166,7 @@ def test_image_cmd_empty_path_errors(tmp_path):
     handler = _get_image_handler()
     _run(handler(session, ""))
 
-    assert session._pending_user_images == []
+    assert session.pending_user_images == []
     assert any(m.kind == "error" and "usage" in m.text for m in session.captured_outbox)
 
 
@@ -172,7 +177,7 @@ def test_image_cmd_missing_file_errors(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "no-such.png"))
 
-    assert session._pending_user_images == []
+    assert session.pending_user_images == []
     assert any(m.kind == "error" and "not found" in m.text for m in session.captured_outbox)
 
 
@@ -184,7 +189,7 @@ def test_image_cmd_unsupported_extension_errors(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "notes.txt"))
 
-    assert session._pending_user_images == []
+    assert session.pending_user_images == []
     assert any(m.kind == "error" and "unsupported" in m.text for m in session.captured_outbox)
 
 
@@ -206,7 +211,7 @@ def test_image_cmd_oversize_with_deny_keeps_queue_empty(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "huge.png"))
 
-    assert session._pending_user_images == []
+    assert session.pending_user_images == []
     assert any(m.kind == "error" for m in session.captured_outbox)
 
 
@@ -223,7 +228,7 @@ def test_image_cmd_oversize_with_ask_no_keeps_queue_empty(tmp_path, monkeypatch)
     handler = _get_image_handler()
     _run(handler(session, "huge.png"))
 
-    assert session._pending_user_images == []
+    assert session.pending_user_images == []
 
 
 def test_image_cmd_no_multimodal_config_skips_gate(tmp_path, monkeypatch):
@@ -237,7 +242,7 @@ def test_image_cmd_no_multimodal_config_skips_gate(tmp_path, monkeypatch):
     handler = _get_image_handler()
     _run(handler(session, "any.png"))
 
-    assert session._pending_user_images, "expected image queued (gate skipped)"
+    assert session.pending_user_images, "expected image queued (gate skipped)"
 
 
 # ── ChatMessage content shape (issue #383 update) ──────────────────────


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 eighth slice. ``@property`` mitigation exposing the session's image-upload queue.

## Changes

### Production
- \`src/reyn/chat/session.py\` — add ``ChatSession.pending_user_images`` ``@property`` returning ``self._pending_user_images``. Write side (= reset on send / append on upload) keeps the underscore name so the production lifecycle is visible at the call site.

### Tests (8 Tier-C1 findings cleared)
- \`tests/test_user_image_input.py\`:
  - 8 \`session._pending_user_images\` reads → \`session.pending_user_images\`
  - Added matching ``@property`` on the test-file ``_FakeSession`` dataclass stub so the test-only call sites resolve uniformly with the real session.

## Why
Production callers in \`slash/image.py\` + \`chainlit_app/{uploads,app}.py\` use \`getattr(session, "_pending_user_images", ...)\` per the existing OS↔skill-host contract — the underscore there is intentional (= "I know I'm reaching into the session internals from a per-feature feeder"). Tests don't have that context, so they get the public property.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit: \`python3 scripts/test_tier_audit.py --check private-state tests/test_user_image_input.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical list-identity semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_user_image_input.py\` → 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)