### PR TITLE
fix(fp-0008): PR-N13 — JSON raw_decode trailing-garbage hardening (shared helper)

### DIFF
--- a/src/reyn/llm/json_parse.py
+++ b/src/reyn/llm/json_parse.py
@@ -1,0 +1,57 @@
+"""Lenient JSON parsing for LLM output — strict -> repair -> raw_decode tiers."""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Callable
+
+_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+
+
+def _repair_trailing_commas(text: str) -> str:
+    """Remove trailing commas — the most common LLM JSON mistake."""
+    return _TRAILING_COMMA_RE.sub(r"\1", text)
+
+
+def loads_lenient(
+    text: str,
+    *,
+    on_raw_decode: Callable[[int, str], None] | None = None,
+) -> Any:
+    """Parse LLM-emitted JSON with escalating leniency.
+
+    Tier 1: strict json.loads.
+    Tier 2: trailing-comma repair, then json.loads.
+    Tier 3: json.JSONDecoder().raw_decode() — extracts the leading
+            complete JSON value and discards trailing garbage (the
+            13977 failure: a valid object followed by extra data).
+
+    ``on_raw_decode(discarded_len, head)`` is invoked when Tier 3 fires
+    (= observability; never silent-recover). ``discarded_len`` is the
+    byte length of the discarded trailing portion; ``head`` is the first
+    ~80 chars of the discarded portion for log context.
+
+    Raises json.JSONDecodeError when even Tier 3 cannot extract a
+    leading value (= genuinely malformed from the first char).
+    """
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    try:
+        return json.loads(_repair_trailing_commas(text))
+    except json.JSONDecodeError:
+        pass
+
+    # Tier 3: raw_decode the leading value, discard trailing garbage.
+    # raw_decode requires the value to start at index 0, so strip leading
+    # whitespace (json.loads already handles this for tiers 1 and 2).
+    stripped = text.lstrip()
+    obj, end = json.JSONDecoder().raw_decode(stripped)
+    # raw_decode raises JSONDecodeError itself if the leading value is
+    # malformed — that propagates, preserving the "genuinely malformed" contract.
+    discarded = stripped[end:]
+    if on_raw_decode is not None and discarded.strip():
+        on_raw_decode(len(discarded), discarded[:80])
+    return obj

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -13,6 +13,7 @@ import httpx
 import litellm
 
 logger = logging.getLogger(__name__)
+from reyn.llm.json_parse import loads_lenient
 from reyn.llm.model_resolver import ModelSpec
 from reyn.llm.pricing import TokenUsage
 from reyn.schemas.models import ContextFrame
@@ -647,11 +648,6 @@ def _extract_json(text: str) -> str:
     return stripped
 
 
-def _repair_json(text: str) -> str:
-    """Remove trailing commas — the most common LLM JSON mistake."""
-    return re.sub(r",(\s*[}\]])", r"\1", text)
-
-
 def _extract_usage(response) -> TokenUsage | None:
     """Extract token usage from a litellm response object."""
     try:
@@ -871,16 +867,18 @@ async def call_llm(
 
         parsed: dict | None = None
         try:
-            parsed = json.loads(text)
-        except json.JSONDecodeError:
-            pass
-
-        if parsed is None:
-            try:
-                parsed = json.loads(_repair_json(text))
-            except json.JSONDecodeError as exc:
-                last_exc = exc
-                continue  # retry
+            parsed = loads_lenient(
+                text,
+                on_raw_decode=lambda discarded_len, head: logger.warning(
+                    "llm_json_raw_decode_recovered: discarded %d bytes of trailing "
+                    "garbage after valid JSON object. head=%r",
+                    discarded_len,
+                    head,
+                ),
+            )
+        except json.JSONDecodeError as exc:
+            last_exc = exc
+            continue  # retry
 
         # Dump response before returning
         finish_reason: str | None = None

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -54,6 +54,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import litellm
+
 from reyn.llm.json_parse import loads_lenient
 
 if TYPE_CHECKING:

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -54,6 +54,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import litellm
+from reyn.llm.json_parse import loads_lenient
 
 if TYPE_CHECKING:
     from reyn.chat.services.token_multiplier_learner import TokenMultiplierLearner
@@ -772,14 +773,15 @@ class CompactionEngine:
         if not raw:
             raise ValueError("compaction LLM returned empty response")
 
-        parsed: dict = {}
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError:
-            # Attempt JSON repair (remove trailing commas — most common LLM mistake).
-            import re
-            repaired = re.sub(r",(\s*[}\]])", r"\1", raw)
-            parsed = json.loads(repaired)
+        parsed: dict = loads_lenient(
+            raw,
+            on_raw_decode=lambda discarded_len, head: logger.warning(
+                "compaction_json_raw_decode_recovered: discarded %d bytes of "
+                "trailing garbage after valid JSON object. head=%r",
+                discarded_len,
+                head,
+            ),
+        )
 
         new_turn_seqs = parsed.get("new_turn_seqs") or []
         covers = compute_covers_through_seq(new_turn_seqs)

--- a/tests/test_llm_json_loads_lenient.py
+++ b/tests/test_llm_json_loads_lenient.py
@@ -1,0 +1,148 @@
+"""Tests for the shared lenient JSON parsing helper (reyn.llm.json_parse)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.llm.json_parse import loads_lenient
+
+
+class TestStrictPassThrough:
+    def test_clean_object_returns_same_as_json_loads(self):
+        """Tier 2: clean JSON object parses identically to json.loads (Tier 1 path)."""
+        text = '{"a": 1, "b": "hello", "c": [1, 2, 3]}'
+        result = loads_lenient(text)
+        assert result == json.loads(text)
+
+    def test_nested_object(self):
+        """Tier 2: nested JSON structure parses correctly via strict path."""
+        text = '{"outer": {"inner": true}, "list": [null, false, 42]}'
+        result = loads_lenient(text)
+        assert result == json.loads(text)
+
+    def test_strict_path_does_not_fire_callback(self):
+        """Tier 2: on_raw_decode callback is NOT called for clean JSON (Tier 1 path)."""
+        calls: list[tuple[int, str]] = []
+        loads_lenient('{"x": 1}', on_raw_decode=lambda n, h: calls.append((n, h)))
+        assert calls == []
+
+
+class TestTrailingCommaRepair:
+    def test_trailing_comma_object_recovers(self):
+        """Tier 2: trailing comma in object is repaired by Tier 2 path."""
+        result = loads_lenient('{"a": 1,}')
+        assert result == {"a": 1}
+
+    def test_trailing_comma_array_recovers(self):
+        """Tier 2: trailing comma in array is repaired by Tier 2 path."""
+        result = loads_lenient('[1, 2, 3,]')
+        assert result == [1, 2, 3]
+
+    def test_trailing_comma_does_not_fire_callback(self):
+        """Tier 2: on_raw_decode callback is NOT called for trailing-comma repair (Tier 2 path)."""
+        calls: list[tuple[int, str]] = []
+        loads_lenient('{"a": 1,}', on_raw_decode=lambda n, h: calls.append((n, h)))
+        assert calls == []
+
+
+class TestTrailingGarbageRecover:
+    def test_trailing_text_recovers_leading_object(self):
+        """Tier 2: valid JSON object followed by trailing text is recovered via Tier 3 raw_decode."""
+        text = '{"a": 1}\n\nsome explanation text'
+        result = loads_lenient(text)
+        assert result == {"a": 1}
+
+    def test_trailing_text_fires_callback(self):
+        """Tier 2: on_raw_decode callback fires with positive discarded_len for trailing garbage."""
+        calls: list[tuple[int, str]] = []
+        text = '{"a": 1}\n\nsome explanation text'
+        result = loads_lenient(text, on_raw_decode=lambda n, h: calls.append((n, h)))
+        assert result == {"a": 1}
+        assert calls, "on_raw_decode must be called for trailing garbage"
+        discarded_len, head = calls[-1]
+        assert discarded_len > 0
+        assert "some explanation text" in head
+
+    def test_13977_style_large_trailing_garbage(self):
+        """Tier 2: large valid JSON + trailing garbage (the 13977 failure pattern) recovers."""
+        payload = {"control": {"type": "finish"}, "artifact": {"type": "x", "data": {}}}
+        trailing = " extra content after the json object"
+        text = json.dumps(payload) + trailing
+        result = loads_lenient(text)
+        assert result == payload
+
+    def test_trailing_garbage_callback_head_capped_at_80(self):
+        """Tier 2: on_raw_decode head argument is capped at 80 chars (not the full trailing string)."""
+        calls: list[tuple[int, str]] = []
+        long_garbage = "x" * 200
+        text = '{"a": 1}' + long_garbage
+        loads_lenient(text, on_raw_decode=lambda n, h: calls.append((n, h)))
+        assert calls, "on_raw_decode must be called for trailing garbage"
+        _, head = calls[-1]
+        # head is capped at 80; the raw trailing is 200 chars, so head < trailing
+        assert len(head) < len(long_garbage)
+
+
+class TestTrailingWhitespaceNotFlagged:
+    def test_trailing_whitespace_only_no_callback(self):
+        """Tier 2: trailing whitespace after valid JSON does NOT fire the on_raw_decode callback."""
+        calls: list[tuple[int, str]] = []
+        text = '{"a": 1}\n  '
+        result = loads_lenient(text, on_raw_decode=lambda n, h: calls.append((n, h)))
+        assert result == {"a": 1}
+        assert calls == [], "callback should not fire for whitespace-only trailing data"
+
+    def test_trailing_newline_only_no_callback(self):
+        """Tier 2: trailing newline after valid JSON does NOT fire the on_raw_decode callback."""
+        calls: list[tuple[int, str]] = []
+        text = '{"a": 1}\n'
+        result = loads_lenient(text, on_raw_decode=lambda n, h: calls.append((n, h)))
+        assert result == {"a": 1}
+        assert calls == []
+
+
+class TestGenuinelyMalformedRaises:
+    def test_not_json_raises(self):
+        """Tier 2: 'not json at all' raises json.JSONDecodeError (not recovered)."""
+        with pytest.raises(json.JSONDecodeError):
+            loads_lenient("not json at all")
+
+    def test_leading_garbage_before_json_raises(self):
+        """Tier 2: garbage before valid JSON ('garbage {...}') raises json.JSONDecodeError."""
+        with pytest.raises(json.JSONDecodeError):
+            loads_lenient('garbage {"a": 1}')
+
+    def test_empty_string_raises(self):
+        """Tier 2: empty string raises json.JSONDecodeError."""
+        with pytest.raises(json.JSONDecodeError):
+            loads_lenient("")
+
+    def test_unclosed_object_raises(self):
+        """Tier 2: genuinely unclosed JSON object raises json.JSONDecodeError."""
+        with pytest.raises(json.JSONDecodeError):
+            loads_lenient('{"a": 1')
+
+
+class TestObservabilityOnlyOnTier3:
+    def test_callback_not_called_for_tier1(self):
+        """Tier 2: callback is never called when Tier 1 (strict) succeeds."""
+        calls: list = []
+        loads_lenient('{"ok": true}', on_raw_decode=lambda n, h: calls.append(n))
+        assert calls == []
+
+    def test_callback_not_called_for_tier2(self):
+        """Tier 2: callback is never called when Tier 2 (repair) succeeds."""
+        calls: list = []
+        loads_lenient('[1,]', on_raw_decode=lambda n, h: calls.append(n))
+        assert calls == []
+
+    def test_callback_called_for_tier3(self):
+        """Tier 2: callback IS called when Tier 3 (raw_decode) fires."""
+        calls: list = []
+        loads_lenient(
+            '{"a": 1} trailing',
+            on_raw_decode=lambda n, h: calls.append(n),
+        )
+        assert calls, "on_raw_decode must be called for trailing garbage"
+        assert all(n > 0 for n in calls)


### PR DESCRIPTION
**[e2e-coder]** — OS-side structural fix for the 13977 "Extra data: char 11353" parse failure. Root cause: valid JSON object followed by trailing garbage was unrecoverable by the existing `_repair_json` (trailing-comma only). Fix: add `raw_decode` as Tier 3 fallback in a shared helper used by both parse sites.

## Why (primary evidence)

`json.loads` error "Extra data: char 11353" means bytes 0-11352 contain a complete valid JSON object, followed by non-whitespace trailing data. `_repair_json` handles trailing commas only — not trailing garbage. `json.JSONDecoder().raw_decode(text)` returns `(obj, end_index)` and ignores everything after `end_index`, recovering the leading object.

## Changes

### New: `src/reyn/llm/json_parse.py` (shared helper, leaf module)

Three-tier escalation in `loads_lenient(text, *, on_raw_decode=None)`:
- **Tier 1**: `json.loads(text)` — strict
- **Tier 2**: trailing-comma repair (`re.sub`), then `json.loads` — preserves existing `_repair_json` behavior
- **Tier 3**: `json.JSONDecoder().raw_decode(text.lstrip())` — extracts leading complete JSON value, discards trailing garbage

No-circular-import confirmed: `json_parse.py` imports only stdlib (`json`, `re`, `typing`). `engine.py` already imports from `reyn.llm.*` at call sites (lazy local imports), so adding `reyn.llm.json_parse` as a module-level import introduces no new import cycle.

### Site 1: `src/reyn/llm/llm.py`

Replace the `json.loads(text)` → `json.loads(_repair_json(text))` → `continue` block with `loads_lenient(...)`. On Tier 3 fires: `logger.warning("llm_json_raw_decode_recovered: ...")`. Removed `_repair_json` — confirmed 0 callers after wiring (grep evidence below).

### Site 2: `src/reyn/services/compaction/engine.py`

Replace inline `json.loads(raw)` → `re.sub(...)` → `json.loads(repaired)` block with `loads_lenient(...)`. On Tier 3 fires: `logger.warning("compaction_json_raw_decode_recovered: ...")`. This removes the duplicated inline repair logic.

### Schema validation unchanged

`loads_lenient` operates at the JSON-syntax layer only. The extracted object flows through the exact same downstream artifact/control schema validation as before. P1-P8 contract is unaffected.

## Existing-mechanism grep evidence (`feedback_existing_mechanism_grep_before_new_fix`)

```
# Before:
grep -rn "raw_decode|JSONDecoder" src/reyn/  → 0 hits (new mechanism, no duplication)
grep -rn "_repair_json" src/reyn/             → 1 hit (definition only in llm.py)
grep -rn "_loads_lenient|loads_lenient|json_parse" src/reyn/  → 0 hits (name is free)
grep -rn "from reyn.llm" src/reyn/services/compaction/engine.py → 3 local import sites (all safe)

# After:
grep -rn "raw_decode|JSONDecoder" src/reyn/  → hits in json_parse.py + caller lambdas only (helper-only)
grep -rn "_repair_json" src/reyn/             → 0 hits (removed)
```

## Observability

Both sites emit `logger.warning` with discarded byte count + first 80 chars of trailing data when Tier 3 fires. Silent recovery is not possible.

## Tests

`tests/test_llm_json_loads_lenient.py` — 19 Tier-2 tests:
- Strict pass-through (Tier 1 path, callback not fired)
- Trailing-comma repair (Tier 2 path, callback not fired)
- Trailing-garbage recovery — the 13977 case (Tier 3 path, callback fires)
- Large payload + trailing garbage (13977-style)
- Trailing whitespace-only: NOT flagged (callback not fired)
- Leading-garbage / genuinely malformed: raises `json.JSONDecodeError`
- Observability fires ONLY on Tier 3

No `MagicMock`/`AsyncMock`/`patch`. Real `loads_lenient` + real closures.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_json_loads_lenient.py` — 0 errors (19/19 OK)
- [x] `pytest -q tests/` — 6270 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`), 5 skipped, 3 xfailed
- [x] `grep -rn "raw_decode|JSONDecoder" src/reyn/` — helper-only after change (0 before)
- [x] No schema validation code touched
- [x] No skill/phase `.md` files touched

Refs #1057