### PR TITLE
feat(fp-0008): PR-K — context_builder inline-boost for mid-size artifacts

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -19,17 +19,44 @@ from reyn.schemas.models import (
 )
 
 ARTIFACT_REF_THRESHOLD = 8000  # characters; larger artifacts are stored by ref in ContextFrame
+MAX_INLINE_BOOST = 65_536  # characters; artifacts up to 64KB are still inlined (inline-boost range)
 
 
-def maybe_ref_artifact(artifact: dict, artifact_path: str | None) -> dict:
+def maybe_ref_artifact(
+    artifact: dict,
+    artifact_path: str | None,
+    *,
+    events: Any = None,
+    phase: str | None = None,
+) -> dict:
     """
-    Return the artifact as-is if small, or an artifact_ref pointer if large.
-    The LLM can read the ref path via a file op.
+    Return the artifact as-is if small-or-medium, or an artifact_ref pointer if large.
+
+    Decision logic:
+      size <= ARTIFACT_REF_THRESHOLD            → inline (existing path)
+      ARTIFACT_REF_THRESHOLD < size <= MAX_INLINE_BOOST → inline (inline-boost path)
+      size > MAX_INLINE_BOOST                   → artifact_ref (existing path)
+
+    The LLM can read artifact_ref paths via a file op. The inline-boost path
+    keeps mid-size artifacts (e.g. SWE-bench task inputs, ~8–28KB) directly
+    visible in the prompt so the LLM does not need a round-trip file read.
     """
     if artifact_path is None:
         return artifact
     serialized = json.dumps(artifact, ensure_ascii=False)
-    if len(serialized) <= ARTIFACT_REF_THRESHOLD:
+    size = len(serialized)
+    if size <= ARTIFACT_REF_THRESHOLD:
+        return artifact
+    if size <= MAX_INLINE_BOOST:
+        # Inline-boost: mid-size artifact stays inlined to prevent fabrication.
+        # Emit an observability event so this decision is auditable.
+        if events is not None:
+            events.emit(
+                "artifact_inline_boost",
+                phase=phase,
+                size_chars=size,
+                artifact_path=artifact_path,
+            )
         return artifact
     return {
         "type": "artifact_ref",
@@ -66,7 +93,7 @@ def build_frame(
         current_phase=phase_name,
         current_phase_role=phase.role,
         instructions=phase.instructions,
-        input_artifact=maybe_ref_artifact(artifact, artifact_path),
+        input_artifact=maybe_ref_artifact(artifact, artifact_path, events=events, phase=phase_name),
         execution=ExecutionState(
             path=list(history)[-10:],
             current_visit=current_visit,

--- a/tests/test_context_builder_inline_boost.py
+++ b/tests/test_context_builder_inline_boost.py
@@ -1,0 +1,159 @@
+"""Tier 2: context_builder inline-boost range invariants (FP-0008 PR-K).
+
+The inline-boost fix adds a second threshold MAX_INLINE_BOOST = 65_536.
+Artifacts in the range (ARTIFACT_REF_THRESHOLD, MAX_INLINE_BOOST] are
+inlined in the prompt instead of being replaced by an artifact_ref pointer.
+Artifacts above MAX_INLINE_BOOST still get artifact_ref'd to prevent prompt
+explosion.
+
+These tests pin all three regions of the decision, the observability event
+for the inline-boost path, and the P1/P5 schema-integrity invariant.
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.context_builder import (
+    ARTIFACT_REF_THRESHOLD,
+    MAX_INLINE_BOOST,
+    maybe_ref_artifact,
+)
+from reyn.events.events import EventLog
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_artifact(target_size: int) -> dict:
+    """Return an artifact whose JSON serialisation is approximately *target_size* chars."""
+    payload = "x" * max(0, target_size - 20)  # leave room for JSON wrapping
+    return {"type": "generic_input", "data": payload}
+
+
+def _serialized_size(artifact: dict) -> int:
+    return len(json.dumps(artifact, ensure_ascii=False))
+
+
+# ── 1. small artifact inlines normally (existing-behaviour pin) ───────────────
+
+
+def test_small_artifact_inlined_normally() -> None:
+    """Tier 2: artifact below ARTIFACT_REF_THRESHOLD inlines (= existing path, no change)."""
+    artifact = _make_artifact(ARTIFACT_REF_THRESHOLD - 500)
+    assert _serialized_size(artifact) < ARTIFACT_REF_THRESHOLD
+
+    result = maybe_ref_artifact(artifact, artifact_path="workspace/run/artifact.jsonl")
+
+    # Inlined: result IS the original artifact, not an artifact_ref dict.
+    assert result is artifact
+
+
+# ── 2. inline-boost range inlines (NEW path) ──────────────────────────────────
+
+
+def test_artifact_in_inline_boost_range_inlines() -> None:
+    """Tier 2: artifact between ARTIFACT_REF_THRESHOLD and MAX_INLINE_BOOST inlines (inline-boost)."""
+    # Build an artifact just over the lower threshold but well under MAX_INLINE_BOOST.
+    artifact = _make_artifact(ARTIFACT_REF_THRESHOLD + 500)
+    size = _serialized_size(artifact)
+    assert ARTIFACT_REF_THRESHOLD < size <= MAX_INLINE_BOOST
+
+    result = maybe_ref_artifact(artifact, artifact_path="workspace/run/artifact.jsonl")
+
+    # Inline-boost: result is still the original artifact, NOT an artifact_ref.
+    assert result is artifact
+    assert result.get("type") != "artifact_ref"
+
+
+# ── 3. above MAX_INLINE_BOOST artifact_refs (prompt-explosion prevention) ─────
+
+
+def test_artifact_above_max_inline_boost_artifact_refs() -> None:
+    """Tier 2: artifact above MAX_INLINE_BOOST is artifact_ref'd (= prevents prompt explosion)."""
+    artifact = _make_artifact(MAX_INLINE_BOOST + 1000)
+    assert _serialized_size(artifact) > MAX_INLINE_BOOST
+
+    result = maybe_ref_artifact(
+        artifact,
+        artifact_path="workspace/run/large.jsonl",
+    )
+
+    # Should be an artifact_ref, not the original artifact.
+    assert result["type"] == "artifact_ref"
+    assert result["ref_path"] == "workspace/run/large.jsonl"
+    assert "size_bytes" in result
+
+
+# ── 4. inline-boost emits observability event ─────────────────────────────────
+
+
+def test_inline_boost_emits_observability_event() -> None:
+    """Tier 2: inline-boost path emits artifact_inline_boost event with size_chars + phase."""
+    events = EventLog()
+    artifact = _make_artifact(ARTIFACT_REF_THRESHOLD + 500)
+    size = _serialized_size(artifact)
+    assert ARTIFACT_REF_THRESHOLD < size <= MAX_INLINE_BOOST
+
+    maybe_ref_artifact(
+        artifact,
+        artifact_path="workspace/run/mid.jsonl",
+        events=events,
+        phase="test_phase",
+    )
+
+    emitted = events.all()
+    boost_events = [e for e in emitted if e.type == "artifact_inline_boost"]
+    (only,) = boost_events  # exactly one boost event
+    assert only.data["phase"] == "test_phase"
+    assert only.data["size_chars"] == size
+    assert only.data["artifact_path"] == "workspace/run/mid.jsonl"
+
+
+# ── 5. small artifact emits no inline-boost event (control) ───────────────────
+
+
+def test_small_artifact_emits_no_inline_boost_event() -> None:
+    """Tier 2: small artifact (below threshold) does not emit artifact_inline_boost event."""
+    events = EventLog()
+    artifact = _make_artifact(ARTIFACT_REF_THRESHOLD - 500)
+    assert _serialized_size(artifact) < ARTIFACT_REF_THRESHOLD
+
+    maybe_ref_artifact(
+        artifact,
+        artifact_path="workspace/run/small.jsonl",
+        events=events,
+        phase="test_phase",
+    )
+
+    boost_events = [e for e in events.all() if e.type == "artifact_inline_boost"]
+    assert boost_events == []
+
+
+# ── 6. inline-boost preserves artifact schema integrity (P1 / P5) ─────────────
+
+
+def test_inline_boost_preserves_artifact_schema_integrity() -> None:
+    """Tier 2: inlined mid-size artifact retains its original type and data fields intact.
+
+    P5 (SSOT): inlining is a prompt-shape decision; the artifact data itself
+    must be identical to what was written to the workspace. P1: schema integrity
+    means the artifact's 'type' field is unchanged (= still valid against
+    the phase's input_schema at the call site).
+    """
+    artifact = {
+        "type": "swe_bench_input",
+        "instance_id": "django__django-12345",
+        "problem_statement": "A" * (ARTIFACT_REF_THRESHOLD + 1000),
+        "extra": {"version": 2},
+    }
+    size = _serialized_size(artifact)
+    assert ARTIFACT_REF_THRESHOLD < size <= MAX_INLINE_BOOST
+
+    result = maybe_ref_artifact(artifact, artifact_path="workspace/run/swe.jsonl")
+
+    # The returned dict is the original artifact, fields intact.
+    assert result["type"] == artifact["type"]
+    assert result["instance_id"] == artifact["instance_id"]
+    assert result["problem_statement"] == artifact["problem_statement"]
+    assert result["extra"] == artifact["extra"]
+    # Confirm it is NOT an artifact_ref
+    assert result.get("ref_path") is None


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-K implementation: OS-side inline-boost fix for mid-size artifact fabrication.

## Primary evidence (sandbox_2 v7 calibration retry 2026-05-28)

4 of 5 v7 [error] cases share a single root cause:

- `ARTIFACT_REF_THRESHOLD = 8000` in `context_builder.py` causes 8 of the swe_bench setup-prompt's input fields to be artifact_ref'd
- 4 of those 8 (instance_ids 13033 / 13398 / 13453 / 13977, sizes 8366–27898 bytes) the LLM **does NOT read via file op** — it fabricates (`"django__django-12345"`, `"The provided problem statement is missing."`)
- Root cause: mid-size artifacts (just over 8KB) get replaced by an artifact_ref pointer the LLM treats as optional to resolve

## Fix (lead-coder Fix A, OS-side input pass-through)

Added `MAX_INLINE_BOOST = 65_536` (64KB) to `context_builder.py`. Decision after the patch:

```
size <= ARTIFACT_REF_THRESHOLD (8000)       → inline (unchanged)
ARTIFACT_REF_THRESHOLD < size <= MAX_INLINE_BOOST → inline (NEW inline-boost)
size > MAX_INLINE_BOOST (65536)             → artifact_ref (unchanged)
```

Mid-size artifacts the LLM CAN read directly are now inlined. Truly huge artifacts (64KB+) still get artifact_ref'd to prevent prompt explosion. P5 (SSOT) and P1 (phase output schema integrity) are preserved — inlining is a prompt-shape decision, the artifact still lives in the workspace.

`maybe_ref_artifact` signature extended with keyword-only `events` and `phase` to emit an `artifact_inline_boost` observability event on the new path. Both kwargs default to `None`; callers that don't pass them are unaffected.

## Files changed (2)

- `src/reyn/context_builder.py` — add `MAX_INLINE_BOOST`, update `maybe_ref_artifact` logic + signature, wire `events`/`phase` through `build_frame`
- `tests/test_context_builder_inline_boost.py` (NEW) — 6 Tier-2 invariant tests

## Test plan

- [x] `python3 scripts/test_tier_audit.py --strict tests/test_context_builder_inline_boost.py` → exit 0, 6 OK, 0 errors
- [x] `python -m pytest -q tests/test_context_builder_inline_boost.py` → 6 passed
- [x] `ruff check src/reyn/context_builder.py tests/test_context_builder_inline_boost.py` → clean
- [x] Tier rule self-check: all 6 docstrings start `Tier 2:`, no mock/AsyncMock/patch, no private state assertions, no format pinning

## Tier rule self-check

- All docstrings: first line `Tier 2: ...` ✓
- No Tier 4 tests ✓
- Invariants are essential (= 3-region decision boundary + observability + schema integrity) ✓
- Audit: 0 violations (tier audit --strict exit 0) ✓

## sandbox_2 next step

v8 retry post-merge (combined with PR-L + PR-M): expected 4 of 5 v7 [error] cases (13033 / 13398 / 13453 / 13977) to drop to 0.

Refs FP-0008 PR-I / PR-J / PR-H (prior wave) + sandbox_2 v7 broker post 2026-05-28.