### PR TITLE
feat(#1240 Wave 2a Batch 2): migrate eval_builder/skill_improver allowed_ops file→fine + durable default

### DIFF
--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -111,8 +111,18 @@ class Phase(BaseModel):
     # ContextFrame and is enforced at executor dispatch (defense in depth). The
     # default reflects the common case: file I/O plus user clarification. An
     # explicit empty list means "no ops" (e.g. pure routing phases).
+    # #1240 Wave 2a: the default uses the fine-grained file kinds (the faithful
+    # uniform equivalent of the legacy coarse `file` grant — same file
+    # capability), so a phase that omits allowed_ops is born fine-native, keeping
+    # the file→fine migration durable end-to-end (the legacy coarse `file` kind
+    # is dropped in Wave 2b). No existing stdlib phase omits allowed_ops, so this
+    # default change is behaviorally inert for them — it only shapes
+    # future-generated / omitting skills.
     allowed_ops: list[str] = Field(
-        default_factory=lambda: ["file", "ask_user"],
+        default_factory=lambda: [
+            "read_file", "write_file", "edit_file", "delete_file",
+            "glob_files", "grep_files", "ask_user",
+        ],
     )
     # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy for
     # ``sandboxed_exec`` ops. When set, the OS applies it to every sandboxed_exec

--- a/src/reyn/stdlib/skills/eval_builder/phases/analyze_skill.md
+++ b/src/reyn/stdlib/skills/eval_builder/phases/analyze_skill.md
@@ -4,7 +4,7 @@ name: analyze_skill
 input: user_message | eval_builder_request
 role: eval_designer
 max_act_turns: 7
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 preprocessor:
   # Step 1: extract target skill name from the input artifact (pure dict/regex — safe mode).
   # Handles all three artifact shapes: top-level target_skill, wrapped data.target_skill,

--- a/src/reyn/stdlib/skills/eval_builder/phases/write_eval.md
+++ b/src/reyn/stdlib/skills/eval_builder/phases/write_eval.md
@@ -4,7 +4,7 @@ name: write_eval
 input: skill_analysis
 role: spec_writer
 can_finish: true
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 ---
 
 Generate the eval.md content, write it to the workspace, and report the result.

--- a/src/reyn/stdlib/skills/skill_builder/artifacts/skill_plan.yaml
+++ b/src/reyn/stdlib/skills/skill_builder/artifacts/skill_plan.yaml
@@ -54,11 +54,14 @@ schema:
               Control IR op kinds this phase may emit. Pick the smallest set
               from `op_catalog` that the phase actually needs — narrower lists
               prevent the LLM from drifting outside the phase's intent and
-              reduce prompt tokens. Common patterns: [file] for read/write
-              phases, [file, ask_user] (the implicit default) for interactive
-              phases, [run_skill] for orchestrator phases, [] for pure
-              decision phases that emit no side effects (e.g. routing,
-              judging). Omit the field to inherit the default [file, ask_user].
+              reduce prompt tokens. Use the fine-grained file op kinds
+              (read_file / write_file / edit_file / delete_file / glob_files /
+              grep_files), picking only what the phase needs. Common patterns:
+              [read_file, write_file] for read/write phases, [read_file,
+              write_file, ask_user] for interactive phases, [run_skill] for
+              orchestrator phases, [] for pure decision phases that emit no side
+              effects (e.g. routing, judging). Omit the field to inherit the
+              default (all fine file kinds + ask_user).
           preprocessor:
             type: array
             description: |

--- a/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/build_skill.md
@@ -120,7 +120,7 @@ input: {input_artifact}
 role: {role}
 model_class: {model_class}
 can_finish: true
-allowed_ops: {allowed_ops as inline YAML list, e.g. [file] or [file, ask_user]}
+allowed_ops: {allowed_ops as inline YAML list, e.g. [read_file, write_file] or [read_file, write_file, ask_user]}
 preprocessor:
   - type: python
     module: {step.module}
@@ -140,9 +140,10 @@ permissions:
 ```
 Omit `can_finish` line if the phase cannot finish.
 Omit `model_class` line if the phase should use the runtime default (standard).
-Omit `allowed_ops` line if the plan didn't specify it (the runtime default
-`[file, ask_user]` will apply). Otherwise transcribe the value verbatim from
-the plan, including the explicit empty list `[]` for pure decision phases.
+Omit `allowed_ops` line if the plan didn't specify it (the runtime default —
+the fine file kinds `[read_file, write_file, edit_file, delete_file, glob_files,
+grep_files, ask_user]` — will apply). Otherwise transcribe the value verbatim
+from the plan, including the explicit empty list `[]` for pure decision phases.
 Omit `preprocessor` and `permissions` blocks entirely when the phase has no
 preprocessor steps. When present, **each preprocessor python step MUST have a
 matching permissions.python entry** (same module + function); without it the

--- a/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
+++ b/src/reyn/stdlib/skills/skill_builder/phases/plan_skill.md
@@ -130,11 +130,15 @@ phases: array of phase definitions, each with:
   - can_finish: true only if this phase may end the workflow
   - allowed_ops: list of Control IR op kinds this phase may emit. Pick the
       smallest subset of `op_catalog` that the phase actually needs.
-      Common patterns:
-        - generation/transformation phases that read or write files: [file]
-        - interactive phases that may need to ask the user: [file, ask_user]
-          (this is the implicit default; you can omit `allowed_ops` for these)
-        - orchestrator phases that invoke sub-skills: [run_skill] or [file, run_skill]
+      Common patterns (use the fine-grained file op kinds — read_file / write_file /
+      edit_file / delete_file / glob_files / grep_files — picking only the ones the
+      phase needs):
+        - phases that read files: [read_file] (+ grep_files / glob_files to search/find)
+        - generation/transformation phases that read and write files: [read_file, write_file]
+          (add edit_file / delete_file as the phase needs)
+        - interactive phases that may need to ask the user: [read_file, write_file, ask_user]
+          (omitting `allowed_ops` gives the implicit default: all fine file kinds + ask_user)
+        - orchestrator phases that invoke sub-skills: [run_skill] or [read_file, write_file, run_skill]
         - pure decision/review phases that only produce a verdict artifact: []
         - phases that fetch external data: [web_fetch] or [web_search, web_fetch]
       Narrower lists are better — they prevent the LLM from drifting outside

--- a/src/reyn/stdlib/skills/skill_importer/phases/convert.md
+++ b/src/reyn/stdlib/skills/skill_importer/phases/convert.md
@@ -455,9 +455,11 @@ allowed_ops: [<op_kinds>]
 `allowed_ops` lists the Control IR op kinds the phase actually emits. Pick
 the smallest set from `op_catalog` — narrower lists keep the LLM on task
 and reduce prompt tokens. If the source skill calls tools (HTTP fetch,
-shell, file I/O), map them to the closest reyn ops. If the phase emits no
+shell, file I/O), map them to the closest reyn ops — file I/O maps to the
+fine file kinds (read_file / write_file / edit_file / delete_file /
+glob_files / grep_files; pick what the phase needs). If the phase emits no
 side effects (pure judging/routing), use `[]`. Omit the field to inherit
-the default `[file, ask_user]`.
+the default (all fine file kinds + ask_user).
 
 If the phase has a python preprocessor (per Step 2's decision), include
 `preprocessor` and `permissions.python` blocks in the frontmatter:

--- a/src/reyn/stdlib/skills/skill_improver/phases/apply_improvements.md
+++ b/src/reyn/stdlib/skills/skill_improver/phases/apply_improvements.md
@@ -5,7 +5,7 @@ input: improvement_plan
 role: implementer
 model_class: standard
 max_act_turns: 1
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 ---
 
 Commit the iteration to history, optionally apply the planned DSL changes, then decide whether to loop or finish.

--- a/src/reyn/stdlib/skills/skill_improver/phases/finalize.md
+++ b/src/reyn/stdlib/skills/skill_improver/phases/finalize.md
@@ -4,7 +4,7 @@ name: finalize
 input: improvement_result
 role: finalizer
 can_finish: true
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 preprocessor:
   # FP-0006 Component B — snapshot the pre-apply skill.md to
   # .reyn/skill-versions/<name>/v<N>.md BEFORE copy-back happens.

--- a/src/reyn/stdlib/skills/skill_improver/phases/plan_improvements.md
+++ b/src/reyn/stdlib/skills/skill_improver/phases/plan_improvements.md
@@ -4,7 +4,7 @@ name: plan_improvements
 input: iteration_state
 role: app_architect
 model_class: strong
-allowed_ops: [file]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 ---
 
 Design concrete, minimal DSL file changes that will improve the target skill's score on the next iteration.

--- a/src/reyn/stdlib/skills/skill_improver/phases/prepare.md
+++ b/src/reyn/stdlib/skills/skill_improver/phases/prepare.md
@@ -4,7 +4,7 @@ name: prepare
 input: user_message | improvement_session
 role: meta_coordinator
 model_class: standard
-allowed_ops: [file, ask_user, run_skill]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, ask_user, run_skill]
 ---
 
 Validate the user's request and produce a fully-populated `improvement_session` for the loop.

--- a/src/reyn/stdlib/skills/skill_improver/phases/run_and_eval.md
+++ b/src/reyn/stdlib/skills/skill_improver/phases/run_and_eval.md
@@ -5,7 +5,7 @@ input: improvement_session
 role: evaluator
 model_class: standard
 max_act_turns: 1
-allowed_ops: [file, run_skill]
+allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, run_skill]
 ---
 
 Run the target skill against the chosen test case via the `eval` stdlib sub-skill, capture the score for this iteration, and update the workspace history file.

--- a/tests/test_replay_eval_builder.py
+++ b/tests/test_replay_eval_builder.py
@@ -53,6 +53,17 @@ def _candidate_write_eval() -> CandidateOutput:
 
 
 def _op_file() -> ControlIROpSpec:
+    # #1240 Wave 2a: kept as the COARSE "file" spec intentionally, even though
+    # eval_builder migrated its allowed_ops file→fine (Batch 2). This is test
+    # scaffolding for the LLM-replay frame, NOT the migrated skill's real
+    # advertised catalog (which is now the 6 fine kinds). Safe because: (i) these
+    # are decide-turn tests whose assertions are catalog-INSENSITIVE (the analysis
+    # output doesn't depend on which file ops are advertised); (ii) the act-path
+    # (fine-op emission → executor route) fidelity is covered by the Batch-1
+    # dogfood (judge_phase, same available_ops mechanism). ★ Wave 2b drops the
+    # coarse "file" op kind, which makes this spec invalid — it MUST be updated to
+    # the fine kinds + the fixtures re-recorded then (the required re-record,
+    # bundled with the coarse-drop in the standard-model env). Tracked in #1240.
     return ControlIROpSpec(
         kind="file",
         description="Read a file",

--- a/tests/test_replay_skill_improver.py
+++ b/tests/test_replay_skill_improver.py
@@ -77,6 +77,17 @@ def _candidate_copy_to_work() -> CandidateOutput:
 
 
 def _op_file() -> ControlIROpSpec:
+    # #1240 Wave 2a: kept as the COARSE "file" spec intentionally, even though
+    # skill_improver migrated its allowed_ops file→fine (Batch 2). This is test
+    # scaffolding for the LLM-replay frame, NOT the migrated skill's real
+    # advertised catalog (which is now the 6 fine kinds). Safe because: (i) these
+    # are decide-turn tests whose assertions are catalog-INSENSITIVE (the output
+    # doesn't depend on which file ops are advertised); (ii) the act-path
+    # (fine-op emission → executor route) fidelity is covered by the Batch-1
+    # dogfood (judge_phase, same available_ops mechanism). ★ Wave 2b drops the
+    # coarse "file" op kind, which makes this spec invalid — it MUST be updated to
+    # the fine kinds + the fixtures re-recorded then (the required re-record,
+    # bundled with the coarse-drop in the standard-model env). Tracked in #1240.
     return ControlIROpSpec(
         kind="file",
         description="Read a file",


### PR DESCRIPTION
**[e2e-coder]** — #1240 **Wave 2a Batch 2** (catalog axis). `Refs #1240`. Completes the `allowed_ops` file→fine migration for the fixture-bearing skills + makes the migration **durable** (fine default + generator instructions). Behavior-preserving.

### Commits (3)
- `a1336866` — migrate eval_builder/skill_improver phase `allowed_ops` `[file]`→fine (uniform, 7 phases; per lead-coder Decision 1).
- `c356e04c` — comment the `_op_file()` replay-test scaffolding: kept COARSE intentionally (these are decide-turn tests whose assertions are catalog-insensitive; act-path fidelity covered by the Batch-1 dogfood), with the required fine-update + fixture re-record correctly deferred to **Wave 2b** (which drops the coarse `file` op kind, invalidating `_op_file()` — re-record bundled with that, in the standard-model env).
- `cda2ce55` — **durability**: `Phase.allowed_ops` default `[file, ask_user]`→uniform fine; generator instructions (plan_skill/build_skill/convert + skill_plan.yaml) → fine, so new/generated skills are born fine-native (else they'd break at the Wave-2b coarse-drop).

### Key findings (verify-before-propagate, Batch-1 lesson applied)
- The eval_builder/skill_improver replay tests passed after migration **not** because re-record was unneeded, but because they **hardcode** the frame catalog (`_op_file()` coarse) → migration-invisible + catalog-insensitive assertions. So re-record is a *fidelity* step → bundled to Wave 2b (where it's *required* by the coarse-drop). Documented inline.
- Generator durability coupled to the runtime default: verified **no stdlib phase omits `allowed_ops`** → the coarse default was unused → migrating it to fine is behaviorally inert for existing skills (zero risk), and is exactly the durability case for future/generated skills. P7-clean (OS-level op-kind default).
- 4th teaching surface (`skill_plan.yaml`) caught via a broad bare-name grep, not just the obvious `.md` examples.

### Test plan
- [x] skill load-from-disk: eval_builder + skill_improver load, fine allowed_ops parsed
- [x] `Phase.allowed_ops` default verified uniform-fine; no default-asserting test broke
- [x] **full-rootdir** `pytest -q --ignore=.claude`: **6739 passed**, 5 skipped, 3 xfailed. 1 failure = pre-existing not-my-diff web_fetch local flake (#1203/#1241 precedent).
- [x] ruff (touched src)

### Deferred to Wave 2b (tracked, not dropped)
- `_op_file()`→fine + the eval_builder/skill_improver fixture re-record (bundled with the coarse `file`/`mcp`/`run_skill` ToolDef drop + `coarsen_op_kind` retire + the `reyn/local` niche-usage check + a broad bare-name sweep).

`#1235` stays draft-held (its RouterLoopCore/memo/cost-events-adapter core feeds Wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)