### PR TITLE
feat(1285): activate plan-axis cumulative force-close — PR1 FLOOR (#1092 plan axis)

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -485,6 +485,7 @@ class _PlanStepHost:
         step: PlanStep,
         prior_results: dict[str, str],
         parent: RouterLoopHost,
+        turn_budget_engine: Any = None,
     ):
         self._plan = plan
         self._step = step
@@ -494,6 +495,16 @@ class _PlanStepHost:
         # Captured by put_outbox; the executor reads this after RouterLoop
         # finishes to collect this step's text contribution.
         self._captured_text: str = ""
+        # #1285 (#1092 plan-axis force-close, PR1): the cumulative-current-turn
+        # TurnBudgetEngine for this step. None → should_force_close is inert
+        # (byte-identical to pre-#1285). A plan step is goal-bearing + autonomous
+        # (no user mid-step), so it mirrors the PHASE axis (PROACTIVE force-close),
+        # not chat's REACTIVE handoff.
+        self._turn_budget_engine = turn_budget_engine
+        # Set by record_force_close when run_loop fires the wrap-up; the planner
+        # reads forced_close_result after the step's run() to use the bounded
+        # consolidation as the step's output (PR1 FLOOR; PR2 re-enters from it).
+        self._forced_close_result: Any = None
 
     # ── RouterLoopHost-required attributes (= identity / static config) ────
 
@@ -565,6 +576,54 @@ class _PlanStepHost:
         # Project context narrowed out by default — plan steps work from
         # the step description, not from project-wide background.
         return ""
+
+    # ── Cumulative-axis force-close (#1285 / #1092 plan axis, PR1 FLOOR) ───
+    # Mirrors the PHASE host (PhaseRouterLoopHost) force-close interface: a
+    # plan step is goal-bearing + autonomous (no user mid-step), so it uses
+    # PROACTIVE force-close (not chat's REACTIVE handoff). When the engine is
+    # absent (not activated), should_force_close is always False = byte-
+    # identical to pre-#1285. ORTHOGONAL to FP-0031-C/D: force-close is the
+    # *cumulative-context* trigger; FP-0031 is the *transient-failure* trigger.
+
+    async def should_force_close(self, messages: list[dict], *, model: str) -> bool:
+        """Layer-1 force-close trigger for the plan axis. RouterLoop.run_loop
+        consults this each turn AFTER compaction; True when the accumulated
+        current-turn content (non-system turns; the wrap-up SP swaps the system
+        turn at force-close time) has reached the TurnBudgetEngine threshold.
+        Engine absent → always False (inert)."""
+        engine = self._turn_budget_engine
+        if engine is None:
+            return False
+        from reyn.services.compaction.engine import estimate_tokens_for_turn
+
+        content_tokens = sum(
+            estimate_tokens_for_turn(m, model, use_chars4=True)
+            for m in messages
+            if isinstance(m, dict) and m.get("role") != "system"
+        )
+        return engine.should_force_close(content_tokens)
+
+    def record_force_close(self, result: Any) -> None:
+        """RouterLoop.run_loop hands the force-close consolidation finish here;
+        the planner reads ``forced_close_result`` after the step's run() to use
+        the bounded consolidation as the step output (PR1 FLOOR). Stored, not
+        acted on (P3 — the planner drives the handoff)."""
+        self._forced_close_result = result
+
+    @property
+    def forced_close_result(self) -> Any:
+        """The consolidation finish of a force-close in the last run, or None."""
+        return self._forced_close_result
+
+    @property
+    def wrap_up_output_reserve(self) -> int | None:
+        """The wrap-up call's OUTPUT budget (``output_reserve``), or None when no
+        engine. RouterLoop._force_close_call passes it as ``max_tokens`` to
+        HARD-CAP the consolidation ≤ output_reserve — the by-construction
+        guarantee (assert_turn_budget_bounds: output_reserve + offload_cap <
+        threshold)."""
+        engine = self._turn_budget_engine
+        return engine.budget.output_reserve if engine is not None else None
 
     # ── Memory file paths (kept for read_memory_body / remember_*) ────────
 
@@ -885,6 +944,22 @@ async def execute_plan(
             )
             _effective_engine = None
 
+    # #1285 (#1092 plan-axis force-close, PR1): build the cumulative-current-turn
+    # TurnBudgetEngine once for all steps (same router_model + resolver).
+    # try_build (not build_default) so a small-context model that cannot satisfy
+    # the by-construction floor DEGRADES to None (force-close inert) rather than
+    # crashing — uniform with phase (PR-F3) + chat (F1). Threaded into each
+    # step's _PlanStepHost below; orthogonal to step-result compaction above.
+    from reyn.services.turn_budget import try_build_default_turn_budget_engine
+    _plan_turn_budget_engine = try_build_default_turn_budget_engine(
+        router_model,
+        # getattr: test/narrow hosts may lack ``resolver`` — mirror the lazy
+        # compaction-engine build above which tolerates the same. try_build then
+        # degrades to None (force-close inert) rather than crashing plan exec.
+        resolver=getattr(parent_host, "resolver", None),
+        use_chars4=True,
+    )
+
     # ADR-0022: allocate plan_id + record plan_started in WAL. plan_id is
     # uuid4-hex[:8] following the existing run_id allocation precedent.
     # The exception-aware finally clause mirrors ADR-0013's runtime
@@ -1007,6 +1082,7 @@ async def execute_plan(
                 )
             narrow_host = _PlanStepHost(
                 plan=plan, step=step, prior_results=step_results, parent=parent_host,
+                turn_budget_engine=_plan_turn_budget_engine,
             )
             sys_prompt = build_plan_step_system_prompt(
                 plan, step, step_results,
@@ -1112,6 +1188,7 @@ async def execute_plan(
                         narrow_host = _PlanStepHost(
                             plan=plan, step=step,
                             prior_results=step_results, parent=parent_host,
+                            turn_budget_engine=_plan_turn_budget_engine,
                         )
                         sub_loop = RouterLoop(
                             host=narrow_host,
@@ -1193,6 +1270,16 @@ async def execute_plan(
                 continue
 
             text = narrow_host.captured_text
+            # #1285 (#1092 plan-axis force-close, PR1 FLOOR): if this step
+            # force-closed (the cumulative-current-turn trigger fired), the
+            # bounded wrap-up consolidation went to record_force_close, NOT the
+            # normal put_outbox capture — so captured_text may be empty/stale.
+            # Use the consolidation as the step's contribution: the step ends
+            # bounded with a clean summary instead of overflowing. (PR2 re-enters
+            # the SAME step from this consolidation; PR1 is the proven floor.)
+            _fc_result = narrow_host.forced_close_result
+            if _fc_result is not None:
+                text = getattr(_fc_result, "content", None) or text
             step_results[step.id] = text
             try:
                 await parent_host.record_plan_step_completed(

--- a/tests/test_force_close_3axis_uniformity_1092.py
+++ b/tests/test_force_close_3axis_uniformity_1092.py
@@ -61,15 +61,17 @@ def test_chat_and_phase_activate_via_try_build_not_build_default() -> None:
         )
 
 
-def test_plan_does_not_wire_turn_budget_engine() -> None:
-    """Tier 2: plan is the articulated third failure-mode — step-scoped with no
-    force-close, so it does NOT build a turn_budget engine (neither helper). Its
-    cumulative content is bounded by fresh-history-per-step + FP-0031, not by the
-    force-close handoff (verified primary-evidence; activation tracked as #1285,
-    escalated-as-tracked — picked up if plan-step overflow is observed)."""
+def test_plan_wires_turn_budget_engine() -> None:
+    """Tier 2: #1285 (#1092 plan-axis activation) — plan NOW builds a turn_budget
+    engine and wires it into ``_PlanStepHost``, so a long plan step force-closes
+    (PR1 FLOOR: the bounded wrap-up consolidation becomes the step output; PR2
+    re-enters the same step from it). Uses ``try_build`` (not ``build_default``)
+    so a small-context model that cannot satisfy the by-construction floor
+    DEGRADES to None (force-close inert) — uniform with phase (PR-F3) + chat (F1):
+    all three axes now wire the engine. (Was deferred at #1092 wave time; this
+    test flipped when #1285 landed.)"""
     called = _called_names(_planner_mod)
-    assert "try_build_default_turn_budget_engine" not in called
-    assert "build_default_turn_budget_engine" not in called
+    assert "try_build_default_turn_budget_engine" in called
 
 
 # ── invariant 2: by-construction floor holds per axis ────────────────────────

--- a/tests/test_plan_force_close_1285.py
+++ b/tests/test_plan_force_close_1285.py
@@ -1,0 +1,122 @@
+"""Tier 2: OS invariant — plan-axis cumulative-current-turn force-close
+(#1285 / #1092 plan axis, PR1 FLOOR).
+
+`_PlanStepHost` now implements the phase-style force-close host interface
+(should_force_close / record_force_close / forced_close_result /
+wrap_up_output_reserve) + is threaded a TurnBudgetEngine at construction, so a
+single long plan step force-closes (bounded current turn) instead of growing
+unbounded. PR1 is the FLOOR (the wrap-up consolidation becomes the step output);
+PR2 re-enters the same step from it.
+
+Mirrors the phase activation test (test_force_close_phase_activation_1092):
+``build_default_turn_budget_engine("gpt-3.5-turbo")`` gives a small-context
+threshold so it can be crossed with crafted content (no 1M-token messages).
+
+No mocks of the engine — a real small-threshold TurnBudgetEngine. No private
+state asserted beyond the documented host interface.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.chat.planner import Plan, PlanStep, _PlanStepHost
+from reyn.services.turn_budget import (
+    assert_turn_budget_bounds,
+    build_default_turn_budget_engine,
+)
+
+_SMALL_MODEL = "gpt-3.5-turbo"  # small max_input → small, crossable threshold
+
+
+def _engine():
+    return build_default_turn_budget_engine(_SMALL_MODEL, use_chars4=True)
+
+
+def _host(engine):
+    step = PlanStep(id="s1", description="do the thing", tools=())
+    plan = Plan(goal="g", steps=(step,))
+    # parent is stored but untouched by the force-close interface.
+    return _PlanStepHost(
+        plan=plan, step=step, prior_results={}, parent=object(),
+        turn_budget_engine=engine,
+    )
+
+
+def _content_msgs(total_tokens_target: int) -> list[dict]:
+    # use_chars4 ⇒ ~4 chars/token; build a user turn whose content crosses target.
+    return [{"role": "user", "content": "x" * (total_tokens_target * 4)}]
+
+
+def test_should_force_close_fires_above_threshold_inert_when_engine_none() -> None:
+    """Tier 2: fires when non-system content ≥ threshold; engine None → inert (False)."""
+    eng = _engine()
+    t = eng.budget.force_close_threshold
+    host = _host(eng)
+    above = _content_msgs(t + 50)
+    below = _content_msgs(max(t - 50, 0))
+    assert asyncio.run(host.should_force_close(above, model="p")) is True
+    assert asyncio.run(host.should_force_close(below, model="p")) is False
+    # Engine absent (not activated) → always False = byte-identical to pre-#1285.
+    assert asyncio.run(_host(None).should_force_close(above, model="p")) is False
+
+
+def test_should_force_close_excludes_system_turns() -> None:
+    """Tier 2: the system turn is excluded from the content measure (the wrap-up
+    SP swaps it at force-close time), so a huge system turn alone does not fire."""
+    eng = _engine()
+    t = eng.budget.force_close_threshold
+    host = _host(eng)
+    msgs = [{"role": "system", "content": "x" * ((t + 100) * 4)},
+            {"role": "user", "content": "small"}]
+    assert asyncio.run(host.should_force_close(msgs, model="p")) is False
+
+
+def test_wrap_up_output_reserve_caps_consolidation() -> None:
+    """Tier 2: wrap_up_output_reserve = engine output_reserve (the wrap-up max_tokens
+    hard-cap), None when no engine."""
+    eng = _engine()
+    assert _host(eng).wrap_up_output_reserve == eng.budget.output_reserve
+    assert _host(None).wrap_up_output_reserve is None
+
+
+def test_record_force_close_roundtrip() -> None:
+    """Tier 2: record_force_close stores the consolidation finish for the planner
+    to read as the step output (FLOOR); None before any force-close."""
+    host = _host(_engine())
+    assert host.forced_close_result is None
+    sentinel = object()
+    host.record_force_close(sentinel)
+    assert host.forced_close_result is sentinel
+
+
+def test_by_construction_termination_bound_holds() -> None:
+    """Tier 2: the plan engine satisfies assert_turn_budget_bounds
+    (force_close_threshold > output_reserve + offload_cap) so each re-entry makes
+    progress — finite re-entries (the #1092 by-construction invariant). Raises if
+    violated."""
+    assert_turn_budget_bounds(_engine().budget)  # must not raise
+
+
+def test_force_close_orthogonal_to_fp0031_retry() -> None:
+    """Tier 2: the force-close trigger is purely content-driven and shares NO state
+    with FP-0031-C/D transient-failure retry — they are distinct triggers that must
+    not conflate (force-close = cumulative-context; FP-0031 = exception-driven).
+
+    should_force_close takes only (messages, model) — no attempt/failure input —
+    so it is idempotent across calls (a retry loop re-invoking the step cannot
+    flip the force-close verdict for the same content), and the engine is built
+    once per step independent of the planner's retry budget.
+    """
+    eng = _engine()
+    host = _host(eng)
+    above = _content_msgs(eng.budget.force_close_threshold + 50)
+    # Idempotent: same content → same verdict regardless of how many times the
+    # planner's retry loop might re-enter (no internal attempt/failure state).
+    verdicts = [asyncio.run(host.should_force_close(above, model="p")) for _ in range(3)]
+    assert verdicts == [True, True, True]
+    # And the force-close interface exposes no retry/attempt/failure coupling.
+    for retry_attr in ("attempt", "retry", "last_exc", "step_retry_limit", "failure"):
+        assert not hasattr(host, retry_attr), (
+            f"_PlanStepHost force-close must not couple to FP-0031 retry state "
+            f"(found {retry_attr!r})"
+        )


### PR DESCRIPTION
**[dogfood-coder]** — Part of #1285 (#1092 plan-axis force-close activation). Design ratified by lead-coder (issue #1285 issuecomment-4622412716; Q-A=re-enter-same-step, Q-B=FP-0031-orthogonal, Q-C=by-construction-assert). **This is PR1 (FLOOR)** of a 2-PR staging (mirrors phase PR-C floor → PR-D re-entry); PR2 wires the same-step re-entry.

## Gap (primary evidence)
The plan axis never force-closed the cumulative current turn — `_PlanStepHost` lacked `should_force_close` / `_turn_budget_engine` / `record_force_close` (0× in planner.py), so `RouterLoop`'s `getattr(host, "should_force_close", None)` → None. A single long plan step grew unbounded (FP-0031-C/D transient-retry + cross-step `compact_step_results` don't bound within-step current-turn). Deliberate #1092 deferral (`phase_router_host.py:333`).

## PR1 (FLOOR — mirrors phase PR-C)
A plan step is goal-bearing + autonomous (no user mid-step) → **PROACTIVE** force-close, mirroring the PHASE host (chat's REACTIVE handoff is unsuitable mid-step).
- `_PlanStepHost`: phase-style force-close interface (`should_force_close` [non-system content ≥ threshold], `record_force_close`, `forced_close_result`, `wrap_up_output_reserve`). Engine absent → inert (byte-identical pre-#1285).
- `execute_plan` builds the `TurnBudgetEngine` once via `try_build_default_turn_budget_engine` (degrades to None for a sub-viable small-context model — uniform with phase F3 / chat F1) and threads it into each step's `_PlanStepHost` (`getattr(resolver)` tolerates narrow/test hosts).
- On force-close the bounded wrap-up consolidation becomes the step's output (FLOOR). **PR2 re-enters the SAME step from it.**

## Invariants (review focus)
- **FP-0031 orthogonality**: force-close = cumulative-context trigger; FP-0031-C/D = transient-failure trigger — distinct paths, no shared state. Compose test asserts `should_force_close` is content-only, idempotent, no retry/attempt coupling.
- **By-construction termination**: `assert_turn_budget_bounds` (threshold > output_reserve + offload_cap) so re-entries are finite (#1092 guarantee).

## Test plan
- [x] 6 new Tier-2 tests (threshold fire/inert, system-turn exclusion, output_reserve cap, record roundtrip, by-construction bound, FP-0031 orthogonality) → pass.
- [x] No regression — force-close suite + planner suite → **175 passed, 2 skipped**.
- [x] Reconciled `test_force_close_3axis_uniformity_1092`: "plan does NOT wire" → "plan wires" (all 3 axes now wire — uniformity complete).
- [x] `test_tier_audit --strict` (new + reconciled) → **green**.
- [ ] (deferred to PR2) same-step re-entry from the consolidation + the full re-plan loop = light dogfood (overlaps #289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
