### PR TITLE
fix(tui): remove stale error-box keybinding refs left by #1217

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -173,7 +173,7 @@ class ReynTUIApp(App):
         # W13 T2-1: F7 keyboard drill for the most-recent failed ToolCallRow.
         # F4 is reserved for async-stack panel focus (Wave-9 / keys_tab
         # description). F5/F6 are FREE since #1217 removed the conv-pane
-        # error-jump (#586) along with the ErrorBox widget — available for reuse.
+        # error-jump (#586) — available for reuse.
         # F7 follows historically.
         Binding("f7", "drill_failed_tool", "Toggle most-recent failed tool row", priority=True, show=False),
         # F9: toggle timestamp prefix (HH:MM) in conv pane headers.

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -172,8 +172,9 @@ class ReynTUIApp(App):
         Binding("f4", "focus_async_stack", "Focus async strip", priority=True, show=False),
         # W13 T2-1: F7 keyboard drill for the most-recent failed ToolCallRow.
         # F4 is reserved for async-stack panel focus (Wave-9 / keys_tab
-        # description); F5/F6 reserved for conv-pane error-jump (#586).
-        # F7 is the first free function key after those reservations.
+        # description). F5/F6 are FREE since #1217 removed the conv-pane
+        # error-jump (#586) along with the ErrorBox widget — available for reuse.
+        # F7 follows historically.
         Binding("f7", "drill_failed_tool", "Toggle most-recent failed tool row", priority=True, show=False),
         # F9: toggle timestamp prefix (HH:MM) in conv pane headers.
         # With ts hidden, body indent shrinks col 8 → col 2, reclaiming

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1,7 +1,7 @@
 """Outbox routing for ReynTUIApp.
 
 Drains ``registry.repl_outbox`` and dispatches each :class:`OutboxMessage`
-to the right widget (conv pane, sticky status, error box, skill activity row,
+to the right widget (conv pane, sticky status, skill activity row,
 preview pane, screen header). Lives in its own module to keep ``app.py``
 focused on composition / lifecycle.
 

--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -732,7 +732,7 @@ class RightPanel(Widget):
             # this, the panel was a Tab/Shift+Tab focus trap (those keys
             # cycle tabs, never exit), and Esc was a silent no-op because
             # the App's escape binding is gated by ``check_action`` which
-            # returns False when nothing else (recording, error box) is
+            # returns False when nothing else (recording) is
             # interceptable. Tab cycling stays; this is purely the exit.
             # A-F4 (wave-8): when the docs tab has an active filter,
             # Esc clears the filter in place instead of dropping focus

--- a/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/keys_tab.py
@@ -37,13 +37,12 @@ _KEY_DETAILS: dict[str, str] = {
     "escape": (
         "Context-aware back/cancel:\n"
         "  • voice mode → cancel recording\n"
-        "  • error box → dismiss\n"
         "  • right panel → close (= drop focus back to input)\n"
         "  • docs filter active → clear filter"
     ),
     "ctrl+b": (
         "Open/close right panel. Opens to the most recent context tab\n"
-        "(= last skill activity → Agents; last error jump → Events)."
+        "(= last skill activity → Agents; last error received → Events)."
     ),
     "space": (
         "Toggle preview pane for cursor row. Works on Events / Agents /\n"


### PR DESCRIPTION
**[tui-coder]** — #1217（error inline scroll-away）が残した stale な error-box keybinding 参照の cleanup

## Why
#1217 は ErrorBox widget・F5/F6 binding・Esc/Shift+Esc dismiss action を撤去したが、**symbol grep では拾えない prose 記述**が 3 箇所残存していた（#1211/#1217 と同じ「symbol は消すが説明文を見逃す」class — TUI UX 探索の keybinding 整合 audit で検出）。削除済 UI を in-app Keys tab が案内し続けるのは user を混乱させる。

## What changed（prose / comment のみ、logic 変更なし）
1. **keys_tab.py** Esc 詳細: `• error box → dismiss` 行を削除（ErrorBox は #1217 で撤去済、Esc では二度と dismiss しない）
2. **keys_tab.py** Ctrl+B 詳細: `last error jump → Events` → `last error received → Events`（「jump」キーは存在しない。`_on_error` が error 受信時に `_last_focal_tab="events"` を set する smart-open は健在なので「received」が正確）
3. **app.py** F7 binding コメント: `F5/F6 reserved for conv-pane error-jump (#586)` の tombstone を「#1217 で error-jump 撤去ゆえ F5/F6 は now FREE・再利用可」に更新（scarce な function key を不要に塞ぐ誤誘導を解消）

## Verification
- ruff clean
- 残 stale error-keybinding prose を src+docs 全域 grep → **0**（残 hit は `reyn events --filter` の無関係 jump / commit sha / hex色 / 本 PR の新 comment 自体）
- `_on_error` の `_last_focal_tab="events"` set が健在なことを確認（Ctrl+B 詳細の wording 根拠）
- keys_tab + smoke test 46 passed

## Tier self-check
test 変更なし（prose + コメントのみ、挙動不変）。既存 keys_tab test（46 passed）が表示文字列を public surface で carry。stale string を pin する test は存在しないことを grep 確認済。

## Test plan
- [x] ruff clean / keys_tab + smoke 46 passed
- [x] 残 stale prose grep 0（src+docs）
- [ ] (manual, skipped — reviewer 環境で) Keys tab を開き Esc 詳細に error-box 行が無いこと、Ctrl+B 詳細が "last error received" になっていることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
