### PR TITLE
fix(swe_bench_runner): extract patch from reyn's pretty-printed Final Output

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -116,29 +116,43 @@ def extract_patch(reyn_stdout: str) -> str:
     # Strategy B: scan every line for a JSON object with a "patch" key.
     lines = reyn_stdout.splitlines()
 
-    # Strategy A
+    # Strategy A — parse the JSON object that follows the marker.
+    # `reyn run` prints the marker, then `json.dumps(result.data, indent=2)`
+    # (multi-line, pretty), then trailing lines (token usage, "events saved →").
+    # A plain json.loads of everything-after-the-marker fails on those trailing
+    # lines, so use raw_decode: it parses the first JSON value starting at the
+    # block and ignores whatever follows.
     marker = "=== Final Output ==="
     for i, line in enumerate(lines):
         if marker in line:
-            json_block = "\n".join(lines[i + 1 :]).strip()
+            json_block = "\n".join(lines[i + 1 :]).lstrip()
             if json_block:
                 try:
-                    obj = json.loads(json_block)
+                    obj, _ = json.JSONDecoder().raw_decode(json_block)
                     return _extract_patch_from_obj(obj)
                 except (json.JSONDecodeError, ValueError):
                     pass  # fall through to Strategy B
             break
 
-    # Strategy B: scan every line
-    for line in lines:
-        line = line.strip()
-        if not line.startswith("{"):
+    # Strategy B: scan for the start of a JSON object anywhere and raw_decode
+    # from there (handles a pretty-printed object with no marker, and trailing
+    # non-JSON text after it).
+    text = reyn_stdout
+    search_from = 0
+    while True:
+        start = text.find("{", search_from)
+        if start == -1:
+            break
+        try:
+            obj, _ = json.JSONDecoder().raw_decode(text[start:])
+        except (json.JSONDecodeError, ValueError):
+            search_from = start + 1
             continue
         try:
-            obj = json.loads(line)
             return _extract_patch_from_obj(obj)
-        except (json.JSONDecodeError, ValueError):
-            continue
+        except ValueError:
+            # parsed a JSON object without a patch key — keep scanning
+            search_from = start + 1
 
     raise ValueError("could not find 'patch' field in reyn output")
 

--- a/tests/test_swe_bench_runner.py
+++ b/tests/test_swe_bench_runner.py
@@ -197,6 +197,37 @@ def test_extract_patch_from_nested() -> None:
     assert patch == "nested_diff\n"
 
 
+def test_extract_patch_from_pretty_json_with_trailing_lines() -> None:
+    """Tier 2: real `reyn run` stdout shape — indent=2 pretty JSON after the
+    marker, followed by trailing token-usage / "events saved →" lines.
+
+    Reproduces the gap where a plain json.loads of everything-after-the-marker
+    fails on the trailing non-JSON lines (the multi-line patch never parsed).
+    The fix (raw_decode) parses the first JSON value and ignores the trailing
+    text.  Uses a multi-line patch so single-line scanning cannot accidentally
+    succeed.
+    """
+    from scripts.swe_bench_runner import extract_patch
+
+    patch_text = "diff --git a/x.py b/x.py\n--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new\n"
+    stdout = (
+        "skill           : swe_bench\n"
+        "model           : standard\n"
+        "\n"
+        "=== Final Output ===\n"
+        + json.dumps(
+            {"type": "swe_bench_result", "data": {"patch": patch_text, "tests_passed": False}},
+            indent=2,
+        )
+        + "\n"
+        "Total tokens: 12345  cost: $0.0042\n"
+        "\n"
+        "events saved → /tmp/state/events/skill_runs/2026-06/x.jsonl\n"
+    )
+
+    assert extract_patch(stdout) == patch_text
+
+
 # ── 10. run_reyn: success ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — parallel small fix found during the C7 faithful re-run (lead-coder-approved). Same class/pattern as the C1/#1063 PR-N13 trailing-garbage `raw_decode` fix (precedent).

## Problem
`extract_patch` did a plain `json.loads` of everything after the `=== Final Output ===` marker. But `reyn run` prints `json.dumps(result.data, indent=2)` (multi-line) followed by trailing lines (token-usage summary, `events saved → …`). So that `json.loads` always failed on the trailing text, and the single-line Strategy-B scan couldn't parse a pretty-printed object either:
```
could not find 'patch' field in reyn output
```
…even though the run produced a valid `swe_bench_result` with a real patch.

**Latent bug, exposed by success:** earlier faithful runs failed before reaching `report` (env-exec gap #1202, verify P1/P8 #1203), so the patch-extraction step never ran. Now that verify→report completes, every successful run hit this parse failure (observed on the 13453 sanity run — pipeline reached report + produced a 5314-char patch in the artifact, but the runner couldn't extract it from stdout).

## Fix
Use `json.JSONDecoder().raw_decode()`, which parses the first JSON value at the start of the block and ignores whatever follows. Strategy B likewise scans for an object start and `raw_decode`s from there (tolerating trailing non-JSON, skipping objects without a `patch` key).

## Test plan
- [x] `pytest tests/test_swe_bench_runner.py -q` → 16 passed (added `test_extract_patch_from_pretty_json_with_trailing_lines` reproducing the real shape: marker + indent=2 JSON + trailing token/events lines + multi-line patch — the existing tests used compact single-line json.dumps with nothing trailing, never exercising this path)
- [x] `ruff check scripts/swe_bench_runner.py tests/test_swe_bench_runner.py` → clean
- [x] `scripts/test_tier_audit.py --strict tests/test_swe_bench_runner.py` → exit 0

C7 signal is unaffected either way (the artifact `swe_bench_result` is ground truth for the verdict); this makes the harness's stdout-based prediction extraction correct for every successful run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
