### PR TITLE
fix(tui): flush sub-skill tool-call rows at correct indent + strip markdown markup from inline header

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -38,6 +38,7 @@ Cost suffix (A4):
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import Literal
 
@@ -147,6 +148,45 @@ def _indent_body(renderable: RenderableType, indent: int = _BODY_INDENT_WITH_TS)
     ``ConversationView._current_body_indent()``.
     """
     return Padding(renderable, (0, 0, 0, indent))
+
+
+# Regex for leading Markdown sigil characters (headers, emphasis, code, blockquote).
+_MD_LEADING_SIGILS = re.compile(r"^[#*`_~> ]+")
+# Paired inline markers: **bold**, *em*, `code`.  Order matters — longest
+# pattern first so ``**x**`` is handled before the single-``*`` pass.
+_MD_BOLD = re.compile(r"\*\*([^*]+)\*\*")
+_MD_EM = re.compile(r"\*([^*]+)\*")
+_MD_CODE = re.compile(r"`([^`]+)`")
+
+
+def _plain_first_line(raw: str) -> str:
+    """Strip Markdown markup from the first line of ``raw`` for inline display.
+
+    Goal: the ``⏺ HH:MM <first-line>`` inline header shows clean prose
+    even when the reply opens with ``**Key finding:** …``, ``## Heading``,
+    or `` `code` ``.
+
+    Steps:
+    1. Take only the first line.
+    2. Remove paired inline emphasis / code markers so ``**x**`` → ``x``,
+       ``*x*`` → ``x``, `` `x` `` → ``x``.  Done BEFORE leading-sigil
+       strip so opening markers are still present for pair matching.
+    3. Strip leading sigil chars (``#``, ``*``, `` ` ``, ``_``, ``~``,
+       ``>``, space) that open Markdown headers / emphasis / blockquote.
+    4. Strip surrounding whitespace.
+
+    Non-markdown text like ``2 * 3 + 1`` is left unchanged — the inline
+    patterns require matching pairs and at least one non-``*`` character
+    between them, so they don't mangle bare arithmetic operators.
+    """
+    line = raw.splitlines()[0].strip() if raw else ""
+    # Apply paired-marker removal first (while the opening markers are intact).
+    line = _MD_BOLD.sub(r"\1", line)
+    line = _MD_EM.sub(r"\1", line)
+    line = _MD_CODE.sub(r"\1", line)
+    # Strip any remaining leading sigil chars (headers, blockquote, stray markers).
+    line = _MD_LEADING_SIGILS.sub("", line)
+    return line.strip()
 
 
 def _msg_header(symbol: str, name_style: str, show_ts: bool = True) -> Text:
@@ -1230,11 +1270,11 @@ class ConversationView(Widget):
             if body_text:
                 # Append first source line (stripped of leading # / * / `) to
                 # keep the header line short and readable.
-                src_first = body_text.splitlines()[0].strip().lstrip("#* `_")
+                src_first = _plain_first_line(body_text)
                 if src_first:
                     first_line_plain = f"{first_line_plain} {src_first}"
         elif body_text:
-            first_line_plain = body_text.splitlines()[0].strip().lstrip("#* `_")
+            first_line_plain = _plain_first_line(body_text)
         else:
             first_line_plain = ""
 
@@ -1763,13 +1803,32 @@ class ConversationView(Widget):
         self._do_flush_tool_call_row(row)
 
     def _do_flush_tool_call_row(self, row: ToolCallRow) -> None:
-        """Actual write-to-RichLog + unmount; safe to call from a timer."""
+        """Actual write-to-RichLog + unmount; safe to call from a timer.
+
+        A4 (flush-indent fix): when the row has a non-empty ``label_prefix``
+        (= sub-skill nesting, e.g. ``"  └─ "``), the prefix is already baked
+        into the Rich Text returned by ``_build_line1()`` / ``_build_line2()``.
+        The live widget renders at column 0 in the DOM (no Padding); flushing
+        via ``_write_body`` would apply an extra ``_indent_body`` Padding on top
+        of the prefix, producing double-indent vs the live widget.  Use
+        ``_write_log`` (column-0, no Padding) for prefixed rows so the flushed
+        line lands at the same visual column as the live widget.
+
+        Top-level rows (empty ``label_prefix``) continue to use ``_write_body``
+        — that path is unchanged by this fix.
+        """
         try:
             line1 = row._build_line1()
             line2 = row._build_line2()
-            self._write_body(line1)
-            if line2.plain:
-                self._write_body(line2)
+            if row._label_prefix:
+                # Sub-skill row: prefix is the indent — write at col 0.
+                self._write_log(line1)
+                if line2.plain:
+                    self._write_log(line2)
+            else:
+                self._write_body(line1)
+                if line2.plain:
+                    self._write_body(line2)
             row.remove()
         except Exception:
             # Same defensive stance as finish_skill_row: a flush

--- a/tests/cli/test_agent_inline_header_markup_strip.py
+++ b/tests/cli/test_agent_inline_header_markup_strip.py
@@ -1,0 +1,104 @@
+"""Tier 2: _plain_first_line strips Markdown markup for inline header display.
+
+A5 fix contract: the ``⏺ HH:MM <first-line>`` inline agent header must show
+clean prose even when the reply's first line contains Markdown markup:
+
+  ``**Key finding:** detail`` → ``Key finding: detail``
+  ``## Heading``              → ``Heading``
+  `` `code` snippet``         → ``code snippet``
+  ``*emphasis* text``         → ``emphasis text``
+
+Public surface tested: ``_plain_first_line`` (module-level helper in
+conversation.py).  The agent reply path (``render_message(kind='agent', ...)``
++ RichLog render) is exercised by the async integration tests in
+``test_conv_inline_header_body.py``; these unit tests pin the helper's
+own stripping logic without requiring a mounted app.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.conversation import _plain_first_line
+
+
+def test_bold_markup_stripped_from_first_line() -> None:
+    """Tier 2: ``**Key finding:** foo bar`` → ``Key finding: foo bar`` (no literal ``*``)."""
+    raw = "**Key finding:** foo bar\nMore detail on line two."
+    result = _plain_first_line(raw)
+    assert "**" not in result, f"bold markers must be removed; got {result!r}"
+    assert "Key finding:" in result, f"bold content must be preserved; got {result!r}"
+    assert "foo bar" in result, f"trailing prose must be preserved; got {result!r}"
+
+
+def test_h2_heading_stripped() -> None:
+    """Tier 2: ``## Heading`` → ``Heading`` (leading ``#`` and spaces removed)."""
+    result = _plain_first_line("## Heading\nBody text.")
+    assert "#" not in result, f"heading sigil must be removed; got {result!r}"
+    assert "Heading" in result, f"heading text must be preserved; got {result!r}"
+
+
+def test_inline_code_markers_stripped() -> None:
+    """Tier 2: `` `code` `` → ``code`` (backtick pairs removed)."""
+    result = _plain_first_line("`code` snippet\nmore text")
+    assert "`" not in result, f"backtick markers must be removed; got {result!r}"
+    assert "code" in result, f"code content must be preserved; got {result!r}"
+    assert "snippet" in result, f"trailing prose must be preserved; got {result!r}"
+
+
+def test_emphasis_markers_stripped() -> None:
+    """Tier 2: ``*emphasis* text`` → ``emphasis text``."""
+    result = _plain_first_line("*emphasis* text")
+    assert result == "emphasis text", (
+        f"single-star emphasis must be stripped; got {result!r}"
+    )
+
+
+def test_only_first_line_processed() -> None:
+    """Tier 2: multi-line input — only the first line is extracted and stripped."""
+    raw = "**First line**\n**Second line** is ignored"
+    result = _plain_first_line(raw)
+    assert "Second line" not in result, (
+        f"only first line should be processed; got {result!r}"
+    )
+    assert "First line" in result, f"first line content must appear; got {result!r}"
+
+
+def test_plain_prose_unchanged() -> None:
+    """Tier 2: ordinary prose without markdown sigils is returned unchanged."""
+    plain = "This is plain text without any markup."
+    result = _plain_first_line(plain)
+    assert result == plain, f"plain prose must be returned as-is; got {result!r}"
+
+
+def test_arithmetic_asterisk_not_mangled() -> None:
+    """Tier 2: bare ``*`` in arithmetic context (no pair) is left untouched.
+
+    ``2 * 3 + 1`` must not become ``2  + 1`` — the regex requires a matching
+    pair with at least one non-``*`` char between them.
+    """
+    result = _plain_first_line("value is 2 * 3 + 1")
+    assert "2" in result and "3" in result and "1" in result, (
+        f"arithmetic operands must survive; got {result!r}"
+    )
+    # The bare * between integers has no pair, so it's left by _MD_EM.
+    # The leading-sigil strip doesn't touch interior chars.
+    # Just ensure the result is sensible (not empty).
+    assert result.strip(), f"result must be non-empty; got {result!r}"
+
+
+def test_empty_input_returns_empty_string() -> None:
+    """Tier 2: empty input → empty output (no crash)."""
+    assert _plain_first_line("") == ""
+
+
+def test_bold_mid_line_stripped() -> None:
+    """Tier 2: ``**x**`` mid-line (no leading sigil) is also de-bolded."""
+    result = _plain_first_line("Result: **critical** error")
+    assert "**" not in result, f"bold markers must be removed; got {result!r}"
+    assert "critical" in result, f"bold content must be preserved; got {result!r}"
+    assert "Result:" in result, f"leading prose must be preserved; got {result!r}"

--- a/tests/cli/test_tool_call_row_flush_indent.py
+++ b/tests/cli/test_tool_call_row_flush_indent.py
@@ -1,0 +1,123 @@
+"""Tier 2: flushed ToolCallRow with label_prefix renders WITHOUT double-indent.
+
+A4 fix contract: when a ToolCallRow carries a non-empty ``label_prefix``
+(= sub-skill nesting, e.g. ``"  └─ "``), the prefix is baked into the
+Rich Text from ``_build_line1()``.  The flush path must NOT add an extra
+hanging-indent Padding on top — that would produce double-indent vs the
+live widget.
+
+Public surfaces tested:
+  - ``render_line1().plain`` (= public accessor for the built text)
+  - Leading whitespace of the flushed line (= col-position signal)
+  - Top-level rows (empty prefix) path is unchanged: the test asserts
+    the prefix-present path differs from the prefix-absent path in
+    leading whitespace, proving the two code paths diverge correctly.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _row_with_prefix(label_prefix: str = "  └─ "):
+    """Unmounted ToolCallRow with label_prefix for direct render testing."""
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+    row = ToolCallRow(
+        tool_name="bash",
+        args_repr="cmd=ls",
+        label_prefix=label_prefix,
+    )
+    row.finish_success(result_snippet="ok")
+    return row
+
+
+def _row_no_prefix():
+    """Unmounted ToolCallRow without label_prefix (top-level)."""
+    from reyn.chat.tui.widgets.tool_call_row import ToolCallRow
+    row = ToolCallRow(
+        tool_name="bash",
+        args_repr="cmd=ls",
+        label_prefix="",
+    )
+    row.finish_success(result_snippet="ok")
+    return row
+
+
+def test_prefixed_row_line1_starts_with_label_prefix() -> None:
+    """Tier 2: _build_line1() on a prefixed row opens with the label_prefix text.
+
+    This is the anchor invariant for the A4 fix: the prefix is baked into
+    the Rich Text that the flush path writes to the RichLog.  The flush
+    path must use _write_log (col-0) for these rows, not _write_body
+    (which would add an extra _indent_body Padding).
+    """
+    row = _row_with_prefix("  └─ ")
+    line1_plain = row.render_line1().plain
+    # The prefix appears at the very start of the rendered text.
+    assert line1_plain.startswith("  └─ "), (
+        f"prefixed row line1 must start with the label_prefix; got {line1_plain!r}"
+    )
+
+
+def test_top_level_row_line1_does_not_start_with_prefix() -> None:
+    """Tier 2: _build_line1() on a top-level row has NO label_prefix leading text.
+
+    Verifies the non-prefix path is unchanged: no extra whitespace is
+    prepended by ToolCallRow itself; the hanging-indent comes from the
+    flush path (_write_body Padding) in the conv pane.
+    """
+    row = _row_no_prefix()
+    line1_plain = row.render_line1().plain
+    # Top-level rows start directly with the state glyph (no prefix spaces).
+    assert not line1_plain.startswith("  └─ "), (
+        f"top-level row must not start with sub-skill prefix; got {line1_plain!r}"
+    )
+    # The line starts with the state glyph (no leading spaces from ToolCallRow).
+    assert not line1_plain.startswith(" "), (
+        f"top-level ToolCallRow must not self-indent; got {line1_plain!r}"
+    )
+
+
+def test_prefixed_row_flush_col_is_prefix_not_double_indent() -> None:
+    """Tier 2: A4 fix — flushed prefixed row must not accumulate double-indent.
+
+    The live widget (pre-flush) renders at column 0 with the label_prefix
+    providing the visual indent.  After the A4 fix, the flush path calls
+    ``_write_log`` (no Padding) for prefixed rows, so the flushed line
+    matches the live rendering: leading chars are exactly the label_prefix,
+    NOT (8-col Padding spaces + label_prefix).
+
+    We verify this by asserting render_line1().plain starts with the
+    literal prefix (not with 8 spaces).  If the old code (_write_body)
+    were used, the Padding is applied OUTSIDE the Rich Text object
+    (= by the RichLog/Padding wrapper), so the plain text itself stays
+    the same — the column-position error manifests in the rendered layout.
+    The plain-text check therefore targets the baked-in prefix rather
+    than trying to observe the Padding wrapper (which is not visible in
+    `.plain`).
+
+    The structural contract verified here: label_prefix must be present
+    at position 0 of the rendered plain text (= the flush path reads the
+    same Text that the live widget renders, without any additional prefix
+    injected by ToolCallRow itself).
+    """
+    row = _row_with_prefix("  └─ ")
+    line1 = row.render_line1()
+    plain = line1.plain
+    # The prefix appears at index 0 — not preceded by any extra whitespace
+    # that would indicate double-indenting.
+    prefix = "  └─ "
+    assert plain.startswith(prefix), (
+        f"flush line must start with bare label_prefix {prefix!r}; "
+        f"got leading chars: {plain[:20]!r}"
+    )
+    # After the prefix, the next non-space char should be the state glyph.
+    after_prefix = plain[len(prefix):]
+    first_nonspace = after_prefix.lstrip()
+    assert first_nonspace and first_nonspace[0] in ("●", "✓", "✗", "⊘"), (
+        f"first char after prefix must be a state glyph; got {after_prefix[:10]!r}"
+    )

--- a/tests/cli/test_tool_call_row_flush_indent.py
+++ b/tests/cli/test_tool_call_row_flush_indent.py
@@ -22,6 +22,32 @@ _SRC = Path(__file__).parent.parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+import pytest
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _line_text(log: RichLog, index: int) -> str:
+    return "".join(seg.text for seg in log.lines[index])
+
+
+def _find_line_containing(log: RichLog, needle: str) -> int:
+    for i, strip in enumerate(log.lines):
+        if needle in "".join(seg.text for seg in strip):
+            return i
+    raise AssertionError(f"{needle!r} never appeared in RichLog")
+
 
 def _row_with_prefix(label_prefix: str = "  └─ "):
     """Unmounted ToolCallRow with label_prefix for direct render testing."""
@@ -82,42 +108,39 @@ def test_top_level_row_line1_does_not_start_with_prefix() -> None:
     )
 
 
-def test_prefixed_row_flush_col_is_prefix_not_double_indent() -> None:
-    """Tier 2: A4 fix — flushed prefixed row must not accumulate double-indent.
+@pytest.mark.asyncio
+async def test_flushed_prefixed_row_lands_at_prefix_not_double_indent() -> None:
+    """Tier 2b: A4 regression guard — flushing a sub-skill ToolCallRow lands at
+    the bare ``label_prefix`` column, NOT an 8-col hanging-indent + prefix.
 
-    The live widget (pre-flush) renders at column 0 with the label_prefix
-    providing the visual indent.  After the A4 fix, the flush path calls
-    ``_write_log`` (no Padding) for prefixed rows, so the flushed line
-    matches the live rendering: leading chars are exactly the label_prefix,
-    NOT (8-col Padding spaces + label_prefix).
-
-    We verify this by asserting render_line1().plain starts with the
-    literal prefix (not with 8 spaces).  If the old code (_write_body)
-    were used, the Padding is applied OUTSIDE the Rich Text object
-    (= by the RichLog/Padding wrapper), so the plain text itself stays
-    the same — the column-position error manifests in the rendered layout.
-    The plain-text check therefore targets the baked-in prefix rather
-    than trying to observe the Padding wrapper (which is not visible in
-    `.plain`).
-
-    The structural contract verified here: label_prefix must be present
-    at position 0 of the rendered plain text (= the flush path reads the
-    same Text that the live widget renders, without any additional prefix
-    injected by ToolCallRow itself).
+    This exercises the REAL ``_do_flush_tool_call_row`` path (the fix's
+    actual code): the prefixed branch uses ``_write_log`` (no Padding).
+    Reverting that branch to ``_write_body`` would wrap the line in an
+    8-cell left ``Padding``, so the rendered RichLog line would start with
+    8 spaces — and this test would FAIL.  (The prior ``render_line1()``-only
+    check could not catch that, because the Padding lives OUTSIDE the Rich
+    Text and is not visible in ``.plain``.)
     """
-    row = _row_with_prefix("  └─ ")
-    line1 = row.render_line1()
-    plain = line1.plain
-    # The prefix appears at index 0 — not preceded by any extra whitespace
-    # that would indicate double-indenting.
-    prefix = "  └─ "
-    assert plain.startswith(prefix), (
-        f"flush line must start with bare label_prefix {prefix!r}; "
-        f"got leading chars: {plain[:20]!r}"
-    )
-    # After the prefix, the next non-space char should be the state glyph.
-    after_prefix = plain[len(prefix):]
-    first_nonspace = after_prefix.lstrip()
-    assert first_nonspace and first_nonspace[0] in ("●", "✓", "✗", "⊘"), (
-        f"first char after prefix must be a state glyph; got {after_prefix[:10]!r}"
-    )
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        row = _row_with_prefix("  └─ ")
+        conv.mount(row)
+        await pilot.pause()
+        conv._do_flush_tool_call_row(row)
+        await pilot.pause()
+
+        idx = _find_line_containing(log, "bash")
+        line = _line_text(log, idx)
+        # Bare prefix at the start — matches the live widget's column.
+        assert line.startswith("  └─ "), (
+            f"flushed prefixed row must start with the bare label_prefix; got {line!r}"
+        )
+        # Regression signal: ``_write_body`` would prepend an 8-cell Padding.
+        assert not line.startswith(" " * 8), (
+            f"flushed prefixed row must NOT carry an 8-col hanging indent "
+            f"(double-indent regression); got {line!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — sub-skill tool-call の flush indent + inline header の markdown markup strip（TUI UX 探索 wave / Tier-2 polish）

会話ペインの 2 つの render polish（同一 file ゆえ bundle）。

## Fix A4 — sub-skill ToolCallRow の flush が二重 indent
`_build_line1` は `label_prefix`（`"  └─ "` sub-skill nesting）を Rich Text に焼き込む。live widget は `padding: 0 0` で DOM col 0 描画 = prefix 自体が indent。だが `_do_flush_tool_call_row` は `_write_body`（`_indent_body` の col-8 Padding 付与）で flush → prefix の上に +8 = **二重 indent**（col 13 vs live col 5）。
**修正**: `_do_flush_tool_call_row` を `row._label_prefix` で分岐 — 非空 prefix（sub-skill）は `_write_log`（col 0、prefix が indent、live と一致）、空 prefix（top-level）は従来通り `_write_body`。`└─` glyph が nesting を伝えるので絶対 column 差は許容。

## Fix A5 — agent inline header に markdown markup が漏れる
`...lstrip("#* \`_")` は **先頭** sigil char しか除去せず、`**Key finding:** detail` → 末尾 `**` が literal で header に残存。
**修正**: module-level `_plain_first_line()` helper（compiled regex）で paired marker 除去（`**x**`→x / `*x*`→x / `` `x` ``→x）後に先頭 sigil strip。`2 * 3` 等の bare operator は pair regex が非 match で安全。2 callsite（旧 1233/1237）を helper 呼びに統一。

## Verification（Opus 独立 verify）
- diff scope: conversation.py = `_plain_first_line` helper + 4 regex + 2 callsite（A5）/ `_do_flush` の label_prefix 分岐（A4）のみ（creep なし）
- ruff clean / tier-audit 0/0 / pytest `-k "tool_call_row_flush or inline_header_markup or agent_markdown or tui_smoke"` = **56 passed**（独立、2 error は無関係 router-loop artifact）

## Tests（faithful、public surface）
- `test_agent_inline_header_markup_strip.py`（8 test）: `**bold**`/`## heading`/`` `code` ``/`*em*`/multi-line/plain/arithmetic-`*`-非破壊/empty — A5 を網羅
- `test_tool_call_row_flush_indent.py`（3 test）: prefixed row の built text が prefix で始まる + 8-space 二重 indent でない（`render_line1().plain` = public accessor で assert）

## ⚠ honest notes（lead 判断用）
1. **A4 test の範囲**: test は `render_line1().plain`（row の built text）を pin し prefix 不変を担保するが、`_do_flush` の `_write_log`/`_write_body` 分岐そのものは直接 exercise していない（full flush-render を RichLog harness で assert すればより強い）。fix 自体は正しいが test は invariant-guard 寄り。
2. **top-level の pre-existing asymmetry（本 PR scope 外）**: top-level tool row も live=col0 / flush=col8 で mismatch（jump）する pre-existing 挙動。finding は sub-skill 二重 indent のみゆえ未修正で残置。tool-call の col0-vs-col8 は「tool 行を reply body と揃えるか」の設計判断を含むので別途（follow-up 候補）。

## Test plan
- [x] ruff / tier-audit / 56 passed
- [x] diff scope（creep なし）
- [ ] (manual, skipped — reviewer 環境) sub-skill を含む skill 実行で tool 行が seal 後も live と同 column（└─ で nesting 可視）であること、`**bold:**` 始まりの reply で header に `*` が出ないことを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
