### PR TITLE
feat(environment): mount-mode container launcher slice-1 (#1324)

### DIFF
--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -85,16 +85,38 @@ def register(sub) -> None:
                    choices=["host", "docker"], default="host",
                    help=(
                        "Where the repo filesystem and commands execute: 'host' "
-                       "(default, no isolation change) or 'docker' (route FS + exec "
-                       "into a running container via --container/--repo-dir)."
+                       "(default, no isolation change) or 'docker'. For docker, "
+                       "either attach to a running container (--container/--repo-dir) "
+                       "or, if --container is omitted, reyn LAUNCHES a mount-mode "
+                       "container (workspace bind-mounted, security-hardened)."
                    ))
     p.add_argument("--container", dest="container", default=None, metavar="NAME",
-                   help="Running container name/id for --env-backend=docker.")
+                   help=(
+                       "Running container name/id to ATTACH to (--env-backend=docker). "
+                       "Omit to have reyn launch a new mount-mode container instead."
+                   ))
     p.add_argument("--repo-dir", dest="repo_dir", default=None, metavar="PATH",
                    help=(
                        "In-container absolute path of the repo working tree "
-                       "(e.g. /repo) for --env-backend=docker. Relative paths "
-                       "resolve against this; commands run with it as cwd."
+                       "(e.g. /repo) for --env-backend=docker ATTACH mode. Relative "
+                       "paths resolve against this; commands run with it as cwd."
+                   ))
+    p.add_argument("--image", dest="image", default=None, metavar="IMAGE",
+                   help=(
+                       "Container image for --env-backend=docker LAUNCH mode "
+                       "(when --container is omitted). Defaults to a sensible "
+                       "generic base; override per task."
+                   ))
+    p.add_argument("--mount", dest="mounts", action="append", default=None,
+                   metavar="host:container[:rw|ro]",
+                   help=(
+                       "Additional bind mount for docker LAUNCH mode (repeatable). "
+                       "The workspace root is always mounted at /workspace."
+                   ))
+    p.add_argument("--keep-container", dest="keep_container", action="store_true",
+                   help=(
+                       "Do not tear down a reyn-launched container after the run "
+                       "(persistent reuse). Default: launched containers are removed."
                    ))
     p.add_argument("--state-dir", dest="state_dir", default=None, metavar="PATH",
                    help=(
@@ -139,7 +161,7 @@ def run(args: argparse.Namespace) -> None:
     project_root = _find_project_root(Path.cwd())
     project_context = load_project_context(session.config, project_root)
     logger = make_logger()
-    env_backend, ws_base_dir, ws_state_dir = _build_environment_backend(args)
+    env_backend, ws_base_dir, ws_state_dir, env_cleanup = _build_environment_backend(args)
     # #997 dir2: the permission/runtime bundle (permission_resolver, mcp_servers,
     # python_allowed_modules, prompt_cache_enabled, sandbox_config, resolver) is
     # derived from config inside Agent.from_config — a caller cannot omit it (the
@@ -183,6 +205,18 @@ def run(args: argparse.Namespace) -> None:
     except Exception as e:
         print(f"\nError during execution: {e}", file=sys.stderr)
         sys.exit(1)
+    finally:
+        # Tear down a reyn-launched mount-mode container (no-op for host /
+        # attach / --keep-container). Best-effort: a teardown failure must not
+        # mask the run outcome.
+        if env_cleanup is not None:
+            try:
+                env_cleanup()
+            except Exception as cleanup_exc:  # noqa: BLE001
+                print(
+                    f"\nWarning: container teardown failed: {cleanup_exc}",
+                    file=sys.stderr,
+                )
 
     print()
     if not result.ok:
@@ -201,46 +235,79 @@ def run(args: argparse.Namespace) -> None:
         sys.exit(2)
 
 
-def _build_environment_backend(args: argparse.Namespace):
-    """Build the EnvironmentBackend + workspace dirs from --env-backend flags.
+def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
+    """Build the EnvironmentBackend + workspace dirs + optional cleanup.
 
-    Returns ``(backend, workspace_base_dir, workspace_state_dir)``:
+    Returns ``(backend, workspace_base_dir, workspace_state_dir, cleanup)``:
 
-    - host (default): ``(None, None, None)`` — the Agent uses its identity
-      HostBackend and default base_dir/state_dir (unchanged behavior).
-    - docker: a single ``DockerEnvironmentBackend`` instance (injected at BOTH
-      the FS and exec seams by the caller), with ``workspace_base_dir`` = the
-      in-container ``--repo-dir`` (so relative paths + command cwd resolve there)
-      and ``workspace_state_dir`` = the host-side ``--state-dir`` (OS state kept
-      off the routed repo FS).
+    - host (default): ``(None, None, None, None)`` — identity HostBackend.
+    - docker ATTACH (``--container`` given): a ``DockerEnvironmentBackend`` over
+      the existing container; base_dir = the in-container ``--repo-dir``; no
+      cleanup (the operator owns the container).
+    - docker LAUNCH (``--container`` omitted): reyn launches a mount-mode
+      container (workspace bind-mounted at ``/workspace``, security-hardened);
+      base_dir = ``/workspace``; ``cleanup`` tears it down after the run unless
+      ``--keep-container``.
 
-    Generic — no skill-specific knowledge (P7).
+    Generic — no skill-specific knowledge (P7). Image / mount / security are
+    agent-level operator config (#1326), independent of phase sandbox-policy.
     """
     backend_kind = getattr(args, "env_backend", "host")
     if backend_kind == "host":
-        return None, None, None
+        return None, None, None, None
 
     if backend_kind == "docker":
-        container = getattr(args, "container", None)
-        repo_dir = getattr(args, "repo_dir", None)
-        state_dir = getattr(args, "state_dir", None)
-        missing = [
-            name for name, val in (("--container", container), ("--repo-dir", repo_dir))
-            if not val
-        ]
-        if missing:
-            print(
-                f"Error: --env-backend=docker requires {', '.join(missing)}.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
         from reyn.environment import DockerEnvironmentBackend
-        backend = DockerEnvironmentBackend(container=container, repo_dir=repo_dir)
-        return (
-            backend,
-            Path(repo_dir),
-            Path(state_dir) if state_dir else None,
+        container = getattr(args, "container", None)
+        state_dir = getattr(args, "state_dir", None)
+        state_path = Path(state_dir) if state_dir else None
+
+        if container:
+            # ATTACH mode: existing operator-owned container (no teardown).
+            repo_dir = getattr(args, "repo_dir", None)
+            if not repo_dir:
+                print(
+                    "Error: --env-backend=docker with --container requires --repo-dir.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            backend = DockerEnvironmentBackend(container=container, repo_dir=repo_dir)
+            return backend, Path(repo_dir), state_path, None
+
+        # LAUNCH mode: reyn starts a mount-mode container (#1324).
+        from reyn.config import _find_project_root
+        from reyn.environment.container_launcher import (
+            DEFAULT_IMAGE,
+            WORKSPACE_DEST_DEFAULT,
+            ContainerLauncher,
+            LaunchConfig,
+            parse_mount_spec,
         )
+        workspace_root = str(_find_project_root(Path.cwd()))
+        try:
+            mounts = [parse_mount_spec(m) for m in (getattr(args, "mounts", None) or [])]
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        keep = bool(getattr(args, "keep_container", False))
+        config = LaunchConfig(
+            workspace_root=workspace_root,
+            image=getattr(args, "image", None) or DEFAULT_IMAGE,
+            mounts=mounts,
+            persistent=keep,
+        )
+        launcher = launcher or ContainerLauncher()
+        try:
+            container_id = launcher.launch(config)
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"launched container : {container_id} (image={config.image})")
+        backend = DockerEnvironmentBackend(
+            container=container_id, repo_dir=WORKSPACE_DEST_DEFAULT
+        )
+        cleanup = None if keep else (lambda: launcher.teardown(container_id))
+        return backend, Path(WORKSPACE_DEST_DEFAULT), state_path, cleanup
 
     # argparse `choices` prevents this, but stay defensive.
     print(f"Error: unknown --env-backend '{backend_kind}'.", file=sys.stderr)

--- a/src/reyn/environment/container_launcher.py
+++ b/src/reyn/environment/container_launcher.py
@@ -1,0 +1,232 @@
+"""ContainerLauncher — launch + lifecycle for a mount-mode Docker container (#1324).
+
+reyn core is otherwise **attach-only**: :class:`~reyn.environment.container_backend.DockerEnvironmentBackend`
+attaches (``docker exec``) to a user-provided ``--container``. This component
+adds the owner-decided **(a) launch path** (#1199 / #1324):
+
+    docker run -d <image> -v <workspace-root>:/workspace <security-flags> \
+        sleep infinity
+
+returning a container id the caller wires into
+``DockerEnvironmentBackend(container=<id>, repo_dir=/workspace)`` — the existing
+attach/exec model is reused unchanged.
+
+**Agent-level operator config, NOT phase-level sandbox-policy** (#1326): the
+container lifecycle (image / mount / network / security) is a once-per-run
+operator decision, supplied via CLI / operator config. It does NOT derive from
+a phase's ``default_sandbox_policy`` (the retired #3 remnant); the per-phase
+:class:`~reyn.sandbox.policy.SandboxPolicy` continues to govern ``sandboxed_exec``
+*inside* the container, a separate layer.
+
+**Security defaults** follow the owner decision (#1324), shared across the
+industry (OpenHands / Hermes / OpenClaw): ``--cap-drop ALL`` / non-root user /
+network off / read-only root filesystem except the writable mounts (+ a tmpfs
+``/tmp`` so the read-only rootfs can still host scratch).
+
+**P7-clean**: no skill / phase / artifact strings — bound only to launch config.
+The Docker invocation is built by the pure :func:`build_docker_run_argv` and run
+through an injectable runner, so launch / teardown are testable without a live
+Docker daemon.
+
+Note: the default image is a configurable reference (:data:`DEFAULT_IMAGE`)
+extended at runtime via ``setup_command``. Shipping a purpose-built reyn base
+image (Dockerfile + publish) is a follow-up tracked in #1324 — the launch
+mechanism here is independent of whether the default is published or bundled.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+from reyn.environment.container_backend import SyncRunner, _sync_runner
+from reyn.sandbox.backend import SandboxResult
+
+# Configurable default generic image (#1324 owner decision (A): a sensible
+# minimal default, extended at runtime via setup_command). Override per run via
+# --image / operator config. A purpose-built reyn base image is a #1324 follow-up.
+DEFAULT_IMAGE = "python:3.12-slim"
+
+# Fixed in-container mount destination for the workspace (override-able via
+# LaunchConfig.workspace_dest). The agent's repo_dir resolves here.
+WORKSPACE_DEST_DEFAULT = "/workspace"
+
+
+@dataclass
+class MountSpec:
+    """A single bind mount, OpenHands-compatible ``host:container:rw|ro``."""
+
+    host: str
+    container: str
+    mode: str = "rw"  # "rw" | "ro"
+
+    def to_arg(self) -> str:
+        """Return the ``-v`` value ``<host>:<container>:<mode>`` (host resolved)."""
+        host_abs = os.path.abspath(os.path.expanduser(self.host))
+        return f"{host_abs}:{self.container}:{self.mode}"
+
+
+def parse_mount_spec(raw: str) -> MountSpec:
+    """Parse ``host:container[:rw|ro]`` into a :class:`MountSpec`.
+
+    The mode is optional and defaults to ``rw``. Raises ``ValueError`` on a
+    malformed spec (missing host/container, or an unknown mode). Absolute
+    Windows-style paths are not supported (POSIX hosts only).
+    """
+    parts = raw.split(":")
+    if len(parts) == 2:
+        host, container = parts
+        mode = "rw"
+    elif len(parts) == 3:
+        host, container, mode = parts
+    else:
+        raise ValueError(
+            f"invalid mount spec {raw!r}: expected 'host:container' or "
+            f"'host:container:rw|ro'"
+        )
+    if not host or not container:
+        raise ValueError(f"invalid mount spec {raw!r}: host and container required")
+    if mode not in ("rw", "ro"):
+        raise ValueError(f"invalid mount mode {mode!r} in {raw!r}: expected 'rw' or 'ro'")
+    return MountSpec(host=host, container=container, mode=mode)
+
+
+@dataclass
+class LaunchConfig:
+    """Operator-level config for launching a mount-mode container.
+
+    workspace_root: host path mounted as the default workspace (= the .reyn
+        parent / project root; resolved by the caller, bounded discovery — the
+        global cwd-vs-project_root fix is #1316, out of scope here).
+    workspace_dest: in-container mount target for workspace_root.
+    image / setup_command: the default generic image + a runtime extension hook.
+    mounts: additional user bind mounts.
+    network: outbound network (default off — the exfiltration gate).
+    user: non-root ``uid[:gid]``; defaults to the host operator's ids so mounted
+        files keep correct ownership and the process is non-root.
+    read_only_rootfs: read-only root filesystem (writable mounts + tmpfs /tmp).
+    persistent / name: reuse a named container across runs (Hermes-style).
+    """
+
+    workspace_root: str
+    workspace_dest: str = WORKSPACE_DEST_DEFAULT
+    image: str = DEFAULT_IMAGE
+    setup_command: str | None = None
+    mounts: list[MountSpec] = field(default_factory=list)
+    network: bool = False
+    user: str | None = None
+    read_only_rootfs: bool = True
+    persistent: bool = False
+    name: str | None = None
+
+
+def _default_user() -> str | None:
+    """Return ``uid:gid`` for the host operator (non-root mount ownership).
+
+    Returns ``None`` on platforms without ``os.getuid`` (e.g. Windows), letting
+    the image's own ``USER`` apply.
+    """
+    getuid = getattr(os, "getuid", None)
+    getgid = getattr(os, "getgid", None)
+    if getuid is None or getgid is None:
+        return None
+    return f"{getuid()}:{getgid()}"
+
+
+def build_docker_run_argv(config: LaunchConfig, *, docker_bin: str = "docker") -> list[str]:
+    """Build the ``docker run`` argv for a mount-mode container (pure function).
+
+    Detached (``-d``) long-lived (``sleep infinity``) so the caller can then
+    ``docker exec`` into it via :class:`DockerEnvironmentBackend`. Security
+    defaults (#1324): drop all caps, non-root, network off unless requested,
+    read-only rootfs with a tmpfs ``/tmp`` and writable bind mounts.
+    """
+    argv: list[str] = [docker_bin, "run", "-d"]
+
+    if config.name:
+        argv += ["--name", config.name]
+
+    # Security baseline.
+    argv += ["--cap-drop", "ALL"]
+    user = config.user if config.user is not None else _default_user()
+    if user:
+        argv += ["--user", user]
+    if not config.network:
+        argv += ["--network", "none"]
+    if config.read_only_rootfs:
+        argv += ["--read-only", "--tmpfs", "/tmp"]
+
+    # Default workspace mount (always rw — the agent edits it).
+    workspace_host = os.path.abspath(os.path.expanduser(config.workspace_root))
+    argv += ["-v", f"{workspace_host}:{config.workspace_dest}:rw"]
+
+    # Additional user mounts.
+    for m in config.mounts:
+        argv += ["-v", m.to_arg()]
+
+    argv += [config.image, "sleep", "infinity"]
+    return argv
+
+
+class ContainerLauncher:
+    """Launch + tear down a mount-mode container (injectable runner for tests)."""
+
+    def __init__(self, *, docker_bin: str = "docker", runner: SyncRunner | None = None) -> None:
+        self.docker_bin = docker_bin
+        self._runner: SyncRunner = runner or _sync_runner
+
+    def launch(self, config: LaunchConfig, *, timeout: int = 120) -> str:
+        """Launch the container and return its id.
+
+        For a persistent config with a ``name`` that already exists, the existing
+        container is reused (Hermes-style) instead of launching a new one. Runs
+        ``setup_command`` (if any) inside the container after launch. Raises
+        ``RuntimeError`` if Docker reports a non-zero exit.
+        """
+        if config.persistent and config.name:
+            existing = self._existing_container(config.name, timeout=timeout)
+            if existing:
+                return existing
+
+        argv = build_docker_run_argv(config, docker_bin=self.docker_bin)
+        res = self._runner(argv, timeout=timeout)
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"container launch failed (rc={res.returncode}): "
+                f"{res.stderr.decode(errors='replace')[:400]}"
+            )
+        container_id = res.stdout.decode(errors="replace").strip()
+        if not container_id:
+            raise RuntimeError("container launch returned an empty container id")
+
+        if config.setup_command:
+            self._run_setup(container_id, config.setup_command, timeout=timeout)
+        return container_id
+
+    def teardown(self, container_id: str, *, timeout: int = 60) -> bool:
+        """Remove the container (``docker rm -f``). Returns True on success."""
+        res = self._runner(
+            [self.docker_bin, "rm", "-f", container_id], timeout=timeout
+        )
+        return res.returncode == 0
+
+    def _existing_container(self, name: str, *, timeout: int) -> str | None:
+        """Return the id of a running container with ``name``, or None."""
+        res = self._runner(
+            [self.docker_bin, "ps", "-q", "-f", f"name=^{name}$"], timeout=timeout
+        )
+        if res.returncode != 0:
+            return None
+        out = res.stdout.decode(errors="replace").strip()
+        return out or None
+
+    def _run_setup(self, container_id: str, setup_command: str, *, timeout: int) -> None:
+        """Run the runtime setup_command inside the container via a login shell."""
+        res = self._runner(
+            [self.docker_bin, "exec", container_id, "sh", "-lc", setup_command],
+            timeout=timeout,
+        )
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"container setup_command failed (rc={res.returncode}): "
+                f"{res.stderr.decode(errors='replace')[:400]}"
+            )

--- a/tests/test_container_launcher.py
+++ b/tests/test_container_launcher.py
@@ -1,0 +1,171 @@
+"""Tier 2: ContainerLauncher invariants — mount-mode launch + security (#1324).
+
+Pins the launcher contract: the `docker run` argv (security defaults +
+workspace mount), mount-spec parsing, and launch/teardown lifecycle. Uses a
+real injectable fake runner (no mocks) so the launch path is exercised without
+a live Docker daemon — mirroring container_backend's fs_runner/runner seam.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reyn.environment.container_launcher import (
+    DEFAULT_IMAGE,
+    WORKSPACE_DEST_DEFAULT,
+    ContainerLauncher,
+    LaunchConfig,
+    MountSpec,
+    build_docker_run_argv,
+    parse_mount_spec,
+)
+from reyn.sandbox.backend import SandboxResult
+
+
+class _FakeRunner:
+    """Records argv calls; returns scripted SandboxResults in order (no mocks)."""
+
+    def __init__(self, results: list[SandboxResult]) -> None:
+        self._results = list(results)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, *, stdin=None, timeout=None) -> SandboxResult:
+        self.calls.append(list(argv))
+        if self._results:
+            return self._results.pop(0)
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+
+def _ok(stdout: bytes = b"") -> SandboxResult:
+    return SandboxResult(returncode=0, stdout=stdout, stderr=b"")
+
+
+# ─── build_docker_run_argv (security-critical core) ────────────────────────────
+
+
+def test_build_argv_security_defaults():
+    """Tier 2: default config emits the #1324 security baseline + workspace mount."""
+    cfg = LaunchConfig(workspace_root="/tmp/ws")
+    argv = build_docker_run_argv(cfg)
+    joined = " ".join(argv)
+    assert argv[:3] == ["docker", "run", "-d"]
+    assert "--cap-drop ALL" in joined
+    assert "--network none" in joined  # network off by default = exfiltration gate
+    assert "--read-only" in joined
+    assert "--tmpfs /tmp" in joined
+    # workspace mounted rw at the fixed default dest.
+    assert f"{os.path.abspath('/tmp/ws')}:{WORKSPACE_DEST_DEFAULT}:rw" in argv
+    assert argv[-3:] == [DEFAULT_IMAGE, "sleep", "infinity"]
+
+
+def test_build_argv_network_on_omits_none():
+    """Tier 2: network=True does NOT add --network none (operator opted in)."""
+    argv = build_docker_run_argv(LaunchConfig(workspace_root="/tmp/ws", network=True))
+    assert "none" not in argv
+
+
+def test_build_argv_read_only_disabled():
+    """Tier 2: read_only_rootfs=False omits --read-only / --tmpfs."""
+    argv = build_docker_run_argv(
+        LaunchConfig(workspace_root="/tmp/ws", read_only_rootfs=False)
+    )
+    assert "--read-only" not in argv
+
+
+def test_build_argv_additional_mounts_and_name():
+    """Tier 2: additional mounts emit -v entries; name emits --name."""
+    cfg = LaunchConfig(
+        workspace_root="/tmp/ws",
+        name="reyn-dev",
+        mounts=[MountSpec(host="/data", container="/mnt/data", mode="ro")],
+    )
+    argv = build_docker_run_argv(cfg)
+    assert "--name" in argv and "reyn-dev" in argv
+    assert f"{os.path.abspath('/data')}:/mnt/data:ro" in argv
+
+
+def test_build_argv_explicit_user_overrides_default():
+    """Tier 2: an explicit non-root user is honored verbatim."""
+    argv = build_docker_run_argv(LaunchConfig(workspace_root="/tmp/ws", user="1234:5678"))
+    assert "--user" in argv
+    assert "1234:5678" in argv
+
+
+# ─── parse_mount_spec ──────────────────────────────────────────────────────────
+
+
+def test_parse_mount_spec_two_part_defaults_rw():
+    """Tier 2: a 2-part host:container spec defaults the mode to rw."""
+    spec = parse_mount_spec("/host/path:/container/path")
+    assert spec.host == "/host/path"
+    assert spec.container == "/container/path"
+    assert spec.mode == "rw"
+
+
+def test_parse_mount_spec_three_part_ro():
+    """Tier 2: a 3-part spec carries the explicit ro mode."""
+    spec = parse_mount_spec("/h:/c:ro")
+    assert spec.mode == "ro"
+
+
+@pytest.mark.parametrize("bad", ["/onlyone", "/h:/c:bogus", "/h:", ":/c", "/h:/c:rw:extra"])
+def test_parse_mount_spec_rejects_malformed(bad):
+    """Tier 2: malformed specs raise ValueError (bad arity or unknown mode)."""
+    with pytest.raises(ValueError):
+        parse_mount_spec(bad)
+
+
+# ─── ContainerLauncher lifecycle (injectable runner) ──────────────────────────
+
+
+def test_launch_returns_container_id():
+    """Tier 2: launch returns the trimmed container id from docker run stdout."""
+    runner = _FakeRunner([_ok(b"abc123\n")])
+    launcher = ContainerLauncher(runner=runner)
+    cid = launcher.launch(LaunchConfig(workspace_root="/tmp/ws"))
+    assert cid == "abc123"
+    assert runner.calls[0][:3] == ["docker", "run", "-d"]
+
+
+def test_launch_nonzero_raises():
+    """Tier 2: a non-zero docker run exit raises RuntimeError."""
+    runner = _FakeRunner([SandboxResult(returncode=1, stdout=b"", stderr=b"boom")])
+    with pytest.raises(RuntimeError, match="launch failed"):
+        ContainerLauncher(runner=runner).launch(LaunchConfig(workspace_root="/tmp/ws"))
+
+
+def test_launch_empty_id_raises():
+    """Tier 2: an empty container id raises rather than returning a bad handle."""
+    runner = _FakeRunner([_ok(b"   \n")])
+    with pytest.raises(RuntimeError, match="empty container id"):
+        ContainerLauncher(runner=runner).launch(LaunchConfig(workspace_root="/tmp/ws"))
+
+
+def test_launch_persistent_reuses_existing():
+    """Tier 2: persistent+name with an existing container reuses it (no docker run)."""
+    runner = _FakeRunner([_ok(b"existing99\n")])  # the `docker ps -q` lookup
+    launcher = ContainerLauncher(runner=runner)
+    cid = launcher.launch(
+        LaunchConfig(workspace_root="/tmp/ws", persistent=True, name="reyn-dev")
+    )
+    assert cid == "existing99"
+    # Only the ps lookup ran; no `docker run`.
+    assert all("run" not in c[:2] for c in runner.calls)
+    assert runner.calls[0][:3] == ["docker", "ps", "-q"]
+
+
+def test_launch_runs_setup_command():
+    """Tier 2: setup_command runs (docker exec) inside the container after launch."""
+    runner = _FakeRunner([_ok(b"cid\n"), _ok(b"")])  # run, then exec
+    launcher = ContainerLauncher(runner=runner)
+    launcher.launch(LaunchConfig(workspace_root="/tmp/ws", setup_command="pip install x"))
+    assert runner.calls[1][:3] == ["docker", "exec", "cid"]
+    assert "pip install x" in runner.calls[1]
+
+
+def test_teardown_removes_container():
+    """Tier 2: teardown issues docker rm -f and reports success."""
+    runner = _FakeRunner([_ok(b"")])
+    assert ContainerLauncher(runner=runner).teardown("cid") is True
+    assert runner.calls[0] == ["docker", "rm", "-f", "cid"]

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -1,17 +1,19 @@
-"""Tier 2: FP-0008 #1115 Stage 2 — `reyn run` container-backend flags.
+"""Tier 2: `reyn run` container-backend flags (FP-0008 #1115 Stage 2 + #1324 mount).
 
-`reyn run --env-backend=docker --container=<id> --repo-dir=/testbed
---state-dir=<host>` builds a single DockerEnvironmentBackend that run.py injects
-at BOTH the FS seam (Agent.environment_backend) and the exec seam
-(Agent.sandbox_backend) — agent-level uniform, 案C-pure. host (default) keeps the
-identity behavior. The flags are generic (no skill-specific knowledge, P7).
+`reyn run --env-backend=docker` either:
+  - ATTACHES to a running container (`--container` + `--repo-dir`) — the #1115
+    Stage 2 behavior; or
+  - LAUNCHES a mount-mode container (`--container` omitted) — the #1324 path:
+    reyn starts a security-hardened container with the workspace bind-mounted at
+    /workspace and returns a teardown cleanup (unless --keep-container).
 
-These pin the flag→backend construction + validation (the new logic). The
-threading of the injected instance through to Workspace / OpContext is already
-pinned by test_backend_injection_threading_1115_stage2.
+Both build a single DockerEnvironmentBackend that run.py injects at BOTH the FS
+seam and the exec seam (agent-level uniform). host (default) keeps identity
+behavior. Flags are generic (no skill-specific knowledge, P7).
 
 No mocks; real argparse.Namespace + real DockerEnvironmentBackend (no docker
-daemon touched — construction only). Docstrings open "Tier 2:".
+daemon touched — attach is construction-only; launch uses an injected fake
+launcher). Docstrings open "Tier 2:".
 """
 from __future__ import annotations
 
@@ -29,28 +31,56 @@ def _args(**kw) -> argparse.Namespace:
         "container": None,
         "repo_dir": None,
         "state_dir": None,
+        "image": None,
+        "mounts": None,
+        "keep_container": False,
     }
     base.update(kw)
     return argparse.Namespace(**base)
 
 
-def test_host_backend_returns_none_triple() -> None:
-    """Tier 2: --env-backend=host yields no backend + default dirs (unchanged behavior)."""
-    backend, base_dir, state_dir = _build_environment_backend(_args(env_backend="host"))
-    assert backend is None
-    assert base_dir is None
-    assert state_dir is None
+class _FakeLauncher:
+    """Records launch configs + teardown calls; never touches Docker (no mocks)."""
+
+    def __init__(self, cid: str = "fakecid") -> None:
+        self.cid = cid
+        self.launched: list = []
+        self.torn_down: list[str] = []
+
+    def launch(self, config, *, timeout: int = 120) -> str:
+        self.launched.append(config)
+        return self.cid
+
+    def teardown(self, container_id: str, *, timeout: int = 60) -> bool:
+        self.torn_down.append(container_id)
+        return True
+
+
+# ─── host (default) ────────────────────────────────────────────────────────────
+
+
+def test_host_backend_returns_none_quad() -> None:
+    """Tier 2: --env-backend=host yields no backend + default dirs + no cleanup."""
+    backend, base_dir, state_dir, cleanup = _build_environment_backend(
+        _args(env_backend="host")
+    )
+    assert (backend, base_dir, state_dir, cleanup) == (None, None, None, None)
 
 
 def test_default_is_host() -> None:
     """Tier 2: a Namespace without env_backend defaults to host (getattr fallback)."""
-    backend, base_dir, state_dir = _build_environment_backend(argparse.Namespace())
-    assert (backend, base_dir, state_dir) == (None, None, None)
+    backend, base_dir, state_dir, cleanup = _build_environment_backend(
+        argparse.Namespace()
+    )
+    assert (backend, base_dir, state_dir, cleanup) == (None, None, None, None)
 
 
-def test_docker_builds_single_backend_with_dirs() -> None:
-    """Tier 2: --env-backend=docker builds a DockerEnvironmentBackend + maps the dirs."""
-    backend, base_dir, state_dir = _build_environment_backend(
+# ─── docker ATTACH (--container given) ─────────────────────────────────────────
+
+
+def test_docker_attach_builds_backend_with_dirs() -> None:
+    """Tier 2: --container + --repo-dir attaches; maps dirs; no teardown (operator-owned)."""
+    backend, base_dir, state_dir, cleanup = _build_environment_backend(
         _args(
             env_backend="docker",
             container="reyn_inst_1",
@@ -61,30 +91,26 @@ def test_docker_builds_single_backend_with_dirs() -> None:
     assert backend is not None
     assert backend.container == "reyn_inst_1"
     assert backend.repo_dir == "/testbed"
-    # base_dir = in-container repo path; state_dir = host-side path.
     assert base_dir == Path("/testbed")
     assert state_dir == Path("/host/state")
+    assert cleanup is None
 
 
-def test_docker_backend_satisfies_both_protocols() -> None:
-    """Tier 2: the single docker instance satisfies BOTH the FS and exec Protocols.
-
-    This is what makes run.py's dual-seam injection (environment_backend +
-    sandbox_backend = the same instance) agent-level uniform (案C-pure).
-    """
+def test_docker_attach_satisfies_both_protocols() -> None:
+    """Tier 2: the single docker instance satisfies BOTH the FS and exec Protocols."""
     from reyn.environment import EnvironmentBackend
     from reyn.sandbox import SandboxBackend
 
-    backend, _b, _s = _build_environment_backend(
+    backend, _b, _s, _c = _build_environment_backend(
         _args(env_backend="docker", container="c", repo_dir="/testbed", state_dir="/h")
     )
     assert isinstance(backend, EnvironmentBackend), "must satisfy the FS seam Protocol"
     assert isinstance(backend, SandboxBackend), "must satisfy the exec seam Protocol"
 
 
-def test_docker_without_state_dir_keeps_base_dir_and_backend() -> None:
-    """Tier 2: --state-dir omitted → state_dir None (host default), backend + base_dir still set."""
-    backend, base_dir, state_dir = _build_environment_backend(
+def test_docker_attach_without_state_dir_keeps_base_dir() -> None:
+    """Tier 2: --state-dir omitted → state_dir None (host default), backend + base_dir set."""
+    backend, base_dir, state_dir, _c = _build_environment_backend(
         _args(env_backend="docker", container="c", repo_dir="/testbed")
     )
     assert backend is not None
@@ -92,13 +118,61 @@ def test_docker_without_state_dir_keeps_base_dir_and_backend() -> None:
     assert state_dir is None
 
 
-def test_docker_missing_container_exits() -> None:
-    """Tier 2: --env-backend=docker without --container is a clean exit."""
-    with pytest.raises(SystemExit):
-        _build_environment_backend(_args(env_backend="docker", repo_dir="/testbed"))
-
-
-def test_docker_missing_repo_dir_exits() -> None:
-    """Tier 2: --env-backend=docker without --repo-dir is a clean exit."""
+def test_docker_attach_missing_repo_dir_exits() -> None:
+    """Tier 2: --container without --repo-dir is a clean exit."""
     with pytest.raises(SystemExit):
         _build_environment_backend(_args(env_backend="docker", container="c"))
+
+
+# ─── docker LAUNCH (--container omitted, #1324) ────────────────────────────────
+
+
+def test_docker_launch_builds_backend_and_cleanup() -> None:
+    """Tier 2: omitting --container launches a mount-mode container at /workspace
+    and wires a teardown cleanup (non-persistent default)."""
+    fake = _FakeLauncher()
+    backend, base_dir, state_dir, cleanup = _build_environment_backend(
+        _args(env_backend="docker"), launcher=fake
+    )
+    assert backend is not None
+    assert backend.container == "fakecid"
+    assert backend.repo_dir == "/workspace"
+    assert base_dir == Path("/workspace")
+    (_launched_cfg,) = fake.launched  # exactly one launch
+    assert callable(cleanup)
+    cleanup()
+    assert fake.torn_down == ["fakecid"]
+
+
+def test_docker_launch_uses_image_and_mounts() -> None:
+    """Tier 2: --image + --mount thread into the LaunchConfig."""
+    fake = _FakeLauncher()
+    _build_environment_backend(
+        _args(env_backend="docker", image="myimg:1", mounts=["/d:/m:ro"]),
+        launcher=fake,
+    )
+    (cfg,) = fake.launched
+    assert cfg.image == "myimg:1"
+    (mount,) = cfg.mounts
+    assert (mount.host, mount.container, mount.mode) == ("/d", "/m", "ro")
+
+
+def test_docker_launch_keep_container_skips_teardown() -> None:
+    """Tier 2: --keep-container → persistent config + no teardown cleanup."""
+    fake = _FakeLauncher()
+    _b, _bd, _sd, cleanup = _build_environment_backend(
+        _args(env_backend="docker", keep_container=True), launcher=fake
+    )
+    assert cleanup is None
+    (cfg,) = fake.launched
+    assert cfg.persistent is True
+
+
+def test_docker_launch_bad_mount_exits() -> None:
+    """Tier 2: a malformed --mount spec is a clean exit (before any launch)."""
+    fake = _FakeLauncher()
+    with pytest.raises(SystemExit):
+        _build_environment_backend(
+            _args(env_backend="docker", mounts=["bogus"]), launcher=fake
+        )
+    assert fake.launched == []  # rejected before launching


### PR DESCRIPTION
**[dogfood-coder]** — mount-mode (#4) **slice-1**. Owner DECISION (a) reyn launches the container; design + scope co-signed by lead-coder. Flow-trace + turnkey spec on #1324. canonical spec: #1199.

## What

reyn core was **attach-only** (`DockerEnvironmentBackend` attaches to a user-provided `--container`). This adds the **(a) launch path**: reyn launches a security-hardened, workspace-mounted container and reuses the existing exec/FS attach model.

## Changes

- **`environment/container_launcher.py`** (new):
  - `MountSpec` + `parse_mount_spec` (OpenHands-compat `host:container[:rw|ro]`).
  - `LaunchConfig` (workspace_root / image / mounts / network / user / read-only / persistent).
  - `build_docker_run_argv` (**pure**, the security-critical core): `docker run -d <image> -v <workspace-root>:/workspace` + **security baseline** `--cap-drop ALL` / non-root `--user` / `--network none` (unless network) / `--read-only` + `--tmpfs /tmp`; `sleep infinity`.
  - `ContainerLauncher.launch/teardown` with persistent-reuse (Hermes) + `setup_command`, **injectable runner**.
- **`cli/commands/run.py`**: `--env-backend=docker` now **LAUNCHES** when `--container` is omitted (ATTACH unchanged when given). New `--image` / `--mount` / `--keep-container`. `_build_environment_backend` returns a 4th `cleanup` callable; `run()` tears the launched container down in a `finally` (best-effort — never masks the run outcome). Workspace root = bounded `_find_project_root` discovery.

## Design corrections honored

- **Agent-level operator config (#1326)**: container lifecycle = once-per-run operator decision (CLI/operator config), **independent of phase sandbox-policy** (#3 remnant). The per-phase `SandboxPolicy` still governs `sandboxed_exec` inside the container (separate layer).
- **eval lane untouched**: `swe_bench_runner` (baked-repo /testbed) is separate.
- **#1316 out of scope**: bounded `_find_project_root` discovery for the workspace root; the global cwd-vs-project_root fix stays its own slice.

## Scope (co-signed)

slice-1 = launcher **mechanism** (launch + mount + security + lifecycle) + configurable default image constant (`python:3.12-slim`) + `--image`/`--mount` + `setup_command`. A purpose-built **bundled reyn base image** (Dockerfile + publish) is a **follow-up tracked in #1324** — the mechanism is independent of image provenance.

## Test plan (no live Docker)

- [x] `pytest tests/test_container_launcher.py` — 18 passed (injectable runner: argv security baseline + mount + parse + launch/teardown/persistent/setup)
- [x] `pytest tests/test_run_container_backend_flags_1115.py` — 12 passed (fake launcher: attach + launch wiring, 4-tuple + teardown, image/mount threading, bad-mount exit)
- [x] broad sweep `-k "environment or container or run_container or backend_injection or sandboxed_exec"` — 69 passed, 2 skipped (landlock Linux-only); eval lane intact
- [x] `scripts/test_tier_audit.py --strict` — 24 OK, 0 errors
- [x] `py_compile` (ruff runs in CI)
- [ ] (deferred — needs live Docker) end-to-end launch+mount against a real daemon: out of unit scope; the pure `build_docker_run_argv` pins the exact argv a daemon would receive

## Follow-ups (tracked in #1324)

bundled reyn base image (Dockerfile/publish); devcontainer.json awareness; eval-lane unify with the launcher. #1316 = separate slice. slice-2 path-resolution (workspace-mount vs baked-repo) = part2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)