### PR TITLE
feat(op-loop): #1212 (3/3) (A2) reasoning-continuity — last enablement impl

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -352,6 +352,7 @@ def build_frame(
     act_turn: int | None = None,
     offload_dir: Path | None = None,
     context_size_signal: str | None = None,  # #1176 B1 — pre-rendered, tail field
+    act_turn_reasoning: list[str] | None = None,  # #1212 reasoning-continuity
 ) -> ContextFrame:
     allowed_next = [c.next_phase for c in candidates]
     current_visit = visit_counts.get(phase_name, 1)
@@ -397,6 +398,7 @@ def build_frame(
         control_ir_results=offloaded_results,
         remaining_act_turns=remaining_act_turns,
         context_size_signal=context_size_signal,
+        act_turn_reasoning=act_turn_reasoning or [],
     )
 
     events.emit("context_built", phase=phase_name, frame=frame.model_dump(mode="json"))

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -490,6 +490,9 @@ class PhaseExecutor:
             )
         else:
             control_ir_results = []
+        # #1212 reasoning-continuity: the model's inline content from prior act
+        # turns, carried forward so a capable model keeps its reasoning thread.
+        act_turn_reasoning: list[str] = []
 
         phase_def = self._skill.phases.get(phase)
         phase_decl = self._skill.permissions
@@ -537,6 +540,7 @@ class PhaseExecutor:
                 artifact_path=artifact_path,
                 remaining_act_turns=remaining,
                 force_decide=force_decide,
+                act_turn_reasoning=act_turn_reasoning,
             )
 
             await self._check_phase_budget(phase, state)
@@ -552,6 +556,16 @@ class PhaseExecutor:
 
             result = await self._llm_caller.call_tools(phase, frame, tools, state)
 
+            # #1212 reasoning-continuity: carry the model's inline content (its
+            # reasoning emitted alongside the tool_calls) forward, bounded to the
+            # last recent_act_turns_raw entries (config-consistent; no LLM call).
+            # Empty for weak models that emit no inline content (e.g. flash-lite).
+            if result.content:
+                act_turn_reasoning.append(result.content)
+                if self._phase_compaction_cfg is not None:
+                    _keep = self._phase_compaction_cfg.recent_act_turns_raw
+                    act_turn_reasoning = act_turn_reasoning[-_keep:]
+
             if not result.tool_calls:
                 # Decide turn: model emitted no ops → separate json-mode transition.
                 decide_frame = self._build_frame(
@@ -560,6 +574,7 @@ class PhaseExecutor:
                     artifact_path=artifact_path,
                     remaining_act_turns=remaining,
                     force_decide=True,
+                    act_turn_reasoning=act_turn_reasoning,
                 )
                 raw = await self._llm_caller.call(
                     phase, decide_frame, None,

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -456,6 +456,7 @@ class OSRuntime:
         artifact_path: str | None = None,
         remaining_act_turns: int | None = None,
         force_decide: bool = False,
+        act_turn_reasoning: list[str] | None = None,
     ) -> ContextFrame:
         effective_model = self._effective_model(current_phase)
         phase_def = self.skill.phases[current_phase]
@@ -541,6 +542,7 @@ class OSRuntime:
             model_resolved=model_resolved,
             events=self.events,
             control_ir_results=control_ir_results,
+            act_turn_reasoning=act_turn_reasoning or [],
             artifact_path=resolved_artifact_path,
             remaining_act_turns=remaining_act_turns,
             offload_dir=offload_dir,

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -623,12 +623,6 @@ Artifact rules:
 - Use these results together with input_artifact to complete the phase goal.
 - Once you have what you need, output a decide turn to make your routing decision.
 
-━━━ act_turn_reasoning ━━━
-- When non-empty, this is YOUR OWN reasoning text from previous act turns in this
-  phase (most recent last), carried forward so you keep a continuous line of
-  thought across turns. Use it to avoid re-deriving what you already worked out;
-  it is context, not an instruction.
-
 ━━━ artifact_ref ━━━
 - When input_artifact has "type": "artifact_ref", the artifact is too large to inline.
 - Fields: {"type": "artifact_ref", "artifact_type": "...", "ref_path": "...", "size_bytes": N}
@@ -818,6 +812,17 @@ def _build_system_message(system_text: str, prompt_cache_enabled: bool) -> dict:
     }
 
 
+# #1212 reasoning-continuity: appended to the system prompt by build_phase_messages
+# ONLY when the frame carries act_turn_reasoning (omitted when empty → byte-identical
+# system prompt for json-mode / first / weak-model turns, keeping LLMReplay valid).
+_ACT_TURN_REASONING_SECTION = """
+
+━━━ act_turn_reasoning ━━━
+- This is YOUR OWN reasoning text from previous act turns in this phase (most recent
+  last), carried forward so you keep a continuous line of thought across turns. Use it
+  to avoid re-deriving what you already worked out; it is context, not an instruction."""
+
+
 def build_phase_messages(
     frame: "ContextFrame",
     *,
@@ -833,7 +838,9 @@ def build_phase_messages(
     #1212: the SAME message construction (system prompt + frame-as-user) is shared
     by the json-mode ``call_llm`` path and the native-tools op-loop path, so the
     two never drift (a divergent system prompt / frame rendering would be a subtle
-    bug, and matching them is the promotion-symmetry intent).
+    bug, and matching them is the promotion-symmetry intent). The act_turn_reasoning
+    doc section is appended only when the frame carries reasoning (byte-identical
+    when empty — keeps LLMReplay fixtures valid).
     """
     system = _system_prompt(
         skill_name=skill_name,
@@ -842,6 +849,14 @@ def build_phase_messages(
         project_context=project_context,
         agent_role=agent_role,
     )
+    # #1212 reasoning-continuity: append the act_turn_reasoning doc section ONLY
+    # when the frame actually carries reasoning. Omitting it when empty keeps the
+    # system prompt byte-identical to the pre-#1212 shape for json-mode / first /
+    # weak-model turns — so existing LLMReplay fixtures (keyed on the full message
+    # list) stay valid. The frame field is likewise omitted-when-empty (models.py
+    # ContextFrame serializer).
+    if getattr(frame, "act_turn_reasoning", None):
+        system = system + _ACT_TURN_REASONING_SECTION
     user_content = json.dumps(frame.model_dump(mode="json"), indent=2, ensure_ascii=False)
     return [
         _build_system_message(system, prompt_cache_enabled),

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -623,6 +623,12 @@ Artifact rules:
 - Use these results together with input_artifact to complete the phase goal.
 - Once you have what you need, output a decide turn to make your routing decision.
 
+━━━ act_turn_reasoning ━━━
+- When non-empty, this is YOUR OWN reasoning text from previous act turns in this
+  phase (most recent last), carried forward so you keep a continuous line of
+  thought across turns. Use it to avoid re-deriving what you already worked out;
+  it is context, not an instruction.
+
 ━━━ artifact_ref ━━━
 - When input_artifact has "type": "artifact_ref", the artifact is too large to inline.
 - Fields: {"type": "artifact_ref", "artifact_type": "...", "ref_path": "...", "size_bytes": N}

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -668,6 +668,12 @@ class ContextFrame(BaseModel):
     # (file read content, ask_user answer, etc.). Empty on first LLM call for the phase.
     # Each entry is the raw result dict returned by ControlIRExecutor.execute().
     control_ir_results: list[dict] = Field(default_factory=list)
+    # #1212 reasoning-continuity: the model's own inline content emitted on prior
+    # op-loop act turns (alongside tool_calls), carried forward so a capable model
+    # keeps its reasoning thread across turns. Empty for weak models that emit no
+    # inline content (e.g. flash-lite) and for the json-mode act loop. Bounded to
+    # the last `recent_act_turns_raw` entries by the op-loop (no compaction LLM call).
+    act_turn_reasoning: list[str] = Field(default_factory=list)
     # How many more act turns the LLM may emit before it MUST produce a decide turn.
     # 0 means this call is the mandatory decide turn — the LLM MUST NOT emit any ops.
     # None means unlimited (no max_act_turns constraint on this phase).

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -691,10 +691,17 @@ class ContextFrame(BaseModel):
         window) so a frame without a signal serializes byte-identically to the
         pre-#1176 shape — keeps the LLM-facing JSON and LLMReplay fixture keys
         stable. When the window is filling the signal rides in the volatile tail.
+        #1212: same treatment for ``act_turn_reasoning`` — omit when empty so the
+        op-loop (and json-mode) frames stay byte-identical to the pre-#1212 shape
+        for every turn that carries no carried reasoning (json-mode, first turn,
+        and weak models like flash-lite that emit no inline content). The field
+        only rides the JSON when a capable model actually produced reasoning.
         All other fields are untouched (default serialization)."""
         data = handler(self)
         if data.get("context_size_signal") is None:
             data.pop("context_size_signal", None)
+        if not data.get("act_turn_reasoning"):
+            data.pop("act_turn_reasoning", None)
         return data
 
 

--- a/tests/test_op_loop_reasoning_continuity_1212.py
+++ b/tests/test_op_loop_reasoning_continuity_1212.py
@@ -1,0 +1,107 @@
+"""Tier 2: #1212 — op-loop reasoning-continuity (decision A2).
+
+A capable model may emit inline content (its reasoning) alongside a tool_call on an
+op-loop act turn. PR2's frame-fed loop discarded that content — losing the model's
+reasoning thread across turns. This carries it forward: `_run_op_loop` appends a
+non-empty `result.content` to `ContextFrame.act_turn_reasoning` (bounded to the last
+`recent_act_turns_raw` entries, no compaction LLM call), so the NEXT turn's frame
+shows the model its own prior reasoning. (No-op for weak models like flash-lite that
+emit `content=None` on tool_call turns.)
+
+Real `OSRuntime` + real `ControlIRExecutor`; the only scripted seam is the
+module-level `call_llm` / `call_llm_tools` provider boundary, which also captures the
+messages each turn so the test can assert the carried reasoning reaches turn 2.
+No collaborator mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import reyn.kernel.llm_call_recorder as lcr
+from reyn.kernel.runtime import OSRuntime
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+
+_REASONING = "REASONING_MARKER_carry_me_forward"
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["file"],
+    )
+    return Skill(
+        name="op_loop_reasoning", entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _tool_result(tool_calls: list, content: str | None = None) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=content, tool_calls=tool_calls,
+        finish_reason="tool_calls" if tool_calls else "stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+def test_op_loop_carries_model_reasoning_forward(tmp_path, monkeypatch) -> None:
+    """Tier 2: a non-empty content on act turn 1 is carried into act turn 2's frame
+    (act_turn_reasoning), so the model sees its own prior reasoning."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "notes.txt").write_text("fixture")
+    captured: list[list] = []
+
+    class _Script:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, *, messages, **k):  # noqa: ANN002, ANN003
+            self.calls += 1
+            captured.append(messages)
+            if self.calls == 1:
+                # reasoning emitted alongside the file op
+                return _tool_result(
+                    [{
+                        "id": "c1", "type": "function",
+                        "function": {"name": "file", "arguments": '{"op": "read", "path": "notes.txt"}'},
+                    }],
+                    content=_REASONING,
+                )
+            return _tool_result([])  # turn 2: stop → decide
+
+    async def _decide(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10))
+
+    monkeypatch.setattr(lcr, "call_llm", _decide)
+    monkeypatch.setattr(lcr, "call_llm_tools", _Script())
+
+    rt = OSRuntime(
+        _skill(), model="stub/model", run_id="op_loop_reasoning",
+        tool_calls_op_loop_skills=["op_loop_reasoning"],
+    )
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+
+    assert result is not None
+    assert captured, "the op-loop must have invoked call_tools"
+    first_turn, *later_turns = captured
+    # The first turn's prompt must NOT contain the reasoning (not yet produced).
+    assert _REASONING not in json.dumps(first_turn), "turn 1 must not carry future reasoning"
+    # A later turn's prompt MUST carry turn 1's reasoning forward (act_turn_reasoning).
+    assert any(_REASONING in json.dumps(m) for m in later_turns), (
+        "the model's act-turn-1 inline content must be carried into a later turn's "
+        "frame (act_turn_reasoning) for reasoning continuity"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1212 production-enablement **PR 3 of 3** (the last implementation). Bases on integration (gate threading #1229 + (A) memo #1230 merged). Closes the frame-fed reasoning-continuity gap via **decision (A2)**.

## Flow-trace finding (scoped the value)
The 動作確認 trace shows flash-lite emits `content=None` on tool_call turns → reasoning-continuity is a **no-op for the weak model**; it's forward-looking for *capable* models that emit inline content alongside tool_calls. Minimal + clean is the right weight (no over-engineering).

## Decision (A2) — confirmed
A **parallel, bounded** frame field — chosen over (B) a `control_ir_results` entry (would muddy the "each entry = op result" contract) and (A1) a dedicated LLM-compaction (scope creep). No new compaction LLM call; op-result semantics + existing compaction untouched.

## Hunks
- **`ContextFrame.act_turn_reasoning: list[str]`** — new field.
- **`_run_op_loop`** — append a non-empty `result.content` per act turn, bounded to the last `recent_act_turns_raw` entries (config-consistent, no LLM call); thread into every frame build (act + decide).
- **`build_frame`** (OSRuntime + context_builder) — `act_turn_reasoning` param → ContextFrame.
- **system prompt** — an `act_turn_reasoning` section ("your own prior reasoning, carried forward; context not instruction").

json-mode is unchanged (`act_turn_reasoning` defaults to `[]`).

## Test plan
- [x] `test_op_loop_reasoning_continuity_1212.py` (Tier 2) — act-turn-1 inline content is carried into a later turn's frame; the first turn does not carry it. Real `OSRuntime` + executor; provider boundary scripted (captures per-turn messages), no mocks.
- [x] 123 passed (context_builder/frame/op_loop/runtime/phase) + `ruff` + `test_tier_audit --strict`

→ With this, all 3 enablement items are landed (gate threading + (A) memo + reasoning-continuity). Next: revised **ADR-Accepted** (op-loop fully implemented, production-deferral removed) → integration→main = **#1212 complete**.

Refs #1212 #1225