### PR TITLE
fix(tui): RightPanel — auto-close on narrow terminal (<60 cols)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -67,6 +67,14 @@ _PANEL_LABELS: dict[str, str] = {
 # trigger (= manual tab switch).
 _LIVE_PANELS = {"events", "agents", "cost", "memory", "pending"}
 _REFRESH_INTERVAL = 2.0
+# Wave Round 2 finding W2 (2026-05-29): below this total terminal width
+# the panel's ``min-width: 44`` (CSS default) crushes the conv pane
+# down to ~16 cols and chat output wraps to 5+ lines per message.
+# Threshold of 60 = panel 44 + conv 16; below that the conv side is
+# functionally unreadable. ``on_resize`` auto-closes the panel below
+# this width — Ctrl+B re-open restores the prior tab so user state
+# survives the visibility flip.
+_PANEL_NARROW_TERMINAL_CUTOFF = 60
 
 
 class RightPanel(Widget):
@@ -262,6 +270,35 @@ class RightPanel(Widget):
         automatically).
         """
         del event  # unused; we re-read app.size below
+        # Wave Round 2 finding W2 (2026-05-29): below
+        # ``_PANEL_NARROW_TERMINAL_CUTOFF`` cols of total terminal width
+        # the panel's ``min-width: 44`` (CSS default) leaves the conv
+        # pane only ~16 cols — chat output wraps to 5+ lines per
+        # message and is effectively unreadable. Auto-close the panel
+        # so the conv pane regains its full width. The app already
+        # restores the last-active tab on ``Ctrl+B`` re-open, so user
+        # state (tab + scroll) survives the auto-close — only the
+        # visibility toggle flips. Flash a short status so the user
+        # understands why their explicit ``Ctrl+B`` open got reversed.
+        try:
+            current_width = int(self.app.size.width or 0)
+        except Exception:
+            current_width = 0
+        if (
+            current_width
+            and current_width < _PANEL_NARROW_TERMINAL_CUTOFF
+            and self.display
+        ):
+            try:
+                self.app.action_toggle_panel()
+                self._flash_status(
+                    f"panel hidden — terminal narrower than "
+                    f"{_PANEL_NARROW_TERMINAL_CUTOFF} cols (Ctrl+B to retry after resize)"
+                )
+            except Exception as exc:
+                logger.warning(
+                    "right_panel narrow-terminal auto-close failed: %s", exc,
+                )
         if self._panel_width == 0:
             return
         max_width = self._max_panel_width()


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration Round 2 finding W2 (P2 / M cost — actually came in at S after design review).

## Observation
At terminal widths below ~60 cols, the panel's `min-width: 44` CSS default left the conv pane only ~16 cols. Chat output wrapped to 5+ lines per message and was effectively unreadable. The user had explicitly opened the panel but ended up unable to read their own conversation.

## Design choice — 1-option strict frame ([[no-compromise-recommendation]])

Evaluated three approaches:

| Option | Outcome | Decision |
|---|---|---|
| **A (chosen)** — auto-close when terminal width < 60 cols, flash status + Ctrl+B re-open hint | Conv pane regains full width; user state survives via existing re-open restore | ✓ |
| B — reduce CSS `min-width` below 44 | Panel content (= headers like `Memory  j↓ k↑ space=open c=copy t=filter`) doesn't fit, trades one crushed surface for another | ✗ |
| C — "panel-unavailable placeholder" inline message | More code paths than the conv-pane crush warrants | ✗ |

**Why A**:
- Conv pane regains full width — primary readable surface preserved
- User state survives: `Ctrl+B` re-open restores the prior tab (existing first-open-restore mechanism)
- Flash status tells the user WHY their open got reversed + surfaces the recovery path
- Mechanism reuse: piggybacks on existing `action_toggle_panel`, no new visibility code path

## Failure mode rationale (= [[mechanism-reuse-failure-mode-separation]])

The `on_resize` mechanism is now reused for two triggers with explicit per-layer failure modes:

- **`on_resize` re-clamp path (existing)**: warns + clamps on `h`/`l` manual width that survives a shrink — silent log on failure (fall-through clamps next paint)
- **`on_resize` auto-close path (new)**: warns + closes panel on CSS-default-width crush — flash status on success so user sees recovery hint; silent log on failure (panel stays open but already broken, no value in raising)

Both reuse the same `on_resize` mechanism with per-trigger failure modes; rationale articulated here so a future tighten attempt doesn't conflate them.

## Verify scope (= [[dogfood-verify-scope-distinction]])

### mechanism
- [x] `pytest tests/cli/test_panel_width_reclamp_on_terminal_resize.py test_right_panel_quick_jump.py test_tui_smoke.py` → 49/49 pass
- [x] `ruff check` → clean

### end-to-end live (= tmux MCP)
1. Boot reyn chat at 80 cols → Ctrl+B → panel opens cleanly ✓
2. `tmux resize-window -x 50` → **panel auto-closes**; conv pane uses full 50 cols (= "panel tabs: ..." hint visible) ✓
3. `tmux resize-window -x 120` → panel stays closed (intentional) ✓
4. `Ctrl+B` → panel re-opens, lands on the last-active tab (= state preserved across the auto-close) ✓

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)