### PR TITLE
fix(tui): AsyncStackPanel — suppress ▌ caret synchronously on Esc

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -222,6 +222,11 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         # Clamped on every navigation step + on render so deletes
         # / completions can't leave a dangling out-of-range cursor.
         self._cursor: int = 0
+        # Set synchronously in ``_return_focus_to_input`` so the
+        # immediately-following ``_refresh()`` renders without the ▌
+        # caret. Cleared on the next ``on_focus`` (= when the panel
+        # actually regains focus). Exploration finding #6.
+        self._focus_releasing: bool = False
 
     # ── Textual lifecycle ────────────────────────────────────────────────────
 
@@ -240,6 +245,9 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         # time. Without this, returning to the panel after entries
         # changed could land on a stale offset.
         self._cursor = 0
+        # Clear the focus-releasing flag (= we're back, so the caret
+        # should render again on the next paint).
+        self._focus_releasing = False
         self._refresh()
 
     def on_blur(self, event: events.Blur) -> None:
@@ -459,7 +467,17 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
             pass
 
     def _return_focus_to_input(self) -> None:
-        """Esc — return focus to the InputBar without staging anything."""
+        """Esc — return focus to the InputBar without staging anything.
+
+        ``_focus_releasing`` is flipped BEFORE the actual focus transfer
+        so the synchronous ``_refresh()`` repaints the rows without the
+        ▌ caret. Without this, Textual's ``on_blur`` only fires on the
+        next event-loop tick (= ``has_focus`` stays True during the
+        gap), so a casual Esc leaves a ~1-frame ghost caret on screen.
+        Exploration finding #6, 2026-05-28.
+        """
+        self._focus_releasing = True
+        self._refresh()
         try:
             from .input_bar import InputBar
             self.app.query_one("#inputbar", InputBar).focus_input()
@@ -588,7 +606,14 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         # cancelled), so the cursor might drift out of bounds.
         if visible:
             self._cursor = max(0, min(self._cursor, len(visible) - 1))
-        focused = self.has_focus
+        # ``_focus_releasing`` is set synchronously in ``_return_focus_to_input``
+        # before focus actually transfers, so a refresh fired in that same
+        # call paints the rows WITHOUT the ▌ caret. Without this, the user
+        # sees a ~1-frame ghost caret after pressing Esc because Textual
+        # dispatches ``on_blur`` only on the next event-loop tick (= the
+        # window when ``has_focus`` is still True but the panel is no
+        # longer the active focus target). Exploration finding #6, 2026-05-28.
+        focused = self.has_focus and not self._focus_releasing
         for i, (agent_id, entry, glyph) in enumerate(visible):
             if i > 0:
                 t.append("\n")


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration finding #6 (P3, S cost).

## Observation
Pressing Esc while the AsyncStackPanel had F4 focus correctly returned focus to the InputBar (typing went to input), but the `▌` cursor glyph remained visible for ~1 render frame before clearing — a brief false impression that focus didn't transfer.

## Root cause
`_return_focus_to_input` called `InputBar.focus_input()` which dispatches the actual focus transfer via Textual's message system. The panel's `on_blur` handler (which calls `_refresh()` to drop the caret) only runs on the NEXT event-loop tick. During that gap, `self.has_focus` is still True so the next render within the gap paints the caret.

## Fix
Introduce `_focus_releasing` flag, set synchronously in `_return_focus_to_input` BEFORE the focus call. `_build_lines` treats `focused = self.has_focus and not self._focus_releasing` so the immediately-following `_refresh()` paints rows without the caret. `on_focus` resets the flag when the panel actually regains focus (= round-trip clean).

## Live verify (tmux MCP)

1. Boot reyn chat + spawn a skill so the panel has a row
2. F4 → `▌ ⟳ async: ...` (caret visible)
3. Esc + `capture-pane` within ~50ms
   - **Before**: caret still visible (~1 frame ghost)
   - **After**: caret cleared synchronously
4. F4 again → caret reappears (round-trip clean)

## Test plan
- [x] `pytest tests/cli/test_async_stack_*` → 45/45 pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 pass
- [x] `ruff check src/reyn/chat/tui/widgets/async_stack_panel.py` → clean
- [x] Manual tmux MCP: F4 → Esc (50ms capture) → no ghost; F4 again → caret restored

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)