### PR TITLE
chore(cron-scheduler): add tasks + running @property (Tier C1 cleanup wave 25)

### DIFF
--- a/src/reyn/cron/scheduler.py
+++ b/src/reyn/cron/scheduler.py
@@ -117,6 +117,16 @@ class CronScheduler:
         self._tasks: dict[str, asyncio.Task] = {}
         self._running: bool = False
 
+    @property
+    def tasks(self) -> dict:
+        """Read-only accessor for the running cron-task map (name → asyncio.Task)."""
+        return self._tasks
+
+    @property
+    def running(self) -> bool:
+        """Read-only flag: True between ``start()`` and ``stop()``."""
+        return self._running
+
     def set_runner(self, runner_fn: Callable[[CronJob], "asyncio.Future"]) -> None:
         """Inject the runner after construction (= web lifespan needs the
         AgentRegistry which is created after the scheduler in some paths).

--- a/tests/test_fp0009_b_cron_scheduler.py
+++ b/tests/test_fp0009_b_cron_scheduler.py
@@ -179,7 +179,7 @@ async def test_start_spawns_tasks_for_enabled_jobs_only():
     try:
         # Give tasks a moment to initialise without firing (schedules are hours away)
         await asyncio.sleep(0.01)
-        task_names = set(sched._tasks.keys())
+        task_names = set(sched.tasks.keys())
         assert "enabled1" in task_names
         assert "enabled2" in task_names
         assert "disabled" not in task_names
@@ -205,8 +205,8 @@ async def test_stop_cancels_all_tasks():
     await sched.stop()
 
     # After stop, no tasks remain in the dict
-    assert sched._tasks == {}
-    assert sched._running is False
+    assert sched.tasks == {}
+    assert sched.running is False
 
 
 @pytest.mark.asyncio
@@ -388,10 +388,10 @@ async def test_start_is_idempotent():
     sched = CronScheduler([job], runner_fn=runner)
 
     await sched.start()
-    task_after_first = dict(sched._tasks)
+    task_after_first = dict(sched.tasks)
 
     await sched.start()  # second call must be no-op
-    task_after_second = dict(sched._tasks)
+    task_after_second = dict(sched.tasks)
 
     # Same task objects — no duplication
     assert set(task_after_first.keys()) == set(task_after_second.keys())

--- a/tests/test_fp0009_b_e2e_scheduler.py
+++ b/tests/test_fp0009_b_e2e_scheduler.py
@@ -199,8 +199,8 @@ async def test_scheduler_built_from_config_jobs_and_run_now(tmp_path: Path) -> N
         await scheduler.stop()
 
     # After stop: no tasks remain, running flag cleared
-    assert scheduler._tasks == {}
-    assert scheduler._running is False
+    assert scheduler.tasks == {}
+    assert scheduler.running is False
 
 
 @pytest.mark.asyncio
@@ -252,7 +252,7 @@ async def test_disabled_job_not_scheduled(tmp_path: Path) -> None:
     await scheduler.start()
     try:
         # Only active_job gets a task; disabled_job does not
-        task_names = set(scheduler._tasks.keys())
+        task_names = set(scheduler.tasks.keys())
         assert "active_job" in task_names
         assert "disabled_job" not in task_names
 


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-fifth slice. Two ``@property`` accessors on \`CronScheduler\` (= bundle since both are scheduler state fields tested in the same module pair).

## Changes

### Production (\`src/reyn/cron/scheduler.py\`)
- ``CronScheduler.tasks`` ``@property`` → ``self._tasks``
- ``CronScheduler.running`` ``@property`` → ``self._running``

Both read-only. Write side stays internal — only the scheduler's own \`start()\` / \`stop()\` paths mutate the state.

### Tests (4 Tier-C1 findings cleared)
- \`tests/test_fp0009_b_cron_scheduler.py\` (2): ``sched._tasks`` + ``sched._running`` reads
- \`tests/test_fp0009_b_e2e_scheduler.py\` (2): ``scheduler._tasks`` + ``scheduler._running`` reads

## Pre-commit caller-scope audit
\`grep -rn "scheduler\\._tasks\\|scheduler\\._running\\|sched\\._tasks\\|sched\\._running" tests/\` → only the 4 migrated sites; no missed callers.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: 0 errors on both touched files
- [x] Load-bearing invariants preserved (= identical dict / bool semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_fp0009_b_cron_scheduler.py tests/test_fp0009_b_e2e_scheduler.py\` → 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)