### PR TITLE
fix(tui): RightPanel — events [d] jump scroll cursor into view after refresh

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -2058,6 +2058,20 @@ class RightPanel(Widget):
         self._docs_files = ordered
         self._docs_cursor = target_idx
         self.set_panel_type("docs")
+        # UX exploration finding F2 (2026-05-29): ``set_panel_type`` →
+        # ``on_tabs_tab_activated`` → ``_scroll_docs_into_view`` runs
+        # synchronously in the same event, before the new tab's content
+        # is painted into ``#panel-scroll``. The scroll helper reads
+        # ``vs.scroll_y`` and ``vs.size.height`` from the panel's prior
+        # state — at minimum the scroll position predates the new
+        # cursor placement, so the viewport stays put and the ``▶``
+        # marker lands off-screen. ``call_after_refresh`` defers the
+        # scroll to the next paint cycle, after the docs content has
+        # been mounted and the new ``_docs_cursor`` is reflected.
+        try:
+            self.app.call_after_refresh(self._scroll_docs_into_view)
+        except Exception:
+            pass
 
     def current_doc_stem(self) -> str:
         """Return the stem of the currently highlighted doc file, or "".


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration Round 2 finding F2 (P2, S cost).

## Observation
Pressing `[d]` on the events tab correctly switches to the Docs tab with the cursor on `reference/runtime/events.md`, but the viewport stayed at its prior scroll position — the `▶` marker landed off-screen and the user had to manually scroll to find it.

## Root cause
`_jump_docs_to_events_md` set `_docs_cursor` then called `set_panel_type("docs")`, which fired `on_tabs_tab_activated` → `_scroll_docs_into_view` synchronously in the same event. At that moment the new tab's content had not yet been painted into the shared `#panel-scroll` widget, so the scroll helper read `scroll_y` / `size.height` from the prior tab's state and skipped (or mis-targeted) the scroll.

## Fix
Defer the scroll via `self.app.call_after_refresh(self._scroll_docs_into_view)` so it runs on the next paint cycle, after the docs content has mounted and the new `_docs_cursor` is reflected in the viewport math.

## Live verify (tmux MCP)

Repro: boot reyn chat → send a message to populate events → Ctrl+B → Tab to Events → press `d`.

**Before**: Docs tab opens at scroll_y=0 — viewport shows top-of-list entries (`builtin-models` / `chat` / `config` etc.). The `▶` cursor is at `reference/runtime/events.md` but invisible until the user presses `k` repeatedly.

**After**: Docs tab opens with viewport scrolled — `▶ events` row is visible at the bottom of the docs list.

## Verify scope (= [[dogfood-verify-scope-distinction]])

### mechanism
- [x] `pytest tests/cli/test_events_tab_*, test_memory_tab_*, test_docs_*, test_pending_tab_preview` → 46/46 pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 pass
- [x] `python scripts/test_tier_audit.py --strict src/reyn/chat/tui/widgets/right_panel/__init__.py` → 0 errors
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/__init__.py` → clean

### end-to-end live (= tmux MCP)
- [x] Live tmux verify: boot reyn → spawn event content → Ctrl+B → Tab to Events → press `d` → `▶ events` row visible at bottom of viewport (= primary evidence in commit message)

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)