### PR TITLE
fix(fp-0008): C4 — lazy litellm import unblocks python harness (5s timeout → SIGKILL)

### DIFF
--- a/src/reyn/embedding/litellm_provider.py
+++ b/src/reyn/embedding/litellm_provider.py
@@ -20,8 +20,6 @@ import logging
 import os
 from typing import Any
 
-import litellm
-
 from reyn.embedding.provider import EmbedBatchResult
 
 logger = logging.getLogger(__name__)
@@ -296,6 +294,7 @@ class LiteLLMEmbeddingProvider:
                 wait = self._retry_backoff ** attempt
                 await asyncio.sleep(wait)
             try:
+                import litellm
                 response = await litellm.aembedding(
                     model=effective_model,
                     input=batch,

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -10,7 +10,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Coroutine, TypeVar, Union
 
 import httpx
-import litellm
 
 logger = logging.getLogger(__name__)
 from reyn.llm.json_parse import loads_lenient
@@ -417,17 +416,30 @@ class LLMToolCallResult:
 
 # Retryable: infrastructure / transient errors where the same call may succeed.
 # Non-retryable: semantic / auth / quota errors (4xx) where retry won't help.
-_RETRYABLE_LITELLM_EXCEPTIONS = (
-    litellm.exceptions.Timeout,           # request timed out
-    litellm.exceptions.APIConnectionError, # network-level connection failure
-    litellm.exceptions.ServiceUnavailableError,  # 503
-    litellm.exceptions.BadGatewayError,    # 502
-    litellm.exceptions.InternalServerError, # 500
-)
+# Resolved lazily so importing this module does not trigger `import litellm`.
+_RETRYABLE_LITELLM_EXCEPTIONS: tuple | None = None
 
 _LLM_RETRY_MAX_ATTEMPTS: int = 3   # total attempts = 1 initial + 2 retries
 _LLM_RETRY_BASE_S: float = 2.0     # first backoff: 2s → 4s → 8s (capped at 16s)
 _LLM_RETRY_MAX_BACKOFF_S: float = 16.0
+
+
+def _get_retryable_litellm_exceptions() -> tuple:
+    """Return the tuple of retryable litellm exceptions, loading litellm lazily.
+
+    Cached in _RETRYABLE_LITELLM_EXCEPTIONS after first call.
+    """
+    global _RETRYABLE_LITELLM_EXCEPTIONS
+    if _RETRYABLE_LITELLM_EXCEPTIONS is None:
+        import litellm
+        _RETRYABLE_LITELLM_EXCEPTIONS = (
+            litellm.exceptions.Timeout,           # request timed out
+            litellm.exceptions.APIConnectionError, # network-level connection failure
+            litellm.exceptions.ServiceUnavailableError,  # 503
+            litellm.exceptions.BadGatewayError,    # 502
+            litellm.exceptions.InternalServerError, # 500
+        )
+    return _RETRYABLE_LITELLM_EXCEPTIONS
 
 
 def _is_retryable_exc(exc: BaseException) -> bool:
@@ -437,7 +449,7 @@ def _is_retryable_exc(exc: BaseException) -> bool:
     Also catches httpx transport-level errors that LiteLLM may not wrap when
     the request fails before reaching the provider's HTTP response logic.
     """
-    if isinstance(exc, _RETRYABLE_LITELLM_EXCEPTIONS):
+    if isinstance(exc, _get_retryable_litellm_exceptions()):
         return True
     if isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout)):
         return True
@@ -834,6 +846,7 @@ async def call_llm(
             })
 
         async def _do_call() -> object:
+            import litellm
             try:
                 return await litellm.acompletion(
                     model=effective_model,
@@ -1056,9 +1069,11 @@ async def call_llm_tools(
         },
     })
 
-    response = await _llm_call_with_retry(
-        lambda: litellm.acompletion(**call_kwargs), effective_model, event_log
-    )
+    async def _tools_call() -> object:
+        import litellm
+        return await litellm.acompletion(**call_kwargs)
+
+    response = await _llm_call_with_retry(_tools_call, effective_model, event_log)
 
     msg = response.choices[0].message
     usage = _extract_usage(response) or TokenUsage()

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import litellm
-
 if TYPE_CHECKING:
     from reyn.events.events import EventLog
 
@@ -68,6 +66,7 @@ def get_max_input_tokens(
         Positive integer token count. Always > 0.
     """
     try:
+        import litellm
         info = litellm.get_model_info(model)
         max_input = info.get("max_input_tokens")
         if max_input and int(max_input) > 0:

--- a/src/reyn/op_runtime/judge_output.py
+++ b/src/reyn/op_runtime/judge_output.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 import json
 from typing import Any, Literal
 
-import litellm
-
 from reyn.schemas.models import JudgeOutputIROp
 
 from . import register
@@ -136,6 +134,7 @@ async def handle(
         resolved_model.split("/", 1)[1] if extra and "/" in resolved_model else resolved_model
     )
 
+    import litellm
     try:
         response = await litellm.acompletion(
             model=effective_model,

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -53,8 +53,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-import litellm
-
 from reyn.llm.json_parse import loads_lenient
 
 if TYPE_CHECKING:
@@ -101,6 +99,7 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
     if cache_key in _token_cache:
         return _token_cache[cache_key]
     try:
+        import litellm
         m = model or "gpt-3.5-turbo"
         count = litellm.token_counter(model=m, text=text or "")
         if count and count > 0:
@@ -763,6 +762,7 @@ class CompactionEngine:
             if len(parts) == 2:
                 effective_model = parts[1]
 
+        import litellm
         response = await litellm.acompletion(
             model=effective_model,
             messages=messages,
@@ -1136,6 +1136,7 @@ async def compact_step_results(
             if len(parts) == 2:
                 effective_model = parts[1]
 
+        import litellm
         response = await litellm.acompletion(
             model=effective_model,
             messages=[
@@ -1310,6 +1311,7 @@ async def compact_control_ir_results(
             if len(parts) == 2:
                 effective_model = parts[1]
 
+        import litellm
         response = await litellm.acompletion(
             model=effective_model,
             messages=[

--- a/tests/test_python_harness_no_litellm_import.py
+++ b/tests/test_python_harness_no_litellm_import.py
@@ -1,0 +1,66 @@
+"""Tier 2: python harness import does NOT load litellm (subprocess).
+
+OS invariant (FP-0008 C4):
+  Importing `reyn.kernel._python_harness` — the child-process entry point
+  for python preprocessor steps — must NOT trigger a transitive `import
+  litellm`. The litellm package takes ~8-14s to initialise; the sandboxed
+  preprocessor subprocess has a 5s timeout, so an eager litellm import
+  causes unconditional SIGKILL before any user code runs.
+
+  Verified in a fresh subprocess so that litellm already present in the
+  test process's sys.modules does not mask the bug.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+def test_harness_import_does_not_load_litellm():
+    """Tier 2: fresh subprocess import of harness leaves litellm out of sys.modules."""
+    code = (
+        "import reyn.kernel._python_harness; "
+        "import sys; "
+        "assert 'litellm' not in sys.modules, "
+        "'litellm was eagerly loaded by harness import: ' + str(sorted(k for k in sys.modules if k.startswith('litellm')))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"harness import loaded litellm (or failed).\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
+def test_harness_import_time_is_below_ceiling():
+    """Tier 2: harness import completes well under the preprocessor timeout ceiling.
+
+    Ceiling is 3.0s — generous enough to avoid flake on slow CI, but well
+    below the pre-fix ~10s and well below the 5s preprocessor timeout.
+    A regression back to the eager litellm chain would produce ~8-14s and
+    fail this guard.
+    """
+    code = (
+        "import sys, time; "
+        "t = time.time(); "
+        "import reyn.kernel._python_harness; "
+        "elapsed = time.time() - t; "
+        "assert elapsed < 3.0, f'harness import took {elapsed:.2f}s (ceiling 3.0s)'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"harness import exceeded ceiling.\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 C4 fix: eliminate litellm eager-import tax from python harness subprocess.

## Problem

`verify` phase preprocessor python steps were dying with SIGKILL before executing any user code:

```
Phase 'verify' preprocessor step[1] python ./sanitize_test_patch.py:sanitize_test_patch
timed out after 5s
```

Root cause (importtime evidence):
```
import reyn.kernel._python_harness  →  ~10.6s total (pre-fix)
  reyn/__init__.py  → from reyn.agent import Agent  (pulls full OS stack)
    → reyn.llm.llm  → import litellm  ← dominant cost: ~8-10s
```

The harness is a stdlib-only child process; it has no need for litellm at startup. The 5s preprocessor timeout was exceeded before a single line of user code ran.

## Fix — Lever 1 only (Lever 2 not needed)

Removed module-level `import litellm` from all 5 eager sites, replacing with per-function lazy `import litellm` at each call site that actually uses it:

| File | Change |
|------|--------|
| `src/reyn/llm/llm.py` | Remove top-level import; add lazy `import litellm` in `_do_call()`, `_tools_call()`, `_get_retryable_litellm_exceptions()` |
| `src/reyn/llm/model_budget.py` | Remove top-level; lazy in `get_max_input_tokens()` |
| `src/reyn/services/compaction/engine.py` | Remove top-level; lazy in `estimate_tokens()` and 3× `acompletion` call sites |
| `src/reyn/op_runtime/judge_output.py` | Remove top-level; lazy in `handle()` |
| `src/reyn/embedding/litellm_provider.py` | Remove top-level; lazy in `_embed_batch_with_retry()` |

`src/reyn/chat/error_format.py` line 21 is a **comment** only — no change needed (confirmed).

Lever 2 (lazy `reyn/__init__.py` / `reyn/kernel/__init__.py`) was **not needed**: Lever 1 alone drops harness import from ~10.6s to ~0.44s with `litellm not in sys.modules`.

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| `import reyn.kernel._python_harness` time | ~10.6s | ~0.44s |
| `'litellm' in sys.modules` after harness import | `True` | `False` |

Measurement command:
```bash
python3 -c "import sys, time; t=time.time(); import reyn.kernel._python_harness; print('harness:', round(time.time()-t,2),'s; litellm:', 'litellm' in sys.modules)"
```

## Behavior unchanged

No logic was modified — only the location of `import litellm` statements (module-top → function-local). All runtime paths that use litellm still receive it via the local lazy import when the function runs.

## No band-aid

The preprocessor timeout remains at 5s. The import tax is actually removed, not masked.

## Tests

`tests/test_python_harness_no_litellm_import.py` (Tier 2, 2 tests, no mocks):
- `test_harness_import_does_not_load_litellm`: fresh subprocess asserts `'litellm' not in sys.modules`
- `test_harness_import_time_is_below_ceiling`: loose 3.0s ceiling (well above post-fix ~0.44s, well below pre-fix ~10s)

Tier audit: 2/2 OK.

## Test plan

- [x] `python3 -c "import sys, time; t=time.time(); import reyn.kernel._python_harness; print('harness:', round(time.time()-t,2),'s; litellm:', 'litellm' in sys.modules)"` → `harness: 0.44 s; litellm: False`
- [x] `python3 -c "from reyn import Agent; print('Agent import OK')"` → `Agent import OK: <class 'reyn.agent.Agent'>` (reyn/__init__.py not touched)
- [x] `ruff check .` → All checks passed
- [x] `pytest -q tests/ -k "harness or litellm or preprocessor or python_step or llm or compaction or embedding or judge"` → 595 passed
- [x] `pytest -q tests/` → 6310 passed, 1 pre-existing failure (test_web_fetch_preview_path_ref), 5 skipped, 3 xfailed

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)