### PR TITLE
fix(dogfood): managed reyn web spawn to stop orphan leak (#268)

### DIFF
--- a/scripts/_reyn_web_proc.py
+++ b/scripts/_reyn_web_proc.py
@@ -1,0 +1,134 @@
+"""Managed reyn-web subprocess — guaranteed teardown, orphan-leak fix (#268).
+
+A bare ``subprocess.Popen`` + ``try/finally`` leaks reyn web when the driver
+process dies via a *signal* (terminal close = SIGHUP, session end = SIGTERM,
+Ctrl-C = SIGINT) BEFORE the ``finally`` block runs — the leftover ``reyn web``
+reparents to launchd (ppid=1) and lingers. (2026-05-31: 27 such orphans on
+ports 8282-8687, ~143MB, from a week of dogfood_step_2 runs whose drivers were
+signal-killed.)
+
+This module:
+- spawns reyn web in its OWN session (``start_new_session=True``) so it leads a
+  process group we can kill wholesale — covering any children reyn web forks;
+- registers ``atexit`` + SIGTERM/SIGINT/SIGHUP handlers that group-kill every
+  managed server, so teardown happens on normal exit, unhandled exception, AND
+  catchable signals.
+
+Residual: SIGKILL (-9) of the driver is uncatchable, so a hard ``kill -9`` can
+still orphan — unavoidable from the parent side. Every other common death path
+is now covered.
+
+Usage:
+    from _reyn_web_proc import spawn_reyn_web, managed_reyn_web
+
+    proc = spawn_reyn_web([reyn_bin, "web", "--port", "8099"], cwd=..., env=...)
+    # ... or, scoped:
+    with managed_reyn_web([reyn_bin, "web", "--port", "8099"]) as proc:
+        ...
+"""
+from __future__ import annotations
+
+import atexit
+import os
+import signal
+import subprocess
+import sys
+from contextlib import contextmanager
+
+_MANAGED: "list[subprocess.Popen]" = []
+_HANDLERS_INSTALLED = False
+
+
+def _terminate(proc: "subprocess.Popen") -> None:
+    """Group-kill a managed reyn web: SIGTERM the group, then SIGKILL on timeout."""
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.terminate()  # fallback: direct child only
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+
+
+def _cleanup_all() -> None:
+    for proc in list(_MANAGED):
+        _terminate(proc)
+    _MANAGED.clear()
+
+
+def _install_handlers() -> None:
+    """Register atexit + signal cleanup once (idempotent)."""
+    global _HANDLERS_INSTALLED
+    if _HANDLERS_INSTALLED:
+        return
+    atexit.register(_cleanup_all)
+
+    def _handler(signum, _frame):
+        _cleanup_all()
+        # Restore default disposition + re-raise so the process exits with the
+        # conventional 128+signum status (don't swallow the signal).
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # e.g. not in the main thread, or signal unsupported on platform.
+            pass
+    _HANDLERS_INSTALLED = True
+
+
+def spawn_reyn_web(cmd, **popen_kwargs) -> "subprocess.Popen":
+    """``subprocess.Popen`` a reyn web command with guaranteed teardown.
+
+    Forces ``start_new_session=True`` (own process group) unless the caller
+    overrides it, and registers the process for atexit/signal cleanup.
+    """
+    _install_handlers()
+    popen_kwargs.setdefault("start_new_session", True)
+    proc = subprocess.Popen(cmd, **popen_kwargs)
+    _MANAGED.append(proc)
+    return proc
+
+
+def stop_reyn_web(proc: "subprocess.Popen") -> None:
+    """Explicitly tear down a managed server now (group-kill) + deregister it.
+
+    For callers that stop the server mid-run rather than at process exit. Safe
+    to call more than once and on an already-dead process.
+    """
+    _terminate(proc)
+    if proc in _MANAGED:
+        _MANAGED.remove(proc)
+
+
+@contextmanager
+def managed_reyn_web(cmd, **popen_kwargs):
+    """Context manager: spawn reyn web, guarantee teardown on block exit."""
+    proc = spawn_reyn_web(cmd, **popen_kwargs)
+    try:
+        yield proc
+    finally:
+        _terminate(proc)
+        if proc in _MANAGED:
+            _MANAGED.remove(proc)
+
+
+def _selftest() -> int:
+    """Smoke: spawn a long sleeper via the manager, confirm it's killed on exit."""
+    with managed_reyn_web([sys.executable, "-c", "import time; time.sleep(120)"]) as p:
+        alive = p.poll() is None
+    killed = p.poll() is not None
+    print(f"spawned_alive={alive} killed_after_context={killed}")
+    return 0 if (alive and killed) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_selftest())

--- a/scripts/spike_lib/worktree.py
+++ b/scripts/spike_lib/worktree.py
@@ -6,6 +6,10 @@ import subprocess
 import time
 from pathlib import Path
 
+# #268: scripts/ is on sys.path (g4_spike inserts it); _reyn_web_proc is the
+# shared managed-spawn helper that guarantees reyn web teardown on signals.
+from _reyn_web_proc import spawn_reyn_web, stop_reyn_web
+
 from spike_lib.http import get_url
 
 
@@ -218,7 +222,10 @@ def start_web_server(
     # tail them post-run for debugging.
     log_path = Path(f"/tmp/reyn-spike-server-{port}.log")
     log_fh = open(log_path, "w", buffering=1)  # noqa: SIM115
-    proc = subprocess.Popen(
+    # #268: spawn via the managed helper (own process group + atexit/signal
+    # teardown) so a signal-killed driver doesn't leak orphaned reyn web on
+    # ports across worktrees — the g4_spike loop spawns one per worktree/port.
+    proc = spawn_reyn_web(
         ["reyn", "web", "--port", str(port)],
         cwd=str(worktree),
         env=env,
@@ -241,10 +248,9 @@ def wait_for_server(port: int, timeout_s: float = 30.0) -> bool:
 
 
 def stop_web_server(proc: subprocess.Popen) -> None:  # type: ignore[type-arg]
-    if proc.poll() is None:
-        proc.terminate()
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+    # #268: delegate to the managed helper so we group-kill (reap any children
+    # reyn web forked) and deregister from the atexit/signal cleanup list.
+    stop_reyn_web(proc)
+    log_fh = getattr(proc, "_spike_log_fh", None)
+    if log_fh is not None and not log_fh.closed:
+        log_fh.close()

--- a/tests/test_reyn_web_proc.py
+++ b/tests/test_reyn_web_proc.py
@@ -1,0 +1,87 @@
+"""Tests for scripts/_reyn_web_proc.py — the #268 reyn-web orphan-leak fix.
+
+Tier 2: OS invariant — a managed reyn-web subprocess is torn down (the whole
+process group, including children) on context exit and via atexit, so a driver
+death does not leak orphans. Uses real subprocesses (no mock): a stand-in
+``sleep`` process for the managed server, and a child it spawns to prove the
+WHOLE group is killed (not just the direct child).
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "_reyn_web_proc.py"
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def test_context_manager_kills_process_on_exit(tmp_path):
+    """Tier 2: managed_reyn_web kills the spawned process when the block exits."""
+    sys.path.insert(0, str(SCRIPT.parent))
+    import _reyn_web_proc as m
+
+    with m.managed_reyn_web([sys.executable, "-c", "import time; time.sleep(120)"]) as proc:
+        assert proc.poll() is None, "process should be alive inside the context"
+        pid = proc.pid
+    # give teardown a moment
+    for _ in range(50):
+        if not _alive(pid):
+            break
+        time.sleep(0.1)
+    assert not _alive(pid), "process must be dead after context exit"
+
+
+def test_group_kill_reaps_child_processes(tmp_path):
+    """Tier 2: teardown group-kills children the server forked (own-session group).
+
+    The stand-in 'server' spawns a long-lived grandchild and writes its PID to a
+    file; after teardown both must be dead — proving start_new_session + killpg
+    reaps the whole group, not just the direct child (the real-world case where
+    reyn web forks workers).
+    """
+    sys.path.insert(0, str(SCRIPT.parent))
+    import _reyn_web_proc as m
+
+    pidfile = tmp_path / "child.pid"
+    code = (
+        "import os, sys, time, subprocess;"
+        "c = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)']);"
+        f"open(r'{pidfile}', 'w').write(str(c.pid));"
+        "time.sleep(120)"
+    )
+    with m.managed_reyn_web([sys.executable, "-c", code]) as proc:
+        parent_pid = proc.pid
+        # wait for the grandchild pid to be recorded
+        for _ in range(50):
+            if pidfile.exists() and pidfile.read_text().strip():
+                break
+            time.sleep(0.1)
+    child_pid = int(pidfile.read_text().strip())
+    for _ in range(50):
+        if not _alive(parent_pid) and not _alive(child_pid):
+            break
+        time.sleep(0.1)
+    assert not _alive(parent_pid), "managed server must be dead"
+    assert not _alive(child_pid), "forked child must also be reaped (group kill)"
+
+
+def test_selftest_entrypoint_passes():
+    """Tier 2: the module's own --selftest smoke returns 0 (spawn->alive->killed)."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "killed_after_context=True" in result.stdout


### PR DESCRIPTION
**[dogfood-coder]** — fixes the reyn-web orphan leak found while investigating the proxy (27 orphaned `reyn web` on ports 8282-8687, ~143MB, from a week of dogfood runs; cleaned up live with user approval).

**Scope (per lead-coder review)**: focused bug-fix — helper + the **tracked** spawner + test only. `dogfood_step_2_measure.py` is an untracked local script (absent on main); its managed-spawn wiring is applied locally and **deferred to a separate PR** so this bug-fix isn't conflated with version-controlling 1067 lines of pre-existing tooling.

## Root cause
Dogfood drivers spawned `reyn web` via bare `subprocess.Popen` + `try/finally`. `finally` only runs on normal exit / handled exception — when the driver is killed by a **signal** (terminal close = SIGHUP, session end = SIGTERM, Ctrl-C = SIGINT) before `finally` runs, the leftover `reyn web` reparents to launchd (ppid=1) and lingers. A bare Popen also doesn't reap workers reyn web forks.

## Fix — `scripts/_reyn_web_proc.py` (shared helper)
- `spawn_reyn_web()`: `Popen` with `start_new_session=True` (own process group) + registers **atexit + SIGTERM/SIGINT/SIGHUP** handlers that **group-kill** every managed server. Covers normal exit, exception, AND catchable signals; group-kill reaps forked workers. SIGKILL (-9) of the driver stays uncatchable (unavoidable from the parent side).
- `stop_reyn_web()` / `managed_reyn_web()` for explicit / scoped teardown.

## Wired spawner (this PR)
- `spike_lib/worktree.py::start_web_server` (tracked; used by `dogfood_g4_spike.py`, which loops one server per worktree/port — matches the sequential-port orphan clusters).
- `dogfood_batch_dispatch.py` only prints a `nohup ... reyn web` *instruction string* (not a programmatic spawn) — unaffected.
- `dogfood_step_2_measure.py` (untracked local) — wiring applied locally, deferred to a separate version-control PR.

## Test plan
- [x] Tier 2 no-mock (real subprocesses), 3 pass: `python -m pytest tests/test_reyn_web_proc.py -q`
  - context-exit teardown kills the process
  - **group-kill reaps a forked grandchild** (proves whole-group teardown)
  - module `--selftest` entrypoint returns 0
- [x] `ruff check` clean (all touched files)
- [x] 27 live orphans cleaned up (user-approved), sparing the 1 under an active claude session

🤖 Generated with [Claude Code](https://claude.com/claude-code)