### PR TITLE
refactor(tui): migrate app/misc colours to palette tokens + semantic-distinction invariant test

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -36,7 +36,6 @@ from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.theme import Theme
 
-from .widgets import ConversationView, InputBar, InterventionWidget, ReynHeader, RightPanel
 from reyn.chat.tui._palette import (
     _BORDER_DIM,
     _CORAL,
@@ -44,6 +43,8 @@ from reyn.chat.tui._palette import (
     _TEXT_BRIGHT,
     _TEXT_DIM,
 )
+
+from .widgets import ConversationView, InputBar, InterventionWidget, ReynHeader, RightPanel
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -37,6 +37,13 @@ from textual.containers import Horizontal
 from textual.theme import Theme
 
 from .widgets import ConversationView, InputBar, InterventionWidget, ReynHeader, RightPanel
+from reyn.chat.tui._palette import (
+    _BORDER_DIM,
+    _CORAL,
+    _TEXT_BODY,
+    _TEXT_BRIGHT,
+    _TEXT_DIM,
+)
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry
@@ -193,12 +200,12 @@ class ReynTUIApp(App):
 
     _REYN_THEME = Theme(
         name="reyn",
-        primary="#C8553D",
-        accent="#C8553D",
+        primary=_CORAL,
+        accent=_CORAL,
         dark=True,
         variables={
-            "block-cursor-background": "#C8553D",
-            "block-cursor-foreground": "#ffffff",
+            "block-cursor-background": _CORAL,
+            "block-cursor-foreground": "#ffffff",  # palette-candidate: white foreground on coral cursor
         },
     )
 
@@ -400,11 +407,11 @@ class ReynTUIApp(App):
                 if info:
                     key, val = info
                     rt.append("    ")
-                    rt.append(f"{key}  ", style="dim #555555")
-                    rt.append(val, style="#dddddd")
+                    rt.append(f"{key}  ", style=f"dim {_TEXT_DIM}")
+                    rt.append(val, style=_TEXT_BRIGHT)
                 conv._write_log(rt)
-            conv._write_log(Text("  Gives you the reins.", style="dim #555555"))
-            conv._write_log(Text("─" * 38, style="#2a2a2a"))
+            conv._write_log(Text("  Gives you the reins.", style=f"dim {_TEXT_DIM}"))
+            conv._write_log(Text("─" * 38, style=_BORDER_DIM))
 
         # ``--no-restore`` was previously surfaced only via a stderr print
         # from the CLI entry point, which the TUI overlay completely hides.
@@ -418,7 +425,7 @@ class ReynTUIApp(App):
             conv._write_log(_RichText(
                 "⚠ --no-restore: in-flight skill state was NOT loaded this run. "
                 "Restart without --no-restore to resume.",
-                style="#d4a017",
+                style="#d4a017",  # palette-candidate: advisory-warning amber (no-restore notice)
             ))
 
         # Start outbox subscription if registry is available
@@ -522,7 +529,7 @@ class ReynTUIApp(App):
             breadcrumb = _RichText()
             breadcrumb.append(
                 f"  ✗ {cancelled} {label} skipped (see /pending list)",
-                style="dim #aa6666",
+                style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
             )
             try:
                 conv = self.query_one("#conversation", ConversationView)
@@ -1200,12 +1207,12 @@ class ReynTUIApp(App):
                 self._voice_status(
                     f"✗ cancelled {cancelled_interventions} "
                     f"intervention{'s' if cancelled_interventions != 1 else ''}",
-                    style="bold #aa6666",
+                    style="bold #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
                 )
             else:
                 self._voice_status(
                     "(nothing to cancel — no session attached)",
-                    style="dim #aa6666",
+                    style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
                 )
             return
 
@@ -1230,7 +1237,7 @@ class ReynTUIApp(App):
             # arrives as a ``status`` outbox frame from the server.
             self._voice_status(
                 "cancel sent to remote — awaiting confirmation",
-                style="dim #aa6666",
+                style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
             )
             # Seal any locally-tracked skill-activity rows so their
             # spinners stop immediately (the remote will send
@@ -1386,7 +1393,7 @@ class ReynTUIApp(App):
                 # like an unimportant aside.
                 self._voice_status(
                     "✗ nothing in-flight to cancel — try /list to see active runs",
-                    style="dim #555555",
+                    style="dim " + _TEXT_DIM,
                 )
                 self._last_idle_cancel_ts = now
             return
@@ -1414,7 +1421,7 @@ class ReynTUIApp(App):
                 f"{'s' if cancelled_tool_calls != 1 else ''}"
             )
         self._voice_status(
-            f"✗ cancelled {' + '.join(parts)}", style="bold #aa6666",
+            f"✗ cancelled {' + '.join(parts)}", style="bold #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
         )
 
     def action_toggle_panel(self) -> None:
@@ -1910,7 +1917,7 @@ class ReynTUIApp(App):
 
     # ── voice input (F2 / Esc) ─────────────────────────────────────────────
 
-    def _voice_status(self, text: str, *, style: str = "dim #aaaaaa") -> None:
+    def _voice_status(self, text: str, *, style: str = "dim " + _TEXT_BODY) -> None:
         """Write a short status line into the conversation pane."""
         try:
             from rich.text import Text as RichText
@@ -2051,7 +2058,7 @@ class ReynTUIApp(App):
             preview = text if len(text) <= 60 else text[:57] + "…"
             dur = diag.get("duration_s", 0.0)
             self._voice_status(
-                f"✓ inserted ({dur:.1f}s): {preview}", style="dim #aaaaaa"
+                f"✓ inserted ({dur:.1f}s): {preview}", style="dim " + _TEXT_BODY
             )
 
     async def action_voice_stop_and_submit(self) -> None:
@@ -2106,7 +2113,7 @@ class ReynTUIApp(App):
         preview = text if len(text) <= 60 else text[:57] + "…"
         dur = diag.get("duration_s", 0.0)
         self._voice_status(
-            f"✓ sent ({dur:.1f}s): {preview}", style="dim #aaaaaa"
+            f"✓ sent ({dur:.1f}s): {preview}", style="dim " + _TEXT_BODY
         )
         await self._yield_for_render()
         _voice_vlog("action_voice_stop_and_submit: about to append + submit")
@@ -2211,19 +2218,19 @@ class ReynTUIApp(App):
         if reason == "no_audio" or dur < 0.3:
             self._voice_status(
                 "(no audio captured — mic permission? wrong device?)",
-                style="dim #aa6666",
+                style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
             )
         elif reason == "silent" or peak < 0.01:
             self._voice_status(
                 f"(silent capture: {dur:.1f}s, peak={peak:.3f}) — "
                 "check mic gain / system input device",
-                style="dim #aa6666",
+                style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
             )
         else:
             self._voice_status(
                 f"(no speech recognised in {dur:.1f}s, peak={peak:.3f}) — "
                 "try speaking closer / louder, or set a larger model",
-                style="dim #aa6666",
+                style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
             )
 
     def _voice_watchdog_tick(self) -> None:
@@ -2257,7 +2264,7 @@ class ReynTUIApp(App):
         self._voice_busy = True
         self._voice_status(
             f"⏰ recording cap reached ({cap:.0f}s) — transcribing & inserting…",
-            style="dim #aa6666",
+            style="dim #aa6666",  # palette-candidate: muted-error/cancel (no exact palette token)
         )
         asyncio.create_task(self._voice_auto_stop_and_insert())
 
@@ -2298,7 +2305,7 @@ class ReynTUIApp(App):
         self._voice_status(
             f"✓ inserted ({dur:.1f}s, auto-stopped): {preview}  — "
             "Ctrl+R to continue dictating, Enter to send",
-            style="dim #aaaaaa",
+            style="dim " + _TEXT_BODY,
         )
 
     def action_voice_cancel(self) -> None:
@@ -2325,7 +2332,7 @@ class ReynTUIApp(App):
             self._voice_input.cancel()
             self._voice_set_input_locked(False)
             self._voice_set_header_state(None)
-            self._voice_status("✗ recording cancelled", style="dim #555555")
+            self._voice_status("✗ recording cancelled", style="dim " + _TEXT_DIM)
             return
         try:
             input_bar = self.query_one("#inputbar", InputBar)

--- a/src/reyn/chat/tui/widgets/donut.py
+++ b/src/reyn/chat/tui/widgets/donut.py
@@ -170,6 +170,8 @@ class DonutScreen(ModalScreen):
 
 
 # Coral gradient — dim → bright, matching the 12-step shade ramp.
+# Decorative: these 12 gradient stops are intentionally not tokenised — they
+# are an easter egg visual effect, not semantic palette values.
 _COLOURS = (
     "#3a1a14",
     "#5a2820",

--- a/src/reyn/chat/tui/widgets/matrix.py
+++ b/src/reyn/chat/tui/widgets/matrix.py
@@ -96,6 +96,7 @@ class MatrixScreen(ModalScreen):
                 if 0 <= dist < col.trail_len:
                     if dist == 0:
                         # Bright head
+                        # Decorative: matrix rain greens intentionally not tokenised (easter egg, not semantic).
                         out.append(ch, style="bold #d8ffd8")
                     elif dist < 3:
                         out.append(ch, style="#88ff88")

--- a/tests/cli/test_palette_semantic_distinctions.py
+++ b/tests/cli/test_palette_semantic_distinctions.py
@@ -1,0 +1,109 @@
+"""Tier 2: palette distinction invariants — semantic tokens must stay pairwise distinct.
+
+Guards the substitute-vs-orthogonal colour distinctions in the TUI palette.
+A future "palette cleanup" that collapses any of these pairs would silently
+erase a designed visual distinction (= CI-invisible regression). This file
+makes the regression visible at CI time.
+
+What this IS: an invariant test — it asserts that semantically separate
+concepts remain visually separable (distinct hex values). The assertions
+pin DISTINCTNESS, not specific hex strings.
+
+What this is NOT: a format-pin test. It does not assert on specific colour
+values, lengths, or sizes. The != assertions below are inequality checks
+on Python string values, not format / shape pins.
+
+Rationale for each pair:
+  - _STATUS_ERROR != _STATUS_CRITICAL: recoverable failures (tool errors,
+    validation failures, retry-able events) vs hard-stop events (permission
+    denied, budget exceeded, phase_failed) are distinct severity tiers. The
+    eye needs a visual cue to tell "retry this" from "session is halted".
+  - _STATUS_SUCCESS != _STATUS_ERROR: success / failure must be
+    distinguishable from each other -- the baseline correctness invariant for
+    any status indicator.
+  - _EVENT_PLAN != _EVENT_SKILL: plan events (orange family) are a
+    separate forensic category from skill-run events (blue family). Collapsing
+    them would erase the ability to scan the events tab and quickly identify
+    which lines belong to plan lifecycle vs. skill execution.
+  - _EVENT_TOOL != _EVENT_SKILL: tool invocations (purple) are distinct
+    from skill orchestration (blue). A developer reading the events pane
+    needs to distinguish "a tool ran" from "a skill ran".
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui._palette import (
+    _EVENT_PLAN,
+    _EVENT_SKILL,
+    _EVENT_TOOL,
+    _STATUS_CRITICAL,
+    _STATUS_ERROR,
+    _STATUS_SUCCESS,
+)
+
+
+def test_status_error_distinct_from_status_critical() -> None:
+    """Tier 2: recoverable-error vs hard-stop severity tiers must stay visually separable.
+
+    _STATUS_ERROR (recoverable: tool failure, validation error, mcp
+    timeout, retry-able) and _STATUS_CRITICAL (hard stop: permission
+    denied, phase_failed, budget exceeded, interrupted) are designed as
+    separate severity tiers. If they collapse to the same colour the user
+    loses the visual cue distinguishing "retry-able" from "session halted".
+    """
+    assert _STATUS_ERROR != _STATUS_CRITICAL, (
+        f"_STATUS_ERROR and _STATUS_CRITICAL must be distinct; "
+        f"got both = {_STATUS_ERROR!r}. "
+        "Collapsing these erases the recoverable-vs-hard-stop severity distinction."
+    )
+
+
+def test_status_success_distinct_from_status_error() -> None:
+    """Tier 2: success and error indicators must be visually distinguishable.
+
+    Baseline correctness invariant -- a status indicator that makes success
+    and failure look the same provides no signal.
+    """
+    assert _STATUS_SUCCESS != _STATUS_ERROR, (
+        f"_STATUS_SUCCESS and _STATUS_ERROR must be distinct; "
+        f"got both = {_STATUS_SUCCESS!r}. "
+        "A status system where success == error provides no information."
+    )
+
+
+def test_event_plan_distinct_from_event_skill() -> None:
+    """Tier 2: plan-event orange and skill-event blue must be visually separable.
+
+    _EVENT_PLAN (plan emitted/aggregated/timeout, orange family) vs
+    _EVENT_SKILL (skill_run/workflow/artifact/index activity, blue family)
+    are different forensic categories in the events tab. The orange plan family
+    gives the operator a quick visual scan path for plan lifecycle across mixed
+    event streams. Collapsing to a single colour removes that scan affordance.
+    """
+    assert _EVENT_PLAN != _EVENT_SKILL, (
+        f"_EVENT_PLAN and _EVENT_SKILL must be distinct; "
+        f"got both = {_EVENT_PLAN!r}. "
+        "Plan orange vs skill blue is a designed forensic separation in the events tab."
+    )
+
+
+def test_event_tool_distinct_from_event_skill() -> None:
+    """Tier 2: tool-invocation purple and skill-orchestration blue must be separable.
+
+    _EVENT_TOOL (tool / mcp invocation, purple) vs _EVENT_SKILL
+    (skill orchestration, blue) appear in the same events tab stream.
+    A developer debugging a plan needs to distinguish "a tool ran" from
+    "a skill ran" without hovering over each row. Collapsing them
+    removes that immediate scan affordance.
+    """
+    assert _EVENT_TOOL != _EVENT_SKILL, (
+        f"_EVENT_TOOL and _EVENT_SKILL must be distinct; "
+        f"got both = {_EVENT_TOOL!r}. "
+        "Tool purple vs skill blue is a designed forensic separation."
+    )


### PR DESCRIPTION
**[tui-coder]** —

Part of the palette-consolidation migration wave (foundation #1102). This is the **app/misc** lane + the **distinction-invariant test** lead-coder requested on #1102.

## Changes
- **`app.py`**: exact-token hardcodes → token refs (value-preserving): `#C8553D`→`_CORAL`, `#555555`→`_TEXT_DIM`, `#dddddd`→`_TEXT_BRIGHT`, `#2a2a2a`→`_BORDER_DIM`, `#aaaaaa`→`_TEXT_BODY`.
- **`donut.py` / `matrix.py`**: easter-egg gradient colours are decorative (not semantic palette values) — left hardcoded with a one-line note.
- **`tests/cli/test_palette_semantic_distinctions.py`** (NEW, Tier 2): the distinction invariant.

## substitute-vs-orthogonal (flagged, NOT collapsed)
Left hardcoded with `# palette-candidate:` comments for a design follow-up (no exact foundation token; near-token collapse would erase a distinct semantic):
- `#ffffff` (white cursor fg on coral) · `#d4a017` (advisory-warning amber) · `#aa6666` (muted-error/cancel — distinct from `_STATUS_ERROR`)

## Distinction-invariant test (lead-coder's #1102 rec)
Guards the orthogonal token pairs — `_STATUS_ERROR != _STATUS_CRITICAL`, `_EVENT_PLAN != _EVENT_SKILL`, `_EVENT_TOOL != _EVENT_SKILL`, `_STATUS_SUCCESS != _STATUS_ERROR`. Pins **distinctness, not hex values** (inequality on string values — not a format-pin). Catches a future "cleanup" that collapses a designed distinction (otherwise CI-invisible).

## Test plan
- [x] `pytest tests/cli/test_palette_semantic_distinctions.py tests/cli/test_tui_smoke.py` — **44 passed**
- [x] `scripts/test_tier_audit.py --strict <test>` — **0 errors** (distinctness `!=` doesn't trip the format-pin regex)
- [x] value-preservation: app.py migrated tokens resolve to original hex (`_CORAL==#C8553D` etc.)
- [x] `import reyn.chat.tui.app` — OK

## Tier self-check
Migration = value-preserving refactor (no test for it; exact-hex assert = Tier-4 format-pin). The new invariant test pins distinctness not values (Tier 2, not a format-pin). No private-state asserts.

## Process note
The working changes were produced by a dispatched sub-agent whose worktree isolation raced with a concurrent foreground `gh pr checkout` (unrelated PR verify). The complete, pre-commit changes were recovered, re-verified, and committed by tui-coder directly — content is the intended deliverable. Filing a memory note so the wave pattern (no foreground git in the main dir while worktree agents are mid-flight) doesn't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)