### PR TITLE
docs(nav): hierarchical Concepts sections + 3 orphaned for-users pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,9 @@ nav:
           - guide/for-users/ask-user-mid-phase.md
           - guide/for-users/chat-and-web-ui.md
           - guide/for-users/work-with-files.md
+          - guide/for-users/enable-semantic-search.md
+          - guide/for-users/run-swe-bench.md
+          - guide/for-users/popular-mcp-servers.md
       - For skill authors:
           - guide/for-skill-authors/index.md
           - Foundation:
@@ -192,37 +195,44 @@ nav:
       - Other:
           - reference/upgrade-policy.md
   - Concepts:
-      - concepts/principles.md
-      - concepts/care-boundary.md
-      - concepts/architecture.md
-      - concepts/phase-vs-skill-vs-os.md
-      - concepts/llm-invocation-surfaces.md
-      - concepts/llm-as-decision-engine.md
-      - concepts/workspace.md
-      - concepts/events.md
-      - concepts/permission-model.md
-      - concepts/sandbox.md
-      - concepts/secret-handling.md
-      - concepts/mcp.md
-      - concepts/universal-catalog.md
-      - concepts/chat-compaction.md
-      - concepts/rag.md
-      - concepts/dogfood-scenarios.md
-      - concepts/operational-intelligence.md
-      - concepts/skill-self-improvement.md
-      - concepts/a2a.md
-      - concepts/memory.md
-      - concepts/multi-agent.md
-      - concepts/topology.md
-      - concepts/plan-mode.md
-      - concepts/async-skill-execution.md
-      - concepts/preprocessor.md
-      - concepts/postprocessor.md
-      - concepts/python-safe-mode.md
-      - concepts/skill-design-patterns.md
-      - concepts/evaluation.md
-      - concepts/skill-resume.md
-      - concepts/voice.md
+      - Architecture:
+          - concepts/principles.md
+          - concepts/architecture.md
+          - concepts/care-boundary.md
+          - concepts/phase-vs-skill-vs-os.md
+          - concepts/llm-invocation-surfaces.md
+          - concepts/llm-as-decision-engine.md
+      - Runtime:
+          - concepts/workspace.md
+          - concepts/events.md
+          - concepts/permission-model.md
+          - concepts/sandbox.md
+          - concepts/secret-handling.md
+      - Skills:
+          - concepts/skill-design-patterns.md
+          - concepts/skill-self-improvement.md
+          - concepts/skill-resume.md
+          - concepts/async-skill-execution.md
+          - concepts/preprocessor.md
+          - concepts/postprocessor.md
+          - concepts/python-safe-mode.md
+      - Multi-agent:
+          - concepts/multi-agent.md
+          - concepts/a2a.md
+          - concepts/topology.md
+          - concepts/plan-mode.md
+      - Data & retrieval:
+          - concepts/rag.md
+          - concepts/memory.md
+          - concepts/operational-intelligence.md
+          - concepts/chat-compaction.md
+      - Tools & integrations:
+          - concepts/mcp.md
+          - concepts/universal-catalog.md
+          - concepts/voice.md
+      - Observability:
+          - concepts/dogfood-scenarios.md
+          - concepts/evaluation.md
       - Agent engineering — seven lenses:
           - concepts/agent-engineering/index.md
           - concepts/agent-engineering/system-design.md


### PR DESCRIPTION
**[docs-maintainer]** — nav restructure per user request: hierarchical+collapsible, default collapsed, unified across whole nav.

## Summary

- **Concepts section restructured**: 31 flat pages grouped into 7 collapsible sub-sections (Architecture / Runtime / Skills / Multi-agent / Data & retrieval / Tools & integrations / Observability). The pre-existing "Agent engineering — seven lenses" sub-section is unchanged. Total page count preserved.
- **For users**: 3 orphaned pages that existed in `docs/guide/for-users/` but were absent from nav are now added: `enable-semantic-search.md`, `run-swe-bench.md`, `popular-mcp-servers.md`.
- **No feature-flag changes**: `navigation.sections` (already present) provides default-collapsed behaviour. `navigation.expand` intentionally NOT added — keeps sections collapsed by default as requested.

## Evidence pack

**Concepts page count before → after** (grep):
```
Before: 31 flat entries under "- Concepts:" + 8 agent-engineering = 39 total
After:  7 sub-sections × (2–7 pages each) + 8 agent-engineering  = 39 total
```
No pages added or removed from Concepts — pure regrouping.

**For users orphaned pages verified present on disk before adding to nav**:
```
docs/guide/for-users/enable-semantic-search.md  ✓
docs/guide/for-users/run-swe-bench.md           ✓
docs/guide/for-users/popular-mcp-servers.md     ✓
```

## Test plan

- [ ] `mkdocs build` passes without warnings (no broken nav paths)
- [ ] Concepts section in sidebar shows 7 collapsible sub-groups
- [ ] All 3 new for-users pages appear under "For users" in sidebar
- [ ] Default state: sections collapsed (no `navigation.expand` in features)