### PR TITLE
docs(guide): add sandbox configuration and usage guide (EN + JA)

### DIFF
--- a/docs/guide/for-users/configure-sandbox.ja.md
+++ b/docs/guide/for-users/configure-sandbox.ja.md
@@ -1,0 +1,142 @@
+---
+type: how-to
+topic: config
+audience: [human]
+applies_to: [reyn.yaml, reyn run]
+---
+
+# サンドボックスの設定
+
+reyn のサンドボックス層は、オペレーターレベルでサブプロセス実行を隔離します。
+オペレーターが `reyn.yaml` でバックエンドとポリシーを設定します。スキルは自身の封じ込めを制御できません。サンドボックスはパーミッションとは直交する概念です — [サンドボックスとパーミッション](../../concepts/architecture/sandbox-vs-permission.md)を参照してください。
+
+## バックエンドの選択
+
+```yaml
+# reyn.yaml
+sandbox:
+  backend: auto          # auto | seatbelt | landlock | noop
+  on_unsupported: warn   # warn | error | ignore
+```
+
+`backend: auto`（デフォルト）は現在のプラットフォームに最適なバックエンドを選択します:
+
+| プラットフォーム | 条件 | バックエンド |
+|---|---|---|
+| macOS | `sandbox-exec` が利用可能 | Seatbelt（SBPL deny-default） |
+| Linux | カーネル ≥ 5.13 かつ `sandbox-linux` パッケージインストール済み | Landlock（+ オプション seccomp-BPF） |
+| その他 | — | Noop（監査のみ、封じ込め無し） |
+
+`on_unsupported` は要求したバックエンドが利用不可の場合の動作を制御します:
+
+| 値 | 動作 |
+|---|---|
+| `warn`（デフォルト） | 警告をログに記録し Noop にフォールバック |
+| `error` | エラーを発生させる — 封じ込めが必須の環境で使用 |
+| `ignore` | サイレントに Noop にフォールバック |
+
+## エージェントレベルのサンドボックスポリシーの設定
+
+`sandbox.policy` により、オペレーターが決定論的なサンドボックスポリシーを宣言できます。設定されている場合、すべての `sandboxed_exec` op **と** パーミッション交差の `SandboxLayer` に適用されます — スキルや LLM はこれを広げることができません。
+
+```yaml
+sandbox:
+  backend: auto
+  policy:
+    network: false
+    write_paths:
+      - "{{workspace}}/output"
+    read_deny_paths:
+      - "~/.ssh"
+      - "~/.aws"
+    timeout_seconds: 120
+```
+
+`sandbox.policy` が省略されている場合（デフォルト）、エージェントレベルの制限はありません: op レベルのフィールドが適用され、SandboxLayer は無制限です。
+
+### ポリシーフィールド
+
+| フィールド | 型 | デフォルト | 意味 |
+|---|---|---|---|
+| `network` | bool | `false` | アウトバウンドネットワークを許可。主要な外部流出ゲート。 |
+| `write_paths` | パスのリスト | `[]` | プロセスが書き込めるパス（厳密なガード）。書き込みは読み取りを含む。 |
+| `read_deny_paths` | パスのリスト | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。Landlock では非対応。 |
+| `read_paths` | パスのリスト | `[]` | レガシー — かつての厳密な読み込み許可リスト。現在、読み込みはデフォルトで広許可のためこのフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
+| `allow_subprocess` | bool | `false` | 子プロセスの生成を許可。Seatbelt では advisory 扱い。 |
+| `env_passthrough` | 文字列のリスト | `[]` | プロセスに引き渡す環境変数名。`PATH` は常に引き渡されます。 |
+| `timeout_seconds` | int | `60` | ウォールクロック制限。期限超過でプロセスを終了。 |
+
+### スコーピングモデル
+
+reyn は**広読み込み・厳密書き込み・ネットワークゲート**モデルを採用しています:
+
+- **読み込みは広許可。** プロセスはファイルシステムの大部分を読み取れます。ポリシーに列挙しなくても dylib 読み込み用のシステムパスが機能します。
+- **ネットワークが外部流出ゲート。** `network: false`（デフォルト）により、プロセスは広く読み取れますがデータを送信できません。
+- **書き込みは厳密。** `write_paths` に記載されたパスのみ書き込み可能。
+- **`read_deny_paths` は多層防御。** バックエンドが deny-after-allow を表現できる場合に、広読み込みサーフェスから機密箇所を除外します。
+
+## バックエンド別の動作
+
+### Seatbelt（macOS）
+
+SBPL deny-default プロファイルを使った `sandbox-exec` を使用。macOS で最も強力な封じ込め。
+
+| フィールド | 適用 |
+|---|---|
+| `write_paths` | 適用 |
+| `network` | 適用 |
+| `read_deny_paths` | **適用** — SBPL deny-after-allow |
+| `allow_subprocess` | Advisory — バイナリブートストラップには process-fork が常時許可 |
+| `timeout_seconds` | 適用 |
+
+### Landlock（Linux）
+
+Linux Landlock LSM のパス以下許可リストルールを使用。
+
+| フィールド | 適用 |
+|---|---|
+| `write_paths` | 適用 — path-beneath 書き込みルール |
+| `network` | Linux 6.7+（ABI v4）で適用。旧カーネルでは警告ログを出力 |
+| `read_deny_paths` | **非対応** — Landlock は許可リストのみで、許可した親から子パスを除外できない。ネットワークゲートが主要な外部流出制御。 |
+| `allow_subprocess` | 利用可能な場合 seccomp-BPF で適用 |
+| `timeout_seconds` | 適用 |
+
+### Noop
+
+封じ込めは適用されません。ポリシーフィールドは監査ログに記録されますが動作には影響しません。封じ込めが利用不可の信頼された環境でのみ使用してください。
+
+## コンテナで実行する（マウントモード）
+
+最も強力な隔離を行うため、またはホスト OS に関わらず一貫した Linux 環境でスキルを実行するために、Docker バックエンドを使用します:
+
+```bash
+# 新しいコンテナを起動（マウントモード）
+reyn run my_skill --env-backend=docker
+
+# 特定のイメージを使用
+reyn run my_skill --env-backend=docker --image my-registry/my-image:latest
+
+# 追加のバインドマウントを指定
+reyn run my_skill --env-backend=docker \
+  --mount /data/inputs:/data/inputs:ro \
+  --mount /data/outputs:/data/outputs:rw
+
+# 実行後もコンテナを残す（検査用）
+reyn run my_skill --env-backend=docker --keep-container
+
+# 既存の実行中コンテナにアタッチ
+reyn run my_skill --env-backend=docker --container my-container --repo-dir /workspace
+```
+
+マウントモードでは、ワークスペースルートが自動的にコンテナ内の `/workspace` にバインドマウントされます。コンテナ内で使用されるサンドボックスバックエンドは `reyn.yaml sandbox.backend` で決まります（通常 Linux では `landlock`）。
+
+### デフォルトイメージ
+
+`--image` を省略した場合、reyn は現在のプラットフォーム向けにビルドされたバンドルベースイメージを使用します。カスタムイメージを使用するには `--image` を渡すか、`reyn.yaml` でデフォルトを設定してください（[`reyn.yaml` リファレンス](../../reference/config/reyn-yaml.md)参照）。
+
+## 関連ドキュメント
+
+- [コンセプト: サンドボックスとパーミッション](../../concepts/architecture/sandbox-vs-permission.md) — 両者が直交する理由
+- [コンセプト: サンドボックス](../../concepts/runtime/sandbox.md) — バックエンドフィールドリファレンスとスコーピングモデルの詳細
+- [リファレンス: `reyn.yaml`](../../reference/config/reyn-yaml.md) — `sandbox:` 設定スキーマ全体
+- [ハウツー: パーミッションの管理](manage-permissions.md) — スキルレベルの機能パーミッションの宣言と承認

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -1,0 +1,158 @@
+---
+type: how-to
+topic: config
+audience: [human]
+applies_to: [reyn.yaml, reyn run]
+---
+
+# Configure the sandbox
+
+reyn's sandbox layer isolates subprocess execution at the operator level.
+The operator sets the backend and policy in `reyn.yaml`; skills do not control
+their own containment. Sandbox is orthogonal to permissions — see
+[Sandbox and permissions](../../concepts/architecture/sandbox-vs-permission.md).
+
+## Choose a backend
+
+```yaml
+# reyn.yaml
+sandbox:
+  backend: auto          # auto | seatbelt | landlock | noop
+  on_unsupported: warn   # warn | error | ignore
+```
+
+`backend: auto` (the default) picks the best available backend for the current
+platform:
+
+| Platform | Condition | Backend |
+|---|---|---|
+| macOS | `sandbox-exec` available | Seatbelt (SBPL deny-default) |
+| Linux | kernel ≥ 5.13, `sandbox-linux` package installed | Landlock (+ optional seccomp-BPF) |
+| Other | — | Noop (audit-only, no enforcement) |
+
+`on_unsupported` controls what happens when you force a backend that is unavailable:
+
+| Value | Behaviour |
+|---|---|
+| `warn` (default) | Log a warning and fall back to Noop |
+| `error` | Raise an error — use this when enforcement is a hard requirement |
+| `ignore` | Silently fall back to Noop |
+
+## Set the agent-level sandbox policy
+
+`sandbox.policy` lets the operator declare a deterministic, operator-controlled
+sandbox policy. When set, it applies to all `sandboxed_exec` ops **and** to the
+`SandboxLayer` of the permission intersection — a skill or the LLM cannot widen it.
+
+```yaml
+sandbox:
+  backend: auto
+  policy:
+    network: false
+    write_paths:
+      - "{{workspace}}/output"
+    read_deny_paths:
+      - "~/.ssh"
+      - "~/.aws"
+    timeout_seconds: 120
+```
+
+When `sandbox.policy` is absent (the default), there is no agent-level
+restriction: op-level fields govern, and the SandboxLayer is unrestricted.
+
+### Policy fields
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `network` | bool | `false` | Allow outbound network. The primary exfiltration gate. |
+| `write_paths` | list of paths | `[]` | Paths the process may write (tight guard). Write implies read. |
+| `read_deny_paths` | list of paths | `[]` | Sensitive paths to deny from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow (Seatbelt); not enforceable on Landlock. |
+| `read_paths` | list of paths | `[]` | Legacy — formerly the strict read allowlist. Reads are broad by default; this field now documents intended read targets only. |
+| `allow_subprocess` | bool | `false` | Allow child-process spawning. Advisory under Seatbelt. |
+| `env_passthrough` | list of strings | `[]` | Env vars passed through to the process. `PATH` is always passed. |
+| `timeout_seconds` | int | `60` | Wall-clock limit; process is killed on expiry. |
+
+### Scoping model
+
+reyn uses a **broad-read, tight-write, network-gated** model:
+
+- **Reads are broad.** The process can read most of the filesystem. System-path
+  enumeration for dylib loading works without enumeration in policy.
+- **Network is the exfiltration gate.** With `network: false` (the default),
+  the process can read broadly but cannot send data out.
+- **Writes are tight.** Only paths in `write_paths` are writable.
+- **`read_deny_paths` is defense-in-depth.** Carves out sensitive locations from
+  the broad read surface where the backend can express a deny-after-allow rule.
+
+## Per-backend behavior
+
+### Seatbelt (macOS)
+
+Uses `sandbox-exec` with an SBPL deny-default profile. Strongest containment
+on macOS.
+
+| Field | Enforcement |
+|---|---|
+| `write_paths` | Enforced |
+| `network` | Enforced |
+| `read_deny_paths` | **Enforced** — SBPL deny-after-allow |
+| `allow_subprocess` | Advisory — process-fork always permitted for binary bootstrap |
+| `timeout_seconds` | Enforced |
+
+### Landlock (Linux)
+
+Uses the Linux Landlock LSM with path-beneath allowlist rules.
+
+| Field | Enforcement |
+|---|---|
+| `write_paths` | Enforced — path-beneath write rules |
+| `network` | Enforced on Linux 6.7+ (ABI v4); warning logged on older kernels |
+| `read_deny_paths` | **Not enforced** — Landlock is allowlist-only and cannot carve a subpath out of an allowed parent. The network gate is the primary exfiltration control. |
+| `allow_subprocess` | Enforced via seccomp-BPF when available |
+| `timeout_seconds` | Enforced |
+
+### Noop
+
+No containment enforced. Policy fields are recorded in the audit log but have no
+effect. Use only in trusted environments where enforcement is unavailable.
+
+## Run in a container (mount mode)
+
+For the strongest isolation — or to run skills against a consistent Linux
+environment regardless of the host OS — use the Docker backend:
+
+```bash
+# Launch a new container (mount mode)
+reyn run my_skill --env-backend=docker
+
+# Use a specific image
+reyn run my_skill --env-backend=docker --image my-registry/my-image:latest
+
+# Add extra bind mounts
+reyn run my_skill --env-backend=docker \
+  --mount /data/inputs:/data/inputs:ro \
+  --mount /data/outputs:/data/outputs:rw
+
+# Keep the container after the run (for inspection)
+reyn run my_skill --env-backend=docker --keep-container
+
+# Attach to an already-running container
+reyn run my_skill --env-backend=docker --container my-container --repo-dir /workspace
+```
+
+In mount mode, the workspace root is automatically bind-mounted at `/workspace`
+inside the container. The sandbox backend used inside the container is determined
+by `reyn.yaml sandbox.backend` as usual (typically `landlock` on Linux).
+
+### Default image
+
+When `--image` is omitted, reyn uses a bundled base image built for the current
+platform. To use a custom image, pass `--image` or set the default in `reyn.yaml`
+(see [`reyn.yaml` reference](../../reference/config/reyn-yaml.md)).
+
+## See also
+
+- [Concepts: Sandbox and permissions](../../concepts/architecture/sandbox-vs-permission.md) — why sandbox and permissions are orthogonal
+- [Concepts: Sandbox](../../concepts/runtime/sandbox.md) — backend field reference and scoping model details
+- [Reference: `reyn.yaml`](../../reference/config/reyn-yaml.md) — full `sandbox:` config schema
+- [How-to: Manage permissions](manage-permissions.md) — declare and approve skill-level capability permissions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - Using Reyn:
               - guide/for-users/chat-and-web-ui.md
               - guide/for-users/manage-permissions.md
+              - guide/for-users/configure-sandbox.md
               - guide/for-users/ask-user-mid-phase.md
           - Files & integrations:
               - guide/for-users/work-with-files.md


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder dispatch より。owner 要望「sandbox 毎の設定・使い方ドキュメント」対応（#1326 agent-level re-level 完了後の unblock）。

## Summary

- `docs/guide/for-users/configure-sandbox.md` + `.ja.md` を新設（EN/JA mirror sync）
- `mkdocs.yml` nav に追加（"Using Reyn" グループ）

**カバー内容（flow-trace 済み）:**
- バックエンド選択（`reyn.yaml sandbox.backend`）
- エージェントレベルサンドボックスポリシー（`sandbox.policy:` 全フィールド）
- 広読み込み・厳密書き込み・ネットワークゲートのスコーピングモデルと rationale
- per-backend 挙動・非対称性（Seatbelt: deny 強制 / Landlock: 非対応 / Noop: 監査のみ）
- マウントモードコンテナ実行（`--env-backend=docker`、`--image`、`--mount`）

**`[[feedback_no_history_refs_in_user_docs]]` 遵守** — 本文に #/PR/FP/ADR inline なし ✅

**変更ページ:** removed 0 / added 1 (`configure-sandbox.md`)

**Note:** `read_deny_paths` は `reyn-yaml.md` の `sandbox.policy` sub-keys table に未記載。user guide には記載済み。reyn-yaml.md への追加は別 PR 候補として記録。

## Test plan

- [ ] `mkdocs build --strict` でリンクエラーなし
- [ ] nav に "Configure the sandbox" が表示されること（"Using Reyn" グループ）
- [ ] See also リンクが全て機能すること
- [ ] JA 版が正常にレンダリングされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)