### PR TITLE
docs(compaction): window-utilization-first arch + remove deprecated config keys

### DIFF
--- a/docs/concepts/data-retrieval/chat-compaction.md
+++ b/docs/concepts/data-retrieval/chat-compaction.md
@@ -10,38 +10,37 @@ How Reyn keeps long chat sessions from overflowing the context window.
 
 ## What it is
 
-When enough turns accumulate, the middle of the history is folded into a
-rolling structured summary. Three zones are fed to the LLM:
+When context fills, the middle of the history is folded into a rolling
+structured summary. Three zones are fed to the LLM:
 
-- **Head** — first N turns (raw, never compacted; preserves the original task context)
+- **Head** — earliest turns (raw, never compacted; preserves the original task context)
 - **Body** — rolling summary produced by the compaction engine
-- **Tail** — last N turns (raw, kept for recency)
+- **Tail** — most-recent turns (raw, kept for recency)
+
+Head and tail sizes are **token-budgeted** — derived from `component_weights`
+against the model's actual context window, not a fixed turn count. Chat fills
+the window raw first; compaction fires only once the history exceeds the
+effective trigger, which is window-relative (derived from the same budgets, not
+an absolute token count).
 
 The `CompactionEngine` is an OS-internal Python helper that makes a direct
 LLM call to produce the summary. It is not a stdlib skill.
 
 ## Compaction paths
 
-Compaction can be triggered by four independent paths. All four use the same
+Compaction can be triggered by three independent paths. All three use the same
 `CompactionEngine` and Head/Body/Tail slice logic.
 
 ### 1. Synchronous pre-frame guard
 
 Before each router LLM call, `_maybe_force_compact_for_router` checks the
 estimated token usage of the current history against the effective trigger
-budget. If over budget, it calls `force_compact_now` synchronously before the
-LLM frame is built. This ensures the prompt never exceeds the budget *before*
-the call — a proactive shrink rather than a reactive one.
+budget (window-relative). If over budget, it calls `force_compact_now`
+synchronously before the LLM frame is built. This ensures the prompt never
+exceeds the budget *before* the call — a proactive shrink rather than a
+reactive one.
 
-### 2. Background post-reply path
-
-After each reply, `CompactionController.spawn_maybe` fires a background task
-when both conditions hold: estimated middle-turn tokens exceed
-`trigger_total_tokens` (default 30 000) and at least `min_compact_batch` turns
-(default 5) are available to absorb. This path is fire-and-forget and never
-blocks the current turn.
-
-### 3. Voluntary compact op (LLM-requested)
+### 2. Voluntary compact op (LLM-requested)
 
 When the window is filling, the OS injects a `## Context window` header with
 the exact-token free window (the context-size signal). The model may emit a
@@ -49,7 +48,7 @@ the exact-token free window (the context-size signal). The model may emit a
 the current axis (chat or phase) and returns the freed tokens and new headroom.
 See [`control-ir.md`](../../reference/runtime/control-ir.md) for the op contract.
 
-### 4. `retry_loop` overflow backstop
+### 3. `retry_loop` overflow backstop
 
 When the pre-frame guard's token estimate under-counts and the router raises a
 context-length error, `retry_loop` takes over. It shrinks head, tail, and the
@@ -88,9 +87,15 @@ The same engine serves three distinct compaction axes:
 - **Planner step axis** — older plan-step results inside an active plan.
 - **Phase axis** — older `control_ir_results` inside a running phase's act loop.
 
-Each axis has both automatic compaction (per-frame or per-reply) and an
-on-demand seam (the `compact` Control IR op, available to the LLM when the
-context-size signal fires).
+Each axis has both automatic compaction (per-frame) and an on-demand seam (the
+`compact` Control IR op, available to the LLM when the context-size signal fires).
+
+## Cost observability
+
+The `/budget` command shows token and cost usage broken down **by purpose**:
+`main`, `phase`, `compaction`, `judge`, and agent-attributed buckets. This lets
+operators see how much of their token spend the compaction engine is consuming
+across a session.
 
 ## Configuration (`reyn.yaml`)
 
@@ -114,10 +119,6 @@ chat:
       session_user_facts:   10
       artifacts_referenced: 35
 
-    # Background trigger (spawn_maybe path only).
-    trigger_total_tokens: 30000
-    min_compact_batch: 5
-
     # Hard cap on summary body tokens (post-truncation).
     body_token_cap: 1500
 
@@ -128,12 +129,19 @@ chat:
 Weights are sum-arbitrary — any positive integers work; Reyn normalises them at
 startup. Larger values give more token budget to that component.
 
+**Removed keys:** `head_size`, `tail_size`, `trigger_total_tokens`, and
+`min_compact_batch` are no longer recognised. If present in `reyn.yaml`, Reyn
+emits a `DeprecationWarning` and ignores them. Remove these keys from your
+config — head/tail sizing is now token-budget via `component_weights`, and
+auto-compaction is window-relative.
+
 ## Trade-offs
 
 **Preserved:** topic arc, decisions, pending items, user facts, referenced
 artifacts (including tool activity — files read / URLs fetched / MCP tools
 called surface as `artifacts_referenced` entries when the result is
-conversation-relevant), and the raw first/last N turns.
+conversation-relevant), and the raw head and tail zones (token-budgeted,
+sized relative to the model's actual context window).
 
 **Lost:** verbatim phrasing of compacted turns; exact ordering of minor
 exchanges. Section budgets are soft — slight overruns self-correct on the
@@ -147,9 +155,9 @@ input and decides whether to record the call under `artifacts_referenced`. Tool
 turns count toward the head/tail/body slice the same as plain conversational
 turns.
 
-Compaction runs in a background asyncio task (path 2) or synchronously before
-the frame (path 1). Events `compaction_started` / `compaction_completed` /
-`compaction_failed` are emitted to the session event log (P6).
+Compaction runs synchronously before the frame (path 1) or on-demand (path 2).
+Events `compaction_started` / `compaction_completed` / `compaction_failed` are
+emitted to the session event log (P6).
 
 ## See also
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -245,7 +245,7 @@ plan:
 | フィールド | 型 | デフォルト | 説明 |
 |-------|------|---------|-------------|
 | `recent_step_results_raw` | int | `3` | 最新 N 件の step_results はそのまま保持し、それより古いものをコンパクション。 |
-| `step_results_ratio` | float | `0.50` | `main_pool`（= `T_max - T_SP`）のうち次ステップの sys_prompt 内 step_results 部分に割り当てる比率。`chat.compaction.body_ratio` の sibling。 |
+| `step_results_ratio` | float | `0.50` | `main_pool`（= `T_max - T_SP`）のうち次ステップの sys_prompt 内 step_results 部分に割り当てる比率。`chat.compaction.component_weights` の body 配分の sibling。 |
 | `summarize_older_threshold_tokens` | int \| null | `null` | 古い step_results をコンパクションする閾値（トークン数）。`null` の場合は `ComputedBudgets`（= `step_results_ratio × main_pool`）から導出。 |
 | `use_chars4_estimate` | bool | `false` | `true` の場合、`litellm.token_counter` の代わりに `len(text)//4` を使用（レイテンシ opt-out、`chat.compaction.use_chars4_estimate` と同じ意味）。 |
 
@@ -748,29 +748,33 @@ embedding:
 
 ## `chat` ブロック
 
-チャットセッションの圧縮設定 — 最近のターンを失わずにコンテキストを簡潔に保つ Head/Body/Tail トークンバジェット。
-
-バジェット配分は **比率ベース**: 4 つの ratio はモデルのメインコンテキストプール (= `T_max - T_SP`) の比率として表現され、合計が ≤ 1.0 でなければなりません（起動時に検証）。**weight dict** で同じ ratio バジェット内の詳細な調整が可能です。レガシーフィールド (`trigger_total_tokens` / `head_size` / `tail_size` / `body_token_cap` / `min_compact_batch` / `section_token_caps`) は、各リプライ後に発火する background パスを駆動します。
+チャットは最初にコンテキストウィンドウを生のターンで充填し、履歴が
+effective trigger（`component_weights` からモデルの実際のコンテキストウィンドウに対して
+ウィンドウ相対で導出）を超えた時点で圧縮が発火します。Head・Tail ゾーンは
+ターン数ではなく **トークンバジェット** で管理されます。
 
 ```yaml
 chat:
   compaction:
-    # 比率ベースのバジェット（合計 ≤ 1.0）:
-    head_ratio: 0.10
-    body_ratio: 0.05
-    tail_ratio: 0.15
-    new_msg_ratio: 0.10
+    # バジェット配分: 整数の重み、起動時に正規化。
+    # キー: head / body / tail / new_msg / compaction_batch
+    component_weights:
+      head:             10
+      body:             5
+      tail:             15
+      new_msg:          10
+      compaction_batch: 60
     section_caps_spec_tokens: 100
     use_chars4_estimate: false        # true = len(text)//4（レイテンシ opt-out）
-    # weight dict（整数の重み、合計値は任意）:
-    component_weights: {head: 10, body: 5, tail: 15, new_msg: 10}
-    section_weights: {decisions: 40, pending: 40, topic_arc: 20, session_user_facts: 20, artifacts_referenced: 30}
-    # レガシー / background-trigger パス:
-    trigger_total_tokens: 30000        # カバーされない中間部がこれを超えると圧縮
-    head_size: 12                      # 最初の N ユーザー/エージェントターンを生のまま保持
-    tail_size: 12                      # 最後の N ユーザー/エージェントターンを生のまま保持
-    body_token_cap: 1500               # 全 body サマリーセクションの合計トークン上限
-    min_compact_batch: 5               # N ターン未満の圧縮はスキップ
+    body_token_cap: 1500               # サマリー body トークン上限（post-truncation）
+    resummarize_passes: 1              # hard_truncate 前の LLM 再圧縮パス数
+    # body 内のセクション配分の重み、起動時に正規化。
+    section_weights:
+      topic_arc:            5
+      decisions:            40
+      pending:              25
+      session_user_facts:   10
+      artifacts_referenced: 35
     section_token_caps:
       topic_arc: 200
       decisions: 400
@@ -779,33 +783,16 @@ chat:
       artifacts_referenced: 300
 ```
 
-### `chat.compaction` ratio フィールド
+### `chat.compaction` フィールド
 
 | フィールド | 型 | デフォルト | 説明 |
 |-------|------|---------|-------------|
-| `head_ratio` | float | `0.10` | `main_pool` のうち HEAD スライス（= 最初の生ターン）に割り当てる比率。 |
-| `body_ratio` | float | `0.05` | `main_pool` のうち BODY（= 構造化サマリー）に割り当てる比率。 |
-| `tail_ratio` | float | `0.15` | `main_pool` のうち TAIL スライス（= 最新の生ターン）に割り当てる比率。 |
-| `new_msg_ratio` | float | `0.10` | `main_pool` のうち incoming ユーザーメッセージに割り当てる比率。 |
-| `section_caps_spec_tokens` | int | `100` | コンパクタープロンプト内の `section_token_caps` シリアライズに割り当てる静的オーバーヘッドバジェット。 |
+| `component_weights` | map[str,int] | `{head:10, body:5, tail:15, new_msg:10, compaction_batch:60}` | 各プロンプトコンポーネントの整数の重み。起動時に `main_pool` に対して正規化。合計値は任意。 |
+| `section_weights` | map[str,int] | （セクションごとのデフォルト） | body バジェット内のサブセクション配分の重み。`component_weights` と同じ shape セマンティクス。 |
+| `section_caps_spec_tokens` | int | `100` | コンパクタープロンプト内の `section_token_caps` シリアライズ用静的オーバーヘッドバジェット。 |
+| `body_token_cap` | int | `1500` | post-truncation 後のサマリー body トークン上限。 |
+| `resummarize_passes` | int | `1` | `topic_arc` が body バジェットを超えた場合の最大 LLM 再圧縮パス数（`hard_truncate` floor 適用前）。`0` = 再圧縮なし（straight to floor）。 |
 | `use_chars4_estimate` | bool | `false` | `true` の場合、`litellm.token_counter` の代わりに `len(text)//4` を使用（大規模デプロイ向けレイテンシ opt-out）。 |
-
-### `chat.compaction` weight dict
-
-| フィールド | 型 | デフォルト | 説明 |
-|-------|------|---------|-------------|
-| `component_weights` | map[str,int] | `{head: 10, body: 5, tail: 15, new_msg: 10}` | ratio バジェット内のコンポーネントごとの配分を駆動する整数の重み。合計値は任意。指定したキーのみオーバーライド。 |
-| `section_weights` | map[str,int] | （セクションごとのデフォルト） | `body_ratio` 内のサブセクション配分の重み。`component_weights` と同じ shape セマンティクス。 |
-
-### `chat.compaction` レガシー / background-path フィールド
-
-| フィールド | 型 | デフォルト | 説明 |
-|-------|------|---------|-------------|
-| `trigger_total_tokens` | int | `30000` | background パス: カバーされない中間部がこのトークン数を超えると圧縮。同期的な pre-frame ガードは ratio フィールドを使用。 |
-| `head_size` | int | `12` | background パス: 生のまま保持する最初のユーザー/エージェントターン数（ターン数ベースのゲート）。 |
-| `tail_size` | int | `12` | background パス: 生のまま保持する最新のユーザー/エージェントターン数（ターン数ベースのゲート）。 |
-| `body_token_cap` | int | `1500` | post-truncation 後のサマリー body トークン上限（legacy ceiling）。 |
-| `min_compact_batch` | int | `5` | 吸収するターン数がこれ未満の場合は圧縮をスキップ（小さな圧縮を回避）。 |
 
 ### `chat.compaction.section_token_caps` フィールド
 
@@ -816,6 +803,13 @@ chat:
 | `pending` | `400` | 保留項目セクションのトークン上限。 |
 | `session_user_facts` | `200` | 圧縮をまたいで引き継ぐユーザーファクトのトークン上限。 |
 | `artifacts_referenced` | `300` | アーティファクト参照一覧のトークン上限。 |
+
+### 廃止キー
+
+`head_size`、`tail_size`、`trigger_total_tokens`、`min_compact_batch` は認識されなくなりました。
+`reyn.yaml` に存在する場合、Reyn は起動時に `DeprecationWarning` を発行して無視します。
+これらのキーを設定ファイルから削除してください — head/tail のサイズ管理は `component_weights`
+によるトークンバジェットに移行し、自動圧縮はウィンドウ相対になりました。
 
 ## `events` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -34,7 +34,7 @@ models:
 | `sandbox` | map | Sandboxed-exec backend selection and unsupported-platform policy. See below. |
 | `action_retrieval` | map | Universal catalog visibility + retrieval settings. See below. |
 | `embedding` | map | RAG embedding model classes and batch settings. See below. |
-| `chat` | map | Chat-session compaction (head/body/tail) settings. See below. |
+| `chat` | map | Chat-session compaction settings. See below. |
 | `voice` | map | Voice input (Whisper) settings for the chat TUI. See below. |
 | `events` | map | Audit-log rotation policy for chat-session event files. See below. |
 | `skill_search` | map | BM25 skill pre-filter settings. See below. |
@@ -254,7 +254,7 @@ plan:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `recent_step_results_raw` | int | `3` | Keep the last N step_results verbatim; compact older ones. |
-| `step_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the step_results portion of the next step's sys_prompt. Sibling to `chat.compaction.body_ratio`. |
+| `step_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the step_results portion of the next step's sys_prompt. Sibling to `chat.compaction.component_weights` body allocation. |
 | `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older step_results are compacted. `null` derives the threshold from `ComputedBudgets` (= `step_results_ratio × main_pool`). |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out, mirrors `chat.compaction.use_chars4_estimate`). |
 
@@ -793,29 +793,33 @@ See [Concepts: RAG — local embedding backend](../../concepts/data-retrieval/ra
 
 ## `chat` block
 
-Chat-session compaction — head/body/tail token budgets that keep context concise without losing recent turns.
-
-Budget allocation is **ratio-based**: each of the four ratios is a fraction of the model's main context pool (= `T_max - T_SP`), and they must sum to ≤ 1.0 (validated at startup). **Weight dicts** allow fine-grained tuning within the same ratio budget. The legacy `trigger_total_tokens` / `head_size` / `tail_size` / `body_token_cap` / `min_compact_batch` / `section_token_caps` fields drive the background path that fires after each reply.
+Chat fills the context window with raw turns first; compaction fires when the
+history exceeds the effective trigger (window-relative, derived from
+`component_weights` against the model's actual context window). Head and tail
+zones are **token-budgeted**, not turn-count gated.
 
 ```yaml
 chat:
   compaction:
-    # Ratio-based budget (sum must be ≤ 1.0):
-    head_ratio: 0.10
-    body_ratio: 0.05
-    tail_ratio: 0.15
-    new_msg_ratio: 0.10
+    # Budget allocation: integer weights, normalised at runtime.
+    # Keys: head / body / tail / new_msg / compaction_batch
+    component_weights:
+      head:             10
+      body:             5
+      tail:             15
+      new_msg:          10
+      compaction_batch: 60
     section_caps_spec_tokens: 100
     use_chars4_estimate: false        # true = len(text)//4 (latency opt-out)
-    # Weight dicts (integer weights, sum-arbitrary):
-    component_weights: {head: 10, body: 5, tail: 15, new_msg: 10}
-    section_weights: {decisions: 40, pending: 40, topic_arc: 20, session_user_facts: 20, artifacts_referenced: 30}
-    # Legacy / background-trigger path:
-    trigger_total_tokens: 30000        # compact when uncovered middle exceeds this
-    head_size: 12                      # first N user/agent turns kept raw
-    tail_size: 12                      # last N user/agent turns kept raw
-    body_token_cap: 1500               # total token cap across all body summary sections
-    min_compact_batch: 5               # skip compaction when fewer than N turns to absorb
+    body_token_cap: 1500               # hard cap on summary body tokens (post-truncation)
+    resummarize_passes: 1              # LLM re-compression passes before hard_truncate floor
+    # Section budget weights within body, normalised at runtime.
+    section_weights:
+      topic_arc:            5
+      decisions:            40
+      pending:              25
+      session_user_facts:   10
+      artifacts_referenced: 35
     section_token_caps:
       topic_arc: 200
       decisions: 400
@@ -824,34 +828,16 @@ chat:
       artifacts_referenced: 300
 ```
 
-### `chat.compaction` ratio fields
+### `chat.compaction` fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `head_ratio` | float | `0.10` | Fraction of `main_pool` reserved for the HEAD slice (= earliest verbatim turns). |
-| `body_ratio` | float | `0.05` | Fraction of `main_pool` reserved for the BODY (= rolling structured summary). |
-| `tail_ratio` | float | `0.15` | Fraction of `main_pool` reserved for the TAIL slice (= most-recent verbatim turns). |
-| `new_msg_ratio` | float | `0.10` | Fraction of `main_pool` reserved for the incoming user message. |
+| `component_weights` | map[str,int] | `{head:10, body:5, tail:15, new_msg:10, compaction_batch:60}` | Integer weights for each prompt component, normalised to `main_pool` at runtime. Sum is arbitrary; larger values give more token budget to that component. |
+| `section_weights` | map[str,int] | (per-section default) | Integer weights for sub-section allocation within the body budget. Same shape semantics as `component_weights`. |
 | `section_caps_spec_tokens` | int | `100` | Static overhead budget for `section_token_caps` serialisation in the compactor prompt. |
-| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of the litellm token counter (latency opt-out for large deployments). |
-| `resummarize_passes` | int | `1` | #271: max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `1` = one judgment-based re-summary then floor; `0` = skip the re-summary (straight to the floor = pre-#271 behaviour). |
-
-### `chat.compaction` weight dicts
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `component_weights` | map[str,int] | `{head: 10, body: 5, tail: 15, new_msg: 10}` | Integer weights driving per-component allocation within the ratio budget. Sum is arbitrary; individual keys override only those components. |
-| `section_weights` | map[str,int] | (per-section default) | Integer weights for sub-section allocation within `body_ratio`. Same shape semantics as `component_weights`. |
-
-### `chat.compaction` legacy / background-path fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `trigger_total_tokens` | int | `30000` | Background path: compact when the uncovered middle exceeds this token count. The synchronous pre-frame guard uses the ratio fields instead. |
-| `head_size` | int | `12` | Background path: number of earliest user/agent turns kept verbatim (turn-count gate). |
-| `tail_size` | int | `12` | Background path: number of most-recent user/agent turns kept verbatim (turn-count gate). |
-| `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation (legacy ceiling). |
-| `min_compact_batch` | int | `5` | Skip compaction when fewer than this many turns would be absorbed (avoids tiny compactions). |
+| `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation. |
+| `resummarize_passes` | int | `1` | Max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `0` = skip re-summary (straight to the floor). |
+| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
 
 ### `chat.compaction.section_token_caps` fields
 
@@ -862,6 +848,14 @@ chat:
 | `pending` | `400` | Token cap for the pending-items section. |
 | `session_user_facts` | `200` | Token cap for user-facts carried across compactions. |
 | `artifacts_referenced` | `300` | Token cap for artifact reference listings. |
+
+### Removed keys
+
+`head_size`, `tail_size`, `trigger_total_tokens`, and `min_compact_batch` are
+no longer recognised. If present in your `reyn.yaml`, Reyn emits a
+`DeprecationWarning` at startup and ignores them. Remove these keys — head/tail
+sizing is now token-budget via `component_weights`, and auto-compaction is
+window-relative.
 
 ## `events` block
 

--- a/docs/reference/stdlib/skill_router.md
+++ b/docs/reference/stdlib/skill_router.md
@@ -27,7 +27,7 @@ ChatSession constructs this on every turn. Selected fields:
 | `user_message` | inbox payload | The latest utterance to route |
 | `chat_id` | session | The agent's own name (used by classify when building memory paths) |
 | `history_path` | session | Path to `history.jsonl`, sliced by the classify preprocessor |
-| `compaction` | config | Head/tail sizes for history slicing |
+| `compaction` | config | Window-first token-budget compaction policy (`component_weights` / `section_weights`) |
 | `available_skills` | session | Project + stdlib catalogue (router/compactor excluded), filtered by `profile.allowed_skills` if set |
 | `available_agents` | registry | Other agents reachable via topology rules — `[{name, role}, ...]` |
 | `memory_index` | session | Pre-merged shared + agent layers (`{status, content}`); `content` is markdown with `(shared)` and `(agent: <name>)` sections |


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- **`chat-compaction.md`**: removes axis-1 background path (removed in #1128 PR-a), rewrites head/tail as token-budgeted zones (not turn-count), describes window-relative `effective_trigger`, adds cost-observability section (`/budget` by-purpose), removes deprecated keys from config example, adds deprecation notice for all 4 removed keys (`head_size` / `tail_size` / `trigger_total_tokens` / `min_compact_batch`)
- **`reyn-yaml.md` + `.ja.md`**: removes ratio fields section (`head_ratio`/`body_ratio` etc., silently ignored since PR-N6), removes legacy/background-path fields section, rewrites `chat` block intro to window-first, adds "Removed keys" deprecation notice. Fixes `step_compaction` cross-ref (`body_ratio` → `component_weights`)
- **`skill_router.md`**: updates compaction context description to "Window-first token-budget compaction"

Verified against: `src/reyn/config.py` (CompactionConfig on origin/main post-#1195), `src/reyn/services/compaction/engine.py` (compute_budgets), `src/reyn/chat/session.py` (_maybe_force_compact_for_router effective_trigger).

`mkdocs build --strict`: 337 warnings (same as origin/main — all pre-existing, 0 from edited files).

## Test plan

- [x] `mkdocs build --strict` — 337 warnings, 0 from edited files
- [x] Verified removed keys emit DeprecationWarning in config.py (lines 1843–1854 origin/main)
- [x] Both `.md` and `.ja.md` variants of `reyn-yaml` updated consistently
- [x] No history/PR/issue references in doc body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)