### PR TITLE
feat(1199): PR-S3.1b-1 require_mcp gate cutover + byte-identical model extensions

### DIFF
--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -71,34 +71,66 @@ class LayerView(Protocol):
 
 class AgentLayer:
     """The GRANT layer: the skill's ``PermissionDecl`` over the default-zone
-    baseline. File axes allow the default zone ∪ the declared paths (faithful to
-    ``require_file_read`` / ``require_file_write`` — reuses the same helpers).
-    Startup-approval grants are runtime state, not part of this static
-    projection (S3.1b decides whether to fold them in)."""
+    baseline, faithful to the ``require_*`` gate logic (reuses the same helpers).
 
-    def __init__(self, decl: "PermissionDecl") -> None:
+    Two pieces of runtime state are folded IN here (#1199 S3.1b ② — NOT a
+    top-level ``approved OR effective`` disjunct, which would let an approval
+    re-grant what a downstream Sandbox/Profile layer denies = a grant-back hole in
+    the full ∩):
+
+    - ``approval_check(axis, value) -> bool``: the startup/config approvals
+      (``_is_config_approved`` / ``_is_path_approved_for``). Folded into the agent
+      allow-set, so ``effective = AgentLayer(…, approvals) ∩ Sandbox ∩ Profile``
+      lets the conjunction restrict approvals too (grant-back forbidden preserved).
+    - ``interactive``: in interactive mode the file decl-grant disjunct is gated
+      off (the user approves at startup, tracked via ``approval_check``); only
+      non-interactive mode honors the declared paths directly (require_file_*).
+    """
+
+    def __init__(
+        self,
+        decl: "PermissionDecl",
+        *,
+        approval_check: "Any" = None,
+        interactive: bool = False,
+    ) -> None:
         self._decl = decl
+        self._approval_check = approval_check
+        self._interactive = interactive
+
+    def _approved(self, axis: CapabilityAxis, value: Any) -> bool:
+        return bool(self._approval_check and self._approval_check(axis, value))
 
     def allows(self, axis: CapabilityAxis, value: Any) -> bool:
         d = self._decl
         if axis is CapabilityAxis.FILE_READ:
-            return _in_default_read_zone(str(value)) or _decl_covers_path(
-                d.file_read, str(value)
+            return (
+                _in_default_read_zone(str(value))
+                or self._approved(axis, value)
+                or (not self._interactive and _decl_covers_path(d.file_read, str(value)))
             )
         if axis is CapabilityAxis.FILE_WRITE:
-            return _in_default_write_zone(str(value)) or _decl_covers_path(
-                d.file_write, str(value)
+            return (
+                _in_default_write_zone(str(value))
+                or self._approved(axis, value)
+                or (not self._interactive and _decl_covers_path(d.file_write, str(value)))
             )
         if axis is CapabilityAxis.NETWORK_HOST:
-            return any(e.get("host") == value for e in d.http_get)
+            return any(e.get("host") == value for e in d.http_get) or self._approved(
+                axis, value
+            )
         if axis is CapabilityAxis.SUBPROCESS:
             return bool(d.shell)
         if axis is CapabilityAxis.MCP:
-            # decl grant: the per-skill mcp list (allowed_mcp is the additional
-            # per-agent allowlist, projected on the profile layer's MCP axis).
-            return value in d.mcp
+            # #1199 S3.1b: faithful to require_mcp (permissions.py:1248+1253) —
+            # the per-skill grant (``decl.mcp``) AND the per-skill allowlist
+            # (``decl.allowed_mcp``: None = no restriction). The per-AGENT
+            # allowlist (AgentProfile.allowed_mcp) is the separate ProfileLayer.
+            in_grant = value in d.mcp
+            in_allowlist = d.allowed_mcp is None or value in d.allowed_mcp
+            return in_grant and in_allowlist
         if axis is CapabilityAxis.SECRET_WRITE:
-            return value in d.secret_write
+            return value in d.secret_write or self._approved(axis, value)
         if axis is CapabilityAxis.PYTHON:
             # value = (module, function)
             return any(
@@ -196,10 +228,13 @@ class EffectivePermission:
         decl: "PermissionDecl",
         sandbox_policy: "SandboxPolicy | None" = None,
         profile: "AgentProfile | None" = None,
+        approval_check: "Any" = None,
+        interactive: bool = False,
     ) -> "EffectivePermission":
-        """Build from the four inputs (zone folded into the agent layer)."""
+        """Build from the four inputs (zone + approvals folded into the agent
+        layer; ② grant-back-safe). Build per op-context (Q3)."""
         return cls([
-            AgentLayer(decl),
+            AgentLayer(decl, approval_check=approval_check, interactive=interactive),
             SandboxLayer(sandbox_policy),
             ProfileLayer(profile),
         ])

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -1243,14 +1243,28 @@ class PermissionResolver:
     async def require_mcp(
         self, decl: PermissionDecl, server: str, bus: RequestBus,
     ) -> None:
-        # PR37: per-agent allowlist check (narrower than project config).
-        # None means no per-agent restriction; list means server must be in it.
-        if decl.allowed_mcp is not None and server not in decl.allowed_mcp:
-            raise PermissionError(
-                f"MCP server {server!r} not in allowed_mcp for caller "
-                f"(agent allowlist exhausted)"
-            )
-        if server not in decl.mcp:
+        # #1199 S3.1b (the migration anchor): the static MCP authority —
+        # decl.mcp ∩ decl.allowed_mcp — now flows through the unified
+        # EffectivePermission model (AgentLayer.MCP), the single conjunctive-∩
+        # source, instead of two inline checks. Byte-identical DECISION; the two
+        # diagnostics below are preserved (same messages + order). Local import
+        # avoids the effective.py → permissions.py circular. The interactive
+        # _approve prompt remains the separate runtime gate (not part of the ∩).
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        if not EffectivePermission([AgentLayer(decl)]).allows(
+            CapabilityAxis.MCP, server
+        ):
+            # PR37: per-agent allowlist check (narrower than project config).
+            if decl.allowed_mcp is not None and server not in decl.allowed_mcp:
+                raise PermissionError(
+                    f"MCP server {server!r} not in allowed_mcp for caller "
+                    f"(agent allowlist exhausted)"
+                )
             raise PermissionError(
                 f"MCP server {server!r} not declared in skill permissions. "
                 f"Add `permissions:\\n  mcp: [{server}]` to the skill.md frontmatter."

--- a/tests/test_1199_s31b_mcp_cutover.py
+++ b/tests/test_1199_s31b_mcp_cutover.py
@@ -1,0 +1,63 @@
+"""Tier 2: S3.1b model extensions + require_mcp cutover (#1199, byte-identical A).
+
+S3.1b-1 extends the S3.1a model to faithfully reproduce the gates (the AgentLayer
+MCP fix + the ② approval-fold + interactive-mode) and cuts over require_mcp (the
+migration anchor) to read EffectivePermission — the existing require_mcp suite
+(tests/test_permissions.py) is the byte-identical decision guard. These tests pin
+the new model behavior, especially the ★② grant-back safety.
+"""
+from __future__ import annotations
+
+from reyn.permissions.effective import (
+    AgentLayer,
+    CapabilityAxis,
+    EffectivePermission,
+    SandboxLayer,
+)
+from reyn.permissions.permissions import PermissionDecl
+from reyn.sandbox.policy import SandboxPolicy
+
+AX = CapabilityAxis
+
+
+def test_agent_layer_mcp_intersects_decl_mcp_and_allowed_mcp() -> None:
+    """Tier 2: AgentLayer.MCP = decl.mcp ∩ decl.allowed_mcp (the S3.1b fix,
+    faithful to require_mcp 1248+1253)."""
+    # in grant + allowlist → permitted
+    assert AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=["fs"])).allows(AX.MCP, "fs")
+    # in grant but allowlist excludes → denied (the decl.allowed_mcp conjunct)
+    assert not AgentLayer(
+        PermissionDecl(mcp=["fs", "web"], allowed_mcp=["fs"])
+    ).allows(AX.MCP, "web")
+    # allowlist None → no per-skill filter, decl.mcp only
+    assert AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=None)).allows(AX.MCP, "fs")
+    # not in decl.mcp → denied even if allowlist includes it
+    assert not AgentLayer(PermissionDecl(mcp=[], allowed_mcp=["fs"])).allows(AX.MCP, "fs")
+    # allowlist=[] blocks all
+    assert not AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=[])).allows(AX.MCP, "fs")
+
+
+def test_approval_folded_inside_agent_layer_is_restricted_by_conjunction() -> None:
+    """Tier 2: (★② grant-back safety) an approval folded INTO the agent layer does
+    NOT re-grant what a downstream Sandbox/Profile layer denies — because it's
+    inside the ∩, not a top-level `approved OR effective` disjunct. This is the
+    security property the ② correction protects."""
+    out = "/outside/zone/x.txt"
+    approve = lambda axis, value: axis is AX.FILE_WRITE and value == out  # noqa: E731
+    agent = AgentLayer(PermissionDecl(), approval_check=approve)
+    # the agent layer alone honors the approval
+    assert agent.allows(AX.FILE_WRITE, out) is True
+    # but a sandbox restricting writes to /sandboxed vetoes — the ∩ DENIES.
+    sandbox = SandboxLayer(SandboxPolicy(write_paths=["/sandboxed"]))
+    assert EffectivePermission([agent, sandbox]).allows(AX.FILE_WRITE, out) is False
+    # (a top-level `approved OR effective` would WRONGLY return True here — the
+    # grant-back hole the fold-inside design closes.)
+
+
+def test_interactive_mode_gates_the_decl_file_grant() -> None:
+    """Tier 2: in interactive mode the decl file-grant disjunct is OFF (the user
+    approves at startup, tracked via approval_check); non-interactive honors the
+    declared paths directly (faithful to require_file_* `not self._interactive`)."""
+    decl = PermissionDecl(file_write=[{"path": "/tmp/declared.txt", "scope": "just_path"}])
+    assert AgentLayer(decl, interactive=False).allows(AX.FILE_WRITE, "/tmp/declared.txt") is True
+    assert AgentLayer(decl, interactive=True).allows(AX.FILE_WRITE, "/tmp/declared.txt") is False


### PR DESCRIPTION
**[e2e-coder]** — PR-S3.1b-1 of #1199 Stage 3. The first gate cutover — `require_mcp` (the migration anchor) — through the unified `EffectivePermission` model, with the model extended to faithfully reproduce the gate logic. **Design-reviewed before impl** (#1199 issuecomment-4620940242, behavior-change gate). Staging A (byte-identical centralization); S3.1c=B does the full-∩ tightening separately.

## Model extensions (`permissions/effective.py`) — faithful, not the S3.1a simplification

The flow-trace found the S3.1a model was a simplification (omitted approvals, mode, `decl.allowed_mcp`). Fixed:
- **`AgentLayer.MCP`**: `decl.mcp ∩ decl.allowed_mcp` (was `decl.mcp` only) — faithful to `require_mcp` (permissions.py:1248+1253).
- **★② approval-fold** (the design-call correction): startup/config approvals fold **inside** the agent layer (`approval_check`, runtime-parameterized per op-context), **not** a top-level `approved OR effective` disjunct — which would let an approval **re-grant** what a downstream Sandbox/Profile layer denies (a grant-back security hole in the full ∩). Inside the layer, `effective = AgentLayer(…,approvals) ∩ Sandbox ∩ Profile` keeps grant-back forbidden structurally.
- **interactive-mode** gating on the file decl-grant disjunct (faithful to `require_file_* not self._interactive`).

## Cutover (`require_mcp`)

The two inline checks (`decl.allowed_mcp` + `decl.mcp`) → `EffectivePermission([AgentLayer(decl)]).allows(MCP, server)` — the single ∩ source. **Byte-identical decision**; the two diagnostics (allowed_mcp / not-declared) are preserved with the same messages + order on the deny path. The interactive `_approve` prompt remains the separate runtime gate (not in the ∩). Local import avoids the `effective.py → permissions.py` circular.

This is **A** (byte-identical): the Sandbox/Profile layers are ⊤ at `require_mcp` today (it doesn't check them), so the 1-layer `effective` exactly reproduces the prior decision. **S3.1c=B** adds the `ProfileLayer` to `require_mcp` (the deliberate tightening, reviewed separately).

## Test plan
- [x] **Byte-identical guard**: the existing `require_mcp` suite (`tests/test_permissions.py`) passes unchanged
- [x] Tier 2 (`tests/test_1199_s31b_mcp_cutover.py`): the MCP-fix unit; **★the ② grant-back safety** (an approval is vetoed by a sandbox deny — the ∩ restricts it, no re-grant); interactive-mode gating
- [x] **Falsification:** (1) drop the `decl.allowed_mcp` conjunct → the byte-identical `require_mcp` test + the MCP-fix test FAIL; (2) `∩ all→any` → the ② grant-back test FAILS (approval re-grants past the sandbox deny — proving the ∩ closes the hole)
- [x] `ruff` + `tier audit` pass
- [x] `pytest -q` from rootdir — **6862 passed** (the byte-identical guard across all require_mcp callers holds), 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal)

## Next
- **S3.1b-2**: cut over the remaining gates (file/shell/secret/http/python/tool + `is_read/write_allowed`), same A, with the approval-fold exercised (approvals as the in-layer disjunct).
- **S3.1c=B**: extend each gate's `effective` to the full `agent ∩ sandbox ∩ profile` (the deliberate tightening; env-axis-vs-backend verified here).

Refs #1199
