### PR TITLE
feat(1092): PR-E by-construction termination gate — max_tokens hard-cap + assert floor

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2780,8 +2780,21 @@ class RouterLoop:
         """
         _llm = self._llm_caller or call_llm_tools
         wrap_messages = self._build_force_close_messages(messages)
+        # #1092 PR-E (by-construction floor): HARD-CAP the wrap-up output at
+        # output_reserve via max_tokens, so the consolidation is ≤ output_reserve
+        # by construction (not just by the wrap-up SP's "be concise"). With
+        # assert_turn_budget_bounds (output_reserve + offload_cap < threshold), the
+        # re-injected checkpoint then provably sits below the threshold → the
+        # re-entry makes progress → termination. The cap rides ModelSpec.kwargs →
+        # call_llm_tools' spec.kwargs → litellm (llm.py). Host-provided
+        # (``wrap_up_output_reserve``); chat hosts return None → no cap (PR-F).
+        _model: Any = resolved_model
+        _reserve = getattr(self.host, "wrap_up_output_reserve", None)
+        if _reserve is not None:
+            from reyn.llm.model_resolver import ModelSpec
+            _model = ModelSpec(model=resolved_model, kwargs={"max_tokens": int(_reserve)})
         return await _llm(
-            model=resolved_model,
+            model=_model,
             messages=wrap_messages,
             tools=[],            # continuation suppression: no tool to call
             tool_choice="auto",  # "none" is not Gemini-safe; moot with tools=[]

--- a/src/reyn/kernel/phase_router_host.py
+++ b/src/reyn/kernel/phase_router_host.py
@@ -374,6 +374,18 @@ class PhaseRouterLoopHost:
         None if the phase did not force-close."""
         return self._forced_close_result
 
+    @property
+    def wrap_up_output_reserve(self) -> int | None:
+        """#1092 PR-E: the wrap-up call's OUTPUT budget (``output_reserve``), or
+        None when the phase has no force-close engine. ``RouterLoop._force_close_call``
+        passes it as ``max_tokens`` to HARD-CAP the consolidation ≤ output_reserve —
+        the by-construction guarantee that the re-injected checkpoint stays below
+        the threshold (assert_turn_budget_bounds enforces output_reserve + offload_cap
+        < threshold). Chat hosts don't implement this → no cap (their handoff is the
+        outer retry_loop terminal, PR-F)."""
+        engine = self._turn_budget_engine
+        return engine.budget.output_reserve if engine is not None else None
+
     # ── Chat-discovery methods (phase = empty) ────────────────────────────
     # #1092 PR-C-0: ``RouterLoop._build_router_caller_state`` calls these EAGERLY
     # while building the per-dispatch RouterCallerState (router_loop.py). A phase

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -91,6 +91,17 @@ class TurnBudget:
     offload_cap: int          # max tokens one post-offload increment can add
     force_close_threshold: int  # max accumulated turn-content tokens before close
 
+    @property
+    def progress_margin(self) -> int:
+        """#1092 PR-E: tokens of NEW-work head-room a force-close re-entry has —
+        i.e. ``force_close_threshold − output_reserve − offload_cap`` (the
+        consolidation is hard-capped ≤ output_reserve; offload_cap is one working
+        increment). The by-construction termination guarantee is exactly
+        ``progress_margin > 0``: each re-entry makes a full increment of new
+        progress below threshold, so a finite-work phase converges in FEW
+        re-entries. Enforced at construction by :func:`assert_turn_budget_bounds`."""
+        return self.force_close_threshold - self.output_reserve - self.offload_cap
+
 
 def compute_turn_budget(
     model: str,
@@ -161,12 +172,28 @@ def assert_turn_budget_bounds(tb: TurnBudget) -> None:
         f"TurnBudget reserves must be non-negative; got output_reserve="
         f"{tb.output_reserve}, offload_cap={tb.offload_cap}"
     )
-    assert tb.force_close_threshold > 0, (
-        f"TurnBudget.force_close_threshold must be > 0 — "
-        f"max_input({tb.max_input}) − T_wrap_SP({tb.T_wrap_SP}) − "
-        f"output_reserve({tb.output_reserve}) − offload_cap({tb.offload_cap}) = "
-        f"{tb.force_close_threshold} ≤ 0 would force-close every turn. "
-        f"Lower the reserves or use a larger-context model."
+    # #1092 PR-E (by-construction termination — LOCKED #1092 issuecomment-4618222625):
+    # the threshold must leave room for the re-injected consolidation (hard-capped
+    # ≤ output_reserve by the wrap-up call's max_tokens) PLUS a full working
+    # increment (offload_cap) below it. Then every force-close re-entry makes a
+    # full increment of NEW progress (not just the minimal ≥1 op that
+    # output_reserve<threshold alone gives — that is fragile, re-entering close to
+    # the visit cap), so a finite-work phase converges to a genuine finish in FEW
+    # re-entries — making the max_phase_visits abort UNREACHABLE for a
+    # well-configured / finite-work phase (a pathological infinite-work phase that
+    # never completes is still backstopped by the visit cap). Strictly implies
+    # threshold > 0 AND no wrap-up overflow (consolidation + T_wrap_SP +
+    # output_reserve ≤ T_max). A config where it fails is rejected at construction
+    # (degenerate → fail-fast).
+    assert tb.force_close_threshold > tb.output_reserve + tb.offload_cap, (
+        f"TurnBudget.force_close_threshold ({tb.force_close_threshold}) must exceed "
+        f"output_reserve ({tb.output_reserve}) + offload_cap ({tb.offload_cap}) = "
+        f"{tb.output_reserve + tb.offload_cap} so a force-close re-entry makes a full "
+        f"increment of progress (the consolidation, hard-capped ≤ output_reserve, "
+        f"plus one increment fit below the threshold). Otherwise the re-entry cannot "
+        f"reliably progress and would force-close-loop toward max_phase_visits — a "
+        f"by-construction termination gap. Lower the reserves or use a larger-context "
+        f"model."
     )
 
 

--- a/tests/test_force_close_phase_activation_1092.py
+++ b/tests/test_force_close_phase_activation_1092.py
@@ -89,30 +89,24 @@ def _host(turn_budget_engine) -> PhaseRouterLoopHost:
     )
 
 
-def _small_threshold_engine(threshold_tokens: int) -> TurnBudgetEngine:
-    """A TurnBudgetEngine whose threshold is a small testable value (large
-    reserves pull it down), so a small message can cross it."""
-    eng = build_default_turn_budget_engine(_MODEL, use_chars4=True)
-    t_max = eng.budget.max_input
-    t_wrap = eng.budget.T_wrap_SP
-    # threshold = t_max - t_wrap - output_reserve - offload_cap
-    offload_cap = 1
-    output_reserve = t_max - t_wrap - offload_cap - threshold_tokens
-    return TurnBudgetEngine(
-        _MODEL, output_reserve=output_reserve, offload_cap=offload_cap,
-        use_chars4=True,
-    )
+def _phase_engine() -> TurnBudgetEngine:
+    """A REAL, non-degenerate engine (gpt-3.5-turbo, threshold ~9968 tok). PR-E's
+    by-construction assert (threshold > output_reserve + offload_cap) forbids the
+    old large-reserve low-threshold trick, so firing tests use the real threshold
+    + threshold-sized content (the D2 integration pattern)."""
+    return build_default_turn_budget_engine("gpt-3.5-turbo", use_chars4=True)
 
 
 @pytest.mark.asyncio
 async def test_phase_host_fires_above_threshold_inert_without_engine() -> None:
     """Tier 2: should_force_close fires when non-system content ≥ threshold, and
     a host without an engine is inert (False)."""
-    eng = _small_threshold_engine(threshold_tokens=50)
+    eng = _phase_engine()
+    t = eng.budget.force_close_threshold
     host = _host(eng)
-    # content_tokens ≈ chars/4 (use_chars4). Build a user turn above/below 50 tok.
-    above = [{"role": "user", "content": "x" * (60 * 4)}]   # ~60 tok ≥ 50
-    below = [{"role": "user", "content": "x" * (40 * 4)}]   # ~40 tok < 50
+    # content_tokens ≈ chars/4 (use_chars4). Size a user turn just above/below t.
+    above = [{"role": "user", "content": "x" * ((t + 500) * 4)}]   # > t tok
+    below = [{"role": "user", "content": "x" * ((t - 500) * 4)}]   # < t tok
     assert await host.should_force_close(above, model="p") is True
     assert await host.should_force_close(below, model="p") is False
     # inert without an engine.
@@ -123,12 +117,14 @@ async def test_phase_host_fires_above_threshold_inert_without_engine() -> None:
 async def test_phase_host_excludes_system_turn_from_content() -> None:
     """Tier 2: the system turn is excluded from the content measure (the wrap-up
     SP swaps it at force-close time). A huge system turn alone does not trip it."""
-    eng = _small_threshold_engine(threshold_tokens=50)
+    eng = _phase_engine()
+    t = eng.budget.force_close_threshold
     host = _host(eng)
-    # A large SYSTEM turn + a tiny user turn → content (user only) stays under.
+    # A large SYSTEM turn (well over threshold) + a tiny user turn → content
+    # (user only) stays under, so it does NOT trip.
     msgs = [
-        {"role": "system", "content": "x" * (10_000 * 4)},  # excluded
-        {"role": "user", "content": "x" * (10 * 4)},        # ~10 tok < 50
+        {"role": "system", "content": "x" * ((t + 2000) * 4)},  # excluded
+        {"role": "user", "content": "x" * (100 * 4)},           # ~100 tok < t
     ]
     assert await host.should_force_close(msgs, model="p") is False
 
@@ -172,12 +168,13 @@ async def test_over_threshold_content_actually_fires_force_close_via_run_loop() 
     drives the REAL threshold-backed trigger so run_loop SWAPS to the force-close
     call (tools=[], trace_caller=router_force_close). Confirms force-close actually
     FIRES end-to-end, not just should_force_close=True in isolation."""
-    eng = _small_threshold_engine(threshold_tokens=20)
+    eng = _phase_engine()
+    t = eng.budget.force_close_threshold
     llm = _CapturingLLM()
     loop = RouterLoop(
         host=_ThresholdHost(eng), chain_id="c2-live", max_iterations=3,
         llm_caller=llm,
     )
-    await loop.run("x" * (40 * 4), [])  # ~40-tok user turn ≥ 20-tok threshold
+    await loop.run("x" * ((t + 500) * 4), [])  # over-threshold user turn → fires
     assert llm.last_kwargs["trace_caller"] == "router_force_close"
     assert llm.last_kwargs["tools"] == []

--- a/tests/test_force_close_termination_1092.py
+++ b/tests/test_force_close_termination_1092.py
@@ -1,0 +1,146 @@
+"""Tier 2/3a: by-construction termination guarantee (#1092 PR-E, the critical gate).
+
+The force-close re-entry (D2) terminates BY CONSTRUCTION, not by luck:
+
+- the wrap-up consolidation is HARD-CAPPED ≤ output_reserve (via max_tokens on the
+  wrap-up call) — so it provably sits below the threshold;
+- ``assert_turn_budget_bounds`` enforces ``force_close_threshold > output_reserve +
+  offload_cap`` (LOCKED #1092) — so the re-injected checkpoint leaves room for a
+  full working increment below the threshold → every re-entry makes a full
+  increment of progress → a finite-work phase converges in FEW re-entries, making
+  the max_phase_visits abort UNREACHABLE for a well-configured phase. A degenerate
+  config is rejected at construction (fail-fast).
+
+The empirical half reuses the D2 force-close firing infra and shows convergence in
+a FEW re-entries (the forward-flag: a legitimate large phase does not exhaust the
+shared max_phase_visits budget). Real engines + real OSRuntime; no mocks.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelSpec
+from reyn.llm.pricing import TokenUsage
+from reyn.services.turn_budget import (
+    TurnBudget,
+    assert_turn_budget_bounds,
+    build_default_turn_budget_engine,
+)
+from tests.test_router_loop import FakeRouterHost
+
+# ── by-construction assert + progress_margin ─────────────────────────────────
+
+
+def test_progress_margin_and_assert_reject_no_progress_config() -> None:
+    """Tier 2: a config with threshold > 0 but output_reserve + offload_cap ≥
+    threshold (no room for a full increment of progress) has progress_margin ≤ 0
+    and is REJECTED by assert_turn_budget_bounds — the by-construction gate (the
+    old threshold>0 check would have passed this degenerate config)."""
+    bad = TurnBudget(
+        max_input=1000, T_wrap_SP=100, output_reserve=400, offload_cap=400,
+        force_close_threshold=1000 - 100 - 400 - 400,  # = 100 > 0, but...
+    )
+    assert bad.force_close_threshold == 100       # threshold IS positive
+    assert bad.progress_margin == 100 - 400 - 400  # = -700 ≤ 0 (no progress room)
+    with pytest.raises(AssertionError):
+        assert_turn_budget_bounds(bad)
+
+
+def test_default_engine_has_positive_progress_margin() -> None:
+    """Tier 2: a well-configured (default-reserve) engine has progress_margin > 0
+    — the re-entry can make a full increment of progress → termination guaranteed,
+    visit-cap-abort unreachable."""
+    for model in ("gpt-4o-mini", "gpt-3.5-turbo"):
+        eng = build_default_turn_budget_engine(model, use_chars4=True)
+        assert eng.budget.progress_margin > 0
+        assert_turn_budget_bounds(eng.budget)  # does not raise
+        # margin == threshold − output_reserve − offload_cap.
+        b = eng.budget
+        assert b.progress_margin == (
+            b.force_close_threshold - b.output_reserve - b.offload_cap
+        )
+
+
+# ── max_tokens hard-cap on the wrap-up call ──────────────────────────────────
+
+
+class _ReserveHost(FakeRouterHost):
+    """FakeRouterHost exposing wrap_up_output_reserve (= a phase host with a
+    force-close engine)."""
+
+    def __init__(self, reserve: int | None, **kw: Any) -> None:
+        super().__init__(**kw)
+        self._reserve = reserve
+
+    @property
+    def wrap_up_output_reserve(self) -> int | None:
+        return self._reserve
+
+
+class _CapturingLLM:
+    def __init__(self) -> None:
+        self.model: Any = None
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.model = kwargs.get("model")
+        return LLMToolCallResult(
+            content="c", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=5, completion_tokens=2),
+        )
+
+
+@pytest.mark.asyncio
+async def test_force_close_hard_caps_output_via_max_tokens() -> None:
+    """Tier 2: when the host exposes wrap_up_output_reserve, the wrap-up call is
+    issued with a ModelSpec carrying max_tokens=output_reserve — hard-capping the
+    consolidation ≤ output_reserve by construction."""
+    llm = _CapturingLLM()
+    loop = RouterLoop(host=_ReserveHost(2048), chain_id="e", max_iterations=3,
+                      llm_caller=llm)
+    await loop._force_close_call(
+        [{"role": "system", "content": "sp"}, {"role": "user", "content": "u"}],
+        resolved_model="gpt-3.5-turbo",
+    )
+    assert isinstance(llm.model, ModelSpec)
+    assert llm.model.kwargs.get("max_tokens") == 2048
+
+
+@pytest.mark.asyncio
+async def test_no_reserve_host_does_not_cap() -> None:
+    """Tier 2: a host WITHOUT wrap_up_output_reserve (= chat) issues the wrap-up
+    call with the bare model string — no cap (chat handoff is PR-F)."""
+    llm = _CapturingLLM()
+    loop = RouterLoop(host=FakeRouterHost(), chain_id="e", max_iterations=3,
+                      llm_caller=llm)
+    await loop._force_close_call(
+        [{"role": "system", "content": "sp"}, {"role": "user", "content": "u"}],
+        resolved_model="gpt-3.5-turbo",
+    )
+    assert llm.model == "gpt-3.5-turbo"  # bare string, no ModelSpec/max_tokens
+
+
+# ── empirical: convergence in FEW re-entries (forward-flag) ───────────────────
+
+
+def test_legitimate_phase_converges_in_few_reentries(tmp_path, monkeypatch) -> None:
+    """Tier 3a: (forward-flag) a phase that force-closes once converges to a
+    genuine finish in a FEW re-entries — well under the max_phase_visits cap (25),
+    so a legitimate large phase does NOT exhaust the shared visit budget. Reuses
+    the D2 force-close firing infra (real OSRuntime, real read_file)."""
+    import asyncio
+
+    from tests.test_force_close_reentry_integration_1092 import _setup
+
+    rt = _setup(monkeypatch, tmp_path, always_read=False)
+    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+    types = [e.type for e in rt.events.all()]
+    assert "phase_force_close_reentered" in types
+    assert result is not None  # converged to a genuine finish
+    # FEW re-entries — far below max_phase_visits (25). loop_limit_exceeded must
+    # NOT fire (the by-construction floor keeps convergence fast).
+    assert types.count("phase_force_close_reentered") <= 3
+    assert "loop_limit_exceeded" not in types


### PR DESCRIPTION
**[e2e-coder]** — PR-E of the #1092 cumulative-axis force-close wave (the load-bearing termination gate). Makes the D2 force-close re-entry terminate **by construction**, not by luck.

## What

The D2 re-entry (persist checkpoint → raw-discard → OS-internal re-enter) needs a guarantee that it *converges* rather than force-close-looping toward `max_phase_visits`. PR-E provides it with two interlocking pieces:

1. **Hard-cap the wrap-up consolidation ≤ `output_reserve`** — `RouterLoop._force_close_call` now passes `max_tokens=output_reserve` to the wrap-up call via `ModelSpec(model, kwargs={"max_tokens": ...})`, which rides `call_llm_tools`' `spec.kwargs` → litellm → the API hard-caps generation. So the re-injected checkpoint is provably ≤ `output_reserve` (not merely "be concise" by the wrap-up SP). Host-provided via `PhaseRouterLoopHost.wrap_up_output_reserve`; **chat hosts return `None` → no cap** (their handoff is the outer `retry_loop` terminal, PR-F) → chat byte-identical.

2. **Strengthen `assert_turn_budget_bounds` to the LOCKED floor** (`#1092` issuecomment-4618222625): `force_close_threshold > output_reserve + offload_cap`. So the threshold leaves room for the capped consolidation **plus a full working increment** below it → every re-entry makes a *full increment of progress* (not the weaker, fragile minimal-≥1-op that `output_reserve < threshold` alone gives). A finite-work / well-configured phase therefore converges in **few** re-entries → the `max_phase_visits` abort is **unreachable** for it. (A pathological *infinite-work* phase that ignores do-not-repeat is still backstopped by the visit cap — D2 covers that end.)

`TurnBudget.progress_margin = threshold − output_reserve − offload_cap` exposes the head-room; the guarantee is exactly `progress_margin > 0`.

## Fallout handled

The strengthened assert rejects a degenerate (no-progress) config at construction, which retired the old large-reserve/low-threshold test trick. The 3 affected C2 firing tests now use a real `gpt-3.5-turbo` engine + threshold-sized content (the D2 integration pattern) — no behavior change, just real-threshold sizing.

## Note ① deferred

Skipping the computed-then-discarded FD2 decide-call on force-close is **deferred** (lead-coder marked it not-required): folding needs a placeholder `LLMOutput` (FD2 is normalized before the orchestrator's force-close re-entry check) for a rare-path (near-overflow) optimization — risk > reward for this PR.

## Test plan

`tests/test_force_close_termination_1092.py` (new, 5 tests):
- [x] Tier 2: `progress_margin` + assert **rejects** a degenerate `threshold > 0` but `output_reserve+offload_cap ≥ threshold` config (the old `>0` check passed it)
- [x] Tier 2: default engines (gpt-4o-mini, gpt-3.5-turbo) have `progress_margin > 0` + assert passes
- [x] Tier 2: wrap-up call hard-capped — `ModelSpec.kwargs["max_tokens"] == output_reserve` when host exposes the reserve
- [x] Tier 2: no-reserve host (chat) → bare model string, **no cap**
- [x] Tier 3a: (forward-flag) a force-closing phase converges to a genuine finish in ≤3 re-entries, **no** `loop_limit_exceeded` (reuses the D2 real-OSRuntime firing infra)

**Falsification** (both fire → tests genuinely pin the claim):
- [x] drop the `max_tokens` cap (bare model) → hard-cap test FAILS
- [x] weaken the assert back to `> 0` → degenerate-reject test FAILS (DID NOT RAISE)

**Gate:**
- [x] `ruff check .` — All checks passed
- [x] `scripts/test_tier_audit.py --strict` (both changed test files) — All checks passed
- [x] `pytest -q` from rootdir — **6806 passed**, 1 pre-existing failure (`test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content`) verified identical on clean `origin/main` without this commit (local-env quirk, CI-green per #1203) and orthogonal to this diff (zero web_fetch files touched)

Refs #1092