### PR TITLE
fix(eval): allow null spec_path in postprocessor output + caller schemas (#1250)

### DIFF
--- a/src/reyn/stdlib/artifacts/eval_result.yaml
+++ b/src/reyn/stdlib/artifacts/eval_result.yaml
@@ -23,9 +23,17 @@ schema:
       type: string
       description: Name of the phase with the lowest pass rate.
     spec_path:
-      type: string
-      description: Path to the eval spec that was run.
+      # Nullable + non-required to match the canonical eval skill-local
+      # eval_result / eval_result_raw / case_run_result (B49 W2-S5): the
+      # LLM emits null when the input carried no spec (= direct chat eval).
+      # This shared-stdlib copy is shadowed by the skill-local one for the
+      # eval skill, but is kept consistent so any future skill resolving
+      # `eval_result` via the stdlib fallback does not re-hit #1250.
+      type: [string, "null"]
+      description: Path to the eval spec that was run (null = direct chat eval, no spec).
     summary:
       type: string
       description: Prose summary of results highlighting key failures or successes.
-  required: [passed, overall_score, passed_criteria, total_criteria, weakest_phase, spec_path, summary]
+  # spec_path is NOT required: pass-through reference, null on direct chat
+  # eval (matches eval skill-local eval_result / eval_result_raw, B49 W2-S5).
+  required: [passed, overall_score, passed_criteria, total_criteria, weakest_phase, summary]

--- a/src/reyn/stdlib/skills/eval/artifacts/eval_result.yaml
+++ b/src/reyn/stdlib/skills/eval/artifacts/eval_result.yaml
@@ -39,8 +39,13 @@ schema:
         Name of the phase with the lowest score (passed through from
         eval_result_raw). Empty string when no phases were judged.
     spec_path:
-      type: string
-      description: Path to the eval spec being run.
+      # Nullable to mirror eval_result_raw / case_run_result (B49 W2-S5):
+      # the LLM emits null when the input carried no spec (= direct chat
+      # eval). This caller-facing schema was missed by that migration (#1250).
+      type: [string, "null"]
+      description: |
+        Path to the eval spec being run. Null when the input carried no
+        spec_path (= direct chat eval without a spec.md reference).
     summary:
       type: string
       description: |

--- a/src/reyn/stdlib/skills/eval/skill.md
+++ b/src/reyn/stdlib/skills/eval/skill.md
@@ -47,7 +47,11 @@ postprocessor:
           overall_score:   {type: number, minimum: 0.0, maximum: 1.0}
           passed:          {type: boolean}
           weakest_phase:   {type: string}
-          spec_path:       {type: string}
+          # spec_path is nullable: the LLM emits null when the input
+          # carried no spec (= direct chat eval). Mirrors the
+          # eval_result_raw / case_run_result nullable shape (B49 W2-S5);
+          # this output_schema was missed by that migration (#1250).
+          spec_path:       {type: [string, "null"]}
           summary:         {type: string}
 graph:
   run_target: [evaluate]

--- a/tests/test_eval_postprocessor.py
+++ b/tests/test_eval_postprocessor.py
@@ -19,7 +19,11 @@ contract only: the function's input dict shape and return dict shape.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 from reyn.stdlib.skills.eval.postprocessor import compute_eval_score
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _wrap(criteria, *, run_status: str = "finished", **extra) -> dict:
@@ -240,3 +244,51 @@ def test_vacuous_pass_provides_required_string_fallbacks() -> None:
     out = compute_eval_score(art)
     assert isinstance(out["weakest_phase"], str) and out["weakest_phase"]
     assert isinstance(out["summary"], str) and out["summary"]
+
+
+# ── spec_path nullable (#1250 regression) ────────────────────────────────────
+
+
+def test_null_spec_path_validates_against_step_output_schema() -> None:
+    """Tier 2: compute_eval_score output carrying spec_path=None passes the
+    python step's output_schema validation — the exact #1250 boundary.
+
+    #1250 root cause: a direct-chat eval (target with no spec.md) →
+    the LLM emits ``spec_path: null`` in eval_result_raw → compute_eval_score
+    passes it through unchanged (it is a pass-through reference field) →
+    the python step's output_schema declared ``spec_path: {type: string}``
+    so jsonschema rejected the present null with "None is not of type
+    'string'" (OutputSchemaViolation), failing the whole eval run at the
+    postprocessor even though target + judge finished.
+
+    The fix makes spec_path nullable in the schema (= complete the B49
+    W2-S5 nullable migration, which had only relaxed eval_result_raw /
+    case_run_result). It is NOT a guard-fill: ``_ensure_required_strings``
+    correctly leaves spec_path untouched because null is the meaningful
+    "no spec" signal (filling it would fabricate a path).
+
+    Falsification: revert spec_path to ``{type: string}`` in skill.md's
+    step output_schema → ``jsonschema.Draft7Validator(...).validate(out)``
+    raises here and this test fails.
+    """
+    import jsonschema
+    import yaml
+
+    skill_md = (
+        _REPO_ROOT / "src" / "reyn" / "stdlib" / "skills" / "eval" / "skill.md"
+    )
+    fm = yaml.safe_load(skill_md.read_text(encoding="utf-8").split("---", 2)[1])
+    py_step = next(
+        s for s in fm["postprocessor"]["steps"] if s["type"] == "python"
+    )
+    step_schema = py_step["output_schema"]
+
+    out = compute_eval_score(_wrap(
+        [_crit(met=True, required=True)],
+        spec_path=None,   # direct-chat eval: input carried no spec.md
+    ))
+    # The pass-through null survives — the guard does NOT fill it.
+    assert out["spec_path"] is None
+    # The runtime validates the step result with exactly this validator
+    # (preprocessor_executor.py: Draft7Validator(step.output_schema)).
+    jsonschema.Draft7Validator(step_schema).validate(out)

--- a/tests/test_eval_skill_spec_path_optional.py
+++ b/tests/test_eval_skill_spec_path_optional.py
@@ -172,6 +172,80 @@ def test_compiled_postprocessor_output_schema_is_envelope_shaped():
     )
 
 
+def _allows_null(type_decl) -> bool:
+    """A JSON-schema ``type`` declaration permits null iff it is the list
+    form containing "null" (e.g. ``["string", "null"]``)."""
+    return isinstance(type_decl, list) and "null" in type_decl
+
+
+# ---------------------------------------------------------------------------
+# spec_path TYPE must allow null (#1250 — completes the B49 W2-S5 migration)
+# ---------------------------------------------------------------------------
+#
+# B49 W2-S5 removed spec_path from `required` (tested above) but left the
+# property TYPE as a bare `string` in two of the four declarations. Removing
+# it from `required` is insufficient: a PRESENT `spec_path: null` (which the
+# LLM legitimately emits on a direct-chat eval) still fails the type
+# constraint ("None is not of type 'string'"). #1250. The eval_result_raw.yaml
+# comment records exactly this: "Required-list removal in PR #403 alone was
+# insufficient because this property-level type constraint still rejected
+# null." These tests pin the TYPE (not just `required`) across ALL spec_path
+# declarations so the migration cannot be left half-applied again.
+
+
+def test_step_output_schema_spec_path_type_allows_null():
+    """Tier 2: (#1250) the python step's output_schema must declare
+    spec_path with a nullable type — the validation that actually fired
+    in the dogfood trace (python_step_failed / compute_eval_score /
+    OutputSchemaViolation)."""
+    fm = _parse_skill_md_frontmatter(_EVAL_SKILL_DIR / "skill.md")
+    py_step = next(s for s in fm["postprocessor"]["steps"] if s["type"] == "python")
+    spec_type = py_step["output_schema"]["properties"]["spec_path"]["type"]
+    assert _allows_null(spec_type), (
+        f"step output_schema spec_path.type must allow null "
+        f'(e.g. ["string", "null"]); got {spec_type!r}. #1250: a present '
+        f"spec_path=null (direct-chat eval) is rejected otherwise."
+    )
+
+
+def test_eval_result_artifact_spec_path_type_allows_null():
+    """Tier 2: (#1250) the caller-facing eval_result artifact (skill-local,
+    = the one the compiler resolves) must declare spec_path nullable."""
+    art = _load_yaml(_EVAL_SKILL_DIR / "artifacts" / "eval_result.yaml")
+    spec_type = art["schema"]["properties"]["spec_path"]["type"]
+    assert _allows_null(spec_type), (
+        f"eval_result spec_path.type must allow null; got {spec_type!r}."
+    )
+
+
+def test_all_spec_path_schema_declarations_allow_null():
+    """Tier 2: (#1250 consumer-audit gate) EVERY spec_path schema
+    declaration across the eval skill artifacts AND the shared stdlib
+    artifact must allow null — so the nullable migration cannot be left
+    partially applied (the original B49 bug: 2 of 4 declarations missed).
+
+    Covers: eval_result_raw, case_run_result, eval skill-local eval_result,
+    and the shared stdlib/artifacts/eval_result (shadowed by the skill-local
+    copy for the eval skill, but kept consistent so a future skill resolving
+    `eval_result` via the stdlib fallback does not re-hit #1250)."""
+    _REPO = Path(__file__).resolve().parent.parent
+    decls = {
+        "eval_result_raw": _EVAL_SKILL_DIR / "artifacts" / "eval_result_raw.yaml",
+        "case_run_result": _EVAL_SKILL_DIR / "artifacts" / "case_run_result.yaml",
+        "eval_result (skill-local)": _EVAL_SKILL_DIR / "artifacts" / "eval_result.yaml",
+        "eval_result (stdlib)": _REPO / "src" / "reyn" / "stdlib" / "artifacts" / "eval_result.yaml",
+    }
+    offenders = {}
+    for label, path in decls.items():
+        spec_type = _load_yaml(path)["schema"]["properties"]["spec_path"]["type"]
+        if not _allows_null(spec_type):
+            offenders[label] = spec_type
+    assert not offenders, (
+        f"these spec_path declarations do NOT allow null (#1250 — partial "
+        f"nullable migration): {offenders}"
+    )
+
+
 def test_skill_md_final_output_keeps_other_required_fields():
     """Tier 2: regression guard for the caller-facing schema.
     Scoring fields (``passed`` / ``overall_score`` / ``passed_criteria``


### PR DESCRIPTION
**[e2e-coder]** — Fixes #1250.

## Root cause (flow-trace, primary evidence)

Dogfood events: `python_step_failed module=./postprocessor.py fn=compute_eval_score kind=OutputSchemaViolation error="None is not of type 'string'"` on a `reyn run eval` of target `direct_llm`, with target + judge both finished.

A direct-chat eval (target with no `spec.md`) makes the LLM emit `spec_path: null` in `eval_result_raw`. `compute_eval_score` passes it through unchanged (pass-through reference field). The postprocessor python step's `output_schema` declared `spec_path: {type: string}`, so `jsonschema` rejected the *present* null → `OutputSchemaViolation`, failing the whole run at the postprocessor.

**This is not a guard slip-through.** `_ensure_required_strings` correctly leaves `spec_path` alone — null is the meaningful "no spec" signal (direct chat eval); filling it would fabricate a path. The real defect is an **incomplete B49 W2-S5 (#403) nullable migration**: that fix relaxed `spec_path` to `[string, "null"]` in `eval_result_raw` + `case_run_result` but missed two further declarations. The `eval_result_raw.yaml` comment already documents why required-list removal alone is insufficient ("this property-level type constraint still rejected null").

## Fix — complete the migration (structural, not symptom)

`spec_path` → `[string, "null"]` in the two missed declarations:
- `skill.md` postprocessor step `output_schema` (← the validation in the trace).
- `artifacts/eval_result.yaml` (skill-local, caller-facing — same null reject one boundary later).

`_ensure_required_strings` unchanged.

## Consumer audit (the bug itself was an audit miss — lead-coder gate)

`grep`'d **every** `spec_path` schema declaration. All five output/intermediate declarations are now nullable-consistent:

| declaration | before | after |
|---|---|---|
| `eval_result_raw.yaml` | `[string,"null"]` (B49) | ✓ |
| `case_run_result.yaml` | `[string,"null"]` (B49) | ✓ |
| eval skill-local `eval_result.yaml` | `string` | `[string,"null"]` |
| `skill.md` step `output_schema` | `string` | `[string,"null"]` |
| `stdlib/artifacts/eval_result.yaml` | `string` + **required** | `[string,"null"]`, not required |

- The **5th** (`stdlib/artifacts/eval_result.yaml`) is a stale *pre-B49* copy, **shadowed** by the skill-local one for the eval skill (verified: the compiler resolves local-first; no other skill references `eval_result` as a schema). Kept consistent so a future skill resolving `eval_result` via the stdlib fallback cannot re-hit #1250.
- `eval_case_input.yaml` (the **input** boundary) intentionally keeps `spec_path` **required** — an eval run references a spec; only the pass-through output is nullable. (The #1250 failure is at the output; input passed in the repro.)

## Sibling finding (out of scope, for triage)

`skill_improver/phases/copy_to_work.md` declares `eval_spec_path` nullable in the intermediate `_prep` step (line ~56) but `{type: string}` + required in the phase final output (line ~162), while `copy_to_work_resolver_pure.py:55` has a `None` branch — potentially the same null-rejection class for a *different* skill/field. Not touched here (needs its own flow-trace). Flagging for a separate issue if confirmed.

## Test plan

- [x] `pytest tests/test_eval_postprocessor.py tests/test_eval_skill_spec_path_optional.py -q` — 23 passed.
- [x] Behavioral regression: `compute_eval_score(spec_path=None)` validates against the real step `output_schema` via the same `Draft7Validator` the runtime uses.
- [x] Type-nullability pins across all spec_path declarations (the prior B49 test only checked `required`, never the type — the exact gap that let this through).
- [x] **Falsification**: reverting the step schema to `{type: string}` fails both the behavioral and declarative tests (verified non-vacuous).
- [x] `ruff check .` — clean.
- [x] `scripts/test_tier_audit.py --strict <changed tests>` — 0 errors.
- [x] Full `pytest -q` from rootdir — _result pasted in a comment below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
