### PR TITLE
fix(tui): AsyncStackPanel narrow-layout no-wrap (on_resize + overflow:hidden)

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -184,8 +184,22 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
     AsyncStackPanel {
         dock: bottom;
         height: auto;
+        max-height: 6;
         padding: 0 1;
         background: transparent;
+        overflow: hidden;
+    }
+    AsyncStackPanel #async_stack_text {
+        /* Force the inner Static to clip rather than wrap when a
+           pre-truncated row's residual width briefly exceeds the
+           constrained panel width (= e.g. between Ctrl+B side-panel
+           mount and the next ``_refresh`` tick, ``self.size.width``
+           reports the wider pre-mount value and ``_build_lines``
+           pre-truncates against that stale budget). Combined with
+           the ``on_resize`` hook below which forces a synchronous
+           rebuild on the new width, wrap is eliminated. */
+        height: auto;
+        overflow: hidden;
     }
     AsyncStackPanel:focus {
         background: #1a1a1a;
@@ -244,6 +258,19 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
 
     def on_blur(self, event: events.Blur) -> None:
         """Repaint to drop the cursor caret when focus leaves."""
+        self._refresh()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Rebuild rows when the panel's own width changes.
+
+        ``_build_lines`` uses ``self.size.width`` to compute
+        ``body_budget`` for per-row truncation. Without this hook the
+        panel only refreshes on the 1 Hz tick, so opening the side
+        panel (Ctrl+B) leaves a window where the rows render
+        pre-truncated against the old wider budget — Rich then wraps
+        the residue across multiple visual lines instead of eliding
+        cleanly. Exploration finding #2, 2026-05-28.
+        """
         self._refresh()
 
     # ── Public API ───────────────────────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration finding #2 (P1, S cost).

## Observation
With Ctrl+B side panel open + 2+ concurrent async rows visible, each row visually wrapped across multiple terminal lines instead of eliding to one line. With 3 concurrent skills, the bottom strip ate 9+ vertical cells for what should have been 3.

## Root cause
`_build_lines` computes per-row truncation budget from `self.size.width` at build time. The 1 Hz `set_interval` tick was the only refresh path, so between a Ctrl+B side-panel mount (= `self.size.width` shrinks) and the next tick, rows rendered pre-truncated against the old wider budget. Rich's Text renderer then wrapped the residue across visual lines instead of eliding.

## Fix (defense-in-depth)

1. **`on_resize` hook** calling `_refresh()` synchronously so the new `self.size.width` immediately drives the next `_build_lines` invocation. Eliminates the stale-budget window.

2. **CSS `overflow: hidden`** on both the panel and the inner Static, plus **`max-height: 6`** on the panel (= `_CAP=5` visible entries + 1 line for the `… +N more` overflow indicator). Any pre-truncated residue or future renderer wrap is now clipped rather than expanding the panel height.

## Live verify (tmux MCP, repro of original finding)

**Before**: 3 concurrent `word_stats_demo` skills + Ctrl+B → each row wrapped across ~3 lines, panel ate 9+ vertical cells.

**After**: same scenario → 3 rows × 1 line each, eliding to `⟳ async: 2026…demo  · Ns`. Toggle Ctrl+B off→on→off→on stays clean (on_resize hook fires correctly).

```
⟳ async: 2026…demo  · 23.7s
⟳ async: 2026…demo  · 26.0s
⟳ async: 2026…demo  · 52.3s
```

## Test plan
- [x] `pytest tests/cli/test_async_stack_*` → 45/45 pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 pass
- [x] `python scripts/test_tier_audit.py --strict <touched test files>` → 0 errors
- [x] `ruff check src/reyn/chat/tui/widgets/async_stack_panel.py` → clean
- [x] Manual tmux MCP repro: 3 concurrent skills + Ctrl+B toggle → 1-line elide preserved

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)