### PR TITLE
chore(session): expose chains as @property (Tier C1 cleanup wave 11)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1863,6 +1863,18 @@ class ChatSession:
         """
         return self._interventions
 
+    @property
+    def chains(self) -> "ChainManager":
+        """Read-only accessor for the session's ChainManager.
+
+        The manager carries rich public API (``find_chain`` / ``has`` /
+        ``get`` / ``all_chain_ids`` / ``register`` / ``update`` /
+        ``resolve``), so exposing the holder via a public name keeps
+        callers off the underscore field. The manager instance is set
+        once in ``__init__`` and never re-bound.
+        """
+        return self._chains
+
     # ── SkillRunner forwarding (FP-0019 Wave 1b) ────────────────────────────────
     # slash/skill.py and slash/tasks.py access these dicts directly via session.
     # Forward to SkillRunner so external callers see the same live dict.

--- a/tests/test_chain_peer_discarded_notify.py
+++ b/tests/test_chain_peer_discarded_notify.py
@@ -93,7 +93,7 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
 
     async def go():
         # A registers a chain waiting on B
-        await sess_a._chains.register(
+        await sess_a.chains.register(
             chain_id="X-001",
             from_user=True,
             depth=1,
@@ -103,7 +103,7 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
             origin_agent="user",
             origin_depth=0,
         )
-        assert sess_a._chains.find_chain("X-001") is not None
+        assert sess_a.chains.find_chain("X-001") is not None
         # Trigger the handler directly
         await sess_a._on_chain_peer_discarded(
             chain_id="X-001",
@@ -113,7 +113,7 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
 
     asyncio.run(go())
     # Chain is gone
-    assert sess_a._chains.find_chain("X-001") is None
+    assert sess_a.chains.find_chain("X-001") is None
     # WAL has chain_resolve for X-001
     events = list(state_log.iter_from(0))
     resolve_events = [
@@ -147,7 +147,7 @@ def test_notify_finds_waiter_and_returns_true(tmp_path: Path):
     registry, sess_a, _sess_b, _log = _make_registry_with_two_agents(tmp_path)
 
     async def go():
-        await sess_a._chains.register(
+        await sess_a.chains.register(
             chain_id="X-002",
             from_user=True,
             depth=1,
@@ -165,7 +165,7 @@ def test_notify_finds_waiter_and_returns_true(tmp_path: Path):
     notified = asyncio.run(go())
     assert notified is True
     # A's chain was force-resolved
-    assert sess_a._chains.find_chain("X-002") is None
+    assert sess_a.chains.find_chain("X-002") is None
 
 
 def test_notify_returns_false_when_no_waiter_tracks_chain(tmp_path: Path):
@@ -191,7 +191,7 @@ def test_notify_excludes_self_from_scan(tmp_path: Path):
 
     async def go():
         # B registers a chain (irrelevant to the discard)
-        await sess_b._chains.register(
+        await sess_b.chains.register(
             chain_id="X-self",
             from_user=False,
             depth=1,
@@ -211,7 +211,7 @@ def test_notify_excludes_self_from_scan(tmp_path: Path):
     # Not notified — only B tracks it, and we exclude B
     assert notified is False
     # B's own chain is intact
-    assert sess_b._chains.find_chain("X-self") is not None
+    assert sess_b.chains.find_chain("X-self") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +227,7 @@ def test_slash_discard_notifies_upstream_chain_waiter(tmp_path: Path, monkeypatc
 
     async def go():
         # A is waiting on B for chain X-D14
-        await sess_a._chains.register(
+        await sess_a.chains.register(
             chain_id="X-D14",
             from_user=True,
             depth=1,
@@ -262,7 +262,7 @@ def test_slash_discard_notifies_upstream_chain_waiter(tmp_path: Path, monkeypatc
 
     # Verifications:
     # 1. A's chain is force-resolved (no longer tracked)
-    assert sess_a._chains.find_chain("X-D14") is None
+    assert sess_a.chains.find_chain("X-D14") is None
     # 2. WAL has chain_resolve for X-D14
     events = list(state_log.iter_from(0))
     resolves = [

--- a/tests/test_multi_agent_p7.py
+++ b/tests/test_multi_agent_p7.py
@@ -138,7 +138,7 @@ async def test_two_simultaneous_delegations_both_resolve(tmp_path: Path):
     # Directly register two chains on A, simulating that A delegated to B
     # and C simultaneously (the router would do this; we bypass the LLM to
     # test pure chain mechanics).
-    await sess_a._chains.register(
+    await sess_a.chains.register(
         chain_id=chain_ab,
         from_user=True,
         depth=1,
@@ -148,7 +148,7 @@ async def test_two_simultaneous_delegations_both_resolve(tmp_path: Path):
         origin_agent="",
         origin_depth=0,
     )
-    await sess_a._chains.register(
+    await sess_a.chains.register(
         chain_id=chain_ac,
         from_user=True,
         depth=1,
@@ -160,30 +160,30 @@ async def test_two_simultaneous_delegations_both_resolve(tmp_path: Path):
     )
 
     # Both chains must be pending now.
-    assert sess_a._chains.has(chain_ab), "chain_ab must be pending after register"
-    assert sess_a._chains.has(chain_ac), "chain_ac must be pending after register"
+    assert sess_a.chains.has(chain_ab), "chain_ab must be pending after register"
+    assert sess_a.chains.has(chain_ac), "chain_ac must be pending after register"
 
     # Resolve chain_ab (B replied).
-    resolved_ab = await sess_a._chains.resolve(chain_ab)
+    resolved_ab = await sess_a.chains.resolve(chain_ab)
     assert resolved_ab is not None, "resolve must return the chain for chain_ab"
     assert resolved_ab.chain_id == chain_ab
 
     # chain_ac must still be pending — resolve is independent.
-    assert sess_a._chains.has(chain_ac), (
+    assert sess_a.chains.has(chain_ac), (
         "chain_ac must still be pending after chain_ab resolves"
     )
-    assert not sess_a._chains.has(chain_ab), (
+    assert not sess_a.chains.has(chain_ab), (
         "chain_ab must no longer be pending after resolve"
     )
 
     # Resolve chain_ac (C replied).
-    resolved_ac = await sess_a._chains.resolve(chain_ac)
+    resolved_ac = await sess_a.chains.resolve(chain_ac)
     assert resolved_ac is not None, "resolve must return the chain for chain_ac"
     assert resolved_ac.chain_id == chain_ac
 
     # Both chains are gone.
-    assert not sess_a._chains.has(chain_ab)
-    assert not sess_a._chains.has(chain_ac)
+    assert not sess_a.chains.has(chain_ab)
+    assert not sess_a.chains.has(chain_ac)
 
     # WAL must have two chain_register and two chain_resolve events.
     wal_entries = list(state_log.iter_from(0))

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -15,7 +15,7 @@ Policy compliance (`docs/deep-dives/contributing/testing.ja.md`):
     - `AgentSnapshot.load(agent_name, path)` for fully external snapshot re-read
     - `iv.future` (the producer-side contract for a UserIntervention)
 - Internal-attribute access is restricted to:
-    - `session._chains.has()` / `.get()` — public ChainManager methods, used as a
+    - `session.chains.has()` / `.get()` — public ChainManager methods, used as a
       precondition check; final post-condition uses `AgentSnapshot.load`.
     - `session._dispatch_intervention` / `_drop_interventions_for_run` /
       `_maybe_answer_oldest_intervention` — session-level thin wrappers over
@@ -293,7 +293,7 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
     })
 
     # Verify chain is registered.
-    assert session._chains.has("chain-res-001"), (
+    assert session.chains.has("chain-res-001"), (
         "Chain should be pending after delegation"
     )
 
@@ -467,10 +467,10 @@ async def test_restore_reconstructs_chains_and_inbox_from_snapshot(tmp_path, mon
     assert payload.get("text") == "hello from snapshot"
 
     # ChainManager must have the chain loaded (public query API).
-    assert session._chains.has(chain_id), (
+    assert session.chains.has(chain_id), (
         f"ChainManager.has({chain_id!r}) returned False after restore_state"
     )
-    pc = session._chains.get(chain_id)
+    pc = session.chains.get(chain_id)
     assert pc is not None
     assert pc.origin_agent == "origin"
     assert "peer_agent" in pc.waiting_on
@@ -791,7 +791,7 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
     chain_id = payload["chain_id"]
 
     # ── chain_register ────────────────────────────────────────────────────
-    await session._chains.register(
+    await session.chains.register(
         chain_id=chain_id,
         from_user=False,
         depth=1,
@@ -803,7 +803,7 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
     )
 
     # ── chain_resolve ─────────────────────────────────────────────────────
-    resolved_chain = await session._chains.resolve(chain_id)
+    resolved_chain = await session.chains.resolve(chain_id)
     assert resolved_chain is not None, "resolve must return the chain"
 
     # ── WAL read: verify P6 invariant ─────────────────────────────────────
@@ -1085,7 +1085,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     # Manually register a pending chain: relay_agent is waiting on "specialist"
     # for a request that came from "origin_agent".
     chain_id = "chain-b2h2-relay-001"
-    await session._chains.register(
+    await session.chains.register(
         chain_id=chain_id,
         from_user=False,
         depth=2,
@@ -1097,7 +1097,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     )
 
     # Confirm the chain exists.
-    assert session._chains.get(chain_id) is not None
+    assert session.chains.get(chain_id) is not None
 
     # _run_router_loop must NOT be called.
     router_called = []
@@ -1122,7 +1122,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     assert not router_called, "B2-H2 relay regression: _run_router_loop was called for a marker"
 
     # Chain must be resolved.
-    assert session._chains.get(chain_id) is None, (
+    assert session.chains.get(chain_id) is None, (
         "B2-H2 relay: chain should be resolved after marker detection, but it is still pending"
     )
 

--- a/tests/test_skill_postprocessor_chain.py
+++ b/tests/test_skill_postprocessor_chain.py
@@ -271,7 +271,7 @@ def test_postprocessor_mid_run_discard_notifies_upstream(
 
     async def go() -> None:
         # A registers a chain waiting on B
-        await sess_a._chains.register(
+        await sess_a.chains.register(
             chain_id="chain-post-001",
             from_user=True,
             depth=1,
@@ -281,7 +281,7 @@ def test_postprocessor_mid_run_discard_notifies_upstream(
             origin_agent="user",
             origin_depth=0,
         )
-        assert sess_a._chains.find_chain("chain-post-001") is not None
+        assert sess_a.chains.find_chain("chain-post-001") is not None
 
         # B starts a skill_run (simulates a skill that has entered __post__)
         b_reg = sess_b._get_skill_registry()
@@ -309,7 +309,7 @@ def test_postprocessor_mid_run_discard_notifies_upstream(
     asyncio.run(go())
 
     # A's chain must be force-resolved
-    assert sess_a._chains.find_chain("chain-post-001") is None, (
+    assert sess_a.chains.find_chain("chain-post-001") is None, (
         "A's pending chain must be resolved after B's run is discarded"
     )
 
@@ -396,7 +396,7 @@ def test_postprocessor_mid_run_chain_timeout_fires(
 
     async def go() -> None:
         # A registers a chain waiting on B — arm the watchdog at the same time
-        chain = await sess_a._chains.register(
+        chain = await sess_a.chains.register(
             chain_id="chain-timeout-post-001",
             from_user=True,
             depth=1,
@@ -406,13 +406,13 @@ def test_postprocessor_mid_run_chain_timeout_fires(
             origin_agent="user",
             origin_depth=0,
         )
-        sess_a._chains.arm_timeout(
+        sess_a.chains.arm_timeout(
             "chain-timeout-post-001",
             on_fire=sess_a._on_chain_timeout_fire,
         )
 
         # Verify chain is registered
-        assert sess_a._chains.find_chain("chain-timeout-post-001") is not None
+        assert sess_a.chains.find_chain("chain-timeout-post-001") is not None
 
         # B starts its skill — simulates __post__ state (no completion)
         b_reg = sess_b._get_skill_registry()
@@ -431,7 +431,7 @@ def test_postprocessor_mid_run_chain_timeout_fires(
     asyncio.run(go())
 
     # A's chain must be force-resolved by the watchdog
-    assert sess_a._chains.find_chain("chain-timeout-post-001") is None, (
+    assert sess_a.chains.find_chain("chain-timeout-post-001") is None, (
         "watchdog must force-resolve A's chain regardless of postprocessor state"
     )
 


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 eleventh slice. Largest single-attr cluster (19 findings) — same ``@property`` mitigation as PRs #944 / #951.

## Changes

### Production
- \`src/reyn/chat/session.py\` — add ``ChatSession.chains`` ``@property`` returning ``self._chains``. The ``ChainManager`` instance is set once in ``__init__`` and never re-bound.

### Tests (19 Tier-C1 findings cleared)
- \`tests/test_chain_peer_discarded_notify.py\` (5)
- \`tests/test_multi_agent_p7.py\` (6)
- \`tests/test_session_invariants.py\` (4)
- \`tests/test_skill_postprocessor_chain.py\` (4)

All call sites were already using the ``ChainManager``'s public methods (``find_chain`` / ``has`` / ``get``) — only the holder access needed lifting:
- \`session._chains.find_chain(X)\` → \`session.chains.find_chain(X)\`
- \`sess_a._chains.has(chain_id)\` → \`sess_a.chains.has(chain_id)\`

## Why
``ChainManager`` carries a stable, rich public API (\`find_chain\` / \`has\` / \`get\` / \`all_chain_ids\` / \`register\` / \`update\` / \`resolve\`). The underscore on the *holder* (= the session's reference to the manager) was the only obstacle to clean test access. Exposing the manager directly via property keeps tests off the underscore without forcing a delegate-method explosion on \`ChatSession\`.

Same pattern as PR #944 (\`intervention_overrides\`), PR #951 (\`interventions\`), PR #952 (\`pending_user_images\`).

## Out of scope
Other findings remain in these test files for different attrs (e.g. ``_router_loop_agent_replies`` in test_session_invariants.py:1241). Different mitigation, separate slice.

## Tier rule self-check
- [x] Test \`Tier 2:\` docstrings preserved
- [x] Audit for ``_chains``: 0 findings on touched files (the 1 remaining error is a different attr articulated above)
- [x] Load-bearing invariants preserved (= identical method-dispatch semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_chain_peer_discarded_notify.py tests/test_multi_agent_p7.py tests/test_session_invariants.py tests/test_skill_postprocessor_chain.py\` → 32 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)