### PR TITLE
docs(swe-bench): fix stale verify/apply cycle cost description

### DIFF
--- a/docs/guide/for-users/run-swe-bench.md
+++ b/docs/guide/for-users/run-swe-bench.md
@@ -129,7 +129,7 @@ reyn eval benchmark swe_bench \
 | 8 | ~4–6 hours  | ~$150–200 |
 | 16 | ~2–3 hours | ~$150–200 (same total; concurrency trades time for parallelism) |
 
-Cost per instance is dominated by the explore + apply + verify loop (~$0.30–0.50 per instance). Problems that require multiple verify/apply cycles cost more.
+Cost per instance is dominated by the explore + apply + verify flow (~$0.30–0.50 per instance). Problems that require re-planning — the model loops from apply back to plan before re-applying — cost more; verify routes only to report and does not add extra iterations.
 
 ## Connecting to the SWE-bench harness
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

`run-swe-bench.md:132` described cost as growing with "multiple verify/apply cycles" — stale since the verify phase now routes only to report (not back to apply). The re-plan loop is apply → plan → apply.

Updated to: verify routes only to report and does not add extra iterations; re-planning (apply→plan→apply) is what raises cost.

Sweep confirmed: only this one line in the guide describes the verify loop behavior. No other stale content found from the verify graph change or the login-shell env-exec fix.

## Test plan

- [x] `mkdocs build --strict` — 337 warnings (same as origin/main, 0 from edited file)
- [x] No history/PR/issue references in body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)