### PR TITLE
fix(#1092 PR-C-0): guard eager chat-discovery + fix converged op-result reconstruction (gate-ON correctness)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2937,8 +2937,13 @@ class RouterLoop:
             describe_skill_fn=self._describe_skill,
             list_agents_fn=self._list_agents,
             describe_agent_fn=self._describe_agent,
-            available_skills=list(self.host.list_available_skills()),
-            available_agents=list(self.host.list_available_agents()),
+            # getattr-guarded (symmetric with ``op_context_factory`` below, #1092
+            # PR-C-0): a RouterLoopCore host that is not the chat RouterHostAdapter
+            # (e.g. PhaseRouterLoopHost — a phase has no skills/agents catalog) need
+            # not implement these chat-discovery methods. Without the guard the
+            # eager call AttributeError'd every op dispatch on the converged path.
+            available_skills=list(getattr(self.host, "list_available_skills", list)()),
+            available_agents=list(getattr(self.host, "list_available_agents", list)()),
             # Async dispatch (= activated handlers)
             send_to_agent=_send_to_agent_bound,
             dispatch_plan_tool=_dispatch_plan_bound,

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -757,6 +757,14 @@ class PhaseExecutor:
                     and set(_parsed) <= {"status", "data", "error"}
                 ):
                     _parsed = _parsed["data"]
+                if not isinstance(_parsed, dict):
+                    # #1092 PR-C-0: normalized op results are not always dicts — e.g.
+                    # read_file is unwrapped to bare-content (a str) by
+                    # _normalise_router_tool_result. control_ir_results is typed
+                    # list[dict] (ContextFrame), so wrap non-dict outcomes. (Masked on
+                    # main while the eager-discovery AttributeError killed dispatch
+                    # before any real op result existed; the host fix unmasks it.)
+                    _parsed = {"result": _parsed}
                 control_ir_results.append(_parsed)
         if self._phase_compaction_cfg is not None:
             _keep = self._phase_compaction_cfg.recent_act_turns_raw

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -112,6 +112,21 @@ class PhaseRouterLoopHost:
             default_sandbox_policy=self._default_sandbox_policy,
         )
 
+    # ── Chat-discovery methods (phase = empty) ────────────────────────────
+    # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY
+    # while building the per-dispatch RouterCallerState (router_loop.py). A phase
+    # has no skills/agents catalog (#1212 PR3 decision A — the catalog is the
+    # phase op tools via ``get_phase_op_catalog``), so they return empty. The
+    # eager call is also getattr-guarded on the RouterLoop side (defence in depth);
+    # implementing them here makes the "phase has no chat discovery" contract
+    # explicit rather than relying on the guard's default.
+
+    def list_available_skills(self) -> list:
+        return []
+
+    def list_available_agents(self) -> list:
+        return []
+
     async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
         """Phase NO-OP — a concept-absent legitimate no-op (P-clean).
 

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -199,6 +199,22 @@ def test_converged_op_loop_dispatches_phase_op_not_unknown_tool(tmp_path, monkey
         "a phase op tool_call must route through the converged path's ctx.tool_catalog, "
         "not be rejected as unknown_tool (the native-dispatch catalog gap)"
     )
+    # #1092 PR-C-0 false-green fix: the op must DISPATCH SUCCESSFULLY through the FULL
+    # converged path — RouterLoop._build_router_caller_state (called per dispatch) is
+    # part of it. The earlier assertion only excluded ``unknown_tool``; a tool_failed
+    # for ANOTHER reason (the eager ``list_available_skills`` AttributeError that died
+    # before the gate, caught by sandbox_2 dogfood) slipped through. Pin the op
+    # actually running: no tool_failed / AttributeError. (Falsified: reverting the
+    # PR-C-0 host fix makes this FAIL.)
+    assert "tool_failed" not in _event_kinds(sink), (
+        "the phase op must dispatch through the FULL converged path (incl. "
+        "_build_router_caller_state) without failing — a tool_failed here means the op "
+        "died before the permission gate (e.g. the eager chat-discovery AttributeError)"
+    )
+    assert "AttributeError" not in repr(sink), (
+        "no AttributeError from the converged dispatch path (RouterLoopCore host "
+        "completeness / getattr-guard, #1092 PR-C-0)"
+    )
 
 
 def test_converged_decide_frame_information_equivalent_to_json_op_loop(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
**[e2e-coder]** — #1092 PR-C-0: gate-ON correctness prerequisite for the convergence enablement (PR-C-1+). Not a PR-B regression (PR-B merged gated-off = host unused; this is the gate-ON path sandbox_2's dogfood exercised).

## What this fixes
sandbox_2 gate-ON dogfood caught the converged op-loop **broken at runtime**: every op dispatch dies with `AttributeError: PhaseRouterLoopHost has no attribute 'list_available_skills'`. Two real bugs, the 2nd unmasked by fixing the 1st + both caught by a strengthened test:

1. **eager unguarded chat-discovery** — `RouterLoop._build_router_caller_state` called `host.list_available_skills()`/`list_available_agents()` eagerly + unguarded (asymmetric with the getattr-guarded `make_router_op_context` 2 lines below). Fix: getattr-guard both (a RouterLoopCore host that isn't the chat adapter need not implement chat-discovery) + `PhaseRouterLoopHost.list_available_skills/agents → []` (explicit "a phase has no skills/agents catalog" contract).
2. **non-dict op-result reconstruction** — the converged FD2 `control_ir_results` reconstruction appended bare-string op results (`read_file` normalizes to bare content) into a `list[dict]` frame field → `ContextFrame` ValidationError once the op actually ran (masked on main while the AttributeError killed dispatch). Fix: wrap non-dict outcomes.

## Test (closes the 3rd dogfood-caught-but-unit-missed instance)
Strengthened the converged-dispatch test to assert the op **dispatches successfully** (no `tool_failed`/`AttributeError`) through the FULL path incl. `_build_router_caller_state` — the prior test only excluded `unknown_tool`, so the AttributeError slipped through (catalog / decide-frame / host-attr = the 3 instances now unit-guarded). **Falsified**: reverting the host fix → the strengthened test FAILS.

## Scope note (reliability regression unaffected)
The reliability 3/6 regression is **separate + confirmed independent** of this AttributeError — sandbox_2's host-patch verify showed reads succeed but the decide-turn still fumbles (native-history characteristic). scope = **capable-scoped** stays valid; the post-PR-C-0 flash-lite 3-way re-measure (sandbox_2, on a clean host) confirms the rate, and capable-N=5 decides weak-specific vs general. Enablement (default flip / `_run_op_loop` retire / compaction→CompactionController / replay re-pricing) = PR-C-1+.

## Verify
- [x] `pytest -q` rootdir — **6740 passed**, 5 skipped, 3 xfailed (1 known web_fetch pre-existing not-my-diff). `ruff check .` clean.
- [x] chat byte-identical: 243 router_loop/replay (getattr-guard finds the chat adapter's methods → unchanged).
- [x] strengthened converged-dispatch test falsified (FAILS without the host fix).

Refs #1092 #1234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)