### PR TITLE
feat(1092): PR-C force-close trigger seam — loop-free per-turn maybe_force_close

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1933,6 +1933,22 @@ class RouterLoop:
             _compact_fn = getattr(self.host, "maybe_compact_messages", None)
             if _compact_fn is not None:
                 messages = await _compact_fn(messages, model=resolved_model)
+            # #1092 PR-C: layer-1 force-close trigger — checked AFTER compaction
+            # (so it sees the shrunk content). A host implements
+            # ``should_force_close`` to decide, from the current accumulated turn
+            # content, whether the CUMULATIVE budget is reached; if so this turn is
+            # force-closed (a clean wrap-up finish) instead of risking overflow.
+            # getattr-guarded → chat/plan hosts that don't implement it → no
+            # force-close (byte-identical). LOOP-FREE by construction: the
+            # force-close result is a finish (no tool_calls) → the loop's terminal
+            # path ends the turn; it is NOT a revert-to-normal that could churn,
+            # and the layer-1 threshold sits ``offload_cap`` below the overflow
+            # point so it fires gracefully BEFORE the layer-2 floor.
+            _force_close_fn = getattr(self.host, "should_force_close", None)
+            _force_close_now = bool(
+                _force_close_fn is not None
+                and await _force_close_fn(messages, model=resolved_model)
+            )
             # ADR-0025: memo lookup — a recorded LLMToolCallResult for
             # this exact (model, messages, tools, tool_choice) tuple
             # short-circuits the call. Used by plan-mode resume so a
@@ -1976,24 +1992,42 @@ class RouterLoop:
                     )
                     result = memo
             if result is None:
-                # Tier 2 testability: tests inject a real-fake callable via
-                # ``_llm_caller`` (= no unittest.mock.patch needed). None
-                # falls through to the module-level ``call_llm_tools`` so
-                # production callers don't have to know about the seam.
-                _llm = self._llm_caller or call_llm_tools
-                result = await _llm(
-                    model=resolved_model,
-                    messages=messages,
-                    tools=tools,
-                    tool_choice="auto",
-                    skill_name="router",
-                    budget=self.budget,
-                    budget_agent=host.agent_name,
-                    trace_caller="router",
-                )
+                if _force_close_now:
+                    # #1092 PR-C: replace the normal act-turn call with the wrap-up
+                    # (force-close) call — swaps the SP for the wrap-up SP +
+                    # suppresses tools, so the result is a finish the loop's
+                    # terminal path consumes (no continuation). The phase-axis
+                    # layer-2 shrink-retry (PR-B) wraps it; chat re-raises to its
+                    # outer retry_loop (B′). P6 audit event before the call.
+                    host.events.emit(
+                        "force_close_triggered",
+                        chain_id=self.chain_id,
+                        iteration=_iteration,
+                    )
+                    result = await self._force_close_call_with_retry(
+                        messages, resolved_model=resolved_model,
+                    )
+                else:
+                    # Tier 2 testability: tests inject a real-fake callable via
+                    # ``_llm_caller`` (= no unittest.mock.patch needed). None
+                    # falls through to the module-level ``call_llm_tools`` so
+                    # production callers don't have to know about the seam.
+                    _llm = self._llm_caller or call_llm_tools
+                    result = await _llm(
+                        model=resolved_model,
+                        messages=messages,
+                        tools=tools,
+                        tool_choice="auto",
+                        skill_name="router",
+                        budget=self.budget,
+                        budget_agent=host.agent_name,
+                        trace_caller="router",
+                    )
                 # Record the fresh result for future resume hit. Defensive:
-                # never let recording failure break the loop.
-                if self._memo_provider is not None and args_hash is not None:
+                # never let recording failure break the loop. NOT for a
+                # force-close result — it is a terminal wrap-up, not a normal
+                # act-turn to replay as-is on resume.
+                if not _force_close_now and self._memo_provider is not None and args_hash is not None:
                     try:
                         await self._memo_provider.record(
                             args_hash=args_hash, result=result,

--- a/tests/test_force_close_trigger_1092.py
+++ b/tests/test_force_close_trigger_1092.py
@@ -1,0 +1,118 @@
+"""Tier 2: OS invariant — force-close trigger seam (#1092 PR-C).
+
+The per-turn layer-1 trigger wires ``should_force_close`` into ``run_loop`` right
+after the compaction hook. When a host signals force-close, the normal act-turn
+LLM call is SWAPPED for the wrap-up (force-close) call, whose finish the loop's
+terminal path consumes. These pin:
+
+- trigger fires → the force-close call is used (``trace_caller="router_force_close"``,
+  ``tools=[]``), not the normal act-turn call;
+- LOOP-FREE: the force-close result is a finish (no tool_calls) → the turn ENDS;
+  the trigger is consulted once and the loop does not churn / re-trigger;
+- no signal → the normal call is used;
+- a host WITHOUT ``should_force_close`` (= chat) → byte-identical normal call
+  (the seam is inert);
+- a ``force_close_triggered`` event is emitted (P6 audit).
+
+No mocks: a real ``RouterLoop`` + ``FakeRouterHost`` subclass + a real capturing
+LLM callable.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import FakeRouterHost
+
+
+class _ForceCloseHost(FakeRouterHost):
+    """FakeRouterHost + a ``should_force_close`` hook returning a fixed decision,
+    counting how often it is consulted (to prove loop-free = consulted once)."""
+
+    def __init__(self, *, force_close: bool, **kw: Any) -> None:
+        super().__init__(**kw)
+        self._force_close = force_close
+        self.should_force_close_calls = 0
+
+    async def should_force_close(self, messages: list[dict], *, model: str) -> bool:
+        self.should_force_close_calls += 1
+        return self._force_close
+
+
+class _CapturingFinishLLM:
+    """Real callable: records each call's kwargs + returns a finish (no tools)."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.last_kwargs: dict = {}
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.call_count += 1
+        self.last_kwargs = kwargs
+        return LLMToolCallResult(
+            content="consolidated handoff", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=40, completion_tokens=8),
+        )
+
+
+def _loop(host: FakeRouterHost, llm: _CapturingFinishLLM) -> RouterLoop:
+    return RouterLoop(host=host, chain_id="chain-trig", max_iterations=5,
+                      llm_caller=llm)
+
+
+@pytest.mark.asyncio
+async def test_trigger_fires_force_close_call() -> None:
+    """Tier 2: when the host signals force-close, the act-turn call is the wrap-up
+    call (trace_caller=router_force_close, tools=[]), not the normal act turn."""
+    host = _ForceCloseHost(force_close=True)
+    llm = _CapturingFinishLLM()
+    await _loop(host, llm).run("do the task", [])
+    assert llm.last_kwargs["trace_caller"] == "router_force_close"
+    assert llm.last_kwargs["tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_force_close_is_terminal_loop_free() -> None:
+    """Tier 2: (★loop-free) the force-close finish (no tool_calls) ENDS the turn —
+    the trigger is consulted once and the loop neither re-triggers nor reverts to
+    a normal call (no threshold→shrink→regrow churn within the loop)."""
+    host = _ForceCloseHost(force_close=True)
+    llm = _CapturingFinishLLM()
+    await _loop(host, llm).run("do the task", [])
+    assert llm.last_kwargs["trace_caller"] == "router_force_close"  # the FC path
+    assert host.should_force_close_calls == 1   # consulted once, then terminal
+    assert llm.call_count == 1                   # one force-close call, no churn
+
+
+@pytest.mark.asyncio
+async def test_no_trigger_uses_normal_call() -> None:
+    """Tier 2: when the host does NOT signal force-close, the normal act-turn call
+    is used (trace_caller=router), not the wrap-up call."""
+    host = _ForceCloseHost(force_close=False)
+    llm = _CapturingFinishLLM()
+    await _loop(host, llm).run("do the task", [])
+    assert llm.last_kwargs["trace_caller"] == "router"
+
+
+@pytest.mark.asyncio
+async def test_chat_host_without_hook_uses_normal_path() -> None:
+    """Tier 2: a host WITHOUT should_force_close (= chat) takes the normal path
+    unchanged — the seam is inert (getattr-guarded)."""
+    host = FakeRouterHost()  # no should_force_close
+    llm = _CapturingFinishLLM()
+    await _loop(host, llm).run("do the task", [])
+    assert llm.last_kwargs["trace_caller"] == "router"
+
+
+@pytest.mark.asyncio
+async def test_force_close_emits_audit_event() -> None:
+    """Tier 2: (P6) a force_close_triggered event is emitted when the trigger fires."""
+    host = _ForceCloseHost(force_close=True)
+    llm = _CapturingFinishLLM()
+    await _loop(host, llm).run("do the task", [])
+    emitted = [e["type"] for e in host._events.emitted]
+    assert "force_close_triggered" in emitted


### PR DESCRIPTION
**[e2e-coder]** — Refs #1092. **PR-C of the cumulative-axis (force-close + handoff) wave** — the loop-free per-turn force-close TRIGGER seam. Approach + the loop-free condition confirmed with lead-coder on #1092.

## What this is

The layer-1 trigger (§5): a per-turn `should_force_close` check wired into `RouterLoop.run_loop` right **after** the compaction hook (so it sees the shrunk content). When a host signals force-close, the normal act-turn LLM call is **swapped** for the wrap-up (force-close) call (PR-B), whose finish the loop's terminal path consumes.

## Loop-free by construction (the coherence condition)

- The force-close result is a **finish (no tool_calls)** → the loop's *existing* terminal path ends the turn. It is **not** a revert-to-normal that could churn.
- The layer-1 threshold sits `offload_cap` below the overflow point (PR-A), so the trigger fires **gracefully before** the layer-2 floor.
- Test-proven: the trigger is consulted **once** then terminal (no in-loop re-trigger / churn).

## Details

- `getattr`-guarded → hosts that don't implement `should_force_close` (chat/plan, and phase until activated) take the normal path unchanged = **byte-identical** (44 existing `router_loop` + `force_close_call` tests pass).
- The force-close result is **not memo-recorded** (it is a terminal wrap-up, not a normal act-turn to replay on resume).
- A `force_close_triggered` event is emitted (**P6** audit).

## Scope / next (agreed with lead-coder)

PR-C is the **seam only** (no host implements `should_force_close` yet → inert in production, like PR-A/PR-B layers). **Next (C2, just before PR-D):** the phase-host activation + a **shared reserve helper** (`offload_cap` = `MAX_OFFLOADED_INLINE_BYTES`; `output_reserve` = a default) — built shared-shaped so PR-F extends to chat/plan with zero rework. Phase force-close goes **live before PR-D**, so D (handoff replaces the floor terminal) and E (floor-fits by-construction) are built + verified on a *live* phase force-close, not blind.

## Test plan

- [x] `pytest tests/test_force_close_trigger_1092.py -q` — 5 passed.
- [x] Tier 2: trigger fires the wrap-up call (`trace_caller=router_force_close`, `tools=[]`); **loop-free terminal** (consulted once, no churn); no-trigger uses the normal call; host without the hook unchanged; P6 event emitted.
- [x] **Falsification**: disabling the trigger fails the trigger test.
- [x] **byte-identical**: 44 existing `router_loop` + `force_close_call` tests unchanged.
- [x] `ruff check` clean; `test_tier_audit --strict` 0 errors.
- [x] Full `pytest -q` from rootdir — _result in a comment below_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
