### PR TITLE
test(tools): #1212 PR3 — guard reframe to intentional chat-router exclusions (D6 scope i)

### DIFF
--- a/tests/test_universal_dispatch_skill_op_coverage_1212.py
+++ b/tests/test_universal_dispatch_skill_op_coverage_1212.py
@@ -1,26 +1,33 @@
-"""Tier 2: universal_dispatch coverage guard for the D6 op-shape codemod (#1212 PR3).
+"""Tier 2: universal_dispatch chat-router coverage guard for stdlib op kinds (#1212 PR3).
 
-Guard invariant (ADR-0035 §"Open items"):
-  The ``universal_dispatch`` op-kind→tool-call mapping MUST be total over
-  the real op kinds that stdlib skills actually reference.  This test fails
-  loudly when a skill uses a real op kind that has no ``{name, arguments}``
-  tool_call route in ``universal_dispatch``, so the PR3 codemod cannot
-  silently miss an op.
+Guard invariant (ADR-0035 D6):
+  Every real op kind a stdlib skill references must be EITHER chat-router-covered
+  by ``universal_dispatch`` OR an explicit ``_INTENTIONAL_CHAT_ROUTER_EXCLUSION``.
+  This fails loudly when a skill gains a new op kind that is neither — an
+  unintentional gap in the chat-router surface.
 
-Scope (per D6 correction, 2026-06-02):
-  - IN: real op kinds found in ``allowed_ops`` frontmatter and
-    preprocessor/postprocessor ``run_op`` step ``op.kind`` literals.
-  - OUT: DSL step types ``iterate`` / ``validate`` / ``python`` /
-    ``lint_plan`` — these are OS-deterministic, never LLM-emitted,
-    and are explicitly out of scope for the D6 codemod.
+Scope axis (per D6 corrections, 2026-06-02 — decision A + scope (i)):
+  The dividing line is **LLM-emitted vs OS-deterministic**, NOT "wraps a real op":
+  - LLM-emitted ops already unified to the native ``{name, arguments}`` tool_call
+    shape by the PR2 op-loop (they execute via the OP registry, kind→IROp).
+  - OS-deterministic literals are intentionally left as ``{kind, ...}`` and are
+    OUT of scope for any shape codemod:
+      · DSL step types ``iterate`` / ``validate`` / ``python`` / ``lint_plan``;
+      · **``run_op`` step ``op:`` literals** — these are authored by the skill,
+        never emitted by an LLM, and (like the DSL above) keep the ``{kind, ...}``
+        ControlIROp shape. Rewriting them to ``{name, arguments}`` was the
+        retracted D6 framing: it is churn without an emission benefit and would
+        require a ``RunOpStep.op`` model change (it rejects the tool_call shape).
+  This test therefore checks op-kind chat-router COVERAGE, not literal shape: it
+  scans ``allowed_ops`` + ``run_op`` ``op.kind`` only to enumerate which op kinds
+  a skill uses, then asserts each is covered-or-excluded.
 
 Coverage contract:
-  For every real op kind k used by any stdlib skill, there must exist at
-  least one qualified name in ``universal_dispatch._OPERATION_RULES`` (or
-  ``_RESOURCE_RULES``) whose category unambiguously covers k.  The explicit
-  op_kind → category correspondence is defined in ``_OP_KIND_CATEGORY`` below
-  and IS the codemod contract: PR3 will rewrite each op kind to the
-  corresponding qualified name(s).
+  For every real op kind k a stdlib skill uses, either a qualified name in
+  ``universal_dispatch._OPERATION_RULES`` / ``_RESOURCE_RULES`` covers its
+  category (``_OP_KIND_CATEGORY`` declares the correspondence), or k is listed in
+  ``_INTENTIONAL_CHAT_ROUTER_EXCLUSIONS`` (skill-internal / control-flow, no
+  chat-router target). PR3 makes ZERO catalog change — decision A.
 
 Load strategy: reads skill files from disk via YAML + frontmatter parsing
 (real data, no hardcoded copies).

--- a/tests/test_universal_dispatch_skill_op_coverage_1212.py
+++ b/tests/test_universal_dispatch_skill_op_coverage_1212.py
@@ -79,11 +79,11 @@ _OP_KIND_CATEGORY: dict[str, str] = {
     "mcp":           "mcp",
     # mcp install ops → "mcp" category (_OPERATION_RULES: mcp__install_*)
     "mcp_install":   "mcp",
-    # ask_user → NOT YET COVERED (no qualified name in universal_dispatch)
-    # embed     → NOT YET COVERED (no qualified name in universal_dispatch)
-    # index_write → NOT YET COVERED (no qualified name in universal_dispatch)
-    # skill_resolve → NOT YET COVERED (no qualified name in universal_dispatch)
-    # (entries above are intentionally absent — see expected-failure comment below)
+    # ask_user / embed / index_write / skill_resolve → INTENTIONAL chat-router
+    # exclusions (ADR-0035 D6 decision A, #1212). Skill-internal run_op /
+    # control-flow ops with no chat-router dispatch target — they execute in the
+    # op-loop via the OP registry (kind→IROp), not universal_dispatch. Absent
+    # here on purpose; enumerated in _INTENTIONAL_CHAT_ROUTER_EXCLUSIONS below.
 }
 
 
@@ -196,20 +196,26 @@ def _skill_real_op_kinds(skill_dir: Path) -> dict[str, set[str]]:
 
 
 def test_universal_dispatch_covers_all_stdlib_skill_real_op_kinds() -> None:
-    """Tier 2: universal_dispatch coverage of stdlib skills' real op kinds tracks
-    exactly the known PR3 gap checklist (drives toward full D6 totality).
+    """Tier 2: every stdlib skill's real op kind is chat-router-covered OR an
+    explicit intentional exclusion (ADR-0035 D6 decision A, #1212).
 
     Guard for the ADR-0035 D6 op-shape codemod (#1212 PR3).
 
     Invariant: every real op kind used in any stdlib skill's ``allowed_ops`` or
-    preprocessor/postprocessor ``run_op`` step has a ``{name, arguments}``
-    tool_call route in ``universal_dispatch`` (appears in ``_OP_KIND_CATEGORY``
-    AND the category is wired in ``_OPERATION_RULES``/``_RESOURCE_RULES``) —
-    EXCEPT the explicitly tracked ``_KNOWN_PR3_GAPS`` (4 op kinds awaiting their
-    PR3 routes). The assertion is EXACT (``uncovered == _KNOWN_PR3_GAPS``), so a
-    new uncovered op kind OR a stale checklist entry both fail. PR3 shrinks the
-    checklist to ``frozenset()`` = full totality; this is a checklist, not a
-    permanent waiver.
+    preprocessor/postprocessor ``run_op`` step is EITHER
+      (a) chat-router-covered — appears in ``_OP_KIND_CATEGORY`` AND its category
+          is wired in ``universal_dispatch._OPERATION_RULES``/``_RESOURCE_RULES``,
+    OR
+      (b) an explicit ``_INTENTIONAL_CHAT_ROUTER_EXCLUSION`` — a skill-internal
+          ``run_op`` / control-flow op with no chat-router dispatch target (it
+          executes in the op-loop via the OP registry, kind→IROp, not the
+          chat-router table).
+    The assertion is EXACT (``uncovered == _INTENTIONAL_CHAT_ROUTER_EXCLUSIONS``),
+    so a NEW uncovered op kind that is neither (a) nor (b) fails (= an
+    unintentional gap), and a STALE exclusion that later gained a route also
+    fails. The exclusion set is PERMANENT (not a shrink-to-``frozenset()``
+    checklist): per decision A, ``universal_dispatch`` is the chat-router surface
+    and skill-internal ops legitimately never join it.
     """
     from reyn.tools.universal_dispatch import (  # noqa: PLC0415
         _OPERATION_RULES,  # type: ignore[attr-defined]  # tested public-enough: PR3 target
@@ -264,23 +270,35 @@ def test_universal_dispatch_covers_all_stdlib_skill_real_op_kinds() -> None:
             # The contract table declares a category but it's not wired yet
             uncovered[kind] = sources
 
-    # ── 4. Assert coverage against the tracked PR3 gap CHECKLIST ───────────
-    # _KNOWN_PR3_GAPS is a CHECKLIST, not a permanent waiver: PR3 adds a
-    # qualified-name route in universal_dispatch for each op kind here and
-    # removes it from this set, driving the set to frozenset() = full D6
-    # totality. Exact-match is enforced so BOTH a NEW uncovered op kind
-    # (superset = an op PR3 would silently miss) AND a STALE entry (a gap PR3
-    # wired but forgot to delete here) go RED — the set can only shrink toward {}.
-    _KNOWN_PR3_GAPS = frozenset({"ask_user", "embed", "index_write", "skill_resolve"})
-    assert set(uncovered) == _KNOWN_PR3_GAPS, (
-        "universal_dispatch op-kind coverage drifted from the tracked PR3 gap "
-        "checklist (ADR-0035 D6).\n\n"
-        f"  uncovered now            : {sorted(uncovered)}\n"
-        f"  expected (PR3 checklist) : {sorted(_KNOWN_PR3_GAPS)}\n\n"
-        "If a NEW op kind is uncovered → add its qualified-name route in "
-        "universal_dispatch._OPERATION_RULES/_RESOURCE_RULES + _OP_KIND_CATEGORY. "
-        "If PR3 just WIRED a route → remove that kind from _KNOWN_PR3_GAPS "
-        "(the goal is frozenset())."
+    # ── 4. Assert against the PERMANENT intentional chat-router exclusion set ──
+    # ADR-0035 D6 decision (A), #1212 (durable record). These 4 op kinds are
+    # SKILL-INTERNAL run_op / control-flow ops with NO chat-router dispatch
+    # target — verified via get_default_registry().lookup() returning None for
+    # embed/index_write/skill_resolve (recall is the chat-exposed RAG macro;
+    # ask_user is control-flow). They execute in the op-loop via the OP registry
+    # (kind→IROp), not universal_dispatch (the chat-router table). So this is a
+    # PERMANENT exclusion set, NOT a shrink-to-{} checklist: universal_dispatch
+    # is the chat-router surface and skill-internal ops legitimately never join
+    # it. Exact-match is enforced so a NEW uncovered op kind absent from this set
+    # (= an unintentional gap) AND a STALE entry (an exclusion that gained a
+    # route) both go RED.
+    _INTENTIONAL_CHAT_ROUTER_EXCLUSIONS = frozenset({
+        "ask_user",       # control-flow (user-input request); not a dispatchable action
+        "embed",          # low-level RAG primitive; chat surface is the `recall` macro
+        "index_write",    # low-level RAG write primitive; not chat-exposed
+        "skill_resolve",  # skill-internal name resolution (preprocessor run_op)
+    })
+    assert set(uncovered) == _INTENTIONAL_CHAT_ROUTER_EXCLUSIONS, (
+        "universal_dispatch op-kind coverage drifted from the intentional "
+        "chat-router exclusion set (ADR-0035 D6 decision A, #1212).\n\n"
+        f"  uncovered now          : {sorted(uncovered)}\n"
+        f"  intentional exclusions : {sorted(_INTENTIONAL_CHAT_ROUTER_EXCLUSIONS)}\n\n"
+        "Every skill op kind must be chat-router-covered OR an explicit "
+        "intentional exclusion. A NEW uncovered op kind → it is either "
+        "chat-exposed (add its route in universal_dispatch._OPERATION_RULES/"
+        "_RESOURCE_RULES + _OP_KIND_CATEGORY) or skill-internal/control-flow "
+        "(add it here with a one-line rationale). A STALE entry (an exclusion "
+        "that gained a chat-router route) also fails — keep this set exact."
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — #1212 PR3. Bases on integration `feat/1212-tool-calls-unification` (PR2 #1221 merged). Two durable decisions on #1212 collapsed this PR to a **single guard-test reframe — zero catalog change, zero codemod, zero model change.**

## Decisions (durable on #1212, referenced here)
- **(A) intentional chat-router exclusion** ([#1212 comment](https://github.com/tya5/reyn/issues/1212#issuecomment-4597800703)): `embed`/`index_write`/`skill_resolve`/`ask_user` are skill-internal `run_op` / control-flow ops with **no chat-router dispatch target** (primary-verified: `get_default_registry().lookup()` returns None for the 3 RAG/skill ops). They execute in the op-loop via the OP registry (kind→IROp), not `universal_dispatch`. → no routes, no new chat tools, FP-0034 catalog untouched.
- **(i) D6 scope** ([#1212 comment](https://github.com/tya5/reyn/issues/1212#issuecomment-4597843994)): the axis is **LLM-emitted vs OS-deterministic**, not "wraps a real op". LLM-emitted ops were already unified to native `{name,arguments}` by the PR2 op-loop; `run_op` `op:` literals are OS-deterministic (skill-authored, never LLM-emitted) → kept as `{kind,...}`, like the `iterate`/`validate`/`python`/`lint_plan` DSL. Empirical: `RunOpStep.op` rejects `{name,arguments}` ("Unable to extract tag using discriminator 'kind'"), so a rewrite would be churn + a model change with no emission benefit.

## What changed (one file)
`tests/test_universal_dispatch_skill_op_coverage_1212.py`:
- `_KNOWN_PR3_GAPS` (shrink-to-`frozenset()` checklist) → **`_INTENTIONAL_CHAT_ROUTER_EXCLUSIONS`** (permanent set, per-op rationale).
- Invariant reframed: every skill op kind must be **chat-router-covered OR an explicit intentional exclusion**; the guard now catches an *unintentional* gap (a new uncovered op that is neither) AND a stale exclusion (one that gained a route).
- Module docstring: the OS-deterministic `run_op`-literal exclusion made explicit (parallels the DSL exclusion); the guard checks op-kind COVERAGE, not literal shape.

## Out of scope / follow-up
**(ii) literal-identity** (run_op also `{name,arguments}`, making skill→catalog promotion a pure copy) is an additive **user-vision follow-up** surfaced to the user — does not block PR3.

## Test plan
- [x] `pytest tests/test_universal_dispatch_skill_op_coverage_1212.py tests/test_universal_dispatch.py` — 105 passed
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` clean (Tier 2)
- [x] full config/tools-touch slice green (no catalog/runtime change → nothing else affected)

Refs #1212