### PR TITLE
fix(fp-0008): PR-N7 — wrap compute_truncate_floor in asyncio.to_thread to unblock event loop

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -546,7 +546,7 @@ class AgentRegistry:
                 and now - self._last_truncation_ts < self._TRUNCATION_THROTTLE_SECS):
             return None
         try:
-            floor = await asyncio.to_thread(self.compute_truncate_floor)
+            floor = self.compute_truncate_floor()
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("WAL truncation: floor computation failed: %s", e)
             return None
@@ -679,12 +679,26 @@ class AgentRegistry:
     def compute_truncate_floor(self) -> int:
         """Return the lowest seq that MUST remain in the WAL.
 
-        ``floor = min(全 持続 agent applied_seq, 全 active skill
-        last_phase_applied_seq) + 1``
+        ``floor = min(全 active session applied_seq, 全 active skill
+        last_phase_applied_seq, 全 active plan last_step_applied_seq) + 1``
 
-        Truly dormant agents (no snapshot file on disk) are *excluded*
-        from the floor calculation. The invariant that justifies this
-        skip:
+        PR-N7 (FP-0008): reads watermarks exclusively from in-memory
+        state — session journal snapshots + per-session skill / plan
+        registries — by walking ``self._agents.values()`` and calling
+        each session's ``iter_applied_seqs`` public method. The pre-N7
+        implementation walked every snapshot file on disk inside the
+        async ``truncate_wal_if_eligible`` caller, which blocked the
+        event loop for O(N agents × disk read) and was the root cause
+        of the 13-hour hang observed in PR-N5 13236 single-instance
+        pilot. The in-memory path matches the existing reyn architecture
+        choice (event loop friendly, event-sourced state from WAL apply,
+        no thread offload).
+
+        Dormant agents (no live ChatSession registered in
+        ``self._agents``) are excluded from the floor calculation — the
+        same skip the pre-N7 disk-read path applied for
+        ``applied_seq == 0`` snapshots. The invariant that justifies
+        this:
 
           A dormant agent has no live ``ChatSession``. WAL events are
           only appended through a session's ``SnapshotJournal``, which
@@ -693,130 +707,34 @@ class AgentRegistry:
           this run, and dropping events older than the dormant agent's
           (zero) applied_seq cannot orphan messages.
 
-          When the dormant agent later receives its first event, the
-          ``SnapshotJournal`` assigns ``applied_seq`` to the freshly
-          allocated WAL seq — effectively a "starts here" stamp — so
-          the agent never gets stuck below the truncation floor.
+          When the dormant agent later receives its first event,
+          ``ensure`` instantiates a session that immediately registers
+          here, and the next floor recompute picks up its watermark.
 
-        Returns 0 when:
-          - no persistent agents found on disk (no constraint anywhere
-            in the system → don't truncate)
-          - any snapshot file is malformed (conservative — keep WAL
-            bloated rather than risk dropping needed entries)
+        R-D16: skills awaiting an intervention for longer than
+        ``_LONG_AWAIT_THRESHOLD_SEC`` are excluded so the WAL can keep
+        advancing — delegated to
+        :meth:`SkillRegistry.iter_applied_phase_seqs` which performs
+        the elapsed check in-memory.
+
+        Returns 0 when no watermark is available (no live session, no
+        active skill, no active plan).
         """
         seqs: list[int] = []
-
-        # Per-agent applied_seq from each agent's main snapshot. Two skip
-        # paths for dormant agents (semantically equivalent — an agent that
-        # has never absorbed a WAL event):
-        #   1. snapshot file missing — fresh agent, never persisted
-        #   2. snapshot file present but ``applied_seq == 0`` — written by
-        #      ``restore_all`` for an agent with no events to absorb
-        #
-        # AgentSnapshot.load is defensive (returns empty on parse error),
-        # which would silently mask corruption as the dormant case. We
-        # parse explicitly here to distinguish: corruption returns
-        # floor=0 (fail closed, keep WAL intact); legitimate ``applied_seq
-        # == 0`` means dormant and can be skipped safely.
-        for name in self.list_names():
-            snap_path = self._dir / name / "state" / "snapshot.json"
-            if not snap_path.is_file():
-                continue
-            try:
-                data = json.loads(snap_path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError) as e:
-                logger.warning(
-                    "WAL truncation: cannot read agent snapshot %s: %s",
-                    snap_path, e,
-                )
-                return 0
-            if not isinstance(data, dict):
-                logger.warning(
-                    "WAL truncation: malformed agent snapshot %s "
-                    "(not an object)", snap_path,
-                )
-                return 0
-            try:
-                applied_seq = int(data.get("applied_seq", 0))
-            except (TypeError, ValueError):
-                return 0
-            if applied_seq == 0:
-                # Dormant — no WAL events have targeted this agent
-                # (SnapshotJournal would have bumped applied_seq above 0
-                # on first append). Skip from floor calc.
-                continue
-            seqs.append(applied_seq)
-
-        # Per-active-skill last_phase_applied_seq. We do NOT load the full
-        # SkillSnapshot dataclass here — only need one int field. Direct
-        # JSON read sidesteps any future schema bumps from breaking
-        # truncation just to extract a number.
-        #
-        # R-D16: skills awaiting an intervention for longer than
-        # ``_LONG_AWAIT_THRESHOLD_SEC`` are excluded from the floor calc.
-        # ``awaiting_since`` is a monotonic timestamp captured by
-        # ``SkillRegistry.mark_awaiting`` when a run begins to wait;
-        # ``None`` (= field absent in older snapshots) means not awaiting
-        # and the skill remains pinned (same as R-D4).
         now = time.monotonic()
-        for name in self.list_names():
-            skills_dir = self._dir / name / "state" / "skills"
-            if not skills_dir.is_dir():
+        for session in self._agents.values():
+            iter_method = getattr(session, "iter_applied_seqs", None)
+            if iter_method is None:
+                # Conservative: a session shim without the method (test
+                # fixtures, future variants) is treated as a non-pinner
+                # — never block truncation on a stale shim.
                 continue
-            for snap_file in skills_dir.glob("*.snapshot.json"):
-                try:
-                    data = json.loads(snap_file.read_text(encoding="utf-8"))
-                except Exception as e:  # noqa: BLE001 — see returns 0 above
-                    logger.warning(
-                        "WAL truncation: cannot read skill snapshot %s: %s",
-                        snap_file, e,
-                    )
-                    return 0
-                if not isinstance(data, dict):
-                    continue
-                awaiting_since = data.get("awaiting_since")
-                if awaiting_since is not None:
-                    try:
-                        elapsed = now - float(awaiting_since)
-                    except (TypeError, ValueError):
-                        elapsed = 0.0
-                    if elapsed >= self._LONG_AWAIT_THRESHOLD_SEC:
-                        # Long-await skill — exclude from floor so the
-                        # WAL can keep advancing. Memo entries below the
-                        # new floor are dropped; resume re-executes the
-                        # awaited op (cache miss behaviour).
-                        continue
-                val = data.get("last_phase_applied_seq", 0)
-                try:
-                    seqs.append(int(val))
-                except (TypeError, ValueError):
-                    return 0
-
-        # ADR-0023 §3.1: per-active-plan last_step_applied_seq. Direct
-        # JSON read mirrors the skill block above. Plans live at
-        # state/plans/<plan_id>.snapshot.json (sibling to per-plan dirs).
-        # If a long-running plan exists, its watermark pins the floor so
-        # plan_step_* events the resume analyzer needs aren't truncated.
-        for name in self.list_names():
-            plans_dir = self._dir / name / "state" / "plans"
-            if not plans_dir.is_dir():
-                continue
-            for snap_file in plans_dir.glob("*.snapshot.json"):
-                try:
-                    data = json.loads(snap_file.read_text(encoding="utf-8"))
-                except Exception as e:  # noqa: BLE001
-                    logger.warning(
-                        "WAL truncation: cannot read plan snapshot %s: %s",
-                        snap_file, e,
-                    )
-                    return 0
-                if isinstance(data, dict):
-                    val = data.get("last_step_applied_seq", 0)
-                    try:
-                        seqs.append(int(val))
-                    except (TypeError, ValueError):
-                        return 0
-
+            seqs.extend(
+                iter_method(
+                    now_ts=now,
+                    long_await_threshold=self._LONG_AWAIT_THRESHOLD_SEC,
+                )
+            )
         if not seqs:
             return 0
         # Drop entries strictly below the lowest absorbed seq. The +1 makes

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -546,7 +546,7 @@ class AgentRegistry:
                 and now - self._last_truncation_ts < self._TRUNCATION_THROTTLE_SECS):
             return None
         try:
-            floor = self.compute_truncate_floor()
+            floor = await asyncio.to_thread(self.compute_truncate_floor)
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("WAL truncation: floor computation failed: %s", e)
             return None

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2042,6 +2042,44 @@ class ChatSession:
         """
         return self._journal
 
+    def iter_applied_seqs(
+        self, *, now_ts: float, long_await_threshold: float,
+    ) -> "list[int]":
+        """Return in-memory applied_seqs for WAL truncation floor calc.
+
+        Surfaces the watermarks AgentRegistry.compute_truncate_floor
+        needs from this session, sourced exclusively from in-memory
+        state (= journal snapshot + skill_registry + plan_registry).
+        No disk I/O — preserves the existing reyn architecture choice
+        (event loop friendly, no thread offload, in-memory state is
+        event-sourced from WAL apply).
+
+        Yielded watermarks:
+          - ``journal.snapshot.applied_seq`` when > 0 (dormant agents
+            with applied_seq == 0 are skipped — the same skip the
+            disk-read path used so behaviour matches)
+          - per active skill: ``last_phase_applied_seq``, with R-D16
+            long-await exclusion (skills awaiting >= long_await_threshold
+            seconds are dropped from the floor so WAL can keep advancing)
+          - per active plan: ``last_step_applied_seq``
+        """
+        out: list[int] = []
+        snap_applied = int(self._journal.snapshot.applied_seq)
+        if snap_applied > 0:
+            out.append(snap_applied)
+        skill_reg = self.get_skill_registry()
+        if skill_reg is not None:
+            out.extend(
+                skill_reg.iter_applied_phase_seqs(
+                    now_ts=now_ts,
+                    long_await_threshold=long_await_threshold,
+                )
+            )
+        plan_reg = self.get_plan_registry()
+        if plan_reg is not None:
+            out.extend(plan_reg.iter_step_applied_seqs())
+        return out
+
     def current_state_summary(self) -> dict:
         """Return a lightweight snapshot for slash-command display.
 

--- a/src/reyn/plan/plan_registry.py
+++ b/src/reyn/plan/plan_registry.py
@@ -486,6 +486,15 @@ class PlanRegistry:
         """Return plan_ids of currently-tracked plans (in registration order)."""
         return list(self._snapshots.keys())
 
+    def iter_step_applied_seqs(self) -> "list[int]":
+        """Return in-memory last_step_applied_seq values for floor calc.
+
+        Mirrors :meth:`SkillRegistry.iter_applied_phase_seqs` — surfaces
+        the watermark the AgentRegistry truncation floor needs from this
+        registry's in-memory state, without disk I/O.
+        """
+        return [int(snap.last_step_applied_seq) for snap in self._snapshots.values()]
+
     # ── persistence ──────────────────────────────────────────────────────
 
     def load_active(self) -> dict[str, PlanSnapshot]:

--- a/src/reyn/skill/skill_registry.py
+++ b/src/reyn/skill/skill_registry.py
@@ -318,6 +318,30 @@ class SkillRegistry:
         """Return run_ids of currently-tracked skill runs (in registration order)."""
         return list(self._snapshots.keys())
 
+    def iter_applied_phase_seqs(
+        self, *, now_ts: float, long_await_threshold: float,
+    ) -> "list[int]":
+        """Return in-memory last_phase_applied_seq values for floor calc.
+
+        Used by AgentRegistry.compute_truncate_floor to derive the WAL
+        truncation floor without disk I/O — preserves the existing reyn
+        architecture choice (= event loop friendly, no thread offload,
+        in-memory state from event-sourced WAL apply).
+
+        R-D16: skills awaiting an intervention for longer than
+        ``long_await_threshold`` (monotonic seconds since
+        ``awaiting_since``) are excluded so the WAL can keep advancing
+        even while a stuck await pins the floor indefinitely.
+        """
+        out: list[int] = []
+        for snap in self._snapshots.values():
+            awaiting_since = snap.awaiting_since
+            if awaiting_since is not None:
+                if (now_ts - float(awaiting_since)) >= long_await_threshold:
+                    continue
+            out.append(int(snap.last_phase_applied_seq))
+        return out
+
     # ── persistence ──────────────────────────────────────────────────────
 
     def load_active(self) -> dict[str, SkillSnapshot]:

--- a/tests/test_registry_wal_size_safety_net.py
+++ b/tests/test_registry_wal_size_safety_net.py
@@ -26,12 +26,10 @@ from pathlib import Path
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.state_log import StateLog
-from reyn.skill.skill_snapshot import SkillSnapshot
 
 # ---------------------------------------------------------------------------
-# Helpers (mirrors test_registry_wal_truncate.py)
+# Helpers (mirrors test_registry_wal_truncate.py post-PR-N7)
 # ---------------------------------------------------------------------------
 
 
@@ -48,12 +46,51 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     )
 
 
+class _ShimSession:
+    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+
+    PR-N7 (FP-0008): the WAL truncation floor reads exclusively from
+    in-memory session state. Tests register a shim into ``_agents`` and
+    seed the watermarks via ``_seed_agent`` / ``_seed_skill``.
+    """
+
+    def __init__(self) -> None:
+        self._seqs: list[int] = []
+
+    def iter_applied_seqs(self, *, now_ts: float, long_await_threshold: float) -> list[int]:
+        return list(self._seqs)
+
+
+def _get_or_create_shim(registry: AgentRegistry, name: str) -> _ShimSession:
+    if name not in registry._agents:
+        AgentProfile.new(name, role="").save(registry._dir / name)
+        registry._agents[name] = _ShimSession()
+    shim = registry._agents[name]
+    assert isinstance(shim, _ShimSession)
+    return shim
+
+
 def _seed_agent(registry: AgentRegistry, name: str, *, applied_seq: int) -> None:
-    AgentProfile.new(name, role="").save(registry._dir / name)
-    snap = AgentSnapshot.empty(name)
-    snap.applied_seq = applied_seq
-    snap_path = registry._dir / name / "state" / "snapshot.json"
-    snap.save(snap_path)
+    shim = _get_or_create_shim(registry, name)
+    if applied_seq > 0:
+        shim._seqs.append(int(applied_seq))
+
+
+def _seed_skill(
+    registry: AgentRegistry,
+    agent_name: str,
+    run_id: str,
+    *,
+    last_phase_applied_seq: int,
+) -> None:
+    """Register an active-skill watermark for the agent's shim session.
+
+    PR-N7: ``run_id`` retained for call-site compatibility; in-memory
+    floor calc only needs the seq.
+    """
+    del run_id
+    shim = _get_or_create_shim(registry, agent_name)
+    shim._seqs.append(int(last_phase_applied_seq))
 
 
 async def _inflate_wal(log: StateLog, *, target_bytes: int) -> None:
@@ -189,15 +226,9 @@ def test_size_safety_net_protects_active_skill_events(tmp_path: Path):
     """
     registry = _make_registry(tmp_path)
     _seed_agent(registry, "alpha", applied_seq=10_000)
-    # Active skill snapshot pulls the floor down to last_phase_applied_seq + 1.
+    # Active skill pulls the floor down to last_phase_applied_seq + 1.
     # Pick a small value so our inflated WAL straddles it.
-    skill_snap = SkillSnapshot.empty("run_active", "demo_skill", {"x": 1})
-    skill_snap.last_phase_applied_seq = 50
-    skill_path = (
-        registry._dir / "alpha" / "state" / "skills" / "run_active.snapshot.json"
-    )
-    skill_path.parent.mkdir(parents=True, exist_ok=True)
-    skill_snap.save(skill_path)
+    _seed_skill(registry, "alpha", "run_active", last_phase_applied_seq=50)
 
     async def go():
         await _inflate_wal(registry._state_log, target_bytes=51_200)

--- a/tests/test_registry_wal_truncate.py
+++ b/tests/test_registry_wal_truncate.py
@@ -1,20 +1,28 @@
 """Tier 2: OS invariant — AgentRegistry's WAL truncation orchestrator.
 
-The orchestrator gathers `applied_seq` across every agent + every active
-skill snapshot, computes the universally-absorbed floor, and rewrites
-the WAL to drop entries below it. This is the policy layer on top of
-`StateLog.truncate_below` (the rewrite primitive, tested separately).
+The orchestrator gathers ``applied_seq`` from every live session + every
+active skill / plan snapshot, computes the universally-absorbed floor,
+and rewrites the WAL to drop entries below it. This is the policy layer
+on top of ``StateLog.truncate_below`` (the rewrite primitive, tested
+separately).
 
-Tests target the public surface (`truncate_wal_if_eligible`,
-`compute_truncate_floor`); observation flows through:
+PR-N7 (FP-0008): the floor calculation reads exclusively from in-memory
+state (= ``ChatSession.iter_applied_seqs`` via the session's journal +
+skill / plan registries), not from disk. Tests therefore register a
+duck-typed shim session into ``registry._agents`` and accumulate
+watermarks (= the seqs the shim yields) in the shim's seq list. On-disk
+profiles are still created so ``list_names`` reflects the right agents
+for unrelated paths, but the floor calc itself never reads files.
+
+Tests target the public surface (``truncate_wal_if_eligible``,
+``compute_truncate_floor``); observation flows through:
   - the on-disk WAL (re-read after truncation)
   - the returned stats dict
-No mocks — we construct real `AgentRegistry` instances backed by real
-snapshots on a temporary `tmp_path`.
 
 Policy compliance:
-- No `unittest.mock` usage (Fake > Mock per docs/deep-dives/contributing/testing.ja.md)
-- No private-state assertion beyond `_last_truncation_ts` for throttle
+- No ``unittest.mock`` usage (Fake > Mock per
+  docs/deep-dives/contributing/testing.ja.md)
+- No private-state assertion beyond ``_last_truncation_ts`` for throttle
   observation, which has no public surface and is the cleanest probe
   (alternative: time-travel patches, which would be worse)
 """
@@ -25,9 +33,7 @@ from pathlib import Path
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.state_log import StateLog
-from reyn.skill.skill_snapshot import SkillSnapshot
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -48,14 +54,49 @@ def _make_registry(tmp_path: Path, *, with_state_log: bool = True) -> AgentRegis
     )
 
 
-def _seed_agent(registry: AgentRegistry, name: str, *, applied_seq: int) -> Path:
-    """Create the on-disk profile + snapshot for an agent with the given applied_seq."""
-    AgentProfile.new(name, role="").save(registry._dir / name)
-    snap = AgentSnapshot.empty(name)
-    snap.applied_seq = applied_seq
-    snap_path = registry._dir / name / "state" / "snapshot.json"
-    snap.save(snap_path)
-    return snap_path
+class _ShimSession:
+    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+
+    Tests accumulate watermarks via the seed helpers below; the shim
+    surfaces them through the same public-surface contract that
+    ``AgentRegistry.compute_truncate_floor`` consumes in production
+    (= session.iter_applied_seqs returning the union of journal +
+    skill + plan watermarks).
+    """
+
+    def __init__(self) -> None:
+        self._seqs: list[int] = []
+
+    def iter_applied_seqs(self, *, now_ts: float, long_await_threshold: float) -> list[int]:
+        return list(self._seqs)
+
+
+def _get_or_create_shim(registry: AgentRegistry, name: str) -> _ShimSession:
+    """Return the shim session for ``name``, creating + registering it
+    on first use. Mirrors the on-disk-profile creation pattern so
+    ``list_names`` still includes the agent.
+    """
+    if name not in registry._agents:
+        AgentProfile.new(name, role="").save(registry._dir / name)
+        registry._agents[name] = _ShimSession()
+    shim = registry._agents[name]
+    assert isinstance(shim, _ShimSession), (
+        f"agent {name!r} is registered with a non-shim object — test fixture bug"
+    )
+    return shim
+
+
+def _seed_agent(registry: AgentRegistry, name: str, *, applied_seq: int) -> None:
+    """Register the agent's session-level applied_seq watermark.
+
+    PR-N7: pushes the watermark into the shim's seq list. ``applied_seq=0``
+    is intentionally a no-op (mirrors the pre-N7 ``dormant skip`` invariant:
+    a session whose journal snapshot has applied_seq == 0 has never
+    absorbed a WAL event and is excluded from the floor calc).
+    """
+    shim = _get_or_create_shim(registry, name)
+    if applied_seq > 0:
+        shim._seqs.append(int(applied_seq))
 
 
 def _seed_skill(
@@ -64,15 +105,16 @@ def _seed_skill(
     run_id: str,
     *,
     last_phase_applied_seq: int,
-) -> Path:
-    """Create the on-disk per-skill snapshot for an agent's active skill."""
-    snap = SkillSnapshot.empty(run_id, "demo_skill", {"input": "x"})
-    snap.last_phase_applied_seq = last_phase_applied_seq
-    snap_path = (
-        registry._dir / agent_name / "state" / "skills" / f"{run_id}.snapshot.json"
-    )
-    snap.save(snap_path)
-    return snap_path
+) -> None:
+    """Register an active-skill watermark for the agent's shim session.
+
+    PR-N7: ``run_id`` is retained in the signature for call-site
+    compatibility with the pre-N7 disk-seed helper, but the in-memory
+    path doesn't need it — the shim only yields the seq.
+    """
+    del run_id  # only needed for the pre-N7 disk path
+    shim = _get_or_create_shim(registry, agent_name)
+    shim._seqs.append(int(last_phase_applied_seq))
 
 
 def _seed_plan(
@@ -81,19 +123,15 @@ def _seed_plan(
     plan_id: str,
     *,
     last_step_applied_seq: int,
-) -> Path:
-    """Create the on-disk per-plan snapshot for an agent's active plan."""
-    from reyn.plan.plan_snapshot import PlanSnapshot, plan_snapshot_path
-    snap = PlanSnapshot.empty(
-        plan_id=plan_id, agent_name=agent_name, chain_id=f"plan_{plan_id}",
-        goal="g",
-    )
-    snap.last_step_applied_seq = last_step_applied_seq
-    snap_path = plan_snapshot_path(
-        registry._dir / agent_name / "state", plan_id,
-    )
-    snap.save(snap_path)
-    return snap_path
+) -> None:
+    """Register an active-plan watermark for the agent's shim session.
+
+    PR-N7: ``plan_id`` retained for call-site compatibility; in-memory
+    floor calc only needs the seq.
+    """
+    del plan_id
+    shim = _get_or_create_shim(registry, agent_name)
+    shim._seqs.append(int(last_step_applied_seq))
 
 
 def _wal_seqs(state_log: StateLog) -> set[int]:
@@ -152,22 +190,6 @@ def test_compute_floor_min_across_skill_and_plan(tmp_path):
     assert floor == 4  # min(10, 6, 3) + 1
 
 
-def test_compute_floor_zero_on_corrupt_plan_snapshot(tmp_path):
-    """Tier 2: malformed plan snapshot is conservative — returns 0,
-    no truncation. Mirrors the corrupt-skill-snapshot fail-closed
-    invariant."""
-    registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=10)
-    _seed_plan(registry, "alpha", "p001", last_step_applied_seq=5)
-    snap_path = (
-        registry._dir / "alpha" / "state" / "plans" / "p001.snapshot.json"
-    )
-    snap_path.write_text("{not valid json", encoding="utf-8")
-
-    floor = registry.compute_truncate_floor()
-    assert floor == 0
-
-
 def test_compute_floor_zero_when_no_persistent_agents(tmp_path):
     """Tier 2: dormant agents (snapshot-less) are skipped; with zero persistent agents, floor=0 (no truncation).
 
@@ -178,22 +200,6 @@ def test_compute_floor_zero_when_no_persistent_agents(tmp_path):
     """
     registry = _make_registry(tmp_path)
     # `default` was auto-created but has no snapshot.json — dormant, skipped.
-    floor = registry.compute_truncate_floor()
-    assert floor == 0
-
-
-def test_compute_floor_zero_on_corrupt_agent_snapshot(tmp_path):
-    """Tier 2: corrupt agent snapshot returns floor=0 (fail closed — keep WAL intact).
-
-    Truncation parses agent snapshots explicitly (rather than going through
-    ``AgentSnapshot.load``'s defensive empty-fallback) so corruption is
-    distinguishable from the legitimate dormant case (``applied_seq == 0``).
-    """
-    registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=5)
-    snap_path = registry._dir / "alpha" / "state" / "snapshot.json"
-    snap_path.write_text("{not valid json", encoding="utf-8")
-
     floor = registry.compute_truncate_floor()
     assert floor == 0
 
@@ -213,18 +219,6 @@ def test_compute_floor_skips_dormant_agent_with_zero_applied_seq(tmp_path):
     floor = registry.compute_truncate_floor()
     # Dormant skipped → floor based on alpha alone
     assert floor == 11
-
-
-def test_compute_floor_zero_on_corrupt_skill_snapshot(tmp_path):
-    """Tier 2: malformed skill snapshot is conservative — returns 0, no truncation."""
-    registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=10)
-    skills_dir = registry._dir / "alpha" / "state" / "skills"
-    skills_dir.mkdir(parents=True, exist_ok=True)
-    (skills_dir / "bad.snapshot.json").write_text("{garbage", encoding="utf-8")
-
-    floor = registry.compute_truncate_floor()
-    assert floor == 0
 
 
 def test_truncate_eligible_drops_below_floor_and_returns_stats(tmp_path):
@@ -277,12 +271,16 @@ def test_truncate_no_op_when_no_state_log(tmp_path):
 
 
 def test_truncate_no_op_when_floor_not_advanced(tmp_path):
-    """Tier 2: floor=0 (corrupt skill snapshot) skips the rewrite entirely."""
+    """Tier 2: floor=0 (no live session pinning a watermark) skips the rewrite entirely.
+
+    PR-N7: with no registered shim sessions, ``compute_truncate_floor``
+    returns 0, and ``truncate_wal_if_eligible`` returns None (= don't
+    truncate, keep WAL intact). Mirrors the conservative fail-closed
+    posture the pre-N7 disk-read path took when no watermark was
+    available.
+    """
     registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=10)
-    skills_dir = registry._dir / "alpha" / "state" / "skills"
-    skills_dir.mkdir(parents=True, exist_ok=True)
-    (skills_dir / "bad.snapshot.json").write_text("{garbage", encoding="utf-8")
+    # No shim sessions registered → no watermarks → floor = 0.
 
     async def go():
         await registry.state_log.append("inbox_put", target="a", payload={})
@@ -295,22 +293,28 @@ def test_truncate_no_op_when_floor_not_advanced(tmp_path):
 
 
 def test_truncate_advances_seqs_across_active_skill_completion(tmp_path):
-    """Tier 2: end-to-end progression — active skill phase-advances, snapshot updates, next truncation drops the older range."""
+    """Tier 2: end-to-end progression — active skill phase-advances,
+    in-memory watermark updates, next truncation drops the older range.
+
+    PR-N7: the watermark mutation that previously happened via
+    ``SkillSnapshot.load + save`` now happens via the shim's seq list
+    directly — the production path also mutates SkillRegistry's
+    in-memory snapshot when ``advance_phase`` fires, and
+    ``iter_applied_phase_seqs`` reads the fresh value.
+    """
     registry = _make_registry(tmp_path)
     _seed_agent(registry, "alpha", applied_seq=10)
-    skill_snap_path = _seed_skill(
-        registry, "alpha", "run_zzz", last_phase_applied_seq=3,
-    )
+    _seed_skill(registry, "alpha", "run_zzz", last_phase_applied_seq=3)
+    shim = registry._agents["alpha"]
 
     async def go():
         for i in range(1, 21):
             await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
         # First truncation: floor = min(10, 3) + 1 = 4 → drop 1..3
         first = await registry.truncate_wal_if_eligible()
-        # Skill phase-advances to seq 15 — bump its snapshot
-        snap = SkillSnapshot.load("run_zzz", skill_snap_path)
-        snap.last_phase_applied_seq = 15
-        snap.save(skill_snap_path)
+        # Skill phase-advances to seq 15 — replace the watermark in the shim
+        # (mirrors SkillRegistry.advance_phase mutating its in-memory snapshot).
+        shim._seqs = [10, 15]
         # Wait past throttle window
         registry._last_truncation_ts = None
         # Second truncation: floor = min(10, 15) + 1 = 11 → drop 4..10

--- a/tests/test_registry_wal_truncate_floor_nonblocking.py
+++ b/tests/test_registry_wal_truncate_floor_nonblocking.py
@@ -1,44 +1,56 @@
-"""Tier 2: OS invariant — compute_truncate_floor runs off the event loop.
+"""Tier 2: OS invariant — compute_truncate_floor reads in-memory state only.
 
-PR-N7 wraps the `compute_truncate_floor` sync call inside
-`asyncio.to_thread` so that disk I/O does not block the event loop
-while `truncate_wal_if_eligible` awaits the floor computation.
+PR-N7 (FP-0008): the floor calculation was rewritten to read exclusively
+from in-memory session state (= ``ChatSession.iter_applied_seqs`` via the
+session's journal snapshot + skill_registry + plan_registry public
+methods). The pre-N7 implementation walked snapshot files on disk inside
+the async ``truncate_wal_if_eligible`` caller — sync I/O in an async
+event loop, which was the root cause of the 13-hour hang observed in the
+PR-N5 13236 single-instance pilot.
 
-These tests verify four invariants via the public surface only:
+Tests assert via the public surface (``compute_truncate_floor``,
+``truncate_wal_if_eligible``) — and the observable file system — that:
 
-1. **Non-blocking** — while `truncate_wal_if_eligible` is awaited, a
-   concurrent `asyncio.sleep(0)` sentinel can make progress.  This
-   proves the event loop was not stalled by the floor scan.
+1. **File I/O occurrence is zero** during ``compute_truncate_floor``.
+   Verified by deleting the ``.reyn/agents/<name>/state/`` directory
+   before computing the floor; with the disk-read path this would
+   silently skip the agent (or raise) — with the in-memory path the
+   floor still reflects the registered session's watermarks because no
+   file is read.
 
-2. **Correctness** — the floor returned by `truncate_wal_if_eligible`
-   equals the floor computed by a direct synchronous call to
-   `compute_truncate_floor` on the same registry state.
+2. **Large N completes quickly**. With 100 registered shim sessions
+   the call returns in under a second (we don't pin a tighter time
+   budget to avoid flake; the prior disk-path would scan O(N) files
+   even on a fast disk and could easily exceed this with real I/O
+   contention).
 
-3. **Semantic identity** — calling `truncate_wal_if_eligible` followed
-   by a fresh `compute_truncate_floor()` returns a consistent floor (no
-   side-effect that corrupts the floor calc for the next caller).
+3. **Correctness preserved** — the returned floor equals
+   ``min(all yielded applied_seqs) + 1`` across every registered shim.
 
-4. **Exception propagation** — if a snapshot file is corrupted so that
-   `compute_truncate_floor` returns 0, `truncate_wal_if_eligible`
-   returns ``None`` (conservative: no truncation).  The exception path
-   inside `asyncio.to_thread` is handled by the existing try/except.
+4. **Dormant sessions skipped** — a shim whose
+   ``iter_applied_seqs`` returns ``[]`` does not pin the floor.
 
-No mocks. Real `AgentRegistry` + real tmp_path file I/O.
+5. **Empty registry returns 0** — no live session, no watermark, no
+   truncation.
+
+No mocks. Real ``AgentRegistry`` with shim sessions duck-typed onto its
+``_agents`` dict; shims expose ``iter_applied_seqs(*, now_ts,
+long_await_threshold)`` which is the entire public-surface contract that
+``compute_truncate_floor`` depends on.
 """
 from __future__ import annotations
 
 import asyncio
-import json
+import shutil
+import time
 from pathlib import Path
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.state_log import StateLog
-from reyn.skill.skill_snapshot import SkillSnapshot
 
 # ---------------------------------------------------------------------------
-# Helpers (mirrors test_registry_wal_truncate.py)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -55,197 +67,155 @@ def _make_registry(tmp_path: Path, *, with_state_log: bool = True) -> AgentRegis
     )
 
 
-def _seed_agent(registry: AgentRegistry, name: str, *, applied_seq: int) -> Path:
+class _ShimSession:
+    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+
+    The public-surface contract that compute_truncate_floor depends on
+    is exactly one method. Tests construct shims with the desired
+    watermarks; no ChatSession boot path needed.
+    """
+
+    def __init__(self, seqs: list[int]) -> None:
+        self._seqs = list(seqs)
+        self.iter_calls = 0
+
+    def iter_applied_seqs(self, *, now_ts: float, long_await_threshold: float) -> list[int]:
+        self.iter_calls += 1
+        return list(self._seqs)
+
+
+def _register_shim(registry: AgentRegistry, name: str, seqs: list[int]) -> _ShimSession:
+    """Register a shim session into the registry's in-memory map.
+
+    Also creates the on-disk profile so ``list_names`` returns the name
+    (some unrelated paths rely on that), but never seeds a snapshot
+    file — the floor calc must succeed without it.
+    """
     AgentProfile.new(name, role="").save(registry._dir / name)
-    snap = AgentSnapshot.empty(name)
-    snap.applied_seq = applied_seq
-    snap_path = registry._dir / name / "state" / "snapshot.json"
-    snap.save(snap_path)
-    return snap_path
-
-
-def _seed_skill(
-    registry: AgentRegistry,
-    agent_name: str,
-    run_id: str,
-    *,
-    last_phase_applied_seq: int,
-) -> Path:
-    snap = SkillSnapshot.empty(run_id, "demo_skill", {"input": "x"})
-    snap.last_phase_applied_seq = last_phase_applied_seq
-    snap_path = (
-        registry._dir / agent_name / "state" / "skills" / f"{run_id}.snapshot.json"
-    )
-    snap.save(snap_path)
-    return snap_path
-
-
-def _corrupt_agent_snapshot(registry: AgentRegistry, name: str) -> None:
-    snap_path = registry._dir / name / "state" / "snapshot.json"
-    snap_path.write_text("{this is not valid json", encoding="utf-8")
+    shim = _ShimSession(seqs)
+    registry._agents[name] = shim
+    return shim
 
 
 # ---------------------------------------------------------------------------
-# Invariant 1 — Non-blocking: event loop makes progress while floor is computed
+# Invariant 1 — File I/O occurrence is zero during compute_truncate_floor
 # ---------------------------------------------------------------------------
 
 
-def test_event_loop_not_blocked_during_floor_scan(tmp_path):
-    """Tier 2: concurrent asyncio.sleep(0) sentinel makes progress during truncate_wal_if_eligible.
+def test_compute_truncate_floor_reads_no_disk_state(tmp_path):
+    """Tier 2: floor is computed from in-memory shims even when on-disk
+    snapshot directories are absent / deleted.
+    """
+    registry = _make_registry(tmp_path)
+    _register_shim(registry, "alpha", [10])
+    _register_shim(registry, "beta", [5])
 
-    With 100 agents (= O(N) file stats + reads), a blocking sync call would
-    stall the event loop for the full scan duration.  By wrapping in
-    asyncio.to_thread, cooperative scheduling resumes — the sentinel counter
-    advances at least once.
+    # Eradicate any on-disk state that the pre-N7 disk-read path would
+    # have walked. compute_truncate_floor must not depend on these files.
+    for name in ("alpha", "beta"):
+        state_dir = registry._dir / name / "state"
+        if state_dir.exists():
+            shutil.rmtree(state_dir)
+
+    floor = registry.compute_truncate_floor()
+    assert floor == 6, "floor must equal min(in-memory seqs) + 1 = min(10,5)+1 = 6"
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — Large N completes quickly (in-memory iteration, not disk)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_truncate_floor_large_n_completes_quickly(tmp_path):
+    """Tier 2: 100 registered shim sessions → floor returns in under 1s.
+
+    We don't pin a tighter budget to avoid CI flake on noisy runners.
+    The point is "no per-agent disk read" not a precise wall-clock.
     """
     N = 100
     registry = _make_registry(tmp_path)
-
-    # Seed N agents with distinct applied_seq values so floor = 2 (min=1 → +1)
     for i in range(1, N + 1):
-        _seed_agent(registry, f"agent_{i:03d}", applied_seq=i)
+        _register_shim(registry, f"agent_{i:03d}", [i])
 
-    sentinel_ticks: list[int] = []
+    t0 = time.monotonic()
+    floor = registry.compute_truncate_floor()
+    elapsed = time.monotonic() - t0
 
-    async def _sentinel() -> None:
-        """Yields cooperatively until cancelled."""
-        tick = 0
-        while True:
-            await asyncio.sleep(0)
-            tick += 1
-            sentinel_ticks.append(tick)
-
-    async def go() -> None:
-        sentinel_task = asyncio.create_task(_sentinel())
-        try:
-            # Append WAL entries so truncation actually fires
-            for i in range(1, 11):
-                await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
-            await registry.truncate_wal_if_eligible()
-        finally:
-            sentinel_task.cancel()
-            try:
-                await sentinel_task
-            except asyncio.CancelledError:
-                pass
-
-    asyncio.run(go())
-
-    # The sentinel must have ticked at least once while the floor scan ran.
-    # If compute_truncate_floor blocked the event loop, sentinel_ticks would
-    # be empty (or very sparse).
-    assert len(sentinel_ticks) > 0, (
-        "sentinel made zero ticks — event loop appears to have been blocked "
-        "during compute_truncate_floor (asyncio.to_thread not working)"
+    assert floor == 2, "floor must equal min(1..100) + 1 = 2"
+    assert elapsed < 1.0, (
+        f"compute_truncate_floor with N=100 took {elapsed:.3f}s; "
+        "in-memory iteration should complete in tens of ms"
     )
 
 
 # ---------------------------------------------------------------------------
-# Invariant 2 — Correctness: async result matches synchronous call
+# Invariant 3 — Correctness preserved: returned floor = min(all yielded) + 1
 # ---------------------------------------------------------------------------
 
 
-def test_floor_via_truncate_matches_direct_sync_call(tmp_path):
-    """Tier 2: floor used by truncate_wal_if_eligible equals compute_truncate_floor() called directly.
+def test_compute_truncate_floor_min_of_all_yielded_seqs(tmp_path):
+    """Tier 2: each shim's yielded seqs combine; floor is min(all) + 1."""
+    registry = _make_registry(tmp_path)
+    _register_shim(registry, "alpha", [8, 3])     # session.applied_seq + 1 skill phase
+    _register_shim(registry, "beta", [5])         # session.applied_seq alone
+    _register_shim(registry, "gamma", [12, 7, 9]) # session + 2 plan steps
 
-    This confirms that wrapping in asyncio.to_thread does not alter the
-    value returned by the sync computation.
+    floor = registry.compute_truncate_floor()
+    assert floor == 4, "floor must equal min(3, 5, 7) + 1 = 4 (min watermark = 3)"
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — Dormant session (no yielded seqs) does not pin the floor
+# ---------------------------------------------------------------------------
+
+
+def test_dormant_session_excluded_from_floor(tmp_path):
+    """Tier 2: a shim whose iter_applied_seqs returns [] is excluded.
+
+    Matches the pre-N7 behaviour where an agent with applied_seq == 0
+    was skipped from the floor calc.
     """
     registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=8)
-    _seed_agent(registry, "beta", applied_seq=5)
-    _seed_skill(registry, "alpha", "run_001", last_phase_applied_seq=3)
+    _register_shim(registry, "alpha", [10])
+    _register_shim(registry, "dormant", [])  # no watermarks
 
-    # Synchronous floor (= reference value)
-    expected_floor = registry.compute_truncate_floor()
-    assert expected_floor == 4  # min(8, 5, 3) + 1
+    floor = registry.compute_truncate_floor()
+    assert floor == 11, "dormant session does not pin floor; alpha's 10 + 1 = 11"
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 — Empty registry returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_empty_registry_returns_zero(tmp_path):
+    """Tier 2: registry with no live sessions returns 0 (= no truncation)."""
+    registry = _make_registry(tmp_path)
+    assert registry.compute_truncate_floor() == 0
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6 — Truncate eligibility chain delivers the in-memory floor
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_wal_if_eligible_uses_in_memory_floor(tmp_path):
+    """Tier 2: truncate_wal_if_eligible drops entries below the in-memory floor.
+
+    End-to-end: register shims → append WAL entries → fire the async
+    eligibility path → observe the dropped/kept partition. No on-disk
+    snapshot files involved.
+    """
+    registry = _make_registry(tmp_path)
+    _register_shim(registry, "alpha", [8])  # session applied_seq = 8 → floor = 9
 
     async def go():
-        for i in range(1, 11):
+        for i in range(1, 12):  # seqs 1..11
             await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
         return await registry.truncate_wal_if_eligible()
 
     stats = asyncio.run(go())
-    assert stats is not None
-    # floor=4 means seq 1..3 dropped, 4..10 kept
-    assert stats["dropped"] == 3
-    assert stats["kept"] == 7
-
-
-# ---------------------------------------------------------------------------
-# Invariant 3 — Semantic identity: truncate then recompute is consistent
-# ---------------------------------------------------------------------------
-
-
-def test_floor_consistent_after_truncation(tmp_path):
-    """Tier 2: compute_truncate_floor() called synchronously after truncate_wal_if_eligible returns the same floor.
-
-    No side-effect from the asyncio.to_thread wrapper should corrupt the
-    floor calculation state for the next synchronous caller.
-    """
-    registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=10)
-
-    async def go():
-        for i in range(1, 15):
-            await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
-        await registry.truncate_wal_if_eligible()
-
-    asyncio.run(go())
-
-    # Synchronous call after the async truncation: same registry, same on-disk
-    # snapshots, so same floor.  The truncation does not mutate snapshot files.
-    floor_after = registry.compute_truncate_floor()
-    assert floor_after == 11  # applied_seq=10 → floor = 11
-
-
-# ---------------------------------------------------------------------------
-# Invariant 4 — Exception propagation: corrupt snapshot → returns None
-# ---------------------------------------------------------------------------
-
-
-def test_corrupt_snapshot_propagates_as_none(tmp_path):
-    """Tier 2: when compute_truncate_floor encounters a corrupt snapshot it
-    returns 0, and truncate_wal_if_eligible returns None (no truncation).
-
-    The exception that emerges from asyncio.to_thread when compute_truncate_floor
-    returns 0 (rather than raising) is handled by the floor <= 0 guard.
-    We also test the actual-raise path by corrupting mid-scan to verify
-    the BLE001 catch wrapping still fires.
-    """
-    registry = _make_registry(tmp_path)
-    _seed_agent(registry, "alpha", applied_seq=10)
-    _corrupt_agent_snapshot(registry, "alpha")
-
-    async def go():
-        await registry.state_log.append("inbox_put", target="a", payload={})
-        return await registry.truncate_wal_if_eligible()
-
-    result = asyncio.run(go())
-    # Corrupt snapshot → compute_truncate_floor returns 0 → no truncation
-    assert result is None
-
-
-def test_large_n_floor_scan_completes(tmp_path):
-    """Tier 2: truncate_wal_if_eligible with 50 agents completes without error.
-
-    Regression guard: asyncio.to_thread default pool is adequate for N < 100
-    agents.  We don't pin the wall-clock time; we only assert completion and
-    correctness.
-    """
-    N = 50
-    registry = _make_registry(tmp_path)
-    # min applied_seq = 1 → floor = 2
-    for i in range(1, N + 1):
-        _seed_agent(registry, f"agent_{i:03d}", applied_seq=i)
-
-    async def go():
-        for i in range(1, 11):
-            await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
-        return await registry.truncate_wal_if_eligible()
-
-    stats = asyncio.run(go())
-    # floor = min(1..50) + 1 = 2 → drop seq 1, keep 2..10
-    assert stats is not None
-    assert stats["dropped"] == 1
-    assert stats["kept"] == 9
+    assert stats is not None, "truncate must fire when floor > 1"
+    # floor = 9 → keep seqs 9..11 (3 entries), drop 1..8 (8 entries)
+    assert stats["dropped"] == 8
+    assert stats["kept"] == 3

--- a/tests/test_registry_wal_truncate_floor_nonblocking.py
+++ b/tests/test_registry_wal_truncate_floor_nonblocking.py
@@ -1,0 +1,251 @@
+"""Tier 2: OS invariant — compute_truncate_floor runs off the event loop.
+
+PR-N7 wraps the `compute_truncate_floor` sync call inside
+`asyncio.to_thread` so that disk I/O does not block the event loop
+while `truncate_wal_if_eligible` awaits the floor computation.
+
+These tests verify four invariants via the public surface only:
+
+1. **Non-blocking** — while `truncate_wal_if_eligible` is awaited, a
+   concurrent `asyncio.sleep(0)` sentinel can make progress.  This
+   proves the event loop was not stalled by the floor scan.
+
+2. **Correctness** — the floor returned by `truncate_wal_if_eligible`
+   equals the floor computed by a direct synchronous call to
+   `compute_truncate_floor` on the same registry state.
+
+3. **Semantic identity** — calling `truncate_wal_if_eligible` followed
+   by a fresh `compute_truncate_floor()` returns a consistent floor (no
+   side-effect that corrupts the floor calc for the next caller).
+
+4. **Exception propagation** — if a snapshot file is corrupted so that
+   `compute_truncate_floor` returns 0, `truncate_wal_if_eligible`
+   returns ``None`` (conservative: no truncation).  The exception path
+   inside `asyncio.to_thread` is handled by the existing try/except.
+
+No mocks. Real `AgentRegistry` + real tmp_path file I/O.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+from reyn.skill.skill_snapshot import SkillSnapshot
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_registry_wal_truncate.py)
+# ---------------------------------------------------------------------------
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in truncation tests")
+
+
+def _make_registry(tmp_path: Path, *, with_state_log: bool = True) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl") if with_state_log else None
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_no_factory,
+        state_log=state_log,
+    )
+
+
+def _seed_agent(registry: AgentRegistry, name: str, *, applied_seq: int) -> Path:
+    AgentProfile.new(name, role="").save(registry._dir / name)
+    snap = AgentSnapshot.empty(name)
+    snap.applied_seq = applied_seq
+    snap_path = registry._dir / name / "state" / "snapshot.json"
+    snap.save(snap_path)
+    return snap_path
+
+
+def _seed_skill(
+    registry: AgentRegistry,
+    agent_name: str,
+    run_id: str,
+    *,
+    last_phase_applied_seq: int,
+) -> Path:
+    snap = SkillSnapshot.empty(run_id, "demo_skill", {"input": "x"})
+    snap.last_phase_applied_seq = last_phase_applied_seq
+    snap_path = (
+        registry._dir / agent_name / "state" / "skills" / f"{run_id}.snapshot.json"
+    )
+    snap.save(snap_path)
+    return snap_path
+
+
+def _corrupt_agent_snapshot(registry: AgentRegistry, name: str) -> None:
+    snap_path = registry._dir / name / "state" / "snapshot.json"
+    snap_path.write_text("{this is not valid json", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — Non-blocking: event loop makes progress while floor is computed
+# ---------------------------------------------------------------------------
+
+
+def test_event_loop_not_blocked_during_floor_scan(tmp_path):
+    """Tier 2: concurrent asyncio.sleep(0) sentinel makes progress during truncate_wal_if_eligible.
+
+    With 100 agents (= O(N) file stats + reads), a blocking sync call would
+    stall the event loop for the full scan duration.  By wrapping in
+    asyncio.to_thread, cooperative scheduling resumes — the sentinel counter
+    advances at least once.
+    """
+    N = 100
+    registry = _make_registry(tmp_path)
+
+    # Seed N agents with distinct applied_seq values so floor = 2 (min=1 → +1)
+    for i in range(1, N + 1):
+        _seed_agent(registry, f"agent_{i:03d}", applied_seq=i)
+
+    sentinel_ticks: list[int] = []
+
+    async def _sentinel() -> None:
+        """Yields cooperatively until cancelled."""
+        tick = 0
+        while True:
+            await asyncio.sleep(0)
+            tick += 1
+            sentinel_ticks.append(tick)
+
+    async def go() -> None:
+        sentinel_task = asyncio.create_task(_sentinel())
+        try:
+            # Append WAL entries so truncation actually fires
+            for i in range(1, 11):
+                await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
+            await registry.truncate_wal_if_eligible()
+        finally:
+            sentinel_task.cancel()
+            try:
+                await sentinel_task
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(go())
+
+    # The sentinel must have ticked at least once while the floor scan ran.
+    # If compute_truncate_floor blocked the event loop, sentinel_ticks would
+    # be empty (or very sparse).
+    assert len(sentinel_ticks) > 0, (
+        "sentinel made zero ticks — event loop appears to have been blocked "
+        "during compute_truncate_floor (asyncio.to_thread not working)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — Correctness: async result matches synchronous call
+# ---------------------------------------------------------------------------
+
+
+def test_floor_via_truncate_matches_direct_sync_call(tmp_path):
+    """Tier 2: floor used by truncate_wal_if_eligible equals compute_truncate_floor() called directly.
+
+    This confirms that wrapping in asyncio.to_thread does not alter the
+    value returned by the sync computation.
+    """
+    registry = _make_registry(tmp_path)
+    _seed_agent(registry, "alpha", applied_seq=8)
+    _seed_agent(registry, "beta", applied_seq=5)
+    _seed_skill(registry, "alpha", "run_001", last_phase_applied_seq=3)
+
+    # Synchronous floor (= reference value)
+    expected_floor = registry.compute_truncate_floor()
+    assert expected_floor == 4  # min(8, 5, 3) + 1
+
+    async def go():
+        for i in range(1, 11):
+            await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
+        return await registry.truncate_wal_if_eligible()
+
+    stats = asyncio.run(go())
+    assert stats is not None
+    # floor=4 means seq 1..3 dropped, 4..10 kept
+    assert stats["dropped"] == 3
+    assert stats["kept"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — Semantic identity: truncate then recompute is consistent
+# ---------------------------------------------------------------------------
+
+
+def test_floor_consistent_after_truncation(tmp_path):
+    """Tier 2: compute_truncate_floor() called synchronously after truncate_wal_if_eligible returns the same floor.
+
+    No side-effect from the asyncio.to_thread wrapper should corrupt the
+    floor calculation state for the next synchronous caller.
+    """
+    registry = _make_registry(tmp_path)
+    _seed_agent(registry, "alpha", applied_seq=10)
+
+    async def go():
+        for i in range(1, 15):
+            await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
+        await registry.truncate_wal_if_eligible()
+
+    asyncio.run(go())
+
+    # Synchronous call after the async truncation: same registry, same on-disk
+    # snapshots, so same floor.  The truncation does not mutate snapshot files.
+    floor_after = registry.compute_truncate_floor()
+    assert floor_after == 11  # applied_seq=10 → floor = 11
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — Exception propagation: corrupt snapshot → returns None
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_snapshot_propagates_as_none(tmp_path):
+    """Tier 2: when compute_truncate_floor encounters a corrupt snapshot it
+    returns 0, and truncate_wal_if_eligible returns None (no truncation).
+
+    The exception that emerges from asyncio.to_thread when compute_truncate_floor
+    returns 0 (rather than raising) is handled by the floor <= 0 guard.
+    We also test the actual-raise path by corrupting mid-scan to verify
+    the BLE001 catch wrapping still fires.
+    """
+    registry = _make_registry(tmp_path)
+    _seed_agent(registry, "alpha", applied_seq=10)
+    _corrupt_agent_snapshot(registry, "alpha")
+
+    async def go():
+        await registry.state_log.append("inbox_put", target="a", payload={})
+        return await registry.truncate_wal_if_eligible()
+
+    result = asyncio.run(go())
+    # Corrupt snapshot → compute_truncate_floor returns 0 → no truncation
+    assert result is None
+
+
+def test_large_n_floor_scan_completes(tmp_path):
+    """Tier 2: truncate_wal_if_eligible with 50 agents completes without error.
+
+    Regression guard: asyncio.to_thread default pool is adequate for N < 100
+    agents.  We don't pin the wall-clock time; we only assert completion and
+    correctness.
+    """
+    N = 50
+    registry = _make_registry(tmp_path)
+    # min applied_seq = 1 → floor = 2
+    for i in range(1, N + 1):
+        _seed_agent(registry, f"agent_{i:03d}", applied_seq=i)
+
+    async def go():
+        for i in range(1, 11):
+            await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
+        return await registry.truncate_wal_if_eligible()
+
+    stats = asyncio.run(go())
+    # floor = min(1..50) + 1 = 2 → drop seq 1, keep 2..10
+    assert stats is not None
+    assert stats["dropped"] == 1
+    assert stats["kept"] == 9

--- a/tests/test_session_skill_registry_integration.py
+++ b/tests/test_session_skill_registry_integration.py
@@ -127,31 +127,32 @@ def test_truncate_hook_unwired_without_registry(tmp_path, monkeypatch):
 def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
     """Tier 2: with registry set, the hook bridges to AgentRegistry.truncate_wal_if_eligible.
 
-    Verified end-to-end: seed alpha's profile (so AgentRegistry's
-    ``list_names`` sees it) and snapshot with a non-zero applied_seq
-    (so the floor calc returns a real value), call ``advance_phase``
-    → hook fires → AgentRegistry executes a real truncation pass.
-    Observable signal is the throttle stamp, which is set only when
-    truncation actually attempts a rewrite (floor > 0).
+    PR-N7 (FP-0008): the floor calc reads in-memory session state via
+    ``ChatSession.iter_applied_seqs``. The session must be registered
+    in ``AgentRegistry._agents`` so the floor walk picks it up; the
+    on-disk profile is created so ``list_names`` reflects the agent
+    (some unrelated paths rely on that).
+
+    Verified end-to-end: register the live session into AgentRegistry,
+    call ``advance_phase`` → SkillRegistry's in-memory snapshot bumps
+    ``last_phase_applied_seq`` → hook fires →
+    ``ChatSession.iter_applied_seqs`` yields a non-zero watermark via
+    the skill_registry pass-through → AgentRegistry executes a real
+    truncation pass. Observable signal is the throttle stamp, which is
+    set only when truncation actually attempts a rewrite (floor > 0).
     """
     from reyn.chat.profile import AgentProfile
-    from reyn.events.agent_snapshot import AgentSnapshot
 
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, with_state_log=True, with_registry=True)
 
-    # Seed alpha as a real on-disk agent so AgentRegistry.list_names
-    # discovers it (it scans the agents/ directory for entries with a
-    # profile.yaml). Without this, alpha is invisible to the truncation
-    # floor calc and floor stays at 0.
+    # On-disk profile so AgentRegistry.list_names reflects the agent.
     AgentProfile.new("alpha", role="").save(
         Path(".reyn") / "agents" / "alpha",
     )
-    snap = AgentSnapshot.empty("alpha")
-    snap.applied_seq = 5
-    snap.save(
-        Path(".reyn") / "agents" / "alpha" / "state" / "snapshot.json",
-    )
+    # Register the live session into the registry's in-memory map so the
+    # PR-N7 in-memory floor walk picks up its iter_applied_seqs.
+    session.agent_registry._agents["alpha"] = session
 
     reg = session.get_skill_registry()
     assert reg.truncate_hook is not None

--- a/tests/test_wal_long_await_floor.py
+++ b/tests/test_wal_long_await_floor.py
@@ -27,12 +27,11 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.state_log import StateLog
 from reyn.skill.skill_snapshot import SkillSnapshot
 
 # ---------------------------------------------------------------------------
-# Helpers (mirror test_registry_wal_truncate.py for consistency)
+# Helpers (mirror test_registry_wal_truncate.py post-PR-N7)
 # ---------------------------------------------------------------------------
 
 
@@ -49,11 +48,48 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     )
 
 
+class _LongAwaitShim:
+    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+
+    PR-N7 (FP-0008): the floor calc reads in-memory state via the
+    session's ``iter_applied_seqs`` public method. This shim mirrors
+    the production behavior end-to-end: the session-level applied_seq
+    is yielded when > 0, and per-skill watermarks are yielded subject
+    to the R-D16 long-await elapsed-time check that the real
+    ``SkillRegistry.iter_applied_phase_seqs`` performs.
+    """
+
+    def __init__(self) -> None:
+        self.agent_seq: int = 0  # ChatSession.journal.snapshot.applied_seq
+        # (last_phase_applied_seq, awaiting_since)
+        self.skills: list[tuple[int, "float | None"]] = []
+
+    def iter_applied_seqs(
+        self, *, now_ts: float, long_await_threshold: float,
+    ) -> list[int]:
+        out: list[int] = []
+        if self.agent_seq > 0:
+            out.append(int(self.agent_seq))
+        for last_seq, awaiting_since in self.skills:
+            if awaiting_since is not None:
+                if (now_ts - float(awaiting_since)) >= long_await_threshold:
+                    continue
+            out.append(int(last_seq))
+        return out
+
+
+def _get_or_create_shim(registry: AgentRegistry, name: str) -> _LongAwaitShim:
+    if name not in registry._agents:
+        AgentProfile.new(name, role="").save(registry._dir / name)
+        registry._agents[name] = _LongAwaitShim()
+    shim = registry._agents[name]
+    assert isinstance(shim, _LongAwaitShim)
+    return shim
+
+
 def _seed_agent(registry: AgentRegistry, name: str, *, applied_seq: int) -> None:
-    AgentProfile.new(name, role="").save(registry._dir / name)
-    snap = AgentSnapshot.empty(name)
-    snap.applied_seq = applied_seq
-    snap.save(registry._dir / name / "state" / "snapshot.json")
+    shim = _get_or_create_shim(registry, name)
+    shim.agent_seq = int(applied_seq)
 
 
 def _seed_skill(
@@ -62,16 +98,19 @@ def _seed_skill(
     run_id: str,
     *,
     last_phase_applied_seq: int,
-    awaiting_since: float | None = None,
-) -> Path:
-    snap = SkillSnapshot.empty(run_id, "demo_skill", {"input": "x"})
-    snap.last_phase_applied_seq = last_phase_applied_seq
-    snap.awaiting_since = awaiting_since
-    snap_path = (
-        registry._dir / agent_name / "state" / "skills" / f"{run_id}.snapshot.json"
-    )
-    snap.save(snap_path)
-    return snap_path
+    awaiting_since: "float | None" = None,
+) -> int:
+    """Register an active-skill watermark on the agent's shim.
+
+    Returns the skill's index in the shim's list so callers can mutate
+    ``awaiting_since`` mid-test (= the clearing-restores-inclusion case).
+    PR-N7: ``run_id`` is retained for call-site compatibility.
+    """
+    del run_id
+    shim = _get_or_create_shim(registry, agent_name)
+    idx = len(shim.skills)
+    shim.skills.append((int(last_phase_applied_seq), awaiting_since))
+    return idx
 
 
 # ---------------------------------------------------------------------------
@@ -154,22 +193,27 @@ def test_floor_mixes_short_long_and_non_await(tmp_path: Path, monkeypatch):
 
 def test_clearing_awaiting_since_restores_inclusion(tmp_path: Path, monkeypatch):
     """Tier 2: when a long-await is resolved (awaiting_since=None), the
-    skill is again included in the floor calc."""
+    skill is again included in the floor calc.
+
+    PR-N7: mutates the in-memory shim directly (the production path
+    mutates ``SkillSnapshot.awaiting_since`` in-memory when
+    ``SkillRegistry.clear_awaiting`` fires, and the next floor
+    recompute reads the fresh value).
+    """
     registry = _make_registry(tmp_path)
     _seed_agent(registry, "alpha", applied_seq=1000)
-    skill_path = _seed_skill(
+    _seed_skill(
         registry, "alpha", "run-x",
         last_phase_applied_seq=50, awaiting_since=10.0,
     )
+    shim = registry._agents["alpha"]
 
     # First: long-await → excluded, floor=1001
     monkeypatch.setattr("reyn.chat.registry.time.monotonic", lambda: 500.0)
     assert registry.compute_truncate_floor() == 1001
 
-    # User answered: clear awaiting_since on disk.
-    snap = SkillSnapshot.load("run-x", skill_path)
-    snap.awaiting_since = None
-    snap.save(skill_path)
+    # User answered: clear awaiting_since in memory.
+    shim.skills[0] = (50, None)
 
     # Now the skill is included again → floor pinned at 51.
     assert registry.compute_truncate_floor() == 51


### PR DESCRIPTION
**[e2e-coder]** — PR-N5 hang root cause + structural fix.

## Why

PR-N5 13236 single-instance pilot hung 13 hours: post-trigger CPU stagnant. Lead-coder code-inspection (2026-05-30) traced to `chat/registry.py:679` `compute_truncate_floor`: it was sync (per-agent `is_file()` + `read_text()` + `json.loads()` across all on-disk snapshot files) but called from `async def truncate_wal_if_eligible`. Sync I/O inside the event loop blocked everything.

Issue: https://github.com/tya5/reyn/issues/1041

## Retract of the first commit chain (Option B → Option D)

The first commits in this branch (64e004e2, a50cb92b) wrapped the disk-reading sync method in `asyncio.to_thread`. Lead-coder retracted that approach 2026-05-30 because it violated the existing reyn architecture choice (event loop friendly + WAL exclusive control via asyncio + event sourcing + no thread offload).

The current commit chain (Option D, 4444143a) replaces the body of `compute_truncate_floor` to read **in-memory state only** — no disk scan — and reverts the `asyncio.to_thread` wrap (no longer needed because the function is now O(N agents) in-memory and sync-friendly even from async).

## The change

| Site | Before | After |
|---|---|---|
| `AgentRegistry.compute_truncate_floor` | walked `list_names()` × per-agent + per-skill + per-plan snapshot files on disk | walks `self._agents.values()` in-memory; each session yields its watermarks via `iter_applied_seqs` |
| `AgentRegistry.truncate_wal_if_eligible` | `floor = await asyncio.to_thread(self.compute_truncate_floor)` | `floor = self.compute_truncate_floor()` (sync, in-memory, no offload) |
| `ChatSession.iter_applied_seqs(now_ts, long_await_threshold)` | NEW public method | orchestrates `journal.snapshot.applied_seq` + skill + plan watermarks via public surfaces |
| `SkillRegistry.iter_applied_phase_seqs(now_ts, long_await_threshold)` | NEW public method | encapsulates `_snapshots` access + R-D16 long-await elapsed-time exclusion |
| `PlanRegistry.iter_step_applied_seqs()` | NEW public method | mirrors above for plan watermarks |

## Architecture choice integrity

| axis | before | after |
|---|---|---|
| event loop friendly | sync I/O in async path (blocked 13h) | in-memory only (sub-ms) |
| event sourcing | disk snapshots read at runtime | in-memory state from WAL apply; disk is startup-restore only |
| WAL exclusive control via asyncio | sync I/O could block other awaits | unchanged — pure in-memory walk yields cooperatively |
| no thread offload | (first commits violated this) | confirmed: zero `asyncio.to_thread` / `threading.Thread` / `aiofiles` in the new path |

## Bounded behavior

`compute_truncate_floor` is now O(N agents × per-session iter_applied_seqs cost). Each session's iter walks its own (in-memory) journal snapshot + at most M active skill + K active plan snapshots — all dict iteration, no I/O.

## What this does NOT fix

- Other sync I/O in async paths elsewhere in the codebase — out of scope, separate fixes.
- WAL truncation semantics — preserved (`StateLog.truncate_below` rewrite primitive untouched).
- Compaction wave bugs — PR-N7 is orthogonal to PR-N3/N4/N5/N6.
- Snapshot loading on startup — `SkillRegistry.load_active()` / `PlanRegistry.load_active()` still read disk (boot-time path); only the runtime floor calc moves to in-memory.

## Test plan

- [x] `pytest -q tests/test_registry_wal_truncate.py tests/test_registry_wal_truncate_floor_nonblocking.py tests/test_registry_wal_size_safety_net.py tests/test_wal_long_await_floor.py tests/test_session_skill_registry_integration.py` — 35 passed
- [x] `python scripts/test_tier_audit.py --strict <new + updated test files>` — 35 OK / 0 warnings / 0 errors
- [x] `pytest -q tests/ -k "registry or truncate or skill or compaction or plan"` — 1507 passed, 0 fails
- [x] `pytest -q tests/` — 6251 passed, 1 pre-existing unrelated failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`, present on main)
- [x] `ruff check .` — All checks passed!
- [x] Scope-guard grep `_COMPACTION_SAFETY_MARGIN|cap_control_ir_result|MAX_CONTROL_IR_RESULT_BYTES` — 0 hits in src/ and tests/

## Test redesign

Tests previously seeded watermarks by writing snapshot JSON to disk and relying on `compute_truncate_floor` to read them. With the in-memory path, that no longer works — tests register shim sessions into `registry._agents` and surface their watermarks through `iter_applied_seqs`. Three corruption-on-disk tests were deleted (`compute_floor_zero_on_corrupt_{agent,skill,plan}_snapshot`) because the in-memory path never reads files; corruption tests for snapshot files belong to load-time test suites, not floor-calc tests.

## Commit chain

| commit | scope |
|---|---|
| 64e004e2 | (superseded) Option B wrap |
| a50cb92b | (superseded) Option B test |
| 4444143a | **Option D** — in-memory iter_applied_seqs + revert wrap + test rewrite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)