### PR TITLE
refactor(tui): InlineThinkingRow — reference _AMBER from palette (hygiene)

### DIFF
--- a/src/reyn/chat/tui/widgets/inline_thinking_row.py
+++ b/src/reyn/chat/tui/widgets/inline_thinking_row.py
@@ -17,6 +17,8 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Label
 
+from reyn.chat.tui._palette import _AMBER
+
 _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"  # 10-frame Braille cycle
 _INTERVAL_S = 0.10  # ~10 fps
 
@@ -32,12 +34,12 @@ class InlineThinkingRow(Widget):
     unmount via ``ConversationView.stop_thinking()``.
     """
 
-    DEFAULT_CSS = """
-    InlineThinkingRow {
+    DEFAULT_CSS = f"""
+    InlineThinkingRow {{
         height: 1;
         padding: 0 2;
-        color: #d4945a;
-    }
+        color: {_AMBER};
+    }}
     """
 
     can_focus = False


### PR DESCRIPTION
**[tui-coder]** — pure hygiene refactor; no behavior change.

## Summary

- `InlineThinkingRow.DEFAULT_CSS` was hardcoding `color: #d4945a` as a raw hex literal instead of referencing the canonical `_AMBER` constant from `reyn.chat.tui._palette`.
- This PR imports `_AMBER` and builds `DEFAULT_CSS` as an f-string injecting `{_AMBER}`, mirroring exactly how `foldable_markdown.py` injects `_CORAL` into its `DEFAULT_CSS`.
- Rendered value is **unchanged** (`#d4945a`). If the palette is re-tuned, the thinking spinner now stays in sync with the streaming cursor (both use `_AMBER`).

## Evidence pack

**`_AMBER == "#d4945a"` proof (value unchanged):**
```
$ python -c "from reyn.chat.tui._palette import _AMBER; print(_AMBER)"
#d4945a
```

**Before (hardcoded literal):**
```python
DEFAULT_CSS = """
InlineThinkingRow {
    height: 1;
    padding: 0 2;
    color: #d4945a;
}
"""
```

**After (palette reference, f-string, mirrors foldable_markdown.py pattern):**
```python
from reyn.chat.tui._palette import _AMBER

DEFAULT_CSS = f"""
InlineThinkingRow {{
    height: 1;
    padding: 0 2;
    color: {_AMBER};
}}
"""
```

## Test plan

- [x] `pytest tests/cli/test_tui_smoke.py -q` — 40 passed
- [x] `ruff check src/reyn/chat/tui/widgets/inline_thinking_row.py` — clean
- [x] `_AMBER == "#d4945a"` confirmed — value unchanged

**NO unit test added.** A test asserting the color hex string would be a format-pinning Tier-4 test (forbidden by testing policy: "NEVER pin algorithm-level / formatting behavior").

## Tier self-check

Pure refactor (hardcoded literal → palette import). No logic change, no new behavior, no new test warranted. Testing policy explicitly prohibits format-pinning tests (Tier 4). Smoke suite confirms the widget still mounts correctly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)