### PR TITLE
feat(1128): step 3 — token-budget head/tail elide (Fork B, window-utilization-first)

### DIFF
--- a/src/reyn/chat/services/compaction_controller.py
+++ b/src/reyn/chat/services/compaction_controller.py
@@ -29,6 +29,8 @@ from reyn.events.events import EventLog
 from reyn.services.compaction.engine import (
     CompactionEngine,
     HistoryChunkToCompact,
+    trim_head,
+    trim_tail,
 )
 
 if TYPE_CHECKING:
@@ -178,22 +180,58 @@ class CompactionController:
 
     # ── internal compaction logic ─────────────────────────────────────────────
 
+    def _select_candidates(
+        self,
+        turns: "list[ChatMessage]",
+        prev_cover: int,
+    ) -> "list[ChatMessage]":
+        """Select compaction candidates using token-budget-derived HEAD/TAIL boundaries.
+
+        #1128 step 3: replaces the old seq-arithmetic on cfg.head_size/tail_size
+        with token-budget trimming via the engine's ComputedBudgets.  Candidates
+        are the turns strictly between the head (trim_head) and tail (trim_tail)
+        slices that also have seq > prev_cover (= not yet covered by the latest
+        summary).
+
+        Falls back to a quarter of get_max_input_tokens when budgets are None
+        (engine not yet initialised — highly unlikely in production but safe).
+        """
+        budgets = getattr(self._engine, "budgets", None)
+        model = getattr(self._engine, "_model", "")
+        use_chars4 = getattr(self._config, "use_chars4_estimate", False)
+        if budgets is not None:
+            head_budget = budgets.head_budget
+            tail_budget = budgets.tail_budget
+        else:
+            from reyn.llm.model_budget import get_max_input_tokens
+            fallback = get_max_input_tokens(model) if model else 100_000
+            head_budget = tail_budget = fallback // 4
+
+        head_turns = trim_head(turns, head_budget, model, use_chars4=use_chars4)
+        tail_turns = trim_tail(turns, tail_budget, model, use_chars4=use_chars4)
+        head_id_set = {id(t) for t in head_turns}
+        tail_id_set = {id(t) for t in tail_turns}
+        return [
+            t for t in turns
+            if id(t) not in head_id_set
+            and id(t) not in tail_id_set
+            and t.seq > prev_cover
+        ]
+
     async def _maybe_compact(self) -> None:
         """Threshold judgement + compaction trigger.
 
         Originally session.py L1313-1368.
 
         Trigger: estimated tokens of user/agent turns whose seq is BOTH:
-        - > head_size (those are HEAD, never compacted)
+        - in the MIDDLE (not HEAD, not TAIL — per token-budget boundaries)
         - > latest_summary.covers_through_seq (already covered)
-        - <= max_seq - tail_size (TAIL is preserved as raw)
         exceeds ``config.trigger_total_tokens`` and the candidate set
         contains at least ``config.min_compact_batch`` turns.
         """
         if self._compacting:
             self._events.emit("compaction_check", outcome="already_running")
             return
-        cfg = self._config
         history = self._history_access()
         # E-full PR-E2 (#383): tool turns (= role="assistant" with
         # tool_calls + role="tool" responses) are now first-class history
@@ -204,20 +242,18 @@ class CompactionController:
             m for m in history
             if m.role in ("user", "assistant", "tool", "agent")
         ]
-        if len(turns) <= cfg.head_size + cfg.tail_size:
-            self._events.emit(
-                "compaction_check", outcome="too_few_turns",
-                turns=len(turns), head=cfg.head_size, tail=cfg.tail_size,
-            )
-            return
 
         latest = self._latest_summary()
         prev_cover = (latest.meta or {}).get("covers_through_seq", 0) if latest else 0
-        cover_floor = max(prev_cover, cfg.head_size)
+        candidates = self._select_candidates(turns, prev_cover)
+        if not candidates:
+            self._events.emit(
+                "compaction_check", outcome="too_few_turns",
+                turns=len(turns),
+            )
+            return
 
-        max_seq = max((t.seq for t in turns), default=0)
-        tail_threshold = max_seq - cfg.tail_size
-        candidates = [t for t in turns if cover_floor < t.seq <= tail_threshold]
+        cfg = self._config
         if len(candidates) < cfg.min_compact_batch:
             self._events.emit(
                 "compaction_check", outcome="below_min_batch",
@@ -270,7 +306,6 @@ class CompactionController:
         if self._compacting:
             self._events.emit("compaction_check", outcome="already_running")
             return
-        cfg = self._config
 
         history = self._history_access()
         turns = [
@@ -282,10 +317,7 @@ class CompactionController:
             return
         latest = self._latest_summary()
         prev_cover = (latest.meta or {}).get("covers_through_seq", 0) if latest else 0
-        cover_floor = max(prev_cover, cfg.head_size)
-        max_seq = max((t.seq for t in turns), default=0)
-        tail_threshold = max_seq - cfg.tail_size
-        candidates = [t for t in turns if cover_floor < t.seq <= tail_threshold]
+        candidates = self._select_candidates(turns, prev_cover)
 
         self._events.emit(
             "compaction_check", outcome="forced_sync",

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -4871,27 +4871,33 @@ class ChatSession:
     def _build_history_for_router(self) -> list[dict]:
         """Slice self.history into OpenAI-style messages for RouterLoop.
 
-        Mirrors the head/tail compaction config so the LLM sees the same
-        context window the old skill_router preprocessor produced.
+        #1128 step 3 (Fork B — window-utilization-first): the elide point now
+        coincides with ``effective_trigger`` (the existing pre-frame compaction
+        trigger) instead of the old turn-count head_size/tail_size.
+
+        - If total token estimate <= effective_trigger: return ALL turns raw
+          (no elide, no duplication).  The LLM sees the full conversation up
+          to the compaction trigger.
+        - Else: elide the middle — head (trim_head) + optional summary bridge
+          + tail (trim_tail).  The pre-frame guard
+          ``_maybe_force_compact_for_router`` has already compacted the middle
+          before this runs, so the elide point is structurally aligned.
+
+        Overlap guard: if trim_head and trim_tail collectively cover all turns
+        (the chat is small relative to budgets but total > trigger — unlikely
+        but possible with large single turns), deduplication by identity
+        ensures no turn appears twice.
+
         Returns [{role: 'user'|'assistant', content: str}, ...] ordered
         chronologically. The system prompt is prepended by RouterLoop itself.
-
-        Only user/agent conversational turns are included. The compaction
-        head_size + tail_size governs which turns to keep.
-
-        Slicing correctness: when ``len(turns) <= head_size + tail_size``,
-        ``head`` and ``tail`` overlap (= the same turns appear at both
-        slice ends). Concatenating ``head + tail`` in that regime
-        produces a fully-duplicated history — observed via dogfood
-        trace v6 as the ROOT CAUSE of the Q4 ``list_skills`` empty-stop
-        attractor (= the LLM saw the same user query twice with the
-        history reset between them, got confused, exited silently).
-        Pre-fix had no overlap guard; this branch returns the full
-        ``turns`` unchanged when no slicing is needed and only takes
-        the head+tail (with optional summary bridge) when the history
-        actually exceeds the window.
+        Only user/agent conversational turns are included; ``summary`` /
+        ``skill_event`` remain Reyn-internal and are filtered out.
         """
-        cfg = self._compaction
+        from reyn.services.compaction.engine import (
+            estimate_tokens_for_turn,
+            trim_head,
+            trim_tail,
+        )
         # E-full (#383): include tool-turn entries (= assistant w/ tool_calls,
         # tool responses) in the slice. The wire-shape builder below
         # forwards them as-is to the LLM. ``summary`` / ``skill_event``
@@ -4901,13 +4907,38 @@ class ChatSession:
             if m.role in ("user", "assistant", "tool", "agent")
         ]
 
-        if len(turns) <= cfg.head_size + cfg.tail_size:
-            # No compaction needed — head+tail would overlap and duplicate.
+        # Resolve token budgets from the compaction engine.
+        _ctrl = getattr(self, "_compaction_controller", None)
+        engine = getattr(_ctrl, "_engine", None)
+        budgets = getattr(engine, "budgets", None)
+        use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+        model = getattr(self, "model", "")
+        if budgets is not None:
+            effective_trigger = budgets.effective_trigger
+            head_budget = budgets.head_budget
+            tail_budget = budgets.tail_budget
+        else:
+            from reyn.llm.model_budget import get_max_input_tokens
+            effective_trigger = get_max_input_tokens(
+                model, events=getattr(self, "_chat_events", None)
+            )
+            head_budget = tail_budget = effective_trigger // 4
+
+        total = sum(
+            estimate_tokens_for_turn(m, model, use_chars4=use_chars4)
+            for m in turns
+        )
+
+        if total <= effective_trigger:
+            # Window-utilization: full raw conversation fits — no elide.
             selected = turns
         else:
-            # Head+tail with optional summary bridge for the elided middle.
-            head = turns[:cfg.head_size]
-            tail = turns[-cfg.tail_size:] if cfg.tail_size else []
+            # Elide the middle: head + optional summary bridge + tail.
+            head = trim_head(turns, head_budget, model, use_chars4=use_chars4)
+            tail = trim_tail(turns, tail_budget, model, use_chars4=use_chars4)
+            # Overlap guard: dedupe by identity so no turn appears twice.
+            head_ids = {id(t) for t in head}
+            tail_deduped = [t for t in tail if id(t) not in head_ids]
             summary = self._latest_summary()
             if summary:
                 summary_text = (
@@ -4919,9 +4950,9 @@ class ChatSession:
                     content=f"[summary of earlier conversation]\n{summary_text}",
                     ts=summary.ts,
                 )]
-                selected = head + bridge + tail
+                selected = head + bridge + tail_deduped
             else:
-                selected = head + tail
+                selected = head + tail_deduped
 
         # E-full (#383) pass-through: ChatMessage IS the wire shape, so the
         # builder just serialises each entry into a litellm-compatible
@@ -4960,32 +4991,64 @@ class ChatSession:
     ) -> tuple[list[dict], list[dict], list[dict], dict | None]:
         """Decompose current history into (head, raw_middle, tail, summary) for retry_loop.
 
-        Mirrors :meth:`_build_history_for_router`'s head/tail slicing but
-        exposes the elided ``raw_middle`` explicitly so the bounded
-        adaptive-shrink ``retry_loop`` (#1125 Item 2) can fold it into the
-        running summary under overflow — instead of the prior degraded
-        compact-once. ``summary`` is the structured dict from the latest
-        persisted summary turn (retry_loop treats it as an immutable base).
+        #1128 step 3: mirrors :meth:`_build_history_for_router`'s token-budget
+        elide threshold (effective_trigger) and exposes the elided ``raw_middle``
+        explicitly so the bounded adaptive-shrink ``retry_loop`` (#1125 Item 2)
+        can fold it into the running summary under overflow.  ``summary`` is the
+        structured dict from the latest persisted summary turn (retry_loop treats
+        it as an immutable base).
 
-        When ``len(turns) <= head_size + tail_size`` the head/tail would
-        overlap (the documented Q4-attractor duplication hazard), so the whole
-        history goes into ``head`` with empty ``raw_middle`` / ``tail`` — there
-        is nothing to elide, and retry_loop's shrink can still trim ``head``.
+        When total token estimate <= effective_trigger the full history goes into
+        ``head`` with empty ``raw_middle`` / ``tail`` — there is nothing to elide,
+        and retry_loop's shrink can still trim ``head``.
         """
-        cfg = self._compaction
+        from reyn.services.compaction.engine import (
+            estimate_tokens_for_turn,
+            trim_head,
+            trim_tail,
+        )
         turns = [
             m for m in self.history
             if m.role in ("user", "assistant", "tool", "agent")
         ]
-        if len(turns) <= cfg.head_size + cfg.tail_size:
+
+        # Resolve token budgets from the compaction engine (same as _build_history_for_router).
+        _ctrl = getattr(self, "_compaction_controller", None)
+        engine = getattr(_ctrl, "_engine", None)
+        budgets = getattr(engine, "budgets", None)
+        use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+        model = getattr(self, "model", "")
+        if budgets is not None:
+            effective_trigger = budgets.effective_trigger
+            head_budget = budgets.head_budget
+            tail_budget = budgets.tail_budget
+        else:
+            from reyn.llm.model_budget import get_max_input_tokens
+            effective_trigger = get_max_input_tokens(
+                model, events=getattr(self, "_chat_events", None)
+            )
+            head_budget = tail_budget = effective_trigger // 4
+
+        total = sum(
+            estimate_tokens_for_turn(m, model, use_chars4=use_chars4)
+            for m in turns
+        )
+
+        if total <= effective_trigger:
+            # Everything fits — no elide; retry_loop can still trim head.
             head_msgs = turns
             raw_middle_msgs: list = []
             tail_msgs: list = []
         else:
-            head_msgs = turns[:cfg.head_size]
-            tail_msgs = turns[-cfg.tail_size:] if cfg.tail_size else []
-            middle_end = len(turns) - cfg.tail_size if cfg.tail_size else len(turns)
-            raw_middle_msgs = turns[cfg.head_size:middle_end]
+            head_msgs = trim_head(turns, head_budget, model, use_chars4=use_chars4)
+            tail_msgs = trim_tail(turns, tail_budget, model, use_chars4=use_chars4)
+            # raw_middle = turns strictly between head and tail (by identity).
+            head_id_set = {id(t) for t in head_msgs}
+            tail_id_set = {id(t) for t in tail_msgs}
+            raw_middle_msgs = [
+                t for t in turns
+                if id(t) not in head_id_set and id(t) not in tail_id_set
+            ]
 
         summary_msg = self._latest_summary()
         summary_dict: dict | None = None

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -431,16 +431,6 @@ class CompactionConfig:
     # skip T2 (straight to the floor, = pre-#271 behaviour).
     resummarize_passes: int = 1
     section_token_caps: CompactionSectionCaps = field(default_factory=CompactionSectionCaps)
-    # head_size / tail_size:
-    # DEPRECATED — retained only for the background `_maybe_compact()` legacy
-    # path which still uses turn-count gates to identify HEAD / TAIL
-    # boundaries. The new synchronous force-trigger path (= pre-frame guard
-    # in `_maybe_force_compact_for_router`) uses token-budget only via
-    # component_weights (= PR-N6). Background-path removal is a separate
-    # root-fix wave; until then these fields exist to keep the legacy lifecycle
-    # working without scope-creeping PR-N3/N6.
-    head_size: int = 12                 # First N user/agent turns = HEAD (background path)
-    tail_size: int = 12                 # Last N user/agent turns = TAIL (background path)
 
 
 @dataclass
@@ -1853,6 +1843,17 @@ def _build_chat_config(raw: object) -> ChatConfig:
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
         return ChatConfig()
+    # #1128 step 3: head_size/tail_size removed — elide is now token-budget
+    # via component_weights.  Emit a deprecation warning so users know to
+    # clean up their YAML.
+    if "head_size" in compaction_raw or "tail_size" in compaction_raw:
+        import warnings
+        warnings.warn(
+            "chat.compaction.head_size/tail_size are deprecated — the turn-count "
+            "limit was removed (#1128); head/tail are now token-budget via "
+            "component_weights. Remove these keys.",
+            DeprecationWarning, stacklevel=2,
+        )
     section_raw = compaction_raw.get("section_token_caps") or {}
     if not isinstance(section_raw, dict):
         section_raw = {}
@@ -1917,8 +1918,6 @@ def _build_chat_config(raw: object) -> ChatConfig:
             compaction_raw.get("resummarize_passes", defaults.resummarize_passes)
         ),
         section_token_caps=section,
-        head_size=int(compaction_raw.get("head_size", defaults.head_size)),
-        tail_size=int(compaction_raw.get("tail_size", defaults.tail_size)),
     )
     return ChatConfig(compaction=compaction)
 

--- a/tests/test_1128_step3_token_budget_headtail.py
+++ b/tests/test_1128_step3_token_budget_headtail.py
@@ -1,0 +1,198 @@
+"""Tier 2: #1128 step 3 — token-budget head/tail elide contract.
+
+Two tests pin the new behaviours introduced in #1128 step 3:
+
+1. Deprecation warning: loading a YAML config with ``chat.compaction.head_size``
+   or ``chat.compaction.tail_size`` emits a ``DeprecationWarning``.
+
+2. Token-budget elide contract for ``_build_history_for_router``:
+   - Small chat (total tokens < effective_trigger): ALL turns returned raw,
+     no elide, no duplication.
+   - Large chat (total tokens > effective_trigger): middle turns elided;
+     head and tail present, at least one middle turn absent.
+
+Policy compliance:
+- No unittest.mock.
+- No private-state assertions.
+- Docstrings start with ``Tier 2: ``.
+- Real config loader (not a mock) for the deprecation test.
+- Real ChatSession with monkeypatched ``get_max_input_tokens`` for the
+  elide test (no mocked collaborators).
+"""
+from __future__ import annotations
+
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import reyn.llm.model_budget as _mb
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: deprecation warning
+# ---------------------------------------------------------------------------
+
+
+def test_head_size_tail_size_emit_deprecation_warning() -> None:
+    """Tier 2: loading a YAML config with ``chat.compaction.head_size`` or
+    ``chat.compaction.tail_size`` emits a ``DeprecationWarning``.
+
+    Uses the real ``_build_chat_config`` loader path — no mocks.  The old
+    keys are silently ignored (head/tail sizing is now controlled by
+    ``component_weights``); users must remove them to silence the warning.
+    """
+    from reyn.config import _build_chat_config  # noqa: PLC0415
+
+    # Both keys present — must emit the warning.
+    with pytest.warns(DeprecationWarning, match="head_size/tail_size are deprecated"):
+        cfg = _build_chat_config({
+            "compaction": {
+                "head_size": 6,
+                "tail_size": 6,
+                "trigger_total_tokens": 30_000,
+            }
+        })
+
+    # The resulting CompactionConfig must NOT have head_size/tail_size fields.
+    import dataclasses
+    field_names = {f.name for f in dataclasses.fields(cfg.compaction)}
+    assert "head_size" not in field_names, (
+        "CompactionConfig must not expose head_size after #1128 step 3 removal"
+    )
+    assert "tail_size" not in field_names, (
+        "CompactionConfig must not expose tail_size after #1128 step 3 removal"
+    )
+
+
+def test_head_size_only_also_warns() -> None:
+    """Tier 2: ``head_size`` alone (without ``tail_size``) also emits the deprecation."""
+    from reyn.config import _build_chat_config  # noqa: PLC0415
+
+    with pytest.warns(DeprecationWarning, match="head_size/tail_size are deprecated"):
+        _build_chat_config({"compaction": {"head_size": 12}})
+
+
+def test_clean_config_no_warning() -> None:
+    """Tier 2: a config without ``head_size``/``tail_size`` emits no DeprecationWarning."""
+    from reyn.config import _build_chat_config  # noqa: PLC0415
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        # Must not raise — no deprecated key present.
+        _build_chat_config({"compaction": {"trigger_total_tokens": 30_000}})
+
+
+# ---------------------------------------------------------------------------
+# Test 2: _build_history_for_router token-budget elide contract
+# ---------------------------------------------------------------------------
+
+
+def _make_session_with_t_max(tmp_path: Path, t_max: int):
+    """Return a ChatSession with a synthetic T_max.
+
+    ``section_caps_spec_tokens=0`` keeps B_M positive for small T_max.
+    ``use_chars4_estimate=True`` makes token counting deterministic.
+    """
+    from reyn.budget.budget import BudgetTracker, CostConfig
+    from reyn.chat.session import ChatSession
+    from reyn.config import CompactionConfig
+    from reyn.events.state_log import StateLog
+
+    original = _mb.get_max_input_tokens
+    _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]
+    try:
+        session = ChatSession(
+            agent_name="default",
+            agent_role="",
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+            compaction_config=CompactionConfig(
+                trigger_total_tokens=100_000,
+                use_chars4_estimate=True,
+                section_caps_spec_tokens=0,
+            ),
+            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+        )
+    finally:
+        _mb.get_max_input_tokens = original
+    return session
+
+
+def _push(session, role: str, content: str) -> None:
+    from reyn.chat.session import ChatMessage
+    if role == "agent":
+        role = "assistant"
+    session.history.append(ChatMessage(role=role, content=content, ts=_now()))
+
+
+# Content that yields 80 tokens (320 chars / 4) via use_chars4_estimate=True.
+# With T_max=2000 (T_SP≈1125, T_comp_SP≈481, section_caps=0):
+#   effective_trigger≈570, head_budget≈87, tail_budget≈131.
+# 3 turns × 80 tokens = 240 < 570 → no elide.
+# 8 turns × 80 tokens = 640 > 570 → elide fires.
+_CONTENT_80TOK = "X" * 320
+
+
+def test_build_history_small_chat_returns_all_turns_raw(tmp_path) -> None:
+    """Tier 2: a small chat (total tokens < effective_trigger) returns ALL turns
+    without elide, and no turn appears more than once.
+
+    This pins the window-utilization-first contract (#1128 step 3 Fork B):
+    the LLM sees the full raw conversation as long as it fits under the
+    trigger threshold.  No duplication can occur from this branch.
+    """
+    # T_max=2000 → effective_trigger≈570.  3 turns × 80 tokens = 240 < 570.
+    session = _make_session_with_t_max(tmp_path, t_max=2000)
+    for text in ["alpha", "beta", "gamma"]:
+        _push(session, "user", text)
+
+    msgs = session._build_history_for_router()
+    contents = [m["content"] for m in msgs]
+
+    assert contents == ["alpha", "beta", "gamma"], (
+        "small chat must return all turns in order — no elide"
+    )
+    assert len(set(contents)) == len(contents), (
+        "window-utilization branch must not duplicate turns"
+    )
+
+
+def test_build_history_large_chat_elides_middle(tmp_path) -> None:
+    """Tier 2: a large chat (total tokens > effective_trigger) elides the middle —
+    head is present, tail is present, and at least one middle turn is absent.
+
+    Uses T_max=2000 (effective_trigger≈570) with 8 turns of 80-token content
+    (total=640 > 570) to force the elide branch.  The deduplication guard
+    ensures no turn appears twice even when head and tail budgets overlap.
+    """
+    session = _make_session_with_t_max(tmp_path, t_max=2000)
+    texts = [f"turn-{i}:" + _CONTENT_80TOK for i in range(8)]
+    for i, text in enumerate(texts):
+        _push(session, "user" if i % 2 == 0 else "assistant", text)
+
+    msgs = session._build_history_for_router()
+    contents = [m["content"] for m in msgs]
+    present = set(contents)
+
+    # Head and tail turns must survive the elide.
+    assert texts[0] in present, "first turn (head) must be present after elide"
+    assert texts[-1] in present, "last turn (tail) must be present after elide"
+
+    # At least one middle turn must be absent (= elide actually fired).
+    middle_absent = any(t not in present for t in texts[1:-1])
+    assert middle_absent, (
+        "expected at least one middle turn elided, but all turns present — "
+        "elide branch did not fire; check that total > effective_trigger"
+    )
+
+    # No duplicates — the overlap deduplication guard must hold.
+    assert len(contents) == len(set(contents)), (
+        "duplicate messages in router view — elide overlap deduplication failed"
+    )

--- a/tests/test_chat_compaction_engine_11axis.py
+++ b/tests/test_chat_compaction_engine_11axis.py
@@ -541,10 +541,12 @@ class _LockHoldingEngine(CompactionEngine):
         self._cfg = _CC(use_chars4_estimate=True)
         self._use_chars4 = True
         self._T_comp_SP = 10
-        # Synthetic budgets — bypass assert_static_bounds.
+        # Synthetic budgets — small head/tail so 11 turns of "x"*200
+        # (50 tokens each via chars4) produce non-empty middle candidates.
+        # head=tail=50 → each budget fits exactly 1 turn; middle=[t2..t10].
         self._budgets = ComputedBudgets(
-            main_pool=100_000, head_budget=10_000, body_budget=5_000,
-            tail_budget=15_000, new_msg_budget=10_000,
+            main_pool=100_000, head_budget=50, body_budget=5_000,
+            tail_budget=50, new_msg_budget=10_000,
             B_M=80_000, main_M_room=65_000, effective_trigger=65_000,
         )
         self.compaction_lock = asyncio.Lock()
@@ -593,7 +595,7 @@ def test_compaction_lock_blocks_concurrent_append() -> None:
     ctrl = CompactionController(
         event_log=EventLog(),
         config=CompactionConfig(
-            head_size=2, tail_size=2, min_compact_batch=1,
+            min_compact_batch=1,
             use_chars4_estimate=True,
         ),
         history_access=lambda: list(history),
@@ -923,7 +925,7 @@ def test_force_compact_now_single_pass_no_race_recovery() -> None:
 
     ctrl = CompactionController(
         event_log=events,
-        config=CompactionConfig(head_size=2, tail_size=2, use_chars4_estimate=True),
+        config=CompactionConfig(use_chars4_estimate=True),
         history_access=_big_history,
         latest_summary=lambda: None,
         compaction_engine=engine,

--- a/tests/test_compaction_controller_invariants.py
+++ b/tests/test_compaction_controller_invariants.py
@@ -21,12 +21,34 @@ from reyn.events.events import EventLog
 from reyn.services.compaction.engine import (
     ChatSummary,
     CompactionEngine,
+    ComputedBudgets,
     HistoryChunkToCompact,
 )
 
 # ---------------------------------------------------------------------------
 # Helpers — minimal ChatMessage stand-in and engine stub
 # ---------------------------------------------------------------------------
+
+
+def _small_budgets(*, head: int = 2, tail: int = 2) -> ComputedBudgets:
+    """Return ComputedBudgets with small head/tail token budgets for tests.
+
+    ``head`` and ``tail`` are in tokens (chars4 units).  All controller
+    tests use ``use_chars4_estimate=True``.  "hi" = 2 chars → max(1, 2//4)
+    = 1 token.  With head=tail=2, trim_head keeps the first 2 turns and
+    trim_tail keeps the last 2, leaving a non-empty middle for a 7-turn
+    history (exactly 3 middle candidates).
+    """
+    return ComputedBudgets(
+        main_pool=1000,
+        head_budget=head,
+        body_budget=100,
+        tail_budget=tail,
+        new_msg_budget=100,
+        B_M=1000,
+        main_M_room=1000,
+        effective_trigger=1000,
+    )
 
 
 @dataclass
@@ -43,12 +65,16 @@ class _AbortingEngine(CompactionEngine):
     """Engine stub that always raises so compaction aborts early.
 
     Inherits from the real engine but overrides compact() — no LLM call.
+    Sets ``_budgets`` to small values so ``_select_candidates`` produces
+    non-empty middle candidates from a moderate-length history.
     """
 
     def __init__(self) -> None:
         # Skip CompactionEngine.__init__ (needs model + events).
         self._model = "stub"
         self._events = EventLog()
+        self._budgets = _small_budgets()
+        self.compaction_lock = asyncio.Lock()
 
     async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
         raise RuntimeError("aborting engine stub: test-time abort")
@@ -61,6 +87,8 @@ class _SucceedingEngine(CompactionEngine):
         self._model = "stub"
         self._events = EventLog()
         self._covers = covers
+        self._budgets = _small_budgets()
+        self.compaction_lock = asyncio.Lock()
 
     async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
         seqs = [int(t.get("seq", 0)) for t in input_chunk.new_turns if isinstance(t, dict)]
@@ -76,6 +104,8 @@ class _BlockingEngine(CompactionEngine):
         self._events = EventLog()
         self._gate = gate
         self.call_count = 0
+        self._budgets = _small_budgets()
+        self.compaction_lock = asyncio.Lock()
 
     async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
         self.call_count += 1
@@ -91,6 +121,8 @@ class _CancellableEngine(CompactionEngine):
         self._events = EventLog()
         self._start = start_gate
         self._cancel = cancel_gate
+        self._budgets = _small_budgets()
+        self.compaction_lock = asyncio.Lock()
 
     async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
         self._start.set()
@@ -109,9 +141,8 @@ def _make_controller(
     _history: list[_FakeMessage] = history if history is not None else []
     cfg = config or CompactionConfig(
         trigger_total_tokens=100,
-        head_size=2,
-        tail_size=2,
         min_compact_batch=3,
+        use_chars4_estimate=True,  # deterministic offline token counts
     )
 
     def _latest_summary():
@@ -154,12 +185,15 @@ def test_threshold_below_trigger_no_compaction():
     _maybe_compact emits compaction_check with outcome='below_threshold'
     and does NOT emit compaction_started.
 
-    Config: trigger=10_000 tokens (very high), 3 candidate turns ~12 tokens
-    total → compaction should not fire.  compaction_check must appear;
-    compaction_started must not.
+    Config: trigger=10_000 tokens (very high), 3 candidate turns ~3 tokens
+    total (using chars4, "hi"=1 token each) → compaction should not fire.
+    The stub engine has head/tail budgets=2 tokens each, so 7 turns leave
+    3 middle candidates above min_compact_batch=3.
+    compaction_check must appear; compaction_started must not.
     """
-    # Build 7 turns: seq 1-7 with short text.  head=2, tail=2 → candidates
-    # are seq 3,4,5 (3 turns, above min_compact_batch=3).
+    # 7 turns: seq 1-7 with "hi" text (1 token each via chars4).
+    # _small_budgets(head=2, tail=2) → head=[seq1,seq2], tail=[seq6,seq7],
+    # candidates=[seq3,seq4,seq5] (3 turns, exactly at min_compact_batch).
     history: list[_FakeMessage] = []
     for i in range(1, 8):
         role = "user" if i % 2 == 1 else "agent"
@@ -168,10 +202,9 @@ def test_threshold_below_trigger_no_compaction():
     ctrl, events = _make_controller(
         history=history,
         config=CompactionConfig(
-            trigger_total_tokens=10_000,  # well above actual token count
-            head_size=2,
-            tail_size=2,
+            trigger_total_tokens=10_000,  # well above actual token count (~3 tok)
             min_compact_batch=3,
+            use_chars4_estimate=True,
         ),
     )
 
@@ -218,9 +251,8 @@ def test_single_flight_lock_prevents_concurrent():
         history=history,
         config=CompactionConfig(
             trigger_total_tokens=1,
-            head_size=2,
-            tail_size=2,
             min_compact_batch=3,
+            use_chars4_estimate=True,
         ),
         engine=blocking_engine,
     )
@@ -280,9 +312,8 @@ def test_cancel_during_shutdown_graceful():
         history=history,
         config=CompactionConfig(
             trigger_total_tokens=1,
-            head_size=2,
-            tail_size=2,
             min_compact_batch=3,
+            use_chars4_estimate=True,
         ),
         engine=cancellable_engine,
     )

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -40,24 +40,52 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _make_session(tmp_path: Path, *, head_size: int = 2, tail_size: int = 2) -> ChatSession:
+def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
+    """Create a ChatSession with a synthetic T_max controlling effective_trigger.
+
+    #1128 step 3: slicing is token-budget based (not turn-count).
+    ``use_chars4_estimate=True`` makes counting deterministic (chars // 4).
+    ``section_caps_spec_tokens=0`` keeps B_M positive for small T_max values.
+
+    Default t_max=1_000_000 → effective_trigger is large → small histories
+    return all turns (no elide).  Pass a small t_max to force the elide branch.
+
+    With t_max=2000 (section_caps_spec_tokens=0, T_SP≈1125 from real router SP,
+    T_comp_SP≈481 from real compaction SP):
+      head_budget≈87, tail_budget≈131, effective_trigger≈570.
+    Turns of content ``'X'*320`` each cost 80 tokens via chars4.  With 8 such
+    turns (total=640 > 570), elide fires.  head=[t0], tail=[t7], middle=[t1-t6].
+    """
+    import reyn.llm.model_budget as _mb
+
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
     bt = BudgetTracker(CostConfig())
     cfg = CompactionConfig(
         trigger_total_tokens=100_000,  # never auto-trigger in unit tests
-        head_size=head_size,
-        tail_size=tail_size,
         body_token_cap=1500,
+        use_chars4_estimate=True,  # deterministic offline token counts
+        section_caps_spec_tokens=0,  # keeps B_M positive for small T_max
     )
-    return ChatSession(
-        agent_name="default",
-        agent_role="",
-        output_language="en",
-        budget_tracker=bt,
-        state_log=state_log,
-        compaction_config=cfg,
-        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
-    )
+    original = _mb.get_max_input_tokens
+    _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]  # noqa: E501
+    try:
+        session = ChatSession(
+            agent_name="default",
+            agent_role="",
+            output_language="en",
+            budget_tracker=bt,
+            state_log=state_log,
+            compaction_config=cfg,
+            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+        )
+    finally:
+        _mb.get_max_input_tokens = original
+    return session
+
+
+# Content that yields exactly 80 tokens per turn via use_chars4_estimate=True.
+# 'X' * 320 = 320 chars → max(1, 320 // 4) = 80 tokens.
+_TURN_80TOK = "X" * 320
 
 
 def _push(session: ChatSession, role: str, text: str) -> None:
@@ -70,31 +98,46 @@ def _push(session: ChatSession, role: str, text: str) -> None:
 
 
 def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
-    """Tier 2: with len(turns) > head+tail, decomposition splits head/raw_middle/tail."""
-    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    """Tier 2: when total tokens > effective_trigger, decomposition produces
+    non-empty head, raw_middle, and tail, and head + raw_middle + tail is a
+    lossless in-order partition of all turns (no dropped or duplicated turn).
+
+    Uses t_max=2000 (effective_trigger≈89) and 8 turns of 20-token content
+    (total=160 > 89) to force the elide branch.
+    """
+    # Each turn = 'X'*320 = 80 tokens (use_chars4); total=640 > trigger≈570 → elide.
+    session = _make_session(tmp_path, t_max=2000)
     for i in range(8):
-        _push(session, "user" if i % 2 == 0 else "assistant", f"turn-{i}")
+        _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
     head, raw_middle, tail, summary = session._decompose_history_for_retry()
 
-    assert [m["content"] for m in head] == ["turn-0", "turn-1"]
-    assert [m["content"] for m in raw_middle] == ["turn-2", "turn-3", "turn-4", "turn-5"]
-    assert [m["content"] for m in tail] == ["turn-6", "turn-7"]
+    assert head, "head must be non-empty after elide"
+    assert tail, "tail must be non-empty after elide"
+    assert raw_middle, "raw_middle must be non-empty for a middle-elide scenario"
     assert summary is None
-    # head + raw_middle + tail is a lossless, in-order partition of the turns
-    # (no dropped or duplicated turn — the concatenation reproduces the input).
-    assert [m["content"] for m in head + raw_middle + tail] == [
-        f"turn-{i}" for i in range(8)
-    ]
+
+    # Lossless partition: concatenating head+raw_middle+tail reproduces all turns.
+    all_via_decomp = head + raw_middle + tail
+    # Same number of messages as were pushed (lossless — nothing dropped).
+    msgs_pushed = 8
+    assert len(all_via_decomp) == msgs_pushed, (
+        f"expected all {msgs_pushed} pushed turns in partition, got {len(all_via_decomp)}"
+    )
+    # No duplicate objects — each turn appears exactly once by identity.
+    assert len(all_via_decomp) == len(set(id(m) for m in all_via_decomp)), (
+        "duplicate message objects detected — partition overlap guard failed"
+    )
 
 
-def test_decompose_no_overlap_when_history_fits_window(tmp_path) -> None:
-    """Tier 2: when len(turns) <= head+tail, everything is head — raw_middle/tail empty.
+def test_decompose_no_elide_when_history_fits_window(tmp_path) -> None:
+    """Tier 2: when total tokens <= effective_trigger, everything is in head —
+    raw_middle and tail are empty (nothing to elide).
 
-    This avoids the documented Q4-attractor duplication (head/tail overlap); there
-    is nothing to elide, and retry_loop's shrink can still trim head.
+    retry_loop's shrink can still trim head if needed.
     """
-    session = _make_session(tmp_path, head_size=4, tail_size=4)
+    # Large t_max → effective_trigger large → 3 short turns easily fit.
+    session = _make_session(tmp_path, t_max=1_000_000)
     for i in range(3):
         _push(session, "user", f"q-{i}")
 
@@ -108,7 +151,7 @@ def test_decompose_no_overlap_when_history_fits_window(tmp_path) -> None:
 
 def test_decompose_extracts_structured_summary(tmp_path) -> None:
     """Tier 2: a persisted summary turn surfaces its structured dict (immutable base)."""
-    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    session = _make_session(tmp_path)
     structured = {"topic_arc": "greeting", "decisions": []}
     session.history.append(ChatMessage(
         role="summary",
@@ -124,38 +167,47 @@ def test_decompose_extracts_structured_summary(tmp_path) -> None:
 
 
 def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
-    """Tier 2: decomposed turns use the same wire serialisation as the normal path.
+    """Tier 2: decomposed head+tail turns use the same wire serialisation as
+    the normal router path (_build_history_for_router).
 
-    retry_loop must rebuild the prompt the normal router send would have produced;
-    a divergent wire shape (different role normalisation, missing tool fields)
-    would make the recovery prompt differ from the live one.
+    retry_loop must rebuild the prompt the normal router send would have
+    produced; a divergent wire shape (different role normalisation, missing
+    tool fields) would make the recovery prompt differ.
+
+    This test forces the elide branch on both paths via t_max=2000 so that
+    _build_history_for_router also returns head+tail (no summary bridge).
     """
-    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    session = _make_session(tmp_path, t_max=2000)
     for i in range(8):
-        _push(session, "user" if i % 2 == 0 else "assistant", f"t-{i}")
+        _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
     head, raw_middle, tail, _summary = session._decompose_history_for_retry()
     via_build = session._build_history_for_router()
-    decomposed_contents = [m["content"] for m in head + tail]
-    # _build_history_for_router (else-branch) = head + [summary bridge?] + tail;
-    # no summary here, so its non-bridge turns are exactly head+tail.
+
+    # Both paths must return the same non-bridge turns in the same order.
+    # _build_history_for_router: head + [bridge?] + tail (no summary → no bridge).
+    # _decompose_history_for_retry: head + raw_middle + tail.
+    # The head and tail turns must be wire-identical across both paths.
+    decomposed_head_tail = [m["content"] for m in head + tail]
     build_contents = [m["content"] for m in via_build]
-    assert decomposed_contents == build_contents
+    assert decomposed_head_tail == build_contents, (
+        "decompose head+tail must match _build_history_for_router output "
+        "(same serialisation, same turns) — retry_loop recovery path must be byte-identical"
+    )
 
 
 def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
-    """Tier 2: with a persisted summary, the recovery bridge text == the normal path's.
+    """Tier 2: with a persisted summary, the recovery bridge text equals the
+    normal router path's bridge.
 
     The recovery prompt rebuilt by ``_router_main_call`` renders the structured
     summary via ``_render_summary_for_storage`` — the same renderer that produced
-    the persisted ``summary.content`` the normal path (``_build_history_for_router``)
-    uses for its bridge. So the summary bridge is byte-identical across the two
-    paths (pinning the fix for the structured-vs-rendered divergence). retry_loop
-    still receives the structured dict as its immutable fold base.
+    the persisted ``summary.content`` the normal path uses for its bridge.
+    So the summary bridge is byte-identical across both paths.
     """
     from reyn.chat.session import _render_summary_for_storage
 
-    session = _make_session(tmp_path, head_size=2, tail_size=2)
+    session = _make_session(tmp_path, t_max=2000)
     structured = {
         "topic_arc": "planning the trip",
         "decisions": ["book the tuesday flight"],
@@ -163,7 +215,6 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         "session_user_facts": [],
         "artifacts_referenced": [],
     }
-    # Store the summary exactly as the controller does: content = rendered form.
     rendered = _render_summary_for_storage(structured)
     session.history.append(ChatMessage(
         role="summary",
@@ -171,8 +222,9 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         ts=_now(),
         meta={"structured": structured, "covers_through_seq": 2},
     ))
-    for i in range(8):  # > head+tail → else-branch → bridge inserted
-        _push(session, "user" if i % 2 == 0 else "assistant", f"t-{i}")
+    # 8 turns of 80 tokens = 640 > trigger≈570 → elide fires → bridge inserted.
+    for i in range(8):
+        _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
     # Normal path bridge content.
     normal = session._build_history_for_router()
@@ -180,8 +232,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         m["content"] for m in normal
         if isinstance(m["content"], str) and m["content"].startswith("[summary")
     )
-    # Recovery path: decomposition hands the structured dict; _router_main_call
-    # renders it the same way → reproduce that bridge text here.
+    # Recovery path renders the structured dict the same way.
     _h, _rm, _t, summary_dict = session._decompose_history_for_retry()
     recovery_bridge = (
         "[summary of earlier conversation]\n" + _render_summary_for_storage(summary_dict)
@@ -201,8 +252,9 @@ def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
     and the learner observes via the ``_RouterUsageShim``. retry_loop's shrink /
     engine.compact recovery is covered separately (PR-N6 Fake-engine tests).
     """
-    session = _make_session(tmp_path, head_size=4, tail_size=4)
-    for i in range(3):  # fits window → empty raw_middle → no engine.compact LLM call
+    # Large t_max → everything fits → empty raw_middle → no engine.compact LLM call.
+    session = _make_session(tmp_path, t_max=1_000_000)
+    for i in range(3):
         _push(session, "user", f"hi-{i}")
 
     head, raw_middle, tail, summary = session._decompose_history_for_retry()

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -1,28 +1,26 @@
-"""Tier 2: ChatSession._build_history_for_router slicing correctness.
+"""Tier 2: ChatSession._build_history_for_router token-budget slicing correctness.
 
-Pins the contract that the messages array fed to the chat router LLM
-mirrors session.history exactly when the history fits within the head
-+ tail window (= no duplication), and applies head/tail slicing only
-when the history exceeds the window.
+#1128 step 3 (Fork B): elide threshold now coincides with effective_trigger
+(the existing pre-frame compaction trigger) instead of the old turn-count
+head_size/tail_size.  The router view returns ALL turns when total token
+estimate <= effective_trigger (window-utilization-first), and elides the
+middle only when the conversation exceeds the budget.
 
-Discovered as the ROOT CAUSE of the Q4 ``list_skills`` empty-stop
-attractor in dogfood trace v6: the prior implementation
-unconditionally concatenated ``turns[:head_size] + turns[-tail_size:]``,
-so any history with ``len(turns) <= head_size + tail_size`` produced a
-fully-duplicated messages array. The LLM saw the same user query twice
-with history reset between them and silently exited.
-
-Tests also pin the per-turn invariant Reyn relies on for pathological
-inputs: even if a user sends two messages in quick succession, each
-turn's messages array reflects the snapshot of session.history at that
-point, with no extra duplication.
+Tests pin:
+- Small conversation (total < effective_trigger): all turns returned, no
+  duplication (the Q4 attractor root cause was exactly this duplication).
+- Large conversation (total > effective_trigger): head + tail with the middle
+  elided; deduplication guard so no turn appears twice.
+- Empty history: empty result.
+- Summary bridge inserted when a summary exists and elide fires.
 """
 from __future__ import annotations
 
+import contextlib
+from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
-
+import reyn.llm.model_budget as _mb
 from reyn.budget.budget import BudgetTracker, CostConfig
 from reyn.chat.session import ChatMessage, ChatSession
 from reyn.config import CompactionConfig
@@ -30,130 +28,174 @@ from reyn.events.state_log import StateLog
 
 
 def _now() -> str:
-    from datetime import datetime, timezone
     return datetime.now(timezone.utc).isoformat()
 
 
-def _make_session(
-    tmp_path: Path,
-    *,
-    head_size: int = 12,
-    tail_size: int = 12,
-) -> ChatSession:
+@contextlib.contextmanager
+def _synthetic_t_max(t_max: int):
+    """Monkeypatch get_max_input_tokens for the duration of the with-block.
+
+    Uses direct module-level replacement (the same pattern used in
+    test_chat_compaction_engine_11axis.py) — no unittest.mock.
+    """
+    original = _mb.get_max_input_tokens
+    _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _mb.get_max_input_tokens = original
+
+
+def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
+    """Create a ChatSession whose compaction engine uses a synthetic T_max.
+
+    ``use_chars4_estimate=True`` makes token estimation deterministic:
+    each character counts as 1/4 token.
+
+    ``t_max`` is injected via monkeypatch so effective_trigger is
+    predictable in tests.  The default (1_000_000) is large enough that
+    any realistic test conversation fits and no elide fires, unless a
+    smaller t_max is passed.
+    """
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
     bt = BudgetTracker(CostConfig())
     cfg = CompactionConfig(
-        trigger_total_tokens=100_000,  # never trigger compaction in unit tests
-        head_size=head_size,
-        tail_size=tail_size,
+        trigger_total_tokens=100_000,  # never trigger background compaction
         body_token_cap=1500,
+        use_chars4_estimate=True,  # deterministic: chars // 4
+        section_caps_spec_tokens=0,  # keeps B_M positive for small T_max values
     )
-    return ChatSession(
-        agent_name="default",
-        agent_role="",
-        output_language="en",
-        budget_tracker=bt,
-        state_log=state_log,
-        compaction_config=cfg,
-        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
-    )
+    # Monkeypatch covers the engine's compute_budgets() call at ChatSession init.
+    with _synthetic_t_max(t_max):
+        return ChatSession(
+            agent_name="default",
+            agent_role="",
+            output_language="en",
+            budget_tracker=bt,
+            state_log=state_log,
+            compaction_config=cfg,
+            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+        )
 
 
-def _push_turn(session, role: str, text: str) -> None:
-    # Issue #383: ChatMessage uses ``content`` field; legacy "agent" role
-    # → "assistant" for new construction.
+def _push(session: ChatSession, role: str, text: str) -> None:
     if role == "agent":
         role = "assistant"
     session.history.append(ChatMessage(role=role, content=text, ts=_now()))
 
 
-# ── No-overlap branch (= len(turns) <= head_size + tail_size) ────────────────
+# ── No-elide branch (total <= effective_trigger) ─────────────────────────────
 
 
-def test_history_fits_in_window_returns_unique_turns(tmp_path):
-    """Tier 2: when history.length <= head_size + tail_size, the
-    messages array equals the history one-for-one — no head+tail
-    overlap duplication.
+def test_history_fits_in_window_returns_all_turns(tmp_path):
+    """Tier 2: when total tokens <= effective_trigger, all turns are returned
+    in order — no elide, no duplication.
 
-    This is the contract that Q4 dogfood violated pre-fix.
+    This pins the window-utilization contract: Fork B shows the full raw
+    conversation until it exceeds the trigger.  The Q4 attractor root cause
+    was duplicate turns from the old turn-count head+tail overlap — this
+    branch can never produce duplicates.
     """
-    session = _make_session(tmp_path, head_size=12, tail_size=12)
-    # 7 turns (= 4 user + 3 agent), well under head+tail=24
-    _push_turn(session, "user", "hello")
-    _push_turn(session, "agent", "Hi there!")
-    _push_turn(session, "user", "what can you do?")
-    _push_turn(session, "agent", "I can help with...")
-    _push_turn(session, "user", "tell me about yourself")
-    _push_turn(session, "agent", "I am a Reyn agent.")
-    _push_turn(session, "user", "list available skills")
+    # Large t_max → effective_trigger large → 7 short turns easily fit.
+    session = _make_session(tmp_path, t_max=1_000_000)
+    pushed = ["hello", "Hi there!", "what can you do?", "I can help...",
+              "tell me about yourself", "I am a Reyn agent.", "list available skills"]
+    for text in pushed:
+        _push(session, "user", text)
 
     msgs = session._build_history_for_router()
-    # No duplicates by content: each unique user turn appears exactly once.
-    user_texts = [m["content"] for m in msgs if m["role"] == "user"]
-    assert user_texts == ["hello", "what can you do?", "tell me about yourself", "list available skills"], (
-        "head+tail overlap duplication regression: user turns duplicated or missing"
+    contents = [m["content"] for m in msgs]
+    # All pushed turns returned — no drops, no duplicates.
+    assert set(contents) == set(pushed), (
+        "window-utilization branch must return all pushed turns"
     )
-    all_texts = [m["content"] for m in msgs]
-    assert len(set(all_texts)) == len(all_texts), (
-        "duplicate messages detected; pre-fix head+tail concat regression"
+    assert len(contents) == len(set(contents)), (
+        "duplicate messages detected — window-utilization branch must return unique turns"
     )
 
 
 def test_empty_history_returns_empty_messages(tmp_path):
-    """Tier 2: empty history → empty messages, no spurious duplication."""
+    """Tier 2: empty history → empty result."""
     session = _make_session(tmp_path)
     msgs = session._build_history_for_router()
-    assert msgs == []
+    assert msgs == [], f"expected empty result for empty history, got {msgs!r}"
 
 
 def test_single_turn_returns_single_message(tmp_path):
-    """Tier 2: 1 turn → 1 message, not 2."""
+    """Tier 2: single turn → exactly one message, no duplication."""
     session = _make_session(tmp_path)
-    _push_turn(session, "user", "hello")
+    _push(session, "user", "hello")
     msgs = session._build_history_for_router()
     assert msgs == [{"role": "user", "content": "hello"}]
 
 
-# ── Boundary: exactly at head + tail ────────────────────────────────────────
+# ── Elide branch (total > effective_trigger) ─────────────────────────────────
+
+# Each "XXXXXXXXXXX...X" text is 320 chars → 80 tokens (chars4).
+# With t_max=2000, section_caps_spec_tokens=0, T_SP≈1125 (real router SP),
+# T_comp_SP≈481 (real compaction SP):
+#   head_budget ≈ 87 tokens
+#   tail_budget ≈ 131 tokens
+#   effective_trigger ≈ 570 tokens
+# 8 turns × 80 tokens = 640 > 570 → elide fires.
+# head=[t0] (87 tokens budget, single 80-tok turn exactly fits).
+# tail=[t7] (131 tokens budget, single 80-tok turn fits).
+# middle=[t1..t6] → 6 turns absent from the router view.
+
+_LONG_TEXT = "X" * 320  # 80 tokens via chars4; use with t_max=2000
 
 
-def test_exactly_head_plus_tail_no_duplication(tmp_path):
-    """Tier 2: len(turns) == head_size + tail_size is the boundary case.
-    Both branches would produce the same result (= all turns, no
-    duplication). Pre-fix would also have worked here because
-    head[:N] + tail[-N:] of a 2N-list IS the full list. Pinning this
-    boundary case explicitly so a future refactor that flips the
-    inequality (= ``<`` vs ``<=``) doesn't silently regress.
+def test_history_exceeds_trigger_elides_middle(tmp_path):
+    """Tier 2: when total tokens > effective_trigger, the middle turns are
+    elided and head + tail are returned without duplication.
+
+    Uses a synthetic T_max=2000 (section_caps_spec_tokens=0) which yields
+    effective_trigger≈570.  8 turns of 80-token text total 640 > 570, so
+    the elide branch fires.
     """
-    session = _make_session(tmp_path, head_size=2, tail_size=2)
-    for i in range(4):
-        _push_turn(session, "user" if i % 2 == 0 else "agent", f"msg-{i}")
+    session = _make_session(tmp_path, t_max=2000)
+    texts = [f"turn-{i}:" + _LONG_TEXT for i in range(8)]
+    for i, text in enumerate(texts):
+        _push(session, "user" if i % 2 == 0 else "assistant", text)
+
     msgs = session._build_history_for_router()
-    assert [m["content"] for m in msgs] == ["msg-0", "msg-1", "msg-2", "msg-3"]
+    contents = [m["content"] for m in msgs]
+
+    # The middle turn(s) must be absent.
+    present = set(contents)
+    assert texts[0] in present, "head turn must be present"
+    assert texts[-1] in present, "tail turn must be present"
+    # At least one middle turn must be absent (= elide occurred).
+    middle_texts = set(texts[1:-1])
+    assert not middle_texts.issubset(present), (
+        "expected at least one middle turn to be elided, but all middle turns present"
+    )
+    # No duplicates.
+    assert len(contents) == len(set(contents)), (
+        "duplicate messages in elide branch — overlap deduplication failed"
+    )
 
 
-# ── Compaction branch (= len(turns) > head + tail) ──────────────────────────
-
-
-def test_history_exceeds_window_applies_head_tail_slice(tmp_path):
-    """Tier 2: when history exceeds head+tail, slicing kicks in and the
-    middle turns are elided. With NO summary bridge, head+tail are
-    concatenated directly.
+def test_elide_inserts_summary_bridge_when_summary_present(tmp_path):
+    """Tier 2: when a summary exists and elide fires, a bridge message is
+    inserted between head and tail.
     """
-    session = _make_session(tmp_path, head_size=2, tail_size=2)
-    for i in range(8):
-        _push_turn(session, "user" if i % 2 == 0 else "agent", f"msg-{i}")
-    # 8 turns > 2+2=4 → head=msg-0..1, tail=msg-6..7
-    msgs = session._build_history_for_router()
-    assert [m["content"] for m in msgs] == ["msg-0", "msg-1", "msg-6", "msg-7"]
+    session = _make_session(tmp_path, t_max=2000)
+    # Inject a summary before the turns.
+    session.history.append(ChatMessage(
+        role="summary",
+        content="summary of earlier",
+        ts=_now(),
+        meta={"structured": {"topic_arc": "test"}, "covers_through_seq": 0},
+    ))
+    # 8 turns × 80 tokens = 640 > effective_trigger≈570 → elide fires.
+    texts = [f"turn-{i}:" + _LONG_TEXT for i in range(8)]
+    for i, text in enumerate(texts):
+        _push(session, "user" if i % 2 == 0 else "assistant", text)
 
-
-def test_zero_tail_size_no_overlap_in_unfit_branch(tmp_path):
-    """Tier 2: tail_size=0 in the unfit branch yields head only, no
-    spurious empty tail to cause off-by-one.
-    """
-    session = _make_session(tmp_path, head_size=2, tail_size=0)
-    for i in range(5):
-        _push_turn(session, "user", f"msg-{i}")
     msgs = session._build_history_for_router()
-    assert [m["content"] for m in msgs] == ["msg-0", "msg-1"]
+    bridge_msgs = [m for m in msgs if isinstance(m.get("content"), str)
+                   and m["content"].startswith("[summary")]
+    assert bridge_msgs, (
+        "expected a summary bridge message when summary exists and elide fires"
+    )

--- a/tests/test_slash_compact_191.py
+++ b/tests/test_slash_compact_191.py
@@ -41,17 +41,35 @@ def _now() -> str:
 
 
 def _make_session(tmp_path) -> ChatSession:
-    return ChatSession(
-        agent_name="default",
-        budget_tracker=BudgetTracker(CostConfig()),
-        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
-        compaction_config=CompactionConfig(
-            head_size=2, tail_size=2, min_compact_batch=1,
-            trigger_total_tokens=100_000,  # high → no auto-fire; /compact forces it
-            use_chars4_estimate=True,      # deterministic offline token counts
-        ),
-        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
-    )
+    """Create a ChatSession with a small synthetic T_max to force non-empty candidates.
+
+    #1128 step 3: _select_candidates uses token-budget boundaries from the engine.
+    With ``t_max=2000`` and ``section_caps_spec_tokens=0`` (T_SP≈1125, T_comp_SP≈481):
+    head_budget≈87, tail_budget≈131, effective_trigger≈570.
+    Turns of 'x'*4000 (=1000 tokens) each individually exceed both budgets, so
+    the Axis-7 single-oversized-turn rule includes exactly one turn in head and
+    one in tail.  With 8 turns: middle=[t1..t6]=6 candidates ≥ min_compact_batch=1.
+    """
+    import reyn.llm.model_budget as _mb
+
+    original = _mb.get_max_input_tokens
+    _mb.get_max_input_tokens = lambda model, **kw: 2000  # type: ignore[assignment]
+    try:
+        session = ChatSession(
+            agent_name="default",
+            budget_tracker=BudgetTracker(CostConfig()),
+            state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+            compaction_config=CompactionConfig(
+                min_compact_batch=1,
+                trigger_total_tokens=100_000,  # high → no auto-fire; /compact forces it
+                use_chars4_estimate=True,      # deterministic offline token counts
+                section_caps_spec_tokens=0,    # keeps B_M positive for small T_max
+            ),
+            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+        )
+    finally:
+        _mb.get_max_input_tokens = original
+    return session
 
 
 def _drain(session) -> list:

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -278,15 +278,18 @@ def test_chat_message_content_list_persists_image_block():
 def _make_history_builder():
     """Pluck ``_build_history_for_router`` in a minimal harness — we
     only need its content-shape decision logic.
+
+    #1128 step 3: slicing is now token-budget based (effective_trigger from
+    engine budgets, falling back to get_max_input_tokens).  Short test turns
+    (1-2 messages of a few tokens) are well below any realistic trigger, so
+    all turns are returned raw — no elide, no duplication.
     """
     from reyn.chat.session import ChatSession
 
     cs = ChatSession.__new__(ChatSession)  # bypass __init__
     cs.history = []  # set by tests
-    # Compaction config must be present; the no-compaction branch fires
-    # when len(turns) <= head + tail, so set both to large.
     from reyn.config import CompactionConfig
-    cs._compaction = CompactionConfig(head_size=100, tail_size=100)
+    cs._compaction = CompactionConfig(use_chars4_estimate=True)
     cs._latest_summary = lambda: None  # type: ignore[method-assign]
     return cs
 

--- a/tests/test_version_snapshot_pure.py
+++ b/tests/test_version_snapshot_pure.py
@@ -107,7 +107,6 @@ def test_parse_on_propose_ignores_unrelated_top_level_keys():
         chat:
           compaction:
             trigger_total_tokens: 30000
-            head_size: 12
         self_improvement:
           on_propose: auto
           max_versions: 7


### PR DESCRIPTION
**[e2e-coder]** — #1128 step 3: Fork B token-budget head/tail elide for router view + compaction candidates.

## Summary

Replaces the chat router-view's **turn-count** head/tail elide (`head_size=12, tail_size=12`) with a **token-budget (window-relative)** elide that coincides with `effective_trigger` (the existing pre-frame compaction trigger). This closes the Q2 silent-context-loss gap: the old elide fired at 24 turns (~before any real conversation), while compaction rescue only engaged at ~680K tokens.

**Fork B (window-utilization-first)**: show the full raw conversation until it exceeds `effective_trigger`; only then elide the middle (which the pre-frame guard's `force_compact_now` has already summarized).

### Changes per file

- **`src/reyn/config.py`** (D1): remove `head_size`/`tail_size` fields from `CompactionConfig`; emit `DeprecationWarning` via the config loader when old YAML keys are present (keys silently ignored; head/tail sizing now driven by `component_weights`).
- **`src/reyn/chat/session.py`** — `_build_history_for_router`: token-budget elide using `trim_head`/`trim_tail` from engine `ComputedBudgets`; `total <= effective_trigger` → full raw view (no elide, no duplication); else head + optional summary bridge + tail with identity-based overlap deduplication. Defensive `getattr` so bypass-`__init__` test harnesses work.
- **`src/reyn/chat/session.py`** — `_decompose_history_for_retry`: mirrors same token-budget threshold; `raw_middle` = turns by identity exclusion from head + tail sets.
- **`src/reyn/chat/services/compaction_controller.py`**: new `_select_candidates(turns, prev_cover)` helper using `trim_head`/`trim_tail` from engine budgets (fallback when `budgets=None`); both `_maybe_compact` and `force_compact_now` use it; empty-candidates emits `too_few_turns`.
- **Tests (8 updated + 1 new)**: remove `head_size`/`tail_size` kwargs from all 8 test files; use `t_max` monkeypatch + `section_caps_spec_tokens=0` for deterministic small budgets; stub engines get `_budgets` with small head/tail; add `tests/test_1128_step3_token_budget_headtail.py` (Tier-2: deprecation warning + router-view token-budget elide contract).

### No trigger changes

`_maybe_force_compact_for_router`'s `effective_trigger` threshold is **unchanged** — Fork B makes the elide coincide with it, not change it.

### PR-a (#1195 axis-1 removal) note

PR-a (`feat/1128-pr-a-axis1-removal`) removes `trigger_total_tokens` / `min_compact_batch` from `CompactionConfig`. That PR should rebase onto this one.

## Test plan

- [x] `python -m pytest -q tests/test_session_router_history_slicing.py tests/test_compaction_controller_invariants.py tests/test_chat_compaction_engine_11axis.py tests/test_retry_loop_chat_wiring_1125.py tests/test_pr_n6_compaction_overflow_retry.py tests/test_slash_compact_191.py tests/test_user_image_input.py tests/test_version_snapshot_pure.py tests/test_1128_step3_token_budget_headtail.py` — 108 passed
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_1128_step3_token_budget_headtail.py tests/test_session_router_history_slicing.py tests/test_compaction_controller_invariants.py tests/test_retry_loop_chat_wiring_1125.py tests/test_slash_compact_191.py` — 0 errors
- [x] `python -c "import reyn.chat.session, reyn.chat.services.compaction_controller, reyn.config"` — clean import
- [ ] **dogfood-gate pending** (sandbox_2 Q2 scenario before merge)

**Dogfood-gate pending (sandbox_2 Q2 scenario) before this merges. PR-a (#1195 axis-1 removal) rebases after.**

Refs #1128
