### PR TITLE
chore(mcp-client): expose stderr capture surface publicly (Tier C1 cleanup wave 12)

### DIFF
--- a/src/reyn/mcp_client.py
+++ b/src/reyn/mcp_client.py
@@ -90,6 +90,17 @@ class MCPClient:
         # ``_open_stdio``; closed in ``close``.
         self._stderr_capture: Any = None  # tempfile.TemporaryFile | None
 
+    @property
+    def stderr_capture(self) -> "Any":
+        """Read-only accessor for the stderr-capture tempfile (or None).
+
+        Tests inspect this to verify the capture lifecycle (= None
+        initially, populated after ``_open_stdio``, None again after
+        ``close_stderr_capture``). The write side stays internal so the
+        lifecycle stays visible at the call sites that own it.
+        """
+        return self._stderr_capture
+
     # ── public API ──────────────────────────────────────────────────────────
 
     def is_initialized(self) -> bool:
@@ -127,12 +138,12 @@ class MCPClient:
             await session.initialize()
         except MCPError:
             await stack.aclose()
-            self._close_stderr_capture()
+            self.close_stderr_capture()
             raise
         except Exception as exc:
             await stack.aclose()
-            tail = self._read_stderr_tail()
-            self._close_stderr_capture()
+            tail = self.read_stderr_tail()
+            self.close_stderr_capture()
             if tail:
                 raise MCPError(
                     f"MCP initialize failed: {exc}\n"
@@ -192,7 +203,7 @@ class MCPClient:
     async def close(self) -> None:
         """Tear down the transport and session. Safe to call repeatedly."""
         if self._stack is None:
-            self._close_stderr_capture()
+            self.close_stderr_capture()
             return
         stack = self._stack
         self._stack = None
@@ -203,16 +214,16 @@ class MCPClient:
         except Exception:
             # Best-effort cleanup; transport may already be down.
             pass
-        self._close_stderr_capture()
+        self.close_stderr_capture()
 
     # ── stderr capture (stdio only) ─────────────────────────────────────────
 
-    _STDERR_TAIL_BYTES = 2048
+    STDERR_TAIL_BYTES = 2048
 
-    def _read_stderr_tail(self) -> str:
+    def read_stderr_tail(self) -> str:
         """Return the tail of the subprocess stderr capture, or ''.
 
-        Reads up to ``_STDERR_TAIL_BYTES`` from the end of the temp
+        Reads up to ``STDERR_TAIL_BYTES`` from the end of the temp
         file. Returns empty string when no capture is configured (= http
         transport, or stdio capture failed to open) or read raises.
         Failures here are advisory: never propagate beyond the helper
@@ -240,11 +251,11 @@ class MCPClient:
                 return ""
         else:
             text = data
-        if len(text) > self._STDERR_TAIL_BYTES:
-            return "...(truncated)\n" + text[-self._STDERR_TAIL_BYTES :]
+        if len(text) > self.STDERR_TAIL_BYTES:
+            return "...(truncated)\n" + text[-self.STDERR_TAIL_BYTES :]
         return text
 
-    def _close_stderr_capture(self) -> None:
+    def close_stderr_capture(self) -> None:
         """Close + delete the stderr temp file, if any. Idempotent."""
         capture = self._stderr_capture
         if capture is None:

--- a/tests/test_mcp_client_stderr_capture.py
+++ b/tests/test_mcp_client_stderr_capture.py
@@ -13,10 +13,10 @@ This file pins the contract independently of the mcp SDK:
   1. ``_open_stdio()`` creates a temp file and passes it as
      ``errlog`` to ``stdio_client`` (= verified via signature
      introspection + the stand-in in ``test_mcp_client.py``).
-  2. ``_read_stderr_tail()`` returns captured text up to the configured
+  2. ``read_stderr_tail()`` returns captured text up to the configured
      byte cap; truncates with a ``...(truncated)`` prefix.
-  3. ``_close_stderr_capture()`` is idempotent and never raises.
-  4. ``_read_stderr_tail()`` on a missing / closed capture returns ``""``.
+  3. ``close_stderr_capture()`` is idempotent and never raises.
+  4. ``read_stderr_tail()`` on a missing / closed capture returns ``""``.
   5. The init-failure branch in ``initialize()`` enriches MCPError
      with the captured tail when present.
 
@@ -51,15 +51,15 @@ def _client(transport_type: str = "stdio") -> MCPClient:
 def test_read_stderr_tail_returns_empty_when_no_capture() -> None:
     """Tier 2: no capture configured → tail is empty string."""
     client = _client()
-    assert client._stderr_capture is None
-    assert client._read_stderr_tail() == ""
+    assert client.stderr_capture is None
+    assert client.read_stderr_tail() == ""
 
 
 def test_close_stderr_capture_is_idempotent_with_no_capture() -> None:
     """Tier 2: closing a never-opened capture is a safe no-op."""
     client = _client()
-    client._close_stderr_capture()  # must not raise
-    client._close_stderr_capture()  # second call also safe
+    client.close_stderr_capture()  # must not raise
+    client.close_stderr_capture()  # second call also safe
 
 
 # ── 2. tail returns captured text ────────────────────────────────────────
@@ -71,7 +71,7 @@ def test_read_stderr_tail_returns_captured_content() -> None:
     capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
     capture.write("ImportError: No module named 'foo'\n")
     client._stderr_capture = capture
-    tail = client._read_stderr_tail()
+    tail = client.read_stderr_tail()
     assert "ImportError: No module named 'foo'" in tail
 
 
@@ -84,14 +84,14 @@ def test_read_stderr_tail_truncates_long_content() -> None:
     """
     client = _client()
     capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
-    long_text = "X" * (MCPClient._STDERR_TAIL_BYTES + 500)
+    long_text = "X" * (MCPClient.STDERR_TAIL_BYTES + 500)
     capture.write(long_text)
     client._stderr_capture = capture
-    tail = client._read_stderr_tail()
+    tail = client.read_stderr_tail()
     assert tail.startswith("...(truncated)")
     # Body length is capped at the configured byte limit.
     body = tail[len("...(truncated)\n"):]
-    assert len(body) == MCPClient._STDERR_TAIL_BYTES
+    assert len(body) == MCPClient.STDERR_TAIL_BYTES
 
 
 def test_close_stderr_capture_clears_attribute() -> None:
@@ -99,9 +99,9 @@ def test_close_stderr_capture_clears_attribute() -> None:
     client = _client()
     client._stderr_capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
     client._stderr_capture.write("anything")
-    client._close_stderr_capture()
-    assert client._stderr_capture is None
-    assert client._read_stderr_tail() == ""
+    client.close_stderr_capture()
+    assert client.stderr_capture is None
+    assert client.read_stderr_tail() == ""
 
 
 # ── 3. tail survives a closed underlying file (= defensive) ─────────────
@@ -119,7 +119,7 @@ def test_read_stderr_tail_returns_empty_when_file_closed() -> None:
     capture.write("should-not-leak")
     capture.close()
     client._stderr_capture = capture
-    assert client._read_stderr_tail() == ""
+    assert client.read_stderr_tail() == ""
 
 
 # ── 4. http transport does not allocate a capture ────────────────────────
@@ -132,8 +132,8 @@ def test_http_transport_does_not_allocate_capture() -> None:
     field stays None so close() is a no-op.
     """
     client = _client("http")
-    assert client._stderr_capture is None
-    client._close_stderr_capture()  # safe
+    assert client.stderr_capture is None
+    client.close_stderr_capture()  # safe
 
 
 # ── 5. open_stdio sets up the capture as a side effect ──────────────────
@@ -148,16 +148,16 @@ def test_open_stdio_allocates_stderr_capture() -> None:
     """
     pytest.importorskip("mcp")  # requires the optional dep
     client = _client()
-    assert client._stderr_capture is None
+    assert client.stderr_capture is None
     cm = client._open_stdio()
     try:
-        assert client._stderr_capture is not None
+        assert client.stderr_capture is not None
         # writable text file with utf-8
-        client._stderr_capture.write("hello")
-        client._stderr_capture.flush()
-        assert client._read_stderr_tail() == "hello"
+        client.stderr_capture.write("hello")
+        client.stderr_capture.flush()
+        assert client.read_stderr_tail() == "hello"
     finally:
-        client._close_stderr_capture()
+        client.close_stderr_capture()
         # cm is an async generator; we never entered it so no awaitable cleanup needed
         del cm
 
@@ -197,4 +197,4 @@ def test_initialize_failure_includes_stderr_tail_in_error() -> None:
     assert "MCP initialize failed" in msg
     assert "Traceback: ImportError: missing dep 'foo'" in msg
     # After error path, capture is closed.
-    assert client._stderr_capture is None
+    assert client.stderr_capture is None


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twelfth slice. Bundled rename + property mitigation on the MCPClient stderr-capture surface (= 10 findings in one test file, single class).

## Changes

### Production (\`src/reyn/mcp_client.py\`)
- Methods renamed (drop \`_\`):
  - \`_read_stderr_tail\` → \`read_stderr_tail\`
  - \`_close_stderr_capture\` → \`close_stderr_capture\`
- Class constant renamed: \`_STDERR_TAIL_BYTES\` → \`STDERR_TAIL_BYTES\`
- New ``@property``: \`stderr_capture\` returns \`self._stderr_capture\` (read-only)
- Internal callers (\`initialize\` / \`close\`) updated to the public names

### Tests (10 Tier-C1 findings cleared)
- \`tests/test_mcp_client_stderr_capture.py\`:
  - 6 \`assert client._stderr_capture …\` reads → \`client.stderr_capture\` (property)
  - 4 \`_read_stderr_tail()\` / \`_close_stderr_capture()\` / \`_STDERR_TAIL_BYTES\` references → public names
  - Module docstring + section comments updated for consistency

## Why
The capture mechanism is the public contract of the MCP stdio transport (= "if the server crashes, the tail is in the error"). The underscore on the helpers was convention-only; no API-stability gate, no external callers (production code is in the same module).

The field ``_stderr_capture`` stays private — production code reads/writes it directly to manage the open/close lifecycle, which we want to keep visible at call sites. Tests get the read-only property.

## Mitigation pattern intentionally bundled
This single class needed two mitigations (= method rename + field property), and splitting into two PRs would add overhead without review-cycle benefit. Each change is independent and the diff is readable per-symbol.

## Tests' write-side fixture pattern
Tests still write to \`client._stderr_capture = tempfile.…\` for fixture setup. The audit policy only flags ``assert`` reads of private state; private writes during test setup are a recognised pattern and not a Tier-4 violation.

## Tier rule self-check
- [x] Test \`Tier 2:\` docstrings preserved
- [x] Audit: \`python3 scripts/test_tier_audit.py --check private-state tests/test_mcp_client_stderr_capture.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical method-dispatch + constant semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_mcp_client_stderr_capture.py tests/test_mcp_client.py\` → 20 passed
- [x] No external callers verified via repo-wide grep on the old underscore names (only docstring references in test files, which are updated for consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)