### PR TITLE
fix(swe_bench): deterministic apply edit-region scaffolding via plan anchors (#1209 PR-B)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/artifacts/plan.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/plan.yaml
@@ -18,9 +18,19 @@ schema:
           description:
             type: string
             description: Human-readable description of what to change in this file and why.
+          anchor:
+            type: string
+            description: >
+              A short VERBATIM single-line snippet copied exactly from the
+              current file at the edit site (a unique landmark). The apply phase
+              greps this anchor to deterministically place the edit-target region
+              into context before editing, so it never edits a file it cannot
+              see. Choose a line unique within the file; for an addition (new
+              function/import) use the nearest existing line.
         required:
           - file
           - description
+          - anchor
     rationale:
       type: string
       description: Overall rationale for this plan — why these edits fix the problem.

--- a/src/reyn/stdlib/skills/swe_bench/escape_anchors.py
+++ b/src/reyn/stdlib/skills/swe_bench/escape_anchors.py
@@ -1,0 +1,45 @@
+"""Phase preprocessor (#1209 PR-B): regex-escape each edit's ``anchor``.
+
+The plan emits ``anchor`` = a short verbatim snippet from the current file at the
+edit site (a grep landmark). The apply preprocessor then runs a deterministic
+``grep`` to fetch that region into context BEFORE the model edits, so the model
+never edits a file it cannot see (the apply-starvation root cause, #1209).
+
+``grep`` compiles its pattern as a regex (``op_runtime/file.py:_execute_grep``),
+so a verbatim snippet containing regex-special chars — parens, dots, brackets,
+``*``/``+``/``|``, ubiquitous in source — must be escaped to match literally.
+This step adds an ``anchor_re`` field per edit; the iterate step greps with it.
+
+Pure data transform (no file access — runs in the sandboxed python-step).
+Deterministic, P5-correct (the OS runs it before the apply LLM; never
+LLM-mutated). ``args_from`` resolves ``_iter.item.anchor_re`` for the grep op.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+def escape_anchors(data: Mapping[str, Any]) -> list[dict]:
+    """Return ``data['edits']`` with a regex-escaped ``anchor_re`` per edit.
+
+    Edits without an ``anchor`` get an empty ``anchor_re`` (the iterate grep
+    then yields zero matches → the apply instructions treat it as not-locatable
+    and report rather than blind-edit). Non-dict entries are skipped.
+
+    The python step receives the FULL artifact: the edit plan lives at
+    ``data["data"]["edits"]`` (inner dict), with a flat ``data["edits"]``
+    fallback for unit tests that inject the inner data directly (mirrors
+    ``parse_test_targets._extract_test_patch``). ``into: data.edits`` writes the
+    returned list back to the same inner location.
+    """
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    edits = inner.get("edits") or []
+    out: list[dict] = []
+    for edit in edits:
+        if not isinstance(edit, dict):
+            continue
+        anchor = edit.get("anchor") or ""
+        out.append({**edit, "anchor_re": re.escape(anchor) if anchor else ""})
+    return out

--- a/src/reyn/stdlib/skills/swe_bench/escape_anchors.py
+++ b/src/reyn/stdlib/skills/swe_bench/escape_anchors.py
@@ -24,9 +24,12 @@ from typing import Any
 def escape_anchors(data: Mapping[str, Any]) -> list[dict]:
     """Return ``data['edits']`` with a regex-escaped ``anchor_re`` per edit.
 
-    Edits without an ``anchor`` get an empty ``anchor_re`` (the iterate grep
-    then yields zero matches → the apply instructions treat it as not-locatable
-    and report rather than blind-edit). Non-dict entries are skipped.
+    Edits without an ``anchor`` get the never-match sentinel ``(?!)`` (NOT an
+    empty string: an empty regex matches every line via ``re.search("", line)``,
+    which would wrongly land in the multi-match path — see #1214 review). The
+    sentinel makes the iterate grep yield zero matches → the apply instructions
+    treat it as not-locatable and report rather than blind-edit. Non-dict entries
+    are skipped.
 
     The python step receives the FULL artifact: the edit plan lives at
     ``data["data"]["edits"]`` (inner dict), with a flat ``data["edits"]``
@@ -41,5 +44,7 @@ def escape_anchors(data: Mapping[str, Any]) -> list[dict]:
         if not isinstance(edit, dict):
             continue
         anchor = edit.get("anchor") or ""
-        out.append({**edit, "anchor_re": re.escape(anchor) if anchor else ""})
+        # Empty/missing anchor → never-match sentinel (NOT "" which matches every
+        # line). `(?!)` is a valid regex that never matches → grep count 0.
+        out.append({**edit, "anchor_re": re.escape(anchor) if anchor else "(?!)"})
     return out

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -17,6 +17,39 @@ default_sandbox_policy:
   allow_subprocess: true
   env_passthrough: ["PATH", "HOME", "PYTHONPATH", "VIRTUAL_ENV", "LANG", "LC_ALL", "TMPDIR"]
   timeout_seconds: 120
+# #1209 PR-B — deterministic edit-region scaffolding. BEFORE the LLM enters this
+# phase, the OS places each edit's target region into context by grepping the
+# plan's verbatim `anchor`, so the model never edits a file it cannot see (the
+# apply-starvation root cause: a large file was offloaded out of view and the
+# model fabricated non-existent old_strings). Deterministic (P5), never
+# LLM-mutated. `escape_anchors` regex-escapes each anchor (grep compiles regex);
+# the iterate step greps each anchor (±50 lines of context) into `_edit_regions`.
+preprocessor:
+  - type: python
+    module: ./escape_anchors.py
+    function: escape_anchors
+    mode: safe
+    into: data.edits
+    output_schema:
+      type: array
+  - type: iterate
+    over: data.edits
+    apply:
+      type: run_op
+      op:
+        kind: file
+        op: grep
+        path: "__placeholder__"
+        pattern: "__placeholder__"
+        output_mode: content
+        context_before: 50
+        context_after: 50
+      args_from:
+        path: "_iter.item.file"
+        pattern: "_iter.item.anchor_re"
+      on_error: skip
+    into: data._edit_regions
+    on_error: skip
 ---
 
 Implement the edit plan by modifying the repository files.
@@ -28,11 +61,27 @@ the test_patch itself after the skill run.  The verify preprocessor reverts any
 test-file edits before running `git apply test_patch`, so apply-phase test edits
 do not count and will not survive into the final diff.
 
-## Step 1 — Read each file before editing
+## Step 1 — Ground each edit in its pre-fetched region
 
-For every file listed in the plan's edits, issue a file read op to retrieve
-the current content.  Do NOT edit from memory — always read first to ensure
-the edit target is accurate.
+The OS has already placed each edit's target region into your input under
+`_edit_regions` (one entry per edit, in plan order) — a `grep` of the plan's
+`anchor` with surrounding context. Use these regions as the source of truth for
+the exact current text; do NOT edit from memory.
+
+For each edit, check its `_edit_regions` entry:
+
+- **One match** → use the matched line and its surrounding context as the basis
+  for the edit's `old_string` (copy the exact current text).
+- **No match** (`count` is 0 / empty) → the anchor was not found, so the edit
+  site is not located. Do NOT guess or fabricate an `old_string` — that produces
+  a no-op or wrong edit. Skip this edit, note the file as not-locatable, and
+  proceed; the verify phase will surface the gap for a re-plan.
+- **Multiple matches** (`count` > 1) → the anchor was not unique. Use the match
+  whose surrounding context best fits the plan's `description` for that edit.
+
+If a region is large or you need more than the ±context shown, issue a targeted
+`read` (with `offset`/`limit`) for that file — a bounded read stays in context
+(it is not offloaded out of view).
 
 ## Step 2 — Apply each edit
 

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -63,6 +63,16 @@ For each file that needs to change, describe:
 - The specific function, method, or code block to modify
 - What the change should be (add, remove, or replace logic)
 - Why this change addresses the problem
+- An **`anchor`**: a short, VERBATIM single-line snippet copied EXACTLY from the
+  current file at the edit site. This is a grep landmark — the apply phase greps
+  it to place the edit's target region into context automatically, so apply
+  never edits a file it cannot see. Requirements:
+  - Copy it character-for-character from a line you actually read (do not
+    paraphrase or reconstruct from memory) — a mismatched anchor finds nothing.
+  - Choose a line **unique** within the file (a distinctive signature,
+    assignment, or comment) so the grep returns exactly one match.
+  - For an **addition** (new function/import/block), anchor on the nearest
+    existing line where the insertion goes.
 
 The plan should be precise enough that the apply phase can execute it without
 further analysis.  Prefer minimal, targeted changes over large rewrites.

--- a/tests/test_apply_region_scaffold_1209.py
+++ b/tests/test_apply_region_scaffold_1209.py
@@ -1,0 +1,143 @@
+"""Tier 2: OS/skill invariant — #1209 PR-B apply deterministic edit-region scaffolding.
+
+The apply phase preprocessor places each edit's target region into context BEFORE
+the model edits, by grepping the plan's verbatim ``anchor`` (the apply-starvation
+fix: the model must never edit a file it cannot see — astropy-13236 fabricated
+old_strings for an offloaded 150KB file). This pins:
+
+  - ``escape_anchors`` regex-escapes each anchor (grep compiles a regex);
+  - the apply preprocessor (escape → iterate grep) binds per-edit regions at
+    ``data._edit_regions``, one entry per edit in plan order, with the grepped
+    context; one-match → region present, not-found → count 0 (graceful, no blind
+    edit), multi-match → count > 1 (ambiguity surfaced).
+
+Real Workspace + real skill loaded from disk + real op_runtime grep via
+PreprocessorExecutor; no collaborator mocks. ``escape_anchors`` is a pure
+data-transform tested directly.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.events.events import EventLog
+from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+from reyn.workspace.workspace import Workspace
+
+SWE_BENCH_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+# ── escape_anchors: pure data transform ─────────────────────────────────────
+
+def test_escape_anchors_adds_regex_escaped_field() -> None:
+    """Tier 2: each edit gains anchor_re = re.escape(anchor); regex chars neutralized."""
+    import re
+    import sys
+
+    sys.path.insert(0, str(SWE_BENCH_DIR))
+    try:
+        from escape_anchors import escape_anchors
+    finally:
+        sys.path.pop(0)
+
+    anchor = "def f(x): return col.formats[idx](x)  # special (.)*+"
+    out = escape_anchors({"edits": [{"file": "a.py", "description": "d", "anchor": anchor}]})
+    assert out[0]["anchor_re"] == re.escape(anchor)
+    # the escaped form compiles + matches the literal text (regex chars neutralized)
+    assert re.compile(out[0]["anchor_re"]).search(f"prefix {anchor} suffix")
+
+
+def test_escape_anchors_empty_anchor_is_empty_re() -> None:
+    """Tier 2: a missing/empty anchor → empty anchor_re (grep yields no match → not-locatable)."""
+    import sys
+
+    sys.path.insert(0, str(SWE_BENCH_DIR))
+    try:
+        from escape_anchors import escape_anchors
+    finally:
+        sys.path.pop(0)
+    out = escape_anchors({"edits": [{"file": "a.py", "description": "d", "anchor": ""}]})
+    assert out[0]["anchor_re"] == ""
+
+
+# ── apply preprocessor: deterministic edit-region scaffolding ───────────────
+
+def _run_apply_preprocessor(tmp_path: Path, file_body: str, edits: list[dict]) -> dict:
+    from reyn.sandbox import NoopBackend
+
+    skill = load_dsl_skill(SWE_BENCH_DIR / "skill.md")
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    ws.write_file("pkg/mod.py", file_body)
+
+    artifact = {
+        "type": "plan",
+        "data": {
+            "instance_id": "x__y-1",
+            "edits": edits,
+            "rationale": "r",
+            "attempt": 1,
+        },
+    }
+    executor = PreprocessorExecutor(
+        skill=skill,
+        workspace=ws,
+        model="standard",
+        events=events,
+        subscribers=[],
+        resolver=None,
+        permission_resolver=None,
+        sandbox_backend=NoopBackend(),
+    )
+    result, _usage = asyncio.run(
+        executor.run(skill.phases["apply"], artifact, output_language=None)
+    )
+    return result["data"]
+
+
+def _big_body(unique_line: str) -> str:
+    head = "".join(f"# filler line {i}\n" for i in range(300))
+    tail = "".join(f"# trailer line {i}\n" for i in range(300))
+    return head + unique_line + "\n" + tail
+
+
+def test_apply_preprocessor_populates_region_for_unique_anchor(tmp_path: Path) -> None:
+    """Tier 2: a unique anchor in a large file → one match + region context in _edit_regions."""
+    anchor = "    has_fill_values = hasattr(col, 'fill_values')  # UNIQUE-ANCHOR-XYZ"
+    data = _run_apply_preprocessor(
+        tmp_path,
+        _big_body(anchor),
+        [{"file": "pkg/mod.py", "description": "apply col formats", "anchor": anchor}],
+    )
+
+    region = data["_edit_regions"][0]  # one entry per edit (empty → IndexError)
+    assert region["status"] == "ok"
+    assert region["count"] == 1
+    # the grepped region carries the anchored line (deterministically in-context)
+    blob = str(region.get("matches"))
+    assert "UNIQUE-ANCHOR-XYZ" in blob
+
+
+def test_apply_preprocessor_anchor_not_found_is_graceful(tmp_path: Path) -> None:
+    """Tier 2: an anchor absent from the file → count 0, no crash (apply must not blind-edit)."""
+    data = _run_apply_preprocessor(
+        tmp_path,
+        _big_body("    real_line = 1  # ACTUAL"),
+        [{"file": "pkg/mod.py", "description": "x", "anchor": "NONEXISTENT-ANCHOR-QQQ"}],
+    )
+    assert data["_edit_regions"][0]["count"] == 0  # one entry per edit (empty → IndexError)
+
+
+def test_apply_preprocessor_multi_match_surfaces_count(tmp_path: Path) -> None:
+    """Tier 2: a non-unique anchor → count > 1 (ambiguity surfaced for the apply model)."""
+    dup = "    x = compute()  # DUP-ANCHOR"
+    body = _big_body(dup) + dup + "\n"  # the anchor appears twice
+    data = _run_apply_preprocessor(
+        tmp_path, body,
+        [{"file": "pkg/mod.py", "description": "x", "anchor": dup}],
+    )
+    assert data["_edit_regions"][0]["count"] >= 2

--- a/tests/test_apply_region_scaffold_1209.py
+++ b/tests/test_apply_region_scaffold_1209.py
@@ -51,8 +51,14 @@ def test_escape_anchors_adds_regex_escaped_field() -> None:
     assert re.compile(out[0]["anchor_re"]).search(f"prefix {anchor} suffix")
 
 
-def test_escape_anchors_empty_anchor_is_empty_re() -> None:
-    """Tier 2: a missing/empty anchor → empty anchor_re (grep yields no match → not-locatable)."""
+def test_escape_anchors_empty_anchor_is_never_match_sentinel() -> None:
+    """Tier 2: a missing/empty anchor → the never-match sentinel `(?!)`, NOT "".
+
+    An empty regex matches every line (`re.search("", line)` → pos 0), which would
+    wrongly land in the multi-match path; the sentinel yields zero matches so the
+    edit is treated as not-locatable (#1214 review).
+    """
+    import re
     import sys
 
     sys.path.insert(0, str(SWE_BENCH_DIR))
@@ -61,7 +67,10 @@ def test_escape_anchors_empty_anchor_is_empty_re() -> None:
     finally:
         sys.path.pop(0)
     out = escape_anchors({"edits": [{"file": "a.py", "description": "d", "anchor": ""}]})
-    assert out[0]["anchor_re"] == ""
+    sentinel = out[0]["anchor_re"]
+    assert sentinel != ""
+    # the sentinel compiles and matches NOTHING (so grep returns count 0)
+    assert re.search(sentinel, "any code line at all") is None
 
 
 # ── apply preprocessor: deterministic edit-region scaffolding ───────────────
@@ -130,6 +139,20 @@ def test_apply_preprocessor_anchor_not_found_is_graceful(tmp_path: Path) -> None
         [{"file": "pkg/mod.py", "description": "x", "anchor": "NONEXISTENT-ANCHOR-QQQ"}],
     )
     assert data["_edit_regions"][0]["count"] == 0  # one entry per edit (empty → IndexError)
+
+
+def test_apply_preprocessor_empty_anchor_is_not_locatable(tmp_path: Path) -> None:
+    """Tier 2: an empty anchor → count 0 (NOT match-all), so the edit is not-locatable.
+
+    Guards the #1214 review finding: an empty regex would match every line and
+    wrongly look like a multi-match; the never-match sentinel keeps count at 0.
+    """
+    data = _run_apply_preprocessor(
+        tmp_path,
+        _big_body("    real_line = 1  # ACTUAL"),
+        [{"file": "pkg/mod.py", "description": "x", "anchor": ""}],
+    )
+    assert data["_edit_regions"][0]["count"] == 0
 
 
 def test_apply_preprocessor_multi_match_surfaces_count(tmp_path: Path) -> None:


### PR DESCRIPTION
**[e2e-coder]** — #1209 **PR-B [skill (3a) deterministic edit-region scaffolding]**, design approved (issuecomment-4593313073). Builds on PR-A (#1213, merged e1d2f4dd).

## What
The apply phase now deterministically places each edit's target region into context **before** the model edits — so it never edits a file it cannot see (the apply-starvation root cause: astropy-13236 fabricated `old_string`s for an offloaded 150KB file). No model-navigation dependence.

- **plan→apply target-carry**: `plan.yaml` `edits[]` gains a **required `anchor`** = a verbatim single-line snippet from the current file at the edit site (a grep landmark). `plan.md` guides emitting a unique, character-for-character anchor (P1: plan output schema).
- **apply preprocessor** (P5/P8-clean, deterministic, never LLM-mutated): `escape_anchors` regex-escapes each anchor (grep compiles a regex — verbatim code has `()[].`), then an `iterate` step greps each anchor (`context_±50`) into `data._edit_regions`.
- **apply.md Step 1** uses `_edit_regions` as source of truth — **Q1 robustness**: 1 match → edit from the region; **not-found (count 0)** → do NOT blind-edit, report for re-plan; **multi-match (count > 1)** → pick the match fitting the plan description.

Reused existing mechanisms (preprocessor python/iterate steps, grep with context, op_runtime) — no reinvent. The op literal carries `__placeholder__` path/pattern overridden by `args_from` (mirrors report.md's iterate).

## Test plan
- [x] `pytest tests/test_apply_region_scaffold_1209.py` → 5 passed (Tier-2: escape regex-neutralization + empty-anchor; preprocessor produces `_edit_regions` for unique-anchor / not-found / multi-match — real Workspace + real skill from disk + real grep via PreprocessorExecutor, no mocks)
- [x] `pytest -k "swe_bench or plan or apply or preprocessor"` → **506 passed** (no regression; skill compiles with new preprocessor + plan schema)
- [x] `ruff check` clean; `test_tier_audit.py --strict` exit 0

Review focus (your note): anchor robustness (multi/not-found handling) + preprocessor P5/P8-clean + plan output schema P1-clean. After merge → sanity re-run 13236 to confirm the apply model now edits from the in-context region (anchor → grep → region) instead of hallucinating → #1209 完遂.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
