### PR TITLE
feat(1092): C2 phase force-close activation + shared reserve helper

### DIFF
--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -476,6 +476,7 @@ class PhaseExecutor:
 
         from reyn.chat.router_loop import RouterLoop
         from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+        from reyn.services.turn_budget import build_default_turn_budget_engine
 
         phase_def = self._skill.phases.get(phase)
         allowed_ops = set(phase_def.allowed_ops) if phase_def is not None else set()
@@ -504,6 +505,20 @@ class PhaseExecutor:
             # host's ``check_phase_budget`` hook → this bound _check_phase_budget).
             check_phase_budget_fn=lambda: self._check_phase_budget(phase, state),
             summary_memo=self._summary_memo,
+            # #1092 C2: activate the cumulative-axis force-close trigger for the
+            # phase. The TurnBudgetEngine is built from the SAME resolved phase
+            # model the compaction engine budgets against (not the cosmetic
+            # run-loop router_model), via the SHARED reserve helper so chat/plan
+            # reuse it rework-free in PR-F. use_chars4=True keeps every term but
+            # T_max model-independent. None when the phase has no compaction
+            # wired (no T_max basis) → the trigger stays inert.
+            turn_budget_engine=(
+                build_default_turn_budget_engine(
+                    self._phase_compaction_engine.model, use_chars4=True
+                )
+                if self._phase_compaction_engine is not None
+                else None
+            ),
         )
         tools = host.get_phase_op_catalog()
         # P6 audit + the distinguishing marker for the converged op-loop (vs the

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -65,6 +65,7 @@ class PhaseRouterLoopHost:
         compaction_cfg: Any = None,
         check_phase_budget_fn: Callable[[], Any] | None = None,
         summary_memo: Any = None,
+        turn_budget_engine: Any = None,
     ) -> None:
         self._control_ir_executor = control_ir_executor
         self._events = events
@@ -87,6 +88,9 @@ class PhaseRouterLoopHost:
         self._check_phase_budget_fn = check_phase_budget_fn
         # #1267: WAL-memo seam for the in-loop (C-4b) compaction summary call.
         self._summary_memo = summary_memo
+        # #1092 C2: cumulative-axis force-close engine (TurnBudgetEngine). None
+        # → the ``should_force_close`` trigger is inert (no phase force-close).
+        self._turn_budget_engine = turn_budget_engine
 
     # ── RouterLoopCore identity / static config ───────────────────────────
 
@@ -319,6 +323,38 @@ class PhaseRouterLoopHost:
         if self._check_phase_budget_fn is None:
             return
         await self._check_phase_budget_fn()
+
+    async def should_force_close(self, messages: list[dict], *, model: str) -> bool:
+        """#1092 C2: the layer-1 force-close trigger for the phase axis.
+
+        ``RouterLoop.run_loop`` consults this each turn AFTER compaction (so it
+        sees the shrunk content). Chat/plan hosts don't implement it (getattr →
+        no-op → byte-identical). Returns True when the accumulated current-turn
+        *content* (every non-system turn — the wrap-up SP swaps the system turn
+        at force-close time, so it is excluded from the content measure) has
+        reached the TurnBudgetEngine's layer-1 threshold. When the engine is
+        absent (not activated) → always False.
+
+        On True, RouterLoop swaps the act-turn call for the wrap-up (force-close)
+        call — a terminal finish (PR-C), which the phase-axis shrink-retry (PR-B)
+        wraps and PR-D's handoff will re-enter from.
+        """
+        engine = self._turn_budget_engine
+        if engine is None:
+            return False
+        from reyn.services.compaction.engine import estimate_tokens_for_turn
+
+        # use_chars4 makes the estimate model-independent (len/4 + fixed image
+        # cost), so the cosmetic run-loop ``model`` (= phase name, not the real
+        # model) is harmless here AND it matches how the engine measured its
+        # own threshold terms (the engine is built use_chars4=True against the
+        # real resolved model, which only governs T_max).
+        content_tokens = sum(
+            estimate_tokens_for_turn(m, model, use_chars4=True)
+            for m in messages
+            if isinstance(m, dict) and m.get("role") != "system"
+        )
+        return engine.should_force_close(content_tokens)
 
     # ── Chat-discovery methods (phase = empty) ────────────────────────────
     # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -783,6 +783,14 @@ class CompactionEngine:
         """Read-only access to the computed budget values."""
         return self._budgets
 
+    @property
+    def model(self) -> str:
+        """The RESOLVED LiteLLM model string (#1172) this engine budgets against.
+        A public accessor so siblings (e.g. #1092 turn_budget) can derive their
+        own budgets from the SAME resolved phase model rather than the cosmetic
+        run-loop router_model."""
+        return self._model
+
     async def _acompletion(self, messages: list[dict], *, response_format: dict | None = None):
         """Single LLM call via the cost-observability chokepoint (#1190).
 

--- a/src/reyn/services/turn_budget/__init__.py
+++ b/src/reyn/services/turn_budget/__init__.py
@@ -13,17 +13,21 @@ the force-close call, and the handoff persist/re-entry land in later PRs and are
 wired through the shared ``RouterLoop`` (chat/plan/phase all route through it).
 """
 from reyn.services.turn_budget.engine import (
+    DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,
     TurnBudget,
     TurnBudgetEngine,
     assert_turn_budget_bounds,
+    build_default_turn_budget_engine,
     compute_turn_budget,
     wrap_up_system_prompt,
 )
 
 __all__ = [
+    "DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS",
     "TurnBudget",
     "TurnBudgetEngine",
     "assert_turn_budget_bounds",
+    "build_default_turn_budget_engine",
     "compute_turn_budget",
     "wrap_up_system_prompt",
 ]

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -223,3 +223,47 @@ class TurnBudgetEngine:
         more normal increment plus the wrap-up call would risk overflow.
         """
         return content_tokens >= self._budget.force_close_threshold
+
+
+# Cross-axis default reserves for the layer-1 force-close threshold (#1092 C2).
+# Shared by ALL axes (phase now; chat/plan in PR-F) so the threshold shape never
+# diverges per-axis. ``output_reserve`` = tokens kept for the wrap-up call's
+# generated consolidation; a wrap-up hand-off is short (essence, not volume —
+# see the wrap-up SP), so a small fixed reserve suffices. A config field can
+# override this later if a model needs it.
+DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS = 2048
+
+
+def build_default_turn_budget_engine(
+    model: str,
+    *,
+    resolver: "ModelResolver | None" = None,
+    use_chars4: bool = False,
+) -> TurnBudgetEngine:
+    """Construct a TurnBudgetEngine with the shared cross-axis default reserves.
+
+    The two reserves are:
+    - ``offload_cap`` — the post-offload per-result inline ceiling (#1093,
+      ``context_builder.MAX_OFFLOADED_INLINE_BYTES``) converted to tokens: the
+      largest a single tool_result can re-add as the "one more turn" increment
+      once offload has capped it.
+    - ``output_reserve`` — :data:`DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS`.
+
+    Building every axis through THIS helper keeps the threshold shape identical
+    across chat/plan/phase (no per-axis drift); PR-F reuses it verbatim. The
+    import of the offload ceiling is local to avoid a module-load cycle.
+    """
+    from reyn.context_builder import MAX_OFFLOADED_INLINE_BYTES
+
+    # The offload ceiling is a BYTE bound; convert to the model's tokens so it is
+    # comparable with the (token-denominated) threshold. Measured once at build.
+    offload_cap = estimate_tokens(
+        "x" * MAX_OFFLOADED_INLINE_BYTES, model, use_chars4=use_chars4
+    )
+    return TurnBudgetEngine(
+        model,
+        output_reserve=DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,
+        offload_cap=offload_cap,
+        resolver=resolver,
+        use_chars4=use_chars4,
+    )

--- a/tests/test_force_close_phase_activation_1092.py
+++ b/tests/test_force_close_phase_activation_1092.py
@@ -16,18 +16,23 @@ No mocks: real engines + a real ModelResolver + a real PhaseRouterLoopHost.
 """
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+from reyn.chat.router_loop import RouterLoop
 from reyn.context_builder import MAX_OFFLOADED_INLINE_BYTES
 from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.model_resolver import ModelResolver
-from reyn.services.compaction.engine import estimate_tokens
+from reyn.llm.pricing import TokenUsage
+from reyn.services.compaction.engine import estimate_tokens, estimate_tokens_for_turn
 from reyn.services.turn_budget import (
     DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,
     TurnBudgetEngine,
     build_default_turn_budget_engine,
 )
-from tests.test_router_loop import FakeEventLog
+from tests.test_router_loop import FakeEventLog, FakeRouterHost
 
 _MODEL = "gpt-4o-mini"
 
@@ -126,3 +131,53 @@ async def test_phase_host_excludes_system_turn_from_content() -> None:
         {"role": "user", "content": "x" * (10 * 4)},        # ~10 tok < 50
     ]
     assert await host.should_force_close(msgs, model="p") is False
+
+
+# ── live path: over-threshold content actually fires force-close (D/E base) ───
+
+
+class _ThresholdHost(FakeRouterHost):
+    """FakeRouterHost whose should_force_close is backed by a REAL small-threshold
+    TurnBudgetEngine (the same non-system content measure PhaseRouterLoopHost
+    uses) — to exercise the trigger→force-close path end-to-end through run_loop."""
+
+    def __init__(self, engine: TurnBudgetEngine, **kw: Any) -> None:
+        super().__init__(**kw)
+        self._engine = engine
+
+    async def should_force_close(self, messages: list[dict], *, model: str) -> bool:
+        content = sum(
+            estimate_tokens_for_turn(m, model, use_chars4=True)
+            for m in messages
+            if isinstance(m, dict) and m.get("role") != "system"
+        )
+        return self._engine.should_force_close(content)
+
+
+class _CapturingLLM:
+    def __init__(self) -> None:
+        self.last_kwargs: dict = {}
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.last_kwargs = kwargs
+        return LLMToolCallResult(
+            content="consolidated", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=2),
+        )
+
+
+@pytest.mark.asyncio
+async def test_over_threshold_content_actually_fires_force_close_via_run_loop() -> None:
+    """Tier 2: (★live path — the D/E foundation) injecting over-threshold content
+    drives the REAL threshold-backed trigger so run_loop SWAPS to the force-close
+    call (tools=[], trace_caller=router_force_close). Confirms force-close actually
+    FIRES end-to-end, not just should_force_close=True in isolation."""
+    eng = _small_threshold_engine(threshold_tokens=20)
+    llm = _CapturingLLM()
+    loop = RouterLoop(
+        host=_ThresholdHost(eng), chain_id="c2-live", max_iterations=3,
+        llm_caller=llm,
+    )
+    await loop.run("x" * (40 * 4), [])  # ~40-tok user turn ≥ 20-tok threshold
+    assert llm.last_kwargs["trace_caller"] == "router_force_close"
+    assert llm.last_kwargs["tools"] == []

--- a/tests/test_force_close_phase_activation_1092.py
+++ b/tests/test_force_close_phase_activation_1092.py
@@ -1,0 +1,128 @@
+"""Tier 2: OS invariant — phase force-close activation + shared reserves (#1092 C2).
+
+C2 makes the layer-1 force-close trigger LIVE on the phase axis (so PR-D/E can be
+built + verified on a real phase force-close, not blind). It pins:
+
+- the SHARED reserve helper builds a TurnBudgetEngine with offload_cap = the
+  per-result offload ceiling (#1093 MAX_OFFLOADED_INLINE_BYTES, in tokens) and
+  output_reserve = the shared default — built once so chat/plan reuse it in PR-F;
+- CompactionEngine exposes its RESOLVED model (#1172) so the phase TurnBudgetEngine
+  budgets against the same model, not the cosmetic run-loop router_model;
+- PhaseRouterLoopHost.should_force_close fires when the accumulated non-system
+  content reaches the threshold, is inert without an engine, and excludes the
+  system turn from the content measure.
+
+No mocks: real engines + a real ModelResolver + a real PhaseRouterLoopHost.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.context_builder import MAX_OFFLOADED_INLINE_BYTES
+from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+from reyn.llm.model_resolver import ModelResolver
+from reyn.services.compaction.engine import estimate_tokens
+from reyn.services.turn_budget import (
+    DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,
+    TurnBudgetEngine,
+    build_default_turn_budget_engine,
+)
+from tests.test_router_loop import FakeEventLog
+
+_MODEL = "gpt-4o-mini"
+
+
+# ── shared reserve helper ────────────────────────────────────────────────────
+
+
+def test_shared_helper_uses_offload_ceiling_and_default_output_reserve() -> None:
+    """Tier 2: build_default_turn_budget_engine sources offload_cap from the
+    #1093 inline ceiling (in tokens) and output_reserve from the shared default."""
+    eng = build_default_turn_budget_engine(_MODEL, use_chars4=True)
+    expected_offload = estimate_tokens(
+        "x" * MAX_OFFLOADED_INLINE_BYTES, _MODEL, use_chars4=True
+    )
+    assert eng.budget.offload_cap == expected_offload
+    assert eng.budget.output_reserve == DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS
+    # threshold still obeys the §5 formula.
+    b = eng.budget
+    assert b.force_close_threshold == (
+        b.max_input - b.T_wrap_SP - b.output_reserve - b.offload_cap
+    )
+
+
+# ── CompactionEngine resolved-model accessor (#1172) ─────────────────────────
+
+
+def test_compaction_engine_exposes_resolved_model() -> None:
+    """Tier 2: CompactionEngine.model returns the RESOLVED LiteLLM string (not the
+    class) — the source the phase TurnBudgetEngine budgets against."""
+    from reyn.services.compaction.engine import CompactionEngine
+
+    resolver = ModelResolver({"myclass": "openai/resolved-model"})
+    eng = CompactionEngine("myclass", events=FakeEventLog(), resolver=resolver)
+    assert eng.model == "openai/resolved-model"  # resolved
+    assert eng.model != "myclass"                # never the raw class (#1172)
+
+
+# ── phase host should_force_close ────────────────────────────────────────────
+
+
+def _host(turn_budget_engine) -> PhaseRouterLoopHost:
+    return PhaseRouterLoopHost(
+        control_ir_executor=None,
+        events=FakeEventLog(),
+        phase="p",
+        decl=None,
+        allowed_ops=None,
+        default_sandbox_policy=None,
+        agent_name="a",
+        agent_role="r",
+        output_language="en",
+        resolve_model_fn=lambda n: n,
+        turn_budget_engine=turn_budget_engine,
+    )
+
+
+def _small_threshold_engine(threshold_tokens: int) -> TurnBudgetEngine:
+    """A TurnBudgetEngine whose threshold is a small testable value (large
+    reserves pull it down), so a small message can cross it."""
+    eng = build_default_turn_budget_engine(_MODEL, use_chars4=True)
+    t_max = eng.budget.max_input
+    t_wrap = eng.budget.T_wrap_SP
+    # threshold = t_max - t_wrap - output_reserve - offload_cap
+    offload_cap = 1
+    output_reserve = t_max - t_wrap - offload_cap - threshold_tokens
+    return TurnBudgetEngine(
+        _MODEL, output_reserve=output_reserve, offload_cap=offload_cap,
+        use_chars4=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase_host_fires_above_threshold_inert_without_engine() -> None:
+    """Tier 2: should_force_close fires when non-system content ≥ threshold, and
+    a host without an engine is inert (False)."""
+    eng = _small_threshold_engine(threshold_tokens=50)
+    host = _host(eng)
+    # content_tokens ≈ chars/4 (use_chars4). Build a user turn above/below 50 tok.
+    above = [{"role": "user", "content": "x" * (60 * 4)}]   # ~60 tok ≥ 50
+    below = [{"role": "user", "content": "x" * (40 * 4)}]   # ~40 tok < 50
+    assert await host.should_force_close(above, model="p") is True
+    assert await host.should_force_close(below, model="p") is False
+    # inert without an engine.
+    assert await _host(None).should_force_close(above, model="p") is False
+
+
+@pytest.mark.asyncio
+async def test_phase_host_excludes_system_turn_from_content() -> None:
+    """Tier 2: the system turn is excluded from the content measure (the wrap-up
+    SP swaps it at force-close time). A huge system turn alone does not trip it."""
+    eng = _small_threshold_engine(threshold_tokens=50)
+    host = _host(eng)
+    # A large SYSTEM turn + a tiny user turn → content (user only) stays under.
+    msgs = [
+        {"role": "system", "content": "x" * (10_000 * 4)},  # excluded
+        {"role": "user", "content": "x" * (10 * 4)},        # ~10 tok < 50
+    ]
+    assert await host.should_force_close(msgs, model="p") is False


### PR DESCRIPTION
**[e2e-coder]** — Refs #1092. **C2 of the cumulative-axis wave** — activates the force-close trigger LIVE on the phase axis + the shared reserve helper. Approach ratified by lead-coder on the broker; this lands the phase activation **before PR-D** so the load-bearing D (handoff) / E (termination) build + verify on a *real* phase force-close (not blind).

## Contents

- **Shared reserve helper** `build_default_turn_budget_engine` (`services/turn_budget`): `offload_cap` = the #1093 per-result inline ceiling (`MAX_OFFLOADED_INLINE_BYTES`, in tokens) + `output_reserve` = `DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS`. Built **shared-shaped from the start** so PR-F reuses it verbatim for chat/plan — no per-axis reserve duplication.
- **`CompactionEngine.model`** — a public accessor for the **resolved** model (#1172), so the phase `TurnBudgetEngine` budgets against the *same* model the compaction engine uses. This avoids the **cosmetic-model trap**: the run-loop `model` for phases is the *phase name* (`router_model=phase` is cosmetic; the real model is resolved inside the phase llm_caller). `use_chars4=True` makes every threshold term but `T_max` model-independent.
- **`PhaseRouterLoopHost.should_force_close`** — the phase-axis layer-1 trigger (consumed by the merged PR-C run_loop seam). Measures the accumulated **non-system** content (the wrap-up SP swaps the system turn at force-close time) vs the threshold. `None` engine → inert.
- **`phase_executor`** builds + passes the engine from the compaction engine's model (else inert).

## Safety before PR-D (traced, not assumed)

The threshold is ~`T_max − reserves` (huge), so only a near-overflow phase trips it → **528 phase/routerloop/compaction tests byte-identical**. And pre-D, a force-close finish just **truncates the act-loop early** → FD2 decides from the partial op-results = a **valid artifact** (smaller/earlier, *not* broken) — strictly better than the prior grow→overflow→**error**. PR-D upgrades the early-truncate into the consolidated handoff/re-entry.

## Test plan

- [x] `pytest tests/test_force_close_phase_activation_1092.py -q` — 5 passed.
- [x] Tier 2: shared-helper reserves + §5 formula; `CompactionEngine.model` resolved (#1172); phase `should_force_close` fires above / inert below / inert without engine / excludes the system turn; **★live-path end-to-end** — over-threshold content drives the real threshold-backed trigger so `run_loop` actually swaps to the force-close call (`tools=[]`, `trace_caller=router_force_close`) = the D/E foundation.
- [x] **Falsification**: dropping the system-turn exclusion fails the exclusion test.
- [x] **byte-identical**: 528 phase/routerloop/compaction tests unchanged.
- [x] `ruff` clean; `test_tier_audit --strict` 0 errors.
- [x] Full `pytest -q` from rootdir — _result in a comment below_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
