### PR TITLE
fix(tui): remove SlashPicker 'find' hardcode via SlashCommand.tab_footer_fn (P7)

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -29,6 +29,13 @@ HandlerFn = Callable[..., Awaitable[None]]
 # ``"discard ab"``). Completers that don't need it (e.g. ``/attach``
 # which always lists agent names) can ignore the arg via a default.
 CompleterFn = Callable[..., list[str]]
+# TabFooterFn signature: ``() -> str | None``. Supplies the optional
+# picker-hint footer line (the dim ``↳ <message>`` sub-row shown once the
+# user types ``/<cmd> ``). Returning ``None`` (or "") means "show nothing
+# right now" — the command owns both the message text and its visibility
+# condition (e.g. /find only surfaces its Tab-recall affordance when there
+# is history to recall). The picker owns the ``↳`` chrome + styling.
+TabFooterFn = Callable[[], "str | None"]
 
 
 @dataclass
@@ -58,6 +65,16 @@ class SlashCommand:
     # ``"docs/concepts/plan-mode.md"``). Defaults to empty tuple so all
     # existing commands without explicit see_also are unaffected.
     see_also: tuple[str, ...] = ()
+    # Optional picker-hint footer supplier. When set, the SlashPicker hint
+    # mode renders a dim ``  ↳ <message>`` sub-row below the summary/usage,
+    # where ``<message>`` is whatever this callable returns. The callable
+    # returns ``None`` (or "") to render nothing — letting the command gate
+    # the footer on runtime state (e.g. /find shows its Tab-recall hint only
+    # when history is non-empty). Defaults to ``None`` so every command
+    # without an explicit footer behaves exactly as before. Keeping the
+    # message + its visibility inside the command (not the widget) is what
+    # makes the picker generic: it never hardcodes a command name.
+    tab_footer_fn: TabFooterFn | None = None
 
 
 class SlashRegistry:
@@ -133,6 +150,7 @@ def slash(
     hidden: bool = False,
     usage: str = "",
     see_also: tuple[str, ...] = (),
+    tab_footer_fn: TabFooterFn | None = None,
 ) -> Callable[[HandlerFn], HandlerFn]:
     """Decorator that registers `fn` as a slash command on import.
 
@@ -145,6 +163,9 @@ def slash(
     ``see_also`` is an optional tuple of repo-relative doc paths surfaced
     in ``/help <cmd>`` focus mode as a footer link (see
     ``SlashCommand.see_also``).
+
+    ``tab_footer_fn`` is an optional ``() -> str | None`` supplier for the
+    picker-hint footer row (see ``SlashCommand.tab_footer_fn``).
     """
 
     def _decorator(fn: HandlerFn) -> HandlerFn:
@@ -157,6 +178,7 @@ def slash(
             hidden=hidden,
             usage=usage,
             see_also=see_also,
+            tab_footer_fn=tab_footer_fn,
         ))
         return fn
 

--- a/src/reyn/chat/slash/find.py
+++ b/src/reyn/chat/slash/find.py
@@ -83,14 +83,32 @@ def _find_history_snapshot() -> list[str]:
 def find_history_has_entries() -> bool:
     """Return True when the find history deque is non-empty.
 
-    Public surface used by :func:`SlashPicker._repaint_hint` to gate
-    the Tab-recall footer row (= "↳ Tab inserts a recent query") on
+    Public surface used by :func:`_find_tab_footer` to gate the
+    Tab-recall footer row (= "↳ Tab inserts a recent query") on
     whether there's actually anything to recall. Callers must NOT
     reach into ``_find_history`` directly — that would bypass the
-    module-level encapsulation and couple widget rendering to a private
-    deque. This wrapper is the minimal clean public surface.
+    module-level encapsulation. This wrapper is the minimal clean
+    public surface.
     """
     return bool(_find_history)
+
+
+def _find_tab_footer() -> str | None:
+    """Picker-hint footer message for /find — the Tab-recall affordance.
+
+    Returns the dim sub-row message ("Tab inserts a recent query")
+    surfaced once the user types ``/find ``, but ONLY when there is
+    history to recall — otherwise ``None`` so the picker renders no
+    footer (avoids implying Tab does something when there's nothing).
+
+    This is the command-owned half of the SlashPicker footer contract
+    (``SlashCommand.tab_footer_fn``): /find owns the message text + the
+    "show only with history" condition; the picker owns the ``↳`` chrome
+    and never hardcodes the command name.
+    """
+    if find_history_has_entries():
+        return "Tab inserts a recent query"
+    return None
 
 
 def _find_completer(session: "object", arg_partial: str = "") -> list[str]:
@@ -114,6 +132,7 @@ def _find_completer(session: "object", arg_partial: str = "") -> list[str]:
     summary="Search the conv pane (substring or regex)",
     usage="/find [-r|-c|-rc] <query>",
     completer=_find_completer,
+    tab_footer_fn=_find_tab_footer,
 )
 async def find_cmd(session: "object", args: str) -> None:
     # Forward the raw arg; the TUI handler validates and surfaces

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -407,17 +407,18 @@ class SlashPicker(RenderableCacheMixin, Static):
                     indent + f"+{hidden} more — keep typing to filter",
                     style="dim " + _TEXT_DIM,
                 )
-        # Tab-recall discovery footer — only for /find, only when history
-        # is non-empty. Surfaces the affordance ("Tab inserts a recent
-        # query") that the module docstring documents but the picker hint
-        # never previously mentioned. We import lazily to avoid a circular
-        # dependency between the widget layer and the slash submodule.
-        if cmd.name == "find":
-            from reyn.chat.slash.find import find_history_has_entries
-            if find_history_has_entries():
+        # Optional command-supplied picker-hint footer. The command owns
+        # both the message and its visibility condition via ``tab_footer_fn``
+        # (e.g. /find surfaces "Tab inserts a recent query" only when there's
+        # history to recall); the picker stays generic — it never hardcodes a
+        # command name, it just renders whatever the command supplies with the
+        # same ``↳`` chrome the usage row uses. ``None`` / "" → render nothing.
+        if cmd.tab_footer_fn is not None:
+            footer = cmd.tab_footer_fn()
+            if footer:
                 indent = " " * (2 + len(name) + 2)
                 t.append("\n")
-                t.append(indent + "↳ Tab inserts a recent query", style="dim " + _TEXT_NEUTRAL)
+                t.append(indent + "↳ " + footer, style="dim " + _TEXT_NEUTRAL)
         self.update(t)
         self._set_rendered_cache(t)
 

--- a/tests/cli/test_find_picker_tab_recall_hint.py
+++ b/tests/cli/test_find_picker_tab_recall_hint.py
@@ -1,21 +1,23 @@
-"""Tier 2: /find picker hint shows Tab-recall footer iff history is non-empty.
+"""Tier 2: SlashPicker renders the command-supplied ``tab_footer_fn`` footer.
 
-Wave-12 T2-2 (Topic A #5). The /find command documents a Tab-recall
-affordance (= last 5 queries accessible via Tab) only in its module
-docstring. The picker hint had no visible surface for this, so users
-had to read source to discover the feature.
+The picker hint can show a dim "↳ <message>" sub-row supplied by a
+command via ``SlashCommand.tab_footer_fn`` (a ``() -> str | None``). The
+command owns the message + its visibility condition; the picker stays
+generic and never hardcodes a command name (P7 — see issue #1070, which
+removed the original ``if cmd.name == "find":`` hardcode).
 
-This PR adds a dim "↳ Tab inserts a recent query" footer row to the
-picker hint, rendered ONLY when:
-  - the command is /find (scoped: other commands unaffected)
-  - find history is non-empty (guard: avoids implying Tab does
-    something when there's nothing to recall)
+/find is the canonical consumer: it surfaces "Tab inserts a recent
+query" only when its history is non-empty (guard: avoids implying Tab
+does something when there's nothing to recall). The first three tests
+pin /find's end-to-end wiring; the last two pin the generic mechanism
+with a synthetic command (proving the picker is not /find-specific).
 
 Public surface tested (no MagicMock, no private-state assertions):
   - /find + non-empty history → hint contains "Tab inserts"
   - /find + empty history → hint does NOT contain "Tab inserts"
-  - non-find command + non-empty history → hint does NOT contain
-    "Tab inserts" (scope guard)
+  - command without tab_footer_fn → no footer (back-compat / scope guard)
+  - synthetic command whose tab_footer_fn returns text → footer rendered
+  - synthetic command whose tab_footer_fn returns None → no footer
 """
 from __future__ import annotations
 
@@ -112,12 +114,14 @@ async def test_find_hint_omits_tab_recall_footer_when_history_empty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_find_hint_omits_tab_recall_footer_even_with_history() -> None:
-    """Tier 2: non-/find command hint does NOT show Tab-recall footer even if history is populated."""
+async def test_command_without_tab_footer_fn_renders_no_footer() -> None:
+    """Tier 2: a command that supplies no tab_footer_fn renders no footer (back-compat)."""
     from reyn.chat.slash import SlashCommand
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets.slash_picker import SlashPicker
 
+    # Populated find history must NOT leak into an unrelated command's hint:
+    # the picker keys off the command's own tab_footer_fn, not global state.
     _clear_find_history()
     _seed_find_history("myquery")
 
@@ -130,7 +134,7 @@ async def test_non_find_hint_omits_tab_recall_footer_even_with_history() -> None
             async def _h(s, a):
                 return None
 
-            # A non-find command: name differs, so the scope guard applies.
+            # No tab_footer_fn → defaults to None → no footer row.
             other_cmd = SlashCommand(
                 name="help",
                 summary="Show command help",
@@ -141,8 +145,72 @@ async def test_non_find_hint_omits_tab_recall_footer_even_with_history() -> None
             text = _picker_text(picker)
 
             assert "Tab inserts" not in text, (
-                f"Expected no 'Tab inserts' in non-/find hint even with populated "
-                f"find history. Got:\n{text!r}"
+                f"Expected no 'Tab inserts' for a command without tab_footer_fn even "
+                f"with populated find history. Got:\n{text!r}"
             )
     finally:
         _clear_find_history()
+
+
+@pytest.mark.asyncio
+async def test_generic_command_tab_footer_fn_text_is_rendered() -> None:
+    """Tier 2: the picker renders ANY command's tab_footer_fn message (not /find-specific)."""
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+
+        # A synthetic, non-find command supplying a footer. Proves the picker
+        # is generic: it renders whatever tab_footer_fn returns, for any name.
+        synthetic = SlashCommand(
+            name="synthetic",
+            summary="A synthetic command for the generic footer test",
+            handler=_h,
+            tab_footer_fn=lambda: "generic footer line",
+        )
+        picker.set_hint(synthetic)
+        await pilot.pause()
+        text = _picker_text(picker)
+
+        assert "generic footer line" in text, (
+            f"Expected the synthetic command's tab_footer_fn message to render. "
+            f"Got:\n{text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_generic_command_tab_footer_fn_none_renders_no_footer() -> None:
+    """Tier 2: a tab_footer_fn returning None renders no footer (visibility is command-owned)."""
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+
+        async def _h(s, a):
+            return None
+
+        synthetic = SlashCommand(
+            name="synthetic",
+            summary="A synthetic command whose footer is currently hidden",
+            handler=_h,
+            tab_footer_fn=lambda: None,
+        )
+        picker.set_hint(synthetic)
+        await pilot.pause()
+        text = _picker_text(picker)
+
+        assert "↳" not in text, (
+            f"Expected no footer chrome when tab_footer_fn returns None. "
+            f"Got:\n{text!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Refs #1070 (lead-coder handoff, P7 + dataclass contract, user 「未解決まで完遂」mandate).

## Problem (P7 violation)

`SlashPicker` — generic OS chat infra — hardcoded `if cmd.name == "find":` (slash_picker.py) to render the Tab-recall footer. A generic widget knowing a skill-specific command name is a P7 violation: every future command wanting a picker footer would add another `name ==` branch.

## Fix

Commands supply their own picker-hint footer via a new field:

```python
SlashCommand.tab_footer_fn: TabFooterFn | None = None   # () -> str | None
```

The **command** owns the message + its visibility condition; the **picker** stays generic and renders whatever the field returns with the same `↳` chrome the usage row uses. The picker no longer knows any command name.

### Why a new field (not reuse `usage` / `see_also`)

Per the existing-mechanism-grep discipline noted in #1070, I checked the existing footer fields first:
- `usage: str` — static, always-rendered, separate render path
- `see_also: tuple` — static doc paths for `/help` focus mode

The find footer is a **conditional, runtime-computed** line (shown only when find history is non-empty). Neither static field can express "compute a footer, maybe None" → a new `Callable[[], str | None]` field is justified. (Design recorded in [#1070 comment](https://github.com/tya5/reyn/issues/1070#issuecomment-4585592921).)

### Bonus: lazy import removed

The previous picker code did a lazy `from reyn.chat.slash.find import find_history_has_entries` (a circular-dependency workaround). The callable now closes over find.py's own function, so the picker no longer imports the slash submodule at all — the circular-dep is gone structurally.

## Scope

- `slash/__init__.py` — `tab_footer_fn` field + threaded through the `slash()` decorator. **Consumer-audited**: `SlashCommand` is constructed only via the decorator; all other call sites (tests) are keyword-only with the field defaulting to `None` → every existing command unchanged.
- `slash/find.py` — `_find_tab_footer()` returns the message iff history non-empty, else None; wired via `@slash(..., tab_footer_fn=...)`.
- `tui/widgets/slash_picker.py` — generic `cmd.tab_footer_fn()` render; `find` literal + lazy import removed.
- `tests/cli/test_find_picker_tab_recall_hint.py` — kept 3 /find e2e tests (value-preserving) + added 2 generic-mechanism tests.

Out of scope (per #1070): `header.py` badge hardcode (separate badge concern).

## Review gates

- [x] ① `find` literal removed from picker — `grep` zero command-name literals, P7-clean
- [x] ② `tab_footer_fn` additive — default `None` → unset commands behave exactly as before (152 slash/picker/find tests green; consumer audit confirms all constructions keyword-only)
- [x] ③ Tier-2 no-mock test — real `SlashCommand` instances; footer renders for a command supplying `tab_footer_fn`, omitted when unset / when it returns `None`
- [x] ④ no existing slash-command regression — `pytest -k "slash or picker or find"` → 152 passed
- [x] P7 articulated: generic widget no longer knows a specific command name

## Test plan

- [x] `pytest tests/cli/test_find_picker_tab_recall_hint.py` — 5 passed (3 /find value-preserving + 2 generic)
- [x] `pytest tests/cli -k "slash or picker or find"` — 152 passed (regression gate)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed
- [x] `grep` 'find'/command-name literal in slash_picker.py → 0; find import in picker → 0
- [x] `ruff check` clean (I001 caught pre-push)
- [x] `scripts/test_tier_audit.py --strict` clean (0 warn / 0 err)
- [x] (skipped — visual) live `reyn chat` `/find ` picker footer with/without history — value-preserving by construction; behavior covered by the 5 Tier-2 tests

## Tier self-check

Only Tier-2 behavior tests (real instances, public `.rendered_text()` surface). No format-pin / no private-state assert / no golden-file. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)