### PR TITLE
feat(tui): lighten InterventionWidget framing — left-bar + single margin (keep prominence)

### DIFF
--- a/src/reyn/chat/tui/widgets/intervention.py
+++ b/src/reyn/chat/tui/widgets/intervention.py
@@ -48,10 +48,10 @@ class InterventionWidget(Widget):
     DEFAULT_CSS = f"""
     InterventionWidget {{
         background: {_IV_SURFACE};
-        border: solid $primary;
-        padding: 1 2;
+        border-left: thick $primary;
+        padding: 0 1;
         height: auto;
-        margin: 1 0;
+        margin: 1 0 0 0;
         color: {_IV_TEXT};
     }}
     InterventionWidget Label.iv-question {{


### PR DESCRIPTION
**[tui-coder]** — InterventionWidget の framing を lighten（会話ペイン inline 整合の継続、TUI UX 探索 wave / Tier-1）

## Why
会話ペインは #1211（reply fold 撤去）/ #1217（error inline）/ #1212（tool-call 統合）で inline-aligned 化が進んだが、`InterventionWidget` は唯一 4 辺 bordered box + 上下 margin で視覚リズムを乱す holdout だった。

## 設計判断: de-box でなく "lighten"（prominence 温存）
**intervention は error と本質的に異なる** — error は passive output（scroll away して良い）だが、**intervention は blocking な call-to-action**（agent が回答待ちで停止中）。完全に passive inline text 化すると user が見逃す regression になる。よって重さは削るが**目立たせる要素（coral アクセント + warm tint）は温存**し、アクセント idiom を inline error の left-bar に揃える。

## What changed（CSS のみ、3 行、`intervention.py` DEFAULT_CSS）
```
- border: solid $primary;     → border-left: thick $primary;   (4辺箱 → 左アクセントバー、error と統一)
- padding: 1 2;               → padding: 0 1;                  (圧縮)
- margin: 1 0;                → margin: 1 0 0 0;               (上下空行 → 上1行のみ)
```
温存: `background: _IV_SURFACE`（tint=prominence）、bold coral question、全 interactive ロジック（chips / hotkey / focus / submit / skip-rest / free-text）— **CSS 以外 0 変更**。

## Verification（Opus 独立 verify）
- diff scope = intervention.py の CSS 3 行のみ（scope creep なし、git diff で確認）
- ruff clean / tier-audit 0 errors 0 warnings
- pytest `-k "intervention or tui_smoke"` = **275 passed**（2 error は無関係 router-loop collection artifact）
- interactive 系 test（chip click / hotkey / free-text / skip-rest / focus）は CSS 変更ゆえ不変で全 pass

## Tier self-check
test 変更なし（CSS のみ、挙動不変）。既存 intervention test は DOM-behavioral assert（Label text / Button id / class 有無）で、旧 border/margin/padding を format-pin する test は存在しないことを grep 確認済。

## Test plan
- [x] ruff / tier-audit / intervention+smoke 275 passed
- [x] diff scope = CSS 3 行のみ
- [ ] (manual, skipped — reviewer/user 環境で **視覚確認推奨**) intervention prompt が左アクセントバー化し上下空行が減ったこと、かつ依然 prompt として目立ち見逃さないこと、chips/hotkey が機能することを目視（prominence の主観調整があればこの PR で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
