### PR TITLE
chore(tier-c): migrate right_panel widget tests off private-state asserts

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -323,6 +323,61 @@ class RightPanel(Widget):
     def preview_visible(self) -> bool:
         return self._preview_visible
 
+    # ── read-only scalar accessors (Tier C Path C cleanup) ───────────────────
+
+    @property
+    def events_chain_isolate(self) -> "str | None":
+        """Active chain isolation filter, or None when off."""
+        return self._events_chain_isolate
+
+    @property
+    def events_verbose(self) -> bool:
+        """Whether events tab verbose mode (show compaction_check) is on."""
+        return self._events_verbose
+
+    @property
+    def memory_type_filter(self) -> "str | None":
+        """Active memory tab per-type filter, or None for all types."""
+        return self._memory_type_filter
+
+    @property
+    def memory_cursor(self) -> int:
+        """Current memory tab cursor index."""
+        return self._memory_cursor
+
+    @property
+    def docs_cursor(self) -> int:
+        """Current docs tab cursor index into ``_docs_files``."""
+        return self._docs_cursor
+
+    @property
+    def docs_lang(self) -> str:
+        """Active docs language preference (``"en"`` or ``"ja"``)."""
+        return self._docs_lang
+
+    @property
+    def docs_filter(self) -> str:
+        """Active docs tab substring filter; empty string means no filter."""
+        return self._docs_filter
+
+    @property
+    def panel_width(self) -> int:
+        """Cached absolute column width; 0 means CSS-default 33% is active."""
+        return self._panel_width
+
+    @property
+    def event_tail_idx(self) -> int:
+        """Index into ``_TAIL_CYCLE`` for the current tail-N setting."""
+        return self._event_tail_idx
+
+    def has_previewable_content(self) -> bool:
+        """Public alias for the internal ``_has_previewable_content`` check.
+
+        Whether the current tab has at least one item the preview pane
+        can render. Keys / cost tabs never have previews.
+        """
+        return self._has_previewable_content()
+
     def cycle(self, delta: int) -> None:
         """Advance (delta=+1) or retreat (delta=-1) through tabs."""
         tabs = self.query_one("#panel-tabs", Tabs)

--- a/tests/cli/test_docs_filter_esc_clear.py
+++ b/tests/cli/test_docs_filter_esc_clear.py
@@ -86,7 +86,7 @@ def test_right_panel_on_key_esc_clears_docs_filter() -> None:
     event = _Event()
     panel.on_key(event)
 
-    assert panel._docs_filter == ""
+    assert panel.docs_filter == ""
     assert invalidated == [True]
     assert event.prevented is True
     assert event.stopped is True

--- a/tests/cli/test_docs_lang_filter.py
+++ b/tests/cli/test_docs_lang_filter.py
@@ -229,8 +229,8 @@ def test_right_panel_g_key_on_docs_tab_toggles_lang() -> None:
 
     ev = _Event()
     panel.on_key(ev)
-    assert panel._docs_lang == "en", (
-        f"First 'g' press on docs tab must toggle ja → en; got {panel._docs_lang!r}"
+    assert panel.docs_lang == "en", (
+        f"First 'g' press on docs tab must toggle ja → en; got {panel.docs_lang!r}"
     )
     assert invalidated == [True]
     assert ev.prevented is True
@@ -238,8 +238,8 @@ def test_right_panel_g_key_on_docs_tab_toggles_lang() -> None:
     # Second press: en → ja.
     ev2 = _Event()
     panel.on_key(ev2)
-    assert panel._docs_lang == "ja", (
-        f"Second 'g' press must toggle en → ja; got {panel._docs_lang!r}"
+    assert panel.docs_lang == "ja", (
+        f"Second 'g' press must toggle en → ja; got {panel.docs_lang!r}"
     )
 
 
@@ -271,8 +271,8 @@ def test_right_panel_g_key_on_memory_tab_does_not_toggle_lang() -> None:
 
     ev = _Event()
     panel.on_key(ev)
-    assert panel._docs_lang == "ja", (
-        f"'g' on memory tab must NOT change _docs_lang; got {panel._docs_lang!r}"
+    assert panel.docs_lang == "ja", (
+        f"'g' on memory tab must NOT change docs_lang; got {panel.docs_lang!r}"
     )
     # _invalidate must NOT have been called (no state change occurred).
     assert invalidated == [], (

--- a/tests/cli/test_events_tab_chain_isolate.py
+++ b/tests/cli/test_events_tab_chain_isolate.py
@@ -56,10 +56,10 @@ async def test_toggle_chain_isolate_captures_cursor_chain() -> None:
             {"type": "phase_started", "data": {"chain_id": "chain-B"}},
         ]
         panel._events_cursor = 0
-        assert panel._events_chain_isolate is None
+        assert panel.events_chain_isolate is None
         became_active = panel.toggle_chain_isolate()
         assert became_active is True
-        assert panel._events_chain_isolate == "chain-A"
+        assert panel.events_chain_isolate == "chain-A"
 
 
 @pytest.mark.asyncio
@@ -77,11 +77,11 @@ async def test_toggle_chain_isolate_second_press_clears() -> None:
         ]
         panel._events_cursor = 0
         panel.toggle_chain_isolate()
-        assert panel._events_chain_isolate == "chain-X"
+        assert panel.events_chain_isolate == "chain-X"
         # Second press clears.
         cleared = panel.toggle_chain_isolate()
         assert cleared is False
-        assert panel._events_chain_isolate is None
+        assert panel.events_chain_isolate is None
 
 
 @pytest.mark.asyncio
@@ -97,7 +97,7 @@ async def test_toggle_chain_isolate_empty_list_returns_false() -> None:
         panel._events_visible = []
         result = panel.toggle_chain_isolate()
         assert result is False
-        assert panel._events_chain_isolate is None
+        assert panel.events_chain_isolate is None
 
 
 @pytest.mark.asyncio
@@ -121,7 +121,7 @@ async def test_toggle_chain_isolate_cursor_event_no_chain_id() -> None:
         panel._events_cursor = 0
         result = panel.toggle_chain_isolate()
         assert result is False
-        assert panel._events_chain_isolate is None
+        assert panel.events_chain_isolate is None
 
 
 def test_render_events_filters_by_chain_isolate(tmp_path: Path) -> None:
@@ -189,7 +189,7 @@ async def test_i_key_on_events_tab_invokes_toggle() -> None:
         key_event = textual_events.Key(key="i", character="i")
         panel.on_key(key_event)
         await pilot.pause()
-        assert panel._events_chain_isolate == "C"
+        assert panel.events_chain_isolate == "C"
 
 
 def test_keys_tab_lists_i_under_panel_explicit() -> None:

--- a/tests/cli/test_events_tab_d_jumps_to_events_md.py
+++ b/tests/cli/test_events_tab_d_jumps_to_events_md.py
@@ -92,7 +92,7 @@ async def test_d_key_on_events_tab_jumps_to_docs_events_md(
         # Start on events tab.
         panel.set_panel_type("events")
         await pilot.pause()
-        assert panel._panel_type == "events"
+        assert panel.panel_type == "events"
 
         # Dispatch 'd'.
         key_event = textual_events.Key(key="d", character="d")
@@ -100,8 +100,8 @@ async def test_d_key_on_events_tab_jumps_to_docs_events_md(
         await pilot.pause()
 
         # Docs tab must now be active.
-        assert panel._panel_type == "docs", (
-            f"Expected panel_type='docs', got {panel._panel_type!r}"
+        assert panel.panel_type == "docs", (
+            f"Expected panel_type='docs', got {panel.panel_type!r}"
         )
         # Cursor must be on events.md (stem = "events").
         stem = panel.current_doc_stem()
@@ -134,10 +134,10 @@ async def test_d_key_on_memory_tab_does_not_open_docs(tmp_path: Path) -> None:
         # Switch to memory tab (not events).
         panel.set_panel_type("memory")
         await pilot.pause()
-        assert panel._panel_type == "memory"
+        assert panel.panel_type == "memory"
 
         # Record docs cursor before the key press.
-        cursor_before = panel._docs_cursor
+        cursor_before = panel.docs_cursor
 
         # Dispatch 'd' — should be a no-op for the docs jump.
         # (Memory tab has no `d` handler, so it falls through to the
@@ -147,8 +147,8 @@ async def test_d_key_on_memory_tab_does_not_open_docs(tmp_path: Path) -> None:
         await pilot.pause()
 
         # Panel must still be on memory, not docs.
-        assert panel._panel_type == "memory", (
-            f"Expected 'memory', got {panel._panel_type!r}"
+        assert panel.panel_type == "memory", (
+            f"Expected 'memory', got {panel.panel_type!r}"
         )
         # Docs cursor must not have moved.
-        assert panel._docs_cursor == cursor_before
+        assert panel.docs_cursor == cursor_before

--- a/tests/cli/test_events_tail_reanchor.py
+++ b/tests/cli/test_events_tail_reanchor.py
@@ -86,7 +86,7 @@ async def test_cycle_event_tail_advances_index() -> None:
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         panel = app.query_one("#right_panel", RightPanel)
-        start = panel._event_tail_idx
+        start = panel.event_tail_idx
         panel.cycle_event_tail()
         await pilot.pause()
-        assert panel._event_tail_idx == (start + 1) % len(_TAIL_CYCLE)
+        assert panel.event_tail_idx == (start + 1) % len(_TAIL_CYCLE)

--- a/tests/cli/test_events_verbose_toggle.py
+++ b/tests/cli/test_events_verbose_toggle.py
@@ -195,22 +195,22 @@ async def test_v_key_on_events_tab_toggles_verbose() -> None:
         await pilot.pause()
 
         # Default state is False (= hide compaction_check)
-        assert panel._events_verbose is False
+        assert panel.events_verbose is False
 
         # First v press → True
         key_event = textual_events.Key(key="v", character="v")
         panel.on_key(key_event)
         await pilot.pause()
-        assert panel._events_verbose is True, (
-            "Expected _events_verbose=True after first v press on events tab"
+        assert panel.events_verbose is True, (
+            "Expected events_verbose=True after first v press on events tab"
         )
 
         # Second v press → False again
         key_event2 = textual_events.Key(key="v", character="v")
         panel.on_key(key_event2)
         await pilot.pause()
-        assert panel._events_verbose is False, (
-            "Expected _events_verbose=False after second v press on events tab"
+        assert panel.events_verbose is False, (
+            "Expected events_verbose=False after second v press on events tab"
         )
 
 
@@ -233,15 +233,15 @@ async def test_v_key_on_memory_tab_does_not_toggle_verbose() -> None:
         panel.set_panel_type("memory")
         await pilot.pause()
 
-        assert panel._events_verbose is False
+        assert panel.events_verbose is False
 
         key_event = textual_events.Key(key="v", character="v")
         panel.on_key(key_event)
         await pilot.pause()
 
         # Must still be False — the v handler is events-tab-only
-        assert panel._events_verbose is False, (
-            "_events_verbose must not change when v is pressed on a non-events tab"
+        assert panel.events_verbose is False, (
+            "events_verbose must not change when v is pressed on a non-events tab"
         )
 
 

--- a/tests/cli/test_memory_tab_type_filter.py
+++ b/tests/cli/test_memory_tab_type_filter.py
@@ -63,7 +63,7 @@ async def test_cycle_memory_type_filter_walks_order() -> None:
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         panel = app.query_one("#right_panel", RightPanel)
-        assert panel._memory_type_filter is None
+        assert panel.memory_type_filter is None
         assert panel.cycle_memory_type_filter() == "user"
         assert panel.cycle_memory_type_filter() == "feedback"
         assert panel.cycle_memory_type_filter() == "project"
@@ -83,7 +83,7 @@ async def test_cycle_resets_memory_cursor() -> None:
         panel = app.query_one("#right_panel", RightPanel)
         panel._memory_cursor = 7
         panel.cycle_memory_type_filter()
-        assert panel._memory_cursor == 0
+        assert panel.memory_cursor == 0
 
 
 def test_render_memory_with_type_filter_keeps_only_target(tmp_path: Path) -> None:
@@ -172,11 +172,11 @@ async def test_t_key_on_memory_tab_invokes_cycle() -> None:
         panel = app.query_one("#right_panel", RightPanel)
         panel.set_panel_type("memory")
         await pilot.pause()
-        assert panel._memory_type_filter is None
+        assert panel.memory_type_filter is None
         key_event = textual_events.Key(key="t", character="t")
         panel.on_key(key_event)
         await pilot.pause()
-        assert panel._memory_type_filter == "user"
+        assert panel.memory_type_filter == "user"
 
 
 def test_keys_tab_t_first_occurrence_is_events() -> None:

--- a/tests/cli/test_panel_width_reclamp_on_terminal_resize.py
+++ b/tests/cli/test_panel_width_reclamp_on_terminal_resize.py
@@ -68,9 +68,9 @@ async def test_terminal_shrink_clamps_cached_panel_width() -> None:
         _stub_max_width(panel, 52)
         panel.on_resize(event=None)  # the handler ignores the event arg
 
-        assert panel._panel_width == 52, (
-            f"on_resize must clamp _panel_width down to the new max; "
-            f"got {panel._panel_width}"
+        assert panel.panel_width == 52, (
+            f"on_resize must clamp panel_width down to the new max; "
+            f"got {panel.panel_width}"
         )
 
 
@@ -87,9 +87,9 @@ async def test_terminal_grow_preserves_cached_panel_width() -> None:
         _stub_max_width(panel, 132)
         panel.on_resize(event=None)
 
-        assert panel._panel_width == 60, (
+        assert panel.panel_width == 60, (
             f"on_resize must NOT re-expand a smaller cached width; "
-            f"got {panel._panel_width}"
+            f"got {panel.panel_width}"
         )
 
 
@@ -106,14 +106,14 @@ async def test_panel_at_css_default_is_left_alone() -> None:
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         panel = app.query_one("#right_panel", RightPanel)
-        # _panel_width default is 0 (= CSS-managed)
-        assert panel._panel_width == 0
+        # panel_width default is 0 (= CSS-managed)
+        assert panel.panel_width == 0
 
         _stub_max_width(panel, 52)
         panel.on_resize(event=None)
 
         # Still 0 — Textual handles the CSS-default reflow on its own.
-        assert panel._panel_width == 0, (
+        assert panel.panel_width == 0, (
             f"on_resize must not touch the CSS-default panel; "
-            f"got {panel._panel_width}"
+            f"got {panel.panel_width}"
         )

--- a/tests/cli/test_pending_tab_preview.py
+++ b/tests/cli/test_pending_tab_preview.py
@@ -55,7 +55,7 @@ def test_has_previewable_content_returns_true_for_pending_with_items() -> None:
     panel._events_visible = []
     panel._memory_entries = []
     panel._agents_items = []
-    assert panel._has_previewable_content() is True
+    assert panel.has_previewable_content() is True
 
 
 def test_has_previewable_content_returns_false_for_pending_empty() -> None:
@@ -69,7 +69,7 @@ def test_has_previewable_content_returns_false_for_pending_empty() -> None:
     panel._events_visible = []
     panel._memory_entries = []
     panel._agents_items = []
-    assert panel._has_previewable_content() is False
+    assert panel.has_previewable_content() is False
 
 
 def test_show_pending_in_preview_writes_intervention_fields() -> None:


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, single-widget slice (`right_panel/__init__.py`).

## Summary
- 32 private-state asserts across 9 test files → migrated to public surface
- ~10 new public accessors on `RightPanel` (additive only): `events_chain_isolate`, `events_verbose`, `memory_type_filter`, `memory_cursor`, `docs_cursor`, `docs_lang`, `docs_filter`, `panel_width`, `event_tail_idx`, `has_previewable_content()` (method alias)
- Note: `panel_type` was already a public property; only the new 10 items are additions
- Part of larger Tier C Path C sweep (sandbox_2 PR #938 AST audit exposure)

## Test plan
- [x] `python scripts/test_tier_audit.py <9 test files>` → 0 violations (52/52 tests)
- [x] `pytest <9 test files>` → 52/52 pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 green
- [x] `ruff check <changed files>` → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced