### PR TITLE
fix(tui): RightPanel header hint completeness (4 sibling findings)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -477,7 +477,8 @@ class ConversationView(Widget):
             # clean lines per stanza on any terminal we expect.
             "  Type [bold]/[/] for commands  ·  [bold]/help[/] for a guide\n"
             "  [bold]Ctrl+B[/] side panel ·  [bold]Ctrl+L[/] clear  ·  [bold]Ctrl+P/N[/] turn\n"
-            "  [dim]panel tabs: keys · events · agents · memory · cost · docs · pending[/]",
+            "  [dim]panel tabs: keys · events · agents · memory · cost · docs · pending"
+            "  ([bold]Tab[/]/[bold]Ctrl+W[/] cycle)[/]",
             id="empty-hint",
             markup=True,
         )

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -2426,9 +2426,13 @@ class RightPanel(Widget):
                 f"  [#555555]j↓ k↑ space=open c=copy a=attach[/]"
             )
         if self._panel_type == "memory":
+            # Wave Round 2 finding F3 (2026-05-29): the [t] type filter
+            # cycle was discoverable only via the Keys tab or by trial
+            # and error — the per-tab header should advertise it the
+            # same way the events tab advertises [f] / [t].
             return (
                 f"[bold {_CORAL}]Memory[/]"
-                f"  [#555555]j↓ k↑ space=open c=copy[/]"
+                f"  [#555555]j↓ k↑ space=open c=copy t=filter[/]"
             )
         if self._panel_type == "cost":
             return f"[bold {_CORAL}]Cost[/]  [#555555]j↓ k↑[/]"
@@ -2458,6 +2462,14 @@ class RightPanel(Widget):
             rbr = "[#555555]][/]"
             kf = f"{lbr}[{_CORAL}]f[/]{rbr}"
             kt = f"{lbr}[{_CORAL}]t[/]{rbr}"
+            # Wave Round 2 finding F1 (2026-05-29): when [v] verbose mode
+            # is ON, surface that state in the header so the user can
+            # tell at a glance — the prior version only flashed a
+            # transient status line on the press, so a user returning
+            # to the tab after a tab-switch had no way to know whether
+            # compaction_check noise was suppressed or not without
+            # re-toggling.
+            v_marker = f"  {lbr}[{_CORAL}]v[/]{rbr}" if self._events_verbose else ""
             # Compact form (~36 cells with "all" filter, 8 more for the
             # longest "internal" filter). Previous text was ~54 cells and
             # truncated past ``[t`` at the new 36-col minimum panel width
@@ -2472,6 +2484,7 @@ class RightPanel(Widget):
                 f"[bold {_CORAL}]Events[/]"
                 f"  {kf}[#555555]:[/]{filter_label}"
                 f"  {kt}[#555555]:[/][#aaaaaa]{tail}[/]"
+                f"{v_marker}"
                 f"  [#555555]j/k sp=open[/]"
             )
         return ""

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -354,6 +354,19 @@ def render_keys(
             group_keys["PANEL"].append(key.lower())
             seen.add(key)
 
+    # Wave Round 2 finding N2 (2026-05-29): Tab / Shift+Tab are
+    # _INPUT_OWNED_KEYS so the loops above surfaced them under INPUT
+    # (= "Confirm" / "Previous"). Their dual role as the panel-focused
+    # tab switcher was invisible — the only documented switchers in the
+    # PANEL group were ⌃W / ⌃⇧W / ⌃⇧O, even though Tab actually drives
+    # the panel-side switch when focus is on the tabs widget. Surface
+    # them as PANEL-context rows so the discoverability gap closes
+    # without disturbing the InputBar-context description.
+    groups["PANEL"].append((_pretty_key("tab"), "Next tab (panel focused)"))
+    group_keys["PANEL"].append("tab")
+    groups["PANEL"].append((_pretty_key("shift+tab"), "Previous tab (panel focused)"))
+    group_keys["PANEL"].append("shift+tab")
+
     # MOUSE group (T1-4, Wave-12): explicit click-interaction rows.
     # These have no key semantics so raw_key is "" for all of them.
     for display, desc in _MOUSE_EXPLICIT:


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration Round 2 bundle (4 P2 / S findings on header hint completeness).

## Findings bundled

| # | Title | Pri | Cost |
|---|---|---|---|
| F1 | Events verbose `[v]` no persistent state in header | P2 | S |
| F3 | Memory `[t]` filter not in header hint | P2 | S |
| N1 | `panel tabs:` hint missing Tab binding info | P2 | S |
| N2 | Keys tab `[PANEL]` section missing Tab/Shift+Tab entries | P2 | S |

All sibling axis = **discoverability of bindings + per-tab toggle state**. Bundling as 1 PR keeps the discoverability theme coherent.

## Fix shapes

### F1 — events verbose `[v]` marker
Surface `[v]` in the header when `_events_verbose` is on. Inline conditional fragment so cell budget stays close when verbose=off.

```
Before (verbose ON, same as OFF): Events  [f]:all  [t]:200  j/k sp=open
After  (verbose ON):              Events  [f]:all  [t]:200  [v]  j/k sp=open
After  (verbose OFF):             Events  [f]:all  [t]:200  j/k sp=open  (= unchanged)
```

### F3 — memory `t=filter` hint
Added `t=filter` to match the events tab pattern.

```
Before: Memory  j↓ k↑ space=open c=copy
After:  Memory  j↓ k↑ space=open c=copy t=filter
```

### N1 — main hint bar Tab/Ctrl+W cycle
Append `(Tab/Ctrl+W cycle)` to the existing `panel tabs:` hint line.

```
Before: panel tabs: keys · events · agents · memory · cost · docs · pending
After:  panel tabs: keys · events · agents · memory · cost · docs · pending  (Tab/Ctrl+W cycle)
```

### N2 — Keys tab `[PANEL]` Tab / Shift+Tab rows
Tab / Shift+Tab were in `_INPUT_OWNED_KEYS` so the app-binding loop skipped them, and the InputBar loop surfaced them only under `[INPUT]` with the "Confirm" description. Their dual role as panel-focused tab switchers was invisible in `[PANEL]` despite working. Added two explicit PANEL rows after `_PANEL_EXPLICIT`:

```
Tab     Next tab (panel focused)
⇧Tab    Previous tab (panel focused)
```

## Verify scope (= [[dogfood-verify-scope-distinction]])

### mechanism
- [x] `pytest tests/cli/test_events_tab_*, test_memory_tab_*, test_agents_tab_header_hint.py, test_empty_hint_discoverability.py, test_keys_tab_panel_bindings.py` → 44/44 pass
- [x] `pytest tests/cli/test_tui_smoke.py` → 40/40 pass
- [x] `python scripts/test_tier_audit.py --strict <touched paths>` → 0 errors
- [x] `ruff check <touched paths>` → clean

### end-to-end live (= tmux MCP)
- [x] N1: empty conv → hint shows `panel tabs: ... (Tab/Ctrl+W cycle)`
- [x] F3: Memory tab header shows `t=filter`
- [x] F1: Events tab after `v` press → `[v]` appears in header + compaction_check rows visible
- [x] N2: Keys tab PANEL group → `Tab Next tab (panel focused)` + `⇧Tab Previous tab (panel focused)` rows visible

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)