### PR TITLE
feat(1092): PR-B force-close call mechanism + phase shrink-retry (cumulative axis)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -27,6 +27,7 @@ from reyn.index.source_manifest import get_source_manifest
 from reyn.llm.llm import call_llm_tools
 from reyn.llm.pricing import TokenUsage
 from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
+from reyn.services.turn_budget import wrap_up_system_prompt
 
 if TYPE_CHECKING:
     from reyn.config import SkillSearchConfig
@@ -2673,6 +2674,58 @@ class RouterLoop:
     # Keep backward-compat alias (tests and callers that reference the old name
     # will still work; the alias delegates to the unified implementation).
     _dedupe_async_tool_calls = _dedupe_tool_calls_round
+
+    def _build_force_close_messages(self, messages: list[dict]) -> list[dict]:
+        """#1092 PR-B: rebuild ``messages`` for the wrap-up (force-close) call.
+
+        The main system turn is replaced by the axis-independent wrap-up SP
+        (``services/turn_budget``); all non-system turns (the working history)
+        are kept verbatim so the model consolidates them. Any pre-existing
+        system turn(s) are dropped (the wrap-up SP is the only system context
+        for this call). Pure — no I/O — so it is unit-testable in isolation.
+        """
+        non_system = [m for m in messages if m.get("role") != "system"]
+        return [
+            {"role": "system", "content": wrap_up_system_prompt()},
+            *non_system,
+        ]
+
+    async def _force_close_call(
+        self,
+        messages: list[dict],
+        *,
+        resolved_model: str,
+    ) -> "LLMToolCallResult":
+        """#1092 PR-B (force-close call): turn the CURRENT turn into a clean
+        ``finish`` instead of letting it overflow the cumulative budget.
+
+        Invoked by the per-turn trigger (PR-C, ``maybe_force_close``) when the
+        accumulated turn content reaches the headroom threshold. This is NOT a
+        truncate (§3): it swaps the main system prompt for the wrap-up SP and
+        ADVERTISES NO TOOLS (``tools=[]``), so the model cannot continue the
+        task and the small consolidation output makes ``finish_reason=stop`` the
+        natural outcome. ``tool_choice`` stays ``"auto"`` (``"none"`` is not
+        Gemini-safe) — moot with an empty tools list. The working history is
+        preserved; only the system turn is replaced (the wrap-up SP tells the
+        model to consolidate that history into a hand-off).
+
+        This method is the single wrap-up call; the layer-2 retry-guarantee
+        (overflow → host-delegated compaction shrink → retry, monotonic) wraps
+        it in a follow-up commit of this same PR. Additive + unwired here, so the
+        chat/phase loops stay byte-identical until PR-C wires the trigger.
+        """
+        _llm = self._llm_caller or call_llm_tools
+        wrap_messages = self._build_force_close_messages(messages)
+        return await _llm(
+            model=resolved_model,
+            messages=wrap_messages,
+            tools=[],            # continuation suppression: no tool to call
+            tool_choice="auto",  # "none" is not Gemini-safe; moot with tools=[]
+            skill_name="router",
+            budget=self.budget,
+            budget_agent=self.host.agent_name,
+            trace_caller="router_force_close",
+        )
 
     async def _execute_tool(self, tc: dict) -> dict:
         """Dispatch one tool call via dispatch_tool (cross-cutting concerns).

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -426,6 +426,28 @@ def _is_empty_router_response(response: Any) -> bool:
     return finish == "stop" and not content.strip() and not tool_calls
 
 
+# Provider context-length errors arrive as litellm exceptions with varied class
+# names/messages; the chat session classifies them by keyword on the message
+# (session.py:5381-5384). #1092 PR-B reuses the SAME keyword set for the phase
+# force-close shrink-retry. NOTE: this list is currently duplicated here +
+# twice in session.py — a future cleanup should lift one shared
+# ``is_context_overflow_error`` (e.g. next to ``ContextOverflowError`` in
+# services/compaction); kept local here to avoid a session.py refactor in PR-B.
+_CONTEXT_OVERFLOW_KEYWORDS = (
+    "context", "token", "length", "limit", "too long", "too large",
+)
+
+
+def _is_context_overflow_error(exc: BaseException) -> bool:
+    """True when *exc* looks like a provider context-length overflow.
+
+    Keyword match on the stringified exception — the same heuristic the chat
+    session uses to convert litellm errors into ``ContextOverflowError``.
+    """
+    msg = str(exc).lower()
+    return any(kw in msg for kw in _CONTEXT_OVERFLOW_KEYWORDS)
+
+
 # ---------------------------------------------------------------------------
 # Host protocol
 # ---------------------------------------------------------------------------
@@ -2726,6 +2748,55 @@ class RouterLoop:
             budget_agent=self.host.agent_name,
             trace_caller="router_force_close",
         )
+
+    async def _force_close_call_with_retry(
+        self,
+        messages: list[dict],
+        *,
+        resolved_model: str,
+    ) -> "LLMToolCallResult":
+        """#1092 PR-B layer-2 (PHASE axis): the force-close call, made robust to
+        its OWN overflow via overflow → host shrink → retry, monotonic to the
+        floor (§5 layer-2 retry-guarantee).
+
+        Axis split (B′, lead-coder confirmed): the CHAT axis does NOT use this —
+        a chat force-close overflow propagates to the session's existing outer
+        ``retry_loop`` (the proven head/middle/tail shrink), so the shrink hook
+        is phase-host-only and ``getattr``-guarded; when absent (chat host) the
+        overflow is re-raised to that outer loop. The PHASE host drives
+        ``run_loop`` directly with no such wrapper, so it shrinks in-loop here via
+        ``maybe_compact_messages`` (the SAME hook json-mode parity uses).
+
+        Monotonic termination: each shrink that changes the messages strictly
+        reduces them; when the host can shrink no further it returns the messages
+        unchanged (identity) = the FLOOR. Until PR-D wires the handoff, reaching
+        the floor RAISES (floor-abort) — PR-D replaces that terminal with the
+        consolidate+hand-off (the §2 "UnrecoveredError → 区切って継続" swap), and
+        PR-E establishes by construction that the floor always fits the wrap-up
+        call (floor_content + T_wrap_SP + output_reserve ≤ T_max), so the
+        replacement is total.
+        """
+        shrink = getattr(self.host, "maybe_compact_messages", None)
+        cur = messages
+        while True:
+            try:
+                return await self._force_close_call(
+                    cur, resolved_model=resolved_model,
+                )
+            except Exception as exc:  # noqa: BLE001
+                if not _is_context_overflow_error(exc):
+                    raise
+                if shrink is None:
+                    # Chat host: no in-loop shrink — propagate to the outer
+                    # session retry_loop (B′ axis-inherited path).
+                    raise
+                shrunk = await shrink(cur, model=resolved_model)
+                if shrunk is cur or shrunk == cur:
+                    # Floor: the host can shrink no further. Pre-PR-D this is a
+                    # genuine terminal → re-raise (floor-abort). PR-D replaces it
+                    # with the handoff.
+                    raise
+                cur = shrunk
 
     async def _execute_tool(self, tc: dict) -> dict:
         """Dispatch one tool call via dispatch_tool (cross-cutting concerns).

--- a/tests/test_force_close_call_1092.py
+++ b/tests/test_force_close_call_1092.py
@@ -119,3 +119,115 @@ async def test_force_close_drops_extra_system_turns() -> None:
     systems = [m for m in sent if m.get("role") == "system"]
     # Exactly one system turn — the wrap-up SP — and no other (sp1/sp2 dropped).
     assert systems == [{"role": "system", "content": wrap_up_system_prompt()}]
+
+
+# ── layer-2 phase shrink-retry (#1092 PR-B 2/2) ──────────────────────────────
+
+
+class _ShrinkHost(FakeRouterHost):
+    """FakeRouterHost + a phase-style maybe_compact_messages that drops the
+    oldest tool message each call, and returns the messages UNCHANGED once there
+    are no tool messages left (= the floor)."""
+
+    async def maybe_compact_messages(
+        self, messages: list[dict], *, model: str
+    ) -> list[dict]:
+        tool_idxs = [i for i, m in enumerate(messages) if m.get("role") == "tool"]
+        if not tool_idxs:
+            return messages  # floor — nothing left to shrink
+        drop = tool_idxs[0]
+        return [m for i, m in enumerate(messages) if i != drop]
+
+
+class _OverflowThenFinishLLM:
+    """Real callable: raises a context-overflow-looking error ``overflow_count``
+    times, then returns ``result``. Records each call."""
+
+    def __init__(self, overflow_count: int, result: LLMToolCallResult) -> None:
+        self._remaining = overflow_count
+        self._result = result
+        self.call_count: int = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.call_count += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            raise RuntimeError("litellm: this model's maximum context length / too large")
+        return self._result
+
+
+def _retry_loop(host: FakeRouterHost, llm) -> RouterLoop:
+    return RouterLoop(host=host, chain_id="chain-fc-retry", max_iterations=5,
+                      llm_caller=llm)
+
+
+def _msgs_with_tools(n: int) -> list[dict]:
+    base = [{"role": "system", "content": "sp"}, {"role": "user", "content": "u"}]
+    return base + [
+        {"role": "tool", "content": f"result {i}", "tool_call_id": f"t{i}"}
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_phase_shrink_retry_recovers_after_overflow() -> None:
+    """Tier 2: a phase force-close call that overflows once is recovered by one
+    host shrink + retry, returning the finish — the layer-2 guarantee in action."""
+    llm = _OverflowThenFinishLLM(overflow_count=1, result=_finish("HANDOFF"))
+    loop = _retry_loop(_ShrinkHost(), llm)
+    result = await loop._force_close_call_with_retry(
+        _msgs_with_tools(3), resolved_model="gpt-4o-mini"
+    )
+    assert result.content == "HANDOFF"
+    assert llm.call_count == 2  # initial overflow + one successful retry
+
+
+@pytest.mark.asyncio
+async def test_phase_shrink_retry_floor_aborts() -> None:
+    """Tier 2: when the call keeps overflowing, the host shrinks monotonically to
+    the floor (no tool messages → identity); at the floor the overflow re-raises
+    (floor-abort, pre-PR-D). Bounded by construction — the shrink strictly
+    reduces each step, so the loop cannot spin."""
+    llm = _OverflowThenFinishLLM(overflow_count=99, result=_finish())
+    loop = _retry_loop(_ShrinkHost(), llm)
+    with pytest.raises(RuntimeError):
+        await loop._force_close_call_with_retry(
+            _msgs_with_tools(2), resolved_model="gpt-4o-mini"
+        )
+    # 2 tool messages → 2 successful shrinks + the floor attempt = 3 LLM calls.
+    assert llm.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chat_host_without_shrink_reraises_overflow() -> None:
+    """Tier 2: (B′ axis split) a host with NO maybe_compact_messages (= chat)
+    re-raises the overflow immediately — it propagates to the session's outer
+    retry_loop, NOT an in-loop shrink. No retry here."""
+    llm = _OverflowThenFinishLLM(overflow_count=1, result=_finish())
+    loop = _retry_loop(FakeRouterHost(), llm)  # no maybe_compact_messages
+    with pytest.raises(RuntimeError):
+        await loop._force_close_call_with_retry(
+            _msgs_with_tools(2), resolved_model="gpt-4o-mini"
+        )
+    assert llm.call_count == 1  # no retry — straight to the outer loop
+
+
+@pytest.mark.asyncio
+async def test_non_overflow_error_is_not_retried() -> None:
+    """Tier 2: a non-overflow exception is re-raised immediately — the shrink
+    path is ONLY for context-overflow, never a blanket retry."""
+    class _BoomLLM:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+            self.calls += 1
+            raise ValueError("unrelated boom")
+
+    llm = _BoomLLM()
+    loop = _retry_loop(_ShrinkHost(), llm)
+    with pytest.raises(ValueError):
+        await loop._force_close_call_with_retry(
+            _msgs_with_tools(3), resolved_model="gpt-4o-mini"
+        )
+    assert llm.calls == 1  # no shrink, no retry

--- a/tests/test_force_close_call_1092.py
+++ b/tests/test_force_close_call_1092.py
@@ -1,0 +1,121 @@
+"""Tier 2: OS invariant — force-close call mechanism (#1092 PR-B).
+
+The cumulative-axis force-close call turns the CURRENT turn into a clean finish
+instead of letting it overflow: it swaps the main system prompt for the
+axis-independent wrap-up SP (``services/turn_budget``) and advertises NO tools,
+so the model consolidates rather than continues (§3). These pin:
+
+- ``messages[0]`` becomes the wrap-up SP; the working (non-system) history is
+  preserved verbatim;
+- ``tools=[]`` (continuation suppression) with ``tool_choice="auto"`` (NOT the
+  Gemini-unsafe ``"none"``);
+- the call returns the model's finish result;
+- only the wrap-up SP is the system context (extra system turns dropped).
+
+No mocks: a real ``RouterLoop`` + ``FakeRouterHost`` + a real capturing
+callable (signature drift raises, unlike AsyncMock).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.services.turn_budget import wrap_up_system_prompt
+from tests.test_router_loop import FakeRouterHost
+
+
+class _CapturingLLM:
+    """Real callable replacing call_llm_tools — records each call's kwargs and
+    returns a canned finish. Policy-compliant (real ``__call__``, not a Mock)."""
+
+    def __init__(self, result: LLMToolCallResult) -> None:
+        self._result = result
+        self.calls: list[dict] = []
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls.append(kwargs)
+        return self._result
+
+
+def _finish(text: str = "consolidated handoff") -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=text, tool_calls=[], finish_reason="stop",
+        usage=TokenUsage(prompt_tokens=50, completion_tokens=10),
+    )
+
+
+def _loop(llm: _CapturingLLM) -> RouterLoop:
+    return RouterLoop(
+        host=FakeRouterHost(), chain_id="chain-fc", max_iterations=5,
+        llm_caller=llm,
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_close_swaps_system_prompt_to_wrap_up_sp() -> None:
+    """Tier 2: the force-close call replaces the system turn with the wrap-up SP
+    and preserves the working (non-system) history verbatim."""
+    llm = _CapturingLLM(_finish())
+    loop = _loop(llm)
+    messages = [
+        {"role": "system", "content": "ORIGINAL MAIN SP"},
+        {"role": "user", "content": "do the task"},
+        {"role": "assistant", "content": "working..."},
+        {"role": "tool", "content": "big tool result", "tool_call_id": "x"},
+    ]
+    await loop._force_close_call(messages, resolved_model="gpt-4o-mini")
+
+    sent = llm.calls[-1]["messages"]
+    assert sent[0] == {"role": "system", "content": wrap_up_system_prompt()}
+    assert "ORIGINAL MAIN SP" not in [m.get("content") for m in sent]
+    assert sent[1:] == messages[1:]  # working history preserved in order
+
+
+@pytest.mark.asyncio
+async def test_force_close_suppresses_continuation_with_empty_tools() -> None:
+    """Tier 2: continuation suppression — tools=[] (model cannot call a tool →
+    must finish) and tool_choice="auto" (NOT the Gemini-unsafe "none")."""
+    llm = _CapturingLLM(_finish())
+    loop = _loop(llm)
+    await loop._force_close_call(
+        [{"role": "system", "content": "sp"}, {"role": "user", "content": "hi"}],
+        resolved_model="gpt-4o-mini",
+    )
+    sent = llm.calls[-1]
+    assert sent["tools"] == []
+    assert sent["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_force_close_returns_finish_result() -> None:
+    """Tier 2: the call returns the model's finish result (the consolidation)."""
+    llm = _CapturingLLM(_finish("HANDOFF"))
+    loop = _loop(llm)
+    result = await loop._force_close_call(
+        [{"role": "system", "content": "sp"}, {"role": "user", "content": "hi"}],
+        resolved_model="gpt-4o-mini",
+    )
+    assert result.finish_reason == "stop"
+    assert result.content == "HANDOFF"
+
+
+@pytest.mark.asyncio
+async def test_force_close_drops_extra_system_turns() -> None:
+    """Tier 2: only the wrap-up SP is the system context — any pre-existing
+    system turn(s) are dropped (robust to non-[0] system placement)."""
+    llm = _CapturingLLM(_finish())
+    loop = _loop(llm)
+    messages = [
+        {"role": "system", "content": "sp1"},
+        {"role": "user", "content": "u"},
+        {"role": "system", "content": "sp2 injected"},
+    ]
+    await loop._force_close_call(messages, resolved_model="gpt-4o-mini")
+    sent = llm.calls[-1]["messages"]
+    systems = [m for m in sent if m.get("role") == "system"]
+    # Exactly one system turn — the wrap-up SP — and no other (sp1/sp2 dropped).
+    assert systems == [{"role": "system", "content": wrap_up_system_prompt()}]


### PR DESCRIPTION
**[e2e-coder]** — Refs #1092. **PR-B of the cumulative-axis (force-close + handoff) wave** — the force-close CALL mechanism + the phase-axis layer-2 shrink-retry. Design + the A-vs-B steer settled with lead-coder on #1092 (B′, condition-1 flow-trace verified).

## What this is

When the per-turn trigger (PR-C) fires, the OS turns the current turn into a clean `finish` instead of letting it overflow. This PR is the **call mechanism** + its **phase-axis overflow robustness**. It is additive + unwired (nothing calls it until PR-C), so the chat/phase RouterLoop stays byte-identical (verified: 42 existing `router_loop` tests unchanged).

## Commit 1/2 — `_force_close_call` (the wrap-up call, §3)

Swaps `messages[0]` (the main system prompt) for the axis-independent wrap-up SP (`services/turn_budget`, PR-A) and advertises **no tools** (`tools=[]`), so the model cannot continue and the small consolidation output makes `finish_reason=stop` the natural outcome — NOT a truncate. `tool_choice` stays `"auto"` (`"none"` is not Gemini-safe; moot with empty tools). Working (non-system) history is preserved; extra system turns are dropped.

## Commit 2/2 — `_force_close_call_with_retry` (layer-2, phase axis, B′)

The force-close call made robust to its **own** overflow: overflow → host `maybe_compact_messages` shrink → retry, monotonic to the floor.

**Axis split (B′, lead-coder-confirmed via a condition-1 flow-trace):** the **chat** axis does NOT use this — a chat force-close overflow propagates to the session's existing outer `retry_loop` (the proven head/middle/tail shrink), so the shrink hook is phase-host-only + `getattr`-guarded; when absent (chat host) the overflow re-raises to that outer loop. The **phase** host drives `run_loop` directly with no such wrapper, so it shrinks in-loop via `maybe_compact_messages` (the same hook json-mode parity uses).

**Monotonic termination:** each shrink that changes the messages strictly reduces them; when the host can shrink no further it returns identity = the floor. **Until PR-D wires the handoff, the floor RE-RAISES (floor-abort)** — PR-D replaces that terminal with the consolidate+hand-off (the §2 "UnrecoveredError → bounded-continue" swap), and **PR-E** establishes by construction that the floor always fits the wrap-up call (`floor_content + T_wrap_SP + output_reserve ≤ T_max`), making the replacement total.

## Out of scope (later PRs)

No trigger (PR-C), no handoff/persist/re-entry (PR-D), no by-construction floor guarantee / genuine-abort (PR-E), no chat layer-2 terminal-hook (PR-D/F). This PR cannot change runtime behavior — it adds two unreferenced methods + tests.

## Notes for review

- `_is_context_overflow_error` mirrors the keyword heuristic the chat session uses (`session.py:5381-5384`); a future cleanup should lift one shared helper (flagged inline) — kept local here to avoid a session.py refactor in PR-B.
- (Carried from PR-A review) the `estimate_tokens` sibling-import → a neutral tokens-util lift is deferred to a later cleanup.

## Test plan

- [x] `pytest tests/test_force_close_call_1092.py -q` — 8 passed.
- [x] Tier 2 coverage: SP-swap + history preservation, `tools=[]`/`tool_choice=auto` suppression, finish return, extra-system-drop; phase shrink-retry recovery, floor-abort (bounded), chat-no-shrink re-raise (B′ split), non-overflow-not-retried.
- [x] **Falsification**: disabling the shrink-retry fails the recovery + floor tests.
- [x] **chat byte-identical**: 42 existing `router_loop` + `empty_stop_retry` tests unchanged (additive/unwired).
- [x] `ruff check` — clean. `scripts/test_tier_audit.py --strict` — 0 errors.
- [x] Full `pytest -q` from rootdir — _result in a comment below_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
