### PR TITLE
feat(fp-0008): #1115 Stage 0 — artifact OS-managed access + deterministic entry-input inject

### DIFF
--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -172,12 +172,28 @@ class PreprocessorExecutor:
 
     async def run(
         self, phase: "Phase", artifact: dict, output_language: str | None,
+        skill_input: dict | None = None,
     ) -> tuple[dict, TokenUsage]:
-        """Apply all preprocessor steps; return (enriched_artifact, accumulated_token_usage)."""
+        """Apply all preprocessor steps; return (enriched_artifact, accumulated_token_usage).
+
+        FP-0008 #1115 Stage 0: when ``skill_input`` (the skill's entry-phase
+        input artifact, held by the OS at ``run_state.skill_input``) is supplied,
+        it is injected at the reserved OS key ``_skill_input`` for the duration
+        of the preprocessor chain, then stripped before the enriched artifact is
+        returned. This gives deterministic preprocessor steps an OS-served,
+        P5-correct view of the entry input (= never LLM-mutated) without a
+        workspace ``file.read`` of a base_dir-coupled artifact path. The key is
+        generic — every skill has an entry input — so it is P7-clean, analogous
+        to the ``_iter`` binding injected by ``_apply_iterate``. Stripping on
+        return keeps it out of the LLM-facing frame and the stored
+        ``*_preprocessed`` artifact (no bloat for skills that don't consume it).
+        """
         if not phase.preprocessor:
             return artifact, TokenUsage()
 
         result = copy.deepcopy(artifact)
+        if skill_input is not None:
+            result["_skill_input"] = copy.deepcopy(skill_input)
         total_usage = TokenUsage()
 
         for i, step in enumerate(phase.preprocessor):
@@ -210,6 +226,10 @@ class PreprocessorExecutor:
                 phase=phase.name, step_index=i, step_type=step.type,
             )
 
+        # FP-0008 #1115 Stage 0: strip the OS-injected entry-input binding so it
+        # never leaks into the LLM-facing frame or the stored artifact. Steps
+        # that needed it have already derived their values into `data.*`.
+        result.pop("_skill_input", None)
         return result, total_usage
 
     # ── Step dispatch ─────────────────────────────────────────────────────────

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -498,7 +498,10 @@ class RunOrchestrator:
             if artifact_path:
                 try:
                     import json as _json
-                    p = Path(artifact_path)
+                    # FP-0008 #1115 Stage 0: last_phase_artifact_path is a
+                    # state_dir-relative handle; resolve it via the OS so resume
+                    # works regardless of base_dir/state_dir coupling.
+                    p = self._workspace.resolve_artifact_handle(artifact_path)
                     if p.is_file():
                         artifact = _json.loads(p.read_text(encoding="utf-8"))
                 except Exception as e:  # noqa: BLE001 — defensive
@@ -536,7 +539,9 @@ class RunOrchestrator:
             if artifact_path_post:
                 try:
                     import json as _json
-                    p = Path(artifact_path_post)
+                    # FP-0008 #1115 Stage 0: resolve the state_dir-relative
+                    # handle via the OS (see the in-flight resume branch above).
+                    p = self._workspace.resolve_artifact_handle(artifact_path_post)
                     if p.is_file():
                         finish_artifact_post = _json.loads(
                             p.read_text(encoding="utf-8")
@@ -608,7 +613,8 @@ class RunOrchestrator:
                 phase_def = self._skill.phases[current_phase]
                 if phase_def.preprocessor:
                     enriched_artifact, pre_usage = await self._preprocessor.run(
-                        phase_def, artifact, output_language
+                        phase_def, artifact, output_language,
+                        skill_input=self._state.skill_input,
                     )
                     self._state.add_usage(pre_usage, None)
                     # Update artifact_path to the enriched file so maybe_ref_artifact

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -427,6 +427,19 @@ class OSRuntime:
             / "control_ir_offload"
             / (self.run_id or "_default")
         )
+        # FP-0008 #1115 Stage 0: store_artifact returns a state_dir-relative
+        # handle (decoupled from base_dir). The LLM-facing artifact_ref produced
+        # by maybe_ref_artifact needs a path the file op can resolve, so the OS
+        # resolves the handle to an absolute path here — consistent with the C5
+        # control_ir offload refs, which are also absolute and pass the workspace
+        # read check (under base_dir in the co-located default). Stage 2
+        # (container backend) swaps this resolution for a container-served read
+        # without touching skills.
+        resolved_artifact_path = (
+            str(self.workspace.resolve_artifact_handle(artifact_path))
+            if artifact_path is not None
+            else None
+        )
         return build_frame(
             phase_name=current_phase,
             phase=phase_def,
@@ -443,7 +456,7 @@ class OSRuntime:
             model_resolved=self._resolver.resolve(effective_model).model,
             events=self.events,
             control_ir_results=control_ir_results,
-            artifact_path=artifact_path,
+            artifact_path=resolved_artifact_path,
             remaining_act_turns=remaining_act_turns,
             offload_dir=offload_dir,
         )

--- a/src/reyn/stdlib/skills/swe_bench/parse_test_targets.py
+++ b/src/reyn/stdlib/skills/swe_bench/parse_test_targets.py
@@ -31,10 +31,13 @@ command string.
 ## Input shape
 
 Called with the full runtime artifact dict. Source priority mirrors
-``sanitize_test_patch.py`` (P5 workspace passthrough):
+``sanitize_test_patch.py`` (P5 deterministic entry-input passthrough):
 
+0. ``_skill_input.data.test_patch`` — the OS-injected original entry artifact
+   (#1115 Stage 0), placed at the top-level ``_skill_input`` binding before the
+   preprocessor runs.  Deterministic, never LLM-mutated.
 1. ``data._input_raw.content`` — JSON of the original ``swe_bench_input``
-   artifact, injected by the preceding ``run_op: file.read`` step.
+   artifact from a ``run_op: file.read`` step (retained for back-compat).
 2. ``data.test_patch`` — set by the sanitize_test_patch step that precedes
    this one in the preprocessor chain.
 3. Top-level ``test_patch`` — flat unit-test direct-call shape.
@@ -55,7 +58,8 @@ def _extract_test_patch(data: Mapping[str, Any]) -> str:
     """Extract the test_patch string from the artifact, following priority chain.
 
     Priority:
-    1. data._input_raw.content (workspace JSON via file.read run_op)
+    0. _skill_input.data.test_patch (OS-injected entry artifact, #1115 Stage 0)
+    1. data._input_raw.content (workspace JSON via file.read run_op — back-compat)
     2. data.test_patch (inner data dict — set by sanitize_test_patch)
     3. top-level test_patch (flat unit-test shape)
 
@@ -64,9 +68,18 @@ def _extract_test_patch(data: Mapping[str, Any]) -> str:
     inner: Any = data.get("data") or {}
     test_patch: Any = None
 
-    # Priority 1: workspace passthrough
-    if isinstance(inner, dict):
-        input_raw = inner.get("_input_raw")
+    # Priority 0 (#1115 Stage 0): OS-injected entry input. The skill's original
+    # entry artifact is placed at the top-level `_skill_input` binding before
+    # the preprocessor runs — deterministic P5 source, never LLM-mutated.
+    skill_input = data.get("_skill_input")
+    if isinstance(skill_input, dict):
+        si_data = skill_input.get("data")
+        if isinstance(si_data, dict):
+            test_patch = si_data.get("test_patch")
+
+    # Priority 1 (back-compat): workspace passthrough — file.read run_op result.
+    if not isinstance(test_patch, str) or not test_patch:
+        input_raw = inner.get("_input_raw") if isinstance(inner, dict) else None
         if isinstance(input_raw, dict):
             content = input_raw.get("content")
             if isinstance(content, str) and content.strip():

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -14,17 +14,11 @@ preprocessor:
   # this guard ensures the report diff is clean even if verify's revert ran
   # against a different working-tree state or was skipped.
   #
-  # Step 1: read the original swe_bench_input artifact from the workspace to
-  # obtain test_patch (same path as verify.md Step 1).
-  - type: run_op
-    op:
-      kind: file
-      op: read
-      path: ".reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json"
-    into: data._input_raw
-    on_error: empty
-  # Step 2: parse test_patch → list of git checkout command strings.
-  # The function returns [] gracefully on absent/empty test_patch.
+  # #1115 Stage 0: parse_test_targets obtains test_patch from the OS-injected
+  # `_skill_input` (the original swe_bench_input entry artifact), same as
+  # verify.md. The prior `.reyn/artifacts/...` file.read step was removed —
+  # that base_dir-coupled magic path breaks once the repo FS routes through a
+  # backend; the OS-held entry input is the deterministic P5 source.
   - type: python
     module: ./parse_test_targets.py
     function: parse_test_targets

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -8,32 +8,22 @@ allowed_ops: [file, shell]
 max_retries: 3
 max_act_turns: 30
 preprocessor:
-  # FP-0008 PR-N15 Step 1: deterministic workspace passthrough — read the
-  # original swe_bench_input artifact from the workspace (stored at skill
-  # start by the OS as the `_input` artifact). This is the P5-correct
-  # source of truth for test_patch — it never passes through the apply
-  # LLM, so it can never be dropped or nulled by a weak model.
+  # FP-0008 PR-N15 / #1115 Stage 0: deterministic entry-input passthrough.
+  # The OS injects the skill's original entry artifact (the `swe_bench_input`)
+  # at the reserved `_skill_input` binding before this preprocessor runs. This
+  # is the P5-correct source of truth for test_patch — it is the OS-held entry
+  # input and never passes through the apply LLM, so it can never be dropped or
+  # nulled by a weak model. No workspace file.read is needed (the prior
+  # `.reyn/artifacts/...` magic-path read was removed in #1115 Stage 0 — that
+  # path coupled the read to base_dir, which breaks once the repo FS routes
+  # through a backend). sanitize_test_patch / parse_test_targets read
+  # `_skill_input.data.test_patch` directly, falling back to `data.test_patch`
+  # for unit tests that inject the verify input directly.
   #
-  # The file path `.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`
-  # is deterministic: the OS always stores the entry-phase artifact at
-  # `{state_dir}/artifacts/{skill_name}/{_input}/v01_{artifact_type}.json`.
-  #
-  # on_error: empty — if the workspace file is absent (e.g. in unit tests
-  # that inject verify input directly), the python step falls back to
-  # reading data.test_patch from the artifact directly (see Step 2).
-  - type: run_op
-    op:
-      kind: file
-      op: read
-      path: ".reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json"
-    into: data._input_raw
-    on_error: empty
-  # FP-0008 PR-N15 Step 2 / PR-O v8: sanitize_test_patch reads test_patch
-  # from data._input_raw.content (workspace JSON) and falls back to
-  # data.test_patch (direct injection for tests). Normalizes line endings
-  # (CRLF → LF), strips BOM, ensures trailing newline. Runs BEFORE the
-  # LLM enters this phase. The sanitized string is written into
-  # `data.test_patch` so `git apply` operates on a clean diff.
+  # FP-0008 PR-O v8: sanitize_test_patch normalizes line endings (CRLF → LF),
+  # strips BOM, ensures a trailing newline. Runs BEFORE the LLM enters this
+  # phase. The sanitized string is written into `data.test_patch` so
+  # `git apply` operates on a clean diff.
   - type: python
     module: ./sanitize_test_patch.py
     function: sanitize_test_patch

--- a/src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py
+++ b/src/reyn/stdlib/skills/swe_bench/sanitize_test_patch.py
@@ -3,29 +3,27 @@
 FP-0008 PR-N15 (= workspace passthrough) + PR-O v8 (= line-ending / BOM /
 trailing-newline normalization).
 
-## Workspace-passthrough design (PR-N15)
+## Deterministic entry-input passthrough (PR-N15 + #1115 Stage 0)
 
-The verify phase preprocessor runs this function AFTER a ``run_op: file.read``
-step that reads the original ``swe_bench_input`` artifact from the workspace:
+The OS injects the skill's original entry artifact (the ``swe_bench_input``)
+at the reserved top-level ``_skill_input`` binding before the verify
+preprocessor runs.  This function reads ``test_patch`` from
+``_skill_input.data.test_patch`` and sanitizes it.  The apply-phase LLM no
+longer echoes ``test_patch`` — the OS-held entry input is the deterministic
+source (P5: Workspace is the single source of truth) and is never LLM-mutated.
 
-    ``.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json``
-
-The read result lands at ``data._input_raw`` (inside the full artifact dict)
-as::
-
-    {"status": "ok", "content": "<JSON string>", ...}
-
-This function reads ``test_patch`` from that JSON string, parses it, and
-sanitizes it.  The apply-phase LLM no longer echoes ``test_patch`` — the
-workspace file is the deterministic source (P5: Workspace is the single
-source of truth).
+#1115 Stage 0 removed the prior ``run_op: file.read`` of
+``.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`` — that magic path
+coupled the read to ``base_dir``, which breaks once the repo filesystem routes
+through a backend.  The ``_skill_input`` binding is base_dir-independent.
 
 ## Fallback
 
-When ``data._input_raw`` is absent or its ``content`` is not valid JSON (e.g.
-in unit tests that inject the verify phase input directly), the function
-falls back to reading ``test_patch`` from the artifact in two structural
-shapes:
+When ``_skill_input`` is absent, the function falls back to the legacy
+``data._input_raw`` shape (a ``run_op: file.read`` result —
+``{"status": "ok", "content": "<JSON string>", ...}`` — retained for unit
+tests that inject it), then to reading ``test_patch`` from the artifact in two
+structural shapes:
 
 - **Full artifact** (runtime shape):
   ``{"type": "...", "data": {"test_patch": "..."}}``
@@ -58,11 +56,14 @@ from typing import Any, Mapping
 def sanitize_test_patch(data: Mapping[str, Any]) -> str:
     """Return a normalized ``test_patch`` string.
 
-    Source priority (P5 workspace passthrough):
+    Source priority (P5 deterministic entry-input passthrough):
+      0. ``_skill_input.data.test_patch`` — the OS-injected original entry
+         artifact (#1115 Stage 0), placed at the top-level ``_skill_input``
+         binding before the preprocessor runs.  Deterministic, never
+         LLM-mutated; replaces the prior base_dir-coupled file.read.
       1. ``data._input_raw.content`` (via artifact's data dict) — JSON of the
-         original swe_bench_input artifact, injected by the preceding
-         ``run_op: file.read`` step.  Parsed to extract ``test_patch`` from
-         the artifact's ``data`` field.
+         original swe_bench_input artifact, from a ``run_op: file.read`` step.
+         Retained for back-compat with unit tests injecting ``_input_raw``.
       2. ``data.test_patch`` from the artifact's ``data`` dict (full runtime
          artifact shape: ``{"type": "...", "data": {"test_patch": "..."}}``)
       3. Top-level ``test_patch`` on the passed-in dict (flat unit-test shape:
@@ -82,11 +83,26 @@ def sanitize_test_patch(data: Mapping[str, Any]) -> str:
     # Extract the inner data dict from the full artifact (runtime shape).
     inner_data: Any = data.get("data") or {}
 
-    # Priority 1: workspace passthrough — run_op file.read result
-    # The preceding run_op step reads the workspace _input artifact and places
-    # its result at data._input_raw. The result shape is:
+    # Priority 0 (#1115 Stage 0): OS-injected entry input. The OS places the
+    # skill's original entry artifact at the top-level `_skill_input` binding
+    # (sibling of `data`) before the preprocessor runs. Shape:
+    # {"type": "swe_bench_input", "data": {"test_patch": "..."}}. This is the
+    # deterministic P5 source — never LLM-mutated — replacing the prior
+    # `.reyn/artifacts/...` file.read (which coupled the read to base_dir).
+    skill_input = data.get("_skill_input")
+    if isinstance(skill_input, dict):
+        si_data = skill_input.get("data")
+        if isinstance(si_data, dict):
+            raw = si_data.get("test_patch")
+
+    # Priority 1 (back-compat): workspace passthrough — run_op file.read result.
+    # Retained so unit tests that inject `data._input_raw` directly still work.
+    # The result shape is:
     # {"status": "ok", "content": "<JSON of swe_bench_input artifact>", ...}
-    input_raw = inner_data.get("_input_raw") if isinstance(inner_data, dict) else None
+    if not isinstance(raw, str) or not raw:
+        input_raw = inner_data.get("_input_raw") if isinstance(inner_data, dict) else None
+    else:
+        input_raw = None
     if isinstance(input_raw, dict):
         content = input_raw.get("content")
         if isinstance(content, str) and content.strip():

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -30,15 +30,40 @@ class Workspace:
         permission_resolver: "PermissionResolver | None" = None,
         skill_name: str = "",
         base_dir: "Path | None" = None,
+        state_dir: "Path | None" = None,
     ) -> None:
         self.base_dir = base_dir.resolve() if base_dir is not None else Path.cwd()
-        self.state_dir = (self.base_dir / ".reyn").resolve()
+        # FP-0008 #1115 Stage 0: state_dir is host-side and decoupled from
+        # base_dir. Default = base_dir/.reyn (backward-compat). A caller that
+        # routes the repo FS through a backend (e.g. a container base_dir)
+        # passes an explicit host-side state_dir, so artifacts + events survive
+        # independently of the repo working tree (container-death recoverable).
+        self.state_dir = (
+            state_dir.resolve()
+            if state_dir is not None
+            else (self.base_dir / ".reyn").resolve()
+        )
         self._events = events
         self.artifacts: list[dict] = []
         self.state_dir.mkdir(parents=True, exist_ok=True)
         (self.state_dir / "artifacts").mkdir(exist_ok=True)
         self._perm = permission_resolver
         self._skill_name = skill_name
+
+    def resolve_artifact_handle(self, handle: str) -> Path:
+        """Resolve a state_dir-relative artifact handle to an absolute path.
+
+        FP-0008 #1115 Stage 0: artifact handles returned by ``store_artifact``
+        are relative to ``state_dir`` (host-side), not ``base_dir``. The OS uses
+        this to serve artifact reads (read-by-ref) without exposing a base_dir
+        FS path. Raises :class:`PermissionError` if the handle escapes state_dir.
+        """
+        resolved = (self.state_dir / handle).resolve()
+        if not resolved.is_relative_to(self.state_dir):
+            raise PermissionError(
+                f"artifact handle {handle!r} escapes state_dir {self.state_dir}"
+            )
+        return resolved
 
     def _resolve_read(self, path_str: str) -> Path:
         p = Path(path_str).expanduser()
@@ -240,9 +265,13 @@ class Workspace:
             json.dumps(artifact, ensure_ascii=False, indent=2), encoding="utf-8"
         )
 
-        # Return path relative to base_dir so the LLM can read it via file ops
-        base_rel = str(abs_path.relative_to(self.base_dir))
-        self.artifacts.append({"phase": phase, "artifact": artifact, "path": base_rel})
+        # FP-0008 #1115 Stage 0: store the state_dir-relative handle (NOT a
+        # base_dir-relative FS path). state_dir is host-side and may be
+        # decoupled from base_dir, so `relative_to(base_dir)` would be invalid.
+        # The OS resolves this handle against state_dir when serving reads
+        # (see resolve_artifact_handle); consumers no longer file.read it.
+        handle = rel  # already state_dir-relative: "artifacts/.../v01_*.json"
+        self.artifacts.append({"phase": phase, "artifact": artifact, "path": handle})
         inner = artifact.get("data", artifact)
         keys = list(inner.keys()) if isinstance(inner, dict) else []
         self._events.emit(
@@ -250,6 +279,6 @@ class Workspace:
             phase=phase,
             artifact_type=artifact_type,
             keys=keys,
-            path=base_rel,
+            path=handle,
         )
-        return base_rel
+        return handle

--- a/tests/test_skill_postprocessor_chain.py
+++ b/tests/test_skill_postprocessor_chain.py
@@ -505,7 +505,11 @@ def test_postprocessor_mid_run_crash_resume_delivers_to_upstream(
     }
     art_path = art_dir / "v01_post_draft.json"
     art_path.write_text(json.dumps(finish_artifact), encoding="utf-8")
-    rel_art_path = str(art_path.relative_to(tmp_path))
+    # #1115 Stage 0: last_phase_artifact_path is a state_dir-relative handle
+    # (state_dir defaults to base_dir/.reyn), resolved via
+    # Workspace.resolve_artifact_handle on resume — matching store_artifact's
+    # new return format.
+    rel_art_path = str(art_path.relative_to(tmp_path / ".reyn"))
 
     run_id = "run_post_chain_003"
 

--- a/tests/test_skill_postprocessor_resume.py
+++ b/tests/test_skill_postprocessor_resume.py
@@ -288,8 +288,12 @@ def test_resume_skips_phase_loop_when_post_phase(tmp_path, monkeypatch):
     art_path.write_text(json.dumps(finish_artifact), encoding="utf-8")
 
     # Build a ResumePlan with current_phase="__post__" pointing to this file.
-    # Path must be relative to cwd (= tmp_path) to match store_artifact's format.
-    rel_path = str(art_path.relative_to(tmp_path))
+    # #1115 Stage 0: last_phase_artifact_path is now a state_dir-relative handle
+    # (resolved via Workspace.resolve_artifact_handle on resume), where
+    # state_dir defaults to base_dir/.reyn. So the handle is relative to
+    # tmp_path/.reyn (= "artifacts/post_skill/__post__/v01_result.json"),
+    # matching store_artifact's new return format.
+    rel_path = str(art_path.relative_to(tmp_path / ".reyn"))
     plan = ResumePlan(
         run_id="run_post_001",
         skill_name="post_skill",

--- a/tests/test_swe_bench_c6_v2_revert_via_shell.py
+++ b/tests/test_swe_bench_c6_v2_revert_via_shell.py
@@ -452,12 +452,34 @@ def test_report_md_has_parse_step_and_iterate_step() -> None:
     )
 
 
-def test_report_md_reads_workspace_input() -> None:
-    """Tier 2: report.md preprocessor reads the workspace swe_bench _input artifact."""
+def test_report_md_uses_os_injected_skill_input_not_basedir_path() -> None:
+    """Tier 2: report.md derives test_patch from the OS-injected _skill_input.
+
+    #1115 Stage 0 removed report.md's ``run_op: file.read`` of the base_dir-
+    coupled ``.reyn/artifacts/swe_bench/_input/...`` path. parse_test_targets
+    now reads ``_skill_input.data.test_patch`` (Priority 0) — verified
+    behaviorally here so the claim matches the test content.
+    """
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
     report_md = (_SKILL_ROOT / "phases" / "report.md").read_text(encoding="utf-8")
-    assert "swe_bench/_input/v01_swe_bench_input.json" in report_md, (
-        "report.md must read the workspace _input artifact to get test_patch"
+    assert "swe_bench/_input/v01_swe_bench_input.json" not in report_md, (
+        "report.md must NOT reference the base_dir-coupled _input magic path "
+        "after #1115 Stage 0"
     )
+    patch = (
+        "diff --git a/tests/test_x.py b/tests/test_x.py\n"
+        "--- a/tests/test_x.py\n+++ b/tests/test_x.py\n@@\n-old\n+new\n"
+    )
+    artifact = {
+        "type": "verify_state",
+        "data": {"instance_id": "i"},
+        "_skill_input": {
+            "type": "swe_bench_input",
+            "data": {"instance_id": "i", "test_patch": patch},
+        },
+    }
+    assert parse_test_targets(artifact) == ["git checkout HEAD -- tests/test_x.py"]
 
 
 def test_apply_md_has_source_only_rule() -> None:

--- a/tests/test_swe_bench_pr_n15_workspace_passthrough.py
+++ b/tests/test_swe_bench_pr_n15_workspace_passthrough.py
@@ -5,37 +5,44 @@ verbatim from the plan input into the `apply_state` output artifact.  Weak
 models (gemini-flash-lite) dropped or nulled the field, causing schema
 validation failure at the verify-phase entry.
 
-Fix shape (PR-N15):
+Fix shape (PR-N15, as evolved by #1115 Stage 0):
   - `test_patch` removed from `apply_state` schema (no more LLM echo).
   - `apply.md` "Carry test_patch" instruction removed.
-  - `verify.md` preprocessor gains a `run_op: file.read` step that reads
-    the workspace-stored ``_input`` artifact (= the original swe_bench_input)
-    before the python sanitizer step.
-  - `sanitize_test_patch.py` updated to read from the workspace-injected
-    ``data._input_raw.content`` (Priority 1), falling back to
-    ``data.test_patch`` in the artifact's data dict (Priority 2) or top-level
-    flat dict (Priority 3, unit-test compat).
+  - The OS injects the skill's original entry artifact at the reserved
+    top-level ``_skill_input`` binding before each preprocessor runs.
+    ``verify.md`` / ``report.md`` read ``_skill_input.data.test_patch`` from
+    there — no workspace ``file.read`` of a base_dir-coupled magic path.
+    (#1115 Stage 0 removed the prior
+    ``.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`` file.read,
+    which coupled the read to base_dir and breaks once the repo FS routes
+    through a backend.)
+  - `sanitize_test_patch.py` reads from ``_skill_input.data.test_patch``
+    (Priority 0), falling back to the legacy ``data._input_raw.content``
+    (Priority 1, retained for unit tests), then ``data.test_patch`` (Priority
+    2) or top-level flat dict (Priority 3, unit-test compat).
 
 This file pins:
   (a) `apply_state` schema does NOT include `test_patch` as a required field.
   (b) `apply.md` does NOT contain the "Carry test_patch" instruction.
-  (c) `verify.md` preprocessor contains a `run_op` step before the python
-      step that reads the workspace input file.
-  (d) `sanitize_test_patch` extracts test_patch from the workspace-injected
-      ``_input_raw.content`` payload (Priority 1 path = the fix for 13977).
+  (c) `verify.md` / `report.md` no longer reference the base_dir-coupled
+      magic path, and `verify.md`'s first preprocessor step is the python
+      sanitizer; `sanitize_test_patch` reads test_patch from the OS-injected
+      ``_skill_input`` binding (Priority 0 = the #1115 Stage 0 mechanism).
+  (d) `sanitize_test_patch` extracts test_patch from the legacy workspace
+      ``_input_raw.content`` payload (Priority 1, back-compat).
   (e) `sanitize_test_patch` handles the full runtime artifact shape
       ``{"type": "apply_state", "data": {"test_patch": "..."}}`` correctly
       (Priority 2 path).
-  (f) `sanitize_test_patch` returns empty string when workspace payload is
-      absent and test_patch is missing (existing behavior preserved).
-  (g) Regression guard: LLM-null test_patch in artifact + workspace content
-      present → workspace value wins (= the 13977 failure mode is fixed).
+  (f) `sanitize_test_patch` returns empty string when all sources are absent.
+  (g) Regression guard: LLM-null test_patch in artifact + entry input present
+      → entry-input value wins (= the 13977 failure mode stays fixed).
 
 Tier rule discipline: every test docstring opens with Tier 2; no mocks; no
 private-state assertions; no format-pinning.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -106,58 +113,131 @@ def test_apply_md_no_carry_test_patch_instruction() -> None:
     )
 
 
-# ── (c) verify.md preprocessor: run_op step reads workspace input ────────────
+# ── (c) #1115 Stage 0: OS-injected _skill_input replaces base_dir file.read ──
 
 
-def test_verify_md_preprocessor_has_run_op_before_python() -> None:
-    """Tier 2: verify.md preprocessor must contain a run_op step before python.
+def test_verify_and_report_md_drop_basedir_coupled_magic_path() -> None:
+    """Tier 2: verify.md / report.md no longer reference the base_dir magic path.
 
-    PR-N15 adds a run_op: file.read step as the FIRST preprocessor step to
-    read the workspace _input artifact.  This must appear BEFORE the python
-    sanitizer step so the sanitizer can consume it.
+    #1115 Stage 0 removed the ``run_op: file.read`` of
+    ``.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json``.  That path
+    coupled the deterministic test_patch read to ``base_dir``, which breaks
+    once the repo filesystem routes through a backend.  The OS-injected
+    ``_skill_input`` binding is base_dir-independent.  This guards against the
+    coupling being reintroduced.
+    """
+    for phase in ("verify", "report"):
+        md = (_SKILL_ROOT / "phases" / f"{phase}.md").read_text(encoding="utf-8")
+        assert "swe_bench/_input/v01_swe_bench_input.json" not in md, (
+            f"{phase}.md must NOT reference the base_dir-coupled _input magic "
+            "path after #1115 Stage 0 — the OS injects _skill_input instead"
+        )
+        assert "into: data._input_raw" not in md, (
+            f"{phase}.md must NOT contain the file.read 'into: data._input_raw' "
+            "step after #1115 Stage 0"
+        )
+
+
+def test_verify_md_first_preprocessor_step_is_python_sanitizer() -> None:
+    """Tier 2: verify.md's first preprocessor step is the python sanitizer.
+
+    With the file.read run_op removed (#1115 Stage 0), the sanitizer no longer
+    depends on a preceding read step — it consumes the OS-injected
+    ``_skill_input`` directly.  So the python step is now first; any ``run_op``
+    that remains (the iterate's inner shell op) must come AFTER it.
     """
     verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
-    run_op_pos = verify_md.find("type: run_op")
     python_pos = verify_md.find("type: python")
-    assert run_op_pos != -1, (
-        "verify.md preprocessor must contain a 'type: run_op' step after PR-N15"
-    )
-    assert python_pos != -1, (
-        "verify.md preprocessor must still contain a 'type: python' step"
-    )
-    assert run_op_pos < python_pos, (
-        "The run_op step must appear BEFORE the python step in verify.md "
-        "so the workspace _input is injected before sanitize_test_patch runs"
+    run_op_pos = verify_md.find("type: run_op")
+    assert python_pos != -1, "verify.md must contain a 'type: python' step"
+    assert run_op_pos == -1 or python_pos < run_op_pos, (
+        "The python sanitizer must precede any run_op step in verify.md after "
+        "#1115 Stage 0 (no file.read run_op precedes it anymore)"
     )
 
 
-def test_verify_md_preprocessor_reads_workspace_input_file() -> None:
-    """Tier 2: verify.md run_op step must target the workspace _input artifact.
+def _make_skill_input_artifact(test_patch, *, inner_test_patch=...) -> dict:
+    """Build the working artifact as the preprocessor sees it under #1115 Stage 0.
 
-    The workspace-stored path for the swe_bench entry-phase input is
-    deterministic: `.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json`.
-    PR-N15 pins this path in the run_op so test_patch is always read from
-    the workspace rather than being LLM-echoed.
+    The OS injects the entry ``swe_bench_input`` artifact at the top-level
+    ``_skill_input`` binding (sibling of ``data``).  ``inner_test_patch`` (when
+    given) sets ``data.test_patch`` to simulate a weak-model apply output;
+    default (``...``) leaves it absent.
     """
-    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
-    assert "swe_bench/_input/v01_swe_bench_input.json" in verify_md, (
-        "verify.md must reference the workspace _input artifact path "
-        "'.reyn/artifacts/swe_bench/_input/v01_swe_bench_input.json' in the "
-        "run_op preprocessor step"
-    )
+    inner_data: dict = {
+        "instance_id": "test__test-1",
+        "files_edited": ["foo.py"],
+        "attempt": 1,
+    }
+    if inner_test_patch is not ...:
+        inner_data["test_patch"] = inner_test_patch
+    return {
+        "type": "apply_state",
+        "data": inner_data,
+        "_skill_input": {
+            "type": "swe_bench_input",
+            "data": {
+                "instance_id": "test__test-1",
+                "repo": "test/test",
+                "base_commit": "abc123",
+                "problem_statement": "Fix a bug",
+                "test_patch": test_patch,
+            },
+        },
+    }
 
 
-def test_verify_md_run_op_injects_into_input_raw() -> None:
-    """Tier 2: verify.md run_op step must inject result into data._input_raw.
+def test_sanitizer_reads_from_skill_input_binding() -> None:
+    """Tier 2: sanitizer extracts test_patch from the OS-injected _skill_input.
 
-    The sanitize_test_patch function reads from data._input_raw.content
-    (Priority 1).  The run_op's into: field must target data._input_raw.
+    This is the #1115 Stage 0 primary path (Priority 0).  The OS injects the
+    entry artifact at ``_skill_input``; the sanitizer reads
+    ``_skill_input.data.test_patch`` — not from the apply LLM output.
     """
-    verify_md = (_SKILL_ROOT / "phases" / "verify.md").read_text(encoding="utf-8")
-    assert "into: data._input_raw" in verify_md, (
-        "verify.md run_op step must use 'into: data._input_raw' so the "
-        "sanitize_test_patch function can read the workspace artifact content"
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    patch_str = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    artifact = _make_skill_input_artifact(patch_str)
+    assert sanitize_test_patch(artifact) == patch_str
+
+
+def test_sanitizer_skill_input_normalizes_crlf() -> None:
+    """Tier 2: sanitizer normalizes CRLF when reading from _skill_input."""
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    raw = "diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@\r\n-a\r\n+b\r\n"
+    result = sanitize_test_patch(_make_skill_input_artifact(raw))
+    assert "\r" not in result
+
+
+def test_sanitizer_skill_input_wins_over_null_inner_test_patch() -> None:
+    """Tier 2: regression guard — _skill_input wins over null data.test_patch.
+
+    Simulates a weak-model apply output where ``data.test_patch`` is null.
+    The OS-injected ``_skill_input`` must take priority (= the 13977 failure
+    mode stays fixed under the #1115 Stage 0 mechanism).
+    """
+    from reyn.stdlib.skills.swe_bench.sanitize_test_patch import sanitize_test_patch
+
+    real_patch = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    artifact = _make_skill_input_artifact(real_patch, inner_test_patch=None)
+    assert sanitize_test_patch(artifact) == real_patch
+
+
+def test_parse_test_targets_reads_from_skill_input_binding() -> None:
+    """Tier 2: parse_test_targets derives revert commands from _skill_input.
+
+    report.md has no sanitize step, so it relies on parse_test_targets reading
+    test_patch directly from the OS-injected ``_skill_input`` (Priority 0).
+    """
+    from reyn.stdlib.skills.swe_bench.parse_test_targets import parse_test_targets
+
+    patch = (
+        "diff --git a/tests/test_x.py b/tests/test_x.py\n"
+        "--- a/tests/test_x.py\n+++ b/tests/test_x.py\n@@\n-old\n+new\n"
     )
+    artifact = _make_skill_input_artifact(patch)
+    assert parse_test_targets(artifact) == ["git checkout HEAD -- tests/test_x.py"]
 
 
 # ── (d) sanitizer: Priority 1 — workspace _input_raw path ───────────────────
@@ -342,4 +422,67 @@ def test_sanitizer_workspace_wins_over_null_artifact_test_patch() -> None:
     assert result == real_patch, (
         "Workspace _input_raw must win over null test_patch in artifact. "
         f"Expected workspace value: {real_patch!r}, got: {result!r}"
+    )
+
+
+# ── (h) #1115 Stage 0: OS-inject round-trip through the real preprocessor ────
+
+
+def test_preprocessor_injects_skill_input_and_strips_it(tmp_path: Path) -> None:
+    """Tier 2: E2E — OS-injected _skill_input drives the deterministic read.
+
+    Runs the real verify-phase preprocessor (real Workspace + real skill loaded
+    from disk + real safe-mode python subprocess) with the entry test_patch
+    supplied ONLY via ``skill_input`` (= what the OS holds at
+    ``run_state.skill_input``), NOT in the phase input artifact's data.
+
+    Asserts the full #1115 Stage 0 contract:
+      - ``data.test_patch`` is populated from ``_skill_input`` (the OS injected
+        it at the top-level binding → sanitize_test_patch read it).
+      - ``_skill_input`` is stripped from the enriched artifact (no leak into
+        the LLM-facing frame / stored artifact).
+    """
+    from reyn.compiler.loader import load_dsl_skill
+    from reyn.events.events import EventLog
+    from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+    from reyn.workspace.workspace import Workspace
+
+    skill = load_dsl_skill(_SKILL_ROOT / "skill.md")
+    verify_phase = skill.phases["verify"]
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    executor = PreprocessorExecutor(
+        skill=skill,
+        workspace=ws,
+        model="standard",
+        events=events,
+        subscribers=[],
+        resolver=None,
+        permission_resolver=None,
+    )
+
+    patch = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@\n-old\n+new\n"
+    # Phase input carries NO test_patch; the entry input does (OS-held).
+    artifact = {
+        "type": "apply_state",
+        "data": {"instance_id": "i", "files_edited": ["x"], "attempt": 1},
+    }
+    skill_input = {
+        "type": "swe_bench_input",
+        "data": {"instance_id": "i", "test_patch": patch},
+    }
+
+    enriched, _usage = asyncio.run(
+        executor.run(
+            verify_phase, artifact, output_language=None, skill_input=skill_input,
+        )
+    )
+
+    assert enriched["data"].get("test_patch") == patch, (
+        "data.test_patch must be derived from the OS-injected _skill_input "
+        f"(got {enriched['data'].get('test_patch')!r})"
+    )
+    assert "_skill_input" not in enriched, (
+        "_skill_input must be stripped from the enriched artifact so it does "
+        "not leak into the LLM frame or the stored artifact"
     )

--- a/tests/test_workspace_state_dir_decouple_1115.py
+++ b/tests/test_workspace_state_dir_decouple_1115.py
@@ -1,0 +1,83 @@
+"""Tier 2: FP-0008 #1115 Stage 0 — Workspace state_dir decouple + artifact handle.
+
+#1115 Stage 0 makes artifact access OS-managed:
+  - ``Workspace`` gains a host-side ``state_dir`` param, decoupled from
+    ``base_dir`` (the repo working tree). Default = ``base_dir/.reyn``
+    (backward-compat).
+  - ``store_artifact`` returns a ``state_dir``-relative handle (no longer a
+    ``base_dir``-relative FS path), so the handle survives independently of
+    where the repo filesystem lives (= container-death recoverable, and the
+    precondition for routing the repo FS through a backend in later stages).
+  - ``resolve_artifact_handle`` is the OS's authoritative resolver for those
+    handles, with a path-escape guard.
+
+This file pins the producer-side decouple contract. No mocks; public surface
+only (``state_dir`` / ``store_artifact`` / ``resolve_artifact_handle``).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.workspace.workspace import Workspace
+
+
+def test_default_state_dir_is_base_dir_reyn(tmp_path: Path) -> None:
+    """Tier 2: default state_dir = base_dir/.reyn (backward-compat)."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    assert ws.state_dir == (tmp_path / ".reyn").resolve()
+
+
+def test_state_dir_can_be_decoupled_from_base_dir(tmp_path: Path) -> None:
+    """Tier 2: an explicit state_dir is honored independently of base_dir.
+
+    This is the capability that lets a later stage put the repo working tree
+    (base_dir) inside a container while artifacts + events stay on the host.
+    """
+    base = tmp_path / "repo"
+    base.mkdir()
+    state = tmp_path / "host_state"
+    ws = Workspace(events=EventLog(), base_dir=base, state_dir=state)
+    assert ws.state_dir == state.resolve()
+    assert not ws.state_dir.is_relative_to(ws.base_dir)
+    # state_dir is created eagerly with its artifacts subdir.
+    assert (state / "artifacts").is_dir()
+
+
+def test_store_artifact_returns_state_dir_relative_handle(tmp_path: Path) -> None:
+    """Tier 2: store_artifact returns a state_dir-relative handle (not base-coupled).
+
+    The handle must be relative (not absolute) and rooted at ``artifacts/`` —
+    independent of base_dir. The OS resolves it against state_dir to read it
+    back, round-tripping the stored content.
+    """
+    base = tmp_path / "repo"
+    base.mkdir()
+    state = tmp_path / "host_state"
+    ws = Workspace(events=EventLog(), base_dir=base, state_dir=state)
+
+    artifact = {"type": "demo", "data": {"x": 1, "y": "two"}}
+    handle = ws.store_artifact("phase_a", artifact, skill_name="demo_skill")
+
+    assert not Path(handle).is_absolute(), f"handle must be relative: {handle!r}"
+    assert handle.startswith("artifacts/"), (
+        f"handle must be state_dir-relative under artifacts/: {handle!r}"
+    )
+    assert not handle.startswith(".reyn"), (
+        "handle must NOT carry the base_dir-coupled .reyn prefix after #1115"
+    )
+
+    resolved = ws.resolve_artifact_handle(handle)
+    assert resolved.is_file()
+    assert resolved.is_relative_to(state.resolve())
+    assert json.loads(resolved.read_text(encoding="utf-8")) == artifact
+
+
+def test_resolve_artifact_handle_rejects_escape(tmp_path: Path) -> None:
+    """Tier 2: resolve_artifact_handle raises on a handle escaping state_dir."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    with pytest.raises(PermissionError):
+        ws.resolve_artifact_handle("../../../etc/passwd")


### PR DESCRIPTION
**[e2e-coder]** — #1115 Stage 0 (artifact OS-managed access + `Workspace.state_dir` decouple). Behavior-preserving enabler for the comprehensive sandbox realignment (OS-on-host + repo-FS-through-backend). Self-driven per the #1115 spec GO; PR-when-ready.

## What this does

Makes artifact addressing OS-managed so the repo working tree (`base_dir`) can later route through a backend while artifacts + events stay host-side (`state_dir`), without skills knowing. Removes the base_dir-coupled magic-path `file.read` from the swe_bench skill — the coupling source flagged in the spec.

## Mechanism (no new op — reuses existing patterns, no throwaway)

- **`Workspace`** (producer, prior commit): host-side `state_dir` param (default `base_dir/.reyn` = backward-compat); `store_artifact` returns a **state_dir-relative handle**; `resolve_artifact_handle` is the OS resolver with a path-escape guard.
- **preprocessor**: OS injects the entry-phase input (`run_state.skill_input`) at the reserved top-level **`_skill_input`** binding for the preprocessor chain, then **strips it** before return (no leak into the LLM frame / stored artifact). Generic + P7-clean (every skill has an entry input), analogous to the existing `_iter` binding.
- **run_orchestrator**: threads `skill_input` into `preprocessor.run`; resume load (in-flight + `__post__`) resolves the handle via `resolve_artifact_handle` instead of `Path(cwd-relative)`.
- **runtime.build_frame**: resolves the handle → absolute for the LLM-facing `artifact_ref` (maybe_ref_artifact) — **consistent with the C5 control_ir offload refs** (absolute, pass the workspace read check under base_dir in the co-located default). Stage 2 swaps this for a container-served read without touching skills.
- **swe_bench verify.md / report.md**: drop the `.reyn/artifacts/.../_input` `file.read` step; `sanitize_test_patch` / `parse_test_targets` read `_skill_input.data.test_patch` (Priority 0), `_input_raw` retained for back-compat.

## Scope note

Part B (`judge_phase` / `eval`'s `.reyn/invoke` reads) is a **structurally distinct** mechanism — the `eval` skill caller constructs an artifact path for arbitrary target-skill phase artifacts, not the OS-held entry input. Migrating it = caller-inlines-artifact (different change set). Split into a follow-up PR to keep this one one-mechanism-per-PR. (Flagging since the spec listed both prefixes as one unit.)

## Tests (no-mock, Tier 2)

- **E2E OS-inject round-trip**: real preprocessor injects `_skill_input` → `sanitize_test_patch` derives `data.test_patch` → `_skill_input` stripped (PR-N15 file §h).
- Behavioral `_skill_input` reads for sanitize + parse (Priority 0); coupling-removal guards (verify/report no longer reference the magic path).
- `Workspace` state_dir decouple round-trip + handle escape guard (new file `test_workspace_state_dir_decouple_1115.py`).
- Rewrote the structural `.md`-shape tests that pinned the old `file.read` mechanism → pin the new OS-inject mechanism (contract reversal → rewrite, not patch-flip).
- Updated 2 resume tests that hardcoded the old base_dir-relative path format → state_dir-relative handle.

## Test plan

- [x] `ruff check .` — clean
- [x] swe_bench skill tests (sanitize / parse / verify / report / c6_v2 / load / invariants / md-shape) — green
- [x] resume suite (e2e / auto / fast_forward / budget / a2a / intervention / session / config / postprocessor resume + chain) — green
- [x] runtime / orchestrator / preprocessor / postprocessor / phase / memo sweep (570 tests) — green
- [x] workspace / e2e / context_builder inline-boost / offload / mediastore (224 + 99 + 72) — green
- [ ] (CI) full-rootdir `pytest -q` — local env has a broken editable install (~60k spurious collection errors, pre-existing, not from this change); relying on CI for full collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)