### PR TITLE
[WIP] feat(#1240 Wave 2a Batch 1): migrate fixture-free skills' allowed_ops file→fine

### DIFF
--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -198,12 +198,57 @@ class ControlIRExecutor:
         """Read-only accessor for the injected ScopedSecretStore (or None)."""
         return self._secret_store
 
+    # #1240 Wave 2a (catalog-build): minimal valid example per fine file kind,
+    # used to build the json-mode ControlIROpSpec advertised in the frame. The
+    # description comes from the unified registry (single source); the example
+    # is the op shape (ControlIROpSpec requires one — it is not on ToolDefinition).
+    _FINE_FILE_OP_EXAMPLES: dict[str, dict[str, Any]] = {
+        "read_file":   {"kind": "read_file", "path": "src/module.py"},
+        "write_file":  {"kind": "write_file", "path": "out.txt", "content": "full file text"},
+        "edit_file":   {"kind": "edit_file", "path": "src/module.py", "old_string": "old", "new_string": "new"},
+        "delete_file": {"kind": "delete_file", "path": "tmp/scratch.txt"},
+        "glob_files":  {"kind": "glob_files", "path": ".", "pattern": "**/*.py"},
+        "grep_files":  {"kind": "grep_files", "path": "src", "pattern": "def \\w+", "glob": "**/*.py"},
+    }
+
+    def _fine_file_op_specs(self) -> list[ControlIROpSpec]:
+        """#1240 Wave 2a: fine-grained file op specs for the json-mode frame.
+
+        Derived from the unified ToolRegistry (the SAME phase=allow
+        ToolDefinitions the op-loop catalog ``_build_phase_tool_catalog`` uses —
+        single source for the description), so a json-mode phase that migrated
+        its ``allowed_ops`` to fine names (read_file/write_file/…) gets matching
+        ``available_control_ops`` in the frame (the LLM SEES + emits the fine
+        kinds). Advertised alongside the coarse ``file`` spec; ``build_frame``
+        filters per phase by ``allowed_ops``, so an un-migrated skill (coarse
+        ``[file]``) still sees only the coarse spec — behavior-preserving.
+
+        Closes the catalog-build gap (#997-class) the Wave-1 β-obviation proof
+        missed: that proof exercised the op-loop dispatch path
+        (``_build_phase_tool_catalog`` → executor.execute) and bypassed this
+        json-mode frame advertisement path (surfaced by the Wave-2a dogfood —
+        migrated phase advertised coarse ``file`` / allowed fine → LLM emitted
+        the coarse ``file`` it was shown → executor skipped it).
+        """
+        from reyn.tools import get_default_registry
+        registry = get_default_registry()
+        specs: list[ControlIROpSpec] = []
+        for name, example in self._FINE_FILE_OP_EXAMPLES.items():
+            tool_def = registry.lookup(name)
+            if tool_def is None or tool_def.gates.phase != "allow":
+                continue
+            specs.append(ControlIROpSpec(
+                kind=name, description=tool_def.description, example=example,
+            ))
+        return specs
+
     def available_ops(self) -> list[ControlIROpSpec]:
         """Return the Control IR op kinds this executor advertises to the LLM.
 
         These specs flow into ContextFrame.available_control_ops; the LLM picks
         from this list when emitting `control_ir`. Op kinds are filtered per
-        runtime config (shell_allowed, mcp_servers configured).
+        runtime config (shell_allowed, mcp_servers configured) and per phase by
+        ``allowed_ops`` in ``build_frame``.
         """
         return [
             ControlIROpSpec(
@@ -224,6 +269,11 @@ class ControlIRExecutor:
                 ),
                 example={"kind": "file", "op": "grep", "path": "src", "pattern": "def \\w+", "glob": "**/*.py", "output_mode": "content"},
             ),
+            # #1240 Wave 2a: fine-grained file kinds (read_file/write_file/…),
+            # advertised alongside the coarse "file" above. build_frame filters
+            # per phase by allowed_ops — migrated (fine) phases see these,
+            # un-migrated (coarse [file]) phases see only the coarse spec.
+            *self._fine_file_op_specs(),
             ControlIROpSpec(
                 kind="ask_user",
                 description=(

--- a/src/reyn/stdlib/skills/judge_phase/phases/judge.md
+++ b/src/reyn/stdlib/skills/judge_phase/phases/judge.md
@@ -4,7 +4,7 @@ name: judge
 input: phase_eval_request
 role: evaluator
 model_class: standard
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 ---
 
 Evaluate the provided phase artifact against each criterion and produce a structured judgment.

--- a/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
@@ -4,7 +4,7 @@ name: build_skill
 input: skill_plan
 role: dsl_writer
 model_class: strong
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 ---
 
 Generate DSL markdown files for the skill defined in data, then write each one to the workspace using file ops.

--- a/src/reyn/stdlib/skills/skill_builder/phases/design_artifacts.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/design_artifacts.md
@@ -4,7 +4,7 @@ name: design_artifacts
 input: skill_structure
 role: schema_designer
 model_class: standard
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 preprocessor:
   - type: lint_plan
     over: data

--- a/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
@@ -3,7 +3,7 @@ type: phase
 name: plan_skill
 input: user_message | skill_request
 role: app_architect
-allowed_ops: [file, ask_user, run_skill]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, ask_user, run_skill]
 ---
 
 Design an Skill structure that fulfills the user's request with appropriate quality controls.

--- a/src/reyn/stdlib/skills/skill_builder/phases/verify_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/verify_skill.md
@@ -5,7 +5,7 @@ input: build_result
 role: dsl_verifier
 can_finish: false
 max_act_turns: 1
-allowed_ops: [file, lint]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, lint]
 ---
 
 ## Step 1 — Run lint (your ONLY act turn)

--- a/src/reyn/stdlib/skills/skill_importer/phases/convert.md
+++ b/src/reyn/stdlib/skills/skill_importer/phases/convert.md
@@ -5,7 +5,7 @@ input: selected_candidate
 role: skill_converter
 can_finish: true
 max_act_turns: 6
-allowed_ops: [file, lint, web_fetch]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, lint, web_fetch]
 preprocessor:
   - type: python
     module: ./detect_reference_format.py

--- a/src/reyn/stdlib/skills/skill_importer/phases/search.md
+++ b/src/reyn/stdlib/skills/skill_importer/phases/search.md
@@ -5,7 +5,7 @@ input: user_message
 role: skill_searcher
 can_finish: false
 max_act_turns: 4
-allowed_ops: [file, web_fetch]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, web_fetch]
 ---
 
 Find skills in a public registry that match what the user is asking for.

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -4,7 +4,7 @@ name: apply
 input: plan
 role: implementer
 model_class: standard
-allowed_ops: [file, sandboxed_exec]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, sandboxed_exec]
 max_act_turns: 30
 # FP-0008 #1115 Stage 2: policy for this phase's sandboxed_exec ops (e.g.
 # python -m py_compile syntax checks), winning over op fields. Permissive —

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -4,7 +4,7 @@ name: explore
 input: swe_bench_input
 role: analyst
 model_class: standard
-allowed_ops: [file, grep, sandboxed_exec]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, sandboxed_exec]
 max_act_turns: 20
 # FP-0008 #1115 Stage 2: policy for any sandboxed_exec op this phase runs while
 # exploring an arbitrary repository (e.g. git log / ls). Permissive; ignored by a

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -4,7 +4,7 @@ name: plan
 input: exploration | verify_state
 role: architect
 model_class: standard
-allowed_ops: [file, grep]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 max_act_turns: 15
 ---
 

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -4,7 +4,7 @@ name: verify
 input: apply_state
 role: tester
 model_class: standard
-allowed_ops: [file, sandboxed_exec]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, sandboxed_exec]
 max_retries: 3
 max_act_turns: 30
 # FP-0008 #1115 Stage 2 (D mechanism): the OS applies this policy to every

--- a/tests/test_eval_judge_e2e_replay_1115.py
+++ b/tests/test_eval_judge_e2e_replay_1115.py
@@ -71,10 +71,12 @@ def test_eval_judge_cross_workspace_artifact_handle_e2e(tmp_path: Path, monkeypa
     abs_path = str(producer.resolve_artifact_handle(handle))
 
     # Run the real judge_phase skill: act turn reads the handed path, decide turn
-    # emits the verdict. The LLM is scripted; the file.read is the boundary.
+    # emits the verdict. The LLM is scripted; the read_file op is the boundary.
+    # #1240 Wave 2a: judge_phase migrated allowed_ops file→fine, so the scripted
+    # op is the fine read_file kind (was the coarse {kind:file, op:read}).
     judge_skill = load_dsl_skill(stdlib_root() / "skills" / "judge_phase" / "skill.md")
     script = [
-        {"type": "act", "ops": [{"kind": "file", "op": "read", "path": abs_path}]},
+        {"type": "act", "ops": [{"kind": "read_file", "path": abs_path}]},
         {
             "type": "decide",
             "control": {

--- a/tests/test_op_fine_grained_dispatch_1240.py
+++ b/tests/test_op_fine_grained_dispatch_1240.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+from reyn.compiler import load_dsl_skill
 from reyn.events.events import EventLog
 from reyn.kernel.control_ir_executor import ControlIRExecutor
 from reyn.permissions.permissions import PermissionResolver
@@ -37,6 +38,7 @@ from reyn.schemas.models import (
     ReadFileIROp,
     WriteFileIROp,
 )
+from reyn.skill.skill_paths import stdlib_root
 from reyn.workspace.workspace import Workspace
 
 
@@ -210,3 +212,46 @@ def test_fine_grep_files_dispatch_via_registry(tmp_path, monkeypatch):
     assert "wave15_marker" in result_str, (
         f"grep_files result must include the matched string: {result[0]}"
     )
+
+
+# ── #1240 Wave 2a: catalog-build (json-mode frame advertisement) full-path ───
+
+
+def test_migrated_phase_advertises_fine_ops_no_gap(tmp_path):
+    """Tier 2: a phase declaring FINE allowed_ops gets the fine ops ADVERTISED
+    by available_ops() with NO phase_op_catalog_gap — the json-mode frame's
+    available_control_ops path.
+
+    This is the full-path catch the Wave-1 β-obviation proof MISSED: that proof
+    exercised executor.execute (dispatch) with directly-constructed fine ops,
+    bypassing available_ops() — the json-mode frame advertisement path. The
+    Wave-2a dogfood surfaced the gap (a migrated phase advertised the coarse
+    "file" / allowed fine → the LLM emitted the coarse op it was SHOWN → the
+    executor skipped it with not_allowed_in_phase → silent correctness failure).
+
+    Load-from-disk full path (not direct construction): load the migrated
+    judge_phase, confirm its phase declares fine allowed_ops, and confirm the
+    executor advertises ALL of them — so runtime.build_frame's
+    `op.kind in allowed` filter yields the fine specs (not an empty set + the
+    #997 phase_op_catalog_gap). If available_ops() still hardcoded only the
+    coarse "file", `gap` below would be the full fine set and this would fail.
+    """
+    skill = load_dsl_skill(stdlib_root() / "skills" / "judge_phase" / "skill.md")
+    judge = skill.phases["judge"]
+    allowed = set(judge.allowed_ops)
+    # Post-migration the phase declares fine kinds, no coarse "file".
+    assert "file" not in allowed, f"judge_phase must be migrated to fine: {allowed}"
+    assert {"read_file", "write_file", "grep_files"} <= allowed, allowed
+
+    executor = _executor(tmp_path, grant=True)
+    advertised = {spec.kind for spec in executor.available_ops()}
+    gap = allowed - advertised
+    assert not gap, (
+        f"phase_op_catalog_gap: judge_phase declares {sorted(allowed)} but "
+        f"available_ops() advertises {sorted(advertised)} — missing {sorted(gap)}. "
+        f"The fine kinds must be advertised so build_frame's allowed-filter yields "
+        f"them (else the LLM sees no/wrong ops and the migration silently fails)."
+    )
+    # And the advertised fine specs carry a usable description (registry-derived).
+    fine_specs = {s.kind: s for s in executor.available_ops() if s.kind in allowed}
+    assert fine_specs["read_file"].description, "fine spec must have a description"

--- a/tests/test_universal_dispatch_skill_op_coverage_1212.py
+++ b/tests/test_universal_dispatch_skill_op_coverage_1212.py
@@ -71,6 +71,15 @@ _DSL_STEP_TYPES_OUT_OF_SCOPE: frozenset[str] = frozenset(
 _OP_KIND_CATEGORY: dict[str, str] = {
     # file ops → "file" category (_OPERATION_RULES: file__read/write/edit/…)
     "file":          "file",
+    # #1240 Wave 2a: fine-grained file kinds (skills migrated allowed_ops
+    # file→fine). Same "file" universal_dispatch category as the coarse kind
+    # (file__read/write/edit/glob/grep qualified names already wired).
+    "read_file":     "file",
+    "write_file":    "file",
+    "edit_file":     "file",
+    "delete_file":   "file",
+    "glob_files":    "file",
+    "grep_files":    "file",
     # run_skill → "skill" resource category (_RESOURCE_RULES: skill → invoke_skill)
     "run_skill":     "skill",
     # web ops → "web" category (_OPERATION_RULES: web__fetch, web__search)


### PR DESCRIPTION
**[e2e-coder]** — **DRAFT / WIP.** #1240 **Wave 2a Batch 1** (catalog axis). `Refs #1240`. Migrates the fixture-free stdlib skills' phase `allowed_ops` from coarse `file` to the fine kinds (uniform, per lead-coder DECISION 1). Behavior-preserving grant (compat-window: fine grants the same ops); the offered catalog changes coarse→fine.

### Migration (uniform: `[file]` → `[read_file, write_file, edit_file, delete_file, glob_files, grep_files]`)
11 phase frontmatter `allowed_ops` lines across judge_phase, skill_builder (design_artifacts/build_skill/plan_skill/verify_skill), skill_importer (search/convert), swe_bench (plan/apply/explore/verify). Non-file ops (lint/ask_user/run_skill/web_fetch/sandboxed_exec) kept; redundant standalone `grep` deduped into `grep_files`. Instructional-body examples NOT touched (separate pass — they affect generated skills).

### Commits
- `906c8c2f` the 11-file frontmatter migration
- `8f34d106` two expected test ripples: `_OP_KIND_CATEGORY` += 6 fine kinds (→ "file" universal_dispatch category, already wired); judge-phase e2e scripted op coarse→fine (`{kind:file,op:read}`→`{kind:read_file}` — the coarse op is now correctly blocked since `is_op_allowed` expands coarse→fine but not fine→coarse)

### Status: mechanical done; dogfood behavioral spot-check PENDING (lead-coder DECISION 2)
The offered-catalog *shape* change (1 coarse op-enum tool → 6 fine tools), not just naming, could shift weak-LLM op-selection — replay-green is insufficient. A dogfood spot-check (migrated judge_phase + swe_bench/grep, standard model) is dispatched to sandbox_2 to confirm op-selection isn't degraded. Un-drafts on that confirmation.

### Test plan
- [x] skill load-from-disk: all 4 skills load, fine allowed_ops parsed, no coarse `file`/`grep` remains
- [x] **full-rootdir** `pytest -q --ignore=.claude`: **6737 passed**, 5 skipped, 3 xfailed. 1 failure = the pre-existing not-my-diff web_fetch local flake (#1203/#1241 precedent).
- [x] tier audit clean (touched test files)
- [ ] dogfood behavioral spot-check (op-selection not degraded by the shape change) — dispatched to sandbox_2

Scope: Batch 2 (eval_builder + skill_improver, which HAVE replay fixtures → migrate + re-record) follows. Wave 2b (coarse-ToolDef drop) after both batches + the niche `reyn/local/*` check. `#1235` stays draft-held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)