### PR TITLE
fix(fp-0008): C5 — control_ir_results per-result offload (size-axis, unblocks 13236)

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -7,6 +7,8 @@ so this module stays testable and free of circular imports.
 from __future__ import annotations
 
 import json
+import uuid
+from pathlib import Path
 from typing import Any
 
 from reyn.schemas.models import (
@@ -20,6 +22,108 @@ from reyn.schemas.models import (
 
 ARTIFACT_REF_THRESHOLD = 8000  # characters; larger artifacts are stored by ref in ContextFrame
 MAX_INLINE_BOOST = 65_536  # characters; artifacts up to 64KB are still inlined (inline-boost range)
+
+# ── control_ir_result per-result offload constants (C5 — FP-0008) ──────────────
+# A single control_ir_result whose JSON serialisation exceeds
+# MAX_CONTROL_IR_RESULT_INLINE_BYTES is offloaded to a workspace scratch file.
+# The inline slot carries head+tail preview + a ref path so the LLM can
+# file.read the full content when needed. No information is lost.
+# This is orthogonal-complementary to count-axis compaction (PR-N5 / PR-N8).
+MAX_CONTROL_IR_RESULT_INLINE_BYTES: int = 8_192   # ~8KB threshold
+OFFLOAD_HEAD_CHARS: int = 2_048                    # first 2KB kept inline
+OFFLOAD_TAIL_CHARS: int = 512                      # last 0.5KB kept inline
+
+
+def _oversized_string_fields(result: dict) -> list[str]:
+    """Return field names whose string value alone exceeds the inline limit."""
+    return [
+        k for k, v in result.items()
+        if isinstance(v, str) and len(v) > MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    ]
+
+
+def offload_control_ir_result(
+    result: dict,
+    result_idx: int,
+    offload_dir: Path,
+    *,
+    events: Any = None,
+    phase: str | None = None,
+) -> dict:
+    """Offload an oversized control_ir_result to a workspace scratch file.
+
+    If the JSON-serialised *result* exceeds MAX_CONTROL_IR_RESULT_INLINE_BYTES:
+      - Full content is written to *offload_dir*/<idx>_<uid>.json.
+      - Each string field larger than the threshold is replaced inline with
+        a head+tail preview and a truncation marker referencing the offload file.
+      - A top-level ``_offload_ref`` key carries the absolute path for direct
+        file.read access.
+      - A ``control_ir_result_offloaded`` event is emitted for audit visibility.
+
+    Small results (at or below threshold) are returned unchanged (identity).
+    No information is lost: the full content is retrievable via the ref path.
+    """
+    serialized = json.dumps(result, ensure_ascii=False)
+    size_chars = len(serialized)
+    if size_chars <= MAX_CONTROL_IR_RESULT_INLINE_BYTES:
+        return result
+
+    # Write full content to workspace scratch — no information loss.
+    offload_dir.mkdir(parents=True, exist_ok=True)
+    uid = uuid.uuid4().hex[:8]
+    offload_filename = f"{result_idx:04d}_{uid}.json"
+    offload_path = offload_dir / offload_filename
+    offload_path.write_text(serialized, encoding="utf-8")
+    ref_path = str(offload_path)
+
+    # Build inline preview: copy result, replace oversized string fields
+    # with head + tail preview + truncation marker + ref path.
+    inline = dict(result)
+    large_fields = _oversized_string_fields(result)
+    for field in large_fields:
+        original = result[field]
+        head = original[:OFFLOAD_HEAD_CHARS]
+        has_tail = len(original) > OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS
+        tail = original[-OFFLOAD_TAIL_CHARS:] if has_tail else ""
+        marker = (
+            f"\n... [TRUNCATED — {len(original):,} chars total; "
+            f"full content at {ref_path}] ..."
+        )
+        inline[field] = head + marker + (f"\n[TAIL PREVIEW]\n{tail}" if tail else "")
+
+    # Top-level ref so the LLM can locate the full result with a single key.
+    inline["_offload_ref"] = ref_path
+
+    if events is not None:
+        events.emit(
+            "control_ir_result_offloaded",
+            phase=phase,
+            result_idx=result_idx,
+            original_size_chars=size_chars,
+            offload_path=ref_path,
+            large_fields=large_fields,
+        )
+
+    return inline
+
+
+def maybe_offload_control_ir_results(
+    control_ir_results: list[dict],
+    offload_dir: Path | None,
+    *,
+    events: Any = None,
+    phase: str | None = None,
+) -> list[dict]:
+    """Apply per-result offload to all control_ir_results that exceed the inline limit.
+
+    When *offload_dir* is None, results pass through unchanged (backward compat).
+    """
+    if offload_dir is None:
+        return control_ir_results
+    return [
+        offload_control_ir_result(r, i, offload_dir, events=events, phase=phase)
+        for i, r in enumerate(control_ir_results)
+    ]
 
 
 def maybe_ref_artifact(
@@ -86,10 +190,24 @@ def build_frame(
     remaining_act_turns: int | None = None,
     run_id: str | None = None,
     act_turn: int | None = None,
+    offload_dir: Path | None = None,
 ) -> ContextFrame:
     allowed_next = [c.next_phase for c in candidates]
     current_visit = visit_counts.get(phase_name, 1)
     total_steps = sum(visit_counts.values())
+
+    # C5 (FP-0008): per-result offload for oversized control_ir_results.
+    # A single result exceeding MAX_CONTROL_IR_RESULT_INLINE_BYTES is offloaded
+    # to a workspace scratch file; the inline slot carries head+tail preview +
+    # a ref path so the LLM can file.read the full content when needed.
+    # Orthogonal-complementary to count-axis compaction (PR-N5 / PR-N8).
+    raw_results = list(control_ir_results or [])
+    offloaded_results = maybe_offload_control_ir_results(
+        raw_results,
+        offload_dir,
+        events=events,
+        phase=phase_name,
+    )
 
     frame = ContextFrame(
         current_phase=phase_name,
@@ -109,7 +227,7 @@ def build_frame(
         output_language=output_language,
         model=effective_model,
         model_resolved=model_resolved,
-        control_ir_results=list(control_ir_results or []),
+        control_ir_results=offloaded_results,
         remaining_act_turns=remaining_act_turns,
     )
 

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -419,6 +419,14 @@ class OSRuntime:
         # When the act budget is exhausted, strip available ops so the LLM has
         # no ops to call and is structurally forced into a decide turn.
         effective_ops = [] if force_decide else filtered_ops
+        # C5 (FP-0008): per-result offload directory — workspace scratch path so
+        # oversized control_ir_results can be written + referenced by the LLM
+        # via a file.read op. Scoped by run_id to avoid cross-run collisions.
+        offload_dir = (
+            self.workspace.state_dir
+            / "control_ir_offload"
+            / (self.run_id or "_default")
+        )
         return build_frame(
             phase_name=current_phase,
             phase=phase_def,
@@ -437,6 +445,7 @@ class OSRuntime:
             control_ir_results=control_ir_results,
             artifact_path=artifact_path,
             remaining_act_turns=remaining_act_turns,
+            offload_dir=offload_dir,
         )
 
     # ── Phase entry + phase execution ─────────────────────────────────────────

--- a/tests/test_context_builder_per_result_offload.py
+++ b/tests/test_context_builder_per_result_offload.py
@@ -1,0 +1,333 @@
+"""Tier 2: control_ir_results per-result offload invariants (C5 — FP-0008).
+
+When a single control_ir_result's JSON serialisation exceeds
+MAX_CONTROL_IR_RESULT_INLINE_BYTES (~8KB), the OS offloads the full content
+to a workspace scratch file and replaces the inline slot with a head+tail
+preview + a ref path. The LLM can file.read the full content when needed.
+No information is lost.
+
+Covered invariants:
+1. Oversized result is bounded inline (≤ OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS +
+   marker, well under original 200K).
+2. Head preview present: inline result starts with the original head text.
+3. Ref reaches full text: reading the offload file yields the full original content.
+4. Small result passes through unchanged (identity).
+5. Multiple large results each offloaded independently.
+6. Observability: control_ir_result_offloaded event emitted with idx + original size.
+7. build_frame integration: oversized result in control_ir_results is bounded in
+   the resulting ContextFrame's control_ir_results field.
+
+Policy compliance:
+- No unittest.mock / MagicMock / AsyncMock / patch.
+- No private-state assertions.
+- Each docstring opens with ``Tier 2: ...``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.context_builder import (
+    MAX_CONTROL_IR_RESULT_INLINE_BYTES,
+    OFFLOAD_HEAD_CHARS,
+    OFFLOAD_TAIL_CHARS,
+    maybe_offload_control_ir_results,
+    offload_control_ir_result,
+)
+from reyn.events.events import EventLog
+from reyn.kernel.runtime import OSRuntime
+from reyn.schemas.models import Phase, Skill, SkillGraph
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_big_result(content_size: int = 200_000) -> dict:
+    """Build a control_ir_result with a ``content`` field of *content_size* chars."""
+    return {
+        "kind": "file.read",
+        "status": "ok",
+        "content": "A" * content_size,
+    }
+
+
+def _serialized_size(obj: dict) -> int:
+    return len(json.dumps(obj, ensure_ascii=False))
+
+
+def _make_events() -> EventLog:
+    return EventLog()
+
+
+def _one_phase_skill() -> Skill:
+    draft = Phase(
+        name="draft",
+        instructions="draft instructions",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=[],
+    )
+    return Skill(
+        name="offload_test_skill",
+        entry_phase="draft",
+        phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Oversized single result is bounded inline
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_result_is_bounded_inline(tmp_path: Path) -> None:
+    """Tier 2: oversized control_ir_result inline size is bounded after offload.
+
+    A result with a ~200K content field (>> 8KB threshold) must produce an
+    inline dict whose JSON serialisation is well under the original size —
+    specifically bounded by OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS plus
+    overhead, not the original 200K.
+    """
+    result = _make_big_result(200_000)
+    original_size = _serialized_size(result)
+    assert original_size > MAX_CONTROL_IR_RESULT_INLINE_BYTES, "precondition: result is oversized"
+
+    offload_dir = tmp_path / "offload"
+    inline = offload_control_ir_result(result, 0, offload_dir)
+
+    inline_size = _serialized_size(inline)
+    # The inline size must be well below the original (not just slightly smaller)
+    # and within a factor of 2× of (OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS) for overhead.
+    bounded_ceiling = (OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS) * 3 + 2_048  # generous overhead
+    assert inline_size < bounded_ceiling, (
+        f"inline_size={inline_size} exceeds bounded ceiling={bounded_ceiling}; "
+        f"original={original_size}"
+    )
+    assert inline_size < original_size, "inline must be smaller than original"
+
+
+# ---------------------------------------------------------------------------
+# 2. Head preview present
+# ---------------------------------------------------------------------------
+
+
+def test_head_preview_present_in_offloaded_result(tmp_path: Path) -> None:
+    """Tier 2: offloaded result retains the first OFFLOAD_HEAD_CHARS chars of the original content.
+
+    The LLM must be able to see the start of the result without a round-trip
+    file.read, so the head preview is non-negotiable.
+    """
+    original_content = "B" * 200_000
+    result = {"kind": "file.read", "status": "ok", "content": original_content}
+
+    offload_dir = tmp_path / "offload"
+    inline = offload_control_ir_result(result, 0, offload_dir)
+
+    inline_content = inline["content"]
+    expected_head = original_content[:OFFLOAD_HEAD_CHARS]
+    assert inline_content.startswith(expected_head), (
+        f"inline content does not start with the expected head preview "
+        f"(first {OFFLOAD_HEAD_CHARS} chars)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Ref reaches full text (no information loss)
+# ---------------------------------------------------------------------------
+
+
+def test_ref_reaches_full_original_content(tmp_path: Path) -> None:
+    """Tier 2: the offload file at _offload_ref contains the complete original content.
+
+    No information is lost: reading the workspace ref path yields the exact
+    same JSON as the original result dict.
+    """
+    original_content = "C" * 200_000
+    result = {"kind": "file.read", "status": "ok", "content": original_content}
+
+    offload_dir = tmp_path / "offload"
+    inline = offload_control_ir_result(result, 0, offload_dir)
+
+    ref_path = inline.get("_offload_ref")
+    assert ref_path is not None, "offloaded result must carry _offload_ref key"
+
+    # Read back and verify full content equality
+    stored_text = Path(ref_path).read_text(encoding="utf-8")
+    stored = json.loads(stored_text)
+    assert stored == result, (
+        "Offload file content does not match original result — information lost"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Small result passes through unchanged (identity)
+# ---------------------------------------------------------------------------
+
+
+def test_small_result_passes_through_unchanged(tmp_path: Path) -> None:
+    """Tier 2: a control_ir_result below MAX_CONTROL_IR_RESULT_INLINE_BYTES is returned as-is.
+
+    The offload path must be transparent for small results so only genuinely
+    oversized results incur the file write.
+    """
+    small_result = {"kind": "file.read", "status": "ok", "content": "tiny content"}
+    assert _serialized_size(small_result) <= MAX_CONTROL_IR_RESULT_INLINE_BYTES
+
+    offload_dir = tmp_path / "offload"
+    returned = offload_control_ir_result(small_result, 0, offload_dir)
+
+    assert returned is small_result, (
+        "Small result must be returned unchanged (identity) — no copy, no offload"
+    )
+    assert not offload_dir.exists(), "No offload dir should be created for small results"
+
+
+# ---------------------------------------------------------------------------
+# 5. Multiple large results each offloaded independently
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_large_results_each_offloaded(tmp_path: Path) -> None:
+    """Tier 2: two oversized control_ir_results are each offloaded to separate files.
+
+    Each result must carry its own independent _offload_ref — they must not
+    share a file (= independent offload per result).
+    """
+    result_a = _make_big_result(100_000)
+    result_b = _make_big_result(150_000)
+    # Make content distinguishable
+    result_a["content"] = "A" * 100_000
+    result_b["content"] = "B" * 150_000
+
+    offload_dir = tmp_path / "offload"
+    inline_a = offload_control_ir_result(result_a, 0, offload_dir)
+    inline_b = offload_control_ir_result(result_b, 1, offload_dir)
+
+    ref_a = inline_a.get("_offload_ref")
+    ref_b = inline_b.get("_offload_ref")
+    assert ref_a is not None and ref_b is not None, "Both results must have _offload_ref"
+    assert ref_a != ref_b, "Each result must be offloaded to a separate file"
+
+    # Verify each ref reaches the correct full original
+    stored_a = json.loads(Path(ref_a).read_text(encoding="utf-8"))
+    stored_b = json.loads(Path(ref_b).read_text(encoding="utf-8"))
+    assert stored_a == result_a, "Ref A must point at result_a"
+    assert stored_b == result_b, "Ref B must point at result_b"
+
+
+# ---------------------------------------------------------------------------
+# 6. Observability: offload event emitted
+# ---------------------------------------------------------------------------
+
+
+def test_offload_event_emitted_with_metadata(tmp_path: Path) -> None:
+    """Tier 2: offloading a large result emits control_ir_result_offloaded event.
+
+    The event carries result_idx + original_size_chars so the offload is
+    audit-visible and not silent.
+    """
+    events = _make_events()
+    original_content = "D" * 50_000
+    result = {"kind": "file.read", "status": "ok", "content": original_content}
+    original_size = _serialized_size(result)
+
+    offload_dir = tmp_path / "offload"
+    offload_control_ir_result(result, 3, offload_dir, events=events, phase="explore")
+
+    emitted = [e for e in events.all() if e.type == "control_ir_result_offloaded"]
+    (only_event,) = emitted  # exactly one offload event for one oversized result
+    ev = only_event.data
+    assert ev["result_idx"] == 3
+    assert ev["original_size_chars"] == original_size
+    assert ev["phase"] == "explore"
+    assert "offload_path" in ev
+
+
+def test_no_event_emitted_for_small_result(tmp_path: Path) -> None:
+    """Tier 2: no control_ir_result_offloaded event is emitted for a small result.
+
+    Only genuinely oversized results should trigger events (= no noise).
+    """
+    events = _make_events()
+    small = {"kind": "file.read", "status": "ok", "content": "tiny"}
+
+    offload_dir = tmp_path / "offload"
+    offload_control_ir_result(small, 0, offload_dir, events=events, phase="explore")
+
+    offload_events = [e for e in events.all() if e.type == "control_ir_result_offloaded"]
+    assert offload_events == [], "No offload event for a small result"
+
+
+# ---------------------------------------------------------------------------
+# 7. maybe_offload_control_ir_results: None offload_dir = passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_none_offload_dir_passes_results_unchanged() -> None:
+    """Tier 2: when offload_dir is None, results are returned unchanged (backward compat).
+
+    Callers that don't supply an offload_dir must see exact passthrough
+    so existing behaviour is preserved for non-OSRuntime callers.
+    """
+    results = [
+        {"kind": "file.read", "status": "ok", "content": "X" * 200_000},
+        {"kind": "file.write", "status": "ok"},
+    ]
+    returned = maybe_offload_control_ir_results(results, offload_dir=None)
+    # Must be the same list objects (passthrough, no copy)
+    assert returned is results
+
+
+# ---------------------------------------------------------------------------
+# 8. build_frame integration: oversized result is bounded in ContextFrame
+# ---------------------------------------------------------------------------
+
+
+def test_build_frame_oversized_control_ir_result_is_bounded(tmp_path: Path) -> None:
+    """Tier 2: build_frame with a real OSRuntime offloads oversized control_ir_results.
+
+    A ~200K content field in a control_ir_result must produce a bounded inline
+    entry in the resulting ContextFrame.control_ir_results. Uses a real OSRuntime
+    (tmp_path workspace, no MagicMock).
+    """
+    import pytest
+    pytest.importorskip("litellm")  # skip if litellm not installed
+
+    import os
+    os.chdir(tmp_path)
+
+    rt = OSRuntime(
+        _one_phase_skill(),
+        model="stub/model",
+        run_id="offload_integration_test",
+        workspace_base_dir=tmp_path,
+    )
+
+    big_result = _make_big_result(200_000)
+    original_size = _serialized_size(big_result)
+
+    frame = rt.build_frame(
+        "draft",
+        {"type": "input", "data": {}},
+        [],
+        "en",
+        control_ir_results=[big_result],
+    )
+
+    (inline,) = frame.control_ir_results  # exactly one result (the one we passed in)
+    inline_size = _serialized_size(inline)
+
+    bounded_ceiling = (OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS) * 3 + 2_048
+    assert inline_size < bounded_ceiling, (
+        f"Frame control_ir_results[0] inline_size={inline_size} not bounded "
+        f"(original={original_size}, ceiling={bounded_ceiling})"
+    )
+    # Ref must be present and reachable
+    ref_path = inline.get("_offload_ref")
+    assert ref_path is not None, "Offloaded result must carry _offload_ref"
+    stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
+    assert stored == big_result, "Ref file must contain the full original result"


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 v9 C5: size-axis restoration as offload-with-ref (last v9 GO blocker). Closes #1093.

## Root cause

- **#1028 (PR-N v8)**: added `cap_control_ir_result` + `MAX_CONTROL_IR_RESULT_BYTES=8_192` (per-result size cap) to `context_builder.py`.
- **#1031 (PR-N3)**: deleted that cap ("Replaces the symptom-fix static per-result cap"), substituting count-axis compaction (`compact_control_ir_results`).
- **Problem**: size-axis (single huge result) and count-axis (many results) are **orthogonal / complementary**, not substitutes. PR-N3's count-compaction keeps recent turns raw → a single 180K op result is unbounded → `13236 explore` 8.3M prompt balloon → ContextWindowExceeded.
- `grep -rn "cap_control_ir_result\|MAX_CONTROL_IR_RESULT_BYTES" src/reyn/` → **0 hits** (confirmed absent on main).

## Fix: offload-not-truncate, aligned with `maybe_ref_artifact` philosophy

PR-N3 correctly rejected static truncate (information loss). This PR restores the size axis as **per-result offload with workspace ref**:

- A `control_ir_result` whose JSON serialisation exceeds `MAX_CONTROL_IR_RESULT_INLINE_BYTES = 8_192` is written to `workspace.state_dir / "control_ir_offload" / <run_id> / <idx>_<uid>.json`.
- The inline slot carries `OFFLOAD_HEAD_CHARS = 2_048` + `OFFLOAD_TAIL_CHARS = 512` preview + truncation marker + `_offload_ref` path.
- The LLM can `file.read` the ref path to retrieve the full content. **No information is lost.**
- Orthogonal-complementary to count-axis (PR-N5 / PR-N8): both axes can coexist.

## Write-path choice: Option B (OSRuntime.build_frame derives offload_dir)

Primary evidence:
- `grep -rn "build_frame(" src/reyn/` → single non-test caller: `OSRuntime.build_frame` in `runtime.py:422`.
- `OSRuntime` already has `self.workspace.state_dir` (constructed at `__init__` line 99–103).
- `build_frame()` in `context_builder.py` is a pure function; adding an `offload_dir: Path | None` param keeps it pure and testable.
- Result: 1-line wiring in `runtime.py` (derive `offload_dir` from `workspace.state_dir`). No new write mechanism; uses existing `pathlib.Path.write_text` (same primitive as `workspace.write_file`).

Option A (act loop) was rejected: `PhaseExecutor` has no workspace access (it receives `build_frame_fn` as a callable to avoid pulling OSRuntime's dependency tree).
Option C was rejected: op results are persisted as events (JSON-lines), not as standalone file-readable JSON at a known path the LLM could directly reference.

## Constants

| Constant | Value | Notes |
|---|---|---|
| `MAX_CONTROL_IR_RESULT_INLINE_BYTES` | `8_192` | Threshold (~8KB), same as old cap |
| `OFFLOAD_HEAD_CHARS` | `2_048` | Head preview (first 2KB) |
| `OFFLOAD_TAIL_CHARS` | `512` | Tail preview (last 0.5KB) |

## Scope

**Changed**: `src/reyn/context_builder.py`, `src/reyn/kernel/runtime.py`, `tests/test_context_builder_per_result_offload.py`

**Not touched**: compaction wave files, cumulative force-close axis (#1092), any other OS module.

## Separation from #1092 (cumulative force-close)

This PR is the **present per-result size axis** only. #1092 (cumulative axis — when total `control_ir_results` across the whole phase exceeds a token budget → force-close) is post-v9 architecture and explicitly out of scope here.

## Test plan

- [x] `ruff check .` — 0 errors
- [x] `python scripts/test_tier_audit.py --strict tests/test_context_builder_per_result_offload.py` — 0 errors, 9/9 OK
- [x] `pytest -q tests/test_context_builder_per_result_offload.py` — 9/9 passed
- [x] `pytest -q tests/` — 6364 passed + 9 new = 6373 passing; 1 pre-existing failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`, confirmed pre-existing via `git stash` + re-run)
- [x] scope-guard grep: `grep -rn "cap_control_ir_result\|MAX_CONTROL_IR_RESULT_BYTES" src/reyn/` → 0 hits (no static cap revival)
- [x] Ref read-back test (`test_ref_reaches_full_original_content`): `Path(ref_path).read_text()` → `json.loads()` → `== original_result` (no info loss confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)