### PR TITLE
fix(1199): protect .reyn/approvals.yaml from broad-zone write (approval-audit bypass)

### DIFF
--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -75,6 +75,14 @@ _CANONICAL_PROTECTED_WRITE_PATHS = (
     ".reyn/mcp.yaml",
     ".reyn/cron.yaml",
     ".reyn/index/sources.yaml",
+    # #1199 security fix: the persisted approval store. It is written ONLY via
+    # the gated approval-decision mechanism (``_persist`` — which also emits the
+    # state_change audit signal). Without this carve-out it sits in the broad
+    # ``.reyn/`` default write zone, so a safe-mode file.write could inject an
+    # approval directly: bypassing the user-approval gate + the audit, and (since
+    # approvals load once into ``self._saved`` at startup) silently activating a
+    # never-approved grant on the NEXT run = approval-audit bypass.
+    ".reyn/approvals.yaml",
 )
 
 

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -50,7 +50,8 @@ def test_other_reyn_paths_still_in_default_zone(tmp_path, monkeypatch):
     for rel in (
         ".reyn/index/events_cursor",
         ".reyn/index/chunks.jsonl",
-        ".reyn/approvals.yaml",
+        # #1199: .reyn/approvals.yaml MOVED to the protected set (was here) —
+        # see test_require_file_write_rejects_approvals_yaml.
         ".reyn/events.jsonl",
         ".reyn/scratch/anything.txt",
         "reyn/local/whatever.py",
@@ -68,6 +69,23 @@ def test_require_file_write_rejects_canonical_without_decl(tmp_path, monkeypatch
     decl = PermissionDecl()  # no axes set
     with pytest.raises(PermissionError, match="was not approved"):
         resolver.require_file_write(decl, ".reyn/mcp.yaml", "skill_x")
+
+
+def test_require_file_write_rejects_approvals_yaml(tmp_path, monkeypatch):
+    """Tier 2: #1199 security fix — a broad-zone file.write to the persisted approval
+    store (.reyn/approvals.yaml) is DENIED without an explicit decl, closing the
+    approval-injection persistence attack (a direct write would otherwise bypass the
+    user-approval gate + audit and silently activate on next startup).
+
+    Falsification contrast: a non-protected sibling under .reyn/ (scratch) is still
+    allowed in-zone — so the denial is specific to the protected-path list, not a
+    blanket .reyn/ write block."""
+    monkeypatch.chdir(tmp_path)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    with pytest.raises(PermissionError, match="was not approved"):
+        resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
+    # contrast: a non-protected .reyn/ path is NOT denied (in default zone).
+    resolver.require_file_write(PermissionDecl(), ".reyn/scratch/notes.txt", "skill_x")
 
 
 def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, monkeypatch):


### PR DESCRIPTION
**[e2e-coder]** — security fix (owner-probed, lead-coder dispatched). ⚠️ **doc-pending #1314** — see note at bottom; do not merge before the doc line is added on rebase.

## The hole (primary-verified)
`.reyn/approvals.yaml` — the persisted approval store — was **not** in `_CANONICAL_PROTECTED_WRITE_PATHS` (which held only mcp.yaml / cron.yaml / index/sources.yaml). It lives in the broad `.reyn/` default write zone, so a safe-mode `file.write` could inject an approval **directly**, bypassing the user-approval gate + the `state_change` audit that legitimate approval writes go through (`_persist`, permissions.py).

**Severity (calibrated):** NOT an immediate in-session escalation — checks read the in-memory `self._saved` dict (loaded once at startup, `_load_saved`), not the file. The vector is **persistence**: a directly-written approval activates a never-approved grant on the **next** startup = **approval-audit bypass**. Same carve-out class as mcp/cron, but the approval store itself was overlooked.

## Fix
- **permissions.py**: add `.reyn/approvals.yaml` to `_CANONICAL_PROTECTED_WRITE_PATHS` (with rationale). It is now excepted from the default write zone → a write requires an explicit decl + approval (the same gate `_persist` already uses for legitimate writes).
- **tests**: moved approvals.yaml out of the "non-protected `.reyn/` paths" list (it was there) + added `test_require_file_write_rejects_approvals_yaml` (DENY + a non-protected-sibling **falsification contrast** so the denial is specific to the protected list, not a blanket `.reyn/` block).

## Scope (aligned with the step-2 HOLD)
**Only** approvals.yaml. The step-2 audit of other `.reyn/` backing stores is **paused** pending the owner's carve-out direction (config-write protection vs use-time gating). Audit results recorded:
- `.reyn/integrations.yaml` — external-transport config, but **no programmatic writer** (operator-edited, no gate to bypass) → not the same class; flagged-not-added.
- `.reyn/config.yaml` — deprecated/removed (ADR-0031).
- `~/.reyn/secrets.env` + `~/.reyn/oauth_tokens.json` — **HOME-absolute**, outside the project `.reyn/` write zone → not broad-zone-writable.

## Test plan
- [x] `pytest tests/test_permission_collapse_phase2.py -q` — 11 passed (incl. new approvals DENY + falsification)
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict tests/test_permission_collapse_phase2.py` — clean
- [x] full `pytest -q` from rootdir — 6876 passed, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, #1203 — orthogonal/CI-green)
- [ ] **(pending)** doc line in `docs/concepts/runtime/permission-model.md` — add `.reyn/approvals.yaml — persisted approval store` as the 4th protected path + "Three paths"→"Four paths", **on rebase after #1314 merges** (the list lives in #1314; keeping code+doc atomic). Do not merge this PR before that.

Refs #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)