### PR TITLE
feat(1092): PR-D1 force-close handoff persist (additive — checkpoint + P6 event)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2007,6 +2007,14 @@ class RouterLoop:
                     result = await self._force_close_call_with_retry(
                         messages, resolved_model=resolved_model,
                     )
+                    # #1092 PR-D1 (detect): hand the consolidation to the host so
+                    # the OS can persist it as a checkpoint + (PR-D2) re-enter.
+                    # getattr-guarded → chat hosts don't implement it (their
+                    # handoff is the outer retry_loop terminal, PR-F) → no-op,
+                    # byte-identical.
+                    _record_fc = getattr(host, "record_force_close", None)
+                    if _record_fc is not None:
+                        _record_fc(result)
                 else:
                     # Tier 2 testability: tests inject a real-fake callable via
                     # ``_llm_caller`` (= no unittest.mock.patch needed). None

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -49,6 +49,45 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger(__name__)
 
+
+def persist_force_close_checkpoint(
+    *,
+    workspace,
+    events,
+    phase: str,
+    skill_name: str,
+    run_id: str | None,
+    forced_close_result,
+) -> "str | None":
+    """#1092 PR-D1: persist a force-close consolidation as a checkpoint artifact
+    (P5) + emit a P6 event. Returns the artifact path, or ``None`` if the phase
+    did not force-close (``forced_close_result is None``).
+
+    ADDITIVE: the caller keeps the FD2-from-partial outcome (= C2 behaviour) — the
+    persisted checkpoint stays unconsumed until PR-D2 switches the outcome to
+    re-enter the same phase from it (the rollback ``previous_control_ir_results``
+    seam). Pure aside from the workspace write + event emit, so it is unit-testable
+    with a real Workspace + EventLog.
+    """
+    if forced_close_result is None:
+        return None
+    checkpoint = {
+        "type": "force_close_checkpoint",
+        "data": {
+            "consolidation": getattr(forced_close_result, "content", None) or "",
+            "phase": phase,
+        },
+    }
+    path = workspace.store_artifact(phase, checkpoint, skill_name=skill_name)
+    events.emit(
+        "phase_force_close_checkpoint_persisted",
+        phase=phase,
+        checkpoint_path=path,
+        chain_id=run_id or phase,
+    )
+    return path
+
+
 # FP-0008 #1135(b): inline cap for the raw LLM output captured on a phase-output
 # validation failure. Larger payloads are offloaded (size axis, non-history) so
 # the P6 events audit log never balloons.
@@ -583,6 +622,23 @@ class PhaseExecutor:
         # as native tool-role turns; the model signals end_turn by emitting no
         # tool_calls, returning control here for the FD2 decide.
         await routerloop.run_loop(messages, tools, False)
+
+        # #1092 PR-D1 (handoff persist — ADDITIVE): if this phase FORCE-CLOSED
+        # (the cumulative-axis trigger fired and run_loop ran the wrap-up call),
+        # persist the consolidation as a checkpoint artifact (P5) + emit a P6
+        # event. ADDITIVE: the FD2-from-partial outcome below is KEPT as the
+        # fallback (= C2 behaviour, a valid artifact), so the checkpoint is
+        # unconsumed until PR-D2 switches the outcome to re-enter from it (no
+        # broken intermediate). ``record_force_close`` is host-only (chat hosts
+        # don't set it → forced_close_result is None → no-op).
+        persist_force_close_checkpoint(
+            workspace=self._control_ir_executor.workspace,
+            events=self._events,
+            phase=phase,
+            skill_name=self._skill.name,
+            run_id=self._run_id,
+            forced_close_result=getattr(host, "forced_close_result", None),
+        )
 
         # FD2: build the SEPARATE json decide frame from the native turns so it is
         # INFORMATION-EQUIVALENT to the json-mode act loop's decide frame (P1/P8 —

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -91,6 +91,10 @@ class PhaseRouterLoopHost:
         # #1092 C2: cumulative-axis force-close engine (TurnBudgetEngine). None
         # → the ``should_force_close`` trigger is inert (no phase force-close).
         self._turn_budget_engine = turn_budget_engine
+        # #1092 PR-D1: the consolidation finish of a force-close in this run_loop
+        # (set via ``record_force_close``), read by PhaseExecutor after the loop
+        # to persist the checkpoint. None = the phase did not force-close.
+        self._forced_close_result: Any = None
 
     # ── RouterLoopCore identity / static config ───────────────────────────
 
@@ -355,6 +359,20 @@ class PhaseRouterLoopHost:
             if isinstance(m, dict) and m.get("role") != "system"
         )
         return engine.should_force_close(content_tokens)
+
+    def record_force_close(self, result: Any) -> None:
+        """#1092 PR-D1: ``RouterLoop.run_loop`` hands the force-close consolidation
+        finish here so the OS (PhaseExecutor) can persist it as a checkpoint after
+        the loop. Stored, not acted on (P3 — the OS executes the handoff). Chat
+        hosts don't implement this (their handoff is the outer retry_loop terminal,
+        PR-F)."""
+        self._forced_close_result = result
+
+    @property
+    def forced_close_result(self) -> Any:
+        """The consolidation finish of a force-close in the last run_loop, or
+        None if the phase did not force-close."""
+        return self._forced_close_result
 
     # ── Chat-discovery methods (phase = empty) ────────────────────────────
     # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY

--- a/tests/test_force_close_handoff_persist_1092.py
+++ b/tests/test_force_close_handoff_persist_1092.py
@@ -1,0 +1,140 @@
+"""Tier 2: OS invariant — force-close handoff persist (#1092 PR-D1, additive).
+
+D1 is the ADDITIVE first half of the handoff: when a phase force-closes, the
+consolidation is persisted as a checkpoint artifact (P5) + a P6 event is emitted,
+WHILE the C2 FD2-from-partial outcome is kept as the fallback (the checkpoint
+stays unconsumed until PR-D2 wires re-entry → no broken intermediate). Pins:
+
+- ``persist_force_close_checkpoint`` writes a ``force_close_checkpoint`` artifact
+  carrying the consolidation + emits ``phase_force_close_checkpoint_persisted``;
+- it is a no-op (returns None, no event) when the phase did not force-close;
+- ``RouterLoop.run_loop`` hands the force-close consolidation to the host via
+  ``record_force_close`` (the detection signal), getattr-guarded;
+- ``PhaseRouterLoopHost`` stores it on ``forced_close_result``.
+
+No mocks: a real Workspace + EventLog + RouterLoop + a real capturing host.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.events.events import EventLog
+from reyn.kernel.phase_executor import persist_force_close_checkpoint
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.workspace.workspace import Workspace
+from tests.test_router_loop import FakeRouterHost
+
+
+def _finish(text: str = "consolidated handoff") -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=text, tool_calls=[], finish_reason="stop",
+        usage=TokenUsage(prompt_tokens=20, completion_tokens=5),
+    )
+
+
+def _event_types(events: EventLog) -> list[str]:
+    return [e.type for e in events.all()]
+
+
+# ── persist_force_close_checkpoint ───────────────────────────────────────────
+
+
+def test_persist_writes_checkpoint_and_emits_event(tmp_path) -> None:
+    """Tier 2: a force-close consolidation is persisted as a checkpoint artifact
+    (P5, path returned) and a P6 event is emitted carrying the path."""
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    path = persist_force_close_checkpoint(
+        workspace=ws, events=events, phase="draft", skill_name="s",
+        run_id="run-1", forced_close_result=_finish("HANDOFF"),
+    )
+    assert isinstance(path, str) and path  # a stored-artifact handle
+    persisted = [
+        e for e in events.all()
+        if e.type == "phase_force_close_checkpoint_persisted"
+    ]
+    assert persisted and persisted[0].data["checkpoint_path"] == path
+    assert persisted[0].data["phase"] == "draft"
+
+
+def test_persist_is_noop_when_not_force_closed(tmp_path) -> None:
+    """Tier 2: additive safety — no force-close (forced_close_result None) →
+    returns None and emits NO checkpoint event."""
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    path = persist_force_close_checkpoint(
+        workspace=ws, events=events, phase="draft", skill_name="s",
+        run_id="run-1", forced_close_result=None,
+    )
+    assert path is None
+    assert "phase_force_close_checkpoint_persisted" not in _event_types(events)
+
+
+# ── detection signal: run_loop → host.record_force_close ──────────────────────
+
+
+class _ForceCloseRecordingHost(FakeRouterHost):
+    """FakeRouterHost that force-closes (should_force_close=True) and records the
+    consolidation (record_force_close → forced_close_result) — the phase-host
+    detection contract."""
+
+    def __init__(self, **kw: Any) -> None:
+        super().__init__(**kw)
+        self.forced_close_result: Any = None
+
+    async def should_force_close(self, messages: list[dict], *, model: str) -> bool:
+        return True
+
+    def record_force_close(self, result: Any) -> None:
+        self.forced_close_result = result
+
+
+class _CapturingFinishLLM:
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        return _finish("RECORDED")
+
+
+@pytest.mark.asyncio
+async def test_run_loop_records_force_close_consolidation_to_host() -> None:
+    """Tier 2: when run_loop force-closes, it hands the consolidation finish to
+    the host via record_force_close (the D1 detection signal)."""
+    host = _ForceCloseRecordingHost()
+    loop = RouterLoop(host=host, chain_id="d1", max_iterations=3,
+                      llm_caller=_CapturingFinishLLM())
+    await loop.run("do the task", [])
+    assert host.forced_close_result is not None
+    assert host.forced_close_result.content == "RECORDED"
+
+
+@pytest.mark.asyncio
+async def test_run_loop_no_record_hook_is_noop() -> None:
+    """Tier 2: a host WITHOUT record_force_close (= chat) is unaffected — the
+    getattr-guarded hook is a no-op (no error), leaving the path unchanged."""
+    class _NoRecordHost(FakeRouterHost):
+        async def should_force_close(self, messages: list[dict], *, model: str) -> bool:
+            return True
+
+    loop = RouterLoop(host=_NoRecordHost(), chain_id="d1", max_iterations=3,
+                      llm_caller=_CapturingFinishLLM())
+    await loop.run("do the task", [])  # must not raise
+
+
+def test_phase_host_record_force_close_stores_result() -> None:
+    """Tier 2: PhaseRouterLoopHost.record_force_close stores the consolidation on
+    forced_close_result (initially None)."""
+    from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+    from tests.test_router_loop import FakeEventLog
+
+    host = PhaseRouterLoopHost(
+        control_ir_executor=None, events=FakeEventLog(), phase="p", decl=None,
+        allowed_ops=None, default_sandbox_policy=None, agent_name="a",
+        agent_role="r", output_language="en", resolve_model_fn=lambda n: n,
+    )
+    assert host.forced_close_result is None
+    r = _finish("STORED")
+    host.record_force_close(r)
+    assert host.forced_close_result is r


### PR DESCRIPTION
**[e2e-coder]** — Refs #1092. **PR-D1 of the cumulative-axis wave** — the **additive** first half of the §6 handoff: persist the force-close consolidation as a checkpoint + event. Design ratified by lead-coder on #1092 (both VERIFY items confirmed).

## What this is

When a phase force-closes (C2 made this live), persist the consolidation as a **checkpoint artifact** (P5) + emit a **P6 event** — while **keeping C2's FD2-from-partial outcome as the fallback**. So the checkpoint is persisted but **unconsumed** until PR-D2 wires re-entry: no broken intermediate, safe-to-land (the A/B/C-unwired → C2-activate pattern).

## Contents

- **Detection signal** — `RouterLoop.run_loop` hands the force-close consolidation finish to the host via the getattr-guarded `record_force_close(result)` hook. Chat hosts don't implement it (their handoff is the outer `retry_loop` terminal, PR-F) → no-op, **byte-identical** (58 phase/router tests unchanged).
- **`PhaseRouterLoopHost`** stores it on `forced_close_result`.
- **`persist_force_close_checkpoint`** (new module-level fn, deps-as-params → unit-testable with a real Workspace + EventLog): writes a `force_close_checkpoint` artifact carrying the consolidation + emits `phase_force_close_checkpoint_persisted`. Returns `None` (no event) when the phase did not force-close.

## Next (PR-D2)

Consume the checkpoint → switch the phase outcome from FD2-from-partial to **OS-internal re-entry** of the same phase, injecting the checkpoint via the **rollback `previous_control_ir_results` seam** (VERIFY-confirmed: `run_orchestrator.py:343-346` → `phase_executor.py:518` `prior_results` → `seed_frame` — graph-bypass, OS-driven, **no graph self-edge** = P7-clean, crash-resume/PR21 family). Chat-axis handoff folds into PR-F.

## Test plan

- [x] `pytest tests/test_force_close_handoff_persist_1092.py -q` — 5 passed.
- [x] Tier 2: persist writes checkpoint + emits event / no-op when not force-closed / run_loop records the consolidation to the host / no-record-hook is a no-op / `PhaseRouterLoopHost` stores the result.
- [x] **Falsification**: dropping the P6 event emit fails the persist test.
- [x] **byte-identical**: 58 phase/router/force-close tests unchanged (additive + getattr-guarded).
- [x] `ruff` clean; `test_tier_audit --strict` 0 errors.
- [x] Full `pytest -q` from rootdir — _result in a comment below_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
