### PR TITLE
chore(safe-mcp-registry): rename _base_url / _registry_urls public (Tier C1 cleanup wave 15)

### DIFF
--- a/src/reyn/safe/mcp/registry.py
+++ b/src/reyn/safe/mcp/registry.py
@@ -91,7 +91,7 @@ from reyn.registry.models import server_info_from_raw
 _DEFAULT_BASE_URL = "https://registry.modelcontextprotocol.io"
 
 
-def _registry_urls() -> list[str]:
+def registry_urls() -> list[str]:
     """Resolve the ordered list of registry URLs to try.
 
     Resolution priority (= same chain as
@@ -114,14 +114,14 @@ def _registry_urls() -> list[str]:
     return [_DEFAULT_BASE_URL]
 
 
-def _base_url() -> str:
+def base_url() -> str:
     """Return the first registry URL (= preserved for backward compat).
 
     Callers that only need a single URL (= legacy paths, tests) can
     keep using this; the multi-URL iteration happens inside ``search``
-    and ``lookup`` via :func:`_registry_urls`.
+    and ``lookup`` via :func:`registry_urls`.
     """
-    return _registry_urls()[0]
+    return registry_urls()[0]
 
 # urlopen timeout in seconds. 10s covers the canonical registry's p99
 # without leaving steps hanging if the network is wedged.
@@ -188,7 +188,7 @@ def _candidates_from_payload(payload: dict) -> list[dict]:
 def search(query: str, *, limit: int = 20) -> list[dict]:
     """Search the MCP registry for servers matching ``query``.
 
-    Iterates the resolved registry URL list (= ``_registry_urls()``)
+    Iterates the resolved registry URL list (= ``registry_urls()``)
     and returns the first non-empty result list — "private first,
     public fallback" semantics. A :class:`RegistryError` from one URL
     falls through to the next; if every URL fails the final error is
@@ -208,7 +208,7 @@ def search(query: str, *, limit: int = 20) -> list[dict]:
 
     qs = urllib.parse.urlencode({"search": query, "limit": str(limit)})
     last_error: RegistryError | None = None
-    for base in _registry_urls():
+    for base in registry_urls():
         try:
             data = _http_get_json(f"{base}/v0.1/servers?{qs}")
         except RegistryError as exc:
@@ -227,7 +227,7 @@ def search(query: str, *, limit: int = 20) -> list[dict]:
 def lookup(server_id: str) -> dict | None:
     """Return the registry entry for the exact ``server_id``, or None.
 
-    Iterates the resolved registry URL list (= ``_registry_urls()``):
+    Iterates the resolved registry URL list (= ``registry_urls()``):
     a 404 from one URL falls through to the next; a non-404 hit
     returns immediately. Returns None when every URL replies 404.
     Raises :class:`RegistryError` if the final URL fails with a
@@ -245,7 +245,7 @@ def lookup(server_id: str) -> dict | None:
 
     encoded_id = urllib.parse.quote(server_id, safe="")
     last_error: RegistryError | None = None
-    for base in _registry_urls():
+    for base in registry_urls():
         try:
             data = _http_get_json(
                 f"{base}/v0.1/servers/{encoded_id}/versions/latest"

--- a/tests/test_safe_mcp_registry.py
+++ b/tests/test_safe_mcp_registry.py
@@ -7,7 +7,7 @@ real against a per-test tmp cache dir.
 
 URL resolution: PR-9 (post #571 collapse arc, 2026-05-24) made the
 base URL resolution honor ``REYN_MCP_REGISTRY_URL`` env var, mirroring
-the chain used by ``reyn.registry.client._base_url``. See the "URL
+the chain used by ``reyn.registry.client.base_url``. See the "URL
 resolution" section below for the tests pinning that behavior.
 
 Threat-model rationale (= ambient registry lookup, no per-skill
@@ -229,25 +229,25 @@ def test_lookup_caches_response(_isolated_cache):
 def test_base_url_default_is_official_registry(monkeypatch):
     """Tier 2: default base URL falls back to the official MCP registry."""
     monkeypatch.delenv("REYN_MCP_REGISTRY_URL", raising=False)
-    assert sr._base_url() == "https://registry.modelcontextprotocol.io"
+    assert sr.base_url() == "https://registry.modelcontextprotocol.io"
 
 
 def test_base_url_honors_env_var(monkeypatch):
     """Tier 2: ``REYN_MCP_REGISTRY_URL`` overrides the default URL.
 
     Mirrors the resolution chain in
-    ``reyn.registry.client._base_url`` so an operator-set private /
+    ``reyn.registry.client.base_url`` so an operator-set private /
     corporate registry applies uniformly to both the async op-handler
     client and this safe-mode skill-internal lookup.
     """
     monkeypatch.setenv("REYN_MCP_REGISTRY_URL", "https://private.example.com/mcp")
-    assert sr._base_url() == "https://private.example.com/mcp"
+    assert sr.base_url() == "https://private.example.com/mcp"
 
 
 def test_base_url_strips_trailing_slash(monkeypatch):
     """Tier 2: trailing slash on the env-var value is normalised away."""
     monkeypatch.setenv("REYN_MCP_REGISTRY_URL", "https://private.example.com/mcp/")
-    assert sr._base_url() == "https://private.example.com/mcp"
+    assert sr.base_url() == "https://private.example.com/mcp"
 
 
 def test_search_uses_overridden_base_url(monkeypatch, _isolated_cache):
@@ -289,7 +289,7 @@ def test_registry_urls_plural_env_var_takes_priority(monkeypatch):
     """Tier 2: ``REYN_MCP_REGISTRY_URLS`` (plural) wins over singular."""
     monkeypatch.setenv("REYN_MCP_REGISTRY_URLS", "https://private.example.com,https://public.example.com")
     monkeypatch.setenv("REYN_MCP_REGISTRY_URL", "https://singular.example.com")
-    assert sr._registry_urls() == [
+    assert sr.registry_urls() == [
         "https://private.example.com",
         "https://public.example.com",
     ]
@@ -299,20 +299,20 @@ def test_registry_urls_falls_back_to_singular(monkeypatch):
     """Tier 2: when plural is unset, singular env var becomes a one-item list."""
     monkeypatch.delenv("REYN_MCP_REGISTRY_URLS", raising=False)
     monkeypatch.setenv("REYN_MCP_REGISTRY_URL", "https://singular.example.com")
-    assert sr._registry_urls() == ["https://singular.example.com"]
+    assert sr.registry_urls() == ["https://singular.example.com"]
 
 
 def test_registry_urls_default(monkeypatch):
     """Tier 2: with neither env var set, default to the public registry."""
     monkeypatch.delenv("REYN_MCP_REGISTRY_URLS", raising=False)
     monkeypatch.delenv("REYN_MCP_REGISTRY_URL", raising=False)
-    assert sr._registry_urls() == ["https://registry.modelcontextprotocol.io"]
+    assert sr.registry_urls() == ["https://registry.modelcontextprotocol.io"]
 
 
 def test_registry_urls_strips_trailing_slashes(monkeypatch):
     """Tier 2: trailing slashes are normalised per-entry."""
     monkeypatch.setenv("REYN_MCP_REGISTRY_URLS", "https://a.example/, https://b.example/mcp/")
-    assert sr._registry_urls() == ["https://a.example", "https://b.example/mcp"]
+    assert sr.registry_urls() == ["https://a.example", "https://b.example/mcp"]
 
 
 def test_lookup_iterates_on_404_fallback(monkeypatch, _isolated_cache):


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 fifteenth slice. ``rename`` mitigation for two module-level helpers in \`reyn.safe.mcp.registry\`.

## Changes

### Production (\`src/reyn/safe/mcp/registry.py\`)
- ``def _registry_urls`` → ``def registry_urls`` (module function)
- ``def _base_url`` → ``def base_url`` (module function)
- 3 module-internal call sites updated (\`lookup\` / \`search\` / \`base_url\` one-liner)
- Sphinx ``:func:`` cross-refs + backtick docstring references updated

### Tests (7 Tier-C1 findings cleared)
- \`tests/test_safe_mcp_registry.py\`:
  - 3 ``sr._base_url()`` → ``sr.base_url()``
  - 4 ``sr._registry_urls()`` → ``sr.registry_urls()``
  - 1 module-docstring back-reference updated

## Why
Both helpers are pure functions with stable, well-documented contracts (= env-var-driven URL resolution: single base via \`base_url\`, multi-URL list via \`registry_urls\`). The leading underscores were Python convention for "module-internal"; callers are all in-module (production) plus this one test file. No API-stability promise was attached to the underscore prefix.

The sibling module \`reyn.registry.client\` keeps its own ``_base_url`` / ``_base_urls`` underscored — different module, different audit scope, no existing findings on that file.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_safe_mcp_registry.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical return-value semantics, only the symbol moved)
- [x] No external callers of the old names verified via repo-wide grep on ``safe.mcp.registry._``

## Test plan
- [x] \`venv/bin/pytest tests/test_safe_mcp_registry.py\` → 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)