### PR TITLE
feat(kernel): #1176 B1 — phase-axis on-demand compact op + context-size signal

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -309,6 +309,7 @@ def build_frame(
     run_id: str | None = None,
     act_turn: int | None = None,
     offload_dir: Path | None = None,
+    context_size_signal: str | None = None,  # #1176 B1 — pre-rendered, tail field
 ) -> ContextFrame:
     allowed_next = [c.next_phase for c in candidates]
     current_visit = visit_counts.get(phase_name, 1)
@@ -347,6 +348,7 @@ def build_frame(
         model_resolved=model_resolved,
         control_ir_results=offloaded_results,
         remaining_act_turns=remaining_act_turns,
+        context_size_signal=context_size_signal,
     )
 
     events.emit("context_built", phase=phase_name, frame=frame.model_dump(mode="json"))

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -318,6 +318,7 @@ class ControlIRExecutor:
         decl: PermissionDecl,
         current_phase: str,
         default_sandbox_policy: dict | None = None,
+        compact_now=None,
     ) -> OpContext:
         """Construct the OpContext for a single dispatch iteration."""
         return OpContext(
@@ -338,6 +339,10 @@ class ControlIRExecutor:
             mcp_servers=self._mcp_servers,
             mcp_clients=self._mcp_clients,
             intervention_bus=self._intervention_bus,
+            # #1176 B1: phase on-demand voluntary compaction capability. None
+            # for batches with no phase compaction engine wired (compact op
+            # then fail-louds compaction_unavailable, same as chat).
+            compact_now=compact_now,
             current_phase=current_phase,
             caller=self._caller,
             # R-D13: propagate the running skill's run_id so nested
@@ -394,6 +399,7 @@ class ControlIRExecutor:
         decl: PermissionDecl | None = None,
         allowed_ops: set[str] | None = None,
         default_sandbox_policy: dict | None = None,
+        compact_now=None,
     ) -> list[dict[str, Any]]:
         """Execute a list of Control IR operations.
 
@@ -407,7 +413,7 @@ class ControlIRExecutor:
         the existing tool_executed events emitted by op_runtime handlers.
         """
         effective_decl = decl or PermissionDecl()
-        ctx = self._build_ctx(effective_decl, phase, default_sandbox_policy)
+        ctx = self._build_ctx(effective_decl, phase, default_sandbox_policy, compact_now=compact_now)
         results: list[dict[str, Any]] = []
 
         # Build a tool catalog for dispatch_tool name/arg validation.

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -55,6 +55,71 @@ _log = logging.getLogger(__name__)
 _RAW_OUTPUT_INLINE_CAP = 8192
 
 
+class _ControlIRResultsHolder:
+    """Mutable handle to the act loop's ``control_ir_results`` accumulator (#1176).
+
+    An on-demand ``compact`` op reaches it via ``OpContext.compact_now`` to
+    compact + replace the accumulated results mid-batch. get/set only — the raw
+    list is never exposed by index, so the OpContext callback stays opaque to
+    the accumulator's storage shape.
+    """
+
+    def __init__(self, initial: "list[dict]") -> None:
+        self._results: list[dict] = list(initial)
+
+    def get(self) -> "list[dict]":
+        return self._results
+
+    def set(self, results: "list[dict]") -> None:
+        self._results = list(results)
+
+
+def _make_phase_compact_now(holder, engine, cfg, events, phase):
+    """Build the phase-axis ``compact_now`` callback (#1176 B1).
+
+    On-demand counterpart to the act loop's automatic compaction: it compacts
+    the SAME older split (keep last ``recent_act_turns_raw`` raw, summarise the
+    rest) via the SAME ``compact_control_ir_results`` primitive — so the emitted
+    compaction events are shape-identical to the auto path (replay-consistent,
+    lead-coder's safety requirement). Returns the chat-byte-identical contract
+    ``{freed_tokens, free_window_after, free_window_before}`` in exact tokens.
+    """
+
+    async def _compact_now() -> dict:
+        from reyn.services.compaction.engine import (
+            compact_control_ir_results,
+            estimate_tokens,
+        )
+
+        model = engine._model  # noqa: SLF001 — resolved litellm string owned by the engine
+
+        def _free_window(results: "list[dict]") -> "tuple[int, int]":
+            budgets = getattr(engine, "budgets", None)
+            trigger = budgets.effective_trigger if budgets is not None else 0
+            used = estimate_tokens(json.dumps(results, ensure_ascii=False), model)
+            return trigger, used
+
+        trigger, before_used = _free_window(holder.get())
+        n_recent = cfg.recent_act_turns_raw
+        results = holder.get()
+        older = results[:-n_recent] if n_recent > 0 else results
+        recent = results[-n_recent:] if n_recent > 0 else []
+        if older:
+            older_compacted = await compact_control_ir_results(
+                older, engine=engine, cfg=cfg, events=events, phase=phase,
+            )
+            holder.set(older_compacted + recent)
+        # else: nothing older to compact — no-op (still report the live window).
+        _, after_used = _free_window(holder.get())
+        return {
+            "freed_tokens": max(0, before_used - after_used),
+            "free_window_after": max(0, trigger - after_used),
+            "free_window_before": max(0, trigger - before_used),
+        }
+
+    return _compact_now
+
+
 class PhaseExecutor:
     """Drives one phase to completion via act/decide loops with retry.
 
@@ -536,13 +601,31 @@ class PhaseExecutor:
             phase_def = self._skill.phases.get(phase)
             phase_decl = self._skill.permissions
             allowed_ops = set(phase_def.allowed_ops) if phase_def is not None else None
+            # #1176 B1: expose on-demand voluntary compaction to the batch's ops.
+            # The holder carries the accumulator across the execute() boundary so
+            # a `compact` op can compact + replace the settled results mid-batch;
+            # we read it back afterward. compact_now is None (→ compact op
+            # fail-louds) when no phase compaction engine is wired.
+            _holder = _ControlIRResultsHolder(control_ir_results)
+            _compact_now = (
+                _make_phase_compact_now(
+                    _holder, self._phase_compaction_engine,
+                    self._phase_compaction_cfg, self._events, phase,
+                )
+                if self._phase_compaction_engine is not None
+                and self._phase_compaction_cfg is not None
+                else None
+            )
             ir_results = await self._control_ir_executor.execute(
                 act.ops, phase=phase, decl=phase_decl, allowed_ops=allowed_ops,
                 default_sandbox_policy=(
                     phase_def.default_sandbox_policy if phase_def is not None else None
                 ),
+                compact_now=_compact_now,
             )
-            control_ir_results = control_ir_results + ir_results
+            # _holder reflects any mid-batch on-demand compaction; the new
+            # results append after the (possibly compacted) settled accumulator.
+            control_ir_results = _holder.get() + ir_results
             prior_attempts = []
             self._events.emit(
                 "act_executed",

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -481,6 +481,29 @@ class OSRuntime:
             if artifact_path is not None
             else None
         )
+        model_resolved = self._resolver.resolve(effective_model).model
+        # #1176 B1: OS-injected context-size signal (symmetric with chat). Render
+        # the exact-token free-window from the phase compaction engine's budget;
+        # render_context_size_signal returns None when the window is ample (most
+        # turns → frame stays stable, no noise) and a header when it is filling.
+        context_size_signal = None
+        _eng = self._phase_compaction_engine
+        _budgets = getattr(_eng, "budgets", None) if _eng is not None else None
+        if _budgets is not None:
+            import json as _json
+
+            from reyn.services.compaction.context_signal import (
+                render_context_size_signal,
+            )
+            from reyn.services.compaction.engine import estimate_tokens
+
+            _used = estimate_tokens(
+                _json.dumps(control_ir_results or [], ensure_ascii=False), model_resolved
+            )
+            context_size_signal = render_context_size_signal(
+                free_window=max(0, _budgets.effective_trigger - _used),
+                effective_trigger=_budgets.effective_trigger,
+            )
         return build_frame(
             phase_name=current_phase,
             phase=phase_def,
@@ -494,12 +517,13 @@ class OSRuntime:
             available_ops=effective_ops,
             op_catalog=all_ops,
             effective_model=effective_model,
-            model_resolved=self._resolver.resolve(effective_model).model,
+            model_resolved=model_resolved,
             events=self.events,
             control_ir_results=control_ir_results,
             artifact_path=resolved_artifact_path,
             remaining_act_turns=remaining_act_turns,
             offload_dir=offload_dir,
+            context_size_signal=context_size_signal,
         )
 
     # ── Phase entry + phase execution ─────────────────────────────────────────

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, model_serializer, model_validator
 
 from reyn.permissions.permissions import PermissionDecl
 
@@ -672,7 +672,24 @@ class ContextFrame(BaseModel):
     # 0 means this call is the mandatory decide turn — the LLM MUST NOT emit any ops.
     # None means unlimited (no max_act_turns constraint on this phase).
     remaining_act_turns: int | None = None
+    # #1176 B1: OS-injected context-size signal (exact-token free-window header),
+    # symmetric with the chat axis. None when the phase window is ample (the OS
+    # omits it). Most per-turn-volatile → kept at the tail with the other
+    # volatile fields so the cached frame prefix above it stays stable.
+    context_size_signal: str | None = None
     current_datetime: datetime = Field(default_factory=lambda: datetime.now().astimezone())
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):  # noqa: ANN001
+        """#1176 B1: omit ``context_size_signal`` entirely when absent (ample
+        window) so a frame without a signal serializes byte-identically to the
+        pre-#1176 shape — keeps the LLM-facing JSON and LLMReplay fixture keys
+        stable. When the window is filling the signal rides in the volatile tail.
+        All other fields are untouched (default serialization)."""
+        data = handler(self)
+        if data.get("context_size_signal") is None:
+            data.pop("context_size_signal", None)
+        return data
 
 
 class Event(BaseModel):

--- a/tests/test_osruntime_phase_compaction_wiring.py
+++ b/tests/test_osruntime_phase_compaction_wiring.py
@@ -258,6 +258,7 @@ class _FakeIRExecutor:
         decl: Any = None,
         allowed_ops: Any = None,
         default_sandbox_policy: Any = None,
+        compact_now: Any = None,  # #1176 B1: mirror the real execute() signature
     ) -> list[dict]:
         """Return one synthetic grep result regardless of the ops list."""
         return [

--- a/tests/test_phase_compact_op_1176.py
+++ b/tests/test_phase_compact_op_1176.py
@@ -1,0 +1,181 @@
+"""Tier 2: OS invariant — #1176 B1 phase-axis on-demand voluntary compaction.
+
+The phase axis gains an on-demand counterpart to its automatic act-loop
+compaction: a `compact` op reaches `OpContext.compact_now` (wired by the act
+loop) which compacts the accumulated `control_ir_results` via the SAME
+`compact_control_ir_results` primitive + the SAME older/recent split as the auto
+path — so the emitted events are shape-identical (replay-consistent). Verified
+with a REAL CompactionEngine + a scripted litellm boundary (no mocks):
+
+  - the compact_now callback frees tokens, replaces the accumulator (holder),
+    and returns the chat-byte-identical {freed_tokens, free_window_after/before};
+  - it emits the SAME `phase_act_results_compacted` event shape as a direct
+    auto-path call (lead-coder's safety requirement);
+  - it is a no-op (freed 0, no event) when there is nothing older to compact;
+  - the ContextFrame context-size signal is omitted from serialization when None
+    (ample window → byte-identical frame) and present when filling.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from reyn.config import CompactionConfig, PhaseActResultsCompactionConfig
+from reyn.events.events import EventLog
+from reyn.kernel.phase_executor import (
+    _ControlIRResultsHolder,
+    _make_phase_compact_now,
+)
+from reyn.schemas.models import ContextFrame
+from reyn.services.compaction.engine import CompactionEngine, compact_control_ir_results
+
+
+class _LLMSummaryFake:
+    """Fake acompletion returning a canned summary (no mock — a real callable)."""
+
+    def __init__(self, summary: str = "PHASE_SUMMARY") -> None:
+        self._summary = summary
+
+    async def __call__(self, model: str, messages: list, **kwargs: Any) -> Any:  # noqa: ARG002
+        class _Msg:
+            content = self._summary
+
+        class _Choice:
+            message = _Msg()
+
+        class _Response:
+            choices = [_Choice()]
+
+        return _Response()
+
+
+def _engine(events: EventLog) -> CompactionEngine:
+    return CompactionEngine(
+        model="gpt-3.5-turbo", events=events,
+        cfg=CompactionConfig(use_chars4_estimate=True), T_SP=0,
+    )
+
+
+def _cfg() -> PhaseActResultsCompactionConfig:
+    # threshold trivially exceeded so the older split actually compacts; keep
+    # the last 2 results raw (same split the auto path uses).
+    return PhaseActResultsCompactionConfig(
+        use_chars4_estimate=True, summarize_older_threshold_tokens=10,
+        recent_act_turns_raw=2,
+    )
+
+
+def _big_results(n: int) -> list[dict]:
+    return [
+        {"kind": "grep", "matches": [f"src/f{i}.py:{j}" for j in range(40)]}
+        for i in range(n)
+    ]
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _types(events: EventLog) -> list[str]:
+    return [e.type for e in events.all()]
+
+
+# ── on-demand compact_now ─────────────────────────────────────────────────────
+
+
+def test_phase_compact_now_frees_tokens_and_updates_holder(monkeypatch) -> None:
+    """Tier 2: compact_now compacts the older split, shrinks the holder, and
+    returns exact-token freed/free-window (chat-byte-identical contract)."""
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", _LLMSummaryFake("SHORT SUMMARY"))
+    events = EventLog()
+    engine, cfg = _engine(events), _cfg()
+    holder = _ControlIRResultsHolder(_big_results(6))
+    before_n = len(holder.get())
+
+    compact_now = _make_phase_compact_now(holder, engine, cfg, events, "p")
+    result = _run(compact_now())
+
+    assert set(result) >= {"freed_tokens", "free_window_after", "free_window_before"}
+    assert result["freed_tokens"] > 0, "compacting 6 big results must free tokens"
+    # holder replaced: older collapsed to one placeholder + the 2 recent raw.
+    assert len(holder.get()) < before_n
+    assert any(r.get("kind") == "__compacted_phase_results__" for r in holder.get())
+    assert "phase_act_results_compacted" in _types(events)
+
+
+def test_phase_compact_now_event_shape_identical_to_auto(monkeypatch) -> None:
+    """Tier 2: safety — the on-demand path emits the SAME phase_act_results_compacted
+    event shape as a direct auto-path call (replay-consistency, lead-coder req)."""
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", _LLMSummaryFake("S"))
+    older = _big_results(4)
+
+    # auto path: call the primitive directly.
+    ev_auto = EventLog()
+    _run(compact_control_ir_results(
+        older, engine=_engine(ev_auto), cfg=_cfg(), events=ev_auto, phase="p",
+    ))
+    auto_evs = [e for e in ev_auto.all() if e.type == "phase_act_results_compacted"]
+
+    # on-demand path: via the compact_now callback (same older as its full set).
+    ev_od = EventLog()
+    holder = _ControlIRResultsHolder(older)  # all 4 older when recent split removes 2
+    _run(_make_phase_compact_now(holder, _engine(ev_od), _cfg(), ev_od, "p")())
+    od_evs = [e for e in ev_od.all() if e.type == "phase_act_results_compacted"]
+
+    assert auto_evs and od_evs, "both paths must emit the compaction event"
+    assert set(auto_evs[0].data.keys()) == set(od_evs[0].data.keys()), (
+        "on-demand compaction event shape must match the auto path "
+        f"(auto={sorted(auto_evs[0].data)}, on-demand={sorted(od_evs[0].data)})"
+    )
+
+
+def test_phase_compact_now_noop_when_nothing_older(monkeypatch) -> None:
+    """Tier 2: with results <= recent_act_turns_raw there is nothing older to
+    compact — no LLM call, no compaction event, freed_tokens 0."""
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", _LLMSummaryFake("S"))
+    events = EventLog()
+    holder = _ControlIRResultsHolder(_big_results(2))  # == recent_act_turns_raw
+    result = _run(_make_phase_compact_now(holder, _engine(events), _cfg(), events, "p")())
+    assert result["freed_tokens"] == 0
+    assert "phase_act_results_compacted" not in _types(events)
+    assert len(holder.get()) == 2, "holder unchanged when nothing older"
+
+
+def test_holder_get_set_roundtrip() -> None:
+    """Tier 2: the holder is a faithful get/set handle (copies, no aliasing)."""
+    h = _ControlIRResultsHolder([{"a": 1}])
+    assert h.get() == [{"a": 1}]
+    h.set([{"b": 2}, {"c": 3}])
+    assert h.get() == [{"b": 2}, {"c": 3}]
+
+
+# ── ContextFrame context-size signal serialization ────────────────────────────
+
+
+def _frame(**kw) -> ContextFrame:
+    base = dict(
+        current_phase="p", instructions="do", candidate_outputs=[],
+        input_artifact={},
+    )
+    base.update(kw)
+    return ContextFrame(**base)
+
+
+def test_frame_omits_signal_when_none() -> None:
+    """Tier 2: an absent (ample-window) signal is omitted from the serialized
+    frame entirely, so the LLM-facing JSON + replay keys stay byte-stable."""
+    dumped = _frame().model_dump(mode="json")
+    assert "context_size_signal" not in dumped
+
+
+def test_frame_includes_signal_when_set() -> None:
+    """Tier 2: a present (filling-window) signal rides in the serialized frame."""
+    dumped = _frame(context_size_signal="## Context window\n  - free ...").model_dump(mode="json")
+    assert dumped.get("context_size_signal", "").startswith("## Context window")


### PR DESCRIPTION
**[e2e-coder]** — B1 phase axis, the deliberate follow-up to the chat-axis compact op (#1177, merged). Design approved at #1176 comments 4586489843 / 4586494064 / 4586504464 (lead-coder); impl-recon turnkey plan there.

## What
Brings the LLM-requested voluntary `compact` op to the **phase** axis, symmetric with chat. Chat had an on-demand seam (`force_compact_now`); phases only auto-compacted act-results at frame-build. This adds the on-demand counterpart **by reusing the existing auto-compaction primitive** (`compact_control_ir_results`) — not a novel mid-phase-state mutation.

## Pieces
- **`_ControlIRResultsHolder`** (get/set; raw list never exposed by index) — the act loop's accumulator handle so a `compact` op can compact + replace the settled results mid-batch.
- **`_make_phase_compact_now`**: compacts the **same older/recent split** as the auto path via the **same `compact_control_ir_results`** primitive → emitted events are **shape-identical** to auto (replay-consistent). Returns the chat-byte-identical `{freed_tokens, free_window_after, free_window_before}` (exact tokens).
- **Threading**: `compact_now` through `control_ir_executor.execute()` → `_build_ctx` → `OpContext.compact_now` (None → the op fail-louds `compaction_unavailable`, same as chat). `_run_act_loop` builds the holder around `execute()` + reads it back (mid-batch compaction reflected). compact_now wired only when a phase compaction engine exists.
- **Phase context-size signal**: `runtime.build_frame` renders the **shared** `render_context_size_signal` from the phase engine's `effective_trigger − estimate(control_ir_results)` (None when ample), placed in the `ContextFrame` volatile tail. A `model_serializer` on `ContextFrame` **omits the field when None** → ample-window frames serialize byte-identically (LLM JSON + LLMReplay fixture keys stable, **no re-record**); the field appears only when filling.
- No aggressive-below-N knob (proactive timing is the value; same split as auto).

## Completes the compact op
chat (#1177) + phase (this) = the LLM-requested voluntary compaction affordance across both axes, paired with the OS-injected context-size signal.

## Test plan (Tier 2, real CompactionEngine + scripted litellm — no mocks)
- [x] `tests/test_phase_compact_op_1176.py` (6): compact_now frees tokens + replaces the holder + chat-byte-identical contract; **event-shape-identical to the auto path** (the replay-consistency safety test); no-op when nothing older; holder get/set; `ContextFrame` omits the signal when None / includes when set.
- [x] auto-compaction path unchanged — `test_phase_act_results_compaction_and_rollback` + `test_osruntime_phase_compaction_wiring` green (Fake IR executor signature mirrored); `test_op_kind_partition_is_total` green.
- [x] full suite `pytest -q` → **6671 passed** (1 known-local `test_web_fetch_preview_path_ref`); ruff + tier-audit `--strict` script clean.

Refs #272 #1128 #1176 #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)