### PR TITLE
docs(config): fix resolution order — add .reyn/mcp.yaml + .reyn/cron.yaml layers

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -578,12 +578,21 @@ api_base: ${LITELLM_API_BASE}    # または直接書く: http://localhost:4000
 
 ## 解決順序
 
-各設定について、Reyn は（優先度が低い方から）マージします:
+各設定について、Reyn は（優先度が低い方から、後の層が前を上書き）マージします:
 
-1. `~/.reyn/config.yaml`（ユーザーグローバル）
-2. `reyn.yaml`（プロジェクト）
-3. `reyn.local.yaml`（プロジェクト、gitignored）
-4. CLI フラグ
+1. **組み込みデフォルト** — reyn 同梱の値（例: `model: standard`）。
+2. `~/.reyn/config.yaml`（ユーザーグローバル）
+3. `reyn.yaml`（プロジェクト、コミット対象）
+4. `reyn.local.yaml`（プロジェクト、gitignored — マシンローカルの上書き + `reyn config set` が書いた値）
+5. `<project>/.reyn/mcp.yaml`（動的 MCP server レジストリ）— **`mcp.servers` セクションについて最後にマージ**。`reyn mcp install` が追加した server が、`reyn.yaml` / `reyn.local.yaml` で手書きした `mcp.servers` を上書きします。
+6. `<project>/.reyn/cron.yaml`（動的 cron レジストリ）— **`cron.jobs` セクションについて最後にマージ**。ランタイム登録 job が name 衝突時に `reyn.yaml` の `cron.jobs` を上書きします。
+7. CLI フラグ — 最後に、呼び出しごとに適用。
+
+層 5・6 はスコープ付きで、それぞれのセクション（`mcp.servers` / `cron.jobs`）のみを持ち、セクション単位でマージされるため、無関係な設定には触れません。`${VAR}` interpolation は全 YAML 層マージ後に 1 回、CLI フラグの前に適用されます。
+
+> **なぜ `.reyn/mcp.yaml` / `.reyn/cron.yaml` が勝つか**: これらは編集して再起動する静的ファイルと違い、ランタイム可変なレジストリ（`reyn mcp install` やランタイム cron 登録が書く）です。最後に置くことで、新規インストールした server / 登録した job が、operator が `reyn.yaml` も触らずに有効エントリになります。
+
+`<project>/.reyn/config.yaml` はロードされません — これは廃止された汎用 config ファイルであり、上記の現役 `.reyn/mcp.yaml` / `.reyn/cron.yaml` レジストリとは別物です。ディスクに残っている場合、reyn は警告を出してスキップします。内容を `reyn.local.yaml` に移行して削除してください。
 
 ## `cost` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -616,16 +616,21 @@ api_base: ${LITELLM_API_BASE}    # or literal: http://localhost:4000
 
 ## Resolution order
 
-For each setting, reyn merges (lowest priority first):
+For each setting, reyn merges these sources, lowest priority first — later layers override earlier:
 
-1. `~/.reyn/config.yaml` (user-global)
-2. `reyn.yaml` (project, committed)
-3. `reyn.local.yaml` (project, gitignored — human edits + tool writes)
-4. CLI flags
+1. **Built-in defaults** — the values shipped with reyn (e.g. `model: standard`).
+2. `~/.reyn/config.yaml` — user-global.
+3. `reyn.yaml` — project, committed.
+4. `reyn.local.yaml` — project, gitignored (machine-local overrides + values written by `reyn config set`).
+5. `<project>/.reyn/mcp.yaml` — the dynamic MCP server registry. Merged **last for the `mcp.servers` section**, so servers added by `reyn mcp install` override any `mcp.servers` you hand-edit in `reyn.yaml` / `reyn.local.yaml`.
+6. `<project>/.reyn/cron.yaml` — the dynamic cron registry. Merged **last for the `cron.jobs` section**, so jobs registered at runtime override `cron.jobs` in `reyn.yaml` on a name collision.
+7. CLI flags — applied last, per invocation.
 
-**`<project>/.reyn/config.yaml` was removed in ADR-0031.** If that file still exists
-on disk, Reyn emits a deprecation warning and does **not** load it. Move its contents
-to `reyn.local.yaml`, then delete the file.
+Layers 5 and 6 are scoped: each carries only its own section (`mcp.servers` / `cron.jobs`) and is merged section-by-section, so it never touches unrelated settings. `${VAR}` interpolation is applied once after all YAML layers are merged, before CLI flags.
+
+> **Why `.reyn/mcp.yaml` and `.reyn/cron.yaml` win**: these are the runtime-mutable registries (written by `reyn mcp install` and runtime cron registration) rather than the edit-and-restart static files. Putting them last means a freshly installed server or registered job is the effective entry without the operator also having to touch `reyn.yaml`.
+
+`<project>/.reyn/config.yaml` is no longer loaded — it is a deprecated general-config file, not the active `.reyn/mcp.yaml` / `.reyn/cron.yaml` registries above. If it still exists on disk, reyn prints a warning and skips it. Move its contents to `reyn.local.yaml`, then delete it.
 
 ## `cost` block
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary

The documented **Resolution order** in `docs/reference/config/reyn-yaml.md` (+ `.ja.md` mirror) was out of sync with the implementation. It listed only 4 layers and jumped straight from `reyn.local.yaml` to CLI flags — omitting the two dynamic registries that `load_config()` (`src/reyn/config.py:1939-1990`) folds in **after** `reyn.local.yaml`:

- `.reyn/mcp.yaml` (issue #470) — merged **last** for the `mcp.servers` section, so runtime / `reyn mcp install` entries override hand-edited `mcp.servers`.
- `.reyn/cron.yaml` (FP-0041) — merged **last** for the `cron.jobs` section, so runtime-registered jobs override `reyn.yaml` `cron.jobs` on name collision.

Operator-visible consequence the old doc hid: an `mcp.servers` entry you put in `reyn.local.yaml` **loses** to `.reyn/mcp.yaml` — a real precedence surprise.

## Changes

- Rewrite the resolution-order list to the actual **7 layers**: built-in defaults → `~/.reyn/config.yaml` → `reyn.yaml` → `reyn.local.yaml` → `.reyn/mcp.yaml` → `.reyn/cron.yaml` → CLI flags, each annotated with its override scope.
- Note that layers 5/6 are **scoped** dynamic registries (only their own section, via `_merge`'s section-aware union), and that `${VAR}` interpolation runs once after all YAML layers and before CLI flags.
- Clarify the ADR-0031 note: it removed the deprecated `.reyn/config.yaml` *general config* file — NOT the active `.reyn/mcp.yaml` / `.reyn/cron.yaml` registries in the same directory (the old phrasing blurred this).
- `.ja.md` mirror gets the same fix + the ADR-0031 note it was previously missing.

## Why now

User spotted it: `config reference ドキュメント見てるんだけど、resolution order が実装と乖離してない?` — verification against `load_config()` confirmed the 2 missing dynamic-registry layers.

Note: this is NOT covered by the `reyn config fields` framework follow-up (#1056) — resolution order is the `load_config()` merge logic, not derivable from the `ReynConfig` dataclass, so it's a standalone doc-accuracy fix.

## Test plan

- [x] Cross-checked the 7-layer order + "merged LAST" override semantics against the `_merge` call sequence in `load_config()` and the section-aware union for `mcp` / `cron` in `_merge()`
- [x] Both EN + JA mirrors list the identical 7 layers
- [ ] (skipped — documentation-only, no executable code) `mkdocs build`

## Tier self-check

Documentation-only PR; no test files touched. No new tests added.

## References

- Implementation: `src/reyn/config.py` `load_config()` (`:1943-1976` merge sequence) + `_merge()` (`:1727-1793` section-aware union for `mcp` / `cron`)
- Sibling docs syncs: #1053 (reyn-yaml.md schema) / #1049 (example) / #1047 (chainlit)
- Related: #1056 (config-fields framework follow-up — separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)