### PR TITLE
fix(config): #1146 — mcp merge override-scalar drop + wire 2 dead fields + non-default no-op guard

### DIFF
--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1609,7 +1609,17 @@ class ReynConfig:
     # (deferred-loading mode).  Default 30; set 0 to disable.
     # Configurable via ``mcp.search_threshold:`` in reyn.yaml.
     # Spring AI experiment: 63–64% token reduction at 40+ MCP tools.
-    mcp_search_threshold: int = 30
+    #
+    # ``schema_internal``: this field is INTERNAL storage derived by the
+    # loader from the ``mcp.search_threshold`` key (see
+    # ``_parse_mcp_search_threshold``); it is NOT itself an operator-settable
+    # top-level key. The operator sets ``mcp.search_threshold`` (a free-form
+    # sub-key of the ``mcp`` dict); ``reyn config set mcp_search_threshold``
+    # would be a no-op on reload. The metadata flag tells
+    # ``walk_config_schema`` to omit it from the settable schema so
+    # ``reyn config set/get/fields`` and the doc-mirror guard don't advertise
+    # a key the set/get path can't honor.
+    mcp_search_threshold: int = field(default=30, metadata={"schema_internal": True})
     # FP-0024 Component A — BM25 skill pre-filter settings.
     # Below threshold: full enum. Above threshold: BM25 top-K filter.
     # Default 20 — current stdlib (~30-50 skills) stays at full enum unless
@@ -1754,7 +1764,19 @@ def _merge(base: dict, override: dict) -> dict:
             existing = result.get("mcp", {})
             existing_servers = existing.get("servers", {}) if isinstance(existing, dict) else {}
             new_servers = val.get("servers", {}) if isinstance(val, dict) else {}
-            result["mcp"] = {**existing, "servers": {**existing_servers, **new_servers}}
+            # Override-wins for scalar mcp keys (``search_threshold``,
+            # ``registries``), server entries union (existing ∪ new). The
+            # earlier ``{**existing, "servers": ...}`` form silently dropped
+            # the override's non-``servers`` keys, making ``mcp.search_threshold``
+            # and ``mcp.registries`` impossible to set from any config layer
+            # (they always fell back to the default). Spreading ``val`` after
+            # ``existing`` restores last-layer-wins for those scalars while the
+            # explicit ``servers`` key keeps the server union intact.
+            result["mcp"] = {
+                **existing,
+                **val,
+                "servers": {**existing_servers, **new_servers},
+            }
         elif key == "cron" and isinstance(val, dict):
             # FP-0041 #489 PR-B: cron jobs merge by name — dynamic
             # entries (= .reyn/cron.yaml) win on collision with legacy
@@ -2045,6 +2067,13 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             for k, v in (merged.get("models") or {}).items()
         },
         api_base=str(merged.get("api_base") or ""),
+        # prompt_cache_enabled / project_context_path were declared as
+        # ReynConfig fields + consumed (llm.py / session.py / agent.py /
+        # _read_project_context) but never read here, so operator config was
+        # silently ignored (always the dataclass default = a no-op set). Wire
+        # them through merged so the operator-set value actually takes effect.
+        prompt_cache_enabled=bool(merged.get("prompt_cache_enabled", True)),
+        project_context_path=str(merged.get("project_context_path", "REYN.md")),
         permissions=dict(merged.get("permissions") or {}),
         mcp=dict(merged.get("mcp") or {}),
         mcp_search_threshold=_parse_mcp_search_threshold(merged.get("mcp")),

--- a/src/reyn/config_schema.py
+++ b/src/reyn/config_schema.py
@@ -62,6 +62,11 @@ class SchemaNode:
     desc: str = ""
     """Description from ``field(metadata={'desc': ...})``, or empty string."""
 
+    field_type: Any = None
+    """Unwrapped (Optional-stripped) field type for scalar leaves, e.g. ``int``,
+    ``str``, or a ``Literal[...]`` — ``None`` for dict leaves. Lets callers
+    introspect valid values (e.g. pick a non-default ``Literal`` member)."""
+
 
 #: Sentinel for fields whose default can only be computed by calling
 #: ``default_factory()``.  We eagerly call the factory so this sentinel
@@ -258,6 +263,14 @@ def _walk(
         if fname not in fields_map:
             continue
         dc_field = fields_map[fname]
+        if _is_schema_internal(dc_field):
+            # Field is internal storage (e.g. loader-derived from a different
+            # operator key), not an operator-settable schema key — omit it
+            # from the settable schema entirely so config set/get/fields and
+            # the doc-mirror guard never advertise a key the set/get path
+            # can't honor. The field's value still flows to its runtime
+            # consumers via the loader; it just isn't a settable dotted key.
+            continue
         dotkey = f"{prefix}.{fname}" if prefix else fname
         inner = _unwrap_optional(ftype)
 
@@ -285,6 +298,7 @@ def _walk(
                 default=default,
                 is_dict_leaf=False,
                 desc=desc,
+                field_type=inner,
             ))
 
 
@@ -294,3 +308,18 @@ def _field_desc(f: dataclasses.Field) -> str:  # type: ignore[type-arg]
     if meta and isinstance(meta, typing.Mapping):
         return str(meta.get("desc", ""))
     return ""
+
+
+def _is_schema_internal(f: dataclasses.Field) -> bool:  # type: ignore[type-arg]
+    """True when a field opts out of the operator-settable schema.
+
+    A field flags itself with ``field(metadata={'schema_internal': True})``
+    when it is internal storage (e.g. loader-derived from a *different*
+    operator key) rather than a directly settable config key. ``walk_config_schema``
+    omits such fields so ``reyn config set/get/fields`` and the doc-mirror
+    guard don't advertise a key whose set/get round-trip the loader can't honor.
+    """
+    meta = getattr(f, "metadata", None)
+    if meta and isinstance(meta, typing.Mapping):
+        return bool(meta.get("schema_internal", False))
+    return False

--- a/tests/test_config_mcp_merge_1146.py
+++ b/tests/test_config_mcp_merge_1146.py
@@ -1,0 +1,141 @@
+"""Tier 2: OS invariant — mcp config merge + schema-internal field (#1146).
+
+Two coupled fixes, both exercised through the public ``load_config`` surface:
+
+1. ``_merge``'s ``mcp`` branch used to drop the override's non-``servers`` keys
+   (``{**existing, "servers": union}``), so ``mcp.search_threshold`` and
+   ``mcp.registries`` set in any config layer were silently discarded (always
+   the default). The fix (``{**existing, **val, "servers": union}``) preserves
+   override scalars while keeping the server union — verified here that both now
+   take effect, and that the server union still works (regression guard for the
+   existing ``test_config_mcp_headers`` behavior).
+
+2. ``mcp_search_threshold`` is internal storage the loader derives from
+   ``mcp.search_threshold``; it is not an operator-settable top-level key
+   (setting it would be a no-op on reload). It is flagged
+   ``field(metadata={'schema_internal': True})`` so ``walk_config_schema`` omits
+   it — verified the operator key ``mcp.search_threshold`` stays settable while
+   the top-level alias is no longer advertised, and the consumer field is intact.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from reyn.config import ReynConfig, load_config
+from reyn.config_schema import (
+    is_valid_config_key,
+    resolve_config_value,
+    walk_config_schema,
+)
+
+
+def _root(tmp_path: Path) -> Path:
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_mcp_search_threshold_set_via_operator_key_takes_effect(tmp_path: Path) -> None:
+    """Tier 2: ``mcp.search_threshold`` set in config reaches cfg.mcp_search_threshold.
+
+    Pre-fix the merge dropped it → always the 30 default. Guards the override-
+    scalar-preservation in ``_merge``.
+    """
+    root = _root(tmp_path)
+    (root / "reyn.local.yaml").write_text(
+        "mcp:\n  search_threshold: 88\n", encoding="utf-8"
+    )
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+    assert cfg.mcp_search_threshold == 88, (
+        f"mcp.search_threshold=88 did not reach the derived field "
+        f"(got {cfg.mcp_search_threshold}) — merge dropped the override scalar"
+    )
+    assert resolve_config_value(cfg, "mcp.search_threshold")[1] == 88
+
+
+def test_mcp_registries_set_in_config_takes_effect(tmp_path: Path) -> None:
+    """Tier 2: ``mcp.registries`` set in config survives merge + exports the env var.
+
+    Pre-fix the merge dropped ``registries`` so the propagation at config.py:2020
+    never fired. Guards the same override-scalar-preservation fix.
+
+    ``load_config`` *sets* ``REYN_MCP_REGISTRY_URLS`` as a side effect (and only
+    when it is unset), so this test explicitly saves/clears/restores both env
+    vars itself — pytest's ``monkeypatch.delenv`` does not track a var the code
+    under test creates, which would otherwise leak into later registry tests.
+    """
+    saved = {k: os.environ.pop(k, None) for k in ("REYN_MCP_REGISTRY_URLS", "REYN_MCP_REGISTRY_URL")}
+    root = _root(tmp_path)
+    (root / "reyn.local.yaml").write_text(
+        "mcp:\n  registries:\n    - https://reg.example.com/v1\n", encoding="utf-8"
+    )
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        cfg = load_config()
+        assert cfg.mcp.get("registries") == ["https://reg.example.com/v1"], (
+            f"mcp.registries did not survive the merge: {cfg.mcp.get('registries')!r}"
+        )
+        assert os.environ.get("REYN_MCP_REGISTRY_URLS") == "https://reg.example.com/v1"
+    finally:
+        os.chdir(old)
+        os.environ.pop("REYN_MCP_REGISTRY_URLS", None)
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+
+def test_mcp_servers_union_preserved_across_layers(tmp_path: Path) -> None:
+    """Tier 2: server entries from different layers union, alongside scalar keys.
+
+    Regression guard: the merge fix must keep the existing servers-union behavior
+    (project ∪ local) AND now also carry a scalar key (search_threshold) set in
+    one layer — both coexist.
+    """
+    root = tmp_path
+    (root / "reyn.yaml").write_text(
+        "model: standard\n"
+        "mcp:\n  search_threshold: 5\n  servers:\n    alpha:\n      type: stdio\n      command: a\n",
+        encoding="utf-8",
+    )
+    (root / "reyn.local.yaml").write_text(
+        "mcp:\n  servers:\n    beta:\n      type: stdio\n      command: b\n",
+        encoding="utf-8",
+    )
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+    servers = cfg.mcp.get("servers") or {}
+    assert "alpha" in servers and "beta" in servers, (
+        f"server union broken — expected alpha+beta, got {sorted(servers)}"
+    )
+    assert cfg.mcp_search_threshold == 5, "scalar key lost when servers also present"
+
+
+def test_mcp_search_threshold_field_is_unadvertised_but_operator_key_valid() -> None:
+    """Tier 2: top-level mcp_search_threshold omitted from the schema; operator key valid.
+
+    The internal field is flagged schema_internal so the walk omits it (a no-op
+    set is not advertised), while the real operator key ``mcp.search_threshold``
+    (a free-form sub-key of the ``mcp`` dict) stays valid and the consumer field
+    survives on the dataclass.
+    """
+    walk_keys = {n.key for n in walk_config_schema()}
+    assert "mcp_search_threshold" not in walk_keys, (
+        "mcp_search_threshold should be omitted from the settable schema "
+        "(schema_internal) — it's a no-op set"
+    )
+    assert not is_valid_config_key("mcp_search_threshold")
+    assert is_valid_config_key("mcp.search_threshold"), (
+        "the real operator key mcp.search_threshold must stay settable"
+    )
+    # Consumer field intact (router_tools reads cfg.mcp_search_threshold).
+    assert ReynConfig().mcp_search_threshold == 30

--- a/tests/test_config_schema_enforcement_1056.py
+++ b/tests/test_config_schema_enforcement_1056.py
@@ -4,12 +4,15 @@ PR1 (`test_config_schema_introspection.py`) proved the walk *includes* known
 nested keys + a top-level no-silent-skip drift guard. This PR2 file closes the
 remaining enforcement gap:
 
-  - **Every** scalar leaf the walk advertises actually round-trips through the
-    real ``reyn config set`` → ``load_config`` → ``resolve_config_value`` path
-    (not just the handful sampled in PR1). This is the framework's whole
-    promise — "adding a config field auto-reflects in reyn config set/get" —
-    pinned for the entire schema, so a future field whose section builder
-    silently drops it (set-able key that doesn't survive reload) fails loudly.
+  - **Every** scalar leaf the walk advertises actually takes effect through the
+    real ``reyn config set`` → ``load_config`` → ``resolve_config_value`` path,
+    set to a **non-default** value (not just the handful sampled in PR1, and not
+    its own default — see #1146). This is the framework's whole promise —
+    "adding a config field auto-reflects in reyn config set/get" — pinned for the
+    entire schema, so a future field whose loader never reads the key (the
+    operator's value silently discarded = a no-op set) fails loudly. A
+    default-valued round-trip passes trivially for such a field; a non-default
+    value exposes it.
   - **Every** free-form dict leaf accepts an arbitrary sub-key.
   - The 6 top-level descriptions migrated out of the deleted ``CONFIG_FIELDS``
     allowlist into ``field(metadata={'desc': ...})`` are preserved (regression
@@ -23,6 +26,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import typing
 from pathlib import Path
 
 import yaml
@@ -30,10 +34,57 @@ import yaml
 from reyn.config import ReynConfig, load_config
 from reyn.config_schema import (
     MISSING,
+    SchemaNode,
     is_valid_config_key,
     resolve_config_value,
     walk_config_schema,
 )
+
+# Fields that silently COERCE an invalid value back to their default (rather
+# than raising a validation error), so a generic "<default>_nd" candidate can't
+# distinguish "loader read+coerced" from a real no-op. Supply a domain-valid
+# non-default so the guard stays decisive. Keyed by dotted key; the iteration
+# itself is still live-walk-derived — this only overrides the candidate VALUE.
+_VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {
+    "skill_resume.default": "skip",  # validated against SKILL_RESUME_POLICIES, coerces
+}
+
+
+def _nondefault_candidate(node: SchemaNode) -> object | None:
+    """Return a non-default value for a scalar leaf, or None to skip it.
+
+    Derives a distinct-but-type-valid value from the node's default + field
+    type. ``Literal`` members come from the type itself; list leaves are skipped
+    (structured entries need shaped dicts — covered by their own builder tests).
+    """
+    if node.key in _VALID_NONDEFAULT_OVERRIDES:
+        return _VALID_NONDEFAULT_OVERRIDES[node.key]
+    d = node.default
+    t = node.field_type
+    if typing.get_origin(t) is typing.Literal:
+        for member in typing.get_args(t):
+            if member != d:
+                return member
+        return None
+    if isinstance(d, bool):
+        return not d
+    if isinstance(d, int):
+        return d + 1
+    if isinstance(d, float):
+        return round(d / 2, 6) if 0.0 < d < 1.0 else (d + 1.0 if d != 0.0 else 1.0)
+    if isinstance(d, str):
+        return (d + "_nd") if d else "nd_val"
+    if isinstance(d, list):
+        return None  # structured-list leaves need shaped entries — skip
+    if d is None:
+        if t is bool:
+            return True
+        if t is int:
+            return 1
+        if t is float:
+            return 1.0
+        return "nd_val"
+    return None
 
 # Top-level fields whose human descriptions were migrated from the (now
 # deleted) hand-maintained ``CONFIG_FIELDS`` allowlist into field metadata.
@@ -53,49 +104,63 @@ def _project_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_every_scalar_leaf_round_trips_through_set_and_load(tmp_path: Path) -> None:
-    """Tier 2: every scalar leaf survives reyn config set → load_config → resolve.
+def test_every_scalar_leaf_takes_effect_on_nondefault_set(tmp_path: Path) -> None:
+    """Tier 2: setting a NON-DEFAULT value on every scalar leaf actually takes effect.
 
-    For each scalar leaf the schema walk advertises, write its own default via
-    the real ``_set`` CLI path, reload the merged config, and assert
-    ``resolve_config_value`` returns the same value. A leaf that is advertised
-    by the walk but is silently dropped by its section builder on reload (=
-    set-able key, value vanishes) re-creates the old allowlist-drift bug; this
-    makes that loud for the *entire* schema, not just sampled keys.
+    The original default-valued round-trip (#1142) passed *trivially* for a field
+    the loader silently ignores: set X → reload → default, and default == X when X
+    is the default. #1146: set a value ≠ default so a no-op-set field (loader never
+    reads the key — e.g. a parse-derived alias like ``mcp_search_threshold``, or a
+    field declared + consumed but never wired into ``load_config`` like the
+    formerly-dead ``prompt_cache_enabled`` / ``project_context_path``) is caught.
+
+    Per field, set V ≠ default and reload (each in an isolated project root so one
+    field's value can't perturb another's load). Then require EITHER:
+      - the value round-trips (``resolve == V``) — loader read the key, OR
+      - ``load_config`` raises (the candidate hit the field's validation) — which
+        also proves the loader *read* the key.
+    A field that silently returns its default after a non-default set is a no-op
+    (the operator's value is discarded on reload) = FAIL.
     """
     from reyn.cli.commands.config import _set
 
-    root = _project_root(tmp_path)
     nodes = [n for n in walk_config_schema() if not n.is_dict_leaf]
     assert nodes, "walk returned no scalar leaves — catastrophic introspection failure"
 
-    mismatches: list[str] = []
+    noops: list[str] = []
+    checked = 0
     old_cwd = os.getcwd()
-    os.chdir(root)
     try:
-        for node in nodes:
-            default = node.default
-            if default is MISSING:
-                # No static default to round-trip (none today; defensive — such a
-                # field is still covered by the resolvable-on-default guard below).
+        for i, node in enumerate(nodes):
+            if node.default is MISSING:
                 continue
-            # Serialise the default to the YAML scalar string the CLI accepts,
-            # exactly as a human typing `reyn config set <key> <value>` would.
-            value_str = yaml.safe_dump(default, default_flow_style=True).strip()
-            _set(node.key, value_str)
-            cfg = load_config()
+            cand = _nondefault_candidate(node)
+            if cand is None or cand == node.default:
+                continue
+            root = tmp_path / f"leaf{i}"
+            root.mkdir()
+            (root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+            os.chdir(root)
+            _set(node.key, yaml.safe_dump(cand, default_flow_style=True).strip())
+            try:
+                cfg = load_config()
+            except Exception:
+                # Loader read the key and rejected the candidate during
+                # validation → the key IS wired (not a no-op). Counts as covered.
+                checked += 1
+                continue
+            checked += 1
             found, got = resolve_config_value(cfg, node.key)
-            if not found:
-                mismatches.append(f"{node.key}: not resolvable after set")
-            elif got != default:
-                mismatches.append(f"{node.key}: set={default!r} got back {got!r}")
+            if not found or got != cand:
+                noops.append(f"{node.key}: set {cand!r} → reload {got!r} (set ignored)")
     finally:
         os.chdir(old_cwd)
 
-    assert not mismatches, (
-        "config leaves that do not round-trip through set→load→resolve "
-        "(advertised by the schema walk but not preserved on reload — a "
-        "section builder is dropping the key): " + "; ".join(mismatches)
+    assert checked > 0, "no scalar leaf exercised — candidate generator returned None for all"
+    assert not noops, (
+        "config leaves whose set is a NO-OP (advertised by the schema walk + "
+        "set-able, but load_config never reads the key, so the operator's value "
+        "is silently discarded on reload): " + "; ".join(noops)
     )
 
 

--- a/tests/test_config_schema_introspection.py
+++ b/tests/test_config_schema_introspection.py
@@ -97,10 +97,20 @@ def test_walk_covers_every_top_level_field_no_silent_skip() -> None:
     dataclass field is added and its section disappears, this fails until
     the type is injected in ``config_schema._patch_localns`` (PR2 will
     auto-resolve and retire the manual injection).
+
+    Fields explicitly flagged ``field(metadata={'schema_internal': True})``
+    (#1146 — internal storage that is NOT an operator-settable key, e.g.
+    ``mcp_search_threshold`` which the loader derives from
+    ``mcp.search_threshold``) are intentionally omitted from the walk and so
+    excluded here — their omission is deliberate, not a silent forward-ref drop.
     """
     nodes = walk_config_schema()
     top_level = {n.key.split(".", 1)[0] for n in nodes}
-    field_names = {f.name for f in dataclasses.fields(ReynConfig)}
+    field_names = {
+        f.name
+        for f in dataclasses.fields(ReynConfig)
+        if not f.metadata.get("schema_internal", False)
+    }
     missing = field_names - top_level
     assert not missing, (
         f"ReynConfig fields with NO node in the schema walk (silently "


### PR DESCRIPTION
**[e2e-coder]** — #1146 (dispatched after my #1145 follow-up finding). Full design recorded in the [#1146 issue comment](https://github.com/tya5/reyn/issues/1146#issuecomment-4585698070). Strengthening #1142's round-trip guard to **non-default** values surfaced three real no-op-set bug classes — root-fixed here.

## Bugs fixed
**1. `_merge` dropped override mcp scalars** (`config.py`). `{**existing, "servers": union}` kept base's mcp keys + unioned servers but **discarded the override's non-`servers` keys** → `mcp.search_threshold` AND `mcp.registries` set in any config layer were silently dropped (always default; the registries propagation at `config.py:2020` never fired). Verified primary-data (direct `_merge` + project + local layers). Fix: `{**existing, **val, "servers": union}` (override-wins scalars, server union unchanged).

**2. `prompt_cache_enabled` / `project_context_path` never read in `load_config`** despite being declared fields + widely consumed (llm/session/agent/`_read_project_context`). Operator config silently ignored. Fix: wire both through `merged`.

**3. `mcp_search_threshold` top-level alias is a no-op** (loader derives it from `mcp.search_threshold`). Flagged `field(metadata={"schema_internal": True})`; `walk_config_schema` omits schema_internal fields (general mechanism, not a hardcoded string). Operator key `mcp.search_threshold` (now functional via #1) stays valid; consumer `cfg.mcp_search_threshold` unchanged.

## Guards (Tier 2, live-walk-derived)
- **`test_config_schema_enforcement_1056`**: every scalar leaf set to a **non-default** value must take effect (round-trip) OR raise on load (validation = loader read the key); silent return-to-default = no-op = FAIL. Per-field isolation. `SchemaNode` gains `field_type` so the generator picks a valid non-default `Literal` member.
- **`test_config_mcp_merge_1146`**: search_threshold + registries take effect; servers union preserved; alias unadvertised but operator key valid + consumer field intact.
- **`test_config_schema_introspection`**: the no-silent-skip guard now excludes schema_internal fields (deliberate omission).

## Why broader than dispatched
The dispatch was "resolve mcp_search_threshold (unadvertise)". But the operator key `mcp.search_threshold` was *itself* dead (merge bug), so unadvertising alone would leave no working way to set it — the merge fix is the prerequisite. The non-default guard then surfaced 2 more unrelated dead fields. Same bug class; root-fixed together. lead-coder approved the expanded scope on the issue.

## Test plan
- [x] `pytest -q --ignore=.claude` → **6580 passed** (1 pre-existing local-only `test_web_fetch_preview_path_ref` HTML-extractor-lib failure, not in CI, unrelated)
- [x] config/mcp/registry sweep (`-k "config or mcp or registr or prompt_cache or context"`) → 1156 passed
- [x] `ruff check` (5 changed files) → clean
- [x] `scripts/test_tier_audit.py --strict` → 30 OK / 0 warn / 0 err
- [x] env-leak guard: registries test explicitly saves/restores `REYN_MCP_REGISTRY_URLS` (load_config sets it; monkeypatch doesn't track code-set vars) — verified no leak into registry tests

Refs #1146 #1056 #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)