### PR TITLE
feat(1199): S3.1c-2 wire SandboxLayer ∩ into file + http gates (full-∩, last piece)

### DIFF
--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from reyn.llm.model_resolver import ModelResolver
     from reyn.permissions.permissions import PermissionDecl, PermissionResolver
     from reyn.sandbox import SandboxBackend
+    from reyn.sandbox.policy import SandboxPolicy
     from reyn.schemas.models import Skill
     from reyn.secrets.store import ScopedSecretStore
     from reyn.user_intervention import RequestBus
@@ -163,3 +164,19 @@ class OpContext:
     # (= not inside a plan step). Shape: ``{"n_done": int, "n_total": int,
     # "step_id": str}``.
     plan_step: dict | None = None
+
+
+def sandbox_policy_from_ctx(ctx: "OpContext") -> "SandboxPolicy | None":
+    """Build the phase ``SandboxPolicy`` from ``ctx.default_sandbox_policy``
+    (the dict declared in phase frontmatter), or ``None`` when unset.
+
+    #1199 S3.1c-2: the file / http gates fold this into their SandboxLayer ∩.
+    Mirrors the conversion ``sandboxed_exec`` already uses
+    (``SandboxPolicy(**ctx.default_sandbox_policy)``) so the SAME phase policy
+    governs both the sandboxed_exec subprocess and the OS's in-process file/http
+    ops. ``None`` → the SandboxLayer is ⊤ (non-sandboxed callers unchanged)."""
+    if ctx.default_sandbox_policy is None:
+        return None
+    from reyn.sandbox.policy import SandboxPolicy
+
+    return SandboxPolicy(**ctx.default_sandbox_policy)

--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -10,6 +10,7 @@ from reyn.schemas.models import FileIROp
 
 from . import register
 from .context import OpContext
+from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 
 _WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index", "mkdir", "move"})
 _READ_OPS = frozenset({"read", "glob", "grep", "stat"})
@@ -154,21 +155,28 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
     # `regenerate_index` the file actually written is `output_path`, not
     # `path`; everything else writes to `path`.
     if ctx.permission_resolver is not None:
+        # #1199 S3.1c-2: fold the phase sandbox policy into the file gate's ∩ —
+        # the path must also fall within the policy's read/write path caps. None
+        # (no phase default_sandbox_policy) → SandboxLayer is ⊤ (unchanged).
+        _sandbox = _sandbox_policy_from_ctx(ctx)
         if op.op in _WRITE_OPS:
             write_target = op.output_path if op.op == "regenerate_index" and op.output_path else op.path
             ctx.permission_resolver.require_file_write(
                 ctx.permission_decl, write_target, ctx.skill_name,
+                sandbox_policy=_sandbox,
             )
             # move also writes to dest_path — gate both source (= the file
             # being effectively deleted) and dest (= the file being created).
             if op.op == "move" and op.dest_path:
                 ctx.permission_resolver.require_file_write(
                     ctx.permission_decl, op.dest_path, ctx.skill_name,
+                    sandbox_policy=_sandbox,
                 )
         elif op.op in _READ_OPS:
             # read / glob / grep / stat — gate against read scope
             ctx.permission_resolver.require_file_read(
                 ctx.permission_decl, op.path, ctx.skill_name,
+                sandbox_policy=_sandbox,
             )
 
     if op.op == "write":

--- a/src/reyn/op_runtime/web.py
+++ b/src/reyn/op_runtime/web.py
@@ -9,6 +9,7 @@ from reyn.schemas.models import WebFetchIROp, WebSearchIROp
 
 from . import register
 from .context import OpContext
+from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 
 
 class _TextExtractor(html.parser.HTMLParser):
@@ -227,8 +228,11 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
                 "kind": "web_fetch", "url": op.url, "status": "error",
                 "error": f"web_fetch: cannot resolve host from URL {op.url!r}",
             }
+        # #1199 S3.1c-2: fold the phase sandbox policy into the http gate's ∩ —
+        # a sandbox with network:false vetoes the fetch (overrides config-allow).
         await ctx.permission_resolver.require_http_get(
             ctx.permission_decl, host, ctx.intervention_bus, ctx.skill_name,
+            sandbox_policy=_sandbox_policy_from_ctx(ctx),
         )
 
     ctx.events.emit("web_fetch_started", url=op.url)

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -49,6 +49,8 @@ from reyn.user_intervention import (
 )
 
 if TYPE_CHECKING:
+    from reyn.sandbox.policy import SandboxPolicy
+
     from .models import Skill
 
 
@@ -914,7 +916,14 @@ class PermissionResolver:
 
     # ── Public check methods ──────────────────────────────────────────────────
 
-    def require_file_read(self, decl: PermissionDecl, path: str, skill_name: str = "") -> None:
+    def require_file_read(
+        self,
+        decl: PermissionDecl,
+        path: str,
+        skill_name: str = "",
+        *,
+        sandbox_policy: "SandboxPolicy | None" = None,
+    ) -> None:
         """
         Raise PermissionError if read/glob/grep access to path is not allowed.
         Default zone (CWD and below) is always granted.
@@ -926,13 +935,21 @@ class PermissionResolver:
         approved (interactively at startup, or via config). A non-interactive
         declared-but-unapproved path therefore denies — the operator pre-approves
         (reyn.yaml ``permissions.file.read: allow``) or runs interactively.
+
+        #1199 S3.1c-2: ``sandbox_policy`` (the phase ``default_sandbox_policy``,
+        passed by the op handler) folds in the SandboxLayer ∩ — the path must
+        ALSO fall within the policy's ``read_paths`` caps. ``None`` (the OS's own
+        in-process ops / non-sandboxed callers) → SandboxLayer is ⊤ (unchanged).
+        ProfileLayer is omitted: it constrains only skill/mcp, never files (⊤).
         """
-        # #1199 S3.1c-1: decl-less EffectivePermission (zone OR approved).
-        # Approvals fold INSIDE the layer (② grant-back-safe).
+        # #1199 S3.1c-1/-2: decl-less AgentLayer ∩ SandboxLayer (zone OR approved,
+        # then narrowed by the sandbox path caps). Approvals fold INSIDE the agent
+        # layer (② grant-back-safe).
         from reyn.permissions.effective import (
             AgentLayer,
             CapabilityAxis,
             EffectivePermission,
+            SandboxLayer,
         )
 
         def _approved(axis: object, value: object) -> bool:
@@ -941,7 +958,8 @@ class PermissionResolver:
             )
 
         if EffectivePermission([
-            AgentLayer(decl, approval_check=_approved)
+            AgentLayer(decl, approval_check=_approved),
+            SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_READ, path):
             return
         raise PermissionError(
@@ -954,7 +972,14 @@ class PermissionResolver:
             f"  - run interactively so the startup guard can prompt for approval."
         )
 
-    def require_file_write(self, decl: PermissionDecl, path: str, skill_name: str = "") -> None:
+    def require_file_write(
+        self,
+        decl: PermissionDecl,
+        path: str,
+        skill_name: str = "",
+        *,
+        sandbox_policy: "SandboxPolicy | None" = None,
+    ) -> None:
         """
         Raise PermissionError if write/edit/delete access to path is not allowed.
         Default zone (.reyn/, reyn/) is always granted.
@@ -964,13 +989,19 @@ class PermissionResolver:
         ``is_write_allowed`` makes (divergence resolved). A declared path is not
         auto-granted; a non-interactive declared-but-unapproved path denies (the
         operator pre-approves via reyn.yaml or runs interactively).
+
+        #1199 S3.1c-2: ``sandbox_policy`` folds in the SandboxLayer ∩ — the path
+        must ALSO fall within the policy's ``write_paths`` caps. ``None`` → ⊤
+        (unchanged). ProfileLayer omitted (⊤ for files).
         """
-        # #1199 S3.1c-1: decl-less EffectivePermission (zone OR approved).
-        # Approvals fold INSIDE the layer (② grant-back-safe).
+        # #1199 S3.1c-1/-2: decl-less AgentLayer ∩ SandboxLayer (zone OR approved,
+        # then narrowed by the sandbox path caps). Approvals fold INSIDE the agent
+        # layer (② grant-back-safe).
         from reyn.permissions.effective import (
             AgentLayer,
             CapabilityAxis,
             EffectivePermission,
+            SandboxLayer,
         )
 
         def _approved(axis: object, value: object) -> bool:
@@ -979,7 +1010,8 @@ class PermissionResolver:
             )
 
         if EffectivePermission([
-            AgentLayer(decl, approval_check=_approved)
+            AgentLayer(decl, approval_check=_approved),
+            SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_WRITE, path):
             return
         raise PermissionError(
@@ -998,6 +1030,8 @@ class PermissionResolver:
         host: str,
         bus: "RequestBus | None" = None,
         skill_name: str = "",
+        *,
+        sandbox_policy: "SandboxPolicy | None" = None,
     ) -> None:
         """Gate HTTP access to ``host`` (#571 Phase 7 unification).
 
@@ -1041,6 +1075,30 @@ class PermissionResolver:
             raise PermissionError(
                 f"HTTP access to host {host!r} denied by config "
                 f"(http.get.{host}: deny)."
+            )
+
+        # #1199 S3.1c-2: SandboxLayer ∩ network. The sandbox is a RESTRICT layer,
+        # so it must veto BEFORE the AgentLayer GRANT tiers below (config-allow /
+        # persisted / legacy) — a config-allowed host must NOT bypass a sandbox
+        # that disallows network. Placed after config-DENY (deny still wins) and
+        # before every allow tier. ``None`` (non-sandboxed callers) → no veto.
+        from reyn.permissions.effective import (
+            CapabilityAxis as _AX,
+        )
+        from reyn.permissions.effective import (
+            EffectivePermission as _EP,
+        )
+        from reyn.permissions.effective import (
+            SandboxLayer as _SL,
+        )
+
+        if not _EP([_SL(sandbox_policy)]).allows(_AX.NETWORK_HOST, host):
+            raise PermissionError(
+                f"HTTP access to host {host!r} denied by the active sandbox "
+                f"policy (network access is disabled). This is a sandbox "
+                f"restriction — it overrides any config/declared allow. Adjust "
+                f"the phase ``default_sandbox_policy`` (``network: true``) if the "
+                f"host should be reachable."
             )
 
         # Config-tier allow short-circuits everything (= operator's

--- a/tests/test_1199_s31c2_full_intersection.py
+++ b/tests/test_1199_s31c2_full_intersection.py
@@ -1,0 +1,139 @@
+"""Tier 2: S3.1c-2 — SandboxLayer ∩ wired into the file + http gates (full-∩).
+
+#1199 S3.1c-2 completes the conjunctive-∩ model: ``require_file_read/write`` and
+``require_http_get`` now fold the phase ``default_sandbox_policy`` into a
+SandboxLayer ∩. A sandbox path/network cap RESTRICTS even an AgentLayer-granted
+(zone / config-approved) path — restrict-only, the sandbox cannot grant. None (the
+OS's own in-process ops / non-sandboxed callers) → SandboxLayer ⊤ (unchanged).
+
+ProfileLayer is intentionally NOT wired into these gates: it constrains only
+skill / mcp (⊤ for file / network), so it would be a provably dead layer.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.sandbox.policy import SandboxPolicy
+from tests.test_permissions import _make_resolver
+
+# ── file gates: SandboxLayer ∩ (path caps) ───────────────────────────────────
+
+
+def test_sandbox_cap_restricts_in_zone_write(tmp_path: Path) -> None:
+    """Tier 2: a sandbox write_paths cap DENIES even an in-zone write — the ∩
+    narrows (sandbox restrict-only over the AgentLayer zone grant)."""
+    r = _make_resolver(tmp_path)
+    # .reyn/x is in the default write zone (AgentLayer grants) but the sandbox
+    # caps writes to /sandboxed → ∩ denies.
+    policy = SandboxPolicy(write_paths=["/sandboxed"])
+    with pytest.raises(PermissionError):
+        r.require_file_write(PermissionDecl(), ".reyn/x.txt", "s", sandbox_policy=policy)
+
+
+def test_sandbox_allow_all_permits(tmp_path: Path) -> None:
+    """Tier 2: write_paths=['/'] (= swe_bench's allow-all policy) → in-zone write
+    passes (the no-current-blast-radius case)."""
+    r = _make_resolver(tmp_path)
+    r.require_file_write(
+        PermissionDecl(), ".reyn/x.txt", "s",
+        sandbox_policy=SandboxPolicy(write_paths=["/"]),
+    )  # no raise
+
+
+def test_no_sandbox_policy_unchanged(tmp_path: Path) -> None:
+    """Tier 2: sandbox_policy=None → SandboxLayer ⊤ — the gate behaves exactly as
+    pre-S3.1c-2 (in-zone write passes; non-sandboxed callers unaffected)."""
+    r = _make_resolver(tmp_path)
+    r.require_file_write(PermissionDecl(), ".reyn/x.txt", "s")  # no raise
+
+
+def test_sandbox_falsification_removing_layer_regrants(tmp_path: Path) -> None:
+    """Tier 2: ★∩-falsification — the SAME in-zone write the sandbox DENIES is
+    ALLOWED once the SandboxLayer is dropped (sandbox_policy=None). Proves the
+    SandboxLayer is load-bearing (over-grant if removed)."""
+    r = _make_resolver(tmp_path)
+    path = ".reyn/x.txt"
+    capped = SandboxPolicy(write_paths=["/sandboxed"])  # does not cover .reyn/
+    with pytest.raises(PermissionError):
+        r.require_file_write(PermissionDecl(), path, "s", sandbox_policy=capped)
+    # drop the SandboxLayer → re-granted by the zone baseline (the over-grant).
+    r.require_file_write(PermissionDecl(), path, "s", sandbox_policy=None)  # no raise
+
+
+def test_sandbox_read_cap_restricts(tmp_path: Path) -> None:
+    """Tier 2: the read gate folds the SandboxLayer too (read_paths cap)."""
+    r = _make_resolver(tmp_path)
+    capped = SandboxPolicy(read_paths=["/sandboxed"])  # excludes cwd
+    with pytest.raises(PermissionError):
+        r.require_file_read(PermissionDecl(), "src/reyn/x.py", "s", sandbox_policy=capped)
+
+
+# ── http gate: SandboxLayer ∩ (network) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_http_sandbox_network_false_denies(tmp_path: Path) -> None:
+    """Tier 2: a sandbox with network:false vetoes http_get (no bus needed —
+    denial precedes the prompt path)."""
+    r = _make_resolver(tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "*"}])
+    with pytest.raises(PermissionError, match="sandbox"):
+        await r.require_http_get(
+            decl, "api.x.com", None, "s", sandbox_policy=SandboxPolicy(network=False),
+        )
+
+
+@pytest.mark.asyncio
+async def test_http_sandbox_bypass_prevention_config_allow(tmp_path: Path) -> None:
+    """Tier 2: ★bypass-prevention — a CONFIG-ALLOWED host is STILL DENIED when the
+    sandbox disables network. The veto sits BEFORE the allow tiers; if it were
+    placed after config-allow this would wrongly pass — so the placement is
+    load-bearing (sandbox RESTRICT overrides AgentLayer config GRANT)."""
+    r = _make_resolver(tmp_path, config={"web.fetch": "allow"})  # blanket config-allow
+    with pytest.raises(PermissionError, match="sandbox"):
+        await r.require_http_get(
+            PermissionDecl(), "api.x.com", None, "s",
+            sandbox_policy=SandboxPolicy(network=False),
+        )
+
+
+@pytest.mark.asyncio
+async def test_http_sandbox_network_true_does_not_veto(tmp_path: Path) -> None:
+    """Tier 2: network:true sandbox + config-allow → passes (sandbox does not veto;
+    the config grant stands)."""
+    r = _make_resolver(tmp_path, config={"web.fetch": "allow"})
+    await r.require_http_get(
+        PermissionDecl(), "api.x.com", None, "s",
+        sandbox_policy=SandboxPolicy(network=True),
+    )  # no raise
+
+
+# ── caller-split: the op-handler helper ──────────────────────────────────────
+
+
+def test_sandbox_policy_from_ctx_builds_and_none() -> None:
+    """Tier 2: the op-handler helper builds a SandboxPolicy from the phase dict and
+    returns None when unset (the caller-split: phase handlers thread the policy,
+    OS-internal callers get None = SandboxLayer ⊤)."""
+    from reyn.events.events import EventLog
+    from reyn.op_runtime.context import OpContext, sandbox_policy_from_ctx
+    from reyn.workspace.workspace import Workspace
+
+    events = EventLog()
+    ws = Workspace(events)
+    with_policy = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        default_sandbox_policy={"network": True, "write_paths": ["/x"]},
+    )
+    policy = sandbox_policy_from_ctx(with_policy)
+    assert policy is not None
+    assert policy.network is True
+    assert policy.write_paths == ["/x"]
+
+    without = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+    )
+    assert sandbox_policy_from_ctx(without) is None


### PR DESCRIPTION
**[e2e-coder]** — #1199 **S3.1c-2** (full-∩), co-signed design (#1199 issuecomment-4623656631). **Completes the conjunctive-∩ permission model** (S3.1a + S3.1b + S3.1c-1 + S3.1c-2). Lands on top of S3.1c-1 (#1312).

## What
`require_file_read/write` + `require_http_get` now fold the phase `default_sandbox_policy` into a **SandboxLayer ∩** — a sandbox path/network cap RESTRICTS even an AgentLayer-granted (zone / config-approved) path (restrict-only; the sandbox cannot grant).

## ★Blast-radius = zero current behavior change (co-signed)
The only stdlib skill with file caps is swe_bench (`read/write_paths: ["/"]` = allow-all → `_path_under(any, "/")` True); every other run has no `default_sandbox_policy` → `SandboxLayer(None)` = ⊤. Pure mechanism-completion — a future restrictive policy is now enforced at the OS's own **in-process** file/http ops. (Not a double-gate: seatbelt/landlock enforce on the sandboxed_exec **subprocess**; this gate covers the previously-ungated in-process Control IR surface — Q2 co-sign.)

## Changes
- **permissions.py**: `require_file_read/write` gain `sandbox_policy=` → `SandboxLayer` in the ∩. `require_http_get` gains it as an **early network veto**, placed *after* config-DENY / *before* the allow tiers so a config-ALLOWED host cannot bypass a `network:false` sandbox (RESTRICT overrides GRANT). **ProfileLayer omitted** (provably ⊤ for file/network — constrains only skill/mcp).
- **context.py**: `sandbox_policy_from_ctx(ctx)` helper (`SandboxPolicy(**dict)`, mirroring sandboxed_exec) — the same phase policy governs the subprocess AND the in-process gates.
- **file.py / web.py**: phase op handlers thread it; OS-internal callers (cron / mcp_install / …) pass nothing = unchanged (the caller-split).

## Test plan
- [x] `pytest tests/test_1199_s31c2_full_intersection.py -q` — 9 passed: ∩-enforced (path cap denies in-zone) / allow-all / no-policy unchanged / **★∩-falsification** (drop layer → re-grant) / read cap / http network:false denies / **★bypass-prevention** (config-allow + network:false STILL denied = veto placement load-bearing) / caller-split helper
- [x] broader file/http/permission suite (s31c1, permissions, http_get, workspace-guard, routerloop_1092) — green
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict tests/test_1199_s31c2_full_intersection.py` — clean
- [x] full `pytest -q` from rootdir — 6875 passed, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, #1203 — orthogonal/CI-green)

Refs #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)