### PR TITLE
docs(nav): remove navigation.sections to fix hidden sub-sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,6 @@ theme:
   name: material
   custom_dir: overrides
   features:
-    - navigation.sections
     - navigation.indexes
     - navigation.top
     - search.suggest


### PR DESCRIPTION
**[docs-maintainer]**

## 問題

`navigation.sections` を有効にすると、Guide のような最上位セクションがグループヘッダーとして固定描画される。その影響で 3 階層目のセクション（For skill authors → Foundation / Composition & multi-agent 等）がサイドバーに描画されず、index.md ページのみが表示されていた。

## 変更内容

- `mkdocs.yml` から `navigation.sections` を削除
- `navigation.indexes` は維持（セクションインデックスページの機能は継続）

## 期待される動作変更

| 変更前 | 変更後 |
|--------|--------|
| Guide / Reference / Concepts がグループヘッダー（固定、折りたたみ不可） | 全セクションが折りたたみ可能なツリー |
| For skill authors 配下の Foundation 等が描画されない | Foundation / Composition 等がデフォルト折りたたみで表示される |

ユーザーが要望した「デフォルト折りたたみ・クリックで展開」は維持される。

## Test plan

- [ ] サイト上で Guide → For skill authors に入り、Foundation / Composition & multi-agent 等のサブセクションがサイドバーに表示されることを確認
- [ ] Concepts セクションが折りたたみ可能なアイテムとして表示されることを確認（グループヘッダーから変更）
- [ ] `mkdocs build --strict` エラーなし（CI で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)