### PR TITLE
chore(tier-c): migrate error_box widget tests off private-state asserts

### DIFF
--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -182,6 +182,23 @@ class ErrorBox(Widget):
             self._inline_hint = ""
             self._first_line_for_header = first_line
 
+    # ── public accessors ─────────────────────────────────────────────────────
+
+    @property
+    def index(self) -> int:
+        """Current stack position (1-based). 0 when no badge is shown."""
+        return self._index
+
+    @property
+    def total(self) -> int:
+        """Total number of stacked errors. 0 or 1 means no badge is shown."""
+        return self._total
+
+    @property
+    def is_expanded(self) -> bool:
+        """True when the detail section is visible (= widget is expanded)."""
+        return self._expanded
+
     # ── header text helpers ───────────────────────────────────────────────────
 
     def _prefix(self) -> str:
@@ -192,6 +209,14 @@ class ErrorBox(Widget):
         if self._run_id_short:
             return f"[#{self._run_id_short}]"
         return ""
+
+    def header_text(self) -> str:
+        """Public accessor — build and return the header line string.
+
+        Delegates to ``_header_text`` so callers have a stable public
+        surface without reaching into the private method.
+        """
+        return self._header_text()
 
     def _header_text(self) -> str:
         """Build the header line for a textual ``Label`` (Rich-markup aware).
@@ -273,7 +298,7 @@ class ErrorBox(Widget):
         self._index = index
         self._total = total
         try:
-            self.query_one(".eb-header", Label).update(self._header_text())
+            self.query_one(".eb-header", Label).update(self.header_text())
         except Exception:
             pass
 
@@ -296,7 +321,7 @@ class ErrorBox(Widget):
     # ── compose ───────────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
-        yield Label(self._header_text(), classes="eb-header")
+        yield Label(self.header_text(), classes="eb-header")
         if self._inline_hint:
             # Wave-10 follow-up I-F12: tag the Label with
             # ``-has-content`` so the CSS visibility toggles to
@@ -378,7 +403,7 @@ class ErrorBox(Widget):
             self._expanded = new_expanded
             try:
                 header = self.query_one(".eb-header", Label)
-                header.update(self._header_text())
+                header.update(self.header_text())
             except Exception:
                 # Header update failed AFTER toggle_class succeeded — roll
                 # both back so the widget stays internally consistent.

--- a/tests/cli/test_error_box_count_badge.py
+++ b/tests/cli/test_error_box_count_badge.py
@@ -43,7 +43,7 @@ def _header_text_of(box) -> str:
     renderable = getattr(label, "_renderable", None) or getattr(label, "renderable", None)
     if renderable is None:
         # Fallback to building the header directly from the widget's helper.
-        return box._header_text()
+        return box.header_text()
     return str(getattr(renderable, "plain", renderable))
 
 
@@ -59,7 +59,7 @@ async def test_single_error_no_badge() -> None:
         conv = app.query_one("#conversation", ConversationView)
         box = conv.mount_error(message="solo error")
         await pilot.pause()
-        header = box._header_text()
+        header = box.header_text()
         # No badge present.
         assert "[1/1]" not in header
         # ``✗ solo error  ▶`` shape preserved.
@@ -79,8 +79,8 @@ async def test_two_errors_renumber_correctly() -> None:
         first = conv.mount_error(message="first error")
         second = conv.mount_error(message="second error")
         await pilot.pause()
-        assert "[1/2]" in first._header_text()
-        assert "[2/2]" in second._header_text()
+        assert "[1/2]" in first.header_text()
+        assert "[2/2]" in second.header_text()
 
 
 @pytest.mark.asyncio
@@ -97,9 +97,9 @@ async def test_three_errors_renumber_correctly() -> None:
             conv.mount_error(message=f"err {i}") for i in range(3)
         ]
         await pilot.pause()
-        assert "[1/3]" in boxes[0]._header_text()
-        assert "[2/3]" in boxes[1]._header_text()
-        assert "[3/3]" in boxes[2]._header_text()
+        assert "[1/3]" in boxes[0].header_text()
+        assert "[2/3]" in boxes[1].header_text()
+        assert "[3/3]" in boxes[2].header_text()
 
 
 @pytest.mark.asyncio
@@ -116,17 +116,17 @@ async def test_dismiss_renumbers_survivors() -> None:
         second = conv.mount_error(message="second")
         third = conv.mount_error(message="third")
         await pilot.pause()
-        assert "[3/3]" in third._header_text()
+        assert "[3/3]" in third.header_text()
         conv.dismiss_last_error()  # removes third
         await pilot.pause()
         # Now 2 remain; renumber to [1/2] [2/2].
-        assert "[1/2]" in first._header_text()
-        assert "[2/2]" in second._header_text()
+        assert "[1/2]" in first.header_text()
+        assert "[2/2]" in second.header_text()
         conv.dismiss_last_error()  # removes second
         await pilot.pause()
         # Single error remaining → no badge.
-        assert "[1/" not in first._header_text()
-        assert "[2/" not in first._header_text()
+        assert "[1/" not in first.header_text()
+        assert "[2/" not in first.header_text()
 
 
 def test_header_text_omits_badge_for_total_one() -> None:
@@ -139,10 +139,10 @@ def test_header_text_omits_badge_for_total_one() -> None:
 
     # total=1, single error case.
     box = ErrorBox(message="x", index=1, total=1)
-    assert "[1/1]" not in box._header_text()
+    assert "[1/1]" not in box.header_text()
     # Defaults: index=0, total=0 — no badge.
     box2 = ErrorBox(message="x")
-    assert "/" not in box2._header_text().split("✗", 1)[1].split("▶")[0]
+    assert "/" not in box2.header_text().split("✗", 1)[1].split("▶")[0]
 
 
 def test_set_index_total_idempotent_skip() -> None:
@@ -156,12 +156,12 @@ def test_set_index_total_idempotent_skip() -> None:
 
     box = ErrorBox(message="x")
     box.set_index_total(2, 3)
-    assert box._index == 2
-    assert box._total == 3
+    assert box.index == 2
+    assert box.total == 3
     # Same values — equality gate short-circuits.
     box.set_index_total(2, 3)
-    assert box._index == 2
-    assert box._total == 3
+    assert box.index == 2
+    assert box.total == 3
 
 
 @pytest.mark.asyncio
@@ -178,4 +178,4 @@ async def test_set_index_total_updates_header() -> None:
         await pilot.pause()
         box.set_index_total(2, 5)
         await pilot.pause()
-        assert "[2/5]" in box._header_text()
+        assert "[2/5]" in box.header_text()

--- a/tests/cli/test_errorbox_onclick_atomic.py
+++ b/tests/cli/test_errorbox_onclick_atomic.py
@@ -45,18 +45,18 @@ async def test_normal_click_toggles_expanded_and_class() -> None:
         conv = app.query_one("#conversation", ConversationView)
         box = conv.mount_error(message="something broke")
         await pilot.pause()
-        assert box._expanded is False
+        assert box.is_expanded is False
         assert not box.has_class("-expanded")
 
         box.on_click()
         await pilot.pause()
-        assert box._expanded is True
+        assert box.is_expanded is True
         assert box.has_class("-expanded")
 
         # Second click toggles back.
         box.on_click()
         await pilot.pause()
-        assert box._expanded is False
+        assert box.is_expanded is False
         assert not box.has_class("-expanded")
 
 
@@ -64,7 +64,7 @@ async def test_normal_click_toggles_expanded_and_class() -> None:
 async def test_header_update_failure_rolls_back_expanded() -> None:
     """Tier 2: header update raising leaves the widget in pre-click state.
 
-    Simulate the failure by replacing ``_header_text`` with a method
+    Simulate the failure by replacing ``header_text`` with a method
     that raises. The post-toggle internal state should match the
     pre-click state — no drift between ``_expanded`` and the CSS
     class.
@@ -78,19 +78,19 @@ async def test_header_update_failure_rolls_back_expanded() -> None:
         conv = app.query_one("#conversation", ConversationView)
         box = conv.mount_error(message="something broke")
         await pilot.pause()
-        pre_expanded = box._expanded
+        pre_expanded = box.is_expanded
         pre_class = box.has_class("-expanded")
 
         def _explode() -> str:
             raise RuntimeError("header update failed")
 
-        box._header_text = _explode  # type: ignore[method-assign]
+        box.header_text = _explode  # type: ignore[method-assign]
         box.on_click()
         await pilot.pause()
 
         # Both should match the pre-click state (rollback).
-        assert box._expanded == pre_expanded, (
-            f"_expanded should rollback to {pre_expanded}, got {box._expanded}"
+        assert box.is_expanded == pre_expanded, (
+            f"is_expanded should rollback to {pre_expanded}, got {box.is_expanded}"
         )
         assert box.has_class("-expanded") == pre_class, (
             f"class should rollback to {pre_class}, got "


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, single-widget slice (`error_box.py`).

## Summary
- 21 private-state asserts in 2 test files → migrated to public surface
- 4 new public accessors on `ErrorBox` (additive only, no signature change to existing API): `index`, `total`, `is_expanded` (properties), and `header_text()` (method delegating to `_header_text`)
- Part of larger Tier C Path C sweep coordinated with sandbox_2 (= non-TUI lane)

## Test plan
- [x] `python scripts/test_tier_audit.py <changed test files>` → 0 violations
- [x] `pytest <changed test files>` → all pass (9/9)
- [x] `ruff check <changed files>` → clean

## Tier self-check (= [[pr-tier-self-check]])
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning (`len(x) < N`) introduced