### PR TITLE
feat(1199): PR-S3.1b-2a is_write_allowed gate cutover + include_decl divergence flag

### DIFF
--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -93,10 +93,19 @@ class AgentLayer:
         *,
         approval_check: "Any" = None,
         interactive: bool = False,
+        include_decl: bool = True,
     ) -> None:
         self._decl = decl
         self._approval_check = approval_check
         self._interactive = interactive
+        # #1199 S3.1b-2: per-gate decl inclusion. The op-runtime file gates
+        # (require_file_read/write) honor the skill's declared paths (decl-full);
+        # the Workspace FS gates (is_read/write_allowed) do NOT (decl-less). This
+        # flag preserves that PRE-EXISTING divergence byte-identically (each gate
+        # keeps its current decision). TRANSITIONAL — removed in S3.1c when the
+        # divergence is reconciled (lead-coder-driven via the file.write
+        # declaration-semantics doc-check).
+        self._include_decl = include_decl
 
     def _approved(self, axis: CapabilityAxis, value: Any) -> bool:
         return bool(self._approval_check and self._approval_check(axis, value))
@@ -107,13 +116,21 @@ class AgentLayer:
             return (
                 _in_default_read_zone(str(value))
                 or self._approved(axis, value)
-                or (not self._interactive and _decl_covers_path(d.file_read, str(value)))
+                or (
+                    self._include_decl
+                    and not self._interactive
+                    and _decl_covers_path(d.file_read, str(value))
+                )
             )
         if axis is CapabilityAxis.FILE_WRITE:
             return (
                 _in_default_write_zone(str(value))
                 or self._approved(axis, value)
-                or (not self._interactive and _decl_covers_path(d.file_write, str(value)))
+                or (
+                    self._include_decl
+                    and not self._interactive
+                    and _decl_covers_path(d.file_write, str(value))
+                )
             )
         if axis is CapabilityAxis.NETWORK_HOST:
             return any(e.get("host") == value for e in d.http_get) or self._approved(

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -1214,14 +1214,29 @@ class PermissionResolver:
 
         Allowed if: default write zone, OR config grants `file.write: allow`, OR
         a per-skill approval covers it.
+
+        #1199 S3.1b-2a (the Workspace write gate): routed through the unified
+        EffectivePermission model — the single conjunctive-∩ source. Byte-identical:
+        a DECL-LESS AgentLayer (``include_decl=False`` — the Workspace gate never
+        honored the skill's declared paths; the op-runtime ``require_file_write``
+        decl-full path is the separate, divergent gate, preserved + reconciled in
+        S3.1c). The config/path approvals fold INSIDE the layer (② grant-back-safe).
         """
-        if _in_default_write_zone(path):
-            return True
-        if self._is_config_approved("file.write"):
-            return True
-        if skill_name and self._is_path_approved_for(path, skill_name, "file.write"):
-            return True
-        return False
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        def _approved(axis: object, value: object) -> bool:
+            return self._is_config_approved("file.write") or (
+                bool(skill_name)
+                and self._is_path_approved_for(str(value), skill_name, "file.write")
+            )
+
+        return EffectivePermission([
+            AgentLayer(PermissionDecl(), approval_check=_approved, include_decl=False)
+        ]).allows(CapabilityAxis.FILE_WRITE, path)
 
     async def require_shell(
         self, decl: PermissionDecl, cmd: str, bus: "RequestBus | None",

--- a/tests/test_1199_s31b2a_write_gate.py
+++ b/tests/test_1199_s31b2a_write_gate.py
@@ -1,0 +1,44 @@
+"""Tier 2: is_write_allowed cutover + the include_decl divergence flag (#1199 S3.1b-2a).
+
+The Workspace write gate (is_write_allowed) is routed through EffectivePermission
+with a DECL-LESS AgentLayer (include_decl=False) — byte-identical, preserving the
+pre-existing divergence from the op-runtime decl-full require_file_write
+(reconciled later in S3.1c). The broad byte-identical guard is the workspace +
+permission suites; these pin the flag mechanism + the cutover directly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.permissions.effective import AgentLayer, CapabilityAxis, EffectivePermission
+from reyn.permissions.permissions import PermissionDecl
+from tests.test_permissions import _make_resolver
+
+AX = CapabilityAxis
+
+
+def test_include_decl_flag_controls_decl_disjunct() -> None:
+    """Tier 2: include_decl gates the file decl-grant disjunct — the mechanism
+    that preserves the Workspace(decl-less) vs op-runtime(decl-full) divergence
+    byte-identically. Same decl, opposite decisions for an out-of-zone declared
+    path."""
+    out = "/tmp/s31b2a-declared.txt"  # outside the default write zone
+    decl = PermissionDecl(file_write=[{"path": out, "scope": "just_path"}])
+    # op-runtime (decl-full): the declared path is honored
+    assert AgentLayer(decl, include_decl=True).allows(AX.FILE_WRITE, out) is True
+    # Workspace (decl-less): the declared path is NOT honored (preserved divergence)
+    assert AgentLayer(decl, include_decl=False).allows(AX.FILE_WRITE, out) is False
+
+
+def test_is_write_allowed_reproduces_current_logic(tmp_path: Path) -> None:
+    """Tier 2: the cutover reproduces is_write_allowed exactly — zone OR
+    config-approved OR path-approved; otherwise denied. (decl-less: the gate
+    takes no decl, so a declared-but-unapproved path is denied.)"""
+    # default write zone (.reyn/) → allowed, no config needed
+    r = _make_resolver(tmp_path)
+    assert r.is_write_allowed(".reyn/x.txt") is True
+    # outside the zone, no approval → denied
+    assert r.is_write_allowed("/tmp/s31b2a-out.txt") is False
+    # config grants file.write → allowed even outside the zone
+    r2 = _make_resolver(tmp_path, config={"file.write": "allow"})
+    assert r2.is_write_allowed("/tmp/s31b2a-out.txt") is True


### PR DESCRIPTION
**[e2e-coder]** — PR-S3.1b-2a of #1199 Stage 3. The first **file-gate** cutover — `is_write_allowed` (the Workspace write gate) — through the unified model, byte-identical. **Design-reviewed** (#1199 issuecomment-4621128382). Anchors S3.1b-2 (remaining gates).

## The pre-existing divergence (preserved, not fixed)

The flow-trace found the Workspace gates (`is_read/write_allowed`) are **decl-less** (`zone OR config OR path`) while the op-runtime gates (`require_file_*`) are **decl-full** (`+ non-interactive decl_covers`) — so a skill's declared path is honored by one entry point but not the other (a latent functional inconsistency; op-runtime is the more-permissive side, **not an over-permission hole**). Per the design call, S3.1b-2 **preserves** this byte-identically and does **not** mix the fix into the refactor (reconcile = S3.1c, lead-coder-driven via the file.write declaration-semantics doc-check).

## What

- **`effective.py` AgentLayer gains `include_decl`** (default `True`): gates the file decl-grant disjunct. Op-runtime gates = decl-full (`include_decl=True`); Workspace gates = decl-less (`include_decl=False`). Preserves the divergence byte-identically. **Transitional** — removed in S3.1c when the divergence is reconciled.
- **`is_write_allowed` → `EffectivePermission`** with a decl-less `AgentLayer`; config/path approvals fold **inside** the layer (② grant-back-safe). Byte-identical: `zone OR config-approved OR path-approved`.

## Test plan
- [x] **Byte-identical guard**: the workspace + permission suites (which exercise `is_write_allowed` via the Workspace) pass unchanged (63 green in the focused run)
- [x] Tier 2 (`tests/test_1199_s31b2a_write_gate.py`): the `include_decl` flag (same decl, opposite decisions for an out-of-zone declared path — the divergence mechanism); `is_write_allowed` reproduces its current logic (zone/config/path)
- [x] **Falsification:** remove the `include_decl` guard → the decl-less variant wrongly honors decl → the flag test FAILS
- [x] `ruff` + `tier audit` pass
- [x] `pytest -q` from rootdir — **6864 passed** (byte-identical guard across all Workspace callers holds), 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal)

## Next
S3.1b-2b (`is_read_allowed` + `require_file_read/write`, decl-full) → S3.1b-2c (remaining op-runtime gates) → S3.1c=B (full-∩ tightening + the divergence reconcile).

Refs #1199
