### PR TITLE
docs(permission-model): document protected write path carve-out in Layer 1 defaults

### DIFF
--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -28,6 +28,16 @@ reyn's permission system gates four kinds of capability: file paths, shell, MCP 
 
 Read/glob/grep anywhere under the project root. Write/edit/delete only under `.reyn/` or `reyn/`. No shell, no MCP, no Python.
 
+**Protected write paths (carve-out from the default zone):** Three paths inside `.reyn/` are excluded from the broad default write grant:
+
+- `.reyn/mcp.yaml` — MCP server configuration
+- `.reyn/cron.yaml` — cron job registry
+- `.reyn/index/sources.yaml` — index source registry
+
+These are the backing stores for capability-gated operations (MCP server install/remove, cron registration, index source management). Each operation goes through a dedicated op handler that validates input, emits an audit event, and enforces its own approval gate. Allowing direct writes via the broad `.reyn/` default zone would bypass both the gate and the audit trail — a skill could silently register a new capability without going through the intended approval flow.
+
+Skills that legitimately need to write these paths must declare them explicitly via `file.write: [{path: ".reyn/mcp.yaml"}]` (or equivalent for the other paths) in `skill.md` frontmatter and obtain the corresponding approval. The canonical route for these operations is the appropriate gated op handler, not direct file writes.
+
 ### Layer 2: skill declarations
 
 A skill that needs something outside the defaults declares it in its `skill.md` frontmatter. At skill startup, the runtime shows a single approval prompt:


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder dispatch より。

## Summary

- `docs/concepts/runtime/permission-model.md` の「Layer 1: defaults」セクションに、protected write path carve-out を明記
- `.reyn/mcp.yaml` / `.reyn/cron.yaml` / `.reyn/index/sources.yaml` はデフォルト write zone から除外される旨と理由を追記
- 理由: これらは capability-gated op handler の backing store。直書きで gate + audit trail を bypass できる（privilege escalation リスク）
- 正規ルートは gated op handler 経由、または明示 `file.write` 宣言+承認

source: `src/reyn/permissions/permissions.py` の `_CANONICAL_PROTECTED_WRITE_PATHS`。

**変更ページ:** removed 0 / added 0 (既存ページへの追記のみ)

## Test plan

- [ ] `mkdocs build --strict` でリンクエラーなし
- [ ] Layer 1 セクションに carve-out の説明が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)