### PR TITLE
fix(tui): cost tab — width-adaptive columns (keep token total at narrow panel)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -2555,7 +2555,7 @@ class RightPanel(Widget):
             )
         return ""
 
-    def _panel_markup(self) -> Any:
+    def _panel_markup(self, content_width: int = 0) -> Any:
         try:
             if self._panel_type == "keys":
                 markup, _, key_ys = render_keys(
@@ -2607,7 +2607,11 @@ class RightPanel(Widget):
                 return rendered
             if self._panel_type == "cost":
                 budget_tracker = getattr(self.app, "_budget_tracker", None)
-                return render_cost(self._project_root, budget_tracker)
+                return render_cost(
+                    self._project_root,
+                    budget_tracker,
+                    content_width=content_width,
+                )
             if self._panel_type == "docs":
                 groups, ordered = build_docs_index(
                     self._project_root, self._docs_filter,

--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -9,10 +9,50 @@ from typing import Any
 
 from .base import _CORAL, _esc, logger
 
-# Budget progress-bar geometry
+# Budget progress-bar geometry (default / wide-panel values)
 _BAR_FILL = "█"
 _BAR_EMPTY = "░"
 _BAR_WIDTH = 24
+
+# Width thresholds for adaptive layout.
+# These are *content* widths (after panel padding is removed — padding
+# is 2 cols total, 1 each side per CSS ``padding: 0 1``).
+#
+#   ≥ _WIDE_THRESHOLD   — full layout (current behaviour unchanged)
+#   ≥ _MEDIUM_THRESHOLD — narrow the NAME column; keep tok + cost + calls
+#   < _MEDIUM_THRESHOLD — NAME narrowed further; drop cost + calls;
+#                         ALWAYS keep token total
+#
+# Budget bar:
+#   ≥ _BAR_THRESHOLD    — full bar + percentage label
+#   < _BAR_THRESHOLD    — suppress bar, keep percentage label only
+_WIDE_THRESHOLD   = 54  # full layout: name :<24 / :<22 / :<28
+_MEDIUM_THRESHOLD = 42  # narrow name: :<18 / :<16 / :<22; still show cost
+_BAR_THRESHOLD    = 44  # bar suppressed below this; pct label kept
+
+
+def _col_widths(content_width: int) -> tuple[int, int, int, int]:
+    """Return (agent_name_w, skill_name_w, model_name_w, budget_label_w).
+
+    Degrade order as width shrinks:
+      - wide  (≥ _WIDE_THRESHOLD):   24, 22, 28, 22
+      - medium (≥ _MEDIUM_THRESHOLD): 18, 16, 22, 18
+      - narrow (< _MEDIUM_THRESHOLD): 14, 12, 18, 14
+    """
+    if content_width >= _WIDE_THRESHOLD:
+        return 24, 22, 28, 22
+    if content_width >= _MEDIUM_THRESHOLD:
+        return 18, 16, 22, 18
+    return 14, 12, 18, 14
+
+
+def _show_cost_calls(content_width: int) -> bool:
+    """Return True when the content is wide enough to show cost + call count.
+
+    Below _MEDIUM_THRESHOLD these fields are clipped by _PanelContent and
+    add noise without being readable — suppress them proactively.
+    """
+    return content_width >= _MEDIUM_THRESHOLD
 
 
 def _new_bucket() -> dict:
@@ -53,13 +93,14 @@ def _sparkline(values: list[float], width: int = 32) -> str:
     return f"[{_CORAL}]{bar}[/]"
 
 
-def _budget_bar(used: float, cap: float) -> str:
-    """Render a 24-cell `█░` progress bar with colour thresholds.
+def _budget_bar(used: float, cap: float, *, bar_width: int = _BAR_WIDTH) -> str:
+    """Render a `█░` progress bar with colour thresholds.
 
+    ``bar_width`` controls the cell count of the bar segment; pass 0 to
+    suppress the bar entirely and emit only the ``[nnn%]`` readout.
     Green below 75 %, coral 75–90 %, red above 90 %. Returns Rich markup.
     """
     ratio = min(1.0, used / cap) if cap > 0 else 0.0
-    filled = round(ratio * _BAR_WIDTH)
     pct = int(ratio * 100)
     if ratio >= 0.9:
         colour = "#ff4444"
@@ -67,16 +108,29 @@ def _budget_bar(used: float, cap: float) -> str:
         colour = _CORAL
     else:
         colour = "#44cc88"
-    bar = _BAR_FILL * filled + _BAR_EMPTY * (_BAR_WIDTH - filled)
-    return f"[{colour}]\\[{bar}][/] [{colour}]{pct:3d}%[/]"
+    if bar_width > 0:
+        filled = round(ratio * bar_width)
+        bar = _BAR_FILL * filled + _BAR_EMPTY * (bar_width - filled)
+        return f"[{colour}]\\[{bar}][/] [{colour}]{pct:3d}%[/]"
+    # No bar — emit percentage only (keeps the readout visible at narrow widths)
+    return f"[{colour}]{pct:3d}%[/]"
 
 
-def _render_budget_caps(lines: list[str], budget_tracker: Any) -> None:
+def _render_budget_caps(
+    lines: list[str],
+    budget_tracker: Any,
+    *,
+    content_width: int = 0,
+) -> None:
     """Append daily token / cost progress bars when caps are configured.
 
     Reads `daily_tokens.hard_limit` and `daily_cost_usd.hard_limit` from
     ``budget_tracker.snapshot()["config"]``. Skips silently when caps are
     unset or the snapshot shape changes.
+
+    ``content_width`` controls adaptive rendering: below ``_BAR_THRESHOLD``
+    the bar segment is suppressed (= only the ``[nnn%]`` readout is shown)
+    to avoid clipping the percentage label at narrow panel widths.
     """
     try:
         snap = budget_tracker.snapshot()
@@ -89,17 +143,19 @@ def _render_budget_caps(lines: list[str], budget_tracker: Any) -> None:
         cost_cap_cfg = getattr(cfg, "daily_cost_usd", None)
         tok_hard = getattr(tok_cap_cfg, "hard_limit", None) if tok_cap_cfg else None
         cost_hard = getattr(cost_cap_cfg, "hard_limit", None) if cost_cap_cfg else None
+        _, _, _, budget_label_w = _col_widths(content_width)
+        bar_w = _BAR_WIDTH if content_width >= _BAR_THRESHOLD else 0
         if tok_hard and tok_hard > 0:
             label = f"{daily_tok_used:,} / {int(tok_hard):,}"
-            bar = _budget_bar(daily_tok_used, tok_hard)
+            bar = _budget_bar(daily_tok_used, tok_hard, bar_width=bar_w)
             lines.append(
-                f"[#555555]    tokens  [/][#aaaaaa]{label:<22}[/]  {bar}"
+                f"[#555555]    tokens  [/][#aaaaaa]{label:<{budget_label_w}}[/]  {bar}"
             )
         if cost_hard and cost_hard > 0:
             label = f"${daily_cost_used:.4f} / ${cost_hard:.4f}"
-            bar = _budget_bar(daily_cost_used, cost_hard)
+            bar = _budget_bar(daily_cost_used, cost_hard, bar_width=bar_w)
             lines.append(
-                f"[#555555]    cost    [/][#aaaaaa]{label:<22}[/]  {bar}"
+                f"[#555555]    cost    [/][#aaaaaa]{label:<{budget_label_w}}[/]  {bar}"
             )
     except Exception as exc:
         logger.warning("right_panel cost: budget cap render failed: %s", exc)
@@ -108,9 +164,24 @@ def _render_budget_caps(lines: list[str], budget_tracker: Any) -> None:
 def render_cost(
     project_root: Path | None,
     budget_tracker: Any = None,
+    *,
+    content_width: int = 0,
 ) -> str:
-    """Render the cost tab, summarising LLM usage from .reyn/events/*.jsonl."""
+    """Render the cost tab, summarising LLM usage from .reyn/events/*.jsonl.
+
+    ``content_width`` is the available content-area width in columns (i.e.
+    the panel width minus horizontal padding). When 0 or unknown the full
+    wide-panel layout is used. As the width shrinks the renderer degrades:
+    first the name columns narrow, then cost + call-count fields are
+    suppressed, while the token total is always kept visible on its own
+    line. The budget bar is replaced by a percentage-only readout below
+    ``_BAR_THRESHOLD`` content columns.
+    """
     lines: list[str] = []
+    agent_name_w, skill_name_w, model_name_w, _budget_label_w = _col_widths(
+        content_width
+    )
+    show_extra = _show_cost_calls(content_width)
 
     if project_root is None:
         lines.append("[#555555]  (no project root)[/]")
@@ -282,7 +353,9 @@ def render_cost(
             lines.append(f"[#555555]    trend   [/]{spark}")
         # Budget cap progress bars (only when caps are configured)
         if budget_tracker is not None:
-            _render_budget_caps(lines, budget_tracker)
+            _render_budget_caps(
+                lines, budget_tracker, content_width=content_width
+            )
     lines.append("")
 
     # ── ALL TIME ──────────────────────────────────────────────────────
@@ -307,14 +380,18 @@ def render_cost(
             # agent total: name bold white, tok light gray, cost bright green
             ag_cost = (
                 f"  [bold #44cc88]${ag['cost']:.4f}[/]"
-                if ag["has_cost"] else ""
+                if ag["has_cost"] and show_extra else ""
             )
-            # name col = 26 chars (2 indent + 24) to align with skill rows (4 + 22)
+            ag_calls = (
+                f"  [#777777]{ag['calls']}c[/]"
+                if show_extra else ""
+            )
+            # name col width adapts to content_width (see _col_widths)
             lines.append(
-                f"[bold #dddddd]  {_esc(agent):<24}[/]"
+                f"[bold #dddddd]  {_esc(agent):<{agent_name_w}}[/]"
                 f"[#aaaaaa]{ag_tok:>7,} tok[/]"
                 f"{ag_cost}"
-                f"  [#777777]{ag['calls']}c[/]"
+                f"{ag_calls}"
             )
             skills = by_agent_skill[agent]
             for skill in sorted(skills):
@@ -323,13 +400,17 @@ def render_cost(
                 # skill rows: dim name, muted green for cost — clearly subordinate
                 cost_part = (
                     f"  [#2d7a4f]${m['cost']:.4f}[/]"
-                    if m["has_cost"] else ""
+                    if m["has_cost"] and show_extra else ""
+                )
+                calls_part = (
+                    f"  [#444444]{m['calls']}c[/]"
+                    if show_extra else ""
                 )
                 lines.append(
-                    f"[#555555]    {_esc(skill):<22}[/]"
+                    f"[#555555]    {_esc(skill):<{skill_name_w}}[/]"
                     f"[#555555]{tok_total:>7,} tok[/]"
                     f"{cost_part}"
-                    f"  [#444444]{m['calls']}c[/]"
+                    f"{calls_part}"
                 )
             lines.append("")
     else:
@@ -350,19 +431,23 @@ def render_cost(
             tok_total = pb["p"] + pb["c"]
             cost_part = (
                 f"  [bold #44cc88]${pb['cost']:.4f}[/]"
-                if pb["has_cost"] else ""
+                if pb["has_cost"] and show_extra else ""
+            )
+            calls_part = (
+                f"  [#777777]{pb['calls']}c[/]"
+                if show_extra else ""
             )
             short_pid = plan_id[:8]
             goal = plan_goals.get(plan_id, "")
             goal_part = (
                 f"  [#666666]{_esc(goal[:32] + ('…' if len(goal) > 32 else ''))}[/]"
-                if goal else ""
+                if goal and show_extra else ""
             )
             lines.append(
                 f"[bold #ff9944]  {short_pid:<8}[/]"
                 f"  [#aaaaaa]{tok_total:>7,} tok[/]"
                 f"{cost_part}"
-                f"  [#777777]{pb['calls']}c[/]"
+                f"{calls_part}"
                 f"{goal_part}"
             )
             steps = by_plan_step.get(plan_id, {})
@@ -371,13 +456,17 @@ def render_cost(
                 step_tok = sb["p"] + sb["c"]
                 step_cost_part = (
                     f"  [#2d7a4f]${sb['cost']:.4f}[/]"
-                    if sb["has_cost"] else ""
+                    if sb["has_cost"] and show_extra else ""
+                )
+                step_calls_part = (
+                    f"  [#444444]{sb['calls']}c[/]"
+                    if show_extra else ""
                 )
                 lines.append(
-                    f"[#555555]    {_esc(step_id):<22}[/]"
+                    f"[#555555]    {_esc(step_id):<{skill_name_w}}[/]"
                     f"[#555555]{step_tok:>7,} tok[/]"
                     f"{step_cost_part}"
-                    f"  [#444444]{sb['calls']}c[/]"
+                    f"{step_calls_part}"
                 )
             lines.append("")
         lines.append("")
@@ -393,13 +482,17 @@ def render_cost(
             tok_total = mb["p"] + mb["c"]
             cost_part = (
                 f"  [#44cc88]${mb['cost']:.4f}[/]"
-                if mb["has_cost"] else ""
+                if mb["has_cost"] and show_extra else ""
+            )
+            calls_part = (
+                f"  [#777777]{mb['calls']}c[/]"
+                if show_extra else ""
             )
             lines.append(
-                f"[#aaaaaa]  {_esc(model_name):<28}[/]"
+                f"[#aaaaaa]  {_esc(model_name):<{model_name_w}}[/]"
                 f"[#555555]{tok_total:>7,} tok[/]"
                 f"{cost_part}"
-                f"  [#777777]{mb['calls']}c[/]"
+                f"{calls_part}"
             )
     else:
         lines.append("[#555555]    (no model data yet)[/]")

--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -71,10 +71,10 @@ class _PanelContent(Static):
 
     def render(self) -> RenderResult:
         try:
-            markup = self._panel._panel_markup()
+            width = self.content_region.width
+            markup = self._panel._panel_markup(content_width=width)
             if not isinstance(markup, str):
                 return markup
-            width = self.content_region.width
             if width <= 0:
                 return Text.from_markup(markup)
             # Truncate each line independently so long values

--- a/tests/cli/test_cost_tab_narrow_columns.py
+++ b/tests/cli/test_cost_tab_narrow_columns.py
@@ -1,0 +1,205 @@
+"""Tier 2: cost tab column widths adapt to narrow panel — token total always visible.
+
+Pins the invariant that ``render_cost`` degrades gracefully as ``content_width``
+shrinks:
+
+1. At NARROW width (< _MEDIUM_THRESHOLD = 42) the agent-row token total
+   (e.g. "3,500 tok") is present in the rendered output and is not clipped —
+   even though cost and call-count fields ARE suppressed at that width.
+2. At WIDE width (≥ _WIDE_THRESHOLD = 54) the full layout is unchanged:
+   token total, cost, and call-count are all present.
+
+These are checked on the PLAIN text returned by ``render_cost`` (= Rich markup
+stripped), which is the public-surface contract of the function. No private
+fields or internal state are asserted.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.text import Text
+
+from reyn.chat.tui.widgets.right_panel.cost_tab import (
+    _MEDIUM_THRESHOLD,
+    _WIDE_THRESHOLD,
+    render_cost,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _strip_markup(markup: str) -> str:
+    """Strip Rich markup tags and return plain text for assertion."""
+    try:
+        return Text.from_markup(markup).plain
+    except Exception:
+        # If markup is broken, fall back to naive tag stripping.
+        import re
+        return re.sub(r"\[[^\]]*\]", "", markup)
+
+
+def _render_plain(project_root: Path, content_width: int) -> str:
+    """Return plain text of render_cost at the given content width."""
+    markup = render_cost(project_root, budget_tracker=None,
+                         content_width=content_width)
+    # markup is a newline-joined string; strip each line individually.
+    return "\n".join(_strip_markup(line) for line in markup.split("\n"))
+
+
+def _make_events(project_root: Path, *, agent: str = "test-agent",
+                 prompt_tokens: int = 3000, completion_tokens: int = 500,
+                 cost_usd: float | None = 0.0123) -> None:
+    """Write a minimal synthetic events dir with one llm_called + one
+    llm_response_received event under agents/<agent>/skill_runs/.
+    """
+    skill_dir = (
+        project_root / ".reyn" / "events" / "agents" / agent / "skill_runs"
+        / "2026-05"
+    )
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    events_file = skill_dir / "2026-05-30T120000_test_skill.jsonl"
+    called = json.dumps({
+        "type": "llm_called",
+        "timestamp": "2026-05-30T12:00:00+00:00",
+        "data": {"model": "claude-sonnet"},
+    })
+    resp_data: dict = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+    }
+    if cost_usd is not None:
+        resp_data["cost_usd"] = cost_usd
+    received = json.dumps({
+        "type": "llm_response_received",
+        "timestamp": "2026-05-30T12:00:01+00:00",
+        "data": resp_data,
+    })
+    events_file.write_text(called + "\n" + received + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_narrow_width_token_total_visible(tmp_path: Path) -> None:
+    """Tier 2: at narrow content width the token total row is always present.
+
+    The token total (prompt + completion) is the load-bearing number in the
+    cost tab — it must survive even when cost + call-count fields are
+    suppressed to avoid clipping. ``content_width`` below ``_MEDIUM_THRESHOLD``
+    (42) is the minimum panel content area.
+    """
+    _make_events(tmp_path, prompt_tokens=3000, completion_tokens=500)
+    # Use a width safely below _MEDIUM_THRESHOLD but above 0.
+    narrow_width = _MEDIUM_THRESHOLD - 4  # = 38
+
+    plain = _render_plain(tmp_path, narrow_width)
+
+    # Token total "3,500" must be present in the rendered output.
+    total = 3000 + 500  # 3500
+    assert f"{total:,}" in plain, (
+        f"Token total {total:,} not found in narrow-width render. "
+        f"Rendered:\n{plain}"
+    )
+    # At narrow width the agent-row token label "tok" must also be visible.
+    assert "tok" in plain, (
+        f"'tok' label missing from narrow-width render. Rendered:\n{plain}"
+    )
+
+
+def test_wide_width_full_layout(tmp_path: Path) -> None:
+    """Tier 2: at wide content width the full layout is unchanged.
+
+    At ≥ _WIDE_THRESHOLD the token total, cost, and call-count columns are
+    all present — no regression from the adaptive-width changes.
+    """
+    _make_events(tmp_path, prompt_tokens=3000, completion_tokens=500,
+                 cost_usd=0.0123)
+    wide_width = _WIDE_THRESHOLD + 10  # = 64, safely above full-layout threshold
+
+    plain = _render_plain(tmp_path, wide_width)
+
+    total = 3000 + 500
+    # Token total
+    assert f"{total:,}" in plain, (
+        f"Token total {total:,} missing from wide render. Rendered:\n{plain}"
+    )
+    # Cost field
+    assert "0.0123" in plain, (
+        f"Cost field missing from wide render. Rendered:\n{plain}"
+    )
+    # Call count
+    assert "1c" in plain, (
+        f"Call-count '1c' missing from wide render. Rendered:\n{plain}"
+    )
+
+
+def test_narrow_width_suppresses_cost_calls(tmp_path: Path) -> None:
+    """Tier 2: at narrow content width cost and call-count are suppressed.
+
+    The BY AGENT / SKILL and BY MODEL agent-row cost + call-count fields must
+    not appear at narrow width so they don't generate invisible clipped noise.
+    The TODAY / ALL TIME sections always show cost (they're fixed-width label
+    rows, not the columnar layout), so we assert only on the section with
+    adaptive column widths.
+    """
+    _make_events(tmp_path, prompt_tokens=3000, completion_tokens=500,
+                 cost_usd=0.0123, agent="my-agent")
+    narrow_width = _MEDIUM_THRESHOLD - 4  # = 38
+
+    plain = _render_plain(tmp_path, narrow_width)
+
+    # The BY AGENT row must not contain "1c" (call-count) or "$0.0123"
+    # (cost). Find the "BY AGENT / SKILL" section and check the agent row.
+    lines = plain.split("\n")
+    in_agent_section = False
+    agent_row = ""
+    for line in lines:
+        if "BY AGENT" in line:
+            in_agent_section = True
+            continue
+        if in_agent_section and "BY " in line and "AGENT" not in line:
+            break  # moved past the section
+        if in_agent_section and "my-agent" in line:
+            agent_row = line
+            break
+
+    assert agent_row, (
+        f"agent row for 'my-agent' not found in narrow render. "
+        f"Full output:\n{plain}"
+    )
+    # Token total must be present.
+    assert "3,500" in agent_row, (
+        f"Token total missing from agent row: {agent_row!r}"
+    )
+    # Cost and call-count must be absent from the agent row at narrow width.
+    assert "0.0123" not in agent_row, (
+        f"Cost unexpectedly present in narrow agent row: {agent_row!r}"
+    )
+    assert "1c" not in agent_row, (
+        f"Call-count unexpectedly present in narrow agent row: {agent_row!r}"
+    )
+
+
+def test_zero_width_does_not_crash(tmp_path: Path) -> None:
+    """Tier 2: content_width=0 (unknown / pre-layout) falls back to wide layout.
+
+    This is the default value when _PanelContent hasn't received its first
+    layout pass yet. It must not crash and must produce readable output.
+    """
+    _make_events(tmp_path, prompt_tokens=100, completion_tokens=50)
+    # Should not raise.
+    plain = _render_plain(tmp_path, content_width=0)
+    assert "150" in plain, (
+        f"Token total 150 missing from zero-width (default) render. "
+        f"Rendered:\n{plain}"
+    )


### PR DESCRIPTION
**[tui-coder]** — Width-adaptive cost tab columns so the token total always survives at narrow panel widths.

## Summary

- Column widths in the cost tab were hardcoded (`agent :<24`, `skill :<22`, `model :<28`, budget label `:<22`, bar `_BAR_WIDTH=24`). At the minimum panel width (~42 content cols, `min-width: 44` CSS minus 2 cols padding), the cost/call-count fields were silently clipped by `_PanelContent.truncate(overflow="ellipsis")`, and the budget bar percentage label was always lost.
- `render_cost` now accepts a `content_width: int = 0` keyword parameter, forwarded from `_PanelContent.render()` (which already has `self.content_region.width`) via `_panel_markup(content_width=width)`.
- Three degradation tiers based on content width:
  - **wide** (≥54 cols): full layout unchanged — `:<24` / `:<22` / `:<28` name columns, cost + call-count always shown
  - **medium** (≥42 cols): name columns narrowed (`:<18` / `:<16` / `:<22`); tok + cost + calls still visible
  - **narrow** (<42 cols): name narrowed further (`:<14` / `:<12` / `:<18`); cost + call-count suppressed; **token total always shown**
- Budget bar: suppressed below 44 content cols (percentage readout `[nnn%]` always kept).
- `content_width=0` (pre-layout default) falls back to wide layout — no crash.

## Evidence-pack

**Narrow panel (38 content cols, below MEDIUM_THRESHOLD=42) — token total survives, cost/calls absent from BY AGENT rows:**
```
  BY AGENT / SKILL
  my-agent       48,200 tok
    skill_router 48,200 tok
  BY MODEL
  claude-sonnet-4-6  48,200 tok
```

**Wide panel (64 content cols, above WIDE_THRESHOLD=54) — full layout unchanged:**
```
  BY AGENT / SKILL
  my-agent                 48,200 tok  $0.0234  1c
    skill_router           48,200 tok  $0.0234  1c
  BY MODEL
  claude-sonnet-4-6            48,200 tok  $0.0234  1c
```

## Test plan

- [x] `pytest tests/cli/test_cost_tab_narrow_columns.py -v` — 4 Tier 2 tests pass
- [x] `pytest tests/cli/ -q -k "cost or panel"` — 82 tests pass, 0 failures
- [x] `pytest tests/cli/test_tui_smoke.py -q` — 40 tests pass, 0 failures
- [x] `ruff check src/reyn/chat/tui/widgets/right_panel/cost_tab.py tests/cli/test_cost_tab_narrow_columns.py` — clean

## Tier self-check

- Tier 2 (subsystem invariant): tests assert on `.plain` public surface of `render_cost` output; no private state accessed; no mocks.
- All 4 new tests have `"""Tier 2: ..."""` first line in docstring.
- Files touched: `cost_tab.py`, `shells.py`, `__init__.py` (cost tab wiring only), `tests/cli/test_cost_tab_narrow_columns.py`. No files outside TUI right_panel touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)