### PR TITLE
fix(fp-0008): C6 v2 — revert test_patch targets via shell run_op (replaces reverted #1098 safe-mode-subprocess approach)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/parse_test_targets.py
+++ b/src/reyn/stdlib/skills/swe_bench/parse_test_targets.py
@@ -1,0 +1,131 @@
+"""FP-0008 C6 v2 — parse test_patch targets for shell-based revert.
+
+Safe-mode python step: parses ``+++ b/<path>`` diff header lines from the
+sanitized ``data.test_patch`` and returns a list of ``git checkout HEAD --
+<path>`` command strings — one per unique target, excluding ``/dev/null``
+and blank paths.
+
+## Why pure string parsing (no subprocess)
+
+v1 (PR #1098) placed ``import subprocess`` in a ``mode: safe`` python step.
+The safe-mode sandbox rejects subprocess at AST parse time
+(``SafeModeViolation``) — the step aborted before any code ran, and the
+verify preprocessor errored on every instance.
+
+v2 separates concerns:
+- This module (mode: safe): pure string → command-list transform (re + json
+  only, both in PURE_STDLIB_ALLOWLIST).
+- Iterate + shell run_op (OS-owned): runs each git checkout command via the
+  op_runtime shell handler, which executes with ``cwd=workspace.base_dir``
+  (FP-0008 PR-I) — the SWE-bench repo root, correct for concurrent benchmarks.
+
+## Why args_from {cmd: _iter.item} works
+
+``_materialize_op`` in ``preprocessor_executor.py`` resolves dot-paths from
+the ``iter_artifact`` dict, which includes ``_iter.item`` injected by
+``_apply_iterate``. The shell op has ``cmd: str`` as a settable field on
+``ShellIROp``, so ``model_copy(update={"cmd": item})`` replaces the
+placeholder. Each iteration builds a fresh ``ShellIROp`` with the resolved
+command string.
+
+## Input shape
+
+Called with the full runtime artifact dict. Source priority mirrors
+``sanitize_test_patch.py`` (P5 workspace passthrough):
+
+1. ``data._input_raw.content`` — JSON of the original ``swe_bench_input``
+   artifact, injected by the preceding ``run_op: file.read`` step.
+2. ``data.test_patch`` — set by the sanitize_test_patch step that precedes
+   this one in the preprocessor chain.
+3. Top-level ``test_patch`` — flat unit-test direct-call shape.
+
+## Output schema
+
+``array of strings`` — zero or more ``git checkout HEAD -- <path>`` command
+strings.  Returns ``[]`` on absent/empty test_patch (graceful no-op).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping
+
+
+def _extract_test_patch(data: Mapping[str, Any]) -> str:
+    """Extract the test_patch string from the artifact, following priority chain.
+
+    Priority:
+    1. data._input_raw.content (workspace JSON via file.read run_op)
+    2. data.test_patch (inner data dict — set by sanitize_test_patch)
+    3. top-level test_patch (flat unit-test shape)
+
+    Returns empty string when all sources are absent/non-string.
+    """
+    inner: Any = data.get("data") or {}
+    test_patch: Any = None
+
+    # Priority 1: workspace passthrough
+    if isinstance(inner, dict):
+        input_raw = inner.get("_input_raw")
+        if isinstance(input_raw, dict):
+            content = input_raw.get("content")
+            if isinstance(content, str) and content.strip():
+                try:
+                    parsed = json.loads(content)
+                    test_patch = (parsed.get("data") or {}).get("test_patch")
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+
+    # Priority 2: inner data.test_patch
+    if not isinstance(test_patch, str) or not test_patch:
+        if isinstance(inner, dict):
+            test_patch = inner.get("test_patch")
+
+    # Priority 3: top-level flat shape
+    if not isinstance(test_patch, str) or not test_patch:
+        test_patch = data.get("test_patch")  # type: ignore[assignment]
+
+    if not isinstance(test_patch, str):
+        return ""
+    return test_patch
+
+
+def _parse_paths(test_patch: str) -> list[str]:
+    """Return deduplicated repo-relative paths from ``+++ b/<path>`` headers.
+
+    Excludes ``/dev/null`` and blank paths. Preserves insertion order.
+    """
+    seen: set[str] = set()
+    paths: list[str] = []
+    for line in test_patch.splitlines():
+        m = re.match(r"^\+\+\+ b?/?(.*)", line)
+        if not m:
+            continue
+        path = m.group(1).strip()
+        if not path or path == "/dev/null" or path.startswith("dev/null"):
+            continue
+        if path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def parse_test_targets(data: Mapping[str, Any]) -> list[str]:
+    """Parse test_patch targets and return git checkout command strings.
+
+    Returns a list of strings of the form::
+
+        ["git checkout HEAD -- tests/test_x.py", ...]
+
+    One entry per unique ``+++ b/<path>`` target in the sanitized test_patch,
+    excluding ``/dev/null``.  Returns ``[]`` when test_patch is absent or empty.
+
+    This is a pure string transform — no subprocess, no filesystem access, no
+    environment reads.  It is safe to call in ``mode: safe`` (uses only ``re``
+    and ``json`` from PURE_STDLIB_ALLOWLIST).
+    """
+    test_patch = _extract_test_patch(data)
+    if not test_patch.strip():
+        return []
+    paths = _parse_paths(test_patch)
+    return [f"git checkout HEAD -- {path}" for path in paths]

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -10,6 +10,13 @@ max_act_turns: 30
 
 Implement the edit plan by modifying the repository files.
 
+## Domain rule — edit SOURCE files only
+
+Edit SOURCE files only.  The SWE-bench harness owns the test files: it applies
+the test_patch itself after the skill run.  The verify preprocessor reverts any
+test-file edits before running `git apply test_patch`, so apply-phase test edits
+do not count and will not survive into the final diff.
+
 ## Step 1 — Read each file before editing
 
 For every file listed in the plan's edits, issue a file read op to retrieve

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -11,6 +11,12 @@ max_act_turns: 15
 Produce a concrete edit plan: a list of files to change and a description of
 what to change in each, sufficient for the apply phase to implement the fix.
 
+## Domain rule — plan SOURCE files only
+
+Plan edits to SOURCE files only.  Do not include test files in the edit plan.
+The SWE-bench harness owns the test files via its own test_patch; apply-phase
+test edits are reverted before verification and will not count.
+
 ## Context
 
 The input is either:

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -7,6 +7,46 @@ model_class: standard
 can_finish: true
 allowed_ops: [shell]
 max_act_turns: 10
+preprocessor:
+  # FP-0008 C6 v2 — belt-and-suspenders: revert test_patch-target files before
+  # git diff HEAD so the final solution patch is source-only regardless of
+  # verify-phase state.  The verify preprocessor already reverts targets, but
+  # this guard ensures the report diff is clean even if verify's revert ran
+  # against a different working-tree state or was skipped.
+  #
+  # Step 1: read the original swe_bench_input artifact from the workspace to
+  # obtain test_patch (same path as verify.md Step 1).
+  - type: run_op
+    op:
+      kind: file
+      op: read
+      path: ".reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json"
+    into: data._input_raw
+    on_error: empty
+  # Step 2: parse test_patch → list of git checkout command strings.
+  # The function returns [] gracefully on absent/empty test_patch.
+  - type: python
+    module: ./parse_test_targets.py
+    function: parse_test_targets
+    mode: safe
+    into: data._revert_cmds
+    output_schema:
+      type: array
+      items: {type: string}
+  # Step 3: run each git checkout command to revert test_patch-target files.
+  - type: iterate
+    over: data._revert_cmds
+    apply:
+      type: run_op
+      op:
+        kind: shell
+        cmd: "git checkout HEAD -- __placeholder__"
+        timeout: 10
+      args_from:
+        cmd: "_iter.item"
+      on_error: skip
+    into: data._revert_results
+    on_error: skip
 ---
 
 Produce the final output by capturing the git diff of all changes made during

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -41,6 +41,46 @@ preprocessor:
     into: data.test_patch
     output_schema:
       type: string
+  #
+  # FP-0008 C6 v2 Step 3: parse test_patch targets → list of git-checkout
+  # command strings.  Pure string transform (re + json only, mode: safe).
+  # Output: ["git checkout HEAD -- tests/test_x.py", ...] — zero or more.
+  # The function itself returns [] on absent/empty test_patch (graceful no-op).
+  - type: python
+    module: ./parse_test_targets.py
+    function: parse_test_targets
+    mode: safe
+    into: data._revert_cmds
+    output_schema:
+      type: array
+      items: {type: string}
+  #
+  # FP-0008 C6 v2 Step 4: iterate over command strings and run each via shell
+  # run_op.  Shell ops execute with cwd=workspace.base_dir (FP-0008 PR-I) =
+  # the SWE-bench repo root, so git checkout operates on the correct working
+  # tree even in concurrent benchmark runs.
+  #
+  # args_from {cmd: "_iter.item"} is resolved by _materialize_op:
+  # the IterateStep injects {_iter: {item: <cmd_string>}} into iter_artifact
+  # before calling _materialize_op, which resolves the dot-path "_iter.item"
+  # to the current command string and replaces ShellIROp.cmd via
+  # model_copy(update={"cmd": item_string}).
+  #
+  # on_error: skip — a path not in HEAD (= new test file) returns non-zero
+  # from git checkout; skip it rather than aborting the whole preprocessor.
+  - type: iterate
+    over: data._revert_cmds
+    apply:
+      type: run_op
+      op:
+        kind: shell
+        cmd: "git checkout HEAD -- __placeholder__"
+        timeout: 10
+      args_from:
+        cmd: "_iter.item"
+      on_error: skip
+    into: data._revert_results
+    on_error: skip
 ---
 
 Run the SWE-bench test patch against the current codebase to determine whether

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -50,6 +50,14 @@ permissions:
       function: sanitize_test_patch
       mode: safe
       timeout: 5
+    # FP-0008 C6 v2: pure string parser — extracts +++ b/<path> targets from
+    # test_patch and returns git checkout command strings.  Mode: safe because
+    # the function uses only re + json (both in PURE_STDLIB_ALLOWLIST) and
+    # performs no filesystem access, subprocess calls, or environment reads.
+    - module: ./parse_test_targets.py
+      function: parse_test_targets
+      mode: safe
+      timeout: 5
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---

--- a/tests/test_swe_bench_c6_v2_revert_via_shell.py
+++ b/tests/test_swe_bench_c6_v2_revert_via_shell.py
@@ -1,0 +1,490 @@
+"""Tier 2: FP-0008 C6 v2 — revert test_patch targets via shell run_op.
+
+Root cause recap: v1 (#1098, reverted in #1099) used ``import subprocess``
+inside a ``mode: safe`` python step.  The safe-mode sandbox rejects subprocess
+at AST parse time (``SafeModeViolation``) — the preprocessor aborted before any
+code ran, and every verify instance errored.
+
+v2 mechanism (this PR):
+  1. ``parse_test_targets.py`` (mode: safe, pure re+json only) — parses
+     ``+++ b/<path>`` headers from test_patch and returns a list of
+     ``git checkout HEAD -- <path>`` command strings.  No subprocess/os.
+  2. ``iterate`` + ``run_op shell`` with ``args_from: {cmd: _iter.item}`` —
+     runs each checkout command via op_runtime's shell handler, which executes
+     with ``cwd=workspace.base_dir`` (FP-0008 PR-I) = the correct repo root.
+  3. Mirror in ``report.md`` preprocessor for source-only final diff.
+
+## Merge gate tests (mandatory per task spec)
+
+(a) SafeModeViolation regression guard:
+    parse_test_targets through real PythonRunner(mode="safe") must SUCCEED
+    (no SafeModeViolation) — this directly reproduces the v1 failure condition.
+
+(b) E2E real-preprocessor-path test:
+    PreprocessorExecutor with real git repo → after preprocessor, contaminated
+    test file is reverted AND ``git apply test_patch`` returns rc=0.
+
+All tests: real git (subprocess), real files in tmp_path, real PythonRunner /
+op_runtime.  No MagicMock / AsyncMock / patch.  Docstrings open "Tier 2:".
+"""
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+# ── Git repo helpers ──────────────────────────────────────────────────────────
+
+
+def _git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    """Run git in cwd; raise on non-zero unless check=False."""
+    return subprocess.run(
+        ["git"] + args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    """Create a git repo with a source file and a test file at HEAD.
+
+    Returns the repo root.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-b", "main"], cwd=repo)
+    _git(["config", "user.email", "test@test.com"], cwd=repo)
+    _git(["config", "user.name", "Test"], cwd=repo)
+    (repo / "mymod.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
+    (repo / "test_mymod.py").write_text(
+        "def test_foo():\n    assert foo() == 1\n", encoding="utf-8"
+    )
+    _git(["add", "mymod.py", "test_mymod.py"], cwd=repo)
+    _git(["commit", "-m", "initial"], cwd=repo)
+    return repo
+
+
+def _make_test_patch() -> str:
+    """A minimal unified diff targeting test_mymod.py."""
+    return (
+        "diff --git a/test_mymod.py b/test_mymod.py\n"
+        "--- a/test_mymod.py\n"
+        "+++ b/test_mymod.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " def test_foo():\n"
+        "     assert foo() == 1\n"
+        "+    assert foo() != 2\n"
+    )
+
+
+# ── (a) SafeModeViolation regression guard ────────────────────────────────────
+
+
+def test_parse_test_targets_safe_mode_no_violation() -> None:
+    """Tier 2: parse_test_targets runs through real PythonRunner(mode='safe') without SafeModeViolation.
+
+    This is the v1 regression guard.  v1 had ``import subprocess`` in the
+    safe-mode module — PythonRunner raised PythonStepError(kind='SafeModeViolation')
+    before any code ran.  v2 must succeed: the module uses only re + json.
+    """
+    from reyn.python_runner import PythonRunner, PythonStepError
+
+    runner = PythonRunner()
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "test_patch": (
+                "diff --git a/tests/test_x.py b/tests/test_x.py\n"
+                "--- a/tests/test_x.py\n"
+                "+++ b/tests/test_x.py\n"
+                "@@ -1 +1 @@\n"
+                "-old\n+new\n"
+            ),
+        },
+    }
+    # Must not raise — especially not PythonStepError(kind='SafeModeViolation').
+    try:
+        result = runner.run(
+            skill_dir=_SKILL_ROOT,
+            module="./parse_test_targets.py",
+            function="parse_test_targets",
+            mode="safe",
+            artifact=artifact,
+            timeout=30,
+            allowed_modules=[],
+        )
+    except PythonStepError as exc:
+        pytest.fail(
+            f"PythonRunner(mode='safe') raised PythonStepError — this reproduces the v1 regression.\n"
+            f"kind={exc.kind!r}, error={exc!s}\n"
+            f"If kind='SafeModeViolation', the module uses a forbidden import "
+            f"(subprocess/os/etc).  v2 must use only re+json."
+        )
+    # Result must be the expected list of checkout commands
+    assert isinstance(result, list), f"Expected list, got {type(result).__name__}: {result!r}"
+    assert any("tests/test_x.py" in cmd for cmd in result), (
+        f"Expected a command targeting tests/test_x.py. Got: {result}"
+    )
+    assert all(cmd.startswith("git checkout HEAD -- ") for cmd in result), (
+        f"All commands must be 'git checkout HEAD -- <path>' strings. Got: {result}"
+    )
+
+
+def test_parse_test_targets_module_no_subprocess_import() -> None:
+    """Tier 2: static guard — parse_test_targets.py has no top-level 'import subprocess' statement.
+
+    Belt-and-suspenders alongside the PythonRunner test above.
+    Checks AST-level imports, not docstring text, to avoid false positives.
+    """
+    import ast
+
+    source = (_SKILL_ROOT / "parse_test_targets.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden = {"subprocess", "os"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name not in forbidden and alias.name.split(".")[0] not in forbidden, (
+                    f"parse_test_targets.py imports forbidden module {alias.name!r}. "
+                    f"'subprocess'/'os' are not in PURE_STDLIB_ALLOWLIST — "
+                    f"importing them in mode:safe triggers SafeModeViolation (= v1 bug)."
+                )
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and (node.module in forbidden or node.module.split(".")[0] in forbidden):
+                pytest.fail(
+                    f"parse_test_targets.py imports from forbidden module {node.module!r}. "
+                    f"'subprocess'/'os' are not in PURE_STDLIB_ALLOWLIST."
+                )
+
+
+# ── Pure parsing unit tests ───────────────────────────────────────────────────
+
+
+def test_parse_test_targets_returns_checkout_commands() -> None:
+    """Tier 2: parse_test_targets returns git checkout command strings."""
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
+    patch = (
+        "diff --git a/tests/test_foo.py b/tests/test_foo.py\n"
+        "--- a/tests/test_foo.py\n"
+        "+++ b/tests/test_foo.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n+new\n"
+    )
+    result = parse_test_targets({"data": {"test_patch": patch}})
+    assert isinstance(result, list)
+    assert result == ["git checkout HEAD -- tests/test_foo.py"], (
+        f"Expected single checkout command. Got: {result}"
+    )
+
+
+def test_parse_test_targets_empty_patch_returns_empty() -> None:
+    """Tier 2: empty test_patch → empty list."""
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
+    assert parse_test_targets({"data": {"test_patch": ""}}) == []
+    assert parse_test_targets({"data": {}}) == []
+    assert parse_test_targets({}) == []
+
+
+def test_parse_test_targets_excludes_dev_null() -> None:
+    """Tier 2: /dev/null on +++ line is excluded."""
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
+    # A new-file hunk has --- /dev/null, +++ b/new_test.py.
+    # The /dev/null appears on the --- line, not the +++ line, so the +++ path
+    # is still included. But when /dev/null appears on a +++ line (deletion),
+    # it must be excluded.
+    patch_with_dev_null_target = (
+        "diff --git a/old.py b/new.py\n"
+        "--- a/old.py\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-gone\n"
+    )
+    result = parse_test_targets({"data": {"test_patch": patch_with_dev_null_target}})
+    assert "/dev/null" not in result, f"/dev/null must not appear in result: {result}"
+    assert all("/dev/null" not in cmd for cmd in result), (
+        f"No command should reference /dev/null: {result}"
+    )
+
+
+def test_parse_test_targets_deduplicates() -> None:
+    """Tier 2: repeated +++ b/<path> lines produce a single command."""
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
+    patch = "+++ b/tests/test_foo.py\n+++ b/tests/test_foo.py\n"
+    result = parse_test_targets({"data": {"test_patch": patch}})
+    assert result.count("git checkout HEAD -- tests/test_foo.py") == 1, (
+        f"Deduplicated path must appear exactly once. Got: {result}"
+    )
+
+
+def test_parse_test_targets_multiple_files() -> None:
+    """Tier 2: patch with two target files → two checkout commands."""
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
+    patch = (
+        "+++ b/tests/test_foo.py\n"
+        "+++ b/tests/test_bar.py\n"
+    )
+    result = parse_test_targets({"data": {"test_patch": patch}})
+    assert "git checkout HEAD -- tests/test_foo.py" in result
+    assert "git checkout HEAD -- tests/test_bar.py" in result
+
+
+# ── (b) E2E real-preprocessor-path test ──────────────────────────────────────
+
+
+def test_verify_preprocessor_reverts_contaminated_test_file_and_git_apply_succeeds(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: E2E — verify preprocessor reverts contaminated test file; git apply succeeds.
+
+    This is the mandatory E2E merge gate test.  It runs the verify phase's
+    full preprocessor chain through PreprocessorExecutor (real Workspace, real
+    skill loaded from disk, real shell op_runtime execution in a real git repo).
+
+    Setup:
+      - git init + commit source file + test file
+      - contaminate test_mymod.py (simulate apply-phase edit)
+      - build artifact with test_patch targeting test_mymod.py
+
+    Assert (after preprocessor):
+      - test_mymod.py is reverted to HEAD content (contamination gone)
+      - ``git apply test_patch`` returns rc=0 (loop-unblock proof)
+    """
+    from reyn.compiler.loader import load_dsl_skill
+    from reyn.events.events import EventLog
+    from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+    from reyn.workspace.workspace import Workspace
+
+    # ── Setup: real git repo ──────────────────────────────────────────────────
+    repo = _setup_repo(tmp_path)
+    test_patch = _make_test_patch()
+
+    # Contaminate test_mymod.py (simulates apply-phase LLM editing the test file)
+    (repo / "test_mymod.py").write_text(
+        "# apply-phase contamination\n"
+        "def test_foo():\n"
+        "    assert foo() == 99  # apply LLM wrote this\n",
+        encoding="utf-8",
+    )
+
+    # Pre-condition: git apply FAILS on the contaminated working tree
+    patch_file = repo / ".reyn_test.patch"
+    patch_file.write_text(test_patch, encoding="utf-8")
+    pre = subprocess.run(
+        ["git", "apply", "--check", str(patch_file)],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert pre.returncode != 0, (
+        "Pre-condition: git apply must fail on contaminated test file before preprocessor. "
+        f"stderr: {pre.stderr}"
+    )
+
+    # ── Load skill + run preprocessor ────────────────────────────────────────
+    skill = load_dsl_skill(_SKILL_ROOT / "skill.md")
+    verify_phase = skill.phases["verify"]
+
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=repo)
+    executor = PreprocessorExecutor(
+        skill=skill,
+        workspace=ws,
+        model="standard",
+        events=events,
+        subscribers=[],
+        resolver=None,
+        permission_resolver=None,
+    )
+
+    # Artifact: simulate apply_state with test_patch already set
+    # (in production, sanitize_test_patch step sets data.test_patch;
+    # we inject it directly here to avoid dependency on file.read step
+    # which would need the workspace artifact path to exist)
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test-instance",
+            "files_edited": ["mymod.py"],
+            "attempt": 1,
+            "test_patch": test_patch,
+        },
+    }
+
+    enriched, _usage = asyncio.run(
+        executor.run(verify_phase, artifact, output_language=None)
+    )
+
+    # ── Assert: test file reverted ────────────────────────────────────────────
+    reverted_content = (repo / "test_mymod.py").read_text(encoding="utf-8")
+    assert "apply-phase contamination" not in reverted_content, (
+        "test_mymod.py must be reverted to HEAD content after preprocessor. "
+        f"Content: {reverted_content!r}"
+    )
+    assert "def test_foo" in reverted_content, (
+        "test_mymod.py must contain the original HEAD content after revert. "
+        f"Content: {reverted_content!r}"
+    )
+
+    # ── Assert: git apply test_patch returns rc=0 (THE loop-unblock proof) ───
+    post = subprocess.run(
+        ["git", "apply", str(patch_file)],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert post.returncode == 0, (
+        "After preprocessor revert, git apply <test_patch> must succeed (returncode 0). "
+        "This proves the apply×verify test-collision loop is unblocked. "
+        f"returncode={post.returncode}, stderr={post.stderr!r}, stdout={post.stdout!r}"
+    )
+
+
+def test_verify_preprocessor_clean_tree_no_error(tmp_path: Path) -> None:
+    """Tier 2: E2E — verify preprocessor runs without error on clean working tree.
+
+    When the working tree is already at HEAD (no contamination), the shell
+    git checkout ops are no-ops and the preprocessor completes successfully.
+    """
+    from reyn.compiler.loader import load_dsl_skill
+    from reyn.events.events import EventLog
+    from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+    from reyn.workspace.workspace import Workspace
+
+    repo = _setup_repo(tmp_path)
+    test_patch = _make_test_patch()
+
+    skill = load_dsl_skill(_SKILL_ROOT / "skill.md")
+    verify_phase = skill.phases["verify"]
+
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=repo)
+    executor = PreprocessorExecutor(
+        skill=skill,
+        workspace=ws,
+        model="standard",
+        events=events,
+        subscribers=[],
+        resolver=None,
+        permission_resolver=None,
+    )
+
+    artifact = {
+        "type": "apply_state",
+        "data": {
+            "instance_id": "test-instance",
+            "files_edited": [],
+            "attempt": 1,
+            "test_patch": test_patch,
+        },
+    }
+
+    # Must not raise even on a clean working tree
+    enriched, _usage = asyncio.run(
+        executor.run(verify_phase, artifact, output_language=None)
+    )
+    assert isinstance(enriched, dict), "Preprocessor must return a dict"
+
+
+# ── Structure pins ────────────────────────────────────────────────────────────
+
+
+def test_verify_md_has_parse_step_and_iterate_step() -> None:
+    """Tier 2: verify.md preprocessor has parse_test_targets python step and iterate step."""
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    assert "parse_test_targets" in verify_md, (
+        "verify.md must reference parse_test_targets in its preprocessor"
+    )
+    assert "type: iterate" in verify_md, (
+        "verify.md must have an iterate step to run shell checkout commands"
+    )
+    assert "data._revert_cmds" in verify_md, (
+        "verify.md must use data._revert_cmds as the iterate over path"
+    )
+
+
+def test_verify_md_shell_step_has_args_from_iter_item() -> None:
+    """Tier 2: verify.md iterate run_op uses args_from to bind cmd from _iter.item."""
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    assert "args_from" in verify_md, (
+        "verify.md must have args_from in the iterate run_op step"
+    )
+    assert "_iter.item" in verify_md, (
+        "verify.md must bind cmd via args_from: {cmd: _iter.item}"
+    )
+
+
+def test_verify_md_parse_step_mode_safe() -> None:
+    """Tier 2: verify.md parse_test_targets step is declared mode: safe."""
+    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
+    # Both sanitize_test_patch and parse_test_targets must declare mode: safe
+    assert verify_md.count("mode: safe") >= 2, (
+        "verify.md must declare mode: safe for both sanitize_test_patch and "
+        f"parse_test_targets. Found {verify_md.count('mode: safe')} occurrences."
+    )
+
+
+def test_report_md_has_parse_step_and_iterate_step() -> None:
+    """Tier 2: report.md preprocessor has parse_test_targets python step and iterate step."""
+    report_md = (_SKILL_ROOT / "phases" / "report.md").read_text(encoding="utf-8")
+    assert "parse_test_targets" in report_md, (
+        "report.md must reference parse_test_targets in its preprocessor"
+    )
+    assert "type: iterate" in report_md, (
+        "report.md must have an iterate step"
+    )
+    assert "preprocessor:" in report_md, (
+        "report.md must have a preprocessor block"
+    )
+
+
+def test_report_md_reads_workspace_input() -> None:
+    """Tier 2: report.md preprocessor reads the workspace swe_bench _input artifact."""
+    report_md = (_SKILL_ROOT / "phases" / "report.md").read_text(encoding="utf-8")
+    assert "swe_bench/_input/v01_swe_bench_input.json" in report_md, (
+        "report.md must read the workspace _input artifact to get test_patch"
+    )
+
+
+def test_apply_md_has_source_only_rule() -> None:
+    """Tier 2: apply.md has the SOURCE files only domain rule."""
+    apply_md = (_SKILL_ROOT / "phases" / "apply.md").read_text(encoding="utf-8")
+    assert "SOURCE files only" in apply_md or "source files only" in apply_md.lower(), (
+        "apply.md must contain the 'SOURCE files only' domain rule"
+    )
+    assert "reverted" in apply_md or "harness owns" in apply_md, (
+        "apply.md must mention test edits are reverted or harness owns test files"
+    )
+
+
+def test_plan_md_has_source_only_rule() -> None:
+    """Tier 2: plan.md has the SOURCE files only domain rule."""
+    plan_md = (_SKILL_ROOT / "phases" / "plan.md").read_text(encoding="utf-8")
+    assert "SOURCE files only" in plan_md or "source files only" in plan_md.lower(), (
+        "plan.md must contain the 'SOURCE files only' domain rule"
+    )
+
+
+def test_skill_md_registers_parse_test_targets() -> None:
+    """Tier 2: skill.md registers parse_test_targets as a safe-mode python step."""
+    skill_md = (_SKILL_ROOT / "skill.md").read_text(encoding="utf-8")
+    assert "parse_test_targets.py" in skill_md, (
+        "skill.md must list parse_test_targets.py in permissions.python"
+    )
+    assert "parse_test_targets" in skill_md, (
+        "skill.md must reference the parse_test_targets function name"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 C6 v2: the last v9 GO blocker. Replaces the reverted PR #1098.

## Problem (v9 instance 13398 — apply×verify test-collision loop)

The apply phase may edit a test file that the test_patch also targets. When
`git apply test_patch` runs, it fails with `error: patch failed: <path>: does
not match index` → verify transitions back to apply → retry loop →
`loop_limit_exceeded`.

## Why v1 (#1098) was reverted (#1099)

v1's `revert_test_targets.py` had `import subprocess` in a `mode: safe` python
preprocessor step. The safe-mode sandbox rejects `subprocess` at AST parse
time (`SafeModeViolation`) — the step aborted before any code ran, and the
verify preprocessor errored on every instance. v1's tests called the revert
function in-process (subprocess works there), never through the real
`PythonRunner(mode="safe")` path, so they passed while the real path failed.

## v2 mechanism (this PR)

Separates concerns cleanly:

**Step 1 — `parse_test_targets.py` (mode: safe, pure string parse)**
Parses `+++ b/<path>` headers from the sanitized `data.test_patch` and returns
a list of `"git checkout HEAD -- <path>"` command strings. Uses only `re` and
`json` (both in `PURE_STDLIB_ALLOWLIST`). No `subprocess`, no `os`, no
filesystem access. Returns `[]` gracefully on absent/empty test_patch.

**Step 2 — `iterate` + `run_op shell` + `args_from: {cmd: "_iter.item"}`**
Iterates over the command strings and runs each via op_runtime's shell handler.
Shell ops execute with `cwd=workspace.base_dir` (FP-0008 PR-I) = the correct
SWE-bench repo root for concurrent benchmark runs. `_materialize_op` in
`preprocessor_executor.py` resolves `_iter.item` from `iter_artifact["_iter"]["item"]`
(injected per-iteration by `_apply_iterate`) and replaces `ShellIROp.cmd` via
`model_copy(update={"cmd": cmd_string})`. `on_error: skip` handles new test
files not in HEAD (git checkout returns non-zero → skip, don't abort).

Both steps added to `verify.md` preprocessor (after `sanitize_test_patch`) and
`report.md` preprocessor (belt-and-suspenders for source-only final diff).
`apply.md` + `plan.md` get the source-only domain rule nudge.

## Files changed

- `src/reyn/stdlib/skills/swe_bench/parse_test_targets.py` — new safe-mode parser
- `src/reyn/stdlib/skills/swe_bench/phases/verify.md` — Steps 3+4 added
- `src/reyn/stdlib/skills/swe_bench/phases/report.md` — revert preprocessor added
- `src/reyn/stdlib/skills/swe_bench/phases/apply.md` — source-only domain rule
- `src/reyn/stdlib/skills/swe_bench/phases/plan.md` — source-only domain rule
- `src/reyn/stdlib/skills/swe_bench/skill.md` — permissions.python entry
- `tests/test_swe_bench_c6_v2_revert_via_shell.py` — 17 Tier-2 tests

P7 compliant: skill-only change, no OS code touched.
P8 compliant: phase instructions describe WHAT/domain; deterministic logic in preprocessor.

Refs #1096

## Test plan

- [x] `ruff check .` → all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_swe_bench_c6_v2_revert_via_shell.py` → 17 ✓, 0 errors
- [x] `pytest -q tests/ -k "swe_bench or preprocessor or revert or parse_test"` → 138 passed
- [x] `pytest -q tests/` → 6408 passed, 1 pre-existing failure (test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content)
- [x] **(a) SafeModeViolation regression guard**: `test_parse_test_targets_safe_mode_no_violation` runs `parse_test_targets` via real `PythonRunner(mode="safe")` → PASSES (no SafeModeViolation). `test_parse_test_targets_module_no_subprocess_import` walks AST to confirm no subprocess/os import.
- [x] **(b) E2E real-preprocessor-path**: `test_verify_preprocessor_reverts_contaminated_test_file_and_git_apply_succeeds` runs full preprocessor via `PreprocessorExecutor` with real `Workspace(base_dir=repo)` + real git repo + real shell op → asserts contaminated test file reverted AND `git apply test_patch` rc=0.
- [x] P7/P8 compliance: skill-only change confirmed (`git diff origin/main --name-only` shows no OS files touched)