### PR TITLE
feat(environment): devcontainer.json awareness for mount launch (#1324 follow-up b)

### DIFF
--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -292,6 +292,7 @@ def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
             WORKSPACE_DEST_DEFAULT,
             ContainerLauncher,
             LaunchConfig,
+            load_devcontainer_config,
             parse_mount_spec,
         )
         # _find_project_root returns None when no reyn.yaml is found up the tree;
@@ -301,16 +302,30 @@ def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
         project_root = _find_project_root(Path.cwd())
         workspace_root = str(project_root if project_root is not None else Path.cwd())
         try:
-            mounts = [parse_mount_spec(m) for m in (getattr(args, "mounts", None) or [])]
+            cli_mounts = [parse_mount_spec(m) for m in (getattr(args, "mounts", None) or [])]
         except ValueError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
         keep = bool(getattr(args, "keep_container", False))
+        # #1324 (b) devcontainer awareness: a workspace devcontainer.json seeds
+        # the launch defaults; explicit CLI flags override it. build-based
+        # devcontainers are not yet supported → warn + use the default image.
+        dc = load_devcontainer_config(workspace_root)
+        if dc is not None and dc.build_based:
+            print(
+                "Warning: build-based devcontainer (dockerFile/build) is not yet "
+                "supported; using the default image.",
+                file=sys.stderr,
+            )
+        cli_image = getattr(args, "image", None)
+        dc_image = dc.image if (dc is not None and not dc.build_based) else None
         config = LaunchConfig(
             workspace_root=workspace_root,
-            image=getattr(args, "image", None) or DEFAULT_IMAGE,
-            mounts=mounts,
+            image=cli_image or dc_image or DEFAULT_IMAGE,
+            mounts=cli_mounts or (dc.mounts if dc is not None else []),
             persistent=keep,
+            setup_command=(dc.setup_command if dc is not None else None),
+            user=(dc.user if dc is not None else None),
         )
         launcher = launcher or ContainerLauncher()
         try:

--- a/src/reyn/environment/container_launcher.py
+++ b/src/reyn/environment/container_launcher.py
@@ -35,9 +35,13 @@ mechanism here is independent of whether the default is published or bundled.
 """
 from __future__ import annotations
 
+import json
 import os
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from reyn.environment.container_backend import SyncRunner, _sync_runner
 from reyn.sandbox.backend import SandboxResult
@@ -128,6 +132,119 @@ class LaunchConfig:
     read_only_rootfs: bool = True
     persistent: bool = False
     name: str | None = None
+
+
+# ── devcontainer.json awareness (#1324 follow-up b) ──────────────────────────
+#
+# When a workspace ships a devcontainer.json, reyn reads a minimal-useful subset
+# to seed the LaunchConfig (industry-standard spec; coding-task oriented). An
+# explicit CLI flag (--image / --mount) overrides the devcontainer default.
+# build/dockerFile-based devcontainers are NOT yet supported — the caller warns
+# and uses the default image (build-based support via the #1329 ensure_image
+# build-on-demand is a tracked follow-up).
+
+
+@dataclass
+class DevcontainerConfig:
+    """A devcontainer.json mapped to the LaunchConfig-relevant subset.
+
+    image:          devcontainer ``image`` (None if absent / build-based).
+    setup_command:  devcontainer ``postCreateCommand`` (once-after-create —
+                    semantically matches reyn's once-on-create setup_command;
+                    postStartCommand is every-start and intentionally NOT mapped).
+    mounts:         devcontainer ``mounts`` (bind mounts only).
+    user:           devcontainer ``remoteUser`` / ``containerUser``.
+    build_based:    True if the devcontainer is dockerFile/build/compose-based
+                    (not yet supported → caller falls back to the default image).
+    """
+
+    image: str | None = None
+    setup_command: str | None = None
+    mounts: list[MountSpec] = field(default_factory=list)
+    user: str | None = None
+    build_based: bool = False
+
+
+def _strip_jsonc(text: str) -> str:
+    """Best-effort strip of JSONC comments + trailing commas (devcontainer.json
+    permits ``//`` / ``/* */`` comments and trailing commas)."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)  # block comments
+    text = re.sub(r"(?m)//.*$", "", text)  # line comments
+    text = re.sub(r",(\s*[}\]])", r"\1", text)  # trailing commas
+    return text
+
+
+def _parse_devcontainer_mount(m: Any) -> MountSpec | None:
+    """Parse a devcontainer ``mounts`` entry → MountSpec.
+
+    Accepts the string form ``source=/h,target=/c[,type=bind][,readonly]`` and
+    the object form ``{"source": "/h", "target": "/c", ...}``. Non-bind mounts
+    (e.g. ``type=volume`` without a host source) are skipped (return None).
+    """
+    src = tgt = None
+    mode = "rw"
+    if isinstance(m, str):
+        for part in m.split(","):
+            if "=" in part:
+                k, v = part.split("=", 1)
+                k = k.strip()
+                if k == "source":
+                    src = v.strip()
+                elif k == "target":
+                    tgt = v.strip()
+            elif part.strip() in ("readonly", "ro"):
+                mode = "ro"
+    elif isinstance(m, Mapping):
+        src = m.get("source")
+        tgt = m.get("target")
+        if m.get("readonly") or m.get("readOnly"):
+            mode = "ro"
+    if not src or not tgt:
+        return None
+    return MountSpec(host=str(src), container=str(tgt), mode=mode)
+
+
+def _map_devcontainer(data: Mapping[str, Any]) -> DevcontainerConfig:
+    cfg = DevcontainerConfig()
+    if data.get("dockerFile") or data.get("build") or data.get("dockerComposeFile"):
+        cfg.build_based = True
+    img = data.get("image")
+    if isinstance(img, str):
+        cfg.image = img
+    pcc = data.get("postCreateCommand")
+    if isinstance(pcc, str):
+        cfg.setup_command = pcc
+    elif isinstance(pcc, list):  # devcontainer allows an argv array
+        cfg.setup_command = " ".join(str(x) for x in pcc)
+    for m in data.get("mounts") or []:
+        ms = _parse_devcontainer_mount(m)
+        if ms is not None:
+            cfg.mounts.append(ms)
+    user = data.get("remoteUser") or data.get("containerUser")
+    if isinstance(user, str):
+        cfg.user = user
+    return cfg
+
+
+def load_devcontainer_config(workspace_root: str) -> DevcontainerConfig | None:
+    """Return the mapped devcontainer config for ``workspace_root``, or None.
+
+    Checks the two standard locations (``.devcontainer/devcontainer.json`` then
+    ``.devcontainer.json``). Parse failures return None (a malformed
+    devcontainer.json must not crash a launch — the caller falls back to defaults).
+    """
+    root = Path(workspace_root)
+    for rel in (".devcontainer/devcontainer.json", ".devcontainer.json"):
+        p = root / rel
+        if p.exists():
+            try:
+                data = json.loads(_strip_jsonc(p.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError, ValueError):
+                return None
+            if isinstance(data, Mapping):
+                return _map_devcontainer(data)
+            return None
+    return None
 
 
 def _default_user() -> str | None:

--- a/tests/test_container_launcher.py
+++ b/tests/test_container_launcher.py
@@ -19,6 +19,7 @@ from reyn.environment.container_launcher import (
     LaunchConfig,
     MountSpec,
     build_docker_run_argv,
+    load_devcontainer_config,
     parse_mount_spec,
 )
 from reyn.sandbox.backend import SandboxResult
@@ -235,3 +236,83 @@ def test_launch_builds_base_image_then_runs():
     assert runner.calls[0][:3] == ["docker", "image", "inspect"]
     assert runner.calls[1][:2] == ["docker", "build"]
     assert runner.calls[2][:3] == ["docker", "run", "-d"]
+
+
+# ─── devcontainer.json awareness (#1324 follow-up b) ──────────────────────────
+
+
+def _write_devcontainer(tmp_path, body: str, *, root_level: bool = False):
+    if root_level:
+        p = tmp_path / ".devcontainer.json"
+    else:
+        (tmp_path / ".devcontainer").mkdir(exist_ok=True)
+        p = tmp_path / ".devcontainer" / "devcontainer.json"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_devcontainer_image_and_postcreate(tmp_path):
+    """Tier 2: image → cfg.image, postCreateCommand → cfg.setup_command (once-after-create)."""
+    _write_devcontainer(tmp_path, '{"image": "python:3.12", "postCreateCommand": "pip install -e ."}')
+    cfg = load_devcontainer_config(str(tmp_path))
+    assert cfg is not None
+    assert cfg.image == "python:3.12"
+    assert cfg.setup_command == "pip install -e ."
+    assert cfg.build_based is False
+
+
+def test_devcontainer_jsonc_comments_and_trailing_commas(tmp_path):
+    """Tier 2: JSONC (// and /* */ comments + trailing commas) parses (spec-compliant)."""
+    _write_devcontainer(tmp_path, """
+    {
+      // line comment
+      "image": "node:20", /* block */
+      "remoteUser": "node",
+    }
+    """)
+    cfg = load_devcontainer_config(str(tmp_path))
+    assert cfg is not None
+    assert cfg.image == "node:20"
+    assert cfg.user == "node"
+
+
+def test_devcontainer_mounts_string_and_user(tmp_path):
+    """Tier 2: string-form mounts → MountSpec; remoteUser → cfg.user."""
+    _write_devcontainer(
+        tmp_path,
+        '{"image": "x", "remoteUser": "dev", '
+        '"mounts": ["source=/host/d,target=/c/d,type=bind", "source=/ro,target=/c/ro,readonly"]}',
+    )
+    cfg = load_devcontainer_config(str(tmp_path))
+    assert cfg is not None
+    assert cfg.user == "dev"
+    m0, m1 = cfg.mounts
+    assert (m0.host, m0.container, m0.mode) == ("/host/d", "/c/d", "rw")
+    assert (m1.host, m1.container, m1.mode) == ("/ro", "/c/ro", "ro")
+
+
+def test_devcontainer_build_based_flagged(tmp_path):
+    """Tier 2: a dockerFile/build devcontainer is flagged build_based (not yet supported)."""
+    _write_devcontainer(tmp_path, '{"build": {"dockerfile": "Dockerfile"}}')
+    cfg = load_devcontainer_config(str(tmp_path))
+    assert cfg is not None
+    assert cfg.build_based is True
+    assert cfg.image is None
+
+
+def test_devcontainer_root_level_location(tmp_path):
+    """Tier 2: the root-level .devcontainer.json location is also detected."""
+    _write_devcontainer(tmp_path, '{"image": "rootimg"}', root_level=True)
+    cfg = load_devcontainer_config(str(tmp_path))
+    assert cfg is not None and cfg.image == "rootimg"
+
+
+def test_devcontainer_absent_returns_none(tmp_path):
+    """Tier 2: no devcontainer.json → None (caller uses defaults)."""
+    assert load_devcontainer_config(str(tmp_path)) is None
+
+
+def test_devcontainer_malformed_returns_none(tmp_path):
+    """Tier 2: a malformed devcontainer.json returns None (must not crash a launch)."""
+    _write_devcontainer(tmp_path, '{"image": "x"  "broken"')
+    assert load_devcontainer_config(str(tmp_path)) is None

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -218,3 +218,50 @@ def test_docker_launch_bad_mount_exits() -> None:
             _args(env_backend="docker", mounts=["bogus"]), launcher=fake
         )
     assert fake.launched == []  # rejected before launching
+
+
+# ─── docker LAUNCH devcontainer awareness (#1324 b) ────────────────────────────
+
+
+def _write_devcontainer(tmp_path, body: str) -> None:
+    (tmp_path / ".devcontainer").mkdir(exist_ok=True)
+    (tmp_path / ".devcontainer" / "devcontainer.json").write_text(body, encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("")  # so _find_project_root resolves here
+
+
+def test_docker_launch_reads_devcontainer_image(tmp_path, monkeypatch) -> None:
+    """Tier 2: #1324b — a workspace devcontainer.json image seeds the LaunchConfig
+    when no --image is given."""
+    _write_devcontainer(tmp_path, '{"image": "dcimg:1", "postCreateCommand": "make"}')
+    monkeypatch.chdir(tmp_path)
+    fake = _FakeLauncher()
+    _build_environment_backend(_args(env_backend="docker"), launcher=fake)
+    (cfg,) = fake.launched
+    assert cfg.image == "dcimg:1"
+    assert cfg.setup_command == "make"
+
+
+def test_docker_launch_cli_image_overrides_devcontainer(tmp_path, monkeypatch) -> None:
+    """Tier 2: #1324b — an explicit --image overrides the devcontainer image."""
+    _write_devcontainer(tmp_path, '{"image": "dcimg:1"}')
+    monkeypatch.chdir(tmp_path)
+    fake = _FakeLauncher()
+    _build_environment_backend(
+        _args(env_backend="docker", image="cli:override"), launcher=fake
+    )
+    (cfg,) = fake.launched
+    assert cfg.image == "cli:override"
+
+
+def test_docker_launch_build_based_devcontainer_warns(tmp_path, monkeypatch, capsys) -> None:
+    """Tier 2: #1324b — a build-based devcontainer warns + falls back to the default
+    image (build-based support is a tracked follow-up)."""
+    from reyn.environment.container_launcher import DEFAULT_IMAGE
+
+    _write_devcontainer(tmp_path, '{"build": {"dockerfile": "Dockerfile"}}')
+    monkeypatch.chdir(tmp_path)
+    fake = _FakeLauncher()
+    _build_environment_backend(_args(env_backend="docker"), launcher=fake)
+    (cfg,) = fake.launched
+    assert cfg.image == DEFAULT_IMAGE
+    assert "build-based devcontainer" in capsys.readouterr().err


### PR DESCRIPTION
**[dogfood-coder]** — #1324 follow-up **(b) devcontainer awareness**. Design + scope co-signed by lead-coder. Parallel with the merged #1340; file non-overlap. Refs #1324.

## What

When a workspace ships a `devcontainer.json`, the docker **LAUNCH** path (`--env-backend=docker` without `--container`, #1324) seeds the `LaunchConfig` from a minimal-useful subset of the industry-standard spec. Explicit CLI flags override it.

## Mapped subset (lean, co-signed)

| devcontainer field | → LaunchConfig | Note |
|---|---|---|
| `image` | `image` | when not build-based |
| `postCreateCommand` | `setup_command` | once-after-create — matches reyn’s once-on-create semantic. `postStartCommand` (every-start) is **not** mapped |
| `mounts` | `mounts` | string (`source=…,target=…[,readonly]`) + object forms |
| `remoteUser` / `containerUser` | `user` | |

**Precedence:** explicit CLI (`--image` / `--mount`) **>** devcontainer **>** default (mirrors the setdefault philosophy).

**Detection:** `.devcontainer/devcontainer.json` then `.devcontainer.json`; parsed as **JSONC** (comments + trailing commas, per spec). A malformed file returns `None` (must not crash a launch).

**build-based** (`dockerFile` / `build` / `dockerComposeFile`): flagged + falls back to the **default image with a warning** (no silent surprise). Build-based support via the #1329 `ensure_image` build-on-demand is tracked in **#1341**.

## Test plan (no live Docker)

- [x] `pytest tests/test_container_launcher.py tests/test_run_container_backend_flags_1115.py` — all pass
- [x] loader: image / postCreateCommand / mounts (string + readonly) / remoteUser / build-based-flag / JSONC / 2-location / absent→None / malformed→None
- [x] run.py merge: devcontainer seeds the LaunchConfig; `--image` overrides; build-based warns + falls back to default
- [x] broad sweep `-k "environment or container or launcher or devcontainer"` — 118 passed, 2 skipped (landlock Linux-only)
- [x] `scripts/test_tier_audit.py --strict` — 42 OK, 0 errors

## #1324 status after this

mount launcher #1328 ✓ / base image #1329 ✓ / part2 #1331 ✓ / dogfood validation #1340 ✓ / **(b) devcontainer (this)**. Remaining: (a2) registry image (owner infra), (c) eval-unify, build-based devcontainer #1341, mount docker integration #1332, network-axis gate #1339 (owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)