### PR TITLE
feat(#1240 Wave 1.5): glob_files/grep_files fine op kinds

### DIFF
--- a/src/reyn/op_runtime/registry.py
+++ b/src/reyn/op_runtime/registry.py
@@ -61,6 +61,8 @@ from reyn.schemas.models import (
     EditFileIROp,
     EmbedIROp,
     FileIROp,
+    GlobFilesIROp,
+    GrepFilesIROp,
     IndexDropIROp,
     IndexQueryIROp,
     IndexWriteIROp,
@@ -125,6 +127,11 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "write_file":  WriteFileIROp,
     "edit_file":   EditFileIROp,
     "delete_file": DeleteFileIROp,
+    # #1240 Wave 1.5: glob_files / grep_files fine kinds (same pattern).
+    # GLOB_FILES/GREP_FILES ToolDefinitions (tools/file.py, gates.phase=allow)
+    # route via the unified registry — same handler path chat uses.
+    "glob_files":  GlobFilesIROp,
+    "grep_files":  GrepFilesIROp,
     "mcp":         MCPIROp,
     "run_skill":   RunSkillIROp,
     "shell":       ShellIROp,
@@ -180,6 +187,10 @@ OP_PURITY: dict[str, OpPurity] = {
     "write_file":  OpPurity.side_effect,
     "edit_file":   OpPurity.side_effect,
     "delete_file": OpPurity.side_effect,
+    # #1240 Wave 1.5: glob_files / grep_files. Same conservative stance as
+    # Wave 1 fine kinds — match the coarse "file" side_effect classification.
+    "glob_files":  OpPurity.side_effect,
+    "grep_files":  OpPurity.side_effect,
     # External / unknown side-effecting.
     "mcp":         OpPurity.external,
     "shell":       OpPurity.external,
@@ -254,7 +265,7 @@ ALL_OP_KINDS: frozenset[str] = frozenset(OP_KIND_MODEL_MAP.keys())
 # ---------------------------------------------------------------------------
 
 COARSE_TO_FINE: dict[str, frozenset[str]] = {
-    "file":      frozenset({"read_file", "write_file", "edit_file", "delete_file", "list_directory"}),
+    "file":      frozenset({"read_file", "write_file", "edit_file", "delete_file", "list_directory", "glob_files", "grep_files"}),
     "mcp":       frozenset({"call_mcp_tool", "list_mcp_servers", "list_mcp_tools"}),
     "run_skill": frozenset({"invoke_skill"}),
 }

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -298,6 +298,31 @@ class DeleteFileIROp(BaseModel):
     path: str
 
 
+# ── #1240 Wave 1.5: glob_files / grep_files fine ops ─────────────────────────
+# Same pattern as Wave 1's read_file/write_file/edit_file/delete_file above.
+# Field names/types mirror the args the registry handler functions read:
+#   _handle_glob (tools/file.py): path, pattern
+#   _handle_grep (tools/file.py): path, pattern, glob, case_sensitive, max_results
+# Both have phase=allow ToolDefinitions (GLOB_FILES/GREP_FILES, tools/file.py),
+# so control_ir_executor routes them via the unified registry (same path as chat).
+
+
+class GlobFilesIROp(BaseModel):
+    kind: Literal["glob_files"]
+    path: str = "."                  # root directory to search from
+    pattern: str                     # glob pattern, e.g. "**/*.py"
+    max_results: int = 50
+
+
+class GrepFilesIROp(BaseModel):
+    kind: Literal["grep_files"]
+    path: str = "."                  # directory or file to search
+    pattern: str                     # regex pattern to search for
+    glob: str | None = None          # file filter glob, e.g. "**/*.py"
+    case_sensitive: bool = False
+    max_results: int = 50
+
+
 class MCPIROp(BaseModel):
     kind: Literal["mcp"]
     server: str
@@ -589,11 +614,15 @@ class CompactIROp(BaseModel):
 #   file, mcp, ask_user, shell, lint, run_skill, web_fetch, web_search,
 #   mcp_install, embed, index_write, index_query, recall, index_drop,
 #   sandboxed_exec, judge_output, skill_resolve, compact.
+# Fine-grained file ops (#1240 Wave 1+1.5): read_file, write_file, edit_file,
+#   delete_file, glob_files, grep_files (phase=allow registry entries).
 ControlIROp = Annotated[
     Union[
         FileIROp,
         # #1240 Wave 1: fine-grained file ops (coarse FileIROp retained for compat).
         ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
+        # #1240 Wave 1.5: glob_files / grep_files fine ops.
+        GlobFilesIROp, GrepFilesIROp,
         MCPIROp, AskUserIROp, ShellIROp, LintIROp,
         RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
         EmbedIROp, IndexWriteIROp, IndexQueryIROp, RecallIROp, IndexDropIROp,

--- a/tests/test_op_fine_grained_dispatch_1240.py
+++ b/tests/test_op_fine_grained_dispatch_1240.py
@@ -1,13 +1,14 @@
-"""Tier 2: #1240 Wave 1 — fine-grained file op kinds dispatch through the
-unified registry (the SAME path chat uses), proving the β-seam obviation.
+"""Tier 2: #1240 Wave 1 + Wave 1.5 — fine-grained file op kinds dispatch
+through the unified registry (the SAME path chat uses), proving the β-seam
+obviation.
 
 The phase→unified-ToolRegistry pivot (#1240, #1092 prerequisite) rests on one
 premise: a phase-emitted *fine* op (``read_file`` / ``write_file`` /
-``edit_file``) routes through ``control_ir_executor._invoker`` →
-``_registry.lookup(op.kind)`` (a phase=allow ToolDefinition) → the SAME handler
-the chat catalog uses (``READ_FILE.handler`` etc., which build a coarse
-``FileIROp`` and reuse the single ``op_runtime.file.handle()`` backend). No
-separate phase op-universe, no β seam.
+``edit_file`` / ``glob_files`` / ``grep_files``) routes through
+``control_ir_executor._invoker`` → ``_registry.lookup(op.kind)`` (a phase=allow
+ToolDefinition) → the SAME handler the chat catalog uses (``READ_FILE.handler``
+etc., which build a coarse ``FileIROp`` and reuse the single
+``op_runtime.file.handle()`` backend). No separate phase op-universe, no β seam.
 
 These tests PROVE that premise rather than assert it: each fine op produces real
 file I/O via a real ``Workspace`` and a real (non-None) ``PermissionResolver``
@@ -16,6 +17,10 @@ file I/O via a real ``Workspace`` and a real (non-None) ``PermissionResolver``
 de-risking the whole pivot. If a fine kind fell back to the legacy ``execute_op``
 skip path (handler_not_implemented), or were silently coarsened to ``file``
 before the allow-list check, these would fail.
+
+Wave 1.5 adds ``test_fine_glob_files_dispatch_via_registry`` and
+``test_fine_grep_files_dispatch_via_registry`` extending the same proof to the
+glob/grep search ops.
 """
 from __future__ import annotations
 
@@ -25,7 +30,13 @@ from pathlib import Path
 from reyn.events.events import EventLog
 from reyn.kernel.control_ir_executor import ControlIRExecutor
 from reyn.permissions.permissions import PermissionResolver
-from reyn.schemas.models import EditFileIROp, ReadFileIROp, WriteFileIROp
+from reyn.schemas.models import (
+    EditFileIROp,
+    GlobFilesIROp,
+    GrepFilesIROp,
+    ReadFileIROp,
+    WriteFileIROp,
+)
 from reyn.workspace.workspace import Workspace
 
 
@@ -129,4 +140,73 @@ def test_fine_write_real_resolver_denies_without_grant(tmp_path, monkeypatch):
     )
     assert not (tmp_path / "denied.txt").exists(), (
         "a denied write must not touch the filesystem"
+    )
+
+
+# ── #1240 Wave 1.5: glob_files / grep_files β-obviation proof ────────────────
+
+
+def test_fine_glob_files_dispatch_via_registry(tmp_path, monkeypatch):
+    """Tier 2: fine glob_files dispatches via the registry handler (GLOB_FILES
+    ToolDefinition, phase=allow) → _handle_glob → coarse FileIROp(op=glob) →
+    file.handle() backend — the same path chat uses.
+
+    ``allowed_ops`` uses the FINE name only (``glob_files``, no coarse ``file``),
+    so a green result also proves no fine→coarse collapse before the allow-list /
+    catalog check (#1240 Wave 1.5, same Q4 proof as Wave 1 ops above).
+    """
+    monkeypatch.chdir(tmp_path)
+    executor = _executor(tmp_path, grant=True)
+
+    # Write a couple of files — one .py, one .txt — so we can verify the glob
+    # only surfaces the .py file via the real file.handle() backend.
+    (tmp_path / "a.py").write_text("print('hello')")
+    (tmp_path / "b.txt").write_text("not python")
+
+    result = asyncio.run(executor.execute(
+        [GlobFilesIROp(kind="glob_files", path=".", pattern="*.py")],
+        phase="draft", allowed_ops={"glob_files"},
+    ))
+    assert result and _ok(result[0]), (
+        f"fine glob_files must execute (not skip/deny): {result}"
+    )
+    # The handler normalises output to {pattern, matches, count} (or a
+    # superset); the real glob must surface a.py.
+    result_str = str(result[0])
+    assert "a.py" in result_str, (
+        f"glob_files result must include a.py: {result[0]}"
+    )
+    assert "b.txt" not in result_str, (
+        f"glob_files with *.py pattern must not include b.txt: {result[0]}"
+    )
+
+
+def test_fine_grep_files_dispatch_via_registry(tmp_path, monkeypatch):
+    """Tier 2: fine grep_files dispatches via the registry handler (GREP_FILES
+    ToolDefinition, phase=allow) → _handle_grep → coarse FileIROp(op=grep) →
+    file.handle() backend — the same path chat uses.
+
+    ``allowed_ops`` uses the FINE name only (``grep_files``, no coarse ``file``),
+    proving no fine→coarse collapse. The grep must surface the matching line
+    from real file I/O (not a stub).
+    """
+    monkeypatch.chdir(tmp_path)
+    executor = _executor(tmp_path, grant=True)
+
+    # Write a file with a distinctive string we can grep for.
+    (tmp_path / "source.py").write_text(
+        "def wave15_marker():\n    return 'glob_grep_proof'\n"
+    )
+
+    result = asyncio.run(executor.execute(
+        [GrepFilesIROp(kind="grep_files", path=".", pattern="wave15_marker")],
+        phase="draft", allowed_ops={"grep_files"},
+    ))
+    assert result and _ok(result[0]), (
+        f"fine grep_files must execute (not skip/deny): {result}"
+    )
+    # The real grep must find the match in source.py.
+    result_str = str(result[0])
+    assert "wave15_marker" in result_str, (
+        f"grep_files result must include the matched string: {result[0]}"
     )

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -38,6 +38,10 @@ _REGISTRY_WIRED_KINDS: frozenset[str] = frozenset({
     "write_file",
     "edit_file",
     "delete_file",
+    # #1240 Wave 1.5: glob_files / grep_files fine kinds. Each has a phase=allow
+    # ToolDefinition (GLOB_FILES/GREP_FILES, tools/file.py) — same dispatch path.
+    "glob_files",
+    "grep_files",
     "lint",
     "mcp",
     "mcp_install",


### PR DESCRIPTION
**[e2e-coder]** — #1240 **Wave 1.5** (model/catalog axis). `Refs #1240`. Additive + behavior-preserving extension of the merged Wave 1 (#1241): adds `glob_files` + `grep_files` fine op kinds so phase Control IR can emit them like chat does (the catalog axis). Prerequisite for Wave 2a — coarse `[file]` grants 10 verbs, and Wave 2a's behavior-preserving migration needs fine models for the chat-equivalent verbs; Wave 1 covered read/write/edit/delete, this adds glob/grep (grep is in active use by swe_bench/explore + swe_bench/plan).

### Commits (2, mirroring Wave 1)
- `25107f9d` ControlIROp union += `GlobFilesIROp`/`GrepFilesIROp` (fields match the chat handler args: glob=path/pattern/max_results; grep=path/pattern/glob/case_sensitive/max_results)
- `fae396a9` `OP_KIND_MODEL_MAP`+`ALL_OP_KINDS` += glob/grep; `OP_PURITY` (=side_effect, matching coarse); `COARSE_TO_FINE["file"]` += glob_files/grep_files; partition-coverage test classifies them as registry-wired; **+2 β-obviation proof tests**

### β-obviation proof (extends the Wave-1 pattern)
`test_fine_glob_files_dispatch_via_registry` + `test_fine_grep_files_dispatch_via_registry`: a phase-emitted fine `glob_files`/`grep_files` op routes via `control_ir_executor` → `_registry.lookup(op.kind)` (GLOB_FILES/GREP_FILES, phase=allow) → `_handle_glob`/`_handle_grep` → coarse `FileIROp(op=glob/grep)` → single `file.handle()` backend (**same path chat uses**) → **real file I/O** (glob surfaces `a.py` not `b.txt`; grep surfaces the matching line). Fine-only `allowed_ops` proves no fine→coarse collapse; real Workspace + real (non-None) PermissionResolver (#1214). Genuine proof, not a structural proxy.

### Test plan
- [x] union validation (fine glob/grep kinds + coarse compat); field accuracy vs handler args verified
- [x] 2 β-obviation dispatch proof tests (real file I/O via the registry path)
- [x] partition-coverage + op-purity-coverage invariants satisfied
- [x] **full-rootdir** `pytest -q --ignore=.claude`: **6714 passed**, 5 skipped, 3 xfailed. The 1 failure (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path`) is the **pre-existing not-my-diff** local HTML-parse quirk (reproduced on clean `origin/main`, bypasses control_ir_executor; CI-green; #1203 precedent — same as #1241).
- [x] ruff + tier audit clean

### Scope / provenance
Implemented as a mechanical mirror of Wave 1 (cost-policy: well-scoped pattern → sonnet sub-agent), diff + proof tests reviewed and independently re-verified by me before push. `list_directory` deferred (no clean coarse-verb/handler mapping, unlike glob/grep). Next: Wave 2a (`allowed_ops` coarse→fine migration). `#1235` stays draft-held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)