### PR TITLE
fix(tui): RightPanel Keys tab — merge duplicate `d` row under [PANEL]

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -310,13 +310,17 @@ def render_keys(
         ("k", "Scroll up (current tab)"),
         ("space", "Toggle preview pane"),
         ("c", "Copy current view (pending tab: claim cursor)"),
-        # A-F2 (wave-8): ``d`` is the primary pending-tab action (=
-        # discard the cursor's intervention).
-        ("d", "Discard cursor (pending tab)"),
-        # T2-5a (wave-12): ``d`` on the events tab opens runtime/events.md
-        # in the Docs tab. Listed as a second row because it's a different
-        # tab context — not a merge of the pending-tab meaning.
-        ("d", "Open events.md reference (events tab)"),
+        # ``d`` does double duty across two tab contexts:
+        #   - A-F2 (wave-8): pending tab → discard cursor's intervention
+        #   - T2-5a (wave-12): events tab → open runtime/events.md
+        # Wave Round 2 finding N5 (2026-05-29): the prior layout
+        # emitted two consecutive ``d`` rows under [PANEL]. Users
+        # encountered them as duplicate entries (= "why is `d` listed
+        # twice?") rather than as one key with two tab-gated meanings.
+        # Merge into a single row with the parenthesised dual-meaning
+        # idiom that ``c`` already uses ("Copy current view (pending
+        # tab: claim cursor)").
+        ("d", "Discard cursor (pending tab) / open events.md (events tab)"),
         # H-F11 (wave-10 follow-up): ``a`` on the Agents tab prefills
         # ``/attach <name>`` into the InputBar for the cursor's agent.
         # Same "per-tab action" idiom as the pending-tab ``d`` / ``c``


### PR DESCRIPTION
**[tui-coder]** — TUI UX exploration Round 2 finding N5 (P3 / S cost). Wave finalize PR.

## Observation
The Keys tab `[PANEL]` group listed two consecutive `d` rows — "Discard cursor (pending tab)" + "Open events.md reference (events tab)" — for the same key. Users encountered them as duplicate entries (= "why is `d` listed twice?") rather than as one key with two tab-gated meanings.

## Fix
Merge into a single row with the parenthesised dual-meaning idiom that `c` already uses ("Copy current view (pending tab: claim cursor)").

**Before**:
```
d   Discard cursor (pending tab)
d   Open events.md reference (events tab)
```

**After**:
```
d   Discard cursor (pending tab) / open events.md (events tab)
```

## Wave Round 2 finalize summary

| # | Status | PR |
|---|---|---|
| F2 (events [d] scroll-into-view) | ✓ open | #1037 |
| F1+F3+N1+N2 (header hint bundle) | ✓ open | #1038 |
| W2 (narrow terminal auto-close) | ✓ open | #1039 |
| **N5 (this PR)** | ✓ open | #1040 |
| W1 (tab label clip ≤45 cols) | DEFERRED | — |
| N4 (cursor drift on list growth) | DEFERRED | — |

**Deferral rationale**:
- **W1**: mostly mitigated by W2 auto-close at <60 cols; manifests only in 60-80 col band at panel min-width, P3 low-leverage
- **N4**: M cost, P3, score 0.5 (= lowest in the wave); cursor-by-event-id refactor not worth the blast radius

## Verify scope (= [[dogfood-verify-scope-distinction]])

### mechanism
- [x] `pytest tests/cli/test_keys_tab_panel_bindings.py tests/cli/test_tui_smoke.py` → 50/50 pass
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/keys_tab.py` → clean

### end-to-end live
- [x] Skipped — single-line copy-edit to an existing Keys tab row description; `test_keys_tab_panel_bindings.py` validates row presence in unit tests. Per CLAUDE.md "Manual / Visual" guidance: this is a copy-edit fix where mechanism-level tests fully cover the surface.

## Tier self-check
- [x] No tests added (= UX fix, Tier 4 = don't write per testing.ja.md)
- [x] No new Mock / AsyncMock / patch usage
- [x] No new `assert obj._private_attr` introduced
- [x] No format-pinning introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)