### PR TITLE
docs(1326): restore ADR-0037 to its immutable point-in-time form

### DIFF
--- a/docs/deep-dives/decisions/0037-sandbox-permission-separation.md
+++ b/docs/deep-dives/decisions/0037-sandbox-permission-separation.md
@@ -57,9 +57,9 @@ declaration.**
 - `reyn.yaml sandbox:` is the canonical location for sandbox backend and
   scoping configuration.
 - CLI flags (`--sandbox`, `--image`, `--mount`) are the runtime override.
-- `default_sandbox_policy` in `phase.md` frontmatter is **retired** (#1326): the
-  key is no longer parsed (a phase that still declares it is silently ignored).
-  Sandbox policy is set at the agent level instead.
+- `default_sandbox_policy` in `phase.md` frontmatter is **deprecated** and
+  being retired. During the migration window it continues to work; new skills
+  should not use it.
 - The `SandboxPolicy` on `sandboxed_exec` op fields still applies (per-op
   policy at execution time), but this is operator/OS context, not skill author
   declaration.
@@ -82,8 +82,8 @@ declaration.**
 - `docs/concepts/architecture/sandbox-vs-permission.md` — concept doc for
   operator and agent audiences (no history refs; published to site).
 - `docs/concepts/runtime/sandbox.md` — updated to agent-level framing;
-  retired `default_sandbox_policy`; updated SandboxPolicy field table.
-- `docs/reference/dsl/phase-md.md` — removal note on `default_sandbox_policy`.
+  deprecated `default_sandbox_policy`; updated SandboxPolicy field table.
+- `docs/reference/dsl/phase-md.md` — deprecation note on `default_sandbox_policy`.
 
 ## Consequences
 
@@ -92,5 +92,5 @@ declaration.**
 2. Operators have a single, clear location for containment configuration.
 3. The permission/sandbox orthogonality is explicitly documented; the two
    systems can evolve independently.
-4. The swe_bench phases' `default_sandbox_policy` was migrated to the agent-level
-   policy the eval harness injects (`reyn.yaml sandbox.policy`) — #1326.
+4. Existing swe_bench phases that use `default_sandbox_policy` need to be
+   migrated during the #1326 window.


### PR DESCRIPTION
**[e2e-coder]** — restore ADR-0037 to its immutable point-in-time form. lead-coder GO (sole-review).

## Why

`docs/deep-dives/decisions/README.md:14`:
> ADRs are immutable once accepted. New facts that contradict a decision get a new ADR that supersedes the old one (the old one keeps its historical value with status updated to "superseded by ADR-XXXX").

#1333 tense-fixed ADR-0037's body (`deprecated` / "migration window" / "need to be migrated" → `retired` / "removal note" / "was migrated") to match the landed implementation. That violates the immutability rule: an ADR is a **point-in-time decision record**, not a living doc. ADR-0037 is the decision record **for** #1326 (not superseded by it), so its body must stay as written.

## What

Reverts **only** the 3 tense-fix sections back to the accepted version. The `#1324` mount/CLI content (`--image`/`--mount`) is untouched. **No information is lost** — the field-retire is documented in the mutable docs (`sandbox.md`, `phase-md.md`/`.ja`, `reyn-yaml.md`/`.ja`).

## Provenance

docs-maintainer flagged it; e2e-coder verified the rule against `README.md:14` (primary source); lead-coder owned that the #1333 review mis-accepted the tense-fix as a judgment call without weighing the governance rule. (The original revert commit was pushed to the #1333 branch *after* its merge — orphaned — so this is the cherry-pick-from-main correction.)

## Test plan

- [x] Diff is docs-only, 7 lines, ADR-0037 body restored to the pre-#1333 (accepted) text — verified against `49b9a9eb^`
- [x] No code / no other docs touched; CI doc/lint only

Refs #1326
