### PR TITLE
docs(config): sync reyn-yaml.md + state-dir.md with ReynConfig schema

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -45,10 +45,13 @@ models:
 | `agent` | マップ | P6 イベント監査証跡と送信 HTTP ヘッダー用のエージェント識別子。以下参照。 |
 | `auth` | マップ | `reyn auth login` 用の OAuth プロバイダー設定。以下参照。 |
 | `cron` | マップ | スケジュール付きスキル実行 (FP-0009 Component B)。以下参照。 |
+| `external_transports` | マップ | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など、FP-0041 #489 PR-D2）。以下参照。 |
+| `multimodal` | マップ | バイナリメディア（画像・音声）のサイズ上限と超過時の挙動 (#364 cluster + #383 ストレージパス)。以下参照。 |
 | `permissions` | マップ | デフォルトの Permission ポリシー。以下参照。 |
-| `state_dir` | パス | Reyn がイベント、承認、Memory を書き込む場所。デフォルト `.reyn/`。 |
+| `plan_resume_raw` | マップ | プランモードのレジューム ポリシーの raw dict（ADR-0023 Phase 2）。プランコーディネーターが遅延パース。 |
 | `prompt_cache_enabled` | bool | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
 | `project_context_path` | 文字列 | すべての Phase システムプロンプトに注入する Markdown ファイル。デフォルト `REYN.md`。 |
+| `shell_allowed` | bool | `shell` op を事前承認（呼び出しごとのゲートを skip）。デフォルト `false`。 |
 | `api_base` | 文字列 | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
 
 ## `models` ブロック
@@ -197,6 +200,7 @@ safety:
 | `safety.loop.max_act_turns_per_phase` | int | `10` | — | 1 回の Phase 訪問内で許可される LLM ↔ op ラリー数。`0` = 無制限。 |
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | ユーザーターンごとのチャットルーター呼び出し数。`0` = 無制限。 |
 | `safety.loop.max_agent_hops` | int | `3` | — | 最大委譲深度（ユーザー → A → B → C = 3 ホップ）。 |
+| `safety.loop.plan_invalid_retries` | int | `1` | — | ルーターが malformed な `plan()` ツール呼び出しを emit した時、エラー + 「内側クォートをエスケープ」 ヒントを user-role directive として追加して LLM に再 emit させる。`0` で無効化。`1`（デフォルト）でチャットターンごとに 1 回の directive 駆動訂正を許可（B51 NF-W6-3）。 |
 
 ### `safety.timeout` フィールド
 
@@ -217,18 +221,33 @@ safety:
 
 ## `plan` ブロック
 
-プランのステップ実行バジェットとリトライ動作を制御します。
+プランのステップ実行バジェット、リトライ動作、ステップ結果コンパクションを制御します。
 
 ```yaml
 plan:
   step_max_iterations: 5   # ステップあたりの最大 RouterLoop ターン数（デフォルト: 5）
   retry_limit: 3           # ステップ失敗時の最大自動リトライ数（デフォルト: 3）
+  step_compaction:
+    recent_step_results_raw: 3                # 最新 N 件の step_results はそのまま保持
+    step_results_ratio: 0.50                  # main_pool のうち step_results に割り当てる比率
+    summarize_older_threshold_tokens: null    # null = main_pool から導出（ComputedBudgets）
+    use_chars4_estimate: false                # true = len(text)//4（レイテンシ opt-out）
 ```
 
 | キー | 型 | デフォルト | 説明 |
 |-----|------|---------|-------------|
 | `step_max_iterations` | integer | `5` | 1 つのプランステップが失敗として記録される前に消費できる最大 RouterLoop イテレーション数。 |
 | `retry_limit` | integer | `3` | 一時的エラーによるステップあたりの最大自動リトライ数。上限到達後はユーザーにバジェット延長を求めます。トークン制限と同様のコスト保護上限として機能します。 |
+| `step_compaction` | マップ | 下記デフォルト | PR-N4 の prior `step_results` コンパクションポリシー。`chat.compaction` の sibling — 蓄積したステップ出力が次ステップの sys_prompt を肥大化させそうな時、古いエントリは `ChatCompactionEngine` で要約されます。 |
+
+### `plan.step_compaction` フィールド
+
+| フィールド | 型 | デフォルト | 説明 |
+|-------|------|---------|-------------|
+| `recent_step_results_raw` | int | `3` | 最新 N 件の step_results はそのまま保持し、それより古いものをコンパクション。 |
+| `step_results_ratio` | float | `0.50` | `main_pool`（= `T_max - T_SP`）のうち次ステップの sys_prompt 内 step_results 部分に割り当てる比率。`chat.compaction.body_ratio` の sibling。 |
+| `summarize_older_threshold_tokens` | int \| null | `null` | 古い step_results をコンパクションする閾値（トークン数）。`null` の場合は `ComputedBudgets`（= `step_results_ratio × main_pool`）から導出。 |
+| `use_chars4_estimate` | bool | `false` | `true` の場合、`litellm.token_counter` の代わりに `len(text)//4` を使用（レイテンシ opt-out、`chat.compaction.use_chars4_estimate` と同じ意味）。 |
 
 ## `web` ブロック
 
@@ -724,24 +743,41 @@ embedding:
 
 組み込みクラス（`classes:` が空または省略時に有効）:
 
-| クラス | モデル |
-|-------|-------|
-| `light` | `openai/text-embedding-3-small` |
-| `standard` | `openai/text-embedding-3-small` |
-| `strong` | `openai/text-embedding-3-large` |
+| クラス | モデル | 備考 |
+|-------|-------|-------|
+| `light` | `openai/text-embedding-3-small` | `OPENAI_API_KEY` が必要。 |
+| `standard` | `openai/text-embedding-3-small` | `OPENAI_API_KEY` が必要。 |
+| `strong` | `openai/text-embedding-3-large` | `OPENAI_API_KEY` が必要。 |
+| `local-mini` | `sentence-transformers/all-MiniLM-L6-v2` | FP-0043。`pip install 'reyn[local-embed]'` が必須。extras が無い場合、初回 `embed()` 呼び出しで raise（`search_actions` の可視化ゲートは hidden へ graceful degrade）。 |
+| `local-e5` | `sentence-transformers/intfloat/multilingual-e5-small` | FP-0043。同じく `local-embed` extras 必須。多言語モデル（非英語コーパスで recall が向上）。 |
+
+FP-0043 の経緯・キャッシュロケーション・トレードオフの全体像は [Concepts: RAG — local embedding backend](../../concepts/rag.ja.md#local-embedding-backend-fp-0043) を参照。
 
 ## `chat` ブロック
 
 チャットセッションの圧縮設定 — 最近のターンを失わずにコンテキストを簡潔に保つ Head/Body/Tail トークンバジェット。
 
+PR-N3 から **比率ベースのバジェット配分** が導入されました: 4 つの ratio はモデルのメインコンテキストプール (= `T_max - T_SP`) の比率として表現され、合計が ≤ 1.0 でなければなりません（エンジン初期化時に `assert_static_bounds()` でアサート）。PR-N6 は同じ ratio バジェット内での詳細な調整のために **weight dict** を追加しました。レガシーフィールド (`trigger_total_tokens` / `head_size` / `tail_size` / `body_token_cap` / `min_compact_batch` / `section_token_caps`) は、各リプライ後に発火する background `_maybe_compact()` パスを駆動します。
+
 ```yaml
 chat:
   compaction:
-    trigger_total_tokens: 30000   # カバーされない中間部がこれを超えると圧縮
-    head_size: 12                  # 最初の N ユーザー/エージェントターンを生のまま保持
-    tail_size: 12                  # 最後の N ユーザー/エージェントターンを生のまま保持
-    body_token_cap: 1500           # 全 body サマリーセクションの合計トークン上限
-    min_compact_batch: 5           # N ターン未満の圧縮はスキップ
+    # PR-N3 ratio ベースのバジェット（合計 ≤ 1.0）:
+    head_ratio: 0.10
+    body_ratio: 0.05
+    tail_ratio: 0.15
+    new_msg_ratio: 0.10
+    section_caps_spec_tokens: 100
+    use_chars4_estimate: false        # true = len(text)//4（レイテンシ opt-out）
+    # PR-N6 weight dict（整数の重み、合計値は任意）:
+    component_weights: {head: 10, body: 5, tail: 15, new_msg: 10}
+    section_weights: {decisions: 40, pending: 40, topic_arc: 20, session_user_facts: 20, artifacts_referenced: 30}
+    # レガシー / background-trigger パス:
+    trigger_total_tokens: 30000        # カバーされない中間部がこれを超えると圧縮
+    head_size: 12                      # 最初の N ユーザー/エージェントターンを生のまま保持
+    tail_size: 12                      # 最後の N ユーザー/エージェントターンを生のまま保持
+    body_token_cap: 1500               # 全 body サマリーセクションの合計トークン上限
+    min_compact_batch: 5               # N ターン未満の圧縮はスキップ
     section_token_caps:
       topic_arc: 200
       decisions: 400
@@ -750,14 +786,32 @@ chat:
       artifacts_referenced: 300
 ```
 
-### `chat.compaction` フィールド
+### `chat.compaction` ratio フィールド（PR-N3）
 
 | フィールド | 型 | デフォルト | 説明 |
 |-------|------|---------|-------------|
-| `trigger_total_tokens` | int | `30000` | 会話のカバーされない中間部がこのトークン数を超えると圧縮を実行。 |
-| `head_size` | int | `12` | 生のまま保持する最初のユーザー/エージェントターン数（要約対象外）。 |
-| `tail_size` | int | `12` | 生のまま保持する最新のユーザー/エージェントターン数。 |
-| `body_token_cap` | int | `1500` | 全 body サマリーセクション合計のトークンバジェット。 |
+| `head_ratio` | float | `0.10` | `main_pool` のうち HEAD スライス（= 最初の生ターン）に割り当てる比率。 |
+| `body_ratio` | float | `0.05` | `main_pool` のうち BODY（= 構造化サマリー）に割り当てる比率。 |
+| `tail_ratio` | float | `0.15` | `main_pool` のうち TAIL スライス（= 最新の生ターン）に割り当てる比率。 |
+| `new_msg_ratio` | float | `0.10` | `main_pool` のうち incoming ユーザーメッセージに割り当てる比率。 |
+| `section_caps_spec_tokens` | int | `100` | コンパクタープロンプト内の `section_token_caps` シリアライズに割り当てる静的オーバーヘッドバジェット。 |
+| `use_chars4_estimate` | bool | `false` | `true` の場合、`litellm.token_counter` の代わりに `len(text)//4` を使用（大規模デプロイ向けレイテンシ opt-out）。 |
+
+### `chat.compaction` weight dict（PR-N6）
+
+| フィールド | 型 | デフォルト | 説明 |
+|-------|------|---------|-------------|
+| `component_weights` | map[str,int] | `{head: 10, body: 5, tail: 15, new_msg: 10}` | ratio バジェット内のコンポーネントごとの配分を駆動する整数の重み。合計値は任意。指定したキーのみオーバーライド。 |
+| `section_weights` | map[str,int] | （セクションごとのデフォルト） | `body_ratio` 内のサブセクション配分の重み。`component_weights` と同じ shape セマンティクス。 |
+
+### `chat.compaction` レガシー / background-path フィールド
+
+| フィールド | 型 | デフォルト | 説明 |
+|-------|------|---------|-------------|
+| `trigger_total_tokens` | int | `30000` | background `_maybe_compact()` パス: カバーされない中間部がこのトークン数を超えると圧縮。同期的 pre-frame ガードは ratio フィールドを使用。 |
+| `head_size` | int | `12` | background パス: 生のまま保持する最初のユーザー/エージェントターン数（ターン数ベースのゲート）。 |
+| `tail_size` | int | `12` | background パス: 生のまま保持する最新のユーザー/エージェントターン数（ターン数ベースのゲート）。 |
+| `body_token_cap` | int | `1500` | post-truncation 後のサマリー body トークン上限（legacy ceiling）。 |
 | `min_compact_batch` | int | `5` | 吸収するターン数がこれ未満の場合は圧縮をスキップ（小さな圧縮を回避）。 |
 
 ### `chat.compaction.section_token_caps` フィールド
@@ -892,6 +946,55 @@ python:
 | `allowed_modules` | list[string] | `[]` | セーフモード Python preprocessor ステップが組み込み stdlib 許可リストに加えてインポートできる追加モジュール名。内部で I/O を行うライブラリ（例: `pandas`、`requests`）はセーフモードのサンドボックスを無効化します — 慎重に管理してください。 |
 
 > unsafe Python ステップ（preprocessor フロントマターの `mode: unsafe`）はこのリストで制限されず、ランタイムで `--allow-unsafe-python` も必要です。完全な Permission 文法は [Reference: permissions](permissions.md) を参照してください。
+
+## `multimodal` ブロック
+
+Reyn がバイナリメディア（`web__fetch` / `file__read` / MCP サーバー由来の画像）を扱う方法と、マルチモーダルアーティファクトのディスク上の保存先を制御します（#364 cluster + #383 PR-C ストレージパス）。
+
+```yaml
+multimodal:
+  max_bytes: 5000000              # 5 MB — Anthropic の per-image API 上限
+  on_oversize: ask                # ask | allow | deny
+  media_dir: .reyn/media          # 画像バイナリのプロジェクト相対ディレクトリ
+  tool_results_dir: .reyn/tool-results   # ツール結果ダンプのプロジェクト相対ディレクトリ
+  base_url: null                  # クロスホスト path_ref 用のオプション正規 URL プレフィックス
+```
+
+| フィールド | 型 | デフォルト | 説明 |
+|-------|------|---------|-------------|
+| `max_bytes` | int | `5000000` (5 MB) | on-oversize ゲートが起動する前のデコード後ペイロードのバイト上限。バイナリサイズ (`len(response.content)` / `len(file_bytes)`) をカウント、base64 後の shape ではない。 |
+| `on_oversize` | 文字列 | `ask` | メディアが `max_bytes` を超えた時の動作: `ask`（intervention bus でサイズ + ソース情報を提示してユーザーに確認、yes でロード、no でドロップ）、`allow`（無条件に受け入れ、信頼済み non-interactive パイプライン向け）、`deny`（無条件に拒否、op は `status="denied"` を返す。コスト重視コンテキスト向け）。 |
+| `media_dir` | 文字列 | `.reyn/media` | 画像バイナリ保存のプロジェクト相対ディレクトリ（#383 PR-C）。ファイルは timestamp + chain-id + tool prefix のフラット命名で `ls -la` が時系列ソートになる。operator が browse + delete 可能。 |
+| `tool_results_dir` | 文字列 | `.reyn/tool-results` | テキスト系ツール結果ダンプのプロジェクト相対ディレクトリ（#385 PoC）。PR-C で writer、PR-D で consumer + preview。 |
+| `base_url` | 文字列 \| null | `null` | クロスホスト `path_ref` 消費用のオプション正規 URL プレフィックス（#385 β cross-host サブタスク）。`"https://reyn.example.com"`（= デプロイ済み `reyn web` の URL）等を設定すると、`MediaStore.save_*` が path_ref に `<base_url>/agents/<agent>/tool-results/<artifact>` を指す `url` フィールドを付与し、A2A peer / MCP client / ブラウザがリソースルーター経由で body を fetch 可能になる。未設定の場合は `url` フィールド非生成（same-host fast-path のみ）。 |
+
+## `external_transports` ブロック
+
+チャット向け受信トランスポート → MCP ツールルーティング（FP-0041 #489 PR-D2）。外部トランスポート名（Slack / LINE / Discord / ...）を、リプライを配信する MCP ツール + ルーター出力をツール引数に shape する `args_template` にマップします。
+
+```yaml
+external_transports:
+  transports:
+    slack:
+      mcp_tool: slack__post_message
+      args_template:
+        channel: "${TRANSPORT_DEST}"
+        text: "${ROUTER_REPLY}"
+    line:
+      mcp_tool: line__push_message
+      args_template:
+        to: "${TRANSPORT_DEST}"
+        messages:
+          - type: text
+            text: "${ROUTER_REPLY}"
+```
+
+| フィールド | 型 | 説明 |
+|-------|------|-------------|
+| `transports.<name>.mcp_tool` | 文字列 | リプライを配信する完全修飾 MCP ツール名 (`<server>__<tool>`)。 |
+| `transports.<name>.args_template` | マップ | MCP ツールに渡される shape。`${TRANSPORT_DEST}` はメッセージごとの宛先 ID（channel / user / room id）に解決、`${ROUTER_REPLY}` はルーターの最終テキストに解決。他の `${VAR}` 参照は標準 interpolation ルールに従って `os.environ` から解決。 |
+
+トランスポートごとの contract と利用可能なテンプレート変数の全集合は `src/reyn/chat/external_routing.py` を参照。
 
 ## 関連情報
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -45,10 +45,13 @@ models:
 | `agent` | map | Agent identity for P6 event audit trail and outgoing HTTP header. See below. |
 | `auth` | map | OAuth provider configurations for `reyn auth login`. See below. |
 | `cron` | map | Scheduled skill executions (FP-0009 Component B). See below. |
+| `external_transports` | map | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.) (FP-0041 #489 PR-D2). See below. |
+| `multimodal` | map | Binary media (image/audio) size cap and on-oversize behaviour (#364 cluster + #383 storage paths). See below. |
 | `permissions` | map | Default permission policy. See below. |
-| `state_dir` | path | Where reyn writes events, approvals, memory. Default `.reyn/`. |
+| `plan_resume_raw` | map | Raw resume-policy dict for plan-mode runs (ADR-0023 Phase 2). Parsed lazily by the plan coordinator. |
 | `prompt_cache_enabled` | bool | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
 | `project_context_path` | string | Markdown file injected into every phase system prompt. Default `REYN.md`. |
+| `shell_allowed` | bool | Pre-approve the `shell` op so it is not gated per-call. Default `false`. |
 | `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
 
 ## `models` block
@@ -204,6 +207,7 @@ safety:
 | `safety.loop.max_act_turns_per_phase` | int | `10` | — | LLM ↔ op volleys allowed inside one phase visit. `0` = unlimited. |
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | Chat-router invocations per user turn. `0` = unlimited. |
 | `safety.loop.max_agent_hops` | int | `3` | — | Maximum delegation depth (user → A → B → C = 3 hops). |
+| `safety.loop.plan_invalid_retries` | int | `1` | — | When the router emits a malformed `plan()` tool call, append the error + an "escape inner quotes" hint and let the LLM re-emit. `0` disables; `1` (default) allows one directive-driven correction per chat turn. (B51 NF-W6-3.) |
 | `safety.loop.skill_calls_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) spawn cap. `hard_limit` + `warn_ratio` sub-fields. Hybrid: loop-detection semantics, budget-style user approval on hit. |
 | `safety.loop.skill_tokens_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) token cap. `hard_limit` + `warn_ratio` sub-fields. |
 
@@ -226,18 +230,33 @@ safety:
 
 ## `plan` block
 
-Controls plan step execution budget and retry behavior.
+Controls plan step execution budget, retry behaviour, and prior-step compaction.
 
 ```yaml
 plan:
   step_max_iterations: 5   # max RouterLoop turns per step (default: 5)
   retry_limit: 3           # max auto-retries per step on failure (default: 3)
+  step_compaction:
+    recent_step_results_raw: 3                # keep the last N step_results verbatim
+    step_results_ratio: 0.50                  # fraction of main_pool reserved for step_results
+    summarize_older_threshold_tokens: null    # null = derive from main_pool (engine ComputedBudgets)
+    use_chars4_estimate: false                # true = len(text)//4 (latency opt-out)
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `step_max_iterations` | integer | `5` | Maximum RouterLoop iterations one plan step may consume before being recorded as failed. |
 | `retry_limit` | integer | `3` | Maximum automatic retries per step on transient errors. When exhausted, the user is prompted to extend the budget. Acts as a cost protection ceiling analogous to token limits. |
+| `step_compaction` | map | see defaults | PR-N4 prior `step_results` compaction policy. Sibling to `chat.compaction` — when accumulated step outputs would balloon the next step's sys_prompt, older entries are summarised by `ChatCompactionEngine`. |
+
+### `plan.step_compaction` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `recent_step_results_raw` | int | `3` | Keep the last N step_results verbatim; compact older ones. |
+| `step_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the step_results portion of the next step's sys_prompt. Sibling to `chat.compaction.body_ratio`. |
+| `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older step_results are compacted. `null` derives the threshold from `ComputedBudgets` (= `step_results_ratio × main_pool`). |
+| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out, mirrors `chat.compaction.use_chars4_estimate`). |
 
 ## `web` block
 
@@ -768,24 +787,41 @@ Each key under `embedding.classes` is a class name. Built-in defaults (`light`, 
 
 Built-in classes (active when `classes:` is empty or absent):
 
-| Class | Model |
-|-------|-------|
-| `light` | `openai/text-embedding-3-small` |
-| `standard` | `openai/text-embedding-3-small` |
-| `strong` | `openai/text-embedding-3-large` |
+| Class | Model | Notes |
+|-------|-------|-------|
+| `light` | `openai/text-embedding-3-small` | Needs `OPENAI_API_KEY`. |
+| `standard` | `openai/text-embedding-3-small` | Needs `OPENAI_API_KEY`. |
+| `strong` | `openai/text-embedding-3-large` | Needs `OPENAI_API_KEY`. |
+| `local-mini` | `sentence-transformers/all-MiniLM-L6-v2` | FP-0043. Requires `pip install 'reyn[local-embed]'`; without the extras, instantiating raises at first `embed()` call (the `search_actions` visibility gate degrades to hidden gracefully). |
+| `local-e5` | `sentence-transformers/intfloat/multilingual-e5-small` | FP-0043. Same `local-embed` extras requirement; multilingual model (better recall on non-English corpora). |
+
+See [Concepts: RAG — local embedding backend](../../concepts/rag.md#local-embedding-backend-fp-0043) for the full story on FP-0043, cache locations, and trade-offs.
 
 ## `chat` block
 
 Chat-session compaction — head/body/tail token budgets that keep context concise without losing recent turns.
 
+PR-N3 introduced **ratio-based** budget allocation: each of the four ratios is a fraction of the model's main context pool (= `T_max - T_SP`), and they must sum to ≤ 1.0 (asserted at engine init via `assert_static_bounds()`). PR-N6 added **weight dicts** for fine-grained tuning under the same ratio budget. The legacy `trigger_total_tokens` / `head_size` / `tail_size` / `body_token_cap` / `min_compact_batch` / `section_token_caps` fields drive the background `_maybe_compact()` path that fires after each reply.
+
 ```yaml
 chat:
   compaction:
-    trigger_total_tokens: 30000   # compact when uncovered middle exceeds this
-    head_size: 12                  # first N user/agent turns kept raw
-    tail_size: 12                  # last N user/agent turns kept raw
-    body_token_cap: 1500           # total token cap across all body summary sections
-    min_compact_batch: 5           # skip compaction when fewer than N turns to absorb
+    # PR-N3 ratio-based budget (sum must be ≤ 1.0):
+    head_ratio: 0.10
+    body_ratio: 0.05
+    tail_ratio: 0.15
+    new_msg_ratio: 0.10
+    section_caps_spec_tokens: 100
+    use_chars4_estimate: false        # true = len(text)//4 (latency opt-out)
+    # PR-N6 weight dicts (integer weights, sum-arbitrary):
+    component_weights: {head: 10, body: 5, tail: 15, new_msg: 10}
+    section_weights: {decisions: 40, pending: 40, topic_arc: 20, session_user_facts: 20, artifacts_referenced: 30}
+    # Legacy / background-trigger path:
+    trigger_total_tokens: 30000        # compact when uncovered middle exceeds this
+    head_size: 12                      # first N user/agent turns kept raw
+    tail_size: 12                      # last N user/agent turns kept raw
+    body_token_cap: 1500               # total token cap across all body summary sections
+    min_compact_batch: 5               # skip compaction when fewer than N turns to absorb
     section_token_caps:
       topic_arc: 200
       decisions: 400
@@ -794,14 +830,32 @@ chat:
       artifacts_referenced: 300
 ```
 
-### `chat.compaction` fields
+### `chat.compaction` ratio fields (PR-N3)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `trigger_total_tokens` | int | `30000` | Compact when the uncovered middle of the conversation exceeds this token count. |
-| `head_size` | int | `12` | Number of earliest user/agent turns kept verbatim (never summarised). |
-| `tail_size` | int | `12` | Number of most-recent user/agent turns kept verbatim. |
-| `body_token_cap` | int | `1500` | Total token budget for all body summary sections combined. |
+| `head_ratio` | float | `0.10` | Fraction of `main_pool` reserved for the HEAD slice (= earliest verbatim turns). |
+| `body_ratio` | float | `0.05` | Fraction of `main_pool` reserved for the BODY (= rolling structured summary). |
+| `tail_ratio` | float | `0.15` | Fraction of `main_pool` reserved for the TAIL slice (= most-recent verbatim turns). |
+| `new_msg_ratio` | float | `0.10` | Fraction of `main_pool` reserved for the incoming user message. |
+| `section_caps_spec_tokens` | int | `100` | Static overhead budget for `section_token_caps` serialisation in the compactor prompt. |
+| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
+
+### `chat.compaction` weight dicts (PR-N6)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `component_weights` | map[str,int] | `{head: 10, body: 5, tail: 15, new_msg: 10}` | Integer weights driving per-component allocation within the ratio budget. Sum is arbitrary; individual keys override only those components. |
+| `section_weights` | map[str,int] | (per-section default) | Integer weights for sub-section allocation within `body_ratio`. Same shape semantics as `component_weights`. |
+
+### `chat.compaction` legacy / background-path fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `trigger_total_tokens` | int | `30000` | Background `_maybe_compact()` path: compact when the uncovered middle exceeds this token count. The synchronous pre-frame guard uses the ratio fields instead. |
+| `head_size` | int | `12` | Background path: number of earliest user/agent turns kept verbatim (turn-count gate). |
+| `tail_size` | int | `12` | Background path: number of most-recent user/agent turns kept verbatim (turn-count gate). |
+| `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation (legacy ceiling). |
 | `min_compact_batch` | int | `5` | Skip compaction when fewer than this many turns would be absorbed (avoids tiny compactions). |
 
 ### `chat.compaction.section_token_caps` fields
@@ -936,6 +990,55 @@ python:
 | `allowed_modules` | list[string] | `[]` | Additional module names that safe-mode Python preprocessor steps may import, on top of the built-in stdlib allowlist. Libraries with internal I/O (e.g. `pandas`, `requests`) defeat safe-mode sandboxing — curate carefully. |
 
 > Unsafe Python steps (`mode: unsafe` in the preprocessor frontmatter) are not restricted by this list and also require `--allow-unsafe-python` at runtime. See [Reference: permissions](permissions.md) for the full permission grammar.
+
+## `multimodal` block
+
+Controls how Reyn handles binary media (images from `web__fetch` / `file__read` / MCP servers) and where multimodal artefacts live on disk (#364 cluster + #383 PR-C storage paths).
+
+```yaml
+multimodal:
+  max_bytes: 5000000              # 5 MB — Anthropic per-image API limit
+  on_oversize: ask                # ask | allow | deny
+  media_dir: .reyn/media          # project-relative dir for image binaries
+  tool_results_dir: .reyn/tool-results   # project-relative dir for tool-result dumps
+  base_url: null                  # optional canonical URL prefix for cross-host path_ref
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_bytes` | int | `5000000` (5 MB) | Decoded-payload byte cap before the on-oversize gate fires. Counts the binary size (`len(response.content)` / `len(file_bytes)`), not the base64-encoded shape. |
+| `on_oversize` | string | `ask` | What to do when a piece of media exceeds `max_bytes`: `ask` (prompt the user via the intervention bus with size + source info; yes loads the media, no drops it), `allow` (silently accept; use in trusted non-interactive pipelines), `deny` (silently reject; the op returns `status="denied"` — use in cost-sensitive contexts). |
+| `media_dir` | string | `.reyn/media` | Project-relative directory for image binary storage (#383 PR-C). Files are flat-named with timestamp + chain-id + tool prefix so `ls -la` sorts chronologically. Operator-browseable and operator-deleteable. |
+| `tool_results_dir` | string | `.reyn/tool-results` | Project-relative directory for text-y tool result dumps (#385 PoC). PR-C lands the writer alongside `media_dir`; PR-D wires the consumer + preview. |
+| `base_url` | string \| null | `null` | Optional canonical URL prefix for cross-host `path_ref` consumption (#385 β cross-host sub-task). When set (e.g. `"https://reyn.example.com"` from a deployed `reyn web`), `MediaStore.save_*` augments the path_ref with a `url` field pointing at `<base_url>/agents/<agent>/tool-results/<artifact>` so A2A peers / MCP clients / browsers can fetch the body via the resources router. Unset → no `url` field minted (same-host fast-path only). |
+
+## `external_transports` block
+
+Inbound transport → MCP tool routing for chat (FP-0041 #489 PR-D2). Maps an external transport name (Slack / LINE / Discord / ...) to the MCP tool that delivers replies, plus an `args_template` describing how router output is shaped into the tool's arguments.
+
+```yaml
+external_transports:
+  transports:
+    slack:
+      mcp_tool: slack__post_message
+      args_template:
+        channel: "${TRANSPORT_DEST}"
+        text: "${ROUTER_REPLY}"
+    line:
+      mcp_tool: line__push_message
+      args_template:
+        to: "${TRANSPORT_DEST}"
+        messages:
+          - type: text
+            text: "${ROUTER_REPLY}"
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transports.<name>.mcp_tool` | string | Fully-qualified MCP tool name (`<server>__<tool>`) that delivers the reply. |
+| `transports.<name>.args_template` | map | Shape passed to the MCP tool. `${TRANSPORT_DEST}` resolves to the per-message destination identifier (channel / user / room id), `${ROUTER_REPLY}` to the router's final text. Other `${VAR}` references resolve from `os.environ` per the standard interpolation rules. |
+
+See `src/reyn/chat/external_routing.py` for the per-transport contract and the full set of available template variables.
 
 ## See also
 

--- a/docs/reference/config/state-dir.ja.md
+++ b/docs/reference/config/state-dir.ja.md
@@ -7,7 +7,7 @@ applies_to: [.reyn/]
 
 # `.reyn/` — 状態ディレクトリ
 
-プロジェクトごとの状態。デフォルトの場所: `<project_root>/.reyn/`。`reyn.yaml` の `state_dir` キーでオーバーライドします。
+プロジェクトごとの状態。場所: `<project_root>/.reyn/` — 固定です。（`reyn.yaml` に `state_dir` knob はありません。ランタイムが検出したプロジェクトルートからパスを構築します。）
 
 ## レイアウト
 

--- a/docs/reference/config/state-dir.md
+++ b/docs/reference/config/state-dir.md
@@ -7,7 +7,7 @@ applies_to: [.reyn/]
 
 # `.reyn/` — state directory
 
-Per-project state. Default location: `<project_root>/.reyn/`. Override via `reyn.yaml`'s `state_dir` key.
+Per-project state. Location: `<project_root>/.reyn/` — fixed. (There is no `state_dir` knob in `reyn.yaml`; the runtime constructs the path from the discovered project root.)
 
 ## Layout
 


### PR DESCRIPTION
**[tui-coder]** —

Companion to #1049 (sample template sync). Addresses drift between `docs/reference/config/{reyn-yaml,state-dir}.md` (+ `.ja.md` mirrors) and the actual `ReynConfig` schema in `src/reyn/config.py`.

## Summary

### A. Spurious config key removed
- `state-dir.md` + `state-dir.ja.md`: drop the "Override via `reyn.yaml`'s `state_dir` key" claim. There is no `state_dir` parser in `ReynConfig`; the path is constructed from the discovered project root (= `Agent` hardcodes `state_dir=".reyn"` in `src/reyn/agent.py:66`).
- `reyn-yaml.md` + `.ja.md`: drop the `state_dir` row from the top-level keys table for the same reason.

### B. Missing top-level fields added (= ReynConfig fields not previously documented)
- `shell_allowed` (bool, default `false`)
- `multimodal` (#364 cluster + #383 storage paths)
- `external_transports` (FP-0041 #489 PR-D2)
- `plan_resume_raw` (ADR-0023 Phase 2; lazy-parsed by the plan coordinator)

### C. Missing sub-fields added to existing sections
- `safety.loop.plan_invalid_retries` (B51 NF-W6-3 self-correction retry)
- `chat.compaction` ratio fields (PR-N3): `head_ratio` / `body_ratio` / `tail_ratio` / `new_msg_ratio` / `section_caps_spec_tokens` / `use_chars4_estimate`
- `chat.compaction` weight dicts (PR-N6): `component_weights` / `section_weights`
- `chat.compaction` legacy fields re-grouped under their own subhead so operators see them as the background-trigger path rather than the canonical one
- `plan.step_compaction` (PR-N4): full `PlannerStepCompactionConfig` subsection with the 4 fields and the `ChatCompactionEngine` relationship
- `embedding` built-in classes table: add `local-mini` / `local-e5` (FP-0043) rows with the `local-embed` extras gating note

### D. New reference sections
- `multimodal` block: `max_bytes` / `on_oversize` / `media_dir` / `tool_results_dir` / `base_url` with the #364 cluster context
- `external_transports` block: `transports.<name>.mcp_tool` + `args_template` with the FP-0041 #489 PR-D2 contract

The `.ja.md` mirror receives the same set of changes in Japanese.

## Why now

User direction: `ドキュメントも追従できてるか確認してね` after the sample template sync in #1049 — verification surfaced this drift on the canonical reference doc.

## Test plan

- [x] Per-keyword presence check in both files (`state_dir` removed → 0 mentions; all newly added fields appear ≥1 time)
- [x] Inline YAML examples match the corresponding dataclass defaults in `src/reyn/config.py` (= `EmbeddingConfig` / `MultimodalConfig` / `PlannerStepCompactionConfig` / `LoopConfig.plan_invalid_retries` / etc. cross-checked)
- [ ] (skipped — purely additive documentation, no executable code touched) `mkdocs build` validation locally — relying on CI mkdocs check if any

## Tier self-check

This PR is documentation-only and touches no test files. No new tests added.

## References

- Schema source of truth: `src/reyn/config.py` (`ReynConfig` + per-section dataclasses)
- Sibling sync: #1049 (= sample template exhaustive sync)
- Earlier sibling: #1047 (= chainlit shipped `config.toml` against upstream 2.11.1)
- `docs/concepts/rag.md` for the FP-0043 local-* embedding story (= unchanged in this PR; only the reference table cross-references it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)