### PR TITLE
feat(sandbox): broad-read scoping + sensitive deny-list (#1199 realignment)

### DIFF
--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -329,6 +329,26 @@ The execution surfaces that perform side-effects, ordered by enforcement strengt
 - **Safe-mode python** is honor-system: AST validation prevents `import os`, and `reyn.safe.*` checks declared paths / hosts / keys. A motivated user with `mode: unsafe` access can bypass; a non-motivated `mode: safe` author cannot accidentally bypass via normal coding patterns.
 - **Unsafe-mode python** is trust-by-declaration: the operator approves `--allow-unsafe-python` at runtime and accepts that the step has full host access.
 
+### Sandbox scoping model (sandboxed_exec)
+
+The `sandboxed_exec` policy (`SandboxPolicy`) is scoped **per axis**. The axes are deliberately asymmetric — each set to the tightness that actually buys safety:
+
+| Axis | Policy | Rationale |
+|---|---|---|
+| write | tight workspace-allowlist (`write_paths`) | The hard guard — bounds what a process can persist. |
+| network | tight (off by default / allowlist) | The exfiltration gate — a process may read widely but cannot send anything out. |
+| exec | controlled (`allow_subprocess`) | Bounds child-process spawning (advisory under Seatbelt). |
+| read | **broad-allow by default** + optional sensitive deny-list | The strict read-allowlist was abolished (#1199 realignment). |
+
+**Why broad read is safe.** The network gate, not the read surface, is the exfiltration control. With network off by default a process may read widely but cannot send data out. A broad read surface also removes the system-path enumeration (`/usr`, `/lib`, dyld cache, …) that every binary needs just to load — enumeration that, when missing, broke the Landlock backend on Linux. This matches industry practice: Codex defaults to broad read + network-off on Linux; Claude Code treats read-restriction as secondary ("affects functionality") behind its write / network guards.
+
+**Defense-in-depth deny-list.** `read_deny_paths` (default: OS-level credential stores — `~/.ssh`, `~/.aws`, `~/.gnupg`, …) carves sensitive locations out of the broad read surface.
+
+**Residual risk (backend asymmetry).** The deny-list is enforceable only where the backend can express a deny-after-allow rule:
+
+- **Seatbelt (macOS / SBPL)** — last-match-wins, so a broad `(allow file-read*)` followed by `(deny file-read* …)` enforces the deny-list.
+- **Landlock (Linux)** — allowlist-only (path-beneath grants; you cannot carve a subpath out of an allowed parent), so the deny-list is **not enforceable**; broad read is a single read rule on `/`. On Linux a compromised in-sandbox process can therefore *read* the sensitive paths the deny-list names — but it stays bounded by the network gate (no exfiltration) and the write / exec guards. The deny-list is defense-in-depth, not the primary boundary; the primary boundary (write-allowlist + network-off) holds identically on both backends.
+
 ## Industry comparison
 
 | Platform | Declaration shape | Runtime ask | Granularity | Enforcement |

--- a/src/reyn/sandbox/backends/landlock.py
+++ b/src/reyn/sandbox/backends/landlock.py
@@ -192,12 +192,25 @@ class LandlockBackend:
             )
             ruleset = landlock.Ruleset()  # type: ignore[attr-defined]
 
-            for path in policy.read_paths:
-                # TODO(fp-0017-b): Linux validation needed — verify access right constants.
-                ruleset.add_path_beneath_rule(  # type: ignore[attr-defined]
-                    path,
-                    read_only=True,
-                )
+            # #1199 realignment — broad read surface. Landlock is allowlist-only
+            # (path-beneath grants; anything not granted is denied), so broad-read
+            # is a single read rule on the filesystem root. This subsumes the old
+            # per-path read allowlist (policy.read_paths) AND fixes the Linux gap
+            # where system paths (/usr, /lib, dyld-equivalents) had to be
+            # enumerated for binaries to even load.
+            #
+            # Residual risk: Landlock CANNOT express a read deny-list (you cannot
+            # carve a subpath out of an allowed parent), so policy.read_deny_paths
+            # is NOT enforced here — unlike Seatbelt (SBPL deny-after-allow). The
+            # core guarantee rests instead on the network gate below: a compromised
+            # process on Linux may read sensitive paths but cannot exfiltrate
+            # (network off unless policy.network). This asymmetry is documented in
+            # the permission-model residual-risk section.
+            # TODO(fp-0017-b): Linux validation needed — verify access right constants.
+            ruleset.add_path_beneath_rule(  # type: ignore[attr-defined]
+                "/",
+                read_only=True,
+            )
 
             for path in policy.write_paths:
                 # TODO(fp-0017-b): Linux validation needed — verify access right constants.

--- a/src/reyn/sandbox/backends/seatbelt.py
+++ b/src/reyn/sandbox/backends/seatbelt.py
@@ -33,19 +33,10 @@ from reyn.sandbox.policy import SandboxPolicy
 
 _logger = logging.getLogger(__name__)
 
-# SBPL always-allowed system paths required for dynamic library loading and
-# basic process bootstrap. Without these, virtually every binary segfaults.
-_ALWAYS_READ_SUBPATHS: tuple[str, ...] = (
-    "/usr/lib",
-    "/System/Library",
-    "/usr/bin",
-    "/bin",
-    "/usr/share",
-    # dyld cache lives under /private/var/db/dyld on modern macOS; without
-    # read access the dynamic linker can't map shared cache and binaries
-    # abort at libc init.
-    "/private/var/db/dyld",
-)
+# #1199 realignment: the broad ``(allow file-read*)`` rule below subsumes the
+# old explicit system-path allowlist (/usr/lib, /System/Library, dyld cache,
+# …) that dynamic-library loading and process bootstrap required. With a broad
+# read surface there is no system-path enumeration to maintain.
 
 
 def _sbpl_quote(s: str) -> str:
@@ -76,34 +67,38 @@ def _build_sbpl_profile(policy: SandboxPolicy) -> str:
         "; binary under (deny default). Without it, even /bin/echo aborts at",
         "; libc init (SIGABRT) on macOS 26+.",
         '(import "bsd.sb")',
-        "",
-        "; — system libraries (dyld cache + framework load paths) —",
     ]
-
-    # Always-allowed read paths for dylib / process bootstrap.
-    system_subpaths = " ".join(
-        f"(subpath {_sbpl_quote(p)})" for p in _ALWAYS_READ_SUBPATHS
-    )
-    lines.append(f"(allow file-read* {system_subpaths})")
 
     # Always-allowed process-exec: without this, sandbox-exec cannot even
     # execvp() the target binary under (deny default) (macOS 26+ is strict).
-    # The filesystem restrictions above still bound what the exec'd process
-    # can read/write/network; we just don't gate the exec syscall itself.
     # process-fork is similarly needed by virtually every interpreter / runtime
     # bootstrap (e.g. CRT init); policy.allow_subprocess remains advisory.
+    lines.append("")
     lines.append("(allow process-exec*)")
     lines.append("(allow process-fork)")
 
-    # User-declared read paths.
-    if policy.read_paths:
-        lines.append("")
-        lines.append("; — policy read_paths —")
-        for raw in policy.read_paths:
-            resolved = str(Path(raw).resolve(strict=False))
-            lines.append(f"(allow file-read* (subpath {_sbpl_quote(resolved)}))")
+    # #1199 realignment — broad read surface. The strict read-allowlist was
+    # abolished: reads are broad by default (this subsumes the old system-path
+    # bootstrap allowlist AND policy.read_paths). Safety comes from the network
+    # gate (off unless policy.network): a process may read widely but cannot
+    # exfiltrate.
+    lines.append("")
+    lines.append("; — broad read (the network gate is the exfiltration guard) —")
+    lines.append("(allow file-read*)")
 
-    # User-declared write paths (write implies read in SBPL).
+    # Defense-in-depth: deny sensitive paths from the broad read surface. SBPL
+    # is last-match-wins, so these (deny ...) rules placed AFTER the broad allow
+    # take precedence for the listed paths.
+    if policy.read_deny_paths:
+        lines.append("")
+        lines.append("; — sensitive read deny-list (defense-in-depth) —")
+        for raw in policy.read_deny_paths:
+            resolved = str(Path(raw).expanduser().resolve(strict=False))
+            lines.append(f"(deny file-read* (subpath {_sbpl_quote(resolved)}))")
+
+    # User-declared write paths. write implies read: the file-read* re-allow is
+    # placed AFTER the deny-list intentionally, so an explicit write target is
+    # readable even if it falls under a denied prefix (an explicit grant wins).
     if policy.write_paths:
         lines.append("")
         lines.append("; — policy write_paths —")

--- a/src/reyn/sandbox/policy.py
+++ b/src/reyn/sandbox/policy.py
@@ -4,10 +4,28 @@ The policy is data only: declared in skill.md (= FP-0017) and passed by the OS
 to a SandboxBackend. P3/P7-aligned — the policy is mechanism-agnostic; backend
 selection lives in `reyn.sandbox.backend.get_default_backend()`.
 
+Scoping model (#1199 realignment, per-axis):
+    write   — tight workspace-allowlist (``write_paths``) = the hard guard.
+    network — tight (default off / allowlist) = the exfiltration gate.
+    exec    — controlled (``allow_subprocess``).
+    read    — **broad-allow by default**. The strict read-allowlist was
+              abolished: the network gate (off by default) blocks
+              exfiltration, so a broad read surface is safe and avoids the
+              system-path enumeration that broke Landlock on Linux. A
+              defense-in-depth ``read_deny_paths`` carves out sensitive
+              credential locations where the backend can express it.
+
 Fields:
     network: allow outbound network access from the sandboxed process
-    read_paths: filesystem paths the process may read (glob patterns OK)
-    write_paths: filesystem paths the process may write
+    read_paths: legacy read-allowlist. Under the broad-read scoping model it
+        no longer restricts reads (reads are broad by default); retained for
+        backward compatibility and as documentation of intended read targets.
+    write_paths: filesystem paths the process may write (write implies read)
+    read_deny_paths: sensitive paths to DENY from the broad read surface
+        (defense-in-depth). Enforced where the backend can express a
+        deny-after-allow rule (Seatbelt / SBPL); NOT enforceable on
+        allowlist-only backends (Landlock), which rely on the network gate.
+        Defaults to OS-level credential locations; ``~`` is expanded.
     allow_subprocess: whether the process may spawn children
     env_passthrough: env-var names that pass through to the sandboxed process
     timeout_seconds: wall-clock cap (enforced by the backend)
@@ -15,6 +33,24 @@ Fields:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
+# OS-level sensitive paths denied from the broad read surface by default
+# (defense-in-depth). These are universal credential / secret store locations,
+# not skill-specific (P7 ok) — the same class as the system-bootstrap paths a
+# backend always allows. A policy may override ``read_deny_paths`` to widen or
+# narrow this set. Workspace-internal secrets (e.g. a project ``.env``) are
+# intentionally NOT in the default — the agent operates inside the workspace,
+# so a blanket workspace deny would break legitimate reads; an operator who
+# needs it can add the path explicitly.
+DEFAULT_SENSITIVE_READ_DENY: tuple[str, ...] = (
+    "~/.ssh",
+    "~/.aws",
+    "~/.gnupg",
+    "~/.config/gcloud",
+    "~/.kube",
+    "~/.docker/config.json",
+    "~/.netrc",
+)
 
 
 @dataclass
@@ -24,6 +60,9 @@ class SandboxPolicy:
     network: bool = False
     read_paths: list[str] = field(default_factory=list)
     write_paths: list[str] = field(default_factory=list)
+    read_deny_paths: list[str] = field(
+        default_factory=lambda: list(DEFAULT_SENSITIVE_READ_DENY)
+    )
     allow_subprocess: bool = False
     env_passthrough: list[str] = field(default_factory=list)
     timeout_seconds: int = 60

--- a/tests/test_sandbox_seatbelt.py
+++ b/tests/test_sandbox_seatbelt.py
@@ -45,16 +45,40 @@ def test_sbpl_profile_default_deny():
     assert "(deny default)" in profile
 
 
-def test_sbpl_profile_read_paths():
-    """Tier 2: read_paths produce file-read* rules with the resolved absolute path."""
+def test_sbpl_profile_broad_read():
+    """Tier 2: #1199 realignment — reads are broad by default; the profile emits a
+    blanket (allow file-read*) rule (a standalone line, not a per-path subpath)."""
+    policy = SandboxPolicy(read_deny_paths=[])
+    profile = _build_sbpl_profile(policy)
+    # Exact-line check: distinguishes the broad rule from per-path
+    # `(allow file-read* (subpath ...))` rules that merely share the prefix.
+    assert "(allow file-read*)" in profile.splitlines()
+
+
+def test_sbpl_profile_read_deny_paths_after_broad_allow():
+    """Tier 2: read_deny_paths emit (deny file-read* (subpath ...)) AFTER the broad
+    (allow file-read*), so SBPL last-match-wins makes the deny win for those paths."""
     from pathlib import Path
 
-    raw = "/tmp/x"
-    resolved = str(Path(raw).resolve(strict=False))
-    policy = SandboxPolicy(read_paths=[raw])
+    deny_raw = "/tmp/secretz"
+    resolved = str(Path(deny_raw).expanduser().resolve(strict=False))
+    policy = SandboxPolicy(read_deny_paths=[deny_raw])
     profile = _build_sbpl_profile(policy)
-    assert "file-read*" in profile
-    assert resolved in profile
+    deny_rule = f'(deny file-read* (subpath "{resolved}"))'
+    assert "(allow file-read*)" in profile
+    assert deny_rule in profile
+    # Ordering matters under last-match-wins: the broad allow must come first.
+    assert profile.index("(allow file-read*)") < profile.index(deny_rule)
+
+
+def test_sbpl_profile_default_includes_sensitive_deny():
+    """Tier 2: the default policy carries the OS-level sensitive deny-list, so the
+    broad read surface excludes ~/.ssh etc by default (defense-in-depth)."""
+    from pathlib import Path
+
+    profile = _build_sbpl_profile(SandboxPolicy())
+    ssh_resolved = str(Path("~/.ssh").expanduser().resolve(strict=False))
+    assert f'(deny file-read* (subpath "{ssh_resolved}"))' in profile
 
 
 def test_sbpl_profile_write_paths_imply_read():


### PR DESCRIPTION
**[dogfood-coder]** — realignment Stage 3 **queue #3** (sandbox scoping). Design co-signed by lead-coder (asymmetric deny-list + residual-risk doc). Independent of part1/#1320 (e2e lane). canonical spec: #1199.

## What

Per-axis sandbox scoping realignment — the **strict read-allowlist is replaced by a broad-read default + an optional sensitive deny-list**. write / network / exec keep their tight allowlists (the primary guards).

| Axis | Policy | Role |
|---|---|---|
| write | tight `write_paths` | hard guard |
| network | off by default / allowlist | **exfiltration gate** |
| exec | `allow_subprocess` | child-spawn control |
| read | **broad-allow** + optional `read_deny_paths` | strict allowlist abolished |

**Why broad-read is safe + why it was needed:** the network gate (off by default) is the exfiltration control, so a broad read surface is safe — a process can read widely but cannot send data out. Broad-read also removes the system-path enumeration (`/usr`, `/lib`, dyld cache, …) every binary needs to load — the enumeration that was the **Landlock Linux gap** (no base-allow → binaries couldn't start). Matches industry (Codex broad-read + network-off on Linux; Claude Code read-restriction = secondary).

## Changes

- **SandboxPolicy** (`sandbox/policy.py`): add `read_deny_paths` (default = OS-level credential stores `~/.ssh` / `~/.aws` / `~/.gnupg` / …; P7-ok — universal, not skill-specific, same class as the system-bootstrap paths a backend always allowed). Document the broad-read model + that `read_paths` no longer restricts reads.
- **seatbelt (SBPL)**: drop the explicit system-path allowlist; emit broad `(allow file-read*)`; emit `read_deny_paths` as `(deny file-read* …)` **after** it (SBPL last-match-wins → deny wins for sensitive paths). write/network/exec unchanged.
- **landlock**: per-path read allowlist → a single read rule on `/` (broad-read → fixes the Linux gap).
- **permission-model.md**: sandbox scoping model + **residual-risk** section.
- **tests**: replace the read-allowlist test with broad-read + deny-list + default-sensitive tests (exact-line + ordering assertions).

## Backend asymmetry (residual risk — documented)

The deny-list is enforceable only where the backend can express deny-after-allow:
- **Seatbelt** — SBPL last-match-wins → deny-list enforced. ✅
- **Landlock** — allowlist-only (cannot carve a subpath out of an allowed parent) → deny-list **not enforceable**; broad read = read rule on `/`. On Linux a compromised in-sandbox process can *read* the deny-listed paths but stays bounded by the network gate (no exfiltration) + write/exec guards. The deny-list is defense-in-depth; the primary boundary (write-allowlist + network-off) holds identically on both backends.

## Test plan

- [x] `pytest -k "sandbox or seatbelt or landlock or sandboxed_exec or policy"` — 154 passed, 5 skipped (landlock Linux-only)
- [x] reproduce-first: the 3 new seatbelt tests FAIL on the pre-change profile (git-stash verified; exact-line assertion avoids the `(allow file-read*)` substring false-positive)
- [x] `scripts/test_tier_audit.py --strict tests/test_sandbox_seatbelt.py` — 12 OK, 0 errors
- [x] `py_compile` on the 3 changed src files (ruff runs in CI)
- [ ] (skipped — Linux-only) Landlock live broad-read/`/` echo + write-block: covered by the existing Linux-gated tests; not runnable on the macOS dev env

Next in queue (after part1+scoping land): mount-mode (#4), then S4.4 part2 (#5) — lead to assign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)