### PR TITLE
feat(fp-0008): #1115 Stage 2 — sandboxed_exec anchors cwd to workspace.base_dir (shell-op parity)

### DIFF
--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -317,12 +317,18 @@ class DockerEnvironmentBackend:
 
     async def run(
         self, argv: list[str], policy: SandboxPolicy, *, stdin: bytes | None = None,
+        cwd: str | None = None,
     ) -> SandboxResult:
         """Plain ``docker exec`` of argv with cwd=repo_dir — NO host-diff bridge.
 
         The files are already in ``repo_dir`` (the agent edited them via the FS
         methods above), so there is nothing to sync in. Honors only
         ``policy.timeout_seconds`` (the fidelity boundary, as in PR-A).
+
+        The host-side ``cwd`` (= the OS's ``workspace.base_dir``) is **ignored**:
+        the repo lives at the in-container ``self.repo_dir`` (``-w``), which a
+        host path can't address. Same asymmetry as policy enforcement — a
+        workspace-coupled backend scopes both to the fidelity boundary.
         """
         exec_argv = [self.docker_bin, "exec", "-w", self.repo_dir, self.container, *argv]
         return await self._runner(exec_argv, stdin=stdin, timeout=policy.timeout_seconds)

--- a/src/reyn/op_runtime/sandboxed_exec.py
+++ b/src/reyn/op_runtime/sandboxed_exec.py
@@ -44,6 +44,13 @@ async def handle(
             timeout_seconds=op.timeout_seconds,
         )
 
+    # Anchor the working directory to the run's workspace base_dir — parity with
+    # the legacy `shell` op (FP-0008 PR-I). Without this, repo-relative `git` /
+    # `pytest` run in the harness process cwd instead of the repo root, which
+    # breaks concurrent benchmark runs. A workspace-coupled backend (e.g. a
+    # container backend) may ignore this host path and use its own baked cwd.
+    cwd = str(ctx.workspace.base_dir)
+
     ctx.events.emit(
         "sandboxed_exec_started",
         argv=list(op.argv),
@@ -53,7 +60,7 @@ async def handle(
         allow_subprocess=op.allow_subprocess,
     )
 
-    result = await backend.run(list(op.argv), policy)
+    result = await backend.run(list(op.argv), policy, cwd=cwd)
 
     stdout_text = result.stdout.decode("utf-8", errors="replace")
     stderr_text = result.stderr.decode("utf-8", errors="replace")

--- a/src/reyn/sandbox/backend.py
+++ b/src/reyn/sandbox/backend.py
@@ -48,6 +48,17 @@ class SandboxBackend(Protocol):
         policy: SandboxPolicy,
         *,
         stdin: bytes | None = None,
+        cwd: str | None = None,
     ) -> SandboxResult:
-        """Execute argv under the given policy and return the result."""
+        """Execute argv under the given policy and return the result.
+
+        ``cwd`` is the working directory the command runs in. The OS passes the
+        run's ``workspace.base_dir`` (= parity with the legacy ``shell`` op,
+        FP-0008 PR-I) so ``git`` / ``pytest`` resolve against the repo root even
+        under concurrent benchmark runs. ``None`` = inherit the parent process
+        cwd. A workspace-coupled backend (e.g. a container backend whose repo
+        lives at an in-container path) may ignore this host-side ``cwd`` and use
+        its own baked working directory — same asymmetry as policy enforcement,
+        which such a backend also scopes to the fidelity boundary.
+        """
         ...

--- a/src/reyn/sandbox/backends/docker.py
+++ b/src/reyn/sandbox/backends/docker.py
@@ -158,8 +158,13 @@ class DockerSandboxBackend:
         policy: SandboxPolicy,
         *,
         stdin: bytes | None = None,
+        cwd: str | None = None,
     ) -> SandboxResult:
         """Clean-reset the container repo, apply the host diff, then exec argv.
+
+        The host-side ``cwd`` is ignored: argv runs at the baked in-container
+        ``repo_dir`` (a host path can't address the container FS).
+
 
         Steps (each via the injected runner):
           1. capture the host diff (vs base_ref);

--- a/src/reyn/sandbox/backends/landlock.py
+++ b/src/reyn/sandbox/backends/landlock.py
@@ -120,8 +120,14 @@ class LandlockBackend:
         policy: SandboxPolicy,
         *,
         stdin: bytes | None = None,
+        cwd: str | None = None,
     ) -> SandboxResult:
-        """Execute argv under Landlock isolation and return the result."""
+        """Execute argv under Landlock isolation and return the result.
+
+        ``cwd`` (= the run's ``workspace.base_dir``) sets the child working
+        directory so repo-relative ``git`` / ``pytest`` resolve correctly; the
+        Landlock ruleset still bounds filesystem access independently.
+        """
         if not self.available():
             raise RuntimeError(
                 "LandlockBackend not available on this platform. "
@@ -226,6 +232,7 @@ class LandlockBackend:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     env=env,
+                    cwd=cwd,
                     start_new_session=True,
                     preexec_fn=lambda: _build_preexec(ruleset),
                 )

--- a/src/reyn/sandbox/backends/seatbelt.py
+++ b/src/reyn/sandbox/backends/seatbelt.py
@@ -164,8 +164,14 @@ class SeatbeltBackend:
         policy: SandboxPolicy,
         *,
         stdin: bytes | None = None,
+        cwd: str | None = None,
     ) -> SandboxResult:
-        """Execute *argv* under the SBPL policy derived from *policy*."""
+        """Execute *argv* under the SBPL policy derived from *policy*.
+
+        ``cwd`` (= the run's ``workspace.base_dir``) is the working directory the
+        sandboxed child inherits, so repo-relative ``git`` / ``pytest`` resolve
+        correctly. The SBPL profile still bounds what that child may read/write.
+        """
         profile_text = _build_sbpl_profile(policy)
 
         # Build env from passthrough allowlist; fall back PATH if not listed.
@@ -198,6 +204,7 @@ class SeatbeltBackend:
                         input=stdin,
                         capture_output=True,
                         env=env,
+                        cwd=cwd,
                         timeout=policy.timeout_seconds,
                         check=False,
                     )

--- a/src/reyn/sandbox/noop_backend.py
+++ b/src/reyn/sandbox/noop_backend.py
@@ -59,6 +59,7 @@ class NoopBackend:
         policy: SandboxPolicy,
         *,
         stdin: bytes | None = None,
+        cwd: str | None = None,
     ) -> SandboxResult:
         _warn_once()
 
@@ -83,6 +84,7 @@ class NoopBackend:
                     input=stdin,
                     capture_output=True,
                     env=env,
+                    cwd=cwd,
                     timeout=policy.timeout_seconds,
                     check=False,
                 )

--- a/tests/test_backend_injection_threading_1115_stage2.py
+++ b/tests/test_backend_injection_threading_1115_stage2.py
@@ -59,7 +59,7 @@ class _StubExecBackend:
     def available(self) -> bool:
         return True
 
-    async def run(self, argv, policy, *, stdin=None) -> SandboxResult:
+    async def run(self, argv, policy, *, stdin=None, cwd=None) -> SandboxResult:
         return SandboxResult(returncode=0, stdout=b"from-stub", stderr=b"")
 
 

--- a/tests/test_default_sandbox_policy_1115_stage2.py
+++ b/tests/test_default_sandbox_policy_1115_stage2.py
@@ -31,12 +31,14 @@ class _PolicyRecordingBackend:
 
     def __init__(self) -> None:
         self.received: SandboxPolicy | None = None
+        self.received_cwd: str | None = None
 
     def available(self) -> bool:
         return True
 
-    async def run(self, argv, policy, *, stdin=None) -> SandboxResult:
+    async def run(self, argv, policy, *, stdin=None, cwd=None) -> SandboxResult:
         self.received = policy
+        self.received_cwd = cwd
         return SandboxResult(returncode=0, stdout=b"", stderr=b"")
 
 

--- a/tests/test_op_sandboxed_exec.py
+++ b/tests/test_op_sandboxed_exec.py
@@ -209,14 +209,22 @@ async def test_dispatch_timeout_status():
 
 
 class _StubBackend:
-    """Real (non-mock) SandboxBackend stub for the injection-seam test."""
+    """Real (non-mock) SandboxBackend stub for the injection-seam test.
+
+    Records the ``cwd`` it was invoked with so the cwd-anchoring contract can be
+    asserted behaviorally.
+    """
 
     name = "stub-injected"
+
+    def __init__(self) -> None:
+        self.received_cwd: str | None = None
 
     def available(self) -> bool:
         return True
 
-    async def run(self, argv, policy, *, stdin=None) -> SandboxResult:
+    async def run(self, argv, policy, *, stdin=None, cwd=None) -> SandboxResult:
+        self.received_cwd = cwd
         return SandboxResult(returncode=0, stdout=b"from-stub", stderr=b"")
 
 
@@ -235,6 +243,64 @@ async def test_injected_sandbox_backend_takes_precedence():
     # The injected instance ran — not the platform default (e.g. seatbelt here).
     assert result["backend"] == "stub-injected"
     assert result["stdout"] == "from-stub"
+
+
+# ─── 4c. cwd anchoring (parity with shell op, FP-0008 PR-I) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_handler_passes_workspace_base_dir_as_cwd():
+    """Tier 2: the handler anchors cwd to workspace.base_dir on backend.run.
+
+    Parity with the legacy `shell` op (FP-0008 PR-I). Asserted behaviorally via
+    a recording stub so repo-relative git/pytest run in the repo root.
+    """
+    ctx, _events = _make_ctx()
+    stub = _StubBackend()
+    ctx.sandbox_backend = stub
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec", argv=["/bin/echo", "x"],
+        env_passthrough=["PATH"], timeout_seconds=10,
+    )
+    await execute_op(op, ctx, caller="control_ir")
+    assert stub.received_cwd == str(ctx.workspace.base_dir)
+
+
+@pytest.mark.asyncio
+async def test_default_backend_actually_runs_in_workspace_cwd(tmp_path):
+    """Tier 2: the default backend's subprocess runs with cwd=workspace.base_dir.
+
+    End-to-end proof (not just handler threading): /bin/pwd executed via the
+    real platform default backend reports the workspace base_dir. Uses realpath
+    on both sides to tolerate macOS /var → /private/var symlink resolution.
+    """
+    import os
+
+    from reyn.events.events import EventLog
+    from reyn.op_runtime.context import OpContext
+    from reyn.workspace.workspace import Workspace
+
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    ctx = OpContext(
+        workspace=ws, events=events,
+        permission_decl=PermissionDecl(), permission_resolver=None,
+    )
+    # Grant read on the cwd: a deny-default backend (seatbelt) otherwise blocks
+    # /bin/pwd from stat-ing its own working directory. This mirrors the
+    # permissive policy a repo-exec phase must declare for git/pytest.
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec", argv=["/bin/pwd"],
+        read_paths=[str(tmp_path)],
+        env_passthrough=["PATH"], timeout_seconds=10,
+    )
+    result = await execute_op(op, ctx, caller="control_ir")
+    assert result["returncode"] == 0, f"/bin/pwd failed: {result!r}"
+    reported = os.path.realpath(result["stdout"].strip())
+    assert reported == os.path.realpath(str(ws.base_dir)), (
+        f"sandboxed_exec ran in {reported!r}, expected workspace base_dir "
+        f"{ws.base_dir!r}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — Refs #1115. Precursor to A-ii (swe_bench shell→sandboxed_exec).

## Why
Found via A-ii flow-trace (primary evidence): `sandboxed_exec` is meant to replace the legacy `shell` op, but it dropped shell's load-bearing `cwd=ctx.workspace.base_dir` (FP-0008 PR-I). `SandboxBackend.run(argv, policy)` had no working directory, so host backends run the subprocess in the harness process cwd. Repo-relative `git` / `pytest` then run outside the repo — and `pytest` can't be patched around with `git -C`-style flags (it needs cwd=repo for rootdir/conftest discovery). This blocks the swe_bench migration and any sandboxed repo exec.

## What (generic, not swe_bench-specific)
- `SandboxBackend.run` gains `cwd: str | None = None` (keyword-only).
- Host backends (noop / seatbelt / landlock) pass `cwd` into the subprocess.
- The `sandboxed_exec` handler passes `cwd=str(ctx.workspace.base_dir)` — the same source the shell op uses.
- Workspace-coupled backends (`DockerEnvironmentBackend`, dead `DockerSandboxBackend`) **ignore** the host cwd and keep their baked in-container `-w repo_dir` — a host path can't address the container FS. Same asymmetry as policy enforcement (container honors only `timeout`), which such a backend also scopes to the fidelity boundary.

Additive: `sandboxed_exec` has **zero** stdlib users today (grep-verified) → no existing skill changes behavior. `cwd` is exec context, not policy (`SandboxPolicy` unchanged) — consistent with the agent-level sandbox invariant.

## Review gate (lead-coder, broker-affirmed)
- ✅ cwd parity: `sandboxed_exec` receives `workspace.base_dir`, equivalent to shell op
- ✅ host backend starts subprocess with `cwd=cwd` (git/pytest run in repo) — pinned no-mock
- ✅ container ignores host cwd, uses `-w repo_dir` (#1120 pattern) — documented + dead-docker mirrored
- ✅ `SandboxResult` compatible, `SandboxPolicy` unchanged (cwd is outside policy)

## Test plan
- [x] `pytest tests/test_op_sandboxed_exec.py tests/test_default_sandbox_policy_1115_stage2.py tests/test_backend_injection_threading_1115_stage2.py tests/test_container_backend_1115_stage2.py tests/test_sandbox_docker.py -q` → green
  - new: `test_handler_passes_workspace_base_dir_as_cwd` (handler→backend threading via recording stub), `test_default_backend_actually_runs_in_workspace_cwd` (real `/bin/pwd` via platform default backend reports base_dir)
- [x] `ruff check .` on changed files → clean
- [x] `scripts/test_tier_audit.py --strict` on the 3 changed test files → 0 violations
- [x] Full suite `pytest -q --ignore=.claude` → 6522 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`, **confirmed failing on clean origin/main with my changes stashed** — HTML-extractor behavior, unrelated to this PR; flagged separately). NOTE: bare `pytest -q` from rootdir reports spurious collection errors from stale `.claude/worktrees/` trees (duplicate-basename) — use `--ignore=.claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)