### PR TITLE
chore(test): use registry.last_truncation_ts property (Tier C1 cleanup wave 14)

### DIFF
--- a/tests/test_registry_wal_size_safety_net.py
+++ b/tests/test_registry_wal_size_safety_net.py
@@ -90,19 +90,19 @@ def test_truncate_wal_bypasses_throttle_when_flag_set(tmp_path: Path):
         # First call: succeeds, stamps throttle
         first = await registry.truncate_wal_if_eligible()
         assert first is not None
-        ts1 = registry._last_truncation_ts
+        ts1 = registry.last_truncation_ts
         assert ts1 is not None
 
         # Second call WITHOUT bypass: throttled (skipped)
         second = await registry.truncate_wal_if_eligible()
         assert second is None
-        assert registry._last_truncation_ts == ts1  # unchanged
+        assert registry.last_truncation_ts == ts1  # unchanged
 
         # Third call WITH bypass: proceeds despite throttle window
         third = await registry.truncate_wal_if_eligible(bypass_throttle=True)
         assert third is not None
-        assert registry._last_truncation_ts is not None
-        assert registry._last_truncation_ts >= ts1
+        assert registry.last_truncation_ts is not None
+        assert registry.last_truncation_ts >= ts1
 
     asyncio.run(go())
 
@@ -163,14 +163,14 @@ def test_maybe_truncate_for_size_bypasses_throttle(tmp_path: Path):
     async def go():
         # Burn the throttle window
         await registry.truncate_wal_if_eligible()
-        ts1 = registry._last_truncation_ts
+        ts1 = registry.last_truncation_ts
         # Inflate
         await _inflate_wal(registry._state_log, target_bytes=51_200)
         # Size-triggered call should proceed even within throttle window
         result = await registry.maybe_truncate_for_size(threshold_bytes=50_000)
         assert result is not None
-        assert registry._last_truncation_ts is not None
-        assert registry._last_truncation_ts >= ts1
+        assert registry.last_truncation_ts is not None
+        assert registry.last_truncation_ts >= ts1
 
     asyncio.run(go())
 


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 fourteenth slice. Test-only one-line migration.

## Changes
\`AgentRegistry\` already exposes \`last_truncation_ts\` as a read-only \`@property\` at \`registry.py:124\`. The test file simply hadn't migrated to the public name yet — no production-side change needed.

- \`tests/test_registry_wal_size_safety_net.py\`: 5 ``registry._last_truncation_ts`` → ``registry.last_truncation_ts``

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_registry_wal_size_safety_net.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical value, only the access path moved)
- [x] No production-side change (= the property already existed)

## Test plan
- [x] \`venv/bin/pytest tests/test_registry_wal_size_safety_net.py\` → 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)