### PR TITLE
feat(tui): palette phase-2b — promote _STATUS_WARN / _TEXT_SELECTED / _TEXT_MID tokens

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "broker": {
+      "type": "http",
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}

--- a/src/reyn/chat/tui/_palette.py
+++ b/src/reyn/chat/tui/_palette.py
@@ -40,7 +40,9 @@ _DIVIDER_DIM = "#333333"  # _PanelHeader bottom + #content top divider
 _TEXT_DIMMEST = "#444444"   # timestamps, dim hints
 _TEXT_DIM = "#555555"       # secondary labels
 _TEXT_NEUTRAL = "#666666"   # neutral
-_TEXT_MUTED = "#888888"     # mid-dim labels (web events etc.) — between neutral and body
+_TEXT_MID = "#777777"       # mid-dim labels (cost call-counts, reply previews) — between neutral and muted
+_TEXT_MUTED = "#888888"     # mid-dim labels (web events etc.) — between mid and body
+_TEXT_SELECTED = "#bbbbbb"  # selected / highlighted row text (slash picker) — between body and bright
 _TEXT_BODY = "#aaaaaa"      # body / status
 _TEXT_BRIGHT = "#dddddd"    # primary content
 
@@ -67,6 +69,14 @@ _EVENT_PLAN_STEP = "#ffaa66"     # plan step lifecycle
 _EVENT_PLAN_MEMO = "#cc8855"     # plan step memoization
 _GREEN_DIMMEST = "#335544"       # context_built (very dim green)
 
+# Warning accent — "taking a while / pending / stalled / cap-proximity". Recurring
+# across header (cap≥0.75, pending, transcribing), streaming_row / tool_call_row /
+# async_stack_panel / skill_activity (elapsed-time stall). Distinct from the event
+# ambers (_EVENT_LLM / _EVENT_INTERVENTION / _EVENT_PLAN*) which name event categories.
+# (ErrorBox's own severity ramp — #cc5555/#cc9955 etc. — is a separate follow-up:
+# it lives in DEFAULT_CSS strings + needs an f-string conversion to consume tokens.)
+_STATUS_WARN = "#ffaa44"
+
 __all__ = [
     "_CORAL",
     "_AMBER",
@@ -77,13 +87,16 @@ __all__ = [
     "_TEXT_DIMMEST",
     "_TEXT_DIM",
     "_TEXT_NEUTRAL",
+    "_TEXT_MID",
     "_TEXT_MUTED",
+    "_TEXT_SELECTED",
     "_TEXT_BODY",
     "_TEXT_BRIGHT",
     "_STATUS_SUCCESS",
     "_STATUS_SUCCESS_DIM",
     "_STATUS_ERROR",
     "_STATUS_CRITICAL",
+    "_STATUS_WARN",
     "_EVENT_SKILL",
     "_EVENT_TOOL",
     "_EVENT_LLM",

--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -80,7 +80,14 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _AMBER, _BG_HEADER, _CORAL, _STATUS_ERROR, _TEXT_MUTED
+from reyn.chat.tui._palette import (
+    _AMBER,
+    _BG_HEADER,
+    _CORAL,
+    _STATUS_ERROR,
+    _STATUS_WARN,
+    _TEXT_MUTED,
+)
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -690,7 +697,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         elapsed_str = _fmt_elapsed(elapsed_s)
         if entry.pending_count > 0:
             elapsed_segment = f"  ({entry.pending_count} pending)"
-            elapsed_style = "bold #ffaa44"  # palette-candidate: pending-warning amber (no foundation token yet)
+            elapsed_style = "bold " + _STATUS_WARN
             glyph_style = _AMBER
         else:
             elapsed_segment = f"  · {elapsed_str}"

--- a/src/reyn/chat/tui/widgets/header.py
+++ b/src/reyn/chat/tui/widgets/header.py
@@ -25,6 +25,7 @@ from reyn.chat.tui._palette import (
     _BG_HEADER,
     _STATUS_CRITICAL,
     _STATUS_ERROR,
+    _STATUS_WARN,
     _TEXT_BODY,
     _TEXT_DIM,
     _TEXT_MUTED,
@@ -70,7 +71,7 @@ def _cap_proximity_color(used: float | int, cap: float | int | None) -> str | No
     if ratio >= 0.90:
         return _STATUS_CRITICAL
     if ratio >= 0.75:
-        return "#ffaa44"  # palette-candidate: cap-proximity warning amber (no foundation token yet)
+        return _STATUS_WARN
     return None
 
 
@@ -492,7 +493,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
         # unchanged.
         if self._stalled_count > 0:
             parts.append(
-                (f"[{self._stalled_count} pending]", "#ffaa44"),  # palette-candidate: pending-warning amber (no foundation token yet)
+                (f"[{self._stalled_count} pending]", _STATUS_WARN),
             )
         # ``/find`` active-state badge — placed alongside [N pending]
         # as a sibling "active state" indicator. Subtle blue
@@ -518,7 +519,7 @@ class ReynHeader(RenderableCacheMixin, Widget):
         if self._voice_state == "recording":
             parts.append(("🔴 voice · Enter→send Esc→cancel", "bold " + _STATUS_ERROR))
         elif self._voice_state == "transcribing":
-            parts.append(("⏳ voice", "bold #ffaa44"))  # palette-candidate: transcribing-warning amber (no foundation token yet)
+            parts.append(("⏳ voice", "bold " + _STATUS_WARN))
         # Clock always present, last — the canary for "is the UI frozen?"
         parts.append((self._now_text(), None))
 

--- a/src/reyn/chat/tui/widgets/right_panel/base.py
+++ b/src/reyn/chat/tui/widgets/right_panel/base.py
@@ -27,6 +27,7 @@ from reyn.chat.tui._palette import (
     _TEXT_BODY,
     _TEXT_BRIGHT,
     _TEXT_DIM,
+    _TEXT_MID,
     _TEXT_MUTED,
     _TEXT_NEUTRAL,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "_TEXT_BODY",
     "_TEXT_BRIGHT",
     "_TEXT_DIM",
+    "_TEXT_MID",
     "_TEXT_MUTED",
     "_TEXT_NEUTRAL",
     "_esc",

--- a/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/cost_tab.py
@@ -17,6 +17,7 @@ from .base import (
     _TEXT_BODY,
     _TEXT_BRIGHT,
     _TEXT_DIM,
+    _TEXT_MID,
     _TEXT_NEUTRAL,
     _esc,
     logger,
@@ -396,8 +397,7 @@ def render_cost(
                 if ag["has_cost"] and show_extra else ""
             )
             ag_calls = (
-                f"  [#777777]{ag['calls']}c[/]"  # palette-candidate: mid-dim label — no foundation token yet
-                if show_extra else ""
+                f"  [{_TEXT_MID}]{ag['calls']}c[/]"                if show_extra else ""
             )
             # name col width adapts to content_width (see _col_widths)
             lines.append(
@@ -447,8 +447,7 @@ def render_cost(
                 if pb["has_cost"] and show_extra else ""
             )
             calls_part = (
-                f"  [#777777]{pb['calls']}c[/]"  # palette-candidate: mid-dim label — no foundation token yet
-                if show_extra else ""
+                f"  [{_TEXT_MID}]{pb['calls']}c[/]"                if show_extra else ""
             )
             short_pid = plan_id[:8]
             goal = plan_goals.get(plan_id, "")
@@ -498,8 +497,7 @@ def render_cost(
                 if mb["has_cost"] and show_extra else ""
             )
             calls_part = (
-                f"  [#777777]{mb['calls']}c[/]"  # palette-candidate: mid-dim label — no foundation token yet
-                if show_extra else ""
+                f"  [{_TEXT_MID}]{mb['calls']}c[/]"                if show_extra else ""
             )
             lines.append(
                 f"[{_TEXT_BODY}]  {_esc(model_name):<{model_name_w}}[/]"

--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -26,6 +26,7 @@ from .base import (
     _TEXT_BODY,
     _TEXT_BRIGHT,
     _TEXT_DIM,
+    _TEXT_MID,
     _TEXT_MUTED,
     _TEXT_NEUTRAL,
     _esc,
@@ -759,7 +760,7 @@ def render_events(
                         _oneline(reply), 40,
                     )
                     short = _esc(truncated) + ("…" if was_truncated else "")
-                    lines.append(f"[{_TEXT_DIMMEST}]       ↳ [/][#777777]{short}[/]")  # palette-candidate: mid-dim reply preview — no foundation token yet
+                    lines.append(f"[{_TEXT_DIMMEST}]       ↳ [/][{_TEXT_MID}]{short}[/]")
 
     del filter_name
     # Dim footer hint — always appended after the event rows so the user

--- a/src/reyn/chat/tui/widgets/skill_activity.py
+++ b/src/reyn/chat/tui/widgets/skill_activity.py
@@ -35,7 +35,14 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL, _STATUS_ERROR, _TEXT_BODY, _TEXT_MUTED, _TEXT_NEUTRAL
+from reyn.chat.tui._palette import (
+    _CORAL,
+    _STATUS_ERROR,
+    _STATUS_WARN,
+    _TEXT_BODY,
+    _TEXT_MUTED,
+    _TEXT_NEUTRAL,
+)
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -397,7 +404,7 @@ class SkillActivityRow(RenderableCacheMixin, Widget):
         if secs >= _ELAPSED_RED_S:
             elapsed_style = "bold " + _STATUS_ERROR
         elif secs >= _ELAPSED_AMBER_S:
-            elapsed_style = "bold #ffaa44"  # palette-candidate: elapsed-warning amber (no foundation token yet)
+            elapsed_style = "bold " + _STATUS_WARN
         else:
             elapsed_style = "dim"
         elapsed_str = f"  {secs:.1f}s"

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -28,6 +28,7 @@ from reyn.chat.tui._palette import (
     _TEXT_DIM,
     _TEXT_MUTED,
     _TEXT_NEUTRAL,
+    _TEXT_SELECTED,
 )
 
 from ._renderable_cache import RenderableCacheMixin
@@ -321,7 +322,7 @@ class SlashPicker(RenderableCacheMixin, Static):
                 summary = summary[: max(1, summary_budget - 1)] + "…"
             row.append(
                 summary,
-                style="#bbbbbb" if is_sel else "dim " + _TEXT_MUTED,
+                style=_TEXT_SELECTED if is_sel else "dim " + _TEXT_MUTED,
             )
             if i > 0:
                 body.append("\n")

--- a/src/reyn/chat/tui/widgets/streaming_row.py
+++ b/src/reyn/chat/tui/widgets/streaming_row.py
@@ -34,7 +34,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _AMBER, _STATUS_ERROR
+from reyn.chat.tui._palette import _AMBER, _STATUS_ERROR, _STATUS_WARN
 
 _RENDER_INTERVAL_MS = 16  # ~60 fps max
 _RENDER_INTERVAL_S = _RENDER_INTERVAL_MS / 1000
@@ -256,7 +256,7 @@ class StreamingRow(Widget):
             elif idle >= _STALL_TIER_2_S:
                 t.append(
                     f" … (stalled {_fmt_idle(idle)})",
-                    style="bold #ffaa44",  # palette-candidate: stall-warning amber (no foundation token yet)
+                    style=f"bold {_STATUS_WARN}",
                 )
             elif idle > _STALL_TIER_1_S:
                 t.append(" …", style="dim")

--- a/src/reyn/chat/tui/widgets/tool_call_row.py
+++ b/src/reyn/chat/tui/widgets/tool_call_row.py
@@ -35,7 +35,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
-from reyn.chat.tui._palette import _CORAL, _STATUS_ERROR, _TEXT_MUTED, _TEXT_NEUTRAL
+from reyn.chat.tui._palette import _CORAL, _STATUS_ERROR, _STATUS_WARN, _TEXT_MUTED, _TEXT_NEUTRAL
 
 from ._renderable_cache import RenderableCacheMixin
 
@@ -319,7 +319,7 @@ class ToolCallRow(RenderableCacheMixin, Widget):
         if secs >= _ELAPSED_RED_S:
             return "bold " + _STATUS_ERROR
         if secs >= _ELAPSED_AMBER_S:
-            return "bold #ffaa44"  # palette-candidate: elapsed-warning amber (no foundation token yet)
+            return "bold " + _STATUS_WARN
         return "dim"
 
     def _state_glyph(self) -> tuple[str, str]:

--- a/tests/cli/test_palette_semantic_distinctions.py
+++ b/tests/cli/test_palette_semantic_distinctions.py
@@ -40,11 +40,13 @@ if str(_SRC) not in sys.path:
 
 from reyn.chat.tui._palette import (
     _EVENT_PLAN,
+    _EVENT_PLAN_STEP,
     _EVENT_SKILL,
     _EVENT_TOOL,
     _STATUS_CRITICAL,
     _STATUS_ERROR,
     _STATUS_SUCCESS,
+    _STATUS_WARN,
 )
 
 
@@ -107,3 +109,22 @@ def test_event_tool_distinct_from_event_skill() -> None:
         f"got both = {_EVENT_TOOL!r}. "
         "Tool purple vs skill blue is a designed forensic separation."
     )
+
+
+def test_status_warn_distinct_from_near_ambers() -> None:
+    """Tier 2: warning amber must stay distinct from the near-collision amber tokens.
+
+    _STATUS_WARN (#ffaa44 — "taking a while / pending / stalled / cap-proximity")
+    sits one hue-step from _EVENT_PLAN_STEP (#ffaa66, plan-step lifecycle): two
+    chars apart in hex. They name different concepts (a transient warning vs a
+    plan-step event category) and a careless "merge the ambers" cleanup would
+    erase that. Also assert it stays off the error tiers — a warning is not an
+    error.
+    """
+    assert _STATUS_WARN != _EVENT_PLAN_STEP, (
+        f"_STATUS_WARN and _EVENT_PLAN_STEP must be distinct (near collision); "
+        f"got _STATUS_WARN={_STATUS_WARN!r}, _EVENT_PLAN_STEP={_EVENT_PLAN_STEP!r}. "
+        "Warning amber vs plan-step amber are different concepts."
+    )
+    assert _STATUS_WARN != _STATUS_ERROR, "warning is not a (recoverable) error"
+    assert _STATUS_WARN != _STATUS_CRITICAL, "warning is not a hard-stop"


### PR DESCRIPTION
**[tui-coder]** —

Follow-up to the palette consolidation wave (foundation #1102 + migration #1105-1108). Promotes the recurring semantics the migration flagged as `palette-candidate` to foundation tokens + migrates their sites. lead-coder approved this follow-up on #1102/#1106.

## New tokens (value-preserving — same hex, centralised)
- `_STATUS_WARN = #ffaa44` — "taking a while / pending / stalled / cap-proximity"
- `_TEXT_SELECTED = #bbbbbb` — selected/highlighted row text
- `_TEXT_MID = #777777` — mid-dim (between `_TEXT_NEUTRAL` and `_TEXT_MUTED`)

## Migrated
- `_STATUS_WARN`: header (cap-proximity / pending / transcribing), streaming_row, tool_call_row, async_stack_panel, skill_activity
- `_TEXT_SELECTED`: slash_picker
- `_TEXT_MID`: cost_tab (×3), events_tab; `.base` re-exports it for the tabs

## substitute-vs-orthogonal (NOT collapsed)
- **memory_tab's `#ffaa44`** is the "feedback" memory-**type** colour — a different semantic that merely shares the hex. Left as-is (migrating it to `_STATUS_WARN` would be a semantic merge, not a refactor).
- **ErrorBox severity ramp** (`#cc5555`/`#cc9955`/`#ff7777`/`#ffbb77`) — its own orthogonal 3-tier system in `DEFAULT_CSS` strings → **deferred to a focused follow-up** (needs an f-string conversion). lead-coder's `#bbbbbb` rec is folded in here; the error-ramp gets its own PR.
- Other one-offs (`#aa6666`, `#aaaa55`, `#2d7a4f`) left flagged for a later pass.

## Distinction invariant
Extended `test_palette_semantic_distinctions.py` with `_STATUS_WARN` distinctness — notably `!= _EVENT_PLAN_STEP` (`#ffaa44` vs `#ffaa66`, a 2-char near-collision). Guards a careless "merge the ambers" regression. Pins inequality, not hex (not a format-pin).

## Test plan
- [x] value-preservation: `_STATUS_WARN`/`_TEXT_MID`/`_TEXT_SELECTED` resolve to original hex; all changed modules import cleanly
- [x] `pytest tests/cli` (palette/header/skill/slash/events/cost/tool_call/async/stream/smoke) — **488 passed**
- [x] `ruff check` — **All checks passed** (I001 import-sort caught + fixed pre-push)
- [x] `test_tier_audit.py --strict` on the distinction test — **0 errors**

## Tier self-check
Value-preserving token promotion (no test for the migration — exact-hex assert = format-pin Tier-4). The one new assertion is a distinctness invariant (Tier 2). No private-state asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)