### PR TITLE
feat(chat): #1125 Item 2 — wire retry_loop into chat overflow path

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -712,6 +712,22 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+class _RouterUsageShim:
+    """Wrap a RouterLoop ``TokenUsage`` as ``.usage`` for ``retry_loop`` (#1125).
+
+    ``retry_loop``'s learner-feedback path reads ``response.usage.prompt_tokens``
+    (the litellm response convention). RouterLoop.run returns the bare
+    ``TokenUsage`` instead, so this shim exposes it under ``.usage`` — letting
+    the adaptive estimator observe the chat axis's actual prompt size. The
+    overflow-recovery caller reads ``.usage`` back out to credit session usage.
+    """
+
+    __slots__ = ("usage",)
+
+    def __init__(self, usage: object) -> None:
+        self.usage = usage
+
+
 def _ts_iso_to_epoch(ts: str | None) -> float | None:
     """Best-effort ISO-8601 → epoch-seconds conversion.
 
@@ -4889,22 +4905,75 @@ class ChatSession:
         # message dict. Path-ref content parts (= ``{"type":"image","path":...}``)
         # are materialised to data URLs **at this boundary** so storage
         # stays light and the LLM sees the inline form it expects.
-        messages: list[dict] = []
+        return [self._serialise_turn(m) for m in selected]
+
+    def _serialise_turn(self, m: "ChatMessage") -> dict:
+        """Serialise one ChatMessage into a litellm-compatible wire dict.
+
+        Path-ref content parts (= ``{"type":"image","path":...}``) are
+        materialised to data URLs at this boundary so storage stays light
+        and the LLM sees the inline form it expects. Shared by
+        :meth:`_build_history_for_router` and
+        :meth:`_decompose_history_for_retry` so both produce identical wire
+        shapes (the retry_loop decomposition must rebuild the same prompt the
+        normal path would have sent).
+        """
         media_store = getattr(self, "_media_store", None)
-        for m in selected:
-            # Legacy "agent" stragglers (= migrated entries that somehow
-            # bypassed _migrate_legacy_chat_message) → normalise on read.
-            role = "assistant" if m.role == "agent" else m.role
-            content = _materialise_path_ref_content(m.content, media_store)
-            msg: dict = {"role": role, "content": content}
-            if m.tool_calls is not None:
-                msg["tool_calls"] = m.tool_calls
-            if m.tool_call_id is not None:
-                msg["tool_call_id"] = m.tool_call_id
-            if m.name is not None:
-                msg["name"] = m.name
-            messages.append(msg)
-        return messages
+        # Legacy "agent" stragglers (= migrated entries that somehow bypassed
+        # _migrate_legacy_chat_message) → normalise on read.
+        role = "assistant" if m.role == "agent" else m.role
+        content = _materialise_path_ref_content(m.content, media_store)
+        msg: dict = {"role": role, "content": content}
+        if m.tool_calls is not None:
+            msg["tool_calls"] = m.tool_calls
+        if m.tool_call_id is not None:
+            msg["tool_call_id"] = m.tool_call_id
+        if m.name is not None:
+            msg["name"] = m.name
+        return msg
+
+    def _decompose_history_for_retry(
+        self,
+    ) -> tuple[list[dict], list[dict], list[dict], dict | None]:
+        """Decompose current history into (head, raw_middle, tail, summary) for retry_loop.
+
+        Mirrors :meth:`_build_history_for_router`'s head/tail slicing but
+        exposes the elided ``raw_middle`` explicitly so the bounded
+        adaptive-shrink ``retry_loop`` (#1125 Item 2) can fold it into the
+        running summary under overflow — instead of the prior degraded
+        compact-once. ``summary`` is the structured dict from the latest
+        persisted summary turn (retry_loop treats it as an immutable base).
+
+        When ``len(turns) <= head_size + tail_size`` the head/tail would
+        overlap (the documented Q4-attractor duplication hazard), so the whole
+        history goes into ``head`` with empty ``raw_middle`` / ``tail`` — there
+        is nothing to elide, and retry_loop's shrink can still trim ``head``.
+        """
+        cfg = self._compaction
+        turns = [
+            m for m in self.history
+            if m.role in ("user", "assistant", "tool", "agent")
+        ]
+        if len(turns) <= cfg.head_size + cfg.tail_size:
+            head_msgs = turns
+            raw_middle_msgs: list = []
+            tail_msgs: list = []
+        else:
+            head_msgs = turns[:cfg.head_size]
+            tail_msgs = turns[-cfg.tail_size:] if cfg.tail_size else []
+            middle_end = len(turns) - cfg.tail_size if cfg.tail_size else len(turns)
+            raw_middle_msgs = turns[cfg.head_size:middle_end]
+
+        summary_msg = self._latest_summary()
+        summary_dict: dict | None = None
+        if summary_msg is not None:
+            structured = (summary_msg.meta or {}).get("structured")
+            if isinstance(structured, dict):
+                summary_dict = structured
+        head = [self._serialise_turn(m) for m in head_msgs]
+        raw_middle = [self._serialise_turn(m) for m in raw_middle_msgs]
+        tail = [self._serialise_turn(m) for m in tail_msgs]
+        return head, raw_middle, tail, summary_dict
 
     def _build_router_system_prompt(self) -> str:
         """Return the router system prompt for the current session state.
@@ -5081,36 +5150,74 @@ class ChatSession:
             )
             if not _is_overflow:
                 raise
-            # PR-N6: overflow detected — force compaction and retry once.
-            # For a full retry_loop, the session would need to expose
-            # head/summary/raw_middle/tail decomposition; that structural
-            # refactor is tracked as a follow-up.  This path covers the
-            # immediate fail-fast-with-recovery contract.
+            # PR-N6 / #1125 Item 2: overflow detected — recover via the bounded
+            # adaptive-shrink retry_loop (replaces the prior degraded
+            # compact-once). The session now exposes the
+            # head/summary/raw_middle/tail decomposition retry_loop needs
+            # (_decompose_history_for_retry), so it can fold raw_middle into the
+            # running summary and monotonically shrink head/tail until the call
+            # fits — the "never dead-end" continuity guarantee. The pre-frame
+            # guard (_maybe_force_compact_for_router) already ran and populated
+            # engine.budgets; retry_loop is the reactive safety net when the
+            # guard's estimate under-counted. UnrecoveredError (all shrink paths
+            # exhausted) is the chat axis's fail-fast surface.
             self._chat_events.emit(
                 "router_context_overflow_detected",
                 error=repr(_exc),
             )
+            from reyn.services.compaction.engine import retry_loop as _retry_loop
+            engine = self._compaction_controller._engine
+            _head, _raw_middle, _tail, _summary_dict = (
+                self._decompose_history_for_retry()
+            )
+            _new_msg = {"role": "user", "content": user_text}
+
+            async def _router_main_call(*, SP, head, summary, tail, new_msg):
+                # Rebuild the router prompt from the (possibly shrunk)
+                # decomposition retry_loop hands back each iteration.
+                _msgs = list(head)
+                if summary:
+                    _summary_text = json.dumps(summary, ensure_ascii=False)
+                    _msgs.append({
+                        "role": "assistant",
+                        "content": (
+                            "[summary of earlier conversation]\n" + _summary_text
+                        ),
+                    })
+                _msgs.extend(tail)
+                try:
+                    _usage = await loop.run(user_text=user_text, history=_msgs)
+                except Exception as _call_exc:
+                    if any(kw in str(_call_exc).lower() for kw in (
+                        "context", "token", "length", "limit", "too long", "too large",
+                    )):
+                        raise _ContextOverflowError(str(_call_exc)) from _call_exc
+                    raise
+                return _RouterUsageShim(_usage)
+
             try:
-                await self._compaction_controller.force_compact_now()
-            except Exception:
-                pass
-            history = self._build_history_for_router()
-            try:
-                router_usage = await loop.run(user_text=user_text, history=history)
-            except Exception as _retry_exc:
-                _retry_str = str(_retry_exc).lower()
-                if any(
-                    kw in _retry_str
-                    for kw in ("context", "token", "length", "limit", "too long", "too large")
-                ):
-                    self._chat_events.emit(
-                        "router_context_overflow_unrecovered",
-                        error=repr(_retry_exc),
-                    )
-                    raise _ContextOverflowError(
-                        f"Router context overflow unrecovered after compaction: {_retry_exc}"
-                    ) from _retry_exc
-                raise
+                _shim = await _retry_loop(
+                    SP=self._build_router_system_prompt(),
+                    head=_head,
+                    summary=_summary_dict,
+                    raw_middle=_raw_middle,
+                    tail=_tail,
+                    new_msg=_new_msg,
+                    cfg=self._compaction,
+                    model=self.model,
+                    engine=engine,
+                    learner=self._token_learner,
+                    main_call=_router_main_call,
+                )
+                router_usage = _shim.usage
+            except (_ContextOverflowError, _UnrecoveredError) as _retry_exc:
+                self._chat_events.emit(
+                    "router_context_overflow_unrecovered",
+                    error=repr(_retry_exc),
+                )
+                raise _ContextOverflowError(
+                    f"Router context overflow unrecovered after bounded shrink: {_retry_exc}"
+                ) from _retry_exc
 
         # F4 Bug 2 / F4 Bug 1: accumulate router LLM usage (with proxy-prefix
         # stripping) into per-session totals via the gateway.

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -5177,7 +5177,13 @@ class ChatSession:
                 # decomposition retry_loop hands back each iteration.
                 _msgs = list(head)
                 if summary:
-                    _summary_text = json.dumps(summary, ensure_ascii=False)
+                    # Render the structured summary via the SAME renderer that
+                    # produced the persisted summary.content (= the normal path's
+                    # bridge text), so the recovery prompt's summary bridge is
+                    # byte-identical to what _build_history_for_router would send.
+                    # retry_loop still folds raw_middle into the *structured*
+                    # dict (its immutable base); only the bridge text is rendered.
+                    _summary_text = _render_summary_for_storage(summary)
                     _msgs.append({
                         "role": "assistant",
                         "content": (

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -1,0 +1,200 @@
+"""Tier 2: OS invariant — retry_loop is wired into the chat overflow path (#1125 Item 2).
+
+PR-N6 built ``retry_loop`` (bounded adaptive-shrink overflow recovery) but the
+chat router never called it — the overflow path ran a degraded compact-once and
+hard-failed if the first compaction itself overflowed. axis-1's eager 30K
+trigger masked the gap by keeping the middle small. This wires the real
+mechanism in:
+
+- ``ChatSession._decompose_history_for_retry`` exposes the
+  head / raw_middle / tail / summary decomposition retry_loop consumes (the
+  structural refactor the prior degraded path's comment punted as "follow-up").
+- The router overflow handler hands that decomposition to ``retry_loop`` so it
+  can fold raw_middle into the summary and monotonically shrink — the
+  "never dead-end" continuity guarantee.
+
+These pin the wiring's *data contract* (the decomposition is retry_loop-shaped
+and the session's real engine/learner feed it). retry_loop's shrink mechanics
+are covered by test_pr_n6_compaction_overflow_retry.py (Fake engine); the literal
+except-block → retry_loop invocation is verified live via dogfood (the real
+RouterLoop LLM overflow is not reconstructable in a unit test without the full
+router stack). No mocks — real ChatSession + real CompactionEngine + real
+retry_loop; ``main_call`` is a retry_loop parameter (a test async fn, as the
+PR-N6 tests use), not a mocked collaborator.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+from reyn.budget.budget import BudgetTracker, CostConfig
+from reyn.chat.session import ChatMessage, ChatSession, _RouterUsageShim
+from reyn.config import CompactionConfig
+from reyn.events.state_log import StateLog
+from reyn.llm.pricing import TokenUsage
+from reyn.services.compaction.engine import retry_loop
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_session(tmp_path: Path, *, head_size: int = 2, tail_size: int = 2) -> ChatSession:
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    bt = BudgetTracker(CostConfig())
+    cfg = CompactionConfig(
+        trigger_total_tokens=100_000,  # never auto-trigger in unit tests
+        head_size=head_size,
+        tail_size=tail_size,
+        body_token_cap=1500,
+    )
+    return ChatSession(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+
+
+def _push(session: ChatSession, role: str, text: str) -> None:
+    if role == "agent":
+        role = "assistant"
+    session.history.append(ChatMessage(role=role, content=text, ts=_now()))
+
+
+# ── _decompose_history_for_retry correctness ─────────────────────────────────
+
+
+def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
+    """Tier 2: with len(turns) > head+tail, decomposition splits head/raw_middle/tail."""
+    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    for i in range(8):
+        _push(session, "user" if i % 2 == 0 else "assistant", f"turn-{i}")
+
+    head, raw_middle, tail, summary = session._decompose_history_for_retry()
+
+    assert [m["content"] for m in head] == ["turn-0", "turn-1"]
+    assert [m["content"] for m in raw_middle] == ["turn-2", "turn-3", "turn-4", "turn-5"]
+    assert [m["content"] for m in tail] == ["turn-6", "turn-7"]
+    assert summary is None
+    # head + raw_middle + tail is a lossless, in-order partition of the turns
+    # (no dropped or duplicated turn — the concatenation reproduces the input).
+    assert [m["content"] for m in head + raw_middle + tail] == [
+        f"turn-{i}" for i in range(8)
+    ]
+
+
+def test_decompose_no_overlap_when_history_fits_window(tmp_path) -> None:
+    """Tier 2: when len(turns) <= head+tail, everything is head — raw_middle/tail empty.
+
+    This avoids the documented Q4-attractor duplication (head/tail overlap); there
+    is nothing to elide, and retry_loop's shrink can still trim head.
+    """
+    session = _make_session(tmp_path, head_size=4, tail_size=4)
+    for i in range(3):
+        _push(session, "user", f"q-{i}")
+
+    head, raw_middle, tail, summary = session._decompose_history_for_retry()
+
+    assert [m["content"] for m in head] == ["q-0", "q-1", "q-2"]
+    assert raw_middle == []
+    assert tail == []
+    assert summary is None
+
+
+def test_decompose_extracts_structured_summary(tmp_path) -> None:
+    """Tier 2: a persisted summary turn surfaces its structured dict (immutable base)."""
+    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    structured = {"topic_arc": "greeting", "decisions": []}
+    session.history.append(ChatMessage(
+        role="summary",
+        content="rendered text",
+        ts=_now(),
+        meta={"structured": structured, "covers_through_seq": 3},
+    ))
+    for i in range(6):
+        _push(session, "user", f"m-{i}")
+
+    _head, _raw_middle, _tail, summary = session._decompose_history_for_retry()
+    assert summary == structured
+
+
+def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
+    """Tier 2: decomposed turns use the same wire serialisation as the normal path.
+
+    retry_loop must rebuild the prompt the normal router send would have produced;
+    a divergent wire shape (different role normalisation, missing tool fields)
+    would make the recovery prompt differ from the live one.
+    """
+    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    for i in range(8):
+        _push(session, "user" if i % 2 == 0 else "assistant", f"t-{i}")
+
+    head, raw_middle, tail, _summary = session._decompose_history_for_retry()
+    via_build = session._build_history_for_router()
+    decomposed_contents = [m["content"] for m in head + tail]
+    # _build_history_for_router (else-branch) = head + [summary bridge?] + tail;
+    # no summary here, so its non-bridge turns are exactly head+tail.
+    build_contents = [m["content"] for m in via_build]
+    assert decomposed_contents == build_contents
+
+
+# ── wiring data contract: session decomposition feeds real retry_loop ────────
+
+
+def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
+    """Tier 2: the session's real decomposition + engine/learner drive retry_loop.
+
+    Proves the wiring data contract end-to-end on the no-overflow path: the
+    session's ``_decompose_history_for_retry`` output is retry_loop-shaped, the
+    real CompactionEngine's budgets are accessible (non-None by construction),
+    and the learner observes via the ``_RouterUsageShim``. retry_loop's shrink /
+    engine.compact recovery is covered separately (PR-N6 Fake-engine tests).
+    """
+    session = _make_session(tmp_path, head_size=4, tail_size=4)
+    for i in range(3):  # fits window → empty raw_middle → no engine.compact LLM call
+        _push(session, "user", f"hi-{i}")
+
+    head, raw_middle, tail, summary = session._decompose_history_for_retry()
+    engine = session._compaction_controller._engine
+    new_msg = {"role": "user", "content": "latest"}
+
+    calls: list[dict] = []
+
+    async def _main_call(*, SP, head, summary, tail, new_msg):
+        calls.append({"head": head, "tail": tail, "summary": summary})
+        return _RouterUsageShim(TokenUsage(prompt_tokens=123))
+
+    shim = asyncio.run(retry_loop(
+        SP=session._build_router_system_prompt(),
+        head=head,
+        summary=summary,
+        raw_middle=raw_middle,
+        tail=tail,
+        new_msg=new_msg,
+        cfg=session._compaction,
+        model=session.model,
+        engine=engine,
+        learner=session._token_learner,
+        main_call=_main_call,
+    ))
+
+    # retry_loop returned the main_call response (the session reads .usage back).
+    assert isinstance(shim, _RouterUsageShim)
+    assert shim.usage.prompt_tokens == 123
+    # No-overflow path → main_call invoked exactly once; unpack enforces that
+    # structurally (raises if calls has 0 or >1 entries) and binds the call.
+    (only_call,) = calls
+    assert [m["content"] for m in only_call["head"]] == ["hi-0", "hi-1", "hi-2"]
+
+
+def test_router_usage_shim_exposes_usage(tmp_path) -> None:
+    """Tier 2: _RouterUsageShim exposes .usage with prompt_tokens (retry_loop's learner contract)."""
+    usage = TokenUsage(prompt_tokens=42, completion_tokens=7)
+    shim = _RouterUsageShim(usage)
+    assert shim.usage is usage
+    assert shim.usage.prompt_tokens == 42

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -143,6 +143,52 @@ def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
     assert decomposed_contents == build_contents
 
 
+def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
+    """Tier 2: with a persisted summary, the recovery bridge text == the normal path's.
+
+    The recovery prompt rebuilt by ``_router_main_call`` renders the structured
+    summary via ``_render_summary_for_storage`` — the same renderer that produced
+    the persisted ``summary.content`` the normal path (``_build_history_for_router``)
+    uses for its bridge. So the summary bridge is byte-identical across the two
+    paths (pinning the fix for the structured-vs-rendered divergence). retry_loop
+    still receives the structured dict as its immutable fold base.
+    """
+    from reyn.chat.session import _render_summary_for_storage
+
+    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    structured = {
+        "topic_arc": "planning the trip",
+        "decisions": ["book the tuesday flight"],
+        "pending": ["confirm hotel"],
+        "session_user_facts": [],
+        "artifacts_referenced": [],
+    }
+    # Store the summary exactly as the controller does: content = rendered form.
+    rendered = _render_summary_for_storage(structured)
+    session.history.append(ChatMessage(
+        role="summary",
+        content=rendered,
+        ts=_now(),
+        meta={"structured": structured, "covers_through_seq": 2},
+    ))
+    for i in range(8):  # > head+tail → else-branch → bridge inserted
+        _push(session, "user" if i % 2 == 0 else "assistant", f"t-{i}")
+
+    # Normal path bridge content.
+    normal = session._build_history_for_router()
+    normal_bridge = next(
+        m["content"] for m in normal
+        if isinstance(m["content"], str) and m["content"].startswith("[summary")
+    )
+    # Recovery path: decomposition hands the structured dict; _router_main_call
+    # renders it the same way → reproduce that bridge text here.
+    _h, _rm, _t, summary_dict = session._decompose_history_for_retry()
+    recovery_bridge = (
+        "[summary of earlier conversation]\n" + _render_summary_for_storage(summary_dict)
+    )
+    assert recovery_bridge == normal_bridge
+
+
 # ── wiring data contract: session decomposition feeds real retry_loop ────────
 
 


### PR DESCRIPTION
**[lead-coder]** — #1125 Item 2. PR-N6 built `retry_loop` (bounded adaptive-shrink overflow recovery) but the chat router **never called it** — the overflow handler ran a degraded compact-once (`session.py` old 5078-5113, which self-admitted "full retry_loop ... tracked as a follow-up") and hard-failed if the first compaction itself overflowed. axis-1's eager 30K trigger masked the gap by keeping the middle small. This wires the real mechanism in — **the prerequisite for #1128 axis-1 removal** (owner-signed-off sequence: wire → then remove).

Implementation owner: lead-coder (OS-core chat compaction). Owner sign-off on this scope: #1125 comment 4585865248.

## What changed
- **`ChatSession._decompose_history_for_retry`** exposes the `head/raw_middle/tail/summary` decomposition retry_loop consumes. Reuses the `head_size`/`tail_size` slicing + the documented Q4-attractor overlap guard; factors per-turn wire serialisation into **`_serialise_turn`** so the recovery prompt is byte-identical to what the normal path (`_build_history_for_router`) sends.
- **Router overflow handler** (`_run_router_loop`) hands that decomposition to `retry_loop` with the session's real engine / learner / cfg. `engine.budgets` is non-None by construction (engine `__init__` always sets `_budgets`; the pre-frame guard also already ran `recompute_budgets()`). On `UnrecoveredError` / `ContextOverflowError` → fail-fast user-visible error (chat axis contract, preserved from the degraded path).
- **`_RouterUsageShim`** exposes RouterLoop's `TokenUsage` as `.usage` so retry_loop's adaptive learner observes the chat axis's actual prompt size.

## Design notes
- The **pre-frame guard** (`_maybe_force_compact_for_router`) is **unchanged** — proactive persistence each turn. retry_loop is the **reactive safety net** when the guard's estimate under-counts (actual > estimate). No persistence added inside retry_loop (the guard owns it; retry_loop fires only on the estimate-miss exception, not every turn).
- Reuses the **same idempotency contract** the prior degraded path already shipped (re-run `loop.run` after overflow): overflow raises at the LLM call **before** any tool dispatch, so bounded re-runs with shrunk history are safe. retry_loop generalises "retry once" → "retry ≤8 with monotonic shrink"; it does not introduce a new idempotency assumption.
- Per owner: "破綻モード = 会話継続不能" → retry_loop is a **necessary component of the never-dead-end guarantee** (shrinks so the eventual wrap-up/handoff call fits).

## Test plan
- [x] Tier 2 `_decompose_history_for_retry` correctness — slicing (head/raw_middle/tail), overlap guard (history fits window → all head, empty raw_middle/tail), structured-summary extraction, **wire-shape parity** with `_build_history_for_router`.
- [x] Tier 2 wiring data contract — real `ChatSession` decomposition + real `CompactionEngine`/`TokenMultiplierLearner` drive `retry_loop` (no-overflow path; proves the decomposition is retry_loop-shaped + budgets accessible + learner observes via the shim). No mocks; `main_call` is a retry_loop parameter (test async fn, as PR-N6 tests use).
- [x] Regression sweep — `test_session_router_history_slicing` / `test_router_loop_chatsession` / `test_chat_compaction_engine_11axis` / `test_pr_n6_compaction_overflow_retry` / `test_path_ref_materialisation` / `test_user_image_input` + new = **107 passed**.
- [x] ruff + tier-audit clean (the two `len(...) == N` were canonical-idiom-rewritten to unpack-enforcement / lossless-partition — behavioral, not format-pin).
- [x] **Dogfood live-verify (sandbox_2)** — *armed post-merge (sandbox_2-agreed waiver: real-overflow reproducer-wait, decide-turn pattern; static review is the merge-gate)*. ORIGINAL ITEM: — the literal `_run_router_loop` except-block → `retry_loop` invocation on a **real** RouterLoop LLM context-overflow (not reconstructable in a unit test without the full router stack). Confirm: `router_context_overflow_detected` emitted → bounded shrink → recovery (or `router_context_overflow_unrecovered` + clean user-visible error at the floor). This is the end-to-end proof complementary to the static wiring tests.

Once this lands, #1128 (axis-1 eager removal + 30K drop + `/compact`) proceeds per the agreed sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
