### PR TITLE
feat(1285): plan-axis force-close same-step re-entry — PR2 (#1092 plan axis)

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -91,6 +91,25 @@ _PLAN_MAX_STEPS = 7
 # Overridable via ``reyn.yaml plan.retry_limit``.
 _PLAN_STEP_RETRY_LIMIT = 3
 
+# #1285 PR2 (#1092 plan-axis force-close re-entry): defensive cap on force-close
+# re-entries per step. by-construction termination (PR1 assert_turn_budget_bounds:
+# progress_margin > 0 ⇒ each re-entry makes progress) already guarantees finite
+# re-entries; this is a generous backstop — on cap the step terminates best-effort
+# at the last consolidation (the PR1 FLOOR). DISTINCT from _PLAN_STEP_RETRY_LIMIT
+# (FP-0031 transient-failure retry) — the two counters never conflate.
+_PLAN_STEP_MAX_FORCE_CLOSE_REENTRIES = 8
+
+# Continuation framing for a force-close re-entry: the bounded wrap-up
+# consolidation is handed back as the next user turn so the re-entered step
+# CONTINUES from it (not a restart). run() builds [system(goal), user(this)];
+# {consolidation} is filled per re-entry.
+_PLAN_STEP_FORCE_CLOSE_CONTINUE_TEMPLATE = (
+    "The work on this step so far has been consolidated below (the working "
+    "context reached its size limit and was wrapped up). Continue from this "
+    "consolidation toward completing the step — do NOT restart from scratch.\n\n"
+    "--- Consolidation of work so far ---\n{consolidation}"
+)
+
 # B42-NF-W6-1: continuation directive passed to RouterLoop's empty-stop
 # retry path. RouterLoop only consults this when the
 # ``REYN_EMPTY_STOP_RETRY=1`` env var is set, so the production code wires
@@ -1131,6 +1150,14 @@ async def execute_plan(
             step_succeeded = False
             desc_preview = (step.description or step.id)[:60]
             attempt = 0
+            # #1285 PR2 (#1092 plan-axis re-entry, Q-A): force-close re-entry
+            # state, DISTINCT from FP-0031 ``attempt`` (cumulative-context vs
+            # transient-failure trigger — never conflated). On force-close the
+            # step re-enters the SAME step from the bounded consolidation
+            # (continuation, not restart), bounded by the by-construction floor
+            # (PR1 assert_turn_budget_bounds) + the defensive cap above.
+            fc_reentries = 0
+            _seed_user_text = step.description
             # Issue #214 (= #180 #2 split): set the plan_step contextvar
             # for the duration of this step's sub-loop. The ContextVar
             # propagates through any asyncio.Task the sub-loop spawns
@@ -1148,13 +1175,47 @@ async def execute_plan(
                         step_id=step.id,
                     ):
                         sub_usage = await sub_loop.run(
-                            user_text=step.description, history=[],
+                            user_text=_seed_user_text, history=[],
                         )
                     if sub_usage is not None:
                         total_usage.prompt_tokens += sub_usage.prompt_tokens
                         total_usage.completion_tokens += sub_usage.completion_tokens
+                    # #1285 PR2: force-close re-entry (the no-exception success
+                    # path — mutually exclusive with the transient-retry except
+                    # branch below). If the step force-closed and the re-entry cap
+                    # is not yet hit, re-enter the SAME step from the bounded
+                    # consolidation (continuation via the next user turn, NOT a
+                    # restart). ``attempt`` RESETS to 0 (fresh transient-retry
+                    # budget for the re-entered turn-set); ``fc_reentries`` is the
+                    # SEPARATE force-close counter (never conflated with attempt).
+                    # On cap → fall through to the FLOOR (the last consolidation is
+                    # the step output via the capture below).
+                    _fc = narrow_host.forced_close_result
+                    if _fc is not None and fc_reentries < _PLAN_STEP_MAX_FORCE_CLOSE_REENTRIES:
+                        fc_reentries += 1
+                        _seed_user_text = _PLAN_STEP_FORCE_CLOSE_CONTINUE_TEMPLATE.format(
+                            consolidation=(getattr(_fc, "content", None) or ""),
+                        )
+                        attempt = 0  # reset transient-retry budget for the re-entry
+                        narrow_host = _PlanStepHost(
+                            plan=plan, step=step,
+                            prior_results=step_results, parent=parent_host,
+                            turn_budget_engine=_plan_turn_budget_engine,
+                        )
+                        sub_loop = RouterLoop(
+                            host=narrow_host,
+                            chain_id=chain_id,
+                            max_iterations=step_max_iterations or _PLAN_STEP_MAX_ITERATIONS,
+                            router_model=router_model,
+                            budget=budget,
+                            system_prompt_override=sys_prompt,
+                            exclude_tools={"plan"},
+                            memo_provider=memo_provider,
+                            empty_stop_retry_directive=_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE,
+                        )
+                        continue  # re-enter — does NOT consume the FP-0031 attempt budget
                     step_succeeded = True
-                    break  # success — exit retry loop
+                    break  # success (or force-close cap reached → FLOOR) — exit retry loop
                 except _PLAN_RETRY_EXCLUDED as exc:
                     raise  # delegate to safety layer / abort path
                 except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1053,3 +1053,151 @@ def test_plan_invalid_retry_directive_handles_empty_input():
     out_none = _build_plan_invalid_retry_directive(None)  # type: ignore[arg-type]
     assert "failed validation:" in out_empty
     assert "failed validation:" in out_none
+
+
+# ── #1285 PR2: plan-axis force-close re-entry (Q-A re-enter-same-step) ────────
+# Force-close is simulated by the fake RouterLoop calling
+# ``host.record_force_close(...)`` (the cumulative-axis trigger), which is what
+# the real RouterLoop.run_loop does on threshold — so these tests exercise
+# execute_plan's re-entry control-flow deterministically without a real LLM.
+
+
+@pytest.mark.asyncio
+async def test_plan_step_force_close_reenters_same_step_and_converges():
+    """Tier 2: #1285 PR2 — a step that force-closes once re-enters the SAME step
+    from the bounded consolidation (continuation, NOT restart) and converges; the
+    re-entry's user turn carries the consolidation text."""
+    import reyn.chat.planner as planner_mod
+    from reyn.chat.planner import execute_plan
+
+    calls: list[str] = []
+
+    class _ForceCloseOnceLoop:
+        def __init__(self, *, host, **kwargs):
+            self.host = host
+
+        async def run(self, *, user_text, history):
+            calls.append(user_text)
+            _n = len(calls)
+            if _n == 1:  # first turn-set of s1 → force-close (cumulative)
+                self.host.record_force_close(
+                    type("FC", (), {"content": "CONSOLIDATED-WORK-XYZ"})()
+                )
+                return None
+            await self.host.put_outbox(kind="agent", text="done", meta={})
+            return None
+
+    orig = planner_mod.RouterLoop
+    planner_mod.RouterLoop = _ForceCloseOnceLoop  # type: ignore[assignment]
+    try:
+        host = _SimpleHost()
+        plan = Plan(
+            goal="g",
+            steps=(
+                PlanStep(id="s1", description="long step", tools=()),
+                PlanStep(id="s2", description="synth", tools=(), depends_on=("s1",)),
+            ),
+        )
+        result = await execute_plan(plan, parent_host=host, chain_id="c0")
+    finally:
+        planner_mod.RouterLoop = orig
+
+    # Re-entered once (s1 ran twice) then converged → s1 not a failure.
+    assert "s1" not in result.step_failures
+    # Q2 continuation: a re-entry user turn carries the consolidation, so the step
+    # CONTINUES from it (not a from-scratch restart) — proves the force-close
+    # re-entry seeded the consolidation rather than re-issuing the original task.
+    assert any("CONSOLIDATED-WORK-XYZ" in c for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_plan_step_force_close_reentry_bounded_by_cap():
+    """Tier 2: #1285 PR2 — a step that force-closes EVERY turn re-enters up to the
+    cap then terminates at the FLOOR (bounded, never infinite)."""
+    import reyn.chat.planner as planner_mod
+    from reyn.chat.planner import (
+        _PLAN_STEP_MAX_FORCE_CLOSE_REENTRIES,
+        execute_plan,
+    )
+
+    calls: list[str] = []
+
+    class _AlwaysForceCloseLoop:
+        def __init__(self, *, host, **kwargs):
+            self.host = host
+
+        async def run(self, *, user_text, history):
+            calls.append(user_text)
+            self.host.record_force_close(type("FC", (), {"content": "C"})())
+            return None
+
+    orig = planner_mod.RouterLoop
+    planner_mod.RouterLoop = _AlwaysForceCloseLoop  # type: ignore[assignment]
+    try:
+        host = _SimpleHost()
+        plan = Plan(
+            goal="g",
+            steps=(
+                PlanStep(id="s1", description="irreducible step", tools=()),
+                PlanStep(id="s2", description="synth", tools=(), depends_on=("s1",)),
+            ),
+        )
+        await execute_plan(plan, parent_host=host, chain_id="c0")
+    finally:
+        planner_mod.RouterLoop = orig
+
+    # Each step force-closes cap times then FLOOR-terminates (cap+1 calls/step);
+    # 2 steps → bounded total, proving no infinite re-entry (the test returning at
+    # all proves finite; the exact count proves it is the cap that bounds it).
+    _n_calls = len(calls)
+    assert _n_calls == 2 * (_PLAN_STEP_MAX_FORCE_CLOSE_REENTRIES + 1)
+
+
+@pytest.mark.asyncio
+async def test_plan_step_force_close_and_transient_compose():
+    """Tier 2: #1285 PR2 Q4 — force-close (cumulative) and FP-0031 transient retry
+    COMPOSE with separate counters: a step that force-closes once AND transient-
+    fails once on the re-entered turn-set still completes (attempt reset to 0 on
+    the force-close re-entry, then the transient retry succeeds — the two triggers
+    never conflate)."""
+    import reyn.chat.planner as planner_mod
+    from reyn.chat.planner import execute_plan
+
+    calls: list[str] = []
+
+    class _ComposeLoop:
+        def __init__(self, *, host, **kwargs):
+            self.host = host
+
+        async def run(self, *, user_text, history):
+            calls.append(user_text)
+            n = len(calls)
+            if n == 1:  # s1 turn-set 1 → force-close (cumulative trigger)
+                self.host.record_force_close(type("FC", (), {"content": "C1"})())
+                return None
+            if n == 2:  # s1 re-entered turn-set → transient failure (FP-0031 trigger)
+                raise RuntimeError("transient on the re-entered turn-set")
+            await self.host.put_outbox(kind="agent", text="done", meta={})
+            return None
+
+    orig = planner_mod.RouterLoop
+    planner_mod.RouterLoop = _ComposeLoop  # type: ignore[assignment]
+    try:
+        host = _SimpleHost()
+        plan = Plan(
+            goal="g",
+            steps=(
+                PlanStep(id="s1", description="force-close then transient", tools=()),
+                PlanStep(id="s2", description="synth", tools=(), depends_on=("s1",)),
+            ),
+        )
+        result = await execute_plan(plan, parent_host=host, chain_id="c0", retry_limit=3)
+    finally:
+        planner_mod.RouterLoop = orig
+
+    # Composed: force-close re-entry (fc_reentries=1) AND a transient retry
+    # (attempt 0→1 after the force-close reset) both fired, and s1 still completed.
+    assert "s1" not in result.step_failures
+    # call 2 = the force-close re-entry (continuation carries the consolidation);
+    # the transient on it is retried (FP-0031) without consuming a force-close.
+    assert "C1" in calls[1]


### PR DESCRIPTION
**[dogfood-coder]** — #1285 **PR2 (same-step re-entry, Q-A)**, builds on PR1 FLOOR (#1304, merged). Design ratified by lead-coder (issue #1285 issuecomment-4622594736 + 4622... GO; single-loop-two-counters approved as the equivalent of nested loops).

## What this adds (on top of PR1 FLOOR)
On force-close the step no longer ends at the consolidation — it **re-enters the SAME step** from the bounded consolidation (continuation, not restart) until it finishes without force-closing. Mirrors phase PR-D2.

## Implementation — single augmented loop, two distinct counters
Lead-approved equivalent of literal nested loops (identical semantics; avoids a ~190-line re-indent / edit-risk):
- **`attempt`** = FP-0031 transient retry (except branch; `++` on transient).
- **`fc_reentries`** = force-close cumulative re-entry (no-exception success branch when `forced_close_result` is set; `++` on force-close, **RESETS `attempt`=0** for a fresh transient budget on the re-entered turn-set).
- Branches **mutually exclusive** (transient XOR force-close XOR done); counters never conflate.

## Design answers
- **Q2 continuation** (confirmed via `run()` flow-trace, router_loop.py:1853/1864): re-entry seeds the consolidation as the next **user** turn → `run()` builds `[system(goal), user(consolidation+continue)]` → the step **continues** from the consolidation (ordering-safe; no assistant-first turn; not a restart).
- **Q3 bound**: by-construction (PR1 `assert_turn_budget_bounds`: `progress_margin>0` ⇒ finite) PRIMARY + defensive cap `_PLAN_STEP_MAX_FORCE_CLOSE_REENTRIES=8`; on cap → FLOOR.
- **Q4 compose**: force-close re-entry + FP-0031 transient retry coexist with separate counters.

## Test plan (review focus: branch-equivalence + Q4 compose)
- [x] re-enter-same-step + converge (+ **Q2**: a re-entry user turn carries the consolidation).
- [x] bounded-by-cap (finite; `== cap+1` per step — proves the cap bounds it).
- [x] **Q4 compose** (force-close once + transient-fail once on the re-entered turn-set → both counters move independently, step completes).
- [x] Deterministic scripted fake RouterLoop (mirrors the FP-0031 retry test harness; no LLM/mock).
- [x] No regression — planner + force-close suite → **191 passed, 2 skipped**; `test_tier_audit --strict` → green.
- [ ] (light dogfood) full real-LLM re-plan loop on a long plan step = #289 plan-axis force-close dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
