### PR TITLE
feat(op-loop): #1212 PR5 — resume semantics decision B (document + pin, last code PR)

### DIFF
--- a/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
+++ b/docs/deep-dives/decisions/0035-phase-tool-calls-unification.md
@@ -177,16 +177,16 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
    (cosmetic), and the only meaningful change is narrowing, which is
    non-behavior-preserving = the deliberate per-phase tightening (= the
    P4-precision win) phases opt into later.
-5. **PR5 — WAL/resume loop-adaptation + replay fixtures (D8).** Resume per op turn;
-   **replay fixtures track the json-mode frame shape, not a tool_call structure**
-   (frame-fed op-loop, D2-impl — the D8b provider-id normalization is moot), round
-   event carry. **Required scope
-   item — act-turn memo decision** (carried from PR2, see Open items): PR2 ships the
-   op-loop's per-tool-turn LLM call (`LLMCallRecorder.call_tools`) WITHOUT decide-memo
-   (model-resolution + budget + cost-record only); PR5 MUST decide whether act turns
-   are memoized for deterministic replay (json-mode-equal crash-recovery guarantee) or
-   left as re-decide-on-resume (weaker, divergence caveat below). Lead-coder leans
-   memoize-for-parity.
+5. **PR5 — op-loop resume semantics: decision (B), documented + pinned.** Shipped
+   scope = **document the resume guarantee** (re-decide-on-resume accepted; the
+   op-execution layer stays WAL-protected via `dispatch_tool`, only a divergent
+   re-decide re-executes) **as opt-in-safe, + a resume test pinning the guarantee
+   boundary** (deterministic re-decide → memo-hit / no re-execution; divergent →
+   re-execute). No new replay fixtures: the op-loop is **frame-fed** (D2-impl — provider
+   tool_call-id normalization is moot, replays like json-mode frame replay), and PR2
+   already covers gate-on/off. The **deterministic act-turn memo (A)** is **deferred +
+   HARD-GATED on op-loop production-enablement** (see Open items — the op-loop is not
+   production-reachable today, so (A) now = YAGNI; it MUST land before any prod opt-in).
 
 ## Open items / risks
 
@@ -203,13 +203,28 @@ docs (no PoC needed). The capability cache (D5) is an optimization over a proven
   like json-mode frame replay, with no provider-id normalization needed. Retained
   here only as the rationale trail; PR5 replay fixtures track the json-mode frame
   shape, not a tool_call structure.
-- **Op-loop act-turn memo / resume divergence (PR2→PR5)**: PR2's `call_tools` skips
-  decide-memo — correct for normal op-loop operation (memo only matters on
-  re-run/resume). But on *resume*, an un-memoized act turn is **re-decided** by the
-  model, which may pick a *different* op than the original run. `dispatch_tool`'s WAL
-  memo is keyed on op+args (`control_ir_executor.py:128`), so a divergent re-decide
-  misses the memo and the op **re-executes** (its side-effect lands outside WAL
-  protection) — a weaker crash-recovery guarantee than json-mode (decide memoized →
-  deterministic control_ir replay → op WAL replay). PR5 decides: memoize act turns for
-  json-mode-equal determinism (lead-coder lean) vs accept re-decide divergence with a
-  documented caveat. Un-opted skills are unaffected (json-mode unchanged).
+- **Op-loop act-turn memo / resume divergence (PR2→PR5) — RESOLVED (B), PR5.**
+  PR2's `call_tools` skips decide-memo — correct for normal op-loop operation (memo
+  only matters on re-run/resume). On *resume* an un-memoized act turn is **re-decided**
+  by the model, which may pick a *different* op than the original run. `dispatch_tool`'s
+  WAL memo is keyed on op+args (`control_ir_executor.py:128`), so a *deterministic*
+  re-decide (same op+args) memo-HITS — the op-execution layer stays WAL-protected, no
+  re-execution; only a *divergent* re-decide misses the memo and **re-executes** the new
+  op (its side-effect lands outside WAL protection) — a weaker crash-recovery guarantee
+  than json-mode (decide memoized → deterministic control_ir replay → op WAL replay).
+
+  **Decision (B)** (#1212, PR5): **accept re-decide-on-resume + document the weaker
+  guarantee as opt-in-safe; defer the deterministic act-turn memo (A) to op-loop
+  production-enablement.** Rationale: the op-loop is **not production-reachable** — no
+  caller threads `tool_calls_op_loop_skills` into `OSRuntime` yet (only tests construct
+  it), so op-loop resume cannot occur in production and the gap has zero current impact.
+  Adding (A) now = YAGNI for an unreachable path. Un-opted skills are unaffected
+  (json-mode unchanged).
+
+  **★ HARD GATE**: (A) deterministic act-turn memo (memoize `call_tools` parallel to
+  `call` → tool_call-sequence replay → `dispatch_tool` memo match → no op re-execution)
+  is a **hard gate for op-loop production-enablement**: the op-loop MUST NOT ship to
+  production (i.e. the gate-threading + opt-in of a real skill) without (A) landing
+  first, else a divergent re-decide could re-run a side-effecting op outside WAL
+  protection. Tracked on the op-loop-enablement issue alongside the other deferred items
+  (D8 offer∩permission, per-phase tightening, (ii) literal-identity).

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -469,7 +469,20 @@ class PhaseExecutor:
         the path is opt-in): the on-demand ``compact`` op, the max-act-turns safety
         intervention (``handle_limit_exceeded``), and rollback-reason injection into
         act turns are json-mode-only here — the op-loop caps act turns then forces the
-        json transition. Act-turn LLM memo / resume divergence = PR5 (ADR Open items).
+        json transition.
+
+        RESUME SEMANTICS (#1212 PR5, decision B). ``call_tools`` skips LLM memo/WAL, so
+        on crash-resume an act turn is **re-decided** (the LLM is re-called) rather than
+        replayed. The op-EXECUTION layer is still WAL-protected: ``dispatch_tool``
+        memoizes each op on (op+args), so a *deterministic* re-decide (same op) memo-hits
+        and does NOT re-execute. Only a *divergent* re-decide (different op) misses the
+        memo and re-executes the new op (its side-effect lands outside WAL protection) —
+        a weaker crash-recovery guarantee than json-mode, accepted as opt-in-safe because
+        the op-loop is not production-reachable (no caller threads
+        ``tool_calls_op_loop_skills`` into the runtime). **HARD GATE**: the deterministic
+        act-turn memo (A) — memoize ``call_tools`` parallel to ``call`` so the tool_call
+        sequence replays exactly — MUST land before any production op-loop opt-in. See
+        ADR-0035 Open items.
         """
         from reyn.kernel.control_ir_executor import _build_phase_tool_catalog
         from reyn.kernel.op_loop import tool_call_to_control_ir_op

--- a/tests/test_op_loop_resume_memo_1212.py
+++ b/tests/test_op_loop_resume_memo_1212.py
@@ -1,0 +1,172 @@
+"""Tier 2: #1212 PR5 — op-loop resume semantics (decision B).
+
+PR5 decision (B): the op-loop accepts re-decide-on-resume (``call_tools`` is not
+LLM-memoized) but the op-EXECUTION layer stays WAL-protected — ``dispatch_tool``
+memoizes each op on (op_invocation_id + args_hash), so a *deterministic*
+re-decide (the model re-emits the same op) memo-HITS and does NOT re-execute the
+side effect. This test pins that guarantee boundary:
+
+  - the op-loop's act-turn op participates in ``dispatch_tool`` resume memo (a
+    matching CommittedStep → ``step_memoized``, no re-execution), AND
+  - ``call_tools`` IS re-invoked on resume (the act turn is re-decided, not
+    replayed) — the documented weaker guarantee that (A), the deterministic
+    act-turn memo, is HARD-GATED to land before any production op-loop opt-in.
+
+Real ``OSRuntime`` + real ``ControlIRExecutor`` + real WAL (``StateLog``); the
+only scripted seam is the module-level ``call_llm`` / ``call_llm_tools`` provider
+boundary (the sanctioned pattern, not a collaborator mock). The ResumePlan is
+built from the run-1 WAL committed steps.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import reyn.kernel.llm_call_recorder as lcr
+from reyn.events.state_log import StateLog
+from reyn.kernel.runtime import OSRuntime
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.skill.skill_resume_analyzer import CommittedStep, ResumePlan
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["file"],
+    )
+    return Skill(
+        name="op_loop_resume", entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _tool_result(tool_calls: list) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls,
+        finish_reason="tool_calls" if tool_calls else "stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+class _OpThenStop:
+    """Deterministic op-loop script: turn 1 emits a file write op, turn 2 stops
+    (→ json decide). Fresh instance per run so the turn counter resets; identical
+    output on every run (deterministic re-decide)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, *a, **k):  # noqa: ANN002, ANN003
+        self.calls += 1
+        if self.calls == 1:
+            return _tool_result([{
+                "id": "c1", "type": "function",
+                "function": {
+                    "name": "file",
+                    "arguments": '{"op": "write", "path": "out.txt", "content": "hi"}',
+                },
+            }])
+        return _tool_result([])
+
+
+def _finish_llm():
+    async def _f(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(
+            data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+    return _f
+
+
+def _committed_steps_from_wal(state_log: StateLog) -> list[CommittedStep]:
+    """Build CommittedSteps from the run-1 WAL step_completed entries (= what the
+    resume coordinator would reconstruct), so run 2 resumes against them."""
+    steps: list[CommittedStep] = []
+    for e in state_log.iter_from(0):
+        if e["kind"] != "step_completed":
+            continue
+        steps.append(CommittedStep(
+            op_invocation_id=e["op_invocation_id"],
+            op_kind=e.get("op_kind", ""),
+            phase=e["phase"],
+            args_hash=e.get("args_hash", ""),
+            seq=e.get("seq", 0),
+            result=e.get("result"),
+            usage=e.get("usage"),
+        ))
+    return steps
+
+
+def test_op_loop_op_memoized_on_resume_act_turn_re_decided(tmp_path, monkeypatch) -> None:
+    """Tier 2: on resume the op-loop re-decides (call_tools re-invoked) but its
+    file op memo-HITS through dispatch_tool (step_memoized, no re-execution) —
+    decision B's guarantee boundary."""
+    monkeypatch.chdir(tmp_path)
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+
+    # ── Run 1: op-loop executes the file op, WAL records the step ─────────────
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    script1 = _OpThenStop()
+    monkeypatch.setattr(lcr, "call_llm_tools", script1)
+
+    sl1 = StateLog(wal)
+    rt1 = OSRuntime(
+        _skill(), model="stub/model", run_id="run_op_resume",
+        state_log=sl1, tool_calls_op_loop_skills=["op_loop_resume"],
+    )
+    r1 = asyncio.run(rt1.run({"type": "input", "data": {}}))
+    assert r1.ok, f"run 1 must complete; got {r1.status}"
+    assert script1.calls >= 1, "op-loop must have called call_tools in run 1"
+
+    committed = _committed_steps_from_wal(sl1)
+    op_steps = [s for s in committed if s.op_kind == "file"]
+    assert op_steps, f"run 1 WAL must hold a file op step; got {[s.op_kind for s in committed]}"
+
+    # ── Run 2: resume against run-1 steps; same deterministic script ──────────
+    sl2 = StateLog(wal)
+    plan = ResumePlan(
+        run_id="run_op_resume", skill_name="op_loop_resume",
+        skill_input={"type": "input", "data": {}}, current_phase="draft",
+        last_phase_artifact_path=None, awaiting_intervention_id=None,
+        committed_steps=committed,
+    )
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    script2 = _OpThenStop()  # fresh counter, identical (deterministic) output
+    monkeypatch.setattr(lcr, "call_llm_tools", script2)
+
+    rt2 = OSRuntime(
+        _skill(), model="stub/model", run_id="run_op_resume",
+        state_log=sl2, resume_plan=plan,
+        tool_calls_op_loop_skills=["op_loop_resume"],
+    )
+    r2 = asyncio.run(rt2.run({"type": "input", "data": {}}))
+    assert r2.ok, f"resume must complete; got {r2.status}"
+
+    # The op-EXECUTION layer is WAL-protected: the FILE op (not just the decide
+    # llm) memo-hits on resume → deterministic re-decide does not re-execute.
+    file_memos = [
+        e for e in rt2.events.all()
+        if e.type == "step_memoized" and e.data.get("tool") == "file"
+    ]
+    assert file_memos, (
+        "the op-loop's file op must memo-hit dispatch_tool on resume (decision B "
+        "safety: a deterministic re-decide does not re-execute the side effect); "
+        f"step_memoized events={[e.data.get('tool') or e.data.get('op_kind') for e in rt2.events.all() if e.type == 'step_memoized']}"
+    )
+    # The documented weaker guarantee: the act turn is RE-DECIDED, not replayed.
+    assert script2.calls >= 1, (
+        "call_tools must be re-invoked on resume (act turns are not LLM-memoized "
+        "— the (A) deterministic act-turn memo is hard-gated for prod enablement)"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1212 PR5, the **last code PR** of the wave. Bases on integration `feat/1212-tool-calls-unification` (PR4 #1223 merged). Decision **(B)**: document the op-loop resume guarantee + pin it; defer the deterministic act-turn memo **(A)** as a HARD GATE on production-enablement.

## Decision (B) — durable on #1212
**Flow-trace finding** ([#1212](https://github.com/tya5/reyn/issues/1212#issuecomment-4598016844)): the op-loop is **not production-reachable** — no caller threads `tool_calls_op_loop_skills` into `OSRuntime` (config→runtime param exists, but only tests construct it; ChatSession→OSRuntime wiring was deferred to enablement in PR2). So op-loop *resume* cannot occur in production today, and the act-turn memo gap has **zero current impact**. Adding (A) now = YAGNI for an unreachable path.

## Guarantee boundary (documented + pinned)
`call_tools` skips LLM memo/WAL, so on resume an act turn is **re-decided** (LLM re-called). The op-EXECUTION layer is still WAL-protected: `dispatch_tool` memoizes on `(op_invocation_id + args_hash)`, so a **deterministic** re-decide memo-HITS (no re-execution); only a **divergent** re-decide misses the memo and re-executes the new op (side-effect outside WAL) — weaker than json-mode, accepted as opt-in-safe.

## ★ HARD GATE
**(A) deterministic act-turn memo** (memoize `call_tools` parallel to `call` → tool_call-sequence replay → `dispatch_tool` memo match → no op re-execution) **MUST land before any production op-loop opt-in.** Recorded in the ADR + to be tracked on the op-loop-enablement issue alongside the other deferred items (D8 offer∩permission, per-phase tightening, (ii) literal-identity).

## What changed (no mechanism change — document + pin)
- **ADR-0035** — Open-item resolved to "(B); (A) deferred + enablement-gated"; PR5 migration line; the HARD GATE.
- **`_run_op_loop` docstring** — resume semantics + hard gate.
- **Tier 2 test** — `tests/test_op_loop_resume_memo_1212.py`: real `OSRuntime` + real WAL (`StateLog`), ResumePlan built from run-1 committed steps; asserts the op-loop's file op memo-HITS `dispatch_tool` on resume (`step_memoized`, `tool=file` — no re-execution) while `call_tools` IS re-invoked (act turn re-decided). No new replay fixtures (frame-fed + PR2 gate coverage).

## Test plan
- [x] `tests/test_op_loop_resume_memo_1212.py` — 1 passed (real OSRuntime + real WAL + ResumePlan, file op memo-hit + call_tools re-decide)
- [x] regression slice (op_loop/resume/memo/dispatcher/control_ir + #1212 wave) — **418 passed**
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` clean (Tier 2)

Refs #1212