### PR TITLE
test(pytest): exclude .claude/worktrees from rootdir collection (norecursedirs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,14 @@ pythonpath = ["src"]
 # dogfood/scripts/ runners on isolated tmp copies. They MUST NOT
 # be collected by the project's main pytest suite — the placeholder
 # stubs (= NotImplementedError) would fail CI at collection time.
-norecursedirs = ["dogfood/fixtures", ".reyn", "reyn-worktrees"]
+#
+# .claude/worktrees/ holds transient git worktrees created by the Agent
+# tool's `isolation: "worktree"` mode (gitignored, local-only). Each is a
+# full copy of the tree at some other branch state, so a rootdir
+# `pytest -q` would otherwise collect tens of thousands of stale-import
+# test modules. Declaring an explicit norecursedirs drops pytest's default
+# `.*` dotdir exclusion, so `.claude` (and `.reyn`) must be listed back.
+norecursedirs = ["dogfood/fixtures", ".reyn", ".claude", "reyn-worktrees"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
**[e2e-coder]** — standalone test-infra fix (endorsed by lead-coder; non-blocking, independent of the #1240 pivot).

## Problem

A rootdir `pytest -q` (the canonical pre-PR verify) breaks locally with **66942 collection errors**. Cause: the Agent tool's `isolation: "worktree"` mode creates transient git worktrees under `.claude/worktrees/` (gitignored, local-only). Each is a full copy of the tree at some *other* branch state, so pytest recurses into all of them (~105 accumulated) and tries to import their stale test modules — failing en masse (`ModuleNotFoundError`, `import file mismatch`, etc.).

CI is unaffected (the worktrees never exist there), but every contributor hits this locally and has to reach for `--ignore=.claude` by hand.

## Fix

Add `.claude` to `norecursedirs`. Root cause is subtle: declaring an explicit `norecursedirs` **drops pytest's built-in `.*` dotdir exclusion**, which is why `.reyn` already had to be listed back manually — `.claude` was simply missed when the worktree feature landed.

## Test plan

- [x] `pytest --co -q` from rootdir — **6741 tests collected, 0 `.claude/worktrees` references** (was: 66942 collection errors).
- [x] `pytest -q` from rootdir — **6732 passed**, 5 skipped, 3 xfailed (identical to the pre-fix real-suite result; the one `test_web_fetch_preview_path_ref` failure is a pre-existing local HTML-extractor env difference on `main`, unrelated to this config-only change — CI-green precedent #1203).
- [x] `ruff check .` — clean.

The worktrees themselves are intentionally **not** touched (they may hold other sessions' in-progress work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
