### PR TITLE
fix(fp-0008): C5-completeness — bound offloaded inline regardless of field type (list/dict bulk)

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -33,12 +33,85 @@ MAX_CONTROL_IR_RESULT_INLINE_BYTES: int = 8_192   # ~8KB threshold
 OFFLOAD_HEAD_CHARS: int = 2_048                    # first 2KB kept inline
 OFFLOAD_TAIL_CHARS: int = 512                      # last 0.5KB kept inline
 
+# Hard-bound guarantee (C5-completeness — FP-0008 v9-IN):
+# After per-field type-aware previews, the offloaded inline dict MUST NOT exceed
+# this limit regardless of field types (list/dict/str/nested). The whole-inline-
+# replace fallback enforces this ceiling unconditionally. Value is set well above
+# head+tail+small-fields overhead (~3KB) but well below any model context limit.
+MAX_OFFLOADED_INLINE_BYTES: int = 16_384  # 16KB absolute ceiling for offloaded inline
 
-def _oversized_string_fields(result: dict) -> list[str]:
-    """Return field names whose string value alone exceeds the inline limit."""
+# Per-field keep threshold: fields whose serialised size is below this are kept
+# as-is (they're small enough not to contribute meaningfully to bloat).
+_FIELD_KEEP_THRESHOLD: int = MAX_CONTROL_IR_RESULT_INLINE_BYTES
+
+
+def _preview_field(value: Any, ref_path: str) -> Any:
+    """Return a bounded preview of *value* for the offloaded inline dict.
+
+    Type-aware strategy:
+      - str  → head (OFFLOAD_HEAD_CHARS) + truncation marker + tail (OFFLOAD_TAIL_CHARS)
+      - list → first K elements (until serialized size ~ OFFLOAD_HEAD_CHARS) +
+               a sentinel string describing remaining count + ref
+      - dict → first N key-value pairs (until serialized size ~ OFFLOAD_HEAD_CHARS) +
+               a sentinel string describing omitted keys + ref
+      - number/bool/None → returned as-is (tiny)
+    """
+    if isinstance(value, str):
+        head = value[:OFFLOAD_HEAD_CHARS]
+        has_tail = len(value) > OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS
+        tail = value[-OFFLOAD_TAIL_CHARS:] if has_tail else ""
+        marker = (
+            f"\n... [TRUNCATED — {len(value):,} chars total; "
+            f"full content at {ref_path}] ..."
+        )
+        return head + marker + (f"\n[TAIL PREVIEW]\n{tail}" if tail else "")
+
+    if isinstance(value, list):
+        preview_items: list = []
+        accumulated = 0
+        for item in value:
+            item_size = len(json.dumps(item, ensure_ascii=False))
+            if accumulated + item_size > OFFLOAD_HEAD_CHARS and preview_items:
+                break
+            preview_items.append(item)
+            accumulated += item_size
+        remaining = len(value) - len(preview_items)
+        if remaining > 0:
+            preview_items.append(
+                f"...({remaining} more elements omitted; full list at {ref_path})"
+            )
+        return preview_items
+
+    if isinstance(value, dict):
+        preview_dict: dict = {}
+        accumulated = 0
+        all_keys = list(value.keys())
+        for k in all_keys:
+            v = value[k]
+            pair_size = len(json.dumps({k: v}, ensure_ascii=False))
+            if accumulated + pair_size > OFFLOAD_HEAD_CHARS and preview_dict:
+                break
+            preview_dict[k] = v
+            accumulated += pair_size
+        omitted = len(all_keys) - len(preview_dict)
+        if omitted > 0:
+            preview_dict["_omitted_keys"] = (
+                f"({omitted} keys omitted; full dict at {ref_path})"
+            )
+        return preview_dict
+
+    # number / bool / None — tiny, keep as-is
+    return value
+
+
+def _oversized_fields(result: dict) -> list[str]:
+    """Return field names whose individual serialised size exceeds the per-field threshold.
+
+    Covers all field types (str, list, dict, etc.) — not just strings.
+    """
     return [
         k for k, v in result.items()
-        if isinstance(v, str) and len(v) > MAX_CONTROL_IR_RESULT_INLINE_BYTES
+        if len(json.dumps(v, ensure_ascii=False)) > _FIELD_KEEP_THRESHOLD
     ]
 
 
@@ -53,11 +126,16 @@ def offload_control_ir_result(
     """Offload an oversized control_ir_result to a workspace scratch file.
 
     If the JSON-serialised *result* exceeds MAX_CONTROL_IR_RESULT_INLINE_BYTES:
-      - Full content is written to *offload_dir*/<idx>_<uid>.json.
-      - Each string field larger than the threshold is replaced inline with
-        a head+tail preview and a truncation marker referencing the offload file.
+      - Full content is written to *offload_dir*/<idx>_<uid>.json (no info loss).
+      - Each oversized field (str/list/dict) is replaced inline with a type-aware
+        preview: str→head+tail, list→first K elements + count, dict→first N pairs.
       - A top-level ``_offload_ref`` key carries the absolute path for direct
         file.read access.
+      - Hard-bound guarantee: if the per-field previews still exceed
+        MAX_OFFLOADED_INLINE_BYTES (e.g. many medium-sized fields), a whole-inline
+        fallback replaces the entire inline with a compact head+tail of the
+        serialised result. This guarantees the inline is bounded regardless of
+        field types, counts, or nesting depth.
       - A ``control_ir_result_offloaded`` event is emitted for audit visibility.
 
     Small results (at or below threshold) are returned unchanged (identity).
@@ -76,23 +154,35 @@ def offload_control_ir_result(
     offload_path.write_text(serialized, encoding="utf-8")
     ref_path = str(offload_path)
 
-    # Build inline preview: copy result, replace oversized string fields
-    # with head + tail preview + truncation marker + ref path.
-    inline = dict(result)
-    large_fields = _oversized_string_fields(result)
-    for field in large_fields:
-        original = result[field]
-        head = original[:OFFLOAD_HEAD_CHARS]
-        has_tail = len(original) > OFFLOAD_HEAD_CHARS + OFFLOAD_TAIL_CHARS
-        tail = original[-OFFLOAD_TAIL_CHARS:] if has_tail else ""
-        marker = (
-            f"\n... [TRUNCATED — {len(original):,} chars total; "
-            f"full content at {ref_path}] ..."
-        )
-        inline[field] = head + marker + (f"\n[TAIL PREVIEW]\n{tail}" if tail else "")
+    # Build inline preview: keep small fields as-is; replace oversized fields
+    # with type-aware previews (str→head+tail, list→first K, dict→first N pairs).
+    inline: dict = {}
+    large_fields = _oversized_fields(result)
+    large_fields_set = set(large_fields)
+    for k, v in result.items():
+        if k in large_fields_set:
+            inline[k] = _preview_field(v, ref_path)
+        else:
+            inline[k] = v
 
     # Top-level ref so the LLM can locate the full result with a single key.
     inline["_offload_ref"] = ref_path
+
+    # Hard-bound guarantee: if per-field previews still exceed the ceiling
+    # (many medium-sized fields, deeply nested structures, etc.), fall back to
+    # a compact whole-inline representation that is guaranteed to fit.
+    inline_serialized = json.dumps(inline, ensure_ascii=False)
+    if len(inline_serialized) > MAX_OFFLOADED_INLINE_BYTES:
+        inline = {
+            "_offload_preview": serialized[:OFFLOAD_HEAD_CHARS],
+            "_offload_tail": serialized[-OFFLOAD_TAIL_CHARS:],
+            "_offload_total_chars": size_chars,
+            "_offload_ref": ref_path,
+            "_offload_note": (
+                f"Result too large for field-level preview "
+                f"({size_chars:,} chars); full content at {ref_path}"
+            ),
+        }
 
     if events is not None:
         events.emit(

--- a/tests/test_context_builder_per_result_offload.py
+++ b/tests/test_context_builder_per_result_offload.py
@@ -1,8 +1,8 @@
-"""Tier 2: control_ir_results per-result offload invariants (C5 — FP-0008).
+"""Tier 2: control_ir_results per-result offload invariants (C5 — FP-0008, v9-IN).
 
 When a single control_ir_result's JSON serialisation exceeds
 MAX_CONTROL_IR_RESULT_INLINE_BYTES (~8KB), the OS offloads the full content
-to a workspace scratch file and replaces the inline slot with a head+tail
+to a workspace scratch file and replaces the inline slot with a bounded
 preview + a ref path. The LLM can file.read the full content when needed.
 No information is lost.
 
@@ -16,6 +16,16 @@ Covered invariants:
 6. Observability: control_ir_result_offloaded event emitted with idx + original size.
 7. build_frame integration: oversized result in control_ir_results is bounded in
    the resulting ContextFrame's control_ir_results field.
+
+C5-completeness additions (v9-IN):
+8. LIST-bulk invariant: result with huge list field → inline ≤ MAX_OFFLOADED_INLINE_BYTES;
+   ref reads back to original (THE regression guard).
+9. dict-bulk invariant: result with huge dict field → same bound.
+10. string-bulk regression: existing string behavior preserved (head+tail+ref).
+11. many-medium-fields: many fields each just under per-field threshold → hard-bound
+    fallback triggers → inline ≤ MAX_OFFLOADED_INLINE_BYTES.
+12. build_frame integration with list-bulk: multi-MB list result → bound holds via
+    the real build_frame path.
 
 Policy compliance:
 - No unittest.mock / MagicMock / AsyncMock / patch.
@@ -31,6 +41,7 @@ import pytest
 
 from reyn.context_builder import (
     MAX_CONTROL_IR_RESULT_INLINE_BYTES,
+    MAX_OFFLOADED_INLINE_BYTES,
     OFFLOAD_HEAD_CHARS,
     OFFLOAD_TAIL_CHARS,
     maybe_offload_control_ir_results,
@@ -331,3 +342,256 @@ def test_build_frame_oversized_control_ir_result_is_bounded(tmp_path: Path) -> N
     assert ref_path is not None, "Offloaded result must carry _offload_ref"
     stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
     assert stored == big_result, "Ref file must contain the full original result"
+
+
+# ---------------------------------------------------------------------------
+# C5-completeness: list-bulk invariant (THE regression guard — FP-0008 v9-IN)
+# ---------------------------------------------------------------------------
+
+
+def test_list_bulk_inline_bounded_and_ref_complete(tmp_path: Path) -> None:
+    """Tier 2: LIST-bulk result inline is bounded by MAX_OFFLOADED_INLINE_BYTES.
+
+    A result whose bulk is a large LIST (e.g. grep matches with content) MUST
+    produce an inline whose serialised size is ≤ MAX_OFFLOADED_INLINE_BYTES,
+    AND the ref file must contain the full original result (no info loss).
+
+    This is the direct regression guard for the C5-completeness bug: before
+    the fix, list/dict fields were left full-size in the inline, causing
+    multi-MB prompt balloons (observed: 3.4M chars, 987K tokens).
+    """
+    # Build a result with a large list field (~multi-MB).
+    # 20,000 items × ~210 chars each ≈ 4.2MB — well above any inline threshold.
+    big_list_result = {
+        "kind": "file",
+        "op": "grep",
+        "status": "ok",
+        "matches": [{"path": f"p{i}", "line": "x" * 200} for i in range(20_000)],
+    }
+
+    offload_dir = tmp_path / "offload"
+    offloaded = offload_control_ir_result(big_list_result, 0, offload_dir)
+
+    # THE invariant: inline must be bounded regardless of list bulk
+    inline_size = len(json.dumps(offloaded, ensure_ascii=False))
+    assert inline_size <= MAX_OFFLOADED_INLINE_BYTES, (
+        f"LIST-bulk inline_size={inline_size:,} exceeds MAX_OFFLOADED_INLINE_BYTES="
+        f"{MAX_OFFLOADED_INLINE_BYTES:,}; list bulk was NOT bounded"
+    )
+
+    # No info loss: ref reads back to original
+    ref_path = offloaded.get("_offload_ref")
+    assert ref_path is not None, "Offloaded result must carry _offload_ref"
+    stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
+    assert stored == big_list_result, (
+        "Ref file must contain the full original list-bulk result (no info loss)"
+    )
+
+
+def test_list_bulk_head_preview_present(tmp_path: Path) -> None:
+    """Tier 2: offloaded list-bulk result contains a partial list preview in the inline.
+
+    The LLM must see the start of the list without a round-trip file.read.
+    The first element of the original list must appear somewhere in the inline.
+    """
+    big_list_result = {
+        "kind": "grep",
+        "status": "ok",
+        "matches": [{"path": f"file_{i}.py", "line": f"match line {i}"} for i in range(5_000)],
+    }
+
+    offload_dir = tmp_path / "offload"
+    offloaded = offload_control_ir_result(big_list_result, 0, offload_dir)
+
+    inline_json = json.dumps(offloaded, ensure_ascii=False)
+    # First element path "file_0.py" must appear in inline (head preview)
+    assert "file_0.py" in inline_json, (
+        "Inline must contain the first list element (head preview for LLM utility)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C5-completeness: dict-bulk invariant
+# ---------------------------------------------------------------------------
+
+
+def test_dict_bulk_inline_bounded_and_ref_complete(tmp_path: Path) -> None:
+    """Tier 2: dict-bulk result inline is bounded by MAX_OFFLOADED_INLINE_BYTES.
+
+    A result with a large DICT field must produce a bounded inline AND a
+    complete ref file. Same guarantee as the list-bulk test.
+    """
+    big_dict = {str(i): "value_" + "y" * 500 for i in range(5_000)}
+    result = {
+        "kind": "env",
+        "status": "ok",
+        "variables": big_dict,
+    }
+    serialized = json.dumps(result, ensure_ascii=False)
+    assert len(serialized) > MAX_CONTROL_IR_RESULT_INLINE_BYTES, (
+        "Precondition: result must exceed inline threshold"
+    )
+
+    offload_dir = tmp_path / "offload"
+    offloaded = offload_control_ir_result(result, 0, offload_dir)
+
+    inline_size = len(json.dumps(offloaded, ensure_ascii=False))
+    assert inline_size <= MAX_OFFLOADED_INLINE_BYTES, (
+        f"dict-bulk inline_size={inline_size:,} exceeds MAX_OFFLOADED_INLINE_BYTES="
+        f"{MAX_OFFLOADED_INLINE_BYTES:,}"
+    )
+
+    ref_path = offloaded.get("_offload_ref")
+    assert ref_path is not None, "dict-bulk: must carry _offload_ref"
+    stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
+    assert stored == result, "Ref file must contain full original dict-bulk result"
+
+
+# ---------------------------------------------------------------------------
+# C5-completeness: string-bulk regression (existing behavior preserved)
+# ---------------------------------------------------------------------------
+
+
+def test_string_bulk_inline_bounded_head_tail_preserved(tmp_path: Path) -> None:
+    """Tier 2: string-bulk result still gets head+tail preview after C5-completeness fix.
+
+    Regression guard: the new type-aware code must preserve existing str behavior —
+    head (OFFLOAD_HEAD_CHARS) + marker + tail (OFFLOAD_TAIL_CHARS) and bounded.
+    """
+    original_content = "S" * 300_000
+    result = {"kind": "file.read", "status": "ok", "content": original_content}
+
+    offload_dir = tmp_path / "offload"
+    offloaded = offload_control_ir_result(result, 0, offload_dir)
+
+    inline_size = len(json.dumps(offloaded, ensure_ascii=False))
+    assert inline_size <= MAX_OFFLOADED_INLINE_BYTES, (
+        f"string-bulk inline_size={inline_size:,} exceeds bound"
+    )
+
+    # Head is present in the content field
+    content_inline = offloaded.get("content", "")
+    assert isinstance(content_inline, str), "String field preview must remain a string"
+    expected_head = original_content[:OFFLOAD_HEAD_CHARS]
+    assert content_inline.startswith(expected_head), (
+        "String field must start with OFFLOAD_HEAD_CHARS preview"
+    )
+
+    # Ref reachable
+    ref_path = offloaded.get("_offload_ref")
+    assert ref_path is not None
+    stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
+    assert stored == result, "Ref must contain full original string-bulk result"
+
+
+# ---------------------------------------------------------------------------
+# C5-completeness: many-medium-fields hard-bound fallback
+# ---------------------------------------------------------------------------
+
+
+def test_many_medium_fields_hard_bound_fallback(tmp_path: Path) -> None:
+    """Tier 2: many-medium-fields result triggers hard-bound fallback → inline ≤ bound.
+
+    A result with many fields each just under _FIELD_KEEP_THRESHOLD can sum
+    to an inline well above MAX_OFFLOADED_INLINE_BYTES after per-field previews.
+    The hard-bound fallback must catch this and replace the whole inline with a
+    compact head+tail representation that fits within MAX_OFFLOADED_INLINE_BYTES.
+
+    This tests the correctness of the whole-inline-replace fallback (step 3 of
+    the bounded-by-construction design).
+    """
+    from reyn.context_builder import _FIELD_KEEP_THRESHOLD
+
+    # Build a result with many fields each slightly under the per-field threshold
+    # so per-field preview logic keeps them all, but the total blows up.
+    # Each field value: just under _FIELD_KEEP_THRESHOLD chars of string
+    field_value_size = _FIELD_KEEP_THRESHOLD - 100  # just under per-field keep threshold
+    # Number of fields to exceed MAX_OFFLOADED_INLINE_BYTES after small-field pass
+    n_fields = (MAX_OFFLOADED_INLINE_BYTES // field_value_size) + 20
+    result = {f"field_{i}": "M" * field_value_size for i in range(n_fields)}
+
+    serialized = json.dumps(result, ensure_ascii=False)
+    assert len(serialized) > MAX_OFFLOADED_INLINE_BYTES, (
+        f"Precondition: result must exceed MAX_OFFLOADED_INLINE_BYTES; "
+        f"got {len(serialized):,}"
+    )
+    assert len(serialized) > MAX_CONTROL_IR_RESULT_INLINE_BYTES, (
+        "Precondition: result must also exceed the basic inline threshold"
+    )
+
+    offload_dir = tmp_path / "offload"
+    offloaded = offload_control_ir_result(result, 0, offload_dir)
+
+    inline_size = len(json.dumps(offloaded, ensure_ascii=False))
+    assert inline_size <= MAX_OFFLOADED_INLINE_BYTES, (
+        f"many-medium-fields fallback did not fire: inline_size={inline_size:,} "
+        f"exceeds MAX_OFFLOADED_INLINE_BYTES={MAX_OFFLOADED_INLINE_BYTES:,}"
+    )
+
+    # Ref reachable and complete
+    ref_path = offloaded.get("_offload_ref")
+    assert ref_path is not None, "Fallback inline must carry _offload_ref"
+    stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
+    assert stored == result, "Ref must contain full original many-medium-fields result"
+
+
+# ---------------------------------------------------------------------------
+# C5-completeness: build_frame integration with list-bulk
+# ---------------------------------------------------------------------------
+
+
+def test_build_frame_list_bulk_control_ir_result_bounded(tmp_path: Path) -> None:
+    """Tier 2: build_frame with list-bulk control_ir_result produces bounded inline.
+
+    Integration path: the real build_frame (via OSRuntime) must apply the
+    bounded offload to a multi-MB list-bulk result, producing an inline that
+    fits within MAX_OFFLOADED_INLINE_BYTES. The ref file must contain the full
+    original result.
+
+    This is the integration-path regression guard (the C6 regression missed
+    a similar integration path test).
+    """
+    pytest.importorskip("litellm")
+
+    import os
+    os.chdir(tmp_path)
+
+    rt = OSRuntime(
+        _one_phase_skill(),
+        model="stub/model",
+        run_id="list_bulk_integration_test",
+        workspace_base_dir=tmp_path,
+    )
+
+    # 20,000 items × ~210 chars each ≈ 4.2MB — deterministically multi-MB
+    big_list_result = {
+        "kind": "file",
+        "op": "grep",
+        "status": "ok",
+        "matches": [{"path": f"p{i}", "line": "x" * 200} for i in range(20_000)],
+    }
+
+    frame = rt.build_frame(
+        "draft",
+        {"type": "input", "data": {}},
+        [],
+        "en",
+        control_ir_results=[big_list_result],
+    )
+
+    (inline,) = frame.control_ir_results
+    inline_size = len(json.dumps(inline, ensure_ascii=False))
+
+    # THE invariant: inline bounded regardless of list bulk
+    assert inline_size <= MAX_OFFLOADED_INLINE_BYTES, (
+        f"build_frame list-bulk inline_size={inline_size:,} exceeds "
+        f"MAX_OFFLOADED_INLINE_BYTES={MAX_OFFLOADED_INLINE_BYTES:,}"
+    )
+
+    # No info loss via ref
+    ref_path = inline.get("_offload_ref")
+    assert ref_path is not None, "build_frame offloaded inline must carry _offload_ref"
+    stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
+    assert stored == big_list_result, (
+        "build_frame ref file must contain the full original list-bulk result"
+    )


### PR DESCRIPTION
**[e2e-coder]** — C5-completeness fix for FP-0008 v9-IN blocker.

## The gap

`offload_control_ir_result` in `context_builder.py` only shrank **string** fields when building the offloaded inline. When a result's bulk was in a **list or dict** field (e.g. a `file grep` op with `output_mode=content` returning a huge `matches` LIST), the function:
- Correctly wrote the full result to a scratch ref file
- But built `inline = dict(result)` keeping the list/dict bulk full-size

Result: the inline was NOT bounded → prompt balloon. Observed: a single 3.4M-char grep result, 96% of a 3.5M-char prompt; at 14096 the result hit 987K tokens ≈ Gemini's 1M limit → latent `ContextWindowExceeded` on any smaller-context model.

## The fix — bounded-by-construction

`src/reyn/context_builder.py`:

1. **`_FIELD_KEEP_THRESHOLD`**: per-field size check covers all types (was string-only).
2. **`_preview_field()`**: type-aware preview per oversized field:
   - `str` → head (OFFLOAD_HEAD_CHARS=2048) + marker + tail (OFFLOAD_TAIL_CHARS=512) — existing behavior preserved
   - `list` → first K elements (until ~OFFLOAD_HEAD_CHARS serialised) + `"...(+N more elements omitted; full list at <ref>)"` sentinel
   - `dict` → first N key-value pairs (until ~OFFLOAD_HEAD_CHARS) + `_omitted_keys` note
   - number/bool/None → kept as-is (tiny)
3. **Hard-bound fallback** (key invariant): after per-field previews, if `len(json.dumps(inline))` STILL exceeds `MAX_OFFLOADED_INLINE_BYTES` (many medium-sized fields, deeply nested, etc.), replace the entire inline with `{_offload_preview, _offload_tail, _offload_total_chars, _offload_ref, _offload_note}`. Guarantees bound **unconditionally**.
4. **`MAX_OFFLOADED_INLINE_BYTES = 16_384`**: hard ceiling for any offloaded inline, well above head+tail+small-field overhead, well below any model context limit.

**No information lost**: full result remains at `_offload_ref` (written before any preview logic).
**P7-clean**: no skill-specific strings in OS code.

## Constants

| Constant | Value | Role |
|---|---|---|
| `MAX_CONTROL_IR_RESULT_INLINE_BYTES` | 8,192 | Trigger threshold (unchanged) |
| `OFFLOAD_HEAD_CHARS` | 2,048 | Head preview per field |
| `OFFLOAD_TAIL_CHARS` | 512 | Tail preview per str field |
| `MAX_OFFLOADED_INLINE_BYTES` | **16,384** | Hard ceiling for offloaded inline (new) |

Refs #1093

## Test plan

- [x] **LIST-bulk invariant** (`test_list_bulk_inline_bounded_and_ref_complete`): 20K-item list (≈4.2MB) → `len(json.dumps(offloaded)) <= MAX_OFFLOADED_INLINE_BYTES` AND `json.loads(Path(ref).read_text()) == original` — **THE regression guard**
- [x] **LIST-bulk head preview present** (`test_list_bulk_head_preview_present`): first list element visible in inline
- [x] **dict-bulk variant** (`test_dict_bulk_inline_bounded_and_ref_complete`): dict-field bulk → same bound + ref complete
- [x] **string-bulk regression** (`test_string_bulk_inline_bounded_head_tail_preserved`): existing str behavior preserved (head+tail+ref)
- [x] **many-medium-fields fallback** (`test_many_medium_fields_hard_bound_fallback`): many fields each just under per-field threshold → hard-bound fallback triggers → inline ≤ bound
- [x] **build_frame integration list-bulk** (`test_build_frame_list_bulk_control_ir_result_bounded`): real OSRuntime build_frame with 4.2MB list-bulk result → bound holds via integration path
- [x] ruff check . → All checks passed
- [x] tier audit → 15/15 OK, 0 errors
- [x] pytest -q tests/ → 6391 passed, 1 pre-existing failure (test_legacy_no_media_store_path_returns_inline_content)