### PR TITLE
feat(tui): /image filesystem path completer + pending-image count badge in input hint

### DIFF
--- a/src/reyn/chat/slash/image.py
+++ b/src/reyn/chat/slash/image.py
@@ -79,7 +79,15 @@ def _image_path_completer(
         # Split into dir part + basename prefix.  When there is no slash
         # the user hasn't chosen a directory yet — use CWD.
         p = Path(expanded).expanduser() if expanded else Path("")
-        if "/" in expanded or expanded.startswith("~"):
+        if expanded.endswith("/"):
+            # Trailing slash → the user has chosen this directory; list its
+            # contents (no basename prefix to filter by). Without this case
+            # ``Path("<dir>/").parent`` would resolve to the PARENT of <dir>
+            # and ``.name`` to <dir>'s own name, listing the parent instead
+            # of descending into the chosen directory.
+            dir_part = p
+            prefix = ""
+        elif "/" in expanded or expanded.startswith("~"):
             # Separate the already-typed directory from the prefix being
             # completed.  ``parent`` resolves to ``"."`` for bare names.
             dir_part = p.parent

--- a/src/reyn/chat/slash/image.py
+++ b/src/reyn/chat/slash/image.py
@@ -21,8 +21,12 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reyn.chat.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.chat.session import ChatSession
 
 # Mirror op_runtime/file._IMAGE_EXTENSIONS so the slash command accepts
 # the same set #365 accepts via `file__read`.
@@ -48,11 +52,79 @@ def _file_size_human(n: int) -> str:
     return f"{n} bytes"
 
 
+# Maximum number of completions surfaced in the picker — keeps the
+# dropdown bounded so a directory with thousands of entries doesn't
+# overwhelm the display.
+_COMPLETER_MAX = 20
+
+
+def _image_path_completer(
+    session: "ChatSession", arg_partial: str = "",
+) -> list[str]:
+    """Filesystem path completer for ``/image <path>``.
+
+    Expands ``~``, splits ``arg_partial`` into a directory part + a
+    basename prefix, lists entries in that directory, and returns:
+    - Directories with a trailing ``/`` (so the user can keep navigating).
+    - Image files whose extension is in ``_IMAGE_EXTENSIONS``
+      (case-insensitive, same set the command itself accepts).
+
+    Results are sorted and capped at ``_COMPLETER_MAX``. Any filesystem
+    error returns ``[]`` — a broken completer must not break the picker.
+    ``session`` is accepted for the CompleterFn contract but unused
+    (filesystem completion is session-independent).
+    """
+    try:
+        expanded = arg_partial.expandtabs() if hasattr(arg_partial, "expandtabs") else arg_partial
+        # Split into dir part + basename prefix.  When there is no slash
+        # the user hasn't chosen a directory yet — use CWD.
+        p = Path(expanded).expanduser() if expanded else Path("")
+        if "/" in expanded or expanded.startswith("~"):
+            # Separate the already-typed directory from the prefix being
+            # completed.  ``parent`` resolves to ``"."`` for bare names.
+            dir_part = p.parent
+            prefix = p.name
+        else:
+            dir_part = Path(".")
+            prefix = expanded
+
+        # Resolve to an absolute path so relative refs work from CWD.
+        abs_dir = (Path.cwd() / dir_part).resolve()
+        if not abs_dir.is_dir():
+            return []
+
+        results: list[str] = []
+        for entry in sorted(abs_dir.iterdir()):
+            name = entry.name
+            if not name.startswith(prefix):
+                continue
+            if entry.is_dir():
+                # Append trailing slash so the user can immediately
+                # continue typing into the chosen directory.
+                candidate = str(dir_part / name) + "/"
+                # Normalise "./<name>/" → "<name>/"
+                if candidate.startswith("./"):
+                    candidate = candidate[2:]
+                results.append(candidate)
+            elif entry.is_file() and _mime_for_path(entry) is not None:
+                candidate = str(dir_part / name)
+                if candidate.startswith("./"):
+                    candidate = candidate[2:]
+                results.append(candidate)
+            if len(results) >= _COMPLETER_MAX:
+                break
+
+        return results
+    except Exception:
+        return []
+
+
 @slash(
     "image",
     summary="Send an image (png/jpg/gif/webp/svg/jpeg)",
     usage="/image <path>",
     aliases=("img",),
+    completer=_image_path_completer,
 )
 async def image_cmd(session: object, args: str) -> None:
     path_str = args.strip()

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1030,8 +1030,14 @@ class ReynTUIApp(App):
                 # would leave the input bar locked until the next
                 # stream_end (which may never come for a pure slash
                 # turn).
+                # B5: also refresh the hint so the pending-image badge
+                # updates after ``/image`` queues an image (or any other
+                # slash that mutates the queue). refresh_hint() is cheap
+                # (one property read + Label.update) and idempotent.
                 try:
-                    self.query_one("#inputbar", InputBar).set_in_flight(False)
+                    bar = self.query_one("#inputbar", InputBar)
+                    bar.set_in_flight(False)
+                    bar.refresh_hint()
                 except Exception:
                     pass
         else:

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -909,21 +909,50 @@ class InputBar(Widget):
         # blocked-state message (``_HINT_IN_FLIGHT``) so pressing Enter
         # during an active LLM turn gives the user explicit feedback
         # that they're blocked — not that the UI is broken.
+        #
+        # B5: in-flight takes precedence over the image badge — the
+        # blocked-state message already says Ctrl+C to cancel, so
+        # adding a badge during a live turn would just be noise. When
+        # NOT in-flight, append the pending-images count badge so the
+        # user can see how many images are queued while composing a
+        # long prompt. One cheap property read; no I/O.
         if getattr(self, "_in_flight", False):
             return self._HINT_IN_FLIGHT
         if width > 0 and width < self._HINT_MID_MIN_WIDTH:
-            return self._HINT_MIN
-        if width > 0 and width < self._HINT_FULL_MIN_WIDTH:
-            return self._HINT_MID
-        return self._HINT_FULL
+            base = self._HINT_MIN
+        elif width > 0 and width < self._HINT_FULL_MIN_WIDTH:
+            base = self._HINT_MID
+        else:
+            base = self._HINT_FULL
+        # Append the pending-image badge when the session has queued
+        # images. Reads via the same app._get_session() path that
+        # _run_completer uses (line 722); guard with try/except so a
+        # missing / detached session never breaks the footer.
+        pending = 0
+        try:
+            session = self.app._get_session()  # type: ignore[attr-defined]
+            if session is not None:
+                pending = len(session.pending_user_images)
+        except Exception:
+            pass
+        if pending > 0:
+            label_word = "image" if pending == 1 else "images"
+            base = f"{base} │ 📎 {pending} {label_word}"
+        return base
 
-    def _update_hint(self) -> None:
-        """Recompute and push the hint label text from the current widget width.
+    def refresh_hint(self) -> None:
+        """Rebuild and push the ``#hints`` Label text from the current state.
 
-        Called from on_resize (= terminal resize) so the footer degrades
-        gracefully instead of silently clipping keys at narrow widths.
-        Width is read from ``self.size.width`` after layout; falls back
-        to 0 (= full hint) when the size is not yet known.
+        Public entry-point for callers that need to poke the badge after
+        an external state change — specifically:
+          (a) after ``/image`` queues a new image (badge count rises), and
+          (b) after a user message is sent (queue drains to 0, badge clears).
+
+        Both are one-shot events that happen in ``app.py``'s slash
+        ``finally`` block and the ``on_input_bar_user_submitted`` handler
+        respectively, so this is called at exactly those two points — no
+        polling, no per-keystroke overhead. Width is read from the live
+        widget size (falls back to 0 = full hint when not yet mounted).
         """
         try:
             w = self.size.width
@@ -934,6 +963,16 @@ class InputBar(Widget):
             label.update(self._build_hint(w))
         except Exception:
             pass
+
+    def _update_hint(self) -> None:
+        """Recompute and push the hint label text from the current widget width.
+
+        Called from on_resize (= terminal resize) so the footer degrades
+        gracefully instead of silently clipping keys at narrow widths.
+        Width is read from ``self.size.width`` after layout; falls back
+        to 0 (= full hint) when the size is not yet known.
+        """
+        self.refresh_hint()
 
     def on_resize(self, event: events.Resize) -> None:
         """Recompute the footer hint whenever the terminal is resized.

--- a/tests/cli/test_input_bar_pending_image_badge.py
+++ b/tests/cli/test_input_bar_pending_image_badge.py
@@ -1,0 +1,230 @@
+"""Tier 2: InputBar hint footer shows a pending-image count badge (B5).
+
+When ``session.pending_user_images`` is non-empty, the ``#hints`` Label
+appends a ``📎 N image(s)`` badge to the normal hint text so the user
+can see how many images are queued while composing a long prompt.
+
+Public surfaces tested:
+  - ``refresh_hint()`` with N pending images → ``#hints`` Label text
+    contains the count badge (singular and plural forms).
+  - ``refresh_hint()`` with 0 pending images → no badge in hint.
+  - The in-flight hint (``_HINT_IN_FLIGHT``) takes precedence over the
+    image badge when in-flight — badge is suppressed.
+
+The test drives a live Textual app via ``run_test`` and asserts on the
+rendered ``#hints`` Label text (public surface), not private fields.
+``refresh_hint()`` is the public entry-point we call to drive badge
+updates (the same method the app's slash ``finally`` block calls).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _label_text(label) -> str:
+    """Read the live rendered text from a Textual Label widget."""
+    return str(label.content)
+
+
+class _FakeSession:
+    """Minimal session stub exposing only ``pending_user_images``."""
+
+    def __init__(self, pending: int = 0) -> None:
+        self._queue: list[dict] = [{"type": "image"} for _ in range(pending)]
+
+    @property
+    def pending_user_images(self) -> list[dict]:
+        return self._queue
+
+
+@pytest.mark.asyncio
+async def test_badge_shown_when_images_pending() -> None:
+    """Tier 2: ``refresh_hint()`` adds badge when pending count > 0.
+
+    A session with 2 pending images is attached to the app via the
+    ``_get_session`` hook.  After calling ``refresh_hint()`` the
+    ``#hints`` Label text must contain the count.
+    """
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    fake_session = _FakeSession(pending=2)
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    # Monkeypatch _get_session to return our stub.
+    app._get_session = lambda: fake_session  # type: ignore[method-assign]
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.refresh_hint()
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "2" in text, f"badge count missing from hint: {text!r}"
+        assert "image" in text, f"badge word 'image' missing from hint: {text!r}"
+        assert "📎" in text, f"paperclip icon missing from hint: {text!r}"
+
+
+@pytest.mark.asyncio
+async def test_badge_singular_form_for_one_image() -> None:
+    """Tier 2: exactly 1 pending image → singular ``image`` (not ``images``)."""
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    fake_session = _FakeSession(pending=1)
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    app._get_session = lambda: fake_session  # type: ignore[method-assign]
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.refresh_hint()
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "1 image" in text, (
+            f"expected '1 image' (singular) in hint; got: {text!r}"
+        )
+        assert "images" not in text, (
+            f"plural 'images' leaked for count=1; got: {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_badge_plural_form_for_multiple_images() -> None:
+    """Tier 2: 3 pending images → plural ``images``."""
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    fake_session = _FakeSession(pending=3)
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    app._get_session = lambda: fake_session  # type: ignore[method-assign]
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.refresh_hint()
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "3 images" in text, (
+            f"expected '3 images' (plural) in hint; got: {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_badge_when_queue_empty() -> None:
+    """Tier 2: empty queue → no badge in hint text."""
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    fake_session = _FakeSession(pending=0)
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    app._get_session = lambda: fake_session  # type: ignore[method-assign]
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.refresh_hint()
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "📎" not in text, f"badge appeared with empty queue: {text!r}"
+        # Normal hint should still be present.
+        assert "Enter" in text, f"normal hint missing after empty-queue refresh: {text!r}"
+
+
+@pytest.mark.asyncio
+async def test_in_flight_suppresses_badge() -> None:
+    """Tier 2: in-flight hint takes precedence — badge is suppressed while locked.
+
+    Preserves the existing B3 invariant: ``_HINT_IN_FLIGHT`` is shown
+    exclusively while in-flight, even if images are pending.
+    """
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    fake_session = _FakeSession(pending=2)
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    app._get_session = lambda: fake_session  # type: ignore[method-assign]
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        # Put the bar in-flight: the badge must be suppressed.
+        bar.set_in_flight(True)
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "responding" in text, (
+            f"in-flight hint missing when in-flight: {text!r}"
+        )
+        assert "📎" not in text, (
+            f"badge should be suppressed while in-flight; got: {text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_badge_appears_after_unlock() -> None:
+    """Tier 2: badge becomes visible again after ``set_in_flight(False)``
+    when images are still queued (i.e. the user sent a text msg that
+    doesn't drain the queue — edge case, but the badge must recover).
+    """
+    from textual.widgets import Label
+
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import InputBar
+
+    fake_session = _FakeSession(pending=1)
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    app._get_session = lambda: fake_session  # type: ignore[method-assign]
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        label = app.query_one("#hints", Label)
+
+        bar.set_in_flight(True)
+        await pilot.pause()
+        # Confirm in-flight hint is showing.
+        assert "responding" in _label_text(label)
+
+        # Unlock — the session still has 1 image pending; badge should reappear.
+        bar.set_in_flight(False)
+        await pilot.pause()
+
+        text = _label_text(label)
+        assert "📎" in text, (
+            f"badge did not reappear after unlock with images still pending: {text!r}"
+        )
+        assert "1 image" in text, (
+            f"badge count incorrect after unlock: {text!r}"
+        )

--- a/tests/cli/test_input_bar_pending_image_badge.py
+++ b/tests/cli/test_input_bar_pending_image_badge.py
@@ -34,7 +34,13 @@ def _label_text(label) -> str:
 
 
 class _FakeSession:
-    """Minimal session stub exposing only ``pending_user_images``."""
+    """Minimal session stub exposing ``pending_user_images``.
+
+    The app's mount path calls a few session methods while wiring up the
+    UI (e.g. ``register_intervention_listener``); they are stubbed as
+    no-ops so ``app.run_test()`` mounts cleanly with this stub injected
+    via ``_get_session``. The badge logic only reads ``pending_user_images``.
+    """
 
     def __init__(self, pending: int = 0) -> None:
         self._queue: list[dict] = [{"type": "image"} for _ in range(pending)]
@@ -42,6 +48,12 @@ class _FakeSession:
     @property
     def pending_user_images(self) -> list[dict]:
         return self._queue
+
+    def __getattr__(self, name: str):
+        # Any session method the app mount touches that the badge test
+        # doesn't care about (register_intervention_listener, etc.) is a
+        # harmless no-op — keeps the stub minimal without whack-a-mole.
+        return lambda *a, **k: None
 
 
 @pytest.mark.asyncio

--- a/tests/test_slash_image_completer.py
+++ b/tests/test_slash_image_completer.py
@@ -1,0 +1,137 @@
+"""Tier 2: ``_image_path_completer`` surfaces filesystem paths for the TUI picker.
+
+When the user types ``/image <path-partial>`` the picker calls
+``cmd.completer(session, arg_partial)`` via ``InputBar._run_completer``.
+This file pins the contract that the completer:
+  - returns image files (.png / .jpg / .jpeg / .gif / .webp / .svg)
+    in the requested directory
+  - appends a trailing ``/`` to directory entries so the user can keep
+    navigating
+  - excludes non-image files (e.g. .txt, .py)
+  - returns ``[]`` for a bad / non-existent path
+  - returns ``[]`` on any OS error (never breaks the picker)
+  - accepts ``session`` for the CompleterFn contract but does not use it
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.slash.image import _image_path_completer
+
+
+class _FakeSession:
+    """Minimal stub — completer doesn't use the session, but the contract
+    requires it as the first argument."""
+    pass
+
+
+# ── happy-path: image files are returned ─────────────────────────────────────
+
+
+def test_image_completer_returns_image_file(tmp_path: Path) -> None:
+    """Tier 2: a directory with an image file returns that file in completions."""
+    (tmp_path / "shot.png").write_bytes(b"")
+    results = _image_path_completer(_FakeSession(), str(tmp_path) + "/")
+    assert any("shot.png" in r for r in results), (
+        f"expected shot.png in completions; got {results}"
+    )
+
+
+def test_image_completer_excludes_non_image_files(tmp_path: Path) -> None:
+    """Tier 2: non-image files (.txt, .py) are excluded from completions."""
+    (tmp_path / "readme.txt").write_bytes(b"")
+    (tmp_path / "script.py").write_bytes(b"")
+    (tmp_path / "photo.jpg").write_bytes(b"")
+    results = _image_path_completer(_FakeSession(), str(tmp_path) + "/")
+    assert all(".txt" not in r and ".py" not in r for r in results), (
+        f"non-image files leaked into completions: {results}"
+    )
+    assert any("photo.jpg" in r for r in results), (
+        f"expected photo.jpg in completions; got {results}"
+    )
+
+
+def test_image_completer_includes_directories_with_trailing_slash(tmp_path: Path) -> None:
+    """Tier 2: subdirectories are returned with a trailing slash."""
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    results = _image_path_completer(_FakeSession(), str(tmp_path) + "/")
+    dir_entries = [r for r in results if r.endswith("/")]
+    assert any("subdir" in r for r in dir_entries), (
+        f"expected subdir/ in completions; got {results}"
+    )
+
+
+def test_image_completer_bad_path_returns_empty() -> None:
+    """Tier 2: a non-existent directory returns [] instead of raising."""
+    result = _image_path_completer(_FakeSession(), "/this/path/does/not/exist/")
+    assert result == [], f"expected [] for bad path, got {result}"
+
+
+def test_image_completer_all_image_extensions_accepted(tmp_path: Path) -> None:
+    """Tier 2: all six supported extensions are included (.png .jpg .jpeg .gif .webp .svg)."""
+    extensions = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]
+    for ext in extensions:
+        (tmp_path / f"file{ext}").write_bytes(b"")
+    results = _image_path_completer(_FakeSession(), str(tmp_path) + "/")
+    for ext in extensions:
+        assert any(ext in r for r in results), (
+            f"extension {ext} not in completions: {results}"
+        )
+
+
+def test_image_completer_case_insensitive_extensions(tmp_path: Path) -> None:
+    """Tier 2: upper-case extensions (.PNG, .JPG) are accepted."""
+    (tmp_path / "UPPER.PNG").write_bytes(b"")
+    (tmp_path / "Mixed.Jpg").write_bytes(b"")
+    results = _image_path_completer(_FakeSession(), str(tmp_path) + "/")
+    assert any("UPPER.PNG" in r for r in results), (
+        f"upper-case .PNG not matched: {results}"
+    )
+    assert any("Mixed.Jpg" in r for r in results), (
+        f"mixed-case .Jpg not matched: {results}"
+    )
+
+
+def test_image_completer_prefix_filtering(tmp_path: Path) -> None:
+    """Tier 2: only entries matching the typed prefix are returned."""
+    (tmp_path / "alpha.png").write_bytes(b"")
+    (tmp_path / "beta.png").write_bytes(b"")
+    # The completer receives the directory + the partial prefix.  The
+    # _run_completer layer does the final startswith filter, but the
+    # completer itself also applies the prefix when iterating.
+    prefix = str(tmp_path) + "/al"
+    results = _image_path_completer(_FakeSession(), prefix)
+    assert any("alpha.png" in r for r in results), (
+        f"expected alpha.png; got {results}"
+    )
+    assert not any("beta.png" in r for r in results), (
+        f"beta.png should be filtered by prefix 'al'; got {results}"
+    )
+
+
+def test_image_completer_bounded_at_max(tmp_path: Path) -> None:
+    """Tier 2: result count is capped at the module constant (default 20)."""
+    from reyn.chat.slash.image import _COMPLETER_MAX
+    for i in range(_COMPLETER_MAX + 10):
+        (tmp_path / f"img{i:03d}.png").write_bytes(b"")
+    results = _image_path_completer(_FakeSession(), str(tmp_path) + "/")
+    assert len(results) <= _COMPLETER_MAX, (
+        f"completer returned more than {_COMPLETER_MAX} results: {len(results)}"
+    )
+
+
+def test_image_completer_session_unused(tmp_path: Path) -> None:
+    """Tier 2: the session argument is accepted but never read — passing None
+    must not crash (completer is session-independent)."""
+    (tmp_path / "img.png").write_bytes(b"")
+    # Pass None explicitly to verify the contract holds.
+    result = _image_path_completer(None, str(tmp_path) + "/")  # type: ignore[arg-type]
+    assert any("img.png" in r for r in result)


### PR DESCRIPTION
**[tui-coder]** — `/image` の filesystem path completer + pending-image count badge（TUI UX 探索 wave / Tier-2 残、user 指示で着手）

残り唯一の Tier-2。Sonnet 実装 → **Opus 独立 verify**（後述の通り 12 件の test 失敗を catch して修正）。

## Fix B2 — `/image <path>` の filesystem path completer
入力時に補完が出ず path を手打ち/貼付するしかなかった。既存 `_run_completer`（input_bar.py、session 取得 + completer 呼び + last-token filter）に plug。
`slash/image.py` に `_image_path_completer(session, arg_partial="")` 追加 + `@slash("image")` に `completer=` 付与。dir は trailing `/` 付きで列挙（ナビ用）、image 拡張子（`_mime_for_path` で gate）のみ、~ 展開、≤20 cap、全 I/O try/except→[]。

## Fix B5 — pending-image count badge
`/image` は `session._pending_user_images` に queue し次 user message で drain するが、成功 reply が流れると queued か分からなかった。入力欄 hint footer に `📎 N image(s)`（単複）を `session.pending_user_images` 非空時に表示。
**refresh-trigger**: 既存 `set_in_flight` 遷移を再利用 + slash の `finally` で `refresh_hint()` 呼び（app.py）。in-flight hint が badge より strict 優先（応答中は badge 抑制、unlock 時に count 再読で復活）。per-keystroke poll なし。

## ⚠ Opus 独立 verify が subagent の false report を catch
subagent は「320 passed / ruff clean / tier 0」と報告したが、**独立 pytest 実行で 12 件 fail**（pushed code が claim と不一致）。2 root cause を Opus 側で修正:
1. **B2 production bug**: trailing-slash `'<dir>/'` を `Path.parent/.name` で split → 親dir を列挙し dir 自身を返す（中身を列挙せず）。trailing-slash branch（dir_part=p, prefix=""）を追加 → 6 completer fail 解消（9 pass）。
2. **B5 test-harness bug**（production code は正）: badge test が bare stub を mount 前に `_get_session` 注入 → app mount が stub の `register_intervention_listener` 等を呼び AttributeError（badge 到達前に死亡）。stub に `__getattr__` no-op を追加 → mount 通過、6 badge test が badge code を実 exercise して pass。

## Verification（Opus 独立、修正後）
- ruff clean / tier-audit 0 errors
- pytest `-k "image or completer or input_bar or hint or picker or tui_smoke"` = **335 passed**（修正前 12 fail → 0、2 error は無関係 router_loop collection artifact）
- completer fix は test で確認（trailing-slash で dir 内 image file 列挙）

## Tests（faithful、public surface）
- `tests/test_slash_image_completer.py`（9）: image 列挙 / 非image 除外 / dir trailing-slash / 全拡張子 / case-insensitive / prefix filter / bound / bad path→[] / session unused
- `tests/cli/test_input_bar_pending_image_badge.py`（6、Textual harness）: badge 表示(N=2) / 単数 / 複数 / 空queue無badge / in-flight 抑制 / unlock 後復活 — assert は `#hints` Label content（public surface）

## Tier self-check
新 test は Tier 2（completer は public module fn、badge は public `#hints` Label content で assert、private-state 不参照、format-pin なし、docstring 1 行目 Tier 宣言）。

## Test plan
- [x] ruff / tier-audit / 335 passed（独立、12 fail 修正済）
- [x] subagent report と pushed code の不一致を catch・修正
- [ ] (manual, skipped — reviewer 環境) `/image ~/` で image file 補完が出ること、`/image <path>` queue 後に入力欄に `📎 1 image` が出て送信後に消えることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
