### PR TITLE
feat(1199): PR-S3.1b-2c-2 require_http_get membership routing (+ NETWORK_HOST wildcard) — S3.1b complete

### DIFF
--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -137,8 +137,15 @@ class AgentLayer:
                 )
             )
         if axis is CapabilityAxis.NETWORK_HOST:
-            return any(e.get("host") == value for e in d.http_get) or self._approved(
-                axis, value
+            # #1199 S3.1b-2c-2: faithful to require_http_get's membership decision —
+            # a specific declared host OR the "*" wildcard (host set unknown at
+            # write-time). The intricate resolution flow (config-deny tiers /
+            # startup_guard host-prompt / legacy compat / per-host persistence)
+            # stays in require_http_get as the non-∩ flow; this axis is just the
+            # decl membership (so S3.1c can ∩ SandboxLayer.network).
+            return (
+                any(e.get("host") in (value, "*") for e in d.http_get)
+                or self._approved(axis, value)
             )
         if axis is CapabilityAxis.SUBPROCESS:
             return bool(d.shell)

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -1124,15 +1124,26 @@ class PermissionResolver:
         if self._saved.get("web.fetch") or self._session.get("web.fetch"):
             return
 
-        # Did the skill declare this host explicitly or via wildcard?
-        has_specific = any(
-            isinstance(e, dict) and e.get("host") == host for e in decl.http_get
+        # #1199 S3.1b-2c-2: the host-MEMBERSHIP decision (specific OR wildcard)
+        # routes through the unified model (NETWORK_HOST axis) — pure decl
+        # membership (no approval_check; the config/persisted/legacy approvals are
+        # the separate disjuncts above). Byte-identical to the prior
+        # `has_specific OR has_wildcard`. This is the seam S3.1c uses to ∩
+        # SandboxLayer.network (closing the gap where a sandboxed skill's http_get
+        # is not network-bound today). has_wildcard stays local for the prompt label.
+        from reyn.permissions.effective import (
+            AgentLayer,
+            CapabilityAxis,
+            EffectivePermission,
         )
+
         has_wildcard = any(
             isinstance(e, dict) and e.get("host") == "*" for e in decl.http_get
         )
 
-        if has_specific or has_wildcard:
+        if EffectivePermission([AgentLayer(decl)]).allows(
+            CapabilityAxis.NETWORK_HOST, host
+        ):
             # Need to prompt — either startup_guard was skipped (=
             # non-interactive run with a still-unapproved specific decl)
             # or this is the wildcard JIT path.

--- a/tests/test_1199_s31b2c2_http_get.py
+++ b/tests/test_1199_s31b2c2_http_get.py
@@ -1,0 +1,56 @@
+"""Tier 2: http_get host-membership cutover + NETWORK_HOST wildcard (#1199 S3.1b-2c-2).
+
+require_http_get's host-MEMBERSHIP decision (has_specific OR has_wildcard) routes
+through the model (NETWORK_HOST axis, decl-membership only — no approval_check, as
+the config/persisted/legacy approvals are separate disjuncts). The intricate
+resolution flow (config-deny tiers / startup_guard prompt / legacy compat) stays.
+The broad byte-identical guard is the http_get/web_fetch suites; these pin the
+NETWORK_HOST wildcard + the membership routing (via the bus=None raise paths).
+python is deliberately NOT routed (resolves+returns a PythonPermission).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.effective import AgentLayer, CapabilityAxis
+from reyn.permissions.permissions import PermissionDecl
+from tests.test_permissions import _make_resolver
+
+AX = CapabilityAxis
+
+
+def test_network_host_wildcard_and_specific() -> None:
+    """Tier 2: NETWORK_HOST honors a specific declared host AND the "*" wildcard
+    (faithful to require_http_get's has_specific OR has_wildcard)."""
+    assert AgentLayer(PermissionDecl(http_get=[{"host": "api.x.com"}])).allows(
+        AX.NETWORK_HOST, "api.x.com"
+    )
+    assert not AgentLayer(PermissionDecl(http_get=[{"host": "api.x.com"}])).allows(
+        AX.NETWORK_HOST, "other.com"
+    )
+    assert AgentLayer(PermissionDecl(http_get=[{"host": "*"}])).allows(
+        AX.NETWORK_HOST, "anything.com"
+    )  # wildcard
+
+
+@pytest.mark.asyncio
+async def test_require_http_get_membership_routes_via_model(tmp_path: Path) -> None:
+    """Tier 2: the membership decision routes through the model — a declared or
+    wildcard host reaches the interactive-prompt path (membership True); an
+    undeclared host falls to the no-declaration legacy path (membership False).
+    Distinguished here via the bus=None raise messages (byte-identical)."""
+    r = _make_resolver(tmp_path)  # no config approvals
+    decl = PermissionDecl(http_get=[{"host": "api.example.com"}])
+    # declared → membership True → needs interactive prompt (bus=None → that path)
+    with pytest.raises(PermissionError, match="requires an interactive prompt"):
+        await r.require_http_get(decl, "api.example.com", None, "skill")
+    # wildcard → membership True → same prompt path
+    with pytest.raises(PermissionError, match="requires an interactive prompt"):
+        await r.require_http_get(
+            PermissionDecl(http_get=[{"host": "*"}]), "any.host.com", None, "skill"
+        )
+    # undeclared → membership False → no-declaration legacy path (distinct message)
+    with pytest.raises(PermissionError, match="not declared and no interactive bus"):
+        await r.require_http_get(PermissionDecl(), "api.example.com", None, "skill")


### PR DESCRIPTION
**[e2e-coder]** — PR-S3.1b-2c-2 of #1199 Stage 3 — the **final S3.1b cutover**, completing the byte-identical gate centralization. **Confirmed** (#1199 issuecomment-4621435932).

## What

- **`AgentLayer.NETWORK_HOST`**: add the `"*"` wildcard → `any(e.host in (value, "*"))` = `require_http_get`'s `has_specific OR has_wildcard`.
- **`require_http_get`**: the host-**membership** decision (1127-1135) routes through `EffectivePermission([AgentLayer(decl)]).allows(NETWORK_HOST, host)` — **pure decl-membership** (no `approval_check`; the config/persisted/legacy approvals stay as the separate disjuncts above). The config-deny tiers, startup_guard prompt, and the no-declaration legacy compat **stay** as the documented non-∩ resolution flow. `has_wildcard` stays local for the prompt label. Byte-identical: the membership decision is unchanged; only its *source* moves to the model.

This is the seam **S3.1c** uses to `∩ SandboxLayer.network` — closing the gap where a sandboxed skill's `http_get` is not network-bound today.

## python — deliberately not routed

`require_python` resolves AND **returns** a `PythonPermission` (safe/unsafe mode) — resolution, not a bool membership; it doesn't fit the `AllowSet` ∩ and the sandbox axes don't per-module-restrict (your (b)). Documented as a deliberate non-fit; no model routing.

## Test plan
- [x] **Byte-identical guard**: the http_get/web_fetch + permission suites pass unchanged (184 green focused)
- [x] Tier 2 (`tests/test_1199_s31b2c2_http_get.py`): the NETWORK_HOST wildcard; the membership routing (declared/wildcard → interactive-prompt path; undeclared → no-declaration legacy path)
- [x] **Falsification:** drop the NETWORK_HOST `"*"` wildcard → the wildcard unit + the wildcard membership-routing test FAIL
- [x] `ruff` + `tier audit` pass
- [x] `pytest -q` from rootdir — **6873 passed** (byte-identical guard across all require_http_get callers holds), 1 pre-existing fail (`test_web_fetch_preview_path_ref`, CI-green #1203, orthogonal)

## S3.1b COMPLETE
8 gates routed through the unified model (mcp / is_write_allowed / is_read_allowed / require_file_read / require_file_write / shell / secret_write / tool / http_get-membership), all byte-identical. **Next: S3.1c=B** — the full-∩ tightening (add Sandbox/Profile layers to the gates) + the owner-decided divergence reconcile (auto-grant removed → deny + decision-enabling message; swe_bench via explicit reyn.yaml).

Refs #1199
