### PR TITLE
chore(sandbox-landlock): add import_error @property (Tier C1 cleanup wave 33)

### DIFF
--- a/src/reyn/sandbox/backends/landlock.py
+++ b/src/reyn/sandbox/backends/landlock.py
@@ -57,6 +57,13 @@ class LandlockBackend:
         self._import_error: str | None = None
         self._available: bool | None = None  # cached result
 
+    @property
+    def import_error(self) -> str | None:
+        """Read-only accessor for the cached ImportError message, or None
+        if the landlock dependency was importable. Set on first
+        ``available()`` call when the import fails."""
+        return self._import_error
+
     def available(self) -> bool:
         """Return True iff Landlock is usable on this platform.
 

--- a/tests/test_sandbox_landlock.py
+++ b/tests/test_sandbox_landlock.py
@@ -50,8 +50,8 @@ def test_landlock_unavailable_when_landlock_pkg_missing(
     result = backend.available()
 
     assert result is False
-    assert backend._import_error is not None
-    assert len(backend._import_error) > 0
+    assert backend.import_error is not None
+    assert len(backend.import_error) > 0
 
 
 def test_landlock_abi_probe_caches(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 thirty-third slice. Single ``@property`` add.

## Changes
\`LandlockBackend._import_error\` captures the ImportError message when the optional \`landlock\` package fails to import on first \`available()\` call. Tests probe it to verify the graceful-degrade contract.

- \`src/reyn/sandbox/backends/landlock.py\` — add \`import_error\` ``@property``
- \`tests/test_sandbox_landlock.py\` — 2 ``backend._import_error\` → ``backend.import_error``

## Tier rule self-check
- [x] Audit clean
- [x] Production write side unchanged
- [x] 6 passed / 2 skipped (= optional landlock not installed on this platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)