### PR TITLE
fix(1267): WAL-memoize phase compaction summary (shared-layer crash-resume fix)

### DIFF
--- a/src/reyn/kernel/llm_call_recorder.py
+++ b/src/reyn/kernel/llm_call_recorder.py
@@ -476,6 +476,22 @@ class LLMCallRecorder:
         """
         return _PhaseMemoProvider(recorder=self, phase=phase, state=state)
 
+    def make_summary_memo(self) -> "_SummaryMemo":
+        """#1267: WAL-memo seam for the phase compaction summary LLM call.
+
+        ``compact_control_ir_results`` (used by json-mode ``_run_act_loop`` and the
+        converged ``_run_routerloop_op_loop`` / C-4b host) summarises older op-results
+        via a non-WAL-memoized ``recorded_acompletion`` call — so on a compaction×resume
+        it re-summarized non-deterministically and the downstream act-turn memo drifted
+        (the #1267 idempotency hole). This seam memoizes that summary against the SAME
+        WAL ``committed_steps`` (op_invocation_id ``f"{phase}.compaction"`` + a content
+        args_hash of (model, older_text), unique-by-content so it never collides with
+        the act-turn id sequence) — so the resume HITS the recorded summary. Reuses
+        this recorder's WAL primitives; no new persistence. No phase/state binding (the
+        phase is passed per call), so one instance serves every compaction in the run.
+        """
+        return _SummaryMemo(recorder=self)
+
     def build_phase_op_loop_messages(
         self, *, phase: str, frame: "ContextFrame",
     ) -> list[dict]:
@@ -781,3 +797,41 @@ class _PhaseMemoProvider:
             usage=result.usage.to_dict() if result.usage else None,
         )
         self._pending_op_id = None
+
+
+class _SummaryMemo:
+    """#1267: WAL-memo for the phase compaction summary call (``make_summary_memo``).
+
+    ``lookup_summary`` / ``record_summary`` bridge the compaction summary onto the
+    SAME WAL ``committed_steps`` the act-turn memos use, keyed by
+    ``op_invocation_id=f"{phase}.compaction"`` + a CONTENT args_hash (of model +
+    older_text). The fixed op_invocation_id is unique-by-content (the args_hash
+    discriminates) and does NOT consume the ``next_llm_invocation_id`` sequence, so it
+    never interleaves with the act-turn ids. On resume the recorded summary is reused
+    (HIT) → no re-summarize → the downstream act-turn memo stays stable (#1267).
+    """
+
+    def __init__(self, *, recorder: "LLMCallRecorder") -> None:
+        self._recorder = recorder
+
+    async def lookup_summary(self, phase: "str | None", args_hash: str) -> "str | None":
+        resume_plan = self._recorder._resume_plan
+        if resume_plan is None:
+            return None
+        op_id = f"{phase or 'phase'}.compaction"
+        memo = _lookup_memoized_step(resume_plan, op_id, phase or "", args_hash)
+        if memo is None:
+            return None
+        result = memo.result
+        if isinstance(result, dict):
+            return result.get("summary")
+        return result if isinstance(result, str) else None
+
+    async def record_summary(self, phase: "str | None", args_hash: str, summary: str) -> None:
+        op_id = f"{phase or 'phase'}.compaction"
+        await self._recorder._wal_step_completed_for_llm(
+            phase=phase or "",
+            op_invocation_id=op_id,
+            args_hash=args_hash,
+            result={"summary": summary},
+        )

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -74,7 +74,7 @@ class _ControlIRResultsHolder:
         self._results = list(results)
 
 
-def _make_phase_compact_now(holder, engine, cfg, events, phase):
+def _make_phase_compact_now(holder, engine, cfg, events, phase, summary_memo=None):
     """Build the phase-axis ``compact_now`` callback (#1176 B1).
 
     On-demand counterpart to the act loop's automatic compaction: it compacts
@@ -107,6 +107,7 @@ def _make_phase_compact_now(holder, engine, cfg, events, phase):
         if older:
             older_compacted = await compact_control_ir_results(
                 older, engine=engine, cfg=cfg, events=events, phase=phase,
+                summary_memo=summary_memo,
             )
             holder.set(older_compacted + recent)
         # else: nothing older to compact — no-op (still report the live window).
@@ -154,6 +155,10 @@ class PhaseExecutor:
         op_loop_enabled: bool = False,
     ) -> None:
         self._llm_caller = llm_caller
+        # #1267: WAL-memo seam for the phase compaction summary call (shared by all
+        # compact_control_ir_results sites — json-mode / converged / on-demand). Built
+        # from the recorder's WAL primitives; getattr-guarded for non-recorder fakes.
+        self._summary_memo = getattr(llm_caller, "make_summary_memo", lambda: None)()
         self._control_ir_executor = control_ir_executor
         self._events = events
         self._skill = skill
@@ -498,6 +503,7 @@ class PhaseExecutor:
             # the converged op-loop limit-checks each turn like _run_act_loop (the
             # host's ``check_phase_budget`` hook → this bound _check_phase_budget).
             check_phase_budget_fn=lambda: self._check_phase_budget(phase, state),
+            summary_memo=self._summary_memo,
         )
         tools = host.get_phase_op_catalog()
         # P6 audit + the distinguishing marker for the converged op-loop (vs the
@@ -631,6 +637,7 @@ class PhaseExecutor:
                 older,
                 engine=self._phase_compaction_engine,
                 cfg=self._phase_compaction_cfg,
+                summary_memo=self._summary_memo,
                 events=self._events,
                 phase=phase,
             )
@@ -717,6 +724,7 @@ class PhaseExecutor:
                     older,
                     engine=self._phase_compaction_engine,
                     cfg=self._phase_compaction_cfg,
+                    summary_memo=self._summary_memo,
                     events=self._events,
                     phase=phase,
                 )
@@ -864,6 +872,7 @@ class PhaseExecutor:
                 _make_phase_compact_now(
                     _holder, self._phase_compaction_engine,
                     self._phase_compaction_cfg, self._events, phase,
+                    self._summary_memo,
                 )
                 if self._phase_compaction_engine is not None
                 and self._phase_compaction_cfg is not None

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -64,6 +64,7 @@ class PhaseRouterLoopHost:
         compaction_engine: Any = None,
         compaction_cfg: Any = None,
         check_phase_budget_fn: Callable[[], Any] | None = None,
+        summary_memo: Any = None,
     ) -> None:
         self._control_ir_executor = control_ir_executor
         self._events = events
@@ -84,6 +85,8 @@ class PhaseRouterLoopHost:
         # check (PhaseExecutor._check_phase_budget bound to this phase + state).
         # None for chat hosts → the per-turn enforcement hook is a no-op.
         self._check_phase_budget_fn = check_phase_budget_fn
+        # #1267: WAL-memo seam for the in-loop (C-4b) compaction summary call.
+        self._summary_memo = summary_memo
 
     # ── RouterLoopCore identity / static config ───────────────────────────
 
@@ -284,6 +287,7 @@ class PhaseRouterLoopHost:
         older_results = [{"result": messages[i].get("content")} for i in older_idxs]
         compacted = await compact_control_ir_results(
             older_results, engine=engine, cfg=cfg, events=self._events, phase=self._phase,
+            summary_memo=self._summary_memo,
         )
         if not compacted or compacted == older_results:
             # Identity (LLM error or under the engine's own threshold) → no change.

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1331,6 +1331,7 @@ async def compact_control_ir_results(
     cfg: "PhaseActResultsCompactionConfig",
     events: "EventLog",
     phase: str | None = None,
+    summary_memo: "Any" = None,
 ) -> list[dict]:
     """Return a list with ``older_results`` summarised into a single
     ``__compacted_phase_results__`` placeholder entry.
@@ -1399,23 +1400,41 @@ async def compact_control_ir_results(
     # Serialise older_results for the LLM call.
     older_text = json.dumps(older_results, ensure_ascii=False, indent=1)
 
-    # Step 4 + 5: call LLM summariser, then hard-truncate.
+    # #1267: content args_hash for the summary memo. The summary is a PURE FUNCTION
+    # of (model, older_text) + the fixed system prompt, and ``older_results`` are
+    # op-result dicts with NO volatile fields that re-accumulate deterministically on
+    # resume (op results are memoized) — so this key is resume-stable. When a
+    # ``summary_memo`` is wired (phase paths), the summary LLM call is WAL-memoized so
+    # a compaction×resume HITS (no re-summarize → downstream act-turn memo stays
+    # stable → no op re-execution). recorded_acompletion is UNCHANGED (memo-wrap only).
+    import hashlib as _hashlib
+    summary_args_hash = _hashlib.sha256(
+        f"{model}\x00{older_text}".encode()
+    ).hexdigest()[:16]
+
+    # Step 4 + 5: call LLM summariser (or memo-replay it), then hard-truncate.
     summary_text: str
     try:
-        from reyn.llm.llm import recorded_acompletion
-        response = await recorded_acompletion(
-            model=model,
-            messages=[
-                {"role": "system", "content": _PHASE_COMPACTION_SYSTEM_PROMPT},
-                {"role": "user", "content": older_text},
-            ],
-            purpose="compaction",
-            recorder=getattr(engine, "_recorder", None),
-            agent=getattr(engine, "_recorder_agent", None),
-        )
-        raw_summary = (response.choices[0].message.content or "").strip()
-        if not raw_summary:
-            raise ValueError("phase act_results compaction LLM returned empty response")
+        raw_summary: str | None = None
+        if summary_memo is not None:
+            raw_summary = await summary_memo.lookup_summary(phase, summary_args_hash)
+        if raw_summary is None:
+            from reyn.llm.llm import recorded_acompletion
+            response = await recorded_acompletion(
+                model=model,
+                messages=[
+                    {"role": "system", "content": _PHASE_COMPACTION_SYSTEM_PROMPT},
+                    {"role": "user", "content": older_text},
+                ],
+                purpose="compaction",
+                recorder=getattr(engine, "_recorder", None),
+                agent=getattr(engine, "_recorder_agent", None),
+            )
+            raw_summary = (response.choices[0].message.content or "").strip()
+            if not raw_summary:
+                raise ValueError("phase act_results compaction LLM returned empty response")
+            if summary_memo is not None:
+                await summary_memo.record_summary(phase, summary_args_hash, raw_summary)
         # Bound the summary to the engine's body_budget (Axis 9 pattern).
         summary_text = hard_truncate_summary(
             raw_summary,

--- a/tests/test_compaction_summary_resume_1267.py
+++ b/tests/test_compaction_summary_resume_1267.py
@@ -1,0 +1,206 @@
+"""Tier 2: #1267 — converged op-loop compaction×resume reuses the recorded summary
+(end-to-end, real WAL ``_SummaryMemo``).
+
+Companion to the path-agnostic unit gates (test_compaction_summary_wal_memo_1267):
+this drives the REAL WAL-backed summary memo through OSRuntime — run 1 fires C-4a
+post-loop compaction (recording the summary as a WAL step); the resume re-runs the
+op-loop (op + act-turn memos HIT), re-fires compaction, and the summary **memo-HITS**
+(no re-summarize) despite a CHANGING scripted summariser — proving the #1267 fix on
+the converged phase variant.
+
+Frozen clock isolates the summary memo from the (separately tested, #1264) datetime
+robustness — the act-turn LLM memos HIT trivially, so the op-loop replays and
+compaction re-fires, leaving the compaction summary as the variable under test.
+
+Falsification: reverting the summary_memo wiring makes the resume re-summarize (the
+changing summariser is called again on run 2).
+
+Real OSRuntime + real CompactionEngine + real WAL; scripted seams = module-level
+``call_llm`` / ``call_llm_tools`` (act-turns) + ``litellm.acompletion`` (the summary).
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+
+import litellm
+
+import reyn.kernel.llm_call_recorder as lcr
+import reyn.schemas.models as _models
+from reyn.config import CompactionConfig, PhaseActResultsCompactionConfig
+from reyn.events.events import EventLog
+from reyn.events.state_log import StateLog
+from reyn.kernel.runtime import OSRuntime
+from reyn.llm.llm import LLMCallResult, LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.services.compaction.engine import CompactionEngine
+from reyn.skill.skill_resume_analyzer import CommittedStep, ResumePlan
+
+_SKILL_NAME = "compaction_summary_resume"
+
+
+class _FrozenInstant(_dt.datetime):
+    def astimezone(self, tz=None):  # noqa: ANN001, ANN201
+        return self
+
+
+_FROZEN = _FrozenInstant(2026, 1, 1, tzinfo=_dt.timezone.utc)
+
+
+class _FrozenClock(_dt.datetime):
+    @classmethod
+    def now(cls, tz=None):  # noqa: ANN001, ANN206
+        return _FROZEN
+
+
+_FINISH = {
+    "type": "finish",
+    "control": {
+        "type": "finish", "decision": "finish", "next_phase": None,
+        "confidence": 1.0, "reason": {"summary": "done"},
+    },
+    "artifact": {"type": "result", "data": {}},
+}
+
+
+def _skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["write_file"], max_act_turns=6,
+    )
+    return Skill(
+        name=_SKILL_NAME, entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+class _TwoWritesThenStop:
+    """turn 1 + 2 emit distinct write_file ops; turn 3 stops. Two accumulated
+    control_ir_results (> recent_act_turns_raw=1) → C-4a post-loop compaction fires."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, *a, **k):  # noqa: ANN002, ANN003
+        i = self.calls
+        self.calls += 1
+        if i < 2:
+            return LLMToolCallResult(
+                content=None,
+                tool_calls=[{
+                    "id": f"c{i}", "type": "function",
+                    "function": {"name": "write_file",
+                                 "arguments": '{"path": ".reyn/c%d.txt", "content": "x"}' % i},
+                }],
+                finish_reason="tool_calls",
+                usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+            )
+        return LLMToolCallResult(
+            content=None, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+
+def _finish_llm():
+    async def _f(model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        return LLMCallResult(data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10))
+    return _f
+
+
+class _SummaryResp:
+    def __init__(self, text: str) -> None:
+        self.choices = [type("C", (), {"message": type("M", (), {"content": text})(), "finish_reason": "stop"})()]
+        self.usage = None
+
+
+def _committed_steps_from_wal(state_log: StateLog) -> list[CommittedStep]:
+    steps: list[CommittedStep] = []
+    for e in state_log.iter_from(0):
+        if e["kind"] != "step_completed":
+            continue
+        steps.append(CommittedStep(
+            op_invocation_id=e["op_invocation_id"], op_kind=e.get("op_kind", ""),
+            phase=e["phase"], args_hash=e.get("args_hash", ""), seq=e.get("seq", 0),
+            result=e.get("result"), usage=e.get("usage"),
+        ))
+    return steps
+
+
+def _engine_cfg():
+    eng = CompactionEngine(
+        model="gpt-3.5-turbo", events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True), T_SP=0,
+    )
+    cfg = PhaseActResultsCompactionConfig(
+        use_chars4_estimate=True, recent_act_turns_raw=1, summarize_older_threshold_tokens=1,
+    )
+    return eng, cfg
+
+
+def test_converged_compaction_summary_memo_hits_on_resume(tmp_path, monkeypatch) -> None:
+    """Tier 2: the converged op-loop's compaction summary memo-HITS on resume — the
+    summariser is NOT re-called despite a changing scripted value (#1267 end-to-end)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_models, "datetime", _FrozenClock)
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+
+    summary_calls = {"n": 0}
+
+    async def _changing_summary(model, messages, **kw):  # noqa: ANN001, ANN003
+        summary_calls["n"] += 1
+        return _SummaryResp(f"COMPACTED_V{summary_calls['n']}")
+    monkeypatch.setattr(litellm, "acompletion", _changing_summary)
+
+    # ── Run 1: 2 ops → C-4a compaction fires → summary recorded (V1) ──────────────
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _TwoWritesThenStop())
+    eng, cfg = _engine_cfg()
+    sl1 = StateLog(wal)
+    rt1 = OSRuntime(
+        _skill(), model="stub/model", run_id="compsum",
+        tool_calls_op_loop_skills=[_SKILL_NAME], state_log=sl1,
+        phase_compaction_engine=eng, phase_compaction_cfg=cfg,
+    )
+    r1 = asyncio.run(rt1.run({"type": "input", "data": {}}))
+    assert r1.ok, f"run 1 must complete; got {r1.status}"
+    assert "phase_act_results_compacted" in [e.type for e in rt1.events.all()], (
+        "run 1 must fire compaction (>recent_act_turns_raw)"
+    )
+    # The converged path has TWO compaction surfaces (C-4b in-loop per-turn + C-4a
+    # post-loop), so run 1 may summarise more than once. Capture the run-1 total; the
+    # gate is that resume adds ZERO new summariser calls (all memo-HIT).
+    run1_summaries = summary_calls["n"]
+    assert run1_summaries >= 1, f"run 1 must summarise at least once; got {run1_summaries}"
+
+    # ── Run 2: resume — op-loop replays, compaction re-fires, summary MEMO-HITS ────
+    committed = _committed_steps_from_wal(sl1)
+    plan = ResumePlan(
+        run_id="compsum", skill_name=_SKILL_NAME,
+        skill_input={"type": "input", "data": {}}, current_phase="draft",
+        last_phase_artifact_path=None, awaiting_intervention_id=None,
+        committed_steps=committed,
+    )
+    monkeypatch.setattr(lcr, "call_llm", _finish_llm())
+    monkeypatch.setattr(lcr, "call_llm_tools", _TwoWritesThenStop())
+    eng2, cfg2 = _engine_cfg()
+    sl2 = StateLog(wal)
+    rt2 = OSRuntime(
+        _skill(), model="stub/model", run_id="compsum",
+        tool_calls_op_loop_skills=[_SKILL_NAME], state_log=sl2, resume_plan=plan,
+        phase_compaction_engine=eng2, phase_compaction_cfg=cfg2,
+    )
+    r2 = asyncio.run(rt2.run({"type": "input", "data": {}}))
+    assert r2.ok, f"resume must complete; got {r2.status}"
+
+    # THE GATE: resume added ZERO new summariser calls — every compaction summary
+    # memo-HIT its recorded value (no re-summarize), despite the changing scripted
+    # summariser. Falsification: reverting the summary_memo wiring makes run 2
+    # re-summarize (summary_calls["n"] grows past run1_summaries with changed values).
+    assert summary_calls["n"] == run1_summaries, (
+        "the converged compaction summary must memo-HIT on resume (no re-summarize) — "
+        f"resume re-called the summariser: run1={run1_summaries} total={summary_calls['n']}"
+    )

--- a/tests/test_compaction_summary_resume_1267.py
+++ b/tests/test_compaction_summary_resume_1267.py
@@ -204,3 +204,93 @@ def test_converged_compaction_summary_memo_hits_on_resume(tmp_path, monkeypatch)
         "the converged compaction summary must memo-HIT on resume (no re-summarize) — "
         f"resume re-called the summariser: run1={run1_summaries} total={summary_calls['n']}"
     )
+
+
+class _JsonModeActsThenFinish:
+    """json-mode act-loop: 2 act turns (each a write_file op) then a finish decide.
+    Two accumulated control_ir_results (> recent_act_turns_raw=1) → _run_act_loop's
+    per-turn compaction fires. Fresh per run; deterministic replay."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, model, frame, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        i = self.calls
+        self.calls += 1
+        if i < 2:
+            return LLMCallResult(
+                data={"type": "act", "ops": [
+                    {"kind": "write_file", "path": ".reyn/j%d.txt" % i, "content": "x"},
+                ]},
+                usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+            )
+        return LLMCallResult(data=_FINISH, usage=TokenUsage(prompt_tokens=20, completion_tokens=10))
+
+
+def _jsonmode_skill() -> Skill:
+    draft = Phase(
+        name="draft", instructions="d",
+        input_schema={"type": "object", "properties": {}},
+        allowed_ops=["write_file"], max_act_turns=6,
+    )
+    return Skill(
+        name="jsonmode_compaction_resume", entry_phase="draft", phases={"draft": draft},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}},
+        final_output_name="result",
+    )
+
+
+def test_jsonmode_compaction_summary_memo_hits_on_resume(tmp_path, monkeypatch) -> None:
+    """Tier 2: the json-mode _run_act_loop compaction summary memo-HITS on resume —
+    the JSON-MODE site's resume wiring threads the summary_memo (verify-each-site, the
+    #1248/C-3 site-wiring discipline; the converged mirror is the sibling test)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_models, "datetime", _FrozenClock)
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+
+    summary_calls = {"n": 0}
+
+    async def _changing_summary(model, messages, **kw):  # noqa: ANN001, ANN003
+        summary_calls["n"] += 1
+        return _SummaryResp(f"COMPACTED_V{summary_calls['n']}")
+    monkeypatch.setattr(litellm, "acompletion", _changing_summary)
+
+    # ── Run 1: json-mode 2 act-turns → per-turn compaction fires → summary recorded ─
+    monkeypatch.setattr(lcr, "call_llm", _JsonModeActsThenFinish())
+    eng, cfg = _engine_cfg()
+    sl1 = StateLog(wal)
+    rt1 = OSRuntime(
+        _jsonmode_skill(), model="stub/model", run_id="jsoncompsum",
+        state_log=sl1, phase_compaction_engine=eng, phase_compaction_cfg=cfg,
+    )  # NOT in tool_calls_op_loop_skills → json-mode path
+    r1 = asyncio.run(rt1.run({"type": "input", "data": {}}))
+    assert r1.ok, f"run 1 must complete; got {r1.status}"
+    assert "phase_act_results_compacted" in [e.type for e in rt1.events.all()], (
+        "run 1 (json-mode) must fire per-turn compaction"
+    )
+    run1_summaries = summary_calls["n"]
+    assert run1_summaries >= 1, f"run 1 must summarise at least once; got {run1_summaries}"
+
+    # ── Run 2: resume — act-loop replays, compaction re-fires, summary MEMO-HITS ───
+    committed = _committed_steps_from_wal(sl1)
+    plan = ResumePlan(
+        run_id="jsoncompsum", skill_name="jsonmode_compaction_resume",
+        skill_input={"type": "input", "data": {}}, current_phase="draft",
+        last_phase_artifact_path=None, awaiting_intervention_id=None,
+        committed_steps=committed,
+    )
+    monkeypatch.setattr(lcr, "call_llm", _JsonModeActsThenFinish())
+    eng2, cfg2 = _engine_cfg()
+    sl2 = StateLog(wal)
+    rt2 = OSRuntime(
+        _jsonmode_skill(), model="stub/model", run_id="jsoncompsum",
+        state_log=sl2, resume_plan=plan,
+        phase_compaction_engine=eng2, phase_compaction_cfg=cfg2,
+    )
+    r2 = asyncio.run(rt2.run({"type": "input", "data": {}}))
+    assert r2.ok, f"resume must complete; got {r2.status}"
+    assert summary_calls["n"] == run1_summaries, (
+        "the json-mode compaction summary must memo-HIT on resume (no re-summarize) — "
+        f"resume re-called the summariser: run1={run1_summaries} total={summary_calls['n']}"
+    )

--- a/tests/test_compaction_summary_wal_memo_1267.py
+++ b/tests/test_compaction_summary_wal_memo_1267.py
@@ -1,0 +1,135 @@
+"""Tier 2: #1267 — the phase compaction summary is WAL-memoized (shared-layer fix).
+
+The compaction summary LLM call (`compact_control_ir_results` via `recorded_acompletion`)
+was not memoized, so a compaction×resume re-summarized non-deterministically → the
+downstream act-turn memo drifted → crash-resume MISS → op re-execution (idempotency
+hole). The fix memo-wraps the summary (content args_hash, `recorded_acompletion`
+unchanged): on resume the recorded summary is reused (HIT, no re-summarize).
+
+This pins the core with a CHANGING-summary test (the only meaningful shape — a fixed
+scripted summary would mask the gap): the summariser returns a different value on each
+call, so a memo-HIT (reusing the first value) is distinguishable from a re-summarize
+(the second value).
+
+- `test_compaction_summary_memo_hit_skips_resummarize`: unit-level, path-agnostic (the
+  shared `compact_control_ir_results`). MISS → calls the summariser + records; HIT →
+  reuses the recorded summary, NO second summariser call.
+- `test_compaction_summary_no_memo_resummarizes` (falsification control): without the
+  memo seam the second call re-summarizes (the gap the fix closes).
+
+Both json-mode `_run_act_loop` and the converged `_run_routerloop_op_loop` call this
+SAME `compact_control_ir_results` with the SAME `summary_memo` (wired in PhaseExecutor),
+so the shared-function behavior pinned here is the behavior on both phase paths; the
+end-to-end converged crash-resume is exercised by the resume-memo suite.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+
+from reyn.config import CompactionConfig, PhaseActResultsCompactionConfig
+from reyn.events.events import EventLog
+from reyn.services.compaction.engine import CompactionEngine, compact_control_ir_results
+
+
+class _Resp:
+    def __init__(self, text: str) -> None:
+        self.choices = [type("C", (), {"message": type("M", (), {"content": text})(), "finish_reason": "stop"})()]
+        self.usage = None
+
+
+def _changing_summary(counter: dict):
+    """litellm.acompletion stub returning a DIFFERENT summary per call (V1, V2, ...)
+    and counting calls — so a memo-HIT (reuse V1) is distinguishable from a
+    re-summarize (V2)."""
+    async def _ac(model, messages, **kw):  # noqa: ANN001, ANN003
+        counter["n"] += 1
+        return _Resp(f"COMPACTED_SUMMARY_V{counter['n']}")
+    return _ac
+
+
+def _engine() -> CompactionEngine:
+    return CompactionEngine(
+        model="gpt-3.5-turbo", events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=True), T_SP=0,
+    )
+
+
+def _cfg() -> PhaseActResultsCompactionConfig:
+    return PhaseActResultsCompactionConfig(
+        use_chars4_estimate=True, recent_act_turns_raw=1,
+        summarize_older_threshold_tokens=1,  # any non-empty older slice exceeds it
+    )
+
+
+# A dict-backed summary memo (the duck-typed seam: lookup_summary / record_summary).
+# Mirrors LLMCallRecorder._SummaryMemo's interface; the real WAL-backed one is
+# exercised end-to-end by the converged resume-memo suite.
+class _DictSummaryMemo:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def lookup_summary(self, phase, args_hash):  # noqa: ANN001
+        return self.store.get(args_hash)
+
+    async def record_summary(self, phase, args_hash, summary):  # noqa: ANN001
+        self.store[args_hash] = summary
+
+
+_OLDER = [{"kind": "file", "op": "read", "content": "fixture content " * 30} for _ in range(3)]
+
+
+def test_compaction_summary_memo_hit_skips_resummarize(monkeypatch) -> None:
+    """Tier 2: with a summary_memo, the SECOND compaction of the same inputs HITS the
+    recorded summary — the summariser is NOT called again (no re-summarize), and the
+    summary is the FIRST value (V1), not the changed second value (V2). This is the
+    #1267 fix: a compaction×resume reuses the recorded summary deterministically."""
+    counter = {"n": 0}
+    monkeypatch.setattr(litellm, "acompletion", _changing_summary(counter))
+    memo = _DictSummaryMemo()
+    engine, cfg = _engine(), _cfg()
+
+    # Run 1 (fresh): MISS → summariser called (V1) → recorded.
+    r1 = asyncio.run(compact_control_ir_results(
+        list(_OLDER), engine=engine, cfg=cfg, events=EventLog(), phase="draft", summary_memo=memo,
+    ))
+    assert counter["n"] == 1, f"run1 must call the summariser once; got {counter['n']}"
+    assert r1 and r1[0].get("kind") == "__compacted_phase_results__"
+    v1 = r1[0]["summary"]
+    assert "V1" in v1, f"run1 summary should be V1; got {v1!r}"
+
+    # Run 2 (resume — same inputs): HIT → summariser NOT called again, reuse V1.
+    r2 = asyncio.run(compact_control_ir_results(
+        list(_OLDER), engine=engine, cfg=cfg, events=EventLog(), phase="draft", summary_memo=memo,
+    ))
+    assert counter["n"] == 1, (
+        "the compaction summary must memo-HIT on the second (resume) compaction — the "
+        f"summariser must NOT be re-called; got {counter['n']} calls (re-summarized)"
+    )
+    assert r2[0]["summary"] == v1, (
+        f"resume must reuse the recorded summary (V1), not the changed V2; got {r2[0]['summary']!r}"
+    )
+
+
+def test_compaction_summary_no_memo_resummarizes(monkeypatch) -> None:
+    """Tier 2: falsification control — WITHOUT the summary_memo seam, the second
+    compaction RE-summarizes (calls the summariser again → V2), the non-deterministic
+    drift the #1267 fix closes."""
+    counter = {"n": 0}
+    monkeypatch.setattr(litellm, "acompletion", _changing_summary(counter))
+    engine, cfg = _engine(), _cfg()
+
+    r1 = asyncio.run(compact_control_ir_results(
+        list(_OLDER), engine=engine, cfg=cfg, events=EventLog(), phase="draft", summary_memo=None,
+    ))
+    r2 = asyncio.run(compact_control_ir_results(
+        list(_OLDER), engine=engine, cfg=cfg, events=EventLog(), phase="draft", summary_memo=None,
+    ))
+    assert counter["n"] == 2, (
+        f"without the memo the summariser is re-called each time; got {counter['n']}"
+    )
+    assert "V1" in r1[0]["summary"] and "V2" in r2[0]["summary"], (
+        "without the memo the resume gets a DIFFERENT (re-summarized) value — the "
+        f"drift #1267 fixes; got r1={r1[0]['summary']!r} r2={r2[0]['summary']!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1267: WAL-memoize the phase compaction summary (shared-layer fix; dispatched as the #1092 wave-closer follow-up). Design pre-approved in [#1267](https://github.com/tya5/reyn/issues/1267) (flow-trace-first).

## Gap

The phase compaction summary LLM call (`compact_control_ir_results` → `recorded_acompletion`) was **not WAL-memoized**, so a compaction×resume re-summarized non-deterministically → the downstream act-turn memo key drifted → crash-resume MISS → op re-execution (idempotency hole). Shared by json-mode `_run_act_loop` + converged `_run_routerloop_op_loop` (+ C-4b in-loop host + on-demand `compact_now`).

## Fix (memo-WRAP; `recorded_acompletion` UNCHANGED)

`compact_control_ir_results` gets an optional `summary_memo` seam:
- content `args_hash = sha256(model, older_text)` — **resume-stable** (`older_results` are volatile-free op-result dicts that re-accumulate deterministically via op-memo).
- **HIT** (resume) → reuse the recorded summary, skip the LLM. **MISS** → `recorded_acompletion` as today + WAL-record.
- `op_invocation_id = f"{phase}.compaction"` + the content hash → unique-by-content, **no act-turn id-sequence interleave**.
- `LLMCallRecorder.make_summary_memo` / `_SummaryMemo` reuse the WAL primitives (`_lookup_memoized_step` / `_wal_step_completed_for_llm`) — no new persistence.

Wired at **all 4** phase `compact_control_ir_results` sites (json-mode per-turn + on-demand; converged C-4a post-loop + C-4b in-loop host). **chat** (`CompactionController`) + **plan** (`compact_step_results`) NOT wired → `recorded_acompletion` as-is = **phase-only scope** (per the issue review). Non-resume unaffected (`resume_plan` None → no lookup). **Chokepoint contract intact**: MISS flows through `recorded_acompletion` (cost recorded); HIT = no litellm = nothing to record.

## chat-CC note (per lead-coder's ask)

The chat `CompactionController` summarises via the same `recorded_acompletion` (engine `_acompletion`) and is likewise non-WAL-memoized — BUT chat resume is a different mechanism (session snapshot / ADR-0025 sub-loop memo, not the phase WAL), so whether it has an equivalent user-visible gap is a **separate investigation** (out of this fix's phase-only scope). Flagging for a separate issue if you judge it warranted.

## Test plan

- [x] `test_compaction_summary_wal_memo_1267` — path-agnostic unit gates on the shared `compact_control_ir_results`: changing-summary → 2nd compaction of the same inputs HITS (no re-summarize, reuses V1 not V2); **falsification control** (no memo seam → re-summarizes V2).
- [x] `test_compaction_summary_resume_1267` — converged end-to-end via real OSRuntime + WAL `_SummaryMemo`: run1 fires compaction → resume replays + re-fires → **zero new summariser calls** (all memo-HIT) despite the changing summariser. **Falsification verified**: disabling the wiring makes resume re-summarize.
- json-mode: covered by the path-agnostic unit test (json-mode `_run_act_loop` calls the **same** `compact_control_ir_results` + `summary_memo`, wired identically at site 716). Happy to add the explicit json-mode crash-resume integration if you'd prefer the literal second variant.
- [x] Compaction + convergence + chat byte-identical regression — 38 passed (non-resume unaffected). `ruff` + `tier-audit` clean.

Refs #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
