### PR TITLE
chore(tier-c): migrate app_outbox router tests off private-state asserts

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -242,7 +242,7 @@ class OutboxRouter:
             "__donut__":                self._on_donut,
             "__cost_inline_toggle__":   self._on_cost_inline_toggle,
             "__expand_last_reply__":    self._on_expand_last_reply,
-            "__copy_last_reply__":      self._on_copy_last_reply,
+            "__copy_last_reply__":      self.on_copy_last_reply,
             "__find__":                 self._on_find,
             "__save__":                 self._on_save,
             "__docs_filter__":          self._on_docs_filter,
@@ -273,6 +273,32 @@ class OutboxRouter:
             "tool_call_completed":      self._on_tool_call_completed,
             "tool_call_failed":         self._on_tool_call_failed,
         }
+
+    # ── public read-only accessors ────────────────────────────────────────────
+
+    @property
+    def find_query(self) -> "str | None":
+        """The active ``/find`` query string, or ``None`` if no search is seeded."""
+        return self._find_query
+
+    @property
+    def find_regex_enabled(self) -> bool:
+        """``True`` when the active ``/find`` cycle uses regex mode."""
+        return self._find_regex
+
+    @property
+    def find_case_sensitive(self) -> bool:
+        """``True`` when the active ``/find`` cycle uses case-sensitive matching."""
+        return self._find_case_sensitive
+
+    @property
+    def find_cursor_index(self) -> "int | None":
+        """Line index of the current ``/find`` cursor, or ``None`` if unset."""
+        return self._find_cursor_idx
+
+    def has_transient_status_timer(self) -> bool:
+        """Return ``True`` when an auto-hide transient-status timer is armed."""
+        return self._transient_status_timer is not None
 
     # ── transient sticky helpers ──────────────────────────────────────────────
 
@@ -538,7 +564,7 @@ class OutboxRouter:
         if not conv.toggle_last_foldable():
             self._show_transient_status(conv, "nothing to expand", duration=2.0)
 
-    def _on_copy_last_reply(
+    def on_copy_last_reply(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
     ) -> None:
         """`__copy_last_reply__` — /copy slash; pipe a buffered reply to OS clipboard.

--- a/tests/cli/test_clipboard_non_blocking.py
+++ b/tests/cli/test_clipboard_non_blocking.py
@@ -99,13 +99,13 @@ async def test_on_copy_last_reply_returns_synchronously() -> None:
         await pilot.pause()
 
         router = OutboxRouter(app)
-        assert not inspect.iscoroutinefunction(router._on_copy_last_reply), (
-            "_on_copy_last_reply must stay sync — the OutboxRouter dispatch loop "
+        assert not inspect.iscoroutinefunction(router.on_copy_last_reply), (
+            "on_copy_last_reply must stay sync — the OutboxRouter dispatch loop "
             "calls handlers without await"
         )
 
         # Drive the handler; it must complete without raising
-        router._on_copy_last_reply(
+        router.on_copy_last_reply(
             OutboxMessage(kind="__copy_last_reply__", text=""),
             conv, header,
         )
@@ -146,8 +146,8 @@ async def test_finish_copy_async_overwrites_placeholder_on_success(
         # And a sticky should now be visible (the success transient)
         # — we can't easily read the sticky text without more plumbing,
         # but a follow-up _show_transient_status would have armed a fresh
-        # timer, so the router's handle field is set.
-        assert router._transient_status_timer is not None
+        # timer, so the router reports an active timer.
+        assert router.has_transient_status_timer()
 
 
 @pytest.mark.asyncio
@@ -169,4 +169,4 @@ async def test_finish_copy_async_surfaces_failure_when_no_tool(
         await router._finish_copy_async(conv, "anything", n=1)
         await pilot.pause()
         # No crash, and a transient was armed (= failure status visible)
-        assert router._transient_status_timer is not None
+        assert router.has_transient_status_timer()

--- a/tests/cli/test_find_regex_case_opt_in.py
+++ b/tests/cli/test_find_regex_case_opt_in.py
@@ -201,10 +201,10 @@ async def test_on_find_with_flags_seeds_router_state() -> None:
             header,
         )
         await pilot.pause()
-        assert router._find_query == "ab."
-        assert router._find_regex is True
-        assert router._find_case_sensitive is False
-        assert router._find_cursor_idx is not None
+        assert router.find_query == "ab."
+        assert router.find_regex_enabled is True
+        assert router.find_case_sensitive is False
+        assert router.find_cursor_index is not None
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_on_find_invalid_regex_emits_error_status() -> None:
         assert snap["active"] is True
         assert "invalid pattern" in snap["body"]
         # No stale cycle state.
-        assert router._find_query is None
+        assert router.find_query is None
 
 
 @pytest.mark.asyncio
@@ -262,12 +262,12 @@ async def test_cycle_find_preserves_flags() -> None:
         await pilot.pause()
         # Cycle forward — should walk only the Foo1/Foo3 case-
         # sensitive matches (skipping foo2).
-        prev_cursor = router._find_cursor_idx
+        prev_cursor = router.find_cursor_index
         router.cycle_find(+1)
         await pilot.pause()
         # The cursor moved AND case_sensitive flag survived.
-        assert router._find_case_sensitive is True
-        new_cursor = router._find_cursor_idx
+        assert router.find_case_sensitive is True
+        new_cursor = router.find_cursor_index
         # New target is the OTHER Foo line, not the foo2 lower-case line.
         assert new_cursor != prev_cursor
         # Sanity: foo2 is at idx between Foo1 and Foo3; verify cursor


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, single-widget slice (`app_outbox.py`).

## Summary
- 9 private-state asserts across 2 test files → migrated to public surface
- New accessors on `OutboxRouter` for find-state + transient timer + on-copy handler
- Part of larger Tier C Path C sweep
- Deferred: 3 multi-src test files (= test_find_cycle_navigation / test_header_badge_click / test_sticky_timer_cancellation) handled in later sweep

## Test plan
- [x] `python scripts/test_tier_audit.py <2 test files>` → 0 violations
- [x] `pytest <2 test files>` → all pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 green
- [x] `ruff check <changed files>` → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced