### PR TITLE
fix(sandbox): update stale sandboxed_exec.py docstring

### DIFF
--- a/src/reyn/op_runtime/sandboxed_exec.py
+++ b/src/reyn/op_runtime/sandboxed_exec.py
@@ -1,9 +1,9 @@
 """sandboxed_exec kind handler — execute argv under a SandboxPolicy (FP-0017).
 
 Routes through `reyn.sandbox.get_default_backend()` so the OS selects the
-appropriate enforcement mechanism per platform. Today the default is
-NoopBackend (no isolation enforced); future waves add SeatbeltBackend
-(macOS) and LandlockBackend (Linux) without touching this handler.
+appropriate enforcement mechanism per platform. `get_default_backend` auto-
+selects SeatbeltBackend (macOS) or LandlockBackend (Linux) where available,
+falling back to NoopBackend on unsupported platforms.
 
 Emits `sandboxed_exec_started` / `sandboxed_exec_completed` events (P6).
 """


### PR DESCRIPTION
**[docs-maintainer]** — stale docstring fix dispatched by lead-coder (PR comment 4586068342).

## Summary

`src/reyn/op_runtime/sandboxed_exec.py` docstring said SeatbeltBackend and LandlockBackend were "future waves", but `get_default_backend()` already auto-selects them on macOS/Linux (landed in #1115 Stage 2 series). Update to reflect the live behaviour.

**Before:**
> Today the default is NoopBackend (no isolation enforced); future waves add SeatbeltBackend (macOS) and LandlockBackend (Linux) without touching this handler.

**After:**
> `get_default_backend` auto-selects SeatbeltBackend (macOS) or LandlockBackend (Linux) where available, falling back to NoopBackend on unsupported platforms.

## Test plan

- [x] No inbound references in CLAUDE.md / README.md / docs/ pointing to this docstring
- [x] 1-line diff, no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)