### PR TITLE
fix(fp-0008): C6 — verify reverts test_patch targets before apply (unblocks apply×verify test-collision loop)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -10,6 +10,11 @@ max_act_turns: 30
 
 Implement the edit plan by modifying the repository files.
 
+**Edit SOURCE files only.** The SWE-bench harness owns the test files via
+its own test patch — any edits you make to test files are automatically
+reverted before verification and will NOT count toward the solution. If the
+plan lists a test file, skip it.
+
 ## Step 1 — Read each file before editing
 
 For every file listed in the plan's edits, issue a file read op to retrieve

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -11,6 +11,10 @@ max_act_turns: 15
 Produce a concrete edit plan: a list of files to change and a description of
 what to change in each, sufficient for the apply phase to implement the fix.
 
+**Plan SOURCE files only.** The SWE-bench harness owns the test files via its
+own test patch — any edits the apply phase makes to test files are reverted
+before verification and will not count. Do not include test files in the plan.
+
 ## Context
 
 The input is either:

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -7,6 +7,45 @@ model_class: standard
 can_finish: true
 allowed_ops: [shell]
 max_act_turns: 10
+preprocessor:
+  # FP-0008 C6 Part 2: read the original swe_bench_input artifact from
+  # the workspace to access test_patch (same source as verify preprocessor).
+  # on_error: empty — if absent (unit tests), the revert step no-ops cleanly.
+  - type: run_op
+    op:
+      kind: file
+      op: read
+      path: ".reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json"
+    into: data._input_raw
+    on_error: empty
+  # Capture repo working directory (shell ops run with cwd=workspace.base_dir).
+  - type: run_op
+    op:
+      kind: shell
+      cmd: pwd
+      timeout: 5
+    into: data._repo_dir
+    on_error: empty
+  # Revert test_patch-target files to HEAD so `git diff HEAD` (Step 1)
+  # produces a source-only diff. After verify's Step 3 (test_patch reversal)
+  # these files should already be clean; this step is a belt-and-suspenders
+  # guard that ensures the final solution patch is never contaminated by
+  # apply-phase test edits, regardless of verify phase state.
+  - type: python
+    module: ./revert_test_targets.py
+    function: revert_test_targets
+    mode: safe
+    into: data._revert_result
+    output_schema:
+      type: object
+      properties:
+        reverted:
+          type: array
+          items: {type: string}
+        errors:
+          type: array
+          items: {type: object}
+      required: [reverted, errors]
 ---
 
 Produce the final output by capturing the git diff of all changes made during

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -41,6 +41,52 @@ preprocessor:
     into: data.test_patch
     output_schema:
       type: string
+  #
+  # FP-0008 C6 Step 3: capture the repo working directory.
+  # Shell ops run with cwd=workspace.base_dir (FP-0008 PR-I), so `pwd`
+  # resolves to the actual SWE-bench repo checkout path — not the
+  # process-level CWD (which may differ in concurrent benchmark runs).
+  # The result is stored at data._repo_dir for the revert step below.
+  # on_error: empty — in unit tests or contexts where shell is unavailable,
+  # the next step gracefully no-ops (no repo_dir → nothing reverted).
+  - type: run_op
+    op:
+      kind: shell
+      cmd: pwd
+      timeout: 5
+    into: data._repo_dir
+    on_error: empty
+  #
+  # FP-0008 C6 Step 4: deterministic revert of test_patch-target files.
+  # Parses `+++ b/<path>` headers from the sanitized data.test_patch and
+  # runs `git checkout HEAD -- <path>` for each target, using the repo_dir
+  # captured in Step 3. This ensures the working tree at test_patch-target
+  # paths matches HEAD before the LLM issues `git apply`, so the apply
+  # never fails with "does not match index" due to apply-phase edits.
+  #
+  # The apply phase may have edited test files (no structural prohibition).
+  # When a test_patch target was already modified by the apply LLM,
+  # `git apply test_patch` fails with "patch failed: does not match index"
+  # → verify transitions back to apply → retry loop → loop_limit_exceeded.
+  # This step breaks the loop by reverting any such contamination.
+  #
+  # Returns {"reverted": [...], "errors": [...]} — informational only.
+  # on_error: empty — absent repo_dir or empty test_patch → no-op (safe).
+  - type: python
+    module: ./revert_test_targets.py
+    function: revert_test_targets
+    mode: safe
+    into: data._revert_result
+    output_schema:
+      type: object
+      properties:
+        reverted:
+          type: array
+          items: {type: string}
+        errors:
+          type: array
+          items: {type: object}
+      required: [reverted, errors]
 ---
 
 Run the SWE-bench test patch against the current codebase to determine whether

--- a/src/reyn/stdlib/skills/swe_bench/revert_test_targets.py
+++ b/src/reyn/stdlib/skills/swe_bench/revert_test_targets.py
@@ -1,0 +1,190 @@
+"""Deterministic test-target revert for swe_bench verify phase.
+
+FP-0008 C6 — verify preprocessor reverts test_patch-target files to HEAD
+before the LLM applies the test_patch. Eliminates the apply×verify loop
+caused by the LLM editing test files that the test_patch also touches.
+
+## Problem (C6)
+
+The apply phase may edit test files (there is no structural prohibition).
+The verify phase applies the test_patch (``git apply test_patch``), which
+also modifies those test files.  When the apply LLM has already written to
+a file the test_patch targets, ``git apply`` fails with
+``error: patch failed: <path>: does not match index`` — the patch context
+no longer matches the working tree.  The verify phase then transitions back
+to apply, which re-edits, re-triggers the same failure, and the cycle
+repeats until ``loop_limit_exceeded``.
+
+## Fix (deterministic, in the preprocessor)
+
+This module is the deterministic corrective step. It runs as a
+``type: python`` preprocessor step in verify BEFORE the LLM call,
+after the test_patch sanitizer step (which guarantees
+``data.test_patch`` is a clean string).
+
+Steps:
+1. Parse ``+++ b/<path>`` diff header lines from ``data.test_patch``.
+   Excludes ``/dev/null`` (= new-file targets that cannot be reverted).
+2. For each target path, run ``git checkout HEAD -- <path>`` in the
+   repo's working directory (= ``data._repo_dir.stdout``, captured by
+   a preceding ``run_op: shell: cmd: pwd`` step that runs with
+   ``cwd=workspace.base_dir``).
+3. Return a summary dict with the reverted paths and any per-path errors.
+   The ``into:`` target (``data._revert_result``) is informational only.
+
+## Graceful no-op (on_error: empty discipline)
+
+The preprocessor step has ``on_error: empty`` as its fallback. The
+function MUST NOT raise on absent/non-string inputs, missing repo_dir,
+or empty test_patch — it returns ``{"reverted": [], "errors": []}`` so
+the preprocessor treats it as an enrichment step, not a hard gate.
+
+## Repo-dir determination
+
+The repo working directory is captured by a preceding ``run_op`` shell
+step (``cmd: pwd``) whose output is stored at ``data._repo_dir``. Because
+shell ops run with ``cwd=ctx.workspace.base_dir`` (FP-0008 PR-I), this
+resolves to the actual SWE-bench repo checkout path, regardless of the
+process-level CWD.
+
+The python subprocess (this module) inherits the process CWD, which in
+concurrent benchmark runs may be the launch directory — NOT workspace
+base_dir. Threading the repo_dir via the artifact is therefore mandatory
+for correctness.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from typing import Any, Mapping
+
+
+def _parse_test_patch_targets(test_patch: str) -> list[str]:
+    """Return repository-relative paths targeted by ``+++ b/<path>`` lines.
+
+    Skips ``/dev/null`` (= deleted-file targets that do not exist on disk)
+    and blank paths.  Returns a deduplicated, insertion-order-preserving list.
+    """
+    targets: list[str] = []
+    seen: set[str] = set()
+    for line in test_patch.splitlines():
+        # Match "+++ b/<path>" or "+++ <path>" (some diffs omit the "b/" prefix)
+        m = re.match(r"^\+\+\+ b?/?(.*)", line)
+        if not m:
+            continue
+        path = m.group(1).strip()
+        # Exclude sentinel paths
+        if not path or path == "/dev/null" or path.startswith("dev/null"):
+            continue
+        if path not in seen:
+            seen.add(path)
+            targets.append(path)
+    return targets
+
+
+def revert_test_targets(data: Mapping[str, Any]) -> dict:
+    """Revert test_patch-target files to HEAD before the LLM applies the patch.
+
+    Reads the sanitized ``data.test_patch`` and the repo dir from
+    ``data._repo_dir.stdout`` (injected by the preceding ``run_op: shell: pwd``
+    preprocessor step).  Runs ``git checkout HEAD -- <paths>`` for each target.
+
+    Returns a dict::
+
+        {
+            "reverted": ["<path>", ...],   # paths successfully reverted
+            "errors":   [{"path": ..., "error": ...}, ...]  # per-path errors
+        }
+
+    Always returns a dict — never raises (graceful no-op on any missing input).
+    """
+    empty_result: dict = {"reverted": [], "errors": []}
+
+    # ── Extract test_patch ────────────────────────────────────────────────────
+    # Priority chain mirrors sanitize_test_patch.py (P5 workspace passthrough):
+    # 1. data._input_raw.content  — workspace JSON (verify & report phases)
+    # 2. data.data.test_patch     — inner data dict (verify phase after sanitize)
+    # 3. top-level test_patch     — flat unit-test direct-call shape
+    inner_data: Any = data.get("data") or {}
+    test_patch: str | None = None
+
+    # Priority 1: workspace passthrough — same source as sanitize_test_patch
+    if isinstance(inner_data, dict):
+        input_raw = inner_data.get("_input_raw")
+        if isinstance(input_raw, dict):
+            content = input_raw.get("content")
+            if isinstance(content, str) and content.strip():
+                try:
+                    parsed = json.loads(content)
+                    test_patch = (parsed.get("data") or {}).get("test_patch")
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+
+    # Priority 2: inner data.test_patch (verify phase: sanitizer already wrote it)
+    if not isinstance(test_patch, str) or not test_patch:
+        if isinstance(inner_data, dict):
+            test_patch = inner_data.get("test_patch")
+
+    # Priority 3: top-level test_patch (flat unit-test direct-call shape)
+    if not isinstance(test_patch, str) or not test_patch:
+        test_patch = data.get("test_patch")  # type: ignore[assignment]
+
+    if not isinstance(test_patch, str) or not test_patch.strip():
+        # No test_patch → nothing to revert
+        return empty_result
+
+    # ── Extract repo_dir from the pwd shell run_op result ────────────────────
+    repo_dir: str | None = None
+    if isinstance(inner_data, dict):
+        repo_dir_raw = inner_data.get("_repo_dir")
+        if isinstance(repo_dir_raw, dict):
+            stdout = repo_dir_raw.get("stdout", "")
+            if isinstance(stdout, str):
+                repo_dir = stdout.strip()
+
+    # Flat dict fallback (unit-test direct-call shape)
+    if not repo_dir:
+        flat_repo_dir = data.get("_repo_dir")  # type: ignore[call-overload]
+        if isinstance(flat_repo_dir, str):
+            repo_dir = flat_repo_dir.strip()
+        elif isinstance(flat_repo_dir, dict):
+            stdout = flat_repo_dir.get("stdout", "")
+            if isinstance(stdout, str):
+                repo_dir = stdout.strip()
+
+    if not repo_dir:
+        # No repo_dir available — cannot revert safely (would use wrong cwd)
+        return empty_result
+
+    # ── Parse targets ─────────────────────────────────────────────────────────
+    targets = _parse_test_patch_targets(test_patch)
+    if not targets:
+        return empty_result
+
+    # ── Revert each target ────────────────────────────────────────────────────
+    reverted: list[str] = []
+    errors: list[dict] = []
+
+    for path in targets:
+        try:
+            result = subprocess.run(
+                ["git", "checkout", "HEAD", "--", path],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode == 0:
+                reverted.append(path)
+            else:
+                # Non-zero exit: path may not exist in HEAD (new test file),
+                # or may already be clean — treat as non-fatal.
+                errors.append({
+                    "path": path,
+                    "error": (result.stderr or result.stdout or "").strip()[:200],
+                })
+        except (subprocess.TimeoutExpired, OSError, ValueError) as exc:
+            errors.append({"path": path, "error": str(exc)[:200]})
+
+    return {"reverted": reverted, "errors": errors}

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -50,6 +50,17 @@ permissions:
       function: sanitize_test_patch
       mode: safe
       timeout: 5
+    # FP-0008 C6: deterministic revert of test_patch-target files to HEAD.
+    # Runs as a `safe`-mode python preprocessor step in the verify phase,
+    # AFTER the sanitizer (which guarantees data.test_patch is a clean string).
+    # Parses `+++ b/<path>` targets from the sanitized test_patch and runs
+    # `git checkout HEAD -- <path>` for each, using the repo_dir captured by
+    # the preceding `run_op: shell: cmd: pwd` step. Breaks the
+    # apply×verify loop caused by the LLM editing test files.
+    - module: ./revert_test_targets.py
+      function: revert_test_targets
+      mode: safe
+      timeout: 30
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---

--- a/tests/test_swe_bench_verify_revert_test_targets.py
+++ b/tests/test_swe_bench_verify_revert_test_targets.py
@@ -1,0 +1,544 @@
+"""Tier 2: FP-0008 C6 — verify preprocessor reverts test_patch targets before apply.
+
+Root cause: the apply phase may edit test files (no structural prohibition).
+The verify phase's ``git apply test_patch`` then fails with
+``error: patch failed: <path>: does not match index`` because the apply LLM
+modified a file the test_patch also targets.  Verify transitions back to
+apply → retry loop → ``loop_limit_exceeded``.
+
+Fix shape (C6, deterministic per PR-N15/C2 pattern):
+  - verify.md preprocessor gains two new steps (after sanitize_test_patch):
+    1. ``run_op: shell: cmd: pwd`` → ``data._repo_dir`` (workspace cwd)
+    2. ``python: revert_test_targets`` → ``data._revert_result``
+       Parses ``+++ b/<path>`` targets from ``data.test_patch`` and runs
+       ``git checkout HEAD -- <path>`` for each, using the repo_dir captured
+       by step 1 (correct cwd, safe for concurrent benchmarks).
+  - report.md gains the same revert preprocessor so ``git diff HEAD``
+    produces a source-only patch.
+  - apply.md / plan.md gain a source-only domain rule (Part 3 nudge).
+
+This file pins:
+  A. The revert mechanism (real git repo fixture, real subprocess, no mocks):
+     working-tree test-file contamination → revert → ``git apply`` succeeds.
+  B. The final-diff mechanism: source edit present, test-target edit present
+     → after revert, ``git diff HEAD`` contains source path, not test path.
+  C. No-op safety: empty test_patch / clean tree → graceful no-op (no error).
+  D. Target parsing: ``_parse_test_patch_targets`` extracts correct paths.
+  E. verify.md preprocessor has the pwd + revert steps in the right order.
+  F. report.md preprocessor has the revert step.
+  G. apply.md + plan.md have the source-only domain rule.
+
+Tier rule discipline:
+  - Every test docstring opens with ``Tier 2:``.
+  - Real git repo via ``tmp_path`` (git init + commit + modify).
+  - Real subprocess git + real files. No MagicMock / AsyncMock / patch.
+  - No private-state assertions.
+  - No format pinning (no ``len(x) == N`` assertions on algorithm internals).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+# ── Git repo fixture ──────────────────────────────────────────────────────────
+
+
+def _git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a git command in ``cwd``; raise on non-zero unless ``check=False``."""
+    return subprocess.run(
+        ["git"] + args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    """Create a git repo with one source file and one test file committed.
+
+    Returns the repo root path.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-b", "main"], cwd=repo)
+    _git(["config", "user.email", "test@test.com"], cwd=repo)
+    _git(["config", "user.name", "Test User"], cwd=repo)
+    # Source file
+    (repo / "mymod.py").write_text("def foo():\n    return 1\n")
+    # Test file
+    (repo / "test_mymod.py").write_text("def test_foo():\n    assert foo() == 1\n")
+    _git(["add", "mymod.py", "test_mymod.py"], cwd=repo)
+    _git(["commit", "-m", "initial"], cwd=repo)
+    return repo
+
+
+def _make_test_patch(repo: Path) -> str:
+    """Build a minimal unified diff that touches ``test_mymod.py``."""
+    return (
+        "diff --git a/test_mymod.py b/test_mymod.py\n"
+        "--- a/test_mymod.py\n"
+        "+++ b/test_mymod.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " def test_foo():\n"
+        "     assert foo() == 1\n"
+        "+    assert foo() != 2\n"
+    )
+
+
+# ── Test A: revert mechanism unblocks git apply ───────────────────────────────
+
+
+def test_revert_unblocks_git_apply(tmp_path: pytest.TempdirFactory) -> None:
+    """Tier 2: Part 1 — contaminated test file reverted; git apply then succeeds.
+
+    Simulates the C6 defect:
+    1. Repo committed with test_mymod.py at HEAD.
+    2. Apply phase contaminates the file (writes different content).
+    3. test_patch targets test_mymod.py — without revert, ``git apply`` fails.
+    4. After revert_test_targets, the file is back at HEAD content.
+    5. ``git apply <test_patch>`` now succeeds (returncode 0).
+
+    This directly proves the loop-unblock: verify can proceed instead of
+    transitioning back to apply.
+    """
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    repo = _setup_repo(tmp_path)
+    test_patch = _make_test_patch(repo)
+
+    # Simulate apply-phase contamination: write different content to the test file
+    (repo / "test_mymod.py").write_text(
+        "# apply-phase contamination\n"
+        "def test_foo():\n"
+        "    assert foo() == 99  # wrong, apply LLM wrote this\n"
+    )
+
+    # Verify that git apply FAILS before the revert (proves the defect)
+    patch_file = repo / ".reyn_test.patch"
+    patch_file.write_text(test_patch)
+    pre_result = subprocess.run(
+        ["git", "apply", "--check", str(patch_file)],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert pre_result.returncode != 0, (
+        "Pre-condition: git apply must fail on contaminated test file. "
+        f"Unexpectedly succeeded; test_patch may not target test_mymod.py. "
+        f"stderr: {pre_result.stderr}"
+    )
+
+    # Run the revert function (the C6 fix)
+    result = revert_test_targets({
+        "test_patch": test_patch,
+        "_repo_dir": str(repo),
+    })
+
+    # Assert test file is back at HEAD content
+    head_content = (repo / "test_mymod.py").read_text()
+    assert "apply-phase contamination" not in head_content, (
+        "test_mymod.py must be reverted to HEAD — contamination still present. "
+        f"Content: {head_content!r}"
+    )
+    assert "def test_foo" in head_content, (
+        "test_mymod.py must contain the original HEAD content after revert. "
+        f"Content: {head_content!r}"
+    )
+
+    # Assert revert function reported success
+    assert "test_mymod.py" in result["reverted"], (
+        f"revert_test_targets must report test_mymod.py as reverted. "
+        f"result['reverted']: {result['reverted']}"
+    )
+
+    # Assert git apply NOW SUCCEEDS — this is the loop-unblock proof
+    post_result = subprocess.run(
+        ["git", "apply", str(patch_file)],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert post_result.returncode == 0, (
+        "After revert, git apply <test_patch> must succeed (returncode 0). "
+        f"This proves the apply×verify loop is unblocked. "
+        f"returncode={post_result.returncode}, stderr={post_result.stderr!r}"
+    )
+
+
+# ── Test B: final diff excludes test-target path ─────────────────────────────
+
+
+def test_final_diff_excludes_test_target(tmp_path: pytest.TempdirFactory) -> None:
+    """Tier 2: Part 2 — final diff is source-only after revert.
+
+    Working tree has BOTH a source edit (mymod.py) and a test-target edit
+    (test_mymod.py, simulating apply-phase contamination).
+    After revert_test_targets, the diff must contain the source path and
+    must NOT contain the test-target path.
+    """
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    repo = _setup_repo(tmp_path)
+    test_patch = _make_test_patch(repo)
+
+    # Edit source file (legitimate fix)
+    (repo / "mymod.py").write_text("def foo():\n    return 2  # fixed\n")
+    # Edit test file (apply-phase contamination, should be excluded)
+    (repo / "test_mymod.py").write_text(
+        "def test_foo():\n    assert foo() == 2  # contamination\n"
+    )
+
+    # Verify both files are dirty before revert
+    diff_before = subprocess.run(
+        ["git", "diff", "HEAD"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "mymod.py" in diff_before, "Pre-condition: source file must be modified"
+    assert "test_mymod.py" in diff_before, "Pre-condition: test file must be modified"
+
+    # Run revert (reverting only the test_patch-targeted file)
+    result = revert_test_targets({
+        "test_patch": test_patch,
+        "_repo_dir": str(repo),
+    })
+    assert "test_mymod.py" in result["reverted"], (
+        f"test_mymod.py must be reported as reverted. result={result}"
+    )
+
+    # Capture the final diff after revert
+    diff_after = subprocess.run(
+        ["git", "diff", "HEAD"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    # Source path must still be in the diff
+    assert "mymod.py" in diff_after, (
+        "Final diff must contain the source edit (mymod.py). "
+        f"diff_after: {diff_after!r}"
+    )
+    # Test-target path must NOT be in the diff
+    assert "test_mymod.py" not in diff_after, (
+        "Final diff must NOT contain the test-target path (test_mymod.py) "
+        "after revert. The solution patch must be source-only. "
+        f"diff_after: {diff_after!r}"
+    )
+
+
+# ── Test C: no-op safety ──────────────────────────────────────────────────────
+
+
+def test_no_op_on_empty_test_patch() -> None:
+    """Tier 2: Part 1 — empty/absent test_patch → graceful no-op, no error."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    result = revert_test_targets({"test_patch": "", "_repo_dir": "/nonexistent"})
+    assert result == {"reverted": [], "errors": []}, (
+        f"Empty test_patch must produce empty result without error. "
+        f"Got: {result}"
+    )
+
+
+def test_no_op_on_absent_test_patch() -> None:
+    """Tier 2: no test_patch field → graceful no-op, no error."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    result = revert_test_targets({"instance_id": "test-1"})
+    assert result == {"reverted": [], "errors": []}, (
+        f"Absent test_patch must produce empty result without error. "
+        f"Got: {result}"
+    )
+
+
+def test_no_op_on_missing_repo_dir() -> None:
+    """Tier 2: no _repo_dir → graceful no-op (cannot revert without cwd)."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    test_patch = (
+        "diff --git a/tests/test_x.py b/tests/test_x.py\n"
+        "+++ b/tests/test_x.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n+new\n"
+    )
+    result = revert_test_targets({"test_patch": test_patch})
+    assert result == {"reverted": [], "errors": []}, (
+        f"Missing _repo_dir must produce empty result without error. "
+        f"Got: {result}"
+    )
+
+
+def test_no_op_on_clean_tree(tmp_path: pytest.TempdirFactory) -> None:
+    """Tier 2: clean working tree → revert runs without error (checkout is a no-op)."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    repo = _setup_repo(tmp_path)
+    test_patch = _make_test_patch(repo)
+
+    # Working tree is clean (no contamination)
+    result = revert_test_targets({
+        "test_patch": test_patch,
+        "_repo_dir": str(repo),
+    })
+    # Should succeed (git checkout HEAD -- on an already-clean file is a no-op)
+    assert isinstance(result, dict), "Result must be a dict"
+    assert "reverted" in result and "errors" in result, (
+        f"Result must have 'reverted' and 'errors' keys. Got: {result}"
+    )
+    # No errors expected when tree is clean
+    assert not result["errors"], (
+        f"No errors expected on a clean tree. Got errors: {result['errors']}"
+    )
+
+
+# ── Test D: target parsing ────────────────────────────────────────────────────
+
+
+def test_parse_targets_extracts_plus_plus_plus_paths() -> None:
+    """Tier 2: _parse_test_patch_targets extracts +++ b/<path> headers correctly."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import _parse_test_patch_targets
+
+    patch = (
+        "diff --git a/tests/test_foo.py b/tests/test_foo.py\n"
+        "--- a/tests/test_foo.py\n"
+        "+++ b/tests/test_foo.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n+new\n"
+        "diff --git a/tests/test_bar.py b/tests/test_bar.py\n"
+        "--- a/tests/test_bar.py\n"
+        "+++ b/tests/test_bar.py\n"
+        "@@ -1 +1 @@\n"
+        "-a\n+b\n"
+    )
+    targets = _parse_test_patch_targets(patch)
+    assert "tests/test_foo.py" in targets, (
+        f"Must extract tests/test_foo.py. Got: {targets}"
+    )
+    assert "tests/test_bar.py" in targets, (
+        f"Must extract tests/test_bar.py. Got: {targets}"
+    )
+
+
+def test_parse_targets_excludes_dev_null() -> None:
+    """Tier 2: _parse_test_patch_targets skips /dev/null targets (new files)."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import _parse_test_patch_targets
+
+    patch = (
+        "diff --git a/tests/test_new.py b/tests/test_new.py\n"
+        "--- /dev/null\n"
+        "+++ b/tests/test_new.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+new file\n"
+    )
+    targets = _parse_test_patch_targets(patch)
+    # /dev/null is the "from" side; the "+++ b/tests/test_new.py" is still a target
+    # (it's a new file, but it exists after the patch — reverts are safe)
+    # The "/dev/null" itself should not appear in targets
+    assert "/dev/null" not in targets, (
+        f"/dev/null must not appear in parsed targets. Got: {targets}"
+    )
+
+
+def test_parse_targets_deduplicates() -> None:
+    """Tier 2: _parse_test_patch_targets deduplicates repeated paths."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import _parse_test_patch_targets
+
+    # Same file appears twice (unusual but possible in some edge-case patches)
+    patch = (
+        "+++ b/tests/test_foo.py\n"
+        "+++ b/tests/test_foo.py\n"
+    )
+    targets = _parse_test_patch_targets(patch)
+    assert targets.count("tests/test_foo.py") == 1, (
+        f"Deduplicated path must appear exactly once. Got: {targets}"
+    )
+
+
+def test_parse_targets_empty_patch_returns_empty() -> None:
+    """Tier 2: _parse_test_patch_targets returns empty list for empty patch."""
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import _parse_test_patch_targets
+
+    targets = _parse_test_patch_targets("")
+    assert targets == [], f"Empty patch must produce empty target list. Got: {targets}"
+
+
+# ── Test E: verify.md preprocessor has pwd + revert steps ────────────────────
+
+
+def test_verify_md_has_pwd_step_before_revert_step() -> None:
+    """Tier 2: verify.md preprocessor has a pwd shell step before the revert python step.
+
+    The revert_test_targets function requires data._repo_dir (from `pwd`) to
+    know the correct cwd. The pwd step must precede the revert step.
+    """
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+
+    # Both steps must be present
+    assert "cmd: pwd" in verify_md, (
+        "verify.md must contain a 'cmd: pwd' preprocessor step to capture repo_dir"
+    )
+    assert "revert_test_targets" in verify_md, (
+        "verify.md must reference the revert_test_targets function"
+    )
+
+    # pwd must appear before revert
+    pwd_pos = verify_md.find("cmd: pwd")
+    revert_pos = verify_md.find("revert_test_targets")
+    assert pwd_pos < revert_pos, (
+        "The 'cmd: pwd' step must appear BEFORE 'revert_test_targets' in "
+        "verify.md preprocessor so that data._repo_dir is available when revert runs. "
+        f"pwd_pos={pwd_pos}, revert_pos={revert_pos}"
+    )
+
+
+def test_verify_md_revert_step_has_on_error_empty() -> None:
+    """Tier 2: verify.md revert preprocessor step is graceful (on_error: empty discipline).
+
+    The revert step must be fault-tolerant — in unit tests or when the repo_dir
+    is unavailable, it must not crash the preprocessor.
+    """
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    # The _repo_dir shell step (pwd) must have on_error: empty
+    assert "on_error: empty" in verify_md, (
+        "verify.md must have at least one 'on_error: empty' for the pwd / revert steps"
+    )
+
+
+def test_verify_md_revert_into_path() -> None:
+    """Tier 2: verify.md revert step stores result at data._revert_result."""
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    assert "data._revert_result" in verify_md, (
+        "verify.md revert step must use 'into: data._revert_result' "
+        "so the result is stored in the artifact for debugging"
+    )
+
+
+def test_verify_md_repo_dir_into_path() -> None:
+    """Tier 2: verify.md pwd step stores result at data._repo_dir."""
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    assert "data._repo_dir" in verify_md, (
+        "verify.md must store pwd result at 'into: data._repo_dir' "
+        "so revert_test_targets can read it"
+    )
+
+
+# ── Test F: report.md preprocessor has the revert step ───────────────────────
+
+
+def test_report_md_has_revert_step() -> None:
+    """Tier 2: report.md preprocessor has the revert_test_targets step.
+
+    Part 2: the report phase must also revert test_patch targets before
+    issuing ``git diff HEAD``, ensuring the final solution patch is
+    source-only even if verify's Step 3 left residual state.
+    """
+    report_md = (_SKILL_ROOT / "phases" / "report.md").read_text(encoding="utf-8")
+    assert "revert_test_targets" in report_md, (
+        "report.md must reference the revert_test_targets function in its preprocessor"
+    )
+    assert "preprocessor:" in report_md, (
+        "report.md must have a preprocessor block"
+    )
+
+
+def test_report_md_reads_workspace_input() -> None:
+    """Tier 2: report.md preprocessor reads workspace _input to get test_patch.
+
+    The verify_state artifact doesn't carry test_patch; the report preprocessor
+    must read it from the workspace _input artifact (same source as verify).
+    """
+    report_md = (_SKILL_ROOT / "phases" / "report.md").read_text(encoding="utf-8")
+    assert "swe_bench/_input/v01_swe_bench_input.json" in report_md, (
+        "report.md must reference the workspace _input artifact path to access test_patch"
+    )
+
+
+# ── Test G: apply.md + plan.md have source-only rule ─────────────────────────
+
+
+def test_apply_md_has_source_only_rule() -> None:
+    """Tier 2: apply.md has the source-only domain rule (Part 3 nudge).
+
+    The rule must indicate that the SWE-bench harness owns test files and that
+    edits to test files are reverted. This is a domain rule (P8-legal), not a
+    Control-IR instruction.
+    """
+    apply_md = (_SKILL_ROOT / "phases" / "apply.md").read_text(encoding="utf-8")
+    assert "SOURCE files only" in apply_md or "source files only" in apply_md.lower(), (
+        "apply.md must contain the 'SOURCE files only' domain rule"
+    )
+    # Must mention that test edits are reverted / won't count
+    assert "reverted" in apply_md or "harness owns" in apply_md, (
+        "apply.md source-only rule must mention that test edits are reverted "
+        "or that the harness owns test files"
+    )
+
+
+def test_plan_md_has_source_only_rule() -> None:
+    """Tier 2: plan.md has the source-only domain rule (Part 3 nudge).
+
+    The planner must be instructed not to include test files in the edit plan.
+    """
+    plan_md = (_SKILL_ROOT / "phases" / "plan.md").read_text(encoding="utf-8")
+    assert "SOURCE files only" in plan_md or "source files only" in plan_md.lower(), (
+        "plan.md must contain the 'SOURCE files only' domain rule"
+    )
+
+
+# ── Test: revert with full artifact shape (verify phase shape) ────────────────
+
+
+def test_revert_reads_from_inner_data_test_patch(
+    tmp_path: pytest.TempdirFactory,
+) -> None:
+    """Tier 2: revert_test_targets reads test_patch from inner data dict.
+
+    In the verify phase, after sanitize_test_patch runs, data.test_patch
+    is set in the inner data dict (full artifact shape). This test ensures
+    the function uses it correctly.
+    """
+    from reyn.stdlib.skills.swe_bench.revert_test_targets import revert_test_targets
+
+    repo = _setup_repo(tmp_path)
+    test_patch = _make_test_patch(repo)
+
+    # Contaminate the test file
+    (repo / "test_mymod.py").write_text("# contaminated\ndef test_foo(): pass\n")
+
+    # Full artifact shape (as seen in verify phase after sanitize_test_patch)
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test-1",
+            "files_edited": ["mymod.py"],
+            "attempt": 1,
+            "test_patch": test_patch,   # set by sanitize_test_patch into: data.test_patch
+            "_repo_dir": {              # set by run_op: shell: cmd: pwd
+                "status": "ok",
+                "stdout": str(repo),
+                "stderr": "",
+                "returncode": 0,
+            },
+        },
+    }
+    result = revert_test_targets(artifact)
+    assert "test_mymod.py" in result["reverted"], (
+        f"Must revert test_mymod.py from full artifact shape. result={result}"
+    )
+    head_content = (repo / "test_mymod.py").read_text()
+    assert "contaminated" not in head_content, (
+        "test_mymod.py must be at HEAD content after revert via full artifact shape"
+    )


### PR DESCRIPTION
**[e2e-coder]** — v9 GO blocker C6: structural fix for the apply×verify loop caused by the LLM editing test files that the test_patch also targets.

## Summary

- **Defect (C6, unmasked by C5 #1094)**: The apply phase lets the LLM edit test files. The verify phase's `git apply <test_patch>` fails with `error: patch failed: <path>: does not match index` when the apply LLM has already modified a file the test_patch targets → verify transitions back to apply → same failure → `loop_limit_exceeded`. Confirmed in 3 instances: 13453 (test_html.py), 14096 (test_sky_coord.py), 13236 (loop_limit_exceeded, patch failed test_mixin.py:697).
- **Fix**: Deterministic preprocessor revert + source-only nudge. Three parts:
  1. **Part 1 (CORE)**: verify.md preprocessor gains a `run_op shell pwd` step (captures workspace.base_dir correctly for concurrent benchmarks, since shell ops run with `cwd=ctx.workspace.base_dir` per PR-I) + a `python revert_test_targets` step that parses `+++ b/<path>` headers from the sanitized test_patch and runs `git checkout HEAD -- <path>` for each, in the repo dir. Runs BEFORE the LLM calls `git apply`, so the working tree at test_patch-target paths always matches HEAD.
  2. **Part 2**: report.md preprocessor reverts test_patch targets before `git diff HEAD` → source-only final patch (belt-and-suspenders; also prevents LLM test edits from landing in the submitted model_patch).
  3. **Part 3**: apply.md + plan.md gain a source-only domain rule (P8-legal: describes WHAT/domain, not Control-IR format).

## Design decisions

**Preprocessor mechanism**: python module (`revert_test_targets.py`) + preceding `run_op: shell: cmd: pwd` (not inline shell cmd). The shell `cmd` field is static — can't template in the test_patch for parsing. The python subprocess (spawned by `python_runner.py`) inherits the OS global CWD, which in concurrent benchmark runs is the launch directory NOT `workspace.base_dir`. The `pwd` shell step runs with `cwd=ctx.workspace.base_dir` (PR-I fix), so its stdout is the actual repo path. Threading `repo_dir` via `data._repo_dir.stdout` into the python step is mandatory for correctness.

**Repo-cwd evidence**: `shell.py:74` explicitly sets `cwd=str(ctx.workspace.base_dir)` (FP-0008 PR-I). `python_runner.py:124` subprocess.run has no `cwd` argument → inherits OS global CWD ≠ workspace.base_dir in concurrent runs. This asymmetry was the correctness-critical ambiguity.

**Part 2 determinism**: report.md has a preprocessor (new), not an instruction. Same three-step chain as verify: file.read workspace _input → shell pwd → python revert_test_targets. Deterministic.

## PR-N15/C2 pattern alignment

Both this PR and PR-N15/C2 use the preprocessor to solve a problem that the weak LLM cannot reliably solve on its own: PR-N15 fixed test_patch source (LLM can't reliably echo large diffs), C6 fixes test file contamination (LLM can't reliably avoid editing test files that the test_patch owns).

## P7/P8 compliance

- Skill-only: all changes in `src/reyn/stdlib/skills/swe_bench/` + `tests/`. No OS code touched.
- P8-compliant: `revert_test_targets.py` contains the deterministic logic; phase instructions describe WHAT/domain only (no Control-IR format described in `.md` files).
- P7 clean: no skill-specific strings in OS code.

Refs #1096

## Test plan

- [x] `pytest -q tests/` from rootdir: 6404 passed, 1 pre-existing failure (test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content)
- [x] `ruff check .`: all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_swe_bench_verify_revert_test_targets.py`: 0 errors, 19/19 OK
- [x] Test A (loop-unblock proof): real git repo, apply-phase contamination → revert → `git apply <test_patch>` returncode 0 (PASSED)
- [x] Test B (source-only diff): source edit + test-target edit → after revert, `git diff HEAD` has source path, NOT test-target path (PASSED)
- [x] Test C (no-op safety): empty/absent test_patch, missing repo_dir, clean tree → all graceful no-ops without error (PASSED)
- [x] sandbox_2 re-run with C6: deferred to sandbox_2's post-merge job (not re-run in this PR per task instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)