### PR TITLE
fix(swe_bench): verify Step 1 treats already-applied test_patch as success, not apply-failure (#1206)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -114,9 +114,25 @@ The flags layer second-line defenses on top of the preprocessor:
 tolerates off-by-N context line counts, and `--whitespace=fix`
 forgives trailing-space drift.
 
-If `git apply` STILL fails after preprocessor sanitization + robust
-flags, treat this as a verify execution failure (not a test failure):
-set `tests_passed = false` and record the failure in `failure_summary`
+Apply the test_patch **once** — do not re-apply it. A second apply of an
+already-applied patch returns non-zero ("patch does not apply") purely
+because the patch is *already in the tree* (idempotency), NOT because it
+failed to apply; reading that second non-zero as an apply failure is a
+mis-diagnosis.
+
+If `git apply` returns non-zero, FIRST determine whether the patch is
+**already applied** before treating it as a failure — reverse-check it:
+
+```
+git apply --reverse --check .reyn/swe_bench_test.patch
+```
+
+If the reverse-check succeeds (returncode 0), the test_patch is already in
+the tree — **proceed to Step 2 and run the tests**; do NOT set
+`tests_passed = false`. Only a patch that is **neither applicable nor
+already-applied** (the `--reverse --check` also returns non-zero) is a
+genuine verify execution failure (not a test failure): set
+`tests_passed = false` and record the failure in `failure_summary`
 (= include the exact stderr from git apply, NOT a vague "patch failed"
 summary). The tests could not be evaluated, so this is not a pass.
 

--- a/tests/test_swe_bench_verify_idempotency_1206.py
+++ b/tests/test_swe_bench_verify_idempotency_1206.py
@@ -1,0 +1,155 @@
+"""Tier 2: OS/skill invariant — swe_bench verify Step 1 distinguishes an
+already-applied test_patch (idempotency rc≠0) from a genuine apply failure
+(#1206, observed in astropy-13977).
+
+Primary evidence backing (13977 faithful in-container run, from #1206):
+  git apply --3way --recount --whitespace=fix .reyn/swe_bench_test.patch  rc=0  ← APPLIED
+  git apply --3way --recount --whitespace=fix .reyn/swe_bench_test.patch  rc=1  ← re-applied → "patch does not apply" (ALREADY applied)
+  git checkout HEAD -- .../test_quantity.py                               rc=0  ← reverted
+  pytest NEVER run.
+The model applied the test_patch (rc=0), re-applied it, read the second
+rc=1 ("patch does not apply" = idempotency = already applied) as an apply
+*failure*, recorded tests_passed=false + a scary failure_summary, reverted,
+and gave up — so a possibly-correct fix was scored FAIL because the tests
+were never run.
+
+The fix (verify.md Step 1) makes the model idempotency-aware: apply once;
+on a non-zero apply, FIRST reverse-check (`git apply --reverse --check`) —
+rc=0 ⇒ already applied ⇒ proceed to Step 2; only neither-applicable-nor-
+already-applied is a genuine verify-execution failure.
+
+Two layers are pinned here:
+  (a) text-presence invariant — verify.md Step 1 actually carries the
+      idempotency distinction (the prompt-side fix exists);
+  (b) **idiom-correctness** — the `git apply --reverse --check` idiom the
+      instruction relies on is a CORRECT classifier: it returns 0 on an
+      already-applied patch and non-zero on a genuine-fail patch. This is
+      the load-bearing premise of the fix, verified deterministically at
+      the git level WITHOUT an LLM (the right form of the acceptance's
+      "fixture exercising the double-apply path"; a recorded LLM-replay
+      would be tautological for a pure prompt fix). The model-following-
+      the-instruction layer is behavioral = a separate light dogfood.
+
+No mocks. No private-state assertions. (a) reads the on-disk skill file;
+(b) drives a throwaway git repo via subprocess.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_VERIFY_MD = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench" / "phases" / "verify.md"
+)
+
+
+# ── (a) text-presence invariant ──────────────────────────────────────────
+
+
+def test_verify_md_step1_carries_idempotency_distinction() -> None:
+    """Tier 2: verify.md Step 1 distinguishes already-applied from apply-failure."""
+    text = _VERIFY_MD.read_text(encoding="utf-8")
+    # The reverse-check idiom must be present (the deterministic classifier the
+    # instruction tells the model to use before declaring an apply failure).
+    assert "--reverse --check" in text, (
+        "verify.md Step 1 must instruct a reverse-check to detect an "
+        "already-applied test_patch before classifying a non-zero apply as a "
+        "failure (#1206 idempotency gap)."
+    )
+    # The already-applied → proceed (NOT fail) semantics must be stated.
+    lowered = text.lower()
+    assert "already applied" in lowered or "already in the tree" in lowered, (
+        "verify.md must name the already-applied case explicitly."
+    )
+    assert "proceed to step 2" in lowered, (
+        "verify.md must tell the model to proceed to running the tests when the "
+        "patch is already applied, not set tests_passed=false."
+    )
+
+
+# ── (b) idiom-correctness (deterministic, no LLM) ────────────────────────
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    (r / "foo.txt").write_text("line1\n", encoding="utf-8")
+    _git(r, "add", "foo.txt")
+    _git(r, "commit", "-qm", "base")
+    return r
+
+
+# A patch that cleanly applies to the committed foo.txt (adds a line).
+_APPLICABLE_PATCH = (
+    "--- a/foo.txt\n"
+    "+++ b/foo.txt\n"
+    "@@ -1 +1,2 @@\n"
+    " line1\n"
+    "+added line\n"
+)
+
+# A patch whose context does NOT match foo.txt — neither applies forward nor
+# reverse-applies (a genuine apply failure, distinct from already-applied).
+_GENUINE_FAIL_PATCH = (
+    "--- a/foo.txt\n"
+    "+++ b/foo.txt\n"
+    "@@ -1 +1,2 @@\n"
+    " nonexistent context line\n"
+    "+added line\n"
+)
+
+
+def test_reverse_check_classifies_already_applied_vs_genuine_fail(repo: Path) -> None:
+    """Tier 2: `git apply --reverse --check` is a correct already-applied classifier.
+
+    This is the load-bearing premise of the #1206 fix — exercised exactly along
+    the double-apply path the model hit in 13977, deterministically, no LLM.
+    """
+    patch = repo / "test.patch"
+    patch.write_text(_APPLICABLE_PATCH, encoding="utf-8")
+
+    # 1. First apply succeeds (rc=0).
+    first = _git(repo, "apply", str(patch))
+    assert first.returncode == 0, f"first apply should succeed: {first.stderr}"
+
+    # 2. Re-apply fails (rc != 0) — idempotency, NOT a real failure. This is the
+    #    exact second-apply the model misread as an apply failure in 13977.
+    second = _git(repo, "apply", str(patch))
+    assert second.returncode != 0, "re-applying an already-applied patch must fail"
+
+    # 3. The fix's idiom: reverse-check on the already-applied patch SUCCEEDS
+    #    (rc=0) → classifies it as already-applied → model should proceed to Step 2.
+    rev_applied = _git(repo, "apply", "--reverse", "--check", str(patch))
+    assert rev_applied.returncode == 0, (
+        "reverse-check must succeed (rc=0) on an already-applied patch — this is "
+        f"how the fix detects 'already applied'. stderr={rev_applied.stderr}"
+    )
+
+    # 4. A genuine-fail patch (context not in the tree) reverse-checks NON-zero,
+    #    so the idiom does NOT mis-classify a real failure as already-applied.
+    genuine = repo / "genuine.patch"
+    genuine.write_text(_GENUINE_FAIL_PATCH, encoding="utf-8")
+    assert _git(repo, "apply", str(genuine)).returncode != 0, (
+        "the genuine-fail patch must not apply forward"
+    )
+    rev_genuine = _git(repo, "apply", "--reverse", "--check", str(genuine))
+    assert rev_genuine.returncode != 0, (
+        "reverse-check must return non-zero on a genuine-fail patch — otherwise "
+        "the fix would mis-classify a real apply failure as already-applied."
+    )


### PR DESCRIPTION
**[dogfood-coder]** — Fixes #1206. Flow-trace + staging ratified by lead-coder (issue #1206 issuecomment-4619420496 → RATIFY).

## Problem (astropy-13977, primary evidence in #1206)
`verify.md` Step 1 mapped **any** non-zero `git apply` to a verify-execution failure (`tests_passed=false`), without distinguishing an **idempotency rc≠0 ("already applied")** from a genuine apply failure. The model applied the test_patch (rc=0), re-applied it, read the second rc≠0 ("patch does not apply" = *already applied*) as a failure, reverted, and gave up — **pytest never ran**, so a possibly-correct fix scored FAIL.

## Fix (skill-prompt only, WHAT-level, P1/P8-clean)
`verify.md` Step 1 is now idempotency-aware:
- Apply the test_patch **once** — do not re-apply.
- On a non-zero apply, **reverse-check first**: `git apply --reverse --check .reyn/swe_bench_test.patch`. rc=0 ⇒ already applied ⇒ **proceed to Step 2 (run tests)**; do NOT set `tests_passed=false`.
- Only **neither-applicable-nor-already-applied** is a genuine verify-execution failure.
- Convergence guard (≥3 consecutive same-error applies) is **orthogonal and untouched**. `--reverse` is an already-used idiom in this file (post-test revert step).

## Tests (no LLM)
- **(a) Tier-2 text-presence invariant** — `verify.md` Step 1 carries the already-applied distinction. Non-vacuous: the idiom is absent on `origin/main` (0 occurrences) and present here (2).
- **(b) deterministic idiom-correctness (the core)** — `git apply --reverse --check` returns **0 on an already-applied patch** and **non-zero on a genuine-fail patch**, exercised along the exact double-apply path from 13977, at the git level, no LLM. This pins the fix's load-bearing premise (the chosen idiom is a correct classifier). Per lead's steer: a recorded LLM-replay would be tautological for a pure prompt fix; the model-follows-instruction layer is a separate light dogfood.

## Test plan
- [x] New tests pass — `pytest tests/test_swe_bench_verify_idempotency_1206.py` → **2 passed**.
- [x] Idiom-correctness premise verified — (b) confirms reverse-check classifies already-applied (rc=0) vs genuine-fail (rc≠0).
- [x] No regression — `pytest tests/test_swe_bench_skill_load.py tests/test_swe_bench_skill_invariants.py tests/test_swe_bench_phase_convergence_guard.py tests/test_swe_bench_skill_md_placeholder_shape.py` → **28 passed**.
- [x] (a) non-vacuous (absent on origin/main, present here).
- [ ] (skipped — behavioral) LLM-follows-instruction confirmation = light dogfood, deferred per lead's 3-layer steer (idiom-correctness here + instruction-presence here + LLM-following as dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
