### PR TITLE
fix(environment): mount-aware state_dir resolution — part2 path-resolution (#1324)

### DIFF
--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -294,7 +294,12 @@ def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
             LaunchConfig,
             parse_mount_spec,
         )
-        workspace_root = str(_find_project_root(Path.cwd()))
+        # _find_project_root returns None when no reyn.yaml is found up the tree;
+        # fall back to cwd so the mount source + state_dir are a real host path
+        # (NOT the bogus "None/.reyn" that str(None) would produce). The global
+        # cwd-vs-project_root resolution refinement is #1316 (separate slice).
+        project_root = _find_project_root(Path.cwd())
+        workspace_root = str(project_root if project_root is not None else Path.cwd())
         try:
             mounts = [parse_mount_spec(m) for m in (getattr(args, "mounts", None) or [])]
         except ValueError as exc:

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -271,6 +271,17 @@ def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+            if state_path is None:
+                # baked-repo model: no bind mount, so OS state cannot be made
+                # coherent with the in-container repo FS. Warn that state will
+                # land on the repo FS (lost on container death) unless host-side.
+                print(
+                    "Warning: --env-backend=docker --container without --state-dir: "
+                    "OS state (events/artifacts) will live on the in-container repo "
+                    "FS and is lost on container death. Pass --state-dir for a "
+                    "host-side state directory.",
+                    file=sys.stderr,
+                )
             backend = DockerEnvironmentBackend(container=container, repo_dir=repo_dir)
             return backend, Path(repo_dir), state_path, None
 
@@ -307,7 +318,13 @@ def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
             container=container_id, repo_dir=WORKSPACE_DEST_DEFAULT
         )
         cleanup = None if keep else (lambda: launcher.teardown(container_id))
-        return backend, Path(WORKSPACE_DEST_DEFAULT), state_path, cleanup
+        # part2 (slice-2): in the workspace-mount model the host workspace_root is
+        # bind-mounted at /workspace, so the OS state dir defaults to the HOST
+        # workspace_root/.reyn — that same dir appears in-container at
+        # /workspace/.reyn, keeping OS index/approvals and the agent FS coherent
+        # (the bind-mount's purpose). An explicit --state-dir still wins.
+        launch_state_path = state_path or (Path(workspace_root) / ".reyn")
+        return backend, Path(WORKSPACE_DEST_DEFAULT), launch_state_path, cleanup
 
     # argparse `choices` prevents this, but stay defensive.
     print(f"Error: unknown --env-backend '{backend_kind}'.", file=sys.stderr)

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -146,16 +146,35 @@ def test_docker_launch_builds_backend_and_cleanup() -> None:
     assert fake.torn_down == ["fakecid"]
 
 
-def test_docker_launch_defaults_state_dir_to_workspace_root_reyn() -> None:
+def test_docker_launch_defaults_state_dir_to_workspace_root_reyn(tmp_path, monkeypatch) -> None:
     """Tier 2: part2 — launch without --state-dir defaults state_dir to the HOST
-    workspace_root/.reyn (the bind-mounted dir → coherent with /workspace/.reyn)."""
-    from reyn.config import _find_project_root
+    workspace_root/.reyn (the bind-mounted dir → coherent with /workspace/.reyn).
 
+    Deterministic: chdir into a tmp project root carrying a reyn.yaml so
+    _find_project_root resolves to tmp_path (not the ambient cwd)."""
+    (tmp_path / "reyn.yaml").write_text("")
+    monkeypatch.chdir(tmp_path)
     fake = _FakeLauncher()
     _b, _bd, state_dir, _c = _build_environment_backend(
         _args(env_backend="docker"), launcher=fake
     )
-    assert state_dir == _find_project_root(Path.cwd()) / ".reyn"
+    assert state_dir == tmp_path.resolve() / ".reyn"
+
+
+def test_docker_launch_state_dir_falls_back_to_cwd_without_reyn_yaml(
+    tmp_path, monkeypatch
+) -> None:
+    """Tier 2: part2/bug1 — with no reyn.yaml up the tree _find_project_root
+    returns None; state_dir must fall back to cwd/.reyn (a real host path), NOT
+    the bogus 'None/.reyn' that str(None) produced. Reproduce-first for the
+    #1328-origin latent bug part2 exposed."""
+    monkeypatch.chdir(tmp_path)  # tmp_path has no reyn.yaml here or above
+    fake = _FakeLauncher()
+    _b, _bd, state_dir, _c = _build_environment_backend(
+        _args(env_backend="docker"), launcher=fake
+    )
+    assert state_dir == tmp_path.resolve() / ".reyn"
+    assert "None" not in str(state_dir)
 
 
 def test_docker_launch_explicit_state_dir_wins() -> None:

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -108,14 +108,16 @@ def test_docker_attach_satisfies_both_protocols() -> None:
     assert isinstance(backend, SandboxBackend), "must satisfy the exec seam Protocol"
 
 
-def test_docker_attach_without_state_dir_keeps_base_dir() -> None:
-    """Tier 2: --state-dir omitted → state_dir None (host default), backend + base_dir set."""
+def test_docker_attach_without_state_dir_keeps_base_dir(capsys) -> None:
+    """Tier 2: --state-dir omitted (attach/baked-repo) → state_dir None + a warning
+    that OS state lands on the in-container repo FS."""
     backend, base_dir, state_dir, _c = _build_environment_backend(
         _args(env_backend="docker", container="c", repo_dir="/testbed")
     )
     assert backend is not None
     assert base_dir == Path("/testbed")
     assert state_dir is None
+    assert "without --state-dir" in capsys.readouterr().err
 
 
 def test_docker_attach_missing_repo_dir_exits() -> None:
@@ -142,6 +144,27 @@ def test_docker_launch_builds_backend_and_cleanup() -> None:
     assert callable(cleanup)
     cleanup()
     assert fake.torn_down == ["fakecid"]
+
+
+def test_docker_launch_defaults_state_dir_to_workspace_root_reyn() -> None:
+    """Tier 2: part2 — launch without --state-dir defaults state_dir to the HOST
+    workspace_root/.reyn (the bind-mounted dir → coherent with /workspace/.reyn)."""
+    from reyn.config import _find_project_root
+
+    fake = _FakeLauncher()
+    _b, _bd, state_dir, _c = _build_environment_backend(
+        _args(env_backend="docker"), launcher=fake
+    )
+    assert state_dir == _find_project_root(Path.cwd()) / ".reyn"
+
+
+def test_docker_launch_explicit_state_dir_wins() -> None:
+    """Tier 2: part2 — an explicit --state-dir overrides the mount-coherent default."""
+    fake = _FakeLauncher()
+    _b, _bd, state_dir, _c = _build_environment_backend(
+        _args(env_backend="docker", state_dir="/host/s"), launcher=fake
+    )
+    assert state_dir == Path("/host/s")
 
 
 def test_docker_launch_uses_image_and_mounts() -> None:


### PR DESCRIPTION
**[dogfood-coder]** — #1324 **part2 (slice-2) path-resolution**, the two-container-model divergence. Consistency model co-signed by lead-coder. Follows merged #1328 (launcher) + #1329 (base image). #1321 DISSOLVE-CLOSED → unblocked.

## Bug fixed (real, from merged #1328)

The launch path defaulted `state_dir` to `None` → Workspace fell back to `base_dir/.reyn` = `/workspace/.reyn` (a **container** path) used **host-side**. So a mount-mode launch without `--state-dir` tried to `mkdir /workspace/.reyn` on the host (no such dir). Confirmed end-to-end: `run.py` launch → `Agent.workspace_state_dir=None` → `runtime.py:110 Workspace(state_dir=None)` → `base_dir/.reyn` (`workspace.py`).

## part2 — mount-model-aware state_dir

| Model | state_dir |
|---|---|
| **workspace-mount** (launch) | defaults to **host `workspace_root/.reyn`**. `workspace_root` is bind-mounted at `/workspace`, so that same dir appears in-container at `/workspace/.reyn` → OS index/approvals and the agent FS are **physically coherent** (the bind-mount’s purpose). Explicit `--state-dir` wins. |
| **baked-repo** (attach) | no bind mount → coherence impossible; host-side-separate. reyn now **warns** when `--state-dir` is omitted (state would land on the in-container repo FS, lost on container death). |

Bounded to `run.py`’s docker branch — the `base_dir`/`state_dir` split (#1115 Stage 0) already carries the rest of the 2-model distinction. **#1316** (global workspace-root resolution) stays out of scope: bounded `_find_project_root`. **#1326** (agent-level sandbox-policy, e2e) is orthogonal (path-mapping, not policy-leveling).

## Test plan

- [x] `pytest tests/test_run_container_backend_flags_1115.py` — 12 passed (launch defaults state_dir to `workspace_root/.reyn`; explicit `--state-dir` wins; attach warns when omitted)
- [x] reproduce-first: the launch-defaults + attach-warn tests FAIL on the pre-fix path (git-stash verified)
- [x] broad sweep `-k "environment or container or launcher or backend_injection or sandboxed_exec"` — 107 passed, 2 skipped (landlock Linux-only)
- [x] `scripts/test_tier_audit.py --strict` — 12 OK, 0 errors

## #1324 status after this

slice-1 launcher (#1328 ✓), base image (#1329 ✓), **part2 path-resolution (this)**. Remaining follow-ups: (a2) registry-published base image (owner infra — lead surfaces), (b) devcontainer.json awareness, (c) eval-unify. #1316 = separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)