### PR TITLE
fix(docs): update instructional gemini model prefix (openai/→gemini/)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,12 +38,12 @@ body:
         - Python version (`python --version`)
         - OS and version
         - Reyn version (`reyn --version`, or `pip show reyn`)
-        - LiteLLM model / provider used (e.g. `openai/gemini-2.5-flash-lite`)
+        - LiteLLM model / provider used (e.g. `gemini/gemini-2.5-flash-lite`)
       placeholder: |
         Python: 3.12.4
         OS: macOS 14.5 / Ubuntu 24.04 / ...
         Reyn: 0.1.0a1
-        Model: openai/gemini-2.5-flash-lite via LiteLLM proxy at localhost:4000
+        Model: gemini/gemini-2.5-flash-lite via LiteLLM proxy at localhost:4000
     validations:
       required: true
 

--- a/docs/deep-dives/contributing/dogfood-tooling.md
+++ b/docs/deep-dives/contributing/dogfood-tooling.md
@@ -43,7 +43,7 @@ After the bundle, both patterns drive from a single YAML config per use case. Pe
 ```yaml
 trace: /tmp/reyn-worktrees/b43-7/.reyn/llm_trace.jsonl
 req_id: 1847830e-8eb0-4056-b129-cc160dc7d3f9
-model: openai/gemini-2.5-flash-lite
+model: gemini/gemini-2.5-flash-lite
 n: 10
 parallel: 8
 classifiers:


### PR DESCRIPTION
**[docs-maintainer]** — follow-up to #1164. Instructional/template files that show `openai/<gemini>` as example config — new users copying these would get the 128K context limit bug.

## Files

- `.github/ISSUE_TEMPLATE/bug_report.yml` — example model string in bug report template
- `docs/deep-dives/contributing/dogfood-tooling.md` — config example block

## Not changed (historical — intentional)

`cookbook/*/transcript.example.txt` and `docs/deep-dives/journal/*` record what actually ran at the time. Changing these would falsify history.

## Test plan

- [x] 2-file diff, no behaviour change
- [x] `grep openai/gemini .github/ docs/deep-dives/contributing/` → 0 remaining instructional occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)