### PR TITLE
chore(session): add router_host @property (Tier C1 cleanup wave 30)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1851,6 +1851,16 @@ class ChatSession:
         return self._agent_role
 
     @property
+    def router_host(self):
+        """Read-only accessor for the session's RouterHostAdapter.
+
+        Tests (Tier-1 protocol-compliance + Tier-2 behavioural) probe
+        the adapter via this surface. The adapter instance is set once
+        in ``__init__`` and never re-bound.
+        """
+        return self._router_host
+
+    @property
     def outbox_interceptor(self):
         """Read-only accessor for the per-session outbox interceptor.
 

--- a/src/reyn/chat/slash/plan.py
+++ b/src/reyn/chat/slash/plan.py
@@ -253,7 +253,7 @@ async def _discard_plan_run(session: "ChatSession", args: str) -> None:
 
     # 3. Delete decomposition artifact (= P5 cleanup).
     try:
-        await session._router_host.delete_plan_decomposition(plan_id=plan_id)
+        await session.router_host.delete_plan_decomposition(plan_id=plan_id)
     except Exception as exc:  # noqa: BLE001
         import logging
         logging.getLogger(__name__).warning(

--- a/tests/test_plan_chatsession_wiring.py
+++ b/tests/test_plan_chatsession_wiring.py
@@ -37,12 +37,12 @@ def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
 
 @pytest.mark.asyncio
 async def test_record_plan_started_creates_per_plan_snapshot(tmp_path, monkeypatch):
-    """Tier 2: RouterHostAdapter.record_plan_started (via session._router_host) writes the per-plan
+    """Tier 2: RouterHostAdapter.record_plan_started (via session.router_host) writes the per-plan
     snapshot file alongside the WAL append + AgentSnapshot mutation."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
 
-    await session._router_host.record_plan_started(
+    await session.router_host.record_plan_started(
         plan_id="p_test", goal="hello", n_steps=2,
     )
 
@@ -71,15 +71,15 @@ async def test_record_plan_step_completed_persists_to_snapshot(tmp_path, monkeyp
     or spilled persistence in the per-plan snapshot)."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    await session._router_host.record_plan_started(
+    await session.router_host.record_plan_started(
         plan_id="p_test", goal="g", n_steps=1,
     )
-    await session._router_host.record_plan_step_started(
+    await session.router_host.record_plan_step_started(
         plan_id="p_test", step_id="s1", depends_on=[], n_tools=0,
     )
 
     text = "step output text"
-    await session._router_host.record_plan_step_completed(
+    await session.router_host.record_plan_step_completed(
         plan_id="p_test", step_id="s1",
         content_len=len(text), result_text=text,
     )
@@ -105,11 +105,11 @@ async def test_record_plan_step_completed_spills_large_text(tmp_path, monkeypatc
 
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    await session._router_host.record_plan_started(
+    await session.router_host.record_plan_started(
         plan_id="p_big", goal="g", n_steps=1,
     )
     huge = "X" * 50_000
-    await session._router_host.record_plan_step_completed(
+    await session.router_host.record_plan_step_completed(
         plan_id="p_big", step_id="s1",
         content_len=len(huge), result_text=huge,
     )
@@ -130,14 +130,14 @@ async def test_record_plan_completed_removes_per_plan_workspace(tmp_path, monkey
 
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    await session._router_host.record_plan_started(
+    await session.router_host.record_plan_started(
         plan_id="p_done", goal="g", n_steps=1,
     )
-    await session._router_host.record_plan_step_completed(
+    await session.router_host.record_plan_step_completed(
         plan_id="p_done", step_id="s1", content_len=5, result_text="hello",
     )
 
-    await session._router_host.record_plan_completed(plan_id="p_done")
+    await session.router_host.record_plan_completed(plan_id="p_done")
 
     # Per-plan workspace dir + snapshot file gone.
     agent_state_dir = (
@@ -155,7 +155,7 @@ async def test_record_plan_aborted_removes_per_plan_workspace(tmp_path, monkeypa
 
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    await session._router_host.record_plan_started(
+    await session.router_host.record_plan_started(
         plan_id="p_abort", goal="g", n_steps=1,
     )
     agent_state_dir = (
@@ -163,7 +163,7 @@ async def test_record_plan_aborted_removes_per_plan_workspace(tmp_path, monkeypa
     )
     assert plan_snapshot_path(agent_state_dir, "p_abort").exists()
 
-    await session._router_host.record_plan_aborted(
+    await session.router_host.record_plan_aborted(
         plan_id="p_abort", reason="test",
     )
     assert not plan_snapshot_path(agent_state_dir, "p_abort").exists()

--- a/tests/test_plan_multi_plan_resume_race.py
+++ b/tests/test_plan_multi_plan_resume_race.py
@@ -126,12 +126,12 @@ async def test_two_plans_dispatched_concurrently_get_independent_snapshots(
     res1, res2 = await asyncio.gather(
         dispatch_plan_tool(
             args=_plan_args("alpha"),
-            parent_host=session._router_host, chain_id="turn_c0",
+            parent_host=session.router_host, chain_id="turn_c0",
             available_tool_names=set(),
         ),
         dispatch_plan_tool(
             args=_plan_args("beta"),
-            parent_host=session._router_host, chain_id="turn_c0",
+            parent_host=session.router_host, chain_id="turn_c0",
             available_tool_names=set(),
         ),
     )
@@ -178,12 +178,12 @@ async def test_concurrent_plans_record_distinct_step_results(
     res1, res2 = await asyncio.gather(
         dispatch_plan_tool(
             args=_plan_args("alpha", n_steps=2),
-            parent_host=session._router_host, chain_id="t0",
+            parent_host=session.router_host, chain_id="t0",
             available_tool_names=set(),
         ),
         dispatch_plan_tool(
             args=_plan_args("beta", n_steps=2),
-            parent_host=session._router_host, chain_id="t0",
+            parent_host=session.router_host, chain_id="t0",
             available_tool_names=set(),
         ),
     )
@@ -332,12 +332,12 @@ async def test_concurrent_plans_wal_events_interleave_correctly(
     res1, res2 = await asyncio.gather(
         dispatch_plan_tool(
             args=_plan_args("alpha", n_steps=2),
-            parent_host=session._router_host, chain_id="t0",
+            parent_host=session.router_host, chain_id="t0",
             available_tool_names=set(),
         ),
         dispatch_plan_tool(
             args=_plan_args("beta", n_steps=2),
-            parent_host=session._router_host, chain_id="t0",
+            parent_host=session.router_host, chain_id="t0",
             available_tool_names=set(),
         ),
     )
@@ -388,12 +388,12 @@ async def test_per_plan_chain_id_propagates_to_step_events(tmp_path, monkeypatch
     res1, res2 = await asyncio.gather(
         dispatch_plan_tool(
             args=_plan_args("alpha"),
-            parent_host=session._router_host, chain_id="t0",
+            parent_host=session.router_host, chain_id="t0",
             available_tool_names=set(),
         ),
         dispatch_plan_tool(
             args=_plan_args("beta"),
-            parent_host=session._router_host, chain_id="t0",
+            parent_host=session.router_host, chain_id="t0",
             available_tool_names=set(),
         ),
     )

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -235,9 +235,9 @@ def test_user_message_invoke_skill_e2e(tmp_path, monkeypatch):
         return result
 
     monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", fake_llm)
-    monkeypatch.setattr(session._router_host, "spawn_skill", fake_adapter_spawn_skill)
+    monkeypatch.setattr(session.router_host, "spawn_skill", fake_adapter_spawn_skill)
     monkeypatch.setattr(
-        session._router_host,
+        session.router_host,
         "list_available_skills",
         lambda: [{"name": "some_skill", "category": "general"}],
     )
@@ -338,10 +338,10 @@ def test_delegate_registers_pending_chain(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_chatsession_satisfies_host_protocol(tmp_path, monkeypatch):
-    """Tier 1: public contract — RouterHostAdapter (session._router_host) exposes all RouterLoopHost required methods and property types. Protocol compliance test; fails when required API is removed or renamed from the adapter."""
+    """Tier 1: public contract — RouterHostAdapter (session.router_host) exposes all RouterLoopHost required methods and property types. Protocol compliance test; fails when required API is removed or renamed from the adapter."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    host = session._router_host
+    host = session.router_host
 
     required = [
         "chat_id", "agent_name", "agent_role",
@@ -375,8 +375,8 @@ def test_resolve_model_uses_resolver(tmp_path, monkeypatch):
     resolver = ModelResolver({"router": "openai/gpt-4o-mini"})
     session = ChatSession(agent_name="test_agent", resolver=resolver)
 
-    assert session._router_host.resolve_model("router") == "openai/gpt-4o-mini"
-    assert session._router_host.resolve_model("unknown") == "unknown"  # pass-through
+    assert session.router_host.resolve_model("router") == "openai/gpt-4o-mini"
+    assert session.router_host.resolve_model("unknown") == "unknown"  # pass-through
 
 
 # ---------------------------------------------------------------------------
@@ -388,7 +388,7 @@ def test_list_available_skills_excludes_stdlib_router(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
 
-    skills = session._router_host.list_available_skills()
+    skills = session.router_host.list_available_skills()
     names = {s.get("name") for s in skills}
     assert "skill_router" not in names
     assert "chat_compactor" not in names


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 thirtieth slice. Single ``@property`` add + caller-scope sweep across 3 test files.

## Changes

### Production
- \`src/reyn/chat/session.py\` — ``ChatSession.router_host`` ``@property`` returning ``self._router_host``
- \`src/reyn/chat/slash/plan.py\` — 1 caller migrated to public name

### Tests (2 Tier-C1 findings + 10 caller-scope sweeps)
- \`tests/test_router_loop_chatsession.py\` — 4 sites (= 2 audit findings)
- \`tests/test_plan_multi_plan_resume_race.py\` — 8 sites (caller-scope sweep)
- \`tests/test_plan_chatsession_wiring.py\` — 2 sites (caller-scope sweep)

All ``session._router_host`` → ``session.router_host``. The adapter is set once in ``__init__`` and never re-bound, so the read-only property surface matches the underlying lifecycle.

## Pre-commit caller-scope audit
``grep -rn "session\._router_host" tests/`` → 0 hits post-fix. Per the slice-18 missed-migration lesson, sweep across the whole test suite, not just the audit-flagged file.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean on the touched files
- [x] Load-bearing invariants preserved (= identical adapter-identity semantics)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_router_loop_chatsession.py tests/test_plan_multi_plan_resume_race.py tests/test_plan_chatsession_wiring.py\` → 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)