### PR TITLE
feat(tui): "↓ N new" indicator when content lands while scrolled up

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -361,6 +361,21 @@ class ConversationView(Widget):
     ConversationView #empty-hint.hidden {
         display: none;
     }
+    /* New-messages-below affordance: a 1-line dim-coral strip docked just
+       above the sticky/async area, shown ONLY while the user is scrolled up
+       AND content arrived after they locked. ``.hidden`` collapses it to
+       zero height in the (default) following case so the layout is unchanged.
+       Coral = the action-accent (= "jump here"). */
+    ConversationView #new-below {
+        dock: bottom;
+        height: auto;
+        color: #C8553D;  /* _CORAL */
+        background: #1a1a1a;  /* _BG_HEADER — subtle strip so it reads as chrome */
+        padding: 0 1;
+    }
+    ConversationView #new-below.hidden {
+        display: none;
+    }
     """
 
     def __init__(self, *, id: str | None = None) -> None:
@@ -437,6 +452,16 @@ class ConversationView(Widget):
         self._recent_replies: list[str] = []
         # Track whether user has scrolled up (suppress auto-scroll while scrolled)
         self._user_scrolled = False
+        # New-messages-below affordance: ``_new_below_baseline`` is the log's
+        # ``max_scroll_y`` captured at the instant the user scrolled up (=
+        # locked their view). While locked, new content grows ``max_scroll_y``;
+        # the delta from the baseline is the row count shown in the ``↓ N new``
+        # indicator. ``-1`` = "not locked" (= following the tail), so the
+        # content-grew watcher knows to stay hidden.
+        self._new_below_baseline: int = -1
+        # Current row count shown in the ``↓ N new`` strip (0 = hidden).
+        # Exposed read-only via the ``new_below_count`` property.
+        self._new_below_count: int = 0
         # Issue 5 — track mounted ErrorBoxes for Escape-to-dismiss
         self._error_boxes: list[ErrorBox] = []
         # Cursor into ``_error_boxes`` for the F5 / F6 jump-to-error
@@ -505,6 +530,12 @@ class ConversationView(Widget):
         # cold-default case.
         yield StickyStatus(id="sticky-status")
         yield AsyncStackPanel(id="async-stack")
+        # New-messages-below affordance. Yielded LAST so the dock:bottom
+        # stacking rule places it ABOVE sticky + async-stack (= right at the
+        # bottom edge of the scrollable log, where new content lands).
+        # Starts hidden; ``_update_new_below`` toggles it while the user is
+        # scrolled up and content arrives below their locked viewport.
+        yield Static("", id="new-below", classes="hidden", markup=True)
 
     def _log(self) -> RichLog:
         return self.query_one("#log", RichLog)
@@ -636,6 +667,17 @@ class ConversationView(Widget):
         ``_user_scrolled`` directly.
         """
         return self._user_scrolled
+
+    @property
+    def new_below_count(self) -> int:
+        """Rows of new content that landed below the locked viewport.
+
+        ``0`` when the user is following the tail (= the ``↓ N new`` strip is
+        hidden); positive while the user is scrolled up and content has
+        arrived since they locked. Read-only accessor for the indicator
+        state — tests assert this rather than poking the Static internals.
+        """
+        return self._new_below_count
 
     @property
     def trim_warned(self) -> bool:
@@ -788,6 +830,17 @@ class ConversationView(Widget):
             # If Textual's cross-widget watch API changes, fail open
             # (= keep historic auto-scroll behaviour) rather than crash mount.
             pass
+        try:
+            # Content-growth signal for the ``↓ N new`` affordance: while the
+            # user is scrolled up, writes don't move ``scroll_y`` (so the
+            # scroll watcher above never fires), but they DO grow the log's
+            # ``virtual_size``. Watching it is a single chokepoint that
+            # covers every write path without instrumenting each one.
+            self.watch(log, "virtual_size", self._on_log_content_grew)
+        except Exception:
+            # Fail open — the indicator is a non-critical affordance; a
+            # watch-API change must not break the conv pane.
+            pass
         # Load persisted timestamp-toggle state. The app instance holds
         # the project root; ConversationView reaches it defensively via
         # app.app (= the Textual ``app`` property on every widget).
@@ -820,6 +873,10 @@ class ConversationView(Widget):
         except Exception:
             pass
         self._user_scrolled = False
+        # Explicit re-engage: drop the lock baseline + clear the ``↓ N new``
+        # affordance so it doesn't linger after the user is back at the tail.
+        self._new_below_baseline = -1
+        self._update_new_below(0)
 
     def _on_log_scroll_y(self, old: float, new: float) -> None:
         """Flip ``auto_scroll`` and ``_user_scrolled`` based on at-bottom check.
@@ -840,11 +897,76 @@ class ConversationView(Widget):
                 log.auto_scroll = True
             if self._user_scrolled:
                 self._user_scrolled = False
+            # Back at the tail: drop the lock baseline + clear the affordance.
+            self._new_below_baseline = -1
+            self._update_new_below(0)
         else:
             if log.auto_scroll:
                 log.auto_scroll = False
             if not self._user_scrolled:
                 self._user_scrolled = True
+            # Just locked the view by scrolling up: capture the current
+            # content extent as the baseline so subsequent growth counts as
+            # "new below". Only capture on the False→True transition so a
+            # scroll WITHIN the locked region doesn't reset the baseline (=
+            # the count keeps accumulating until the user returns to bottom).
+            if self._new_below_baseline < 0:
+                self._new_below_baseline = int(log.max_scroll_y)
+                self._update_new_below(0)
+
+    def _on_log_content_grew(self, old: object, new: object) -> None:
+        """RichLog ``virtual_size`` changed — refresh the ``↓ N new`` count.
+
+        Fires on every write (the size grows as content is appended). Only
+        meaningful while the user has locked their view above the tail
+        (``_new_below_baseline >= 0``); otherwise the user is following and
+        the indicator stays hidden. The count is ``max_scroll_y - baseline``
+        — i.e. the rows of content that landed below the locked viewport.
+        """
+        if self._new_below_baseline < 0:
+            return
+        try:
+            log = self._log()
+        except Exception:
+            return
+        delta = int(log.max_scroll_y) - self._new_below_baseline
+        self._update_new_below(max(0, delta))
+
+    def _update_new_below(self, count: int) -> None:
+        """Show / hide the ``↓ N new`` indicator with ``count`` rows below.
+
+        ``count <= 0`` hides the strip (collapses to zero height); a positive
+        count shows ``↓ N new · Alt+End`` in coral. Defensive: a missing
+        widget (pre-mount / torn-down) is a silent no-op.
+        """
+        self._new_below_count = max(0, count)
+        try:
+            strip = self.query_one("#new-below", Static)
+        except Exception:
+            return
+        if count <= 0:
+            if "hidden" not in strip.classes:
+                strip.add_class("hidden")
+            return
+        noun = "new line" if count == 1 else "new lines"
+        strip.update(f"↓ {count} {noun} below · Alt+End to jump")
+        if "hidden" in strip.classes:
+            strip.remove_class("hidden")
+
+    def on_click(self, event: object) -> None:
+        """Click on the ``↓ N new`` strip jumps to the bottom (= Alt+End).
+
+        Only the indicator strip triggers the jump; clicks elsewhere in the
+        conv pane keep their default (no-op / text-select) behaviour. The
+        widget-id guard keeps this handler scoped so it doesn't hijack other
+        click targets in the pane.
+        """
+        try:
+            target_id = getattr(getattr(event, "widget", None), "id", None)
+        except Exception:
+            target_id = None
+        if target_id == "new-below":
+            self._snap_to_bottom()
 
     # ── empty state ───────────────────────────────────────────────────────────
 

--- a/tests/cli/test_conv_new_below_indicator.py
+++ b/tests/cli/test_conv_new_below_indicator.py
@@ -1,0 +1,138 @@
+"""Tier 2: conv pane "↓ N new" affordance while the user is scrolled up.
+
+Issue #1144 #1. The conv pane already suppresses auto-scroll when the user
+scrolls up to read history (``_user_scrolled`` + ``auto_scroll`` flip — see
+test_user_scroll_suppresses_auto.py). But until now nothing TOLD the user
+that new content had landed below their locked viewport — they had to blind-
+guess Alt+End. This adds a docked ``↓ N new lines below · Alt+End`` strip,
+shown only while scrolled up AND content arrived since the lock.
+
+Contract pinned here (public surface only — ``conv.new_below_count`` accessor
++ the ``#new-below`` strip's ``hidden`` class; no private-state asserts):
+  - following the tail (not scrolled up) → count stays 0 even as content writes
+  - scrolled up + later writes → count > 0 (the affordance appears)
+  - returning to the bottom → count resets to 0 (affordance clears)
+  - the strip's ``hidden`` class tracks count (0 ⇒ hidden, >0 ⇒ visible)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.text import Text
+from textual.widgets import RichLog, Static
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _fill_log(log: RichLog, n_lines: int, *, label: str = "baseline") -> None:
+    """Lay down enough content to make ``max_scroll_y`` non-zero."""
+    for i in range(n_lines):
+        log.write(Text(f"{label} {i}"))
+
+
+@pytest.mark.asyncio
+async def test_following_tail_keeps_count_zero() -> None:
+    """Tier 2: while following the tail, writes never raise the new-below count."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        await pilot.pause()
+        # Never scrolled up → following the tail → no "new below" affordance.
+        assert conv.user_scrolled is False
+        assert conv.new_below_count == 0
+
+
+@pytest.mark.asyncio
+async def test_scrolled_up_then_content_raises_count() -> None:
+    """Tier 2: content arriving after a scroll-up lock shows the ``↓ N new`` strip."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        assert log.max_scroll_y > 5, (
+            f"test setup: need scrollback (max_scroll_y={log.max_scroll_y})"
+        )
+
+        # User scrolls up → lock the view, baseline captured, nothing new yet.
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        await pilot.pause()
+        assert conv.user_scrolled is True
+        assert conv.new_below_count == 0, "no new content has arrived since lock yet"
+
+        # New content lands below the locked viewport.
+        _fill_log(log, 20, label="late")
+        await pilot.pause()
+        await pilot.pause()
+        assert conv.new_below_count > 0, (
+            "content arriving while scrolled up must raise the new-below count"
+        )
+
+        # The strip is visible (not hidden) when the count is positive.
+        strip = conv.query_one("#new-below", Static)
+        assert not strip.has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_return_to_bottom_clears_count() -> None:
+    """Tier 2: scrolling back to the tail clears the count + hides the strip."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        await pilot.pause()
+        _fill_log(log, 20, label="late")
+        await pilot.pause()
+        await pilot.pause()
+        assert conv.new_below_count > 0  # precondition: affordance is showing
+
+        # User returns to the tail.
+        log.scroll_end(animate=False)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert conv.user_scrolled is False
+        assert conv.new_below_count == 0
+        strip = conv.query_one("#new-below", Static)
+        assert strip.has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_strip_starts_hidden() -> None:
+    """Tier 2: the strip is hidden on a fresh pane (default following state)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        strip = conv.query_one("#new-below", Static)
+        assert strip.has_class("hidden")
+        assert conv.new_below_count == 0


### PR DESCRIPTION
**[tui-coder]** — Refs #1144 (#1 of the scroll/navigation UX exploration backlog). First PR of the scroll/nav topic.

## Problem

The conv pane already suppresses auto-scroll when the user scrolls up to read history (`_user_scrolled` + `auto_scroll` flip — `test_user_scroll_suppresses_auto.py`). But nothing **told** the user that new content had landed below their locked viewport — they had to blind-guess Alt+End to catch up. (Classic chat-scroll affordance gap; `grep` confirmed no existing indicator.)

## Fix

A docked dim-coral strip `↓ N new lines below · Alt+End to jump`, shown **only** while scrolled up AND content arrived since the lock. Collapses to zero height (`.hidden`) in the default following case → layout unchanged when not scrolled up. Clicking the strip jumps to the bottom (= Alt+End).

## Design

- **Single detection chokepoint** (not per-write instrumentation): a watcher on the RichLog's `virtual_size` reactive fires on every write (content growth), covering all write paths without touching each one. Mirrors the existing `scroll_y` watcher next to it.
- **Count** = `max_scroll_y - baseline`, where the baseline is `max_scroll_y` captured at the instant the user scrolls up (the False→True `_user_scrolled` transition in `_on_log_scroll_y`).
- **Clear** on return to the tail via any path — scroll, Alt+End, submit (`_snap_to_bottom`), or `clear()` — drops the baseline + hides the strip.
- `_CORAL` (action accent, "jump here") on a subtle `_BG_HEADER` strip; CSS follows this file's existing literal-hex + `/* _TOKEN */` convention (the empty-hint precedent).

## Scope

`src/reyn/chat/tui/widgets/conversation.py` only — CSS rule, `compose()` Static, `__init__` state, the `virtual_size` watch, baseline capture in `_on_log_scroll_y`, `_on_log_content_grew` / `_update_new_below` / `on_click`, and a `new_below_count` public accessor. No OS/cross-process surface.

## Tests (Tier 2)

`tests/cli/test_conv_new_below_indicator.py` — real `ReynTUIApp` harness (same pattern as `test_user_scroll_suppresses_auto.py`), public surface only (`conv.new_below_count` accessor + the `#new-below` strip's `hidden` class):
- following the tail → count stays 0 as content writes
- scrolled up + later writes → count > 0 (strip visible)
- return to bottom → count resets to 0 (strip hidden)
- fresh pane → strip starts hidden

## Test plan

- [x] `pytest tests/cli/test_conv_new_below_indicator.py` — 4 passed
- [x] `pytest tests/cli -k "scroll or user_scroll or conversation or auto_scroll"` — 57 passed (regression: `_on_log_scroll_y` / `_snap_to_bottom` changes don't break existing scroll-lock behavior)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed (CSS parses, ConversationView mounts with the new Static)
- [x] `ruff check` clean
- [x] `scripts/test_tier_audit.py --strict` clean (0 errors)
- [ ] (skipped — visual) live `reyn chat`: scroll up mid-stream, confirm `↓ N new` appears + Alt+End/click jumps + it clears — behavior is covered by the 4 Tier-2 harness tests; geometry-dependent visual is a manual follow-up

## Tier self-check

Tier-2 behavior tests, real instances, public accessor + DOM class assertions. No format-pin / no private-state assert / no golden-file. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)