### PR TITLE
feat(1200): PR-F1 chat FS-seam backend injection (additive)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1248,6 +1248,13 @@ class ChatSession:
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
         sandbox_config: "SandboxConfig | None" = None,
+        # #1200 PR-F1 (agent-level-uniform backend, FS seam): the agent's
+        # EnvironmentBackend INSTANCE, threaded to the chat Workspace so chat's
+        # file ops run on the SAME backend as the OSRuntime path (and plan, which
+        # delegates tool exec to chat via _PlanStepHost). None → HostBackend (the
+        # workspace's own default) → unchanged behaviour. The sibling exec seam
+        # (sandbox_backend string via sandbox_config) already flows agent-level.
+        environment_backend: "EnvironmentBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
         embedding_config: "EmbeddingConfig | None" = None,
@@ -1284,6 +1291,10 @@ class ChatSession:
         # Plumbed through to spawned Agents so sandboxed_exec backend selection
         # honors the operator's declared policy.
         self._sandbox_config = sandbox_config
+        # #1200 PR-F1: agent EnvironmentBackend instance for the chat FS seam
+        # (passed to the router Workspace in make_router_op_context). None →
+        # HostBackend default.
+        self._environment_backend = environment_backend
         # Issue #364 — multi-modal cluster: media-size gate config plumbed
         # through to spawned Agents AND to the router host adapter (=
         # chat-router web__fetch / file__read / mcp paths).
@@ -4712,6 +4723,9 @@ class ChatSession:
             events=self._chat_events,
             permission_resolver=self._perm,
             skill_name="chat_router",
+            # #1200 PR-F1 (FS seam): run chat file ops on the agent's
+            # EnvironmentBackend instance (None → Workspace's HostBackend default).
+            environment_backend=self._environment_backend,
         )
         return OpContext(
             workspace=workspace,

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -61,6 +61,13 @@ class Workspace:
         self._perm = permission_resolver
         self._skill_name = skill_name
 
+    @property
+    def backend(self) -> "EnvironmentBackend":
+        """The EnvironmentBackend this workspace's IO runs on (#1200): the
+        injected instance, or the default HostBackend. Read-only — for wiring
+        verification (e.g. confirming chat/plan/phase share one agent backend)."""
+        return self._backend
+
     def resolve_artifact_handle(self, handle: str) -> Path:
         """Resolve a state_dir-relative artifact handle to an absolute path.
 

--- a/tests/test_1200_chat_fs_backend.py
+++ b/tests/test_1200_chat_fs_backend.py
@@ -1,0 +1,47 @@
+"""Tier 2: chat FS-seam backend injection (#1200 PR-F1, additive).
+
+#1200 threads the agent's EnvironmentBackend INSTANCE to the chat axis so chat
+file ops run on the SAME backend as the OSRuntime path (and plan, which delegates
+tool exec to chat via _PlanStepHost). F1 is the FS seam: ChatSession gains an
+``environment_backend`` param → its router Workspace runs IO on it. Additive —
+None falls back to the workspace's HostBackend default (unchanged behaviour); the
+exec seam (sandbox_backend string via sandbox_config) already flows agent-level,
+so this is safe-to-land regardless of the (pending) exec instance-vs-string call.
+
+No mocks: real ChatSession + real EnvironmentBackend instances.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.chat.session import ChatSession
+from reyn.environment.host_backend import HostBackend
+from reyn.events.state_log import StateLog
+
+
+def _session(tmp_path: Path, *, environment_backend=None) -> ChatSession:
+    return ChatSession(
+        agent_name="b",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        environment_backend=environment_backend,
+    )
+
+
+def test_chat_workspace_uses_injected_backend(tmp_path) -> None:
+    """Tier 2: the agent EnvironmentBackend instance reaches the chat router
+    Workspace (identity) — the FS seam fix."""
+    agent_backend = HostBackend()
+    session = _session(tmp_path, environment_backend=agent_backend)
+    ws = session._make_router_op_context().workspace
+    assert ws.backend is agent_backend          # the SAME injected instance
+
+
+def test_chat_workspace_defaults_to_host_backend(tmp_path) -> None:
+    """Tier 2: with no injected backend the Workspace keeps its HostBackend
+    default — additive, behaviour unchanged (safe-to-land)."""
+    session = _session(tmp_path)
+    ws = session._make_router_op_context().workspace
+    assert isinstance(ws.backend, HostBackend)
+    # and it is NOT some specific foreign instance (default-constructed).
+    assert ws.backend is not HostBackend()       # distinct default instance


### PR DESCRIPTION
**[e2e-coder]** — PR-F1 of #1200 (agent-level-uniform backend injection). Flow-trace + staging lead-coder-ratified (#1200 issuecomment-4619045277 / -4619056401). F1 is the **FS seam**, additive.

## What

The flow-trace refined the scope to a **single seam**: exec (`sandbox_backend` string via `sandbox_config`) already flows agent-level, and plan has no own backend (`_PlanStepHost` delegates all tool exec to chat) — so the only real gap is the **FS seam: the agent's `EnvironmentBackend` instance never reached chat's `Workspace`**.

- `ChatSession.__init__` gains an `environment_backend` param, threaded to the router `Workspace` in `_make_router_op_context`. Chat file ops now run on the **same** backend as the OSRuntime path (and plan inherits chat via delegation).
- `None` → the Workspace's `HostBackend` default → **unchanged behaviour**. Inert until an entry point (F2) passes a real backend → **safe-to-land**, and safe regardless of the exec decision.
- `Workspace` gains a read-only `backend` property (public surface for wiring verification — used by this test + the F3 uniformity review-gate).

## Test plan
- [x] Tier 2: the injected agent backend reaches the chat Workspace (identity); `None` keeps the `HostBackend` default (additive)
- [x] **Falsification:** drop the `Workspace(environment_backend=…)` threading → the injection test FAILS
- [x] `ruff` + `tier audit` pass; 123 workspace/session tests unchanged
- [x] `pytest -q` from rootdir — **6829 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref` — CI-green #1203, orthogonal)

## Next (F2 — exec seam, verify done)
I completed the lead-coder-requested `handle_sandboxed_exec` verify: `op_runtime/sandboxed_exec.py:30` = `ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)`; `get_default_backend` **builds per-call (no reuse)** + has **no docker** (Seatbelt/Landlock/Noop only). Chat leaves `ctx.sandbox_backend=None` → rebuild-per-call → **FS≠exec → the exec instance-thread is required** (non-negotiable per the single-shared-sandbox invariant). Low-invasiveness: `OpContext.sandbox_backend` already exists (`context.py:127`) → F2 sets the agent instance in `_make_router_op_context`. Details on #1200.

Refs #1200
