### PR TITLE
feat(1190): cost-observability stage (iii) — AST guard + /cost per-purpose + agent attribution

### DIFF
--- a/src/reyn/budget/budget.py
+++ b/src/reyn/budget/budget.py
@@ -320,6 +320,10 @@ class BudgetTracker:
             self._skill_tokens_cap = CostLimitConfig()
         self._agent_tokens: dict[str, int] = defaultdict(int)
         self._agent_cost_usd: dict[str, float] = defaultdict(float)
+        # #1190 stage (iii): per-purpose cost attribution (main/phase/compaction/
+        # judge/skill_node_adapt/dogfood) for the /budget breakdown payoff.
+        self._purpose_tokens: dict[str, int] = defaultdict(int)
+        self._purpose_cost_usd: dict[str, float] = defaultdict(float)
         self._chain_skill_calls: dict[tuple[str, str], int] = defaultdict(int)
         self._chain_skill_tokens: dict[tuple[str, str], int] = defaultdict(int)
         # FP-0003: per-(chain_id, skill) extensions granted via the
@@ -550,6 +554,11 @@ class BudgetTracker:
         cost_usd, _ = estimate_cost(model, usage)
         cost_usd = cost_usd or 0.0
 
+        # #1190 stage (iii): per-purpose attribution for the /budget breakdown.
+        if purpose is not None:
+            self._purpose_tokens[purpose] += usage.total_tokens
+            self._purpose_cost_usd[purpose] += cost_usd
+
         if agent is not None:
             new_tokens = self._agent_tokens[agent] + usage.total_tokens
             self._agent_tokens[agent] = new_tokens
@@ -765,6 +774,9 @@ class BudgetTracker:
         return {
             "agent_tokens": dict(self._agent_tokens),
             "agent_cost_usd": dict(self._agent_cost_usd),
+            # #1190 stage (iii): per-purpose cost attribution.
+            "purpose_tokens": dict(self._purpose_tokens),
+            "purpose_cost_usd": dict(self._purpose_cost_usd),
             "chain_skill_calls": {
                 f"{cid}/{sk}": v
                 for (cid, sk), v in self._chain_skill_calls.items()
@@ -1208,6 +1220,18 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
             )
         else:
             lines.append(f"    cost:    ${cost:>9.4f}              (no cap)")
+        lines.append("")
+
+    # #1190 stage (iii): per-purpose cost attribution — where the spend went
+    # (main / phase / compaction / judge / skill_node_adapt / dogfood).
+    purpose_tokens = snapshot.get("purpose_tokens") or {}
+    purpose_cost = snapshot.get("purpose_cost_usd") or {}
+    if purpose_tokens or purpose_cost:
+        lines.append("  By purpose:")
+        for p in sorted(set(purpose_tokens) | set(purpose_cost)):
+            tok = purpose_tokens.get(p, 0)
+            cost = purpose_cost.get(p, 0.0)
+            lines.append(f"    {p:<18}{tok:>10,} tok | ${cost:.4f}")
         lines.append("")
 
     if snapshot["chain_skill_calls"]:

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -874,6 +874,8 @@ async def execute_plan(
                 resolver=parent_host.resolver,
                 # #1190 stage (ii): record planner step-results compaction spend.
                 recorder=budget,
+                # #1190 stage (iii) Part 4: attribute planner compaction to the host's agent.
+                recorder_agent=getattr(parent_host, "agent_name", None),
             )
         except Exception as exc:  # noqa: BLE001 — best-effort; skip if unavailable
             logger.warning(

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1818,6 +1818,8 @@ class ChatSession:
                 resolver=self._resolver,
                 # #1190 stage (ii): record chat compaction LLM spend (purpose=compaction).
                 recorder=self._budget_tracker,
+                # #1190 stage (iii) Part 4: attribute chat compaction to this session's agent.
+                recorder_agent=self.agent_name,
             ),
             history_appender=self._append_history,
             make_summary_message=lambda rendered, structured, covers: ChatMessage(

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -257,6 +257,13 @@ class RunOrchestrator:
             events=self._events,
             safety=self._safety,
             recorder=self._budget_tracker,
+            # #1190 stage (iii) Part 4: attribute skill_node adaptation to the
+            # run's agent (caller "agents/<name>" → "<name>").
+            recorder_agent=(
+                self._caller.split("/", 1)[1]
+                if self._caller and self._caller.startswith("agents/")
+                else None
+            ),
         )
         self._state.add_usage(usage, None)
         return adapted

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -251,6 +251,14 @@ class OSRuntime:
                     resolver=self._resolver,
                     # #1190 stage (ii): record phase act-results compaction spend.
                     recorder=budget_tracker,
+                    # #1190 stage (iii) Part 4: attribute phase compaction to the
+                    # run's agent (caller "agents/<name>" → "<name>"), matching
+                    # the main phase call's budget agent (LLMCallRecorder).
+                    recorder_agent=(
+                        caller.split("/", 1)[1]
+                        if caller and caller.startswith("agents/")
+                        else None
+                    ),
                 )
             except Exception:  # noqa: BLE001 — best-effort; skip if unavailable
                 phase_compaction_engine = None

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -749,6 +749,14 @@ async def recorded_acompletion(
     """
     import litellm
 
+    # #1190 stage (iii): typo guard — a purpose outside the known set would
+    # silently land spend in an unattributed bucket in /cost.
+    if purpose not in LLM_PURPOSES:
+        raise ValueError(
+            f"recorded_acompletion: unknown purpose {purpose!r}; "
+            f"must be one of {LLM_PURPOSES}"
+        )
+
     extra = proxy_kwargs()
     effective_model = model.split("/", 1)[1] if extra and "/" in model else model
     base_kwargs = dict(extra_kwargs or {})

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -708,6 +708,7 @@ class CompactionEngine:
         system_prompt_provider: Callable[[], str] | None = None,
         resolver: "ModelResolver | None" = None,
         recorder: object | None = None,
+        recorder_agent: str | None = None,
     ) -> None:
         # #1172: resolve the model CLASS ("standard"/"light"/"strong") to its
         # LiteLLM string at construction — by-construction guarantee that no
@@ -726,6 +727,10 @@ class CompactionEngine:
         # #1190 stage (ii): BudgetTracker for cost recording (purpose=compaction)
         # via recorded_acompletion. None = unrecorded (e.g. ad-hoc/test engines).
         self._recorder = recorder
+        # #1190 stage (iii) Part 4: agent for per-agent cost attribution. Chat
+        # compaction = the session's agent_name; phase compaction = the run's
+        # agent. None = attributed to no agent (legacy/test engines).
+        self._recorder_agent = recorder_agent
         self._events = events
         # Axis 10: opt-out flag
         from reyn.config import CompactionConfig as _CC
@@ -795,6 +800,7 @@ class CompactionEngine:
             messages=messages,
             purpose="compaction",
             recorder=self._recorder,
+            agent=self._recorder_agent,
             response_format=response_format,
         )
 
@@ -1240,6 +1246,7 @@ async def compact_step_results(
             ],
             purpose="compaction",
             recorder=getattr(engine, "_recorder", None),
+            agent=getattr(engine, "_recorder_agent", None),
         )
         raw_summary = (response.choices[0].message.content or "").strip()
         if not raw_summary:
@@ -1408,6 +1415,7 @@ async def compact_control_ir_results(
             ],
             purpose="compaction",
             recorder=getattr(engine, "_recorder", None),
+            agent=getattr(engine, "_recorder_agent", None),
         )
         raw_summary = (response.choices[0].message.content or "").strip()
         if not raw_summary:

--- a/src/reyn/skill/skill_node_runner.py
+++ b/src/reyn/skill/skill_node_runner.py
@@ -29,6 +29,7 @@ async def _adapt_artifact(
     llm_timeout: float = 60.0,
     llm_max_retries: int = 3,
     recorder: object | None = None,
+    recorder_agent: str | None = None,
 ) -> tuple[dict, TokenUsage]:
     """
     Call LLM to convert a sub-app's final_output data to the parent's target schema.
@@ -59,6 +60,7 @@ async def _adapt_artifact(
         messages=[{"role": "user", "content": prompt}],
         purpose="skill_node_adapt",
         recorder=recorder,
+        agent=recorder_agent,
         response_format={"type": "json_object"},
         extra_kwargs={"timeout": llm_timeout, "num_retries": llm_max_retries},
     )
@@ -93,6 +95,7 @@ async def execute_skill_node(
     events: EventLog,
     limits: Any = None,
     recorder: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
+    recorder_agent: str | None = None,  # #1190 stage (iii) Part 4: per-agent attribution
 ) -> tuple[dict, TokenUsage]:
     """
     Run a sub-app to completion and adapt its final_output to target_schema.
@@ -137,5 +140,6 @@ async def execute_skill_node(
         llm_timeout=llm_timeout,
         llm_max_retries=llm_max_retries,
         recorder=recorder,
+        recorder_agent=recorder_agent,
     )
     return adapted, token_usage + adapt_usage

--- a/tests/test_cost_chokepoint_1190.py
+++ b/tests/test_cost_chokepoint_1190.py
@@ -144,3 +144,72 @@ def test_ledger_persists_purpose_and_omits_when_none(tmp_path: Path) -> None:
     lines = [json.loads(line) for line in (tmp_path / "ledger.jsonl").read_text().splitlines() if line.strip()]
     assert lines[0]["purpose"] == "phase"
     assert "purpose" not in lines[1], "None purpose must be omitted (legacy byte-identical)"
+
+
+def test_recorded_acompletion_rejects_unknown_purpose() -> None:
+    """Tier 2: stage (iii) Part 3 — an unknown purpose (typo) is rejected at the
+    chokepoint before any LLM call, so a mis-tagged call cannot silently land in
+    no per-purpose bucket."""
+    import pytest
+
+    with pytest.raises(ValueError, match="purpose"):
+        asyncio.run(recorded_acompletion(
+            model="m", messages=[{"role": "user", "content": "x"}],
+            purpose="compcation",  # typo of "compaction"
+            recorder=None,
+        ))
+    # every advertised purpose is accepted (guards against the list drifting out
+    # of sync with the assert).
+    assert set(LLM_PURPOSES) >= {"main", "phase", "compaction", "judge",
+                                 "skill_node_adapt", "dogfood"}
+
+
+def test_compaction_engine_threads_agent(monkeypatch) -> None:
+    """Tier 2: stage (iii) Part 4 — CompactionEngine(recorder_agent=...) attributes
+    its compaction spend to that agent (end-to-end agent threading through
+    recorded_acompletion → record_llm)."""
+    from reyn.config import CompactionConfig
+    from reyn.events.events import EventLog
+    from reyn.services.compaction.engine import CompactionEngine, HistoryChunkToCompact
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        return _resp(content=json.dumps({
+            "topic_arc": "arc", "new_turn_seqs": [1],
+            "decisions": [], "pending": [],
+            "session_user_facts": [], "artifacts_referenced": [],
+        }))
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    rec = _Recorder()
+    engine = CompactionEngine(
+        model="gpt-4o", events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True),
+        recorder=rec, recorder_agent="researcher",
+    )
+    asyncio.run(engine.compact(HistoryChunkToCompact(
+        previous_summary=None,
+        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        section_token_caps={},
+    )))
+    assert [c["agent"] for c in rec.calls] == ["researcher"]
+
+
+def test_budget_per_purpose_breakdown_visible() -> None:
+    """Tier 2: stage (iii) Part 2 — the cost-observability payoff: per-purpose
+    spend is aggregated and surfaced (snapshot + /budget full rendering), so a
+    user can see how much compaction vs main cost."""
+    from reyn.budget.budget import BudgetTracker, CostConfig, format_budget_full
+
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_llm(model="m", agent="a", usage=TokenUsage(prompt_tokens=100, completion_tokens=20), purpose="main")
+    tracker.record_llm(model="m", agent="a", usage=TokenUsage(prompt_tokens=40, completion_tokens=10), purpose="compaction")
+    tracker.record_llm(model="m", agent="a", usage=TokenUsage(prompt_tokens=5, completion_tokens=5), purpose="compaction")
+
+    snap = tracker.snapshot()
+    # aggregation: two compaction calls summed, main separate.
+    assert snap["purpose_tokens"]["main"] == 120
+    assert snap["purpose_tokens"]["compaction"] == 60
+
+    rendered = format_budget_full(snap, attached=None)
+    assert "By purpose:" in rendered
+    assert "compaction" in rendered and "main" in rendered

--- a/tests/test_cost_chokepoint_ast_guard_1190.py
+++ b/tests/test_cost_chokepoint_ast_guard_1190.py
@@ -1,0 +1,78 @@
+"""Tier 2: OS invariant — #1190 stage (iii) keystone AST guard.
+
+`litellm.acompletion` may be called ONLY inside `recorded_acompletion`
+(`src/reyn/llm/llm.py`). Every other call site would bypass the cost-observability
+chokepoint (no usage recording, no purpose attribution) — exactly the class of
+bug #1190 closes. This guard makes that bypass *impossible by construction*, not
+merely currently-absent: a new `litellm.acompletion(...)` anywhere else in
+`src/reyn/` fails here at PR time (same omit-pin pattern as the #1172 resolver
+guard and the #997 op-exposure guard).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _is_litellm_acompletion_call(node: ast.AST) -> bool:
+    """True for a ``litellm.acompletion(...)`` CALL.
+
+    Only call sites bypass the chokepoint. An attribute *reference* /
+    *assignment* (e.g. ``litellm.acompletion = self._handle`` in LLMReplay, the
+    monkeypatch that the chokepoint relies on) is not a bypass — exclude it.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "acompletion"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "litellm"
+    )
+
+
+def _recorded_acompletion_span(llm_py: Path) -> tuple[int, int]:
+    """Return the (start, end) line span of the ``recorded_acompletion`` def."""
+    tree = ast.parse(llm_py.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            node.name == "recorded_acompletion"
+        ):
+            return node.lineno, (node.end_lineno or node.lineno)
+    raise AssertionError("recorded_acompletion not found in llm.py — chokepoint moved?")
+
+
+def test_litellm_acompletion_only_inside_recorded_acompletion() -> None:
+    """Tier 2: the single cost chokepoint is the only `litellm.acompletion` caller."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+    llm_py = (src / "llm" / "llm.py").resolve()
+    start, end = _recorded_acompletion_span(llm_py)
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not _is_litellm_acompletion_call(node):
+                continue
+            # Allowed iff inside recorded_acompletion's body in llm.py (its
+            # nested `_once` helper lives within that line span).
+            inside = py.resolve() == llm_py and start <= node.lineno <= end
+            if not inside:
+                offenders.append(f"{py.relative_to(root)}:{node.lineno}")
+
+    assert not offenders, (
+        "litellm.acompletion called outside recorded_acompletion (bypasses the "
+        "#1190 cost chokepoint — no usage recording / purpose attribution). "
+        "Route the call through reyn.llm.llm.recorded_acompletion(purpose=...). "
+        f"Offending sites: {offenders}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1190 cost-observability chokepoint **stage (iii)** (keystone + visibility payoff + complete attribution). Base = #1192 (stage ii, merged); rebased onto 06fbf37b.

## What

Closes the common-ization: by-construction guarantee + the visibility payoff + complete per-agent attribution.

1. **AST guard (keystone)** — `tests/test_cost_chokepoint_ast_guard_1190.py` asserts `litellm.acompletion` is **called** only inside `recorded_acompletion` across `src/reyn/`. Attribute *reference* / monkeypatch (LLMReplay's `litellm.acompletion = self._handle`) is excluded — only call sites bypass recording. Makes a future bypass impossible at PR time (same omit-pin pattern as #1172 resolver / #997 op-exposure guards).
2. **/cost per-purpose breakdown (payoff)** — `BudgetTracker` aggregates per-purpose tokens/cost; `snapshot()` exposes `purpose_tokens`/`purpose_cost_usd`; `format_budget_full` renders a `By purpose:` section. Compaction vs main vs judge spend is now actually visible.
3. **purpose typo guard** — `recorded_acompletion` raises `ValueError` when `purpose ∉ LLM_PURPOSES`, so a mis-tagged call can't silently land unattributed.
4. **agent threading (completeness)** — `CompactionEngine` gains `recorder_agent` (chat = session `agent_name`, phase = caller-derived `agents/<name>`); `skill_node_runner` threads `recorder_agent` (run agent). Completes per-agent budget attribution that was `agent=None` for compaction/skill_node before.

## Test plan

- [x] `pytest tests/test_cost_chokepoint_1190.py tests/test_cost_chokepoint_ast_guard_1190.py -q` → 9 passed
- [x] `ruff check` (all touched src + tests) → clean
- [x] `python scripts/test_tier_audit.py --strict <changed tests>` → 0 violations
- [x] Regression sweep `-k "compaction or budget or skill_node or chokepoint or 1190 or 1172"` → 258 passed
- [x] Full suite (rootdir, CI-faithful minus gitignored `.claude` worktree cruft) → **6697 passed**, 5 skipped, 3 xfailed. The 1 failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) is **pre-existing on the base commit** (verified by stash) — an env-dependent HTML-extraction quirk, unrelated to cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
