### PR TITLE
docs(control-ir): add mcp_drop_server op kind entry

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -22,6 +22,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `web_fetch` | Fetch a single URL and return extracted text | Tier 1 — default allow; `web.fetch: deny` in `reyn.yaml` blocks |
 | `mcp` | Call a tool on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter |
 | `mcp_install` | Install an MCP server from the registry into the project config | `permissions.mcp_install: true` in skill frontmatter |
+| `mcp_drop_server` | Remove an MCP server from project/local/user config (FP-0034 §D23, inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
 | `embed` | Embed texts or artifact chunks via a LiteLLM embedding model | none (embedding API cost) |
 | `index_write` | Write embedded chunks to an index backend (SQLite) | none |
 | `index_query` | Semantic vector search over one indexed source | none |


### PR DESCRIPTION
**[lead-coder]** docs-maintainer audit で primary evidence backed drift 検出した sync gap fix。

## Primary evidence

- `src/reyn/op_runtime/mcp_drop_server.py` で `kind="mcp_drop_server"` 既 定義 (line 184, 203, 261)
- `docs/reference/runtime/control-ir.md` の Op kinds テーブルに **未記載**

= CLAUDE.md hard rule (`docs/reference/runtime/control-ir.md must stay synced with OP_KIND_MODEL_MAP`) 対象の docs drift。

## Change

`mcp_drop_server` 行を `mcp_install` 直後に追加 (= inverse op、 論理位置):

\`\`\`
| \`mcp_drop_server\` | Remove an MCP server from project/local/user config (FP-0034 §D23, inverse of \`mcp_install\`) | \`permissions.mcp_drop_server: true\` in skill frontmatter |
\`\`\`

## Test plan

- [x] docs only change (= no code、 audit / test impact なし)
- [x] CLAUDE.md hard rule sync 履行
- [x] docs-maintainer audit suggest 採用

## docs-maintainer activation 経由 detect ⭐

本 PR = docs-maintainer (= 新 role agent、 2026-05-28 deploy) 活用 instance 確立、 lead-coder 負荷軽減 effective path 検証。 future drift detection sustain 期待。

🤖 Generated with [Claude Code](https://claude.com/claude-code)