### PR TITLE
feat(chat): #191 /compact slash command + chat-axis compression metric

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -5131,20 +5131,59 @@ class ChatSession:
         }
 
     async def _compact_now_for_op(self) -> dict:
-        """#272/#1128: voluntary-compaction callback wired to the compact op.
+        """#272/#1128/#191: voluntary-compaction callback (compact op + /compact).
 
-        Runs the existing synchronous compaction and reports the freed tokens +
-        the free window afterwards in EXACT tokens (unit-aligned with the
-        context-size signal + media load-contract error). Raises propagate to
-        the op handler, which surfaces them as a structured op error.
+        Runs the existing synchronous compaction and reports what it did.
+
+        Axis note (#191, traced): the CHAT router prompt is head+tail TURN-COUNT
+        bounded (``_build_history_for_router``), so the router-view
+        ``freed_tokens`` is structurally ~0 even when compaction fires — chat
+        compaction COMPRESSES the already-elided middle into a summary bridge
+        rather than shrinking the bounded view. So the meaningful chat metric is
+        ``summarized_turns`` + ``compressed_tokens`` (raw middle) → ``bridge_tokens``
+        (the summary). ``freed_tokens`` is kept for the op contract shared with
+        the phase axis (where it IS the real control_ir shrink), but is ~0 for
+        chat — callers front the compression numbers, not freed, for chat.
         """
+        import json as _json
+
+        from reyn.services.compaction.engine import estimate_tokens
+
+        use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+
+        def _cover() -> int:
+            s = self._latest_summary()
+            return int((s.meta or {}).get("covers_through_seq", 0)) if s is not None else 0
+
+        def _est(text: str) -> int:
+            try:
+                return estimate_tokens(text, self.model, use_chars4=use_chars4)
+            except Exception:  # noqa: BLE001 — estimation best-effort
+                return 0
+
         effective_trigger, before = self._free_window_now()
+        prev_cover = _cover()
         await self._compaction_controller.force_compact_now()
         _, after = self._free_window_now()
+        new_cover = _cover()
+
+        # Chat middle-compression: the conversational turns newly covered by the
+        # summary bridge (prev_cover < seq <= new_cover) and their raw vs bridge
+        # token cost. Empty when nothing was compacted (new_cover == prev_cover).
+        conv = [m for m in self.history if m.role in ("user", "assistant", "tool", "agent")]
+        middle = [m for m in conv if prev_cover < int(getattr(m, "seq", 0) or 0) <= new_cover]
+        summary = self._latest_summary()
+        bridge_text = summary.text if summary is not None else ""
+        if not isinstance(bridge_text, str):
+            bridge_text = _json.dumps(bridge_text, ensure_ascii=False)
         return {
             "freed_tokens": max(0, before - after),
             "free_window_after": max(0, effective_trigger - after),
             "free_window_before": max(0, effective_trigger - before),
+            # #191 chat-axis compression metric (the meaningful chat signal):
+            "summarized_turns": len(middle),
+            "compressed_tokens": sum(_est(m.text) for m in middle),
+            "bridge_tokens": _est(bridge_text) if summary is not None else 0,
         }
 
     async def _maybe_force_compact_for_router(

--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -214,6 +214,7 @@ from reyn.chat.slash import agents as _agents_mod  # noqa: E402, F401
 from reyn.chat.slash import budget as _budget_mod  # noqa: E402, F401
 from reyn.chat.slash import chat as _chat_mod  # noqa: E402, F401
 from reyn.chat.slash import clear_history as _clear_history_mod  # noqa: E402, F401
+from reyn.chat.slash import compact as _compact_mod  # noqa: E402, F401
 from reyn.chat.slash import concept as _concept_mod  # noqa: E402, F401
 from reyn.chat.slash import copy as _copy_mod  # noqa: E402, F401
 from reyn.chat.slash import cost_inline as _cost_inline_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/compact.py
+++ b/src/reyn/chat/slash/compact.py
@@ -1,0 +1,77 @@
+"""``/compact`` — compact the conversation history now to free context window.
+
+The fourth user-facing avoidance mechanism for the conversation-window
+dead-end (#191): the LLM-judgment route (the `compact` op) and the mandatory
+`retry_loop` backstop already exist; this gives the **user** on-demand control,
+matching the window-utilization-first compaction policy (#1185) where the user
+decides when to spend a compaction rather than aggressive auto-compaction
+imposing it.
+
+Unlike the `compact` op (LLM-emitted, routed through the op runtime), this is
+user input → it calls the session-level compaction directly. It reuses
+``ChatSession._compact_now_for_op`` (the same `force_compact_now` wrapper the
+compact op uses), so the freed-token report is the **same contract** as the op:
+``{freed_tokens, free_window_after}``.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.chat.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.chat.session import ChatSession
+
+
+@slash(
+    "compact",
+    summary="Compact the conversation history now to free up context window",
+    usage="/compact",
+    see_also=("docs/reference/runtime/control-ir.md",),
+)
+async def compact_cmd(session: "ChatSession", args: str) -> None:
+    """``/compact`` — fire on-demand history compaction and report what it freed.
+
+    Routes through the session's compaction wrapper (force_compact_now); reports
+    freed tokens + the free window afterwards in exact tokens (same contract as
+    the `compact` op). Fail-loud on error rather than a silent no-op.
+    """
+    compact_now = getattr(session, "_compact_now_for_op", None)
+    if compact_now is None:
+        await reply_error(
+            session,
+            "compaction is not available in this session "
+            "(no compaction engine wired).",
+        )
+        return
+
+    try:
+        result = await compact_now()
+    except Exception as exc:  # noqa: BLE001 — surface to the user, never crash the REPL
+        await reply_error(session, f"compaction failed: {exc}")
+        return
+
+    # #191: front the chat compression metric, not router-view `freed_tokens`
+    # (structurally ~0 for chat — the router prompt is head+tail TURN-bounded, so
+    # compaction COMPRESSES the already-elided middle into a summary bridge rather
+    # than shrinking the bounded view). What's meaningful: how many older turns
+    # were summarised and the raw→bridge token compression.
+    n = result.get("summarized_turns", 0)
+    if n <= 0:
+        free_after = result.get("free_window_after")
+        tail = f" Free window: ~{free_after} tokens." if free_after is not None else ""
+        await reply(
+            session,
+            "✓ Nothing to compact right now — recent history already fits the "
+            "window." + tail,
+        )
+        return
+
+    compressed = result.get("compressed_tokens", 0)
+    bridge = result.get("bridge_tokens", 0)
+    word = "turn" if n == 1 else "turns"
+    await reply(
+        session,
+        f"✓ Compacted — summarised {n} older {word} (~{compressed} tokens) into a "
+        f"~{bridge}-token summary bridge.",
+    )

--- a/tests/test_slash_compact_191.py
+++ b/tests/test_slash_compact_191.py
@@ -1,0 +1,149 @@
+"""Tier 2: OS invariant — /compact slash fires on-demand compaction + reports freed.
+
+#191 enabler: the user-control avoidance mechanism for the conversation-window
+dead-end (the LLM `compact` op + the retry_loop backstop being the other routes).
+`/compact` runs the session-level compaction directly (user input, not an LLM op)
+via the same `force_compact_now` wrapper the compact op uses (`_compact_now_for_op`),
+and reports freed tokens + the free window afterwards.
+
+Real instances, no mocks: a real ChatSession with a real CompactionController/
+engine; only `litellm.acompletion` (the compaction LLM call) is monkeypatched to a
+plain async callable returning a scripted summary. Verifies the slash actually
+fires compaction and reports the freed tokens — not LLM behavior.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import litellm
+
+from reyn.budget.budget import BudgetTracker, CostConfig
+from reyn.chat.session import ChatMessage, ChatSession
+from reyn.chat.slash import REGISTRY
+from reyn.config import CompactionConfig
+from reyn.events.state_log import StateLog
+
+# Compaction summary the engine's litellm call returns; new_turn_seqs lists the
+# candidate turn seqs (head=2/tail=2 over 8 turns → candidates 3..6).
+_SUMMARY_JSON = json.dumps({
+    "topic_arc": "compacted summary of older turns",
+    "decisions": [], "pending": [],
+    "session_user_facts": [], "artifacts_referenced": [],
+    "new_turn_seqs": [3, 4, 5, 6],
+})
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_session(tmp_path) -> ChatSession:
+    return ChatSession(
+        agent_name="default",
+        budget_tracker=BudgetTracker(CostConfig()),
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+        compaction_config=CompactionConfig(
+            head_size=2, tail_size=2, min_compact_batch=1,
+            trigger_total_tokens=100_000,  # high → no auto-fire; /compact forces it
+            use_chars4_estimate=True,      # deterministic offline token counts
+        ),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+
+
+def _drain(session) -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+def _reply_text(session) -> str:
+    return " ".join(getattr(m, "text", "") for m in _drain(session))
+
+
+def test_compact_slash_registered() -> None:
+    """Tier 2: /compact resolves in the slash registry to its handler."""
+    cmd = REGISTRY.get("compact")
+    assert cmd is not None
+    assert cmd.name == "compact"
+
+
+def _populate(session) -> None:
+    # 8 user turns (seq 1..8 auto-assigned); head=2/tail=2 → candidates 3..6.
+    for _ in range(8):
+        session._append_history(ChatMessage(role="user", content="x" * 4000, ts=_now()))
+
+
+def _script_compaction_llm(monkeypatch) -> None:
+    async def _fake_acompletion(model, messages, **kw):  # noqa: ANN001, ANN003
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=_SUMMARY_JSON))]
+        )
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+
+def test_compact_now_for_op_real_chat_measurement(tmp_path, monkeypatch) -> None:
+    """Tier 2: with a REAL engine (not a stub), _compact_now_for_op on the chat
+    axis reports the middle-COMPRESSION metric — summarized_turns>0 and
+    compressed_tokens shrunk into a smaller bridge — while router-view
+    freed_tokens is ~0 (structural: the router prompt is head+tail turn-bounded,
+    so compaction bridges the already-elided middle rather than shrinking the
+    view). Closes the #1177/#1182 test gap (those scripted a compact_now stub)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    _populate(session)
+    _script_compaction_llm(monkeypatch)
+
+    result = asyncio.run(session._compact_now_for_op())
+
+    assert result["summarized_turns"] > 0, "compaction must have summarised older turns"
+    assert result["compressed_tokens"] > 0
+    assert result["compressed_tokens"] > result["bridge_tokens"], (
+        "the summary bridge must be smaller than the raw middle it compresses"
+    )
+    # router-view freed is ~0 for chat (the documented structural finding) — it is
+    # NOT the chat signal; assert it doesn't masquerade as a large freeing.
+    assert result["freed_tokens"] < result["compressed_tokens"]
+    assert any(m.role == "summary" for m in session.history)
+
+
+def test_compact_slash_reports_compression(tmp_path, monkeypatch) -> None:
+    """Tier 2: /compact runs real compaction and reports the summarised-turns +
+    raw→bridge compression (not a misleading router-view 'freed' number)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    _populate(session)
+    _script_compaction_llm(monkeypatch)
+
+    asyncio.run(REGISTRY.get("compact").handler(session, ""))
+
+    text = _reply_text(session).lower()
+    assert "summaris" in text and "bridge" in text, (
+        f"expected a summarised-turns + bridge compression report; got: {text!r}"
+    )
+    assert any(m.role == "summary" for m in session.history), (
+        "compaction must have produced a summary turn in history"
+    )
+
+
+def test_compact_slash_nothing_to_compact(tmp_path, monkeypatch) -> None:
+    """Tier 2: with no compactable turns, /compact reports nothing to compact
+    (freed=0 path) — never a misleading 'freed' claim."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    # 3 turns < head(2)+tail(2) → no candidates → force_compact_now no-ops.
+    for _ in range(3):
+        session._append_history(ChatMessage(role="user", content="hi", ts=_now()))
+
+    async def _fail_acompletion(*a, **k):  # noqa: ANN002, ANN003
+        raise AssertionError("no LLM call expected when there is nothing to compact")
+    monkeypatch.setattr(litellm, "acompletion", _fail_acompletion)
+
+    asyncio.run(REGISTRY.get("compact").handler(session, ""))
+
+    text = _reply_text(session).lower()
+    assert "nothing to compact" in text, f"expected the no-op report; got: {text!r}"


### PR DESCRIPTION
**[e2e-coder]** — #191 enabler (settled, design #1185). The user-control avoidance mechanism for the conversation-window dead-end — 4th route alongside the LLM `compact` op (#1177) + the `retry_loop` backstop. Metric design + 2 follow-ups confirmed by lead-coder (broker).

## What
`src/reyn/chat/slash/compact.py`: `/compact` runs on-demand history compaction via the session-level `force_compact_now` wrapper (`_compact_now_for_op`) — user input, routed directly (not the op runtime) — and reports what it did. Registered in the slash module (after `clear-history`).

## Traced finding (this PR's substance — lead-coder-confirmed)
The CHAT router prompt is **head+tail TURN-COUNT bounded** (`_build_history_for_router`), so router-view `freed_tokens` is **structurally ~0** even when compaction fires (debug: before_used 4033 → after_used 4054). Chat compaction **compresses the already-elided middle into a summary bridge** — it doesn't shrink the bounded view. So:
- `_compact_now_for_op` now also returns the **chat compression metric**: `summarized_turns` + `compressed_tokens` (raw middle) → `bridge_tokens` (the summary).
- `/compact` fronts that — *"summarised N older turns (~X tok) into a ~Y-tok bridge"* — not the misleading `freed` number.
- `freed_tokens` stays in the op contract shared with the phase axis but is documented **per-axis**: **chat = middle-compression / phase = control_ir shrink** (phase B1 #1182 freed IS real).

This also corrected the #1185 analysis (lead-coder): the real window-utilization lever is **head/tail turn count**, not the 30K trigger.

## Follow-ups (flagged, not in this PR)
1. **Align the merged compact op #1177's freed-report** to this chat compression metric (the op handler already passes the new fields through; only its report/event wording needs updating).
2. The #1185 knob correction (head/tail count) — lead-coder articulating to the user.

## Test plan (Tier 2, real CompactionEngine + scripted litellm — no stub)
- [x] `tests/test_slash_compact_191.py` (4): **real-measurement** pin (`freed~0` + `summarized_turns>0` + `compressed>bridge` via the real `_compact_now_for_op`, not a stub — closes the #1177/#1182 test gap where `compact_now` was stubbed); `/compact` reports the compression; no-op path; registration.
- [x] compact/slash/session/router/chatsession/media_cap sweep → 673 passed (additive `_compact_now_for_op` fields, no regression); ruff + tier-audit `--strict` clean.
- [ ] full suite (running; CI gates).

Refs #191 #1185 #1177 #1182 #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)