### PR TITLE
fix(fp-0008): PR-N12 — correct benchmark permission doc shape + real functional test

### DIFF
--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -72,10 +72,12 @@
 # operator pre-approve specific tools so the router doesn't gate them at
 # runtime.
 #
-# Shape: nested dict where leaves are ``allow``. Categories:
+# Shape: a dotted kind key mapped to the flat string ``allow`` (or the
+# nested ``file: {write: allow}`` form). The config permission layer is
+# NON-glob — it does not accept path-glob dicts. Categories:
 #   shell             — pre-approve all shell ops
 #   file.delete       — pre-approve file-delete ops
-#   file.write        — pre-approve file-write ops (path-glob keyed)
+#   file.write        — pre-approve all file-write ops (flat kind grant, non-glob)
 #   python.safe       — pre-approve the python preprocessor's safe mode
 #                       (stdlib skill_router uses this — already set in reyn.yaml)
 #   mcp.<server>      — pre-approve a specific MCP server's tool surface
@@ -87,20 +89,30 @@
 #   mcp:
 #     github: allow
 #
-# Headless / benchmark pre-approval (PR-N9 / PR-N11): benchmark Agents are
-# constructed with ``intervention_bus=None`` (= ``reyn eval benchmark ...``),
-# so any permission the skill declares (e.g. swe_bench's ``file.write: "*"``)
-# raises a RuntimeError on the first control_ir op instead of asking the
-# user. Pre-approve the same surface here to clear the prompt — main
+# Headless / benchmark pre-approval (PR-N9 / PR-N11 / PR-N12): benchmark
+# Agents are constructed with ``intervention_bus=None`` (= ``reyn eval
+# benchmark ...``), so any permission the skill declares (e.g. swe_bench's
+# ``file.write``) raises a RuntimeError on the first control_ir op instead
+# of asking the user. Pre-approve the kind here to clear the prompt — main
 # ``reyn.yaml`` is intentionally left alone (= chat sessions have a bus and
 # CAN ask interactively, so this stays a local / headless-only concern):
 #
 # permissions:
-#   file.write:
-#     "*": allow
+#   file.write: allow
 #
-# Narrow the glob (e.g. ``"workspace/**"``) for a tighter scope. Without
-# this entry, benchmark runs fail at the first ``file.write`` control_ir op.
+# The value MUST be the flat string ``allow`` (= same shape as the
+# checked-in ``reyn.yaml``'s ``python.safe: allow``). The config
+# permission layer is NON-glob: it only recognises a dotted key mapped
+# to ``allow`` / ``deny`` (or the nested ``file: {write: allow}`` form).
+# A glob dict like ``file.write: {"*": allow}`` is NEVER matched by the
+# loader (``_is_config_approved``) and silently fails closed — the
+# benchmark would still hit a permission RuntimeError at the first
+# ``file.write`` op.
+#
+# ``file.write: allow`` grants the whole write-class kind (write / edit
+# / delete) for all skills. If you need a tighter, path-scoped grant,
+# that lives in a different layer (the startup-approval / saved-approval
+# mechanism that records specific paths), not in this config block.
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_reyn_local_example_benchmark_permissions.py
+++ b/tests/test_reyn_local_example_benchmark_permissions.py
@@ -1,127 +1,122 @@
-"""Tier 2: OS invariant — reyn.local.yaml.example documents the benchmark
-permission pre-approval that PR-N9 (intervention_bus=None) made mandatory.
+"""Tier 2: OS invariant — the benchmark permission pre-approval documented
+in reyn.local.yaml.example is a SHAPE the real PermissionResolver accepts.
 
-PR-N11 (FP-0008): PR-N9 wired the benchmark Agent with
-``intervention_bus=None`` to escape the tty-prompt hang. Without a
-bus, the permission system can't ask for approval, so any skill that
-declares a write-side surface (e.g. swe_bench's ``file.write: "*"``)
-raises a RuntimeError on the first control_ir op.
+PR-N9 wired the benchmark Agent with ``intervention_bus=None`` to escape
+the tty-prompt hang. Without a bus, the permission system can't ask, so a
+skill that declares a write surface (e.g. swe_bench's ``file.write``)
+raises unless the kind is pre-approved in config. PR-N11 documented a
+pre-approval snippet in ``reyn.local.yaml.example`` — but the documented
+shape was WRONG: it used a nested glob (``file.write: {"*": allow}``)
+which ``PermissionResolver._is_config_approved`` never matches, so a
+benchmark using that snippet would still fail closed.
 
-The fix-shape (= Option C, lead-coder strict): document the pre-approval
-pattern in ``reyn.local.yaml.example`` so operators copy the entry into
-their ``reyn.local.yaml`` before running benchmarks. The main
-``reyn.yaml`` is intentionally NOT modified — pre-approval is a
-benchmark / headless concern, not a default for chat runs.
+PR-N12 corrects the doc to the flat ``file.write: allow`` shape and
+replaces the prior YAML-round-trip test (= false-confidence format pin
+that never invoked the loader) with a REAL functional invariant: build a
+``PermissionResolver`` from the documented config and assert
+``require_file_write`` actually clears for an out-of-zone path. The
+contract under test is "paste the documented snippet → benchmark writes
+are approved", end to end through the real permission mechanism.
 
-This file pins both halves of the contract:
-
-1. **Example presence**: the ``reyn.local.yaml.example`` source contains
-   a documented ``permissions: file.write: "*": allow`` block (as a
-   commented opt-in example). Catches a regression that drops the
-   guidance back to "operators have to figure it out" — the same
-   regression PR-N9 + this PR are written together to prevent.
-
-2. **Parseable shape**: when the commented example is uncommented and
-   parsed as YAML, the resulting structure matches the layout the
-   permissions loader expects (`permissions.file.write["*"] == "allow"`).
-   Catches a typo regression in the example (= a future edit that
-   silently breaks the YAML the operator pastes).
-
-No mocks. Real file read + real YAML parse.
+No mocks. Real ``PermissionResolver`` + real ``require_file_write`` +
+real tmp_path. Per testing policy: Fake/real over Mock.
 """
 from __future__ import annotations
 
-import textwrap
 from pathlib import Path
 
-import yaml
+import pytest
+
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
 
 _EXAMPLE_PATH = Path(__file__).resolve().parents[1] / "reyn.local.yaml.example"
 
 
-def test_example_documents_file_write_pre_approval() -> None:
-    """Tier 2: the example documents the benchmark permission pre-approval.
+def _out_of_zone_path(tmp_path: Path) -> str:
+    """An absolute path outside the default write zone (.reyn/ , reyn/).
 
-    Source-text invariant: the example contains the canonical opt-in
-    snippet. A future edit that drops the guidance regresses the PR-N9
-    + PR-N11 contract and operators lose the breadcrumb that explains
-    why benchmark runs fail without ``reyn.local.yaml``.
+    A plain tmp file under a non-reyn directory is out of zone, so
+    require_file_write must consult config / approvals rather than
+    auto-granting via the default-zone shortcut.
+    """
+    return str(tmp_path / "workspace" / "patch_target.py")
+
+
+def test_flat_config_shape_clears_require_file_write(tmp_path: Path) -> None:
+    """Tier 2: a PermissionResolver built from the DOCUMENTED flat shape
+    (``file.write: allow``) clears ``require_file_write`` for an
+    out-of-zone path without raising.
+
+    This is the functional contract PR-N11 meant to pin but didn't: the
+    documented snippet, fed to the real resolver, actually approves the
+    benchmark's write surface.
+    """
+    resolver = PermissionResolver(
+        {"file.write": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+    decl = PermissionDecl()  # empty — no per-path declaration
+    # Must NOT raise: config grant covers the write-class kind.
+    resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
+
+
+def test_nested_glob_shape_does_not_clear_require_file_write(tmp_path: Path) -> None:
+    """Tier 2: the WRONG nested-glob shape (``file.write: {"*": allow}``)
+    does NOT clear ``require_file_write`` — it raises PermissionError.
+
+    This pins the regression PR-N12 fixes: the PR-N11 documented snippet
+    (a nested glob dict) is silently unmatched by ``_is_config_approved``,
+    so a benchmark using it would still fail closed. The doc must use the
+    flat shape; this test fails if anyone reintroduces the glob form as
+    "supported".
+    """
+    resolver = PermissionResolver(
+        {"file.write": {"*": "allow"}},
+        project_root=tmp_path,
+        interactive=False,
+    )
+    decl = PermissionDecl()
+    with pytest.raises(PermissionError):
+        resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
+
+
+def test_nested_to_string_shape_also_clears(tmp_path: Path) -> None:
+    """Tier 2: the alternate nested-to-string shape (``file: {write: allow}``)
+    also clears — documenting that the loader accepts both the flat
+    dotted-key and the nested-to-string forms (but NOT the glob dict).
+    """
+    resolver = PermissionResolver(
+        {"file": {"write": "allow"}},
+        project_root=tmp_path,
+        interactive=False,
+    )
+    decl = PermissionDecl()
+    resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
+
+
+def test_example_documents_flat_file_write_allow() -> None:
+    """Tier 2: reyn.local.yaml.example documents the FLAT shape, not the glob.
+
+    Source-text guard: the example must show ``file.write: allow`` and
+    must NOT show the nested-glob form that fails closed. Catches a
+    regression back to the PR-N11 mistake.
     """
     src = _EXAMPLE_PATH.read_text(encoding="utf-8")
-    assert "permissions:" in src, (
-        "reyn.local.yaml.example does not mention 'permissions:' — "
-        "PR-N11 documents the benchmark pre-approval and a future edit "
-        "appears to have removed it."
+    assert "file.write: allow" in src, (
+        "reyn.local.yaml.example must document the flat 'file.write: allow' "
+        "shape — the only form the config permission layer accepts for "
+        "benchmark pre-approval."
     )
-    assert "file.write" in src, (
-        "reyn.local.yaml.example does not document the 'file.write' "
-        "pre-approval — required for benchmark dispatch since PR-N9 "
-        "wired intervention_bus=None."
-    )
-    assert '"*": allow' in src or "'*': allow" in src, (
-        "reyn.local.yaml.example does not show the '*: allow' shape "
-        "operators paste into their reyn.local.yaml."
-    )
-
-
-def test_documented_snippet_parses_to_expected_permission_shape() -> None:
-    """Tier 2: the operator-paste snippet, when parsed as YAML, matches
-    the permissions loader's expected layout.
-
-    Reads the commented snippet from the example, strips the leading
-    comment markers (``# ``), parses, and asserts the structure. If a
-    future edit changes the indentation / key shape so the parsed YAML
-    no longer carries ``permissions.file.write["*"] == "allow"``, the
-    operator's paste would silently fail at load time.
-    """
-    # The canonical snippet text (= what we expect operators to paste).
-    canonical = textwrap.dedent(
-        """\
-        permissions:
-          file.write:
-            "*": allow
-        """
-    )
-    parsed = yaml.safe_load(canonical)
-
-    assert isinstance(parsed, dict)
-    assert "permissions" in parsed
-    perms = parsed["permissions"]
-    assert isinstance(perms, dict)
-    assert "file.write" in perms
-    fw = perms["file.write"]
-    assert isinstance(fw, dict)
-    assert fw.get("*") == "allow", (
-        f"canonical snippet does not yield permissions.file.write['*']=='allow'; "
-        f"got {fw!r}"
-    )
-
-
-def test_example_carries_canonical_snippet_verbatim() -> None:
-    """Tier 2: the example text includes the canonical snippet verbatim
-    (modulo comment markers + leading indentation).
-
-    Ensures operator copy-paste actually produces the parseable YAML
-    we tested above. We strip the comment-line prefix ``# `` from each
-    line of the documented block and assert the stripped content
-    matches the canonical snippet.
-    """
-    src = _EXAMPLE_PATH.read_text(encoding="utf-8")
-    # Find the documented block: any 4 consecutive lines starting with
-    # ``# permissions:`` / ``#   file.write:`` / ``#     "*": allow`` (or
-    # similar comment shapes). We assert presence of each piece on a
-    # commented line — robust against trailing-blank / spacing tweaks.
-    lines = src.splitlines()
-    commented_perms = any(
-        line.lstrip().startswith("#") and "permissions:" in line for line in lines
-    )
-    commented_file_write = any(
-        line.lstrip().startswith("#") and "file.write" in line for line in lines
-    )
-    commented_allow = any(
-        line.lstrip().startswith("#") and "allow" in line and "*" in line
-        for line in lines
-    )
-    assert commented_perms, "no commented ``permissions:`` line in example"
-    assert commented_file_write, "no commented ``file.write:`` line in example"
-    assert commented_allow, "no commented ``\"*\": allow`` line in example"
+    # The broken nested-glob form must not be presented as a paste-able
+    # snippet line. The WHY prose may mention it inline (= explaining why
+    # it fails), so we only reject the standalone paste form: a comment
+    # line whose content, after stripping the leading '#' and whitespace,
+    # *starts with* the glob mapping key.
+    for line in src.splitlines():
+        stripped = line.lstrip("#").strip()
+        assert not stripped.startswith('"*": allow'), (
+            f"reyn.local.yaml.example shows the nested-glob paste form on a "
+            f"standalone line ({line!r}); _is_config_approved never matches "
+            f"it (= the PR-N11 bug). Use the flat 'file.write: allow' form."
+        )


### PR DESCRIPTION
**[e2e-coder]** — corrects my own PR-N11 (#1051) doc-shape bug. Issue: #1054.

## Why

PR-N11 documented a **wrong** pre-approval shape in `reyn.local.yaml.example`:

```yaml
permissions:
  file.write:
    "*": allow        # ← nested glob — NEVER matched by the loader
```

`PermissionResolver._is_config_approved("file.write")` (permissions.py:513) only returns True for:
- `_config["file.write"] == "allow"` (flat dotted-key string), or
- `_config["file"] == "allow"`, or
- `_config["file"]["write"] == "allow"` (nested-to-string)

A glob dict (`file.write: {"*": allow}`) is never matched → fails closed. A benchmark using the PR-N11 snippet would still hit a `PermissionError` on the first `file.write` op (= sandbox_2 dogfood 13977/13236/14096 regression).

## The deeper bug: false-confidence test

PR-N11's `test_documented_snippet_parses_to_expected_permission_shape` claimed (in its docstring) to verify "the permissions loader's expected layout" — but it only did a YAML round-trip and asserted on the parsed dict. It **never invoked the loader**, so it pinned the wrong shape with false confidence. A format-pin test masquerading as an integration test.

## Fix

1. `reyn.local.yaml.example` → flat `file.write: allow` + WHY doc (config layer is non-glob; glob dict fails closed; path-scoped grants live in a separate startup/saved-approval layer).
2. Tests rewritten to a **real PermissionResolver functional invariant**:
   - `test_flat_config_shape_clears_require_file_write` — `{"file.write": "allow"}` → `require_file_write` on out-of-zone path does NOT raise.
   - `test_nested_glob_shape_does_not_clear_require_file_write` — `{"file.write": {"*": "allow"}}` → `require_file_write` RAISES (pins the regression).
   - `test_nested_to_string_shape_also_clears` — `{"file": {"write": "allow"}}` also clears (documents the accepted alt form).
   - `test_example_documents_flat_file_write_allow` — source-text guard: example shows flat form, no standalone glob paste line.

## Primary evidence

- permissions.py:513 `_is_config_approved` — quoted above.
- permissions.py:28 module docstring: `file.write: allow   # grants all write-class ops for all skills` — the canonical flat form.
- permissions.py:1010 `require_file_write` returns clean when `_is_config_approved("file.write")` is True.

## Test plan

- [x] `pytest -q tests/test_reyn_local_example_benchmark_permissions.py` — 4 passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_reyn_local_example_benchmark_permissions.py` — 4 OK / 0 warnings / 0 errors
- [x] `pytest -q tests/ -k "permission or benchmark"` — 175 passed
- [x] `ruff check .` — All checks passed!

## Scope

- ALLOWED: `reyn.local.yaml.example`, `tests/test_reyn_local_example_benchmark_permissions.py`
- NOT touched: `permissions.py` (mechanism is correct), `eval_benchmark.py` (PR-N9 fix preserved), chat compaction wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)