### PR TITLE
fix(fp-0008): propagate shell_allowed + permission_resolver in eval benchmark

### DIFF
--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -63,6 +63,24 @@ def register_benchmark(eval_sub) -> None:
         "--model", default=None, metavar="MODEL",
         help="Model override (default: from reyn.yaml)",
     )
+    p.add_argument(
+        "--allow-shell", dest="allow_shell", action="store_true",
+        help=(
+            "Enable the 'shell' Control IR op for every task in this batch. "
+            "Required when the target skill declares `permissions.shell: true` "
+            "(e.g. `swe_bench`, which checks out repos + runs tests). "
+            "Off by default for safety; matches `reyn run --allow-shell`."
+        ),
+    )
+    p.add_argument(
+        "--allow-unsafe-python", "--allow-untrusted-python",
+        dest="allow_unsafe_python", action="store_true",
+        help=(
+            "Enable unsafe-mode Python preprocessor steps (no AST sandboxing) "
+            "for every task in this batch. Safe-mode python steps run without "
+            "this flag. Off by default; matches `reyn run --allow-unsafe-python`."
+        ),
+    )
 
 
 def run_benchmark(args: argparse.Namespace) -> None:
@@ -220,8 +238,22 @@ async def _run_single_task(
     session,
     run_dir: Path,
     semaphore: asyncio.Semaphore,
+    shell_allowed: bool = False,
+    permission_resolver=None,
+    python_allowed_modules: list[str] | None = None,
 ) -> dict:
-    """Run a single task under the semaphore; return a result record."""
+    """Run a single task under the semaphore; return a result record.
+
+    ``shell_allowed`` + ``permission_resolver`` are derived once at batch
+    start (= from ``--allow-shell`` / ``--allow-unsafe-python`` + the
+    skill's declared permissions) and threaded through every task so the
+    Agent's op_catalog exposes the shell op uniformly. Without this, the
+    LLM doesn't see ``shell`` in the catalog and hallucinates a fake
+    schema (= ``{kind: "shell", op: "run", command: ...}`` vs the real
+    ``{kind: "shell", cmd: ...}``), every retry hits the validator, the
+    batch reports $0.00 cost + 100% error rate. See PR-D follow-up to PR-B
+    (= FP-0008 sandbox_2 calibration block 2026-05-28).
+    """
     from reyn.agent import Agent
     from reyn.config import _find_project_root, load_project_context
     from reyn.user_intervention import StdinInterventionBus
@@ -242,6 +274,10 @@ async def _run_single_task(
             resolver=session.resolver,
             intervention_bus=StdinInterventionBus(),
             safety=session.safety_for(argparse.Namespace()),
+            shell_allowed=shell_allowed,
+            permission_resolver=permission_resolver,
+            python_allowed_modules=python_allowed_modules or list(session.config.python.allowed_modules),
+            mcp_servers=session.config.mcp,
             prompt_cache_enabled=session.config.prompt_cache_enabled,
             project_context=project_context,
             caller="direct",
@@ -314,6 +350,17 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
 
     session = session_mod.Session.from_args(args)
     model = getattr(args, "model", None) or session.config.model
+
+    # Derive shell_allowed + permission_resolver once at batch start (= mirrors
+    # `reyn run`'s pattern in cli/commands/run.py). Without this, the Agent's
+    # OS runtime keeps `shell` out of the op_catalog and the LLM hallucinates
+    # a fake schema on every retry — see _run_single_task docstring.
+    shell_allowed = session.shell_allowed_for(args)
+    unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
+    from reyn.cli.commands.run import _build_permission_resolver
+    perm_resolver = _build_permission_resolver(
+        session.config, shell_allowed, unsafe_python=unsafe_python,
+    )
 
     # Load tasks
     tasks_path = Path(args.tasks)
@@ -388,6 +435,8 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
                 session=session,
                 run_dir=run_dir,
                 semaphore=semaphore,
+                shell_allowed=shell_allowed,
+                permission_resolver=perm_resolver,
             )
         except Exception as exc:
             # A task failure never aborts the batch — log and record the error.

--- a/tests/test_eval_benchmark_cli.py
+++ b/tests/test_eval_benchmark_cli.py
@@ -38,6 +38,8 @@ def _make_benchmark_args(
     limit: int | None = None,
     resume: bool = False,
     model: str | None = None,
+    allow_shell: bool = False,
+    allow_unsafe_python: bool = False,
 ) -> argparse.Namespace:
     ns = argparse.Namespace()
     ns.skill_name = skill_name
@@ -47,6 +49,8 @@ def _make_benchmark_args(
     ns.limit = limit
     ns.resume = resume
     ns.model = model
+    ns.allow_shell = allow_shell
+    ns.allow_unsafe_python = allow_unsafe_python
     ns.eval_cmd = "benchmark"
     return ns
 
@@ -143,6 +147,45 @@ def test_benchmark_parses() -> None:
     assert args.concurrency == 8
     assert args.limit == 50
     assert args.resume is True
+    # Permission-flag defaults (= off, matching reyn run)
+    assert args.allow_shell is False
+    assert args.allow_unsafe_python is False
+
+
+def test_benchmark_parses_allow_flags() -> None:
+    """Tier 2: '--allow-shell' + '--allow-unsafe-python' flags parse correctly.
+
+    Pins the parity with ``reyn run``'s permission flags (= PR-D follow-up
+    to PR-B, FP-0008 2026-05-28 calibration block). Without these flags,
+    skills like ``swe_bench`` that declare ``permissions.shell: true``
+    can't actually execute shell ops in batch mode.
+    """
+    from reyn.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "eval", "benchmark", "swe_bench",
+        "--tasks", "tasks.jsonl",
+        "--output", "results/",
+        "--allow-shell",
+        "--allow-unsafe-python",
+    ])
+    assert args.allow_shell is True
+    assert args.allow_unsafe_python is True
+
+
+def test_benchmark_parses_legacy_unsafe_python_alias() -> None:
+    """Tier 2: legacy '--allow-untrusted-python' alias still parses (parity with reyn run)."""
+    from reyn.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "eval", "benchmark", "my_skill",
+        "--tasks", "tasks.jsonl",
+        "--output", "results/",
+        "--allow-untrusted-python",
+    ])
+    assert args.allow_unsafe_python is True
 
 
 # ── test 2: load_tasks valid ──────────────────────────────────────────────────
@@ -380,7 +423,8 @@ def test_single_task_failure_no_abort(
     call_count = 0
 
     async def _stub_run_single_task(
-        task, instance_id, skill, skill_root, model, session, run_dir, semaphore
+        task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
+        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
     ):
         nonlocal call_count
         async with semaphore:
@@ -427,3 +471,98 @@ def test_single_task_failure_no_abort(
     )
     # Find the error entry for t1 in completed_ids (it's still in the list)
     assert "t1" in data.get("completed_ids", []), "t1 must be tracked even when it errored"
+
+
+# ── test 12: --allow-shell propagates to per-task runner ──────────────────────
+
+
+def test_allow_shell_propagates_to_single_task(
+    benchmark_workspace, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Tier 2: --allow-shell flag reaches _run_single_task as ``shell_allowed=True``.
+
+    Pins the FP-0008 PR-D fix (= 2026-05-28 calibration block root cause).
+    Without the propagation, the Agent's op_catalog omits shell + the LLM
+    hallucinates a fake shell schema → every retry fails → batch reports
+    100% error with $0.00 cost.
+
+    Verifies the wiring at the per-task layer: when ``--allow-shell`` is
+    set on the namespace, ``_run_single_task`` is called with
+    ``shell_allowed=True``. The reverse (= flag absent → ``shell_allowed=False``)
+    is the default-off path.
+    """
+    # Override the stub Session to honor the actual allow_shell flag
+    # (= the workspace fixture defaults to always-False; we want truth-following)
+    from reyn.cli import session as session_mod
+    from reyn.cli.commands import eval_benchmark as bm
+    from reyn.config import ReynConfig, SafetyConfig
+    from reyn.llm.model_resolver import ModelResolver
+
+    class _TruthfulSession:
+        config = ReynConfig()
+        resolver = ModelResolver({})
+
+        @classmethod
+        def from_args(cls, _args):
+            return cls()
+
+        def model_for(self, args):
+            return "standard", "standard"
+
+        def output_language_for(self, args):
+            return None
+
+        def safety_for(self, args):
+            return SafetyConfig()
+
+        def shell_allowed_for(self, args):
+            return bool(getattr(args, "allow_shell", False))
+
+    monkeypatch.setattr(session_mod, "Session", _TruthfulSession)
+
+    captured: dict = {}
+
+    async def _capture_shell_allowed(
+        task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
+        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
+    ):
+        async with semaphore:
+            captured["shell_allowed"] = shell_allowed
+            captured["permission_resolver_built"] = permission_resolver is not None
+            return {"instance_id": instance_id, "cost_usd": 0.0}
+
+    monkeypatch.setattr(bm, "_run_single_task", _capture_shell_allowed)
+
+    tasks_path = benchmark_workspace.write_tasks([{"instance_id": "t1"}])
+    output_dir = tmp_path / "bench_output_shell"
+
+    # Case A: --allow-shell set → shell_allowed=True reaches the runner
+    args_on = _make_benchmark_args(
+        skill_name="test_skill",
+        tasks_path=str(tasks_path),
+        output_dir=str(output_dir),
+        concurrency=1,
+        allow_shell=True,
+    )
+    asyncio.run(bm._run_benchmark_async(args_on))
+    assert captured["shell_allowed"] is True, (
+        "Expected shell_allowed=True to reach _run_single_task when --allow-shell is set"
+    )
+    assert captured["permission_resolver_built"] is True, (
+        "Expected a non-None permission_resolver to be built when --allow-shell is set"
+    )
+
+    # Case B: --allow-shell absent → shell_allowed=False is the default
+    captured.clear()
+    output_dir_b = tmp_path / "bench_output_no_shell"
+    args_off = _make_benchmark_args(
+        skill_name="test_skill",
+        tasks_path=str(tasks_path),
+        output_dir=str(output_dir_b),
+        concurrency=1,
+        allow_shell=False,
+    )
+    asyncio.run(bm._run_benchmark_async(args_off))
+    assert captured["shell_allowed"] is False, (
+        "Expected shell_allowed=False when --allow-shell is not set"
+    )


### PR DESCRIPTION
**[e2e-coder]** — PR-D follow-up to PR-B #976. Root-cause fix for the 2026-05-28 sandbox_2 calibration block on `reyn eval benchmark swe_bench`.

## Summary

`reyn eval benchmark` shipped without forwarding `shell_allowed` / `permission_resolver` / `python_allowed_modules` / `mcp_servers` to the per-task `Agent` constructor. Skills declaring `permissions.shell: true` (= `swe_bench`) therefore saw NO shell entry in `op_catalog`: the LLM had no real schema, hallucinated a fake shape (`{kind:"shell", op:"run", command:"..."}` vs the real `{kind:"shell", cmd:"..."}`), and every 3-retry cycle failed validator + accumulated $0.00 cost + 100% error rate.

Primary-evidence-backed (= llm_trace.jsonl inspection per [[feedback_dogfood_trace_obligation]]) report from sandbox_2 dogfood env:
> LLM emits `{kind:"shell", op:"run", command:"..."}`; validator rejects `shell.cmd required`. op_catalog confirmed shell-entry-absent in user-prompt section.

## Fix shape

Bring `reyn eval benchmark` to parity with `reyn run`'s permission-derivation pattern:

- Add `--allow-shell` + `--allow-unsafe-python` (+ legacy alias `--allow-untrusted-python`) flags. Defaults off (matches `reyn run`).
- Derive `shell_allowed` once at batch start via `session.shell_allowed_for(args)`.
- Build permission resolver via `_build_permission_resolver(config, shell_allowed, unsafe_python=...)` once, share across per-task `Agent`s.
- `_run_single_task` accepts new kwargs + threads them through to `Agent(shell_allowed=..., permission_resolver=..., python_allowed_modules=..., mcp_servers=...)`.

The docstring on `_run_single_task` captures the hallucination failure mode so the why is preserved at the call site.

## Test plan

- [x] `pytest -q tests/test_eval_benchmark_cli.py` → **14/14 pass** (11 existing + 3 new).
- [x] `ruff check src/reyn/cli/commands/eval_benchmark.py tests/test_eval_benchmark_cli.py` → clean.
- [x] **Tier rule self-check** (= [[feedback_pr_tier_rule_self_check]]):
   - docstrings: every new test opens with `"""Tier 2:` ✓
   - no Mock / AsyncMock / MagicMock / patch ✓ (= existing test file already complied + new tests added the same way)
   - no private-state assertions ✓
   - no format-pinning ✓

## Files changed

- `src/reyn/cli/commands/eval_benchmark.py` — `register_benchmark` adds 2 flags; `_run_benchmark_async` derives `shell_allowed` + `perm_resolver` once; `_run_single_task` accepts + threads through to `Agent(...)`.
- `tests/test_eval_benchmark_cli.py`:
  - `test_benchmark_parses` extended (default-off assertions for new flags)
  - NEW `test_benchmark_parses_allow_flags` — both flags reach `args`
  - NEW `test_benchmark_parses_legacy_unsafe_python_alias` — legacy `--allow-untrusted-python` still parses
  - NEW `test_allow_shell_propagates_to_single_task` — end-to-end wiring: `--allow-shell` → Session → `_run_single_task(shell_allowed=True, permission_resolver=non-None)` + the inverse case (= default off)

## Sandbox_2 next step

Once merged, sandbox_2 re-runs the 10-instance calibration with `reyn eval benchmark swe_bench --allow-shell --tasks subset_10.jsonl --output results/ --limit 10`. Expected outcome: cost > $0, LLM-emitted shell ops match the real `ShellIROp.cmd` schema, validator pass.

Refs FP-0008 #9 (= closed, this is PR-B follow-up). Refs PR-B #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)