### PR TITLE
chore(tier-c): wave 4 sweep — multi-src TUI test files

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -275,6 +275,47 @@ class ReynTUIApp(App):
         """
         return self._panel_visible
 
+    @property
+    def outbox_router(self) -> "OutboxRouter | None":
+        """The active ``OutboxRouter`` instance, or ``None`` when no registry.
+
+        Set to a live router by ``_outbox_loop`` when a registry is
+        attached; reset to ``None`` when the loop exits. Tests use this
+        to assert on router presence / absence without reaching into the
+        private slot — per CLAUDE.md testing policy.
+        """
+        return self._outbox_router
+
+    @property
+    def current_stream_id(self) -> "str | None":
+        """The msg_id of the most-recently started stream, or ``None``.
+
+        Updated on every ``__stream_start__`` and cleared to ``None``
+        when the matching ``__stream_end__`` arrives. Tests that need to
+        assert on the global stream pointer use this property rather than
+        ``_current_stream_id`` directly.
+        """
+        return self._current_stream_id
+
+    @property
+    def agent_name(self) -> "str | None":
+        """The current agent name string shown in the header.
+
+        Updated by ``_on_attach_request`` when ``/attach`` changes the
+        active agent. Tests assert on this rather than ``_agent_name``.
+        """
+        return self._agent_name
+
+    def skill_exec_snapshot(self) -> "dict[str, dict]":
+        """Return a shallow copy of the in-flight skill-exec registry.
+
+        ``_skill_exec`` maps run_id → metadata dict for every skill that
+        is currently executing.  Tests call this to assert on membership
+        without holding a live reference to the internal dict — per
+        CLAUDE.md testing policy.
+        """
+        return dict(self._skill_exec)
+
     # ── composition ───────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -300,6 +300,19 @@ class OutboxRouter:
         """Return ``True`` when an auto-hide transient-status timer is armed."""
         return self._transient_status_timer is not None
 
+    @property
+    def transient_status_timer(self) -> "Any":
+        """The Textual ``Timer`` handle for the pending auto-hide, or ``None``.
+
+        Tests that need to assert on timer identity (= two successive
+        transients replace the handle, not reuse it) or inspect the
+        timer's internal stopped state use this property rather than
+        reaching into ``_transient_status_timer`` directly — per
+        CLAUDE.md testing policy.  Callers must NOT mutate the returned
+        object; use ``_cancel_transient_timer()`` to stop it.
+        """
+        return self._transient_status_timer
+
     # ── transient sticky helpers ──────────────────────────────────────────────
 
     def _cancel_transient_timer(self) -> None:

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -731,6 +731,28 @@ class ConversationView(Widget):
             return []
         return panel.snapshot()
 
+    @property
+    def stream_rows(self) -> "dict[str, StreamingRow]":
+        """Shallow copy of the in-flight stream-row registry (msg_id → row).
+
+        Tests that need to assert on stream routing (= which msg_ids are
+        live, which have been sealed and removed) call this rather than
+        accessing ``_stream_rows`` directly — per CLAUDE.md testing
+        policy.  Returns a snapshot; do not mutate the returned dict.
+        """
+        return dict(self._stream_rows)
+
+    @property
+    def foldables(self) -> "list[FoldableMarkdown]":
+        """A copy of the list of live ``FoldableMarkdown`` widgets.
+
+        Populated by ``_write_agent_markdown_with_fold`` when a reply is
+        long enough to fold. Tests use this to locate the widgets without
+        reaching into ``_foldables`` directly — per CLAUDE.md testing
+        policy. Returns a shallow list copy; do not mutate.
+        """
+        return list(self._foldables)
+
     def on_mount(self) -> None:
         """Wire a scroll watcher so user scroll-up suppresses auto-scroll.
 

--- a/src/reyn/chat/tui/widgets/foldable_markdown.py
+++ b/src/reyn/chat/tui/widgets/foldable_markdown.py
@@ -94,6 +94,34 @@ class FoldableMarkdown(Widget):
         """Return True when the widget is currently in expanded state."""
         return self._expanded
 
+    @property
+    def remaining_lines(self) -> int:
+        """Number of lines hidden in collapsed state (= total − preview threshold).
+
+        Displayed in the collapsed hint footer. Tests assert on this
+        value to verify the fold logic without reaching into
+        ``_remaining_lines`` directly.
+        """
+        return self._remaining_lines
+
+    @property
+    def preview_text(self) -> str:
+        """The Markdown text shown in the collapsed (preview) state.
+
+        Tests assert on this to verify which lines land in the preview
+        section without reaching into ``_preview_text`` directly.
+        """
+        return self._preview_text
+
+    @property
+    def full_text(self) -> str:
+        """The complete Markdown text shown in the expanded state.
+
+        Tests assert on this to verify the full reply content without
+        reaching into ``_full_text`` directly.
+        """
+        return self._full_text
+
     def _refresh_display(self) -> None:
         """Update the body Static and hint Label to match _expanded."""
         try:

--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -638,6 +638,27 @@ class ReynHeader(RenderableCacheMixin, Widget):
         """
         return self._find_state
 
+    def format_status(self) -> Text:
+        """Public alias for the internal ``_format_status()`` builder.
+
+        Returns the current status Rich Text (right side of the header).
+        Tests use this to assert on rendered agent name and model without
+        reaching into the private implementation.
+        """
+        return self._format_status()
+
+    @property
+    def badge_offsets(self) -> dict[str, tuple[int, int]]:
+        """Read-only copy of the badge-name → (start, end) cell-range map.
+
+        Populated by ``_format_status`` whenever a badge is rendered.
+        Keys are ``"find"``, ``"pending"``, or ``"voice"``; values are
+        ``(start_cell, end_cell)`` in text-relative (= status-text-local)
+        coordinates. Tests use this to verify badge placement without
+        reaching into the private dict.
+        """
+        return dict(self._badge_offsets)
+
     def badge_at_x(self, x: int) -> str | None:
         """Return the badge key under widget-local cell column ``x``, or None.
 

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -351,6 +351,25 @@ class RightPanel(Widget):
         return self._docs_cursor
 
     @property
+    def events_cursor(self) -> int:
+        """Current events tab cursor index into the visible event list."""
+        return self._events_cursor
+
+    @property
+    def agents_cursor(self) -> int:
+        """Current agents tab cursor index into ``_agents_items``."""
+        return self._agents_cursor
+
+    @property
+    def event_filter_idx(self) -> int:
+        """Index of the active event-filter group in ``_FILTER_GROUPS``.
+
+        Use ``cycle_event_filter()`` to advance it; this property is
+        read-only and intended for test assertions.
+        """
+        return self._event_filter_idx
+
+    @property
     def docs_lang(self) -> str:
         """Active docs language preference (``"en"`` or ``"ja"``)."""
         return self._docs_lang

--- a/tests/cli/test_find_cycle_navigation.py
+++ b/tests/cli/test_find_cycle_navigation.py
@@ -76,12 +76,12 @@ async def test_cycle_find_forward_steps_through_matches() -> None:
         )
         await pilot.pause()
         # Initial /find lands on the first below-cursor match = idx 0
-        assert router._find_cursor_idx == 0
+        assert router.find_cursor_index == 0
 
         # Cycle forward → next match (idx 2)
         router.cycle_find(+1)
         await pilot.pause()
-        assert router._find_cursor_idx == 2
+        assert router.find_cursor_index == 2
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
         assert snap["active"] is True
         assert "match 2/3" in snap["body"]
@@ -91,7 +91,7 @@ async def test_cycle_find_forward_steps_through_matches() -> None:
         # Cycle forward again → idx 4
         router.cycle_find(+1)
         await pilot.pause()
-        assert router._find_cursor_idx == 4
+        assert router.find_cursor_index == 4
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
         assert "match 3/3" in snap["body"]
 
@@ -123,14 +123,14 @@ async def test_cycle_find_forward_wraps_to_first() -> None:
             header,
         )
         await pilot.pause()
-        assert router._find_cursor_idx == 0
+        assert router.find_cursor_index == 0
         # Forward to last, then forward again → wrap to first
         router.cycle_find(+1)
         await pilot.pause()
-        assert router._find_cursor_idx == 2
+        assert router.find_cursor_index == 2
         router.cycle_find(+1)
         await pilot.pause()
-        assert router._find_cursor_idx == 0
+        assert router.find_cursor_index == 0
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
         assert "match 1/2" in snap["body"]
 
@@ -164,19 +164,19 @@ async def test_cycle_find_backward_steps_and_wraps() -> None:
             header,
         )
         await pilot.pause()
-        assert router._find_cursor_idx == 0
+        assert router.find_cursor_index == 0
 
         # Backward from first → wraps to last (idx 4)
         router.cycle_find(-1)
         await pilot.pause()
-        assert router._find_cursor_idx == 4
+        assert router.find_cursor_index == 4
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
         assert "match 3/3" in snap["body"]
 
         # Backward again → idx 2 (middle)
         router.cycle_find(-1)
         await pilot.pause()
-        assert router._find_cursor_idx == 2
+        assert router.find_cursor_index == 2
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
         assert "match 2/3" in snap["body"]
 
@@ -194,7 +194,7 @@ async def test_cycle_find_without_prior_query_shows_usage_hint() -> None:
         conv = app.query_one("#conversation", ConversationView)
         # No /find dispatched — cycle should report usage.
         router = OutboxRouter(app)
-        assert router._find_query is None
+        assert router.find_query is None
         router.cycle_find(+1)
         await pilot.pause()
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
@@ -232,8 +232,8 @@ async def test_cycle_find_handles_buffer_mutation_to_zero_matches() -> None:
             header,
         )
         await pilot.pause()
-        assert router._find_query == "tag"
-        assert router._find_cursor_idx is not None
+        assert router.find_query == "tag"
+        assert router.find_cursor_index is not None
 
         # Wipe the buffer — Ctrl+L equivalent.
         conv.clear()
@@ -244,8 +244,8 @@ async def test_cycle_find_handles_buffer_mutation_to_zero_matches() -> None:
         snap = conv._sticky().snapshot()  # type: ignore[union-attr]
         assert "no matches for 'tag'" in snap["body"]
         # State cleared so a fresh /find isn't shadowed.
-        assert router._find_query is None
-        assert router._find_cursor_idx is None
+        assert router.find_query is None
+        assert router.find_cursor_index is None
 
 
 @pytest.mark.asyncio
@@ -279,7 +279,7 @@ async def test_action_find_next_safe_when_router_absent() -> None:
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
         # Router never started (no registry); attribute is None.
-        assert app._outbox_router is None
+        assert app.outbox_router is None
         # Both actions must be safe no-ops.
         app.action_find_next()
         app.action_find_prev()
@@ -313,5 +313,5 @@ async def test_initial_find_seeds_cycle_state() -> None:
             header,
         )
         await pilot.pause()
-        assert router._find_query == "apple"
-        assert router._find_cursor_idx == 1  # 'apple' is at line idx 1
+        assert router.find_query == "apple"
+        assert router.find_cursor_index == 1  # 'apple' is at line idx 1

--- a/tests/cli/test_foldable_markdown_toggle.py
+++ b/tests/cli/test_foldable_markdown_toggle.py
@@ -61,16 +61,16 @@ async def test_foldable_collapsed_shows_preview_and_glyph() -> None:
         assert foldables, "FoldableMarkdown should be mounted for long reply"
         fm = foldables[-1]
         assert not fm.is_expanded(), "widget starts collapsed"
-        assert fm._remaining_lines == 30, (
-            f"remaining_lines should be 30 (60 lines - 30 threshold), got {fm._remaining_lines}"
+        assert fm.remaining_lines == 30, (
+            f"remaining_lines should be 30 (60 lines - 30 threshold), got {fm.remaining_lines}"
         )
         hint = fm._collapsed_hint()
         assert "▶" in hint, f"collapsed hint should contain ▶, got: {hint!r}"
         assert "more lines" in hint, f"collapsed hint should contain 'more lines', got: {hint!r}"
         # Preview text should be first 30 lines
-        assert "line 0" in fm._preview_text
+        assert "line 0" in fm.preview_text
         # Full text should contain all lines
-        assert "line 59" in fm._full_text
+        assert "line 59" in fm.full_text
 
 
 # ── 2. After toggle() → full text + ▼ hint ───────────────────────────────────
@@ -167,10 +167,10 @@ async def test_conv_foldables_list_has_one_after_long_reply() -> None:
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
-        assert not conv._foldables, "starts empty"
+        assert not conv.foldables, "starts empty"
         conv._write_agent_markdown_with_fold(_long_reply(60))
         await pilot.pause()
-        (only_foldable,) = conv._foldables
+        (only_foldable,) = conv.foldables
 
 
 # ── 6. toggle_last_foldable() toggles latest and returns True ────────────────
@@ -188,7 +188,7 @@ async def test_toggle_last_foldable_returns_true_and_toggles() -> None:
         conv._write_agent_markdown_with_fold(_long_reply(60))
         await pilot.pause()
 
-        fm = conv._foldables[-1]
+        fm = conv.foldables[-1]
         assert not fm.is_expanded()
 
         result = conv.toggle_last_foldable()

--- a/tests/cli/test_header_badge_click.py
+++ b/tests/cli/test_header_badge_click.py
@@ -56,8 +56,8 @@ async def test_badge_offsets_populated_for_find_badge() -> None:
         header = app.query_one("#header", ReynHeader)
         header.set_find_state("foo", position=1, total=3)
         await pilot.pause()
-        assert "find" in header._badge_offsets
-        start, end = header._badge_offsets["find"]
+        assert "find" in header.badge_offsets
+        start, end = header.badge_offsets["find"]
         # Range should be non-trivial (badge is ~17 cells: "[find: 'foo' 1/3]").
         assert end > start
         assert end - start >= 10
@@ -75,8 +75,8 @@ async def test_badge_offsets_populated_for_pending_badge() -> None:
         header = app.query_one("#header", ReynHeader)
         header.refresh_status(stalled_count=3)
         await pilot.pause()
-        assert "pending" in header._badge_offsets
-        start, end = header._badge_offsets["pending"]
+        assert "pending" in header.badge_offsets
+        start, end = header.badge_offsets["pending"]
         assert end > start
 
 
@@ -91,9 +91,9 @@ async def test_badge_offsets_empty_when_no_badges() -> None:
         await pilot.pause()
         header = app.query_one("#header", ReynHeader)
         # Nothing set up — no badges.
-        assert "find" not in header._badge_offsets
-        assert "pending" not in header._badge_offsets
-        assert "voice" not in header._badge_offsets
+        assert "find" not in header.badge_offsets
+        assert "pending" not in header.badge_offsets
+        assert "voice" not in header.badge_offsets
 
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ async def test_badge_at_x_hits_find_badge() -> None:
         rendered = header.rendered_text()
         text_cells = cell_len(rendered)
         text_left = header.size.width - 2 - text_cells
-        find_start, find_end = header._badge_offsets["find"]
+        find_start, find_end = header.badge_offsets["find"]
         # Pick the middle of the badge.
         mid_x = text_left + (find_start + find_end) // 2
         assert header.badge_at_x(mid_x) == "find"
@@ -173,12 +173,12 @@ async def test_click_on_find_badge_invokes_action_find_next() -> None:
             header,
         )
         await pilot.pause()
-        initial_cursor = router._find_cursor_idx
+        initial_cursor = router.find_cursor_index
         # Synthesise click on the find badge.
         rendered = header.rendered_text()
         text_cells = cell_len(rendered)
         text_left = header.size.width - 2 - text_cells
-        find_start, find_end = header._badge_offsets["find"]
+        find_start, find_end = header.badge_offsets["find"]
         mid_x = text_left + (find_start + find_end) // 2
         click = textual_events.Click(
             chain=1, widget=header, x=mid_x, y=0,
@@ -189,7 +189,7 @@ async def test_click_on_find_badge_invokes_action_find_next() -> None:
         header.on_click(click)
         await pilot.pause()
         # Cursor advanced after the click-driven find_next.
-        assert router._find_cursor_idx != initial_cursor
+        assert router.find_cursor_index != initial_cursor
 
 
 @pytest.mark.asyncio
@@ -208,7 +208,7 @@ async def test_click_on_pending_badge_opens_panel_to_pending_tab() -> None:
         header.refresh_status(stalled_count=2)
         await pilot.pause()
         # Pre-state: panel hidden.
-        assert app._panel_visible is False
+        assert app.panel_visible is False
         rendered = header.rendered_text()
         text_cells = cell_len(rendered)
         text_left = header.size.width - 2 - text_cells
@@ -223,7 +223,7 @@ async def test_click_on_pending_badge_opens_panel_to_pending_tab() -> None:
         header.on_click(click)
         await pilot.pause()
         # Panel opens to pending tab.
-        assert app._panel_visible is True
+        assert app.panel_visible is True
         panel = app.query_one("#right_panel", RightPanel)
         tabs = panel.query_one("#panel-tabs")
         assert tabs.active == "pending"
@@ -243,7 +243,7 @@ async def test_click_outside_badge_is_silent_no_op() -> None:
         header = app.query_one("#header", ReynHeader)
         header.set_find_state("foo", 1, 3)
         await pilot.pause()
-        before_panel = app._panel_visible
+        before_panel = app.panel_visible
         # Click far-left (= title region).
         click = textual_events.Click(
             chain=1, widget=header, x=2, y=0,
@@ -254,4 +254,4 @@ async def test_click_outside_badge_is_silent_no_op() -> None:
         header.on_click(click)
         await pilot.pause()
         # Panel unchanged (= no badge was hit, no action).
-        assert app._panel_visible == before_panel
+        assert app.panel_visible == before_panel

--- a/tests/cli/test_skill_done_cleanup_independent.py
+++ b/tests/cli/test_skill_done_cleanup_independent.py
@@ -79,10 +79,10 @@ async def test_skill_done_finished_cleans_up_fully() -> None:
         await pilot.pause()
 
         # Confirm setup is in place.
-        assert run_id in app._skill_exec
+        assert run_id in app.skill_exec_snapshot()
         assert any(
             s["agent_id"] == run_id
-            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            for s in conv.async_stack_snapshot()
         )
         assert input_bar.is_in_flight()
 
@@ -92,13 +92,13 @@ async def test_skill_done_finished_cleans_up_fully() -> None:
         await pilot.pause()
 
         # _skill_exec cleaned up.
-        assert run_id not in app._skill_exec, (
+        assert run_id not in app.skill_exec_snapshot(), (
             "_skill_exec must not contain run_id after skill done"
         )
         # AsyncStackPanel row removed.
         assert all(
             s["agent_id"] != run_id
-            for s in conv._async_stack().snapshot()  # type: ignore[union-attr]
+            for s in conv.async_stack_snapshot()
         ), "AsyncStackPanel must not have the row after skill done: finished"
         # InputBar unlocked (last skill popped → _skill_exec empty).
         assert not input_bar.is_in_flight(), (
@@ -155,7 +155,7 @@ async def test_finish_skill_row_raise_does_not_block_other_cleanup() -> None:
         await pilot.pause()
 
         # _skill_exec must be cleaned up despite finish_skill_row raising.
-        assert run_id not in app._skill_exec, (
+        assert run_id not in app.skill_exec_snapshot(), (
             "_skill_exec.pop must run even when finish_skill_row raises"
         )
         # remove_async_task must have been invoked.
@@ -220,7 +220,7 @@ async def test_remove_async_task_raise_does_not_block_other_cleanup() -> None:
         await pilot.pause()
 
         # _skill_exec must be cleaned up (it runs BEFORE remove_async_task).
-        assert run_id not in app._skill_exec, (
+        assert run_id not in app.skill_exec_snapshot(), (
             "_skill_exec.pop must run even when remove_async_task raises"
         )
         # InputBar must be unlocked — this runs AFTER remove_async_task, so

--- a/tests/cli/test_sticky_timer_cancellation.py
+++ b/tests/cli/test_sticky_timer_cancellation.py
@@ -62,11 +62,11 @@ async def test_two_transients_cancel_the_first_timer() -> None:
 
         router = OutboxRouter(app)
         router._show_transient_status(conv, "first")
-        first_timer = router._transient_status_timer
+        first_timer = router.transient_status_timer
         assert first_timer is not None
 
         router._show_transient_status(conv, "second")
-        second_timer = router._transient_status_timer
+        second_timer = router.transient_status_timer
         assert second_timer is not None
         assert second_timer is not first_timer, (
             "second arming must replace the timer handle, not re-use it"
@@ -99,14 +99,14 @@ async def test_live_status_cancels_pending_transient_timer() -> None:
         router = OutboxRouter(app)
         # Arm a transient
         router._show_transient_status(conv, "cost-inline on")
-        assert router._transient_status_timer is not None
+        assert router.transient_status_timer is not None
 
         # Live status arrives — must cancel the timer
         router._on_status(
             OutboxMessage(kind="status", text="thinking…"),
             conv, header,
         )
-        assert router._transient_status_timer is None
+        assert router.transient_status_timer is None
         # And the live status is showing
         sticky = conv.query_one("#sticky-status", StickyStatus)
         assert sticky.has_class("active")
@@ -128,13 +128,13 @@ async def test_stream_start_cancels_pending_transient_timer() -> None:
 
         router = OutboxRouter(app)
         router._show_transient_status(conv, "/cost-inline on")
-        assert router._transient_status_timer is not None
+        assert router.transient_status_timer is not None
 
         router._on_stream_start(
             OutboxMessage(kind="__stream_start__", text="", meta={"msg_id": "x"}),
             conv, header,
         )
-        assert router._transient_status_timer is None
+        assert router.transient_status_timer is None
 
 
 @pytest.mark.asyncio
@@ -159,7 +159,7 @@ async def test_attach_clears_sticky_and_cancels_transient() -> None:
         # Also arm a transient (could be from a slash that fired earlier)
         router = OutboxRouter(app)
         router._show_transient_status(conv, "earlier transient")
-        assert router._transient_status_timer is not None
+        assert router.transient_status_timer is not None
 
         # Now /attach a new agent — must clear sticky and cancel timer
         # Set _agent_registry to a non-None sentinel so the handler doesn't no-op
@@ -168,11 +168,11 @@ async def test_attach_clears_sticky_and_cancels_transient() -> None:
             OutboxMessage(kind="__attach_request__", text="bob"),
             conv, header,
         )
-        assert app._agent_name == "bob"
+        assert app.agent_name == "bob"
         assert not sticky.has_class("active"), (
             "sticky must be cleared after attach (previous agent's spinner is stale)"
         )
-        assert router._transient_status_timer is None
+        assert router.transient_status_timer is None
 
 
 @pytest.mark.asyncio
@@ -182,7 +182,7 @@ async def test_cancel_transient_is_idempotent_when_no_timer() -> None:
     async with app.run_test(headless=True, size=(120, 30)) as pilot:
         await pilot.pause()
         router = OutboxRouter(app)
-        assert router._transient_status_timer is None
+        assert router.transient_status_timer is None
         # Should not raise
         router._cancel_transient_timer()
-        assert router._transient_status_timer is None
+        assert router.transient_status_timer is None

--- a/tests/cli/test_stream_route_by_msg_id.py
+++ b/tests/cli/test_stream_route_by_msg_id.py
@@ -74,7 +74,7 @@ async def test_single_stream_chunks_land_on_their_row() -> None:
         router._on_stream_chunk(_chunk_msg("A1", "world"), conv, header)
         await pilot.pause()
 
-        row = conv._stream_rows.get("A1")
+        row = conv.stream_rows.get("A1")
         assert row is not None
         assert row.full_text() == "hello world"
 
@@ -116,8 +116,8 @@ async def test_late_chunk_from_old_stream_routes_to_its_own_row() -> None:
         router._on_stream_chunk(_chunk_msg("A1", " — late"), conv, header)
         await pilot.pause()
 
-        a_row = conv._stream_rows.get("A1")
-        b_row = conv._stream_rows.get("B1")
+        a_row = conv.stream_rows.get("A1")
+        b_row = conv.stream_rows.get("B1")
         assert a_row is not None and b_row is not None
         assert a_row.full_text() == "from a  — late", (
             f"A's late chunk leaked into B's row; A.full_text={a_row.full_text()!r}"
@@ -145,18 +145,18 @@ async def test_end_of_older_stream_does_not_clear_current_pointer() -> None:
         router._on_stream_start(_start_msg("A1"), conv, header)
         router._on_stream_start(_start_msg("B1"), conv, header)
         # Latest is B1
-        assert app._current_stream_id == "B1"
+        assert app.current_stream_id == "B1"
 
         # A1 finishes after B1 started
         router._on_stream_end(_end_msg("A1"), conv, header)
         # The latest pointer must NOT have been wiped to None
-        assert app._current_stream_id == "B1", (
+        assert app.current_stream_id == "B1", (
             f"older stream's end cleared the global; got {app._current_stream_id!r}"
         )
 
         # When the latest does end, the global clears
         router._on_stream_end(_end_msg("B1"), conv, header)
-        assert app._current_stream_id is None
+        assert app.current_stream_id is None
 
 
 @pytest.mark.asyncio
@@ -179,7 +179,7 @@ async def test_chunk_with_no_msg_id_is_silently_dropped() -> None:
         router._on_stream_chunk(bad_chunk, conv, header)
         await pilot.pause()
         # No row created
-        assert conv._stream_rows == {}
+        assert conv.stream_rows == {}
 
 
 @pytest.mark.asyncio
@@ -200,7 +200,7 @@ async def test_end_seals_only_the_named_stream() -> None:
 
         router._on_stream_end(_end_msg("A1"), conv, header)
         await pilot.pause()
-        assert "A1" not in conv._stream_rows
-        assert "B1" in conv._stream_rows, (
+        assert "A1" not in conv.stream_rows
+        assert "B1" in conv.stream_rows, (
             "ending A1 must not touch B1's row"
         )

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -88,8 +88,8 @@ async def test_header_refresh_updates_status():
         await pilot.pause()
         header = app.query_one("#header", ReynHeader)
         header.refresh_status(agent_name="bob", model="m2")
-        assert "bob" in header._format_status()
-        assert "m2" in header._format_status()
+        assert "bob" in header.format_status()
+        assert "m2" in header.format_status()
 
 
 # ── test: input bar ───────────────────────────────────────────────────────────
@@ -333,7 +333,7 @@ async def test_streaming_via_begin_append_end():
         result = conv.end_stream("stream_abc")
         assert result == "token1 token2"
         # After end, the stream_id is removed
-        assert "stream_abc" not in conv._stream_rows
+        assert "stream_abc" not in conv.stream_rows
 
 
 # ── test: intervention widget ─────────────────────────────────────────────────
@@ -756,48 +756,48 @@ async def test_preview_pane_shift_jk_moves_parent_tab_cursor():
         panel._docs_cursor = 0
 
         pane.on_key(_FakeKey("J"))
-        assert panel._docs_cursor == 1, "J should advance the docs cursor"
+        assert panel.docs_cursor == 1, "J should advance the docs cursor"
         pane.on_key(_FakeKey("n"))  # bonus alias
-        assert panel._docs_cursor == 2, "n alias should also advance"
+        assert panel.docs_cursor == 2, "n alias should also advance"
         pane.on_key(_FakeKey("J"))  # wrap forward
-        assert panel._docs_cursor == 0
+        assert panel.docs_cursor == 0
         pane.on_key(_FakeKey("K"))  # wrap backward
-        assert panel._docs_cursor == 2
+        assert panel.docs_cursor == 2
         pane.on_key(_FakeKey("p"))  # bonus alias for previous
-        assert panel._docs_cursor == 1
+        assert panel.docs_cursor == 1
 
         # Lowercase j / k must NOT move the parent cursor (still scroll-inside).
-        before = panel._docs_cursor
+        before = panel.docs_cursor
         pane.on_key(_FakeKey("j"))
         pane.on_key(_FakeKey("k"))
-        assert panel._docs_cursor == before, "lowercase j/k must not move parent cursor"
+        assert panel.docs_cursor == before, "lowercase j/k must not move parent cursor"
 
         # ── events tab: same contract on the events cursor ──
         panel._panel_type = "events"
         panel._events_visible = [{"type": "e0"}, {"type": "e1"}, {"type": "e2"}]
         panel._events_cursor = 0
         pane.on_key(_FakeKey("J"))
-        assert panel._events_cursor == 1
+        assert panel.events_cursor == 1
         pane.on_key(_FakeKey("K"))
-        assert panel._events_cursor == 0
+        assert panel.events_cursor == 0
 
         # ── memory tab ──
         panel._panel_type = "memory"
         panel._memory_entries = [object(), object(), object()]
         panel._memory_cursor = 0
         pane.on_key(_FakeKey("J"))
-        assert panel._memory_cursor == 1
+        assert panel.memory_cursor == 1
         pane.on_key(_FakeKey("K"))
-        assert panel._memory_cursor == 0
+        assert panel.memory_cursor == 0
 
         # ── agents tab ──
         panel._panel_type = "agents"
         panel._agents_items = [{"kind": "x"}, {"kind": "y"}]
         panel._agents_cursor = 0
         pane.on_key(_FakeKey("J"))
-        assert panel._agents_cursor == 1
+        assert panel.agents_cursor == 1
         pane.on_key(_FakeKey("K"))
-        assert panel._agents_cursor == 0
+        assert panel.agents_cursor == 0
 
 
 # ── test: right panel — events tab chronological sort ───────────────────────
@@ -873,14 +873,14 @@ async def test_event_filter_cycling_rotates_through_groups():
         panel = app.query_one("#right_panel")
 
         n = len(_FILTER_GROUPS)
-        assert panel._event_filter_idx == 0  # initial state
+        assert panel.event_filter_idx == 0  # initial state
 
         for i in range(1, n + 1):
             panel.cycle_event_filter()
-            assert panel._event_filter_idx == i % n
+            assert panel.event_filter_idx == i % n
 
         # Wrap-around: after n cycles we land back at 0
-        assert panel._event_filter_idx == 0
+        assert panel.event_filter_idx == 0
 
 
 # ── test: right panel — docs cursor navigation ───────────────────────────────
@@ -906,15 +906,15 @@ async def test_docs_cursor_advances_with_j_keypress():
         panel._docs_cursor = 0
 
         panel._docs_move(+1)
-        assert panel._docs_cursor == 1
+        assert panel.docs_cursor == 1
         panel._docs_move(+1)
-        assert panel._docs_cursor == 2
+        assert panel.docs_cursor == 2
         # Wraparound — stepping past the last file returns to index 0.
         panel._docs_move(+1)
-        assert panel._docs_cursor == 0
+        assert panel.docs_cursor == 0
         # Reverse from the top wraps to the last file.
         panel._docs_move(-1)
-        assert panel._docs_cursor == 2
+        assert panel.docs_cursor == 2
 
 
 # ── test: right panel — tab cycling ──────────────────────────────────────────
@@ -981,16 +981,16 @@ async def test_slash_picker_wraps_around_at_boundaries():
             for i in range(3)
         ]
         picker.set_matches(candidates)
-        assert picker._selected == 0
+        assert picker.selected_index == 0
 
         # Walk forward N times: 0 -> 1 -> 2 -> 0 (wrap)
         picker.move_selection(+1)
-        assert picker._selected == 1
+        assert picker.selected_index == 1
         picker.move_selection(+1)
-        assert picker._selected == 2
+        assert picker.selected_index == 2
         picker.move_selection(+1)
-        assert picker._selected == 0
+        assert picker.selected_index == 0
 
         # Walk backward from 0 wraps to the last entry
         picker.move_selection(-1)
-        assert picker._selected == len(candidates) - 1
+        assert picker.selected_index == len(candidates) - 1


### PR DESCRIPTION
**[tui-coder]** — Tier C Path C cleanup, Wave 4 multi-src sweep (= closing wave).

## Summary
- 31 private-state asserts across 7 multi-src TUI test files → migrated to public surface (79/79 green)
- 14 new public accessors added across 6 src widgets (header, right_panel, app, app_outbox, conversation, foldable_markdown)
- Closes out the TUI lane for Tier C Path C
- Audit remaining (full TUI lane): 30 violations (= out-of-lane / non-TUI-widget references not in our scope)

**New accessors added:**
- `ReynHeader`: `format_status()` public method + `badge_offsets` property
- `RightPanel`: `events_cursor` + `agents_cursor` + `event_filter_idx` properties
- `ReynTUIApp`: `outbox_router` + `current_stream_id` + `agent_name` properties + `skill_exec_snapshot()` method
- `OutboxRouter`: `transient_status_timer` property
- `ConversationView`: `stream_rows` + `foldables` properties
- `FoldableMarkdown`: `remaining_lines` + `preview_text` + `full_text` properties

**Already public from waves 1-3 (no src change needed):** `docs_cursor`, `memory_cursor` (RightPanel); `find_query`, `find_cursor_index`, `has_transient_status_timer` (OutboxRouter); `panel_visible` (app); `async_stack_snapshot()` (ConversationView); `selected_index` (SlashPicker).

## Test plan
- [x] `python scripts/test_tier_audit.py <7 test files>` → 0 violations (was 31)
- [x] `pytest <7 test files> -q` → 79/79 pass in 21.74s
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 green (regression check)
- [x] `ruff check <all 13 changed files>` → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring
- [x] No new Mock usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)