### PR TITLE
chore(action-index): rename db_path property public (Tier C1 cleanup wave 34)

### DIFF
--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -240,7 +240,7 @@ class ActionEmbeddingIndex:
     # ── SQLite persistence helpers (Phase 2 step 2) ───────────────────────
 
     @property
-    def _db_path(self) -> Path | None:
+    def db_path(self) -> Path | None:
         if self._persist_dir is None:
             return None
         return self._persist_dir / "index.db"
@@ -265,7 +265,7 @@ class ActionEmbeddingIndex:
 
         Caller MUST hold ``_build_lock``.
         """
-        db_path = self._db_path
+        db_path = self.db_path
         if db_path is None or not db_path.exists():
             return False
         try:
@@ -317,7 +317,7 @@ class ActionEmbeddingIndex:
 
         Caller MUST hold ``_build_lock``.
         """
-        db_path = self._db_path
+        db_path = self.db_path
         if db_path is None or self._catalog_hash is None:
             return
         try:

--- a/tests/test_action_embedding_index.py
+++ b/tests/test_action_embedding_index.py
@@ -381,4 +381,4 @@ def test_no_persist_dir_no_file_created(tmp_path: "Path") -> None:
     idx = ActionEmbeddingIndex(persist_dir=None)
     _run(idx.build(items, _FakeEmbeddingProvider(), "standard"))
     assert idx.is_ready() is True
-    assert idx._db_path is None
+    assert idx.db_path is None


### PR DESCRIPTION
**[dogfood-coder]** — Tier C1 cleanup sweep batch P1 thirty-fourth slice. Property-name rename.

\`ActionEmbeddingIndex\` already exposed \`_db_path\` as a \`@property\`. Drop the underscore so tests + production resolve to the public name. Pure path-computation with stable semantics.

- \`src/reyn/tools/action_index.py\` — \`def _db_path\` → \`def db_path\` + 2 in-class callers
- \`tests/test_action_embedding_index.py\` — 1 reference

18 tests passed. Audit clean.