### PR TITLE
chore(chunkers-safe): rename _approx_tokens + _suffix_no_dot public (Tier C1 cleanup wave 21)

### DIFF
--- a/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
@@ -193,11 +193,11 @@ def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int
             content_hash = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
             metadata = {
                 "source_path": file_path,
-                "source_type": _suffix_no_dot(file_path) or "unknown",
+                "source_type": suffix_no_dot(file_path) or "unknown",
                 "content_hash": content_hash,
                 "embedding_model": "",   # filled in by embed op
                 "chunk_index": chunk_idx,
-                "size_tokens": _approx_tokens(chunk_text),
+                "size_tokens": approx_tokens(chunk_text),
                 "parent_context": parent_ctx if preserve else None,
                 "extra": {},
             }
@@ -211,7 +211,7 @@ def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int
     return chunk_idx
 
 
-def _suffix_no_dot(path: str) -> str:
+def suffix_no_dot(path: str) -> str:
     """Return the file extension without the leading dot (e.g. ``foo.md`` → ``md``).
 
     Replaces ``pathlib.PurePath(path).suffix.lstrip(".")`` which the
@@ -224,7 +224,7 @@ def _suffix_no_dot(path: str) -> str:
     return name[idx + 1:]
 
 
-def _approx_tokens(text: str) -> int:
+def approx_tokens(text: str) -> int:
     """Rough token count: ~4 chars per token (GPT-style BPE approximation)."""
     return max(1, len(text) // 4)
 
@@ -258,8 +258,8 @@ def _split_heading(text, max_size, min_size, overlap):
         section_end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
         section_text = text[section_start:section_end]
         heading_label = h.group(2).strip()
-        if _approx_tokens(section_text) <= max_size:
-            if _approx_tokens(section_text) >= min_size:
+        if approx_tokens(section_text) <= max_size:
+            if approx_tokens(section_text) >= min_size:
                 yield section_text, heading_label
         else:
             for sub, _ in _split_blank_line(section_text, max_size, min_size, overlap):
@@ -275,10 +275,10 @@ def _split_blank_line(text, max_size, min_size, overlap):
         para = para.strip()
         if not para:
             continue
-        para_size = _approx_tokens(para)
+        para_size = approx_tokens(para)
         if current_size + para_size > max_size and current:
             chunk = "\n\n".join(current)
-            if _approx_tokens(chunk) >= min_size:
+            if approx_tokens(chunk) >= min_size:
                 yield chunk, None
             current = [para]
             current_size = para_size
@@ -287,7 +287,7 @@ def _split_blank_line(text, max_size, min_size, overlap):
             current_size += para_size
     if current:
         chunk = "\n\n".join(current)
-        if _approx_tokens(chunk) >= min_size:
+        if approx_tokens(chunk) >= min_size:
             yield chunk, None
 
 
@@ -297,10 +297,10 @@ def _split_sentence(text, max_size, min_size, overlap):
     current: list[str] = []
     current_size = 0
     for sent in sentences:
-        s_size = _approx_tokens(sent)
+        s_size = approx_tokens(sent)
         if current_size + s_size > max_size and current:
             chunk = " ".join(current)
-            if _approx_tokens(chunk) >= min_size:
+            if approx_tokens(chunk) >= min_size:
                 yield chunk, None
             current = [sent]
             current_size = s_size
@@ -309,5 +309,5 @@ def _split_sentence(text, max_size, min_size, overlap):
             current_size += s_size
     if current:
         chunk = " ".join(current)
-        if _approx_tokens(chunk) >= min_size:
+        if approx_tokens(chunk) >= min_size:
             yield chunk, None

--- a/tests/test_chunkers_safe_write_chunks.py
+++ b/tests/test_chunkers_safe_write_chunks.py
@@ -280,7 +280,7 @@ def test_write_chunks_skips_unreadable_files(tmp_path: Path, monkeypatch: pytest
 def test_suffix_no_dot(path: str, expected: str):
     """Tier 2: _suffix_no_dot strips the leading dot; mirrors
     pathlib.PurePath.suffix.lstrip(".") for the production paths."""
-    assert _C._suffix_no_dot(path) == expected
+    assert _C.suffix_no_dot(path) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +320,7 @@ def test_split_heading_large_section_sub_splits():
     total_text = " ".join(t for t, _ in chunks)
     assert "word" in total_text, "chunked content must appear in output"
     assert all(
-        _C._approx_tokens(t) <= 30 for t, _ in chunks
+        _C.approx_tokens(t) <= 30 for t, _ in chunks
     ), "each chunk must be near or under max_size"
 
 
@@ -332,7 +332,7 @@ def test_split_blank_line_packs_paragraphs_into_max_size():
 
     assert chunks, "expected chunks from 10-paragraph text"
     for chunk_text, _ in chunks:
-        assert _C._approx_tokens(chunk_text) <= 40
+        assert _C.approx_tokens(chunk_text) <= 40
 
 
 def test_split_blank_line_parent_context_is_none():
@@ -347,7 +347,7 @@ def test_split_blank_line_respects_min_size():
     text = "Tiny.\n\nA longer paragraph with sufficient content to pass min size check."
     chunks = list(_C._split_blank_line(text, max_size=1000, min_size=20, overlap=0.0))
     for chunk_text, _ in chunks:
-        assert _C._approx_tokens(chunk_text) >= 5
+        assert _C.approx_tokens(chunk_text) >= 5
 
 
 def test_split_sentence_splits_at_sentence_boundaries():


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-first slice. ``rename`` mitigation for two module-level helpers in \`reyn.stdlib.skills.index_docs.chunkers_safe\`.

## Changes

### Production (\`src/reyn/stdlib/skills/index_docs/chunkers_safe.py\`)
- ``def _approx_tokens`` → ``def approx_tokens``
- ``def _suffix_no_dot`` → ``def suffix_no_dot``
- All in-module callers (multiple per function) updated.

### Tests (4 Tier-C1 findings cleared)
- \`tests/test_chunkers_safe_write_chunks.py\`:
  - 3 ``_C._approx_tokens(...)`` → ``_C.approx_tokens(...)``
  - 1 ``_C._suffix_no_dot(...)`` → ``_C.suffix_no_dot(...)``

## Why
Both functions have stable pure-function contracts:
- ``approx_tokens(text) -> int`` — approximate token count for a text segment.
- ``suffix_no_dot(path) -> str`` — strip the leading dot from a file extension.

Tests probe both directly to verify the helper contract. Underscore prefixes were convention only; no API-stability promise, no external callers (verified via repo-wide grep — the sibling modules \`index_events/chunkers.py\` and \`index_docs/chunkers_preproc_safe.py\` carry their own private \`_approx_tokens\` helpers, isolated to those modules with no audit findings against them).

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_chunkers_safe_write_chunks.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical numeric / string semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_chunkers_safe_write_chunks.py\` → 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)