### PR TITLE
feat(llm): #1190 stage (ii) — migrate all bypass sites onto the cost chokepoint

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -872,6 +872,8 @@ async def execute_plan(
                 # via the host's resolver so the engine never hands an
                 # unresolved class to litellm.
                 resolver=parent_host.resolver,
+                # #1190 stage (ii): record planner step-results compaction spend.
+                recorder=budget,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort; skip if unavailable
             logger.warning(

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1816,6 +1816,8 @@ class ChatSession:
                 events=self._chat_events,
                 system_prompt_provider=self._build_router_system_prompt,
                 resolver=self._resolver,
+                # #1190 stage (ii): record chat compaction LLM spend (purpose=compaction).
+                recorder=self._budget_tracker,
             ),
             history_appender=self._append_history,
             make_summary_message=lambda rendered, structured, covers: ChatMessage(

--- a/src/reyn/dogfood/interpretation.py
+++ b/src/reyn/dogfood/interpretation.py
@@ -145,25 +145,22 @@ async def generate_interpretation(
     ``"(interpretation unavailable: ...)"``.
     """
     try:
-        import litellm  # type: ignore[import]
-
-        from reyn.llm.llm import proxy_kwargs
+        # #1190 stage (ii): route through the cost chokepoint (purpose=dogfood,
+        # recorder=None — auxiliary trace surface, unrecorded). Stub-injection
+        # still works: recorded_acompletion calls litellm.acompletion underneath.
+        from reyn.llm.llm import recorded_acompletion
     except ImportError as exc:
         return f"(interpretation unavailable: {exc})"
 
     messages = build_prompt(scenario, scenario_result)
-    extra = proxy_kwargs()
-    effective_model = (
-        model.split("/", 1)[1] if extra and "/" in model else model
-    )
 
     try:
-        response = await litellm.acompletion(
-            model=effective_model,
+        response = await recorded_acompletion(
+            model=model,
             messages=messages,
-            timeout=timeout,
-            num_retries=1,
-            **extra,
+            purpose="dogfood",
+            recorder=None,
+            extra_kwargs={"timeout": timeout, "num_retries": 1},
         )
     except Exception as exc:  # noqa: BLE001 — auxiliary surface, must not bubble
         return f"(interpretation unavailable: {type(exc).__name__}: {exc})"

--- a/src/reyn/dogfood/verifiers/reply.py
+++ b/src/reyn/dogfood/verifiers/reply.py
@@ -33,8 +33,6 @@ async def _default_judge_fn(rubric: list[str], reply_text: str) -> dict:
     """
     import json
 
-    import litellm
-
     rubric_text = "\n".join(f"- {item}" for item in rubric)
     system_text = (
         "You are a strict evaluator. Score the following reply against the rubric.\n"
@@ -49,29 +47,21 @@ async def _default_judge_fn(rubric: list[str], reply_text: str) -> dict:
         {"role": "user", "content": user_text},
     ]
 
-    from reyn.llm.llm import proxy_kwargs
+    # #1190 stage (ii): route through the cost chokepoint (purpose=dogfood,
+    # recorder=None — eval verifier surface). The response_format fallback is
+    # absorbed by the chokepoint. Stub-injection still intercepts at
+    # litellm.acompletion underneath.
+    from reyn.llm.llm import recorded_acompletion
 
-    extra = proxy_kwargs()
-    model = "gemini-2.5-flash-lite"
-    effective_model = model.split("/", 1)[1] if extra and "/" in model else model
-
-    try:
-        response = await litellm.acompletion(
-            model=effective_model,
-            messages=messages,
-            response_format={"type": "json_object"},
-            timeout=30.0,
-            num_retries=2,
-            **extra,
-        )
-    except Exception:
-        response = await litellm.acompletion(
-            model=effective_model,
-            messages=messages,
-            timeout=30.0,
-            num_retries=2,
-            **extra,
-        )
+    response = await recorded_acompletion(
+        model="gemini-2.5-flash-lite",
+        messages=messages,
+        purpose="dogfood",
+        recorder=None,
+        response_format={"type": "json_object"},
+        fallback_without_response_format=True,
+        extra_kwargs={"timeout": 30.0, "num_retries": 2},
+    )
 
     raw: str = (response.choices[0].message.content or "").strip()
     if raw.startswith("```"):

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -96,9 +96,12 @@ class ControlIRExecutor:
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
+        budget_tracker: object | None = None,
     ) -> None:
         self.workspace = workspace
         self.events = events
+        # #1190 stage (ii): cost recorder for LLM-calling ops (judge_output).
+        self._budget_tracker = budget_tracker
         self._intervention_bus = intervention_bus
         self._max_phase_visits = max_phase_visits
         self._shell_allowed = shell_allowed
@@ -339,6 +342,8 @@ class ControlIRExecutor:
             mcp_servers=self._mcp_servers,
             mcp_clients=self._mcp_clients,
             intervention_bus=self._intervention_bus,
+            # #1190 stage (ii): cost recorder for LLM-calling ops (judge_output).
+            budget_tracker=self._budget_tracker,
             # #1176 B1: phase on-demand voluntary compaction capability. None
             # for batches with no phase compaction engine wired (compact op
             # then fail-louds compaction_unavailable, same as chat).

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -117,7 +117,9 @@ class RunOrchestrator:
         state_log: Any,
         caller: str,
         max_phase_visits: int,
+        budget_tracker: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
     ) -> None:
+        self._budget_tracker = budget_tracker
         self._phase_executor = phase_executor
         self._skill = skill
         self._workspace = workspace
@@ -254,6 +256,7 @@ class RunOrchestrator:
             resolver=self._resolver,
             events=self._events,
             safety=self._safety,
+            recorder=self._budget_tracker,
         )
         self._state.add_usage(usage, None)
         return adapted

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -184,6 +184,7 @@ class OSRuntime:
             multimodal_config=multimodal_config,
             media_store=media_store,
             secret_store=secret_store,
+            budget_tracker=budget_tracker,  # #1190 stage (ii): judge_output cost recording
         )
         self._preprocessor = PreprocessorExecutor(
             skill=skill,
@@ -248,6 +249,8 @@ class OSRuntime:
                     # class); resolve via the same resolver the main phase LLM
                     # call uses (runtime.py main-call: self._resolver.resolve).
                     resolver=self._resolver,
+                    # #1190 stage (ii): record phase act-results compaction spend.
+                    recorder=budget_tracker,
                 )
             except Exception:  # noqa: BLE001 — best-effort; skip if unavailable
                 phase_compaction_engine = None
@@ -300,6 +303,7 @@ class OSRuntime:
             state_log=state_log,
             caller=caller,
             max_phase_visits=self._max_phase_visits,
+            budget_tracker=budget_tracker,  # #1190 stage (ii): skill_node_adapt cost recording
         )
 
     # ── Backward-compat properties (FP-0020 Component A) ───────────────────

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -79,6 +79,11 @@ class OpContext:
     # (same contract as ask_user without an intervention_bus).
     compact_now: "Callable[[], Awaitable[dict]] | None" = None
 
+    # #1190 stage (ii): BudgetTracker for cost recording from ops that make LLM
+    # calls (judge_output → purpose="judge"). Threaded by the OpContext builders
+    # (control_ir_executor / router_host_adapter); None = unrecorded.
+    budget_tracker: object | None = None
+
     # PR20: caller provenance threaded from the parent Agent so sub-skill
     # invocations land under the same `events/<caller>/skill_runs/...` tree.
     # Format: "direct" or "agents/<name>" (validated in Agent).

--- a/src/reyn/op_runtime/judge_output.py
+++ b/src/reyn/op_runtime/judge_output.py
@@ -126,33 +126,21 @@ async def handle(
     ]
 
     # ── 4. LLM call ──────────────────────────────────────────────────────────
-    from reyn.llm.llm import proxy_kwargs
+    # #1190 stage (ii): route through the cost chokepoint (purpose="judge",
+    # recorder from the OpContext). It owns proxy + prefix-strip + the
+    # response_format fallback + usage recording.
+    from reyn.llm.llm import recorded_acompletion
 
-    extra = proxy_kwargs()
-    # Strip provider prefix when routing via local proxy (same as call_llm).
-    effective_model = (
-        resolved_model.split("/", 1)[1] if extra and "/" in resolved_model else resolved_model
+    response = await recorded_acompletion(
+        model=resolved_model,
+        messages=messages,
+        purpose="judge",
+        recorder=getattr(ctx, "budget_tracker", None),
+        agent=getattr(ctx, "agent_id", None),
+        response_format={"type": "json_object"},
+        fallback_without_response_format=True,
+        extra_kwargs={"timeout": 30.0, "num_retries": 2},
     )
-
-    import litellm
-    try:
-        response = await litellm.acompletion(
-            model=effective_model,
-            messages=messages,
-            response_format={"type": "json_object"},
-            timeout=30.0,
-            num_retries=2,
-            **extra,
-        )
-    except Exception:
-        # Fallback: retry without response_format (for providers that don't support it)
-        response = await litellm.acompletion(
-            model=effective_model,
-            messages=messages,
-            timeout=30.0,
-            num_retries=2,
-            **extra,
-        )
 
     raw_content: str = (response.choices[0].message.content or "").strip()
 

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -707,6 +707,7 @@ class CompactionEngine:
         T_SP: int = 0,
         system_prompt_provider: Callable[[], str] | None = None,
         resolver: "ModelResolver | None" = None,
+        recorder: object | None = None,
     ) -> None:
         # #1172: resolve the model CLASS ("standard"/"light"/"strong") to its
         # LiteLLM string at construction — by-construction guarantee that no
@@ -722,6 +723,9 @@ class CompactionEngine:
             from reyn.llm.model_resolver import ModelResolver as _MR
             resolver = _MR({})
         self._model = resolver.resolve(model).model
+        # #1190 stage (ii): BudgetTracker for cost recording (purpose=compaction)
+        # via recorded_acompletion. None = unrecorded (e.g. ad-hoc/test engines).
+        self._recorder = recorder
         self._events = events
         # Axis 10: opt-out flag
         from reyn.config import CompactionConfig as _CC
@@ -779,25 +783,20 @@ class CompactionEngine:
         return self._budgets
 
     async def _acompletion(self, messages: list[dict], *, response_format: dict | None = None):
-        """Single litellm.acompletion call with proxy routing applied.
+        """Single LLM call via the cost-observability chokepoint (#1190).
 
         Shared by ``compact`` (JSON response) and ``_resummarize_topic_arc``
-        (text response) so the proxy_kwargs + provider-prefix-strip routing is
-        in one place.
+        (text response). The chokepoint owns proxy_kwargs + provider-prefix
+        strip + records usage (purpose="compaction") via the engine's recorder.
         """
-        from reyn.llm.llm import proxy_kwargs
-        extra = proxy_kwargs()
-        # Strip provider prefix for proxy routing.
-        effective_model = self._model
-        if extra.get("custom_llm_provider") == "openai":
-            parts = self._model.split("/", 1)
-            if len(parts) == 2:
-                effective_model = parts[1]
-        import litellm
-        kwargs: dict = {"model": effective_model, "messages": messages, **extra}
-        if response_format is not None:
-            kwargs["response_format"] = response_format
-        return await litellm.acompletion(**kwargs)
+        from reyn.llm.llm import recorded_acompletion
+        return await recorded_acompletion(
+            model=self._model,
+            messages=messages,
+            purpose="compaction",
+            recorder=self._recorder,
+            response_format=response_format,
+        )
 
     async def _resummarize_topic_arc(self, topic_arc: str, body_budget: int) -> str:
         """T2 (#271): LLM re-compression of an overshooting ``topic_arc``.
@@ -1232,22 +1231,15 @@ async def compact_step_results(
     # Step 5 + 6: call LLM summariser, then hard-truncate.
     summary_text: str
     try:
-        from reyn.llm.llm import proxy_kwargs
-        extra = proxy_kwargs()
-        effective_model = model
-        if extra.get("custom_llm_provider") == "openai":
-            parts = model.split("/", 1)
-            if len(parts) == 2:
-                effective_model = parts[1]
-
-        import litellm
-        response = await litellm.acompletion(
-            model=effective_model,
+        from reyn.llm.llm import recorded_acompletion
+        response = await recorded_acompletion(
+            model=model,
             messages=[
                 {"role": "system", "content": _STEP_RESULTS_SUMMARY_PROMPT},
                 {"role": "user", "content": older_text},
             ],
-            **extra,
+            purpose="compaction",
+            recorder=getattr(engine, "_recorder", None),
         )
         raw_summary = (response.choices[0].message.content or "").strip()
         if not raw_summary:
@@ -1407,22 +1399,15 @@ async def compact_control_ir_results(
     # Step 4 + 5: call LLM summariser, then hard-truncate.
     summary_text: str
     try:
-        from reyn.llm.llm import proxy_kwargs
-        extra = proxy_kwargs()
-        effective_model = model
-        if extra.get("custom_llm_provider") == "openai":
-            parts = model.split("/", 1)
-            if len(parts) == 2:
-                effective_model = parts[1]
-
-        import litellm
-        response = await litellm.acompletion(
-            model=effective_model,
+        from reyn.llm.llm import recorded_acompletion
+        response = await recorded_acompletion(
+            model=model,
             messages=[
                 {"role": "system", "content": _PHASE_COMPACTION_SYSTEM_PROMPT},
                 {"role": "user", "content": older_text},
             ],
-            **extra,
+            purpose="compaction",
+            recorder=getattr(engine, "_recorder", None),
         )
         raw_summary = (response.choices[0].message.content or "").strip()
         if not raw_summary:

--- a/src/reyn/skill/skill_node_runner.py
+++ b/src/reyn/skill/skill_node_runner.py
@@ -10,7 +10,6 @@ import json
 from typing import Any, Callable
 
 from reyn.events.events import EventLog
-from reyn.llm.llm import proxy_kwargs
 from reyn.llm.model_resolver import ModelResolver
 from reyn.llm.pricing import TokenUsage
 from reyn.schemas.models import SkillNodeSpec
@@ -29,13 +28,12 @@ async def _adapt_artifact(
     *,
     llm_timeout: float = 60.0,
     llm_max_retries: int = 3,
+    recorder: object | None = None,
 ) -> tuple[dict, TokenUsage]:
     """
     Call LLM to convert a sub-app's final_output data to the parent's target schema.
     Returns (adapted_artifact, token_usage).
     """
-    import litellm
-
     prompt_lines = [
         "Convert the following data to the target schema.\n",
         f"Source (type: {source_type}):",
@@ -54,13 +52,15 @@ async def _adapt_artifact(
     if output_language:
         prompt_lines.append(f"Output language: {output_language}")
     prompt = "\n".join(prompt_lines)
-    response = await litellm.acompletion(
+    # #1190 stage (ii): route through the cost chokepoint (purpose=skill_node_adapt).
+    from reyn.llm.llm import recorded_acompletion
+    response = await recorded_acompletion(
         model=resolver.resolve(model).model,
         messages=[{"role": "user", "content": prompt}],
+        purpose="skill_node_adapt",
+        recorder=recorder,
         response_format={"type": "json_object"},
-        timeout=llm_timeout,
-        num_retries=llm_max_retries,
-        **proxy_kwargs(),
+        extra_kwargs={"timeout": llm_timeout, "num_retries": llm_max_retries},
     )
     raw = json.loads(response.choices[0].message.content)
     usage = TokenUsage()
@@ -92,6 +92,7 @@ async def execute_skill_node(
     resolver: ModelResolver,
     events: EventLog,
     limits: Any = None,
+    recorder: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
 ) -> tuple[dict, TokenUsage]:
     """
     Run a sub-app to completion and adapt its final_output to target_schema.
@@ -135,5 +136,6 @@ async def execute_skill_node(
         model=model, resolver=resolver, events=events,
         llm_timeout=llm_timeout,
         llm_max_retries=llm_max_retries,
+        recorder=recorder,
     )
     return adapted, token_usage + adapt_usage

--- a/tests/test_cost_chokepoint_1190.py
+++ b/tests/test_cost_chokepoint_1190.py
@@ -105,6 +105,35 @@ def test_recorded_acompletion_response_format_fallback(monkeypatch) -> None:
     assert [c["purpose"] for c in rec.calls] == ["judge"]
 
 
+def test_compaction_engine_records_compaction_purpose(monkeypatch) -> None:
+    """Tier 2: stage (ii) — a real CompactionEngine threaded with a recorder
+    records its compaction LLM call as purpose="compaction" (end-to-end through
+    recorded_acompletion), confirming the recorder threading."""
+    from reyn.config import CompactionConfig
+    from reyn.events.events import EventLog
+    from reyn.services.compaction.engine import CompactionEngine, HistoryChunkToCompact
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        return _resp(content=json.dumps({
+            "topic_arc": "arc", "new_turn_seqs": [1],
+            "decisions": [], "pending": [],
+            "session_user_facts": [], "artifacts_referenced": [],
+        }))
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    rec = _Recorder()
+    engine = CompactionEngine(
+        model="gpt-4o", events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True), recorder=rec,
+    )
+    asyncio.run(engine.compact(HistoryChunkToCompact(
+        previous_summary=None,
+        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        section_token_caps={},
+    )))
+    assert [c["purpose"] for c in rec.calls] == ["compaction"]
+
+
 def test_ledger_persists_purpose_and_omits_when_none(tmp_path: Path) -> None:
     """Tier 2: the budget ledger persists `purpose` when given, and omits the
     field entirely when None (pre-#1190 lines stay byte-identical)."""


### PR DESCRIPTION
**[e2e-coder]** — #1190 stage (ii) of 3 (design approved; stage i merged as #1191). lead-coder reviews each stage.

## This stage — all 9 `litellm.acompletion` sites now route through `recorded_acompletion`
(So stage iii's AST guard can make that the *only* call site.) Recorders threaded so each axis records with its `purpose` bucket:

| Site | purpose | recorder threading |
|---|---|---|
| compaction engine ×3 (`_acompletion`, `compact_step_results`, `compact_control_ir_results`) | `compaction` | `CompactionEngine.__init__` gains `recorder`; threaded at the 3 construction sites (session=`self._budget_tracker`, planner=`budget`, runtime=`budget_tracker`) |
| `judge_output` ×2 | `judge` | `OpContext` gains `budget_tracker`; threaded OSRuntime → `ControlIRExecutor` → `_build_ctx` → OpContext |
| `skill_node_runner._adapt_artifact` | `skill_node_adapt` | threaded OSRuntime → `RunOrchestrator` → `execute_skill_node` → `_adapt_artifact` |
| dogfood (`interpretation`, `verifiers/reply`) | `dogfood` | `recorder=None` (auxiliary surface) |

Each site keeps its own response-shape handling (`.content` / json fallback) above the chokepoint; the chokepoint absorbs `proxy_kwargs` + provider-prefix strip + the `response_format` fallback. Removed now-unused `litellm`/`proxy_kwargs` imports.

## Replay-safe
Every site still bottoms out at `litellm.acompletion` under the chokepoint → `LLMReplay` fixtures unaffected.

## Test plan
- [x] `test_cost_chokepoint_1190`: compaction records `purpose="compaction"` end-to-end (real `CompactionEngine` + recorder stub + scripted litellm).
- [x] 480-test judge/skill_node/control_ir/run_orchestrator/replay/compaction/phase/osruntime/budget sweep green; ruff + tier-audit `--strict` clean.
- [ ] full suite (running; CI gates).

## Next
Stage (iii) keystone: AST guard (`litellm.acompletion` only inside `recorded_acompletion`, #1172/#997 pattern) + per-purpose `/cost` test.

Refs #1190 #191
