### PR TITLE
feat(fp-0008): #1115 Stage 2 — DockerEnvironmentBackend (dual-Protocol, bridge-free)

### DIFF
--- a/src/reyn/environment/__init__.py
+++ b/src/reyn/environment/__init__.py
@@ -6,6 +6,12 @@ local Python filesystem; a container backend (Stage 2) lets the repo FS live in
 a container while the OS + permission layer stay host-side.
 """
 from reyn.environment.backend import EnvironmentBackend, GrepResult
+from reyn.environment.container_backend import DockerEnvironmentBackend
 from reyn.environment.host_backend import HostBackend
 
-__all__ = ["EnvironmentBackend", "GrepResult", "HostBackend"]
+__all__ = [
+    "DockerEnvironmentBackend",
+    "EnvironmentBackend",
+    "GrepResult",
+    "HostBackend",
+]

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -1,0 +1,328 @@
+"""DockerEnvironmentBackend — repo FS + exec INSIDE a Docker container (FP-0008 #1115 Stage 2).
+
+One class implementing BOTH Protocols (案C-pure):
+  - :class:`~reyn.environment.backend.EnvironmentBackend` — repo filesystem ops
+    run *inside* the container against ``repo_dir`` (e.g. ``/testbed``);
+  - :class:`~reyn.sandbox.backend.SandboxBackend` — ``run()`` exec inside the
+    same container.
+
+Injecting the SAME instance at ``Workspace.environment_backend`` (FS) and
+``OpContext.sandbox_backend`` (exec) makes file edits + commands hit one
+container target — the agent edits ``/testbed`` directly, so there is **no
+host-diff bridge** (unlike the interim FP-0017/PR-A ``DockerSandboxBackend``,
+whose ``git diff host → reset → apply into container`` logic is deliberately
+DROPPED here — that bridge, and the per-call reset / tracked-untracked
+gymnastics, were artifacts of file-on-host / exec-in-container divergence).
+``run()`` is a plain ``docker exec`` because the files are already in
+``repo_dir``.
+
+Fidelity: FS ops are executed as ``docker exec <c> python3 -c <script> <args>``
+so the container reproduces the EXACT Python filesystem semantics of
+:class:`~reyn.environment.host_backend.HostBackend` (stat dict shape, ``glob``
+recursive ``**``, ``grep`` Python-``re`` matching) rather than shell tools whose
+semantics differ. This is the exec-per-op MVP (one ``docker exec`` per FS op);
+a persistent in-container IO-responder is a later optimization.
+
+Axis-agnostic / P7-clean: no skill / phase / artifact strings; bound to a
+``(container, repo_dir)`` pair. FS uses a sync runner (the EnvironmentBackend
+Protocol is sync, matching Workspace); ``run()`` uses an async runner (the
+SandboxBackend Protocol is async). Both are injectable so the orchestration is
+unit-testable without a live Docker daemon.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Pattern
+
+from reyn.environment.backend import GrepResult
+from reyn.sandbox.backend import SandboxResult
+from reyn.sandbox.policy import SandboxPolicy
+
+# Sync runner: execute argv (optionally stdin), return SandboxResult. Injected so
+# the FS-op orchestration is testable without Docker; default = _sync_runner.
+SyncRunner = Callable[..., SandboxResult]
+# Async runner: same contract for run() (mirrors PR-A DockerSandboxBackend).
+AsyncRunner = Callable[..., Awaitable[SandboxResult]]
+
+
+def _sync_runner(
+    argv: list[str], *, stdin: bytes | None = None, timeout: int | None = None
+) -> SandboxResult:
+    """Real sync runner: spawn argv via ``subprocess.run`` and capture output."""
+    try:
+        completed = subprocess.run(
+            argv, input=stdin, capture_output=True, timeout=timeout, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return SandboxResult(
+            returncode=-1, stdout=b"", stderr=f"timed out after {timeout}s".encode(),
+        )
+    return SandboxResult(
+        returncode=completed.returncode, stdout=completed.stdout or b"", stderr=completed.stderr or b"",
+    )
+
+
+async def _async_runner(
+    argv: list[str], *, stdin: bytes | None = None, timeout: int | None = None
+) -> SandboxResult:
+    """Real async runner for run() (mirrors PR-A's _subprocess_runner)."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(input=stdin), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return SandboxResult(returncode=-1, stdout=b"", stderr=f"timed out after {timeout}s".encode())
+    return SandboxResult(
+        returncode=proc.returncode if proc.returncode is not None else -1,
+        stdout=out or b"", stderr=err or b"",
+    )
+
+
+# ── In-container Python snippets (read args from sys.argv; emit on stdout) ────
+# Paths are passed as argv (NOT interpolated into the script) so no shell/Python
+# quoting hazard. Structured results are JSON on stdout; bytes are raw stdout.
+
+_READ = (
+    "import sys,os\n"
+    "p=sys.argv[1]\n"
+    "if not os.path.exists(p): sys.exit(7)\n"
+    "sys.stdout.buffer.write(open(p,'rb').read())\n"
+)
+_WRITE = (
+    "import sys,os\n"
+    "p=sys.argv[1]\n"
+    "d=os.path.dirname(p)\n"
+    "if d: os.makedirs(d,exist_ok=True)\n"
+    "open(p,'wb').write(sys.stdin.buffer.read())\n"
+)
+_DELETE = (
+    "import sys,os\n"
+    "p=sys.argv[1]\n"
+    "if os.path.exists(p) and os.path.isfile(p):\n"
+    "  os.unlink(p); print('1')\n"
+    "else:\n"
+    "  print('0')\n"
+)
+_MKDIR = (
+    "import sys,os\n"
+    "p=sys.argv[1]; parents=sys.argv[2]=='1'\n"
+    "if os.path.exists(p):\n"
+    "  print('exists' if os.path.isdir(p) else 'notdir')\n"
+    "else:\n"
+    "  (os.makedirs if parents else os.mkdir)(p)\n"
+    "  print('created')\n"
+)
+_MOVE = (
+    "import sys,os,shutil\n"
+    "s=sys.argv[1]; d=sys.argv[2]\n"
+    "if not os.path.exists(s):\n"
+    "  print('0')\n"
+    "else:\n"
+    "  pd=os.path.dirname(d)\n"
+    "  os.makedirs(pd,exist_ok=True) if pd else None\n"
+    "  shutil.move(s,d); print('1')\n"
+)
+_STAT = (
+    "import sys,os,json\n"
+    "p=sys.argv[1]\n"
+    "if not os.path.exists(p):\n"
+    "  print('null')\n"
+    "else:\n"
+    "  st=os.stat(p)\n"
+    "  print(json.dumps({'size':st.st_size,'mtime':st.st_mtime,'ctime':st.st_ctime,"
+    "'is_dir':os.path.isdir(p),'is_file':os.path.isfile(p),'mode':oct(st.st_mode & 0o777)}))\n"
+)
+_GLOB = (
+    "import sys,glob,json,os\n"
+    "pat=sys.argv[1]; root=sys.argv[2]\n"
+    "if root:\n"
+    "  import pathlib; res=[str(x) for x in pathlib.Path(root).glob(pat)]\n"
+    "else:\n"
+    "  res=glob.glob(pat,recursive=True)\n"
+    "print(json.dumps(res))\n"
+)
+# grep: argv = pattern, flags, root, glob_or_'', file_type_or_'', output_mode,
+#       head_limit_or_'-1', context_before, context_after
+_GREP = (
+    "import sys,re,json,os,pathlib\n"
+    "pat,flags,root,g,ft,mode,hl,cb,ca=sys.argv[1:10]\n"
+    "rx=re.compile(pat,int(flags)); hl=int(hl); cb=int(cb); ca=int(ca)\n"
+    "rp=pathlib.Path(root)\n"
+    "cands=[rp] if rp.is_file() else sorted(f for f in rp.glob(g or '**/*') if f.is_file())\n"
+    "cands=[f for f in cands if (not ft or f.suffix.lstrip('.')==ft.lstrip('.'))]\n"
+    "out={'output_mode':mode,'files':[],'count':0,'matches':[]}\n"
+    "if mode=='files_with_matches':\n"
+    "  for f in cands:\n"
+    "    try:\n"
+    "      if rx.search(f.read_text('utf-8','replace')): out['files'].append(str(f))\n"
+    "    except OSError: pass\n"
+    "elif mode=='count':\n"
+    "  t=0\n"
+    "  for f in cands:\n"
+    "    try: t+=len(rx.findall(f.read_text('utf-8','replace')))\n"
+    "    except OSError: pass\n"
+    "  out['count']=t\n"
+    "else:\n"
+    "  done=False\n"
+    "  for f in cands:\n"
+    "    if done: break\n"
+    "    try: lines=f.read_text('utf-8','replace').splitlines()\n"
+    "    except OSError: continue\n"
+    "    for i,line in enumerate(lines):\n"
+    "      if not rx.search(line): continue\n"
+    "      e={'path':str(f),'line_number':i+1,'content':line}\n"
+    "      if cb or ca:\n"
+    "        s=max(0,i-cb); en=min(len(lines),i+ca+1)\n"
+    "        e['context']=[{'line_number':j+1,'content':lines[j],'is_match':j==i} for j in range(s,en)]\n"
+    "      out['matches'].append(e)\n"
+    "      if hl>=0 and len(out['matches'])>=hl: done=True; break\n"
+    "print(json.dumps(out))\n"
+)
+
+
+class DockerEnvironmentBackend:
+    """Repo FS + exec inside a Docker container (dual-Protocol, bridge-free)."""
+
+    name: str = "docker"
+
+    def __init__(
+        self,
+        *,
+        container: str,
+        repo_dir: str,
+        docker_bin: str = "docker",
+        python_bin: str = "python3",
+        fs_runner: SyncRunner | None = None,
+        runner: AsyncRunner | None = None,
+    ) -> None:
+        self.container = container
+        self.repo_dir = repo_dir
+        self.docker_bin = docker_bin
+        self.python_bin = python_bin
+        self._fs_runner: SyncRunner = fs_runner or _sync_runner
+        self._runner: AsyncRunner = runner or _async_runner
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+
+    def _py(self, script: str, *args: str, stdin: bytes | None = None) -> SandboxResult:
+        # `python3 -c CODE a b` → sys.argv == ['-c', 'a', 'b'] (args start at [1]).
+        # Paths/patterns go as argv (NOT interpolated into CODE) — quote/newline
+        # safe + no injection (lead-coder Stage 2 review-gate).
+        argv = [
+            self.docker_bin, "exec", *(["-i"] if stdin is not None else []),
+            self.container, self.python_bin, "-c", script, *args,
+        ]
+        return self._fs_runner(argv, stdin=stdin)
+
+    @staticmethod
+    def _ok(res: SandboxResult) -> bool:
+        return res.returncode == 0
+
+    # ── EnvironmentBackend (FS, sync — executed in-container) ──────────────────
+
+    def read_bytes(self, path: Path) -> bytes | None:
+        res = self._py(_READ, str(path))
+        if res.returncode == 7:
+            return None
+        if res.returncode != 0:
+            return None
+        return res.stdout
+
+    def write_bytes(self, path: Path, data: bytes) -> None:
+        res = self._py(_WRITE, str(path), stdin=data)
+        if not self._ok(res):
+            raise OSError(f"container write failed for {path}: {res.stderr.decode('utf-8','replace')}")
+
+    def delete(self, path: Path) -> bool:
+        res = self._py(_DELETE, str(path))
+        return self._ok(res) and res.stdout.strip() == b"1"
+
+    def mkdir(self, path: Path, *, parents: bool = True) -> bool:
+        res = self._py(_MKDIR, str(path), "1" if parents else "0")
+        token = res.stdout.strip()
+        if token == b"notdir":
+            raise FileExistsError(f"path exists but is not a directory: {str(path)!r}")
+        return token == b"created"
+
+    def move(self, src: Path, dst: Path) -> bool:
+        res = self._py(_MOVE, str(src), str(dst))
+        return self._ok(res) and res.stdout.strip() == b"1"
+
+    def stat(self, path: Path) -> dict | None:
+        res = self._py(_STAT, str(path))
+        if not self._ok(res):
+            return None
+        payload = res.stdout.decode("utf-8", "replace").strip()
+        if payload == "null" or not payload:
+            return None
+        return json.loads(payload)
+
+    def glob(self, pattern: str, *, root: Path | None = None) -> list[Path]:
+        res = self._py(_GLOB, pattern, str(root) if root is not None else "")
+        if not self._ok(res):
+            return []
+        return [Path(s) for s in json.loads(res.stdout.decode("utf-8", "replace") or "[]")]
+
+    def grep(
+        self,
+        root: Path,
+        regex: Pattern[str],
+        *,
+        glob: str | None = None,
+        file_type: str | None = None,
+        output_mode: str = "content",
+        head_limit: int | None = None,
+        context_before: int = 0,
+        context_after: int = 0,
+    ) -> GrepResult:
+        res = self._py(
+            _GREP,
+            regex.pattern, str(regex.flags), str(root), glob or "", file_type or "",
+            output_mode, str(head_limit if head_limit is not None else -1),
+            str(context_before), str(context_after),
+        )
+        if not self._ok(res):
+            return GrepResult(output_mode=output_mode)
+        data: dict[str, Any] = json.loads(res.stdout.decode("utf-8", "replace") or "{}")
+        return GrepResult(
+            output_mode=data.get("output_mode", output_mode),
+            files=[Path(s) for s in data.get("files", [])],
+            count=int(data.get("count", 0)),
+            matches=[{**m, "path": Path(m["path"])} for m in data.get("matches", [])],
+        )
+
+    # ── SandboxBackend (exec, async — plain container exec, NO bridge) ─────────
+
+    def available(self) -> bool:
+        """True when the docker binary exists and the daemon is reachable."""
+        if shutil.which(self.docker_bin) is None:
+            return False
+        try:
+            completed = subprocess.run(
+                [self.docker_bin, "info"], capture_output=True, timeout=10, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return completed.returncode == 0
+
+    async def run(
+        self, argv: list[str], policy: SandboxPolicy, *, stdin: bytes | None = None,
+    ) -> SandboxResult:
+        """Plain ``docker exec`` of argv with cwd=repo_dir — NO host-diff bridge.
+
+        The files are already in ``repo_dir`` (the agent edited them via the FS
+        methods above), so there is nothing to sync in. Honors only
+        ``policy.timeout_seconds`` (the fidelity boundary, as in PR-A).
+        """
+        exec_argv = [self.docker_bin, "exec", "-w", self.repo_dir, self.container, *argv]
+        return await self._runner(exec_argv, stdin=stdin, timeout=policy.timeout_seconds)

--- a/tests/test_container_backend_1115_stage2.py
+++ b/tests/test_container_backend_1115_stage2.py
@@ -1,0 +1,160 @@
+"""Tier 2: FP-0008 #1115 Stage 2 — DockerEnvironmentBackend (dual-Protocol, bridge-free).
+
+The container backend implements BOTH EnvironmentBackend (repo FS) and
+SandboxBackend (exec), executing FS ops as in-container ``python3 -c`` so the
+container reproduces HostBackend's exact Python semantics. ``run()`` is a plain
+``docker exec`` — NO host-diff bridge.
+
+These tests use a real **local** runner Fake (not a mock): it strips the
+``docker exec`` prefix and runs the SAME ``python3 -c <script> <args>`` on the
+LOCAL interpreter against a real tmp filesystem. So the actual in-container
+snippets are exercised end-to-end (Python-semantics parity), just without a
+live Docker daemon.
+
+Pins:
+  (a) the backend satisfies BOTH Protocols (EnvironmentBackend + SandboxBackend);
+  (b) every FS op produces the SAME result as HostBackend (semantics parity);
+  (c) run() is a plain `docker exec -w <repo_dir> <container> <argv>` with NO
+      diff / reset / apply bridge steps;
+  (d) FS args are passed via argv (path with shell-special chars round-trips).
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.environment.backend import EnvironmentBackend
+from reyn.environment.container_backend import DockerEnvironmentBackend
+from reyn.environment.host_backend import HostBackend
+from reyn.sandbox.backend import SandboxBackend, SandboxResult
+from reyn.sandbox.policy import SandboxPolicy
+
+
+def _local_docker_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+    """Fake: strip the `docker exec … python3 -c SCRIPT ARGS` prefix and run
+    SCRIPT locally on the test interpreter against the real (tmp) filesystem."""
+    i = argv.index("-c")
+    local = [sys.executable, "-c", argv[i + 1], *argv[i + 2:]]
+    completed = subprocess.run(local, input=stdin, capture_output=True, check=False)
+    return SandboxResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout or b"",
+        stderr=completed.stderr or b"",
+    )
+
+
+def _backend(repo_dir: Path) -> DockerEnvironmentBackend:
+    return DockerEnvironmentBackend(
+        container="testc", repo_dir=str(repo_dir), fs_runner=_local_docker_runner,
+    )
+
+
+def test_satisfies_both_protocols(tmp_path: Path) -> None:
+    """Tier 2: (a) one class is both an EnvironmentBackend and a SandboxBackend."""
+    be = _backend(tmp_path)
+    assert isinstance(be, EnvironmentBackend)
+    assert isinstance(be, SandboxBackend)
+    assert be.name == "docker"
+
+
+def test_fs_ops_match_host_backend_semantics(tmp_path: Path) -> None:
+    """Tier 2: (b) every FS op behaves identically to HostBackend.
+
+    Run the same op on HostBackend (real local FS) and the container backend
+    (in-container snippet, also hitting the real local FS via the Fake runner)
+    and assert equal results — the Python-semantics parity guarantee.
+    """
+    host = HostBackend()
+    cont = _backend(tmp_path)
+
+    f = tmp_path / "dir" / "a.txt"
+
+    # read (missing) → None on both
+    assert host.read_bytes(f) is None
+    assert cont.read_bytes(f) is None
+
+    # write → read round-trip identical
+    cont.write_bytes(f, "héllo-本文\n".encode())
+    assert cont.read_bytes(f) == host.read_bytes(f) == "héllo-本文\n".encode()
+
+    # stat parity (size / flags / mode / mtime)
+    assert cont.stat(f) == host.stat(f)
+    assert cont.stat(tmp_path / "missing") is host.stat(tmp_path / "missing")  # both None
+
+    # mkdir: created / exists / notdir parity
+    d = tmp_path / "newdir"
+    assert cont.mkdir(d) is True
+    assert host.mkdir(d) is False          # already exists as dir
+    assert cont.mkdir(d) is False
+    with pytest.raises(FileExistsError):
+        cont.mkdir(f)                       # a file sits there
+
+    # glob parity (relative under root)
+    assert sorted(str(p) for p in cont.glob("**/*.txt", root=tmp_path)) == \
+        sorted(str(p) for p in host.glob("**/*.txt", root=tmp_path))
+
+    # move parity
+    dst = tmp_path / "moved" / "b.txt"
+    assert cont.move(f, dst) is True
+    assert cont.read_bytes(dst) == "héllo-本文\n".encode()
+    assert cont.move(tmp_path / "nope", dst) is False
+
+    # delete parity
+    assert cont.delete(dst) is True
+    assert cont.delete(dst) is False
+
+
+def test_grep_matches_host_backend(tmp_path: Path) -> None:
+    """Tier 2: (b) grep parity — same matches as HostBackend (Python re in-container)."""
+    host = HostBackend()
+    cont = _backend(tmp_path)
+    (tmp_path / "x.py").write_text("alpha\nNEEDLE here\nbeta\n", encoding="utf-8")
+    (tmp_path / "y.py").write_text("nothing\n", encoding="utf-8")
+
+    rx = re.compile("NEEDLE")
+    h = host.grep(tmp_path, rx, output_mode="files_with_matches")
+    c = cont.grep(tmp_path, rx, output_mode="files_with_matches")
+    assert sorted(str(p) for p in c.files) == sorted(str(p) for p in h.files)
+
+    hc = host.grep(tmp_path, rx)
+    cc = cont.grep(tmp_path, rx)
+    [hhit] = hc.matches
+    [chit] = cc.matches
+    assert chit["line_number"] == hhit["line_number"] == 2
+    assert chit["content"] == hhit["content"]
+
+
+def test_fs_arg_with_special_chars_roundtrips(tmp_path: Path) -> None:
+    """Tier 2: (d) a path with shell-special chars survives (argv-passed, not interpolated)."""
+    cont = _backend(tmp_path)
+    weird = tmp_path / "a b$x;'q.txt"
+    cont.write_bytes(weird, b"ok")
+    assert cont.read_bytes(weird) == b"ok"
+
+
+def test_run_is_plain_docker_exec_no_bridge(tmp_path: Path) -> None:
+    """Tier 2: (c) run() = plain `docker exec -w repo_dir container argv`, no bridge."""
+    calls: list[list[str]] = []
+
+    async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+        calls.append(argv)
+        return SandboxResult(returncode=0, stdout=b"out", stderr=b"")
+
+    import asyncio
+
+    be = DockerEnvironmentBackend(
+        container="testc", repo_dir="/testbed", runner=_record_runner,
+    )
+    res = asyncio.run(be.run(["pytest", "-x"], SandboxPolicy(timeout_seconds=30)))
+
+    assert res.returncode == 0 and res.stdout == b"out"
+    # exactly one exec call — no host-diff / reset / clean / apply steps
+    [argv] = calls
+    assert argv == ["docker", "exec", "-w", "/testbed", "testc", "pytest", "-x"]
+    joined = " ".join(a for c in calls for a in c)
+    for bridge_token in ("diff", "reset", "clean", "apply"):
+        assert bridge_token not in joined, f"bridge step {bridge_token!r} must be absent"


### PR DESCRIPTION
**[e2e-coder]** — #1115 Stage 2 (C7-solving foundation). The container backend that lets the agent edit `/testbed` IN the container with **zero host-diff bridge**. Scope LOCKED with lead-coder (C7 prebuilt-container backend; mode-split + permission unification = Stage 3).

## What this does (案C-pure, lead-coder-confirmed)

ONE class implements BOTH Protocols, so injecting the same instance at `Workspace.environment_backend` (FS) + `OpContext.sandbox_backend` (exec) makes FS + exec hit **one container target**:

- **EnvironmentBackend (repo FS)** — `read_bytes/write_bytes/delete/mkdir/move/stat/glob/grep` run as `docker exec <c> python3 -c <script> <args>`, so the container reproduces **HostBackend's exact Python semantics** (stat dict shape, glob recursive `**`, grep Python-`re`) — not shell tools whose semantics differ. exec-per-op MVP (one `docker exec` per FS op); a persistent in-container IO-responder is a later optimization.
- **SandboxBackend (exec)** — `run()` is a **plain** `docker exec -w repo_dir <c> argv`.

## The bridge is DROPPED (realignment core)

The interim PR-A `DockerSandboxBackend`'s `git diff host → reset → clean → apply into container` logic is **deliberately removed**. Files are already in `repo_dir` (the agent edited them via the FS methods), so per-call reset / tracked-untracked gymnastics vanish — these were artifacts of the file-on-host / exec-in-container divergence this realignment retires.

## Security / escaping

FS args (paths, patterns) are passed **via argv**, never interpolated into the `python3 -c` code — quote/newline safe, no injection (lead-coder review-gate). FS methods are sync (EnvironmentBackend Protocol is sync, matching Workspace); `run()` is async (SandboxBackend Protocol). Both runners injectable. Axis-agnostic / P7-clean.

## Additive only

The backend is **not wired into any run yet** (the C7 harness dual-seam injection is a follow-up), so there is **zero behavior change** to existing host runs.

## Tests (no-mock, Tier 2)

A real **local** runner Fake strips the `docker exec` prefix and runs the SAME in-container snippets on the test interpreter against a real tmp filesystem — so the actual snippets are exercised end-to-end **without a live Docker daemon**:
- both-Protocol conformance (`EnvironmentBackend` + `SandboxBackend`);
- every FS op produces the **same result as HostBackend** (semantics parity, incl. grep matches);
- `run()` = plain `docker exec -w repo_dir container argv` with **NO** diff/reset/clean/apply;
- a path with shell-special chars round-trips (argv-passed).

## Test plan / review gate

- [x] `pytest tests/test_container_backend_1115_stage2.py` (5) — green
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations
- [x] environment / sandbox / workspace sweep (106, 3 docker-skipped) — green
- Review gate: behavior-preservation (host unchanged — additive) ✓ / bridge-logic absent ✓ / Python-semantics parity (vs HostBackend) ✓ / argv-escaping ✓ / backend-name contract (`name="docker"`) ✓
- [ ] (CI) full-rootdir `pytest -q` — local editable install broken (pre-existing); relying on CI.

Follow-up (Stage 2 cont.): C7 harness wires this backend at both seams + the swe_bench verify runs in-container (true clean PASS-rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)