### PR TITLE
docs(cli): add eval benchmark + mcp refresh subcommand reference

### DIFF
--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -59,12 +59,15 @@ While a session is active, lines starting with `/` are intercepted and never rou
 
 | Command | Effect |
 |---------|--------|
+| `/agent edit role <text>` | Rewrite the attached agent's persona (#906) |
 | `/agent new <name>` | Create new agent and attach to it |
 | `/agents` | List loaded agents and which one is currently attached |
 | `/answer <id-prefix> <text>` | Answer a pending `ask_user` / permission prompt (id-prefix: any unique prefix of the intervention id) |
 | `/attach <name>` | Switch the REPL pointer to another agent (the previous one keeps running in the background) |
 | `/budget [reset]` | Full budget breakdown; `/budget reset` clears per-process counters (see [config/budget](../config/budget.md)) |
 | `/cancel <id-prefix>` | Cancel a running skill (accepts any unique prefix of the run_id) |
+| `/clear-history` | Wipe chat history (**destructive**; clears in-memory + persistent history, #903) |
+| `/concept <term>` | Inline glossary lookup (T1-3) |
 | `/copy [N\|list]` | Copy an agent reply to the clipboard (1 = newest, 2 = one turn back, …) |
 | `/cost` | Quick token + USD cost summary for this agent |
 | `/cost-inline` | Toggle per-turn cost suffix in conversation |

--- a/docs/reference/cli/eval.md
+++ b/docs/reference/cli/eval.md
@@ -7,23 +7,47 @@ applies_to: [reyn eval]
 
 # `reyn eval`
 
-Evaluate a skill. Three subcommands:
+Evaluate a skill. Subcommands:
 
 | Subcommand | Description |
 |------------|-------------|
 | `run` | Run a skill against a golden JSONL dataset; gate CI on pass rate |
 | `report` | Summarise past `reyn eval run` results for a skill |
 | `compare` | Compare pass rate across two skill versions using P6 event log |
+| `benchmark` | Run a skill across a JSONL task file with concurrent dispatch (FP-0008 PR-B); used by SWE-bench harness |
 | `spec` | Legacy: run an `eval.md` spec file non-interactively (backward compat) |
 
 ## Synopsis
 
 ```
-reyn eval run <SKILL_NAME> [OPTIONS]
-reyn eval report <SKILL_NAME> [OPTIONS]
-reyn eval compare <SKILL_NAME> [OPTIONS]
-reyn eval spec FILE [OPTIONS]
+reyn eval run       <SKILL_NAME> [OPTIONS]
+reyn eval report    <SKILL_NAME> [OPTIONS]
+reyn eval compare   <SKILL_NAME> [OPTIONS]
+reyn eval benchmark <SKILL_NAME> --tasks PATH --output DIR
+                                 [--concurrency N] [--limit N] [--resume]
+                                 [--model MODEL] [common flags]
+reyn eval spec      FILE [OPTIONS]
 ```
+
+## Subcommand: `benchmark`
+
+Run a skill against a JSONL task file with concurrent dispatch. Each line of the task file is one task input matching the skill's `input_schema`. Used as the execution layer for the SWE-bench harness wrapper (see [guide: run-swe-bench](../../guide/for-users/run-swe-bench.md)).
+
+```
+reyn eval benchmark <SKILL_NAME> --tasks PATH --output DIR [OPTIONS]
+```
+
+| Flag | Description |
+|---|---|
+| `<SKILL_NAME>` | Skill name to run (resolved via reyn/project → local → stdlib) |
+| `--tasks PATH` | **required** — JSONL task file; each line = one task input |
+| `--output DIR` | **required** — output directory; results written under `<DIR>/run_<timestamp>/` |
+| `--concurrency N` | Max concurrent skill runs (default: `4`) |
+| `--limit N` | Stop after the first N tasks (applied after `--resume` filtering) |
+| `--resume` | Resume from latest prior run in `<output>`; skip already-completed tasks |
+| `--model MODEL` | Model override (default: from `reyn.yaml`) |
+
+The benchmark dispatcher uses workspace-isolated runs (= `_benchmark_isolated_workspace` in `cli/commands/eval_benchmark.py`) so concurrent task runs do not collide on cwd/files.
 
 ## Non-interactive constraint
 

--- a/docs/reference/cli/mcp.md
+++ b/docs/reference/cli/mcp.md
@@ -12,14 +12,34 @@ Manage MCP server configuration and expose Reyn agents to external MCP-aware cli
 ## Synopsis
 
 ```
-reyn mcp serve     [--project PATH] [--timeout SECONDS] [common flags]
-reyn mcp search    <QUERY>
-reyn mcp install   <SERVER_ID> [--scope SCOPE] [--env KEY=VALUE ...] [--non-interactive]
-reyn mcp list      [--probe]
-reyn mcp remove    <NAME> [--scope SCOPE]
-reyn mcp set-secret <SERVER> <KEY>[=<VALUE>]
-reyn mcp clear-secret <SERVER> [<KEY>]
+reyn mcp serve         [--project PATH] [--timeout SECONDS] [common flags]
+reyn mcp search        <QUERY>
+reyn mcp install       <SERVER_ID> [--scope SCOPE] [--env KEY=VALUE ...] [--non-interactive]
+reyn mcp list          [--probe]
+reyn mcp remove        <NAME> [--scope SCOPE]
+reyn mcp refresh       [--project PATH]
+reyn mcp set-secret    <SERVER> <KEY>[=<VALUE>]
+reyn mcp clear-secret  <SERVER> [<KEY>]
 ```
+
+### `refresh` quick reference
+
+`reyn mcp refresh` (= FP-0037-S1) re-probes all configured MCP servers and writes results to the persistent cache file (`.reyn/state/mcp_tools_cache.json`). Active `reyn chat` sessions pick up the new cache on their next turn boundary — **no restart required**.
+
+```
+reyn mcp refresh [--project PATH]
+```
+
+| Flag | Description |
+|---|---|
+| `--project PATH` | Project root containing `reyn.yaml` (default: closest ancestor with `reyn.yaml`) |
+
+Use cases:
+- After `reyn mcp install` adds a new server, force a re-probe so active chat sessions see it on the next turn.
+- After editing `.reyn/mcp.yaml` by hand, push the change into the active cache.
+- As a periodic operator command to refresh tool availability without restarting chat sessions.
+
+**Passive auto-refresh** (= FP-0037-S2、 PR #1003): active chat sessions also watch `reyn.yaml` mtime + `.reyn/mcp.yaml` mtime on each turn boundary; an edit to either is picked up without the explicit `reyn mcp refresh` invocation. The explicit CLI subcommand remains useful for the use cases above (= operator-driven re-probe / scripted refresh).
 
 ## Overview
 


### PR DESCRIPTION
**[lead-coder]** docs-maintainer audit suggest 採用 amendment (= 5 CLI reference gaps fix)。

## docs-maintainer audit 結果反映

### Fix 1: `docs/reference/cli/eval.md` — `benchmark` subcommand reference
- Commit `1f34c044` (2026-05-27) FP-0008 PR-B #976
- subcommand table + synopsis + benchmark section + flag table 追加

### Fix 2: `docs/reference/cli/mcp.md` — `refresh` subcommand reference
- Commit `ca555dbf` (2026-05-28) FP-0037-S1 #1002
- synopsis 行 + quick reference section (= 「no restart required」 + 3 use cases)

### Fix 3: `docs/reference/cli/mcp.md` — FP-0037-S2 passive auto-refresh 補足
- PR #1003 FP-0037-S2 yaml mtime watch passive auto-refresh articulate
- `refresh` section に passive auto-refresh note 追加

### Fix 4-6: `docs/reference/cli/chat.md` — 3 slash commands 追加
- `/agent edit role <text>` (= #906、 bbfd4daf、 rewrite attached agent's persona)
- `/clear-history` (= #903、 080b3a9c、 destructive chat history wipe)
- `/concept <term>` (= 9ab828ba、 docs refresh 28秒後 landing で取りこぼし)

## Test plan
- [x] docs only change
- [x] primary evidence backed (= src 実装 + commit cite)
- [x] docs-maintainer audit suggest 採用

🤖 Generated with [Claude Code](https://claude.com/claude-code)