### PR TITLE
feat(fp-0008): C7 #2 PR-A — DockerSandboxBackend + sandbox_backend injection seam

### DIFF
--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from reyn.events.events import EventLog
     from reyn.llm.model_resolver import ModelResolver
     from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+    from reyn.sandbox import SandboxBackend
     from reyn.schemas.models import Skill
     from reyn.secrets.store import ScopedSecretStore
     from reyn.user_intervention import RequestBus
@@ -99,6 +100,15 @@ class OpContext:
     # When None, sandboxed_exec falls back to platform auto-detection
     # (= same as no-config-loaded behavior).
     sandbox_config: "SandboxConfig | None" = None
+
+    # FP-0008 C7 #2: runtime backend-instance override for sandboxed_exec.
+    # When set, the sandboxed_exec handler uses this backend INSTANCE verbatim
+    # instead of resolving one by name from sandbox_config. This is the seam for
+    # *stateful* backends bound to a runtime resource (e.g. DockerSandboxBackend
+    # bound to a specific container + host workspace) that a name-based factory
+    # cannot construct. Generic: any caller owning such a resource may inject
+    # one; None preserves the default name-based platform auto-selection.
+    sandbox_backend: "SandboxBackend | None" = None
 
     # Issue #364: declarative cap on binary media size (= images from
     # web__fetch / file__read / MCP / user input). When None, the gate

--- a/src/reyn/op_runtime/sandboxed_exec.py
+++ b/src/reyn/op_runtime/sandboxed_exec.py
@@ -23,7 +23,11 @@ async def handle(
     ctx: OpContext,
     caller: Literal["preprocessor", "control_ir"],
 ) -> dict:
-    backend = get_default_backend(ctx.sandbox_config)
+    # A runtime backend instance injected on the OpContext takes precedence over
+    # name-based platform auto-selection (FP-0008 C7 #2). This lets a caller
+    # route exec into a stateful backend (e.g. a Docker container) that the
+    # name-based factory cannot build, without the handler knowing the caller.
+    backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)
     policy = SandboxPolicy(
         network=op.network,
         read_paths=list(op.read_paths),

--- a/src/reyn/sandbox/backends/docker.py
+++ b/src/reyn/sandbox/backends/docker.py
@@ -1,0 +1,205 @@
+"""DockerSandboxBackend — execute argv inside a prepared Docker container.
+
+A :class:`~reyn.sandbox.backend.SandboxBackend` that runs commands inside an
+already-created Docker container, syncing a host git workspace into the
+container's repo directory before each run. On every ``run()`` the container's
+``repo_dir`` is **clean-reset** to ``base_ref`` and the host workspace's current
+diff (vs ``base_ref``) is applied, so the command observes the host's cumulative
+changes layered on top of the container's prepared environment — preserving any
+built dependencies (compiled C extensions, installed packages) that live in the
+image but not in the host clone.
+
+Construction is caller-driven: whoever owns the container + host workspace (e.g.
+an evaluation harness) builds the instance and injects it via
+``OpContext.sandbox_backend``. This module is **axis-agnostic / P7-clean** — it
+contains no skill names, phase names, or benchmark-specific strings. It is a
+generic exec backend bound to a ``(container, repo_dir, base_ref, workspace)``
+tuple, and doubles as a real isolation backend for ``sandboxed_exec``.
+
+The actual subprocess execution is delegated to an injectable ``runner`` so the
+``run()`` orchestration (host-diff → clean-reset → apply → exec) is testable
+without a live Docker daemon. The default runner uses ``asyncio`` subprocesses.
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import subprocess
+from typing import Awaitable, Callable
+
+from reyn.sandbox.backend import SandboxResult
+from reyn.sandbox.policy import SandboxPolicy
+
+# A runner executes one argv (optionally feeding *stdin* bytes, optionally
+# bounded by *timeout* seconds) and returns a SandboxResult. Injected so run()
+# is unit-testable without Docker; the default is _subprocess_runner.
+Runner = Callable[..., Awaitable[SandboxResult]]
+
+
+async def _subprocess_runner(
+    argv: list[str],
+    *,
+    stdin: bytes | None = None,
+    timeout: int | None = None,
+) -> SandboxResult:
+    """Real runner: spawn argv as an asyncio subprocess and capture output."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out, err = await asyncio.wait_for(
+            proc.communicate(input=stdin), timeout=timeout
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return SandboxResult(
+            returncode=-1,
+            stdout=b"",
+            stderr=f"Command timed out after {timeout}s".encode(),
+        )
+    return SandboxResult(
+        returncode=proc.returncode if proc.returncode is not None else -1,
+        stdout=out or b"",
+        stderr=err or b"",
+    )
+
+
+class DockerSandboxBackend:
+    """Run argv inside a Docker container with a host git workspace synced in.
+
+    Args:
+        container:           Container name or id to ``docker exec`` into.
+        repo_dir:            Path of the git repo *inside* the container
+                             (e.g. ``/testbed``). reset/apply/exec target it.
+        base_ref:            Commit the container repo is reset to before each
+                             run (diff-accumulation guard).
+        host_workspace_dir:  Host path of the git clone whose diff (vs
+                             ``base_ref``) is applied into the container.
+        docker_bin/git_bin:  Binary names (overridable for tests / non-PATH).
+        runner:              Injected executor (defaults to ``_subprocess_runner``).
+    """
+
+    name: str = "docker"
+
+    def __init__(
+        self,
+        *,
+        container: str,
+        repo_dir: str,
+        base_ref: str,
+        host_workspace_dir: str,
+        docker_bin: str = "docker",
+        git_bin: str = "git",
+        runner: Runner | None = None,
+    ) -> None:
+        self.container = container
+        self.repo_dir = repo_dir
+        self.base_ref = base_ref
+        self.host_workspace_dir = host_workspace_dir
+        self.docker_bin = docker_bin
+        self.git_bin = git_bin
+        self._runner: Runner = runner or _subprocess_runner
+
+    # ── command construction ─────────────────────────────────────────────────
+
+    def _host_diff_argv(self) -> list[str]:
+        # Cumulative host diff (tracked changes) vs the base commit, on the host.
+        return [self.git_bin, "-C", self.host_workspace_dir, "diff", self.base_ref]
+
+    def _reset_argv(self) -> list[str]:
+        return [
+            self.docker_bin, "exec", self.container,
+            self.git_bin, "-C", self.repo_dir, "reset", "--hard", self.base_ref,
+        ]
+
+    def _clean_argv(self) -> list[str]:
+        return [
+            self.docker_bin, "exec", self.container,
+            self.git_bin, "-C", self.repo_dir, "clean", "-fd",
+        ]
+
+    def _apply_argv(self) -> list[str]:
+        # The diff is fed to `git apply` via stdin (`docker exec -i`).
+        return [
+            self.docker_bin, "exec", "-i", self.container,
+            self.git_bin, "-C", self.repo_dir, "apply",
+        ]
+
+    def _exec_argv(self, argv: list[str]) -> list[str]:
+        # Run the caller's command with cwd = repo_dir inside the container.
+        return [self.docker_bin, "exec", "-w", self.repo_dir, self.container, *argv]
+
+    # ── availability ─────────────────────────────────────────────────────────
+
+    def available(self) -> bool:
+        """True when the docker binary exists and the daemon is reachable."""
+        if shutil.which(self.docker_bin) is None:
+            return False
+        try:
+            completed = subprocess.run(
+                [self.docker_bin, "info"],
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return completed.returncode == 0
+
+    # ── execution ────────────────────────────────────────────────────────────
+
+    async def run(
+        self,
+        argv: list[str],
+        policy: SandboxPolicy,
+        *,
+        stdin: bytes | None = None,
+    ) -> SandboxResult:
+        """Clean-reset the container repo, apply the host diff, then exec argv.
+
+        Steps (each via the injected runner):
+          1. capture the host diff (vs base_ref);
+          2. ``git reset --hard base_ref`` + ``git clean -fd`` in the container
+             (prevents cross-call diff accumulation);
+          3. ``git apply`` the host diff (skipped when the diff is empty);
+          4. exec argv with cwd=repo_dir under ``policy.timeout_seconds``.
+
+        Any setup-step failure short-circuits with that step's returncode so the
+        caller sees the real cause rather than a misleading test result.
+        """
+        diff_res = await self._runner(self._host_diff_argv())
+        if diff_res.returncode != 0:
+            return SandboxResult(
+                returncode=diff_res.returncode or 1,
+                stdout=b"",
+                stderr=b"host diff failed: " + diff_res.stderr,
+            )
+        diff = diff_res.stdout
+
+        for step_argv in (self._reset_argv(), self._clean_argv()):
+            res = await self._runner(step_argv)
+            if res.returncode != 0:
+                return SandboxResult(
+                    returncode=res.returncode or 1,
+                    stdout=b"",
+                    stderr=b"container clean-reset failed: " + res.stderr,
+                )
+
+        if diff.strip():
+            apply_res = await self._runner(self._apply_argv(), stdin=diff)
+            if apply_res.returncode != 0:
+                return SandboxResult(
+                    returncode=apply_res.returncode or 1,
+                    stdout=b"",
+                    stderr=b"git apply failed: " + apply_res.stderr,
+                )
+
+        return await self._runner(
+            self._exec_argv(list(argv)),
+            stdin=stdin,
+            timeout=policy.timeout_seconds,
+        )

--- a/tests/test_op_sandboxed_exec.py
+++ b/tests/test_op_sandboxed_exec.py
@@ -205,6 +205,53 @@ async def test_dispatch_timeout_status():
     assert result["status"] == "timeout"
 
 
+# ─── 4b. Injected backend override (FP-0008 C7 #2) ───────────────────────────
+
+
+class _StubBackend:
+    """Real (non-mock) SandboxBackend stub for the injection-seam test."""
+
+    name = "stub-injected"
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None) -> SandboxResult:
+        return SandboxResult(returncode=0, stdout=b"from-stub", stderr=b"")
+
+
+@pytest.mark.asyncio
+async def test_injected_sandbox_backend_takes_precedence():
+    """Tier 2: OpContext.sandbox_backend instance overrides name-based selection."""
+    ctx, _events = _make_ctx()
+    ctx.sandbox_backend = _StubBackend()
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec",
+        argv=["/bin/echo", "x"],
+        env_passthrough=["PATH"],
+        timeout_seconds=10,
+    )
+    result = await execute_op(op, ctx, caller="control_ir")
+    # The injected instance ran — not the platform default (e.g. seatbelt here).
+    assert result["backend"] == "stub-injected"
+    assert result["stdout"] == "from-stub"
+
+
+@pytest.mark.asyncio
+async def test_no_injected_backend_falls_back_to_default():
+    """Tier 2: with no injected backend, sandboxed_exec uses the platform default."""
+    ctx, _events = _make_ctx()
+    assert ctx.sandbox_backend is None
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec",
+        argv=["/bin/echo", "x"],
+        env_passthrough=["PATH"],
+        timeout_seconds=10,
+    )
+    result = await execute_op(op, ctx, caller="control_ir")
+    assert result["backend"] in {"noop", "seatbelt", "landlock"}
+
+
 # ─── 5. Noop one-shot warning ────────────────────────────────────────────────
 
 

--- a/tests/test_sandbox_docker.py
+++ b/tests/test_sandbox_docker.py
@@ -1,0 +1,197 @@
+"""Tier 2: DockerSandboxBackend orchestration + availability invariants (FP-0008 C7 #2).
+
+DockerSandboxBackend runs argv inside a Docker container, clean-resetting the
+container repo to ``base_ref`` and applying the host workspace diff before each
+run. The live ``docker exec`` path requires a Docker daemon (validated by the
+PR-B e2e faithful run, not here); these tests pin the docker-independent
+contract via the public ``run()`` surface with an injected recording runner:
+
+- Protocol conformance + name.
+- ``available()`` reports False when the docker binary is absent.
+- ``run()`` issues host-diff → clean-reset → apply → exec in order, with the
+  base_ref / repo_dir / container / timeout / stdin threaded correctly.
+- ``run()`` skips ``git apply`` when the host diff is empty.
+- ``run()`` short-circuits (surfacing the real returncode) when host-diff,
+  clean-reset, or apply fails.
+
+No mocks of collaborators — the runner double is a real recording callable
+(like NoopBackend, not a MagicMock).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.sandbox import SandboxBackend, SandboxPolicy, SandboxResult
+from reyn.sandbox.backends.docker import DockerSandboxBackend
+
+
+class _RecordingRunner:
+    """Real (non-mock) runner double: records calls, returns queued results.
+
+    Defaults to a success result when the queue is exhausted so a test only
+    needs to enqueue the results it cares about.
+    """
+
+    def __init__(self, results: list[SandboxResult] | None = None) -> None:
+        self.calls: list[dict] = []
+        self._results: list[SandboxResult] = list(results) if results else []
+
+    async def __call__(
+        self,
+        argv: list[str],
+        *,
+        stdin: bytes | None = None,
+        timeout: int | None = None,
+    ) -> SandboxResult:
+        self.calls.append({"argv": list(argv), "stdin": stdin, "timeout": timeout})
+        if self._results:
+            return self._results.pop(0)
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+
+def _backend(runner: _RecordingRunner) -> DockerSandboxBackend:
+    return DockerSandboxBackend(
+        container="cont",
+        repo_dir="/testbed",
+        base_ref="BASECOMMIT",
+        host_workspace_dir="/host/ws",
+        runner=runner,
+    )
+
+
+# ── Protocol + availability ──────────────────────────────────────────────────
+
+
+def test_protocol_conformance_and_name():
+    """Tier 2: DockerSandboxBackend conforms to SandboxBackend with name 'docker'."""
+    backend = _backend(_RecordingRunner())
+    assert isinstance(backend, SandboxBackend)
+    assert backend.name == "docker"
+
+
+def test_available_false_when_docker_binary_missing():
+    """Tier 2: available() is False when the docker binary is not on PATH."""
+    backend = DockerSandboxBackend(
+        container="c",
+        repo_dir="/testbed",
+        base_ref="b",
+        host_workspace_dir="/ws",
+        docker_bin="reyn-nonexistent-docker-xyz",
+    )
+    assert backend.available() is False
+
+
+# ── run() orchestration ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_orchestrates_diff_reset_apply_exec_in_order():
+    """Tier 2: run() issues host-diff → reset → clean → apply → exec with correct args."""
+    runner = _RecordingRunner(
+        results=[
+            SandboxResult(0, b"DIFFBYTES", b""),  # host diff (non-empty)
+            SandboxResult(0, b"", b""),  # reset
+            SandboxResult(0, b"", b""),  # clean
+            SandboxResult(0, b"", b""),  # apply
+            SandboxResult(0, b"PYTEST-OUT", b""),  # exec
+        ]
+    )
+    backend = _backend(runner)
+
+    result = await backend.run(["pytest", "-x"], SandboxPolicy(timeout_seconds=42))
+
+    assert result.returncode == 0
+    assert result.stdout == b"PYTEST-OUT"
+
+    argvs = [c["argv"] for c in runner.calls]
+
+    # 1. host diff vs base, on the host clone
+    assert argvs[0] == ["git", "-C", "/host/ws", "diff", "BASECOMMIT"]
+    # 2. clean-reset to base in the container
+    assert argvs[1][:2] == ["docker", "exec"]
+    assert {"reset", "--hard", "BASECOMMIT"} <= set(argvs[1])
+    assert "/testbed" in argvs[1]
+    # 3. clean -fd
+    assert {"clean", "-fd"} <= set(argvs[2])
+    # 4. apply receives the diff via stdin
+    assert "apply" in argvs[3]
+    assert runner.calls[3]["stdin"] == b"DIFFBYTES"
+    # 5. exec the caller argv (cwd=repo_dir) is the FINAL step, under the timeout
+    assert argvs[-1] == ["docker", "exec", "-w", "/testbed", "cont", "pytest", "-x"]
+    assert runner.calls[-1]["timeout"] == 42
+
+
+@pytest.mark.asyncio
+async def test_run_skips_apply_when_diff_empty():
+    """Tier 2: run() skips `git apply` when the host diff is empty (clean base)."""
+    runner = _RecordingRunner(
+        results=[
+            SandboxResult(0, b"", b""),  # host diff EMPTY
+            SandboxResult(0, b"", b""),  # reset
+            SandboxResult(0, b"", b""),  # clean
+            SandboxResult(0, b"OUT", b""),  # exec
+        ]
+    )
+    backend = _backend(runner)
+
+    result = await backend.run(["pytest"], SandboxPolicy())
+
+    assert result.stdout == b"OUT"
+    argvs = [c["argv"] for c in runner.calls]
+    # apply step is absent (empty diff) and exec still runs as the final step
+    assert not any("apply" in a for a in argvs)
+    assert argvs[-1] == ["docker", "exec", "-w", "/testbed", "cont", "pytest"]
+
+
+@pytest.mark.asyncio
+async def test_run_short_circuits_on_host_diff_failure():
+    """Tier 2: run() surfaces host-diff failure and stops before touching the container."""
+    runner = _RecordingRunner(results=[SandboxResult(128, b"", b"not a git repo")])
+    backend = _backend(runner)
+
+    result = await backend.run(["pytest"], SandboxPolicy())
+
+    assert result.returncode == 128
+    assert b"host diff failed" in result.stderr
+    # stopped before touching the container (no docker exec issued)
+    assert not any(c["argv"][:2] == ["docker", "exec"] for c in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_run_short_circuits_on_reset_failure():
+    """Tier 2: run() surfaces clean-reset failure and does not exec the command."""
+    runner = _RecordingRunner(
+        results=[
+            SandboxResult(0, b"DIFF", b""),  # host diff
+            SandboxResult(1, b"", b"reset boom"),  # reset fails
+        ]
+    )
+    backend = _backend(runner)
+
+    result = await backend.run(["pytest"], SandboxPolicy())
+
+    assert result.returncode == 1
+    assert b"container clean-reset failed" in result.stderr
+    # the caller command never ran (short-circuited at clean-reset)
+    assert not any("pytest" in c["argv"] for c in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_run_short_circuits_on_apply_failure():
+    """Tier 2: run() surfaces `git apply` failure and does not exec the command."""
+    runner = _RecordingRunner(
+        results=[
+            SandboxResult(0, b"DIFF", b""),  # host diff
+            SandboxResult(0, b"", b""),  # reset
+            SandboxResult(0, b"", b""),  # clean
+            SandboxResult(1, b"", b"patch does not apply"),  # apply fails
+        ]
+    )
+    backend = _backend(runner)
+
+    result = await backend.run(["pytest"], SandboxPolicy())
+
+    assert result.returncode == 1
+    assert b"git apply failed" in result.stderr
+    # the caller command never ran (short-circuited at git apply)
+    assert not any("pytest" in c["argv"] for c in runner.calls)


### PR DESCRIPTION
**[e2e-coder]** — C7 #2 PR-A: generic OS mechanism for routing `sandboxed_exec` into a stateful (e.g. Docker) backend.

## Context
C7 #2 = **skill-verify-faithful**: run the `swe_bench` skill's verify pytest inside the official image container so its self-check is accurate (un-handicapped patch → true clean PASS-rate, resolving the confounded host-handicapped lower-bound). Design articulated + approved by lead-coder. 2-PR split:
- **PR-A (this)** = generic OS mechanism: `DockerSandboxBackend` + `OpContext.sandbox_backend` injection seam. Standalone-reviewable, P7-clean, security dual-value.
- **PR-B (next)** = benchmark wiring: `verify.md` `shell→sandboxed_exec` migration + default-backend regression guard + harness container lifecycle + 5 Class A e2e faithful run.

## Changes
- `reyn/sandbox/backends/docker.py` — `DockerSandboxBackend` (FP-0017 `SandboxBackend` Protocol). `run()` = clean-reset container repo to `base_ref` (`git reset --hard && git clean -fd`) → `git apply` host diff → exec argv at `repo_dir` under policy timeout. Clean-reset prevents cross-call diff accumulation; image-built deps preserved. Subprocess execution is an injectable `runner` → orchestration unit-testable without a Docker daemon.
- `op_runtime/context.py` — `OpContext.sandbox_backend` instance-override (TYPE_CHECKING import, default `None`).
- `op_runtime/sandboxed_exec.py` — `backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)`.

## Design notes (review focus)
- **(a) Generic injection** — instance-override is benchmark-independent; any caller owning a stateful resource can inject. Chosen over a `SandboxConfig` name-field because docker-per-container is *stateful* (bound to a container), unlike stateless-by-name seatbelt/landlock. Runtime handle stays out of the declarative policy.
- **(b) P7-clean** — zero skill/phase/benchmark strings in the backend; it's a `(container, repo_dir, base_ref, workspace)`-bound exec backend that doubles as a real isolation backend for `sandboxed_exec`.
- **YAGNI** — docker NOT added to `get_default_backend` name-table (instance-injection only); security named-use deferred to real need.

## Test plan
- [x] `pytest tests/test_sandbox_docker.py tests/test_op_sandboxed_exec.py -q` → **22 passed**
- [x] `ruff check` (changed files) → clean
- [x] broader sandbox/op sweep (factory / seatbelt / config-uniform / control-ir-executor) → 39 passed, 1 skipped
- [x] import smoke: `OpContext.sandbox_backend` field present; `DockerSandboxBackend.name == "docker"`
- [x] Tier compliance: all new tests carry a `Tier 2:` docstring; real instances (recording runner / stub backend), no MagicMock; public-surface only (`run()` orchestration, not private `_*_argv`)
- [x] (skipped — deferred to PR-B; docker-requiring) live `docker exec` faithful path → validated by the 5 Class A e2e run in PR-B (honestly separated, per PR3 precedent)

> NOTE: local full-rootdir `pytest --co` shows ~60468 **pre-existing** collection errors in unrelated modules (tui/web/cli/mcp_search referencing absent symbols). Stash-verified **identical on the pristine base** (6137 vs 6144 collected = exactly this PR's +7 new tests, **zero new errors**) — not introduced by this diff. CI (clean env) is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)