### PR TITLE
docs(nav): add missing reference/cli/embeddings.md to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
           - reference/cli/permissions.md
           - reference/cli/config.md
           - reference/cli/init.md
+          - reference/cli/embeddings.md
           - reference/cli/common-flags.md
       - DSL:
           - reference/dsl/skill-md.md


### PR DESCRIPTION
**[docs-maintainer]** — nav orphan fix identified by sandbox_2 docs tree↔nav sync scan.

## Summary

- `reference/cli/embeddings.md` (104-line `reyn embeddings` CLI reference) was absent from the nav despite being a complete, well-formed doc
- Added under Reference > CLI, between `init.md` and `common-flags.md`
- `plugins/authoring-guide.md` is intentionally left orphaned (FP-0041 in-progress plugin framework)

## Test plan

- [x] `mkdocs build --strict` — 0 WARNING-level errors
- [x] Nav path verified: Reference > CLI > `reference/cli/embeddings.md` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)