### PR TITLE
feat(llm): per-(model,call-shape) response_format capability cache (#1212 PR1/D5)

### DIFF
--- a/src/reyn/llm/capability_cache.py
+++ b/src/reyn/llm/capability_cache.py
@@ -1,0 +1,51 @@
+"""Per-(model, call-shape) ``response_format`` capability cache (#1212 D5).
+
+Caches whether a model accepts ``response_format`` for a given call shape so the
+broad ``except Exception`` fallback in ``recorded_acompletion`` does not re-pay
+the provider's 400 round-trip on every call after the first.
+
+The capability is **call-shape specific**, not just per-model: e.g. Gemini
+accepts ``response_format`` alone (json-mode) but rejects ``response_format``
+*combined with* ``tools`` (the #1212 op-loop call). So the cache key includes
+whether ``tools`` are present — ``(model, has_tools)`` — and the two cases are
+recorded independently.
+
+Pure optimization: behavior is unchanged (the fallback already handles the 400);
+the cache only lets a known-incapable (model, shape) skip the doomed
+``response_format`` attempt proactively. Process-local + thread-safe; cleared on
+restart (a capability is stable for a model build, and re-probing once is cheap).
+"""
+from __future__ import annotations
+
+import threading
+
+_lock = threading.Lock()
+# (model, has_tools) -> response_format supported on that shape. Absent = unknown.
+_cache: dict[tuple[str, bool], bool] = {}
+
+
+def response_format_supported(model: str, *, has_tools: bool) -> bool | None:
+    """Return cached support for ``response_format`` on (model, has_tools).
+
+    ``None`` means "not yet probed" — the caller should attempt and record.
+    """
+    with _lock:
+        return _cache.get((model, has_tools))
+
+
+def record_response_format_support(model: str, *, has_tools: bool, supported: bool) -> None:
+    """Record whether (model, has_tools) accepts ``response_format``."""
+    with _lock:
+        _cache[(model, has_tools)] = supported
+
+
+def reset() -> None:
+    """Clear the cache (test isolation; also valid at runtime to force re-probe)."""
+    with _lock:
+        _cache.clear()
+
+
+def snapshot() -> dict[tuple[str, bool], bool]:
+    """Return a copy of the current cache (read surface for tests/diagnostics)."""
+    with _lock:
+        return dict(_cache)

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -768,10 +768,32 @@ async def recorded_acompletion(
             call_kwargs["response_format"] = rf
         return await litellm.acompletion(model=effective_model, messages=messages, **call_kwargs)
 
+    # #1212 D5: per-(model, call-shape) capability cache. If this model+shape is
+    # already known to reject response_format, skip the doomed attempt and go
+    # straight to the no-response_format call (only on the fallback-enabled path,
+    # so non-fallback callers keep their exact raise-on-error semantics). Pure
+    # optimization — the fallback below still handles a first/uncached 400.
+    from reyn.llm.capability_cache import (
+        record_response_format_support,
+        response_format_supported,
+    )
+
+    has_tools = bool(base_kwargs.get("tools"))
+    rf = response_format
+    if (
+        response_format is not None
+        and fallback_without_response_format
+        and response_format_supported(effective_model, has_tools=has_tools) is False
+    ):
+        rf = None
+
     try:
-        response = await _once(response_format)
+        response = await _once(rf)
+        if rf is not None:
+            record_response_format_support(effective_model, has_tools=has_tools, supported=True)
     except Exception:
-        if response_format is not None and fallback_without_response_format:
+        if rf is not None and fallback_without_response_format:
+            record_response_format_support(effective_model, has_tools=has_tools, supported=False)
             response = await _once(None)
         else:
             raise

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -789,7 +789,7 @@ async def recorded_acompletion(
 
     try:
         response = await _once(rf)
-        if rf is not None:
+        if rf is not None and fallback_without_response_format:
             record_response_format_support(effective_model, has_tools=has_tools, supported=True)
     except Exception:
         if rf is not None and fallback_without_response_format:

--- a/tests/test_capability_cache_1212.py
+++ b/tests/test_capability_cache_1212.py
@@ -1,0 +1,124 @@
+"""Tier 2: #1212 D5 — per-(model, call-shape) response_format capability cache.
+
+The cache lets the ``recorded_acompletion`` chokepoint skip a doomed
+``response_format`` attempt after the provider rejected it once, instead of
+re-paying the 400 round-trip on every call. The capability is call-shape
+specific (``response_format`` alone vs combined with ``tools``), so the key is
+``(model, has_tools)``.
+
+Real cache + the real chokepoint; the only scripted seam is ``litellm.acompletion``
+(the external provider boundary — the sanctioned pattern in
+``test_cost_chokepoint_1190``), not a reyn collaborator mock.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+import pytest
+
+from reyn.llm import capability_cache as cc
+from reyn.llm.llm import recorded_acompletion
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    cc.reset()
+    yield
+    cc.reset()
+
+
+# ── cache module ────────────────────────────────────────────────────────────
+
+def test_cache_records_and_reads_per_shape() -> None:
+    """Tier 2: (model, has_tools) are independent keys; an un-probed shape reads None."""
+    assert cc.response_format_supported("m", has_tools=False) is None
+    cc.record_response_format_support("m", has_tools=False, supported=True)
+    cc.record_response_format_support("m", has_tools=True, supported=False)
+    assert cc.response_format_supported("m", has_tools=False) is True
+    assert cc.response_format_supported("m", has_tools=True) is False
+    assert cc.snapshot() == {("m", False): True, ("m", True): False}
+
+
+def test_cache_reset_clears() -> None:
+    """Tier 2: reset() clears recorded capabilities."""
+    cc.record_response_format_support("m", has_tools=False, supported=True)
+    cc.reset()
+    assert cc.response_format_supported("m", has_tools=False) is None
+
+
+# ── wiring into the recorded_acompletion chokepoint ─────────────────────────
+
+class _Resp:
+    """Minimal stand-in for a litellm response (recorder=None → not introspected)."""
+
+
+def test_chokepoint_caches_rejection_and_skips_next(monkeypatch) -> None:
+    """Tier 2: a response_format rejection is cached → the next call skips it.
+
+    First call: rf attempted → rejected → fallback without rf (litellm sees
+    [True, False]). The (model, has_tools=False) shape is now cached unsupported,
+    so the SECOND call skips the doomed rf attempt entirely — litellm sees one
+    more call, without rf ([True, False, False]) rather than re-probing.
+    """
+    calls: list[bool] = []
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        has_rf = "response_format" in kw
+        calls.append(has_rf)
+        if has_rf:
+            raise ValueError("response_format unsupported")
+        return _Resp()
+
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    async def _call():
+        return await recorded_acompletion(
+            model="m", messages=[{"role": "user", "content": "x"}], purpose="judge",
+            recorder=None, response_format={"type": "json_object"},
+            fallback_without_response_format=True,
+        )
+
+    asyncio.run(_call())
+    assert calls == [True, False]
+    assert cc.response_format_supported("m", has_tools=False) is False
+
+    asyncio.run(_call())
+    assert calls == [True, False, False], "2nd call must skip the doomed rf attempt"
+
+
+def test_chokepoint_caches_success(monkeypatch) -> None:
+    """Tier 2: a successful response_format call caches support=True."""
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        return _Resp()
+
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    asyncio.run(recorded_acompletion(
+        model="m2", messages=[{"role": "user", "content": "x"}], purpose="judge",
+        recorder=None, response_format={"type": "json_object"},
+        fallback_without_response_format=True,
+    ))
+    assert cc.response_format_supported("m2", has_tools=False) is True
+
+
+def test_chokepoint_no_fallback_leaves_cache_untouched(monkeypatch) -> None:
+    """Tier 2: with fallback disabled, the chokepoint neither consults nor records
+    the cache (exact raise-on-error semantics preserved for non-fallback callers)."""
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        if "response_format" in kw:
+            raise ValueError("rf unsupported")
+        return _Resp()
+
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    async def _call():
+        return await recorded_acompletion(
+            model="m3", messages=[{"role": "user", "content": "x"}], purpose="judge",
+            recorder=None, response_format={"type": "json_object"},
+            fallback_without_response_format=False,
+        )
+
+    with pytest.raises(ValueError):
+        asyncio.run(_call())
+    assert cc.response_format_supported("m3", has_tools=False) is None

--- a/tests/test_capability_cache_1212.py
+++ b/tests/test_capability_cache_1212.py
@@ -102,9 +102,8 @@ def test_chokepoint_caches_success(monkeypatch) -> None:
     assert cc.response_format_supported("m2", has_tools=False) is True
 
 
-def test_chokepoint_no_fallback_leaves_cache_untouched(monkeypatch) -> None:
-    """Tier 2: with fallback disabled, the chokepoint neither consults nor records
-    the cache (exact raise-on-error semantics preserved for non-fallback callers)."""
+def test_chokepoint_no_fallback_rejection_leaves_cache_untouched(monkeypatch) -> None:
+    """Tier 2: fallback disabled + rf rejected → raises, cache untouched (semantics preserved)."""
     async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
         if "response_format" in kw:
             raise ValueError("rf unsupported")
@@ -122,3 +121,23 @@ def test_chokepoint_no_fallback_leaves_cache_untouched(monkeypatch) -> None:
     with pytest.raises(ValueError):
         asyncio.run(_call())
     assert cc.response_format_supported("m3", has_tools=False) is None
+
+
+def test_chokepoint_no_fallback_success_not_recorded(monkeypatch) -> None:
+    """Tier 2: fallback disabled + rf SUCCEEDS → still not recorded.
+
+    The invariant is "only the fallback-enabled path touches the cache". A
+    non-fallback caller whose response_format call succeeds must NOT write the
+    cache either (closes claim==content for the success path, not just rejection).
+    """
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        return _Resp()
+
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    asyncio.run(recorded_acompletion(
+        model="m4", messages=[{"role": "user", "content": "x"}], purpose="judge",
+        recorder=None, response_format={"type": "json_object"},
+        fallback_without_response_format=False,
+    ))
+    assert cc.response_format_supported("m4", has_tools=False) is None


### PR DESCRIPTION
**[e2e-coder]** — #1212 impl wave **PR1/5** (D5), into integration branch `feat/1212-tool-calls-unification`. Standalone, pure optimization (no behavior change).

## What
`src/reyn/llm/capability_cache.py` — caches whether a `(model, has_tools)` shape accepts `response_format`. After the provider rejects it once, `recorded_acompletion` skips the doomed attempt on subsequent calls instead of re-paying the 400 round-trip through the existing `except Exception` fallback.

**Call-shape keyed**: Gemini accepts `response_format` alone (json-mode) but rejects it *combined with* `tools` (the #1212 op-loop call), so `(model, has_tools)` are independent keys. Only the fallback-enabled path consults/records the cache → non-fallback callers keep exact raise-on-error semantics.

## Test plan (Tier-2, real cache + real chokepoint; scripted litellm boundary only)
- [x] cache record/read/reset + per-shape key independence
- [x] chokepoint caches a rejection → 2nd call skips the rf attempt (`[True,False]` → `[True,False,False]`)
- [x] chokepoint caches success
- [x] fallback-disabled leaves the cache untouched (semantics preserved)
- [x] **existing `test_cost_chokepoint_1190` (8 tests) unchanged** = behavior-preserving
- [x] ruff + `test_tier_audit --strict` clean

Per ADR-0035 D5. PR2 (native-tools op-loop) will be the cache's first combined-mode consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)