### PR TITLE
feat(tui): render multi-line tool-result strings as YAML block scalars

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -92,6 +92,43 @@ _REFRESH_INTERVAL = 2.0
 _PANEL_NARROW_TERMINAL_CUTOFF = 60
 
 
+def _yaml_block_dump(value: Any) -> str:
+    """``yaml`` dump with multi-line strings rendered as block scalars (``|``).
+
+    Plain ``yaml.safe_dump`` emits a multi-line string as a single-quoted
+    *folded* scalar: each ``\\n`` becomes a blank line and continuations are
+    quote-indented. For the tool-result payloads the events / recent-skill
+    previews surface (e.g. an email body or an MCP ``text`` content block),
+    that mangles the original line structure into something harder to read
+    than the raw text — the verbatim result is faithfully present but not
+    legible, so the operator falls back to the (paraphrase-prone) prose.
+
+    A custom ``str`` representer using block style (``|``) for any string
+    containing a newline keeps the lines intact; single-line strings keep
+    the default style. Raises if PyYAML is unavailable — callers keep their
+    JSON fallback. Pass an already JSON-normalised value (Path/datetime etc.
+    coerced to str) since ``yaml`` can't represent arbitrary types.
+    """
+    import yaml as _yaml
+
+    class _BlockDumper(_yaml.SafeDumper):
+        pass
+
+    def _str_rep(dumper: Any, data: str) -> Any:
+        style = "|" if "\n" in data else None
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+    _BlockDumper.add_representer(str, _str_rep)
+    return _yaml.dump(
+        value,
+        Dumper=_BlockDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+        width=120,
+    )
+
+
 class RightPanel(Widget):
     """Swappable right-side panel with tab bar.
 
@@ -1119,17 +1156,10 @@ class RightPanel(Widget):
         from rich.text import Text as RichText
         body: str
         try:
-            import yaml as _yaml
             normalised = _json.loads(
                 _json.dumps(value, default=str, ensure_ascii=False),
             )
-            body = _yaml.safe_dump(
-                normalised,
-                default_flow_style=False,
-                allow_unicode=True,
-                sort_keys=False,
-                width=120,
-            )
+            body = _yaml_block_dump(normalised)
         except Exception:
             try:
                 body = _json.dumps(value, indent=2, default=str, ensure_ascii=False)
@@ -2233,13 +2263,7 @@ class RightPanel(Widget):
                     normalised = _json.loads(
                         _json.dumps(events, default=str, ensure_ascii=False),
                     )
-                    body = _yaml.safe_dump(
-                        {"events": normalised},
-                        default_flow_style=False,
-                        allow_unicode=True,
-                        sort_keys=False,
-                        width=120,
-                    )
+                    body = _yaml_block_dump({"events": normalised})
                     lines.append(body.rstrip())
                 except Exception:
                     lines.append(_json.dumps(events, indent=2, default=str))

--- a/tests/cli/test_yaml_block_dump.py
+++ b/tests/cli/test_yaml_block_dump.py
@@ -1,0 +1,68 @@
+"""Tier 2: right-panel YAML dump renders multi-line strings as readable blocks.
+
+Tool results reach the right panel verbatim, but plain ``yaml.safe_dump``
+emits a multi-line string (email body, MCP ``text`` content block) as a
+single-quoted *folded* scalar — every ``\\n`` becomes a blank line and
+continuations are quote-indented, so the faithful content is illegible and
+the operator falls back to the paraphrase-prone prose. ``_yaml_block_dump``
+uses a block scalar (``|``) for multi-line strings instead.
+
+These pin the two properties that matter, NOT the exact whitespace (= not a
+format-pin):
+  - **fidelity**: the rendered YAML round-trips back to the original value
+    (rendering must never alter the verbatim result)
+  - **readability**: a multi-line string uses block style (``|`` present);
+    a single-line string does not
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+import yaml
+
+from reyn.chat.tui.widgets.right_panel import _yaml_block_dump
+
+
+def test_multiline_string_roundtrips_unchanged() -> None:
+    """Tier 2: a multi-line string survives block-scalar dump → load unchanged."""
+    body = "山田様\n\nお世話になっております。\n火曜14時で可能でしょうか。\n田中"
+    out = _yaml_block_dump({"body": body})
+    # Rendering must not corrupt the verbatim content.
+    assert yaml.safe_load(out) == {"body": body}
+
+
+def test_multiline_string_uses_block_style() -> None:
+    """Tier 2: a newline-containing string renders as a block scalar (readable)."""
+    out = _yaml_block_dump({"text": "Found 3 messages:\n1. a\n2. b\n3. c"})
+    assert "|" in out, (
+        "multi-line strings must use block style (|) so they read as text, "
+        f"not a folded quoted scalar. Got:\n{out!r}"
+    )
+    # And the lines are intact (round-trip fidelity, not a format-pin).
+    assert yaml.safe_load(out) == {"text": "Found 3 messages:\n1. a\n2. b\n3. c"}
+
+
+def test_single_line_string_stays_plain() -> None:
+    """Tier 2: a single-line string is NOT forced into block style."""
+    out = _yaml_block_dump({"status": "ok"})
+    assert "|" not in out, f"single-line value should stay plain, got:\n{out!r}"
+    assert yaml.safe_load(out) == {"status": "ok"}
+
+
+def test_nested_email_shape_roundtrips() -> None:
+    """Tier 2: a realistic nested tool-result shape round-trips intact."""
+    result = {
+        "status": "ok",
+        "data": {"messages": [{
+            "from": "Tanaka <tanaka@example.co.jp>",
+            "subject": "Re: 打ち合わせ",
+            "body": "お世話になっております。\n明日の件、よろしくお願いします。",
+        }]},
+    }
+    out = _yaml_block_dump(result)
+    assert yaml.safe_load(out) == result


### PR DESCRIPTION
**[tui-coder]** — Refs #393. Concrete first fix under the framing settled with the user: tool-result **display** is a UI-side concern (system renders the verbatim result faithfully), decoupled from the LLM's reply.

## Problem (observed, not speculative)

The right panel already surfaces tool results **verbatim** via `yaml.safe_dump` (events / recent-skill previews). Dogfooding a self-made **Outlook MCP**, the panel held the *correct* result — but plain `safe_dump` renders a multi-line string (email body, MCP `text` content block) as a single-quoted **folded** scalar: every `\n` becomes a blank line, continuations are quote-indented. Observed output:

```yaml
body: '山田様


    お世話になっております。田中です。

    来週の打ち合わせですが…'
```

The faithful content is present but **illegible**, so the operator falls back to the LLM's prose summary — which is exactly what paraphrases names/words wrong. So the verbatim surface failed at its job not for lack of data but for lack of legibility.

## Fix

`_yaml_block_dump`: a shared dumper with a custom `str` representer that uses block style (`|`) for any string containing a newline (single-line strings keep default style). Both right-panel YAML sites (`_render_as_yaml` + the recent-skill events bundle) route through it. Now:

```yaml
body: |-
  山田様

  お世話になっております。田中です。
  来週の打ち合わせですが…
```

— original line structure intact, no double-spacing / quote noise. Readable enough to be the *trusted* surface, so the LLM prose can be treated as commentary.

## Test plan

- [x] `pytest tests/cli/test_yaml_block_dump.py` — 4 passed (round-trip fidelity + block-style for multiline + plain for single-line + nested email shape)
- [x] `pytest tests/cli -k "right_panel or events_tab or recent_skill or panel"` — 112 passed (regression)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed
- [x] `ruff check` clean
- [x] `scripts/test_tier_audit.py --strict` clean (0 errors)
- [x] before/after rendering verified directly on representative email + MCP-content shapes (the observed evidence above)

## Tier self-check

Tier-2 behavior tests; assert **round-trip fidelity** (rendering never alters the verbatim result) + block-vs-plain style — NOT exact whitespace (not a format-pin). Real PyYAML, no MagicMock / no private-state / no golden. ✓

## Note on scope / direction

This is the legibility half. The broader framing (① LLM reasons over real data via ref→context, ② LLM commentary may paraphrase, ③ system renders verbatim result for the user) and whether to make the verbatim surface more *prominent* by default remain open in #393 for product arbitration. This PR is the bounded, observed-gap fix the user approved ("それ助かる").

🤖 Generated with [Claude Code](https://claude.com/claude-code)