### PR TITLE
fix(tui): tool-call failure sets events focal tab for smart Ctrl+B (C6)

### DIFF
--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -1514,6 +1514,12 @@ class OutboxRouter:
             conv.fail_tool_call_row(op_id, error=reason)
         except Exception:
             pass
+        # C6: a tool failure is something the user will want to inspect, so
+        # set the smart-Ctrl+B focal tab to events (same as ``_on_error``).
+        # Without this the focal tab stays on whatever the last skill-trace
+        # event set (= agents), and Ctrl+B after a tool failure opens the
+        # Agents tab instead of the Events trace the user came to see.
+        self._app._last_focal_tab = "events"
 
     def _on_embedding_lifecycle(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/tests/cli/test_tool_failure_focuses_events.py
+++ b/tests/cli/test_tool_failure_focuses_events.py
@@ -1,0 +1,71 @@
+"""Tier 2b: a tool-call failure sets the smart-Ctrl+B focal tab to events (C6).
+
+C6 gap: ``OutboxRouter._on_tool_call_failed`` rendered the failed row but never
+set ``_last_focal_tab``, so it stayed on whatever the last skill-trace event set
+(= agents). Ctrl+B after a tool failure then opened the Agents tab instead of the
+Events trace the user came to inspect. ``_on_error`` already set events; this
+brings the tool-failure path in line.
+
+Public surface: after a ``tool_call_failed``, opening the panel
+(``action_toggle_panel`` = Ctrl+B) lands on the Events tab
+(``RightPanel.panel_type == "events"``).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.app_outbox import OutboxRouter
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.right_panel import RightPanel
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_failure_sets_events_focal_tab_for_ctrl_b() -> None:
+    """Tier 2b: Ctrl+B after a tool failure opens the Events tab (not Agents)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        # Precondition: a prior skill-trace event left the focal tab on
+        # "agents" — the stale state the C6 bug would leave Ctrl+B pointing
+        # at after a tool failure. (Setup only; the assert is on the public
+        # panel_type after Ctrl+B.)
+        app._last_focal_tab = "agents"
+        msg = OutboxMessage(
+            kind="tool_call_failed",
+            text="",
+            meta={
+                "op_id": "op-fail-1",
+                "error_kind": "Boom",
+                "error_message": "kaboom",
+            },
+        )
+        router._on_tool_call_failed(msg, conv, None)
+
+        # Public surface: Ctrl+B opens the panel and lands on Events.
+        app.action_toggle_panel()
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        assert panel.panel_type == "events", (
+            f"Ctrl+B after a tool failure must open the Events tab; "
+            f"got {panel.panel_type!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — tool-call 失敗時に smart-Ctrl+B の focal tab を events に（TUI UX 探索 wave / Tier-2 C6、調査で確認）

## Why（調査で confirmed）
`OutboxRouter._on_tool_call_failed` は失敗行を描画するが `_last_focal_tab` を set していなかった → 直近の skill-trace event が set した値（= agents）のまま。tool 失敗後に Ctrl+B を押すと、見たい Events trace でなく Agents tab が開く。`_on_error`（1417）は既に events を set 済で、tool-failure path をそれに揃える。

## What changed（1 行 + test）
`_on_tool_call_failed` の末尾に `self._app._last_focal_tab = "events"`（`_on_error` と同パターン）。

## Verification（Opus 独立 verify + falsification）
- diff scope: app_outbox.py 1 行 + 新 test 1 file のみ
- ruff clean / smoke 41 passed
- **falsification-verified**: test は router handler を駆動→`action_toggle_panel`(Ctrl+B)→**public `RightPanel.panel_type == "events"`** を assert。precondition で `_last_focal_tab="agents"` を seed（setup のみ）。**fix 行を削除すると panel が seed の agents に着地し test が FAIL** することを確認（削除→fail→復元→pass）。

## 補足（小 UX 判断）
「tool 失敗後 Ctrl+B を Events にする」は小さな UX 挙動判断。失敗 = trace を見たい、という想定（`_on_error` と同軸）。reversible。

## Tier self-check
新 test は Tier 2b（public surface = `panel.panel_type` で assert、private `_last_focal_tab` は **setup seed のみで assert せず**、format-pin なし、docstring 1 行目 Tier 宣言）。

## Test plan
- [x] ruff / smoke 41 passed / C6 test pass + falsification(削除→fail)
- [ ] (manual, skipped — reviewer 環境) tool を失敗させた後 Ctrl+B が Events tab を開くことを目視
