### PR TITLE
docs(nav): restrict label link to index.md pages only

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -21,7 +21,7 @@
           {% for child in item.children %}
             {% if child.children %}
               {% set first = child.children[0] %}
-              {% set has_index = not first.children %}
+              {% set has_index = (not first.children) and (first.file.name == "index") %}
               <li class="reyn-sidebar-group">
                 {% if has_index %}
                   <a class="reyn-sidebar-group-label{% if first.active %} active{% endif %}"


### PR DESCRIPTION
**[docs-maintainer]**

## 問題（#1089 の潜在バグ）

`has_index = not first.children` の判定が広すぎて、`index.md` 以外のページ（CLI → run.md、Architecture → principles.md 等）でもラベルがリンク化される状態だった。デプロイ前に検出。

## 修正

```jinja
{% set has_index = (not first.children) and (first.file.name == "index") %}
```

`first.file.name == "index"` を追加し、実際の index ページのみラベルリンク化する。

| セクション | 修正前 | 修正後 |
|-----------|--------|--------|
| For skill authors (index.md あり) | リンク ✓ | リンク ✓ |
| CLI (run.md が先頭) | 誤ってリンク | span のまま ✓ |
| Architecture (principles.md が先頭) | 誤ってリンク | span のまま ✓ |

## Test plan

- [x] `mkdocs build --strict` エラーなし
- [x] For skill authors ラベル → `<a href>` (index.md あり)
- [x] CLI ラベル → `<span>` (index.md なし)
- [ ] CI 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)