### PR TITLE
feat(1092): PR-A force-close foundation — services/turn_budget/ (cumulative axis)

### DIFF
--- a/src/reyn/services/turn_budget/__init__.py
+++ b/src/reyn/services/turn_budget/__init__.py
@@ -1,0 +1,29 @@
+"""turn_budget — cumulative-axis (current-turn) context bound for chat/plan/phase.
+
+The third growth axis (#1092): compaction bounds the PAST (finished turns) and
+per-term cap/offload bounds each SINGLE item; this service bounds the
+CUMULATIVE size of the CURRENT turn. When the working context approaches its
+limit, the OS force-closes the current turn (elicits a clean ``finish``, not a
+truncate) and hands off a consolidated checkpoint to a fresh continuation.
+
+This package is the sibling of ``services/compaction/`` and ``services/offload/``
+(the other two axes). PR-A (this foundation) provides only the axis-independent
+wrap-up system prompt and the headroom computation; the per-turn trigger hook,
+the force-close call, and the handoff persist/re-entry land in later PRs and are
+wired through the shared ``RouterLoop`` (chat/plan/phase all route through it).
+"""
+from reyn.services.turn_budget.engine import (
+    TurnBudget,
+    TurnBudgetEngine,
+    assert_turn_budget_bounds,
+    compute_turn_budget,
+    wrap_up_system_prompt,
+)
+
+__all__ = [
+    "TurnBudget",
+    "TurnBudgetEngine",
+    "assert_turn_budget_bounds",
+    "compute_turn_budget",
+    "wrap_up_system_prompt",
+]

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -1,0 +1,225 @@
+"""Cumulative-axis turn-budget engine (#1092 force-close + handoff, PR-A foundation).
+
+Mirrors ``services/compaction/engine.py`` field-for-field where it can:
+
+- a dedicated, axis-independent system prompt (the **wrap-up SP**) — sibling of
+  the compaction summariser SP. Its token cost (``T_wrap_SP``) is measured once
+  at engine init, the same way compaction measures ``T_comp_SP``.
+- a pure budget derivation (``compute_turn_budget``) + a fail-fast bounds check
+  (``assert_turn_budget_bounds``) — the same split as compaction's
+  ``compute_budgets`` / ``assert_static_bounds``.
+
+The headroom (§5 of #1092) is a two-layer design. This module provides **layer 1**
+(the derived 目安): the largest accumulated current-turn *content* (history,
+measured WITHOUT the system prompt — the SP is swapped for the wrap-up SP at
+force-close time) that still leaves room for (a) one more normal increment
+(bounded by the per-term ``offload_cap``), (b) the wrap-up SP, and (c) the
+wrap-up call's own generated output (``output_reserve``)::
+
+    force_close_threshold = T_max − T_wrap_SP − output_reserve − offload_cap
+
+When the accumulated content reaches that threshold, the OS force-closes rather
+than risk the next turn overflowing. **Layer 2** (the precision-independent
+guarantee: a wrap-up call that still overflows → compaction shrink → retry,
+monotonic) is NOT in this foundation PR — it lands with the force-close call
+(PR-B). The subtraction here is a disposable estimate; the retry is the body.
+
+NO wiring lives here: the per-turn trigger hook (PR-C), the force-close call
+(PR-B), and the handoff persist/re-entry (PR-D) consume this service through the
+shared ``RouterLoop`` so chat/plan/phase share one implementation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from reyn.services.compaction.engine import estimate_tokens
+
+if TYPE_CHECKING:
+    from reyn.llm.model_resolver import ModelResolver
+
+
+# Axis-independent (P7-clean) + field-agnostic (P8-clean): the prompt switches
+# the model's role to "consolidate and stop", but does NOT name any skill,
+# phase, or artifact type, and does NOT enumerate the output schema or describe
+# the Control IR format — the OS injects the finish-only candidate at call time
+# (the same seam the rest of the OS uses), and the per-axis "what was done so
+# far" context is injected separately at force-close time (§8: one SP + per-axis
+# context injection). Sibling of compaction's summariser SP.
+_WRAP_UP_SYSTEM_PROMPT = """\
+You are being asked to WRAP UP the current unit of work because its working \
+context is approaching its size limit. Do NOT continue the task and do NOT \
+request or call any further tools or operations. Your only job now is to \
+consolidate what has happened so far into a single, final hand-off so a fresh \
+continuation can pick the work up without re-reading the raw history.
+
+Cover, compactly:
+
+- What is DONE — the essential conclusions, findings, and results produced so \
+far, distilled as knowledge. Summarise large inputs you read down to what \
+matters; do not paste their contents back.
+- Where the OUTPUTS live — reference any files or stored artifacts by their \
+location rather than inlining large data.
+- What REMAINS — the next concrete step(s) still needed to finish.
+- What must NOT be repeated — actions already completed that a continuation \
+should not redo.
+
+Keep it concise and self-contained, and prefer references over large inline \
+content. This consolidation replaces the raw working history for the next step, \
+so anything omitted here is lost: capture the essence, not the volume."""
+
+
+def wrap_up_system_prompt() -> str:
+    """The axis-independent wrap-up system prompt (the single SP of §8).
+
+    Exposed as a function (not just the constant) so callers depend on a stable
+    surface and a future templated variant stays source-compatible.
+    """
+    return _WRAP_UP_SYSTEM_PROMPT
+
+
+@dataclass(frozen=True)
+class TurnBudget:
+    """Derived layer-1 headroom for one (model, config) context.
+
+    Computed once per engine init. All token counts are in the model's tokens.
+    """
+
+    max_input: int            # T_max — model input budget (excludes output)
+    T_wrap_SP: int            # wrap-up SP cost (the binding SP at wrap-up time)
+    output_reserve: int       # tokens reserved for the wrap-up call's OUTPUT
+    offload_cap: int          # max tokens one post-offload increment can add
+    force_close_threshold: int  # max accumulated turn-content tokens before close
+
+
+def compute_turn_budget(
+    model: str,
+    *,
+    T_wrap_SP: int,
+    output_reserve: int,
+    offload_cap: int,
+    resolver: "ModelResolver | None" = None,
+) -> TurnBudget:
+    """Derive the layer-1 force-close threshold (§5) — pure, no I/O beyond the
+    model catalog lookup.
+
+    Parameters
+    ----------
+    model:
+        Model class ("standard"/"light"/...) or a literal LiteLLM string.
+        Resolved to the LiteLLM string before the catalog lookup (#1172: an
+        unresolved class makes ``get_max_input_tokens`` fall back to the 128K
+        default and silently mis-budget — the same trap compaction hit).
+    T_wrap_SP:
+        Token cost of the wrap-up system prompt (measured by the engine via
+        ``estimate_tokens``). It is the SP present during the wrap-up call, so
+        it is the binding SP term in the threshold.
+    output_reserve:
+        Tokens reserved for the wrap-up call's generated consolidation.
+    offload_cap:
+        Upper bound on the tokens a single post-offload increment (one more
+        normal turn's new content) can add — this is what makes "one more turn"
+        a finite, known quantity (size axis = #1093 / ``services/offload/``).
+
+    Returns
+    -------
+    TurnBudget with ``force_close_threshold = T_max − T_wrap_SP −
+    output_reserve − offload_cap``. The threshold is NOT clamped here (callers
+    validate via :func:`assert_turn_budget_bounds`); a non-positive threshold
+    signals a misconfiguration, not a runtime state.
+    """
+    from reyn.llm.model_budget import get_max_input_tokens
+
+    if resolver is None:
+        from reyn.llm.model_resolver import ModelResolver as _MR
+
+        resolver = _MR({})
+    resolved_model = resolver.resolve(model).model
+
+    max_input = get_max_input_tokens(resolved_model)
+    threshold = max_input - T_wrap_SP - output_reserve - offload_cap
+    return TurnBudget(
+        max_input=max_input,
+        T_wrap_SP=T_wrap_SP,
+        output_reserve=output_reserve,
+        offload_cap=offload_cap,
+        force_close_threshold=threshold,
+    )
+
+
+def assert_turn_budget_bounds(tb: TurnBudget) -> None:
+    """Fail-fast invariants on a derived TurnBudget (sibling of compaction's
+    ``assert_static_bounds``): the threshold must leave real working room, so a
+    misconfigured reserve/offload_cap/model fails at construction rather than by
+    force-closing on every single turn.
+    """
+    assert tb.T_wrap_SP > 0, (
+        f"TurnBudget.T_wrap_SP must be > 0 (the wrap-up SP was not measured); "
+        f"got {tb.T_wrap_SP}"
+    )
+    assert tb.output_reserve >= 0 and tb.offload_cap >= 0, (
+        f"TurnBudget reserves must be non-negative; got output_reserve="
+        f"{tb.output_reserve}, offload_cap={tb.offload_cap}"
+    )
+    assert tb.force_close_threshold > 0, (
+        f"TurnBudget.force_close_threshold must be > 0 — "
+        f"max_input({tb.max_input}) − T_wrap_SP({tb.T_wrap_SP}) − "
+        f"output_reserve({tb.output_reserve}) − offload_cap({tb.offload_cap}) = "
+        f"{tb.force_close_threshold} ≤ 0 would force-close every turn. "
+        f"Lower the reserves or use a larger-context model."
+    )
+
+
+class TurnBudgetEngine:
+    """Holds the wrap-up SP + the derived layer-1 budget for one (model, config).
+
+    Mirrors ``CompactionEngine``'s init shape: resolve the model class once,
+    measure the dedicated-SP token cost (``T_wrap_SP``) once, derive the budget,
+    and assert its bounds fail-fast. The per-turn trigger (PR-C) calls
+    :meth:`should_force_close` with the current accumulated turn-content size.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        output_reserve: int,
+        offload_cap: int,
+        resolver: "ModelResolver | None" = None,
+        use_chars4: bool = False,
+    ) -> None:
+        if resolver is None:
+            from reyn.llm.model_resolver import ModelResolver as _MR
+
+            resolver = _MR({})
+        self._model = resolver.resolve(model).model
+        # Measure the wrap-up SP cost once, on the RESOLVED model (the #1172
+        # discipline) — the same way CompactionEngine measures T_comp_SP.
+        self._T_wrap_SP: int = estimate_tokens(
+            _WRAP_UP_SYSTEM_PROMPT, self._model, use_chars4=use_chars4
+        )
+        self._budget: TurnBudget = compute_turn_budget(
+            self._model,
+            T_wrap_SP=self._T_wrap_SP,
+            output_reserve=output_reserve,
+            offload_cap=offload_cap,
+            resolver=resolver,
+        )
+        assert_turn_budget_bounds(self._budget)
+
+    @property
+    def budget(self) -> TurnBudget:
+        """The derived layer-1 TurnBudget (read-only)."""
+        return self._budget
+
+    @property
+    def wrap_up_sp(self) -> str:
+        """The wrap-up system prompt this engine measured."""
+        return _WRAP_UP_SYSTEM_PROMPT
+
+    def should_force_close(self, content_tokens: int) -> bool:
+        """True when the accumulated current-turn *content* (history measured
+        WITHOUT the system prompt) has reached the layer-1 threshold, i.e. one
+        more normal increment plus the wrap-up call would risk overflow.
+        """
+        return content_tokens >= self._budget.force_close_threshold

--- a/tests/test_turn_budget_foundation_1092.py
+++ b/tests/test_turn_budget_foundation_1092.py
@@ -1,0 +1,178 @@
+"""Tier 2: OS invariant — turn_budget foundation (#1092 force-close + handoff, PR-A).
+
+The cumulative-axis service derives a layer-1 force-close threshold and measures
+the wrap-up system prompt cost. These pin the foundation contract BEFORE any
+wiring (the trigger hook / force-close call / handoff land in later PRs):
+
+- the threshold IS ``T_max − T_wrap_SP − output_reserve − offload_cap`` (§5);
+- ``should_force_close`` is a clean ≥-threshold boundary;
+- the threshold is monotone-decreasing in every reserve term (a bigger reserve
+  → force-close sooner — the property the retry-guarantee leans on);
+- the engine resolves a model CLASS before the catalog lookup (#1172 discipline
+  shared with CompactionEngine — an unresolved class silently mis-budgets);
+- ``assert_turn_budget_bounds`` fails fast on a degenerate config rather than
+  force-closing on every turn.
+
+No mocks: real ``ModelResolver`` instances + the real model-budget catalog +
+the real ``estimate_tokens``. Public surface only (the dataclass fields,
+``should_force_close``, the module functions).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.llm.model_resolver import ModelResolver
+from reyn.services.compaction.engine import estimate_tokens
+from reyn.services.turn_budget import (
+    TurnBudget,
+    TurnBudgetEngine,
+    assert_turn_budget_bounds,
+    compute_turn_budget,
+    wrap_up_system_prompt,
+)
+
+_MODEL = "gpt-4o-mini"  # a real catalog entry (T_max looked up, not hardcoded)
+
+
+# ── threshold formula (§5) ───────────────────────────────────────────────────
+
+
+def test_threshold_is_max_input_minus_all_reserves() -> None:
+    """Tier 2: force_close_threshold == T_max − T_wrap_SP − output_reserve −
+    offload_cap. Asserted as a RELATIONSHIP against the returned ``max_input``
+    so it holds regardless of the catalog's actual T_max for the model."""
+    b = compute_turn_budget(
+        _MODEL, T_wrap_SP=200, output_reserve=4000, offload_cap=8000
+    )
+    assert b.force_close_threshold == b.max_input - 200 - 4000 - 8000
+    assert b.T_wrap_SP == 200
+    assert b.output_reserve == 4000
+    assert b.offload_cap == 8000
+
+
+def test_should_force_close_boundary() -> None:
+    """Tier 2: should_force_close is False strictly below the threshold and True
+    at and above it (≥ boundary — at-threshold means the next increment would
+    cross, so close now)."""
+    eng = TurnBudgetEngine(_MODEL, output_reserve=4000, offload_cap=8000)
+    t = eng.budget.force_close_threshold
+    assert eng.should_force_close(t - 1) is False
+    assert eng.should_force_close(t) is True
+    assert eng.should_force_close(t + 1) is True
+
+
+def test_threshold_monotone_decreasing_in_each_reserve() -> None:
+    """Tier 2: a larger T_wrap_SP / output_reserve / offload_cap each lowers the
+    threshold (force-close sooner). Monotonicity is the property the layer-2
+    retry-guarantee relies on — shrinking accumulated content can only move you
+    back under the threshold, never past it."""
+    base = compute_turn_budget(
+        _MODEL, T_wrap_SP=100, output_reserve=1000, offload_cap=1000
+    )
+    bigger_sp = compute_turn_budget(
+        _MODEL, T_wrap_SP=500, output_reserve=1000, offload_cap=1000
+    )
+    bigger_out = compute_turn_budget(
+        _MODEL, T_wrap_SP=100, output_reserve=5000, offload_cap=1000
+    )
+    bigger_off = compute_turn_budget(
+        _MODEL, T_wrap_SP=100, output_reserve=1000, offload_cap=5000
+    )
+    assert bigger_sp.force_close_threshold < base.force_close_threshold
+    assert bigger_out.force_close_threshold < base.force_close_threshold
+    assert bigger_off.force_close_threshold < base.force_close_threshold
+
+
+# ── wrap-up SP ───────────────────────────────────────────────────────────────
+
+
+def test_engine_measures_wrap_up_sp() -> None:
+    """Tier 2: the engine measures T_wrap_SP via estimate_tokens on the wrap-up
+    SP (the same way CompactionEngine measures T_comp_SP), and exposes that SP."""
+    eng = TurnBudgetEngine(_MODEL, output_reserve=4000, offload_cap=8000)
+    assert eng.budget.T_wrap_SP > 0
+    assert eng.budget.T_wrap_SP == estimate_tokens(wrap_up_system_prompt(), _MODEL)
+    assert eng.wrap_up_sp == wrap_up_system_prompt()
+
+
+def test_wrap_up_sp_instructs_consolidate_and_stop() -> None:
+    """Tier 2: the wrap-up SP carries the role-switch CONTRACT — consolidate and
+    stop, not continue, and name the §4 facets. Pinned by semantic substring
+    only (NOT exact text / length / whitespace, which would be Tier 4)."""
+    lowered = wrap_up_system_prompt().lower()
+    assert "wrap up" in lowered
+    assert "do not continue" in lowered
+    # §4 structure: the consolidation facets are named (done / remaining / repeat).
+    for facet in ("done", "remain", "repeat"):
+        assert facet in lowered
+
+
+# ── #1172 resolver discipline ────────────────────────────────────────────────
+
+
+def test_resolver_applied_to_model_class_before_catalog_lookup() -> None:
+    """Tier 2: a model CLASS is resolved to its LiteLLM string before the catalog
+    lookup — so compute_turn_budget("myclass", resolver=...) sees the SAME T_max
+    as the resolved literal model. Without resolution the class would fall through
+    to get_max_input_tokens' 128K default and mis-budget (the #1172 trap)."""
+    resolver = ModelResolver({"myclass": _MODEL})
+    via_class = compute_turn_budget(
+        "myclass", T_wrap_SP=200, output_reserve=4000, offload_cap=8000,
+        resolver=resolver,
+    )
+    via_literal = compute_turn_budget(
+        _MODEL, T_wrap_SP=200, output_reserve=4000, offload_cap=8000,
+    )
+    assert via_class.max_input == via_literal.max_input
+    assert via_class.force_close_threshold == via_literal.force_close_threshold
+
+
+def test_engine_resolves_model_class_for_wrap_sp_and_budget() -> None:
+    """Tier 2: the engine, like CompactionEngine, resolves the class at init so
+    both the T_wrap_SP measurement and the budget use the real model."""
+    resolver = ModelResolver({"myclass": _MODEL})
+    via_class = TurnBudgetEngine(
+        "myclass", output_reserve=4000, offload_cap=8000, resolver=resolver
+    )
+    via_literal = TurnBudgetEngine(_MODEL, output_reserve=4000, offload_cap=8000)
+    assert via_class.budget.max_input == via_literal.budget.max_input
+    assert via_class.budget.T_wrap_SP == via_literal.budget.T_wrap_SP
+
+
+# ── fail-fast bounds (sibling of compaction assert_static_bounds) ─────────────
+
+
+def test_assert_bounds_rejects_nonpositive_threshold() -> None:
+    """Tier 2: a config whose reserves exceed T_max (threshold ≤ 0) is rejected
+    fail-fast — otherwise the engine would force-close on every single turn."""
+    bad = TurnBudget(
+        max_input=1000, T_wrap_SP=200, output_reserve=900, offload_cap=200,
+        force_close_threshold=1000 - 200 - 900 - 200,  # = -300
+    )
+    assert bad.force_close_threshold <= 0
+    with pytest.raises(AssertionError):
+        assert_turn_budget_bounds(bad)
+
+
+def test_assert_bounds_rejects_unmeasured_wrap_sp() -> None:
+    """Tier 2: T_wrap_SP must be > 0 (a zero means the SP was never measured)."""
+    bad = TurnBudget(
+        max_input=128000, T_wrap_SP=0, output_reserve=4000, offload_cap=8000,
+        force_close_threshold=128000 - 0 - 4000 - 8000,
+    )
+    with pytest.raises(AssertionError):
+        assert_turn_budget_bounds(bad)
+
+
+def test_engine_init_fails_fast_on_degenerate_config() -> None:
+    """Tier 2: TurnBudgetEngine asserts its bounds at construction, so an
+    impossible reserve fails at init rather than at first force-close."""
+    with pytest.raises(AssertionError):
+        TurnBudgetEngine(_MODEL, output_reserve=10**9, offload_cap=0)
+
+
+def test_well_formed_engine_passes_bounds() -> None:
+    """Tier 2: a normal config yields a positive threshold and constructs."""
+    eng = TurnBudgetEngine(_MODEL, output_reserve=4000, offload_cap=8000)
+    assert eng.budget.force_close_threshold > 0
+    assert_turn_budget_bounds(eng.budget)  # does not raise


### PR DESCRIPTION
**[e2e-coder]** — Refs #1092. **PR-A of the cumulative-axis (force-close + handoff) wave** — foundation only, no wiring. Design + staging approved by lead-coder on #1092 (durable comment).

## What this is

The third growth axis (§1 of #1092): compaction bounds the **past** (finished turns); per-term offload (#1093, `services/offload/`) bounds each **single item**; this new `services/turn_budget/` will bound the **cumulative** size of the **current turn**. PR-A lays the foundation; the trigger/call/handoff land in PR-B..F via the shared `RouterLoop`.

## Contents (sibling of `services/compaction/` + `services/offload/`)

- **Wrap-up system prompt** (the single axis-independent SP of §8). P7/P8-clean: it switches the model's role to *consolidate-and-stop*, but names no skill/phase/artifact type and does not enumerate the output schema or describe Control IR — the OS injects the finish-only candidate + per-axis context at force-close time (later PRs). Sibling of the compaction summariser SP; its cost `T_wrap_SP` is measured once at init exactly as `CompactionEngine` measures `T_comp_SP`.
- **Layer-1 headroom** (§5 目安) — `compute_turn_budget`:
  `force_close_threshold = T_max − T_wrap_SP − output_reserve − offload_cap`.
  `offload_cap` (the size axis) makes "one more turn's increment" a finite known quantity. Pure derivation + a fail-fast `assert_turn_budget_bounds` — the same split as compaction's `compute_budgets` / `assert_static_bounds`.
- **`TurnBudgetEngine`** — resolves the model class before the catalog lookup (the #1172 discipline shared with `CompactionEngine`), measures `T_wrap_SP`, derives + asserts the budget, exposes `should_force_close(content_tokens)` for the PR-C trigger.

**Layer 2** (the precision-independent retry-guarantee: a wrap-up call that still overflows → compaction shrink → retry, monotonic) is *not* here — it lands with the force-close call (PR-B). The subtraction is a disposable estimate; the retry is the body.

## Out of scope (later PRs)

No wiring: no RouterLoop hook, no force-close call, no handoff persist/re-entry. This PR cannot change any runtime behavior — it only adds an unreferenced package + its tests.

## Test plan

- [x] `pytest tests/test_turn_budget_foundation_1092.py -q` — 11 passed.
- [x] Tier 2 coverage: threshold formula (relationship vs returned `max_input`, catalog-agnostic), `should_force_close` ≥-boundary, threshold monotone-decreasing in each reserve, `T_wrap_SP` measurement, #1172 resolve discipline (class → resolved before catalog), fail-fast bounds (non-positive threshold / unmeasured SP / degenerate engine init).
- [x] **Falsification**: dropping any term from the threshold formula (e.g. `− offload_cap`) fails the formula + monotonicity tests; restore → 11 pass.
- [x] `ruff check` — clean. `scripts/test_tier_audit.py --strict` — 0 errors (dropped an exact-text/length pin that tripped Tier 4; kept semantic-substring intent only).
- [x] Full `pytest -q` from rootdir — _result in a comment below_ (PR-A only adds files; no existing-code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
