### PR TITLE
feat(1199): PR-S3.1a conjunctive-∩ effective-permission model (additive, unwired)

### DIFF
--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -1,0 +1,205 @@
+"""Effective-permission model — #1199 S3.1 conjunctive-∩ invariant (S3.1a).
+
+The OS-level permission rule (#1115 / #1199 S3.1): a capability is permitted iff
+EVERY permission layer permits it — **effective = ⋂ layers, restrict-only,
+grant-back forbidden**. No layer's deny can be re-granted by another layer; ∩ can
+only narrow.
+
+Four inputs, three ⋂ layers:
+- **agent** (`PermissionDecl` + the default zone): the GRANT layer. Its allow-set
+  is the default zone (layer-0 baseline) ∪ the skill's explicit declarations. The
+  zone is folded in here as the baseline — NOT a separate ∩ restrictor (a
+  separate zone restrictor would cancel the decl grants that intentionally extend
+  beyond the zone; the byte-identical requirement forces zone-as-baseline).
+- **sandbox** (`SandboxPolicy`): runtime caps (paths / network / subprocess / env).
+- **profile** (`AgentProfile`): agent-level allowlists (skills / mcp).
+
+Per #1199 design call (issuecomment-4620567488): Q2 = per-VALUE membership
+conjunction (no materialized intersected sets — `allows(axis, value) = ∀L:
+L.allows(axis, value)`; path scope handled inside each layer's match). Q3 =
+compute per op-context (SandboxPolicy is phase-variable), so build an
+`EffectivePermission` from the live layers at gate time and memoize on the
+context, not in any resolver `__init__`.
+
+**S3.1a is the model + projections only — UNWIRED (byte-identical).** The live
+`PermissionResolver` gates are unchanged; S3.1b switches them to read
+`EffectivePermission.allows`. A layer that does not constrain an axis returns
+``True`` for it (⊤ — it never narrows the ∩).
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol
+
+from reyn.permissions.permissions import (
+    _decl_covers_path,
+    _in_default_read_zone,
+    _in_default_write_zone,
+)
+
+if TYPE_CHECKING:
+    from reyn.chat.profile import AgentProfile
+    from reyn.permissions.permissions import PermissionDecl
+    from reyn.sandbox.policy import SandboxPolicy
+
+
+class CapabilityAxis(Enum):
+    """The canonical capability axes (#1199 Q1: 9 axes; network at host
+    granularity — scheme/port is a deferred follow-up). Every permission layer
+    projects onto these, so the ⋂ is computed on one vocabulary."""
+
+    FILE_READ = "file_read"
+    FILE_WRITE = "file_write"
+    NETWORK_HOST = "network_host"
+    SUBPROCESS = "subprocess"
+    MCP = "mcp"
+    SKILL = "skill"
+    SECRET_WRITE = "secret_write"
+    PYTHON = "python"
+    ENV = "env"
+
+
+class LayerView(Protocol):
+    """One permission layer's projection. ``allows(axis, value)`` answers, for a
+    concrete request value (a path / host / name / (module, function) / env var),
+    whether THIS layer permits it. A layer that does not constrain ``axis``
+    returns ``True`` (⊤) so it never narrows the conjunction."""
+
+    def allows(self, axis: CapabilityAxis, value: Any) -> bool:  # pragma: no cover
+        ...
+
+
+class AgentLayer:
+    """The GRANT layer: the skill's ``PermissionDecl`` over the default-zone
+    baseline. File axes allow the default zone ∪ the declared paths (faithful to
+    ``require_file_read`` / ``require_file_write`` — reuses the same helpers).
+    Startup-approval grants are runtime state, not part of this static
+    projection (S3.1b decides whether to fold them in)."""
+
+    def __init__(self, decl: "PermissionDecl") -> None:
+        self._decl = decl
+
+    def allows(self, axis: CapabilityAxis, value: Any) -> bool:
+        d = self._decl
+        if axis is CapabilityAxis.FILE_READ:
+            return _in_default_read_zone(str(value)) or _decl_covers_path(
+                d.file_read, str(value)
+            )
+        if axis is CapabilityAxis.FILE_WRITE:
+            return _in_default_write_zone(str(value)) or _decl_covers_path(
+                d.file_write, str(value)
+            )
+        if axis is CapabilityAxis.NETWORK_HOST:
+            return any(e.get("host") == value for e in d.http_get)
+        if axis is CapabilityAxis.SUBPROCESS:
+            return bool(d.shell)
+        if axis is CapabilityAxis.MCP:
+            # decl grant: the per-skill mcp list (allowed_mcp is the additional
+            # per-agent allowlist, projected on the profile layer's MCP axis).
+            return value in d.mcp
+        if axis is CapabilityAxis.SECRET_WRITE:
+            return value in d.secret_write
+        if axis is CapabilityAxis.PYTHON:
+            # value = (module, function)
+            return any(
+                (p.module, p.function) == tuple(value) for p in d.python
+            )
+        # SKILL / ENV: the decl does not constrain → ⊤.
+        return True
+
+
+class SandboxLayer:
+    """The RESTRICT layer: ``SandboxPolicy`` runtime caps. An empty path/host list
+    means the policy declares no restriction on that axis (⊤) — restrict-only:
+    a policy narrows only by listing. ``network``/``allow_subprocess`` are the
+    degenerate 2-element lattice (False = ⊥ denies the whole axis)."""
+
+    def __init__(self, policy: "SandboxPolicy | None") -> None:
+        self._policy = policy
+
+    def allows(self, axis: CapabilityAxis, value: Any) -> bool:
+        p = self._policy
+        if p is None:
+            return True  # no sandbox layer → unrestricted
+        if axis is CapabilityAxis.FILE_READ:
+            return not p.read_paths or any(
+                _path_under(str(value), root) for root in p.read_paths
+            )
+        if axis is CapabilityAxis.FILE_WRITE:
+            return not p.write_paths or any(
+                _path_under(str(value), root) for root in p.write_paths
+            )
+        if axis is CapabilityAxis.NETWORK_HOST:
+            return bool(p.network)
+        if axis is CapabilityAxis.SUBPROCESS:
+            return bool(p.allow_subprocess)
+        if axis is CapabilityAxis.ENV:
+            return not p.env_passthrough or value in p.env_passthrough
+        # MCP / SKILL / SECRET_WRITE / PYTHON: sandbox does not constrain → ⊤.
+        return True
+
+
+class ProfileLayer:
+    """The ALLOWLIST layer: ``AgentProfile`` agent-level allowlists. ``None`` means
+    no per-agent restriction (⊤). Generalizes the existing ``allowed_mcp`` ∩
+    precedent (agent-list ∩ project) to the unified model."""
+
+    def __init__(self, profile: "AgentProfile | None") -> None:
+        self._profile = profile
+
+    def allows(self, axis: CapabilityAxis, value: Any) -> bool:
+        pr = self._profile
+        if pr is None:
+            return True
+        if axis is CapabilityAxis.SKILL:
+            return pr.allowed_skills is None or value in pr.allowed_skills
+        if axis is CapabilityAxis.MCP:
+            return pr.allowed_mcp is None or value in pr.allowed_mcp
+        return True  # profile constrains only skill / mcp
+
+
+def _path_under(path_str: str, root: str) -> bool:
+    """True if ``path_str`` is ``root`` or a descendant (resolved). Used for the
+    sandbox path caps (mirrors the recursive-scope match shape)."""
+    from pathlib import Path
+
+    try:
+        p = Path(path_str).expanduser().resolve()
+        r = Path(root).expanduser().resolve()
+    except Exception:
+        return False
+    if p == r:
+        return True
+    try:
+        p.relative_to(r)
+        return True
+    except ValueError:
+        return False
+
+
+class EffectivePermission:
+    """The conjunctive-∩ resolver: a capability is permitted iff EVERY layer
+    permits it. Restrict-only / grant-back forbidden is a STRUCTURAL property of
+    ``all(...)`` — no layer's ``False`` can be overridden. Build per op-context
+    from the live layers (Q3); cheap, no materialized sets (Q2)."""
+
+    def __init__(self, layers: "list[LayerView]") -> None:
+        self._layers = list(layers)
+
+    def allows(self, axis: CapabilityAxis, value: Any) -> bool:
+        return all(layer.allows(axis, value) for layer in self._layers)
+
+    @classmethod
+    def of(
+        cls,
+        *,
+        decl: "PermissionDecl",
+        sandbox_policy: "SandboxPolicy | None" = None,
+        profile: "AgentProfile | None" = None,
+    ) -> "EffectivePermission":
+        """Build from the four inputs (zone folded into the agent layer)."""
+        return cls([
+            AgentLayer(decl),
+            SandboxLayer(sandbox_policy),
+            ProfileLayer(profile),
+        ])

--- a/tests/test_1199_effective_permission.py
+++ b/tests/test_1199_effective_permission.py
@@ -1,0 +1,118 @@
+"""Tier 2: conjunctive-∩ effective-permission model (#1199 S3.1a, unwired).
+
+S3.1a builds the model + projections; it is UNWIRED (the live PermissionResolver
+gates are unchanged — byte-identical). These tests pin the structural invariant
+the model exists to guarantee: effective = ⋂ layers, restrict-only, grant-back
+forbidden — including the ★non-negotiable falsification (removing a layer from
+the ∩ re-grants a denied capability → over-grant).
+"""
+from __future__ import annotations
+
+from reyn.chat.profile import AgentProfile
+from reyn.permissions.effective import (
+    AgentLayer,
+    CapabilityAxis,
+    EffectivePermission,
+    ProfileLayer,
+    SandboxLayer,
+)
+from reyn.permissions.permissions import PermissionDecl
+from reyn.sandbox.policy import SandboxPolicy
+
+AX = CapabilityAxis
+
+
+# ── conjunction: every layer must permit ─────────────────────────────────────
+
+
+def test_capability_permitted_iff_all_layers_permit() -> None:
+    """Tier 2: subprocess is permitted only when BOTH the agent grant AND the
+    sandbox cap allow it — a single layer's deny vetoes."""
+    decl = PermissionDecl(shell=True)                      # agent grants subprocess
+    # agent grants + sandbox allows → permitted
+    eff = EffectivePermission.of(
+        decl=decl, sandbox_policy=SandboxPolicy(allow_subprocess=True)
+    )
+    assert eff.allows(AX.SUBPROCESS, None) is True
+    # agent grants but sandbox caps it → denied (sandbox vetoes)
+    eff2 = EffectivePermission.of(
+        decl=decl, sandbox_policy=SandboxPolicy(allow_subprocess=False)
+    )
+    assert eff2.allows(AX.SUBPROCESS, None) is False
+    # sandbox would allow but agent never granted → denied (agent vetoes)
+    eff3 = EffectivePermission.of(
+        decl=PermissionDecl(shell=False),
+        sandbox_policy=SandboxPolicy(allow_subprocess=True),
+    )
+    assert eff3.allows(AX.SUBPROCESS, None) is False
+
+
+# ── ★the non-negotiable falsification ─────────────────────────────────────────
+
+
+def test_falsification_removing_a_layer_regrants_a_denied_capability() -> None:
+    """Tier 2: (★required) a layer's deny CANNOT be re-granted downstream — and
+    removing that layer from the ∩ makes the over-grant possible, proving the
+    deny is load-bearing (restrict-only is a structural property of ⋂).
+
+    network: agent grants the host, sandbox denies network → effective denies.
+    Drop the sandbox layer → the host is re-granted (over-grant) → FAIL-shape."""
+    decl = PermissionDecl(http_get=[{"host": "api.example.com"}])  # agent grants host
+    sandbox = SandboxPolicy(network=False)                          # sandbox denies network
+
+    full = EffectivePermission.of(decl=decl, sandbox_policy=sandbox)
+    assert full.allows(AX.NETWORK_HOST, "api.example.com") is False  # ∩ denies
+
+    # FALSIFICATION: drop the denying layer from the ∩ → the deny is re-granted.
+    without_sandbox = EffectivePermission([AgentLayer(decl)])
+    assert without_sandbox.allows(AX.NETWORK_HOST, "api.example.com") is True  # over-grant
+
+    # Same shape for a profile deny (skill allowlist):
+    prof = AgentProfile(name="a", allowed_skills=["allowed_skill"])
+    eff = EffectivePermission([AgentLayer(PermissionDecl()), ProfileLayer(prof)])
+    assert eff.allows(AX.SKILL, "blocked_skill") is False
+    assert EffectivePermission([AgentLayer(PermissionDecl())]).allows(
+        AX.SKILL, "blocked_skill"
+    ) is True  # remove profile layer → re-granted
+
+
+# ── zone is the agent-layer baseline (∪), not a separate ∩ restrictor ─────────
+
+
+def test_zone_is_agent_baseline_grants_beyond_zone_survive() -> None:
+    """Tier 2: the default zone is folded into the agent layer (∪ baseline) — a
+    decl grant OUTSIDE the zone is permitted (it is NOT cancelled by a separate
+    zone ∩ restrictor). This is what the byte-identical requirement forces."""
+    # .reyn/ is the default write zone → allowed with no decl grant.
+    agent = AgentLayer(PermissionDecl())
+    assert agent.allows(AX.FILE_WRITE, ".reyn/x.txt") is True
+    # an absolute path outside the zone → needs a decl grant.
+    outside = "/tmp/reyn-s31a-test/out.txt"
+    assert AgentLayer(PermissionDecl()).allows(AX.FILE_WRITE, outside) is False
+    granted = AgentLayer(
+        PermissionDecl(file_write=[{"path": outside, "scope": "just_path"}])
+    )
+    assert granted.allows(AX.FILE_WRITE, outside) is True  # decl grant beyond zone survives
+
+
+# ── unconstrained axis = ⊤ (a layer never narrows axes it doesn't own) ────────
+
+
+def test_unconstrained_axis_is_top() -> None:
+    """Tier 2: a layer returns True for axes it doesn't constrain, so it never
+    narrows the ∩ on those axes (the sandbox doesn't gate skills; the profile
+    doesn't gate files)."""
+    assert SandboxLayer(SandboxPolicy()).allows(AX.SKILL, "any") is True
+    assert ProfileLayer(AgentProfile(name="a")).allows(AX.FILE_WRITE, "/x") is True
+    # None layers are fully ⊤.
+    assert SandboxLayer(None).allows(AX.FILE_WRITE, "/anything") is True
+    assert ProfileLayer(None).allows(AX.MCP, "any-server") is True
+
+
+def test_empty_sandbox_path_list_is_unrestricted() -> None:
+    """Tier 2: an empty sandbox path list declares no restriction on that axis
+    (⊤, restrict-only) — a policy narrows only by listing paths."""
+    assert SandboxLayer(SandboxPolicy(write_paths=[])).allows(AX.FILE_WRITE, "/x") is True
+    assert SandboxLayer(
+        SandboxPolicy(write_paths=["/sandboxed"])
+    ).allows(AX.FILE_WRITE, "/elsewhere") is False


### PR DESCRIPTION
**[e2e-coder]** — PR-S3.1a of #1199 Stage 3 (permission unification). The conjunctive-∩ effective-permission model — **additive + unwired (byte-identical)**. Per the design call (#1199 issuecomment-4620567488); the schema input is #1199 issuecomment-4620543082.

## What

`permissions/effective.py` — the OS-level rule: **effective permission = ⋂ layers, restrict-only, grant-back forbidden.**

- **`CapabilityAxis`** — the 9 canonical axes (Q1; network at host granularity, scheme/port deferred).
- **Three ⋂ layers** projecting the four inputs:
  - **`AgentLayer`** (`PermissionDecl` + default zone) — the GRANT layer. File axes allow the default zone ∪ declared paths, faithful to `require_file_read`/`require_file_write` (reuses `_in_default_*_zone` + `_decl_covers_path`). **The zone is folded in as the layer-0 baseline (∪), NOT a separate ∩ restrictor** — the byte-identical requirement forces this (a zone restrictor would cancel decl grants that intentionally extend beyond it).
  - **`SandboxLayer`** (`SandboxPolicy`) — RESTRICT caps (paths/network/subprocess/env); empty list = no restriction on that axis (⊤, restrict-only).
  - **`ProfileLayer`** (`AgentProfile`) — ALLOWLIST (skills/mcp; `None` = ⊤) — generalizes the existing `allowed_mcp` ∩ precedent.
- **`EffectivePermission.allows(axis, value) = all(L.allows(axis, value))`** — per-VALUE membership conjunction (Q2: no materialized sets, scope inside each match); build per op-context (Q3). A layer returns ⊤ for axes it doesn't constrain → never narrows the ∩. **restrict-only / grant-back-forbidden is a structural property of `all(...)`.**

## Unwired (byte-identical)

The live `PermissionResolver` gates are unchanged — S3.1a is the model + projections only; **S3.1b** switches the gates to read `EffectivePermission`. Zero existing-code changes (the module only imports the existing helpers).

## Test plan

`tests/test_1199_effective_permission.py` (5):
- [x] Tier 2: conjunction — a capability is permitted iff every layer permits (any veto denies)
- [x] Tier 2: **★the required falsification** — removing a layer from the ∩ re-grants a denied capability (over-grant), proving each deny is load-bearing
- [x] Tier 2: zone-as-agent-baseline — decl grants beyond the zone survive (not cancelled)
- [x] Tier 2: unconstrained-axis = ⊤; empty sandbox path list = unrestricted

**Falsification (source):**
- [x] break the conjunction (`all`→`any`) → the conjunction + the ★falsification tests FAIL

**Gate:**
- [x] `ruff` + `tier audit` pass
- [x] `pytest -q` from rootdir — **6856 passed**, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal — and this PR is additive, zero existing-code changes)

## Next
S3.1b = switch the resolver gates to read `EffectivePermission` (the byte-identical cutover). Open design questions for your S3.1b dispatch: path-scope lattice (`recursive ⊐ just_path`), startup-approval folding, the env-axis empty-list semantics vs the sandbox backend's actual enforcement.

Refs #1199
