### PR TITLE
feat(1303): S-I.2 index_docs cutover — chunker streams to provider-direct embed+index

### DIFF
--- a/src/reyn/safe/embed_index.py
+++ b/src/reyn/safe/embed_index.py
@@ -26,13 +26,22 @@ Design (ADR-0033 op-separation reasons preserved internally)
   the write so the per-turn router system prompt reflects the latest chunk
   count / model (mirrors the old ``index_write`` op).
 
-Permission / config context
----------------------------
-Mirrors :mod:`reyn.safe.file` / :mod:`reyn.safe.http`: the parent wires the
-workspace root + embedding config via :func:`_set_context` before the user
-step runs (the python harness does this). Writes land only under
-``<workspace_root>/.reyn/index/`` (the default write zone), so the safe-mode
-step needs no out-of-zone declaration.
+Config context (self-sufficient — #1303 S-I.2 fork (B))
+-------------------------------------------------------
+This module resolves its own workspace root + embedding config, mirroring the
+old embed op's self-loading (``op_runtime/embed.py``), so the python harness
+needs **no** extra wiring:
+
+- **workspace_root** defaults to ``Path.cwd()``. The chunker subprocess runs
+  in the workspace, and ``cwd == workspace`` is the established contract — the
+  chunker already writes ``.reyn/index/<source>/.lock`` relative to cwd. All
+  index writes land under ``<cwd>/.reyn/index/`` (the default write zone), so
+  the safe-mode step needs no out-of-zone declaration.
+- **provider / embedding config** come from ``REYN_EMBEDDING_PROVIDER`` +
+  ``load_config().embedding`` (byte-identical to the old embed op).
+
+:func:`_set_context` overrides these for tests; any field left ``None`` keeps
+the default resolution. :func:`_reset_context` restores the defaults.
 
 Internal layering
 -----------------
@@ -44,6 +53,7 @@ validator only rejects *user-code* imports outside the allowlist, and
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
@@ -55,42 +65,69 @@ from reyn.index.source_manifest import SourceEntry, get_source_manifest
 
 # ── Internal state ─────────────────────────────────────────────────────────
 #
-# Set once at python-harness start-up via :func:`_set_context` (mirrors
-# ``reyn.safe.file`` / ``reyn.safe.http``'s module-globals contract).
+# All ``None`` = use the self-sufficient defaults (cwd / env / lazy config).
+# :func:`_set_context` overrides any subset for tests; :func:`_reset_context`
+# restores the defaults. Mirrors the module-globals contract of
+# ``reyn.safe.file`` / ``reyn.safe.http``, but defaulting (not requiring) so
+# the harness needs no wiring (#1303 S-I.2 fork (B)).
 
 _workspace_root: Path | None = None
-_embedding_config: dict = {}
-_provider_name: str = "litellm"
-_context_initialised: bool = False
+_embedding_config: dict | None = None
+_provider_name: str | None = None
 
 
 def _set_context(
     *,
-    workspace_root: str | Path,
+    workspace_root: str | Path | None = None,
     embedding_config: dict | None = None,
-    provider_name: str = "litellm",
+    provider_name: str | None = None,
 ) -> None:
-    """Wire the workspace root + embedding config into this module.
+    """Override the self-sufficient defaults (test / explicit-wiring hook).
 
-    Called by the python harness before the user step runs. Tests that
-    exercise the API directly call this to establish a controlled context.
-    Idempotent — overwrites the previous context.
+    Any argument left ``None`` keeps the default resolution for that field.
     """
-    global _workspace_root, _embedding_config, _provider_name, _context_initialised
-    _workspace_root = Path(workspace_root)
-    _embedding_config = dict(embedding_config or {})
-    _provider_name = provider_name
-    _context_initialised = True
+    global _workspace_root, _embedding_config, _provider_name
+    if workspace_root is not None:
+        _workspace_root = Path(workspace_root)
+    if embedding_config is not None:
+        _embedding_config = dict(embedding_config)
+    if provider_name is not None:
+        _provider_name = provider_name
 
 
-def _require_context() -> Path:
-    if not _context_initialised or _workspace_root is None:
-        raise RuntimeError(
-            "reyn.safe.embed_index: context not initialised. The parent "
-            "process must call _set_context(workspace_root=...) before the "
-            "safe-mode step runs (the python harness wires this)."
-        )
-    return _workspace_root
+def _reset_context() -> None:
+    """Clear all overrides → back to the self-sufficient defaults."""
+    global _workspace_root, _embedding_config, _provider_name
+    _workspace_root = None
+    _embedding_config = None
+    _provider_name = None
+
+
+def _resolve() -> tuple[Path, str, dict]:
+    """Resolve (workspace_root, provider_name, embedding_config), defaulting to
+    the self-sufficient sources when not overridden:
+      - workspace_root: ``Path.cwd()`` (cwd == workspace contract).
+      - provider_name: ``REYN_EMBEDDING_PROVIDER`` env (default ``"litellm"``).
+      - embedding_config: ``load_config().embedding`` for litellm (mirrors the
+        old embed op); ``{}`` otherwise.
+    """
+    ws = _workspace_root if _workspace_root is not None else Path.cwd()
+    pname = (
+        _provider_name
+        if _provider_name is not None
+        else os.environ.get("REYN_EMBEDDING_PROVIDER", "litellm")
+    )
+    if _embedding_config is not None:
+        cfg = _embedding_config
+    elif pname == "litellm":
+        try:
+            from reyn.config import load_config
+            cfg = load_config().embedding or {}
+        except Exception:
+            cfg = {}
+    else:
+        cfg = {}
+    return ws, pname, cfg
 
 
 # ── Core ───────────────────────────────────────────────────────────────────
@@ -115,8 +152,8 @@ async def embed_and_index_async(
 
     Returns ``{embedded, skipped_embed, written, skipped_write}``.
     """
-    workspace_root = _require_context()
-    provider = get_provider(_provider_name, config=_embedding_config)
+    workspace_root, provider_name, embedding_config = _resolve()
+    provider = get_provider(provider_name, config=embedding_config)
     backend = SqliteIndexBackend(workspace_root=workspace_root)
 
     # Resume key: hashes already indexed (skip BEFORE embedding = cost save).
@@ -251,4 +288,9 @@ def embed_and_index(
     )
 
 
-__all__ = ["embed_and_index", "embed_and_index_async", "_set_context"]
+__all__ = [
+    "embed_and_index",
+    "embed_and_index_async",
+    "_set_context",
+    "_reset_context",
+]

--- a/src/reyn/stdlib/skills/index_docs/artifacts/index_summary.yaml
+++ b/src/reyn/stdlib/skills/index_docs/artifacts/index_summary.yaml
@@ -1,23 +1,20 @@
 name: index_summary
 description: |
   Caller-facing summary of a completed index_docs run. Returned by the
-  skill postprocessor after chunk + embed + index_write pipeline completes.
+  skill postprocessor after the chunk → provider-direct embed+index pipeline
+  completes.
 
-  Fields are nested under their respective postprocessor step outputs:
-  - chunk_stats: result of write_chunks_with_lock (python step)
-  - embed_result: result of embed op
-  - index_result: result of index_write op
+  #1303 Stage I: embedding + index writing are folded into the single
+  write_chunks_with_lock step (it streams chunks into reyn.safe.embed_index),
+  so all run counts now live under one ``chunk_stats`` sub-dict — the separate
+  ``embed_result`` (embed op) and ``index_result`` (index_write op) groups are
+  gone with the run-ops.
 
   The source field and strategy fields (boundary, max_chunk_size_tokens) are
   echoed from the LLM's chunk_strategy decision artifact.
-
-  Bug note (batch 17 S2): the original schema had top-level required fields
-  (chunk_count, embedded_count, etc.) but the postprocessor steps write into
-  data.chunk_stats, data.embed_result, data.index_result sub-dicts.
-  Schema updated to match actual postprocessor output structure.
 schema:
   type: object
-  required: [source, chunk_stats, embed_result, index_result]
+  required: [source, chunk_stats]
   properties:
     source:
       type: string
@@ -31,41 +28,28 @@ schema:
     chunk_stats:
       type: object
       required: [chunk_count, source_lock_acquired]
-      description: Result of the write_chunks_with_lock python step.
+      description: Result of the write_chunks_with_lock step (chunk + embed + index).
       properties:
         chunk_count:
           type: integer
           minimum: 0
-          description: Total chunks produced by the chunker step.
+          description: Total chunks produced (= embedded + skipped_embed).
         source_lock_acquired:
           type: boolean
           description: Whether the source-level lock was acquired.
-        chunks_path:
-          type: string
-          description: Path to chunks.jsonl within the workspace.
-    embed_result:
-      type: object
-      required: [embedded_count, skipped_count]
-      description: Result of the embed op.
-      properties:
-        embedded_count:
+        embedded:
           type: integer
           minimum: 0
-          description: Chunks that were embedded (new or changed).
-        skipped_count:
+          description: Chunks newly embedded this run.
+        skipped_embed:
           type: integer
           minimum: 0
-          description: Chunks skipped (content_hash already in output_artifact).
-    index_result:
-      type: object
-      required: [written]
-      description: Result of the index_write op.
-      properties:
+          description: Chunks skipped before embedding (content_hash already indexed = resume).
         written:
           type: integer
           minimum: 0
           description: Chunks written to the index backend.
-        skipped:
+        skipped_write:
           type: integer
           minimum: 0
-          description: Chunks skipped by index_write (duplicate content_hash).
+          description: Chunks skipped at write time (duplicate content_hash).

--- a/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
+++ b/src/reyn/stdlib/skills/index_docs/chunkers_safe.py
@@ -27,6 +27,7 @@ import json
 import re
 import time as _time
 
+from reyn.safe import embed_index as _embed_index
 from reyn.safe import file as _safe_file
 from reyn.safe import process as _safe_process
 
@@ -70,19 +71,20 @@ def extract_and_split(artifact: dict) -> list:
 # ─── write_chunks_with_lock ─────────────────────────────────────────────────
 
 
-_CHUNKS_JSONL_PATH = "artifacts/chunks.jsonl"
-
-
 def write_chunks_with_lock(artifact: dict) -> dict:
     """Postprocessor python step (mode: safe): source-level advisory lock +
-    chunked JSONL write.
+    provider-direct embed+index (#1303 Stage I).
 
     Receives the artifact after ``extract_and_split`` has placed the ordered
     file list at ``data.chunk_list``. Acquires the source-level lock under
     ``.reyn/index/<source>/.lock`` (= default-zone write), reads each source
     file's content (= default-zone read, granted by ``preprocessor_executor``
-    via CWD), splits into chunks per strategy, writes ``artifacts/chunks.jsonl``
-    (= requires ``permissions.file.write: artifacts``), releases the lock.
+    via CWD), splits into chunks per strategy, and **streams** the chunks
+    straight into :func:`reyn.safe.embed_index.embed_and_index` — which embeds
+    them provider-direct and writes the vectors to
+    ``.reyn/index/<source>/index.db`` (default-zone write) — then releases the
+    lock. There is no intermediate ``<cwd>/artifacts/*.jsonl`` file: the old
+    ``embed`` + ``index_write`` run-ops are folded into this one step.
 
     The lock is recovered as stale when the holder PID is no longer alive
     (= ``reyn.safe.process.pid_alive`` returns False), matching the
@@ -92,9 +94,12 @@ def write_chunks_with_lock(artifact: dict) -> dict:
 
     Returns:
         {
-            "chunk_count":          int,
+            "chunk_count":          int,   # = embedded + skipped_embed
             "source_lock_acquired": bool,
-            "chunks_path":          str,
+            "embedded":             int,   # chunks newly embedded
+            "skipped_embed":        int,   # chunks skipped pre-embed (resume)
+            "written":              int,   # chunks written to the index
+            "skipped_write":        int,   # dup content_hash at write time
         }
     """
     data = artifact.get("data") or {}
@@ -106,6 +111,9 @@ def write_chunks_with_lock(artifact: dict) -> dict:
         "preserve_parent_context": bool(data.get("preserve_parent_context", True)),
     }
     source = str(data.get("source") or "unknown")
+    mode = str(data.get("mode") or "append")
+    description = data.get("description")
+    path = data.get("path")
     chunk_list = data.get("chunk_list") or []
     file_paths: list[str] = []
     seen: set[str] = set()
@@ -144,33 +152,43 @@ def write_chunks_with_lock(artifact: dict) -> dict:
     lock_acquired = True
 
     try:
-        chunk_count = _write_chunks_jsonl_from_paths(file_paths, strategy)
+        stats = _embed_index.embed_and_index(
+            _iter_chunks_from_paths(file_paths, strategy),
+            source,
+            "standard",
+            mode=mode,
+            description=description if isinstance(description, str) else None,
+            path=path if isinstance(path, str) else None,
+        )
     finally:
         _safe_file.delete(lock_path, missing_ok=True)
 
     return {
-        "chunk_count": chunk_count,
+        "chunk_count": stats["embedded"] + stats["skipped_embed"],
         "source_lock_acquired": lock_acquired,
-        "chunks_path": _CHUNKS_JSONL_PATH,
+        "embedded": stats["embedded"],
+        "skipped_embed": stats["skipped_embed"],
+        "written": stats["written"],
+        "skipped_write": stats["skipped_write"],
     }
 
 
-# ─── JSONL writer + split helpers ───────────────────────────────────────────
+# ─── chunk generator + split helpers ────────────────────────────────────────
 #
 # Originally duplicated from the (now-deleted) ``chunkers.py``
 # ``apply_strategy`` codepath; kept here as the canonical home. Pure regex
 # + string ops, no external dependencies.
 
 
-def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int:
-    """Chunk an ordered list of file paths and write artifacts/chunks.jsonl.
+def _iter_chunks_from_paths(file_paths: list[str], strategy: dict):
+    """Yield chunk dicts (``{text, metadata}``) from an ordered file list.
 
-    Reads source files via :mod:`reyn.safe.file`; writes the JSONL output
-    via the same. The output path ``artifacts/chunks.jsonl`` is outside
-    the default ``.reyn/`` write zone and is granted explicitly in
-    skill.md via ``permissions.file.write: artifacts``.
-
-    Returns the number of chunks written (= one JSONL row per chunk).
+    Reads source files via :mod:`reyn.safe.file` and streams the chunks
+    straight into :func:`reyn.safe.embed_index.embed_and_index` — no
+    intermediate JSONL file (#1303 Stage I). A generator so a bulk index
+    holds only one embed batch in memory at a time. Pure regex + string ops,
+    no external dependencies. Unreadable files are silently skipped (matches
+    the legacy OSError-swallowing read loop).
     """
     boundary = strategy["boundary"]
     max_size = strategy["max_chunk_size_tokens"]
@@ -178,10 +196,7 @@ def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int
     overlap = strategy.get("overlap_ratio", 0.0)
     preserve = strategy.get("preserve_parent_context", True)
 
-    _safe_file.mkdir("artifacts", parents=True, exist_ok=True)
-
     chunk_idx = 0
-    chunk_records: list[str] = []
     for file_path in file_paths:
         try:
             text = _safe_file.read(file_path)
@@ -195,20 +210,14 @@ def _write_chunks_jsonl_from_paths(file_paths: list[str], strategy: dict) -> int
                 "source_path": file_path,
                 "source_type": suffix_no_dot(file_path) or "unknown",
                 "content_hash": content_hash,
-                "embedding_model": "",   # filled in by embed op
+                "embedding_model": "",   # filled in by embed_and_index
                 "chunk_index": chunk_idx,
                 "size_tokens": approx_tokens(chunk_text),
                 "parent_context": parent_ctx if preserve else None,
                 "extra": {},
             }
-            record = {"text": chunk_text, "metadata": metadata}
-            chunk_records.append(json.dumps(record, ensure_ascii=False))
+            yield {"text": chunk_text, "metadata": metadata}
             chunk_idx += 1
-
-    # Single write to keep the file atomic-ish (= no partial JSONL on
-    # mid-write crash; the prior unsafe-mode version streamed line-by-line).
-    _safe_file.write(_CHUNKS_JSONL_PATH, "\n".join(chunk_records) + ("\n" if chunk_records else ""))
-    return chunk_idx
 
 
 def suffix_no_dot(path: str) -> str:

--- a/src/reyn/stdlib/skills/index_docs/skill.md
+++ b/src/reyn/stdlib/skills/index_docs/skill.md
@@ -6,8 +6,8 @@ description: |
 
   Phase 1 (LLM): inspect file samples + cost preflight, decide a chunk
   strategy, or abort if cost is unexpectedly high.
-  Phase 2 (Skill.postprocessor): deterministic chunk → embed → index_write
-  pipeline; LLM is not involved.
+  Phase 2 (Skill.postprocessor): deterministic chunk → provider-direct
+  embed+index pipeline; LLM is not involved.
 
   Override the chunkers module for project-specific formats (Python AST,
   custom Markdown, etc.) via `extends: stdlib/index_docs` + module override.
@@ -17,7 +17,7 @@ final_output_description: |
   LLM-contract artifact: chunking strategy decision (boundary, chunk size,
   overlap, parent context flag) plus echoed passthrough fields (source,
   path, description, mode). The skill postprocessor uses this to run the
-  deterministic chunk → embed → index_write pipeline.
+  deterministic chunk → provider-direct embed+index pipeline.
 finish_criteria:
   - File samples and cost preflight were reviewed
   - A chunk_strategy was decided (or abort was issued for high-cost inputs)
@@ -48,23 +48,16 @@ permissions:
       function: extract_and_split
       mode: safe
       timeout: 30
-    # FP-0042 Phase 2.2 (2026-05-23): write_chunks_with_lock migrated to
-    # chunkers_safe.py (mode: safe). Source file reads + lock + jsonl
-    # write all go through reyn.safe.file; PID identity + liveness go
-    # through reyn.safe.process. The artifacts/ write zone below grants
-    # the chunks.jsonl output (= outside the default .reyn/ zone).
+    # #1303 Stage I (2026-06-04): write_chunks_with_lock streams chunks
+    # straight into reyn.safe.embed_index (provider-direct embed+index) —
+    # no intermediate JSONL file. Source reads go through reyn.safe.file;
+    # PID identity + liveness through reyn.safe.process; embed+index writes
+    # land under .reyn/index/<source>/ (default write zone). No out-of-zone
+    # file.write grant is needed (the old `artifacts` grant is dropped).
     - module: ./chunkers_safe.py
       function: write_chunks_with_lock
       mode: safe
       timeout: 300
-  # FP-0042 Phase 2.2: write_chunks_with_lock writes the chunked JSONL
-  # output to ``<cwd>/artifacts/chunks.jsonl`` — outside the default
-  # ``.reyn/`` write zone, so it needs an explicit grant. The lock file
-  # at ``.reyn/index/<source>/.lock`` does not need a declaration (=
-  # default-zone write).
-  file.write:
-    - path: artifacts
-      scope: recursive
 postprocessor:
   output_schema: index_summary
   steps:
@@ -81,7 +74,9 @@ postprocessor:
           required: [source_path]
           properties:
             source_path: {type: string}
-    # Step 2: safe — lock + file content read + .jsonl write via reyn.safe.file.
+    # Step 2: safe — lock + file content read + provider-direct embed+index
+    # (streams chunks into reyn.safe.embed_index; folds the old embed +
+    # index_write run-ops, no intermediate file). #1303 Stage I.
     - type: python
       module: ./chunkers_safe.py
       function: write_chunks_with_lock
@@ -93,26 +88,10 @@ postprocessor:
         properties:
           chunk_count:          {type: integer, minimum: 0}
           source_lock_acquired: {type: boolean}
-          chunks_path:          {type: string}
-    - type: run_op
-      into: data.embed_result
-      op:
-        kind: embed
-        input_artifact: artifacts/chunks.jsonl
-        output_artifact: artifacts/chunks_with_vectors.jsonl
-      args_from: {}
-    - type: run_op
-      into: data.index_result
-      op:
-        kind: index_write
-        source: __placeholder__
-        input_artifact: artifacts/chunks_with_vectors.jsonl
-        mode: append
-      args_from:
-        source: data.source
-        mode: data.mode
-        description: data.description
-        path: data.path
+          embedded:             {type: integer, minimum: 0}
+          skipped_embed:        {type: integer, minimum: 0}
+          written:              {type: integer, minimum: 0}
+          skipped_write:        {type: integer, minimum: 0}
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---
@@ -135,14 +114,15 @@ the LLM has decided the chunking strategy.
 2. **Skill.postprocessor** (deterministic, LLM not involved):
    - `extract_and_split` (python step, safe): enumerates source files via
      glob; no file content read
-   - `write_chunks_with_lock` (python step, safe): reads each source file
-     via `reyn.safe.file`, splits into chunks per strategy, acquires
-     source-level advisory lock (UX gap fix D), writes
-     `artifacts/chunks.jsonl` to the workspace
-   - `embed` (run_op): reads `chunks.jsonl`, embeds via LiteLLM, writes
-     `artifacts/chunks_with_vectors.jsonl` (progress events = UX gap fix C)
-   - `index_write` (run_op): reads `chunks_with_vectors.jsonl`, writes to
-     `SqliteIndexBackend`, updates `SourceManifest`
+   - `write_chunks_with_lock` (python step, safe): acquires the source-level
+     advisory lock (UX gap fix D), reads each source file via `reyn.safe.file`,
+     splits into chunks per strategy, and **streams** the chunks into
+     `reyn.safe.embed_index.embed_and_index` — which embeds them provider-direct
+     and writes the vectors to `SqliteIndexBackend`
+     (`.reyn/index/<source>/index.db`), then updates `SourceManifest`. No
+     intermediate file (#1303 Stage I folds the old `embed` + `index_write`
+     run-ops into this step). Resume = DB-as-checkpoint: already-indexed
+     `content_hash`es are skipped before embedding.
 
 ## Input
 
@@ -164,9 +144,11 @@ flag-form CLI wrapper is tracked as carry-over but not implemented in 1.0.
 
 `index_summary` with:
 - `source` — the indexed source name
-- `chunk_count` — total chunks produced
-- `embedded_count` / `skipped_count` — embed op results
-- `written_count` — chunks written to the index backend
+- `chunk_stats` — the write_chunks_with_lock result:
+  - `chunk_count` — total chunks produced (= `embedded` + `skipped_embed`)
+  - `embedded` / `skipped_embed` — newly embedded vs skipped pre-embed (resume)
+  - `written` / `skipped_write` — written to the index vs dup `content_hash`
+  - `source_lock_acquired` — whether the source lock was held
 - `boundary` / `max_chunk_size_tokens` — strategy used
 
 ## Override pattern (ADR-0033 §2.1)
@@ -199,12 +181,16 @@ postprocessor:
       into: data.chunk_stats
       mode: safe
       output_schema: ...
-    # embed + index_write steps unchanged (inherited)
+    # embed+index happen inside write_chunks_with_lock (it streams chunks
+    # into reyn.safe.embed_index) — no separate embed / index_write steps.
 ```
 
-The pre-FP-0042 single-step `apply_strategy` override path was retired in
-Phase 2.8 — projects that previously overrode it should split into the
-two-step chain above.
+A project chunker override should call
+`reyn.safe.embed_index.embed_and_index(chunks, source, "standard", mode=...,
+description=..., path=...)` from its `write_chunks_with_lock` so the
+provider-direct embed+index, DB-checkpoint resume, and SourceManifest upsert
+are preserved. The pre-FP-0042 single-step `apply_strategy` override path was
+retired in Phase 2.8.
 
 ## Cost preflight (UX gap fix B)
 
@@ -220,5 +206,8 @@ with a `SourceLockedError` (= clear error message listing the holder PID).
 
 ## Progress feedback (UX gap fix C)
 
-The `embed` op handler emits `embed_progress` events per batch, available
-in the event log and surfaced by the TUI's cost/progress tab.
+Per-batch `embed_progress` events came from the old `embed` op. With embedding
+folded into the safe-mode `write_chunks_with_lock` step (which runs in the
+python-harness subprocess), per-batch progress does not currently cross the
+subprocess boundary — tracked as a follow-up (#1306). Phase-1 `cost_preflight`
+(the cost the LLM approves up front) is unchanged.

--- a/tests/test_1303_si1_safe_embed_index.py
+++ b/tests/test_1303_si1_safe_embed_index.py
@@ -63,8 +63,10 @@ def _chunk(text: str, idx: int) -> dict:
 def _wire(tmp_path: Path):
     register_provider("counting_fake", CountingFakeProvider)
     CountingFakeProvider.embedded_texts = 0
+    ei._reset_context()
     ei._set_context(workspace_root=tmp_path, provider_name="counting_fake")
     yield
+    ei._reset_context()
 
 
 @pytest.mark.asyncio
@@ -167,3 +169,28 @@ def test_sync_wrapper(tmp_path: Path) -> None:
         [_chunk("sync path chunk", 0)], source="s", model="standard",
     )
     assert result["embedded"] == 1
+
+
+@pytest.mark.asyncio
+async def test_workspace_defaults_to_cwd(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: with no workspace_root override, the index lands under cwd
+    (the cwd==workspace contract the safe-mode chunker relies on)."""
+    ei._reset_context()
+    ei._set_context(provider_name="counting_fake")  # provider only, ws=cwd
+    monkeypatch.chdir(tmp_path)
+    await ei.embed_and_index_async([_chunk("cwd chunk", 0)], source="d", model="standard")
+    assert (tmp_path / ".reyn" / "index" / "d" / "index.db").exists()
+
+
+@pytest.mark.asyncio
+async def test_set_context_overrides_cwd(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: an explicit _set_context(workspace_root=...) override wins over
+    cwd — the index lands at the override, not the working directory."""
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    ei._reset_context()
+    ei._set_context(workspace_root=other, provider_name="counting_fake")
+    monkeypatch.chdir(tmp_path)
+    await ei.embed_and_index_async([_chunk("override chunk", 0)], source="d", model="standard")
+    assert (other / ".reyn" / "index" / "d" / "index.db").exists()
+    assert not (tmp_path / ".reyn" / "index" / "d" / "index.db").exists()

--- a/tests/test_chunkers_safe_write_chunks.py
+++ b/tests/test_chunkers_safe_write_chunks.py
@@ -1,15 +1,15 @@
-"""Tier 2 — chunkers_safe.write_chunks_with_lock contract tests (FP-0042 Phase 2.2).
+"""Tier 2 — chunkers_safe.write_chunks_with_lock contract tests.
 
-Tests the safe-mode postprocessor step that replaced chunkers.py's
-unsafe-mode ``write_chunks_with_lock`` (= advisory lock + chunked
-JSONL write). Coverage mirrors the lock-discipline tests previously
-exercised against the deprecated ``apply_strategy`` so the contract
-stays observably stable across the migration.
+Tests the safe-mode postprocessor step: advisory lock + provider-direct
+embed+index. #1303 Stage I folded the old `embed` + `index_write` run-ops
+into this step — it now streams chunks into `reyn.safe.embed_index` (no
+intermediate `artifacts/chunks.jsonl`) which embeds them and writes the
+vectors to `.reyn/index/<source>/index.db`. Lock-discipline coverage is
+preserved across the cutover.
 
-The function reads source files + writes ``artifacts/chunks.jsonl`` +
-acquires ``.reyn/index/<source>/.lock`` — all through reyn.safe.file.
-The autouse fixture sets a permission context that grants reads
-under tmp_path and writes under tmp_path/.reyn/ + tmp_path/artifacts/.
+The function reads source files via reyn.safe.file (granted under tmp_path)
+and the embed+index writes go to `<cwd>/.reyn/index/` via SqliteIndexBackend.
+A deterministic fake embedding provider avoids any litellm API call.
 """
 from __future__ import annotations
 
@@ -20,7 +20,37 @@ from pathlib import Path
 
 import pytest
 
+from reyn.embedding import register_provider
+from reyn.embedding.provider import EmbedBatchResult
+from reyn.index import SqliteIndexBackend
+from reyn.index.source_manifest import get_source_manifest
+from reyn.safe import embed_index as ei
 from reyn.safe import file as sf
+
+
+class _FakeEmbedProvider:
+    """Deterministic embedding provider (no API)."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self._batch_size = 100
+
+    async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
+        return EmbedBatchResult(
+            vectors=[[float(len(t)), 0.0, 0.0, 0.0] for t in texts],
+            model=model or "fake-embed",
+            total_tokens=sum(len(t) for t in texts),
+        )
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return sum(len(t) for t in texts)
+
+    def get_dimension(self, model: str) -> int:
+        return 4
+
+
+class _RaisingEmbedProvider(_FakeEmbedProvider):
+    async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
+        raise RuntimeError("embed boom")
 
 
 def _load_chunkers_safe():
@@ -41,35 +71,35 @@ _C = _load_chunkers_safe()
 
 
 @pytest.fixture(autouse=True)
-def _reset_safe_file_context():
-    """Reset reyn.safe.file's module-global permission context per test."""
+def _reset_contexts():
+    """Reset reyn.safe.file + reyn.safe.embed_index module-global contexts."""
+    register_provider("fake_cs", _FakeEmbedProvider)
     sf._read_paths = ()
     sf._write_paths = ()
     sf._context_initialised = False
+    ei._reset_context()
     yield
     sf._read_paths = ()
     sf._write_paths = ()
     sf._context_initialised = False
+    ei._reset_context()
 
 
 @pytest.fixture
 def sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Wire a sandbox tmpdir: cwd here, safe.file context grants reads
-    under tmp_path and writes under tmp_path/.reyn + tmp_path/artifacts.
+    under tmp_path and writes under tmp_path/.reyn, and embed_index uses the
+    deterministic fake provider (index writes land at <cwd>/.reyn/index/).
 
-    Mirrors how the production preprocessor_executor wires the
-    subprocess's permission context (= CWD as default read zone;
-    .reyn/ as default write zone; plus explicit artifacts/ from
-    skill.md).
+    Mirrors how production wires the safe-mode step (= CWD as default read
+    zone; .reyn/ as default write zone; embed_index self-sufficient via cwd).
     """
     monkeypatch.chdir(tmp_path)
     sf._set_permission_context(
         read_paths=[str(tmp_path)],
-        write_paths=[
-            str(tmp_path / ".reyn"),
-            str(tmp_path / "artifacts"),
-        ],
+        write_paths=[str(tmp_path / ".reyn")],
     )
+    ei._set_context(provider_name="fake_cs")  # workspace_root defaults to cwd
     return tmp_path
 
 
@@ -97,9 +127,11 @@ def _strategy_payload(*, source: str, file_paths: list[str]) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_write_chunks_writes_jsonl_under_artifacts(sandbox: Path):
-    """Tier 2: write_chunks_with_lock writes artifacts/chunks.jsonl with one
-    JSON object per line, summary dict reflects the count."""
+def test_write_chunks_builds_index(sandbox: Path):
+    """Tier 2: write_chunks_with_lock embeds + writes chunks straight to the
+    SQLite index (no intermediate JSONL); the summary reflects the counts."""
+    import asyncio
+
     md = sandbox / "doc.md"
     md.write_text("Hello world.\n\nSecond paragraph.\n", encoding="utf-8")
 
@@ -110,17 +142,36 @@ def test_write_chunks_writes_jsonl_under_artifacts(sandbox: Path):
 
     assert result["chunk_count"] > 0
     assert result["source_lock_acquired"] is True
-    assert result["chunks_path"] == "artifacts/chunks.jsonl"
+    assert result["embedded"] == result["chunk_count"]
+    assert result["written"] == result["chunk_count"]
 
-    chunks_path = sandbox / "artifacts" / "chunks.jsonl"
-    assert chunks_path.exists()
-    lines = [json.loads(l) for l in chunks_path.read_text().splitlines() if l.strip()]
-    assert len(lines) == result["chunk_count"]
-    for ln in lines:
-        assert "text" in ln
-        assert "metadata" in ln
-        assert "content_hash" in ln["metadata"]
-        assert "source_path" in ln["metadata"]
+    # No intermediate file; the chunks landed in the index.
+    assert not (sandbox / "artifacts" / "chunks.jsonl").exists()
+    stat = asyncio.run(SqliteIndexBackend(workspace_root=sandbox).stat("s1"))
+    assert stat["chunk_count"] == result["chunk_count"]
+
+    # SourceManifest upsert (router system-prompt rebuild reflects the run).
+    entry = asyncio.run(get_source_manifest(sandbox).get("s1"))
+    assert entry is not None
+    assert entry.chunk_count == result["chunk_count"]
+    assert entry.description == "test docs"
+
+
+def test_write_chunks_resume_skips_reembed(sandbox: Path):
+    """Tier 2: ★resume through the chunker path — a second run over the same
+    source re-embeds nothing (existing_hashes pre-embed skip)."""
+    md = sandbox / "doc.md"
+    md.write_text("Hello world.\n\nSecond paragraph.\n\nThird.\n", encoding="utf-8")
+    artifact = _make_artifact(_strategy_payload(source="r1", file_paths=[str(md)]))
+
+    first = _C.write_chunks_with_lock(artifact)
+    assert first["embedded"] > 0
+
+    second = _C.write_chunks_with_lock(
+        _make_artifact(_strategy_payload(source="r1", file_paths=[str(md)]))
+    )
+    assert second["embedded"] == 0
+    assert second["skipped_embed"] == first["chunk_count"]
 
 
 def test_write_chunks_lock_released_on_success(sandbox: Path):
@@ -138,16 +189,21 @@ def test_write_chunks_lock_released_on_success(sandbox: Path):
 
 
 def test_write_chunks_lock_released_on_error(sandbox: Path):
-    """Tier 2: the .lock file is deleted even if the chunking raises.
+    """Tier 2: the .lock file is deleted even if embed+index raises.
 
-    Simulate an inner failure by passing a non-list ``chunk_list`` (=
-    the iteration over ``data.chunk_list`` raises). The lock acquire
-    happens before that, so the ``finally`` block must reap it.
+    Inject a failing provider so embed_and_index raises *inside* the try
+    block (after the lock is acquired); the ``finally`` must reap the lock.
     """
-    artifact = _make_artifact(_strategy_payload(source="err_test", file_paths=[]))
-    artifact["data"]["chunk_list"] = 42  # not iterable as a list of dicts
+    register_provider("raising_cs", _RaisingEmbedProvider)
+    ei._set_context(provider_name="raising_cs")
 
-    with pytest.raises(Exception):
+    md = sandbox / "doc.md"
+    md.write_text("some content here", encoding="utf-8")
+    artifact = _make_artifact(
+        _strategy_payload(source="err_test", file_paths=[str(md)])
+    )
+
+    with pytest.raises(Exception, match="embed boom"):
         _C.write_chunks_with_lock(artifact)
 
     lock_path = sandbox / ".reyn" / "index" / "err_test" / ".lock"
@@ -228,9 +284,11 @@ def test_write_chunks_takes_over_corrupted_lock(sandbox: Path):
 def test_write_chunks_skips_unreadable_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Tier 2: a source path outside the declared read zone is silently
     skipped (matches the legacy OSError-swallowing read loop). When all
-    inputs are denied, the JSONL is empty and chunk_count is 0.
+    inputs are denied, no chunks are produced and chunk_count is 0.
     """
+    register_provider("fake_cs", _FakeEmbedProvider)
     monkeypatch.chdir(tmp_path)
+    ei._set_context(provider_name="fake_cs")
     grant = tmp_path / "ok"
     grant.mkdir()
     denied = tmp_path / "denied"
@@ -244,10 +302,7 @@ def test_write_chunks_skips_unreadable_files(tmp_path: Path, monkeypatch: pytest
         # files in tmp_path/denied/ stay unreadable, which is the path under
         # test.
         read_paths=[str(grant), str(tmp_path / ".reyn")],
-        write_paths=[
-            str(tmp_path / ".reyn"),
-            str(tmp_path / "artifacts"),
-        ],
+        write_paths=[str(tmp_path / ".reyn")],
     )
 
     artifact = _make_artifact(
@@ -256,9 +311,7 @@ def test_write_chunks_skips_unreadable_files(tmp_path: Path, monkeypatch: pytest
     result = _C.write_chunks_with_lock(artifact)
 
     assert result["chunk_count"] == 0
-    chunks_path = tmp_path / "artifacts" / "chunks.jsonl"
-    # Output file is written (possibly empty) — the writer always produces it.
-    assert chunks_path.exists()
+    assert result["embedded"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_index_docs_skill.py
+++ b/tests/test_index_docs_skill.py
@@ -3,7 +3,8 @@
 Covers:
   - skill.md parses and compiles without errors
   - entry_phase, graph, final_output_name correctness
-  - Skill.postprocessor steps = python → embed_run_op → index_write_run_op
+  - Skill.postprocessor steps = python (extract_and_split) → python
+    (write_chunks_with_lock, which embeds+indexes provider-direct) — #1303 S-I
   - Permissions declare python/trusted for all three chunker functions
   - input_schema validates correctly (required fields, mode default)
   - chunk_strategy artifact declares passthrough + strategy fields
@@ -18,7 +19,7 @@ from pathlib import Path
 import pytest
 
 from reyn.compiler.loader import load_dsl_skill
-from reyn.schemas.models import Postprocessor, PythonStep, RunOpStep, Skill
+from reyn.schemas.models import Postprocessor, PythonStep, Skill
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -173,20 +174,19 @@ def test_index_docs_postprocessor_output_name():
     assert skill.postprocessor.output_name == "index_summary"
 
 
-def test_index_docs_postprocessor_four_steps():
-    """Tier 2: postprocessor has steps: python → python → run_op → run_op.
-
-    Post-FP-0042 Phase 2.2: both python steps now run mode: safe via
-    chunkers_safe.py (= extract_and_split + write_chunks_with_lock).
-    Steps 2 and 3 are the existing embed and index_write run_ops.
+def test_index_docs_postprocessor_no_run_ops():
+    """Tier 2: the postprocessor has no run_op steps — #1303 Stage I folded the
+    embed + index_write run-ops into the write_chunks_with_lock python step,
+    which streams chunks into reyn.safe.embed_index.
     """
     skill = _load()
     steps = skill.postprocessor.steps
     assert steps, "expected postprocessor steps to be present"
-    assert steps[0].type == "python"
-    assert steps[1].type == "python"
-    assert steps[2].type == "run_op"
-    assert steps[3].type == "run_op"
+    # The cutover removed both run_op steps; only safe-python steps remain.
+    assert all(s.type == "python" for s in steps), "no run_op steps should remain"
+    fns = [s.function for s in steps if isinstance(s, PythonStep)]
+    assert "extract_and_split" in fns
+    assert "write_chunks_with_lock" in fns
 
 
 def test_index_docs_postprocessor_step0_is_extract_and_split():
@@ -199,42 +199,13 @@ def test_index_docs_postprocessor_step0_is_extract_and_split():
 
 
 def test_index_docs_postprocessor_step1_is_write_chunks_with_lock():
-    """Tier 2: postprocessor step[1] calls write_chunks_with_lock (safe, reyn.safe.file + reyn.safe.process)."""
+    """Tier 2: postprocessor step[1] calls write_chunks_with_lock — the safe
+    step that now also embeds + indexes (streams to reyn.safe.embed_index)."""
     skill = _load()
     step = skill.postprocessor.steps[1]
     assert isinstance(step, PythonStep)
     assert step.function == "write_chunks_with_lock"
     assert step.into == "data.chunk_stats"
-
-
-def test_index_docs_postprocessor_step2_is_embed_op():
-    """Tier 2: postprocessor step[2] is a run_op wrapping an embed op."""
-    skill = _load()
-    step = skill.postprocessor.steps[2]
-    assert isinstance(step, RunOpStep)
-    assert step.op.kind == "embed"
-    assert step.op.input_artifact == "artifacts/chunks.jsonl"
-    assert step.op.output_artifact == "artifacts/chunks_with_vectors.jsonl"
-
-
-def test_index_docs_postprocessor_step3_is_index_write_op():
-    """Tier 2: postprocessor step[3] is a run_op wrapping an index_write op."""
-    skill = _load()
-    step = skill.postprocessor.steps[3]
-    assert isinstance(step, RunOpStep)
-    assert step.op.kind == "index_write"
-    assert step.op.input_artifact == "artifacts/chunks_with_vectors.jsonl"
-
-
-def test_index_docs_postprocessor_step3_args_from():
-    """Tier 2: index_write run_op uses args_from to inject source + mode from artifact."""
-    skill = _load()
-    step = skill.postprocessor.steps[3]
-    assert isinstance(step, RunOpStep)
-    assert "source" in step.args_from
-    assert "mode" in step.args_from
-    assert step.args_from["source"] == "data.source"
-    assert step.args_from["mode"] == "data.mode"
 
 
 # ---------------------------------------------------------------------------
@@ -315,11 +286,12 @@ def test_index_docs_chunk_strategy_boundary_has_enum():
 
 
 def test_index_docs_postprocessor_output_schema_has_required_fields():
-    """Tier 2: postprocessor output_schema includes source + nested step result groups.
+    """Tier 2: postprocessor output_schema includes source + the chunk_stats
+    result group.
 
-    Schema updated in batch 17 dogfood (commit 0c50a20) to match actual
-    postprocessor step output shape: nested chunk_stats / embed_result /
-    index_result groups under data, not flat chunk_count / embedded_count.
+    #1303 Stage I: the embed + index_write run-ops folded into
+    write_chunks_with_lock, so all run counts live under one chunk_stats group
+    (the separate embed_result / index_result groups are gone).
     """
     skill = _load()
     schema = skill.postprocessor.output_schema
@@ -328,13 +300,14 @@ def test_index_docs_postprocessor_output_schema_has_required_fields():
     else:
         data_props = schema.get("properties", {})
 
-    for field in ("source", "chunk_stats", "embed_result", "index_result"):
+    for field in ("source", "chunk_stats"):
         assert field in data_props, (
             f"Required field '{field}' missing from postprocessor output schema"
         )
+    # The old run-op result groups are gone.
+    assert "embed_result" not in data_props
+    assert "index_result" not in data_props
 
     chunk_stats_props = data_props["chunk_stats"].get("properties", {})
-    assert "chunk_count" in chunk_stats_props, "chunk_stats.chunk_count missing"
-
-    embed_props = data_props["embed_result"].get("properties", {})
-    assert "embedded_count" in embed_props, "embed_result.embedded_count missing"
+    for f in ("chunk_count", "embedded", "skipped_embed", "written"):
+        assert f in chunk_stats_props, f"chunk_stats.{f} missing"


### PR DESCRIPTION
**[e2e-coder]** — #1303 Stage I, sub-stage **S-I.2** (design-reviewed: issue #1303 issuecomment-4622618974, fork **B** confirmed). **First behavior-changing** sub-stage. Builds on S-I.1 (#1305, merged).

## What
The index_docs chunker now **streams chunks straight into `reyn.safe.embed_index`** (provider-direct embed+index). The old `embed` + `index_write` run-ops, the intermediate `<cwd>/artifacts/chunks.jsonl` file, and the `file.write: artifacts` grant are **all removed**.

- **`reyn.safe.embed_index` → self-sufficient (fork B)**: defaults `workspace_root` to `Path.cwd()` (the chunker already relies on cwd==workspace — it writes the `.reyn/` lock relative to cwd); provider/config from `REYN_EMBEDDING_PROVIDER` + `load_config().embedding` — **byte-identical config sourcing to the old embed op** (embed.py:170-180). `_set_context` stays as a test/override hook (+ `_reset_context`); **cwd==workspace default made explicit in the docstring + an override test** (per your ask). No python-harness wiring needed — the S-I.1 deferral was correct.
- **`chunkers_safe.py`**: `_write_chunks_jsonl_from_paths` → `_iter_chunks_from_paths` (a generator; no JSONL write). `write_chunks_with_lock` streams it to `embed_and_index(model="standard")` under the source lock and returns the embed/index counts.
- **`skill.md`**: dropped the two run_op steps + `file.write: artifacts`; updated the `write_chunks` output_schema + Execution-flow / Output / Override / Progress docs.
- **`index_summary.yaml`**: folded `embed_result`/`index_result` into one `chunk_stats` group (one step = one result).

## Verify (your reqs — exercised through the chunker path, not just the unit)
- **index_docs e2e**: `test_write_chunks_builds_index` runs extract→chunk→embed→index and asserts the SQLite index DB is built (no JSONL).
- **resume**: `test_write_chunks_resume_skips_reembed` runs the chunker twice over the same source → 2nd run `embedded == 0`, `skipped_embed == chunk_count` (★existing_hashes pre-embed skip, 0 re-embed).
- **SourceManifest upsert**: asserted in the build test (entry chunk_count + description).
- functional-equivalence to the old run_op path: same chunks → same content_hashes → same index rows + manifest; just no intermediate file.

## Test plan
- [x] `pytest tests/test_chunkers_safe_write_chunks.py tests/test_index_docs_skill.py tests/test_1303_si1_safe_embed_index.py -q` — green (contract-reversal tests rewritten, not patched: index-built/resume/manifest/lock-released-on-error/cwd-default+override; index_docs structure → 2-step / chunk_stats shape)
- [x] targeted index/recall/embed/manifest surface (test_op_embed, test_op_recall, test_source_manifest, test_router_indexed_sources, test_index_docs_pure_split_invariants) — 92 passed
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict` (changed test files) — clean (pinned behavior not step-count)
- [x] full `pytest -q` from rootdir — 6885 passed, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, #1203 — orthogonal/CI-green, not this diff)

## Note
Progress-events regression (`embed_progress` was from the embed op; the chunker subprocess can't emit it) is tracked in **#1306** — takes effect with this cutover, as flagged in S-I.1.

Refs #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)