### PR TITLE
fix(dogfood): llm-emitted-ops match real events 'type' field + add json-decode source (#1135)

### DIFF
--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -1248,6 +1248,19 @@ def mode_llm_advertised_ops(records: list[dict], request_id: str) -> None:
 # (existing validation_error/phase_failed etc. are UNCHANGED). failure_kind is
 # an explicit enum field on the event (not derived from the event name).
 _VALIDATION_FAIL_EVENT = "phase_output_validation_failed"
+_JSON_DECODE_FAIL_EVENT = "llm_output_json_decode_failed"
+
+
+def _event_type(e: dict) -> str:
+    """Return an event's type, tolerating both on-disk conventions.
+
+    The P6 events log writes the type under ``"type"`` (``EventLog.emit`` ->
+    ``Event(type=...)``); some WAL/legacy records use ``"kind"``. Match either
+    so the read-side finds real events (the events log) AND hand-written
+    fixtures. (Field is top-level — NOT under ``data``, which carries the
+    skill-level ``failure_kind`` enum, a different thing.)
+    """
+    return e.get("type") or e.get("kind") or ""
 
 
 def _op_kind_keys(op: dict) -> "tuple[str, list[str]]":
@@ -1283,16 +1296,23 @@ def _resolve_raw_output(ev: dict, state_dir: "Path | None") -> "str | None":
 
 
 def mode_llm_emitted_ops(records: list[dict], request_id: str, root: "Path | None") -> None:
-    """Structured summary of the control_ir ops the model EMITTED.
+    """Structured summary of the LLM output the model EMITTED, across 3 sources.
 
-    Two sources, both reduced to ``{kind, keys}``:
-      1. The LLM response for *request_id* — its ``ops`` array (the ops the
-         model emitted on a successful parse).
-      2. Validation-failure events (``control_ir_validation_error`` etc.) whose
-         ``raw_output`` / ``raw_output_ref`` carries the raw model output that
-         FAILED validation — so "emitted a valid-looking op but it was rejected"
-         is visible. (Requires FP-0008 #1135(b) write-side; until that lands the
-         events simply carry no raw_output and this half shows nothing.)
+      1. The LLM response for *request_id* — its ``ops`` array (the ops emitted
+         on a successful parse), reduced to ``{kind, keys}``.
+      2. ``phase_output_validation_failed`` events (POST-parse, #1137): the
+         model emitted parseable JSON whose ops were REJECTED by validation —
+         ``raw_output`` (inline) / ``raw_output_ref`` (state_dir-relative
+         offload) reduced to ``{kind, keys}`` + the explicit ``failure_kind``.
+      3. ``llm_output_json_decode_failed`` events (PRE-parse, #1141 sibling):
+         the model emitted UNPARSEABLE JSON — no ops to extract, so show
+         ``failure_kind`` + ``error`` + the (position-aware-truncated) raw
+         slice verbatim. This is the classification signal for "weak-model
+         malformed" vs "OS-repairable" decode failures.
+
+    Sources 2 & 3 come from the events log (``--root``); their on-disk type
+    field is ``type`` (matched via ``_event_type``), and they are NOT keyed by
+    request_id, so all such events under --root are listed.
 
     Pairs with ``llm-advertised-ops``: advertised (what the OS offered) vs
     emitted (what the model produced), for decide-turn failure classification.
@@ -1327,54 +1347,68 @@ def mode_llm_emitted_ops(records: list[dict], request_id: str, root: "Path | Non
                 else:
                     print(f"    (non-dict op: {op!r})")
 
-    # Source 2: phase_output_validation_failed events carrying raw model output.
-    # Events live in the events log (--root), not the LLM trace, and are
-    # phase-keyed (no request_id), so we list all such events. Per canonical
-    # contract (#1135) this is a single NEW event with an explicit failure_kind
-    # field and a state_dir-relative raw_output_ref (state_dir == --root here:
-    # the offload root the relative ref resolves under).
+    # Sources 2 & 3 live in the events log (--root), not the LLM trace, and are
+    # NOT request_id-keyed (events carry agent_id/run_id, not request_id), so we
+    # list all such events. The on-disk type field is "type" (EventLog.emit ->
+    # Event(type=...)); matching is via _event_type() which tolerates type/kind.
     if root is None:
         return
     state_dir = root
-    fail_events = [
-        e for e in _all_events(root)
-        if e.get("kind") == _VALIDATION_FAIL_EVENT
-        or (isinstance(e.get("data"), dict) and e["data"].get("kind") == _VALIDATION_FAIL_EVENT)
+    all_evs = _all_events(root)
+
+    # Source 2: phase_output_validation_failed (POST-parse, #1137). raw_output is
+    # parseable JSON whose ops were rejected by validation -> reduce to {kind,keys}.
+    fail_events = [e for e in all_evs if _event_type(e) == _VALIDATION_FAIL_EVENT]
+    raw_bearing = [
+        e for e in fail_events
+        if (d := e.get("data", e)).get("raw_output") or d.get("raw_output_ref")
     ]
-    raw_bearing = []
-    for e in fail_events:
-        d = e.get("data", e)
-        if d.get("raw_output") or d.get("raw_output_ref"):
-            raw_bearing.append(e)
-    if not raw_bearing:
-        print()
-        print(f"  {_VALIDATION_FAIL_EVENT} events with raw_output: none")
-        print("  (= no rejected-op records; or FP-0008 #1135(b) write-side not yet landed)")
-        return
     print()
-    print(f"  {_VALIDATION_FAIL_EVENT} events with raw model output ({len(raw_bearing)}):")
-    for e in raw_bearing:
+    if not raw_bearing:
+        print(f"  {_VALIDATION_FAIL_EVENT} events with raw_output: none")
+    else:
+        print(f"  {_VALIDATION_FAIL_EVENT} events with raw model output ({len(raw_bearing)}):")
+        for e in raw_bearing:
+            d = e.get("data", e)
+            failure_kind = d.get("failure_kind", "?")  # explicit enum field (canonical #1135)
+            phase = d.get("phase", "?")
+            raw = _resolve_raw_output(e, state_dir)
+            ops_summary = "?"
+            if raw:
+                try:
+                    parsed = json.loads(raw)
+                    ops = parsed.get("ops") if isinstance(parsed, dict) else None
+                    if isinstance(ops, list):
+                        ops_summary = ", ".join(
+                            f"{_op_kind_keys(o)[0]}{_op_kind_keys(o)[1]}"
+                            for o in ops if isinstance(o, dict)
+                        ) or "(no ops in raw)"
+                    else:
+                        ops_summary = "(raw not act-shaped)"
+                except (json.JSONDecodeError, AttributeError):
+                    ops_summary = "(raw unparseable)"
+            else:
+                ops_summary = "(raw_output_ref unresolved)"
+            print(f"    failure_kind={failure_kind}  phase={phase}  emitted={ops_summary}")
+
+    # Source 3: llm_output_json_decode_failed (PRE-parse, #1141 sibling). raw_output
+    # is by definition UNPARSEABLE JSON, so there are no {kind,keys} to extract —
+    # surface failure_kind + error + the (position-aware-truncated) raw slice
+    # verbatim, which is the diagnostic for weak-model-malformed vs OS-repairable.
+    decode_events = [e for e in all_evs if _event_type(e) == _JSON_DECODE_FAIL_EVENT]
+    print()
+    if not decode_events:
+        print(f"  {_JSON_DECODE_FAIL_EVENT} events: none")
+        return
+    print(f"  {_JSON_DECODE_FAIL_EVENT} events ({len(decode_events)}):")
+    for e in decode_events:
         d = e.get("data", e)
-        failure_kind = d.get("failure_kind", "?")  # explicit enum field (canonical #1135)
-        phase = d.get("phase", "?")
-        raw = _resolve_raw_output(e, state_dir)
-        ops_summary = "?"
-        if raw:
-            try:
-                parsed = json.loads(raw)
-                ops = parsed.get("ops") if isinstance(parsed, dict) else None
-                if isinstance(ops, list):
-                    ops_summary = ", ".join(
-                        f"{_op_kind_keys(o)[0]}{_op_kind_keys(o)[1]}"
-                        for o in ops if isinstance(o, dict)
-                    ) or "(no ops in raw)"
-                else:
-                    ops_summary = "(raw not act-shaped)"
-            except (json.JSONDecodeError, AttributeError):
-                ops_summary = "(raw unparseable)"
-        else:
-            ops_summary = "(raw_output_ref unresolved)"
-        print(f"    failure_kind={failure_kind}  phase={phase}  emitted={ops_summary}")
+        failure_kind = d.get("failure_kind", "?")
+        error = d.get("error", "?")
+        raw = d.get("raw_output")
+        raw_head = (raw[:200] + " …") if isinstance(raw, str) and len(raw) > 200 else raw
+        print(f"    failure_kind={failure_kind}  error={error}")
+        print(f"      raw_output: {raw_head!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dogfood_trace_llm_modes.py
+++ b/tests/test_dogfood_trace_llm_modes.py
@@ -419,6 +419,10 @@ def test_emitted_ops_reads_validation_fail_event_raw_output(tmp_path):
     Canonical contract (tya5/reyn#1135): a single NEW additive event
     `phase_output_validation_failed` carries inline raw_output + an explicit
     `failure_kind` enum field. Verifies the read-side parses it to kind+keys.
+
+    NOTE: the event uses the REAL on-disk shape — top-level ``"type"`` (what
+    EventLog.emit writes), NOT ``"kind"``. An earlier fixture used ``"kind"``
+    and masked a read-side filter that matched on the wrong field.
     """
     trace = tmp_path / "llm_trace.jsonl"
     _write_trace(trace, [
@@ -430,7 +434,7 @@ def test_emitted_ops_reads_validation_fail_event_raw_output(tmp_path):
     events.parent.mkdir(parents=True, exist_ok=True)
     raw = json.dumps({"type": "act", "ops": [{"kind": "file", "op": "write", "path": "x"}]})
     events.write_text(json.dumps({
-        "kind": "phase_output_validation_failed",
+        "type": "phase_output_validation_failed",
         "timestamp": "2026-05-31T00:00:00",
         "data": {"phase": "apply", "attempt": 2, "failure_kind": "artifact_data",
                  "error": "bad", "raw_output": raw},
@@ -465,7 +469,7 @@ def test_emitted_ops_reads_relative_offload_ref(tmp_path):
     events = tmp_path / "events" / "e.jsonl"
     events.parent.mkdir(parents=True, exist_ok=True)
     events.write_text(json.dumps({
-        "kind": "phase_output_validation_failed",
+        "type": "phase_output_validation_failed",
         "timestamp": "2026-05-31T00:00:00",
         "data": {"phase": "verify", "attempt": 1, "failure_kind": "ops_structure",
                  "error": "too big", "raw_output": None, "raw_output_ref": rel_ref},
@@ -474,3 +478,60 @@ def test_emitted_ops_reads_relative_offload_ref(tmp_path):
     assert rc == 0, out
     assert "failure_kind=ops_structure" in out
     assert "shell" in out and "cmd" in out  # deref'd + parsed from the relative offload file
+
+
+def test_emitted_ops_reads_real_type_field_not_kind(tmp_path):
+    """Tier 2: source-2 matches the REAL events-log type field (``type``), not ``kind``.
+
+    Regression guard for the #1136 read-side bug surfaced by the #1135 end-to-end
+    dispatch: EventLog.emit writes ``{"type": <name>, "data": {...}}``, so a filter
+    that matched ``kind`` found zero real events. This fixture is deliberately the
+    real shape; if the read-side reverts to matching ``kind`` it goes silent here.
+    """
+    trace = tmp_path / "t.jsonl"
+    _write_trace(trace, [
+        {"kind": "request", "request_id": REQUEST_ID_A, "messages": []},
+        {"kind": "response", "request_id": REQUEST_ID_A,
+         "content": json.dumps({"type": "act", "ops": []})},
+    ])
+    events = tmp_path / "events" / "e.jsonl"
+    events.parent.mkdir(parents=True, exist_ok=True)
+    raw = json.dumps({"type": "act", "ops": [{"kind": "shell", "cmd": "ls"}]})
+    events.write_text(json.dumps({
+        "type": "phase_output_validation_failed",  # REAL shape
+        "data": {"failure_kind": "control_ir", "phase": "decide", "raw_output": raw},
+    }) + "\n", encoding="utf-8")
+    out, rc = _run(["--mode", "llm-emitted-ops", REQUEST_ID_A, "--trace", str(trace), "--root", str(tmp_path)])
+    assert rc == 0, out
+    assert "phase_output_validation_failed events with raw model output (1)" in out
+    assert "failure_kind=control_ir" in out and "phase=decide" in out
+
+
+def test_emitted_ops_surfaces_json_decode_failure_event(tmp_path):
+    """Tier 2: source-3 surfaces a PRE-parse llm_output_json_decode_failed event.
+
+    #1141 sibling (opt A, #1135): the model emitted UNPARSEABLE JSON, so there
+    are no {kind,keys} — the read-side shows failure_kind + error + raw slice
+    verbatim (the weak-model-malformed vs OS-repairable classification signal).
+    """
+    trace = tmp_path / "t.jsonl"
+    _write_trace(trace, [
+        {"kind": "request", "request_id": REQUEST_ID_A, "messages": []},
+        {"kind": "response", "request_id": REQUEST_ID_A,
+         "content": json.dumps({"type": "act", "ops": []})},
+    ])
+    events = tmp_path / "events" / "e.jsonl"
+    events.parent.mkdir(parents=True, exist_ok=True)
+    bad_raw = '{"type": "act", "ops": [{"kind": "file", "old_string": "a\\xff"'  # invalid \escape
+    events.write_text(json.dumps({
+        "type": "llm_output_json_decode_failed",  # REAL shape, #1141
+        "data": {"failure_kind": "json_decode",
+                 "error": "Invalid \\escape: line 1 column 41",
+                 "raw_output": bad_raw},
+    }) + "\n", encoding="utf-8")
+    out, rc = _run(["--mode", "llm-emitted-ops", REQUEST_ID_A, "--trace", str(trace), "--root", str(tmp_path)])
+    assert rc == 0, out
+    assert "llm_output_json_decode_failed events (1)" in out
+    assert "failure_kind=json_decode" in out
+    assert "Invalid" in out and "escape" in out  # error surfaced
+    assert "old_string" in out                    # raw slice shown verbatim


### PR DESCRIPTION
**[dogfood-coder]** — output of the #1135 end-to-end verification dispatch. The live-run half is blocked (local LiteLLM proxy down), but prepping it via code inspection surfaced a **real read-side bug** plus completed the json-decode read-side branch.

## The bug (in merged #1136, found via the end-to-end lens)
`mode_llm_emitted_ops` source-2 filtered events on `e.get("kind")`, but the P6 events log writes the type under **`type`** (`EventLog.emit` → `Event(type=...)`; observed on disk: `{"type": "phase_output_validation_failed", "data": {...}}`). So the read-side matched **zero real events**. The unit tests passed only because their fixtures used the wrong key (`"kind"`) — exactly the synthetic-event gap this dispatch targets. `_all_events` does no `type`→`kind` normalization, so source-2 was silently blind to production data.

## Fixes
- **`_event_type(e)`** helper (tolerates `type` + legacy `kind`); source-2 now matches real events. Verified no sibling instances — all other `.get("kind")` reads are on WAL records or LLM-trace request/response records, which legitimately use `kind`.
- **Source-3: `llm_output_json_decode_failed`** (#1141 sibling, PRE-parse). `raw_output` is unparseable by definition, so no `{kind,keys}` — show `failure_kind` + `error` + the position-aware-truncated raw slice verbatim. This is the read-side branch I committed to in #1135, now that the shape is locked.
- Tests rewritten to the **real on-disk shape** (`type`); the prior `kind` fixtures were the masking error.

## Test plan
- [x] 26 pass (`python -m pytest tests/test_dogfood_trace_llm_modes.py -q`), incl. 2 new: `test_emitted_ops_reads_real_type_field_not_kind` (regression guard — goes silent if reverted to `kind`), `test_emitted_ops_surfaces_json_decode_failure_event`
- [x] `ruff check` clean
- [x] Verified no sibling `type`/`kind` mismatches in events-log reads
- [ ] (deferred — live half) real events flowing from a live weak-model run → read-side isolates them. Blocked on the LiteLLM proxy being up; tracked for the next live capture (e2e's run or a chat session once the proxy is reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)