### PR TITLE
fix(tui): AsyncStackPanel elide-priority — prefer summary over agent_id

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -654,17 +654,24 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         summary_budget = max(
             0, body_budget - prefix_cells - sep_cells - elapsed_cells,
         )
-        # Wave-11 B#5: when summary would be wiped to ≤ a few cells
-        # by a long agent_id (typical UUID = 36 cells), middle-elide
-        # the id to free room for the more-informative summary.
-        # Identity preserved via head+tail preview; full id is rarely
-        # needed at-a-glance, but the summary tells the user what's
-        # actually running.
-        if entry.summary and summary_budget < _MIN_SUMMARY_BUDGET_CELLS:
+        # Wave-11 B#5 + exploration finding #3 (2026-05-28): the
+        # summary (= skill name) is the most user-readable signal —
+        # ``word_stats_demo`` tells the user WHAT is running, while
+        # the agent_id (= timestamp + skill + 4-hex suffix) is mostly
+        # a unique-ish handle. So whenever rendering the full summary
+        # would require truncating it, middle-elide the agent_id
+        # first to free cells (= the head+tail preview still
+        # disambiguates among ≤ _CAP simultaneous tasks, while the
+        # full skill name lands without the ``word_stats…`` truncation
+        # the prior threshold-based logic left behind for narrow-ish
+        # widths). Identity floor is _MIN_ELIDED_ID_CELLS; below that
+        # the panel is so narrow we accept summary truncation too.
+        desired_summary_cells = cell_len(entry.summary or "")
+        if entry.summary and summary_budget < desired_summary_cells:
             fixed_cells = cell_len(f"{glyph} async: ") + sep_cells + elapsed_cells
             target_id_cells = max(
                 _MIN_ELIDED_ID_CELLS,
-                body_budget - fixed_cells - _MIN_SUMMARY_BUDGET_CELLS,
+                body_budget - fixed_cells - desired_summary_cells,
             )
             if target_id_cells < cell_len(agent_id):
                 agent_id = _middle_elide_id(agent_id, target_id_cells)


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration finding #3 (P2, S cost).

## Observation
When the agent_id has a 4-hex suffix (= 37 cells, e.g. `20260528T111015Z_word_stats_demo_6c71`), the skill name `word_stats_demo` was truncated to `word_stats…` while the longer agent_id rendered in full. The most user-readable signal was the first thing to drop.

## Root cause
The Wave-11 B#5 elide logic was threshold-gated on `summary_budget < _MIN_SUMMARY_BUDGET_CELLS` (= 8). For widths in the `8 ≤ summary_budget < cell_len(summary)` band, the threshold never fired so the id stayed full and the summary truncated. reyn's actual agent_id format (`{ts}_{name}_{4-hex}`, 37 cells) hits this band frequently.

## Fix
Invert the trigger to `summary_budget < desired_summary_cells` (= elide id whenever the full summary wouldn't fit). The agent_id's head+tail middle-elide preserves enough to disambiguate among `≤ _CAP` simultaneous tasks (= timestamp head + 4-hex suffix tail both retained), while the full skill name lands.

## Live verify

Direct render test at width 76, agent_id `20260528T111015Z_word_stats_demo_6c71` + summary `word_stats_demo`:

**Before** (threshold-gated, no elide trigger):
```
⟳ async: 20260528T111015Z_word_stats_demo_6c71  · word_stats…  · ...
```

**After** (this PR, summary-priority elide):
```
⟳ async: 20260528T11101…stats_demo_6c71  · word_stats_demo  · ...
```

= 4-hex suffix tail `_6c71` preserved for differentiation among concurrent runs, skill name fully visible.

## Test plan
- [x] `pytest tests/cli/test_async_stack_*` → 45/45 pass (existing narrow-elide test invariants hold)
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 pass
- [x] `python scripts/test_tier_audit.py --strict tests/cli/test_async_stack_narrow_elide.py` → 0 errors
- [x] `ruff check src/reyn/chat/tui/widgets/async_stack_panel.py` → clean
- [x] Direct render test at width 76 reproduces the inversion behavior (= scripted Python verify since the specific width band needed precise width control beyond casual tmux dogfood)

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)