### PR TITLE
feat(fp-0008): PR-N v8 — control_ir_results per-result size cap (OS context_builder)

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -21,6 +21,123 @@ from reyn.schemas.models import (
 ARTIFACT_REF_THRESHOLD = 8000  # characters; larger artifacts are stored by ref in ContextFrame
 MAX_INLINE_BOOST = 65_536  # characters; artifacts up to 64KB are still inlined (inline-boost range)
 
+# Per-result size cap for control_ir_results (FP-0008 PR-N v8).
+# sandbox_2 v8 calibration (2026-05-28) showed file_read / shell op results
+# accumulating unbounded across act turns; at N=14 turns the prompt reached
+# 100K-400K tokens (396K / 366K / 217K / 113K / 101K observed), triggering
+# OS-side termination. 8 KiB per result keeps a 14-turn run well under 200K
+# characters of accumulated results while still fitting typical file snippets
+# and shell output. The full result body is preserved in the act_executed
+# event (P6 audit guarantee) and the LLM can issue a follow-up file_read with
+# offset/limit if it needs more content.
+MAX_CONTROL_IR_RESULT_BYTES = 8_192  # bytes; results exceeding this are truncated
+_TRUNCATION_PREVIEW_BYTES = 2_048   # bytes shown at the head of a truncated result
+_TRUNCATION_TAIL_BYTES = 512        # bytes shown at the tail of a truncated result
+
+
+def _large_field_keys(result: dict) -> list[str]:
+    """Return field names in *result* whose string values are candidates for truncation.
+
+    We truncate string-valued fields that are likely to carry large content:
+    ``content`` (file_read), ``stdout`` / ``stderr`` (shell / sandboxed_exec),
+    and ``output`` (any future op that follows the same convention).  All other
+    fields (status, kind, path, …) are left intact so the LLM retains
+    structured metadata.
+    """
+    return [k for k in ("content", "stdout", "stderr", "output") if isinstance(result.get(k), str)]
+
+
+def _truncate_string_to_bytes(s: str, max_bytes: int) -> tuple[str, int]:
+    """Return *(truncated_str, original_byte_len)*.
+
+    The returned string is at most *max_bytes* bytes when encoded as UTF-8.
+    We do a simple encode-slice-decode so we never split a multi-byte character.
+    """
+    encoded = s.encode("utf-8")
+    original = len(encoded)
+    if original <= max_bytes:
+        return s, original
+    return encoded[:max_bytes].decode("utf-8", errors="ignore"), original
+
+
+def cap_control_ir_result(
+    result: dict,
+    idx: int,
+    *,
+    events: Any = None,
+    phase: str | None = None,
+    run_id: str | None = None,
+    turn: int | None = None,
+) -> dict:
+    """Return *result* with large string fields truncated to MAX_CONTROL_IR_RESULT_BYTES.
+
+    If no field exceeds the cap the original dict is returned unchanged.
+    When truncation occurs:
+    - Each oversized field is replaced with a structured marker string that
+      includes the original byte count, a head preview, and a tail preview.
+    - A ``control_ir_result_truncated`` observability event is emitted so the
+      truncation is audit-visible (P6).
+
+    The marker format is deliberately human-readable and LLM-parseable so the
+    model can tell at a glance how much content was omitted and issue a
+    targeted file_read with offset/limit if it needs more.
+    """
+    large_keys = _large_field_keys(result)
+    if not large_keys:
+        return result
+
+    truncated_fields: dict[str, int] = {}
+    new_result = dict(result)
+
+    for key in large_keys:
+        value: str = result[key]
+        encoded = value.encode("utf-8")
+        original_bytes = len(encoded)
+        if original_bytes <= MAX_CONTROL_IR_RESULT_BYTES:
+            continue
+
+        # Build head + tail preview.
+        head_bytes = min(_TRUNCATION_PREVIEW_BYTES, MAX_CONTROL_IR_RESULT_BYTES)
+        tail_bytes = min(_TRUNCATION_TAIL_BYTES, MAX_CONTROL_IR_RESULT_BYTES - head_bytes)
+        head = encoded[:head_bytes].decode("utf-8", errors="ignore")
+        tail = encoded[-tail_bytes:].decode("utf-8", errors="ignore") if tail_bytes > 0 else ""
+
+        marker_parts = [
+            f"<truncated: original {original_bytes} bytes, cap {MAX_CONTROL_IR_RESULT_BYTES} bytes>",
+            f"<preview (first {len(head.encode())} bytes)>",
+            head,
+            "</preview>",
+        ]
+        if tail:
+            marker_parts += [
+                f"<tail (last {len(tail.encode())} bytes)>",
+                tail,
+                "</tail>",
+            ]
+        marker_parts.append(
+            "<note: full content preserved in act_executed event log (P6); "
+            "issue a file.read op with offset/limit for targeted access></note>"
+        )
+        new_result[key] = "\n".join(marker_parts)
+        truncated_fields[key] = original_bytes
+
+    if not truncated_fields:
+        return result
+
+    if events is not None:
+        events.emit(
+            "control_ir_result_truncated",
+            phase=phase,
+            run_id=run_id,
+            turn=turn,
+            result_idx=idx,
+            result_kind=result.get("kind"),
+            truncated_fields=truncated_fields,
+            cap_bytes=MAX_CONTROL_IR_RESULT_BYTES,
+        )
+
+    return new_result
+
 
 def maybe_ref_artifact(
     artifact: dict,
@@ -84,10 +201,27 @@ def build_frame(
     control_ir_results: list[dict] | None = None,
     artifact_path: str | None = None,
     remaining_act_turns: int | None = None,
+    run_id: str | None = None,
+    act_turn: int | None = None,
 ) -> ContextFrame:
     allowed_next = [c.next_phase for c in candidates]
     current_visit = visit_counts.get(phase_name, 1)
     total_steps = sum(visit_counts.values())
+
+    # Apply per-result size cap before the results enter the LLM prompt.
+    # Large file_read / shell / sandboxed_exec results can balloon the prompt
+    # to 100K-400K tokens over N=14 act turns (FP-0008 PR-N v8).
+    capped_results = [
+        cap_control_ir_result(
+            r,
+            idx,
+            events=events,
+            phase=phase_name,
+            run_id=run_id,
+            turn=act_turn,
+        )
+        for idx, r in enumerate(control_ir_results or [])
+    ]
 
     frame = ContextFrame(
         current_phase=phase_name,
@@ -107,7 +241,7 @@ def build_frame(
         output_language=output_language,
         model=effective_model,
         model_resolved=model_resolved,
-        control_ir_results=control_ir_results or [],
+        control_ir_results=capped_results,
         remaining_act_turns=remaining_act_turns,
     )
 

--- a/tests/test_context_builder_result_size_cap.py
+++ b/tests/test_context_builder_result_size_cap.py
@@ -1,0 +1,309 @@
+"""Tier 2: control_ir_results per-result size cap invariants (FP-0008 PR-N v8).
+
+The size-cap fix adds MAX_CONTROL_IR_RESULT_BYTES = 8_192.  Results whose
+string-valued content fields (content / stdout / stderr / output) exceed the
+cap are truncated with a structured marker; results below the cap pass through
+unchanged.  A ``control_ir_result_truncated`` observability event is emitted
+for every truncated result (P6 audit guarantee).
+
+Test coverage:
+  1. small result (< cap) → passed through unchanged, no event
+  2. large result (> cap) → content field truncated + marker present
+  3. truncation marker contains size signal (original byte count, cap)
+  4. observability event emitted with correct fields
+  5. result metadata fields (kind, status, path) survive truncation intact
+  6. cap value is tunable via exported constant
+  7. cumulative prompt size for N=10 turns with large results stays bounded
+  8. build_frame wires cap for every result in control_ir_results
+  9. result with no large-content fields passes through unchanged
+ 10. multiple large fields in one result (stdout + stderr) both truncated
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.context_builder import (
+    MAX_CONTROL_IR_RESULT_BYTES,
+    build_frame,
+    cap_control_ir_result,
+)
+from reyn.events.events import EventLog
+from reyn.schemas.models import (
+    CandidateOutput,
+    Phase,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _large_content(extra_bytes: int = 1000) -> str:
+    """Return a string whose UTF-8 encoding exceeds MAX_CONTROL_IR_RESULT_BYTES."""
+    target = MAX_CONTROL_IR_RESULT_BYTES + extra_bytes
+    return "A" * target
+
+
+def _small_content(under_bytes: int = 500) -> str:
+    """Return a string whose UTF-8 encoding is below MAX_CONTROL_IR_RESULT_BYTES."""
+    target = MAX_CONTROL_IR_RESULT_BYTES - under_bytes
+    return "B" * max(0, target)
+
+
+def _byte_len(s: str) -> int:
+    return len(s.encode("utf-8"))
+
+
+def _minimal_phase() -> Phase:
+    return Phase(
+        name="test_phase",
+        role="test",
+        instructions="test instructions",
+        input_schema={},
+        allowed_ops=[],
+    )
+
+
+def _minimal_candidate(next_phase: str = "end") -> CandidateOutput:
+    return CandidateOutput(
+        next_phase=next_phase,
+        description="finish",
+        schema_name="test_artifact",
+        artifact_schema={},
+        control_type="finish",
+    )
+
+
+# ── 1. small result passes through unchanged ─────────────────────────────────
+
+
+def test_small_result_passes_through_unchanged() -> None:
+    """Tier 2: result with content below cap is returned as-is (identity check)."""
+    result = {"kind": "file", "op": "read", "status": "ok", "content": _small_content()}
+    capped = cap_control_ir_result(result, 0)
+    assert capped is result
+
+
+def test_small_result_emits_no_event() -> None:
+    """Tier 2: small result (below cap) does not emit a control_ir_result_truncated event."""
+    events = EventLog()
+    result = {"kind": "file", "op": "read", "status": "ok", "content": _small_content()}
+    cap_control_ir_result(result, 0, events=events, phase="p")
+    trunc_events = [e for e in events.all() if e.type == "control_ir_result_truncated"]
+    assert trunc_events == []
+
+
+# ── 2. large result is truncated + marker present ─────────────────────────────
+
+
+def test_large_content_field_is_truncated() -> None:
+    """Tier 2: content field exceeding cap is replaced with a truncation marker."""
+    large = _large_content()
+    result = {"kind": "file", "op": "read", "status": "ok", "content": large}
+    capped = cap_control_ir_result(result, 0)
+
+    capped_content = capped["content"]
+    # The marker, not the original content, should be present.
+    assert "<truncated:" in capped_content
+    # The capped content string is shorter than the original.
+    assert _byte_len(capped_content) < _byte_len(large)
+
+
+def test_large_stdout_field_is_truncated() -> None:
+    """Tier 2: stdout field (shell/sandboxed_exec result) exceeding cap is truncated."""
+    large = _large_content()
+    result = {"kind": "shell", "status": "ok", "returncode": 0, "stdout": large, "stderr": ""}
+    capped = cap_control_ir_result(result, 0)
+    assert "<truncated:" in capped["stdout"]
+
+
+# ── 3. truncation marker contains size signal ─────────────────────────────────
+
+
+def test_truncation_marker_contains_original_byte_count() -> None:
+    """Tier 2: truncation marker carries original byte count so the LLM knows the omission size."""
+    large = _large_content(extra_bytes=5000)
+    original_bytes = _byte_len(large)
+    result = {"kind": "file", "op": "read", "status": "ok", "content": large}
+    capped = cap_control_ir_result(result, 0)
+
+    marker = capped["content"]
+    assert str(original_bytes) in marker
+
+
+def test_truncation_marker_contains_cap_value() -> None:
+    """Tier 2: truncation marker includes the cap value for transparency."""
+    large = _large_content()
+    result = {"kind": "file", "op": "read", "status": "ok", "content": large}
+    capped = cap_control_ir_result(result, 0)
+    assert str(MAX_CONTROL_IR_RESULT_BYTES) in capped["content"]
+
+
+# ── 4. observability event emitted ────────────────────────────────────────────
+
+
+def test_truncation_emits_observability_event() -> None:
+    """Tier 2: truncated result emits control_ir_result_truncated event with required fields."""
+    events = EventLog()
+    large = _large_content()
+    original_bytes = _byte_len(large)
+    result = {"kind": "file", "op": "read", "status": "ok", "content": large}
+    cap_control_ir_result(
+        result, 3,
+        events=events, phase="act_phase", run_id="run-1", turn=5,
+    )
+
+    trunc_events = [e for e in events.all() if e.type == "control_ir_result_truncated"]
+    (ev,) = trunc_events  # exactly one event
+    assert ev.data["phase"] == "act_phase"
+    assert ev.data["run_id"] == "run-1"
+    assert ev.data["turn"] == 5
+    assert ev.data["result_idx"] == 3
+    assert ev.data["result_kind"] == "file"
+    assert ev.data["cap_bytes"] == MAX_CONTROL_IR_RESULT_BYTES
+    assert "content" in ev.data["truncated_fields"]
+    assert ev.data["truncated_fields"]["content"] == original_bytes
+
+
+# ── 5. metadata fields survive truncation intact ──────────────────────────────
+
+
+def test_metadata_fields_survive_truncation() -> None:
+    """Tier 2: kind / status / path / op fields are not modified by truncation."""
+    result = {
+        "kind": "file",
+        "op": "read",
+        "path": "src/foo.py",
+        "status": "ok",
+        "content": _large_content(),
+    }
+    capped = cap_control_ir_result(result, 0)
+    assert capped["kind"] == "file"
+    assert capped["op"] == "read"
+    assert capped["path"] == "src/foo.py"
+    assert capped["status"] == "ok"
+
+
+# ── 6. cap value is tunable via exported constant ─────────────────────────────
+
+
+def test_cap_constant_is_exported_and_numeric() -> None:
+    """Tier 2: MAX_CONTROL_IR_RESULT_BYTES is an exported numeric constant (future tuning)."""
+    assert isinstance(MAX_CONTROL_IR_RESULT_BYTES, int)
+    assert MAX_CONTROL_IR_RESULT_BYTES > 0
+
+
+# ── 7. cumulative prompt size is bounded over N=10 turns ─────────────────────
+
+
+def test_cumulative_prompt_size_bounded_over_10_turns() -> None:
+    """Tier 2: after 10 turns of accumulation, total capped-results JSON stays bounded.
+
+    Each turn adds one file_read result with a large content field.  Without
+    the cap the total would reach ~14× the per-result raw size.  With the cap,
+    total JSON of all accumulated results stays under a reasonable bound.
+    """
+    # Simulate 10 turns each adding one 100 KB result.
+    large = "X" * 100_000  # ~100 KB per result
+    accumulated: list[dict] = []
+    events = EventLog()
+
+    for turn in range(10):
+        raw_result = {
+            "kind": "file", "op": "read", "status": "ok",
+            "path": f"file_{turn}.py", "content": large,
+        }
+        capped = cap_control_ir_result(raw_result, turn, events=events, phase="p", turn=turn)
+        accumulated.append(capped)
+
+    total_json_bytes = len(json.dumps(accumulated, ensure_ascii=False).encode("utf-8"))
+    # Bounded: each result's content is capped; 10 results should be well
+    # under 500 KB (without cap they'd be ~1 MB).
+    upper_bound = 500_000
+    assert total_json_bytes < upper_bound, (
+        f"Accumulated results too large: {total_json_bytes} bytes >= {upper_bound}"
+    )
+
+    # Every turn should have emitted at least one truncation event.
+    trunc_events = [e for e in events.all() if e.type == "control_ir_result_truncated"]
+    assert len(trunc_events) > 0
+
+
+# ── 8. build_frame wires cap for every result ─────────────────────────────────
+
+
+def test_build_frame_applies_cap_to_control_ir_results() -> None:
+    """Tier 2: build_frame applies cap_control_ir_result to every entry in control_ir_results."""
+    events = EventLog()
+    large = _large_content()
+    results = [
+        {"kind": "file", "op": "read", "status": "ok", "content": large},
+        {"kind": "file", "op": "read", "status": "ok", "content": large},
+    ]
+    phase = _minimal_phase()
+    candidate = _minimal_candidate()
+
+    frame = build_frame(
+        phase_name="test_phase",
+        phase=phase,
+        artifact={"type": "test_artifact", "data": {}},
+        candidates=[candidate],
+        output_language="en",
+        history=[],
+        visit_counts={},
+        finish_criteria=["done"],
+        max_phase_visits=None,
+        available_ops=[],
+        effective_model="test-model",
+        model_resolved="test-model-resolved",
+        events=events,
+        control_ir_results=results,
+    )
+
+    # Both results in the frame should be truncated.
+    frame_results = frame.control_ir_results
+    for r in frame_results:
+        assert "<truncated:" in r["content"]
+
+    # At least one truncation event should have been emitted (one per truncated result).
+    trunc_events = [e for e in events.all() if e.type == "control_ir_result_truncated"]
+    assert len(trunc_events) > 0
+
+
+# ── 9. result with no large-content fields passes unchanged ───────────────────
+
+
+def test_result_with_no_large_fields_passes_unchanged() -> None:
+    """Tier 2: result with only metadata (no content/stdout/stderr/output) is not modified."""
+    result = {
+        "kind": "file",
+        "op": "write",
+        "path": "out.txt",
+        "status": "ok",
+    }
+    capped = cap_control_ir_result(result, 0)
+    assert capped is result
+
+
+# ── 10. multiple large fields in one result both truncated ────────────────────
+
+
+def test_multiple_large_fields_both_truncated() -> None:
+    """Tier 2: result with large stdout AND large stderr has both fields truncated."""
+    large = _large_content()
+    result = {
+        "kind": "shell",
+        "status": "error",
+        "returncode": 1,
+        "stdout": large,
+        "stderr": large,
+    }
+    events = EventLog()
+    capped = cap_control_ir_result(result, 0, events=events, phase="p")
+
+    assert "<truncated:" in capped["stdout"]
+    assert "<truncated:" in capped["stderr"]
+
+    # One truncation event per result (both fields listed in truncated_fields of the same event).
+    trunc_events = [e for e in events.all() if e.type == "control_ir_result_truncated"]
+    (ev,) = trunc_events  # exactly one event (both fields folded into a single event)
+    assert "stdout" in ev.data["truncated_fields"]
+    assert "stderr" in ev.data["truncated_fields"]


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 PR-N v8: control_ir_results per-result size cap

## Primary evidence (= sandbox_2 v8 calibration 2026-05-28)

5 of 9 v8 errors attributed to prompt balloon:
- Turn N's `file_read` / `shell` op results accumulate into turn N+1's prompt
- At N=14 turns the prompt reaches 100K-400K tokens
- Observed: **396K / 366K / 217K / 113K / 101K tokens** per-run in `/tmp/swe-bench-cal/results_retry_v8/`
- LLM context cap hit → OS-side termination

Primary evidence: per-turn token count in v8 trace. NOT speculation.

## Design decision: Option (A) per-result size cap

Chose (A) over (B) sliding-window and (C) summarization because:
- (A) is simplest and most predictable: each result capped independently
- (B) drops earlier results entirely (LLM loses context of prior ops)
- (C) requires an LLM round-trip per truncated result (cost + latency)
- (A) is consistent with the existing `artifact_ref` / `MAX_INLINE_BOOST` mechanism on the input side (= sibling OS-level size gate)

## Fix shape

`src/reyn/context_builder.py`:
- `MAX_CONTROL_IR_RESULT_BYTES = 8_192` — cap per result (8 KiB)
- `cap_control_ir_result()` — new OS-level function, truncates `content` / `stdout` / `stderr` / `output` fields exceeding the cap
- `build_frame()` — applies cap to every result before assembling ContextFrame
- Truncation marker: `<truncated: original N bytes, cap 8192 bytes>` + head/tail preview
- Full result preserved in `act_executed` event (P6 audit guarantee)
- `control_ir_result_truncated` observability event emitted with `phase` / `run_id` / `turn` / `result_idx` / `result_kind` / `truncated_fields` / `cap_bytes`

## Cap value rationale (= observation-data-backed)

8 KiB keeps a 14-turn run well under 200K characters of accumulated results.
At 14 turns × 8 KiB = 112 KB capped results total vs. 14 × 100 KB = 1.4 MB uncapped.
Typical file snippets and grep results fit within 8 KiB; multi-file reads that exceed it
get a head+tail preview + the LLM can issue a targeted `file.read` with `offset`/`limit`.

## NOT symptom fix

- ❌ Raise model context cap — burns more tokens, root cause remains
- ❌ Force `--max-turns 5` — limits capability, doesn't fix accumulation
- ❌ Per-skill bespoke caps — P7 violation (OS must not contain skill-specific strings)

## sandbox_2 next step

v9 retry post-merge: expected 5 of 9 v8 errors drop to 0 (396K/366K/217K/113K/101K balloon cases eliminated).

## Test plan

### Automated (= pre-push verified ✅)

- [x] `python3 scripts/test_tier_audit.py --strict tests/test_context_builder_result_size_cap.py` → exit 0, 13/13 ✓
- [x] `python -m pytest -q tests/test_context_builder_result_size_cap.py tests/test_context_builder_inline_boost.py` → 19 passed
- [x] `ruff check src/reyn/context_builder.py tests/test_context_builder_result_size_cap.py` → clean
- [x] Full `python -m pytest -q` from rootdir — running in background at commit time

### Test coverage (Tier 2, 13 tests)

1. small result (< cap) → passed through unchanged (identity)
2. small result emits no truncation event
3. large `content` field truncated + marker present
4. large `stdout` field truncated
5. truncation marker contains original byte count
6. truncation marker contains cap value
7. observability event emitted with all required fields
8. metadata fields (kind, status, path, op) survive truncation
9. `MAX_CONTROL_IR_RESULT_BYTES` exported and numeric (future tunability)
10. cumulative prompt size bounded over N=10 turns with 100 KB results
11. `build_frame` applies cap to every result in `control_ir_results`
12. result with no large-content fields passes through unchanged
13. `stdout` + `stderr` both truncated in single result → single event

### Tier-rule self-check ✅

- Every test docstring opens with `"""Tier 2:`
- No `unittest.mock` / `AsyncMock` / `MagicMock` / `patch`
- No private-state assertions (`_field`)
- No format pinning (count assertions use `(x,) = list` unpacking or `> 0`)
- Invariant is essential: size cap is an OS-level guarantee against prompt balloon

🤖 Generated with [Claude Code](https://claude.com/claude-code)