### PR TITLE
fix(test-audit): unpack-enforcement for Tier-3 op spec uniqueness (PR #1000 audit fix)

### DIFF
--- a/tests/test_tier3_op_description_positive_frame.py
+++ b/tests/test_tier3_op_description_positive_frame.py
@@ -90,11 +90,11 @@ def test_shell_op_description_is_positive_frame(tmp_path: Path) -> None:
     executor = _build_executor(tmp_path, shell_allowed=True)
     specs = executor.available_ops()
     shell_specs = [s for s in specs if s.kind == "shell"]
-    assert len(shell_specs) == 1, (
-        f"Expected exactly one shell op spec when shell_allowed=True; "
-        f"got {len(shell_specs)}"
-    )
-    _assert_no_misleading_caveat(shell_specs[0].description, "shell")
+    # unpack-enforcement (= behavior pin, not size pin): raises
+    # ValueError when shell_specs has != 1 element. Caught by the
+    # test framework with a clear message.
+    (shell_spec,) = shell_specs
+    _assert_no_misleading_caveat(shell_spec.description, "shell")
 
 
 def test_shell_op_description_carries_positive_affirmation(tmp_path: Path) -> None:
@@ -123,11 +123,9 @@ def test_mcp_op_description_is_positive_frame(tmp_path: Path) -> None:
         mcp_servers={"servers": {"github": {"transport": "stdio"}}},
     )
     mcp_specs = [s for s in executor.available_ops() if s.kind == "mcp"]
-    assert len(mcp_specs) == 1, (
-        f"Expected exactly one mcp op spec when mcp_servers is non-empty; "
-        f"got {len(mcp_specs)}"
-    )
-    _assert_no_misleading_caveat(mcp_specs[0].description, "mcp")
+    # unpack-enforcement (= behavior pin, not size pin)
+    (mcp_spec,) = mcp_specs
+    _assert_no_misleading_caveat(mcp_spec.description, "mcp")
 
 
 def test_mcp_install_tool_description_is_positive_frame() -> None:


### PR DESCRIPTION
**[e2e-coder]** — PR #1000 audit-violation fix, urgent (= blocking #1001 + #1003 merge).

## Primary evidence (verified per [[feedback_peer_broker_articulate_verify_obligation]])

`python3 scripts/test_tier_audit.py --strict tests/test_tier3_op_description_positive_frame.py` on main:

```
✗ test_shell_op_description_is_positive_frame
    line 93: format pinning: len(shell_specs) == 1
✗ test_mcp_op_description_is_positive_frame
    line 126: format pinning: len(mcp_specs) == 1
Summary: 5 tests / errors: 2 / Exit code: 1
```

## Root cause

PR #1000 shipped 2 `assert len(X) == 1` direct asserts. Audit script flags as Tier-4 format-pinning. My own [[feedback_pr_tier_rule_self_check]] discipline missed this because I only ran `pytest` + `ruff`, not `scripts/test_tier_audit.py --strict`. Will add audit script to my pre-PR-push checklist.

## Fix shape (α — unpack-enforcement, lead-coder strict-ideal pick)

```python
# Before (Tier-4 violation)
assert len(shell_specs) == 1, "..."

# After (canonical idiom, behavior pin not size pin)
(shell_spec,) = shell_specs   # ValueError on mismatch — same semantics
```

Same behavior (= ValueError raised when count != 1), no size literal in the assertion. Per the audit script's canonical-idiom allow-list.

## Test plan

- [x] `python3 scripts/test_tier_audit.py --strict tests/test_tier3_op_description_positive_frame.py` → **5/5 OK / 0 errors / exit 0**
- [x] `pytest -q tests/test_tier3_op_description_positive_frame.py` → **5/5 pass** (no behavior change)
- [x] Tier rule self-check + audit script clean ✓

## Files changed (1)

- `tests/test_tier3_op_description_positive_frame.py` — 2 sites converted (= +8 / -10)

Unblocks PR #1001 (tui-coder Tier C2/C3 wiring) + PR #1003 (FP-0037 S2). Refs PR #1000 (= introduced the format-pin in the same wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)