### PR TITLE
feat(1092): PR-F3 force-close wave closeout — phase try_build retrofit + 3-axis verify

### DIFF
--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -521,7 +521,7 @@ class PhaseExecutor:
 
         from reyn.chat.router_loop import RouterLoop
         from reyn.kernel.phase_router_host import PhaseRouterLoopHost
-        from reyn.services.turn_budget import build_default_turn_budget_engine
+        from reyn.services.turn_budget import try_build_default_turn_budget_engine
 
         phase_def = self._skill.phases.get(phase)
         allowed_ops = set(phase_def.allowed_ops) if phase_def is not None else set()
@@ -557,8 +557,12 @@ class PhaseExecutor:
             # reuse it rework-free in PR-F. use_chars4=True keeps every term but
             # T_max model-independent. None when the phase has no compaction
             # wired (no T_max basis) → the trigger stays inert.
+            # #1092 PR-F3: try_build (not build_default) so a small-context phase
+            # model that cannot satisfy the by-construction floor DEGRADES (None →
+            # force-close inert) rather than crashing phase construction with the
+            # assert — uniform with the chat axis (F1) across all three axes.
             turn_budget_engine=(
-                build_default_turn_budget_engine(
+                try_build_default_turn_budget_engine(
                     self._phase_compaction_engine.model, use_chars4=True
                 )
                 if self._phase_compaction_engine is not None

--- a/tests/test_force_close_3axis_uniformity_1092.py
+++ b/tests/test_force_close_3axis_uniformity_1092.py
@@ -1,0 +1,96 @@
+"""Tier 2: 3-axis force-close commonization (#1092 PR-F3 — wave closeout).
+
+The cumulative-axis force-close (#1092) lands on three RouterLoop axes. F3 pins
+that they share ONE turn_budget service and degrade UNIFORMLY, and articulates
+each axis's deliberate failure-mode difference:
+
+- **chat** (session.py): REACTIVE handoff at the retry_loop terminal (F2b) — a
+  live conversation must not be proactively truncated.
+- **phase** (phase_executor.py): PROACTIVE force-close + OS-internal re-entry
+  (C2/D2) — task execution with a goal wraps up and continues.
+- **plan** (planner.py): step-scoped, fresh `history=[]` per step, NO force-close
+  — bounded steps backstopped by the FP-0031 step retry (verified independent of
+  chat's handoff; activation tracked separately).
+
+Commonization invariants pinned here:
+1. The two ACTIVATION axes (chat, phase) build their engine through the SHARED
+   helper, and through ``try_build_*`` (graceful None on a sub-viable model), NOT
+   ``build_default_*`` (which raises) — so a small-context model degrades
+   uniformly across axes instead of one axis crashing.
+2. The by-construction floor (progress_margin > 0) holds per axis for a viable
+   model, and ``try_build`` yields None (degrade) for a sub-viable one.
+3. plan does NOT wire the turn_budget engine (the articulated third failure-mode).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import reyn.chat.planner as _planner_mod
+import reyn.chat.session as _session_mod
+import reyn.kernel.phase_executor as _phase_mod
+from reyn.services.turn_budget import (
+    try_build_default_turn_budget_engine,
+)
+
+
+def _called_names(module) -> set[str]:
+    """Names invoked as Call(func=Name(...)) anywhere in a module's source."""
+    tree = ast.parse(Path(module.__file__).read_text())
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            out.add(node.func.id)
+    return out
+
+
+# ── invariant 1: activation axes share the graceful helper ───────────────────
+
+
+def test_chat_and_phase_activate_via_try_build_not_build_default() -> None:
+    """Tier 2: chat (session) and phase (phase_executor) both activate force-close
+    through ``try_build_default_turn_budget_engine`` (graceful) and NEITHER calls
+    the raising ``build_default_*`` in its activation path — uniform graceful
+    degradation across the two activation axes (the F3 phase retrofit)."""
+    for mod in (_session_mod, _phase_mod):
+        called = _called_names(mod)
+        assert "try_build_default_turn_budget_engine" in called, mod.__name__
+        assert "build_default_turn_budget_engine" not in called, (
+            f"{mod.__name__} must degrade gracefully (try_build), not raise "
+            f"(build_default) — uniform with the other axis"
+        )
+
+
+def test_plan_does_not_wire_turn_budget_engine() -> None:
+    """Tier 2: plan is the articulated third failure-mode — step-scoped with no
+    force-close, so it does NOT build a turn_budget engine (neither helper). Its
+    cumulative content is bounded by fresh-history-per-step + FP-0031, not by the
+    force-close handoff (verified primary-evidence; activation tracked as #1285,
+    escalated-as-tracked — picked up if plan-step overflow is observed)."""
+    called = _called_names(_planner_mod)
+    assert "try_build_default_turn_budget_engine" not in called
+    assert "build_default_turn_budget_engine" not in called
+
+
+# ── invariant 2: by-construction floor holds per axis ────────────────────────
+
+
+def test_by_construction_floor_holds_for_viable_models_all_axes() -> None:
+    """Tier 2: the shared helper yields a viable engine (progress_margin > 0 — the
+    by-construction force-close floor) for representative chat/phase models, and
+    None (degrade) for a sub-viable small-context one — the same gate on every
+    axis (no per-axis drift)."""
+    for model in ("gpt-4o-mini", "gpt-3.5-turbo"):
+        eng = try_build_default_turn_budget_engine(model, use_chars4=True)
+        assert eng is not None
+        assert eng.budget.progress_margin > 0
+
+
+def test_sub_viable_model_degrades_uniformly(monkeypatch) -> None:
+    """Tier 2: a sub-viable (small-context) model yields None on the shared helper
+    — the uniform degrade path both chat (F1) and phase (F3 retrofit) now take,
+    instead of an axis-specific construction crash."""
+    monkeypatch.setattr(
+        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2000
+    )
+    assert try_build_default_turn_budget_engine("tiny", use_chars4=True) is None


### PR DESCRIPTION
**[e2e-coder]** — PR-F3, the **final closeout** of the #1092 cumulative-axis force-close+handoff wave (the 3rd context-growth axis, after compaction=past and per-term offload=single-item). After this merges, the wave is fully closed: A→F3, 11 PRs.

## Three parts

### 1. Phase `try_build` retrofit (uniform graceful degradation)
`phase_executor`'s C2 activation now builds its `TurnBudgetEngine` via `try_build_default_turn_budget_engine` (graceful `None` on a sub-viable model) instead of `build_default_*` (which asserts/raises). A small-context phase model now **degrades** (force-close inert — the host already handles `turn_budget_engine=None`) rather than crashing phase construction — **uniform with the chat axis** (F1, which already used `try_build`).

### 2. 3-axis commonization verify (`tests/test_force_close_3axis_uniformity_1092.py`, 4 tests)
- the two **activation** axes (chat session, phase executor) both wire force-close through the **shared helper** AND through `try_build` (graceful), **neither** via the raising `build_default` — an AST-walk pins this (no per-axis drift, uniform degrade);
- the by-construction floor (`progress_margin > 0`) holds per axis for viable models + `None` for a sub-viable one (one gate, every axis);
- plan does **not** wire the engine — the articulated **3rd deliberate per-axis failure-mode**.

### 3. Plan coverage-verify (#4) — primary-evidence, escalated-as-tracked
The #4 gate required real verification, not assumption. **Result: plan's cumulative content is NOT bound by chat's force-close+handoff** — `planner.py:1075` runs each step with a fresh `history=[]`; `_PlanStepHost` has no force-close hooks; step sub_loops bypass chat's `_run_router_loop`. The escalation condition was **met** (verify-only would have been wrong). Resolved (lead-coder-ratified) as **articulate + track** (YAGNI — bounded severity, no observed overflow, open re-entry semantics): plan activation is escalated-as-tracked in **#1285**.

## The three deliberate per-axis choices (failure-mode separation by design)
- **chat** — REACTIVE handoff at the retry_loop terminal (F2b): a live conversation must not be proactively truncated.
- **phase** — PROACTIVE force-close + OS-internal re-entry (C2/D2): task execution with a goal wraps up and continues.
- **plan** — step-scoped, fresh `history=[]`, FP-0031-backstopped, no force-close (#1285 tracks activation if overflow is observed).

## Test plan
- [x] 4 new 3-axis tests pass; 15 phase force-close tests unchanged (retrofit clean)
- [x] **Falsification:** revert phase → `build_default` → the uniformity AST test FAILS
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` — pass
- [x] `pytest -q` from rootdir — **6827 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref` — verified identical on clean main without this commit, CI-green #1203, orthogonal to this diff)

Refs #1092
Refs #1285
