### PR TITLE
fix(tui): Matrix rain — drop double-width katakana (column bleed)

### DIFF
--- a/src/reyn/chat/tui/widgets/matrix.py
+++ b/src/reyn/chat/tui/widgets/matrix.py
@@ -1,11 +1,17 @@
 """MatrixScreen — easter egg invoked via the hidden `/matrix` slash command.
 
-Cascading green katakana / ASCII rain à la 1999 Wachowski. Press any key
-(or click) to dismiss and return to the chat.
+Cascading green ASCII rain à la 1999 Wachowski. Press any key (or click)
+to dismiss and return to the chat.
 
 Performance note: re-renders the whole grid each tick (~14 fps). Cheap
 enough for typical terminal sizes; not optimised because it's an easter
 egg, not a production widget.
+
+Note: katakana characters (East Asian Wide, cell_len == 2) were removed from
+_CHARS.  Each render column is allocated exactly one terminal cell; emitting
+a double-width glyph overwrites the adjacent column's cell and produces a
+visual smear on most terminals.  The ASCII/symbol set preserves the green-
+rain aesthetic with no cell-width mismatch.
 """
 from __future__ import annotations
 
@@ -16,12 +22,8 @@ from textual.app import ComposeResult
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
-_KATAKANA = (
-    "アイウエオカキクケコサシスセソタチツテトナニヌネノ"
-    "ハヒフヘホマミムメモヤユヨラリルレロワヲン"
-)
 _SYMBOLS = "01:.\"=*+-<>?|/\\~$#@&"
-_CHARS = _KATAKANA + _SYMBOLS
+_CHARS = _SYMBOLS
 
 
 class _Column:

--- a/tests/cli/test_matrix_chars_single_width.py
+++ b/tests/cli/test_matrix_chars_single_width.py
@@ -29,7 +29,8 @@ from reyn.chat.tui.widgets.matrix import _CHARS  # noqa: E402
 
 def test_all_chars_are_single_cell_width() -> None:
     """Tier 2: Every char in _CHARS must have cell_len == 1 (no East-Asian-Wide glyphs)."""
-    wide = [(ch, cell_len(ch)) for ch in _CHARS if cell_len(ch) != 1]
+    widths = [(ch, cell_len(ch)) for ch in _CHARS]
+    wide = [(ch, w) for ch, w in widths if w != 1]
     assert wide == [], (
         f"_CHARS contains {len(wide)} double-width character(s) that would cause "
         f"column bleed in the Matrix rain render loop: {wide}"

--- a/tests/cli/test_matrix_chars_single_width.py
+++ b/tests/cli/test_matrix_chars_single_width.py
@@ -1,0 +1,41 @@
+"""Tier 2: Every character in matrix._CHARS is single-cell-width (cell_len == 1).
+
+The Matrix rain render loop allocates exactly one terminal cell per column
+per row.  Any East-Asian-Wide character (cell_len == 2) placed in _CHARS
+would overwrite the adjacent column's cell, producing a double-wide smear
+on most terminals.  This test enforces the single-width invariant to prevent
+wide chars from sneaking back into _CHARS.
+
+Tier self-check:
+  - No MagicMock / AsyncMock / patch
+  - Docstring declares Tier 2
+  - Exercises the public module-level constant _CHARS directly
+  - No private-state assertions
+  - No snapshot / golden-file output
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rich.cells import cell_len
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.matrix import _CHARS  # noqa: E402
+
+
+def test_all_chars_are_single_cell_width() -> None:
+    """Tier 2: Every char in _CHARS must have cell_len == 1 (no East-Asian-Wide glyphs)."""
+    wide = [(ch, cell_len(ch)) for ch in _CHARS if cell_len(ch) != 1]
+    assert wide == [], (
+        f"_CHARS contains {len(wide)} double-width character(s) that would cause "
+        f"column bleed in the Matrix rain render loop: {wide}"
+    )
+
+
+def test_chars_is_non_empty() -> None:
+    """Tier 2: _CHARS must be non-empty so the rain animation has glyphs to draw."""
+    assert len(_CHARS) > 0, "_CHARS is empty — Matrix rain has no characters to render"


### PR DESCRIPTION
**[tui-coder]** — Fix column bleed in the Matrix easter egg caused by East-Asian-Wide katakana characters in `_CHARS`.

## Summary

- `_CHARS` previously included full-width katakana (`アイウエオ…`, 46 chars). `cell_len('ア') == 2`, but the render loop assigns exactly one terminal cell per `x` column index. Emitting a double-width glyph overwrites the right half of the adjacent column, producing a smeared double-wide bleed on most terminals.
- Fix (Option A — simple, safe): removed `_KATAKANA` and the `_CHARS = _KATAKANA + _SYMBOLS` concatenation. `_CHARS` is now `_SYMBOLS` (20 single-cell ASCII/symbol chars). Green-rain aesthetic is preserved.
- Added a Tier-2 invariant test (`tests/cli/test_matrix_chars_single_width.py`) that asserts every character in `_CHARS` has `cell_len == 1`, preventing wide chars from sneaking back in.

## Evidence pack

Before (katakana is wide):
```
>>> from rich.cells import cell_len
>>> cell_len('ア')
2
>>> cell_len('カ')
2
```

After (all _CHARS are single-cell):
```
>>> from reyn.chat.tui.widgets.matrix import _CHARS
>>> all(cell_len(c) == 1 for c in _CHARS)
True
>>> [(c, cell_len(c)) for c in _CHARS if cell_len(c) != 1]
[]
```

## Test plan

- [x] `pytest tests/cli/ -q -k matrix` — 2 passed (invariant tests)
- [x] `pytest tests/cli/test_tui_smoke.py -q` — 40 passed
- [x] `ruff check src/reyn/chat/tui/widgets/matrix.py tests/cli/test_matrix_chars_single_width.py` — clean

## Tier self-check

- Test Tier: **Tier 2 — OS/widget invariant** (single-cell-width contract for `_CHARS` is a real runtime requirement, not a format pin)
- No `MagicMock` / `AsyncMock` / `patch`
- No private-state assertions
- No snapshot / golden-file output
- Docstrings declare `Tier 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)