### PR TITLE
docs(config): #1056 (d) — mirror drift guard (example + reference doc ↔ schema)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -345,6 +345,7 @@ action_retrieval:
 | `embedding_class` | string \| null | `"local-mini"` | Name of an entry in [`embedding.classes`](../../concepts/rag.md) to use for action-retrieval semantic search.  Default `local-mini` (= `sentence-transformers/all-MiniLM-L6-v2`).  When `null` or empty, `search_actions` is excluded from `tools=` even when wrappers are enabled.  Setting this also enables eager embedding build on cold-start sessions to avoid first-turn hallucinations.  **Graceful degrade**: if the chosen class points at a `sentence-transformers/` model but the `local-embed` extras aren't installed, reyn silently treats this as `null` and `list_actions` surfaces the install command to the LLM. Set explicitly to `standard` (= OpenAI) or `null` (= opt out) to override. |
 | `hot_list_n` | int | `10` | Hot-list projection size for top-N `freq+recency` direct aliases. Must be ≥ 0. `0` opts out entirely (= minimal mode). |
 | `mode` | string | `"default"` | Operational mode label: `"minimal"` (max cache stability, no hot list) / `"default"` (balanced) / `"performance"` (large hot list).  Free-form string; callers layer semantics on top. |
+| `hot_list_seed` | list \| string | `"default"` | Seed for the hot-list projection. `"default"` uses the built-in freq+recency seeding; a list of qualified action names (e.g. `["skill__index_docs"]`) pins those as the initial hot list before usage stats accumulate. |
 
 ### Quick-start — opt out
 
@@ -620,6 +621,8 @@ Layers 5 and 6 are scoped: each carries only its own section (`mcp.servers` / `c
 
 Budget caps and rate limits. All fields are optional; omitting a field (or setting its `hard_limit` to `null`) means **unlimited**.
 
+Each token / cost cap (`per_agent_tokens`, `per_agent_cost_usd`, `daily_*`, `monthly_*`) is a `CostLimitConfig` with four sub-fields: `hard_limit` (the cap; `null` = unlimited), `warn_ratio` (warn threshold as a fraction of `hard_limit`, default `0.8`), `ask_on_exceed` (when `true`, prompt for approval to extend the cap on hit instead of aborting), and `extension_calls` (how many approved extensions to grant before the cap is enforced hard). The examples below set only the commonly-tuned `hard_limit` / `warn_ratio`; the other two default to `false` / `0`.
+
 ```yaml
 cost:
   # Per-agent caps (in-memory, reset on restart or /budget reset)
@@ -715,6 +718,8 @@ The MCP runtime is an optional dependency: install with `pip install -e ".[mcp]"
 ### `mcp.search_threshold`
 
 When the total number of MCP tools (across all connected servers) reaches this threshold, `build_tools()` switches from inlining all MCP tool schemas to using Anthropic's `tool_search_tool` (deferred-loading mode). Default `30`. Set `0` to disable.
+
+> **Note**: internally this is the `ReynConfig.mcp_search_threshold` field, but the operator-facing key is `mcp.search_threshold` (read from the `mcp:` block) — set it there, not as a top-level `mcp_search_threshold:`.
 
 ```yaml
 mcp:

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -135,6 +135,8 @@
 # above which ``build_tools()`` switches from inlining every tool schema to
 # Anthropic's ``tool_search_tool`` (deferred-loading mode). Default 30 (= Spring AI
 # experiment shows 63–64% token reduction at 40+ tools). Set 0 to disable.
+# (Internally the ``ReynConfig.mcp_search_threshold`` field — set it via the
+# ``mcp.search_threshold`` key here, not a top-level ``mcp_search_threshold:``.)
 #
 # ``mcp.registries``: a list of external registry URLs. Propagated
 # into ``REYN_MCP_REGISTRY_URLS`` so the subprocess-side safe registry resolver

--- a/tests/test_config_mirror_coverage_1056.py
+++ b/tests/test_config_mirror_coverage_1056.py
@@ -1,0 +1,98 @@
+"""Tier 2: OS invariant — config doc/example mirror drift guard (#1056 (d)).
+
+`reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md` are
+hand-curated mirrors of the `ReynConfig` schema (the human comments, ordering,
+and worked examples are deliberately authored — see #1049/#1053). They drift
+the moment a config field is added without a matching mirror edit.
+
+This guard closes that loop in **`--check` mode** (verify, not generate — full
+auto-generation would destroy the curated human guidance the schema can't
+reproduce): every field the live `walk_config_schema()` advertises must be
+documented in BOTH mirrors. It derives the expected field set from the schema
+(zero hand-enumeration), so it auto-extends as fields change.
+
+Granularity = **field NAME** (word-boundary), plus every top-level section.
+Rationale:
+  - Repeated dataclass types (e.g. `CostLimitConfig` appears 9× across
+    cost.* / safety.loop.*_per_chain) are documented ONCE as a shape, not 36
+    times — name-level coverage matches that good-docs practice, whereas
+    dotted-key-precise coverage would force bloated per-instance tables.
+  - Word-boundary raw-text presence is robust against the mirrors' ad-hoc
+    structure (commented nested YAML in the example; Markdown tables + YAML
+    blocks + prose in the docs). A structure parser produced false-negatives
+    in development; raw presence does not.
+
+Known limitation (acceptable for a drift guard): a *new* field that reuses an
+*existing* field name (e.g. another `timeout`) is not caught by the name check
+alone — but a new top-level section or a genuinely new field name is. The
+top-level section check below backstops the most impactful drift.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from reyn.config_schema import walk_config_schema
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXAMPLE = _REPO_ROOT / "reyn.local.yaml.example"
+_DOCS = _REPO_ROOT / "docs" / "reference" / "config" / "reyn-yaml.md"
+
+
+def _present(name: str, text: str) -> bool:
+    """True when *name* appears as a whole word in *text*."""
+    return re.search(r"\b" + re.escape(name) + r"\b", text) is not None
+
+
+def _schema_field_names() -> set[str]:
+    """Every distinct leaf field-name in the ReynConfig schema."""
+    return {n.key.rsplit(".", 1)[-1] for n in walk_config_schema()}
+
+
+def _schema_top_level() -> set[str]:
+    """Every top-level ReynConfig section/field name."""
+    return {n.key.split(".", 1)[0] for n in walk_config_schema()}
+
+
+def test_example_documents_every_config_field() -> None:
+    """Tier 2: reyn.local.yaml.example mentions every config field name + section.
+
+    A field added to ReynConfig but never added to the example template fails
+    here — the example is advertised as an "exhaustive" mirror, so a silent gap
+    is drift. Derives the field set from the live schema (no hand-enumeration).
+    """
+    text = _EXAMPLE.read_text(encoding="utf-8")
+    missing_fields = sorted(n for n in _schema_field_names() if not _present(n, text))
+    missing_top = sorted(t for t in _schema_top_level() if not _present(t, text))
+    assert not missing_fields and not missing_top, (
+        f"reyn.local.yaml.example is missing config fields {missing_fields} "
+        f"and top-level sections {missing_top} — add a documented block "
+        f"mirroring the new ReynConfig field(s)."
+    )
+
+
+def test_docs_documents_every_config_field() -> None:
+    """Tier 2: docs/reference/config/reyn-yaml.md mentions every field name + section.
+
+    Same drift guard for the reference doc. A new config field must appear in
+    the reference (a table row, YAML example, or prose mention) — derived from
+    the live schema, zero hand-enumeration.
+    """
+    text = _DOCS.read_text(encoding="utf-8")
+    missing_fields = sorted(n for n in _schema_field_names() if not _present(n, text))
+    missing_top = sorted(t for t in _schema_top_level() if not _present(t, text))
+    assert not missing_fields and not missing_top, (
+        f"docs/reference/config/reyn-yaml.md is missing config fields "
+        f"{missing_fields} and top-level sections {missing_top} — document the "
+        f"new ReynConfig field(s) in the reference."
+    )
+
+
+def test_mirror_files_exist() -> None:
+    """Tier 2: the two mirror files exist at their expected paths.
+
+    Guards the path constants above against a future move that would make the
+    coverage checks silently vacuous (file unreadable → test error, not pass).
+    """
+    assert _EXAMPLE.is_file(), f"missing config example mirror: {_EXAMPLE}"
+    assert _DOCS.is_file(), f"missing config reference doc: {_DOCS}"


### PR DESCRIPTION
**[e2e-coder]** — final #1056 item (the (d) generation/check axis). Closes the loop on the two hand-curated config mirrors that were manually synced in #1049/#1053.

## Decision: `--check`, not generate
Full auto-generation would destroy the curated human content — per-field prose, deliberate ordering, worked examples with inline comments, category explanations — none of which the schema carries (it has only type/default/desc). lead-coder leaned `--check`; agreed. So this is a **drift guard**, not a generator.

## What
Tier-2 test (`tests/test_config_mirror_coverage_1056.py`): every field the **live** `walk_config_schema()` advertises must be documented in BOTH `reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md`. Field set derived from the schema → **zero hand-enumeration**, auto-extends as fields change.

**Granularity = field NAME (word-boundary) + every top-level section.** Rationale (in the docstring):
- `CostLimitConfig` appears 9× (cost.* / safety.loop.*_per_chain); documenting its 4 sub-fields once as a *shape* is good docs — dotted-key-precise coverage would force 36 bloated per-instance rows.
- Word-boundary raw-text presence is robust against the mirrors' ad-hoc structure (commented nested YAML; Markdown tables + YAML blocks + prose). A structure parser produced false-negatives in development.
- Known limitation (acceptable for a drift guard, documented): a new field reusing an *existing* name isn't caught by the name check alone — the top-level-section check backstops the high-impact drift.

## Genuine gaps the guard surfaced (synced in this PR)
The manual sync was incomplete:
- **docs**: `ask_on_exceed` + `extension_calls` (CostLimitConfig sub-fields, documented once in the cost shape note), `hot_list_seed` (action_retrieval table row), `mcp_search_threshold`.
- **example**: `mcp_search_threshold` note.

## ⚠️ Follow-up finding (NOT fixed here — flagging for triage)
`mcp_search_threshold` is a **top-level schema field** but the loader only reads `mcp.search_threshold` (intentional per the field comment). So `reyn config set mcp_search_threshold 99` writes the key, but reload resolves to the default **30** — the schema advertises a top-level key the set/get path can't honor. **This is exactly the schema↔set/get drift #1142 guards** — #1142 missed it because its round-trip test uses default values (30→30 passes trivially). Candidate #1142 follow-up: round-trip on a NON-default value + either honor top-level `mcp_search_threshold` or stop advertising it as a top-level key. Verified reproducible (set 99 → resolves 30).

## Test plan
- [x] `pytest tests/test_config_mirror_coverage_1056.py` → 3 passed
- [x] `pytest -k config` → 314 passed, 0 fail
- [x] `ruff check` (new test) → clean
- [x] `scripts/test_tier_audit.py --strict` → 3 OK / 0 warn / 0 err
- [x] Coverage probe re-run after sync → 0 missing names, 0 missing top-level sections in both mirrors

Refs #1056 #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)