### PR TITLE
ci(fp-0008): PR-CI-D — pytest-xdist parallel execution + test isolation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: pip install -e ".[dev,mcp,web]"
 
       - name: Run tests
-        run: python -m pytest -q
+        run: python -m pytest -q -n auto
 
   lint:
     name: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ Changelog = "https://github.com/tya5/reyn/blob/main/CHANGELOG.md"
 dev = [
     "pytest>=8.0",
     "pytest-cov",
+    "pytest-xdist>=3.5",
     "ruff",
     "mypy",
     "pytest-asyncio>=0.23",


### PR DESCRIPTION
**[e2e-coder]** — Closes #1065 (D axis).

## Summary

Enables pytest-xdist parallel test execution after a mandatory separability investigation. All 6296 tests are parallel-safe with zero isolation markers needed.

## Primary evidence — serial vs parallel (local, 6296 tests)

| Run mode | passed | failed | skipped | xfailed | wall time |
|---|---|---|---|---|---|
| serial (`-q`) | 6296 | 1 (pre-existing) | 5 | 3 | 413s (~6m53s) |
| parallel (`-q -n auto`) | 6296 | 1 (pre-existing) | 5 | 3 | 202s (~3m22s) |

Pass count parity: identical. The pre-existing failure is `test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content` (known from the issue baseline).

## Separability investigation (Step 2–3 of spec)

**Result: 0 parallel-unsafe tests discovered.**

I ran `pytest -q -n auto` against the full suite. Every failure classification category was checked:

- shared module-level state — none detected
- port binding — none detected (no fixed-port web/MCP tests colliding)
- temp file / fixed path collision — none detected (fixtures already use `tmp_path`)
- order-dependence — none detected
- async event-loop sharing — none detected (pytest-asyncio strict mode already isolates loops per test)

## Isolation table

| Test | Classification | Isolation action |
|---|---|---|
| (none) | — | — |

**0 isolation needed — all parallel-safe.**

## Scale-guard decision (Step 4)

Took the "clean path": since 0 parallel-unsafe tests were found, no scale guard was triggered. Full `-n auto` applied to the entire suite.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | Added `pytest-xdist>=3.5` to `[dev]` extras |
| `.github/workflows/test.yml` | `python -m pytest -q` → `python -m pytest -q -n auto` |

## Assertion-untouched statement

No test assertions were changed. No `src/` logic was changed. This PR is purely infrastructure (deps + workflow flag).

## Test plan

- [x] `pytest -q -n auto` — 6296 passed, 1 pre-existing failed, 5 skipped, 3 xfailed (verified locally)
- [x] `pytest -q` (serial) — 6296 passed, 1 pre-existing failed, 5 skipped, 3 xfailed (verified locally before this PR)
- [x] `ruff check .` — All checks passed
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — YAML valid
- [x] No assertions changed (confirmed: only pyproject.toml + test.yml modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)