### PR TITLE
chore(progress-bridges): public TRACKED_EVENTS + detached + use events.subscribers (Tier C1 cleanup wave 22)

### DIFF
--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -812,7 +812,7 @@ class _MCPProgressBridge:
     notification delivery failed).
     """
 
-    _TRACKED_EVENTS = frozenset({
+    TRACKED_EVENTS = frozenset({
         "phase_started",
         "llm_called",
         "act_executed",
@@ -833,6 +833,15 @@ class _MCPProgressBridge:
         self._ordinal = 0
         self._detached = False
         self._tasks: list[asyncio.Task[None]] = []
+
+    @property
+    def detached(self) -> bool:
+        """Read-only accessor for the bridge's detached flag.
+
+        Symmetric with ``_A2AProgressBridge.detached``; tests verify the
+        attach / detach lifecycle via this surface.
+        """
+        return self._detached
 
     def attach(self) -> None:
         events = getattr(self._session, "_chat_events", None)
@@ -858,7 +867,7 @@ class _MCPProgressBridge:
         if self._detached:
             return
         event_type = getattr(event, "type", None)
-        if event_type not in self._TRACKED_EVENTS:
+        if event_type not in self.TRACKED_EVENTS:
             return
         data = getattr(event, "data", {}) or {}
         message = self._format_message(event_type, data)

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -733,7 +733,7 @@ class _A2AProgressBridge:
     ``_handle_async_mode._run``) is the authoritative outcome.
     """
 
-    _TRACKED_EVENTS = frozenset({
+    TRACKED_EVENTS = frozenset({
         "phase_started",
         "llm_called",
         "act_executed",
@@ -757,6 +757,16 @@ class _A2AProgressBridge:
         self._detached = False
         self._tasks: list[asyncio.Task[None]] = []
 
+    @property
+    def detached(self) -> bool:
+        """Read-only accessor for the bridge's detached flag.
+
+        Tests verify the attach / detach lifecycle via this surface.
+        Mutation continues to go through ``self._detached`` so the
+        lifecycle call sites in ``detach`` stay visible.
+        """
+        return self._detached
+
     def attach(self) -> None:
         events = getattr(self._session, "_chat_events", None)
         if events is not None:
@@ -779,7 +789,7 @@ class _A2AProgressBridge:
         if self._detached:
             return
         event_type = getattr(event, "type", None)
-        if event_type not in self._TRACKED_EVENTS:
+        if event_type not in self.TRACKED_EVENTS:
             return
         data = getattr(event, "data", {}) or {}
         message = self.format_message(event_type, data)

--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -16,7 +16,7 @@ future third instance is the trigger to lift to a shared base.
 
 Pins:
 
-  1. ``_A2AProgressBridge`` exists with ``_TRACKED_EVENTS`` = the 3
+  1. ``_A2AProgressBridge`` exists with ``TRACKED_EVENTS`` = the 3
      declared kinds, matching ``_MCPProgressBridge``'s scope (= the
      contract two bridges share).
   2. ``attach()`` subscribes to ``session._chat_events``;
@@ -93,7 +93,7 @@ def _make_bridge(*, captured_posts: list[tuple[str, dict]], events: EventLog | N
 
 
 def test_a2a_progress_bridge_tracks_three_lifecycle_events() -> None:
-    """Tier 2: ``_A2AProgressBridge._TRACKED_EVENTS`` matches the MCP
+    """Tier 2: ``_A2AProgressBridge.TRACKED_EVENTS`` matches the MCP
     bridge's scope exactly (= same 3 lifecycle event kinds). This
     keeps the per-protocol bridges aligned so a future third-instance
     abstraction has a stable contract to lift.
@@ -101,8 +101,8 @@ def test_a2a_progress_bridge_tracks_three_lifecycle_events() -> None:
     from reyn.mcp_server import _MCPProgressBridge
     from reyn.web.routers.a2a import _A2AProgressBridge
 
-    assert _A2AProgressBridge._TRACKED_EVENTS == _MCPProgressBridge._TRACKED_EVENTS
-    assert _A2AProgressBridge._TRACKED_EVENTS == frozenset({
+    assert _A2AProgressBridge.TRACKED_EVENTS == _MCPProgressBridge.TRACKED_EVENTS
+    assert _A2AProgressBridge.TRACKED_EVENTS == frozenset({
         "phase_started", "llm_called", "act_executed",
     })
 
@@ -117,9 +117,9 @@ def test_attach_subscribes_to_chat_events() -> None:
     """
     captured: list = []
     bridge, events = _make_bridge(captured_posts=captured)
-    assert bridge.on_event not in events._subscribers
+    assert bridge.on_event not in events.subscribers
     bridge.attach()
-    assert bridge.on_event in events._subscribers
+    assert bridge.on_event in events.subscribers
 
 
 def test_detach_unsubscribes_from_chat_events() -> None:
@@ -129,10 +129,10 @@ def test_detach_unsubscribes_from_chat_events() -> None:
     captured: list = []
     bridge, events = _make_bridge(captured_posts=captured)
     bridge.attach()
-    assert bridge.on_event in events._subscribers
+    assert bridge.on_event in events.subscribers
     bridge.detach()
-    assert bridge.on_event not in events._subscribers
-    assert bridge._detached is True
+    assert bridge.on_event not in events.subscribers
+    assert bridge.detached is True
 
 
 def test_detach_is_idempotent() -> None:
@@ -152,7 +152,7 @@ def test_detach_is_idempotent() -> None:
 
 
 def test_untracked_event_kinds_are_ignored() -> None:
-    """Tier 2: events outside ``_TRACKED_EVENTS`` (= e.g.
+    """Tier 2: events outside ``TRACKED_EVENTS`` (= e.g.
     ``intervention_routed`` / ``phase_completed`` / ``agent_response``)
     do NOT fire a webhook.
     """
@@ -313,7 +313,9 @@ def test_late_event_after_detach_is_ignored() -> None:
     bridge.attach()
 
     # Manually invoke detach but DO NOT remove the subscriber yet (=
-    # simulate the race window).
+    # simulate the race window). Setting the private storage attribute
+    # directly is the canonical "fixture state" pattern; the assertion-side
+    # uses the public ``bridge.detached`` accessor.
     bridge._detached = True
 
     async def _drive() -> None:


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-second slice. **Three** bundled Tier-C1 fixes in a single test file (= ``tests/test_a2a_webhook_progress_267_gap2.py``), grouped because all three are in the progress-bridge area and lift to the same area's public API.

## Changes

### (a) ``_TRACKED_EVENTS`` → ``TRACKED_EVENTS`` (class constant)
Both progress bridges share the same frozenset shape and the test cross-compares them to lock in the symmetry — so the constant is effectively part of their stable contract.
- \`src/reyn/web/routers/a2a.py\`: ``_A2AProgressBridge._TRACKED_EVENTS`` → ``TRACKED_EVENTS`` + 1 in-class read
- \`src/reyn/mcp_server.py\`: ``_MCPProgressBridge._TRACKED_EVENTS`` → ``TRACKED_EVENTS`` + 1 in-class read

### (b) ``bridge._detached`` → ``bridge.detached`` (\`@property\`)
Read-only ``@property`` on both bridges. Tests verify attach / detach lifecycle through it.
- Both production files updated symmetrically (= matches the secret_store / sibling-property pattern used in earlier slices).
- One test that simulates the detach race window writes to ``bridge._detached`` directly — that write stays on the underscore name (= canonical "fixture state" pattern; the audit only flags assertion-side reads of private state, not test setup writes).

### (c) ``events._subscribers`` → ``events.subscribers``
\`EventLog\` already exposes a ``subscribers`` ``@property`` at \`src/reyn/events/events.py:45\`. The test simply hadn't migrated — drop 4 reads to the existing public accessor.

## Migrated findings (6 cleared in one PR)
- 2 ``_TRACKED_EVENTS``
- 4 ``events._subscribers``

## Why bundle
All three changes belong to the same test file's progress-bridge concerns. Splitting into 3 separate PRs would add review overhead without changing the review surface (= each diff is independently readable per the per-symbol structure).

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_a2a_webhook_progress_267_gap2.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical frozenset shape, identical lifecycle gates, identical subscriber list identity)
- [x] No private-state assertions added; only removed
- [x] Pre-commit caller-scope audit done (= grep \`_TRACKED_EVENTS\` / \`bridge._detached\` / \`events._subscribers\` across the whole repo before push to avoid the slice-18 missed-migration recurrence)

## Test plan
- [x] \`venv/bin/pytest tests/test_a2a_webhook_progress_267_gap2.py\` → 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)