### PR TITLE
feat(fp-0008): PR-G — explore/plan input-artifact field access scaffolding

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -11,10 +11,36 @@ Understand the problem by reading the `problem_statement` and finding the
 relevant code in the repository.  The goal is to identify the files most
 likely to need editing.
 
+## Where to find the input fields
+
+This phase receives an input artifact of type `swe_bench_input`. Its `data`
+object contains every field you need. Concretely, the input shape is:
+
+```json
+{
+  "type": "swe_bench_input",
+  "data": {
+    "instance_id": "django__django-12345",
+    "repo": "django/django",
+    "base_commit": "d16bfe05a744909de4b27f5875fe0d4ed41ce607",
+    "problem_statement": "<GitHub issue body, typically 1-3 paragraphs>",
+    "hints_text": "<optional hint string, may be empty>",
+    "test_patch": "<unified diff text>"
+  }
+}
+```
+
+All six fields are present in the prompt's artifact section that the OS
+gives you (= no need to grep / search / probe to find them). Read them
+directly from `data.*` — do NOT abort with "problem_statement missing"
+before reading the artifact, because the fields ARE there. If you genuinely
+cannot find them, recheck the prompt's input-artifact block before aborting.
+
 ## Step 1 — Read the problem statement
 
-Read `problem_statement` from the input artifact.  If `hints_text` is
-non-empty, use it as additional guidance for where to look.
+Read `data.problem_statement` from the input artifact. This is the GitHub
+issue text describing the bug to fix. If `data.hints_text` is non-empty,
+use it as additional guidance for where to look.
 
 ## Step 2 — Locate relevant code with grep
 
@@ -37,9 +63,14 @@ entire repository.
 
 ## Step 4 — Inspect the test_patch to understand expected behavior
 
-Read the `test_patch` field from the input to understand what the tests expect
-the fixed code to do.  This gives a precise specification: the fix must make
-those tests pass.  Do NOT apply the test_patch now — that happens in verify.
+Read `data.test_patch` from the input artifact to understand what the tests
+expect the fixed code to do.  This is a unified diff string that has been
+present in the input from Step 1 — you do NOT need to issue a shell or file
+op to access it. The value lives at `data.test_patch` in the same input
+artifact as `data.problem_statement`.
+
+This gives a precise specification: the fix must make those tests pass. Do
+NOT apply the test_patch now — that happens in verify.
 
 ## Step 5 — Record exploration findings
 

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -14,19 +14,34 @@ what to change in each, sufficient for the apply phase to implement the fix.
 
 The input is either:
 
-- `exploration` — first plan for this instance (attempt 1)
-- `verify_state` — a prior verify attempt failed; use `failure_summary` plus
-  the exploration notes from the workspace to revise the plan
+- `exploration` (= attempt 1) — produced by the previous explore phase.
+  Read its `data` fields (which files contain the bug, what the root cause
+  appears to be, candidate edit targets) to ground the plan.
+- `verify_state` (= attempt > 1) — a prior verify attempt failed. Read
+  `data.failure_summary` to understand which tests failed and why, plus
+  the exploration artifact saved to the workspace by the earlier explore
+  phase.
+
+In both cases the fields are present in the prompt's input-artifact block
+(= the OS injects the artifact data structurally — no need to abort with
+"exploration missing" before reading the prompt). You may ALSO need to
+refer back to the original SWE-bench input fields (`problem_statement`,
+`test_patch`) for context — those were carried into the workspace by the
+explore phase and can be re-read via a file op against the exploration
+summary if needed.
 
 ## Step 1 — Review the exploration summary
 
-Read the workspace artifact from the explore phase.  If the input is a
-`verify_state`, also read `failure_summary` to understand which tests failed
-and why.
+Read the workspace artifact from the explore phase. Look for the fields
+explore.md recorded: which files contain the bug, what the root cause
+appears to be, and which code regions need to change.
+
+If the input artifact type is `verify_state`, also read its
+`data.failure_summary` to understand which tests failed and why.
 
 When re-planning (attempt > 1), first read the previous plan and the verify
-failure summary from the workspace.  Avoid repeating edits that already failed
-without changing the approach.
+failure summary from the workspace.  Avoid repeating edits that already
+failed without changing the approach.
 
 ## Step 2 — Re-read targeted code sections (if needed)
 

--- a/tests/test_swe_bench_skill_pr_g_field_access.py
+++ b/tests/test_swe_bench_skill_pr_g_field_access.py
@@ -1,0 +1,161 @@
+"""Tier 2: FP-0008 PR-G -- explore/plan input artifact field access.
+
+Defect surfaced by sandbox_2 v5 calibration retry (2026-05-28): 3 of 8
+aborts in v5 hit explore/plan with reasons like:
+
+  "The problem_statement and test_patch are missing"
+  "Could not read the exploration summary or test patch"
+  "Act turns limit reached before reading problem statement"
+
+Root cause: weak LLMs (gemini-2.5-flash-lite) did not navigate the
+input artifact's `data.*` fields without explicit prompt scaffolding.
+The original explore.md/plan.md said "Read `problem_statement` from
+the input artifact" -- template-style reference that the weak LLM
+treated as ambiguous and aborted on.
+
+This file pins:
+  (a) explore.md includes an explicit "Where to find the input
+      fields" section showing the artifact data shape.
+  (b) explore.md instructs reading `data.problem_statement` /
+      `data.test_patch` directly from the prompt artifact section
+      (= no need to grep/probe).
+  (c) explore.md warns against aborting with "field missing" before
+      reading the artifact.
+  (d) plan.md instructs reading the exploration artifact's `data`
+      fields + accessing `data.failure_summary` on verify_state.
+
+The rule shape is positive (= required content), so future authors
+can rephrase as long as the substance is present.
+
+Tier rule discipline: every test docstring opens with Tier 2; no
+mocks; no private-state assertions; no format-pinning.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+def _read_phase(name: str) -> str:
+    return (_SKILL_ROOT / "phases" / f"{name}.md").read_text(encoding="utf-8")
+
+
+# Section 1: explore.md field-access instructions ----------------------------
+
+
+def test_explore_md_shows_input_artifact_shape() -> None:
+    """Tier 2: explore.md shows the input artifact data shape inline."""
+    text = _read_phase("explore")
+    # The artifact-shape block should appear (= JSON example with the
+    # six data fields). Soft check: confirm the section header + the
+    # six field names appear.
+    assert "Where to find the input fields" in text or "input artifact" in text.lower(), (
+        "explore.md must include an explicit section telling the LLM "
+        "where the input fields live"
+    )
+    for field in ("instance_id", "repo", "base_commit", "problem_statement",
+                  "hints_text", "test_patch"):
+        assert field in text, (
+            f"explore.md must reference the {field!r} input field "
+            f"explicitly (= weak LLM navigation aid)"
+        )
+
+
+def test_explore_md_uses_data_dot_prefix_for_field_access() -> None:
+    """Tier 2: explore.md uses `data.<field>` form to anchor the access pattern."""
+    text = _read_phase("explore")
+    # Look for at least one explicit `data.problem_statement` or
+    # `data.test_patch` reference. The dot-prefix form tells the LLM
+    # the access path; bare `problem_statement` was ambiguous.
+    assert "data.problem_statement" in text or "data.test_patch" in text, (
+        "explore.md must use `data.<field>` access syntax (= explicit "
+        "path) at least once so weak LLMs can pattern-match the field "
+        "location in the input artifact"
+    )
+
+
+def test_explore_md_warns_against_premature_abort() -> None:
+    """Tier 2: explore.md tells the LLM NOT to abort with `field missing`.
+
+    The v5 retry aborts were of the shape `"problem_statement and
+    test_patch are missing"` -- weak LLMs giving up before reading the
+    artifact block. The instruction must call this out so the LLM
+    re-reads the prompt rather than aborting.
+    """
+    text = _read_phase("explore").lower()
+    # Soft check: confirm both ingredients (= "abort" warning + the
+    # specific concern about pre-read abort) appear somewhere.
+    assert "abort" in text, (
+        "explore.md should mention the abort anti-pattern so the LLM "
+        "is steered away from premature 'fields missing' aborts"
+    )
+    assert "missing" in text or "before reading" in text, (
+        "explore.md should articulate that fields ARE in the prompt "
+        "(= do not abort before reading)"
+    )
+
+
+# Section 2: plan.md field-access instructions -------------------------------
+
+
+def test_plan_md_distinguishes_exploration_vs_verify_state() -> None:
+    """Tier 2: plan.md tells the LLM which fields to read per input type."""
+    text = _read_phase("plan")
+    # plan.md accepts two input artifact types; both branches must be
+    # described.
+    assert "exploration" in text and "verify_state" in text, (
+        "plan.md must describe both `exploration` and `verify_state` "
+        "input branches so the LLM dispatches on the artifact type"
+    )
+
+
+def test_plan_md_references_failure_summary_on_verify_state() -> None:
+    """Tier 2: plan.md instructs reading `data.failure_summary` on verify_state input."""
+    text = _read_phase("plan")
+    assert "failure_summary" in text, (
+        "plan.md must reference `failure_summary` (= the field carrying "
+        "the prior-attempt diagnostic on verify_state inputs)"
+    )
+
+
+def test_plan_md_warns_against_premature_abort() -> None:
+    """Tier 2: plan.md tells the LLM NOT to abort before reading the input."""
+    text = _read_phase("plan").lower()
+    # Same anti-pattern as explore.md: weak LLMs aborted with
+    # "exploration missing" before reading.
+    assert "abort" in text or "missing" in text, (
+        "plan.md should articulate that the input artifact's data IS "
+        "present in the prompt (= no premature abort)"
+    )
+
+
+# Section 3: schema fields match the documented shape ------------------------
+
+
+def test_input_schema_lists_documented_fields() -> None:
+    """Tier 2: swe_bench_input.yaml schema matches the fields documented in explore.md.
+
+    Catches drift between the schema and the explore.md "Where to find
+    the input fields" section. If the schema gains/loses a field, the
+    explore.md docs section must follow (= or vice versa).
+    """
+    import yaml
+
+    raw = (_SKILL_ROOT / "artifacts" / "swe_bench_input.yaml").read_text(
+        encoding="utf-8",
+    )
+    doc = yaml.safe_load(raw)
+    schema_fields = set(doc["schema"]["properties"].keys())
+    expected = {
+        "instance_id", "repo", "base_commit",
+        "problem_statement", "hints_text", "test_patch",
+    }
+    assert schema_fields == expected, (
+        f"swe_bench_input schema fields drifted from documented set. "
+        f"Schema has: {schema_fields}; docs reference: {expected}. "
+        f"Update either schema OR explore.md so they stay synced."
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-G. v5 calibration retry showed 3/8 aborts in explore/plan hit "problem_statement/test_patch missing" — weak LLM (gemini-2.5-flash-lite) treating template-style prompt references as ambiguous. Same class of bug as PR-F Defect 1.

## Primary evidence (v5 broker 2026-05-28)

```
abort: "The problem_statement and test_patch are missing, which are critical..."
abort: "Could not read the exploration summary or test patch, preventing edit plan"
abort: "Act turns limit reached before reading problem statement..."
```

Root cause: original `explore.md` said `Read \`problem_statement\` from the input artifact` — template-style reference that the weak LLM treated as ambiguous and aborted on rather than reading the prompt's artifact section.

## Fix shape (per [[feedback_generalize_for_reyn_not_overfit_to_instance]] — class fix, skill-layer for now)

Same shape as PR-F's setup.md fix (= concrete-example + explicit-substitute + anti-abort warning):

- **explore.md**: new "Where to find the input fields" section with full input artifact JSON example + explicit anti-abort directive ("fields ARE in the prompt") + Step 1 + Step 4 rewritten to use `data.problem_statement` / `data.test_patch` dotted-path syntax.
- **plan.md**: Context section describes both `exploration` and `verify_state` input branches with explicit `data.*` patterns + anti-abort directive.

## Generalization candidate (= deferred per rule-of-three N=1)

The class of bug ("weak LLM struggles to navigate nested input data fields without explicit scaffolding") likely affects other skills. A skill DSL declaration like `expose_input_fields: [problem_statement, test_patch]` could auto-inject the scaffolding. Lift trigger = N=2 instance (= another skill exhibits same symptom).

## Test plan

- [x] `pytest -q tests/test_swe_bench_skill_pr_g_field_access.py tests/test_swe_bench_skill_pr_f_defects.py tests/test_swe_bench_skill_load.py tests/test_swe_bench_skill_invariants.py` → **30/30 pass** (= 23 existing + 7 new)
- [x] `python3 scripts/test_tier_audit.py --strict tests/test_swe_bench_skill_pr_g_field_access.py` → **7/7 OK, exit 0**
- [x] `ruff check src/reyn/stdlib/skills/swe_bench/ tests/test_swe_bench_skill_pr_g_field_access.py` → clean
- [x] **Tier rule self-check** ([[feedback_pr_tier_rule_self_check]]):
   - docstrings open with `"""Tier 2:` ✓
   - no Mock / AsyncMock / MagicMock / patch ✓
   - no private-state assertions ✓
   - no format-pinning ✓ (= tests check phrase presence + dotted-path access form, not exact whitespace)

## sandbox_2 next step

v6 retry post-merge: expected explore/plan abort rate drop from 3/8 to ≤1/8 + more instances reach apply/verify + first non-zero true pass_rate signal from flash-lite on astropy subset.

Refs FP-0008 PR-F #1008 (= same class shape, fixed for setup.md). Refs sandbox_2 v5 calibration broker 2026-05-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)