### PR TITLE
feat(environment): bundled reyn base image, build-on-demand (#1324 follow-up a)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ where = ["src"]
 include = ["reyn*"]
 
 [tool.setuptools.package-data]
-"reyn" = ["py.typed", "stdlib/**/*", "chainlit_app/assets/**/*"]
+"reyn" = ["py.typed", "stdlib/**/*", "chainlit_app/assets/**/*", "environment/*.Dockerfile"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/reyn/environment/container_launcher.py
+++ b/src/reyn/environment/container_launcher.py
@@ -37,14 +37,25 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from reyn.environment.container_backend import SyncRunner, _sync_runner
 from reyn.sandbox.backend import SandboxResult
 
-# Configurable default generic image (#1324 owner decision (A): a sensible
-# minimal default, extended at runtime via setup_command). Override per run via
-# --image / operator config. A purpose-built reyn base image is a #1324 follow-up.
-DEFAULT_IMAGE = "python:3.12-slim"
+# The bundled reyn base image (#1324): a minimal generic agent runtime built ON
+# DEMAND from reyn_base.Dockerfile (local-build, no registry). The tag is local
+# (not registry-qualified); a registry-published variant is a #1324 follow-up.
+REYN_BASE_IMAGE = "reyn-base:local"
+
+# Default image for a launched container = the bundled reyn base, extended at
+# runtime via setup_command (#1324 owner decision (A)). Override per run via
+# --image / operator config.
+DEFAULT_IMAGE = REYN_BASE_IMAGE
+
+
+def _reyn_base_dockerfile() -> Path:
+    """Path to the bundled reyn base Dockerfile (shipped as package data)."""
+    return Path(__file__).parent / "reyn_base.Dockerfile"
 
 # Fixed in-container mount destination for the workspace (override-able via
 # LaunchConfig.workspace_dest). The agent's repo_dir resolves here.
@@ -187,6 +198,7 @@ class ContainerLauncher:
             if existing:
                 return existing
 
+        self.ensure_image(config.image)
         argv = build_docker_run_argv(config, docker_bin=self.docker_bin)
         res = self._runner(argv, timeout=timeout)
         if res.returncode != 0:
@@ -208,6 +220,35 @@ class ContainerLauncher:
             [self.docker_bin, "rm", "-f", container_id], timeout=timeout
         )
         return res.returncode == 0
+
+    def ensure_image(self, image: str, *, timeout: int = 600) -> None:
+        """Build the bundled reyn base image on demand if it is missing.
+
+        Only the bundled local tag (:data:`REYN_BASE_IMAGE`) is built here — any
+        other ``image`` is left to ``docker run`` to pull. A present image is a
+        no-op (``docker image inspect`` succeeds). Raises ``RuntimeError`` if the
+        build fails. The build timeout is generous (apt layers).
+        """
+        if image != REYN_BASE_IMAGE:
+            return
+        inspect = self._runner(
+            [self.docker_bin, "image", "inspect", image], timeout=timeout
+        )
+        if inspect.returncode == 0:
+            return  # already built
+        dockerfile = _reyn_base_dockerfile()
+        res = self._runner(
+            [
+                self.docker_bin, "build", "-t", image,
+                "-f", str(dockerfile), str(dockerfile.parent),
+            ],
+            timeout=timeout,
+        )
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"reyn base image build failed (rc={res.returncode}): "
+                f"{res.stderr.decode(errors='replace')[:400]}"
+            )
 
     def _existing_container(self, name: str, *, timeout: int) -> str | None:
         """Return the id of a running container with ``name``, or None."""

--- a/src/reyn/environment/reyn_base.Dockerfile
+++ b/src/reyn/environment/reyn_base.Dockerfile
@@ -1,0 +1,26 @@
+# reyn base image (#1324) — minimal generic agent runtime.
+#
+# Philosophy (OpenClaw / Hermes-aligned): keep the base SMALL; a task extends it
+# at runtime via the launcher's setup_command. Heavier, non-universal toolchains
+# (e.g. build-essential for C-extension builds, ~200MB+) are intentionally NOT
+# baked — use `--image` with a custom image, or add them via setup_command,
+# when a task actually needs them.
+#
+# Built on demand by reyn.environment.container_launcher (local-build-on-demand,
+# no registry). A registry-published variant is a tracked #1324 follow-up.
+FROM python:3.12-slim
+
+# Near-universal agent tooling: git (repo ops), curl + ca-certificates
+# (network fetches / TLS verification). apt lists removed to keep the layer small.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root default user. The launcher also passes `--user <host uid:gid>` at run
+# time (which overrides this); this USER is the safe fallback when it does not.
+RUN useradd --create-home --shell /bin/bash reyn
+USER reyn
+WORKDIR /workspace

--- a/tests/test_container_launcher.py
+++ b/tests/test_container_launcher.py
@@ -13,6 +13,7 @@ import pytest
 
 from reyn.environment.container_launcher import (
     DEFAULT_IMAGE,
+    REYN_BASE_IMAGE,
     WORKSPACE_DEST_DEFAULT,
     ContainerLauncher,
     LaunchConfig,
@@ -123,7 +124,8 @@ def test_launch_returns_container_id():
     """Tier 2: launch returns the trimmed container id from docker run stdout."""
     runner = _FakeRunner([_ok(b"abc123\n")])
     launcher = ContainerLauncher(runner=runner)
-    cid = launcher.launch(LaunchConfig(workspace_root="/tmp/ws"))
+    # Non-base image → ensure_image is a no-op, so the first call is docker run.
+    cid = launcher.launch(LaunchConfig(workspace_root="/tmp/ws", image="img:test"))
     assert cid == "abc123"
     assert runner.calls[0][:3] == ["docker", "run", "-d"]
 
@@ -132,14 +134,18 @@ def test_launch_nonzero_raises():
     """Tier 2: a non-zero docker run exit raises RuntimeError."""
     runner = _FakeRunner([SandboxResult(returncode=1, stdout=b"", stderr=b"boom")])
     with pytest.raises(RuntimeError, match="launch failed"):
-        ContainerLauncher(runner=runner).launch(LaunchConfig(workspace_root="/tmp/ws"))
+        ContainerLauncher(runner=runner).launch(
+            LaunchConfig(workspace_root="/tmp/ws", image="img:test")
+        )
 
 
 def test_launch_empty_id_raises():
     """Tier 2: an empty container id raises rather than returning a bad handle."""
     runner = _FakeRunner([_ok(b"   \n")])
     with pytest.raises(RuntimeError, match="empty container id"):
-        ContainerLauncher(runner=runner).launch(LaunchConfig(workspace_root="/tmp/ws"))
+        ContainerLauncher(runner=runner).launch(
+            LaunchConfig(workspace_root="/tmp/ws", image="img:test")
+        )
 
 
 def test_launch_persistent_reuses_existing():
@@ -159,7 +165,11 @@ def test_launch_runs_setup_command():
     """Tier 2: setup_command runs (docker exec) inside the container after launch."""
     runner = _FakeRunner([_ok(b"cid\n"), _ok(b"")])  # run, then exec
     launcher = ContainerLauncher(runner=runner)
-    launcher.launch(LaunchConfig(workspace_root="/tmp/ws", setup_command="pip install x"))
+    launcher.launch(
+        LaunchConfig(
+            workspace_root="/tmp/ws", image="img:test", setup_command="pip install x"
+        )
+    )
     assert runner.calls[1][:3] == ["docker", "exec", "cid"]
     assert "pip install x" in runner.calls[1]
 
@@ -169,3 +179,59 @@ def test_teardown_removes_container():
     runner = _FakeRunner([_ok(b"")])
     assert ContainerLauncher(runner=runner).teardown("cid") is True
     assert runner.calls[0] == ["docker", "rm", "-f", "cid"]
+
+
+# ─── ensure_image (bundled reyn base, build-on-demand) ─────────────────────────
+
+
+def test_ensure_image_builds_base_when_absent():
+    """Tier 2: a missing reyn base image is built from the bundled Dockerfile."""
+    runner = _FakeRunner([
+        SandboxResult(returncode=1, stdout=b"", stderr=b"No such image"),  # inspect
+        _ok(b""),  # build
+    ])
+    ContainerLauncher(runner=runner).ensure_image(REYN_BASE_IMAGE)
+    assert runner.calls[0][:3] == ["docker", "image", "inspect"]
+    build = runner.calls[1]
+    assert build[:4] == ["docker", "build", "-t", REYN_BASE_IMAGE]
+    assert "-f" in build and build[-1].endswith("environment")  # context = dockerfile dir
+
+
+def test_ensure_image_skips_build_when_present():
+    """Tier 2: a present reyn base image is a no-op (inspect succeeds, no build)."""
+    runner = _FakeRunner([_ok(b"sha256:...")])  # inspect succeeds
+    ContainerLauncher(runner=runner).ensure_image(REYN_BASE_IMAGE)
+    assert all("build" not in c[:2] for c in runner.calls)
+    (only_call,) = runner.calls
+    assert only_call[:3] == ["docker", "image", "inspect"]
+
+
+def test_ensure_image_noop_for_non_base_image():
+    """Tier 2: a non-base image is left to docker run to pull — ensure does nothing."""
+    runner = _FakeRunner([])
+    ContainerLauncher(runner=runner).ensure_image("python:3.12-slim")
+    assert runner.calls == []
+
+
+def test_ensure_image_build_failure_raises():
+    """Tier 2: a failed base-image build raises RuntimeError."""
+    runner = _FakeRunner([
+        SandboxResult(returncode=1, stdout=b"", stderr=b"absent"),  # inspect
+        SandboxResult(returncode=1, stdout=b"", stderr=b"build broke"),  # build
+    ])
+    with pytest.raises(RuntimeError, match="base image build failed"):
+        ContainerLauncher(runner=runner).ensure_image(REYN_BASE_IMAGE)
+
+
+def test_launch_builds_base_image_then_runs():
+    """Tier 2: launching with the default (base) image builds it on demand first."""
+    runner = _FakeRunner([
+        SandboxResult(returncode=1, stdout=b"", stderr=b"absent"),  # inspect
+        _ok(b""),  # build
+        _ok(b"cid42\n"),  # run
+    ])
+    cid = ContainerLauncher(runner=runner).launch(LaunchConfig(workspace_root="/tmp/ws"))
+    assert cid == "cid42"
+    assert runner.calls[0][:3] == ["docker", "image", "inspect"]
+    assert runner.calls[1][:2] == ["docker", "build"]
+    assert runner.calls[2][:3] == ["docker", "run", "-d"]


### PR DESCRIPTION
**[dogfood-coder]** — #1324 follow-up **(a) bundled reyn base image**. Lead co-signed (a1=X) local-build-on-demand. Follows merged #1328 (mount launcher slice-1).

## What

The mount launcher’s default image was a public constant (`python:3.12-slim`). Per the owner decision (#1324 **(A)**: reyn ships a default generic image), this bundles a **minimal reyn base image built on demand locally** — faithful to "同梱" (in-repo bundle), with **zero registry / infra commitment**.

(a2) registry-publish (`ghcr` + CI) is a distinct **owner infra decision** and a tracked #1324 follow-up — lead surfaces it to owner as a non-blocking future option; it does not block this slice.

## Changes

- **`environment/reyn_base.Dockerfile`** (new, shipped as package-data): `FROM python:3.12-slim` + `git` + `curl` + `ca-certificates` + a non-root user. **Minimal by design** (OpenClaw/Hermes model) — heavier, non-universal toolchains (`build-essential`, ~200MB+) are intentionally **not** baked; a task adds them via `setup_command` or a custom `--image`. (Lead’s lean note on build-essential → defer to setup_command; minimal base.)
- **`container_launcher.py`**: `DEFAULT_IMAGE` → `REYN_BASE_IMAGE` (`"reyn-base:local"`); `ContainerLauncher.ensure_image()` builds the bundled image on demand (`docker image inspect` → `docker build -f reyn_base.Dockerfile`) **only for the local base tag** (other images are left to `docker run` to pull); `launch()` ensures the image before run.
- **`pyproject.toml`**: ship `environment/*.Dockerfile` as package-data.

## Test plan (no live Docker — injectable runner)

- [x] `pytest tests/test_container_launcher.py tests/test_run_container_backend_flags_1115.py` — 33 passed
- [x] new ensure_image tests: builds-when-absent / skips-when-present / noop-for-non-base / build-failure-raises / launch-builds-base-then-runs
- [x] existing launch-lifecycle tests pin a non-base `--image` so `ensure_image` is a no-op there (isolation)
- [x] broad sweep `-k "environment or container or launcher or sandboxed_exec or backend_injection"` — 105 passed, 2 skipped (landlock Linux-only)
- [x] `scripts/test_tier_audit.py --strict` — 0 errors; Dockerfile path resolves + ships as package-data
- [ ] (deferred — needs live Docker) actual `docker build` of the base image + a launched run: out of unit scope; ensure_image argv is pinned

## Follow-ups (tracked in #1324)

(a2) registry-published base image (`ghcr` + publish CI) — owner infra decision; (b) devcontainer.json awareness; (c) eval-unify; (d) slice-2 path-resolution (part2). #1316 = separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)