### PR TITLE
refactor(permission): protect-at-use carve-out — drop mcp.yaml + cron.yaml (#1199 realignment)

### DIFF
--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -30,16 +30,21 @@ reyn's permission system gates four kinds of capability: file paths, shell, MCP 
 
 Read/glob/grep anywhere under the project root. Write/edit/delete only under `.reyn/` or `reyn/`. No shell, no MCP, no Python.
 
-**Exception — protected write paths:** Four paths inside `.reyn/` are carved out from the default write grant because each backs a capability-gated operation that carries its own approval gate and audit event. Allowing direct writes to these paths via the broad `.reyn/` zone would bypass those controls — a skill could silently register a new capability without going through the intended authorization flow.
+**Exception — protected write paths:** A small set of paths inside `.reyn/` are carved out from the default write grant because a direct write would bypass an authorization or audit surface. The carve-out is deliberately narrow — a path needs it only when it lacks a *downstream* gate.
 
-| Protected path | Backs |
-|---|---|
-| `.reyn/approvals.yaml` | The persistent approval store — only the runtime authorization flow writes here |
-| `.reyn/mcp.yaml` | MCP server configuration |
-| `.reyn/cron.yaml` | Cron job registry |
-| `.reyn/index/sources.yaml` | Index source registry |
+| Protected path | Backs | Why carved out |
+|---|---|---|
+| `.reyn/approvals.yaml` | The persistent approval store — only the runtime authorization flow writes here | Permanent. It *is* the approval gate; there is no later use-gate, so a direct write would silently activate a never-approved grant on the next startup (#1199). |
+| `.reyn/index/sources.yaml` | Index source registry | Transitional — carved out until the S3.4 part1 op-layer gate lands. |
 
-A skill that legitimately needs to write one of these paths must declare it explicitly (e.g. `file.write: [{path: ".reyn/mcp.yaml"}]` in `skill.md` frontmatter) and obtain the corresponding approval. The intended route for these operations is the appropriate gated op handler — not direct file writes.
+**Protect-at-use (principle).** A config-write carve-out is *redundant* when the capability it configures is gated downstream at use time. `.reyn/mcp.yaml` and `.reyn/cron.yaml` were therefore **removed** from the carve-out:
+
+- `.reyn/mcp.yaml` — writing it (installing a server) grants nothing on its own. *Using* a server still passes a per-server check at call time (`require_mcp`), so download + execute of the server package is gated regardless of who wrote the config.
+- `.reyn/cron.yaml` — registering a job goes through the standard tool gate (`require_cron_register` / `require_file_write`); fired jobs run only under a user-launched in-process scheduler, and each fired op is itself permission-gated.
+
+A skill that legitimately needs to write a *still-protected* path must declare it explicitly (e.g. `file.write: [{path: ".reyn/index/sources.yaml"}]` in `skill.md` frontmatter) and obtain the corresponding approval. The intended route remains the appropriate gated op handler — not direct file writes.
+
+**Residual risk.** With mcp/cron at protect-at-use, a safe-mode step *can* now write `.reyn/mcp.yaml` / `.reyn/cron.yaml` directly via the broad `.reyn/` zone. This is intentional and bounded: the write changes only inert configuration. The authority it appears to grant (an MCP server, a cron job) is not realized until the gated use path (`require_mcp` / scheduler + op gates) is crossed, which a config write cannot bypass. The approval store keeps its carve-out precisely because it has no such downstream gate.
 
 ### Layer 2: skill declarations
 

--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -35,7 +35,7 @@ Read/glob/grep anywhere under the project root. Write/edit/delete only under `.r
 | Protected path | Backs | Why carved out |
 |---|---|---|
 | `.reyn/approvals.yaml` | The persistent approval store — only the runtime authorization flow writes here | Permanent. It *is* the approval gate; there is no later use-gate, so a direct write would silently activate a never-approved grant on the next startup (#1199). |
-| `.reyn/index/sources.yaml` | Index source registry | Transitional — carved out until the S3.4 part1 op-layer gate lands. |
+| `.reyn/index/sources.yaml` | Index source registry | Transitional — carved out until the index write-gate is effective end-to-end (#1320: the postprocessor scope must carry a sandbox-policy source; the S3.4 part1 op-layer gate alone does not fire in the real index flow). |
 
 **Protect-at-use (principle).** A config-write carve-out is *redundant* when the capability it configures is gated downstream at use time. `.reyn/mcp.yaml` and `.reyn/cron.yaml` were therefore **removed** from the carve-out:
 

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -56,24 +56,32 @@ if TYPE_CHECKING:
 
 _DEFAULT_WRITE_ZONES = (".reyn", "reyn")
 
-# #571 collapse arc Phase 2: canonical paths whose write is gated by a
-# specific op handler (= mcp_install / mcp_drop_server / cron_register /
-# index_drop) AND therefore must not be silently default-zone-allowed.
-# Skills that legitimately need to mutate these must declare them
-# explicitly via ``file.write: [{path: ...}]`` (or via the bool-axis
-# compat shim that auto-expands into the equivalent file.write entry —
-# see ``PermissionDecl._compat_expand_bool_axes``).
+# #571 collapse arc Phase 2 / realignment: canonical paths whose write
+# must NOT be silently default-zone-allowed because a direct write would
+# bypass an authorization / audit surface.
 #
-# Why exempt these specific paths only: they back capability that the
-# OS treats as a distinct event-emit + audit-trail surface (server
-# install / cron register / index drop). Letting any safe-mode python
-# step write them via the broad ``.reyn/`` default zone bypasses the
-# corresponding gate. The narrow exception preserves the broad
-# ``.reyn/`` write zone for everything else (= chunkers, cursors,
-# scratch state).
+# Protect-at-use migration: ``.reyn/mcp.yaml`` and ``.reyn/cron.yaml`` were
+# REMOVED from this set. Their config carve-out is redundant given a
+# downstream use-gate — writing the config alone grants nothing usable:
+#   - mcp.yaml: USING a server passes a per-server gate at call time
+#     (``require_mcp``, op_runtime/mcp.py). Installing (= writing mcp.yaml)
+#     without that gate is inert.
+#   - cron.yaml: registering a job goes through the standard tool gate
+#     (``require_cron_register`` / ``require_file_write``); fired jobs only
+#     run under a user-launched in-process scheduler and their ops are
+#     themselves permission-gated.
+# ``.reyn/index/sources.yaml`` stays carved out transitionally until the
+# S3.4 part1 op-layer gate lands. ``.reyn/approvals.yaml`` stays
+# permanently — it is the approval store itself and has no downstream
+# use-gate (see below).
+#
+# Skills that legitimately need to mutate a carved-out path must declare
+# it explicitly via ``file.write: [{path: ...}]`` (or the bool-axis compat
+# shim that auto-expands into the equivalent entry). Letting a safe-mode
+# python step write one via the broad ``.reyn/`` default zone bypasses the
+# corresponding gate. The narrow exception preserves the broad ``.reyn/``
+# write zone for everything else (= chunkers, cursors, scratch state).
 _CANONICAL_PROTECTED_WRITE_PATHS = (
-    ".reyn/mcp.yaml",
-    ".reyn/cron.yaml",
     ".reyn/index/sources.yaml",
     # #1199 security fix: the persisted approval store. It is written ONLY via
     # the gated approval-decision mechanism (``_persist`` — which also emits the
@@ -113,11 +121,13 @@ def _is_canonical_protected_write(path_str: str) -> bool:
 def _in_default_write_zone(path_str: str) -> bool:
     """Return True if path falls within a default-granted write zone (.reyn/ or reyn/).
 
-    Exception: canonical paths gated by specific op handlers (#571
-    collapse arc Phase 2 — ``.reyn/mcp.yaml`` / ``.reyn/cron.yaml`` /
-    ``.reyn/index/sources.yaml``) return False here so the corresponding
-    skill / op handler is forced to declare the explicit ``file.write``
-    entry (= or the bool-axis compat shim expands to it).
+    Exception: canonical protected paths (see
+    ``_CANONICAL_PROTECTED_WRITE_PATHS`` — ``.reyn/index/sources.yaml``
+    transitionally + ``.reyn/approvals.yaml``) return False here so the
+    write is forced through its explicit ``file.write`` declaration / gated
+    flow rather than the broad ``.reyn/`` zone. ``.reyn/mcp.yaml`` and
+    ``.reyn/cron.yaml`` were removed from this set (protect-at-use — their
+    downstream use-gate makes the config carve-out redundant).
     """
     if _is_canonical_protected_write(path_str):
         return False

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -71,7 +71,9 @@ _DEFAULT_WRITE_ZONES = (".reyn", "reyn")
 #     run under a user-launched in-process scheduler and their ops are
 #     themselves permission-gated.
 # ``.reyn/index/sources.yaml`` stays carved out transitionally until the
-# S3.4 part1 op-layer gate lands. ``.reyn/approvals.yaml`` stays
+# index write-gate is effective end-to-end (#1320: the postprocessor scope
+# must carry a sandbox-policy source; the S3.4 part1 op-layer gate alone
+# does not fire in the real index flow). ``.reyn/approvals.yaml`` stays
 # permanently — it is the approval store itself and has no downstream
 # use-gate (see below).
 #

--- a/src/reyn/safe/file.py
+++ b/src/reyn/safe/file.py
@@ -70,14 +70,20 @@ _read_paths: tuple[str, ...] = ()
 _write_paths: tuple[str, ...] = ()
 _context_initialised: bool = False
 
-# #571 collapse arc Phase 2: canonical paths whose write must go through
-# a specific op handler (= mcp_install / mcp_drop_server / cron_register
-# / index_drop) or, for ``.reyn/approvals.yaml``, the runtime
-# approval-decision flow (#1199). Listing one of these in ``_write_paths``
-# via a parent directory (e.g. ``.reyn/``) is no longer enough; the path
-# must appear in ``_write_paths`` *exactly* (= via an explicit
-# ``file.write: [{path: ...}]`` decl, or via the bool-axis compat shim
-# that auto-expands to the same entry).
+# #571 collapse arc Phase 2 / realignment: canonical paths whose write
+# must go through a specific op handler (= ``index_drop`` for
+# ``.reyn/index/sources.yaml``, transitionally) or, for
+# ``.reyn/approvals.yaml``, the runtime approval-decision flow (#1199).
+# Listing one of these in ``_write_paths`` via a parent directory
+# (e.g. ``.reyn/``) is no longer enough; the path must appear in
+# ``_write_paths`` *exactly* (= via an explicit ``file.write: [{path:
+# ...}]`` decl, or via the bool-axis compat shim that auto-expands to
+# the same entry).
+#
+# Protect-at-use migration: ``.reyn/mcp.yaml`` and ``.reyn/cron.yaml``
+# were REMOVED from this set — using a server (``require_mcp``) / firing
+# a cron job (gated, user-launched scheduler) is gated downstream, so the
+# config-write carve-out is redundant. See the parent permissions.py note.
 #
 # #1199 (safe.file side): ``.reyn/approvals.yaml`` is the persisted
 # approval store, written ONLY via the gated approval-decision mechanism.
@@ -93,8 +99,6 @@ _context_initialised: bool = False
 # modules because this one runs in the python-harness subprocess where
 # importing the parent's permissions module is not always available.
 _CANONICAL_PROTECTED_WRITE_PATHS = (
-    ".reyn/mcp.yaml",
-    ".reyn/cron.yaml",
     ".reyn/index/sources.yaml",
     ".reyn/approvals.yaml",
 )

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -2,12 +2,14 @@
 
 Verifies the OS-invariants introduced by Phase 2:
 
-1. The canonical protected paths (.reyn/mcp.yaml / .reyn/cron.yaml /
-   .reyn/index/sources.yaml / .reyn/approvals.yaml) are excepted from the
-   broad `.reyn/` default write zone — direct `safe.file.write` to them
-   requires an explicit `file.write: [{path: ...}]` declaration. The
-   approvals.yaml entry (#1199) must hold on BOTH the permissions.py and
-   safe.file enforcement copies (drift-guarded).
+1. The canonical protected paths (.reyn/index/sources.yaml transitionally
+   + .reyn/approvals.yaml) are excepted from the broad `.reyn/` default
+   write zone — direct `safe.file.write` to them requires an explicit
+   `file.write: [{path: ...}]` declaration. The approvals.yaml entry
+   (#1199) must hold on BOTH the permissions.py and safe.file enforcement
+   copies (drift-guarded). .reyn/mcp.yaml and .reyn/cron.yaml were REMOVED
+   from this set (protect-at-use — a downstream use-gate makes the
+   config-write carve-out redundant); they are now default-zone-allowed.
 2. The bool-axis compat shim in `PermissionDecl.from_dict` expands each
    set bool axis (mcp_install / mcp_drop_server / cron_register /
    index_drop) into the equivalent `file.write` entry, so existing
@@ -37,7 +39,7 @@ from reyn.permissions.permissions import (
 
 
 def test_canonical_protected_paths_excepted_from_default_zone(tmp_path, monkeypatch):
-    """Tier 2: the 3 canonical paths return False from _in_default_write_zone."""
+    """Tier 2: each canonical protected path returns False from _in_default_write_zone."""
     monkeypatch.chdir(tmp_path)
     for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
         assert _in_default_write_zone(rel) is False, (
@@ -57,6 +59,10 @@ def test_other_reyn_paths_still_in_default_zone(tmp_path, monkeypatch):
         ".reyn/events.jsonl",
         ".reyn/scratch/anything.txt",
         "reyn/local/whatever.py",
+        # realignment: mcp.yaml + cron.yaml REMOVED from the carve-out
+        # (protect-at-use) — they are now ordinary default-zone writes.
+        ".reyn/mcp.yaml",
+        ".reyn/cron.yaml",
     ):
         assert _in_default_write_zone(rel) is True, (
             f"{rel!r} should remain in the default write zone (non-canonical)"
@@ -70,7 +76,7 @@ def test_require_file_write_rejects_canonical_without_decl(tmp_path, monkeypatch
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     decl = PermissionDecl()  # no axes set
     with pytest.raises(PermissionError, match="was not approved"):
-        resolver.require_file_write(decl, ".reyn/mcp.yaml", "skill_x")
+        resolver.require_file_write(decl, ".reyn/index/sources.yaml", "skill_x")
 
 
 def test_require_file_write_rejects_approvals_yaml(tmp_path, monkeypatch):
@@ -99,10 +105,12 @@ def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, m
     """
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
-    decl = PermissionDecl(file_write=[{"path": ".reyn/mcp.yaml", "scope": "just_path"}])
-    resolver.session_approve_path(".reyn/mcp.yaml", "skill_x", "file.write")
+    decl = PermissionDecl(
+        file_write=[{"path": ".reyn/index/sources.yaml", "scope": "just_path"}]
+    )
+    resolver.session_approve_path(".reyn/index/sources.yaml", "skill_x", "file.write")
     # Should not raise — startup_guard's session approval covers the path.
-    resolver.require_file_write(decl, ".reyn/mcp.yaml", "skill_x")
+    resolver.require_file_write(decl, ".reyn/index/sources.yaml", "skill_x")
 
 
 # ── legacy bool-axis keys are removed (#571 Phase 5) ───────────────────────────
@@ -139,7 +147,7 @@ def test_canonical_path_via_explicit_file_write_requires_startup_approval(tmp_pa
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     decl = PermissionDecl.from_dict({
-        "file.write": [{"path": ".reyn/mcp.yaml", "scope": "just_path"}],
+        "file.write": [{"path": ".reyn/index/sources.yaml", "scope": "just_path"}],
     })
     from reyn.permissions.permissions import _in_default_write_zone
     prompt_paths = [
@@ -149,7 +157,7 @@ def test_canonical_path_via_explicit_file_write_requires_startup_approval(tmp_pa
         and not _in_default_write_zone(entry["path"])
         and not resolver._is_path_approved_for(entry["path"], "skill_x", "file.write")
     ]
-    assert ".reyn/mcp.yaml" in prompt_paths
+    assert ".reyn/index/sources.yaml" in prompt_paths
 
 
 # ── reyn.safe.file enforcement ────────────────────────────────────────────────
@@ -166,7 +174,7 @@ def test_safe_file_check_write_rejects_canonical_via_parent_dir(tmp_path, monkey
         write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
     )
     with pytest.raises(PermissionError, match="canonical protected path"):
-        safe_file._check_write(str(tmp_path / ".reyn" / "mcp.yaml"))
+        safe_file._check_write(str(tmp_path / ".reyn" / "index" / "sources.yaml"))
 
 
 def test_safe_file_check_write_accepts_canonical_via_explicit_path(tmp_path, monkeypatch):
@@ -179,11 +187,11 @@ def test_safe_file_check_write_accepts_canonical_via_explicit_path(tmp_path, mon
         write_paths=[
             str(tmp_path / ".reyn"),
             str(tmp_path / "reyn"),
-            str(tmp_path / ".reyn" / "mcp.yaml"),  # explicit
+            str(tmp_path / ".reyn" / "index" / "sources.yaml"),  # explicit
         ],
     )
     # Should not raise.
-    safe_file._check_write(str(tmp_path / ".reyn" / "mcp.yaml"))
+    safe_file._check_write(str(tmp_path / ".reyn" / "index" / "sources.yaml"))
 
 
 def test_safe_file_check_write_still_allows_non_canonical_under_reyn(tmp_path, monkeypatch):
@@ -237,3 +245,38 @@ def test_canonical_protected_lists_stay_in_sync():
     from reyn.safe.file import _CANONICAL_PROTECTED_WRITE_PATHS as safe_paths
 
     assert _CANONICAL_PROTECTED_WRITE_PATHS == safe_paths
+
+
+def test_mcp_cron_now_allowed_after_carveout_removal(tmp_path, monkeypatch):
+    """Tier 2: realignment — .reyn/mcp.yaml and .reyn/cron.yaml are removed from the
+    carve-out (protect-at-use), so a broad-zone write to them is ALLOWED on both
+    enforcement paths. Safety holds downstream: using a server passes require_mcp
+    (op_runtime/mcp.py) and cron jobs fire only under a user-launched, op-gated
+    scheduler — so writing the config alone grants nothing usable.
+
+    Falsification contrast: .reyn/approvals.yaml (no downstream use-gate) is still
+    DENIED via the same broad zone — the removal is specific to mcp/cron, not a
+    blanket relaxation.
+    """
+    monkeypatch.chdir(tmp_path)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    from reyn.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
+    )
+
+    for rel in (".reyn/mcp.yaml", ".reyn/cron.yaml"):
+        # permissions.py path: no explicit decl needed — now in the default zone.
+        assert _in_default_write_zone(rel) is True
+        assert _is_canonical_protected_write(rel) is False
+        resolver.require_file_write(PermissionDecl(), rel, "skill_x")
+        # safe.file enforcement path: broad-zone prefix match is enough now.
+        safe_file._check_write(str(tmp_path / rel))
+
+    # contrast: approvals.yaml remains protected on both paths.
+    with pytest.raises(PermissionError, match="was not approved"):
+        resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
+    with pytest.raises(PermissionError, match="canonical protected path"):
+        safe_file._check_write(str(tmp_path / ".reyn" / "approvals.yaml"))


### PR DESCRIPTION
**[dogfood-coder]** — realignment Stage 3 **queue #1** (carve-out redesign). Follows the merged #1318 gap-fix; the #1318 drift-guard forced the lockstep update of both list copies. canonical spec: #1199.

## What

A config-write carve-out is **redundant** when the configured capability is gated downstream at use time. `.reyn/mcp.yaml` and `.reyn/cron.yaml` both have such a gate, so they are removed from `_CANONICAL_PROTECTED_WRITE_PATHS` (both `permissions.py` + `safe.file` copies).

| Path | Disposition | Why |
|---|---|---|
| `.reyn/mcp.yaml` | **removed** (protect-at-use) | Using a server passes `require_mcp` per-server at call time (`op_runtime/mcp.py:161`). Writing the config alone is inert. |
| `.reyn/cron.yaml` | **removed** (protect-at-use) | Registration goes through the standard tool gate (`require_cron_register` / `require_file_write`); fired jobs run only under a user-launched in-process scheduler with op-gated execution. |
| `.reyn/index/sources.yaml` | **kept (transitional)** | Until the S3.4 part1 op-layer gate lands. |
| `.reyn/approvals.yaml` | **kept (permanent)** | It *is* the approval gate — no downstream use-gate (#1199 / #1315). |

## Changes

- `permissions.py` + `safe.file`: drop the two paths; rewrite the rationale comments + `_in_default_write_zone` docstring.
- `permission-model.md`: protect-at-use **principle** + **residual-risk** section + updated carve-out table.
- tests: repoint the generic carve-out-mechanism tests to the still-protected `index/sources.yaml`; add `test_mcp_cron_now_allowed_after_carveout_removal` (now-allowed on **both** enforcement paths, with approvals-still-DENY contrast).

## Safety basis (flow-trace-confirmed, file:line)

- `op_runtime/mcp.py:161` calls `require_mcp(...)` — per-server use-gate intact.
- `tools/cron.py:37,213` — `require_cron_register` + standard `require_file_write` gate; fired ops permission-gated.
- Only `test_permission_collapse_phase2.py` carries carve-out-membership assertions (other mcp/cron tests reference the config path but not the carve-out) → test impact bounded to one file.

## Residual risk (documented in the doc)

A safe-mode step can now write `.reyn/mcp.yaml` / `.reyn/cron.yaml` via the broad `.reyn/` zone. Intentional + bounded: it changes only inert config; the authority is not realized until the gated use path (`require_mcp` / scheduler + op gates) is crossed, which a config write cannot bypass.

## Test plan

- [x] `pytest tests/test_permission_collapse_phase2.py` — 14 passed
- [x] reproduce-first: `test_mcp_cron_now_allowed_after_carveout_removal` FAILS on the pre-change list (git-stash verified)
- [x] broad sweep `-k "permission or safe_file or mcp or cron or canonical or approval or index_drop or collapse"` — 753 passed, 2 skipped (mcp/cron op flows intact, no regression)
- [x] `scripts/test_tier_audit.py --strict` — 14 OK, 0 errors

Next in queue: S4.4 part1 (index/recall/embed op-layer gate), after which `index/sources.yaml` leaves the carve-out too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)