### PR TITLE
feat(chat): #272/#1128 compact op — LLM-requested voluntary compaction + context-size signal (chat axis)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -30,6 +30,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `index_drop` | Remove an indexed source entirely (destructive) | `permissions.index_drop: ask` in skill frontmatter |
 | `judge_output` | LLM scorer: rubric + threshold + `on_fail` policy | none (LLM cost) |
 | `skill_resolve` | Resolve a skill name to its on-disk path (read-only) | none |
+| `compact` | Voluntarily compact the conversation/phase history (advisory) | none (LLM cost; the mandatory `retry_loop` backstop is independent) |
 
 ## Common envelope
 
@@ -475,6 +476,45 @@ Returns:
 **OpPurity**: `world` (filesystem metadata read; result may vary if skills are added/removed between calls).
 
 **Use case**: stdlib python steps that need a skill's absolute path can offload the filesystem walk to this op and stay in `mode: safe`. See R-PURE-MODE Class D refactor — `skill_improver/copy_to_work_resolver` and `eval_builder/analyze_skill_resolver` are the primary consumers.
+
+---
+
+## `compact`
+
+Voluntarily compact the conversation/phase history *now*, freeing context
+window. The OS injects a **context-size signal** (a `## Context window` header
+with the exact-token free window) when the window is filling; the model may
+respond by emitting `compact` instead of waiting for the mandatory `retry_loop`
+backstop. The op routes to the caller-wired compaction (chat:
+`force_compact_now`) and reports the freed tokens + the free window afterwards,
+in exact tokens (unit-aligned with the media load-contract error so "should I
+compact" and "what fits now" use the same scale).
+
+```json
+{
+  "kind": "compact"
+}
+```
+
+Fields:
+- `reason` (str, optional): Short model-supplied rationale for the audit trail. The OS never interprets it.
+
+Returns:
+- `status: "ok" | "error"`
+- `freed_tokens: int` — tokens removed from the window by the compaction
+- `free_window_after: int` — exact-token headroom after compaction
+- `free_window_before: int` — headroom before (for delta reasoning)
+- On error: `error_kind` (`compaction_unavailable` when no compaction context is wired here; `compaction_failed`) + `error`.
+
+**Events**: `compact_op_requested` / `compact_op_completed` (`freed_tokens`, `free_window_after`) / `compact_op_failed` / `compact_op_unavailable` (P6). The inner compaction engine emits its own compaction events.
+
+**Permission**: none required (LLM cost only). Voluntary and independent of the involuntary `retry_loop` backstop, which always runs regardless.
+
+**OpPurity**: `external` (LLM cost + history/state mutation; like `recall`, a macro whose inner engine emits its own events).
+
+**Visibility**: advertised to the LLM (tool / `available_control_ops`) only when the window is filling — paired with the context-size signal — so it is not offered when there is nothing to compact (mirrors the `search_actions` visibility gate). The permission gate stays "allow"; only *when surfaced* is gated.
+
+**Axis scope (chat vs phase)**: the LLM-requested `compact` op is wired for the **chat** axis, which is the live conversation dead-end and the only axis with an on-demand compaction seam (`force_compact_now`). **Phases already auto-compact** older act-results every frame (`compact_control_ir_results`, gated on act-result count) — there is no on-demand force-compact seam there — so the LLM-requested-compact gap in phases is small and covered by the existing automatic compaction. An on-demand **phase** force-compact seam (mid-phase `control_ir_results` summarisation + a phase context-size signal) is a deliberate **follow-up** rather than a rushed mid-phase-state mutation.
 
 ---
 

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1572,6 +1572,10 @@ class RouterLoop:
                         skill_metadata_lookup=_skill_meta_map or None,
                         mcp_tool_lookup=_mcp_tool_map or None,
                     )
+        # #272/#1128: compute the OS context-size signal once. It is None when
+        # the window is ample (then compact stays hidden + the SP header is
+        # omitted); non-None when filling (compact tool + header appear together).
+        _ctx_signal = _render_context_size_signal_for_host(host)
         tools = build_tools(
             skills_for_tools,
             host.list_available_agents(),
@@ -1581,6 +1585,7 @@ class RouterLoop:
             universal_wrappers_enabled=_univ_enabled,
             search_actions_visible=_search_visible,
             hot_list_aliases=_hot_list_aliases,
+            compact_visible=_ctx_signal is not None,
         )
         # D2-wrapper scope expansion (B38): propagate schemas for ALL
         # session-visible actions into invoke_action's description so the
@@ -1649,11 +1654,10 @@ class RouterLoop:
                 # configured + index ready); False there means the SP and tools=
                 # both exclude search_actions, eliminating the N5 hallucination.
                 search_actions_enabled=_search_visible if _univ_enabled else True,
-                # #272/#1128: OS-injected context-size signal (header). Computed
-                # from the host's live free-window so the LLM can voluntarily
-                # `compact` before the backstop. Rendered LAST in the SP (most
-                # volatile section → preserves the cached prefix above it).
-                context_size_signal=_render_context_size_signal_for_host(host),
+                # #272/#1128: OS-injected context-size signal (header), computed
+                # once above. Rendered LAST in the SP (most volatile section →
+                # preserves the cached prefix above it); None when ample.
+                context_size_signal=_ctx_signal,
             )
         # ChatSession._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -184,6 +184,27 @@ def _strip_frontmatter(content: str) -> str:
 _MEDIA_IMAGE_TOKEN_COST = 1024
 
 
+def _render_context_size_signal_for_host(host: "RouterLoopHost") -> "str | None":
+    """#272/#1128: render the OS-injected context-size header from the host's
+    live free-window, or None when the host exposes no status (test stubs).
+    Best-effort — never breaks a turn.
+    """
+    status_fn = getattr(host, "context_window_status", None)
+    if status_fn is None:
+        return None
+    try:
+        status = status_fn()
+        if not status:
+            return None
+        from reyn.services.compaction.context_signal import render_context_size_signal
+        return render_context_size_signal(
+            free_window=status["free_window"],
+            effective_trigger=status["effective_trigger"],
+        )
+    except Exception:  # noqa: BLE001 — signal is advisory; absence is harmless
+        return None
+
+
 def _build_media_followup_message(
     *,
     tool_name: str,
@@ -1628,6 +1649,11 @@ class RouterLoop:
                 # configured + index ready); False there means the SP and tools=
                 # both exclude search_actions, eliminating the N5 hallucination.
                 search_actions_enabled=_search_visible if _univ_enabled else True,
+                # #272/#1128: OS-injected context-size signal (header). Computed
+                # from the host's live free-window so the LLM can voluntarily
+                # `compact` before the backstop. Rendered LAST in the SP (most
+                # volatile section → preserves the cached prefix above it).
+                context_size_signal=_render_context_size_signal_for_host(host),
             )
         # ChatSession._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2569,6 +2569,8 @@ class RouterLoop:
         # (= host.make_router_op_context) so the permission resolver and
         # intervention_bus are present for the index_drop gate.
         "recall", "drop_source",
+        # #272/#1128: voluntary history compaction (handler → execute_op → compact op).
+        "compact",
         # FP-0034 Phase 1: universal catalog wrappers.  Handlers in
         # src/reyn/tools/universal_catalog.py — list_actions enumerates
         # via ctx.router_state, describe_action / invoke_action route

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -31,6 +31,7 @@ def build_system_prompt(
     universal_wrappers_enabled: bool = False,  # FP-0034 PR-3b-v
     cwd: str | None = None,
     search_actions_enabled: bool = True,  # FP-0034 §D14 — default True preserves byte-compat
+    context_size_signal: str | None = None,  # #272/#1128 — pre-rendered, appended LAST
 ) -> str:
     """Render the system prompt for the tool_use router loop.
 
@@ -470,6 +471,15 @@ def build_system_prompt(
             f"  - Always reply in language: {output_language}."
             "  Do NOT switch language even for error messages or clarifying questions."
         )
+
+    # ── 14. Context-size signal (#272/#1128) ─────────────────────────────────
+    # OS-injected, pre-rendered by the caller (router_loop / phase runtime) from
+    # the live free-window. Placed LAST because it is the most per-turn-volatile
+    # section — keeping it at the tail preserves the cached SP prefix above it.
+    # P8-clean: OS-level vocabulary, no skill-specific enumeration; the `compact`
+    # op format itself is advertised separately via the tool/control_ir catalog.
+    if context_size_signal:
+        parts.append(context_size_signal)
 
     return "\n".join(parts)
 

--- a/src/reyn/chat/router_tools.py
+++ b/src/reyn/chat/router_tools.py
@@ -764,6 +764,17 @@ def build_tools(
             dispatch_kind=_drop_source_def.dispatch_kind,
         ))
 
+    # ── #272/#1128: compact (voluntary history compaction) ─────────────────────
+    _compact_def = _registry.lookup("compact")
+    if _compact_def is not None and _compact_def.gates.router == "allow":
+        _compact_rendered = _compact_def.render_for_router()
+        specs.append(ToolSpec(
+            name=_compact_rendered["function"]["name"],
+            description=_compact_rendered["function"]["description"],
+            parameters=_compact_rendered["function"]["parameters"],
+            dispatch_kind=_compact_def.dispatch_kind,
+        ))
+
     # ── D. MCP tools (permission-gated) ──────────────────────────────────────
     #
     # FP-0024 Component D: threshold-based switch.

--- a/src/reyn/chat/router_tools.py
+++ b/src/reyn/chat/router_tools.py
@@ -250,6 +250,7 @@ def build_tools(
     universal_wrappers_enabled: bool = False,  # FP-0034 PR-3b-i: opt-in catalog wrappers
     search_actions_visible: bool = False,       # FP-0034 Phase 2 step 1: D14 visibility gate
     hot_list_aliases: list[dict] | None = None,  # FP-0034 Phase 2 step 3: hot list direct aliases
+    compact_visible: bool = False,              # #272/#1128: visibility-gate compact on window-fill
 ) -> list[dict]:
     """Build the tools= argument for litellm.acompletion.
 
@@ -765,8 +766,14 @@ def build_tools(
         ))
 
     # ── #272/#1128: compact (voluntary history compaction) ─────────────────────
+    # Visibility-gated (like search_actions §D14): only advertised when the
+    # window is filling (compact_visible, paired with the context-size signal).
+    # Offering compact on an empty window is noise + nothing to compact; gates
+    # stay router=allow (permission), this controls when it's surfaced. Keeping
+    # it hidden on ample-window turns also leaves tools= (and LLMReplay fixtures
+    # keyed on it) byte-stable.
     _compact_def = _registry.lookup("compact")
-    if _compact_def is not None and _compact_def.gates.router == "allow":
+    if compact_visible and _compact_def is not None and _compact_def.gates.router == "allow":
         _compact_rendered = _compact_def.render_for_router()
         specs.append(ToolSpec(
             name=_compact_rendered["function"]["name"],

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -213,6 +213,10 @@ class RouterHostAdapter:
         # emittable `compact` control_ir op can voluntarily compact history.
         # ``None`` = no compaction context (compact op returns a clear error).
         compact_now: Any = None,
+        # #272/#1128 context-size signal: callable () -> {free_window,
+        # effective_trigger} (exact tokens) for the OS-injected SP header.
+        # ``None`` = no signal rendered (e.g. test stubs).
+        context_window_status: Any = None,
         # FP-0037 S1: persistent MCP tools cache directory.
         # Default is Path(".reyn/state") which resolves relative to cwd
         # (= the project root in all production entry points). Tests pass
@@ -309,6 +313,8 @@ class RouterHostAdapter:
         self._media_followup_budget = media_followup_budget
         # #272/#1128 compact op: voluntary-compaction callable (or None).
         self._compact_now = compact_now
+        # #272/#1128 context-size signal: live budget provider (or None).
+        self._context_window_status = context_window_status
 
     # --- RouterLoopHost identity attributes ---
 
@@ -776,6 +782,16 @@ class RouterHostAdapter:
     def resolve_model(self, name: str) -> str:
         """Resolve config model name (e.g. 'router') to actual model id."""
         return self._resolver.resolve(name).model
+
+    def context_window_status(self) -> "dict | None":
+        """#272/#1128: live exact-token context budget for the SP context-size
+        signal, or None when no provider is wired (= signal omitted)."""
+        if self._context_window_status is None:
+            return None
+        try:
+            return self._context_window_status()
+        except Exception:  # noqa: BLE001 — signal is best-effort, never break a turn
+            return None
 
     # --- Plan-mode lifecycle persistence (ADR-0022 Phase 1) ---
     #

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -208,6 +208,11 @@ class RouterHostAdapter:
         # left for the media follow-up after the (capped) tool text, so
         # router_loop bounds media materialisation. ``None`` = unbounded (pre-#272).
         media_followup_budget: Any = None,
+        # #272/#1128 compact op: awaitable () -> {freed_tokens, free_window_after}
+        # wired by ChatSession to its force_compact_now wrapper, so the LLM-
+        # emittable `compact` control_ir op can voluntarily compact history.
+        # ``None`` = no compaction context (compact op returns a clear error).
+        compact_now: Any = None,
         # FP-0037 S1: persistent MCP tools cache directory.
         # Default is Path(".reyn/state") which resolves relative to cwd
         # (= the project root in all production entry points). Tests pass
@@ -302,6 +307,8 @@ class RouterHostAdapter:
         self._cap_tool_result = cap_tool_result
         # #272 media axis: per-turn media-budget provider (or None).
         self._media_followup_budget = media_followup_budget
+        # #272/#1128 compact op: voluntary-compaction callable (or None).
+        self._compact_now = compact_now
 
     # --- RouterLoopHost identity attributes ---
 
@@ -1393,4 +1400,6 @@ class RouterHostAdapter:
             multimodal_config=self._multimodal_config,
             # Issue #383 PR-C: shared MediaStore for path-ref save/read.
             media_store=self._media_store,
+            # #272/#1128: voluntary-compaction capability for the compact op.
+            compact_now=self._compact_now,
         )

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1759,6 +1759,9 @@ class ChatSession:
             # #272/#1128 compact op: voluntary-compaction callback so the LLM-
             # emittable `compact` control_ir op can compact chat history.
             compact_now=self._compact_now_for_op,
+            # #272/#1128 context-size signal: live exact-token budget so the
+            # router SP can show the LLM the free window (header).
+            context_window_status=self._context_window_status,
             # B25-S5-1: thread eager-build flag so RouterLoop awaits build
             # before computing _search_visible on the first turn.
             eager_embedding_build=self._eager_embedding_build,
@@ -5114,6 +5117,18 @@ class ChatSession:
         except Exception:  # noqa: BLE001 — estimation best-effort
             estimated = 0
         return effective_trigger, estimated
+
+    def _context_window_status(self) -> dict:
+        """#272/#1128: live exact-token context budget for the context-size
+        signal (header). ``{free_window, effective_trigger}`` — free_window is
+        the headroom before the involuntary backstop, unit-aligned with the
+        compact op result + media load-contract error.
+        """
+        effective_trigger, used = self._free_window_now()
+        return {
+            "free_window": max(0, effective_trigger - used),
+            "effective_trigger": effective_trigger,
+        }
 
     async def _compact_now_for_op(self) -> dict:
         """#272/#1128: voluntary-compaction callback wired to the compact op.

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1756,6 +1756,9 @@ class ChatSession:
             # #272 media axis: per-turn media budget (= cap − tool text tokens)
             # so router_loop bounds the media follow-up (overflow media → ref).
             media_followup_budget=self._media_followup_budget,
+            # #272/#1128 compact op: voluntary-compaction callback so the LLM-
+            # emittable `compact` control_ir op can compact chat history.
+            compact_now=self._compact_now_for_op,
             # B25-S5-1: thread eager-build flag so RouterLoop awaits build
             # before computing _search_visible on the first turn.
             eager_embedding_build=self._eager_embedding_build,
@@ -5083,6 +5086,51 @@ class ChatSession:
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
         text_tokens = estimate_tokens(tool_content, self.model, use_chars4=use_chars4)
         return max(0, self._per_turn_cap_tokens() - text_tokens)
+
+    def _free_window_now(self) -> "tuple[int, int]":
+        """Return ``(effective_trigger, estimated_history_tokens)`` for the
+        current router history (#272/#1128 compact op + context-size signal).
+
+        ``free_window = effective_trigger − estimated_history_tokens`` is the
+        exact-token headroom before the involuntary backstop fires — the unit
+        the context-size signal and the load-contract error both speak.
+        """
+        import json as _json
+
+        from reyn.services.compaction.engine import estimate_tokens
+
+        controller = getattr(self, "_compaction_controller", None)
+        engine = getattr(controller, "_engine", None) if controller is not None else None
+        budgets = getattr(engine, "budgets", None)
+        if budgets is not None:
+            effective_trigger = budgets.effective_trigger
+        else:
+            from reyn.llm.model_budget import get_max_input_tokens
+            effective_trigger = get_max_input_tokens(self.model, events=self._chat_events)
+        use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+        try:
+            combined = _json.dumps(self._build_history_for_router(), ensure_ascii=False)
+            estimated = estimate_tokens(combined, self.model, use_chars4=use_chars4)
+        except Exception:  # noqa: BLE001 — estimation best-effort
+            estimated = 0
+        return effective_trigger, estimated
+
+    async def _compact_now_for_op(self) -> dict:
+        """#272/#1128: voluntary-compaction callback wired to the compact op.
+
+        Runs the existing synchronous compaction and reports the freed tokens +
+        the free window afterwards in EXACT tokens (unit-aligned with the
+        context-size signal + media load-contract error). Raises propagate to
+        the op handler, which surfaces them as a structured op error.
+        """
+        effective_trigger, before = self._free_window_now()
+        await self._compaction_controller.force_compact_now()
+        _, after = self._free_window_now()
+        return {
+            "freed_tokens": max(0, before - after),
+            "free_window_after": max(0, effective_trigger - after),
+            "free_window_before": max(0, effective_trigger - before),
+        }
 
     async def _maybe_force_compact_for_router(
         self,

--- a/src/reyn/op_runtime/__init__.py
+++ b/src/reyn/op_runtime/__init__.py
@@ -114,6 +114,9 @@ def available_kinds() -> list[str]:
 # Eagerly import handler modules so they self-register.
 from . import ask_user as _ask_user  # noqa: F401, E402
 
+# #272/#1128: voluntary LLM-initiated compaction op.
+from . import compact as _compact  # noqa: F401, E402
+
 # ADR-0033: RAG-extensible OS — embed / index_* / recall ops
 from . import embed as _embed  # noqa: F401, E402
 from . import file as _file  # noqa: F401, E402

--- a/src/reyn/op_runtime/compact.py
+++ b/src/reyn/op_runtime/compact.py
@@ -1,0 +1,87 @@
+"""compact op — voluntary, LLM-initiated history compaction (#272 / #1128).
+
+When the OS-injected context-size signal shows the window is filling, the model
+may emit a ``compact`` control_ir op instead of waiting for the mandatory
+``retry_loop`` backstop. The op routes through ``ctx.compact_now`` — an
+awaitable the caller (ChatSession / phase runtime) wires to its existing
+synchronous compaction (``force_compact_now``). The result reports freed tokens
+and the free window afterwards in EXACT tokens, unit-aligned with the
+context-size signal + the media load-contract error, so the model reasons
+consistently about "should I compact" and "what fits now".
+
+P7/P8: no skill-specific strings. The op is OS-level vocabulary only; the
+optional ``reason`` is model-supplied audit text the OS never interprets.
+
+OpPurity: external (LLM cost + history mutation; the inner compaction engine
+emits its own events).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from reyn.schemas.models import CompactIROp
+
+from . import register
+from .context import OpContext
+
+
+async def handle(
+    op: CompactIROp,
+    ctx: OpContext,
+    caller: Literal["preprocessor", "control_ir"],
+) -> dict:
+    """Run a voluntary compaction via ``ctx.compact_now``.
+
+    Returns a result dict; never raises. If no compaction capability is wired
+    (``ctx.compact_now is None``) the op returns a clear error rather than a
+    silent no-op (same contract as ask_user without an intervention_bus) so the
+    model isn't misled into thinking the window was freed.
+    """
+    if ctx.compact_now is None:
+        ctx.events.emit("compact_op_unavailable", run_id=ctx.run_id, phase=ctx.current_phase)
+        return {
+            "kind": "compact",
+            "status": "error",
+            "error_kind": "compaction_unavailable",
+            "error": (
+                "compact requested but no compaction context is wired here "
+                "(ctx.compact_now is None). Voluntary compaction is only "
+                "available where a session/phase compaction engine exists."
+            ),
+        }
+
+    ctx.events.emit(
+        "compact_op_requested",
+        run_id=ctx.run_id,
+        phase=ctx.current_phase,
+        reason=op.reason,
+    )
+    try:
+        result = await ctx.compact_now()
+    except Exception as exc:  # noqa: BLE001 — surface as op error, never crash the turn
+        ctx.events.emit(
+            "compact_op_failed", run_id=ctx.run_id, phase=ctx.current_phase, error=str(exc)
+        )
+        return {
+            "kind": "compact",
+            "status": "error",
+            "error_kind": "compaction_failed",
+            "error": str(exc),
+        }
+
+    # ``result`` carries exact-token fields from the caller's wrapper
+    # ({freed_tokens, free_window_after, ...}). Pass them through verbatim so
+    # the unit-alignment with the context-size signal is preserved.
+    out: dict = {"kind": "compact", "status": "ok"}
+    out.update(result or {})
+    ctx.events.emit(
+        "compact_op_completed",
+        run_id=ctx.run_id,
+        phase=ctx.current_phase,
+        freed_tokens=out.get("freed_tokens"),
+        free_window_after=out.get("free_window_after"),
+    )
+    return out
+
+
+register("compact", handle)

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from reyn.config import MultimodalConfig, SandboxConfig, WebConfig
     from reyn.events.events import EventLog
     from reyn.llm.model_resolver import ModelResolver
@@ -67,6 +69,15 @@ class OpContext:
     # User interventions (ask_user, permission prompts in PR7)
     intervention_bus: "RequestBus | None" = None
     current_phase: str = ""
+
+    # #272/#1128: voluntary-compaction capability for the `compact` op.
+    # An awaitable zero-arg callable the caller (ChatSession / phase runtime)
+    # wires to its synchronous compaction (force_compact_now), returning
+    # {"freed_tokens", "free_window_after", ...} in exact tokens. None when no
+    # compaction context is available (e.g. preprocessor / direct construction)
+    # → the compact op returns a clear error rather than silently no-op'ing
+    # (same contract as ask_user without an intervention_bus).
+    compact_now: "Callable[[], Awaitable[dict]] | None" = None
 
     # PR20: caller provenance threaded from the parent Agent so sub-skill
     # invocations land under the same `events/<caller>/skill_runs/...` tree.

--- a/src/reyn/op_runtime/registry.py
+++ b/src/reyn/op_runtime/registry.py
@@ -55,6 +55,7 @@ from pydantic import BaseModel
 
 from reyn.schemas.models import (
     AskUserIROp,
+    CompactIROp,
     EmbedIROp,
     FileIROp,
     IndexDropIROp,
@@ -131,6 +132,9 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "judge_output": JudgeOutputIROp,
     # R-PURE-MODE Wave 5a: resolve a skill name to its on-disk path.
     "skill_resolve": SkillResolveIROp,
+    # #272/#1128: LLM-emittable voluntary compaction (advisory; the mandatory
+    # retry_loop backstop is independent).
+    "compact": CompactIROp,
 }
 
 # ---------------------------------------------------------------------------
@@ -180,6 +184,11 @@ OP_PURITY: dict[str, OpPurity] = {
     "judge_output": OpPurity.llm,
     # R-PURE-MODE Wave 5a: read-only path resolution, no external API calls.
     "skill_resolve": OpPurity.world,
+    # #272/#1128: compact triggers a compaction LLM call (cost) AND mutates
+    # history/state; like `recall` it is a macro whose inner compaction engine
+    # emits its own events. external = emit both started+completed so a crash
+    # mid-compaction surfaces as ambiguous on resume.
+    "compact": OpPurity.external,
 }
 
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -524,17 +524,39 @@ class SkillResolveIROp(BaseModel):
     name: str   # short skill name, e.g. "skill_improver" (no slashes or extensions)
 
 
+class CompactIROp(BaseModel):
+    """Voluntarily compact the conversation/phase history (#272 / #1128).
+
+    LLM-emittable advisory control_ir op: when the OS-injected context-size
+    signal shows the window is filling, the model can request a compaction
+    rather than waiting for the involuntary ``retry_loop`` backstop. The OS
+    runs the existing synchronous compaction (``force_compact_now``) and
+    returns the freed tokens + the free window afterwards (exact tokens,
+    unit-aligned with the load-contract / context-size signal) so the model
+    can reason consistently about "should I compact" and "what fits now".
+
+    Voluntary (LLM-initiated) and independent of the mandatory retry_loop
+    backstop — this op never replaces it.
+
+    P7/P8 note: carries no skill-specific fields. ``reason`` is optional
+    free-text the model may supply for the audit trail; the OS never
+    interprets it.
+    """
+    kind: Literal["compact"]
+    reason: str | None = None   # optional model-supplied rationale (audit only)
+
+
 # Discriminated union — Pydantic selects the variant via the "kind" field.
 # All variants below are implemented in `op_runtime/`:
 #   file, mcp, ask_user, shell, lint, run_skill, web_fetch, web_search,
 #   mcp_install, embed, index_write, index_query, recall, index_drop,
-#   sandboxed_exec, judge_output, skill_resolve.
+#   sandboxed_exec, judge_output, skill_resolve, compact.
 ControlIROp = Annotated[
     Union[
         FileIROp, MCPIROp, AskUserIROp, ShellIROp, LintIROp,
         RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
         EmbedIROp, IndexWriteIROp, IndexQueryIROp, RecallIROp, IndexDropIROp,
-        SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp,
+        SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,
     ],
     Field(discriminator="kind"),
 ]

--- a/src/reyn/services/compaction/context_signal.py
+++ b/src/reyn/services/compaction/context_signal.py
@@ -1,0 +1,49 @@
+"""Context-size signal renderer (#272 / #1128) — the design core.
+
+The OS injects an exact-token "how full is the context window" signal into the
+router / phase prompt so the LLM can decide whether to emit a voluntary
+``compact`` op before the mandatory ``retry_loop`` backstop fires. The numbers
+are EXACT tokens, unit-aligned with the media load-contract error
+(``free_window`` / ``media_size``), so the model reasons consistently about
+"should I compact" and "what fits now".
+
+P8-clean: OS-level vocabulary only, no skill-specific enumeration. The ``compact``
+op format itself is advertised separately (tool catalog / available_control_ops);
+this section only states the budget + a neutral pointer.
+
+Shared by both axes — chat (router_loop → build_system_prompt) and phase
+(runtime → phase prompt) render the identical header so the model sees a
+symmetric signal everywhere.
+"""
+from __future__ import annotations
+
+#: Below this fraction of the window remaining, the header nudges toward compaction.
+_LOW_FRACTION = 0.25
+
+
+def render_context_size_signal(*, free_window: int, effective_trigger: int) -> str:
+    """Render the context-size header from exact-token budget numbers.
+
+    Args:
+        free_window: exact tokens of headroom before auto-compaction fires
+            (= effective_trigger − estimated current history tokens).
+        effective_trigger: the total compaction threshold (window size) in
+            exact tokens.
+
+    Returns the rendered header section (a single multi-line string).
+    """
+    free_window = max(0, int(free_window))
+    effective_trigger = max(0, int(effective_trigger))
+    used = max(0, effective_trigger - free_window)
+    lines = [
+        "## Context window",
+        f"  - used: ~{used} tokens of ~{effective_trigger}",
+        f"  - free before auto-compaction: ~{free_window} tokens",
+    ]
+    if effective_trigger > 0 and free_window <= int(effective_trigger * _LOW_FRACTION):
+        lines.append(
+            "  - The free window is low. If you still have work to do, call "
+            "`compact` to summarise older history and free room before "
+            "continuing (large tool results / steps fit better afterwards)."
+        )
+    return "\n".join(lines)

--- a/src/reyn/services/compaction/context_signal.py
+++ b/src/reyn/services/compaction/context_signal.py
@@ -17,11 +17,19 @@ symmetric signal everywhere.
 """
 from __future__ import annotations
 
-#: Below this fraction of the window remaining, the header nudges toward compaction.
+#: Only render the signal once the window is at least this used (= free_window
+#: at or below this fraction of the trigger). Above it the window is ample, so
+#: the header is omitted entirely — no per-turn SP noise / fixture churn when
+#: compaction is irrelevant. The signal appears exactly when it becomes
+#: actionable (the LLM still has room to act before the backstop).
+_SHOW_FRACTION = 0.5
+#: At or below this fraction free, the header adds an explicit compact nudge.
 _LOW_FRACTION = 0.25
 
 
-def render_context_size_signal(*, free_window: int, effective_trigger: int) -> str:
+def render_context_size_signal(
+    *, free_window: int, effective_trigger: int
+) -> "str | None":
     """Render the context-size header from exact-token budget numbers.
 
     Args:
@@ -30,17 +38,22 @@ def render_context_size_signal(*, free_window: int, effective_trigger: int) -> s
         effective_trigger: the total compaction threshold (window size) in
             exact tokens.
 
-    Returns the rendered header section (a single multi-line string).
+    Returns the rendered header section, or ``None`` when the window is still
+    ample (free_window above ``_SHOW_FRACTION`` of the trigger) — the caller
+    omits the section so the SP stays stable + noise-free until compaction
+    becomes relevant.
     """
     free_window = max(0, int(free_window))
     effective_trigger = max(0, int(effective_trigger))
+    if effective_trigger <= 0 or free_window > int(effective_trigger * _SHOW_FRACTION):
+        return None
     used = max(0, effective_trigger - free_window)
     lines = [
         "## Context window",
         f"  - used: ~{used} tokens of ~{effective_trigger}",
         f"  - free before auto-compaction: ~{free_window} tokens",
     ]
-    if effective_trigger > 0 and free_window <= int(effective_trigger * _LOW_FRACTION):
+    if free_window <= int(effective_trigger * _LOW_FRACTION):
         lines.append(
             "  - The free window is low. If you still have work to do, call "
             "`compact` to summarise older history and free room before "

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -46,6 +46,7 @@ def get_default_registry() -> ToolRegistry:
         LIST_AGENTS,
         LIST_SKILLS,
     )
+    from reyn.tools.compact import COMPACT
     from reyn.tools.cron import (
         CRON_DISABLE,
         CRON_ENABLE,
@@ -92,7 +93,6 @@ def get_default_registry() -> ToolRegistry:
         REMEMBER_AGENT,
         REMEMBER_SHARED,
     )
-    from reyn.tools.compact import COMPACT
     from reyn.tools.plan import PLAN
     from reyn.tools.read_tool_result import READ_TOOL_RESULT
     from reyn.tools.recall import RECALL

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -92,6 +92,7 @@ def get_default_registry() -> ToolRegistry:
         REMEMBER_AGENT,
         REMEMBER_SHARED,
     )
+    from reyn.tools.compact import COMPACT
     from reyn.tools.plan import PLAN
     from reyn.tools.read_tool_result import READ_TOOL_RESULT
     from reyn.tools.recall import RECALL
@@ -128,6 +129,7 @@ def get_default_registry() -> ToolRegistry:
     # RAG ops (ADR-0033 Phase 1)
     registry.register(RECALL)
     registry.register(DROP_SOURCE)
+    registry.register(COMPACT)
     # File ops (Wave 2 — Open Q #6 fine-grained naming)
     registry.register(READ_FILE)
     registry.register(WRITE_FILE)

--- a/src/reyn/tools/compact.py
+++ b/src/reyn/tools/compact.py
@@ -1,0 +1,90 @@
+"""compact ToolDefinition (#272 / #1128) — voluntary history compaction.
+
+Router- and phase-callable LLM entry point that lets the model voluntarily
+compact the conversation/phase history when the OS-injected context-size signal
+shows the window filling, instead of waiting for the mandatory retry_loop
+backstop. The handler delegates to ``op_runtime.compact``, which routes to the
+caller-wired ``OpContext.compact_now`` capability and returns the freed tokens +
+free window afterwards in exact tokens.
+
+Per ADR-0026: the ToolDefinition lives here; registration is in
+get_default_registry() in tools/__init__.py.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_COMPACT_DESCRIPTION = (
+    "Compact the conversation history now: summarise older turns to free up "
+    "context window. Use this when the 'Context window' status shows the free "
+    "window getting low and you still have work to do — compacting first frees "
+    "room so subsequent steps and large tool results fit. Returns the freed "
+    "tokens and the free window afterwards (exact tokens). The system also "
+    "compacts automatically as a backstop; this lets you do it proactively."
+)
+
+_COMPACT_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "reason": {
+            "type": "string",
+            "description": (
+                "Optional short rationale for the audit trail (e.g. 'window "
+                "low before reading large file'). Not interpreted by the OS."
+            ),
+        },
+    },
+    "required": [],
+}
+
+
+async def _handle_compact(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Dispatch the compact op via op_runtime.
+
+    Builds a CompactIROp and calls the registered compact handler with the
+    OpContext from ctx.phase_state (phase-side) or ctx.router_state factory
+    (router-side). The op handler errors cleanly if no compaction capability
+    is wired, so this never silently no-ops.
+    """
+    from reyn.op_runtime import execute_op
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+    from reyn.schemas.models import CompactIROp
+
+    reason = args.get("reason")
+    op = CompactIROp(kind="compact", reason=str(reason) if reason else None)
+
+    _op_ctx = ctx.phase_state.op_context if ctx.phase_state is not None else None
+    if _op_ctx is not None and isinstance(_op_ctx, OpContext):
+        legacy_ctx = _op_ctx
+    elif (
+        ctx.router_state is not None
+        and ctx.router_state.op_context_factory is not None
+    ):
+        legacy_ctx = ctx.router_state.op_context_factory()
+    else:
+        # Minimal context (no compaction capability) → the op handler returns
+        # a clear compaction_unavailable error rather than a silent no-op.
+        legacy_ctx = OpContext(
+            workspace=ctx.workspace,
+            events=ctx.events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=ctx.permission_resolver,
+            skill_name="",
+            subscribers=getattr(ctx.events, "subscribers", []),
+        )
+
+    return await execute_op(op, legacy_ctx, caller="control_ir")
+
+
+COMPACT = ToolDefinition(
+    name="compact",
+    description=_COMPACT_DESCRIPTION,
+    parameters=_COMPACT_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_compact,
+    category="context",
+    purity="side_effect",
+)

--- a/tests/test_compact_op_272.py
+++ b/tests/test_compact_op_272.py
@@ -1,0 +1,115 @@
+"""Tier 2: OS invariant — #272/#1128 compact op (voluntary history compaction).
+
+Covers the op handler contract + the OS-injected context-size signal renderer
+with REAL collaborators (real execute_op, real OpContext, a hand-written async
+capability — no mocks):
+  - compact routes to the caller-wired OpContext.compact_now and passes through
+    its exact-token result ({freed_tokens, free_window_after});
+  - fail-loud when unwired (compaction_unavailable) — never a silent no-op;
+  - a raising capability surfaces as compaction_failed, never crashes the turn;
+  - the context-size signal is gated: None when the window is ample, a header
+    when filling, and a compact nudge when low (exact-token, unit-aligned).
+
+The chat/phase wiring of ``compact_now`` itself is exercised end-to-end in the
+axis wiring tests; here the op + signal contracts are pinned in isolation.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.op_runtime import execute_op
+from reyn.op_runtime.context import OpContext
+from reyn.permissions.permissions import PermissionDecl
+from reyn.schemas.models import CompactIROp
+from reyn.services.compaction.context_signal import render_context_size_signal
+
+
+class _Events:
+    def __init__(self) -> None:
+        self.subscribers: list = []
+        self.emitted: list[tuple] = []
+
+    def emit(self, *args, **kw):  # noqa: ANN002, ANN003
+        self.emitted.append((args[0] if args else None, kw))
+
+    def types(self) -> list:
+        return [t for t, _ in self.emitted]
+
+
+def _ctx(compact_now=None) -> OpContext:
+    return OpContext(
+        workspace=None,
+        events=_Events(),
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        skill_name="",
+        compact_now=compact_now,
+    )
+
+
+# ── op handler contract ──────────────────────────────────────────────────────
+
+
+def test_compact_routes_to_capability_and_passes_exact_tokens() -> None:
+    """Tier 2: compact calls ctx.compact_now and returns its exact-token result."""
+    async def _cap() -> dict:
+        return {"freed_tokens": 1200, "free_window_after": 8000, "free_window_before": 6800}
+
+    ctx = _ctx(_cap)
+    op = CompactIROp(kind="compact", reason="window low before big read")
+    result = asyncio.run(execute_op(op, ctx, caller="control_ir"))
+    assert result["status"] == "ok"
+    assert result["freed_tokens"] == 1200
+    assert result["free_window_after"] == 8000
+    assert "compact_op_completed" in ctx.events.types()
+
+
+def test_compact_fail_loud_when_unwired() -> None:
+    """Tier 2: no compaction context → structured compaction_unavailable error,
+    never a silent no-op (the model must not believe the window was freed)."""
+    ctx = _ctx(None)
+    result = asyncio.run(execute_op(CompactIROp(kind="compact"), ctx, caller="control_ir"))
+    assert result["status"] == "error"
+    assert result["error_kind"] == "compaction_unavailable"
+    assert "freed_tokens" not in result, "must not fabricate freed tokens when unavailable"
+
+
+def test_compact_capability_raise_becomes_error_never_crashes() -> None:
+    """Tier 2: a raising compaction surfaces as compaction_failed, not an exception."""
+    async def _boom() -> dict:
+        raise RuntimeError("force_compact_race_unrecovered")
+
+    result = asyncio.run(execute_op(CompactIROp(kind="compact"), _ctx(_boom), caller="control_ir"))
+    assert result["status"] == "error"
+    assert result["error_kind"] == "compaction_failed"
+    assert "force_compact_race_unrecovered" in result["error"]
+
+
+# ── context-size signal (OS-injected, gated, exact-token) ──────────────────────
+
+
+def test_signal_none_when_window_ample() -> None:
+    """Tier 2: ample window → no signal (no per-turn SP noise / fixture churn)."""
+    assert render_context_size_signal(free_window=90_000, effective_trigger=100_000) is None
+    # degenerate / unknown trigger → no signal (can't reason about a 0 window).
+    assert render_context_size_signal(free_window=0, effective_trigger=0) is None
+
+
+def test_signal_appears_when_filling_with_exact_tokens() -> None:
+    """Tier 2: filling window → header with exact-token used/free numbers."""
+    sig = render_context_size_signal(free_window=40_000, effective_trigger=100_000)
+    assert sig is not None
+    assert "Context window" in sig
+    assert "60000" in sig and "40000" in sig  # exact used/free tokens, not buckets
+
+
+_NUDGE = "If you still have work to do"  # distinctive marker (header always says "auto-compaction")
+
+
+def test_signal_nudges_compact_only_when_low() -> None:
+    """Tier 2: a low free window adds the explicit compact nudge; a merely-filling
+    one shows the budget without nudging."""
+    low = render_context_size_signal(free_window=10_000, effective_trigger=100_000)
+    assert low is not None and _NUDGE in low
+    filling = render_context_size_signal(free_window=40_000, effective_trigger=100_000)
+    assert filling is not None and _NUDGE not in filling

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -8,9 +8,10 @@ coarse op kind to ``OP_KIND_MODEL_MAP`` but forgets the registry entry,
 the kind silently falls back to the legacy ``execute_op`` path and the
 ADR-0026 M4 unification claim regresses unnoticed.
 
-The 11 kinds pinned here are the ones FP-0039 §S1 audit found wired:
+The kinds pinned here are the ones FP-0039 §S1 audit found wired:
 file / mcp / run_skill / shell / lint / ask_user / web_fetch /
-web_search / mcp_install / recall / sandboxed_exec. The 6 RAG / internal
+web_search / mcp_install / recall / sandboxed_exec — plus ``compact``
+(#272/#1128, phase=allow registry entry). The 6 RAG / internal
 kinds (embed / index_* / judge_output / skill_resolve) intentionally
 stay on the legacy path and are documented in this test's expected-
 legacy set so adding them later is an explicit change, not a silent one.
@@ -38,6 +39,13 @@ _REGISTRY_WIRED_KINDS: frozenset[str] = frozenset({
     "shell",
     "web_fetch",
     "web_search",
+    # #272/#1128: compact has a phase=allow registry ToolDefinition, so the op
+    # dispatches through the unified registry. The phase compaction CAPABILITY
+    # (OpContext.compact_now) is wired for chat now; in phases it is unwired
+    # until the B1 follow-up (#1176), so a phase-emitted compact fail-louds with
+    # compaction_unavailable rather than silently no-op'ing. Dispatch path is
+    # registry-wired either way → classified here.
+    "compact",
 })
 
 # Coarse op kinds that intentionally still dispatch via the legacy

--- a/tests/test_router_tools.py
+++ b/tests/test_router_tools.py
@@ -53,6 +53,9 @@ EXPECTED_TOOL_NAMES = [
     # when the ToolRegistry contains them (B17-S6-1 / B17-S8-2 fix).
     "recall",
     "drop_source",
+    # compact (#272/#1128) — always exposed; voluntary history compaction
+    # paired with the OS-injected context-size signal.
+    "compact",
 ]
 
 
@@ -98,15 +101,15 @@ MCP_TOOL_NAMES = {"list_mcp_servers", "list_mcp_tools", "call_mcp_tool"}
 SAMPLE_MCP_SERVERS = [{"name": "fs", "description": "Filesystem MCP server"}]
 
 
-def test_build_tools_returns_19_tools_when_no_extras():
+def test_build_tools_returns_expected_baseline_tools():
     """Tier 2: No file / MCP extras: 11 baseline + web_search (E1, always on)
     + web_fetch (E2, FP-0022: always on, handler-level approval)
     + read_tool_result (E3, B49 Step 2 v6 fix: lazy-expand half of the
     preview-driven design, surfaced for router-side use)
     + reyn_src_list + reyn_src_read (F1/F2, always on)
-    + plan (G1, always on) + recall + drop_source (H1/H2, always on).
-    All file-class tools and MCP remain gated, so 19 total at the
-    unconfigured baseline.
+    + plan (G1, always on) + recall + drop_source (H1/H2, always on)
+    + compact (#272/#1128, always on). All file-class tools and MCP remain
+    gated, so the unconfigured baseline is exactly EXPECTED_TOOL_NAMES.
     """
     tools = build_tools(SAMPLE_SKILLS, SAMPLE_AGENTS)
     assert _tool_names(tools) == EXPECTED_TOOL_NAMES, (

--- a/tests/test_router_tools.py
+++ b/tests/test_router_tools.py
@@ -53,9 +53,9 @@ EXPECTED_TOOL_NAMES = [
     # when the ToolRegistry contains them (B17-S6-1 / B17-S8-2 fix).
     "recall",
     "drop_source",
-    # compact (#272/#1128) — always exposed; voluntary history compaction
-    # paired with the OS-injected context-size signal.
-    "compact",
+    # compact (#272/#1128) is NOT in the baseline — it is visibility-gated
+    # (compact_visible) and only appears when the window is filling, paired
+    # with the context-size signal (see test_compact_visible_gates_tool).
 ]
 
 
@@ -107,9 +107,10 @@ def test_build_tools_returns_expected_baseline_tools():
     + read_tool_result (E3, B49 Step 2 v6 fix: lazy-expand half of the
     preview-driven design, surfaced for router-side use)
     + reyn_src_list + reyn_src_read (F1/F2, always on)
-    + plan (G1, always on) + recall + drop_source (H1/H2, always on)
-    + compact (#272/#1128, always on). All file-class tools and MCP remain
-    gated, so the unconfigured baseline is exactly EXPECTED_TOOL_NAMES.
+    + plan (G1, always on) + recall + drop_source (H1/H2, always on). compact
+    (#272/#1128) is visibility-gated (off by default), so the unconfigured
+    baseline is exactly EXPECTED_TOOL_NAMES. All file-class tools and MCP
+    remain gated.
     """
     tools = build_tools(SAMPLE_SKILLS, SAMPLE_AGENTS)
     assert _tool_names(tools) == EXPECTED_TOOL_NAMES, (
@@ -123,6 +124,21 @@ def test_tool_order_is_deterministic():
     tools_b = build_tools(SAMPLE_SKILLS, SAMPLE_AGENTS)
     assert _tool_names(tools_a) == _tool_names(tools_b)
     assert _tool_names(tools_a) == EXPECTED_TOOL_NAMES
+
+
+def test_compact_visible_gates_tool():
+    """Tier 2: #272/#1128 — `compact` is exposed only when compact_visible=True
+    (window filling), and absent by default (ample window). Mirrors the
+    search_actions §D14 visibility gate; keeps tools= stable on ample-window
+    turns (and LLMReplay fixtures keyed on tools byte-stable).
+    """
+    default = _tool_names(build_tools(SAMPLE_SKILLS, SAMPLE_AGENTS))
+    assert "compact" not in default, "compact must be hidden when the window is ample"
+
+    gated = _tool_names(build_tools(SAMPLE_SKILLS, SAMPLE_AGENTS, compact_visible=True))
+    assert "compact" in gated, "compact must appear when the window is filling"
+    # Enabling the gate only adds compact — no other tool churn.
+    assert set(gated) - set(default) == {"compact"}
 
 
 def test_no_forbidden_schema_keywords():


### PR DESCRIPTION
**[e2e-coder]** — compact op, chat axis. Design = #1128 comment 4586175953 (lead-coder approved); scope/decisions confirmed via broker (B2 + visibility-gate endorsed). Phase axis = deliberate follow-up #1176.

## What
An LLM-requested **voluntary** compaction affordance, paired with an OS-injected **context-size signal**, so the model can free context window *before* the mandatory `retry_loop` backstop fires. Completes the conversation-dead-end suite's proactive half (text/size/media handled by #1161/#271/#1171).

## Pieces
- **op-layer**: `CompactIROp` + registry (`OP_KIND_MODEL_MAP` + `OpPurity=external`) + `OpContext.compact_now` capability (ask_user/intervention_bus precedent) + `op_runtime/compact.py` handler — routes to the caller-wired capability, **fail-loud** (`compaction_unavailable`) if unwired (never a silent no-op), exact-token `{freed_tokens, free_window_after}` passthrough.
- **chat capability**: `ChatSession._compact_now_for_op` wraps `force_compact_now`, reporting exact-token freed/free-window via `_free_window_now`; threaded through `RouterHostAdapter` → `OpContext`.
- **chat tool**: `tools/compact.py` (optional `reason`) advertised in `build_tools` + registry-dispatch allow-list.
- **context-size signal** (design core): shared `render_context_size_signal` (`services/compaction/context_signal.py`) — exact-token `used/free` header + a compact nudge when low; **unit-aligned** with the media load-contract error. Appended **last** in the SP (most volatile → preserves the cached prefix).
- **visibility-gating**: the signal + the compact tool are surfaced **only when the window is filling** (`compact_visible`, mirroring the `search_actions` §D14 gate). `gates.router=allow` (permission) is unchanged — only *when surfaced* is gated. Offering compact on an empty window is noise; this also keeps `tools=` byte-stable on ample turns, so the LLMReplay router fixtures pass **without re-recording**.

## Phase axis (out of scope → follow-up #1176)
Chat is the live dead-end and the only axis with an on-demand compaction seam (`force_compact_now`). Phases **already auto-compact** act-results every frame (`compact_control_ir_results`, phase_executor.py:421) — no on-demand seam exists. Building a mid-phase-state force-compact seam is a deliberate follow-up (#1176, design articulated), not a rushed addition. The op is registry-wired uniformly; a phase-emitted compact fail-louds (`compaction_unavailable`) until #1176 wires `compact_now` there.

## Test plan (Tier 2, real collaborators — no mocks)
- [x] `tests/test_compact_op_272.py`: real `execute_op` + real `OpContext` + hand-written async capability — routes + exact-token passthrough; fail-loud `compaction_unavailable` when unwired; raising capability → `compaction_failed` (never crashes); signal gated (None ample / header+exact-tokens filling / compact nudge only when low).
- [x] `test_router_tools::test_compact_visible_gates_tool` — compact hidden by default, appears when `compact_visible=True`, no other tool churn.
- [x] `control-ir.md` synced (table row + `## compact` section + chat/phase asymmetry note) — mandatory registry↔reference sync (CLAUDE.md).
- [x] `test_op_kind_partition_is_total` — compact classified registry-wired.
- [x] full suite `pytest -q` → 6662 passed (1 known-local `test_web_fetch_preview_path_ref`; the partition test failure is fixed in the final commit); ruff + tier-audit clean; LLMReplay router fixtures green without re-record.

Refs #272 #1128 #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)