### PR TITLE
feat(tui): streaming agent replies commit inline header, grouping captured at stream-start (#1253 Plan A)

### DIFF
--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -418,6 +418,11 @@ class ConversationView(Widget):
     def __init__(self, *, id: str | None = None) -> None:
         super().__init__(id=id)
         self._stream_rows: dict[str, StreamingRow] = {}
+        # Grouping decision captured at stream-START (guardrail ①, #1253).
+        # Maps msg_id → is_new_turn bool, populated in begin_stream and consumed
+        # in end_stream / end_stream_cancelled so the header is written with
+        # stream-start timing (not seal-time).
+        self._stream_new_turn: dict[str, bool] = {}
         self._skill_rows: dict[str, SkillActivityRow] = {}
         # Issue #427 step 4: per-tool_call inline rows keyed by op_id
         # (= dispatch_tool's args_hash, propagated via forwarder OutboxMessage
@@ -1042,6 +1047,7 @@ class ConversationView(Widget):
         symbol: str,
         name_style: str,
         body_text: Text,
+        is_new_turn: bool | None = None,
     ) -> None:
         """Write header + body inline (#646 Claude Code style) with col-8 hanging indent.
 
@@ -1064,12 +1070,22 @@ class ConversationView(Widget):
 
         This is the load-bearing writer for ``render_user_message`` and
         ``_render_agent_markdown`` (plain-text first-line path).
+
+        ``is_new_turn`` (#1253 Plan A guardrail ①):
+          - ``None`` (default): call ``_check_new_turn`` + update
+            ``_last_speaker`` / ``_last_speaker_at`` as usual (non-streaming
+            callers: ``render_user_message``, ``_render_agent_markdown``).
+          - A bool: use it directly. Do NOT call ``_check_new_turn`` (skip its
+            side-effects) and do NOT update ``_last_speaker`` /
+            ``_last_speaker_at`` (the streaming caller already anchored them in
+            ``begin_stream``).
         """
-        now = time.time()
         log = self._log()
-        is_new_turn = self._check_new_turn(speaker, log)
-        self._last_speaker = speaker
-        self._last_speaker_at = now
+        if is_new_turn is None:
+            now = time.time()
+            is_new_turn = self._check_new_turn(speaker, log)
+            self._last_speaker = speaker
+            self._last_speaker_at = now
 
         indent = self._current_body_indent()
 
@@ -1445,10 +1461,23 @@ class ConversationView(Widget):
     # ── streaming support ─────────────────────────────────────────────────────
 
     def begin_stream(self, msg_id: str, agent_name: str = "") -> StreamingRow:
-        """Start a streaming agent message row. Returns the row widget."""
+        """Start a streaming agent message row. Returns the row widget.
+
+        #1253 Plan A (guardrail ①): capture the grouping decision at START
+        so that the inline header written at seal-time reflects the stream-start
+        timing, not the (potentially different) seal timing.  The date-separator
+        and turn-anchor side-effects of ``_check_new_turn`` fire here; the
+        actual header write is deferred to ``end_stream`` via
+        ``_commit_stream_inline``.
+        """
         self._consume_empty_hint()
-        # Same agent-identity styling as _render_agent_markdown (_AMBER).
-        self._maybe_write_header("reyn", _GLYPH_AGENT, "bold " + _AMBER)
+        # Capture grouping decision NOW (stream-start timing) and anchor
+        # _last_speaker / _last_speaker_at so same-window consecutive streams
+        # group correctly.
+        log = self._log()
+        is_new_turn = self._check_new_turn("reyn", log)
+        self._last_speaker = "reyn"
+        self._last_speaker_at = time.time()
         # Pass the current body indent so the streaming row aligns with
         # body text for the current timestamp-toggle state (Fix 2 / A1).
         row = StreamingRow(
@@ -1457,6 +1486,7 @@ class ConversationView(Widget):
             indent=self._current_body_indent(),
         )
         self._stream_rows[msg_id] = row
+        self._stream_new_turn[msg_id] = is_new_turn
         self.mount(row)
         return row
 
@@ -1465,12 +1495,43 @@ class ConversationView(Widget):
         if row is not None:
             row.append(text)
 
+    def _commit_stream_inline(self, full: str, is_new_turn: bool) -> None:
+        """Commit the sealed streaming reply as inline ``HH:MM ⏺ first-line`` form.
+
+        #1253 Plan A: called from ``end_stream`` with the grouping decision
+        captured at stream-START.
+
+        /copy preservation: records the FULL reply in ``_recent_replies`` here
+        (NOT just the rest after the first line) so ``last_reply_text()``
+        returns the whole thing.  Using ``_write_agent_markdown(rest)`` would
+        record only the body minus the first line, which would truncate the
+        /copy result.
+        """
+        # /copy: record full reply first.
+        self._recent_replies.append(full)
+        if len(self._recent_replies) > _RECENT_REPLIES_MAX:
+            self._recent_replies = self._recent_replies[-_RECENT_REPLIES_MAX:]
+
+        first_line_plain = _plain_first_line(full)
+        self._maybe_write_inline_header_body(
+            "reyn", _GLYPH_AGENT, "bold " + _AMBER, Text(first_line_plain),
+            is_new_turn=is_new_turn,
+        )
+
+        body_lines = full.splitlines()
+        if len(body_lines) > 1:
+            rest = "\n".join(body_lines[1:])
+            # Render rest as Markdown at col-8 WITHOUT re-recording in
+            # _recent_replies (already recorded `full` above).
+            self._write_body(RichMarkdown(rest))
+
     def end_stream(self, msg_id: str) -> str:
         """Seal the stream and flush the final content INTO the RichLog inline,
         then remove the transient StreamingRow widget so the bottom of the
         pane stays empty (or holds the next streaming row).
 
-        Replies render full inline regardless of length (Claude-Code-style).
+        Replies render inline as ``HH:MM ⏺ <first-line>`` with grouping
+        captured at stream-start (#1253 Plan A).
         """
         row = self._stream_rows.pop(msg_id, None)
         if row is None:
@@ -1480,9 +1541,11 @@ class ConversationView(Widget):
         row.seal()
         self.stop_thinking()  # unmount inline spinner (turn reply started)
         self.hide_status()
+        # Pop the stream-start grouping decision (default True = new turn).
+        is_new_turn = self._stream_new_turn.pop(msg_id, True)
         if full:
             try:
-                self._write_agent_markdown(full)
+                self._commit_stream_inline(full, is_new_turn)
             except Exception:
                 self._log().write(Text(full))
         self._log().write(Text(""))
@@ -1527,6 +1590,9 @@ class ConversationView(Widget):
         row.seal()
         self.stop_thinking()  # unmount inline spinner (cancelled stream)
         self.hide_status()
+        # Pop (and discard) the stream-start grouping decision so the dict
+        # doesn't leak entries when the stream is cancelled (#1253).
+        self._stream_new_turn.pop(msg_id, None)
         if full:
             # Wave-10 G-F10: stash the partial in the recent-replies ring
             # buffer so ``/copy`` after a cancel returns the fragment the

--- a/tests/cli/test_streaming_inline_header_1253.py
+++ b/tests/cli/test_streaming_inline_header_1253.py
@@ -1,0 +1,208 @@
+"""Tier 2: streaming agent replies commit inline ``HH:MM ⏺ <first-line>`` header (#1253 Plan A).
+
+Design: ``end_stream`` now calls ``_commit_stream_inline`` which writes the
+reply in the same form as the non-streaming ``_render_agent_markdown`` path
+(inline ``HH:MM ⏺ <first-line>``), with grouping decision captured at
+``begin_stream`` time (guardrail ①).
+
+Three invariants tested:
+
+1. **Inline commit**: after begin/append/end_stream the committed RichLog line
+   that contains the reply body starts with ``HH:MM ⏺`` at col 0 (not a
+   separate lone-glyph header line above an indented body).
+
+2. **Grouping regression (guardrail ①)**: two consecutive streamed replies
+   within the grouping window — the second reply's first line is body-at-indent
+   (no fresh ``⏺`` header glyph on the same line as the body text).
+
+3. **/copy preservation**: after a multi-line streamed reply,
+   ``conv.last_reply_text()`` returns the FULL reply including the first line.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from textual.widgets import RichLog
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.conversation import _GLYPH_AGENT
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None,
+        agent_name="test-agent",
+        model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _richlog_lines(conv: ConversationView) -> list[str]:
+    """Plain-text list of every non-empty line in the RichLog."""
+    log = conv._log()
+    return [
+        getattr(strip, "text", "") or ""
+        for strip in getattr(log, "lines", [])
+    ]
+
+
+def _find_first_line_containing(lines: list[str], needle: str) -> int:
+    for i, text in enumerate(lines):
+        if needle in text:
+            return i
+    raise AssertionError(f"text {needle!r} never appeared in RichLog lines: {lines!r}")
+
+
+@pytest.mark.asyncio
+async def test_streaming_end_commits_inline_header() -> None:
+    """Tier 2: end_stream writes ``HH:MM ⏺ <body>`` inline, not a lone glyph above indented body.
+
+    Mirrors the assertion style of
+    ``test_body_hanging_indent.py::test_agent_markdown_body_is_inline_with_header``
+    but via the streaming path.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv._show_timestamps = True
+        row = conv.begin_stream("msg-inline-test", "test-agent")
+        row.append("hello world line one")
+        await pilot.pause()
+
+        conv.end_stream("msg-inline-test")
+        await pilot.pause()
+
+        lines = _richlog_lines(conv)
+        idx = _find_first_line_containing(lines, "hello world line one")
+        line = lines[idx]
+
+        # Inline: the body-containing line must start with HH:MM at col 0.
+        assert re.search(r"^\d{2}:\d{2}", line), (
+            f"streaming inline line must start with HH:MM at col 0; got {line!r}"
+        )
+        # The agent glyph must be on the SAME line as the body text.
+        assert _GLYPH_AGENT in line, (
+            f"agent glyph must be on the same inline line; got {line!r}"
+        )
+        # Must NOT start with spaces (= old indented body on a separate line).
+        assert not line.startswith(" "), (
+            f"inline line must NOT start with spaces (col-0 anchor); got {line!r}"
+        )
+
+        # Verify no standalone lone-glyph line ABOVE the body line.
+        # A lone-glyph line would be a line containing only the timestamp + glyph
+        # (i.e. the glyph is present but the body text is NOT on that line).
+        for i, text in enumerate(lines[:idx]):
+            if _GLYPH_AGENT in text and "hello world" not in text:
+                # This would be the old-style standalone header above the body.
+                assert False, (
+                    f"found a standalone glyph line at [{i}] above body line [{idx}]: "
+                    f"{text!r}\nbody line: {line!r}"
+                )
+
+
+@pytest.mark.asyncio
+async def test_streaming_grouping_captured_at_start() -> None:
+    """Tier 2: second consecutive stream within window groups (guardrail ①).
+
+    Two back-to-back begin/append/end_stream calls within the grouping window.
+    The first reply must have the ``HH:MM ⏺`` header inline.
+    The second reply must NOT have a fresh ``⏺`` glyph on its first body line
+    (it should be grouped = body-at-indent only, no new header).
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv._show_timestamps = True
+
+        # First stream.
+        row1 = conv.begin_stream("msg-group-1", "test-agent")
+        row1.append("first reply body text")
+        await pilot.pause()
+        conv.end_stream("msg-group-1")
+        await pilot.pause()
+
+        # Second stream immediately after (within grouping window).
+        row2 = conv.begin_stream("msg-group-2", "test-agent")
+        row2.append("second reply body text")
+        await pilot.pause()
+        conv.end_stream("msg-group-2")
+        await pilot.pause()
+
+        lines = _richlog_lines(conv)
+
+        # First reply: must have inline HH:MM ⏺ on the same line as the body.
+        idx1 = _find_first_line_containing(lines, "first reply body text")
+        line1 = lines[idx1]
+        assert re.search(r"^\d{2}:\d{2}", line1), (
+            f"first reply must have inline header; got {line1!r}"
+        )
+        assert _GLYPH_AGENT in line1, (
+            f"first reply inline line must have glyph; got {line1!r}"
+        )
+
+        # Second reply: body line should NOT start with HH:MM ⏺ (grouped = body-only).
+        idx2 = _find_first_line_containing(lines, "second reply body text")
+        line2 = lines[idx2]
+        # Grouped: the body line must start with spaces (= hanging-indent Padding),
+        # NOT with HH:MM or the glyph.
+        assert not re.search(r"^\d{2}:\d{2}", line2), (
+            f"second grouped reply must NOT have a fresh HH:MM header; got {line2!r}"
+        )
+        assert _GLYPH_AGENT not in line2, (
+            f"second grouped reply body line must NOT contain glyph (grouped); got {line2!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_streaming_copy_preserves_full_reply() -> None:
+    """Tier 2: last_reply_text() returns the full multi-line reply after end_stream.
+
+    Guards the /copy ring-buffer fix: ``_commit_stream_inline`` records
+    the full reply (including the first line), NOT just the body rest.
+    If only the rest were recorded, the first line would be missing from
+    the /copy result.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        full_text = "First line of reply\nSecond line of reply\nThird line of reply"
+        row = conv.begin_stream("msg-copy-test", "test-agent")
+        row.append(full_text)
+        await pilot.pause()
+
+        conv.end_stream("msg-copy-test")
+        await pilot.pause()
+
+        result = conv.last_reply_text()
+        assert result is not None, "last_reply_text() must be non-None after end_stream"
+        # Full reply including first line must be present.
+        assert "First line of reply" in result, (
+            f"last_reply_text() must include first line; got {result!r}"
+        )
+        assert "Second line of reply" in result, (
+            f"last_reply_text() must include second line; got {result!r}"
+        )
+        assert "Third line of reply" in result, (
+            f"last_reply_text() must include third line; got {result!r}"
+        )
+        # The full text should match exactly (guardrail: not just a subset).
+        assert result == full_text, (
+            f"last_reply_text() must equal the full reply text;\n"
+            f"expected: {full_text!r}\ngot:      {result!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — streaming agent reply を inline header（`HH:MM ⏺ <first-line>`）で commit、grouping は stream-start で capture（#1253 A6 Plan A）

## Why（#1253 A6、flow-trace → lead ratify Plan A）
streaming reply は `begin_stream` で standalone `HH:MM ⏺` header 行を書き `end_stream` で body を col8 に commit → scroll-back で **lone-⏺ header + 別行 body** になり、非streaming（`_render_agent_markdown` の inline `HH:MM ⏺ first-line`）と不整合。Plan A で committed form を inline 統一。

**axis enumeration**（issue #1253）: (a) header→seal [committed inline 必須] / (b) StreamingRow が during-streaming header 担当 [StreamingRow core 改修ゆえ却下=Plan B] / (c)(d)(e) primary-evidence で却下。**Plan A = (a) のみ、during-streaming は headerless + seal-time first-line shift 許容**（lead ratify）。

## What changed（conversation.py、84 行）
- **guardrail① grouping を stream-start で capture**: `begin_stream` が `_check_new_turn`（date-sep/turn-anchor side-effects を start で発火）+ `_last_speaker`/`_last_speaker_at` anchor + `_stream_new_turn[msg_id]` に is_new_turn 保存（header は書かない）。`_maybe_write_inline_header_body` に `is_new_turn: bool|None` param 追加（None=自己判定[非streaming 不変] / bool=与えられた値を使い `_check_new_turn` 再実行も `_last_speaker` 再 anchor もしない）。`end_stream` が captured を pop して適用 → **grouping は seal-time でなく stream-start 基準**。
- **/copy 保全**（flow-trace で catch した seam）: `_commit_stream_inline` が **full reply を `_recent_replies` に append**（`_write_agent_markdown(rest)` だと first-line 欠落ゆえ、body lines 2+ は `_write_body(RichMarkdown(rest))` で render し full を別途記録）→ `last_reply_text()` は完全な reply を返す。
- inline split: first-line plain（`_plain_first_line`）+ rest markdown（= 非streaming と同 layout/trade-off）。
- **guardrail② cancel-path**: `end_stream_cancelled` は `_stream_new_turn.pop` で dict leak 防止、✗ cancelled 表示は温存（cancelled fragment は意図的に差別化、inline 化しない）。

## Verification（Opus 独立 + falsification、guardrail③）
- impl diff = ratify 済 spec と完全一致（全 seam）
- 3 新 test 独立 pass / ruff clean / tier-audit 0
- **falsification-verified（両 load-bearing seam）**: /copy → `append(full)`→`append("")` で copy test FAIL ／ grouping → captured is_new_turn を True 固定で grouping test FAIL、復元で 3 pass = 真の regression guard
- broader `-k stream/conv/copy/group/agent_markdown/smoke/end_stream` = **255 passed**。11 collection errors は私の diff 起因でない（force_close_1092 + router_loop の local-env quirk、main では clean collect = lead が #1295 で独立確認済）
- 非streaming `_render_agent_markdown` 不変（is_new_turn 無指定→None→自己判定、test_body_hanging_indent 全 pass）

## Tests（faithful、public surface + falsification）
`tests/cli/test_streaming_inline_header_1253.py`（3、Textual harness）:
- streaming end が inline `HH:MM ⏺ first-line`（col0、lone-⏺ 行なし）を commit
- grouping captured-at-start（2 連続 streamed reply が window 内で 2nd grouped=header 抑制）
- /copy full reply 保全（`last_reply_text()` == full、first-line 含む）

## Tier self-check
Tier 2b（public = RichLog 行 / `last_reply_text()` で assert、private-state 不参照、format-pin なし、docstring Tier 宣言）。両 seam を falsification で実証。

## Test plan
- [x] ruff / tier-audit 0 / 3 新 test pass / broader 255 passed
- [x] 両 load-bearing seam falsification（/copy + grouping、revert→fail→復元）
- [x] 非streaming 不変（_render_agent_markdown / body_hanging_indent）+ 11 errors が私の diff 起因でないこと確認
- [x] (skipped — Textual harness が inline commit/grouping/copy を behavior-level に pin + falsification 済、reviewer 環境の目視は substantive にカバー) 実機で stream → seal 時 inline header 化、window 内連続 reply の grouping、/copy 完全性を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
