### PR TITLE
feat(chat): #1128 size-axis — chat tool-result cap/offload (dead-end #1)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2148,6 +2148,17 @@ class RouterLoop:
                     content_str = json.dumps(r, default=str)
                     if post_text:
                         content_str = f"{content_str}\n\n---\n{post_text}"
+                    # #1128 size axis (dead-end #1): cap an oversized tool result
+                    # ONCE at this chokepoint — the full body is offloaded to the
+                    # #385 store (lossless) and content_str becomes a bounded
+                    # preview, so BOTH consumers below (the live prompt append +
+                    # the persisted-history _append_entry) get the capped form.
+                    # This makes every tool turn individually compactable, so the
+                    # chat retry_loop's shrink can always fold it. getattr keeps
+                    # partial/test hosts a no-op.
+                    _cap = getattr(self.host, "cap_tool_result", None)
+                    if _cap is not None:
+                        content_str = _cap(content_str)
                     messages.append({
                         "role": "tool",
                         "tool_call_id": tc["id"],

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -200,6 +200,10 @@ class RouterHostAdapter:
         multimodal_config: Any = None,
         # Issue #383 PR-C: media + tool-result file storage.
         media_store: Any = None,
+        # #1128 size axis: per-turn tool-result cap/offload callable. Takes the
+        # serialised tool-result string and returns it unchanged (within cap) or
+        # an offloaded bounded preview. ``None`` = no cap (identity).
+        cap_tool_result: Any = None,
         # FP-0037 S1: persistent MCP tools cache directory.
         # Default is Path(".reyn/state") which resolves relative to cwd
         # (= the project root in all production entry points). Tests pass
@@ -290,8 +294,20 @@ class RouterHostAdapter:
         self._multimodal_config = multimodal_config
         # Issue #383 PR-C: store the MediaStore for path-ref save/read.
         self._media_store = media_store
+        # #1128 size axis: per-turn tool-result cap/offload callable (or None).
+        self._cap_tool_result = cap_tool_result
 
     # --- RouterLoopHost identity attributes ---
+
+    def cap_tool_result(self, content_str: str) -> str:
+        """#1128 size axis: cap an oversized tool-result string at the
+        router_loop chokepoint. Delegates to the session-supplied callable
+        (which offloads the full body via the #385 store + returns a bounded
+        preview); identity when no capper was wired (= legacy / test paths).
+        """
+        if self._cap_tool_result is None:
+            return content_str
+        return self._cap_tool_result(content_str)
 
     @property
     def media_store(self) -> Any:

--- a/src/reyn/chat/services/tool_result_cap.py
+++ b/src/reyn/chat/services/tool_result_cap.py
@@ -1,0 +1,155 @@
+"""Chat tool-result size cap — offload-based, lossless (#1128 size axis / dead-end #1).
+
+Every chat tool-result turn is made individually compactable (≤ a bound well
+under ``B_M``) so the chat retry_loop's shrink can always fold it into the
+summary — closing the persistent dead-end where one huge tool result could never
+be compacted away.
+
+Mechanism (mirrors ``context_builder.offload_control_ir_result``, the phase
+analog): when a tool-result string exceeds the cap, the FULL body is written to
+``tool_results_dir`` via the shared ``services.offload.offload_value`` (lossless,
+restorable through ``MediaStore.read_tool_result``) and the inline is replaced
+with a bounded preview (head + tail) carrying a project-relative ``_offload_ref``
++ ``_offload_content_hash``. There is NO lossy ``[:N]`` truncation of raw content
+and NO store-less discard path — the body is always recoverable, so the head/tail
+preview is lossless overall (feedback_no_lossy_truncate_without_user_judgment).
+
+Threshold is B_M-relative + token-unit (dead-end-free on ALL models, not just
+large-context): ``cap_tokens = min(FIXED_CEIL_TOKENS, floor(α · effective_trigger))``
+is computed by the caller (the session, which owns the engine budgets) and passed
+in; this module applies it via ``estimate_tokens`` for unit consistency with the
+budgets.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+from reyn.services.compaction.engine import estimate_tokens
+from reyn.services.offload.store import offload_value
+
+# Hard ceiling (chars) on the inline preview, even after head/tail bounding —
+# mirrors ``context_builder.MAX_OFFLOADED_INLINE_BYTES`` so a pathological
+# preview can never balloon the prompt.
+MAX_TOOL_RESULT_INLINE_BYTES: int = 16_384
+_PREVIEW_HEAD_CHARS: int = 6_000
+_PREVIEW_TAIL_CHARS: int = 2_000
+
+
+def cap_tool_result_content(
+    content_str: str,
+    *,
+    cap_tokens: int,
+    model: str,
+    store_dir: Path,
+    use_chars4: bool = False,
+    project_root: Path | None = None,
+    events: Any = None,
+) -> str:
+    """Return *content_str* unchanged if within the cap, else its offloaded preview.
+
+    Args:
+        content_str:  The serialised tool-result text (router_loop:2148 chokepoint).
+        cap_tokens:   Token budget for the inline; results estimated above it are
+                      offloaded. ``<= 0`` disables the cap (identity).
+        model:        Model name for ``estimate_tokens`` unit consistency.
+        store_dir:    ``tool_results_dir`` — where the full body is written.
+        use_chars4:   Match the engine's token estimator (``cfg.use_chars4_estimate``)
+                      so the size measurement is unit-consistent with the
+                      ``effective_trigger`` budget the cap is derived from.
+        project_root: When given, the inline ``_offload_ref`` is made
+                      project-relative so ``MediaStore.read_tool_result`` (which
+                      resolves project-relative paths) can read it back.
+        events:       Optional EventLog; a ``tool_result_offloaded`` audit event
+                      is emitted on offload (P6).
+
+    Returns:
+        The original string when ``estimate_tokens(content_str) <= cap_tokens``;
+        otherwise a bounded JSON preview string (head + tail + ``_offload_ref`` +
+        ``_offload_content_hash``), guaranteed ``<= MAX_TOOL_RESULT_INLINE_BYTES``.
+        The full body is always stored first — no information is lost.
+    """
+    if cap_tokens <= 0:
+        return content_str
+    if estimate_tokens(content_str, model, use_chars4=use_chars4) <= cap_tokens:
+        return content_str
+
+    result = offload_value(
+        content_str,
+        store_dir=store_dir,
+        preview_strategy=None,  # chat axis: caller (this fn) builds the bounded preview
+        filename=f"toolresult_{uuid.uuid4().hex[:8]}.txt",
+    )
+
+    ref = result.path_ref
+    if project_root is not None:
+        try:
+            ref = str(Path(result.path_ref).resolve().relative_to(Path(project_root).resolve()))
+        except ValueError:
+            # Body landed outside project_root (unusual) — keep the absolute ref.
+            ref = result.path_ref
+
+    def _fits(p: str) -> bool:
+        # Primary bound: the offloaded preview must itself be within cap_tokens,
+        # so it is < effective_trigger < B_M and therefore single-turn
+        # compactable (the by-construction dead-end-#1 closure — holds on ALL
+        # models, including small-context, not just large). MAX_TOOL_RESULT_INLINE_BYTES
+        # is an additional absolute char ceiling (latency / pathological guard).
+        return (
+            estimate_tokens(p, model, use_chars4=use_chars4) <= cap_tokens
+            and len(p) <= MAX_TOOL_RESULT_INLINE_BYTES
+        )
+
+    head_chars, tail_chars = _PREVIEW_HEAD_CHARS, _PREVIEW_TAIL_CHARS
+    preview = _build_preview(
+        content_str, ref=ref, content_hash=result.content_hash,
+        head_chars=head_chars, tail_chars=tail_chars,
+    )
+    # Shrink head/tail symmetrically until the preview fits cap_tokens. Floor at
+    # 0 (= a bare marker with no head/tail) so even a tiny cap converges to the
+    # lossless ref-only marker rather than looping; the full body is always in
+    # the store regardless.
+    while not _fits(preview) and (head_chars > 0 or tail_chars > 0):
+        head_chars = head_chars // 2 if head_chars > 64 else 0
+        tail_chars = tail_chars // 2 if tail_chars > 64 else 0
+        preview = _build_preview(
+            content_str, ref=ref, content_hash=result.content_hash,
+            head_chars=head_chars, tail_chars=tail_chars,
+        )
+
+    if events is not None:
+        events.emit(
+            "tool_result_offloaded",
+            total_chars=len(content_str),
+            cap_tokens=cap_tokens,
+            ref=ref,
+            content_hash=result.content_hash,
+        )
+    return preview
+
+
+def _build_preview(
+    content_str: str,
+    *,
+    ref: str,
+    content_hash: str,
+    head_chars: int,
+    tail_chars: int,
+) -> str:
+    """Build the bounded inline preview JSON for an offloaded tool result."""
+    return json.dumps(
+        {
+            "_offload_ref": ref,
+            "_offload_content_hash": content_hash,
+            "_offload_total_chars": len(content_str),
+            "_offload_note": (
+                f"Tool result offloaded ({len(content_str)} chars); read the full "
+                f"body via read_tool_result({ref!r})."
+            ),
+            "_offload_head": content_str[:head_chars] if head_chars > 0 else "",
+            "_offload_tail": content_str[-tail_chars:] if tail_chars > 0 else "",
+        },
+        ensure_ascii=False,
+    )

--- a/src/reyn/chat/services/tool_result_cap.py
+++ b/src/reyn/chat/services/tool_result_cap.py
@@ -6,36 +6,61 @@ summary — closing the persistent dead-end where one huge tool result could nev
 be compacted away.
 
 Mechanism (mirrors ``context_builder.offload_control_ir_result``, the phase
-analog): when a tool-result string exceeds the cap, the FULL body is written to
-``tool_results_dir`` via the shared ``services.offload.offload_value`` (lossless,
-restorable through ``MediaStore.read_tool_result``) and the inline is replaced
-with a bounded preview (head + tail) carrying a project-relative ``_offload_ref``
-+ ``_offload_content_hash``. There is NO lossy ``[:N]`` truncation of raw content
-and NO store-less discard path — the body is always recoverable, so the head/tail
-preview is lossless overall (feedback_no_lossy_truncate_without_user_judgment).
+analog): when a tool-result string exceeds the cap, the FULL body is stored via
+the injected ``save_fn`` (= ``MediaStore.save_tool_result``, the #385 store —
+lossless + restorable via ``MediaStore.read_tool_result``, same
+``.reyn/tool-results/`` dir + path-ref shape) and the inline is replaced with a
+bounded preview (head/tail + the project-relative ``_offload_ref`` path +
+``_offload_content_hash``).
+
+Offload-based, NO lossy ``[:N]`` truncation of raw content and NO store-less
+discard path — the body is always recoverable, so the head/tail preview is
+lossless overall (feedback_no_lossy_truncate_without_user_judgment).
 
 Threshold is B_M-relative + token-unit (dead-end-free on ALL models, not just
 large-context): ``cap_tokens = min(FIXED_CEIL_TOKENS, floor(α · effective_trigger))``
 is computed by the caller (the session, which owns the engine budgets) and passed
 in; this module applies it via ``estimate_tokens`` for unit consistency with the
-budgets.
+budgets. The offloaded **preview itself** is bounded to ``≤ cap_tokens`` (not a
+fixed char ceiling), so even on a small-context model the capped turn fits a
+compaction call (the by-construction crux — see #1128 4585990x).
 """
 from __future__ import annotations
 
 import json
-import uuid
-from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from reyn.services.compaction.engine import estimate_tokens
-from reyn.services.offload.store import offload_value
 
-# Hard ceiling (chars) on the inline preview, even after head/tail bounding —
-# mirrors ``context_builder.MAX_OFFLOADED_INLINE_BYTES`` so a pathological
-# preview can never balloon the prompt.
+# Additional absolute char ceiling on the inline preview (latency / pathological
+# guard), on top of the primary token-unit ≤ cap_tokens bound. Mirrors
+# ``context_builder.MAX_OFFLOADED_INLINE_BYTES``.
 MAX_TOOL_RESULT_INLINE_BYTES: int = 16_384
 _PREVIEW_HEAD_CHARS: int = 6_000
 _PREVIEW_TAIL_CHARS: int = 2_000
+
+# Cap-policy knobs (#1128 size axis).
+#   ALPHA            — fraction of effective_trigger; the dead-end-safety knob.
+#                      0.5 leaves headroom for the immutable previous_summary +
+#                      section-caps-spec that share the compaction call's input
+#                      alongside the single capped turn (≤ α·eff + summary + spec
+#                      ≤ B_M).
+#   FIXED_CEIL_TOKENS — upper clamp so large-context models still get a LEAN
+#                      per-turn inline (cost/latency knob), not a B_M-sized one.
+ALPHA: float = 0.5
+FIXED_CEIL_TOKENS: int = 4096
+
+
+def compute_cap_tokens(effective_trigger: int) -> int:
+    """B_M-relative per-turn cap: ``min(FIXED_CEIL_TOKENS, floor(ALPHA·effective_trigger))``.
+
+    By construction ``< effective_trigger ≤ B_M``, so a capped tool-result turn
+    always fits a single compaction call on ANY model (dead-end #1 closure,
+    model-independent). Returns 0 (= cap disabled) for a non-positive trigger.
+    """
+    if effective_trigger <= 0:
+        return 0
+    return min(FIXED_CEIL_TOKENS, int(ALPHA * effective_trigger))
 
 
 def cap_tool_result_content(
@@ -43,9 +68,8 @@ def cap_tool_result_content(
     *,
     cap_tokens: int,
     model: str,
-    store_dir: Path,
+    save_fn: Callable[[str], dict],
     use_chars4: bool = False,
-    project_root: Path | None = None,
     events: Any = None,
 ) -> str:
     """Return *content_str* unchanged if within the cap, else its offloaded preview.
@@ -55,20 +79,21 @@ def cap_tool_result_content(
         cap_tokens:   Token budget for the inline; results estimated above it are
                       offloaded. ``<= 0`` disables the cap (identity).
         model:        Model name for ``estimate_tokens`` unit consistency.
-        store_dir:    ``tool_results_dir`` — where the full body is written.
+        save_fn:      Stores the full body and returns a path-ref block with at
+                      least ``"path"`` (project-relative, read back via
+                      ``MediaStore.read_tool_result``) and ``"content_hash"``.
+                      In production this is ``MediaStore.save_tool_result`` (the
+                      #385 store) — lossless, never truncating.
         use_chars4:   Match the engine's token estimator (``cfg.use_chars4_estimate``)
                       so the size measurement is unit-consistent with the
                       ``effective_trigger`` budget the cap is derived from.
-        project_root: When given, the inline ``_offload_ref`` is made
-                      project-relative so ``MediaStore.read_tool_result`` (which
-                      resolves project-relative paths) can read it back.
         events:       Optional EventLog; a ``tool_result_offloaded`` audit event
                       is emitted on offload (P6).
 
     Returns:
         The original string when ``estimate_tokens(content_str) <= cap_tokens``;
         otherwise a bounded JSON preview string (head + tail + ``_offload_ref`` +
-        ``_offload_content_hash``), guaranteed ``<= MAX_TOOL_RESULT_INLINE_BYTES``.
+        ``_offload_content_hash``) with ``estimate_tokens(preview) <= cap_tokens``.
         The full body is always stored first — no information is lost.
     """
     if cap_tokens <= 0:
@@ -76,27 +101,16 @@ def cap_tool_result_content(
     if estimate_tokens(content_str, model, use_chars4=use_chars4) <= cap_tokens:
         return content_str
 
-    result = offload_value(
-        content_str,
-        store_dir=store_dir,
-        preview_strategy=None,  # chat axis: caller (this fn) builds the bounded preview
-        filename=f"toolresult_{uuid.uuid4().hex[:8]}.txt",
-    )
-
-    ref = result.path_ref
-    if project_root is not None:
-        try:
-            ref = str(Path(result.path_ref).resolve().relative_to(Path(project_root).resolve()))
-        except ValueError:
-            # Body landed outside project_root (unusual) — keep the absolute ref.
-            ref = result.path_ref
+    block = save_fn(content_str)
+    ref = block.get("path", "")
+    content_hash = block.get("content_hash", "")
 
     def _fits(p: str) -> bool:
         # Primary bound: the offloaded preview must itself be within cap_tokens,
         # so it is < effective_trigger < B_M and therefore single-turn
         # compactable (the by-construction dead-end-#1 closure — holds on ALL
-        # models, including small-context, not just large). MAX_TOOL_RESULT_INLINE_BYTES
-        # is an additional absolute char ceiling (latency / pathological guard).
+        # models, including small-context). MAX_TOOL_RESULT_INLINE_BYTES is an
+        # additional absolute char ceiling (latency / pathological guard).
         return (
             estimate_tokens(p, model, use_chars4=use_chars4) <= cap_tokens
             and len(p) <= MAX_TOOL_RESULT_INLINE_BYTES
@@ -104,18 +118,17 @@ def cap_tool_result_content(
 
     head_chars, tail_chars = _PREVIEW_HEAD_CHARS, _PREVIEW_TAIL_CHARS
     preview = _build_preview(
-        content_str, ref=ref, content_hash=result.content_hash,
+        content_str, ref=ref, content_hash=content_hash,
         head_chars=head_chars, tail_chars=tail_chars,
     )
     # Shrink head/tail symmetrically until the preview fits cap_tokens. Floor at
-    # 0 (= a bare marker with no head/tail) so even a tiny cap converges to the
-    # lossless ref-only marker rather than looping; the full body is always in
-    # the store regardless.
+    # 0 (= a bare lossless ref-marker) so even a tiny cap converges rather than
+    # loops; the full body is always in the store regardless.
     while not _fits(preview) and (head_chars > 0 or tail_chars > 0):
         head_chars = head_chars // 2 if head_chars > 64 else 0
         tail_chars = tail_chars // 2 if tail_chars > 64 else 0
         preview = _build_preview(
-            content_str, ref=ref, content_hash=result.content_hash,
+            content_str, ref=ref, content_hash=content_hash,
             head_chars=head_chars, tail_chars=tail_chars,
         )
 
@@ -125,7 +138,7 @@ def cap_tool_result_content(
             total_chars=len(content_str),
             cap_tokens=cap_tokens,
             ref=ref,
-            content_hash=result.content_hash,
+            content_hash=content_hash,
         )
     return preview
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1749,6 +1749,10 @@ class ChatSession:
             multimodal_config=self._multimodal_config,
             # Issue #383 PR-C: shared MediaStore for image + tool-result storage.
             media_store=self._media_store,
+            # #1128 size axis: per-turn tool-result cap/offload (dead-end #1).
+            # Late-bound method — the engine budgets it reads are computed by
+            # the time a tool result flows through router_loop at runtime.
+            cap_tool_result=self._cap_tool_result,
             # B25-S5-1: thread eager-build flag so RouterLoop awaits build
             # before computing _search_visible on the first turn.
             eager_embedding_build=self._eager_embedding_build,
@@ -5003,6 +5007,48 @@ class ChatSession:
             project_context=self._router_host.get_project_context(),
             indexed_sources_section=None,
             universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
+        )
+
+    def _cap_tool_result(self, content_str: str) -> str:
+        """#1128 size axis (dead-end #1): cap an oversized chat tool result.
+
+        Derives the B_M-relative per-turn cap from the engine budgets
+        (``effective_trigger``; falls back to the model's max-input tokens before
+        budgets are computed) and delegates to ``cap_tool_result_content``, which
+        OFFLOADS the full body via the #385 store (``MediaStore.save_tool_result``,
+        lossless + restorable via ``read_tool_result``) and returns a bounded
+        preview ``≤ cap_tokens``. Threaded into ``RouterHostAdapter`` so
+        router_loop caps every tool result at the single ``content_str``
+        chokepoint, making each tool turn individually compactable (so the chat
+        retry_loop's shrink can always fold it). No-op when no media_store is
+        configured (= nowhere to store the body losslessly).
+        """
+        store = self._media_store
+        if store is None:
+            return content_str
+        from reyn.chat.services.tool_result_cap import (
+            cap_tool_result_content,
+            compute_cap_tokens,
+        )
+
+        controller = getattr(self, "_compaction_controller", None)
+        engine = getattr(controller, "_engine", None) if controller is not None else None
+        budgets = getattr(engine, "budgets", None)
+        if budgets is not None:
+            effective_trigger = budgets.effective_trigger
+        else:
+            from reyn.llm.model_budget import get_max_input_tokens
+            effective_trigger = get_max_input_tokens(self.model, events=self._chat_events)
+
+        cap_tokens = compute_cap_tokens(effective_trigger)
+        use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+        return cap_tool_result_content(
+            content_str,
+            cap_tokens=cap_tokens,
+            model=self.model,
+            save_fn=store.save_tool_result,
+            use_chars4=use_chars4,
+            events=self._chat_events,
         )
 
     async def _maybe_force_compact_for_router(

--- a/tests/test_tool_result_cap_1128.py
+++ b/tests/test_tool_result_cap_1128.py
@@ -1,17 +1,17 @@
 """Tier 2: OS invariant — chat tool-result cap is offload-based + by-construction bounded (#1128).
 
 The size-axis fix for conversation dead-end #1: an oversized chat tool result is
-OFFLOADED (full body stored, lossless, restorable) and replaced inline with a
-bounded preview whose estimated tokens are ``<= cap_tokens``. Because
-``cap_tokens = min(FIXED_CEIL, floor(0.5·effective_trigger)) < effective_trigger``,
+OFFLOADED via the #385 store (full body saved, lossless, restorable) and replaced
+inline with a bounded preview whose estimated tokens are ``<= cap_tokens``.
+Because ``cap_tokens = min(FIXED_CEIL, floor(0.5·effective_trigger)) < effective_trigger``,
 the capped result is single-turn compactable on every model — so retry_loop's
 shrink can always fold it (closes the dead-end).
 
-These pin the helper's contract with the real offload store + real
-``MediaStore.read_tool_result`` read-back (no mocks):
+These pin the helper's contract against the real ``MediaStore.save_tool_result``
+store + real ``read_tool_result`` read-back (no mocks):
   - under-cap content is identity (no offload),
   - over-cap content is offloaded + the inline preview is ``<= cap_tokens`` (the
-    by-construction bound, across small + large caps),
+    by-construction bound, across small + large caps = model-independent),
   - the full body reads back losslessly via ``read_tool_result`` (the
     no-lossy-truncate guarantee — body is never discarded or raw-``[:N]``-cut),
   - cap_tokens<=0 disables the cap.
@@ -20,6 +20,7 @@ These pin the helper's contract with the real offload store + real
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -34,34 +35,33 @@ from reyn.workspace.media_store import MediaStore
 _MODEL = "gpt-4o"
 
 
-def _store_dir(tmp_path: Path) -> Path:
-    # Mirror MediaStore's default tool_results_dir layout so read_tool_result
-    # (project-relative under tool_results_dir) resolves the body we wrote.
-    return tmp_path / ".reyn" / "tool-results"
-
-
 def test_under_cap_content_is_identity(tmp_path: Path) -> None:
     """Tier 2: a result within cap_tokens is returned unchanged (no offload)."""
+    store = MediaStore(project_root=tmp_path)
     content = "small tool result"
     out = cap_tool_result_content(
         content, cap_tokens=2048, model=_MODEL,
-        store_dir=_store_dir(tmp_path), use_chars4=True,
+        save_fn=store.save_tool_result, use_chars4=True,
     )
     assert out == content
-    # Nothing written when under cap.
-    assert not _store_dir(tmp_path).exists() or not any(_store_dir(tmp_path).iterdir())
+    # Nothing stored when under cap.
+    tr_dir = store.tool_results_dir
+    assert not tr_dir.exists() or not any(tr_dir.iterdir())
 
 
 @pytest.mark.parametrize("cap_tokens", [256, 1024, 4096])
 def test_over_cap_preview_is_within_cap_tokens(tmp_path: Path, cap_tokens: int) -> None:
     """Tier 2: an oversized result's inline preview is <= cap_tokens (by-construction).
 
-    Holds across small + large caps — the dead-end-#1 closure is model-independent.
+    Holds across small + large caps — the dead-end-#1 closure is model-independent
+    (covers the α-composition + bare-marker sanity-checks: the preview always
+    fits the budget regardless of cap size).
     """
+    store = MediaStore(project_root=tmp_path)
     content = "X" * 400_000  # ~100k tokens (chars//4) — far over any cap
     out = cap_tool_result_content(
         content, cap_tokens=cap_tokens, model=_MODEL,
-        store_dir=_store_dir(tmp_path), project_root=tmp_path, use_chars4=True,
+        save_fn=store.save_tool_result, use_chars4=True,
     )
     assert out != content, "oversized content must be offloaded, not returned raw"
     assert estimate_tokens(out, _MODEL, use_chars4=True) <= cap_tokens, (
@@ -78,16 +78,14 @@ def test_offloaded_body_reads_back_lossless(tmp_path: Path) -> None:
     The no-lossy-truncate guarantee: the body is stored, never discarded or
     raw-truncated. The inline preview is just a bounded pointer.
     """
-    import json
-
+    store = MediaStore(project_root=tmp_path)
     content = "LINE\n" * 50_000  # large, distinctive
     out = cap_tool_result_content(
         content, cap_tokens=512, model=_MODEL,
-        store_dir=_store_dir(tmp_path), project_root=tmp_path, use_chars4=True,
+        save_fn=store.save_tool_result, use_chars4=True,
     )
     ref = json.loads(out)["_offload_ref"]
 
-    store = MediaStore(project_root=tmp_path)
     body, found = store.read_tool_result(ref)
     assert found, f"read_tool_result could not locate the offloaded body at {ref!r}"
     assert body == content, "read-back must return the full original body (lossless)"
@@ -95,9 +93,10 @@ def test_offloaded_body_reads_back_lossless(tmp_path: Path) -> None:
 
 def test_cap_disabled_when_zero(tmp_path: Path) -> None:
     """Tier 2: cap_tokens<=0 disables the cap (identity, no offload)."""
+    store = MediaStore(project_root=tmp_path)
     content = "Y" * 100_000
     out = cap_tool_result_content(
         content, cap_tokens=0, model=_MODEL,
-        store_dir=_store_dir(tmp_path), use_chars4=True,
+        save_fn=store.save_tool_result, use_chars4=True,
     )
     assert out == content

--- a/tests/test_tool_result_cap_1128.py
+++ b/tests/test_tool_result_cap_1128.py
@@ -1,0 +1,103 @@
+"""Tier 2: OS invariant — chat tool-result cap is offload-based + by-construction bounded (#1128).
+
+The size-axis fix for conversation dead-end #1: an oversized chat tool result is
+OFFLOADED (full body stored, lossless, restorable) and replaced inline with a
+bounded preview whose estimated tokens are ``<= cap_tokens``. Because
+``cap_tokens = min(FIXED_CEIL, floor(0.5·effective_trigger)) < effective_trigger``,
+the capped result is single-turn compactable on every model — so retry_loop's
+shrink can always fold it (closes the dead-end).
+
+These pin the helper's contract with the real offload store + real
+``MediaStore.read_tool_result`` read-back (no mocks):
+  - under-cap content is identity (no offload),
+  - over-cap content is offloaded + the inline preview is ``<= cap_tokens`` (the
+    by-construction bound, across small + large caps),
+  - the full body reads back losslessly via ``read_tool_result`` (the
+    no-lossy-truncate guarantee — body is never discarded or raw-``[:N]``-cut),
+  - cap_tokens<=0 disables the cap.
+
+``use_chars4=True`` matches the chars//4 estimator deterministically offline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.services.tool_result_cap import (
+    MAX_TOOL_RESULT_INLINE_BYTES,
+    cap_tool_result_content,
+)
+from reyn.services.compaction.engine import estimate_tokens
+from reyn.workspace.media_store import MediaStore
+
+_MODEL = "gpt-4o"
+
+
+def _store_dir(tmp_path: Path) -> Path:
+    # Mirror MediaStore's default tool_results_dir layout so read_tool_result
+    # (project-relative under tool_results_dir) resolves the body we wrote.
+    return tmp_path / ".reyn" / "tool-results"
+
+
+def test_under_cap_content_is_identity(tmp_path: Path) -> None:
+    """Tier 2: a result within cap_tokens is returned unchanged (no offload)."""
+    content = "small tool result"
+    out = cap_tool_result_content(
+        content, cap_tokens=2048, model=_MODEL,
+        store_dir=_store_dir(tmp_path), use_chars4=True,
+    )
+    assert out == content
+    # Nothing written when under cap.
+    assert not _store_dir(tmp_path).exists() or not any(_store_dir(tmp_path).iterdir())
+
+
+@pytest.mark.parametrize("cap_tokens", [256, 1024, 4096])
+def test_over_cap_preview_is_within_cap_tokens(tmp_path: Path, cap_tokens: int) -> None:
+    """Tier 2: an oversized result's inline preview is <= cap_tokens (by-construction).
+
+    Holds across small + large caps — the dead-end-#1 closure is model-independent.
+    """
+    content = "X" * 400_000  # ~100k tokens (chars//4) — far over any cap
+    out = cap_tool_result_content(
+        content, cap_tokens=cap_tokens, model=_MODEL,
+        store_dir=_store_dir(tmp_path), project_root=tmp_path, use_chars4=True,
+    )
+    assert out != content, "oversized content must be offloaded, not returned raw"
+    assert estimate_tokens(out, _MODEL, use_chars4=True) <= cap_tokens, (
+        "the offloaded inline preview must itself fit cap_tokens so it is "
+        "single-turn compactable (the by-construction dead-end-#1 bound)"
+    )
+    assert len(out) <= MAX_TOOL_RESULT_INLINE_BYTES
+    assert "_offload_ref" in out
+
+
+def test_offloaded_body_reads_back_lossless(tmp_path: Path) -> None:
+    """Tier 2: the full body is recoverable via MediaStore.read_tool_result (lossless).
+
+    The no-lossy-truncate guarantee: the body is stored, never discarded or
+    raw-truncated. The inline preview is just a bounded pointer.
+    """
+    import json
+
+    content = "LINE\n" * 50_000  # large, distinctive
+    out = cap_tool_result_content(
+        content, cap_tokens=512, model=_MODEL,
+        store_dir=_store_dir(tmp_path), project_root=tmp_path, use_chars4=True,
+    )
+    ref = json.loads(out)["_offload_ref"]
+
+    store = MediaStore(project_root=tmp_path)
+    body, found = store.read_tool_result(ref)
+    assert found, f"read_tool_result could not locate the offloaded body at {ref!r}"
+    assert body == content, "read-back must return the full original body (lossless)"
+
+
+def test_cap_disabled_when_zero(tmp_path: Path) -> None:
+    """Tier 2: cap_tokens<=0 disables the cap (identity, no offload)."""
+    content = "Y" * 100_000
+    out = cap_tool_result_content(
+        content, cap_tokens=0, model=_MODEL,
+        store_dir=_store_dir(tmp_path), use_chars4=True,
+    )
+    assert out == content

--- a/tests/test_tool_result_cap_1128.py
+++ b/tests/test_tool_result_cap_1128.py
@@ -28,6 +28,7 @@ import pytest
 from reyn.chat.services.tool_result_cap import (
     MAX_TOOL_RESULT_INLINE_BYTES,
     cap_tool_result_content,
+    compute_cap_tokens,
 )
 from reyn.services.compaction.engine import estimate_tokens
 from reyn.workspace.media_store import MediaStore
@@ -100,3 +101,146 @@ def test_cap_disabled_when_zero(tmp_path: Path) -> None:
         save_fn=store.save_tool_result, use_chars4=True,
     )
     assert out == content
+
+
+# ── load-bearing integration: capped turn folds via retry_loop, uncapped dead-ends ──
+#
+# The dead-end-#1 proof (#1128): a single oversized tool result can never be
+# compacted away → retry_loop's shrink can't fold it → UnrecoveredError. Capping
+# it (≤ cap_tokens < B_M) makes the single turn fit a compaction call, so
+# retry_loop folds it WITHOUT CompactionOverflowError. This drives the REAL
+# retry_loop + real ComputedBudgets + real compute_cap_tokens + real cap helper;
+# engine.compact is gated to the real B_M overflow semantics (engine.py:930-934)
+# without a live LLM.
+
+def _budgets():
+    from reyn.services.compaction.engine import ComputedBudgets
+    return ComputedBudgets(
+        main_pool=10_000, head_budget=200, body_budget=500,
+        tail_budget=200, new_msg_budget=1_000,
+        B_M=8_000, main_M_room=7_000, effective_trigger=7_000,
+        section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                      "session_user_facts": 50, "artifacts_referenced": 175},
+    )
+
+
+class _BMGatedEngine:
+    """Real ComputedBudgets + a compact() gated on B_M, mirroring the real
+    engine's overflow semantics (engine.py:930-934) — no live LLM. A chunk whose
+    estimated tokens exceed B_M raises CompactionOverflowError (= the dead-end);
+    otherwise it folds into a stub summary."""
+
+    def __init__(self, budgets):
+        self.budgets = budgets
+
+    async def compact(self, input_chunk):
+        from reyn.services.compaction.engine import (
+            ChatSummary,
+            CompactionOverflowError,
+        )
+        prev = json.dumps(input_chunk.previous_summary or {}, ensure_ascii=False)
+        turns = json.dumps(input_chunk.new_turns, ensure_ascii=False, default=str)
+        total = estimate_tokens(prev + turns, _MODEL, use_chars4=True)
+        if total > self.budgets.B_M:
+            raise CompactionOverflowError(f"chunk {total} tok > B_M {self.budgets.B_M}")
+        seq = max(
+            (t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)),
+            default=0,
+        )
+        return ChatSummary(topic_arc="folded", covers_through_seq=seq)
+
+
+async def _size_aware_main_call(**kwargs):
+    """Main send that overflows when the assembled prompt exceeds main_M_room.
+
+    Needed to surface the dead-end: retry_loop *defers* an overflowing
+    raw_middle turn into the tail (it doesn't raise), so without a size-aware
+    main call a big-but-deferred turn would just pass. With this, the uncapped
+    big turn bounces raw_middle↔tail (compact overflows in middle, main overflows
+    in tail) until UnrecoveredError — exactly the dead-end the cap closes.
+    """
+    from types import SimpleNamespace
+
+    from reyn.services.compaction.engine import ContextOverflowError
+
+    head = kwargs.get("head") or []
+    summary = kwargs.get("summary")
+    tail = kwargs.get("tail") or []
+    new_msg = kwargs.get("new_msg") or {}
+    text = (
+        json.dumps(head, default=str)
+        + json.dumps(summary or {}, default=str)
+        + json.dumps(tail, default=str)
+        + json.dumps(new_msg, default=str)
+    )
+    if estimate_tokens(text, _MODEL, use_chars4=True) > _budgets().main_M_room:
+        raise ContextOverflowError("main prompt exceeds main_M_room")
+    return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=500), choices=[])
+
+
+def _retry_loop_with(raw_middle_turn: dict):
+    import asyncio
+    import tempfile
+
+    from reyn.chat.services.token_multiplier_learner import TokenMultiplierLearner
+    from reyn.config import CompactionConfig
+    from reyn.services.compaction.engine import retry_loop
+
+    learner = TokenMultiplierLearner(
+        storage_path=Path(tempfile.mkdtemp()) / "m.json"
+    )
+    return asyncio.run(retry_loop(
+        SP="system",
+        head=[],
+        summary=None,
+        raw_middle=[raw_middle_turn],
+        tail=[],
+        new_msg={"role": "user", "content": "hi", "seq": 99},
+        cfg=CompactionConfig(),
+        model=_MODEL,
+        engine=_BMGatedEngine(_budgets()),  # type: ignore[arg-type]
+        learner=learner,
+        main_call=_size_aware_main_call,
+        max_iterations=8,
+    ))
+
+
+def test_capped_tool_turn_folds_via_retry_loop_without_overflow(tmp_path: Path) -> None:
+    """Tier 2: load-bearing — a CAPPED oversized tool result folds via retry_loop.
+
+    The dead-end-#1 closure: cap an oversized tool result (≤ cap_tokens < B_M),
+    put it in raw_middle, run the real retry_loop — engine.compact succeeds (the
+    capped turn fits B_M), so it folds with NO CompactionOverflowError /
+    UnrecoveredError.
+    """
+    store = MediaStore(project_root=tmp_path)
+    cap_tokens = compute_cap_tokens(_budgets().effective_trigger)
+    capped = cap_tool_result_content(
+        "Z" * 80_000,  # ~20k tokens — far over B_M=8000, the dead-end shape
+        cap_tokens=cap_tokens, model=_MODEL,
+        save_fn=store.save_tool_result, use_chars4=True,
+    )
+    assert estimate_tokens(capped, _MODEL, use_chars4=True) < _budgets().B_M, (
+        "precondition: the capped turn must fit the compaction budget"
+    )
+    result = _retry_loop_with({"role": "tool", "content": capped, "seq": 5})
+    assert result is not None  # folded + main_call succeeded, no exception raised
+
+
+def test_uncapped_oversized_tool_turn_dead_ends(tmp_path: Path) -> None:
+    """Tier 2: contrast — the UNCAPPED oversized turn dead-ends, proving the cap is load-bearing.
+
+    Without the cap, the single oversized tool turn exceeds B_M, engine.compact
+    keeps raising CompactionOverflowError, retry_loop's shrink cannot fold a
+    single un-splittable turn → it terminates in error. This is exactly the
+    dead-end the cap closes.
+    """
+    from reyn.services.compaction.engine import (
+        CompactionOverflowError,
+        UnrecoveredError,
+    )
+
+    uncapped = "Z" * 80_000  # ~20k tokens > B_M=8000
+    assert estimate_tokens(uncapped, _MODEL, use_chars4=True) > _budgets().B_M
+    with pytest.raises((UnrecoveredError, CompactionOverflowError)):
+        _retry_loop_with({"role": "tool", "content": uncapped, "seq": 5})


### PR DESCRIPTION
**[e2e-coder]** — #1128 size axis (conversation dead-end #1). Canonical design = sandbox_2 (#1128 comments 4585939965 + 4585951328), ratified by lead-coder + sandbox_2 (preview-bound refinement). Implementation = e2e-coder. Standalone PR, independent of #1157 dogfood.

## What
Every chat tool-result turn is made individually compactable (≤ a bound well under `B_M`) so the chat retry_loop's shrink can always fold it — closing the dead-end where one huge tool result could never be compacted away.

- **`chat/services/tool_result_cap.py`** — `cap_tool_result_content`: offloads an oversized tool result via the injected `save_fn` (= `MediaStore.save_tool_result`, the #385 store — full body saved losslessly, restorable via `read_tool_result`, canonical `tool_result_ref` path shape) and returns a bounded inline preview (head/tail + project-relative `_offload_ref` + `_offload_content_hash`). **No lossy `[:N]` raw truncate, no store-less discard** (feedback_no_lossy_truncate_without_user_judgment) — the body is always stored, so the head/tail preview is lossless overall.
- **Threshold** (B_M-relative, token-unit, model-independent): `compute_cap_tokens(eff) = min(FIXED_CEIL_TOKENS=4096, ⌊ALPHA=0.5·effective_trigger⌋)`. ★ The offloaded **preview itself** is bounded to ≤ cap_tokens (token-unit, `estimate_tokens` matching the engine's `use_chars4`), not a fixed char ceiling — so even on a small-context model the capped turn fits a compaction call (the by-construction crux; resolved the small-model hole in the original fixed-byte spec, ratified by sandbox_2). `MAX_TOOL_RESULT_INLINE_BYTES` is an additional absolute char guard.
- **Wiring**: `session._cap_tool_result` (cap_tokens from the engine budgets `effective_trigger`, fallback `get_max_input_tokens`; `use_chars4` matching the engine) → threaded as a `cap_tool_result` callable through `RouterHostAdapter` → called ONCE at the `router_loop:2148` `content_str` chokepoint (after post_text, before BOTH the live-prompt append and the persisted `_append_entry`), getattr-guarded so partial/test hosts no-op.
- **role=tool audit**: the router_loop tool-result loop is the SOLE tool-result append site (the adjacent 2119 site is the `role="assistant"` tool-CALL turn, not a result) → no belt-and-suspenders needed.

## Out of scope (separate follow-ups)
media-count edge (single tool_result with many images, #1128 4585981068); planner/phase axis; #1092 cumulative (dead-end #2); axis-1 eager-compaction removal (#1128 Item 1, parked).

## Test plan (Tier 2, no mocks)
- [x] `tests/test_tool_result_cap_1128.py` (8): under-cap identity; over-cap preview ≤ cap_tokens across small+large caps (by-construction, model-independent); full body reads back lossless via real `MediaStore.read_tool_result`; cap-disabled; **load-bearing** — a CAPPED turn folds via real `retry_loop` without `CompactionOverflowError`, while the UNCAPPED turn dead-ends (`UnrecoveredError`) — real `retry_loop` + real `ComputedBudgets` + real `compute_cap_tokens` + B_M-gated `compact` (engine.py:930-934 semantics) + size-aware main_call, no live LLM.
- [x] chat/session/router/compaction sweep → 1014 passed; ruff + `test_tier_audit --strict` clean
- [x] `_offload_ref` consumer audit incl `tests/`: reused the canonical `save_tool_result` path shape (unchanged); nothing parses the preview's `_offload_ref` (LLM-facing text)
- [x] full suite `pytest -q --ignore=.claude` → 6626 passed; 2 unrelated failures: `test_web_fetch_preview_path_ref` (known local-only HTML-extractor lib diff, not in CI) + `test_fp0009_b_cron_scheduler::...scheduler_continues` (flaky — **passes in isolation**; this branch's diff is chat-only and never touches cron, which runs via `Agent.run`→OSRuntime not the chat router host)

Refs #1128 #1095 #1093 #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)