### PR TITLE
feat(security): sandbox stdio MCP server subprocess via Seatbelt wrap (#1344)

### DIFF
--- a/src/reyn/mcp_client.py
+++ b/src/reyn/mcp_client.py
@@ -18,7 +18,9 @@ Environment variable expansion:
 """
 from __future__ import annotations
 
+import os
 import tempfile
+import warnings
 from contextlib import AsyncExitStack
 from typing import Any
 
@@ -89,6 +91,10 @@ class MCPClient:
         # ``tempfile.TemporaryFile`` does. Lazily created in
         # ``_open_stdio``; closed in ``close``.
         self._stderr_capture: Any = None  # tempfile.TemporaryFile | None
+        # #1344: path of the temp Seatbelt profile (.sb) used to sandbox a
+        # stdio MCP server's subprocess, if one was generated in _open_stdio.
+        # Unlinked in close(). None for non-stdio / non-seatbelt / unsandboxed.
+        self._sandbox_profile_path: str | None = None
 
     @property
     def stderr_capture(self) -> "Any":
@@ -144,12 +150,23 @@ class MCPClient:
             await stack.aclose()
             tail = self.read_stderr_tail()
             self.close_stderr_capture()
+            # #1344 migration hint: a sandboxed stdio server runs with network
+            # DISABLED by default (secure-by-default). A server that needs the
+            # network (e.g. a GitHub MCP) will fail init — point the operator at
+            # the `network: true` opt-in knob rather than leave an opaque error.
+            hint = ""
+            if self._type == "stdio" and not self._config.get("network", False):
+                hint = (
+                    "\nHint (#1344): this MCP server runs sandboxed with network "
+                    "DISABLED by default. If it needs network access, add "
+                    "`network: true` to its server config."
+                )
             if tail:
                 raise MCPError(
                     f"MCP initialize failed: {exc}\n"
-                    f"--- subprocess stderr (tail) ---\n{tail}"
+                    f"--- subprocess stderr (tail) ---\n{tail}{hint}"
                 ) from exc
-            raise MCPError(f"MCP initialize failed: {exc}") from exc
+            raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
 
         self._stack = stack
         self._session = session
@@ -256,7 +273,18 @@ class MCPClient:
         return text
 
     def close_stderr_capture(self) -> None:
-        """Close + delete the stderr temp file, if any. Idempotent."""
+        """Close + delete the stderr temp file + the #1344 Seatbelt profile, if
+        any. Idempotent — called at every teardown path."""
+        # #1344: unlink the temp Seatbelt profile (.sb) generated for a
+        # sandboxed stdio MCP server. Best-effort; a leaked temp file must not
+        # break teardown.
+        profile_path = self._sandbox_profile_path
+        if profile_path is not None:
+            self._sandbox_profile_path = None
+            try:
+                os.unlink(profile_path)
+            except OSError:
+                pass
         capture = self._stderr_capture
         if capture is None:
             return
@@ -278,6 +306,61 @@ class MCPClient:
         # Unreachable due to __init__ validation, but keep defensive.
         raise ValueError(f"Unsupported MCP server type: {self._type!r}")
 
+    def _build_mcp_sandbox_policy(self):
+        """SandboxPolicy for a sandboxed stdio MCP server (#1344).
+
+        read broad (#1323 scoping) + the default sensitive deny-list; write tight
+        to the server's working dir; ``network`` is OPERATOR-declared per server
+        (``network: true`` in the MCP config) and defaults OFF — secure-by-default,
+        because the sandbox policy is the operator's, not the LLM's. The default-off
+        means a network-needing server (e.g. a GitHub MCP) must declare
+        ``network: true`` (see the migration hint surfaced on init failure).
+        """
+        from reyn.sandbox import SandboxPolicy
+
+        cwd = self._config.get("cwd") or os.getcwd()
+        return SandboxPolicy(
+            network=bool(self._config.get("network", False)),
+            write_paths=[cwd],
+        )
+
+    def _sandbox_wrap_stdio(self, command: str, args: list[str]) -> "tuple[str, list[str]]":
+        """Wrap ``(command, args)`` so the MCP server subprocess runs sandboxed (#1344).
+
+        Seatbelt (macOS): returns ``("sandbox-exec", ["-f", <profile>, command,
+        *args])`` with a generated SBPL profile (a temp ``.sb`` unlinked in
+        ``close``). MCP stdio is persistent, so the wrap is at the COMMAND level
+        (the backend's one-shot ``run()`` does not fit). Other backends
+        (landlock/docker) are not yet wrapped here (#1344 follow-up) — the server
+        then runs UNSANDBOXED with a warning (never silently).
+        """
+        from reyn.sandbox import get_default_backend
+
+        try:
+            backend = get_default_backend()
+            name = getattr(backend, "name", None)
+            available = backend.available()
+        except Exception:  # noqa: BLE001 — a backend probe must not block a launch
+            name, available = None, False
+        if name == "seatbelt" and available:
+            from reyn.sandbox.backends.seatbelt import _build_sbpl_profile
+
+            profile = _build_sbpl_profile(self._build_mcp_sandbox_policy())
+            fh = tempfile.NamedTemporaryFile(
+                suffix=".sb", mode="w", delete=False, encoding="utf-8",
+            )
+            fh.write(profile)
+            fh.close()
+            self._sandbox_profile_path = fh.name
+            return "sandbox-exec", ["-f", fh.name, command, *args]
+        warnings.warn(
+            f"MCP stdio server {command!r} runs UNSANDBOXED "
+            f"(sandbox backend={name or 'none'}); only the Seatbelt wrap is "
+            f"implemented (#1344) — Landlock/docker wrapping is a follow-up.",
+            stacklevel=2,
+        )
+        return command, args
+
     def _open_stdio(self):
         from mcp.client.stdio import StdioServerParameters, stdio_client
 
@@ -285,6 +368,9 @@ class MCPClient:
         if not command:
             raise MCPError("stdio MCP server config requires 'command'")
         args = list(self._config.get("args") or [])
+        # #1344: wrap the server subprocess in the platform sandbox (Seatbelt)
+        # so an LLM-invoked MCP tool cannot escape the sandbox via the server.
+        command, args = self._sandbox_wrap_stdio(command, args)
         env = self._config.get("env")
         params = StdioServerParameters(
             command=command,

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -8,6 +8,7 @@ and ``ClientSession`` at the module they're imported from.
 from __future__ import annotations
 
 import asyncio
+import warnings
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest import mock
@@ -113,12 +114,33 @@ async def _fake_http_client(url, headers=None, timeout=30):
     yield ("read_stream_obj", "write_stream_obj", lambda: None)
 
 
+class _NoopBackend:
+    """A non-seatbelt sandbox backend stand-in (#1344): the stdio wrap then
+    no-ops (warns), so these transport-passthrough tests stay isolated from the
+    sandbox-wrap layer (which has its own test_mcp_client_sandbox_wrap.py)."""
+
+    name = "noop"
+
+    def available(self) -> bool:
+        return True
+
+
 @pytest.fixture
 def patched_sdk():
-    """Patch the SDK entry points used by MCPClient."""
+    """Patch the SDK entry points used by MCPClient.
+
+    Also pins a noop sandbox backend so the #1344 stdio sandbox-wrap leaves the
+    command untouched here — these tests verify transport config forwarding, not
+    the sandbox wrap (that is tested separately).
+    """
     with mock.patch("mcp.client.stdio.stdio_client", _fake_stdio_client), \
          mock.patch("mcp.client.streamable_http.streamablehttp_client", _fake_http_client), \
-         mock.patch("mcp.ClientSession", _FakeSession):
+         mock.patch("mcp.ClientSession", _FakeSession), \
+         mock.patch("reyn.sandbox.get_default_backend", lambda config=None: _NoopBackend()), \
+         warnings.catch_warnings():
+        # The noop backend makes the #1344 stdio wrap a no-op + warn — expected
+        # here (these tests isolate transport forwarding, not the sandbox wrap).
+        warnings.filterwarnings("ignore", message=".*runs UNSANDBOXED.*")
         yield
 
 

--- a/tests/test_mcp_client_sandbox_wrap.py
+++ b/tests/test_mcp_client_sandbox_wrap.py
@@ -1,0 +1,98 @@
+"""Tier 2: stdio MCP server subprocess is sandbox-wrapped (#1344).
+
+The MCP server launched by ``_open_stdio`` must run under the platform sandbox
+so an LLM-invoked MCP tool cannot escape via the server. Pins the Seatbelt
+command-wrap (the implemented backend), the per-server network opt-in
+(default OFF = secure-by-default), the unsandboxed warning for other backends,
+and the temp-profile cleanup.
+
+No mocks: a real ``_FakeBackend`` (name + available()) injected via monkeypatch
+of ``reyn.sandbox.get_default_backend``; the real ``_build_sbpl_profile`` builds
+the asserted SBPL.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp_client import MCPClient
+
+
+class _FakeBackend:
+    """A real (non-mock) sandbox-backend stand-in: just name + available()."""
+
+    def __init__(self, name: str, available: bool = True) -> None:
+        self.name = name
+        self._available = available
+
+    def available(self) -> bool:
+        return self._available
+
+
+def _stdio_client(**cfg) -> MCPClient:
+    base = {"type": "stdio", "command": "my-mcp", "args": ["--flag"]}
+    base.update(cfg)
+    return MCPClient(base)
+
+
+def _patch_backend(monkeypatch, backend) -> None:
+    monkeypatch.setattr("reyn.sandbox.get_default_backend", lambda config=None: backend)
+
+
+def test_seatbelt_wrap_wraps_command(monkeypatch):
+    """Tier 2: under Seatbelt, the command is wrapped as sandbox-exec -f <profile>
+    cmd args; the profile is a deny-default SBPL with broad-read, network OFF."""
+    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    client = _stdio_client()
+    cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert cmd == "sandbox-exec"
+    assert args[0] == "-f"
+    profile_path = args[1]  # the wrap's output (not private state)
+    assert profile_path.endswith(".sb")
+    assert args[-2:] == ["my-mcp", "--flag"]  # original command preserved after the wrapper
+    profile = Path(profile_path).read_text()
+    assert "(deny default)" in profile
+    assert "(allow file-read*)" in profile.splitlines()  # broad-read (#1323)
+    assert "(allow network*)" not in profile  # network OFF by default
+
+
+def test_seatbelt_wrap_network_opt_in(monkeypatch):
+    """Tier 2: an operator-declared `network: true` opts the server into network
+    (the per-server knob; default is off = secure-by-default)."""
+    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    client = _stdio_client(network=True)
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile = Path(args[1]).read_text()
+    assert "(allow network*)" in profile
+
+
+def test_non_seatbelt_warns_unsandboxed(monkeypatch):
+    """Tier 2: a backend without a Seatbelt wrap (e.g. noop) leaves the command
+    unchanged and WARNS that the server runs unsandboxed (never silent)."""
+    _patch_backend(monkeypatch, _FakeBackend("noop"))
+    client = _stdio_client()
+    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+        cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert cmd == "my-mcp"
+    assert args == ["--flag"]  # unchanged → no wrap applied
+
+
+def test_unavailable_seatbelt_warns(monkeypatch):
+    """Tier 2: Seatbelt present but available()=False → unsandboxed + warn (not wrapped)."""
+    _patch_backend(monkeypatch, _FakeBackend("seatbelt", available=False))
+    client = _stdio_client()
+    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+        cmd, _ = client._sandbox_wrap_stdio("my-mcp", [])
+    assert cmd == "my-mcp"
+
+
+def test_profile_cleaned_on_close(monkeypatch):
+    """Tier 2: the temp Seatbelt profile is unlinked on teardown (no leak)."""
+    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    client = _stdio_client()
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile_path = args[1]  # wrap output (not private state)
+    assert Path(profile_path).exists()
+    client.close_stderr_capture()
+    assert not Path(profile_path).exists()  # teardown unlinked it


### PR DESCRIPTION
**[dogfood-coder]** — #1344 stdio MCP sandbox-escape fix, seatbelt path (settled, design co-signed). Same root as #1339 (sandbox model not covering all exec paths). Refs #1339 #1323.

## Problem

`mcp_client._open_stdio` launched the MCP server as a **raw host subprocess** (`stdio_client(StdioServerParameters(command=raw))`), no sandbox → an LLM-invoked MCP tool had **full host access** — it could do what `sandboxed_exec` denies.

## Fix (Seatbelt, the implemented backend)

- **`_sandbox_wrap_stdio`**: on Seatbelt + available → wrap as `sandbox-exec -f <profile> <cmd> <args>`. MCP stdio is **persistent**, so the wrap is at the **command level** (the backend’s one-shot `run()` doesn’t fit). Reuses `seatbelt._build_sbpl_profile`. Temp `.sb` unlinked on `close()`. Other backends (landlock/docker) not yet wrapped → server runs **UNSANDBOXED with a warning** (never silent).
- **`_build_mcp_sandbox_policy`**: read broad (#1323) + sensitive deny-list; write tight to the server cwd; **network = operator-declared per server** (`network: true`), **default OFF** — secure-by-default (sandbox policy is the operator’s, not the LLM’s).
- **Migration hint**: a sandboxed stdio server with network off that fails init gets a clear *“add `network: true`”* hint (default-off **breaks** network-needing servers like a GitHub MCP — surfaced with the stderr-capture tail).

## Test plan (no live sandbox — injected fake backend)

- [x] `pytest tests/test_mcp_client_sandbox_wrap.py` — Seatbelt wrap (command + profile + broad-read + network off/on), non-seatbelt → unsandboxed warn, unavailable-seatbelt → warn, temp-profile cleanup on close (assertions use the wrap’s return + filesystem, not private state)
- [x] `pytest -k "mcp_client"` — 30 passed (existing transport tests pin a noop backend to isolate transport forwarding from the wrap; expected unsandboxed-warning suppressed there)
- [x] broad `-k "sandbox or seatbelt or mcp"` sweep — 604 passed, 5 skipped (no regression)
- [x] `scripts/test_tier_audit.py --strict` — 0 errors

## Owner-input pending (tracked in #1344)

- landlock helper-exec wrap (`restrict_self` → `execvp` helper) + docker in-container wrap;
- the network **default-off value** (an operator knob — confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)