### PR TITLE
chore(permissions+session): public helpers for state-change observers (Tier C1 cleanup wave 27)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1873,6 +1873,15 @@ class ChatSession:
         return self._last_reply_to
 
     @property
+    def on_perm_persist_cb(self):
+        """Read-only accessor for the permission-persist callback that this
+        session registered on its ``PermissionResolver`` (or None if no
+        resolver / no callback was wired). Tests verify the
+        register/unregister balance through this surface.
+        """
+        return self._on_perm_persist_cb
+
+    @property
     def interventions(self) -> "InterventionRegistry":
         """Read-only public accessor for the session's InterventionRegistry.
 

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -360,6 +360,21 @@ class PermissionResolver:
         # callback so a project-wide grant notifies every active session.
         self._on_persist_callbacks: list[Callable[[str, bool], None]] = []
 
+    # ── Public read helpers (= Tier-C1 cleanup wave 27) ───────────────────
+
+    def saved_get(self, key: str) -> bool | None:
+        """Read accessor for the persisted approvals map. Returns the
+        stored boolean (or None when not yet recorded)."""
+        return self._saved.get(key)
+
+    def on_persist_callback_count(self) -> int:
+        """Return the number of registered ``on_persist`` callbacks.
+
+        Tests / observers use this to verify register / unregister
+        balance without reaching into the internal list.
+        """
+        return len(self._on_persist_callbacks)
+
     # ── Persistence ──────────────────────────────────────────────────────────
 
     def _load_saved(self) -> dict[str, bool]:

--- a/tests/test_permission_state_change_emitter.py
+++ b/tests/test_permission_state_change_emitter.py
@@ -146,7 +146,7 @@ def test_persist_callback_exception_does_not_crash_persist(tmp_path):
     # Good callback still fired despite bad_cb raising.
     assert good_calls == ["safe.key"]
     # And approvals.yaml side still completed.
-    assert resolver._saved.get("safe.key") is True
+    assert resolver.saved_get("safe.key") is True
 
 
 # ── ChatSession wiring ────────────────────────────────────────────────
@@ -216,7 +216,7 @@ def test_session_with_no_resolver_works_unchanged(tmp_path):
         snapshot_path=tmp_path / "loner_snapshot.json",
         # permission_resolver=None — default
     )
-    assert session._on_perm_persist_cb is None
+    assert session.on_perm_persist_cb is None
     # No exception even though no resolver was wired.
 
 
@@ -229,12 +229,12 @@ async def test_session_shutdown_unregisters_callback(tmp_path):
     resolver = _make_resolver(tmp_path)
     session = _make_session(tmp_path, agent_name="ephemeral", perm_resolver=resolver)
 
-    pre = len(resolver._on_persist_callbacks)
+    pre = resolver.on_persist_callback_count()
     assert pre == 1
 
     await session.shutdown()
     # Drain the shutdown signal that shutdown put on the inbox so the
     # call doesn't block other tests if reused. Inbox shutdown isn't
     # the focus here — just confirming unregister fired.
-    assert session._on_perm_persist_cb is None
-    assert len(resolver._on_persist_callbacks) == pre - 1
+    assert session.on_perm_persist_cb is None
+    assert resolver.on_persist_callback_count() == pre - 1


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-seventh slice. Three bundled fixes for the permission-state-change-emitter contract (= all in the same test file, same #398 v4 wiring).

## Changes

### (a) Production (\`src/reyn/permissions/permissions.py\`)
Two read helpers on \`PermissionResolver\`:
- ``saved_get(key) -> bool | None`` — accessor for the persisted-approvals map
- ``on_persist_callback_count() -> int`` — register/unregister balance probe

### (b) Production (\`src/reyn/chat/session.py\`)
- ``ChatSession.on_perm_persist_cb`` \`@property\` — None before wiring, the callable while wired, None again after shutdown unregister

### Tests (4 Tier-C1 findings cleared)
- \`tests/test_permission_state_change_emitter.py\`:
  - 1 ``resolver._saved.get(...)`` → ``resolver.saved_get(...)``
  - 2 ``session._on_perm_persist_cb`` → ``session.on_perm_persist_cb``
  - 1 ``len(resolver._on_persist_callbacks)`` → ``resolver.on_persist_callback_count()``

## Pre-commit caller-scope audit
Clean — no other test sites reaching into ``_saved`` / ``_on_perm_persist_cb`` / ``_on_persist_callbacks``.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: 0 errors on the touched file
- [x] Load-bearing invariants preserved (= identical lookup / identity / count semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_permission_state_change_emitter.py\` → 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)