### PR TITLE
feat(fp-0008): C5 #223 Phase 2 — migrate MediaStore local offload to common service (dedup complete)

### DIFF
--- a/src/reyn/services/offload/store.py
+++ b/src/reyn/services/offload/store.py
@@ -11,6 +11,27 @@ preview differs per use-site (LLM cognition context, output format, etc.).
 
 Content hash format: ``"sha256:<hex>"`` — matches MediaStore (media_store.py)
 so Phase 2 can unify the two implementations without a format migration.
+
+★ Three-party preview-bound contract
+=====================================
+When ``preview_strategy=None`` (= the chat/MediaStore axis), the service
+stores the content and computes the hash, but does **NOT** apply any preview
+bound.  Responsibility for bounding the inline preview lies with the CALLER:
+
+- **phase axis** (``preview_strategy`` is a real Callable):
+  The injected strategy holds the hard size-bound (e.g. the #1100 bound).
+  The service delegates entirely to the strategy — it neither caps nor expands
+  the result.
+
+- **chat axis** (``preview_strategy=None``, used by ``MediaStore``):
+  ``OffloadResult.preview`` is ``None``.  The calling code (e.g.
+  ``web.py`` ``_generate_web_fetch_preview``, first 10 lines) is responsible
+  for constructing and bounding the preview before returning it to the LLM.
+  The service does NOT bound anything on this axis.
+
+- **service**:  Holds **no** preview bound when ``preview_strategy=None``.
+  A future axis must NOT assume "the service bounds for me" — it must either
+  supply a strategy or bound externally.
 """
 from __future__ import annotations
 
@@ -27,7 +48,9 @@ class OffloadResult:
     """Returned by :func:`offload_value` after writing the full content to disk.
 
     Attributes:
-        preview:      The inline preview produced by the injected strategy.
+        preview:      The inline preview produced by the injected strategy, or
+                      ``None`` when ``preview_strategy=None`` was passed (= chat
+                      axis; the caller builds the preview externally).
                       Shape is strategy-dependent — callers may attach it to
                       the inline slot as-is.
         path_ref:     Absolute path string pointing at the file containing the
@@ -45,7 +68,7 @@ def offload_value(
     value: Any,
     *,
     store_dir: Path,
-    preview_strategy: Callable[[Any, str], Any],
+    preview_strategy: Callable[[Any, str], Any] | None = None,
     filename: str | None = None,
 ) -> OffloadResult:
     """Write *value* to *store_dir* and return preview + path_ref + content_hash.
@@ -58,14 +81,21 @@ def offload_value(
         value:            The value to offload (dict or str; other types via json).
         store_dir:        Directory to write the full content into. Created if
                           absent (parents included).
-        preview_strategy: Callable ``(value, path_ref) -> preview``. Invoked
-                          after the file is written so ``path_ref`` is available
-                          for embedding in the preview (e.g. truncation markers).
+        preview_strategy: Callable ``(value, path_ref) -> preview``, or ``None``.
+                          When provided, invoked after the file is written so
+                          ``path_ref`` is available for embedding in the preview
+                          (e.g. truncation markers); the result lands in
+                          ``OffloadResult.preview``.
+                          When ``None`` (= chat axis / MediaStore), the service
+                          performs NO preview generation; ``OffloadResult.preview``
+                          is ``None`` and the CALLER is responsible for bounding
+                          the inline preview externally.  See the module-level
+                          ★ three-party preview-bound contract for details.
         filename:         Optional explicit filename. When omitted a unique name
                           is derived from a UUID fragment.
 
     Returns:
-        :class:`OffloadResult` with preview, path_ref, content_hash.
+        :class:`OffloadResult` with preview (or ``None``), path_ref, content_hash.
     """
     store_dir.mkdir(parents=True, exist_ok=True)
 
@@ -79,7 +109,7 @@ def offload_value(
 
     path_ref = str(dest)
     content_hash = "sha256:" + hashlib.sha256(serialized.encode()).hexdigest()
-    preview = preview_strategy(value, path_ref)
+    preview = preview_strategy(value, path_ref) if preview_strategy is not None else None
 
     return OffloadResult(preview=preview, path_ref=path_ref, content_hash=content_hash)
 

--- a/src/reyn/workspace/media_store.py
+++ b/src/reyn/workspace/media_store.py
@@ -62,6 +62,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from reyn.services.offload.store import offload_value, read_offloaded
+
 # Conservative mapping from MIME type to file extension; unknown types
 # fall back to ``""`` so the storage layer still writes a file (= user
 # can rename / inspect with their preferred tool). Extension is purely
@@ -303,23 +305,37 @@ class MediaStore:
         return a path-ref block (= ``{"type": "tool_result_ref", "path":
         ..., "mime_type": ..., "content_hash": ...}``).
 
-        PR-C lands this writer alongside ``save_image`` so the
-        abstraction is uniform across multimodal axes. The CONSUMER
-        side (= web_fetch / file_read text-path rework to actually
-        emit path-refs + preview) is deferred to PR-D per #385.
+        The LOCAL store + hash is delegated to :func:`offload_value` from
+        ``services/offload/store.py`` (Phase 2 of the offload-dedup effort,
+        FP-0008 C5 #223).  The return block shape is IDENTICAL to the
+        pre-migration contract — callers are unaffected.
+
+        Preview-bound note: ``preview_strategy=None`` is passed so the
+        common service performs no preview bounding.  The preview is built
+        externally by the caller (e.g. ``web.py`` ``_generate_web_fetch_preview``).
+        See the ★ three-party bound contract in
+        ``services/offload/store.py`` module docstring.
         """
-        self._tool_results_dir.mkdir(parents=True, exist_ok=True)
         chain_short = _safe_token(chain_id)[:6] if chain_id else ""
         tool_token = _safe_token(tool) or "tool"
         ext = _ext_for_mime(mime_type)
         filename = f"{_timestamp()}-{chain_short}-{tool_token}-{seq}{ext}"
-        path = self._tool_results_dir / filename
-        path.write_text(content, encoding="utf-8")
+
+        result = offload_value(
+            content,
+            store_dir=self._tool_results_dir,
+            preview_strategy=None,
+            filename=filename,
+        )
+
+        # Convert absolute path_ref to project-relative path for the block.
+        abs_path = Path(result.path_ref)
+        rel_path = str(abs_path.relative_to(self._project_root))
         block: dict = {
             "type": "tool_result_ref",
-            "path": str(path.relative_to(self._project_root)),
+            "path": rel_path,
             "mime_type": mime_type,
-            "content_hash": "sha256:" + hashlib.sha256(content.encode()).hexdigest(),
+            "content_hash": result.content_hash,
         }
         self._attach_cross_host_fields(block, filename=filename, chain_id=chain_id)
         return block
@@ -329,18 +345,31 @@ class MediaStore:
 
         Validates the resolved path lives inside ``tool_results_dir``.
         Returns ``(text, found)``.
+
+        The LOCAL read is delegated to :func:`read_offloaded` from
+        ``services/offload/store.py`` (Phase 2 of the offload-dedup effort).
+        The ``(text, found)`` contract and ``PermissionError`` boundary are
+        preserved identically — callers are unaffected.
+
+        Path resolution: ``path_str`` is project-relative; we resolve it
+        under ``self._project_root`` to an absolute path before passing
+        to ``read_offloaded`` (which expects an absolute path_str).
+        The boundary ``base_dir=self._tool_results_dir`` ensures the
+        ``PermissionError`` fires for any path outside ``tool_results_dir``.
         """
-        full = (self._project_root / path_str).resolve()
+        # Resolve project-relative → absolute before calling read_offloaded,
+        # which validates against base_dir (= tool_results_dir).
+        abs_path = str((self._project_root / path_str).resolve())
         try:
-            full.relative_to(self._tool_results_dir)
-        except ValueError as exc:
+            return read_offloaded(abs_path, base_dir=self._tool_results_dir)
+        except PermissionError:
+            # Re-raise with the original MediaStore error message shape so
+            # existing consumers that match on "outside tool_results_dir"
+            # continue to work.
             raise PermissionError(
                 f"path {path_str!r} is outside tool_results_dir "
                 f"{self._tool_results_dir} — refusing to read"
-            ) from exc
-        if not full.exists():
-            return "", False
-        return full.read_text(encoding="utf-8"), True
+            )
 
     # ── Cross-host routing (#385 β core impl sub-task 1) ──────────────
 

--- a/tests/test_mediastore_common_offload_phase2.py
+++ b/tests/test_mediastore_common_offload_phase2.py
@@ -1,0 +1,392 @@
+"""Tier 2: MediaStore Phase 2 — common offload service migration preservation guards.
+
+Pins the invariants of the FP-0008 C5 #223 Phase 2 migration: the LOCAL
+store+hash+read core of ``save_tool_result`` / ``read_tool_result`` is
+delegated to ``services/offload/store.py``, while the return-block shape,
+(text, found) contract, PermissionError boundary, and cross-host methods are
+preserved BYTE-FOR-BYTE.
+
+Covered invariants:
+1. save_tool_result block shape unchanged:
+   {type:"tool_result_ref", path:<project-relative>, mime_type, content_hash:"sha256:..."};
+   the file is written under tool_results_dir with the original content;
+   content_hash is correct.
+2. read_tool_result round-trip: save then read → original content + found=True.
+3. read_tool_result missing file → ("", False).
+4. read_tool_result outside tool_results_dir → PermissionError (boundary preserved).
+5. preview_strategy=None additive change:
+   offload_value(..., preview_strategy=None) → OffloadResult.preview is None,
+   store + hash still work correctly.
+6. Existing phase tests (with a real strategy) still pass (additive change verified).
+7. Cross-host methods (read_tool_result_by_uri / by_url / _attach_cross_host_fields)
+   are unchanged — their existing tests pass (structural assertion).
+8. web_fetch flow: the save_tool_result call contract + path_ref shape still holds.
+
+Policy compliance:
+- No unittest.mock / MagicMock / AsyncMock / patch (except monkeypatch for httpx).
+- No private-state assertions.
+- Each docstring opens with ``Tier 2: ...``.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.services.offload.store import OffloadResult, offload_value
+from reyn.workspace.media_store import MediaStore, MediaStoreConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path: Path) -> MediaStore:
+    return MediaStore(MediaStoreConfig(), project_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. save_tool_result block shape unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_save_tool_result_block_shape_preserved(tmp_path: Path) -> None:
+    """Tier 2: save_tool_result returns the expected block shape after migration.
+
+    The block must contain exactly:
+      {type:"tool_result_ref", path:<project-relative>, mime_type, content_hash:"sha256:..."}
+    The file at ``path`` must exist under tool_results_dir with the original content.
+    The content_hash must equal sha256 of the UTF-8 encoded content.
+    """
+    store = _store(tmp_path)
+    content = "hello from phase 2 migration\n"
+    block = store.save_tool_result(
+        content, mime_type="text/plain", chain_id="abc123", tool="web_fetch", seq=1,
+    )
+
+    # Block shape
+    assert block["type"] == "tool_result_ref"
+    assert block["mime_type"] == "text/plain"
+    # path is project-relative (no leading /)
+    assert not block["path"].startswith("/")
+    assert block["path"].startswith(".reyn/tool-results/")
+    assert block["path"].endswith(".txt")
+    assert "content_hash" in block
+    assert block["content_hash"].startswith("sha256:")
+
+    # File written under tool_results_dir with original content
+    full = tmp_path / block["path"]
+    assert full.exists(), "file must be written under tool_results_dir"
+    assert full.read_text(encoding="utf-8") == content
+
+    # content_hash is correct sha256 of content bytes
+    expected_hash = "sha256:" + hashlib.sha256(content.encode()).hexdigest()
+    assert block["content_hash"] == expected_hash
+
+
+def test_save_tool_result_html_block_shape(tmp_path: Path) -> None:
+    """Tier 2: text/html mime → .html extension; block shape preserved for non-plain types."""
+    store = _store(tmp_path)
+    content = "<html><body>hello</body></html>"
+    block = store.save_tool_result(content, mime_type="text/html", tool="web_fetch", seq=1)
+
+    assert block["type"] == "tool_result_ref"
+    assert block["mime_type"] == "text/html"
+    assert block["path"].endswith(".html")
+    full = tmp_path / block["path"]
+    assert full.read_text(encoding="utf-8") == content
+    expected_hash = "sha256:" + hashlib.sha256(content.encode()).hexdigest()
+    assert block["content_hash"] == expected_hash
+
+
+def test_save_tool_result_path_is_project_relative_not_absolute(tmp_path: Path) -> None:
+    """Tier 2: the block 'path' field must be project-relative, not absolute.
+
+    After migration, offload_value returns an absolute path_ref; the wrapper
+    must convert to project-relative. This test guards that conversion.
+    """
+    store = _store(tmp_path)
+    block = store.save_tool_result("content", mime_type="text/plain")
+
+    assert not block["path"].startswith("/"), (
+        f"path must be project-relative, got absolute: {block['path']!r}"
+    )
+    assert block["path"].startswith(".reyn/tool-results/")
+
+
+# ---------------------------------------------------------------------------
+# 2. read_tool_result round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_read_tool_result_round_trip(tmp_path: Path) -> None:
+    """Tier 2: save_tool_result + read_tool_result(returned path) → original content + found=True."""
+    store = _store(tmp_path)
+    content = "Line 1\nLine 2\nLine 3\n"
+    block = store.save_tool_result(content, mime_type="text/plain")
+
+    text, found = store.read_tool_result(block["path"])
+    assert found is True
+    assert text == content
+
+
+def test_read_tool_result_unicode_round_trip(tmp_path: Path) -> None:
+    """Tier 2: Unicode content is preserved through the save→read round-trip.
+
+    Verifies UTF-8 write + read is byte-identical for non-ASCII characters.
+    """
+    store = _store(tmp_path)
+    content = "日本語テスト\n中文测试\n한국어 테스트\n"
+    block = store.save_tool_result(content, mime_type="text/plain")
+
+    text, found = store.read_tool_result(block["path"])
+    assert found is True
+    assert text == content
+
+
+# ---------------------------------------------------------------------------
+# 3. read_tool_result missing → ("", False)
+# ---------------------------------------------------------------------------
+
+
+def test_read_tool_result_missing_returns_not_found(tmp_path: Path) -> None:
+    """Tier 2: a valid path inside tool_results_dir for a non-existent file → ("", False).
+
+    Matches the pre-migration contract: found=False for deleted/never-written files.
+    """
+    store = _store(tmp_path)
+    # Ensure the directory exists so path validation passes.
+    store.tool_results_dir.mkdir(parents=True, exist_ok=True)
+    fake_rel = str(
+        (store.tool_results_dir / "does-not-exist.txt").relative_to(tmp_path)
+    )
+
+    text, found = store.read_tool_result(fake_rel)
+    assert found is False
+    assert text == ""
+
+
+# ---------------------------------------------------------------------------
+# 4. read_tool_result outside tool_results_dir → PermissionError
+# ---------------------------------------------------------------------------
+
+
+def test_read_tool_result_outside_boundary_raises_permission_error(tmp_path: Path) -> None:
+    """Tier 2: a path outside tool_results_dir raises PermissionError.
+
+    The error message must contain 'outside tool_results_dir' — the same
+    shape as the pre-migration implementation so downstream consumers
+    that match on the error string keep working.
+    """
+    store = _store(tmp_path)
+    (tmp_path / "secret.txt").write_text("not allowed", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="outside tool_results_dir"):
+        store.read_tool_result("secret.txt")
+
+
+def test_read_tool_result_traversal_raises_permission_error(tmp_path: Path) -> None:
+    """Tier 2: a ../traversal path outside tool_results_dir raises PermissionError."""
+    store = _store(tmp_path)
+
+    with pytest.raises(PermissionError, match="outside tool_results_dir"):
+        store.read_tool_result("../etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# 5. preview_strategy=None additive change: OffloadResult.preview is None
+# ---------------------------------------------------------------------------
+
+
+def test_offload_value_preview_strategy_none_returns_none_preview(tmp_path: Path) -> None:
+    """Tier 2: offload_value with preview_strategy=None → OffloadResult.preview is None.
+
+    The chat/MediaStore axis passes None; the service must NOT crash and must
+    return preview=None. Store + hash must still work correctly.
+    """
+    content = "some text content"
+    result = offload_value(
+        content,
+        store_dir=tmp_path / "store",
+        preview_strategy=None,
+        filename="test.txt",
+    )
+
+    assert isinstance(result, OffloadResult)
+    assert result.preview is None, (
+        f"preview must be None when preview_strategy=None, got {result.preview!r}"
+    )
+    # Store + hash still work
+    assert result.path_ref.endswith("test.txt")
+    stored = Path(result.path_ref).read_text(encoding="utf-8")
+    assert stored == content
+    expected_hash = "sha256:" + hashlib.sha256(content.encode()).hexdigest()
+    assert result.content_hash == expected_hash
+
+
+def test_offload_value_preview_strategy_none_with_dict_value(tmp_path: Path) -> None:
+    """Tier 2: preview_strategy=None works for dict values (json serialisation path)."""
+    value = {"key": "value", "count": 42}
+    result = offload_value(
+        value,
+        store_dir=tmp_path / "store",
+        preview_strategy=None,
+        filename="test.json",
+    )
+
+    assert result.preview is None
+    assert Path(result.path_ref).exists()
+    import json
+    stored = json.loads(Path(result.path_ref).read_text(encoding="utf-8"))
+    assert stored == value
+
+
+# ---------------------------------------------------------------------------
+# 6. Additive change verified: existing phase caller with a real strategy still works
+# ---------------------------------------------------------------------------
+
+
+def test_offload_value_real_strategy_still_works_after_additive_change(tmp_path: Path) -> None:
+    """Tier 2: offload_value with a real strategy (non-None) still works correctly.
+
+    Making preview_strategy optional (= additive) must not break the phase
+    axis that passes real strategies. This test guards that the additive
+    change does not regress existing phase callers.
+    """
+    calls: list = []
+
+    def recording_strategy(value: Any, path_ref: str) -> str:
+        calls.append((value, path_ref))
+        return f"preview:{path_ref}"
+
+    value = {"data": "phase axis content"}
+    result = offload_value(
+        value,
+        store_dir=tmp_path / "store",
+        preview_strategy=recording_strategy,
+    )
+
+    assert result.preview is not None, "preview must be non-None when strategy provided"
+    assert calls, "strategy must be invoked"
+    assert result.preview == f"preview:{result.path_ref}"
+
+
+# ---------------------------------------------------------------------------
+# 7. Cross-host methods structural verification
+# ---------------------------------------------------------------------------
+
+
+def test_cross_host_method_read_by_uri_unchanged(tmp_path: Path) -> None:
+    """Tier 2: read_tool_result_by_uri is untouched by the Phase 2 migration.
+
+    Verifies the same-host round-trip (URI → content) still works, confirming
+    cross-host methods were not accidentally modified.
+    """
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="test-agent",
+    )
+    block = store.save_tool_result(
+        "uri content\n", mime_type="text/plain", chain_id="c1",
+    )
+
+    text, found = store.read_tool_result_by_uri(block["resource_uri"])
+    assert found is True
+    assert text == "uri content\n"
+
+
+def test_cross_host_method_read_by_url_unchanged(tmp_path: Path) -> None:
+    """Tier 2: read_tool_result_by_url is untouched by the Phase 2 migration.
+
+    Verifies the same-host URL short-circuit still works, confirming
+    cross-host methods were not accidentally modified.
+    """
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_path,
+        agent_name="test-agent",
+        base_url="https://reyn.example.com",
+    )
+    block = store.save_tool_result(
+        "url content\n", mime_type="text/plain", chain_id="c1", tool="web_fetch", seq=1,
+    )
+
+    text, found = store.read_tool_result_by_url(block["url"])
+    assert found is True
+    assert text == "url content\n"
+
+
+def test_attach_cross_host_fields_unchanged_with_agent_name(tmp_path: Path) -> None:
+    """Tier 2: _attach_cross_host_fields is untouched — cross-host block fields
+    are still emitted with the same schema when agent_name is set.
+    """
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=tmp_path,
+        agent_name="researcher",
+        base_url="https://reyn.example.com",
+    )
+    block = store.save_tool_result(
+        "body", mime_type="text/plain", chain_id="chain1",
+    )
+
+    assert block["source_agent"] == "researcher"
+    assert block["source_chain_id"] == "chain1"
+    assert block["resource_uri"].startswith("reyn-tool-result://researcher/")
+    assert "url" in block
+    filename = Path(block["path"]).name
+    assert block["url"].endswith(f"/tool-results/{filename}")
+
+
+def test_save_image_is_unchanged_by_phase2_migration(tmp_path: Path) -> None:
+    """Tier 2: save_image is NOT migrated in Phase 2 (out of scope) and
+    must continue to work byte-for-byte identically.
+    """
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="vision",
+    )
+    data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    block = store.save_image(
+        data, mime_type="image/png", chain_id="c2", tool="web_fetch", seq=1,
+    )
+
+    assert block["type"] == "image"
+    assert block["path"].startswith(".reyn/media/")
+    full = tmp_path / block["path"]
+    assert full.read_bytes() == data
+    expected_hash = "sha256:" + hashlib.sha256(data).hexdigest()
+    assert block["content_hash"] == expected_hash
+
+
+# ---------------------------------------------------------------------------
+# 8. web_fetch flow: save_tool_result call site + path_ref block shape
+# ---------------------------------------------------------------------------
+
+
+def test_web_fetch_call_site_block_shape_via_media_store(tmp_path: Path) -> None:
+    """Tier 2: the web_fetch/web.py call site (ctx.media_store.save_tool_result(...))
+    must produce a path_ref block whose shape is identical to the pre-migration contract.
+
+    This test verifies the contract from the web.py caller's perspective:
+    save_tool_result returns {type:"tool_result_ref", path:..., mime_type:..., content_hash:...}
+    and the file exists + is readable at that path.
+    """
+    store = _store(tmp_path)
+    # Simulate the web.py call: text content with text/html mime type.
+    extracted_body = "<html><head><title>T</title></head><body><p>content</p></body></html>"
+    block = store.save_tool_result(
+        extracted_body, mime_type="text/html; charset=utf-8",
+        chain_id="chain123", tool="web_fetch", seq=1,
+    )
+
+    # Block shape as expected by web.py + preview generation
+    assert block["type"] == "tool_result_ref"
+    assert "path" in block
+    assert "mime_type" in block
+    assert "content_hash" in block
+    assert block["content_hash"].startswith("sha256:")
+    # File exists and contains the full body
+    full = tmp_path / block["path"]
+    assert full.exists()
+    assert full.read_text(encoding="utf-8") == extracted_body


### PR DESCRIPTION
**[e2e-coder]** — Completes the offload dedup that Phase 1 (#1103) started: the phase axis already delegates to `services/offload/store.py`; this PR migrates the chat/#385 axis.

## What changed

**`services/offload/store.py` (additive)**
- `preview_strategy` is now `Optional[Callable]` (default `None`). When `None`, `OffloadResult.preview = None` and the service stores + hashes only. Phase callers that pass a strategy are completely unaffected — the type signature is backward-compatible.

**`workspace/media_store.py` (LOCAL core only)**
- `save_tool_result`: the local store + content_hash computation is now delegated to `offload_value(content, store_dir=tool_results_dir, preview_strategy=None, filename=...)`. The absolute `path_ref` returned by the service is converted to project-relative for the block. Block shape is **identical**: `{type:"tool_result_ref", path:<project-relative>, mime_type, content_hash:"sha256:..."}` + cross-host augmentation via `_attach_cross_host_fields`.
- `read_tool_result`: the local read is delegated to `read_offloaded(abs_path, base_dir=tool_results_dir)`. Project-relative `path_str` is resolved to absolute under `project_root` before the call; the `PermissionError` message shape is preserved so consumers matching on `"outside tool_results_dir"` keep working.

**Untouched (confirmed by `git diff`):** `read_tool_result_by_uri`, `read_tool_result_by_url`, `_attach_cross_host_fields`, `save_image`, `read_image`, `web_fetch.py`, `op_runtime/web.py`.

## ★ Three-party preview-bound contract

When `preview_strategy=None`, the common service bounds **nothing** — it stores and hashes only. Preview responsibility is:

| Axis | Who builds/bounds preview | Where documented |
|---|---|---|
| **phase** | The injected `preview_strategy` callable (holds #1100 hard-bound) | Strategy implementation |
| **chat** | The CALLER — `web.py` `_generate_web_fetch_preview` (first 10 lines) | `web.py` + this PR |
| **service** | **NO bound** when `preview_strategy=None` | `store.py` module docstring + `offload_value` docstring |

This contract is documented in:
1. `services/offload/store.py` module-level docstring (★ three-party preview-bound contract section)
2. `offload_value` docstring (`preview_strategy` parameter description)
3. `save_tool_result` docstring in `media_store.py`

A future axis MUST NOT assume "the service bounds for me" — it must supply a strategy or bound externally.

## Scope

**Migrated:** LOCAL store+hash (`save_tool_result`) + LOCAL read (`read_tool_result`)
**NOT touched:** cross-host `read_tool_result_by_uri` / `_by_url` / `_attach_cross_host_fields` / `save_image` — these are HTTP/RPC methods, not local-file offload

## Tests

`tests/test_mediastore_common_offload_phase2.py` — 16 Tier 2 migration-preservation guards:
1. save_tool_result block shape preserved (type/path-relative/mime/content_hash + correct sha256)
2. read_tool_result round-trip → original content + found=True
3. Unicode round-trip
4. read_tool_result missing file → ("", False)
5. PermissionError for path outside tool_results_dir (message shape preserved)
6. Traversal PermissionError
7. `offload_value(preview_strategy=None)` → `OffloadResult.preview is None`, store+hash work
8. `preview_strategy=None` with dict value (json path)
9. Real strategy still works (additive change verified)
10. `read_tool_result_by_uri` unchanged (same-host round-trip)
11. `read_tool_result_by_url` unchanged
12. `_attach_cross_host_fields` unchanged (resource_uri/source_agent/url shape)
13. `save_image` unchanged (out of scope)
14. web_fetch call site block shape

All pass. No MagicMock. No private-state assertions. Tier audit: 16/16 OK.

Refs #1093

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest -q tests/ -k "media_store or tool_result or offload or web_fetch or context_builder"` — 219 passed, 1 known pre-existing failure (`test_legacy_no_media_store_path_returns_inline_content`)
- [x] `python scripts/test_tier_audit.py --strict tests/test_mediastore_common_offload_phase2.py` — 16/16 OK, 0 errors
- [x] `pytest -q tests/` full suite — 6444 passed, 5 skipped, 3 xfailed, 1 known pre-existing failure (confirmed the ONLY pre-existing failure)
- [x] `git diff` confirms `read_tool_result_by_uri`, `read_tool_result_by_url`, `_attach_cross_host_fields`, `save_image` have zero changes
- [ ] **tui-coder must UX-verify expand-on-demand (LLM reads preview → `read_tool_result` to expand) before merge** — this PR preserves the existing contract but the TUI UX path has not been manually exercised by this session