### PR TITLE
feat(fp-0008): PR-B — reyn eval benchmark CLI (Component B of #9)

### DIFF
--- a/src/reyn/cli/commands/eval.py
+++ b/src/reyn/cli/commands/eval.py
@@ -68,6 +68,7 @@ def register(sub) -> None:
     _register_report(eval_sub)
     _register_compare(eval_sub)
     _register_spec(eval_sub)
+    _register_benchmark(eval_sub)
 
     p.set_defaults(func=_dispatch)
 
@@ -83,9 +84,11 @@ def _dispatch(args: argparse.Namespace) -> None:
         _run_compare(args)
     elif cmd == "spec":
         _run_spec(args)
+    elif cmd == "benchmark":
+        _run_benchmark(args)
     else:
         # Should never happen because eval_sub.required = True.
-        print("Error: expected sub-command: run | report | compare | spec", file=sys.stderr)
+        print("Error: expected sub-command: run | report | compare | spec | benchmark", file=sys.stderr)
         sys.exit(1)
 
 
@@ -882,3 +885,20 @@ def _run_spec_case(
         print(f"  {data['summary']}")
 
     return ({"case_name": case.name, **data}, result.token_usage, result.cost_usd)
+
+
+# ── `reyn eval benchmark` ─────────────────────────────────────────────────────
+
+
+def _register_benchmark(eval_sub) -> None:
+    """Register the `reyn eval benchmark` sub-command (delegated to eval_benchmark)."""
+    from reyn.cli.commands.eval_benchmark import register_benchmark
+
+    register_benchmark(eval_sub)
+
+
+def _run_benchmark(args: argparse.Namespace) -> None:
+    """Execute `reyn eval benchmark` (delegated to eval_benchmark)."""
+    from reyn.cli.commands.eval_benchmark import run_benchmark
+
+    run_benchmark(args)

--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -1,0 +1,418 @@
+"""`reyn eval benchmark` — generic batch skill runner.
+
+Executes a skill against a JSONL task file concurrently, writing per-instance
+results to an output directory.  Designed for large benchmark runs (e.g.
+SWE-bench Verified) but intentionally skill-agnostic.
+
+Usage
+-----
+reyn eval benchmark <skill_name> \\
+    --tasks <jsonl-path> \\
+    --output <results-dir> \\
+    --concurrency <N>           # default 4
+    [--limit <N>]               # subset for quick try
+    [--resume]                  # continue from prior run
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+# ── public entry points (called from eval.py) ─────────────────────────────────
+
+
+def register_benchmark(eval_sub) -> None:
+    """Register the `reyn eval benchmark` sub-command."""
+    p = eval_sub.add_parser(
+        "benchmark",
+        help="Run a skill against a JSONL task file in batch (generic benchmark runner)",
+    )
+    p.add_argument(
+        "skill_name", metavar="SKILL",
+        help="Skill name to run (resolved via reyn/project → local → stdlib)",
+    )
+    p.add_argument(
+        "--tasks", required=True, metavar="PATH",
+        help="Path to JSONL task file; each line is one task input (matches skill's input_schema)",
+    )
+    p.add_argument(
+        "--output", required=True, metavar="DIR",
+        help="Output directory; results are written under <DIR>/run_<timestamp>/",
+    )
+    p.add_argument(
+        "--concurrency", type=int, default=4, metavar="N",
+        help="Maximum number of concurrent skill runs (default: 4)",
+    )
+    p.add_argument(
+        "--limit", type=int, default=None, metavar="N",
+        help="Stop after the first N tasks (applied after --resume filtering)",
+    )
+    p.add_argument(
+        "--resume", action="store_true",
+        help="Resume from the latest prior run in <output>; skip already-completed tasks",
+    )
+    p.add_argument(
+        "--model", default=None, metavar="MODEL",
+        help="Model override (default: from reyn.yaml)",
+    )
+
+
+def run_benchmark(args: argparse.Namespace) -> None:
+    """Entry point for `reyn eval benchmark` — called by eval._dispatch."""
+    from reyn.llm.llm import run_async as _run_async
+
+    run_async = _run_async
+    run_async(_run_benchmark_async(args))
+
+
+# ── JSONL task parsing ────────────────────────────────────────────────────────
+
+
+def load_tasks(path: Path) -> list[dict]:
+    """Parse a JSONL file; raise SystemExit on malformed lines.
+
+    Tolerates trailing blank lines; surface a clear error on JSON decode failure
+    including line number and decode reason.
+    """
+    tasks: list[dict] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(
+                f"Error: tasks file line {lineno}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not isinstance(obj, dict):
+            print(
+                f"Error: tasks file line {lineno}: expected a JSON object, got {type(obj).__name__}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        tasks.append(obj)
+    return tasks
+
+
+# ── instance_id / run_id helpers ──────────────────────────────────────────────
+
+
+def _instance_id(task: dict, index: int) -> str:
+    """Derive a stable instance identifier from the task dict."""
+    if "instance_id" in task:
+        return str(task["instance_id"])
+    return f"task_{index:04d}"
+
+
+def _make_run_id() -> str:
+    """Generate a run identifier from current UTC time."""
+    return "run_" + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+# ── resume: read prior completed set ─────────────────────────────────────────
+
+
+def _find_latest_run_dir(output_root: Path) -> Path | None:
+    """Return the most recent run_* subdirectory, or None if none exists."""
+    candidates = sorted(
+        (d for d in output_root.iterdir() if d.is_dir() and d.name.startswith("run_")),
+        key=lambda d: d.name,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _load_completed_ids(run_dir: Path) -> set[str]:
+    """Read completed instance_ids from a prior run's summary.json."""
+    summary_path = run_dir / "summary.json"
+    if not summary_path.exists():
+        return set()
+    try:
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+        return set(data.get("completed_ids", []))
+    except Exception:
+        return set()
+
+
+# ── summary.json helpers ──────────────────────────────────────────────────────
+
+
+def _write_summary(
+    run_dir: Path,
+    run_id: str,
+    skill_name: str,
+    results: list[dict],
+    total_tasks: int,
+) -> None:
+    """Write (or overwrite) summary.json from current results list."""
+    completed = len(results)
+    total_cost = sum(r.get("cost_usd") or 0.0 for r in results)
+    avg_cost = total_cost / completed if completed else 0.0
+
+    # tests_passed: only computed if ANY result has the field
+    has_tests_passed = any("tests_passed" in r for r in results)
+    passed = sum(1 for r in results if r.get("tests_passed") is True) if has_tests_passed else None
+    pass_rate = (passed / completed) if (has_tests_passed and completed) else None
+
+    # attempts: only if field present
+    has_attempts = any("attempts" in r for r in results)
+    if has_attempts:
+        attempt_values = [r["attempts"] for r in results if isinstance(r.get("attempts"), (int, float))]
+        avg_attempts: float | None = (sum(attempt_values) / len(attempt_values)) if attempt_values else None
+    else:
+        avg_attempts = None
+
+    # completed_ids: used by --resume
+    completed_ids = [r["instance_id"] for r in results]
+
+    summary = {
+        "run_id": run_id,
+        "skill": skill_name,
+        "total": total_tasks,
+        "completed": completed,
+        "passed": passed,
+        "pass_rate": pass_rate,
+        "total_cost_usd": total_cost,
+        "avg_cost_per_instance": avg_cost,
+        "avg_attempts": avg_attempts,
+        "completed_ids": completed_ids,
+    }
+
+    summary_path = run_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+# ── workspace isolation ───────────────────────────────────────────────────────
+
+
+@contextmanager
+def _benchmark_isolated_workspace() -> Iterator[Path]:
+    """Run body inside a throwaway temp directory to isolate .reyn/ writes."""
+    original_cwd = Path.cwd()
+    with tempfile.TemporaryDirectory(prefix="reyn-benchmark-") as tmp:
+        try:
+            os.chdir(tmp)
+            yield Path(tmp)
+        finally:
+            os.chdir(original_cwd)
+
+
+# ── per-task runner ───────────────────────────────────────────────────────────
+
+
+async def _run_single_task(
+    task: dict,
+    instance_id: str,
+    skill,
+    skill_root: str,
+    model: str,
+    session,
+    run_dir: Path,
+    semaphore: asyncio.Semaphore,
+) -> dict:
+    """Run a single task under the semaphore; return a result record."""
+    from reyn.agent import Agent
+    from reyn.config import _find_project_root, load_project_context
+    from reyn.user_intervention import StdinInterventionBus
+
+    async with semaphore:
+        # Build input artifact
+        input_artifact: dict
+        if "type" in task:
+            input_artifact = task
+        else:
+            input_artifact = {"type": "user_message", "data": task}
+
+        project_root = _find_project_root(Path.cwd())
+        project_context = load_project_context(session.config, project_root)
+
+        agent = Agent(
+            model=model,
+            resolver=session.resolver,
+            intervention_bus=StdinInterventionBus(),
+            safety=session.safety_for(argparse.Namespace()),
+            prompt_cache_enabled=session.config.prompt_cache_enabled,
+            project_context=project_context,
+            caller="direct",
+        )
+
+        result_data: dict = {}
+        error_msg: str | None = None
+        cost_usd: float | None = None
+
+        try:
+            with _benchmark_isolated_workspace():
+                run_result = await agent.run(skill, input_artifact)
+
+            if run_result.ok:
+                result_data = run_result.data
+            else:
+                error_msg = f"skill ended with status '{run_result.status}'"
+            cost_usd = run_result.cost_usd
+
+            # Write P6 event log (per-instance)
+            log_dir = run_dir / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            _write_instance_log(log_dir / f"{instance_id}.jsonl", run_result)
+
+        except Exception as exc:
+            error_msg = str(exc)
+
+        record: dict = {
+            "instance_id": instance_id,
+            "cost_usd": cost_usd,
+            "error": error_msg,
+        }
+
+        # Lift well-known optional fields from result_data generically
+        if "tests_passed" in result_data:
+            record["tests_passed"] = result_data["tests_passed"]
+        if "attempts" in result_data:
+            record["attempts"] = result_data["attempts"]
+
+        # Write patch file if the output includes a patch field
+        if "patch" in result_data and isinstance(result_data.get("patch"), str):
+            patches_dir = run_dir / "patches"
+            patches_dir.mkdir(parents=True, exist_ok=True)
+            (patches_dir / f"{instance_id}.diff").write_text(
+                result_data["patch"], encoding="utf-8"
+            )
+
+        return record
+
+
+def _write_instance_log(log_path: Path, run_result) -> None:
+    """Write a minimal per-instance event log entry."""
+    entry = {
+        "status": run_result.status,
+        "cost_usd": run_result.cost_usd,
+    }
+    if run_result.error:
+        entry["error"] = run_result.error
+    log_path.write_text(json.dumps(entry, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+# ── main async loop ───────────────────────────────────────────────────────────
+
+
+async def _run_benchmark_async(args: argparse.Namespace) -> None:
+    """Core async implementation of `reyn eval benchmark`."""
+    from reyn.cli import session as session_mod
+    from reyn.cli.skill_loader import resolve_skill_path
+    from reyn.compiler import load_dsl_skill
+
+    session = session_mod.Session.from_args(args)
+    model = getattr(args, "model", None) or session.config.model
+
+    # Load tasks
+    tasks_path = Path(args.tasks)
+    if not tasks_path.exists():
+        print(f"Error: tasks file not found: {tasks_path}", file=sys.stderr)
+        sys.exit(1)
+
+    all_tasks = load_tasks(tasks_path)
+    if not all_tasks:
+        print("Error: tasks file is empty.", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve skill
+    skill_dir, inferred_root = resolve_skill_path(args.skill_name)
+    skill_md = skill_dir / "skill.md"
+    try:
+        skill = load_dsl_skill(str(skill_md), skill_root=str(inferred_root))
+    except Exception as e:
+        print(f"Error: failed to compile skill '{args.skill_name}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build output dir
+    output_root = Path(args.output)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    run_id = _make_run_id()
+    run_dir = output_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # Resume: find completed ids from latest prior run
+    skip_ids: set[str] = set()
+    if args.resume:
+        prior = _find_latest_run_dir(output_root)
+        # prior may be run_dir itself if timestamps collide in tests; skip it
+        if prior and prior != run_dir:
+            skip_ids = _load_completed_ids(prior)
+            if skip_ids:
+                print(f"  --resume: skipping {len(skip_ids)} already-completed instance(s)")
+
+    # Filter tasks
+    pending: list[tuple[int, dict]] = []
+    for i, task in enumerate(all_tasks):
+        iid = _instance_id(task, i)
+        if iid not in skip_ids:
+            pending.append((i, task))
+
+    # Apply --limit (N remaining, not N total)
+    if args.limit is not None and args.limit > 0:
+        pending = pending[: args.limit]
+
+    total_tasks = len(all_tasks)
+    print(f"eval benchmark: {args.skill_name}")
+    print(f"  model:       {model}")
+    print(f"  tasks:       {tasks_path}  ({total_tasks} total, {len(pending)} to run)")
+    print(f"  concurrency: {args.concurrency}")
+    print(f"  output:      {run_dir}")
+    print()
+
+    results: list[dict] = []
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    # Collect coroutines; run with semaphore
+    async def _task_with_progress(index: int, task: dict) -> None:
+        iid = _instance_id(task, index)
+        try:
+            record = await _run_single_task(
+                task=task,
+                instance_id=iid,
+                skill=skill,
+                skill_root=str(inferred_root),
+                model=model,
+                session=session,
+                run_dir=run_dir,
+                semaphore=semaphore,
+            )
+        except Exception as exc:
+            # A task failure never aborts the batch — log and record the error.
+            record = {"instance_id": iid, "cost_usd": None, "error": str(exc)}
+        results.append(record)
+        status = "pass" if record.get("tests_passed") is True else (
+            "error" if record.get("error") else "done"
+        )
+        print(f"  [{status}]  {iid}")
+        # Write summary incrementally after each completion
+        _write_summary(run_dir, run_id, args.skill_name, results, total_tasks)
+
+    await asyncio.gather(*(_task_with_progress(i, t) for i, t in pending))
+
+    # Final summary
+    print()
+    completed = len(results)
+    errors = sum(1 for r in results if r.get("error"))
+    print(f"benchmark complete: {args.skill_name}")
+    print(f"  completed: {completed}/{len(pending)}")
+    if errors:
+        print(f"  errors:    {errors}")
+    has_tests_passed = any("tests_passed" in r for r in results)
+    if has_tests_passed:
+        passed = sum(1 for r in results if r.get("tests_passed") is True)
+        rate = passed / completed if completed else 0.0
+        print(f"  passed:    {passed}/{completed} ({rate:.1%})")
+    print(f"  summary → {run_dir / 'summary.json'}")

--- a/tests/test_eval_benchmark_cli.py
+++ b/tests/test_eval_benchmark_cli.py
@@ -1,0 +1,429 @@
+"""Tier 2: OS invariant — ``reyn eval benchmark`` CLI command.
+
+Pins the Component-B benchmark invariants (FP-0008 PR-B):
+
+1. test_benchmark_parses                  — arg parsing (all flags)
+2. test_load_tasks_valid                  — valid JSONL → correct task list
+3. test_load_tasks_malformed              — malformed JSON → SystemExit with line number
+4. test_load_tasks_trailing_newline       — trailing blank lines tolerated
+5. test_summary_json_shape                — summary.json written with required fields
+6. test_summary_json_pass_rate_null       — pass_rate null when tests_passed absent
+7. test_summary_json_has_tests_passed     — pass_rate computed when tests_passed present
+8. test_resume_skips_completed            — --resume filters already-completed ids
+9. test_limit_applied_after_resume        — --limit caps remaining (not total) tasks
+10. test_concurrency_cap_honored           — semaphore limits concurrent executions
+11. test_single_task_failure_no_abort      — one error does not abort the batch
+
+No mocks (``unittest.mock`` / ``AsyncMock`` / ``MagicMock`` / ``patch``).
+Real instances and direct monkeypatching via ``pytest.MonkeyPatch`` only.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_benchmark_args(
+    skill_name: str,
+    tasks_path: str,
+    output_dir: str,
+    concurrency: int = 4,
+    limit: int | None = None,
+    resume: bool = False,
+    model: str | None = None,
+) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.skill_name = skill_name
+    ns.tasks = tasks_path
+    ns.output = output_dir
+    ns.concurrency = concurrency
+    ns.limit = limit
+    ns.resume = resume
+    ns.model = model
+    ns.eval_cmd = "benchmark"
+    return ns
+
+
+def _make_tasks_jsonl(tasks: list[dict]) -> str:
+    return "\n".join(json.dumps(t, ensure_ascii=False) for t in tasks)
+
+
+# ── fixture: benchmark_workspace ─────────────────────────────────────────────
+
+
+@pytest.fixture()
+def benchmark_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Set up a temporary benchmark workspace.
+
+    Returns a namespace with helpers; monkeypatches Session, load_dsl_skill,
+    resolve_skill_path so tests run without a live reyn.yaml or skill on disk.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # Stub Session
+    from reyn.cli import session as session_mod
+    from reyn.config import ReynConfig, SafetyConfig
+    from reyn.llm.model_resolver import ModelResolver
+
+    class _StubSession:
+        config = ReynConfig()
+        resolver = ModelResolver({})
+
+        @classmethod
+        def from_args(cls, _args):
+            return cls()
+
+        def model_for(self, args):
+            return "standard", "standard"
+
+        def output_language_for(self, args):
+            return None
+
+        def safety_for(self, args):
+            return SafetyConfig()
+
+        def shell_allowed_for(self, args):
+            return False
+
+    monkeypatch.setattr(session_mod, "Session", _StubSession)
+
+    # Stub load_dsl_skill
+    import reyn.compiler as compiler_mod
+    sentinel_skill = types.SimpleNamespace(name="test_skill")
+    monkeypatch.setattr(compiler_mod, "load_dsl_skill", lambda *a, **kw: sentinel_skill)
+
+    # Stub resolve_skill_path
+    from reyn.cli import skill_loader as sl_mod
+    monkeypatch.setattr(
+        sl_mod,
+        "_resolve_skill_path_raw",
+        lambda name: (tmp_path / "skills" / name, tmp_path),
+    )
+
+    ns = types.SimpleNamespace()
+    ns.tmp_path = tmp_path
+
+    def write_tasks(tasks: list[dict]) -> Path:
+        p = tmp_path / "tasks.jsonl"
+        p.write_text(_make_tasks_jsonl(tasks), encoding="utf-8")
+        return p
+
+    ns.write_tasks = write_tasks
+    return ns
+
+
+# ── test 1: arg parsing ───────────────────────────────────────────────────────
+
+
+def test_benchmark_parses() -> None:
+    """Tier 2: 'eval benchmark SKILL --tasks FILE --output DIR' parses all flags."""
+    from reyn.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "eval", "benchmark", "my_skill",
+        "--tasks", "tasks.jsonl",
+        "--output", "results/",
+        "--concurrency", "8",
+        "--limit", "50",
+        "--resume",
+    ])
+    assert args.command == "eval"
+    assert args.eval_cmd == "benchmark"
+    assert args.skill_name == "my_skill"
+    assert args.tasks == "tasks.jsonl"
+    assert args.output == "results/"
+    assert args.concurrency == 8
+    assert args.limit == 50
+    assert args.resume is True
+
+
+# ── test 2: load_tasks valid ──────────────────────────────────────────────────
+
+
+def test_load_tasks_valid(tmp_path: Path) -> None:
+    """Tier 2: valid JSONL with 3 task objects → 3 dicts returned."""
+    from reyn.cli.commands.eval_benchmark import load_tasks
+
+    tasks = [
+        {"instance_id": "t1", "input": "a"},
+        {"instance_id": "t2", "input": "b"},
+        {"instance_id": "t3", "input": "c"},
+    ]
+    p = tmp_path / "tasks.jsonl"
+    p.write_text(_make_tasks_jsonl(tasks) + "\n", encoding="utf-8")
+
+    loaded = load_tasks(p)
+    assert len(loaded) == 3
+    assert loaded[0]["instance_id"] == "t1"
+    assert loaded[2]["instance_id"] == "t3"
+
+
+# ── test 3: malformed line raises SystemExit with line number ─────────────────
+
+
+def test_load_tasks_malformed(tmp_path: Path, capsys) -> None:
+    """Tier 2: malformed JSON line → SystemExit(1); message includes line number."""
+    from reyn.cli.commands.eval_benchmark import load_tasks
+
+    content = '{"ok": 1}\nnot-valid-json\n{"ok": 3}\n'
+    p = tmp_path / "bad.jsonl"
+    p.write_text(content, encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        load_tasks(p)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "line 2" in captured.err
+
+
+# ── test 4: trailing newline tolerated ────────────────────────────────────────
+
+
+def test_load_tasks_trailing_newline(tmp_path: Path) -> None:
+    """Tier 2: JSONL file with trailing blank line is parsed without error."""
+    from reyn.cli.commands.eval_benchmark import load_tasks
+
+    content = '{"instance_id": "t1"}\n{"instance_id": "t2"}\n\n'
+    p = tmp_path / "trailing.jsonl"
+    p.write_text(content, encoding="utf-8")
+
+    loaded = load_tasks(p)
+    assert len(loaded) == 2
+
+
+# ── test 5: summary.json shape ────────────────────────────────────────────────
+
+
+def test_summary_json_shape(tmp_path: Path) -> None:
+    """Tier 2: _write_summary writes all required top-level fields."""
+    from reyn.cli.commands.eval_benchmark import _write_summary
+
+    run_dir = tmp_path / "run_20260527_120000"
+    run_dir.mkdir()
+
+    results = [
+        {"instance_id": "t1", "cost_usd": 0.10, "error": None},
+        {"instance_id": "t2", "cost_usd": 0.20, "error": None},
+    ]
+    _write_summary(run_dir, "run_20260527_120000", "my_skill", results, total_tasks=5)
+
+    summary_path = run_dir / "summary.json"
+    assert summary_path.exists()
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    required_keys = {
+        "run_id", "skill", "total", "completed",
+        "passed", "pass_rate", "total_cost_usd",
+        "avg_cost_per_instance", "avg_attempts",
+    }
+    missing = required_keys - data.keys()
+    assert not missing, f"summary.json missing keys: {missing}"
+
+    assert data["run_id"] == "run_20260527_120000"
+    assert data["skill"] == "my_skill"
+    assert data["total"] == 5
+    assert data["completed"] == 2
+    assert abs(data["total_cost_usd"] - 0.30) < 1e-6
+    assert abs(data["avg_cost_per_instance"] - 0.15) < 1e-6
+
+
+# ── test 6: pass_rate null when tests_passed absent ───────────────────────────
+
+
+def test_summary_json_pass_rate_null(tmp_path: Path) -> None:
+    """Tier 2: pass_rate is null when no result has a tests_passed field."""
+    from reyn.cli.commands.eval_benchmark import _write_summary
+
+    run_dir = tmp_path / "run_null"
+    run_dir.mkdir()
+
+    results = [
+        {"instance_id": "t1", "cost_usd": 0.05},
+        {"instance_id": "t2", "cost_usd": 0.05},
+    ]
+    _write_summary(run_dir, "run_null", "generic_skill", results, total_tasks=2)
+
+    data = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    assert data["passed"] is None
+    assert data["pass_rate"] is None
+
+
+# ── test 7: pass_rate computed when tests_passed present ──────────────────────
+
+
+def test_summary_json_has_tests_passed(tmp_path: Path) -> None:
+    """Tier 2: pass_rate is computed correctly when tests_passed is present."""
+    from reyn.cli.commands.eval_benchmark import _write_summary
+
+    run_dir = tmp_path / "run_tp"
+    run_dir.mkdir()
+
+    results = [
+        {"instance_id": "t1", "cost_usd": 0.1, "tests_passed": True},
+        {"instance_id": "t2", "cost_usd": 0.1, "tests_passed": False},
+        {"instance_id": "t3", "cost_usd": 0.1, "tests_passed": True},
+    ]
+    _write_summary(run_dir, "run_tp", "coding_skill", results, total_tasks=3)
+
+    data = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    assert data["passed"] == 2
+    assert abs(data["pass_rate"] - 2 / 3) < 1e-6
+
+
+# ── test 8: --resume skips completed ids ──────────────────────────────────────
+
+
+def test_resume_skips_completed(tmp_path: Path) -> None:
+    """Tier 2: _load_completed_ids + _find_latest_run_dir skip already-done instances."""
+    from reyn.cli.commands.eval_benchmark import (
+        _find_latest_run_dir,
+        _load_completed_ids,
+    )
+
+    output_root = tmp_path / "results"
+    output_root.mkdir()
+
+    # Simulate prior run with summary.json containing completed_ids
+    prior_run = output_root / "run_20260527_100000"
+    prior_run.mkdir()
+    summary = {
+        "run_id": "run_20260527_100000",
+        "skill": "my_skill",
+        "total": 3,
+        "completed": 2,
+        "completed_ids": ["t1", "t2"],
+    }
+    (prior_run / "summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False), encoding="utf-8"
+    )
+
+    latest = _find_latest_run_dir(output_root)
+    assert latest is not None
+    assert latest.name == "run_20260527_100000"
+
+    completed = _load_completed_ids(latest)
+    assert completed == {"t1", "t2"}
+
+
+# ── test 9: --limit applied after resume filtering ───────────────────────────
+
+
+def test_limit_applied_after_resume(tmp_path: Path) -> None:
+    """Tier 2: --limit N caps to N remaining tasks (after skip_ids removed)."""
+    from reyn.cli.commands.eval_benchmark import _instance_id
+
+    all_tasks = [{"instance_id": f"t{i}"} for i in range(10)]
+    skip_ids = {"t0", "t1", "t2"}
+
+    # Simulate the filtering logic from _run_benchmark_async
+    pending = [
+        (i, task) for i, task in enumerate(all_tasks)
+        if _instance_id(task, i) not in skip_ids
+    ]
+    limit = 4
+    pending = pending[:limit]
+
+    assert len(pending) == 4
+    ids = [_instance_id(t, i) for i, t in pending]
+    assert "t0" not in ids
+    assert "t1" not in ids
+    assert "t2" not in ids
+    # first 4 remaining: t3, t4, t5, t6
+    assert ids == ["t3", "t4", "t5", "t6"]
+
+
+# ── test 10: concurrency cap honored ─────────────────────────────────────────
+
+
+def test_concurrency_cap_honored() -> None:
+    """Tier 2: asyncio.Semaphore(N) caps concurrent executions to N."""
+    max_concurrent = 0
+    current = 0
+
+    async def _runner(sem: asyncio.Semaphore) -> None:
+        nonlocal max_concurrent, current
+        async with sem:
+            current += 1
+            if current > max_concurrent:
+                max_concurrent = current
+            await asyncio.sleep(0)  # yield
+            current -= 1
+
+    async def _run_all() -> None:
+        sem = asyncio.Semaphore(3)
+        await asyncio.gather(*(_runner(sem) for _ in range(10)))
+
+    asyncio.run(_run_all())
+    assert max_concurrent <= 3, (
+        f"Semaphore(3) should cap concurrency to 3; observed {max_concurrent}"
+    )
+
+
+# ── test 11: single-task failure does not abort batch ────────────────────────
+
+
+def test_single_task_failure_no_abort(
+    benchmark_workspace, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Tier 2: one task raising an exception is recorded as error; others complete."""
+    from reyn.cli.commands import eval_benchmark as bm
+
+    call_count = 0
+
+    async def _stub_run_single_task(
+        task, instance_id, skill, skill_root, model, session, run_dir, semaphore
+    ):
+        nonlocal call_count
+        async with semaphore:
+            call_count += 1
+            if instance_id == "t1":
+                raise RuntimeError("simulated skill failure")
+            return {"instance_id": instance_id, "cost_usd": 0.01}
+
+    monkeypatch.setattr(bm, "_run_single_task", _stub_run_single_task)
+
+    tasks = [
+        {"instance_id": "t0"},
+        {"instance_id": "t1"},  # will fail
+        {"instance_id": "t2"},
+    ]
+    tasks_path = benchmark_workspace.write_tasks(tasks)
+    output_dir = tmp_path / "bench_output"
+
+    args = _make_benchmark_args(
+        skill_name="test_skill",
+        tasks_path=str(tasks_path),
+        output_dir=str(output_dir),
+        concurrency=2,
+    )
+
+    # _run_benchmark_async raises SystemExit on bad tasks file — shouldn't here
+    # We test that it completes and writes summary for non-failing tasks.
+    asyncio.run(bm._run_benchmark_async(args))
+
+    # Find the run directory
+    run_dirs = list(output_dir.iterdir())
+    assert run_dirs, "No run directory created"
+    run_dir = run_dirs[0]
+
+    summary_path = run_dir / "summary.json"
+    assert summary_path.exists(), "summary.json not written"
+
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    # All 3 tasks are "completed" (= processed); 1 has an error recorded
+    # The batch does NOT abort on task failure — all 3 must have been attempted.
+    assert call_count == 3, f"All 3 tasks should have been attempted; got {call_count}"
+    assert data["completed"] == 3, (
+        f"All 3 tasks should appear in completed count; got {data['completed']}"
+    )
+    # Find the error entry for t1 in completed_ids (it's still in the list)
+    assert "t1" in data.get("completed_ids", []), "t1 must be tracked even when it errored"


### PR DESCRIPTION
**[e2e-coder]** — Component B of FP-0008 (issue #9, SWE-bench participation). Adds `reyn eval benchmark` generic batch skill runner.

## Summary

- New `src/reyn/cli/commands/eval_benchmark.py` (~420 lines): full implementation of `reyn eval benchmark <skill> --tasks <jsonl> --output <dir> [--concurrency N] [--limit N] [--resume]`
- `src/reyn/cli/commands/eval.py`: `_register_benchmark` + `_run_benchmark` thin wrappers + dispatch hook (22 lines changed)
- `tests/test_eval_benchmark_cli.py`: 11 Tier 2 tests — arg parsing, JSONL load/error, summary.json shape, --resume, --limit, concurrency cap, failure tolerance

## Design decisions

- Split into sibling `eval_benchmark.py` (>200 lines per brief guidance) imported from `eval.py` via thin wrappers
- `completed` count in summary.json includes tasks that errored (= all "processed"); `error` field distinguishes them from successful runs
- `completed_ids` written to summary.json for `--resume` to consume; excluded from the public spec fields but necessary for resume logic
- `tests_passed` / `attempts` / `patch` fields handled generically (no swe_bench strings anywhere)
- `_task_with_progress` catches exceptions from `_run_single_task` so one failure never propagates to `asyncio.gather`

## Test plan

- [x] `python -m pytest -q tests/test_eval_benchmark_cli.py` — 11 passed
- [x] `reyn eval benchmark --help` — shows usage cleanly (verified via `build_parser()`)
- [x] `ruff check src/reyn/cli/commands/eval.py src/reyn/cli/commands/eval_benchmark.py tests/test_eval_benchmark_cli.py` — clean
- [x] Tier rule self-check: `grep -nE 'assert .*\._[a-z_]+'` → empty; `grep -nE 'AsyncMock|MagicMock|patch\(|Mock\('` → empty; all test docstrings start with `"""Tier 2:`
- [x] Full suite: 5962 passed, 1 pre-existing failure unrelated to this PR (`test_web_fetch_preview_path_ref.py`)

## Cross-PR signal for PR-A (swe_bench skill)

The benchmark CLI expects `final_output` fields `tests_passed: bool`, `attempts: int`, and `patch: str` — all optional and checked generically. PR-A's `SweBenchResult` schema with those exact field names will plug in without any CLI changes.

Refs #9.