### PR TITLE
feat(fp-0008): #224 — TTL-prune stale control_ir offload scratch dirs (C5 follow-up)

### DIFF
--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -102,6 +102,18 @@ class OSRuntime:
             skill_name=skill.name,
             base_dir=workspace_base_dir,
         )
+        # C5 follow-up (#224): bound the growth of per-run control_ir offload
+        # scratch dirs. Prune stale ones (TTL by mtime) once at top-level run
+        # start — sub-runs (parent_run_id set) skip it to avoid redundant
+        # sweeps; the TTL preserves active + recently-completed (resume-reachable)
+        # runs. Best-effort: the helper swallows FS errors so GC never breaks a run.
+        if parent_run_id is None:
+            from reyn.services.offload import prune_stale_offload_dirs
+            pruned = prune_stale_offload_dirs(
+                self.workspace.state_dir / "control_ir_offload"
+            )
+            if pruned:
+                self.events.emit("control_ir_offload_pruned", count=pruned)
         # Populate internal limit attributes from SafetyConfig.
         _safety = safety or SafetyConfig()
         self._safety = _safety

--- a/src/reyn/services/offload/__init__.py
+++ b/src/reyn/services/offload/__init__.py
@@ -1,12 +1,16 @@
 """Offload service — axis-agnostic infrastructure for preview-driven file offloading."""
 from reyn.services.offload.store import (
+    DEFAULT_OFFLOAD_TTL_SECONDS,
     OffloadResult,
     offload_value,
+    prune_stale_offload_dirs,
     read_offloaded,
 )
 
 __all__ = [
+    "DEFAULT_OFFLOAD_TTL_SECONDS",
     "OffloadResult",
     "offload_value",
+    "prune_stale_offload_dirs",
     "read_offloaded",
 ]

--- a/src/reyn/services/offload/store.py
+++ b/src/reyn/services/offload/store.py
@@ -37,10 +37,19 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
+
+# Default time-to-live for per-run offload scratch directories (24h). Offload
+# files are only needed during the producing run (incl. its resume window) for
+# the LLM to file.read the full content of an offloaded result; once a run is
+# well past, its scratch dir is dead weight. Pruning is TTL-based (by mtime) so
+# active + recently-completed runs (resume-reachable) are preserved.
+DEFAULT_OFFLOAD_TTL_SECONDS = 24 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -176,3 +185,40 @@ def read_offloaded(
         return "".join(sliced), True
 
     return raw, True
+
+
+def prune_stale_offload_dirs(
+    offload_root: Path,
+    *,
+    ttl_seconds: float = DEFAULT_OFFLOAD_TTL_SECONDS,
+    now: float | None = None,
+) -> int:
+    """Remove per-run offload subdirectories older than ``ttl_seconds``.
+
+    ``offload_root`` is the parent that holds one subdirectory per run (keyed
+    by run_id), e.g. ``{state_dir}/control_ir_offload/``. A subdirectory is
+    removed when its mtime is older than ``now - ttl_seconds`` — so active and
+    recently-completed runs (still resume-reachable, see
+    :data:`DEFAULT_OFFLOAD_TTL_SECONDS`) are preserved.
+
+    Axis-agnostic + P7-clean: no skill / phase / artifact-type strings; the
+    caller supplies the concrete root. Fully defensive — a missing root or any
+    filesystem error is swallowed so scratch GC can never break a run. Returns
+    the number of subdirectories removed.
+
+    ``now`` is injectable for deterministic testing (defaults to wall-clock).
+    """
+    cutoff = (time.time() if now is None else now) - ttl_seconds
+    removed = 0
+    try:
+        children = list(offload_root.iterdir())
+    except OSError:
+        return 0
+    for child in children:
+        try:
+            if child.is_dir() and child.stat().st_mtime < cutoff:
+                shutil.rmtree(child, ignore_errors=True)
+                removed += 1
+        except OSError:
+            continue
+    return removed

--- a/tests/test_offload_prune_ttl_224.py
+++ b/tests/test_offload_prune_ttl_224.py
@@ -1,0 +1,81 @@
+"""Tier 2: FP-0008 #224 — control_ir offload scratch-dir TTL pruning.
+
+C5 (#1093) writes oversized control_ir_results to per-run scratch dirs
+``{state_dir}/control_ir_offload/<run_id>/``. Without pruning these accumulate
+one directory per run forever. ``prune_stale_offload_dirs`` removes per-run
+subdirs older than a TTL (by mtime), preserving active + recently-completed
+(resume-reachable) runs.
+
+Pins (no mocks; deterministic via the injectable ``now``):
+  (a) subdirs older than the TTL are removed; recent ones are kept;
+  (b) a missing root is a defensive no-op (returns 0);
+  (c) non-directory entries + the boundary are handled correctly.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from reyn.services.offload import (
+    DEFAULT_OFFLOAD_TTL_SECONDS,
+    prune_stale_offload_dirs,
+)
+
+
+def _make_run_dir(root: Path, run_id: str, *, age_seconds: float, now: float) -> Path:
+    d = root / run_id
+    d.mkdir(parents=True)
+    (d / "0000_abc.json").write_text("payload", encoding="utf-8")
+    mtime = now - age_seconds
+    os.utime(d, (mtime, mtime))
+    return d
+
+
+def test_prune_removes_stale_keeps_recent(tmp_path: Path) -> None:
+    """Tier 2: (a) stale run dirs pruned, recent ones preserved (TTL by mtime)."""
+    root = tmp_path / "control_ir_offload"
+    root.mkdir()
+    now = 1_000_000.0
+    ttl = 3600.0
+
+    stale = _make_run_dir(root, "run_old", age_seconds=ttl + 60, now=now)
+    fresh = _make_run_dir(root, "run_new", age_seconds=ttl - 60, now=now)
+
+    removed = prune_stale_offload_dirs(root, ttl_seconds=ttl, now=now)
+
+    assert removed == 1
+    assert not stale.exists()
+    assert fresh.exists()
+    assert (fresh / "0000_abc.json").read_text(encoding="utf-8") == "payload"
+
+
+def test_prune_missing_root_is_noop(tmp_path: Path) -> None:
+    """Tier 2: (b) a non-existent root prunes nothing and does not raise."""
+    assert prune_stale_offload_dirs(tmp_path / "does_not_exist") == 0
+
+
+def test_prune_ignores_non_directory_entries(tmp_path: Path) -> None:
+    """Tier 2: (c) stray files under the root are left untouched."""
+    root = tmp_path / "control_ir_offload"
+    root.mkdir()
+    now = 1_000_000.0
+    stray = root / "stray.txt"
+    stray.write_text("x", encoding="utf-8")
+    os.utime(stray, (now - 10 * DEFAULT_OFFLOAD_TTL_SECONDS,) * 2)
+
+    removed = prune_stale_offload_dirs(root, now=now)
+
+    assert removed == 0
+    assert stray.exists()
+
+
+def test_prune_default_ttl_keeps_just_created_dir(tmp_path: Path) -> None:
+    """Tier 2: a freshly-created run dir survives the default-TTL prune."""
+    root = tmp_path / "control_ir_offload"
+    root.mkdir()
+    current = root / "run_current"
+    current.mkdir()
+    (current / "data.json").write_text("live", encoding="utf-8")
+
+    assert prune_stale_offload_dirs(root) == 0
+    assert current.exists()


### PR DESCRIPTION
**[e2e-coder]** — C5 follow-up (#224). Bounds the growth of the per-run control_ir offload scratch directories introduced by C5 (#1093).

## Problem

C5 writes oversized `control_ir_results` to `{state_dir}/control_ir_offload/<run_id>/` so the LLM can `file.read` the full content. These dirs accumulated **one per run, forever** — no cleanup existed.

## Fix

- **`services/offload/store.py`**: `prune_stale_offload_dirs(root, *, ttl_seconds=DEFAULT_OFFLOAD_TTL_SECONDS (24h), now=None)` — removes per-run subdirs older than the TTL (by mtime). Axis-agnostic + P7-clean (no skill/phase/artifact strings; caller supplies the concrete root). Fully defensive (swallows FS errors so GC can never break a run). `now` injectable for deterministic tests.
- **`runtime.py`**: `OSRuntime.__init__` prunes once at **top-level** run start (`parent_run_id is None` → sub-runs skip the redundant sweep); emits `control_ir_offload_pruned` (P6) when any dir is removed.

## Why TTL, not eager per-run delete

Offload files are `file.read` by the LLM during the producing run **including its resume window**. Eager end-of-run deletion would break resume (the restored `control_ir_results` still carry `_offload_ref` paths). TTL by mtime preserves active + recently-completed (resume-reachable) runs while bounding accumulation.

## Test plan

- [x] `pytest tests/test_offload_prune_ttl_224.py` (no-mock, Tier 2, deterministic via injected `now`): stale pruned / recent kept; missing-root no-op; non-dir entries ignored; freshly-created dir survives default TTL — green
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations
- [x] offload / runtime / resume / control_ir / e2e / orchestrator / memo sweep (430) — green
- [ ] (CI) full-rootdir `pytest -q` — local editable install broken (pre-existing ~60k spurious collection errors); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)