### PR TITLE
docs(write-replay-tests): warn that -k filtered runs exclude replay tests

### DIFF
--- a/docs/guide/for-reyn-developers/write-replay-tests.md
+++ b/docs/guide/for-reyn-developers/write-replay-tests.md
@@ -292,6 +292,12 @@ python -m pytest tests/test_replay_my_area.py -v
 Commit the new fixture alongside the prompt change. Reviewers can diff the
 `prompt_preview` field in the JSONL to see what changed.
 
+> **Warning — `-k` filtered runs exclude replay tests.** If your local test run uses
+> `-k some_keyword` that does not match replay test names, replay tests are silently
+> skipped and the run appears green. This masks broken fixtures until CI runs the
+> full suite. Always run the full replay suite (`pytest tests/test_replay_*.py -v`)
+> after any change to phase instructions, tool catalog, or LLM-call boundaries.
+
 ---
 
 ## NEVER rules for replay tests


### PR DESCRIPTION
**[docs-maintainer]** — sandbox_2 cross-ref audit で発見した docs drift。

## Summary

`write-replay-tests.md` の「Update fixtures after intentional prompt changes」セクション（L277 付近）に `-k` フィルタ警告を追加。

`pytest -k some_keyword` でリプレイテストが除外されるケースでは、フィクスチャが破損していても false-green になる。CI が full suite を実行するまで見逃される。

**変更ページ:** removed 0 / added 0（既存ページへの警告追記のみ）

## Test plan

- [ ] L277 付近に Warning admonition が表示されること
- [ ] 既存のリプレイテスト手順が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)