### PR TITLE
feat(fp-0008): #1135 sibling — capture raw LLM output on pre-parse JSON-decode failure

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -14,6 +14,31 @@ import httpx
 logger = logging.getLogger(__name__)
 from reyn.llm.json_parse import loads_lenient
 from reyn.llm.model_resolver import ModelSpec
+
+# FP-0008 #1135 sibling: inline cap for the raw output captured on a pre-parse
+# JSON-decode failure (opt A — llm layer, no offload).
+_JSON_DECODE_RAW_CAP = 8192
+
+
+def _truncate_json_for_event(raw: str, pos: "int | None", cap: int = _JSON_DECODE_RAW_CAP) -> str:
+    """Bound the raw LLM output for the json-decode-failure event (#1135 sibling).
+
+    Returns *raw* unchanged when ≤ ``cap``. Otherwise returns a ``cap``-byte
+    window centered on the JSONDecodeError position (where the malformation is),
+    or the head when ``pos`` is unknown, with ``…[N bytes before/after]`` markers.
+    Inline-only: the malformation in a decode failure is diagnosable from the
+    window, so no offload is needed at the llm layer.
+    """
+    if len(raw) <= cap:
+        return raw
+    if pos is None:
+        return raw[:cap] + f"\n…[truncated {len(raw) - cap} bytes]"
+    half = cap // 2
+    start = max(0, min(pos - half, len(raw) - cap))
+    end = start + cap
+    head = f"…[{start} bytes before]\n" if start > 0 else ""
+    tail = f"\n…[{len(raw) - end} bytes after]" if end < len(raw) else ""
+    return head + raw[start:end] + tail
 from reyn.llm.pricing import TokenUsage
 from reyn.schemas.models import ContextFrame
 
@@ -922,6 +947,21 @@ async def call_llm(
             )
         return result
 
+    # FP-0008 #1135 sibling (opt A, canonical contract in #1135): capture the
+    # raw LLM output into the always-on P6 events log on a pre-parse JSON-decode
+    # failure — otherwise it survives only in the opt-in REYN_LLM_TRACE_DUMP, so
+    # the failure (e.g. a malformed `\escape`) is undiagnosable from events. The
+    # read-side is dogfood_trace --mode llm-emitted-ops. Inline-cap only: the llm
+    # layer has no state_dir to offload to, and a decode malformation is
+    # diagnosable from a window around the error position.
+    if event_log is not None:
+        _pos = getattr(last_exc, "pos", None)
+        event_log.emit(
+            "llm_output_json_decode_failed",
+            failure_kind="json_decode",
+            error=str(last_exc),
+            raw_output=_truncate_json_for_event(last_raw, _pos),
+        )
     raise ValueError(
         f"LLM returned invalid JSON after repair and retry.\n"
         f"Error: {last_exc}\n"

--- a/tests/test_llm_json_decode_capture_1135.py
+++ b/tests/test_llm_json_decode_capture_1135.py
@@ -1,0 +1,119 @@
+"""Tier 2: FP-0008 #1135 sibling — capture raw LLM output on pre-parse JSON-decode failure.
+
+`call_llm` previously raised a bare ValueError (only the first 800 chars of the
+raw in its message) when the model's output failed to parse after the JSON-repair
+retry — so the failure (e.g. run3's malformed-escape case in an apply file edit)
+was undiagnosable from the always-on events log; the raw lived only in the
+opt-in REYN_LLM_TRACE_DUMP.
+
+Per the canonical #1135 contract (opt A, inline-cap, llm layer): emit an additive
+`llm_output_json_decode_failed` event carrying the raw (truncated to a window
+around the decode position). No offload (the llm layer has no state_dir).
+
+Unit tests of the truncation helper + a behavioral test driving the real
+`call_llm` JSON-decode-fail path with a stubbed `litellm.acompletion` (a real
+async callable — allowed by testing policy, not MagicMock). Docstring opens "Tier 2:".
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.llm.llm import _JSON_DECODE_RAW_CAP, _truncate_json_for_event
+
+# ── unit: truncation helper ───────────────────────────────────────────────────
+
+
+def test_truncate_returns_raw_unchanged_when_within_cap() -> None:
+    """Tier 2: raw ≤ cap is returned verbatim."""
+    raw = '{"k": "v"}'
+    assert _truncate_json_for_event(raw, pos=3) == raw
+
+
+def test_truncate_windows_around_pos_when_oversized() -> None:
+    """Tier 2: oversized raw → a cap-sized window centered on the error position, with markers."""
+    raw = "A" * 5000 + "X" + "B" * 5000  # > cap, malformation 'X' at pos 5000
+    out = _truncate_json_for_event(raw, pos=5000, cap=100)
+    assert len(out) < len(raw)
+    assert "X" in out, "the window must include the error position"
+    assert "bytes before]" in out and "bytes after]" in out
+    # the marker byte-accounting must sum to the original length
+    import re
+    before = int(re.search(r"\[(\d+) bytes before\]", out).group(1))
+    after = int(re.search(r"\[(\d+) bytes after\]", out).group(1))
+    assert before + 100 + after == len(raw)
+
+
+def test_truncate_head_when_pos_unknown() -> None:
+    """Tier 2: oversized raw with no position → head slice + truncation marker."""
+    raw = "z" * 20000
+    out = _truncate_json_for_event(raw, pos=None, cap=8192)
+    assert out.startswith("z" * 8192)
+    assert "truncated" in out and str(20000 - 8192) in out
+
+
+def test_cap_default_is_8192() -> None:
+    """Tier 2: the inline cap constant is 8192 (canonical contract)."""
+    assert _JSON_DECODE_RAW_CAP == 8192
+
+
+# ── behavioral: call_llm emits the event on a JSON-decode failure ─────────────
+
+
+def _fake_litellm_response(content: str):
+    msg = type("_Msg", (), {"content": content, "tool_calls": None})()
+    choice = type("_Choice", (), {"message": msg, "finish_reason": "stop"})()
+    usage = type("_Usage", (), {"prompt_tokens": 10, "completion_tokens": 5})()
+    return type("_Resp", (), {"choices": [choice], "usage": usage})()
+
+
+class _ScriptedBadJSON:
+    """Real async callable stub returning unparseable JSON (allowed by testing policy)."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.call_count = 0
+
+    async def __call__(self, **kwargs):
+        self.call_count += 1
+        return _fake_litellm_response(self._content)
+
+
+@pytest.mark.asyncio
+async def test_call_llm_emits_json_decode_failed_event(monkeypatch) -> None:
+    """Tier 2: a JSON-decode failure in call_llm emits llm_output_json_decode_failed with the raw.
+
+    Drives the real call_llm path; litellm.acompletion is a real async stub
+    returning content with an invalid `\\q` escape (unparseable after repair).
+    Asserts the additive event fires with failure_kind + error + raw_output, and
+    that the run still raises (behavior preserved).
+    """
+    import litellm
+
+    from reyn.events.events import EventLog
+    from reyn.llm.llm import call_llm
+    from reyn.schemas.models import ContextFrame
+    from reyn.testing.replay import REPLAY_DATETIME
+
+    bad = '{"type": "act", "ops": [{"path": "x\\q"}]}'  # invalid \q escape → JSONDecodeError
+    monkeypatch.setattr(litellm, "acompletion", _ScriptedBadJSON(bad))
+
+    events = EventLog()
+    frame = ContextFrame(
+        current_phase="apply",
+        instructions="edit",
+        input_artifact={},
+        candidate_outputs=[],
+        output_language="en",
+        current_datetime=REPLAY_DATETIME,
+    )
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        await call_llm("gemini-2.5-flash-lite", frame, timeout=5, max_retries=0, event_log=events)
+
+    evs = [e for e in events.all() if e.type == "llm_output_json_decode_failed"]
+    assert evs, "a JSON-decode failure must emit llm_output_json_decode_failed"
+    d = evs[-1].data
+    assert d["failure_kind"] == "json_decode"
+    assert d["error"]  # the JSONDecodeError message
+    assert "ops" in d["raw_output"], "the raw model output must be captured"
+    assert d["raw_output_ref"] is None if "raw_output_ref" in d else True  # opt A: inline only


### PR DESCRIPTION
**[e2e-coder]** — Refs #1135, #1115. The sibling pre-parse capture (user "complete until resolved" mandate). Built to the **canonical contract locked in #1135** (opt A; lead-coder decision + sandbox_2 read-side confirm, both in-issue per the contract-in-issue discipline).

## Why
#1137 captures **post-parse** phase-output validation failures. The **pre-parse** layer — `call_llm`'s JSON-repair-fail at `llm.py:926` — left the model's raw output in **no events-layer record** (only the first 800 chars in the exception + the opt-in `REYN_LLM_TRACE_DUMP`). The C7 run3 apply-phase malformed-escape failure was thus undiagnosable from events.

## What (opt A — inline-cap at the llm layer)
Additive event `llm_output_json_decode_failed` at the JSON-decode-fail boundary:
```
data: {failure_kind: "json_decode", error: str, raw_output: str}
```
- emitted via the in-scope `event_log`; **inline-cap only** (the llm layer has no `state_dir` to offload to — and a decode malformation is diagnosable from a window around the error position).
- `_truncate_json_for_event`: raw ≤8192B verbatim; else a cap-sized window centered on `JSONDecodeError.pos` (or head when pos unknown) with `…[N bytes before/after]` markers.
- **additive + behavior-preserving**: the `ValueError` still raises; existing events unchanged.
- read-side = `dogfood_trace --mode llm-emitted-ops` (sandbox_2); inline-only confirmed sufficient for the decode case (no `raw_output_ref`).

## Review gate (#1135)
- ✅ capture boundary = llm layer (before kernel), event_log in scope
- ✅ inline-cap (8192 named const); no offload at the llm layer (no state_dir) — opt A as decided
- ✅ existing behavior unchanged (ValueError still raised; no existing event touched)
- ✅ Tier 2 no-mock; real pre-parse-fail capture test

## Test plan
- [x] `pytest tests/test_llm_json_decode_capture_1135.py -q` → 5 passed (truncation: verbatim ≤cap / pos-centered window w/ byte-accurate markers / head-on-unknown-pos / cap=8192; behavioral: real `litellm.acompletion` stub → bad JSON → event fires w/ failure_kind+error+raw_output, ValueError still raised)
- [x] llm regression sweep (`-k "llm_trace or llm_call or json_parse or llm_json"`) → 70 passed
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean / 0 violations
- [x] Full suite `pytest -q --ignore=.claude` → 6557 passed, 1 pre-existing failure (`test_web_fetch_preview_path_ref`, local extractor-lib diff, not in CI)

Completes the trace-infra: post-parse (#1137) + pre-parse (this) malformed-output capture, both read by `dogfood_trace --mode llm-emitted-ops`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)