### PR TITLE
feat(fp-0008): PR-F — swe_bench skill defect fixes (placeholder + schema invariant)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_result.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_result.yaml
@@ -8,7 +8,7 @@ schema:
       description: The SWE-bench instance identifier, carried through from the input.
     patch:
       type: string
-      description: The unified diff produced by `git diff HEAD` after all edits. Empty string if no changes were made.
+      description: The unified diff produced by `git diff HEAD` after all edits. Empty string ONLY when tests_passed is also false (= no-op completion); validation rejects tests_passed=true + patch="" combinations.
     tests_passed:
       type: boolean
       description: True if all test_patch tests passed in the final verify phase; false otherwise.
@@ -21,3 +21,16 @@ schema:
     - patch
     - tests_passed
     - attempts
+  # FP-0008 PR-F: forbid tests_passed=true + patch="" (= LLM-confabulated
+  # pass with no actual edits, observed in sandbox_2 v4 calibration retry
+  # astropy-14309 false-positive). When tests_passed is true, the patch
+  # MUST be non-empty (= at least one byte of diff content).
+  oneOf:
+    - properties:
+        tests_passed:
+          const: false
+    - properties:
+        tests_passed:
+          const: true
+        patch:
+          minLength: 1

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -35,6 +35,11 @@ Collect the following from the input and the diff output:
 - `tests_passed`: from `verify_state.tests_passed`
 - `attempts`: from `verify_state.attempt`
 
+**Validation contract**: `swe_bench_result` enforces that `tests_passed=true`
+ONLY when `patch` is non-empty. If `git diff HEAD` produced an empty patch
+(= no code changes were made by the apply phase), set `tests_passed=false`
+— an empty-patch "pass" is a no-op submission and the schema rejects it.
+
 ## When to finish
 
 After the diff is captured, finish the skill by emitting `swe_bench_result`

--- a/src/reyn/stdlib/skills/swe_bench/phases/setup.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/setup.md
@@ -12,14 +12,25 @@ SWE-bench harness requires.
 
 ## Step 1 — Check out base_commit
 
-Issue a shell op to run:
+The input artifact (`swe_bench_input`) carries a `base_commit` field whose
+value is a git commit SHA (e.g. `"d16bfe05a744909de4b27f5875fe0d4ed41ce607"`).
 
-```
-git checkout <base_commit>
+Issue a shell op whose `cmd` is the literal command **with the SHA value
+substituted in**. For example, when `base_commit` is
+`"d16bfe05a744909de4b27f5875fe0d4ed41ce607"`, the shell op must look like:
+
+```json
+{"kind": "shell", "cmd": "git checkout d16bfe05a744909de4b27f5875fe0d4ed41ce607"}
 ```
 
-where `<base_commit>` is the value from the input artifact.  If the checkout
-fails (non-zero exit code), abort with a clear message explaining the failure.
+**Critical**: do NOT emit a literal placeholder like `git checkout <base_commit>` —
+that is template-style notation for documentation, not a runnable command. The
+shell op's `cmd` field must contain the actual SHA, not the `<base_commit>`
+placeholder. Read the SHA from the input artifact and inline it into the cmd
+string.
+
+If the checkout fails (non-zero exit code), abort with a clear message
+explaining the failure.
 
 ## Step 2 — Confirm the working tree is clean
 

--- a/tests/test_swe_bench_skill_pr_f_defects.py
+++ b/tests/test_swe_bench_skill_pr_f_defects.py
@@ -1,0 +1,152 @@
+"""Tier 2: FP-0008 PR-F -- swe_bench skill defect fixes.
+
+Two defects surfaced by sandbox_2 v4 calibration retry (2026-05-28):
+
+1. Placeholder substitution failure -- original setup.md said
+   git checkout <base_commit>, which weak LLMs (gemini-2.5-
+   flash-lite) emitted as the LITERAL shell cmd string instead of
+   substituting the actual SHA value from the input artifact.
+   2 of 5 abort instances in v4 retry hit this.
+
+2. Schema invariant gap -- swe_bench_result schema allowed
+   tests_passed=true with an empty patch (no edits). v4 retrys
+   astropy-14309 finished with that combo, producing a false-positive
+   pass_rate of 1/10 masking the true 0/10 outcome.
+
+This file pins:
+  (a) setup.md instruction includes an explicit substitute-the-SHA
+      directive.
+  (b) setup.md shows a concrete hex-SHA example next to git checkout.
+  (c) swe_bench_result schema has a oneOf constraint that rejects
+      tests_passed=true with an empty patch.
+  (d) swe_bench_result schema accepts the two valid shapes:
+      tests_passed=false (any patch) and tests_passed=true with a
+      non-empty patch.
+
+Tier rule discipline: every test docstring opens with Tier 2; no
+mocks; no private-state assertions; no format-pinning. Schema
+validation uses jsonschema directly against the loaded schema dict.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+def _load_result_schema() -> dict:
+    """Tier 2 helper: load swe_bench_result yaml schema field as a dict."""
+    import yaml
+
+    raw = (_SKILL_ROOT / "artifacts" / "swe_bench_result.yaml").read_text(
+        encoding="utf-8",
+    )
+    doc = yaml.safe_load(raw)
+    return doc["schema"]
+
+
+def test_setup_md_includes_substitute_instruction() -> None:
+    """Tier 2: setup.md must instruct the LLM to substitute the actual SHA."""
+    setup_md = (_SKILL_ROOT / "phases" / "setup.md").read_text(encoding="utf-8")
+    assert "substitute" in setup_md.lower(), (
+        "setup.md must include an explicit substitute-with-actual-SHA "
+        "instruction post-PR-F"
+    )
+
+
+def test_setup_md_shows_concrete_sha_example() -> None:
+    """Tier 2: setup.md must show a concrete hex-SHA next to git checkout."""
+    setup_md = (_SKILL_ROOT / "phases" / "setup.md").read_text(encoding="utf-8")
+    import re
+    pattern = re.compile(r"git checkout [0-9a-f]{7,}")
+    assert pattern.search(setup_md), (
+        "setup.md should include a git-checkout hex-sha as a concrete "
+        "example so the LLM understands the substituted shape"
+    )
+
+
+def test_swe_bench_result_schema_rejects_passed_true_with_empty_patch() -> None:
+    """Tier 2: schema must reject tests_passed=true with empty patch."""
+    import jsonschema
+
+    schema = _load_result_schema()
+    invalid_instance = {
+        "instance_id": "test__test-1",
+        "patch": "",
+        "tests_passed": True,
+        "attempts": 1,
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_instance, schema=schema)
+
+
+def test_swe_bench_result_schema_accepts_passed_true_with_non_empty_patch() -> None:
+    """Tier 2: schema accepts tests_passed=true when patch is non-empty."""
+    import jsonschema
+
+    schema = _load_result_schema()
+    valid_instance = {
+        "instance_id": "test__test-1",
+        "patch": "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n",
+        "tests_passed": True,
+        "attempts": 1,
+    }
+    jsonschema.validate(instance=valid_instance, schema=schema)
+
+
+def test_swe_bench_result_schema_accepts_passed_false_with_empty_patch() -> None:
+    """Tier 2: schema accepts tests_passed=false with an empty patch."""
+    import jsonschema
+
+    schema = _load_result_schema()
+    valid_instance = {
+        "instance_id": "test__test-1",
+        "patch": "",
+        "tests_passed": False,
+        "attempts": 1,
+    }
+    jsonschema.validate(instance=valid_instance, schema=schema)
+
+
+def test_swe_bench_result_schema_accepts_passed_false_with_non_empty_patch() -> None:
+    """Tier 2: schema accepts tests_passed=false with a non-empty patch."""
+    import jsonschema
+
+    schema = _load_result_schema()
+    valid_instance = {
+        "instance_id": "test__test-1",
+        "patch": "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+wrong\n",
+        "tests_passed": False,
+        "attempts": 3,
+    }
+    jsonschema.validate(instance=valid_instance, schema=schema)
+
+
+def test_swe_bench_result_schema_carries_oneof_constraint() -> None:
+    """Tier 2: structural -- schema dict carries a oneOf constraint."""
+    schema = _load_result_schema()
+    assert "oneOf" in schema, (
+        "swe_bench_result.yaml schema must carry a oneOf constraint "
+        "pinning the tests_passed/patch invariant (FP-0008 PR-F)"
+    )
+
+
+def test_report_md_articulates_validation_contract() -> None:
+    """Tier 2: report.md tells the LLM about the patch-non-empty-if-passed rule."""
+    report_md = (_SKILL_ROOT / "phases" / "report.md").read_text(
+        encoding="utf-8",
+    )
+    text = report_md.lower()
+    assert "validation" in text or "schema" in text, (
+        "report.md must mention the validation/schema contract so the "
+        "LLM understands the patch-non-empty-if-passed rule"
+    )
+    assert "empty" in text, (
+        "report.md must articulate the empty-patch consequence (set "
+        "tests_passed=false when diff is empty)"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-F. Two defects from sandbox_2 v4 calibration retry (2026-05-28), bundled root-fix-strict per [[feedback_no_compromise_recommendation]].

## Defect 1: placeholder literal-emission (2 of 5 v4 aborts)

Primary evidence:
```
abort reason: "Failed to checkout the base commit due to an invalid commit SHA"
shell cmd: 'git checkout <base_commit>'  (literal placeholder)
```

Weak LLMs (gemini-2.5-flash-lite) emitted `<base_commit>` as the literal shell cmd value instead of substituting the actual SHA. Fix: rewrote `setup.md` Step 1 with explicit substitute-instruction + concrete hex-SHA example + explicit warning against literal-placeholder emission.

## Defect 2: schema invariant gap (1 false-positive masking 0/10)

Primary evidence:
```json
{"instance_id": "astropy-14309", "patch": "", "tests_passed": true, "attempts": 1}
```

`swe_bench_result` schema permitted `tests_passed=true + patch=""`. v4's reported `pass_rate=1/10` was a no-op false-positive; true `pass_rate=0/10`. Fix: added `oneOf` constraint to `swe_bench_result.yaml` rejecting that combo; updated `report.md` Step 2 with "Validation contract" subsection articulating the rule.

## Why both in one PR

- Both defects in the same skill (= `src/reyn/stdlib/skills/swe_bench/`)
- Both blocking the v5 retry primary deliverable (= realistic pass_rate baseline)
- No coupling between the two fixes (= sets of touched files don't overlap functionally), but landing together avoids two PR-review round-trips for a single-author scope

## Test plan

- [x] `pytest -q tests/test_swe_bench_skill_pr_f_defects.py tests/test_swe_bench_skill_load.py tests/test_swe_bench_skill_invariants.py` → **23/23 pass** (= 15 existing + 8 new)
- [x] `python3 scripts/test_tier_audit.py --strict tests/test_swe_bench_skill_pr_f_defects.py` → **8/8 OK, exit 0**
- [x] `ruff check src/reyn/stdlib/skills/swe_bench/ tests/test_swe_bench_skill_pr_f_defects.py` → clean
- [x] **Tier rule self-check** ([[feedback_pr_tier_rule_self_check]]):
   - docstrings open with `"""Tier 2:` ✓
   - no Mock / AsyncMock / MagicMock / patch ✓
   - no private-state assertions ✓
   - no format-pinning ✓ (= 8 tests cover the 2 defects + 4 valid-shape acceptance cases + 1 structural guard + 1 contract-articulation check)

## Files changed (4)

- `src/reyn/stdlib/skills/swe_bench/phases/setup.md` — Step 1 rewrite (Defect 1)
- `src/reyn/stdlib/skills/swe_bench/phases/report.md` — Step 2 contract articulation (Defect 2 LLM-side)
- `src/reyn/stdlib/skills/swe_bench/artifacts/swe_bench_result.yaml` — `oneOf` invariant (Defect 2 schema-side)
- `tests/test_swe_bench_skill_pr_f_defects.py` — 8 Tier-2 invariant tests (NEW)

## sandbox_2 next step

Optional v5 retry post-merge: same `--allow-shell --clone-task-repo` invocation; expected (a) Defect-1-driven aborts drop, (b) any LLM that tries `tests_passed=true + empty patch` is rejected at validation. First realistic pass_rate baseline for flash-lite on SWE-bench subset becomes available.

Refs FP-0008 PR-A #977 + PR-E #1007. Primary evidence from sandbox_2 v4 broker 2026-05-28T01:01:42Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)