### PR TITLE
feat(fp-0008): #1135(b) — capture raw LLM output on phase-output validation failure (write-side)

### DIFF
--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pydantic
@@ -47,6 +48,11 @@ if TYPE_CHECKING:
     from reyn.user_intervention import RequestBus
 
 _log = logging.getLogger(__name__)
+
+# FP-0008 #1135(b): inline cap for the raw LLM output captured on a phase-output
+# validation failure. Larger payloads are offloaded (size axis, non-history) so
+# the P6 events audit log never balloons.
+_RAW_OUTPUT_INLINE_CAP = 8192
 
 
 class PhaseExecutor:
@@ -104,6 +110,44 @@ class PhaseExecutor:
         # _run_act_loop so RunOrchestrator can snapshot them at A → B
         # transition (= `rollback_state.snapshot_phase_history`).
         self._last_control_ir_results: list[dict] = []
+
+    # ── #1135(b): raw-output capture on phase-output validation failure ───────
+
+    def _emit_output_validation_failed(
+        self, *, phase: str, attempt: int, failure_kind: str, error: str, raw: dict,
+    ) -> None:
+        """Emit the additive `phase_output_validation_failed` event (#1135b).
+
+        Captures the model's raw emitted output that failed validation into the
+        always-on P6 audit log — otherwise it survives only in the opt-in
+        REYN_LLM_TRACE_DUMP. Emitted ALONGSIDE the existing kind-specific
+        validation event (which is left unchanged for TUI/test back-compat).
+
+        Per #1135 canonical contract: inline ``raw_output`` when ≤ cap, else a
+        ``raw_output_ref`` = state_dir-RELATIVE offload handle (the offload value
+        returns an absolute ref; converted to relative explicitly so the ref is
+        portable in the long-lived audit log). Exactly one of raw_output /
+        raw_output_ref is non-null. No hash field.
+        """
+        serialized = json.dumps(raw, ensure_ascii=False)
+        raw_output: str | None = None
+        raw_output_ref: str | None = None
+        if len(serialized.encode("utf-8")) <= _RAW_OUTPUT_INLINE_CAP:
+            raw_output = serialized
+        else:
+            from reyn.services.offload import offload_value
+            state_dir = self._control_ir_executor.workspace.state_dir
+            res = offload_value(serialized, store_dir=state_dir / "control_ir_offload")
+            raw_output_ref = str(Path(res.path_ref).relative_to(state_dir))
+        self._events.emit(
+            "phase_output_validation_failed",
+            phase=phase,
+            attempt=attempt,
+            failure_kind=failure_kind,
+            error=error,
+            raw_output=raw_output,
+            raw_output_ref=raw_output_ref,
+        )
 
     # ── Phase-budget enforcement (moved up from Component B shim) ─────────────
 
@@ -179,6 +223,7 @@ class PhaseExecutor:
         allowed_next: list[str],
         state: "RunState",
         input_artifact: dict | None = None,
+        attempt: int = 0,
     ) -> tuple[NormalizationResult, LLMOutput]:
         """Normalize and validate one LLM response.
 
@@ -195,9 +240,17 @@ class PhaseExecutor:
             result = normalize(raw, allowed_next)
         except ControlIRValidationError as exc:
             self._events.emit("control_ir_validation_error", phase=current_phase, error=str(exc))
+            self._emit_output_validation_failed(
+                phase=current_phase, attempt=attempt, failure_kind="control_ir",
+                error=str(exc), raw=raw,
+            )
             raise ValueError(str(exc)) from exc
         except NormalizationError as exc:
             self._events.emit("normalization_error", phase=current_phase, error=str(exc))
+            self._emit_output_validation_failed(
+                phase=current_phase, attempt=attempt, failure_kind="normalization",
+                error=str(exc), raw=raw,
+            )
             raise ValueError(str(exc)) from exc
 
         self._events.emit(
@@ -233,6 +286,10 @@ class PhaseExecutor:
             _validate_artifact_structure(normalized, current_phase)
         except ValueError as exc:
             self._events.emit("validation_error", phase=current_phase, error=str(exc))
+            self._emit_output_validation_failed(
+                phase=current_phase, attempt=attempt, failure_kind="artifact_structure",
+                error=str(exc), raw=raw,
+            )
             raise
 
         # P7-clean: the OS supplies the generic context dict; only the
@@ -263,6 +320,10 @@ class PhaseExecutor:
         if errors:
             error_str = "; ".join(errors)
             self._events.emit("validation_error", phase=current_phase, error=error_str)
+            self._emit_output_validation_failed(
+                phase=current_phase, attempt=attempt, failure_kind="artifact_data",
+                error=error_str, raw=raw,
+            )
             raise ValueError(
                 f"Artifact data validation failed for '{normalized.get('type')}': {error_str}"
             )
@@ -276,12 +337,20 @@ class PhaseExecutor:
         except pydantic.ValidationError as exc:
             msg = f"Invalid ops structure: {exc}"
             self._events.emit("validation_error", phase=current_phase, error=msg)
+            self._emit_output_validation_failed(
+                phase=current_phase, attempt=attempt, failure_kind="ops_structure",
+                error=msg, raw=raw,
+            )
             raise ValueError(msg) from exc
 
         try:
             validate_output(output, candidates)
         except ValidationError as exc:
             self._events.emit("validation_error", phase=current_phase, error=str(exc))
+            self._emit_output_validation_failed(
+                phase=current_phase, attempt=attempt, failure_kind="output_validation",
+                error=str(exc), raw=raw,
+            )
             raise ValueError(str(exc)) from exc
 
         return result, output
@@ -451,6 +520,10 @@ class PhaseExecutor:
             try:
                 act = ActOutput.model_validate(raw)
             except pydantic.ValidationError as exc:
+                self._emit_output_validation_failed(
+                    phase=phase, attempt=len(prior_attempts), failure_kind="act_ops",
+                    error=str(exc), raw=raw,
+                )
                 prior_attempts.append({"raw": json.dumps(raw, ensure_ascii=False), "error": str(exc)})
                 if len(prior_attempts) > max_phase_retries:
                     self._events.emit("phase_failed", phase=phase,
@@ -504,6 +577,7 @@ class PhaseExecutor:
             try:
                 result, output = self._validate_phase_output(
                     raw, phase, candidates, allowed_next, state, input_artifact=artifact,
+                    attempt=len(prior_attempts),
                 )
                 return result, output, len(prior_attempts)
             except WorkflowAbortedError:

--- a/tests/test_phase_output_validation_failed_1135b.py
+++ b/tests/test_phase_output_validation_failed_1135b.py
@@ -1,0 +1,139 @@
+"""Tier 2: FP-0008 #1135(b) — phase_output_validation_failed event captures raw LLM output.
+
+When a phase output fails validation, the model's raw emitted output was only in
+the opt-in REYN_LLM_TRACE_DUMP — never in the always-on P6 events log (phase_failed
+/ validation_error carried only the error string). This made failures like the
+decide-turn "missing control block" undiagnosable from events alone.
+
+The additive `phase_output_validation_failed` event (canonical contract in #1135)
+carries the raw output: inline when ≤ cap, else a **state_dir-relative** offload
+handle. Existing validation events are unchanged (TUI/test back-compat).
+
+These pin the new contract behaviorally: inline vs offload by size, the ref is
+state_dir-relative (not absolute) and round-trips via read_offloaded, exactly-one
+of raw_output/raw_output_ref, failure_kind, and a real validation-failure path
+emits the event alongside the unchanged kind-specific one.
+
+Real EventLog / Workspace / ControlIRExecutor; no mocks. Docstring opens "Tier 2:".
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.kernel.phase_executor import _RAW_OUTPUT_INLINE_CAP, PhaseExecutor
+from reyn.services.offload import read_offloaded
+from reyn.workspace.workspace import Workspace
+
+
+def _executor(tmp_path: Path) -> tuple[PhaseExecutor, EventLog, Workspace]:
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path, state_dir=tmp_path / "state")
+    cie = ControlIRExecutor(
+        workspace=ws, events=events, permission_resolver=None, skill_name="t",
+    )
+    # Only control_ir_executor (for workspace.state_dir) + events are exercised by
+    # the capture helper; the rest are inert stores.
+    px = PhaseExecutor(
+        llm_caller=None, control_ir_executor=cie, events=events, skill=None,
+        safety=None, intervention_bus=None, build_frame_fn=None,
+    )
+    return px, events, ws
+
+
+def _last_pov_event(events: EventLog) -> dict:
+    evs = [e for e in events.all() if e.type == "phase_output_validation_failed"]
+    assert evs, "expected a phase_output_validation_failed event"
+    return evs[-1].data
+
+
+def test_small_raw_is_inline(tmp_path: Path) -> None:
+    """Tier 2: a raw output ≤ cap is captured inline in raw_output, ref is null."""
+    px, events, _ws = _executor(tmp_path)
+    raw = {"type": "decide", "oops": "no control block"}
+    px._emit_output_validation_failed(
+        phase="verify", attempt=2, failure_kind="control_ir", error="missing control", raw=raw,
+    )
+    d = _last_pov_event(events)
+    assert d["phase"] == "verify"
+    assert d["attempt"] == 2
+    assert d["failure_kind"] == "control_ir"
+    assert d["error"] == "missing control"
+    assert d["raw_output"] == json.dumps(raw, ensure_ascii=False)
+    assert d["raw_output_ref"] is None
+    # exactly-one invariant
+    assert (d["raw_output"] is None) != (d["raw_output_ref"] is None)
+
+
+def test_large_raw_is_offloaded_with_relative_ref(tmp_path: Path) -> None:
+    """Tier 2: a raw output > cap offloads; ref is state_dir-RELATIVE and round-trips.
+
+    This pins the cross-session contract: the write-side stores a relative ref
+    (not the absolute offload path) and the read-side dereferences it via
+    read_offloaded(state_dir / ref, base_dir=state_dir).
+    """
+    px, events, ws = _executor(tmp_path)
+    big = "x" * (_RAW_OUTPUT_INLINE_CAP + 100)
+    raw = {"type": "act", "ops": [{"kind": "sandboxed_exec", "blob": big}]}
+    px._emit_output_validation_failed(
+        phase="verify", attempt=1, failure_kind="act_ops", error="bad", raw=raw,
+    )
+    d = _last_pov_event(events)
+    assert d["raw_output"] is None
+    ref = d["raw_output_ref"]
+    assert ref is not None
+    # ref must be RELATIVE (not an absolute path)
+    assert not Path(ref).is_absolute(), f"ref must be state_dir-relative, got {ref!r}"
+    # exactly-one invariant
+    assert (d["raw_output"] is None) != (d["raw_output_ref"] is None)
+    # read-side contract: read_offloaded(state_dir / ref, base_dir=state_dir) round-trips.
+    recovered, found = read_offloaded(str(ws.state_dir / ref), base_dir=ws.state_dir)
+    assert found is True
+    assert json.loads(recovered) == raw
+    # the offloaded file lives under the control_ir_offload root.
+    assert ref.startswith("control_ir_offload")
+
+
+def test_existing_validation_events_unchanged_and_new_event_additive(tmp_path: Path) -> None:
+    """Tier 2: a real normalize failure emits BOTH the unchanged kind-specific event and the new one.
+
+    Drives the real _validate_phase_output path with a control-less raw so
+    normalize() rejects it — exercising the additive emit (back-compat: the
+    existing control_ir_validation_error / normalization_error event still fires).
+    """
+    from reyn.kernel.run_state import RunState
+    from reyn.schemas.models import CandidateOutput
+
+    px, events, _ws = _executor(tmp_path)
+    candidates = [
+        CandidateOutput(
+            next_phase="report", schema_name="r",
+            artifact_schema={"type": "object", "properties": {}},
+            control_type="transition", description="",
+        )
+    ]
+    state = RunState()
+    # A raw with no usable control block → normalize raises → emits a kind-specific
+    # validation event AND the additive phase_output_validation_failed.
+    bad_raw = {"artifact": {"type": "r", "data": {}}}
+    try:
+        px._validate_phase_output(
+            bad_raw, "verify", candidates, ["report"], state, attempt=0,
+        )
+    except (ValueError, Exception):
+        pass  # validation is expected to reject; we assert on the emitted events
+
+    types = [e.type for e in events.all()]
+    assert "phase_output_validation_failed" in types, (
+        f"the additive capture event must fire on a validation failure; got {types}"
+    )
+    # back-compat: a kind-specific validation event still fired (unchanged).
+    assert any(
+        t in types for t in ("control_ir_validation_error", "normalization_error", "validation_error")
+    ), f"existing kind-specific validation event must still fire (back-compat); got {types}"
+    d = _last_pov_event(events)
+    assert d["failure_kind"] in {"control_ir", "normalization", "artifact_structure",
+                                 "artifact_data", "ops_structure", "output_validation"}
+    assert d["raw_output"] == json.dumps(bad_raw, ensure_ascii=False)


### PR DESCRIPTION
**[e2e-coder]** — Refs #1135, #1115. Write-side of the trace-infra fix; built to the **canonical contract in [#1135's comment](https://github.com/tya5/reyn/issues/1135)** (the single source of truth — all broker `v-FINAL-N` messages were superseded). Read-side (`dogfood_trace --mode llm-emitted-ops`) is sandbox_2's parallel PR.

## Why
A phase-output validation failure (e.g. the decide-turn `missing required 'control' block` from the C7 flask-5014 run) left the model's raw emitted output only in the opt-in `REYN_LLM_TRACE_DUMP`; the always-on P6 events log carried just the error string. So the failure couldn't be classified (weak-model malformed output vs OS parse-edge) from events alone.

## What (canonical contract)
Additive event `phase_output_validation_failed`, emitted at each validation-failure site (per attempt):
```
data: {phase, attempt, failure_kind, error, raw_output|null, raw_output_ref|null}
  failure_kind: control_ir | normalization | artifact_structure | artifact_data
              | ops_structure | output_validation | act_ops
  raw_output     = model raw output, INLINE when ≤ 8192B (named const)
  raw_output_ref = >cap: a state_dir-RELATIVE offload handle
  invariant: exactly one of {raw_output, raw_output_ref} when a raw exists  (no hash)
```
- offload reuses `services/offload` (`store_dir = state_dir/control_ir_offload`); `offload_value` returns an absolute ref → converted to **state_dir-relative** explicitly (not copying C5's absolute refs — this event is in the long-lived P6 audit log, so a portable ref is correct).
- read-side: `read_offloaded(str(state_dir / raw_output_ref), base_dir=state_dir)`.
- **additive**: existing `control_ir_validation_error` / `normalization_error` / `validation_error` / `phase_failed` events are **unchanged** (TUI + test consumers back-compat); `failure_kind` is a field, existing events keep their kinds.

## Review gate (#1135)
- ✅ relative handle matches both sides (test round-trips via read_offloaded base_dir=state_dir)
- ✅ `read_offloaded` base_dir=state_dir boundary check
- ✅ cap→offload size axis (8192 named const)
- ✅ existing events unchanged (back-compat — test asserts the kind-specific event still fires)
- ✅ Tier 2 no-mock
- ⏭ after this lands: flask-5014 re-run isolates the decide-turn failing output → classify weak-model vs OS-parse-edge (separate follow-up per #1135)

## Test plan
- [x] `pytest tests/test_phase_output_validation_failed_1135b.py -q` → 3 passed (inline ≤cap; offload >cap with state_dir-relative ref + read_offloaded round-trip + control_ir_offload root; real validation-fail path emits new event AND unchanged kind-specific event)
- [x] phase_executor / validation regression sweep → 26 passed (no regression; existing events unchanged)
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean / 0 violations
- [x] Full suite `pytest -q --ignore=.claude` → 6544 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`, local extractor-lib diff, not in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)