### PR TITLE
feat(agent): #997 dir2 PR-A — Agent.from_config wiring factory + migrate run/cron/mcp

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -123,6 +123,99 @@ class Agent:
         self.run_id: str | None = run_id
         self.events_path: Path | None = None
 
+    @classmethod
+    def from_config(
+        cls,
+        config: "ReynConfig",
+        *,
+        shell_allowed: bool,
+        model: str | None = None,
+        safety: "SafetyConfig | None" = None,
+        resolver: ModelResolver | None = None,
+        python_allowed_modules: list[str] | None = None,
+        caller: str = "direct",
+        unsafe_python: bool = False,
+        interactive: bool | None = None,
+        strict: bool = False,
+        subscribers: list[Callable] | None = None,
+        intervention_bus: RequestBus | None = None,
+        project_context: str = "",
+        agent_role: str = "",
+        budget_tracker: BudgetTracker | None = None,
+        multimodal_config: "MultimodalConfig | None" = None,
+        media_store: "MediaStore | None" = None,
+        secret_store: "ScopedSecretStore | None" = None,
+        workspace_base_dir: "Path | None" = None,
+        workspace_state_dir: "Path | None" = None,
+        run_id: str | None = None,
+        environment_backend: "EnvironmentBackend | None" = None,
+        sandbox_backend: "SandboxBackend | None" = None,
+    ) -> "Agent":
+        """Construct a fully-wired Agent from a ReynConfig (#997 dir2).
+
+        Construction-time prevention of the FP-0008 / #1133 wiring-gap class:
+        the permission/runtime bundle that direct callers historically
+        hand-listed (and sometimes omitted — e.g. ``eval benchmark`` shipped
+        without ``permission_resolver`` / ``shell_allowed``, so a phase that
+        declared ``shell`` got the op filtered to nothing and the LLM
+        hallucinated a fake schema) is derived here from ``config`` once. A
+        caller need only decide ``shell_allowed`` (+ any per-invocation extras);
+        it **cannot** forget ``permission_resolver`` / ``mcp_servers`` /
+        ``python_allowed_modules`` / ``prompt_cache_enabled`` / ``sandbox_config``.
+
+        ``model`` / ``safety`` / ``resolver`` default to the config-derived value
+        but accept an override (e.g. ``reyn run`` passes an args-aware
+        ``safety`` for ``--max-phase-visits`` and friends). The gap-prone bundle
+        is always derived — it is intentionally not overridable.
+
+        The permission-resolver derivation matches ``cli.run._build_permission_resolver``
+        (inlined here to keep the factory in the core layer, dependency-free of
+        the cli package). ``interactive`` defaults to ``sys.stdin.isatty()``.
+        """
+        import sys
+
+        from reyn.config import _find_project_root
+
+        perm_config = dict(getattr(config, "permissions", {}) or {})
+        if shell_allowed and "shell" not in perm_config:
+            perm_config["shell"] = "allow"
+        permission_resolver = PermissionResolver(
+            config_permissions=perm_config,
+            project_root=_find_project_root(Path.cwd()),
+            interactive=sys.stdin.isatty() if interactive is None else interactive,
+            unsafe_python_allowed=unsafe_python,
+        )
+        return cls(
+            model=model if model is not None else config.model,
+            strict=strict,
+            subscribers=subscribers,
+            intervention_bus=intervention_bus,
+            shell_allowed=shell_allowed,
+            resolver=resolver if resolver is not None else ModelResolver(config.models),
+            permission_resolver=permission_resolver,
+            safety=safety if safety is not None else config.safety,
+            mcp_servers=config.mcp,
+            python_allowed_modules=(
+                list(python_allowed_modules)
+                if python_allowed_modules is not None
+                else list(config.python.allowed_modules)
+            ),
+            prompt_cache_enabled=config.prompt_cache_enabled,
+            project_context=project_context,
+            agent_role=agent_role,
+            caller=caller,
+            budget_tracker=budget_tracker,
+            sandbox_config=config.sandbox,
+            multimodal_config=multimodal_config,
+            media_store=media_store,
+            secret_store=secret_store,
+            workspace_base_dir=workspace_base_dir,
+            workspace_state_dir=workspace_state_dir,
+            run_id=run_id,
+            environment_backend=environment_backend,
+            sandbox_backend=sandbox_backend,
+        )
+
     @property
     def caller(self) -> str:
         return self._caller

--- a/src/reyn/cli/commands/cron.py
+++ b/src/reyn/cli/commands/cron.py
@@ -289,22 +289,18 @@ def _build_runner():
         project_context = load_project_context(config, project_root)
         logger = make_logger()
 
-        perm_resolver = _build_permission_resolver(config, shell_allowed=False)
-        agent = Agent(
+        # #997 dir2: config-derived permission/runtime bundle wired by
+        # Agent.from_config (cron jobs run unattended → shell_allowed=False).
+        agent = Agent.from_config(
+            config,
+            shell_allowed=False,
             model=resolved,
+            resolver=resolver,
             strict=False,
             subscribers=[logger],
             intervention_bus=StdinInterventionBus(),
-            shell_allowed=False,
-            resolver=resolver,
-            permission_resolver=perm_resolver,
-            safety=config.safety,
-            mcp_servers=config.mcp,
-            python_allowed_modules=list(config.python.allowed_modules),
-            prompt_cache_enabled=config.prompt_cache_enabled,
             project_context=project_context,
             caller="cron",
-            sandbox_config=config.sandbox,
         )
 
         skill_dir, skill_root = resolve_skill_path(job.skill)

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -656,18 +656,14 @@ def run_install(args: argparse.Namespace) -> None:
         os.environ.setdefault("LITELLM_API_BASE", config.api_base)
     resolver = ModelResolver(config.models)
     logger = make_logger()
-    agent = Agent(
-        model=config.model,
+    # #997 dir2: config-derived permission/runtime bundle wired by from_config.
+    agent = Agent.from_config(
+        config,
+        shell_allowed=False,
+        resolver=resolver,
         strict=False,
         subscribers=[logger],
         intervention_bus=StdinInterventionBus(),
-        shell_allowed=False,
-        resolver=resolver,
-        permission_resolver=perm_resolver,
-        safety=config.safety,
-        mcp_servers=config.mcp,
-        python_allowed_modules=list(config.python.allowed_modules),
-        prompt_cache_enabled=config.prompt_cache_enabled,
         project_context=project_context,
         caller="direct",
     )

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -133,10 +133,6 @@ def run(args: argparse.Namespace) -> None:
     if not unsafe_python and loaded.skill_md is not None:
         from reyn.skill.skill_paths import is_stdlib_skill
         unsafe_python = is_stdlib_skill(loaded.skill_md.parent)
-    perm_resolver = _build_permission_resolver(
-        session.config, shell_allowed, unsafe_python=unsafe_python,
-    )
-
     from reyn.agent import Agent
     from reyn.config import _find_project_root, load_project_context
     from reyn.user_intervention import StdinInterventionBus
@@ -144,21 +140,24 @@ def run(args: argparse.Namespace) -> None:
     project_context = load_project_context(session.config, project_root)
     logger = make_logger()
     env_backend, ws_base_dir, ws_state_dir = _build_environment_backend(args)
-    agent = Agent(
+    # #997 dir2: the permission/runtime bundle (permission_resolver, mcp_servers,
+    # python_allowed_modules, prompt_cache_enabled, sandbox_config, resolver) is
+    # derived from config inside Agent.from_config — a caller cannot omit it (the
+    # FP-0008 / #1133 wiring-gap class). Only the per-invocation overrides
+    # (args-aware safety, the docker env backend, workspace dirs, logger) are
+    # passed here.
+    agent = Agent.from_config(
+        session.config,
+        shell_allowed=shell_allowed,
         model=model,
+        safety=safety,
+        resolver=session.resolver,
+        unsafe_python=unsafe_python,
         strict=args.strict,
         subscribers=[logger],
         intervention_bus=StdinInterventionBus(),
-        shell_allowed=shell_allowed,
-        resolver=session.resolver,
-        permission_resolver=perm_resolver,
-        safety=safety,
-        mcp_servers=session.config.mcp,
-        python_allowed_modules=list(session.config.python.allowed_modules),
-        prompt_cache_enabled=session.config.prompt_cache_enabled,
         project_context=project_context,
         caller="direct",
-        sandbox_config=session.config.sandbox,
         # FP-0008 #1115 Stage 2: inject the SAME container backend instance at
         # both seams (FS = environment_backend, exec = sandbox_backend), agent-
         # level uniform. None (host) preserves the default identity behavior.

--- a/tests/test_agent_from_config_wiring_997.py
+++ b/tests/test_agent_from_config_wiring_997.py
@@ -1,0 +1,63 @@
+"""Tier 2: OS invariant — Agent.from_config wiring factory (#997 dir2, PR-A).
+
+``Agent.from_config`` is the construction-time prevention of the FP-0008 / #1133
+wiring-gap class: it derives the permission/runtime bundle (permission_resolver,
+mcp_servers, python_allowed_modules, prompt_cache_enabled, sandbox_config,
+resolver) from a ReynConfig so a direct caller cannot omit it. ``model`` /
+``safety`` / ``resolver`` / ``python_allowed_modules`` default to the
+config-derived value but accept an override.
+
+These pin the public, observable contract of the factory: the config-default and
+override behavior of ``model``, and that construction succeeds for both
+shell_allowed modes (the perm-resolver derivation — including the shell
+pre-approval branch — runs without the caller supplying a resolver). The 3
+migrated CLI callers (run / cron / mcp, this PR) exercise the full bundle through
+their existing command tests; PR-B adds the AST omit-pin (Agent() only via
+from_config) for the structural "cannot omit" guarantee, alongside the dir3
+``phase_op_catalog_gap`` runtime event (#1152) that catches any residual gap.
+
+No mocks — real ReynConfig + real Agent.
+"""
+from __future__ import annotations
+
+from reyn.agent import Agent
+from reyn.config import ReynConfig
+
+
+def test_from_config_model_defaults_to_config() -> None:
+    """Tier 2: from_config(config) uses config.model when no override is given."""
+    cfg = ReynConfig(model="standard")
+    agent = Agent.from_config(cfg, shell_allowed=False, interactive=False)
+    assert agent.model == "standard"
+
+
+def test_from_config_model_override_wins() -> None:
+    """Tier 2: an explicit model override replaces the config default."""
+    cfg = ReynConfig(model="standard")
+    agent = Agent.from_config(cfg, shell_allowed=False, model="strong", interactive=False)
+    assert agent.model == "strong"
+
+
+def test_from_config_constructs_in_both_shell_modes() -> None:
+    """Tier 2: the perm-resolver derivation runs for both shell modes without a caller resolver.
+
+    shell_allowed=True exercises the shell pre-approval branch (config_permissions
+    gains ``shell: allow``); shell_allowed=False the plain path. A caller supplies
+    neither permission_resolver nor the rest of the bundle — the factory derives
+    it. Construction succeeding for both proves the gap-prone wiring is produced
+    internally (the FP-0008 caller could not).
+    """
+    cfg = ReynConfig(model="standard")
+    for shell_allowed in (True, False):
+        agent = Agent.from_config(cfg, shell_allowed=shell_allowed, interactive=False)
+        assert isinstance(agent, Agent)
+        assert agent.caller == "direct"
+
+
+def test_from_config_caller_override() -> None:
+    """Tier 2: a non-default caller (validated by Agent.__init__) is forwarded."""
+    cfg = ReynConfig(model="standard")
+    agent = Agent.from_config(
+        cfg, shell_allowed=False, caller="agents/reviewer", interactive=False
+    )
+    assert agent.caller == "agents/reviewer"


### PR DESCRIPTION
**[e2e-coder]** — #997 dir2 (GO'd by lead-coder), PR-A of a 2-PR split. Construction-time prevention of the FP-0008/#1133 wiring-gap class (#1152 dir3 detects at runtime; this prevents at construction = more upstream, bounded-by-construction). Design recorded in the [#997 issue comment](https://github.com/tya5/reyn/issues/997#issuecomment-4585778062).

## What
**`Agent.from_config(config, *, shell_allowed, ...)`** derives the permission/runtime bundle (permission_resolver / mcp_servers / python_allowed_modules / prompt_cache_enabled / sandbox_config / resolver) from ReynConfig in one place — a caller **cannot omit** it (the FP-0008 origin: `eval benchmark` shipped without permission_resolver/shell_allowed → phase declaring `shell` filtered to nothing → LLM hallucinated). `model`/`safety`/`resolver`/`python_allowed_modules` default to config-derived with optional override (e.g. `reyn run`'s args-aware safety); the gap-prone bundle is always derived. permission_resolver derivation is inlined (its deps — `reyn.config` + `reyn.permissions` — are core) so the factory stays in the core layer, importable by all callers without a cli inversion.

**Migrated 3 clean config-derived callers**: `run.py`, `cron.py`, `mcp.py`. Each drops its hand-listed bundle for `from_config` + per-invocation extras. (`mcp.py` now also wires `sandbox_config` it previously omitted — behavior-identical at the default `backend="auto"`, honors operator config if set: the same normalization that makes the derivation a fix.)

## Split (PR-B follows)
PR-B migrates the remaining callers — `eval_benchmark` (needs a `_run_single_task` signature change: drop the passed-in resolver, thread `unsafe_python`; its resolver is built via the same `_build_permission_resolver`, so from_config is identical, no pre-approvals lost), `eval.py`×2, `web/server` — and adds the **AST omit-pin** (condition d: `Agent(` constructed only via `from_config` + tests + the documented `sub_skill_runner` parent-propagation exemption — it propagates the parent runtime's bundle, not config-derived). That delivers the structural "cannot omit" guarantee.

## Test plan
- [x] `pytest tests/test_agent_from_config_wiring_997.py` → 4 passed (Tier-clean public-surface: model default/override, dual-mode construction exercising the perm-derivation/shell-preapproval branch, caller forwarding)
- [x] `pytest -q --ignore=.claude` → **6602 passed** (1 pre-existing local-only `test_web_fetch_preview_path_ref`, not in CI) — the migrated CLI callers' existing command tests exercise the `from_config` path
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean (4 OK)

Refs #997 #1133 #976 #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)