### PR TITLE
feat(fp-0008): C7 PR3 — Tier1 Docker faithful eval via swebench run_evaluation delegation

### DIFF
--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -15,14 +15,24 @@ reyn eval benchmark <skill_name> \\
 
 Capability tiers (C7 — honest verification accounting)
 -------------------------------------------------------
-Tier 1 (docker):         Docker daemon reachable — official SWE-bench image eval (PR2).
-Tier 2 (linux_host):     Linux host without Docker — uv-based faithful build (PR3).
+Tier 1 (docker):         Docker daemon reachable — official SWE-bench image eval (PR3).
+                         Delegates authoritative scoring to swebench.harness.run_evaluation.main,
+                         which pulls the official pre-built image and runs the test_cmd via Docker.
+                         swebench is a Tier1-ONLY lazy optional dependency — NOT imported at
+                         module top, NOT part of reyn's core install.
+                         Install separately: pip install swebench
+Tier 2 (linux_host):     Linux host without Docker — uv-based faithful build (future PR).
 Tier 3 (no_faithful_env): macOS/Windows or no Docker — skip verification; never emit
                           a non-faithful PASS/FAIL.
 
 THE INVARIANT: NEVER count a verify_skipped result as pass or fail.
 pass_rate is computed over the faithful-verified subset ONLY.  When that
 subset is empty, pass_rate is null.
+
+Binary-sharpening (C7): For Tier-1 evaluated results, the authoritative C7
+pass/fail is the harness verdict (harness_resolved) from swebench's official
+eval — NOT the skill's self-check (tests_passed).  compute_faithful_accounting
+uses harness_resolved when present; tests_passed is recorded as informational only.
 """
 from __future__ import annotations
 
@@ -51,9 +61,14 @@ _NO_FAITHFUL_ENV_REASON = (
     "SWE-bench specs need the official Linux build toolchain"
 )
 
-# Stub reason for Tier 1/2 — faithful eval not yet implemented (PR2/PR3).
-_TIER1_STUB_REASON = (
-    "faithful eval not yet implemented (Tier1 docker / Tier2 uv — PR2/PR3)"
+# Stub reason for Tier 2 (linux_host) — faithful eval not yet implemented.
+_TIER2_STUB_REASON = (
+    "faithful eval not yet implemented (Tier2 uv-based Linux build — future PR)"
+)
+
+# Reason emitted when Tier 1 is selected but swebench is not installed.
+_TIER1_SWEBENCH_MISSING_REASON = (
+    "Tier1 requires swebench (pip install swebench) — not installed"
 )
 
 
@@ -112,6 +127,197 @@ def _make_verify_skip_record(tier: str, reason: str) -> dict:
         "verify_skipped": True,
         "verify_skip_reason": reason,
     }
+
+
+# ── Tier-1: model_patch extraction ──────────────────────────────────────────────
+
+
+def extract_model_patch(workspace: "Path") -> str:
+    """Extract ``git diff HEAD`` from the skill's workspace directory.
+
+    This is the AI's solution: the cumulative diff of all changes made
+    by the skill relative to the base commit checked out in the workspace.
+
+    Returns the diff string (may be empty if no changes were made).
+    Raises ``subprocess.CalledProcessError`` if git is not available or the
+    workspace is not a git repository.
+    """
+    result = subprocess.run(
+        ["git", "diff", "HEAD"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    # git diff HEAD exits 0 whether or not there are changes
+    result.check_returncode()
+    return result.stdout
+
+
+def build_swebench_prediction(instance_id: str, model_patch: str) -> dict:
+    """Build the swebench prediction dict for one instance.
+
+    swebench's run_evaluation.main loads the full instance (repo/base_commit/
+    test_patch/version) from the official HuggingFace dataset by instance_id,
+    so the prediction only needs the model_patch (the AI's solution diff).
+
+    Constants mirror swebench.harness.run_evaluation:
+      KEY_INSTANCE_ID = "instance_id"
+      KEY_MODEL       = "model_name_or_path"
+      KEY_PREDICTION  = "model_patch"
+    """
+    return {
+        "instance_id": instance_id,
+        "model_name_or_path": "reyn",
+        "model_patch": model_patch,
+    }
+
+
+# ── Tier-1: swebench delegation (LAZY IMPORT — swebench is NOT a reyn core dep) ──
+#
+# swebench is a Tier1-only optional benchmark extra.  It is intentionally NOT
+# imported at module top so that:
+#   (a) reyn's runtime and all non-Tier1 code paths never import swebench, and
+#   (b) the import error on missing swebench is surfaced as an honest-skip,
+#       not a module-level ImportError that breaks every `reyn eval benchmark` run.
+#
+# Install separately when running Tier1 evals on a Docker host:
+#   pip install swebench
+#
+# DO NOT add swebench to reyn's core install_requires / pyproject.toml deps.
+
+
+def run_tier1_swebench_eval(
+    instance_id: str,
+    model_patch: str,
+    dataset_name: str = "princeton-nlp/SWE-bench_Verified",
+    split: str = "test",
+    run_id: str | None = None,
+    timeout: int = 1800,
+    working_dir: "Path | None" = None,
+) -> dict:
+    """Delegate authoritative scoring to swebench's official run_evaluation.main.
+
+    This is the Tier-1 faithful eval path.  It pulls the official pre-built
+    SWE-bench Docker image (namespace="swebench"), applies model_patch +
+    test_patch in the container, runs the test_cmd, and parses the result
+    via swebench's official logic.
+
+    Returns a dict with:
+      - "resolved":  bool — authoritative pass/fail verdict from swebench
+      - "run_id":    str  — the swebench run_id used
+      - "report_path": str — path to the per-instance report.json
+
+    Raises:
+      - ``RuntimeError("swebench_missing")`` if swebench is not installed
+        (caller should convert to honest-skip with _TIER1_SWEBENCH_MISSING_REASON).
+      - ``RuntimeError("eval_error:<msg>")`` on any other evaluation failure.
+
+    IMPORTANT: swebench writes its logs relative to cwd.
+    ``working_dir`` must be set to a temp directory so logs are isolated and
+    don't pollute the reyn project tree.
+
+    Architecture note:
+    - swebench.harness.run_evaluation.main is used (not run_instances directly)
+      because main handles the full flow: predictions file → dataset load →
+      run_instances → clean → make_run_report.
+    - The predictions are written to a temp JSON file as a JSON array (one dict
+      per line in swebench format) and passed via predictions_path.
+    - Per-instance report.json path:
+        logs/run_evaluation/<run_id>/reyn/<instance_id>/report.json
+      (relative to working_dir; LOG_REPORT="report.json";
+       model_name_or_path="reyn" with "/" → "__" replacement = "reyn")
+    """
+    # Lazy import — Tier1 ONLY.  swebench is NOT a reyn core dependency.
+    try:
+        from swebench.harness.run_evaluation import (  # type: ignore[import]
+            LOG_REPORT,
+            RUN_EVALUATION_LOG_DIR,
+        )
+        from swebench.harness.run_evaluation import (
+            main as swebench_run_evaluation_main,
+        )
+    except ImportError:
+        raise RuntimeError("swebench_missing")
+
+    import os
+    import uuid
+
+    effective_run_id = run_id or ("reyn_tier1_" + uuid.uuid4().hex[:8])
+    prediction = build_swebench_prediction(instance_id, model_patch)
+
+    with tempfile.TemporaryDirectory(prefix="reyn-tier1-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Write predictions to a JSON file (swebench expects a JSON array)
+        predictions_path = tmp_path / "predictions.json"
+        predictions_path.write_text(
+            json.dumps([prediction], ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        # swebench writes logs relative to cwd — we run from working_dir (or
+        # a temp subdir) so logs don't land in reyn's project tree.
+        run_cwd = working_dir if working_dir is not None else tmp_path
+        run_cwd = Path(run_cwd)
+
+        try:
+            orig_cwd = Path.cwd()
+            os.chdir(run_cwd)
+            try:
+                swebench_run_evaluation_main(
+                    dataset_name=dataset_name,
+                    split=split,
+                    instance_ids=[instance_id],
+                    predictions_path=str(predictions_path),
+                    run_id=effective_run_id,
+                    max_workers=1,
+                    force_rebuild=False,
+                    cache_level="env",
+                    clean=False,
+                    open_file_limit=4096,
+                    timeout=timeout,
+                    namespace="swebench",
+                    rewrite_reports=False,
+                    modal=False,
+                    instance_image_tag="latest",
+                    env_image_tag="latest",
+                    report_dir=str(run_cwd),
+                )
+            finally:
+                os.chdir(orig_cwd)
+        except Exception as exc:
+            raise RuntimeError(f"eval_error:{exc}") from exc
+
+        # Read the per-instance report.json.
+        # swebench writes it at:
+        #   <cwd>/logs/run_evaluation/<run_id>/reyn/<instance_id>/report.json
+        # model_name_or_path="reyn" → no "/" so no "__" substitution needed.
+        report_path = (
+            run_cwd
+            / RUN_EVALUATION_LOG_DIR
+            / effective_run_id
+            / "reyn"
+            / instance_id
+            / LOG_REPORT
+        )
+
+        if not report_path.exists():
+            raise RuntimeError(
+                f"eval_error:swebench report.json not found at {report_path}"
+            )
+
+        try:
+            report_data = json.loads(report_path.read_text(encoding="utf-8"))
+            resolved: bool = bool(report_data[instance_id]["resolved"])
+        except (KeyError, json.JSONDecodeError, TypeError) as exc:
+            raise RuntimeError(f"eval_error:failed to parse report.json: {exc}") from exc
+
+        return {
+            "resolved": resolved,
+            "run_id": effective_run_id,
+            "report_path": str(report_path),
+        }
 
 
 # ── public entry points (called from eval.py) ─────────────────────────────────
@@ -272,12 +478,26 @@ def compute_faithful_accounting(results: list[dict]) -> dict:
     ONLY (results where verify_skipped is not True).  A verify_skipped result
     is NEVER counted as pass or fail.
 
+    Binary-sharpening (C7 PR3): For Tier-1 evaluated results, the authoritative
+    C7 verdict is harness_resolved (the swebench official eval result), NOT the
+    skill's self-check (tests_passed).  The pass-source priority is:
+
+      1. harness_resolved  — present on Tier-1 (Docker) results; authoritative.
+      2. tests_passed      — present on Tier-2/3 results; informational only
+                             when harness_resolved is also present.
+
+    When a faithful result has harness_resolved, it is used exclusively.
+    When it only has tests_passed (no harness_resolved), tests_passed is used.
+    A faithful result with neither field contributes to faithful_verified_count
+    but not to faithful_passed (it neither increments nor decrements the count).
+
     Returns a dict with:
       - faithful_verified_count: int — number of results where verify_skipped is falsy
-      - faithful_passed: int | None — pass count over faithful subset (None if no
-        faithful result has a tests_passed field)
+      - faithful_passed: int | None — pass count over faithful subset using
+        harness_resolved (authoritative) if present, else tests_passed; None if
+        no faithful result has either field
       - faithful_pass_rate: float | None — pass_rate over faithful subset (None if
-        faithful_verified_count == 0 or no tests_passed field present)
+        faithful_verified_count == 0 or no verdict field present)
       - skip_count: int — number of results with verify_skipped == True
     """
     faithful = [r for r in results if not r.get("verify_skipped")]
@@ -286,10 +506,22 @@ def compute_faithful_accounting(results: list[dict]) -> dict:
     faithful_count = len(faithful)
     skip_count = len(skipped)
 
-    # tests_passed: only computed if ANY faithful result has the field
-    has_tests_passed = any("tests_passed" in r for r in faithful)
-    if has_tests_passed and faithful_count > 0:
-        passed = sum(1 for r in faithful if r.get("tests_passed") is True)
+    # Determine pass count using the binary-sharpened priority:
+    # harness_resolved (authoritative Tier-1 verdict) > tests_passed (self-check)
+    has_any_verdict = any(
+        "harness_resolved" in r or "tests_passed" in r for r in faithful
+    )
+    if has_any_verdict and faithful_count > 0:
+        passed = 0
+        for r in faithful:
+            if "harness_resolved" in r:
+                # Tier-1 path: use the harness verdict exclusively
+                if r["harness_resolved"] is True:
+                    passed += 1
+            elif "tests_passed" in r:
+                # Tier-2/3 path: use the skill self-check
+                if r["tests_passed"] is True:
+                    passed += 1
         pass_rate: float | None = passed / faithful_count
     else:
         passed = None
@@ -487,6 +719,9 @@ async def _run_single_task(
         result_data: dict = {}
         error_msg: str | None = None
         cost_usd: float | None = None
+        # For Tier-1: extract the model_patch while the workspace is still live.
+        # Stored here so it's accessible after the workspace context manager exits.
+        _tier1_model_patch: str | None = None
 
         try:
             with _benchmark_isolated_workspace(
@@ -514,6 +749,16 @@ async def _run_single_task(
                 )
                 run_result = await agent.run(skill, input_artifact)
 
+                # Tier-1: extract model_patch while workspace is still live.
+                # The workspace directory is deleted when the context manager exits,
+                # so git diff HEAD must be captured here.
+                if verify_tier == _TIER_DOCKER:
+                    try:
+                        _tier1_model_patch = extract_model_patch(workspace_path)
+                    except Exception:
+                        # Extraction failure is handled in the dispatch block below.
+                        _tier1_model_patch = None
+
             if run_result.ok:
                 result_data = run_result.data
             else:
@@ -538,24 +783,56 @@ async def _run_single_task(
         # Dispatch on verify_tier to determine whether this result is
         # faithfully verified or should be marked as skipped.
         #
-        # Tier 1 (docker): PR2 will implement Docker-based official-image eval.
-        #   Until then, stub — mark skipped with PR2/PR3 pending reason.
-        # Tier 2 (linux_host): PR3 will implement uv-based build eval.
-        #   Until then, stub — mark skipped with PR2/PR3 pending reason.
+        # Tier 1 (docker): Delegate authoritative scoring to swebench's
+        #   official run_evaluation.main.  Extracts model_patch (captured above
+        #   while the workspace was live) then calls swebench with the official
+        #   pre-built image.  On success, sets harness_resolved (bool) as the
+        #   authoritative C7 pass/fail.  On error (missing swebench, docker
+        #   failure, patch-extraction failure, etc.) → honest-skip with a clear
+        #   reason; NEVER fake PASS/FAIL.
+        # Tier 2 (linux_host): uv-based build eval (future PR).
+        #   Until then, stub — mark skipped with pending reason.
         # Tier 3 (no_faithful_env): ALWAYS skip — no faithful env available.
         #   On macOS/Windows, the AI's self-check (tests_passed from the skill)
         #   MUST NOT be promoted to an authoritative pass/fail.
-        #
-        # The structure here is the dispatch skeleton that PR2/PR3 will fill in.
-        # When a tier is fully implemented, replace the stub block with real eval.
         if verify_tier == _TIER_DOCKER:
-            # PR2: implement Docker-based official-image eval here.
-            # For now: stub — skip with pending reason.
-            record.update(_make_verify_skip_record(_TIER_DOCKER, _TIER1_STUB_REASON))
+            # Tier 1: Docker-based official SWE-bench image eval (C7 PR3).
+            # model_patch was captured inside the workspace context above.
+            task_data = task.get("data", task) if isinstance(task, dict) else {}
+            dataset_name = (
+                task_data.get("dataset_name", "princeton-nlp/SWE-bench_Verified")
+                if isinstance(task_data, dict)
+                else "princeton-nlp/SWE-bench_Verified"
+            )
+            tier1_skip_reason: str | None = None
+            if _tier1_model_patch is None:
+                tier1_skip_reason = "Tier1 eval error: failed to extract model_patch (git diff HEAD)"
+            else:
+                try:
+                    tier1_result = run_tier1_swebench_eval(
+                        instance_id=instance_id,
+                        model_patch=_tier1_model_patch,
+                        dataset_name=dataset_name,
+                    )
+                    record["verify_tier"] = _TIER_DOCKER
+                    record["verify_skipped"] = False
+                    record["harness_resolved"] = tier1_result["resolved"]
+                except RuntimeError as rte:
+                    msg = str(rte)
+                    if msg == "swebench_missing":
+                        tier1_skip_reason = _TIER1_SWEBENCH_MISSING_REASON
+                    else:
+                        # eval_error:<msg> or other runtime failure
+                        clean_msg = msg.removeprefix("eval_error:") if msg.startswith("eval_error:") else msg
+                        tier1_skip_reason = f"Tier1 eval error: {clean_msg}"
+                except Exception as exc:
+                    tier1_skip_reason = f"Tier1 eval error: {exc}"
+            if tier1_skip_reason is not None:
+                record.update(_make_verify_skip_record(_TIER_DOCKER, tier1_skip_reason))
         elif verify_tier == _TIER_LINUX_HOST:
-            # PR3: implement uv-based Linux build eval here.
-            # For now: stub — skip with pending reason.
-            record.update(_make_verify_skip_record(_TIER_LINUX_HOST, _TIER1_STUB_REASON))
+            # Tier 2 (linux_host) — uv-based build eval (future PR).
+            # Until then, stub — mark skipped with pending reason.
+            record.update(_make_verify_skip_record(_TIER_LINUX_HOST, _TIER2_STUB_REASON))
         else:
             # Tier 3 (no_faithful_env) — always skip.
             # The AI's self-check result (tests_passed from skill output) is

--- a/tests/test_eval_benchmark_tier1_swebench.py
+++ b/tests/test_eval_benchmark_tier1_swebench.py
@@ -1,0 +1,415 @@
+"""Tier 2: OS invariant — Tier-1 swebench delegation + binary-sharpening.
+
+Pins the C7 PR3 invariants (FP-0008 C7):
+
+1.  test_model_patch_extraction_real_repo    — real git repo + modify → git diff HEAD
+2.  test_model_patch_extraction_empty        — no changes → empty diff string
+3.  test_prediction_dict_shape               — build_swebench_prediction returns correct shape
+4.  test_accounting_harness_resolved_wins    — harness_resolved=T + tests_passed=F → counted as PASS
+5.  test_accounting_harness_resolved_false   — harness_resolved=F + tests_passed=T → counted as FAIL
+6.  test_accounting_tests_passed_fallback    — no harness_resolved → tests_passed used (Tier-2/3)
+7.  test_accounting_mixed_tier1_and_tier2    — mix of harness_resolved and tests_passed results
+8.  test_accounting_skipped_excluded_harness — skipped result with harness_resolved excluded
+9.  test_swebench_missing_honest_skip        — swebench ImportError → RuntimeError('swebench_missing')
+10. test_lazy_import_not_at_module_top       — swebench NOT in sys.modules after module import
+11. test_tier1_routing_structure             — docker_available=True → classify returns 'docker'
+12. test_make_verify_skip_record_tier1       — _make_verify_skip_record with _TIER_DOCKER
+
+No mocks (``unittest.mock`` / ``AsyncMock`` / ``MagicMock`` / ``patch``).
+Tests that require Docker or swebench-installed are NOT included here — those
+are e2e tests validated separately on a Docker host.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_tier1_pass(instance_id: str) -> dict:
+    """Tier-1 faithfully-verified passing result (harness_resolved=True)."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": "docker",
+        "verify_skipped": False,
+        "harness_resolved": True,
+        # skill self-check says False — must be overridden by harness_resolved
+        "tests_passed": False,
+    }
+
+
+def _make_tier1_fail(instance_id: str) -> dict:
+    """Tier-1 faithfully-verified failing result (harness_resolved=False)."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": "docker",
+        "verify_skipped": False,
+        "harness_resolved": False,
+        # skill self-check says True — must be overridden by harness_resolved
+        "tests_passed": True,
+    }
+
+
+def _make_tier2_pass(instance_id: str) -> dict:
+    """Tier-2/3 result with only tests_passed (no harness_resolved)."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": "linux_host",
+        "verify_skipped": False,
+        "tests_passed": True,
+    }
+
+
+def _make_tier2_fail(instance_id: str) -> dict:
+    """Tier-2/3 result with only tests_passed=False (no harness_resolved)."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": "linux_host",
+        "verify_skipped": False,
+        "tests_passed": False,
+    }
+
+
+def _make_skipped_with_harness(instance_id: str) -> dict:
+    """Verify-skipped result that also carries harness_resolved (must be excluded)."""
+    return {
+        "instance_id": instance_id,
+        "verify_tier": "docker",
+        "verify_skipped": True,
+        "verify_skip_reason": "Tier1 eval error: test",
+        "harness_resolved": True,  # must NOT count — skipped overrides
+    }
+
+
+# ── 1-2: extract_model_patch ──────────────────────────────────────────────────
+
+
+def test_model_patch_extraction_real_repo(tmp_path) -> None:
+    """Tier 2: extract_model_patch returns git diff HEAD from a real modified repo.
+
+    Uses a real git repository (not a mock) to verify the extraction.
+    The diff must contain the expected change and be non-empty.
+    """
+    from reyn.cli.commands.eval_benchmark import extract_model_patch
+
+    # Set up a real git repo
+    subprocess.run(
+        ["git", "init"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+
+    # Create and commit a base file
+    (tmp_path / "hello.py").write_text("def hello():\n    pass\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "base"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+
+    # Simulate AI's solution: modify the file
+    (tmp_path / "hello.py").write_text(
+        'def hello():\n    return "world"\n', encoding="utf-8"
+    )
+
+    patch = extract_model_patch(tmp_path)
+
+    assert isinstance(patch, str), "model_patch must be a string"
+    assert len(patch) > 0, "model_patch must be non-empty after modification"
+    # The diff must reference the changed file and the new content
+    assert "hello.py" in patch
+    assert 'return "world"' in patch or "+    return" in patch
+
+
+def test_model_patch_extraction_empty(tmp_path) -> None:
+    """Tier 2: extract_model_patch returns empty string when there are no changes.
+
+    git diff HEAD exits 0 with empty output when no files are modified.
+    """
+    from reyn.cli.commands.eval_benchmark import extract_model_patch
+
+    subprocess.run(
+        ["git", "init"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    (tmp_path / "unchanged.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "base"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+
+    patch = extract_model_patch(tmp_path)
+
+    assert patch == "", f"Expected empty diff when no changes, got: {patch!r}"
+
+
+# ── 3: build_swebench_prediction ─────────────────────────────────────────────
+
+
+def test_prediction_dict_shape() -> None:
+    """Tier 2: build_swebench_prediction returns the correct swebench prediction shape.
+
+    swebench uses KEY_INSTANCE_ID='instance_id', KEY_MODEL='model_name_or_path',
+    KEY_PREDICTION='model_patch'.  The prediction dict must match exactly.
+    """
+    from reyn.cli.commands.eval_benchmark import build_swebench_prediction
+
+    patch = "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n"
+    pred = build_swebench_prediction("django__django-12345", patch)
+
+    # Verify the exact keys swebench expects
+    assert pred["instance_id"] == "django__django-12345"
+    assert pred["model_name_or_path"] == "reyn"
+    assert pred["model_patch"] == patch
+
+    # No extra keys that would confuse swebench
+    assert set(pred.keys()) == {"instance_id", "model_name_or_path", "model_patch"}
+
+
+# ── 4-8: compute_faithful_accounting binary-sharpening ───────────────────────
+
+
+def test_accounting_harness_resolved_wins() -> None:
+    """Tier 2: harness_resolved=True + tests_passed=False → counted as PASS.
+
+    THE regression guard: C7 pass-rate must follow the authoritative harness
+    verdict (harness_resolved), NOT the skill self-check (tests_passed).
+    When both fields are present on a faithful result, harness_resolved wins.
+    """
+    from reyn.cli.commands.eval_benchmark import compute_faithful_accounting
+
+    results = [_make_tier1_pass("t1"), _make_tier1_fail("t2")]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_verified_count"] == 2
+    assert acct["faithful_passed"] == 1, (
+        "Expected 1 pass from harness_resolved (True+False), "
+        f"NOT from tests_passed (False+True); got {acct['faithful_passed']}"
+    )
+    assert abs(acct["faithful_pass_rate"] - 0.5) < 1e-9, (
+        f"Expected pass_rate=0.5 following harness_resolved, "
+        f"got {acct['faithful_pass_rate']}"
+    )
+
+
+def test_accounting_harness_resolved_false() -> None:
+    """Tier 2: harness_resolved=False + tests_passed=True → counted as FAIL.
+
+    Harness verdict trumps skill self-check even when the self-check claims pass.
+    """
+    from reyn.cli.commands.eval_benchmark import compute_faithful_accounting
+
+    results = [_make_tier1_fail("t1")]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_passed"] == 0, (
+        "harness_resolved=False must count as fail even when tests_passed=True; "
+        f"got faithful_passed={acct['faithful_passed']}"
+    )
+    assert acct["faithful_pass_rate"] == 0.0
+
+
+def test_accounting_tests_passed_fallback() -> None:
+    """Tier 2: when no harness_resolved present, tests_passed is used (Tier-2/3 path).
+
+    The fallback path (Tier-2/3 results without harness_resolved) still works
+    correctly using tests_passed.
+    """
+    from reyn.cli.commands.eval_benchmark import compute_faithful_accounting
+
+    results = [_make_tier2_pass("t1"), _make_tier2_fail("t2")]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_passed"] == 1
+    assert abs(acct["faithful_pass_rate"] - 0.5) < 1e-9
+
+
+def test_accounting_mixed_tier1_and_tier2() -> None:
+    """Tier 2: mix of Tier-1 (harness_resolved) and Tier-2/3 (tests_passed) results.
+
+    Each result uses its own verdict source.
+    Tier-1 result with harness_resolved=True contributes a pass.
+    Tier-2 result with tests_passed=True contributes a pass.
+    """
+    from reyn.cli.commands.eval_benchmark import compute_faithful_accounting
+
+    results = [
+        _make_tier1_pass("t1"),   # harness_resolved=True → PASS
+        _make_tier1_fail("t2"),   # harness_resolved=False → FAIL
+        _make_tier2_pass("t3"),   # tests_passed=True → PASS
+        _make_tier2_fail("t4"),   # tests_passed=False → FAIL
+    ]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_verified_count"] == 4
+    assert acct["faithful_passed"] == 2
+    assert abs(acct["faithful_pass_rate"] - 0.5) < 1e-9
+
+
+def test_accounting_skipped_excluded_harness() -> None:
+    """Tier 2: a verify_skipped result with harness_resolved is excluded from accounting.
+
+    The invariant: NEVER count a verify_skipped result as pass or fail,
+    even if it carries a harness_resolved field.
+    """
+    from reyn.cli.commands.eval_benchmark import compute_faithful_accounting
+
+    results = [_make_skipped_with_harness("s1")]
+    acct = compute_faithful_accounting(results)
+
+    assert acct["faithful_verified_count"] == 0
+    assert acct["faithful_passed"] is None
+    assert acct["faithful_pass_rate"] is None
+    assert acct["skip_count"] == 1
+
+
+# ── 9: swebench-missing → honest-skip ────────────────────────────────────────
+
+
+def test_swebench_missing_honest_skip() -> None:
+    """Tier 2: run_tier1_swebench_eval raises RuntimeError('swebench_missing')
+    when swebench is not installed.
+
+    The harness converts this to verify_skipped with _TIER1_SWEBENCH_MISSING_REASON.
+    NEVER emits fake PASS/FAIL — honest-skip is the only valid outcome when swebench
+    is unavailable.
+
+    This test uses a lightweight injectable: since swebench is not installed in
+    the CI environment, the real lazy import raises ImportError and the function
+    raises RuntimeError('swebench_missing') — no mocks needed.
+    """
+    from reyn.cli.commands.eval_benchmark import (
+        _TIER1_SWEBENCH_MISSING_REASON,
+        run_tier1_swebench_eval,
+    )
+
+    # Ensure swebench is not currently installed in THIS venv
+    # (it's a Tier1-only optional dep, not in reyn's core requirements)
+    if "swebench" in sys.modules:
+        pytest.skip(
+            "swebench is installed in this environment; "
+            "the swebench-missing path is only exercisable when it is absent"
+        )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        run_tier1_swebench_eval("test__test-1", "some diff")
+
+    assert str(exc_info.value) == "swebench_missing", (
+        f"Expected RuntimeError('swebench_missing'), got {exc_info.value!r}"
+    )
+
+    # Confirm the skip reason string is non-empty and contains key instructions
+    assert "pip install swebench" in _TIER1_SWEBENCH_MISSING_REASON
+    assert len(_TIER1_SWEBENCH_MISSING_REASON) > 0
+
+
+# ── 10: lazy-import gating ────────────────────────────────────────────────────
+
+
+def test_lazy_import_not_at_module_top() -> None:
+    """Tier 2: swebench is NOT imported at module top of eval_benchmark.
+
+    After importing eval_benchmark, 'swebench' must not appear in sys.modules.
+    This guarantees that reyn's runtime + all non-Tier1 code paths never pay
+    the swebench import cost or fail with ImportError if swebench is absent.
+
+    The test imports eval_benchmark fresh in a subprocess to guarantee a clean
+    sys.modules state independent of the test runner's import history.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "sys.path.insert(0, 'src'); "
+                "import reyn.cli.commands.eval_benchmark; "
+                "swebench_keys = [k for k in sys.modules if 'swebench' in k]; "
+                "print('swebench_in_modules:', bool(swebench_keys)); "
+                "print('keys:', swebench_keys)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Subprocess failed:\n{result.stderr}"
+    )
+    output = result.stdout
+    assert "swebench_in_modules: False" in output, (
+        f"swebench should NOT be imported at module top of eval_benchmark.\n"
+        f"subprocess output: {output!r}"
+    )
+
+
+# ── 11: Tier-1 routing structure ──────────────────────────────────────────────
+
+
+def test_tier1_routing_structure() -> None:
+    """Tier 2: classify_verification_tier with docker_available=True → 'docker'.
+
+    The 'docker' tier is the entry point for Tier-1 swebench delegation.
+    Routing invariant: when Docker is available, ALL platforms return 'docker'.
+    """
+    from reyn.cli.commands.eval_benchmark import (
+        _TIER_DOCKER,
+        classify_verification_tier,
+    )
+
+    for platform_sys in ("Darwin", "Linux", "Windows"):
+        result = classify_verification_tier(
+            docker_available=True, platform_system=platform_sys
+        )
+        assert result == _TIER_DOCKER, (
+            f"Expected 'docker' when docker_available=True on {platform_sys}, "
+            f"got {result!r}"
+        )
+
+
+# ── 12: _make_verify_skip_record with TIER_DOCKER ─────────────────────────────
+
+
+def test_make_verify_skip_record_tier1() -> None:
+    """Tier 2: _make_verify_skip_record with _TIER_DOCKER produces correct fields.
+
+    When Tier-1 eval fails (swebench missing or docker error), the result must
+    be marked as verify_skipped=True with verify_tier='docker' and a non-empty
+    reason.  This is the honest-skip invariant for Tier-1.
+    """
+    from reyn.cli.commands.eval_benchmark import (
+        _TIER1_SWEBENCH_MISSING_REASON,
+        _TIER_DOCKER,
+        _make_verify_skip_record,
+    )
+
+    record = _make_verify_skip_record(_TIER_DOCKER, _TIER1_SWEBENCH_MISSING_REASON)
+
+    assert record["verify_skipped"] is True
+    assert record["verify_tier"] == _TIER_DOCKER
+    assert record["verify_skip_reason"] == _TIER1_SWEBENCH_MISSING_REASON
+    assert len(record["verify_skip_reason"]) > 0
+    # Must NOT contain any verdict fields — no fake PASS/FAIL
+    assert "harness_resolved" not in record
+    assert "tests_passed" not in record


### PR DESCRIPTION
**[e2e-coder]** — FP-0008 C7 PR3: Tier-1 swebench delegation for Docker-based authoritative eval.

## Architecture

The benchmark is canonical SWE-bench: the **skill (agent) generates a solution patch (model_patch)**; the **harness (evaluator) scores it** via the OFFICIAL swebench eval. The skill's own verify phase is just an AI self-check — NOT the authoritative score.

PR3 implements Tier 1: when Docker is available, the harness delegates authoritative scoring to **swebench's official `run_evaluation.main`** — pulls the official pre-built image (`swebench/sweb.eval.x86_64.<encoded_iid>`), applies `model_patch + test_patch`, runs `test_cmd`, parses with the official logic → `resolved` (True/False). This bypasses the macOS C-extension build wall + gives max fidelity.

## What PR3 implements (`eval_benchmark.py` harness + tests ONLY — OS/skill untouched)

### Tier-1 routing
When `detect_verification_tier()` returns `"docker"`, routes to the new Tier-1 faithful eval. Tier 2 stub + Tier 3 honest-skip from PR1 unchanged.

### swebench = Tier1-ONLY, LAZY, OPTIONAL dependency
- `swebench` imported ONLY inside `run_tier1_swebench_eval`, with a local `import` — NOT at module top.
- If swebench is not installed when Tier1 is selected: `RuntimeError("swebench_missing")` → honest-skip with reason `"Tier1 requires swebench (pip install swebench) — not installed"`. NEVER emits fake PASS/FAIL.
- swebench is documented as Tier1-only extra in the module docstring. NOT added to reyn core deps.

### model_patch extraction → swebench prediction
- `extract_model_patch(workspace)`: runs `git diff HEAD` in the skill's workspace directory (the AI's cumulative solution diff). Captured INSIDE the `with _benchmark_isolated_workspace(...)` block — before the tempdir is deleted.
- `build_swebench_prediction(instance_id, model_patch)`: returns `{instance_id, model_name_or_path: "reyn", model_patch}`.

### swebench delegation — entry point used: `run_evaluation.main`
Used `run_evaluation.main` (not `run_instances` directly) because `main` handles the full flow: predictions file → dataset load → run_instances → clean → `make_run_report`. The predictions are written to a temp JSON file (array of one dict). `run_evaluation.main` was called with `namespace="swebench"`, `max_workers=1`, `force_rebuild=False`, `cache_level="env"`.

**Per-instance report.json location** (verified against installed swebench):
```
<cwd>/logs/run_evaluation/<run_id>/reyn/<instance_id>/report.json
```
Content: `{ "<instance_id>": { "resolved": bool, "patch_successfully_applied": bool, ... } }`

The `resolved` field is the authoritative verdict (uses `ResolvedStatus.FULL` check internally via `get_eval_report` → `get_resolution_status`).

### Binary-sharpening (lead-coder key checkpoint)
The C7 authoritative pass/fail = swebench `resolved` verdict (`harness_resolved`), NOT skill's `tests_passed` self-check.

`compute_faithful_accounting` updated with priority:
1. `harness_resolved` — present on Tier-1 results; **authoritative**
2. `tests_passed` — Tier-2/3 self-check; used only when `harness_resolved` absent

`tests_passed` stays present in the result record as informational, not driving the pass-rate.

### Honest-skip preserved
- No Docker / swebench-missing / eval-error → `verify_skipped=True` with clear reason
- `compute_faithful_accounting` still excludes skipped; shows "N/M faithful, K skipped"

## Verified swebench API

```
swebench.harness.run_evaluation.main(
    dataset_name, split, instance_ids, predictions_path,
    max_workers, force_rebuild, cache_level, clean, open_file_limit,
    run_id, timeout, namespace, rewrite_reports, modal,
    instance_image_tag="latest", env_image_tag="latest", report_dir="."
)
```

Per-instance report.json path (relative to cwd):
`logs/run_evaluation/<run_id>/reyn/<instance_id>/report.json`

Resolved parsed via: `json.loads(report_path.read_text())[instance_id]["resolved"]`

## P7 note
This PR touches **only** `src/reyn/cli/commands/eval_benchmark.py` (benchmark harness) and `tests/test_eval_benchmark_tier1_swebench.py` (new tests). The OS runtime, skill files, and all other modules are untouched.

## Test plan

- [x] `ruff check .` — clean (0 errors)
- [x] `python scripts/test_tier_audit.py --strict tests/test_eval_benchmark_tier1_swebench.py` — 12/12 OK, 0 errors
- [x] `pytest -q tests/ -k "tier1_swebench or eval_benchmark or capability_tier"` — 24/24 passed
- [x] `pytest -q tests/` (full suite) — 6472 passed, 1 known pre-existing failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`), 5 skipped, 3 xfailed
- [x] swebench NOT imported at module top — verified via subprocess sys.modules check (test #10)
- [x] swebench-missing → honest-skip — verified via `RuntimeError("swebench_missing")` path (test #9); swebench not in reyn's venv
- [x] binary-sharpening: `harness_resolved=True, tests_passed=False` → PASS; `harness_resolved=False, tests_passed=True` → FAIL (tests #4, #5)
- [x] OS/skill untouched — `git diff --stat HEAD^..HEAD` = eval_benchmark.py + test file only
- [x] (e2e Docker — validated separately on a Docker host, not in CI which has no Docker)

Refs #1097