### PR TITLE
feat(fp-0008): #1115 Stage 1 — EnvironmentBackend seam (host=identity, behavior-preserving)

### DIFF
--- a/src/reyn/environment/__init__.py
+++ b/src/reyn/environment/__init__.py
@@ -1,0 +1,11 @@
+"""Environment backends (FP-0008 #1115) — repo-filesystem mechanism abstraction.
+
+``EnvironmentBackend`` decouples the Workspace from the concrete filesystem the
+repo working tree lives on. ``HostBackend`` (Stage 1) is the identity over the
+local Python filesystem; a container backend (Stage 2) lets the repo FS live in
+a container while the OS + permission layer stay host-side.
+"""
+from reyn.environment.backend import EnvironmentBackend, GrepResult
+from reyn.environment.host_backend import HostBackend
+
+__all__ = ["EnvironmentBackend", "GrepResult", "HostBackend"]

--- a/src/reyn/environment/backend.py
+++ b/src/reyn/environment/backend.py
@@ -1,0 +1,127 @@
+"""EnvironmentBackend Protocol — repo-filesystem mechanism abstraction (FP-0008 #1115 Stage 1).
+
+The Protocol decouples the :class:`~reyn.workspace.workspace.Workspace` from the
+concrete filesystem the repo working tree lives on. The **host** backend
+(:class:`~reyn.environment.host_backend.HostBackend`) is an identity over the
+local Python filesystem — exactly the behavior Workspace had inline before this
+seam existed. A later stage (#1115 Stage 2) adds a container backend so the
+repo FS can live inside a container while the OS + permission layer stay on the
+host (industry pattern: OpenHands Runtime / Hermes docker-exec).
+
+Contract / division of responsibility (behavior-preserving):
+  - Workspace owns the **permission gate** (``_resolve_read`` / ``_resolve_write``
+    against ``base_dir`` + the PermissionResolver), **relative-path resolution**,
+    and **event emission** (``workspace_updated``).
+  - The backend receives ABSOLUTE, already-permission-resolved paths and
+    performs only the IO. This keeps the permission boundary host-side and
+    enforced uniformly regardless of where the repo FS lives.
+
+``grep`` is a **primitive** (an environment-internal scan), not a host-side
+composition of glob + N reads: against a container backend a host-composed
+scan would need N round-trips, so the scan must run *inside* the environment
+(the host backend runs Python ``re``; a container backend runs the scan in the
+container, preserving Python ``re`` semantics). ``edit``, by contrast, is a
+pure host-side transform and stays a **composition**
+(``Workspace.edit`` = backend read → ``str.replace`` → backend write) rather
+than a backend primitive.
+
+``exec`` convergence with the FP-0017 ``SandboxBackend`` is intentionally NOT
+part of this Protocol yet — ``exec`` already has a backend abstraction
+(``reyn.sandbox``); folding it in is a separate step (#1115 Stage 1b) to keep
+this repo-FS seam behavior-preserving and reviewable in isolation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Pattern, Protocol, runtime_checkable
+
+
+@dataclass
+class GrepResult:
+    """Result of an environment-internal grep scan.
+
+    Populated according to ``output_mode``:
+      - ``"files_with_matches"`` → ``files`` (absolute Paths of matching files)
+      - ``"count"``              → ``count`` (total match count)
+      - ``"content"``            → ``matches`` (list of hit dicts, ``path`` as a
+        Path; the caller relativizes for presentation)
+    """
+
+    output_mode: str
+    files: list[Path] = field(default_factory=list)
+    count: int = 0
+    matches: list[dict] = field(default_factory=list)
+
+
+@runtime_checkable
+class EnvironmentBackend(Protocol):
+    """Repo-filesystem backend protocol.
+
+    Implementations declare a ``name`` attribute (= ``"host"`` now; ``"container"``
+    at Stage 2) and operate on ABSOLUTE paths the Workspace has already resolved
+    and permission-checked. See the module docstring for the
+    responsibility split.
+    """
+
+    name: str
+
+    def read_bytes(self, path: Path) -> bytes | None:
+        """Return the file's bytes, or ``None`` if the path does not exist."""
+        ...
+
+    def write_bytes(self, path: Path, data: bytes) -> None:
+        """Write ``data`` to ``path``, creating parent directories as needed."""
+        ...
+
+    def delete(self, path: Path) -> bool:
+        """Delete a regular file. Return ``True`` if removed, ``False`` if the
+        path is absent or is not a regular file."""
+        ...
+
+    def mkdir(self, path: Path, *, parents: bool = True) -> bool:
+        """Create a directory. Return ``True`` if newly created, ``False`` if it
+        already existed as a directory. Raise ``FileExistsError`` if a
+        non-directory already sits at ``path``."""
+        ...
+
+    def move(self, src: Path, dst: Path) -> bool:
+        """Move ``src`` to ``dst`` (creating ``dst`` parents). Return ``True`` on
+        success, ``False`` if ``src`` does not exist."""
+        ...
+
+    def stat(self, path: Path) -> dict | None:
+        """Return a metadata dict (``size`` / ``mtime`` / ``ctime`` / ``is_dir`` /
+        ``is_file`` / ``mode``), or ``None`` if ``path`` does not exist."""
+        ...
+
+    def glob(self, pattern: str, *, root: Path | None = None) -> list[Path]:
+        """Expand a glob pattern.
+
+        When ``root`` is ``None``, ``pattern`` is an absolute pattern matched
+        recursively. Otherwise ``pattern`` is matched relative to ``root``.
+        Returns all matches (files AND directories); the caller filters.
+        """
+        ...
+
+    def grep(
+        self,
+        root: Path,
+        regex: Pattern[str],
+        *,
+        glob: str | None = None,
+        file_type: str | None = None,
+        output_mode: str = "content",
+        head_limit: int | None = None,
+        context_before: int = 0,
+        context_after: int = 0,
+    ) -> GrepResult:
+        """Scan files under ``root`` for ``regex`` and return a :class:`GrepResult`.
+
+        ``root`` is an absolute, permission-resolved path. When ``root`` is a
+        file, only that file is scanned; otherwise files matching ``glob``
+        (default ``**/*``) under it, optionally filtered to ``file_type``
+        (extension), are scanned. This is the environment-internal scan
+        primitive (see module docstring).
+        """
+        ...

--- a/src/reyn/environment/host_backend.py
+++ b/src/reyn/environment/host_backend.py
@@ -1,0 +1,144 @@
+"""HostBackend — identity EnvironmentBackend over the local Python filesystem.
+
+FP-0008 #1115 Stage 1. This backend reproduces exactly the filesystem behavior
+the :class:`~reyn.workspace.workspace.Workspace` performed inline before the
+:class:`~reyn.environment.backend.EnvironmentBackend` seam existed — so wiring
+Workspace to a ``HostBackend`` is behavior-preserving. It receives ABSOLUTE,
+already-permission-resolved paths (the Workspace owns the permission gate +
+relative-path resolution + event emission; see the backend module docstring).
+"""
+from __future__ import annotations
+
+import glob as _glob
+from pathlib import Path
+from typing import Any, Pattern
+
+from reyn.environment.backend import GrepResult
+
+
+class HostBackend:
+    """Identity backend: the repo working tree IS the local filesystem."""
+
+    name = "host"
+
+    def read_bytes(self, path: Path) -> bytes | None:
+        if path.exists():
+            return path.read_bytes()
+        return None
+
+    def write_bytes(self, path: Path, data: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def delete(self, path: Path) -> bool:
+        if path.exists() and path.is_file():
+            path.unlink()
+            return True
+        return False
+
+    def mkdir(self, path: Path, *, parents: bool = True) -> bool:
+        if path.exists():
+            if path.is_dir():
+                return False
+            raise FileExistsError(
+                f"path exists but is not a directory: {str(path)!r}"
+            )
+        path.mkdir(parents=parents, exist_ok=False)
+        return True
+
+    def move(self, src: Path, dst: Path) -> bool:
+        if not src.exists():
+            return False
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        src.rename(dst)
+        return True
+
+    def stat(self, path: Path) -> dict | None:
+        if not path.exists():
+            return None
+        st = path.stat()
+        return {
+            "size": st.st_size,
+            "mtime": st.st_mtime,
+            "ctime": st.st_ctime,
+            "is_dir": path.is_dir(),
+            "is_file": path.is_file(),
+            "mode": oct(st.st_mode & 0o777),
+        }
+
+    def glob(self, pattern: str, *, root: Path | None = None) -> list[Path]:
+        if root is None:
+            # Absolute pattern (recursive) — matches the legacy abs-path branch.
+            return [Path(p) for p in _glob.glob(pattern, recursive=True)]
+        # Relative pattern matched under root — matches the legacy rel branch.
+        return list(root.glob(pattern))
+
+    def grep(
+        self,
+        root: Path,
+        regex: Pattern[str],
+        *,
+        glob: str | None = None,
+        file_type: str | None = None,
+        output_mode: str = "content",
+        head_limit: int | None = None,
+        context_before: int = 0,
+        context_after: int = 0,
+    ) -> GrepResult:
+        # Gather candidate files (env-internal scan; mirrors _execute_grep).
+        if root.is_file():
+            candidates = [root]
+        else:
+            glob_pattern = glob or "**/*"
+            candidates = sorted(f for f in root.glob(glob_pattern) if f.is_file())
+        if file_type:
+            ext = file_type.lstrip(".")
+            candidates = [f for f in candidates if f.suffix.lstrip(".") == ext]
+
+        if output_mode == "files_with_matches":
+            matched: list[Path] = []
+            for f in candidates:
+                try:
+                    if regex.search(f.read_text(encoding="utf-8", errors="replace")):
+                        matched.append(f)
+                except OSError:
+                    continue
+            return GrepResult(output_mode="files_with_matches", files=matched)
+
+        if output_mode == "count":
+            total = 0
+            for f in candidates:
+                try:
+                    total += len(regex.findall(f.read_text(encoding="utf-8", errors="replace")))
+                except OSError:
+                    continue
+            return GrepResult(output_mode="count", count=total)
+
+        matches: list[dict] = []
+        done = False
+        for f in candidates:
+            if done:
+                break
+            try:
+                lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
+            except OSError:
+                continue
+            for i, line in enumerate(lines):
+                if not regex.search(line):
+                    continue
+                entry: dict[str, Any] = {"path": f, "line_number": i + 1, "content": line}
+                if context_before or context_after:
+                    start = max(0, i - context_before)
+                    end = min(len(lines), i + context_after + 1)
+                    entry["context"] = [
+                        {"line_number": j + 1, "content": lines[j], "is_match": j == i}
+                        for j in range(start, end)
+                    ]
+                matches.append(entry)
+                if head_limit is not None and len(matches) >= head_limit:
+                    done = True
+                    break
+        return GrepResult(output_mode="content", matches=matches)
+
+
+__all__ = ["HostBackend"]

--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -277,20 +277,22 @@ def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
     except re.error as exc:
         return {"kind": "file", "op": "grep", "status": "error", "error": f"invalid regex: {exc}"}
 
-    search_root = Path(op.path) if op.path else Path(".")
+    # FP-0008 #1115 Stage 1: the glob+read+regex scan is an environment-internal
+    # primitive run by the backend (Workspace.grep gates the root + delegates).
+    # The handler keeps presentation: regex compile / error envelopes / relativize.
     try:
-        resolved_root = ctx.workspace._resolve_read(str(search_root))
+        result = ctx.workspace.grep(
+            op.path or ".",
+            regex,
+            glob=op.glob,
+            file_type=op.file_type,
+            output_mode=op.output_mode,
+            head_limit=op.head_limit,
+            context_before=op.context_before,
+            context_after=op.context_after,
+        )
     except PermissionError as exc:
         return {"kind": "file", "op": "grep", "status": "denied", "error": str(exc)}
-
-    if resolved_root.is_file():
-        candidates = [resolved_root]
-    else:
-        glob_pattern = op.glob or "**/*"
-        candidates = sorted(f for f in resolved_root.glob(glob_pattern) if f.is_file())
-    if op.file_type:
-        ext = op.file_type.lstrip(".")
-        candidates = [f for f in candidates if f.suffix.lstrip(".") == ext]
 
     def _rel(p: Path) -> str:
         try:
@@ -298,55 +300,27 @@ def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
         except ValueError:
             return str(p)
 
-    if op.output_mode == "files_with_matches":
-        matched: list[str] = []
-        for f in candidates:
-            try:
-                if regex.search(f.read_text(encoding="utf-8", errors="replace")):
-                    matched.append(_rel(f))
-            except OSError:
-                continue
+    if result.output_mode == "files_with_matches":
+        matched = [_rel(f) for f in result.files]
         ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=len(matched))
         return {"kind": "file", "op": "grep", "status": "ok",
                 "output_mode": "files_with_matches", "files": matched, "count": len(matched)}
 
-    if op.output_mode == "count":
-        total = 0
-        for f in candidates:
-            try:
-                total += len(regex.findall(f.read_text(encoding="utf-8", errors="replace")))
-            except OSError:
-                continue
-        ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=total)
+    if result.output_mode == "count":
+        ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=result.count)
         return {"kind": "file", "op": "grep", "status": "ok",
-                "output_mode": "count", "count": total}
+                "output_mode": "count", "count": result.count}
 
     matches: list[dict] = []
-    head_limit = op.head_limit
-    done = False
-    for f in candidates:
-        if done:
-            break
-        try:
-            lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
-            continue
-        rel = _rel(f)
-        for i, line in enumerate(lines):
-            if not regex.search(line):
-                continue
-            entry: dict[str, Any] = {"path": rel, "line_number": i + 1, "content": line}
-            if op.context_before or op.context_after:
-                start = max(0, i - op.context_before)
-                end = min(len(lines), i + op.context_after + 1)
-                entry["context"] = [
-                    {"line_number": j + 1, "content": lines[j], "is_match": j == i}
-                    for j in range(start, end)
-                ]
-            matches.append(entry)
-            if head_limit is not None and len(matches) >= head_limit:
-                done = True
-                break
+    for hit in result.matches:
+        entry: dict[str, Any] = {
+            "path": _rel(hit["path"]),
+            "line_number": hit["line_number"],
+            "content": hit["content"],
+        }
+        if "context" in hit:
+            entry["context"] = hit["context"]
+        matches.append(entry)
 
     ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=len(matches))
     return {"kind": "file", "op": "grep", "status": "ok",

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import glob as _glob
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from reyn.environment.host_backend import HostBackend
 from reyn.events.events import EventLog
 
 if TYPE_CHECKING:
+    from reyn.environment.backend import EnvironmentBackend, GrepResult
     from reyn.permissions.permissions import PermissionResolver
 
 
@@ -31,7 +33,16 @@ class Workspace:
         skill_name: str = "",
         base_dir: "Path | None" = None,
         state_dir: "Path | None" = None,
+        environment_backend: "EnvironmentBackend | None" = None,
     ) -> None:
+        # FP-0008 #1115 Stage 1: the repo working tree is accessed through a
+        # pluggable EnvironmentBackend. Default = HostBackend (identity over the
+        # local filesystem = legacy behavior). Stage 2 supplies a container
+        # backend so the repo FS can live in a container while this OS layer +
+        # the permission gate stay host-side. The permission gate, relative-path
+        # resolution, and event emission stay here; the backend does only IO on
+        # the absolute paths this class resolves.
+        self._backend: "EnvironmentBackend" = environment_backend or HostBackend()
         self.base_dir = base_dir.resolve() if base_dir is not None else Path.cwd()
         # FP-0008 #1115 Stage 0: state_dir is host-side and decoupled from
         # base_dir. Default = base_dir/.reyn (backward-compat). A caller that
@@ -93,9 +104,10 @@ class Workspace:
     def read_file(self, path_str: str) -> tuple[str, bool]:
         """Read a file. Returns (content, found). Raises PermissionError if denied."""
         path = self._resolve_read(path_str)
-        if path.exists():
-            return path.read_text(encoding="utf-8"), True
-        return "", False
+        data = self._backend.read_bytes(path)
+        if data is None:
+            return "", False
+        return data.decode("utf-8"), True
 
     def read_file_bytes(self, path_str: str) -> tuple[bytes, bool]:
         """Read a file as raw bytes (issue #365).
@@ -106,25 +118,24 @@ class Workspace:
         denied by the workspace policy.
         """
         path = self._resolve_read(path_str)
-        if path.exists():
-            return path.read_bytes(), True
-        return b"", False
+        data = self._backend.read_bytes(path)
+        if data is None:
+            return b"", False
+        return data, True
 
     def write_file(self, path_str: str, content: str) -> None:
         """Write a file into the project. Raises PermissionError if denied."""
         path = self._resolve_write(path_str)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content, encoding="utf-8")
+        self._backend.write_bytes(path, content.encode("utf-8"))
         self._events.emit("workspace_updated", path=str(path))
 
     def delete_file(self, path_str: str) -> bool:
         """Delete a file from the project. Returns True if deleted, False if not found."""
         path = self._resolve_write(path_str)
-        if path.exists() and path.is_file():
-            path.unlink()
+        deleted = self._backend.delete(path)
+        if deleted:
             self._events.emit("workspace_updated", path=str(path))
-            return True
-        return False
+        return deleted
 
     def make_directory(self, path_str: str, *, parents: bool = True) -> bool:
         """Create a directory under the project (issue #356).
@@ -136,15 +147,16 @@ class Workspace:
         explicitly approved.
         """
         path = self._resolve_write(path_str)
-        if path.exists():
-            if path.is_dir():
-                return False
+        try:
+            created = self._backend.mkdir(path, parents=parents)
+        except FileExistsError:
+            # Preserve the legacy message which embeds the caller's path_str.
             raise FileExistsError(
                 f"path exists but is not a directory: {path_str!r}"
-            )
-        path.mkdir(parents=parents, exist_ok=False)
-        self._events.emit("workspace_updated", path=str(path))
-        return True
+            ) from None
+        if created:
+            self._events.emit("workspace_updated", path=str(path))
+        return created
 
     def move_path(self, src_str: str, dst_str: str) -> bool:
         """Move / rename a file or directory (issue #356).
@@ -155,12 +167,10 @@ class Workspace:
         """
         src = self._resolve_write(src_str)
         dst = self._resolve_write(dst_str)
-        if not src.exists():
-            return False
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        src.rename(dst)
-        self._events.emit("workspace_updated", path=str(dst))
-        return True
+        moved = self._backend.move(src, dst)
+        if moved:
+            self._events.emit("workspace_updated", path=str(dst))
+        return moved
 
     def stat_path(self, path_str: str) -> dict | None:
         """Filesystem metadata for a file / directory (issue #356).
@@ -171,17 +181,7 @@ class Workspace:
         string, e.g. ``"0o644"``). Gated by ``_resolve_read``.
         """
         path = self._resolve_read(path_str)
-        if not path.exists():
-            return None
-        st = path.stat()
-        return {
-            "size": st.st_size,
-            "mtime": st.st_mtime,
-            "ctime": st.st_ctime,
-            "is_dir": path.is_dir(),
-            "is_file": path.is_file(),
-            "mode": oct(st.st_mode & 0o777),
-        }
+        return self._backend.stat(path)
 
     def glob_files(self, pattern: str, max_results: int = 50) -> list[str]:
         """
@@ -222,13 +222,13 @@ class Workspace:
             # whose first max_results matches are directories (common at the
             # project root: .claude, .git, .github, .reyn, .venv, ...) silently
             # truncates the file list to ~zero.
-            raw = sorted(_glob.glob(pattern, recursive=True))
+            raw = sorted(str(m) for m in self._backend.glob(pattern))
             files = [m for m in raw if Path(m).is_file()]
             return files[:max_results]
 
         # Same fix for the relative-path branch: filter to files first, then
         # cap at max_results.
-        ws_matches = sorted(self.base_dir.glob(pattern))
+        ws_matches = sorted(self._backend.glob(pattern, root=self.base_dir))
         files_only = [m for m in ws_matches if m.is_file()]
         result = []
         for m in files_only[:max_results]:
@@ -237,6 +237,38 @@ class Workspace:
             except ValueError:
                 pass
         return result
+
+    def grep(
+        self,
+        path_str: str,
+        regex: "re.Pattern[str]",
+        *,
+        glob: str | None = None,
+        file_type: str | None = None,
+        output_mode: str = "content",
+        head_limit: int | None = None,
+        context_before: int = 0,
+        context_after: int = 0,
+    ) -> "GrepResult":
+        """Permission-resolve the search root and run the backend's scan.
+
+        FP-0008 #1115 Stage 1: ``grep`` is an environment-internal scan
+        primitive — the Workspace gates the root via ``_resolve_read`` (raising
+        PermissionError when denied) and delegates the glob+read+regex scan to
+        the backend, which returns absolute Paths. The caller (file op handler)
+        relativizes for presentation. See [[environment.backend]] module docs.
+        """
+        root = self._resolve_read(path_str)
+        return self._backend.grep(
+            root,
+            regex,
+            glob=glob,
+            file_type=file_type,
+            output_mode=output_mode,
+            head_limit=head_limit,
+            context_before=context_before,
+            context_after=context_after,
+        )
 
     def store_artifact(
         self,

--- a/tests/test_environment_backend_1115_stage1.py
+++ b/tests/test_environment_backend_1115_stage1.py
@@ -1,0 +1,153 @@
+"""Tier 2: FP-0008 #1115 Stage 1 — EnvironmentBackend seam.
+
+Stage 1 introduces an EnvironmentBackend so the repo working tree can later
+route through a pluggable backend (host=identity now / container at Stage 2)
+while the OS + permission layer stay host-side. This file pins:
+
+  (a) HostBackend satisfies the EnvironmentBackend Protocol (runtime_checkable);
+  (b) Workspace ROUTES every repo-FS op through its backend (not the raw
+      filesystem directly) — proven with a real recording backend (a Fake, not
+      a mock), so a non-host backend at Stage 2 will actually be exercised;
+  (c) with the default HostBackend the FS ops round-trip identically (= the
+      identity / behavior-preservation property, beyond the broad existing
+      file-op suites);
+  (d) grep is a backend primitive (Workspace.grep delegates the scan);
+  (e) the permission gate + state_dir artifact storage stay host-side (NOT
+      routed through the repo-FS backend).
+
+No mocks: collaborators are real instances or a hand-written recording Fake
+(per testing policy). Assertions use public surfaces only.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from reyn.environment.backend import EnvironmentBackend, GrepResult
+from reyn.environment.host_backend import HostBackend
+from reyn.events.events import EventLog
+from reyn.workspace.workspace import Workspace
+
+
+class _RecordingBackend:
+    """A real EnvironmentBackend that records which ops it served, delegating
+    the actual IO to a wrapped HostBackend. A Fake (test double), not a mock.
+    """
+
+    name = "recording"
+
+    def __init__(self) -> None:
+        self._inner = HostBackend()
+        self.calls: list[str] = []
+
+    def read_bytes(self, path: Path) -> bytes | None:
+        self.calls.append("read_bytes")
+        return self._inner.read_bytes(path)
+
+    def write_bytes(self, path: Path, data: bytes) -> None:
+        self.calls.append("write_bytes")
+        self._inner.write_bytes(path, data)
+
+    def delete(self, path: Path) -> bool:
+        self.calls.append("delete")
+        return self._inner.delete(path)
+
+    def mkdir(self, path: Path, *, parents: bool = True) -> bool:
+        self.calls.append("mkdir")
+        return self._inner.mkdir(path, parents=parents)
+
+    def move(self, src: Path, dst: Path) -> bool:
+        self.calls.append("move")
+        return self._inner.move(src, dst)
+
+    def stat(self, path: Path) -> dict | None:
+        self.calls.append("stat")
+        return self._inner.stat(path)
+
+    def glob(self, pattern: str, *, root: Path | None = None) -> list[Path]:
+        self.calls.append("glob")
+        return self._inner.glob(pattern, root=root)
+
+    def grep(self, root, regex, **kw) -> GrepResult:
+        self.calls.append("grep")
+        return self._inner.grep(root, regex, **kw)
+
+
+def test_host_backend_satisfies_protocol() -> None:
+    """Tier 2: (a) HostBackend is a structural EnvironmentBackend."""
+    assert isinstance(HostBackend(), EnvironmentBackend)
+    assert HostBackend().name == "host"
+
+
+def test_workspace_routes_every_fs_op_through_backend(tmp_path: Path) -> None:
+    """Tier 2: (b) Workspace delegates each repo-FS op to its backend.
+
+    A recording backend proves the seam is real — if any op bypassed the
+    backend (touched the FS directly), its name would be absent from `calls`.
+    """
+    backend = _RecordingBackend()
+    ws = Workspace(events=EventLog(), base_dir=tmp_path, environment_backend=backend)
+
+    ws.write_file("a.txt", "hello")
+    content, found = ws.read_file("a.txt")
+    assert (content, found) == ("hello", True)
+    ws.make_directory("sub")
+    ws.move_path("a.txt", "sub/b.txt")
+    ws.stat_path("sub/b.txt")
+    ws.glob_files("**/*.txt")
+    ws.delete_file("sub/b.txt")
+    ws.grep("sub", re.compile("x"))
+
+    for op in ("write_bytes", "read_bytes", "mkdir", "move", "stat", "glob", "delete", "grep"):
+        assert op in backend.calls, f"Workspace did not route {op!r} through the backend"
+
+
+def test_default_backend_is_host_identity(tmp_path: Path) -> None:
+    """Tier 2: (c) with the default HostBackend, FS ops round-trip identically."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    assert ws._backend.name == "host"  # noqa: SLF001 — documents the default wiring
+
+    ws.write_file("dir/x.txt", "data-本文")
+    content, found = ws.read_file("dir/x.txt")
+    assert (content, found) == ("data-本文", True)
+
+    info = ws.stat_path("dir/x.txt")
+    assert info is not None and info["is_file"] is True and info["size"] > 0
+
+    assert ws.glob_files("dir/*.txt") == ["dir/x.txt"]
+    assert ws.delete_file("dir/x.txt") is True
+    assert ws.read_file("dir/x.txt") == ("", False)
+
+
+def test_grep_primitive_via_backend(tmp_path: Path) -> None:
+    """Tier 2: (d) Workspace.grep delegates the scan to the backend and returns
+    a GrepResult with absolute Paths."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    ws.write_file("code.py", "alpha\nNEEDLE here\nbeta\n")
+    ws.write_file("other.py", "no match\n")
+
+    res = ws.grep(".", re.compile("NEEDLE"), output_mode="files_with_matches")
+    assert isinstance(res, GrepResult)
+    assert [p.name for p in res.files] == ["code.py"]
+    assert all(p.is_absolute() for p in res.files)
+
+    content_res = ws.grep(".", re.compile("NEEDLE"))
+    assert content_res.output_mode == "content"
+    assert len(content_res.matches) == 1
+    assert content_res.matches[0]["line_number"] == 2
+
+    count_res = ws.grep(".", re.compile("a"), output_mode="count")
+    assert count_res.count >= 1
+
+
+def test_state_dir_artifacts_not_routed_through_repo_backend(tmp_path: Path) -> None:
+    """Tier 2: (e) artifact storage is host-side (state_dir) — NOT routed through
+    the repo-FS backend (Stage 0 decouple intent: artifacts survive on host even
+    when the repo FS lives in a container)."""
+    backend = _RecordingBackend()
+    ws = Workspace(events=EventLog(), base_dir=tmp_path, environment_backend=backend)
+
+    handle = ws.store_artifact("p", {"type": "demo", "data": {"v": 1}}, skill_name="s")
+    # store_artifact wrote the file without going through the repo-FS backend.
+    assert "write_bytes" not in backend.calls
+    assert ws.resolve_artifact_handle(handle).is_file()

--- a/tests/test_environment_backend_1115_stage1.py
+++ b/tests/test_environment_backend_1115_stage1.py
@@ -103,11 +103,18 @@ def test_workspace_routes_every_fs_op_through_backend(tmp_path: Path) -> None:
 
 
 def test_default_backend_is_host_identity(tmp_path: Path) -> None:
-    """Tier 2: (c) with the default HostBackend, FS ops round-trip identically."""
+    """Tier 2: (c) with the default backend, FS ops round-trip identically.
+
+    The write→read→stat→glob→delete round-trip below runs against the REAL
+    local filesystem under tmp_path — pinning the host-identity property
+    behaviorally (no private-state inspection of the backend).
+    """
     ws = Workspace(events=EventLog(), base_dir=tmp_path)
-    assert ws._backend.name == "host"  # noqa: SLF001 — documents the default wiring
 
     ws.write_file("dir/x.txt", "data-本文")
+    # Host identity: the default backend wrote through to the REAL local FS.
+    assert (tmp_path / "dir" / "x.txt").read_text(encoding="utf-8") == "data-本文"
+
     content, found = ws.read_file("dir/x.txt")
     assert (content, found) == ("data-本文", True)
 
@@ -133,8 +140,11 @@ def test_grep_primitive_via_backend(tmp_path: Path) -> None:
 
     content_res = ws.grep(".", re.compile("NEEDLE"))
     assert content_res.output_mode == "content"
-    assert len(content_res.matches) == 1
-    assert content_res.matches[0]["line_number"] == 2
+    # Unpack-enforcement: exactly the one matching line, with correct content
+    # (= the grep-returns-the-right-match invariant, not a count format-pin).
+    [hit] = content_res.matches
+    assert hit["line_number"] == 2
+    assert "NEEDLE" in hit["content"]
 
     count_res = ws.grep(".", re.compile("a"), output_mode="count")
     assert count_res.count >= 1


### PR DESCRIPTION
**[e2e-coder]** — #1115 Stage 1. Introduces the EnvironmentBackend seam so the repo working tree can later route through a pluggable backend (host=identity now / container at Stage 2) while the OS + permission layer stay host-side (OpenHands Runtime / Hermes pattern). **Behavior-preserving** (host=identity). Self-driven per lead-coder's Stage 1 GO.

## What this does

- **`src/reyn/environment/`**: `EnvironmentBackend` Protocol (`@runtime_checkable`) + `GrepResult` + `HostBackend` — the identity backend over the local Python filesystem, reproducing the FS behavior Workspace had inline.
- **Workspace routes** read/write/delete/mkdir/move/stat/glob through the backend. The **permission gate** (`_resolve_read`/`_resolve_write`), relative-path resolution, and **event emission** stay in Workspace; the backend does only IO on the absolute paths Workspace resolves. Default = `HostBackend`.
- **grep = backend PRIMITIVE** (an environment-internal scan — a host-composed glob+N-read would need N round-trips against a container backend). New public `Workspace.grep` gates the root + delegates the scan; `file.py _execute_grep` keeps only presentation (regex compile / error envelopes / relativize).
- **edit = COMPOSE** (not a primitive): `_execute_edit` already composes via `ws.read_file`/`write_file`, which now route through the backend — no change.
- **`store_artifact` stays host-side** (`state_dir`), NOT routed through the repo-FS backend — honoring Stage 0's decouple intent (artifacts survive on host even when the repo FS lives in a container).

## Scope decision: exec → Stage 1b (lead-coder accepted)

`exec` convergence (FP-0017 `SandboxBackend.run` → `EnvironmentBackend.exec`) is **split to Stage 1b**: exec already has a backend abstraction, is orthogonal to the repo-FS seam, and bundling would inflate the behavior-preservation gate. Stage 1 (FS routing) is independently coherent at host=identity with **no interim break** (exec stays on SandboxBackend, unchanged). Stage 1b is a **prerequisite for Stage 2** (container needs FS+exec on one backend/target). Order: 1 → 1b → 2.

Unlike #1116 (producer format change + deferred consumer → interim break), this PR splits along an **orthogonal seam** (FS vs exec), so the split is safe — confirmed with lead-coder.

## Tests (no-mock, Tier 2) — `test_environment_backend_1115_stage1.py`

- HostBackend satisfies the `EnvironmentBackend` Protocol (runtime_checkable);
- **Workspace routes every FS op through the backend** — proven with a real recording **Fake** (not a mock), so a non-host backend at Stage 2 will actually be exercised;
- default HostBackend round-trips identically (identity / behavior-preservation);
- grep delegates to the backend + returns absolute Paths;
- state_dir artifact storage is NOT routed through the repo-FS backend.

## Test plan (behavior-preservation coverage)

- [x] `ruff check .` — clean
- [x] Stage 1 backend tests (5) — green
- [x] FS / op_runtime / file mkdir-move-stat / grep / glob / tool / media / index sweep — green
- [x] broad sweep incl. eval / swe_bench / runtime / resume (**785 tests**) — green
- [ ] (CI) full-rootdir `pytest -q` — local editable install broken (~60k pre-existing spurious collection errors, not from this change); relying on CI.

Note: this is a behavior-preserving refactor (no value-format change), so the consumer-audit gate (`feedback_value_format_change_consumer_audit_review_gate`) is N/A; the behavior-preservation coverage above is the relevant gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)