### PR TITLE
refactor(tui): token-ref genuine hex dups in app_outbox + async_stack_panel

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -24,6 +24,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui._palette import _TEXT_DIM, _TEXT_MUTED
 
 from .widgets import ConversationView, ReynHeader, RightPanel
 
@@ -505,10 +506,10 @@ class OutboxRouter:
             conv.clear()
             from rich.text import Text as _RichText
             for line in interrupted:
-                conv._write_log(_RichText(line, style="dim #888888"))
+                conv._write_log(_RichText(line, style=f"dim {_TEXT_MUTED}"))
             conv._write_log(_RichText(
                 f"── attached to {new_name} ──",
-                style="dim #555555",
+                style=f"dim {_TEXT_DIM}",
             ))
 
     def _on_matrix(

--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -187,16 +187,16 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
     the height — input bar regains full vertical space.
     """
 
-    DEFAULT_CSS = """
-    AsyncStackPanel {
+    DEFAULT_CSS = f"""
+    AsyncStackPanel {{
         dock: bottom;
         height: auto;
         max-height: 6;
         padding: 0 1;
         background: transparent;
         overflow: hidden;
-    }
-    AsyncStackPanel #async_stack_text {
+    }}
+    AsyncStackPanel #async_stack_text {{
         /* Force the inner Static to clip rather than wrap when a
            pre-truncated row's residual width briefly exceeds the
            constrained panel width (= e.g. between Ctrl+B side-panel
@@ -207,10 +207,10 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
            rebuild on the new width, wrap is eliminated. */
         height: auto;
         overflow: hidden;
-    }
-    AsyncStackPanel:focus {
-        background: #1a1a1a;
-    }
+    }}
+    AsyncStackPanel:focus {{
+        background: {_BG_HEADER};
+    }}
     """
 
     # Focusable so the F4 binding can route focus here and j/k


### PR DESCRIPTION
**[tui-coder]** — Refs #1169. Continues the hardcoded-hex consolidation (user direction: refactor hardcoded colours to token-reference).

## Changes (2 genuine category-1 token-dups)

- `app_outbox.py`: attach-replay markers `style="dim #888888"` / `style="dim #555555"` → `f"dim {_TEXT_MUTED}"` / `f"dim {_TEXT_DIM}"` (Python Rich-style strings).
- `async_stack_panel.py`: `:focus` background `#1a1a1a` → `{_BG_HEADER}` (DEFAULT_CSS → f-string; token already imported).

Value-preserving — tokens == original hexes (async_stack CSS renders same `#1a1a1a`, braces balanced, no unresolved f-string; 40 smoke green).

## Audit-count correction (recorded in #1169)

The earlier "26 category-1" was inflated by hex mentions inside **docstrings / CSS comments** + one **coincidental collision**. Genuine active dups ≈ 8. Non-targets identified:
- `events_tab.py` / `right_panel/__init__.py`: hex only in a docstring / CSS comment (not active code).
- `foldable_markdown.py` `#cc9955`: coincidentally equals `_SEV_MED` but is an unrelated hover-hint colour — tokenising would mis-couple to ErrorBox severity, so **left literal** (substitute-vs-orthogonal: coincidental, not a semantic dup).

## Test plan

- [x] async_stack rendered CSS value-preserving (`#1a1a1a` kept) + brace-balanced + no unresolved f-string
- [x] app_outbox imports OK; both files' genuine hex → 0
- [x] `pytest tests/cli/test_tui_smoke.py` — 40 passed
- [x] `ruff check` clean

No test added (value-preserving token-ref refactor; smoke covers parse). Same convention as #1105–1108 / #1170.

Refs #1169 — remaining genuine: `intervention.py` (5, delicate mixed CSS block, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)