### PR TITLE
fix(fp-0008): #1133 — advertise sandboxed_exec in available_ops (model-driven exec was structurally broken)

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -228,6 +228,28 @@ class ControlIRExecutor:
                 ),
                 example={"kind": "shell", "cmd": "reyn run my_skill 'hello'", "timeout": 120},
             )] if self._shell_allowed else []),
+            ControlIROpSpec(
+                kind="sandboxed_exec",
+                description=(
+                    "Execute a command under a sandbox policy and return stdout, stderr, "
+                    "and returncode. "
+                    "argv: the command as a LIST of strings — argv[0] is the executable, "
+                    "e.g. [\"python\", \"-m\", \"pytest\", \"-x\"]. It is NOT a single shell "
+                    "string and NOT a 'command'/'cmd' field — always provide argv as a list. "
+                    "There is no shell: pipes, redirects (>, 2>&1), globs, and &&/|| are NOT "
+                    "interpreted — pass real argv tokens only. "
+                    "Runs in the project root directory; stdout and stderr are captured "
+                    "separately (do not append redirections). "
+                    "Optional policy fields (network: bool, read_paths/write_paths: list[str], "
+                    "allow_subprocess: bool, env_passthrough: list[str], timeout_seconds: int) "
+                    "may be omitted — when the phase declares a default sandbox policy the OS "
+                    "applies it and overrides them. "
+                    "Use for git, pytest, build, and other repository commands. "
+                    "Status: enabled by default — issue sandboxed_exec ops directly; do not "
+                    "abort on permission concerns."
+                ),
+                example={"kind": "sandboxed_exec", "argv": ["python", "-m", "pytest", "-x", "--tb=short"]},
+            ),
             *([ControlIROpSpec(
                 kind="mcp",
                 description=(

--- a/tests/test_sandboxed_exec_advertised_1133.py
+++ b/tests/test_sandboxed_exec_advertised_1133.py
@@ -1,0 +1,98 @@
+"""Tier 2: FP-0008 #1133 — sandboxed_exec is advertised in available_ops().
+
+Root cause of the C7 verify-fail (live flask-5014): `available_ops()` never
+emitted a `sandboxed_exec` ControlIROpSpec, so a phase that declared
+`allowed_ops: [sandboxed_exec]` (after the #1126/#1127 migration) had the op
+filtered to nothing — the LLM never saw `argv`, guessed a shell `command`
+string, and failed ActOutput validation. Same class as
+test ... wire-full-frontmatter-to-runtime path: handler/runtime wired, the
+advertisement path was not.
+
+These pin: the spec exists, its description makes `argv` a required LIST (not a
+shell string / not a `command` field), its example is a valid op, and a phase
+that allows sandboxed_exec actually surfaces it through the allowed_ops filter.
+
+No mocks; real ControlIRExecutor + real SandboxedExecIROp. Docstrings open "Tier 2:".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.permissions.permissions import PermissionResolver
+from reyn.schemas.models import SandboxedExecIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _executor(tmp_path: Path, *, shell_allowed: bool = False) -> ControlIRExecutor:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return ControlIRExecutor(
+        workspace=ws,
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={}, project_root=tmp_path, interactive=False
+        ),
+        skill_name="t",
+        shell_allowed=shell_allowed,
+    )
+
+
+def _spec(executor, kind):
+    return next((s for s in executor.available_ops() if s.kind == kind), None)
+
+
+def test_sandboxed_exec_is_advertised(tmp_path: Path) -> None:
+    """Tier 2: available_ops() includes a sandboxed_exec spec (the missing advertisement)."""
+    spec = _spec(_executor(tmp_path), "sandboxed_exec")
+    assert spec is not None, (
+        "available_ops() must advertise sandboxed_exec — without it a phase that "
+        "lists it in allowed_ops gets the op filtered to nothing."
+    )
+
+
+def test_sandboxed_exec_advertised_regardless_of_shell_allowed(tmp_path: Path) -> None:
+    """Tier 2: sandboxed_exec is advertised even when shell is off (it is not the shell op)."""
+    assert _spec(_executor(tmp_path, shell_allowed=False), "sandboxed_exec") is not None
+    assert _spec(_executor(tmp_path, shell_allowed=True), "sandboxed_exec") is not None
+
+
+def test_sandboxed_exec_description_requires_argv_list_not_command_string(tmp_path: Path) -> None:
+    """Tier 2: the description steers the LLM to argv-as-list, not a shell `command` string.
+
+    This directly counters the observed failure (model emitted `command: "git …"`).
+    """
+    desc = _spec(_executor(tmp_path), "sandboxed_exec").description.lower()
+    assert "argv" in desc, "description must name the argv field"
+    assert "list" in desc, "description must say argv is a list"
+    # Must warn it is not a single shell string / not a command field.
+    assert "command" in desc or "cmd" in desc, (
+        "description should explicitly contrast with a shell command/cmd field"
+    )
+    assert "shell" in desc, "description should state there is no shell interpretation"
+
+
+def test_sandboxed_exec_example_is_a_valid_op(tmp_path: Path) -> None:
+    """Tier 2: the advertised example validates as a real SandboxedExecIROp with a list argv."""
+    spec = _spec(_executor(tmp_path), "sandboxed_exec")
+    assert isinstance(spec.example.get("argv"), list), "example argv must be a list"
+    op = SandboxedExecIROp(**spec.example)  # raises if the advertised example is invalid
+    assert op.kind == "sandboxed_exec"
+    assert op.argv == spec.example["argv"]
+
+
+def test_phase_allowing_sandboxed_exec_surfaces_it_through_filter(tmp_path: Path) -> None:
+    """Tier 2: with allowed_ops={sandboxed_exec}, the op survives the available-ops filter.
+
+    Mirrors the runtime build_frame filter (runtime.py: op.kind in allowed). This is
+    the exact regression: pre-#1133, sandboxed_exec ∈ allowed_ops but ∉ available_ops()
+    → filtered to nothing.
+    """
+    executor = _executor(tmp_path)
+    allowed = {"file", "sandboxed_exec"}
+    filtered = [op for op in executor.available_ops() if op.kind in allowed]
+    kinds = {op.kind for op in filtered}
+    assert "sandboxed_exec" in kinds, (
+        f"a phase allowing sandboxed_exec must surface it; filtered kinds={kinds}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — Refs #1133, #1115. Forward-fix for a latent regression my #1126/#1127 migration exposed; lands on its own merit (orthogonal to the new decide-turn observation below).

## Root cause (primary evidence)
`available_ops()` (control_ir_executor) never emitted a `sandboxed_exec` `ControlIROpSpec`. So the op was never advertised to the LLM — `argv` appeared **0×** in the request context (lead-coder confirmed via `dogfood_trace --mode llm-context`). After #1126/#1127 moved swe_bench phases onto `allowed_ops: [sandboxed_exec]`, the per-phase available-ops filter (`op.kind in allowed_ops`) dropped the op to nothing. The model, never shown `argv`, guessed a shell `command` string → `ActOutput` rejected it (`argv` required). The live flask-5014 verify failed this way 3×; the only valid `sandboxed_exec` ops in that run were **preprocessor-built** (`args_from`), never model-emitted.

Same class as the loader-gap pattern: handler + runtime were wired; the **LLM-advertisement path** was not.

## Fix
Add the `sandboxed_exec` `ControlIROpSpec` to `available_ops()`:
- description steers the model to **argv as a LIST**, explicitly warns it is **not** a shell `command`/`cmd` string and there is **no shell** interpretation (the exact observed failure mode); covers all `SandboxedExecIROp` policy fields; example uses a list `argv`.
- **unconditional** (not gated like `shell`): `sandboxed_exec` is default-permissible and works under every backend; per-phase `allowed_ops` is the gate, like `file`/`run_skill`. **Additive** — phases not allowing it are unaffected (catalog is filtered per `allowed_ops`).

## Gate-6 validation (both sides + provenance — applied the co-sign-provenance lesson)
Re-ran flask-5014 in-container **with this fix**:
- **REQUEST side**: the verify request context now contains the `sandboxed_exec` spec with "argv: the command as a LIST" (deterministic build confirms `available_control_ops=[file, sandboxed_exec]` with argv in the description).
- **RESPONSE side (provenance = LLM-authored responses, not preprocessor)**: the model emitted `sandboxed_exec` with `argv` **×5** and `command`/`cmd` **×0** — e.g. setup `argv:["git","checkout","7ee9ceb…"]`, verify `argv:["python","-m","pytest","tests/test_blueprints.py"]`. Before the fix: argv 0 / all `command`. → model-driven exec restored.

## Scope note (separate, NOT this PR)
The re-run's verify still didn't reach a test PASS, but the **failure mode changed** (`argv Field required` → `decide-turn output missing required 'control' block`) — a *different* issue. Request-side check shows the control contract **is** advertised and the model produced valid control blocks in 5/5 other-phase decides, so this is not the same absent-advertisement bug; it leans weak-model inconsistency but the specific failing decide output isn't fully isolated yet. Being articulated as a separate issue with that evidence — not bundled here.

## Test plan
- [x] `pytest tests/test_sandboxed_exec_advertised_1133.py tests/test_control_ir_executor.py tests/test_op_sandboxed_exec.py -q` → 33 passed (spec present; advertised regardless of shell_allowed; description requires argv-list-not-command; example is a valid `SandboxedExecIROp`; allowed_ops:[sandboxed_exec] surfaces it through the filter)
- [x] `ruff` + `scripts/test_tier_audit.py --strict` → clean / 0 violations
- [x] P7: zero skill-specific strings in the spec
- [x] Full suite `pytest -q --ignore=.claude` → 6541 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`, local extractor-lib diff, not in CI)
- [x] **Live re-run** (flask-5014, in-container) — model now emits valid `argv` (gate-6, evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)