### PR TITLE
[WIP] feat(#1092 Fork 1 PR-A): phase act-loop → RouterLoop convergence

### DIFF
--- a/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
+++ b/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
@@ -1,0 +1,126 @@
+# ADR-0036 (#1092) — chat/plan/phase within-unit history + compaction + force-close unification (Fork 1: RouterLoop convergence)
+
+**Status**: ACCEPTED (user GO 2026-06-02 "懸念点なし、進められるなら進めて"; e2e technical review APPROVE, 3 precisions folded).
+**Track**: #1092 (umbrella). **Canonical contract / staging**: GitHub issue **#1234** (FD1–FD7 + staging PR-A..E + test discipline + scope boundary).
+**Builds on**: **ADR-0035** (#1212 — phase op-loop / separate-decide / frame-fed; a landed file at `docs/deep-dives/decisions/0035-phase-tool-calls-unification.md`). This ADR **PRESERVES** #1212's separate-decide and converges only the within-unit act-loop history representation (frame-fed → RouterLoop message-history).
+**Recon foundation**: e2e DEEP_DIVE.md / DEEP_DIVE_2.md / DEEP_DIVE_3.md (primary-evidence flow-trace on main).
+
+## Context
+
+`CompactionEngine` (head/middle/tail/new + retry, dead-end-free; `services/compaction/engine.py`) is
+**already shared** by all three subsystems. The divergence is the higher layer — the **within-unit act-loop
+shape**:
+
+| | within-unit act-loop | within-unit compaction | cross-unit result-passing (OUT of scope) |
+|---|---|---|---|
+| **chat** | RouterLoop over a saved `ChatMessage` list (native-tools) | CompactionController on the message list | — |
+| **plan-step** | RouterLoop (saved history per step, native-tools) `planner.py:1029` | step-axis (engine) | `step_results: dict[str,str]`, dependency-gated into next step's prompt |
+| **phase** | **FRAME-FED outlier**: `_run_op_loop`/`_run_act_loop` rebuild the frame each turn, `control_ir_results` in the frame, NO message list | `compact_control_ir_results` (engine) | workspace artifacts via `input_schema` (P5) |
+
+So chat + plan-step share the saved-message-history RouterLoop; **phase is the lone outlier** purely because
+its act-loop is frame-fed (#1212).
+
+## Scope boundary (user-locked 2026-06-02)
+
+- **IN**: commonize the **within-unit conversation-history (act-turns) + compaction + force-close** across
+  chat / plan-step / phase — bring phase's act-loop onto the shared RouterLoop saved-history.
+- **OUT (unchanged)**: **cross-step `step_results` / cross-phase workspace-artifacts** result-passing — the
+  cross-unit result axis (structurally identical, both result-passing not conversation-history). User confirmed
+  "今回そこに手を加える必要はなさそう".
+- **OUT (deferred)**: reasoning-preservation (`act_turn_reasoning`) — revisit after history+compaction
+  commonized (user: "リスニング(reasoning)の保存については一旦議論から外したい").
+
+## Decisions
+
+### FD1 — Phase converges onto the shared RouterLoop within-unit act-loop
+Phase supplies a phase-side `RouterLoopHost` (events = phase EventLog; recording = OS WAL via `LLMCallRecorder`).
+The phase frame's static parts (instructions, candidates, op schemas) → `system_prompt_override` (exactly how
+plan injects its step prompt). Act-turns become RouterLoop iterations with a **persistent message history**
+(assistant tool_calls + tool-result messages); `control_ir_results` become tool-result messages.
+`max_iterations` = phase `max_act_turns`.
+
+**FD1 precision (e2e review — the meatiest PR-A scope point): the gap is the tool-catalog BUILD SOURCE, not
+dispatch.** Dispatch is ALREADY shared — RouterLoop executes via `dispatch_tool` (`reyn.dispatch`), the same
+dispatcher the op-executor uses (no dispatch gap). But RouterLoop builds its tool catalog from **chat-discovery**
+(`host.list_available_skills` + universal-catalog wrappers `list_actions`/`search_actions`), NOT from
+`allowed_ops`. So **PR-A needs a catalog-source REPLACE seam in RouterLoop**: a phase supplies
+`_build_phase_tool_catalog(allowed_ops)` (EXISTS ✓) **INSTEAD of** chat discovery — and per #1212 PR3 decision A
+(chat-router tools ≠ phase ops) it must **REPLACE, not augment** (no skills/agents/mcp/universal-wrappers inside
+a phase). `RouterLoopHost` also has ~10 chat-specific methods (skills/agents/mcp/memory/web/project) the
+phase-host stubs. `system_prompt_override` handles the prompt ✓. **→ PR-A scope = RouterLoop catalog-source seam
++ phase-host (op catalog + stubs)** — bigger than "supply a host", but tractable + no structural blocker.
+
+### FD2 — RouterLoop is json-mode-free; the structured transition stays a separable post-pend (肝)
+*(3-source locked: user direction + primary-evidence + e2e §3a.)* RouterLoop runs ops native-tools
+(`call_llm_tools`, `tool_choice=auto`), ends on `end_turn`. The phase **then** does its structured-transition
+json `.call` (P1/P8: control+artifact). This **PRESERVES #1212's separate-decide — it is NOT a reversal.** The
+saved-history change is only the act-loop's op-RESULT turn-representation (frame-rebuild → message-list /
+native-tool-role), **orthogonal** to the transition decide.
+
+### FD3 — (i)/(ii) split: only the ops-emission envelope converges; transition json is permanent
+Phase has two json usages: **(i) ops-emission** (json-mode phases emit ops in the `control_ir` JSON field;
+op-loop emits native tool_calls) and **(ii) transition decide** (structured json `.call`). Convergence retires
+**ONLY (i)** — eventually all phases emit ops as native tool_calls (PR-E). **(ii) is never a retire target**
+(P1/P8 transition contract). The ADR states (i)/(ii) explicitly alongside P1/P8 so "(ii) is unchanged" is
+unambiguous.
+
+### FD4 — Crash-recovery memo unifies cleanly (no hard-finding)
+*(e2e §3b good-news, review-verified.)* (A)'s `call_tools` memo and plan's `SubLoopMemoProvider` are the **same
+pattern** — `compute_sub_loop_args_hash` docstring literally says "Mirrors `dispatcher._compute_llm_args_hash`
+shape" + `_serialise/_deserialise` on `LLMToolCallResult` (content/tool_calls/finish_reason/usage) +
+`get_recorded_result(args_hash)`/`record`. **Precision (e2e): they differ in backend AND args_hash INPUT** —
+`SubLoopMemoProvider` hashes **MESSAGES**, (A) hashes the **FRAME** (`ContextFrame.model_dump`). Under RouterLoop,
+phase moves to messages → **phase ADOPTS `compute_sub_loop_args_hash` (messages-based)**; (A)'s frame-based hash
+**RETIRES WITH frame-fed**. So FD4 is cleaner than "two backends of one hash": *phase adopts the
+SubLoopMemoProvider hash + serialise, with an OS-WAL backend*. No incompatibility — folded into PR-A.
+
+### FD5 — Compaction + force-close reuse directly once phase has a message-history
+`CompactionController`/engine drive the phase message-history. `force_compact_now` + the summary-bridge
+(`chat/slash/compact.py` in-place middle replacement) apply once phase has a message-history. A phase can
+compress its act-history mid-loop + continue.
+- **FD5-decision (lead-coder call, override-able)**: phase compaction on the message-history **REPLACES**
+  `compact_control_ir_results` (the message-history becomes the within-phase SSoT for act-turns; avoid
+  double-compaction). Lands in PR-B.
+- **FD5-decision (lead-coder call, override-able)**: phase force-close is triggered by the **`compact` op /
+  budget**, NOT a user `/compact` slash (the slash is chat-only; a phase is not a user conversation). Phase
+  reuses the `force_compact_now` + summary-bridge **mechanism**, not the chat user-surface. Lands in PR-C.
+  **Grounded (e2e review): phase ALREADY has `_make_phase_compact_now` (`phase_executor.py:77`, #1176 B1)
+  reached by the `compact` op** — today it compacts `control_ir_results`; PR-C **re-points it to the
+  message-history** via `CompactionController`/`force_compact_now` (not the `/compact` slash). The trigger seam
+  already exists; PR-C only changes its target.
+
+### FD6 — Replay re-pricing: native tool_call-id normalization returns, bounded by reusing chat's handling
+Frame-fed made provider-id normalization MOOT (#1212); RouterLoop threads native tool_call ids → it returns.
+BUT `testing/replay.py` (keys on `model + canonical_json(messages)`) + chat RouterLoop replay **already handle
+native tool_calls**. Reuse: phase RouterLoop replay == chat RouterLoop replay (same machinery). Net-new:
+phase-specific fixtures only. Lands in PR-D.
+
+### FD7 — Staging: op-loop-first; json-mode convergence is the last, large PR
+The op-loop ALREADY emits native tool_calls → converging it to RouterLoop is incremental. json-mode → RouterLoop
+= switching ops from the control_ir envelope to native tool_calls = "op-loop as default" (all 36 phases run
+json-mode today) = much larger. Staging:
+- **PR-A** — op-loop → RouterLoop behind the gate: phase-side `RouterLoopHost` + `system_prompt_override` +
+  WAL-backed `memo_provider` (FD4) + structured-transition post-pend (FD2). Core convergence, behavior-preserving
+  for opt-in (`tool_calls_op_loop_skills`) skills.
+- **PR-B** — compaction: drive `CompactionController`/engine on the phase message-history; replace
+  `compact_control_ir_results` (FD5).
+- **PR-C** — force-close/summary-bridge for the phase act-history, op/budget-triggered (FD5).
+- **PR-D** — replay fixtures for the phase RouterLoop (reuse chat's machinery, FD6).
+- **PR-E (later, large)** — json-mode convergence = op-loop-as-default + retire (i) the control_ir emission path
+  + gate removal (FD3). Gate bridges the interim.
+
+## Consequences
+- **+** One within-unit act-loop shape across chat/plan-step/phase (RouterLoop), one compaction controller, one
+  force-close mechanism. Phase stops being the frame-fed outlier.
+- **+** Promotion symmetry advances (plan→skill): both run the same RouterLoop act-loop + native tools; a
+  working plan-step generalizes toward a skill phase with the same loop substrate.
+- **−** #1212's frame-fed replay-simplification is given back (FD6) — bounded by reusing chat's existing native
+  tool_call handling.
+- **−** PR-E (json-mode retire) is large (36 phases); gated migration absorbs the risk.
+
+## Test discipline (per testing.ja.md)
+- Tier 2: phase RouterLoopHost wiring (real Workspace/EventLog, no Mock); memo_provider OS-WAL round-trip
+  (non-default value, set→crash→resume→identical — reuse #1142/#1146 lesson).
+- Tier 3: phase RouterLoop replay fixtures (reuse chat machinery, FD6); compaction-on-message-history behavior.
+- Wire-full-frontmatter: load-from-disk path for any new config; full-rootdir suite for prompt/config changes.
+- Falsification: enforcement/permission tests use a real (non-None) PermissionResolver (#1214/#1215 lesson).

--- a/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
+++ b/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
@@ -46,9 +46,40 @@ dispatcher the op-executor uses (no dispatch gap). But RouterLoop builds its too
 `allowed_ops`. So **PR-A needs a catalog-source REPLACE seam in RouterLoop**: a phase supplies
 `_build_phase_tool_catalog(allowed_ops)` (EXISTS ✓) **INSTEAD of** chat discovery — and per #1212 PR3 decision A
 (chat-router tools ≠ phase ops) it must **REPLACE, not augment** (no skills/agents/mcp/universal-wrappers inside
-a phase). `RouterLoopHost` also has ~10 chat-specific methods (skills/agents/mcp/memory/web/project) the
-phase-host stubs. `system_prompt_override` handles the prompt ✓. **→ PR-A scope = RouterLoop catalog-source seam
-+ phase-host (op catalog + stubs)** — bigger than "supply a host", but tractable + no structural blocker.
+a phase). `system_prompt_override` handles the prompt ✓.
+
+**FD1 RESOLVED — (c) narrow-core extraction** (lead-coder call; e2e verify-gate line-mapped, APPROVE). The
+`RouterLoopHost` Protocol is actually **~30 methods** (not ~10) — most chat-specific (web/reyn_src/memory/
+file_*/mcp_*/discovery/spawn/send_to_agent/record_plan_*). Rejected: (a) a ~30-method stub phase-host (27 stubs =
+throwaway under the user's no-throwaway principle, fragile); (b) a full chat-host refactor (too big, risks the
+live chat path). **(c)**: extract the host calls RouterLoop's **loop** directly makes into a **`RouterLoopCore`
+Protocol**; `RouterLoopHost = RouterLoopCore + chat-extras`; RouterLoop's loop is typed against
+`RouterLoopCore`; the chat `RouterHostAdapter` (a superset) satisfies `RouterLoopCore` for free (zero chat
+risk); the **PhaseRouterLoopHost implements `RouterLoopCore` only, ZERO chat-extra stubs**.
+
+verify-gate (e2e, line-mapped — no chat-extra couples into the loop-core, so (c) holds):
+- **`RouterLoopCore` = 6 shared members**: `events` (property) · `make_router_op_context()` (the OpContext
+  for `dispatch_tool` — the op-execution bridge) · `resolve_model(name)` · `put_outbox(...)` · attrs
+  `agent_name` / `agent_role` / `output_language`. (`append_history_entry` / `record_plan_*` / `resolver` are
+  NOT directly called by RouterLoop → out of core; no plan-record no-op needed.)
+- **`get_phase_op_catalog()`** stays a **getattr-hook** (phase-only; chat doesn't implement it), already added
+  in the catalog-source seam (8d48b4ef).
+- **chat-extras (outside core, phase-unreached)**: list_available_skills/agents, get_memory_index/mcp/web/
+  file_perms/project/universal/embedding/sandbox, memory_*, file_*, mcp_*, web_*, reyn_src_*, spawn/run_skill/
+  send_to_agent. They live in the chat-discovery setup, the chat-SP-build (override-skipped), or chat-dispatch
+  handlers — phase ops dispatch via the op handlers + the phase OpContext, never these.
+
+**Refinement (i)**: the chat-discovery SETUP (`router_loop.py` ~1486-1717, `list_available_skills`/`get_*`) runs
+BEFORE the seam — guard it behind `_phase_op_catalog is None` so a phase calls zero discovery methods (grows the
+catalog-source seam from "override `tools=`" to "skip setup + set `tools=`"; no cascade to the chat adapter;
+chat byte-identical). **Refinement (ii)**: `put_outbox` is a phase **no-op** — phase has no user outbox (its
+output is the result artifact / transition), a legitimate concept-absent no-op, not a fragile chat stub. The
+Tier-2 test asserts this is **not load-bearing** (phase accumulates op-results into the message-history; no-op-ing
+`put_outbox` drops nothing phase needs — if it were load-bearing, the test fails).
+
+**→ PR-A scope** = catalog-source seam (✓ 8d48b4ef) + `RouterLoopCore` extraction + setup-guard +
+PhaseRouterLoopHost (6 core impls + `get_phase_op_catalog`, zero chat-extra stubs). Throwaway-free,
+chat-unaffected, P7-aligned (no chat-tool-exec baked into the loop).
 
 ### FD2 — RouterLoop is json-mode-free; the structured transition stays a separable post-pend (肝)
 *(3-source locked: user direction + primary-evidence + e2e §3a.)* RouterLoop runs ops native-tools

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2630,6 +2630,22 @@ class RouterLoop:
         except (json.JSONDecodeError, KeyError):
             args = {}
 
+        # #1092 PR-A (FD1, ADR-0036): op-EXECUTION seam, symmetric to the
+        # catalog-source REPLACE seam in run(). A phase host supplies its op
+        # catalog (get_phase_op_catalog) AND owns op execution
+        # (execute_phase_op → the shared control_ir_executor: same dispatch /
+        # permission / events / WAL the json-mode op-loop uses). Because the
+        # phase host REPLACES the whole catalog with its op catalog, EVERY tool
+        # call in phase mode is a control-IR op-kind, so all calls delegate to
+        # the host. RouterLoop stays generic — it holds NO phase op-kind strings
+        # (`file__read` / `exec` / ...), keeping P7 (no skill/op-specific
+        # strings in OS code) intact. chat / plan-step hosts do not implement
+        # the method (getattr → None), so their dispatch path below is
+        # byte-identical.
+        _exec_phase_op = getattr(self.host, "execute_phase_op", None)
+        if _exec_phase_op is not None:
+            return await _exec_phase_op(name=name, args=args)
+
         if name not in self._catalog and "__" in name:
             name, args = self._maybe_salvage_qualified_direct_call(name, args)
 

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1483,6 +1483,13 @@ class RouterLoop:
         """
         self._total_usage = TokenUsage()
         host = self.host
+        # #1092 PR-A (FD1, ADR-0036): catalog-source REPLACE seam. A phase host
+        # supplies its op tool catalog (allowed_ops via _build_phase_tool_catalog),
+        # which REPLACES chat-discovery — a phase has no skills/agents/mcp/universal
+        # (#1212 PR3 decision A). getattr-fallback so chat / plan-step hosts (no such
+        # method) keep the existing chat-discovery tool-build byte-identically.
+        _phase_op_catalog_getter = getattr(host, "get_phase_op_catalog", None)
+        _phase_op_catalog = _phase_op_catalog_getter() if _phase_op_catalog_getter else None
         all_skills = host.list_available_skills()
         # FP-0024 Component A — BM25 skill pre-filter.
         # Narrow available_skills to top-K BM25 keyword matches when the
@@ -1678,17 +1685,24 @@ class RouterLoop:
         # the window is ample (then compact stays hidden + the SP header is
         # omitted); non-None when filling (compact tool + header appear together).
         _ctx_signal = _render_context_size_signal_for_host(host)
-        tools = build_tools(
-            skills_for_tools,
-            host.list_available_agents(),
-            file_permissions=host.get_file_permissions(),
-            mcp_servers=host.get_mcp_servers(),
-            web_fetch_allowed=host.get_web_fetch_allowed(),
-            universal_wrappers_enabled=_univ_enabled,
-            search_actions_visible=_search_visible,
-            hot_list_aliases=_hot_list_aliases,
-            compact_visible=_ctx_signal is not None,
-        )
+        if _phase_op_catalog is not None:
+            # #1092 PR-A (FD1): phase op catalog REPLACES chat-discovery. The
+            # chat-discovery setup above ran on the phase host's stubs
+            # (empty skills/agents/mcp, universal off) — harmless; its build_tools
+            # result is discarded here in favor of the op catalog.
+            tools = list(_phase_op_catalog)
+        else:
+            tools = build_tools(
+                skills_for_tools,
+                host.list_available_agents(),
+                file_permissions=host.get_file_permissions(),
+                mcp_servers=host.get_mcp_servers(),
+                web_fetch_allowed=host.get_web_fetch_allowed(),
+                universal_wrappers_enabled=_univ_enabled,
+                search_actions_visible=_search_visible,
+                hot_list_aliases=_hot_list_aliases,
+                compact_visible=_ctx_signal is not None,
+            )
         # D2-wrapper scope expansion (B38): propagate schemas for ALL
         # session-visible actions into invoke_action's description so the
         # LLM can see canonical arg key names when it routes via the wrapper,

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -430,11 +430,45 @@ def _is_empty_router_response(response: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 @runtime_checkable
-class RouterLoopHost(Protocol):
-    """Abstract surface RouterLoop needs.
+class RouterLoopCore(Protocol):
+    """#1092 PR-A (ADR-0036 FD1, decision c): the NARROW core surface the
+    RouterLoop act-loop actually depends on — the members RouterLoop's loop
+    directly calls for ANY host (chat / plan-step / phase). A phase implements
+    ONLY this (via PhaseRouterLoopHost) — no chat-extra stubs. The chat
+    ``RouterHostAdapter`` is a superset and satisfies this for free.
+
+    The chat-extras (skills/agents/mcp/memory/web/file/reyn_src/embedding/
+    discovery/spawn/send_to_agent/record_plan_*) live on ``RouterLoopHost``
+    below; they are reached only via the chat-discovery setup, the chat
+    system-prompt build, or chat-dispatch handlers — a phase never reaches them
+    (its op catalog REPLACES chat-discovery, and its ops dispatch via the op
+    handlers + ``make_router_op_context``). ``get_phase_op_catalog`` is a
+    phase-only getattr-hook (not declared here — chat doesn't implement it).
+    """
+
+    agent_name: str
+    agent_role: str
+    output_language: str | None
+
+    @property
+    def events(self) -> Any:
+        """EventLog (has .emit(type: str, **data)) for tool dispatch events."""
+        ...
+
+    def resolve_model(self, name: str) -> str: ...
+    def make_router_op_context(self) -> Any: ...
+    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None: ...
+
+
+@runtime_checkable
+class RouterLoopHost(RouterLoopCore, Protocol):
+    """Abstract surface RouterLoop needs (chat-mode superset of RouterLoopCore).
 
     Implemented by RouterHostAdapter in
-    src/reyn/chat/services/router_host_adapter.py.
+    src/reyn/chat/services/router_host_adapter.py. Extends RouterLoopCore
+    (#1092 PR-A) with the chat-only methods (discovery / tool-exec primitives /
+    plan-record); the core members are inherited (the redundant re-declarations
+    below are harmless Protocol overlap, pending a follow-up cleanup).
     """
 
     # Static catalogue access

--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -380,6 +380,24 @@ class LLMCallRecorder:
         )
         return result
 
+    def make_phase_memo_provider(
+        self, *, phase: str, state: "RunState",
+    ) -> "_PhaseMemoProvider":
+        """#1092 PR-A (FD4): expose ``call_tools``'s WAL memo as a RouterLoop
+        ``memo_provider`` seam.
+
+        When the converged op-loop drives the shared ``RouterLoop`` (Fork 1),
+        the act-turn LLM call moves from ``call_tools`` into RouterLoop's own
+        call path; this provider relocates the SAME op_invocation_id-sequenced
+        WAL ``committed_steps`` memo (#1212 decision A) to RouterLoop's
+        ``get_recorded_result`` / ``record`` seam — keeping json-mode-equal
+        crash recovery WITHOUT a new persistence mechanism (true FD4 unify, no
+        new args_hash-only store). Bound to this recorder's WAL collaborators
+        (``_resume_plan`` / ``_state_log`` / ``_run_id`` / ``_skill_registry``)
+        and the per-run ``state`` (for ``next_llm_invocation_id``).
+        """
+        return _PhaseMemoProvider(recorder=self, phase=phase, state=state)
+
     # ── Model resolution ───────────────────────────────────────────────────────
 
     def _effective_model(self, phase_name: str) -> str:
@@ -568,3 +586,96 @@ class LLMCallRecorder:
                 chain_id=self._chain_id,
                 **check.context,
             )
+
+
+class _PhaseMemoProvider:
+    """#1092 PR-A (FD4): the phase-side ``memo_provider`` for ``RouterLoop``.
+
+    Bridges RouterLoop's args_hash-keyed memo seam (``get_recorded_result`` /
+    ``record``) onto the SAME op_invocation_id-sequenced WAL ``committed_steps``
+    the json-mode op-loop's ``LLMCallRecorder.call_tools`` uses (#1212 decision
+    A), so the RouterLoop-driven op-loop keeps json-mode-equal crash recovery.
+    Created via ``LLMCallRecorder.make_phase_memo_provider`` and reuses the
+    recorder's own WAL primitives (no duplication, no new persistence).
+
+    **op_invocation_id pairing (FD4 correctness crux).** RouterLoop calls
+    ``get_recorded_result(hash)`` exactly once per act turn, then
+    ``record(hash, result)`` only on a MISS. The id is allocated in ``get``
+    (``state.next_llm_invocation_id`` — called every turn on BOTH fresh and
+    resume) and consumed by the matching ``record``. So the id SEQUENCE is
+    driven by ``get`` and stays deterministic across fresh-vs-resume, including
+    the resume lookup-HIT path where ``record`` is skipped: the hit consumed the
+    id for its lookup, and the next turn's ``get`` advances to the next id
+    regardless. This mirrors ``call_tools``'s single ``next_llm_invocation_id``
+    per turn. Pinned by the crash-recovery round-trip test (set→crash→resume→
+    json-mode-equal, non-default values).
+
+    args_hash: RouterLoop computes the messages-based ``compute_sub_loop_args_hash``;
+    this provider stores AND looks up by that value, so a resume recomputes the
+    same hash from the same messages and the WAL match holds. (``call_tools``'s
+    frame-based ``_compute_llm_args_hash`` is moot here — an opted-in skill never
+    takes the ``call_tools`` path, so there is no cross-contamination.)
+    """
+
+    def __init__(
+        self, *, recorder: "LLMCallRecorder", phase: str, state: "RunState",
+    ) -> None:
+        self._recorder = recorder
+        self._phase = phase
+        self._state = state
+        # The id allocated by the most recent get_recorded_result, consumed by
+        # the matching record (RouterLoop's get-then-record-on-miss per turn).
+        self._pending_op_id: str | None = None
+
+    def get_recorded_result(self, args_hash: str) -> "LLMToolCallResult | None":
+        from reyn.llm.llm import LLMToolCallResult
+
+        op_id = self._state.next_llm_invocation_id(self._phase)
+        self._pending_op_id = op_id
+        resume_plan = self._recorder._resume_plan
+        if resume_plan is None:
+            return None
+        memo = _lookup_memoized_step(resume_plan, op_id, self._phase, args_hash)
+        if memo is None:
+            return None
+        stored = self._recorder._extract_memoized_llm_result(
+            memo, phase=self._phase, op_invocation_id=op_id,
+        )
+        if stored is None:
+            return None
+        self._recorder._events.emit(
+            "step_memoized",
+            run_id=self._recorder._run_id,
+            phase=self._phase,
+            op_invocation_id=op_id,
+            op_kind="llm",
+            args_hash=args_hash,
+        )
+        return LLMToolCallResult(
+            content=stored.get("content"),
+            tool_calls=stored.get("tool_calls") or [],
+            finish_reason=stored.get("finish_reason"),
+            usage=TokenUsage(prompt_tokens=0, completion_tokens=0),
+        )
+
+    async def record(
+        self, *, args_hash: str, result: "LLMToolCallResult",
+    ) -> None:
+        op_id = self._pending_op_id
+        if op_id is None:
+            # Defensive: record without a preceding get (not RouterLoop's
+            # get-then-record-on-miss flow). Allocate one so the WAL still
+            # records this turn rather than silently dropping it.
+            op_id = self._state.next_llm_invocation_id(self._phase)
+        await self._recorder._wal_step_completed_for_llm(
+            phase=self._phase,
+            op_invocation_id=op_id,
+            args_hash=args_hash,
+            result={
+                "content": result.content,
+                "tool_calls": result.tool_calls,
+                "finish_reason": result.finish_reason,
+            },
+            usage=result.usage.to_dict() if result.usage else None,
+        )
+        self._pending_op_id = None

--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -28,7 +28,7 @@ BudgetEnforcer / WalRecorder have ≥ 2 consumers.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from reyn.budget.budget import BudgetExceeded, format_refusal_message
 from reyn.dispatch.dispatcher import _compute_llm_args_hash, _lookup_memoized_step
@@ -414,6 +414,49 @@ class LLMCallRecorder:
             pricing_snapshot=pricing_snapshot,
         )
         return result
+
+    def make_phase_llm_caller(
+        self, *, phase: str, state: "RunState",
+    ) -> Callable:
+        """#1092 PR-A (step5): a ``call_llm_tools``-shaped callable for
+        RouterLoop's ``_llm_caller`` injection point.
+
+        Routes the phase act-turn LLM call through ``_call_phase_llm_core`` so
+        the phase's cost accounting (``state.add_usage``) + phase-flavored
+        ``llm_called`` / ``llm_response_received`` events are preserved when the
+        generic RouterLoop drives the converged op-loop (lead-coder STEP5
+        decision, #1234). RouterLoop invokes ``_llm_caller`` ONLY on a memo-MISS
+        (resume-HIT short-circuits via the ``memo_provider``), so this is the
+        fresh-call path — matching ``call_tools``' fresh path exactly; resume
+        replays events from the log (ADR-0002), no double cost/emit. Resolves the
+        phase model itself (mirrors ``call_tools``), ignoring RouterLoop's
+        router-model arg (the act-turn call uses the phase's model).
+        """
+        resolved_spec = self._resolver.resolve(self._effective_model(phase))
+        resolved_model = resolved_spec.model
+
+        async def _phase_llm_caller(
+            *,
+            messages: list[dict],
+            tools: list[dict],
+            model: object = None,
+            tool_choice: object = None,
+            skill_name: str | None = None,
+            budget: object = None,
+            budget_agent: str | None = None,
+            trace_caller: str | None = None,
+            **_kwargs: object,
+        ) -> "LLMToolCallResult":
+            return await self._call_phase_llm_core(
+                phase=phase,
+                resolved_spec=resolved_spec,
+                resolved_model=resolved_model,
+                messages=messages,
+                tools=tools,
+                state=state,
+            )
+
+        return _phase_llm_caller
 
     def make_phase_memo_provider(
         self, *, phase: str, state: "RunState",

--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -316,6 +316,55 @@ class LLMCallRecorder:
                         usage=TokenUsage(prompt_tokens=0, completion_tokens=0),
                     )
 
+        result = await self._call_phase_llm_core(
+            phase=phase,
+            resolved_spec=resolved_spec,
+            resolved_model=resolved_model,
+            messages=messages,
+            tools=tools,
+            state=state,
+        )
+
+        # (A) #1225: per-step WAL record so a resume replays this act turn's
+        # tool_calls deterministically (same shape ``call`` records for the decide).
+        await self._wal_step_completed_for_llm(
+            phase=phase,
+            op_invocation_id=op_invocation_id,
+            args_hash=args_hash,
+            result={
+                "content": result.content,
+                "tool_calls": result.tool_calls,
+                "finish_reason": result.finish_reason,
+            },
+            usage=result.usage.to_dict() if result.usage else None,
+        )
+        return result
+
+    async def _call_phase_llm_core(
+        self,
+        *,
+        phase: str,
+        resolved_spec: object,
+        resolved_model: str,
+        messages: list[dict],
+        tools: list[dict],
+        state: "RunState",
+    ) -> "LLMToolCallResult":
+        """The shared 'messages-in' core of the phase native-tools LLM call.
+
+        Budget pre-check + ``llm_called`` event + ``call_llm_tools`` + cost
+        recording (``state.add_usage`` / ``_record_budget_post_llm``) +
+        ``llm_response_received`` event — the phase-flavored cost/audit
+        semantics. Used by ``call_tools`` (frame-built messages + WAL memo) AND
+        by the #1092 PR-A RouterLoop adapter (RouterLoop-supplied messages +
+        memo via the ``memo_provider`` seam). Memo (lookup/record) is NOT here —
+        it wraps this core. lead-coder STEP5 decision (#1234): phase cost
+        accounting is mandatory + events stay phase-flavored so the gate's
+        behavior-preserving contract holds at the AUDIT layer too (opt-in must
+        not be observable in the event log = P6). The adapter invokes this on
+        the memo-MISS path ONLY — resume-HIT skips the LLM call and replays
+        events from the log (ADR-0002), so no double cost/emit.
+        """
         self._check_budget_pre_llm(resolved_model)
         self._events.emit(
             "llm_called",
@@ -363,20 +412,6 @@ class LLMCallRecorder:
             completion_tokens=result.usage.completion_tokens if result.usage else None,
             cost_usd=cost_usd,
             pricing_snapshot=pricing_snapshot,
-        )
-
-        # (A) #1225: per-step WAL record so a resume replays this act turn's
-        # tool_calls deterministically (same shape ``call`` records for the decide).
-        await self._wal_step_completed_for_llm(
-            phase=phase,
-            op_invocation_id=op_invocation_id,
-            args_hash=args_hash,
-            result={
-                "content": result.content,
-                "tool_calls": result.tool_calls,
-                "finish_reason": result.finish_reason,
-            },
-            usage=result.usage.to_dict() if result.usage else None,
         )
         return result
 

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -1,0 +1,155 @@
+"""PhaseRouterLoopHost — #1092 PR-A (FD1, ADR-0036).
+
+The phase-side ``RouterLoopCore`` implementation that lets a phase act-loop
+drive the shared chat ``RouterLoop`` (Fork 1 convergence). It mirrors the
+proven narrow ``_PlanStepHost`` (``chat/planner.py``) shape but is
+TERMINAL-VALUED: a phase has no parent chat host to delegate to, and — per
+#1212 PR3 decision A — no skills / agents / mcp / universal catalog.
+
+It owns BOTH halves of the convergence seam:
+
+- ``get_phase_op_catalog`` — the catalog-source REPLACE seam (``RouterLoop.run``
+  uses this INSTEAD of chat-discovery ``build_tools`` when present).
+- ``execute_phase_op`` — the op-execution seam (``RouterLoop._execute_tool``
+  delegates every phase tool call here). It converts the native tool call to a
+  ``ControlIROp`` and runs it through the SHARED ``control_ir_executor`` so
+  dispatch / permission / events / WAL match the json-mode op-loop exactly.
+
+RouterLoop stays generic (P7): it holds no phase op-kind strings. This host is
+the chat-vs-phase polymorphism point — the same role ``RouterHostAdapter``
+(chat) and ``_PlanStepHost`` (plan-step) play for their loops.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+class PhaseRouterLoopHost:
+    """RouterLoopCore for a single phase act-loop iteration set.
+
+    Construction deps all originate in ``PhaseExecutor._run_op_loop``'s scope
+    (``phase_executor.py``): the shared ``control_ir_executor``, the phase
+    ``EventLog``, the current phase name + ``PermissionDecl`` + ``allowed_ops``
+    + phase-default ``SandboxPolicy``, plus agent identity and the OS model
+    resolver (passed as ``resolve_model_fn`` so this host stays decoupled from
+    OSRuntime's resolver wiring — the loop only needs ``name -> model id``).
+    """
+
+    def __init__(
+        self,
+        *,
+        control_ir_executor: Any,
+        events: Any,
+        phase: str,
+        decl: Any,
+        allowed_ops: set[str] | None,
+        default_sandbox_policy: dict | None,
+        agent_name: str,
+        agent_role: str,
+        output_language: str | None,
+        resolve_model_fn: Callable[[str], str],
+    ) -> None:
+        self._control_ir_executor = control_ir_executor
+        self._events = events
+        self._phase = phase
+        self._decl = decl
+        self._allowed_ops = allowed_ops
+        self._default_sandbox_policy = default_sandbox_policy
+        self._agent_name = agent_name
+        self._agent_role = agent_role
+        self._output_language = output_language
+        self._resolve_model_fn = resolve_model_fn
+
+    # ── RouterLoopCore identity / static config ───────────────────────────
+
+    @property
+    def agent_name(self) -> str:
+        return self._agent_name
+
+    @property
+    def agent_role(self) -> str:
+        return self._agent_role
+
+    @property
+    def output_language(self) -> str | None:
+        return self._output_language
+
+    @property
+    def events(self) -> Any:
+        return self._events
+
+    def resolve_model(self, name: str) -> str:
+        return self._resolve_model_fn(name)
+
+    def make_router_op_context(self) -> Any:
+        """Vestigial for phase — returns None.
+
+        RouterLoop's ``op_context_factory`` (= this method) feeds its CHAT
+        tool-dispatch handlers (file / web / mcp), which phase ops BYPASS: a
+        phase op routes via :meth:`execute_phase_op` → ``control_ir_executor``,
+        which builds its OWN ``OpContext`` internally. So this is never reached
+        on the phase path; it exists only to satisfy ``RouterLoopCore``.
+        """
+        return None
+
+    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+        """Phase NO-OP — a concept-absent legitimate no-op (P-clean).
+
+        A phase's output is its artifact + transition, not a user-facing outbox
+        stream. The phase act-loop accumulates op results into the RouterLoop
+        message history (the phase's working state), so no-op-ing the outbox
+        drops nothing the phase relies on — unlike a fragile chat stub.
+        """
+        return None
+
+    # ── Catalog-source REPLACE seam ───────────────────────────────────────
+
+    def get_phase_op_catalog(self) -> list[dict]:
+        """The phase's op tool catalog in litellm ``tools=`` list shape.
+
+        REPLACES chat-discovery in ``RouterLoop.run`` (a phase has no skills /
+        agents / mcp / universal). Mirrors the exact build the json-mode
+        ``_run_op_loop`` does today (``phase_executor.py``): ``allowed_ops`` →
+        ``_build_phase_tool_catalog`` → ``{"type": "function", **entry}`` list.
+        """
+        from reyn.kernel.control_ir_executor import _build_phase_tool_catalog
+
+        catalog = _build_phase_tool_catalog(self._allowed_ops or set())
+        return [{"type": "function", **entry} for entry in catalog.values()]
+
+    # ── op-execution seam ─────────────────────────────────────────────────
+
+    async def execute_phase_op(self, *, name: str, args: dict) -> Any:
+        """Run one phase op through the SHARED control_ir_executor.
+
+        Converts the native tool call to a ``ControlIROp`` then dispatches via
+        ``control_ir_executor.execute`` — the same dispatch / permission /
+        events / WAL path the json-mode op-loop uses (``_run_op_loop`` @
+        ``execute(ops, ...)``). On an invalid op shape it MIRRORS the json-mode
+        per-turn validation (emit ``validation_error`` + return an error result
+        the model sees in the next turn's message history) rather than crashing
+        the loop.
+        """
+        from reyn.kernel.op_loop import tool_call_to_control_ir_op
+
+        try:
+            op = tool_call_to_control_ir_op(
+                {"function": {"name": name, "arguments": args}}
+            )
+        except Exception as exc:  # noqa: BLE001 — invalid op shape (mirror json-mode)
+            self._events.emit(
+                "validation_error",
+                phase=self._phase,
+                error=f"invalid tool_call op: {exc}",
+            )
+            return {"status": "error", "kind": "invalid_op", "error": str(exc)}
+
+        results = await self._control_ir_executor.execute(
+            [op],
+            phase=self._phase,
+            decl=self._decl,
+            allowed_ops=self._allowed_ops,
+            default_sandbox_policy=self._default_sandbox_policy,
+        )
+        return results[0] if results else {}


### PR DESCRIPTION
**[e2e-coder]** — **DRAFT / WIP.** #1092 Fork 1 **PR-A** (op-loop → RouterLoop convergence). Canonical contract = #1234 (FD1–FD7). `Refs #1234`. Behavior-preserving behind the `tool_calls_op_loop_skills` gate (un-opted = json-mode `_run_act_loop`, byte-identical).

### Status: seams + host landed; rewire + tests pending (NOT yet functional)
Pushed for visibility (user caught the un-pushed branch). The convergence is **not yet wired** — the seams are dormant until step 5 drives RouterLoop from `_run_op_loop`. Do not review for merge yet.

### Landed (6 commits)
- `4e3fc693` ADR-0036 (Fork 1 design; builds on the real on-main ADR-0035)
- `8d48b4ef` **catalog-source REPLACE seam** — `RouterLoop.run` takes `host.get_phase_op_catalog()` instead of chat-discovery `build_tools` (a phase has no skills/agents/mcp/universal, #1212 PR3 decision A). chat byte-identical via getattr-fallback.
- `197d40db` ADR FD1 record — (c) narrow-core extraction
- `b9d0fce8` **`RouterLoopCore`** narrow Protocol extracted (`RouterLoopHost` extends it; chat adapter satisfies it free)
- `1dc78528` **op-execution seam** (FD2/β) — `_execute_tool` delegates phase op-kinds to `host.execute_phase_op`; RouterLoop holds no phase op-kind strings (P7); α rejected as a P7 violation (lead-coder affirm). chat byte-identical.
- `a247f0b8` **`PhaseRouterLoopHost`** — terminal-valued narrow `RouterLoopCore` (mirrors `_PlanStepHost`), owns both seams; `execute_phase_op` → shared `control_ir_executor` with json-mode-mirror error handling.

### Flow-trace findings (resolved on #1234)
- Finding 1 (host surface) → reconciled to core-7 (phase op-kinds bypass the chat registry-dispatch path).
- Finding 2 (the real scope add) → RouterLoop had no op-execution path; closed by the β seam.

### Remaining before un-drafting
- [ ] Step 4 — WAL-backed `memo_provider` (FD4; `get_recorded_result`/`record` over OS WAL)
- [ ] Step 5 — rewire `_run_op_loop` → construct `PhaseRouterLoopHost` + drive RouterLoop (`system_prompt_override` = phase frame static parts; LLM call via `call_llm_tools` path + WAL memo; transition post-pend), gated
- [ ] Step 6 — Tier2 `execute_phase_op` runs a real op via `control_ir_executor` + result enters message-history (real Workspace/EventLog/PermissionResolver, no mocks) · memo WAL round-trip (non-default; set→crash→resume→identical) · Tier3 phase RouterLoop replay · gate-off byte-identical

### Test plan (run before un-drafting)
- [ ] (skipped — WIP) full-rootdir `pytest -q && ruff check .` — system-prompt/frame-shape touched ⇒ full suite, not subset (#1231 lesson)
- [x] router_loop + replay green at each landed commit (243 passed; chat byte-identical)
- [x] `PhaseRouterLoopHost` verified: import + catalog shape + `isinstance(h, RouterLoopCore)` True + ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)