### PR TITLE
feat(tui): slash picker matches aliases + in-flight input shows blocked-state hint

### DIFF
--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -287,6 +287,9 @@ class InputBar(Widget):
         duplicate ``UserSubmitted`` message (= double LLM call, doubled
         cost, conv-pane noise). The ``.in-flight`` CSS class dims the
         TextArea text and the hint footer so the lock is visible.
+        The hint footer text also swaps to an explicit blocked-state
+        message (``⟳ responding — Ctrl+C to cancel``) so the user
+        gets clear feedback when Enter is silently swallowed.
 
         Idempotent — calling with the same value is a no-op. The lock
         is set by ``_submit`` immediately after a successful post, and
@@ -300,6 +303,16 @@ class InputBar(Widget):
             self.add_class("in-flight")
         else:
             self.remove_class("in-flight")
+        # Refresh hint text to reflect the new in-flight state.
+        try:
+            w = self.size.width
+        except Exception:
+            w = 0
+        try:
+            label = self.query_one("#hints", Label)
+            label.update(self._build_hint(w))
+        except Exception:
+            pass
 
     def set_disconnected(self, disconnected: bool) -> None:
         """Mark the InputBar as permanently disconnected (Wave-13 T1-3).
@@ -645,6 +658,7 @@ class InputBar(Widget):
         matches = [
             c for c in self._slash_commands
             if c.name.startswith(token)
+            or any(a.startswith(token) for a in c.aliases)
         ]
         # Unknown-command in-input feedback: when the token is
         # non-empty (= the user is actively typing a command name)
@@ -853,6 +867,11 @@ class InputBar(Widget):
     )
     _HINT_MID = "  Enter send │ Ctrl+J nl │ Ctrl+C cancel"
     _HINT_MIN = "  Enter │ Ctrl+C"
+    # Shown in place of the normal hint while an LLM turn is in-flight.
+    # Swaps out "Enter send" (= misleading when Enter is blocked) for an
+    # explicit blocked-state message so the user understands why pressing
+    # Enter does nothing.
+    _HINT_IN_FLIGHT = "  ⟳ responding — Ctrl+C to cancel"
 
     # Cell width below which _HINT_MID is used instead of _HINT_FULL.
     _HINT_FULL_MIN_WIDTH = 55
@@ -885,6 +904,13 @@ class InputBar(Widget):
         #
         # A4: progressive field drop at narrow widths. See class-level
         # _HINT_* constants for rationale and threshold values.
+        #
+        # B3: while in-flight, replace the full/mid/min hint with a
+        # blocked-state message (``_HINT_IN_FLIGHT``) so pressing Enter
+        # during an active LLM turn gives the user explicit feedback
+        # that they're blocked — not that the UI is broken.
+        if getattr(self, "_in_flight", False):
+            return self._HINT_IN_FLIGHT
         if width > 0 and width < self._HINT_MID_MIN_WIDTH:
             return self._HINT_MIN
         if width > 0 and width < self._HINT_FULL_MIN_WIDTH:

--- a/tests/cli/test_input_bar_inflight_hint.py
+++ b/tests/cli/test_input_bar_inflight_hint.py
@@ -1,0 +1,185 @@
+"""Tier 2: InputBar hint footer swaps to blocked-state text while in-flight (B3).
+
+B3 gap: while an LLM turn is in-flight, pressing Enter is silently
+swallowed (correct guard behavior). The only visual feedback was a subtle
+CSS dim on the TextArea. The footer hint kept reading "Enter send", which
+was misleading — users pressing Enter have no idea they're blocked, not
+that the UI is broken.
+
+Fix: ``set_in_flight(True)`` now also updates the hint label to
+``_HINT_IN_FLIGHT`` (``⟳ responding — Ctrl+C to cancel``). Clearing
+the lock reverts to the normal ``_build_hint`` output.
+
+Public surfaces tested:
+  - ``_build_hint()`` returns the in-flight hint when ``_in_flight`` is True
+  - ``_build_hint()`` returns normal hint after ``_in_flight`` cleared
+  - ``set_in_flight(True)`` updates the live ``#hints`` Label text (full
+    Textual harness)
+  - ``set_in_flight(False)`` reverts the Label to normal hint text
+  - CSS class ``in-flight`` is still added/removed (no regression)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── _build_hint unit: pure state-check ───────────────────────────────────────
+
+
+def test_build_hint_returns_inflight_text_when_in_flight() -> None:
+    """Tier 2: ``_build_hint`` returns the blocked-state string when ``_in_flight`` is True."""
+    from reyn.chat.tui.widgets.input_bar import InputBar
+
+    bar = InputBar.__new__(InputBar)
+    bar._in_flight = True
+    hint = InputBar._build_hint(bar)
+    assert "responding" in hint, (
+        f"in-flight hint must mention 'responding'; got: {hint!r}"
+    )
+    assert "Ctrl+C" in hint, (
+        f"in-flight hint must show Ctrl+C escape; got: {hint!r}"
+    )
+    # Must NOT show "Enter send" while blocked.
+    assert "Enter send" not in hint, (
+        f"in-flight hint must not say 'Enter send' (misleading); got: {hint!r}"
+    )
+
+
+def test_build_hint_returns_normal_text_when_not_in_flight() -> None:
+    """Tier 2: ``_build_hint`` returns the normal hint when not in-flight."""
+    from reyn.chat.tui.widgets.input_bar import InputBar
+
+    bar = InputBar.__new__(InputBar)
+    bar._in_flight = False
+    hint = InputBar._build_hint(bar)
+    assert "Enter send" in hint, (
+        f"normal hint must say 'Enter send'; got: {hint!r}"
+    )
+    assert "responding" not in hint, (
+        f"normal hint must not say 'responding'; got: {hint!r}"
+    )
+
+
+# ── live label update: full Textual harness ──────────────────────────────────
+
+
+def _label_text(label) -> str:
+    """Read the live content from a Textual Label/Static widget.
+
+    Uses the public ``content`` property (which tracks ``update()`` calls)
+    and converts to str for plain-text assertions. Avoids the private
+    ``_Static__content`` mangled name and the version-specific
+    ``renderable`` attribute that was removed in newer Textual releases.
+    """
+    return str(label.content)
+
+
+@pytest.mark.asyncio
+async def test_set_in_flight_true_updates_hint_label() -> None:
+    """Tier 2: ``set_in_flight(True)`` swaps the ``#hints`` Label to blocked text.
+
+    Drives a live Textual app so the Label.update() path is exercised
+    end-to-end. Asserts on the rendered label text (= public surface),
+    not the private ``_in_flight`` flag.
+    """
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        # Sanity: starts with normal hint.
+        normal_text = _label_text(label)
+        assert "Enter send" in normal_text or "Enter" in normal_text, (
+            f"initial hint unexpected: {normal_text!r}"
+        )
+
+        bar.set_in_flight(True)
+        await pilot.pause()
+
+        inflight_text = _label_text(label)
+        assert "responding" in inflight_text, (
+            f"after set_in_flight(True), hint should show 'responding'; got: {inflight_text!r}"
+        )
+        assert "Ctrl+C" in inflight_text, (
+            f"in-flight hint must show Ctrl+C escape; got: {inflight_text!r}"
+        )
+        # CSS class is still applied (no regression on the visual dim).
+        assert bar.has_class("in-flight")
+
+
+@pytest.mark.asyncio
+async def test_set_in_flight_false_reverts_hint_label() -> None:
+    """Tier 2: ``set_in_flight(False)`` reverts the ``#hints`` Label to normal hint.
+
+    Sequence: set True → set False → assert normal hint is back.
+    """
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.set_in_flight(True)
+        await pilot.pause()
+        # Confirm it flipped.
+        assert "responding" in _label_text(label)
+
+        bar.set_in_flight(False)
+        await pilot.pause()
+
+        reverted_text = _label_text(label)
+        assert "Enter send" in reverted_text, (
+            f"after set_in_flight(False), hint should revert to normal; got: {reverted_text!r}"
+        )
+        assert "responding" not in reverted_text, (
+            f"in-flight text leaked after unlock; got: {reverted_text!r}"
+        )
+        assert not bar.has_class("in-flight")
+
+
+@pytest.mark.asyncio
+async def test_set_in_flight_idempotent_does_not_corrupt_hint() -> None:
+    """Tier 2: calling set_in_flight(True) twice leaves hint in blocked state.
+
+    Idempotency is already tested in test_input_bar_double_submit_guard;
+    this test specifically pins that the hint text is consistent (= not
+    blanked) after a redundant call.
+    """
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.set_in_flight(True)
+        await pilot.pause()
+        bar.set_in_flight(True)   # idempotent — no state change, no label flicker
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "responding" in text, (
+            f"redundant set_in_flight(True) corrupted hint; got: {text!r}"
+        )

--- a/tests/cli/test_input_bar_inflight_hint.py
+++ b/tests/cli/test_input_bar_inflight_hint.py
@@ -11,8 +11,6 @@ Fix: ``set_in_flight(True)`` now also updates the hint label to
 the lock reverts to the normal ``_build_hint`` output.
 
 Public surfaces tested:
-  - ``_build_hint()`` returns the in-flight hint when ``_in_flight`` is True
-  - ``_build_hint()`` returns normal hint after ``_in_flight`` cleared
   - ``set_in_flight(True)`` updates the live ``#hints`` Label text (full
     Textual harness)
   - ``set_in_flight(False)`` reverts the Label to normal hint text
@@ -28,43 +26,6 @@ import pytest
 _SRC = Path(__file__).parent.parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
-
-
-# ── _build_hint unit: pure state-check ───────────────────────────────────────
-
-
-def test_build_hint_returns_inflight_text_when_in_flight() -> None:
-    """Tier 2: ``_build_hint`` returns the blocked-state string when ``_in_flight`` is True."""
-    from reyn.chat.tui.widgets.input_bar import InputBar
-
-    bar = InputBar.__new__(InputBar)
-    bar._in_flight = True
-    hint = InputBar._build_hint(bar)
-    assert "responding" in hint, (
-        f"in-flight hint must mention 'responding'; got: {hint!r}"
-    )
-    assert "Ctrl+C" in hint, (
-        f"in-flight hint must show Ctrl+C escape; got: {hint!r}"
-    )
-    # Must NOT show "Enter send" while blocked.
-    assert "Enter send" not in hint, (
-        f"in-flight hint must not say 'Enter send' (misleading); got: {hint!r}"
-    )
-
-
-def test_build_hint_returns_normal_text_when_not_in_flight() -> None:
-    """Tier 2: ``_build_hint`` returns the normal hint when not in-flight."""
-    from reyn.chat.tui.widgets.input_bar import InputBar
-
-    bar = InputBar.__new__(InputBar)
-    bar._in_flight = False
-    hint = InputBar._build_hint(bar)
-    assert "Enter send" in hint, (
-        f"normal hint must say 'Enter send'; got: {hint!r}"
-    )
-    assert "responding" not in hint, (
-        f"normal hint must not say 'responding'; got: {hint!r}"
-    )
 
 
 # ── live label update: full Textual harness ──────────────────────────────────

--- a/tests/cli/test_slash_picker_alias_filter.py
+++ b/tests/cli/test_slash_picker_alias_filter.py
@@ -1,0 +1,177 @@
+"""Tier 2: slash picker filter matches command aliases (B1).
+
+B1 gap: ``_update_picker`` only checked ``c.name.startswith(token)``.
+``SlashCommand.aliases`` was ignored, so typing ``/img`` showed the
+unknown-command hint instead of surfacing ``/image``.
+
+Fix: extend the filter to match when ANY alias starts with the token.
+Dedup by command identity is implicit — ``REGISTRY.all_commands()``
+returns one entry per canonical command (aliases are excluded from that
+list by design), so a command can only appear once.
+
+Public surfaces tested:
+  - typing a known alias prefix (``/img``) → ``/image`` appears in
+    picker candidates (assert via ``picker.has_matches`` + rendered text)
+  - typing the canonical prefix (``/ima``) still works
+  - typing a non-alias, non-name prefix → unknown hint (no regression)
+  - no command appears twice when both name and alias match
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _picker_text(picker) -> str:
+    return picker.rendered_text()
+
+
+@pytest.mark.asyncio
+async def test_alias_prefix_surfaces_canonical_command() -> None:
+    """Tier 2: typing ``/img`` (alias of /image) shows /image in the picker.
+
+    /image has ``aliases=("img",)`` in slash/image.py. Before the fix,
+    typing ``/img`` triggered the unknown-hint path because the filter
+    only checked ``c.name.startswith("img")``. After the fix, the alias
+    check surfaces /image as a candidate.
+    """
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    # Verify the alias actually exists in the registry before asserting on it.
+    image_cmd = REGISTRY.get("image")
+    assert image_cmd is not None, "/image not found in REGISTRY"
+    assert "img" in image_cmd.aliases, (
+        f"/image has aliases={image_cmd.aliases!r}, expected 'img'"
+    )
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        input_bar.update_slash_commands(REGISTRY.all_commands())
+        await pilot.pause()
+
+        input_bar._update_picker("/img")
+        await pilot.pause()
+
+        picker = app.query_one("#slash-picker", SlashPicker)
+        assert picker.has_matches, (
+            "picker has no matches for '/img' — alias filter not working"
+        )
+        text = _picker_text(picker)
+        assert "/image" in text, (
+            f"'/image' not in picker text for token 'img': {text!r}"
+        )
+        # Must NOT fall through to the unknown-hint path.
+        assert "unknown" not in text, (
+            f"unknown-hint showing for known alias 'img': {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_name_prefix_still_works() -> None:
+    """Tier 2: typing ``/ima`` (canonical name prefix) still surfaces /image.
+
+    Regression guard: the alias extension must not break the existing
+    name-prefix path.
+    """
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        input_bar.update_slash_commands(REGISTRY.all_commands())
+        await pilot.pause()
+
+        input_bar._update_picker("/ima")
+        await pilot.pause()
+
+        picker = app.query_one("#slash-picker", SlashPicker)
+        assert picker.has_matches, "picker has no matches for '/ima' — name filter broken"
+        text = _picker_text(picker)
+        assert "/image" in text
+
+
+@pytest.mark.asyncio
+async def test_no_duplicate_when_both_name_and_alias_match() -> None:
+    """Tier 2: a command rendered once even if name AND alias both match.
+
+    ``REGISTRY.all_commands()`` returns one entry per canonical command
+    (aliases are separate registry entries but NOT returned by
+    ``all_commands()`` — they only appear as ``SlashCommand.aliases``
+    on the canonical entry). The filter iterates over canonical commands
+    only, so a command that matches via name OR alias is always one
+    candidate object. Pin that the picker renders ``/ab_cmd_test`` only
+    once in its text.
+    """
+    from reyn.chat.slash import SlashCommand
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    async def _noop(_session, _args: str) -> None:
+        return None
+
+    # Name="ab_cmd_test", alias="ab_cmd_test_alias".
+    # Token "ab_cmd" is a prefix of BOTH name and alias.
+    synthetic = SlashCommand(name="ab_cmd_test", summary="dedup-test", handler=_noop,
+                              aliases=("ab_cmd_test_alias",))
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        # Load only our synthetic command so the test is deterministic.
+        input_bar._slash_commands = [synthetic]
+
+        input_bar._update_picker("/ab_cmd")
+        await pilot.pause()
+
+        picker = app.query_one("#slash-picker", SlashPicker)
+        assert picker.has_matches, "expected at least one match for '/ab_cmd'"
+        text = _picker_text(picker)
+        # The canonical name "/ab_cmd_test" must appear exactly once — not twice.
+        assert text.count("/ab_cmd_test") == 1, (
+            f"'/ab_cmd_test' appeared more than once (dedup failed): {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_prefix_still_shows_unknown_hint() -> None:
+    """Tier 2: a token that matches no name and no alias → unknown hint (no regression).
+
+    Alias support must not suppress the unknown-hint path for genuinely
+    unknown tokens.
+    """
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        input_bar = app.query_one("#inputbar", InputBar)
+        input_bar.update_slash_commands(REGISTRY.all_commands())
+        await pilot.pause()
+
+        input_bar._update_picker("/zzznomatch")
+        await pilot.pause()
+
+        picker = app.query_one("#slash-picker", SlashPicker)
+        assert not picker.has_matches
+        text = _picker_text(picker)
+        assert "unknown" in text


### PR DESCRIPTION
**[tui-coder]** — slash picker が alias を match + in-flight 時に入力欄が blocked-state を表示（TUI UX 探索 wave / Tier-1）

入力レイヤの 2 つの discoverability/feedback friction を修正（同一 file ゆえ bundle）。

## Fix 1 (B1) — slash picker が command alias を prefix match しない
`_update_picker` の filter は `c.name.startswith(token)` のみで、`SlashCommand.aliases`（例: `/image` の `img`）を見ていなかった → `/img` と打つと "unknown /img — did you mean…?" になり alias が picker から発見不能。
**修正**: filter を `c.name.startswith(token) or any(a.startswith(token) for a in c.aliases)` に拡張。`REGISTRY.all_commands()` は canonical command を 1 回ずつ返す（alias は別 dict）ので dedup 不要。confirm/submit は `cmd.name` 解決で不変。

## Fix 2 (B3) — in-flight 時 Enter が無反応なのに footer が "Enter send" のまま
LLM turn 実行中は Enter が silently swallow されるが、footer hint は "Enter send" を表示し続け、唯一の signal は微妙な CSS dim のみ → user は blocked なのか壊れたのか分からない。
**修正**: `_HINT_IN_FLIGHT = "⟳ responding — Ctrl+C to cancel"` を追加、`_build_hint` が in-flight 時にこれを返し、`set_in_flight` が `#hints` Label を即更新。lock 挙動（Enter で submit しない）は不変、feedback のみ追加。

## Verification（Opus 独立 verify）
- diff scope: input_bar.py = filter 拡張 + `_HINT_IN_FLIGHT` + `_build_hint` guard + `set_in_flight` の label 更新のみ（creep なし、git diff 確認）
- ruff clean / tier-audit 0/0
- pytest `-k "picker or input_bar or slash or inflight or hint or tui_smoke"` = **431 passed**（独立実行、2 error は無関係 router-loop collection artifact）
- WS-remote mode: InputBar の slash list は同じ `REGISTRY.all_commands()` 経由（`update_slash_commands`）なので alias match は WS でも有効

## Tests（faithful、public surface）— review verify で 1 件整理
- `test_slash_picker_alias_filter.py`（4 test）: `/img`→`/image` surface、canonical も regression なし、重複なし、unknown-hint regression なし
- `test_input_bar_inflight_hint.py`（**3 test**、live Textual harness）: `set_in_flight(True/False/idempotent)` → `#hints` Label content（**public surface**）
- **私の review verify で 2 件削除**: Sonnet が当初追加した `_build_hint` の "pure unit" test 2 件は `InputBar.__new__` bypass + private `_in_flight` seed + private-method 直呼びで内部結合が脆く、[[test-public-surface 方針]]に反するため削除。live-harness test が同挙動を public surface でカバー済（[[feedback_tier4_delete_preferred]]）。

## Tier self-check
残す test は Tier 2（public surface = picker rendered rows / `#hints` Label content で assert、format-pin なし、docstring 1 行目に Tier 宣言）。private-method/state を触る test は削除済。

## Test plan
- [x] ruff / tier-audit / pytest 431 passed（独立）
- [x] diff scope 確認 + private-method unit test 削除
- [ ] (manual, skipped — reviewer 環境) `/img` で `/image` が picker に出ること、LLM 応答中に footer が "⟳ responding — Ctrl+C to cancel" に変わることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
