### PR TITLE
chore(a2a-bridge): rename _on_event / _format_message to drop underscores (Tier C1 cleanup wave 13)

### DIFF
--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -760,7 +760,7 @@ class _A2AProgressBridge:
     def attach(self) -> None:
         events = getattr(self._session, "_chat_events", None)
         if events is not None:
-            events.add_subscriber(self._on_event)
+            events.add_subscriber(self.on_event)
 
     def detach(self) -> None:
         if self._detached:
@@ -768,12 +768,12 @@ class _A2AProgressBridge:
         self._detached = True
         events = getattr(self._session, "_chat_events", None)
         if events is not None:
-            events.remove_subscriber(self._on_event)
+            events.remove_subscriber(self.on_event)
         for task in self._tasks:
             if not task.done():
                 task.cancel()
 
-    def _on_event(self, event: "object") -> None:
+    def on_event(self, event: "object") -> None:
         # Sync callback from EventLog dispatcher. Filter by type, build
         # payload, schedule async POST.
         if self._detached:
@@ -782,7 +782,7 @@ class _A2AProgressBridge:
         if event_type not in self._TRACKED_EVENTS:
             return
         data = getattr(event, "data", {}) or {}
-        message = self._format_message(event_type, data)
+        message = self.format_message(event_type, data)
         self._ordinal += 1
         ordinal = self._ordinal
         try:
@@ -795,7 +795,7 @@ class _A2AProgressBridge:
         self._tasks.append(task)
 
     @staticmethod
-    def _format_message(event_type: str, data: dict) -> str:
+    def format_message(event_type: str, data: dict) -> str:
         if event_type == "phase_started":
             phase = data.get("phase") or "?"
             return f"phase: {phase}"

--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -23,7 +23,7 @@ Pins:
      ``detach()`` unsubscribes + cancels in-flight tasks; idempotent.
   3. Untracked event types are ignored (= ``intervention_routed`` /
      ``phase_completed`` / etc. don't fire the bridge).
-  4. ``_format_message`` produces the expected text for each kind.
+  4. ``format_message`` produces the expected text for each kind.
   5. ``_send`` POSTs the canonical progress payload to the configured
      webhook_url.
   6. ``ordinal`` is monotonic across multiple events on one bridge.
@@ -111,15 +111,15 @@ def test_a2a_progress_bridge_tracks_three_lifecycle_events() -> None:
 
 
 def test_attach_subscribes_to_chat_events() -> None:
-    """Tier 2: ``attach()`` adds the bridge's ``_on_event`` callback to
+    """Tier 2: ``attach()`` adds the bridge's ``on_event`` callback to
     the session's chat_events subscriber list (= so EventLog dispatches
     will reach the bridge).
     """
     captured: list = []
     bridge, events = _make_bridge(captured_posts=captured)
-    assert bridge._on_event not in events._subscribers
+    assert bridge.on_event not in events._subscribers
     bridge.attach()
-    assert bridge._on_event in events._subscribers
+    assert bridge.on_event in events._subscribers
 
 
 def test_detach_unsubscribes_from_chat_events() -> None:
@@ -129,9 +129,9 @@ def test_detach_unsubscribes_from_chat_events() -> None:
     captured: list = []
     bridge, events = _make_bridge(captured_posts=captured)
     bridge.attach()
-    assert bridge._on_event in events._subscribers
+    assert bridge.on_event in events._subscribers
     bridge.detach()
-    assert bridge._on_event not in events._subscribers
+    assert bridge.on_event not in events._subscribers
     assert bridge._detached is True
 
 
@@ -199,28 +199,28 @@ def test_tracked_events_each_fire_one_post() -> None:
 
 
 def test_format_message_for_each_event_kind() -> None:
-    """Tier 2: ``_format_message`` outputs the canonical human-readable
+    """Tier 2: ``format_message`` outputs the canonical human-readable
     text per event kind. Matches the MCP bridge's format so peer
     consumers can apply the same parser to both transports.
     """
     from reyn.web.routers.a2a import _A2AProgressBridge
 
-    assert _A2AProgressBridge._format_message(
+    assert _A2AProgressBridge.format_message(
         "phase_started", {"phase": "planning"},
     ) == "phase: planning"
-    assert _A2AProgressBridge._format_message(
+    assert _A2AProgressBridge.format_message(
         "llm_called", {"model": "gemini-2.5-flash-lite"},
     ) == "llm: gemini-2.5-flash-lite"
     # Singular form for 1 op.
-    assert _A2AProgressBridge._format_message(
+    assert _A2AProgressBridge.format_message(
         "act_executed", {"op_count": 1},
     ) == "act: 1 op"
     # Plural form for N>1.
-    assert _A2AProgressBridge._format_message(
+    assert _A2AProgressBridge.format_message(
         "act_executed", {"op_count": 5},
     ) == "act: 5 ops"
     # Missing fields fall back to "?".
-    assert _A2AProgressBridge._format_message(
+    assert _A2AProgressBridge.format_message(
         "phase_started", {},
     ) == "phase: ?"
 


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 thirteenth slice. ``rename`` mitigation on the two helper methods of \`_A2AProgressBridge\`.

## Changes

### Production (\`src/reyn/web/routers/a2a.py\`)
- ``_on_event`` → ``on_event`` (method)
- ``_format_message`` → ``format_message`` (method)
- Internal callers updated (\`attach\` / \`detach\` registrations + the one \`self._format_message\` call inside \`on_event\`)

### Tests (9 Tier-C1 findings cleared)
- \`tests/test_a2a_webhook_progress_267_gap2.py\`:
  - 4 ``bridge._on_event`` → ``bridge.on_event``
  - 5 ``_A2AProgressBridge._format_message`` → ``.format_message``
  - Docstring references updated for consistency

## Why
Both methods are stable testable units (event-type filter + per-kind text formatter). The underscore was convention only; only in-class callers reference them, so the rename is fully mechanical.

The class itself (\`_A2AProgressBridge\`) keeps its underscore — it's module-private and the tests import it explicitly, which is a recognised pattern outside Tier-4 scope.

## Out of scope
Other findings in this file (= \`_TRACKED_EVENTS\` class constant, \`_subscribers\` EventLog internal, \`_detached\` flag) are different attrs needing different mitigations; deferred to subsequent slices.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit: ``_on_event`` and ``_format_message`` findings cleared. Remaining errors articulated above.
- [x] Load-bearing invariants preserved (= identical method-dispatch semantics, only the symbol moved)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_a2a_webhook_progress_267_gap2.py\` → 12 passed
- [x] No external callers of the old names verified via repo-wide grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)