### PR TITLE
chore(session): add outbox_interceptor + last_reply_to @property (Tier C1 cleanup wave 16)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1851,6 +1851,28 @@ class ChatSession:
         return self._agent_role
 
     @property
+    def outbox_interceptor(self):
+        """Read-only accessor for the per-session outbox interceptor.
+
+        Set by the web layer's ``_wire_external_outbox_interceptor`` when
+        external transports are configured; remains ``None`` otherwise.
+        Mutation continues to go through ``self._outbox_interceptor``
+        so the wire-up call site stays visible.
+        """
+        return self._outbox_interceptor
+
+    @property
+    def last_reply_to(self):
+        """Read-only accessor for the most-recent inbox ``reply_to``.
+
+        Captured by the sender-attribution path and used by
+        ``_put_outbox`` to default the outbox message's ``reply_to``
+        when the caller did not supply one. Tests verify the capture
+        + default chain through this surface.
+        """
+        return self._last_reply_to
+
+    @property
     def interventions(self) -> "InterventionRegistry":
         """Read-only public accessor for the session's InterventionRegistry.
 

--- a/tests/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/test_fp0041_prd2_outbox_interceptor.py
@@ -68,7 +68,7 @@ def test_attribution_captures_reply_to_from_payload(tmp_path):
         "sender": "slack:U1",
         "reply_to": rt,
     })
-    assert session._last_reply_to is rt
+    assert session.last_reply_to is rt
 
 
 def test_attribution_does_not_clear_reply_to_when_payload_lacks_it(tmp_path):
@@ -81,7 +81,7 @@ def test_attribution_does_not_clear_reply_to_when_payload_lacks_it(tmp_path):
     session._handle_sender_attribution({"sender": "slack:U1", "reply_to": rt})
     # Second payload, no reply_to.
     session._handle_sender_attribution({"sender": "slack:U1"})
-    assert session._last_reply_to is rt
+    assert session.last_reply_to is rt
 
 
 def test_attribution_updates_reply_to_when_payload_carries_new_one(tmp_path):
@@ -94,7 +94,7 @@ def test_attribution_updates_reply_to_when_payload_carries_new_one(tmp_path):
     session._handle_sender_attribution({
         "sender": "slack:U1", "reply_to": new_rt,
     })
-    assert session._last_reply_to is new_rt
+    assert session.last_reply_to is new_rt
 
 
 # ── Section 2: _put_outbox reply_to defaulting + interceptor ──────────

--- a/tests/web/test_external_outbox_interceptor_wiring.py
+++ b/tests/web/test_external_outbox_interceptor_wiring.py
@@ -78,7 +78,7 @@ def test_wire_sets_interceptor_on_session(tmp_path):
     invocation consults it.
     """
     session = _make_session(tmp_path)
-    assert session._outbox_interceptor is None
+    assert session.outbox_interceptor is None
 
     routing = ExternalTransportRouting(transports={
         "slack": ExternalTransportEntry(
@@ -87,8 +87,8 @@ def test_wire_sets_interceptor_on_session(tmp_path):
         ),
     })
     _wire_external_outbox_interceptor(session, routing)
-    assert session._outbox_interceptor is not None
-    assert callable(session._outbox_interceptor)
+    assert session.outbox_interceptor is not None
+    assert callable(session.outbox_interceptor)
 
 
 # ── dispatcher: separator validation ──────────────────────────────────
@@ -175,4 +175,4 @@ def test_factory_skips_wiring_when_no_external_transports(tmp_path):
     routing = ExternalTransportRouting()
     if routing.transports:
         _wire_external_outbox_interceptor(session, routing)
-    assert session._outbox_interceptor is None
+    assert session.outbox_interceptor is None


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 sixteenth slice. Two related scalar ``@property`` accessors on \`ChatSession\` (= bundle since both fields are on the same class and both test files cover the outbox-interceptor flow).

## Changes

### Production (\`src/reyn/chat/session.py\`)
- ``ChatSession.outbox_interceptor`` ``@property`` → ``self._outbox_interceptor``
- ``ChatSession.last_reply_to`` ``@property`` → ``self._last_reply_to``

Both are read-only; write side stays on the underscore name so the lifecycle call sites (\`_wire_external_outbox_interceptor\` and the sender-attribution helper) stay visible.

### Tests (7 Tier-C1 findings cleared)
- \`tests/web/test_external_outbox_interceptor_wiring.py\` (4 findings):
  - ``session._outbox_interceptor`` reads → ``session.outbox_interceptor``
- \`tests/test_fp0041_prd2_outbox_interceptor.py\` (3 findings):
  - ``session._last_reply_to`` reads → ``session.last_reply_to``

Test setup writes (= ``session._last_reply_to = ExternalRef(...)``) stay on the underscore name — the audit policy only flags ``assert`` reads of private state; setting up fixture storage via the private field is a recognised test-setup pattern and not a Tier-4 violation.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit: \`python3 scripts/test_tier_audit.py --check private-state tests/web/test_external_outbox_interceptor_wiring.py tests/test_fp0041_prd2_outbox_interceptor.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical identity / truthiness semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/web/test_external_outbox_interceptor_wiring.py tests/test_fp0041_prd2_outbox_interceptor.py\` → 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)