### PR TITLE
feat(swe_bench): deterministic test_patch sanitizer at verify entry (FP-0008 PR-O v8)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -7,6 +7,19 @@ model_class: standard
 allowed_ops: [file, shell]
 max_retries: 3
 max_act_turns: 30
+preprocessor:
+  # FP-0008 PR-O v8: deterministic test_patch sanitizer normalizes
+  # line endings (CRLF → LF), strips BOM, ensures trailing newline.
+  # Runs BEFORE the LLM enters this phase. The sanitized string is
+  # written into `data.test_patch`, replacing the LLM-visible field
+  # so `git apply` operates on a clean diff.
+  - type: python
+    module: ./sanitize_test_patch.py
+    function: sanitize_test_patch
+    mode: safe
+    into: data.test_patch
+    output_schema:
+      type: string
 ---
 
 Run the SWE-bench test patch against the current codebase to determine whether
@@ -14,23 +27,34 @@ the fix is correct.
 
 ## Step 1 — Apply the test_patch
 
-The `test_patch` field in the input contains a unified diff that adds or
-modifies test files.  Apply it with:
+The `data.test_patch` field in the input is a unified diff. The
+verify-phase preprocessor has already normalized it deterministically
+(= CRLF → LF, BOM stripped, trailing newline ensured) so `git apply`
+operates on a clean diff.
+
+Write the sanitized diff to a temp file (e.g. `.reyn/swe_bench_test.patch`)
+then apply with robust flags:
 
 ```
-git apply --check <test_patch_content>
+git apply --3way --recount --whitespace=fix .reyn/swe_bench_test.patch
 ```
 
-Write `test_patch` to a temporary file (e.g. `.reyn/swe_bench_test.patch`)
-then run:
+The flags layer second-line defenses on top of the preprocessor:
+`--3way` enables merge-style recovery on context drift, `--recount`
+tolerates off-by-N context line counts, and `--whitespace=fix`
+forgives trailing-space drift.
 
-```
-git apply .reyn/swe_bench_test.patch
-```
+If `git apply` STILL fails after preprocessor sanitization + robust
+flags, record the failure in `failure_summary` (= include the exact
+stderr from git apply, NOT a vague "patch failed" summary) and treat
+this as a verify execution failure (not a test failure) — transition
+back to apply so the patch can be re-examined.
 
-If `git apply` fails, record the failure in `failure_summary` and treat this
-as a verify execution failure (not a test failure) — transition back to apply
-so the patch can be re-examined.
+**Do NOT skip the test_patch** — an unapplied test patch means tests
+can't be evaluated; that's NOT a pass. The schema invariant
+(`oneOf` on `swe_bench_result`) rejects `tests_passed=true` with an
+empty patch, but an unapplied test_patch could still produce a
+mis-attributed `tests_passed=true` if the LLM bypasses Step 1.
 
 ## Step 2 — Run the tests
 

--- a/src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py
+++ b/src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py
@@ -1,0 +1,63 @@
+"""Deterministic test_patch sanitization for swe_bench verify phase.
+
+FP-0008 PR-O v8 (= sandbox_2 v8 calibration retry 2026-05-28 root
+cause): SWE-bench input ``data.test_patch`` may carry artifacts from
+upstream collection / serialization that cause ``git apply`` to
+reject the patch:
+
+- **Line endings**: CRLF in patch content while target files have
+  LF (or vice versa) — the diff context lines don't byte-match.
+- **BOM**: a UTF-8 BOM at the start of the patch string makes the
+  first diff header unparseable.
+- **Trailing-newline drift**: missing final newline causes some git
+  versions to reject the last hunk.
+
+This module is a ``safe``-mode Python preprocessor step that runs
+BEFORE the LLM enters the verify phase. The verify-phase
+preprocessor writes the return value into ``data.test_patch`` via
+``into:``, replacing the LLM-visible field with the deterministically-
+normalized version.
+
+Sanitization is conservative + idempotent: valid diffs pass through
+unchanged; only the specific artifact patterns above are normalized.
+
+Author judgment per [[feedback_root_cause_until_structural_fix]]:
+deterministic preprocessor > LLM-driven prompt-side normalization
+(= the LLM cannot reliably perform byte-level diff cleanup without
+mistakes; OS preprocessor is structurally sound).
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def sanitize_test_patch(data: Mapping[str, Any]) -> str:
+    """Return a normalized ``data.test_patch`` string.
+
+    Steps (all idempotent):
+      1. Remove UTF-8 BOM if present at the start.
+      2. Normalize line endings to LF (= strip CR characters).
+      3. Ensure the patch ends with a single trailing newline.
+
+    Returns the sanitized string. When ``test_patch`` is absent or
+    non-string, returns an empty string (= the preprocessor ``into:``
+    target lands as empty; ``verify.md``'s instruction handles the
+    empty case explicitly).
+    """
+    raw = data.get("test_patch")
+    if not isinstance(raw, str) or not raw:
+        return ""
+
+    # 1. BOM
+    if raw.startswith("﻿"):
+        raw = raw[1:]
+
+    # 2. Line endings
+    if "\r" in raw:
+        raw = raw.replace("\r\n", "\n").replace("\r", "\n")
+
+    # 3. Trailing newline
+    if not raw.endswith("\n"):
+        raw = raw + "\n"
+
+    return raw

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -40,6 +40,16 @@ permissions:
     - path: "*"
       scope: recursive
   shell: true
+  # FP-0008 PR-O v8: deterministic test_patch sanitizer (= line-ending
+  # / BOM / trailing-newline normalization) runs as a `safe`-mode
+  # python preprocessor step at the verify phase entry, BEFORE the
+  # LLM issues `git apply`. Eliminates the sandbox_2 v8 test_patch
+  # apply-reject failure class structurally.
+  python:
+    - module: ./sanitize_test_patch.py
+      function: sanitize_test_patch
+      mode: safe
+      timeout: 5
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---

--- a/tests/test_swe_bench_sanitize_test_patch.py
+++ b/tests/test_swe_bench_sanitize_test_patch.py
@@ -1,0 +1,111 @@
+"""Tier 2: FP-0008 PR-O v8 — test_patch sanitization preprocessor.
+
+sandbox_2 v8 calibration retry (2026-05-28) showed 1 instance + 2
+rollback events with test_patch git apply reject. Root cause:
+SWE-bench input `data.test_patch` may carry line-ending / BOM /
+trailing-newline artifacts that vanilla git apply rejects.
+
+Fix shape (structural per [[feedback_root_cause_until_structural_fix]]):
+deterministic Python preprocessor step at verify phase entry
+sanitizes test_patch BEFORE the LLM issues `git apply`. The step
+is declared with ``into: data.test_patch`` so the return value (=
+the sanitized string) replaces the LLM-visible field.
+
+This file pins the sanitizer behavior:
+  1. CRLF line endings normalized to LF.
+  2. UTF-8 BOM at start stripped.
+  3. Missing trailing newline added.
+  4. Already-clean diff passed through unchanged (= idempotent).
+  5. Absent / non-string test_patch yields "" (= verify phase
+     handles the empty case via instruction).
+  6. Combined artifacts (= BOM + CRLF + no-newline) all handled
+     in one pass.
+
+Tier rule discipline: every test docstring opens with Tier 2; no
+mocks; no private-state assertions; no format-pinning (= we check
+behavior on the returned string, not internal state).
+"""
+from __future__ import annotations
+
+from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+
+def test_crlf_normalized_to_lf() -> None:
+    """Tier 2: CRLF line endings in test_patch normalize to LF."""
+    raw = "diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@\r\n-a\r\n+b\r\n"
+    out = sanitize_test_patch({"test_patch": raw})
+    assert "\r" not in out, (
+        f"CRLF normalization failed; output still contains '\\r': {out!r}"
+    )
+
+
+def test_bom_stripped() -> None:
+    """Tier 2: UTF-8 BOM at start of test_patch is stripped."""
+    raw = "﻿diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-a\n+b\n"
+    out = sanitize_test_patch({"test_patch": raw})
+    assert not out.startswith("﻿")
+    assert out.startswith("diff ")
+
+
+def test_trailing_newline_added() -> None:
+    """Tier 2: missing trailing newline is added (= single \\n at end)."""
+    raw = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-a\n+b"
+    out = sanitize_test_patch({"test_patch": raw})
+    assert out.endswith("\n")
+
+
+def test_already_clean_diff_passthrough() -> None:
+    """Tier 2: a clean diff passes through with no transformations."""
+    clean = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-a\n+b\n"
+    out = sanitize_test_patch({"test_patch": clean})
+    assert out == clean, (
+        f"Clean diff should pass through unchanged; got modification: "
+        f"original={clean!r} sanitized={out!r}"
+    )
+
+
+def test_absent_test_patch_yields_empty() -> None:
+    """Tier 2: data without test_patch field returns empty string."""
+    out = sanitize_test_patch({"instance_id": "t1"})
+    assert out == ""
+
+
+def test_non_string_test_patch_yields_empty() -> None:
+    """Tier 2: non-string test_patch (= None / int / dict) returns empty."""
+    assert sanitize_test_patch({"test_patch": None}) == ""
+    assert sanitize_test_patch({"test_patch": 42}) == ""
+    assert sanitize_test_patch({"test_patch": {}}) == ""
+
+
+def test_empty_string_test_patch_yields_empty() -> None:
+    """Tier 2: empty-string test_patch returns empty string (= no-op)."""
+    assert sanitize_test_patch({"test_patch": ""}) == ""
+
+
+def test_combined_artifacts_all_handled() -> None:
+    """Tier 2: BOM + CRLF + missing trailing newline all sanitized in one pass."""
+    raw = "﻿diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@\r\n-a\r\n+b"
+    out = sanitize_test_patch({"test_patch": raw})
+    assert not out.startswith("﻿")
+    assert "\r" not in out
+    assert out.endswith("\n")
+    assert out.startswith("diff ")
+
+
+def test_sanitization_idempotent_on_repeated_calls() -> None:
+    """Tier 2: sanitizing twice produces the same result as once."""
+    raw = "﻿diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@\r\n-a\r\n+b"
+    once = sanitize_test_patch({"test_patch": raw})
+    twice = sanitize_test_patch({"test_patch": once})
+    assert twice == once, (
+        "Sanitization is not idempotent — applying twice produced different "
+        f"output: once={once!r} twice={twice!r}"
+    )
+
+
+def test_lone_cr_normalized() -> None:
+    """Tier 2: classic-Mac lone CR line endings normalize to LF."""
+    raw = "diff --git a/x b/x\r--- a/x\r+++ b/x\r@@\r-a\r+b\r"
+    out = sanitize_test_patch({"test_patch": raw})
+    assert "\r" not in out
+    assert out.endswith("\n")


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-O v8 (sandbox_2 v8 calibration retry, Class C defect 1 instance + 2 rollback events on 13977-partial).

## Summary

- Adds a deterministic `safe`-mode Python preprocessor step at `swe_bench/verify` phase entry that normalizes `data.test_patch` (BOM strip / CRLF→LF / trailing newline) BEFORE the LLM issues `git apply`.
- Preprocessor returns the sanitized string and is declared with `into: data.test_patch` + `output_schema: {type: string}` — the LLM sees a clean diff in its input artifact.
- 10 Tier-2 tests cover CRLF / lone-CR / BOM / trailing-newline / combined / clean-passthrough / idempotency / absent / non-string / empty.

## Why structural (= preprocessor, not prompt instruction)

Per `[[feedback_root_cause_until_structural_fix]]` + `[[feedback_no_compromise_recommendation]]`: the LLM cannot reliably perform byte-level diff cleanup; deterministic OS-side normalization eliminates the failure class. Reusable for any future skill that needs canonical-diff input.

## Test plan

- [x] `pytest -q tests/test_swe_bench_sanitize_test_patch.py` — 10 passed
- [x] `pytest -q tests/ -k swe_bench` — 73 passed (no regression in adjacent skill_load / shape_only / placeholder pin tests)
- [x] `python scripts/test_tier_audit.py --strict tests/test_swe_bench_sanitize_test_patch.py` — 10 OK, 0 violations
- [x] `ruff check src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py tests/test_swe_bench_sanitize_test_patch.py` — clean
- [x] PR Tier-rule self-check (per `[[feedback_pr_tier_rule_self_check]]`): docstrings declare Tier 2 / no Tier-4 patterns / invariants are behavior contracts (= sanitize output shape, not algorithm internals) / audit-strict 0

## Cascade context

This is one of 4 PRs (PR-N / PR-O / PR-P / PR-Q) in the FP-0008 v8 cascade addressing sandbox_2 v8 calibration findings:

- PR-N: `control_ir_results` size cap (OS)
- **PR-O** (this PR): test_patch sanitization at swe_bench/verify entry
- PR-P: investigation-first per-turn act-op observation
- PR-Q: LLM API retry / error recovery (OS llm.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)