### PR TITLE
fix(tui): flush top-level tool-call + skill-activity rows at col 0 to match live (#1245)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -1820,15 +1820,18 @@ class ConversationView(Widget):
         try:
             line1 = row._build_line1()
             line2 = row._build_line2()
-            if row._label_prefix:
-                # Sub-skill row: prefix is the indent — write at col 0.
-                self._write_log(line1)
-                if line2.plain:
-                    self._write_log(line2)
-            else:
-                self._write_body(line1)
-                if line2.plain:
-                    self._write_body(line2)
+            # #1245: flush at col 0 (``_write_log``, no Padding) for ALL rows
+            # so the flushed line lands at the same column as the LIVE widget
+            # (ToolCallRow CSS = ``padding: 0 0`` = col 0). ``_write_body``
+            # would add an 8-cell hanging-indent the live row never had,
+            # jumping the row right at seal (the top-level mismatch tracked
+            # in #1245). Any ``label_prefix`` (sub-skill nesting) is already
+            # baked into the Rich Text by ``_build_line1`` / ``_build_line2``,
+            # so the col-0 write preserves it (prefix = the visual indent) —
+            # this generalises the #1242 prefixed-row fix to top-level rows.
+            self._write_log(line1)
+            if line2.plain:
+                self._write_log(line2)
             row.remove()
         except Exception:
             # Same defensive stance as finish_skill_row: a flush
@@ -1871,7 +1874,12 @@ class ConversationView(Widget):
         row.finish(success=success, reason=reason, aborted=aborted)
         try:
             finished_text = row._build_finished()
-            self._write_body(finished_text)
+            # #1245: flush at col 0 to match the LIVE SkillActivityRow (CSS
+            # ``padding: 0 0``). ``_write_body``'s 8-cell hanging-indent
+            # jumped the finished breadcrumb right at seal. Any
+            # ``label_prefix`` is baked into ``_build_finished``'s Text, so
+            # the col-0 write preserves it.
+            self._write_log(finished_text)
             row.remove()
         except Exception:
             # If anything in the flush path fails, leave the row mounted

--- a/tests/cli/test_tool_call_row_flush_indent.py
+++ b/tests/cli/test_tool_call_row_flush_indent.py
@@ -92,9 +92,9 @@ def test_prefixed_row_line1_starts_with_label_prefix() -> None:
 def test_top_level_row_line1_does_not_start_with_prefix() -> None:
     """Tier 2: _build_line1() on a top-level row has NO label_prefix leading text.
 
-    Verifies the non-prefix path is unchanged: no extra whitespace is
-    prepended by ToolCallRow itself; the hanging-indent comes from the
-    flush path (_write_body Padding) in the conv pane.
+    Verifies the row's own text is col-0 origin (no self-indent). Per #1245
+    the flush path now writes top-level rows via ``_write_log`` (col 0) too,
+    matching the live widget — see ``test_flushed_toplevel_tool_row_lands_at_col0``.
     """
     row = _row_no_prefix()
     line1_plain = row.render_line1().plain
@@ -143,4 +143,63 @@ async def test_flushed_prefixed_row_lands_at_prefix_not_double_indent() -> None:
         assert not line.startswith(" " * 8), (
             f"flushed prefixed row must NOT carry an 8-col hanging indent "
             f"(double-indent regression); got {line!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_flushed_toplevel_tool_row_lands_at_col0() -> None:
+    """Tier 2b: #1245 regression guard — a flushed TOP-LEVEL ToolCallRow lands
+    at col 0, matching the live widget (CSS ``padding: 0 0``), NOT col 8.
+
+    Exercises the real ``_do_flush_tool_call_row`` path. Before #1245 the
+    top-level branch used ``_write_body`` → an 8-cell hanging-indent Padding
+    the live row never had → the row jumped right at seal. Reverting to
+    ``_write_body`` makes the flushed line start with 8 spaces → this FAILS.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        row = _row_no_prefix()
+        conv.mount(row)
+        await pilot.pause()
+        conv._do_flush_tool_call_row(row)
+        await pilot.pause()
+
+        idx = _find_line_containing(log, "bash")
+        line = _line_text(log, idx)
+        # Live ToolCallRow renders at col 0; the flushed line must match.
+        assert not line.startswith(" "), (
+            f"flushed top-level tool row must start at col 0 (no leading "
+            f"space, no 8-cell hanging indent); got {line!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_flushed_skill_row_lands_at_col0() -> None:
+    """Tier 2b: #1245 regression guard — a finished SkillActivityRow flushes at
+    col 0, matching the live widget (CSS ``padding: 0 0``), NOT col 8.
+
+    Before #1245 ``finish_skill_row`` used ``_write_body`` → an 8-cell
+    hanging-indent → the finished breadcrumb jumped right at seal. Reverting
+    to ``_write_body`` makes the flushed line start with 8 spaces → FAILS.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+
+        conv.start_skill_row("run-xyz", "code_review")
+        await pilot.pause()
+        conv.finish_skill_row("run-xyz", success=True)
+        await pilot.pause()
+
+        idx = _find_line_containing(log, "code_review")
+        line = _line_text(log, idx)
+        assert not line.startswith(" "), (
+            f"flushed skill row must start at col 0 (no leading space); "
+            f"got {line!r}"
         )


### PR DESCRIPTION
**[tui-coder]** — top-level tool-call + skill-activity rows を col 0 で flush して live に揃える（#1245、flow-trace-first → lead ratify → impl）

## Why（#1245、flow-trace 確定済）
`ToolCallRow` / `SkillActivityRow` は live で `padding: 0 0`（col 0）描画だが、flush 経路が:
- `_do_flush_tool_call_row` の top-level branch = `_write_body`（8-cell hanging indent）
- `finish_skill_row` = `_write_body`（同上、prefix 分岐なしで全 skill row）

→ seal 時に row が col 0 → col 8 へ **jump**。#1242 は sub-skill（prefixed）tool row のみ `_write_log`(col 0) 化していた。本 PR が top-level tool row + 全 skill row に一般化。

## What changed（approach (A)、lead ratify 済 — issue #1245）
- `_do_flush_tool_call_row`: **unconditional `_write_log`(col 0) に collapse**。`label_prefix`（sub-skill）は `_build_line1/2` に baked 済ゆえ col-0 write で保持（live と同列、#1242 fix を一般化）。
- `finish_skill_row`: `_write_body` → `_write_log`(col 0)。`label_prefix` は `_build_finished` に baked 済。

**機構軸 enumeration**（issue 記載）: (A) flush→col0 [採用: #1242 一貫・live 不変・low blast] / (B) live→col8 [却下: sub-skill nesting 逆転] / (C) no-op [却下]。impl-time check（lead 指摘）= `_build_finished`/`_build_line1` が col0-origin（baked indent なし、prefix のみ baked）を read で確認済。

## Verification（Opus 独立 + falsification）
- ruff clean / tier-audit 0 errors
- flush test file 5 passed
- **falsification-verified**: `_write_log`→`_write_body` に revert すると 3 harness flush test（prefixed / top-level tool / skill）が **FAIL**（flushed 行頭が 8-space になる）、復元で 5 pass = 真の regression guard
- broader `-k conv/tool_call/skill_activity/flush/tui_smoke` = **240 passed**。11 collection errors は**私の diff 起因でない**（9 = `test_force_close_*_1092`[#1092 wave OS lane]、2 = router_loop の `from tests.X import` package quirk）— `conversation.py` 単独 import OK + flush test pass で確認、local-only collection error（CI 別処理）

## Tests（faithful、public surface + falsification）
`tests/cli/test_tool_call_row_flush_indent.py` に追加（true flush-capture、harness で実 flush → RichLog 行頭を public assert）:
- `test_flushed_toplevel_tool_row_lands_at_col0`（top-level ToolCallRow）
- `test_flushed_skill_row_lands_at_col0`（SkillActivityRow finish）
+ line1-invariant test の stale docstring（旧 `_write_body` path 言及）を修正。

## Tier self-check
新 test は Tier 2b（public = RichLog 行頭 col0 を assert、load-bearing UX guarantee ゆえ format-pin でない、private-state 不参照、docstring 1 行目 Tier 宣言）。falsification で guard を実証。

## Test plan
- [x] ruff / tier-audit 0 / flush test 5 passed / falsification（revert→3 fail→復元）
- [x] 11 collection errors が私の diff 起因でないこと確認（conversation.py import OK）
- [x] (skipped — Textual harness が flush-capture で col0 を behavior-level に pin 済、reviewer 環境での目視は substantive にカバー) 実機で skill 実行 → tool/skill breadcrumb が seal 後も col0 で live と揃うことの目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
