### PR TITLE
feat(enablement): #1212 (1/3) op-loop gate threading — config → all run paths

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -66,6 +66,7 @@ class Agent:
         run_id: str | None = None,
         environment_backend: "EnvironmentBackend | None" = None,
         sandbox_backend: "SandboxBackend | None" = None,
+        tool_calls_op_loop_skills: list[str] | None = None,
     ) -> None:
         self.model = model
         # FP-0008 #1132: the events audit log lives under state_dir. Honor an
@@ -80,6 +81,9 @@ class Agent:
         self._subscribers = list(subscribers or [])
         self._intervention_bus = intervention_bus
         self._shell_allowed = shell_allowed
+        # #1212: skills opted into the native-tools op-loop (config-driven gate,
+        # threaded to OSRuntime so the op-loop is reachable on the real run path).
+        self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
         self._safety = safety or SafetyConfig()
         self._resolver = resolver or ModelResolver({})
         self._permission_resolver = permission_resolver
@@ -214,6 +218,7 @@ class Agent:
             run_id=run_id,
             environment_backend=environment_backend,
             sandbox_backend=sandbox_backend,
+            tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
         )
 
     @property
@@ -307,6 +312,7 @@ class Agent:
             plan_step=plan_step,
             workspace_base_dir=self._workspace_base_dir,
             workspace_state_dir=self._workspace_state_dir,
+            tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,
         )
         return await self._runtime.run(initial_input, output_language=output_language)
 

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -190,6 +190,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 budget_tracker=budget_tracker,
                 sandbox_config=session_cfg.config.sandbox,
                 multimodal_config=session_cfg.config.multimodal,
+                tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
                 action_retrieval_config=session_cfg.config.action_retrieval,
                 embedding_config=session_cfg.config.embedding,
                 agent_id=session_cfg.config.agent.id,

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1222,6 +1222,7 @@ class ChatSession:
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
+        tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
         agent_id: str | None = None,
     ) -> None:
         """
@@ -1257,6 +1258,8 @@ class ChatSession:
         # through to spawned Agents AND to the router host adapter (=
         # chat-router web__fetch / file__read / mcp paths).
         self._multimodal_config = multimodal_config
+        # #1212: op-loop gate, threaded to Agents spawned for chat-run skills.
+        self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
         # Issue #383 PR-C — single MediaStore instance per ChatSession,
         # constructed from the multimodal config's storage dirs.
         # Subsequently threaded into spawned Agents (= for control-IR
@@ -3089,6 +3092,7 @@ class ChatSession:
             multimodal_config=self._multimodal_config,
             media_store=self._media_store,
             run_id=run_id,
+            tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,
         )
 
     async def _put_outbox(self, msg: OutboxMessage) -> None:

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -300,6 +300,7 @@ def run(args: argparse.Namespace) -> None:
             budget_tracker=budget_tracker,
             sandbox_config=session_cfg.config.sandbox,
             multimodal_config=session_cfg.config.multimodal,
+            tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,
             embedding_config=session_cfg.config.embedding,
             eager_embedding_build=getattr(args, "eager_embedding_build", False),

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -442,6 +442,7 @@ def _build_live_runner(agent_name: str):
                 budget_tracker=budget_tracker,
                 sandbox_config=config.sandbox,
                 multimodal_config=config.multimodal,
+                tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
                 action_retrieval_config=config.action_retrieval,
             )
             s.load_history()

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -411,6 +411,7 @@ def run_serve(args: argparse.Namespace) -> None:
             # ``noop``) never reaches the sandboxed_exec handler.
             sandbox_config=session_cfg.config.sandbox,
             multimodal_config=session_cfg.config.multimodal,
+            tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,
             embedding_config=session_cfg.config.embedding,
         )

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -118,8 +118,10 @@ class RunOrchestrator:
         caller: str,
         max_phase_visits: int,
         budget_tracker: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
+        tool_calls_op_loop_skills: list[str] | None = None,  # #1212: gate, propagated to sub-skills
     ) -> None:
         self._budget_tracker = budget_tracker
+        self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
         self._phase_executor = phase_executor
         self._skill = skill
         self._workspace = workspace
@@ -257,6 +259,7 @@ class RunOrchestrator:
             events=self._events,
             safety=self._safety,
             recorder=self._budget_tracker,
+            tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,  # #1212 sub-skill gate
             # #1190 stage (iii) Part 4: attribute skill_node adaptation to the
             # run's agent (caller "agents/<name>" → "<name>").
             recorder_agent=(

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -99,6 +99,9 @@ class OSRuntime:
         self._chain_id = chain_id
         self._budget_tracker = budget_tracker
         self._budget_skill_name = skill_name or skill.name
+        # #1212: retained so sub-skill runs (run_skill / @sub_skill nodes) inherit
+        # the same op-loop gate — a sub-skill named in the list also op-loops.
+        self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
         self.events = EventLog(
             subscribers=subscribers, run_id=run_id, plan_step=plan_step,
         )

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -320,6 +320,7 @@ class OSRuntime:
             caller=caller,
             max_phase_visits=self._max_phase_visits,
             budget_tracker=budget_tracker,  # #1190 stage (ii): skill_node_adapt cost recording
+            tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,  # #1212 sub-skill gate
         )
 
     # ── Backward-compat properties (FP-0020 Component A) ───────────────────

--- a/src/reyn/skill/skill_node_runner.py
+++ b/src/reyn/skill/skill_node_runner.py
@@ -96,6 +96,7 @@ async def execute_skill_node(
     limits: Any = None,
     recorder: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
     recorder_agent: str | None = None,  # #1190 stage (iii) Part 4: per-agent attribution
+    tool_calls_op_loop_skills: list[str] | None = None,  # #1212: gate inherited by the sub-skill
 ) -> tuple[dict, TokenUsage]:
     """
     Run a sub-app to completion and adapt its final_output to target_schema.
@@ -115,6 +116,7 @@ async def execute_skill_node(
         subscribers=subscribers,
         resolver=resolver,
         safety=limits,
+        tool_calls_op_loop_skills=tool_calls_op_loop_skills,
     )
     run_result = await sub_runtime.run(input_artifact, output_language=output_language)
     token_usage = sub_runtime._token_usage

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -267,6 +267,7 @@ def _get_registry():
                 # the runtime kept using Seatbelt.
                 sandbox_config=config.sandbox,
                 multimodal_config=config.multimodal,
+                tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
                 action_retrieval_config=config.action_retrieval,
                 embedding_config=config.embedding,
                 eager_embedding_build=_eager_embedding_build,

--- a/tests/test_op_loop_enablement_threading_1212.py
+++ b/tests/test_op_loop_enablement_threading_1212.py
@@ -1,0 +1,105 @@
+"""Tier 2: #1212 enablement — the op-loop gate threads config → Agent → OSRuntime.
+
+PR2 wired the op-loop gate at the OSRuntime↔PhaseExecutor seam but no production
+caller threaded `tool_calls_op_loop_skills` in — the op-loop was reachable only by
+constructing OSRuntime directly in a test. This pins the real-path wiring: a skill
+named in `config.tool_calls_op_loop_skills`, run via `Agent.from_config(config)`
+(the hub for swe_bench / run / cron / web / mcp / eval), actually runs the
+native-tools op-loop. A skill NOT in the list stays json-mode (unchanged).
+
+Real `Agent` + real `OSRuntime` via the public `Agent.from_config` + `agent.run`;
+the only scripted seam is the module-level `call_llm` / `call_llm_tools` provider
+boundary (the sanctioned pattern), not a collaborator mock.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import reyn.kernel.llm_call_recorder as lcr
+from reyn.agent import Agent
+from reyn.config import ReynConfig
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+
+_SKILL_NAME = "op_loop_thread"
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=[],
+    )
+    return Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _tool_result(tool_calls: list) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls,
+        finish_reason="tool_calls" if tool_calls else "stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+def _patch_llms(monkeypatch, tools_calls: list, decide_calls: list) -> None:
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        tools_calls.append(1)
+        return _tool_result([])  # no ops → straight to the json decide
+
+    async def _decide(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        decide_calls.append(1)
+        return LLMCallResult(data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10))
+
+    monkeypatch.setattr(lcr, "call_llm", _decide)
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+
+def test_from_config_gate_threads_to_op_loop(tmp_path, monkeypatch) -> None:
+    """Tier 2: a skill in config.tool_calls_op_loop_skills, run via Agent.from_config,
+    runs the op-loop (call_llm_tools invoked)."""
+    monkeypatch.chdir(tmp_path)
+    tools_calls: list[int] = []
+    decide_calls: list[int] = []
+    _patch_llms(monkeypatch, tools_calls, decide_calls)
+
+    config = ReynConfig(tool_calls_op_loop_skills=[_SKILL_NAME])
+    agent = Agent.from_config(config, shell_allowed=False, model="stub/model")
+    result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
+
+    assert result.ok, f"run must complete; got {result.status}"
+    assert tools_calls == [1], (
+        "config gate must thread Agent.from_config → OSRuntime → op-loop "
+        "(call_llm_tools invoked for the op-turn)"
+    )
+    assert decide_calls == [1], "op-loop decide uses the json-mode call"
+
+
+def test_from_config_unlisted_skill_stays_json_mode(tmp_path, monkeypatch) -> None:
+    """Tier 2: a skill NOT in the config list runs json-mode — call_llm_tools is
+    never invoked (zero-change for un-opted skills)."""
+    monkeypatch.chdir(tmp_path)
+    tools_calls: list[int] = []
+    decide_calls: list[int] = []
+    _patch_llms(monkeypatch, tools_calls, decide_calls)
+
+    config = ReynConfig(tool_calls_op_loop_skills=[])  # empty → nothing opted in
+    agent = Agent.from_config(config, shell_allowed=False, model="stub/model")
+    result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
+
+    assert result.ok, f"run must complete; got {result.status}"
+    assert tools_calls == [], "an unlisted skill must not invoke the native-tools path"


### PR DESCRIPTION
**[e2e-coder]** — #1212 production-enablement **PR 1 of 3** (user retracted the deferral: finish through to main). Bases on integration. Makes the op-loop **reachable on every real path a skill runs**, not just direct OSRuntime test construction.

## Flow-trace finding (scope narrowed)
The threading hub is **`Agent.from_config(config)`** — swe_bench (`eval_benchmark`), run, cron, web, mcp, eval all route through it. Only 2 OSRuntime sites exist (`agent.py` + `skill_node_runner`); ChatSession routes via Agent. So "wire ~10 entrypoints" collapses to: Agent (init/from_config/OSRuntime) + the 3-hop sub-skill chain + the chat ChatSession path.

## Hunks
1. **Agent** — `__init__` param + `from_config` threads `config.tool_calls_op_loop_skills` + Agent→OSRuntime pass (covers swe_bench + all `from_config` CLI/web entrypoints at once).
2. **Sub-skill propagation** — a nested `run_skill`/`@sub_skill` skill named in the gate also op-loops (deferring it would re-introduce the rejected deferral). 3-hop: OSRuntime stores → `RunOrchestrator` → `execute_skill_node` → sub-OSRuntime.
3. **Chat path** — `ChatSession` param + the spawned Agent gets the gate; the 5 ChatSession sites (chainlit / web / dogfood / mcp / chat) pass `config.tool_calls_op_loop_skills`.

→ A skill in `config.tool_calls_op_loop_skills` (e.g. `reyn.yaml: tool_calls_op_loop_skills: [swe_bench]`) now op-loops from top-level, sub-skill, and chat paths.

## Test plan
- [x] `test_op_loop_enablement_threading_1212.py` (Tier 2) — a skill in `config.tool_calls_op_loop_skills` run via `Agent.from_config` runs the op-loop (`call_llm_tools` invoked); an unlisted skill stays json-mode. Real Agent + OSRuntime via public `from_config`/`run`; provider boundary scripted, no mocks.
- [x] broad regression (chat/agent/runtime/session/skill_node/op_loop/cli) — **1840 passed**
- [x] `ruff` clean · `test_tier_audit --strict` clean (Tier 2)
- [x] `chainlit_app` edit compiles (chainlit = optional dep, absent locally; CI has it)

Next: PR 2/3 = (A) crash-recovery memo (resolves the HARD GATE) → PR 3/3 = reasoning-continuity. Then ADR-Accepted (reflecting all 3) → integration→main.

Refs #1212 #1225