### PR TITLE
feat(fp-0008): PR-Q v8 — LLM API retry / error recovery (OS llm.py)

### DIFF
--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -190,6 +190,7 @@ class LLMCallRecorder:
             project_context=self._project_context,
             agent_role=self._agent_role,
             trace_caller=f"phase:{phase}",
+            event_log=self._events,
         )
         raw = llm_result.data
         cost_usd: float | None = None

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Coroutine, TypeVar, Union
 
+import httpx
 import litellm
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,7 @@ from reyn.schemas.models import ContextFrame
 
 if TYPE_CHECKING:
     from reyn.budget.budget import BudgetTracker
+    from reyn.events.events import EventLog
 
 T = TypeVar("T")
 
@@ -408,6 +410,103 @@ class LLMToolCallResult:
     # raw message for debugging:
     raw_message: object | None = None
 
+# ---------------------------------------------------------------------------
+# Infrastructure retry — exponential backoff on transient LLM API errors
+# ---------------------------------------------------------------------------
+
+# Retryable: infrastructure / transient errors where the same call may succeed.
+# Non-retryable: semantic / auth / quota errors (4xx) where retry won't help.
+_RETRYABLE_LITELLM_EXCEPTIONS = (
+    litellm.exceptions.Timeout,           # request timed out
+    litellm.exceptions.APIConnectionError, # network-level connection failure
+    litellm.exceptions.ServiceUnavailableError,  # 503
+    litellm.exceptions.BadGatewayError,    # 502
+    litellm.exceptions.InternalServerError, # 500
+)
+
+_LLM_RETRY_MAX_ATTEMPTS: int = 3   # total attempts = 1 initial + 2 retries
+_LLM_RETRY_BASE_S: float = 2.0     # first backoff: 2s → 4s → 8s (capped at 16s)
+_LLM_RETRY_MAX_BACKOFF_S: float = 16.0
+
+
+def _is_retryable_exc(exc: BaseException) -> bool:
+    """Return True for infrastructure errors that justify a retry attempt.
+
+    Catches litellm's typed exceptions for 5xx / timeout / connection failures.
+    Also catches httpx transport-level errors that LiteLLM may not wrap when
+    the request fails before reaching the provider's HTTP response logic.
+    """
+    if isinstance(exc, _RETRYABLE_LITELLM_EXCEPTIONS):
+        return True
+    if isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout)):
+        return True
+    return False
+
+
+def _backoff_s(attempt: int) -> float:
+    """Exponential backoff: 2s, 4s, 8s, … capped at _LLM_RETRY_MAX_BACKOFF_S.
+
+    ``attempt`` is 0-indexed (= attempt 0 is the first retry, after the initial
+    call fails).  Min 0.0 — never negative if someone passes a negative index.
+    """
+    return min(_LLM_RETRY_BASE_S * (2 ** attempt), _LLM_RETRY_MAX_BACKOFF_S)
+
+
+async def _llm_call_with_retry(
+    coro_fn,
+    model: str,
+    event_log: "EventLog | None",
+) -> object:
+    """Execute ``coro_fn()`` with infrastructure-error retry + backoff.
+
+    ``coro_fn`` must be a zero-arg async callable that returns the litellm
+    response object.  It is called once per attempt.
+
+    Emits ``llm_call_retry`` on each retry and ``llm_call_retry_exhausted``
+    when all attempts are exhausted.  When ``event_log`` is None, observability
+    events are silently skipped (= callers without an EventLog context).
+
+    Raises the last exception when all retries are exhausted.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(_LLM_RETRY_MAX_ATTEMPTS):
+        try:
+            return await coro_fn()
+        except BaseException as exc:
+            if not _is_retryable_exc(exc):
+                raise
+            last_exc = exc
+            retries_remaining = _LLM_RETRY_MAX_ATTEMPTS - attempt - 1
+            if retries_remaining == 0:
+                if event_log is not None:
+                    try:
+                        event_log.emit(
+                            "llm_call_retry_exhausted",
+                            model=model,
+                            attempt_n=attempt + 1,
+                            error_kind=type(exc).__name__,
+                        )
+                    except Exception:
+                        pass
+                raise
+            backoff = _backoff_s(attempt)
+            if event_log is not None:
+                try:
+                    event_log.emit(
+                        "llm_call_retry",
+                        model=model,
+                        attempt_n=attempt + 1,
+                        error_kind=type(exc).__name__,
+                        backoff_s=backoff,
+                    )
+                except Exception:
+                    pass
+            await asyncio.sleep(backoff)
+    # Should be unreachable — loop always raises or returns.
+    assert last_exc is not None
+    raise last_exc  # pragma: no cover
+
+
 _SYSTEM_BASE = """\
 You are an AI agent executing a phase in a structured workflow.
 Respond with ONLY valid JSON — no markdown fences, no explanation, no comments.
@@ -618,6 +717,7 @@ async def call_llm(
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,
     trace_caller: str | None = None,
+    event_log: "EventLog | None" = None,
 ) -> LLMCallResult:
     """
     Call the LLM and return a parsed JSON dict.
@@ -737,19 +837,26 @@ async def call_llm(
                 "spec_kwargs": spec_kwargs,
             })
 
-        try:
-            response = await litellm.acompletion(
-                model=effective_model,
-                messages=messages,
-                response_format={"type": "json_object"},
-                **spec_kwargs,
-                **common_kwargs,
-                **extra,
-            )
-        except Exception:
-            response = await litellm.acompletion(
-                model=effective_model, messages=messages, **spec_kwargs, **common_kwargs, **extra,
-            )
+        async def _do_call() -> object:
+            try:
+                return await litellm.acompletion(
+                    model=effective_model,
+                    messages=messages,
+                    response_format={"type": "json_object"},
+                    **spec_kwargs,
+                    **common_kwargs,
+                    **extra,
+                )
+            except Exception:
+                return await litellm.acompletion(
+                    model=effective_model,
+                    messages=messages,
+                    **spec_kwargs,
+                    **common_kwargs,
+                    **extra,
+                )
+
+        response = await _llm_call_with_retry(_do_call, effective_model, event_log)
 
         usage = _extract_usage(response)
         last_raw = response.choices[0].message.content or ""
@@ -825,6 +932,7 @@ async def call_llm_tools(
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,
     trace_caller: str | None = None,
+    event_log: "EventLog | None" = None,
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -950,7 +1058,9 @@ async def call_llm_tools(
         },
     })
 
-    response = await litellm.acompletion(**call_kwargs)
+    response = await _llm_call_with_retry(
+        lambda: litellm.acompletion(**call_kwargs), effective_model, event_log
+    )
 
     msg = response.choices[0].message
     usage = _extract_usage(response) or TokenUsage()

--- a/tests/test_llm_call_retry.py
+++ b/tests/test_llm_call_retry.py
@@ -1,0 +1,391 @@
+"""Tier 2: OS invariant — LLM call infrastructure retry + event observability.
+
+Guards the retry wrapper around the LiteLLM call boundary introduced in
+FP-0008 PR-Q v8:
+
+1. test_no_retry_on_success
+   Successful call on first attempt → no retry, no retry events emitted.
+
+2. test_retry_and_succeed
+   Timeout on attempt 1 → retry fires, succeeds on attempt 2.
+   llm_call_retry event emitted with correct fields.
+
+3. test_all_retries_exhausted
+   Timeout on all 3 attempts → llm_call_retry_exhausted event emitted,
+   exception propagates.
+
+4. test_4xx_no_retry
+   BadRequestError (4xx semantic) → immediate failure, no retry, no events.
+
+5. test_backoff_shape
+   Backoff values follow the exponential curve: _backoff_s(0)=2s,
+   _backoff_s(1)=4s, _backoff_s(2)=8s — capped at 16s.
+
+6. test_httpx_errors_retried
+   Raw httpx.ConnectError and httpx.ReadTimeout are retried (= transport-level
+   errors LiteLLM may not wrap).
+
+No real network calls — tests use a counter-based async callable stub that
+fails K times then succeeds (real instance, no unittest.mock).
+asyncio.sleep is monkeypatched to a no-op so tests run at full speed.
+"""
+from __future__ import annotations
+
+import httpx
+import litellm
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.llm.llm import (
+    _LLM_RETRY_BASE_S,
+    _LLM_RETRY_MAX_ATTEMPTS,
+    _LLM_RETRY_MAX_BACKOFF_S,
+    _backoff_s,
+    _is_retryable_exc,
+    _llm_call_with_retry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event_log() -> EventLog:
+    """Real EventLog with no persistent subscribers (in-memory only)."""
+    return EventLog()
+
+
+class _FailThenSucceedCallable:
+    """Zero-arg async callable: raises ``exc`` for the first ``fail_count``
+    calls, then returns ``success_response``.
+
+    Real instance — no mock machinery.
+    """
+
+    def __init__(self, fail_count: int, exc: BaseException, success_response: object) -> None:
+        self._fail_count = fail_count
+        self._exc = exc
+        self._success = success_response
+        self.call_count: int = 0
+
+    async def __call__(self) -> object:
+        self.call_count += 1
+        if self.call_count <= self._fail_count:
+            raise self._exc
+        return self._success
+
+
+class _AlwaysFailCallable:
+    """Zero-arg async callable that always raises ``exc``."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.call_count: int = 0
+
+    async def __call__(self) -> object:
+        self.call_count += 1
+        raise self._exc
+
+
+def _fake_response(content: str = '{"ok": true}') -> object:
+    """Minimal litellm-response-shaped object for testing."""
+    class _Choice:
+        class _Msg:
+            def __init__(self, c: str) -> None:
+                self.content = c
+                self.tool_calls = None
+        message = _Msg(content)
+        finish_reason = "stop"
+
+    class _Response:
+        choices = [_Choice()]
+        usage = None
+
+    return _Response()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: no retry on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_success(monkeypatch):
+    """Tier 2: retry wrapper — success on first attempt emits no retry events.
+
+    Invariant: when the coro_fn succeeds immediately, _llm_call_with_retry
+    must not emit llm_call_retry or llm_call_retry_exhausted.
+    """
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", lambda _: _no_op_coro())
+
+    log = _make_event_log()
+    resp = _fake_response()
+
+    async def _ok():
+        return resp
+
+    result = await _llm_call_with_retry(_ok, "model-x", log)
+    assert result is resp
+
+    types = [e.type for e in log.all()]
+    assert "llm_call_retry" not in types
+    assert "llm_call_retry_exhausted" not in types
+
+
+async def _no_op_coro():
+    """Dummy coroutine for asyncio.sleep monkey-patch."""
+
+
+# ---------------------------------------------------------------------------
+# Test 2: retry on timeout, succeed on attempt 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_and_succeed(monkeypatch):
+    """Tier 2: retry wrapper — timeout on attempt 1, success on attempt 2.
+
+    Invariant: one llm_call_retry event emitted, no exhausted event, correct
+    error_kind and attempt_n fields.
+    """
+    import reyn.llm.llm as llm_mod
+    slept: list[float] = []
+    async def _fake_sleep(s: float) -> None:
+        slept.append(s)
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep)
+
+    log = _make_event_log()
+    resp = _fake_response()
+    stub = _FailThenSucceedCallable(
+        fail_count=1,
+        exc=litellm.exceptions.Timeout("timed out", model="m", llm_provider="p"),
+        success_response=resp,
+    )
+
+    result = await _llm_call_with_retry(stub, "test-model", log)
+    assert result is resp
+    assert stub.call_count == 2
+
+    # Exactly one retry event (present) and no exhausted event (absent)
+    retry_events = [e for e in log.all() if e.type == "llm_call_retry"]
+    assert retry_events, "at least one llm_call_retry event must be emitted after a timeout"
+    assert not any(e.type == "llm_call_retry_exhausted" for e in log.all()), (
+        "llm_call_retry_exhausted must NOT be emitted when retry succeeds"
+    )
+
+    ev = retry_events[0]
+    assert ev.data["model"] == "test-model"
+    assert ev.data["error_kind"] == "Timeout"
+    assert ev.data["attempt_n"] == 1
+    assert ev.data["backoff_s"] == _backoff_s(0)
+
+    # Sleep called once with the correct backoff
+    assert slept == [_backoff_s(0)]
+
+
+# ---------------------------------------------------------------------------
+# Test 3: all retries exhausted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_retries_exhausted(monkeypatch):
+    """Tier 2: retry wrapper — all 3 attempts fail → exhausted event + exception.
+
+    Invariant: llm_call_retry_exhausted emitted on terminal failure; the
+    original exception propagates; call_count == _LLM_RETRY_MAX_ATTEMPTS.
+    """
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
+
+    log = _make_event_log()
+    exc = litellm.exceptions.ServiceUnavailableError("503", response=None, llm_provider="test", model="m")
+    stub = _AlwaysFailCallable(exc)
+
+    with pytest.raises(litellm.exceptions.ServiceUnavailableError):
+        await _llm_call_with_retry(stub, "model-503", log)
+
+    assert stub.call_count == _LLM_RETRY_MAX_ATTEMPTS
+
+    exhausted = [e for e in log.all() if e.type == "llm_call_retry_exhausted"]
+    assert exhausted, "llm_call_retry_exhausted must be emitted when all retries fail"
+    assert exhausted[0].data["model"] == "model-503"
+    assert exhausted[0].data["error_kind"] == "ServiceUnavailableError"
+
+
+async def _fake_sleep_noop(_: float) -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Test 4: 4xx error — no retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_4xx_no_retry(monkeypatch):
+    """Tier 2: retry wrapper — BadRequestError (4xx) propagates immediately, no retry.
+
+    Invariant: semantic / validation errors must not be retried (retrying
+    won't fix a bad request shape).
+    """
+    import reyn.llm.llm as llm_mod
+    sleep_calls: list[float] = []
+    async def _record_sleep(s: float) -> None:
+        sleep_calls.append(s)
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _record_sleep)
+
+    log = _make_event_log()
+    exc = litellm.exceptions.BadRequestError(
+        "invalid request", response=None, llm_provider="test", model="m"
+    )
+    stub = _AlwaysFailCallable(exc)
+
+    with pytest.raises(litellm.exceptions.BadRequestError):
+        await _llm_call_with_retry(stub, "model-bad", log)
+
+    # Only attempted once — no retry
+    assert stub.call_count == 1
+    assert sleep_calls == []
+
+    types = [e.type for e in log.all()]
+    assert "llm_call_retry" not in types
+    assert "llm_call_retry_exhausted" not in types
+
+
+# ---------------------------------------------------------------------------
+# Test 5: backoff shape
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_shape():
+    """Tier 2: _backoff_s — exponential curve capped at max.
+
+    Verifies the mathematical shape without relying on exact constants so a
+    future config change doesn't silently break the invariant.
+    """
+    # Monotonically increasing up to the cap
+    b0 = _backoff_s(0)
+    b1 = _backoff_s(1)
+    b2 = _backoff_s(2)
+    b3 = _backoff_s(3)
+
+    assert b0 > 0, "first backoff must be positive"
+    assert b1 > b0, "second backoff must be larger than first"
+    assert b2 > b1, "third backoff must be larger than second"
+
+    # Each step doubles up to the cap
+    assert b1 == min(b0 * 2, _LLM_RETRY_MAX_BACKOFF_S)
+    assert b2 == min(b0 * 4, _LLM_RETRY_MAX_BACKOFF_S)
+
+    # Cap is respected
+    assert b3 <= _LLM_RETRY_MAX_BACKOFF_S
+
+    # Concrete values (documentation + regression guard against constant changes)
+    assert b0 == _LLM_RETRY_BASE_S
+    assert b1 == _LLM_RETRY_BASE_S * 2
+    assert b2 == _LLM_RETRY_BASE_S * 4
+
+
+# ---------------------------------------------------------------------------
+# Test 6: httpx transport errors retried
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_httpx_errors_retried(monkeypatch):
+    """Tier 2: retry wrapper — httpx.ConnectError and httpx.ReadTimeout are retried.
+
+    LiteLLM may not wrap transport-level errors that occur before the HTTP
+    response is received. The retry wrapper must catch them directly.
+    """
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
+
+    resp = _fake_response()
+
+    for exc_cls in (httpx.ConnectError, httpx.ReadTimeout):
+        log = _make_event_log()
+        try:
+            raw_exc = exc_cls("connection failed")
+        except TypeError:
+            # Some httpx exception constructors require a request object
+            raw_exc = exc_cls.__new__(exc_cls)
+
+        stub = _FailThenSucceedCallable(
+            fail_count=1,
+            exc=raw_exc,
+            success_response=resp,
+        )
+
+        result = await _llm_call_with_retry(stub, "model-net", log)
+        assert result is resp, f"{exc_cls.__name__} should be retried"
+        assert stub.call_count == 2
+
+        retry_events = [e for e in log.all() if e.type == "llm_call_retry"]
+        assert retry_events, f"{exc_cls.__name__}: expected at least one llm_call_retry event"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: _is_retryable_exc classification
+# ---------------------------------------------------------------------------
+
+
+def test_is_retryable_exc_classification():
+    """Tier 2: _is_retryable_exc — correct classification of retryable vs non-retryable.
+
+    Checks the classification function directly against concrete exception
+    instances without exercising the full retry loop.
+    """
+    # Retryable
+    assert _is_retryable_exc(litellm.exceptions.Timeout("t", model="m", llm_provider="p"))
+    assert _is_retryable_exc(litellm.exceptions.APIConnectionError("c", llm_provider="p", model="m"))
+    assert _is_retryable_exc(
+        litellm.exceptions.InternalServerError("500", response=None, llm_provider="p", model="m")
+    )
+    assert _is_retryable_exc(
+        litellm.exceptions.ServiceUnavailableError("503", response=None, llm_provider="p", model="m")
+    )
+    assert _is_retryable_exc(
+        litellm.exceptions.BadGatewayError("502", response=None, llm_provider="p", model="m")
+    )
+
+    # Non-retryable
+    assert not _is_retryable_exc(
+        litellm.exceptions.BadRequestError("400", response=None, llm_provider="p", model="m")
+    )
+    assert not _is_retryable_exc(
+        litellm.exceptions.AuthenticationError("401", response=None, llm_provider="p", model="m")
+    )
+    assert not _is_retryable_exc(
+        litellm.exceptions.RateLimitError("429", response=None, llm_provider="p", model="m")
+    )
+    assert not _is_retryable_exc(ValueError("unexpected"))
+
+
+# ---------------------------------------------------------------------------
+# Test 8: event_log=None suppresses events (no crash)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_log_none_no_crash(monkeypatch):
+    """Tier 2: retry wrapper — event_log=None suppresses observability events without crashing.
+
+    Callers that don't pass an EventLog must still benefit from retry behavior.
+    """
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
+
+    resp = _fake_response()
+    stub = _FailThenSucceedCallable(
+        fail_count=1,
+        exc=litellm.exceptions.Timeout("timed out", model="m", llm_provider="p"),
+        success_response=resp,
+    )
+
+    # No event_log — must not raise
+    result = await _llm_call_with_retry(stub, "model-y", None)
+    assert result is resp
+    assert stub.call_count == 2


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-Q v8 implementation

## Summary

- sandbox_2 v8 calibration (2026-05-28) identified 2 instances (12907 / 14309) where the OS terminated a skill run due to a LiteLLM infrastructure error (timeout / 5xx), not a cognition error. Pre-fix the OS had zero retry logic — one network blip killed the entire run.
- Added `_llm_call_with_retry` wrapper around both `litellm.acompletion` call sites in `llm.py` (`call_llm` and `call_llm_tools`), with exponential backoff (2s → 4s → 8s, cap 16s, max 3 attempts).
- `LLMCallRecorder` now passes its `EventLog` to `call_llm` so `llm_call_retry` / `llm_call_retry_exhausted` events are emitted into the P6 audit trail.

## Fix shape

- **Retryable**: `litellm.exceptions.Timeout`, `APIConnectionError`, `InternalServerError` (500), `BadGatewayError` (502), `ServiceUnavailableError` (503), `httpx.ConnectError`, `httpx.ReadTimeout`
- **Not retried**: 4xx semantic errors (`BadRequestError`, `AuthenticationError`, `RateLimitError`) — retrying won't fix a bad request shape or exhausted quota
- **Max retries**: 3 total attempts (= 1 initial + 2 retries); author judgment — lead-coder spec said "1-2 retries before terminal failure", 3 total is the minimum that covers one retry + one grace attempt

## Files touched

- `src/reyn/llm/llm.py` — `_llm_call_with_retry`, `_is_retryable_exc`, `_backoff_s`, `_RETRYABLE_LITELLM_EXCEPTIONS`; added `event_log` param to `call_llm` and `call_llm_tools`
- `src/reyn/kernel/llm_call_recorder.py` — passes `event_log=self._events` to `call_llm`
- `tests/test_llm_call_retry.py` — NEW: 8 Tier-2 tests

## Test plan

- [x] `python3 scripts/test_tier_audit.py --strict tests/test_llm_call_retry.py` → exit 0, 8/8 pass
- [x] `python -m pytest -q tests/test_llm_call_retry.py tests/test_llm_call_recorder_invariants.py tests/test_llm_tools.py tests/test_llm_trace_dump.py` → 37 passed
- [x] `ruff check src/reyn/llm/llm.py tests/test_llm_call_retry.py src/reyn/kernel/llm_call_recorder.py` → clean
- [ ] Full CI (triggered by push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)