### PR TITLE
fix(model-budget): #1162-(B) provider-prefix-strip-retry — resolve proxy-routed models' real window

### DIFF
--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -35,6 +35,24 @@ _FALLBACK_MAX_INPUT_TOKENS = 128_000
 _warned_models: set[str] = set()
 
 
+def _lookup_max_input(model: str) -> "int | None":
+    """Return ``max_input_tokens`` from LiteLLM's catalog for *model*, or None
+    when the model is unrecognized or has no positive window.
+
+    No fallback, no events — pure catalog lookup so callers can compose retries
+    (e.g. provider-prefix-strip, #1162).
+    """
+    try:
+        import litellm
+        info = litellm.get_model_info(model)
+        max_input = info.get("max_input_tokens")
+        if max_input and int(max_input) > 0:
+            return int(max_input)
+    except Exception:
+        pass  # Not in catalog / no positive window.
+    return None
+
+
 def get_max_input_tokens(
     model: str,
     *,
@@ -65,15 +83,24 @@ def get_max_input_tokens(
     int
         Positive integer token count. Always > 0.
     """
-    try:
-        import litellm
-        info = litellm.get_model_info(model)
-        max_input = info.get("max_input_tokens")
-        if max_input and int(max_input) > 0:
-            return int(max_input)
-        # Model is in catalog but max_input_tokens is None/0 — fall through.
-    except Exception:
-        pass  # Not in catalog — fall through to default.
+    max_input = _lookup_max_input(model)
+    if max_input is not None:
+        return max_input
+
+    # #1162: provider-prefixed proxy models miss the catalog under the prefix
+    # but resolve under the bare model name. e.g. ``openai/gemini-2.5-flash-lite``
+    # (routing Gemini through an openai-compat proxy) is not in litellm's openai
+    # catalog → exception → would fall to the 128K default, over-compacting a
+    # real 1M window by ~87%. Strip the FIRST provider segment and retry before
+    # falling back. This only IMPROVES resolution: a still-unknown bare name
+    # falls through to the same conservative fallback as before (safe even if a
+    # proxy aliases the prefixed name to something else — the bare lookup just
+    # misses → 128K).
+    if "/" in model:
+        bare = model.split("/", 1)[1]
+        max_input = _lookup_max_input(bare)
+        if max_input is not None:
+            return max_input
 
     # Fallback path: emit warning once per model.
     if model not in _warned_models:

--- a/tests/test_model_budget.py
+++ b/tests/test_model_budget.py
@@ -91,7 +91,7 @@ def test_prefix_strip_resolution_emits_no_fallback_event() -> None:
 
 
 def test_unknown_prefixed_model_still_falls_back() -> None:
-    """Tier 2 (regression guard): a prefixed model whose bare name is also unknown
+    """Tier 2: regression guard — a prefixed model whose bare name is also unknown
     keeps the 128K fallback — prefix-strip only improves resolution, never hides
     a genuinely-unknown model."""
     events = EventLog()

--- a/tests/test_model_budget.py
+++ b/tests/test_model_budget.py
@@ -7,8 +7,14 @@ Invariants guarded:
   4. Fallback value is always > 0 (safe for downstream compaction math).
   5. Repeated calls for the same unknown model emit the event only once
      per EventLog instance (no event flood).
+  6. #1162 provider-prefix-strip-retry: a proxy-routed ``<provider>/<model>``
+     that misses the catalog under the prefix resolves under the bare name
+     (avoids premature over-compaction); a still-unknown name keeps the
+     fallback (and still emits the event).
 """
 from __future__ import annotations
+
+import pytest
 
 from reyn.events.events import EventLog
 from reyn.llm.model_budget import _FALLBACK_MAX_INPUT_TOKENS, get_max_input_tokens
@@ -47,3 +53,50 @@ def test_fallback_value_always_positive() -> None:
     """Tier 2: the fallback default is a positive integer (safe for compaction arithmetic)."""
     assert isinstance(_FALLBACK_MAX_INPUT_TOKENS, int)
     assert _FALLBACK_MAX_INPUT_TOKENS > 0
+
+
+# ── #1162 provider-prefix-strip-retry ─────────────────────────────────────────
+
+_BARE = "gemini-2.5-flash-lite"  # cataloged at 1M (≠ 128K fallback) per the issue probe
+
+
+@pytest.mark.parametrize("wrong_prefix", ["openai", "anthropic", "vertex_ai"])
+def test_proxy_prefixed_model_resolves_via_prefix_strip(wrong_prefix: str) -> None:
+    """Tier 2: a ``<wrong-provider>/<model>`` (= proxy routing) resolves to the
+    same real window as the bare model via prefix-strip-retry — not the 128K
+    fallback. ``openai/gemini-2.5-flash-lite`` was returning 128K (~87% of a
+    real 1M window wasted on premature compaction) before #1162.
+    """
+    bare_window = get_max_input_tokens(_BARE)
+    if bare_window == _FALLBACK_MAX_INPUT_TOKENS:
+        pytest.skip(f"litellm catalog lacks {_BARE!r} in this env — strip target absent")
+    prefixed_window = get_max_input_tokens(f"{wrong_prefix}/{_BARE}")
+    assert prefixed_window == bare_window, (
+        f"{wrong_prefix}/{_BARE} must resolve to the bare model's window "
+        f"({bare_window}) via prefix-strip, got {prefixed_window}"
+    )
+    assert prefixed_window > _FALLBACK_MAX_INPUT_TOKENS, (
+        "prefix-strip must surface the real (>128K) window, not the fallback"
+    )
+
+
+def test_prefix_strip_resolution_emits_no_fallback_event() -> None:
+    """Tier 2: a prefix-strip-resolvable model does NOT emit model_budget_fallback
+    (it resolved — the event is reserved for genuinely-unknown models)."""
+    if get_max_input_tokens(_BARE) == _FALLBACK_MAX_INPUT_TOKENS:
+        pytest.skip(f"litellm catalog lacks {_BARE!r} in this env")
+    events = EventLog()
+    get_max_input_tokens(f"openai/{_BARE}", events=events)
+    assert not [e for e in events.all() if e.type == "model_budget_fallback"]
+
+
+def test_unknown_prefixed_model_still_falls_back() -> None:
+    """Tier 2 (regression guard): a prefixed model whose bare name is also unknown
+    keeps the 128K fallback — prefix-strip only improves resolution, never hides
+    a genuinely-unknown model."""
+    events = EventLog()
+    model = "openai/totally-made-up-proxy-model-1162-xyz"
+    result = get_max_input_tokens(model, events=events)
+    assert result == _FALLBACK_MAX_INPUT_TOKENS
+    # the fallback event still fires for the genuinely-unknown model (unchanged).
+    assert [e for e in events.all() if e.type == "model_budget_fallback"]


### PR DESCRIPTION
**[e2e-coder]** — #1162 code-robustness half (the config-prefix half landed in #1164/#1168). sandbox_2 found the bug via #1157 dogfood; this completes the #1162 thread. (Crossed lead-coder's load-balance retract in-flight — already finished + tested when it arrived; lead-coder confirmed I PR my branch rather than waste the work; media-count cap went to sandbox_2.)

## Bug
`get_max_input_tokens("openai/gemini-2.5-flash-lite")` (Gemini routed via an openai-compat proxy) → litellm has no such model under the openai catalog → exception → **128K fallback**, while the real window is **1M**. reyn then fires pre-frame guard / early compaction at 128K, wasting **~87%** of the real context (premature over-compaction).

## Fix — provider-prefix-strip-retry (resolution-only, safe)
`get_max_input_tokens`: on initial catalog miss/exception, **strip the first provider segment and retry the bare name** (`openai/gemini-2.5-flash-lite` → `gemini-2.5-flash-lite` → 1M). A still-unknown bare name keeps the 128K fallback (and still emits `model_budget_fallback`) — strip only *improves* resolution, never hides a genuinely-unknown model. Extracted `_lookup_max_input` as the no-fallback/no-event catalog probe so the retry composes cleanly.

Defense-in-depth: #1168 made the default config class-ref'd (immediate fix), but this protects any operator who later hardcodes a literal `<provider>/<model>` proxy string.

## Test plan (Tier 2, real litellm — no mocks)
- [x] `tests/test_model_budget.py`: `openai|anthropic|vertex_ai / gemini-2.5-flash-lite` all resolve to the bare model's real (>128K) window via prefix-strip (parametrized, skips if catalog lacks the model); prefix-strip resolution emits NO `model_budget_fallback`; genuinely-unknown prefixed model keeps 128K + still emits the event. 9 model_budget tests pass; 248 budget/compaction sweep pass.
- [x] ruff clean.

Refs #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)