### PR TITLE
feat(fp-0008): C5 #223 Phase 1 — common preview-driven-offload service + phase migration

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -19,6 +19,7 @@ from reyn.schemas.models import (
     Phase,
     PhaseConstraints,
 )
+from reyn.services.offload.store import offload_value
 
 ARTIFACT_REF_THRESHOLD = 8000  # characters; larger artifacts are stored by ref in ContextFrame
 MAX_INLINE_BOOST = 65_536  # characters; artifacts up to 64KB are still inlined (inline-boost range)
@@ -115,47 +116,23 @@ def _oversized_fields(result: dict) -> list[str]:
     ]
 
 
-def offload_control_ir_result(
-    result: dict,
-    result_idx: int,
-    offload_dir: Path,
-    *,
-    events: Any = None,
-    phase: str | None = None,
-) -> dict:
-    """Offload an oversized control_ir_result to a workspace scratch file.
+def _phase_preview_strategy(result: dict, ref_path: str) -> dict:
+    """Phase-axis preview strategy: type-aware per-field previews + hard-bound fallback.
 
-    If the JSON-serialised *result* exceeds MAX_CONTROL_IR_RESULT_INLINE_BYTES:
-      - Full content is written to *offload_dir*/<idx>_<uid>.json (no info loss).
-      - Each oversized field (str/list/dict) is replaced inline with a type-aware
-        preview: str→head+tail, list→first K elements + count, dict→first N pairs.
-      - A top-level ``_offload_ref`` key carries the absolute path for direct
-        file.read access.
-      - Hard-bound guarantee: if the per-field previews still exceed
-        MAX_OFFLOADED_INLINE_BYTES (e.g. many medium-sized fields), a whole-inline
-        fallback replaces the entire inline with a compact head+tail of the
-        serialised result. This guarantees the inline is bounded regardless of
-        field types, counts, or nesting depth.
-      - A ``control_ir_result_offloaded`` event is emitted for audit visibility.
+    This is the phase-specific policy for what a bounded inline looks like.
+    It is injected into the common offload infrastructure via ``offload_value``.
 
-    Small results (at or below threshold) are returned unchanged (identity).
-    No information is lost: the full content is retrievable via the ref path.
+    Logic:
+      - Small fields (≤ _FIELD_KEEP_THRESHOLD) are kept as-is.
+      - Oversized fields get type-aware previews via ``_preview_field``.
+      - A top-level ``_offload_ref`` is added.
+      - Hard-bound guarantee: if the result still exceeds MAX_OFFLOADED_INLINE_BYTES
+        (many medium-sized fields, deeply nested structures), a whole-inline fallback
+        replaces the entire inline with a compact head+tail of the serialised result.
     """
     serialized = json.dumps(result, ensure_ascii=False)
     size_chars = len(serialized)
-    if size_chars <= MAX_CONTROL_IR_RESULT_INLINE_BYTES:
-        return result
 
-    # Write full content to workspace scratch — no information loss.
-    offload_dir.mkdir(parents=True, exist_ok=True)
-    uid = uuid.uuid4().hex[:8]
-    offload_filename = f"{result_idx:04d}_{uid}.json"
-    offload_path = offload_dir / offload_filename
-    offload_path.write_text(serialized, encoding="utf-8")
-    ref_path = str(offload_path)
-
-    # Build inline preview: keep small fields as-is; replace oversized fields
-    # with type-aware previews (str→head+tail, list→first K, dict→first N pairs).
     inline: dict = {}
     large_fields = _oversized_fields(result)
     large_fields_set = set(large_fields)
@@ -183,6 +160,57 @@ def offload_control_ir_result(
                 f"({size_chars:,} chars); full content at {ref_path}"
             ),
         }
+
+    return inline
+
+
+def offload_control_ir_result(
+    result: dict,
+    result_idx: int,
+    offload_dir: Path,
+    *,
+    events: Any = None,
+    phase: str | None = None,
+) -> dict:
+    """Offload an oversized control_ir_result to a workspace scratch file.
+
+    Thin wrapper around the common offload infrastructure
+    (``services.offload.offload_value``) with the phase-axis preview strategy
+    injected. The preview strategy applies type-aware per-field previews
+    (str→head+tail, list→first K elements + count, dict→first N pairs) plus a
+    hard-bound whole-inline fallback to guarantee ≤ MAX_OFFLOADED_INLINE_BYTES.
+
+    If the JSON-serialised *result* exceeds MAX_CONTROL_IR_RESULT_INLINE_BYTES:
+      - Full content is written to *offload_dir*/<idx>_<uid>.json (no info loss).
+      - Each oversized field (str/list/dict) is replaced inline with a type-aware
+        preview; a top-level ``_offload_ref`` key carries the absolute path.
+      - ``_offload_content_hash`` is added to the inline (new: allows verified
+        read-back via ``read_offloaded``).
+      - Hard-bound guarantee: inline is always ≤ MAX_OFFLOADED_INLINE_BYTES.
+      - A ``control_ir_result_offloaded`` event is emitted for audit visibility.
+
+    Small results (at or below threshold) are returned unchanged (identity).
+    No information is lost: the full content is retrievable via the ref path.
+    """
+    serialized = json.dumps(result, ensure_ascii=False)
+    size_chars = len(serialized)
+    if size_chars <= MAX_CONTROL_IR_RESULT_INLINE_BYTES:
+        return result
+
+    offload_filename = f"{result_idx:04d}_{uuid.uuid4().hex[:8]}.json"
+    offload_result = offload_value(
+        result,
+        store_dir=offload_dir,
+        preview_strategy=_phase_preview_strategy,
+        filename=offload_filename,
+    )
+
+    # The preview dict produced by _phase_preview_strategy is our inline.
+    inline: dict = offload_result.preview
+    # Attach content_hash for verified read-back (new in Phase 1).
+    inline["_offload_content_hash"] = offload_result.content_hash
+    ref_path = offload_result.path_ref
+    large_fields = _oversized_fields(result)
 
     if events is not None:
         events.emit(

--- a/src/reyn/services/offload/__init__.py
+++ b/src/reyn/services/offload/__init__.py
@@ -1,0 +1,12 @@
+"""Offload service — axis-agnostic infrastructure for preview-driven file offloading."""
+from reyn.services.offload.store import (
+    OffloadResult,
+    offload_value,
+    read_offloaded,
+)
+
+__all__ = [
+    "OffloadResult",
+    "offload_value",
+    "read_offloaded",
+]

--- a/src/reyn/services/offload/store.py
+++ b/src/reyn/services/offload/store.py
@@ -1,0 +1,148 @@
+"""Offload store — axis-agnostic infrastructure for value-to-file offloading.
+
+"Offload" = a value is too large to inline → write the full content to a
+workspace file, return a short preview (produced by an injected strategy) +
+a path reference + a content hash so the reader can verify integrity later.
+
+This module is **axis-agnostic / P7-clean**: it contains no skill names,
+phase names, artifact-type literals, or any other OS-internal domain strings.
+Preview generation is strategy-injected because what constitutes a useful
+preview differs per use-site (LLM cognition context, output format, etc.).
+
+Content hash format: ``"sha256:<hex>"`` — matches MediaStore (media_store.py)
+so Phase 2 can unify the two implementations without a format migration.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class OffloadResult:
+    """Returned by :func:`offload_value` after writing the full content to disk.
+
+    Attributes:
+        preview:      The inline preview produced by the injected strategy.
+                      Shape is strategy-dependent — callers may attach it to
+                      the inline slot as-is.
+        path_ref:     Absolute path string pointing at the file containing the
+                      full serialised content.
+        content_hash: ``"sha256:<hex>"`` digest of the full serialised bytes.
+                      Verifiable via :func:`read_offloaded` with the same hash.
+    """
+
+    preview: Any
+    path_ref: str
+    content_hash: str
+
+
+def offload_value(
+    value: Any,
+    *,
+    store_dir: Path,
+    preview_strategy: Callable[[Any, str], Any],
+    filename: str | None = None,
+) -> OffloadResult:
+    """Write *value* to *store_dir* and return preview + path_ref + content_hash.
+
+    Serialisation: dicts are serialised via ``json.dumps(ensure_ascii=False)``;
+    strings are written directly (UTF-8). Other types are serialised via
+    ``json.dumps`` as well.
+
+    Args:
+        value:            The value to offload (dict or str; other types via json).
+        store_dir:        Directory to write the full content into. Created if
+                          absent (parents included).
+        preview_strategy: Callable ``(value, path_ref) -> preview``. Invoked
+                          after the file is written so ``path_ref`` is available
+                          for embedding in the preview (e.g. truncation markers).
+        filename:         Optional explicit filename. When omitted a unique name
+                          is derived from a UUID fragment.
+
+    Returns:
+        :class:`OffloadResult` with preview, path_ref, content_hash.
+    """
+    store_dir.mkdir(parents=True, exist_ok=True)
+
+    if filename is None:
+        uid = uuid.uuid4().hex[:8]
+        filename = f"{uid}.json"
+
+    dest = store_dir / filename
+    serialized = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
+    dest.write_text(serialized, encoding="utf-8")
+
+    path_ref = str(dest)
+    content_hash = "sha256:" + hashlib.sha256(serialized.encode()).hexdigest()
+    preview = preview_strategy(value, path_ref)
+
+    return OffloadResult(preview=preview, path_ref=path_ref, content_hash=content_hash)
+
+
+def read_offloaded(
+    path_str: str,
+    *,
+    base_dir: Path,
+    content_hash: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+) -> tuple[str, bool]:
+    """Read back offloaded content with path-boundary validation.
+
+    Args:
+        path_str:     Absolute path string to the offloaded file (the
+                      ``path_ref`` from :class:`OffloadResult`).
+        base_dir:     Validation boundary. The resolved path MUST be under
+                      ``base_dir``; raises :class:`PermissionError` otherwise.
+                      Mirrors ``MediaStore.read_tool_result``'s boundary check.
+        content_hash: When provided, verifies the SHA-256 of the **full**
+                      (pre-slice) content. Raises :class:`ValueError` on
+                      mismatch. Format: ``"sha256:<hex>"``.
+        offset:       0-indexed line slice start. ``None`` = from beginning.
+        limit:        Maximum number of lines to return. ``None`` = all lines.
+
+    Returns:
+        ``(content, found)`` where ``found=False`` when the file does not exist.
+
+    Raises:
+        PermissionError: When ``path_str`` resolves outside ``base_dir``.
+        ValueError:      When ``content_hash`` is provided and does not match.
+    """
+    full = Path(path_str).resolve()
+    base_resolved = base_dir.resolve()
+    try:
+        full.relative_to(base_resolved)
+    except ValueError as exc:
+        raise PermissionError(
+            f"path {path_str!r} is outside base_dir "
+            f"{base_resolved} — refusing to read"
+        ) from exc
+
+    if not full.exists():
+        return "", False
+
+    raw = full.read_text(encoding="utf-8")
+
+    # Integrity check on full content (before any slice)
+    if content_hash is not None:
+        actual = "sha256:" + hashlib.sha256(raw.encode()).hexdigest()
+        if actual != content_hash:
+            raise ValueError(
+                f"content_hash mismatch for {path_str!r}: "
+                f"expected {content_hash!r}, got {actual!r}"
+            )
+
+    # Line-based slice
+    if offset is not None or limit is not None:
+        lines = raw.splitlines(keepends=True)
+        start = offset if offset is not None else 0
+        end = (start + limit) if limit is not None else None
+        sliced = lines[start:end]
+        return "".join(sliced), True
+
+    return raw, True

--- a/tests/test_context_builder_per_result_offload.py
+++ b/tests/test_context_builder_per_result_offload.py
@@ -1,4 +1,4 @@
-"""Tier 2: control_ir_results per-result offload invariants (C5 — FP-0008, v9-IN).
+"""Tier 2: control_ir_results per-result offload invariants (C5 — FP-0008, v9-IN + Phase 1 migration).
 
 When a single control_ir_result's JSON serialisation exceeds
 MAX_CONTROL_IR_RESULT_INLINE_BYTES (~8KB), the OS offloads the full content
@@ -27,6 +27,11 @@ C5-completeness additions (v9-IN):
 12. build_frame integration with list-bulk: multi-MB list result → bound holds via
     the real build_frame path.
 
+Phase 1 migration additions:
+13. Offloaded result now carries ``_offload_content_hash`` (new: Phase 1 common core wires content hash).
+14. Content hash read-back: read_offloaded(path_ref, content_hash=hash) == original full result.
+15. build_frame list-bulk: inline ≤ MAX_OFFLOADED_INLINE_BYTES + content_hash present (integration via real build_frame).
+
 Policy compliance:
 - No unittest.mock / MagicMock / AsyncMock / patch.
 - No private-state assertions.
@@ -50,6 +55,7 @@ from reyn.context_builder import (
 from reyn.events.events import EventLog
 from reyn.kernel.runtime import OSRuntime
 from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.services.offload.store import read_offloaded
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -594,4 +600,121 @@ def test_build_frame_list_bulk_control_ir_result_bounded(tmp_path: Path) -> None
     stored = json.loads(Path(ref_path).read_text(encoding="utf-8"))
     assert stored == big_list_result, (
         "build_frame ref file must contain the full original list-bulk result"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 migration: content_hash present in offloaded inline
+# ---------------------------------------------------------------------------
+
+
+def test_offloaded_result_carries_content_hash(tmp_path: Path) -> None:
+    """Tier 2: Phase 1 — offloaded inline now carries _offload_content_hash.
+
+    After the common-core migration, every offloaded result must include
+    ``_offload_content_hash`` in the inline dict so callers can verify
+    integrity via read_offloaded(path_ref, content_hash=...).
+    """
+    result = _make_big_result(200_000)
+    offload_dir = tmp_path / "offload"
+    inline = offload_control_ir_result(result, 0, offload_dir)
+
+    assert "_offload_content_hash" in inline, (
+        "Phase 1: offloaded inline must carry _offload_content_hash key"
+    )
+    content_hash = inline["_offload_content_hash"]
+    assert content_hash.startswith("sha256:"), (
+        f"content_hash must start with 'sha256:', got {content_hash!r}"
+    )
+
+
+def test_offloaded_content_hash_read_back_matches_original(tmp_path: Path) -> None:
+    """Tier 2: Phase 1 — content_hash from inline enables verified read-back == original.
+
+    Using the content_hash from the inline, read_offloaded must return the
+    full original result without raising, and the parsed result must equal
+    the original dict.
+    """
+    original_content = "E" * 200_000
+    result = {"kind": "file.read", "status": "ok", "content": original_content}
+    offload_dir = tmp_path / "offload"
+    inline = offload_control_ir_result(result, 0, offload_dir)
+
+    ref_path = inline["_offload_ref"]
+    content_hash = inline["_offload_content_hash"]
+
+    # Verified read-back using the hash from the inline
+    raw, found = read_offloaded(ref_path, base_dir=offload_dir, content_hash=content_hash)
+    assert found is True, "read_offloaded must find the offloaded file"
+    stored = json.loads(raw)
+    assert stored == result, (
+        "Verified read-back via content_hash must yield the full original result"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 migration: build_frame list-bulk — inline bounded + content_hash present
+# ---------------------------------------------------------------------------
+
+
+def test_build_frame_list_bulk_bounded_and_content_hash_present(tmp_path: Path) -> None:
+    """Tier 2: Phase 1 — build_frame list-bulk: inline ≤ MAX_OFFLOADED_INLINE_BYTES + hash present.
+
+    Integration path via real build_frame (OSRuntime): list-bulk result must
+    produce a bounded inline AND the inline must carry _offload_content_hash
+    so callers can do verified read-back.
+
+    This is the integration-path guard for Phase 1 migration: both C5-completeness
+    (the bound invariant) and the new content_hash addition must hold simultaneously.
+    """
+    pytest.importorskip("litellm")
+
+    import os
+    os.chdir(tmp_path)
+
+    rt = OSRuntime(
+        _one_phase_skill(),
+        model="stub/model",
+        run_id="list_bulk_hash_integration_test",
+        workspace_base_dir=tmp_path,
+    )
+
+    big_list_result = {
+        "kind": "file",
+        "op": "grep",
+        "status": "ok",
+        "matches": [{"path": f"p{i}", "line": "x" * 200} for i in range(20_000)],
+    }
+
+    frame = rt.build_frame(
+        "draft",
+        {"type": "input", "data": {}},
+        [],
+        "en",
+        control_ir_results=[big_list_result],
+    )
+
+    (inline,) = frame.control_ir_results
+    inline_size = len(json.dumps(inline, ensure_ascii=False))
+
+    # C5-completeness invariant still holds
+    assert inline_size <= MAX_OFFLOADED_INLINE_BYTES, (
+        f"build_frame list-bulk inline_size={inline_size:,} exceeds "
+        f"MAX_OFFLOADED_INLINE_BYTES={MAX_OFFLOADED_INLINE_BYTES:,}"
+    )
+
+    # Phase 1: content_hash is present
+    assert "_offload_content_hash" in inline, (
+        "Phase 1: build_frame offloaded inline must carry _offload_content_hash"
+    )
+
+    # Verified read-back == original
+    ref_path = inline["_offload_ref"]
+    content_hash = inline["_offload_content_hash"]
+    # offload_dir is inside tmp_path; use tmp_path as base_dir for boundary check
+    raw, found = read_offloaded(ref_path, base_dir=tmp_path, content_hash=content_hash)
+    assert found is True
+    stored = json.loads(raw)
+    assert stored == big_list_result, (
+        "Phase 1: verified read-back via build_frame content_hash must yield full original"
     )

--- a/tests/test_services_offload_store.py
+++ b/tests/test_services_offload_store.py
@@ -1,0 +1,398 @@
+"""Tier 2: services.offload.store — axis-agnostic offload infrastructure invariants.
+
+Covered invariants:
+1. offload_value writes full content + returns correct path_ref and sha256 content_hash.
+2. read_offloaded returns full original content via path_ref.
+3. read_offloaded integrity: correct content_hash passes; wrong content_hash raises ValueError.
+4. read_offloaded path-boundary: a path outside base_dir raises PermissionError.
+5. read_offloaded slice: offset/limit returns the right line window.
+6. preview_strategy injection: custom strategy is invoked; its output is the preview field.
+7. offload_value with explicit filename uses that exact filename.
+8. read_offloaded returns (empty, False) when the file does not exist.
+9. offload_value serialises dict values via json (not str).
+10. content_hash format matches "sha256:<hex>" convention (MediaStore-compatible).
+
+Policy compliance:
+- No unittest.mock / MagicMock / AsyncMock / patch.
+- No private-state assertions.
+- Each docstring opens with ``Tier 2: ...``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.services.offload.store import OffloadResult, offload_value, read_offloaded
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _identity_strategy(value: Any, path_ref: str) -> Any:
+    """Preview strategy that returns the value unchanged (for testing injection)."""
+    return value
+
+
+def _constant_strategy(value: Any, path_ref: str) -> str:
+    """Preview strategy that returns a fixed string (to verify strategy output lands in result)."""
+    return f"preview:constant:{path_ref}"
+
+
+def _path_embedding_strategy(value: Any, path_ref: str) -> dict:
+    """Preview strategy that embeds path_ref in its output (verifies path_ref is passed)."""
+    return {"ref": path_ref, "summary": "test preview"}
+
+
+def _make_dict_value(size: int = 100) -> dict:
+    """Build a simple dict value for testing."""
+    return {"key": "A" * size, "other": 42}
+
+
+# ---------------------------------------------------------------------------
+# 1. offload_value writes full content + correct path_ref + sha256 content_hash
+# ---------------------------------------------------------------------------
+
+
+def test_offload_value_writes_full_content(tmp_path: Path) -> None:
+    """Tier 2: offload_value writes full serialised content to store_dir.
+
+    The file at path_ref must contain the complete JSON-serialised value
+    so that no information is lost.
+    """
+    value = _make_dict_value(200)
+    result = offload_value(value, store_dir=tmp_path / "store", preview_strategy=_identity_strategy)
+
+    assert isinstance(result, OffloadResult)
+    stored_text = Path(result.path_ref).read_text(encoding="utf-8")
+    stored = json.loads(stored_text)
+    assert stored == value, "Stored file must contain the full original value"
+
+
+def test_offload_value_correct_content_hash(tmp_path: Path) -> None:
+    """Tier 2: offload_value returns the correct sha256 content_hash.
+
+    The hash must be ``"sha256:<hex>"`` of the serialised UTF-8 bytes,
+    matching the MediaStore convention for Phase 2 unification.
+    """
+    value = {"data": "hello" * 10}
+    result = offload_value(value, store_dir=tmp_path / "store", preview_strategy=_identity_strategy)
+
+    serialized = json.dumps(value, ensure_ascii=False)
+    expected_hash = "sha256:" + hashlib.sha256(serialized.encode()).hexdigest()
+    assert result.content_hash == expected_hash, (
+        f"content_hash mismatch: got {result.content_hash!r}, expected {expected_hash!r}"
+    )
+
+
+def test_offload_value_path_ref_is_absolute(tmp_path: Path) -> None:
+    """Tier 2: offload_value path_ref is an absolute filesystem path.
+
+    Callers (including read_offloaded) must receive an unambiguous path.
+    """
+    value = {"x": 1}
+    result = offload_value(value, store_dir=tmp_path / "store", preview_strategy=_identity_strategy)
+
+    assert Path(result.path_ref).is_absolute(), (
+        f"path_ref must be absolute, got: {result.path_ref!r}"
+    )
+    assert Path(result.path_ref).exists(), "path_ref must point at an existing file"
+
+
+# ---------------------------------------------------------------------------
+# 2. read_offloaded returns full original content via path_ref
+# ---------------------------------------------------------------------------
+
+
+def test_read_offloaded_returns_full_content(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded(path_ref) returns the full stored content.
+
+    The round-trip offload_value → read_offloaded must recover the original.
+    """
+    value = {"lines": ["line1", "line2", "line3"], "count": 3}
+    store_dir = tmp_path / "store"
+    result = offload_value(value, store_dir=store_dir, preview_strategy=_identity_strategy)
+
+    content, found = read_offloaded(result.path_ref, base_dir=store_dir)
+    assert found is True
+    recovered = json.loads(content)
+    assert recovered == value, "read_offloaded must return the full original content"
+
+
+# ---------------------------------------------------------------------------
+# 3. Integrity check: correct hash passes, wrong hash raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_read_offloaded_correct_hash_passes(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded with the correct content_hash succeeds without raising.
+
+    Verifies that a matching hash is accepted — read-back works with integrity.
+    """
+    value = {"item": "B" * 100}
+    store_dir = tmp_path / "store"
+    result = offload_value(value, store_dir=store_dir, preview_strategy=_identity_strategy)
+
+    # Should not raise
+    content, found = read_offloaded(
+        result.path_ref, base_dir=store_dir, content_hash=result.content_hash
+    )
+    assert found is True
+    assert json.loads(content) == value
+
+
+def test_read_offloaded_wrong_hash_raises_value_error(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded with a wrong content_hash raises ValueError.
+
+    Integrity enforcement must reject tampered or mismatched content.
+    """
+    value = {"item": "C" * 100}
+    store_dir = tmp_path / "store"
+    result = offload_value(value, store_dir=store_dir, preview_strategy=_identity_strategy)
+
+    wrong_hash = "sha256:" + "0" * 64
+
+    with pytest.raises(ValueError, match="content_hash mismatch"):
+        read_offloaded(result.path_ref, base_dir=store_dir, content_hash=wrong_hash)
+
+
+# ---------------------------------------------------------------------------
+# 4. Path-boundary validation: outside base_dir raises PermissionError
+# ---------------------------------------------------------------------------
+
+
+def test_read_offloaded_outside_base_dir_raises_permission_error(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded rejects paths outside base_dir with PermissionError.
+
+    Path-traversal protection: any path that resolves outside base_dir must be
+    refused, mirroring MediaStore.read_tool_result boundary enforcement.
+    """
+    store_dir = tmp_path / "store"
+    store_dir.mkdir(parents=True)
+
+    # Write a file in a sibling directory (outside store_dir)
+    sibling_dir = tmp_path / "sibling"
+    sibling_dir.mkdir()
+    sibling_file = sibling_dir / "secret.json"
+    sibling_file.write_text('{"secret": true}', encoding="utf-8")
+
+    with pytest.raises(PermissionError):
+        read_offloaded(str(sibling_file), base_dir=store_dir)
+
+
+def test_read_offloaded_traversal_path_raises_permission_error(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded rejects ``../`` path traversal with PermissionError.
+
+    A path constructed with ``../`` that resolves outside base_dir must be
+    refused even when it refers to an existing file.
+    """
+    store_dir = tmp_path / "store"
+    store_dir.mkdir(parents=True)
+
+    # Write a legitimate file outside store_dir
+    outside_file = tmp_path / "outside.json"
+    outside_file.write_text('{"x": 1}', encoding="utf-8")
+
+    # Construct a path using traversal from inside store_dir
+    traversal_path = str(store_dir / "../outside.json")
+
+    with pytest.raises(PermissionError):
+        read_offloaded(traversal_path, base_dir=store_dir)
+
+
+# ---------------------------------------------------------------------------
+# 5. Slice: offset/limit returns the right line window
+# ---------------------------------------------------------------------------
+
+
+def test_read_offloaded_slice_offset_and_limit(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded with offset/limit returns the correct line window.
+
+    A 10-line file sliced with offset=2, limit=3 must return lines 2,3,4
+    (0-indexed), preserving newlines.
+    """
+    store_dir = tmp_path / "store"
+    store_dir.mkdir(parents=True)
+    lines = [f"line{i}\n" for i in range(10)]
+    target = store_dir / "slice_test.txt"
+    target.write_text("".join(lines), encoding="utf-8")
+
+    content, found = read_offloaded(str(target), base_dir=store_dir, offset=2, limit=3)
+    assert found is True
+    result_lines = content.splitlines()
+    assert result_lines == ["line2", "line3", "line4"], (
+        f"Expected lines [line2, line3, line4], got {result_lines}"
+    )
+
+
+def test_read_offloaded_slice_offset_only(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded with offset only returns from that line to end."""
+    store_dir = tmp_path / "store"
+    store_dir.mkdir(parents=True)
+    lines = [f"line{i}\n" for i in range(5)]
+    target = store_dir / "offset_test.txt"
+    target.write_text("".join(lines), encoding="utf-8")
+
+    content, found = read_offloaded(str(target), base_dir=store_dir, offset=3)
+    assert found is True
+    result_lines = content.splitlines()
+    assert result_lines == ["line3", "line4"], (
+        f"Expected [line3, line4], got {result_lines}"
+    )
+
+
+def test_read_offloaded_slice_limit_only(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded with limit only returns the first N lines."""
+    store_dir = tmp_path / "store"
+    store_dir.mkdir(parents=True)
+    lines = [f"line{i}\n" for i in range(5)]
+    target = store_dir / "limit_test.txt"
+    target.write_text("".join(lines), encoding="utf-8")
+
+    content, found = read_offloaded(str(target), base_dir=store_dir, limit=2)
+    assert found is True
+    result_lines = content.splitlines()
+    assert result_lines == ["line0", "line1"], (
+        f"Expected [line0, line1], got {result_lines}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. preview_strategy injection: custom strategy is invoked; output lands in preview
+# ---------------------------------------------------------------------------
+
+
+def test_preview_strategy_is_invoked(tmp_path: Path) -> None:
+    """Tier 2: offload_value invokes the injected preview_strategy.
+
+    The result.preview must be the exact return value of the strategy.
+    """
+    value = {"data": "hello"}
+    store_dir = tmp_path / "store"
+
+    calls: list[tuple] = []
+
+    def recording_strategy(v: Any, path_ref: str) -> str:
+        calls.append((v, path_ref))
+        return f"recorded:{path_ref}"
+
+    result = offload_value(value, store_dir=store_dir, preview_strategy=recording_strategy)
+
+    assert calls, "Strategy must be called at least once"
+    v_arg, path_ref_arg = calls[-1]
+    assert v_arg == value, "Strategy must receive the original value"
+    assert path_ref_arg == result.path_ref, "Strategy must receive the path_ref"
+    assert result.preview == f"recorded:{result.path_ref}", (
+        "result.preview must be the strategy's return value"
+    )
+
+
+def test_preview_strategy_path_ref_embedding(tmp_path: Path) -> None:
+    """Tier 2: preview_strategy receives the written path_ref for embedding in truncation markers.
+
+    Strategies that embed the path_ref (e.g. "full content at <path>") must
+    receive it correctly from offload_value.
+    """
+    value = {"big": "X" * 1000}
+    store_dir = tmp_path / "store"
+    result = offload_value(value, store_dir=store_dir, preview_strategy=_path_embedding_strategy)
+
+    assert isinstance(result.preview, dict)
+    assert result.preview["ref"] == result.path_ref, (
+        "preview_strategy must receive the exact path_ref that was written"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Explicit filename
+# ---------------------------------------------------------------------------
+
+
+def test_offload_value_explicit_filename_used(tmp_path: Path) -> None:
+    """Tier 2: when filename is provided, offload_value uses that exact filename.
+
+    This enables callers (like the phase axis) to embed idx/uid in the name
+    for human-readable workspace inspection.
+    """
+    value = {"x": 1}
+    store_dir = tmp_path / "store"
+    explicit_name = "0001_abc12345.json"
+
+    result = offload_value(
+        value,
+        store_dir=store_dir,
+        preview_strategy=_identity_strategy,
+        filename=explicit_name,
+    )
+
+    assert Path(result.path_ref).name == explicit_name, (
+        f"Expected filename {explicit_name!r}, got {Path(result.path_ref).name!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. File-not-found returns (empty, False)
+# ---------------------------------------------------------------------------
+
+
+def test_read_offloaded_missing_file_returns_not_found(tmp_path: Path) -> None:
+    """Tier 2: read_offloaded returns ("", False) when the file does not exist.
+
+    Matches MediaStore.read_tool_result's convention for past-EOF / deleted files.
+    """
+    store_dir = tmp_path / "store"
+    store_dir.mkdir(parents=True)
+    nonexistent = store_dir / "does_not_exist.json"
+
+    content, found = read_offloaded(str(nonexistent), base_dir=store_dir)
+    assert found is False
+    assert content == ""
+
+
+# ---------------------------------------------------------------------------
+# 9. Dict serialisation via json (not str())
+# ---------------------------------------------------------------------------
+
+
+def test_offload_value_dict_serialised_as_json(tmp_path: Path) -> None:
+    """Tier 2: offload_value serialises dict values via json.dumps (not str()).
+
+    The stored file must be valid JSON parseable back to the original dict.
+    """
+    value = {"nested": {"a": 1, "b": [2, 3]}, "flag": True}
+    store_dir = tmp_path / "store"
+    result = offload_value(value, store_dir=store_dir, preview_strategy=_identity_strategy)
+
+    raw = Path(result.path_ref).read_text(encoding="utf-8")
+    # Must parse as valid JSON
+    parsed = json.loads(raw)
+    assert parsed == value, "Stored dict must round-trip through JSON without loss"
+
+
+# ---------------------------------------------------------------------------
+# 10. content_hash format: "sha256:<hex>"
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_format_sha256_prefix(tmp_path: Path) -> None:
+    """Tier 2: content_hash is in the ``"sha256:<hex>"`` format.
+
+    This matches MediaStore.save_tool_result's convention
+    (``"sha256:" + hashlib.sha256(content.encode()).hexdigest()``)
+    so Phase 2 unification requires no format migration.
+    """
+    value = {"sample": "data"}
+    result = offload_value(value, store_dir=tmp_path / "s", preview_strategy=_identity_strategy)
+
+    assert result.content_hash.startswith("sha256:"), (
+        f"content_hash must start with 'sha256:', got: {result.content_hash!r}"
+    )
+    hex_part = result.content_hash[len("sha256:"):]
+    # SHA-256 hex digest contains only hex characters
+    assert hex_part and all(c in "0123456789abcdef" for c in hex_part), (
+        f"content_hash hex part is not a valid hex digest: {hex_part!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 C5 #223 Phase 1: extract common offload infrastructure into `services/offload/` and migrate the phase (control_ir_result) axis to it.

## Summary

- **Duplication problem**: Reyn has two independent "offload-to-file" implementations — (1) the phase axis in `context_builder.py` (`offload_control_ir_result` etc.) and (2) the chat/#385 axis in `media_store.py` (`MediaStore.save_tool_result`). Both write full content to a file and return a preview + path reference, but the phase impl has no content hash and no path-boundary validated read-back.

- **Common infrastructure** (`src/reyn/services/offload/store.py`): axis-agnostic `offload_value(value, *, store_dir, preview_strategy, filename)` + `read_offloaded(path_str, *, base_dir, content_hash, offset, limit)`. Preview is **strategy-injected** because what constitutes a useful preview differs per axis (LLM cognition is affected differently by phase context vs chat context — the phase type-aware field preview is the phase's policy, not generic infra). Content hash format: `"sha256:<hex>"` — matches MediaStore exactly so Phase 2 can unify without a format migration.

- **Phase axis migration** (`context_builder.py`): `offload_control_ir_result` is now a thin wrapper around `offload_value` with `_phase_preview_strategy` injected. All external behavior is preserved. One additive change: the offloaded inline now carries `_offload_content_hash`, enabling verified read-back.

- **Phase 1 scope guard**: `media_store.py`, `read_tool_result.py`, `web_fetch.py`, anything under `src/reyn/chat/` or `src/reyn/tools/` — NOT touched. That's Phase 2, coordinated with tui-coder.

- **P7 note**: `src/reyn/services/offload/` contains no skill names, phase names, or artifact-type literals. Verified with `grep`.

## What phase gains in Phase 1

- `_offload_content_hash` in every offloaded inline — callers can now do `read_offloaded(ref_path, base_dir=offload_dir, content_hash=hash)` for verified read-back.
- Path-boundary-validated read-back via the common `read_offloaded` (mirrors MediaStore's boundary enforcement).
- Sha256 content integrity on every offloaded result.
- C5-completeness bound (≤ `MAX_OFFLOADED_INLINE_BYTES`) preserved unchanged.

## Test plan

- [x] `pytest -q tests/test_services_offload_store.py` → 17/17 pass
- [x] `pytest -q tests/test_context_builder_per_result_offload.py` → 35/35 pass (15 existing + 20 new/extended)
- [x] `python scripts/test_tier_audit.py --strict tests/test_services_offload_store.py` → 0 errors
- [x] `ruff check .` → all checks passed
- [x] `pytest -q tests/` → 6428 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`), 5 skipped, 3 xfailed
- [x] `git diff --stat` shows no changes to `media_store.py`, `read_tool_result.py`, `web_fetch.py`, or `src/reyn/chat/` / `src/reyn/tools/`
- [x] `grep -rn "control_ir\|phase\|artifact\|skill" src/reyn/services/offload/` → only docstring prose, no code literals (P7 clean)

Refs #1093