### PR TITLE
feat(chat): #272 media-cap core — per-turn media bound + load-contract (dead-end media axis)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -178,11 +178,18 @@ def _strip_frontmatter(content: str) -> str:
     return "\n".join(body_lines).rstrip("\n") + ("\n" if body_lines else "")
 
 
+# #272 media axis: per-image token estimate, mirroring the compaction engine's
+# ``_IMAGE_FIXED_TOKEN_COST`` (services/compaction/engine.py) so the per-turn
+# media bound is unit-consistent with how a turn's image cost is measured.
+_MEDIA_IMAGE_TOKEN_COST = 1024
+
+
 def _build_media_followup_message(
     *,
     tool_name: str,
     media_blocks: list[dict],
     media_store: Any = None,
+    budget_tokens: int | None = None,
 ) -> dict | None:
     """Build a multimodal follow-up user message for MCP tool results that
     include image / non-text content blocks (issue #362 → #383 PR-C).
@@ -209,6 +216,15 @@ def _build_media_followup_message(
         {"type": "text", "text": f"Tool `{tool_name}` returned the following image(s):"},
     ]
     rendered = 0
+    materialized = 0  # #272: images actually embedded (count against budget_tokens)
+
+    def _over_budget() -> bool:
+        # #272 per-turn media bound: materialise an image only while the running
+        # image cost stays within budget_tokens; overflow → small lossless ref.
+        if budget_tokens is None:
+            return False
+        return (materialized + 1) * _MEDIA_IMAGE_TOKEN_COST > budget_tokens
+
     for block in media_blocks:
         if not isinstance(block, dict):
             continue
@@ -224,6 +240,21 @@ def _build_media_followup_message(
                 # see path-refs in the first place, so this is defensive
                 # only.
                 continue
+            if _over_budget():
+                # #272: overflow media stays a small ref (lossless — the image
+                # remains on disk, materialisable later via the load-contract).
+                # NEVER materialise beyond the per-turn budget → result turn
+                # stays ≤ cap_tokens.
+                parts.append({
+                    "type": "text",
+                    "text": (
+                        f"[image not loaded — exceeds the per-turn media budget. "
+                        f"Stored at {path} ({mime}); load it with read_tool_result "
+                        f"when the context has room.]"
+                    ),
+                })
+                rendered += 1
+                continue
             try:
                 data_bytes, found = media_store.read_image(path)
             except PermissionError:
@@ -237,6 +268,7 @@ def _build_media_followup_message(
                 "image_url": {"url": f"data:{mime};base64,{data_b64}"},
             })
             rendered += 1
+            materialized += 1
             continue
         # Inline shape (pre-PR-C): use the base64 directly.
         data = block.get("data")
@@ -2182,10 +2214,20 @@ class RouterLoop:
                         # path-ref blocks are materialised to data URLs at
                         # the LLM wire boundary. ``getattr`` keeps tests
                         # that mock the host with bare attributes happy.
+                        # #272: bound the media follow-up to the budget left
+                        # after the (already-capped) tool text, so the whole
+                        # result turn stays ≤ the per-turn cap. Overflow media
+                        # stays a small lossless ref. getattr keeps partial/test
+                        # hosts unbounded (pre-#272 behaviour).
+                        _media_budget = getattr(host, "media_followup_budget", None)
+                        _budget_tokens = (
+                            _media_budget(content_str) if _media_budget is not None else None
+                        )
                         followup = _build_media_followup_message(
                             tool_name=tc.get("function", {}).get("name", "tool"),
                             media_blocks=media_blocks,
                             media_store=getattr(host, "media_store", None),
+                            budget_tokens=_budget_tokens,
                         )
                         if followup is not None:
                             messages.append(followup)

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -204,6 +204,10 @@ class RouterHostAdapter:
         # serialised tool-result string and returns it unchanged (within cap) or
         # an offloaded bounded preview. ``None`` = no cap (identity).
         cap_tool_result: Any = None,
+        # #272 media axis: callable (tool_content_str) -> int giving the tokens
+        # left for the media follow-up after the (capped) tool text, so
+        # router_loop bounds media materialisation. ``None`` = unbounded (pre-#272).
+        media_followup_budget: Any = None,
         # FP-0037 S1: persistent MCP tools cache directory.
         # Default is Path(".reyn/state") which resolves relative to cwd
         # (= the project root in all production entry points). Tests pass
@@ -296,6 +300,8 @@ class RouterHostAdapter:
         self._media_store = media_store
         # #1128 size axis: per-turn tool-result cap/offload callable (or None).
         self._cap_tool_result = cap_tool_result
+        # #272 media axis: per-turn media-budget provider (or None).
+        self._media_followup_budget = media_followup_budget
 
     # --- RouterLoopHost identity attributes ---
 
@@ -308,6 +314,16 @@ class RouterHostAdapter:
         if self._cap_tool_result is None:
             return content_str
         return self._cap_tool_result(content_str)
+
+    def media_followup_budget(self, tool_content: str) -> int | None:
+        """#272 media axis: tokens left for a tool turn's media follow-up after
+        its (capped) text, or None when no media bound is wired (= pre-#272
+        unbounded). router_loop passes this to the media-followup builder so
+        overflow media stays a small lossless ref and the turn stays ≤ cap.
+        """
+        if self._media_followup_budget is None:
+            return None
+        return self._media_followup_budget(tool_content)
 
     @property
     def media_store(self) -> Any:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1753,6 +1753,9 @@ class ChatSession:
             # Late-bound method — the engine budgets it reads are computed by
             # the time a tool result flows through router_loop at runtime.
             cap_tool_result=self._cap_tool_result,
+            # #272 media axis: per-turn media budget (= cap − tool text tokens)
+            # so router_loop bounds the media follow-up (overflow media → ref).
+            media_followup_budget=self._media_followup_budget,
             # B25-S5-1: thread eager-build flag so RouterLoop awaits build
             # before computing _search_visible on the first turn.
             eager_embedding_build=self._eager_embedding_build,
@@ -5026,10 +5029,28 @@ class ChatSession:
         store = self._media_store
         if store is None:
             return content_str
-        from reyn.chat.services.tool_result_cap import (
-            cap_tool_result_content,
-            compute_cap_tokens,
+        from reyn.chat.services.tool_result_cap import cap_tool_result_content
+
+        use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+        return cap_tool_result_content(
+            content_str,
+            cap_tokens=self._per_turn_cap_tokens(),
+            model=self.model,
+            save_fn=store.save_tool_result,
+            use_chars4=use_chars4,
+            events=self._chat_events,
         )
+
+    def _per_turn_cap_tokens(self) -> int:
+        """The B_M-relative per-turn cap (#1128/#272), shared by the tool-result
+        text cap and the per-turn media bound.
+
+        ``compute_cap_tokens(effective_trigger)`` — derived from the engine
+        budgets (falls back to the model's max-input tokens before budgets are
+        computed). A whole result turn (capped text + materialised media) is
+        held ≤ this so it stays single-turn compactable.
+        """
+        from reyn.chat.services.tool_result_cap import compute_cap_tokens
 
         controller = getattr(self, "_compaction_controller", None)
         engine = getattr(controller, "_engine", None) if controller is not None else None
@@ -5039,17 +5060,23 @@ class ChatSession:
         else:
             from reyn.llm.model_budget import get_max_input_tokens
             effective_trigger = get_max_input_tokens(self.model, events=self._chat_events)
+        return compute_cap_tokens(effective_trigger)
 
-        cap_tokens = compute_cap_tokens(effective_trigger)
+    def _media_followup_budget(self, tool_content: str) -> int:
+        """#272 media axis: tokens left for a tool turn's media follow-up after
+        its (already-capped) text.
+
+        ``per-turn cap − estimate_tokens(tool_content)`` (floored at 0) — so the
+        whole result turn (capped text + materialised media) stays ≤ the per-turn
+        cap and remains single-turn compactable. router_loop passes this to
+        ``_build_media_followup_message`` to bound media materialisation; overflow
+        media stays a small lossless ref.
+        """
+        from reyn.services.compaction.engine import estimate_tokens
+
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
-        return cap_tool_result_content(
-            content_str,
-            cap_tokens=cap_tokens,
-            model=self.model,
-            save_fn=store.save_tool_result,
-            use_chars4=use_chars4,
-            events=self._chat_events,
-        )
+        text_tokens = estimate_tokens(tool_content, self.model, use_chars4=use_chars4)
+        return max(0, self._per_turn_cap_tokens() - text_tokens)
 
     async def _maybe_force_compact_for_router(
         self,

--- a/src/reyn/tools/read_tool_result.py
+++ b/src/reyn/tools/read_tool_result.py
@@ -159,6 +159,26 @@ def _emit_event(ctx: ToolContext, **fields: Any) -> None:
         pass
 
 
+# #272 media axis load-contract: image refs are not text-loadable. The per-image
+# prompt cost is fixed (mirrors services/compaction/engine._IMAGE_FIXED_TOKEN_COST
+# and router_loop._MEDIA_IMAGE_TOKEN_COST) — what the LLM needs to know is the
+# context cost, not the on-disk byte size.
+_MEDIA_REF_IMAGE_TOKEN_COST = 1024
+_IMAGE_REF_EXTENSIONS = (
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".svg",
+)
+
+
+def _is_image_ref(identifier: str) -> bool:
+    """True when *identifier* (path / url / resource_uri) names an image file.
+
+    Detection is extension-based on the final path segment — sufficient because
+    media refs are minted by MediaStore.save_* with the mime-derived extension.
+    """
+    tail = identifier.rstrip("/").rsplit("/", 1)[-1].split("?", 1)[0].lower()
+    return tail.endswith(_IMAGE_REF_EXTENSIONS)
+
+
 def _source_agent_from_uri(resource_uri: str) -> str | None:
     """Extract the source_agent from a resource_uri for event tagging."""
     from reyn.workspace.media_store import parse_resource_uri
@@ -369,6 +389,32 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             identifier_kind=identifier_kind, identifier=identifier, error=err,
         )
         return {"status": "error", "error": err}
+
+    # #272 media-axis load-contract (never ref→ref, never overflow): an image
+    # ref is NOT text-loadable here. Reading its raw bytes as text would return
+    # binary garbage and — if large — overflow the prompt; returning another ref
+    # would loop. So return a SMALL structured error carrying the context cost
+    # (never the binary, never a ref). The image itself re-enters the
+    # conversation through the per-turn-bounded media follow-up (#272 Part-1),
+    # not as text — this keeps media structurally unable to overflow the prompt.
+    if _is_image_ref(identifier):
+        err = (
+            f"'{identifier}' is an image ref — not loadable as text via "
+            f"read_tool_result (~{_MEDIA_REF_IMAGE_TOKEN_COST} tokens of image "
+            f"data in context). Images re-enter the conversation through the "
+            f"bounded media follow-up, not as text; do not inline the raw bytes."
+        )
+        _emit_event(
+            ctx, status="error", error_kind="media_not_text_loadable",
+            identifier_kind=identifier_kind, identifier=identifier, error=err,
+            media_size_tokens=_MEDIA_REF_IMAGE_TOKEN_COST,
+        )
+        return {
+            "status": "error",
+            "error_kind": "media_not_text_loadable",
+            "error": err,
+            "media_size_tokens": _MEDIA_REF_IMAGE_TOKEN_COST,
+        }
 
     # Dispatch by identifier kind (= #385 β core impl sub-task 3c).
     #

--- a/tests/test_media_cap_272.py
+++ b/tests/test_media_cap_272.py
@@ -1,0 +1,153 @@
+"""Tier 2: OS invariant — #272 media-cap core (per-turn media bound + load-contract).
+
+Closes the media-axis conversation dead-end structurally (the text/count axes are
+closed by #1161 + #1157):
+  - Part-1 per-turn media bound: a tool turn's media follow-up is bounded to the
+    budget left after its (already chat-capped) text; overflow path-ref images
+    stay a small LOSSLESS ref (image remains on disk), NEVER materialised beyond
+    budget → result turn stays ≤ the per-turn cap.
+  - Part-2 load-contract: reading a media (image) ref back via read_tool_result
+    returns a small structured error (never the raw binary, never another ref),
+    so a read-back can neither overflow the prompt nor loop ref→ref.
+
+Together: media cannot structurally overflow the prompt (ref-default + bounded
+read-back). give-up = valid continue (bytes preserved on disk, conversation
+continues) — dead-end-free without requiring every image be usable.
+
+No collaborator mocks: pure _build_media_followup_message + real read_tool_result
+handler with a real MediaStore-backed OpContext.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.chat.router_loop import _MEDIA_IMAGE_TOKEN_COST, _build_media_followup_message
+from reyn.tools.read_tool_result import _handle, _is_image_ref
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.workspace.media_store import MediaStore, MediaStoreConfig
+
+
+class _StubStore:
+    """Minimal media_store: read_image returns fixed bytes for any path."""
+
+    def read_image(self, path: str):  # noqa: ARG002
+        return b"PNGBYTES", True
+
+
+def _img_blocks(n: int) -> list[dict]:
+    return [
+        {"type": "image", "path": f".reyn/tool-results/img{i}.png", "mime_type": "image/png"}
+        for i in range(n)
+    ]
+
+
+# ── Part-1: per-turn media bound ─────────────────────────────────────────────
+
+
+def _imgs(fu: dict) -> list[dict]:
+    return [p for p in fu["content"] if p.get("type") == "image_url"]
+
+
+def _overflow_refs(fu: dict) -> list[dict]:
+    return [p for p in fu["content"] if p.get("type") == "text" and "not loaded" in p.get("text", "")]
+
+
+def test_media_followup_materialises_only_within_budget() -> None:
+    """Tier 2: materialised image cost stays within budget; overflow → refs, none dropped."""
+    blocks = _img_blocks(3)
+    budget = _MEDIA_IMAGE_TOKEN_COST + 200  # room for one image only
+    fu = _build_media_followup_message(
+        tool_name="t", media_blocks=blocks, media_store=_StubStore(), budget_tokens=budget,
+    )
+    imgs, refs = _imgs(fu), _overflow_refs(fu)
+    assert imgs, "an image that fits the budget materialises"
+    assert len(imgs) * _MEDIA_IMAGE_TOKEN_COST <= budget, (
+        "materialised image cost must stay within the per-turn budget"
+    )
+    assert refs, "images over budget become small refs (not materialised)"
+    assert len(imgs) + len(refs) == len(blocks), "every block represented — none silently dropped"
+
+
+def test_media_followup_unbounded_when_no_budget() -> None:
+    """Tier 2: budget_tokens=None preserves the pre-#272 unbounded behaviour (no overflow refs)."""
+    blocks = _img_blocks(3)
+    fu = _build_media_followup_message(
+        tool_name="t", media_blocks=blocks, media_store=_StubStore(), budget_tokens=None,
+    )
+    assert not _overflow_refs(fu), "unbounded → nothing deferred to a ref"
+    assert len(_imgs(fu)) == len(blocks), "all blocks materialise when unbounded"
+
+
+def test_overflow_ref_is_lossless_pointer() -> None:
+    """Tier 2: an over-budget image becomes a ref naming its on-disk path (lossless)."""
+    fu = _build_media_followup_message(
+        tool_name="t", media_blocks=_img_blocks(1), media_store=_StubStore(),
+        budget_tokens=0,  # nothing fits → the image becomes a ref
+    )
+    assert not _imgs(fu), "budget 0 → no image materialises"
+    refs = _overflow_refs(fu)
+    assert refs, "the over-budget image is preserved as a ref"
+    assert ".reyn/tool-results/img0.png" in refs[0]["text"], (
+        "overflow ref must carry the on-disk path so the image is not lost"
+    )
+
+
+# ── Part-2: load-contract (image ref read-back → small error, never ref/binary) ──
+
+
+def _ctx(media_store):
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+
+    class _Events:
+        subscribers: list = []
+
+        def emit(self, *a, **k):
+            pass
+
+    ev = _Events()
+
+    def _factory():
+        return OpContext(
+            workspace=None, events=ev, permission_decl=PermissionDecl(),
+            permission_resolver=None, skill_name="", subscribers=[],
+            media_store=media_store,
+        )
+
+    return ToolContext(
+        events=ev, permission_resolver=None, workspace=None, caller_kind="router",
+        router_state=RouterCallerState(op_context_factory=_factory), phase_state=None,
+    )
+
+
+def test_image_ref_read_back_returns_small_error_never_binary(tmp_path: Path) -> None:
+    """Tier 2: read_tool_result on an image ref → small structured error, not binary, not a ref."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    result = asyncio.run(_handle({"path": ".reyn/tool-results/pic.png"}, _ctx(store)))
+    assert result["status"] == "error"
+    assert result["error_kind"] == "media_not_text_loadable"
+    assert "media_size_tokens" in result, "the LLM needs the context cost of the image"
+    # never ref→ref: the result carries no path-ref / offload pointer to re-load.
+    assert "_offload_ref" not in result and "tool_result_ref" not in str(result)
+
+
+def test_text_ref_read_back_is_not_guarded(tmp_path: Path) -> None:
+    """Tier 2: a TEXT tool-result ref still reads normally (the guard is image-only)."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    block = store.save_tool_result("hello body\n", mime_type="text/plain", chain_id="c", tool="x", seq=1)
+    result = asyncio.run(_handle({"path": block["path"]}, _ctx(store)))
+    assert result["status"] == "ok"
+    assert result["content"] == "hello body\n"
+
+
+def test_is_image_ref_extensions() -> None:
+    """Tier 2: _is_image_ref recognises image extensions across path / url / uri tails."""
+    for ident in (
+        ".reyn/tool-results/a.png", "x.JPG", "y.jpeg", "z.gif", "w.webp",
+        "https://h/agents/me/tool-results/p.png?v=1",
+        "reyn-tool-result://me/q.bmp",
+    ):
+        assert _is_image_ref(ident), ident
+    for ident in (".reyn/tool-results/a.txt", "notes.json", "data.bin", "readme"):
+        assert not _is_image_ref(ident), ident


### PR DESCRIPTION
**[e2e-coder]** — #272 media-cap **core** (conversation dead-end, media axis). Owner-GO'd; canonical design = sandbox_2 #1128 comments 4586034800 + 4586068342, dispatch spec #1128 4586158219 (lead-coder review-passed). Implementation = e2e. Standalone core PR; independent of #1157 dogfood.

Closes the media-axis dead-end structurally (text/count via #1161 + #1157; size via #271):

## Part-1 — per-turn media bound (`router_loop` + `session` + `RouterHostAdapter`)
A tool turn's media follow-up is bounded to the budget left after its (already chat-capped) text, so the whole result turn stays ≤ the per-turn cap and remains single-turn compactable.
- `_build_media_followup_message` gains `budget_tokens`: materialises images while the running cost (`_MEDIA_IMAGE_TOKEN_COST=1024`/image, mirroring the engine's `_IMAGE_FIXED_TOKEN_COST`) stays within budget; overflow path-ref images stay a small **lossless** text ref (image remains on disk). **Never** materialises beyond budget. `None` = unbounded (pre-#272 / partial-host).
- `session._per_turn_cap_tokens` (factored from `_cap_tool_result`) + `_media_followup_budget(tool_content)` = `cap − estimate_tokens(text)`, threaded via `RouterHostAdapter.media_followup_budget` → router_loop passes it to the builder (getattr-guarded).

## Part-2 — load-contract (`read_tool_result`)
Reading an **image** ref back returns a small structured error (`error_kind=media_not_text_loadable`, carrying the context cost) — never the raw binary (garbage + overflow), never another ref (loop). So a read-back can neither overflow nor ref→ref. The image re-enters only through the per-turn-bounded follow-up (Part-1).

## Structural dead-end-free
ref-default (turn ≤ cap) + bounded read-back (image-or-small-error) ⇒ media cannot overflow the prompt. give-up = valid continue (bytes preserved on disk, conversation continues).

## Out of scope (follow-ups)
On-demand image re-materialisation as a content block (fits→image affordance — needs a new content-block load op, like the compact op); compact op; downscale; K-image selection.

## Test plan (Tier 2, no collaborator mocks)
- [x] `tests/test_media_cap_272.py` (6): Part-1 budget bound (materialised cost ≤ budget; overflow→lossless ref naming the on-disk path; none dropped; unbounded preserved); Part-2 (image ref → `media_not_text_loadable`, never binary/ref; text ref still reads; `_is_image_ref` extensions).
- [x] media/router/chat/tool sweep → 917 passed; `read_tool_result` regression suite green (guard is image-only)
- [x] full suite `pytest -q --ignore=.claude` → **6633 passed** (1 unrelated known local-only `test_web_fetch_preview_path_ref`, not in CI)
- [x] ruff + `test_tier_audit --strict` clean; consumer audit incl `tests/` (backward-compatible — `budget_tokens`/new error_kind are additive; the 2 existing `_build_media_followup_message` callers pass no budget = unbounded)

Refs #272 #1128 #1161 #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)