### PR TITLE
feat(1092): PR-F2b chat-axis force-close handoff (the load-bearing piece)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1041,6 +1041,16 @@ def _iv_meta(iv: "UserIntervention") -> dict:
     return out
 
 
+# #1092 PR-F2b: max force-close handoffs per user turn. ONE is enough by
+# construction — after a handoff the F2a reset slices [consolidation (≤
+# output_reserve < threshold)] + new turn, which fits for any turn whose NEW
+# message fits the post-consolidation budget (the normal case). The only input a
+# 2nd handoff couldn't help is a single new message too large to ever fit — so at
+# the cap we raise the genuine dead-end. This is chat's bounded analogue of
+# phase's max_phase_visits (25), made tight (1) by the by-construction floor.
+_MAX_FORCE_CLOSE_HANDOFFS = 1
+
+
 def _is_force_close_consolidation(summary: "ChatMessage") -> bool:
     """#1092 PR-F2a: True iff a ``summary`` turn is a force-close handoff
     consolidation — identified by the dedicated ``consolidation`` structured
@@ -5435,11 +5445,64 @@ class ChatSession:
         # the assembled history fits before the router LLM call.
         # ISSUE #5: pass user_text so Axis-11 new_msg_budget check fires.
         await self._maybe_force_compact_for_router(new_msg_text=user_text)
-        history = self._build_history_for_router()
 
-        # PR-N6: wrap loop.run() to detect context overflow and invoke
-        # retry_loop. The retry_loop is the bounded shrink mechanism;
-        # keep _maybe_force_compact_for_router unchanged (= pre-frame guard).
+        from reyn.services.compaction.engine import (
+            ContextOverflowError as _ContextOverflowError,
+        )
+
+        # #1092 PR-F2b: bounded force-close handoff loop. _router_run_with_shrink
+        # runs the router with the reactive retry_loop shrink; if even the floor
+        # overflows it raises _ContextOverflowError. On that terminal we force-
+        # close: consolidate the (floor) context into a capped summary (≤
+        # output_reserve) + install it covers-all — firing F2a's durable
+        # covers-respecting reset so the re-entry slices [consolidation] + new
+        # turns, NOT the raw head/tail that just overflowed. By construction
+        # (F1 max_tokens cap + F2a true-reset) a normal turn converges in ONE
+        # handoff; cap=1 backstops the irreducible single-oversized-message
+        # dead-end (no infinite loop) — the chat analogue of phase's
+        # max_phase_visits, except the by-construction floor makes 1 enough.
+        _handoffs = 0
+        while True:
+            try:
+                router_usage = await self._router_run_with_shrink(loop, user_text)
+                break
+            except _ContextOverflowError as _overflow_exc:
+                _reserve = getattr(
+                    self._router_host, "wrap_up_output_reserve", None
+                )
+                if _reserve is None or _handoffs >= _MAX_FORCE_CLOSE_HANDOFFS:
+                    # force-close unavailable (sub-viable model → no cap wired) OR
+                    # cap reached (the new message is irreducibly too large to fit
+                    # even after a full consolidation) → genuine dead-end.
+                    self._chat_events.emit(
+                        "router_context_overflow_unrecovered",
+                        error=repr(_overflow_exc),
+                    )
+                    raise
+                await self._force_close_handoff(loop, user_text)
+                _handoffs += 1
+
+        # F4 Bug 2 / F4 Bug 1: accumulate router LLM usage (with proxy-prefix
+        # stripping) into per-session totals via the gateway.
+        if router_usage is not None:
+            self._budget.add_router_usage(
+                usage=router_usage,
+                resolver=self._resolver,
+                router_model_name=loop.router_model,
+            )
+
+    async def _router_run_with_shrink(self, loop, user_text: str) -> "Any":
+        """#1092 PR-F2b: run the router once with the reactive bounded-shrink
+        ``retry_loop`` (PR-N6 / #1125). Returns the router usage, or raises
+        ``_ContextOverflowError`` when even the floor overflows (the terminal the
+        F2b handoff loop catches to force-close). Rebuilds the history each call
+        so a force-close re-entry sees the post-handoff (F2a-reset) slice.
+
+        Extracted from ``_run_router_loop`` so the handoff loop can re-invoke it
+        across a force-close. No ``router_context_overflow_unrecovered`` event
+        here — the caller emits it ONLY when it actually gives up (cap reached /
+        sub-viable model), so a recoverable handoff is not mislogged as a dead-end.
+        """
         from reyn.services.compaction.engine import (
             ContextOverflowError as _ContextOverflowError,
         )
@@ -5447,31 +5510,18 @@ class ChatSession:
             UnrecoveredError as _UnrecoveredError,
         )
 
+        history = self._build_history_for_router()
         try:
-            router_usage = await loop.run(user_text=user_text, history=history)
+            return await loop.run(user_text=user_text, history=history)
         except Exception as _exc:
-            # Detect litellm context-length errors and convert to ContextOverflowError.
             _exc_str = str(_exc).lower()
-            _is_overflow = any(
+            if not any(
                 kw in _exc_str
                 for kw in ("context", "token", "length", "limit", "too long", "too large")
-            )
-            if not _is_overflow:
+            ):
                 raise
-            # PR-N6 / #1125 Item 2: overflow detected — recover via the bounded
-            # adaptive-shrink retry_loop (replaces the prior degraded
-            # compact-once). The session now exposes the
-            # head/summary/raw_middle/tail decomposition retry_loop needs
-            # (_decompose_history_for_retry), so it can fold raw_middle into the
-            # running summary and monotonically shrink head/tail until the call
-            # fits — the "never dead-end" continuity guarantee. The pre-frame
-            # guard (_maybe_force_compact_for_router) already ran and populated
-            # engine.budgets; retry_loop is the reactive safety net when the
-            # guard's estimate under-counted. UnrecoveredError (all shrink paths
-            # exhausted) is the chat axis's fail-fast surface.
             self._chat_events.emit(
-                "router_context_overflow_detected",
-                error=repr(_exc),
+                "router_context_overflow_detected", error=repr(_exc)
             )
             from reyn.services.compaction.engine import retry_loop as _retry_loop
             engine = self._compaction_controller._engine
@@ -5481,16 +5531,8 @@ class ChatSession:
             _new_msg = {"role": "user", "content": user_text}
 
             async def _router_main_call(*, SP, head, summary, tail, new_msg):
-                # Rebuild the router prompt from the (possibly shrunk)
-                # decomposition retry_loop hands back each iteration.
                 _msgs = list(head)
                 if summary:
-                    # Render the structured summary via the SAME renderer that
-                    # produced the persisted summary.content (= the normal path's
-                    # bridge text), so the recovery prompt's summary bridge is
-                    # byte-identical to what _build_history_for_router would send.
-                    # retry_loop still folds raw_middle into the *structured*
-                    # dict (its immutable base); only the bridge text is rendered.
                     _summary_text = _render_summary_for_storage(summary)
                     _msgs.append({
                         "role": "assistant",
@@ -5523,21 +5565,86 @@ class ChatSession:
                     learner=self._token_learner,
                     main_call=_router_main_call,
                 )
-                router_usage = _shim.usage
+                return _shim.usage
             except (_ContextOverflowError, _UnrecoveredError) as _retry_exc:
-                self._chat_events.emit(
-                    "router_context_overflow_unrecovered",
-                    error=repr(_retry_exc),
-                )
                 raise _ContextOverflowError(
-                    f"Router context overflow unrecovered after bounded shrink: {_retry_exc}"
+                    f"Router context overflow after bounded shrink: {_retry_exc}"
                 ) from _retry_exc
 
-        # F4 Bug 2 / F4 Bug 1: accumulate router LLM usage (with proxy-prefix
-        # stripping) into per-session totals via the gateway.
-        if router_usage is not None:
-            self._budget.add_router_usage(
-                usage=router_usage,
-                resolver=self._resolver,
-                router_model_name=loop.router_model,
-            )
+    async def _force_close_handoff(self, loop, user_text: str) -> None:
+        """#1092 PR-F2b: at the overflow terminal, consolidate the working context
+        into a capped force-close summary and install it covers-all — firing F2a's
+        durable covers-respecting reset so the re-entry slices ``[consolidation] +
+        new turn`` instead of the raw head/tail that just overflowed. The
+        consolidation is hard-capped ≤ output_reserve (F1) and made to fit by the
+        bounded fallback in ``_force_close_wrap_up``. Emits a P6
+        ``router_force_close_handoff`` event. ``user_text`` is unused here (the new
+        message is re-applied by the loop's next ``_router_run_with_shrink``); kept
+        for symmetry / future audit.
+        """
+        resolved_model = self._resolver.resolve(self.model).model
+        consolidation = await self._force_close_wrap_up(loop, resolved_model)
+        covers = max(self._next_seq - 1, 0)
+        structured = {"consolidation": consolidation}
+        msg = ChatMessage(
+            role="summary",
+            content=_render_summary_for_storage(structured),
+            ts=_now_iso(),
+            meta={"structured": structured, "covers_through_seq": covers},
+        )
+        self._append_history(msg)
+        self._chat_events.emit(
+            "router_force_close_handoff",
+            covers_through_seq=covers,
+            consolidation_chars=len(consolidation),
+        )
+
+    async def _force_close_wrap_up(self, loop, resolved_model: str) -> str:
+        """#1092 PR-F2b (Fork 1 — wrap-up-fits): produce the capped consolidation
+        via the force-close wrap-up call, made to FIT by a bounded fallback that
+        shrinks the input if the wrap-up itself would overflow — the chat analogue
+        of phase's ``_force_close_call_with_retry`` (chat's wrap-up runs OUTSIDE
+        retry_loop, so it has no built-in recovery). Input candidates, decreasing:
+        ``[summary + raw_middle + tail]`` → ``[summary + tail]`` → ``[summary]``.
+        If even summary-only overflows, the model is RUNTIME sub-viable (distinct
+        from the config-time ``try_build``=None gate — the engine IS wired here) →
+        raise, which the handoff loop surfaces as a genuine dead-end.
+        """
+        from reyn.services.compaction.engine import (
+            ContextOverflowError as _ContextOverflowError,
+        )
+
+        _head, _raw_middle, _tail, _summary_dict = (
+            self._decompose_history_for_retry()
+        )
+        _summary_msg: list[dict] = []
+        if _summary_dict:
+            _summary_msg = [{
+                "role": "assistant",
+                "content": (
+                    "[summary of earlier conversation]\n"
+                    + _render_summary_for_storage(_summary_dict)
+                ),
+            }]
+        _candidates = [
+            _summary_msg + _raw_middle + _tail,
+            _summary_msg + _tail,
+            _summary_msg,
+        ]
+        _last_exc: "Exception | None" = None
+        for _inp in _candidates:
+            try:
+                _result = await loop._force_close_call(
+                    _inp, resolved_model=resolved_model
+                )
+                return _result.content or ""
+            except Exception as _exc:
+                if not any(kw in str(_exc).lower() for kw in (
+                    "context", "token", "length", "limit", "too long", "too large",
+                )):
+                    raise
+                _last_exc = _exc
+        raise _ContextOverflowError(
+            "force-close wrap-up overflowed even at summary-only "
+            f"(runtime sub-viable model): {_last_exc}"
+        )

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -1,0 +1,197 @@
+"""Tier 2/3a: chat-axis force-close handoff (#1092 PR-F2b — the load-bearing piece).
+
+When the chat overflow recovery (retry_loop) exhausts even at its floor, the
+session FORCE-CLOSES instead of dead-ending: it consolidates the working context
+into a capped summary (≤ output_reserve, F1) and installs it covers-all — firing
+F2a's durable covers-respecting reset so the re-entry slices [consolidation] +
+the new turn (not the raw head/tail that overflowed). By construction it
+converges in ONE handoff; a cap=1 backstops the irreducible single-oversized-
+message dead-end (no infinite loop).
+
+Driven through the REAL retry_loop + handoff with a hand-written fake RouterLoop
+(a collaborator double, NOT a MagicMock) that raises a context-overflow until the
+consolidation appears in the sliced history — exercising the real terminal →
+force-close → re-enter path. The chat analogue of D2's phase firing infra.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from reyn.chat.session import _MAX_FORCE_CLOSE_HANDOFFS, ChatMessage
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.services.compaction.engine import ContextOverflowError
+from tests.test_session_router_history_slicing import _make_session, _push
+
+_CONSOL = "CONSOLIDATION-MARK-XYZ"
+
+
+def _has_consolidation(history: list[dict]) -> bool:
+    return any(_CONSOL in str(m.get("content", "")) for m in history)
+
+
+def _capture_events(session) -> list[str]:
+    seen: list[str] = []
+    session._chat_events.add_subscriber(lambda e: seen.append(e.type))
+    return seen
+
+
+def _msg(role: str, text: str) -> ChatMessage:
+    return ChatMessage(role=role, content=text, ts=datetime.now(timezone.utc).isoformat())
+
+
+class _FakeRouterLoop:
+    """Collaborator double for RouterLoop. ``run`` raises a context-overflow
+    until the force-close consolidation appears in the sliced history (then
+    converges); ``_force_close_call`` returns the capped consolidation. With
+    ``always_overflow`` it never converges (the irreducible-message case)."""
+
+    def __init__(self, *args: Any, always_overflow: bool = False, **kwargs: Any) -> None:
+        self.router_model = "fake-model"
+        self.force_close_calls = 0
+        self.always_overflow = always_overflow
+
+    async def run(self, *, user_text: str, history: list[dict]) -> TokenUsage:
+        if self.always_overflow or not _has_consolidation(history):
+            raise ContextOverflowError("simulated context_length too large")
+        return TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+    async def _force_close_call(
+        self, messages: list[dict], *, resolved_model: str
+    ) -> LLMToolCallResult:
+        self.force_close_calls += 1
+        return LLMToolCallResult(
+            content=_CONSOL, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=5, completion_tokens=3),
+        )
+
+
+def _install_fake_loop(monkeypatch, **kw) -> _FakeRouterLoop:
+    fake = _FakeRouterLoop(**kw)
+    monkeypatch.setattr("reyn.chat.router_loop.RouterLoop", lambda *a, **k: fake)
+    return fake
+
+
+# ── firing: handoff fires, installs the consolidation, converges in one ───────
+
+
+@pytest.mark.asyncio
+async def test_handoff_fires_installs_consolidation_and_converges(
+    tmp_path, monkeypatch
+) -> None:
+    """Tier 3a: a forced overflow terminal drives the force-close handoff — it
+    fires the `router_force_close_handoff` event, installs the consolidation, and
+    the re-entry converges in ONE handoff (the by-construction backstop (a))."""
+    session = _make_session(tmp_path)  # viable T_max → force-close engine wired
+    for t in ("U1-old", "A1-old", "U2-old"):
+        _push(session, "user" if t.startswith("U") else "assistant", t)
+    _install_fake_loop(monkeypatch)
+    events = _capture_events(session)
+
+    await session._run_router_loop("new question", "chain-1")
+
+    # The P6 event log (audit truth) shows EXACTLY ONE handoff → converged
+    # in one (the by-construction backstop (a)); the run returned (no raise).
+    assert events.count("router_force_close_handoff") == 1
+    slice_msgs = session._build_history_for_router()
+    assert _has_consolidation(slice_msgs)              # reaches-LLM
+
+
+@pytest.mark.asyncio
+async def test_handoff_cap_raises_no_infinite_loop(tmp_path, monkeypatch) -> None:
+    """Tier 3a: (cap=1 backstop) an irreducible turn (overflows even after
+    consolidation) does NOT infinite-loop — after one handoff the cap raises the
+    genuine dead-end. force_close fired exactly once."""
+    session = _make_session(tmp_path)  # viable T_max → force-close engine wired
+    _push(session, "user", "U1-old")
+    _install_fake_loop(monkeypatch, always_overflow=True)
+    events = _capture_events(session)
+
+    with pytest.raises(ContextOverflowError):
+        await session._run_router_loop("irreducibly huge", "chain-1")
+
+    # bounded: EXACTLY one handoff fired (== _MAX_FORCE_CLOSE_HANDOFFS), then the
+    # cap raised the genuine dead-end — no infinite loop.
+    assert events.count("router_force_close_handoff") == _MAX_FORCE_CLOSE_HANDOFFS
+    assert "router_context_overflow_unrecovered" in events        # genuine dead-end
+
+
+# ── wrap-up-fits: bounded fallback (Fork 1) ──────────────────────────────────
+
+
+class _FailFirstLoop:
+    """_force_close_call overflows on the first ``fail_first`` attempts, then
+    succeeds — exercises the bounded wrap-up fallback shrinking through its
+    decreasing input candidates until one fits."""
+
+    def __init__(self, fail_first: int = 2) -> None:
+        self.attempts = 0
+        self._fail_first = fail_first
+
+    async def _force_close_call(
+        self, messages: list[dict], *, resolved_model: str
+    ) -> LLMToolCallResult:
+        self.attempts += 1
+        if self.attempts <= self._fail_first:
+            raise ContextOverflowError("wrap-up input too large")
+        return LLMToolCallResult(
+            content=_CONSOL, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=5, completion_tokens=3),
+        )
+
+
+@pytest.mark.asyncio
+async def test_wrap_up_bounded_fallback_fits(tmp_path) -> None:
+    """Tier 2: when the richer wrap-up inputs overflow, the bounded fallback
+    shrinks (through its decreasing candidates) until one fits and the
+    consolidation is produced (wrap-up-fits — Fork 1's chat _force_close_call_
+    with_retry analogue)."""
+    session = _make_session(tmp_path, t_max=2000)
+    for t in ("U1", "A1", "U2", "A2"):
+        _push(session, "user" if t.startswith("U") else "assistant", t)
+    loop = _FailFirstLoop(fail_first=2)
+    out = await session._force_close_wrap_up(loop, resolved_model="m")
+    assert out == _CONSOL
+    assert loop.attempts == 3  # 2 over-large candidates fell back, 3rd fit
+
+
+class _AlwaysOverflowWrapUp:
+    async def _force_close_call(self, messages, *, resolved_model):
+        raise ContextOverflowError("overflow even at summary-only")
+
+
+@pytest.mark.asyncio
+async def test_wrap_up_sub_viable_raises(tmp_path) -> None:
+    """Tier 2: if even summary-only overflows, the model is RUNTIME sub-viable →
+    _force_close_wrap_up raises (the handoff loop surfaces it as a dead-end)."""
+    session = _make_session(tmp_path, t_max=2000)
+    _push(session, "user", "U1")
+    with pytest.raises(ContextOverflowError):
+        await session._force_close_wrap_up(_AlwaysOverflowWrapUp(), resolved_model="m")
+
+
+# ── install: covering consolidation + covered turns dropped (reaches-LLM) ─────
+
+
+@pytest.mark.asyncio
+async def test_force_close_handoff_installs_covering_consolidation(tmp_path) -> None:
+    """Tier 2: _force_close_handoff (running the REAL _force_close_wrap_up against
+    a fake loop) installs a covers-all force-close summary (firing F2a's reset) —
+    the consolidation reaches the slice and the covered raw turns are dropped; the
+    P6 event fires."""
+    session = _make_session(tmp_path, t_max=2000)
+    session._append_history(_msg("user", "U1-covered"))
+    session._append_history(_msg("assistant", "A1-covered"))
+    events = _capture_events(session)
+
+    await session._force_close_handoff(loop=_FakeRouterLoop(), user_text="x")
+
+    slice_blob = "\n".join(
+        str(m.get("content", "")) for m in session._build_history_for_router()
+    )
+    assert _CONSOL in slice_blob                # consolidation reaches the slice
+    assert "U1-covered" not in slice_blob        # covered raw turns dropped
+    assert "router_force_close_handoff" in events


### PR DESCRIPTION
**[e2e-coder]** — PR-F2b of the #1092 force-close wave — **the load-bearing piece** (the chat-axis handoff). Stands on F2a's durable covers-respecting slice (#1283, merged). After this, only F3 (plan coverage-verify + the C2→`try_build` phase-uniformity retrofit + 3-axis verify) closes the wave.

## What

When chat's reactive `retry_loop` exhausts even at its floor — the `UnrecoveredError` terminal (`session.py`) that used to dead-end with `_ContextOverflowError` — the session now **force-closes** instead of raising: consolidate the working context into a capped summary and install it covers-all → fire F2a's reset so the re-entry slices `[consolidation] + the new turn`, not the raw head/tail that overflowed. Chat continues past a turn that won't fit.

- `_run_router_loop` wraps the run+retry in a **bounded force-close handoff loop**; the run+retry is extracted to `_router_run_with_shrink` (raises `_ContextOverflowError` at the terminal, **no** unrecovered event — the caller emits it only on actual give-up, so a recoverable handoff isn't mislogged as a dead-end).
- `_force_close_handoff`: consolidate (capped) + install a covers-all summary with the dedicated `consolidation` field (fires F2a) + emit P6 `router_force_close_handoff`.
- `_force_close_wrap_up` (**Fork 1 — wrap-up-fits**): the wrap-up call made to FIT by a bounded fallback shrinking the input `[summary+raw_middle+tail] → [summary+tail] → [summary]` — the chat analogue of phase's `_force_close_call_with_retry` (chat's wrap-up runs *outside* `retry_loop`). If even summary-only overflows, the model is **runtime** sub-viable → raise (distinct from the config-time `try_build`=None gate — the engine IS wired here).

## Termination (lead-coder's #5, resolved)

By construction (F1 `max_tokens` cap + F2a reset) a normal turn converges in **ONE** handoff: post-handoff `history = consolidation (≤ output_reserve < threshold)`, so `[consolidation] + new_msg` fits iff the new message fits the post-consolidation budget. `_MAX_FORCE_CLOSE_HANDOFFS=1` backstops the only non-converging input — a single new message too large to ever fit — by raising the genuine dead-end (no infinite loop). Chat's tight analogue of phase's `max_phase_visits` (1 vs 25). A sub-viable model (reserve `None`) also dead-ends cleanly.

## Test plan — the 4 non-negotiables

`tests/test_force_close_chat_handoff_1092.py` (5), driven through the **real** `retry_loop`+handoff with a hand-written fake RouterLoop (a collaborator double, **not** a mock):
- [x] **(i) reaches-LLM** — the handoff installs the consolidation and it reaches the re-entry slice
- [x] **(ii) firing** — a forced terminal fires `router_force_close_handoff` and converges in ONE handoff (asserted on the **event log** = audit truth)
- [x] **(iii) wrap-up-fits** — the bounded fallback shrinks until it fits; summary-only overflow → sub-viable raise
- [x] **(iv) oversized → cap raises** — an irreducible turn does NOT infinite-loop; exactly one handoff then the genuine dead-end

**Falsification:**
- [x] handoff skips the install → the firing test FAILS (no reaches-LLM / no convergence)
- [x] wrap-up single-candidate (no fallback) → the wrap-up-fits test FAILS

**Gate:**
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` — pass (asserts moved to the event log, not call-counts)
- [x] 987 chat/router/retry/compaction tests pass unchanged (the `_run_router_loop` refactor preserves the non-overflow + retry-recovery behavior)
- [x] `pytest -q` from rootdir — **6823 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref` — verified identical on clean main without this commit, CI-green #1203, orthogonal to this diff)

Refs #1092
