### PR TITLE
fix(fp-0008): PR-N15 — test_patch deterministic workspace passthrough (C2)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/artifacts/apply_state.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/apply_state.yaml
@@ -15,11 +15,7 @@ schema:
       type: integer
       minimum: 1
       description: Which attempt number this is (matches the plan.attempt that was executed).
-    test_patch:
-      type: string
-      description: The test_patch string from the input, carried forward so verify can apply it.
   required:
     - instance_id
     - files_edited
     - attempt
-    - test_patch

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -37,8 +37,7 @@ For non-Python files, skip this step.
 
 ## Step 4 — Record what was changed
 
-Collect the repository-relative paths of all files that were modified.  Carry
-`test_patch` from the input so the verify phase can access it.
+Collect the repository-relative paths of all files that were modified.
 
 ## When to transition
 

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -8,11 +8,32 @@ allowed_ops: [file, shell]
 max_retries: 3
 max_act_turns: 30
 preprocessor:
-  # FP-0008 PR-O v8: deterministic test_patch sanitizer normalizes
-  # line endings (CRLF → LF), strips BOM, ensures trailing newline.
-  # Runs BEFORE the LLM enters this phase. The sanitized string is
-  # written into `data.test_patch`, replacing the LLM-visible field
-  # so `git apply` operates on a clean diff.
+  # FP-0008 PR-N15 Step 1: deterministic workspace passthrough — read the
+  # original swe_bench_input artifact from the workspace (stored at skill
+  # start by the OS as the `_input` artifact). This is the P5-correct
+  # source of truth for test_patch — it never passes through the apply
+  # LLM, so it can never be dropped or nulled by a weak model.
+  #
+  # The file path `.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`
+  # is deterministic: the OS always stores the entry-phase artifact at
+  # `{state_dir}/artifacts/{skill_name}/{_input}/v01_{artifact_type}.json`.
+  #
+  # on_error: empty — if the workspace file is absent (e.g. in unit tests
+  # that inject verify input directly), the python step falls back to
+  # reading data.test_patch from the artifact directly (see Step 2).
+  - type: run_op
+    op:
+      kind: file
+      op: read
+      path: ".reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json"
+    into: data._input_raw
+    on_error: empty
+  # FP-0008 PR-N15 Step 2 / PR-O v8: sanitize_test_patch reads test_patch
+  # from data._input_raw.content (workspace JSON) and falls back to
+  # data.test_patch (direct injection for tests). Normalizes line endings
+  # (CRLF → LF), strips BOM, ensures trailing newline. Runs BEFORE the
+  # LLM enters this phase. The sanitized string is written into
+  # `data.test_patch` so `git apply` operates on a clean diff.
   - type: python
     module: ./sanitize_test_patch.py
     function: sanitize_test_patch

--- a/src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py
+++ b/src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py
@@ -1,25 +1,48 @@
 """Deterministic test_patch sanitization for swe_bench verify phase.
 
-FP-0008 PR-O v8 (= sandbox_2 v8 calibration retry 2026-05-28 root
-cause): SWE-bench input ``data.test_patch`` may carry artifacts from
-upstream collection / serialization that cause ``git apply`` to
-reject the patch:
+FP-0008 PR-N15 (= workspace passthrough) + PR-O v8 (= line-ending / BOM /
+trailing-newline normalization).
 
-- **Line endings**: CRLF in patch content while target files have
-  LF (or vice versa) — the diff context lines don't byte-match.
-- **BOM**: a UTF-8 BOM at the start of the patch string makes the
-  first diff header unparseable.
-- **Trailing-newline drift**: missing final newline causes some git
-  versions to reject the last hunk.
+## Workspace-passthrough design (PR-N15)
 
-This module is a ``safe``-mode Python preprocessor step that runs
-BEFORE the LLM enters the verify phase. The verify-phase
-preprocessor writes the return value into ``data.test_patch`` via
-``into:``, replacing the LLM-visible field with the deterministically-
-normalized version.
+The verify phase preprocessor runs this function AFTER a ``run_op: file.read``
+step that reads the original ``swe_bench_input`` artifact from the workspace:
 
-Sanitization is conservative + idempotent: valid diffs pass through
-unchanged; only the specific artifact patterns above are normalized.
+    ``.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json``
+
+The read result lands at ``data._input_raw`` (inside the full artifact dict)
+as::
+
+    {"status": "ok", "content": "<JSON string>", ...}
+
+This function reads ``test_patch`` from that JSON string, parses it, and
+sanitizes it.  The apply-phase LLM no longer echoes ``test_patch`` — the
+workspace file is the deterministic source (P5: Workspace is the single
+source of truth).
+
+## Fallback
+
+When ``data._input_raw`` is absent or its ``content`` is not valid JSON (e.g.
+in unit tests that inject the verify phase input directly), the function
+falls back to reading ``test_patch`` from the artifact in two structural
+shapes:
+
+- **Full artifact** (runtime shape):
+  ``{"type": "...", "data": {"test_patch": "..."}}``
+- **Flat dict** (unit-test direct-call shape):
+  ``{"test_patch": "..."}``
+
+## Sanitization steps (PR-O v8)
+
+All steps are conservative and idempotent — valid diffs pass through unchanged:
+
+1. Remove UTF-8 BOM if present at the start.
+2. Normalize line endings to LF (= strip CR characters).
+3. Ensure the patch ends with a single trailing newline.
+
+Returns the sanitized string.  When all sources are absent/non-string,
+returns an empty string (the verify-phase instruction handles the empty case
+explicitly).
 
 Author judgment per [[feedback_root_cause_until_structural_fix]]:
 deterministic preprocessor > LLM-driven prompt-side normalization
@@ -28,23 +51,62 @@ mistakes; OS preprocessor is structurally sound).
 """
 from __future__ import annotations
 
+import json
 from typing import Any, Mapping
 
 
 def sanitize_test_patch(data: Mapping[str, Any]) -> str:
-    """Return a normalized ``data.test_patch`` string.
+    """Return a normalized ``test_patch`` string.
 
-    Steps (all idempotent):
+    Source priority (P5 workspace passthrough):
+      1. ``data._input_raw.content`` (via artifact's data dict) — JSON of the
+         original swe_bench_input artifact, injected by the preceding
+         ``run_op: file.read`` step.  Parsed to extract ``test_patch`` from
+         the artifact's ``data`` field.
+      2. ``data.test_patch`` from the artifact's ``data`` dict (full runtime
+         artifact shape: ``{"type": "...", "data": {"test_patch": "..."}}``)
+      3. Top-level ``test_patch`` on the passed-in dict (flat unit-test shape:
+         ``{"test_patch": "..."}``)
+
+    Sanitization steps (all idempotent):
       1. Remove UTF-8 BOM if present at the start.
       2. Normalize line endings to LF (= strip CR characters).
       3. Ensure the patch ends with a single trailing newline.
 
-    Returns the sanitized string. When ``test_patch`` is absent or
-    non-string, returns an empty string (= the preprocessor ``into:``
-    target lands as empty; ``verify.md``'s instruction handles the
-    empty case explicitly).
+    Returns the sanitized string. When all sources are absent or non-string,
+    returns an empty string (= the preprocessor ``into:`` target lands as
+    empty; ``verify.md``'s instruction handles the empty case explicitly).
     """
-    raw = data.get("test_patch")
+    raw: Any = None
+
+    # Extract the inner data dict from the full artifact (runtime shape).
+    inner_data: Any = data.get("data") or {}
+
+    # Priority 1: workspace passthrough — run_op file.read result
+    # The preceding run_op step reads the workspace _input artifact and places
+    # its result at data._input_raw. The result shape is:
+    # {"status": "ok", "content": "<JSON of swe_bench_input artifact>", ...}
+    input_raw = inner_data.get("_input_raw") if isinstance(inner_data, dict) else None
+    if isinstance(input_raw, dict):
+        content = input_raw.get("content")
+        if isinstance(content, str) and content.strip():
+            try:
+                parsed = json.loads(content)
+                # Workspace file is the full artifact:
+                # {"type": "swe_bench_input", "data": {"test_patch": ...}}
+                raw = (parsed.get("data") or {}).get("test_patch")
+            except (json.JSONDecodeError, AttributeError):
+                pass
+
+    # Priority 2: data.test_patch from inner data dict (runtime artifact shape)
+    if not isinstance(raw, str) or not raw:
+        if isinstance(inner_data, dict):
+            raw = inner_data.get("test_patch")
+
+    # Priority 3: top-level test_patch (flat unit-test direct-call shape)
+    if not isinstance(raw, str) or not raw:
+        raw = data.get("test_patch")
+
     if not isinstance(raw, str) or not raw:
         return ""
 

--- a/tests/test_swe_bench_pr_n15_workspace_passthrough.py
+++ b/tests/test_swe_bench_pr_n15_workspace_passthrough.py
@@ -1,0 +1,345 @@
+"""Tier 2: FP-0008 PR-N15 — test_patch deterministic workspace passthrough.
+
+Root cause: `apply.md` instructed the apply-phase LLM to echo `test_patch`
+verbatim from the plan input into the `apply_state` output artifact.  Weak
+models (gemini-flash-lite) dropped or nulled the field, causing schema
+validation failure at the verify-phase entry.
+
+Fix shape (PR-N15):
+  - `test_patch` removed from `apply_state` schema (no more LLM echo).
+  - `apply.md` "Carry test_patch" instruction removed.
+  - `verify.md` preprocessor gains a `run_op: file.read` step that reads
+    the workspace-stored ``_input`` artifact (= the original swe_bench_input)
+    before the python sanitizer step.
+  - `sanitize_test_patch.py` updated to read from the workspace-injected
+    ``data._input_raw.content`` (Priority 1), falling back to
+    ``data.test_patch`` in the artifact's data dict (Priority 2) or top-level
+    flat dict (Priority 3, unit-test compat).
+
+This file pins:
+  (a) `apply_state` schema does NOT include `test_patch` as a required field.
+  (b) `apply.md` does NOT contain the "Carry test_patch" instruction.
+  (c) `verify.md` preprocessor contains a `run_op` step before the python
+      step that reads the workspace input file.
+  (d) `sanitize_test_patch` extracts test_patch from the workspace-injected
+      ``_input_raw.content`` payload (Priority 1 path = the fix for 13977).
+  (e) `sanitize_test_patch` handles the full runtime artifact shape
+      ``{"type": "apply_state", "data": {"test_patch": "..."}}`` correctly
+      (Priority 2 path).
+  (f) `sanitize_test_patch` returns empty string when workspace payload is
+      absent and test_patch is missing (existing behavior preserved).
+  (g) Regression guard: LLM-null test_patch in artifact + workspace content
+      present → workspace value wins (= the 13977 failure mode is fixed).
+
+Tier rule discipline: every test docstring opens with Tier 2; no mocks; no
+private-state assertions; no format-pinning.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+# ── (a) apply_state schema: test_patch not in required ───────────────────────
+
+
+def test_apply_state_schema_no_test_patch_required() -> None:
+    """Tier 2: apply_state.yaml must not require test_patch.
+
+    PR-N15 removes test_patch from apply_state so the apply-phase LLM
+    is never asked to echo the large diff string.  A weak model that
+    cannot faithfully copy test_patch will no longer cause a schema
+    validation failure.
+    """
+    raw = (_SKILL_ROOT / "artifacts" / "apply_state.yaml").read_text(encoding="utf-8")
+    doc = yaml.safe_load(raw)
+    required = doc.get("schema", {}).get("required", [])
+    assert "test_patch" not in required, (
+        "apply_state.schema.required must not include 'test_patch' after PR-N15. "
+        f"Actual required: {required}"
+    )
+
+
+def test_apply_state_schema_no_test_patch_property() -> None:
+    """Tier 2: apply_state.yaml must not define a test_patch property.
+
+    Removes the field entirely so the LLM is not tempted to fill it
+    (a defined-but-not-required field still leaks through the LLM prompt).
+    """
+    raw = (_SKILL_ROOT / "artifacts" / "apply_state.yaml").read_text(encoding="utf-8")
+    doc = yaml.safe_load(raw)
+    properties = doc.get("schema", {}).get("properties", {})
+    assert "test_patch" not in properties, (
+        "apply_state.schema.properties must not include 'test_patch' after PR-N15. "
+        f"Actual properties: {sorted(properties.keys())}"
+    )
+
+
+# ── (b) apply.md: no "Carry test_patch" instruction ──────────────────────────
+
+
+def test_apply_md_no_carry_test_patch_instruction() -> None:
+    """Tier 2: apply.md must not contain the 'Carry test_patch' instruction.
+
+    PR-N15 removes the line that asked the LLM to echo test_patch so
+    the apply phase has no knowledge of test_patch propagation.
+    """
+    apply_md = (_SKILL_ROOT / "phases" / "apply.md").read_text(encoding="utf-8")
+    # The old instruction contained the words "Carry" and "test_patch"
+    # together.  Both must no longer co-occur.
+    assert "Carry" not in apply_md or "test_patch" not in apply_md or (
+        "Carry" not in apply_md and "test_patch" not in apply_md
+    ), (
+        "apply.md must not contain 'Carry ... test_patch' instruction after PR-N15"
+    )
+    # Stronger check: the specific instruction phrase must be absent
+    assert "Carry `test_patch`" not in apply_md, (
+        "apply.md still contains the old 'Carry `test_patch`' instruction — "
+        "this must be removed in PR-N15"
+    )
+
+
+# ── (c) verify.md preprocessor: run_op step reads workspace input ────────────
+
+
+def test_verify_md_preprocessor_has_run_op_before_python() -> None:
+    """Tier 2: verify.md preprocessor must contain a run_op step before python.
+
+    PR-N15 adds a run_op: file.read step as the FIRST preprocessor step to
+    read the workspace _input artifact.  This must appear BEFORE the python
+    sanitizer step so the sanitizer can consume it.
+    """
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    run_op_pos = verify_md.find("type: run_op")
+    python_pos = verify_md.find("type: python")
+    assert run_op_pos != -1, (
+        "verify.md preprocessor must contain a 'type: run_op' step after PR-N15"
+    )
+    assert python_pos != -1, (
+        "verify.md preprocessor must still contain a 'type: python' step"
+    )
+    assert run_op_pos < python_pos, (
+        "The run_op step must appear BEFORE the python step in verify.md "
+        "so the workspace _input is injected before sanitize_test_patch runs"
+    )
+
+
+def test_verify_md_preprocessor_reads_workspace_input_file() -> None:
+    """Tier 2: verify.md run_op step must target the workspace _input artifact.
+
+    The workspace-stored path for the swe_bench entry-phase input is
+    deterministic: `.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`.
+    PR-N15 pins this path in the run_op so test_patch is always read from
+    the workspace rather than being LLM-echoed.
+    """
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    assert "swe_bench/_input/v01_swe_bench_input.json" in verify_md, (
+        "verify.md must reference the workspace _input artifact path "
+        "'.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json' in the "
+        "run_op preprocessor step"
+    )
+
+
+def test_verify_md_run_op_injects_into_input_raw() -> None:
+    """Tier 2: verify.md run_op step must inject result into data._input_raw.
+
+    The sanitize_test_patch function reads from data._input_raw.content
+    (Priority 1).  The run_op's into: field must target data._input_raw.
+    """
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    assert "into: data._input_raw" in verify_md, (
+        "verify.md run_op step must use 'into: data._input_raw' so the "
+        "sanitize_test_patch function can read the workspace artifact content"
+    )
+
+
+# ── (d) sanitizer: Priority 1 — workspace _input_raw path ───────────────────
+
+
+def _make_workspace_artifact(test_patch: str) -> dict:
+    """Build the full artifact dict as the preprocessor sees it after run_op.
+
+    The run_op step injects the workspace file read result at data._input_raw.
+    The read result shape is {"status": "ok", "content": "<JSON>", ...}.
+    The JSON is the full swe_bench_input artifact.
+    """
+    swe_bench_input_artifact = {
+        "type": "swe_bench_input",
+        "data": {
+            "instance_id": "test__test-1",
+            "repo": "test/test",
+            "base_commit": "abc123",
+            "problem_statement": "Fix a bug",
+            "test_patch": test_patch,
+        },
+    }
+    return {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test__test-1",
+            "files_edited": ["foo.py"],
+            "attempt": 1,
+            "_input_raw": {
+                "status": "ok",
+                "content": json.dumps(swe_bench_input_artifact),
+            },
+        },
+    }
+
+
+def test_sanitizer_reads_from_workspace_input_raw() -> None:
+    """Tier 2: sanitizer extracts test_patch from data._input_raw.content.
+
+    This is the PR-N15 primary fix path (Priority 1).  When the run_op
+    step has injected _input_raw.content with the workspace JSON, the
+    sanitizer reads test_patch from there — not from the apply LLM output.
+    """
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    patch_str = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    artifact = _make_workspace_artifact(patch_str)
+    result = sanitize_test_patch(artifact)
+    assert result == patch_str, (
+        f"Sanitizer must read test_patch from data._input_raw.content. "
+        f"Expected: {patch_str!r}, got: {result!r}"
+    )
+
+
+def test_sanitizer_workspace_path_normalizes_crlf() -> None:
+    """Tier 2: sanitizer normalizes CRLF in test_patch from workspace source."""
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    raw = "diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@\r\n-a\r\n+b\r\n"
+    artifact = _make_workspace_artifact(raw)
+    result = sanitize_test_patch(artifact)
+    assert "\r" not in result, (
+        "CRLF normalization must apply even when reading from workspace source"
+    )
+
+
+# ── (e) sanitizer: Priority 2 — full runtime artifact shape ─────────────────
+
+
+def test_sanitizer_reads_from_full_artifact_data_dict() -> None:
+    """Tier 2: sanitizer reads test_patch from artifact['data']['test_patch'].
+
+    Priority 2 path: when _input_raw is absent but test_patch is present
+    in the artifact's inner data dict (full runtime artifact shape).  This
+    was the broken path before PR-N15 — the old code did data.get('test_patch')
+    where data was the FULL artifact dict, looking at the wrong level.
+    """
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    patch_str = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    # Full artifact shape without _input_raw — must still work via fallback
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test__test-1",
+            "files_edited": ["foo.py"],
+            "attempt": 1,
+            "test_patch": patch_str,
+        },
+    }
+    result = sanitize_test_patch(artifact)
+    assert result == patch_str, (
+        f"Sanitizer must read test_patch from artifact['data']['test_patch']. "
+        f"Expected: {patch_str!r}, got: {result!r}"
+    )
+
+
+# ── (f) sanitizer: empty when all sources absent ─────────────────────────────
+
+
+def test_sanitizer_empty_when_no_sources() -> None:
+    """Tier 2: sanitizer returns empty string when all test_patch sources absent.
+
+    Both _input_raw and test_patch missing → empty string (verify phase
+    instruction handles this case explicitly).
+    """
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test__test-1",
+            "files_edited": ["foo.py"],
+            "attempt": 1,
+        },
+    }
+    assert sanitize_test_patch(artifact) == ""
+
+
+def test_sanitizer_empty_when_workspace_content_invalid_json() -> None:
+    """Tier 2: sanitizer returns empty string when _input_raw.content is not JSON.
+
+    on_error: empty in the run_op step can produce _input_raw=None or
+    an empty content field.  The sanitizer must not raise in these cases.
+    """
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test__test-1",
+            "files_edited": [],
+            "attempt": 1,
+            "_input_raw": {"status": "error", "content": "NOT JSON {{{"},
+        },
+    }
+    # Should not raise; falls through to missing test_patch → empty string
+    result = sanitize_test_patch(artifact)
+    assert result == ""
+
+
+# ── (g) regression: LLM-null + workspace present → workspace wins ────────────
+
+
+def test_sanitizer_workspace_wins_over_null_artifact_test_patch() -> None:
+    """Tier 2: regression guard for 13977 failure mode.
+
+    The original bug: apply LLM emitted test_patch=null → schema fail.
+    After PR-N15, apply_state no longer has test_patch at all, and the
+    verify preprocessor injects test_patch from the workspace.
+
+    This test simulates the scenario where _input_raw is present (from
+    workspace passthrough) and test_patch in the inner data is absent/null
+    (= what a weak-model apply-phase output would look like if test_patch
+    were still in the schema).  The workspace value must win.
+    """
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    real_patch = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test__test-1",
+            "files_edited": ["foo.py"],
+            "attempt": 1,
+            # test_patch in the artifact data is null (= weak LLM dropped it)
+            "test_patch": None,
+            # But _input_raw has the real value from the workspace
+            "_input_raw": {
+                "status": "ok",
+                "content": json.dumps({
+                    "type": "swe_bench_input",
+                    "data": {
+                        "instance_id": "test__test-1",
+                        "test_patch": real_patch,
+                    },
+                }),
+            },
+        },
+    }
+    result = sanitize_test_patch(artifact)
+    assert result == real_patch, (
+        "Workspace _input_raw must win over null test_patch in artifact. "
+        f"Expected workspace value: {real_patch!r}, got: {result!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 C2: apply_state test_patch=null = deterministic-split violation fix

## Bug (13977 cap_err_1)

```
apply_state validation: 'test_patch': None is not of type 'string'
```

### Root cause — two layers

**Layer 1** (`apply.md:40-41`): The apply-phase LLM was instructed to echo `test_patch` (a large unified diff) verbatim from the plan input into the `apply_state` output artifact. A weak model (gemini-flash-lite) dropped/nulled the field → schema validation failure at the verify-phase entry. This is a P5 violation: deterministic passthrough of input data was delegated to LLM cognition.

**Layer 2** (`sanitize_test_patch.py:47`): The sanitizer called `data.get("test_patch")` where `data` was the **full artifact dict** (`{"type": "apply_state", "data": {...}}`). Since `test_patch` is nested at `artifact["data"]["test_patch"]`, the sanitizer ALWAYS returned `""` in production and overwrote any LLM-echoed value with empty string. This was hidden by Layer 1.

### Apply → verify test_patch flow (pre-fix)

```
swe_bench_input.test_patch
  → plan artifact (explore/plan read it for context)
    → apply LLM: "Carry test_patch from input" → apply_state.test_patch (WEAK LLM DROPS)
      → verify preprocessor sanitizer: data.get("test_patch") on FULL ARTIFACT → None → ""
        → verify LLM: data.test_patch = "" → FAIL
```

### Apply → verify test_patch flow (post-fix)

```
swe_bench_input.test_patch
  [OS stores at .reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json]
    → verify preprocessor step 1 (run_op: file.read):
        reads workspace file → data._input_raw.content = JSON string
      → verify preprocessor step 2 (python: sanitize_test_patch):
          reads from data._input_raw.content (Priority 1, workspace source)
          → sanitize (CRLF/BOM/newline) → data.test_patch = clean diff
        → verify LLM: data.test_patch = real patch → PASS
```

The apply LLM no longer touches test_patch. The workspace file is the P5 single source of truth.

## Fix (skill-layer only, no OS change — P7 compliant)

### Files changed

| File | Change |
|------|--------|
| `phases/apply.md` | Remove "Carry `test_patch` from the input" instruction (lines 40-41) |
| `artifacts/apply_state.yaml` | Remove `test_patch` field (schema.properties + required) |
| `phases/verify.md` | Add `run_op: file.read` as Step 1 preprocessor (reads workspace `_input` artifact → `data._input_raw`) |
| `sanitize_test_patch.py` | Rewrite: Priority 1 = `data._input_raw.content` (workspace JSON); Priority 2 = `artifact["data"]["test_patch"]` (fix old path bug); Priority 3 = top-level `test_patch` (unit-test compat) |
| `tests/test_swe_bench_pr_n15_workspace_passthrough.py` | 12 new Tier-2 tests |

### Method A vs B decision

Issue #1060 offered two methods. Method B (preprocessor injection) was chosen because:
- `sanitize_test_patch.py` preprocessor already existed (PR-O) and its `into: data.test_patch` / `mode: safe` wiring was already in place
- Adding a `run_op: file.read` step BEFORE the python step reuses the existing preprocessor chain mechanism — no new OS mechanism needed
- The workspace `_input` artifact path (`.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`) is deterministic from the OS `store_artifact` convention
- `json` module is in the safe-mode stdlib allowlist (already), so JSON parsing in the sanitizer needs no permission change

### P5/P1 grounding

- **P5**: `test_patch` is input data stored in the workspace at skill start. The OS always writes the entry-phase artifact to `state_dir/artifacts/{skill_name}/_input/v01_{type}.json`. The verify preprocessor reads it via `run_op: file.read` — no LLM intermediary.
- **P1**: The apply phase no longer knows about test_patch propagation. Apply-phase output schema (apply_state) is smaller and more correct — just records what the apply LLM actually owns (files_edited, attempt, instance_id).

## Test plan

- [x] `ruff check .` — All checks passed
- [x] Tier audit: `python scripts/test_tier_audit.py --strict tests/test_swe_bench_pr_n15_workspace_passthrough.py` — 0 errors
- [x] New tests (12): `pytest tests/test_swe_bench_pr_n15_workspace_passthrough.py` — 12/12 PASSED
- [x] Existing sanitize tests: `pytest tests/test_swe_bench_sanitize_test_patch.py` — 10/10 PASSED (backward compat via Priority 3 flat dict shape)
- [x] All swe_bench tests: `pytest -k "swe_bench or test_patch or sanitize"` — 92/92 PASSED
- [x] Full suite: `pytest -q tests/` — 6158 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` — unrelated to this PR, present on main)
- [x] Skill compile: `load_dsl_skill(swe_bench/skill.md)` — loads with 2 preprocessor steps on verify (run_op + python)
- [x] apply_state schema validation: artifact without test_patch field validates OK

**Scope guard**: Only `src/reyn/stdlib/skills/swe_bench/` + `tests/` touched. No OS code (`kernel/`, `permissions/`, `op_runtime/`, `services/`) modified.

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)