### PR TITLE
chore(intervention-registry): add has_active / has_stalled / is_queued read helpers (Tier C1 cleanup wave 26)

### DIFF
--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -92,6 +92,26 @@ class InterventionRegistry:
         # exclusive — an iv is in one or the other, never both.
         self._stalled: dict[str, UserIntervention] = {}
 
+    # ── Read helpers for tests / external observers ─────────────────────────
+
+    def has_active(self, iv_id: str) -> bool:
+        """Return True iff *iv_id* is currently in the active queue."""
+        return iv_id in self._active
+
+    def has_stalled(self, iv_id: str) -> bool:
+        """Return True iff *iv_id* is currently in the stalled queue."""
+        return iv_id in self._stalled
+
+    def is_queued(self, iv_id: str) -> bool:
+        """Return True iff *iv_id* is currently in the FIFO order deque.
+
+        The order deque tracks the emission sequence for the active map;
+        an entry stays in both ``_active`` and the order deque while
+        active, and leaves both when ``mark_stalled`` / ``deliver_answer``
+        / ``discard_stalled`` / ``claim_stalled`` runs.
+        """
+        return iv_id in self._order
+
     # ── Listener registration (issue #254 Phase 1) ───────────────────────────
 
     def register_listener(self, listener_id: str) -> None:

--- a/tests/test_pending_intervention_268.py
+++ b/tests/test_pending_intervention_268.py
@@ -103,8 +103,8 @@ def test_registry_mark_stalled_moves_iv_from_active_to_stalled() -> None:
     reg._order.append(iv.id)
 
     assert reg.mark_stalled(iv.id) is True
-    assert iv.id not in reg._active
-    assert iv.id not in reg._order
+    assert not reg.has_active(iv.id)
+    assert not reg.is_queued(iv.id)
     assert reg.get_stalled(iv.id) is iv
     assert reg.stalled_count() == 1
 
@@ -161,7 +161,7 @@ def test_registry_discard_stalled_resolves_future_with_empty_answer() -> None:
         reg._stalled[iv.id] = iv
         # Discard from another "channel".
         assert reg.discard_stalled(iv.id) is True
-        assert iv.id not in reg._stalled
+        assert not reg.has_stalled(iv.id)
         return await iv.future
 
     answer = asyncio.run(_drive())
@@ -187,7 +187,7 @@ def test_registry_claim_stalled_rebinds_origin_and_returns_iv() -> None:
     claimed = reg.claim_stalled(iv.id, "tui:new-session")
     assert claimed is iv
     assert claimed.origin_channel_id == "tui:new-session"
-    assert iv.id not in reg._stalled
+    assert not reg.has_stalled(iv.id)
 
 
 def test_registry_claim_stalled_returns_none_when_not_stalled() -> None:


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-sixth slice. Three lightweight membership-check helpers on \`InterventionRegistry\` so tests stop reaching for the private ``_active`` / ``_stalled`` / ``_order`` storage.

## Changes

### Production (\`src/reyn/chat/services/intervention_registry.py\`)
Add three read-only helpers next to the existing public API:
- ``has_active(iv_id) -> bool`` — membership on the active dict
- ``has_stalled(iv_id) -> bool`` — membership on the stalled dict
- ``is_queued(iv_id) -> bool`` — membership on the FIFO order deque

Storage layout unchanged; only the read surface widens. The registry already has ``get`` / ``list_active`` / ``queued_count`` / ``get_stalled`` / ``list_stalled`` / ``stalled_count`` — these three helpers fill the membership-only gap.

### Tests (4 Tier-C1 findings cleared)
- \`tests/test_pending_intervention_268.py\`:
  - ``iv.id not in reg._active`` → ``not reg.has_active(iv.id)`` (2 sites)
  - ``iv.id not in reg._order`` → ``not reg.is_queued(iv.id)`` (1 site)
  - ``iv.id in/not in reg._stalled`` → ``reg.has_stalled(...) / not reg.has_stalled(...)`` (1 site)

Test setup writes (``reg._active[iv.id] = iv`` / ``reg._order.append(iv.id)``) keep the underscore — those are fixture-state setup, not assertion reads. Audit policy correctly leaves them alone.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: 0 errors on the touched file
- [x] Load-bearing invariants preserved (= identical membership semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_pending_intervention_268.py\` → 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)