### PR TITLE
chore(tier-c): migrate slash_picker test off private-state asserts

### DIFF
--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -91,6 +91,15 @@ class SlashPicker(RenderableCacheMixin, Static):
     # ── public API ────────────────────────────────────────────────────────────
 
     @property
+    def selected_index(self) -> int:
+        """Currently highlighted row index (0-based).
+
+        Always 0 when no matches are loaded. Read-only; mutate via
+        ``move_selection`` or ``select_at_y``.
+        """
+        return self._selected
+
+    @property
     def visible_(self) -> bool:
         """True iff the picker is showing selectable matches.
 

--- a/tests/cli/test_slash_picker_click.py
+++ b/tests/cli/test_slash_picker_click.py
@@ -69,16 +69,16 @@ async def test_select_at_y_moves_selection_to_clicked_row() -> None:
         picker = app.query_one("#slash-picker", SlashPicker)
         picker.set_matches(_candidates(5))
         await pilot.pause()
-        assert picker._selected == 0
+        assert picker.selected_index == 0
 
         # Hit row 3 directly
         assert picker.select_at_y(3) is True
-        assert picker._selected == 3
+        assert picker.selected_index == 3
         assert picker.selected_command().name == "cmd3"
 
         # Hit row 0 — back to top
         assert picker.select_at_y(0) is True
-        assert picker._selected == 0
+        assert picker.selected_index == 0
 
 
 @pytest.mark.asyncio
@@ -94,7 +94,7 @@ async def test_select_at_y_rejects_out_of_range() -> None:
         # Beyond the last row → no change, returns False
         assert picker.select_at_y(99) is False
         assert picker.select_at_y(3) is False     # one past last (idx 2)
-        assert picker._selected == 0
+        assert picker.selected_index == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, single-widget slice (`slash_picker.py`).

## Summary
- 4 private-state asserts in test_slash_picker_click.py → migrated to public surface
- 1 new accessor (`selected_index`) on `SlashPicker` (additive only)
- Part of larger Tier C Path C sweep
- Deferred: test_tui_smoke.py picker._selected asserts handled in later multi-src wave

## Test plan
- [x] `python scripts/test_tier_audit.py tests/cli/test_slash_picker_click.py` → 0 violations
- [x] `pytest tests/cli/test_slash_picker_click.py` → all pass
- [x] `ruff check <changed files>` → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced