### PR TITLE
feat(fp-0008): #1115 Stage 2 — thread per-run backend injection (Agent→OSRuntime→seams)

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -11,6 +11,8 @@ from reyn.config import OnLimitConfig, SafetyConfig
 
 if TYPE_CHECKING:
     from reyn.config import MultimodalConfig, SandboxConfig
+    from reyn.environment.backend import EnvironmentBackend
+    from reyn.sandbox.backend import SandboxBackend
     from reyn.secrets.store import ScopedSecretStore
     from reyn.workspace.media_store import MediaStore
 from reyn.events.event_store import EventStore
@@ -61,6 +63,8 @@ class Agent:
         secret_store: "ScopedSecretStore | None" = None,
         workspace_base_dir: "Path | None" = None,
         run_id: str | None = None,
+        environment_backend: "EnvironmentBackend | None" = None,
+        sandbox_backend: "SandboxBackend | None" = None,
     ) -> None:
         self.model = model
         self.state_dir = ".reyn"
@@ -88,6 +92,12 @@ class Agent:
         self._media_store = media_store
         self._secret_store = secret_store
         self._workspace_base_dir = workspace_base_dir
+        # FP-0008 #1115 Stage 2: per-run backend injection. The SAME instance
+        # (a dual-Protocol DockerEnvironmentBackend) is passed as BOTH so repo
+        # FS + exec hit one container target; defaults None → host (HostBackend
+        # for FS, get_default_backend for exec) = behavior-preserving.
+        self._environment_backend = environment_backend
+        self._sandbox_backend = sandbox_backend
         self._runtime: OSRuntime | None = None
         # FP-0008 PR-R (= tui-coder finding #1 propagation): run_id from
         # construction site preserves the canonical run_id set by the
@@ -182,6 +192,8 @@ class Agent:
             resume_plan=resume_plan,
             parent_run_id=parent_run_id,
             sandbox_config=self._sandbox_config,
+            environment_backend=self._environment_backend,
+            sandbox_backend=self._sandbox_backend,
             multimodal_config=self._multimodal_config,
             media_store=self._media_store,
             secret_store=self._secret_store,

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from reyn.config import MultimodalConfig, SandboxConfig
+    from reyn.sandbox.backend import SandboxBackend
     from reyn.secrets.store import ScopedSecretStore
     from reyn.workspace.media_store import MediaStore
 
@@ -91,6 +92,7 @@ class ControlIRExecutor:
         resume_plan: Any = None,
         run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
+        sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
@@ -130,6 +132,12 @@ class ControlIRExecutor:
         # policy. ``None`` means the factory falls through to platform
         # auto-detection (= unchanged behavior pre-wiring).
         self._sandbox_config = sandbox_config
+        # FP-0008 #1115 Stage 2: per-run injected exec backend instance. When
+        # set (a dual-Protocol container backend), it takes precedence over
+        # name-based platform selection in the sandboxed_exec handler
+        # (``ctx.sandbox_backend or get_default_backend(...)``). ``None`` =
+        # platform auto-detect (unchanged host behavior).
+        self._sandbox_backend = sandbox_backend
         # Issue #364 — multi-modal media-size gate config (= reyn.yaml
         # ``multimodal:`` section). Threaded into OpContext so binary paths
         # (web__fetch / file__read / MCP / user input) can consult the cap
@@ -318,6 +326,9 @@ class ControlIRExecutor:
             agent_id=getattr(self.events, "agent_id", None),
             # FP-0017 follow-up: declarative sandbox config (reyn.yaml).
             sandbox_config=self._sandbox_config,
+            # FP-0008 #1115 Stage 2: per-run injected exec backend instance
+            # (dual-Protocol container backend); None → platform auto-detect.
+            sandbox_backend=self._sandbox_backend,
             # Issue #364 — multi-modal cluster media-size gate.
             multimodal_config=self._multimodal_config,
             # Issue #383 PR-C — media + tool-result file storage.

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from reyn.events.events import EventLog
     from reyn.llm.model_resolver import ModelResolver
     from reyn.permissions.permissions import PermissionResolver
+    from reyn.sandbox.backend import SandboxBackend
     from reyn.schemas.models import Phase, PreprocessorStep, Skill
     from reyn.secrets.store import ScopedSecretStore
     from reyn.user_intervention import RequestBus
@@ -109,6 +110,7 @@ class PreprocessorExecutor:
         caller: str = "direct",
         run_id: str | None = None,
         secret_store: "ScopedSecretStore | None" = None,
+        sandbox_backend: "SandboxBackend | None" = None,
     ) -> None:
         self._skill = skill
         self._workspace = workspace
@@ -128,6 +130,10 @@ class PreprocessorExecutor:
         # FP-0016 D: per-skill credential scoping. None = unrestricted
         # (= preserves backward compat for callers that don't supply a store).
         self._secret_store = secret_store
+        # FP-0008 #1115 Stage 2: per-run injected exec backend instance, so a
+        # preprocessor sandboxed_exec runs in the same (container) target as the
+        # rest of the run. None → platform auto-detect (unchanged host behavior).
+        self._sandbox_backend = sandbox_backend
 
     @property
     def secret_store(self):
@@ -168,6 +174,8 @@ class PreprocessorExecutor:
             agent_id=getattr(self._events, "agent_id", None),
             # FP-0016 D: per-skill credential scoping.
             secret_store=self._secret_store,
+            # FP-0008 #1115 Stage 2: per-run injected exec backend instance.
+            sandbox_backend=self._sandbox_backend,
         )
 
     async def run(

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -12,7 +12,9 @@ from reyn.schemas.models import CandidateOutput, ContextFrame, Skill
 if TYPE_CHECKING:
     from reyn.budget.budget import BudgetTracker
     from reyn.config import MultimodalConfig, PhaseActResultsCompactionConfig, SandboxConfig
+    from reyn.environment.backend import EnvironmentBackend
     from reyn.events.state_log import StateLog
+    from reyn.sandbox.backend import SandboxBackend
     from reyn.secrets.store import ScopedSecretStore
     from reyn.services.compaction.engine import CompactionEngine
     from reyn.skill.skill_registry import SkillRegistry
@@ -76,6 +78,8 @@ class OSRuntime:
         resume_plan: Any = None,
         parent_run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
+        environment_backend: "EnvironmentBackend | None" = None,
+        sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
@@ -101,6 +105,7 @@ class OSRuntime:
             permission_resolver=permission_resolver,
             skill_name=skill.name,
             base_dir=workspace_base_dir,
+            environment_backend=environment_backend,
         )
         # C5 follow-up (#224): bound the growth of per-run control_ir offload
         # scratch dirs. Prune stale ones (TTL by mtime) once at top-level run
@@ -173,6 +178,7 @@ class OSRuntime:
             resume_plan=resume_plan,
             run_id=run_id,
             sandbox_config=sandbox_config,
+            sandbox_backend=sandbox_backend,
             multimodal_config=multimodal_config,
             media_store=media_store,
             secret_store=secret_store,
@@ -191,6 +197,7 @@ class OSRuntime:
             caller=caller,
             run_id=run_id,
             secret_store=secret_store,
+            sandbox_backend=sandbox_backend,
         )
         # FP-0020 Component A: all mutable run-scope state encapsulated in RunState.
         self._state = RunState()

--- a/tests/test_backend_injection_threading_1115_stage2.py
+++ b/tests/test_backend_injection_threading_1115_stage2.py
@@ -1,0 +1,156 @@
+"""Tier 2: FP-0008 #1115 Stage 2 — per-run backend injection threading.
+
+The C7 harness injects ONE dual-Protocol container backend at both run-level
+seams. This file pins that an injected backend actually reaches those seams
+through the Agent → OSRuntime → {Workspace (FS), OpContext (exec)} threading
+added for Stage 2:
+
+  (a) an injected ``environment_backend`` reaches Workspace FS ops (so repo
+      file ops would hit the container);
+  (b) an injected ``sandbox_backend`` reaches the sandboxed_exec OpContext (so
+      exec would hit the same container) — both via ControlIRExecutor and via
+      PreprocessorExecutor.
+
+No mocks: a real recording EnvironmentBackend Fake + the (real, non-mock)
+SandboxBackend stub pattern from test_op_sandboxed_exec.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.environment.host_backend import HostBackend
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+from reyn.kernel.runtime import OSRuntime
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.sandbox.backend import SandboxResult
+from reyn.schemas.models import Phase, RunOpStep, SandboxedExecIROp, Skill, SkillGraph
+from reyn.workspace.workspace import Workspace
+
+
+class _RecordingEnvBackend:
+    """Real EnvironmentBackend Fake recording which ops it served (delegates IO)."""
+
+    name = "recording"
+
+    def __init__(self) -> None:
+        self._inner = HostBackend()
+        self.calls: list[str] = []
+
+    def read_bytes(self, p): self.calls.append("read_bytes"); return self._inner.read_bytes(p)
+    def write_bytes(self, p, d): self.calls.append("write_bytes"); self._inner.write_bytes(p, d)
+    def delete(self, p): self.calls.append("delete"); return self._inner.delete(p)
+    def mkdir(self, p, *, parents=True): self.calls.append("mkdir"); return self._inner.mkdir(p, parents=parents)
+    def move(self, s, d): self.calls.append("move"); return self._inner.move(s, d)
+    def stat(self, p): self.calls.append("stat"); return self._inner.stat(p)
+    def glob(self, pat, *, root=None): self.calls.append("glob"); return self._inner.glob(pat, root=root)
+    def grep(self, root, rx, **kw): self.calls.append("grep"); return self._inner.grep(root, rx, **kw)
+
+
+class _StubExecBackend:
+    """Real (non-mock) SandboxBackend stub — proves the injected exec backend ran."""
+
+    name = "stub-injected"
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None) -> SandboxResult:
+        return SandboxResult(returncode=0, stdout=b"from-stub", stderr=b"")
+
+
+def _one_phase_skill() -> Skill:
+    p = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}}, allowed_ops=[],
+    )
+    return Skill(
+        name="thread_test", entry_phase="draft", phases={"draft": p},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}}, final_output_name="result",
+    )
+
+
+def test_osruntime_threads_environment_backend_to_workspace(tmp_path: Path) -> None:
+    """Tier 2: (a) an injected environment_backend serves the run's workspace FS."""
+    rec = _RecordingEnvBackend()
+    rt = OSRuntime(
+        _one_phase_skill(), model="stub/model", run_id="r1",
+        workspace_base_dir=tmp_path, environment_backend=rec,
+    )
+    rt.workspace.write_file("note.txt", "hi")
+    content, found = rt.workspace.read_file("note.txt")
+
+    assert (content, found) == ("hi", True)
+    assert "write_bytes" in rec.calls and "read_bytes" in rec.calls
+
+
+def _sandboxed_exec_executor(tmp_path: Path) -> ControlIRExecutor:
+    events = EventLog()
+    return ControlIRExecutor(
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        events=events,
+        permission_resolver=PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False),
+        skill_name="thread_test",
+        sandbox_backend=_StubExecBackend(),
+    )
+
+
+def test_control_ir_executor_threads_sandbox_backend_to_op_context(tmp_path: Path) -> None:
+    """Tier 2: (b) an injected sandbox_backend reaches the sandboxed_exec OpContext.
+
+    Run a sandboxed_exec op through the executor (constructed with the injected
+    backend) and assert the injected instance ran — proving _build_ctx threaded
+    sandbox_backend onto the OpContext.
+    """
+    executor = _sandboxed_exec_executor(tmp_path)
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec", argv=["/bin/echo", "x"],
+        env_passthrough=["PATH"], timeout_seconds=10,
+    )
+    results = asyncio.run(
+        executor.execute([op], phase="p", decl=PermissionDecl(), allowed_ops={"sandboxed_exec"})
+    )
+    [res] = results
+    assert res["backend"] == "stub-injected"
+    assert res["stdout"] == "from-stub"
+
+
+def test_preprocessor_executor_accepts_sandbox_backend(tmp_path: Path) -> None:
+    """Tier 2: (b) PreprocessorExecutor threads sandbox_backend onto its OpContext.
+
+    A preprocessor sandboxed_exec must hit the same injected backend, so the
+    executor stores it and builds it into the op context. Run a one-step
+    preprocessor with a sandboxed_exec run_op and assert the injected backend ran.
+    """
+    from reyn.events.events import EventLog
+
+    events = EventLog()
+    skill = _one_phase_skill()
+    phase = Phase(
+        name="pp", instructions="d", input_schema={"type": "object", "properties": {}},
+        allowed_ops=["sandboxed_exec"],
+        preprocessor=[
+            RunOpStep(
+                type="run_op",
+                op=SandboxedExecIROp(
+                    kind="sandboxed_exec", argv=["/bin/echo", "x"],
+                    env_passthrough=["PATH"], timeout_seconds=10,
+                ),
+                into="data._exec",
+            )
+        ],
+    )
+    pe = PreprocessorExecutor(
+        skill=skill,
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        model="standard", events=events, subscribers=[], resolver=None,
+        permission_resolver=PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False),
+        sandbox_backend=_StubExecBackend(),
+    )
+    enriched, _usage = asyncio.run(pe.run(phase, {"type": "x", "data": {}}, None))
+    assert enriched["data"]["_exec"]["backend"] == "stub-injected"


### PR DESCRIPTION
**[e2e-coder]** — #1115 Stage 2 cont. (C7 harness wiring, part 1 of 2). The run-level injection capability so the C7 harness can pass ONE dual-Protocol container backend (#1120 `DockerEnvironmentBackend`) at both seams → repo FS + exec hit one container target.

## What this does

- **Agent + OSRuntime** gain `environment_backend` + `sandbox_backend` params (defaults `None` → host: `HostBackend` for FS, `get_default_backend` for exec = behavior-preserving).
- **`environment_backend` → Workspace** (FS ops route into the backend — the Stage 1 seam).
- **`sandbox_backend` → `OpContext.sandbox_backend`** (the PR-A exec seam), threaded through BOTH `ControlIRExecutor._build_ctx` AND `PreprocessorExecutor._build_op_ctx` so a preprocessor `sandboxed_exec` hits the same target. Mirrors the existing `sandbox_config` threading exactly.

## Additive only

No caller injects a non-default backend yet — the **C7 benchmark wiring** (build the container + inject `DockerEnvironmentBackend` at both seams) and the **interim `DockerSandboxBackend` removal** are the **next PR** (they need docker + are the consumer/cleanup). So this PR is **zero behavior change** to existing host runs.

## Tests (no-mock, Tier 2)

- an injected `environment_backend` serves the run's workspace FS (recording-Fake via a real `OSRuntime`);
- an injected `sandbox_backend` reaches the `sandboxed_exec` OpContext through **both** the ControlIRExecutor path and the PreprocessorExecutor path — a real (non-mock) SandboxBackend stub runs → result `backend == "stub-injected"`.

## Test plan

- [x] `pytest tests/test_backend_injection_threading_1115_stage2.py` (3) — green
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations
- [x] runtime / orchestrator / preprocessor / agent / sandbox / resume / swe_bench / container-backend sweep (567) — green
- [ ] (CI) full-rootdir `pytest -q` — local editable install broken (pre-existing); relying on CI.

Next (Stage 2 cont., part 2): C7 benchmark builds the pre-built container + injects `DockerEnvironmentBackend` at both seams + removes the interim apply-into-prebuilt `DockerSandboxBackend`. The actual faithful PASS-rate measurement is a separate slot (faithful conditions only — no confounded number, task #183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)