### PR TITLE
fix(test): apply polling helper to fast_tool_call_defers_flush (Issue #927 follow-on)

### DIFF
--- a/tests/cli/test_conv_pane_tool_call_lifecycle.py
+++ b/tests/cli/test_conv_pane_tool_call_lifecycle.py
@@ -189,10 +189,13 @@ async def test_fast_tool_call_defers_flush_so_row_stays_visible_briefly():
             "(= the F-H deferred-flush should be set; the row "
             "should NOT unmount synchronously on complete)"
         )
-        # Wait past the threshold with generous CI margin — row
-        # should be flushed by now.
-        await pilot.pause(0.6)
-        assert len(list(conv.query(ToolCallRow))) == 0
+        # Wait past the threshold for the deferred flush. Issue #927
+        # taught that fixed ``pilot.pause(0.6)`` is non-deterministic
+        # under CI load — the timer + ``remove()`` task may still be
+        # in the event-loop queue when the pause returns. The polling
+        # helper yields repeatedly so the unmount can land, and caps
+        # at 2s to surface a genuine regression rather than hang.
+        assert await _wait_until_no_tool_rows(pilot, conv) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — flake-guardian axis fix dispatched from lead-coder (PR #1011 CI flake observation).

## Background
PR #1011 CI run [26569209349](https://github.com/tya5/reyn/actions/runs/26569209349) pytest 3.11 caught this test flaking with the exact pattern Issue #927 / PR #932 documented:

```
tests/cli/test_conv_pane_tool_call_lifecycle.py:195
await pilot.pause(0.6)
> assert len(list(conv.query(ToolCallRow))) == 0
E AssertionError: assert 1 == 0
E  + where 1 = len([ToolCallRow(id='toolcall_op-fast')])
```

PR #1011 diff (= permissions.py + test_permission_resolver_consults_decl.py) is orthogonal to ToolCallRow / conv_pane / pilot.pause surface — independent flake, not PR #1011 regression.

## Root cause (= same as Issue #927)

The `_wait_until_no_tool_rows` polling helper added in PR #932 was applied to two tests in this file (= lines 136 / 154 / 417) but missed this one. Same root cause:

- `_flush_tool_call_row` schedules the unmount via `app.set_timer(0.3, ...)` (= F-H min-display-time mechanism)
- Fixed 600ms `pilot.pause(0.6)` is non-deterministic under CI load
- Timer + `remove()` task may still be in the event-loop queue when the pause returns
- → `assert 1 == 0` exactly as #927 captured N=6 instances

## Fix

Mirror the established pattern (= memory `[[event-loop-dependent-test-polling]]`):

```diff
-    await pilot.pause(0.6)
-    assert len(list(conv.query(ToolCallRow))) == 0
+    assert await _wait_until_no_tool_rows(pilot, conv) == 0
```

The helper polls in 0.05s steps up to 2s, yielding control repeatedly so every pending timer + remove task gets a chance to land. The 2s cap stops the test from hanging if the unmount is genuinely broken (= a real regression still surfaces as `return 1`).

## Test plan
- [x] pytest 5x stress on the migrated test → 5/5 pass
- [x] pytest full file (`test_conv_pane_tool_call_lifecycle.py`) → 21/21 pass
- [x] `python scripts/test_tier_audit.py tests/cli/test_conv_pane_tool_call_lifecycle.py` → 0 errors
- [x] `ruff check` on changed file → clean

## Tier self-check
- [x] All edited tests still declare Tier in docstring (= unchanged)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)