### PR TITLE
refactor(tui): single-source the intervention warm surface (cross-file dup)

### DIFF
--- a/src/reyn/chat/tui/_palette.py
+++ b/src/reyn/chat/tui/_palette.py
@@ -114,6 +114,18 @@ _STATUS_SUCCESS_DARK = "#3a9968"
 # accent, and _STATUS_READY olive.
 _HINT_ACTION = "#9a8a52"
 
+# Intervention widget warm surface (promoted from cross-file duplicates that
+# lived in BOTH intervention.py DEFAULT_CSS and theme.tcss — a drift hazard
+# now that theme.tcss can reference _palette via the $reyn-* CSS vars). These
+# name the intervention widget's own warm theme; distinct from the global
+# _BG_*/_TEXT_* ramp. The remaining intervention browns (#2a1a10 / #443322 /
+# #aa8866 / #664433 / #ddaa88) are intervention.py-only (single-use) → left
+# literal there (tokenising single-use colours adds indirection without a
+# single-source win).
+_IV_SURFACE = "#1e1510"          # intervention widget background
+_IV_TEXT = "#eeddcc"             # intervention default text
+_IV_HOVER = "#e0664e"            # intervention button hover / focus
+
 __all__ = [
     "_CORAL",
     "_AMBER",
@@ -150,6 +162,9 @@ __all__ = [
     "_STATUS_READY",
     "_STATUS_SUCCESS_DARK",
     "_HINT_ACTION",
+    "_IV_SURFACE",
+    "_IV_TEXT",
+    "_IV_HOVER",
     "css_variables",
 ]
 
@@ -182,4 +197,7 @@ def css_variables() -> dict[str, str]:
         "reyn-status-critical": _STATUS_CRITICAL,
         "reyn-status-warn": _STATUS_WARN,
         "reyn-event-intervention": _EVENT_INTERVENTION,
+        "reyn-iv-surface": _IV_SURFACE,
+        "reyn-iv-text": _IV_TEXT,
+        "reyn-iv-hover": _IV_HOVER,
     }

--- a/src/reyn/chat/tui/theme.tcss
+++ b/src/reyn/chat/tui/theme.tcss
@@ -103,12 +103,12 @@ InputBar #hints {
 
 /* Intervention widget */
 InterventionWidget {
-    background: #1e1510;
+    background: $reyn-iv-surface;
     border: solid $primary;
     padding: 1 2;
     height: auto;
     margin: 1 0;
-    color: #eeddcc;
+    color: $reyn-iv-text;
 }
 
 InterventionWidget .iv-question {
@@ -133,7 +133,7 @@ InterventionWidget Button {
 }
 
 InterventionWidget Button:hover {
-    background: #e0664e;
+    background: $reyn-iv-hover;
 }
 
 InterventionWidget Button:focus {
@@ -142,6 +142,6 @@ InterventionWidget Button:focus {
        the previous "background lightens slightly" cue was a 1.28:1
        contrast change relative to the hover state, indistinguishable
        without color vision. */
-    background: #e0664e;
+    background: $reyn-iv-hover;
     text-style: bold reverse;
 }

--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -18,7 +18,14 @@ from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Button, Input, Label
 
-from reyn.chat.tui._palette import _EVENT_INTERVENTION, _TEXT_BODY, _TEXT_MUTED
+from reyn.chat.tui._palette import (
+    _EVENT_INTERVENTION,
+    _IV_HOVER,
+    _IV_SURFACE,
+    _IV_TEXT,
+    _TEXT_BODY,
+    _TEXT_MUTED,
+)
 
 
 class InterventionWidget(Widget):
@@ -40,12 +47,12 @@ class InterventionWidget(Widget):
 
     DEFAULT_CSS = f"""
     InterventionWidget {{
-        background: #1e1510;
+        background: {_IV_SURFACE};
         border: solid $primary;
         padding: 1 2;
         height: auto;
         margin: 1 0;
-        color: #eeddcc;
+        color: {_IV_TEXT};
     }}
     InterventionWidget Label.iv-question {{
         color: {_EVENT_INTERVENTION};
@@ -84,7 +91,7 @@ class InterventionWidget(Widget):
         min-width: 6;
     }}
     InterventionWidget Button:hover {{
-        background: #e0664e;
+        background: {_IV_HOVER};
     }}
     InterventionWidget Input {{
         margin-top: 1;


### PR DESCRIPTION
**[tui-coder]** — #1169 **category-2b**, unblocked by #1186. lead-coder's revised second-opinion + my agreement.

## Why now (post-#1186 calculus)

`#1e1510` / `#eeddcc` / `#e0664e` were duplicated in **both** `theme.tcss` and `intervention.py` — a genuine cross-file **drift hazard** (change one, the other silently drifts). Pre-#1186 I left them literal (tokenising didn't reduce edit-sites: `.tcss` couldn't reference Python tokens). **#1186's CSS-var bridge changed that** — both sides can now reference `_palette`, so promoting collapses 2 literals → 1 source cheaply. Genuine cross-file dup ⇒ tokenise (unlike the single-use category-2a browns).

## Changes

- `_palette.py`: `_IV_SURFACE` / `_IV_TEXT` / `_IV_HOVER` + their `reyn-iv-*` CSS-var rows.
- `theme.tcss`: → `$reyn-iv-surface` / `-text` / `-hover`.
- `intervention.py`: → `{_IV_SURFACE}` / `{_IV_TEXT}` / `{_IV_HOVER}`.

## Left literal (intentional, value-based)

`intervention.py`'s `#2a1a10`/`#443322`/`#aa8866`/`#664433`/`#ddaa88` are intervention-only **single-use** (no cross-file dup) → tokenising adds indirection without a single-source win. `theme.tcss`'s `#ffffff` has no token. **Value-based localize** (tokenise cross-file dups, leave single-use), not mechanical exhaustion.

## Value-preserving

Tokens == original hexes (verified: intervention CSS renders the same 3 hexes, `css_variables()` values match, braces balanced). **42 smoke + bridge + 72 intervention regression tests green.**

## Test plan

- [x] theme.tcss remaining hex = only `#ffffff`; intervention.py active 3 hex → 0 (category-2a browns intentionally remain)
- [x] intervention CSS value-preserving + `css_variables()` 3 new rows consistent
- [x] `pytest tests/cli/test_tui_smoke.py test_palette_css_variables.py` — 42 passed
- [x] `pytest tests/cli -k intervention` — 72 passed
- [x] `ruff check` (Python files) clean / tier-audit clean

No test added (value-preserving token-ref; the #1186 css-var bridge test already pins var==token for the new `reyn-iv-*` rows; smoke covers parse).

Refs #1169 — **category-2b done**; the consolidation's genuine targets (category-1 + cross-file category-2b + category-3) are now all single-sourced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)