### PR TITLE
feat(1303): S-I.4 recall query embedding provider-direct (drop embed-op dependency)

### DIFF
--- a/src/reyn/op_runtime/recall.py
+++ b/src/reyn/op_runtime/recall.py
@@ -1,19 +1,36 @@
 """recall macro op handler — embed query → iterate index_query → merge top-K.
 
-Dispatches sub-ops (embed + index_query) via the OS execute_op path so
-events are emitted per sub-op (P6 audit trail, same pattern as iterate.py
-which also calls sub-op handlers via execute_op).
+The query embedding is computed **provider-direct** (#1303 S-I.4 — mirrors
+``ActionEmbeddingIndex``); it no longer dispatches an ``embed`` sub-op. The
+``index_query`` sub-ops still go through ``execute_op`` (P6 per-source events).
 
 ADR-0033 §2.1: macro op, OpPurity.external.
 """
 from __future__ import annotations
 
+import os
 from typing import Literal
 
-from reyn.schemas.models import EmbedIROp, IndexQueryIROp, RecallIROp
+from reyn.embedding import get_provider
+from reyn.schemas.models import IndexQueryIROp, RecallIROp
 
 from . import execute_op, register
 from .context import OpContext
+
+
+def _resolve_provider():
+    """Resolve the embedding provider the same way the old embed op did
+    (env override + reyn.yaml embedding config); kept inline so recall has no
+    dependency on the embed op (which #1303 S-I.5 deletes)."""
+    name = os.environ.get("REYN_EMBEDDING_PROVIDER", "litellm")
+    if name == "litellm":
+        try:
+            from reyn.config import load_config
+            cfg = load_config().embedding
+        except Exception:
+            cfg = None
+        return get_provider(name, config=cfg or {})
+    return get_provider(name, config={})
 
 
 async def handle(
@@ -24,7 +41,7 @@ async def handle(
     """Execute a recall macro op (ADR-0033 §2.1).
 
     Steps:
-      1. Embed the query text via embed sub-op (Form A inline).
+      1. Embed the query text provider-direct (#1303 S-I.4).
       2. For each source, run index_query sub-op.
       3. Merge all top-K chunks globally by score, return top_k.
 
@@ -34,24 +51,19 @@ async def handle(
     if not op.sources:
         return {"chunks": [], "mode": "fallback"}
 
-    # ── 1. Embed query ────────────────────────────────────────────────────────
-    embed_op = EmbedIROp(
-        kind="embed",
-        texts=[op.query],
-        model=op.embedding_model,
-    )
-    embed_result = await execute_op(embed_op, ctx, caller=caller)
-
-    if embed_result.get("status") in ("error", "denied", "skipped"):
-        # Embed failed — fallback to empty result
+    # ── 1. Embed query (provider-direct; was an embed sub-op) ─────────────────
+    try:
+        provider = _resolve_provider()
+        embed_result = await provider.embed([op.query], op.embedding_model)
+        vectors = embed_result.get("vectors", [])
+    except Exception as exc:  # provider/config failure → graceful fallback
         ctx.events.emit(
             "recall_embed_failed",
             query=op.query,
-            error=embed_result.get("error", "unknown"),
+            error=str(exc),
         )
         return {"chunks": [], "mode": "fallback"}
 
-    vectors = embed_result.get("vectors", [])
     if not vectors:
         return {"chunks": [], "mode": "fallback"}
 

--- a/tests/test_op_recall.py
+++ b/tests/test_op_recall.py
@@ -1,7 +1,8 @@
 """Tier 2: recall macro op handler OS invariants (ADR-0033 Phase 1).
 
-Tests use FakeEmbeddingProvider (monkeypatched into embed handler) and real
-SqliteIndexBackend for end-to-end recall dispatch.
+Tests use FakeEmbeddingProvider (monkeypatched into the recall handler's
+provider-direct embed call, #1303 S-I.4) and a real SqliteIndexBackend for
+end-to-end recall dispatch.
 """
 from __future__ import annotations
 
@@ -85,8 +86,8 @@ def _chunk(text: str, vec: list[float], ch: str) -> ChunkRecord:
 async def test_recall_happy_path_returns_chunks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: recall macro embeds query, queries source, returns merged top-K."""
     fake = FakeEmbeddingProvider()
-    import reyn.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+    import reyn.op_runtime.recall as _recall_mod
+    monkeypatch.setattr(_recall_mod, "get_provider", lambda *a, **kw: fake)
 
     import os
     monkeypatch.chdir(tmp_path)
@@ -116,8 +117,8 @@ async def test_recall_happy_path_returns_chunks(tmp_path: Path, monkeypatch: pyt
 async def test_recall_empty_sources_returns_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: recall with empty sources list returns fallback immediately."""
     fake = FakeEmbeddingProvider()
-    import reyn.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+    import reyn.op_runtime.recall as _recall_mod
+    monkeypatch.setattr(_recall_mod, "get_provider", lambda *a, **kw: fake)
 
     import os
     monkeypatch.chdir(tmp_path)
@@ -141,8 +142,8 @@ async def test_recall_empty_sources_returns_fallback(tmp_path: Path, monkeypatch
 async def test_recall_merges_multiple_sources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: recall merges chunks from multiple sources, sorted by score."""
     fake = FakeEmbeddingProvider()
-    import reyn.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+    import reyn.op_runtime.recall as _recall_mod
+    monkeypatch.setattr(_recall_mod, "get_provider", lambda *a, **kw: fake)
 
     import os
     monkeypatch.chdir(tmp_path)
@@ -170,8 +171,8 @@ async def test_recall_merges_multiple_sources(tmp_path: Path, monkeypatch: pytes
 async def test_recall_top_k_limits_merged_results(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: recall top_k limits total chunks returned across all sources."""
     fake = FakeEmbeddingProvider()
-    import reyn.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+    import reyn.op_runtime.recall as _recall_mod
+    monkeypatch.setattr(_recall_mod, "get_provider", lambda *a, **kw: fake)
 
     import os
     monkeypatch.chdir(tmp_path)
@@ -199,8 +200,8 @@ async def test_recall_top_k_limits_merged_results(tmp_path: Path, monkeypatch: p
 async def test_recall_mode_all_semantic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: when all sources return semantic results, mode='semantic'."""
     fake = FakeEmbeddingProvider()
-    import reyn.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+    import reyn.op_runtime.recall as _recall_mod
+    monkeypatch.setattr(_recall_mod, "get_provider", lambda *a, **kw: fake)
 
     import os
     monkeypatch.chdir(tmp_path)
@@ -220,3 +221,36 @@ async def test_recall_mode_all_semantic(tmp_path: Path, monkeypatch: pytest.Monk
     assert result.get("status") != "error", result
     # s1 has content, embed returns a vector → semantic
     assert result["mode"] == "semantic"
+
+
+@pytest.mark.asyncio
+async def test_recall_embed_failure_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: a provider-direct embed failure → graceful fallback (empty
+    chunks, mode=fallback) + a recall_embed_failed event (#1303 S-I.4 replaced
+    the embed sub-op error-status check with a try/except around provider.embed)."""
+    class _RaisingProvider:
+        def __init__(self) -> None:
+            self._batch_size = 10
+
+        async def embed(self, texts: list[str], model: str) -> Any:
+            raise RuntimeError("embedding endpoint down")
+
+        def estimate_tokens(self, texts: list[str]) -> int:
+            return 0
+
+        def get_dimension(self, model: str) -> int:
+            return 3
+
+    import reyn.op_runtime.recall as _recall_mod
+    monkeypatch.setattr(_recall_mod, "get_provider", lambda *a, **kw: _RaisingProvider())
+    monkeypatch.chdir(tmp_path)
+
+    ctx = _make_ctx(tmp_path)
+    op = RecallIROp(
+        kind="recall", query="q", sources=["s1"], top_k=5, embedding_model="standard",
+    )
+    result = await execute_op(op, ctx, caller="control_ir")
+
+    assert result["chunks"] == []
+    assert result["mode"] == "fallback"
+    assert any(e.type == "recall_embed_failed" for e in ctx.events.all())


### PR DESCRIPTION
**[e2e-coder]** — #1303 Stage I, sub-stage **S-I.4** (recall → provider-direct). Builds on S-I.1/2/3 (merged). This removes the **last embed-op caller** — the precondition for S-I.5 deleting the orphaned ops.

## What
recall's query embedding now calls `provider.embed` **directly** (mirrors `ActionEmbeddingIndex`) instead of dispatching an `embed` sub-op via `execute_op`.

- **`op_runtime/recall.py`**: `_resolve_provider()` inline (mirrors the old embed op's `REYN_EMBEDDING_PROVIDER` + `load_config().embedding` resolution, so recall has no embed-op dependency). The embed sub-op block → a `try/except` around `provider.embed` with the **same graceful fallback** (empty chunks, `mode=fallback`, `recall_embed_failed` event). The `index_query` sub-ops still go through `execute_op` (per-source P6 events preserved). Dropped the now-unused `EmbedIROp` import.

## Equivalence / verify (your reqs)
- query-embedding equivalence: same `provider.embed([query], embedding_model)` call the embed sub-op made (Form A); recall's own P6 events preserved (`recall_embed_failed` on failure; per-source `index_query` events unchanged).
- embed-failure fallback: previously an embed sub-op `status in (error/denied/skipped)` → fallback; now a `try/except` → identical fallback. Pinned by a new test.

## Test plan
- [x] `pytest tests/test_op_recall.py -q` — 6 passed (5 retargeted: fake-provider monkeypatch moved from the embed module → the recall module; +`test_recall_embed_failure_falls_back` pins the try/except → fallback + `recall_embed_failed` event)
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict tests/test_op_recall.py` — clean
- [x] full `pytest -q` from rootdir — 6891 passed, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, #1203 — orthogonal/CI-green)

## Next
S-I.5 (final): delete the now-orphaned `embed` + `index_write` op handlers + schemas + registry/`control-ir.md` sync (no remaining caller — recall was the last embed-op user; index_docs/index_events stopped using both in S-I.2/S-I.3). `EmbeddingProvider` / `SqliteIndexBackend` / `index_query` stay.

Refs #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)