### PR TITLE
fix(permission): close approvals.yaml safe-mode write bypass (#1199 completion)

### DIFF
--- a/src/reyn/safe/file.py
+++ b/src/reyn/safe/file.py
@@ -72,20 +72,31 @@ _context_initialised: bool = False
 
 # #571 collapse arc Phase 2: canonical paths whose write must go through
 # a specific op handler (= mcp_install / mcp_drop_server / cron_register
-# / index_drop). Listing one of these in ``_write_paths`` via a parent
-# directory (e.g. ``.reyn/``) is no longer enough; the path must appear
-# in ``_write_paths`` *exactly* (= via an explicit ``file.write: [{path:
-# ...}]`` decl, or via the bool-axis compat shim that auto-expands to
-# the same entry).
+# / index_drop) or, for ``.reyn/approvals.yaml``, the runtime
+# approval-decision flow (#1199). Listing one of these in ``_write_paths``
+# via a parent directory (e.g. ``.reyn/``) is no longer enough; the path
+# must appear in ``_write_paths`` *exactly* (= via an explicit
+# ``file.write: [{path: ...}]`` decl, or via the bool-axis compat shim
+# that auto-expands to the same entry).
+#
+# #1199 (safe.file side): ``.reyn/approvals.yaml`` is the persisted
+# approval store, written ONLY via the gated approval-decision mechanism.
+# Without this carve-out on the safe.file enforcement path, a safe-mode
+# python step could inject an approval via the broad ``.reyn/`` zone —
+# bypassing the user-approval gate + audit (the subprocess always receives
+# ``.reyn/`` in its write_paths, see preprocessor_executor). The parent
+# permissions.py gate alone did not cover this enforcement path.
 #
 # Mirrors ``reyn.permissions.permissions._CANONICAL_PROTECTED_WRITE_PATHS``
-# — keep the two lists in sync. They live in two modules because this
-# one runs in the python-harness subprocess where importing the parent's
-# permissions module is not always available.
+# — keep the two lists in sync (drift-guarded by
+# ``test_canonical_protected_lists_stay_in_sync``). They live in two
+# modules because this one runs in the python-harness subprocess where
+# importing the parent's permissions module is not always available.
 _CANONICAL_PROTECTED_WRITE_PATHS = (
     ".reyn/mcp.yaml",
     ".reyn/cron.yaml",
     ".reyn/index/sources.yaml",
+    ".reyn/approvals.yaml",
 )
 
 

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -2,10 +2,12 @@
 
 Verifies the OS-invariants introduced by Phase 2:
 
-1. The three canonical protected paths (.reyn/mcp.yaml / .reyn/cron.yaml /
-   .reyn/index/sources.yaml) are excepted from the broad `.reyn/`
-   default write zone — direct `safe.file.write` to them requires an
-   explicit `file.write: [{path: ...}]` declaration.
+1. The canonical protected paths (.reyn/mcp.yaml / .reyn/cron.yaml /
+   .reyn/index/sources.yaml / .reyn/approvals.yaml) are excepted from the
+   broad `.reyn/` default write zone — direct `safe.file.write` to them
+   requires an explicit `file.write: [{path: ...}]` declaration. The
+   approvals.yaml entry (#1199) must hold on BOTH the permissions.py and
+   safe.file enforcement copies (drift-guarded).
 2. The bool-axis compat shim in `PermissionDecl.from_dict` expands each
    set bool axis (mcp_install / mcp_drop_server / cron_register /
    index_drop) into the equivalent `file.write` entry, so existing
@@ -195,4 +197,43 @@ def test_safe_file_check_write_still_allows_non_canonical_under_reyn(tmp_path, m
     )
     # Cursor file under .reyn/index/ but NOT sources.yaml → still allowed.
     safe_file._check_write(str(tmp_path / ".reyn" / "index" / "events_cursor"))
-    safe_file._check_write(str(tmp_path / ".reyn" / "approvals.yaml"))
+    # A scratch state file directly under .reyn/ (not a protected path).
+    safe_file._check_write(str(tmp_path / ".reyn" / "chunk_cache.json"))
+
+
+def test_safe_file_check_write_rejects_approvals_yaml(tmp_path, monkeypatch):
+    """Tier 2: #1199 security fix (safe.file side) — a safe-mode file.write to the
+    persisted approval store (.reyn/approvals.yaml) covered only by the broad
+    .reyn/ zone is DENIED, closing the approval-injection bypass on the
+    python-harness enforcement path. The parent permissions.py gate alone left
+    this open: the subprocess always receives .reyn/ in its write_paths.
+
+    Falsification contrast: a non-protected sibling under .reyn/ stays writable
+    in-zone — the denial is specific to the protected-path list.
+    """
+    monkeypatch.chdir(tmp_path)
+    from reyn.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
+    )
+    with pytest.raises(PermissionError, match="canonical protected path"):
+        safe_file._check_write(str(tmp_path / ".reyn" / "approvals.yaml"))
+    # contrast: a non-protected .reyn/ scratch path is NOT denied (in default zone).
+    safe_file._check_write(str(tmp_path / ".reyn" / "scratch_state.json"))
+
+
+def test_canonical_protected_lists_stay_in_sync():
+    """Tier 2: the two _CANONICAL_PROTECTED_WRITE_PATHS copies must not drift.
+
+    permissions.permissions and safe.file each define the list — the safe
+    module runs in the python-harness subprocess and cannot import the parent
+    permissions module, so the constant is duplicated. This drift-guard pins
+    them equal, so any future add/remove of a protected path must touch BOTH
+    copies. Closes the recurrence class behind the #1199 gap, where
+    approvals.yaml was added to the parent list only.
+    """
+    from reyn.safe.file import _CANONICAL_PROTECTED_WRITE_PATHS as safe_paths
+
+    assert _CANONICAL_PROTECTED_WRITE_PATHS == safe_paths


### PR DESCRIPTION
**[dogfood-coder]** — Security gap-fix (flow-trace-discovered, co-signed by lead-coder). First of the realignment Stage 3 queue, **precedes** the carve-out redesign.

## Problem

The #1199 carve-out that protects `.reyn/approvals.yaml` from a broad-zone `file.write` was added to `permissions.permissions._CANONICAL_PROTECTED_WRITE_PATHS` (4 paths) but **not** to its `safe.file` mirror (3 paths), despite the "keep the two lists in sync" comment.

The `safe.file` list is the enforcement point for **safe-mode python steps**: the python-harness subprocess always receives the broad `.reyn/` zone in `write_paths` (`preprocessor_executor`). With approvals.yaml absent from the safe.file carve-out, `safe.file._check_write` falls through to the broad-zone prefix match and **allows** a write to `.reyn/approvals.yaml`. That is exactly the #1199 threat — a safe-mode step injecting an approval, bypassing the user-approval gate + audit — left open on the enforcement path the parent gate does not cover. A test (`test_safe_file_check_write_still_allows_non_canonical_under_reyn`) actively pinned the insecure behavior, and `permission-model.md`'s uniform-gating claim contradicted it.

## Fix

- **(a)** add `.reyn/approvals.yaml` to `safe.file._CANONICAL_PROTECTED_WRITE_PATHS` — now matches the parent list.
- **(b)** replace the test's insecure approvals-writable assertion with a true non-canonical scratch example; add `test_safe_file_check_write_rejects_approvals_yaml` (safe.file counterpart of the existing permissions.py rejects test, with falsification contrast).
- **(c)** doc: no change needed — `permission-model.md` already describes 4 protected paths incl approvals and claims uniform gating; the fix makes the code match the doc.
- **(d) root-cause:** `test_canonical_protected_lists_stay_in_sync` drift-guard pins the two duplicated lists equal. The duplication is structural (the safe module runs in the subprocess and cannot import the parent permissions module), so a drift-guard is the durable fix that closes this recurrence class.

## Evidence

- Both new tests **FAIL** on the pre-fix list, **PASS** after (reproduce-first, git-stash verified; non-vacuous).
- `tests/test_permission_collapse_phase2.py`: 13 passed.
- Broader perm/safe-file sweep (`-k "permission or safe_file or canonical or approval"`): 212 passed, 2 skipped.
- test-tier audit `--strict`: 13 OK, 0 errors.

## Test plan

- [x] `pytest tests/test_permission_collapse_phase2.py` — 13 passed
- [x] reproduce-first: both new tests fail on pre-fix list (git-stash verified)
- [x] broader sweep — 212 passed
- [x] `scripts/test_tier_audit.py --strict` — 0 errors

After this lands, the carve-out redesign (queue #1) rebases and removes mcp/cron from both lists; the drift-guard then forces both copies to be updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)