### PR TITLE
docs(readme): fix broken link + update local embedding status

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ reyn run my_skill '{"type":"request","data":{"topic":"AI in education"}}'
 reyn run my_skill "Summarize AI trends in education."
 ```
 
-Full tutorial: [docs/guide/getting-started/02-your-first-skill.md](docs/guide/getting-started/02-your-first-skill.md)
+Full tutorial: [docs/guide/getting-started/03-your-first-skill.md](docs/guide/getting-started/03-your-first-skill.md)
 
 ### Index documents and chat
 
@@ -403,7 +403,7 @@ The "framework foundation" framing is honest, not a hedge. The following live do
 - **RAG evaluation framework.** Hosted eval pipelines and rubric marketplaces — eval-as-a-service is a downstream consumer of `LLMReplay`, not bundled.
 - **IDE integration.** Editor plugins, in-IDE retrieval, semantic search panels — downstream territory.
 - **Memory layer migration.** Reyn 0.x's inline-expansion memory continues to work; migration to `recall(sources=["memory"])` is phase 1.5 (1.1+), gated on dogfood-retest non-regression.
-- **Local embedding models.** sentence-transformers / ollama — phase 2.
+- **Ollama embedding models.** ollama-backed local embedding — phase 2. (= sentence-transformers local-mini / local-e5 shipped in FP-0043 Phase 2/4, default since 2026-05)
 - **Sensitive-data redaction policy.** Phase 2 — in 1.0, the docs warn but do not redact.
 
 Post-1.0 vision (= the "Flywheel" — operational intelligence, skill self-improvement, RAG routing) is captured under `docs/deep-dives/research/landscape/milestone-flywheel.md` and FP-0006..0010. Mentioned for transparency, not promised.


### PR DESCRIPTION
**[lead-coder]** docs-maintainer audit suggest 採用 amendment (#1 + #2 high severity)。

## docs-maintainer audit 結果反映

### Fix 1: Broken relative link (severity: high)
README.md line 104 broken link primary evidence backed:
- 旧: \`02-your-first-skill.md\` (= 不存在)
- 新: \`03-your-first-skill.md\` (= 実ファイル、 \`02-chat-mode.md\` 挿入で番号繰り下げ)

### Fix 2: \"What's not in 1.0\" local embedding 陳腐化 (severity: high)
README.md line 406 = FP-0043 Phase 2/4 land 後の状態反映漏れ:
- primary evidence (3 件):
  - \`src/reyn/embedding/sentence_transformers_provider.py\` 存在 (= FP-0043 Phase 2 Component B)
  - \`src/reyn/config.py:1150\` \`embedding_class = \"local-mini\"\` default (= Phase 4 以降)
  - \`docs/concepts/rag.md:186\` \"two sentence-transformers-backed (= local; activated by the local-embed extras)\" として documented
- 訂正: ollama-backed のみ phase 2 残、 sentence-transformers shipped articulate

### Defer: Project Status section (severity: medium)
docs-maintainer audit #3 (= line 390-395 stale snapshot) は別 batch update に defer (= timing lead-coder 判断 articulate)。

## Test plan

- [x] docs only change (= code / audit impact なし)
- [x] primary evidence backed drift fix
- [x] docs-maintainer audit suggest 採用

🤖 Generated with [Claude Code](https://claude.com/claude-code)