### PR TITLE
feat(dogfood): compaction_check outcome tabulator (#1128 axis-1 measurement gate)

### DIFF
--- a/scripts/compaction_outcome_dist.py
+++ b/scripts/compaction_outcome_dist.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tabulate `compaction_check` outcomes from chat events logs — #1128 axis-1 measurement gate.
+
+The axis-1 removal decision (issue #1128) is gated on PRIMARY EVIDENCE: across
+live chat sessions, does the BACKGROUND path (`_maybe_compact`) ever do real
+compaction work (`outcome="triggering"`), or is all real compaction done by the
+forced-sync pre-frame guard (`outcome="forced_sync"`)? If `triggering` ≈ 0 while
+`forced_sync` carries the real work, the background path (axis-1) is redundant.
+
+Outcome → path map (verified against
+`src/reyn/chat/services/compaction_controller.py`, HEAD d71f544a):
+
+  BACKGROUND `_maybe_compact` (axis-1, removal candidate):
+    too_few_turns / below_min_batch / below_threshold / triggering
+    (+ already_running — AMBIGUOUS, both paths emit it)
+  FORCED-SYNC `force_compact_now` (axis-2 pre-frame guard, stays):
+    forced_sync / forced_sync_no_turns
+    (+ already_running — AMBIGUOUS)
+
+Real compaction happens ONLY on `triggering` (axis-1) or `forced_sync` (axis-2).
+
+Usage:
+    python scripts/compaction_outcome_dist.py <events.jsonl> [<events2.jsonl> ...]
+    python scripts/compaction_outcome_dist.py <dir>   # recurse *.jsonl under dir
+
+Emits a JSON summary to stdout (redirect to a file for the #1128 record, then
+cat+copy it — never hand-type the numbers).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# outcome → which path emits it. "ambiguous" = emitted by both paths.
+_BACKGROUND = {"too_few_turns", "below_min_batch", "below_threshold", "triggering"}
+_FORCED_SYNC = {"forced_sync", "forced_sync_no_turns"}
+_AMBIGUOUS = {"already_running"}
+# the two outcomes that mean "real compaction actually ran":
+_REAL_WORK = {"triggering": "axis1_background", "forced_sync": "axis2_forced_sync"}
+
+
+def _iter_event_files(args: list[str]):
+    for a in args:
+        p = Path(a)
+        if p.is_dir():
+            yield from sorted(p.rglob("*.jsonl"))
+        elif p.exists():
+            yield p
+
+
+def _path_of(outcome: str) -> str:
+    if outcome in _BACKGROUND:
+        return "background_axis1"
+    if outcome in _FORCED_SYNC:
+        return "forced_sync_axis2"
+    if outcome in _AMBIGUOUS:
+        return "ambiguous_both"
+    return "unknown"
+
+
+def collect(files) -> dict:
+    by_outcome: dict[str, int] = {}
+    by_path: dict[str, int] = {"background_axis1": 0, "forced_sync_axis2": 0,
+                               "ambiguous_both": 0, "unknown": 0}
+    files_seen = 0
+    files_with_events = 0
+    for f in files:
+        files_seen += 1
+        had = False
+        for line in f.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("type") != "compaction_check":
+                continue
+            had = True
+            data = ev.get("data", ev)  # outcome may be top-level or under data
+            outcome = data.get("outcome") or ev.get("outcome") or "<none>"
+            by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+            by_path[_path_of(outcome)] += 1
+        if had:
+            files_with_events += 1
+    total = sum(by_outcome.values())
+    triggering = by_outcome.get("triggering", 0)
+    forced_sync = by_outcome.get("forced_sync", 0)
+    real_total = triggering + forced_sync
+    return {
+        "files_seen": files_seen,
+        "files_with_compaction_check": files_with_events,
+        "total_compaction_check": total,
+        "by_outcome": dict(sorted(by_outcome.items(), key=lambda kv: -kv[1])),
+        "by_path": by_path,
+        "real_compaction": {
+            "axis1_background_triggering": triggering,
+            "axis2_forced_sync": forced_sync,
+            "total": real_total,
+            "axis1_share": (triggering / real_total) if real_total else None,
+        },
+        "interpretation_hint": (
+            "axis1_share == 0 (with real_total > 0) => background path never did "
+            "real compaction => axis-1 redundant. axis1_share is None => no real "
+            "compaction observed at all => sample insufficient to decide."
+        ),
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    files = list(_iter_event_files(argv[1:]))
+    if not files:
+        print(json.dumps({"error": "no .jsonl files found", "args": argv[1:]}))
+        return 1
+    print(json.dumps(collect(files), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_compaction_outcome_dist.py
+++ b/tests/test_compaction_outcome_dist.py
@@ -1,0 +1,83 @@
+"""Tests for scripts/compaction_outcome_dist.py — #1128 axis-1 measurement gate.
+
+Tier 2: OS invariant — verifies the compaction_check outcome tabulator correctly
+maps each outcome to its emitting path (background axis-1 vs forced-sync axis-2)
+and isolates "real compaction" (triggering / forced_sync) from no-op checks.
+Uses subprocess + hand-crafted JSONL events fixtures (no reyn imports needed).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "compaction_outcome_dist.py"
+
+
+def _run(args: list[str]) -> tuple[str, int]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)] + args,
+        capture_output=True, text=True,
+    )
+    return result.stdout + result.stderr, result.returncode
+
+
+def _write_events(path: Path, outcomes: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for o in outcomes:
+        lines.append(json.dumps({"type": "compaction_check", "data": {"outcome": o}}))
+    # a non-compaction event must be ignored
+    lines.append(json.dumps({"type": "phase_started", "data": {"phase": "x"}}))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_maps_outcomes_to_paths_and_isolates_real_compaction(tmp_path):
+    """Tier 2: outcome→path map + real-compaction isolation (the #1128 metric)."""
+    ev = tmp_path / "events" / "log.jsonl"
+    _write_events(ev, [
+        "too_few_turns", "below_min_batch", "below_threshold",  # background no-ops
+        "triggering",                                            # axis-1 real work
+        "forced_sync", "forced_sync",                            # axis-2 real work
+        "already_running",                                       # ambiguous
+    ])
+    out, rc = _run([str(ev)])
+    assert rc == 0, out
+    d = json.loads(out)
+    assert d["total_compaction_check"] == 7
+    assert d["by_path"]["background_axis1"] == 4   # 3 no-ops + triggering
+    assert d["by_path"]["forced_sync_axis2"] == 2
+    assert d["by_path"]["ambiguous_both"] == 1
+    assert d["real_compaction"]["axis1_background_triggering"] == 1
+    assert d["real_compaction"]["axis2_forced_sync"] == 2
+    assert d["real_compaction"]["total"] == 3
+    assert abs(d["real_compaction"]["axis1_share"] - (1 / 3)) < 1e-9
+
+
+def test_no_real_compaction_yields_null_share(tmp_path):
+    """Tier 2: checks-fired-but-no-real-work => axis1_share=None (sample insufficient).
+
+    Operationalizes the event-type-only-extrapolation trap: compaction_check
+    firing != compaction happening.
+    """
+    ev = tmp_path / "events" / "log.jsonl"
+    _write_events(ev, ["too_few_turns", "too_few_turns", "below_min_batch"])
+    out, rc = _run([str(ev)])
+    assert rc == 0, out
+    d = json.loads(out)
+    assert d["total_compaction_check"] == 3
+    assert d["real_compaction"]["total"] == 0
+    assert d["real_compaction"]["axis1_share"] is None
+
+
+def test_recurses_directory_of_jsonl(tmp_path):
+    """Tier 2: a directory arg recurses *.jsonl and aggregates."""
+    _write_events(tmp_path / "a" / "s1.jsonl", ["triggering"])
+    _write_events(tmp_path / "b" / "s2.jsonl", ["forced_sync"])
+    out, rc = _run([str(tmp_path)])
+    assert rc == 0, out
+    d = json.loads(out)
+    assert d["files_with_compaction_check"] == 2
+    assert d["real_compaction"]["axis1_background_triggering"] == 1
+    assert d["real_compaction"]["axis2_forced_sync"] == 1


### PR DESCRIPTION
**[dogfood-coder]** — measurement tooling for the #1128 axis-1 removal gate (lead-coder dispatched). Opening this **before** the opportunistic live-session capture so the methodology (the outcome→path map) is reviewable before I rely on it.

## Why
The #1128 decision (remove axis-1 = background `_maybe_compact`) is gated on **primary evidence**, not the static-read hypothesis: across live chat sessions, does the background path ever do *real* compaction (`outcome=triggering`), or does the forced-sync pre-frame guard (`outcome=forced_sync`) carry all real work? If `triggering≈0` while `forced_sync` does the work → axis-1 redundant.

## What
`scripts/compaction_outcome_dist.py` tabulates `compaction_check` events by outcome and maps each to its emitting path, **verified against `src/reyn/chat/services/compaction_controller.py`** (HEAD `d71f544a`):

| outcome | path | real compaction? |
|---|---|---|
| `too_few_turns` / `below_min_batch` / `below_threshold` | background (axis-1) | no |
| `triggering` | background (axis-1) | **yes** |
| `forced_sync` | forced-sync (axis-2) | **yes** |
| `forced_sync_no_turns` | forced-sync (axis-2) | no |
| `already_running` | ambiguous (both emit it) | no |

It isolates `real_compaction` (triggering vs forced_sync) from no-op checks — operationalizing the event-type-only-extrapolation trap (**`compaction_check` firing ≠ compaction happening**). `axis1_share` = triggering / (triggering + forced_sync); `None` when no real compaction observed (sample insufficient).

## Test plan
- [x] Tier 2 no-mock (subprocess + JSONL fixtures), 3 pass: `python -m pytest tests/test_compaction_outcome_dist.py -q`
- [x] `ruff check` clean (both files)
- [x] Parser validated on real pytest events fixtures: 26 `compaction_check` events parsed, `triggering=0/forced_sync=0 → axis1_share=null` (expected for tiny test sessions; **NOT** #1128 evidence — that needs live long sessions)
- [ ] (deferred — not part of this PR) live-session distribution capture → recorded to #1128 with file-cat. Opportunistic, no forced run, no concurrent benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)