### PR TITLE
chore(tier-c): migrate streaming_row widget tests off private-state asserts

### DIFF
--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -337,3 +337,38 @@ class StreamingRow(Widget):
 
     def full_text(self) -> str:
         return self._accumulated
+
+    # ── Public accessors (Tier C Path C cleanup) ─────────────────────────────
+
+    @property
+    def sealed(self) -> bool:
+        """True once ``seal()`` has been called (stream complete latch)."""
+        return self._sealed
+
+    @property
+    def accumulated(self) -> str:
+        """The concatenated text accumulated so far via ``append()`` calls."""
+        return self._accumulated
+
+    @property
+    def interval_handle(self):  # type: ignore[return]
+        """The ``set_interval`` handle for the 16 ms render-coalescing timer.
+
+        ``None`` before ``on_mount`` or after ``seal()`` stops the timer.
+        Exposed so tests can verify liveness without reaching into private state.
+        """
+        return self._interval_handle
+
+    @property
+    def height_dirty(self) -> bool:
+        """True when ``append()`` has grown content since the last flush.
+
+        Set by ``append()``; consumed (reset to False) by ``_flush_render``
+        when it calls ``scroll_visible``.
+        """
+        return self._height_dirty
+
+    @height_dirty.setter
+    def height_dirty(self, value: bool) -> None:
+        """Allow tests to reset the flag to establish a clean baseline."""
+        self._height_dirty = value

--- a/tests/cli/test_streaming_row_perf.py
+++ b/tests/cli/test_streaming_row_perf.py
@@ -63,7 +63,7 @@ async def test_interval_handle_stored_on_mount() -> None:
         conv = app.query_one("#conversation", ConversationView)
         row = conv.begin_stream("perf_handle_test", "reyn")
         await pilot.pause()
-        assert row._interval_handle is not None, (
+        assert row.interval_handle is not None, (
             "set_interval handle must be stored for seal() to stop later"
         )
 
@@ -83,14 +83,14 @@ async def test_seal_stops_interval_handle() -> None:
         conv = app.query_one("#conversation", ConversationView)
         row = conv.begin_stream("perf_seal_test", "reyn")
         await pilot.pause()
-        assert row._interval_handle is not None
-        captured_handle = row._interval_handle
+        assert row.interval_handle is not None
+        captured_handle = row.interval_handle
 
         row.append("hello")
         row.seal()
         await pilot.pause()
 
-        assert row._interval_handle is None, "handle should be cleared after seal"
+        assert row.interval_handle is None, "handle should be cleared after seal"
         # The captured handle's stop() flag should be set
         active_event = getattr(captured_handle, "_active", None)
         if active_event is not None and hasattr(active_event, "is_set"):
@@ -118,15 +118,15 @@ async def test_seal_before_mount_defers_cancel_to_on_mount() -> None:
         row = StreamingRow(prefix="reyn", id="defer_seal_test")
         row.append("rapid burst")
         row.seal()
-        assert row._sealed
-        assert row._interval_handle is None  # never started
+        assert row.sealed
+        assert row.interval_handle is None  # never started
 
         conv.mount(row)
         await pilot.pause()
 
         # After on_mount: interval was started THEN stopped immediately
         # because _sealed was already True.
-        assert row._interval_handle is None, (
+        assert row.interval_handle is None, (
             "deferred seal must stop the just-started interval in on_mount"
         )
 
@@ -153,7 +153,7 @@ async def test_append_grows_accumulated_string_linearly() -> None:
             row.append(c)
         await pilot.pause()
 
-        assert row._accumulated == "alpha beta gamma"
+        assert row.accumulated == "alpha beta gamma"
         assert row.full_text() == "alpha beta gamma", (
             "full_text() must read from _accumulated, not rebuild from a list"
         )

--- a/tests/cli/test_streaming_row_scroll_visible.py
+++ b/tests/cli/test_streaming_row_scroll_visible.py
@@ -38,9 +38,9 @@ def test_append_marks_height_dirty() -> None:
     from reyn.chat.tui.widgets.streaming_row import StreamingRow
 
     row = StreamingRow(prefix="")
-    assert row._height_dirty is False
+    assert row.height_dirty is False
     row.append("hello")
-    assert row._height_dirty is True
+    assert row.height_dirty is True
 
 
 @pytest.mark.asyncio
@@ -67,14 +67,14 @@ async def test_flush_render_calls_scroll_visible_once_per_append_cycle() -> None
 
         # Reset (the row may have flushed during begin_stream).
         calls.clear()
-        row._height_dirty = False
+        row.height_dirty = False
 
         row.append("hello world")
-        assert row._height_dirty is True
+        assert row.height_dirty is True
         row._flush_render()
         (only_call,) = calls  # exactly one scroll_visible per append+flush cycle
         # After flush, the flag is consumed.
-        assert row._height_dirty is False
+        assert row.height_dirty is False
 
 
 @pytest.mark.asyncio
@@ -104,7 +104,7 @@ async def test_cursor_blink_alone_does_not_call_scroll_visible() -> None:
 
         row.scroll_visible = _spy  # type: ignore[method-assign]
         calls.clear()
-        row._height_dirty = False
+        row.height_dirty = False
 
         # Drive enough flush ticks to cross a cursor-blink boundary
         # (= every 30 flushes, see ``_flush_render``). The row has not


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, single-widget slice (`streaming_row.py`).

## Summary
- 11 private-state asserts across 2 test files → migrated to public surface
- 4 new public accessors on `StreamingRow` (additive only): `sealed`, `accumulated`, `interval_handle`, `height_dirty` (with setter for test baseline reset)
- Part of larger Tier C Path C sweep

## Test plan
- [x] `python scripts/test_tier_audit.py <changed test files>` → 0 violations
- [x] `pytest <changed test files>` → all pass (10/10)
- [x] `ruff check <changed files>` → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced