### PR TITLE
fix(tui): keys_tab correctness — esc detail key + F3 text + events i/v grouping

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -33,11 +33,13 @@ _KEY_DETAILS: dict[str, str] = {
         "more horizontal space for content. Persists via tui_prefs.json."
     ),
     "f3": (
-        "Drill-down expands the cursor's skill row to show phase history,\n"
-        "tool calls, and per-phase events. Mouse-click on the row does\n"
-        "the same. No-op when no skill row has cursor focus."
+        "Bulk-toggle expand on all in-flight skill + tool-call rows at once\n"
+        "(mouse-click does the same per-row). One keypress aligns every row\n"
+        "to a single convergence state — mixed sets (one expanded, one\n"
+        "collapsed) flip to match the first row. Shows a 'no active rows'\n"
+        "hint when nothing is in flight."
     ),
-    "esc": (
+    "escape": (
         "Context-aware back/cancel:\n"
         "  • voice mode → cancel recording\n"
         "  • error box → dismiss\n"
@@ -326,14 +328,6 @@ def render_keys(
         # Same "per-tab action" idiom as the pending-tab ``d`` / ``c``
         # discard / claim shortcuts.
         ("a", "Attach to cursor agent (agents tab)"),
-        # Wave-11 A#2: ``i`` on the Events tab isolates the cursor's
-        # chain_id so the user can read one chain's lifecycle without
-        # interleaving noise from other concurrent chains. T2-3: added
-        # "(events tab)" suffix so the gating is visible without Space-expand.
-        ("i", "Isolate cursor's chain (events tab only)"),
-        # Events tab ``v`` = toggle verbose mode. Default-off hides
-        # compaction_check noise; verbose-on shows everything.
-        ("v", "Toggle verbose (events tab)"),
         # Lang toggle: each doc concept appears once; ``g`` switches the
         # preferred language (ja ↔ en). Only active on the Docs tab.
         ("g", "Toggle docs language preference (ja ↔ en, docs tab only)"),
@@ -370,6 +364,23 @@ def render_keys(
     group_keys["PANEL"].append("tab")
     groups["PANEL"].append((_pretty_key("shift+tab"), "Previous tab (panel focused)"))
     group_keys["PANEL"].append("shift+tab")
+
+    # Wave-11 A#2 / fix/tui-keys-tab-correctness: ``i`` and ``v`` are events-tab
+    # keys handled via RightPanel.on_key and routed through ``_EVENTS_KEYS``.
+    # They were previously surfaced via ``_PANEL_EXPLICIT`` (= rendered under
+    # [PANEL]) which misrepresented their gating. Surface them here as synthetic
+    # rows under [EVENTS (gated)] — the correct group per ``_key_group_for``.
+    # Only emit if not already surfaced from app/InputBar BINDINGS.
+    if "i" not in binding_seen:
+        groups["EVENTS (gated)"].append(
+            (_pretty_key("i"), "Isolate cursor's chain (events tab only)")
+        )
+        group_keys["EVENTS (gated)"].append("i")
+    if "v" not in binding_seen:
+        groups["EVENTS (gated)"].append(
+            (_pretty_key("v"), "Toggle verbose (events tab)")
+        )
+        group_keys["EVENTS (gated)"].append("v")
 
     # MOUSE group (T1-4, Wave-12): explicit click-interaction rows.
     # These have no key semantics so raw_key is "" for all of them.

--- a/tests/cli/test_keys_tab_correctness.py
+++ b/tests/cli/test_keys_tab_correctness.py
@@ -1,0 +1,222 @@
+"""Tier 2: keys_tab correctness fixes — esc detail key, F3 bulk-toggle text, events i/v grouping.
+
+Three correctness fixes (fix/tui-keys-tab-correctness):
+
+B1 — ``_KEY_DETAILS`` was keyed ``"esc"`` but the InputBar Binding uses
+     ``"escape"``, so the Esc detail block was permanently unreachable.
+     Fix: key renamed ``"escape"``.
+
+B2 — ``_KEY_DETAILS["f3"]`` described cursor-based drill-down semantics but
+     the actual action (``action_skill_expand_toggle``) bulk-toggles ALL
+     in-flight skill + tool-call rows.  Fix: description updated to reflect
+     the real behavior.
+
+B3 — Keys ``i`` (isolate chain) and ``v`` (toggle verbose) are events-tab
+     keys (routed via ``_EVENTS_KEYS``).  They were listed in ``_PANEL_EXPLICIT``
+     and therefore rendered under ``[PANEL]``, hiding their events-tab gating.
+     Fix: removed from ``_PANEL_EXPLICIT``; surfaced as synthetic rows under
+     ``[EVENTS (gated)]``.
+
+All assertions use the public surface — ``render_keys()`` plain text and
+``_KEY_DETAILS`` dict membership — NOT private module state.
+State setup that has no dedicated public reset API (module-level cursor /
+expanded set) uses the module globals directly, as per the pattern established
+in ``test_keys_tab_details_and_mouse.py``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets.right_panel import keys_tab as _kt
+from reyn.chat.tui.widgets.right_panel.keys_tab import (
+    _KEY_DETAILS,
+    get_keys_cursor,
+    get_keys_expanded,
+    keys_move,
+    render_keys,
+    toggle_expand_cursor,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _reset_keys_state() -> None:
+    """Reset module-level cursor and expanded state between tests."""
+    _kt._keys_cursor = 0
+    _kt._keys_expanded = set()
+
+
+def _app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test",
+        model="test",
+        budget_tracker=None,
+    )
+
+
+# ── B1: Esc detail key fix ────────────────────────────────────────────────────
+
+
+def test_b1_escape_key_in_key_details() -> None:
+    """Tier 2: _KEY_DETAILS is keyed 'escape' (not 'esc') so the lookup succeeds."""
+    assert "escape" in _KEY_DETAILS, (
+        "'escape' must be a key in _KEY_DETAILS (was 'esc' before B1 fix)"
+    )
+    assert "esc" not in _KEY_DETAILS, (
+        "'esc' must NOT be a key in _KEY_DETAILS — the InputBar binding is 'escape'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_b1_esc_row_expand_detail_non_empty() -> None:
+    """Tier 2: the Esc row's Space-expand detail renders non-empty after toggle.
+
+    Before B1 the key was 'esc', but ``toggle_expand_cursor`` stores the raw
+    key from ``flat_key_list`` (= 'escape' per InputBar.BINDINGS), so
+    ``_KEY_DETAILS.get('escape', '')`` always returned '' — the detail block
+    was permanently unreachable.
+    """
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        markup, flat_key_list, _ = render_keys(app, cursor=0, expanded=set())
+
+        assert "escape" in flat_key_list, (
+            f"'escape' must appear in flat_key_list; got: {flat_key_list}"
+        )
+        esc_idx = flat_key_list.index("escape")
+        keys_move(esc_idx, len(flat_key_list))
+
+        # Toggle expand — must succeed (return True) and render non-empty detail.
+        did_open = toggle_expand_cursor(flat_key_list)
+        assert did_open, (
+            "toggle_expand_cursor must return True when opening the Esc detail "
+            "(returned False = detail key lookup failed, B1 fix not applied)"
+        )
+
+        markup_after, _, _ = render_keys(
+            app,
+            cursor=get_keys_cursor(),
+            expanded=get_keys_expanded(),
+        )
+        # The detail text mentions context-aware back/cancel semantics.
+        assert "context-aware" in markup_after.lower(), (
+            f"Esc detail block must render 'context-aware' text; got:\n{markup_after}"
+        )
+
+
+# ── B2: F3 bulk-toggle wording ────────────────────────────────────────────────
+
+
+def test_b2_f3_detail_contains_bulk_toggle_wording() -> None:
+    """Tier 2: _KEY_DETAILS['f3'] reflects bulk-toggle semantics, not cursor-drill-down."""
+    detail = _KEY_DETAILS.get("f3", "")
+    assert detail, "_KEY_DETAILS must have an 'f3' entry"
+    lower = detail.lower()
+    # New wording must mention bulk behavior.
+    assert "bulk" in lower or "all" in lower, (
+        f"F3 detail must describe bulk-toggle behaviour; got:\n{detail}"
+    )
+    # Old stale wording must be absent (cursor-based drill-down).
+    assert "cursor's skill row" not in lower, (
+        f"F3 detail must NOT contain stale cursor-based wording; got:\n{detail}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_b2_f3_expand_renders_bulk_toggle_text() -> None:
+    """Tier 2: F3 row Space-expand renders the updated bulk-toggle detail text."""
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        markup, flat_key_list, _ = render_keys(app, cursor=0, expanded=set())
+        assert "f3" in flat_key_list, (
+            f"f3 must appear in flat_key_list; got: {flat_key_list}"
+        )
+        f3_idx = flat_key_list.index("f3")
+        keys_move(f3_idx, len(flat_key_list))
+
+        did_open = toggle_expand_cursor(flat_key_list)
+        assert did_open, "toggle_expand_cursor must return True for f3"
+
+        markup_after, _, _ = render_keys(
+            app,
+            cursor=get_keys_cursor(),
+            expanded=get_keys_expanded(),
+        )
+        # B2: detail now describes bulk-toggle, not cursor-based drill-down.
+        assert "bulk-toggle" in markup_after.lower(), (
+            f"F3 detail must render 'bulk-toggle' wording; got:\n{markup_after}"
+        )
+        # Old stale wording must not appear in the expanded detail.
+        assert "cursor's skill row" not in markup_after.lower(), (
+            f"F3 detail must NOT render stale cursor-based wording; got:\n{markup_after}"
+        )
+
+
+# ── B3: i and v under EVENTS group, not PANEL ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_b3_i_and_v_appear_under_events_group() -> None:
+    """Tier 2: 'i' and 'v' render under [EVENTS (gated)], not under [PANEL].
+
+    Before B3, both keys were in _PANEL_EXPLICIT and therefore rendered under
+    the [PANEL] header, hiding the fact that they are events-tab-gated.
+    After B3, they are emitted as synthetic rows under [EVENTS (gated)].
+    """
+    _reset_keys_state()
+    app = _app()
+    async with app.run_test(headless=True, size=(120, 50)) as pilot:
+        await pilot.pause()
+
+        rendered, _, _ = render_keys(app, cursor=0, expanded=set())
+
+        events_idx = rendered.find("[EVENTS (gated)]")
+        panel_idx = rendered.find("[PANEL]")
+        # Both group headers must be present.
+        assert events_idx >= 0, "[EVENTS (gated)] group header missing from rendered output"
+        assert panel_idx >= 0, "[PANEL] group header missing from rendered output"
+
+        # Locate the EVENTS section boundary: text between [EVENTS (gated)]
+        # and the next group header ([DOCS (gated)]).
+        docs_idx = rendered.find("[DOCS (gated)]")
+        if docs_idx < 0:
+            docs_idx = len(rendered)
+        events_section = rendered[events_idx:docs_idx]
+
+        # ``i`` and ``v`` (their descriptions) must appear inside the EVENTS section.
+        assert "Isolate cursor" in events_section, (
+            f"'i' (Isolate cursor) must appear in [EVENTS (gated)] section; "
+            f"events_section:\n{events_section}"
+        )
+        assert "Toggle verbose" in events_section, (
+            f"'v' (Toggle verbose) must appear in [EVENTS (gated)] section; "
+            f"events_section:\n{events_section}"
+        )
+
+        # Neither description must appear in the PANEL section.
+        # PANEL section: text between [PANEL] header and [EVENTS (gated)] header.
+        # (_GROUP_ORDER is: GLOBAL, INPUT, CONVERSATION, PANEL, EVENTS (gated), ...)
+        panel_section = rendered[panel_idx:events_idx]
+        assert "Isolate cursor" not in panel_section, (
+            f"'i' (Isolate cursor) must NOT appear under [PANEL]; "
+            f"panel_section:\n{panel_section}"
+        )
+        assert "Toggle verbose" not in panel_section, (
+            f"'v' (Toggle verbose) must NOT appear under [PANEL]; "
+            f"panel_section:\n{panel_section}"
+        )

--- a/tests/cli/test_keys_tab_details_and_mouse.py
+++ b/tests/cli/test_keys_tab_details_and_mouse.py
@@ -124,7 +124,7 @@ def test_key_details_has_at_least_six_entries() -> None:
 
 @pytest.mark.asyncio
 async def test_toggle_expand_f3_row_shows_detail() -> None:
-    """Tier 2: toggle_expand_cursor() on the F3 row → detail block contains 'drill-down'."""
+    """Tier 2: toggle_expand_cursor() on the F3 row → detail block reflects bulk-toggle wording."""
     _reset_keys_state()
     app = _app()
     async with app.run_test(headless=True, size=(120, 40)) as pilot:
@@ -149,13 +149,15 @@ async def test_toggle_expand_f3_row_shows_detail() -> None:
         assert did_open, "toggle_expand_cursor should return True when opening"
 
         # Re-render with updated state and check for detail text.
+        # B2 fix: F3 now describes bulk-toggle behaviour (not cursor-based
+        # drill-down), so assert on the new wording sentinel.
         markup_after, _, _ = render_keys(
             app,
             cursor=get_keys_cursor(),
             expanded=get_keys_expanded(),
         )
-        assert "drill-down" in markup_after.lower(), (
-            f"After expand on F3 row, rendered output must contain 'drill-down'; "
+        assert "bulk-toggle" in markup_after.lower(), (
+            f"After expand on F3 row, rendered output must contain 'bulk-toggle'; "
             f"got:\n{markup_after}"
         )
 
@@ -181,8 +183,8 @@ async def test_toggle_expand_twice_hides_detail() -> None:
         markup_open, _, _ = render_keys(
             app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
         )
-        assert "drill-down" in markup_open.lower(), (
-            "Detail must be visible after first toggle"
+        assert "bulk-toggle" in markup_open.lower(), (
+            "Detail must be visible after first toggle (bulk-toggle wording)"
         )
 
         # Second toggle: close.
@@ -190,13 +192,12 @@ async def test_toggle_expand_twice_hides_detail() -> None:
         markup_closed, _, _ = render_keys(
             app, cursor=get_keys_cursor(), expanded=get_keys_expanded(),
         )
-        # The bare row description for F3 is "Drill-down …" per _PANEL_EXPLICIT
-        # / CONVERSATION group. The *inline detail block* lines are the ones
-        # emitted by the expand logic (prefixed with dim #aaaaaa). After
-        # close, those extra detail lines must be gone. We detect this by
-        # checking that the detail text from _KEY_DETAILS["f3"] is absent —
-        # the per-phase / tool-calls sentences are not in the row description.
-        detail_sentinel = "per-phase events"
+        # The *inline detail block* lines are emitted by the expand logic
+        # (prefixed with dim #aaaaaa). After close, those extra detail lines
+        # must be gone. We detect this by checking that distinctive text
+        # from _KEY_DETAILS["f3"] is absent — "convergence state" is not
+        # in the short row description, only in the expanded detail block.
+        detail_sentinel = "convergence state"
         assert detail_sentinel not in markup_closed, (
             f"After second toggle detail must be hidden; "
             f"sentinel {detail_sentinel!r} still present:\n{markup_closed}"


### PR DESCRIPTION
**[tui-coder]** — Three correctness fixes to `keys_tab.py` (TUI-internal only, no OS changes).

## Summary

- **B1 (HIGH):** `_KEY_DETAILS` was keyed `"esc"` but `InputBar.BINDINGS` uses `Binding("escape", …)`. The `toggle_expand_cursor` lookup `_KEY_DETAILS.get("escape", "")` always returned `""` — Esc expand detail permanently unreachable. Fix: rename key `"esc"` → `"escape"`.
- **B2 (MED):** `_KEY_DETAILS["f3"]` described cursor-based drill-down, but `action_skill_expand_toggle` (app.py:1599-1658) bulk-toggles ALL in-flight `SkillActivityRow` + `ToolCallRow` to a convergence state. Fix: rewrite description to match actual behavior.
- **B3 (MED):** Keys `i` (isolate chain) and `v` (toggle verbose) were in `_PANEL_EXPLICIT` → rendered under `[PANEL]`, misrepresenting their events-tab gating. Fix: removed from `_PANEL_EXPLICIT`; surfaced as synthetic rows under `[EVENTS (gated)]`, following the Tab/Shift+Tab synthetic-row pattern (~line 363-372).

## Evidence pack

**B1 — binding vs. detail key mismatch:**
```
# InputBar.BINDINGS (input_bar.py:72)
Binding("escape", "dismiss_picker", "Dismiss", …)

# Before fix — _KEY_DETAILS key (keys_tab.py:40)
"esc": ("Context-aware back/cancel:\n  • …")

# After fix
"escape": ("Context-aware back/cancel:\n  • …")

# Lookup site (toggle_expand_cursor, keys_tab.py:472)
raw_key = flat_key_list[idx]          # = "escape" (from InputBar binding)
if … raw_key not in _KEY_DETAILS:    # "escape" not in {"esc": …} → True → no-op
    return False                      # detail block was never reachable
```

**B2 — stale text vs. actual action:**
```
# Before fix
"f3": "Drill-down expands the cursor's skill row to show phase history,\n
        tool calls, and per-phase events. … No-op when no skill row has cursor focus."

# action_skill_expand_toggle (app.py:1634-1655) — actual behavior
rows = list(skill_rows) + list(tool_rows)   # ALL in-flight rows
if not rows:
    conv.show_status("no active rows to expand", …)   # shows hint, not silent no-op
target_expand = not rows[0].is_expanded             # convergence state
for row in rows:
    if row.is_expanded != target_expand:
        row.toggle_expand()                          # bulk toggle

# After fix
"f3": "Bulk-toggle expand on all in-flight skill + tool-call rows at once\n
        (mouse-click does the same per-row). One keypress aligns every row\n
        to a single convergence state — mixed sets (one expanded, one\n
        collapsed) flip to match the first row. Shows a 'no active rows'\n
        hint when nothing is in flight."
```

**B3 — grouping before/after:**
```
# Before: _PANEL_EXPLICIT list (rendered under [PANEL])
("i", "Isolate cursor's chain (events tab only)"),
("v", "Toggle verbose (events tab)"),

# After: removed from _PANEL_EXPLICIT; synthetic rows appended to EVENTS group
if "i" not in binding_seen:
    groups["EVENTS (gated)"].append((_pretty_key("i"), "Isolate cursor's chain (events tab only)"))
if "v" not in binding_seen:
    groups["EVENTS (gated)"].append((_pretty_key("v"), "Toggle verbose (events tab)"))
```

## Test plan

- [x] `pytest tests/cli/test_keys_tab_correctness.py tests/cli/test_keys_tab_details_and_mouse.py tests/cli/test_keys_tab_panel_bindings.py tests/cli/test_keys_tab_content_sweep_t2_3.py tests/cli/test_keys_tab_scroll_into_view.py -q` → **35 passed** in 21.59s
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/keys_tab.py tests/cli/test_keys_tab_correctness.py` → **All checks passed**
- [x] (skipped — TUI headless only, no manual visual run needed for dict key / text / grouping fixes)

## Tier self-check

New test file `tests/cli/test_keys_tab_correctness.py`:
- Tier 2 (OS invariant / render contract): docstring first line `"""Tier 2: …"""` on all tests.
- Asserts on `render_keys()` plain-text output and `_KEY_DETAILS` dict membership — public surface only.
- No `MagicMock` / `patch` / private-state asserts (`_field`).
- State setup uses module globals (`_keys_cursor`, `_keys_expanded`) via the established reset pattern in `test_keys_tab_details_and_mouse.py`.
- Updated `test_keys_tab_details_and_mouse.py` tests 4/5 to use new F3 sentinel text (`"bulk-toggle"` / `"convergence state"`) matching the B2 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)