### PR TITLE
chore(chainlit): sync shipped config.toml with upstream 2.11.1 canonical

### DIFF
--- a/src/reyn/chainlit_app/assets/.chainlit/config.toml
+++ b/src/reyn/chainlit_app/assets/.chainlit/config.toml
@@ -3,36 +3,210 @@
 # made after first launch are preserved (= idempotent copy mirroring
 # Chainlit's own ``init_config`` posture).
 #
-# Partial TOML is fine: ``chainlit/config.py::load_settings`` extracts
-# ``[project]`` / ``[features]`` / ``[UI]`` sections and feeds them
-# through the pydantic ``ProjectSettings`` / ``FeaturesSettings`` /
-# ``UISettings`` constructors, which fill in defaults for any missing
-# fields. ``[meta].generated_by`` is the only required field (= the loader
-# raises if absent or <= "0.3.0").
+# Synced against the chainlit 2.11.1 canonical template (= what
+# ``chainlit init`` writes into a fresh project). Field comments are
+# upstream's own; reyn-specific overrides + their rationale are
+# explicitly marked ``# reyn override`` so an operator can tell at a
+# glance which lines were already set for them.
+#
+# Partial TOML is still safe: chainlit's pydantic loader fills any
+# missing field with its default. We ship the full surface so
+# operators can see all knobs in one place instead of having to know
+# about chainlit's upstream template.
+
+[project]
+# List of environment variables to be provided by each user to use the app.
+user_env = []
+
+# Duration (in seconds) during which the session is saved when the connection is lost
+session_timeout = 3600
+
+# Duration (in seconds) of the user session expiry
+user_session_timeout = 1296000  # 15 days
+
+# Enable third parties caching (e.g., LangChain cache)
+cache = false
+
+# Whether to persist user environment variables (API keys) to the database
+# Set to true to store user env vars in DB, false to exclude them for security
+persist_user_env = false
+
+# Whether to mask user environment variables (API keys) in the UI with password type
+# Set to true to show API keys as ***, false to show them as plain text
+mask_user_env = false
+
+# Authorized origins
+allow_origins = ["*"]
+
+[features]
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = false
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Enable rendering of user messages markdown
+user_message_markdown = true
+
+# Autoscroll new user messages at the top of the window
+user_message_autoscroll = true
+
+# Autoscroll new assistant messages
+assistant_message_autoscroll = true
+
+# Automatically tag threads with the current chat profile (if a chat profile is used)
+auto_tag_thread = true
+
+# Allow users to edit their own messages
+edit_message = true
+
+# Allow users to share threads (backend + UI). Requires an app-defined on_shared_thread_view callback.
+allow_thread_sharing = false
+
+# Enable favorite messages
+favorites = false
+
+[features.slack]
+# Add emoji reaction when message is received (requires reactions:write OAuth scope)
+reaction_on_message_received = false
+
+# Authorize users to spontaneously upload files with messages
+[features.spontaneous_file_upload]
+    enabled = true
+    # Define accepted file types using MIME types
+    # Examples:
+    # 1. For specific file types:
+    #    accept = ["image/jpeg", "image/png", "application/pdf"]
+    # 2. For all files of certain type:
+    #    accept = ["image/*", "audio/*", "video/*"]
+    # 3. For specific file extensions:
+    #    accept = { "application/octet-stream" = [".xyz", ".pdb"] }
+    # Note: Using "*/*" is not recommended as it may cause browser warnings
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
+[features.audio]
+    # Enable audio features
+    enabled = false
+    # Sample rate of the audio
+    sample_rate = 24000
+
+[features.mcp]
+    # Enable Model Context Protocol (MCP) features
+    enabled = false
+
+[features.mcp.sse]
+    enabled = true
+
+[features.mcp.streamable-http]
+    enabled = true
+
+[features.mcp.stdio]
+    enabled = true
+    # Only the executables in the allow list can be used for MCP stdio server.
+    # Only need the base name of the executable, e.g. "npx", not "/usr/bin/npx".
+    # Please don't comment this line for now, we need it to parse the executable name.
+    allowed_executables = [ "npx", "uvx" ]
 
 [UI]
-# Required by chainlit's pydantic ``UISettings`` (= no default; the
-# loader raises ``ValidationError`` when missing). Shows in the
-# browser tab title + ``[UI]`` panel header.
+# reyn override: required by chainlit's pydantic ``UISettings`` (= no
+# default; the loader raises ``ValidationError`` when missing). Shows
+# in the browser tab title + ``[UI]`` panel header.
 name = "reyn"
 
-# Skip the "Start a new chat?" confirmation popup when the operator
-# clicks the agent-switch / new-chat button. Operators dogfooding the
-# reyn picker (#888) want to flip between agents quickly; the extra
-# confirm step adds friction without preventing real mistakes
-# (= reyn keeps history per agent regardless).
+# default_theme = "dark"
+
+# Force a specific language for all users (e.g., "en-US", "he-IL", "fr-FR")
+# If not set, the browser's language will be used
+# language = "en-US"
+
+# layout = "wide"
+
+# default_sidebar_state = "open"  # Options: "open", "closed", "hidden"
+
+# Chat settings display location: "message_composer" (default) or "sidebar" (header)
+# chat_settings_location = "message_composer"
+
+# Default state of chat settings sidebar when location is "sidebar"
+# default_chat_settings_open = false
+
+# reyn override: skip the "Start a new chat?" confirmation popup when
+# the operator clicks the agent-switch / new-chat button. Operators
+# dogfooding the reyn picker (#888) want to flip between agents
+# quickly; the extra confirm step adds friction without preventing
+# real mistakes (= reyn keeps history per agent regardless).
 confirm_new_chat = false
 
-# Hide chainlit's "New Chat" button. In a reyn context it triggers a
-# bare session reset (= clean_session socket event → on_chat_end →
-# on_chat_start cycle); the attached agent, history, and panel state
-# all rebuild identically, so the button is functionally a page
-# reload. Operators dogfooding mistook it for a "create new agent"
-# affordance — see the chat-profile picker / `/agent new <name>`
-# slash / settings panel for the actual agent management entry
-# points. Remove this line and the public/reyn.css ship to put the
-# upstream button back.
+# Description of the assistant. This is used for HTML tags.
+# description = ""
+
+# Chain of Thought (CoT) display mode. Can be "hidden", "tool_call" or "full".
+cot = "full"
+
+# reyn override: hide chainlit's "New Chat" button. In a reyn context
+# it triggers a bare session reset (= clean_session socket event →
+# on_chat_end → on_chat_start cycle); the attached agent, history,
+# and panel state all rebuild identically, so the button is
+# functionally a page reload. Operators dogfooding mistook it for a
+# "create new agent" affordance — see the chat-profile picker /
+# `/agent new <name>` slash / settings panel for the actual agent
+# management entry points. Remove this line and the public/reyn.css
+# ship to put the upstream button back.
 custom_css = "/public/reyn.css"
 
+# Specify additional attributes for a custom CSS file
+# custom_css_attributes = "media=\"print\""
+
+# Specify a JavaScript file that can be used to customize the user interface.
+# The JavaScript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
+# The style of alert boxes. Can be "classic" or "modern".
+alert_style = "classic"
+
+# Specify additional attributes for custom JS file
+# custom_js_attributes = "async type = \"module\""
+
+# Custom login page image, relative to public directory or external URL
+# login_page_image = "/public/custom-background.jpg"
+
+# Custom login page image filter (Tailwind internal filters, no dark/light variants)
+# login_page_image_filter = "brightness-50 grayscale"
+# login_page_image_dark_filter = "contrast-200 blur-sm"
+
+# Specify a custom meta URL (used for meta tags like og:url)
+# custom_meta_url = "https://github.com/Chainlit/chainlit"
+
+# Specify a custom meta image url.
+# custom_meta_image_url = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
+
+# Load assistant logo directly from URL.
+logo_file_url = ""
+
+# Load assistant avatar image directly from URL.
+default_avatar_file_url = ""
+
+# Avatar size in pixels (default: 20).
+# avatar_size = 20
+
+# Specify a custom build directory for the frontend.
+# This can be used to customize the frontend code.
+# Be careful: If this is a relative path, it should not start with a slash.
+# custom_build = "./public/build"
+
+# Specify optional one or more custom links in the header.
+# [[UI.header_links]]
+#     name = "Issues"
+#     display_name = "Report Issue"
+#     icon_url = "https://avatars.githubusercontent.com/u/128686189?s=200&v=4"
+#     url = "https://github.com/Chainlit/chainlit/issues"
+#     target = "_blank" (default)  # Optional: "_self", "_parent", "_top".
+
 [meta]
-generated_by = "reyn-chainlit-app"
+# Chainlit's loader raises if this is absent or compares semver-≤ "0.3.0".
+# Synced against chainlit 2.11.1 canonical; bumping the marker on the
+# shipped template makes the chainlit upgrade signal explicit so a
+# future ``reyn chainlit`` launch on an older chainlit fails fast
+# rather than silently passing a stale shape.
+generated_by = "reyn-chainlit-app over chainlit 2.11.1"


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- `src/reyn/chainlit_app/assets/.chainlit/config.toml` (= the file copied to operator cwd on first `reyn chainlit` launch) had drifted from upstream — shipped 38 lines / 1827 bytes vs chainlit 2.11.1 canonical 178 lines / 5923 bytes.
- Re-synced against `chainlit init` 2.11.1 output: full `[project]`, `[features]`, `[features.spontaneous_file_upload]`, `[features.audio]`, `[features.mcp]` + `sse/streamable-http/stdio` subsections (including `allowed_executables = [ "npx", "uvx" ]`), and expanded `[UI]` fields (`cot`, `alert_style`, `language`, `layout`, `default_sidebar_state`, `chat_settings_location`, etc.).
- Preserved 3 reyn-specific overrides + bumped `[meta].generated_by`:
  - `[UI].name = "reyn"` (= required by pydantic `UISettings`)
  - `[UI].confirm_new_chat = false` (= agent picker friction fix #888)
  - `[UI].custom_css = "/public/reyn.css"` (= hides upstream "New Chat" button)
  - `[meta].generated_by = "reyn-chainlit-app over chainlit 2.11.1"` (= bumped so older-chainlit fail-fast comparison is explicit)
- Each override carries an inline `# reyn override` rationale so future chainlit version syncs can diff vs canonical at a glance.

## Why now

User direction: `reyn config fields が最新に追従できてない。対策して`. Investigation across `reyn.local.yaml`, `src/reyn/config.py`, `tui_prefs.json`, and `src/reyn/chainlit_app/assets/.chainlit/config.toml` identified the chainlit shipped template as the drift target (= the others stay in sync via pydantic / dataclass schemas; only this hand-curated TOML had fallen behind).

## Test plan

- [x] `pytest tests/cli/test_chainlit_first_run.py` — 18 passed (= existing pins on `generated_by`, `confirm_new_chat = false`, `custom_css` still hold after the expansion)
- [x] `tomllib.loads(shipped)` — parses clean
- [x] `chainlit.config.load_config()` against a copied workdir — loads clean, `cfg.ui.name == "reyn"`
- [ ] (skipped — no UI-behavior change introduced; field semantics are upstream chainlit's) manual `reyn chainlit` smoke

## Tier self-check

This PR is config-only and touches no test files. No new tests added.

## References

- Upstream baseline: `chainlit init` against chainlit 2.11.1 (= the version pinned in `pyproject.toml`)
- Field semantics inspected via [[3rd-party UI field semantics]] memory (= PR #895 lesson) before committing the override comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)