### PR TITLE
chore(session+skill-registry): public surface for skill-registry access (Tier C1 cleanup wave 28)

### DIFF
--- a/src/reyn/chat/services/auto_resume_handler.py
+++ b/src/reyn/chat/services/auto_resume_handler.py
@@ -64,7 +64,7 @@ class AutoResumeHandler:
     ) -> None:
         self._events = event_log
         self._state_log = state_log
-        self._get_skill_registry = get_skill_registry
+        self.get_skill_registry = get_skill_registry
         self._drop_interventions_for_run = drop_interventions_for_run
         self._launcher = launcher
 
@@ -123,7 +123,7 @@ class AutoResumeHandler:
             SkillResumeCoordinator as _Coord,
         )
 
-        registry = self._get_skill_registry()
+        registry = self.get_skill_registry()
         if registry is None or self._state_log is None:
             return []
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1637,7 +1637,7 @@ class ChatSession:
             enqueue_skill_completed=self._enqueue_skill_completed,
             accumulate=self._accumulate,
             drop_interventions_for_run=self._drop_interventions_for_run,
-            get_skill_registry=self._get_skill_registry,
+            get_skill_registry=self.get_skill_registry,
             ask_budget_extension=self._ask_budget_extension,
             outbox=self.outbox,
         )
@@ -1781,7 +1781,7 @@ class ChatSession:
         self._auto_resume_handler = AutoResumeHandler(
             event_log=self._chat_events,
             state_log=self._state_log,
-            get_skill_registry=self._get_skill_registry,
+            get_skill_registry=self.get_skill_registry,
             drop_interventions_for_run=self._drop_interventions_for_run,
             launcher=self._skill_runner.spawn_resumed_skill,
         )
@@ -1901,6 +1901,15 @@ class ChatSession:
         underscore name; this property is the read-only public view.
         """
         return self._on_limit
+
+    @property
+    def agent_registry(self):
+        """Read-only accessor for the session's owning AgentRegistry (or None
+        when running outside a registry). Tests verify cross-agent state
+        (= e.g. AgentRegistry.last_truncation_ts on shared WAL) via this
+        surface.
+        """
+        return self._registry
 
     @property
     def interventions(self) -> "InterventionRegistry":
@@ -2778,7 +2787,7 @@ class ChatSession:
     # (RunSpawner wave). Callers go through ``self._skill_runner`` directly;
     # the AutoResumeHandler wiring in __init__ uses the method reference.
 
-    def _get_skill_registry(self) -> "SkillRegistry | None":
+    def get_skill_registry(self) -> "SkillRegistry | None":
         """Return the per-agent SkillRegistry, lazily constructed on first call.
 
         Returns None when no state_log is wired (test / standalone mode) —
@@ -2825,7 +2834,7 @@ class ChatSession:
         Returns None when no state_log is wired — test / standalone
         mode without persistence.
 
-        Truncate hook mirrors _get_skill_registry: fires
+        Truncate hook mirrors get_skill_registry: fires
         AgentRegistry.truncate_wal_if_eligible after every durable
         per-plan mutation (= last_step_applied_seq bump).
         """

--- a/src/reyn/chat/slash/skill.py
+++ b/src/reyn/chat/slash/skill.py
@@ -64,7 +64,7 @@ async def _list_skill_runs(session: "ChatSession") -> None:
     list) display as roots — the parent has either completed or this
     is a stale snapshot.
     """
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     if reg is None:
         await reply(session, "(no active skills — state log not configured)")
         return
@@ -168,7 +168,7 @@ async def _discard_skill_run(session: "ChatSession", args: str) -> None:
     if not run_id:
         await reply_error(session, "Usage: /skill discard <run_id> [--force]")
         return
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     if reg is None:
         await reply_error(session, "skill registry not available")
         return

--- a/src/reyn/chat/slash/tasks.py
+++ b/src/reyn/chat/slash/tasks.py
@@ -127,7 +127,7 @@ def _list_skill_lines(session: "ChatSession") -> list[str]:
     if not running:
         return []
     started_at = getattr(session, "running_skills_started_at", {}) or {}
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     now = time.monotonic()
     lines: list[str] = []
     for run_id in running.keys():
@@ -190,7 +190,7 @@ async def _task_status(session: "ChatSession", args: str) -> None:
 async def _skill_status(session: "ChatSession", run_id: str) -> None:
     started_at = getattr(session, "running_skills_started_at", {}) or {}
     elapsed = time.monotonic() - started_at.get(run_id, time.monotonic())
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     out: list[str] = [
         f"skill run {run_id}",
         f"  elapsed:  {_format_elapsed(elapsed)}",

--- a/src/reyn/skill/skill_registry.py
+++ b/src/reyn/skill/skill_registry.py
@@ -81,6 +81,11 @@ class SkillRegistry:
         self._snapshots: dict[str, SkillSnapshot] = {}
 
     @property
+    def truncate_hook(self):
+        """Read-only accessor for the registered WAL-truncate hook (or None)."""
+        return self._truncate_hook
+
+    @property
     def state_dir(self) -> Path:
         """Public view of the per-agent state directory (R-D10).
 

--- a/tests/test_chain_peer_discarded_notify.py
+++ b/tests/test_chain_peer_discarded_notify.py
@@ -238,7 +238,7 @@ def test_slash_discard_notifies_upstream_chain_waiter(tmp_path: Path, monkeypatc
             origin_depth=0,
         )
         # B has a skill_run processing chain X-D14
-        b_reg = sess_b._get_skill_registry()
+        b_reg = sess_b.get_skill_registry()
         assert b_reg is not None
         await b_reg.start(
             run_id="run_b_d14",
@@ -301,7 +301,7 @@ def test_slash_discard_no_chain_does_not_notify(tmp_path: Path, monkeypatch):
     registry.notify_chain_discarded = fake_notify  # type: ignore[assignment]
 
     async def go():
-        b_reg = sess_b._get_skill_registry()
+        b_reg = sess_b.get_skill_registry()
         await b_reg.start(
             run_id="run_b_solo", skill_name="standalone",
             skill_input={"type": "input", "data": {}},

--- a/tests/test_nested_skill_path.py
+++ b/tests/test_nested_skill_path.py
@@ -156,7 +156,7 @@ def test_skill_list_shows_root_skill_flat(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     session.is_attached = True
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     assert reg is not None
 
     async def go():
@@ -186,7 +186,7 @@ def test_skill_list_shows_parent_child_lineage(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     session.is_attached = True
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     assert reg is not None
 
     async def go():
@@ -216,7 +216,7 @@ def test_skill_list_handles_three_level_chain(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     session.is_attached = True
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     assert reg is not None
 
     async def go():
@@ -256,7 +256,7 @@ def test_skill_list_handles_orphaned_child(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     session.is_attached = True
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     assert reg is not None
 
     async def go():

--- a/tests/test_resume_auto_e2e.py
+++ b/tests/test_resume_auto_e2e.py
@@ -173,7 +173,7 @@ def test_e2e_chatsession_auto_resume_completes_crashed_skill(tmp_path: Path, mon
         rt = _StubResumeRuntime(
             _make_skill(),
             resume_plan=decision.plan,
-            skill_registry=session._get_skill_registry(),
+            skill_registry=session.get_skill_registry(),
             state_log=session._state_log,
         )
         result = await rt.run(decision.plan.skill_input)

--- a/tests/test_session_skill_registry_integration.py
+++ b/tests/test_session_skill_registry_integration.py
@@ -12,7 +12,7 @@ them a correctly-wired SkillRegistry. A wiring regression would silently
 disable resume.
 
 Observation flows through:
-  - ChatSession._get_skill_registry() return value type
+  - ChatSession.get_skill_registry() return value type
   - The returned registry's behavior when its lifecycle methods are called
     (does start() append to the WAL? does the hook fire?)
 No mocks — real ChatSession with no LLM (we never call _run_skill_awaitable),
@@ -65,7 +65,7 @@ def test_get_skill_registry_returns_none_without_state_log(tmp_path, monkeypatch
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, with_state_log=False, with_registry=False)
-    assert session._get_skill_registry() is None
+    assert session.get_skill_registry() is None
 
 
 def test_get_skill_registry_lazy_constructs_with_state_log(tmp_path, monkeypatch):
@@ -77,9 +77,9 @@ def test_get_skill_registry_lazy_constructs_with_state_log(tmp_path, monkeypatch
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, with_state_log=True, with_registry=False)
 
-    reg1 = session._get_skill_registry()
+    reg1 = session.get_skill_registry()
     assert isinstance(reg1, SkillRegistry)
-    reg2 = session._get_skill_registry()
+    reg2 = session.get_skill_registry()
     assert reg1 is reg2  # cached
 
 
@@ -90,7 +90,7 @@ def test_skill_registry_writes_to_session_state_log(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, with_state_log=True, with_registry=False)
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
 
     async def go():
         await reg.start(
@@ -120,8 +120,8 @@ def test_truncate_hook_unwired_without_registry(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, with_state_log=True, with_registry=False)
-    reg = session._get_skill_registry()
-    assert reg._truncate_hook is None
+    reg = session.get_skill_registry()
+    assert reg.truncate_hook is None
 
 
 def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
@@ -153,8 +153,8 @@ def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
         Path(".reyn") / "agents" / "alpha" / "state" / "snapshot.json",
     )
 
-    reg = session._get_skill_registry()
-    assert reg._truncate_hook is not None
+    reg = session.get_skill_registry()
+    assert reg.truncate_hook is not None
 
     async def go():
         await reg.start(run_id="r", skill_name="s", skill_input={})
@@ -165,4 +165,4 @@ def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
 
     # Throttle stamp set proves the hook reached AgentRegistry's truncation
     # path AND truncation actually attempted a rewrite (floor>0).
-    assert session._registry.last_truncation_ts is not None
+    assert session.agent_registry.last_truncation_ts is not None

--- a/tests/test_skill_postprocessor_chain.py
+++ b/tests/test_skill_postprocessor_chain.py
@@ -284,7 +284,7 @@ def test_postprocessor_mid_run_discard_notifies_upstream(
         assert sess_a.chains.find_chain("chain-post-001") is not None
 
         # B starts a skill_run (simulates a skill that has entered __post__)
-        b_reg = sess_b._get_skill_registry()
+        b_reg = sess_b.get_skill_registry()
         assert b_reg is not None
         await b_reg.start(
             run_id="run_b_post_001",
@@ -415,7 +415,7 @@ def test_postprocessor_mid_run_chain_timeout_fires(
         assert sess_a.chains.find_chain("chain-timeout-post-001") is not None
 
         # B starts its skill — simulates __post__ state (no completion)
-        b_reg = sess_b._get_skill_registry()
+        b_reg = sess_b.get_skill_registry()
         assert b_reg is not None
         await b_reg.start(
             run_id="run_b_timeout_001",

--- a/tests/test_skill_slash_command.py
+++ b/tests/test_skill_slash_command.py
@@ -58,7 +58,7 @@ async def test_skill_list_shows_active_runs(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     assert reg is not None
     await reg.start(
         run_id="run_A", skill_name="blog_writer",
@@ -114,7 +114,7 @@ async def test_skill_discard_completes_with_discarded_status(tmp_path, monkeypat
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     await reg.start(
         run_id="run_to_discard", skill_name="demo",
         skill_input={"type": "input", "data": {}},
@@ -145,7 +145,7 @@ async def test_skill_discard_without_force_is_confirmation_only(tmp_path, monkey
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     await reg.start(
         run_id="run_pending", skill_name="long_writer",
         skill_input={"type": "input", "data": {}},
@@ -182,7 +182,7 @@ async def test_skill_discard_without_force_leaves_task_running(tmp_path, monkeyp
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     await reg.start(
         run_id="run_keep_running", skill_name="demo",
         skill_input={"type": "input", "data": {}},
@@ -221,7 +221,7 @@ async def test_skill_discard_force_flag_order_independent(tmp_path, monkeypatch)
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     await reg.start(
         run_id="run_flag_first", skill_name="demo",
         skill_input={"type": "input", "data": {}},
@@ -261,7 +261,7 @@ async def test_skill_discard_cancels_running_task(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     await reg.start(
         run_id="run_running", skill_name="demo",
         skill_input={"type": "input", "data": {}},
@@ -292,7 +292,7 @@ async def test_skill_discard_drops_interventions(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    reg = session._get_skill_registry()
+    reg = session.get_skill_registry()
     await reg.start(
         run_id="run_with_iv", skill_name="demo",
         skill_input={"type": "input", "data": {}},


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-eighth slice. Three bundled fixes for the ChatSession ↔ SkillRegistry ↔ AgentRegistry access path (= all in the same test file).

## Changes

### (a) Production: rename + 2 new properties
- \`src/reyn/chat/session.py\`:
  - ``_get_skill_registry`` → ``get_skill_registry`` (method rename, many in-tree callers)
  - ``ChatSession.agent_registry`` ``@property`` returning ``self._registry``
- \`src/reyn/skill/skill_registry.py\`:
  - ``SkillRegistry.truncate_hook`` ``@property`` returning ``self._truncate_hook``

### (b) Production-side callers updated
- \`src/reyn/chat/slash/skill.py\` + \`slash/tasks.py\` + \`services/auto_resume_handler.py\` — all use the public ``get_skill_registry`` name

### (c) Tests (4 Tier-C1 findings cleared + 6 caller-scope sweeps)
- 4 audit findings in \`tests/test_session_skill_registry_integration.py\` cleared:
  - ``_get_skill_registry`` (1), ``_truncate_hook`` (2), ``_registry`` (1)
- Plus 5 sibling test files swept for caller-scope consistency (= per slice-18 missed-migration lesson):
  - \`test_nested_skill_path.py\`, \`test_resume_auto_e2e.py\`, \`test_chain_peer_discarded_notify.py\`, \`test_skill_slash_command.py\`, \`test_skill_postprocessor_chain.py\`

## Notes
- ``test_skill_runner_invariants.py`` has a LOCAL ``def _get_skill_registry()`` stub — left unchanged (local scope, not the renamed method).
- ``skill_runner.py``'s ``self._get_skill_registry`` is a **callback attribute** (different namespace) — left unchanged.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: \`python3 scripts/test_tier_audit.py --check private-state tests/test_session_skill_registry_integration.py\` → 0 errors
- [x] Load-bearing invariants preserved (= identical method semantics, identical hook + registry identity)
- [x] No private-state assertions added; only removed
- [x] Caller-scope audit ran (= grep across whole repo) — all production + test sites of the renamed method swept

## Test plan
- [x] \`venv/bin/pytest tests/test_session_skill_registry_integration.py tests/test_chain_peer_discarded_notify.py tests/test_skill_slash_command.py tests/test_nested_skill_path.py\` → 33 passed
- [x] \`grep -rn "._get_skill_registry()" --include="*.py"\` post-rename → only the LOCAL stub + the callback-attribute sites remain (= scoped explanations above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)