### PR TITLE
feat(security): MCP stdio network defaults to single-source DEFAULT_SANDBOX_NETWORK (#1339-D)

### DIFF
--- a/src/reyn/mcp_client.py
+++ b/src/reyn/mcp_client.py
@@ -150,16 +150,21 @@ class MCPClient:
             await stack.aclose()
             tail = self.read_stderr_tail()
             self.close_stderr_capture()
-            # #1344 migration hint: a sandboxed stdio server runs with network
-            # DISABLED by default (secure-by-default). A server that needs the
-            # network (e.g. a GitHub MCP) will fail init — point the operator at
-            # the `network: true` opt-in knob rather than leave an opaque error.
+            # #1344/#1339-D migration hint: a sandboxed stdio server defaults to
+            # the single-source network posture (DEFAULT_SANDBOX_NETWORK); the
+            # operator isolates a server with `network: false`. If a server was
+            # isolated and fails init for a network reason, point the operator at
+            # the knob rather than leave an opaque error.
+            from reyn.sandbox.policy import DEFAULT_SANDBOX_NETWORK
+
             hint = ""
-            if self._type == "stdio" and not self._config.get("network", False):
+            if self._type == "stdio" and not self._config.get(
+                "network", DEFAULT_SANDBOX_NETWORK
+            ):
                 hint = (
-                    "\nHint (#1344): this MCP server runs sandboxed with network "
-                    "DISABLED by default. If it needs network access, add "
-                    "`network: true` to its server config."
+                    "\nHint (#1344): this MCP server is sandboxed with network "
+                    "DISABLED (`network: false` in its config). If it needs "
+                    "network access, set `network: true` (or remove the override)."
                 )
             if tail:
                 raise MCPError(
@@ -311,16 +316,20 @@ class MCPClient:
 
         read broad (#1323 scoping) + the default sensitive deny-list; write tight
         to the server's working dir; ``network`` is OPERATOR-declared per server
-        (``network: true`` in the MCP config) and defaults OFF — secure-by-default,
-        because the sandbox policy is the operator's, not the LLM's. The default-off
-        means a network-needing server (e.g. a GitHub MCP) must declare
-        ``network: true`` (see the migration hint surfaced on init failure).
+        (``network: false`` in the MCP config to isolate) and defaults to
+        :data:`~reyn.sandbox.policy.DEFAULT_SANDBOX_NETWORK` (#1339 / sandbox-model
+        completion D) — the SAME single-source default as sandboxed_exec, so the
+        sandbox network posture is consistent across surfaces. The guarantee is
+        operator-ownership (the policy is the operator's, not the LLM's — the LLM
+        cannot set it), not default-off; an operator who wants an isolated server
+        sets ``network: false`` (see the migration hint surfaced on init failure).
         """
         from reyn.sandbox import SandboxPolicy
+        from reyn.sandbox.policy import DEFAULT_SANDBOX_NETWORK
 
         cwd = self._config.get("cwd") or os.getcwd()
         return SandboxPolicy(
-            network=bool(self._config.get("network", False)),
+            network=bool(self._config.get("network", DEFAULT_SANDBOX_NETWORK)),
             write_paths=[cwd],
         )
 

--- a/tests/test_mcp_client_sandbox_wrap.py
+++ b/tests/test_mcp_client_sandbox_wrap.py
@@ -42,7 +42,7 @@ def _patch_backend(monkeypatch, backend) -> None:
 
 def test_seatbelt_wrap_wraps_command(monkeypatch):
     """Tier 2: under Seatbelt, the command is wrapped as sandbox-exec -f <profile>
-    cmd args; the profile is a deny-default SBPL with broad-read, network OFF."""
+    cmd args; the profile is a deny-default SBPL with broad-read."""
     _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
     client = _stdio_client()
     cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
@@ -54,17 +54,39 @@ def test_seatbelt_wrap_wraps_command(monkeypatch):
     profile = Path(profile_path).read_text()
     assert "(deny default)" in profile
     assert "(allow file-read*)" in profile.splitlines()  # broad-read (#1323)
-    assert "(allow network*)" not in profile  # network OFF by default
+
+
+def test_seatbelt_wrap_network_default(monkeypatch):
+    """Tier 2: #1339-D reproduce-first — with no per-server override the Seatbelt
+    profile follows the single-source default (network ON when
+    DEFAULT_SANDBOX_NETWORK is True). FAILS on the pre-D hardcoded default-off
+    (asserts on observable wrap output, not the private policy object)."""
+    from reyn.sandbox.policy import DEFAULT_SANDBOX_NETWORK
+
+    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    client = _stdio_client()  # no `network` key
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile = Path(args[1]).read_text()
+    assert ("(allow network*)" in profile) is DEFAULT_SANDBOX_NETWORK
 
 
 def test_seatbelt_wrap_network_opt_in(monkeypatch):
-    """Tier 2: an operator-declared `network: true` opts the server into network
-    (the per-server knob; default is off = secure-by-default)."""
+    """Tier 2: an operator-declared `network: true` keeps the server on network."""
     _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
     client = _stdio_client(network=True)
     _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
     profile = Path(args[1]).read_text()
     assert "(allow network*)" in profile
+
+
+def test_seatbelt_wrap_network_opt_out(monkeypatch):
+    """Tier 2: #1339-D — an operator-declared `network: false` ISOLATES the server
+    (the opt-OUT knob; the network gate is now operator-set, not default-off)."""
+    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    client = _stdio_client(network=False)
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile = Path(args[1]).read_text()
+    assert "(allow network*)" not in profile
 
 
 def test_non_seatbelt_warns_unsandboxed(monkeypatch):


### PR DESCRIPTION
**[dogfood-coder]** — sandbox-model completion **PR2 (D)**. Stacked after #1347 (merged); branched clean off main (DEFAULT_SANDBOX_NETWORK now in main). permission layer UNCHANGED — sandbox layer only. Refs #1339 #1344.

## Change

`_build_mcp_sandbox_policy` hardcoded `network=False`. It now defaults to `reyn.sandbox.policy.DEFAULT_SANDBOX_NETWORK` — the **same single-source default as sandboxed_exec** (#1347 / PR1) — so the sandbox network posture is consistent across surfaces (exec + MCP). The init-failure migration hint is updated to reflect the opt-OUT model (`network: false` to isolate).

## Security posture (deliberate, owner design D)

This flips MCP stdio from default-OFF to default-ON network. The guarantee is **operator-ownership**, not default-off: PR1 (#1339) closed the LLM-settable hole, so the policy is the operator’s and **the LLM cannot set it**. An operator isolates a server with `network: false` (the opt-OUT knob). This makes MCP consistent with `sandboxed_exec` (both follow `DEFAULT_SANDBOX_NETWORK`, owner-flippable in one place).

## Test plan

- [x] `pytest tests/test_mcp_client_sandbox_wrap.py tests/test_mcp_client.py` — 19 passed
- [x] **reproduce-first**: `test_seatbelt_wrap_network_default` FAILS on the pre-D hardcoded off (asserts observable wrap output `("(allow network*)" in profile) is DEFAULT_SANDBOX_NETWORK`; git-checkout-main of mcp_client.py verified) — no private-state assert (Tier-4 audit clean)
- [x] opt-in (`network: true`) + opt-out (`network: false`) knobs both pinned
- [x] `ruff check` clean; `test_tier_audit.py --strict` 0 errors

## Wave status

PR1 #1347 merged (#1339 core). **PR3 (E landlock)** pre-built on `sandbox-model-e-landlock` — rebase + open after this merges (touches the same mcp_client.py, different function). After PR3 the sandbox model is complete: exec + MCP both operator-policy, LLM-uninvolved, all backends wrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)