### PR TITLE
feat(tui): lift 3 informational palette tokens to WCAG AA (warm-aligned)

### DIFF
--- a/src/reyn/chat/tui/_palette.py
+++ b/src/reyn/chat/tui/_palette.py
@@ -91,7 +91,10 @@ _SEV_MED_HOVER = "#ffbb77"       # medium severity (hover)
 # aborted (app.py, conversation), the 8-colour-terminal error glyph fallback
 # (sticky_status), and the remote-limited mode marker (pending_tab). Distinct
 # shade from _STATUS_ERROR (active failure) and _SEV_HIGH (ErrorBox severity).
-_RED_MUTED = "#aa6666"
+# Lightened from #aa6666 (= 4.32:1, below WCAG AA) to clear 4.5:1 against the
+# panel bg (#111111 → 5.11:1) — this carries cancel/abort text, so it must be
+# legible. Kept in its own pink-red lane, distinct from the brand _CORAL.
+_RED_MUTED = "#b87272"
 # "ready / idle-but-available" agent/process state (olive). Orthogonal to
 # _STATUS_SUCCESS (running/done green) — the agents + pending panels show
 # ready ◐ in olive vs running in green so the two states stay scannable.
@@ -99,11 +102,17 @@ _STATUS_READY = "#aaaa55"
 # Dark success green — low-emphasis success tone for cost figures (cost_tab).
 # Darker sibling of _STATUS_SUCCESS (#44cc88) / _STATUS_SUCCESS_DIM (#88ddaa,
 # lighter); reads as "nominal" without competing with the brighter greens.
-_STATUS_SUCCESS_DARK = "#2d7a4f"
-# Actionable inline recovery hint (ErrorBox eb-inline-hint, muted gold).
+# Lightened from #2d7a4f (= 3.60:1, below WCAG AA) to 4.5:1+ against the panel
+# bg (#111111 → 5.34:1) — it labels cost figures (informational numbers), so
+# it must be legible. Stays the dimmest of the three success greens.
+_STATUS_SUCCESS_DARK = "#3a9968"
+# Actionable inline recovery hint (ErrorBox eb-inline-hint, warm olive-gold).
 # Distinct from _TEXT_DIM (the metadata eb-hint) so the extracted recovery
-# action reads as "do this", not just dim metadata.
-_HINT_ACTION = "#8a7a4a"
+# action reads as "do this", not just dim metadata. Lightened from #8a7a4a
+# (= 4.46:1, just below WCAG AA) to 4.5:1+ (#111111 → 5.51:1) while keeping
+# its own olive-gold lane — distinct from _SEV_MED amber, _AMBER agent
+# accent, and _STATUS_READY olive.
+_HINT_ACTION = "#9a8a52"
 
 __all__ = [
     "_CORAL",

--- a/tests/cli/test_palette_contrast_aa.py
+++ b/tests/cli/test_palette_contrast_aa.py
@@ -1,0 +1,75 @@
+"""Tier 2: accessibility — adjusted palette tokens meet WCAG AA on the panel bg.
+
+These tokens label informational text (cancel/abort messages, cost figures,
+the ErrorBox recovery hint) and were below WCAG AA 4.5:1 against the panel
+background; they were lightened (staying in their own hue lane + matching the
+warm worldview) to clear 4.5:1. This pins the contrast INVARIANT — the
+accessibility guarantee — not the exact hex (any future on-brand value that
+keeps ≥4.5:1 passes), so it is a behavioural assertion, NOT a format-pin.
+
+Reference: WCAG 2.1 SC 1.4.3 — 4.5:1 for normal text. Dark-mode guidance also
+favours muted/desaturated tones on a soft-black bg (these stay muted).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui._palette import (
+    _BG_PANEL,
+    _HINT_ACTION,
+    _RED_MUTED,
+    _STATUS_SUCCESS_DARK,
+)
+
+_AA_NORMAL = 4.5
+
+
+def _relative_luminance(hex_color: str) -> float:
+    """WCAG relative luminance of an ``#rrggbb`` colour."""
+    h = hex_color.lstrip("#")
+    channels = [int(h[i:i + 2], 16) / 255 for i in (0, 2, 4)]
+
+    def _linear(c: float) -> float:
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (_linear(c) for c in channels)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(fg: str, bg: str) -> float:
+    """WCAG contrast ratio between two ``#rrggbb`` colours (≥ 1.0)."""
+    l1, l2 = _relative_luminance(fg), _relative_luminance(bg)
+    hi, lo = max(l1, l2), min(l1, l2)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+@pytest.mark.parametrize(
+    "name, token",
+    [
+        ("_RED_MUTED", _RED_MUTED),
+        ("_STATUS_SUCCESS_DARK", _STATUS_SUCCESS_DARK),
+        ("_HINT_ACTION", _HINT_ACTION),
+    ],
+)
+def test_informational_token_meets_aa_on_panel_bg(name: str, token: str) -> None:
+    """Tier 2: token carrying informational text clears WCAG AA on the panel bg."""
+    ratio = _contrast_ratio(token, _BG_PANEL)
+    assert ratio >= _AA_NORMAL, (
+        f"{name} ({token}) contrast on {_BG_PANEL} is {ratio:.2f}:1, below WCAG "
+        f"AA {_AA_NORMAL}:1. This token labels informational text and must stay "
+        "legible — pick an on-brand value that keeps ≥4.5:1."
+    )
+
+
+def test_contrast_helper_sanity() -> None:
+    """Tier 2: the contrast helper matches known WCAG anchors (guards the math)."""
+    # Black vs white is the maximum 21:1; identical colours are 1:1.
+    assert round(_contrast_ratio("#000000", "#ffffff")) == 21
+    assert _contrast_ratio("#777777", "#777777") == pytest.approx(1.0)


### PR DESCRIPTION
**[tui-coder]** — Accessibility/contrast pass on the centralised palette. New TUI exploration topic (accessibility), grounded in: (1) the project site's worldview, (2) WCAG + dark-mode best practices, (3) a mechanical contrast audit of the now-consolidated tokens.

## Method (observe-grounded)

- **Audit**: computed WCAG contrast for every palette token vs the panel bg `#111111`. Triaged "FAIL" into genuine gaps (informational text < 4.5:1) vs intentionally-dim decorative vs already-mitigated.
- **Worldview** (`docs/stylesheets/extra.css`): coral primary `#C8553D` + **warm** neutrals (`#EFEDEA`→`#807B74`→`#0E0D0C`); dark-mode accent `#DD8C75` (coral, desaturated-for-dark).
- **Best practice** (sources below): 4.5:1 normal text; on dark bg, prefer **muted/desaturated** tones (saturated colours vibrate); soft-black bg (already `#111111`).

## Changes — 3 informational tokens lifted to AA

| token | before | after | contrast | carries |
|---|---|---|---|---|
| `_RED_MUTED` | `#aa6666` (4.32) | `#b87272` | **5.11** | cancel/abort text |
| `_STATUS_SUCCESS_DARK` | `#2d7a4f` (3.60) | `#3a9968` | **5.34** | cost figures |
| `_HINT_ACTION` | `#8a7a4a` (4.46) | `#9a8a52` | **5.51** | ErrorBox recovery hint |

Each lightened **within its own hue lane** (warm-aligned, still muted) and **collision-checked** against neighbours (`_HINT_ACTION` clear of `_SEV_MED`/`_AMBER`/`_STATUS_READY`; `_RED_MUTED` clear of brand `_CORAL`). Consumed by reference → propagates everywhere, no hardcoded-hex leftovers (grep-verified).

## Deliberately NOT changed (honest triage)

- `_TEXT_MID` `#777777` (4.22): lifting to ≥4.5 collapses it into `_TEXT_MUTED` `#888888` (5.33) — no "distinctly dimmer + AA" rung exists between them. Belongs to a larger **warm-grey ramp re-tone** (TUI greys are cool, site is warm) — separate, bigger scope.
- `_SEV_HIGH` `#cc5555` (4.49): at-threshold but already mitigated by ErrorBox's non-colour left-bar (documented in `error_box.py`).
- intentionally-dim decorative tokens (timestamps, `context_built` green).

> Note: chose to keep functional/identity hues (green=success, olive-gold hint) + warmth + AA over substituting literal brand swatches, because the literal-coral substitution collided with load-bearing tokens (`_AMBER`). Honest interpretation of "match the worldview" = warm + muted + accessible, without breaking distinctness/convention. **This is a deliberate visual change — please eyeball the actual colours.**

## Test plan

- [x] `pytest tests/cli/test_palette_contrast_aa.py` — 4 passed (3 tokens ≥4.5:1 + helper sanity)
- [x] `pytest tests/cli/test_palette_semantic_distinctions.py test_palette_severity_distinct.py` — distinctness invariants still green (new values stay distinct)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed (CSS parses with new values)
- [x] grep: no `#aa6666`/`#2d7a4f`/`#8a7a4a` literal outside `_palette.py` (token-driven)
- [x] `ruff check` clean / `scripts/test_tier_audit.py --strict` clean (0 errors)
- [ ] (skipped — visual) live eyeball of the new tones in `reyn chat` — **the user will review after merge** (per direction); contrast/parse covered by tests

## Tier self-check

Tier-2 invariant test asserting the **contrast ratio** (real WCAG math), not exact hex → not a format-pin. No private-state / no golden. ✓

Sources: [WCAG contrast guide](https://web-accessibility-checker.com/en/blog/color-contrast-wcag-guide) · [Dark-mode accessibility (AccessibilityChecker)](https://www.accessibilitychecker.org/blog/dark-mode-accessibility/) · [Designing for Dark Mode (Wildnet Edge)](https://www.wildnetedge.com/blogs/dark-mode-ui-essential-tips-for-color-palettes-and-accessibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)