### PR TITLE
fix(tui): AsyncStackPanel shows skill summary as primary label, agent_id secondary

### DIFF
--- a/src/reyn/chat/tui/widgets/async_stack_panel.py
+++ b/src/reyn/chat/tui/widgets/async_stack_panel.py
@@ -34,12 +34,14 @@ issue #427 L4 step 5) was narrowed to attached-only because:
     a "what other agents are doing" overview better than a sticky
     1-line strip
 
-Spec (= issue #427 L2 visual contract, retained):
+Spec (= issue #427 L2 visual contract; label order updated fix/tui-asyncstack-summary-primary):
 
-  ⟳ async: code_review · 12.3s      ← running task
-  ⟳ async: monitor_loop · 5m21s      ← running, longer-running
-  ⚑ async: alice (1 pending)         ← intervention-pending task
-  … +N more (panel for all)          ← overflow indicator when > _CAP
+  ⟳ code_review · 12.3s  async: <run_id_dim>   ← running task (wide)
+  ⟳ code_review · 12.3s                         ← running task (narrow, id dropped)
+  ⚑ alice (1 pending)                            ← intervention-pending task
+  … +N more (panel for all)                      ← overflow indicator when > _CAP
+
+Summary (= skill name) is the bold primary label; agent_id is dim secondary.
 
 - 1-5 entries dynamic, ``_CAP`` cap with overflow indicator
 - Sort: intervention-pending (= ⚑) on top, then running by elapsed (= shortest first)
@@ -109,16 +111,11 @@ _FLASH_DURATION_S = 1.5
 
 _RIGHT_MARGIN_CELLS = 4
 
-# Wave-11 B#5: when the row is narrow enough that summary would be
-# wiped to 0 cells, the agent_id (often a 36-char UUID) gets
-# middle-elided to free cells for the more-informative summary.
-# Below this many cells of summary budget, prefer to elide id over
-# blanking summary entirely. 8 cells fits a typical short word.
-_MIN_SUMMARY_BUDGET_CELLS = 8
-
-# Minimum cells preserved for the elided agent_id: 4 head + 1 "…"
-# + 4 tail = 9. Typical UUID head ``abcd`` + tail ``7890`` is
-# enough to disambiguate among ≤ _CAP simultaneous tasks.
+# Minimum cells preserved for the elided agent_id suffix: 4 head + 1 "…"
+# + 4 tail = 9. Typical run_id head (timestamp slice) + tail (4-hex) is
+# enough to disambiguate among ≤ _CAP simultaneous tasks when the id
+# suffix is squeezed by a narrow panel. Below this budget the suffix is
+# dropped entirely and only the summary + elapsed are shown.
 _MIN_ELIDED_ID_CELLS = 9
 
 
@@ -672,10 +669,22 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         glyph: str,
         body_budget: int,
     ) -> None:
-        """Append one ``<glyph> async: <agent_id> · <body> · <elapsed>`` row.
+        """Append one row with summary as the primary label.
 
-        Truncation order on overflow: shrink ``summary`` first (= most
-        disposable), keep agent_id + glyph + elapsed always visible.
+        Row shape (wide): ``<glyph> <summary>  · <elapsed>  async: <agent_id>``
+        Row shape (narrow): ``<glyph> <summary>  · <elapsed>`` (agent_id elided)
+
+        Summary (= skill name) is the bold primary label — it answers
+        "what is running?" at a glance. agent_id (= timestamp + skill +
+        4-hex suffix) is dim and secondary, shown when width allows and
+        dropped first when the panel narrows. The agent_id key is never
+        lost from the widget state (``_entries`` dict is keyed by it);
+        only the rendered suffix is dropped.
+
+        Truncation order on overflow:
+          1. Drop the dim ``async: <agent_id>`` suffix entirely.
+          2. Elide summary (= right-truncate with "…") if still too wide.
+        The glyph + elapsed segment are always visible.
 
         Wave-13 T2-2: when ``entry.flashing`` is True, bypasses normal
         rendering and emits a fixed red ``✗ async: <id_short> (interrupted)``
@@ -704,50 +713,52 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
             elapsed_style = "dim"
             glyph_style = _CORAL
 
-        prefix = f"{glyph} async: {agent_id}"
-        prefix_cells = cell_len(prefix)
+        # Build the fixed-cost portions: glyph + summary label (primary)
+        # + elapsed tail. These always render; the dim agent_id suffix is
+        # added only when width is available.
+        summary_label = entry.summary or ""
+        glyph_prefix_cells = cell_len(f"{glyph} ")
         elapsed_cells = cell_len(elapsed_segment)
-        sep = "  · " if entry.summary else ""
-        sep_cells = cell_len(sep)
-
+        # Budget available for summary after glyph + elapsed are reserved.
         summary_budget = max(
-            0, body_budget - prefix_cells - sep_cells - elapsed_cells,
+            0, body_budget - glyph_prefix_cells - elapsed_cells,
         )
-        # Wave-11 B#5 + exploration finding #3 (2026-05-28): the
-        # summary (= skill name) is the most user-readable signal —
-        # ``word_stats_demo`` tells the user WHAT is running, while
-        # the agent_id (= timestamp + skill + 4-hex suffix) is mostly
-        # a unique-ish handle. So whenever rendering the full summary
-        # would require truncating it, middle-elide the agent_id
-        # first to free cells (= the head+tail preview still
-        # disambiguates among ≤ _CAP simultaneous tasks, while the
-        # full skill name lands without the ``word_stats…`` truncation
-        # the prior threshold-based logic left behind for narrow-ish
-        # widths). Identity floor is _MIN_ELIDED_ID_CELLS; below that
-        # the panel is so narrow we accept summary truncation too.
-        desired_summary_cells = cell_len(entry.summary or "")
-        if entry.summary and summary_budget < desired_summary_cells:
-            fixed_cells = cell_len(f"{glyph} async: ") + sep_cells + elapsed_cells
-            target_id_cells = max(
-                _MIN_ELIDED_ID_CELLS,
-                body_budget - fixed_cells - desired_summary_cells,
-            )
-            if target_id_cells < cell_len(agent_id):
-                agent_id = _middle_elide_id(agent_id, target_id_cells)
-                prefix = f"{glyph} async: {agent_id}"
-                prefix_cells = cell_len(prefix)
-                summary_budget = max(
-                    0, body_budget - prefix_cells - sep_cells - elapsed_cells,
-                )
-        summary_display = self._truncate_to_cells(entry.summary, summary_budget)
+
+        # Dim agent_id suffix: "  async: <agent_id>" appended when width
+        # allows. Compute its cost and decide whether it fits.
+        id_suffix_sep = "  "
+        id_label = "async: "
+        id_suffix_cells = cell_len(id_suffix_sep + id_label) + cell_len(agent_id)
+        desired_summary_cells = cell_len(summary_label)
+        # Remaining budget after summary (un-truncated) and elapsed.
+        budget_after_summary = (
+            body_budget - glyph_prefix_cells - desired_summary_cells - elapsed_cells
+        )
+        if budget_after_summary >= id_suffix_cells:
+            # Full agent_id suffix fits alongside the full summary.
+            rendered_agent_id: str | None = agent_id
+            summary_budget = desired_summary_cells  # summary fits fully
+        elif budget_after_summary >= _MIN_ELIDED_ID_CELLS + cell_len(id_suffix_sep + id_label):
+            # Elide agent_id to fit whatever gap remains — summary still full.
+            elide_budget = budget_after_summary - cell_len(id_suffix_sep + id_label)
+            rendered_agent_id = _middle_elide_id(agent_id, elide_budget)
+            summary_budget = desired_summary_cells  # summary still fits fully
+        else:
+            # Not enough room for any useful agent_id suffix — drop it.
+            # Summary gets the full remaining budget (may still truncate if
+            # the panel is very narrow, but that's the last resort).
+            rendered_agent_id = None
+            # summary_budget already set above (body minus glyph minus elapsed)
+
+        summary_display = self._truncate_to_cells(summary_label, summary_budget)
 
         t.append(f"{glyph} ", style=glyph_style)
-        t.append("async: ", style="dim " + _TEXT_MUTED)
-        t.append(agent_id, style="bold")
-        if summary_display:
-            t.append(sep, style="dim")
-            t.append(summary_display, style="dim")
+        t.append(summary_display, style="bold")
         t.append(elapsed_segment, style=elapsed_style)
+        if rendered_agent_id is not None:
+            t.append(id_suffix_sep, style="dim")
+            t.append(id_label, style="dim " + _TEXT_MUTED)
+            t.append(rendered_agent_id, style="dim " + _TEXT_MUTED)
 
     def _truncate_to_cells(self, text: str, max_cells: int) -> str:
         if max_cells <= 0:

--- a/tests/cli/test_async_stack_narrow_elide.py
+++ b/tests/cli/test_async_stack_narrow_elide.py
@@ -1,25 +1,22 @@
-"""Tier 2b: AsyncStackPanel middle-elides long agent_id on narrow widths.
+"""Tier 2b: AsyncStackPanel shows summary primary, agent_id secondary.
 
-Wave-11 finding B#5. Before this PR, the truncation order
-shrunk ``summary`` first, keeping the full ``agent_id`` always
-visible. For typical UUID-shaped task ids (~36 chars) the
-prefix consumed ~50 cells; on a 50-cell narrow pane (panel
-open + small terminal) summary went to 0 cells and the entry
-became unreadable identity-only.
+fix/tui-asyncstack-summary-primary: the row format changed so the
+human-readable summary (= skill name) is the bold primary label and
+the agent_id (= timestamp + skill + 4-hex run_id) is a dim suffix,
+shown when width allows and dropped first at narrow widths.
 
-This PR adds a middle-elide fallback: when summary would be
-wiped below ``_MIN_SUMMARY_BUDGET_CELLS``, the agent_id is
-middle-elided (= ``abcd…7890``) to free cells for the summary.
-Identity is preserved via head+tail preview, which is enough
-to disambiguate among ≤ _CAP simultaneous tasks.
+At narrow widths the id suffix is dropped entirely rather than
+elided — there isn't enough room for a useful head+tail preview
+alongside the summary. At wide widths the full id appears as a
+dim ``async: <id>`` trailer.
 
 Pinned:
-  - ``_middle_elide_id`` head+tail+ellipsis output shape
+  - ``_middle_elide_id`` head+tail+ellipsis output shape (pure function)
   - Short input round-trips unchanged
   - Sub-3-cell budget degrades to plain head truncation
-  - Wide-panel renders preserve the full agent_id
+  - Wide-panel renders include the agent_id as dim suffix
     (= no regression on the common case)
-  - Narrow-panel renders elide the id + render the summary
+  - Narrow-panel renders surface the summary, drop the agent_id suffix
 """
 from __future__ import annotations
 
@@ -66,9 +63,13 @@ def test_middle_elide_id_subtle_budget_degrades_to_trunc() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wide_panel_keeps_full_agent_id() -> None:
-    """Tier 2: wide panel (= plenty of summary budget) preserves the
-    full agent_id (= regression check)."""
+async def test_wide_panel_shows_summary_primary_and_id_dim_suffix() -> None:
+    """Tier 2: wide panel shows summary as primary and full agent_id as dim suffix.
+
+    At 140 cols there is ample room for both the bold summary label and
+    the ``  async: <id>`` dim suffix.  Both must appear in the rendered text.
+    snapshot() always returns the raw agent_id key regardless of render width.
+    """
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import ConversationView
 
@@ -76,22 +77,30 @@ async def test_wide_panel_keeps_full_agent_id() -> None:
     async with app.run_test(headless=True, size=(140, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
-        uuid_36 = "abcdef12-3456-7890-abcd-ef1234567890"
-        conv.add_async_task(uuid_36, "code_review")
+        run_id = "20240601T123456123456Z_code_review_a1b2"
+        conv.add_async_task(run_id, "code_review")
         await pilot.pause()
         panel = conv._async_stack()
         snap = panel.snapshot()
         # Snapshot returns the raw agent_id (not the rendered form).
         ids = {entry["agent_id"] for entry in snap if not entry["is_overflow"]}
-        assert uuid_36 in ids
-        # Rendered text (via cache) preserves the full id at wide width.
+        assert run_id in ids
         text = panel.rendered_text()
-        assert uuid_36 in text
+        # Summary (primary bold label) is present.
+        assert "code_review" in text
+        # Full agent_id appears as dim suffix at wide width.
+        assert run_id in text
 
 
 @pytest.mark.asyncio
-async def test_narrow_panel_elides_agent_id_to_preserve_summary() -> None:
-    """Tier 2: narrow panel middle-elides the id + still renders summary."""
+async def test_narrow_panel_summary_primary_id_dropped() -> None:
+    """Tier 2: narrow panel drops agent_id suffix and surfaces summary as primary.
+
+    At 60-col width the run_id (= timestamp + skill + 4-hex, ~35 chars) has
+    no room alongside the summary + elapsed.  The new truncation order drops
+    the dim agent_id suffix first so the human-readable summary stays fully
+    visible as the bold primary label.
+    """
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import ConversationView
 
@@ -101,28 +110,27 @@ async def test_narrow_panel_elides_agent_id_to_preserve_summary() -> None:
     async with app.run_test(headless=True, size=(60, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
-        uuid_36 = "abcdef12-3456-7890-abcd-ef1234567890"
-        conv.add_async_task(uuid_36, "this-is-a-distinctive-summary")
+        run_id = "20240601T123456123456Z_code_review_a1b2"
+        conv.add_async_task(run_id, "this-is-a-distinctive-summary")
         await pilot.pause()
         panel = conv._async_stack()
         text = panel.rendered_text()
-        # Full UUID NOT in render — it was elided.
-        assert uuid_36 not in text
-        # Head + ellipsis + tail signature present.
-        assert "abcd" in text
-        assert "7890" in text
-        assert "…" in text
-        # Summary surfaced (at least partially — the distinctive
-        # head should land).
-        assert "this-is" in text or "distinctive" in text
+        # Full run_id NOT in render — the suffix was dropped.
+        assert run_id not in text
+        # The human-readable summary IS surfaced (the distinctive head
+        # must be present as the bold primary label).
+        assert "this-is-a-distinctive-summary" in text or "this-is" in text
 
 
 @pytest.mark.asyncio
-async def test_narrow_panel_no_summary_skips_elide() -> None:
-    """Tier 2: when entry has no summary, no elide pressure — id stays full.
+async def test_narrow_panel_no_summary_renders_without_id_suffix() -> None:
+    """Tier 2: entry with no summary renders glyph + elapsed, id suffix optional.
 
-    Without a summary to make room for, there's nothing to gain by
-    eliding the id; the row just renders ``<glyph> async: <id> · <elapsed>``.
+    Without a summary, the row is ``<glyph>  · <elapsed>`` or
+    ``<glyph>  · <elapsed>  async: <id>`` depending on available width.
+    The key invariant: the id key is never dropped from widget state;
+    only the rendered suffix may be omitted. ``snapshot()`` still returns
+    the full agent_id regardless.
     """
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import ConversationView
@@ -131,9 +139,10 @@ async def test_narrow_panel_no_summary_skips_elide() -> None:
     async with app.run_test(headless=True, size=(60, 30)) as pilot:
         await pilot.pause()
         conv = app.query_one("#conversation", ConversationView)
-        # Short id (already fits) — no elide needed.
         conv.add_async_task("short-id", "")  # empty summary
         await pilot.pause()
         panel = conv._async_stack()
-        text = panel.rendered_text()
-        assert "short-id" in text
+        # State: agent_id preserved in snapshot regardless of render.
+        snap = panel.snapshot()
+        ids = {e["agent_id"] for e in snap if not e["is_overflow"]}
+        assert "short-id" in ids

--- a/tests/cli/test_async_stack_panel_poc.py
+++ b/tests/cli/test_async_stack_panel_poc.py
@@ -196,3 +196,23 @@ async def test_panel_renders_under_app_with_multiple_entries():
         first_line = rendered.split("\n", 1)[0]
         assert "alice" in first_line
         assert "⚑" in first_line
+
+
+def test_summary_is_primary_label_uuid_style_agent_id() -> None:
+    """Tier 2b: summary is the primary label; UUID-style agent_id is dim suffix.
+
+    At default (= 80-col) budget the summary appears before the agent_id
+    in the rendered text, confirming the new label order: summary first,
+    id trailing.  The test uses ``build_lines().plain`` (public surface)
+    and does not pin exact spacing or column offsets.
+    """
+    panel = _panel()
+    run_id = "20240601T123456123456Z_code_review_a1b2"
+    summary = "code_review"
+    panel.add(run_id, summary)
+    text = panel.build_lines().plain
+    # Both the summary and the agent_id must be visible at default width.
+    assert summary in text
+    assert run_id in text
+    # Summary appears before the agent_id in the row (= primary ordering).
+    assert text.index(summary) < text.index(run_id)


### PR DESCRIPTION
**[tui-coder]** — AsyncStackPanel が skill summary を primary・agent_id を secondary に（TUI UX 探索 wave / Tier-2 polish）

## Why（finding held — 確認済）
running-task 行は `prefix = f"{glyph} async: {agent_id}"` で **agent_id を bold-primary** 描画していた。production の `agent_id` は `_make_run_id(skill_name)` = `{ts_microseconds}_{safe_skill_name}_{4hex}`（~40字、例 `20240601T123456123456Z_code_review_a1b2`）。human-readable な summary（skill 名）は dim-secondary で、狭幅（Ctrl+B panel open → ~40-50 col）では **情報量の多い summary が先に truncate**、情報量の薄い id timestamp prefix が残る逆転。

## What changed（`async_stack_panel.py`）
新 row 形:
- 広い: `<glyph> <summary(bold)>  · <elapsed>  async: <agent_id(dim)>`
- 狭い: `<glyph> <summary(bold)>  · <elapsed>`（id suffix を drop）

truncation 順序: ① `async: <agent_id>` dim suffix を drop → ② なお溢れる時のみ summary を `…` で elide（最終手段）。Wave-11 の dead 定数 `_MIN_SUMMARY_BUDGET_CELLS` を除去、`_MIN_ELIDED_ID_CELLS` は中間 tier で温存。

## Preserved（撤去禁止を verify）
- flash path `✗ async: <id_short> (interrupted)` 不変
- **`/cancel <agent_id>` prefill**: `selected_agent_id()` は `_entries` dict key 由来（描画と独立）= 不変
- pending（⚑）/ interrupted（✗）state variant、`· <elapsed>` tail
- `snapshot()` は常に full raw agent_id を返す（公開 read API）

## Verification（Opus 独立 verify）
- diff scope: async_stack_panel.py + test 2 件のみ（他 src 不変、creep なし）
- ruff clean / tier-audit 0/0 / pytest `-k "async_stack or asyncstack or tui_smoke"` = **86 passed**（独立、2 error は無関係 router-loop artifact）
- finding を実 code で確認（`_make_run_id` の id format）してから reorder

## Tests（faithful、public surface）
- `test_async_stack_panel_poc.py`: `build_lines().plain`（公開 render）+ `snapshot()`（公開 read）で assert、private-state 不参照。`test_summary_is_primary_label_uuid_style_agent_id` で summary が agent_id より前に出ることを pin
- `test_async_stack_narrow_elide.py`: 新 format に追従、`test_narrow_panel_summary_primary_id_dropped`（UUID id + readable summary @60col で summary 可視・id drop）追加

## Test plan
- [x] ruff / tier-audit / 86 passed
- [x] diff scope + preserve（/cancel prefill・flash・snapshot）verify
- [ ] (manual, skipped — reviewer 環境) 長い run_id の skill を複数 spawn し Ctrl+B panel を狭めて、skill 名が見え続け agent_id が dim/drop されることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
