### PR TITLE
fix(fp-0008): PR-N9 — benchmark Agent uses intervention_bus=None (no tty hang)

### DIFF
--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -323,7 +323,6 @@ async def _run_single_task(
     """
     from reyn.agent import Agent
     from reyn.config import _find_project_root, load_project_context
-    from reyn.user_intervention import StdinInterventionBus
 
     async with semaphore:
         # Build input artifact
@@ -347,7 +346,13 @@ async def _run_single_task(
                 agent = Agent(
                     model=model,
                     resolver=session.resolver,
-                    intervention_bus=StdinInterventionBus(),
+                    # PR-N9: benchmark is a non-interactive subprocess. An
+                    # interactive bus blocks on tty raw_mode at limit-checkpoint
+                    # boundaries (= sandbox_2 13977 4h+ hang at apply visit 6).
+                    # Passing None routes through safety/limit_handler.py:173-179
+                    # ``no_bus`` clean abort, the same path scripted/headless
+                    # callers use. See FP-0008 PR-N9 / issue #1045.
+                    intervention_bus=None,
                     safety=session.safety_for(argparse.Namespace()),
                     shell_allowed=shell_allowed,
                     permission_resolver=permission_resolver,

--- a/tests/test_eval_benchmark_no_interactive_bus.py
+++ b/tests/test_eval_benchmark_no_interactive_bus.py
@@ -1,0 +1,126 @@
+"""Tier 2: OS invariant — eval_benchmark dispatch uses no interactive bus.
+
+PR-N9 (FP-0008): sandbox_2 13977 dogfood hung 4 hours at apply visit 6
+boundary because ``eval_benchmark.py:350`` wired an interactive
+``StdinInterventionBus`` into the Agent. When the safety limit
+checkpoint fired (apply phase max_phase_visits cap exceeded), the bus
+tried to read from tty raw_mode via ``prompt_toolkit.PromptSession``,
+blocking the asyncio event loop indefinitely in a non-interactive
+subprocess.
+
+Fix: pass ``intervention_bus=None`` so the existing
+``safety/limit_handler.py:173-179`` ``no_bus`` clean-abort path fires
+instead. This file pins both halves of that contract:
+
+1. **Wiring invariant**: the eval_benchmark module no longer imports or
+   instantiates ``StdinInterventionBus``. Caught at import time and via
+   source-text inspection so a future re-introduction surfaces in CI.
+2. **Receiver invariant**: with ``bus=None`` and the default interactive
+   ``OnLimitConfig``, ``handle_limit_exceeded`` returns a clean
+   ``no_bus`` ``LimitDecision`` with ``allow_continue=False`` — the same
+   path other headless callers (= dispatch_tool / scripted runs) rely on.
+
+No mocks. Real ``handle_limit_exceeded`` invocation; real source-text
+inspection of the eval_benchmark module.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from reyn.cli.commands import eval_benchmark
+from reyn.config import OnLimitConfig
+from reyn.safety.limit_handler import handle_limit_exceeded
+
+
+def test_eval_benchmark_does_not_import_stdininterventionbus() -> None:
+    """Tier 2: eval_benchmark module source must not import StdinInterventionBus.
+
+    A re-introduced import is a strong signal that the wiring regressed
+    to the pre-PR-N9 interactive-bus path. We use source-text inspection
+    (``inspect.getsource``) rather than ``importlib.util`` AST walks
+    because the regression we care about is the literal source line —
+    that's what reviewers and merge conflicts touch.
+    """
+    src = inspect.getsource(eval_benchmark)
+    assert "StdinInterventionBus" not in src, (
+        "eval_benchmark.py references StdinInterventionBus — "
+        "PR-N9 wired it out to avoid prompt_async hang in non-interactive "
+        "subprocess context. Re-introducing the import is a regression."
+    )
+
+
+def test_eval_benchmark_agent_call_passes_intervention_bus_none() -> None:
+    """Tier 2: the Agent(...) construction site in eval_benchmark passes
+    ``intervention_bus=None`` so the safety_helper no_bus path fires at
+    limit-checkpoint boundaries.
+
+    Source-text regression guard: pins the literal kwarg so a future edit
+    that drops the ``None`` (or re-adds an interactive bus) surfaces in
+    CI rather than at the next 4-hour dogfood hang.
+    """
+    src = inspect.getsource(eval_benchmark)
+    # The kwarg must appear literally; ordering / surrounding whitespace
+    # is incidental. We assert presence, not column alignment.
+    assert "intervention_bus=None" in src, (
+        "eval_benchmark.py does not pass intervention_bus=None to the "
+        "benchmark-time Agent constructor. PR-N9 requires this for the "
+        "no_bus clean-abort path to fire instead of hanging on tty."
+    )
+
+
+def test_handle_limit_exceeded_with_bus_none_returns_no_bus_decision() -> None:
+    """Tier 2: receiver-side contract — handle_limit_exceeded(bus=None)
+    with default interactive OnLimitConfig returns a clean ``no_bus``
+    decision, never blocking on a bus that doesn't exist.
+
+    This is the behavior the PR-N9 wiring fix relies on. If this
+    invariant breaks, a benchmark with ``intervention_bus=None`` would
+    no longer abort cleanly at limit checkpoints.
+    """
+    on_limit = OnLimitConfig()  # default mode = "interactive"
+    assert on_limit.mode == "interactive", (
+        "Default OnLimitConfig mode changed; this test assumed "
+        "'interactive' as the default and the PR-N9 fix relied on it."
+    )
+
+    decision = asyncio.run(
+        handle_limit_exceeded(
+            bus=None,
+            on_limit=on_limit,
+            kind="max_phase_visits",
+            run_id="benchmark-run",
+            prompt="Phase visit cap exceeded — extend?",
+        )
+    )
+
+    assert decision.allow_continue is False, (
+        "no_bus path must NOT allow continuation; benchmark would hang "
+        "trying to extend with no bus to ask"
+    )
+    assert decision.reason == "no_bus", (
+        f"no_bus path must surface reason='no_bus' for audit; got {decision.reason!r}"
+    )
+    assert decision.extension == 0.0
+
+
+def test_handle_limit_exceeded_with_bus_none_under_auto_extend_falls_through_to_unattended() -> None:
+    """Tier 2: when auto_extend budget is exhausted and bus is None, the
+    fall-through abort surfaces as ``unattended`` (= existing behavior;
+    PR-N9 wiring does not regress this path).
+    """
+    on_limit = OnLimitConfig(mode="auto_extend", auto_extend_times=0)
+
+    decision = asyncio.run(
+        handle_limit_exceeded(
+            bus=None,
+            on_limit=on_limit,
+            kind="router_cap",
+            run_id="benchmark-run",
+            prompt="Router cap exceeded — extend?",
+        )
+    )
+
+    assert decision.allow_continue is False
+    assert decision.reason == "unattended"
+    assert decision.extension == 0.0


### PR DESCRIPTION
**[e2e-coder]** — sandbox_2 13977 4h+ hang root cause. Issue: https://github.com/tya5/reyn/issues/1045

## Why

sandbox_2 dogfood 13977 (= Class A residual) hung 4+ hours at apply visit 6 boundary. macOS sample showed main thread asyncio kqueue idle wait + bg thread `queue.SimpleQueue.get` blocked. Lead-coder code-inspection (2026-05-30) traced to `eval_benchmark.py:350`:

```python
agent = Agent(
    ...
    intervention_bus=StdinInterventionBus(),    # ← wired regardless of subprocess context
    safety=session.safety_for(argparse.Namespace()),  # ← default interactive mode
    ...
)
```

When apply phase hits `max_phase_visits=5` cap, `safety/limit_handler.handle_limit_exceeded` calls `bus.request(...)`. `StdinInterventionBus` delegates to `prompt_toolkit.PromptSession.prompt_async()` which blocks indefinitely on tty raw_mode in a non-interactive subprocess.

13236 (clean EOFError) vs 13977 (prompt_async hang) are two code paths of the same pre-existing structural issue — depending on whether `input()` raises immediately or `prompt_async` hangs.

## The change (Option B, minimum surface)

`src/reyn/cli/commands/eval_benchmark.py`:

| | Before | After |
|---|---|---|
| import | `from reyn.user_intervention import StdinInterventionBus` | (removed) |
| line 350 | `intervention_bus=StdinInterventionBus(),` | `intervention_bus=None,` (+ comment) |

The `None` value routes through `safety/limit_handler.py:173-179`:

```python
# interactive
if bus is None:
    return LimitDecision(allow_continue=False, extension=0.0, reason="no_bus")
```

No new mechanism added. The receiver was already wired for headless callers (dispatch_tool, scripted runs) — this PR activates the same path for benchmark.

## Why Option B (per lead-coder strict)

- **Option A** (= conditionalize on isatty / TTY detection): adds new control flow, more surface, requires careful test matrix across subprocess shapes.
- **Option B** (= unconditional `None` at benchmark call site): 1-line wiring change. Benchmark IS non-interactive by definition; no detection needed.
- **Option C** (= introduce a NullInterventionBus subclass): adds a class; doesn't add semantic value vs `None`. `bus is None` is the existing branch.

## What this does NOT change

- `safety/limit_handler.py` — receiver path untouched.
- `user_intervention.py` — `StdinInterventionBus` still exists and is still used by interactive CLI paths.
- Compaction wave (PR-N3/N4/N5/N6/N7/N8) — orthogonal.
- Other Agent constructors elsewhere in the codebase — out of scope.

## Test plan

- [x] `pytest -q tests/test_eval_benchmark_no_interactive_bus.py` — 4 passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_eval_benchmark_no_interactive_bus.py` — 4 OK / 0 warnings / 0 errors
- [x] `pytest -q tests/ -k "benchmark or eval_benchmark or limit_handler or intervention"` — 273 passed
- [x] `ruff check .` — All checks passed!
- [x] Source-text grep `grep -n StdinInterventionBus src/reyn/cli/commands/eval_benchmark.py` — 0 hits after fix

## Architectural integrity

- event loop friendly ✓ — `bus is None` returns immediately, no I/O
- event sourcing ✓ — `LimitDecision` carries `reason="no_bus"` for audit
- no thread offload ✓ — pure sync branch in `handle_limit_exceeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)