### PR TITLE
fix(1172): phase CompactionEngine budget resolves the model class (static-path 128K confound)

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -732,8 +732,14 @@ class CompactionEngine:
         self._system_prompt_provider = system_prompt_provider
 
         # Axis 2: measure comp_SP token cost once at init.
+        # #1172 completion: use the RESOLVED self._model (not the raw class) so
+        # token-counting + budget derivation see the real litellm model. The
+        # static path (no system_prompt_provider) does NOT recompute_budgets(),
+        # so __init__ is the only chance to resolve — passing the raw class
+        # "standard" here made get_max_input_tokens() fall back to 128K and
+        # handicapped every phase compaction (offload fired far too early).
         self._T_comp_SP: int = estimate_tokens(
-            _COMPACTION_SYSTEM_PROMPT, model, use_chars4=self._use_chars4
+            _COMPACTION_SYSTEM_PROMPT, self._model, use_chars4=self._use_chars4
         )
 
         if system_prompt_provider is not None:
@@ -742,7 +748,7 @@ class CompactionEngine:
             # to the first recompute_budgets() call below.
             # Initialise with a placeholder so _budgets is always set.
             self._budgets: ComputedBudgets = compute_budgets(
-                self._cfg, model, T_SP=T_SP, T_comp_SP=self._T_comp_SP
+                self._cfg, self._model, T_SP=T_SP, T_comp_SP=self._T_comp_SP
             )
             # Run the first recompute immediately so the provider is consulted
             # at init time and assert_static_bounds fires fail-fast.
@@ -750,7 +756,7 @@ class CompactionEngine:
         else:
             # Static path: T_SP is fixed for the session lifetime.
             self._budgets = compute_budgets(
-                self._cfg, model, T_SP=T_SP, T_comp_SP=self._T_comp_SP
+                self._cfg, self._model, T_SP=T_SP, T_comp_SP=self._T_comp_SP
             )
             assert_static_bounds(self._cfg, self._budgets)
 

--- a/tests/test_compaction_resolver_aware_1172.py
+++ b/tests/test_compaction_resolver_aware_1172.py
@@ -96,6 +96,38 @@ def test_planner_default_light_class_is_resolved(monkeypatch) -> None:
     assert _run_capture(monkeypatch, engine) == "openai/resolved-light"
 
 
+def test_static_path_budget_uses_resolved_model_window() -> None:
+    """Tier 2: #1172 completion — a STATIC-path CompactionEngine (no
+    system_prompt_provider, e.g. the phase / swe_bench engine) derives its
+    budget from the RESOLVED model's real context window, not the 128K
+    unresolved-class fallback.
+
+    Pre-fix, __init__ called compute_budgets() with the raw class string while
+    self._model was resolved only for the litellm call — so the static path
+    (which never recompute_budgets()) handicapped every phase compaction to a
+    128K offload threshold (the C7 confound). The budget must reflect the real
+    window.
+    """
+    from reyn.llm.model_budget import get_max_input_tokens
+
+    real_model = "openai/gemini-2.5-flash-lite"
+    real_window = get_max_input_tokens(real_model)
+
+    engine = CompactionEngine(
+        model="standard",  # the class — phase engines pass the raw runtime class
+        events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True),
+        resolver=ModelResolver({"standard": real_model}),
+        # no system_prompt_provider → static path (the swe_bench/phase shape)
+    )
+    # main_pool = T_max - T_SP(=0 default); must be the RESOLVED model's window,
+    # not the 128K unresolved-class fallback.
+    assert engine.budgets.main_pool == real_window, (
+        "static-path budget must use the resolved model's real window; "
+        f"got {engine.budgets.main_pool} (128000 = the unresolved-class fallback)"
+    )
+
+
 def test_literal_litellm_string_passes_through(monkeypatch) -> None:
     """Tier 2: an unknown literal litellm string is unchanged (passthrough);
     resolver omitted defaults to an empty (builtin-only) resolver, so a string


### PR DESCRIPTION
**[e2e-coder]** — Refs #1172. Surfaced by the C7 faithful in-container run (lead-coder co-signed the root cause).

## Root cause (primary evidence)
#1172 made `CompactionEngine` resolve the model class for the litellm **call** (`self._model`, engine.py:719) and `recompute_budgets` (770), but `__init__`'s `compute_budgets` calls (**745** dynamic, **753** static) + the `T_comp_SP` estimate (**736**) still used the **raw class string**.

- **Dynamic path** (chat: has `system_prompt_provider`) self-corrects — line 749 immediately calls `recompute_budgets` → 770 uses `self._model`. So chat compaction was unaffected.
- **Static path** (the **phase / swe_bench engine**: no `system_prompt_provider`) never recomputes → its budget came from `get_max_input_tokens("standard")` → the **128K unresolved-class fallback** → every phase compaction handicapped to a 128K offload threshold (control_ir offload fired far too early, dropping context the agent should have kept).

Empirically (this branch): a static-path `CompactionEngine(model="standard", resolver={standard: gemini-2.5-flash-lite})` now derives `main_pool=1,048,576` (was `128,000`).

## Fix
`model` → `self._model` at 736 / 745 / 753 (matching the already-correct line 770). The `735-737` `estimate_tokens` is the tokenizer axis (not the 128K window bug) but the same raw-model leak — fixed in this PR for consistency (per lead-coder review note 2).

## Test plan
- [x] New Tier-2 `test_static_path_budget_uses_resolved_model_window` in `test_compaction_resolver_aware_1172.py` — pins the gap the existing #1172 test missed (it checked "resolver is passed" but not "compute_budgets uses the resolved model"). Real engine + real resolver, no mocks.
- [x] `pytest -k "compaction or budget or resolver or 1172 or 1190"` → 413 passed
- [x] `ruff check` (engine + test) → clean
- [x] `scripts/test_tier_audit.py --strict` (test) → 0 errors

## Why it matters (C7)
The C7 faithful in-container measurement was confounded — at 128K the phase control_ir-offload fired 184× during apply, dropping explore/plan context → the agent ran below its true ability. This restores the real window so C7's PASS-rate isn't measured on a handicapped agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
