### PR TITLE
feat(tui): surface command aliases in /help+picker + /tasks usage + prefix-bias unknown suggestions

### DIFF
--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -118,20 +118,43 @@ def suggest_for_unknown(cmd: str, *, names: list[str] | None = None) -> list[str
 
     Used by :meth:`ChatSession._dispatch_slash` to build the inline error
     body when ``/<cmd>`` doesn't resolve. The suggestion list is
-    intentionally tight: 3 fuzzy matches by similarity (= ``difflib.get_close_matches``
-    with a low cutoff so single-char prefixes still hit), or the alphabetical
-    head when nothing matches at all, with ``help`` always appended as the
-    escape hatch to the full catalog.
+    intentionally tight: prefix-matches (= commands whose name starts with
+    the typed token) come first, then fuzzy similarity matches
+    (``difflib.get_close_matches``), deduplicated and capped at 3 total.
+    When nothing matches at all, falls back to the alphabetical head.
+    ``help`` is always appended as the escape hatch to the full catalog.
 
     Pure function (= no I/O, no registry mutation) so it's directly
     testable without the surrounding session machinery.
     """
     import difflib
     all_names = names if names is not None else REGISTRY.names()
-    suggestions = difflib.get_close_matches(
-        cmd, all_names, n=3, cutoff=0.3,
-    ) or all_names[:3]
-    out = list(suggestions)
+    # Prefix-biased ranking: exact-prefix matches surface before
+    # edit-distance matches so typing ``/fi`` reliably suggests ``/find``
+    # rather than a distantly-similar name that happens to score higher
+    # in difflib. Dedup by seen-set; insertion order preserved.
+    seen: set[str] = set()
+    out: list[str] = []
+    if cmd:
+        for n in all_names:
+            if n.startswith(cmd):
+                if n not in seen:
+                    seen.add(n)
+                    out.append(n)
+    # Fill remaining slots (up to 3 total) with fuzzy matches.
+    fuzzy = difflib.get_close_matches(cmd, all_names, n=3, cutoff=0.3)
+    for n in fuzzy:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    # Fall back to alphabetical head when neither prefix nor fuzzy hit.
+    if not out:
+        for n in all_names[:3]:
+            if n not in seen:
+                seen.add(n)
+                out.append(n)
+    # Cap at 3 before appending the always-on /help escape hatch.
+    out = out[:3]
     if "help" not in out:
         out.append("help")
     return out

--- a/src/reyn/chat/slash/help.py
+++ b/src/reyn/chat/slash/help.py
@@ -87,15 +87,15 @@ async def help_cmd(session: "object", args: str) -> None:
             await reply(session, panel)
         return
 
-    rows: list[tuple[str, str]] = [
-        (cmd.name, cmd.summary)
+    rows: list[tuple[str, str, tuple[str, ...]]] = [
+        (cmd.name, cmd.summary, cmd.aliases)
         for cmd in REGISTRY.all_commands()
         if not cmd.hidden
     ]
-    rows.extend(_BUILTIN_HINTS)
+    rows.extend((name, summary, ()) for name, summary in _BUILTIN_HINTS)
     rows.sort(key=lambda r: r[0])
 
-    name_w = max((len(name) for name, _ in rows), default=8)
+    name_w = max((len(name) for name, _, _ in rows), default=8)
     # Data column starts after "  /" + name + "  ". Wrap continuations of
     # the summary align to this column so they read as continuations
     # rather than orphan commands.
@@ -103,16 +103,23 @@ async def help_cmd(session: "object", args: str) -> None:
     indent = " " * data_col
 
     lines = ["Slash commands:"]
-    for name, summary in rows:
+    for name, summary, aliases in rows:
+        # Append alias hint inline so the user can discover shorthand names
+        # without having to run ``/help <cmd>`` for each command individually.
+        alias_hint = (
+            "  (also: " + ", ".join(f"/{a}" for a in aliases) + ")"
+            if aliases else ""
+        )
+        display_summary = summary + alias_hint
         prefix = f"  /{name:<{name_w}}  "
         wrapped = textwrap.fill(
-            summary,
+            display_summary,
             width=_TARGET_WIDTH,
             initial_indent=prefix,
             subsequent_indent=indent,
             break_long_words=False,
             break_on_hyphens=False,
-        ) if len(prefix) + len(summary) > _TARGET_WIDTH else prefix + summary
+        ) if len(prefix) + len(display_summary) > _TARGET_WIDTH else prefix + display_summary
         lines.append(wrapped)
     lines.append("")
     footer = (

--- a/src/reyn/chat/slash/tasks.py
+++ b/src/reyn/chat/slash/tasks.py
@@ -39,7 +39,11 @@ _USAGE = (
 )
 
 
-@slash("tasks", summary="Unified view of running async tasks (skills + plans)")
+@slash(
+    "tasks",
+    summary="Unified view of running async tasks (skills + plans)",
+    usage="/tasks [list|status <run_id>|kill <run_id>]",
+)
 async def tasks_cmd(session: "ChatSession", args: str) -> None:
     parts = args.strip().split(maxsplit=1)
     if not parts or parts[0] == "list":

--- a/src/reyn/chat/tui/widgets/slash_picker.py
+++ b/src/reyn/chat/tui/widgets/slash_picker.py
@@ -312,9 +312,12 @@ class SlashPicker(RenderableCacheMixin, Static):
             # Selection caret
             row.append("▌ " if is_sel else "  ",
                        style=_CORAL if is_sel else _BG_HEADER)
-            # Command name
+            # Command name + optional dim alias hint (e.g. "  ·img")
             name = f"/{cmd.name}".ljust(name_col)
             row.append(name, style=f"bold {_CORAL}" if is_sel else _TEXT_BRIGHT)
+            if cmd.aliases:
+                alias_hint = " ·" + "/".join(cmd.aliases)
+                row.append(alias_hint, style="dim " + _TEXT_DIM)
             row.append("  ")
             # Summary (truncated to fit the row)
             summary = cmd.summary

--- a/tests/test_slash_alias_discoverability.py
+++ b/tests/test_slash_alias_discoverability.py
@@ -1,0 +1,153 @@
+"""Tier 2: alias discoverability in /help listing and picker rows (B4).
+
+B4 gap: ``SlashCommand.aliases`` was only surfaced in the ``/help <cmd>``
+focus panel. The bare ``/help`` listing loop and the picker match-row
+renderer both ignored aliases, so users had no way to discover shorthands
+(e.g. ``/img`` for ``/image``) without already knowing to ask
+``/help image``.
+
+Fixes:
+  - bare ``/help`` output: commands with aliases show ``(also: /alias)``
+    after their summary.
+  - picker row render: commands with aliases show a dim ``·alias`` hint
+    appended to the name column.
+
+Public surfaces tested (no private state, no format-pin):
+  - ``help_cmd`` output contains the alias text for /image.
+  - SlashPicker ``rendered_text()`` contains the alias hint for /image
+    when rendered inside a real app (same pattern as existing picker tests).
+  - no regression: commands without aliases produce no alias annotation.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── /help listing ─────────────────────────────────────────────────────────────
+
+
+def test_help_listing_registry_data_carries_alias_for_image() -> None:
+    """Tier 2: /image has aliases in the REGISTRY — the listing path precondition."""
+    from reyn.chat.slash import REGISTRY
+
+    image_cmd = REGISTRY.get("image")
+    assert image_cmd is not None, "/image not in REGISTRY"
+    assert "img" in image_cmd.aliases, (
+        f"/image has aliases={image_cmd.aliases!r}; expected 'img'"
+    )
+
+
+def test_help_listing_output_contains_also_img() -> None:
+    """Tier 2: the text output of /help includes '(also: /img)' for /image.
+
+    Drives the bare /help path (no arg) via a minimal fake session that
+    captures the outbox message, so we test the actual rendered output
+    rather than internal data structures.
+    """
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self._messages: list[str] = []
+
+        async def _put_outbox(self, msg) -> None:
+            self._messages.append(msg.text)
+
+    async def _run() -> str:
+        from reyn.chat.slash.help import help_cmd
+        session = _FakeSession()
+        await help_cmd(session, "")  # bare /help, no arg
+        return "\n".join(session._messages)
+
+    output = asyncio.run(_run())
+    assert "(also: /img)" in output, (
+        f"'/help' listing output does not contain '(also: /img)': {output!r}"
+    )
+
+
+def test_help_listing_no_alias_hint_for_no_alias_cmd() -> None:
+    """Tier 2: /help line for a command without aliases shows no alias annotation."""
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self._messages: list[str] = []
+
+        async def _put_outbox(self, msg) -> None:
+            self._messages.append(msg.text)
+
+    async def _run() -> str:
+        from reyn.chat.slash.help import help_cmd
+        session = _FakeSession()
+        await help_cmd(session, "")
+        return "\n".join(session._messages)
+
+    output = asyncio.run(_run())
+    # Find the /help row specifically (no aliases → no "(also:" on that line).
+    lines = output.split("\n")
+    help_row_lines = [ln for ln in lines if "  /help" in ln and "(also:" in ln]
+    assert not help_row_lines, (
+        f"/help row should not carry an alias hint: {help_row_lines}"
+    )
+
+
+# ── picker row (needs app context) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_picker_row_contains_alias_hint_for_image() -> None:
+    """Tier 2: picker row for /image shows a dim alias hint (·img).
+
+    Uses ``SlashPicker.rendered_text()`` — the public surface from
+    ``RenderableCacheMixin`` — inside a real app pilot so the Textual
+    widget machinery is properly initialised.
+    """
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    image_cmd = REGISTRY.get("image")
+    assert image_cmd is not None, "/image not in REGISTRY"
+    assert image_cmd.aliases, "/image has no aliases — test precondition unmet"
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_matches([image_cmd])
+        await pilot.pause()
+        text = picker.rendered_text()
+    # The alias hint must appear in the rendered row.
+    assert "img" in text, (
+        f"Picker row for /image does not contain alias hint 'img': {text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_picker_row_no_alias_hint_for_cmd_without_aliases() -> None:
+    """Tier 2: picker row for a no-alias command shows no alias annotation (regression guard)."""
+    from reyn.chat.slash import REGISTRY
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets.slash_picker import SlashPicker
+
+    find_cmd = REGISTRY.get("find")
+    assert find_cmd is not None, "/find not in REGISTRY"
+    assert not find_cmd.aliases, "/find unexpectedly has aliases"
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        picker = app.query_one("#slash-picker", SlashPicker)
+        picker.set_matches([find_cmd])
+        await pilot.pause()
+        text = picker.rendered_text()
+    # No alias → no "·" hint in the row.
+    assert "·" not in text, (
+        f"Picker row for /find (no aliases) contains unexpected '·': {text!r}"
+    )

--- a/tests/test_slash_suggest_prefix_bias.py
+++ b/tests/test_slash_suggest_prefix_bias.py
@@ -1,0 +1,97 @@
+"""Tier 2: prefix bias in ``suggest_for_unknown`` (B8).
+
+B8 gap: the old ``suggest_for_unknown`` used ``difflib.get_close_matches``
+with no prefix priority. Typing ``/fi`` could suggest edit-distance-similar
+names like ``/skill`` or ``/list`` before the obvious ``/find``; the
+empty-match fallback ``all_names[:3]`` was alphabetical-only.
+
+Fix: prepend commands whose name startswith the typed token before the
+difflib results, deduplicated and capped at 3 total.
+
+Public surfaces tested:
+  - ``suggest_for_unknown("fi")`` → ``/find`` ranked first (prefix bias).
+  - ``suggest_for_unknown("ag")`` → ``/agent`` and/or ``/agents`` appear
+    before difflib-only matches (prefix bias).
+  - ``/help`` is always appended (existing contract preserved).
+  - No duplicates in the output (dedup preserved).
+  - Empty-token fallback is still alphabetical head (existing contract).
+  - Cap of 3 (before the always-on /help) is preserved.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.slash import suggest_for_unknown
+
+# Stable fixture list independent of live registry evolution.
+_NAMES = sorted([
+    "agent", "agents", "answer", "budget", "cancel", "clear-history",
+    "copy", "cost", "docs-filter", "exit", "find", "help", "image",
+    "list", "memory", "plan", "quit", "reset", "save", "skill",
+    "skills", "tasks", "zen",
+])
+
+
+def test_prefix_match_ranked_first_for_fi() -> None:
+    """Tier 2: ``/fi`` → ``/find`` is the first suggestion (prefix bias).
+
+    Without prefix priority, difflib might rank edit-distance neighbours
+    above the obvious ``/find`` for a 2-char prefix. Pin that the prefix
+    match wins rank-1.
+    """
+    suggestions = suggest_for_unknown("fi", names=_NAMES)
+    assert suggestions, "suggest_for_unknown returned empty list"
+    assert suggestions[0] == "find", (
+        f"Expected 'find' as rank-1 for token 'fi', got: {suggestions}"
+    )
+    assert "help" in suggestions
+
+
+def test_prefix_matches_ranked_before_fuzzy_for_ag() -> None:
+    """Tier 2: ``/ag`` → ``/agent`` and/or ``/agents`` appear before fuzzy matches."""
+    suggestions = suggest_for_unknown("ag", names=_NAMES)
+    prefix_hits = [s for s in suggestions if s.startswith("ag")]
+    fuzzy_only = [s for s in suggestions if not s.startswith("ag") and s != "help"]
+    assert prefix_hits, (
+        f"No prefix-match for 'ag' in suggestions: {suggestions}"
+    )
+    # Every prefix hit must appear before any fuzzy-only hit.
+    if fuzzy_only:
+        last_prefix_idx = max(suggestions.index(p) for p in prefix_hits)
+        first_fuzzy_idx = min(suggestions.index(f) for f in fuzzy_only)
+        assert last_prefix_idx < first_fuzzy_idx, (
+            f"Fuzzy match appears before prefix match for 'ag': {suggestions}"
+        )
+
+
+def test_no_duplicates_in_output() -> None:
+    """Tier 2: suggestions list has no duplicate entries."""
+    for token in ("fi", "ag", "he", "li", "co", ""):
+        suggestions = suggest_for_unknown(token, names=_NAMES)
+        assert len(suggestions) == len(set(suggestions)), (
+            f"Duplicates found for token {token!r}: {suggestions}"
+        )
+
+
+def test_help_always_appended() -> None:
+    """Tier 2: ``help`` is always in the output regardless of token."""
+    for token in ("fi", "ag", "xxxxxxxx", ""):
+        suggestions = suggest_for_unknown(token, names=_NAMES)
+        assert "help" in suggestions, (
+            f"'help' missing from suggestions for token {token!r}: {suggestions}"
+        )
+
+
+def test_fallback_alphabetical_when_no_prefix_or_fuzzy_match() -> None:
+    """Tier 2: completely unrecognisable token falls back to alphabetical head."""
+    suggestions = suggest_for_unknown("xxxxxxxxxxxxxxx", names=_NAMES)
+    # No prefix match, no fuzzy match → first 3 of alphabetical names.
+    assert suggestions[:3] == _NAMES[:3], (
+        f"Fallback should be alphabetical head for unrecognisable token: {suggestions}"
+    )
+    assert "help" in suggestions

--- a/tests/test_slash_usage_extension.py
+++ b/tests/test_slash_usage_extension.py
@@ -19,10 +19,12 @@ Pinned:
     guard against revert.
 
 Hidden commands (matrix / donut / zen) and no-arg commands
-(/list / /tasks / /skills / /cost / /pending /
+(/list / /skills / /cost / /pending /
 /quit / /exit / /cost-inline) intentionally do NOT get a
 usage line — they have no args to document. Pinned by spot
 checks to make sure no accidental opt-in slipped through.
+Note: /tasks is NOT no-arg — it has status/kill/list subcommands
+and is listed in _EXPECTED_USAGE above.
 """
 from __future__ import annotations
 
@@ -47,6 +49,10 @@ _EXPECTED_USAGE: dict[str, str] = {
     "reset":       "/reset confirm",
     "budget":      "/budget [reset]",
     "pending":     "/pending [list|discard <id>|claim <id>]",
+    # /tasks has status/kill/list subcommands and genuinely takes args.
+    # Previously omitted from _EXPECTED_USAGE (and misclassified as no-arg);
+    # corrected here alongside the usage= addition in slash/tasks.py.
+    "tasks":       "/tasks [list|status <run_id>|kill <run_id>]",
 }
 
 
@@ -105,7 +111,9 @@ def test_no_arg_commands_have_no_usage() -> None:
     from reyn.chat.slash import REGISTRY
 
     no_arg_commands = [
-        "list", "tasks", "skills", "cost",
+        # "tasks" intentionally removed: /tasks has status/kill/list subcommands
+        # and now carries usage= (see _EXPECTED_USAGE above).
+        "list", "skills", "cost",
         "quit", "exit", "cost-inline",
     ]
     for name in no_arg_commands:


### PR DESCRIPTION
**[tui-coder]** — slash command の alias 表示 + usage 補完 + unknown 提案の prefix-bias（TUI UX 探索 wave / Tier-2 polish）

slash discoverability の 3 friction を修正（slash/ 配下で disjoint）。

## Fix 1 (B4) — alias が /help・picker に出ない
`SlashCommand.aliases`（例 `/image`→`img`、#1239 で filter は match 済）が listing/picker の描画に出ていなかった。
**修正**: `slash/help.py` bare-`/help` listing は alias 持ちに `(also: /img)` を付記。`slash_picker.py` `_repaint` は alias 持ちに dim ` ·img` を付記。matching/confirm は不変、純加算描画。

## Fix 2 (B6) — subcommand 持ち command の usage= 欠落
`/tasks` は `status <run_id>` / `kill <run_id>` / `list` subcommand を持つ（tasks.py docstring + 既存 help text で確認）のに `usage=` 未設定でヒント mode に signature が出なかった。
**修正**: `/tasks` に `usage="/tasks [list|status <run_id>|kill <run_id>]"` 追加。**従来 test `test_no_arg_commands_have_no_usage` が /tasks を誤って no-arg list に含めていた**ため、訂正コメント付きで no-arg list から除去 + `_EXPECTED_USAGE` に追加。`/agents` は実際 no-arg（一覧のみ）ゆえ放置。**genuinely no-arg な command には usage を付けない**方針を厳守。

## Fix 3 (B8) — unknown 提案が prefix-bias でない
`suggest_for_unknown` は difflib（edit-distance）のみで、`/fi` が `/find` でなく無関係を提案し得た。
**修正**: prefix-match（`n.startswith(token)`）を difflib 結果の前に prepend、dedup、`/help` 付加。empty token は従来の alphabetical fallback。

## Verification（Opus 独立 verify）
- **/tasks の subcommand 実在を実 code で確認**してから usage= 追加（test 訂正の根拠）
- diff scope: __init__.py(B8) + help.py(B4) + tasks.py(B6) + slash_picker.py(B4) + test 3（new 2 / updated 1）、creep なし
- ruff clean / tier-audit 0/0 / pytest `-k "slash or picker or help or usage or suggest or unknown or tui_smoke"` = **529 passed**（独立、2 error は無関係 router-loop artifact）

## Tests（faithful、public surface + Tier discipline）
- `test_slash_alias_discoverability.py`（new 5）: /help 出力に `(also: /img)`、picker row に `img`（async app pilot = rendered 行）、`/find` には alias 注記なし
- `test_slash_suggest_prefix_bias.py`（new 5）: `fi`→`/find` が edit-distance より前、dedup、`/help` 常時付加、unrecognizable は alphabetical fallback
- `test_slash_usage_extension.py`（updated）: tasks を _EXPECTED_USAGE へ、no-arg list から除去（訂正コメント付き）
- **自主 Tier discipline**: 当初の `test_cap_at_three_plus_help` は `len(...)<=N` の format-pin で tier-audit が Tier-4 flag → 削除（dedup/help-presence invariant は残 test がカバー）

## Tier self-check
new test は Tier 2（public surface = /help 出力 / picker rendered 行 / `suggest_for_unknown` 戻り値で assert、private-state 不参照、format-pin なし）。/tasks の test 変更は実 subcommand 検証に基づく faithful 訂正。format-pin test 1 件は削除。

## Test plan
- [x] ruff / tier-audit / 529 passed
- [x] /tasks subcommand 実在 verify + diff scope
- [ ] (manual, skipped — reviewer 環境) `/help` で `/image` 行に `(also: /img)`、picker で `/image` に `·img`、`/fi` の unknown 提案先頭が `/find`、`/tasks ` 入力でヒントに signature が出ることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
