### PR TITLE
feat(fp-0008): C7 PR1 — benchmark capability detection + honest-skip (no fake PASS/FAIL)

### DIFF
--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -12,6 +12,17 @@ reyn eval benchmark <skill_name> \\
     --concurrency <N>           # default 4
     [--limit <N>]               # subset for quick try
     [--resume]                  # continue from prior run
+
+Capability tiers (C7 — honest verification accounting)
+-------------------------------------------------------
+Tier 1 (docker):         Docker daemon reachable — official SWE-bench image eval (PR2).
+Tier 2 (linux_host):     Linux host without Docker — uv-based faithful build (PR3).
+Tier 3 (no_faithful_env): macOS/Windows or no Docker — skip verification; never emit
+                          a non-faithful PASS/FAIL.
+
+THE INVARIANT: NEVER count a verify_skipped result as pass or fail.
+pass_rate is computed over the faithful-verified subset ONLY.  When that
+subset is empty, pass_rate is null.
 """
 from __future__ import annotations
 
@@ -19,6 +30,7 @@ import argparse
 import asyncio
 import json
 import logging
+import platform
 import subprocess
 import sys
 import tempfile
@@ -26,6 +38,81 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
+
+# ── capability detection (C7 — honest-skip foundation) ───────────────────────
+
+_TIER_DOCKER = "docker"
+_TIER_LINUX_HOST = "linux_host"
+_TIER_NO_FAITHFUL_ENV = "no_faithful_env"
+
+# Human-readable skip reason injected into every Tier 3 result record.
+_NO_FAITHFUL_ENV_REASON = (
+    "no faithful verification environment (requires Docker or a Linux host); "
+    "SWE-bench specs need the official Linux build toolchain"
+)
+
+# Stub reason for Tier 1/2 — faithful eval not yet implemented (PR2/PR3).
+_TIER1_STUB_REASON = (
+    "faithful eval not yet implemented (Tier1 docker / Tier2 uv — PR2/PR3)"
+)
+
+
+def classify_verification_tier(
+    *,
+    docker_available: bool,
+    platform_system: str,
+) -> str:
+    """Pure classifier: return the verification tier string from explicit inputs.
+
+    Tier 1 (docker):         Docker daemon is reachable.
+    Tier 2 (linux_host):     Linux host, no Docker.
+    Tier 3 (no_faithful_env): macOS / Windows / any other platform without Docker.
+
+    Intentionally pure (no I/O) so it can be unit-tested without any
+    subprocess or platform probing.  The probe that gathers the real
+    inputs is ``detect_verification_tier()``.
+    """
+    if docker_available:
+        return _TIER_DOCKER
+    if platform_system == "Linux":
+        return _TIER_LINUX_HOST
+    return _TIER_NO_FAITHFUL_ENV
+
+
+def detect_verification_tier() -> str:
+    """Probe real environment and return the verification tier string.
+
+    Calls ``classify_verification_tier`` with:
+    - docker_available: True iff ``docker info`` exits 0 within 5 s.
+    - platform_system: ``platform.system()`` (= "Linux" / "Darwin" / "Windows" …).
+
+    Keep this thin — all classification logic lives in the pure classifier.
+    """
+    docker_ok = False
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=5,
+        )
+        docker_ok = result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        docker_ok = False
+
+    return classify_verification_tier(
+        docker_available=docker_ok,
+        platform_system=platform.system(),
+    )
+
+
+def _make_verify_skip_record(tier: str, reason: str) -> dict:
+    """Return the three fields added to every verify-skipped result record."""
+    return {
+        "verify_tier": tier,
+        "verify_skipped": True,
+        "verify_skip_reason": reason,
+    }
+
 
 # ── public entry points (called from eval.py) ─────────────────────────────────
 
@@ -178,6 +265,44 @@ def _load_completed_ids(run_dir: Path) -> set[str]:
 # ── summary.json helpers ──────────────────────────────────────────────────────
 
 
+def compute_faithful_accounting(results: list[dict]) -> dict:
+    """Compute faithful PASS-rate accounting from a list of result records.
+
+    THE INVARIANT: pass_rate is computed over the faithful-verified subset
+    ONLY (results where verify_skipped is not True).  A verify_skipped result
+    is NEVER counted as pass or fail.
+
+    Returns a dict with:
+      - faithful_verified_count: int — number of results where verify_skipped is falsy
+      - faithful_passed: int | None — pass count over faithful subset (None if no
+        faithful result has a tests_passed field)
+      - faithful_pass_rate: float | None — pass_rate over faithful subset (None if
+        faithful_verified_count == 0 or no tests_passed field present)
+      - skip_count: int — number of results with verify_skipped == True
+    """
+    faithful = [r for r in results if not r.get("verify_skipped")]
+    skipped = [r for r in results if r.get("verify_skipped")]
+
+    faithful_count = len(faithful)
+    skip_count = len(skipped)
+
+    # tests_passed: only computed if ANY faithful result has the field
+    has_tests_passed = any("tests_passed" in r for r in faithful)
+    if has_tests_passed and faithful_count > 0:
+        passed = sum(1 for r in faithful if r.get("tests_passed") is True)
+        pass_rate: float | None = passed / faithful_count
+    else:
+        passed = None
+        pass_rate = None
+
+    return {
+        "faithful_verified_count": faithful_count,
+        "faithful_passed": passed,
+        "faithful_pass_rate": pass_rate,
+        "skip_count": skip_count,
+    }
+
+
 def _write_summary(
     run_dir: Path,
     run_id: str,
@@ -185,16 +310,24 @@ def _write_summary(
     results: list[dict],
     total_tasks: int,
 ) -> None:
-    """Write (or overwrite) summary.json from current results list."""
+    """Write (or overwrite) summary.json from current results list.
+
+    The ``pass_rate`` field is the FAITHFUL pass_rate — computed over
+    verify-skipped=false results only.  When the faithful subset is empty,
+    pass_rate is null.  The ``passed`` field likewise counts only faithful
+    results.  verify-skipped counts are shown prominently under
+    ``verify_accounting``.
+    """
     completed = len(results)
     total_cost = sum(r.get("cost_usd") or 0.0 for r in results)
     avg_cost = total_cost / completed if completed else 0.0
 
-    # tests_passed: only computed if ANY result has the field
-    has_tests_passed = any("tests_passed" in r for r in results)
-    passed = sum(1 for r in results if r.get("tests_passed") is True) if has_tests_passed else None
-    pass_rate = (passed / completed) if (has_tests_passed and completed) else None
+    # Faithful PASS-rate accounting (C7 invariant)
+    acct = compute_faithful_accounting(results)
+    passed = acct["faithful_passed"]
+    pass_rate = acct["faithful_pass_rate"]
 
+    # Backward compat: also keep the old has_tests_passed path for completed_ids
     # attempts: only if field present
     has_attempts = any("attempts" in r for r in results)
     if has_attempts:
@@ -213,6 +346,15 @@ def _write_summary(
         "completed": completed,
         "passed": passed,
         "pass_rate": pass_rate,
+        # Prominent faithful-verification accounting block (C7 invariant).
+        # Never bury the skip count — it must be visible at a glance.
+        "verify_accounting": {
+            "faithful_verified": acct["faithful_verified_count"],
+            "faithful_passed": acct["faithful_passed"],
+            "faithful_pass_rate": acct["faithful_pass_rate"],
+            "verify_skipped": acct["skip_count"],
+            "total": completed,
+        },
         "total_cost_usd": total_cost,
         "avg_cost_per_instance": avg_cost,
         "avg_attempts": avg_attempts,
@@ -308,6 +450,7 @@ async def _run_single_task(
     permission_resolver=None,
     python_allowed_modules: list[str] | None = None,
     clone_task_repo: bool = False,
+    verify_tier: str = _TIER_NO_FAITHFUL_ENV,
 ) -> dict:
     """Run a single task under the semaphore; return a result record.
 
@@ -320,6 +463,12 @@ async def _run_single_task(
     ``{kind: "shell", cmd: ...}``), every retry hits the validator, the
     batch reports $0.00 cost + 100% error rate. See PR-D follow-up to PR-B
     (= FP-0008 sandbox_2 calibration block 2026-05-28).
+
+    ``verify_tier`` is detected ONCE at batch start via
+    ``detect_verification_tier()`` and passed through to every task.  It
+    drives the honest-skip decision (C7 invariant): when there is no
+    faithful verification environment, the result is marked verify_skipped
+    instead of emitting a non-faithful PASS/FAIL.
     """
     from reyn.agent import Agent
     from reyn.config import _find_project_root, load_project_context
@@ -385,7 +534,38 @@ async def _run_single_task(
             "error": error_msg,
         }
 
-        # Lift well-known optional fields from result_data generically
+        # ── C7: Verification tier dispatch ────────────────────────────────────
+        # Dispatch on verify_tier to determine whether this result is
+        # faithfully verified or should be marked as skipped.
+        #
+        # Tier 1 (docker): PR2 will implement Docker-based official-image eval.
+        #   Until then, stub — mark skipped with PR2/PR3 pending reason.
+        # Tier 2 (linux_host): PR3 will implement uv-based build eval.
+        #   Until then, stub — mark skipped with PR2/PR3 pending reason.
+        # Tier 3 (no_faithful_env): ALWAYS skip — no faithful env available.
+        #   On macOS/Windows, the AI's self-check (tests_passed from the skill)
+        #   MUST NOT be promoted to an authoritative pass/fail.
+        #
+        # The structure here is the dispatch skeleton that PR2/PR3 will fill in.
+        # When a tier is fully implemented, replace the stub block with real eval.
+        if verify_tier == _TIER_DOCKER:
+            # PR2: implement Docker-based official-image eval here.
+            # For now: stub — skip with pending reason.
+            record.update(_make_verify_skip_record(_TIER_DOCKER, _TIER1_STUB_REASON))
+        elif verify_tier == _TIER_LINUX_HOST:
+            # PR3: implement uv-based Linux build eval here.
+            # For now: stub — skip with pending reason.
+            record.update(_make_verify_skip_record(_TIER_LINUX_HOST, _TIER1_STUB_REASON))
+        else:
+            # Tier 3 (no_faithful_env) — always skip.
+            # The AI's self-check result (tests_passed from skill output) is
+            # NOT promoted to an authoritative pass/fail when verify_skipped.
+            record.update(_make_verify_skip_record(_TIER_NO_FAITHFUL_ENV, _NO_FAITHFUL_ENV_REASON))
+
+        # Lift well-known optional fields from result_data generically.
+        # tests_passed is still recorded for debugging/analysis, but it is
+        # excluded from pass_rate computation when verify_skipped is True
+        # (enforced in compute_faithful_accounting via the faithful subset filter).
         if "tests_passed" in result_data:
             record["tests_passed"] = result_data["tests_passed"]
         if "attempts" in result_data:
@@ -436,6 +616,11 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
     perm_resolver = _build_permission_resolver(
         session.config, shell_allowed, unsafe_python=unsafe_python,
     )
+
+    # C7: Detect verification tier ONCE at batch start.
+    # All tasks in this run share the same host environment, so detecting
+    # once and threading through is correct and efficient.
+    verify_tier = detect_verification_tier()
 
     # Load tasks
     tasks_path = Path(args.tasks)
@@ -492,6 +677,10 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
     print(f"  tasks:       {tasks_path}  ({total_tasks} total, {len(pending)} to run)")
     print(f"  concurrency: {args.concurrency}")
     print(f"  output:      {run_dir}")
+    print(f"  verify_tier: {verify_tier}")
+    if verify_tier == _TIER_NO_FAITHFUL_ENV:
+        print("  NOTE: no faithful verification env — all results will be verify_skipped=true")
+        print("        pass_rate will be null (0 faithful-verified tasks)")
     print()
 
     results: list[dict] = []
@@ -513,6 +702,7 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
                 shell_allowed=shell_allowed,
                 permission_resolver=perm_resolver,
                 clone_task_repo=clone_task_repo,
+                verify_tier=verify_tier,
             )
         except Exception as exc:
             # A task failure never aborts the batch — log and record the error.
@@ -527,17 +717,34 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
 
     await asyncio.gather(*(_task_with_progress(i, t) for i, t in pending))
 
-    # Final summary
+    # Final summary — C7 invariant: always show the prominent accounting line.
     print()
     completed = len(results)
     errors = sum(1 for r in results if r.get("error"))
+    acct = compute_faithful_accounting(results)
+    faithful_n = acct["faithful_verified_count"]
+    skip_k = acct["skip_count"]
+    faithful_passed = acct["faithful_passed"]
+    faithful_rate = acct["faithful_pass_rate"]
+
     print(f"benchmark complete: {args.skill_name}")
     print(f"  completed: {completed}/{len(pending)}")
     if errors:
         print(f"  errors:    {errors}")
-    has_tests_passed = any("tests_passed" in r for r in results)
-    if has_tests_passed:
-        passed = sum(1 for r in results if r.get("tests_passed") is True)
-        rate = passed / completed if completed else 0.0
-        print(f"  passed:    {passed}/{completed} ({rate:.1%})")
+    # Prominent accounting line — required by C7 invariant.  Never bury the
+    # skip count.  This line appears in stdout AND summary.json.
+    if faithful_passed is not None:
+        rate_str = f"  ({faithful_rate:.1%})" if faithful_rate is not None else ""
+        print(
+            f"  faithful verified: {faithful_n}/{completed}"
+            f"  |  passed: {faithful_passed}/{faithful_n}{rate_str}"
+            f"  |  skipped (no faithful env): {skip_k}"
+        )
+    else:
+        print(
+            f"  faithful verified: {faithful_n}/{completed}"
+            f"  |  skipped (no faithful env): {skip_k}"
+        )
+    if faithful_n == 0:
+        print("  pass_rate: n/a (0 faithful verified)")
     print(f"  summary → {run_dir / 'summary.json'}")

--- a/tests/test_eval_benchmark_capability_tier.py
+++ b/tests/test_eval_benchmark_capability_tier.py
@@ -1,0 +1,236 @@
+"""Tier 2: OS invariant — benchmark capability-detection + honest-skip + faithful-PASS-rate.
+
+Pins the C7 PR1 invariants (FP-0008 C7):
+
+1. test_classify_tier_docker         — docker_available=True → "docker"
+2. test_classify_tier_linux_host     — docker=False + Linux → "linux_host"
+3. test_classify_tier_no_faithful_darwin  — docker=False + Darwin → "no_faithful_env"
+4. test_classify_tier_no_faithful_windows — docker=False + Windows → "no_faithful_env"
+5. test_accounting_faithful_only     — pass_rate computed over faithful subset only
+6. test_accounting_skip_excluded     — verify_skipped result excluded from rate
+7. test_accounting_skip_count        — skip_count matches skipped result count
+8. test_accounting_empty_faithful    — pass_rate null when 0 faithful results
+9. test_honest_skip_fields           — no_faithful_env path → verify_skipped=True + reason + tier
+10. test_honest_skip_reason_nonempty — verify_skip_reason is non-empty string
+11. test_honest_skip_tier_set        — verify_tier field equals the detected tier
+
+No mocks (``unittest.mock`` / ``AsyncMock`` / ``MagicMock`` / ``patch``).
+Pure classifier + real accounting dicts — no subprocess / platform probing.
+"""
+from __future__ import annotations
+
+import pytest  # noqa: F401 — used for pytest.raises in future tests
+
+from reyn.cli.commands.eval_benchmark import (
+    _TIER_DOCKER,
+    _TIER_LINUX_HOST,
+    _TIER_NO_FAITHFUL_ENV,
+    _make_verify_skip_record,
+    classify_verification_tier,
+    compute_faithful_accounting,
+)
+
+# ── 1-4: classify_verification_tier (pure, explicit inputs) ──────────────────
+
+
+def test_classify_tier_docker() -> None:
+    """Tier 2: docker_available=True → returns 'docker' regardless of platform."""
+    result = classify_verification_tier(docker_available=True, platform_system="Darwin")
+    assert result == _TIER_DOCKER
+
+    result2 = classify_verification_tier(docker_available=True, platform_system="Linux")
+    assert result2 == _TIER_DOCKER
+
+    result3 = classify_verification_tier(docker_available=True, platform_system="Windows")
+    assert result3 == _TIER_DOCKER
+
+
+def test_classify_tier_linux_host() -> None:
+    """Tier 2: docker=False + platform_system='Linux' → returns 'linux_host'."""
+    result = classify_verification_tier(docker_available=False, platform_system="Linux")
+    assert result == _TIER_LINUX_HOST
+
+
+def test_classify_tier_no_faithful_darwin() -> None:
+    """Tier 2: docker=False + Darwin → returns 'no_faithful_env'."""
+    result = classify_verification_tier(docker_available=False, platform_system="Darwin")
+    assert result == _TIER_NO_FAITHFUL_ENV
+
+
+def test_classify_tier_no_faithful_windows() -> None:
+    """Tier 2: docker=False + Windows → returns 'no_faithful_env'."""
+    result = classify_verification_tier(docker_available=False, platform_system="Windows")
+    assert result == _TIER_NO_FAITHFUL_ENV
+
+
+# ── 5-8: compute_faithful_accounting ─────────────────────────────────────────
+
+
+def _faithful_pass(instance_id: str) -> dict:
+    """Build a faithfully-verified passing result record."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": _TIER_DOCKER,
+        "verify_skipped": False,
+        "tests_passed": True,
+    }
+
+
+def _faithful_fail(instance_id: str) -> dict:
+    """Build a faithfully-verified failing result record."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": _TIER_DOCKER,
+        "verify_skipped": False,
+        "tests_passed": False,
+    }
+
+
+def _skipped(instance_id: str) -> dict:
+    """Build a verify-skipped result record (no_faithful_env)."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": _TIER_NO_FAITHFUL_ENV,
+        "verify_skipped": True,
+        "verify_skip_reason": "test skip reason",
+        # tests_passed from skill's self-check — must NOT count in the rate
+        "tests_passed": True,
+    }
+
+
+def test_accounting_faithful_only() -> None:
+    """Tier 2: pass_rate is computed over the faithful-verified subset only.
+
+    Given 2 faithful (1 pass, 1 fail) + 1 skipped (has tests_passed=True),
+    the pass_rate must be 1/2 = 0.5, NOT 2/3.
+    """
+    results = [
+        _faithful_pass("t1"),
+        _faithful_fail("t2"),
+        _skipped("t3"),
+    ]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_verified_count"] == 2
+    assert acct["faithful_passed"] == 1
+    assert abs(acct["faithful_pass_rate"] - 0.5) < 1e-9, (
+        f"Expected faithful_pass_rate=0.5, got {acct['faithful_pass_rate']}"
+    )
+
+
+def test_accounting_skip_excluded() -> None:
+    """Tier 2: a verify_skipped result (even with tests_passed=True) is excluded from rate."""
+    # 3 skipped (all claiming tests_passed=True) + 0 faithful
+    results = [_skipped(f"s{i}") for i in range(3)]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_verified_count"] == 0
+    # No faithful results → pass_rate must be null, not 100%
+    assert acct["faithful_passed"] is None, (
+        "faithful_passed should be None when there are no faithful results"
+    )
+    assert acct["faithful_pass_rate"] is None, (
+        "faithful_pass_rate should be None when there are no faithful results — "
+        "never emit a non-faithful PASS/FAIL"
+    )
+
+
+def test_accounting_skip_count() -> None:
+    """Tier 2: skip_count matches the number of results with verify_skipped=True."""
+    results = [
+        _faithful_pass("t1"),
+        _skipped("s1"),
+        _skipped("s2"),
+        _faithful_fail("t2"),
+    ]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["skip_count"] == 2
+    assert acct["faithful_verified_count"] == 2
+
+
+def test_accounting_empty_faithful() -> None:
+    """Tier 2: pass_rate is null when 0 results are faithful-verified."""
+    results = [_skipped("s1"), _skipped("s2")]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_verified_count"] == 0
+    assert acct["faithful_pass_rate"] is None
+    assert acct["faithful_passed"] is None
+
+
+# ── 9-11: honest-skip marking (_make_verify_skip_record + no_faithful_env path) ─
+
+
+def test_honest_skip_fields() -> None:
+    """Tier 2: _make_verify_skip_record returns verify_skipped=True + tier + reason fields."""
+    record = _make_verify_skip_record(_TIER_NO_FAITHFUL_ENV, "test reason")
+
+    assert record["verify_skipped"] is True
+    assert record["verify_tier"] == _TIER_NO_FAITHFUL_ENV
+    assert "verify_skip_reason" in record
+
+
+def test_honest_skip_reason_nonempty() -> None:
+    """Tier 2: the no_faithful_env skip reason is a non-empty string."""
+    from reyn.cli.commands.eval_benchmark import _NO_FAITHFUL_ENV_REASON
+
+    assert isinstance(_NO_FAITHFUL_ENV_REASON, str)
+    assert len(_NO_FAITHFUL_ENV_REASON) > 0
+
+
+def test_honest_skip_tier_set() -> None:
+    """Tier 2: verify_tier field in the skip record equals the tier passed in."""
+    for tier in (_TIER_DOCKER, _TIER_LINUX_HOST, _TIER_NO_FAITHFUL_ENV):
+        record = _make_verify_skip_record(tier, "some reason")
+        assert record["verify_tier"] == tier, (
+            f"Expected verify_tier={tier!r}, got {record['verify_tier']!r}"
+        )
+
+
+# ── integration: accounting + summary.json contains verify_accounting block ──
+
+
+def test_write_summary_verify_accounting_block(tmp_path) -> None:
+    """Tier 2: _write_summary emits a prominent verify_accounting block in summary.json.
+
+    When all results are verify_skipped=True, pass_rate must be null and
+    verify_accounting.verify_skipped must equal the total completed count.
+    """
+    import json
+
+    from reyn.cli.commands.eval_benchmark import _write_summary
+
+    run_dir = tmp_path / "run_c7_test"
+    run_dir.mkdir()
+
+    # Simulate 3 tasks all skipped (= macOS without Docker host)
+    results = [
+        {
+            "instance_id": f"t{i}",
+            "cost_usd": 0.05,
+            "verify_tier": _TIER_NO_FAITHFUL_ENV,
+            "verify_skipped": True,
+            "verify_skip_reason": "no faithful env",
+            "tests_passed": True,  # skill self-check — must not count
+        }
+        for i in range(3)
+    ]
+
+    _write_summary(run_dir, "run_c7_test", "swe_bench", results, total_tasks=3)
+
+    data = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+
+    # Top-level pass_rate must be null (0 faithful verified)
+    assert data["pass_rate"] is None, (
+        f"pass_rate should be null when all results are verify_skipped; got {data['pass_rate']}"
+    )
+    assert data["passed"] is None
+
+    # verify_accounting block must be present and prominent
+    assert "verify_accounting" in data, "summary.json must contain a 'verify_accounting' block"
+    va = data["verify_accounting"]
+
+    assert va["faithful_verified"] == 0
+    assert va["verify_skipped"] == 3
+    assert va["faithful_pass_rate"] is None

--- a/tests/test_eval_benchmark_cli.py
+++ b/tests/test_eval_benchmark_cli.py
@@ -429,7 +429,8 @@ def test_single_task_failure_no_abort(
 
     async def _stub_run_single_task(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, permission_resolver=None, python_allowed_modules=None, clone_task_repo=False,
+        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
+        clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         nonlocal call_count
         async with semaphore:
@@ -529,7 +530,8 @@ def test_allow_shell_propagates_to_single_task(
 
     async def _capture_shell_allowed(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, permission_resolver=None, python_allowed_modules=None, clone_task_repo=False,
+        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
+        clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         async with semaphore:
             captured["shell_allowed"] = shell_allowed
@@ -619,7 +621,7 @@ def test_clone_task_repo_propagates_to_single_task(
     async def _capture_clone_flag(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
         shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
-        clone_task_repo=False,
+        clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         async with semaphore:
             captured["clone_task_repo"] = clone_task_repo


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 C7 PR1: benchmark capability-detection + honest-skip + faithful-PASS-rate accounting.

## Why this PR

The reyn SWE-bench benchmark clones+checks-out a repo but doesn't faithfully build/install it.  The `tests_passed` field from the skill's self-check is produced by the AI on a non-faithful host (e.g. macOS arm64 where astropy C-extensions can't build), so emitting it as an authoritative PASS/FAIL produces fabricated metrics.

The full design is a **3-tier capability-aware system**:
- **Tier 1 (docker)**: Docker daemon reachable → run official SWE-bench Linux image eval (PR2)
- **Tier 2 (linux_host)**: Linux host without Docker → uv-based faithful build eval (PR3)
- **Tier 3 (no_faithful_env)**: macOS / Windows / no Docker → **SKIP verification**; never emit a non-faithful PASS/FAIL

**PR1 is the foundation only**: capability detection + Tier3 honest-skip + faithful-PASS-rate accounting.  Tier1/Tier2 dispatch points are present as stubs — real eval lands in PR2/PR3.

## THE INVARIANT (the whole point)

> NEVER emit a non-faithful PASS/FAIL.  When there's no faithful verification environment, the result is marked SKIPPED (not pass, not fail), and the PASS-rate is computed over the faithful-verified subset ONLY, with the skip count shown prominently.

## What changes

Only `src/reyn/cli/commands/eval_benchmark.py` (benchmark harness) and tests.
**OS/skill code is untouched** (P7 note: eval_benchmark.py is harness code allowed to know platform/docker — this is explicitly not OS code).

### New public functions

- `classify_verification_tier(*, docker_available: bool, platform_system: str) -> str`
  Pure classifier — returns `"docker"` / `"linux_host"` / `"no_faithful_env"`.
- `detect_verification_tier() -> str`
  Thin probe (docker info subprocess + platform.system()) → calls pure classifier.
- `compute_faithful_accounting(results: list[dict]) -> dict`
  Faithful-subset-only pass_rate + skip_count accounting.

### New result fields

Every result record gains:
- `verify_tier`: `"docker"` / `"linux_host"` / `"no_faithful_env"`
- `verify_skipped`: `True` / `False`
- `verify_skip_reason`: non-empty string (explains why verification was skipped)

### summary.json

The `verify_accounting` block is now **prominent, not buried**:
```json
"verify_accounting": {
  "faithful_verified": 0,
  "faithful_passed": null,
  "faithful_pass_rate": null,
  "verify_skipped": 3,
  "total": 3
}
```

### stdout summary (prominent accounting line)

```
faithful verified: 0/3  |  skipped (no faithful env): 3
pass_rate: n/a (0 faithful verified)
```

## Platform finding

macOS arm64 cannot build astropy C-extensions; the official SWE-bench suite uses Linux docker. This is the structural reason why Tier3 (no_faithful_env) is the honest answer on any non-Linux non-Docker host.

## Tests (12 new, all Tier 2, no mocks)

`tests/test_eval_benchmark_capability_tier.py`:
- `classify_verification_tier`: docker=True→docker; False+Linux→linux_host; False+Darwin→no_faithful_env; False+Windows→no_faithful_env
- `compute_faithful_accounting`: faithful-only rate; skip excluded; skip count; empty faithful
- `_make_verify_skip_record`: fields present; reason non-empty; tier matches
- `_write_summary` integration: verify_accounting block + null pass_rate with all-skipped

Tier audit: 12/12 pass, 0 errors, 0 warnings.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_eval_benchmark_capability_tier.py` — 12/12 pass, 0 errors
- [x] `pytest -q tests/ -k "eval_benchmark or capability or tier"` — 106 passed
- [x] `pytest -q tests/` — 6456 passed, 1 known pre-existing failure (test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content), 5 skipped, 3 xfailed
- [x] P7 check: `git diff --stat HEAD~2` shows only `eval_benchmark.py` + tests — OS/skill code untouched

Refs #1097