### PR TITLE
feat(1303): S-I.3 index_events cutover — chunker streams to provider-direct embed+index

### DIFF
--- a/src/reyn/stdlib/skills/index_events/artifacts/index_events_summary.yaml
+++ b/src/reyn/stdlib/skills/index_events/artifacts/index_events_summary.yaml
@@ -1,7 +1,8 @@
 name: index_events_summary
 description: |
   Caller-facing summary of a completed index_events run. Returned by the
-  skill postprocessor after chunk → embed → index_write pipeline completes.
+  skill postprocessor after the chunk → provider-direct embed+index pipeline
+  completes.
 
   Fields mirror the incremental processing results: how many runs were
   indexed, skipped (incomplete), or filtered out, plus the new cursor
@@ -46,7 +47,11 @@ schema:
             in Phase 1.
     chunk_stats:
       type: object
-      description: Result of the collect_chunks python step.
+      description: |
+        Result of the run_collect_chunks step (chunk + provider-direct
+        embed+index). #1303 Stage I folded the embed + index_write run-ops
+        into this step, so the embed/index counts live here (the separate
+        embed_result / index_result groups are gone with the run-ops).
       properties:
         chunk_count:
           type: integer
@@ -57,23 +62,18 @@ schema:
         filtered_runs:
           type: integer
           minimum: 0
-    embed_result:
-      type: object
-      description: Result of the embed op.
-      properties:
-        embedded_count:
+        embedded:
           type: integer
           minimum: 0
-        skipped_count:
+        skipped_embed:
           type: integer
           minimum: 0
-    index_result:
-      type: object
-      description: Result of the index_write op.
-      properties:
         written:
           type: integer
           minimum: 0
-        skipped:
+        skipped_write:
           type: integer
           minimum: 0
+        max_completed_at:
+          type: string
+          description: Max completed_at of the indexed batch (fed to run_advance_cursor).

--- a/src/reyn/stdlib/skills/index_events/chunkers.py
+++ b/src/reyn/stdlib/skills/index_events/chunkers.py
@@ -38,11 +38,11 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
+from reyn.safe import embed_index as _embed_index
 from reyn.safe import file as _safe_file
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
-_CHUNKS_JSONL_PATH = "artifacts/event_chunks.jsonl"
 _ERROR_EXCERPT_MAX = 200
 _EPOCH_ISO = "1970-01-01T00:00:00Z"
 
@@ -246,12 +246,22 @@ def run_collect_chunks(artifact: dict) -> dict:
     leading to hallucinated file paths and chunk_count=0). File discovery is
     purely deterministic and belongs in the postprocessor, not in LLM context.
 
-    Writes chunks to artifacts/event_chunks.jsonl for the embed op.
+    Streams chunks straight into reyn.safe.embed_index (provider-direct
+    embed+index, #1303 Stage I — no intermediate event_chunks.jsonl, the old
+    embed + index_write run-ops folded in). Tracks the max completed_at while
+    streaming so run_advance_cursor can advance the cursor from data (it no
+    longer re-reads a file).
+
     Returns summary dict placed at data.chunk_stats:
         {
-            "chunk_count":   int,
-            "skipped_runs":  int,
-            "filtered_runs": int,
+            "chunk_count":      int,   # = embedded + skipped_embed
+            "skipped_runs":     int,
+            "filtered_runs":    int,
+            "embedded":         int,
+            "skipped_embed":    int,
+            "written":          int,
+            "skipped_write":    int,
+            "max_completed_at": str,   # for run_advance_cursor
         }
     """
     data = artifact.get("data") or {}
@@ -268,45 +278,60 @@ def run_collect_chunks(artifact: dict) -> dict:
     events_root = ".reyn/events"
     file_paths = _discover_event_files(events_root)
 
-    _safe_file.mkdir(_dirname(_CHUNKS_JSONL_PATH), parents=True, exist_ok=True)
+    # Mutable holder updated by the generator as it streams (so the counts +
+    # cursor are available after embed_and_index drains the generator).
+    acc = {"skipped_runs": 0, "filtered_runs": 0, "max_dt": None, "max_ts": ""}
 
-    chunk_count = 0
-    skipped_runs = 0
-    filtered_runs = 0
-    chunk_index = 0
-    records: list[str] = []
+    def _gen_chunks():
+        chunk_index = 0
+        for run_id, events, source_file in _stream_runs(file_paths):
+            result = _build_chunk(run_id, events, source_file, since_dt, skill_filter)
+            if result is None:
+                acc["skipped_runs"] += 1
+                continue
+            if result.get("_filtered"):
+                acc["filtered_runs"] += 1
+                continue
+            result["metadata"]["chunk_index"] = chunk_index
+            # Track max completed_at (same field + datetime compare the old
+            # _find_max_cursor_from_chunks used, now computed inline).
+            extra = result["metadata"].get("extra") or {}
+            completed_at = str(extra.get("ended_at") or extra.get("completed_at") or "")
+            if completed_at:
+                dt = _parse_iso_safe(completed_at)
+                if dt and (acc["max_dt"] is None or dt > acc["max_dt"]):
+                    acc["max_dt"] = dt
+                    acc["max_ts"] = completed_at
+            yield {"text": result["text"], "metadata": result["metadata"]}
+            chunk_index += 1
 
-    for run_id, events, source_file in _stream_runs(file_paths):
-        result = _build_chunk(run_id, events, source_file, since_dt, skill_filter)
-        if result is None:
-            skipped_runs += 1
-            continue
-        if result.get("_filtered"):
-            filtered_runs += 1
-            continue
-        result["metadata"]["chunk_index"] = chunk_index
-        record = {
-            "text": result["text"],
-            "metadata": result["metadata"],
-        }
-        records.append(json.dumps(record, ensure_ascii=False))
-        chunk_count += 1
-        chunk_index += 1
-
-    _safe_file.write(_CHUNKS_JSONL_PATH, "\n".join(records) + ("\n" if records else ""))
+    stats = _embed_index.embed_and_index(
+        _gen_chunks(),
+        "events",
+        "standard",
+        mode="append",
+        description="P6 event runs indexed by index_events skill",
+    )
 
     return {
-        "chunk_count": chunk_count,
-        "skipped_runs": skipped_runs,
-        "filtered_runs": filtered_runs,
+        "chunk_count": stats["embedded"] + stats["skipped_embed"],
+        "skipped_runs": acc["skipped_runs"],
+        "filtered_runs": acc["filtered_runs"],
+        "embedded": stats["embedded"],
+        "skipped_embed": stats["skipped_embed"],
+        "written": stats["written"],
+        "skipped_write": stats["skipped_write"],
+        "max_completed_at": acc["max_ts"],
     }
 
 
 def run_advance_cursor(artifact: dict) -> dict:
     """Postprocessor python step: advance .reyn/index/events_cursor.
 
-    Reads the max completed_at from written event_chunks.jsonl, then calls
-    advance_cursor() to write the new value atomically.
+    Reads the max completed_at from ``data.chunk_stats`` (computed inline by
+    run_collect_chunks while it streamed the chunks — #1303 Stage I removed the
+    intermediate file it used to re-read), then calls advance_cursor() to write
+    the new value atomically.
 
     Returns summary placed at data.cursor_result:
         {
@@ -325,7 +350,7 @@ def run_advance_cursor(artifact: dict) -> dict:
     filtered_runs = int(chunk_stats.get("filtered_runs") or 0)
 
     cursor_path = ".reyn/index/events_cursor"
-    new_cursor = _find_max_cursor_from_chunks()
+    new_cursor = str(chunk_stats.get("max_completed_at") or "")
     if not new_cursor:
         existing = read_cursor(cursor_path)
         new_cursor = existing if existing else _EPOCH_ISO
@@ -663,35 +688,6 @@ def _discover_event_files(events_root: str) -> list[str]:
     pattern = f"{events_root}/**/*.jsonl"
     matches = _glob_mod.glob(pattern, recursive=True)
     return sorted(m for m in matches if _is_regular_file(m))
-
-
-def _find_max_cursor_from_chunks() -> str | None:
-    """Read the just-written event_chunks.jsonl and find the max completed_at."""
-    if not _path_exists_safe(_CHUNKS_JSONL_PATH):
-        return None
-    try:
-        content = _safe_file.read(_CHUNKS_JSONL_PATH)
-    except (OSError, PermissionError):
-        return None
-    max_ts: str | None = None
-    max_dt: datetime | None = None
-    for line in content.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            record = json.loads(line)
-            meta = record.get("metadata") or {}
-            extra = meta.get("extra") or {}
-            completed_at = str(extra.get("ended_at") or extra.get("completed_at") or "")
-            if completed_at:
-                dt = _parse_iso_safe(completed_at)
-                if dt and (max_dt is None or dt > max_dt):
-                    max_dt = dt
-                    max_ts = completed_at
-        except Exception:
-            continue
-    return max_ts
 
 
 def _parse_iso_safe(ts: str) -> datetime | None:

--- a/src/reyn/stdlib/skills/index_events/skill.md
+++ b/src/reyn/stdlib/skills/index_events/skill.md
@@ -6,8 +6,8 @@ description: |
   (FP-0009 Component A).
 
   Phase 1 (LLM): resolve cursor + discover event files, narrate indexing range.
-  Phase 2 (Skill.postprocessor): deterministic chunk → embed → index_write →
-  cursor-advance pipeline; LLM is not involved.
+  Phase 2 (Skill.postprocessor): deterministic chunk → provider-direct
+  embed+index → cursor-advance pipeline; LLM is not involved.
 
   Incremental via .reyn/index/events_cursor — only new runs (since last index)
   are processed on each invocation. Failed runs carry truncated error summaries.
@@ -17,7 +17,7 @@ final_output_description: |
   LLM-contract artifact: echoes back the resolved since timestamp, inventory
   summary (count + ts range), optional skill filter, and mode. The skill
   postprocessor re-globs event files deterministically and uses `since` to
-  run the deterministic chunk → embed → index_write pipeline.
+  run the deterministic chunk → provider-direct embed+index pipeline.
 finish_criteria:
   - Preprocessor-resolved scan context was reviewed
   - scan_plan artifact echoes since, event_files_count, skill_filter, and mode
@@ -34,8 +34,10 @@ permissions:
     # File reads / writes / stat / glob go through reyn.safe.file; the
     # atomic cursor update uses reyn.safe.file.write_atomic. Event-file
     # reads under .reyn/events/ + cursor reads/writes under
-    # .reyn/index/events_cursor are inside the default zones; the chunks
-    # JSONL output below requires the explicit artifacts/ grant.
+    # .reyn/index/events_cursor are inside the default zones. #1303 Stage I:
+    # run_collect_chunks now streams chunks into reyn.safe.embed_index (which
+    # writes under .reyn/index/, default zone) — no out-of-zone JSONL output,
+    # so the old file.write:artifacts grant is dropped.
     - module: ./chunkers.py
       function: resolve_scan_context
       mode: safe
@@ -48,16 +50,13 @@ permissions:
       function: run_advance_cursor
       mode: safe
       timeout: 10
-  # FP-0042 Phase 2.3: run_collect_chunks writes the chunked JSONL output
-  # to ``<cwd>/artifacts/event_chunks.jsonl`` — outside the default
-  # ``.reyn/`` write zone, so it needs an explicit grant.
-  file.write:
-    - path: artifacts
-      scope: recursive
 postprocessor:
   output_schema: index_events_summary
   steps:
-    # Step 1: safe — walk events_root, group by run, produce chunks.jsonl
+    # Step 1: safe — walk events_root, group by run, and stream the chunks
+    # into reyn.safe.embed_index (provider-direct embed+index to the "events"
+    # source; folds the old embed + index_write run-ops, no intermediate
+    # file). #1303 Stage I.
     - type: python
       module: ./chunkers.py
       function: run_collect_chunks
@@ -67,28 +66,15 @@ postprocessor:
         type: object
         required: [chunk_count, skipped_runs, filtered_runs]
         properties:
-          chunk_count:    {type: integer, minimum: 0}
-          skipped_runs:   {type: integer, minimum: 0}
-          filtered_runs:  {type: integer, minimum: 0}
-    # Step 2: embed the chunks.jsonl artifact
-    - type: run_op
-      into: data.embed_result
-      op:
-        kind: embed
-        input_artifact: artifacts/event_chunks.jsonl
-        output_artifact: artifacts/event_chunks_with_vectors.jsonl
-      args_from: {}
-    # Step 3: write to "events" index source
-    - type: run_op
-      into: data.index_result
-      op:
-        kind: index_write
-        source: events
-        input_artifact: artifacts/event_chunks_with_vectors.jsonl
-        mode: append
-        description: "P6 event runs indexed by index_events skill"
-      args_from: {}
-    # Step 4: advance cursor to max completed_at of this batch
+          chunk_count:      {type: integer, minimum: 0}
+          skipped_runs:     {type: integer, minimum: 0}
+          filtered_runs:    {type: integer, minimum: 0}
+          embedded:         {type: integer, minimum: 0}
+          skipped_embed:    {type: integer, minimum: 0}
+          written:          {type: integer, minimum: 0}
+          skipped_write:    {type: integer, minimum: 0}
+          max_completed_at: {type: string}
+    # Step 2: advance cursor to max completed_at of this batch
     - type: python
       module: ./chunkers.py
       function: run_advance_cursor
@@ -110,8 +96,10 @@ required_credentials: []
 ## Overview
 
 `index_events` indexes the P6 event log at run granularity (1 run = 1 chunk)
-into the existing RAG infrastructure (ADR-0033). Uses `embed` / `index_write`
-/ `recall` ops — zero OS changes. Incremental via `.reyn/index/events_cursor`.
+into the existing RAG infrastructure (ADR-0033). The chunker streams runs into
+`reyn.safe.embed_index` (provider-direct embed+index; #1303 Stage I folded the
+old `embed` / `index_write` run-ops) and `recall` reads it back. Incremental
+via `.reyn/index/events_cursor`.
 
 ## Execution flow
 
@@ -122,12 +110,15 @@ into the existing RAG infrastructure (ADR-0033). Uses `embed` / `index_write`
      into the `scan_plan` artifact and finishes immediately
 
 2. **Skill.postprocessor** (deterministic, LLM not involved):
-   - `collect_run_chunks` (python step, unsafe): walks `.reyn/events/` from
-     cursor, groups events by run boundary, writes `artifacts/event_chunks.jsonl`
-   - `embed` (run_op): embeds each chunk's text field
-   - `index_write` (run_op): writes to `events` index source
-   - `advance_cursor` (python step, unsafe): writes max completed_at to
-     `.reyn/index/events_cursor`
+   - `run_collect_chunks` (python step, safe): walks `.reyn/events/` from the
+     cursor, groups events by run boundary, and **streams** the chunks into
+     `reyn.safe.embed_index.embed_and_index` — which embeds them provider-direct
+     and writes the vectors to the `events` index source
+     (`.reyn/index/events/index.db`), tracking the max `completed_at`. No
+     intermediate file (#1303 Stage I folds the old `embed` + `index_write`
+     run-ops into this step). Resume = DB-as-checkpoint.
+   - `run_advance_cursor` (python step, safe): writes the max `completed_at`
+     (from `data.chunk_stats`) to `.reyn/index/events_cursor`
 
 ## Input
 

--- a/tests/test_index_events_skill.py
+++ b/tests/test_index_events_skill.py
@@ -25,14 +25,38 @@ from pathlib import Path
 import pytest
 
 from reyn.context_builder import ARTIFACT_REF_THRESHOLD
+from reyn.embedding import register_provider
+from reyn.embedding.provider import EmbedBatchResult
+from reyn.safe import embed_index as ei
 from reyn.safe import file as sf
 from reyn.stdlib.skills.index_events.chunkers import (
     advance_cursor,
     collect_run_chunks,
     read_cursor,
     resolve_scan_context,
+    run_advance_cursor,
     run_collect_chunks,
 )
+
+
+class _FakeEmbedProvider:
+    """Deterministic embedding provider (no API) for run_collect_chunks tests."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self._batch_size = 100
+
+    async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
+        return EmbedBatchResult(
+            vectors=[[float(len(t)), 0.0, 0.0, 0.0] for t in texts],
+            model=model or "fake-embed",
+            total_tokens=sum(len(t) for t in texts),
+        )
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return sum(len(t) for t in texts)
+
+    def get_dimension(self, model: str) -> int:
+        return 4
 
 
 @pytest.fixture(autouse=True)
@@ -51,10 +75,16 @@ def _safe_file_context(tmp_path: Path):
         read_paths=[str(tmp_path)],
         write_paths=[str(tmp_path)],
     )
+    # #1303 Stage I: run_collect_chunks streams into reyn.safe.embed_index;
+    # wire a deterministic fake provider (workspace_root defaults to cwd).
+    register_provider("fake_ev", _FakeEmbedProvider)
+    ei._reset_context()
+    ei._set_context(provider_name="fake_ev")
     yield
     sf._read_paths = ()
     sf._write_paths = ()
     sf._context_initialised = False
+    ei._reset_context()
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -383,9 +413,14 @@ def test_index_events_skill_has_postprocessor():
     assert skill.postprocessor is not None
     assert isinstance(skill.postprocessor, Postprocessor)
     step_types = [s.type for s in skill.postprocessor.steps]
-    assert step_types == ["python", "run_op", "run_op", "python"], (
-        f"Expected [python, run_op, run_op, python] steps, got: {step_types}"
+    # #1303 Stage I folded the embed + index_write run-ops into run_collect_chunks;
+    # only safe-python steps remain (collect + advance_cursor).
+    assert all(t == "python" for t in step_types), (
+        f"Expected only python steps post-cutover, got: {step_types}"
     )
+    fns = [s.function for s in skill.postprocessor.steps]
+    assert "run_collect_chunks" in fns
+    assert "run_advance_cursor" in fns
 
 
 def test_index_events_skill_postprocessor_output():
@@ -514,8 +549,8 @@ def test_run_collect_chunks_reglobs_files_internally(tmp_path, monkeypatch):
         }
     }
 
-    # run_collect_chunks writes to cwd-relative artifacts/event_chunks.jsonl
-    # Change cwd to tmp_path so the re-glob and output path are correct
+    # run_collect_chunks re-globs + streams to embed_index (cwd-relative).
+    # Change cwd to tmp_path so the re-glob and .reyn/index output are correct.
     original_cwd = os.getcwd()
     os.chdir(str(tmp_path))
     try:
@@ -527,6 +562,56 @@ def test_run_collect_chunks_reglobs_files_internally(tmp_path, monkeypatch):
         f"Expected 1 chunk from re-glob, got {result['chunk_count']}. "
         f"Skipped: {result['skipped_runs']}, filtered: {result['filtered_runs']}"
     )
+    # #1303 Stage I: the chunk landed in the events index (no intermediate file).
+    assert result["embedded"] == 1
+    assert not (tmp_path / "artifacts" / "event_chunks.jsonl").exists()
+    import asyncio
+
+    from reyn.index import SqliteIndexBackend
+
+    stat = asyncio.run(SqliteIndexBackend(workspace_root=tmp_path).stat("events"))
+    assert stat["chunk_count"] == 1
+
+
+def test_run_collect_chunks_resume_skips_reembed(tmp_path, monkeypatch):
+    """Tier 2: ★resume through the index_events chunker path — a second pass
+    over the same events re-embeds nothing (existing_hashes pre-embed skip)."""
+    events_dir = tmp_path / ".reyn" / "events" / "2026-05"
+    events_dir.mkdir(parents=True)
+    (events_dir / "rc.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in _run_events(skill="s", run_id="r1")) + "\n",
+        encoding="utf-8",
+    )
+    artifact = {"data": {"since": "1970-01-01T00:00:00Z", "mode": "append"}}
+    monkeypatch.chdir(str(tmp_path))
+
+    first = run_collect_chunks(artifact)
+    assert first["embedded"] == 1
+
+    second = run_collect_chunks({"data": {"since": "1970-01-01T00:00:00Z", "mode": "append"}})
+    assert second["embedded"] == 0
+    assert second["skipped_embed"] == 1
+
+
+def test_run_advance_cursor_uses_chunk_stats_max(tmp_path, monkeypatch):
+    """Tier 2: run_advance_cursor advances from data.chunk_stats.max_completed_at
+    (the value run_collect_chunks tracked inline) — no intermediate file read."""
+    monkeypatch.chdir(str(tmp_path))
+    (tmp_path / ".reyn" / "index").mkdir(parents=True)
+    artifact = {
+        "data": {
+            "chunk_stats": {
+                "chunk_count": 2,
+                "skipped_runs": 0,
+                "filtered_runs": 0,
+                "max_completed_at": "2026-05-15T10:00:00Z",
+            }
+        }
+    }
+    result = run_advance_cursor(artifact)
+    assert result["new_cursor"] == "2026-05-15T10:00:00Z"
+    assert result["indexed_runs"] == 2
+    assert read_cursor(".reyn/index/events_cursor") == "2026-05-15T10:00:00Z"
 
 
 # ── TODO(fp-0009): Tier 3 e2e ─────────────────────────────────────────────────

--- a/tests/test_universal_dispatch_skill_op_coverage_1212.py
+++ b/tests/test_universal_dispatch_skill_op_coverage_1212.py
@@ -299,7 +299,10 @@ def test_universal_dispatch_covers_all_stdlib_skill_real_op_kinds() -> None:
     # route) both go RED.
     _INTENTIONAL_CHAT_ROUTER_EXCLUSIONS = frozenset({
         "ask_user",       # control-flow (user-input request); not a dispatchable action
-        "embed",          # low-level RAG primitive; chat surface is the `recall` macro
+        # #1303 Stage I: "embed" / "index_write" run-ops removed from index_docs +
+        # index_events (chunkers now stream into reyn.safe.embed_index), so no
+        # stdlib skill declares them any more — they drop out of the skill op-kind
+        # scan entirely (the ops still exist in the OS registry until S-I.5).
         # #1240 Wave 2b: coarse "file" kind dropped from OP_KIND_MODEL_MAP and the
         # LLM-facing catalog. It is still used in OS-deterministic preprocessor
         # run_op steps (skill_improver copy_to_work/finalize) because PreprocessorExecutor
@@ -308,7 +311,6 @@ def test_universal_dispatch_covers_all_stdlib_skill_real_op_kinds() -> None:
         # not a chat-router dispatch target. Migration to fine-kind run_op is a
         # separate work item (requires wiring PreprocessorExecutor → ToolRegistry).
         "file",           # legacy coarse kind; still in OS-deterministic preprocessor run_ops
-        "index_write",    # low-level RAG write primitive; not chat-exposed
         "skill_resolve",  # skill-internal name resolution (preprocessor run_op)
     })
     assert set(uncovered) == _INTENTIONAL_CHAT_ROUTER_EXCLUSIONS, (
@@ -366,8 +368,9 @@ def test_skill_real_op_kind_scanner_finds_known_ops() -> None:
     spot_checks = {
         "read_file",     # many skills, allowed_ops
         "sandboxed_exec", # swe_bench, allowed_ops + run_op preprocessor
-        "embed",         # index_docs + index_events, run_op postprocessor
-        "index_write",   # index_docs + index_events, run_op postprocessor
+        # #1303 Stage I removed the "embed" / "index_write" run-ops from
+        # index_docs + index_events (chunkers stream into reyn.safe.embed_index),
+        # so no stdlib skill declares them any more.
         "recall",        # ops_report + skill_improver, run_op preprocessor
         "skill_resolve", # eval_builder + skill_improver, run_op preprocessor
     }


### PR DESCRIPTION
**[e2e-coder]** — #1303 Stage I, sub-stage **S-I.3** (index_events cutover; same pattern as S-I.2 #1308, merged). Builds on S-I.1/S-I.2's `reyn.safe.embed_index`.

## What
`run_collect_chunks` now **streams** event-run chunks straight into `reyn.safe.embed_index` (provider-direct embed+index to the `events` source). The `embed` + `index_write` run-ops, the intermediate `artifacts/event_chunks.jsonl`, and the `file.write: artifacts` grant are **all removed**.

## ★Cursor wrinkle (index_events-specific)
`run_advance_cursor` used to **re-read the intermediate `event_chunks.jsonl`** to find the batch's max `completed_at` — that file is now gone. Fix: `run_collect_chunks` tracks max `completed_at` **inline while streaming** (same `extra.ended_at` field + `_parse_iso_safe` datetime compare the old `_find_max_cursor_from_chunks` used) and threads it through `data.chunk_stats.max_completed_at`; `run_advance_cursor` reads it from there. The now-orphaned `_find_max_cursor_from_chunks` is deleted.

- **chunkers.py**: `run_collect_chunks` → generator + `embed_and_index(source="events", mode="append", description=...)`; `run_advance_cursor` reads `data.chunk_stats.max_completed_at`.
- **skill.md**: drop the embed + index_write run_op steps + `file.write: artifacts`; update `run_collect` output_schema + Execution-flow / Overview / Output docs.
- **index_events_summary.yaml**: fold `embed_result`/`index_result` into `chunk_stats` (+ `max_completed_at`).
- **#1212 op-coverage**: drop `embed`/`index_write` from the skill-used op-kind sets — no stdlib skill declares them post-cutover (the ops stay in the OS registry until S-I.5).

## Verify (your reqs — through the index_events chunker path)
- **e2e**: `test_run_collect_chunks_reglobs_files_internally` now asserts the `events` index DB is built (no JSONL).
- **resume**: `test_run_collect_chunks_resume_skips_reembed` — 2nd pass `embedded == 0`, `skipped_embed == 1` (★existing_hashes pre-embed skip).
- **cursor**: `test_run_advance_cursor_uses_chunk_stats_max` — cursor advances from `data.chunk_stats.max_completed_at` (the wrinkle fix), no file read.

## Test plan
- [x] `pytest tests/test_index_events_skill.py tests/test_universal_dispatch_skill_op_coverage_1212.py -q` — 22 passed (contract-reversal tests updated: no-run-ops / index-built / resume / cursor-from-stats)
- [x] broader index_events consumers (fp0009 scheduler/cron, universal_dispatch, op_recall, source_manifest) — green
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict` (changed test files) — clean
- [x] full `pytest -q` from rootdir — 6890 passed, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, #1203 — orthogonal/CI-green)

Refs #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)