### PR TITLE
fix(security): thread SandboxLayer ∩ into mcp_install/mcp_drop file-write gate (#1352-C)

### DIFF
--- a/src/reyn/op_runtime/mcp_drop_server.py
+++ b/src/reyn/op_runtime/mcp_drop_server.py
@@ -36,6 +36,7 @@ from reyn.schemas.models import MCPDropServerIROp
 
 from . import register
 from .context import OpContext
+from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 
 # ---------------------------------------------------------------------------
 # helpers (yaml read/write — mirror mcp_install for parity)
@@ -217,8 +218,11 @@ async def handle(
     # removed — per-server granularity in mutations is operator-
     # config-level concern, not per-op runtime concern.
     if ctx.permission_resolver is not None:
+        # #1352-C: thread the agent/operator sandbox policy (SandboxLayer ∩),
+        # same as op_runtime/file.py — was missing here (permission-only gap).
         ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(config_path), ctx.skill_name,
+            sandbox_policy=_sandbox_policy_from_ctx(ctx),
         )
 
     # ── 3. Capture env keys before mutation ────────────────────────────

--- a/src/reyn/op_runtime/mcp_install.py
+++ b/src/reyn/op_runtime/mcp_install.py
@@ -28,6 +28,7 @@ from reyn.schemas.models import MCPInstallIROp
 
 from . import register
 from .context import OpContext
+from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 
 # ---------------------------------------------------------------------------
 # Runtime-hint → command name
@@ -242,8 +243,13 @@ async def handle(
         project_root = Path(ctx.workspace.root)
     config_path = _scope_to_path(op.scope, project_root)
     if ctx.permission_resolver is not None:
+        # #1352-C: thread the agent/operator sandbox policy (SandboxLayer ∩),
+        # same as op_runtime/file.py — was missing here, so the write/http gates
+        # ran permission-only (SandboxLayer ⊤). None → ⊤ (unchanged).
+        _sandbox = _sandbox_policy_from_ctx(ctx)
         ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(config_path), ctx.skill_name,
+            sandbox_policy=_sandbox,
         )
         # Registry fetch happened via RegistryClient above — gate the
         # host symmetrically so the OS exercises its own permission
@@ -255,6 +261,7 @@ async def handle(
                 "registry.modelcontextprotocol.io",
                 ctx.intervention_bus,
                 ctx.skill_name,
+                sandbox_policy=_sandbox,
             )
 
     # ── 4. Credentials: resolve isSecret env vars from env_overrides or

--- a/tests/test_mcp_drop_server.py
+++ b/tests/test_mcp_drop_server.py
@@ -470,3 +470,40 @@ def test_mcp_drop_server_tool_scope_enum_three_tiers() -> None:
 
     scope_prop = MCP_DROP_SERVER_OP.parameters["properties"]["scope"]
     assert set(scope_prop["enum"]) == {"local", "project", "user"}
+
+
+# ── #1352-C: SandboxLayer ∩ threaded into the mcp file-write gate ──────────
+
+
+def test_mcp_drop_server_sandbox_policy_denies_out_of_cap_write(tmp_path: Path) -> None:
+    """Tier 2: #1352-C reproduce-first — the drop handler threads the agent sandbox
+    policy into require_file_write, so a write to the config path OUTSIDE the
+    policy's write_paths cap is DENIED (SandboxLayer ∩) even when the permission
+    layer GRANTS it. FAILS pre-C (sandbox_policy not threaded → SandboxLayer ⊤
+    → the permission grant alone lets the write through)."""
+    import dataclasses
+
+    from reyn.op_runtime.mcp_drop_server import handle as drop_handle
+
+    cfg_path = tmp_path / "reyn.local.yaml"
+    _seed_config(cfg_path, {"filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]}})
+
+    # Permission layer GRANTS the write to the config path (so the test isolates
+    # the SandboxLayer denial, not a permission denial).
+    resolver = _resolver(tmp_path)
+    canonical = str(cfg_path)
+    resolver.session_approve_path(canonical, "test_mcp_drop_server", "file.write")
+    decl = PermissionDecl(file_write=[{"path": canonical, "scope": "just_path"}])
+    base_ctx = _make_op_ctx(tmp_path, permission_decl=decl, resolver=resolver)
+
+    # Operator sandbox policy: write only under a dir that EXCLUDES reyn.local.yaml.
+    ctx = dataclasses.replace(
+        base_ctx,
+        default_sandbox_policy={"write_paths": [str(tmp_path / "allowed_only")]},
+    )
+
+    op = MCPDropServerIROp(
+        kind="mcp_drop_server", server="filesystem", scope="local", clear_secrets=False,
+    )
+    with pytest.raises(PermissionError):
+        _run(drop_handle(op=op, ctx=ctx, caller="control_ir"))

--- a/tests/test_mcp_drop_server.py
+++ b/tests/test_mcp_drop_server.py
@@ -507,3 +507,36 @@ def test_mcp_drop_server_sandbox_policy_denies_out_of_cap_write(tmp_path: Path) 
     )
     with pytest.raises(PermissionError):
         _run(drop_handle(op=op, ctx=ctx, caller="control_ir"))
+
+
+def test_mcp_drop_server_realistic_workspace_default_allows_config_write(tmp_path: Path) -> None:
+    """Tier 2: #1352-C regression guard — under the REALISTIC chat/phase concrete
+    default (write_paths=[workspace.base_dir], as #1347 sets for chat), the mcp
+    config write to base_dir/reyn.local.yaml is UNDER the cap, so the SandboxLayer
+    ∩ added by #1352-C does NOT deny it. Guards against a latent regression where
+    threading sandbox_policy would block legitimate in-workspace config writes."""
+    import dataclasses
+
+    from reyn.op_runtime.mcp_drop_server import handle as drop_handle
+
+    cfg_path = tmp_path / "reyn.local.yaml"
+    _seed_config(cfg_path, {"filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]}})
+
+    resolver = _resolver(tmp_path)
+    canonical = str(cfg_path)
+    resolver.session_approve_path(canonical, "test_mcp_drop_server", "file.write")
+    decl = PermissionDecl(file_write=[{"path": canonical, "scope": "just_path"}])
+    base_ctx = _make_op_ctx(tmp_path, permission_decl=decl, resolver=resolver)
+
+    # Realistic default: write cap == the workspace base_dir (tmp_path). The
+    # config path (tmp_path/reyn.local.yaml) is UNDER it → ∩ must allow.
+    ctx = dataclasses.replace(
+        base_ctx,
+        default_sandbox_policy={"write_paths": [str(tmp_path)]},
+    )
+
+    op = MCPDropServerIROp(
+        kind="mcp_drop_server", server="filesystem", scope="local", clear_secrets=False,
+    )
+    result = _run(drop_handle(op=op, ctx=ctx, caller="control_ir"))
+    assert result["status"] == "ok"  # NOT denied — config write is in-workspace

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -589,3 +589,38 @@ def test_mcp_install_op_registered_in_default_registry():
     assert tool is not None
     assert tool.gates.phase == "allow"
     assert tool.gates.router == "deny"
+
+
+# ── #1352-C: SandboxLayer ∩ threaded into the mcp_install file-write gate ──
+
+
+def test_mcp_install_sandbox_policy_denies_out_of_cap_write(tmp_path, monkeypatch):
+    """Tier 2: #1352-C reproduce-first — the install handler threads the agent
+    sandbox policy into require_file_write, so the config write OUTSIDE the
+    policy's write_paths cap is DENIED (SandboxLayer ∩) even when the permission
+    layer GRANTS it. network=True isolates the denial to the write cap (not the
+    http gate). FAILS pre-C (sandbox_policy not threaded → SandboxLayer ⊤)."""
+    import dataclasses
+
+    monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
+    resolver = _make_resolver(tmp_path)
+    decl = _phase5_install_decl(resolver)  # permission layer GRANTS file.write + http.get
+    bus = _AutoApproveInterventionBus()
+    base_ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
+
+    # Operator sandbox policy: network ON (so the http gate is not the cause),
+    # write only under a dir that EXCLUDES the .reyn/mcp.yaml config path.
+    ctx = dataclasses.replace(
+        base_ctx,
+        default_sandbox_policy={"network": True, "write_paths": [str(tmp_path / "allowed_only")]},
+    )
+
+    op = MCPInstallIROp(
+        kind="mcp_install",
+        server_id="io.github.modelcontextprotocol/server-filesystem",
+        scope="local",
+    )
+
+    with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
+        with pytest.raises(PermissionError):
+            _run(mcp_install_handle(op, ctx, "control_ir"))


### PR DESCRIPTION
**[dogfood-coder]** — sandbox-coverage audit residual **C** (#1352), owner-dispatched. permission layer UNCHANGED — sandbox layer only. Refs #1352.

## Change

`op_runtime/mcp_install.py` + `mcp_drop_server.py` called `require_file_write` (and mcp_install's `require_http_get`) **without** `sandbox_policy` — the one in-process file-write path the audit found NOT threading the agent/operator policy (unlike `file.py` / `web.py` / `index_*`). They ran permission-only (SandboxLayer ⊤). Fix threads `sandbox_policy_from_ctx(ctx)` identically to `file.py`. `None → ⊤` (unchanged for non-sandboxed callers).

## Test plan

- [x] `pytest tests/test_mcp_install_op.py tests/test_mcp_drop_server.py` — 33 passed
- [x] **reproduce-first** (both handlers): a config write outside the policy `write_paths` cap is DENIED (SandboxLayer ∩) even when the permission layer GRANTS it; both tests FAIL on pre-fix (`git stash` of the handler verified — the write went through on the permission grant alone). install test sets `network: true` to isolate the denial to the write cap (not the http gate).
- [x] `ruff` clean; `test_tier_audit.py --strict` 0 errors

## Wave context

Residual C of #1352 (owner-dispatched). A (shell removal + D stale-comment) and B (python OS-sandbox, design-first) follow; #1 (chat-vs-phase asymmetry) awaits owner. owner insight: sandbox = file-sharing(mount /workspace) execution substrate → all subprocess via sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)