### PR TITLE
fix(op-catalog): positive-frame Tier-3 op descriptions (drop runtime-irrelevant caveat)

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -214,10 +214,9 @@ class ControlIRExecutor:
                     "timeout: max seconds to wait (default 120). "
                     "Runs in the project root directory. "
                     "Use for running sub-processes such as 'reyn run ...'. "
-                    "Tier 3 op (declared + approved): when adding 'shell' to phase.allowed_ops, "
-                    "skill.permissions.shell must also be set to true "
-                    "(OS rejects at runtime with PermissionError if undeclared, "
-                    "even when phase allows)."
+                    "Status: enabled — this op's presence in op_catalog means "
+                    "shell permission is verified for this phase. Issue shell "
+                    "ops directly; do not abort on permission concerns."
                 ),
                 example={"kind": "shell", "cmd": "reyn run my_skill 'hello'", "timeout": 120},
             )] if self._shell_allowed else []),
@@ -229,10 +228,9 @@ class ControlIRExecutor:
                     "tool: the tool name exposed by that server. "
                     "args: arguments dict to pass to the tool. "
                     "Returns: content (text), raw (full MCP result). "
-                    "Tier 2 op (declared + approved): when adding 'mcp' to phase.allowed_ops, "
-                    "skill.permissions.mcp must also list the server name "
-                    "(OS rejects at runtime with PermissionError if undeclared, "
-                    "even when phase allows)."
+                    "Status: enabled — this op's presence in op_catalog means "
+                    "mcp permission is verified for this phase. Issue mcp ops "
+                    "directly; do not abort on permission concerns."
                 ),
                 example={"kind": "mcp", "server": "my_tool", "tool": "search", "args": {"query": "hello"}},
             )] if self._mcp_servers else []),

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -24,11 +24,9 @@ _MCP_INSTALL_DESCRIPTION = (
     "Fetches server.json, gates via permission resolver, "
     "prompts for secrets, and writes the server entry to the "
     "appropriate scope config file (local / project / user). "
-    "Tier 3 op (declared + approved): when adding 'mcp_install' to phase.allowed_ops, "
-    "skill.permissions must declare `file.write: [{path: .reyn/mcp.yaml}]` "
-    "and `http.get: [{host: registry.modelcontextprotocol.io}]` "
-    "(OS rejects at runtime with PermissionError if undeclared, "
-    "even when phase allows)."
+    "Status: enabled — this tool's presence in your tool list means "
+    "the required `file.write` and `http.get` permissions are verified. "
+    "Call mcp_install directly; do not abort on permission concerns."
 )
 
 _MCP_INSTALL_PARAMETERS: dict[str, Any] = {

--- a/tests/test_tier3_op_description_positive_frame.py
+++ b/tests/test_tier3_op_description_positive_frame.py
@@ -1,0 +1,167 @@
+"""Tier 2: positive-frame invariant for Tier-3 op descriptions in op_catalog.
+
+When the OS exposes a Tier-3 op (= ``shell`` / ``mcp`` / ``mcp_install``,
+etc.) in the LLM-visible op_catalog, its presence in the catalog already
+means the precondition (= permission declared + caller-side enabled)
+has been satisfied. The op's ``description`` field is read at runtime
+by the LLM, NOT by skill authors — so it must NOT describe failure
+modes the LLM cannot actually trigger from the current state.
+
+Empirical precedent (FP-0008 sandbox_2 2026-05-28 calibration retry):
+the previous shell op description carried a "Tier 3 op (declared +
+approved): ... OS rejects at runtime with PermissionError if
+undeclared" caveat. Even though the caveat described a state the LLM
+could never reach (= the catalog visibility itself was the affirmation
+that the permission was declared), a small / cheap LLM read the
+caveat as a runtime warning, generated an ``abort`` artifact with
+confidence 1.0, and returned a synthetic "permissions.shell: true is
+required" reason — without ever attempting to issue the shell op.
+All 10 SWE-bench calibration instances aborted at the setup phase.
+
+The fix: replace the runtime-irrelevant caveat with a positive-frame
+``Status: enabled — ... do not abort on permission concerns`` clause.
+This test pins the invariant so future op-description authors don't
+re-introduce the same misleading caveat shape.
+
+Specifically:
+  1. ``shell`` op description (= when ``shell_allowed=True``) is
+     positive-frame: no "OS rejects" / "PermissionError if undeclared"
+     phrasing.
+  2. ``mcp`` op description (= when ``mcp_servers`` non-empty) is
+     positive-frame: same anti-pattern check.
+  3. ``mcp_install`` tool description (= different module path, same
+     class of misleading caveat) is positive-frame.
+
+The rule is **negative** (= no banned phrases), not positive (= no
+required exact wording), so authors can rewrite the affirmation
+freely as long as they don't re-add the failure-mode caveat.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_NEGATIVE_PHRASES = (
+    "OS rejects at runtime",
+    "PermissionError if undeclared",
+    "must also be set to true",
+    "(declared + approved)",
+)
+
+
+def _assert_no_misleading_caveat(description: str, op_name: str) -> None:
+    """Helper: every negative phrase must be absent from the description."""
+    for phrase in _NEGATIVE_PHRASES:
+        assert phrase not in description, (
+            f"{op_name} description re-introduces the misleading caveat "
+            f"phrase {phrase!r} — see "
+            f"tests/test_tier3_op_description_positive_frame.py for the "
+            f"rationale (FP-0008 sandbox_2 2026-05-28 retry precedent)."
+        )
+
+
+def _build_executor(
+    tmp_path: Path,
+    *,
+    shell_allowed: bool = False,
+    mcp_servers: dict | None = None,
+):
+    """Construct a minimal ControlIRExecutor under tmp_path (no global state)."""
+    import os
+
+    from reyn.events.events import EventLog
+    from reyn.kernel.control_ir_executor import ControlIRExecutor
+    from reyn.workspace.workspace import Workspace
+
+    os.chdir(tmp_path)  # Workspace anchors to CWD; isolate to tmp
+    events = EventLog()
+    workspace = Workspace(events=events)
+    return ControlIRExecutor(
+        workspace=workspace,
+        events=events,
+        shell_allowed=shell_allowed,
+        mcp_servers=mcp_servers,
+    )
+
+
+def test_shell_op_description_is_positive_frame(tmp_path: Path) -> None:
+    """Tier 2: shell op description (when enabled) has no failure-mode caveat."""
+    executor = _build_executor(tmp_path, shell_allowed=True)
+    specs = executor.available_ops()
+    shell_specs = [s for s in specs if s.kind == "shell"]
+    assert len(shell_specs) == 1, (
+        f"Expected exactly one shell op spec when shell_allowed=True; "
+        f"got {len(shell_specs)}"
+    )
+    _assert_no_misleading_caveat(shell_specs[0].description, "shell")
+
+
+def test_shell_op_description_carries_positive_affirmation(tmp_path: Path) -> None:
+    """Tier 2: shell op description names its enabled status explicitly.
+
+    Without an affirmative "Status: enabled" / "verified" / similar
+    marker, a small LLM defaults to "permission not declared" defensive
+    abort. The positive frame is the structural fix.
+    """
+    executor = _build_executor(tmp_path, shell_allowed=True)
+    shell_specs = [s for s in executor.available_ops() if s.kind == "shell"]
+    description = shell_specs[0].description.lower()
+    affirmation_words = ("enabled", "verified", "available")
+    assert any(w in description for w in affirmation_words), (
+        f"shell op description should carry an affirmative marker "
+        f"(one of {affirmation_words}); got: {shell_specs[0].description!r}"
+    )
+
+
+def test_mcp_op_description_is_positive_frame(tmp_path: Path) -> None:
+    """Tier 2: mcp op description (when servers configured) has no failure-mode caveat."""
+    # mcp_servers shape: ControlIRExecutor.__init__ reads .get("servers", {}),
+    # so the canonical input is {"servers": {<name>: <config>}}.
+    executor = _build_executor(
+        tmp_path,
+        mcp_servers={"servers": {"github": {"transport": "stdio"}}},
+    )
+    mcp_specs = [s for s in executor.available_ops() if s.kind == "mcp"]
+    assert len(mcp_specs) == 1, (
+        f"Expected exactly one mcp op spec when mcp_servers is non-empty; "
+        f"got {len(mcp_specs)}"
+    )
+    _assert_no_misleading_caveat(mcp_specs[0].description, "mcp")
+
+
+def test_mcp_install_tool_description_is_positive_frame() -> None:
+    """Tier 2: mcp_install tool description has no failure-mode caveat.
+
+    Lives in ``src/reyn/tools/mcp_install.py`` (= different module than
+    the control_ir_executor specs), but exhibits the same anti-pattern.
+    Per [[feedback_schema_exposure_surface_audit]], all surfaces with
+    the same shape get fixed together.
+    """
+    from reyn.tools.mcp_install import _MCP_INSTALL_DESCRIPTION
+
+    _assert_no_misleading_caveat(_MCP_INSTALL_DESCRIPTION, "mcp_install")
+
+
+def test_no_tier3_op_uses_skill_author_phrasing(tmp_path: Path) -> None:
+    """Tier 2: no Tier-3 op description carries skill-author-doc phrasing.
+
+    "phase.allowed_ops" / "skill.permissions" / similar config-name
+    references belong in skill-author docs (= docs/reference/dsl/),
+    NOT in the runtime op_catalog the LLM reads. This test catches a
+    broader class of "wrong-audience phrasing" than the negative-phrase
+    list above.
+    """
+    executor = _build_executor(
+        tmp_path,
+        shell_allowed=True,
+        mcp_servers={"servers": {"x": {"transport": "stdio"}}},
+    )
+    skill_author_phrases = ("phase.allowed_ops", "skill.permissions")
+    for spec in executor.available_ops():
+        for phrase in skill_author_phrases:
+            assert phrase not in spec.description, (
+                f"Op {spec.kind!r} description carries skill-author "
+                f"phrasing {phrase!r} that is wrong-audience for the "
+                f"runtime LLM. Reword as a runtime affirmation."
+            )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 sandbox_2 calibration retry root-cause fix (2026-05-28). All 10 SWE-bench instances aborted at the setup phase because the shell op description in op_catalog carried a runtime-irrelevant caveat that a small LLM read as a runtime warning.

## Primary evidence (sandbox_2 trace + OS code verified)

Per [[feedback_peer_broker_articulate_verify_obligation]], verified the claim before acting:

- **OS code** (`src/reyn/kernel/control_ir_executor.py:209-223`): shell op is conditionally added to specs ONLY when `self._shell_allowed=True`. The catalog visibility itself IS the affirmation. The "Tier 3 op (declared + approved): ... OS rejects at runtime" caveat in the description describes an unreachable state from the LLM's vantage point.
- **LLM trace** (sandbox_2 llm_trace_full.jsonl): `control.type=abort`, `confidence=1.0`, `data.reason: "Shell access is not declared in skill permissions ... Please add 'permissions:\n  shell: true' to the skill.md frontmatter."` — the LLM converted *absence of an affirmation* into "not declared", aborted defensively without ever issuing the shell op.
- **Audit (per [[feedback_schema_exposure_surface_audit]])**: same anti-pattern at 3 sites total — shell + mcp in `control_ir_executor.py`, mcp_install in `tools/mcp_install.py`. All 3 converted in one PR.

## Fix shape (root-fix-strict, per [[feedback_no_compromise_recommendation]])

Replace the caveat with positive-frame affirmation:

> "Status: enabled — this op's presence in op_catalog means <op-name> permission is verified for this phase. Issue <op-name> ops directly; do not abort on permission concerns."

Same audience (= runtime LLM), accurate framing (= reflects actual state, not unreachable failure mode).

## Why not a "skill SP / instruction" band-aid

Per [[feedback_sp_modification_forbidden_without_malfunction]]: SP modification requires LLM-malfunction evidence. We have it. Per [[feedback_thesis_aligned_decisions]]: structural fix first. The misleading caveat IS the structural defect; removing it IS the structural fix. Skill-level band-aids (= "add to setup.md: 'shell op available, don't abort'") would leave the defect for the next caller / phase / skill to hit.

## Test plan

- [x] `pytest -q tests/test_tier3_op_description_positive_frame.py` → **5/5 pass** (new invariant)
- [x] `pytest -q tests/test_control_ir_executor.py tests/test_shell_unified.py tests/test_mcp_client.py` → **36/36 pass** (no regressions on adjacent surface)
- [x] `ruff check src/reyn/kernel/control_ir_executor.py src/reyn/tools/mcp_install.py tests/test_tier3_op_description_positive_frame.py` → All checks passed
- [x] **Tier rule self-check** ([[feedback_pr_tier_rule_self_check]]):
   - test docstrings start with `"""Tier 2:` ✓
   - no Mock / AsyncMock / MagicMock / patch ✓
   - no private-state assertions ✓ (`grep -nE 'assert .*\._[a-z_]+' tests/test_tier3_op_description_positive_frame.py` → empty)
   - no format-pinning ✓ (= assertions check phrase presence/absence + semantic affirmation-word membership, not exact whitespace)

## Files changed (3)

- `src/reyn/kernel/control_ir_executor.py` — shell + mcp op description rewritten
- `src/reyn/tools/mcp_install.py` — mcp_install tool description rewritten
- `tests/test_tier3_op_description_positive_frame.py` (NEW) — 5 Tier-2 invariant tests (= negative phrase audit + positive affirmation check + skill-author-phrasing audit)

## Follow-up

After this lands, sandbox_2 retries the 10-instance SWE-bench calibration. Expected outcome: LLM issues shell ops directly + we get real cost / pass_rate data.

Refs FP-0008 PR-D #995. Refs issue #997 (= cross-cutting Tier-3 op exposure invariant — this PR addresses one specific surface within that broader concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)