### PR TITLE
feat(fp-0008): #1056 PR1 — recursive ReynConfig schema introspection (config set/get/fields)

### DIFF
--- a/src/reyn/cli/commands/config.py
+++ b/src/reyn/cli/commands/config.py
@@ -6,8 +6,7 @@ import sys
 from pathlib import Path
 
 from reyn.config import load_config
-
-from ..templates import CONFIG_FIELDS
+from reyn.config_schema import is_valid_config_key, resolve_config_value, walk_config_schema
 
 
 def register(sub) -> None:
@@ -56,17 +55,18 @@ def run(args: argparse.Namespace) -> None:
 
 
 def _fields() -> None:
-    W_KEY, W_DEF, W_SCOPE = 18, 10, 34
-    header = f"{'Field':<{W_KEY}}  {'Default':<{W_DEF}}  {'Scope':<{W_SCOPE}}  Description"
+    """List all config fields derived from the live ReynConfig schema."""
+    import dataclasses as _dc
+    W_KEY, W_TYPE, W_DEF = 46, 14, 20
+    header = f"{'Field':<{W_KEY}}  {'Type':<{W_TYPE}}  {'Default':<{W_DEF}}  Description"
     print(header)
     print("─" * len(header))
-    for f in CONFIG_FIELDS:
-        print(f"{f['key']:<{W_KEY}}  {f['default']:<{W_DEF}}  {f['scope']:<{W_SCOPE}}  {f['desc']}")
-        print(f"{'':>{W_KEY}}  {'':>{W_DEF}}  {'':>{W_SCOPE}}  Values:  {f['values']}")
-        print(f"{'':>{W_KEY}}  {'':>{W_DEF}}  {'':>{W_SCOPE}}  Example: {f['example'].splitlines()[0]}")
-        for extra_line in f['example'].splitlines()[1:]:
-            print(f"{'':>{W_KEY}}  {'':>{W_DEF}}  {'':>{W_SCOPE}}           {extra_line}")
-        print()
+    for node in walk_config_schema():
+        default_str = repr(node.default) if node.default is not _dc.MISSING else "(required)"
+        if len(default_str) > W_DEF:
+            default_str = default_str[:W_DEF - 1] + "…"
+        kind = "(free-form dict)" if node.is_dict_leaf else node.type_repr
+        print(f"{node.key:<{W_KEY}}  {kind:<{W_TYPE}}  {default_str:<{W_DEF}}  {node.desc}")
 
 
 def _show() -> None:
@@ -86,14 +86,21 @@ def _show() -> None:
 
 
 def _get(key: str) -> None:
+    """Get a config value by dotted key.
+
+    Distinguishes "key exists with value None" from "key does not exist
+    in the schema" — the old ``getattr(config, key, None)`` conflated them.
+    """
     import yaml
     config = load_config()
-    value = getattr(config, key, None)
-    if value is None:
+    found, value = resolve_config_value(config, key)
+    if not found:
         print(f"Error: unknown config key '{key}'", file=sys.stderr)
         print("Run 'reyn config fields' to see available keys.", file=sys.stderr)
         sys.exit(1)
-    if isinstance(value, (dict, list)):
+    if value is None:
+        print("(not set)")
+    elif isinstance(value, (dict, list)):
         print(yaml.dump(value, allow_unicode=True, default_flow_style=False), end="")
     else:
         print(value)
@@ -248,10 +255,20 @@ def _migrate_mcp(*, dry_run: bool = False) -> None:
 
 
 def _set(key: str, value: str) -> None:
+    """Set a config key in reyn.local.yaml.
+
+    Validates *key* against the full ReynConfig schema (including nested
+    keys like ``safety.loop.max_phase_visits`` and free-form dict sub-keys
+    like ``mcp.servers.github.url``).
+
+    Writes the correct nested YAML structure — ``safety.loop.max_phase_visits``
+    becomes ``{safety: {loop: {max_phase_visits: <value>}}}`` rather than
+    the flat ``{safety: {'loop.max_phase_visits': <value>}}`` the old 1-level
+    split produced.
+    """
     import yaml
-    valid_keys = {f["key"] for f in CONFIG_FIELDS}
-    check_key = key.split(".")[0] if "." in key else key
-    if check_key not in valid_keys:
+
+    if not is_valid_config_key(key):
         print(f"Error: unknown config key '{key}'", file=sys.stderr)
         print("Run 'reyn config fields' to see available keys.", file=sys.stderr)
         sys.exit(1)
@@ -268,11 +285,18 @@ def _set(key: str, value: str) -> None:
     except Exception:
         parsed = value
 
-    if "." in key:
-        parent, child = key.split(".", 1)
-        current.setdefault(parent, {})[child] = parsed
-    else:
-        current[key] = parsed
+    # Recurse the dotted path through nested dicts via setdefault so that
+    # ``safety.loop.max_phase_visits`` writes {safety: {loop: {max_phase_visits: v}}}
+    # instead of {safety: {'loop.max_phase_visits': v}}.
+    parts = key.split(".")
+    node: dict = current
+    for part in parts[:-1]:
+        existing = node.get(part)
+        if not isinstance(existing, dict):
+            existing = {}
+            node[part] = existing
+        node = existing
+    node[parts[-1]] = parsed
 
     local_cfg.write_text(yaml.dump(current, allow_unicode=True, default_flow_style=False),
                          encoding="utf-8")

--- a/src/reyn/config_schema.py
+++ b/src/reyn/config_schema.py
@@ -1,0 +1,295 @@
+"""Recursive ReynConfig schema introspection.
+
+Provides :func:`walk_config_schema` which traverses the ``ReynConfig``
+dataclass hierarchy and yields :class:`SchemaNode` objects — one per
+dotted key.  Used by ``reyn config fields``, ``reyn config get``, and
+``reyn config set`` so those commands track the *real* schema rather
+than a hand-maintained ``CONFIG_FIELDS`` list.
+
+Design notes
+------------
+- **Forward-ref robustness**: ``from __future__ import annotations``
+  makes all type annotations strings.  Naively calling
+  ``typing.get_type_hints(ReynConfig)`` fails on forward refs like
+  ``'ExternalTransportRouting'`` that are lazily imported in
+  ``config.py``.  We resolve per-dataclass using the *class module's*
+  own ``__dict__`` as ``globalns``, extended with the two known
+  lazy-import types.  See :func:`_get_hints_safe`.
+
+- **Dict leaf (free-form)**: any field whose unwrapped type is ``dict``
+  or ``dict[K, V]`` is treated as a free-form dict — the operator may
+  set arbitrary sub-keys under it (e.g. ``mcp.servers.github.url``).
+  We emit a single :class:`SchemaNode` with ``is_dict_leaf=True``
+  instead of recursing.
+
+- **Scalar leaf**: any field whose unwrapped type is not a dataclass
+  and not a dict is a scalar leaf.
+
+- **None-vs-unknown**: the walk records the real default value
+  (including ``None``) so callers can distinguish "key exists, default
+  is None" from "key does not exist in schema".
+"""
+from __future__ import annotations
+
+import dataclasses
+import sys
+import types
+import typing
+from dataclasses import dataclass as _dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+@_dataclass
+class SchemaNode:
+    """One entry in the flattened config schema."""
+
+    key: str
+    """Dotted key, e.g. ``safety.loop.max_phase_visits``."""
+
+    type_repr: str
+    """Human-readable type string, e.g. ``int``, ``str | None``."""
+
+    default: Any
+    """Default value, or :data:`MISSING` if there is no static default."""
+
+    is_dict_leaf: bool = False
+    """True when this key is a free-form dict (operator sets arbitrary sub-keys)."""
+
+    desc: str = ""
+    """Description from ``field(metadata={'desc': ...})``, or empty string."""
+
+
+#: Sentinel for fields whose default can only be computed by calling
+#: ``default_factory()``.  We eagerly call the factory so this sentinel
+#: should only appear if the factory itself raises.
+MISSING: object = dataclasses.MISSING
+
+
+def walk_config_schema(cls: type | None = None) -> list[SchemaNode]:
+    """Return a flat list of :class:`SchemaNode` for every dotted key in *cls*.
+
+    *cls* defaults to :class:`~reyn.config.ReynConfig`.  Call with a
+    sub-dataclass to walk a sub-tree.
+
+    The list order is depth-first, reflecting field declaration order.
+    """
+    if cls is None:
+        from reyn.config import ReynConfig  # noqa: PLC0415
+        cls = ReynConfig
+    nodes: list[SchemaNode] = []
+    _walk(cls, prefix="", nodes=nodes, seen=set())
+    return nodes
+
+
+def is_valid_config_key(key: str) -> bool:
+    """Return True when *key* is a valid config key.
+
+    A key is valid if:
+    - It exactly matches a leaf node's dotted key, OR
+    - It starts with a dict-leaf node's dotted key followed by a ``"."``
+      (free-form sub-key, e.g. ``mcp.servers.github.url``).
+    """
+    nodes = walk_config_schema()
+    for node in nodes:
+        if node.is_dict_leaf:
+            if key == node.key or key.startswith(node.key + "."):
+                return True
+        else:
+            if key == node.key:
+                return True
+    return False
+
+
+def resolve_config_value(config: Any, key: str) -> tuple[bool, Any]:
+    """Resolve a dotted *key* against a loaded config instance.
+
+    Returns ``(found, value)`` where *found* is True when the key exists
+    in the schema.  When *found* is False, *value* is ``None``.  When
+    *found* is True, *value* may legitimately be ``None`` — callers
+    **must** use the boolean, not a None-check, to distinguish "unknown
+    key" from "key with None value".
+    """
+    if not is_valid_config_key(key):
+        return False, None
+
+    parts = key.split(".")
+    obj: Any = config
+    for part in parts:
+        if obj is None:
+            return True, None
+        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            if hasattr(obj, part):
+                obj = getattr(obj, part)
+            else:
+                # Free-form dict key that doesn't exist yet — valid key, absent value.
+                return True, None
+        elif isinstance(obj, dict):
+            obj = obj.get(part)
+        else:
+            # Scalar reached before path was exhausted — treat as absent.
+            return True, None
+    return True, obj
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _get_hints_safe(cls: type) -> dict[str, Any]:
+    """Call ``typing.get_type_hints`` robustly for *cls*.
+
+    Uses the class's own module namespace as ``globalns`` to resolve
+    forward refs declared in that module.  Adds the two known
+    lazy-imported types (``ExternalTransportRouting``,
+    ``OAuthProviderConfig``) which are not present in ``reyn.config``'s
+    module globals at import time.
+
+    Returns an empty dict on failure (= walk falls back to skipping).
+    """
+    try:
+        localns: dict[str, Any] = dict(vars(sys.modules[cls.__module__]))
+        # Patch in lazy-import types that are referenced as forward refs
+        # but not imported at the top of config.py.
+        _patch_localns(localns)
+        return typing.get_type_hints(cls, globalns=localns)
+    except Exception:
+        # Fallback: return empty so the walk skips this class cleanly
+        # rather than crashing.  Callers will log / skip silently.
+        return {}
+
+
+def _patch_localns(ns: dict[str, Any]) -> None:
+    """Inject lazy-import types that appear as forward refs in config.py."""
+    if "ExternalTransportRouting" not in ns:
+        try:
+            from reyn.chat.external_routing import ExternalTransportRouting  # noqa: PLC0415
+            ns["ExternalTransportRouting"] = ExternalTransportRouting
+        except ImportError:
+            pass
+    if "OAuthProviderConfig" not in ns:
+        try:
+            from reyn.secrets.oauth import OAuthProviderConfig  # noqa: PLC0415
+            ns["OAuthProviderConfig"] = OAuthProviderConfig
+        except ImportError:
+            pass
+
+
+def _unwrap_optional(ftype: Any) -> Any:
+    """Strip ``Optional`` / ``X | None`` wrappers.
+
+    Returns the unwrapped type if the only non-None arg exists,
+    otherwise returns *ftype* unchanged.
+    """
+    if isinstance(ftype, types.UnionType):
+        args = typing.get_args(ftype)
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+        return ftype
+    origin = getattr(ftype, "__origin__", None)
+    if origin is typing.Union:
+        args = typing.get_args(ftype)
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return ftype
+
+
+def _is_dict_type(ftype: Any) -> bool:
+    """Return True when *ftype* is any flavour of ``dict``."""
+    if ftype is dict:
+        return True
+    origin = getattr(ftype, "__origin__", None)
+    return origin is dict
+
+
+def _type_repr(ftype: Any) -> str:
+    """Return a short human-readable string for *ftype*."""
+    if hasattr(ftype, "__name__"):
+        return ftype.__name__
+    return str(ftype)
+
+
+def _field_default(f: dataclasses.Field) -> Any:  # type: ignore[type-arg]
+    """Return the best available default for a dataclass field.
+
+    Calls ``default_factory()`` when there is no static default.
+    Returns :data:`MISSING` only when both are absent.
+    """
+    if f.default is not dataclasses.MISSING:
+        return f.default
+    if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+        try:
+            return f.default_factory()  # type: ignore[misc]
+        except Exception:
+            return MISSING
+    return MISSING
+
+
+def _walk(
+    cls: type,
+    prefix: str,
+    nodes: list[SchemaNode],
+    seen: set[type],
+) -> None:
+    """Depth-first traversal of *cls* (a dataclass).
+
+    Mutates *nodes* in place.  *seen* prevents infinite recursion on
+    self-referential schemas (shouldn't occur in practice but guards
+    against it).
+    """
+    if cls in seen:
+        return
+    seen = seen | {cls}
+
+    if not dataclasses.is_dataclass(cls):
+        return
+
+    hints = _get_hints_safe(cls)
+    fields_map: dict[str, dataclasses.Field] = {  # type: ignore[type-arg]
+        f.name: f for f in dataclasses.fields(cls)
+    }
+
+    for fname, ftype in hints.items():
+        if fname not in fields_map:
+            continue
+        dc_field = fields_map[fname]
+        dotkey = f"{prefix}.{fname}" if prefix else fname
+        inner = _unwrap_optional(ftype)
+
+        if _is_dict_type(inner):
+            # Free-form dict leaf — operator may set arbitrary sub-keys.
+            desc = _field_desc(dc_field)
+            default = _field_default(dc_field)
+            nodes.append(SchemaNode(
+                key=dotkey,
+                type_repr="dict",
+                default=default,
+                is_dict_leaf=True,
+                desc=desc,
+            ))
+        elif dataclasses.is_dataclass(inner):
+            # Nested dataclass — recurse.
+            _walk(inner, prefix=dotkey, nodes=nodes, seen=seen)
+        else:
+            # Scalar leaf.
+            desc = _field_desc(dc_field)
+            default = _field_default(dc_field)
+            nodes.append(SchemaNode(
+                key=dotkey,
+                type_repr=_type_repr(inner),
+                default=default,
+                is_dict_leaf=False,
+                desc=desc,
+            ))
+
+
+def _field_desc(f: dataclasses.Field) -> str:  # type: ignore[type-arg]
+    """Extract ``desc`` from ``field(metadata={'desc': ...})``, or return ``""``."""
+    meta = getattr(f, "metadata", None)
+    if meta and isinstance(meta, typing.Mapping):
+        return str(meta.get("desc", ""))
+    return ""

--- a/tests/test_config_schema_introspection.py
+++ b/tests/test_config_schema_introspection.py
@@ -81,15 +81,61 @@ def test_walk_includes_free_form_dict_leaves() -> None:
         assert expected in dict_keys, f"{expected!r} not in dict_leaf keys: {sorted(dict_keys)}"
 
 
-def test_walk_total_nodes_covers_all_top_level_fields() -> None:
-    """Tier 2: walk produces at least as many nodes as top-level ReynConfig fields."""
+def test_walk_covers_every_top_level_field_no_silent_skip() -> None:
+    """Tier 2: every ReynConfig top-level field is represented in the walk
+    (= no section silently skipped by the forward-ref empty-hints fallback).
+
+    Drift-proof invariant (the framework's whole point): adding a config
+    field auto-reflects in ``reyn config set/get/fields``. But
+    ``_get_hints_safe`` returns ``{}`` on a forward-ref resolution failure,
+    which makes ``_walk`` emit ZERO nodes for that class — silently dropping
+    the section and re-creating the old allowlist-reject bug for a future
+    field, with NO error (the original bug, but invisible).
+
+    This test makes the drift loud: a dropped section → its field name
+    absent from the walk's top-level keys → CI fail. If a new forward-ref
+    dataclass field is added and its section disappears, this fails until
+    the type is injected in ``config_schema._patch_localns`` (PR2 will
+    auto-resolve and retire the manual injection).
+    """
     nodes = walk_config_schema()
-    top_level_count = len(dataclasses.fields(ReynConfig))
-    # Walk recurses into nested DCs, so total > top-level count
-    assert len(nodes) >= top_level_count, (
-        f"Only {len(nodes)} nodes for {top_level_count} top-level fields; "
-        "recursion may have stopped prematurely"
+    top_level = {n.key.split(".", 1)[0] for n in nodes}
+    field_names = {f.name for f in dataclasses.fields(ReynConfig)}
+    missing = field_names - top_level
+    assert not missing, (
+        f"ReynConfig fields with NO node in the schema walk (silently "
+        f"skipped — the section produced zero dotted keys): {sorted(missing)}. "
+        f"Most likely a forward-ref resolution failure dropped the section; "
+        f"inject the type in config_schema._patch_localns."
     )
+
+
+def test_walk_forward_ref_sections_produce_nested_keys() -> None:
+    """Tier 2: the forward-ref-bearing dataclass sections produce their nested
+    keys (targeted regression guard for the _patch_localns injection).
+
+    ``external_transports`` (ExternalTransportRouting) and ``auth``
+    (OAuthProviderConfig) annotate forward refs that naive get_type_hints
+    cannot resolve. If their injection in ``_patch_localns`` is dropped or a
+    new forward-ref section is added without injection, the section silently
+    yields zero nodes. This asserts each forward-ref section contributes at
+    least one dotted key under its own prefix.
+    """
+    nodes = walk_config_schema()
+    by_prefix: dict[str, int] = {}
+    for n in nodes:
+        by_prefix[n.key.split(".", 1)[0]] = by_prefix.get(n.key.split(".", 1)[0], 0) + 1
+    # Each forward-ref section must contribute >= 1 node (key under its prefix).
+    for section in ("external_transports", "auth"):
+        # Only assert if the section is a real ReynConfig field (guards against
+        # a future rename making the test silently vacuous).
+        assert section in {f.name for f in dataclasses.fields(ReynConfig)}, (
+            f"{section!r} is no longer a ReynConfig field — update this guard"
+        )
+        assert by_prefix.get(section, 0) >= 1, (
+            f"forward-ref section {section!r} produced 0 nodes — its type "
+            f"likely failed to resolve (check config_schema._patch_localns)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_schema_introspection.py
+++ b/tests/test_config_schema_introspection.py
@@ -1,0 +1,322 @@
+"""Tier 2: OS invariant — ReynConfig schema introspection (#1056 PR1).
+
+Covers:
+  - walk_config_schema() completeness (known nested key present + correct type/default)
+  - _set() writes correctly nested YAML for 3-level dotted keys
+  - _set() accepts free-form dict sub-keys (mcp, permissions, models, etc.)
+  - _get() resolves dotted paths against a real loaded config
+  - Invalid key rejection by is_valid_config_key()
+  - Forward-ref robustness: walk completes without raising
+  - None-value ≠ unknown-key: output_language default None is returned, not error
+"""
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.config import ReynConfig
+from reyn.config_schema import (
+    MISSING,
+    SchemaNode,
+    is_valid_config_key,
+    resolve_config_value,
+    walk_config_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: write a minimal reyn.yaml so load_config() has a project root
+# ---------------------------------------------------------------------------
+
+def _project_root(tmp_path: Path) -> Path:
+    """Create a minimal reyn.yaml so _find_project_root succeeds."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Walk completeness
+# ---------------------------------------------------------------------------
+
+
+def test_walk_includes_safety_loop_max_phase_visits() -> None:
+    """Tier 2: walk includes the real 3-level nested field safety.loop.max_phase_visits."""
+    nodes = walk_config_schema()
+    keys = {n.key for n in nodes}
+    assert "safety.loop.max_phase_visits" in keys, (
+        "safety.loop.max_phase_visits missing from walk — walk may not be recursing"
+    )
+
+
+def test_walk_safety_loop_max_phase_visits_type_and_default() -> None:
+    """Tier 2: safety.loop.max_phase_visits has type=int and default=25."""
+    nodes = walk_config_schema()
+    node = next(n for n in nodes if n.key == "safety.loop.max_phase_visits")
+    assert node.type_repr == "int"
+    assert node.default == 25
+    assert node.is_dict_leaf is False
+
+
+def test_walk_forward_ref_robustness() -> None:
+    """Tier 2: walk completes without raising (forward-ref eval regression guard).
+
+    ReynConfig contains forward-ref string annotations (ExternalTransportRouting,
+    ActionRetrievalConfig, OAuthProviderConfig).  Naive get_type_hints() raises;
+    the robust per-class-module resolver must not.
+    """
+    # Must not raise — if it does, forward-ref resolution is broken.
+    nodes = walk_config_schema()
+    assert len(nodes) > 0, "walk returned no nodes — catastrophic failure"
+
+
+def test_walk_includes_free_form_dict_leaves() -> None:
+    """Tier 2: known free-form dict fields are present with is_dict_leaf=True."""
+    nodes = walk_config_schema()
+    dict_keys = {n.key for n in nodes if n.is_dict_leaf}
+    # permissions, mcp, models are the three documented free-form dicts at top level
+    for expected in ("permissions", "mcp", "models"):
+        assert expected in dict_keys, f"{expected!r} not in dict_leaf keys: {sorted(dict_keys)}"
+
+
+def test_walk_total_nodes_covers_all_top_level_fields() -> None:
+    """Tier 2: walk produces at least as many nodes as top-level ReynConfig fields."""
+    nodes = walk_config_schema()
+    top_level_count = len(dataclasses.fields(ReynConfig))
+    # Walk recurses into nested DCs, so total > top-level count
+    assert len(nodes) >= top_level_count, (
+        f"Only {len(nodes)} nodes for {top_level_count} top-level fields; "
+        "recursion may have stopped prematurely"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. _set() nested write
+# ---------------------------------------------------------------------------
+
+
+def test_set_nested_three_level_produces_nested_yaml(tmp_path: Path) -> None:
+    """Tier 2: _set safety.loop.max_phase_visits writes {safety: {loop: {max_phase_visits: 50}}}."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _set
+        _set("safety.loop.max_phase_visits", "50")
+        local_yaml = root / "reyn.local.yaml"
+        assert local_yaml.exists(), "reyn.local.yaml not created by _set"
+        data = yaml.safe_load(local_yaml.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+        # Must NOT be flat {safety: {'loop.max_phase_visits': 50}}
+        assert isinstance(data.get("safety"), dict), (
+            f"safety key not a nested dict; got: {data}"
+        )
+        assert isinstance(data["safety"].get("loop"), dict), (
+            f"safety.loop not a nested dict; got: {data['safety']}"
+        )
+        assert data["safety"]["loop"].get("max_phase_visits") == 50, (
+            f"safety.loop.max_phase_visits not set correctly; got: {data}"
+        )
+        # Flat key must NOT exist (old bug: {'loop.max_phase_visits': 50})
+        assert "loop.max_phase_visits" not in data.get("safety", {}), (
+            f"Flat 'loop.max_phase_visits' key found — nested-write bug not fixed: {data}"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_set_two_level_nested_key(tmp_path: Path) -> None:
+    """Tier 2: _set cost.rate_limit_warn_ratio writes {cost: {rate_limit_warn_ratio: 0.9}}."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _set
+        _set("cost.rate_limit_warn_ratio", "0.9")
+        local_yaml = root / "reyn.local.yaml"
+        data = yaml.safe_load(local_yaml.read_text(encoding="utf-8"))
+        assert isinstance(data.get("cost"), dict)
+        assert abs(data["cost"].get("rate_limit_warn_ratio", -1) - 0.9) < 1e-9
+    finally:
+        os.chdir(old_cwd)
+
+
+# ---------------------------------------------------------------------------
+# 3. _set() free-form dict sub-key acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_set_free_form_dict_subkey_mcp(tmp_path: Path) -> None:
+    """Tier 2: mcp.servers.github.url is accepted without being enumerated."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _set
+        # Must not sys.exit — free-form sub-keys under mcp are valid
+        _set("mcp.servers.github.url", "https://api.example.com/mcp/")
+        local_yaml = root / "reyn.local.yaml"
+        data = yaml.safe_load(local_yaml.read_text(encoding="utf-8"))
+        assert isinstance(data.get("mcp"), dict)
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_set_free_form_dict_subkey_permissions(tmp_path: Path) -> None:
+    """Tier 2: permissions.shell accepts arbitrary sub-key."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _set
+        _set("permissions.shell", "allow")
+        local_yaml = root / "reyn.local.yaml"
+        data = yaml.safe_load(local_yaml.read_text(encoding="utf-8"))
+        assert data.get("permissions", {}).get("shell") == "allow"
+    finally:
+        os.chdir(old_cwd)
+
+
+# ---------------------------------------------------------------------------
+# 4. _get() dotted-path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_get_nested_key_resolves_correctly(tmp_path: Path, capsys) -> None:
+    """Tier 2: _get('safety.loop.max_phase_visits') prints the default value, not an error."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _get
+        _get("safety.loop.max_phase_visits")
+        captured = capsys.readouterr()
+        assert "25" in captured.out, (
+            f"Expected '25' in output, got: {captured.out!r}"
+        )
+        assert captured.err == "", (
+            f"Unexpected stderr: {captured.err!r}"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_get_top_level_scalar(tmp_path: Path, capsys) -> None:
+    """Tier 2: _get('model') prints 'standard'."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _get
+        _get("model")
+        captured = capsys.readouterr()
+        assert "standard" in captured.out
+        assert captured.err == ""
+    finally:
+        os.chdir(old_cwd)
+
+
+# ---------------------------------------------------------------------------
+# 5. Invalid key rejection
+# ---------------------------------------------------------------------------
+
+
+def test_is_valid_config_key_rejects_nonexistent() -> None:
+    """Tier 2: a genuinely absent key is rejected by is_valid_config_key."""
+    assert not is_valid_config_key("safety.loop.nonexistent_xyz_12345"), (
+        "Nonexistent key should be invalid"
+    )
+
+
+def test_is_valid_config_key_accepts_known_nested() -> None:
+    """Tier 2: safety.loop.max_phase_visits is accepted."""
+    assert is_valid_config_key("safety.loop.max_phase_visits")
+
+
+def test_is_valid_config_key_accepts_free_form_subkey() -> None:
+    """Tier 2: mcp.servers.github.url is accepted as a free-form sub-key."""
+    assert is_valid_config_key("mcp.servers.github.url")
+
+
+def test_set_rejects_invalid_key(tmp_path: Path) -> None:
+    """Tier 2: _set with an invalid key calls sys.exit(1)."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _set
+        with pytest.raises(SystemExit) as exc_info:
+            _set("safety.loop.totally_nonexistent_key_xyz", "42")
+        assert exc_info.value.code == 1
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_get_rejects_invalid_key(tmp_path: Path) -> None:
+    """Tier 2: _get with an invalid key calls sys.exit(1)."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _get
+        with pytest.raises(SystemExit) as exc_info:
+            _get("completely_nonexistent_key_xyz_12345")
+        assert exc_info.value.code == 1
+    finally:
+        os.chdir(old_cwd)
+
+
+# ---------------------------------------------------------------------------
+# 6. None value ≠ unknown key
+# ---------------------------------------------------------------------------
+
+
+def test_get_none_value_is_not_unknown_key(tmp_path: Path, capsys) -> None:
+    """Tier 2: output_language default=None prints '(not set)', not 'unknown key'."""
+    root = _project_root(tmp_path)
+    old_cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        from reyn.cli.commands.config import _get
+        # Should NOT sys.exit — None is a legitimate value, not an unknown key
+        _get("output_language")
+        captured = capsys.readouterr()
+        assert "unknown" not in captured.err.lower(), (
+            f"_get('output_language') treated None default as unknown key: {captured.err!r}"
+        )
+        assert "(not set)" in captured.out, (
+            f"Expected '(not set)' for None-default field, got: {captured.out!r}"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_resolve_config_value_none_not_unknown() -> None:
+    """Tier 2: resolve_config_value returns (found=True, None) for output_language, not (False, None)."""
+    config = ReynConfig()
+    found, value = resolve_config_value(config, "output_language")
+    assert found is True, "output_language should be found in schema"
+    assert value is None, f"output_language default should be None, got {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# 7. resolve_config_value contract
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_nested_key_default_value() -> None:
+    """Tier 2: resolve_config_value returns the default for safety.loop.max_phase_visits."""
+    config = ReynConfig()
+    found, value = resolve_config_value(config, "safety.loop.max_phase_visits")
+    assert found is True
+    assert value == 25
+
+
+def test_resolve_unknown_key_returns_not_found() -> None:
+    """Tier 2: resolve_config_value returns (False, None) for an absent key."""
+    config = ReynConfig()
+    found, value = resolve_config_value(config, "safety.loop.nonexistent_xyz")
+    assert found is False
+    assert value is None


### PR DESCRIPTION
**[e2e-coder]** — #1056 PR1 functional fix: replace hardcoded CONFIG_FIELDS allowlist with recursive ReynConfig schema introspection.

## Summary

Three CLI bugs fixed, all caused by the hand-maintained `CONFIG_FIELDS` list (6 entries) diverging from `ReynConfig` (31 top-level fields, ~124 dotted keys when recursed):

1. **`_set` 25-reject allowlist**: `valid_keys = {f["key"] for f in CONFIG_FIELDS}` + `check_key = key.split(".")[0]` → `safety.loop.max_phase_visits`, `cost.daily_tokens.hard_limit`, and 23 other valid keys all rejected as "unknown config key".
2. **`_set` nested-write bug**: `key.split(".", 1)` → `current.setdefault(parent, {})[child] = parsed` writes flat `{safety: {'loop.max_phase_visits': 50}}` instead of nested `{safety: {loop: {max_phase_visits: 50}}}` for 3-level keys.
3. **`_get` top-level only + None conflation**: `getattr(config, key, None)` — dotted keys return None → "unknown key"; also `output_language` (legit None default) reports as unknown.
4. **`_fields` 6-entry only**: `CONFIG_FIELDS` loop shows 6 fields instead of all 124 dotted keys.

## Design

New `src/reyn/config_schema.py`:
- `walk_config_schema(cls=ReynConfig)` — recursive depth-first walk via `dataclasses.fields()` + `get_type_hints()`.
- **Forward-ref robustness**: per-dataclass `get_type_hints(globalns=sys.modules[cls.__module__].__dict__)` patched with `ExternalTransportRouting` + `OAuthProviderConfig` (lazy-import forward refs that fail with naive global resolution — verified by lead-coder).
- **Dict leaf**: any `dict` or `dict[K, V]` typed field becomes a free-form leaf (`is_dict_leaf=True`); operator can set arbitrary sub-keys (e.g. `mcp.servers.github.url`).
- `is_valid_config_key(key)` — validates full dotted paths + free-form sub-keys.
- `resolve_config_value(config, key)` — returns `(found: bool, value)`, separating "absent key" from "key with None value".

CLI rewire in `src/reyn/cli/commands/config.py`:
- `_fields`: iterates `walk_config_schema()` (124 nodes).
- `_get`: uses `resolve_config_value()` — dotted paths work; None != unknown.
- `_set`: validates via `is_valid_config_key()`; writes nested YAML via path recursion through `setdefault`.

`CONFIG_FIELDS` import removed from `commands/config.py` (no longer referenced). List retained in `templates.py` for PR2 (desc/example metadata migration).

## P7 note

`config_schema.py` and CLI changes are pure OS/config layer — no skill-specific strings, no phase names, no artifact types. P7 clean.

## What's deferred to PR2

- `field(metadata={'desc': ..., 'example': ...})` inline migration for all ReynConfig fields
- Tier-2 contract test enforcing that every operator-facing leaf has `desc` metadata
- Generation axis (`reyn.local.yaml.example` + `reyn-yaml.md` from walk)

## Test plan

- [x] `ruff check .` — 0 errors
- [x] `python3 scripts/test_tier_audit.py --strict tests/test_config_schema_introspection.py` — 20 tests, 0 Tier-4 violations
- [x] `pytest -q tests/ -k "config"` — 305 passed
- [x] `pytest -q` (full suite) — 6375 passed, 1 pre-existing failure (`test_legacy_no_media_store_path_returns_inline_content` in `test_web_fetch_preview_path_ref.py` — exists on main)
- [x] Walk completeness: `safety.loop.max_phase_visits` in walk, type=int, default=25
- [x] Nested write: `_set("safety.loop.max_phase_visits", "50")` produces `{safety: {loop: {max_phase_visits: 50}}}` in YAML (flat key absent)
- [x] Free-form dict: `mcp.servers.github.url` accepted; `permissions.shell` accepted
- [x] `_get("safety.loop.max_phase_visits")` prints `25` (not error)
- [x] `_get("output_language")` prints `(not set)` (not "unknown key") — None-vs-unknown fix
- [x] Invalid key `safety.loop.nonexistent_xyz` → sys.exit(1) from both `_set` and `_get`
- [x] Forward-ref robustness: walk completes without raising

Refs #1056