### PR TITLE
fix(permissions): require_file_*/read/write honor decl in non-interactive mode (PR-H)

### DIFF
--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -135,6 +135,57 @@ def _in_default_read_zone(path_str: str) -> bool:
         return False
 
 
+def _decl_covers_path(entries: list[dict], path: str) -> bool:
+    """Whether the skill's declared file_read / file_write entries cover ``path``.
+
+    Used by ``require_file_read`` / ``require_file_write`` in non-interactive
+    mode to honor skill declarations directly (FP-0008 PR-H, 2026-05-28).
+
+    Matching rules:
+
+    - ``path == "*"`` in any entry → wildcard, matches anything.
+    - Empty / missing entry path → skip the entry.
+    - ``scope: "recursive"`` → matches the declared path itself OR any
+      descendant resolved-path.
+    - ``scope: "just_path"`` (default) → matches the resolved declared path
+      exactly.
+
+    Returns False on any resolution error so the caller can fall through
+    to the standard PermissionError.
+    """
+    if not entries:
+        return False
+    try:
+        p_resolved = Path(path).expanduser().resolve()
+    except Exception:
+        return False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        decl_path = entry.get("path", "")
+        scope = entry.get("scope", "just_path")
+        if not decl_path:
+            continue
+        if decl_path == "*":
+            return True
+        try:
+            decl_resolved = Path(decl_path).expanduser().resolve()
+        except Exception:
+            continue
+        if scope == "recursive":
+            if p_resolved == decl_resolved:
+                return True
+            try:
+                p_resolved.relative_to(decl_resolved)
+                return True
+            except ValueError:
+                pass
+        else:  # just_path
+            if p_resolved == decl_resolved:
+                return True
+    return False
+
+
 @dataclass
 class PythonPermission:
     """Per-(module, function) permission for a python preprocessor step.
@@ -914,12 +965,23 @@ class PermissionResolver:
         Raise PermissionError if read/glob/grep access to path is not allowed.
         Default zone (CWD and below) is always granted.
         Outside CWD, the path must have been approved at startup or via config.
+
+        FP-0008 PR-H (2026-05-28): in non-interactive mode where the
+        startup guard cannot prompt the user, honor the skill's
+        declared paths directly. This brings runtime into alignment
+        with declared intent for batch/cron/CI workflows. Same class
+        of wiring-gap fix as PR #1004 (= Tool→OpContext bridge).
+        Interactive mode is unchanged — the user may decline at
+        startup, decline is tracked in ``_session``, and is respected
+        by ``_is_path_approved_for`` above.
         """
         if _in_default_read_zone(path):
             return
         if self._is_config_approved("file.read"):
             return
         if self._is_path_approved_for(path, skill_name, "file.read"):
+            return
+        if not self._interactive and _decl_covers_path(decl.file_read, path):
             return
         raise PermissionError(
             f"read from '{path}' was not approved. "
@@ -936,12 +998,20 @@ class PermissionResolver:
         Raise PermissionError if write/edit/delete access to path is not allowed.
         Default zone (.reyn/, reyn/) is always granted.
         Outside the default zone, the path must have been approved at startup.
+
+        FP-0008 PR-H (2026-05-28): in non-interactive mode where the
+        startup guard cannot prompt the user, honor the skill's
+        declared paths directly. See ``require_file_read`` for the
+        rationale (= PR #1004 class N=2 trigger; wiring gap that
+        leaves declared intent un-honored in batch mode).
         """
         if _in_default_write_zone(path):
             return
         if self._is_config_approved("file.write"):
             return
         if self._is_path_approved_for(path, skill_name, "file.write"):
+            return
+        if not self._interactive and _decl_covers_path(decl.file_write, path):
             return
         raise PermissionError(
             f"write to '{path}' was not approved. "

--- a/tests/test_permission_resolver_consults_decl.py
+++ b/tests/test_permission_resolver_consults_decl.py
@@ -1,0 +1,249 @@
+"""Tier 2: FP-0008 PR-H -- PermissionResolver consults decl.file_* in non-interactive mode.
+
+Defect surfaced by sandbox_2 v6 calibration retry (2026-05-28): 3 of 7
+aborts hit `file.write was not approved` PermissionError even though
+the swe_bench skill declares `file.write: [{path: "*", scope: "recursive"}]`.
+
+Root cause (= class N=2 of PR #1004 Tool-OpContext bridge):
+``PermissionResolver.require_file_write`` (and ``_read``) accept a
+``decl: PermissionDecl`` parameter but never consult it. The runtime
+checks only (a) default zone, (b) config-level allow, (c) saved/session
+approval populated by interactive startup prompts. In non-interactive
+mode (= benchmark subprocess, ``sys.stdin.isatty() == False``), the
+startup prompts cannot fire -> no session approval -> runtime denies
+even though the skill DID declare the path.
+
+Fix (= same root-fix-strict pattern as PR #1004): consult
+``decl.file_*`` directly in non-interactive mode. Interactive mode is
+unchanged so user-decline tracking via ``_session`` is respected.
+
+This file pins:
+  1. In non-interactive mode, a declared file.write path is honored.
+  2. In non-interactive mode, a declared file.read path is honored.
+  3. Wildcard ``"*"`` declared path covers any runtime path.
+  4. ``scope: "recursive"`` covers descendants.
+  5. ``scope: "just_path"`` (default) covers exact path only.
+  6. In INTERACTIVE mode, the new check does NOT fire (= existing
+     model preserved, user-decline still respected).
+  7. The ``decl`` parameter is documented + used; previous
+     un-consulted state would re-introduce the bug.
+
+Tier rule discipline: every test docstring opens with Tier 2; no
+mocks; no private-state assertions; no format-pinning.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.permissions import (
+    PermissionDecl,
+    PermissionResolver,
+    _decl_covers_path,
+)
+
+# Section 1: _decl_covers_path helper --------------------------------------
+
+
+def test_decl_covers_path_wildcard_matches_anything() -> None:
+    """Tier 2: declared path '*' covers any runtime path."""
+    entries = [{"path": "*", "scope": "recursive"}]
+    assert _decl_covers_path(entries, "/tmp/anything/at/all.txt") is True
+    assert _decl_covers_path(entries, "/etc/passwd") is True
+
+
+def test_decl_covers_path_recursive_matches_descendants(tmp_path: Path) -> None:
+    """Tier 2: declared scope=recursive covers descendant runtime paths."""
+    declared = str(tmp_path / "work")
+    (tmp_path / "work").mkdir()
+    nested = tmp_path / "work" / "sub" / "file.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("x")
+    entries = [{"path": declared, "scope": "recursive"}]
+    assert _decl_covers_path(entries, str(nested)) is True
+    # The declared path itself also matches
+    assert _decl_covers_path(entries, declared) is True
+
+
+def test_decl_covers_path_just_path_exact_match_only(tmp_path: Path) -> None:
+    """Tier 2: declared scope=just_path covers ONLY the exact path."""
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("a")
+    file_b = tmp_path / "b.txt"
+    file_b.write_text("b")
+    entries = [{"path": str(file_a), "scope": "just_path"}]
+    assert _decl_covers_path(entries, str(file_a)) is True
+    assert _decl_covers_path(entries, str(file_b)) is False
+
+
+def test_decl_covers_path_just_path_no_descendant_match(tmp_path: Path) -> None:
+    """Tier 2: declared scope=just_path does NOT match descendants."""
+    declared_dir = tmp_path / "work"
+    declared_dir.mkdir()
+    nested = declared_dir / "sub" / "file.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("x")
+    entries = [{"path": str(declared_dir), "scope": "just_path"}]
+    assert _decl_covers_path(entries, str(nested)) is False
+
+
+def test_decl_covers_path_empty_entries_returns_false() -> None:
+    """Tier 2: empty entries list returns False (= no declared coverage)."""
+    assert _decl_covers_path([], "/anything") is False
+
+
+def test_decl_covers_path_missing_path_field_skipped() -> None:
+    """Tier 2: entry without a path field is skipped (= no crash, just no match)."""
+    entries = [{"scope": "recursive"}, {"path": "", "scope": "recursive"}]
+    assert _decl_covers_path(entries, "/anything") is False
+
+
+# Section 2: require_file_write integration -------------------------------
+
+
+def test_require_file_write_honors_declared_wildcard_in_non_interactive(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-interactive mode + declared wildcard path -> require_file_write passes.
+
+    The exact swe_bench scenario: skill declares ``file.write:
+    [{path: "*", scope: "recursive"}]`` and runs in non-interactive
+    mode (= benchmark subprocess). Pre-PR-H this raised
+    PermissionError; post-PR-H it passes silently.
+    """
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    decl = PermissionDecl(
+        file_write=[{"path": "*", "scope": "recursive"}],
+    )
+    out_of_zone = tmp_path.parent / "elsewhere" / "out.txt"
+    # Must NOT raise
+    resolver.require_file_write(decl, str(out_of_zone), "swe_bench")
+
+
+def test_require_file_read_honors_declared_wildcard_in_non_interactive(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-interactive mode + declared wildcard path -> require_file_read passes."""
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    decl = PermissionDecl(
+        file_read=[{"path": "*", "scope": "recursive"}],
+    )
+    out_of_zone = tmp_path.parent / "elsewhere" / "in.txt"
+    resolver.require_file_read(decl, str(out_of_zone), "swe_bench")
+
+
+def test_require_file_write_honors_declared_specific_path_in_non_interactive(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-interactive mode + declared specific path -> require_file_write passes."""
+    out_of_zone = tmp_path.parent / "elsewhere" / "specific.txt"
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    decl = PermissionDecl(
+        file_write=[{"path": str(out_of_zone), "scope": "just_path"}],
+    )
+    resolver.require_file_write(decl, str(out_of_zone), "my_skill")
+
+
+def test_require_file_write_undeclared_path_still_denied_in_non_interactive(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-interactive mode + path NOT in decl -> PermissionError raised.
+
+    The fix is targeted: declared paths are honored, undeclared paths
+    are still gated. PR-H does NOT bypass security entirely.
+    """
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    decl = PermissionDecl(
+        file_write=[{"path": str(tmp_path / "declared"), "scope": "just_path"}],
+    )
+    not_declared = tmp_path.parent / "elsewhere" / "undeclared.txt"
+    with pytest.raises(PermissionError):
+        resolver.require_file_write(decl, str(not_declared), "my_skill")
+
+
+# Section 3: interactive mode preservation --------------------------------
+
+
+def test_require_file_write_interactive_mode_ignores_declaration(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: interactive mode does NOT consult decl (= existing model preserved).
+
+    In interactive mode, the user is expected to approve at startup via
+    ``startup_guard`` prompts. Their decision is tracked in
+    ``_session`` / ``_saved`` and consulted via
+    ``_is_path_approved_for``. The new decl-consult check is gated on
+    ``not self._interactive`` so interactive sessions retain the
+    interactive-prompt-required posture (= user decline is honored).
+    """
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=True,
+    )
+    decl = PermissionDecl(
+        file_write=[{"path": "*", "scope": "recursive"}],
+    )
+    out_of_zone = tmp_path.parent / "elsewhere" / "out.txt"
+    with pytest.raises(PermissionError):
+        resolver.require_file_write(decl, str(out_of_zone), "my_skill")
+
+
+def test_require_file_read_interactive_mode_ignores_declaration(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: interactive mode does NOT consult decl for reads either (symmetry)."""
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=True,
+    )
+    decl = PermissionDecl(
+        file_read=[{"path": "*", "scope": "recursive"}],
+    )
+    out_of_zone = tmp_path.parent / "elsewhere" / "in.txt"
+    with pytest.raises(PermissionError):
+        resolver.require_file_read(decl, str(out_of_zone), "my_skill")
+
+
+# Section 4: default zone + config-allow still take precedence -----------
+
+
+def test_require_file_write_default_zone_passes_without_decl(tmp_path: Path) -> None:
+    """Tier 2: default-write-zone paths (.reyn/ or reyn/) are granted without decl.
+
+    Default-WRITE zones (per ``_DEFAULT_WRITE_ZONES``) are
+    ``.reyn/`` and ``reyn/`` only -- not CWD broadly. Pre-PR-H
+    rule preserved: paths inside those zones pass without any decl
+    consultation.
+    """
+    import os
+    os.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    resolver.require_file_write(PermissionDecl(), ".reyn/state.json", "")
+
+
+def test_require_file_write_config_allow_passes_without_decl(tmp_path: Path) -> None:
+    """Tier 2: config-level allow grants regardless of decl (existing rule).
+
+    The pre-PR-H rule order is preserved: ``_in_default_*_zone`` then
+    ``_is_config_approved`` then ``_is_path_approved_for`` then the
+    new decl-consult check. Config-level allow short-circuits before
+    the new check is reached.
+    """
+    resolver = PermissionResolver(
+        config_permissions={"file.write": "allow"},
+        project_root=tmp_path,
+        interactive=True,  # interactive but config-allow short-circuits
+    )
+    out_of_zone = tmp_path.parent / "elsewhere" / "x.txt"
+    # No decl, no prompt -- config allow alone passes.
+    resolver.require_file_write(PermissionDecl(), str(out_of_zone), "")


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-H per user direction on issue #1010 (a) 採用。 PR #1004 class N=2 trigger (= same wiring-gap pattern, permission resolver layer this time).

## Primary evidence

Sandbox_2 v6 calibration retry (2026-05-28): 3 of 7 aborts on `file.write was not approved` even though swe_bench declares `file.write: [{path: "*", scope: "recursive"}]`. Root cause: `require_file_write` accepts `decl: PermissionDecl` but never consults it — the `decl` arg was dead code (= `permissions.py:946-953` confirmed via grep).

In interactive mode the user is prompted at startup; in non-interactive (`sys.stdin.isatty()==False`, benchmark/cron/CI subprocess), no prompt fires → no session approval → runtime denies the declared path.

## Fix shape

New `_decl_covers_path(entries, path) -> bool` helper:
- `path == "*"` wildcard → any runtime path matches
- `scope: "recursive"` → declared path itself + descendants
- `scope: "just_path"` (default) → declared path only

Consulted from `require_file_read` and `require_file_write` after the existing checks, gated on `not self._interactive`:

```python
if _in_default_*_zone(path): return
if self._is_config_approved(...): return
if self._is_path_approved_for(...): return
if not self._interactive and _decl_covers_path(decl.file_*, path): return  # NEW
raise PermissionError(...)
```

Interactive mode unchanged (= user-decline tracked in `_session` still respected). Non-interactive mode aligns runtime with declared intent.

## Per [[feedback_generalize_for_reyn_not_overfit_to_instance]]

N=2 of the wiring-gap class (PR #1004 was N=1). Fix benefits ALL skills with `file.read`/`file.write` declarations in batch / cron / CI — not just swe_bench. Sister surfaces (`require_shell` / `require_mcp` / `require_http_get`) deferred — different decl shapes need per-call thinking; N=3 generalization trigger if same class shows up there.

## Test plan

- [x] `pytest -q tests/test_permission_resolver_consults_decl.py tests/test_permission_*.py` → **61/61 pass** (= 14 new + 47 adjacent regression-clean)
- [x] `python3 scripts/test_tier_audit.py --strict tests/test_permission_resolver_consults_decl.py` → **14/14 OK, exit 0**
- [x] `ruff check src/reyn/permissions/permissions.py tests/test_permission_resolver_consults_decl.py` → clean
- [x] **Tier rule self-check** ([[feedback_pr_tier_rule_self_check]]):
   - docstrings open with `"""Tier 2:` ✓
   - no Mock / AsyncMock / MagicMock / patch ✓
   - no private-state assertions ✓ (= tests use `interactive=` ctor arg, a public param)
   - no format-pinning ✓

## 14 new tests

| Section | Test | Pinning |
|---|---|---|
| 1 — `_decl_covers_path` helper | 6 tests | wildcard / recursive / just_path / empty / missing-path / exact-only |
| 2 — non-interactive integration | 4 tests | wildcard reaches require_file_write/read / specific path / undeclared still denied |
| 3 — interactive mode preserved | 2 tests | both read+write raise on decl-only (= model unchanged for interactive users) |
| 4 — pre-existing rules preserved | 2 tests | default zone + config allow short-circuit before new check |

## sandbox_2 next step

v7 retry post-merge: `file.write not approved` aborts drop 3/7 → 0/N + first non-zero apply phase activity for declared-path-write tasks. True pass_rate may still be 0% (= flash-lite capability lower bound) but OS-layer wiring fully aligned with declared intent.

Closes issue #1010 (= user direction: (a) OS-side root-fix採用). Refs PR #1004 (= class N=1). Refs sandbox_2 v6 calibration broker 2026-05-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)