### PR TITLE
feat(tui): Alt+Home jumps conv log to top (symmetric with Alt+End)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -156,6 +156,7 @@ class ReynTUIApp(App):
         # waiting for a manual PageDown chain.
         Binding("alt+up", "conv_scroll_line_up", "Scroll up 1 line", priority=True, show=False),
         Binding("alt+down", "conv_scroll_line_down", "Scroll down 1 line", priority=True, show=False),
+        Binding("alt+home", "conv_scroll_home", "Scroll to top", priority=True, show=False),
         Binding("alt+end", "conv_scroll_end", "Scroll to bottom", priority=True, show=False),
         # ``/find`` cycle navigation. After ``/find <query>`` lands the
         # first match, Ctrl+G cycles forward and Ctrl+Shift+G cycles
@@ -1516,6 +1517,14 @@ class ReynTUIApp(App):
         try:
             conv = self.query_one("#conversation", ConversationView)
             conv.scroll_line_down()
+        except Exception:
+            pass
+
+    def action_conv_scroll_home(self) -> None:
+        """Alt+Home — jump the conv log to the top (oldest content)."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.scroll_to_top()
         except Exception:
             pass
 

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -2559,6 +2559,28 @@ class ConversationView(Widget):
                 pass
         self._user_scrolled = True
 
+    def scroll_to_top(self) -> None:
+        """Jump the conv log to the very top (oldest content), no focus change.
+
+        Symmetric with ``scroll_to_bottom`` (Alt+End): the conv log has
+        ``can_focus=False`` so Textual's default Home key never reaches it,
+        and there was a jump-to-bottom but no jump-to-top. Sets
+        ``_user_scrolled`` so the scroll watcher doesn't yank the user back
+        to the tail on the next write (they're now reading the oldest
+        history). The ``scroll_y`` watcher also fires from the position
+        change, arming the same scroll-lock + ``↓ N new`` baseline as a
+        manual scroll-up.
+        """
+        log = self._log()
+        try:
+            log.scroll_home(animate=False)
+        except Exception:
+            try:
+                log.scroll_to(y=0, animate=False)
+            except Exception:
+                pass
+        self._user_scrolled = True
+
     def scroll_page_down(self) -> None:
         """Scroll the conv log down one page without changing focus."""
         log = self._log()

--- a/tests/cli/test_conv_scroll_to_top.py
+++ b/tests/cli/test_conv_scroll_to_top.py
@@ -1,0 +1,95 @@
+"""Tier 2: Alt+Home jumps the conv log to the top (symmetric with Alt+End).
+
+Issue #1144 #3. The conv pane had keyboard scroll for PageUp/Down, line
+up/down (Alt+Up/Down), and jump-to-bottom (Alt+End) — but no jump-to-top.
+The log has ``can_focus=False`` so Textual's default Home never reaches it.
+This adds ``scroll_to_top`` + an Alt+Home binding/action mirroring the
+existing Alt+End → ``scroll_to_bottom`` path.
+
+Public surface only (``conv.scroll_to_top`` / ``app.action_conv_scroll_home``
++ the ``user_scrolled`` accessor + ``log.scroll_y``); no private-state asserts.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.text import Text
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _fill_log(log: RichLog, n_lines: int) -> None:
+    for i in range(n_lines):
+        log.write(Text(f"line {i}"))
+
+
+@pytest.mark.asyncio
+async def test_scroll_to_top_jumps_and_locks() -> None:
+    """Tier 2: ``scroll_to_top`` moves to y=0 and sets the user-scrolled lock."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+        # Default: following the tail (bottom).
+        assert log.max_scroll_y > 5, (
+            f"test setup: need scrollback (max_scroll_y={log.max_scroll_y})"
+        )
+
+        conv.scroll_to_top()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert log.scroll_y == 0, f"expected top (y=0), got {log.scroll_y}"
+        # Reading the oldest content = scrolled up: auto-scroll must stay off.
+        assert conv.user_scrolled is True
+
+
+@pytest.mark.asyncio
+async def test_action_conv_scroll_home_dispatches_to_top() -> None:
+    """Tier 2: the Alt+Home action wires through to ``scroll_to_top``."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        _fill_log(log, 60)
+        await pilot.pause()
+
+        app.action_conv_scroll_home()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert log.scroll_y == 0
+
+
+@pytest.mark.asyncio
+async def test_alt_home_binding_registered() -> None:
+    """Tier 2: an Alt+Home binding is registered and maps to conv_scroll_home."""
+    app = _make_app()
+    hits = [
+        b for b in app.BINDINGS
+        if getattr(b, "key", None) == "alt+home"
+        and getattr(b, "action", None) == "conv_scroll_home"
+    ]
+    assert hits, "Alt+Home → conv_scroll_home binding must be registered"


### PR DESCRIPTION
**[tui-coder]** — Refs #1144 (#3 of the scroll/navigation backlog). #1 (`↓ N new`) merged as #1148; #2 (find match `N/M` count) was verified **already-built** (header `[find:'q' N/M]` badge + cycle refresh — recorded in #1144).

## Problem

The conv pane has keyboard scroll for PageUp/Down, line up/down (Alt+Up/Down), and jump-to-bottom (Alt+End) — but **no jump-to-top**. The log is `can_focus=False`, so Textual's default Home key never reaches it. Asymmetric: you could leap to the tail of a long history but not the head.

## Fix

`ConversationView.scroll_to_top()` (mirrors `scroll_to_bottom`) + an **Alt+Home** binding/action dispatching to it. Scrolling to the top sets `_user_scrolled` so auto-scroll stays suppressed (you're reading the oldest content); the existing `scroll_y` watcher also arms the `↓ N new` baseline (from #1148), so a write while parked at the top is announced — same scroll-lock semantics as a manual scroll-up.

## g/G considered, not added

The conv scroll bindings all use an **Alt+ modifier** (Alt+Up/Down/Home/End) to avoid clobbering the single-key bindings the right-panel tabs register (e.g. `f`/`t`). A bare `g`/`G` would be inconsistent with that scheme and risk that conflict, so Alt+Home (symmetric with Alt+End) is the clean fit.

## Scope

`app.py` (binding + action) + `conversation.py` (`scroll_to_top`). The Keys tab picks up the new binding automatically (it iterates `app.BINDINGS`; description "Scroll to top").

## Test plan

- [x] `pytest tests/cli/test_conv_scroll_to_top.py` — 3 passed (method jumps to y=0 + locks; action wires through; Alt+Home binding registered)
- [x] `pytest tests/cli -k "scroll or conversation or auto_scroll or keys_tab"` — 99 passed (regression incl. Keys-tab binding render)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed
- [x] `ruff check` clean
- [x] `scripts/test_tier_audit.py --strict` clean (0 errors)
- [ ] (skipped — visual) live `reyn chat`: Alt+Home on a long history jumps to the oldest line — covered by the harness tests; geometry-visual is a manual follow-up

## Tier self-check

Tier-2 behavior tests, real instances, public surface (`scroll_to_top` / `action_conv_scroll_home` / `user_scrolled` / `scroll_y` / `BINDINGS`). No format-pin / no private-state assert / no golden. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)