### PR TITLE
refactor(tui): migrate conversation/input/row widget colours to palette tokens

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -80,7 +80,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _AMBER, _CORAL
+from reyn.chat.tui._palette import _AMBER, _CORAL, _TEXT_MUTED, _STATUS_ERROR, _BG_HEADER
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -648,13 +648,13 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
                 if i == self._cursor:
                     t.append("▌ ", style=_CORAL)
                 else:
-                    t.append("  ", style="#1a1a1a")
+                    t.append("  ", style=_BG_HEADER)
             self._append_row(t, agent_id, entry, glyph, body_budget)
         overflow = len(self._entries) - len(visible)
         if overflow > 0:
             t.append("\n")
             tail = f"… +{overflow} more (panel for all)"
-            t.append(self._truncate_to_cells(tail, body_budget), style="dim #888888")
+            t.append(self._truncate_to_cells(tail, body_budget), style="dim " + _TEXT_MUTED)
         return t
 
     def _append_row(
@@ -680,7 +680,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         if entry.flashing:
             id_short = _middle_elide_id(agent_id, min(16, body_budget - 24))
             flash_text = f"✗ async: {id_short} (interrupted)"
-            t.append(self._truncate_to_cells(flash_text, body_budget), style="bold #ff6644")
+            t.append(self._truncate_to_cells(flash_text, body_budget), style="bold " + _STATUS_ERROR)
             return
 
         if entry.frozen_elapsed_s is not None:
@@ -690,7 +690,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         elapsed_str = _fmt_elapsed(elapsed_s)
         if entry.pending_count > 0:
             elapsed_segment = f"  ({entry.pending_count} pending)"
-            elapsed_style = "bold #ffaa44"
+            elapsed_style = "bold #ffaa44"  # palette-candidate: pending-warning amber (no foundation token yet)
             glyph_style = _AMBER
         else:
             elapsed_segment = f"  · {elapsed_str}"
@@ -735,7 +735,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         summary_display = self._truncate_to_cells(entry.summary, summary_budget)
 
         t.append(f"{glyph} ", style=glyph_style)
-        t.append("async: ", style="dim #888888")
+        t.append("async: ", style="dim " + _TEXT_MUTED)
         t.append(agent_id, style="bold")
         if summary_display:
             t.append(sep, style="dim")

--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -80,7 +80,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _AMBER, _CORAL, _TEXT_MUTED, _STATUS_ERROR, _BG_HEADER
+from reyn.chat.tui._palette import _AMBER, _BG_HEADER, _CORAL, _STATUS_ERROR, _TEXT_MUTED
 
 from ._renderable_cache import RenderableCacheMixin
 

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -57,10 +57,10 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.chat.tui._palette import (
     _AMBER,
     _CORAL,
-    _TEXT_NEUTRAL,
+    _EVENT_INTERVENTION,
     _TEXT_DIM,
     _TEXT_MUTED,
-    _EVENT_INTERVENTION,
+    _TEXT_NEUTRAL,
 )
 
 from .async_stack_panel import AsyncStackPanel

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -54,7 +54,14 @@ from textual.widgets import RichLog, Static
 logger = logging.getLogger(__name__)
 
 from reyn.chat.outbox import OutboxMessage
-from reyn.chat.tui._palette import _AMBER, _CORAL
+from reyn.chat.tui._palette import (
+    _AMBER,
+    _CORAL,
+    _TEXT_NEUTRAL,
+    _TEXT_DIM,
+    _TEXT_MUTED,
+    _EVENT_INTERVENTION,
+)
 
 from .async_stack_panel import AsyncStackPanel
 from .error_box import ErrorBox
@@ -162,7 +169,7 @@ def _msg_header(symbol: str, name_style: str, show_ts: bool = True) -> Text:
     """
     t = Text()
     if show_ts:
-        t.append(time.strftime("%H:%M"), style="dim #666666")
+        t.append(time.strftime("%H:%M"), style="dim " + _TEXT_NEUTRAL)
         t.append(" ")
     t.append(symbol, style=name_style)
     return t
@@ -182,7 +189,7 @@ def _build_header_prefix(symbol: str, name_style: str, show_ts: bool = True) -> 
     """
     t = Text()
     if show_ts:
-        t.append(time.strftime("%H:%M"), style="dim #666666")
+        t.append(time.strftime("%H:%M"), style="dim " + _TEXT_NEUTRAL)
         t.append(" ")
     t.append(symbol, style=name_style)
     t.append(" ")  # trailing space so body starts immediately after symbol
@@ -218,9 +225,9 @@ def _render_lifecycle_marker(text: str) -> Text:
     lead_dashes = 2
     label_cells = cell_len(label)
     trail_dashes = max(1, _DASH_TOTAL - lead_dashes - label_cells)
-    t.append("─" * lead_dashes, style="dim #666666")
-    t.append(label, style="dim #666666")
-    t.append("─" * trail_dashes, style="dim #666666")
+    t.append("─" * lead_dashes, style="dim " + _TEXT_NEUTRAL)
+    t.append(label, style="dim " + _TEXT_NEUTRAL)
+    t.append("─" * trail_dashes, style="dim " + _TEXT_NEUTRAL)
     return t
 
 
@@ -239,9 +246,9 @@ def _date_separator(date_str: str) -> Text:
     lead_dashes = 2
     label_cells = cell_len(label)
     trail_dashes = max(1, _DASH_TOTAL - lead_dashes - label_cells)
-    t.append("─" * lead_dashes, style="dim #666666")
-    t.append(label, style="dim #666666")
-    t.append("─" * trail_dashes, style="dim #666666")
+    t.append("─" * lead_dashes, style="dim " + _TEXT_NEUTRAL)
+    t.append(label, style="dim " + _TEXT_NEUTRAL)
+    t.append("─" * trail_dashes, style="dim " + _TEXT_NEUTRAL)
     return t
 
 
@@ -334,7 +341,7 @@ class ConversationView(Widget):
         /* Dim by default; only the active/hover scrollbar uses the coral
            highlight. Avoids the full-track coral block when content fits
            in one viewport. */
-        scrollbar-color: #2a2a2a;
+        scrollbar-color: #2a2a2a;  /* _BORDER_DIM */
         scrollbar-color-hover: $primary;
         scrollbar-color-active: $primary;
         scrollbar-background: transparent;
@@ -346,7 +353,7 @@ class ConversationView(Widget):
         padding: 0 1;
     }
     ConversationView #empty-hint {
-        color: #555555;
+        color: #555555;  /* _TEXT_DIM */
         padding: 0 1;
         height: auto;
     }
@@ -1115,7 +1122,7 @@ class ConversationView(Widget):
         if _is_lifecycle_marker(text):
             self._write_log(_render_lifecycle_marker(text))
             return
-        self._maybe_write_header("system", _GLYPH_SYSTEM, "bold #888888")
+        self._maybe_write_header("system", _GLYPH_SYSTEM, "bold " + _TEXT_MUTED)
         for line in text.splitlines() or [""]:
             self._write_body(Text(line))
         self._write_log(Text(""))
@@ -1164,7 +1171,7 @@ class ConversationView(Widget):
         else:
             first_line_plain = ""
 
-        inline_body = Text(first_line_plain, style="dim #888888" if meta_pfx else "")
+        inline_body = Text(first_line_plain, style="dim " + _TEXT_MUTED if meta_pfx else "")
 
         # _AMBER for agent identity — distinct from _CORAL (interactive
         # affordances).
@@ -1519,7 +1526,7 @@ class ConversationView(Widget):
                 self._log().write(
                     Text("✗ cancelled (partial reply):", style="bold #aa6666"),
                 )
-                self._write_body(Text(full, style="dim italic #888888"))
+                self._write_body(Text(full, style="dim italic " + _TEXT_MUTED))
             except Exception:
                 self._log().write(Text(full))
         self._log().write(Text(""))
@@ -1931,7 +1938,7 @@ class ConversationView(Widget):
             old_trailer = " (see events)" if old_has_trace else ""
             self._write_log(_RichText(
                 f"  ✗ {old_summary} (rolled to log){old_trailer}",
-                style="dim #555555",
+                style="dim " + _TEXT_DIM,
             ))
         # Stop the inline thinking spinner — the turn is over (it failed).
         # When the user is at the tail, a bare ``stop_thinking`` + ``hide_status``
@@ -2097,7 +2104,7 @@ class ConversationView(Widget):
         # secondary cleanup.
         self._write_log(_RichText(
             f"  ✗ {summary} (dismissed){trailer}",
-            style="dim #555555",
+            style="dim " + _TEXT_DIM,
         ))
         try:
             box.remove()
@@ -2155,7 +2162,7 @@ class ConversationView(Widget):
         noun = "error" if n == 1 else "errors"
         self._write_log(_RichText(
             f"  ✗ {n} {noun} dismissed (see events)",
-            style="dim #555555",
+            style="dim " + _TEXT_DIM,
         ))
         # C[1] fix: zero out session._error_box_count.  Defensive guard.
         try:
@@ -2285,7 +2292,7 @@ class ConversationView(Widget):
             body = f"⌁ {tokens}t │ ${cost_usd:.4f} │ {elapsed_s:.1f}s"
         t = Text(
             body,
-            style="dim #666666",
+            style="dim " + _TEXT_NEUTRAL,
             justify="right",
         )
         # ``(top=0, right=6, bottom=0, left=0)`` — reserve 6 cells on
@@ -2395,7 +2402,7 @@ class ConversationView(Widget):
         warning_text = f"↑ earlier history trimmed ({start:,} lines)"
         # Permanent log line — survives the turn-flash sticky overwrite.
         try:
-            self._write_log(Text(f"  {warning_text}", style="dim italic #888888"))
+            self._write_log(Text(f"  {warning_text}", style="dim italic " + _TEXT_MUTED))
         except Exception:
             pass
         # Sticky glance-cue — may be overwritten by the next status
@@ -2694,7 +2701,7 @@ class ConversationView(Widget):
             self._write_log(_RichText(
                 f"  ✗ {_error_count_before_clear} {_noun} cleared"
                 " (see events tab, filter=error)",
-                style="dim #555555",
+                style="dim " + _TEXT_DIM,
             ))
         # Wave-10 G-F1: sweep in-flight ToolCallRow widgets too. They
         # share the same "child of ConversationView, not a RichLog
@@ -2834,5 +2841,5 @@ def _format_intervention_line(msg: OutboxMessage) -> Text:
     # Intervention prefix is agent-identity (= the agent asking a question),
     # so it matches the agent header colour (_AMBER), not the action colour.
     t.append("  Aria asks  ", style="bold " + _AMBER)
-    t.append(msg.text, style="#ffcc88")
+    t.append(msg.text, style=_EVENT_INTERVENTION)
     return t

--- a/src/reyn/chat/tui/widgets/error_box.py
+++ b/src/reyn/chat/tui/widgets/error_box.py
@@ -47,7 +47,7 @@ class ErrorBox(Widget):
            is right at the WCAG AA threshold for large text and below for
            small text. The vertical bar gives the eye a shape / position
            cue that survives quick scrolling and color-blind users. */
-        border-left: solid #cc5555;
+        border-left: solid #cc5555;  /* palette-candidate: error-high severity ramp (distinct from _STATUS_ERROR) */
     }
     /* W13 A#3: severity-tier border-left overrides (3 colors).
        HIGH (default / ``.-sev-high``) keeps the existing #cc5555 red —
@@ -55,44 +55,44 @@ class ErrorBox(Widget):
        MED  (``.-sev-med``) → amber to signal recoverable / transient.
        LOW  (``.-sev-low``) → grey to signal user-input mistake. */
     ErrorBox.-sev-med {
-        border-left: solid #cc9955;
+        border-left: solid #cc9955;  /* palette-candidate: error-med severity ramp */
     }
     ErrorBox.-sev-low {
-        border-left: solid #666666;
+        border-left: solid #666666;  /* palette-candidate: error-low severity ramp */
     }
     /* Header line — always visible */
     ErrorBox Label.eb-header {
-        color: #cc5555;
+        color: #cc5555;  /* palette-candidate: error-high severity ramp */
         height: 1;
         width: 1fr;
         padding: 0 1;
     }
     ErrorBox.-sev-med Label.eb-header {
-        color: #cc9955;
+        color: #cc9955;  /* palette-candidate: error-med severity ramp */
     }
     ErrorBox.-sev-low Label.eb-header {
-        color: #888888;
+        color: #888888;  /* _TEXT_MUTED (CSS string — cannot use Python variable) */
     }
     ErrorBox:hover Label.eb-header {
-        color: #ff7777;
+        color: #ff7777;  /* palette-candidate: error-high hover (lighter sibling of #cc5555) */
     }
     ErrorBox.-sev-med:hover Label.eb-header {
-        color: #ffbb77;
+        color: #ffbb77;  /* palette-candidate: error-med hover */
     }
     ErrorBox.-sev-low:hover Label.eb-header {
-        color: #aaaaaa;
+        color: #aaaaaa;  /* _TEXT_BODY (CSS string — cannot use Python variable) */
     }
     /* Detail block — hidden until expanded */
     ErrorBox Static.eb-details {
         display: none;
-        color: #777777;
+        color: #777777;  /* palette-candidate: error-detail body (between _TEXT_NEUTRAL and _TEXT_MUTED) */
         height: auto;
         width: 1fr;
         padding: 0 2;
     }
     ErrorBox Label.eb-hint {
         display: none;
-        color: #555555;
+        color: #555555;  /* _TEXT_DIM (CSS string — cannot use Python variable) */
         height: 1;
         width: 1fr;
         padding: 0 2;
@@ -107,7 +107,7 @@ class ErrorBox(Widget):
        reads as actionable, not just metadata. */
     ErrorBox Label.eb-inline-hint {
         display: none;
-        color: #8a7a4a;
+        color: #8a7a4a;  /* palette-candidate: inline-hint actionable (distinct from metadata) */
         height: 1;
         width: 1fr;
         padding: 0 2;

--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -23,11 +23,11 @@ from textual.widgets import Label
 
 from reyn.chat.tui._palette import (
     _BG_HEADER,
-    _TEXT_BODY,
-    _TEXT_MUTED,
-    _TEXT_DIM,
     _STATUS_CRITICAL,
     _STATUS_ERROR,
+    _TEXT_BODY,
+    _TEXT_DIM,
+    _TEXT_MUTED,
 )
 
 from ._renderable_cache import RenderableCacheMixin

--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -21,6 +21,15 @@ from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Label
 
+from reyn.chat.tui._palette import (
+    _BG_HEADER,
+    _TEXT_BODY,
+    _TEXT_MUTED,
+    _TEXT_DIM,
+    _STATUS_CRITICAL,
+    _STATUS_ERROR,
+)
+
 from ._renderable_cache import RenderableCacheMixin
 
 # Trailing date suffix on a model id: ``-YYYYMMDD`` (8 digits) or the
@@ -59,9 +68,9 @@ def _cap_proximity_color(used: float | int, cap: float | int | None) -> str | No
         return None
     ratio = used_f / cap_f
     if ratio >= 0.90:
-        return "#ff4444"
+        return _STATUS_CRITICAL
     if ratio >= 0.75:
-        return "#ffaa44"
+        return "#ffaa44"  # palette-candidate: cap-proximity warning amber (no foundation token yet)
     return None
 
 
@@ -94,7 +103,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
     ReynHeader {
         dock: top;
         height: 1;
-        background: #1a1a1a;
+        background: #1a1a1a;  /* _BG_HEADER */
         layout: horizontal;
     }
     ReynHeader #title {
@@ -104,7 +113,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
         width: auto;
     }
     ReynHeader #status {
-        color: #aaaaaa;
+        color: #aaaaaa;  /* _TEXT_BODY */
         text-align: right;
         padding: 0 1;
         width: 1fr;
@@ -450,7 +459,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
                 None,
             ))
         if include_model and self._model:
-            parts.append((_shorten_model_id(self._model), "dim #888888"))
+            parts.append((_shorten_model_id(self._model), "dim " + _TEXT_MUTED))
 
         if include_tokens:
             tok_str = f"{self._tokens_today:,}"
@@ -483,7 +492,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
         # unchanged.
         if self._stalled_count > 0:
             parts.append(
-                (f"[{self._stalled_count} pending]", "#ffaa44"),
+                (f"[{self._stalled_count} pending]", "#ffaa44"),  # palette-candidate: pending-warning amber (no foundation token yet)
             )
         # ``/find`` active-state badge — placed alongside [N pending]
         # as a sibling "active state" indicator. Subtle blue
@@ -507,9 +516,9 @@ class ReynHeader(RenderableCacheMixin, Widget):
         # so users discover dictate-and-send / cancel without reading docs.
         # Kept short (11 cells) so it survives narrow-terminal truncation.
         if self._voice_state == "recording":
-            parts.append(("🔴 voice · Enter→send Esc→cancel", "bold #ff6644"))
+            parts.append(("🔴 voice · Enter→send Esc→cancel", "bold " + _STATUS_ERROR))
         elif self._voice_state == "transcribing":
-            parts.append(("⏳ voice", "bold #ffaa44"))
+            parts.append(("⏳ voice", "bold #ffaa44"))  # palette-candidate: transcribing-warning amber (no foundation token yet)
         # Clock always present, last — the canary for "is the UI frozen?"
         parts.append((self._now_text(), None))
 
@@ -525,7 +534,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
         cur = 0
         for i, (text, style) in enumerate(parts):
             if i > 0:
-                out.append(sep, style="dim #555555")
+                out.append(sep, style="dim " + _TEXT_DIM)
                 cur += sep_w
             seg_w = cell_len(text)
             if text.startswith("[find:"):

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -83,8 +83,8 @@ class InputBar(Widget):
         dock: bottom;
         height: auto;
         max-height: 22;
-        background: #111111;
-        border-top: solid #2a2a2a;
+        background: #111111;  /* _BG_PANEL */
+        border-top: solid #2a2a2a;  /* _BORDER_DIM */
     }
     InputBar TextArea {
         background: transparent;
@@ -96,11 +96,11 @@ class InputBar(Widget):
     }
     InputBar #hints {
         height: 1;
-        color: #555555;
+        color: #555555;  /* _TEXT_DIM */
         padding: 0 2;
     }
     InputBar.in-flight TextArea {
-        color: #666666;
+        color: #666666;  /* _TEXT_NEUTRAL */
     }
     InputBar.in-flight #hints {
         color: #886633;
@@ -109,7 +109,7 @@ class InputBar(Widget):
         border-top: solid #553333;
     }
     InputBar.disconnected TextArea {
-        color: #555555;
+        color: #555555;  /* _TEXT_DIM */
     }
     InputBar.disconnected #hints {
         color: #553333;

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -35,7 +35,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL, _TEXT_NEUTRAL, _TEXT_MUTED, _TEXT_BODY, _STATUS_ERROR
+from reyn.chat.tui._palette import _CORAL, _STATUS_ERROR, _TEXT_BODY, _TEXT_MUTED, _TEXT_NEUTRAL
 
 from ._renderable_cache import RenderableCacheMixin
 

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -35,7 +35,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL
+from reyn.chat.tui._palette import _CORAL, _TEXT_NEUTRAL, _TEXT_MUTED, _TEXT_BODY, _STATUS_ERROR
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -395,9 +395,9 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
 
         # ── Elapsed segment (always kept) ─────────────────────────────────
         if secs >= _ELAPSED_RED_S:
-            elapsed_style = "bold #ff6644"
+            elapsed_style = "bold " + _STATUS_ERROR
         elif secs >= _ELAPSED_AMBER_S:
-            elapsed_style = "bold #ffaa44"
+            elapsed_style = "bold #ffaa44"  # palette-candidate: elapsed-warning amber (no foundation token yet)
         else:
             elapsed_style = "dim"
         elapsed_str = f"  {secs:.1f}s"
@@ -482,7 +482,7 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
         # ── Assemble the Text object ───────────────────────────────────────
         t = Text()
         if self._label_prefix:
-            t.append(self._label_prefix, style="dim #666666")
+            t.append(self._label_prefix, style="dim " + _TEXT_NEUTRAL)
         t.append(glyph_str, style=_CORAL)
         # skill_name#abcd — normal weight
         t.append(skill_id_display, style="bold")
@@ -522,7 +522,7 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
 
         t = Text()
         if self._label_prefix:
-            t.append(self._label_prefix, style="dim #666666")
+            t.append(self._label_prefix, style="dim " + _TEXT_NEUTRAL)
 
         if self._success:
             glyph_str = "✓ "
@@ -599,7 +599,7 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
                 skill_budget = max(4, total_width - _RIGHT_MARGIN_CELLS - prefix_cells - glyph_cells - sep_cells)
                 skill_id = self._truncate_to_cells(skill_id, skill_budget)
 
-            t.append(glyph_str, style="dim #888888")
+            t.append(glyph_str, style="dim " + _TEXT_MUTED)
             t.append(skill_id, style="dim")
             t.append("  · ", style="dim")
             t.append(cancel_msg, style="dim")
@@ -651,10 +651,10 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
         if self._label_prefix:
             # Indent the history line under the same prefix so a sub-
             # skill's drill-down nests visually with its parent.
-            t.append(" " * len(self._label_prefix), style="dim #666666")
+            t.append(" " * len(self._label_prefix), style="dim " + _TEXT_NEUTRAL)
         t.append("  ↳ phases: ", style="dim")
         if not self._phase_history:
-            t.append("(none yet)", style="dim #666666")
+            t.append("(none yet)", style="dim " + _TEXT_NEUTRAL)
             return t
         # The history is "(phase, visit, elapsed_at_entry)" for each
         # entry. Render each as "name(elapsed_at_entry)", with the
@@ -671,7 +671,7 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
                 t.append(label, style=f"italic {_CORAL}")
                 t.append("(now)", style="dim")
             else:
-                t.append(label, style="dim #aaaaaa")
+                t.append(label, style="dim " + _TEXT_BODY)
                 t.append(f"({entered_at:.1f}s)", style="dim")
         return t
 
@@ -691,23 +691,23 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
         if self._label_prefix:
             # Indent under the same prefix as the head/history lines
             # so a sub-skill's tool list nests visually with its parent.
-            t.append(" " * len(self._label_prefix), style="dim #666666")
+            t.append(" " * len(self._label_prefix), style="dim " + _TEXT_NEUTRAL)
         t.append(f"  ↳ tools ({len(self._tool_calls)}): ", style="dim")
         for i, (tool_name, args) in enumerate(
             self._tool_calls[:_TOOL_DRILL_MAX_RENDER]
         ):
             if i > 0:
                 t.append(", ", style="dim")
-            t.append(tool_name, style="dim #aaaaaa")
+            t.append(tool_name, style="dim " + _TEXT_BODY)
             if args:
                 # Compress args to a short hint so the tools-line
                 # stays readable. Full args live on the
                 # ToolCallRow (= ``_tool_call_rows[op_id]``).
                 snippet = args if len(args) <= 14 else args[:13] + "…"
-                t.append(f"({snippet})", style="dim #888888")
+                t.append(f"({snippet})", style="dim " + _TEXT_MUTED)
         hidden = len(self._tool_calls) - _TOOL_DRILL_MAX_RENDER
         if hidden > 0:
-            t.append(f", +{hidden} more", style="dim #666666")
+            t.append(f", +{hidden} more", style="dim " + _TEXT_NEUTRAL)
         return t
 
     def _refresh(self) -> None:

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -20,7 +20,15 @@ from textual.message import Message
 from textual.widgets import Static
 
 from reyn.chat.slash import SlashCommand
-from reyn.chat.tui._palette import _CORAL
+from reyn.chat.tui._palette import (
+    _CORAL,
+    _BG_HEADER,
+    _TEXT_BRIGHT,
+    _TEXT_MUTED,
+    _TEXT_BODY,
+    _TEXT_DIM,
+    _TEXT_NEUTRAL,
+)
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -44,7 +52,7 @@ class SlashPicker(RenderableCacheMixin, Static):
         height: auto;
         /* 8 command rows + 1 "+N more" footer + 2 border rows = 11. */
         max-height: 11;
-        background: #1a1a1a;
+        background: #1a1a1a;  /* _BG_HEADER */
         border: solid $primary;
         padding: 0 1;
         display: none;
@@ -302,10 +310,10 @@ class SlashPicker(RenderableCacheMixin, Static):
             row = Text()
             # Selection caret
             row.append("▌ " if is_sel else "  ",
-                       style=_CORAL if is_sel else "#1a1a1a")
+                       style=_CORAL if is_sel else _BG_HEADER)
             # Command name
             name = f"/{cmd.name}".ljust(name_col)
-            row.append(name, style=f"bold {_CORAL}" if is_sel else "#dddddd")
+            row.append(name, style=f"bold {_CORAL}" if is_sel else _TEXT_BRIGHT)
             row.append("  ")
             # Summary (truncated to fit the row)
             summary = cmd.summary
@@ -313,7 +321,7 @@ class SlashPicker(RenderableCacheMixin, Static):
                 summary = summary[: max(1, summary_budget - 1)] + "…"
             row.append(
                 summary,
-                style="#bbbbbb" if is_sel else "dim #888888",
+                style="#bbbbbb" if is_sel else "dim " + _TEXT_MUTED,
             )
             if i > 0:
                 body.append("\n")
@@ -326,7 +334,7 @@ class SlashPicker(RenderableCacheMixin, Static):
             body.append("\n")
             body.append(
                 f"  +{hidden} more — keep typing to filter",
-                style="dim #888888",
+                style="dim " + _TEXT_MUTED,
             )
         self.update(body)
         self._set_rendered_cache(body)
@@ -356,10 +364,10 @@ class SlashPicker(RenderableCacheMixin, Static):
         if len(summary) > summary_budget:
             summary = summary[: max(1, summary_budget - 1)] + "…"
         t = Text()
-        t.append("  ", style="#1a1a1a")
-        t.append(name, style="dim #888888")
+        t.append("  ", style=_BG_HEADER)
+        t.append(name, style="dim " + _TEXT_MUTED)
         t.append("  ")
-        t.append(summary, style="dim #888888")
+        t.append(summary, style="dim " + _TEXT_MUTED)
         # Structured usage line — surfaced as a second hint row when
         # the command opts in via ``SlashCommand.usage``. Indented
         # under the summary with a ``↳`` connector so the eye groups
@@ -381,8 +389,8 @@ class SlashPicker(RenderableCacheMixin, Static):
             if len(usage_text) > usage_budget:
                 usage_text = usage_text[: max(1, usage_budget - 1)] + "…"
             t.append("\n")
-            t.append(indent + "↳ usage: ", style="dim #666666")
-            t.append(usage_text, style="dim #aaaaaa")
+            t.append(indent + "↳ usage: ", style="dim " + _TEXT_NEUTRAL)
+            t.append(usage_text, style="dim " + _TEXT_BODY)
         # Completion rows (if the command supplied a CompleterFn — e.g.
         # /attach surfacing agent names). Indented under the hint row,
         # one per line, dim, informational only.
@@ -390,13 +398,13 @@ class SlashPicker(RenderableCacheMixin, Static):
             indent = " " * (2 + len(name) + 2)
             for c in self._completions:
                 t.append("\n")
-                t.append(indent + c, style="dim #888888")
+                t.append(indent + c, style="dim " + _TEXT_MUTED)
             hidden = self._total_completions - len(self._completions)
             if hidden > 0:
                 t.append("\n")
                 t.append(
                     indent + f"+{hidden} more — keep typing to filter",
-                    style="dim #555555",
+                    style="dim " + _TEXT_DIM,
                 )
         # Tab-recall discovery footer — only for /find, only when history
         # is non-empty. Surfaces the affordance ("Tab inserts a recent
@@ -408,7 +416,7 @@ class SlashPicker(RenderableCacheMixin, Static):
             if find_history_has_entries():
                 indent = " " * (2 + len(name) + 2)
                 t.append("\n")
-                t.append(indent + "↳ Tab inserts a recent query", style="dim #666666")
+                t.append(indent + "↳ Tab inserts a recent query", style="dim " + _TEXT_NEUTRAL)
         self.update(t)
         self._set_rendered_cache(t)
 
@@ -428,15 +436,15 @@ class SlashPicker(RenderableCacheMixin, Static):
         typed = self._unknown_token
         suggestions = self._unknown_suggestions
         t = Text()
-        t.append("  ", style="#1a1a1a")
+        t.append("  ", style=_BG_HEADER)
         t.append("unknown ", style="dim #d4756a")
         t.append(f"/{typed}", style="dim #d4756a")
         if suggestions:
-            t.append("  — did you mean ", style="dim #888888")
+            t.append("  — did you mean ", style="dim " + _TEXT_MUTED)
             for i, sug in enumerate(suggestions):
                 if i > 0:
-                    t.append(" ", style="dim #888888")
-                t.append(f"/{sug}", style="dim #aaaaaa")
-            t.append("?", style="dim #888888")
+                    t.append(" ", style="dim " + _TEXT_MUTED)
+                t.append(f"/{sug}", style="dim " + _TEXT_BODY)
+            t.append("?", style="dim " + _TEXT_MUTED)
         self.update(t)
         self._set_rendered_cache(t)

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -21,12 +21,12 @@ from textual.widgets import Static
 
 from reyn.chat.slash import SlashCommand
 from reyn.chat.tui._palette import (
-    _CORAL,
     _BG_HEADER,
-    _TEXT_BRIGHT,
-    _TEXT_MUTED,
+    _CORAL,
     _TEXT_BODY,
+    _TEXT_BRIGHT,
     _TEXT_DIM,
+    _TEXT_MUTED,
     _TEXT_NEUTRAL,
 )
 

--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -34,7 +34,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _AMBER
+from reyn.chat.tui._palette import _AMBER, _STATUS_ERROR
 
 _RENDER_INTERVAL_MS = 16  # ~60 fps max
 _RENDER_INTERVAL_S = _RENDER_INTERVAL_MS / 1000
@@ -251,12 +251,12 @@ class StreamingRow(Widget):
             if idle >= _STALL_TIER_3_S:
                 t.append(
                     f" … (no token in {_fmt_idle(idle)}, Ctrl+C to cancel)",
-                    style="bold #ff6644",
+                    style="bold " + _STATUS_ERROR,
                 )
             elif idle >= _STALL_TIER_2_S:
                 t.append(
                     f" … (stalled {_fmt_idle(idle)})",
-                    style="bold #ffaa44",
+                    style="bold #ffaa44",  # palette-candidate: stall-warning amber (no foundation token yet)
                 )
             elif idle > _STALL_TIER_1_S:
                 t.append(" …", style="dim")

--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -35,7 +35,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL
+from reyn.chat.tui._palette import _CORAL, _TEXT_NEUTRAL, _TEXT_MUTED, _STATUS_ERROR
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -317,9 +317,9 @@ class ToolCallRow(RenderableCacheMixin, Widget):
     def _elapsed_style(self) -> str:
         secs = self._elapsed_s()
         if secs >= _ELAPSED_RED_S:
-            return "bold #ff6644"
+            return "bold " + _STATUS_ERROR
         if secs >= _ELAPSED_AMBER_S:
-            return "bold #ffaa44"
+            return "bold #ffaa44"  # palette-candidate: elapsed-warning amber (no foundation token yet)
         return "dim"
 
     def _state_glyph(self) -> tuple[str, str]:
@@ -329,7 +329,7 @@ class ToolCallRow(RenderableCacheMixin, Widget):
         if self._success:
             return ("✓", "bold green")
         if self._aborted:
-            return ("⊘", "dim #888888")
+            return ("⊘", "dim " + _TEXT_MUTED)
         return ("✗", "bold red")
 
     def _truncate_to_cells(self, text: str, max_cells: int) -> str:
@@ -425,7 +425,7 @@ class ToolCallRow(RenderableCacheMixin, Widget):
             args_display = self._args_repr
 
         if self._label_prefix:
-            t.append(self._label_prefix, style="dim #666666")
+            t.append(self._label_prefix, style="dim " + _TEXT_NEUTRAL)
         t.append(glyph_with_space, style=glyph_style)
         t.append(tool_open, style="bold" if not self._finished else "dim")
         t.append(args_display, style="dim")
@@ -470,7 +470,7 @@ class ToolCallRow(RenderableCacheMixin, Widget):
             body, body_budget,
         )
         t = Text()
-        t.append(_RESULT_INDENT, style="dim #666666")
+        t.append(_RESULT_INDENT, style="dim " + _TEXT_NEUTRAL)
         t.append(snippet, style=body_style)
         return t
 
@@ -486,8 +486,8 @@ class ToolCallRow(RenderableCacheMixin, Widget):
             return self._result_snippet, "dim"
         if self._finished and not self._success and self._reason:
             if self._aborted:
-                return f"⊘ {self._reason}", "dim #888888"
-            return f"✗ {self._reason}", "dim #ff6644"
+                return f"⊘ {self._reason}", "dim " + _TEXT_MUTED
+            return f"✗ {self._reason}", "dim " + _STATUS_ERROR
         return "", "dim"
 
     def _refresh(self) -> None:

--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -35,7 +35,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL, _TEXT_NEUTRAL, _TEXT_MUTED, _STATUS_ERROR
+from reyn.chat.tui._palette import _CORAL, _STATUS_ERROR, _TEXT_MUTED, _TEXT_NEUTRAL
 
 from ._renderable_cache import RenderableCacheMixin
 


### PR DESCRIPTION
**[tui-coder]** — Pure value-preserving palette token migration for the 9 conv/input/row widgets. Rendered colours are byte-identical to pre-PR.

## Per-file hex → token changes

| File | Hexes migrated | Left hardcoded |
|------|---------------|----------------|
| `conversation.py` | `#666666`→`_TEXT_NEUTRAL`, `#555555`→`_TEXT_DIM`, `#888888`→`_TEXT_MUTED`, `#ffcc88`→`_EVENT_INTERVENTION` | `#4abbb5` (user glyph teal, decorative), `#aa6666` (cancelled-partial dim red, decorative) |
| `streaming_row.py` | `#ff6644`→`_STATUS_ERROR` | `#ffaa44` (stall-warning amber, palette-candidate) |
| `skill_activity.py` | `#ff6644`→`_STATUS_ERROR`, `#666666`→`_TEXT_NEUTRAL`, `#888888`→`_TEXT_MUTED`, `#aaaaaa`→`_TEXT_BODY` | `#ffaa44` (elapsed-warning amber, palette-candidate) |
| `tool_call_row.py` | `#ff6644`→`_STATUS_ERROR`, `#888888`→`_TEXT_MUTED`, `#666666`→`_TEXT_NEUTRAL` | `#ffaa44` (elapsed-warning amber, palette-candidate) |
| `async_stack_panel.py` | `#ff6644`→`_STATUS_ERROR`, `#888888`→`_TEXT_MUTED`, `#1a1a1a`→`_BG_HEADER` | `#ffaa44` (pending-warning amber, palette-candidate) |
| `slash_picker.py` | `#1a1a1a`→`_BG_HEADER`, `#dddddd`→`_TEXT_BRIGHT`, `#888888`→`_TEXT_MUTED`, `#aaaaaa`→`_TEXT_BODY`, `#666666`→`_TEXT_NEUTRAL`, `#555555`→`_TEXT_DIM` | `#bbbbbb` (selected summary, decorative), `#d4756a` (unknown-cmd red, decorative) |
| `input_bar.py` | None (all hex is in CSS strings, annotated with `/* _TOKEN */` comments) | `#111111`→CSS comment, `#2a2a2a`→CSS comment, `#553333` (disconnected red, widget-local) |
| `header.py` | `#ff4444`→`_STATUS_CRITICAL`, `#ff6644`→`_STATUS_ERROR`, `#888888`→`_TEXT_MUTED`, `#555555`→`_TEXT_DIM` | `#ffaa44` (multiple: cap-proximity / pending / transcribing amber, palette-candidate), `#88aacc` (find-badge blue, decorative) |
| `error_box.py` | None (all hex is in CSS strings, annotated) | Full severity ramp — see below |

## Flagged widget-local colours (substitute-vs-orthogonal analysis)

These are **left hardcoded** with `# palette-candidate: <semantic>` or `/* palette-candidate: <semantic> */` comments. They must NOT be collapsed to an approximate existing foundation token because they form an intentional distinct semantic ramp:

### `error_box.py` — SEVERITY RAMP (HIGH/MED/LOW)
- `#cc5555` — HIGH border + header (distinct dim red vs `_STATUS_ERROR` = `#ff6644`)
- `#cc9955` — MED border + header (amber tier)
- `#ff7777` — HIGH hover (lighter than `#cc5555`)
- `#ffbb77` — MED hover
- `#777777` — detail body (between `_TEXT_NEUTRAL` and `_TEXT_MUTED`)
- `#8a7a4a` — inline-hint actionable (intentionally different from metadata greys)
- **Substitute-vs-orthogonal**: These are a **severity ramp** (3-tier HIGH/MED/LOW with distinct hover states). Collapsing to `_STATUS_ERROR` / `_STATUS_CRITICAL` would lose the MED/LOW tiers. They are **orthogonal** to the status tokens — they carry "error UI severity" semantics, not "event type" semantics.

### `#ffaa44` — WARNING AMBER (multiple widgets)
Used for: elapsed-warning (SkillActivityRow/ToolCallRow), stall-warning (StreamingRow), pending-warning (AsyncStackPanel/header), cap-proximity (header), transcribing (header). This amber has a consistent semantic across 5 widgets ("taking a while / attention needed") but no foundation token yet. Design follow-up: introduce `_WARN_AMBER` or similar.

### Other decorative one-offs left unchanged
`#4abbb5`, `#aa6666`, `#bbbbbb`, `#d4756a`, `#88aacc` — no near foundation token; distinct widget-specific accent.

## Test plan

- [x] `pytest tests/cli/ -q -k "conversation or intervention or input_bar or skill_activity or slash or error or header or stream or tool_call or async_stack"` — 573 passed
- [x] `pytest tests/cli/test_tui_smoke.py -q` — 40 passed
- [x] (skipped — visual rendering) Rendered colours byte-identical to pre-PR (value-preserving refactor, no logic change)

## Tier self-check
Pure value-preserving refactor — no new test warranted. No Tier 1 contract changes (imports only). No Tier 2 invariant changes. All existing tests continue to verify rendered output via `.plain` / public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)