### PR TITLE
feat(1200): PR-F2 chat exec-seam backend injection (additive)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1255,6 +1255,17 @@ class ChatSession:
         # workspace's own default) → unchanged behaviour. The sibling exec seam
         # (sandbox_backend string via sandbox_config) already flows agent-level.
         environment_backend: "EnvironmentBackend | None" = None,
+        # #1200 PR-F2 (exec seam): the agent's SandboxBackend INSTANCE, set on the
+        # chat router OpContext so sandboxed_exec runs on the SAME backend as the
+        # OSRuntime path (sandboxed_exec.py: `ctx.sandbox_backend or
+        # get_default_backend(...)`). REQUIRED — without it chat falls to
+        # get_default_backend (rebuild-per-call, no docker) → a DIFFERENT backend
+        # than the FS seam → single-shared-sandbox violation. For a docker agent
+        # this is the SAME object as environment_backend (DockerEnvironmentBackend
+        # satisfies both protocols). None → unchanged (get_default_backend). This
+        # is the INSTANCE; the `sandbox_backend` STRING (exec-tool gating) still
+        # flows separately via sandbox_config.
+        sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
         embedding_config: "EmbeddingConfig | None" = None,
@@ -1295,6 +1306,10 @@ class ChatSession:
         # (passed to the router Workspace in make_router_op_context). None →
         # HostBackend default.
         self._environment_backend = environment_backend
+        # #1200 PR-F2: agent SandboxBackend instance for the chat exec seam (set
+        # on the router OpContext). None → get_default_backend. The INSTANCE, not
+        # the sandbox_config.backend STRING (exec-tool gating).
+        self._sandbox_backend = sandbox_backend
         # Issue #364 — multi-modal cluster: media-size gate config plumbed
         # through to spawned Agents AND to the router host adapter (=
         # chat-router web__fetch / file__read / mcp paths).
@@ -4736,6 +4751,9 @@ class ChatSession:
             mcp_servers=self._mcp_servers_flat(),
             run_id=None,  # FP-0021: chat router is outside run scope
             agent_id=self._agent_id,  # FP-0016 E
+            # #1200 PR-F2 (exec seam): run chat sandboxed_exec on the agent's
+            # SandboxBackend instance (None → get_default_backend, unchanged).
+            sandbox_backend=self._sandbox_backend,
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/tests/test_1200_chat_fs_backend.py
+++ b/tests/test_1200_chat_fs_backend.py
@@ -19,12 +19,13 @@ from reyn.environment.host_backend import HostBackend
 from reyn.events.state_log import StateLog
 
 
-def _session(tmp_path: Path, *, environment_backend=None) -> ChatSession:
+def _session(tmp_path: Path, *, environment_backend=None, sandbox_backend=None) -> ChatSession:
     return ChatSession(
         agent_name="b",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
         environment_backend=environment_backend,
+        sandbox_backend=sandbox_backend,
     )
 
 
@@ -45,3 +46,42 @@ def test_chat_workspace_defaults_to_host_backend(tmp_path) -> None:
     assert isinstance(ws.backend, HostBackend)
     # and it is NOT some specific foreign instance (default-constructed).
     assert ws.backend is not HostBackend()       # distinct default instance
+
+
+# ── exec seam (#1200 PR-F2): OpContext.sandbox_backend instance ──────────────
+
+
+class _FakeSandboxBackend:
+    """Minimal SandboxBackend double (structural Protocol) for identity wiring."""
+
+    def available(self) -> bool:
+        return True
+
+
+def test_chat_opcontext_uses_injected_sandbox_backend(tmp_path) -> None:
+    """Tier 2: the agent SandboxBackend instance reaches the chat router
+    OpContext (identity) → sandboxed_exec runs on it (`ctx.sandbox_backend or
+    get_default_backend`), the SAME backend as the FS seam (single-shared-sandbox)."""
+    agent_sandbox = _FakeSandboxBackend()
+    session = _session(tmp_path, sandbox_backend=agent_sandbox)
+    ctx = session._make_router_op_context()
+    assert ctx.sandbox_backend is agent_sandbox       # the SAME injected instance
+
+
+def test_chat_opcontext_sandbox_backend_none_by_default(tmp_path) -> None:
+    """Tier 2: with no injected sandbox backend the OpContext leaves it None →
+    sandboxed_exec falls to get_default_backend (unchanged behaviour)."""
+    session = _session(tmp_path)
+    ctx = session._make_router_op_context()
+    assert ctx.sandbox_backend is None
+
+
+def test_one_instance_serves_both_seams(tmp_path) -> None:
+    """Tier 2: (★the single-shared-sandbox invariant) a docker-style backend
+    passed as BOTH environment_backend + sandbox_backend reaches the FS seam
+    (Workspace) AND the exec seam (OpContext) as the SAME object."""
+    one = HostBackend()  # stands in for a DockerEnvironmentBackend (both protocols)
+    session = _session(tmp_path, environment_backend=one, sandbox_backend=one)
+    ctx = session._make_router_op_context()
+    assert ctx.workspace.backend is one          # FS seam
+    assert ctx.sandbox_backend is one            # exec seam — same instance


### PR DESCRIPTION
**[e2e-coder]** — PR-F2 of #1200. The exec seam, completing the load-bearing **wiring**. The deferred per-frontend entry-point activation is a tracked follow-up (below) — **#1200's deliverable is the wiring**; this scope refinement is lead-coder-ratified.

## What

The exec verify (lead-coder-ratified) confirmed chat's exec falls to `get_default_backend` (rebuild-per-call, no docker) when the OpContext has no `sandbox_backend` instance → a **different** backend than the FS seam → single-shared-sandbox violation. F2 threads the agent's `SandboxBackend` **instance**:

- `ChatSession.__init__` gains a `sandbox_backend` **instance** param (distinct from the `sandbox_backend` *string* that flows via `sandbox_config` for exec-tool gating), set on the chat router `OpContext` in `_make_router_op_context`. Chat `sandboxed_exec` now runs on the **same** backend as the FS seam (and the OSRuntime path).
- For a docker agent this is the **same object** as `environment_backend` (F1) — `DockerEnvironmentBackend` satisfies both the `EnvironmentBackend` and `SandboxBackend` protocols; one shared instance serves both seams.
- `None` → unchanged (`get_default_backend`). **Additive / inert**, safe-to-land (same shape as F1).

## Deliverable = wiring (not incomplete — scope-refined)

F1 (FS) + F2 (exec) complete the **in-session wiring**: `ChatSession` threads the agent backend to **both** seams (Workspace + OpContext), and the single-shared-sandbox invariant holds. This is exactly the #1200 goal — *chat-in-container is now **possible*** (a caller can pass one backend and it reaches chat's FS + exec, and plan via `_PlanStepHost` delegation). The wiring is **inert by default** (`None` → `HostBackend`, byte-identical) but is a **verified capability awaiting activation**, not dead code (the #1092 unwired-foundation pattern).

The **per-frontend entry-point activation** (adding `--env-backend` build to cli/chat, web/deps, chainlit, cli/dogfood) is a separate **speculative feature** — there are **zero** container-chat consumers today — so it's **deferred + tracked** (same discipline as the #1092 plan-activation defer): see the tracking note posted to #1200.

## Test plan
- [x] Tier 2: the injected `SandboxBackend` reaches the OpContext (identity); `None` by default
- [x] Tier 2: ★the single-shared-sandbox invariant — one backend passed as BOTH params reaches the FS (Workspace) AND exec (OpContext) seams as the SAME object
- [x] **Falsification:** drop the OpContext `sandbox_backend` threading → the exec identity test FAILS
- [x] `ruff` + `tier audit` pass; `pytest -q` from rootdir — **6832 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal)

## Next
F3 = the `Workspace.backend` / `OpContext` uniformity review-gate test (chat/plan/phase one instance; differ = reject) → #1200 closeout as "injection wired + verified".

Refs #1200