### PR TITLE
fix(security): symmetrize phase sandbox policy with chat — concrete default not None (#1352-#1)

### DIFF
--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -163,14 +163,23 @@ class OSRuntime:
         # executor so sandboxed_exec backend selection honors the operator's
         # declared backend / on_unsupported policy. None → platform default.
         self._sandbox_config = sandbox_config
-        # #1326: the agent-level (operator) sandbox policy carried by
-        # ``reyn.yaml sandbox.policy`` (None when the operator declares none →
-        # the SandboxLayer stays ⊤). Threaded into the phase / orchestrator /
-        # pre- + post-processor executors so it is the deterministic policy for
-        # the permission ∩ + sandboxed ops, replacing the retired phase-scoped
-        # default_sandbox_policy.
-        self._agent_sandbox_policy = (
-            sandbox_config.policy if sandbox_config is not None else None
+        # #1326 + #1352-#1: the agent-level sandbox policy threaded into the phase /
+        # orchestrator / pre- + post-processor executors as the deterministic
+        # policy for the permission ∩ + sandboxed ops.
+        #
+        # #1352-#1 symmetrization: previously this was the operator policy
+        # verbatim-or-None → when the operator declared no policy the phase
+        # SandboxLayer stayed ⊤ (permission-only), while chat (#1347) already
+        # resolved a CONCRETE default. resolve_sandbox_policy now gives phase the
+        # SAME operator-or-concrete-default (write-tight to the workspace
+        # base_dir, network=DEFAULT_SANDBOX_NETWORK, sensitive read-deny), so the
+        # sandbox ∩ is active for phase ops by default too. Operator config still
+        # wins verbatim when set. (Audit residual #1; chat/phase asymmetry closed.)
+        from reyn.sandbox.policy import resolve_sandbox_policy
+
+        self._agent_sandbox_policy = resolve_sandbox_policy(
+            sandbox_config.policy if sandbox_config is not None else None,
+            write_paths=[str(self.workspace.base_dir)],
         )
         # Issue #364 multi-modal cluster: media-size gate config.
         self._multimodal_config = multimodal_config
@@ -385,6 +394,16 @@ class OSRuntime:
     def phase_compaction_cfg(self) -> "PhaseActResultsCompactionConfig | None":
         """PR-N8: read-only accessor for wiring-verification tests."""
         return self._phase_compaction_cfg
+
+    @property
+    def agent_sandbox_policy(self) -> dict | None:
+        """#1352-#1: read-only accessor for the RESOLVED agent sandbox policy.
+
+        Mirrors the chat factory (#1347): resolve_sandbox_policy yields an
+        operator-or-concrete-default policy (never None) — wiring-verification
+        tests assert the symmetrization without reaching into private state.
+        """
+        return self._agent_sandbox_policy
 
     # ── Phase setup ────────────────────────────────────────────────────────────
 

--- a/tests/test_1326_sandbox_policy_agent_level.py
+++ b/tests/test_1326_sandbox_policy_agent_level.py
@@ -246,3 +246,40 @@ def test_postprocessor_cap_absent_without_agent_policy(tmp_path: Path) -> None:
     runner = _RecordingPythonRunner()
     _run_postprocessor(tmp_path, agent_policy=None, runner=runner)
     assert runner.sandbox_write_paths is None
+
+
+# ── #1352-#1: OSRuntime symmetrizes phase policy with chat (concrete default) ──
+
+
+def test_osruntime_resolves_concrete_default_when_operator_absent(tmp_path: Path) -> None:
+    """Tier 2: #1352-#1 reproduce-first — OSRuntime symmetrizes with the chat
+    factory (#1347): with NO operator sandbox.policy the resolved agent policy is a
+    CONCRETE default (write-tight to workspace base_dir, network=
+    DEFAULT_SANDBOX_NETWORK), NOT None. FAILS pre-#1 (was sandbox_config.policy-or-
+    None → None → the phase SandboxLayer stayed ⊤ = permission-only)."""
+    from reyn.kernel.runtime import OSRuntime
+    from reyn.sandbox.policy import DEFAULT_SANDBOX_NETWORK
+
+    runtime = OSRuntime(
+        _one_phase_skill(), model="gpt-3.5-turbo", run_id="sym-default",
+        workspace_base_dir=tmp_path,
+    )
+    pol = runtime.agent_sandbox_policy
+    assert pol is not None  # was None pre-#1 → phase ran permission-only
+    assert pol["network"] is DEFAULT_SANDBOX_NETWORK
+    assert pol["write_paths"] == [str(tmp_path.resolve())]  # write-tight to base_dir
+
+
+def test_osruntime_operator_policy_wins_verbatim(tmp_path: Path) -> None:
+    """Tier 2: #1352-#1 — an operator-declared reyn.yaml sandbox.policy is returned
+    verbatim (resolve_sandbox_policy passes config through), so symmetrization does
+    not override an explicit operator policy."""
+    from reyn.config import SandboxConfig
+    from reyn.kernel.runtime import OSRuntime
+
+    cfg = SandboxConfig(policy={"network": False, "write_paths": ["/only/here"]})
+    runtime = OSRuntime(
+        _one_phase_skill(), model="gpt-3.5-turbo", run_id="sym-operator",
+        workspace_base_dir=tmp_path, sandbox_config=cfg,
+    )
+    assert runtime.agent_sandbox_policy == {"network": False, "write_paths": ["/only/here"]}


### PR DESCRIPTION
**[dogfood-coder]** — sandbox-coverage audit residual **#1** (#1352), owner GO (symmetrize). permission layer UNCHANGED — sandbox layer only. Refs #1352.

## Change

The audit found a chat-vs-phase asymmetry: chat OpContext factories (#1347) resolve a **concrete** default sandbox policy, but the phase/orchestrator/pre+post-processor path used the operator policy **verbatim-or-None** (`kernel/runtime.py`). So with no operator `reyn.yaml sandbox.policy`, phase (skill) file/http ops ran permission-only (SandboxLayer ⊤) while chat already had the ∩ active.

`runtime` now resolves the SAME concrete default for phase via `resolve_sandbox_policy(write_paths=[workspace.base_dir])` — symmetric with chat. Operator config still wins verbatim.

## Impact (audited + full-suite-confirmed: MINIMAL)

All stdlib skill `file.write` decls are project-relative (under base_dir); reyn memory = `.reyn/memory` (under base_dir); `mcp_install` always writes `.reyn/mcp.yaml` (#470, under base_dir); swe_bench eval injects its own policy. **Full suite: 6934 passed / 0 failed** — the symmetrization breaks nothing.

The ONLY out-of-base_dir write affected is **`mcp_drop` scope=user** (`~/.reyn/config.yaml`, a rare legacy global-config cleanup). Under the workspace-tight default it now requires an operator `sandbox.policy` with broader `write_paths`.

**Edge decision = operator-policy-required (not exempt)** — rationale: (a) widening the shared `resolve_sandbox_policy` default to include `~/.reyn` would also loosen the **sandboxed_exec** write cap (same default), undesirable; (b) a per-op exemption would contradict #1352-C’s clean threading; (c) an out-of-workspace global-config write legitimately warrants explicit operator opt-in (consistent with the sandbox model). The case is rare/legacy. *(This differs from the lead’s initial lean toward exempt-if-own-gate; raising for confirmation.)*

## Test plan

- [x] `OSRuntime` resolves a concrete default (write_paths=[base_dir], network=DEFAULT_SANDBOX_NETWORK) when operator absent — **reproduce-first: FAILS pre-#1** (was None → phase permission-only)
- [x] operator policy returned verbatim (symmetrization does not override explicit config)
- [x] new read-only `agent_sandbox_policy` accessor (mirrors the `phase_compaction_cfg` wiring-accessor pattern — no private-state assert)
- [x] **full suite: 6934 passed, 8 skipped, 3 xfailed, 0 failed** (the impact confirmation — all skills’ phase paths)
- [x] `ruff` clean; `test_tier_audit.py --strict` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)