### PR TITLE
fix(1128): PR-b — serialize A2A run_one_iteration via shared per-agent lock

### DIFF
--- a/src/reyn/chat/agent_locks.py
+++ b/src/reyn/chat/agent_locks.py
@@ -1,0 +1,46 @@
+"""Per-agent serialization lock registry — shared by ALL transport layers.
+
+MCP (``reyn.mcp_server``) and A2A (``reyn.web.routers.a2a``) both drive
+``ChatSession.run_one_iteration`` for the same shared session instance. Without
+cross-transport coordination a concurrent MCP request and an A2A drain loop on
+the same agent race at every ``await`` inside ``run_one_iteration``, corrupting
+``session.history`` (both callers mutate it concurrently).
+
+The fix: every transport that drives ``run_one_iteration`` acquires the same
+per-agent ``asyncio.Lock`` before entering the critical section.
+
+This module is the single registry for those locks.  Both ``mcp_server`` and
+``a2a`` import ``get_agent_lock`` from here; they therefore share the same
+``_AGENT_LOCKS`` dict and thus the same lock object for any given agent name.
+
+Design constraints:
+- Module-level singleton dict: one process, one event-loop — the module is
+  imported once and the dict is stable for the process lifetime.
+- ``asyncio.Lock`` is not thread-safe, but Reyn runs on a single asyncio
+  event loop, so this is fine.
+- The lock is keyed by the *agent name string* — the same identity used by
+  ``AgentRegistry.get_or_load``.  Transport callers must use the canonical
+  name (not a URL slug or alias) so the key matches.
+"""
+from __future__ import annotations
+
+import asyncio
+
+# Module-level registry — intentionally a plain dict.
+# Callers must NOT mutate this dict directly; use ``get_agent_lock`` only.
+_AGENT_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def get_agent_lock(agent_name: str) -> asyncio.Lock:
+    """Return the per-agent ``asyncio.Lock`` for *agent_name*.
+
+    Creates the lock on first access; subsequent calls with the same name
+    return the **same** ``asyncio.Lock`` object (identity guarantee).  Locks
+    for different names are distinct objects.
+
+    Thread-safety: this function is NOT thread-safe (dict.setdefault is not
+    atomic across threads), but Reyn is single-threaded asyncio — concurrent
+    coroutines on the same loop are safe here because Python's GIL prevents
+    true parallelism during the ``setdefault`` call.
+    """
+    return _AGENT_LOCKS.setdefault(agent_name, asyncio.Lock())

--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -36,6 +36,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from reyn.chat.agent_locks import get_agent_lock as _get_agent_lock
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -58,20 +60,15 @@ _IDLE_POLL_INTERVAL_SECONDS: float = 0.05
 _IDLE_GRACE_SECONDS: float = 0.05
 
 
-# Per-agent serialization lock. Concurrent FastAPI request handlers (e.g.
-# the A2A endpoint) can reach ``send_to_agent_impl`` in parallel for the
-# same agent; without serialization both coroutines race on
-# ``session.history[-1]`` (RouterLoop reads the wrong prompt) and on
-# reply harvesting (each picks up the other's ``role="agent"`` entries).
+# Per-agent serialization lock — shared across ALL transport layers (MCP +
+# A2A).  ``_get_agent_lock`` is imported from ``reyn.chat.agent_locks`` at the
+# top of this file so MCP and A2A share the SAME lock object per agent name.
+# See that module for the full rationale.
+#
 # FP-0013: with MessageBus, the inbox is the serialization point but the
 # lock is retained as a belt-and-suspenders measure during the migration
 # period — it prevents concurrent calls from racing on history harvest
 # (baseline → MessageBus.request → history-read must be atomic per agent).
-_AGENT_LOCKS: dict[str, asyncio.Lock] = {}
-
-
-def _get_agent_lock(agent_name: str) -> asyncio.Lock:
-    return _AGENT_LOCKS.setdefault(agent_name, asyncio.Lock())
 
 
 async def _get_session(registry: "AgentRegistry", name: str) -> "object":

--- a/src/reyn/web/routers/a2a.py
+++ b/src/reyn/web/routers/a2a.py
@@ -43,6 +43,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from reyn.chat.agent_locks import get_agent_lock
 from reyn.mcp_server import DEFAULT_SEND_TIMEOUT_SECONDS, send_to_agent_impl
 from reyn.web.deps import get_registry, get_run_registry
 
@@ -497,6 +498,7 @@ async def _escalate_to_task(
             session = await _get_session_for_monitor(registry, agent_name)
             completed = await _await_skill_completion(
                 session, skill_run_id, deadline_s=600.0,
+                agent_name=agent_name,
             )
             if not completed:
                 run_registry.update(
@@ -544,6 +546,7 @@ async def _get_session_for_monitor(registry, agent_name: str):
 
 async def _await_skill_completion(
     session, skill_run_id: str, *, deadline_s: float = 600.0,
+    agent_name: str,
 ) -> bool:
     """Poll ``session.running_skills`` until ``skill_run_id`` is no longer
     active, OR the deadline fires.
@@ -559,6 +562,13 @@ async def _await_skill_completion(
     mark the run_registry entry as ``status="timeout"`` rather than
     ``"completed"`` to avoid conflating "we gave up waiting" with a real
     completion).
+
+    ``agent_name`` is used to acquire the per-agent serialization lock
+    (shared with MCP via ``reyn.chat.agent_locks``) around each
+    ``run_one_iteration`` call so A2A drain turns and MCP turns on the
+    same session do not race on ``session.history``.  The lock is held
+    only for the duration of a single iteration (NOT the entire polling
+    loop) so MCP callers are not blocked for the full ``deadline_s``.
     """
     deadline = asyncio.get_event_loop().time() + deadline_s
     while True:
@@ -572,10 +582,14 @@ async def _await_skill_completion(
     # Final inbox drain: pump iterations until quiescent so the
     # skill_completion_injected inbox entry is consumed and the
     # narration turn lands in history.
+    # Each iteration is wrapped in the per-agent lock so A2A drain turns
+    # serialize with concurrent MCP (or registry.run()) turns on the same
+    # shared ChatSession.
     for _ in range(20):  # bounded; each iteration consumes one inbox msg
         if session.inbox.empty():
             break
-        await session.run_one_iteration()
+        async with get_agent_lock(agent_name):
+            await session.run_one_iteration()
     return True
 
 

--- a/tests/test_a2a_sync_async_escalation.py
+++ b/tests/test_a2a_sync_async_escalation.py
@@ -98,7 +98,7 @@ async def test_await_skill_completion_returns_true_when_task_done():
     asyncio.create_task(_trigger())
 
     result = await asyncio.wait_for(
-        _await_skill_completion(session, "run-1", deadline_s=2.0),
+        _await_skill_completion(session, "run-1", deadline_s=2.0, agent_name="test-agent"),
         timeout=3.0,
     )
     assert result is True
@@ -118,7 +118,7 @@ async def test_await_skill_completion_returns_true_immediately_when_no_such_run_
     session = _Session(running_skills={})
     # Should complete well under the deadline
     result = await asyncio.wait_for(
-        _await_skill_completion(session, "phantom", deadline_s=1.0),
+        _await_skill_completion(session, "phantom", deadline_s=1.0, agent_name="test-agent"),
         timeout=2.0,
     )
     assert result is True
@@ -142,7 +142,7 @@ async def test_await_skill_completion_returns_false_on_deadline():
     session = _Session(running_skills={"run-x": task})
 
     result = await asyncio.wait_for(
-        _await_skill_completion(session, "run-x", deadline_s=0.2),
+        _await_skill_completion(session, "run-x", deadline_s=0.2, agent_name="test-agent"),
         timeout=1.0,
     )
     assert result is False

--- a/tests/test_agent_locks_shared_1128.py
+++ b/tests/test_agent_locks_shared_1128.py
@@ -1,0 +1,139 @@
+"""Tier 2: OS invariant tests for the shared per-agent lock registry (#1128).
+
+Pins the cross-transport serialization guarantee introduced in PR-b of
+issue #1128: MCP and A2A must acquire the SAME ``asyncio.Lock`` for a
+given agent name so concurrent MCP+A2A calls to the same session serialize
+rather than racing on ``session.history``.
+
+Invariants exercised:
+  (a) ``get_agent_lock("x")`` is idempotent: repeated calls return the
+      identical lock object (``is`` identity).
+  (b) Different agent names yield distinct lock objects.
+  (c) MCP and A2A obtain the SAME lock object for the same agent_name —
+      both import from ``reyn.chat.agent_locks``; the module-level dict
+      ensures identity.
+  (d) Concurrent coroutines acquiring the same lock are serialized:
+      critical sections do not overlap (behavioral, not count-pin).
+
+Policy compliance (docs/deep-dives/contributing/testing.ja.md):
+- No unittest.mock / MagicMock / AsyncMock / patch.
+- Real ``asyncio.Lock`` instances via the public ``get_agent_lock`` surface.
+- No private-state assertions (``_AGENT_LOCKS`` internals not touched).
+- No ``len(x) == N`` count pins; behavioral / identity assertions only.
+- Each test docstring first line is exactly ``Tier 2: ...``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.chat.agent_locks import get_agent_lock
+
+# ---------------------------------------------------------------------------
+# (a) Idempotency — same name → same lock object
+# ---------------------------------------------------------------------------
+
+
+def test_same_name_returns_same_lock() -> None:
+    """Tier 2: get_agent_lock returns the identical lock object on repeated calls."""
+    lock_first = get_agent_lock("agent-alpha")
+    lock_second = get_agent_lock("agent-alpha")
+    assert lock_first is lock_second, (
+        "get_agent_lock must return the same asyncio.Lock instance for the same "
+        "agent_name on every call (idempotency / identity guarantee)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) Different names yield distinct locks
+# ---------------------------------------------------------------------------
+
+
+def test_different_names_return_distinct_locks() -> None:
+    """Tier 2: get_agent_lock returns distinct lock objects for different agent names."""
+    lock_a = get_agent_lock("agent-one")
+    lock_b = get_agent_lock("agent-two")
+    assert lock_a is not lock_b, (
+        "get_agent_lock must return distinct asyncio.Lock objects for different "
+        "agent names — sharing a lock across agents would over-serialize"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) Cross-transport sharing: MCP and A2A import from the same registry
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_and_a2a_share_same_lock_registry() -> None:
+    """Tier 2: MCP and A2A obtain the same lock object for the same agent_name.
+
+    This is the central cross-transport guarantee of #1128 PR-b: both
+    mcp_server and a2a import ``get_agent_lock`` (aliased as
+    ``_get_agent_lock`` in mcp_server) from ``reyn.chat.agent_locks``.
+    Because Python module imports are singletons, the module-level
+    ``_AGENT_LOCKS`` dict is shared, so the same agent_name yields the
+    same ``asyncio.Lock`` object regardless of which transport calls it.
+    """
+    # Import MCP's accessor — it is aliased as _get_agent_lock in mcp_server
+    # but the underlying function is the same object from agent_locks.
+    from reyn.mcp_server import (
+        _get_agent_lock as mcp_get_lock,  # type: ignore[attr-defined]  # noqa: PLC0415
+    )
+
+    agent = "cross-transport-agent"
+    lock_via_agent_locks = get_agent_lock(agent)
+    lock_via_mcp = mcp_get_lock(agent)
+
+    assert lock_via_agent_locks is lock_via_mcp, (
+        "MCP's _get_agent_lock and reyn.chat.agent_locks.get_agent_lock must "
+        "return the SAME asyncio.Lock object for the same agent_name. "
+        "If they differ, a concurrent MCP+A2A pair on the same agent bypasses "
+        "the serialization guarantee."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) Behavioral: concurrent coroutines are serialized (no overlap)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_lock_acquirers_are_serialized() -> None:
+    """Tier 2: concurrent coroutines acquiring the same agent lock are serialized.
+
+    Two coroutines race to enter a critical section guarded by
+    ``get_agent_lock``.  The invariant: their execution windows must not
+    overlap — the second coroutine must not enter before the first exits.
+    Verified by recording entry/exit times and asserting non-overlap.
+    """
+    agent = "serialization-test-agent"
+    # Track whether the lock was observed as already held when the second
+    # coroutine reached the acquire site.  A real asyncio.Lock serializes:
+    # the second coroutine blocks until the first releases.
+    inside_flag: list[bool] = []  # True if critical section was entered while other held it
+    lock_held = asyncio.Event()  # signals "first is inside the section"
+    first_released = asyncio.Event()
+
+    async def first_holder() -> None:
+        async with get_agent_lock(agent):
+            lock_held.set()
+            # Hold lock long enough for second to try to acquire.
+            await asyncio.sleep(0.02)
+            first_released.set()
+
+    async def second_waiter() -> None:
+        # Wait until first has entered, then try to acquire — this races
+        # with first_holder holding the lock.
+        await lock_held.wait()
+        async with get_agent_lock(agent):
+            # If we reach here before first released, the lock didn't serialize.
+            inside_flag.append(first_released.is_set())
+
+    await asyncio.gather(first_holder(), second_waiter())
+
+    assert inside_flag, "second_waiter must have entered the critical section at least once"
+    assert all(inside_flag), (
+        "second_waiter entered the critical section before first_holder released "
+        "the lock — the per-agent lock is not serializing concurrent coroutines"
+    )


### PR DESCRIPTION
**[e2e-coder]** — fix(1128): PR-b — serialize A2A `run_one_iteration` via shared per-agent lock

## Summary

**Latent race fixed:** `_await_skill_completion` in `a2a.py` called `session.run_one_iteration()` with no per-agent lock, while MCP already held `_get_agent_lock(agent_name)` around its own drives of the same method. A concurrent MCP request and A2A inbox-drain loop on the same shared `ChatSession` raced at every `await` point inside `run_one_iteration`, allowing both to mutate `session.history` concurrently.

**Critical correctness: shared lock registry.** If MCP and A2A each had their own `_AGENT_LOCKS` dict, a concurrent MCP+A2A pair would still bypass the serialization. This PR lifts the registry to a shared module so both transports obtain the **same `asyncio.Lock` object** for a given agent name.

## Changes

### New: `src/reyn/chat/agent_locks.py`

Shared module exposing `get_agent_lock(agent_name: str) -> asyncio.Lock` backed by a module-level `dict[str, asyncio.Lock]`. Keyed by agent name string — the same identity `AgentRegistry.get_or_load` uses.

### `src/reyn/mcp_server.py`

- Replaced local `_AGENT_LOCKS: dict[str, asyncio.Lock]` and `_get_agent_lock()` function with `from reyn.chat.agent_locks import get_agent_lock as _get_agent_lock`.
- The alias `_get_agent_lock` preserves the existing call site at line 215 (`async with _get_agent_lock(agent_name):`) exactly — behavior unchanged.

### `src/reyn/web/routers/a2a.py`

- Added `from reyn.chat.agent_locks import get_agent_lock` import.
- `_await_skill_completion()` gained a new required keyword argument `agent_name: str`.
- Each `run_one_iteration()` call in the drain loop is now wrapped with `async with get_agent_lock(agent_name):`.
- **Wrap granularity**: lock is held for the duration of one iteration only, NOT the full polling loop. This mirrors MCP's wrap (which covers one full `MessageBus.request` turn) without blocking MCP for the entire `deadline_s` (up to 600s).
- The `_monitor()` closure in `_escalate_to_task` already had `agent_name` in scope — the call site update is a one-line addition.

### `tests/test_agent_locks_shared_1128.py` (new)

Tier 2 OS invariant tests pinning:
- (a) `get_agent_lock("x")` is idempotent — identical object on repeated calls.
- (b) Different names yield distinct lock objects.
- (c) MCP and A2A obtain the SAME lock object for the same agent_name — imports both accessors and asserts `is` identity. This is the central cross-transport guarantee.
- (d) Behavioral: concurrent coroutines are serialized — second waiter enters only after first releases.

### `tests/test_a2a_sync_async_escalation.py` (updated)

Three existing direct `_await_skill_completion(...)` calls updated to pass the new required `agent_name="test-agent"` kwarg.

## A2A `run_one_iteration` call sites — grep-confirmed complete set

```
$ grep -n "run_one_iteration" src/reyn/web/routers/a2a.py
578:        await session.run_one_iteration()
```

**Exactly one site.** It is inside `_await_skill_completion`'s drain loop. Wrapped with `async with get_agent_lock(agent_name):` in this PR.

## Test plan

- [x] `python -m pytest -q tests/test_agent_locks_shared_1128.py` — 4 passed
- [x] `python -m pytest -q -k "a2a or mcp_server or agent_lock"` — 167 passed, 1 skipped
- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_agent_locks_shared_1128.py tests/test_a2a_sync_async_escalation.py` — 0 errors

Refs #1128
