### PR TITLE
feat(fp-0008): #1115 Stage 2 (D) — phase default_sandbox_policy mechanism

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -291,7 +291,12 @@ class ControlIRExecutor:
             ),
         ]
 
-    def _build_ctx(self, decl: PermissionDecl, current_phase: str) -> OpContext:
+    def _build_ctx(
+        self,
+        decl: PermissionDecl,
+        current_phase: str,
+        default_sandbox_policy: dict | None = None,
+    ) -> OpContext:
         """Construct the OpContext for a single dispatch iteration."""
         return OpContext(
             workspace=self.workspace,
@@ -329,6 +334,9 @@ class ControlIRExecutor:
             # FP-0008 #1115 Stage 2: per-run injected exec backend instance
             # (dual-Protocol container backend); None → platform auto-detect.
             sandbox_backend=self._sandbox_backend,
+            # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy
+            # (frontmatter); sandboxed_exec applies it phase-default-wins.
+            default_sandbox_policy=default_sandbox_policy,
             # Issue #364 — multi-modal cluster media-size gate.
             multimodal_config=self._multimodal_config,
             # Issue #383 PR-C — media + tool-result file storage.
@@ -363,6 +371,7 @@ class ControlIRExecutor:
         phase: str = "",
         decl: PermissionDecl | None = None,
         allowed_ops: set[str] | None = None,
+        default_sandbox_policy: dict | None = None,
     ) -> list[dict[str, Any]]:
         """Execute a list of Control IR operations.
 
@@ -376,7 +385,7 @@ class ControlIRExecutor:
         the existing tool_executed events emitted by op_runtime handlers.
         """
         effective_decl = decl or PermissionDecl()
-        ctx = self._build_ctx(effective_decl, phase)
+        ctx = self._build_ctx(effective_decl, phase, default_sandbox_policy)
         results: list[dict[str, Any]] = []
 
         # Build a tool catalog for dispatch_tool name/arg validation.

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -465,6 +465,9 @@ class PhaseExecutor:
             allowed_ops = set(phase_def.allowed_ops) if phase_def is not None else None
             ir_results = await self._control_ir_executor.execute(
                 act.ops, phase=phase, decl=phase_decl, allowed_ops=allowed_ops,
+                default_sandbox_policy=(
+                    phase_def.default_sandbox_policy if phase_def is not None else None
+                ),
             )
             control_ir_results = control_ir_results + ir_results
             prior_attempts = []

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -176,6 +176,9 @@ class PreprocessorExecutor:
             secret_store=self._secret_store,
             # FP-0008 #1115 Stage 2: per-run injected exec backend instance.
             sandbox_backend=self._sandbox_backend,
+            # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy so a
+            # preprocessor sandboxed_exec uses the phase's declared policy.
+            default_sandbox_policy=phase.default_sandbox_policy,
         )
 
     async def run(

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -640,6 +640,9 @@ class RunOrchestrator:
                 decide_results = await self._phase_executor._control_ir_executor.execute(
                     output.ops, phase=current_phase, decl=current_decl,
                     allowed_ops=current_allowed,
+                    default_sandbox_policy=(
+                        current_def.default_sandbox_policy if current_def is not None else None
+                    ),
                 )
                 if decide_results:
                     self._events.emit(

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -110,6 +110,13 @@ class OpContext:
     # one; None preserves the default name-based platform auto-selection.
     sandbox_backend: "SandboxBackend | None" = None
 
+    # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy (dict of
+    # SandboxPolicy kwargs) declared in the phase frontmatter. When set, the
+    # sandboxed_exec handler builds the policy from this (phase-default WINS over
+    # the op's own fields) so a skill declares the policy once + the LLM cannot
+    # override it (deterministic + P8-clean). None → use the op-level fields.
+    default_sandbox_policy: dict | None = None
+
     # Issue #364: declarative cap on binary media size (= images from
     # web__fetch / file__read / MCP / user input). When None, the gate
     # is skipped — direct-OpContext constructions in tests stay

--- a/src/reyn/op_runtime/sandboxed_exec.py
+++ b/src/reyn/op_runtime/sandboxed_exec.py
@@ -28,14 +28,21 @@ async def handle(
     # route exec into a stateful backend (e.g. a Docker container) that the
     # name-based factory cannot build, without the handler knowing the caller.
     backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)
-    policy = SandboxPolicy(
-        network=op.network,
-        read_paths=list(op.read_paths),
-        write_paths=list(op.write_paths),
-        allow_subprocess=op.allow_subprocess,
-        env_passthrough=list(op.env_passthrough),
-        timeout_seconds=op.timeout_seconds,
-    )
+    # FP-0008 #1115 Stage 2 (D): a phase-level default_sandbox_policy (declared
+    # in the phase frontmatter, P8-clean) WINS over the op's own fields — so the
+    # policy is deterministic and the LLM cannot override it. Falls back to the
+    # op-level fields when no phase default is set (unchanged behavior).
+    if ctx.default_sandbox_policy is not None:
+        policy = SandboxPolicy(**ctx.default_sandbox_policy)
+    else:
+        policy = SandboxPolicy(
+            network=op.network,
+            read_paths=list(op.read_paths),
+            write_paths=list(op.write_paths),
+            allow_subprocess=op.allow_subprocess,
+            env_passthrough=list(op.env_passthrough),
+            timeout_seconds=op.timeout_seconds,
+        )
 
     ctx.events.emit(
         "sandboxed_exec_started",

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -114,6 +114,18 @@ class Phase(BaseModel):
     allowed_ops: list[str] = Field(
         default_factory=lambda: ["file", "ask_user"],
     )
+    # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy for
+    # ``sandboxed_exec`` ops. When set, the OS applies it to every sandboxed_exec
+    # in this phase (phase-default WINS over op-level fields) so the policy is
+    # declared once in the phase frontmatter — deterministic + P8-clean (the
+    # skill body never describes the Control IR policy). ``None`` → fall back to
+    # the op's own policy fields (unchanged behavior). Shape mirrors
+    # SandboxPolicy kwargs (network / read_paths / write_paths /
+    # allow_subprocess / env_passthrough / timeout_seconds) — a plain exec-policy
+    # dict with no reyn-idiosyncratic naming, so Stage 3's unified permission
+    # block can relocate it verbatim into a ``permissions.exec:`` subsection
+    # (field-location move only; value structure / threading / precedence stay).
+    default_sandbox_policy: dict[str, Any] | None = None
 
 
 class SkillNodeSpec(BaseModel):

--- a/tests/test_default_sandbox_policy_1115_stage2.py
+++ b/tests/test_default_sandbox_policy_1115_stage2.py
@@ -1,0 +1,104 @@
+"""Tier 2: FP-0008 #1115 Stage 2 (D) — phase default_sandbox_policy mechanism.
+
+A phase may declare a ``default_sandbox_policy`` in its frontmatter. The OS
+applies it to every ``sandboxed_exec`` op in that phase, **phase-default WINS**
+over the op's own policy fields — so the policy is declared once, deterministic,
+and the LLM cannot override it (P8-clean: the skill body never describes the
+Control IR policy). This is the generic enabler for migrating skills off the
+deprecated ``shell`` op to ``sandboxed_exec`` (#1115 Stage 2, exec-routing A).
+
+Generic (P7): no skill / phase / artifact strings — ANY phase can declare a
+default policy. Tests use a real recording SandboxBackend Fake (not a mock) to
+capture the policy the handler built.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.sandbox.backend import SandboxResult
+from reyn.sandbox.policy import SandboxPolicy
+from reyn.schemas.models import SandboxedExecIROp
+from reyn.workspace.workspace import Workspace
+
+
+class _PolicyRecordingBackend:
+    """Real SandboxBackend Fake that records the SandboxPolicy it received."""
+
+    name = "policy-recording"
+
+    def __init__(self) -> None:
+        self.received: SandboxPolicy | None = None
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None) -> SandboxResult:
+        self.received = policy
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+
+def _executor(tmp_path: Path) -> tuple[ControlIRExecutor, _PolicyRecordingBackend]:
+    from reyn.events.events import EventLog
+
+    events = EventLog()
+    backend = _PolicyRecordingBackend()
+    ex = ControlIRExecutor(
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={}, project_root=tmp_path, interactive=False
+        ),
+        skill_name="dsp_test",
+        sandbox_backend=backend,
+    )
+    return ex, backend
+
+
+def _run_exec(ex, *, default_sandbox_policy):
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec", argv=["/bin/echo", "x"],
+        # op-level fields = restrictive defaults (network False, subprocess False)
+        env_passthrough=["PATH"], timeout_seconds=10,
+    )
+    return asyncio.run(
+        ex.execute(
+            [op], phase="p", decl=PermissionDecl(),
+            allowed_ops={"sandboxed_exec"},
+            default_sandbox_policy=default_sandbox_policy,
+        )
+    )
+
+
+def test_phase_default_policy_wins_over_op_fields(tmp_path: Path) -> None:
+    """Tier 2: phase default_sandbox_policy overrides the op's own fields."""
+    ex, backend = _executor(tmp_path)
+    _run_exec(ex, default_sandbox_policy={
+        "network": True,
+        "allow_subprocess": True,
+        "read_paths": ["/a"],
+        "write_paths": ["/b"],
+        "env_passthrough": ["PATH", "HOME"],
+        "timeout_seconds": 99,
+    })
+    pol = backend.received
+    assert pol is not None
+    # The phase default won — NOT the op's restrictive defaults.
+    assert pol.network is True
+    assert pol.allow_subprocess is True
+    assert pol.timeout_seconds == 99
+    assert pol.read_paths == ["/a"] and pol.write_paths == ["/b"]
+
+
+def test_no_phase_default_falls_back_to_op_fields(tmp_path: Path) -> None:
+    """Tier 2: with no phase default, the op's own policy fields are used."""
+    ex, backend = _executor(tmp_path)
+    _run_exec(ex, default_sandbox_policy=None)
+    pol = backend.received
+    assert pol is not None
+    # The op's restrictive defaults (network/subprocess False) — unchanged path.
+    assert pol.network is False
+    assert pol.allow_subprocess is False
+    assert pol.timeout_seconds == 10

--- a/tests/test_osruntime_phase_compaction_wiring.py
+++ b/tests/test_osruntime_phase_compaction_wiring.py
@@ -257,6 +257,7 @@ class _FakeIRExecutor:
         phase: str = "",
         decl: Any = None,
         allowed_ops: Any = None,
+        default_sandbox_policy: Any = None,
     ) -> list[dict]:
         """Return one synthetic grep result regardless of the ops list."""
         return [


### PR DESCRIPTION
**[e2e-coder]** — #1115 Stage 2, exec-routing (A) part 1/2: the generic `default_sandbox_policy` mechanism. The enabler for migrating skills off the deprecated `shell` op to `sandboxed_exec` (so their exec routes through the container backend in-container).

## What

A phase declares a default `SandboxPolicy` in its frontmatter; the OS applies it to every `sandboxed_exec` in that phase — **phase-default WINS** over the op's own fields. The policy is declared once, deterministic, LLM-unoverridable (P8-clean: the skill body never describes the Control IR policy).

- `Phase.default_sandbox_policy: dict | None` — a **plain exec-policy dict** (SandboxPolicy kwargs), no reyn-idiosyncratic naming, so Stage 3's unified permission block can relocate it verbatim into a `permissions.exec:` subsection (field-location move only; value/threading/precedence unchanged — lead-coder forward-compat gate).
- `OpContext.default_sandbox_policy` + threading: `ControlIRExecutor.execute` / `_build_ctx` (act + decide paths via `phase_executor` / `run_orchestrator`) + `PreprocessorExecutor._build_op_ctx`.
- `sandboxed_exec` handler: `SandboxPolicy(**ctx.default_sandbox_policy)` when set, else the op-level fields (unchanged fallback).

## Generic / additive

P7-clean: no skill/phase/artifact strings — **any** phase may declare a default policy. No phase sets it yet (the swe_bench `shell`→`sandboxed_exec` migration is part 2/2), so **zero behavior change**.

## Tests (no-mock, Tier 2, deterministic — no docker/proxy)

A real recording `SandboxBackend` Fake captures the built policy: phase-default wins over op fields; no phase-default → op fields. Also updated the `_FakeIRExecutor` test double to track the new `execute()` kwarg.

## Test plan

- [x] `pytest tests/test_default_sandbox_policy_1115_stage2.py` (2) + osruntime-compaction + op_sandboxed_exec (23) — green
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations
- [x] phase / preprocessor / orchestrator / runtime / control_ir / sandbox / skill-load sweep (381, 3 docker-skipped) — green
- [ ] (CI) full-rootdir — local editable install broken (pre-existing); relying on CI.

Next (part 2/2): swe_bench verify.md/report.md `shell`→`sandboxed_exec` + declare `default_sandbox_policy` (permissive: network/subprocess/paths for git+pytest). Gold-flow gate (outcome semantics / C6 revert / PR-N15 determinism / convergence guard) preserved; full host-re-run outcome-invariance validation is proxy-deferred (#183: C7 PASS-rate not trusted/reported until that passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)