### PR TITLE
feat(fp-0008): #1115 Stage 2 — `reyn run` container EnvironmentBackend flags (β2a, dual-seam injection)

### DIFF
--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -77,6 +77,31 @@ def register(sub) -> None:
                        "Enable unsafe-mode Python preprocessor steps (no AST sandboxing). "
                        "Safe-mode python steps run without this flag. Off by default."
                    ))
+    # FP-0008 #1115 Stage 2: route the repo filesystem + command execution
+    # through a container EnvironmentBackend instead of the host. Generic (any
+    # skill); the OS stays on the host, only the repo FS + exec cross into the
+    # container. Used e.g. for faithful in-container benchmarking.
+    p.add_argument("--env-backend", dest="env_backend",
+                   choices=["host", "docker"], default="host",
+                   help=(
+                       "Where the repo filesystem and commands execute: 'host' "
+                       "(default, no isolation change) or 'docker' (route FS + exec "
+                       "into a running container via --container/--repo-dir)."
+                   ))
+    p.add_argument("--container", dest="container", default=None, metavar="NAME",
+                   help="Running container name/id for --env-backend=docker.")
+    p.add_argument("--repo-dir", dest="repo_dir", default=None, metavar="PATH",
+                   help=(
+                       "In-container absolute path of the repo working tree "
+                       "(e.g. /repo) for --env-backend=docker. Relative paths "
+                       "resolve against this; commands run with it as cwd."
+                   ))
+    p.add_argument("--state-dir", dest="state_dir", default=None, metavar="PATH",
+                   help=(
+                       "Host-side directory for OS state/artifacts (events, "
+                       "offload, artifact handles), kept off the routed repo FS. "
+                       "Recommended with --env-backend=docker so state stays on the host."
+                   ))
     p.set_defaults(func=run)
 
 
@@ -118,6 +143,7 @@ def run(args: argparse.Namespace) -> None:
     project_root = _find_project_root(Path.cwd())
     project_context = load_project_context(session.config, project_root)
     logger = make_logger()
+    env_backend, ws_base_dir, ws_state_dir = _build_environment_backend(args)
     agent = Agent(
         model=model,
         strict=args.strict,
@@ -133,6 +159,13 @@ def run(args: argparse.Namespace) -> None:
         project_context=project_context,
         caller="direct",
         sandbox_config=session.config.sandbox,
+        # FP-0008 #1115 Stage 2: inject the SAME container backend instance at
+        # both seams (FS = environment_backend, exec = sandbox_backend), agent-
+        # level uniform. None (host) preserves the default identity behavior.
+        environment_backend=env_backend,
+        sandbox_backend=env_backend,
+        workspace_base_dir=ws_base_dir,
+        workspace_state_dir=ws_state_dir,
     )
 
     input_type = initial_input.get("type", "unknown")
@@ -167,6 +200,52 @@ def run(args: argparse.Namespace) -> None:
 
     if not result.ok:
         sys.exit(2)
+
+
+def _build_environment_backend(args: argparse.Namespace):
+    """Build the EnvironmentBackend + workspace dirs from --env-backend flags.
+
+    Returns ``(backend, workspace_base_dir, workspace_state_dir)``:
+
+    - host (default): ``(None, None, None)`` — the Agent uses its identity
+      HostBackend and default base_dir/state_dir (unchanged behavior).
+    - docker: a single ``DockerEnvironmentBackend`` instance (injected at BOTH
+      the FS and exec seams by the caller), with ``workspace_base_dir`` = the
+      in-container ``--repo-dir`` (so relative paths + command cwd resolve there)
+      and ``workspace_state_dir`` = the host-side ``--state-dir`` (OS state kept
+      off the routed repo FS).
+
+    Generic — no skill-specific knowledge (P7).
+    """
+    backend_kind = getattr(args, "env_backend", "host")
+    if backend_kind == "host":
+        return None, None, None
+
+    if backend_kind == "docker":
+        container = getattr(args, "container", None)
+        repo_dir = getattr(args, "repo_dir", None)
+        state_dir = getattr(args, "state_dir", None)
+        missing = [
+            name for name, val in (("--container", container), ("--repo-dir", repo_dir))
+            if not val
+        ]
+        if missing:
+            print(
+                f"Error: --env-backend=docker requires {', '.join(missing)}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        from reyn.environment import DockerEnvironmentBackend
+        backend = DockerEnvironmentBackend(container=container, repo_dir=repo_dir)
+        return (
+            backend,
+            Path(repo_dir),
+            Path(state_dir) if state_dir else None,
+        )
+
+    # argparse `choices` prevents this, but stay defensive.
+    print(f"Error: unknown --env-backend '{backend_kind}'.", file=sys.stderr)
+    sys.exit(1)
 
 
 def _read_input(args: argparse.Namespace) -> str:

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -1,0 +1,104 @@
+"""Tier 2: FP-0008 #1115 Stage 2 — `reyn run` container-backend flags.
+
+`reyn run --env-backend=docker --container=<id> --repo-dir=/testbed
+--state-dir=<host>` builds a single DockerEnvironmentBackend that run.py injects
+at BOTH the FS seam (Agent.environment_backend) and the exec seam
+(Agent.sandbox_backend) — agent-level uniform, 案C-pure. host (default) keeps the
+identity behavior. The flags are generic (no skill-specific knowledge, P7).
+
+These pin the flag→backend construction + validation (the new logic). The
+threading of the injected instance through to Workspace / OpContext is already
+pinned by test_backend_injection_threading_1115_stage2.
+
+No mocks; real argparse.Namespace + real DockerEnvironmentBackend (no docker
+daemon touched — construction only). Docstrings open "Tier 2:".
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from reyn.cli.commands.run import _build_environment_backend
+
+
+def _args(**kw) -> argparse.Namespace:
+    base = {
+        "env_backend": "host",
+        "container": None,
+        "repo_dir": None,
+        "state_dir": None,
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_host_backend_returns_none_triple() -> None:
+    """Tier 2: --env-backend=host yields no backend + default dirs (unchanged behavior)."""
+    backend, base_dir, state_dir = _build_environment_backend(_args(env_backend="host"))
+    assert backend is None
+    assert base_dir is None
+    assert state_dir is None
+
+
+def test_default_is_host() -> None:
+    """Tier 2: a Namespace without env_backend defaults to host (getattr fallback)."""
+    backend, base_dir, state_dir = _build_environment_backend(argparse.Namespace())
+    assert (backend, base_dir, state_dir) == (None, None, None)
+
+
+def test_docker_builds_single_backend_with_dirs() -> None:
+    """Tier 2: --env-backend=docker builds a DockerEnvironmentBackend + maps the dirs."""
+    backend, base_dir, state_dir = _build_environment_backend(
+        _args(
+            env_backend="docker",
+            container="reyn_inst_1",
+            repo_dir="/testbed",
+            state_dir="/host/state",
+        )
+    )
+    assert backend is not None
+    assert backend.container == "reyn_inst_1"
+    assert backend.repo_dir == "/testbed"
+    # base_dir = in-container repo path; state_dir = host-side path.
+    assert base_dir == Path("/testbed")
+    assert state_dir == Path("/host/state")
+
+
+def test_docker_backend_satisfies_both_protocols() -> None:
+    """Tier 2: the single docker instance satisfies BOTH the FS and exec Protocols.
+
+    This is what makes run.py's dual-seam injection (environment_backend +
+    sandbox_backend = the same instance) agent-level uniform (案C-pure).
+    """
+    from reyn.environment import EnvironmentBackend
+    from reyn.sandbox import SandboxBackend
+
+    backend, _b, _s = _build_environment_backend(
+        _args(env_backend="docker", container="c", repo_dir="/testbed", state_dir="/h")
+    )
+    assert isinstance(backend, EnvironmentBackend), "must satisfy the FS seam Protocol"
+    assert isinstance(backend, SandboxBackend), "must satisfy the exec seam Protocol"
+
+
+def test_docker_without_state_dir_keeps_base_dir_and_backend() -> None:
+    """Tier 2: --state-dir omitted → state_dir None (host default), backend + base_dir still set."""
+    backend, base_dir, state_dir = _build_environment_backend(
+        _args(env_backend="docker", container="c", repo_dir="/testbed")
+    )
+    assert backend is not None
+    assert base_dir == Path("/testbed")
+    assert state_dir is None
+
+
+def test_docker_missing_container_exits() -> None:
+    """Tier 2: --env-backend=docker without --container is a clean exit."""
+    with pytest.raises(SystemExit):
+        _build_environment_backend(_args(env_backend="docker", repo_dir="/testbed"))
+
+
+def test_docker_missing_repo_dir_exits() -> None:
+    """Tier 2: --env-backend=docker without --repo-dir is a clean exit."""
+    with pytest.raises(SystemExit):
+        _build_environment_backend(_args(env_backend="docker", container="c"))


### PR DESCRIPTION
**[e2e-coder]** — Refs #1115. PR-β2a of the #234 wave (lead-coder ruled fork → option (a): generic `reyn run` flags). Foundational, skill-agnostic half of the C7 in-container wiring; PR-β2b adds the per-instance container lifecycle that drives it.

## What
Generic container-backend flags on `reyn run` so the repo FS + command exec route through a running container while the OS stays host-side (#1115 option ②):
- `--env-backend {host,docker}` (default `host` = unchanged identity behavior)
- `--container NAME` — running container for docker
- `--repo-dir PATH` — in-container repo working tree (relative paths + cwd resolve here)
- `--state-dir PATH` — host-side OS state/artifacts dir (kept off the routed FS)

`_build_environment_backend` constructs **one** `DockerEnvironmentBackend`; run.py injects that **same instance** at both seams — `Agent.environment_backend` (FS) and `Agent.sandbox_backend` (exec) — agent-level uniform (案C-pure), landing on the seam #1121 already created. `workspace_base_dir` = `--repo-dir`; `workspace_state_dir` = `--state-dir`.

**Cross-process correctness**: a live backend *instance* can't cross a subprocess boundary, so config (flags) crosses and the instance is reconstructed inside `run.py` — consistent with the existing `sandbox_config`→`get_default_backend` pattern.

## Review gate mapping (lead-coder)
- ✅ **gate 1 (flags GENERIC, P7)**: zero swe_bench/swebench/testbed strings in run.py (the in-container example uses a neutral `/repo`). Flags are generic container-backend params.
- ✅ **gate 2 (dual-seam, same instance)**: one `DockerEnvironmentBackend` injected at both `environment_backend` + `sandbox_backend`; pinned via a test asserting the single instance satisfies BOTH the `EnvironmentBackend` and `SandboxBackend` Protocols.
- (gates 3–6 — bridge-free in-container patch, runner lifecycle, exec/eval split, supervised live run — are PR-β2b.)

## Test plan
- [x] `pytest tests/test_run_container_backend_flags_1115.py -q` → 7 passed (host triple; docker single-backend+dirs; dual-Protocol; no-state-dir; missing-container/-repo-dir exits)
- [x] `reyn run --help` shows all 4 flags wired
- [x] P7: `grep -c "swe_bench|swebench|testbed" run.py` → 0
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean / 0 violations
- [x] Full suite `pytest -q --ignore=.claude` → 6531 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`, local extractor-lib diff, not in CI)
- [ ] (skipped — PR-β2b) live in-container run: needs the lifecycle PR + user-supervised docker. host path unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)