### PR TITLE
feat(os): #997 — Tier-3 op exposure invariant guard + phase_op_catalog_gap event

### DIFF
--- a/src/reyn/kernel/run_state.py
+++ b/src/reyn/kernel/run_state.py
@@ -52,6 +52,11 @@ class RunState:
     # Trusted input (PR33)
     skill_input: dict | None = None
 
+    # #997: phases for which a phase_op_catalog_gap event has already been
+    # emitted this run (dedup — the gap is a static config fact, so warn once
+    # per phase rather than every act-turn).
+    op_catalog_gap_warned: set[str] = field(default_factory=set)
+
     # ── Navigation / phase lifecycle ────────────────────────────────────────
 
     def begin_phase(self, phase: str) -> int:

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -437,6 +437,22 @@ class OSRuntime:
         allowed = set(phase_def.allowed_ops)
         all_ops = self.control_ir_executor.available_ops()
         filtered_ops = [op for op in all_ops if op.kind in allowed]
+        # #997: wiring-gap detection. A phase that declares an op in allowed_ops
+        # which the executor does NOT advertise (e.g. `shell` while
+        # shell_allowed=False, `mcp` with no servers configured) has that op
+        # filtered to nothing — the LLM sees the phase instruction referencing
+        # the op but no schema, and hallucinates a fake one (the FP-0008 / #1133
+        # failure class). Surface it as a P6 event so the trace tool catches the
+        # caller-side wiring gap proactively, once per phase per run.
+        gap = allowed - {op.kind for op in all_ops}
+        if gap and current_phase not in self._state.op_catalog_gap_warned:
+            self._state.op_catalog_gap_warned.add(current_phase)
+            self.events.emit(
+                "phase_op_catalog_gap",
+                phase=current_phase,
+                missing_ops=sorted(gap),
+                advertised_ops=sorted(op.kind for op in all_ops),
+            )
         # When the act budget is exhausted, strip available ops so the LLM has
         # no ops to call and is structurally forced into a decide turn.
         effective_ops = [] if force_decide else filtered_ops

--- a/tests/test_op_exposure_invariant_997.py
+++ b/tests/test_op_exposure_invariant_997.py
@@ -1,0 +1,216 @@
+"""Tier 2: OS invariant — Tier-3 op exposure + wiring-gap event (#997).
+
+Generalises the #1133 sandboxed_exec fix into the structural invariant that
+prevents the whole #1133 / FP-0008 class:
+
+> For every Tier-3 op X, if the runtime config enables X, the LLM's op catalog
+> MUST advertise X's schema; and if a phase declares X in allowed_ops while the
+> runtime did NOT enable it (so X is filtered to nothing), the OS must surface
+> the wiring gap as an event before the LLM hallucinates a fake schema.
+
+Direction 1 (op-exposure invariant): ``available_ops()`` advertises shell iff
+``shell_allowed``, mcp iff mcp servers are configured, and the unconditional set
+(sandboxed_exec / web_fetch / web_search / file / run_skill / lint / ask_user)
+regardless of flags — the last pinning #1133 (sandboxed_exec was the op that
+went missing).
+
+Direction 3 (wiring-gap event): ``build_frame`` emits a ``phase_op_catalog_gap``
+event (once per phase per run) when a phase's ``allowed_ops`` references an op
+the executor does not advertise — the exact pre-#1133 failure shape (phase says
+"use shell", shell gated off, op filtered to nothing, LLM hallucinates).
+
+No mocks — real ControlIRExecutor + real OSRuntime.build_frame.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.kernel.runtime import OSRuntime
+from reyn.permissions.permissions import PermissionResolver
+from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.workspace.workspace import Workspace
+
+# Ops the catalog advertises regardless of runtime flags. sandbox_exec is the
+# #1133 regression anchor (it was the op that went missing). The list is derived
+# from the invariant intent, not the implementation — a future change that gates
+# one of these behind a flag must update this guard deliberately.
+_UNCONDITIONAL_OPS = {
+    "file",
+    "ask_user",
+    "sandboxed_exec",
+    "lint",
+    "run_skill",
+    "web_fetch",
+    "web_search",
+}
+
+
+def _executor(
+    tmp_path: Path, *, shell_allowed: bool = False, mcp_servers: dict | None = None
+) -> ControlIRExecutor:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return ControlIRExecutor(
+        workspace=ws,
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={}, project_root=tmp_path, interactive=False
+        ),
+        skill_name="t",
+        shell_allowed=shell_allowed,
+        mcp_servers=mcp_servers,
+    )
+
+
+def _kinds(executor: ControlIRExecutor) -> set[str]:
+    return {spec.kind for spec in executor.available_ops()}
+
+
+# ── Direction 1: op-exposure invariant ──────────────────────────────────────
+
+
+@pytest.mark.parametrize("shell_allowed", [True, False])
+def test_shell_advertised_iff_shell_allowed(tmp_path: Path, shell_allowed: bool) -> None:
+    """Tier 2: shell is in the op catalog exactly when shell_allowed is set."""
+    kinds = _kinds(_executor(tmp_path, shell_allowed=shell_allowed))
+    assert ("shell" in kinds) is shell_allowed, (
+        f"shell advertised={('shell' in kinds)} but shell_allowed={shell_allowed} "
+        f"— exposure must track the permission flag (#997 invariant)"
+    )
+
+
+@pytest.mark.parametrize(
+    "mcp_servers, expect",
+    [
+        (None, False),
+        ({"servers": {}}, False),
+        ({"servers": {"gh": {"type": "http", "url": "http://x"}}}, True),
+    ],
+)
+def test_mcp_advertised_iff_servers_configured(
+    tmp_path: Path, mcp_servers: dict | None, expect: bool
+) -> None:
+    """Tier 2: mcp is in the op catalog exactly when mcp servers are configured."""
+    kinds = _kinds(_executor(tmp_path, mcp_servers=mcp_servers))
+    assert ("mcp" in kinds) is expect, (
+        f"mcp advertised={('mcp' in kinds)} but servers configured={expect}"
+    )
+
+
+@pytest.mark.parametrize(
+    "shell_allowed, mcp_servers",
+    [
+        (False, None),
+        (True, None),
+        (False, {"servers": {"gh": {"type": "http", "url": "http://x"}}}),
+        (True, {"servers": {"gh": {"type": "http", "url": "http://x"}}}),
+    ],
+)
+def test_unconditional_ops_always_advertised(
+    tmp_path: Path, shell_allowed: bool, mcp_servers: dict | None
+) -> None:
+    """Tier 2: the flag-independent ops are always advertised (incl. sandboxed_exec = #1133).
+
+    This is the generalised #1133 regression lock: no matter the shell/mcp flags,
+    the unconditional Tier-3 + core ops must stay in the catalog. The original bug
+    was sandboxed_exec silently absent from the spec list.
+    """
+    kinds = _kinds(_executor(tmp_path, shell_allowed=shell_allowed, mcp_servers=mcp_servers))
+    missing = _UNCONDITIONAL_OPS - kinds
+    assert not missing, (
+        f"unconditional ops missing from op catalog: {sorted(missing)} "
+        f"(shell_allowed={shell_allowed}, mcp={bool(mcp_servers)})"
+    )
+
+
+# ── Direction 3: phase_op_catalog_gap wiring-gap event ───────────────────────
+
+
+def _skill_with_allowed_ops(allowed_ops: list[str]) -> Skill:
+    phase = Phase(
+        name="act",
+        instructions="do work",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=allowed_ops,
+    )
+    return Skill(
+        name="gap_test_skill",
+        entry_phase="act",
+        phases={"act": phase},
+        graph=SkillGraph(transitions={}, can_finish_phases=["act"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _gap_events(events: EventLog) -> list:
+    return [e for e in events.all() if e.type == "phase_op_catalog_gap"]
+
+
+def test_phase_op_catalog_gap_emitted_when_declared_op_not_advertised(tmp_path: Path) -> None:
+    """Tier 2: a phase declaring shell while shell is gated off emits phase_op_catalog_gap.
+
+    The pre-#1133 failure shape: allowed_ops references an op the executor does
+    not advertise (shell, shell_allowed=False) → op filtered to nothing. The
+    event surfaces the caller-side wiring gap proactively.
+    """
+    pytest.importorskip("litellm")
+    import os
+
+    os.chdir(tmp_path)
+    rt = OSRuntime(
+        _skill_with_allowed_ops(["file", "shell"]),  # shell declared, shell_allowed defaults False
+        model="stub/model",
+        run_id="gap_test",
+        workspace_base_dir=tmp_path,
+    )
+    rt.build_frame("act", {"type": "input", "data": {}}, [], "en")
+
+    gaps = _gap_events(rt.events)
+    assert gaps, "expected a phase_op_catalog_gap event for the gated-off shell op"
+    d = gaps[-1].data
+    assert d["phase"] == "act"
+    assert "shell" in d["missing_ops"], f"missing_ops should name shell: {d['missing_ops']}"
+    assert "file" not in d["missing_ops"], "file is advertised — must not be flagged as a gap"
+
+
+def test_no_gap_event_when_all_declared_ops_advertised(tmp_path: Path) -> None:
+    """Tier 2: a phase declaring only advertised ops emits no wiring-gap event."""
+    pytest.importorskip("litellm")
+    import os
+
+    os.chdir(tmp_path)
+    rt = OSRuntime(
+        _skill_with_allowed_ops(["file", "sandboxed_exec"]),  # both unconditional
+        model="stub/model",
+        run_id="no_gap_test",
+        workspace_base_dir=tmp_path,
+    )
+    rt.build_frame("act", {"type": "input", "data": {}}, [], "en")
+    assert not _gap_events(rt.events), (
+        "no gap event expected when every declared op is advertised"
+    )
+
+
+def test_phase_op_catalog_gap_emitted_once_per_phase(tmp_path: Path) -> None:
+    """Tier 2: the gap event is deduped — emitted once per phase per run, not per turn."""
+    pytest.importorskip("litellm")
+    import os
+
+    os.chdir(tmp_path)
+    rt = OSRuntime(
+        _skill_with_allowed_ops(["file", "shell"]),
+        model="stub/model",
+        run_id="dedup_test",
+        workspace_base_dir=tmp_path,
+    )
+    rt.build_frame("act", {"type": "input", "data": {}}, [], "en")
+    rt.build_frame("act", {"type": "input", "data": {}}, [], "en")
+    rt.build_frame("act", {"type": "input", "data": {}}, [], "en")
+    assert len(_gap_events(rt.events)) == 1, (
+        "the static config gap should warn once per phase per run, not every build_frame"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #997 direction 1 (dispatched core) + direction 3 (rider, my-judgment-OK per lead-coder). Generalises my #1133 fix into the structural guard for the whole #1133 / FP-0008 class.

## Direction 1 — op-exposure invariant test (bounded core)
`tests/test_op_exposure_invariant_997.py`, Tier 2, real `ControlIRExecutor` (no mocks), parametrized:
- **shell advertised iff `shell_allowed`**
- **mcp advertised iff mcp servers configured**
- **unconditional set always advertised** (`sandboxed_exec` / `web_fetch` / `web_search` / `file` / `run_skill` / `lint` / `ask_user`) across all flag combos — the generalised **#1133 regression lock** (sandboxed_exec was the op that silently went missing).

Per my scope investigation: only 2 ops are conditionally gated (shell, mcp); the rest are unconditional — so the guard is small + decisive.

## Direction 3 — `phase_op_catalog_gap` wiring-gap event (cheap/clean rider)
`runtime.py build_frame`: when a phase's `allowed_ops` references an op the executor does **not** advertise (e.g. `shell` while `shell_allowed=False`), emit a P6 `phase_op_catalog_gap` event (`missing_ops` + `advertised_ops`) — the exact pre-#1133 symptom (op filtered to nothing → LLM hallucinates), now surfaced in `events.jsonl` + replay **before** the hallucination. Detected via `allowed_ops − advertised_kinds` delta (not instruction parsing). Deduped **once per phase per run** via `RunState.op_catalog_gap_warned` (the gap is a static config fact, not a per-turn event). Op kinds are OS-level vocabulary → event payload is **P7-clean**.

## Direction 2 — deferred
The `build_agent_runtime` helper to dedup the **~8** duplicated caller-side `*_allowed` wiring sites (run/dogfood/chat/cron/source/eval_benchmark×2/mcp×3 — more than the issue's "2") is a sizable cross-command refactor; deferred to a separate decision per lead-coder. (This session created new callers — `reyn run --env-backend=docker` + `swe_bench_runner` — so the future-caller gap risk is real; not instant-YAGNI.)

## Test plan
- [x] `pytest tests/test_op_exposure_invariant_997.py tests/test_sandboxed_exec_advertised_1133.py` → 17 passed
- [x] runtime/events/run_state sweep (`-k "runtime or build_frame or run_state or event or offload or compaction"`) → 609 passed
- [x] `pytest -q --ignore=.claude` → **6592 passed** (1 pre-existing local-only `test_web_fetch_preview_path_ref` HTML-extractor failure, not in CI, unrelated)
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean (6 OK)

Refs #997 #1133 #976 #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)