### PR TITLE
chore(test): use ControlIRExecutor.resume_plan property (Tier C1 cleanup wave 24)

### DIFF
--- a/tests/test_control_ir_executor_resume_plan.py
+++ b/tests/test_control_ir_executor_resume_plan.py
@@ -76,13 +76,13 @@ def test_constructor_accepts_resume_plan(tmp_path):
     plan = _plan_with([])
     executor, _ = _executor(tmp_path, resume_plan=plan)
     # Stored for propagation; introspectable for downstream coordination
-    assert executor._resume_plan is plan
+    assert executor.resume_plan is plan
 
 
 def test_constructor_default_none(tmp_path):
     """Tier 2: backward compat — default resume_plan is None."""
     executor, _ = _executor(tmp_path)
-    assert executor._resume_plan is None
+    assert executor.resume_plan is None
 
 
 def test_resume_plan_is_propagated_to_dispatch_context(tmp_path, monkeypatch):


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-fourth slice. Test-only migration to an existing public property.

## Changes
\`ControlIRExecutor\` already exposes \`resume_plan\` as a read-only \`@property\` at \`src/reyn/kernel/control_ir_executor.py:148\`. The test file simply hadn't migrated to the public name — no production-side change needed.

- \`tests/test_control_ir_executor_resume_plan.py\`: 2 ``executor._resume_plan`` → ``executor.resume_plan``

## Pre-commit caller-scope audit
\`grep -rn "_resume_plan" tests/\` → no other test sites reaching for the private name.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: 0 errors on the touched file
- [x] Load-bearing invariants preserved (= identical identity semantics)
- [x] No production-side change (= the property already existed)

## Test plan
- [x] \`venv/bin/pytest tests/test_control_ir_executor_resume_plan.py\` → 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)