### PR TITLE
fix(env): docker exec into a login shell so image env-activation is honored

### DIFF
--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -320,7 +320,7 @@ class DockerEnvironmentBackend:
         self, argv: list[str], policy: SandboxPolicy, *, stdin: bytes | None = None,
         cwd: str | None = None,
     ) -> SandboxResult:
-        """Plain ``docker exec`` of argv with cwd=repo_dir — NO host-diff bridge.
+        """``docker exec`` of argv (via a login shell) with cwd=repo_dir — NO host-diff bridge.
 
         The files are already in ``repo_dir`` (the agent edited them via the FS
         methods above), so there is nothing to sync in. Honors only
@@ -331,5 +331,20 @@ class DockerEnvironmentBackend:
         host path can't address. Same asymmetry as policy enforcement — a
         workspace-coupled backend scopes both to the fidelity boundary.
         """
-        exec_argv = [self.docker_bin, "exec", "-w", self.repo_dir, self.container, *argv]
+        # Run inside a LOGIN shell so the image's env-activation (conda / nvm /
+        # rbenv / pyenv — set up in /etc/profile or ~/.bash_profile/~/.bashrc)
+        # is in effect. A plain ``docker exec <argv>`` uses only the base PATH
+        # and misses login-activated tooling — e.g. a SWE-bench image installs
+        # pytest into a ``conda activate``-d env, so ``python -m pytest`` under a
+        # direct exec resolves the base python (no pytest) and fails. This is a
+        # generic correctness fix: the backend knows nothing image-specific, it
+        # just honors whatever the image's login profile activates.
+        #
+        # ``bash -lc 'exec "$@"' reyn-exec <argv>`` passes argv as positional
+        # params ($1..), NOT spliced into the script text, so there is no
+        # shell-injection / quoting surface (``"$@"`` re-exec is argv-faithful).
+        exec_argv = [
+            self.docker_bin, "exec", "-w", self.repo_dir, self.container,
+            "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
+        ]
         return await self._runner(exec_argv, stdin=stdin, timeout=policy.timeout_seconds)

--- a/tests/test_container_backend_1115_stage2.py
+++ b/tests/test_container_backend_1115_stage2.py
@@ -2,8 +2,9 @@
 
 The container backend implements BOTH EnvironmentBackend (repo FS) and
 SandboxBackend (exec), executing FS ops as in-container ``python3 -c`` so the
-container reproduces HostBackend's exact Python semantics. ``run()`` is a plain
-``docker exec`` — NO host-diff bridge.
+container reproduces HostBackend's exact Python semantics. ``run()`` is a
+``docker exec`` into a login shell (so the image's env-activation is honored) —
+NO host-diff bridge.
 
 These tests use a real **local** runner Fake (not a mock): it strips the
 ``docker exec`` prefix and runs the SAME ``python3 -c <script> <args>`` on the
@@ -14,8 +15,9 @@ live Docker daemon.
 Pins:
   (a) the backend satisfies BOTH Protocols (EnvironmentBackend + SandboxBackend);
   (b) every FS op produces the SAME result as HostBackend (semantics parity);
-  (c) run() is a plain `docker exec -w <repo_dir> <container> <argv>` with NO
-      diff / reset / apply bridge steps;
+  (c) run() is a `docker exec -w <repo_dir> <container> bash -lc 'exec "$@"' …
+      <argv>` (login-shell, env-activation honored) with NO diff/reset/apply
+      bridge steps, and argv pass through as positional params (no injection);
   (d) FS args are passed via argv (path with shell-special chars round-trips).
 """
 from __future__ import annotations
@@ -136,8 +138,15 @@ def test_fs_arg_with_special_chars_roundtrips(tmp_path: Path) -> None:
     assert cont.read_bytes(weird) == b"ok"
 
 
-def test_run_is_plain_docker_exec_no_bridge(tmp_path: Path) -> None:
-    """Tier 2: (c) run() = plain `docker exec -w repo_dir container argv`, no bridge."""
+def test_run_is_login_shell_docker_exec_no_bridge(tmp_path: Path) -> None:
+    """Tier 2: (c) run() = `docker exec -w repo_dir container` into a LOGIN shell
+    (`bash -lc 'exec "$@"' …`) so the image's env-activation is honored, no bridge.
+
+    A plain `docker exec <argv>` uses the base PATH only and misses login-shell
+    tooling (e.g. a SWE-bench image's `conda activate`-d pytest). The argv are
+    passed as positional params after the script — NOT spliced into the script
+    text — so there is no shell-injection / quoting surface.
+    """
     calls: list[list[str]] = []
 
     async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
@@ -154,7 +163,40 @@ def test_run_is_plain_docker_exec_no_bridge(tmp_path: Path) -> None:
     assert res.returncode == 0 and res.stdout == b"out"
     # exactly one exec call — no host-diff / reset / clean / apply steps
     [argv] = calls
-    assert argv == ["docker", "exec", "-w", "/testbed", "testc", "pytest", "-x"]
+    assert argv == [
+        "docker", "exec", "-w", "/testbed", "testc",
+        "bash", "-lc", 'exec "$@"', "reyn-exec", "pytest", "-x",
+    ]
     joined = " ".join(a for c in calls for a in c)
     for bridge_token in ("diff", "reset", "clean", "apply"):
         assert bridge_token not in joined, f"bridge step {bridge_token!r} must be absent"
+
+
+def test_run_argv_passed_as_positional_params_not_interpolated(tmp_path: Path) -> None:
+    """Tier 2: (b/argv-safe) shell-special chars in argv survive verbatim — the
+    login-shell wrapper forwards them as positional params, never interpolated.
+
+    The exact argv (including a token with `$`, `;`, spaces, quotes) must appear
+    as trailing list elements after the fixed `bash -lc 'exec "$@"' reyn-exec`
+    prefix, proving no quoting/injection seam was opened by the login-shell wrap.
+    """
+    calls: list[list[str]] = []
+
+    async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+        calls.append(argv)
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+    import asyncio
+
+    be = DockerEnvironmentBackend(
+        container="testc", repo_dir="/testbed", runner=_record_runner,
+    )
+    hostile = ["python", "-c", "print('a; rm -rf $HOME')", "x y", '"q"']
+    asyncio.run(be.run(hostile, SandboxPolicy(timeout_seconds=30)))
+
+    [argv] = calls
+    prefix = ["docker", "exec", "-w", "/testbed", "testc",
+              "bash", "-lc", 'exec "$@"', "reyn-exec"]
+    assert argv[: len(prefix)] == prefix
+    # argv survives byte-for-byte as positional params (no escaping mutation)
+    assert argv[len(prefix):] == hostile


### PR DESCRIPTION
**[e2e-coder]** — ③ of the C7 faithful-eval fix cascade (lead-coder-reviewed). Generic DockerEnvironmentBackend correctness fix; blocker for faithful agent-driven in-container verify.

## Problem (primary evidence)
`DockerEnvironmentBackend.run()` issued a plain `docker exec <argv>` (base PATH only). SWE-bench prebuilt images install their toolchain into a login-shell-activated env (`conda activate testbed`), so the agent's in-container `python -m pytest …` resolves the **base** interpreter — which has no pytest — and the verify phase fails before collecting a single test. **Generic backend bug, not SWE-specific** (any image whose tools come from conda/nvm/rbenv/pyenv login-activation).

```
# astropy-13453 prebuilt image
direct  docker exec -w /testbed <c> python -m pytest --version  -> "No module named pytest"
login   docker exec -w /testbed <c> bash -lc 'exec "$@"' reyn-exec python -m pytest --version -> pytest 7.4.0
```

## Fix
Exec through a **login shell**, P7-clean (backend stays image-agnostic):
```python
exec_argv = [docker, "exec", "-w", repo_dir, container,
             "bash", "-lc", 'exec "$@"', "reyn-exec", *argv]
```
`bash -l` sources the image's profile/bashrc (activates the env); argv are forwarded as **positional params** (`$1..`) and re-exec'd with `exec "$@"` — never spliced into the script text, so there is **no shell-injection / quoting surface**.

## Verification (lead-coder's 4 axes, all primary-evidence)
- **(a) generic** — zero image/skill-specific strings; just a login shell. ✅
- **(b) argv-safe** — hostile `'a; echo PWNED $HOME'` forwarded verbatim as one positional arg, not evaluated/word-split. Pinned by new test `test_run_argv_passed_as_positional_params_not_interpolated`. ✅
- **(c) no regression** — flask-5014 (also a `testbed` conda env!) direct→base python(no pytest); login→`testbed/bin/python` + pytest 7.3.0. The gap was **universal** across SWE-bench images; login-shell strictly improves. cwd `-w /testbed` survives (confirmed `pwd`=/testbed). Container backend suite 18/18. ✅
- **(d) SWE-aligned** — login-shell conda activation is exactly the official harness's env convention. ✅

## Test plan
- [x] `pytest tests/ scripts/ src/reyn/stdlib/skills/swe_bench/ -q` → 6707 passed (1 pre-existing unrelated failure `test_web_fetch_preview_path_ref` — fails identically on origin/main with this change stashed; flagged separately, not from this PR)
- [x] `pytest tests/test_container_backend_1115_stage2.py …` → 18 passed
- [x] `ruff check .` → clean
- [x] `scripts/test_tier_audit.py --strict tests/test_container_backend_1115_stage2.py` → exit 0
- [x] Empirical in-container proof (astropy-13453 + flask-5014, above)

Existing assertion `run() == plain docker exec` was a deliberate contract reversal → renamed + rewrote the test to pin the login-shell intent (`feedback_contract_reversal_rewrites_tests`), not a literal flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
