### PR TITLE
fix(compact-op): #1177 report alignment — surface chat compression metric (event + doc)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -502,12 +502,12 @@ Fields:
 
 Returns:
 - `status: "ok" | "error"`
-- `freed_tokens: int` — tokens removed from the window by the compaction
-- `free_window_after: int` — exact-token headroom after compaction
-- `free_window_before: int` — headroom before (for delta reasoning)
+- `freed_tokens: int` — exact-token reduction. **Per-axis meaning (#191)**: on the **phase** axis this is the real `control_ir_results` shrink. On the **chat** axis it is **~0 by construction** — the router prompt is head+tail *turn*-count bounded (`_build_history_for_router`), so compaction does not shrink the bounded view; it compresses the already-elided middle into a summary bridge. Don't front `freed_tokens` for chat.
+- `free_window_after` / `free_window_before: int` — exact-token headroom after / before.
+- **Chat-axis compression metric** (the meaningful chat signal; `null` on the phase axis): `summarized_turns: int` (older turns folded into the bridge), `compressed_tokens: int` (their raw token cost), `bridge_tokens: int` (the summary's token cost). The chat value is the `compressed_tokens → bridge_tokens` compression, not `freed_tokens`.
 - On error: `error_kind` (`compaction_unavailable` when no compaction context is wired here; `compaction_failed`) + `error`.
 
-**Events**: `compact_op_requested` / `compact_op_completed` (`freed_tokens`, `free_window_after`) / `compact_op_failed` / `compact_op_unavailable` (P6). The inner compaction engine emits its own compaction events.
+**Events**: `compact_op_requested` / `compact_op_completed` (`freed_tokens`, `free_window_after`, + chat-axis `summarized_turns` / `compressed_tokens` / `bridge_tokens`) / `compact_op_failed` / `compact_op_unavailable` (P6). The inner compaction engine emits its own compaction events.
 
 **Permission**: none required (LLM cost only). Voluntary and independent of the involuntary `retry_loop` backstop, which always runs regardless.
 

--- a/src/reyn/op_runtime/compact.py
+++ b/src/reyn/op_runtime/compact.py
@@ -69,9 +69,13 @@ async def handle(
             "error": str(exc),
         }
 
-    # ``result`` carries exact-token fields from the caller's wrapper
-    # ({freed_tokens, free_window_after, ...}). Pass them through verbatim so
-    # the unit-alignment with the context-size signal is preserved.
+    # ``result`` carries the caller's wrapper fields, passed through verbatim.
+    # The meaningful metric is per-axis (#191): the CHAT wrapper reports the
+    # middle-compression (summarized_turns + compressed_tokens → bridge_tokens;
+    # router-view freed_tokens is ~0 because the router prompt is head+tail
+    # turn-bounded), while the PHASE wrapper reports a real control_ir
+    # freed_tokens shrink. The event surfaces all fields via .get() so each axis
+    # populates the ones that apply (the other side stays None).
     out: dict = {"kind": "compact", "status": "ok"}
     out.update(result or {})
     ctx.events.emit(
@@ -80,6 +84,10 @@ async def handle(
         phase=ctx.current_phase,
         freed_tokens=out.get("freed_tokens"),
         free_window_after=out.get("free_window_after"),
+        # #191 chat-axis compression metric (None on the phase axis):
+        summarized_turns=out.get("summarized_turns"),
+        compressed_tokens=out.get("compressed_tokens"),
+        bridge_tokens=out.get("bridge_tokens"),
     )
     return out
 

--- a/tests/test_compact_op_272.py
+++ b/tests/test_compact_op_272.py
@@ -64,6 +64,28 @@ def test_compact_routes_to_capability_and_passes_exact_tokens() -> None:
     assert "compact_op_completed" in ctx.events.types()
 
 
+def test_compact_chat_compression_fields_pass_through_to_result_and_event() -> None:
+    """Tier 2: #191/#1177 — the chat-axis compression metric (summarized_turns +
+    compressed_tokens → bridge_tokens) flows through the op result AND the
+    compact_op_completed event, so chat compaction is reported by its real value
+    (not the ~0 router-view freed_tokens)."""
+    async def _chat_cap() -> dict:
+        return {
+            "freed_tokens": 0, "free_window_after": 90_000, "free_window_before": 90_000,
+            "summarized_turns": 4, "compressed_tokens": 1200, "bridge_tokens": 80,
+        }
+
+    ctx = _ctx(_chat_cap)
+    result = asyncio.run(execute_op(CompactIROp(kind="compact"), ctx, caller="control_ir"))
+    assert result["status"] == "ok"
+    assert result["summarized_turns"] == 4
+    assert result["compressed_tokens"] == 1200 and result["bridge_tokens"] == 80
+    # the completion event carries the compression fields too (per-axis report).
+    ev = next(kw for (t, kw) in ctx.events.emitted if t == "compact_op_completed")
+    assert ev["summarized_turns"] == 4
+    assert ev["compressed_tokens"] == 1200 and ev["bridge_tokens"] == 80
+
+
 def test_compact_fail_loud_when_unwired() -> None:
     """Tier 2: no compaction context → structured compaction_unavailable error,
     never a silent no-op (the model must not believe the window was freed)."""


### PR DESCRIPTION
**[e2e-coder]** — follow-up #1 to #1187 (lead-coder dispatch). Small, settled.

## What
After #1187 the chat-axis compaction metric (`summarized_turns` + `compressed_tokens` → `bridge_tokens`) is what `_compact_now_for_op` returns for chat (router-view `freed_tokens` is ~0 by construction — head+tail turn-bounded). The compact op handler **already passes those fields through** to the op result (`out.update(result)`), but the `compact_op_completed` **event** only emitted `freed_tokens`/`free_window_after`. This aligns the op's report to `/compact`'s per-axis expression.

## Changes
- `op_runtime/compact.py`: `compact_op_completed` event now also emits `summarized_turns` / `compressed_tokens` / `bridge_tokens` (via `.get()` → each axis populates what applies: **chat** = compression + `freed~0`, **phase** = real `control_ir` `freed`).
- `control-ir.md` compact section: documents the **per-axis `freed_tokens` meaning** (phase = control_ir shrink / chat = ~0, compression is the real signal) + the chat compression fields in Returns + Events.

## Test plan (Tier 2)
- [x] `test_compact_op_272`: compression fields flow through the op **result** AND the **completion event** (real `execute_op` + `OpContext`, scripted `compact_now`).
- [x] compact sweep → 178 passed; ruff + tier-audit `--strict` clean.

Refs #191 #1177 #1182 #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)