### PR TITLE
feat(1128): step 4 PR-c — collapse force_compact_now to a single pass (max_passes 2→1)

### DIFF
--- a/src/reyn/chat/services/compaction_controller.py
+++ b/src/reyn/chat/services/compaction_controller.py
@@ -246,120 +246,62 @@ class CompactionController:
         finally:
             self._compacting = False
 
-    def _estimate_current_history_tokens(self) -> int:
-        """Cheap chars/4 estimate of the total text tokens in current history.
-
-        Used by the race-recovery loop in :meth:`force_compact_now` to
-        re-measure after each compaction pass.
-        """
-        history = self._history_access()
-        return sum(
-            _estimate_tokens(m.text)
-            for m in history
-            if m.role in ("user", "assistant", "tool", "agent")
-        )
-
-    async def force_compact_now(self, *, max_passes: int = 2) -> None:
-        """Synchronous force-trigger with race-recovery loop (ISSUE #6, Option B).
+    async def force_compact_now(self) -> None:
+        """Synchronous force-trigger — single pass (#1128 PR-c).
 
         Used by the pre-frame guard in ``_maybe_force_compact_for_router`` when
         the projected prompt would exceed the model's max_input_tokens.  Emits
-        the same events as the background path but with ``outcome="forced_sync"``
-        on the ``compaction_check`` event.
+        ``compaction_check`` with ``outcome="forced_sync"``.
 
-        Race tolerance (Option B):
-            Between the fire-decision and lock-acquisition, other async
-            coroutines may append to history (sync ``_append_history`` calls).
-            After each compaction pass, we re-measure the post-state and re-run
-            if still over budget, up to ``max_passes`` total.  Beyond that, a
-            ``force_compact_race_unrecovered`` event is emitted and
-            ``ForceCompactRaceUnrecoveredError`` is raised — the contract is
-            fail-fast (lead-coder accept condition 2026-05-29): the caller
-            must surface the unrecovered state rather than allow a silent
-            over-budget LLM call.
+        #1128 PR-c: collapsed from the former Option-B race-recovery loop
+        (``max_passes`` re-measure + ``ForceCompactRaceUnrecoveredError``) to a
+        single pass. That loop existed to re-run when another coroutine appended
+        to history mid-compaction. Cross-driver turn serialization is now
+        structural — every transport that drives ``run_one_iteration`` holds the
+        shared per-agent lock (PR-b, ``reyn.chat.agent_locks``), and within a
+        turn ``_append_history`` is synchronous — so no concurrent append can
+        land during this method. If the single pass under-shoots (the guard's
+        estimate under-counted), the ``retry_loop`` overflow backstop in
+        ``_run_router_loop`` folds raw_middle and monotonically shrinks: that is
+        the under-shoot floor, replacing the multi-pass-or-raise contract.
 
-            Choice of Option B over Option A (= async _append_history + lock):
-            Option B is more localised (no call-site changes to _append_history),
-            matches Python async semantics where sync appends are sequential
-            within a coroutine, and the worst-case is a single over-budget turn
-            that resolves on the very next interaction cycle. Pairing the
-            ``force_compact_race_unrecovered`` event with a raise preserves the
-            mathematical invariant: either compaction succeeds within
-            max_passes, or the caller sees a hard error — never a silent
-            over-budget prompt.
-
-        The existing background ``spawn_maybe()`` fire-and-forget path is
-        unaffected; both paths can co-exist (sync = pre-frame guard,
-        async = post-reply background trigger).
-
-        Axis 8: acquires the engine's ``compaction_lock`` for the duration of
-        each run.  Any concurrent code path that appends to ChatSession.history
-        and needs to serialise with compaction must await the same lock before
-        appending.
+        Axis 8: acquires the engine's ``compaction_lock`` for the run.
         """
         if self._compacting:
             self._events.emit("compaction_check", outcome="already_running")
             return
         cfg = self._config
 
-        for pass_n in range(max_passes):
-            history = self._history_access()
-            turns = [
-                m for m in history
-                if m.role in ("user", "assistant", "tool", "agent")
-            ]
-            if not turns:
-                self._events.emit("compaction_check", outcome="forced_sync_no_turns")
-                return
-            latest = self._latest_summary()
-            prev_cover = (latest.meta or {}).get("covers_through_seq", 0) if latest else 0
-            cover_floor = max(prev_cover, cfg.head_size)
-            max_seq = max((t.seq for t in turns), default=0)
-            tail_threshold = max_seq - cfg.tail_size
-            candidates = [t for t in turns if cover_floor < t.seq <= tail_threshold]
+        history = self._history_access()
+        turns = [
+            m for m in history
+            if m.role in ("user", "assistant", "tool", "agent")
+        ]
+        if not turns:
+            self._events.emit("compaction_check", outcome="forced_sync_no_turns")
+            return
+        latest = self._latest_summary()
+        prev_cover = (latest.meta or {}).get("covers_through_seq", 0) if latest else 0
+        cover_floor = max(prev_cover, cfg.head_size)
+        max_seq = max((t.seq for t in turns), default=0)
+        tail_threshold = max_seq - cfg.tail_size
+        candidates = [t for t in turns if cover_floor < t.seq <= tail_threshold]
 
-            self._events.emit(
-                "compaction_check", outcome="forced_sync",
-                candidate_count=len(candidates),
-                pass_n=pass_n,
-            )
-            if not candidates:
-                return
-
-            self._compacting = True
-            async with self._engine.compaction_lock:
-                try:
-                    await self._run_compaction(candidates, latest)
-                except Exception as exc:
-                    self._events.emit("compaction_failed", error=str(exc))
-                    return
-                finally:
-                    self._compacting = False
-
-            # Re-measure post-compaction. If still over effective_trigger, loop.
-            budgets = getattr(self._engine, "budgets", None)
-            effective_trigger = (
-                budgets.effective_trigger if budgets is not None else 0
-            )
-            if effective_trigger > 0:
-                post_tokens = self._estimate_current_history_tokens()
-                if post_tokens <= effective_trigger:
-                    return  # budget recovered — done
-            else:
-                return  # no trigger info — assume done
-
-        # All passes exhausted; race not fully recovered.
-        # Fail-fast per lead-coder accept condition 2026-05-29: the contract
-        # is "compaction succeeds within max_passes OR raises". Silent-continue
-        # would allow an over-budget prompt to reach the LLM.
-        from reyn.services.compaction.engine import (
-            ForceCompactRaceUnrecoveredError,
-        )
         self._events.emit(
-            "force_compact_race_unrecovered",
-            passes=max_passes,
+            "compaction_check", outcome="forced_sync",
+            candidate_count=len(candidates),
         )
-        raise ForceCompactRaceUnrecoveredError(passes=max_passes)
+        if not candidates:
+            return
+
+        self._compacting = True
+        async with self._engine.compaction_lock:
+            try:
+                await self._run_compaction(candidates, latest)
+            except Exception as exc:
+                self._events.emit("compaction_failed", error=str(exc))
+            finally:
+                self._compacting = False
 
     async def _run_compaction(
         self,

--- a/tests/test_chat_compaction_engine_11axis.py
+++ b/tests/test_chat_compaction_engine_11axis.py
@@ -19,8 +19,9 @@ Covers:
 - Axis 10 opt-out: use_chars4_estimate=True → chars//4 used, no litellm call needed.
 - ISSUE #4: recompute_budgets() with dynamic provider changes effective_trigger.
 - ISSUE #5: NewMsgExceedsBudgetError raised when new_msg exceeds new_msg_budget.
-- ISSUE #6: force_compact_now() race-recovery loop: N=2 passes when post-compaction
-  still over budget; force_compact_race_unrecovered event when race persists.
+- #1128 PR-c: force_compact_now() is a single synchronous pass (the Option-B
+  multi-pass race-recovery loop was removed — serialization is now structural
+  via the shared per-agent lock; retry_loop is the under-shoot floor).
 - PR-N6: weight normalization invariants.
 
 Policy compliance:
@@ -864,7 +865,7 @@ def test_new_msg_exceeds_budget_error_fields_and_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ISSUE #6: force_compact_now race-recovery loop (Option B)
+# #1128 PR-c: force_compact_now is a single synchronous pass
 # ---------------------------------------------------------------------------
 
 
@@ -895,32 +896,24 @@ class _CountingEngine(CompactionEngine):
         return ChatSummary(topic_arc="stub", covers_through_seq=0)
 
 
-def test_force_compact_now_emits_race_unrecovered_when_always_over_budget() -> None:
-    """Tier 2: force_compact_now emits event AND raises ForceCompactRaceUnrecoveredError
-    when the history remains over budget after max_passes compaction runs.
+def test_force_compact_now_single_pass_no_race_recovery() -> None:
+    """Tier 2: #1128 PR-c — force_compact_now runs exactly ONE compaction pass
+    and emits no force_compact_race_unrecovered event, even when the history
+    stays large.
 
-    Simulates the race by using a history_access callable that always returns
-    history with token count > effective_trigger, regardless of how many times
-    compaction runs (= race always wins).
-
-    Invariants verified via public API (= lead-coder accept condition 2026-05-29
-    pairing event emit with fail-fast raise — never silent-continue):
-    - force_compact_race_unrecovered event emitted with passes=max_passes.
-    - ForceCompactRaceUnrecoveredError raised with passes attribute.
-    - compact() was called exactly max_passes times before the raise.
+    The former Option-B multi-pass race-recovery loop was removed: cross-driver
+    turn serialization is now structural (the shared per-agent lock, PR-b), so a
+    single pass suffices and the retry_loop overflow backstop is the under-shoot
+    floor. Verified via the public surface — compact() is invoked once and no
+    race-unrecovered event is emitted.
     """
-    import pytest
-
     from reyn.chat.services.compaction_controller import CompactionController
-    from reyn.services.compaction.engine import (
-        ForceCompactRaceUnrecoveredError,
-    )
 
     events = EventLog()
     engine = _CountingEngine()
 
-    # 600 turns * 100 tokens/turn = 60_000 > effective_trigger=50_000.
-    # History never shrinks (simulating continuous concurrent appends).
+    # 600 large turns — stays well "over budget"; pre-#1128 this drove a 2nd
+    # pass + a race-unrecovered raise. Post-PR-c it is a single pass.
     def _big_history() -> list[_FakeMessage]:
         return [
             _FakeMessage(role="user" if i % 2 == 0 else "assistant",
@@ -930,11 +923,7 @@ def test_force_compact_now_emits_race_unrecovered_when_always_over_budget() -> N
 
     ctrl = CompactionController(
         event_log=events,
-        config=CompactionConfig(
-            head_size=2, tail_size=2, min_compact_batch=1,
-            trigger_total_tokens=1_000,
-            use_chars4_estimate=True,
-        ),
+        config=CompactionConfig(head_size=2, tail_size=2, use_chars4_estimate=True),
         history_access=_big_history,
         latest_summary=lambda: None,
         compaction_engine=engine,
@@ -946,77 +935,12 @@ def test_force_compact_now_emits_race_unrecovered_when_always_over_budget() -> N
         render_summary=lambda s: str(s),
     )
 
-    with pytest.raises(ForceCompactRaceUnrecoveredError) as exc_info:
-        asyncio.run(ctrl.force_compact_now(max_passes=2))
-    assert exc_info.value.passes == 2
+    asyncio.run(ctrl.force_compact_now())
 
-    unrecovered = [e for e in events.all() if e.type == "force_compact_race_unrecovered"]
-    assert unrecovered, (
-        "force_compact_race_unrecovered event must be emitted when race persists"
+    assert engine.compact_call_count == 1, (
+        f"force_compact_now must run exactly one pass, got {engine.compact_call_count}"
     )
-    assert unrecovered[0].data["passes"] == 2
-    assert engine.compact_call_count == 2, (
-        f"compact() should be called exactly 2 times, got {engine.compact_call_count}"
-    )
-
-
-def test_force_compact_now_returns_early_when_budget_recovered() -> None:
-    """Tier 2: force_compact_now returns without emitting force_compact_race_unrecovered
-    when the history is within budget after the first pass.
-
-    Uses a history_access callable that returns small history on the second call
-    (= simulates budget recovery after one compaction pass).
-    """
-    from reyn.chat.services.compaction_controller import CompactionController
-
-    events = EventLog()
-    engine = _CountingEngine()
-
-    call_count: list[int] = [0]
-
-    def _shrinking_history() -> list[_FakeMessage]:
-        """First call: big history (over budget). Second+: small history (within budget)."""
-        call_count[0] += 1
-        if call_count[0] == 1:
-            # 600 turns * 100 tokens = 60_000 > effective_trigger=50_000
-            return [
-                _FakeMessage(role="user" if i % 2 == 0 else "assistant",
-                             text="a" * 400, seq=i + 1)
-                for i in range(600)
-            ]
-        else:
-            # After compaction: small history = 5 turns * 100 tokens = 500 < 50_000
-            return [
-                _FakeMessage(role="user" if i % 2 == 0 else "assistant",
-                             text="a" * 400, seq=i + 1)
-                for i in range(5)
-            ]
-
-    ctrl = CompactionController(
-        event_log=events,
-        config=CompactionConfig(
-            head_size=1, tail_size=1, min_compact_batch=1,
-            trigger_total_tokens=1_000,
-            use_chars4_estimate=True,
-        ),
-        history_access=_shrinking_history,
-        latest_summary=lambda: None,
-        compaction_engine=engine,
-        history_appender=lambda m: None,
-        make_summary_message=lambda rendered, structured, covers: _FakeMessage(
-            role="summary", text=rendered, seq=0,
-            meta={"structured": structured, "covers_through_seq": covers},
-        ),
-        render_summary=lambda s: str(s),
-    )
-
-    asyncio.run(ctrl.force_compact_now(max_passes=2))
-
     unrecovered = [e for e in events.all() if e.type == "force_compact_race_unrecovered"]
     assert not unrecovered, (
-        "force_compact_race_unrecovered must NOT be emitted when budget was recovered"
-    )
-    assert engine.compact_call_count == 1, (
-        f"compact() should be called exactly 1 time when budget recovers after pass 1, "
-        f"got {engine.compact_call_count}"
+        "single-pass force_compact_now must not emit force_compact_race_unrecovered"
     )


### PR DESCRIPTION
**[e2e-coder]** — #1128 step 4 **PR-c**. Refs #1128. Depends on **PR-b (#1194, merged a12a819e)**.

## What

Now that cross-driver turn serialization is structural (PR-b: every transport driving `run_one_iteration` holds the shared per-agent lock, and within a turn `_append_history` is synchronous), the synchronous `force_compact_now` can no longer race with a concurrent history append — so the Option-B race-recovery loop is unnecessary.

- Remove the `for pass_n in range(max_passes)` loop → **single pass**.
- Remove the post-pass re-measure + the `ForceCompactRaceUnrecoveredError` raise. Contract shifts from "succeeds within max_passes OR raises" to "single pass; the `retry_loop` overflow backstop (already wired in `_run_router_loop`) is the under-shoot floor" — still never a silent over-budget prompt.
- Drop the `max_passes` parameter.
- Remove the now-dead `_estimate_current_history_tokens` (only the re-measure used it).
- `ForceCompactRaceUnrecoveredError` class + exports left in place (no longer raised here; harmless, still referenced by the compact op's error-string handling).

## Coordination with PR-a (#1195)

Both edit `force_compact_now` + `tests/test_chat_compaction_engine_11axis.py`. PR-a (Q2-held) removes the **lock** (keeps the loop); PR-c removes the **loop** (keeps the lock). The reconciled state is single-pass + no-lock. Whichever merges second rebases — I'll absorb it. lead-coder is aware; PR-c is by-construction safe post-PR-b and merge-independent of PR-a's Q2 gate.

## Test plan

- [x] Replaced the two ISSUE #6 race-recovery tests (multi-pass raise / budget-recovered) with a single-pass invariant (`compact()` invoked once, no `force_compact_race_unrecovered` event).
- [x] Affected tests (`11axis`, `compaction_controller_invariants`, `slash_compact_191`, `compact_op_272`, `retry_loop_chat_wiring`) — 55 passed.
- [x] `ruff check` — clean · `scripts/test_tier_audit.py --strict` (11axis) — 0 errors
- [x] Affected-area sweep (`-k "compaction or session or chat or slash or retry_loop or compact_op"`) — 693 passed
- [x] Full CI-faithful suite — **6696 passed**, 5 skipped, 3 xfailed. The 1 failure (`test_web_fetch_preview_path_ref`) is pre-existing on the base + passes in CI (env-dependent HTML-extraction quirk, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
