### PR TITLE
docs(journal): correct C7 attribution — 8KB-offload structural confound (#1209)

### DIFF
--- a/docs/deep-dives/journal/183-c7-faithful-eval-completion.md
+++ b/docs/deep-dives/journal/183-c7-faithful-eval-completion.md
@@ -1,7 +1,11 @@
 # C7 — Faithful in-container SWE-bench eval: completion (internal signal)
 
-**Status**: ✅ Faithful 完遂 — 2026-06-01. Faithful agent-driven in-container pipeline
-runs end-to-end structurally clean; all 5 Class A verdicts independently co-signed.
+**Status**: ✅ Faithful 完遂 — 2026-06-01 (install-fidelity + pipeline plumbing proven).
+⚠️ **ATTRIBUTION CORRECTED 2026-06-01** (see "Attribution correction" below): the original
+"all 5 MODEL-AXIS / zero structural confound" was **wrong** — a structural confound (a fixed
+8 KB control_ir offload cap starving the apply phase of file content, issue #1209) was found
+via a later context-adequacy (layer-3) re-check. The verdicts are a **mixed (A) structural +
+(B) model-navigation** interplay, not pure model-axis.
 **Owner**: e2e-coder (faithful run + structural rule-out) + lead-coder (per-step review,
 independent co-sign, canonical sign-off).
 **Scope**: FP-0008 benchmark's faithful test-evaluation layer (issue #183), built on the
@@ -32,7 +36,11 @@ Runs: `--env-backend=docker`, official prebuilt image, `/testbed`, zero host ins
 Every verdict was **independently co-signed by lead-coder** via their own events parse (not
 a summary hand-off).
 
-| instance | reached verify→report? | tests_passed | patch | verdict failure-mode (all MODEL-AXIS, distinct) |
+> ⚠️ The "failure-mode" column below was written under the original (incorrect) pure-model-axis
+> reading. See **Attribution correction** — the failures are a mixed (A) 8 KB-offload structural
+> confound + (B) model-navigation interplay, not pure model cognition.
+
+| instance | reached verify→report? | tests_passed | patch | verdict failure-mode (revised: see Attribution correction) |
 |----------|:----------------------:|:------------:|-------|--------------------------------------------------|
 | astropy-13453 | ✅ | false | 5065 B | edit applied but introduced an `IndentationError` in `html.py` (bad edit). pytest ran in testbed. |
 | astropy-13236 | ✅ | false | 0 B | all 6 `file op=edit` on `table.py` returned `status=error` (old_string no-match → file never written) → empty diff. OS reported each error faithfully; 13453 capture worked → not plumbing. base-commit checkout only in setup → not a revert. |
@@ -43,13 +51,16 @@ a summary hand-off).
 **Summary:**
 - **4/5 reached verify→report** (faithful pipeline structurally clean). 1/5 (14096) aborted at
   apply on malformed LLM JSON — model-axis, not an OS bug.
-- **All 5 FAILs are MODEL-AXIS**, in five distinct flavors (bad edit / no-match edits / circular
-  import / verify double-apply confusion / unparseable JSON). **Zero structural confounds.**
 - **install-fidelity** (pytest runs in the testbed env, no "No module named pytest" on any
   instance) + **env-exec** (login-shell) + **verify→report reach** + **patch capture**
-  (13453/13398/13977 produced real diffs) all **PROVEN**.
-- **Internal-signal PASS-rate = 0/5** — entirely weak-model-bound. A stronger model would raise
-  PASS with **no OS changes**. This is the expected internal-signal shape, not a defect.
+  (13453/13398/13977 produced real diffs) all **PROVEN**. These remain solid.
+- ⚠️ **Attribution: NOT "all 5 model-axis / zero structural confound" (corrected — see below).**
+  A structural confound was found: the apply phase was starved of file content by a fixed 8 KB
+  control_ir offload cap (#1209). The verdicts are a **mixed (A) structural + (B) model-navigation**
+  interplay (severity scales with file size / offload aggressiveness), not pure model cognition.
+- **Internal-signal PASS-rate = 0/5** — but **NOT cleanly weak-model-bound**: the 8 KB-offload
+  confound impaired the apply phase in ≥3/5, so a fix (#1209) is expected to raise PASS, not only
+  a stronger model. Still NOT a leaderboard score.
 
 ## Structural rule-out (the discipline that made the result trustworthy)
 
@@ -67,7 +78,55 @@ discipline of this arc (`feedback_structural_verify_before_attribution_default`,
   refuted it: plain `git apply --check` **and** the reyn `--3way --recount --whitespace=fix --check`
   both succeed on this test_patch at base (the "lacks blob" line is a `--3way` warning that falls
   back to direct and applies). The run's failure was purely the model re-applying an already-applied
-  patch and misreading rc=1. → **model-axis workflow error**, plus skill-robustness enhancement #1206.
+  patch and misreading rc=1. → workflow error, plus skill-robustness enhancement #1206.
+
+> ⚠️ **The 13236 rule-out above stopped one layer too early.** It cleared structure (plumbing)
+> and outcome (edit `status=error`) but NOT *context-adequacy* — see the correction below.
+
+## Attribution correction (2026-06-01, context-adequacy / layer-3 re-check)
+
+The original conclusion ("all 5 model-axis, zero structural confound") was reached after
+clearing two verification layers — pipeline structure and event-level outcome — but **not a
+third: context-adequacy** (did the model receive a fair context?). Per the user-direction pin
+`feedback_context_adequacy_before_model_axis_attribution`, re-reading the `context_built`
+frames the apply model actually decided from refuted the pure-model-axis call.
+
+**Root confound (#1209):** `context_builder.py:33` sets a **fixed 8 KB** control_ir inline cap.
+Any `file.read` result over 8 KB has its `content` offloaded to a handle and dropped from the
+next decide frame. So in the `apply` phase the model reads a source file, the OS offloads the
+content, and on the *next* turn it emits `file.edit old_string=…` for a file it can no longer
+see — and fabricates plausible-but-nonexistent `old_string`s from training recall.
+
+**Per-edit primary evidence** (apply phase; `in_preview` = old_string visible in the decide
+frame; `ok/err` = edit applied vs `status=error`):
+
+| inst | edits ok/err | old_string in_preview | note |
+|------|:------------:|:---------------------:|------|
+| 13236 | 0/6 | 0 | table.py = 150 KB; all 6 old_strings absent from the file entirely = hallucination (confirmed against the offloaded content) |
+| 14096 | 0/9 | 0 | 215 content-offloads; fully starved → invalid-JSON abort downstream |
+| 13453 | 9/12 | 3 | mixed — 9 edits landed (context sometimes adequate), 12 blind failures |
+| 13977 | 1/4 | 0 | mixed — 4 blind failures + verify idempotency gap (#1206) |
+| 13398 | 11/3 | 2 | mostly adequate (11 edits landed) — closest to genuine model judgment (circular import) |
+
+**The true attribution is a mixed interplay**, ratio varying per instance:
+- **(A) structural confound** — the 8 KB offload makes the full file un-inline, so the model
+  cannot copy real `old_string`s. Dominant in 13236 / 14096 (large files, heavy offload).
+- **(B) model-navigation gap** — instead of recovering the content (`read_offloaded`, or reading
+  a targeted region), the weak model looped read→offload→hallucinate. A recovery affordance that
+  a stronger model would use exists but went unused.
+
+Neither "pure model-axis" (original error) nor "pure context bug" (the opposite over-correction)
+is right. The fix needs **both axes**: (A) window-derive the 8 KB cap (root-fix, same class as
+#1201/#1172) + (B) make the offload-recovery affordance effective (discoverable `read_offloaded`
+/ apply skill guidance to read targeted regions). Tracked: **#1209**.
+
+**Measurement honesty (pre-conclusion checklist):** the cross-instance "not in file =
+hallucination" count is reliable only where the edited file is confirmed in the offload sample
+(13236 / 14096); for 13398's small inline files it over-counts (11 edits succeeded → those
+old_strings were real). The robust cross-instance signals are `in_preview` + edit `ok/err`. The
+fully rigorous per-edit `status × old_string × actual-file` join + dogfood-coder's independent
+`in_preview=False` corroboration (13453 / 13977) finalize the precise counts; this section
+states the established direction, not exact per-edit totals.
 
 ## The 5 structural fixes that unblocked faithful agent-driven runs
 


### PR DESCRIPTION
**[e2e-coder]** — corrects the C7 attribution record per lead-coder steer (review-before-merge: accuracy of a correction matters). Found via the context-adequacy (layer-3) re-check using the new user-direction pin `feedback_context_adequacy_before_model_axis_attribution`.

## What was wrong
The merged 183-c7-faithful-eval-completion.md concluded **"all 5 model-axis / zero structural confound"**. That cleared two verification layers (pipeline structure + event outcome) but NOT context-adequacy.

## The confound (#1209)
`context_builder.py:33` = fixed **8 KB** control_ir inline cap. Any `file.read` >8 KB has its `content` offloaded out of the next decide frame → in `apply`, the model edits a file it can no longer see and fabricates non-existent `old_string`s. Per-edit primary evidence: 13236 = 6/6 old_strings absent from the 150 KB file (hallucination-because-blind), in_preview=0; 14096 = 215 offloads, 0/9; vs 13398 = 11/14 edits landed (mild).

## The corrected attribution = mixed interplay
- **(A) structural confound** — 8 KB offload makes the file un-inline (severe in 13236/14096).
- **(B) model-navigation gap** — model hallucinated instead of recovering (`read_offloaded`/region-read).

Neither "pure model-axis" (original error) nor "pure context bug" (over-correction). Both-axes fix tracked in **#1209**, dispatched after lead-coder's design steer.

## Edits
- Status banner + summary bullets corrected; per-instance table flagged + a new **Attribution correction** section with the per-edit table, the (A)+(B) framing, and a **measurement-honesty caveat** (offload-sample `in_file` reliable only for confirmed-offloaded large files; robust signals = `in_preview` + edit ok/err).
- install-fidelity / env-exec / verify→report / patch-capture proofs untouched (still solid).

## Test plan
- [x] Docs-only; no code touched. References: #1209, #1206, the pin (cite-only, no nav links).

**Hold for lead-coder review before merge** (per their steer). dogfood-coder's independent 13453/13977 `in_preview=False` corroboration to be folded into the final co-sign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
