### PR TITLE
feat(fp-0008): #1115 Stage 2 — swe_bench_runner per-instance container lifecycle (β2b, live-validated)

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -224,6 +224,98 @@ def run_reyn(
     return {"ok": True, "patch": patch}
 
 
+# ── in-container lifecycle (β2b) ─────────────────────────────────────────────
+
+
+def _default_docker_runner(argv: list[str], *, timeout: int = 180):
+    """Run a docker CLI command and return the CompletedProcess.
+
+    Injectable in tests so the lifecycle is exercised without a real daemon.
+    """
+    return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+
+
+def run_reyn_in_container(
+    instance: dict[str, Any],
+    *,
+    image: str,
+    repo_dir: str = "/testbed",
+    state_dir: str | None = None,
+    docker_bin: str = "docker",
+    reyn_base: list[str] | None = None,
+    timeout: int = 600,
+    docker_runner=None,
+    container_name: str | None = None,
+) -> dict[str, Any]:
+    """Run `swe_bench` inside a fresh per-instance container; return a result dict.
+
+    Lifecycle (FP-0008 #1115 Stage 2 β2b):
+      1. ``docker run -d --name <name> <image> sleep infinity`` — start the
+         pre-built SWE-bench instance container (repo already at ``repo_dir``).
+      2. ``reyn run swe_bench --env-backend=docker --container <name>
+         --repo-dir <repo_dir> --state-dir <host>`` — the skill's repo FS +
+         commands route into the container (bridge-free, /testbed direct edit);
+         the final ``git diff HEAD`` runs in-container, so the model_patch is the
+         in-container diff (parsed by the existing ``extract_patch``).
+      3. ``docker rm -f <name>`` — teardown, **always** (even on failure).
+
+    Returns the same shape as :func:`run_reyn`
+    (``{"ok": True, "patch": ...}`` / ``{"ok": False, "error": ...}``).
+
+    ``docker_runner`` is injectable for tests: ``callable(argv, *, timeout)`` →
+    an object with ``.returncode`` / ``.stdout`` / ``.stderr``.
+    """
+    import tempfile
+    import uuid
+
+    runner = docker_runner or _default_docker_runner
+    instance_id = instance["instance_id"]
+    name = container_name or f"reyn_swebench_{instance_id}_{uuid.uuid4().hex[:8]}"
+    host_state = state_dir or tempfile.mkdtemp(prefix="reyn_swebench_state_")
+
+    print(
+        f"[swe_bench_runner] docker run image={image} name={name} (instance={instance_id})",
+        file=sys.stderr,
+    )
+    try:
+        start = runner(
+            [docker_bin, "run", "-d", "--name", name, image, "sleep", "infinity"],
+            timeout=300,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"ok": False, "error": f"docker run error: {exc}"}
+    if start.returncode != 0:
+        return {
+            "ok": False,
+            "error": f"docker run failed (rc={start.returncode}): {(start.stderr or '')[:400]}",
+        }
+
+    try:
+        base = reyn_base if reyn_base is not None else ["reyn", "run", "swe_bench"]
+        full_cmd = [
+            *base,
+            "--env-backend=docker",
+            "--container", name,
+            "--repo-dir", repo_dir,
+            "--state-dir", host_state,
+        ]
+        return run_reyn(instance, reyn_cmd=full_cmd, timeout=timeout)
+    finally:
+        try:
+            rm = runner([docker_bin, "rm", "-f", name], timeout=120)
+            if getattr(rm, "returncode", 0) != 0:
+                print(
+                    f"[swe_bench_runner] WARN teardown rm -f {name} rc={rm.returncode}: "
+                    f"{(rm.stderr or '')[:200]}",
+                    file=sys.stderr,
+                )
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(
+                f"[swe_bench_runner] WARN teardown rm -f {name} raised: {exc}",
+                file=sys.stderr,
+            )
+
+
 # ── CLI entry point ──────────────────────────────────────────────────────────
 
 
@@ -267,6 +359,42 @@ def build_parser() -> argparse.ArgumentParser:
             "Useful for testing with a local install: --reyn-cmd 'python -m reyn'."
         ),
     )
+    # FP-0008 #1115 Stage 2 (β2b): faithful in-container run. When
+    # --env-backend=docker, the runner owns the per-instance container lifecycle
+    # (docker run the official SWE-bench image → reyn run inside it via the
+    # generic --env-backend flags → teardown), so the swe_bench skill's
+    # repo FS + commands execute against the pre-built /testbed, not the host.
+    p.add_argument(
+        "--env-backend", dest="env_backend", choices=["host", "docker"],
+        default="host",
+        help=(
+            "Where the swe_bench skill's repo FS + commands run: 'host' (default) "
+            "or 'docker' (per-instance container from --image; faithful in-container run)."
+        ),
+    )
+    p.add_argument(
+        "--image", dest="image", default=None, metavar="IMAGE",
+        help=(
+            "Docker image for --env-backend=docker — the pre-built SWE-bench "
+            "instance image whose repo is checked out at --repo-dir (e.g. an "
+            "official swebench/sweb.eval.* image). Required with --env-backend=docker."
+        ),
+    )
+    p.add_argument(
+        "--repo-dir", dest="repo_dir", default="/testbed", metavar="PATH",
+        help="In-container repo working tree for --env-backend=docker (default: /testbed).",
+    )
+    p.add_argument(
+        "--state-dir", dest="state_dir", default=None, metavar="PATH",
+        help=(
+            "Host-side OS state/artifacts dir for --env-backend=docker. "
+            "Defaults to a per-run temp directory when omitted."
+        ),
+    )
+    p.add_argument(
+        "--docker-bin", dest="docker_bin", default="docker", metavar="BIN",
+        help="Docker CLI binary for --env-backend=docker (default: docker).",
+    )
 
     return p
 
@@ -304,8 +432,26 @@ def main(argv: list[str] | None = None) -> int:
     else:
         reyn_cmd = None  # run_reyn uses default ["reyn", "run", "swe_bench"]
 
-    # ── run reyn ──────────────────────────────────────────────────────────────
-    result = run_reyn(instance, reyn_cmd=reyn_cmd, timeout=args.timeout)
+    # ── run reyn (host, or in a per-instance container for faithful eval) ──────
+    if getattr(args, "env_backend", "host") == "docker":
+        if not args.image:
+            print(
+                "Error: --env-backend=docker requires --image "
+                "(the pre-built SWE-bench instance image).",
+                file=sys.stderr,
+            )
+            return 1
+        result = run_reyn_in_container(
+            instance,
+            image=args.image,
+            repo_dir=args.repo_dir,
+            state_dir=args.state_dir,
+            docker_bin=args.docker_bin,
+            reyn_base=reyn_cmd,
+            timeout=args.timeout,
+        )
+    else:
+        result = run_reyn(instance, reyn_cmd=reyn_cmd, timeout=args.timeout)
 
     # ── emit harness output ───────────────────────────────────────────────────
     if result["ok"]:

--- a/tests/test_swe_bench_runner_container_1115.py
+++ b/tests/test_swe_bench_runner_container_1115.py
@@ -1,0 +1,180 @@
+"""Tier 2: FP-0008 #1115 Stage 2 (β2b) — swe_bench_runner per-instance container lifecycle.
+
+``run_reyn_in_container`` owns the per-instance Docker lifecycle for a faithful
+in-container run: ``docker run -d`` the pre-built image → ``reyn run swe_bench``
+with the generic ``--env-backend=docker`` flags → ``docker rm -f`` (always).
+
+Lifecycle (docker) is exercised via an injectable recording runner — no daemon.
+The reyn subprocess is a small recording shim that captures the flags it received
+and prints a Final Output block, so the flag wiring + patch extraction are pinned
+end-to-end without a real reyn install. No mocks. Docstrings open "Tier 2:".
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from scripts.swe_bench_runner import run_reyn_in_container
+
+_INSTANCE = {
+    "instance_id": "marshmallow-code__marshmallow-1359",
+    "repo": "marshmallow-code/marshmallow",
+    "base_commit": "abc123",
+    "problem_statement": "Fix a bug.",
+    "test_patch": "diff --git a/tests/t.py b/tests/t.py",
+}
+
+
+class _RecordingDocker:
+    """Injectable docker runner: records argv, returns a configurable result."""
+
+    def __init__(self, *, run_rc: int = 0, run_stderr: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._run_rc = run_rc
+        self._run_stderr = run_stderr
+
+    def __call__(self, argv, *, timeout=180):
+        self.calls.append(list(argv))
+        is_run = "run" in argv
+        return types.SimpleNamespace(
+            returncode=self._run_rc if is_run else 0,
+            stdout="container_id_123\n",
+            stderr=self._run_stderr if is_run else "",
+        )
+
+
+def _recording_reyn(tmp_path: Path):
+    """A reyn shim that writes its received argv to a file and prints a patch.
+
+    Returns ``(reyn_base, argv_out_path)``.
+    """
+    script = tmp_path / "rec_reyn.py"
+    script.write_text(
+        "import sys, os, json\n"
+        "open(os.environ['REYN_ARGV_OUT'], 'w', encoding='utf-8')"
+        ".write('\\n'.join(sys.argv[1:]))\n"
+        "print('=== Final Output ===')\n"
+        "print(json.dumps({'patch': 'diff --git a/f b/f\\n--- a/f\\n+++ b/f\\n'}))\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "argv.txt"
+    base = ["env", f"REYN_ARGV_OUT={out}", sys.executable, str(script)]
+    return base, out
+
+
+def test_container_lifecycle_happy_path(tmp_path: Path) -> None:
+    """Tier 2: docker run → reyn → docker rm, returns ok+patch, run precedes rm, same name."""
+    docker = _RecordingDocker()
+    reyn_base, _argv_out = _recording_reyn(tmp_path)
+
+    result = run_reyn_in_container(
+        _INSTANCE,
+        image="swebench/sweb.eval.x86_64.example:latest",
+        repo_dir="/testbed",
+        state_dir=str(tmp_path / "state"),
+        reyn_base=reyn_base,
+        timeout=30,
+        docker_runner=docker,
+    )
+
+    assert result["ok"] is True, f"expected ok, got {result!r}"
+    assert result["patch"].startswith("diff --git a/f b/f")
+
+    # Behavior: a `docker run` precedes a `docker rm -f` for the SAME container.
+    run_idx = next(i for i, c in enumerate(docker.calls) if c[:2] == ["docker", "run"])
+    rm_idx = next(i for i, c in enumerate(docker.calls) if c[:3] == ["docker", "rm", "-f"])
+    assert run_idx < rm_idx, f"container must be started before teardown: {docker.calls}"
+    run_call, rm_call = docker.calls[run_idx], docker.calls[rm_idx]
+    assert "swebench/sweb.eval.x86_64.example:latest" in run_call
+    name = run_call[run_call.index("--name") + 1]
+    assert rm_call[-1] == name, f"teardown must target the started container: {docker.calls}"
+
+
+def test_container_passes_generic_env_backend_flags_to_reyn(tmp_path: Path) -> None:
+    """Tier 2: reyn is invoked with the generic --env-backend=docker flags + the container name."""
+    docker = _RecordingDocker()
+    reyn_base, argv_out = _recording_reyn(tmp_path)
+    state = str(tmp_path / "state")
+
+    run_reyn_in_container(
+        _INSTANCE,
+        image="img:latest",
+        repo_dir="/testbed",
+        state_dir=state,
+        reyn_base=reyn_base,
+        timeout=30,
+        docker_runner=docker,
+    )
+
+    received = argv_out.read_text(encoding="utf-8").splitlines()
+    name = docker.calls[0][docker.calls[0].index("--name") + 1]
+    assert "--env-backend=docker" in received
+    assert "--container" in received and received[received.index("--container") + 1] == name
+    assert "--repo-dir" in received and received[received.index("--repo-dir") + 1] == "/testbed"
+    assert "--state-dir" in received and received[received.index("--state-dir") + 1] == state
+    # run_reyn appends the instance JSON as the final argv.
+    assert any(_INSTANCE["instance_id"] in tok for tok in received)
+
+
+def test_container_teardown_runs_even_on_reyn_failure(tmp_path: Path) -> None:
+    """Tier 2: a reyn non-zero exit still tears the container down (finally)."""
+    docker = _RecordingDocker()
+    # A reyn base that exits non-zero (no Final Output).
+    reyn_base = ["env", "X=1", sys.executable, "-c", "import sys; sys.exit(1)"]
+
+    result = run_reyn_in_container(
+        _INSTANCE,
+        image="img:latest",
+        state_dir=str(tmp_path / "s"),
+        reyn_base=reyn_base,
+        timeout=30,
+        docker_runner=docker,
+    )
+
+    assert result["ok"] is False
+    # rm -f must still have been called after the failed reyn run.
+    assert any(c[:3] == ["docker", "rm", "-f"] for c in docker.calls), docker.calls
+
+
+def test_container_docker_run_failure_skips_reyn_and_teardown(tmp_path: Path) -> None:
+    """Tier 2: a failed `docker run` returns an error and does not run reyn or rm."""
+    docker = _RecordingDocker(run_rc=1, run_stderr="no such image")
+    reyn_base, argv_out = _recording_reyn(tmp_path)
+
+    result = run_reyn_in_container(
+        _INSTANCE,
+        image="img:missing",
+        state_dir=str(tmp_path / "s"),
+        reyn_base=reyn_base,
+        timeout=30,
+        docker_runner=docker,
+    )
+
+    assert result["ok"] is False
+    assert "docker run failed" in result["error"]
+    # Behavior: the run was attempted, but no teardown (nothing started) and
+    # reyn was never invoked.
+    assert any(c[:2] == ["docker", "run"] for c in docker.calls), docker.calls
+    assert not any(c[:3] == ["docker", "rm", "-f"] for c in docker.calls), (
+        f"no teardown when the container never started: {docker.calls}"
+    )
+    assert not argv_out.exists(), "reyn must not run when the container failed to start"
+
+
+def test_runner_parser_has_container_flags() -> None:
+    """Tier 2: build_parser wires the --env-backend/--image/--repo-dir/--state-dir flags."""
+    import argparse
+    import contextlib
+    import io
+
+    from scripts.swe_bench_runner import build_parser
+
+    parser = build_parser()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), contextlib.suppress(SystemExit):
+        parser.parse_args(["--help"])
+    help_text = buf.getvalue()
+    for flag in ("--env-backend", "--image", "--repo-dir", "--state-dir"):
+        assert flag in help_text, f"{flag} must be wired in swe_bench_runner"
+    assert isinstance(parser, argparse.ArgumentParser)


### PR DESCRIPTION
**[e2e-coder]** — Refs #1115. PR-β2b of the #234 wave; completes the C7 in-container harness wiring on top of the generic `reyn run` flags (#1130). **Live-validated** (user-supervised) before opening, per write+validate-together.

## What
`swe_bench_runner.py` gains the per-instance Docker lifecycle for a faithful in-container run. New flags `--env-backend{host,docker}/--image/--repo-dir(default /testbed)/--state-dir/--docker-bin`. `run_reyn_in_container` owns the lifecycle:
1. `docker run -d --name <name> <image> sleep infinity` (pre-built SWE-bench instance image, repo at `--repo-dir`)
2. `reyn run swe_bench --env-backend=docker --container <name> --repo-dir … --state-dir <host>` (the generic flags from #1130) — skill repo FS + commands route into the container
3. `docker rm -f <name>` — teardown, **always** (finally)

The final `git diff HEAD` runs in-container, so the model_patch is the in-container diff (parsed by the existing `extract_patch`). `host` (default) path unchanged. exec=backend / eval=swebench-delegate split preserved.

## Live validation (primary evidence — lead-coder's 7-point checklist)
Run: `pallets__flask-5014` (<15-min tier, pure-Python) on official image `swebench/sweb.eval.x86_64.pallets_1776_flask-5014` (3.99GB, amd64-on-arm64). Events: `.reyn/events/.../2026-05-31T103107_swe_bench.jsonl`.
- ✅ **FS-seam → container**: `file.read src/flask/blueprints.py` returned the real `/testbed` flask content
- ✅ **exec-seam → container**: `sandboxed_exec_completed backend=docker rc=0` for `git apply --3way …` and `git checkout HEAD -- tests/test_blueprints.py`
- ✅ **dual-seam live-proven**: the one injected `DockerEnvironmentBackend` served both FS-read and docker-exec (案C-pure)
- ✅ setup→explore→plan→apply completed; ✅ state host-side; ✅ teardown clean (0 containers after); ✅ P4 gating correct (setup skipped file/run_skill)
- ⚠️ **verify did not reach PASS**: the weak model (gemini-2.5-flash-lite) emitted `sandboxed_exec` ops **missing `argv`** (3 attempts). Structural-verify: the op is correctly advertised — the *same* model emitted a *valid* argv `sandboxed_exec` (git apply, rc=0) — so this is weak-model op-shape inconsistency, **not** a plumbing/advertisement issue. Per "flow > PASS, first instance" + "PASS = internal signal", the in-container flow proof is the milestone; the verify-op-formatting is a weak-model calibration observation, not a C7 blocker.

Minor note (follow-up, not this PR): events use the hardcoded `Agent.state_dir=".reyn"` rather than `workspace_state_dir`/`--state-dir` — both host-side (P6 OK) but not co-located with the container-split state dir.

## Test plan
- [x] `pytest tests/test_swe_bench_runner_container_1115.py tests/test_swe_bench_runner.py -q` → 20 passed (lifecycle: run→reyn→rm; teardown-on-failure; run-fail-skips-teardown; generic flags reach reyn; parser flags)
- [x] `ruff` + `scripts/test_tier_audit.py --strict` → clean / 0 violations (size-pins rewritten to behavior-pins)
- [x] Full suite `pytest -q --ignore=.claude` → 6536 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`, local extractor-lib diff, not in CI)
- [x] **Live in-container run** (above) — flow proven end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)