### PR TITLE
feat(compaction): #271 — re-summarize 3-tier topic_arc bounding (hard_truncate → judgment-first)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -834,6 +834,7 @@ chat:
 | `new_msg_ratio` | float | `0.10` | Fraction of `main_pool` reserved for the incoming user message. |
 | `section_caps_spec_tokens` | int | `100` | Static overhead budget for `section_token_caps` serialisation in the compactor prompt. |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of the litellm token counter (latency opt-out for large deployments). |
+| `resummarize_passes` | int | `1` | #271: max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `1` = one judgment-based re-summary then floor; `0` = skip the re-summary (straight to the floor = pre-#271 behaviour). |
 
 ### `chat.compaction` weight dicts
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -246,6 +246,8 @@
 #     tail_size: 12
 #     body_token_cap: 1500
 #     min_compact_batch: 5
+#     resummarize_passes: 1            # #271: LLM re-compression passes on topic_arc
+#                                      # overshoot before the hard_truncate floor (0 = skip)
 #     section_token_caps:
 #       topic_arc: 200
 #       decisions: 400

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -425,6 +425,11 @@ class CompactionConfig:
     trigger_total_tokens: int = 30000   # background trigger: compact when middle exceeds this
     body_token_cap: int = 1500          # hard cap on summary body tokens (post-truncation)
     min_compact_batch: int = 5          # skip compact when fewer than N turns to absorb
+    # #271 re-summarize (T2): max LLM re-compression passes when a produced
+    # topic_arc overshoots body_budget, before the deterministic T3
+    # hard_truncate floor. 1 = one judgment-based re-summary then floor; 0 =
+    # skip T2 (straight to the floor, = pre-#271 behaviour).
+    resummarize_passes: int = 1
     section_token_caps: CompactionSectionCaps = field(default_factory=CompactionSectionCaps)
     # head_size / tail_size:
     # DEPRECATED — retained only for the background `_maybe_compact()` legacy
@@ -1907,6 +1912,9 @@ def _build_chat_config(raw: object) -> ChatConfig:
         body_token_cap=int(compaction_raw.get("body_token_cap", defaults.body_token_cap)),
         min_compact_batch=int(
             compaction_raw.get("min_compact_batch", defaults.min_compact_batch)
+        ),
+        resummarize_passes=int(
+            compaction_raw.get("resummarize_passes", defaults.resummarize_passes)
         ),
         section_token_caps=section,
         head_size=int(compaction_raw.get("head_size", defaults.head_size)),

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -497,6 +497,29 @@ Output ONLY the JSON object — no explanation, no markdown fences.
 """
 
 
+# #271 re-summarize (T2): a DISTINCT prompt for the overshoot case. The main
+# compaction SP forbids re-summarising `previous_summary` (immutable base); this
+# one EXPLICITLY relaxes that — it is the controlled re-compression pass invoked
+# only when the produced topic_arc overshoots body_budget. LLM-judgment loss
+# (preserve decision-relevant, drop least essential) replaces the blind char-cut
+# of hard_truncate; the deterministic floor (T3) still applies after.
+_RESUMMARIZE_SYSTEM_PROMPT = """\
+You are compressing a single rolling-summary narrative (the `topic_arc`) that
+overshot its token budget. Rewrite it to fit within the target budget.
+
+You MAY re-compress, rephrase, and drop content — this is an explicit
+re-summarisation pass (unlike the main compaction step, here re-summarising is
+REQUIRED to shrink the text).
+
+Rules:
+- Preserve the MOST decision-relevant content; drop the least essential.
+- Keep VERBATIM: file paths, line numbers, commit hashes, decision identifiers
+  (PR-N6, FP-0008, issue #1035), temporal markers, exit/error codes.
+- Match the original language.
+- Output ONLY the rewritten narrative text — no JSON, no markdown, no preamble.
+"""
+
+
 def compute_covers_through_seq(new_turn_seqs: list) -> int:
     """Return max(new_turn_seqs) or 0 when the list is empty.
 
@@ -729,6 +752,54 @@ class CompactionEngine:
         """Read-only access to the computed budget values."""
         return self._budgets
 
+    async def _acompletion(self, messages: list[dict], *, response_format: dict | None = None):
+        """Single litellm.acompletion call with proxy routing applied.
+
+        Shared by ``compact`` (JSON response) and ``_resummarize_topic_arc``
+        (text response) so the proxy_kwargs + provider-prefix-strip routing is
+        in one place.
+        """
+        from reyn.llm.llm import proxy_kwargs
+        extra = proxy_kwargs()
+        # Strip provider prefix for proxy routing.
+        effective_model = self._model
+        if extra.get("custom_llm_provider") == "openai":
+            parts = self._model.split("/", 1)
+            if len(parts) == 2:
+                effective_model = parts[1]
+        import litellm
+        kwargs: dict = {"model": effective_model, "messages": messages, **extra}
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        return await litellm.acompletion(**kwargs)
+
+    async def _resummarize_topic_arc(self, topic_arc: str, body_budget: int) -> str:
+        """T2 (#271): LLM re-compression of an overshooting ``topic_arc``.
+
+        Invokes the compactor model with the distinct relaxation prompt
+        (``_RESUMMARIZE_SYSTEM_PROMPT``) to rewrite ``topic_arc`` to fit
+        ``body_budget`` tokens — LLM-judgment loss (preserve decision-relevant)
+        rather than the blind char-cut. Returns the original on any LLM error or
+        empty response (T3 hard_truncate is the floor either way).
+        """
+        try:
+            messages = [
+                {"role": "system", "content": _RESUMMARIZE_SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": (
+                        f"Target budget: {body_budget} tokens.\n\n"
+                        f"topic_arc to compress:\n{topic_arc}"
+                    ),
+                },
+            ]
+            response = await self._acompletion(messages)
+            rewritten = (response.choices[0].message.content or "").strip()
+            return rewritten or topic_arc
+        except Exception as exc:  # noqa: BLE001 — re-summarize is best-effort; T3 floors it.
+            self._events.emit("summary_resummarize_failed", error=str(exc))
+            return topic_arc
+
     async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
         """Run one compaction LLM call and return a ChatSummary.
 
@@ -752,22 +823,8 @@ class CompactionEngine:
             {"role": "user", "content": user_content},
         ]
 
-        from reyn.llm.llm import proxy_kwargs
-        extra = proxy_kwargs()
-
-        # Strip provider prefix for proxy routing.
-        effective_model = self._model
-        if extra.get("custom_llm_provider") == "openai":
-            parts = self._model.split("/", 1)
-            if len(parts) == 2:
-                effective_model = parts[1]
-
-        import litellm
-        response = await litellm.acompletion(
-            model=effective_model,
-            messages=messages,
-            response_format={"type": "json_object"},
-            **extra,
+        response = await self._acompletion(
+            messages, response_format={"type": "json_object"}
         )
 
         raw = (response.choices[0].message.content or "").strip()
@@ -793,10 +850,31 @@ class CompactionEngine:
                 default=0,
             )
 
-        # Axis 9: hard-truncate the topic_arc to body_budget.
-        topic_arc = hard_truncate_summary(
-            str(parsed.get("topic_arc") or ""),
-            self._budgets.body_budget,
+        # #271 — 3-tier topic_arc bounding (replaces the lone Axis-9 blind cut):
+        #   T1 fit         — within budget → no LLM, unchanged (common case).
+        #   T2 re-summarize — overshoot → LLM re-compression (judgment loss, the
+        #                     user's "intentional summary compression is fine"),
+        #                     bounded to ``resummarize_passes`` (default 1).
+        #   T3 hard_truncate — deterministic floor, always applied last so
+        #                     topic_arc ≤ body_budget is NEVER violated (the
+        #                     dead-end-free bound; rare backstop after T2).
+        body_budget = self._budgets.body_budget
+        topic_arc = str(parsed.get("topic_arc") or "")
+        passes = max(0, int(getattr(self._cfg, "resummarize_passes", 1)))
+        for _ in range(passes):
+            before_tokens = estimate_tokens(topic_arc, self._model, use_chars4=self._use_chars4)
+            if before_tokens <= body_budget:
+                break  # T1: fits
+            topic_arc = await self._resummarize_topic_arc(topic_arc, body_budget)
+            self._events.emit(
+                "summary_resummarized",
+                original_tokens=before_tokens,
+                target_budget=body_budget,
+                result_tokens=estimate_tokens(topic_arc, self._model, use_chars4=self._use_chars4),
+            )
+        topic_arc = hard_truncate_summary(  # T3: deterministic floor
+            topic_arc,
+            body_budget,
             self._model,
             self._events,
             use_chars4=self._use_chars4,

--- a/tests/test_resummarize_3tier_271.py
+++ b/tests/test_resummarize_3tier_271.py
@@ -1,0 +1,130 @@
+"""Tier 2: OS invariant — #271 re-summarize 3-tier topic_arc bounding.
+
+`CompactionEngine.compact` bounds the produced `topic_arc` to `body_budget` via a
+3-tier ladder, replacing the lone blind `hard_truncate` char-cut:
+  - T1 fit         — within budget → no LLM, unchanged (no `summary_resummarized`).
+  - T2 re-summarize — overshoot → ONE LLM re-compression (distinct relaxation
+                      prompt; `summary_resummarized` emitted) = judgment-based loss.
+  - T3 hard_truncate — deterministic floor, ALWAYS applied last so
+                      `topic_arc ≤ body_budget` is never violated (even when T2
+                      still overshoots → `body_summary_hard_truncated`).
+
+Drives a REAL CompactionEngine; `litellm.acompletion` is monkeypatched at the
+boundary (a real async callable) to script the compaction JSON + the re-summarize
+text, distinguished by system prompt. `use_chars4_estimate=True` for deterministic
+offline token counts. No collaborator mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.config import CompactionConfig
+from reyn.events.events import EventLog
+from reyn.services.compaction.engine import (
+    _COMPACTION_SYSTEM_PROMPT,
+    _RESUMMARIZE_SYSTEM_PROMPT,
+    CompactionEngine,
+    HistoryChunkToCompact,
+    estimate_tokens,
+)
+
+_MODEL = "gpt-4o"
+
+
+def _resp(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _engine(passes: int = 1) -> tuple[CompactionEngine, EventLog]:
+    events = EventLog()
+    cfg = CompactionConfig(use_chars4_estimate=True, resummarize_passes=passes)
+    return CompactionEngine(_MODEL, events, cfg), events
+
+
+def _run(monkeypatch, engine, events, *, compaction_arc: str, resummarize_arc: str):
+    """Monkeypatch litellm.acompletion to script both calls; run compact once."""
+    calls = {"compaction": 0, "resummarize": 0}
+
+    async def _scripted(**kwargs):
+        sys_prompt = kwargs["messages"][0]["content"]
+        if sys_prompt == _RESUMMARIZE_SYSTEM_PROMPT:
+            calls["resummarize"] += 1
+            return _resp(resummarize_arc)
+        calls["compaction"] += 1
+        return _resp(json.dumps({
+            "topic_arc": compaction_arc,
+            "new_turn_seqs": [1],
+            "decisions": [], "pending": [],
+            "session_user_facts": [], "artifacts_referenced": [],
+        }))
+
+    monkeypatch.setattr("litellm.acompletion", _scripted)
+    chunk = HistoryChunkToCompact(
+        previous_summary=None,
+        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        section_token_caps={},
+    )
+    summary = asyncio.run(engine.compact(chunk))
+    return summary, calls, [e.type for e in events.all()]
+
+
+def test_t1_fit_no_resummarize(monkeypatch) -> None:
+    """Tier 2: a topic_arc within body_budget is unchanged — no re-summarize, no event."""
+    engine, events = _engine()
+    bb = engine.budgets.body_budget
+    arc = "x " * (bb // 2)  # ~bb/2 tokens (chars//4 of "x " repeats) — fits
+    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=arc, resummarize_arc="short")
+    assert calls["resummarize"] == 0, "T1 fit must not invoke the re-summarize LLM"
+    assert "summary_resummarized" not in types
+    assert estimate_tokens(summary.topic_arc, _MODEL, use_chars4=True) <= bb
+
+
+def test_t2_resummarize_fits(monkeypatch) -> None:
+    """Tier 2: an overshooting topic_arc is re-summarized (event emitted) and fits."""
+    engine, events = _engine()
+    bb = engine.budgets.body_budget
+    big = "word " * (bb * 4)            # ~4·bb tokens — overshoot
+    small = "compressed summary " * (bb // 8)  # fits under bb
+    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=big, resummarize_arc=small)
+    assert calls["resummarize"] == 1, "T2 must invoke the re-summarize LLM once"
+    assert "summary_resummarized" in types
+    # T2 result fit → no hard-truncate needed.
+    assert "body_summary_hard_truncated" not in types
+    assert estimate_tokens(summary.topic_arc, _MODEL, use_chars4=True) <= bb
+
+
+def test_t3_floor_when_resummarize_still_overshoots(monkeypatch) -> None:
+    """Tier 2: if T2 re-summarize still overshoots, T3 hard_truncate floors it.
+
+    The deterministic bound `topic_arc ≤ body_budget` holds even when the LLM
+    re-summary itself overshoots — the dead-end-free guarantee is never violated.
+    """
+    engine, events = _engine()
+    bb = engine.budgets.body_budget
+    big = "word " * (bb * 4)             # overshoot
+    still_big = "still too long " * (bb * 2)  # re-summary ALSO overshoots
+    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=big, resummarize_arc=still_big)
+    assert calls["resummarize"] == 1
+    assert "summary_resummarized" in types
+    assert "body_summary_hard_truncated" in types, "T3 floor must fire when T2 overshoots"
+    assert estimate_tokens(summary.topic_arc, _MODEL, use_chars4=True) <= bb, (
+        "the topic_arc ≤ body_budget guarantee must hold even when T2 overshoots"
+    )
+
+
+def test_passes_zero_skips_resummarize(monkeypatch) -> None:
+    """Tier 2: resummarize_passes=0 skips T2 (straight to the T3 floor = pre-#271)."""
+    engine, events = _engine(passes=0)
+    bb = engine.budgets.body_budget
+    big = "word " * (bb * 4)
+    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=big, resummarize_arc="short")
+    assert calls["resummarize"] == 0, "passes=0 must not invoke re-summarize"
+    assert "summary_resummarized" not in types
+    assert "body_summary_hard_truncated" in types  # T3 floor still bounds it
+    assert estimate_tokens(summary.topic_arc, _MODEL, use_chars4=True) <= bb


### PR DESCRIPTION
**[e2e-coder]** — #271 (compaction-completeness wave). Owner-approved spec = #1128 comment 4586001765 (sandbox_2 design). Resumed per the user's direct "#271 now" instruction; lead-coder confirmed sequencing (#271 land → then media-cap core).

## What
Replaces the lone mechanical blind char-cut of `topic_arc` (`engine.py` Axis-9 `hard_truncate`) with a 3-tier ladder — judgment-first loss, deterministic floor preserved:
- **T1 fit** — `topic_arc` ≤ `body_budget` → unchanged, no LLM (common case).
- **T2 re-summarize** — overshoot → ONE LLM re-compression via a **distinct relaxation prompt** (`_RESUMMARIZE_SYSTEM_PROMPT` — the main compaction SP forbids re-summarising the immutable base; T2 explicitly permits re-compression). LLM-judgment loss (preserve decision-relevant, keep verbatim paths/ids) = the user's "intentional summary compression is fine". Emits `summary_resummarized`. Bounded by `resummarize_passes` (default 1; `0` = skip = pre-#271).
- **T3 hard_truncate** — the existing deterministic floor, **always applied last** so `topic_arc ≤ body_budget` is **never** violated (the dead-end-free bound; now a rare backstop after T2).

Factored the litellm call into `CompactionEngine._acompletion` (shared by compact's JSON call + the new text-mode `_resummarize_topic_arc`). re-summarize is best-effort (returns original + `summary_resummarize_failed` on LLM error; T3 floors it regardless).

**Loss-quality improvement, NOT dead-end-critical** (T3 already guaranteed the bound) — per the owner's lossless/lossy direction.

## Config
`chat.compaction.resummarize_passes` (default 1), wired parser→`CompactionConfig` + documented in `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md` (satisfies the #1145 mirror-coverage guard).

## Test plan (Tier 2, no collaborator mocks)
- [x] `tests/test_resummarize_3tier_271.py` (4): real `CompactionEngine` + scripted `litellm.acompletion` (distinguished by system prompt) — T1 fit (no re-summarize, no event); T2 fits (`summary_resummarized` emitted, no hard-truncate); T3 floor (re-summary still overshoots → `body_summary_hard_truncated` + `topic_arc ≤ body_budget` guarantee holds); `passes=0` skips T2.
- [x] compaction/config/chat sweep → 597 passed; ruff + `test_tier_audit --strict` clean
- [x] full suite `pytest -q --ignore=.claude` → **6631 passed**; 1 unrelated failure: `test_web_fetch_preview_path_ref` (known local-only HTML-extractor lib diff, not in CI)

Next: media-cap core (#1128 4586158219, top-pri queue) immediately after this lands.

Refs #271 #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)