### PR TITLE
chore(tier-c): migrate ConversationView tests off private-state asserts

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -613,6 +613,124 @@ class ConversationView(Widget):
             pass
         return self._show_timestamps
 
+    # ── Public state accessors (Tier C Path C — replaces private-attr asserts) ─
+
+    @property
+    def user_scrolled(self) -> bool:
+        """True when the user has manually scrolled away from the tail.
+
+        Read-only accessor for the ``_user_scrolled`` latch. Tests and
+        external observers should read this property rather than accessing
+        ``_user_scrolled`` directly.
+        """
+        return self._user_scrolled
+
+    @property
+    def trim_warned(self) -> bool:
+        """True when the one-shot ring-buffer-trim warning has been emitted.
+
+        The latch fires at most once per session (or per clear()). Tests
+        that need to verify whether the trim warning fired should use this
+        property rather than accessing ``_trim_warned`` directly.
+        """
+        return self._trim_warned
+
+    @property
+    def last_long_reply(self) -> str | None:
+        """Tail text of the most recent long agent reply (= fold tail), or None.
+
+        Mirrors the ``_last_long_reply`` slot: set when the most recent
+        reply triggered the B3 fold (= too long for inline), cleared when
+        a subsequent short reply fits inline. Use ``has_pending_expand``
+        for the boolean form; this property exposes the raw value for
+        tests that need to distinguish *which* tail was stashed.
+        """
+        return self._last_long_reply
+
+    @property
+    def last_speaker_at(self) -> float:
+        """Wall-clock timestamp (``time.time()`` epoch seconds) of the last header write.
+
+        Used by header-grouping tests to verify the clock source is wall
+        time and not monotonic. Read-only — tests that need to simulate
+        time passage write ``conv._last_speaker_at`` directly for setup.
+        """
+        return self._last_speaker_at
+
+    @property
+    def last_header_date(self) -> str:
+        """``YYYY-MM-DD`` string of the last date-separator written, or ``""`` before any message.
+
+        ``clear()`` updates this to today so same-day Ctrl+L doesn't
+        re-emit the date separator. Tests verify this via the property
+        rather than accessing ``_last_header_date`` directly.
+        """
+        return self._last_header_date
+
+    def turn_anchors_snapshot(self) -> tuple[int, ...]:
+        """Return a snapshot of the current turn-anchor list as an immutable tuple.
+
+        Each value is an absolute line position (drop-aware, monotonically
+        growing). Tests should use this rather than accessing
+        ``_turn_anchors`` directly.
+        """
+        return tuple(self._turn_anchors)
+
+    @property
+    def tool_call_row_ids(self) -> frozenset:
+        """Frozenset of op_id strings for currently-tracked in-flight tool-call rows.
+
+        Supports membership tests (``op_id in conv.tool_call_row_ids``),
+        emptiness checks (``not conv.tool_call_row_ids``), and equality
+        (``conv.tool_call_row_ids == frozenset()``). Tests should use this
+        rather than accessing ``_tool_call_rows`` directly.
+        """
+        return frozenset(self._tool_call_rows)
+
+    def error_box_count(self) -> int:
+        """Number of currently-mounted (undismissed) ErrorBox widgets.
+
+        Tests should use this rather than accessing ``_error_boxes`` directly.
+        Zero means no live error boxes; ``> 0`` means at least one is
+        mounted and visible. See also ``has_error_boxes()`` for the boolean
+        form.
+        """
+        return len(self._error_boxes)
+
+    def richlog_start_line(self, log: "RichLog") -> int:
+        """Public wrapper around ``_richlog_start_line`` for test access.
+
+        Returns the RichLog's cumulative dropped-lines counter (=
+        ``log._start_line``) with a one-shot warning when the attribute is
+        missing. Tests that verify the ring-buffer trim / anchor-projection
+        logic should call this rather than ``_richlog_start_line`` directly.
+        """
+        return self._richlog_start_line(log)
+
+    def absolute_line_position(self, log: "RichLog") -> int:
+        """Public wrapper around ``_absolute_line_position`` for test access.
+
+        Returns ``richlog_start_line(log) + len(log.lines)`` — the
+        monotonically-growing absolute write position. Tests that verify
+        anchor storage should call this rather than ``_absolute_line_position``
+        directly.
+        """
+        return self._absolute_line_position(log)
+
+    def async_stack_snapshot(self) -> list:
+        """Return the AsyncStackPanel's current snapshot list, or ``[]`` if absent.
+
+        Mirrors the ``AsyncStackPanel.snapshot()`` return shape: a list of
+        dicts with at minimum ``agent_id``, ``summary``, and ``is_overflow``
+        keys. Returns an empty list when the panel is not mounted (= test
+        harness path or pre-compose). Tests should call this rather than
+        accessing ``_async_stack().snapshot()`` directly.
+        """
+        panel = self._async_stack()
+        if panel is None:
+            return []
+        return panel.snapshot()
+
     def on_mount(self) -> None:
         """Wire a scroll watcher so user scroll-up suppresses auto-scroll.
 

--- a/tests/cli/test_async_stack_panel_plan_lifecycle.py
+++ b/tests/cli/test_async_stack_panel_plan_lifecycle.py
@@ -58,7 +58,7 @@ async def test_plan_summary_adds_async_stack_row() -> None:
         router._on_system(msg, conv, header)
         await pilot.pause()
 
-        snap = conv._async_stack().snapshot()  # type: ignore[union-attr]
+        snap = conv.async_stack_snapshot()
         rows = [s for s in snap if not s["is_overflow"]]
         assert any(
             s["agent_id"] == "plan-abc12345-def6" for s in rows
@@ -90,7 +90,7 @@ async def test_plan_complete_removes_async_stack_row() -> None:
         await pilot.pause()
         assert any(
             s["agent_id"] == "plan-zzz999"
-            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            for s in conv.async_stack_snapshot()
             if not s["is_overflow"]
         )
 
@@ -104,7 +104,7 @@ async def test_plan_complete_removes_async_stack_row() -> None:
         await pilot.pause()
         assert all(
             s["agent_id"] != "plan-zzz999"
-            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            for s in conv.async_stack_snapshot()
         )
 
 
@@ -137,7 +137,7 @@ async def test_non_plan_system_message_does_not_touch_async_stack() -> None:
         router._on_system(msg, conv, header)
         await pilot.pause()
 
-        assert conv._async_stack().snapshot() == [], (  # type: ignore[union-attr]
+        assert conv.async_stack_snapshot() == [], (
             "non-plan system message must not touch the AsyncStackPanel"
         )
 
@@ -171,4 +171,4 @@ async def test_missing_plan_id_is_silent_noop() -> None:
         router._on_system(msg, conv, header)
         await pilot.pause()
         # Panel stays empty — no row keyed on empty string.
-        assert conv._async_stack().snapshot() == []  # type: ignore[union-attr]
+        assert conv.async_stack_snapshot() == []

--- a/tests/cli/test_async_stack_panel_wired.py
+++ b/tests/cli/test_async_stack_panel_wired.py
@@ -66,7 +66,7 @@ async def test_add_async_task_surfaces_entry_in_snapshot() -> None:
         conv = app.query_one("#conversation", ConversationView)
         conv.add_async_task("run-abc", "code_review")
         await pilot.pause()
-        snap = conv._async_stack().snapshot()  # type: ignore[union-attr]
+        snap = conv.async_stack_snapshot()
         # First non-overflow entry should be our task.
         running = [s for s in snap if not s["is_overflow"]]
         assert running, "task should appear in panel snapshot"
@@ -88,13 +88,13 @@ async def test_remove_async_task_drops_entry() -> None:
         await pilot.pause()
         assert any(
             s["agent_id"] == "run-xyz"
-            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            for s in conv.async_stack_snapshot()
         )
         conv.remove_async_task("run-xyz")
         await pilot.pause()
         assert all(
             s["agent_id"] != "run-xyz"
-            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            for s in conv.async_stack_snapshot()
         )
 
 
@@ -115,10 +115,10 @@ async def test_clear_async_tasks_empties_panel() -> None:
         conv.add_async_task("run-1", "a")
         conv.add_async_task("run-2", "b")
         await pilot.pause()
-        assert len(conv._async_stack().snapshot()) >= 2  # type: ignore[union-attr]
+        assert len(conv.async_stack_snapshot()) >= 2
         conv.clear()
         await pilot.pause()
-        assert conv._async_stack().snapshot() == []  # type: ignore[union-attr]
+        assert conv.async_stack_snapshot() == []
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_clear_preserves_date_header.py
+++ b/tests/cli/test_clear_preserves_date_header.py
@@ -53,9 +53,9 @@ async def test_clear_sets_last_header_date_to_today() -> None:
         await pilot.pause()
 
         today = time.strftime("%Y-%m-%d")
-        assert conv._last_header_date == today, (
-            f"clear() should set _last_header_date to today's date "
-            f"({today!r}); got {conv._last_header_date!r}"
+        assert conv.last_header_date == today, (
+            f"clear() should set last_header_date to today's date "
+            f"({today!r}); got {conv.last_header_date!r}"
         )
 
 

--- a/tests/cli/test_conv_clear_sweeps_tool_call_rows.py
+++ b/tests/cli/test_conv_clear_sweeps_tool_call_rows.py
@@ -58,7 +58,7 @@ async def test_clear_removes_in_flight_tool_call_widgets() -> None:
         assert app.query(ToolCallRow), (
             "test scaffolding broken — ToolCallRow should be mounted"
         )
-        assert "op-clear-1" in conv._tool_call_rows
+        assert "op-clear-1" in conv.tool_call_row_ids
 
         conv.clear()
         await pilot.pause()
@@ -66,9 +66,9 @@ async def test_clear_removes_in_flight_tool_call_widgets() -> None:
         assert not app.query(ToolCallRow), (
             "ToolCallRow widget should be removed from DOM after clear()"
         )
-        assert not conv._tool_call_rows, (
-            f"_tool_call_rows dict should be empty after clear(), "
-            f"got {list(conv._tool_call_rows.keys())!r}"
+        assert not conv.tool_call_row_ids, (
+            f"tool_call_row_ids should be empty after clear(), "
+            f"got {conv.tool_call_row_ids!r}"
         )
 
 
@@ -105,7 +105,7 @@ async def test_tool_completion_after_clear_does_not_raise() -> None:
         )
         await pilot.pause()
         # Dict stays empty.
-        assert "op-late-completion" not in conv._tool_call_rows
+        assert "op-late-completion" not in conv.tool_call_row_ids
 
 
 @pytest.mark.asyncio
@@ -124,4 +124,4 @@ async def test_clear_with_no_tool_call_rows_is_no_op_safe() -> None:
         # No tool calls created — just clear.
         conv.clear()
         await pilot.pause()
-        assert conv._tool_call_rows == {}
+        assert conv.tool_call_row_ids == frozenset()

--- a/tests/cli/test_conv_ts_toggle.py
+++ b/tests/cli/test_conv_ts_toggle.py
@@ -84,7 +84,7 @@ async def test_ts_on_by_default_header_contains_timestamp():
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
 
-        assert conv._show_timestamps is True
+        assert conv.show_timestamps is True
         conv.render_user_message("hello ts-on")
         await pilot.pause()
 
@@ -129,7 +129,7 @@ async def test_ts_off_after_toggle_no_timestamp_in_header():
         # Flip to off.
         new_state = conv.toggle_timestamps()
         assert new_state is False
-        assert conv._show_timestamps is False
+        assert conv.show_timestamps is False
 
         conv.render_user_message("hello ts-off")
         await pilot.pause()
@@ -165,11 +165,11 @@ async def test_toggle_twice_returns_to_on():
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
 
-        assert conv._show_timestamps is True
+        assert conv.show_timestamps is True
         conv.toggle_timestamps()
-        assert conv._show_timestamps is False
+        assert conv.show_timestamps is False
         conv.toggle_timestamps()
-        assert conv._show_timestamps is True
+        assert conv.show_timestamps is True
 
         # Body rendered after second toggle uses ts-on inline layout.
         log = conv.query_one(RichLog)
@@ -201,12 +201,12 @@ async def test_f9_dispatch_flips_state_and_flashes_status():
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
 
-        before = conv._show_timestamps
+        before = conv.show_timestamps
         app.action_toggle_timestamps()
         await pilot.pause()
 
-        assert conv._show_timestamps is not before, (
-            "action_toggle_timestamps must flip _show_timestamps"
+        assert conv.show_timestamps is not before, (
+            "action_toggle_timestamps must flip show_timestamps"
         )
         # Flash status: StickyStatus should have been updated (we don't
         # assert exact text to avoid pinning sticky internals, but the

--- a/tests/cli/test_dismiss_last_error_single_iter.py
+++ b/tests/cli/test_dismiss_last_error_single_iter.py
@@ -50,7 +50,7 @@ async def test_dismiss_writes_breadcrumb_for_most_recent_error() -> None:
         conv.mount_error(message="middle error message")
         conv.mount_error(message="most recent error message")
         await pilot.pause()
-        assert conv._error_boxes, "setup: expected error boxes to be mounted"
+        assert conv.error_box_count() > 0, "setup: expected error boxes to be mounted"
 
         conv.dismiss_last_error()
         await pilot.pause()
@@ -62,7 +62,7 @@ async def test_dismiss_writes_breadcrumb_for_most_recent_error() -> None:
             f"log:\n{log_text!r}"
         )
         # At least one box still in the list (the older two remain).
-        assert len(conv._error_boxes) > 0
+        assert conv.error_box_count() > 0
 
 
 @pytest.mark.asyncio
@@ -78,7 +78,7 @@ async def test_dismiss_with_no_errors_is_noop() -> None:
         # Must not raise.
         conv.dismiss_last_error()
         await pilot.pause()
-        assert conv._error_boxes == []
+        assert conv.error_box_count() == 0
 
 
 @pytest.mark.asyncio
@@ -101,7 +101,7 @@ async def test_sequential_dismisses_pop_last_in_first_out() -> None:
         conv.dismiss_last_error()  # → A
         await pilot.pause()
 
-        assert conv._error_boxes == []
+        assert conv.error_box_count() == 0
         log_text = _log_text(conv)
         # All three breadcrumbs written, in last-in-first-out order.
         idx_C = log_text.find("C newest")

--- a/tests/cli/test_fold_stash_expired_marker.py
+++ b/tests/cli/test_fold_stash_expired_marker.py
@@ -99,15 +99,15 @@ async def test_long_reply_after_fold_adds_second_foldable():
 
         conv._write_agent_markdown_with_fold(_long_reply(60))
         await pilot.pause()
-        first_stash = conv._last_long_reply
+        first_stash = conv.last_long_reply
 
         conv._write_agent_markdown_with_fold(_long_reply(80))
         await pilot.pause()
         # has_pending_expand still True (latest reply is also long)
         assert conv.has_pending_expand
-        # _last_long_reply replaced with second reply's tail
-        assert conv._last_long_reply is not None
-        assert conv._last_long_reply != first_stash
+        # last_long_reply replaced with second reply's tail
+        assert conv.last_long_reply is not None
+        assert conv.last_long_reply != first_stash
         # Two FoldableMarkdown widgets mounted
         foldables = list(conv.query(FoldableMarkdown))
         fm_first, fm_second = foldables  # exactly 2 foldable widgets expected

--- a/tests/cli/test_header_grouping_wall_clock.py
+++ b/tests/cli/test_header_grouping_wall_clock.py
@@ -58,13 +58,13 @@ async def test_last_speaker_at_is_wall_clock_after_header_write() -> None:
         now_wall = time.time()
         # The stored timestamp should be within ~10s of the wall-clock
         # reading and definitely in the wall-clock range (= > 1e9).
-        assert conv._last_speaker_at > 1e9, (
-            f"_last_speaker_at should be a wall-clock timestamp "
-            f"(seconds since epoch); got {conv._last_speaker_at}"
+        assert conv.last_speaker_at > 1e9, (
+            f"last_speaker_at should be a wall-clock timestamp "
+            f"(seconds since epoch); got {conv.last_speaker_at}"
         )
-        assert abs(conv._last_speaker_at - now_wall) < 10.0, (
-            f"_last_speaker_at should be roughly now (within 10s); "
-            f"got {conv._last_speaker_at} vs now={now_wall}"
+        assert abs(conv.last_speaker_at - now_wall) < 10.0, (
+            f"last_speaker_at should be roughly now (within 10s); "
+            f"got {conv.last_speaker_at} vs now={now_wall}"
         )
 
 

--- a/tests/cli/test_intervention_respects_user_scroll.py
+++ b/tests/cli/test_intervention_respects_user_scroll.py
@@ -56,7 +56,7 @@ async def test_intervention_scrolls_visible_when_user_at_tail() -> None:
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
-        assert conv._user_scrolled is False
+        assert conv.user_scrolled is False
 
         async def _cb(_a: str) -> None:
             return None
@@ -172,7 +172,7 @@ async def test_mount_error_scrolls_visible_when_user_at_tail() -> None:
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
-        assert conv._user_scrolled is False
+        assert conv.user_scrolled is False
 
         # Just verify the mount completes without raising — the
         # positive-case scroll-visible behaviour is hard to observe

--- a/tests/cli/test_jump_anchor_marks_user_scrolled.py
+++ b/tests/cli/test_jump_anchor_marks_user_scrolled.py
@@ -71,7 +71,7 @@ async def test_jump_to_relative_anchor_marks_user_scrolled_true() -> None:
         conv._jump_to_relative_anchor(-1)
         await pilot.pause()
 
-        assert conv._user_scrolled is True, (
+        assert conv.user_scrolled is True, (
             "_jump_to_relative_anchor(-1) must mark user_scrolled True "
             "so the next chunk's auto_scroll doesn't snap back to the tail"
         )
@@ -109,7 +109,7 @@ async def test_jump_keeps_user_scrolled_even_on_forward_to_last_anchor() -> None
         conv._jump_to_relative_anchor(+1)
         await pilot.pause()
 
-        assert conv._user_scrolled is True, (
+        assert conv.user_scrolled is True, (
             "_jump_to_relative_anchor(+1) must mark user_scrolled True "
             "regardless of where the jump lands relative to the tail"
         )

--- a/tests/cli/test_richlog_no_focus_steal.py
+++ b/tests/cli/test_richlog_no_focus_steal.py
@@ -118,7 +118,7 @@ async def test_ctrl_p_turn_nav_still_scrolls_without_focus() -> None:
         conv._maybe_write_header("user", ">", "bold")
         conv._maybe_write_header("reyn", "⏺", "bold")
         await pilot.pause()
-        assert len(conv._turn_anchors) >= 1
+        assert len(conv.turn_anchors_snapshot()) >= 1
 
         # jump_prev_turn must not raise even without RichLog focus
         conv.jump_prev_turn()

--- a/tests/cli/test_richlog_start_line_helper.py
+++ b/tests/cli/test_richlog_start_line_helper.py
@@ -56,7 +56,7 @@ async def test_normal_call_returns_attribute_value() -> None:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
         log = _StubLog(start_line=137)
-        assert conv._richlog_start_line(log) == 137
+        assert conv.richlog_start_line(log) == 137
 
 
 @pytest.mark.asyncio
@@ -72,7 +72,7 @@ async def test_missing_attribute_returns_zero_fallback() -> None:
         # Reset warning state in case the previous test fired it.
         conv._start_line_warned = False
         log = _StubLog()  # no _start_line attribute
-        assert conv._richlog_start_line(log) == 0
+        assert conv.richlog_start_line(log) == 0
 
 
 @pytest.mark.asyncio
@@ -95,15 +95,15 @@ async def test_missing_attribute_logs_one_shot_warning(caplog) -> None:
 
         with caplog.at_level(logging.WARNING):
             caplog.clear()
-            conv._richlog_start_line(log)
+            conv.richlog_start_line(log)
             first_count = sum(
                 1 for r in caplog.records
                 if "RichLog._start_line is missing" in r.getMessage()
             )
             # Three more calls — should NOT log again.
-            conv._richlog_start_line(log)
-            conv._richlog_start_line(log)
-            conv._richlog_start_line(log)
+            conv.richlog_start_line(log)
+            conv.richlog_start_line(log)
+            conv.richlog_start_line(log)
             total_count = sum(
                 1 for r in caplog.records
                 if "RichLog._start_line is missing" in r.getMessage()
@@ -136,6 +136,6 @@ async def test_absolute_line_position_uses_helper() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = _StubLog(start_line=42)
         # absolute = start_line + len(log.lines); lines is empty, so 42.
-        assert conv._absolute_line_position(log) == 42
+        assert conv.absolute_line_position(log) == 42
         log.lines = [1, 2, 3]  # 3 entries
-        assert conv._absolute_line_position(log) == 45
+        assert conv.absolute_line_position(log) == 45

--- a/tests/cli/test_scroll_to_bottom_no_dead_assign.py
+++ b/tests/cli/test_scroll_to_bottom_no_dead_assign.py
@@ -41,8 +41,8 @@ async def test_scroll_to_bottom_still_resets_user_scrolled_flag() -> None:
         conv._user_scrolled = True
         conv.scroll_to_bottom()
         await pilot.pause()
-        assert conv._user_scrolled is False, (
-            "scroll_to_bottom must still leave _user_scrolled False; "
+        assert conv.user_scrolled is False, (
+            "scroll_to_bottom must still leave user_scrolled False; "
             "the flag set was delegated to _snap_to_bottom, not removed"
         )
 

--- a/tests/cli/test_sticky_status_overwrite_priority.py
+++ b/tests/cli/test_sticky_status_overwrite_priority.py
@@ -149,13 +149,13 @@ async def test_trim_warning_writes_permanent_log_line() -> None:
         # for the test — the public ``_maybe_warn_about_trimmed_history``
         # reads via ``getattr(log, "_start_line", 0)``.
         log._start_line = 137  # type: ignore[attr-defined]
-        assert not conv._trim_warned
+        assert not conv.trim_warned
 
         conv._maybe_warn_about_trimmed_history(log)
         await pilot.pause()
 
         # One-shot — the flag flips so subsequent calls are no-ops.
-        assert conv._trim_warned
+        assert conv.trim_warned
 
         # The permanent log line was written.
         log_lines = [

--- a/tests/cli/test_turn_anchors_survive_trim.py
+++ b/tests/cli/test_turn_anchors_survive_trim.py
@@ -83,15 +83,15 @@ async def test_anchor_survives_partial_trim_and_projects_correctly() -> None:
         # Now record a header anchor.
         conv._maybe_write_header("user", ">", "bold")
         await pilot.pause()
-        assert conv._turn_anchors  # at least one anchor recorded
-        anchor_abs = conv._turn_anchors[0]
+        assert conv.turn_anchors_snapshot()  # at least one anchor recorded
+        anchor_abs = conv.turn_anchors_snapshot()[0]
         assert anchor_abs >= 20, f"expected anchor past baseline, got {anchor_abs}"
 
         # Simulate a trim that pushes _start_line up by less than the anchor.
         log._start_line += 5
 
         # Stored anchor stays constant (= absolute storage).
-        assert conv._turn_anchors[0] == anchor_abs
+        assert conv.turn_anchors_snapshot()[0] == anchor_abs
 
         # Projection subtracts the trim offset.
         resolved = conv._resolve_anchors_to_current_view(log)
@@ -112,7 +112,7 @@ async def test_anchor_dropped_when_target_trimmed() -> None:
         # Write a header at absolute position N.
         conv._maybe_write_header("user", ">", "bold")
         await pilot.pause()
-        anchor = conv._turn_anchors[0]
+        anchor = conv.turn_anchors_snapshot()[0]
 
         # Trim past the anchor — its target line has been ring-buffered out.
         log._start_line = anchor + 10
@@ -143,7 +143,7 @@ async def test_jump_no_crash_when_all_anchors_trimmed() -> None:
         conv.jump_next_turn()
         await pilot.pause()
         # And the one-shot warning latched
-        assert conv._trim_warned
+        assert conv.trim_warned
 
 
 @pytest.mark.asyncio
@@ -158,10 +158,10 @@ async def test_clear_resets_trim_warn_latch() -> None:
         await pilot.pause()
         log._start_line = 999_999
         conv.jump_prev_turn()
-        assert conv._trim_warned
+        assert conv.trim_warned
 
         conv.clear()
-        assert not conv._trim_warned, "clear() must reset the trim-warned latch"
+        assert not conv.trim_warned, "clear() must reset the trim-warned latch"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_user_scroll_suppresses_auto.py
+++ b/tests/cli/test_user_scroll_suppresses_auto.py
@@ -64,7 +64,7 @@ async def test_initial_state_auto_scroll_on_flag_off() -> None:
         conv = app.query_one("#conversation", ConversationView)
         log = conv.query_one(RichLog)
         assert log.auto_scroll is True
-        assert conv._user_scrolled is False
+        assert conv.user_scrolled is False
 
 
 # ── user scroll up → suppress ────────────────────────────────────────────────
@@ -97,7 +97,7 @@ async def test_scroll_up_disables_auto_scroll_and_sets_flag() -> None:
         assert log.auto_scroll is False, (
             "auto_scroll should flip off when user scrolls above the bottom"
         )
-        assert conv._user_scrolled is True
+        assert conv.user_scrolled is True
 
 
 # ── user scroll back to bottom → re-arm ──────────────────────────────────────
@@ -118,7 +118,7 @@ async def test_returning_to_bottom_rearms_auto_scroll() -> None:
         log.scroll_to(y=0, animate=False)
         await pilot.pause()
         assert log.auto_scroll is False
-        assert conv._user_scrolled is True
+        assert conv.user_scrolled is True
 
         # User scrolls back to the bottom
         log.scroll_end(animate=False)
@@ -128,7 +128,7 @@ async def test_returning_to_bottom_rearms_auto_scroll() -> None:
         assert log.auto_scroll is True, (
             "auto_scroll should re-arm when user returns to the tail"
         )
-        assert conv._user_scrolled is False
+        assert conv.user_scrolled is False
 
 
 # ── writes during scroll-up don't snap back ──────────────────────────────────
@@ -191,14 +191,14 @@ async def test_render_user_message_snaps_back_to_bottom() -> None:
         log.scroll_to(y=0, animate=False)
         await pilot.pause()
         assert log.auto_scroll is False
-        assert conv._user_scrolled is True
+        assert conv.user_scrolled is True
 
         conv.render_user_message("hello again")
         await pilot.pause()
         await pilot.pause()
 
         assert log.auto_scroll is True
-        assert conv._user_scrolled is False
+        assert conv.user_scrolled is False
         # And we're (close to) the bottom — scroll_y == max_scroll_y
         assert log.scroll_y >= log.max_scroll_y - 1
 
@@ -219,10 +219,10 @@ async def test_clear_resets_scroll_state() -> None:
         await pilot.pause()
         log.scroll_to(y=0, animate=False)
         await pilot.pause()
-        assert conv._user_scrolled is True
+        assert conv.user_scrolled is True
         assert log.auto_scroll is False
 
         conv.clear()
         await pilot.pause()
-        assert conv._user_scrolled is False
+        assert conv.user_scrolled is False
         assert log.auto_scroll is True


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, single-widget slice (`conversation.py`).

## Summary
- 52 private-state asserts across 16 test files → migrated to public surface
- ~11 new public accessors on `ConversationView` (additive only, no API change)
- Part of larger Tier C Path C sweep, biggest single-widget slice

## Test plan
- [x] `python scripts/test_tier_audit.py <16 test files>` → 0 violations
- [x] `pytest <16 test files>` → 63/63 pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 green (= no regression)
- [x] `ruff check <changed files>` → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced