### PR TITLE
feat(1199): S3.4 Part1 — route index/recall/embed FS-ops through the permission gate

### DIFF
--- a/src/reyn/index/backends/sqlite.py
+++ b/src/reyn/index/backends/sqlite.py
@@ -53,6 +53,30 @@ def _db_path(workspace_root: Path, source: str) -> Path:
     return workspace_root / ".reyn" / "index" / source / "index.db"
 
 
+def _within_paths(path: Path, roots: "list[str]") -> bool:
+    """True if ``path`` is one of ``roots`` or a descendant (resolved). #1199
+    S3.4 Part1 — the sandbox write_paths cap check for the host-direct index
+    write. Mirrors the resolved-path-under match in permissions/effective.py
+    (replicated here so reyn.index does not depend on reyn.permissions)."""
+    try:
+        p = Path(path).expanduser().resolve()
+    except Exception:
+        return False
+    for root in roots:
+        try:
+            r = Path(root).expanduser().resolve()
+        except Exception:
+            continue
+        if p == r:
+            return True
+        try:
+            p.relative_to(r)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
 def _open_db(db_file: Path) -> sqlite3.Connection:
     db_file.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_file), check_same_thread=False)
@@ -87,10 +111,24 @@ class SqliteIndexBackend:
     Args:
         workspace_root: Root directory of the Reyn workspace.  Defaults to
             ``Path.cwd()`` so tests can instantiate without explicit wiring.
+        sandbox_write_paths: #1199 S3.4 Part1 — when set (the phase sandbox
+            policy's ``write_paths``, forwarded into the safe-mode subprocess
+            where this backend's write bypasses ``require_file_*``), ``write``
+            self-gates the DB path against the cap before opening it. ``None`` =
+            no sandbox cap (in-process callers, which are already gated at the
+            op layer). The SQLite I/O itself stays host-direct (random-access /
+            lock cannot go on the read_file/write_file abstraction); only the
+            path is checked, before ``sqlite3.connect``.
     """
 
-    def __init__(self, workspace_root: Path | None = None) -> None:
+    def __init__(
+        self,
+        workspace_root: Path | None = None,
+        *,
+        sandbox_write_paths: "list[str] | None" = None,
+    ) -> None:
         self._root = workspace_root if workspace_root is not None else Path.cwd()
+        self._sandbox_write_paths = sandbox_write_paths
 
     # ------------------------------------------------------------------
     # write
@@ -103,6 +141,19 @@ class SqliteIndexBackend:
         mode: Literal["append", "replace"],
     ) -> WriteResult:
         db_file = _db_path(self._root, source)
+        # #1199 S3.4 Part1: SandboxLayer ∩ for the host-direct index write —
+        # gate the DB path against the phase sandbox write_paths cap BEFORE the
+        # connection opens (mirrors S3.1c-2's _path_under restrict-only).
+        if self._sandbox_write_paths is not None and not _within_paths(
+            db_file, self._sandbox_write_paths
+        ):
+            raise PermissionError(
+                f"index write to {str(db_file)!r} denied by the active sandbox "
+                f"policy (path outside write_paths={self._sandbox_write_paths!r}). "
+                f"This is a sandbox restriction on the OS's host-direct index "
+                f"write. Adjust the phase default_sandbox_policy write_paths if "
+                f"the index should be writable here."
+            )
         conn = _open_db(db_file)
         written = 0
         skipped = 0

--- a/src/reyn/kernel/_python_harness.py
+++ b/src/reyn/kernel/_python_harness.py
@@ -195,6 +195,10 @@ def main() -> int:
         # #571 collapse arc Phase 3: host allowlist for reyn.safe.http
         # gating. Empty = no HTTP via safe.http.
         http_hosts = list(req.get("http_hosts") or [])
+        # #1199 S3.4 Part1: the phase sandbox policy's write_paths cap (None =
+        # no sandbox cap on the host-direct index write). Only present when the
+        # phase declares a default_sandbox_policy with write_paths.
+        sandbox_write_paths = req.get("sandbox_write_paths")
 
         if mode not in ("safe", "unsafe"):
             raise ValueError(f"unknown mode: {mode!r}")
@@ -235,6 +239,18 @@ def main() -> int:
             _safe_http._set_permission_context(http_hosts=http_hosts)
         except ImportError:
             pass
+
+        # #1199 S3.4 Part1: forward the phase sandbox write_paths cap to
+        # reyn.safe.embed_index so the host-direct index write (SqliteIndexBackend)
+        # self-gates the DB path against it. Only set when present (None = no cap).
+        if sandbox_write_paths is not None:
+            try:
+                from reyn.safe import embed_index as _safe_embed_index
+                _safe_embed_index._set_context(
+                    sandbox_write_paths=list(sandbox_write_paths),
+                )
+            except ImportError:
+                pass
 
         # Defensive copy so user mutations don't affect the parent's data.
         result = fn(copy.deepcopy(artifact))

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -562,6 +562,21 @@ class PreprocessorExecutor:
             and entry.get("host") != "*"
         ]
 
+        # #1199 S3.4 Part1: forward the phase sandbox write_paths cap so a
+        # safe-mode step's host-direct index write (reyn.safe.embed_index →
+        # SqliteIndexBackend) self-gates against it. None when the phase declares
+        # no default_sandbox_policy (or no write_paths) → no cap (unchanged).
+        # getattr: the preprocessor path passes a PhaseIR (has the field); the
+        # postprocessor path passes a _PostprocessorScope (skill-level, no phase
+        # policy source yet) → None there (the index-write location; see the
+        # postprocessor-policy-source follow-up).
+        _sbx = getattr(phase, "default_sandbox_policy", None) or None
+        sandbox_write_paths = (
+            list(_sbx.get("write_paths") or [])
+            if isinstance(_sbx, dict) and _sbx.get("write_paths") is not None
+            else None
+        )
+
         try:
             result = await asyncio.to_thread(
                 self._python_runner.run,
@@ -575,6 +590,7 @@ class PreprocessorExecutor:
                 file_read_paths=file_read_paths,
                 file_write_paths=file_write_paths,
                 http_hosts=http_hosts,
+                sandbox_write_paths=sandbox_write_paths,
             )
         except PythonStepError as exc:
             self._events.emit(

--- a/src/reyn/op_runtime/index_drop.py
+++ b/src/reyn/op_runtime/index_drop.py
@@ -18,7 +18,7 @@ from reyn.index.source_manifest import get_source_manifest
 from reyn.schemas.models import IndexDropIROp
 
 from . import register
-from .context import OpContext
+from .context import OpContext, sandbox_policy_from_ctx
 
 
 async def handle(
@@ -51,9 +51,20 @@ async def handle(
     # and the per-source distinction was operator-UX rather than
     # security).
     if ctx.permission_resolver is not None:
+        sandbox_policy = sandbox_policy_from_ctx(ctx)
         sources_yaml = workspace_root / ".reyn" / "index" / "sources.yaml"
         ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(sources_yaml), ctx.skill_name,
+            sandbox_policy=sandbox_policy,
+        )
+        # #1199 S3.4 Part1: gate the actual deletion target — the source dir —
+        # not just the manifest, so the destructive drop respects the phase
+        # sandbox write_paths cap (S3.1c-2 ∩). The SQLite/dir removal stays
+        # host-direct; the gate fires before backend.drop opens/removes it.
+        source_dir = workspace_root / ".reyn" / "index" / op.source
+        ctx.permission_resolver.require_file_write(
+            ctx.permission_decl, str(source_dir), ctx.skill_name,
+            sandbox_policy=sandbox_policy,
         )
 
     backend = SqliteIndexBackend(workspace_root=workspace_root)

--- a/src/reyn/op_runtime/index_query.py
+++ b/src/reyn/op_runtime/index_query.py
@@ -16,7 +16,7 @@ from reyn.index import SqliteIndexBackend
 from reyn.schemas.models import IndexQueryIROp
 
 from . import register
-from .context import OpContext
+from .context import OpContext, sandbox_policy_from_ctx
 
 # ---------------------------------------------------------------------------
 # Errors
@@ -72,6 +72,19 @@ async def handle(
         )
 
     workspace_root = ctx.workspace.base_dir
+
+    # #1199 S3.4 Part1: route the index FS-op through the permission gate (the
+    # SQLite I/O itself stays host-direct — random-access/lock can't go on the
+    # read_file abstraction — so we gate the DB path BEFORE the backend opens
+    # it, with the phase sandbox_policy ∩, same shape as S3.1c-2). Closes the
+    # hole where a sandbox read_paths cap could not constrain index reads.
+    if ctx.permission_resolver is not None:
+        db_path = workspace_root / ".reyn" / "index" / op.source / "index.db"
+        ctx.permission_resolver.require_file_read(
+            ctx.permission_decl, str(db_path), ctx.skill_name,
+            sandbox_policy=sandbox_policy_from_ctx(ctx),
+        )
+
     backend = SqliteIndexBackend(workspace_root=workspace_root)
 
     try:

--- a/src/reyn/python_runner.py
+++ b/src/reyn/python_runner.py
@@ -87,6 +87,7 @@ class PythonRunner:
         file_read_paths: list[str] | None = None,
         file_write_paths: list[str] | None = None,
         http_hosts: list[str] | None = None,
+        sandbox_write_paths: list[str] | None = None,
     ) -> Any:
         """Execute `function` in `module` against `artifact`.
 
@@ -119,6 +120,11 @@ class PythonRunner:
             # #571 Phase 3: host allowlist for reyn.safe.http gating.
             "http_hosts": list(http_hosts or []),
         }
+        # #1199 S3.4 Part1: forward the phase sandbox write_paths cap (only when
+        # set) so reyn.safe.embed_index's host-direct index write self-gates. None
+        # (no phase sandbox policy) → key omitted → harness leaves the cap unset.
+        if sandbox_write_paths is not None:
+            request["sandbox_write_paths"] = list(sandbox_write_paths)
 
         try:
             proc = subprocess.run(

--- a/src/reyn/safe/embed_index.py
+++ b/src/reyn/safe/embed_index.py
@@ -74,6 +74,13 @@ from reyn.index.source_manifest import SourceEntry, get_source_manifest
 _workspace_root: Path | None = None
 _embedding_config: dict | None = None
 _provider_name: str | None = None
+# #1199 S3.4 Part1: the phase sandbox policy's write_paths cap, forwarded into
+# this subprocess by the python harness (the OS knows the phase policy; the
+# subprocess does not). None = no cap (SqliteIndexBackend write is ungated by
+# the sandbox = unchanged). A sentinel of () means "set but empty" = deny all
+# out-of-(empty) ... but the harness only sets it when a phase policy declares
+# write_paths, so None vs a list is the live distinction.
+_sandbox_write_paths: "list[str] | None" = None
 
 
 def _set_context(
@@ -81,26 +88,32 @@ def _set_context(
     workspace_root: str | Path | None = None,
     embedding_config: dict | None = None,
     provider_name: str | None = None,
+    sandbox_write_paths: "list[str] | None" = None,
 ) -> None:
-    """Override the self-sufficient defaults (test / explicit-wiring hook).
+    """Override the self-sufficient defaults (test / harness-wiring hook).
 
     Any argument left ``None`` keeps the default resolution for that field.
+    (``sandbox_write_paths`` defaults to no cap; the harness sets it from the
+    phase ``default_sandbox_policy.write_paths`` — #1199 S3.4 Part1.)
     """
-    global _workspace_root, _embedding_config, _provider_name
+    global _workspace_root, _embedding_config, _provider_name, _sandbox_write_paths
     if workspace_root is not None:
         _workspace_root = Path(workspace_root)
     if embedding_config is not None:
         _embedding_config = dict(embedding_config)
     if provider_name is not None:
         _provider_name = provider_name
+    if sandbox_write_paths is not None:
+        _sandbox_write_paths = list(sandbox_write_paths)
 
 
 def _reset_context() -> None:
     """Clear all overrides → back to the self-sufficient defaults."""
-    global _workspace_root, _embedding_config, _provider_name
+    global _workspace_root, _embedding_config, _provider_name, _sandbox_write_paths
     _workspace_root = None
     _embedding_config = None
     _provider_name = None
+    _sandbox_write_paths = None
 
 
 def _resolve() -> tuple[Path, str, dict]:
@@ -154,7 +167,12 @@ async def embed_and_index_async(
     """
     workspace_root, provider_name, embedding_config = _resolve()
     provider = get_provider(provider_name, config=embedding_config)
-    backend = SqliteIndexBackend(workspace_root=workspace_root)
+    # #1199 S3.4 Part1: pass the forwarded phase sandbox write_paths cap so the
+    # host-direct index write self-gates the DB path before connecting (the
+    # subprocess has no ctx.permission_resolver / op-layer gate).
+    backend = SqliteIndexBackend(
+        workspace_root=workspace_root, sandbox_write_paths=_sandbox_write_paths,
+    )
 
     # Resume key: hashes already indexed (skip BEFORE embedding = cost save).
     # Append resumes against the existing DB; replace rebuilds from scratch, so

--- a/tests/test_1199_s34_part1_fs_op_gate.py
+++ b/tests/test_1199_s34_part1_fs_op_gate.py
@@ -1,0 +1,169 @@
+"""Tier 2: S3.4 Part1 — index/recall/embed FS-ops routed through the permission gate.
+
+#1199 S3.4 Part1 closes the hole where index reads/writes opened sqlite3 host-direct
+(bypassing require_file_*), so S3.1c-2's SandboxLayer ∩ never applied. Two seams:
+  - OS-side op handlers (index_query / index_drop) call require_file_read/write
+    with the phase sandbox_policy ∩ BEFORE invoking the backend.
+  - the WRITE path runs in the safe subprocess (no ctx): the sandbox write_paths
+    cap is forwarded into the subprocess (harness → embed_index) and
+    SqliteIndexBackend self-gates the DB path before sqlite3.connect (co-signed B).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.index.backend import ChunkRecord
+from reyn.index.backends.sqlite import SqliteIndexBackend
+from reyn.op_runtime.context import OpContext
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.schemas.models import IndexDropIROp, IndexQueryIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _chunk() -> ChunkRecord:
+    return ChunkRecord(
+        text="x", vector=[0.1, 0.2, 0.0, 0.0],
+        metadata={
+            "content_hash": "h1", "source_path": "f", "source_type": "generic",
+            "embedding_model": "m", "chunk_index": 0, "size_tokens": 1,
+            "parent_context": None,
+        },
+        score=None,
+    )
+
+
+async def _write(backend: SqliteIndexBackend):
+    return await backend.write("s", [_chunk()], "append")
+
+
+# ── SqliteIndexBackend write self-gate (subprocess write path) ───────────────
+
+
+def test_write_denies_outside_sandbox_cap(tmp_path: Path) -> None:
+    """Tier 2: the host-direct index write DENIES when the DB path is outside the
+    forwarded sandbox write_paths cap (gate fires before sqlite3.connect)."""
+    b = SqliteIndexBackend(workspace_root=tmp_path, sandbox_write_paths=["/sandboxed"])
+    with pytest.raises(PermissionError, match="sandbox"):
+        asyncio.run(_write(b))
+    # and nothing was written (denial precedes the open).
+    assert not (tmp_path / ".reyn" / "index" / "s" / "index.db").exists()
+
+
+def test_write_allows_within_sandbox_cap(tmp_path: Path) -> None:
+    """Tier 2: a cap that covers the workspace allows the write (swe_bench ["/"]
+    allow-all is the live no-blast case)."""
+    b = SqliteIndexBackend(workspace_root=tmp_path, sandbox_write_paths=[str(tmp_path)])
+    assert asyncio.run(_write(b))["written"] == 1
+
+
+def test_write_no_cap_unchanged(tmp_path: Path) -> None:
+    """Tier 2: sandbox_write_paths=None (in-process callers / no phase policy) →
+    no sandbox gate, write behaves as pre-S3.4."""
+    assert asyncio.run(_write(SqliteIndexBackend(workspace_root=tmp_path)))["written"] == 1
+
+
+def test_write_sandbox_falsification(tmp_path: Path) -> None:
+    """Tier 2: ★∩-falsification — the SAME write the cap DENIES is ALLOWED once the
+    cap is dropped (None). Proves the self-gate is load-bearing (over-grant if removed)."""
+    with pytest.raises(PermissionError):
+        asyncio.run(_write(SqliteIndexBackend(
+            workspace_root=tmp_path, sandbox_write_paths=["/sandboxed"],
+        )))
+    assert asyncio.run(_write(SqliteIndexBackend(
+        workspace_root=tmp_path, sandbox_write_paths=None,
+    )))["written"] == 1
+
+
+# ── embed_index forwards the cap to the backend (subprocess context) ─────────
+
+
+class _FakeProvider:
+    def __init__(self, config=None) -> None:
+        self._batch_size = 100
+
+    async def embed(self, texts, model):
+        return {"vectors": [[1.0, 0.0, 0.0, 0.0] for _ in texts],
+                "model": model or "fake", "total_tokens": len(texts)}
+
+    def estimate_tokens(self, texts):
+        return len(texts)
+
+    def get_dimension(self, model):
+        return 4
+
+
+def test_embed_index_forwards_cap_to_backend(tmp_path: Path) -> None:
+    """Tier 2: the harness-set sandbox_write_paths context flows from embed_index
+    into SqliteIndexBackend → a restrictive cap DENIES the streamed index write."""
+    from reyn.embedding import register_provider
+    from reyn.safe import embed_index as ei
+
+    register_provider("fake_s34", _FakeProvider)
+    ei._reset_context()
+    ei._set_context(
+        workspace_root=tmp_path, provider_name="fake_s34",
+        sandbox_write_paths=["/sandboxed"],  # excludes tmp_path
+    )
+    chunk = {"text": "hello", "metadata": {"content_hash": "h1"}}
+    try:
+        with pytest.raises(PermissionError, match="sandbox"):
+            asyncio.run(ei.embed_and_index_async([chunk], "src", "standard"))
+    finally:
+        ei._reset_context()
+
+
+# ── OS-side op-handler gates (read / drop) ───────────────────────────────────
+
+
+def _ctx(tmp_path: Path, *, sandbox_policy: dict | None) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events, base_dir=tmp_path)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    return OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, skill_name="s",
+        default_sandbox_policy=sandbox_policy,
+    )
+
+
+def test_index_query_gated_by_sandbox_read_cap(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: index_query routes through require_file_read with the phase
+    sandbox_policy ∩ — a read_paths cap excluding the index path DENIES the query
+    (the in-zone DB path is narrowed by the sandbox)."""
+    from reyn.op_runtime.index_query import handle
+
+    monkeypatch.chdir(tmp_path)  # so .reyn/index/... is in the default read zone
+    ctx = _ctx(tmp_path, sandbox_policy={"read_paths": ["/sandboxed"]})
+    op = IndexQueryIROp(kind="index_query", source="src", query_vector=[0.1], top_k=1)
+    with pytest.raises(PermissionError):
+        asyncio.run(handle(op, ctx, caller="control_ir"))
+
+
+def test_index_query_no_policy_passes(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: with no sandbox policy, the in-zone index read is not blocked
+    (returns fallback for an absent index)."""
+    from reyn.op_runtime.index_query import handle
+
+    monkeypatch.chdir(tmp_path)
+    ctx = _ctx(tmp_path, sandbox_policy=None)
+    op = IndexQueryIROp(kind="index_query", source="src", query_vector=[0.1], top_k=1)
+    result = asyncio.run(handle(op, ctx, caller="control_ir"))
+    assert result["mode"] == "fallback"  # no index yet, but NOT denied
+
+
+def test_index_drop_gates_source_dir_by_sandbox_cap(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: index_drop gates the SOURCE DIR (the deletion target) under the
+    sandbox write_paths cap — a cap excluding it DENIES the destructive drop."""
+    from reyn.op_runtime.index_drop import handle
+
+    monkeypatch.chdir(tmp_path)
+    ctx = _ctx(tmp_path, sandbox_policy={"write_paths": ["/sandboxed"]})
+    op = IndexDropIROp(kind="index_drop", source="src")
+    with pytest.raises(PermissionError):
+        asyncio.run(handle(op, ctx, caller="control_ir"))


### PR DESCRIPTION
**[e2e-coder]** — #1199 S3.4 Part1, co-signed B (#1199 issuecomment-4626295899). Closes the FS-op-mediation bypass. ⚠️ **Honest scope: the read/drop gates FIRE; the write-gate is wired+tested but does NOT fire end-to-end until #1321** — see "Known gap" below. lead-coder sole-review.

## The hole
`SqliteIndexBackend` opens `sqlite3.connect` host-direct, bypassing `require_file_*` — so S3.1c-2's SandboxLayer ∩ never applied to index reads/writes (a sandbox read/write_paths cap could not constrain them). Design = **(B)**: gate at the index layer (SQLite I/O stays host-direct — random-access/lock can't go on the read_file/write_file abstraction; only the **path** is checked before connect). (B) was chosen over an OS-side pre-spawn gate because the latter is P7-violating — `preprocessor_executor` is generic and would have to bake `.reyn/index/<runtime-source>/` specifics into OS code.

## What FIRES (read/drop — phase op handlers have `ctx.sandbox_policy`)
- **index_query**: `require_file_read` on `.reyn/index/<source>/index.db` (sandbox_policy ∩) before `backend.query`.
- **index_drop**: `require_file_write` on the **source dir** (the deletion target, not just `sources.yaml`) before `backend.drop`.
- **recall**: gated transitively via its `index_query` sub-op.

## Write-path mechanism (wired + tested)
- `preprocessor_executor` forwards the phase `default_sandbox_policy.write_paths` → `python_runner` → req → harness (mirroring the existing `http.get` allowlist forward), which sets `reyn.safe.embed_index`'s `sandbox_write_paths` context.
- `embed_index` passes it to `SqliteIndexBackend`, whose `write` **self-gates the DB path** (`_within_paths`, mirroring `effective._path_under` — replicated so `reyn.index` doesn't depend on `reyn.permissions`) before `sqlite3.connect`. `None` = no cap (in-process callers, already op-gated).

## ★Known gap (co-signed, tracked in #1321)
The index write runs in the **postprocessor** (the index_docs/index_events chunker is a postprocessor python step), and `_PostprocessorScope` is skill-level — **no phase sandbox-policy source** — so the forwarded cap is always `None` there and the write-gate **does not fire end-to-end** for the actual index flow. The mechanism is correct + ready (fires when a policy is supplied); the postprocessor-policy source is a design question entangled with the mount/network model (owner input) → **#1321**. Zero current blast (no stdlib skill declares a sandbox policy = same as S3.1c-2). I deliberately do **not** claim this PR "gates the index write" end-to-end.

## Sequencing note
Removing `.reyn/index/sources.yaml` from the carve-out (protect-at-use migration) must wait for **#1321**, not this PR — protect-at-use isn't established until the write-gate is effective. (sandbox_2's carve-out follow-up: hold sources.yaml.)

## Also fixed
`_PostprocessorScope` AttributeError regression (the full suite caught it) — `getattr(phase, "default_sandbox_policy", None)`.

## Test plan
- [x] `pytest tests/test_1199_s34_part1_fs_op_gate.py -q` — 8 passed: backend self-gate DENY/allow/no-cap/★∩-falsification / embed_index forwards cap / index_query gated by sandbox read cap + no-policy passes / index_drop source-dir gated
- [x] regression-guard (index_backend / embed_index / op_recall / index_workspace_guard / chunkers / index_events / **postprocessor_e2e** / **eval_judge_e2e**) — green
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict tests/test_1199_s34_part1_fs_op_gate.py` — clean
- [x] full `pytest -q` from rootdir — 6886 passed, 1 pre-existing fail (`test_web_fetch_preview_path_ref`, #1203 — orthogonal/CI-green)

Refs #1199, #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)