### PR TITLE
feat(fp-0008): #1115 Stage 2 — thread workspace_state_dir (Agent→OSRuntime→Workspace)

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -62,6 +62,7 @@ class Agent:
         media_store: "MediaStore | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
         workspace_base_dir: "Path | None" = None,
+        workspace_state_dir: "Path | None" = None,
         run_id: str | None = None,
         environment_backend: "EnvironmentBackend | None" = None,
         sandbox_backend: "SandboxBackend | None" = None,
@@ -92,6 +93,12 @@ class Agent:
         self._media_store = media_store
         self._secret_store = secret_store
         self._workspace_base_dir = workspace_base_dir
+        # FP-0008 #1115 Stage 2: host-side workspace state_dir (artifacts +
+        # events), decoupled from base_dir. For an in-container run base_dir is
+        # the container repo (e.g. /testbed) while state_dir stays on the host
+        # so artifacts/events survive container teardown (Stage 0 decouple).
+        # None → Workspace default (base_dir/.reyn = unchanged host behavior).
+        self._workspace_state_dir = workspace_state_dir
         # FP-0008 #1115 Stage 2: per-run backend injection. The SAME instance
         # (a dual-Protocol DockerEnvironmentBackend) is passed as BOTH so repo
         # FS + exec hit one container target; defaults None → host (HostBackend
@@ -199,6 +206,7 @@ class Agent:
             secret_store=self._secret_store,
             plan_step=plan_step,
             workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
         )
         return await self._runtime.run(initial_input, output_language=output_language)
 

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -85,6 +85,7 @@ class OSRuntime:
         secret_store: "ScopedSecretStore | None" = None,
         plan_step: dict | None = None,
         workspace_base_dir: "Path | None" = None,
+        workspace_state_dir: "Path | None" = None,
         phase_compaction_engine: "CompactionEngine | None" = None,
         phase_compaction_cfg: "PhaseActResultsCompactionConfig | None" = None,
     ) -> None:
@@ -105,6 +106,7 @@ class OSRuntime:
             permission_resolver=permission_resolver,
             skill_name=skill.name,
             base_dir=workspace_base_dir,
+            state_dir=workspace_state_dir,
             environment_backend=environment_backend,
         )
         # C5 follow-up (#224): bound the growth of per-run control_ir offload

--- a/tests/test_state_dir_threading_1115_stage2.py
+++ b/tests/test_state_dir_threading_1115_stage2.py
@@ -1,0 +1,60 @@
+"""Tier 2: FP-0008 #1115 Stage 2 — workspace state_dir threading.
+
+For an in-container run, the workspace base_dir is the container repo (e.g.
+``/testbed``) while the state_dir (artifacts + events) must stay on the HOST so
+they survive container teardown (the Stage 0 decouple). This needs base_dir and
+state_dir to be threadable independently from the run construction.
+
+Pins (public surface only — no mocks):
+  (a) OSRuntime threads workspace_state_dir → Workspace.state_dir, decoupled
+      from base_dir;
+  (b) default (no workspace_state_dir) keeps the legacy base_dir/.reyn = host
+      behavior unchanged.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.kernel.runtime import OSRuntime
+from reyn.schemas.models import Phase, Skill, SkillGraph
+
+
+def _one_phase_skill() -> Skill:
+    p = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}}, allowed_ops=[],
+    )
+    return Skill(
+        name="state_dir_test", entry_phase="draft", phases={"draft": p},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}}, final_output_name="result",
+    )
+
+
+def test_state_dir_threads_decoupled_from_base_dir(tmp_path: Path) -> None:
+    """Tier 2: (a) workspace_state_dir is honored independently of base_dir."""
+    base = tmp_path / "container_testbed"
+    base.mkdir()
+    host_state = tmp_path / "host_state"
+
+    rt = OSRuntime(
+        _one_phase_skill(), model="stub/model", run_id="r1",
+        workspace_base_dir=base, workspace_state_dir=host_state,
+    )
+
+    assert rt.workspace.base_dir == base.resolve()
+    assert rt.workspace.state_dir == host_state.resolve()
+    assert not rt.workspace.state_dir.is_relative_to(rt.workspace.base_dir)
+    # artifacts live under the host state_dir, not the (container) base_dir.
+    assert (host_state / "artifacts").is_dir()
+
+
+def test_default_state_dir_is_base_dir_reyn(tmp_path: Path) -> None:
+    """Tier 2: (b) without workspace_state_dir, state_dir = base_dir/.reyn (host)."""
+    base = tmp_path / "repo"
+    base.mkdir()
+    rt = OSRuntime(
+        _one_phase_skill(), model="stub/model", run_id="r2",
+        workspace_base_dir=base,
+    )
+    assert rt.workspace.state_dir == (base / ".reyn").resolve()


### PR DESCRIPTION
**[e2e-coder]** — #1115 Stage 2 cont. (C7 in-container prerequisite). Threads `workspace_state_dir` so a run can have base_dir in the container (`/testbed`) while artifacts + events stay on the host.

## Why

For an in-container run, the workspace `base_dir` is the container repo (`/testbed`), but the `state_dir` (artifacts + events) must stay on the **host** so they survive container teardown — the Stage 0 decouple. This needs `base_dir` and `state_dir` threadable independently from the run construction.

## What

- **Agent + OSRuntime** gain a `workspace_state_dir` param → `Workspace(state_dir=)`. Named to avoid collision with `Agent.state_dir` (the host event-store path). Default `None` → `Workspace` default (`base_dir/.reyn`) = unchanged host behavior.

## Additive only

No caller passes it yet — the C7 benchmark wiring will (with `base_dir=/testbed` + `state_dir=host`). Zero behavior change to existing runs.

## Test plan

- [x] `pytest tests/test_state_dir_threading_1115_stage2.py` (2, public-surface, no-mock) — green
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations
- [x] agent / runtime / workspace / resume sweep (370) — green
- [ ] (CI) full-rootdir `pytest -q` — local editable install broken (pre-existing); relying on CI.

Part of the part-2-full arc (lead-coder-confirmed, user-supervised): state_dir threading (this) → exec-routing migration (swe_bench skill shell→sandboxed_exec, A) → container lifecycle + in-container model_patch + #1112 removal → live faithful run (#183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)