### PR TITLE
feat(1199): PR-S3.1b-2c require_shell/secret_write/tool cutovers (+ TOOL axis, secret wildcard)

### DIFF
--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -57,6 +57,10 @@ class CapabilityAxis(Enum):
     SECRET_WRITE = "secret_write"
     PYTHON = "python"
     ENV = "env"
+    # #1199 S3.1b-2c: the per-skill tool allowlist (decl.tool) — a distinct
+    # capability axis (gated by require_tool) not in the original 9; added here
+    # for the require_tool cutover.
+    TOOL = "tool"
 
 
 class LayerView(Protocol):
@@ -147,7 +151,18 @@ class AgentLayer:
             in_allowlist = d.allowed_mcp is None or value in d.allowed_mcp
             return in_grant and in_allowlist
         if axis is CapabilityAxis.SECRET_WRITE:
-            return value in d.secret_write or self._approved(axis, value)
+            # #1199 S3.1b-2c: faithful to require_secret_write — a specific key OR
+            # the "*" wildcard (runtime-determined keys, gated by the per-value
+            # op-execution prompt). _approved kept for symmetry (no current
+            # secret approval source, but harmless).
+            return (
+                value in d.secret_write
+                or "*" in d.secret_write
+                or self._approved(axis, value)
+            )
+        if axis is CapabilityAxis.TOOL:
+            # #1199 S3.1b-2c: the per-skill tool allowlist (require_tool).
+            return value in d.tool
         if axis is CapabilityAxis.PYTHON:
             # value = (module, function)
             return any(

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -1215,7 +1215,19 @@ class PermissionResolver:
         ``"GITHUB_TOKEN"`` and ``"*"`` is functionally equivalent to
         just ``"*"`` but conveys intent more clearly.
         """
-        if key in decl.secret_write or "*" in decl.secret_write:
+        # #1199 S3.1b-2c: the static secret-write authority (specific key OR "*"
+        # wildcard) flows through the unified model (SECRET_WRITE axis).
+        # Byte-identical. The operator's per-value op-execution prompt (for the
+        # wildcard) is the separate runtime gate, unchanged.
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        if EffectivePermission([AgentLayer(decl)]).allows(
+            CapabilityAxis.SECRET_WRITE, key
+        ):
             return
         raise PermissionError(
             f"Secret-store write of key {key!r} not declared in skill permissions. "
@@ -1289,7 +1301,18 @@ class PermissionResolver:
     async def require_shell(
         self, decl: PermissionDecl, cmd: str, bus: "RequestBus | None",
     ) -> None:
-        if not decl.shell:
+        # #1199 S3.1b-2c: the static shell authority (decl.shell) flows through the
+        # unified model (SUBPROCESS axis). Byte-identical; the _approve prompt
+        # remains the separate runtime gate.
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        if not EffectivePermission([AgentLayer(decl)]).allows(
+            CapabilityAxis.SUBPROCESS, None
+        ):
             raise PermissionError(
                 f"shell access not declared in skill permissions. "
                 f"Add `permissions:\\n  shell: true` to the skill.md frontmatter."
@@ -1424,7 +1447,17 @@ class PermissionResolver:
     async def require_tool(
         self, decl: PermissionDecl, tool: str, bus: RequestBus,
     ) -> None:
-        if tool not in decl.tool:
+        # #1199 S3.1b-2c: the static tool authority (decl.tool) flows through the
+        # unified model (TOOL axis). Byte-identical; the _approve prompt remains.
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
+        )
+
+        if not EffectivePermission([AgentLayer(decl)]).allows(
+            CapabilityAxis.TOOL, tool
+        ):
             raise PermissionError(
                 f"tool {tool!r} not declared in skill permissions. "
                 f"Add `permissions:\\n  tool: [{tool}]` to the skill.md frontmatter."

--- a/tests/test_1199_s31b2c_oprt_gates.py
+++ b/tests/test_1199_s31b2c_oprt_gates.py
@@ -1,0 +1,56 @@
+"""Tier 2: op-runtime gate cutovers + model axis additions (#1199 S3.1b-2c).
+
+The clean op-runtime gates (require_shell / require_secret_write / require_tool)
+route their static decl authority through the unified EffectivePermission model,
+byte-identical (each gate's existing suite is the broad guard). Adds the TOOL axis
+(decl.tool, require_tool) and the SECRET_WRITE "*" wildcard (require_secret_write).
+The intricate gates (require_http_get / require_python) are deferred — see the
+S3.1b-2c PR / a 2c-2 design call (config-deny tiers / prompt flows / perm-return
+make the model a marginal, awkward fit).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.effective import AgentLayer, CapabilityAxis
+from reyn.permissions.permissions import PermissionDecl
+from tests.test_permissions import _make_resolver
+
+AX = CapabilityAxis
+
+
+def test_tool_axis_membership() -> None:
+    """Tier 2: the new TOOL axis = value in decl.tool (faithful to require_tool)."""
+    assert AgentLayer(PermissionDecl(tool=["grep"])).allows(AX.TOOL, "grep") is True
+    assert AgentLayer(PermissionDecl(tool=["grep"])).allows(AX.TOOL, "rm") is False
+
+
+def test_secret_write_wildcard_and_specific() -> None:
+    """Tier 2: SECRET_WRITE honors a specific key AND the "*" wildcard (faithful to
+    require_secret_write's two declaration shapes)."""
+    assert AgentLayer(PermissionDecl(secret_write=["GH_TOKEN"])).allows(AX.SECRET_WRITE, "GH_TOKEN")
+    assert not AgentLayer(PermissionDecl(secret_write=["GH_TOKEN"])).allows(AX.SECRET_WRITE, "OTHER")
+    assert AgentLayer(PermissionDecl(secret_write=["*"])).allows(AX.SECRET_WRITE, "ANYTHING")  # wildcard
+
+
+def test_require_secret_write_cutover_reproduces_logic(tmp_path: Path) -> None:
+    """Tier 2: require_secret_write (sync, no _approve) routed through the model —
+    specific key OR "*" → ok; undeclared → raise. Byte-identical."""
+    r = _make_resolver(tmp_path)
+    r.require_secret_write(PermissionDecl(secret_write=["K"]), "K")        # declared → ok
+    r.require_secret_write(PermissionDecl(secret_write=["*"]), "ANY_KEY")  # wildcard → ok
+    with pytest.raises(PermissionError, match="not declared"):
+        r.require_secret_write(PermissionDecl(), "K")                      # undeclared → raise
+
+
+def test_require_shell_gate_denies_when_undeclared(tmp_path: Path) -> None:
+    """Tier 2: require_shell's model gate (SUBPROCESS = decl.shell) denies before
+    the _approve prompt when shell is not declared. (The shell=True + _approve flow
+    is covered by the broad permission suite.)"""
+    import asyncio
+
+    r = _make_resolver(tmp_path)
+    with pytest.raises(PermissionError, match="not declared"):
+        asyncio.run(r.require_shell(PermissionDecl(shell=False), "ls", None))


### PR DESCRIPTION
**[e2e-coder]** — PR-S3.1b-2c of #1199 Stage 3. The clean op-runtime gates (`require_shell`/`require_secret_write`/`require_tool`) through the unified model, byte-identical (design call #1199 issuecomment-4621128382). **Scope-refined: the two intricate gates (`require_http_get`/`require_python`) are deferred — see below.**

## What

**Model additions** (`permissions/effective.py`):
- **TOOL axis** — the per-skill tool allowlist (`decl.tool`), a distinct axis not in the original 9 (Sandbox/Profile are ⊤ on it).
- **SECRET_WRITE `"*"` wildcard** — `AgentLayer.SECRET_WRITE` honors `"*"` (faithful to `require_secret_write`'s two declaration shapes).

**Cutovers** (`permissions.py`), each byte-identical, the `_approve` prompt (where present) preserved as the separate runtime gate:
- `require_shell` → SUBPROCESS axis (`decl.shell`)
- `require_secret_write` → SECRET_WRITE axis (specific key OR `"*"`; sync, no `_approve`; the operator's per-value op-execution prompt for the wildcard is unchanged)
- `require_tool` → TOOL axis (`decl.tool`)

## ★Scope refinement: http_get + python deferred (flow-trace finding)

The remaining two op-runtime gates are **not** the clean decl-grant pattern:
- `require_http_get` — config-deny tiers + `startup_guard` host-prompt + wildcard + legacy `web.fetch` compat + per-host ALWAYS/NEVER persistence.
- `require_python` — resolves *and returns* a `PythonPermission` (not a bool gate) with safe/unsafe modes.

The model would handle only a small decl-membership check while the bulk of each flow stays — **marginal value, awkward fit**. Recommend a **2c-2 design call**: route only the membership through the model, or leave these as-is with a note (they're not a natural ∩ fit). Holding them for your steer rather than forcing an intricate byte-identical cutover.

## Test plan
- [x] **Byte-identical guard**: the permission suites (shell/secret/tool + prompt-phrasing) pass unchanged (60 green focused)
- [x] Tier 2 (`tests/test_1199_s31b2c_oprt_gates.py`): the TOOL axis; the SECRET_WRITE wildcard; `require_secret_write` cutover; `require_shell` gate-deny
- [x] **Falsification:** remove the secret `"*"` wildcard → the wildcard test + the cutover test FAIL
- [x] `ruff` + `tier audit` pass
- [x] `pytest -q` from rootdir — **6871 passed** (byte-identical guard across all shell/secret/tool callers holds), 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal)

## Next
2c-2 (http_get/python, per your steer) → S3.1c=B (full-∩ tightening + the Workspace/op-runtime divergence reconcile, owner-gated per your doc-check).

Refs #1199
