### PR TITLE
chore(chunkers-preproc-safe): rename _path_suffix / _detect_structure public (Tier C1 cleanup wave 29)

### DIFF
--- a/src/reyn/stdlib/skills/index_docs/chunkers_preproc_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_preproc_safe.py
@@ -20,7 +20,7 @@ Output-shape contract: the two functions here return the same shape
 as the pre-FP-0042 ``chunkers.py`` implementations did, so the
 LLM-facing artifact at ``data.samples_result`` / ``data.cost`` is
 bit-compatible across the migration. Field names, key sets,
-rounding, and the ``_detect_structure`` heuristic all mirror the
+rounding, and the ``detect_structure`` heuristic all mirror the
 legacy unsafe-mode versions.
 """
 from __future__ import annotations
@@ -58,12 +58,12 @@ def _is_regular_file(path: str) -> bool:
     return (int(info.get("mode", 0)) & _S_IFMT) == _S_IFREG
 
 
-def _path_suffix(path: str) -> str:
+def path_suffix(path: str) -> str:
     """Return the lowercase extension including the leading dot.
 
     Pathlib is not in the safe-mode allowlist, so use plain string
     manipulation. Mirrors ``pathlib.PurePath.suffix`` for the cases
-    that matter to ``_detect_structure``:
+    that matter to ``detect_structure``:
 
     - ``foo.md`` → ``.md``
     - ``.hidden`` → ``""`` (hidden file with no real extension)
@@ -80,7 +80,7 @@ def _approx_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
-def _detect_structure(text: str, ext: str) -> str:
+def detect_structure(text: str, ext: str) -> str:
     """Heuristic structure hint for LLM strategy context.
 
     Mirrors the pre-FP-0042 ``chunkers.py`` heuristic exactly so the
@@ -152,7 +152,7 @@ def gather_samples(artifact: dict) -> dict:
     by_ext: dict[str, list[str]] = {}
     total_bytes = 0
     for f in files:
-        ext = _path_suffix(f)
+        ext = path_suffix(f)
         by_ext.setdefault(ext, []).append(f)
         try:
             total_bytes += int(_safe_file.stat(f).get("size", 0))
@@ -181,7 +181,7 @@ def gather_samples(artifact: dict) -> dict:
                 "path": f,
                 "excerpt": excerpt,
                 "size_tokens": _approx_tokens(text),
-                "structure_hint": _detect_structure(text, _path_suffix(f)),
+                "structure_hint": detect_structure(text, path_suffix(f)),
             }
         )
 

--- a/tests/test_chunkers_preproc_safe.py
+++ b/tests/test_chunkers_preproc_safe.py
@@ -298,7 +298,7 @@ def test_cost_preflight_not_exceeded_for_few_files(grant_tmp_read: Path):
 
 
 # ---------------------------------------------------------------------------
-# _path_suffix / _detect_structure (internal helpers — pinned because the
+# path_suffix / detect_structure (internal helpers — pinned because the
 # LLM-facing structure_hint string must stay stable across the migration)
 # ---------------------------------------------------------------------------
 
@@ -316,8 +316,8 @@ def test_cost_preflight_not_exceeded_for_few_files(grant_tmp_read: Path):
     ],
 )
 def test_path_suffix_mirrors_pathlib(path: str, expected: str):
-    """Tier 2: _path_suffix matches pathlib.PurePath.suffix for our cases."""
-    assert _C._path_suffix(path) == expected
+    """Tier 2: path_suffix matches pathlib.PurePath.suffix for our cases."""
+    assert _C.path_suffix(path) == expected
 
 
 @pytest.mark.parametrize(
@@ -333,7 +333,7 @@ def test_path_suffix_mirrors_pathlib(path: str, expected: str):
     ],
 )
 def test_detect_structure_mirrors_unsafe_heuristic(ext: str, text: str, expected: str):
-    """Tier 2: _detect_structure strings match chunkers.py's legacy heuristic
+    """Tier 2: detect_structure strings match chunkers.py's legacy heuristic
     exactly — the LLM sees identical structure_hint values across the
     FP-0042 migration."""
-    assert _C._detect_structure(text, ext) == expected
+    assert _C.detect_structure(text, ext) == expected


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 twenty-ninth slice. ``rename`` for two pure-function module helpers in \`reyn.stdlib.skills.index_docs.chunkers_preproc_safe\`.

## Changes
- ``def _path_suffix`` → ``def path_suffix`` (file-extension extractor)
- ``def _detect_structure`` → ``def detect_structure`` (Markdown / TOML / generic structure heuristic)
- In-module callers + docstring refs updated.

Tests (2 Tier-C1 findings cleared in \`tests/test_chunkers_preproc_safe.py\`):
- ``_C._path_suffix(...)`` → ``_C.path_suffix(...)``
- ``_C._detect_structure(...)`` → ``_C.detect_structure(...)``

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: 0 errors
- [x] Pure-function rename, no behaviour change
- [x] No external callers (= verified via repo-wide grep, sibling \`chunkers_safe\` / \`index_events/chunkers\` keep their own private helpers)

## Test plan
- [x] \`venv/bin/pytest tests/test_chunkers_preproc_safe.py\` → 25 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)