### PR TITLE
feat(#1092 Fork 1 PR-B): phase act-loop → RouterLoop convergence (gated, default off)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -54,6 +54,7 @@ models:
 | `shell_allowed` | bool | Pre-approve the `shell` op so it is not gated per-call. Default `false`. |
 | `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
 | `tool_calls_op_loop_skills` | list | **Transitional (#1212).** Skill names opted into the native-tools op-loop phase mechanism (ops emitted as native `tool_calls` and run through the shared executor) instead of the json-mode `control_ir` batch. Default empty = all skills use json-mode (unchanged). Removed once the op-loop becomes the default. |
+| `routerloop_convergence_skills` | list | **Transitional (#1092 PR-B).** Skill names opted into the converged op-loop — the phase act-loop drives the shared `RouterLoop.run_loop` (op results thread as native tool-role message-history). Takes precedence over `tool_calls_op_loop_skills`. Default empty = every skill unchanged. Removed once convergence becomes the default. |
 
 ## `models` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -75,6 +75,15 @@
 # -----------------------------------------------------------------------------
 # tool_calls_op_loop_skills:
 #   - my_skill
+# -----------------------------------------------------------------------------
+# routerloop_convergence_skills: TRANSITIONAL (#1092 PR-B). Skill names opted into
+# the converged op-loop — their phase act-loop drives the shared RouterLoop.run_loop
+# (op results thread as native tool-role message-history). Takes precedence over
+# tool_calls_op_loop_skills. Default empty = every skill unchanged. Removed once
+# convergence becomes the default.
+# -----------------------------------------------------------------------------
+# routerloop_convergence_skills:
+#   - my_skill
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -67,6 +67,7 @@ class Agent:
         environment_backend: "EnvironmentBackend | None" = None,
         sandbox_backend: "SandboxBackend | None" = None,
         tool_calls_op_loop_skills: list[str] | None = None,
+        routerloop_convergence_skills: list[str] | None = None,
     ) -> None:
         self.model = model
         # FP-0008 #1132: the events audit log lives under state_dir. Honor an
@@ -84,6 +85,9 @@ class Agent:
         # #1212: skills opted into the native-tools op-loop (config-driven gate,
         # threaded to OSRuntime so the op-loop is reachable on the real run path).
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
+        # #1092 PR-B: skills opted into the converged op-loop (config-driven gate,
+        # threaded to OSRuntime so the converged path is reachable on the real run).
+        self._routerloop_convergence_skills = list(routerloop_convergence_skills or [])
         self._safety = safety or SafetyConfig()
         self._resolver = resolver or ModelResolver({})
         self._permission_resolver = permission_resolver
@@ -219,6 +223,7 @@ class Agent:
             environment_backend=environment_backend,
             sandbox_backend=sandbox_backend,
             tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
+            routerloop_convergence_skills=config.routerloop_convergence_skills,
         )
 
     @property
@@ -313,6 +318,7 @@ class Agent:
             workspace_base_dir=self._workspace_base_dir,
             workspace_state_dir=self._workspace_state_dir,
             tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,
+            routerloop_convergence_skills=self._routerloop_convergence_skills,
         )
         return await self._runtime.run(initial_input, output_language=output_language)
 

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -191,6 +191,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 sandbox_config=session_cfg.config.sandbox,
                 multimodal_config=session_cfg.config.multimodal,
                 tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
+                routerloop_convergence_skills=session_cfg.config.routerloop_convergence_skills,
                 action_retrieval_config=session_cfg.config.action_retrieval,
                 embedding_config=session_cfg.config.embedding,
                 agent_id=session_cfg.config.agent.id,

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1834,6 +1834,26 @@ class RouterLoop:
         if not history or history[-1].get("role") != "user":
             messages.append({"role": "user", "content": user_text})
 
+        return await self.run_loop(messages, tools, _univ_enabled)
+
+    async def run_loop(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        _univ_enabled: bool,
+    ) -> "TokenUsage":
+        """#1092 PR-B (FD1, ADR-0036): the shared op-execution loop (convergence ii).
+
+        Extracted verbatim from ``run()`` so the chat ``run()`` (after its
+        chat-specific pre-loop setup) AND a phase host (via a RouterLoop built with
+        PhaseRouterLoopHost) drive the SAME loop = true convergence. The loop body
+        is unchanged; chat-specific terminals (put_outbox spawn-acks, text reply)
+        are host-polymorphic and go inert for a phase host (no-op put_outbox,
+        async_count=0). FD2: the phase transition is a SEPARATE structured-json
+        call the phase host post-pends AFTER this loop returns at end_turn — it is
+        NOT in this loop (P1/P8 preserved).
+        """
+        host = self.host
         # B28-Q2 Case A: per-turn counters for chat_turn_completed_inline.
         # _routing_decided_fired: set to True the first time routing_decided
         #   is emitted in this turn (= invoke_action or hot_list_alias path).

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2740,6 +2740,16 @@ class RouterLoop:
         # _normalise_router_tool_result unwraps read_file / list_directory
         # to the bare-content / bare-list shapes the host adapter returned.
         "read_file", "write_file", "delete_file", "list_directory",
+        # #1092 PR-B (FD1): phase-side fine file kinds. edit_file / glob_files /
+        # grep_files are registry ToolDefinitions (tools/file.py, registered in
+        # tools/__init__.py) that the chat router never exposed as router tools
+        # (chat uses list_directory), but they are in the phase default
+        # allowed_ops (#1240). When a phase drives RouterLoop via run_loop, its
+        # op catalog advertises these, so _invoke_router_tool must route them
+        # through the same registry path — closing the dispatch gap that the
+        # obviated op-exec seam (ADR-0036) would otherwise have needed a host
+        # hook for. Chat is unaffected (chat build_tools never lists them).
+        "edit_file", "glob_files", "grep_files",
         # Phase 3.5-B-light — invoke_skill.  Handler delegates via
         # RouterCallerState.run_skill_fn (= chain_id pre-bound) so PR14
         # multi-hop chain semantics propagate into nested run_skill /

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1854,6 +1854,16 @@ class RouterLoop:
         NOT in this loop (P1/P8 preserved).
         """
         host = self.host
+        # #1092 PR-B: keep the DISPATCH catalog (``self._catalog``, consumed by
+        # ``_execute_tool`` → ``dispatch_tool``'s ``name in ctx.tool_catalog`` gate)
+        # in lockstep with the ADVERTISED ``tools=``. For the chat ``run()`` path
+        # this is idempotent (run() already set it from the same post-exclude
+        # ``tools``). For a phase host that drives ``run_loop`` directly (bypassing
+        # run()'s pre-loop setup), this is the ONLY place it gets set — without it
+        # a native tool_call (read_file …) advertised to the model is rejected as
+        # ``unknown_tool`` (the native-dispatch catalog gap caught by #1092 dogfood).
+        self._catalog = {t["function"]["name"]: t for t in tools}
+        self._tool_names = frozenset(self._catalog.keys())
         # B28-Q2 Case A: per-turn counters for chat_turn_completed_inline.
         # _routing_decided_fired: set to True the first time routing_decided
         #   is emitted in this turn (= invoke_action or hot_list_alias path).

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1223,6 +1223,7 @@ class ChatSession:
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
+        routerloop_convergence_skills: list[str] | None = None,  # #1092 PR-B: convergence gate
         agent_id: str | None = None,
     ) -> None:
         """
@@ -1260,6 +1261,7 @@ class ChatSession:
         self._multimodal_config = multimodal_config
         # #1212: op-loop gate, threaded to Agents spawned for chat-run skills.
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
+        self._routerloop_convergence_skills = list(routerloop_convergence_skills or [])
         # Issue #383 PR-C — single MediaStore instance per ChatSession,
         # constructed from the multimodal config's storage dirs.
         # Subsequently threaded into spawned Agents (= for control-IR
@@ -3093,6 +3095,7 @@ class ChatSession:
             media_store=self._media_store,
             run_id=run_id,
             tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,
+            routerloop_convergence_skills=self._routerloop_convergence_skills,
         )
 
     async def _put_outbox(self, msg: OutboxMessage) -> None:

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -301,6 +301,7 @@ def run(args: argparse.Namespace) -> None:
             sandbox_config=session_cfg.config.sandbox,
             multimodal_config=session_cfg.config.multimodal,
             tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
+            routerloop_convergence_skills=session_cfg.config.routerloop_convergence_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,
             embedding_config=session_cfg.config.embedding,
             eager_embedding_build=getattr(args, "eager_embedding_build", False),

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -443,6 +443,7 @@ def _build_live_runner(agent_name: str):
                 sandbox_config=config.sandbox,
                 multimodal_config=config.multimodal,
                 tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
+                routerloop_convergence_skills=config.routerloop_convergence_skills,
                 action_retrieval_config=config.action_retrieval,
             )
             s.load_history()

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -412,6 +412,7 @@ def run_serve(args: argparse.Namespace) -> None:
             sandbox_config=session_cfg.config.sandbox,
             multimodal_config=session_cfg.config.multimodal,
             tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
+            routerloop_convergence_skills=session_cfg.config.routerloop_convergence_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,
             embedding_config=session_cfg.config.embedding,
         )

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1560,6 +1560,15 @@ class ReynConfig:
             "path, unchanged. Removed once the op-loop becomes the default."
         )},
     )
+    routerloop_convergence_skills: list[str] = field(
+        default_factory=list,
+        metadata={"desc": (
+            "TRANSITIONAL (#1092 PR-B): skill names opted into the converged op-loop "
+            "(phase act-loop drives the shared RouterLoop.run_loop). Takes precedence "
+            "over tool_calls_op_loop_skills. Skills not listed are unchanged. Removed "
+            "once convergence becomes the default."
+        )},
+    )
     # LiteLLM proxy: non-secret base URL only.
     # API keys must be set as environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
     # — never stored in config files.
@@ -2076,6 +2085,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         },
         tool_calls_op_loop_skills=[
             str(s) for s in (merged.get("tool_calls_op_loop_skills") or [])
+        ],
+        routerloop_convergence_skills=[
+            str(s) for s in (merged.get("routerloop_convergence_skills") or [])
         ],
         api_base=str(merged.get("api_base") or ""),
         # prompt_cache_enabled / project_context_path were declared as

--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -476,6 +476,30 @@ class LLMCallRecorder:
         """
         return _PhaseMemoProvider(recorder=self, phase=phase, state=state)
 
+    def build_phase_op_loop_messages(
+        self, *, phase: str, frame: "ContextFrame",
+    ) -> list[dict]:
+        """#1092 PR-B (FD1): the seed ``[system, user(frame)]`` messages for the
+        converged op-loop.
+
+        The phase host drives ``RouterLoop.run_loop`` with these as the starting
+        message list (RouterLoop then threads ``{assistant, tool_calls}`` +
+        ``{tool, ...}`` turns natively). Single-sourced via the SAME
+        ``build_phase_messages`` helper that the json-mode ``call_tools`` uses, so
+        the SP + frame seed never drift between the two op-loop paths.
+        """
+        from reyn.llm.llm import build_phase_messages
+        phase_def = self._skill.phases.get(phase)
+        return build_phase_messages(
+            frame,
+            skill_name=self._skill.name,
+            skill_description=self._skill.description,
+            phase_role=phase_def.role if phase_def else None,
+            project_context=self._project_context,
+            agent_role=self._agent_role,
+            prompt_cache_enabled=self._prompt_cache_enabled,
+        )
+
     # ── Model resolution ───────────────────────────────────────────────────────
 
     def _effective_model(self, phase_name: str) -> str:

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -725,17 +725,42 @@ class PhaseExecutor:
         # tool_calls, returning control here for the FD2 decide.
         await routerloop.run_loop(messages, tools, False)
 
-        # FD2: reconstruct control_ir_results from the native tool-role turns so the
-        # SEPARATE json decide frame carries the op outcomes (P1/P8 — transition is
-        # post-pended here, never inside run_loop).
+        # FD2: build the SEPARATE json decide frame from the native turns so it is
+        # INFORMATION-EQUIVALENT to the #1212 _run_op_loop decide frame (P1/P8 —
+        # transition post-pended here, never inside run_loop). Two structural pieces
+        # the json-mode decide frame relies on (their absence is the #1092 dogfood
+        # reliability regression: a context-inadequate decide frame, not a model-axis
+        # limit — the weak model fumbles the decide because it sees LESS than json-mode):
+        #   (a) act_turn_reasoning — the model's inline content from the native
+        #       assistant turns (reasoning continuity, exactly what _run_op_loop
+        #       carries forward across act turns), and
+        #   (b) control_ir_results in the RAW op-result shape — unwrapping
+        #       dispatch_tool's {"status": "ok", "data": <op result>} envelope so the
+        #       outcomes render the same way the json-mode op-loop renders them.
         control_ir_results: list[dict] = list(prior_results)
+        act_turn_reasoning: list[str] = []
         for _m in messages:
-            if _m.get("role") == "tool":
+            _role = _m.get("role")
+            if _role == "assistant":
+                _ac = _m.get("content")
+                if isinstance(_ac, str) and _ac:
+                    act_turn_reasoning.append(_ac)
+            elif _role == "tool":
                 _content = _m.get("content")
                 try:
-                    control_ir_results.append(_json.loads(_content))
+                    _parsed = _json.loads(_content)
                 except (TypeError, ValueError):
-                    control_ir_results.append({"result": _content})
+                    _parsed = {"result": _content}
+                if (
+                    isinstance(_parsed, dict)
+                    and "data" in _parsed
+                    and set(_parsed) <= {"status", "data", "error"}
+                ):
+                    _parsed = _parsed["data"]
+                control_ir_results.append(_parsed)
+        if self._phase_compaction_cfg is not None:
+            _keep = self._phase_compaction_cfg.recent_act_turns_raw
+            act_turn_reasoning = act_turn_reasoning[-_keep:]
         self._last_control_ir_results = control_ir_results
 
         decide_frame = self._build_frame(
@@ -744,6 +769,7 @@ class PhaseExecutor:
             artifact_path=artifact_path,
             remaining_act_turns=0,
             force_decide=True,
+            act_turn_reasoning=act_turn_reasoning,
         )
         raw = await self._llm_caller.call(
             phase, decide_frame, None, rollback_context, state,

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -682,6 +682,14 @@ class PhaseExecutor:
             resolve_model_fn=lambda name: cie._resolver.resolve(name).model,
         )
         tools = host.get_phase_op_catalog()
+        # P6 audit + the distinguishing marker for the converged path (vs the
+        # #1212 phase-native _run_op_loop) — consumed by the full-path test and
+        # the dogfood host-polymorphism trace.
+        self._events.emit(
+            "phase_routerloop_op_loop_started",
+            phase=phase,
+            tool_count=len(tools),
+        )
 
         prior_results = (
             list(rollback_context["previous_control_ir_results"])

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -152,6 +152,7 @@ class PhaseExecutor:
         phase_compaction_engine: "CompactionEngine | None" = None,
         phase_compaction_cfg: "PhaseActResultsCompactionConfig | None" = None,
         op_loop_enabled: bool = False,
+        routerloop_convergence_enabled: bool = False,
     ) -> None:
         self._llm_caller = llm_caller
         self._control_ir_executor = control_ir_executor
@@ -182,6 +183,11 @@ class PhaseExecutor:
         # (tool_calls_op_loop_skills) resolved at PhaseExecutor construction. Default
         # False = json-mode, byte-for-byte unchanged.
         self._op_loop_enabled = op_loop_enabled
+        # #1092 PR-B (FD1): when True, the phase act-loop drives the SHARED
+        # RouterLoop.run_loop (true convergence, ii) — op results thread as native
+        # tool-role history, dispatch/memo reuse RouterLoop. Takes precedence over
+        # the #1212 phase-native _run_op_loop gate. Default False = unchanged.
+        self._routerloop_convergence_enabled = routerloop_convergence_enabled
 
     # ── #1135(b): raw-output capture on phase-output validation failure ───────
 
@@ -618,6 +624,124 @@ class PhaseExecutor:
                 results=ir_results,
             )
 
+    # ── Converged op loop (#1092 PR-B, RouterLoop.run_loop) ──────────────────────
+
+    async def _run_routerloop_op_loop(
+        self,
+        phase: str,
+        artifact: dict,
+        candidates: list[CandidateOutput],
+        output_language: str | None,
+        max_act_turns: int,
+        max_phase_retries: int,
+        artifact_path: str | None,
+        state: "RunState",
+        rollback_context: dict | None = None,
+    ) -> tuple[dict, list[dict]]:
+        """#1092 PR-B (FD1, ADR-0036): CONVERGED op-loop — the phase act-loop drives
+        the SHARED ``RouterLoop.run_loop`` (true convergence, ii).
+
+        vs ``_run_op_loop`` (#1212, phase-native frame-fed): this path builds a
+        ``RouterLoop`` with a ``PhaseRouterLoopHost`` and drives its extracted
+        ``run_loop``, so op results thread as NATIVE ``{assistant,tool_calls}`` +
+        ``{tool,...}`` message-history (the frame-fed → native reversal), and
+        dispatch / memo / compaction reuse the shared loop. Phase ops dispatch via
+        RouterLoop's ``REGISTRY_DISPATCH_TOOLS`` registry path (op-exec seam
+        obviated by #1240, ADR-0036); the phase ``OpContext`` is provisioned by
+        ``host.make_router_op_context`` (= ``_build_ctx``) so permission/sandbox
+        gates enforce identically to ``control_ir_executor.execute``.
+
+        FD2 (P1/P8): the transition decide is a SEPARATE structured-json ``call``
+        AFTER ``run_loop`` returns at end_turn — it is NOT in the loop. Chat-specific
+        terminals inside ``run_loop`` (put_outbox spawn-acks / text reply) go inert
+        for the phase host (no-op ``put_outbox``, ``async_count == 0`` because phase
+        op kinds are not async ``dispatch_kind``). Gated
+        (``routerloop_convergence_enabled``); un-opted skills are byte unchanged.
+        """
+        import json as _json
+
+        from reyn.chat.router_loop import RouterLoop
+        from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+
+        phase_def = self._skill.phases.get(phase)
+        allowed_ops = set(phase_def.allowed_ops) if phase_def is not None else set()
+        decl = self._skill.permissions
+        sandbox = phase_def.default_sandbox_policy if phase_def is not None else None
+        cie = self._control_ir_executor
+
+        host = PhaseRouterLoopHost(
+            control_ir_executor=cie,
+            events=self._events,
+            phase=phase,
+            decl=decl,
+            allowed_ops=allowed_ops,
+            default_sandbox_policy=sandbox,
+            agent_name=self._skill.name,
+            agent_role=(phase_def.role if phase_def is not None else phase),
+            output_language=output_language,
+            resolve_model_fn=lambda name: cie._resolver.resolve(name).model,
+        )
+        tools = host.get_phase_op_catalog()
+
+        prior_results = (
+            list(rollback_context["previous_control_ir_results"])
+            if rollback_context and rollback_context.get("previous_control_ir_results")
+            else []
+        )
+        seed_frame = self._build_frame(
+            phase, artifact, candidates, output_language,
+            control_ir_results=prior_results,
+            artifact_path=artifact_path,
+            remaining_act_turns=max_act_turns,
+        )
+        messages = self._llm_caller.build_phase_op_loop_messages(
+            phase=phase, frame=seed_frame,
+        )
+
+        routerloop = RouterLoop(
+            host=host,
+            chain_id=self._run_id or phase,
+            max_iterations=max_act_turns,
+            # cosmetic: the phase llm_caller resolves the phase model itself.
+            router_model=phase,
+            budget=getattr(state, "budget", None),
+            memo_provider=self._llm_caller.make_phase_memo_provider(
+                phase=phase, state=state,
+            ),
+            llm_caller=self._llm_caller.make_phase_llm_caller(
+                phase=phase, state=state,
+            ),
+        )
+        # Drive the SHARED op-execution loop. Op results thread into ``messages``
+        # as native tool-role turns; the model signals end_turn by emitting no
+        # tool_calls, returning control here for the FD2 decide.
+        await routerloop.run_loop(messages, tools, False)
+
+        # FD2: reconstruct control_ir_results from the native tool-role turns so the
+        # SEPARATE json decide frame carries the op outcomes (P1/P8 — transition is
+        # post-pended here, never inside run_loop).
+        control_ir_results: list[dict] = list(prior_results)
+        for _m in messages:
+            if _m.get("role") == "tool":
+                _content = _m.get("content")
+                try:
+                    control_ir_results.append(_json.loads(_content))
+                except (TypeError, ValueError):
+                    control_ir_results.append({"result": _content})
+        self._last_control_ir_results = control_ir_results
+
+        decide_frame = self._build_frame(
+            phase, artifact, candidates, output_language,
+            control_ir_results=control_ir_results,
+            artifact_path=artifact_path,
+            remaining_act_turns=0,
+            force_decide=True,
+        )
+        raw = await self._llm_caller.call(
+            phase, decide_frame, None, rollback_context, state,
+        )
+        return raw, []
+
     # ── Act loop ──────────────────────────────────────────────────────────────
 
     async def _run_act_loop(
@@ -928,10 +1052,17 @@ class PhaseExecutor:
         phase_def = self._skill.phases[phase]
         max_act_turns = phase_def.max_act_turns if phase_def.max_act_turns > 0 else 10
 
-        # #1212 PR2: gated dispatch. Opted-in skills run the native-tools op-loop;
-        # the default json-mode act loop is unchanged. Both return (raw_decide, prior)
-        # and feed the same decide-with-retry path (transition stays json-mode).
-        act_loop = self._run_op_loop if self._op_loop_enabled else self._run_act_loop
+        # Gated dispatch. All three return (raw_decide, prior) and feed the same
+        # decide-with-retry path (transition stays json-mode = FD2).
+        #   #1092 PR-B: converged op-loop (phase drives shared RouterLoop.run_loop).
+        #   #1212 PR2:  phase-native frame-fed op-loop (native-tools request only).
+        #   default:    json-mode act loop, byte-for-byte unchanged.
+        if self._routerloop_convergence_enabled:
+            act_loop = self._run_routerloop_op_loop
+        elif self._op_loop_enabled:
+            act_loop = self._run_op_loop
+        else:
+            act_loop = self._run_act_loop
         raw, prior_attempts = await act_loop(
             phase, artifact, candidates, output_language,
             max_act_turns, max_phase_retries, artifact_path,

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -94,19 +94,23 @@ class PhaseRouterLoopHost:
         return self._resolve_model_fn(name)
 
     def make_router_op_context(self) -> Any:
-        """Phase ``OpContext`` factory — STUB in PR-A (returns None); wired in PR-B.
+        """Phase ``OpContext`` factory for the registry tool-dispatch handlers.
 
         RouterLoop's ``op_context_factory`` (= this method) feeds the registry
         tool-dispatch handlers (``REGISTRY_DISPATCH_TOOLS`` path). With the op-exec
         seam obviated (see module docstring), phase ops route through that same
-        registry path, so this MUST return a real phase ``OpContext`` (carrying the
-        phase ``PermissionDecl`` / ``allowed_ops`` / sandbox policy) for the handlers
-        to enforce phase permissions — the role the obviated seam's
-        ``control_ir_executor`` dispatch played. PR-A is inert (this host is not yet
-        wired into ``PhaseExecutor``), so the None stub is never reached; PR-B
-        implements it as part of the convergence wiring.
+        registry path, so this returns the SAME phase ``OpContext`` the json-mode
+        op-loop builds — delegated to ``ControlIRExecutor._build_ctx`` with the
+        phase ``PermissionDecl`` + sandbox policy so the registry handlers enforce
+        phase permissions identically to ``control_ir_executor.execute`` (the role
+        the obviated seam played). Single-sourced via the executor so there is no
+        second permission/sandbox provisioning path to drift (P3/P5).
         """
-        return None
+        return self._control_ir_executor._build_ctx(
+            self._decl,
+            self._phase,
+            default_sandbox_policy=self._default_sandbox_policy,
+        )
 
     async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
         """Phase NO-OP — a concept-absent legitimate no-op (P-clean).

--- a/src/reyn/kernel/run_orchestrator.py
+++ b/src/reyn/kernel/run_orchestrator.py
@@ -119,9 +119,11 @@ class RunOrchestrator:
         max_phase_visits: int,
         budget_tracker: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: gate, propagated to sub-skills
+        routerloop_convergence_skills: list[str] | None = None,  # #1092 PR-B: convergence gate
     ) -> None:
         self._budget_tracker = budget_tracker
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
+        self._routerloop_convergence_skills = list(routerloop_convergence_skills or [])
         self._phase_executor = phase_executor
         self._skill = skill
         self._workspace = workspace
@@ -260,6 +262,7 @@ class RunOrchestrator:
             safety=self._safety,
             recorder=self._budget_tracker,
             tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,  # #1212 sub-skill gate
+            routerloop_convergence_skills=self._routerloop_convergence_skills,  # #1092 PR-B
             # #1190 stage (iii) Part 4: attribute skill_node adaptation to the
             # run's agent (caller "agents/<name>" → "<name>").
             recorder_agent=(

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -89,6 +89,7 @@ class OSRuntime:
         phase_compaction_engine: "CompactionEngine | None" = None,
         phase_compaction_cfg: "PhaseActResultsCompactionConfig | None" = None,
         tool_calls_op_loop_skills: list[str] | None = None,
+        routerloop_convergence_skills: list[str] | None = None,
     ) -> None:
         self.skill = skill
         self.model = model
@@ -102,6 +103,9 @@ class OSRuntime:
         # #1212: retained so sub-skill runs (run_skill / @sub_skill nodes) inherit
         # the same op-loop gate — a sub-skill named in the list also op-loops.
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
+        # #1092 PR-B (FD1): skills opted into the converged op-loop (phase drives the
+        # shared RouterLoop.run_loop). Same data-driven P7-OK gate shape as #1212.
+        self._routerloop_convergence_skills = list(routerloop_convergence_skills or [])
         self.events = EventLog(
             subscribers=subscribers, run_id=run_id, plan_step=plan_step,
         )
@@ -290,6 +294,9 @@ class OSRuntime:
             # skill names as data (P7-OK); this skill runs the native-tools op-loop
             # iff its name is listed. Default empty = json-mode (zero change).
             op_loop_enabled=skill.name in (tool_calls_op_loop_skills or ()),
+            # #1092 PR-B: converged op-loop gate (takes precedence over op_loop_enabled).
+            routerloop_convergence_enabled=skill.name
+            in (routerloop_convergence_skills or ()),
         )
         # FP-0020 Component D: phase sequence + transitions + rollback + skill-node
         # dispatch + resume + SkillRegistry lifecycle extracted to RunOrchestrator.
@@ -321,6 +328,7 @@ class OSRuntime:
             max_phase_visits=self._max_phase_visits,
             budget_tracker=budget_tracker,  # #1190 stage (ii): skill_node_adapt cost recording
             tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,  # #1212 sub-skill gate
+            routerloop_convergence_skills=self._routerloop_convergence_skills,  # #1092 PR-B
         )
 
     # ── Backward-compat properties (FP-0020 Component A) ───────────────────

--- a/src/reyn/skill/skill_node_runner.py
+++ b/src/reyn/skill/skill_node_runner.py
@@ -97,6 +97,7 @@ async def execute_skill_node(
     recorder: object | None = None,  # #1190 stage (ii): skill_node_adapt cost recording
     recorder_agent: str | None = None,  # #1190 stage (iii) Part 4: per-agent attribution
     tool_calls_op_loop_skills: list[str] | None = None,  # #1212: gate inherited by the sub-skill
+    routerloop_convergence_skills: list[str] | None = None,  # #1092 PR-B: convergence gate inherited
 ) -> tuple[dict, TokenUsage]:
     """
     Run a sub-app to completion and adapt its final_output to target_schema.
@@ -117,6 +118,7 @@ async def execute_skill_node(
         resolver=resolver,
         safety=limits,
         tool_calls_op_loop_skills=tool_calls_op_loop_skills,
+        routerloop_convergence_skills=routerloop_convergence_skills,
     )
     run_result = await sub_runtime.run(input_artifact, output_language=output_language)
     token_usage = sub_runtime._token_usage

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -268,6 +268,7 @@ def _get_registry():
                 sandbox_config=config.sandbox,
                 multimodal_config=config.multimodal,
                 tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
+                routerloop_convergence_skills=config.routerloop_convergence_skills,
                 action_retrieval_config=config.action_retrieval,
                 embedding_config=config.embedding,
                 eager_embedding_build=_eager_embedding_build,

--- a/tests/test_routerloop_convergence_entrypoint_parity_1092.py
+++ b/tests/test_routerloop_convergence_entrypoint_parity_1092.py
@@ -1,0 +1,40 @@
+"""Tier 2: #1092 PR-B — every call site that threads the #1212 op-loop gate
+(``tool_calls_op_loop_skills=``) ALSO threads the convergence gate
+(``routerloop_convergence_skills=``).
+
+Catches the leaf entry-point trap (the #1248 class, one layer below the wired
+spine): a constructor call that passes ``tool_calls_op_loop_skills`` but forgets
+``routerloop_convergence_skills`` leaves the converged op-loop unreachable from
+THAT entry point — e.g. ``cli/commands/dogfood.py`` (the sandbox_2 dogfood path),
+``cli/commands/chat.py`` / ``mcp.py`` / ``chainlit_app/app.py``. An AST-walk pins
+the parity so a new entry point (or a future caller) can't silently drop one gate
+while keeping the other.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_OLD = "tool_calls_op_loop_skills"
+_NEW = "routerloop_convergence_skills"
+
+
+def test_every_op_loop_gate_callsite_also_threads_convergence_gate() -> None:
+    """Tier 2: no Call passes ``tool_calls_op_loop_skills=`` without
+    ``routerloop_convergence_skills=`` (the two gates thread in lockstep)."""
+    offenders: list[str] = []
+    for py in _SRC.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            if _OLD in kwargs and _NEW not in kwargs:
+                offenders.append(
+                    f"{py.relative_to(_SRC.parents[1])}:{node.lineno}"
+                )
+    assert not offenders, (
+        "these call sites thread the #1212 op-loop gate but NOT the #1092 "
+        f"convergence gate (leaf reachability trap): {sorted(set(offenders))}"
+    )

--- a/tests/test_routerloop_convergence_permission_gate_1092.py
+++ b/tests/test_routerloop_convergence_permission_gate_1092.py
@@ -1,0 +1,131 @@
+"""Tier 2: #1092 PR-B bar-2 — the converged path's make_router_op_context provisions a
+REAL phase OpContext, so a phase op is GATED by the phase PermissionDecl.
+
+This closes the #1248 advertise/wire-path silent-FAIL class for the converged op-loop at
+unit level (the bar-2 dogfood bar, made sandbox_2-independent): when a phase drives the
+shared RouterLoop, op dispatch reaches the registry handler, which builds its OpContext
+from ``ctx.router_state.op_context_factory`` (= PhaseRouterLoopHost.make_router_op_context).
+If that factory returned None / an empty PermissionDecl, the handler would fall back to an
+empty decl and silently auto-permit (the #1248 trap). This test proves the factory yields
+the real phase ``PermissionDecl`` + a real (non-None) ``PermissionResolver``, and that a
+write the decl does NOT allow is actually DENIED — routed through the SAME registry handler
+the converged run_loop dispatches to (``_handle_write`` → ``_build_legacy_op_context`` →
+``op_context_factory()`` → ``execute_op`` → ``require_file_write``).
+
+Mock-free: real Workspace + real PermissionResolver + real PhaseRouterLoopHost +
+ControlIRExecutor + the real registry handler.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.kernel.control_ir_executor import ControlIRExecutor
+from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.tools.file import _handle_write
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.workspace.workspace import Workspace
+
+
+def _converged_host(tmp_path: Path, *, decl: PermissionDecl) -> PhaseRouterLoopHost:
+    """Build the converged-path host with a REAL resolver + the given phase decl."""
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    ws = Workspace(events, permission_resolver=resolver, base_dir=tmp_path)
+    cie = ControlIRExecutor(
+        workspace=ws, events=events, permission_resolver=resolver, skill_name="bar2",
+    )
+    return PhaseRouterLoopHost(
+        control_ir_executor=cie,
+        events=events,
+        phase="draft",
+        decl=decl,
+        allowed_ops={"write_file"},
+        default_sandbox_policy=None,
+        agent_name="bar2",
+        agent_role="draft",
+        output_language=None,
+        resolve_model_fn=lambda name: name,
+    )
+
+
+def _dispatch_write(host: PhaseRouterLoopHost, path: str) -> dict:
+    """Dispatch write_file through the SAME registry path the converged run_loop uses:
+    _handle_write → _build_legacy_op_context(ctx.router_state.op_context_factory).
+
+    The ToolContext's own events/permission_resolver/workspace are placeholders — the
+    registry handler resolves its OpContext from ``router_state.op_context_factory`` (=
+    the phase host's make_router_op_context), which OVERRIDES them. That override IS the
+    bar-2 path under test.
+    """
+    events = EventLog()
+    tool_ctx = ToolContext(
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={}, project_root=Path("/tmp"), interactive=False,
+        ),
+        workspace=Workspace(events),
+        caller_kind="router",
+        router_state=RouterCallerState(op_context_factory=host.make_router_op_context),
+    )
+    return asyncio.run(_handle_write({"path": path, "content": "x"}, tool_ctx))
+
+
+def test_make_router_op_context_provisions_real_phase_context(tmp_path) -> None:
+    """Tier 2: make_router_op_context returns a real OpContext carrying the phase decl +
+    a non-None resolver (NOT None / empty-decl auto-permit — the #1248 silent-FAIL guard)."""
+    decl = PermissionDecl()
+    host = _converged_host(tmp_path, decl=decl)
+    op_ctx = host.make_router_op_context()
+    assert op_ctx is not None, "make_router_op_context must NOT return None (the #1248 trap)"
+    assert op_ctx.permission_resolver is not None, (
+        "the converged OpContext must carry a REAL PermissionResolver — None auto-permits"
+    )
+    assert op_ctx.permission_decl is decl, (
+        "the converged OpContext must carry the PHASE PermissionDecl, not an empty fallback"
+    )
+
+
+def test_converged_dispatch_denies_write_outside_phase_decl(tmp_path) -> None:
+    """Tier 2: a write the phase PermissionDecl does NOT allow is DENIED when dispatched
+    through the converged path's registry handler (the bar-2 enforcement claim).
+
+    Falsification: adding ``denied`` to ``decl.file_write`` (see the sibling
+    ``..._allows...`` test) makes the SAME write succeed — so this assertion gates on the
+    decl, not on an unrelated failure.
+    """
+    decl = PermissionDecl()  # empty write allowlist → nothing declared writable
+    host = _converged_host(tmp_path, decl=decl)
+    # A project-relative path OUTSIDE the default write zone (.reyn/) — denied unless the
+    # phase decl declares it (so the DECL is the gating factor, not the absolute-path rule).
+    denied = "data/bar2_gate.txt"
+
+    result = _dispatch_write(host, denied)
+
+    blob = json.dumps(result, default=str)
+    assert ("denied" in blob) or ("permission" in blob), (
+        f"the write must be permission-gated (denied), not silently allowed; got {result!r}"
+    )
+    assert not (tmp_path / denied).exists(), "the denied write must NOT have touched the filesystem"
+
+
+def test_converged_dispatch_allows_write_declared_in_phase_decl(tmp_path) -> None:
+    """Tier 2: the SAME write SUCCEEDS once the phase PermissionDecl declares the path
+    writable — proving the previous denial gates on the decl (the falsification control),
+    and that the converged provisioning is not deny-all."""
+    target = "data/bar2_gate.txt"  # same path as the denial test
+    decl = PermissionDecl(file_write=[{"path": target, "scope": "just_path"}])
+    host = _converged_host(tmp_path, decl=decl)
+
+    result = _dispatch_write(host, target)
+
+    blob = json.dumps(result, default=str)
+    assert "denied" not in blob and "permission" not in blob, (
+        f"a write declared in the phase decl must NOT be denied; got {result!r}"
+    )
+    assert (tmp_path / target).exists(), "the allowed write should have been performed"

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -199,3 +199,79 @@ def test_converged_op_loop_dispatches_phase_op_not_unknown_tool(tmp_path, monkey
         "a phase op tool_call must route through the converged path's ctx.tool_catalog, "
         "not be rejected as unknown_tool (the native-dispatch catalog gap)"
     )
+
+
+def test_converged_decide_frame_information_equivalent_to_json_op_loop(tmp_path, monkeypatch) -> None:
+    """Tier 2: the converged FD2 decide frame carries the SAME information the #1212
+    json-mode op-loop decide frame does — act_turn_reasoning + RAW control_ir_results.
+
+    Regression guard for the #1092 PR-B GATE-2 finding (the decide-fumble reliability
+    regression, invisible to unit tests until dogfood): the converged decide frame was
+    WEAKER than _run_op_loop's — (a) act_turn_reasoning was not collected from the native
+    assistant turns, and (b) control_ir_results were the dispatch-wrapped
+    ``{"status":"ok","data":<r>}`` envelope instead of the raw op result. Both = a general
+    context-inadequacy bug. This pins information-equivalence so a future refactor can't
+    silently re-introduce it.
+    """
+    monkeypatch.chdir(tmp_path)
+    captured: dict = {"frame": None}
+    turn = {"n": 0}
+
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        i = turn["n"]
+        turn["n"] += 1
+        if i == 0:
+            return LLMToolCallResult(
+                content="reading the file to decide",  # native assistant reasoning
+                tool_calls=[{
+                    "id": "c1", "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "x.txt"}'},
+                }],
+                finish_reason="tool_calls",
+                usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+            )
+        return LLMToolCallResult(
+            content=None, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+    async def _decide(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        captured["frame"] = frame
+        return LLMCallResult(
+            data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+
+    monkeypatch.setattr(lcr, "call_llm", _decide)
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["read_file"],
+    )
+    skill = Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+    config = ReynConfig(routerloop_convergence_skills=[_SKILL_NAME])
+    agent = Agent.from_config(config, shell_allowed=False, model="stub/model")
+    result = asyncio.run(agent.run(skill, {"type": "input", "data": {}}))
+
+    assert result.ok, f"run must complete; got {result.status}"
+    fr = captured["frame"]
+    assert fr is not None, "the FD2 decide frame must be built + passed to the json decide call"
+    # (a) reasoning continuity: the model's native assistant content is carried into the
+    # decide frame (exactly what _run_op_loop carries via act_turn_reasoning).
+    assert any("reading the file" in r for r in fr.act_turn_reasoning), (
+        "converged decide frame must carry act_turn_reasoning from the native assistant "
+        f"turns (got {fr.act_turn_reasoning!r})"
+    )
+    # (b) raw op-result shape: control_ir_results must be unwrapped, NOT the dispatch_tool
+    # {"status":"ok","data":<r>} envelope (which the json-mode op-loop never carries).
+    assert fr.control_ir_results, "the decide frame must carry the op results"
+    for r in fr.control_ir_results:
+        assert not (
+            isinstance(r, dict) and "data" in r and set(r) <= {"status", "data", "error"}
+        ), f"control_ir_results must be raw op results, not the dispatch envelope: {r!r}"

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -129,3 +129,73 @@ def test_from_config_unlisted_skill_no_convergence(tmp_path, monkeypatch) -> Non
     assert "phase_routerloop_op_loop_started" not in _event_kinds(sink), (
         "an unlisted skill must not reach the converged op-loop"
     )
+
+
+def test_converged_op_loop_dispatches_phase_op_not_unknown_tool(tmp_path, monkeypatch) -> None:
+    """Tier 2: a phase op tool_call (read_file) emitted in the converged op-loop
+    DISPATCHES — the dispatch catalog is in sync with the advertised tools.
+
+    Regression for the native-dispatch catalog gap (#1092 PR-B dogfood bar 1): the
+    converged path advertises the phase's fine ops as ``tools=`` but the dispatch-side
+    ``ctx.tool_catalog`` (= ``RouterLoop._catalog``) was only populated in ``run()``'s
+    pre-loop, which the phase path bypasses (it drives ``run_loop`` directly) → a
+    native ``read_file`` tool_call was advertised yet rejected as ``unknown_tool``.
+    Fixed by syncing ``self._catalog`` from ``tools`` at ``run_loop`` start.
+    """
+    monkeypatch.chdir(tmp_path)
+    sink: list = []
+    turn = {"n": 0}
+
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        i = turn["n"]
+        turn["n"] += 1
+        if i == 0:
+            return LLMToolCallResult(
+                content=None,
+                tool_calls=[{
+                    "id": "c1", "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "x.txt"}'},
+                }],
+                finish_reason="tool_calls",
+                usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+            )
+        return LLMToolCallResult(
+            content=None, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+    async def _decide(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(
+            data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+
+    monkeypatch.setattr(lcr, "call_llm", _decide)
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["read_file"],  # the op catalog advertises read_file as a tool
+    )
+    skill = Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+    config = ReynConfig(routerloop_convergence_skills=[_SKILL_NAME])
+    agent = Agent.from_config(
+        config, shell_allowed=False, model="stub/model", subscribers=[sink.append],
+    )
+    result = asyncio.run(agent.run(skill, {"type": "input", "data": {}}))
+
+    assert result.ok, f"run must complete; got {result.status}"
+    assert "phase_routerloop_op_loop_started" in _event_kinds(sink)
+    # The advertised read_file tool_call must DISPATCH (catalog check passes) — never
+    # be rejected as unknown_tool (the native-dispatch catalog gap). A nonexistent
+    # path yields not_found, which is a successful dispatch (catalog OK), not
+    # unknown_tool.
+    assert "unknown_tool" not in repr(sink), (
+        "a phase op tool_call must route through the converged path's ctx.tool_catalog, "
+        "not be rejected as unknown_tool (the native-dispatch catalog gap)"
+    )

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -1,0 +1,131 @@
+"""Tier 2: #1092 PR-B enablement — the converged op-loop gate threads
+config → Agent → OSRuntime → PhaseExecutor (the real run path).
+
+Commit 2b wired ``routerloop_convergence_enabled`` at the OSRuntime↔PhaseExecutor
+seam, but a direct-kwarg test would reproduce the #1248 advertise/wire-path trap:
+it would pass with the production config→runtime PRODUCER missing. This pins the
+full path: a skill named in ``config.routerloop_convergence_skills``, run via
+``Agent.from_config(config)`` (the hub for swe_bench / run / cron / web / mcp /
+eval), actually reaches ``PhaseExecutor._run_routerloop_op_loop`` (asserted via the
+``phase_routerloop_op_loop_started`` event, the distinguishing marker vs the #1212
+phase-native ``_run_op_loop``). A skill NOT in the list never reaches it.
+
+Real ``Agent`` + real ``OSRuntime`` via the public ``Agent.from_config`` +
+``agent.run``; the only scripted seam is the module-level ``call_llm`` /
+``call_llm_tools`` provider boundary (the sanctioned pattern), not a collaborator
+mock.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import reyn.kernel.llm_call_recorder as lcr
+from reyn.agent import Agent
+from reyn.config import ReynConfig
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+
+_SKILL_NAME = "converge_thread"
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=[],
+    )
+    return Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _patch_llms(monkeypatch, tools_calls: list, decide_calls: list) -> None:
+    async def _tools(*a, **k):  # noqa: ANN002, ANN003
+        tools_calls.append(1)
+        # No tool_calls → the op-loop reaches end_turn immediately; the converged
+        # path then post-pends the FD2 json decide (separate ``call``).
+        return LLMToolCallResult(
+            content=None, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+    async def _decide(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        decide_calls.append(1)
+        return LLMCallResult(
+            data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+
+    monkeypatch.setattr(lcr, "call_llm", _decide)
+    monkeypatch.setattr(lcr, "call_llm_tools", _tools)
+
+
+def _event_kinds(subscribers_sink: list) -> list[str]:
+    out: list[str] = []
+    for ev in subscribers_sink:
+        kind = getattr(ev, "type", None) or getattr(ev, "kind", None)
+        if kind is None and isinstance(ev, dict):
+            kind = ev.get("type") or ev.get("kind")
+        if kind is not None:
+            out.append(kind)
+    return out
+
+
+def test_from_config_gate_reaches_converged_op_loop(tmp_path, monkeypatch) -> None:
+    """Tier 2: a skill in config.routerloop_convergence_skills, run via
+    Agent.from_config, reaches the CONVERGED op-loop (RouterLoop.run_loop)."""
+    monkeypatch.chdir(tmp_path)
+    tools_calls: list[int] = []
+    decide_calls: list[int] = []
+    _patch_llms(monkeypatch, tools_calls, decide_calls)
+    sink: list = []
+
+    config = ReynConfig(routerloop_convergence_skills=[_SKILL_NAME])
+    agent = Agent.from_config(
+        config, shell_allowed=False, model="stub/model", subscribers=[sink.append],
+    )
+    result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
+
+    assert result.ok, f"run must complete; got {result.status}"
+    assert "phase_routerloop_op_loop_started" in _event_kinds(sink), (
+        "config.routerloop_convergence_skills must thread Agent.from_config → "
+        "OSRuntime → PhaseExecutor._run_routerloop_op_loop (the converged path), "
+        "not stay on the #1212 phase-native path"
+    )
+    # The op-loop ran (call_llm_tools) and the FD2 transition was a separate json
+    # decide (call_llm) — P1/P8 post-pend after run_loop.
+    assert tools_calls == [1], "the converged op-loop must invoke call_llm_tools"
+    assert decide_calls == [1], "FD2: the transition decide uses the json-mode call"
+
+
+def test_from_config_unlisted_skill_no_convergence(tmp_path, monkeypatch) -> None:
+    """Tier 2: a skill NOT in the config list never reaches the converged op-loop
+    (the start event is absent) — zero-change for un-opted skills."""
+    monkeypatch.chdir(tmp_path)
+    tools_calls: list[int] = []
+    decide_calls: list[int] = []
+    _patch_llms(monkeypatch, tools_calls, decide_calls)
+    sink: list = []
+
+    config = ReynConfig(routerloop_convergence_skills=[])  # nothing opted in
+    agent = Agent.from_config(
+        config, shell_allowed=False, model="stub/model", subscribers=[sink.append],
+    )
+    result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
+
+    assert result.ok, f"run must complete; got {result.status}"
+    assert "phase_routerloop_op_loop_started" not in _event_kinds(sink), (
+        "an unlisted skill must not reach the converged op-loop"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1092 Fork 1 **PR-B: phase act-loop → RouterLoop convergence** (true convergence, ii). User decided both axes (converge + frame-fed→native). Builds on PR-A scaffolding (#1255). Design contract: #1234 (closed) + ADR-0036.

Gated, **default OFF** → byte-for-byte unchanged for every current skill. The flip-to-default is PR-C.

## What this does

Wires the phase act-loop to drive the **shared `RouterLoop.run_loop`** (true convergence): op results thread as native `{assistant,tool_calls}`+`{tool,...}` message-history (the frame-fed→native reversal), and dispatch / memo reuse the shared loop. The transition decide stays a **separate** structured-json call after the loop (FD2, P1/P8 preserved).

**6 commits:**
1. `5467a680` — extract `RouterLoop.run_loop` (the op-execution loop body) so chat `run()` + the phase host both drive it. Pure extraction, **chat byte-identical** (243 router/replay tests).
2. `ec69b128` — `REGISTRY_DISPATCH_TOOLS += edit_file/glob_files/grep_files` (root-fix closure of the dispatch gap the obviated op-exec seam would have needed a host hook for).
3. `bf7a3d45` — `PhaseExecutor._run_routerloop_op_loop`: build `PhaseRouterLoopHost` + the #1255 adapters (`make_phase_llm_caller`/`make_phase_memo_provider`), drive `run_loop`, FD2 decide post-pend; `make_router_op_context` delegates to `_build_ctx` (single-sourced permission/sandbox provisioning).
4. `47cbdb29` — wire the `routerloop_convergence_skills` opt-in gate through the spine (config→agent→session→runtime→orchestrator→skill_node) + example + docs.
5. `e37f10f7` — full-path `Agent.from_config` reachability test + the `phase_routerloop_op_loop_started` distinguishing event.
6. `27bb9674` — thread the gate through the 4 leaf entry points (cli dogfood/chat/mcp + chainlit) + an **AST parity invariant** test.

## op-exec seam obviation (ADR-0036)

The #1240 catalog axis made phase op tool names the unified fine registry kinds, which RouterLoop's `_invoke_router_tool` already routes via `REGISTRY_DISPATCH_TOOLS` — so dispatch is shared (FD1's "dispatch already shared" vindicated) and PhaseRouterLoopHost is catalog-only. The phase `OpContext` comes from `make_router_op_context` → `_build_ctx` (the FD1 "op-execution bridge"), enforcing phase permission/sandbox identically to `control_ir_executor.execute`.

## Verification

- [x] `pytest -q` rootdir — **6740 passed**, 5 skipped, 3 xfailed (HEAD 7372b308). The 1 `test_web_fetch_preview_path_ref` failure is the known pre-existing local HTML-extractor env difference (not-my-diff; CI-green precedent #1203). CI pytest 3.11/3.12 green (lead-coder confirmed).
- [x] `ruff check .` + `test_tier_audit.py --strict` clean.
- [x] chat byte-identical: 243 router_loop/replay tests (the run_loop extraction is pure).
- [x] full-path reachability: `Agent.from_config(routerloop_convergence_skills=[skill])` reaches `_run_routerloop_op_loop` + completes (op-loop + FD2 decide); unlisted skill unchanged.
- [x] entry-point parity: AST-walk invariant — every `tool_calls_op_loop_skills=` call site also threads `routerloop_convergence_skills=` (5/5; lead-coder falsified by temp-deleting a gate → test FAILs correctly).
- [x] **GATE-2 keepers** (decide-frame info-equivalence): `d81d250b` fix + `10131cc1` equivalence guard — lead-coder verified + falsified.
- [x] **bar-2 permission-gate = CLOSED via integration test `7372b308`** (real non-None `PermissionResolver` + real `PermissionDecl`, routed through the converged `make_router_op_context` → registry `_handle_write` dispatch; deny-undeclared / allow-declared falsification pair). lead-coder verified + **self-falsified** (revert `make_router_op_context` to None → all 3 FAIL). Closes the #1248 silent-FAIL class at unit level, sandbox_2-independent.
- [ ] sandbox_2 live dogfood = **complementary confirmation, in-progress (NON-blocking)** — bar-1 catalog-sync already confirmed in a real run (`unknown_tool` 0/6); the live host-polymorphism + permission-gate traces and capable-N=5 (scope-finalize, a PR-C thread) are confirmatory only. NOT a merge gate — the GATE-2 keepers + the bar-2 integration test satisfy it.

## Deferred → PR-C

retire the #1212 phase-native `_run_op_loop` frame-fed path · flip the default off the gate (once dogfood-stable) · converge phase compaction to RouterLoop's `CompactionController` · replay re-pricing (provider tool_call-id normalization for native op-loop fixtures) · retire the PR2-scope deferrals.

Refs #1240 #1234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

