### PR TITLE
fix(compaction): #1172 CompactionEngine resolver-aware — resolve model class by construction (3-axis dead-end fix)

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -521,6 +521,12 @@ class _PlanStepHost:
     def events(self) -> Any:
         return self._parent.events
 
+    @property
+    def resolver(self) -> Any:
+        # #1172: delegate to parent so a nested CompactionEngine resolves
+        # model classes through the same chain.
+        return self._parent.resolver
+
     # ── Catalog narrowing — what tools / skills / agents are visible ──────
 
     def list_available_skills(self) -> list[dict]:
@@ -862,6 +868,10 @@ async def execute_plan(
                 events=parent_host.events,
                 T_SP=0,
                 cfg=None,  # use default CompactionConfig for budget derivation
+                # #1172: router_model defaults to the class "light" — resolve
+                # via the host's resolver so the engine never hands an
+                # unresolved class to litellm.
+                resolver=parent_host.resolver,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort; skip if unavailable
             logger.warning(

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -506,6 +506,11 @@ class RouterLoopHost(Protocol):
     # Resolve router model (config "router" → real model id)
     def resolve_model(self, name: str) -> str: ...
 
+    # The bound ModelResolver (#1172) — components that build their own LLM
+    # callers (e.g. the planner's lazy CompactionEngine) resolve through it.
+    @property
+    def resolver(self) -> Any: ...
+
     # Plan-mode lifecycle persistence (ADR-0022 Phase 1).
     # Optional — implementations that don't support plan-mode crash
     # recovery (e.g. test stubs) leave these as no-ops. Real chat

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -755,6 +755,17 @@ class RouterHostAdapter:
 
     # --- Model resolution ---
 
+    @property
+    def resolver(self) -> Any:
+        """The bound ``ModelResolver``.
+
+        Exposed (#1172) so components that construct their own LLM callers —
+        e.g. the planner's lazy ``CompactionEngine`` — can resolve model
+        classes through the same chain as the router. ``resolve_model`` is the
+        scalar convenience wrapper; this is the full resolver object.
+        """
+        return self._resolver
+
     def resolve_model(self, name: str) -> str:
         """Resolve config model name (e.g. 'router') to actual model id."""
         return self._resolver.resolve(name).model

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1801,9 +1801,15 @@ class ChatSession:
             history_access=lambda: self.history,
             latest_summary=self._latest_summary,
             compaction_engine=CompactionEngine(
+                # #1172: pass self.model (a model CLASS like "standard") plus
+                # the resolver — CompactionEngine resolves to a litellm string
+                # by construction. Without resolution the engine would hand
+                # "standard" straight to litellm (BadRequestError) and every
+                # compaction trigger would fail (dead-end-critical).
                 model=self.model,
                 events=self._chat_events,
                 system_prompt_provider=self._build_router_system_prompt,
+                resolver=self._resolver,
             ),
             history_appender=self._append_history,
             make_summary_message=lambda rendered, structured, covers: ChatMessage(

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -244,6 +244,10 @@ class OSRuntime:
                     events=self.events,
                     T_SP=0,
                     cfg=None,  # default CompactionConfig for budget derivation
+                    # #1172: phase axis — `model` is the raw runtime param (a
+                    # class); resolve via the same resolver the main phase LLM
+                    # call uses (runtime.py main-call: self._resolver.resolve).
+                    resolver=self._resolver,
                 )
             except Exception:  # noqa: BLE001 — best-effort; skip if unavailable
                 phase_compaction_engine = None

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
         PlannerStepCompactionConfig,
     )
     from reyn.events.events import EventLog
+    from reyn.llm.model_resolver import ModelResolver
 
 logger = logging.getLogger(__name__)
 
@@ -667,9 +668,20 @@ class CompactionEngine:
     Parameters
     ----------
     model:
-        LiteLLM model string (e.g. ``"gemini/gemini-2.5-flash-lite"``).
+        Model CLASS name (``"standard"`` / ``"light"`` / ``"strong"``) OR a
+        literal LiteLLM string.  It is resolved to a LiteLLM string via
+        ``resolver`` at construction (#1172) — the engine NEVER hands an
+        unresolved class to ``litellm.acompletion`` (which rejects it with
+        ``BadRequestError model=standard``, failing every compaction trigger).
     events:
         Session-scoped EventLog for observability.
+    resolver:
+        Required ``ModelResolver`` used to resolve ``model`` to its LiteLLM
+        string in ``__init__`` (same chain the router/main LLM call uses).
+        By-construction guarantee (#1172): because resolution happens inside
+        the engine, no construction site (chat / planner / phase) can leak an
+        unresolved model class to litellm.  Pass ``ModelResolver({})`` for an
+        already-resolved literal string (passthrough).
     cfg:
         CompactionConfig; used for use_chars4_estimate. When None a default
         config is used (for backward-compat test construction).
@@ -694,8 +706,22 @@ class CompactionEngine:
         *,
         T_SP: int = 0,
         system_prompt_provider: Callable[[], str] | None = None,
+        resolver: "ModelResolver | None" = None,
     ) -> None:
-        self._model = model
+        # #1172: resolve the model CLASS ("standard"/"light"/"strong") to its
+        # LiteLLM string at construction — by-construction guarantee that no
+        # downstream litellm.acompletion call (or estimate_tokens below) ever
+        # receives an unresolved class (litellm rejects "standard" with
+        # BadRequestError, failing every compaction trigger). A literal string
+        # passes through unchanged. resolver defaults to an empty passthrough
+        # ModelResolver so already-resolved callers/tests need not pass one;
+        # every PRODUCTION construction site MUST pass its real resolver
+        # (enforced by tests/test_compaction_resolver_aware_1172.py so a future
+        # caller cannot reintroduce the unresolved-class leak).
+        if resolver is None:
+            from reyn.llm.model_resolver import ModelResolver as _MR
+            resolver = _MR({})
+        self._model = resolver.resolve(model).model
         self._events = events
         # Axis 10: opt-out flag
         from reyn.config import CompactionConfig as _CC

--- a/tests/test_compaction_resolver_aware_1172.py
+++ b/tests/test_compaction_resolver_aware_1172.py
@@ -1,0 +1,168 @@
+"""Tier 2: OS invariant — #1172 CompactionEngine is resolver-aware (by-construction).
+
+THE BUG (dead-end-critical, all 3 compaction axes): chat / planner / phase each
+constructed ``CompactionEngine(model=<class>)`` with an UNRESOLVED model class
+("standard" / "light"). The engine forwards ``model`` straight to
+``litellm.acompletion``, which rejects a class name
+(``BadRequestError model=standard``) — so compaction failed on EVERY trigger and
+the entire dead-end-prevention stack (axis-1/2, retry_loop, chat-cap,
+re-summarize) was non-functional at runtime. Fake-engine unit tests missed it
+because they never exercised the real model→litellm path.
+
+THE FIX (by-construction): ``CompactionEngine.__init__`` resolves ``model`` via a
+``ModelResolver`` at construction, so the engine NEVER hands an unresolved class
+to litellm regardless of caller. This file pins both halves with REAL
+collaborators (no Fake engine, no mock resolver):
+
+  1. Behavioral — a real ``CompactionEngine`` built from a model CLASS + a real
+     ``ModelResolver`` calls ``litellm.acompletion`` with the RESOLVED litellm
+     string, never the raw class. Covers all 3 axes (one shared engine).
+  2. Regression guard (AST) — every ``CompactionEngine(...)`` construction in
+     ``src/`` passes a ``resolver=`` kwarg, so a future 4th caller cannot
+     reintroduce the unresolved-class leak. Catches the aliased construction
+     (``_CCE(...)`` in kernel/runtime.py) too.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from reyn.config import CompactionConfig
+from reyn.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.services.compaction.engine import CompactionEngine, HistoryChunkToCompact
+
+# ── Behavioral: real engine + real resolver → litellm sees the RESOLVED string ──
+
+
+def _resp(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _run_capture(monkeypatch, engine: CompactionEngine) -> str:
+    """Drive one real compact(); return the ``model`` litellm.acompletion saw."""
+    seen: dict[str, str] = {}
+
+    async def _capture(**kwargs):
+        seen["model"] = kwargs["model"]
+        return _resp(json.dumps({
+            "topic_arc": "arc", "new_turn_seqs": [1],
+            "decisions": [], "pending": [],
+            "session_user_facts": [], "artifacts_referenced": [],
+        }))
+
+    monkeypatch.setattr("litellm.acompletion", _capture)
+    chunk = HistoryChunkToCompact(
+        previous_summary=None,
+        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        section_token_caps={},
+    )
+    asyncio.run(engine.compact(chunk))
+    return seen["model"]
+
+
+def test_model_class_is_resolved_before_litellm(monkeypatch) -> None:
+    """Tier 2: a CompactionEngine built from the CLASS "standard" calls litellm
+    with the resolved litellm string — never the raw class (#1172 bug)."""
+    resolver = ModelResolver({"standard": "openai/resolved-standard"})
+    engine = CompactionEngine(
+        model="standard",  # the class that broke litellm pre-#1172
+        events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True),
+        resolver=resolver,
+    )
+    model_seen = _run_capture(monkeypatch, engine)
+    assert model_seen == "openai/resolved-standard", (
+        "the engine must resolve the model class before calling litellm; "
+        f"litellm saw {model_seen!r} (a raw class would be rejected)"
+    )
+    assert model_seen != "standard", "the unresolved class must never reach litellm"
+
+
+def test_planner_default_light_class_is_resolved(monkeypatch) -> None:
+    """Tier 2: the planner axis's default class "light" is resolved too."""
+    resolver = ModelResolver({"light": "openai/resolved-light"})
+    engine = CompactionEngine(
+        model="light",  # planner.py router_model default
+        events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True),
+        resolver=resolver,
+    )
+    assert _run_capture(monkeypatch, engine) == "openai/resolved-light"
+
+
+def test_literal_litellm_string_passes_through(monkeypatch) -> None:
+    """Tier 2: an unknown literal litellm string is unchanged (passthrough);
+    resolver omitted defaults to an empty (builtin-only) resolver, so a string
+    that is neither a configured class nor a builtin reaches litellm as-is."""
+    engine = CompactionEngine(
+        model="myvendor/custom-not-a-builtin",
+        events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True),
+    )  # no resolver → passthrough default (ModelResolver({}))
+    assert _run_capture(monkeypatch, engine) == "myvendor/custom-not-a-builtin"
+
+
+# ── Regression guard: every src CompactionEngine construction passes resolver= ──
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _compaction_engine_constructions(path: Path) -> list[ast.Call]:
+    """Every CompactionEngine(...) construction in *path*, resolving import
+    aliases (e.g. ``from ... import CompactionEngine as _CCE``) so the kernel
+    runtime's ``_CCE(...)`` call is caught alongside bare ``CompactionEngine(``.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").endswith(
+            "compaction.engine"
+        ):
+            for alias in node.names:
+                if alias.name == "CompactionEngine":
+                    aliases.add(alias.asname or alias.name)
+    if not aliases:
+        return []
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and (
+            node.func.id in aliases
+        ):
+            calls.append(node)
+    return calls
+
+
+def test_every_src_construction_passes_resolver() -> None:
+    """Tier 2: every CompactionEngine(...) construction under src/ passes a
+    ``resolver=`` kwarg — the by-construction guarantee that no compaction axis
+    leaks an unresolved model class to litellm (#1172). A new construction site
+    that omits resolver= reintroduces the dead-end-critical bug and fails here.
+    """
+    src = _repo_root() / "src" / "reyn"
+    found = 0
+    for py in src.rglob("*.py"):
+        for call in _compaction_engine_constructions(py):
+            found += 1
+            kwargs = {kw.arg for kw in call.keywords if kw.arg is not None}
+            assert "resolver" in kwargs, (
+                f"{py.relative_to(_repo_root())}:{call.lineno} constructs "
+                "CompactionEngine without resolver= — an unresolved model class "
+                "would be handed to litellm (BadRequestError). Pass the caller's "
+                "ModelResolver so the engine resolves the class by construction."
+            )
+    assert found >= 3, (
+        f"expected the 3 known compaction axes (chat/planner/phase), found {found}"
+        " — did a construction site move? update this guard."
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1172 CRITICAL (sandbox_2 pre-frame dogfood finding + lead-coder code-confirmed). Canonical design = #1172 comment 4586340147 ((B) by-construction, lead-coder recommended). Push-through top priority.

## The bug (dead-end-critical, all 3 compaction axes)
All 3 compaction-engine construction sites passed an **unresolved model CLASS**:
| axis | site | model arg | evidence |
|---|---|---|---|
| chat | `session.py:1803` | `self.model="standard"` | ✅ live (`compaction_failed model=standard`) |
| planner | `planner.py:866` | `router_model` default `"light"` | ✅ code-confirmed |
| phase | `kernel/runtime.py:242` (`_CCE`) | raw runtime `model` | ✅ confirmed (main-call resolves at :493, engine got raw) |

The engine forwards `model` straight to `litellm.acompletion`, which rejects a class (`BadRequestError model=standard`). So compaction failed on **every trigger** → axis-1/2, `retry_loop`, chat-cap, re-summarize all non-functional at runtime (latent: real compaction needs >30K middle, rare; dogfood first triggered it).

## Fix — (B) by-construction
`CompactionEngine.__init__` resolves `model` via a `ModelResolver` at construction (same chain as router/main-call). The engine **never** hands an unresolved class to litellm regardless of caller — also fixes the `estimate_tokens(model)` calls in `__init__` that got the bogus class.
- `resolver` defaults to an empty (builtin-only) passthrough → already-resolved callers/tests need not pass one (zero churn to the 5 existing engine-test files); **all 3 production sites pass their real resolver**.
- Host exposes its `ModelResolver` via a new `resolver` property (`RouterLoopHost` protocol + `RouterHostAdapter` + `_PlanStepHost` delegate) so the planner's lazy engine resolves through the same chain.

## Dead-end relevance
This unblocks the dead-end-prevention stack at runtime — the text/size/media fixes (#1161/#271/#272) only help once compaction actually runs.

## Test plan (Tier 2, real collaborators — the Fake-engine unit tests missed this path)
- [x] `tests/test_compaction_resolver_aware_1172.py` (4): real `CompactionEngine` + real `ModelResolver` → litellm sees the **resolved** string for class `"standard"` and planner's `"light"` (never the raw class); unknown literal passes through; **AST regression guard** asserts every `src/` `CompactionEngine(...)` construction passes `resolver=` (resolves import aliases → catches `_CCE` + a future 4th caller).
- [x] compaction + planner + router + chatsession + model_resolver + phase_act + osruntime_phase suites → 336 passed
- [x] broad chat/kernel/services/plan sweep → 1233 passed, 1 xfailed
- [x] tier-audit (format-pin + private-state-ast) green; ruff clean
- [ ] full suite `pytest -q` (running as merge gate — will post result)

Refs #1172 #1161 #271 #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)