### PR TITLE
docs(reyn-yaml): add read_deny_paths to sandbox.policy reference

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -328,11 +328,12 @@ sandbox:
 
 | キー | 型 | デフォルト | 説明 |
 |-----|------|---------|-------------|
-| `network` | bool | `false` | サンドボックスプロセスからの外向きネットワークを許可。 |
-| `read_paths` | list[文字列] | `[]` | プロセスが読み取り可能なパス（glob 可）。 |
-| `write_paths` | list[文字列] | `[]` | プロセスが書き込み可能なパス。 |
-| `allow_subprocess` | bool | `false` | 子プロセスの spawn を許可するか。 |
-| `env_passthrough` | list[文字列] | `[]` | サンドボックスプロセスへ通過させる環境変数名。 |
+| `network` | bool | `false` | サンドボックスプロセスからの外向きネットワークを許可。主要な外部流出ゲート。 |
+| `write_paths` | list[文字列] | `[]` | プロセスが書き込み可能なパス（厳密なガード）。書き込みは読み取りを含む。 |
+| `read_deny_paths` | list[文字列] | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。許可リストのみのバックエンド（Landlock）では非対応。 |
+| `read_paths` | list[文字列] | `[]` | **レガシー。** かつての厳密な読み込み許可リスト。現在のスコーピングモデルでは読み込みはデフォルトで広許可のため、このフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
+| `allow_subprocess` | bool | `false` | 子プロセスの spawn を許可するか。Seatbelt では advisory 扱い。 |
+| `env_passthrough` | list[文字列] | `[]` | サンドボックスプロセスへ通過させる環境変数名。`PATH` は常に通過します。 |
 | `timeout_seconds` | int | `60` | バックエンドが強制する実時間上限。 |
 
 [リファレンス: control-ir — `sandboxed_exec`](../runtime/control-ir.md#sandboxed_exec) で op スキーマとバックエンド選択の詳細を参照してください。

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -339,11 +339,12 @@ When `sandbox.policy` is present, these mirror the `SandboxPolicy` fields. Unkno
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `network` | bool | `false` | Allow outbound network from the sandboxed process. |
-| `read_paths` | list[string] | `[]` | Filesystem paths the process may read (glob patterns OK). |
-| `write_paths` | list[string] | `[]` | Filesystem paths the process may write. |
-| `allow_subprocess` | bool | `false` | Whether the process may spawn children. |
-| `env_passthrough` | list[string] | `[]` | Env-var names that pass through to the sandboxed process. |
+| `network` | bool | `false` | Allow outbound network from the sandboxed process. The primary exfiltration gate. |
+| `write_paths` | list[string] | `[]` | Filesystem paths the process may write (tight guard). Write implies read for these paths. |
+| `read_deny_paths` | list[string] | `[]` | Sensitive paths to DENY from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow rules (Seatbelt); not enforceable on allowlist-only backends (Landlock). |
+| `read_paths` | list[string] | `[]` | **Legacy.** Formerly the strict read allowlist. Reads are broad by default under the current scoping model; this field now documents intended read targets only. |
+| `allow_subprocess` | bool | `false` | Whether the process may spawn children. Advisory under Seatbelt. |
+| `env_passthrough` | list[string] | `[]` | Env-var names that pass through to the sandboxed process. `PATH` is always passed through. |
 | `timeout_seconds` | int | `60` | Wall-clock cap enforced by the backend. |
 
 See [Reference: control-ir — `sandboxed_exec`](../runtime/control-ir.md#sandboxed_exec) for the op schema and backend selection details.

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -990,10 +990,11 @@ class SandboxConfig:
             production environments). ``'ignore'`` silently falls back.
             Allowed: ``{'warn', 'error', 'ignore'}``.
         policy:
-            #1326 — the agent-level (operator) sandbox policy: a mapping of
-            ``SandboxPolicy`` kwargs (``network`` / ``read_paths`` /
-            ``write_paths`` / ``allow_subprocess`` / ``env_passthrough`` /
-            ``timeout_seconds``). When set it is the deterministic policy the OS
+            The agent-level (operator) sandbox policy: a mapping of
+            ``SandboxPolicy`` kwargs (``network`` / ``write_paths`` /
+            ``read_deny_paths`` / ``read_paths`` / ``allow_subprocess`` /
+            ``env_passthrough`` / ``timeout_seconds``). When set it is the
+            deterministic policy the OS
             applies to sandboxed ops + the SandboxLayer of the permission ∩ —
             WINNING over op-declared fields (the LLM cannot widen it). ``None``
             (absent) means *no agent-level restriction* — the SandboxLayer stays


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder GO (docs drift gap fix)。

## Summary

`reyn-yaml.md` の `sandbox.policy` sub-keys table に `read_deny_paths` が未記載だったため追加。

- `read_deny_paths`: 広読み込みサーフェスからの機密パス除外（defense-in-depth）、deny-after-allow 対応バックエンド（Seatbelt）のみ適用
- `read_paths`: legacy 注記追加（現 broad-read モデルでは制限フィールドとして機能しない）
- `config.py` SandboxConfig.policy docstring の kwargs リストにも `read_deny_paths` を追加

**変更ページ:** removed 0 / added 0（既存ページ更新のみ）

## Test plan

- [ ] `reyn-yaml.md` sandbox.policy table に `read_deny_paths` 行が表示されること
- [ ] `config.py` の kwargs リストが policy.py の SandboxPolicy fields と一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)