### PR TITLE
fix(fp-0008): #1132 — events audit log honors workspace_state_dir

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -68,7 +68,14 @@ class Agent:
         sandbox_backend: "SandboxBackend | None" = None,
     ) -> None:
         self.model = model
-        self.state_dir = ".reyn"
+        # FP-0008 #1132: the events audit log lives under state_dir. Honor an
+        # explicit workspace_state_dir (the same host-side dir that holds the
+        # Workspace's artifacts + control_ir_offload) so events co-locate with
+        # the rest of the run's state — required for an in-container run where
+        # base_dir is the container repo and state is kept host-side. Falls back
+        # to the cwd-relative ".reyn" default (unchanged host behavior) when no
+        # explicit state dir is given.
+        self.state_dir = str(workspace_state_dir) if workspace_state_dir is not None else ".reyn"
         self.strict = strict
         self._subscribers = list(subscribers or [])
         self._intervention_bus = intervention_bus

--- a/tests/test_events_state_dir_1132.py
+++ b/tests/test_events_state_dir_1132.py
@@ -1,0 +1,52 @@
+"""Tier 2: FP-0008 #1132 — the events audit log honors workspace_state_dir.
+
+The events log lives under `Agent.state_dir` (`Path(state_dir)/events/...`). That
+was hardcoded to the cwd-relative `.reyn`, so a run that passed an explicit
+host-side `--state-dir` (e.g. an in-container run, where base_dir is the container
+repo and state is kept host-side) had its Workspace artifacts/offload under
+`--state-dir` but its events split off under `.reyn` — not co-located.
+
+Now `Agent.state_dir` honors `workspace_state_dir` when provided (events
+co-locate with the rest of the run's state), and still defaults to `.reyn` for
+the common no-state-dir case (unchanged host behavior).
+
+Real Agent, no mocks. Docstring opens "Tier 2:".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.agent import Agent
+
+
+def test_state_dir_honors_workspace_state_dir(tmp_path: Path) -> None:
+    """Tier 2: an explicit workspace_state_dir becomes Agent.state_dir (events root)."""
+    host_state = tmp_path / "host_state"
+    agent = Agent(model="standard", workspace_state_dir=host_state)
+    assert agent.state_dir == str(host_state)
+    # The events directory the run will use derives from state_dir, so it
+    # co-locates under the host state dir (alongside artifacts / control_ir_offload).
+    events_root = Path(agent.state_dir) / "events"
+    assert events_root.is_relative_to(host_state), (
+        f"events must live under the explicit state dir; got {events_root}"
+    )
+
+
+def test_state_dir_defaults_to_reyn_when_unset(tmp_path: Path) -> None:
+    """Tier 2: with no workspace_state_dir, Agent.state_dir defaults to .reyn (back-compat)."""
+    agent = Agent(model="standard")
+    assert agent.state_dir == ".reyn"
+
+
+def test_workspace_and_events_state_dir_co_locate(tmp_path: Path) -> None:
+    """Tier 2: the events root and the Workspace state dir share the same root.
+
+    Closes the #1132 split: both derive from the one workspace_state_dir, so a
+    consumer resolving an event's raw_output_ref against the offload root (which
+    lives under the Workspace state dir) finds it co-located with the events.
+    """
+    host_state = tmp_path / "s"
+    agent = Agent(model="standard", workspace_state_dir=host_state)
+    # Agent.state_dir (events) and the workspace_state_dir threaded to Workspace
+    # are the same host dir — events/, artifacts/, control_ir_offload/ all under it.
+    assert Path(agent.state_dir) == host_state


### PR DESCRIPTION
**[e2e-coder]** — Refs #1132, #1135, #1115. The MINOR finding from the #1135 C7 in-container run; now unblocked (lead-coder queued it after #1135b/#1137 landed, same events area = serial).

## Why
The events log lives under `Agent.state_dir` (`Path(state_dir)/events/...`), hardcoded to cwd-relative `.reyn`. A run passing an explicit host-side `--state-dir` (the in-container case: base_dir = container repo, state kept host-side) had its Workspace artifacts + `control_ir_offload` under `--state-dir` but its **events split off under `.reyn`** — not co-located. Both host-side (P6 held), but the dirs diverged.

## Fix
Derive `Agent.state_dir` from `workspace_state_dir` when provided (events co-locate with the run's other state, the same host dir the Workspace uses); fall back to `.reyn` when unset (unchanged default host behavior). `Agent.state_dir`'s only consumer is the events dir (grep-verified) — additive + back-compat.

## Closes the #1135 read-side caveat
The `phase_output_validation_failed.raw_output_ref` is resolved against the offload root under `state_dir`. With this fix events + offload + artifacts share one root, so the read-side resolution (`base_dir=state_dir`) finds the offloaded raw co-located with the events that reference it.

## Test plan
- [x] `pytest tests/test_events_state_dir_1132.py -q` → 3 passed (state_dir == workspace_state_dir + derived events root under it; defaults to `.reyn` unset; events & Workspace state co-locate)
- [x] agent/events regression sweep (`-k "agent or events_state or events_path"`) → 320 passed (no regression)
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean / 0 violations
- [x] Full suite `pytest -q --ignore=.claude` → 6552 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`, local extractor-lib diff, not in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)