### PR TITLE
feat(kernel): #1212 PR2 — native-tools op-loop Phase mechanism (gated, D1–D4)

### DIFF
--- a/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
+++ b/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
@@ -44,6 +44,22 @@ op-loop call (tools=):  stop_reason=tool_use  → execute op → feed result →
 then transition call (response_format, no tools) → {control, artifact}  (structured)
 ```
 
+**D2-impl — op results are FRAME-fed, not native tool-role-threaded** (intentional,
+PR2 `kernel/phase_executor.py:_run_op_loop`). Each op turn rebuilds the phase frame
+with the accumulated `control_ir_results` and issues an **independent** `call_tools`
+([system, user(frame)] + tools) — exactly like the json-mode `_run_act_loop` rebuilds
+the frame each turn. Op results are NOT appended back as native
+`{role:assistant, tool_calls}` + `{role:tool, ...}` messages. Trade-off (deliberate):
+- **(+)** reuses the json-mode frame builder (no drift) / each call is self-contained
+  (no dangling-tool_call API hazard) / **simplifies PR5 replay** — no provider-specific
+  native tool-message is persisted, so the op-loop replays exactly like json-mode frame
+  replay (see Open items: the D8b provider-id-normalization concern is **moot**).
+- **(−)** the model loses *native* tool-call continuity across turns; it sees prior
+  results as frame context rather than its own tool-message history. Mitigated by the
+  `control_ir_results` in every frame; the residual behavioral risk (real model redoes
+  an op / stalls instead of progressing op-by-op) is settled by **動作確認** (real-model
+  op-by-op progression), not the scripted Tier-2/3 plumbing tests.
+
 **D3 — Trigger = `stop_reason`** (weak/strong, provider-common). reyn's llm layer
 already normalizes tool-extraction vs content (`llm/llm.py:741`); the transition
 call's schema enforcement suppresses the empty-stop attractor (`planner.py:101`).
@@ -149,8 +165,10 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
 4. **PR4 — allowed_ops tool-name granularity (D7).** Linter target swap + the 36-phase
    kind→sub-tool expansion (behavior-preserving) + offer-layer `allowed_ops ∩ permission`
    filter (D8 permission). Per-phase tightening deferred to a follow-up.
-5. **PR5 — WAL/resume loop-adaptation + replay fixtures (D8).** Resume per tool_call,
-   Tier-3 fixtures to the tool_call structure, round event carry. **Required scope
+5. **PR5 — WAL/resume loop-adaptation + replay fixtures (D8).** Resume per op turn;
+   **replay fixtures track the json-mode frame shape, not a tool_call structure**
+   (frame-fed op-loop, D2-impl — the D8b provider-id normalization is moot), round
+   event carry. **Required scope
    item — act-turn memo decision** (carried from PR2, see Open items): PR2 ships the
    op-loop's per-tool-turn LLM call (`LLMCallRecorder.call_tools`) WITHOUT decide-memo
    (model-resolution + budget + cost-record only); PR5 MUST decide whether act turns
@@ -165,8 +183,14 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
   ops; pin with a coverage test before the rewrite.
 - **D7 follow-up tightening**: where to draw "actually-used tools" per phase (needs a
   usage scan), explicitly deferred so the behavior-preserving wave stays mechanical.
-- **Replay (D8b)**: native tool_call ids are provider-specific — fixtures must
-  normalize them so Tier-3 stays provider-agnostic at the replay boundary.
+- **Replay (D8b) — MOOT under the frame-fed op-loop (D2-impl).** This concern
+  assumed native tool-role messages would be threaded back into the conversation (so
+  their provider-specific `tool_call` ids would need normalizing at the replay
+  boundary). PR2 feeds op results via the rebuilt frame's `control_ir_results`
+  instead, so **no native tool-message is persisted** — the op-loop replays exactly
+  like json-mode frame replay, with no provider-id normalization needed. Retained
+  here only as the rationale trail; PR5 replay fixtures track the json-mode frame
+  shape, not a tool_call structure.
 - **Op-loop act-turn memo / resume divergence (PR2→PR5)**: PR2's `call_tools` skips
   decide-memo — correct for normal op-loop operation (memo only matters on
   re-run/resume). But on *resume*, an un-memoized act turn is **re-decided** by the

--- a/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
+++ b/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
@@ -150,7 +150,13 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
    kind→sub-tool expansion (behavior-preserving) + offer-layer `allowed_ops ∩ permission`
    filter (D8 permission). Per-phase tightening deferred to a follow-up.
 5. **PR5 — WAL/resume loop-adaptation + replay fixtures (D8).** Resume per tool_call,
-   Tier-3 fixtures to the tool_call structure, round event carry.
+   Tier-3 fixtures to the tool_call structure, round event carry. **Required scope
+   item — act-turn memo decision** (carried from PR2, see Open items): PR2 ships the
+   op-loop's per-tool-turn LLM call (`LLMCallRecorder.call_tools`) WITHOUT decide-memo
+   (model-resolution + budget + cost-record only); PR5 MUST decide whether act turns
+   are memoized for deterministic replay (json-mode-equal crash-recovery guarantee) or
+   left as re-decide-on-resume (weaker, divergence caveat below). Lead-coder leans
+   memoize-for-parity.
 
 ## Open items / risks
 
@@ -161,3 +167,13 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
   usage scan), explicitly deferred so the behavior-preserving wave stays mechanical.
 - **Replay (D8b)**: native tool_call ids are provider-specific — fixtures must
   normalize them so Tier-3 stays provider-agnostic at the replay boundary.
+- **Op-loop act-turn memo / resume divergence (PR2→PR5)**: PR2's `call_tools` skips
+  decide-memo — correct for normal op-loop operation (memo only matters on
+  re-run/resume). But on *resume*, an un-memoized act turn is **re-decided** by the
+  model, which may pick a *different* op than the original run. `dispatch_tool`'s WAL
+  memo is keyed on op+args (`control_ir_executor.py:128`), so a divergent re-decide
+  misses the memo and the op **re-executes** (its side-effect lands outside WAL
+  protection) — a weaker crash-recovery guarantee than json-mode (decide memoized →
+  deterministic control_ir replay → op WAL replay). PR5 decides: memoize act turns for
+  json-mode-equal determinism (lead-coder lean) vs accept re-decide divergence with a
+  documented caveat. Un-opted skills are unaffected (json-mode unchanged).

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -53,6 +53,7 @@ models:
 | `project_context_path` | string | Markdown file injected into every phase system prompt. Default `REYN.md`. |
 | `shell_allowed` | bool | Pre-approve the `shell` op so it is not gated per-call. Default `false`. |
 | `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
+| `tool_calls_op_loop_skills` | list | **Transitional (#1212).** Skill names opted into the native-tools op-loop phase mechanism (ops emitted as native `tool_calls` and run through the shared executor) instead of the json-mode `control_ir` batch. Default empty = all skills use json-mode (unchanged). Removed once the op-loop becomes the default. |
 
 ## `models` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -67,6 +67,17 @@
 
 
 # -----------------------------------------------------------------------------
+# tool_calls_op_loop_skills: TRANSITIONAL (#1212). Skill names opted into the
+# native-tools op-loop phase mechanism — their ops are emitted as native
+# tool_calls and run through the shared executor instead of the json-mode
+# control_ir batch. Default empty = every skill uses json-mode (unchanged).
+# Removed once the op-loop becomes the default.
+# -----------------------------------------------------------------------------
+# tool_calls_op_loop_skills:
+#   - my_skill
+
+
+# -----------------------------------------------------------------------------
 # permissions: pre-approved permission grants — same structure as phase
 # frontmatter ``permissions:`` block, but value is always ``allow``. Lets the
 # operator pre-approve specific tools so the router doesn't gate them at

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1552,6 +1552,14 @@ class ReynConfig:
         default_factory=dict,
         metadata={"desc": "Map of model class names to LiteLLM model strings."},
     )
+    tool_calls_op_loop_skills: list[str] = field(
+        default_factory=list,
+        metadata={"desc": (
+            "TRANSITIONAL (#1212): skill names opted into the native-tools op-loop "
+            "execution path. Skills not listed use the default json-mode execution "
+            "path, unchanged. Removed once the op-loop becomes the default."
+        )},
+    )
     # LiteLLM proxy: non-secret base URL only.
     # API keys must be set as environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
     # — never stored in config files.
@@ -2066,6 +2074,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             str(k): (v if isinstance(v, dict) else str(v))
             for k, v in (merged.get("models") or {}).items()
         },
+        tool_calls_op_loop_skills=[
+            str(s) for s in (merged.get("tool_calls_op_loop_skills") or [])
+        ],
         api_base=str(merged.get("api_base") or ""),
         # prompt_cache_enabled / project_context_path were declared as
         # ReynConfig fields + consumed (llm.py / session.py / agent.py /

--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 
 from reyn.budget.budget import BudgetExceeded, format_refusal_message
 from reyn.dispatch.dispatcher import _compute_llm_args_hash, _lookup_memoized_step
-from reyn.llm.llm import call_llm
+from reyn.llm.llm import call_llm, call_llm_tools
 from reyn.llm.llm import proxy_kwargs as _proxy_kwargs
 from reyn.llm.pricing import TokenUsage, estimate_cost
 from reyn.schemas.models import ContextFrame, Skill
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from reyn.budget.budget import BudgetTracker
     from reyn.events.state_log import StateLog
     from reyn.kernel.run_state import RunState
+    from reyn.llm.llm import LLMToolCallResult
     from reyn.llm.model_resolver import ModelResolver
     from reyn.skill.skill_registry import SkillRegistry
 
@@ -226,6 +227,95 @@ class LLMCallRecorder:
         )
 
         return raw
+
+    async def call_tools(
+        self,
+        phase: str,
+        frame: ContextFrame,
+        tools: list[dict],
+        state: "RunState",
+        *,
+        response_format: dict | None = None,
+    ) -> "LLMToolCallResult":
+        """#1212 PR2: native-tools variant of ``call``. Returns the raw assistant
+        message (content / tool_calls / finish_reason) for the op-loop.
+
+        Shares ``call``'s model-resolution + budget pre-check + cost-record + the
+        ``llm_called`` / ``llm_response_received`` events, and builds the [system,
+        user(frame)] messages via the SAME ``build_phase_messages`` helper as the
+        json-mode path (no drift), but calls ``call_llm_tools`` instead of
+        ``call_llm`` and — per ADR-0035 PR2 scope — **skips decide-memo and the
+        per-step WAL** (the op-EXECUTION crash-recovery WAL is owned by the
+        control_ir_executor's ``dispatch_tool``, D8; act-turn LLM memoization is a
+        PR5 decision, see ADR Open items). Un-opted skills never reach here, so the
+        json-mode ``call`` path is byte-for-byte unchanged.
+        """
+        from reyn.llm.llm import build_phase_messages
+
+        resolved_spec = self._resolver.resolve(self._effective_model(phase))
+        resolved_model = resolved_spec.model
+        phase_def = self._skill.phases.get(phase)
+
+        messages = build_phase_messages(
+            frame,
+            skill_name=self._skill.name,
+            skill_description=self._skill.description,
+            phase_role=phase_def.role if phase_def else None,
+            project_context=self._project_context,
+            agent_role=self._agent_role,
+            prompt_cache_enabled=self._prompt_cache_enabled,
+        )
+
+        self._check_budget_pre_llm(resolved_model)
+        self._events.emit(
+            "llm_called",
+            run_id=self._run_id,
+            skill=self._skill.name,
+            phase=phase,
+            model=resolved_model,
+        )
+        result = await call_llm_tools(
+            model=resolved_spec,
+            messages=messages,
+            tools=tools,
+            response_format=response_format,
+            timeout=self._llm_timeout,
+            max_retries=self._llm_max_retries,
+            prompt_cache_enabled=self._prompt_cache_enabled,
+            skill_name=self._skill.name,
+            skill_description=self._skill.description,
+            trace_caller=f"phase:{phase}",
+            event_log=self._events,
+        )
+
+        cost_usd: float | None = None
+        pricing_snapshot: dict | None = None
+        if result.usage:
+            _pricing_model = (
+                resolved_model.split("/", 1)[1]
+                if "/" in resolved_model and _proxy_kwargs()
+                else resolved_model
+            )
+            cost_usd, pricing_snapshot = estimate_cost(_pricing_model, result.usage)
+            state.add_usage(result.usage, cost_usd)
+            self._record_budget_post_llm(resolved_model, result.usage)
+        self._events.emit(
+            "llm_response_received",
+            run_id=self._run_id,
+            skill=self._skill.name,
+            phase=phase,
+            response_type="tool_calls" if result.tool_calls else "content",
+            raw={
+                "tool_calls": result.tool_calls,
+                "content": result.content,
+                "finish_reason": result.finish_reason,
+            },
+            prompt_tokens=result.usage.prompt_tokens if result.usage else None,
+            completion_tokens=result.usage.completion_tokens if result.usage else None,
+            cost_usd=cost_usd,
+            pricing_snapshot=pricing_snapshot,
+        )
+        return result
 
     # ── Model resolution ───────────────────────────────────────────────────────
 

--- a/src/reyn/kernel/op_loop.py
+++ b/src/reyn/kernel/op_loop.py
@@ -1,0 +1,48 @@
+"""#1212 PR2: native-tools op-loop helpers.
+
+The op-loop (ADR-0035 D1-D4) executes a phase's ops via native function-calling
+instead of the json-mode ``control_ir`` batch: the model emits ``tool_calls``,
+each is converted to a ``ControlIROp`` and run through the SHARED
+``control_ir_executor`` (D8 — same dispatch / permission / events / WAL as the
+json-mode path), and the result is fed back as a tool-role message until the
+model stops requesting tools (``end_turn``); a separate json-mode transition call
+then yields ``{control, artifact}``.
+
+PR2 uses KIND-level tool names (the tool name IS the op kind, from
+``_build_phase_tool_catalog``). Tool-name granularity (``file__read``) is PR4.
+"""
+from __future__ import annotations
+
+import json
+
+from pydantic import TypeAdapter
+
+from reyn.schemas.models import ControlIROp
+
+_CONTROL_IR_ADAPTER: TypeAdapter = TypeAdapter(ControlIROp)
+
+
+def tool_call_to_control_ir_op(tool_call: dict) -> ControlIROp:
+    """Convert one native ``tool_call`` to a ``ControlIROp`` for the shared executor.
+
+    A tool_call is ``{"id": ..., "function": {"name": <kind>, "arguments": <json>}}``.
+    PR2: the tool name is the op kind (kind-level catalog); ``arguments`` is the
+    provider's JSON string (or already a dict) of op fields. The op is built by
+    validating ``{"kind": <name>, **args}`` against the ``ControlIROp``
+    discriminated union (``discriminator="kind"``).
+
+    Raises ``json.JSONDecodeError`` on malformed arguments and
+    ``pydantic.ValidationError`` on an unknown kind / invalid fields — both are
+    caught by the op-loop's per-turn validation (mirrors the json-mode
+    ``ActOutput.model_validate`` failure path).
+    """
+    fn = tool_call.get("function") or {}
+    kind = fn.get("name") or ""
+    raw_args = fn.get("arguments")
+    if isinstance(raw_args, str):
+        args = json.loads(raw_args) if raw_args.strip() else {}
+    elif isinstance(raw_args, dict):
+        args = dict(raw_args)
+    else:
+        args = {}
+    return _CONTROL_IR_ADAPTER.validate_python({"kind": kind, **args})

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -453,6 +453,18 @@ class PhaseExecutor:
         ``tool_calls_op_loop_skills`` (gate) — un-opted skills stay on _run_act_loop
         with zero change.
 
+        INTENTIONAL DESIGN — op results are FRAME-fed, not native-tool-role-threaded
+        (ADR-0035 D2-impl). Each turn rebuilds the frame with the accumulated
+        ``control_ir_results`` and issues an INDEPENDENT ``call_tools`` (no growing
+        ``{role:assistant,tool_calls}`` + ``{role:tool,...}`` history is threaded back),
+        exactly mirroring how json-mode _run_act_loop rebuilds the frame each turn.
+        Trade-off: (+) reuses the json-mode frame builder (no drift) / each call is
+        self-contained (no dangling-tool_call API hazard) / PR5 replay = json-mode
+        frame replay (provider tool_call-id normalization is moot); (−) the model loses
+        native cross-turn tool-call continuity (mitigated — prior results are in every
+        frame). The residual "real model progresses op-by-op (no redo/stall)" risk is
+        settled by 動作確認, not the scripted plumbing tests.
+
         PR2-scope simplifications vs _run_act_loop (deferred follow-ups; safe because
         the path is opt-in): the on-demand ``compact`` op, the max-act-turns safety
         intervention (``handle_limit_exceeded``), and rollback-reason injection into

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -151,6 +151,7 @@ class PhaseExecutor:
         build_frame_fn,
         phase_compaction_engine: "CompactionEngine | None" = None,
         phase_compaction_cfg: "PhaseActResultsCompactionConfig | None" = None,
+        op_loop_enabled: bool = False,
     ) -> None:
         self._llm_caller = llm_caller
         self._control_ir_executor = control_ir_executor
@@ -175,6 +176,12 @@ class PhaseExecutor:
         # _run_act_loop so RunOrchestrator can snapshot them at A → B
         # transition (= `rollback_state.snapshot_phase_history`).
         self._last_control_ir_results: list[dict] = []
+        # #1212 PR2: when True, this skill is opted into the native-tools op-loop
+        # (_run_op_loop) instead of the json-mode act loop (_run_act_loop). The OS
+        # decides the mechanism (P3); the gate is a config-held list of skill names
+        # (tool_calls_op_loop_skills) resolved at PhaseExecutor construction. Default
+        # False = json-mode, byte-for-byte unchanged.
+        self._op_loop_enabled = op_loop_enabled
 
     # ── #1135(b): raw-output capture on phase-output validation failure ───────
 
@@ -419,6 +426,160 @@ class PhaseExecutor:
             raise ValueError(str(exc)) from exc
 
         return result, output
+
+    # ── Op loop (#1212 native-tools, gated) ────────────────────────────────────
+
+    async def _run_op_loop(
+        self,
+        phase: str,
+        artifact: dict,
+        candidates: list[CandidateOutput],
+        output_language: str | None,
+        max_act_turns: int,
+        max_phase_retries: int,
+        artifact_path: str | None,
+        state: "RunState",
+        rollback_context: dict | None = None,
+    ) -> tuple[dict, list[dict]]:
+        """#1212 PR2: native-tools op-loop — gated variant of _run_act_loop (D1–D4).
+
+        Same per-turn frame rebuild / phase-axis compaction / rollback-history
+        restore / phase-budget check as the json-mode act loop, but a phase's ops are
+        emitted as native ``tool_calls`` and run through the SHARED
+        control_ir_executor (D8 — same dispatch / permission / events / WAL) instead
+        of the json-mode ``control_ir`` field. The model signals "done with ops" by
+        emitting zero tool_calls; a separate json-mode transition ``call`` then yields
+        the raw {control, artifact}. Reached only for skills opted into
+        ``tool_calls_op_loop_skills`` (gate) — un-opted skills stay on _run_act_loop
+        with zero change.
+
+        PR2-scope simplifications vs _run_act_loop (deferred follow-ups; safe because
+        the path is opt-in): the on-demand ``compact`` op, the max-act-turns safety
+        intervention (``handle_limit_exceeded``), and rollback-reason injection into
+        act turns are json-mode-only here — the op-loop caps act turns then forces the
+        json transition. Act-turn LLM memo / resume divergence = PR5 (ADR Open items).
+        """
+        from reyn.kernel.control_ir_executor import _build_phase_tool_catalog
+        from reyn.kernel.op_loop import tool_call_to_control_ir_op
+
+        if rollback_context and rollback_context.get("previous_control_ir_results"):
+            control_ir_results: list[dict] = list(
+                rollback_context["previous_control_ir_results"]
+            )
+        else:
+            control_ir_results = []
+
+        phase_def = self._skill.phases.get(phase)
+        phase_decl = self._skill.permissions
+        allowed_ops = set(phase_def.allowed_ops) if phase_def is not None else None
+        catalog = _build_phase_tool_catalog(allowed_ops or set())
+        tools = [{"type": "function", **entry} for entry in catalog.values()]
+
+        act_turn_count = 0
+        first_call = True
+
+        while True:
+            effective_max_act_turns = state.effective_act_turn_cap(phase, max_act_turns)
+            remaining = (
+                effective_max_act_turns - act_turn_count
+                if effective_max_act_turns > 0
+                else None
+            )
+            force_decide = remaining is not None and remaining <= 0
+
+            # Phase-axis compaction (same policy as json-mode _run_act_loop).
+            if (
+                self._phase_compaction_engine is not None
+                and self._phase_compaction_cfg is not None
+                and len(control_ir_results)
+                > self._phase_compaction_cfg.recent_act_turns_raw
+            ):
+                from reyn.services.compaction.engine import (
+                    compact_control_ir_results,
+                )
+                n_recent = self._phase_compaction_cfg.recent_act_turns_raw
+                recent = control_ir_results[-n_recent:]
+                older = control_ir_results[:-n_recent]
+                older_compacted = await compact_control_ir_results(
+                    older,
+                    engine=self._phase_compaction_engine,
+                    cfg=self._phase_compaction_cfg,
+                    events=self._events,
+                    phase=phase,
+                )
+                control_ir_results = older_compacted + recent
+
+            frame = self._build_frame(
+                phase, artifact, candidates, output_language,
+                control_ir_results=control_ir_results,
+                artifact_path=artifact_path,
+                remaining_act_turns=remaining,
+                force_decide=force_decide,
+            )
+
+            await self._check_phase_budget(phase, state)
+
+            # Budget exhausted → force the json-mode transition (decide) now.
+            if force_decide:
+                raw = await self._llm_caller.call(
+                    phase, frame, None,
+                    rollback_context if first_call else None, state,
+                )
+                self._last_control_ir_results = control_ir_results
+                return raw, []
+
+            result = await self._llm_caller.call_tools(phase, frame, tools, state)
+
+            if not result.tool_calls:
+                # Decide turn: model emitted no ops → separate json-mode transition.
+                decide_frame = self._build_frame(
+                    phase, artifact, candidates, output_language,
+                    control_ir_results=control_ir_results,
+                    artifact_path=artifact_path,
+                    remaining_act_turns=remaining,
+                    force_decide=True,
+                )
+                raw = await self._llm_caller.call(
+                    phase, decide_frame, None,
+                    rollback_context if first_call else None, state,
+                )
+                self._last_control_ir_results = control_ir_results
+                return raw, []
+
+            first_call = False
+            act_turn_count += 1
+
+            ops = []
+            invalid: list[str] = []
+            for tc in result.tool_calls:
+                try:
+                    ops.append(tool_call_to_control_ir_op(tc))
+                except Exception as exc:  # noqa: BLE001 — invalid op shape
+                    invalid.append(str(exc))
+            if invalid:
+                # Mirror json-mode's act_ops validation_error event (the model is
+                # told via the next frame's results that the op did not run).
+                self._events.emit(
+                    "validation_error", phase=phase,
+                    error=f"invalid tool_call op(s): {'; '.join(invalid)}",
+                )
+
+            ir_results = await self._control_ir_executor.execute(
+                ops, phase=phase, decl=phase_decl, allowed_ops=allowed_ops,
+                default_sandbox_policy=(
+                    phase_def.default_sandbox_policy if phase_def is not None else None
+                ),
+            )
+            control_ir_results = control_ir_results + ir_results
+            self._events.emit(
+                "act_executed",
+                phase=phase,
+                op_count=len(ops),
+                op_kinds=[op.kind for op in ops],
+                act_turn=act_turn_count,
+                ops=[op.model_dump() for op in ops],
+                results=ir_results,
+            )
 
     # ── Act loop ──────────────────────────────────────────────────────────────
 
@@ -707,7 +868,11 @@ class PhaseExecutor:
         phase_def = self._skill.phases[phase]
         max_act_turns = phase_def.max_act_turns if phase_def.max_act_turns > 0 else 10
 
-        raw, prior_attempts = await self._run_act_loop(
+        # #1212 PR2: gated dispatch. Opted-in skills run the native-tools op-loop;
+        # the default json-mode act loop is unchanged. Both return (raw_decide, prior)
+        # and feed the same decide-with-retry path (transition stays json-mode).
+        act_loop = self._run_op_loop if self._op_loop_enabled else self._run_act_loop
+        raw, prior_attempts = await act_loop(
             phase, artifact, candidates, output_language,
             max_act_turns, max_phase_retries, artifact_path,
             state,

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -88,6 +88,7 @@ class OSRuntime:
         workspace_state_dir: "Path | None" = None,
         phase_compaction_engine: "CompactionEngine | None" = None,
         phase_compaction_cfg: "PhaseActResultsCompactionConfig | None" = None,
+        tool_calls_op_loop_skills: list[str] | None = None,
     ) -> None:
         self.skill = skill
         self.model = model
@@ -282,6 +283,10 @@ class OSRuntime:
             build_frame_fn=self.build_frame,
             phase_compaction_engine=self._phase_compaction_engine,  # PR-N8
             phase_compaction_cfg=self._phase_compaction_cfg,        # PR-N8
+            # #1212 PR2: OS-decided mechanism gate (P3). The config holds opted-in
+            # skill names as data (P7-OK); this skill runs the native-tools op-loop
+            # iff its name is listed. Default empty = json-mode (zero change).
+            op_loop_enabled=skill.name in (tool_calls_op_loop_skills or ()),
         )
         # FP-0020 Component D: phase sequence + transitions + rollback + skill-node
         # dispatch + resume + SkillRegistry lifecycle extracted to RunOrchestrator.

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1068,6 +1068,7 @@ async def call_llm_tools(
     messages: list[dict],            # OpenAI-format messages (role/content/tool_calls/tool_call_id)
     tools: list[dict],               # OpenAI-format tools array
     tool_choice: str = "auto",       # "auto" | "required" | "none" (note: "none" not Gemini-safe)
+    response_format: dict | None = None,  # #1212 D4: opt-in uniform tools+rf; None = chat default
     timeout: float | None = None,
     max_retries: int = 1,
     skill_name: str = "router",      # for budget/event tagging
@@ -1182,7 +1183,10 @@ async def call_llm_tools(
         **spec_kwargs,
         # Gemini-safe forced settings override spec_kwargs:
         "stream": False,             # Gemini #21041: streaming + tools bug
-        # No response_format: incompatible with tools= on most providers
+        # response_format is OPT-IN (#1212 D4): threaded separately to the
+        # chokepoint below (not here) WITH the fallback, so a provider that
+        # rejects tools+response_format (e.g. Gemini 400) degrades to tools-only
+        # via the PR1 capability cache. Default None = chat behavior (tools only).
         # No thinking kwargs: disabled by default on all providers
         **extra,
     }
@@ -1214,6 +1218,9 @@ async def call_llm_tools(
         return await recorded_acompletion(
             model=_model, messages=_messages, purpose=purpose,
             recorder=None, extra_kwargs=_kw,
+            # #1212 D4: opt-in response_format with the cache-backed degrade.
+            response_format=response_format,
+            fallback_without_response_format=response_format is not None,
         )
 
     response = await _llm_call_with_retry(_tools_call, effective_model, event_log)

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -827,6 +827,37 @@ def _build_system_message(system_text: str, prompt_cache_enabled: bool) -> dict:
     }
 
 
+def build_phase_messages(
+    frame: "ContextFrame",
+    *,
+    skill_name: str = "",
+    skill_description: str = "",
+    phase_role: str | None = None,
+    project_context: str = "",
+    agent_role: str = "",
+    prompt_cache_enabled: bool = True,
+) -> list[dict]:
+    """Build the [system, user] message pair for a phase LLM call.
+
+    #1212: the SAME message construction (system prompt + frame-as-user) is shared
+    by the json-mode ``call_llm`` path and the native-tools op-loop path, so the
+    two never drift (a divergent system prompt / frame rendering would be a subtle
+    bug, and matching them is the promotion-symmetry intent).
+    """
+    system = _system_prompt(
+        skill_name=skill_name,
+        skill_description=skill_description,
+        phase_role=phase_role,
+        project_context=project_context,
+        agent_role=agent_role,
+    )
+    user_content = json.dumps(frame.model_dump(mode="json"), indent=2, ensure_ascii=False)
+    return [
+        _build_system_message(system, prompt_cache_enabled),
+        {"role": "user", "content": user_content},
+    ]
+
+
 async def call_llm(
     model: "Union[str, ModelSpec]",
     frame: ContextFrame,
@@ -880,18 +911,15 @@ async def call_llm(
                 format_refusal_message(check, agent=budget_agent),
             )
 
-    system = _system_prompt(
+    messages: list[dict] = build_phase_messages(
+        frame,
         skill_name=skill_name,
         skill_description=skill_description,
         phase_role=phase_role,
         project_context=project_context,
         agent_role=agent_role,
+        prompt_cache_enabled=prompt_cache_enabled,
     )
-    user_content = json.dumps(frame.model_dump(mode="json"), indent=2, ensure_ascii=False)
-    messages: list[dict] = [
-        _build_system_message(system, prompt_cache_enabled),
-        {"role": "user", "content": user_content},
-    ]
 
     # Build combined injection list: rollback context first, then same-phase retries
     all_injections: list[dict[str, str]] = []

--- a/tests/test_call_llm_tools_response_format_1212.py
+++ b/tests/test_call_llm_tools_response_format_1212.py
@@ -1,0 +1,92 @@
+"""Tier 2: #1212 PR2 — call_llm_tools opt-in response_format degrades via the cache.
+
+The op-loop call (D4) specifies tools + response_format uniformly. On a provider
+that rejects the combination (Gemini 400), reyn's broad fallback drops
+response_format and retries tools-only, and the PR1 capability cache records the
+(model, has_tools=True) shape so the next call skips the doomed attempt. With
+response_format=None (the chat default), call_llm_tools is unchanged.
+
+Real call_llm_tools + real capability cache; the only scripted seam is
+litellm.acompletion (the external provider boundary, the sanctioned pattern in
+test_cost_chokepoint_1190 / test_capability_cache_1212), not a collaborator mock.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+import pytest
+
+from reyn.llm import capability_cache as cc
+from reyn.llm.llm import call_llm_tools
+
+_TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "file__read",
+        "description": "read",
+        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+    },
+}]
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    cc.reset()
+    yield
+    cc.reset()
+
+
+class _Msg:
+    tool_calls = None
+    content = "done"
+
+
+class _Choice:
+    message = _Msg()
+    finish_reason = "stop"
+
+
+class _Resp:
+    choices = [_Choice()]
+    usage = None
+
+
+def test_response_format_degrades_and_caches(monkeypatch) -> None:
+    """Tier 2: combined tools+response_format → 400 → tools-only retry succeeds,
+    and (model, has_tools=True) is cached unsupported."""
+    calls: list[bool] = []
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        has_rf = "response_format" in kw
+        calls.append(has_rf)
+        if has_rf:
+            raise ValueError("combined tools+response_format unsupported (Gemini 400)")
+        return _Resp()
+
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    res = asyncio.run(call_llm_tools(
+        model="m", messages=[{"role": "user", "content": "x"}],
+        tools=_TOOLS, response_format={"type": "json_object"},
+    ))
+    assert res is not None
+    assert calls == [True, False], "first attempt with rf 400s → retry tools-only"
+    assert cc.response_format_supported("m", has_tools=True) is False
+
+
+def test_no_response_format_is_chat_default_no_cache(monkeypatch) -> None:
+    """Tier 2: response_format=None (chat default) → no rf attempt, cache untouched."""
+    calls: list[bool] = []
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        calls.append("response_format" in kw)
+        return _Resp()
+
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    asyncio.run(call_llm_tools(
+        model="m2", messages=[{"role": "user", "content": "x"}], tools=_TOOLS,
+    ))
+    assert calls == [False], "no response_format ever sent"
+    assert cc.response_format_supported("m2", has_tools=True) is None

--- a/tests/test_config_op_loop_skills_1212.py
+++ b/tests/test_config_op_loop_skills_1212.py
@@ -1,0 +1,40 @@
+"""Tier 2: #1212 PR2 — `tool_calls_op_loop_skills` opt-in loads from reyn.yaml.
+
+The native-tools op-loop is rolled out per-skill via a config opt-in list (the
+P-clean rollout flag: the OS decides the execution mechanism, config carries skill
+*names* as data, Phase frontmatter is unchanged). This pins the load-from-disk
+path so the field is actually wired through `load_config` (not just a dataclass
+default), using a NON-DEFAULT value so an unwired/aliased field can't pass
+trivially.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from reyn.config import load_config
+
+
+def _write_reyn_yaml(path: Path, content: dict) -> None:
+    path.write_text(
+        yaml.dump(content, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+def test_op_loop_skills_loaded_from_reyn_yaml(tmp_path: Path) -> None:
+    """Tier 2: a non-default opt-in list in reyn.yaml is parsed onto ReynConfig."""
+    _write_reyn_yaml(
+        tmp_path / "reyn.yaml",
+        {"tool_calls_op_loop_skills": ["swe_bench", "eval"]},
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.tool_calls_op_loop_skills == ["swe_bench", "eval"]
+
+
+def test_op_loop_skills_default_empty_when_absent(tmp_path: Path) -> None:
+    """Tier 2: absent from reyn.yaml → empty list (json-mode default for every skill)."""
+    _write_reyn_yaml(tmp_path / "reyn.yaml", {"model": "standard"})
+    cfg = load_config(tmp_path)
+    assert cfg.tool_calls_op_loop_skills == []

--- a/tests/test_op_loop_conversion_1212.py
+++ b/tests/test_op_loop_conversion_1212.py
@@ -1,0 +1,40 @@
+"""Tier 2: #1212 PR2 — native tool_call → ControlIROp conversion (kind-level).
+
+The op-loop bridges native tool_calls to the SHARED control_ir_executor by
+building a ControlIROp from each tool_call. PR2 uses kind-level tool names (the
+tool name is the op kind), so the op is the discriminated-union member for that
+kind with the call's arguments. Real ControlIROp models, no mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.kernel.op_loop import tool_call_to_control_ir_op
+from reyn.schemas.models import FileIROp
+
+
+def test_tool_call_json_string_arguments_builds_op() -> None:
+    """Tier 2: a tool_call with JSON-string arguments → the matching ControlIROp."""
+    tc = {
+        "id": "c1",
+        "type": "function",
+        "function": {"name": "file", "arguments": '{"op": "read", "path": "x.py"}'},
+    }
+    op = tool_call_to_control_ir_op(tc)
+    assert isinstance(op, FileIROp)
+    assert op.kind == "file" and op.op == "read" and op.path == "x.py"
+
+
+def test_tool_call_dict_arguments_builds_op() -> None:
+    """Tier 2: arguments already a dict (not a JSON string) also build the op."""
+    tc = {"function": {"name": "file", "arguments": {"op": "grep", "path": ".", "pattern": "def "}}}
+    op = tool_call_to_control_ir_op(tc)
+    assert isinstance(op, FileIROp)
+    assert op.op == "grep" and op.pattern == "def "
+
+
+def test_tool_call_unknown_kind_raises() -> None:
+    """Tier 2: an unknown op kind raises (caught by the op-loop's per-turn validation)."""
+    tc = {"function": {"name": "not_a_real_kind", "arguments": "{}"}}
+    with pytest.raises(Exception):  # pydantic ValidationError on the discriminated union
+        tool_call_to_control_ir_op(tc)

--- a/tests/test_op_loop_gate_dispatch_1212.py
+++ b/tests/test_op_loop_gate_dispatch_1212.py
@@ -1,0 +1,152 @@
+"""Tier 2: #1212 PR2 — native-tools op-loop gate dispatch + op execution.
+
+The OS decides the phase mechanism (P3): a skill listed in
+``tool_calls_op_loop_skills`` runs the native-tools op-loop (``_run_op_loop``), where
+a phase's ops are emitted as native ``tool_calls`` and run through the SHARED
+control_ir_executor; the decide turn is a separate json-mode transition call. A skill
+NOT listed stays on the json-mode act loop (``_run_act_loop``), byte-for-byte
+unchanged (the gate defaults to off).
+
+Drives the real ``OSRuntime`` through its public ``run`` surface. The only scripted
+seam is the module-level ``call_llm`` / ``call_llm_tools`` in ``llm_call_recorder``
+(the provider boundary — the same sanctioned pattern as
+``test_llm_call_recorder_invariants``), not a collaborator mock. Real ``EventLog``,
+real ``control_ir_executor``, real workspace, real ``Skill``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import reyn.kernel.llm_call_recorder as lcr
+from reyn.kernel.runtime import OSRuntime
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+
+_FINISH_RESULT = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill(allowed_ops: list[str]) -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=allowed_ops,
+    )
+    return Skill(
+        name="op_loop_gate", entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _tool_result(tool_calls: list) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls,
+        finish_reason="tool_calls" if tool_calls else "stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+def _finish_call_llm():
+    async def _f(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(
+            data=_FINISH_RESULT,
+            usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+    return _f
+
+
+def test_gate_off_uses_json_mode(tmp_path, monkeypatch) -> None:
+    """Tier 2: a skill NOT in tool_calls_op_loop_skills runs json-mode; the
+    native-tools path (call_llm_tools) is never invoked."""
+    monkeypatch.chdir(tmp_path)
+    tools_calls: list[int] = []
+
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        tools_calls.append(1)
+        return _tool_result([])
+
+    monkeypatch.setattr(lcr, "call_llm", _finish_call_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+    rt = OSRuntime(_skill([]), model="stub/model", run_id="gate_off")
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+
+    assert result is not None
+    assert tools_calls == [], "opted-out skill must not invoke the native-tools path"
+    assert any(e.type == "llm_called" for e in rt.events.all()), "json-mode call ran"
+
+
+def test_gate_on_routes_to_op_loop(tmp_path, monkeypatch) -> None:
+    """Tier 2: a skill in tool_calls_op_loop_skills runs the op-loop — the op-turn
+    goes through call_llm_tools and (model emits no ops) the decide is a json-mode
+    call. Proves the gate routes to _run_op_loop and its decide path."""
+    monkeypatch.chdir(tmp_path)
+    tools_calls: list[int] = []
+    decide_calls: list[int] = []
+
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        tools_calls.append(1)
+        return _tool_result([])  # no ops → op-loop goes straight to decide
+
+    async def _decide(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        decide_calls.append(1)
+        return LLMCallResult(
+            data=_FINISH_RESULT,
+            usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+
+    monkeypatch.setattr(lcr, "call_llm", _decide)
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+    rt = OSRuntime(
+        _skill([]), model="stub/model", run_id="gate_on",
+        tool_calls_op_loop_skills=["op_loop_gate"],
+    )
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+
+    assert result is not None
+    assert tools_calls == [1], "op-loop must invoke call_llm_tools for the op-turn"
+    assert decide_calls == [1], "op-loop decide must use the json-mode call"
+
+
+def test_gate_on_executes_op_via_tool_call(tmp_path, monkeypatch) -> None:
+    """Tier 2: a native tool_call is converted to a ControlIROp and run through the
+    SHARED control_ir_executor (act_executed event with the op kind), then the model
+    stops emitting tool_calls → the json-mode decide finishes. Asserts the mechanism
+    (tool_call → op → executor → event), independent of the op's own success."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "hello.txt").write_text("hi")
+
+    turns = iter([
+        _tool_result([{
+            "id": "c1", "type": "function",
+            "function": {"name": "file", "arguments": '{"op": "read", "path": "hello.txt"}'},
+        }]),
+        _tool_result([]),  # done with ops → decide
+    ])
+
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        return next(turns)
+
+    monkeypatch.setattr(lcr, "call_llm", _finish_call_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+    rt = OSRuntime(
+        _skill(["file"]), model="stub/model", run_id="gate_op_exec",
+        tool_calls_op_loop_skills=["op_loop_gate"],
+    )
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+
+    assert result is not None
+    acts = [e for e in rt.events.all() if e.type == "act_executed"]
+    assert acts, "the tool_call must drive an act_executed (op ran via the shared executor)"
+    assert "file" in acts[0].data["op_kinds"], "the converted op kind reaches the executor"


### PR DESCRIPTION
**[e2e-coder]** — #1212 PR2 of the tool_calls-unification wave. Bases on the integration branch `feat/1212-tool-calls-unification` (PR1 #1219 + PR3-groundwork #1220 already merged there). ADR-0035 = spec.

## What
The native-tools op-loop Phase mechanism (D1–D4), **gated + behavior-preserving**. A skill opted into `config.tool_calls_op_loop_skills` emits its ops as native `tool_calls` and runs them through the **SHARED** `control_ir_executor` (D8 — same dispatch/permission/events/WAL); the decide turn is a separate json-mode transition `.call`. Un-opted skills stay on `_run_act_loop`, byte-for-byte unchanged (gate defaults off).

## Hunks (per-hunk review order)
1. **config.py** — `tool_calls_op_loop_skills: list[str]` opt-in flag (TRANSITIONAL; data-only, P7-OK).
2. **llm.py** — `call_llm_tools` opt-in `response_format` (D4, cache-backed degrade) + extracted `build_phase_messages` shared by json-mode `.call` and the op-loop (no drift).
3. **op_loop.py** — `tool_call_to_control_ir_op` conversion bridge (native tool_call → discriminated-union `ControlIROp`).
4. **llm_call_recorder.py** — `LLMCallRecorder.call_tools`: native-tools sibling of `.call`. Same model-resolution + budget pre-check + cost-record + `llm_called`/`llm_response_received` events + the shared `build_phase_messages`; calls `call_llm_tools`; **PR2 scope: skips decide-memo/per-step WAL** (op-execution WAL owned by `dispatch_tool`, D8).
5. **phase_executor.py** — `_run_op_loop` (per-turn frame rebuild / compaction / rollback-restore / phase-budget mirror `_run_act_loop`; ops via tool_calls; empty tool_calls → json decide) + `op_loop_enabled` gate param + gated dispatch at `_process_phase`.
6. **runtime.py** — gate seam: `tool_calls_op_loop_skills` param → `op_loop_enabled = skill.name in (...)` → PhaseExecutor (OS decides mechanism, P3).
7. **ADR-0035** — act-turn memo / resume-divergence flagged to PR5 Open-items (not silently dropped, per review).

## Deliberately deferred (called out, not dropped)
- **Caller-threading** (ChatSession → OSRuntime + the ~10 config entrypoints): the e2e-enablement step where the gate is flipped on. Half-wiring one of ten callers is worse than none (inconsistent); all default safe-off. Gate is reachable+tested at the OSRuntime seam now.
- **PR2-scope simplifications in `_run_op_loop`** vs `_run_act_loop` (safe because opt-in): on-demand `compact` op, max-act-turns safety intervention (`handle_limit_exceeded`), rollback-reason injection into act turns — json-mode-only here; the op-loop caps act turns then forces the json decide.
- **Act-turn LLM memo / deterministic resume** = PR5 (ADR Open-items; lead-coder leans memoize-for-parity).

## Invariants
P1 (Phase frontmatter unchanged) · P3 (OS decides mechanism) · P5/P6 (ops via shared executor → same permission/events/WAL) · P7 (config holds skill names as data, no skill-strings in OS).

## Test plan (Tier 2 — real OSRuntime via public `run`, only provider boundary scripted)
`tests/test_op_loop_gate_dispatch_1212.py`:
- [x] gate-off → json-mode, `call_llm_tools` never invoked (zero-change)
- [x] gate-on → routes to `_run_op_loop`, op-turn via `call_llm_tools`, decide via json `.call`
- [x] gate-on → native tool_call → `ControlIROp` → shared executor (`act_executed` with op kind)
- [x] `pytest -q` PR2 suite + adjacency (37 passed: gate/conversion/response_format/config/capability_cache/recorder-invariants/memoization-e2e/compaction-rollback)
- [x] `ruff check` clean on all changed src
- [x] `test_tier_audit.py --strict` clean on the new test (3/3 OK, Tier 2)
- [x] rebased onto fresh integration (PR1/PR3-groundwork), re-verified green post-rebase

Refs #1212