### PR TITLE
fix(1092): PR-C-2.5 — converged op-loop op-dispatch WAL memo (crash-resume part 1/2)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1442,6 +1442,13 @@ class RouterLoop:
         self.max_iterations = max_iterations
         self.router_model = router_model
         self.budget = budget
+        # #1092 PR-C-2.5: phase-relative op-dispatch counter for crash-resume WAL
+        # memoization. Only advanced when the host opts a dispatch into phase-memo
+        # mode (``host.op_dispatch_memo()`` non-None); chat hosts never do, so this
+        # stays 0 and the chat dispatch path is byte-identical. The counter +
+        # ``phase`` form the ``op_invocation_id`` (``<phase>.<idx>``) that
+        # ``dispatch_tool`` memoizes against committed WAL steps on resume.
+        self._phase_op_idx = 0
         # When set, RouterLoop skips ``build_system_prompt(host=...)`` and uses
         # this string verbatim as the system message. Plan executor uses this
         # to inject a step-specific narrow prompt (= "you are executing step X
@@ -2662,6 +2669,38 @@ class RouterLoop:
 
         if name not in self._catalog and "__" in name:
             name, args = self._maybe_salvage_qualified_direct_call(name, args)
+
+        # #1092 PR-C-2.5: phase-mode op-dispatch WAL memoization. A phase host
+        # returns the per-phase resume wiring; chat hosts don't implement the hook
+        # (getattr → None), so the chat dispatch path below is byte-identical
+        # (``caller_kind="router"``, no state_log/skill_run_id → no WAL step).
+        memo = getattr(self.host, "op_dispatch_memo", lambda: None)()
+        if memo is not None:
+            # Phase op: thread state_log + skill_run_id + resume_plan + a
+            # phase-relative op_invocation_id into dispatch_tool so the op WAL-step
+            # records (and memo-HITS on resume — no re-execution). This restores the
+            # json-mode-equal crash-resume HARD GATE (#1225 Decision A) for the
+            # converged op-loop, which the registry dispatch otherwise bypassed.
+            op_invocation_id = f"{memo['phase'] or 'phase'}.{self._phase_op_idx}"
+            self._phase_op_idx += 1
+            dctx = DispatchContext(
+                caller_kind="skill_phase",
+                caller_id=self.host.agent_name,
+                chain_id=self.chain_id,
+                tool_catalog=self._catalog,
+                events=self.host.events,
+                state_log=memo["state_log"],
+                skill_run_id=memo["skill_run_id"],
+                phase=memo["phase"],
+                resume_plan=memo["resume_plan"],
+            )
+            return await dispatch_tool(
+                name=name,
+                args=args,
+                ctx=dctx,
+                invoker=functools.partial(self._invoke_router_tool, name),
+                op_invocation_id=op_invocation_id,
+            )
 
         dctx = DispatchContext(
             caller_kind="router",

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -112,6 +112,36 @@ class PhaseRouterLoopHost:
             default_sandbox_policy=self._default_sandbox_policy,
         )
 
+    def op_dispatch_memo(self) -> dict | None:
+        """Phase-mode op-dispatch WAL-memoization context (#1092 PR-C-2.5).
+
+        ``RouterLoop._execute_tool`` consults this hook to decide whether a phase
+        op dispatch is crash-resume memoized. A phase host returns the per-phase
+        WAL wiring (``state_log`` + ``skill_run_id`` + ``resume_plan`` + ``phase``)
+        so the dispatch threads them into ``dispatch_tool`` (with a phase-relative
+        ``op_invocation_id``), reproducing the json-mode-equal crash-resume HARD
+        GATE (#1225 Decision A): on resume the op memo-HITS and does not
+        re-execute. Single-sourced from the shared ``ControlIRExecutor`` so there
+        is no second resume-wiring path to drift (P5/P6).
+
+        Chat hosts do NOT implement this method — ``RouterLoop._execute_tool``
+        getattr-guards it to ``None``, leaving the chat dispatch path byte-identical
+        (``caller_kind="router"``, no WAL step). Returns ``None`` here too when the
+        executor has no WAL wired (state_log/skill_run_id absent = non-resumable run),
+        so a non-resumable phase run also stays on the plain dispatch path.
+        """
+        cie = self._control_ir_executor
+        state_log = getattr(cie, "_state_log", None)
+        skill_run_id = getattr(cie, "_skill_run_id", None)
+        if state_log is None or skill_run_id is None:
+            return None
+        return {
+            "state_log": state_log,
+            "skill_run_id": skill_run_id,
+            "resume_plan": getattr(cie, "_resume_plan", None),
+            "phase": self._phase,
+        }
+
     # ── Chat-discovery methods (phase = empty) ────────────────────────────
     # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY
     # while building the per-dispatch RouterCallerState (router_loop.py). A phase

--- a/tests/test_routerloop_convergence_resume_memo_1092.py
+++ b/tests/test_routerloop_convergence_resume_memo_1092.py
@@ -1,0 +1,221 @@
+"""Tier 2: #1092 PR-C-2.5 — the CONVERGED op-loop serves the crash-resume
+op-dispatch WAL-memoization HARD GATE (json-mode-equal, #1225 Decision A).
+
+Background (the #1128 gap this PR closes). The converged op-loop dispatches
+phase ops through ``RouterLoop._execute_tool`` → ``dispatch_tool``. On main that
+call passed ``caller_kind="router"`` with no ``state_log`` / ``skill_run_id`` /
+``op_invocation_id``, so phase ops wrote NO WAL step — the converged path did not
+memoize op dispatches for crash resume (empirically: ``resume_memo_1212`` failed
+on the converged path with WAL = ``[llm, llm, llm]``, no op step). Retiring the
+frame-fed ``_run_op_loop`` (which DID serve this via the shared
+``control_ir_executor``) would therefore drop the PR5 HARD GATE.
+
+The fix (PR-C-2.5): ``RouterLoop._execute_tool`` consults a host hook
+(``op_dispatch_memo()``). A phase host returns the per-phase WAL wiring so the
+dispatch threads ``state_log`` + ``skill_run_id`` + ``resume_plan`` +
+``op_invocation_id`` (``caller_kind="skill_phase"``); chat hosts don't implement
+the hook (getattr → None), so the chat dispatch path is byte-identical.
+
+This test pins the restored guarantee end-to-end through the real OSRuntime:
+  - run 1: a converged op-loop write_file op writes a ``step_completed`` WAL step
+    (the PORT's effect — absent it, no op step → falsifies); AND
+  - run 2 (resume): the op memo-HITS ``dispatch_tool`` (``step_memoized``,
+    ``tool=write_file``) so the side effect does NOT re-execute, AND the act-turn
+    ``call_tools`` memo-HITS (replayed deterministically, not re-invoked).
+
+Real OSRuntime + real ControlIRExecutor + real WAL (StateLog); the only scripted
+seam is the module-level ``call_llm`` / ``call_llm_tools`` provider boundary (the
+sanctioned pattern). The ``routerloop_convergence_skills`` gate routes this skill
+to the converged op-loop (on this branch the two gates still co-exist; #1092 PR-C-3
+merges them).
+
+Falsification: reverting the ``op_dispatch_memo`` host hook + the
+``RouterLoop._execute_tool`` phase-memo branch makes run 1's WAL hold no op step
+(``op_steps`` empty) → this test FAILS, proving it gates on the port.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+
+import reyn.kernel.llm_call_recorder as lcr
+import reyn.schemas.models as _models
+from reyn.events.state_log import StateLog
+from reyn.kernel.runtime import OSRuntime
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.skill.skill_resume_analyzer import CommittedStep, ResumePlan
+
+_SKILL_NAME = "converged_resume"
+# A path under the default ``.reyn/`` write zone — no PermissionDecl needed, so
+# the write COMPLETES (a ``step_completed`` WAL step, the memoizable shape) rather
+# than being denied (which would record ``step_failed`` and not memo on resume).
+_WRITE_PATH = ".reyn/converged_resume.txt"
+
+class _FrozenInstant(_dt.datetime):
+    def astimezone(self, tz=None):  # noqa: ANN001, ANN201
+        return self
+
+
+_FROZEN = _FrozenInstant(2026, 1, 1, tzinfo=_dt.timezone.utc)
+
+
+class _FrozenClock(_dt.datetime):
+    @classmethod
+    def now(cls, tz=None):  # noqa: ANN001, ANN206
+        return _FROZEN
+
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["write_file"],
+    )
+    return Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _tool_result(tool_calls: list) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls,
+        finish_reason="tool_calls" if tool_calls else "stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+class _WriteThenStop:
+    """Deterministic converged op-loop script: turn 1 emits a write_file op,
+    turn 2 stops (→ FD2 json decide). Fresh instance per run so the turn counter
+    resets; identical output on every run (deterministic replay)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, *a, **k):  # noqa: ANN002, ANN003
+        self.calls += 1
+        if self.calls == 1:
+            return _tool_result([{
+                "id": "c1", "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "arguments": '{"path": "%s", "content": "hi"}' % _WRITE_PATH,
+                },
+            }])
+        return _tool_result([])
+
+
+def _finish_llm():
+    async def _f(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(
+            data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10),
+        )
+    return _f
+
+
+def _committed_steps_from_wal(state_log: StateLog) -> list[CommittedStep]:
+    steps: list[CommittedStep] = []
+    for e in state_log.iter_from(0):
+        if e["kind"] != "step_completed":
+            continue
+        steps.append(CommittedStep(
+            op_invocation_id=e["op_invocation_id"],
+            op_kind=e.get("op_kind", ""),
+            phase=e["phase"],
+            args_hash=e.get("args_hash", ""),
+            seq=e.get("seq", 0),
+            result=e.get("result"),
+            usage=e.get("usage"),
+        ))
+    return steps
+
+
+def test_converged_op_dispatch_memoized_on_resume(tmp_path, monkeypatch) -> None:
+    """Tier 2: on resume a converged op-loop op memo-HITS dispatch_tool (no
+    re-execution) and its act turn replays deterministically — the json-mode-equal
+    crash-resume HARD GATE, now served by the converged path (PR-C-2.5)."""
+    monkeypatch.chdir(tmp_path)
+    # Freeze current_datetime so the act-turn LLM memo key is stable across the
+    # run-1 / run-2 (resume) boundary — a real crash-resume happens at a later
+    # wall-clock time, so this isolates the op-dispatch memo (the PR-C-2.5 subject)
+    # from the orthogonal question of whether the LLM-call memo key is
+    # datetime-robust (tracked separately).
+    monkeypatch.setattr(_models, "datetime", _FrozenClock)
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+
+    # ── Run 1: converged op-loop executes the write_file op; WAL records it ───────
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    script1 = _WriteThenStop()
+    monkeypatch.setattr(lcr, "call_llm_tools", script1)
+
+    sl1 = StateLog(wal)
+    rt1 = OSRuntime(
+        _skill(), model="stub/model", run_id="converged_resume_run",
+        state_log=sl1, routerloop_convergence_skills=[_SKILL_NAME],
+    )
+    r1 = asyncio.run(rt1.run({"type": "input", "data": {}}))
+    assert r1.ok, f"run 1 must complete; got {r1.status}"
+    assert script1.calls >= 1, "converged op-loop must have called call_tools in run 1"
+
+    committed = _committed_steps_from_wal(sl1)
+    op_steps = [s for s in committed if s.op_kind == "write_file"]
+    # The PORT's effect: the converged op dispatch wrote a WAL op step. Absent the
+    # op_dispatch_memo hook + the _execute_tool phase-memo branch, this is empty
+    # (the #1128 gap) — so this assertion falsifies the fix.
+    assert op_steps, (
+        "run 1 WAL must hold a write_file op step (the converged op-dispatch WAL "
+        f"memoization PR-C-2.5 restores); got {[s.op_kind for s in committed]}"
+    )
+
+    # ── Run 2: resume against run-1 steps; same deterministic script ─────────────
+    sl2 = StateLog(wal)
+    plan = ResumePlan(
+        run_id="converged_resume_run", skill_name=_SKILL_NAME,
+        skill_input={"type": "input", "data": {}}, current_phase="draft",
+        last_phase_artifact_path=None, awaiting_intervention_id=None,
+        committed_steps=committed,
+    )
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    script2 = _WriteThenStop()  # fresh counter, identical (deterministic) output
+    monkeypatch.setattr(lcr, "call_llm_tools", script2)
+
+    rt2 = OSRuntime(
+        _skill(), model="stub/model", run_id="converged_resume_run",
+        state_log=sl2, resume_plan=plan,
+        routerloop_convergence_skills=[_SKILL_NAME],
+    )
+    r2 = asyncio.run(rt2.run({"type": "input", "data": {}}))
+    assert r2.ok, f"resume must complete; got {r2.status}"
+
+    # (A) the act-turn LLM call replays deterministically: call_tools is NOT
+    # re-invoked on resume (memo-HIT returns the recorded tool_calls).
+    assert script2.calls == 0, (
+        "call_tools must memo-HIT on resume (act turn replayed deterministically); "
+        f"got {script2.calls} fresh invocations"
+    )
+    # (B) the op the replayed act turn produced also memo-hits dispatch_tool → the
+    # side-effecting write does NOT re-execute (json-mode-equal crash recovery).
+    file_memos = [
+        e for e in rt2.events.all()
+        if e.type == "step_memoized" and e.data.get("tool") == "write_file"
+    ]
+    assert file_memos, (
+        "the converged op-loop's write_file op must memo-hit dispatch_tool on "
+        "resume (deterministic replay does not re-execute the side effect); "
+        f"step_memoized={[e.data.get('tool') for e in rt2.events.all() if e.type == 'step_memoized']}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1092 PR-C-2.5 (re-sequenced before C-3 per lead-coder's #1128 decision). Restores **one of two** components of the converged op-loop's crash-resume guarantee.

> ⚠️ **Scope honesty:** this PR lands the **op-dispatch WAL-memo component only**. The json-mode-equal crash-resume **HARD GATE is NOT yet fully satisfied** — a second gap (the LLM-call memo's datetime-robustness, see below) must close in **C-2.6** first. **Both** C-2.5 and C-2.6 gate C-3's retirement of the frame-fed `_run_op_loop`. The HARD-GATE-satisfied milestone is after both land.

## The #1128 gap (part 1/2)

The converged op-loop dispatched phase ops via `RouterLoop._execute_tool → dispatch_tool` with `caller_kind="router"` and no `state_log`/`skill_run_id`/`op_invocation_id`, so phase ops wrote **no WAL step**. The PR5 json-mode-equal crash-resume HARD GATE (#1225 Decision A) that the frame-fed `_run_op_loop` served (via the shared `control_ir_executor`) was therefore **not served** by the converged path. Empirically, `resume_memo` on the converged path produced a WAL of `[llm, llm, llm]` with no op step.

## Fix (host-delegated, parallel to the converged op-context provisioning)

`RouterLoop._execute_tool` consults a host hook **`op_dispatch_memo()`**:
- `PhaseRouterLoopHost` returns the per-phase WAL wiring (`state_log` + `skill_run_id` + `resume_plan` + `phase`) from the **shared `ControlIRExecutor`** (single-sourced, no second resume-wiring path), so the dispatch threads `caller_kind="skill_phase"` + a phase-relative `op_invocation_id` (`<phase>.<idx>`).
- **Chat hosts don't implement the hook** (`getattr → None`), so the chat dispatch path is **byte-identical** (`caller_kind="router"`, no WAL step). RouterLoop stays generic — no phase/WAL concepts hardcoded into the shared loop (P7-clean).

## Known gap 2/2 → C-2.6 (tracked, NOT silent)

The converged op-loop's **LLM-call** memo keys on `compute_sub_loop_args_hash(messages)` which includes the seed frame's `current_datetime` — unlike frame-fed's `_compute_llm_args_hash` (which excludes volatile fields via `_LLM_VOLATILE_FRAME_FIELDS`). On a real **later-time resume** (T2 ≠ T1) the LLM act-turn memo MISSES → the act turn re-invokes → a non-deterministic production model can diverge → the op re-executes → the HARD GATE breaks **despite this op-dispatch fix**. The `_PhaseMemoProvider` docstring itself assumes "resume recomputes the same hash from the same messages" — `current_datetime` violates that.

The gate test here **freezes the clock** to isolate the op-dispatch memo. C-2.6 will add the datetime-robust LLM-memo key (lean: host-delegated memo-key hook, mirroring this PR) + a **real datetime-change resume test** (T1→T2≠T1).

## Test plan

- [x] `test_routerloop_convergence_resume_memo_1092` — run1 writes a `write_file` WAL op step; run2 (resume) memo-HITS it (`step_memoized`, no re-execution) + act turn replays. Passes.
- [x] **Falsification**: reverting the `op_dispatch_memo` hook + the `_execute_tool` phase-memo branch empties run1's op steps → the test fails (gates on the port).
- [x] **Chat byte-identical** (biggest risk): `test_replay_skill_router` + `test_router_loop*` suites — 61 passed, 1 xfailed (chat dispatch path unchanged).
- [x] Convergence + plan-memo (`compute_sub_loop_args_hash` users): `*convergence*_1092` + `test_plan_memo_replay` — 13 passed.
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` — clean (Tier 2).

Refs #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)
