### PR TITLE
feat(fp-0008): #1115 Stage 2 — swe_bench setup/explore/apply shell→sandboxed_exec (complete the migration)

### DIFF
--- a/docs/guide/for-users/run-swe-bench.md
+++ b/docs/guide/for-users/run-swe-bench.md
@@ -7,7 +7,7 @@ This guide walks through using Reyn to solve [SWE-bench Verified](https://www.sw
 ## Prerequisites
 
 - **Python 3.11+** with `reyn` installed and `reyn` on `PATH`.
-- **A configured LLM** — set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or whichever provider your `reyn.yaml` points at.  The `swe_bench` skill uses the `shell` op and needs file read/write; no additional permissions setup is required because `shell: true` and `file.write: ["*"]` are declared in the skill's `skill.md`.
+- **A configured LLM** — set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or whichever provider your `reyn.yaml` points at.  The `swe_bench` skill runs commands via the `sandboxed_exec` op and needs file read/write; no additional permissions setup is required because `sandboxed_exec` is permitted by default and `file.write: ["*"]` is declared in the skill's `skill.md`.
 - **Git** available in `PATH` (the skill runs `git checkout`, `git diff`).
 - **The target repo's test runner** (e.g. `pytest`, `tox`) installed in the environment where `reyn run` executes — or inside the Docker container if you're using the official harness.
 - *(Optional)* **Docker** if you're connecting to the official SWE-bench evaluation harness.
@@ -190,7 +190,7 @@ Wait — the `--reyn-cmd` flag replaces the base command list (`reyn run swe_ben
 - No LLM credentials: set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / the relevant env var for your model provider.
 - No models configured: run `reyn config` or add a `model:` entry to `reyn.yaml`.
 - The repo clone failed: ensure the repository is cloned at the path the skill expects, or that `git` can access the remote.
-- `shell: true` permission not granted: the `swe_bench` skill declares `shell: true` in its frontmatter; `reyn run` respects this automatically for stdlib skills, so you should not need `--allow-shell`.
+- Exec not permitted: the `swe_bench` skill runs commands via the `sandboxed_exec` op, which is permitted by default (no `--allow-shell` or extra permission entry needed) for stdlib skills.
 
 **`could not find 'patch' field in reyn output`** — reyn ran but did not produce a `swe_bench_result` artifact with a `patch` field. This means the skill aborted or the `report` phase failed. Check the stderr output for the `reyn run` diagnostic lines, or run the instance manually:
 

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -4,8 +4,19 @@ name: apply
 input: plan
 role: implementer
 model_class: standard
-allowed_ops: [file, shell]
+allowed_ops: [file, sandboxed_exec]
 max_act_turns: 30
+# FP-0008 #1115 Stage 2: policy for this phase's sandboxed_exec ops (e.g.
+# python -m py_compile syntax checks), winning over op fields. Permissive —
+# operates on an arbitrary repository. Ignored by a container EnvironmentBackend
+# (the C7 path); best-effort on host backends.
+default_sandbox_policy:
+  network: true
+  read_paths: ["/"]
+  write_paths: ["/"]
+  allow_subprocess: true
+  env_passthrough: ["PATH", "HOME", "PYTHONPATH", "VIRTUAL_ENV", "LANG", "LC_ALL", "TMPDIR"]
+  timeout_seconds: 120
 ---
 
 Implement the edit plan by modifying the repository files.
@@ -36,9 +47,9 @@ that the op succeeded before proceeding to the next.
 
 ## Step 3 — Basic syntax check (when applicable)
 
-If the edited files are Python, issue a shell op running
-`python -m py_compile <file>` on each modified file.  If a compile error is
-reported, correct the syntax before transitioning.
+If the edited files are Python, run `python -m py_compile <file>` on each
+modified file.  If a compile error is reported, correct the syntax before
+transitioning.
 
 For non-Python files, skip this step.
 
@@ -65,8 +76,8 @@ reads of that file.  Re-reading accumulates results in the context without
 advancing the plan.  The accumulated read results will NOT change — the file
 content is fixed until an edit op is issued.
 
-Similarly, if you have attempted the same shell command (same command string)
-**3 or more consecutive times** and it keeps failing with the same error,
-STOP and transition rather than retrying.  Repeated shell failures with
-identical error output indicate a structural problem that additional retries
-will not resolve within this budget.
+Similarly, if you have attempted the same command (same argv) **3 or more
+consecutive times** and it keeps failing with the same error, STOP and
+transition rather than retrying.  Repeated command failures with identical
+error output indicate a structural problem that additional retries will not
+resolve within this budget.

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -4,8 +4,18 @@ name: explore
 input: swe_bench_input
 role: analyst
 model_class: standard
-allowed_ops: [file, grep, shell]
+allowed_ops: [file, grep, sandboxed_exec]
 max_act_turns: 20
+# FP-0008 #1115 Stage 2: policy for any sandboxed_exec op this phase runs while
+# exploring an arbitrary repository (e.g. git log / ls). Permissive; ignored by a
+# container EnvironmentBackend (the C7 path), best-effort on host backends.
+default_sandbox_policy:
+  network: true
+  read_paths: ["/"]
+  write_paths: ["/"]
+  allow_subprocess: true
+  env_passthrough: ["PATH", "HOME", "PYTHONPATH", "VIRTUAL_ENV", "LANG", "LC_ALL", "TMPDIR"]
+  timeout_seconds: 120
 ---
 
 Understand the problem by reading the `problem_statement` and finding the
@@ -66,9 +76,9 @@ entire repository.
 
 Read `data.test_patch` from the input artifact to understand what the tests
 expect the fixed code to do.  This is a unified diff string that has been
-present in the input from Step 1 — you do NOT need to issue a shell or file
-op to access it. The value lives at `data.test_patch` in the same input
-artifact as `data.problem_statement`.
+present in the input from Step 1 — you do NOT need to issue any op to access
+it. The value lives at `data.test_patch` in the same input artifact as
+`data.problem_statement`.
 
 This gives a precise specification: the fix must make those tests pass. Do
 NOT apply the test_patch now — that happens in verify.

--- a/src/reyn/stdlib/skills/swe_bench/phases/setup.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/setup.md
@@ -4,8 +4,19 @@ name: setup
 input: swe_bench_input
 role: initializer
 model_class: standard
-allowed_ops: [shell]
+allowed_ops: [sandboxed_exec]
 max_act_turns: 5
+# FP-0008 #1115 Stage 2: policy for this phase's sandboxed_exec ops (git
+# checkout / git status / pytest --version), winning over op fields. Permissive
+# — operates on an arbitrary repository. Ignored by a container EnvironmentBackend
+# (the C7 path); best-effort on host backends.
+default_sandbox_policy:
+  network: true
+  read_paths: ["/"]
+  write_paths: ["/"]
+  allow_subprocess: true
+  env_passthrough: ["PATH", "HOME", "PYTHONPATH", "VIRTUAL_ENV", "LANG", "LC_ALL", "TMPDIR"]
+  timeout_seconds: 120
 ---
 
 Prepare the repository for the fix by checking out the exact commit the
@@ -16,32 +27,31 @@ SWE-bench harness requires.
 The input artifact (`swe_bench_input`) carries a `base_commit` field whose
 value is a git commit SHA (e.g. `"d16bfe05a744909de4b27f5875fe0d4ed41ce607"`).
 
-Issue a shell op whose `cmd` is the literal command **with the SHA value
+Run `git checkout` against that SHA, **with the actual value from the artifact
 substituted in**. For example, when `base_commit` is
-`"d16bfe05a744909de4b27f5875fe0d4ed41ce607"`, the shell op must look like:
+`"d16bfe05a744909de4b27f5875fe0d4ed41ce607"`, run:
 
-```json
-{"kind": "shell", "cmd": "git checkout d16bfe05a744909de4b27f5875fe0d4ed41ce607"}
+```
+git checkout d16bfe05a744909de4b27f5875fe0d4ed41ce607
 ```
 
-**Critical**: do NOT emit a literal placeholder like `git checkout <base_commit>` —
-that is template-style notation for documentation, not a runnable command. The
-shell op's `cmd` field must contain the actual SHA, not the `<base_commit>`
-placeholder. Read the SHA from the input artifact and inline it into the cmd
-string.
+**Critical**: do NOT run a literal placeholder like `git checkout <base_commit>` —
+that is template-style notation for documentation, not a runnable command. Read
+the actual SHA from the input artifact and use it; never the `<base_commit>`
+placeholder text.
 
 If the checkout fails (non-zero exit code), abort with a clear message
 explaining the failure.
 
 ## Step 2 — Confirm the working tree is clean
 
-Issue a shell op to run `git status --short`.  If there are unexpected
-uncommitted changes from a prior run (this can happen in repeated batch
-evaluation), run `git checkout -- .` to reset them before proceeding.
+Run `git status --short`.  If there are unexpected uncommitted changes from a
+prior run (this can happen in repeated batch evaluation), run
+`git checkout -- .` to reset them before proceeding.
 
 ## Step 3 — Verify test infrastructure is available
 
-Issue a shell op to verify that a Python test runner is available.  A simple
+Run a quick check that a Python test runner is available.  A simple
 `python -m pytest --version` (or `python -m unittest --version` as fallback)
 is enough.  Record the outcome in `summary` — do NOT abort if the runner is
 missing; note it and continue so the verify phase can detect the real failure.

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -39,7 +39,9 @@ permissions:
   file.write:
     - path: "*"
       scope: recursive
-  shell: true
+  # FP-0008 #1115 Stage 2: all phases migrated off the deprecated `shell` op to
+  # `sandboxed_exec` (which has default permissibility — no permissions entry).
+  # `permissions.shell` removed: no phase emits `kind: shell` any more.
   # FP-0008 PR-O v8: deterministic test_patch sanitizer (= line-ending
   # / BOM / trailing-newline normalization) runs as a `safe`-mode
   # python preprocessor step at the verify phase entry, BEFORE the
@@ -51,7 +53,7 @@ permissions:
       mode: safe
       timeout: 5
     # FP-0008 C6 v2: pure string parser — extracts +++ b/<path> targets from
-    # test_patch and returns git checkout command strings.  Mode: safe because
+    # test_patch and returns git checkout argv lists.  Mode: safe because
     # the function uses only re + json (both in PURE_STDLIB_ALLOWLIST) and
     # performs no filesystem access, subprocess calls, or environment reads.
     - module: ./parse_test_targets.py
@@ -69,8 +71,8 @@ commit, explores the codebase to understand the problem, plans and applies
 edits, verifies against the provided test patch, then emits a `git diff`
 patch as the final output.
 
-All required capabilities (`read_file`, `edit_file`, `shell`, `grep`) are
-existing OS ops — no OS changes required (P7 compliant).
+All required capabilities (`read_file`, `edit_file`, `sandboxed_exec`, `grep`)
+are existing OS ops — no OS changes required (P7 compliant).
 
 ## Phase flow
 

--- a/tests/test_swe_bench_sandboxed_exec_migration_1115.py
+++ b/tests/test_swe_bench_sandboxed_exec_migration_1115.py
@@ -1,0 +1,78 @@
+"""Tier 2: FP-0008 #1115 Stage 2 — swe_bench fully migrated off the shell op.
+
+After A-ii (#1126, verify/report) + this PR (setup/explore/apply), every exec
+phase in the swe_bench skill uses `sandboxed_exec` (routing through the run's
+EnvironmentBackend) instead of the deprecated `shell` op, and the skill no
+longer declares `permissions.shell`. These pins guard against a regression that
+re-introduces `shell` and against the P8 violation (Control-IR JSON in a body)
+that setup.md previously carried.
+
+Real skill loaded from disk (no mocks); docstrings open "Tier 2:".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.sandbox import SandboxPolicy
+
+_SKILL_ROOT = (
+    Path(__file__).parent.parent / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+_PHASES = _SKILL_ROOT / "phases"
+
+# Phases that run commands (exec). plan is pure file+grep (no exec).
+_EXEC_PHASES = ("setup", "explore", "apply", "verify", "report")
+
+
+def _skill():
+    return load_dsl_skill(_SKILL_ROOT / "skill.md")
+
+
+def test_no_phase_allows_shell_op() -> None:
+    """Tier 2: no swe_bench phase lists the deprecated `shell` op in allowed_ops."""
+    skill = _skill()
+    for name, phase in skill.phases.items():
+        assert "shell" not in phase.allowed_ops, (
+            f"Phase '{name}' still lists 'shell' in allowed_ops: {phase.allowed_ops}. "
+            f"#1115 Stage 2 migrated all exec to sandboxed_exec."
+        )
+
+
+def test_exec_phases_use_sandboxed_exec_with_policy() -> None:
+    """Tier 2: every exec phase uses sandboxed_exec and declares a valid default_sandbox_policy."""
+    skill = _skill()
+    for name in _EXEC_PHASES:
+        phase = skill.phases[name]
+        assert "sandboxed_exec" in phase.allowed_ops, (
+            f"Phase '{name}' must allow sandboxed_exec. Got: {phase.allowed_ops}"
+        )
+        policy = phase.default_sandbox_policy
+        assert isinstance(policy, dict) and policy, (
+            f"Phase '{name}' must declare a non-empty default_sandbox_policy reaching "
+            f"the Phase object. Got: {policy!r}"
+        )
+        SandboxPolicy(**policy)  # raises on an unknown/typo'd key
+
+
+def test_skill_no_longer_declares_shell_permission() -> None:
+    """Tier 2: skill.permissions.shell is removed (no phase emits kind: shell)."""
+    skill = _skill()
+    assert skill.permissions.shell is False, (
+        "swe_bench.permissions.shell must be removed after the sandboxed_exec "
+        "migration — no phase emits the shell op."
+    )
+
+
+def test_no_phase_body_embeds_control_ir_shell_json() -> None:
+    """Tier 2: no phase body embeds a Control-IR shell JSON literal (P8 cleanup).
+
+    setup.md previously hard-coded `{"kind": "shell", "cmd": ...}` in its body —
+    a P8 violation (Control IR format is OS-injected, not described in the body).
+    """
+    for md in _PHASES.glob("*.md"):
+        text = md.read_text(encoding="utf-8")
+        assert '"kind": "shell"' not in text and "kind: shell" not in text, (
+            f"{md.name} embeds a Control-IR shell literal — P8 violation. "
+            f"Describe WHAT to run; the OS injects the op format."
+        )


### PR DESCRIPTION
**[e2e-coder]** — Refs #1115. PR-α of the #234 wave; completes the swe_bench shell→sandboxed_exec migration started in #1126 (verify/report).

## Why
After this, **every** exec phase routes commands through the run's `EnvironmentBackend` (host today, container for C7). This is required for container coherence (#234): with a mix of `shell` (host subprocess) and `sandboxed_exec` (backend) phases, setup's `git checkout` would run on the host while verify runs in the container — splitting repo state. **Behavior-preserving on host** (cwd-anchored `sandboxed_exec` ≡ old `shell` op).

## Changes
- **setup.md / explore.md / apply.md**: `allowed_ops` shell→sandboxed_exec; declare a permissive `default_sandbox_policy` (arbitrary-repo git/pytest; container-ignored, host-best-effort), mirroring the merged verify/report pattern.
- **setup.md P8 cleanup**: removed the hard-coded Control-IR JSON (`{"kind":"shell","cmd":...}`) from the body — that enumerated op format (P8 violation). Replaced with WHAT/domain instruction (run `git checkout <SHA>` with the actual `base_commit` substituted); the OS injects the op format. **Phase meaning unchanged.** Body shell-op references ("issue a shell op", "Repeated shell failures") neutralized to command-level wording.
- **skill.md**: `permissions.shell` removed — verified zero `kind: shell` / `cmd:` across all phases (plan is file+grep; the rest sandboxed_exec). `sandboxed_exec` is permitted by default (no permissions entry). Overview + parse comment updated.
- **docs/guide/for-users/run-swe-bench.md**: shell→sandboxed_exec references (EN-only file, no JA mirror).

## Review gate (lead-coder, broker-affirmed)
- ✅ `permissions.shell` removed only after grep-confirming zero `kind: shell` / `cmd:` skill-wide
- ✅ setup.md P8 cleanup is WHAT-preserving (Control-IR JSON gone from body; no op-format/field enumeration; phase semantics unchanged)
- ✅ #1126 pattern replicated consistently (allowed_ops, default_sandbox_policy)

## Test plan
- [x] new `tests/test_swe_bench_sandboxed_exec_migration_1115.py` (Tier 2, real-skill load): no phase allows shell; each exec phase uses sandboxed_exec + valid `SandboxPolicy` dict; `skill.permissions.shell` removed; no phase body embeds Control-IR shell JSON (P8 pin) → 4 passed
- [x] swe_bench + sandbox sweep (`-k "swe_bench or sandboxed_exec or default_sandbox_policy"`) → 143 passed
- [x] setup.md/shell-referencing tests (placeholder-shape, shell-op-cwd, compaction, intervention) → 54 passed
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` on the new test → clean / 0 violations
- [x] Full suite `pytest -q --ignore=.claude` → 6531 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`, local HTML-extractor-lib diff, not in CI — see #1124/#1126)
- [ ] (skipped — belongs to #234) live run: deferred to the container-lifecycle PR-β + live C7, user-supervised. This PR is behavior-preserving on host.

Next in the wave: **PR-β** = container lifecycle (docker run per-instance + `DockerEnvironmentBackend` injected at both seams + in-container model_patch + remove dead #1112 `DockerSandboxBackend`), then the user-supervised live C7 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)