### PR TITLE
docs(nav): add sub-groups to Reference DSL and Config sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,26 +157,31 @@ nav:
               - reference/cli/source.md
               - reference/cli/common-flags.md
       - DSL:
-          - reference/dsl/skill-md.md
-          - reference/dsl/phase-md.md
-          - reference/dsl/artifact-yaml.md
-          - reference/dsl/preprocessor.md
-          - reference/dsl/postprocessor.md
-          - reference/dsl/graph.md
-          - reference/dsl/profile-yaml.md
-          - reference/dsl/topology-yaml.md
+          - Schema:
+              - reference/dsl/skill-md.md
+              - reference/dsl/phase-md.md
+              - reference/dsl/artifact-yaml.md
+              - reference/dsl/graph.md
+          - Execution:
+              - reference/dsl/preprocessor.md
+              - reference/dsl/postprocessor.md
+          - Multi-agent:
+              - reference/dsl/profile-yaml.md
+              - reference/dsl/topology-yaml.md
       - Runtime:
           - reference/runtime/context-frame.md
           - reference/runtime/llm-output-contract.md
           - reference/runtime/control-ir.md
           - reference/runtime/events.md
       - Config:
-          - reference/config/reyn-yaml.md
-          - reference/config/permissions.md
-          - reference/config/budget.md
-          - reference/config/state-dir.md
-          - reference/config/multi-agent.md
-          - reference/builtin-models.md
+          - Core:
+              - reference/config/reyn-yaml.md
+              - reference/config/permissions.md
+              - reference/config/budget.md
+          - Infrastructure:
+              - reference/config/state-dir.md
+              - reference/config/multi-agent.md
+              - reference/builtin-models.md
       - Stdlib:
           - reference/stdlib/index.md
           - Routing:


### PR DESCRIPTION
**[docs-maintainer]** — Reference nav consistency fix

## Summary

DSL (8 files) and Config (6 files) were flat while CLI and Stdlib already had sub-groups. Adds sub-group hierarchy to complete Reference section uniformity.

**DSL** (8 → 3 groups):
- Schema: skill-md, phase-md, artifact-yaml, graph
- Execution: preprocessor, postprocessor
- Multi-agent: profile-yaml, topology-yaml

**Config** (6 → 2 groups):
- Core: reyn-yaml, permissions, budget
- Infrastructure: state-dir, multi-agent, builtin-models

Runtime (4 files), Testing (2), Replay (2) remain flat — appropriate for their size.

## Test plan

- [x] `mkdocs build --strict` — 0 warnings ✅
- [x] Page count: **removed 14 / added 14 / dropped 0** (8 DSL + 6 Config pages reorganized, none dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)