### PR TITLE
[WIP] feat(#1240 Wave 1): fine-grained file op kinds (phase = chat-tools subset, model/catalog axis)

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -488,7 +488,16 @@ class ControlIRExecutor:
                 })
                 continue
 
-            op_args = op.model_dump(exclude={"kind"})
+            # #1240 Wave 1: exclude None so unset optional fields are OMITTED
+            # rather than sent as JSON null. The coarse FILE_OP schema tolerates
+            # null, but the fine-grained ToolDefinition schemas (read_file etc.)
+            # type optional fields strictly (e.g. offset: integer), and a model
+            # default of None dumps to null which fails strict validation. Omit
+            # matches how the chat LLM emits these args (absent when unset);
+            # handlers rebuild the op from args with the same defaults, so this
+            # is functionally identical for coarse ops (only the memoization
+            # args_hash shifts, consistently for record + lookup).
+            op_args = op.model_dump(exclude={"kind"}, exclude_none=True)
 
             async def _invoker(args: dict, _op=op, _ctx=ctx, _name=op.kind) -> Any:
                 # ADR-0026 Phase 4 step 2: dispatch via the unified

--- a/src/reyn/op_runtime/registry.py
+++ b/src/reyn/op_runtime/registry.py
@@ -57,6 +57,8 @@ from pydantic import BaseModel
 from reyn.schemas.models import (
     AskUserIROp,
     CompactIROp,
+    DeleteFileIROp,
+    EditFileIROp,
     EmbedIROp,
     FileIROp,
     IndexDropIROp,
@@ -66,6 +68,7 @@ from reyn.schemas.models import (
     LintIROp,
     MCPInstallIROp,
     MCPIROp,
+    ReadFileIROp,
     RecallIROp,
     RunSkillIROp,
     SandboxedExecIROp,
@@ -73,6 +76,7 @@ from reyn.schemas.models import (
     SkillResolveIROp,
     WebFetchIROp,
     WebSearchIROp,
+    WriteFileIROp,
 )
 
 
@@ -113,6 +117,14 @@ class OpPurity(str, Enum):
 
 OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "file":        FileIROp,
+    # #1240 Wave 1: fine-grained file kinds (phase = chat-tools subset). Listed
+    # alongside the coarse "file" (coarse+fine union; coarse retained for compat).
+    # control_ir_executor routes each via the registry (READ_FILE/WRITE_FILE/...
+    # ToolDefinitions, gates.phase=allow) — no separate op_runtime handler.
+    "read_file":   ReadFileIROp,
+    "write_file":  WriteFileIROp,
+    "edit_file":   EditFileIROp,
+    "delete_file": DeleteFileIROp,
     "mcp":         MCPIROp,
     "run_skill":   RunSkillIROp,
     "shell":       ShellIROp,
@@ -159,6 +171,15 @@ OP_PURITY: dict[str, OpPurity] = {
     "web_search":  OpPurity.world,
     # Side effect (workspace mutation; file/write/delete fall here).
     "file":        OpPurity.side_effect,
+    # #1240 Wave 1: fine-grained file kinds. Match the coarse "file"
+    # classification (side_effect) for behavior-preservation across the
+    # migration — the coarse kind is uniformly side_effect regardless of verb,
+    # so the fine kinds keep that conservative stance. (A read_file→world
+    # accuracy refinement is a separate decision, out of pivot scope.)
+    "read_file":   OpPurity.side_effect,
+    "write_file":  OpPurity.side_effect,
+    "edit_file":   OpPurity.side_effect,
+    "delete_file": OpPurity.side_effect,
     # External / unknown side-effecting.
     "mcp":         OpPurity.external,
     "shell":       OpPurity.external,
@@ -233,7 +254,7 @@ ALL_OP_KINDS: frozenset[str] = frozenset(OP_KIND_MODEL_MAP.keys())
 # ---------------------------------------------------------------------------
 
 COARSE_TO_FINE: dict[str, frozenset[str]] = {
-    "file":      frozenset({"read_file", "write_file", "delete_file", "list_directory"}),
+    "file":      frozenset({"read_file", "write_file", "edit_file", "delete_file", "list_directory"}),
     "mcp":       frozenset({"call_mcp_tool", "list_mcp_servers", "list_mcp_tools"}),
     "run_skill": frozenset({"invoke_skill"}),
 }

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -260,6 +260,44 @@ class FileIROp(BaseModel):
     header: str | None = None        # optional preamble prepended before the entries (e.g. "# Memory Index\n\n")
 
 
+# ── #1240 Wave 1: fine-grained file ops (phase = chat-tools subset) ──────────
+# These fine kinds let phase Control IR emit the SAME tool names the chat
+# catalog uses (read_file/write_file/edit_file/delete_file) instead of the
+# coarse ``{kind:"file", op:<verb>}`` envelope — the catalog axis of the #1240
+# 2-axis unification. Execution stays unified and there is NO backend
+# duplication: the op_runtime fine handlers are thin adapters that build the
+# coarse ``FileIROp`` and reuse the single ``file.handle()`` backend (same
+# permission / WAL path). The coarse ``FileIROp`` is retained for
+# behavior-preserving compat (Wave 2 migrates skills' ``allowed_ops`` to fine
+# names + drops the coarse phase-only ToolDefinition).
+
+
+class ReadFileIROp(BaseModel):
+    kind: Literal["read_file"]
+    path: str
+    offset: int | None = None        # line number to start reading from (0-indexed); None = beginning
+    limit: int | None = None         # number of lines to read; None = all
+
+
+class WriteFileIROp(BaseModel):
+    kind: Literal["write_file"]
+    path: str
+    content: str
+
+
+class EditFileIROp(BaseModel):
+    kind: Literal["edit_file"]
+    path: str
+    old_string: str                  # exact text to replace (must be unique unless replace_all=True)
+    new_string: str                  # replacement text
+    replace_all: bool = False        # replace all occurrences instead of requiring uniqueness
+
+
+class DeleteFileIROp(BaseModel):
+    kind: Literal["delete_file"]
+    path: str
+
+
 class MCPIROp(BaseModel):
     kind: Literal["mcp"]
     server: str
@@ -553,7 +591,10 @@ class CompactIROp(BaseModel):
 #   sandboxed_exec, judge_output, skill_resolve, compact.
 ControlIROp = Annotated[
     Union[
-        FileIROp, MCPIROp, AskUserIROp, ShellIROp, LintIROp,
+        FileIROp,
+        # #1240 Wave 1: fine-grained file ops (coarse FileIROp retained for compat).
+        ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
+        MCPIROp, AskUserIROp, ShellIROp, LintIROp,
         RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
         EmbedIROp, IndexWriteIROp, IndexQueryIROp, RecallIROp, IndexDropIROp,
         SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,

--- a/tests/test_control_ir_executor_resume_plan.py
+++ b/tests/test_control_ir_executor_resume_plan.py
@@ -99,11 +99,12 @@ def test_resume_plan_is_propagated_to_dispatch_context(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     # The args_hash must match what dispatch_tool computes for the op.
-    # ControlIRExecutor passes op.model_dump(exclude={"kind"}) as args.
+    # ControlIRExecutor passes op.model_dump(exclude={"kind"}, exclude_none=True)
+    # as args (#1240 Wave 1: None optionals are omitted, not sent as null).
     op = FileIROp(
         kind="file", op="write", path="x.txt", content="fresh",
     )
-    op_args = op.model_dump(exclude={"kind"})
+    op_args = op.model_dump(exclude={"kind"}, exclude_none=True)
     args_hash = _compute_args_hash(op_args)
 
     plan = _plan_with([

--- a/tests/test_op_fine_grained_dispatch_1240.py
+++ b/tests/test_op_fine_grained_dispatch_1240.py
@@ -1,0 +1,132 @@
+"""Tier 2: #1240 Wave 1 — fine-grained file op kinds dispatch through the
+unified registry (the SAME path chat uses), proving the β-seam obviation.
+
+The phase→unified-ToolRegistry pivot (#1240, #1092 prerequisite) rests on one
+premise: a phase-emitted *fine* op (``read_file`` / ``write_file`` /
+``edit_file``) routes through ``control_ir_executor._invoker`` →
+``_registry.lookup(op.kind)`` (a phase=allow ToolDefinition) → the SAME handler
+the chat catalog uses (``READ_FILE.handler`` etc., which build a coarse
+``FileIROp`` and reuse the single ``op_runtime.file.handle()`` backend). No
+separate phase op-universe, no β seam.
+
+These tests PROVE that premise rather than assert it: each fine op produces real
+file I/O via a real ``Workspace`` and a real (non-None) ``PermissionResolver``
+(#1214 — a None resolver would auto-permit and mask the gate). Green here means
+β-obviation is demonstrated end-to-end at the executor layer (recon Q4 confirmed),
+de-risking the whole pivot. If a fine kind fell back to the legacy ``execute_op``
+skip path (handler_not_implemented), or were silently coarsened to ``file``
+before the allow-list check, these would fail.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.permissions.permissions import PermissionResolver
+from reyn.schemas.models import EditFileIROp, ReadFileIROp, WriteFileIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _executor(tmp_path: Path, *, grant: bool) -> ControlIRExecutor:
+    """Real ControlIRExecutor with a real Workspace + real PermissionResolver.
+
+    ``grant=True`` declares file.read/file.write allow (the skill-declared
+    permission); ``grant=False`` declares nothing, so the real resolver denies
+    (NOT a None resolver, which would auto-permit and mask the gate — #1214).
+    """
+    events = EventLog()
+    ws = Workspace(events=events)
+    resolver = PermissionResolver(
+        config_permissions=(
+            {"file.read": "allow", "file.write": "allow"} if grant else {}
+        ),
+        project_root=tmp_path,
+        interactive=False,
+    )
+    return ControlIRExecutor(
+        ws, events,
+        permission_resolver=resolver,
+        skill_name="test_skill",
+        chain_id="c1",
+        skill_run_id="run_001",
+    )
+
+
+def _ok(result: dict) -> bool:
+    """A non-error, non-skipped, non-denied op result."""
+    return result.get("status") not in ("error", "denied", "skipped")
+
+
+def test_fine_write_then_read_dispatch_via_registry(tmp_path, monkeypatch):
+    """Tier 2: fine write_file + read_file execute via the registry handler
+    (same path as chat) with real file I/O — the β-obviation proof.
+
+    ``allowed_ops`` uses the FINE name only (no coarse "file"), so a green
+    result also proves the op dispatches AS write_file/read_file and is not
+    coarsened to "file" before the allow-list / catalog check (recon Q4
+    "no fine→coarse collapse").
+    """
+    monkeypatch.chdir(tmp_path)
+    executor = _executor(tmp_path, grant=True)
+
+    w = asyncio.run(executor.execute(
+        [WriteFileIROp(kind="write_file", path="out.txt", content="hello pivot")],
+        phase="draft", allowed_ops={"write_file"},
+    ))
+    assert w and _ok(w[0]), f"fine write_file must execute (not skip/deny): {w}"
+    # Ground truth: the registry handler → file.handle() backend actually wrote.
+    # A legacy skip (handler_not_implemented) or a coarsen-then-reject would
+    # leave no file here.
+    assert (tmp_path / "out.txt").read_text() == "hello pivot"
+
+    r = asyncio.run(executor.execute(
+        [ReadFileIROp(kind="read_file", path="out.txt")],
+        phase="draft", allowed_ops={"read_file"},
+    ))
+    assert r and _ok(r[0]), f"fine read_file must execute: {r}"
+    # The fine read returned what the fine write produced — unified backend.
+    assert "hello pivot" in str(r[0])
+
+
+def test_fine_edit_file_dispatch_via_registry(tmp_path, monkeypatch):
+    """Tier 2: fine edit_file routes via the registry handler + applies a real
+    unique-string edit (the #1240 edit_file addition)."""
+    monkeypatch.chdir(tmp_path)
+    executor = _executor(tmp_path, grant=True)
+    (tmp_path / "doc.txt").write_text("alpha beta gamma")
+
+    e = asyncio.run(executor.execute(
+        [EditFileIROp(
+            kind="edit_file", path="doc.txt",
+            old_string="beta", new_string="DELTA",
+        )],
+        phase="draft", allowed_ops={"edit_file"},
+    ))
+    assert e and _ok(e[0]), f"fine edit_file must execute: {e}"
+    assert (tmp_path / "doc.txt").read_text() == "alpha DELTA gamma"
+
+
+def test_fine_write_real_resolver_denies_without_grant(tmp_path, monkeypatch):
+    """Tier 2: the real (non-None) PermissionResolver actually gates the fine op
+    — with NO file.write declaration the write is denied, not auto-permitted
+    (#1214 falsification).
+
+    The fine write_file traverses the SAME ``require_file_write`` gate the coarse
+    op does (inside the shared ``file.handle()`` backend). A None resolver would
+    let this slip; the deny proves the gate is live on the fine path.
+    """
+    monkeypatch.chdir(tmp_path)
+    executor = _executor(tmp_path, grant=False)
+
+    res = asyncio.run(executor.execute(
+        [WriteFileIROp(kind="write_file", path="denied.txt", content="leak")],
+        phase="draft", allowed_ops={"write_file"},
+    ))
+    assert res and not _ok(res[0]), (
+        f"ungranted fine write must be denied by the real resolver: {res}"
+    )
+    assert not (tmp_path / "denied.txt").exists(), (
+        "a denied write must not touch the filesystem"
+    )

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -30,6 +30,14 @@ from reyn.tools import get_default_registry
 _REGISTRY_WIRED_KINDS: frozenset[str] = frozenset({
     "ask_user",
     "file",
+    # #1240 Wave 1: fine-grained file kinds. Each has a phase=allow
+    # ToolDefinition (READ_FILE/WRITE_FILE/EDIT_FILE/DELETE_FILE, tools/file.py)
+    # that control_ir_executor routes via the registry (op.kind → _registry.lookup)
+    # — the SAME handler chat uses. Coarse "file" stays registry-wired for compat.
+    "read_file",
+    "write_file",
+    "edit_file",
+    "delete_file",
     "lint",
     "mcp",
     "mcp_install",


### PR DESCRIPTION
**[e2e-coder]** — **DRAFT / WIP.** #1240 **Wave 1** (model/catalog axis) of the phase→unified-ToolRegistry pivot — the #1092 prerequisite. `Refs #1240`. Canonical contract = #1240; recon = `/tmp/reyn-1092-recon/PIVOT_SCOPE_RECON.md`. Behavior-preserving (coarse `file` retained; staged compat).

### Goal
Let phase Control IR emit the SAME fine-grained file tool kinds the chat catalog uses (`read_file`/`write_file`/`edit_file`/`delete_file`) instead of the coarse `{kind:"file", op:<verb>}` envelope — the catalog axis of the 2-axis unification, so phase becomes a chat-tools subset.

### Flow-trace finding: Wave 1 is SMALLER than the contract assumed
The contract listed "op_runtime fine handlers" + "`tool_call_to_control_ir_op` verb-reinjection drop". Both turned out **unnecessary**:
- `control_ir_executor._invoker` (control_ir_executor.py:505-506) already routes each op via the registry by `op.kind` (`_registry.lookup(op.kind)`, phase=allow). The fine file ops already have phase=allow ToolDefinitions (`READ_FILE`/… `tools/file.py`) whose handlers build a coarse `FileIROp` and reuse the single `file.handle()` backend. So a phase-emitted `read_file` routes to the **same handler chat uses** — the β-seam obviation the recon predicted (Q4), needing **no new op_runtime handler**.
- `tool_call_to_control_ir_op` already converts fine names via the union (no `__` → no verb re-injection), so **no converter change**.

### Landed (2 commits)
- `538e97c8` ControlIROp union += `ReadFileIROp`/`WriteFileIROp`/`EditFileIROp`/`DeleteFileIROp` (chat naming). Coarse `FileIROp` retained (both validate via the discriminator).
- `c858c995` `OP_KIND_MODEL_MAP` += fine kinds → `ALL_OP_KINDS` coarse+fine union; `OP_PURITY` += fine (=`side_effect`, matching coarse); `COARSE_TO_FINE["file"]` += `edit_file` (compat so `allowed_ops:["file"]` permits all fine); partition-coverage test classifies the fine kinds as registry-wired.

### Remaining before un-drafting
- [ ] β-obviation **proof test** (next commit): a phase-emitted fine `read_file`/`write_file` op executes via `control_ir_executor` through the registry handler (same path as chat) + reads/writes a real file — pins the recon Q4 inference. Real Workspace/EventLog + **real (non-None) PermissionResolver** (enforcement-test rule, #1214).

### Test plan
- [x] fine+coarse union validation (discriminator); coarse `{kind:file,op:write}` compat intact
- [x] `ALL_OP_KINDS` includes fine; `is_op_allowed("read_file"/.../"edit_file", {"file"})` True (compat)
- [x] 755 op/control_ir/dispatch/purity/partition/1212 tests pass + ruff
- [ ] β-obviation dispatch proof test (above)
- [ ] (skipped — WIP) full-rootdir `pytest -q && ruff check .`

Scope: Wave 1 = model/catalog only. `allowed_ops` migration + coarse-ToolDef drop = Wave 2; native op-loop convergence (#1092 redux) = Wave 3. `#1235` (β-seam PR-A) stays draft-held; its convergence-core (RouterLoopCore/memo/adapter) survives & feeds Wave 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)