### PR TITLE
refactor(tui): shells.py DEFAULT_CSS → f-string consuming palette tokens

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/base.py
+++ b/src/reyn/chat/tui/widgets/right_panel/base.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import logging
 
 from reyn.chat.tui._palette import (
+    _BG_HEADER,
     _BORDER_DIM,
     _CORAL,
+    _DIVIDER_DIM,
     _EVENT_INTERVENTION,
     _EVENT_LLM,
     _EVENT_PLAN,
@@ -39,8 +41,10 @@ from reyn.chat.tui._text_util import _esc
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "_BG_HEADER",
     "_BORDER_DIM",
     "_CORAL",
+    "_DIVIDER_DIM",
     "_EVENT_INTERVENTION",
     "_EVENT_LLM",
     "_EVENT_PLAN",

--- a/src/reyn/chat/tui/widgets/right_panel/shells.py
+++ b/src/reyn/chat/tui/widgets/right_panel/shells.py
@@ -19,7 +19,15 @@ from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Label, RichLog, Static
 
-from .base import _esc, logger
+from .base import (
+    _BG_HEADER,
+    _BORDER_DIM,
+    _DIVIDER_DIM,
+    _TEXT_BODY,
+    _TEXT_DIM,
+    _esc,
+    logger,
+)
 
 if TYPE_CHECKING:
     from . import RightPanel
@@ -28,13 +36,13 @@ if TYPE_CHECKING:
 class _PanelHeader(Static):
     """Fixed header strip — 1 line of text + bottom border."""
 
-    DEFAULT_CSS = """
-    _PanelHeader {
-        background: #1a1a1a;
-        color: #aaaaaa;
+    DEFAULT_CSS = f"""
+    _PanelHeader {{
+        background: {_BG_HEADER};
+        color: {_TEXT_BODY};
         padding: 0 1;
-        border-bottom: solid #333333;
-    }
+        border-bottom: solid {_DIVIDER_DIM};
+    }}
     """
 
     def __init__(self, panel: "RightPanel", **kwargs) -> None:
@@ -116,15 +124,15 @@ class _PanelTop(Widget):
 
     can_focus = True
 
-    DEFAULT_CSS = """
-    _PanelTop {
+    DEFAULT_CSS = f"""
+    _PanelTop {{
         height: 1fr;
         layout: vertical;
-        border-left: solid #2a2a2a;
-    }
-    _PanelTop.x-focused {
+        border-left: solid {_BORDER_DIM};
+    }}
+    _PanelTop.x-focused {{
         border-left: solid $primary;
-    }
+    }}
     """
 
 
@@ -158,42 +166,42 @@ class _PreviewPane(Widget):
 
         pass
 
-    DEFAULT_CSS = """
-    _PreviewPane {
+    DEFAULT_CSS = f"""
+    _PreviewPane {{
         display: none;
         height: 1fr;
-        border-top: solid #2a2a2a;
-        border-left: solid #2a2a2a;
+        border-top: solid {_BORDER_DIM};
+        border-left: solid {_BORDER_DIM};
         layout: vertical;
-    }
-    _PreviewPane.preview-visible {
+    }}
+    _PreviewPane.preview-visible {{
         display: block;
-    }
-    _PreviewPane #preview-header {
+    }}
+    _PreviewPane #preview-header {{
         height: 1;
-        color: #555555;
-        background: #1a1a1a;
+        color: {_TEXT_DIM};
+        background: {_BG_HEADER};
         padding: 0 1;
-    }
-    _PreviewPane:focus {
+    }}
+    _PreviewPane:focus {{
         border-top: solid $primary;
         border-left: solid $primary;
-    }
-    _PreviewPane:focus #preview-header {
+    }}
+    _PreviewPane:focus #preview-header {{
         color: $primary;
-    }
-    _PreviewPane RichLog {
+    }}
+    _PreviewPane RichLog {{
         background: transparent;
         height: 1fr;
         padding: 0 1;
         overflow-x: auto;
-        scrollbar-color: #2a2a2a;
+        scrollbar-color: {_BORDER_DIM};
         scrollbar-color-hover: $primary;
         scrollbar-color-active: $primary;
         scrollbar-background: transparent;
         scrollbar-size-vertical: 1;
         scrollbar-size-horizontal: 1;
-    }
+    }}
     """
 
     def __init__(self, **kwargs) -> None:


### PR DESCRIPTION
**[tui-coder]** — Refs #1169 (first PR of the hardcoded-hex consolidation; user direction: "if there are many hardcoded spots, refactor to token-reference first").

## What

`right_panel/shells.py`'s four shell widgets hardcoded **9 hex** in their DEFAULT_CSS that exactly duplicate existing palette tokens. Converted the three affected blocks (`_PanelHeader` / `_PanelTop` / `_PreviewPane`) to f-strings consuming the tokens — same pattern as `error_box` (#1113). `base.py` now re-exports `_BG_HEADER` + `_DIVIDER_DIM`.

| literal | → token |
|---|---|
| `#1a1a1a` | `{_BG_HEADER}` |
| `#aaaaaa` | `{_TEXT_BODY}` |
| `#333333` | `{_DIVIDER_DIM}` |
| `#2a2a2a` | `{_BORDER_DIM}` |
| `#555555` | `{_TEXT_DIM}` |

`$primary` (Textual CSS var) stays literal; `#preview-header` (ID selector, not a colour) untouched.

## Value-preserving

Each token == its original literal hex. Verified: rendered DEFAULT_CSS keeps the same hexes, braces balanced, no unresolved `{_`/`{{`; **40 smoke tests green** (CSS parses at mount). No behaviour change.

## No test added

A value-preserving token-reference refactor has no behaviour to pin — an exact-hex assert would be a Tier-4 format-pin. Smoke confirms the CSS parses. Same convention as the palette migration PRs (#1105–1108).

## Test plan

- [x] rendered CSS value-preserving (token == old hex) + brace-balanced + no unresolved f-string (asserted on all 3 classes)
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed (CSS parses)
- [x] grep: 0 hex literal left in shells.py
- [x] `ruff check` clean

Refs #1169 — 9 of the 26 category-1 token-duplicates cleared. Next: intervention.py (7), then the core cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)