### PR TITLE
fix(1092): PR-C-4b — bound converged op-loop in-loop message-history (per-turn compaction)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1894,6 +1894,14 @@ class RouterLoop:
 
         for _iteration in range(self.max_iterations):
             resolved_model = host.resolve_model(self.router_model)
+            # #1092 PR-C-4b: per-turn in-loop message-history compaction. A phase
+            # host implements ``maybe_compact_messages`` to proactively bound the
+            # converged op-loop's growing native tool-message history (json-mode
+            # parity). Chat hosts don't implement it (getattr → None) → no-op, so
+            # the chat loop is byte-identical.
+            _compact_fn = getattr(self.host, "maybe_compact_messages", None)
+            if _compact_fn is not None:
+                messages = await _compact_fn(messages, model=resolved_model)
             # ADR-0025: memo lookup — a recorded LLMToolCallResult for
             # this exact (model, messages, tools, tool_choice) tuple
             # short-circuits the call. Used by plan-mode resume so a

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -489,6 +489,11 @@ class PhaseExecutor:
             agent_role=(phase_def.role if phase_def is not None else phase),
             output_language=output_language,
             resolve_model_fn=lambda name: cie._resolver.resolve(name).model,
+            # #1092 PR-C-4b: wire the phase compaction engine/cfg so the host's
+            # per-turn ``maybe_compact_messages`` hook can proactively bound the
+            # converged op-loop's in-loop message-history (json-mode parity).
+            compaction_engine=self._phase_compaction_engine,
+            compaction_cfg=self._phase_compaction_cfg,
         )
         tools = host.get_phase_op_catalog()
         # P6 audit + the distinguishing marker for the converged op-loop (vs the

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -61,6 +61,8 @@ class PhaseRouterLoopHost:
         agent_role: str,
         output_language: str | None,
         resolve_model_fn: Callable[[str], str],
+        compaction_engine: Any = None,
+        compaction_cfg: Any = None,
     ) -> None:
         self._control_ir_executor = control_ir_executor
         self._events = events
@@ -72,6 +74,11 @@ class PhaseRouterLoopHost:
         self._agent_role = agent_role
         self._output_language = output_language
         self._resolve_model_fn = resolve_model_fn
+        # #1092 PR-C-4b: phase compaction engine + config for the per-turn in-loop
+        # message-history compaction hook (``maybe_compact_messages``). Both None
+        # when the phase has no compaction wired → the hook is a no-op.
+        self._compaction_engine = compaction_engine
+        self._compaction_cfg = compaction_cfg
 
     # ── RouterLoopCore identity / static config ───────────────────────────
 
@@ -217,6 +224,75 @@ class PhaseRouterLoopHost:
         new_msg = dict(msg)
         new_msg["content"] = json.dumps(cleaned, sort_keys=True, ensure_ascii=False)
         return new_msg
+
+    async def maybe_compact_messages(self, messages: list[dict], *, model: str) -> list[dict]:
+        """#1092 PR-C-4b: per-turn in-loop message-history compaction for the
+        converged op-loop. ``RouterLoop.run_loop`` calls this at the top of each
+        iteration; chat hosts do NOT implement it (getattr-guarded → no-op → chat
+        byte-identical).
+
+        WHY: the converged op-loop threads op results as native ``tool`` messages
+        that accumulate linearly (measured ~unbounded, +N tok/op, no proactive
+        bound — RouterLoop's retry-shrink/voluntary-compact are overflow-only
+        last-resorts). This recovers json-mode's PROACTIVE per-turn bounding (the
+        json-mode act loop summarises older control_ir_results once they exceed
+        ``recent_act_turns_raw``).
+
+        HOW (validity-preserving, no structural mutation): when the serialised
+        history exceeds the phase compaction trigger, the OLDER ``tool`` messages'
+        result CONTENTS (beyond the last ``recent_act_turns_raw``) are folded into
+        one summary via the SHARED ``compact_control_ir_results`` (the SAME engine
+        primitive C-4a / the json-mode loop use — no bespoke compaction logic);
+        the summary replaces the FIRST older tool message's content and the rest
+        get a tiny marker. NO messages are added/removed and NO
+        assistant↔tool pairing / role-alternation changes — so tool_call_id pairing
+        stays API-valid across providers, and the only delta is shrunk ``tool``
+        contents (token bound).
+
+        CRASH-RESUME (scoped, json-mode-parity per #1267): the compaction summary
+        is a non-WAL-memoized LLM call (shared engine), so compaction×resume has the
+        SAME pre-existing memo-drift as json-mode (tracked #1267, NOT introduced
+        here). The no-compaction window keeps op + LLM memo-HIT (#1263 / #1264).
+        Best-effort: ``compact_control_ir_results`` never raises (LLM error →
+        identity + ``phase_act_results_compaction_failed``).
+        """
+        engine = self._compaction_engine
+        cfg = self._compaction_cfg
+        if engine is None or cfg is None:
+            return messages
+
+        from reyn.services.compaction.engine import compact_control_ir_results
+
+        n_recent = getattr(cfg, "recent_act_turns_raw", 1)
+        tool_idxs = [i for i, m in enumerate(messages) if m.get("role") == "tool"]
+        if len(tool_idxs) <= n_recent:
+            # Not enough older tool results to fold — leave the history as-is.
+            return messages
+        older_idxs = tool_idxs[:-n_recent] if n_recent > 0 else tool_idxs
+
+        # Fold the OLDER tool-result contents into one summary via the SHARED
+        # primitive (wrap each content as a result dict so the engine sees a list).
+        # ``compact_control_ir_results`` applies its OWN token threshold (the same
+        # gate json-mode uses) and returns identity — without an LLM call — when the
+        # older slice is under it, so calling it each turn is cheap until the history
+        # actually grows past the threshold.
+        older_results = [{"result": messages[i].get("content")} for i in older_idxs]
+        compacted = await compact_control_ir_results(
+            older_results, engine=engine, cfg=cfg, events=self._events, phase=self._phase,
+        )
+        if not compacted or compacted == older_results:
+            # Identity (LLM error or under the engine's own threshold) → no change.
+            return messages
+        summary = compacted[0].get("summary") if isinstance(compacted[0], dict) else None
+        if not summary:
+            return messages
+
+        new = list(messages)
+        first = older_idxs[0]
+        new[first] = {**messages[first], "content": f"[earlier tool results compacted: {summary}]"}
+        for i in older_idxs[1:]:
+            new[i] = {**messages[i], "content": "[compacted — folded into the earlier summary]"}
+        return new
 
     # ── Chat-discovery methods (phase = empty) ────────────────────────────
     # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY

--- a/tests/test_routerloop_convergence_inloop_compaction_1092.py
+++ b/tests/test_routerloop_convergence_inloop_compaction_1092.py
@@ -1,0 +1,205 @@
+"""Tier 2: #1092 PR-C-4b — the converged op-loop's IN-LOOP message-history is
+proactively BOUNDED (not linear) by per-turn compaction.
+
+The converged op-loop threads op results as native ``tool`` messages that
+accumulate linearly (measured: +N tok/op, no proactive bound — RouterLoop's
+retry-shrink / voluntary-compact are overflow-only last-resorts). json-mode's act
+loop proactively compacts older results once they exceed ``recent_act_turns_raw``;
+C-4b folds the converged path into the SAME bounding via a per-turn host hook
+(``PhaseRouterLoopHost.maybe_compact_messages``) that summarises OLDER ``tool``
+message contents through the SHARED ``compact_control_ir_results`` primitive
+(no bespoke logic), in-place (no message added/removed → tool_call_id pairing +
+role-alternation stay API-valid).
+
+This pins the BEHAVIOR end-to-end: across many converged act-turns with sizeable
+op results + a low compaction threshold, the serialised message-history token
+count PLATEAUS (bounded) instead of growing linearly with the turn count, and
+``phase_act_results_compacted`` is emitted.
+
+Falsification: with the compaction engine/cfg unwired (the hook becomes a no-op),
+the history grows LINEARLY (asserted by the sibling no-compaction control) — so the
+bounding gates on the C-4b hook firing.
+
+Crash-resume is out of scope here (json-mode-parity, tracked #1267): the no-compaction
+window keeps op + LLM memo-HIT (#1263 / #1264); compaction×resume memo drift is a
+shared pre-existing gap, not introduced by C-4b.
+
+Real OSRuntime + real CompactionEngine; scripted seams are the module-level
+``call_llm`` / ``call_llm_tools`` (op-loop) and ``litellm.acompletion`` (summary).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import litellm
+
+import reyn.kernel.llm_call_recorder as lcr
+from reyn.config import CompactionConfig, PhaseActResultsCompactionConfig
+from reyn.events.events import EventLog
+from reyn.kernel.runtime import OSRuntime
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.services.compaction.engine import CompactionEngine, estimate_tokens
+
+_SKILL_NAME = "converged_inloop_compaction"
+_N_OPS = 8
+# A sizeable op result so each accumulated tool message is non-trivial and the
+# bounded-vs-linear difference is unambiguous.
+_OP_RESULT_FILLER = "lorem ipsum dolor sit amet " * 40
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["read_file"],
+        max_act_turns=_N_OPS + 2,
+    )
+    return Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _tool_result(tool_calls: list) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls,
+        finish_reason="tool_calls" if tool_calls else "stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+class _NReadsThenStop:
+    """Emit a read_file op for _N_OPS turns, then stop. Captures the serialised
+    message-history token estimate it RECEIVES each turn (the growth curve)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.tokens_per_turn: list[int] = []
+
+    async def __call__(self, *a, **k):  # noqa: ANN002, ANN003
+        msgs = k.get("messages") or (a[1] if len(a) > 1 else [])
+        self.tokens_per_turn.append(
+            estimate_tokens(json.dumps(msgs, default=str, ensure_ascii=False), "gpt-3.5-turbo")
+        )
+        i = self.calls
+        self.calls += 1
+        if i < _N_OPS:
+            return _tool_result([{
+                "id": f"c{i}", "type": "function",
+                "function": {"name": "read_file", "arguments": json.dumps({"path": "notes.txt"})},
+            }])
+        return _tool_result([])
+
+
+def _finish_llm():
+    async def _f(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10))
+    return _f
+
+
+class _SummaryMsg:
+    content = "[short compacted summary of earlier reads]"
+
+
+class _SummaryChoice:
+    message = _SummaryMsg()
+    finish_reason = "stop"
+
+
+class _SummaryResp:
+    choices = [_SummaryChoice()]
+    usage = None
+
+
+def _run(tmp_path, monkeypatch, *, wire_compaction: bool):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "notes.txt").write_text(_OP_RESULT_FILLER)
+
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    script = _NReadsThenStop()
+    monkeypatch.setattr(lcr, "call_llm_tools", script)
+
+    async def _fake_acompletion(model, messages, **kw):  # noqa: ANN001, ANN003
+        return _SummaryResp()
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    kwargs = {}
+    if wire_compaction:
+        kwargs["phase_compaction_engine"] = CompactionEngine(
+            model="gpt-3.5-turbo", events=EventLog(),
+            cfg=CompactionConfig(use_chars4_estimate=True), T_SP=0,
+        )
+        kwargs["phase_compaction_cfg"] = PhaseActResultsCompactionConfig(
+            use_chars4_estimate=True, recent_act_turns_raw=1,
+            summarize_older_threshold_tokens=1,
+        )
+
+    rt = OSRuntime(
+        _skill(), model="stub/model", run_id="convc4b",
+        tool_calls_op_loop_skills=[_SKILL_NAME], **kwargs,
+    )
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+    types = [e.type for e in rt.events.all()]
+    return result, script.tokens_per_turn, types
+
+
+def test_converged_inloop_message_history_bounded_by_compaction(tmp_path, monkeypatch) -> None:
+    """Tier 2: with C-4b compaction wired, the converged op-loop's in-loop
+    message-history PLATEAUS (bounded) instead of growing linearly, and
+    phase_act_results_compacted is emitted."""
+    result, tokens, types = _run(tmp_path, monkeypatch, wire_compaction=True)
+    assert result is not None
+    assert "phase_routerloop_op_loop_started" in types, f"converged path must run; {types[:8]}"
+    assert "phase_act_results_compacted" in types, (
+        f"C-4b per-turn compaction must fire across the op-loop; events={types}"
+    )
+    assert len(tokens) >= _N_OPS, f"expected ~{_N_OPS} act-turn samples; got {len(tokens)}"
+    # BOUNDED (result-content): without compaction each read accumulates the FULL
+    # op-result content (≈ op_result_tokens / op — the large-op degradation driver:
+    # per-op growth scales with op-result size). With C-4b the OLDER op-result
+    # contents collapse to one summary, so the steady-state per-op growth is the
+    # FIXED tool_call-request overhead (id/name/args), which does NOT scale with
+    # result size. Assert the steady per-op delta is WELL BELOW the op-result size
+    # (= the result content is being summarised, not accumulated).
+    op_result_tokens = estimate_tokens(_OP_RESULT_FILLER, "gpt-3.5-turbo")
+    steady_delta = tokens[-1] - tokens[-2]
+    assert steady_delta < op_result_tokens * 0.5, (
+        "C-4b must bound the op-result-content growth: the steady per-op delta "
+        f"({steady_delta}) must be well below the op-result size ({op_result_tokens}) "
+        f"— i.e. older results summarised, not accumulated; series={tokens}"
+    )
+
+
+def test_falsification_unwired_compaction_grows_linearly(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsification control — with the compaction engine/cfg UNWIRED the
+    hook is a no-op, so the converged in-loop history grows LINEARLY (per-op delta
+    ≈ full op-result size), proving the sibling test's bounding gates on the C-4b
+    hook firing."""
+    result, tokens, types = _run(tmp_path, monkeypatch, wire_compaction=False)
+    assert result is not None
+    assert "phase_act_results_compacted" not in types, "no compaction without engine/cfg"
+    assert len(tokens) >= _N_OPS
+    # LINEAR: without C-4b each read accumulates the FULL op-result content, so the
+    # steady per-op delta ≈ the op-result size (the unbounded, result-size-scaling
+    # growth the hook closes — the measure_b.py baseline).
+    op_result_tokens = estimate_tokens(_OP_RESULT_FILLER, "gpt-3.5-turbo")
+    steady_delta = tokens[-1] - tokens[-2]
+    assert steady_delta > op_result_tokens * 0.8, (
+        "without C-4b the steady per-op delta must ≈ the full op-result size "
+        f"({op_result_tokens}) — unbounded result accumulation; got {steady_delta}, "
+        f"series={tokens}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1092 PR-C-4b: bounds the converged op-loop's in-loop message-history via per-turn compaction (the last compaction surface; completes the within-unit compaction commonisation with C-4a).

## Why

The (B) sufficiency-verify (measured, reported earlier) showed the converged op-loop's native tool-message history grows **linearly with no proactive bound** (per-op growth ∝ op-result size; RouterLoop's retry-shrink/voluntary-compact are overflow-only last-resorts). Large-op phases (SWE-bench big-file reads) × turn count → model-context overflow, where json-mode proactively compacts. lead-coder confirmed C-4b GO at **json-mode-parity**.

## Fix (host-delegated, C-2.5/C-2.6 pattern)

- `RouterLoop.run_loop` calls `host.maybe_compact_messages(messages, model)` at the top of each iteration. **Chat hosts don't implement it** (`getattr → None`) → no-op → **chat byte-identical**. RouterLoop stays generic (P7).
- `PhaseRouterLoopHost.maybe_compact_messages` folds OLDER `tool`-result message **contents** (beyond `recent_act_turns_raw`) into one summary via the **shared `compact_control_ir_results`** (the same engine primitive json-mode/C-4a use — no bespoke logic; best-effort, never raises). **In-place**: no message added/removed, so `assistant`↔`tool` `tool_call_id` pairing + role-alternation stay API-valid across providers.

## Scope (honest)

Bounds the op-**result-content** growth — the large-op degradation driver (older results summarised → per-op growth no longer scales with result size). A residual **fixed-rate** tool_call-**request** overhead remains (old assistant tool_call messages kept for pairing validity), independent of result size — *not* the degradation driver. A fuller plateau (removing old assistant/tool pairs) would need structural surgery (role-alternation) — flagging as a possible refinement; happy to follow up if you'd prefer the full plateau.

## Crash-resume (json-mode-parity, #1267)

The no-compaction window keeps op + LLM memo-HIT (#1263/#1264, verified). compaction×resume memo drift is the **shared pre-existing gap** tracked in **#1267** (compaction summary not WAL-memoized) — **not introduced here**; fixing it at the shared engine layer benefits both chat and converged.

## Test plan

- [x] `test_converged_inloop_message_history_bounded_by_compaction` — steady per-op delta well below the op-result size (content summarised) + `phase_act_results_compacted` emitted. Passes.
- [x] **Falsification control** — `test_falsification_unwired_compaction_grows_linearly`: engine/cfg unwired → per-op delta ≈ full op-result size (linear, the measure_b baseline). Passes.
- [x] **Impl-falsification** (verified locally): reverting the `run_loop` hook → the bounded test fails.
- [x] Convergence suite + chat byte-identical (`test_replay_skill_router` / `test_router_loop`) + plan-memo — 64 passed, 1 xfailed (no regression).
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` — clean (Tier 2).

Refs #1092, #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
