### PR TITLE
feat(fp-0008): PR-J — explore.md placeholder shape (PR-F class N+1)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -14,21 +14,31 @@ likely to need editing.
 ## Where to find the input fields
 
 This phase receives an input artifact of type `swe_bench_input`. Its `data`
-object contains every field you need. Concretely, the input shape is:
+object contains every field you need. The shape (with ALL-CAPS placeholders
+denoting values you must read from the actual artifact in the prompt — NOT
+literal values to copy) is:
 
 ```json
 {
   "type": "swe_bench_input",
   "data": {
-    "instance_id": "django__django-12345",
-    "repo": "django/django",
-    "base_commit": "d16bfe05a744909de4b27f5875fe0d4ed41ce607",
-    "problem_statement": "<GitHub issue body, typically 1-3 paragraphs>",
-    "hints_text": "<optional hint string, may be empty>",
-    "test_patch": "<unified diff text>"
+    "instance_id": "<INSTANCE_ID_FROM_ARTIFACT>",
+    "repo": "<REPO_SLUG_FROM_ARTIFACT>",
+    "base_commit": "<COMMIT_SHA_FROM_ARTIFACT>",
+    "problem_statement": "<GITHUB_ISSUE_BODY_FROM_ARTIFACT>",
+    "hints_text": "<OPTIONAL_HINTS_FROM_ARTIFACT>",
+    "test_patch": "<UNIFIED_DIFF_FROM_ARTIFACT>"
   }
 }
 ```
+
+**Critical**: the angle-bracketed `<…_FROM_ARTIFACT>` strings above are
+documentation placeholders showing the SHAPE of the data. They are NOT
+literal values you should copy into shell commands, file paths, grep
+patterns, or any other tool call. The actual values live in the prompt's
+input-artifact section; read them from there and inline the REAL values
+(e.g. real owner/repo string like `astropy/astropy`, real 40-char SHA,
+real issue body text) into your tool calls.
 
 All six fields are present in the prompt's artifact section that the OS
 gives you (= no need to grep / search / probe to find them). Read them

--- a/tests/test_swe_bench_skill_pr_j_placeholder_shape.py
+++ b/tests/test_swe_bench_skill_pr_j_placeholder_shape.py
@@ -1,0 +1,143 @@
+"""Tier 2: FP-0008 PR-J -- explore.md placeholder shape (PR-F class N+1).
+
+Defect surfaced by sandbox_2 v6 calibration retry (2026-05-28): 2 of 9
+aborts hit `file_not_found` cascades because the LLM literal-copied
+the example values from explore.md's input-artifact JSON shape block:
+
+  Pre-PR-J explore.md:
+    "instance_id": "django__django-12345",
+    "repo": "django/django",
+
+A weak LLM (gemini-2.5-flash-lite) treated `"django/django"` as the
+literal repo name (= not pattern-match value, but actual data) and
+fabricated context anchored on that. File reads + grep ops then hit
+file_not_found because the actual task was an astropy instance, not
+a django one.
+
+This is the same class of bug as PR-F Defect 1 (setup.md `<base_commit>`
+literal-emission). PR-G partial fix gap: PR-G rewrote explore.md's
+field-access section but used realistic-looking example values
+(`"django__django-12345"`, `"django/django"`) instead of ALL-CAPS
+obvious-placeholder shape that PR-F established as the canonical
+mitigation.
+
+This file pins:
+  1. explore.md's JSON example uses `<*_FROM_ARTIFACT>` ALL-CAPS
+     placeholder shape (NOT `django/django` or other realistic-
+     looking literals that weak LLMs might copy).
+  2. explore.md includes an explicit Critical warning that the
+     placeholders are SHAPE documentation, not values to copy.
+  3. No literal-looking realistic example values (django/django,
+     django__django-N) appear inside the input-artifact JSON shape
+     block.
+
+Tier rule discipline: every test docstring opens with Tier 2; no
+mocks; no private-state assertions; no format-pinning.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+def _read_explore_md() -> str:
+    return (_SKILL_ROOT / "phases" / "explore.md").read_text(encoding="utf-8")
+
+
+def test_explore_md_uses_all_caps_placeholder_in_artifact_block() -> None:
+    """Tier 2: explore.md input-artifact JSON shape uses _FROM_ARTIFACT placeholders."""
+    text = _read_explore_md()
+    # At least one ALL-CAPS _FROM_ARTIFACT marker must appear in the
+    # input-artifact block (= the canonical PR-F-style mitigation shape).
+    assert "_FROM_ARTIFACT" in text, (
+        "explore.md must use ALL-CAPS `<*_FROM_ARTIFACT>` placeholder "
+        "shape in the input-artifact JSON example (PR-F class extension)"
+    )
+
+
+def test_explore_md_warns_against_literal_copy() -> None:
+    """Tier 2: explore.md includes an explicit Critical warning against literal copy.
+
+    The PR-F established pattern: the LLM must understand the
+    angle-bracketed placeholders are SHAPE documentation. Without an
+    explicit warning, weak LLMs literal-copy.
+    """
+    text = _read_explore_md().lower()
+    # Soft check: "critical" + "not a literal" / "not literal" / "shape"
+    # phrasing must appear.
+    assert "critical" in text, (
+        "explore.md must include a Critical warning section about "
+        "placeholder vs value distinction"
+    )
+    assert (
+        "not" in text and ("literal" in text or "copy" in text or "shape" in text)
+    ), (
+        "explore.md's Critical section must articulate that placeholders "
+        "are NOT literal values to copy"
+    )
+
+
+def test_explore_md_does_not_use_realistic_placeholder_repo_name() -> None:
+    """Tier 2: explore.md does NOT show `django/django` as an example repo.
+
+    Realistic-looking example values triggered literal-copy by weak
+    LLMs in v6 retry. The PR-J fix replaces them with ALL-CAPS shape
+    placeholders. This test catches accidental regression to
+    realistic-example shape (= e.g. future author rewrites with
+    'requests/requests' or 'numpy/numpy').
+
+    Rule (negative): no `<owner>/<owner>` pattern with realistic
+    org/repo names inside the input-artifact JSON shape block.
+    Note: this DOES allow such names in non-shape contexts (e.g. the
+    intro paragraph mentioning "SWE-bench Verified covers Django,
+    Astropy, ..." would be fine).
+    """
+    text = _read_explore_md()
+    # Find the input-artifact JSON shape block by anchor + closing brace.
+    anchor = "Where to find the input fields"
+    if anchor in text:
+        block_start = text.index(anchor)
+        # Search up to the next h2 / h1 boundary
+        block_end_candidates = [
+            text.find("\n## ", block_start + 1),
+            text.find("\n# ", block_start + 1),
+            len(text),
+        ]
+        block_end = min([c for c in block_end_candidates if c > 0])
+        block = text[block_start:block_end]
+    else:
+        block = text
+    forbidden_realistic = (
+        '"django/django"',
+        '"django__django-12345"',
+        '"requests/requests"',
+        '"numpy/numpy"',
+    )
+    for phrase in forbidden_realistic:
+        assert phrase not in block, (
+            f"explore.md input-artifact shape block re-introduces a "
+            f"realistic-looking placeholder {phrase!r}. Weak LLMs "
+            f"literal-copy these. Use ALL-CAPS `<*_FROM_ARTIFACT>` "
+            f"shape instead (PR-F established pattern)."
+        )
+
+
+def test_explore_md_artifact_block_uses_six_placeholder_fields() -> None:
+    """Tier 2: ALL-CAPS placeholders cover the six swe_bench_input fields.
+
+    The placeholder shape preserves the field names + types so the LLM
+    can still pattern-match the artifact shape; only the example
+    values change from realistic to obvious-placeholder.
+    """
+    text = _read_explore_md()
+    # Each of the six fields must appear in the input-artifact block.
+    for field in ("instance_id", "repo", "base_commit",
+                  "problem_statement", "hints_text", "test_patch"):
+        assert field in text, (
+            f"explore.md must still reference the {field!r} field "
+            f"(= field-access pattern preserved post-PR-J)"
+        )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-J. PR-F class N=2 trigger ([[feedback_generalize_for_reyn_not_overfit_to_instance]] generalization candidate). Sandbox_2 v6 calibration retry showed 2 of 9 errors hit file_not_found cascades from LLM literal-copying realistic-looking placeholder values.

## Primary evidence (sandbox_2 v6)

Pre-PR-J explore.md (= post-PR-G state):
```
"instance_id": "django__django-12345",
"repo": "django/django",
```

Weak LLM (gemini-2.5-flash-lite) literal-copied `"django/django"` as the actual repo name. Fabricated context anchored on django paths → file_read / grep ops hit not-found (actual task was astropy). Same class as PR-F Defect 1 (`<base_commit>` literal-emission in setup.md). PR-G's partial gap: rewrote the field-access section but used realistic-looking example values instead of PR-F's established ALL-CAPS obvious-placeholder shape.

## Fix shape

Convert realistic examples → ALL-CAPS shape placeholders:
- `"<INSTANCE_ID_FROM_ARTIFACT>"`
- `"<REPO_SLUG_FROM_ARTIFACT>"`
- `"<COMMIT_SHA_FROM_ARTIFACT>"`
- `"<GITHUB_ISSUE_BODY_FROM_ARTIFACT>"`
- `"<OPTIONAL_HINTS_FROM_ARTIFACT>"`
- `"<UNIFIED_DIFF_FROM_ARTIFACT>"`

Plus explicit Critical warning that angle-bracketed `<*_FROM_ARTIFACT>` strings are SHAPE documentation, NOT literal values to copy into tool calls.

## Generalization candidate (per [[feedback_generalize_for_reyn_not_overfit_to_instance]])

PR-F + PR-J = N=2 instances of "weak LLM literal-emits documentation placeholder as runtime value". Class lift candidate: skill DSL annotation like `{shape_only: true}` that auto-converts realistic examples to `<UPPERCASE_FROM_ARTIFACT>` form. Defer to N=3 per rule-of-three.

## Test plan

- [x] `pytest -q tests/test_swe_bench_skill_pr_j_placeholder_shape.py tests/test_swe_bench_skill_pr_g_field_access.py tests/test_swe_bench_skill_pr_f_defects.py tests/test_swe_bench_skill_load.py tests/test_swe_bench_skill_invariants.py` → **34/34 pass** (= 4 new + 30 existing adjacent)
- [x] `python3 scripts/test_tier_audit.py --strict tests/test_swe_bench_skill_pr_j_placeholder_shape.py` → **4/4 OK, exit 0**
- [x] `ruff check src/reyn/stdlib/skills/swe_bench/phases/explore.md tests/test_swe_bench_skill_pr_j_placeholder_shape.py` → All checks passed
- [x] **Tier rule self-check**:
   - docstrings open with `"""Tier 2:` ✓
   - no Mock / AsyncMock / MagicMock / patch ✓
   - no private-state assertions ✓
   - no format-pinning ✓ (= tests check substring presence + negative phrase audit; no whitespace/format pinning)

## 4 new Tier-2 tests

| Test | Pinning |
|---|---|
| `..._uses_all_caps_placeholder_in_artifact_block` | positive: `_FROM_ARTIFACT` marker present |
| `..._warns_against_literal_copy` | positive: Critical + "not literal / not copy / shape" phrasing |
| `..._does_not_use_realistic_placeholder_repo_name` | negative: no realistic owner/repo literals in shape block |
| `..._artifact_block_uses_six_placeholder_fields` | field-access coverage preserved (PR-G compatibility) |

## sandbox_2 next step

v7 retry post-merge (combined with PR-H file.write + PR-I chdir-race fixes): expected 2 file_not_found-cascade aborts drop to 0.

Refs FP-0008 PR-F #1008 (= class N=1, setup.md `<base_commit>`). Refs PR-G #1009 (= partial gap PR-J closes). Refs sandbox_2 v6 calibration broker 2026-05-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)