### PR TITLE
docs(nav): make group label a link when section has index page

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -416,6 +416,13 @@ kbd {
   font-size: 12px;
   font-weight: 500;
   color: #807B74;
+  text-decoration: none;
+}
+a.reyn-sidebar-group-label:hover {
+  color: #131211;
+}
+a.reyn-sidebar-group-label.active {
+  color: #C8553D;
 }
 .reyn-sidebar-list--nested {
   margin-left: 8px;

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -20,11 +20,20 @@
         <ul class="reyn-sidebar-list">
           {% for child in item.children %}
             {% if child.children %}
+              {% set first = child.children[0] %}
+              {% set has_index = not first.children %}
               <li class="reyn-sidebar-group">
-                <span class="reyn-sidebar-group-label">{{ child.title }}</span>
+                {% if has_index %}
+                  <a class="reyn-sidebar-group-label{% if first.active %} active{% endif %}"
+                     href="{{ first.url | url }}">{{ child.title }}</a>
+                {% else %}
+                  <span class="reyn-sidebar-group-label">{{ child.title }}</span>
+                {% endif %}
                 <ul class="reyn-sidebar-list reyn-sidebar-list--nested">
                   {% for grandchild in child.children %}
-                    {% if grandchild.children %}
+                    {% if loop.first and has_index %}
+                      {# index page used as label link above — skip #}
+                    {% elif grandchild.children %}
                       <li class="reyn-sidebar-subgroup-item">
                         <details class="reyn-sidebar-subgroup"{% if grandchild.active %} open{% endif %}>
                           <summary>{{ grandchild.title }}</summary>


### PR DESCRIPTION
**[docs-maintainer]**

## 問題

`navigation.indexes` の意図（セクションラベル = インデックスページへのリンク）がカスタムテンプレートで実装されておらず、「For skill authors」ラベル（非クリック）と「For skill authors」ページリンクが二重表示されていた。

## 変更内容

### `overrides/main.html`
セクションの最初の grandchild がページ（子なし）の場合:
- ラベル `<span>` → `<a>` リンク（index ページへ）
- loop 内の重複エントリをスキップ

index ページを持たないセクションは `<span>` のまま変更なし。

### `docs/stylesheets/extra.css`
`a.reyn-sidebar-group-label` の hover / active スタイル追加。

## Test plan

- [ ] For skill authors ラベルがクリック可能になり、For skill authors インデックスページに遷移する
- [ ] ラベル直下の重複「For skill authors」ページエントリが消える
- [ ] Foundation / Composition 等のサブセクションは引き続き表示される
- [ ] index ページを持たないセクション（Getting started 等）はラベルが非クリックのまま
- [ ] `mkdocs build --strict` エラーなし（CI 確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)