### PR TITLE
refactor(tui): migrate RightPanel tab colours to palette tokens

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -12,6 +12,7 @@ from rich.text import Text as RichText
 from rich.tree import Tree as RichTree
 
 from reyn.chat.tui._palette import _DIVIDER_DIM, _TEXT_DIMMEST
+
 from .base import (
     _CORAL,
     _EVENT_PLAN,

--- a/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/agents_tab.py
@@ -11,7 +11,17 @@ from rich.console import Group as RichGroup
 from rich.text import Text as RichText
 from rich.tree import Tree as RichTree
 
-from .base import _CORAL, logger
+from reyn.chat.tui._palette import _DIVIDER_DIM, _TEXT_DIMMEST
+from .base import (
+    _CORAL,
+    _EVENT_PLAN,
+    _STATUS_ERROR,
+    _STATUS_SUCCESS,
+    _TEXT_BRIGHT,
+    _TEXT_DIM,
+    _TEXT_MUTED,
+    logger,
+)
 
 
 def _compact_ts(ts: str) -> str:
@@ -435,16 +445,16 @@ def render_agents(
     y_counter = 0
 
     if registry is None:
-        return "[#555555]  (no registry)[/]", flat_items, item_ys
+        return f"[{_TEXT_DIM}]  (no registry)[/]", flat_items, item_ys
 
     try:
         names = registry.list_names()
     except Exception as exc:
         logger.warning("right_panel agents: registry.list_names() failed: %s", exc)
-        return "[#555555]  (registry unavailable)[/]", flat_items, item_ys
+        return f"[{_TEXT_DIM}]  (registry unavailable)[/]", flat_items, item_ys
 
     if not names:
-        return "[#555555]  (no agents)[/]", flat_items, item_ys
+        return f"[{_TEXT_DIM}]  (no agents)[/]", flat_items, item_ys
 
     try:
         attached = registry.attached_name
@@ -508,15 +518,15 @@ def render_agents(
         has_work = bool(agent_skills) or bool(agent_plans)
         if has_work:
             status_glyph, status_text, status_style = (
-                "● ", "running", "#44cc88",
+                "● ", "running", _STATUS_SUCCESS,
             )
         elif in_loaded:
             status_glyph, status_text, status_style = (
-                "◐ ", "ready", "#aaaa55",
+                "◐ ", "ready", "#aaaa55",  # palette-candidate: agent ready (olive) — no foundation token yet
             )
         else:
             status_glyph, status_text, status_style = (
-                "○ ", "idle", "#555555",
+                "○ ", "idle", _TEXT_DIM,
             )
         # Apply ``reverse`` text-style on the cursor row so it stands out
         # without adding a column-prefix shift (= the attached ``▶ ``
@@ -527,11 +537,11 @@ def render_agents(
         label = RichText()
         label.append(
             "▶ " if is_attached else "  ",
-            style="#555555" + cursor_suffix,
+            style=_TEXT_DIM + cursor_suffix,
         )
         label.append(
             name,
-            style=("bold " + _CORAL if is_attached else "#dddddd") + cursor_suffix,
+            style=("bold " + _CORAL if is_attached else _TEXT_BRIGHT) + cursor_suffix,
         )
         label.append("  ", style="" + cursor_suffix)
         label.append(
@@ -545,7 +555,7 @@ def render_agents(
         })
         item_ys.append(agent_label_y)
 
-        tree = RichTree(label, guide_style="#333333")
+        tree = RichTree(label, guide_style=_DIVIDER_DIM)
 
         def _cursor_prefix(idx: int) -> tuple[str, str]:
             """Return (prefix, name_style) for selectable item ``idx``.
@@ -582,15 +592,15 @@ def render_agents(
                 # SkillActivityRow does (≥30s amber, ≥60s red) so a
                 # slow / stuck skill stands out at a glance.
                 if elapsed >= 60:
-                    elapsed_style = "bold #ff6644"
+                    elapsed_style = f"bold {_STATUS_ERROR}"
                 elif elapsed >= 30:
-                    elapsed_style = "bold #ffaa44"
+                    elapsed_style = "bold #ffaa44"  # palette-candidate: warning amber — no foundation token yet
                 else:
-                    elapsed_style = "#888888"
+                    elapsed_style = _TEXT_MUTED
                 skill_label.append(f"{elapsed:3d}s  ", style=elapsed_style)
                 skill_label.append(
                     info.get("skill_name", "?"),
-                    style=name_style or "#dddddd",
+                    style=name_style or _TEXT_BRIGHT,
                 )
                 # Wave-7 Topic C-F2: surface plan-step attribution as a
                 # ``[plan N/M]`` badge after the skill name so the
@@ -630,9 +640,9 @@ def render_agents(
                 if phase:
                     visits = info.get("phase_visits", 1)
                     phase_label = RichText()
-                    phase_label.append(phase, style="#555555")
+                    phase_label.append(phase, style=_TEXT_DIM)
                     if visits > 1:
-                        phase_label.append(f"  v{visits}", style="#444444")
+                        phase_label.append(f"  v{visits}", style=_TEXT_DIMMEST)
                     skill_node.add(phase_label)
                     y_counter += 1
                 flat_items.append({
@@ -685,26 +695,26 @@ def render_agents(
                 pfx, _ = _cursor_prefix(len(flat_items))
                 plan_label = RichText()
                 plan_label.append(pfx, style=_CORAL)
-                plan_label.append("plan ", style="#888888")
-                plan_label.append(p["plan_id"], style="#ff9944")
+                plan_label.append("plan ", style=_TEXT_MUTED)
+                plan_label.append(p["plan_id"], style=_EVENT_PLAN)
                 plan_label.append(
                     f"  {p['done']}/{p['total']}",
-                    style="#dddddd",
+                    style=_TEXT_BRIGHT,
                 )
                 if p["failed"]:
                     plan_label.append(
-                        f"  ({p['failed']} failed)", style="#ff6644",
+                        f"  ({p['failed']} failed)", style=_STATUS_ERROR,
                     )
                 plan_label.append(
                     f"  {p['status']}",
-                    style="#44cc88" if p["status"] == "running" else "#aaaa55",
+                    style=_STATUS_SUCCESS if p["status"] == "running" else "#aaaa55",  # palette-candidate: agent ready (olive) — no foundation token yet
                 )
                 plan_node = tree.add(plan_label)
                 item_ys.append(y_counter)
                 y_counter += 1
                 if p["goal"]:
                     goal = p["goal"][:60] + ("…" if len(p["goal"]) > 60 else "")
-                    plan_node.add(RichText(goal, style="#555555"))
+                    plan_node.add(RichText(goal, style=_TEXT_DIM))
                     y_counter += 1
                 flat_items.append({
                     "kind": "running_plan",
@@ -754,7 +764,7 @@ def render_agents(
         )
         if recent_skills or recent_plans:
             recent_node = tree.add(
-                RichText("recent", style="#777777")
+                RichText("recent", style="#777777")  # palette-candidate: mid-dim label — no foundation token yet
             )
             # The "recent" header occupies its own line.
             y_counter += 1
@@ -769,24 +779,24 @@ def render_agents(
                 #                       crashed / killed prior session)
                 status = s["status"]
                 if status == "ok":
-                    glyph, glyph_style = "✓ ", "#44cc88"
+                    glyph, glyph_style = "✓ ", _STATUS_SUCCESS
                 elif status == "stuck":
-                    glyph, glyph_style = "⊘ ", "#ffaa44"
+                    glyph, glyph_style = "⊘ ", "#ffaa44"  # palette-candidate: warning amber — no foundation token yet
                 else:
-                    glyph, glyph_style = "✗ ", "#ff6644"
+                    glyph, glyph_style = "✗ ", _STATUS_ERROR
                 line.append(glyph, style=glyph_style)
-                line.append(s["skill_name"], style="#bbbbbb")
+                line.append(s["skill_name"], style="#bbbbbb")  # palette-candidate: near-bright label — no foundation token yet
                 if s["duration_s"] > 0:
-                    line.append(f"  {s['duration_s']:.1f}s", style="#555555")
+                    line.append(f"  {s['duration_s']:.1f}s", style=_TEXT_DIM)
                 if status == "stuck":
                     line.append(
                         f"  (stuck @ {s.get('stuck_at', '?')})",
-                        style="#aa8844",
+                        style="#aa8844",  # palette-candidate: warning ochre — no foundation token yet
                     )
                 elif status != "ok":
-                    line.append(f"  ({status})", style="#aa6655")
+                    line.append(f"  ({status})", style="#aa6655")  # palette-candidate: muted error — no foundation token yet
                 if s["ts"]:
-                    line.append(f"  {_compact_ts(s['ts'])}", style="#444444")
+                    line.append(f"  {_compact_ts(s['ts'])}", style=_TEXT_DIMMEST)
                 recent_node.add(line)
                 item_ys.append(y_counter)
                 y_counter += 1
@@ -800,25 +810,25 @@ def render_agents(
                 line = RichText()
                 line.append(pfx, style=_CORAL)
                 ok = p["status"] == "ok"
-                line.append("✓ " if ok else "✗ ", style="#44cc88" if ok else "#ff6644")
-                line.append("plan ", style="#888888")
-                line.append(p["plan_id"], style="#ff9944")
+                line.append("✓ " if ok else "✗ ", style=_STATUS_SUCCESS if ok else _STATUS_ERROR)
+                line.append("plan ", style=_TEXT_MUTED)
+                line.append(p["plan_id"], style=_EVENT_PLAN)
                 line.append(
                     f"  {p['n_completed']}/{p['n_completed'] + p['n_failed']}",
-                    style="#bbbbbb",
+                    style="#bbbbbb",  # palette-candidate: near-bright label — no foundation token yet
                 )
                 if p["status"] == "interrupted" and p["exc_type"]:
-                    line.append(f"  {p['exc_type']}", style="#aa6655")
+                    line.append(f"  {p['exc_type']}", style="#aa6655")  # palette-candidate: muted error — no foundation token yet
                 elif p["status"] == "partial":
-                    line.append(f"  ({p['n_failed']} failed)", style="#aa6655")
+                    line.append(f"  ({p['n_failed']} failed)", style="#aa6655")  # palette-candidate: muted error — no foundation token yet
                 if p["ts"]:
-                    line.append(f"  {_compact_ts(p['ts'])}", style="#444444")
+                    line.append(f"  {_compact_ts(p['ts'])}", style=_TEXT_DIMMEST)
                 node = recent_node.add(line)
                 item_ys.append(y_counter)
                 y_counter += 1
                 if p["goal"]:
                     goal = p["goal"][:60] + ("…" if len(p["goal"]) > 60 else "")
-                    node.add(RichText(goal, style="#555555"))
+                    node.add(RichText(goal, style=_TEXT_DIM))
                     y_counter += 1
                 flat_items.append({
                     "kind": "recent_plan",
@@ -851,7 +861,7 @@ def render_agents(
                     if msg_count > 0 else ""
                 )
                 tree.add(RichText(
-                    f"last: {ts_str}{count_part}", style="#555555",
+                    f"last: {ts_str}{count_part}", style=_TEXT_DIM,
                 ))
                 y_counter += 1
                 if snippet:
@@ -869,8 +879,8 @@ def render_agents(
                         else flattened[:_max - 1] + "…"
                     )
                     line2 = RichText()
-                    line2.append("↳ ", style="#555555")
-                    line2.append(short, style="#444444")
+                    line2.append("↳ ", style=_TEXT_DIM)
+                    line2.append(short, style=_TEXT_DIMMEST)
                     tree.add(line2)
                     y_counter += 1
 

--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from reyn.chat.tui._palette import _TEXT_DIMMEST
+
 from .base import (
     _CORAL,
     _EVENT_PLAN,

--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -7,7 +7,19 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-from .base import _CORAL, _esc, logger
+from reyn.chat.tui._palette import _TEXT_DIMMEST
+from .base import (
+    _CORAL,
+    _EVENT_PLAN,
+    _STATUS_CRITICAL,
+    _STATUS_SUCCESS,
+    _TEXT_BODY,
+    _TEXT_BRIGHT,
+    _TEXT_DIM,
+    _TEXT_NEUTRAL,
+    _esc,
+    logger,
+)
 
 # Budget progress-bar geometry (default / wide-panel values)
 _BAR_FILL = "█"
@@ -62,8 +74,8 @@ def _new_bucket() -> dict:
 
 def _cost_str(bucket: dict) -> str:
     if not bucket["has_cost"]:
-        return "[#555555]N/A[/]"
-    return f"[#44cc88]${bucket['cost']:.4f}[/]"
+        return f"[{_TEXT_DIM}]N/A[/]"
+    return f"[{_STATUS_SUCCESS}]${bucket['cost']:.4f}[/]"
 
 
 def _tok(p: int, c: int) -> str:
@@ -78,8 +90,8 @@ def _tok(p: int, c: int) -> str:
     load-bearing number and stays visible on line 1.
     """
     return (
-        f"[#dddddd]{p + c:,}[/]\n"
-        f"[#555555]      ({p:,}p + {c:,}c)[/]"
+        f"[{_TEXT_BRIGHT}]{p + c:,}[/]\n"
+        f"[{_TEXT_DIM}]      ({p:,}p + {c:,}c)[/]"
     )
 
 
@@ -103,11 +115,11 @@ def _budget_bar(used: float, cap: float, *, bar_width: int = _BAR_WIDTH) -> str:
     ratio = min(1.0, used / cap) if cap > 0 else 0.0
     pct = int(ratio * 100)
     if ratio >= 0.9:
-        colour = "#ff4444"
+        colour = _STATUS_CRITICAL
     elif ratio >= 0.75:
         colour = _CORAL
     else:
-        colour = "#44cc88"
+        colour = _STATUS_SUCCESS
     if bar_width > 0:
         filled = round(ratio * bar_width)
         bar = _BAR_FILL * filled + _BAR_EMPTY * (bar_width - filled)
@@ -149,13 +161,13 @@ def _render_budget_caps(
             label = f"{daily_tok_used:,} / {int(tok_hard):,}"
             bar = _budget_bar(daily_tok_used, tok_hard, bar_width=bar_w)
             lines.append(
-                f"[#555555]    tokens  [/][#aaaaaa]{label:<{budget_label_w}}[/]  {bar}"
+                f"[{_TEXT_DIM}]    tokens  [/][{_TEXT_BODY}]{label:<{budget_label_w}}[/]  {bar}"
             )
         if cost_hard and cost_hard > 0:
             label = f"${daily_cost_used:.4f} / ${cost_hard:.4f}"
             bar = _budget_bar(daily_cost_used, cost_hard, bar_width=bar_w)
             lines.append(
-                f"[#555555]    cost    [/][#aaaaaa]{label:<{budget_label_w}}[/]  {bar}"
+                f"[{_TEXT_DIM}]    cost    [/][{_TEXT_BODY}]{label:<{budget_label_w}}[/]  {bar}"
             )
     except Exception as exc:
         logger.warning("right_panel cost: budget cap render failed: %s", exc)
@@ -184,12 +196,12 @@ def render_cost(
     show_extra = _show_cost_calls(content_width)
 
     if project_root is None:
-        lines.append("[#555555]  (no project root)[/]")
+        lines.append(f"[{_TEXT_DIM}]  (no project root)[/]")
         return "\n".join(lines)
 
     events_root = project_root / ".reyn" / "events"
     if not events_root.is_dir():
-        lines.append("[#555555]  (no events yet)[/]")
+        lines.append(f"[{_TEXT_DIM}]  (no events yet)[/]")
         return "\n".join(lines)
 
     today_str = datetime.date.today().isoformat()
@@ -336,21 +348,21 @@ def render_cost(
     # line clipped to ``(litellm estimate — may differ from …)`` and
     # the actionable half ("from actual provider billing") never
     # reached the user.
-    lines.append("[#555555]  (litellm estimate —[/]")
-    lines.append("[#555555]   may differ from actual billing)[/]")
+    lines.append(f"[{_TEXT_DIM}]  (litellm estimate —[/]")
+    lines.append(f"[{_TEXT_DIM}]   may differ from actual billing)[/]")
     lines.append("")
 
     # ── TODAY ────────────────────────────────────────────────────────
-    lines.append("[bold #aaaaaa]  TODAY[/]")
+    lines.append(f"[bold {_TEXT_BODY}]  TODAY[/]")
     if today["calls"] == 0:
-        lines.append("[#555555]    (no calls today)[/]")
+        lines.append(f"[{_TEXT_DIM}]    (no calls today)[/]")
     else:
-        lines.append(f"[#555555]    tokens  [/]{_tok(today['p'], today['c'])}")
-        lines.append(f"[#555555]    cost    [/]{_cost_str(today)}")
-        lines.append(f"[#555555]    calls   [/][#dddddd]{today['calls']}[/]")
+        lines.append(f"[{_TEXT_DIM}]    tokens  [/]{_tok(today['p'], today['c'])}")
+        lines.append(f"[{_TEXT_DIM}]    cost    [/]{_cost_str(today)}")
+        lines.append(f"[{_TEXT_DIM}]    calls   [/][{_TEXT_BRIGHT}]{today['calls']}[/]")
         spark = _sparkline(today["call_costs"])
         if spark:
-            lines.append(f"[#555555]    trend   [/]{spark}")
+            lines.append(f"[{_TEXT_DIM}]    trend   [/]{spark}")
         # Budget cap progress bars (only when caps are configured)
         if budget_tracker is not None:
             _render_budget_caps(
@@ -359,37 +371,37 @@ def render_cost(
     lines.append("")
 
     # ── ALL TIME ──────────────────────────────────────────────────────
-    lines.append("[bold #aaaaaa]  ALL TIME[/]")
+    lines.append(f"[bold {_TEXT_BODY}]  ALL TIME[/]")
     if total["calls"] == 0:
-        lines.append("[#555555]    (no LLM calls)[/]")
+        lines.append(f"[{_TEXT_DIM}]    (no LLM calls)[/]")
     else:
-        lines.append(f"[#555555]    tokens  [/]{_tok(total['p'], total['c'])}")
-        lines.append(f"[#555555]    cost    [/]{_cost_str(total)}")
-        lines.append(f"[#555555]    calls   [/][#dddddd]{total['calls']}[/]")
+        lines.append(f"[{_TEXT_DIM}]    tokens  [/]{_tok(total['p'], total['c'])}")
+        lines.append(f"[{_TEXT_DIM}]    cost    [/]{_cost_str(total)}")
+        lines.append(f"[{_TEXT_DIM}]    calls   [/][{_TEXT_BRIGHT}]{total['calls']}[/]")
         spark = _sparkline(total["call_costs"])
         if spark:
-            lines.append(f"[#555555]    trend   [/]{spark}")
+            lines.append(f"[{_TEXT_DIM}]    trend   [/]{spark}")
     lines.append("")
 
     # ── BY AGENT / SKILL ──────────────────────────────────────────────
-    lines.append("[bold #aaaaaa]  BY AGENT / SKILL[/]")
+    lines.append(f"[bold {_TEXT_BODY}]  BY AGENT / SKILL[/]")
     if by_agent_skill:
         for agent in sorted(by_agent_skill):
             ag = by_agent[agent]
             ag_tok = ag["p"] + ag["c"]
             # agent total: name bold white, tok light gray, cost bright green
             ag_cost = (
-                f"  [bold #44cc88]${ag['cost']:.4f}[/]"
+                f"  [bold {_STATUS_SUCCESS}]${ag['cost']:.4f}[/]"
                 if ag["has_cost"] and show_extra else ""
             )
             ag_calls = (
-                f"  [#777777]{ag['calls']}c[/]"
+                f"  [#777777]{ag['calls']}c[/]"  # palette-candidate: mid-dim label — no foundation token yet
                 if show_extra else ""
             )
             # name col width adapts to content_width (see _col_widths)
             lines.append(
-                f"[bold #dddddd]  {_esc(agent):<{agent_name_w}}[/]"
-                f"[#aaaaaa]{ag_tok:>7,} tok[/]"
+                f"[bold {_TEXT_BRIGHT}]  {_esc(agent):<{agent_name_w}}[/]"
+                f"[{_TEXT_BODY}]{ag_tok:>7,} tok[/]"
                 f"{ag_cost}"
                 f"{ag_calls}"
             )
@@ -399,22 +411,22 @@ def render_cost(
                 tok_total = m["p"] + m["c"]
                 # skill rows: dim name, muted green for cost — clearly subordinate
                 cost_part = (
-                    f"  [#2d7a4f]${m['cost']:.4f}[/]"
+                    f"  [#2d7a4f]${m['cost']:.4f}[/]"  # palette-candidate: dim success green — no foundation token yet
                     if m["has_cost"] and show_extra else ""
                 )
                 calls_part = (
-                    f"  [#444444]{m['calls']}c[/]"
+                    f"  [{_TEXT_DIMMEST}]{m['calls']}c[/]"
                     if show_extra else ""
                 )
                 lines.append(
-                    f"[#555555]    {_esc(skill):<{skill_name_w}}[/]"
-                    f"[#555555]{tok_total:>7,} tok[/]"
+                    f"[{_TEXT_DIM}]    {_esc(skill):<{skill_name_w}}[/]"
+                    f"[{_TEXT_DIM}]{tok_total:>7,} tok[/]"
                     f"{cost_part}"
                     f"{calls_part}"
                 )
             lines.append("")
     else:
-        lines.append("[#555555]    (no skill runs yet)[/]")
+        lines.append(f"[{_TEXT_DIM}]    (no skill runs yet)[/]")
     lines.append("")
 
     # ── BY PLAN ──────────────────────────────────────────────────────
@@ -422,7 +434,7 @@ def render_cost(
     # using plan-mode). Sort plans by descending cost so the expensive
     # ones surface first.
     if by_plan:
-        lines.append("[bold #aaaaaa]  BY PLAN[/]")
+        lines.append(f"[bold {_TEXT_BODY}]  BY PLAN[/]")
         sorted_plans = sorted(
             by_plan.items(),
             key=lambda kv: (-kv[1]["cost"], -(kv[1]["p"] + kv[1]["c"])),
@@ -430,22 +442,22 @@ def render_cost(
         for plan_id, pb in sorted_plans:
             tok_total = pb["p"] + pb["c"]
             cost_part = (
-                f"  [bold #44cc88]${pb['cost']:.4f}[/]"
+                f"  [bold {_STATUS_SUCCESS}]${pb['cost']:.4f}[/]"
                 if pb["has_cost"] and show_extra else ""
             )
             calls_part = (
-                f"  [#777777]{pb['calls']}c[/]"
+                f"  [#777777]{pb['calls']}c[/]"  # palette-candidate: mid-dim label — no foundation token yet
                 if show_extra else ""
             )
             short_pid = plan_id[:8]
             goal = plan_goals.get(plan_id, "")
             goal_part = (
-                f"  [#666666]{_esc(goal[:32] + ('…' if len(goal) > 32 else ''))}[/]"
+                f"  [{_TEXT_NEUTRAL}]{_esc(goal[:32] + ('…' if len(goal) > 32 else ''))}[/]"
                 if goal and show_extra else ""
             )
             lines.append(
-                f"[bold #ff9944]  {short_pid:<8}[/]"
-                f"  [#aaaaaa]{tok_total:>7,} tok[/]"
+                f"[bold {_EVENT_PLAN}]  {short_pid:<8}[/]"
+                f"  [{_TEXT_BODY}]{tok_total:>7,} tok[/]"
                 f"{cost_part}"
                 f"{calls_part}"
                 f"{goal_part}"
@@ -455,16 +467,16 @@ def render_cost(
                 sb = steps[step_id]
                 step_tok = sb["p"] + sb["c"]
                 step_cost_part = (
-                    f"  [#2d7a4f]${sb['cost']:.4f}[/]"
+                    f"  [#2d7a4f]${sb['cost']:.4f}[/]"  # palette-candidate: dim success green — no foundation token yet
                     if sb["has_cost"] and show_extra else ""
                 )
                 step_calls_part = (
-                    f"  [#444444]{sb['calls']}c[/]"
+                    f"  [{_TEXT_DIMMEST}]{sb['calls']}c[/]"
                     if show_extra else ""
                 )
                 lines.append(
-                    f"[#555555]    {_esc(step_id):<{skill_name_w}}[/]"
-                    f"[#555555]{step_tok:>7,} tok[/]"
+                    f"[{_TEXT_DIM}]    {_esc(step_id):<{skill_name_w}}[/]"
+                    f"[{_TEXT_DIM}]{step_tok:>7,} tok[/]"
                     f"{step_cost_part}"
                     f"{step_calls_part}"
                 )
@@ -472,7 +484,7 @@ def render_cost(
         lines.append("")
 
     # ── BY MODEL ─────────────────────────────────────────────────────
-    lines.append("[bold #aaaaaa]  BY MODEL[/]")
+    lines.append(f"[bold {_TEXT_BODY}]  BY MODEL[/]")
     if by_model:
         sorted_models = sorted(
             by_model.items(),
@@ -481,21 +493,21 @@ def render_cost(
         for model_name, mb in sorted_models:
             tok_total = mb["p"] + mb["c"]
             cost_part = (
-                f"  [#44cc88]${mb['cost']:.4f}[/]"
+                f"  [{_STATUS_SUCCESS}]${mb['cost']:.4f}[/]"
                 if mb["has_cost"] and show_extra else ""
             )
             calls_part = (
-                f"  [#777777]{mb['calls']}c[/]"
+                f"  [#777777]{mb['calls']}c[/]"  # palette-candidate: mid-dim label — no foundation token yet
                 if show_extra else ""
             )
             lines.append(
-                f"[#aaaaaa]  {_esc(model_name):<{model_name_w}}[/]"
-                f"[#555555]{tok_total:>7,} tok[/]"
+                f"[{_TEXT_BODY}]  {_esc(model_name):<{model_name_w}}[/]"
+                f"[{_TEXT_DIM}]{tok_total:>7,} tok[/]"
                 f"{cost_part}"
                 f"{calls_part}"
             )
     else:
-        lines.append("[#555555]    (no model data yet)[/]")
+        lines.append(f"[{_TEXT_DIM}]    (no model data yet)[/]")
 
     # Footer hint: ``/budget reset`` only clears per-agent + per-chain
     # counters used by the safety hard-stop rate limiter. The TODAY /
@@ -505,7 +517,7 @@ def render_cost(
     # this distinction surfaced once, where they can see it.
     lines.append("")
     lines.append(
-        "[#555555]  /budget reset clears per-agent counters "
+        f"[{_TEXT_DIM}]  /budget reset clears per-agent counters "
         "(daily totals persist — they come from the event log)[/]"
     )
 

--- a/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/docs_tab.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .base import _CORAL, _esc
+from .base import _CORAL, _TEXT_BODY, _TEXT_DIM, _TEXT_NEUTRAL, _esc
 
 # ---------------------------------------------------------------------------
 # Language helpers
@@ -112,13 +112,13 @@ def render_docs(
     and which rows are annotated with a dim fallback suffix.
     """
     if project_root is None:
-        return "[#555555]  (no project root)[/]"
+        return f"[{_TEXT_DIM}]  (no project root)[/]"
     # Mirror the fallback logic in build_docs_index.
     docs_root = project_root / "docs" / "en"
     if not docs_root.is_dir():
         docs_root = project_root / "docs"
     if not docs_root.is_dir():
-        return "[#555555]  (docs/ not found)[/]"
+        return f"[{_TEXT_DIM}]  (docs/ not found)[/]"
 
     lines: list[str] = []
 
@@ -126,8 +126,8 @@ def render_docs(
     # setting without having to press ``g``.
     other_lang = "en" if lang == "ja" else "ja"
     lines.append(
-        f"[#aaaaaa]  lang: [/][{_CORAL}]{lang}[/]"
-        f"[#555555]  ({other_lang} fallback)  \\[g] to toggle[/]"
+        f"[{_TEXT_BODY}]  lang: [/][{_CORAL}]{lang}[/]"
+        f"[{_TEXT_DIM}]  ({other_lang} fallback)  \\[g] to toggle[/]"
     )
     lines.append("")
 
@@ -138,18 +138,18 @@ def render_docs(
         # filter UI requires. ``RightPanel.on_key`` now clears in place
         # on Esc when ``_docs_filter`` is non-empty.
         lines.append(
-            f"[#aaaaaa]  filter: [/][{_CORAL}]{_esc(docs_filter)}[/]"
-            f"[#555555]  (Esc to clear)[/]"
+            f"[{_TEXT_BODY}]  filter: [/][{_CORAL}]{_esc(docs_filter)}[/]"
+            f"[{_TEXT_DIM}]  (Esc to clear)[/]"
         )
         lines.append("")
     if not groups:
-        lines.append("[#555555]  (no matches)[/]")
+        lines.append(f"[{_TEXT_DIM}]  (no matches)[/]")
         return "\n".join(lines)
 
     file_idx = 0
     for section in sorted(groups):
         label = section.upper() if section else "ROOT"
-        lines.append(f"[bold #aaaaaa]  \\[{_esc(label)}][/]")
+        lines.append(f"[bold {_TEXT_BODY}]  \\[{_esc(label)}][/]")
         for md in groups[section]:
             indent = "    "
             base = _base_stem(md)
@@ -171,8 +171,8 @@ def render_docs(
                 )
             else:
                 lines.append(
-                    f"[#666666]{indent}  {_esc(base)}[/]"
-                    + (f"[dim #666666]{fallback_suffix}[/]" if fallback_suffix else "")
+                    f"[{_TEXT_NEUTRAL}]{indent}  {_esc(base)}[/]"
+                    + (f"[dim {_TEXT_NEUTRAL}]{fallback_suffix}[/]" if fallback_suffix else "")
                 )
             file_idx += 1
         lines.append("")

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from rich.cells import cell_len
 
 from reyn.chat.tui._palette import _TEXT_DIMMEST
+
 from .base import (
     _BORDER_DIM,
     _CORAL,

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from rich.cells import cell_len
 
+from reyn.chat.tui._palette import _TEXT_DIMMEST
 from .base import (
     _BORDER_DIM,
     _CORAL,
@@ -600,11 +601,11 @@ def render_events(
     restore the full unfiltered view.
     """
     if project_root is None:
-        return "[#555555]  (no project root)[/]", [], []
+        return f"[{_TEXT_DIM}]  (no project root)[/]", [], []
 
     events_root = project_root / ".reyn" / "events"
     if not events_root.is_dir():
-        return "[#555555]  (no events yet)[/]", [], []
+        return f"[{_TEXT_DIM}]  (no events yet)[/]", [], []
 
     if cache is None:
         cache = {}
@@ -665,19 +666,19 @@ def render_events(
         #      cycle to a different filter (the `[f]` header hint is only
         #      visible when the panel is wider than the filter name).
         if not all_events:
-            return "[#555555]  (no matching events)[/]", [], []
+            return f"[{_TEXT_DIM}]  (no matching events)[/]", [], []
         # Split the two hints across separate lines so each survives the
         # 44-cell minimum panel width independently. The single-line
         # form was ~47 cells and clipped to ``press [f] to cycle filter
         # · [t] for ta…`` at narrow widths, hiding the ``[t]`` tail-size
         # discoverability cue entirely.
         return (
-            f"[#555555]  (no events matching filter: [/]"
-            f"[bold #aaaaaa]{_esc(filter_name)}[/][#555555])[/]\n"
-            f"[#555555]  press [/][bold #aaaaaa]\\[f][/]"
-            f"[#555555] to cycle filter[/]\n"
-            f"[#555555]  press [/][bold #aaaaaa]\\[t][/]"
-            f"[#555555] for tail size[/]"
+            f"[{_TEXT_DIM}]  (no events matching filter: [/]"
+            f"[bold {_TEXT_BODY}]{_esc(filter_name)}[/][{_TEXT_DIM}])[/]\n"
+            f"[{_TEXT_DIM}]  press [/][bold {_TEXT_BODY}]\\[f][/]"
+            f"[{_TEXT_DIM}] to cycle filter[/]\n"
+            f"[{_TEXT_DIM}]  press [/][bold {_TEXT_BODY}]\\[t][/]"
+            f"[{_TEXT_DIM}] for tail size[/]"
         ), [], []
 
     # Newest-first window — also returned to the caller for cursor / preview
@@ -701,8 +702,8 @@ def render_events(
             f"  [#88aacc]⛓ chain isolated:[/] [bold {_CORAL}]{_esc(short)}[/]"
         )
         lines.append(
-            "  [#555555]  press [/][bold #aaaaaa]\\[i][/]"
-            "[#555555] to clear isolation[/]"
+            f"  [{_TEXT_DIM}]  press [/][bold {_TEXT_BODY}]\\[i][/]"
+            f"[{_TEXT_DIM}] to clear isolation[/]"
         )
     prev_chain: str | None = None
     for i, ev in enumerate(windowed):
@@ -723,7 +724,7 @@ def render_events(
         ts = _esc(raw_ts[11:19] if len(raw_ts) >= 19 else raw_ts)
         color = _EVENT_COLORS.get(ev_type, _DEFAULT_EVENT_COLOR)
         hint = _esc(_oneline(_event_hint(ev)))
-        hint_part = f"  [#555555]{hint}[/]" if hint else ""
+        hint_part = f"  [{_TEXT_DIM}]{hint}[/]" if hint else ""
         cursor_prefix = (
             f"[bold {_CORAL}]▶ [/]" if i == cursor else "  "
         )
@@ -734,14 +735,14 @@ def render_events(
         # memory_tab / agents_tab.
         event_ys.append(len(lines))
         lines.append(
-            f"{cursor_prefix}[#444444]{ts}[/]  [{color}]{_esc(ev_type)}[/]{hint_part}"
+            f"{cursor_prefix}[{_TEXT_DIMMEST}]{ts}[/]  [{color}]{_esc(ev_type)}[/]{hint_part}"
         )
         if ev_type == "user_message_received":
             cid = data.get("chain_id")
             if cid:
                 reply = chain_replies.get(cid)
                 if reply is None:
-                    lines.append("[#444444]       ↳ [/][#555555](awaiting…)[/]")
+                    lines.append(f"[{_TEXT_DIMMEST}]       ↳ [/][{_TEXT_DIM}](awaiting…)[/]")
                 else:
                     # Cell-width truncate (not ``[:72]``) so CJK / wide
                     # characters obey the 40-cell preview budget instead
@@ -757,17 +758,17 @@ def render_events(
                         _oneline(reply), 40,
                     )
                     short = _esc(truncated) + ("…" if was_truncated else "")
-                    lines.append(f"[#444444]       ↳ [/][#777777]{short}[/]")
+                    lines.append(f"[{_TEXT_DIMMEST}]       ↳ [/][#777777]{short}[/]")  # palette-candidate: mid-dim reply preview — no foundation token yet
 
     del filter_name
     # Dim footer hint — always appended after the event rows so the user
     # can discover the [d] docs shortcut from the events tab itself.
-    lines.append("[#555555]  ? press \\[d] for events.md reference[/]")
+    lines.append(f"[{_TEXT_DIM}]  ? press \\[d] for events.md reference[/]")
     # Compaction-check suppression footer: when at least 1 event was
     # hidden, surface a dim hint so the user can discover the [v] toggle.
     if n_compaction_check_hidden > 0:
         lines.append(
-            f"[#444444]  ↩ {n_compaction_check_hidden} compaction_check hidden"
+            f"[{_TEXT_DIMMEST}]  ↩ {n_compaction_check_hidden} compaction_check hidden"
             " (\\[v] to show)[/]"
         )
     return "\n".join(lines), windowed, event_ys

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from textual.binding import Binding
 
-from .base import _CORAL, _esc
+from .base import _CORAL, _TEXT_BODY, _TEXT_BRIGHT, _TEXT_DIM, _esc
 
 if TYPE_CHECKING:
     from textual.app import App
@@ -415,7 +415,7 @@ def render_keys(
         raw_keys = group_keys.get(group_name, [])
         if not entries:
             continue
-        lines.append(f"[bold #aaaaaa]  \\[{_esc(group_name)}][/]")
+        lines.append(f"[bold {_TEXT_BODY}]  \\[{_esc(group_name)}][/]")
         # MOUSE rows can be much longer than 6 chars — use a wider cap for
         # the MOUSE group so the descriptions don't collide with the key col.
         if group_name == "MOUSE":
@@ -433,7 +433,7 @@ def render_keys(
             cursor_prefix = f"[bold {_CORAL}]▶[/] " if is_cursor else "  "
             key_col = f"{_esc(key_display):<{key_width}}"
             lines.append(
-                f"{cursor_prefix}[{_CORAL}]{key_col}[/]  [#dddddd]{_esc(desc)}[/]"
+                f"{cursor_prefix}[{_CORAL}]{key_col}[/]  [{_TEXT_BRIGHT}]{_esc(desc)}[/]"
             )
 
             # Inline detail block when this row is expanded.
@@ -442,13 +442,13 @@ def render_keys(
                 if detail:
                     for detail_line in detail.splitlines():
                         lines.append(
-                            f"  [dim #aaaaaa]    {_esc(detail_line)}[/]"
+                            f"  [dim {_TEXT_BODY}]    {_esc(detail_line)}[/]"
                         )
 
             row_idx += 1
         lines.append("")
     if not lines:
-        lines.append("[#555555]  (no bindings)[/]")
+        lines.append(f"[{_TEXT_DIM}]  (no bindings)[/]")
     return "\n".join(lines), flat_key_list, key_ys
 
 

--- a/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/memory_tab.py
@@ -5,13 +5,24 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .base import _CORAL, _esc
+from .base import (
+    _CORAL,
+    _EVENT_SKILL,
+    _EVENT_TOOL,
+    _STATUS_SUCCESS,
+    _TEXT_BODY,
+    _TEXT_BRIGHT,
+    _TEXT_DIM,
+    _TEXT_MUTED,
+    _TEXT_NEUTRAL,
+    _esc,
+)
 
 _TYPE_COLORS: dict[str, str] = {
-    "user":      "#88aaff",
-    "feedback":  "#ffaa44",
-    "project":   "#44cc88",
-    "reference": "#cc88ff",
+    "user":      _EVENT_SKILL,
+    "feedback":  "#ffaa44",  # palette-candidate: feedback amber — no foundation token yet (near _EVENT_PLAN_STEP #ffaa66 but distinct)
+    "project":   _STATUS_SUCCESS,
+    "reference": _EVENT_TOOL,
 }
 
 
@@ -80,7 +91,7 @@ def render_memory(
     ``flat_entries`` (= metadata, not a navigable memory entry).
     """
     if project_root is None:
-        return "[#555555]  (no project root)[/]", [], []
+        return f"[{_TEXT_DIM}]  (no project root)[/]", [], []
 
     from reyn.memory.memory import list_entries
 
@@ -100,8 +111,8 @@ def render_memory(
             f"[bold {_CORAL}]{_esc(type_filter.upper())}[/]"
         )
         lines.append(
-            "  [#555555]  press [/][bold #aaaaaa]\\[t][/]"
-            "[#555555] to cycle filter[/]"
+            f"  [{_TEXT_DIM}]  press [/][bold {_TEXT_BODY}]\\[t][/]"
+            f"[{_TEXT_DIM}] to cycle filter[/]"
         )
 
     # Hot now section (issue #192). Always renders the header so the
@@ -113,7 +124,7 @@ def render_memory(
     # rows once the ARS forwarder emits ``hot_list_updated``.
     # Capped at _HOT_LIST_MAX_VISIBLE so a long ranking doesn't push
     # the SHARED / AGENT entries off the top of a narrow panel.
-    lines.append("[bold #ffaa44]  HOT NOW[/]")
+    lines.append("[bold #ffaa44]  HOT NOW[/]")  # palette-candidate: feedback amber — no foundation token yet
     if hot_list:
         for entry in hot_list[:_HOT_LIST_MAX_VISIBLE]:
             try:
@@ -126,18 +137,18 @@ def render_memory(
             if freq <= 0:
                 continue
             ago = _fmt_ago(entry.get("last_ts") if hasattr(entry, "get") else None)
-            ago_suffix = f"  [#555555]{ago}[/]" if ago else ""
+            ago_suffix = f"  [{_TEXT_DIM}]{ago}[/]" if ago else ""
             lines.append(
-                f"[#ffaa44]    🔥 [/][#dddddd]{_esc(name)}[/]  "
-                f"[#666666]×{freq}[/]{ago_suffix}"
+                f"[#ffaa44]    🔥 [/][{_TEXT_BRIGHT}]{_esc(name)}[/]  "  # palette-candidate: feedback amber — no foundation token yet
+                f"[{_TEXT_NEUTRAL}]×{freq}[/]{ago_suffix}"
             )
         overflow = len(hot_list) - _HOT_LIST_MAX_VISIBLE
         if overflow > 0:
             lines.append(
-                f"[#555555]    … {overflow} more[/]"
+                f"[{_TEXT_DIM}]    … {overflow} more[/]"
             )
     else:
-        lines.append("[#555555]    (no router activity yet)[/]")
+        lines.append(f"[{_TEXT_DIM}]    (no router activity yet)[/]")
     lines.append("")
 
     def _render_scope(entries: list, label: str, label_color: str) -> None:
@@ -149,9 +160,9 @@ def render_memory(
             # "re…`` at the default 33%-panel content width (~22 cells).
             # Splitting preserves both the "empty" signal and the
             # call-to-action and survives narrow panes.
-            lines.append("[#555555]    (empty)[/]")
+            lines.append(f"[{_TEXT_DIM}]    (empty)[/]")
             lines.append(
-                "[#555555]    try: \"remember <fact>\"[/]"
+                f"[{_TEXT_DIM}]    try: \"remember <fact>\"[/]"
             )
             lines.append("")
             return
@@ -185,21 +196,21 @@ def render_memory(
                 entry_ys.append(len(lines))
                 is_cursor = (len(flat_entries) - 1) == cursor
                 indent = f"[bold {_CORAL}]    ▶ [/]" if is_cursor else "      "
-                name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
+                name_style = f"bold {_CORAL}" if is_cursor else _TEXT_BRIGHT
                 lines.append(f"{indent}[{name_style}]{_esc(e.name)}[/]")
                 if e.description:
-                    lines.append(f"[#555555]        {_esc(e.description)}[/]")
+                    lines.append(f"[{_TEXT_DIM}]        {_esc(e.description)}[/]")
         if other:
-            lines.append("[bold #888888]    \\[OTHER][/]")
+            lines.append(f"[bold {_TEXT_MUTED}]    \\[OTHER][/]")
             for e in other:
                 flat_entries.append(e)
                 entry_ys.append(len(lines))
                 is_cursor = (len(flat_entries) - 1) == cursor
                 indent = f"[bold {_CORAL}]    ▶ [/]" if is_cursor else "      "
-                name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
+                name_style = f"bold {_CORAL}" if is_cursor else _TEXT_BRIGHT
                 lines.append(f"{indent}[{name_style}]{_esc(e.name)}[/]")
                 if e.description:
-                    lines.append(f"[#555555]        {_esc(e.description)}[/]")
+                    lines.append(f"[{_TEXT_DIM}]        {_esc(e.description)}[/]")
         lines.append("")
 
     # Shared memory
@@ -253,7 +264,7 @@ def _render_embedding_section(
         device_part = f" · {_esc(device)}" if device else ""
         model_part = f" · {_esc(model)}" if model else ""
         lines.append(
-            f"[#888888]    ⟳ loading…[/][#aaaaaa]{model_part}{device_part}[/]"
+            f"[{_TEXT_MUTED}]    ⟳ loading…[/][{_TEXT_BODY}]{model_part}{device_part}[/]"
         )
     elif kind == "embedding_skill_done":
         try:
@@ -263,7 +274,7 @@ def _render_embedding_section(
         dim_part = f" · {dim}d" if dim > 0 else ""
         model_part = f" · {_esc(model)}" if model else ""
         lines.append(
-            f"[#44cc88]    ✓ loaded[/][#cccccc]{model_part}{dim_part}[/]"
+            f"[{_STATUS_SUCCESS}]    ✓ loaded[/][#cccccc]{model_part}{dim_part}[/]"  # palette-candidate: near-bright — no foundation token yet
         )
     elif kind == "embedding_error":
         hint_raw = str(state.get("retry_hint", "") or "")
@@ -273,15 +284,15 @@ def _render_embedding_section(
         hint = hint_raw if len(hint_raw) <= max_hint else hint_raw[:max_hint - 1].rstrip() + "…"
         model_part = f" · {_esc(model)}" if model else ""
         lines.append(
-            f"[#ff6666]    ✗ error[/][#dddddd]{model_part}[/]"
+            f"[#ff6666]    ✗ error[/][{_TEXT_BRIGHT}]{model_part}[/]"  # palette-candidate: embedding error red — no foundation token yet (distinct from _STATUS_ERROR #ff6644)
         )
         if hint:
-            lines.append(f"[#aaaaaa]      {_esc(hint)}[/]")
+            lines.append(f"[{_TEXT_BODY}]      {_esc(hint)}[/]")
     else:
         # Unknown kind from a future emitter — show the raw text as a
         # graceful fallback rather than rendering nothing at all.
         text = str(state.get("text", "") or "(no detail)")
-        lines.append(f"[#888888]    {_esc(text)}[/]")
+        lines.append(f"[{_TEXT_MUTED}]    {_esc(text)}[/]")
     lines.append("")
 
 

--- a/src/reyn/chat/tui/widgets/right_panel/pending_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/pending_tab.py
@@ -19,7 +19,15 @@ from typing import Any
 
 from rich.text import Text as RichText
 
-from .base import _CORAL
+from .base import (
+    _CORAL,
+    _EVENT_SKILL,
+    _TEXT_BODY,
+    _TEXT_BRIGHT,
+    _TEXT_DIM,
+    _TEXT_MUTED,
+    _TEXT_NEUTRAL,
+)
 
 # ── kind-specific row renderers ──────────────────────────────────────────────
 #
@@ -45,7 +53,7 @@ def _render_kind_intervention(
         ↳ <summary>
     """
     pfx = f"[bold {_CORAL}]▶ [/]" if is_cursor else "  "
-    name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
+    name_style = f"bold {_CORAL}" if is_cursor else _TEXT_BRIGHT
 
     iv_id_short = str(view.get("id", ""))[:8]
     origin = str(view.get("origin_channel_id", ""))
@@ -55,15 +63,15 @@ def _render_kind_intervention(
 
     head = (
         f"{pfx}[{name_style}]intervention[/]  "
-        f"[#888888]{iv_id_short}[/]  "
-        f"[#88aaff]{origin}[/]  "
-        f"[#666666]{age}[/]"
+        f"[{_TEXT_MUTED}]{iv_id_short}[/]  "
+        f"[{_EVENT_SKILL}]{origin}[/]  "
+        f"[{_TEXT_NEUTRAL}]{age}[/]"
     )
     lines = [head]
     if summary:
-        lines.append(f"    [#666666]↳[/] [#aaaaaa]{summary[:60]}[/]")
+        lines.append(f"    [{_TEXT_NEUTRAL}]↳[/] [{_TEXT_BODY}]{summary[:60]}[/]")
     if detail:
-        lines.append(f"      [#555555]{detail[:60]}[/]")
+        lines.append(f"      [{_TEXT_DIM}]{detail[:60]}[/]")
     return lines
 
 
@@ -80,13 +88,13 @@ def _render_kind_unknown(
     legible even in that transitional state.
     """
     pfx = f"[bold {_CORAL}]▶ [/]" if is_cursor else "  "
-    name_style = f"bold {_CORAL}" if is_cursor else "#dddddd"
+    name_style = f"bold {_CORAL}" if is_cursor else _TEXT_BRIGHT
     kind = str(view.get("kind", "?"))
     iv_id_short = str(view.get("id", ""))[:8]
     summary = str(view.get("summary", ""))
     return [
-        f"{pfx}[{name_style}]{kind}[/]  [#888888]{iv_id_short}[/]  "
-        f"[#aaaaaa]{summary[:60]}[/]",
+        f"{pfx}[{name_style}]{kind}[/]  [{_TEXT_MUTED}]{iv_id_short}[/]  "
+        f"[{_TEXT_BODY}]{summary[:60]}[/]",
     ]
 
 
@@ -159,24 +167,24 @@ def render_pending(
 
     if remote_mode:
         return (
-            "[#aa6666]  remote — limited[/]\n"
-            "[#666666]    Pending operations require local session state[/]\n"
-            "[#666666]    (v1 ``--connect`` scoped disable per #277 / #276 Phase C-(b))[/]",
+            "[#aa6666]  remote — limited[/]\n"  # palette-candidate: remote mode muted red — no foundation token yet
+            f"[{_TEXT_NEUTRAL}]    Pending operations require local session state[/]\n"
+            f"[{_TEXT_NEUTRAL}]    (v1 ``--connect`` scoped disable per #277 / #276 Phase C-(b))[/]",
             flat_items,
             item_ys,
         )
 
     if not pending_ops:
         return (
-            "[#555555]  No pending operations[/]\n"
-            "[#555555]    (stalled / cross-channel ops surface here)[/]",
+            f"[{_TEXT_DIM}]  No pending operations[/]\n"
+            f"[{_TEXT_DIM}]    (stalled / cross-channel ops surface here)[/]",
             flat_items,
             item_ys,
         )
 
     lines: list[str] = [
         f"[bold {_CORAL}]  Pending operations[/] "
-        f"[#666666]({len(pending_ops)})[/]",
+        f"[{_TEXT_NEUTRAL}]({len(pending_ops)})[/]",
     ]
 
     for idx, view in enumerate(pending_ops):


### PR DESCRIPTION
**[tui-coder]** — Pure value-preserving refactor: replace hardcoded hex literals in RightPanel tab renderers with foundation token references from `reyn.chat.tui._palette` (via `.base`). No colour changes — each substituted hex matches the token exactly.

## Per-file hex count (before → after)

| File | Hex before | Hex after (residual) |
|---|---|---|
| `cost_tab.py` | 40 | 3 (#777777 ×3, #2d7a4f ×2 — 5 widget-local, but 2 are the same 2 colours repeated) |
| `agents_tab.py` | 35 | 8 (widget-local) |
| `memory_tab.py` | 18 | 5 (widget-local) |
| `events_tab.py` | 16 | 2 (#88aacc decorative, #777777 widget-local) |
| `pending_tab.py` | 9 | 1 (#aa6666 widget-local) |
| `docs_tab.py` | 10 | 0 |
| `keys_tab.py` | 4 | 0 |
| `shells.py` | 9 | 9 (CSS context — cannot use Python variable refs) |

## Flagged widget-local colours (left hardcoded — substitute-vs-orthogonal)

These do NOT exactly match any foundation token. Each is a distinct shade that would be collapsed into a near-but-not-equal token if migrated — the substitute-vs-orthogonal discipline requires leaving them until a matching token is added to `_palette.py`.

| Colour | Files | Semantic | Notes |
|---|---|---|---|
| `#777777` | cost_tab, agents_tab, events_tab | mid-dim label / "recent" header | Between `_TEXT_MUTED` (#888888) and `_DIVIDER_DIM` (#333333) — no foundation token |
| `#2d7a4f` | cost_tab | dim success green (subordinate skill cost) | Distinct from `_STATUS_SUCCESS` (#44cc88) — intentionally dimmer |
| `#aaaa55` | agents_tab | agent "ready" (olive) | Loaded-but-idle 3-state. Not in palette |
| `#ffaa44` | agents_tab, memory_tab | warning amber / feedback type | Close to `_EVENT_PLAN_STEP` (#ffaa66) but distinct — collapsing would change the rendered colour |
| `#bbbbbb` | agents_tab | near-bright skill label | Between `_TEXT_BODY` (#aaaaaa) and `_TEXT_BRIGHT` (#dddddd) |
| `#aa8844` | agents_tab | stuck indicator ochre | No palette token |
| `#aa6655` | agents_tab | muted error (aborted status) | Between `_STATUS_ERROR` (#ff6644) and TEXT range — no token |
| `#7a9fc7` | memory_tab | agent scope label | Decorative teal — unique |
| `#6aa9c7` | memory_tab | EMBEDDINGS header | Decorative teal — unique |
| `#cccccc` | memory_tab | loaded model text | Between `_TEXT_BRIGHT` and white — no token |
| `#ff6666` | memory_tab | embedding error | Close to `_STATUS_ERROR` (#ff6644) but 2 channels differ — collapsing would change colour |
| `#88aacc` | events_tab | chain-isolated teal | Decorative |
| `#aa6666` | pending_tab | remote-mode dim red | Decorative |

Design follow-up: `#777777`, `#ffaa44`, `#bbbbbb`, `#aa6655` are the highest-volume candidates for promotion to `_palette.py`.

`shells.py` CSS hex is unchanged — Textual `DEFAULT_CSS` strings cannot reference Python variables.

## Test plan

- [x] `pytest tests/cli/ -q -k "events or cost or agents or memory or pending or docs or panel"` — 233 passed, 0 failed
- [x] `pytest tests/cli/test_tui_smoke.py -q` — 40 passed, 0 failed

## Tier self-check

Pure value-preserving refactor. No new tests added:
- Exact-hex assertions would be Tier 4 (format-pin) — prohibited by testing policy
- Existing tab render tests (in the test suite above) exercise the render paths and pass
- No behaviour change: every substituted hex equals the token's value byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)