### PR TITLE
chore(session+test-stub): journal @property + _task stub rename (Tier C1 cleanup wave 10)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1904,6 +1904,18 @@ class ChatSession:
         """
         return self._pending_user_images
 
+    @property
+    def journal(self) -> "SnapshotJournal":
+        """Read-only accessor for the session's SnapshotJournal.
+
+        The journal carries rich public API (``record_plan_started`` /
+        ``record_plan_aborted`` / ``append_inbox`` / ``consume_inbox`` /
+        ``snapshot``); exposing the holder via a public name keeps slash
+        commands and tests off the underscore field. The journal
+        instance is set once in ``__init__`` and never re-bound.
+        """
+        return self._journal
+
     def current_state_summary(self) -> dict:
         """Return a lightweight snapshot for slash-command display.
 

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -85,7 +85,7 @@ async def test_plan_list_shows_active_ids_without_task(tmp_path, monkeypatch):
     session.is_attached = True
 
     # Simulate a plan_id surviving in the agent snapshot without a task.
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="plan_xyz789", goal="g", n_steps=2,
     )
     consumed = await session._maybe_handle_slash("/plan list")
@@ -122,10 +122,10 @@ async def test_plan_discard_records_plan_aborted(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="p_to_discard", goal="g", n_steps=2,
     )
-    assert "p_to_discard" in session._journal.snapshot.active_plan_ids
+    assert "p_to_discard" in session.journal.snapshot.active_plan_ids
 
     consumed = await session._maybe_handle_slash(
         "/plan discard p_to_discard confirm",
@@ -133,7 +133,7 @@ async def test_plan_discard_records_plan_aborted(tmp_path, monkeypatch):
     assert consumed is True
 
     # active_plan_ids cleared via plan_aborted apply.
-    assert "p_to_discard" not in session._journal.snapshot.active_plan_ids
+    assert "p_to_discard" not in session.journal.snapshot.active_plan_ids
 
     # Confirmation message in outbox.
     msgs = _drain_outbox(session)
@@ -163,7 +163,7 @@ async def test_plan_discard_cancels_running_task(tmp_path, monkeypatch):
     task = asyncio.create_task(_task_body())
     await started.wait()
     session.running_plans["p_running"] = task
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="p_running", goal="g", n_steps=1,
     )
 
@@ -200,7 +200,7 @@ async def test_plan_discard_deletes_decomposition_artifact(tmp_path, monkeypatch
     artifact = decomposition_path(agent_state_dir, "p_artifact")
     assert artifact.exists()
 
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="p_artifact", goal="g", n_steps=2,
     )
 
@@ -218,7 +218,7 @@ async def test_plan_discard_emits_plan_aborted_outbox(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="p_aborted_emit", goal="g", n_steps=2,
     )
 

--- a/tests/test_slash_destructive_confirm_parity.py
+++ b/tests/test_slash_destructive_confirm_parity.py
@@ -58,8 +58,8 @@ class _CancelSession:
 
     def __init__(self, rid: str):
         self._rid = rid
-        self._task = _CancelTask()
-        self.running_skills = {rid: self._task}
+        self.task = _CancelTask()
+        self.running_skills = {rid: self.task}
         self.running_skills_started_at = {}
         self.outbox_messages: list[OutboxMessage] = []
 
@@ -94,7 +94,7 @@ async def test_cancel_no_confirm_shows_warning_not_cancelled() -> None:
     await cmd.handler(sess, rid)
 
     # task must NOT be cancelled
-    assert not sess._task.cancelled
+    assert not sess.task.cancelled
 
     # outbox must contain a system warning with "confirm" hint
     warn_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
@@ -117,7 +117,7 @@ async def test_cancel_with_confirm_cancels_task() -> None:
     cmd = _get_cmd("cancel")
     await cmd.handler(sess, f"{rid} confirm")
 
-    assert sess._task.cancelled
+    assert sess.task.cancelled
 
     # outbox must carry the cancel-requested system message
     system_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
@@ -143,15 +143,15 @@ async def test_plan_discard_no_confirm_shows_warning(tmp_path, monkeypatch):
     )
     session.is_attached = True
 
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="p_warn", goal="g", n_steps=2,
     )
-    assert "p_warn" in session._journal.snapshot.active_plan_ids
+    assert "p_warn" in session.journal.snapshot.active_plan_ids
 
     await session._maybe_handle_slash("/plan discard p_warn")
 
     # Plan must still be active.
-    assert "p_warn" in session._journal.snapshot.active_plan_ids
+    assert "p_warn" in session.journal.snapshot.active_plan_ids
 
     # Outbox must carry a warning with "confirm" hint.
     msgs = []
@@ -177,7 +177,7 @@ async def test_plan_discard_with_confirm_discards_plan(tmp_path, monkeypatch):
     )
     session.is_attached = True
 
-    await session._journal.record_plan_started(
+    await session.journal.record_plan_started(
         plan_id="p_confirm", goal="g", n_steps=2,
     )
 
@@ -187,7 +187,7 @@ async def test_plan_discard_with_confirm_discards_plan(tmp_path, monkeypatch):
     assert consumed is True
 
     # Plan must be cleared.
-    assert "p_confirm" not in session._journal.snapshot.active_plan_ids
+    assert "p_confirm" not in session.journal.snapshot.active_plan_ids
 
     # Outbox must carry the "discarded plan run" confirmation.
     msgs = []


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 tenth slice. Two narrow Tier-C1 fixes in adjacent test files.

## Changes

### (a) ``ChatSession.journal`` ``@property`` (5 findings)

The session's ``SnapshotJournal`` instance previously sat behind the underscored ``_journal`` field. The journal carries a rich public API (``record_plan_started`` / ``record_plan_aborted`` / ``append_inbox`` / ``consume_inbox`` / ``snapshot``), so exposing the holder via a public property keeps slash command tests off the underscore. Set once in ``__init__``, never re-bound.

Files:
- \`src/reyn/chat/session.py\` — add ``journal`` ``@property``
- \`tests/test_plan_slash_command.py\` (2 findings cleared) — \`session._journal\` → \`session.journal\`
- \`tests/test_slash_destructive_confirm_parity.py\` (3 findings cleared) — same

### (b) ``_CancelSession._task`` → ``task`` rename (2 findings)

The test-only ``_CancelSession`` stub had an underscore-prefixed ``_task`` field. Production ``ChatSession`` has no such attribute — the underscore was stub-fixture convention only. Rename to drop the underscore.

Files:
- \`tests/test_slash_destructive_confirm_parity.py\` (2 findings cleared)
  - stub field: \`self._task\` → \`self.task\` (definition + assignment)
  - test assertions: \`sess._task.cancelled\` → \`sess.task.cancelled\`

## Why bundle?
Both fixes touch \`tests/test_slash_destructive_confirm_parity.py\` and are small enough that splitting into two PRs would add overhead without review-cycle benefit. Each fix is self-contained and the diff is readable per-file.

## Tier rule self-check
- [x] Test \`Tier 2:\` docstrings preserved
- [x] Audit: \`python3 scripts/test_tier_audit.py --check private-state tests/test_plan_slash_command.py tests/test_slash_destructive_confirm_parity.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical attr-access semantics, only the symbol moved)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_plan_slash_command.py tests/test_slash_destructive_confirm_parity.py\` → 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)