### PR TITLE
feat(op-runtime): #1212 PR4 — op-native file verb granularity for allowed_ops (D7, mechanism)

### DIFF
--- a/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
+++ b/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
@@ -162,9 +162,21 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
 3. **PR3 — op-shape codemod (D6).** Deterministic `universal_dispatch` rewrite of the
    11 skill files' real ops to `{name, arguments}`; preprocessor/postprocessor DSL
    untouched. Mechanical — Sonnet-suitable, with an AST/round-trip guard test.
-4. **PR4 — allowed_ops tool-name granularity (D7).** Linter target swap + the 36-phase
-   kind→sub-tool expansion (behavior-preserving) + offer-layer `allowed_ops ∩ permission`
-   filter (D8 permission). Per-phase tightening deferred to a follow-up.
+4. **PR4 — allowed_ops op-native file verb granularity (D7).** Shipped scope =
+   the **mechanism only**: `file` (the lone op kind with a real tool-verb axis)
+   gains `file__<verb>` granularity — gating (`is_op_instance_allowed`, op-aware),
+   catalog (`file__verb` drops the implied `op`), conversion, and the linter
+   target swap (`ALL_TOOL_NAMES`). Coarse `file` stays behavior-preserving (all
+   verbs); all other kinds are single-verb (no-op); the chat-router taxonomy is
+   NOT adopted (decision A). **Deferred follow-ups** (#1212 rationale, tracked
+   pre-close): (a) **offer-layer `allowed_ops ∩ permission` filter (D8)** — there
+   is no clean kind-level permission-granted set at offer time (grants are
+   per-key, arg-dependent, interactive), and the enforce layer already gates, so
+   the offer-filter is marginal; (b) **per-phase frontmatter expansion** — under
+   the D7 mechanism a coarse `file` is identical to the all-verbs expansion
+   (cosmetic), and the only meaningful change is narrowing, which is
+   non-behavior-preserving = the deliberate per-phase tightening (= the
+   P4-precision win) phases opt into later.
 5. **PR5 — WAL/resume loop-adaptation + replay fixtures (D8).** Resume per op turn;
    **replay fixtures track the json-mode frame shape, not a tool_call structure**
    (frame-fed op-loop, D2-impl — the D8b provider-id normalization is moot), round

--- a/src/reyn/compiler/linter.py
+++ b/src/reyn/compiler/linter.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import jsonschema
 
-from reyn.op_runtime.registry import ALL_OP_KINDS as _KNOWN_OP_KINDS
+from reyn.op_runtime.registry import ALL_TOOL_NAMES as _KNOWN_ALLOWED_OPS_NAMES
 
 from .parser import _split_frontmatter, parse_artifact
 
@@ -156,12 +156,13 @@ def _lint_allowed_ops(path: Path, fm: dict) -> list[LintIssue]:
                 f"allowed_ops[{i}] must be a string op kind, got {type(val).__name__}",
             ))
             continue
-        if val not in _KNOWN_OP_KINDS:
+        if val not in _KNOWN_ALLOWED_OPS_NAMES:
             issues.append(LintIssue(
                 "warning", path,
-                f"allowed_ops[{i}]='{val}' is not a known Control IR op kind. "
-                f"Known kinds: {sorted(_KNOWN_OP_KINDS)}. "
-                f"Unknown kinds will be silently filtered out at runtime.",
+                f"allowed_ops[{i}]='{val}' is not a known Control IR op kind or "
+                f"file verb tool-name (e.g. file__read). "
+                f"Known names: {sorted(_KNOWN_ALLOWED_OPS_NAMES)}. "
+                f"Unknown names will be silently filtered out at runtime.",
             ))
         if val in seen:
             issues.append(LintIssue(

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -55,22 +55,44 @@ def _build_phase_tool_catalog(allowed_ops: set[str]) -> dict[str, dict]:
     Returns a dict[str, dict] in litellm tools= entry shape:
         {op_kind: {"function": {"name": op_kind, "parameters": <json schema>}}}
     """
+    from reyn.op_runtime.registry import split_tool_name
     from reyn.tools import get_default_registry
     registry = get_default_registry()
 
     catalog: dict[str, dict] = {}
-    for kind in allowed_ops:
+    for name in allowed_ops:
+        # #1212 PR4 (D7): a verb-granular file tool-name (file__read) resolves to
+        # the `file` schema; the verb is implied by the tool name, so its `op`
+        # field is dropped from the offered parameters (the conversion re-injects
+        # it). All other names are kinds (tool-name == kind).
+        kind, verb = split_tool_name(name)
         tool_def = registry.lookup(kind)
         if tool_def is None or tool_def.gates.phase != "allow":
-            catalog[kind] = {"function": {"name": kind}}
+            catalog[name] = {"function": {"name": name}}
             continue
-        catalog[kind] = {
+        params = dict(tool_def.parameters)
+        if verb is not None:
+            params = _drop_schema_property(params, "op")
+        catalog[name] = {
             "function": {
-                "name": kind,
-                "parameters": dict(tool_def.parameters),
+                "name": name,
+                "parameters": params,
             }
         }
     return catalog
+
+
+def _drop_schema_property(schema: dict, prop: str) -> dict:
+    """Return a copy of a JSON-schema object with ``prop`` removed from
+    ``properties`` and ``required`` (used to hide an implied field)."""
+    out = dict(schema)
+    props = out.get("properties")
+    if isinstance(props, dict) and prop in props:
+        out["properties"] = {k: v for k, v in props.items() if k != prop}
+    req = out.get("required")
+    if isinstance(req, list) and prop in req:
+        out["required"] = [r for r in req if r != prop]
+    return out
 
 
 class ControlIRExecutor:
@@ -447,10 +469,14 @@ class ControlIRExecutor:
         _registry = get_default_registry()
 
         # Lazy import to avoid module-init cycles.
-        from reyn.op_runtime.registry import is_op_allowed
+        # #1212 PR4 (D7): op-aware allowance — gates a file op by its verb
+        # (file__read) when allowed_ops is verb-granular, while a coarse `file`
+        # entry still allows every verb (behavior-preserving). Non-file ops are
+        # unchanged (delegates to is_op_allowed on op.kind).
+        from reyn.op_runtime.registry import is_op_instance_allowed
 
         for op_idx, op in enumerate(ops):
-            if allowed_ops is not None and not is_op_allowed(op.kind, allowed_ops):
+            if allowed_ops is not None and not is_op_instance_allowed(op, allowed_ops):
                 self.events.emit(
                     "control_ir_skipped",
                     kind=op.kind, reason="not_allowed_in_phase",

--- a/src/reyn/kernel/op_loop.py
+++ b/src/reyn/kernel/op_loop.py
@@ -17,6 +17,7 @@ import json
 
 from pydantic import TypeAdapter
 
+from reyn.op_runtime.registry import split_tool_name
 from reyn.schemas.models import ControlIROp
 
 _CONTROL_IR_ADAPTER: TypeAdapter = TypeAdapter(ControlIROp)
@@ -37,7 +38,7 @@ def tool_call_to_control_ir_op(tool_call: dict) -> ControlIROp:
     ``ActOutput.model_validate`` failure path).
     """
     fn = tool_call.get("function") or {}
-    kind = fn.get("name") or ""
+    name = fn.get("name") or ""
     raw_args = fn.get("arguments")
     if isinstance(raw_args, str):
         args = json.loads(raw_args) if raw_args.strip() else {}
@@ -45,4 +46,9 @@ def tool_call_to_control_ir_op(tool_call: dict) -> ControlIROp:
         args = dict(raw_args)
     else:
         args = {}
+    # #1212 PR4 (D7): a verb-granular file tool-name (file__read) maps back to a
+    # `file` op with its implied `op` verb re-injected; a plain kind is unchanged.
+    kind, verb = split_tool_name(name)
+    if verb is not None:
+        args.setdefault("op", verb)
     return _CONTROL_IR_ADAPTER.validate_python({"kind": kind, **args})

--- a/src/reyn/op_runtime/registry.py
+++ b/src/reyn/op_runtime/registry.py
@@ -49,6 +49,7 @@ key off registry names.
 """
 from __future__ import annotations
 
+import typing as _t
 from enum import Enum
 
 from pydantic import BaseModel
@@ -262,3 +263,65 @@ def is_op_allowed(op_kind: str, allowed_ops: set[str] | frozenset[str]) -> bool:
         if fine_set is not None and op_kind in fine_set:
             return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# #1212 PR4 (D7): op-native file verb granularity
+# ---------------------------------------------------------------------------
+# `file` is the ONLY op kind with a genuine tool-verb axis (FileIROp.op:
+# read / write / edit / delete / glob / grep / …); every other op kind is
+# single-verb, so its tool-name == its kind (a no-op under granularity).
+# Decision (a), #1212: the chat-router taxonomy (web__fetch / mcp__call_tool)
+# is deliberately NOT adopted as the allowed_ops vocabulary — that is a separate
+# surface (PR3 decision A). The verb set is derived from the model so it never
+# drifts from FileIROp.
+_FILE_VERBS: frozenset[str] = frozenset(
+    a
+    for a in _t.get_args(OP_KIND_MODEL_MAP["file"].model_fields["op"].annotation)
+    if isinstance(a, str)
+)
+FILE_VERB_TOOL_NAMES: frozenset[str] = frozenset(f"file__{v}" for v in _FILE_VERBS)
+
+# Every name the linter / catalog may legitimately see in allowed_ops.
+ALL_TOOL_NAMES: frozenset[str] = ALL_OP_KINDS | FILE_VERB_TOOL_NAMES
+
+
+def op_tool_name(kind: str, op: str | None = None) -> str:
+    """Canonical op-native tool-name (D7).
+
+    ``file`` + a verb → ``file__<verb>``; every other kind → the kind itself
+    (single-verb, tool-name == kind).
+    """
+    if kind == "file" and op:
+        return f"file__{op}"
+    return kind
+
+
+def split_tool_name(tool_name: str) -> tuple[str, str | None]:
+    """Inverse of :func:`op_tool_name`: split a tool-name into ``(kind, verb)``.
+
+    ``"file__read"`` → ``("file", "read")``; a plain kind (``"web_fetch"``) →
+    ``("web_fetch", None)``. Used by the op-loop catalog + conversion to map a
+    verb-granular file tool back to a ``file`` op with its ``op`` field.
+    """
+    if tool_name.startswith("file__"):
+        return "file", tool_name[len("file__"):]
+    return tool_name, None
+
+
+def is_op_instance_allowed(op: object, allowed_ops: set[str] | frozenset[str]) -> bool:
+    """Op-aware allowance (D7): gate a ControlIROp *instance* against an
+    ``allowed_ops`` set that may mix coarse kinds and file verb-level tool-names.
+
+    - **file op**: allowed iff coarse ``"file"`` is in ``allowed_ops`` (legacy —
+      every verb, behavior-preserving for existing ``allowed_ops: [file]``
+      frontmatter) OR ``file__<op.op>`` is in ``allowed_ops`` (per-verb
+      tightening, the D7/P4 precision win — e.g. read but not delete).
+    - **any other op**: delegates to ``is_op_allowed(op.kind, ...)`` unchanged.
+    """
+    kind = getattr(op, "kind", None) or ""
+    if kind == "file":
+        if "file" in allowed_ops:
+            return True
+        return op_tool_name("file", getattr(op, "op", None)) in allowed_ops
+    return is_op_allowed(kind, allowed_ops)

--- a/tests/test_allowed_ops_file_verb_granularity_1212.py
+++ b/tests/test_allowed_ops_file_verb_granularity_1212.py
@@ -1,0 +1,160 @@
+"""Tier 2: #1212 PR4 (D7) — op-native file verb granularity in allowed_ops.
+
+`file` is the only op kind with a genuine tool-verb axis (FileIROp.op), so PR4
+gives `allowed_ops` verb granularity for it alone: `file__read` allows read but
+NOT delete (the P4-precision win), while a coarse `file` entry keeps allowing
+every verb (behavior-preserving for existing frontmatter). Every other op kind
+is single-verb (tool-name == kind, unchanged). The chat-router taxonomy is NOT
+adopted (decision A — phase-op surface stays separate from the chat router).
+
+Real `ControlIRExecutor` + real `PermissionResolver` + real `Workspace` for the
+end-to-end gating proof (the allowed_ops frontend filter precedes dispatch, so a
+real resolver — not `permission_resolver=None` auto-permit — keeps the test
+honest). Registry / catalog / conversion / linter units use real objects too.
+No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from reyn.compiler.linter import _lint_allowed_ops
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor, _build_phase_tool_catalog
+from reyn.kernel.op_loop import tool_call_to_control_ir_op
+from reyn.op_runtime.registry import (
+    FILE_VERB_TOOL_NAMES,
+    is_op_instance_allowed,
+    op_tool_name,
+    split_tool_name,
+)
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.schemas.models import FileIROp, WebFetchIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _make_executor(tmp_path: Path) -> tuple[ControlIRExecutor, EventLog]:
+    events = EventLog()
+    ws = Workspace(events=events)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    executor = ControlIRExecutor(
+        workspace=ws, events=events, permission_resolver=resolver,
+        skill_name="pr4_test", chain_id="chain-pr4",
+    )
+    return executor, events
+
+
+def _run(coro) -> Any:
+    return asyncio.run(coro)
+
+
+def _skipped_kinds(events: EventLog) -> list[str]:
+    return [
+        e.data.get("kind")
+        for e in events.all()
+        if e.type == "control_ir_skipped"
+        and e.data.get("reason") == "not_allowed_in_phase"
+    ]
+
+
+# ── Registry unit ───────────────────────────────────────────────────────────
+
+
+def test_file_verb_tool_names_derived_from_model() -> None:
+    """Tier 2: the file verb tool-names are derived from FileIROp.op (no drift)."""
+    assert "file__read" in FILE_VERB_TOOL_NAMES
+    assert "file__delete" in FILE_VERB_TOOL_NAMES
+    # round-trip: op_tool_name ∘ split_tool_name is identity for file verbs
+    for name in FILE_VERB_TOOL_NAMES:
+        kind, verb = split_tool_name(name)
+        assert kind == "file" and verb is not None
+        assert op_tool_name(kind, verb) == name
+
+
+def test_is_op_instance_allowed_coarse_and_granular() -> None:
+    """Tier 2: coarse `file` allows every verb (legacy); `file__read` allows read
+    but NOT delete (P4 precision); non-file ops delegate to kind membership."""
+    read = FileIROp(kind="file", op="read", path="x")
+    delete = FileIROp(kind="file", op="delete", path="x")
+    web = WebFetchIROp(kind="web_fetch", url="http://x")
+
+    # coarse — behavior-preserving for existing `allowed_ops: [file]`
+    assert is_op_instance_allowed(read, {"file"})
+    assert is_op_instance_allowed(delete, {"file"})
+    # granular — the read-but-not-delete win
+    assert is_op_instance_allowed(read, {"file__read"})
+    assert not is_op_instance_allowed(delete, {"file__read"})
+    # non-file unchanged
+    assert is_op_instance_allowed(web, {"web_fetch"})
+    assert not is_op_instance_allowed(web, {"web_search"})
+
+
+# ── End-to-end gating through the real executor ──────────────────────────────
+
+
+def test_file_verb_gating_end_to_end(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the allowed_ops frontend filter enforces file verb granularity via
+    the real executor — file__read admits a read op and skips a delete op, while
+    a coarse `file` entry admits the delete (behavior-preserving)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "hello.txt").write_text("hi")
+    decl = PermissionDecl()
+    read = FileIROp(kind="file", op="read", path="hello.txt")
+    delete = FileIROp(kind="file", op="delete", path="hello.txt")
+
+    # granular allow-read: read NOT skipped, delete skipped
+    ex1, ev1 = _make_executor(tmp_path)
+    _run(ex1.execute([read], phase="p", decl=decl, allowed_ops={"file__read"}))
+    assert "file" not in _skipped_kinds(ev1), "file__read must admit a read op"
+
+    ex2, ev2 = _make_executor(tmp_path)
+    _run(ex2.execute([delete], phase="p", decl=decl, allowed_ops={"file__read"}))
+    assert _skipped_kinds(ev2) == ["file"], "file__read must skip a delete op (P4 win)"
+
+    # coarse file: delete NOT skipped (legacy behavior-preserving)
+    ex3, ev3 = _make_executor(tmp_path)
+    _run(ex3.execute([delete], phase="p", decl=decl, allowed_ops={"file"}))
+    assert "file" not in _skipped_kinds(ev3), "coarse `file` must admit every verb"
+
+
+# ── Catalog + conversion (op-loop offer) ─────────────────────────────────────
+
+
+def test_catalog_file_verb_drops_implied_op(tmp_path: Path) -> None:
+    """Tier 2: a file__read catalog tool carries the file schema with `op` dropped
+    (the verb is implied by the name); coarse `file` keeps `op`; web_fetch is a
+    plain kind-level tool."""
+    catalog = _build_phase_tool_catalog({"file__read", "file", "web_fetch"})
+    fr_props = catalog["file__read"]["function"]["parameters"]["properties"]
+    coarse_props = catalog["file"]["function"]["parameters"]["properties"]
+    assert "op" not in fr_props, "file__read implies op=read; op must be dropped"
+    assert "op" in coarse_props, "coarse file keeps the op selector"
+    assert catalog["web_fetch"]["function"]["name"] == "web_fetch"
+
+
+def test_conversion_file_verb_injects_op() -> None:
+    """Tier 2: a file__read tool_call converts to FileIROp(op=read); a coarse
+    file tool_call keeps the op carried in its arguments."""
+    op = tool_call_to_control_ir_op(
+        {"function": {"name": "file__read", "arguments": '{"path": "x.py"}'}}
+    )
+    assert isinstance(op, FileIROp) and op.op == "read" and op.path == "x.py"
+    coarse = tool_call_to_control_ir_op(
+        {"function": {"name": "file", "arguments": '{"op": "write", "path": "y", "content": "z"}'}}
+    )
+    assert isinstance(coarse, FileIROp) and coarse.op == "write"
+
+
+# ── Linter ───────────────────────────────────────────────────────────────────
+
+
+def test_linter_accepts_file_verb_warns_unknown() -> None:
+    """Tier 2: the linter accepts file__read (a known verb tool-name) and warns on
+    an invented file verb."""
+    ok = _lint_allowed_ops(Path("p.md"), {"allowed_ops": ["file__read", "file", "web_fetch"]})
+    assert ok == [], f"known names must not warn, got {ok}"
+    bad = _lint_allowed_ops(Path("p.md"), {"allowed_ops": ["file__bogus"]})
+    assert any("file__bogus" in i.message for i in bad), "unknown verb tool-name must warn"


### PR DESCRIPTION
**[e2e-coder]** — #1212 PR4. Bases on integration `feat/1212-tool-calls-unification` (PR3 #1222 merged). Ships the **D7 mechanism only** per lead-coder's approved scope-trim; D8 + frontmatter expansion are deferred follow-ups ([#1212 rationale](https://github.com/tya5/reyn/issues/1212#issuecomment-4597948780)).

## Decision (durable on #1212)
**(a) op-native, file-centric granularity** ([#1212](https://github.com/tya5/reyn/issues/1212#issuecomment-4597899372)): `file` is the **only** op kind with a genuine tool-verb axis (`FileIROp.op`: read/write/edit/delete/glob/grep/…). So `allowed_ops` gains `file__<verb>` granularity for `file` alone; every other kind is single-verb (tool-name == kind, no-op). The `universal_dispatch` chat-router taxonomy is **not** adopted (would re-conflate the chat-router ↔ phase-op surfaces that PR3 decision A separated).

## Hunks (per-hunk review order)
1. **registry.py** — `FILE_VERB_TOOL_NAMES` (derived from `FileIROp.op` so it never drifts), `ALL_TOOL_NAMES`, `op_tool_name` / `split_tool_name`, and **`is_op_instance_allowed`** (op-aware: a file op is gated by its verb when `allowed_ops` is granular; a coarse `file` entry still allows every verb = behavior-preserving; non-file delegates to `is_op_allowed` unchanged).
2. **control_ir_executor.py** — gating call `is_op_allowed(op.kind, …)` → `is_op_instance_allowed(op, …)`; `_build_phase_tool_catalog` resolves `file__<verb>` to the file schema with the implied `op` field dropped (new `_drop_schema_property` helper).
3. **op_loop.py** — conversion: `file__<verb>` tool_call → `FileIROp(op=<verb>)`; coarse `file` unchanged.
4. **linter.py** — `allowed_ops` validated against `ALL_TOOL_NAMES` (kinds ∪ `file__<verb>`).

## Behavior preservation
Existing `allowed_ops: [file]` frontmatter is **unchanged** in behavior — coarse `file` allows every verb (verified: coarse `{file}` ≡ all-10-verbs expansion). Non-file kinds are untouched. The P4-precision win (`file__read` admits read, skips delete) is *available* but opt-in per phase.

## Deferred (approved follow-ups, #1212 rationale)
- **D8 offer-layer `allowed_ops ∩ permission` filter** — no clean kind-level permission-granted set at offer time (grants are per-key/arg-dependent/interactive); enforce layer already gates; marginal value.
- **Per-phase frontmatter expansion** — cosmetic under D7 (coarse ≡ all-verbs); the real value is per-phase narrowing = non-behavior-preserving tightening, opted into individually.

## Test plan
- [x] `tests/test_allowed_ops_file_verb_granularity_1212.py` — 6 passed: end-to-end gating via **real `ControlIRExecutor` + real `PermissionResolver`** (read admitted, delete skipped under `file__read`; coarse `file` admits delete), registry/catalog/conversion/linter units
- [x] broad pre-PR `pytest` slice (executor/permission/linter/op-loop/registry/skill/preprocessor/expander/loader + #1212 wave) — **719 passed**
- [x] `ruff check` clean on all changed files
- [x] `test_tier_audit.py --strict` clean (Tier 2)

Refs #1212