### PR TITLE
feat(llm): #1190 stage (i) — cost-observability chokepoint + record_llm purpose

### DIFF
--- a/src/reyn/budget/budget.py
+++ b/src/reyn/budget/budget.py
@@ -169,8 +169,14 @@ class BudgetLedger:
         model: str,
         tokens: int,
         cost_usd: float,
+        purpose: str | None = None,
     ) -> None:
-        """Append one record and fsync."""
+        """Append one record and fsync.
+
+        ``purpose`` (#1190) is the cost-attribution bucket
+        (main/phase/compaction/judge/skill_node_adapt/dogfood). Omitted from the
+        record when None so pre-#1190 ledger lines stay byte-identical.
+        """
         # Build ISO-8601 timestamp with local UTC offset.
         now = time.time()
         lt = time.localtime(now)
@@ -190,6 +196,8 @@ class BudgetLedger:
             "tokens": tokens,
             "cost_usd": cost_usd,
         }
+        if purpose is not None:
+            record["purpose"] = purpose
         line = json.dumps(record, ensure_ascii=False) + "\n"
         # Guard against partial writes from a previous crash (no trailing newline).
         need_lead = self._needs_lead_newline()
@@ -526,6 +534,7 @@ class BudgetTracker:
         usage: TokenUsage,
         chain_id: str | None = None,
         skill: str | None = None,
+        purpose: str | None = None,
     ) -> BudgetCheck:
         """Update counters after a successful LLM call.
 
@@ -574,6 +583,7 @@ class BudgetTracker:
                 model=model,
                 tokens=usage.total_tokens,
                 cost_usd=cost_usd,
+                purpose=purpose,
             )
 
         # Warn on daily / monthly thresholds

--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -405,6 +405,7 @@ class LLMCallRecorder:
         check = self._budget_tracker.record_llm(
             model=model, agent=agent, usage=usage,
             chain_id=self._chain_id, skill=self._budget_skill_name,
+            purpose="phase",  # #1190: the OS phase-execution LLM path
         )
         for dim in check.warn_dimensions:
             self._events.emit(

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -713,6 +713,70 @@ def proxy_kwargs() -> dict:
     return {"api_base": api_base, "custom_llm_provider": "openai", "api_key": api_key}
 
 
+# #1190 cost-observability: the valid purpose (cost-attribution) buckets. Every
+# recorded_acompletion call must tag one so /cost can break spend down by where
+# the LLM call originated. ``dogfood`` covers test/trace sites (recorder=None).
+LLM_PURPOSES: tuple[str, ...] = (
+    "main", "phase", "compaction", "judge", "skill_node_adapt", "dogfood",
+)
+
+
+async def recorded_acompletion(
+    *,
+    model: str,
+    messages: list,
+    purpose: str,
+    recorder: object | None = None,
+    agent: str | None = None,
+    response_format: dict | None = None,
+    fallback_without_response_format: bool = False,
+    extra_kwargs: dict | None = None,
+) -> object:
+    """Single cost-observability chokepoint for ALL ``litellm.acompletion`` calls (#1190).
+
+    Absorbs proxy routing + provider-prefix strip, performs the call (with an
+    optional ``response_format`` retry-without fallback), extracts usage, and
+    records it via ``recorder.record_llm(purpose=...)`` **by construction** when
+    a recorder is given. Returns the RAW litellm response — callers keep their
+    own response-shape handling (``.content`` / json parse / tool extraction)
+    above. ``purpose`` is the required cost-attribution bucket (see
+    ``LLM_PURPOSES``).
+
+    Stage (iii)'s AST guard (tya5/reyn#1190) enforces that ``litellm.acompletion``
+    is called ONLY inside this function, so no LLM call can bypass recording.
+    Replay-safe: the call still bottoms out at ``litellm.acompletion``, which
+    ``LLMReplay`` monkeypatches.
+    """
+    import litellm
+
+    extra = proxy_kwargs()
+    effective_model = model.split("/", 1)[1] if extra and "/" in model else model
+    base_kwargs = dict(extra_kwargs or {})
+    base_kwargs.update(extra)  # Reyn proxy kwargs win over caller-supplied ones
+
+    async def _once(rf: dict | None) -> object:
+        call_kwargs = dict(base_kwargs)
+        if rf is not None:
+            call_kwargs["response_format"] = rf
+        return await litellm.acompletion(model=effective_model, messages=messages, **call_kwargs)
+
+    try:
+        response = await _once(response_format)
+    except Exception:
+        if response_format is not None and fallback_without_response_format:
+            response = await _once(None)
+        else:
+            raise
+
+    if recorder is not None:
+        usage = _extract_usage(response)
+        if usage is not None:
+            recorder.record_llm(
+                model=effective_model, agent=agent, usage=usage, purpose=purpose,
+            )
+    return response
+
+
 def _build_system_message(system_text: str, prompt_cache_enabled: bool) -> dict:
     """Build the system message, optionally with an Anthropic cache_control marker.
 
@@ -749,6 +813,7 @@ async def call_llm(
     agent_role: str = "",
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,
+    purpose: str = "main",  # #1190 cost-attribution bucket (see LLM_PURPOSES)
     trace_caller: str | None = None,
     event_log: "EventLog | None" = None,
 ) -> LLMCallResult:
@@ -871,24 +936,21 @@ async def call_llm(
             })
 
         async def _do_call() -> object:
-            import litellm
-            try:
-                return await litellm.acompletion(
-                    model=effective_model,
-                    messages=messages,
-                    response_format={"type": "json_object"},
-                    **spec_kwargs,
-                    **common_kwargs,
-                    **extra,
-                )
-            except Exception:
-                return await litellm.acompletion(
-                    model=effective_model,
-                    messages=messages,
-                    **spec_kwargs,
-                    **common_kwargs,
-                    **extra,
-                )
+            # #1190: route through the single cost-observability chokepoint
+            # (proxy + prefix-strip + json_object fallback live there now).
+            # recorder=None here — call_llm keeps its own retry-aware
+            # record-once below (the chokepoint records the bypass sites that
+            # have no existing record). ``extra`` is re-derived inside the
+            # chokepoint, so only spec/common kwargs are passed through.
+            return await recorded_acompletion(
+                model=effective_model,
+                messages=messages,
+                purpose=purpose,
+                recorder=None,
+                response_format={"type": "json_object"},
+                fallback_without_response_format=True,
+                extra_kwargs={**spec_kwargs, **common_kwargs},
+            )
 
         response = await _llm_call_with_retry(_do_call, effective_model, event_log)
 
@@ -944,6 +1006,7 @@ async def call_llm(
                 model=effective_model,
                 agent=budget_agent,
                 usage=result.usage,
+                purpose=purpose,
             )
         return result
 
@@ -982,6 +1045,7 @@ async def call_llm_tools(
     prompt_cache_enabled: bool = True,
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,
+    purpose: str = "main",  # #1190 cost-attribution bucket (chat router = main)
     trace_caller: str | None = None,
     event_log: "EventLog | None" = None,
 ) -> LLMToolCallResult:
@@ -1110,8 +1174,17 @@ async def call_llm_tools(
     })
 
     async def _tools_call() -> object:
-        import litellm
-        return await litellm.acompletion(**call_kwargs)
+        # #1190: route through the single cost-observability chokepoint.
+        # recorder=None — call_llm_tools keeps its own record below; the
+        # chokepoint re-derives proxy kwargs (idempotent) so only the
+        # pre-built tools/tool_choice/response_format kwargs flow as extras.
+        _kw = dict(call_kwargs)
+        _model = _kw.pop("model")
+        _messages = _kw.pop("messages")
+        return await recorded_acompletion(
+            model=_model, messages=_messages, purpose=purpose,
+            recorder=None, extra_kwargs=_kw,
+        )
 
     response = await _llm_call_with_retry(_tools_call, effective_model, event_log)
 
@@ -1126,6 +1199,7 @@ async def call_llm_tools(
             model=effective_model,
             agent=budget_agent,
             usage=usage,
+            purpose=purpose,
         )
 
     # Normalize tool_calls to plain dicts so callers don't depend on litellm internals

--- a/tests/test_cost_chokepoint_1190.py
+++ b/tests/test_cost_chokepoint_1190.py
@@ -1,0 +1,117 @@
+"""Tier 2: OS invariant — #1190 stage (i) cost-observability chokepoint.
+
+`recorded_acompletion` is the single cost-recording chokepoint: it absorbs proxy
+routing + provider-prefix strip + the response_format fallback, performs the
+`litellm.acompletion` call, and records usage via `recorder.record_llm(purpose=...)`
+by construction when a recorder is given. `record_llm` + the budget ledger gain a
+`purpose` cost-attribution bucket. (Stage ii migrates the 5 bypass sites; stage
+iii adds the AST guard making bypass impossible.)
+
+Real instances + a hand-written recorder stub + scripted `litellm.acompletion`
+(a plain async callable) — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import litellm
+
+from reyn.budget.budget import BudgetLedger
+from reyn.llm.llm import LLM_PURPOSES, recorded_acompletion
+from reyn.llm.pricing import TokenUsage
+
+
+class _Recorder:
+    """Hand-written recorder capturing record_llm calls (not a mock)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def record_llm(self, **kw: Any) -> None:
+        self.calls.append(kw)
+
+
+def _resp(prompt: int = 10, completion: int = 5, content: str = "ok") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion),
+    )
+
+
+def test_recorded_acompletion_records_with_purpose(monkeypatch) -> None:
+    """Tier 2: the chokepoint records usage via recorder.record_llm tagged with
+    the call's purpose (by construction when a recorder is given)."""
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        return _resp(prompt=30, completion=7)
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    rec = _Recorder()
+    resp = asyncio.run(recorded_acompletion(
+        model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
+        purpose="compaction", recorder=rec, agent="a1",
+    ))
+    assert resp.choices[0].message.content == "ok", "returns the RAW litellm response"
+    # one record, tagged compaction (behavioral — the recorded purpose sequence).
+    assert [c["purpose"] for c in rec.calls] == ["compaction"]
+    call = rec.calls[0]
+    assert call["agent"] == "a1"
+    assert isinstance(call["usage"], TokenUsage) and call["usage"].total_tokens == 37
+    assert "compaction" in LLM_PURPOSES
+
+
+def test_recorded_acompletion_no_record_when_recorder_none(monkeypatch) -> None:
+    """Tier 2: recorder=None (e.g. call_llm's own retry-aware record path, or a
+    dogfood site) → the call still runs, nothing is recorded here."""
+    called = {"n": 0}
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        called["n"] += 1
+        return _resp()
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    resp = asyncio.run(recorded_acompletion(
+        model="m", messages=[{"role": "user", "content": "x"}],
+        purpose="dogfood", recorder=None,
+    ))
+    assert called["n"] == 1 and resp.choices[0].message.content == "ok"
+
+
+def test_recorded_acompletion_response_format_fallback(monkeypatch) -> None:
+    """Tier 2: when response_format is rejected, the chokepoint retries without it
+    (and records the successful call once)."""
+    calls: list[bool] = []
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        has_rf = "response_format" in kw
+        calls.append(has_rf)
+        if has_rf:
+            raise ValueError("response_format unsupported")
+        return _resp()
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    rec = _Recorder()
+    asyncio.run(recorded_acompletion(
+        model="m", messages=[{"role": "user", "content": "x"}], purpose="judge",
+        recorder=rec, response_format={"type": "json_object"},
+        fallback_without_response_format=True,
+    ))
+    assert calls == [True, False], "first attempt with rf fails → retry without rf"
+    # records once (on the successful call), tagged judge — the failed attempt
+    # raised before recording.
+    assert [c["purpose"] for c in rec.calls] == ["judge"]
+
+
+def test_ledger_persists_purpose_and_omits_when_none(tmp_path: Path) -> None:
+    """Tier 2: the budget ledger persists `purpose` when given, and omits the
+    field entirely when None (pre-#1190 lines stay byte-identical)."""
+    ledger = BudgetLedger(tmp_path / "ledger.jsonl")
+    ledger.append(agent="a", model="m", tokens=10, cost_usd=0.0, purpose="phase")
+    ledger.append(agent="a", model="m", tokens=5, cost_usd=0.0)  # no purpose
+
+    lines = [json.loads(line) for line in (tmp_path / "ledger.jsonl").read_text().splitlines() if line.strip()]
+    assert lines[0]["purpose"] == "phase"
+    assert "purpose" not in lines[1], "None purpose must be omitted (legacy byte-identical)"


### PR DESCRIPTION
**[e2e-coder]** — #1190 stage (i) of 3 (design approved; fork = explicit threading, llm.py home, purpose enum, dogfood via chokepoint, incremental). lead-coder reviews each stage.

## This stage
The single chokepoint every `acompletion` will route through + the `purpose` cost-attribution field.
- **`recorded_acompletion`** (llm.py): absorbs `proxy_kwargs` + provider-prefix strip + the `response_format` retry-without fallback, calls `litellm.acompletion`, and records usage via `recorder.record_llm(purpose=...)` **by construction** when a recorder is given. Returns the **raw** litellm response (callers keep their `.content`/json/tool handling above). `LLM_PURPOSES = main|phase|compaction|judge|skill_node_adapt|dogfood`.
- **`record_llm` + `BudgetLedger`** gain a `purpose` field — omitted from the ledger record when None, so pre-#1190 lines stay byte-identical.
- **`call_llm` + `call_llm_tools`** route their acompletion through the chokepoint (`recorder=None` — each keeps its existing retry-aware record-once, now `purpose`-tagged; the chokepoint's by-construction recording lands the bypass sites in stage ii). `LLMCallRecorder` (OS phase path) records `purpose="phase"`.

## Replay-safe (verified)
The chokepoint still bottoms out at `litellm.acompletion`, which `LLMReplay` monkeypatches at module level → fixtures unaffected. The 675-test llm/budget/replay/router/compaction/skill_node sweep is green.

## Sequencing (per design)
- **(i, this PR)**: chokepoint + record_llm/ledger purpose + call_llm/call_llm_tools routed.
- (ii): migrate the 5 bypass sites (compaction ×3, judge_output, skill_node_adapt) + dogfood sites onto the chokepoint (purpose-tagged; recorder threaded so they record).
- (iii) **keystone**: AST guard — `litellm.acompletion` appears only inside `recorded_acompletion` (#1172/#997 pattern) + per-purpose /cost test.

## Follow-up noted
Optionally centralise `call_llm`'s own record into the chokepoint (per-call vs the current retry-aware record-once — a minor cost-accounting semantics change on the rare empty-response-retry path; deferred here to avoid changing counts).

## Test plan (Tier 2, real recorder/ledger + scripted litellm — no mocks)
- [x] `tests/test_cost_chokepoint_1190.py` (4): records-with-purpose; recorder=None → no record; response_format fallback records once on success; ledger persists purpose + omits when None.
- [x] 675 llm/budget/replay/router/compaction/skill_node sweep green; ruff + tier-audit `--strict` clean.
- [ ] full suite (CI gates).

Refs #1190 #191