### PR TITLE
feat(1199): PR-S3.1b-2b is_read_allowed + require_file_read/write cutovers

### DIFF
--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -975,13 +975,31 @@ class PermissionResolver:
         startup, decline is tracked in ``_session``, and is respected
         by ``_is_path_approved_for`` above.
         """
-        if _in_default_read_zone(path):
-            return
-        if self._is_config_approved("file.read"):
-            return
-        if self._is_path_approved_for(path, skill_name, "file.read"):
-            return
-        if not self._interactive and _decl_covers_path(decl.file_read, path):
+        # #1199 S3.1b-2b: the op-runtime read gate — DECL-FULL EffectivePermission
+        # (include_decl=True; the skill's declared paths are honored in
+        # non-interactive mode). Byte-identical: zone OR config-approved OR
+        # path-approved OR (non-interactive AND decl_covers). Approvals fold
+        # INSIDE the layer (② grant-back-safe); interactive mode gates the decl
+        # disjunct, faithful to the prior logic.
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        def _approved(axis: object, value: object) -> bool:
+            return self._is_config_approved("file.read") or self._is_path_approved_for(
+                str(value), skill_name, "file.read"
+            )
+
+        if EffectivePermission([
+            AgentLayer(
+                decl,
+                approval_check=_approved,
+                interactive=self._interactive,
+                include_decl=True,
+            )
+        ]).allows(CapabilityAxis.FILE_READ, path):
             return
         raise PermissionError(
             f"read from '{path}' was not approved. "
@@ -1005,13 +1023,29 @@ class PermissionResolver:
         rationale (= PR #1004 class N=2 trigger; wiring gap that
         leaves declared intent un-honored in batch mode).
         """
-        if _in_default_write_zone(path):
-            return
-        if self._is_config_approved("file.write"):
-            return
-        if self._is_path_approved_for(path, skill_name, "file.write"):
-            return
-        if not self._interactive and _decl_covers_path(decl.file_write, path):
+        # #1199 S3.1b-2b: the op-runtime write gate — DECL-FULL EffectivePermission
+        # (include_decl=True). Byte-identical: zone OR config-approved OR
+        # path-approved OR (non-interactive AND decl_covers). Approvals fold INSIDE
+        # the layer (② grant-back-safe); interactive mode gates the decl disjunct.
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        def _approved(axis: object, value: object) -> bool:
+            return self._is_config_approved("file.write") or self._is_path_approved_for(
+                str(value), skill_name, "file.write"
+            )
+
+        if EffectivePermission([
+            AgentLayer(
+                decl,
+                approval_check=_approved,
+                interactive=self._interactive,
+                include_decl=True,
+            )
+        ]).allows(CapabilityAxis.FILE_WRITE, path):
             return
         raise PermissionError(
             f"write to '{path}' was not approved. "
@@ -1200,14 +1234,28 @@ class PermissionResolver:
 
         Allowed if: the path is in the default read zone (under CWD), OR config
         grants `file.read: allow`, OR a per-skill approval covers it.
+
+        #1199 S3.1b-2b (the Workspace read gate): routed through the unified
+        EffectivePermission model — DECL-LESS AgentLayer (the Workspace gate never
+        honored the skill's declared paths; the op-runtime ``require_file_read``
+        decl-full path is the separate divergent gate, preserved + reconciled in
+        S3.1c). Byte-identical: zone OR config-approved OR path-approved.
         """
-        if _in_default_read_zone(path):
-            return True
-        if self._is_config_approved("file.read"):
-            return True
-        if skill_name and self._is_path_approved_for(path, skill_name, "file.read"):
-            return True
-        return False
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        def _approved(axis: object, value: object) -> bool:
+            return self._is_config_approved("file.read") or (
+                bool(skill_name)
+                and self._is_path_approved_for(str(value), skill_name, "file.read")
+            )
+
+        return EffectivePermission([
+            AgentLayer(PermissionDecl(), approval_check=_approved, include_decl=False)
+        ]).allows(CapabilityAxis.FILE_READ, path)
 
     def is_write_allowed(self, path: str, skill_name: str = "") -> bool:
         """Check if writing `path` is allowed.

--- a/tests/test_1199_s31b2b_read_file_gates.py
+++ b/tests/test_1199_s31b2b_read_file_gates.py
@@ -1,0 +1,49 @@
+"""Tier 2: is_read_allowed + require_file_read/write cutovers (#1199 S3.1b-2b).
+
+Continues the S3.1b-2 A-discipline through the unified model: the Workspace read
+gate (is_read_allowed) is DECL-LESS (include_decl=False); the op-runtime file
+gates (require_file_read/write) are DECL-FULL (include_decl=True, honoring the
+skill's declared paths in non-interactive mode). Each gate's broad byte-identical
+guard is its existing permission/workspace suite; these pin the divergence
+directly. (require_file_* are sync.)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.permissions import PermissionDecl
+from tests.test_permissions import _make_resolver
+
+
+def test_require_file_write_decl_full_honors_declared_path(tmp_path: Path) -> None:
+    """Tier 2: the op-runtime require_file_write is DECL-FULL — a non-interactive
+    skill's declared out-of-zone path is honored (the decl-full side of the
+    divergence; the Workspace is_write_allowed denies the same path)."""
+    r = _make_resolver(tmp_path)  # non-interactive
+    out = "/tmp/s31b2b-declared.txt"
+    decl = PermissionDecl(file_write=[{"path": out, "scope": "just_path"}])
+    r.require_file_write(decl, out)  # declared → honored (no raise)
+    with pytest.raises(PermissionError, match="was not approved"):
+        r.require_file_write(PermissionDecl(), out)  # not declared → raises
+
+
+def test_require_file_read_decl_full_honors_declared_path(tmp_path: Path) -> None:
+    """Tier 2: require_file_read decl-full, same shape (FILE_READ)."""
+    r = _make_resolver(tmp_path)
+    out = "/tmp/s31b2b-read-declared.txt"
+    decl = PermissionDecl(file_read=[{"path": out, "scope": "just_path"}])
+    r.require_file_read(decl, out)
+    with pytest.raises(PermissionError, match="was not approved"):
+        r.require_file_read(PermissionDecl(), out)
+
+
+def test_is_read_allowed_reproduces_current_logic(tmp_path: Path) -> None:
+    """Tier 2: is_read_allowed reproduces zone OR config OR path (decl-less) — and
+    does NOT honor decl (it takes none; the preserved divergence)."""
+    r = _make_resolver(tmp_path)
+    assert r.is_read_allowed("a-file-under-cwd.txt") is True   # relative → read zone (CWD)
+    assert r.is_read_allowed("/tmp/s31b2b-out.txt") is False   # outside, no approval
+    r2 = _make_resolver(tmp_path, config={"file.read": "allow"})
+    assert r2.is_read_allowed("/tmp/s31b2b-out.txt") is True   # config grant


### PR DESCRIPTION
**[e2e-coder]** — PR-S3.1b-2b of #1199 Stage 3. The file-read gate + the op-runtime file gates, continuing the A byte-identical cutover (design call #1199 issuecomment-4621128382; same discipline as the merged S3.1b-2a).

## What

- **`is_read_allowed` → DECL-LESS** `AgentLayer` (`include_decl=False`), same shape as `is_write_allowed` (2a). Byte-identical: `zone OR config-approved OR path-approved`.
- **`require_file_read` / `require_file_write` → DECL-FULL** `AgentLayer` (`include_decl=True`, `interactive=self._interactive`). Byte-identical: `zone OR config-approved OR path-approved OR (non-interactive AND decl_covers)`. Approvals fold **inside** the layer (② grant-back-safe); the interactive-mode gate on the decl disjunct is preserved; the raise-on-deny messages are unchanged.

The Workspace(decl-less) vs op-runtime(decl-full) divergence is preserved byte-identically via the `include_decl` flag (transitional; reconciled in S3.1c).

## Test plan
- [x] **Byte-identical guard**: the file-permission + workspace suites (esp. `test_permission_resolver_consults_decl`, which exercises `require_file_*` with decl) pass unchanged (81 green in the focused run)
- [x] Tier 2 (`tests/test_1199_s31b2b_read_file_gates.py`): the op-runtime gates honor a declared out-of-zone path (decl-full); `is_read_allowed` reproduces zone/config/path (decl-less)
- [x] **Falsification:** `require_file_write` `include_decl=True→False` → the decl-full honor test FAILS (the declared path is wrongly denied)
- [x] `ruff` + `tier audit` pass
- [x] `pytest -q` from rootdir — **6867 passed** (byte-identical guard across all file-gate callers holds), 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal)

## Next
S3.1b-2c (`require_shell`/`secret_write`/`http_get`/`python`/`tool`) → S3.1c=B (full-∩ tightening + the divergence reconcile, lead-coder-driven via the file.write declaration-semantics doc-check).

Refs #1199
