### PR TITLE
docs(testing): fix Tier docstring format in example code

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -324,7 +324,7 @@ Tier 3a の各エリアには、フィクスチャがカバーしていないフ
 ```python
 @pytest.mark.replay("fixtures/llm/my_area/my_scenario.jsonl")
 def test_wrong_input_raises_missing_fixture():
-    """Tier 3a drift detection: instructions / candidate_outputs の変更は
+    """Tier 3a: drift detection — instructions / candidate_outputs の変更は
     フィクスチャの再記録が必要。さもなければテストが大きな音で失敗する。"""
     frame = ContextFrame(
         current_phase="classify",

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -398,7 +398,7 @@ Each Tier 3a area has one test that intentionally constructs a frame the fixture
 ```python
 @pytest.mark.replay("fixtures/llm/my_area/my_scenario.jsonl")
 def test_wrong_input_raises_missing_fixture():
-    """Tier 3a drift detection: changes to instructions / candidate_outputs
+    """Tier 3a: drift detection — changes to instructions / candidate_outputs
     must be reflected in re-recorded fixtures, otherwise the test fails loudly."""
     frame = ContextFrame(
         current_phase="classify",


### PR DESCRIPTION
**[docs-maintainer]** — `feedback_tier_docstring_colon_immediately` によるドキュメント drift 修正。

## Summary

`testing.md` + `testing.ja.md` のサンプルコードの docstring 形式が tier-audit rule 違反だったため修正。

- **Before**: `"""Tier 3a drift detection: ...` （colon が N 直後にない）
- **After**: `"""Tier 3a: drift detection — ...` （`test_tier_audit.py --strict` 準拠）

**変更ページ:** removed 0 / added 0（既存ページ内サンプルコード修正のみ）

## Test plan

- [ ] 変更箇所が `Tier N:` 形式（colon 直後）になっていること
- [ ] 他の docstring 例 (`"""Tier 3a: skill_router...`) は正形式のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)