### PR TITLE
fix(swe_bench): verify routes only to report (P1/P8); drop un-satisfiable graph edges

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -115,10 +115,10 @@ tolerates off-by-N context line counts, and `--whitespace=fix`
 forgives trailing-space drift.
 
 If `git apply` STILL fails after preprocessor sanitization + robust
-flags, record the failure in `failure_summary` (= include the exact
-stderr from git apply, NOT a vague "patch failed" summary) and treat
-this as a verify execution failure (not a test failure) — transition
-back to apply so the patch can be re-examined.
+flags, treat this as a verify execution failure (not a test failure):
+set `tests_passed = false` and record the failure in `failure_summary`
+(= include the exact stderr from git apply, NOT a vague "patch failed"
+summary). The tests could not be evaluated, so this is not a pass.
 
 **Do NOT skip the test_patch** — an unapplied test patch means tests
 can't be evaluated; that's NOT a pass. The schema invariant
@@ -168,37 +168,37 @@ the test files applied when it produces the final diff.
 
 ## Step 4 — Evaluate the outcome
 
-Inspect the test runner's exit code and output:
+Inspect the test runner's exit code and output and record the verdict:
 
-- Exit code 0, all tests collected and passed → `tests_passed = true` → transition to report
-- Non-zero exit code, test failures reported → `tests_passed = false` → transition back to plan
-  (the plan phase will revise the fix based on `failure_summary`)
+- Exit code 0, all tests collected and passed → `tests_passed = true`,
+  `failure_summary = ""`.
+- Non-zero exit code, test failures reported → `tests_passed = false`, and
+  record a concise `failure_summary`: which test names failed, the assertion
+  error messages, and any relevant tracebacks.
 
-Record a concise `failure_summary` when tests fail: which test names failed,
-the assertion error messages, and any relevant tracebacks.  This summary is
-the primary input for the next plan phase.
+Whether the tests passed or failed, the verdict is captured in `tests_passed`
++ `failure_summary` — the downstream phase consumes that outcome. The skill
+always carries the best-effort patch forward, even when the tests did not pass
+(matching SWE-bench harness expectations).
 
 ## Retry limit
 
 If `attempt` has reached the maximum allowed (3 by default), set
-`tests_passed = false` and transition to report anyway — the skill reports the
-best-effort patch even when tests did not pass, matching SWE-bench harness
+`tests_passed = false` and record the best-effort outcome — the skill reports
+the patch even when the tests did not pass, matching SWE-bench harness
 expectations.
 
 ## Convergence guard — MANDATORY
 
 If `git apply` (or `git apply --check`) has failed **3 or more consecutive
 times** with the same error (same `returncode`, same `stderr` substring), STOP
-attempting to apply the patch.  Do ONE of:
-
-- If the error is "No valid patches in input" or a similar content-empty
-  error: the patch you wrote is invalid.  Transition back to **apply** so the
-  fix can be re-examined.
-- If the error is a context-line conflict: the repository state differs from
-  what the patch expects.  Transition back to **apply** with the failure
-  summary.
+attempting to apply the patch.  In either of these cases — "No valid patches
+in input" (the patch you wrote is invalid) or a context-line conflict (the
+repository state differs from what the patch expects) — set
+`tests_passed = false` and record the exact `git apply` error in
+`failure_summary`.
 
 Do NOT write a new version of the same patch and retry `git apply` in a loop.
 Each identical write+apply pair consumes 2 turns with zero forward progress.
-After 3 consecutive failures, treating the error as structural and transitioning
-is always more productive than additional retries.
+After 3 consecutive failures, treating the error as structural and recording
+the best-effort outcome is always more productive than additional retries.

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -20,7 +20,7 @@ graph:
   explore: [plan]
   plan:    [apply]
   apply:   [verify, plan]
-  verify:  [report, apply]
+  verify:  [report]
   report:  []
 routing:
   intents: [task]
@@ -78,11 +78,12 @@ are existing OS ops — no OS changes required (P7 compliant).
 
 ```
 setup → explore → plan → apply → verify → report
-                              ↑        ↓
-                              └─ plan ←┘  (tests fail → back to plan)
-                                     ↑
-                              apply ←─┘  (verify execution failed → back to apply)
 ```
+
+`verify` always proceeds to `report`, carrying the verdict (`tests_passed` +
+`failure_summary`); `report` produces the best-effort patch whether the tests
+passed or failed. A test-failure re-plan loop (verify → plan to revise the fix)
+is a tracked enhancement, not yet wired into the graph.
 
 | Phase   | Role        | Responsibility |
 |---------|-------------|----------------|
@@ -90,7 +91,7 @@ setup → explore → plan → apply → verify → report
 | explore | analyst     | Grep and read to find relevant code; save exploration notes |
 | plan    | architect   | Decide which files to edit and what to change |
 | apply   | implementer | Execute the plan via file edits |
-| verify  | tester      | Run test_patch tests; transition to report on pass, back to apply on fail |
+| verify  | tester      | Run test_patch tests; record the `tests_passed` verdict, then report |
 | report  | reporter    | Run `git diff HEAD` to produce the final patch |
 
 ## Input

--- a/tests/test_swe_bench_phase_convergence_guard.py
+++ b/tests/test_swe_bench_phase_convergence_guard.py
@@ -190,25 +190,40 @@ def test_apply_md_convergence_guard_has_action():
 
 
 # ---------------------------------------------------------------------------
-# Test 6: verify.md convergence guard has transition-back-to-apply as action
+# Test 6: verify.md convergence guard records a best-effort verdict as the action
 # ---------------------------------------------------------------------------
 
-def test_verify_md_convergence_guard_has_apply_transition_action():
-    """Tier 2: verify.md convergence guard must specify transitioning back to apply.
+def test_verify_md_convergence_guard_records_verdict_action():
+    """Tier 2: verify.md convergence guard must prescribe recording the verdict.
 
-    In the observed failure pattern (14182), the correct action when git apply
-    keeps failing is to go back to the apply phase to re-examine the fix.
-    The guard must explicitly prescribe this transition so the LLM exits the
-    verify dead-end loop productively rather than aborting.
+    In the observed failure pattern (14182) the LLM looped on a failing git
+    apply.  The guard must give a concrete escape action so the LLM exits the
+    dead-end loop productively rather than aborting.  The action is to RECORD
+    the best-effort outcome (`tests_passed = false` + the git apply error in
+    `failure_summary`) — NOT to prescribe a phase transition: verify must not
+    hardcode a next phase (P1/P8), and the only satisfiable verify transition
+    is to report (which the OS offers as the sole candidate). The former
+    "transition back to apply" guidance named an un-satisfiable edge (apply
+    requires a `plan` artifact verify cannot emit).
     """
     text = _read_phase(_VERIFY_MD)
     start = text.find(_CONVERGENCE_HEADER)
     assert start != -1
-    guard_section = text[start:]
+    guard_section = text[start:].lower()
 
-    # The guard section must mention transitioning back to apply.
-    assert "apply" in guard_section.lower(), (
-        "verify.md Convergence guard must mention transitioning back to 'apply' "
-        "as the action when git apply fails repeatedly.  Without this, the LLM "
-        "will abort instead of returning to the apply phase for re-examination."
+    # The guard must give a concrete action: record the failure verdict.
+    assert "failure_summary" in guard_section and "tests_passed" in guard_section, (
+        "verify.md Convergence guard must prescribe recording the best-effort "
+        "verdict (tests_passed = false + failure_summary) as the escape action "
+        "when git apply fails repeatedly, so the LLM records the outcome and "
+        "proceeds rather than aborting."
     )
+    # And it must NOT hardcode a transition back to the apply *phase* (P1/P8).
+    # "git apply" / "attempting to apply the patch" are command references and
+    # are fine; the banned markers are the phase-transition phrasings.
+    for banned in ("back to apply", "transition back to", "transition to apply"):
+        assert banned not in guard_section, (
+            f"verify.md Convergence guard must not prescribe {banned!r} — the "
+            "verify→apply edge is un-satisfiable and hardcoding a next phase "
+            "violates P1/P8.  Record the verdict and let the OS offer candidates."
+        )

--- a/tests/test_swe_bench_skill_load.py
+++ b/tests/test_swe_bench_skill_load.py
@@ -152,7 +152,11 @@ def test_swe_bench_graph_transitions():
     assert sorted(t.get("apply", [])) == ["plan", "verify"], (
         f"apply transitions: {t.get('apply')}"
     )
-    assert sorted(t.get("verify", [])) == ["apply", "report"], (
+    # verify → report only: report is the sole satisfiable transition (it
+    # accepts verify_state). The former verify → apply edge required a `plan`
+    # artifact (edits/rationale) that verify cannot emit (un-satisfiable); the
+    # re-plan loop is a tracked enhancement, not yet wired.
+    assert sorted(t.get("verify", [])) == ["report"], (
         f"verify transitions: {t.get('verify')}"
     )
     assert t.get("report", []) == [], f"report transitions: {t.get('report')}"


### PR DESCRIPTION
**[e2e-coder]** — ① of the C7 faithful-eval fix cascade (lead-coder-reviewed), layered on top of #1202 (③). Root-fixes the P1/P8 violation in the swe_bench verify phase that crashed astropy-13453.

## Problem (primary evidence)
astropy-13453 failed hard at verify after 3 attempts:
```
Artifact data validation failed for 'verify_state': 'edits' is a required property;
'rationale' is a required property
```
Trace of the cause:
- `verify.md` prescribed **"transition back to plan"** (Step 4) and **"transition back to apply"** (convergence guard). A Phase must not name its next phase (**P1**); instructions must not prescribe transitions (**P8**) — the OS injects `candidate_outputs` at runtime.
- `"plan"` was **not even a verify graph candidate** (`graph: verify → [report, apply]`) — the instruction named an impossible target.
- `verify → apply` **is** in the graph but is **un-satisfiable**: apply's `input` is the `plan` artifact (requires `edits`/`rationale`), which verify — producing `verify_state` — cannot emit. Told to transition there, the model was forced to fabricate `edits`/`rationale` and failed validation → the crash.
- `skill.md` internally contradicted itself: diagram says "tests fail → back to **plan**", table says "back to **apply** on fail", graph says `[report, apply]`.

| edge | verify emits | target accepts | satisfiable? |
|------|-----|-----|-----|
| verify→report | verify_state | verify_state | ✅ |
| verify→apply | verify_state | **plan** (edits/rationale) | ❌ fired the crash |

## Fix (minimal, P1/P8-compliant)
- **Graph**: `verify → [report]` — the sole satisfiable transition (report accepts `verify_state`). Both pass and fail terminate at report, which carries the verdict (`tests_passed` + `failure_summary`) and produces the best-effort patch.
- **verify.md**: every step describes the **domain outcome only** (record `tests_passed` + `failure_summary`) — no hardcoded next phase. The OS offers `[report]`.
- **skill.md**: diagram + table reconciled to the actual linear flow.

The test-failure **re-plan loop** (verify → plan to revise the fix) is a **tracked enhancement**, not wired here. Notable correction to the earlier framing: `plan.md` input is already `exploration | verify_state`, so plan *can* receive the failure artifact — the loop is a small follow-up (1 graph edge + re-plan guidance), not a large rework. I'll file the ticket.

## Test plan
- [x] `pytest tests/ -k swe_bench` → 123 passed
- [x] `pytest test_swe_bench_skill_load.py test_swe_bench_skill_invariants.py test_swe_bench_phase_convergence_guard.py` → 21 passed
- [x] `ruff check .` → clean
- [x] `scripts/test_tier_audit.py --strict <2 changed tests>` → exit 0
- [x] verify.md grep clean of `transition`/`back to plan`/`back to apply`/`to report`

Two tests were deliberate contract reversals → rewritten (not literal-flipped): the graph-edge pin (`verify → [report]`) and the convergence-guard action test (renamed `…_records_verdict_action`, now pins "record the verdict, not a phase transition").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
