### PR TITLE
feat(swe_bench): wire verify→plan re-plan iteration loop + not_locatable propagation (#1204)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/artifacts/apply_state.yaml
+++ b/src/reyn/stdlib/skills/swe_bench/artifacts/apply_state.yaml
@@ -15,6 +15,15 @@ schema:
       type: integer
       minimum: 1
       description: Which attempt number this is (matches the plan.attempt that was executed).
+    not_locatable:
+      type: array
+      items:
+        type: string
+      description: >-
+        Anchors of edits that were dropped at apply because their anchor matched
+        no region in the target file (count 0). Recorded so a re-plan can choose
+        different anchors/locations instead of reissuing the same unlocatable
+        edit. Empty when every planned edit was locatable.
   required:
     - instance_id
     - files_edited

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -120,6 +120,13 @@ For non-Python files, skip this step.
 
 Collect the repository-relative paths of all files that were modified.
 
+If your input carries a `not_locatable` list (edits the preprocessor dropped
+because their anchor matched no region in the target file), preserve each
+dropped edit's `anchor` in your output. This hands the unlocatable anchors to a
+possible re-plan so it can choose different anchors instead of reissuing the
+same edit. When the list is absent or empty (every planned edit was locatable),
+record an empty list.
+
 ## When to transition
 
 After all edits are applied (and syntax is clean if applicable), transition to

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -50,6 +50,11 @@ When re-planning (attempt > 1), first read the previous plan and the verify
 failure summary from the workspace.  Avoid repeating edits that already
 failed without changing the approach.
 
+Set this plan's `attempt` to the input `verify_state`'s `attempt` + 1 (a plan
+built from `exploration` is `attempt = 1`). Advancing the counter each re-plan
+is what lets the verify-phase retry limit bound the loop — a plan that does not
+increment would let the cycle run unbounded.
+
 ## Step 2 — Re-read targeted code sections (if needed)
 
 If the verify failure summary points to a code region not covered in the

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -192,15 +192,26 @@ Inspect the test runner's exit code and output and record the verdict:
   record a concise `failure_summary`: which test names failed, the assertion
   error messages, and any relevant tracebacks.
 
+When `tests_passed = false`, check the input for a non-empty `not_locatable`
+list (anchors the apply phase could not locate in the target file). When it is
+non-empty you MUST **append** those anchors to `failure_summary` — for example:
+"Not locatable: <anchors>. Choose different anchors or edit locations." Append
+this to the test-failure diagnosis; do not replace it. This hands the
+unlocatable anchors to a revised fix so it does not reissue the same edit.
+
 Whether the tests passed or failed, the verdict is captured in `tests_passed`
-+ `failure_summary` — the downstream phase consumes that outcome. The skill
-always carries the best-effort patch forward, even when the tests did not pass
++ `failure_summary`, which the downstream phase consumes. The skill always
+carries the best-effort patch forward, even when the tests did not pass
 (matching SWE-bench harness expectations).
+
+When `tests_passed = false` and `attempt` is still below the maximum (3), the
+fix did not work but attempts remain: the outcome warrants revising the fix and
+trying again, so make `failure_summary` precise enough to guide that revision.
 
 ## Retry limit
 
-If `attempt` has reached the maximum allowed (3 by default), set
-`tests_passed = false` and record the best-effort outcome — the skill reports
+If `attempt` has reached the maximum allowed (3 by default), the revision
+budget is spent: record the best-effort outcome as final — the skill reports
 the patch even when the tests did not pass, matching SWE-bench harness
 expectations.
 

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -19,8 +19,8 @@ graph:
   setup:   [explore]
   explore: [plan]
   plan:    [apply]
-  apply:   [verify, plan]
-  verify:  [report]
+  apply:   [verify]
+  verify:  [report, plan]
   report:  []
 routing:
   intents: [task]

--- a/tests/test_swe_bench_replan_loop_1204.py
+++ b/tests/test_swe_bench_replan_loop_1204.py
@@ -1,0 +1,129 @@
+"""Tier 2: OS/skill invariant — swe_bench verify→plan re-plan iteration loop
+(#1204, deferred from #1203).
+
+Pins the re-plan loop wiring + the not_locatable propagation that feeds it:
+  - Graph: `verify` routes to BOTH `report` and `plan` (re-plan reachable); the
+    previously-unsatisfiable `apply → plan` edge is removed (apply emits
+    apply_state, plan accepts exploration|verify_state only — a dead edge).
+  - `apply_state` carries a `not_locatable` field (the anchors the apply
+    preprocessor dropped); apply.md instructs carrying them; verify.md MUST
+    append them to `failure_summary` on failure so a re-plan avoids reissuing
+    the same unlocatable edit; plan increments `attempt` so the verify retry
+    limit bounds the loop.
+
+NOTE on determinism: the carry (apply→apply_state) and the fold
+(verify→failure_summary) are LLM-mediated — there is no per-phase deterministic
+postprocessor in the OS (postprocessor is skill-level only; schemas/models.py).
+The full deterministic upgrade is tracked separately. These are faithful-copy
+instructions over already-visible data (degraded-not-broken on omission, bounded
+by the 3-attempt limit), a different class from the #1216 hallucination break —
+so the behavioral fold is verified by a light dogfood, and these Tier-2 tests
+pin the deterministic substrate (graph edges, schema field, instruction
+presence, P1/P8 cleanliness) that the behavior depends on.
+
+No mocks. Uses real load_dsl_skill + on-disk phase-file reads.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.schemas.models import Skill
+
+_SKILL_DIR = (
+    Path(__file__).parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+_SKILL_MD = _SKILL_DIR / "skill.md"
+_SKILL_ROOT = _SKILL_MD.parent.parent.parent  # src/reyn/stdlib/
+_APPLY_MD = _SKILL_DIR / "phases" / "apply.md"
+_VERIFY_MD = _SKILL_DIR / "phases" / "verify.md"
+_PLAN_MD = _SKILL_DIR / "phases" / "plan.md"
+_APPLY_STATE = _SKILL_DIR / "artifacts" / "apply_state.yaml"
+
+
+def _load() -> Skill:
+    return load_dsl_skill(_SKILL_MD, skill_root=_SKILL_ROOT)
+
+
+# ── graph: re-plan edge added, dead apply→plan edge removed ──────────────────
+
+
+def test_verify_routes_to_report_and_plan() -> None:
+    """Tier 2: verify's candidates include BOTH report and plan (re-plan reachable)."""
+    skill = _load()
+    verify_targets = skill.graph.transitions.get("verify", [])
+    assert "report" in verify_targets, "verify must still reach report (terminal)"
+    assert "plan" in verify_targets, (
+        "verify must reach plan for the re-plan loop (the #1204 edge). "
+        f"got: {verify_targets}"
+    )
+
+
+def test_apply_to_plan_dead_edge_removed() -> None:
+    """Tier 2: the unsatisfiable apply→plan edge is removed (apply only reaches verify).
+
+    apply emits `apply_state`; plan accepts only `exploration | verify_state`, so
+    `apply → plan` could never satisfy plan's input_schema — a dead edge. The
+    re-plan loop runs through verify→plan; an all-not-locatable apply still
+    produces a (partial) patch → verify → re-plan.
+    """
+    skill = _load()
+    apply_targets = skill.graph.transitions.get("apply", [])
+    assert "plan" not in apply_targets, (
+        f"the dead apply→plan edge must be removed; got: {apply_targets}"
+    )
+    assert "verify" in apply_targets
+
+
+# ── not_locatable propagation substrate (schema + instructions) ──────────────
+
+
+def test_apply_state_schema_carries_not_locatable() -> None:
+    """Tier 2: apply_state declares a `not_locatable` field (the re-plan input signal)."""
+    text = _APPLY_STATE.read_text(encoding="utf-8")
+    assert "not_locatable" in text, (
+        "apply_state must declare not_locatable so the dropped anchors can flow to a re-plan."
+    )
+
+
+def test_apply_md_carries_not_locatable() -> None:
+    """Tier 2: apply.md instructs carrying the dropped anchors into the output."""
+    text = _APPLY_MD.read_text(encoding="utf-8").lower()
+    assert "not_locatable" in text and "anchor" in text, (
+        "apply.md Step 4 must instruct preserving the not_locatable anchors in the output."
+    )
+
+
+def test_verify_md_must_append_not_locatable_to_failure_summary() -> None:
+    """Tier 2: verify.md MUST-append the not_locatable anchors into failure_summary on failure."""
+    text = _VERIFY_MD.read_text(encoding="utf-8")
+    assert "not_locatable" in text, "verify.md must reference the not_locatable input signal."
+    lowered = text.lower()
+    assert "append" in lowered and "failure_summary" in lowered, (
+        "verify.md must instruct appending the not_locatable anchors to failure_summary "
+        "(append-pattern, preserving the test-failure diagnosis)."
+    )
+
+
+def test_verify_md_has_replan_outcome_guidance() -> None:
+    """Tier 2: verify.md steers toward re-planning while attempts remain (P1/P8: no phase name)."""
+    lowered = _VERIFY_MD.read_text(encoding="utf-8").lower()
+    assert "below the maximum" in lowered or "attempts remain" in lowered, (
+        "verify.md must describe the tests-failed-and-attempts-remain outcome so the OS can "
+        "offer the re-plan candidate."
+    )
+
+
+def test_plan_md_increments_attempt_for_bounding() -> None:
+    """Tier 2: plan.md instructs incrementing attempt so the retry limit bounds the loop."""
+    lowered = _PLAN_MD.read_text(encoding="utf-8").lower()
+    assert "attempt" in lowered and "+ 1" in lowered, (
+        "plan.md must instruct attempt = verify_state.attempt + 1 so the loop is bounded "
+        "by the verify retry limit (an un-incremented attempt loops unbounded)."
+    )
+
+# (P1/P8 "verify.md names no transition phase" is enforced structurally by the OS
+# — a phase only ever picks from OS-offered candidates, never a hardcoded target —
+# and is covered behaviorally by the graph-transition tests above; a string-absence
+# grep on the .md is a format-pin, so it is intentionally not asserted here.)

--- a/tests/test_swe_bench_skill_load.py
+++ b/tests/test_swe_bench_skill_load.py
@@ -149,14 +149,17 @@ def test_swe_bench_graph_transitions():
     assert t.get("setup") == ["explore"], f"setup transitions: {t.get('setup')}"
     assert t.get("explore") == ["plan"], f"explore transitions: {t.get('explore')}"
     assert t.get("plan") == ["apply"], f"plan transitions: {t.get('plan')}"
-    assert sorted(t.get("apply", [])) == ["plan", "verify"], (
+    # apply → verify only: the former apply → plan edge was un-satisfiable
+    # (apply emits apply_state; plan accepts exploration|verify_state) and was
+    # removed when the re-plan loop landed — re-plan runs through verify → plan.
+    assert sorted(t.get("apply", [])) == ["verify"], (
         f"apply transitions: {t.get('apply')}"
     )
-    # verify → report only: report is the sole satisfiable transition (it
-    # accepts verify_state). The former verify → apply edge required a `plan`
-    # artifact (edits/rationale) that verify cannot emit (un-satisfiable); the
-    # re-plan loop is a tracked enhancement, not yet wired.
-    assert sorted(t.get("verify", [])) == ["report"], (
+    # verify → {report, plan}: report terminates with the best-effort patch;
+    # plan is the re-plan loop edge (verify emits verify_state, which plan
+    # accepts) — taken on test failure while attempts remain, bounded by the
+    # verify retry limit.
+    assert sorted(t.get("verify", [])) == ["plan", "report"], (
         f"verify transitions: {t.get('verify')}"
     )
     assert t.get("report", []) == [], f"report transitions: {t.get('report')}"


### PR DESCRIPTION
**[dogfood-coder]** — Fixes #1204 (last swe_bench self-drive item). Flow-trace + staging + design ratified by lead-coder (issue #1204 issuecomment-4619673576 → 4619713369): Q-A=remove apply→plan, Q-B=propagate not_locatable, fold=append-pattern.

## What this wires
On test failure with attempts remaining, the skill now **re-plans** from `failure_summary`, re-applies, and re-verifies — bounded by the attempt limit — instead of terminating at `report` on the first failure (the old behavior from #1203).

## Changes
- **Graph** (`skill.md`): `verify:[report]` → `verify:[report, plan]` (re-plan edge; verify emits `verify_state`, plan accepts it = satisfiable). Removed the **dead** `apply:[verify, plan]` → `apply:[verify]` edge (apply emits `apply_state`; plan accepts `exploration|verify_state` only = un-satisfiable). Re-plan runs through verify→plan, so an all-not-locatable apply still produces a partial patch → verify → re-plan. **[Q-A]**
- **not_locatable propagation [Q-B]** — makes apply.md's existing promise ("verify surfaces the not_locatable gap for a re-plan") *real* instead of fiction: `apply_state` += `not_locatable` (anchors the apply preprocessor dropped); apply.md Step 4 carries them; verify.md Step 4 **MUST-appends** them to `failure_summary` on failure (append-pattern — preserves the test diagnosis + adds the anchors); plan already consumes `failure_summary`. Without this a re-plan is blind to the not-locatable failure mode and reissues the same unlocatable anchor, wasting the budget the #1216 drop set up.
- **attempt bounding**: plan.md instructs `attempt = verify_state.attempt + 1` so the verify retry limit (3) actually bounds the loop.

## Determinism caveat (primary-evidence finding)
The carry (apply→apply_state) and fold (verify→failure_summary) are **LLM-mediated** — there is **no per-phase deterministic postprocessor** in the OS (postprocessor is skill-level only: `compiler/parser` + `expander` read it from skill.md frontmatter; `phase_executor` has no postprocessor handling; phase output = normalized LLM artifact, not a working-data merge). These are **faithful-copy instructions over already-visible data** (omission = degraded-not-broken, bounded by 3 attempts) — a different class from the #1216 hallucination break. The full deterministic upgrade (per-phase postprocessor, preprocessor symmetry) is tracked in **#1293**.

## Test plan
- [x] `pytest test_swe_bench_replan_loop_1204` + regression (skill_load [reconciled graph], skill_invariants [reachability], skill_md_placeholder_shape, convergence_guard, drop_not_locatable_1216, apply_region_scaffold_1209) → **47 passed**.
- [x] `test_tier_audit --strict` on new + reconciled test files → **16 OK / 0 errors**.
- [x] Reconciled `test_swe_bench_graph_transitions` to the new topology (apply→verify only, verify→{report,plan}).
- [x] P1/P8: verify.md names no transition target (left to OS-structural enforcement + graph tests; string-absence grep would be a format-pin).
- [ ] (skipped — behavioral) full re-plan loop apply→verify(fail)→plan→apply→verify(pass)→report with attempt bounding + the LLM-mediated carry/fold = light dogfood (deterministic substrate pinned by the Tier-2 tests above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
