### PR TITLE
feat(fp-0008): PR-L — per-phase max_act_turns budgets for swe_bench

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -5,6 +5,7 @@ input: plan
 role: implementer
 model_class: standard
 allowed_ops: [file, shell]
+max_act_turns: 30
 ---
 
 Implement the edit plan by modifying the repository files.

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -14,21 +14,31 @@ likely to need editing.
 ## Where to find the input fields
 
 This phase receives an input artifact of type `swe_bench_input`. Its `data`
-object contains every field you need. Concretely, the input shape is:
+object contains every field you need. The shape (with ALL-CAPS placeholders
+denoting values you must read from the actual artifact in the prompt — NOT
+literal values to copy) is:
 
 ```json
 {
   "type": "swe_bench_input",
   "data": {
-    "instance_id": "django__django-12345",
-    "repo": "django/django",
-    "base_commit": "d16bfe05a744909de4b27f5875fe0d4ed41ce607",
-    "problem_statement": "<GitHub issue body, typically 1-3 paragraphs>",
-    "hints_text": "<optional hint string, may be empty>",
-    "test_patch": "<unified diff text>"
+    "instance_id": "<INSTANCE_ID_FROM_ARTIFACT>",
+    "repo": "<REPO_SLUG_FROM_ARTIFACT>",
+    "base_commit": "<COMMIT_SHA_FROM_ARTIFACT>",
+    "problem_statement": "<GITHUB_ISSUE_BODY_FROM_ARTIFACT>",
+    "hints_text": "<OPTIONAL_HINTS_FROM_ARTIFACT>",
+    "test_patch": "<UNIFIED_DIFF_FROM_ARTIFACT>"
   }
 }
 ```
+
+**Critical**: the angle-bracketed `<…_FROM_ARTIFACT>` strings above are
+documentation placeholders showing the SHAPE of the data. They are NOT
+literal values you should copy into shell commands, file paths, grep
+patterns, or any other tool call. The actual values live in the prompt's
+input-artifact section; read them from there and inline the REAL values
+(e.g. real owner/repo string like `astropy/astropy`, real 40-char SHA,
+real issue body text) into your tool calls.
 
 All six fields are present in the prompt's artifact section that the OS
 gives you (= no need to grep / search / probe to find them). Read them

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -5,6 +5,7 @@ input: swe_bench_input
 role: analyst
 model_class: standard
 allowed_ops: [file, grep, shell]
+max_act_turns: 20
 ---
 
 Understand the problem by reading the `problem_statement` and finding the

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -5,6 +5,7 @@ input: exploration | verify_state
 role: architect
 model_class: standard
 allowed_ops: [file, grep]
+max_act_turns: 15
 ---
 
 Produce a concrete edit plan: a list of files to change and a description of

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -6,6 +6,7 @@ role: reporter
 model_class: standard
 can_finish: true
 allowed_ops: [shell]
+max_act_turns: 10
 ---
 
 Produce the final output by capturing the git diff of all changes made during

--- a/src/reyn/stdlib/skills/swe_bench/phases/setup.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/setup.md
@@ -5,6 +5,7 @@ input: swe_bench_input
 role: initializer
 model_class: standard
 allowed_ops: [shell]
+max_act_turns: 5
 ---
 
 Prepare the repository for the fix by checking out the exact commit the

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -6,6 +6,7 @@ role: tester
 model_class: standard
 allowed_ops: [file, shell]
 max_retries: 3
+max_act_turns: 30
 ---
 
 Run the SWE-bench test patch against the current codebase to determine whether

--- a/tests/test_swe_bench_phase_act_turn_budgets.py
+++ b/tests/test_swe_bench_phase_act_turn_budgets.py
@@ -1,0 +1,137 @@
+"""Tier 2: OS invariant — swe_bench per-phase max_act_turns budgets are wired
+end-to-end through the compile pipeline (FP-0008 PR-L).
+
+Verifies that the per-phase budget declared in each swe_bench phase frontmatter
+(`max_act_turns: N`) is loaded by the compiler and exposed on the compiled
+`Skill.phases[<name>].max_act_turns` — NOT the global default of 10.
+
+No mocks.  Uses real load_dsl_skill on the installed on-disk files.
+No private-state assertions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.schemas.models import Skill
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+_SKILL_MD = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench" / "skill.md"
+)
+_SKILL_ROOT = _SKILL_MD.parent.parent.parent  # src/reyn/stdlib/
+
+
+def _load() -> Skill:
+    """Load the swe_bench skill via the full compile pipeline."""
+    return load_dsl_skill(_SKILL_MD, skill_root=_SKILL_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Expected per-phase budgets (= the hypothesis declared in phase frontmatter)
+# ---------------------------------------------------------------------------
+
+_EXPECTED_BUDGETS: dict[str, int] = {
+    "setup":   5,
+    "explore": 20,
+    "plan":    15,
+    "apply":   30,
+    "verify":  30,
+    "report":  10,
+}
+
+_GLOBAL_DEFAULT = 10
+
+
+# ---------------------------------------------------------------------------
+# Test 1: each phase has the expected per-phase budget (not the global default)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("phase_name,expected_budget", sorted(_EXPECTED_BUDGETS.items()))
+def test_per_phase_budget_matches_frontmatter(phase_name: str, expected_budget: int):
+    """Tier 2: Skill.phases[<phase>].max_act_turns == declared frontmatter value.
+
+    Guards that the per-phase `max_act_turns` frontmatter key survives the full
+    compile pipeline (parser → expander → Skill model).  A failure here means
+    the loader silently dropped the budget declaration and would fall back to
+    the global default (10), leaving the LLM under-budgeted for complex phases.
+    """
+    skill = _load()
+    phase = skill.phases[phase_name]
+    assert phase.max_act_turns == expected_budget, (
+        f"Phase '{phase_name}': expected max_act_turns={expected_budget}, "
+        f"got {phase.max_act_turns}. "
+        f"Check frontmatter in phases/{phase_name}.md."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: all phases with budgets != global default are not accidentally 10
+# ---------------------------------------------------------------------------
+
+def test_no_phase_silently_reverts_to_global_default():
+    """Tier 2: None of the 6 swe_bench phases silently inherit the global default.
+
+    The global default (10) is insufficient for complex phases like apply and
+    verify.  This test pins that every phase has an explicit, intentional budget
+    that differs from what the executor would supply if max_act_turns were 0.
+
+    Note: report is intentionally set to 10 (same value as global default) but
+    the mechanism is still exercised — the frontmatter declares it explicitly,
+    so the value is not a silent fallback but a deliberate choice.
+    """
+    skill = _load()
+    phases_without_budget = [
+        name
+        for name, phase in skill.phases.items()
+        if phase.max_act_turns == 0
+    ]
+    assert phases_without_budget == [], (
+        f"These phases have max_act_turns=0 (= compiler default for 'not declared'): "
+        f"{phases_without_budget}. Add explicit max_act_turns to their frontmatter."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: heavy phases (apply + verify) exceed the global default significantly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("phase_name", ["apply", "verify"])
+def test_heavy_phases_exceed_global_default(phase_name: str):
+    """Tier 2: apply and verify phases have budgets > global default (10).
+
+    These phases require multiple file edits, shell ops, pytest runs, and
+    parse-and-retry loops.  A budget <= 10 is empirically insufficient
+    (sandbox_2 v7 calibration: 4 of 5 aborts hit remaining_act_turns=0).
+    """
+    skill = _load()
+    budget = skill.phases[phase_name].max_act_turns
+    assert budget > _GLOBAL_DEFAULT, (
+        f"Phase '{phase_name}': budget {budget} must exceed global default "
+        f"{_GLOBAL_DEFAULT} to handle SWE-bench task complexity."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: setup phase has a budget <= global default (lightweight phase)
+# ---------------------------------------------------------------------------
+
+def test_setup_phase_is_lightweight():
+    """Tier 2: setup phase budget <= global default (5 turns is sufficient).
+
+    setup only does `git checkout`, `git status`, and `pytest --version` —
+    three shell ops at most.  A budget significantly above 10 would be wasteful
+    and mask runaway behaviour.
+    """
+    skill = _load()
+    budget = skill.phases["setup"].max_act_turns
+    assert budget <= _GLOBAL_DEFAULT, (
+        f"Phase 'setup': budget {budget} should be <= {_GLOBAL_DEFAULT} "
+        f"(setup is a lightweight phase doing only git checkout + verify)."
+    )

--- a/tests/test_swe_bench_skill_pr_j_placeholder_shape.py
+++ b/tests/test_swe_bench_skill_pr_j_placeholder_shape.py
@@ -1,0 +1,143 @@
+"""Tier 2: FP-0008 PR-J -- explore.md placeholder shape (PR-F class N+1).
+
+Defect surfaced by sandbox_2 v6 calibration retry (2026-05-28): 2 of 9
+aborts hit `file_not_found` cascades because the LLM literal-copied
+the example values from explore.md's input-artifact JSON shape block:
+
+  Pre-PR-J explore.md:
+    "instance_id": "django__django-12345",
+    "repo": "django/django",
+
+A weak LLM (gemini-2.5-flash-lite) treated `"django/django"` as the
+literal repo name (= not pattern-match value, but actual data) and
+fabricated context anchored on that. File reads + grep ops then hit
+file_not_found because the actual task was an astropy instance, not
+a django one.
+
+This is the same class of bug as PR-F Defect 1 (setup.md `<base_commit>`
+literal-emission). PR-G partial fix gap: PR-G rewrote explore.md's
+field-access section but used realistic-looking example values
+(`"django__django-12345"`, `"django/django"`) instead of ALL-CAPS
+obvious-placeholder shape that PR-F established as the canonical
+mitigation.
+
+This file pins:
+  1. explore.md's JSON example uses `<*_FROM_ARTIFACT>` ALL-CAPS
+     placeholder shape (NOT `django/django` or other realistic-
+     looking literals that weak LLMs might copy).
+  2. explore.md includes an explicit Critical warning that the
+     placeholders are SHAPE documentation, not values to copy.
+  3. No literal-looking realistic example values (django/django,
+     django__django-N) appear inside the input-artifact JSON shape
+     block.
+
+Tier rule discipline: every test docstring opens with Tier 2; no
+mocks; no private-state assertions; no format-pinning.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+def _read_explore_md() -> str:
+    return (_SKILL_ROOT / "phases" / "explore.md").read_text(encoding="utf-8")
+
+
+def test_explore_md_uses_all_caps_placeholder_in_artifact_block() -> None:
+    """Tier 2: explore.md input-artifact JSON shape uses _FROM_ARTIFACT placeholders."""
+    text = _read_explore_md()
+    # At least one ALL-CAPS _FROM_ARTIFACT marker must appear in the
+    # input-artifact block (= the canonical PR-F-style mitigation shape).
+    assert "_FROM_ARTIFACT" in text, (
+        "explore.md must use ALL-CAPS `<*_FROM_ARTIFACT>` placeholder "
+        "shape in the input-artifact JSON example (PR-F class extension)"
+    )
+
+
+def test_explore_md_warns_against_literal_copy() -> None:
+    """Tier 2: explore.md includes an explicit Critical warning against literal copy.
+
+    The PR-F established pattern: the LLM must understand the
+    angle-bracketed placeholders are SHAPE documentation. Without an
+    explicit warning, weak LLMs literal-copy.
+    """
+    text = _read_explore_md().lower()
+    # Soft check: "critical" + "not a literal" / "not literal" / "shape"
+    # phrasing must appear.
+    assert "critical" in text, (
+        "explore.md must include a Critical warning section about "
+        "placeholder vs value distinction"
+    )
+    assert (
+        "not" in text and ("literal" in text or "copy" in text or "shape" in text)
+    ), (
+        "explore.md's Critical section must articulate that placeholders "
+        "are NOT literal values to copy"
+    )
+
+
+def test_explore_md_does_not_use_realistic_placeholder_repo_name() -> None:
+    """Tier 2: explore.md does NOT show `django/django` as an example repo.
+
+    Realistic-looking example values triggered literal-copy by weak
+    LLMs in v6 retry. The PR-J fix replaces them with ALL-CAPS shape
+    placeholders. This test catches accidental regression to
+    realistic-example shape (= e.g. future author rewrites with
+    'requests/requests' or 'numpy/numpy').
+
+    Rule (negative): no `<owner>/<owner>` pattern with realistic
+    org/repo names inside the input-artifact JSON shape block.
+    Note: this DOES allow such names in non-shape contexts (e.g. the
+    intro paragraph mentioning "SWE-bench Verified covers Django,
+    Astropy, ..." would be fine).
+    """
+    text = _read_explore_md()
+    # Find the input-artifact JSON shape block by anchor + closing brace.
+    anchor = "Where to find the input fields"
+    if anchor in text:
+        block_start = text.index(anchor)
+        # Search up to the next h2 / h1 boundary
+        block_end_candidates = [
+            text.find("\n## ", block_start + 1),
+            text.find("\n# ", block_start + 1),
+            len(text),
+        ]
+        block_end = min([c for c in block_end_candidates if c > 0])
+        block = text[block_start:block_end]
+    else:
+        block = text
+    forbidden_realistic = (
+        '"django/django"',
+        '"django__django-12345"',
+        '"requests/requests"',
+        '"numpy/numpy"',
+    )
+    for phrase in forbidden_realistic:
+        assert phrase not in block, (
+            f"explore.md input-artifact shape block re-introduces a "
+            f"realistic-looking placeholder {phrase!r}. Weak LLMs "
+            f"literal-copy these. Use ALL-CAPS `<*_FROM_ARTIFACT>` "
+            f"shape instead (PR-F established pattern)."
+        )
+
+
+def test_explore_md_artifact_block_uses_six_placeholder_fields() -> None:
+    """Tier 2: ALL-CAPS placeholders cover the six swe_bench_input fields.
+
+    The placeholder shape preserves the field names + types so the LLM
+    can still pattern-match the artifact shape; only the example
+    values change from realistic to obvious-placeholder.
+    """
+    text = _read_explore_md()
+    # Each of the six fields must appear in the input-artifact block.
+    for field in ("instance_id", "repo", "base_commit",
+                  "problem_statement", "hints_text", "test_patch"):
+        assert field in text, (
+            f"explore.md must still reference the {field!r} field "
+            f"(= field-access pattern preserved post-PR-J)"
+        )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-L: per-phase act-turn budgets for swe_bench

## Primary evidence

sandbox_2 v7 calibration (2026-05-28): 4 of 5 aborts hit `remaining_act_turns: 0` at abort time. Global default `max_act_turns_per_phase: 10` (src/reyn/config.py:220) is insufficient for SWE-bench task complexity.

## Mechanism: Option A — per-phase frontmatter field

`max_act_turns: N` added to each `phases/*.md` frontmatter. The wiring already existed end-to-end — no new OS code added:

- `compiler/parser.py`: reads `int(fm.get("max_act_turns", 0))`
- `compiler/ir.py`: `PhaseDef.max_act_turns = 0` (0 = use system default)
- `compiler/expander.py`: passes value through to `Phase(max_act_turns=...)`
- `kernel/phase_executor.py:490`: `phase_def.max_act_turns if > 0 else 10`

Global default (`src/reyn/config.py:220`) unchanged at 10 — all other skills unaffected.

## Per-phase budgets applied

| Phase | Budget | Rationale |
|-------|--------|-----------|
| setup | 5 | `git checkout` + `git status` + `pytest --version` — 3 shell ops max |
| explore | 20 | Grep + multi-file read to build mental model |
| plan | 15 | Synthesize edit plan, re-read targeted sections if needed |
| apply | 30 | Multiple file reads + edits + `py_compile` checks |
| verify | 30 | Write patch file + `git apply` + pytest run + parse + revert |
| report | 10 | `git diff HEAD` + field collection — light LLM work |

## Files touched

- `src/reyn/stdlib/skills/swe_bench/phases/setup.md` — `max_act_turns: 5`
- `src/reyn/stdlib/skills/swe_bench/phases/explore.md` — `max_act_turns: 20`
- `src/reyn/stdlib/skills/swe_bench/phases/plan.md` — `max_act_turns: 15`
- `src/reyn/stdlib/skills/swe_bench/phases/apply.md` — `max_act_turns: 30`
- `src/reyn/stdlib/skills/swe_bench/phases/verify.md` — `max_act_turns: 30`
- `src/reyn/stdlib/skills/swe_bench/phases/report.md` — `max_act_turns: 10`
- `tests/test_swe_bench_phase_act_turn_budgets.py` (NEW) — 4 Tier-2 invariant tests

## Test plan

- [x] `python3 scripts/test_tier_audit.py --strict tests/test_swe_bench_phase_act_turn_budgets.py` — exit 0 (4 tests, 0 errors, 0 warnings)
- [x] `python -m pytest -q tests/test_swe_bench_phase_act_turn_budgets.py tests/test_swe_bench_skill_*.py` — 38 passed
- [x] `ruff check src/reyn/stdlib/skills/swe_bench/ src/reyn/compiler/ tests/test_swe_bench_phase_act_turn_budgets.py` — clean

**Tier-rule self-check**: all test docstrings start `"""Tier 2: ...`; no mocks/patch/MagicMock; no private-state assertions (`._field`); no format-pinning; no Tier-4 items.

Refs FP-0008 PR-I / PR-J / PR-H / PR-K + sandbox_2 v7 calibration 2026-05-28.