### PR TITLE
chore(llm-replay): rename LLMReplay._key to key (Tier C1 cleanup wave 20)

### DIFF
--- a/src/reyn/testing/replay.py
+++ b/src/reyn/testing/replay.py
@@ -102,7 +102,7 @@ class LLMReplay:
     # ── Key computation ────────────────────────────────────────────────────────
 
     @staticmethod
-    def _key(
+    def key(
         model: str,
         messages: list[dict],
         tools: list[dict] | None = None,
@@ -213,7 +213,7 @@ class LLMReplay:
         """
         tools: list[dict] | None = kwargs.get("tools")
         tool_choice: str | None = kwargs.get("tool_choice")
-        key = self._key(model, messages, tools=tools, tool_choice=tool_choice)
+        key = self.key(model, messages, tools=tools, tool_choice=tool_choice)
 
         if self.mode == "replay":
             return self._replay(key, model, messages)

--- a/tests/test_llm_replay.py
+++ b/tests/test_llm_replay.py
@@ -6,7 +6,7 @@ Covers:
 - Backward compat: no tools → legacy key format, stable across runs.
 - tool_choice alone (same tools, different tool_choice) → distinct keys.
 
-No real LLM is called; all tests exercise _key() directly.
+No real LLM is called; all tests exercise key() directly.
 """
 from __future__ import annotations
 
@@ -36,8 +36,8 @@ _TOOLS_B = [
 
 def test_cache_key_differs_when_tools_differ():
     """Tier 3a: Same model + messages + different tools must produce distinct keys."""
-    key_a = LLMReplay._key(_MODEL, _MESSAGES, tools=_TOOLS_A)
-    key_b = LLMReplay._key(_MODEL, _MESSAGES, tools=_TOOLS_B)
+    key_a = LLMReplay.key(_MODEL, _MESSAGES, tools=_TOOLS_A)
+    key_b = LLMReplay.key(_MODEL, _MESSAGES, tools=_TOOLS_B)
     assert key_a != key_b, (
         "Cache collision: different tools= arrays produced identical SHA-256 keys"
     )
@@ -45,8 +45,8 @@ def test_cache_key_differs_when_tools_differ():
 
 def test_cache_key_same_when_tools_identical():
     """Tier 3a: Same model + messages + same tools → identical key (idempotent)."""
-    key_1 = LLMReplay._key(_MODEL, _MESSAGES, tools=_TOOLS_A)
-    key_2 = LLMReplay._key(_MODEL, _MESSAGES, tools=_TOOLS_A)
+    key_1 = LLMReplay.key(_MODEL, _MESSAGES, tools=_TOOLS_A)
+    key_2 = LLMReplay.key(_MODEL, _MESSAGES, tools=_TOOLS_A)
     assert key_1 == key_2, (
         "Cache key is not stable: identical tools= arrays produced different keys"
     )
@@ -70,19 +70,19 @@ def test_cache_key_handles_no_tools():
     legacy_key = h.hexdigest()
 
     # None (absent) — no tools at all.
-    assert LLMReplay._key(_MODEL, _MESSAGES) == legacy_key
+    assert LLMReplay.key(_MODEL, _MESSAGES) == legacy_key
     # Empty list — semantically identical to "no tools".
-    assert LLMReplay._key(_MODEL, _MESSAGES, tools=[]) == legacy_key
+    assert LLMReplay.key(_MODEL, _MESSAGES, tools=[]) == legacy_key
     # None tool_choice alongside None tools.
-    assert LLMReplay._key(_MODEL, _MESSAGES, tools=None, tool_choice=None) == legacy_key
+    assert LLMReplay.key(_MODEL, _MESSAGES, tools=None, tool_choice=None) == legacy_key
     # Empty string tool_choice alongside empty tools.
-    assert LLMReplay._key(_MODEL, _MESSAGES, tools=[], tool_choice="") == legacy_key
+    assert LLMReplay.key(_MODEL, _MESSAGES, tools=[], tool_choice="") == legacy_key
 
 
-def test_cache_key_tool_choice_affects_key():
+def test_cache_key_tool_choice_affectskey():
     """Tier 3a: Same messages + same tools but different tool_choice → distinct keys."""
-    key_auto = LLMReplay._key(_MODEL, _MESSAGES, tools=_TOOLS_A, tool_choice="auto")
-    key_required = LLMReplay._key(_MODEL, _MESSAGES, tools=_TOOLS_A, tool_choice="required")
+    key_auto = LLMReplay.key(_MODEL, _MESSAGES, tools=_TOOLS_A, tool_choice="auto")
+    key_required = LLMReplay.key(_MODEL, _MESSAGES, tools=_TOOLS_A, tool_choice="required")
     assert key_auto != key_required, (
         "Cache collision: 'auto' vs 'required' tool_choice produced identical keys"
     )


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twentieth slice. ``rename`` mitigation for the cache-key \`@staticmethod\` on \`LLMReplay\`.

## Changes

### Production (\`src/reyn/testing/replay.py\`)
- ``def _key`` (\`@staticmethod\`) → ``def key``
- ``self._key(...)`` (one production call site at line 216) → ``self.key(...)``

### Tests (4 Tier-C1 findings cleared)
- \`tests/test_llm_replay.py\`:
  - 10 ``LLMReplay._key(...)`` → ``LLMReplay.key(...)``
  - 1 module-docstring back-reference updated

## Why
The cache-key computation has a stable, well-documented contract:
- Byte-identical to the pre-PR35 format on the legacy path (= preserves existing fixture keys without re-recording).
- Pipe-delimited payload incorporating tools and tool_choice on the PR35+ path.

Both branches are pinned by the test suite. The leading underscore was convention only — no API-stability promise, no external callers (verified via repo-wide grep).

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_llm_replay.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical hash semantics on both branches)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_llm_replay.py\` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)