### PR TITLE
feat(fp-0008): PR-A — swe_bench stdlib skill (Component A of #9)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/artifacts/apply_state.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/apply_state.yaml
@@ -1,0 +1,25 @@
+name: apply_state
+description: State after the apply phase — which files were edited and the current attempt count.
+schema:
+  type: object
+  properties:
+    instance_id:
+      type: string
+      description: SWE-bench instance identifier (carried from input).
+    files_edited:
+      type: array
+      items:
+        type: string
+      description: Repository-relative paths of files that were modified in this apply phase.
+    attempt:
+      type: integer
+      minimum: 1
+      description: Which attempt number this is (matches the plan.attempt that was executed).
+    test_patch:
+      type: string
+      description: The test_patch string from the input, carried forward so verify can apply it.
+  required:
+    - instance_id
+    - files_edited
+    - attempt
+    - test_patch

--- a/src/reyn/stdlib/skills/swe_bench/artifacts/exploration.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/exploration.yaml
@@ -1,0 +1,24 @@
+name: exploration
+description: Findings from the explore phase — relevant files, symbols, and context needed to plan the fix.
+schema:
+  type: object
+  properties:
+    instance_id:
+      type: string
+      description: SWE-bench instance identifier (carried from input).
+    relevant_files:
+      type: array
+      items:
+        type: string
+      description: Repository-relative paths of files identified as relevant to the fix.
+    summary:
+      type: string
+      description: Prose summary of what the problem is and where in the codebase it originates.
+    hints_used:
+      type: boolean
+      description: True if hints_text was non-empty and influenced the exploration.
+  required:
+    - instance_id
+    - relevant_files
+    - summary
+    - hints_used

--- a/src/reyn/stdlib/skills/swe_bench/artifacts/plan.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/plan.yaml
@@ -1,0 +1,35 @@
+name: plan
+description: Edit plan produced by the plan phase — which files to change and what each change accomplishes.
+schema:
+  type: object
+  properties:
+    instance_id:
+      type: string
+      description: SWE-bench instance identifier (carried from input).
+    edits:
+      type: array
+      description: Ordered list of file edits to apply.
+      items:
+        type: object
+        properties:
+          file:
+            type: string
+            description: Repository-relative path of the file to edit.
+          description:
+            type: string
+            description: Human-readable description of what to change in this file and why.
+        required:
+          - file
+          - description
+    rationale:
+      type: string
+      description: Overall rationale for this plan — why these edits fix the problem.
+    attempt:
+      type: integer
+      minimum: 1
+      description: Which attempt this plan corresponds to (1 = first attempt, increments after verify failure).
+  required:
+    - instance_id
+    - edits
+    - rationale
+    - attempt

--- a/src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_input.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_input.yaml
@@ -1,0 +1,29 @@
+name: swe_bench_input
+description: Input for a single SWE-bench task — matches the official SWE-bench Verified dataset format.
+schema:
+  type: object
+  properties:
+    instance_id:
+      type: string
+      description: Unique identifier for this SWE-bench instance (e.g. "django__django-12345").
+    repo:
+      type: string
+      description: GitHub repository slug (e.g. "django/django").
+    base_commit:
+      type: string
+      description: Git commit SHA that the repository must be checked out to before applying the fix.
+    problem_statement:
+      type: string
+      description: Natural-language description of the bug or feature request to fix (the GitHub issue body).
+    hints_text:
+      type: string
+      description: Optional hints from the issue thread that may help locate relevant code.
+    test_patch:
+      type: string
+      description: Unified diff of the test file(s) that the harness applies to verify the fix. These tests must pass after the fix is applied but fail on base_commit.
+  required:
+    - instance_id
+    - repo
+    - base_commit
+    - problem_statement
+    - test_patch

--- a/src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_result.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_result.yaml
@@ -1,0 +1,23 @@
+name: swe_bench_result
+description: Final output of a swe_bench skill run — the git diff patch, test outcome, and attempt count.
+schema:
+  type: object
+  properties:
+    instance_id:
+      type: string
+      description: The SWE-bench instance identifier, carried through from the input.
+    patch:
+      type: string
+      description: The unified diff produced by `git diff HEAD` after all edits. Empty string if no changes were made.
+    tests_passed:
+      type: boolean
+      description: True if all test_patch tests passed in the final verify phase; false otherwise.
+    attempts:
+      type: integer
+      minimum: 1
+      description: Total number of apply/verify cycles performed (1 = solved on first attempt).
+  required:
+    - instance_id
+    - patch
+    - tests_passed
+    - attempts

--- a/src/reyn/stdlib/skills/swe_bench/artifacts/verify_state.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/verify_state.yaml
@@ -1,0 +1,23 @@
+name: verify_state
+description: Outcome of the verify phase — test results and whether to proceed to report or retry.
+schema:
+  type: object
+  properties:
+    instance_id:
+      type: string
+      description: SWE-bench instance identifier (carried from input).
+    tests_passed:
+      type: boolean
+      description: True if all test_patch tests passed; false if any failed or errored.
+    attempt:
+      type: integer
+      minimum: 1
+      description: Attempt number that was just verified.
+    failure_summary:
+      type: string
+      description: Brief description of which tests failed and why, to guide the next plan phase. Empty string when tests_passed is true.
+  required:
+    - instance_id
+    - tests_passed
+    - attempt
+    - failure_summary

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -1,0 +1,45 @@
+---
+type: phase
+name: apply
+input: plan
+role: implementer
+model_class: standard
+allowed_ops: [file, shell]
+---
+
+Implement the edit plan by modifying the repository files.
+
+## Step 1 — Read each file before editing
+
+For every file listed in the plan's edits, issue a file read op to retrieve
+the current content.  Do NOT edit from memory — always read first to ensure
+the edit target is accurate.
+
+## Step 2 — Apply each edit
+
+For each entry in the plan, issue the appropriate file op:
+
+- Use an edit op for targeted replacements within an existing file
+- Use a write op only when creating a new file or replacing the entire content
+  of a file
+
+Apply edits in the order they appear in the plan.  After each edit, confirm
+that the op succeeded before proceeding to the next.
+
+## Step 3 — Basic syntax check (when applicable)
+
+If the edited files are Python, issue a shell op running
+`python -m py_compile <file>` on each modified file.  If a compile error is
+reported, correct the syntax before transitioning.
+
+For non-Python files, skip this step.
+
+## Step 4 — Record what was changed
+
+Collect the repository-relative paths of all files that were modified.  Carry
+`test_patch` from the input so the verify phase can access it.
+
+## When to transition
+
+After all edits are applied (and syntax is clean if applicable), transition to
+the verify phase.

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -1,0 +1,53 @@
+---
+type: phase
+name: explore
+input: swe_bench_input
+role: analyst
+model_class: standard
+allowed_ops: [file, grep, shell]
+---
+
+Understand the problem by reading the `problem_statement` and finding the
+relevant code in the repository.  The goal is to identify the files most
+likely to need editing.
+
+## Step 1 — Read the problem statement
+
+Read `problem_statement` from the input artifact.  If `hints_text` is
+non-empty, use it as additional guidance for where to look.
+
+## Step 2 — Locate relevant code with grep
+
+Use grep ops to search the repository for symbols, error messages, or
+identifiers mentioned in the problem statement.  Typical searches:
+
+- Exception class names or error strings quoted in the problem statement
+- Function or method names that the issue describes as broken
+- File paths mentioned in the issue or hints
+
+Issue multiple grep ops as needed.  Prefer targeted patterns over broad
+searches.
+
+## Step 3 — Read the most relevant files
+
+For each file identified in Step 2, issue file read ops to understand the
+surrounding context.  Focus on the functions, classes, or code paths that the
+problem statement references.  Read only what is needed — avoid loading the
+entire repository.
+
+## Step 4 — Inspect the test_patch to understand expected behavior
+
+Read the `test_patch` field from the input to understand what the tests expect
+the fixed code to do.  This gives a precise specification: the fix must make
+those tests pass.  Do NOT apply the test_patch now — that happens in verify.
+
+## Step 5 — Record exploration findings
+
+Summarize what you found: which files contain the bug, what the root cause
+appears to be, and which code regions need to change.  This summary is passed
+to the plan phase.
+
+## When to transition
+
+After the exploration is complete, transition to the plan phase with a
+populated exploration artifact.

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -1,0 +1,50 @@
+---
+type: phase
+name: plan
+input: exploration | verify_state
+role: architect
+model_class: standard
+allowed_ops: [file, grep]
+---
+
+Produce a concrete edit plan: a list of files to change and a description of
+what to change in each, sufficient for the apply phase to implement the fix.
+
+## Context
+
+The input is either:
+
+- `exploration` — first plan for this instance (attempt 1)
+- `verify_state` — a prior verify attempt failed; use `failure_summary` plus
+  the exploration notes from the workspace to revise the plan
+
+## Step 1 — Review the exploration summary
+
+Read the workspace artifact from the explore phase.  If the input is a
+`verify_state`, also read `failure_summary` to understand which tests failed
+and why.
+
+When re-planning (attempt > 1), first read the previous plan and the verify
+failure summary from the workspace.  Avoid repeating edits that already failed
+without changing the approach.
+
+## Step 2 — Re-read targeted code sections (if needed)
+
+If the verify failure summary points to a code region not covered in the
+original exploration, issue additional file read or grep ops to close the gap
+before committing to a new plan.
+
+## Step 3 — Formulate the edit plan
+
+For each file that needs to change, describe:
+
+- The specific function, method, or code block to modify
+- What the change should be (add, remove, or replace logic)
+- Why this change addresses the problem
+
+The plan should be precise enough that the apply phase can execute it without
+further analysis.  Prefer minimal, targeted changes over large rewrites.
+
+## When to transition
+
+Once the plan is ready, transition to the apply phase.

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -1,0 +1,42 @@
+---
+type: phase
+name: report
+input: verify_state
+role: reporter
+model_class: standard
+can_finish: true
+allowed_ops: [shell]
+---
+
+Produce the final output by capturing the git diff of all changes made during
+this skill run.
+
+## Step 1 — Capture the git diff
+
+Issue a shell op:
+
+```
+git diff HEAD
+```
+
+The output is the unified diff of all edits applied by the apply phase(s)
+relative to the base_commit.  This is the patch the SWE-bench harness will
+apply to the pristine base_commit repository when evaluating the submission.
+
+If `git diff HEAD` produces no output (no changes), record an empty string
+for the patch — this is a valid (though unsuccessful) submission.
+
+## Step 2 — Record the final result
+
+Collect the following from the input and the diff output:
+
+- `instance_id`: from `verify_state.instance_id`
+- `patch`: the raw string output of `git diff HEAD`
+- `tests_passed`: from `verify_state.tests_passed`
+- `attempts`: from `verify_state.attempt`
+
+## When to finish
+
+After the diff is captured, finish the skill by emitting `swe_bench_result`
+with all four fields populated.  This is the terminal phase — no further
+transitions are possible.

--- a/src/reyn/stdlib/skills/swe_bench/phases/setup.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/setup.md
@@ -1,0 +1,41 @@
+---
+type: phase
+name: setup
+input: swe_bench_input
+role: initializer
+model_class: standard
+allowed_ops: [shell]
+---
+
+Prepare the repository for the fix by checking out the exact commit the
+SWE-bench harness requires.
+
+## Step 1 — Check out base_commit
+
+Issue a shell op to run:
+
+```
+git checkout <base_commit>
+```
+
+where `<base_commit>` is the value from the input artifact.  If the checkout
+fails (non-zero exit code), abort with a clear message explaining the failure.
+
+## Step 2 — Confirm the working tree is clean
+
+Issue a shell op to run `git status --short`.  If there are unexpected
+uncommitted changes from a prior run (this can happen in repeated batch
+evaluation), run `git checkout -- .` to reset them before proceeding.
+
+## Step 3 — Verify test infrastructure is available
+
+Issue a shell op to verify that a Python test runner is available.  A simple
+`python -m pytest --version` (or `python -m unittest --version` as fallback)
+is enough.  Record the outcome in `summary` — do NOT abort if the runner is
+missing; note it and continue so the verify phase can detect the real failure.
+
+## When to transition
+
+After all three steps complete (with or without errors noted), transition to
+the next phase.  The exploration phase will work regardless of whether the
+test runner is confirmed.

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -1,0 +1,87 @@
+---
+type: phase
+name: verify
+input: apply_state
+role: tester
+model_class: standard
+allowed_ops: [file, shell]
+max_retries: 3
+---
+
+Run the SWE-bench test patch against the current codebase to determine whether
+the fix is correct.
+
+## Step 1 — Apply the test_patch
+
+The `test_patch` field in the input contains a unified diff that adds or
+modifies test files.  Apply it with:
+
+```
+git apply --check <test_patch_content>
+```
+
+Write `test_patch` to a temporary file (e.g. `.reyn/swe_bench_test.patch`)
+then run:
+
+```
+git apply .reyn/swe_bench_test.patch
+```
+
+If `git apply` fails, record the failure in `failure_summary` and treat this
+as a verify execution failure (not a test failure) — transition back to apply
+so the patch can be re-examined.
+
+## Step 2 — Run the tests
+
+After the patch is applied, run the test files that were added or modified by
+the patch.  Determine the test file paths from the diff header lines
+(`+++ b/<path>`).
+
+Issue a shell op:
+
+```
+python -m pytest <test_file_path> -x --tb=short 2>&1
+```
+
+If pytest is not available, fall back to:
+
+```
+python -m unittest <test_module> 2>&1
+```
+
+## Step 3 — Revert the test_patch
+
+After the test run (pass or fail), revert the test patch to restore the
+repository to the state expected by the harness:
+
+```
+git checkout -- <test_file_paths>
+```
+
+or:
+
+```
+git apply --reverse .reyn/swe_bench_test.patch
+```
+
+The SWE-bench harness applies the test patch itself — the skill must NOT leave
+the test files applied when it produces the final diff.
+
+## Step 4 — Evaluate the outcome
+
+Inspect the test runner's exit code and output:
+
+- Exit code 0, all tests collected and passed → `tests_passed = true` → transition to report
+- Non-zero exit code, test failures reported → `tests_passed = false` → transition back to plan
+  (the plan phase will revise the fix based on `failure_summary`)
+
+Record a concise `failure_summary` when tests fail: which test names failed,
+the assertion error messages, and any relevant tracebacks.  This summary is
+the primary input for the next plan phase.
+
+## Retry limit
+
+If `attempt` has reached the maximum allowed (3 by default), set
+`tests_passed = false` and transition to report anyway — the skill reports the
+best-effort patch even when tests did not pass, matching SWE-bench harness
+expectations.

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -1,0 +1,96 @@
+---
+type: skill
+name: swe_bench
+description: Solve a SWE-bench task — reproduce a GitHub issue fix in a real repository, verify with the provided tests, and emit a git diff patch.
+entry: setup
+final_output: swe_bench_result
+final_output_description: |
+  The git diff patch produced for this SWE-bench instance, whether the tests
+  passed, and how many apply/verify attempts were made.
+finish_criteria:
+  - setup has checked out base_commit and prepared the environment
+  - explore has identified the relevant code regions
+  - plan has recorded a concrete edit plan in the workspace
+  - apply has executed all planned edits
+  - verify has run the test_patch tests and recorded the outcome
+  - report has captured the final git diff as the patch string
+  - swe_bench_result records instance_id, patch, tests_passed, and attempts
+graph:
+  setup:   [explore]
+  explore: [plan]
+  plan:    [apply]
+  apply:   [verify, plan]
+  verify:  [report, apply]
+  report:  []
+routing:
+  intents: [task]
+  when_to_use:
+    - Input contains instance_id, base_commit, and problem_statement (SWE-bench format)
+    - User wants to run a SWE-bench task or GitHub issue fix benchmark
+    - Batch evaluation loop calls this skill per SWE-bench instance
+  when_not_to_use:
+    - User wants to fix arbitrary code without a base_commit anchor
+    - No test_patch provided to verify the fix (use skill_builder or direct_llm instead)
+    - User wants to evaluate an existing skill's quality (use eval skill instead)
+permissions:
+  file.read:
+    - path: "*"
+      scope: recursive
+  file.write:
+    - path: "*"
+      scope: recursive
+  shell: true
+# FP-0016 D: this skill needs no static secrets / OAuth tokens.
+required_credentials: []
+---
+
+## Overview
+
+Solves a single SWE-bench Verified task end-to-end: checks out the target
+commit, explores the codebase to understand the problem, plans and applies
+edits, verifies against the provided test patch, then emits a `git diff`
+patch as the final output.
+
+All required capabilities (`read_file`, `edit_file`, `shell`, `grep`) are
+existing OS ops — no OS changes required (P7 compliant).
+
+## Phase flow
+
+```
+setup → explore → plan → apply → verify → report
+                              ↑        ↓
+                              └─ plan ←┘  (tests fail → back to plan)
+                                     ↑
+                              apply ←─┘  (verify execution failed → back to apply)
+```
+
+| Phase   | Role        | Responsibility |
+|---------|-------------|----------------|
+| setup   | initializer | Check out base_commit, confirm test runner is available |
+| explore | analyst     | Grep and read to find relevant code; save exploration notes |
+| plan    | architect   | Decide which files to edit and what to change |
+| apply   | implementer | Execute the plan via file edits |
+| verify  | tester      | Run test_patch tests; transition to report on pass, back to apply on fail |
+| report  | reporter    | Run `git diff HEAD` to produce the final patch |
+
+## Input
+
+Structured `swe_bench_input` artifact matching the SWE-bench dataset format:
+
+```json
+{
+  "type": "swe_bench_input",
+  "data": {
+    "instance_id": "django__django-12345",
+    "repo": "django/django",
+    "base_commit": "abc123def456",
+    "problem_statement": "BUG: ...",
+    "hints_text": "Look at foo/bar.py ...",
+    "test_patch": "diff --git a/tests/... ..."
+  }
+}
+```
+
+## Output
+
+`swe_bench_result` with the git diff patch, pass/fail outcome, and attempt count.

--- a/tests/test_swe_bench_skill_invariants.py
+++ b/tests/test_swe_bench_skill_invariants.py
@@ -1,0 +1,196 @@
+"""Tier 2: OS invariant — swe_bench skill structural invariants (FP-0008 PR-A).
+
+Verifies graph-level correctness properties:
+  - The graph terminates at `report` (no outgoing edges from the terminal phase)
+  - Every phase in the graph is reachable from the entry phase
+  - No orphan phases exist (every declared phase is reachable)
+  - Every artifact referenced by a phase `input:` has a corresponding YAML file
+
+No mocks.  Uses real load_dsl_skill.
+No private-state assertions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.schemas.models import Skill
+
+# ---------------------------------------------------------------------------
+# Shared helper
+# ---------------------------------------------------------------------------
+
+_SKILL_MD = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench" / "skill.md"
+)
+_SKILL_ROOT = _SKILL_MD.parent.parent.parent  # src/reyn/stdlib/
+
+
+def _load() -> Skill:
+    return load_dsl_skill(_SKILL_MD, skill_root=_SKILL_ROOT)
+
+
+def _reachable_phases(skill: Skill) -> set[str]:
+    """BFS from entry_phase through graph.transitions."""
+    visited: set[str] = set()
+    queue = [skill.entry_phase]
+    while queue:
+        node = queue.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        for nxt in skill.graph.transitions.get(node, []):
+            queue.append(nxt)
+    return visited
+
+
+# ---------------------------------------------------------------------------
+# Test 1: terminal phase has no outgoing transitions
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_report_is_terminal():
+    """Tier 2: 'report' phase has no outgoing transitions (= terminal node).
+
+    Pins the contract that the graph terminates cleanly at report.  If a
+    transition from report were accidentally added, the skill would never
+    finish and the OS would hit the max_phase_visits safety cap.
+    """
+    skill = _load()
+    transitions_from_report = skill.graph.transitions.get("report", [])
+    assert transitions_from_report == [], (
+        f"'report' must be a terminal phase (no transitions), "
+        f"but has edges to: {transitions_from_report}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: all phases are reachable from entry
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_all_phases_reachable():
+    """Tier 2: every phase in skill.phases is reachable from 'setup'.
+
+    An orphan phase (declared in phases/ but not reachable from the entry)
+    would never execute and indicates a missing graph edge.  This test
+    catches such gaps so the PR author notices before review.
+    """
+    skill = _load()
+    reachable = _reachable_phases(skill)
+    declared = set(skill.phases.keys())
+    orphans = declared - reachable
+    assert not orphans, (
+        f"Orphan phases detected (declared but not reachable from 'setup'): "
+        f"{sorted(orphans)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: no phases outside declared set are in the graph
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_graph_references_no_undeclared_phases():
+    """Tier 2: every phase name in graph.transitions is present in skill.phases.
+
+    Catches typos in the graph YAML where a transition points to a phase
+    name that has no corresponding phase file.
+    """
+    skill = _load()
+    declared = set(skill.phases.keys())
+    for src, targets in skill.graph.transitions.items():
+        assert src in declared, (
+            f"graph source '{src}' not in skill.phases: {sorted(declared)}"
+        )
+        for tgt in targets:
+            assert tgt in declared, (
+                f"graph target '{tgt}' (from '{src}') not in skill.phases: "
+                f"{sorted(declared)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: entry phase is reachable (trivial sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_entry_phase_is_reachable():
+    """Tier 2: entry_phase 'setup' is in the reachable set.
+
+    Trivially true unless the entry_phase itself were somehow missing from
+    skill.phases, which would also cause a load failure.  Kept as an
+    explicit assertion to document the invariant.
+    """
+    skill = _load()
+    reachable = _reachable_phases(skill)
+    assert skill.entry_phase in reachable, (
+        f"entry_phase '{skill.entry_phase}' not in reachable phases: {sorted(reachable)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: there is exactly one terminal phase and it is 'report'
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_exactly_one_terminal_phase():
+    """Tier 2: exactly one terminal phase exists and it is named 'report'.
+
+    A skill with zero terminal phases would loop forever.  A skill with
+    multiple terminal phases has ambiguous finish semantics.  This test
+    enforces the single-terminal invariant.
+    """
+    skill = _load()
+    terminal_phases = [
+        name
+        for name in skill.phases
+        if not skill.graph.transitions.get(name)
+    ]
+    assert len(terminal_phases) == 1, (
+        f"Expected exactly 1 terminal phase, found {len(terminal_phases)}: "
+        f"{sorted(terminal_phases)}"
+    )
+    assert terminal_phases[0] == "report", (
+        f"Terminal phase must be 'report', got: '{terminal_phases[0]}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: all phase input artifact YAMLs exist on disk
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_phase_artifact_yamls_exist():
+    """Tier 2: every artifact name referenced by a phase input has a YAML file.
+
+    The DSL loader resolves artifact files from skill-local artifacts/ dir.
+    This test verifies the on-disk presence of each artifact YAML so that a
+    missing file is caught here rather than silently failing at load time.
+    (load_dsl_skill itself would also raise — this test provides a clearer
+    failure message identifying the missing artifact by name.)
+    """
+    artifacts_dir = _SKILL_MD.parent / "artifacts"
+    skill = _load()
+    for phase_name, phase in skill.phases.items():
+        # phase.input_schema_name is the artifact name (or a combined name for
+        # multi-input phases).  The artifact YAML files are in artifacts/.
+        # We verify the directory contains at least the artifacts we declared.
+        pass  # Load success already proves artifact resolution; directory check below.
+
+    # Check the artifacts directory directly for the declared artifact files.
+    declared_artifacts = {
+        "swe_bench_input",
+        "swe_bench_result",
+        "exploration",
+        "plan",
+        "apply_state",
+        "verify_state",
+    }
+    for artifact_name in declared_artifacts:
+        yaml_path = artifacts_dir / f"{artifact_name}.yaml"
+        assert yaml_path.exists(), (
+            f"Artifact YAML missing: {yaml_path}. "
+            f"Add {artifact_name}.yaml to swe_bench/artifacts/."
+        )

--- a/tests/test_swe_bench_skill_load.py
+++ b/tests/test_swe_bench_skill_load.py
@@ -1,0 +1,173 @@
+"""Tier 2: OS invariant — swe_bench stdlib skill loads and compiles cleanly (FP-0008 PR-A).
+
+Verifies that the swe_bench skill.md and all its phase/artifact files load
+through the full DSL compile pipeline without error, and that the top-level
+skill properties match the spec declared in skill.md.
+
+No mocks.  Uses real load_dsl_skill on the installed on-disk files.
+No private-state assertions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.schemas.models import Skill
+
+# ---------------------------------------------------------------------------
+# Shared fixture path
+# ---------------------------------------------------------------------------
+
+_SKILL_MD = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench" / "skill.md"
+)
+_SKILL_ROOT = _SKILL_MD.parent.parent.parent  # src/reyn/stdlib/
+
+
+def _load() -> Skill:
+    """Load the swe_bench skill via the full compile pipeline."""
+    return load_dsl_skill(_SKILL_MD, skill_root=_SKILL_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: skill.md exists on disk
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_skill_md_exists():
+    """Tier 2: swe_bench/skill.md exists at the expected stdlib path."""
+    assert _SKILL_MD.exists(), f"skill.md not found at {_SKILL_MD}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: full compile pipeline succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_skill_compiles():
+    """Tier 2: load_dsl_skill compiles swe_bench/skill.md without raising.
+
+    Guards that all phase and artifact files are present, parseable, and
+    consistent with the skill frontmatter.  A load error would indicate a
+    missing artifact YAML, a malformed phase frontmatter, or an undeclared
+    artifact name referenced in a phase's `input:` line.
+    """
+    skill = _load()
+    assert isinstance(skill, Skill)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: skill name matches frontmatter
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_skill_name():
+    """Tier 2: skill.name == 'swe_bench' after full compile."""
+    skill = _load()
+    assert skill.name == "swe_bench"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: entry phase is 'setup'
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_entry_phase():
+    """Tier 2: skill.entry_phase == 'setup' as declared in frontmatter."""
+    skill = _load()
+    assert skill.entry_phase == "setup"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: final_output_name is 'swe_bench_result'
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_final_output_name():
+    """Tier 2: skill.final_output_name == 'swe_bench_result'.
+
+    Pins that the final_output frontmatter key resolves to the correct
+    artifact YAML, which the OS uses to validate the finish artifact.
+    """
+    skill = _load()
+    assert skill.final_output_name == "swe_bench_result"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: final_output_schema is non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_final_output_schema_nonempty():
+    """Tier 2: skill.final_output_schema is a non-empty dict.
+
+    Confirms the swe_bench_result.yaml artifact was parsed and its schema
+    was expanded into the Skill object.
+    """
+    skill = _load()
+    assert isinstance(skill.final_output_schema, dict)
+    assert skill.final_output_schema, "final_output_schema must not be empty"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: all 6 phases are present
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_all_phases_present():
+    """Tier 2: skill.phases contains all 6 expected phase names.
+
+    Each phase file (setup, explore, plan, apply, verify, report) must
+    parse and compile.  A missing or unreadable phase file raises during
+    load_dsl_skill, so this test is a corollary of test_swe_bench_skill_compiles.
+    Here we also assert the exact set for explicitness.
+    """
+    skill = _load()
+    expected = {"setup", "explore", "plan", "apply", "verify", "report"}
+    actual = set(skill.phases.keys())
+    assert expected == actual, (
+        f"Phase mismatch. Expected: {sorted(expected)}. Got: {sorted(actual)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: graph transitions match the spec
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_graph_transitions():
+    """Tier 2: skill graph transitions match the spec in skill.md frontmatter.
+
+    Pins each edge in the 6-phase graph so that a typo in the graph YAML
+    or a future accidental edit is caught immediately.
+    """
+    skill = _load()
+    t = skill.graph.transitions
+    assert t.get("setup") == ["explore"], f"setup transitions: {t.get('setup')}"
+    assert t.get("explore") == ["plan"], f"explore transitions: {t.get('explore')}"
+    assert t.get("plan") == ["apply"], f"plan transitions: {t.get('plan')}"
+    assert sorted(t.get("apply", [])) == ["plan", "verify"], (
+        f"apply transitions: {t.get('apply')}"
+    )
+    assert sorted(t.get("verify", [])) == ["apply", "report"], (
+        f"verify transitions: {t.get('verify')}"
+    )
+    assert t.get("report", []) == [], f"report transitions: {t.get('report')}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: description field is non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_description_nonempty():
+    """Tier 2: skill.description is a non-empty string.
+
+    The description is used by the router to match skills to user intents.
+    An empty description prevents the router from selecting the skill.
+    """
+    skill = _load()
+    assert skill.description, "swe_bench skill.description must be non-empty"


### PR DESCRIPTION
**[e2e-coder]** — Component A of FP-0008 (#9): the `swe_bench` stdlib skill.

## Summary

- Adds `src/reyn/stdlib/skills/swe_bench/` with 1 `skill.md`, 6 phase files, and 6 artifact YAMLs
- 6-phase graph: `setup → explore → plan → apply ↔ verify → report` (loop on test failure, max 3 attempts)
- `final_output: swe_bench_result` — `instance_id`, `patch` (git diff), `tests_passed`, `attempts`
- All phases use `model_class: standard` (no strong-model cost gate violations)
- No OS files touched (P7 compliant)
- 2 Tier 2 test files, 15 tests total — all pass

## Phases

| Phase | Role | Key ops |
|-------|------|---------|
| `setup` | initializer | `shell` — `git checkout <base_commit>` |
| `explore` | analyst | `file`, `grep`, `shell` — locate relevant code |
| `plan` | architect | `file`, `grep` — produce edit list from exploration or verify failure |
| `apply` | implementer | `file`, `shell` — execute edits + py_compile check |
| `verify` | tester | `file`, `shell` — apply test_patch, run pytest, revert test_patch |
| `report` | reporter | `shell` — `git diff HEAD` to produce the final patch |

## Artifacts

- `swe_bench_input` — entry schema (SWE-bench dataset format)
- `swe_bench_result` — final output schema
- `exploration`, `plan`, `apply_state`, `verify_state` — inter-phase state

## Note on gitignore

`artifacts/` is gitignored at repo root. Stdlib artifact YAMLs were committed with `git add -f` — same pattern used by `skill_improver`, `eval_builder`, and all other stdlib skills.

## Cross-PR signal for PR-B

- `verify.md` applies/reverts `test_patch` within the skill. PR-B's batch runner will need to pass `test_patch` from the JSONL input; no structural change required to this skill.
- The `max_retries: 3` frontmatter key in `verify.md` is informational for phase instructions. Actual loop termination is controlled by the `attempt` counter threaded through `apply_state` → `verify_state`. PR-B may want to configure this per run.

## Test plan

- [x] `pytest -q tests/test_swe_bench_skill_load.py tests/test_swe_bench_skill_invariants.py` — 15 passed
- [x] `ruff check src/reyn/stdlib/skills/swe_bench/ tests/test_swe_bench_*.py` — all checks passed
- [x] `grep -nE 'assert .*\._[a-z_]+' tests/test_swe_bench_*.py` — empty (no private-state assertions)
- [x] `grep -nE 'AsyncMock|MagicMock|patch\(|Mock\(' tests/test_swe_bench_*.py` — empty (no mocks)
- [x] `grep -nE '"""Tier [0-9]' tests/test_swe_bench_*.py` — all 15 test docstrings open with Tier 2 declaration
- [x] Full suite: 5966 passed, 1 pre-existing failure in `test_web_fetch_preview_path_ref.py` (unrelated)

**Tier-rule self-check**: no Tier 4 tests, no private state access, no mocks, all docstrings carry Tier 2 tag, lead-coder audit criteria met.