### PR TITLE
feat(1092): PR-F1 chat-axis turn_budget activation (additive — reserve + assert + graceful degradation)

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -226,7 +226,17 @@ class RouterHostAdapter:
         # When None, only the user-global ~/.reyn/config.yaml is watched.
         # ChatSession passes the project root so all 3 tiers are covered.
         project_root: Path | None = None,
+        # #1092 PR-F1 (chat activation): the shared turn_budget engine the chat
+        # axis budgets against. Built by ChatSession via
+        # build_default_turn_budget_engine off the CompactionEngine's RESOLVED
+        # model (#1172-safe). Sole consumer (for now) is wrap_up_output_reserve —
+        # which hard-caps the force-close wrap-up call's output. None = no engine
+        # (legacy / test paths) → no cap (== pre-PR-F behaviour). ADDITIVE: chat
+        # never calls _force_close_call until the F2 handoff lands, so wiring the
+        # reserve here is inert until then.
+        turn_budget_engine: Any = None,
     ) -> None:
+        self._turn_budget_engine = turn_budget_engine
         self._agent_name = agent_name
         self._agent_role = agent_role
         self.output_language = output_language
@@ -315,6 +325,28 @@ class RouterHostAdapter:
         self._compact_now = compact_now
         # #272/#1128 context-size signal: live budget provider (or None).
         self._context_window_status = context_window_status
+
+    @property
+    def wrap_up_output_reserve(self) -> int | None:
+        """#1092 PR-F1: the force-close wrap-up call's OUTPUT budget
+        (``output_reserve``), or None when the chat axis has no turn_budget engine.
+        ``RouterLoop._force_close_call`` passes it as ``max_tokens`` to HARD-CAP the
+        consolidation ≤ output_reserve — the by-construction guarantee that the
+        re-injected handoff stays below threshold (``assert_turn_budget_bounds``,
+        run at engine construction, enforces output_reserve + offload_cap <
+        threshold). Mirrors ``PhaseRouterLoopHost.wrap_up_output_reserve``.
+
+        NOTE — chat deliberately exposes ONLY this (the wrap-up cap), not
+        ``should_force_close``: chat is REACTIVE-only. Unlike a phase (task
+        execution — proactively force-closing to wrap-up-and-continue is correct
+        because the phase has a goal), chat is a *live conversation* where a
+        proactive mid-turn force-close would truncate the user's conversation
+        prematurely. So chat handles growth via the bounded ``retry_loop`` shrink
+        and force-closes only at the last-resort floor-exhausted terminal (the F2
+        handoff). This is a deliberate per-axis architectural choice
+        (failure-mode separation), NOT a missing proactive trigger."""
+        engine = self._turn_budget_engine
+        return engine.budget.output_reserve if engine is not None else None
 
     # --- RouterLoopHost identity attributes ---
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1695,11 +1695,31 @@ class ChatSession:
             get_router_host=lambda: self._router_host,
         )
 
+        # #1092 PR-F1 (chat activation): build the chat axis's turn_budget engine
+        # off the RESOLVED model (#1172-safe — resolve self.model exactly as the
+        # CompactionEngine does; never hand the cosmetic class to the budget).
+        # try_build_* returns None (NOT raise) when the model's context is too
+        # small to satisfy the by-construction force-close floor (output_reserve +
+        # offload_cap < threshold) — a small-context model is a legitimate chat
+        # session that simply cannot support force-close, so it degrades to the
+        # pre-force-close path (no cap, no handoff) rather than failing __init__.
+        # ADDITIVE: the engine's sole consumer is
+        # RouterHostAdapter.wrap_up_output_reserve, inert until the F2 handoff
+        # calls _force_close_call — chat stays REACTIVE-only (see the property's
+        # docstring for the deliberate per-axis choice).
+        from reyn.services.turn_budget import try_build_default_turn_budget_engine
+        _chat_turn_budget_engine = try_build_default_turn_budget_engine(
+            self._resolver.resolve(self.model).model,
+            use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
+        )
+
         # PR-refactor-session-1 wave 3 PR3: RouterHostAdapter — concrete
         # RouterLoopHost implementation extracted from ChatSession. Constructed
         # last in __init__ because it receives callbacks that reference self
         # (all of which are bound methods, resolved at call time not here).
         self._router_host = RouterHostAdapter(
+            # #1092 PR-F1: the chat turn_budget engine (resolved-model, asserted).
+            turn_budget_engine=_chat_turn_budget_engine,
             agent_name=self.agent_name,
             agent_role=self._agent_role,
             output_language=self.output_language,

--- a/src/reyn/services/turn_budget/__init__.py
+++ b/src/reyn/services/turn_budget/__init__.py
@@ -19,6 +19,7 @@ from reyn.services.turn_budget.engine import (
     assert_turn_budget_bounds,
     build_default_turn_budget_engine,
     compute_turn_budget,
+    try_build_default_turn_budget_engine,
     wrap_up_system_prompt,
 )
 
@@ -29,5 +30,6 @@ __all__ = [
     "assert_turn_budget_bounds",
     "build_default_turn_budget_engine",
     "compute_turn_budget",
+    "try_build_default_turn_budget_engine",
     "wrap_up_system_prompt",
 ]

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -294,3 +294,34 @@ def build_default_turn_budget_engine(
         resolver=resolver,
         use_chars4=use_chars4,
     )
+
+
+def try_build_default_turn_budget_engine(
+    model: str,
+    *,
+    resolver: "ModelResolver | None" = None,
+    use_chars4: bool = False,
+) -> "TurnBudgetEngine | None":
+    """:func:`build_default_turn_budget_engine`, but returns ``None`` instead of
+    raising when the model's context is too small to satisfy the by-construction
+    force-close floor (``output_reserve + offload_cap < force_close_threshold``).
+
+    Such a model genuinely CANNOT support force-close termination by construction
+    (there is no room for a capped consolidation plus a working increment below
+    the threshold) — that is a property of the model's small context, NOT a
+    misconfiguration. So a caller that activates force-close opportunistically
+    (e.g. a chat/plan session that may run on any model) degrades to its
+    pre-force-close path (no wrap-up cap, no handoff — the existing retry_loop
+    terminal) rather than failing to construct. Where a non-viable config IS a bug
+    (the reserves were mis-set for a known large model), call
+    ``build_default_turn_budget_engine`` directly so the assert still fires.
+
+    The viability gate is exactly the engine's own construction-time
+    ``assert_turn_budget_bounds`` — caught here so the result is None, not a raise;
+    no bounds logic is duplicated (which would drift from the engine's measure)."""
+    try:
+        return build_default_turn_budget_engine(
+            model, resolver=resolver, use_chars4=use_chars4
+        )
+    except AssertionError:
+        return None

--- a/tests/test_force_close_chat_activation_1092.py
+++ b/tests/test_force_close_chat_activation_1092.py
@@ -1,0 +1,116 @@
+"""Tier 2: chat-axis turn_budget activation (#1092 PR-F1, ADDITIVE).
+
+F1 wires the chat axis to the SHARED turn_budget service (the C2 payoff): the
+ChatSession builds a TurnBudgetEngine off the RESOLVED model (#1172-safe) and
+hands it to RouterHostAdapter, which exposes ``wrap_up_output_reserve`` — the
+``output_reserve`` that RouterLoop._force_close_call will pass as ``max_tokens``
+to hard-cap the chat handoff's consolidation (the F2 by-construction floor).
+
+ADDITIVE / inert: chat never calls ``_force_close_call`` until the F2 handoff
+lands, so this changes no chat behaviour on its own. And chat deliberately
+exposes ONLY the reserve, NOT ``should_force_close`` — chat is REACTIVE-only (a
+proactive mid-turn force-close would truncate a live conversation; a phase, being
+task execution, proactively wraps up — a deliberate per-axis architectural
+choice, not a missing trigger).
+
+No mocks: real engines, a real ModelResolver, a real ChatSession.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+from reyn.services.turn_budget import (
+    DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,
+    build_default_turn_budget_engine,
+    try_build_default_turn_budget_engine,
+)
+from tests.test_router_host_adapter_invariants import _make_adapter
+
+# ── adapter property ─────────────────────────────────────────────────────────
+
+
+def test_adapter_exposes_reserve_when_engine_present() -> None:
+    """Tier 2: with a turn_budget engine, wrap_up_output_reserve ==
+    engine.budget.output_reserve (the cap RouterLoop._force_close_call applies)."""
+    eng = build_default_turn_budget_engine("gpt-4o-mini", use_chars4=True)
+    adapter = _make_adapter(turn_budget_engine=eng)
+    assert adapter.wrap_up_output_reserve == eng.budget.output_reserve
+    assert adapter.wrap_up_output_reserve == DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS
+
+
+def test_adapter_reserve_none_without_engine() -> None:
+    """Tier 2: no engine (legacy / test paths) → None → no cap (== the
+    pre-PR-F chat behaviour; the cap only engages once an engine is wired)."""
+    adapter = _make_adapter()
+    assert adapter.wrap_up_output_reserve is None
+
+
+def test_adapter_does_not_expose_proactive_trigger() -> None:
+    """Tier 2: chat is REACTIVE-only — the adapter exposes wrap_up_output_reserve
+    (the wrap-up cap) but NOT should_force_close (the proactive trigger). This is
+    the deliberate per-axis choice: phase force-closes proactively, chat only at
+    the F2 floor-exhausted terminal."""
+    adapter = _make_adapter(
+        turn_budget_engine=build_default_turn_budget_engine("gpt-4o-mini", use_chars4=True)
+    )
+    assert not hasattr(adapter, "should_force_close")
+
+
+# ── session-level wiring (the F1 change: resolve model + build + pass) ─────────
+
+
+def test_chat_session_activates_turn_budget_via_resolved_model(tmp_path: Path) -> None:
+    """Tier 2: a real ChatSession builds the chat turn_budget engine off the
+    RESOLVED model (#1172-safe — never the cosmetic class) and its router host
+    exposes a non-None, asserted reserve. Exercises the session wiring (resolve
+    self.model + build_default_turn_budget_engine + pass to the adapter), via the
+    public ``session.router_host`` surface."""
+    session = ChatSession(
+        agent_name="f1",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    reserve = session.router_host.wrap_up_output_reserve
+    assert reserve is not None                                  # activated
+    assert reserve == DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS     # shared default
+
+
+# ── graceful degradation: small-context model cannot support force-close ───────
+
+
+def test_try_build_returns_none_for_small_context_model(monkeypatch) -> None:
+    """Tier 2: a model whose context is too small for the by-construction floor
+    (output_reserve + offload_cap < threshold) yields None — NOT a raise. The
+    model genuinely cannot support force-close; the caller degrades."""
+    monkeypatch.setattr(
+        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2000
+    )
+    assert try_build_default_turn_budget_engine("tiny", use_chars4=True) is None
+
+
+def test_try_build_returns_engine_for_large_context_model() -> None:
+    """Tier 2: a normal large-context model yields a real engine (the floor holds)."""
+    eng = try_build_default_turn_budget_engine("gpt-4o-mini", use_chars4=True)
+    assert eng is not None
+    assert eng.budget.output_reserve == DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS
+
+
+def test_chat_session_on_small_model_constructs_without_force_close(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Tier 2: a ChatSession on a too-small-context model STILL CONSTRUCTS (no
+    __init__ raise) and exposes reserve=None — force-close is simply unavailable,
+    chat falls back to the pre-force-close path. Regression guard: building the
+    engine unconditionally would assert-fail here and break every small-model
+    chat session."""
+    monkeypatch.setattr(
+        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2000
+    )
+    session = ChatSession(
+        agent_name="f1-small",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    assert session.router_host.wrap_up_output_reserve is None  # degraded, no crash

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -109,6 +109,7 @@ def _make_adapter(
     delegation_list: "list[dict] | None" = None,
     agent_replies_list: "list[str] | None" = None,
     resolver: ModelResolver | None = None,
+    turn_budget_engine: object = None,
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -162,6 +163,7 @@ def _make_adapter(
         spawn_plan_task=_null_spawn_plan_task,
         delegation_tracker=lambda: _delegations,
         agent_replies_tracker=lambda: _replies,
+        turn_budget_engine=turn_budget_engine,
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — PR-F1 of the #1092 cumulative-axis force-close wave (the wave's last PR; staged F1/F2/F3 per the design review #1092 issuecomment-4618340494). F1 is the **additive** chat-axis activation; F2 lands the load-bearing handoff, F3 the plan + 3-axis verify.

## What

Wires the **chat** axis to the shared turn_budget service (the C2 payoff), additively:

- `ChatSession` builds a `TurnBudgetEngine` off the **resolved** model (resolve `self.model` exactly as the `CompactionEngine` does — #1172-safe, never the cosmetic class) and hands it to `RouterHostAdapter`.
- `RouterHostAdapter` exposes `wrap_up_output_reserve` (mirrors `PhaseRouterLoopHost`) — the `output_reserve` that `RouterLoop._force_close_call` passes as `max_tokens` to hard-cap the chat handoff's consolidation.

**Inert until F2:** chat never calls `_force_close_call` until the F2 handoff (at the `session.py:5453` `retry_loop` terminal) lands → no chat behaviour change on its own → safe-to-land.

## ★ Graceful degradation (`try_build_default_turn_budget_engine`, new shared helper)

`build_default_*` asserts the by-construction floor (`output_reserve + offload_cap < threshold`) at construction. A model whose context is too **small** to satisfy that floor genuinely cannot support force-close by construction — but it's still a legitimate chat session. So `try_build_*` returns `None` (not raise) on the floor failure; the session degrades to the pre-force-close path (no cap, no handoff — the existing `retry_loop` terminal) rather than failing `__init__`. Building unconditionally asserts-fail and would break **every small-context chat session** (the full suite caught this: `slash_compact` / history-slicing on a 2000-tok model). F3's plan axis reuses this helper.

## ★ Deliberate per-axis architectural choice (not a missing trigger)

Chat exposes **only** the wrap-up cap, **not** `should_force_close`. A **phase** is task execution — proactively force-closing to wrap-up-and-continue is correct (it has a goal). **Chat** is a *live conversation* — a proactive mid-turn force-close would truncate the user's conversation prematurely. So chat handles growth via the bounded `retry_loop` shrink and force-closes only at the last-resort floor-exhausted terminal (F2). Failure-mode separation by design.

## Test plan

`tests/test_force_close_chat_activation_1092.py` (7):
- [x] Tier 2: adapter exposes `wrap_up_output_reserve == engine.budget.output_reserve` with an engine; `None` without (== pre-PR-F: no cap)
- [x] Tier 2: adapter has no `should_force_close` (reactive-only — the per-axis choice)
- [x] Tier 2: a real `ChatSession` activates the engine off the resolved model + exposes a non-None asserted reserve (public `session.router_host` surface)
- [x] Tier 2: `try_build` → `None` for a small-context (2000-tok) model, an engine for a large one
- [x] Tier 2: a `ChatSession` on a 2000-tok model constructs without raising + reserve `None` (degradation regression guard)

**Falsification:**
- [x] drop the session's `turn_budget_engine=` wiring → session activation test FAILS (reserve None)
- [x] use `build_default_*` (unconditional assert) instead of `try_build_*` → small-model chat tests FAIL at `__init__` (this was the full-suite catch that drove the helper)

**Gate:**
- [x] `ruff check` (changed files) — All checks passed
- [x] `scripts/test_tier_audit.py --strict` — pass
- [x] `_make_adapter` gains a `turn_budget_engine` param (shared helper, same PR) — invariants 7 pass
- [x] `pytest -q` from rootdir — **6813 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref` — verified identical on clean main without this commit, CI-green #1203, orthogonal to this diff)

Refs #1092
