### PR TITLE
feat(1092): PR-C-5 — converged op-loop json-mode-parity (PR2-deferrals: budget/rollback/force-close)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1894,6 +1894,14 @@ class RouterLoop:
 
         for _iteration in range(self.max_iterations):
             resolved_model = host.resolve_model(self.router_model)
+            # #1092 PR-C-5 (2): per-turn phase wall-clock budget enforcement. A phase
+            # host implements ``check_phase_budget`` (RAISES PhaseBudgetExceededError
+            # when over budget, unless on_limit grants an extension) — the same
+            # enforcement json-mode runs before each call_llm. Chat hosts don't
+            # implement it (getattr → None) → no-op, chat byte-identical.
+            _budget_fn = getattr(self.host, "check_phase_budget", None)
+            if _budget_fn is not None:
+                await _budget_fn()
             # #1092 PR-C-4b: per-turn in-loop message-history compaction. A phase
             # host implements ``maybe_compact_messages`` to proactively bound the
             # converged op-loop's growing native tool-message history (json-mode

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -523,7 +523,10 @@ class PhaseExecutor:
         routerloop = RouterLoop(
             host=host,
             chain_id=self._run_id or phase,
-            max_iterations=max_act_turns,
+            # #1092 PR-C-5 (4): use the EFFECTIVE act-turn cap (resume-adjusted), not
+            # the raw max_act_turns, so the converged op-loop force-closes
+            # json-mode-equally (mirrors _run_act_loop's state.effective_act_turn_cap).
+            max_iterations=state.effective_act_turn_cap(phase, max_act_turns),
             # cosmetic: the phase llm_caller resolves the phase model itself.
             router_model=phase,
             budget=getattr(state, "budget", None),

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -494,6 +494,10 @@ class PhaseExecutor:
             # converged op-loop's in-loop message-history (json-mode parity).
             compaction_engine=self._phase_compaction_engine,
             compaction_cfg=self._phase_compaction_cfg,
+            # #1092 PR-C-5 (2): wire per-turn phase wall-clock budget enforcement so
+            # the converged op-loop limit-checks each turn like _run_act_loop (the
+            # host's ``check_phase_budget`` hook → this bound _check_phase_budget).
+            check_phase_budget_fn=lambda: self._check_phase_budget(phase, state),
         )
         tools = host.get_phase_op_catalog()
         # P6 audit + the distinguishing marker for the converged op-loop (vs the
@@ -519,6 +523,23 @@ class PhaseExecutor:
         messages = self._llm_caller.build_phase_op_loop_messages(
             phase=phase, frame=seed_frame,
         )
+        # #1092 PR-C-5 (3): surface the rollback REASON to the converged op-loop.
+        # json-mode's _run_act_loop injects it into the act frame (via call_llm's
+        # rollback_context, llm.py); the converged op-loop turns (call_llm_tools) do
+        # NOT carry rollback_context — only the FD2 decide does. Append the rejection
+        # feedback as a seed user turn (same wording as json-mode) so the op-loop
+        # ADAPTS its op-gathering to the feedback, not just the final decide. The
+        # restored prior_results (above) already prevent redo; this adds the "why".
+        if rollback_context and rollback_context.get("reason"):
+            messages.append({
+                "role": "user",
+                "content": (
+                    f"Your previous output was rolled back by "
+                    f"[{rollback_context.get('rollback_from', '?')}]: "
+                    f"{rollback_context['reason']}\n"
+                    "Please revise your output to address the feedback."
+                ),
+            })
 
         routerloop = RouterLoop(
             host=host,

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -63,6 +63,7 @@ class PhaseRouterLoopHost:
         resolve_model_fn: Callable[[str], str],
         compaction_engine: Any = None,
         compaction_cfg: Any = None,
+        check_phase_budget_fn: Callable[[], Any] | None = None,
     ) -> None:
         self._control_ir_executor = control_ir_executor
         self._events = events
@@ -79,6 +80,10 @@ class PhaseRouterLoopHost:
         # when the phase has no compaction wired → the hook is a no-op.
         self._compaction_engine = compaction_engine
         self._compaction_cfg = compaction_cfg
+        # #1092 PR-C-5 (2): async callable that runs the phase wall-clock budget
+        # check (PhaseExecutor._check_phase_budget bound to this phase + state).
+        # None for chat hosts → the per-turn enforcement hook is a no-op.
+        self._check_phase_budget_fn = check_phase_budget_fn
 
     # ── RouterLoopCore identity / static config ───────────────────────────
 
@@ -293,6 +298,23 @@ class PhaseRouterLoopHost:
         for i in older_idxs[1:]:
             new[i] = {**messages[i], "content": "[compacted — folded into the earlier summary]"}
         return new
+
+    async def check_phase_budget(self) -> None:
+        """#1092 PR-C-5 (2): per-turn phase wall-clock budget enforcement for the
+        converged op-loop. ``RouterLoop.run_loop`` calls this at the top of each
+        iteration (before the act-turn LLM call); chat hosts don't implement it
+        (getattr-guarded → no-op → chat byte-identical).
+
+        Delegates to the bound ``PhaseExecutor._check_phase_budget(phase, state)``
+        (the SAME enforcement the json-mode ``_run_act_loop`` runs before each
+        call_llm): it RAISES ``PhaseBudgetExceededError`` when the phase exceeds its
+        wall-clock budget, unless ``safety.on_limit`` approves a continuation
+        (extension granted + clock reset). Without this, a runaway converged phase
+        would never be limit-checked — the #1128 safety-net gap this closes.
+        """
+        if self._check_phase_budget_fn is None:
+            return
+        await self._check_phase_budget_fn()
 
     # ── Chat-discovery methods (phase = empty) ────────────────────────────
     # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY

--- a/tests/test_routerloop_convergence_parity_deferrals_1092.py
+++ b/tests/test_routerloop_convergence_parity_deferrals_1092.py
@@ -1,0 +1,239 @@
+"""Tier 2: #1092 PR-C-5 — the converged op-loop serves the PR2-deferrals at
+json-mode-parity (verify-before-retire / serve-before-retire, #1128).
+
+Three deferrals the converged op-loop did NOT serve (the frame-fed _run_op_loop
+"PR2-scope simplifications vs _run_act_loop") are ported / fixed here; this pins
+each with a #1128 gate (wiring + sufficiency + falsification):
+
+(2) handle_limit_exceeded — per-turn phase wall-clock budget enforcement. The
+    converged op-loop now runs the SAME _check_phase_budget json-mode runs before
+    each call_llm, via a run_loop host-hook. (safety-critical.)
+(3) rollback-reason injection — the rollback rejection feedback now reaches the
+    converged op-loop seed (not just the FD2 decide).
+(4) force-close effective_act_turn_cap — the converged op-loop uses the
+    resume-adjusted effective cap, not the raw max_act_turns.
+
+(1) on-demand compact op is documented obviated by C-4b auto-compaction (no port).
+
+Real OSRuntime + real PhaseExecutor; the only scripted seam is the module-level
+call_llm / call_llm_tools provider boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import reyn.kernel.llm_call_recorder as lcr
+import reyn.kernel.run_state as run_state
+from reyn.config import OnLimitConfig, SafetyConfig, TimeoutConfig
+from reyn.kernel.run_state import RunState
+from reyn.kernel.runtime import OSRuntime
+from reyn.kernel.runtime_types import PhaseBudgetExceededError
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import CandidateOutput, Phase, Skill, SkillGraph
+
+_SKILL_NAME = "converged_deferrals"
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill(allowed_ops=None) -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=allowed_ops or [],
+    )
+    return Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def _stop_tools():
+    async def _t(*a, **k):  # noqa: ANN002, ANN003
+        return LLMToolCallResult(
+            content=None, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+    return _t
+
+
+def _finish_llm():
+    async def _f(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10))
+    return _f
+
+
+# ── (2) handle_limit_exceeded: per-turn phase budget enforcement ────────────────
+
+
+def test_converged_op_loop_enforces_phase_budget(tmp_path, monkeypatch) -> None:
+    """Tier 2: the converged op-loop enforces the per-turn phase wall-clock budget
+    (C-5 deferral 2). Over budget with on_limit=unattended → PhaseBudgetExceededError,
+    the SAME enforcement json-mode runs (full, not a degraded stand-in).
+
+    Falsification: reverting the run_loop check_phase_budget hook makes the over-budget
+    converged run complete normally (no enforcement) — verified locally.
+    """
+    monkeypatch.chdir(tmp_path)
+    # Deterministic over-budget clock: begin_phase records phase_started_at on the
+    # first monotonic() call; every later call jumps +10000s so elapsed >> budget.
+    _ticks = {"n": 0}
+
+    def _fake_monotonic():
+        v = _ticks["n"] * 10000.0
+        _ticks["n"] += 1
+        return v
+    monkeypatch.setattr(run_state.time, "monotonic", _fake_monotonic)
+
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _stop_tools())
+
+    safety = SafetyConfig(
+        timeout=TimeoutConfig(phase_seconds=1.0),
+        on_limit=OnLimitConfig(mode="unattended"),  # over-budget → immediate abort/raise
+    )
+    rt = OSRuntime(
+        _skill(), model="stub/model", run_id="convbudget",
+        tool_calls_op_loop_skills=[_SKILL_NAME], safety=safety,
+    )
+    # The per-turn budget hook fires at the top of the op-loop's first iteration
+    # (before call_llm_tools); elapsed (10000s) >> 1s budget → _check_phase_budget
+    # raises PhaseBudgetExceededError, which the orchestrator surfaces as a
+    # ``phase_budget_exceeded`` RunResult (FP-0005). Without the hook the run would
+    # finish normally (no enforcement) — the falsification.
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+    assert result.status == "phase_budget_exceeded", (
+        "the converged op-loop must enforce the per-turn phase budget (C-5 deferral 2); "
+        f"got status={result.status!r} (expected phase_budget_exceeded)"
+    )
+
+
+# ── (3) rollback-reason injection into the converged op-loop seed ────────────────
+
+
+def test_converged_op_loop_seed_surfaces_rollback_reason(tmp_path, monkeypatch) -> None:
+    """Tier 2: the rollback rejection reason reaches the converged op-loop SEED
+    (C-5 deferral 3) — so the op-loop adapts its op-gathering, not just the FD2
+    decide. json-mode injects it into the act frame via call_llm's rollback_context;
+    the converged op-loop turns don't carry rollback_context, so the port appends the
+    feedback to the seed. Driven by a direct ``_run_routerloop_op_loop`` call with a
+    rollback_context (parallel to the json-mode rollback test that calls
+    ``_run_act_loop`` directly).
+
+    Falsification: reverting the seed-injection makes the reason absent from the
+    op-loop seed (it would then appear only in the FD2 decide).
+    """
+    monkeypatch.chdir(tmp_path)
+    _REASON = "the artifact omitted the required citations"
+    captured = {"seed": None}
+
+    async def _capture_tools(*a, **k):  # noqa: ANN002, ANN003
+        if captured["seed"] is None:
+            captured["seed"] = k.get("messages", [])
+        return LLMToolCallResult(
+            content=None, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _capture_tools)
+
+    rt = OSRuntime(
+        _skill(), model="stub/model", run_id="convrollback",
+        tool_calls_op_loop_skills=[_SKILL_NAME],
+    )
+    state = rt._state
+    state.begin_phase("draft")
+    cand = CandidateOutput(
+        next_phase="draft", control_type="transition", schema_name="result",
+        artifact_schema={"type": "object", "properties": {}},
+    )
+    rollback_context = {
+        "rejected_artifact": {"type": "result", "data": {}},
+        "reason": _REASON,
+        "rollback_from": "review",
+        "previous_control_ir_results": [],
+    }
+    asyncio.run(rt._phase_executor._run_routerloop_op_loop(
+        "draft", {"type": "input", "data": {}}, [cand], None,
+        2, 2, None, state, rollback_context=rollback_context,
+    ))
+
+    seed_blob = str(captured["seed"])
+    assert _REASON in seed_blob, (
+        "the converged op-loop seed must surface the rollback reason (C-5 deferral 3) "
+        f"so the op-loop adapts; reason {_REASON!r} not in seed messages={captured['seed']!r}"
+    )
+
+
+# ── (4) force-close uses the effective (resume-adjusted) act-turn cap ────────────
+
+
+def test_converged_op_loop_uses_effective_act_turn_cap(tmp_path, monkeypatch) -> None:
+    """Tier 2: the converged op-loop force-closes at the EFFECTIVE act-turn cap, not
+    the raw max_act_turns (C-5 deferral 4, json-mode-parity). A monkeypatched
+    effective cap (3) below the phase's raw max_act_turns (10) bounds the op-loop to
+    3 act turns.
+
+    Falsification: reverting the fix (raw max_act_turns) runs up to 10 turns.
+    """
+    monkeypatch.chdir(tmp_path)
+    _EFFECTIVE = 3
+    monkeypatch.setattr(
+        RunState, "effective_act_turn_cap",
+        lambda self, phase, base_cap: _EFFECTIVE,
+    )
+
+    calls = {"n": 0}
+
+    async def _never_stop(*a, **k):  # noqa: ANN002, ANN003
+        # Always emit a read_file tool_call (continue) so the op-loop never
+        # voluntarily ends — it runs until max_iterations (= the effective cap)
+        # bounds it, exposing whether that cap is effective (3) or raw (10).
+        i = calls["n"]
+        calls["n"] += 1
+        return LLMToolCallResult(
+            content=None,
+            tool_calls=[{
+                "id": f"c{i}", "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "x.txt"}'},
+            }],
+            finish_reason="tool_calls",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _never_stop)
+
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["read_file"], max_act_turns=10,  # raw cap 10; effective (patched) = 3
+    )
+    skill = Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+    rt = OSRuntime(
+        skill, model="stub/model", run_id="convcap",
+        tool_calls_op_loop_skills=[_SKILL_NAME],
+    )
+    asyncio.run(rt.run({"type": "input", "data": {}}))
+    # The op-loop (always emitting tool_calls) ran exactly the EFFECTIVE cap (3),
+    # not the raw 10 — proving converged force-close honors the resume-adjusted cap.
+    assert calls["n"] == _EFFECTIVE, (
+        "the converged op-loop must bound iterations by the EFFECTIVE act-turn cap "
+        f"({_EFFECTIVE}), not the raw max_act_turns (10); call_tools fired {calls['n']}x"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1092 PR-C-5: the convergence wave finale. Resolves the PR2-deferrals so the converged op-loop reaches json-mode-parity, under the **#1128 verify-before-retire / serve-before-retire** discipline (each deferral verified-served or ported *before* it's closed; nothing retired on an unverified "RouterLoop covers it").

Bundle PR (per lead-coder: OK if per-item #1128 gates are explicit). The safety port (2) is sectioned below for focused review.

## Per-item #1128 gates (wiring + sufficiency + falsification)

### (2) handle_limit_exceeded — PORT (safety-critical)
**Gap:** the converged op-loop did not enforce the per-turn phase wall-clock budget (RouterLoop's `budget` is cost-tracking only) — a runaway converged phase was never limit-checked.
**Port:** host-hook (C-2.5/C-2.6 pattern) — `run_loop` calls `host.check_phase_budget()` at the top of each iteration; `PhaseRouterLoopHost.check_phase_budget` delegates to the bound `PhaseExecutor._check_phase_budget(phase, state)` — the **same** enforcement json-mode runs before each `call_llm` (RAISES `PhaseBudgetExceededError` over budget unless `on_limit` grants an extension). Chat hosts don't implement it (`getattr → None`) → chat byte-identical.
- **wiring/sufficiency:** real `_check_phase_budget` (full enforcement, not a stub).
- **falsification (verified):** revert the run_loop hook → over-budget converged run finishes normally (no `phase_budget_exceeded`).

### (3) rollback-reason injection — PORT
**Gap:** the FD2 decide gets `rollback_context`, but the op-loop **seed** didn't surface the rollback reason (json-mode injects it into the act frame from turn 1).
**Port:** append the rejection feedback (same wording as json-mode's `call_llm` injection) to the converged op-loop seed when `rollback_context` carries a reason → the op-loop adapts its op-gathering, not just the decide.
- **falsification (verified):** revert the injection → reason absent from the seed.

### (4) force-close `effective_act_turn_cap` — FIX
**Gap:** converged drove `RouterLoop(max_iterations=raw max_act_turns)`; json-mode uses `state.effective_act_turn_cap(phase, max_act_turns)` (resume-adjusted).
**Fix:** converged now uses the effective cap → json-mode-equal force-close.
- **falsification (verified):** revert to raw → the op-loop runs the raw cap (10) instead of the effective (3).

### (1) on-demand compact op — DOCUMENT obviated (no port)
Not advertised in the converged catalog (json-mode-only); C-4b's auto-compaction covers the bounding purpose (auto ≥ on-demand for bounding), and `compact_now` returns only freed-window status (no non-bounding use). So this is not a converged capability being dropped — no port needed.

## Crash-resume
No-compaction window keeps op+LLM memo-HIT (#1263/#1264). The compaction×resume memo drift is the shared pre-existing gap tracked in **#1267** (not introduced here).

## Test plan
- [x] `test_routerloop_convergence_parity_deferrals_1092` — (2)/(3)/(4) gates, **all 3 impl-falsified** (revert each port → its test fails; restored → pass).
- [x] Convergence suite + chat byte-identical (`test_replay_skill_router` / `test_router_loop`) — 59 passed, 1 xfailed (no regression).
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` — clean (Tier 2).
- [ ] Full `pytest -q` from rootdir — running (will report).

Refs #1092, #1267
Closes the within-unit convergence commonization (force-close + deferrals resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
