### PR TITLE
chore(session): add on_limit @property (Tier C1 cleanup wave 23)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1882,6 +1882,17 @@ class ChatSession:
         return self._on_perm_persist_cb
 
     @property
+    def on_limit(self) -> "_OnLimitConfig":
+        """Read-only accessor for the safety-loop OnLimit config.
+
+        Captured at construction from ``SafetyConfig.on_limit``; tests
+        verify the mode + auto_extend semantics through this surface.
+        Production callers in ``session.py`` continue to use the
+        underscore name; this property is the read-only public view.
+        """
+        return self._on_limit
+
+    @property
     def interventions(self) -> "InterventionRegistry":
         """Read-only public accessor for the session's InterventionRegistry.
 

--- a/tests/test_safety_phase2_wiring.py
+++ b/tests/test_safety_phase2_wiring.py
@@ -169,7 +169,7 @@ def test_chatsession_default_on_limit_is_interactive() -> None:
     See ``OnLimitConfig`` docstring for the headless safety story.
     """
     s = ChatSession(agent_name="t")
-    assert s._on_limit.mode == "interactive"
+    assert s.on_limit.mode == "interactive"
 
 
 def test_chatsession_threads_on_limit_through_constructor() -> None:
@@ -180,6 +180,6 @@ def test_chatsession_threads_on_limit_through_constructor() -> None:
     """
     on_limit = OnLimitConfig(mode="interactive", auto_extend_times=5)
     s = ChatSession(agent_name="t", safety=SafetyConfig(on_limit=on_limit))
-    assert s._on_limit is on_limit
-    assert s._on_limit.mode == "interactive"
-    assert s._on_limit.auto_extend_times == 5
+    assert s.on_limit is on_limit
+    assert s.on_limit.mode == "interactive"
+    assert s.on_limit.auto_extend_times == 5


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-third slice. Single ``@property`` add for the safety-loop OnLimit config.

## Changes

### Production (\`src/reyn/chat/session.py\`)
- ``ChatSession.on_limit`` ``@property`` returning ``self._on_limit``.
- Read-only. The field is init-time-captured from ``SafetyConfig.on_limit`` and never re-bound, so the read-only surface matches the lifecycle.

### Tests (4 Tier-C1 findings cleared)
- \`tests/test_safety_phase2_wiring.py\`:
  - 4 ``s._on_limit`` reads (mode / identity / mode / auto_extend_times) → ``s.on_limit``

## Why
The OnLimit config (= safety-loop ask vs unattended behaviour, auto-extend, etc.) is set once at construction; tests probe its shape via the session surface. Same ``@property`` mitigation as previous session-field slices.

## Pre-commit caller-scope audit (= slice-18 lesson)
\`grep -rn "session\\._on_limit" tests/\` → 0 hits across the whole test suite. No further test migrations needed.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_safety_phase2_wiring.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical mode / identity / auto_extend_times semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_safety_phase2_wiring.py\` → 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)