### PR TITLE
feat(1092): PR-F2a durable force-close covers-respecting slice (gated, byte-identical)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1041,6 +1041,19 @@ def _iv_meta(iv: "UserIntervention") -> dict:
     return out
 
 
+def _is_force_close_consolidation(summary: "ChatMessage") -> bool:
+    """#1092 PR-F2a: True iff a ``summary`` turn is a force-close handoff
+    consolidation — identified by the dedicated ``consolidation`` structured
+    field (set by the F2b handoff). This is the GATE for the durable
+    covers-respecting reset in :meth:`ChatSession._build_history_for_router`:
+    when present, the slicer drops the covered raw head/tail and slices
+    ``[consolidation] + post-consolidation turns``. Normal compaction summaries
+    lack the field → the slicer keeps its head/tail+bridge behaviour unchanged
+    (normal chat stays byte-identical)."""
+    structured = (summary.meta or {}).get("structured") or {}
+    return bool(structured.get("consolidation"))
+
+
 def _render_summary_for_storage(structured: dict) -> str:
     """Render a chat_summary structured dict to a quick-display text blob.
 
@@ -1049,6 +1062,13 @@ def _render_summary_for_storage(structured: dict) -> str:
     form for LLM consumption — this is for human consumption only.
     """
     parts: list[str] = []
+    # #1092 PR-F2a: a force-close handoff consolidation carries its (free-text)
+    # body in the dedicated ``consolidation`` field — render it verbatim and
+    # first (it IS the conversation's carried-forward essence). Absent on normal
+    # compaction summaries → no output change for them (byte-identical).
+    consolidation = (structured.get("consolidation") or "").strip()
+    if consolidation:
+        parts.append(consolidation)
     topic = (structured.get("topic_arc") or "").strip()
     if topic:
         parts.append(f"[topic] {topic}")
@@ -4911,6 +4931,40 @@ class ChatSession:
             m for m in self.history
             if m.role in ("user", "assistant", "tool", "agent")
         ]
+
+        # #1092 PR-F2a: durable force-close reset. When the latest summary is a
+        # force-close handoff consolidation (covers-all), the conversation
+        # overflowed even when shrunk to its floor — so the slicer DROPS the
+        # covered raw head/tail permanently and slices [consolidation bridge] +
+        # the turns appended AFTER the consolidation. This is DURABLE (re-applied
+        # every turn, not a one-shot override): the next user turn slices
+        # [consolidation] + recent turns, never re-slicing the dropped raw
+        # head/tail → no immediate re-overflow. Position-based (turns after the
+        # consolidation in history order), NOT seq>covers — assistant/tool turns
+        # keep seq=0 (only user/agent get a monotonic seq), so a seq filter would
+        # wrongly drop post-handoff assistant replies. GATED to force-close
+        # consolidations only (the dedicated `consolidation` field) — normal
+        # compaction summaries fall through to the unchanged head/tail+bridge
+        # path below, so normal chat stays byte-identical.
+        _fc_summary = self._latest_summary()
+        if _fc_summary is not None and _is_force_close_consolidation(_fc_summary):
+            _idx = next(
+                (i for i, m in enumerate(self.history) if m is _fc_summary), -1
+            )
+            _post = [
+                m for m in self.history[_idx + 1:]
+                if m.role in ("user", "assistant", "tool", "agent")
+            ]
+            _summary_text = (
+                _fc_summary.content if isinstance(_fc_summary.content, str)
+                else json.dumps(_fc_summary.content, ensure_ascii=False)
+            )
+            _bridge = [ChatMessage(
+                role="assistant",
+                content=f"[summary of earlier conversation]\n{_summary_text}",
+                ts=_fc_summary.ts,
+            )]
+            return [self._serialise_turn(m) for m in (_bridge + _post)]
 
         # Resolve token budgets from the compaction engine.
         _ctrl = getattr(self, "_compaction_controller", None)

--- a/tests/test_force_close_covers_slice_1092.py
+++ b/tests/test_force_close_covers_slice_1092.py
@@ -1,0 +1,125 @@
+"""Tier 2: durable force-close covers-respecting slice (#1092 PR-F2a).
+
+F2a is the slice mechanism the F2b chat handoff stands on. When the latest chat
+summary is a force-close handoff consolidation (identified by the dedicated
+``consolidation`` structured field), ``_build_history_for_router`` DROPS the
+covered raw head/tail and slices ``[consolidation bridge] + turns appended after
+the consolidation`` — the durable "true reset" (re-applied every turn, so a
+subsequent turn never re-slices the dropped raw history → no re-overflow). This
+is the chat analogue of phase's checkpoint-reset (D2).
+
+★Gated: only a force-close consolidation triggers the drop. Normal compaction
+summaries (no ``consolidation`` field) fall through to the unchanged
+head/tail+bridge path → normal chat stays byte-identical (pinned below + by the
+unchanged test_session_router_history_slicing suite).
+
+No mocks: a real ChatSession with a synthetic T_max.
+"""
+from __future__ import annotations
+
+from reyn.chat.session import (
+    ChatMessage,
+    _is_force_close_consolidation,
+    _render_summary_for_storage,
+)
+from tests.test_session_router_history_slicing import _make_session, _now, _push
+
+
+def _append_force_close_summary(session, consolidation: str) -> ChatMessage:
+    """Append a force-close consolidation summary (the F2b install shape)."""
+    msg = ChatMessage(
+        role="summary",
+        content=_render_summary_for_storage({"consolidation": consolidation}),
+        ts=_now(),
+        meta={"structured": {"consolidation": consolidation}, "covers_through_seq": 0},
+    )
+    session.history.append(msg)
+    return msg
+
+
+# ── the durable reset: covered raw head/tail dropped ─────────────────────────
+
+
+def test_force_close_consolidation_drops_covered_head_tail(tmp_path) -> None:
+    """Tier 2: with a force-close consolidation as the latest summary, the slice
+    is [consolidation bridge] only — the covered raw head/tail is dropped (the
+    true reset), and the consolidation text reaches the prompt."""
+    session = _make_session(tmp_path)
+    for t in ("U1-covered", "A1-covered", "U2-covered", "A2-covered"):
+        _push(session, "user" if t.startswith("U") else "assistant", t)
+    _append_force_close_summary(session, "CONSOLIDATED-ESSENCE")
+
+    msgs = session._build_history_for_router()
+    blob = "\n".join(m["content"] for m in msgs if isinstance(m.get("content"), str))
+    assert "CONSOLIDATED-ESSENCE" in blob          # consolidation reaches the slice
+    for covered in ("U1-covered", "A1-covered", "U2-covered", "A2-covered"):
+        assert covered not in blob                  # covered raw head/tail dropped
+
+
+def test_post_consolidation_turns_retained_including_assistant(tmp_path) -> None:
+    """Tier 2: turns appended AFTER the consolidation are retained — including an
+    assistant turn (seq=0). Pins the position-based (not seq>covers) filter: a
+    seq filter would wrongly drop post-handoff assistant replies."""
+    session = _make_session(tmp_path)
+    _push(session, "user", "U1-covered")
+    _push(session, "assistant", "A1-covered")
+    _append_force_close_summary(session, "CONSOL")
+    _push(session, "user", "U2-after")
+    _push(session, "assistant", "A2-after-assistant")  # seq=0
+
+    msgs = session._build_history_for_router()
+    blob = "\n".join(m["content"] for m in msgs if isinstance(m.get("content"), str))
+    assert "CONSOL" in blob
+    assert "U2-after" in blob
+    assert "A2-after-assistant" in blob             # seq=0 assistant retained
+    assert "U1-covered" not in blob                 # pre-consolidation dropped
+    assert "A1-covered" not in blob
+
+
+# ── the gate: normal compaction summaries unaffected (byte-identical) ──────────
+
+
+def test_normal_compaction_summary_does_not_trigger_reset(tmp_path) -> None:
+    """Tier 2: a NORMAL compaction summary (no `consolidation` field) does NOT
+    trigger the force-close reset — the raw turns still appear (head/tail+bridge
+    behaviour unchanged). With a large T_max (no elide) all raw turns are
+    returned, proving the reset branch did not fire."""
+    session = _make_session(tmp_path)  # default T_max huge → no elide
+    _push(session, "user", "U1-raw")
+    _push(session, "assistant", "A1-raw")
+    session.history.append(ChatMessage(
+        role="summary", content="[topic] x", ts=_now(),
+        meta={"structured": {"topic_arc": "x"}, "covers_through_seq": 0},
+    ))
+
+    msgs = session._build_history_for_router()
+    blob = "\n".join(m["content"] for m in msgs if isinstance(m.get("content"), str))
+    assert "U1-raw" in blob and "A1-raw" in blob    # raw turns NOT dropped
+
+
+# ── unit: detection + renderer ───────────────────────────────────────────────
+
+
+def test_is_force_close_consolidation_detection() -> None:
+    """Tier 2: the gate keys on the dedicated `consolidation` structured field."""
+    fc = ChatMessage(role="summary", content="", ts=_now(),
+                     meta={"structured": {"consolidation": "x"}})
+    normal = ChatMessage(role="summary", content="", ts=_now(),
+                         meta={"structured": {"topic_arc": "x"}})
+    no_meta = ChatMessage(role="summary", content="", ts=_now(), meta=None)
+    assert _is_force_close_consolidation(fc) is True
+    assert _is_force_close_consolidation(normal) is False
+    assert _is_force_close_consolidation(no_meta) is False
+
+
+def test_render_consolidation_field_verbatim_and_normal_unchanged() -> None:
+    """Tier 2: the renderer surfaces the consolidation verbatim; a normal
+    structured dict (no consolidation) renders exactly as before (byte-identical)."""
+    assert "MY-CONSOLIDATION" in _render_summary_for_storage(
+        {"consolidation": "MY-CONSOLIDATION"}
+    )
+    # normal summary: unchanged output (no `consolidation` → no new lines).
+    assert _render_summary_for_storage({"topic_arc": "T"}) == "[topic] T"
+    assert _render_summary_for_storage(
+        {"decisions": ["d1"]}
+    ) == "[decisions]\n  - d1"


### PR DESCRIPTION
**[e2e-coder]** — PR-F2a of the #1092 force-close wave. F is split into **F2a** (this — the durable covers-respecting slice mechanism) and **F2b** (the chat handoff that uses it), per the design review (#1092 issuecomment-4618514431). F2a is the core-path slice change, landed + verified in isolation; F3 (plan + 3-axis) closes the wave.

## Why (architectural finding #3)

The flow-trace found that chat's `_build_history_for_router` **always re-slices `head(budget) + summary-bridge + tail(budget)` of the RAW history** — there is no covers-based dropping. So a force-close "install consolidation as summary" would only swap the *bridge* (`body_budget`→`output_reserve`); the re-entry stays `head_budget + consolidation + tail_budget + new_msg` = the **same shape that just raised `UnrecoveredError`** → converges only iff `output_reserve < body_budget`, not by construction. Phase re-enters with *only* the checkpoint (true reset); F2a gives chat the same.

## What

- `_build_history_for_router` gains an **early branch**: when the latest summary is a force-close consolidation, **drop the covered raw head/tail** and slice `[consolidation bridge] + turns appended after the consolidation`. **Durable** — re-applied every turn (not a transient one-shot override), so a subsequent turn never re-slices the dropped raw history → no immediate re-overflow. This makes the F2b backstop (a) by-construction.
- **Position-based** (turns after the consolidation in history order), not `seq>covers`: assistant/tool turns keep `seq=0` (only user/agent get a monotonic seq), so a seq filter would wrongly drop post-handoff assistant replies.
- `_render_summary_for_storage` renders the dedicated free-text `consolidation` field verbatim, so it reaches the LLM via the bridge's `summary.content`.

## ★ Gated → normal chat byte-identical

The reset fires **only** for a force-close consolidation (the dedicated `consolidation` structured field). Normal compaction summaries fall through to the unchanged head/tail+bridge path.

## Test plan

`tests/test_force_close_covers_slice_1092.py` (5):
- [x] Tier 2: force-close consolidation → covered raw head/tail dropped + consolidation reaches the slice
- [x] Tier 2: post-consolidation turns retained **including a seq=0 assistant** (the position-filter pin)
- [x] Tier 2: a normal compaction summary does **not** trigger the reset (the gate)
- [x] Tier 2: detection helper + renderer (consolidation verbatim; normal unchanged)

**Falsification:**
- [x] gate always-on → the normal-compaction test FAILS (the gate is what keeps normal chat byte-identical)
- [x] seq-based filter → the seq=0-assistant retention test FAILS (position-filter is load-bearing)

**Byte-identical regression:**
- [x] `test_session_router_history_slicing` + `test_1128_step3_token_budget_headtail` + compaction suites — **48 pass unchanged**

**Gate:**
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` — pass
- [x] `pytest -q` from rootdir — **6818 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref` — verified identical on clean main without this commit, CI-green #1203, orthogonal to this diff)

Refs #1092
