### PR TITLE
chore(router-loop): rename _REGISTRY_DISPATCH_TOOLS constant public (Tier C1 cleanup wave 17)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2457,7 +2457,7 @@ class RouterLoop:
     # RouterCallerState callable fields populated by ``_build_router_caller_state``.
     # Tools NOT in this set fall through to the legacy if/elif tree below; the
     # set expands cluster-by-cluster as Phase 3.5 lands the remaining adapters.
-    _REGISTRY_DISPATCH_TOOLS: frozenset[str] = frozenset({
+    REGISTRY_DISPATCH_TOOLS: frozenset[str] = frozenset({
         # Phase 3 step 2 (commit 649a426)
         "list_skills", "describe_skill", "list_agents", "describe_agent",
         "delegate_to_agent", "plan",
@@ -2805,16 +2805,16 @@ class RouterLoop:
         """Execute a validated tool call by name.
 
         Called by dispatch_tool after name/args validation. Tools in
-        ``_REGISTRY_DISPATCH_TOOLS`` go through the unified registry path
+        ``REGISTRY_DISPATCH_TOOLS`` go through the unified registry path
         (= ADR-0026); the rest fall through to the legacy if/elif tree
         until Phase 3.5 ports their handlers.
         """
         # ADR-0026 M4 Phase 3 step 2 — registry dispatch for activated tools
-        if name in self._REGISTRY_DISPATCH_TOOLS:
+        if name in self.REGISTRY_DISPATCH_TOOLS:
             return await self._invoke_via_registry(name, args)
 
         # All router tool clusters are now dispatched via the unified
-        # registry — see ``_REGISTRY_DISPATCH_TOOLS`` at the top of this
+        # registry — see ``REGISTRY_DISPATCH_TOOLS`` at the top of this
         # method.  Phase 3 step 2 + Phase 3.5-D / A+C / B-light / B-mid /
         # B-heavy migrations land here; the legacy if/elif tree was
         # retained only for clusters whose adapter design needed

--- a/tests/test_router_tools.py
+++ b/tests/test_router_tools.py
@@ -377,26 +377,26 @@ def test_drop_source_in_build_tools():
 
 
 def test_recall_in_dispatch_registry():
-    """Tier 2: recall is in RouterLoop._REGISTRY_DISPATCH_TOOLS for runtime dispatch.
+    """Tier 2: recall is in RouterLoop.REGISTRY_DISPATCH_TOOLS for runtime dispatch.
 
     B17-S6-1 fix: without this, dispatch_tool would fall through to the
     legacy if/elif tree and return {"error": "unhandled tool: recall"}.
-    _REGISTRY_DISPATCH_TOOLS is a class attribute on RouterLoop.
+    REGISTRY_DISPATCH_TOOLS is a class attribute on RouterLoop.
     """
     from reyn.chat.router_loop import RouterLoop
-    assert "recall" in RouterLoop._REGISTRY_DISPATCH_TOOLS, (
-        "'recall' missing from RouterLoop._REGISTRY_DISPATCH_TOOLS"
+    assert "recall" in RouterLoop.REGISTRY_DISPATCH_TOOLS, (
+        "'recall' missing from RouterLoop.REGISTRY_DISPATCH_TOOLS"
     )
 
 
 def test_drop_source_in_dispatch_registry():
-    """Tier 2: drop_source is in RouterLoop._REGISTRY_DISPATCH_TOOLS for runtime dispatch.
+    """Tier 2: drop_source is in RouterLoop.REGISTRY_DISPATCH_TOOLS for runtime dispatch.
 
     B17-S8-2 fix: without this, dispatch_tool would fall through to the
     legacy if/elif tree and return {"error": "unhandled tool: drop_source"}.
-    _REGISTRY_DISPATCH_TOOLS is a class attribute on RouterLoop.
+    REGISTRY_DISPATCH_TOOLS is a class attribute on RouterLoop.
     """
     from reyn.chat.router_loop import RouterLoop
-    assert "drop_source" in RouterLoop._REGISTRY_DISPATCH_TOOLS, (
-        "'drop_source' missing from RouterLoop._REGISTRY_DISPATCH_TOOLS"
+    assert "drop_source" in RouterLoop.REGISTRY_DISPATCH_TOOLS, (
+        "'drop_source' missing from RouterLoop.REGISTRY_DISPATCH_TOOLS"
     )

--- a/tests/test_router_tools_universal_wrappers.py
+++ b/tests/test_router_tools_universal_wrappers.py
@@ -221,7 +221,7 @@ def test_wrappers_are_in_router_loop_dispatch_set() -> None:
 
     Prevents the regression that landed initially in PR-3b-i: wrappers
     were added to ``tools=`` and registered in the unified registry,
-    but the RouterLoop dispatch set (``_REGISTRY_DISPATCH_TOOLS``) was
+    but the RouterLoop dispatch set (``REGISTRY_DISPATCH_TOOLS``) was
     not extended, so when the LLM actually called list_actions /
     describe_action / invoke_action the router returned
     ``{"error": "unhandled tool: <name>"}`` to the LLM.
@@ -235,9 +235,9 @@ def test_wrappers_are_in_router_loop_dispatch_set() -> None:
         "list_actions", "search_actions",
         "describe_action", "invoke_action",
     ):
-        assert wrapper in RouterLoop._REGISTRY_DISPATCH_TOOLS, (
+        assert wrapper in RouterLoop.REGISTRY_DISPATCH_TOOLS, (
             f"Universal wrapper {wrapper!r} is in get_default_registry() "
-            f"but not in RouterLoop._REGISTRY_DISPATCH_TOOLS. The LLM "
+            f"but not in RouterLoop.REGISTRY_DISPATCH_TOOLS. The LLM "
             f"would see 'unhandled tool: {wrapper}' on every call."
         )
 
@@ -477,11 +477,11 @@ async def test_non_qualified_name_does_not_redirect() -> None:
     tool names — the caller (dispatch_tool) already validated them
     against the catalog, so unrecognised names correctly error.
 
-    Uses a name not in _REGISTRY_DISPATCH_TOOLS to avoid registry dispatch.
+    Uses a name not in REGISTRY_DISPATCH_TOOLS to avoid registry dispatch.
     The '__' check must NOT match names that are plain alphanumeric.
     """
     loop = _CapturingRouterLoop()
-    # 'unknown_plain_tool' has no '__' and is not in _REGISTRY_DISPATCH_TOOLS.
+    # 'unknown_plain_tool' has no '__' and is not in REGISTRY_DISPATCH_TOOLS.
     result = await loop._invoke_router_tool("unknown_plain_tool", {})
 
     # No _invoke_via_registry call via the alias path — falls through to error


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 seventeenth slice. ``rename`` mitigation for the \`RouterLoop\` class constant.

## Changes

### Production (\`src/reyn/chat/router_loop.py\`)
- ``_REGISTRY_DISPATCH_TOOLS`` → ``REGISTRY_DISPATCH_TOOLS`` (class constant)
- 1 in-class read site (``self._REGISTRY_DISPATCH_TOOLS`` → ``self.REGISTRY_DISPATCH_TOOLS``) + 2 docstring references updated

### Tests (3 Tier-C1 findings cleared across 2 files)
- \`tests/test_router_tools.py\` (2 findings)
- \`tests/test_router_tools_universal_wrappers.py\` (1 finding)

All references: ``RouterLoop._REGISTRY_DISPATCH_TOOLS`` → ``RouterLoop.REGISTRY_DISPATCH_TOOLS``

## Why
The constant defines the frozenset of tool names that route through the unified registry path. Tests need to assert "this tool is in the dispatch set" — a stable, public-API kind of contract. The underscore prefix was convention only.

## Out of scope
``_calls`` findings on a test stub in \`test_router_tools_universal_wrappers.py\` — different attr, deferred to a follow-up slice.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit on the ``_REGISTRY_DISPATCH_TOOLS`` findings: 0 (the 2 remaining errors are the \`_calls\` attr, articulated above)
- [x] Load-bearing invariants preserved (= identical frozenset semantics, only the symbol moved)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_router_tools.py tests/test_router_tools_universal_wrappers.py\` → 38 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)