### PR TITLE
chore(control-ir-executor): add mcp_clients @property (Tier C1 cleanup wave 32)

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -151,6 +151,16 @@ class ControlIRExecutor:
         return self._resume_plan
 
     @property
+    def mcp_clients(self) -> dict:
+        """Read-only accessor for the cached MCP client map (server name →
+        client). Tests inspect this to verify the teardown lifecycle
+        (= ``teardown_mcp_clients`` empties the dict). Production
+        callers continue to use ``self._mcp_clients`` for the write
+        side (= ops cache new clients there).
+        """
+        return self._mcp_clients
+
+    @property
     def secret_store(self):
         """Read-only accessor for the injected ScopedSecretStore (or None)."""
         return self._secret_store

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -358,10 +358,10 @@ def test_teardown_mcp_clients_empties_dict(patched_sdk):
 
         # The dict must be empty — no stale refs that could be GC-finalised
         # cross-task after this point.
-        assert not executor._mcp_clients, "_mcp_clients must be empty after teardown"
+        assert not executor.mcp_clients, "_mcp_clients must be empty after teardown"
 
         # Second call is a no-op (nothing to close, no exception).
         await executor.teardown_mcp_clients()
-        assert not executor._mcp_clients
+        assert not executor.mcp_clients
 
     asyncio.run(_run_it())


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 thirty-second slice. Single ``@property`` add for the MCP client cache.

## Changes

### Production (\`src/reyn/kernel/control_ir_executor.py\`)
- ``ControlIRExecutor.mcp_clients`` ``@property`` returning ``self._mcp_clients``.

Production callers continue to use ``self._mcp_clients`` for the write side (= ops cache new clients there). The read-only property is for tests verifying the ``teardown_mcp_clients`` lifecycle.

### Tests (2 Tier-C1 findings cleared)
- \`tests/test_mcp_client.py\`:
  - 2 ``assert not executor._mcp_clients`` → ``assert not executor.mcp_clients``

Test setup writes (``executor._mcp_clients["a"] = client``) keep the underscore — fixture state, not assertion reads.

## Tier rule self-check
- [x] Tier 2 docstrings preserved
- [x] Audit clean: 0 errors
- [x] Load-bearing invariants preserved (= identical dict identity / truthiness)
- [x] No private-state assertions added; only removed

## Test plan
- [x] \`venv/bin/pytest tests/test_mcp_client.py\` → 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)