### PR TITLE
feat(sandbox): Landlock re-exec shim for stdio MCP wrapping (#1344 follow-up E)

### DIFF
--- a/src/reyn/mcp_client.py
+++ b/src/reyn/mcp_client.py
@@ -338,10 +338,12 @@ class MCPClient:
 
         Seatbelt (macOS): returns ``("sandbox-exec", ["-f", <profile>, command,
         *args])`` with a generated SBPL profile (a temp ``.sb`` unlinked in
-        ``close``). MCP stdio is persistent, so the wrap is at the COMMAND level
-        (the backend's one-shot ``run()`` does not fit). Other backends
-        (landlock/docker) are not yet wrapped here (#1344 follow-up) — the server
-        then runs UNSANDBOXED with a warning (never silently).
+        ``close``). Landlock (Linux, #1344 follow-up E): returns the
+        ``reyn.sandbox.landlock_exec`` re-exec shim argv (the COMMAND-level
+        analog — Landlock has no CLI wrapper). MCP stdio is persistent, so the
+        wrap is at the COMMAND level (the backend's one-shot ``run()`` does not
+        fit). Other backends (docker) are not yet wrapped here — the server then
+        runs UNSANDBOXED with a warning (never silently).
         """
         from reyn.sandbox import get_default_backend
 
@@ -362,10 +364,18 @@ class MCPClient:
             fh.close()
             self._sandbox_profile_path = fh.name
             return "sandbox-exec", ["-f", fh.name, command, *args]
+        if name == "landlock" and available:
+            # #1344 follow-up E: the Landlock re-exec shim restricts itself then
+            # execs the target (Linux-validation-pending — see landlock_exec).
+            from reyn.sandbox.landlock_exec import build_landlock_exec_argv
+
+            return build_landlock_exec_argv(
+                self._build_mcp_sandbox_policy(), command, args
+            )
         warnings.warn(
             f"MCP stdio server {command!r} runs UNSANDBOXED "
-            f"(sandbox backend={name or 'none'}); only the Seatbelt wrap is "
-            f"implemented (#1344) — Landlock/docker wrapping is a follow-up.",
+            f"(sandbox backend={name or 'none'}); only Seatbelt + Landlock wraps "
+            f"are implemented (#1344) — docker wrapping is a follow-up.",
             stacklevel=2,
         )
         return command, args

--- a/src/reyn/sandbox/landlock_exec.py
+++ b/src/reyn/sandbox/landlock_exec.py
@@ -1,0 +1,155 @@
+"""landlock_exec — a re-exec shim that restricts the current process under
+Landlock, then execs a target command (FP-0017 / #1344 follow-up E).
+
+Why a shim. A persistent stdio MCP server is a long-running subprocess, so the
+backend's one-shot ``run()`` does not fit; the wrap must be at the COMMAND level
+— mirroring the Seatbelt ``sandbox-exec -f <profile> cmd`` wrap in
+``mcp_client._sandbox_wrap_stdio``. Landlock has no CLI wrapper, so this module
+IS the wrapper::
+
+    python -m reyn.sandbox.landlock_exec --policy <json> -- <command> <args...>
+
+``main()`` applies ``landlock.Ruleset().restrict_self()`` to *itself*, then
+``os.execvp()``s the target — the target inherits the irrevocable restriction
+(Landlock restrictions survive ``execve``).
+
+Linux-validation-pending. The ruleset build + ``restrict_self()`` here MIRROR
+``LandlockBackend.run`` and carry the SAME ``fp-0017-b`` "Linux validation
+needed" TODOs (the maintainer dev environment is macOS-only). On a non-Linux /
+no-landlock host the shim REFUSES to run (raises), so a caller never gets a
+false sense of enforcement. When the backend's ruleset build is Linux-validated,
+this and the backend should consolidate onto one shared ruleset builder; until
+then they intentionally duplicate (each independently carries the unvalidated
+caveat — no NEW unvalidated surface is introduced).
+
+Deferred-validation plan (#1344): real end-to-end enforcement is validated on a
+Linux host — reyn's own docker backend (#1324 launcher) can spin a Linux
+container and exercise this shim's restrict_self() effects (fs/net actually
+blocked). Tracked as a follow-up; not run here (these tests are structural +
+skip-if-no-landlock).
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import sys
+
+from .policy import SandboxPolicy
+
+_MODULE = "reyn.sandbox.landlock_exec"
+
+
+def _policy_to_json(policy: SandboxPolicy) -> str:
+    """Serialize a SandboxPolicy to a single JSON arg (round-trips via
+    :func:`_policy_from_json`)."""
+    return json.dumps(dataclasses.asdict(policy), separators=(",", ":"))
+
+
+def _policy_from_json(s: str) -> SandboxPolicy:
+    """Reconstruct a SandboxPolicy from the JSON produced by
+    :func:`_policy_to_json`."""
+    return SandboxPolicy(**json.loads(s))
+
+
+def build_landlock_exec_argv(
+    policy: SandboxPolicy, command: str, args: list[str]
+) -> tuple[str, list[str]]:
+    """Return ``(executable, argv)`` that runs ``command`` under this Landlock
+    policy via the re-exec shim.
+
+    Pure (no side effects) — the COMMAND-level wrap analog of the Seatbelt
+    ``("sandbox-exec", ["-f", <profile>, command, *args])`` wrap. The returned
+    ``executable`` is the current interpreter so the shim is import-resolvable
+    in the same environment; ``--`` separates the shim args from the target.
+    """
+    return sys.executable, [
+        "-m",
+        _MODULE,
+        "--policy",
+        _policy_to_json(policy),
+        "--",
+        command,
+        *args,
+    ]
+
+
+def _parse_args(argv: list[str]) -> tuple[SandboxPolicy, str, list[str]]:
+    """Parse the shim's own argv into ``(policy, command, args)``.
+
+    Structural-testable without Landlock (the enforcement is in
+    :func:`_apply_landlock`)."""
+    parser = argparse.ArgumentParser(prog=f"python -m {_MODULE}", add_help=False)
+    parser.add_argument("--policy", required=True)
+    parser.add_argument("rest", nargs=argparse.REMAINDER)
+    ns = parser.parse_args(argv)
+    rest = list(ns.rest)
+    # argparse.REMAINDER keeps the leading "--" separator — strip it.
+    if rest and rest[0] == "--":
+        rest = rest[1:]
+    if not rest:
+        parser.error("no target command after --")
+    return _policy_from_json(ns.policy), rest[0], rest[1:]
+
+
+def _apply_landlock(policy: SandboxPolicy) -> None:
+    """Restrict the CURRENT process under ``policy`` via Landlock.
+
+    Raises ``RuntimeError`` if Landlock is unavailable on this host — the shim
+    must never exec the target UNRESTRICTED (that would be a silent escape).
+
+    Mirrors ``LandlockBackend.run``'s ruleset build + ``restrict_self`` (same
+    ``fp-0017-b`` Linux-validation TODOs)."""
+    from .backends.landlock import LandlockBackend
+
+    backend = LandlockBackend()
+    if not backend.available():
+        raise RuntimeError(
+            f"{_MODULE}: Landlock unavailable on this host "
+            f"(import_error={backend.import_error!r}); refusing to exec the "
+            "target unrestricted. Run on Linux 5.13+ with the `landlock` package."
+        )
+
+    # TODO(fp-0017-b): Linux validation needed — verify Ruleset construction,
+    # add_path_beneath_rule / add_net_port_rule API + access constants for the
+    # installed landlock package version (mirrors LandlockBackend.run).
+    import landlock  # noqa: PLC0415
+
+    ruleset = landlock.Ruleset()  # type: ignore[attr-defined]
+    # Broad read (#1199 / #1323): allowlist-only, so a single read rule on "/".
+    # read_deny_paths is NOT expressible on Landlock (the network gate is the
+    # exfil guard) — same residual-risk asymmetry as the backend.
+    ruleset.add_path_beneath_rule("/", read_only=True)  # type: ignore[attr-defined]
+    for path in policy.write_paths:
+        ruleset.add_path_beneath_rule(path, read_only=False)  # type: ignore[attr-defined]
+    if not policy.network and hasattr(ruleset, "add_net_port_rule"):
+        ruleset.add_net_port_rule(deny_all_outbound=True)  # type: ignore[attr-defined]
+    ruleset.restrict_self()  # type: ignore[attr-defined]
+
+    if not policy.allow_subprocess:
+        try:
+            from .backends.seccomp import install_seccomp_filter  # noqa: PLC0415
+        except ImportError:
+            install_seccomp_filter = None  # type: ignore[assignment]
+        if install_seccomp_filter is not None:
+            install_seccomp_filter(policy)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point: parse argv, apply Landlock to self, exec the target.
+
+    Returns a non-zero code only on failure; on success ``os.execvp`` replaces
+    the process and never returns."""
+    policy, command, args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        _apply_landlock(policy)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)  # noqa: T201
+        return 2
+    os.execvp(command, [command, *args])
+    return 127  # unreachable on success (execvp replaces the process)
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised as a subprocess
+    raise SystemExit(main())

--- a/tests/test_landlock_exec_shim_1344e.py
+++ b/tests/test_landlock_exec_shim_1344e.py
@@ -1,0 +1,122 @@
+"""Tier 2: Landlock re-exec shim for stdio MCP wrapping (#1344 follow-up E).
+
+A persistent stdio MCP server can't use the backend's one-shot run(); on Linux
+it is wrapped at the COMMAND level by re-execing through
+``reyn.sandbox.landlock_exec``, which restricts itself then execs the target.
+
+Scope of these tests is STRUCTURAL (the maintainer dev env is macOS-only):
+  - the pure argv builder + policy JSON round-trip + arg parse (no Landlock);
+  - the refuse-to-run guarantee when Landlock is unavailable (so the shim never
+    execs the target unrestricted = no silent escape).
+Real end-to-end ENFORCEMENT (restrict_self actually blocking fs/net) is
+Linux-validation-pending — the same caveat the landlock backend carries
+(fp-0017-b) — and is skipped where Landlock is unavailable.
+
+No mocks — the real SandboxPolicy / real shim functions / a real subprocess.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from reyn.sandbox.landlock_exec import (
+    _MODULE,
+    _parse_args,
+    _policy_from_json,
+    _policy_to_json,
+    build_landlock_exec_argv,
+)
+from reyn.sandbox.policy import SandboxPolicy
+
+
+def _landlock_available() -> bool:
+    from reyn.sandbox.backends.landlock import LandlockBackend
+
+    return LandlockBackend().available()
+
+
+# ── pure: argv builder + policy round-trip + parse (no Landlock needed) ────────
+
+
+def test_build_argv_is_python_shim():
+    """Tier 2: the wrap is the current interpreter running the shim module, with
+    the policy JSON and the target after ``--`` (COMMAND-level analog of the
+    Seatbelt sandbox-exec wrap)."""
+    pol = SandboxPolicy(network=False, write_paths=["/ws"])
+    exe, argv = build_landlock_exec_argv(pol, "my-mcp", ["--flag", "x"])
+    assert exe == sys.executable
+    assert argv[:2] == ["-m", _MODULE]
+    assert "--policy" in argv
+    # the target command + args follow the "--" separator, unchanged
+    sep = argv.index("--")
+    assert argv[sep + 1:] == ["my-mcp", "--flag", "x"]
+
+
+def test_policy_json_roundtrips_all_fields():
+    """Tier 2: every policy field survives the JSON arg round-trip (so the shim
+    enforces the operator's policy, not a lossy subset)."""
+    pol = SandboxPolicy(
+        network=True,
+        read_paths=["/r"],
+        write_paths=["/w"],
+        read_deny_paths=["~/.ssh"],
+        allow_subprocess=True,
+        env_passthrough=["PATH", "HOME"],
+        timeout_seconds=42,
+    )
+    assert _policy_from_json(_policy_to_json(pol)) == pol
+
+
+def test_parse_args_recovers_policy_and_target():
+    """Tier 2: _parse_args inverts build_landlock_exec_argv (the shim sees the
+    same policy + target the wrap encoded). The leading ``-m <module>`` is
+    consumed by python, so the shim's own argv is everything after it."""
+    pol = SandboxPolicy(network=False, write_paths=["/ws"])
+    _exe, argv = build_landlock_exec_argv(pol, "my-mcp", ["--flag"])
+    shim_argv = argv[2:]  # drop ["-m", module] (python's args, not the shim's)
+    parsed_pol, command, args = _parse_args(shim_argv)
+    assert parsed_pol == pol
+    assert command == "my-mcp"
+    assert args == ["--flag"]
+
+
+# ── refuse-to-run guarantee (no false enforcement) ────────────────────────────
+
+
+@pytest.mark.skipif(
+    _landlock_available(), reason="Landlock available — enforcement path Linux-validated separately"
+)
+def test_apply_landlock_refuses_when_unavailable():
+    """Tier 2: where Landlock is unavailable, _apply_landlock RAISES — the shim
+    must never exec the target unrestricted (no silent escape)."""
+    from reyn.sandbox.landlock_exec import _apply_landlock
+
+    with pytest.raises(RuntimeError, match="Landlock unavailable"):
+        _apply_landlock(SandboxPolicy())
+
+
+@pytest.mark.skipif(
+    _landlock_available(), reason="Landlock available — enforcement path Linux-validated separately"
+)
+def test_main_subprocess_refuses_when_unavailable():
+    """Tier 2: run as a real subprocess on a no-Landlock host, the shim exits
+    non-zero and does NOT exec the target (end-to-end of the refuse path)."""
+    import os
+    from pathlib import Path
+
+    import reyn
+
+    pol = SandboxPolicy()
+    exe, argv = build_landlock_exec_argv(pol, "/bin/echo", ["SHOULD-NOT-RUN"])
+    # Run the shim against the reyn under test (not a venv-installed copy) by
+    # pinning PYTHONPATH to this checkout's src root (env-dependent path lesson).
+    src_root = Path(reyn.__file__).resolve().parent.parent
+    env = {**os.environ, "PYTHONPATH": str(src_root)}
+    proc = subprocess.run(
+        [exe, *argv], capture_output=True, text=True, timeout=30, env=env,
+    )
+    assert proc.returncode == 2  # the refuse exit code
+    assert "Landlock unavailable" in proc.stderr
+    assert "SHOULD-NOT-RUN" not in proc.stdout  # the target never ran

--- a/tests/test_mcp_client_sandbox_wrap.py
+++ b/tests/test_mcp_client_sandbox_wrap.py
@@ -2,8 +2,9 @@
 
 The MCP server launched by ``_open_stdio`` must run under the platform sandbox
 so an LLM-invoked MCP tool cannot escape via the server. Pins the Seatbelt
-command-wrap (the implemented backend), the per-server network opt-in
-(default OFF = secure-by-default), the unsandboxed warning for other backends,
+command-wrap (macOS) + the Landlock re-exec shim (Linux, #1344-E), the
+per-server network default (single-source DEFAULT_SANDBOX_NETWORK, #1339-D)
+with operator opt-in / opt-out, the unsandboxed warning for other backends,
 and the temp-profile cleanup.
 
 No mocks: a real ``_FakeBackend`` (name + available()) injected via monkeypatch
@@ -87,6 +88,24 @@ def test_seatbelt_wrap_network_opt_out(monkeypatch):
     _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
     profile = Path(args[1]).read_text()
     assert "(allow network*)" not in profile
+
+
+def test_landlock_wrap_uses_reexec_shim(monkeypatch):
+    """Tier 2: under Landlock (#1344 follow-up E), the command is wrapped as the
+    reyn.sandbox.landlock_exec re-exec shim (python -m ... --policy ... -- cmd
+    args) — the COMMAND-level analog of the Seatbelt wrap (no UNSANDBOXED warn)."""
+    import sys
+    import warnings
+
+    _patch_backend(monkeypatch, _FakeBackend("landlock"))
+    client = _stdio_client()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any UNSANDBOXED warn would fail here
+        cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert cmd == sys.executable
+    assert args[:2] == ["-m", "reyn.sandbox.landlock_exec"]
+    sep = args.index("--")
+    assert args[sep + 1:] == ["my-mcp", "--flag"]  # original command preserved
 
 
 def test_non_seatbelt_warns_unsandboxed(monkeypatch):


### PR DESCRIPTION
**[dogfood-coder]** — sandbox-model completion **PR3 (E)**, the final piece. Rebased clean onto main after #1347 + #1348 merged. permission layer UNCHANGED — sandbox layer only. Refs #1344 #1339 #1324.

## Change

A persistent stdio MCP server can't use the backend's one-shot `run()`; on Linux it is now wrapped at the COMMAND level (the analog of the Seatbelt `sandbox-exec -f <profile>` wrap) by re-execing through a new `reyn.sandbox.landlock_exec` module:

```
python -m reyn.sandbox.landlock_exec --policy <json> -- <command> <args...>
```

`main()` applies `landlock.Ruleset().restrict_self()` to **itself**, then `os.execvp()`s the target — the target inherits the irrevocable restriction (Landlock survives `execve`). `mcp_client._sandbox_wrap_stdio` gains a landlock branch returning `build_landlock_exec_argv(...)` instead of the UNSANDBOXED warning.

## Honest verification state (Linux-validation-pending, owner-confirmed defer)

- the shim's ruleset build + `restrict_self()` **mirror `LandlockBackend.run`** and carry the SAME `fp-0017-b` "Linux validation needed" TODOs — **no NEW unvalidated surface**;
- on a non-Linux / no-landlock host the shim **REFUSES to run** (raises → exit 2) so a caller never gets a false sense of enforcement;
- **deferred-validation plan (owner hint):** real end-to-end enforcement (fs/net actually blocked) is validated on a Linux host via reyn's own **docker backend (#1324 launcher)** — recorded in the module docstring + [#1344 comment](https://github.com/tya5/reyn/issues/1344#issuecomment-4628610190). Tracked follow-up, not run here.

## Test plan

- [x] `pytest tests/test_landlock_exec_shim_1344e.py tests/test_mcp_client_sandbox_wrap.py tests/test_mcp_client.py` — 24 passed (E landlock + PR2 network tests coexist post-rebase)
- [x] structural (no Landlock needed): argv builder + policy JSON round-trip + arg parse
- [x] refuse-to-run guarantee: `_apply_landlock` raises + the shim subprocess exits 2 without running the target where Landlock is unavailable
- [x] **reproduce-first**: `test_landlock_wrap_uses_reexec_shim` FAILS on main (pre-E the landlock backend warned UNSANDBOXED) — git-checkout-main of mcp_client.py verified
- [x] enforcement tests skip-if-no-landlock (Linux-validation-pending)
- [x] `ruff` clean; `test_tier_audit.py --strict` 0 errors

## Wave complete

With this, the sandbox model is complete: **exec (#1347) + MCP (#1345/#1348)** both operator-policy + LLM-uninvolved; backend wrap = Seatbelt (macOS, validated) + Landlock (Linux, structural + validation-deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)