### PR TITLE
feat(agent): #997 dir2 PR-B — migrate eval/web callers + AST omit-pin

### DIFF
--- a/src/reyn/cli/commands/eval.py
+++ b/src/reyn/cli/commands/eval.py
@@ -272,12 +272,14 @@ def _run_case(
     project_root = _find_project_root(Path.cwd())
     project_context = load_project_context(session.config, project_root)
 
-    agent = Agent(
+    # #997 dir2: config-derived permission/runtime bundle via from_config.
+    agent = Agent.from_config(
+        session.config,
+        shell_allowed=False,
         model=model,
         resolver=session.resolver,
-        intervention_bus=StdinInterventionBus(),
         safety=session.safety_for(argparse.Namespace()),
-        prompt_cache_enabled=session.config.prompt_cache_enabled,
+        intervention_bus=StdinInterventionBus(),
         project_context=project_context,
         caller="direct",
     )
@@ -843,12 +845,14 @@ def _run_spec_case(
     project_context = load_project_context(
         session.config, _find_project_root(Path.cwd()),
     )
-    agent = Agent(
+    # #997 dir2: config-derived permission/runtime bundle via from_config.
+    agent = Agent.from_config(
+        session.config,
+        shell_allowed=False,
         model=model,
         resolver=session.resolver,
-        intervention_bus=StdinInterventionBus(),
         safety=session.safety_for(args),
-        prompt_cache_enabled=session.config.prompt_cache_enabled,
+        intervention_bus=StdinInterventionBus(),
         project_context=project_context,
         caller="direct",
     )

--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -679,19 +679,20 @@ async def _run_single_task(
     run_dir: Path,
     semaphore: asyncio.Semaphore,
     shell_allowed: bool = False,
-    permission_resolver=None,
+    unsafe_python: bool = False,
     python_allowed_modules: list[str] | None = None,
     clone_task_repo: bool = False,
     verify_tier: str = _TIER_NO_FAITHFUL_ENV,
 ) -> dict:
     """Run a single task under the semaphore; return a result record.
 
-    ``shell_allowed`` + ``permission_resolver`` are derived once at batch
-    start (= from ``--allow-shell`` / ``--allow-unsafe-python`` + the
-    skill's declared permissions) and threaded through every task so the
-    Agent's op_catalog exposes the shell op uniformly. Without this, the
-    LLM doesn't see ``shell`` in the catalog and hallucinates a fake
-    schema (= ``{kind: "shell", op: "run", command: ...}`` vs the real
+    ``shell_allowed`` + ``unsafe_python`` are derived once at batch start
+    (= from ``--allow-shell`` / ``--allow-unsafe-python``) and threaded through
+    every task; ``Agent.from_config`` then derives the permission_resolver (and
+    the rest of the runtime bundle) per task so the Agent's op_catalog exposes
+    the shell op uniformly (#997 dir2 — the benchmark cannot omit the bundle).
+    Without this, the LLM doesn't see ``shell`` in the catalog and hallucinates
+    a fake schema (= ``{kind: "shell", op: "run", command: ...}`` vs the real
     ``{kind: "shell", cmd: ...}``), every retry hits the validator, the
     batch reports $0.00 cost + 100% error rate. See PR-D follow-up to PR-B
     (= FP-0008 sandbox_2 calibration block 2026-05-28).
@@ -727,9 +728,25 @@ async def _run_single_task(
             with _benchmark_isolated_workspace(
                 task=task, clone_task_repo=clone_task_repo,
             ) as workspace_path:
-                agent = Agent(
+                # #997 dir2: the permission/runtime bundle (permission_resolver,
+                # mcp_servers, python_allowed_modules, prompt_cache_enabled,
+                # sandbox_config, resolver) is derived from config inside
+                # from_config — the benchmark cannot omit it (this WAS the FP-0008
+                # gap: a missing permission_resolver/shell_allowed left shell out
+                # of the catalog, the LLM hallucinated a fake schema). The
+                # permission resolver is derived per task from shell_allowed +
+                # unsafe_python (identical to the prior batch-built one, which used
+                # the same _build_permission_resolver). interactive=False: a
+                # benchmark subprocess is non-interactive.
+                agent = Agent.from_config(
+                    session.config,
+                    shell_allowed=shell_allowed,
                     model=model,
                     resolver=session.resolver,
+                    safety=session.safety_for(argparse.Namespace()),
+                    python_allowed_modules=python_allowed_modules or None,
+                    unsafe_python=unsafe_python,
+                    interactive=False,
                     # PR-N9: benchmark is a non-interactive subprocess. An
                     # interactive bus blocks on tty raw_mode at limit-checkpoint
                     # boundaries (= sandbox_2 13977 4h+ hang at apply visit 6).
@@ -737,12 +754,6 @@ async def _run_single_task(
                     # ``no_bus`` clean abort, the same path scripted/headless
                     # callers use. See FP-0008 PR-N9 / issue #1045.
                     intervention_bus=None,
-                    safety=session.safety_for(argparse.Namespace()),
-                    shell_allowed=shell_allowed,
-                    permission_resolver=permission_resolver,
-                    python_allowed_modules=python_allowed_modules or list(session.config.python.allowed_modules),
-                    mcp_servers=session.config.mcp,
-                    prompt_cache_enabled=session.config.prompt_cache_enabled,
                     project_context=project_context,
                     caller="direct",
                     workspace_base_dir=workspace_path,
@@ -882,17 +893,15 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
     session = session_mod.Session.from_args(args)
     model = getattr(args, "model", None) or session.config.model
 
-    # Derive shell_allowed + permission_resolver once at batch start (= mirrors
-    # `reyn run`'s pattern in cli/commands/run.py). Without this, the Agent's
-    # OS runtime keeps `shell` out of the op_catalog and the LLM hallucinates
-    # a fake schema on every retry — see _run_single_task docstring.
+    # Derive shell_allowed + unsafe_python once at batch start and thread them
+    # through every task; Agent.from_config derives the permission_resolver (+
+    # the rest of the runtime bundle) per task (#997 dir2). Without the right
+    # shell_allowed the Agent's OS runtime keeps `shell` out of the op_catalog
+    # and the LLM hallucinates a fake schema on every retry — see
+    # _run_single_task docstring.
     shell_allowed = session.shell_allowed_for(args)
     unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
     clone_task_repo = bool(getattr(args, "clone_task_repo", False))
-    from reyn.cli.commands.run import _build_permission_resolver
-    perm_resolver = _build_permission_resolver(
-        session.config, shell_allowed, unsafe_python=unsafe_python,
-    )
 
     # C7: Detect verification tier ONCE at batch start.
     # All tasks in this run share the same host environment, so detecting
@@ -977,7 +986,7 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
                 run_dir=run_dir,
                 semaphore=semaphore,
                 shell_allowed=shell_allowed,
-                permission_resolver=perm_resolver,
+                unsafe_python=unsafe_python,
                 clone_task_repo=clone_task_repo,
                 verify_tier=verify_tier,
             )

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -59,21 +59,16 @@ def _make_cron_runner():
         skill_dir, skill_root = resolve_skill_path(job.skill)
         skill = load_dsl_skill(skill_dir / "skill.md", skill_root=skill_root)
 
-        perm_resolver = PermissionResolver(
-            config_permissions=dict(cfg.permissions),
-            project_root=project_root,
+        # #997 dir2: config-derived permission/runtime bundle via from_config
+        # (the web cron path is non-interactive → interactive=False, matching the
+        # prior hand-built resolver). resolver now derives from cfg.models (was an
+        # empty ModelResolver() default) so class-name model resolution works.
+        agent = Agent.from_config(
+            cfg,
+            shell_allowed=False,
             interactive=False,
-        )
-
-        agent = Agent(
-            model=cfg.model,
-            permission_resolver=perm_resolver,
-            mcp_servers=cfg.mcp,
-            python_allowed_modules=list(cfg.python.allowed_modules),
-            prompt_cache_enabled=cfg.prompt_cache_enabled,
             project_context=project_context,
             caller="cron",
-            sandbox_config=cfg.sandbox,
         )
 
         result = await agent.run(skill, dict(job.input))

--- a/tests/test_agent_construction_via_factory_997.py
+++ b/tests/test_agent_construction_via_factory_997.py
@@ -1,0 +1,88 @@
+"""Tier 2: OS invariant — config-derived Agent construction goes via from_config (#997 dir2 PR-B).
+
+Construction-time omit-prevention (condition d of #997 dir2): a config-derived
+caller must NOT raw-construct ``Agent(...)`` — it must go through
+``Agent.from_config``, which derives the permission/runtime bundle
+(permission_resolver / mcp_servers / python_allowed_modules / prompt_cache_enabled
+/ sandbox_config / resolver) so the FP-0008 / #1133 wiring gap cannot recur (a
+caller forgetting permission_resolver → shell filtered out of the op catalog →
+the LLM hallucinates a fake schema). ``Agent.from_config`` is an attribute call,
+so it is not a bare construction and not flagged.
+
+This is the third layer of the #1133-class defense: dir3 ``phase_op_catalog_gap``
+runtime detection (#1152) + PR-A factory construct-test (#1155) + this pin.
+
+Exemptions are the two parent-propagation paths that spawn an Agent from an
+already-wired parent context (NOT a fresh ReynConfig), so ``from_config`` does
+not apply — they forward the bundle they were given:
+  - ``skill/sub_skill_runner.py``: a sub-skill inherits the parent OSRuntime's
+    resolver + permission_resolver.
+  - ``chat/session.py``: ChatSession's agent-spawn forwards the session's own
+    ``self._perm`` / ``self._resolver`` / ``self._mcp_servers``, all wired at
+    session construction.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "reyn"
+
+# Parent-propagation exemptions (paths relative to src/reyn). These construct an
+# Agent from an already-wired parent context, not a fresh config — from_config
+# (config → bundle) does not apply to them.
+_EXEMPT = {
+    "skill/sub_skill_runner.py",
+    "chat/session.py",
+}
+
+
+def _bare_agent_constructions() -> list[tuple[str, int]]:
+    """Every bare ``Agent(...)`` call (func is the Name ``Agent``) under src/reyn.
+
+    ``Agent.from_config(...)`` is an attribute call (func is an ``ast.Attribute``)
+    and is intentionally excluded — that is the sanctioned construction path.
+    """
+    hits: list[tuple[str, int]] = []
+    for path in _SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "Agent"
+            ):
+                hits.append((path.relative_to(_SRC).as_posix(), node.lineno))
+    return hits
+
+
+def test_no_unexpected_bare_agent_construction() -> None:
+    """Tier 2: bare Agent(...) appears only in the documented parent-propagation exemptions.
+
+    Any new config-derived caller (e.g. a future docker/swebench bridge) that
+    raw-constructs Agent(...) fails here — forcing it through Agent.from_config
+    so it cannot omit the permission/runtime bundle (the #1133 / FP-0008 gap).
+    """
+    offenders = [(f, ln) for f, ln in _bare_agent_constructions() if f not in _EXEMPT]
+    assert not offenders, (
+        "config-derived Agent construction must go through Agent.from_config "
+        "(#997 dir2 — so the permission/runtime bundle cannot be omitted, the "
+        f"FP-0008 / #1133 wiring-gap class). Bare Agent(...) outside the "
+        f"documented parent-propagation exemptions: {offenders}. Either migrate "
+        f"to Agent.from_config, or (if it genuinely propagates an already-wired "
+        f"parent bundle) add it to _EXEMPT with a rationale."
+    )
+
+
+def test_exemptions_are_not_stale() -> None:
+    """Tier 2: each exemption still contains a bare Agent(...) (no vacuous allow-list).
+
+    If an exempted file stops raw-constructing Agent, it must be dropped from
+    _EXEMPT so the pin stays tight (an unused exemption silently widens the hole
+    for a future raw construction in that file).
+    """
+    files_with_bare = {f for f, _ in _bare_agent_constructions()}
+    stale = [f for f in _EXEMPT if f not in files_with_bare]
+    assert not stale, (
+        f"exemption(s) no longer contain a bare Agent(...) — remove from _EXEMPT: {stale}"
+    )

--- a/tests/test_eval_benchmark_cli.py
+++ b/tests/test_eval_benchmark_cli.py
@@ -429,7 +429,7 @@ def test_single_task_failure_no_abort(
 
     async def _stub_run_single_task(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
+        shell_allowed=False, unsafe_python=False, python_allowed_modules=None,
         clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         nonlocal call_count
@@ -530,12 +530,11 @@ def test_allow_shell_propagates_to_single_task(
 
     async def _capture_shell_allowed(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
+        shell_allowed=False, unsafe_python=False, python_allowed_modules=None,
         clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         async with semaphore:
             captured["shell_allowed"] = shell_allowed
-            captured["permission_resolver_built"] = permission_resolver is not None
             return {"instance_id": instance_id, "cost_usd": 0.0}
 
     monkeypatch.setattr(bm, "_run_single_task", _capture_shell_allowed)
@@ -555,9 +554,10 @@ def test_allow_shell_propagates_to_single_task(
     assert captured["shell_allowed"] is True, (
         "Expected shell_allowed=True to reach _run_single_task when --allow-shell is set"
     )
-    assert captured["permission_resolver_built"] is True, (
-        "Expected a non-None permission_resolver to be built when --allow-shell is set"
-    )
+    # #997 dir2: the permission_resolver is no longer passed to _run_single_task
+    # — Agent.from_config derives it per task from shell_allowed (+ unsafe_python).
+    # That the bundle is wired (not omittable) is covered by the from_config
+    # factory tests + the AST omit-pin; here we pin the shell_allowed propagation.
 
     # Case B: --allow-shell absent → shell_allowed=False is the default
     captured.clear()
@@ -620,7 +620,7 @@ def test_clone_task_repo_propagates_to_single_task(
 
     async def _capture_clone_flag(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, permission_resolver=None, python_allowed_modules=None,
+        shell_allowed=False, unsafe_python=False, python_allowed_modules=None,
         clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         async with semaphore:


### PR DESCRIPTION
**[e2e-coder]** — #997 dir2 PR-B (2/2), completes dir2. PR-A (#1155, merged) landed `Agent.from_config` + run/cron/mcp; this migrates the rest + adds the structural **cannot-omit** guarantee (condition d).

## Migrations to `Agent.from_config`
- **`eval_benchmark._run_single_task`**: signature surgery — drop the passed-in `permission_resolver`, thread `unsafe_python`; from_config derives the resolver per task. Verified identical to the prior batch-built resolver (same `_build_permission_resolver`) → **no PR-N11 pre-approvals lost**. Batch-start precompute + the `run` import removed.
- **`eval.py` ×2**: were under-wired (no permission_resolver / mcp_servers / python_allowed_modules) — from_config now derives them (latent fix).
- **`web/server.py`**: drop the hand-built PermissionResolver (interactive=False, identical to from_config); resolver now derives from `cfg.models` (was an empty `ModelResolver()` default → class-name resolution works). Noted as a behavior change.

## AST omit-pin (condition d)
`tests/test_agent_construction_via_factory_997.py` (Tier 2) walks `src/reyn` and asserts bare `Agent(...)` appears **only** in the two documented parent-propagation exemptions:
- `skill/sub_skill_runner.py` — sub-skill inherits the parent OSRuntime's resolver + permission_resolver.
- `chat/session.py` — ChatSession's agent-spawn forwards the session's own `self._perm`/`self._resolver`/`self._mcp_servers` (wired at session construction).

Both inherit an already-wired bundle from a parent (not a fresh ReynConfig), so `from_config` doesn't apply. Any new config-derived caller that raw-constructs `Agent` fails the pin → forced through `from_config`. A second test guards the allow-list against going stale.

**Three-layer #1133-class defense now complete**: dir3 `phase_op_catalog_gap` runtime event (#1152) + PR-A factory construct-test (#1155) + this construction-time omit-pin.

## Test plan
- [x] `pytest tests/test_eval_benchmark_cli.py tests/test_agent_construction_via_factory_997.py tests/test_agent_from_config_wiring_997.py` → 27 passed
- [x] `pytest -q --ignore=.claude` → **6612 passed** (1 pre-existing local-only `test_web_fetch_preview_path_ref`, not in CI)
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` → clean
- [x] Updated the 3 eval_benchmark_cli tests to the new signature; dropped the obsolete "permission_resolver passed to runner" assertion (resolver derived inside from_config now); shell_allowed/clone propagation (FP-0008 contract) preserved

Refs #997 #1133 #976 #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)