### PR TITLE
docs(nav): fix hidden sub-sections in custom sidebar template

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -423,6 +423,38 @@ kbd {
 .reyn-sidebar-list--top {
   margin-bottom: 12px;
 }
+.reyn-sidebar-subgroup-item {
+  margin-top: 4px;
+}
+.reyn-sidebar-subgroup > summary {
+  display: block;
+  padding: 3px 0 2px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #807B74;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.reyn-sidebar-subgroup > summary::-webkit-details-marker {
+  display: none;
+}
+.reyn-sidebar-subgroup > summary::marker {
+  display: none;
+}
+.reyn-sidebar-subgroup > summary::before {
+  content: '› ';
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 400;
+  transition: transform 150ms;
+}
+.reyn-sidebar-subgroup[open] > summary::before {
+  transform: rotate(90deg);
+}
+.reyn-sidebar-list--deep {
+  margin-left: 14px;
+}
 
 /* ---- TOC rail (reyn) ---- */
 .reyn-toc-inner {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
   name: material
   custom_dir: overrides
   features:
+    - navigation.sections
     - navigation.indexes
     - navigation.top
     - search.suggest

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -24,7 +24,21 @@
                 <span class="reyn-sidebar-group-label">{{ child.title }}</span>
                 <ul class="reyn-sidebar-list reyn-sidebar-list--nested">
                   {% for grandchild in child.children %}
-                    {% if not grandchild.children %}
+                    {% if grandchild.children %}
+                      <li class="reyn-sidebar-subgroup-item">
+                        <details class="reyn-sidebar-subgroup"{% if grandchild.active %} open{% endif %}>
+                          <summary>{{ grandchild.title }}</summary>
+                          <ul class="reyn-sidebar-list reyn-sidebar-list--deep">
+                            {% for ggchild in grandchild.children %}
+                              <li>
+                                <a href="{{ ggchild.url | url }}"
+                                  {% if ggchild.active %}class="active"{% endif %}>{{ ggchild.title }}</a>
+                              </li>
+                            {% endfor %}
+                          </ul>
+                        </details>
+                      </li>
+                    {% else %}
                       <li>
                         <a href="{{ grandchild.url | url }}"
                           {% if grandchild.active %}class="active"{% endif %}>{{ grandchild.title }}</a>


### PR DESCRIPTION
**[docs-maintainer]**

## 真因

`overrides/main.html` のカスタムテンプレートに以下のバグがあった:

```jinja
{% if not grandchild.children %}
  <li><a href="...">{{ grandchild.title }}</a></li>
{% endif %}
```

`grandchild.children` が存在するアイテム（= Foundation / Composition & multi-agent 等のサブセクション）を**全件スキップ**していた。子を持たないページ（index.md 等）だけが描画され、サブセクションは DOM に一切存在しない状態だった。

## 変更内容

### `overrides/main.html`
`grandchild.children` が存在する場合は `<details>/<summary>` でサブグループを描画するよう修正。
- デフォルト: 閉じた状態
- `grandchild.active` が True（= 現在ページがそのセクション内）: 自動展開
- ユーザーが summary クリックで開閉可能

### `docs/stylesheets/extra.css`
`reyn-sidebar-subgroup` 用スタイル追加（`›` 展開インジケーター付き、既存デザインに合わせた 12px / #807B74）。

### `mkdocs.yml`
`navigation.sections` を復元（#1087 で真因特定前に誤って削除していた）。カスタムテンプレートがサイドバーを完全置換しているため、このオプションは副作用なし。

## Test plan

- [ ] For skill authors ページで Foundation / Composition & multi-agent 等が `›` 付きサブグループとして表示される
- [ ] デフォルト閉じた状態、クリックで開閉できる
- [ ] そのサブセクション内のページを開いたとき、対応するサブグループが自動展開される
- [ ] `mkdocs build --strict` エラーなし（CI 確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)